### PR TITLE
Add support for Melvin, a powerful Sandia SON desktop

### DIFF
--- a/scripts/ccsm_utils/Machines/config_compilers.xml
+++ b/scripts/ccsm_utils/Machines/config_compilers.xml
@@ -559,6 +559,13 @@ for mct, etc.
   <ADD_SLIBS>-L$(NETCDF_PATH)/lib -lnetcdff -lnetcdf</ADD_SLIBS>
 </compiler>
 
+<compiler COMPILER="gnu" MACH="melvin">
+  <NETCDF_PATH>$(NETCDFROOT)</NETCDF_PATH>
+  <PNETCDF_PATH>$(PNETCDFROOT)</PNETCDF_PATH>
+  <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) </ADD_SLIBS>
+  <ADD_CPPFLAGS> -DHAVE_COMM_F2C </ADD_CPPFLAGS>
+</compiler>
+
 <compiler>
   <ADD_CPPDEFS MODEL="pop2"> -D_USE_FLOW_CONTROL </ADD_CPPDEFS>
 </compiler>

--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -463,6 +463,30 @@
     <PES_PER_NODE>2</PES_PER_NODE>
 </machine>
 
+<machine MACH="melvin">
+    <DESC>Linux workstation for Jenkins testing</DESC>
+    <OS>LINUX</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <CESMSCRATCHROOT>$ENV{HOME}/acme/scratch</CESMSCRATCHROOT>
+    <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
+    <DIN_LOC_ROOT>$ENV{HOME}/acme/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/acme/ptclmdata</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$ENV{HOME}/archive/$CASE</DOUT_S_ROOT>
+    <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
+
+    <CCSM_BASELINE>$ENV{HOME}/acme/baselines</CCSM_BASELINE>
+    <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
+    <BATCHQUERY></BATCHQUERY>
+    <BATCHSUBMIT></BATCHSUBMIT>
+    <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
+<!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
+    <GMAKE_J>16</GMAKE_J>
+    <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
+    <PES_PER_NODE>2</PES_PER_NODE>
+</machine>
+
 <machine MACH="mira">
          <DESC>ANL IBM BG/Q, os is BGP, 16 pes/node, batch system is cobalt</DESC>
          <COMPILERS>ibm</COMPILERS>

--- a/scripts/ccsm_utils/Machines/env_mach_specific.melvin
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.melvin
@@ -1,0 +1,33 @@
+#! /bin/csh -f
+
+#===============================================================================
+# Melinv specific settings
+#===============================================================================
+
+setenv LD_LIBRARY_PATH /usr/lib64:/usr/lib:$LD_LIBRARY_PATH
+
+# gcc-4.7.4
+setenv PATH /home/jgfouca/packages/gcc-4.7.4-install/bin:$PATH
+setenv LD_LIBRARY_PATH /home/jgfouca/packages/gcc-4.7.4-install/lib:$LD_LIBRARY_PATH
+setenv LD_LIBRARY_PATH /home/jgfouca/packages/gcc-4.7.4-install/lib64:$LD_LIBRARY_PATH
+setenv LD_LIBRARY_PATH /usr/lib64/gfortran/modules:$LD_LIBRARY_PATH
+
+# openmpi
+setenv PATH /home/jgfouca/packages/openmpi-1.8.1-install/bin:$PATH
+setenv LD_LIBRARY_PATH /home/jgfouca/packages/openmpi-1.8.1-install/lib:$LD_LIBRARY_PATH
+setenv MPI_BIN /home/jgfouca/packages/openmpi-1.8.1-install/bin
+setenv MPI_SYSCONFIG /etc/compat-openmpi-x86_64
+setenv MPI_FORTRAN_MOD_DIR /home/jgfouca/packages/openmpi-1.8.1-install/lib
+setenv MPI_INCLUDE /home/jgfouca/packages/openmpi-1.8.1-install/include
+setenv MPI_LIB /home/jgfouca/packages/openmpi-1.8.1-install/lib
+setenv MPI_MAN /home/jgfouca/packages/openmpi-1.8.1-install/share/man
+setenv MPI_HOME /home/jgfouca/packages/openmpi-1.8.1-install
+
+# Get newer netcdf
+setenv NETCDFROOT /home/jgfouca/packages/netcdf-4.3.2-install
+setenv PATH $NETCDFROOT/bin:$PATH
+setenv LD_LIBRARY_PATH $NETCDFROOT/lib:$LD_LIBRARY_PATH
+setenv NETCDF_INCLUDES $NETCDFROOT/include
+setenv NETCDF_LIBS $NETCDFROOT/lib
+
+setenv PNETCDFROOT $NETCDFROOT

