### PR TITLE
SEG-28 Update ESMF to newer CESM version

### DIFF
--- a/models/utils/esmf_wrf_timemgr/ChangeLog
+++ b/models/utils/esmf_wrf_timemgr/ChangeLog
@@ -1,4 +1,46 @@
 ===============================================================
+Originator: jshollen
+Date: Oct 28, 2014
+Model: esmf_wrf_timemgr
+Version: esmf_wrf_timemgr_141028
+One-line Summary: ESMF_TimeMod fix, line 838 broke nag build.  
+
+M       ESMF_TimeMod.F90
+
+===============================================================
+Originator: douglasj
+Date: Oct 6, 2014
+Model: esmf_wrf_timemgr
+Version: esmf_wrf_timemgr_141006
+One-line Summary: Add variable width years and standalone Makefile
+
+On Oct 6, 2014 at 15:50 MT (at ~revision 64105)
+  svn merge $SVNREPO/esmf_wrf_timemgr/trunk $SVNREPO//esmf_wrf_timemgr/branches/esmf_variable_width_year
+  svn merge $SVNREPO/esmf_wrf_timemgr/trunk https://svn-ccsm-models.cgd.ucar.edu/esmf_wrf_timemgr/branches/esmf_library_makefile/
+
+M       ESMF_TimeMod.F90
+A       Makefile
+
+===============================================================
+Originator: muszala
+Date: May 29, 2014
+Model: esmf_wrf_timemgr
+Version: esmf_wrf_timemgr_140529
+One-line Summary: change deallocate statements in ESMF_ClockMod.F90
+
+M       ESMF_ClockMod.F90
+===============================================================
+Originator: muszala
+Date: May 23, 2014
+Model: esmf_wrf_timemgr
+Version: esmf_wrf_timemgr_140523
+One-line Summary: add if(associated) to ESMF_ClockDestroy
+
+Note: use with rtm1_0_38 and tested with clm4_5_72.  this should work with older
+versions of clm and rtm however.
+
+M       ESMF_ClockMod.F90
+===============================================================
 Originator: santos
 Date: Feb 13, 2012
 Model: esmf_wrf_timemgr

--- a/models/utils/esmf_wrf_timemgr/ESMF_ClockMod.F90
+++ b/models/utils/esmf_wrf_timemgr/ESMF_ClockMod.F90
@@ -277,15 +277,22 @@
         ESMF_ClockCreate = clocktmp
       END FUNCTION ESMF_ClockCreate
 
-
-! Deallocate memory for ESMF_Clock
+      !
+      ! Deallocate memory for ESMF_Clock
+      !
       SUBROUTINE ESMF_ClockDestroy( clock, rc )
+
          TYPE(ESMF_Clock), INTENT(INOUT) :: clock
          INTEGER,          INTENT(  OUT), OPTIONAL :: rc
+
+         if (associated(clock%clockint)) then
+            if (associated(clock%clockint%AlarmList)) deallocate(clock%clockint%AlarmList)
+            deallocate(clock%clockint)
+         endif
+
          ! TBH:  ignore deallocate errors, for now
-         DEALLOCATE( clock%clockint%AlarmList )
-         DEALLOCATE( clock%clockint )
          IF ( PRESENT( rc ) ) rc = ESMF_SUCCESS
+
       END SUBROUTINE ESMF_ClockDestroy
 
 

--- a/models/utils/esmf_wrf_timemgr/ESMF_TimeMod.F90
+++ b/models/utils/esmf_wrf_timemgr/ESMF_TimeMod.F90
@@ -82,6 +82,7 @@
 ! Required inherited and overridden ESMF_Base class methods
 
       public ESMF_TimeCopy
+      public ESMF_SetYearWidth
 
 ! !PRIVATE MEMBER FUNCTIONS:
 
@@ -121,6 +122,8 @@
 ! The following line turns the CVS identifier string into a printable variable.
       character(*), parameter, private :: version = &
       '$Id$'
+
+      integer :: yearWidth = 4
 
 !==============================================================================
 !
