### PR TITLE
Fixing the old style of specifying the PIO filesystem hints

### DIFF
--- a/scripts/ccsm_utils/Machines/config_compilers.xml
+++ b/scripts/ccsm_utils/Machines/config_compilers.xml
@@ -293,6 +293,7 @@ for mct, etc.
   <PNETCDF_PATH></PNETCDF_PATH>
   <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nc-config --flibs) </ADD_SLIBS>
   <ADD_CPPFLAGS> -DHAVE_COMM_F2C </ADD_CPPFLAGS>
+  <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
 </compiler>
 
 <compiler COMPILER="intel14">

--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -65,7 +65,6 @@
 <machine MACH="redsky">
         <DESC>SNL Redsky cluster, Linux (x86_64)</DESC>                                 <!-- can be anything -->
         <OS>LINUX</OS>                              <!-- LINUX,Darwin,CNL,AIX,BGL,BGP -->
-        <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
         <COMPILERS>intel</COMPILERS>     <!-- intel,ibm,pgi,pathscale,gnu,cray,lahey -->
         <MPILIBS>openmpi,mpi-serial</MPILIBS>                <!-- openmpi, mpich, ibm, mpi-serial -->
         <CESMSCRATCHROOT>/gscratch1/$USER/acme_scratch</CESMSCRATCHROOT>


### PR DESCRIPTION
Moving all instances of the old style of specifying the
filesystem hints to the newer style. Without the fix, these
filesystem hints are not recognized and hence not used.

[BFB]