--- a/scripts/ccsm_utils/Machines/mkbatch.melvin
+++ b/scripts/ccsm_utils/Machines/mkbatch.melvin
@@ -1,0 +1,120 @@
+#! /bin/tcsh -f
+
+#################################################################################
+if ($PHASE == set_batch) then
+#################################################################################
+source ./Tools/ccsm_getenv || exit -1
+
+# Determine tasks and threads for batch queue 
+
+
+
+set maxthrds = 0
+set minthrds = $MAX_TASKS_PER_NODE
+@ n = 0
+foreach model ($MODELS)
+  @ n = $n + 1
+  if ($NTHRDS[$n] > $MAX_TASKS_PER_NODE ) then
+     echo "ERROR, NTHRDS maximum is $MAX_TASKS_PER_NODE"
+     echo "you have set NTHRDS = ( $NTHRDS[$n] ) - must reset"
+     exit 1
+  endif   
+  if ($NTHRDS[$n] > $maxthrds) then
+     set maxthrds = $NTHRDS[$n]
+  endif
+  if ($NTHRDS[$n] < $minthrds) then
+     set minthrds = $NTHRDS[$n]
+  endif
+end
+
+
+./xmlchange -file env_mach_pes.xml -id COST_PES -val 0
+# This is the maximum number of mpi tasks we want on a node.
+@ ptile = ${MAX_TASKS_PER_NODE} / 2
+set ntasks_tot = `${CASEROOT}/Tools/taskmaker.pl -sumtasks`
+
+if ($maxthrds > $minthrds) then
+# We don't need this if all we are doing is exploiting hyperthreading
+  if ( $maxthrds > 2) then
+    set task_geo   = `${CASEROOT}/Tools/taskmaker.pl`
+  endif
+  set thrd_geo   = `${CASEROOT}/Tools/taskmaker.pl -thrdgeom`
+else
+  if ($maxthrds > 1) then
+    @ ptile = $MAX_TASKS_PER_NODE / $maxthrds
+  endif 
+endif
+
+@ nodes = ${ntasks_tot} / ${ptile}
+if ( ${ntasks_tot} % ${ptile} > 0) then
+  @ nodes = $nodes + 1
+endif
+# costpes is the number of nodes used * the number of cores per node
+# or the total number of cores used, that needs to be set for cost
+@ costpes = ${nodes} * ${PES_PER_NODE}
+
+./xmlchange -file env_mach_pes.xml -id COST_PES -val ${costpes}
+
+if ($?TESTMODE) then
+ set file = $CASEROOT/${CASE}.test 
+else
+ set file = $CASEROOT/${CASE}.run 
+endif
+
+cat >! $file << EOF1
+#! /bin/tcsh -f
+EOF1
+
+#################################################################################
+else if ($PHASE == set_exe) then
+#################################################################################
+    source ./Tools/ccsm_getenv || exit -1
+
+    set maxthrds = `${CASEROOT}/Tools/taskmaker.pl -maxthrds`
+    set maxtasks = `${CASEROOT}/Tools/taskmaker.pl -sumtasks`
+
+    cat >> ${CASEROOT}/${CASE}.run << EOF1
+# -------------------------------------------------------------------------
+# Run the model
+# -------------------------------------------------------------------------
+
+set maxthrds = $maxthrds
+set maxtasks = $maxtasks
+
+cd \$RUNDIR
+echo "\`date\` -- CSM EXECUTION BEGINS HERE" 
+setenv MP_LABELIO yes
+setenv OMP_NUM_THREADS \$maxthrds
+if ( "\$MPILIB" == "mpi-serial" ) then
+    \$EXEROOT/cesm.exe >&! cesm.log.\$LID
+else
+    mpirun -np \$maxtasks \$EXEROOT/cesm.exe >&! cesm.log.\$LID
+endif
+
+wait
+echo "\`date\` -- CSM EXECUTION HAS FINISHED" 
+
+# -------------------------------------------------------------------------
+# For Postprocessing
+# -------------------------------------------------------------------------
+EOF1
+
+
+#################################################################################
+else if ($PHASE == set_larch) then
+#################################################################################
+
+    echo " Archiving not supported on this machine."
+
+#################################################################################
+else
+#################################################################################
+
+    echo "  PHASE setting of $PHASE is not an accepted value"
+    echo "  accepted values are set_batch, set_exe and set_larch"
+    exit 1
+
+#################################################################################
+endif
+#################################################################################
+

