### PR TITLE
Fixing memory leak for CLM restart files

### DIFF
--- a/models/lnd/clm/src/ED/main/EDRestVectorMod.F90
+++ b/models/lnd/clm/src/ED/main/EDRestVectorMod.F90
@@ -485,6 +485,7 @@ contains
 
       call get_clmlevel_gsmap(clmlevel='cohort', gsmap=gsmap)
       call mct_gsmap_OP(gsmap, iam, gsmOP)
+      deallocate(gsmOP)
 
       !
       ! cohort level vars

--- a/models/lnd/clm/src/main/GetGlobalValuesMod.F90
+++ b/models/lnd/clm/src/main/GetGlobalValuesMod.F90
@@ -58,6 +58,7 @@ contains
     call get_clmlevel_gsmap(clmlevel=trim(clmlevel), gsmap=gsmap)
     call mct_gsmap_op(gsmap, iam, gsmap_ordered)
     GetGlobalIndex = gsmap_ordered(decomp_index - beg_index + 1)
+    deallocate(gsmap_ordered)
 
   end function GetGlobalIndex
 

--- a/models/lnd/clm/src_clm40/main/GetGlobalValuesMod.F90
+++ b/models/lnd/clm/src_clm40/main/GetGlobalValuesMod.F90
@@ -58,6 +58,7 @@ contains
     call get_clmlevel_gsmap(clmlevel=trim(clmlevel), gsmap=gsmap)
     call mct_gsmap_op(gsmap, iam, gsmap_ordered)
     GetGlobalIndex = gsmap_ordered(decomp_index - beg_index + 1)
+    deallocate(gsmap_ordered)
 
   end function GetGlobalIndex
 


### PR DESCRIPTION
Memory leak bug existed in cesm1_3_beta10 tag related to restart files for CLM. 
- This memory leak bug was reported to NCAR: [Bug 2029](http://bugs.cgd.ucar.edu/show_bug.cgi?id=2029).
- In this PR, memory leak bug is fixed at one of the locations within CLM code (models/lnd/clm/src/util_share/GetGlobalValuesMod.F90).
-  A second memory leak bug, which relates to ED code (as reported in [Bug 2029](http://bugs.cgd.ucar.edu/show_bug.cgi?id=2029)), will be fixed in a separate PR because it originated from a different changeset (114fbe8).
