### PR TITLE
Quicker build times on Mira

### DIFF
--- a/scripts/ccsm_utils/Machines/Depends.mira
+++ b/scripts/ccsm_utils/Machines/Depends.mira
@@ -12,3 +12,30 @@ mo_drydep.o: mo_drydep.F90
 time_management.o: time_management.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -qsmp=noauto:noomp $<
 
+
+### These files take long time to compile with default optimization flags.
+### Reducing optimization gives <1min build-times and little impact on model run time.
+### begin
+## atm files taking more than a minute to compile
+# this takes 9 mins to compile at default -O3 level
+buffer.o: buffer.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O0 $<
+
+## lnd files taking more than a minute to compile
+# this takes 4 mins to compile with -O3 -qsmp=omp
+BiogeophysRestMod.o: BiogeophysRestMod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O0 -qsmp=noopt $<
+
+# this takes 17 mins to compile with -O3 -qsmp=omp
+CNrestMod.o: CNrestMod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O0 -qsmp=noopt $<
+
+# this takes 4 mins to compile with -qsmp=omp
+clmtypeInitMod.o: clmtypeInitMod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -qsmp=noopt $<
+
+# this takes 2 mins to compile with -qsmp=omp
+clmtype.o: clmtype.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -qsmp=noopt $<
+### end
+


### PR DESCRIPTION
This reduces optimization on files taking >1min to compile.
The impact on run-time is less than 0.1%.
[BFB]