@@ -805,6 +808,7 @@ recursive subroutine ESMF_TimeGet(time, YY, MM, DD, D, Dl, H, M, S, MS, &
       integer, intent(in) :: minute
       integer, intent(in) :: second
       character*(*), intent(out) :: TimeString
+      character*(256) :: TimeFormatString
 ! !DESCRIPTION:
 !     Convert {\tt ESMF\_Time}'s value into ISO 8601 format YYYY-MM-DDThh:mm:ss
 !
@@ -831,8 +835,9 @@ recursive subroutine ESMF_TimeGet(time, YY, MM, DD, D, Dl, H, M, S, MS, &
 
 !$$$here...  add negative sign for YR<0
 !$$$here...  add Sn, Sd ??
-      write(TimeString,FMT="(I4.4,'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2,':',I2.2)") &
-             year,month,dayofmonth,hour,minute,second
+      write(TimeFormatString,FMT="(A,I4.4,A,I4.4,A)") &
+           "(I", yearWidth, ".", yearWidth, "'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2,':',I2.2)"
+      write(TimeString,FMT=TimeFormatString) year,month,dayofmonth,hour,minute,second
 
       end subroutine ESMFold_TimeGetString
 
@@ -1545,6 +1550,20 @@ SUBROUTINE timeaddmonths( time, MM, ierr )
   time%basetime%s = time%basetime%s + isec
 
 END SUBROUTINE timeaddmonths
+
+!==============================================================================
+
+! Increment Time by number of seconds between start of year and start 
+! of month MM.  
+! 1 <= MM <= 12
+! Time is NOT normalized.  
+SUBROUTINE ESMF_setYearWidth( yearWidthIn )
+
+    integer, intent(in) :: yearWidthIn
+
+    yearWidth = yearWidthIn
+
+END SUBROUTINE ESMF_setYearWidth
 
 !==============================================================================
 !==============================================================================

--- a/models/utils/esmf_wrf_timemgr/Makefile
+++ b/models/utils/esmf_wrf_timemgr/Makefile
@@ -1,0 +1,60 @@
+.SUFFIXES: .F90 .o
+
+OBJS = ESMF_AlarmClockMod.o \
+	   ESMF_AlarmMod.o \
+	   ESMF_BaseMod.o \
+	   ESMF_BaseTimeMod.o \
+	   ESMF_CalendarMod.o \
+	   ESMF_ClockMod.o \
+	   ESMF.o \
+	   ESMF_FractionMod.o \
+	   ESMF_ShrTimeMod.o \
+	   ESMF_Stubs.o \
+	   ESMF_TimeIntervalMod.o \
+	   ESMF_TimeMod.o \
+	   MeatMod.o \
+	   wrf_error_fatal.o \
+	   wrf_message.o
+
+all: $(OBJS)
+	ar -ru libesmf_time.a *.o
+	
+ESMF_AlarmClockMod.o: ESMF_AlarmMod.o ESMF_ClockMod.o ESMF_TimeIntervalMod.o ESMF_TimeMod.o
+
+ESMF_AlarmMod.o: ESMF_BaseMod.o ESMF_TimeIntervalMod.o ESMF_TimeMod.o
+
+ESMF_BaseMod.o:
+
+ESMF_BaseTimeMod.o: ESMF_BaseMod.o
+
+ESMF_CalendarMod.o: ESMF_BaseMod.o ESMF_BaseTimeMod.o
+
+ESMF_ClockMod.o: ESMF_BaseMod.o ESMF_TimeIntervalMod.o ESMF_TimeMod.o ESMF_AlarmMod.o ESMF_TimeMod.o
+
+ESMF.o: ESMF_AlarmMod.o ESMF_BaseMod.o ESMF_BaseTimeMod.o \
+		ESMF_CalendarMod.o ESMF_ClockMod.o ESMF_FractionMod.o \
+		ESMF_TimeIntervalMod.o ESMF_TimeMod.o ESMF_ShrTimeMod.o \
+		ESMF_AlarmClockMod.o ESMF_Stubs.o MeatMod.o 
+
+ESMF_FractionMod.o:
+
+ESMF_ShrTimeMod.o: ESMF_BaseMod.o ESMF_BaseTimeMod.o ESMF_CalendarMod.o
+
+ESMF_Stubs.o: ESMF_BaseMod.o ESMF_CalendarMod.o
+
+ESMF_TimeIntervalMod.o: ESMF_BaseMod.o ESMF_BaseTimeMod.o ESMF_FractionMod.o ESMF_CalendarMod.o ESMF_ShrTimeMod.o
+
+ESMF_TimeMod.o: ESMF_BaseMod.o ESMF_BaseTimeMod.o ESMF_TimeIntervalMod.o ESMF_CalendarMod.o ESMF_ShrTimeMod.o ESMF_Stubs.o
+
+MeatMod.o: ESMF_BaseMod.o
+
+wrf_error_fatal.o:
+
+wrf_message.o:
+
+clean:
+	rm -rf *.o *.mod *.a
+
+.F90.o:
+	$(RM) $@ $*.mod
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I.


### PR DESCRIPTION
Updates to revision 66083 from the CESM repo.

This includes some necessary modifications to the ESMF time manager used
within ACME for MPAS components.
