### PR TITLE
Fixed uninitialized vars in rrtmg_sw_spcvmc.f90 and diffusion_solver.F90

### DIFF
--- a/models/atm/cam/src/physics/cam/diffusion_solver.F90
+++ b/models/atm/cam/src/physics/cam/diffusion_solver.F90
@@ -305,6 +305,7 @@
     real(r8) :: ttemp(pcols,pver)			 ! temporary temperature array
     real(r8) :: ttemp0(pcols,pver)			 ! temporary temperature array
 
+    dtk(:ncol,:pver) = 0.0_r8 !BSINGH(10/15/2014):Initialized to zero;This variable was uninitialized when we diffuse anything except than 'u' and 'v'
     ! ------------------------------------------------ !
     ! Parameters for implicit surface stress treatment !
     ! ------------------------------------------------ !

--- a/models/atm/cam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
+++ b/models/atm/cam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
@@ -296,7 +296,8 @@
          pnicu(jk)=0._r8
          pnifu(jk)=0._r8
       enddo
-
+      pbbfsu(:,:) = 0.0_r8 !BSINGH(10/15/2014): uninitialized variable, setting it to zero
+      pbbfsd(:,:) = 0.0_r8 !BSINGH(10/15/2014): uninitialized variable, setting it to zero
 
 ! Calculate the optical depths for gaseous absorption and Rayleigh scattering
 


### PR DESCRIPTION
Fixed uninitialized variables in models/atm/cam/src/physics/cam/diffusion_solver.F90
and models/atm/cam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90.
These uninitialized variables were caught by using NAG compiler with full debug
options. The results stayed B4B.
