### PR TITLE
Add three additional tests to acme_integration.

### DIFF
--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -656,6 +656,7 @@
     </grid>
     <grid name="f19_g16">
       <test name="ERB">
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="pgi" testtype="aux_cam">titan</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
@@ -697,9 +698,11 @@
     </grid>
     <grid name="f45_g37">
       <test name="ERB">
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
       </test>
       <test name="ERH">
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
       </test>


### PR DESCRIPTION
These tests were initially left out when acme_integration was
first created. Since then, I've determined that these tests were
only failing because the archive directory was not defined for redsky.
Now that that's been defined, these tests should work.

[BFB]
