### PR TITLE
Capturing user's SoftEnv keys

### DIFF
--- a/scripts/ccsm_utils/Machines/env_mach_specific.mira
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.mira
@@ -26,3 +26,5 @@ soft add @ibm-compilers-2014-02
 soft add +cmake
 
 
+# Capture user's software environment for archiving with performance data
+printenv >& software_environment.txt


### PR DESCRIPTION
User's software environment on Mira needs to be captured for archiving with performance data.

[BFB]

How-to test the change: check for existence of
- $CASEROOT/software_environment.txt and
- $EXEROOT/build_environment.txt
