### PR TITLE
terminating syslog monitoring script when ACME run completes

### DIFF
--- a/scripts/ccsm_utils/Machines/syslog.bluewaters
+++ b/scripts/ccsm_utils/Machines/syslog.bluewaters
@@ -24,7 +24,7 @@ $remaining $sample_interval
 EOF1
 /bin/cp -p $run/cesm.log.$lid $dir/cesm.log.$lid.$remaining
 
-while (1)
+while ($remaining > 0)
   grep -a -i "nstep" $run/*atm.log.$lid | tail > $dir/atm.log.$lid.nstep.$remaining
 #  grep -a -i "nstep" $run/cesm.log.$lid | tail > $dir/cesm.log.$lid.nstep.$remaining
   grep -a -i "timestep" $run/*lnd.log.$lid | tail > $dir/lnd.log.$lid.timestep.$remaining
@@ -37,6 +37,7 @@ while (1)
   chmod a+r $dir/*
   sleep $sample_interval
   set remaining = `qstat -f $jid | grep Walltime.Remaining | sed 's/ *Walltime.Remaining = *\([0-9]*\) */\1/' `
+  if ("X$remaining" == "X") set remaining = 0
   cat > $run/Walltime.Remaining << EOF2
 $remaining $sample_interval
 EOF2

--- a/scripts/ccsm_utils/Machines/syslog.cetus
+++ b/scripts/ccsm_utils/Machines/syslog.cetus
@@ -30,7 +30,7 @@ $remaining $sample_interval
 EOF1
 /bin/cp -p $run/cesm.log.$lid $dir/cesm.log.$lid.$remaining
 
-while (1)
+while ($remaining > 0)
   grep -a -i "nstep" $run/*atm.log.$lid | tail > $dir/atm.log.$lid.nstep.$remaining
 #  grep -a -i "nstep" $run/cesm.log.$lid | tail > $dir/cesm.log.$lid.nstep.$remaining
   grep -a -i "timestep" $run/*lnd.log.$lid | tail > $dir/lnd.log.$lid.timestep.$remaining

--- a/scripts/ccsm_utils/Machines/syslog.edison
+++ b/scripts/ccsm_utils/Machines/syslog.edison
@@ -24,7 +24,7 @@ $remaining $sample_interval
 EOF1
 /bin/cp -p $run/cesm.log.$lid $dir/cesm.log.$lid.$remaining
 
-while (1)
+while ($remaining > 0)
   grep -a -i "nstep" $run/*atm.log.$lid | tail > $dir/atm.log.$lid.nstep.$remaining
 #  grep -a -i "nstep" $run/cesm.log.$lid | tail > $dir/cesm.log.$lid.nstep.$remaining
   grep -a -i "timestep" $run/*lnd.log.$lid | tail > $dir/lnd.log.$lid.timestep.$remaining
@@ -37,6 +37,7 @@ while (1)
   chmod a+r $dir/*
   sleep $sample_interval
   set remaining = `qstat -f $jid | grep Walltime.Remaining | sed 's/ *Walltime.Remaining = *\([0-9]*\) */\1/' `
+  if ("X$remaining" == "X") set remaining = 0
   cat > $run/Walltime.Remaining << EOF2
 $remaining $sample_interval
 EOF2

--- a/scripts/ccsm_utils/Machines/syslog.hopper
+++ b/scripts/ccsm_utils/Machines/syslog.hopper
@@ -24,7 +24,7 @@ $remaining $sample_interval
 EOF1
 /bin/cp -p $run/cesm.log.$lid $dir/cesm.log.$lid.$remaining
 
-while (1)
+while ($remaining > 0)
   grep -a -i "nstep" $run/*atm.log.$lid | tail > $dir/atm.log.$lid.nstep.$remaining
 #  grep -a -i "nstep" $run/cesm.log.$lid | tail > $dir/cesm.log.$lid.nstep.$remaining
   grep -a -i "timestep" $run/*lnd.log.$lid | tail > $dir/lnd.log.$lid.timestep.$remaining
@@ -37,6 +37,7 @@ while (1)
   chmod a+r $dir/*
   sleep $sample_interval
   set remaining = `qstat -f $jid | grep Walltime.Remaining | sed 's/ *Walltime.Remaining = *\([0-9]*\) */\1/' `
+  if ("X$remaining" == "X") set remaining = 0
   cat > $run/Walltime.Remaining << EOF2
 $remaining $sample_interval
 EOF2

--- a/scripts/ccsm_utils/Machines/syslog.mira
+++ b/scripts/ccsm_utils/Machines/syslog.mira
@@ -30,7 +30,7 @@ $remaining $sample_interval
 EOF1
 /bin/cp -p $run/cesm.log.$lid $dir/cesm.log.$lid.$remaining
 
-while (1)
+while ($remaining > 0)
   grep -a -i "nstep" $run/*atm.log.$lid | tail > $dir/atm.log.$lid.nstep.$remaining
 #  grep -a -i "nstep" $run/cesm.log.$lid | tail > $dir/cesm.log.$lid.nstep.$remaining
   grep -a -i "timestep" $run/*lnd.log.$lid | tail > $dir/lnd.log.$lid.timestep.$remaining

--- a/scripts/ccsm_utils/Machines/syslog.titan
+++ b/scripts/ccsm_utils/Machines/syslog.titan
@@ -24,7 +24,7 @@ $remaining $sample_interval
 EOF1
 /bin/cp -p $run/cesm.log.$lid $dir/cesm.log.$lid.$remaining
 
-while (1)
+while ($remaining > 0)
   grep -a -i "nstep" $run/*atm.log.$lid | tail > $dir/atm.log.$lid.nstep.$remaining
 #  grep -a -i "nstep" $run/cesm.log.$lid | tail > $dir/cesm.log.$lid.nstep.$remaining
   grep -a -i "timestep" $run/*lnd.log.$lid | tail > $dir/lnd.log.$lid.timestep.$remaining
@@ -37,6 +37,7 @@ while (1)
   chmod a+r $dir/*
   sleep $sample_interval
   set remaining = `qstat -f $jid | grep Walltime.Remaining | sed 's/ *Walltime.Remaining = *\([0-9]*\) */\1/' `
+  if ("X$remaining" == "X") set remaining = 0
   cat > $run/Walltime.Remaining << EOF2
 $remaining $sample_interval
 EOF2


### PR DESCRIPTION
The syslog progress monitoring script is designed to run until the batch job script kills it, which occurs after the ACME run completes. When the job script is killed because requested time is exceeded, the syslog job is not also terminated on Mira.

Here syslog is modified to test whether the remaining time is <= 0 or the ACME job is complete. If so, the script will then terminate itself. For maintenance purposes the same modification is applied to all versions of syslog, even though it has only been identified as needed on Mira.

This has been tested on hopper, edison, mira, and titan, both with jobs that ran out of time and jobs that completed successfully. This is bit-for-bit (as it does not touch the model or its build).