--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -60,27 +60,141 @@
         <machine compiler="pgi" testtype="prerelease">hopper</machine>
         <machine compiler="ibm" testtype="prerelease">intrepid</machine>
       </test>
+      <test name="ERS">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
+      </test>
       <test name="ERS_D">
         <machine compiler="intel" testtype="aux_drv">yellowstone</machine>
       </test>
       <test name="ERS_IOP">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
       </test>
       <test name="ERS_IOP4c">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
       </test>
       <test name="ERS_IOP4p">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
       </test>
       <test name="ERS_N2">
@@ -97,14 +211,42 @@
         <machine compiler="pgi" testtype="prerelease">titan</machine>
       </test>
       <test name="NCK">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
         <machine compiler="intel" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="prebeta">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="pgi" testtype="prerelease">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="ibm" testtype="prerelease">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="intel" testtype="prebeta">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
@@ -165,9 +307,37 @@
         <machine compiler="ibm" testtype="prerelease">intrepid</machine>
       </test>
       <test name="PEA_P1_M">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
@@ -197,13 +367,41 @@
         <machine compiler="pgi" testtype="prerelease">titan</machine>
       </test>
       <test name="SMS">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
         <machine compiler="pgi" testtype="prebeta">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="pgi" testtype="prerelease">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="ibm" testtype="prerelease">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="intel" testtype="prebeta">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
@@ -215,9 +413,37 @@
     </grid>
     <grid name="ne30_g16_rx1">
       <test name="ERS">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
         <machine compiler="intel" testtype="prebeta">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="prebeta">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
         <machine compiler="pgi" testtype="prebeta">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
       </test>
       <test name="ERS_D">
         <machine compiler="ibm" testtype="prebeta">cetus</machine>
@@ -225,23 +451,107 @@
         <machine compiler="ibm" testtype="prebeta">mira</machine>
       </test>
       <test name="ERS_IOP">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
       </test>
       <test name="ERS_IOP4c">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
       </test>
       <test name="ERS_IOP4p">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
       </test>
     </grid>
@@ -394,13 +704,69 @@
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
       </test>
       <test name="ERS">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
       </test>
       <test name="ERS_D">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
       </test>
@@ -1510,11 +1876,69 @@
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
       </test>
+      <test name="ERS">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
+      </test>
       <test name="ERS_IOP">
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel " testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="intel" testtype="prebeta">janus</machine>
+        <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="null" testtype="acme_developer">null</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
@@ -3081,9 +3505,9 @@
         <machine compiler="nag" testtype="prealpha">goldbach</machine>
         <machine compiler="nag" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="aux_clm45" testmods="clm/decStart">yellowstone</machine>
+        <machine compiler="pgi" testtype="aux_clm45" testmods="clm/decStart">yellowstone</machine>
         <machine compiler="intel" testtype="aux_clm_short">yellowstone</machine>
         <machine compiler="pgi" testtype="aux_clm_short">yellowstone</machine>
-        <machine compiler="pgi" testtype="aux_clm45" testmods="clm/decStart">yellowstone</machine>
       </test>
       <test name="ERS_D">
         <machine compiler="nag" testtype="aux_clm_short" testmods="clm/reduceOutput">goldbach</machine>
@@ -3296,11 +3720,11 @@
       <test name="ERS_Ld42">
         <machine compiler="nag" testtype="aux_clm45" testmods="clm/reduceOutput">goldbach</machine>
       </test>
-      <test name="SMS_Ln48_D">
-        <machine compiler="nag" testtype="aux_clm45" testmods="clm/oldhyd">goldbach</machine>
-      </test>
       <test name="SMS_D">
         <machine compiler="gnu" testtype="aux_clm45_np4" testmods="clm/default">mac</machine>
+      </test>
+      <test name="SMS_Ln48_D">
+        <machine compiler="nag" testtype="aux_clm45" testmods="clm/oldhyd">goldbach</machine>
       </test>
       <test name="SSP">
         <machine compiler="intel" testtype="aux_scripts">yellowstone</machine>


### PR DESCRIPTION
This is the key step towards moving more testing of ACME
onto Melvin through Jenkins.
