### PR TITLE
CESMSCRATCHROOT on Mira

### DIFF
--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -342,7 +342,7 @@
          <DESC>ANL IBM BG/Q, os is BGP, 16 pes/node, batch system is cobalt</DESC>
          <COMPILERS>ibm</COMPILERS>
          <MPILIBS>ibm</MPILIBS>
-         <CESMSCRATCHROOT>/projects/$PROJECT/$ENV{USER}/scratch/exe</CESMSCRATCHROOT>
+         <CESMSCRATCHROOT>/projects/$PROJECT/$ENV{USER}</CESMSCRATCHROOT>
          <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
          <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
          <DIN_LOC_ROOT>/projects/ccsm/inputdata</DIN_LOC_ROOT>


### PR DESCRIPTION
This commit addresses removes extraneous directoris added to CESMSCRATCHROOT on Mira.

On all other platforms, the CESM scratch directory has the form:

/path/to/scratchsystem/user/casename
And then within this directory, there are various subdirectorires such as bld (where the executable is build and stored), run, where the data is written while the model is running.  

On Mira, CESMSCRATCHROOT is set to
/projects/$PROJECT/$CCSMUSER/$CASE/scratch/exe

The addition of "scratch/exe" is pointless.  

For reference, the archive directory on Mira is set to:
/projects/$PROJECT/$CCSMUSER/archive/$CASE

This change is BFB
