### PR TITLE
Updating Mira makefile to pass ACME tests.

### DIFF
--- a/scripts/ccsm_utils/Machines/Depends.mira
+++ b/scripts/ccsm_utils/Machines/Depends.mira
@@ -1,3 +1,10 @@
+QSMPFLAGS:= 
+ifeq ($(compile_threaded), true)
+  QSMPFLAGS += -qsmp=noauto:noomp
+endif
+shr_reprosum_mod.o: shr_reprosum_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(QSMPFLAGS) $<
+
 mo_sethet.o: mo_sethet.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -qsmp=noauto:noomp $<
 mo_drydep.o: mo_drydep.F90


### PR DESCRIPTION
This reverts commit #eb8cdbe, which was intended to fix a build problem
in the case '-compset ICRUCLM45 -res f09_f09 -mach mira'. In this
case, threading is disabled by default, but shr_reprosum_mod.F90
is compiled with qsmp flag, which leads to undefined references.
That commit led to run-time errors (signal 6 / SIGABRT) in ACME
tests. With this commit, ACME tests pass on Mira and the I case
above also builds and runs.
