### PR TITLE
Updating build-namelist to create DIN_LOC_ROOT

### DIFF
--- a/models/atm/datm/bld/build-namelist
+++ b/models/atm/datm/bld/build-namelist
@@ -400,9 +400,7 @@ if ( $GRID eq "CLM_USRDAT" && $CLM_USRDAT_NAME =~ /^(UNSET|)$/ ) {
 EOF
 }
 
-(-d $DIN_LOC_ROOT)  or  die <<"EOF";
-** $ProgName - CESM inputdata root is not a directory: \"$DIN_LOC_ROOT\" **
-EOF
+(-d $DIN_LOC_ROOT)  or mkdir $DIN_LOC_ROOT;
 if ($print>=2) { print "CESM inputdata root directory: $DIN_LOC_ROOT$eol"; }
 
 if ($opts{'test'}) {

--- a/models/drv/bld/build-namelist
+++ b/models/drv/bld/build-namelist
@@ -303,9 +303,7 @@ foreach my $file (@files) {
     }
 }
 my $DIN_LOC_ROOT = $xmlvars{'DIN_LOC_ROOT'};
-(-d $DIN_LOC_ROOT)  or  die <<"EOF";
-** $ProgName - CCSM inputdata root is not a directory: \"$DIN_LOC_ROOT\" **
-EOF
+(-d $DIN_LOC_ROOT)  or mkdir $DIN_LOC_ROOT ;
 if ($print>=2) { print "CESM inputdata root directory: $DIN_LOC_ROOT$eol"; }
 
 # Note - $USER is not in the config_defintion.xml file - it is only in the environment

--- a/models/glc/cism/bld/build-namelist
+++ b/models/glc/cism/bld/build-namelist
@@ -368,9 +368,7 @@ my $GLC_NCPL               = $xmlvars{'GLC_NCPL'};
 my $CISM_USE_TRILINOS      = $xmlvars{'CISM_USE_TRILINOS'};
 my $CISM_OBSERVED_IC       = $xmlvars{'CISM_OBSERVED_IC'};
 
-(-d $DIN_LOC_ROOT)  or  die <<"EOF";
-** $ProgName - CCSM inputdata root is not a directory: \"$DIN_LOC_ROOT\" **
-EOF
+(-d $DIN_LOC_ROOT)  or mkdir $DIN_LOC_ROOT
 if ($print>=2) { print "CESM inputdata root directory: $DIN_LOC_ROOT$eol"; }
 
 ####################################

--- a/models/ice/dice/bld/build-namelist
+++ b/models/ice/dice/bld/build-namelist
@@ -287,9 +287,7 @@ my $ICE_DOMAIN_PATH = $xmlvars{'ICE_DOMAIN_PATH'};
 my $ICE_GRID        = $xmlvars{'ICE_GRID'};
 my $DICE_MODE       = $xmlvars{'DICE_MODE'};
 
-(-d $DIN_LOC_ROOT)  or  die <<"EOF";
-** $ProgName - CCSM inputdata root is not a directory: \"$DIN_LOC_ROOT\" **
-EOF
+(-d $DIN_LOC_ROOT)  or mkdir $DIN_LOC_ROOT;
 if ($print>=2) { 
     print "  CESM inputdata root directory: $DIN_LOC_ROOT$eol"; 
     print "  dice_mode is $DICE_MODE \n";

--- a/models/lnd/dlnd/bld/build-namelist
+++ b/models/lnd/dlnd/bld/build-namelist
@@ -304,9 +304,7 @@ my $LND_GRID         = $xmlvars{'LND_GRID'};
 my $DLND_MODE        = $xmlvars{'DLND_MODE'};        
 my $GLC_NEC          = $xmlvars{'GLC_NEC'};
 
-(-d $DIN_LOC_ROOT)  or  die <<"EOF";
-** $ProgName - CCSM inputdata root is not a directory: \"$DIN_LOC_ROOT\" **
-EOF
+(-d $DIN_LOC_ROOT)  or mkdir $DIN_LOC_ROOT;
 if ($print>=2) { print "CESM inputdata root directory: $DIN_LOC_ROOT$eol"; }
 
 ####################################

--- a/models/ocn/docn/bld/build-namelist
+++ b/models/ocn/docn/bld/build-namelist
@@ -288,9 +288,7 @@ my $OCN_GRID        = $xmlvars{'OCN_GRID'};
 my $DOCN_MODE       = $xmlvars{'DOCN_MODE'};
 my $SSTICE_STREAM   = $xmlvars{'SSTICE_STREAM'};
 
-(-d $DIN_LOC_ROOT)  or  die <<"EOF";
-** $ProgName - CCSM inputdata root is not a directory: \"$DIN_LOC_ROOT\" **
-EOF
+(-d $DIN_LOC_ROOT)  or mkdir $DIN_LOC_ROOT;
 if ($print>=2) { 
     print "CESM inputdata root directory: $DIN_LOC_ROOT \n"; 
     print "  docn mode is $DOCN_MODE \n";

--- a/models/ocn/pop2/bld/build-namelist
+++ b/models/ocn/pop2/bld/build-namelist
@@ -493,9 +493,7 @@ if ($tmp > 0) {
 print "POP2 build-namelist: ocn_grid is $OCN_GRID \n";
 print "POP2 build-namelist: ocn_tracer_modules are @OCN_TRACER_MODULES \n";
 
-(-d $DIN_LOC_ROOT)  or  die <<"EOF";
-** $ProgName - CCSM inputdata root is not a directory: \"$DIN_LOC_ROOT\" **
-EOF
+(-d $DIN_LOC_ROOT)  or mkdir $DIN_LOC_ROOT;
 if ($print>=2) { print "CESM inputdata root directory: $DIN_LOC_ROOT$eol"; }
 
 #-----------------------------------------------------------------------------------------------

--- a/models/rof/drof/bld/build-namelist
+++ b/models/rof/drof/bld/build-namelist
@@ -309,9 +309,7 @@ if ($ROF_GRID eq "null") {
     }
 }
 
-(-d $DIN_LOC_ROOT)  or  die <<"EOF";
-** $ProgName - CESM inputdata root is not a directory: \"$DIN_LOC_ROOT\" **
-EOF
+(-d $DIN_LOC_ROOT)  or mkdir $DIN_LOC_ROOT;
 if ($print>=2) { print "CESM inputdata root directory: $DIN_LOC_ROOT$eol"; }
 
 ####################################

--- a/models/rof/rtm/bld/build-namelist
+++ b/models/rof/rtm/bld/build-namelist
@@ -299,9 +299,7 @@ my $ROF_GRID        = $xmlvars{'ROF_GRID'};
 my $LND_GRID        = $xmlvars{'LND_GRID'};
 my $ROF_NCPL        = $xmlvars{'ROF_NCPL'};
 
-(-d $DIN_LOC_ROOT)  or  die <<"EOF";
-** $ProgName - CCSM inputdata root is not a directory: \"$DIN_LOC_ROOT\" **
-EOF
+(-d $DIN_LOC_ROOT)  or mkdir $DIN_LOC_ROOT;
 if ($print>=2) { 
     print "CESM inputdata root directory: $DIN_LOC_ROOT \n"; 
 }


### PR DESCRIPTION
This is useful when the input_data directory doesn't exist prior to
setting up a new case directory. Previously, if the input_data directory
didn't exist the build scripts for a case would fail.
