### PR TITLE
modifying one line to eliminate Cray compiler complaint

### DIFF
--- a/models/rof/rtm/src/riverroute/RtmMod.F90
+++ b/models/rof/rtm/src/riverroute/RtmMod.F90
@@ -400,8 +400,8 @@ contains
          !-------------------------------------------------------
          ! Put in a check for a negative rdirc value and abort.
          !-------------------------------------------------------
-         if ( tempr(i,j) .lt. 0 ) call shr_sys_abort( trim(subname)//' ERROR: Found a negative RTM_FLOW_DIRECTION. &
-              This is currently not supported. ' )
+         if ( tempr(i,j) .lt. 0 ) call shr_sys_abort( trim(subname)// &
+              ' ERROR: Found a negative RTM_FLOW_DIRECTION. This is currently not supported. ' )
          n = (j-1)*rtmlon + i
          rdirc(n) = nint(tempr(i,j))
       enddo


### PR DESCRIPTION
One line in RtmMod.F90 has a continuation '&' in the middle of string, and the Cray compiler would not compile this. Rewriting this to place the continuation outside of the string eliminates the problem.

With this change the model built (PGI on Titan) and ran successfully. The modified line is only executed if the model aborts, and this error condition was not tested. Otherwise, this change is bit-for-bit.
