### PR TITLE
Print refdir when build namelist script fails to find restart file

### DIFF
--- a/models/rof/rtm/bld/rtm.buildnml.csh
+++ b/models/rof/rtm/bld/rtm.buildnml.csh
@@ -63,6 +63,7 @@ if ($RUN_TYPE == 'hybrid' || $RUN_TYPE == "branch" ) then
         set fncheck = "${RUN_REFCASE}.clm2.r.${RUN_REFDATE}-${RUN_REFTOD}.nc"
         if !(-e "$refdir/$fncheck") then
           echo "rtm.buildnml.csh could not find restart file for branch or hybrid start"
+          echo "refdir is" $refdir
           exit -8
         endif
       endif


### PR DESCRIPTION
When you know the refdir, the error becomes easy to fix:

The refdir should be something like this:
    $DIN_LOC_ROOT/ccsm4_init/b40_20th_2d_r07c5cn_161jp/1979-01-01

cd to ccsm init area: cd $DIN_LOC_ROOT/ccsm4_init
get files based on 2nd-to-last directory in refdir: svn co https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/ccsm4_init/b40_20th_2d_r07c5cn_161jp
