### PR TITLE
Cleaning up ${PROJECT} logic in Lawrencium machine files.

### DIFF
--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -390,6 +390,7 @@
          <SUPPORTED_BY>jnjohnson at lbl dot gov</SUPPORTED_BY>
          <GMAKE_J>12</GMAKE_J>
          <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
+         <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 </machine>
 
 <machine MACH="lawrencium-lr3">
@@ -411,6 +412,7 @@
          <SUPPORTED_BY>jnjohnson at lbl dot gov</SUPPORTED_BY>
          <GMAKE_J>16</GMAKE_J>
          <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
+         <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 </machine>
 
 <machine MACH="mira">

--- a/scripts/ccsm_utils/Machines/mkbatch.lawrencium-lr2
+++ b/scripts/ccsm_utils/Machines/mkbatch.lawrencium-lr2
@@ -6,19 +6,6 @@ if ($PHASE == set_batch) then
 
 source ./Tools/ccsm_getenv || exit -1
 
-if ($?ACCOUNT) then
-  set account_name = $ACCOUNT
-else
-  if (-e ~/.cesm_proj) then
-     set account_name = `head -1 ~/.cesm_proj`
-  else
-     echo "WARNING: invalid account number P00000000 used by default"
-     echo "WARNING: please use the ACCOUNT environment variable or ~/.cesm_proj to set this in the future"
-     set account_name = P00000000
-  endif
-endif
-
-
 set ntasks  = `${CASEROOT}/Tools/taskmaker.pl -sumonly`
 set maxthrds = `${CASEROOT}/Tools/taskmaker.pl -maxthrds`
 @ nodes = $ntasks / ${MAX_TASKS_PER_NODE}
@@ -41,7 +28,7 @@ cat >! $file << EOF1
 #!/bin/csh -f
 #SBATCH --job-name=${CASE}
 #SBATCH --partition=lr2
-#SBATCH --account=$account_name
+#SBATCH --account=${PROJECT}
 #SBATCH --time=$tlimit
 #SBATCH --nodes=$nodes
 #SBATCH --ntasks=$ntasks

--- a/scripts/ccsm_utils/Machines/mkbatch.lawrencium-lr3
+++ b/scripts/ccsm_utils/Machines/mkbatch.lawrencium-lr3
@@ -6,19 +6,6 @@ if ($PHASE == set_batch) then
 
 source ./Tools/ccsm_getenv || exit -1
 
-if ($?ACCOUNT) then
-  set account_name = $ACCOUNT
-else
-  if (-e ~/.cesm_proj) then
-     set account_name = `head -1 ~/.cesm_proj`
-  else
-     echo "WARNING: invalid account number P00000000 used by default"
-     echo "WARNING: please use the ACCOUNT environment variable or ~/.cesm_proj to set this in the future"
-     set account_name = P00000000
-  endif
-endif
-
-
 set ntasks  = `${CASEROOT}/Tools/taskmaker.pl -sumonly`
 set maxthrds = `${CASEROOT}/Tools/taskmaker.pl -maxthrds`
 @ nodes = $ntasks / ${MAX_TASKS_PER_NODE}
@@ -41,7 +28,7 @@ cat >! $file << EOF1
 #!/bin/csh -f
 #SBATCH --job-name=${CASE}
 #SBATCH --partition=lr3
-#SBATCH --account=$account_name
+#SBATCH --account=${PROJECT}
 #SBATCH --time=$tlimit
 #SBATCH --nodes=$nodes
 #SBATCH --ntasks=$ntasks


### PR DESCRIPTION
- Removed ${ACCOUNT} logic from Lawrencium mkbatch.\* files.
- These files now refer to ${PROJECT} instead.
- PROJECT variable is now required for Lawrencium machines.
