### PR TITLE
Eliminating 'failure' message generated by calling 'svn info'

### DIFF
--- a/scripts/ccsm_utils/Tools/cesm_buildexe
+++ b/scripts/ccsm_utils/Tools/cesm_buildexe
@@ -216,30 +216,34 @@ endif
 #--- save model provenance with the executable
 cd $CCSMROOT
 
-git describe > $EXEROOT/GIT_DESCRIBE.$LID
-chmod 664 $EXEROOT/GIT_DESCRIBE.$LID
-/bin/cp -p $EXEROOT/GIT_DESCRIBE.$LID $EXEROOT/GIT_DESCRIBE
+if (-d $CCSMROOT/.git) then
+  git describe > $EXEROOT/GIT_DESCRIBE.$LID
+  chmod 664 $EXEROOT/GIT_DESCRIBE.$LID
+  /bin/cp -p $EXEROOT/GIT_DESCRIBE.$LID $EXEROOT/GIT_DESCRIBE
 
-if (-f $CCSMROOT/.git/logs/HEAD) then
-  /bin/cp $CCSMROOT/.git/logs/HEAD $EXEROOT/GIT_LOGS_HEAD.$LID
-  chmod 664 $EXEROOT/GIT_LOGS_HEAD.$LID
-  /bin/cp -p $EXEROOT/GIT_LOGS_HEAD.$LID $EXEROOT/GIT_LOGS_HEAD
-else
-  /bin/rm -f $EXEROOT/GIT_LOGS_HEAD
-  touch $EXEROOT/GIT_LOGS_HEAD
+  if (-f $CCSMROOT/.git/logs/HEAD) then
+    /bin/cp $CCSMROOT/.git/logs/HEAD $EXEROOT/GIT_LOGS_HEAD.$LID
+    chmod 664 $EXEROOT/GIT_LOGS_HEAD.$LID
+    /bin/cp -p $EXEROOT/GIT_LOGS_HEAD.$LID $EXEROOT/GIT_LOGS_HEAD
+  else
+    /bin/rm -f $EXEROOT/GIT_LOGS_HEAD
+    touch $EXEROOT/GIT_LOGS_HEAD
+  endif
 endif
 
-svn info > $EXEROOT/SVN_INFO.$LID
-chmod 664 $EXEROOT/SVN_INFO.$LID
-/bin/cp -p $EXEROOT/SVN_INFO.$LID $EXEROOT/SVN_INFO
+if (-d $CCSMROOT/.svn) then
+  svn info > $EXEROOT/SVN_INFO.$LID
+  chmod 664 $EXEROOT/SVN_INFO.$LID
+  /bin/cp -p $EXEROOT/SVN_INFO.$LID $EXEROOT/SVN_INFO
 
-if (-f $CCSMROOT/.svn/wc.db) then
-  /bin/cp $CCSMROOT/.svn/wc.db $EXEROOT/SVN_WC.DB.$LID
-  chmod 664 $EXEROOT/SVN_WC.DB.$LID
-  /bin/cp -p $EXEROOT/SVN_WC.DB.$LID $EXEROOT/SVN_WC.DB
-else
-  /bin/rm -f $EXEROOT/SVN_WC.DB
-  touch $EXEROOT/SVN_WC.DB
+  if (-f $CCSMROOT/.svn/wc.db) then
+    /bin/cp $CCSMROOT/.svn/wc.db $EXEROOT/SVN_WC.DB.$LID
+    chmod 664 $EXEROOT/SVN_WC.DB.$LID
+    /bin/cp -p $EXEROOT/SVN_WC.DB.$LID $EXEROOT/SVN_WC.DB
+  else
+    /bin/rm -f $EXEROOT/SVN_WC.DB
+    touch $EXEROOT/SVN_WC.DB
+  endif
 endif
 
 if (-d $CASEROOT/SourceMods) then


### PR DESCRIPTION
'git describe' and 'svn info' are both called in the logic that archives provenance
for the code with performance data, to provide something that will work both with
ACME and with non-ACME versions of CESM. This generates 'failed' messages 
depending on whether this is a git or a subversion repository.

Logic is added to test whether .git or .svn exist at the repository root before calling
git or svn commands, respectively. (This appears to be a standard approach.)

(bit-for-bit - does not touch source code or compiler options)
