### PR TITLE
Including the Fortran C interface cmake module before using it

### DIFF
--- a/models/utils/timing/CMakeLists.txt
+++ b/models/utils/timing/CMakeLists.txt
@@ -1,3 +1,4 @@
+INCLUDE(FortranCInterface)
 FortranCInterface_HEADER(cmake_fortran_c_interface.h
                          MACRO_NAMESPACE  "FCI_")
 


### PR DESCRIPTION
The Fortran C interface cmake module needs to be included before
using functions in the module. Without the fix a cmake build of
the timing util will fail.

[B4B]
