### PR TITLE
When a testcase (*_IOP) needs to create a sub testcase, put the sub test...

### DIFF
--- a/scripts/ccsm_utils/Tools/testcase_begin
+++ b/scripts/ccsm_utils/Tools/testcase_begin
@@ -49,7 +49,7 @@ echo "test started $sdate" >>& CaseStatus
 #======================================================================
 
 if ( ${CASE} =~ *_IOP*) then
-  set iopbase_argv = `echo ${TEST_ARGV} |  sed 's/_IOP[A-Z4cp]*//'`
+  set iopbase_argv = "`echo ${TEST_ARGV} |  sed 's/_IOP[A-Z4cp]*//' | sed 's/ -testroot [^ ]* / /'` -testroot $CASEROOT"
   set iopbase_case = `echo ${CASE} |  sed 's/_IOP[A-Z4cp]*//'`
   set iopflags = `echo $CASE | sed 's/^.*_IOP\([A-Z4cp]*\).*/\1/'`
   echo "running create_test ${iopbase_argv}  -clean off -testid ${TEST_TESTID}" >>& $TESTSTATUS_LOG
@@ -62,7 +62,7 @@ if ( ${CASE} =~ *_IOP*) then
   cd $CASEROOT  || exit -9
   ./xmlchange  HIST_OPTION='$STOP_OPTION'
   ./xmlchange  HIST_N='$STOP_N'
-  cd ../${iopbase_case}  || exit -9
+  cd ${iopbase_case}  || exit -9
   cp $CASEROOT/env_build.xml* .
   cp $CASEROOT/env_run.xml* .
   foreach file (env_build.xml*)

--- a/scripts/ccsm_utils/Tools/testcase_end
+++ b/scripts/ccsm_utils/Tools/testcase_end
@@ -10,8 +10,8 @@
 if ( ${CASE} =~ *_IOP* && $basestatus == "PASS") then
   gunzip $CASEROOT/logs/cpl.log*.gz
   set cpllogi = `ls -1t $CASEROOT/logs/cpl.log* | head -1`
-  gunzip $CASEROOT/../${iopbase_case}/logs/cpl.log*.gz
-  set cpllogn = `ls -1t $CASEROOT/../${iopbase_case}/logs/cpl.log* | head -1`
+  gunzip $CASEROOT/${iopbase_case}/logs/cpl.log*.gz
+  set cpllogn = `ls -1t $CASEROOT/${iopbase_case}/logs/cpl.log* | head -1`
   $CASETOOLS/check_exactrestart.pl $cpllogn $cpllogi >>& $TESTSTATUS_LOG
   set pass = `tail -1 $TESTSTATUS_LOG | grep PASS | wc -l`
   if ( $pass != 0 ) then
@@ -299,7 +299,7 @@ if ( "$memleak" !~ "" || "$pesmaxmem_incr" != "" || "$tput_decr" !~ "" || "$tput
 endif
 
 if ( ${CASE} =~ *_IOP* ) then
-  cat ../${iopbase_case}/TestStatus >> $TESTSTATUS_OUT
+  cat ${iopbase_case}/TestStatus >> $TESTSTATUS_OUT
 endif
 
 #======================================================================


### PR DESCRIPTION
...case in the directory of the original test

This was causing problems and ambiguity when the sub testcase had the
same name as a testcase in the xml_category that was being run.

This change resulted in the very first 100% pass of a significant
test category that I've ever seen since we've started.
