### PR TITLE
Defining default MPAS compsets, and adding runoff

### DIFF
--- a/scripts/ccsm_utils/Case.template/config_compsets.xml
+++ b/scripts/ccsm_utils/Case.template/config_compsets.xml
@@ -175,7 +175,8 @@ value of RUN_STARTDATE will be date2.
 <COMPSET sname="C_INTERANNUAL"        alias="CIAF" >2000_DATM%IAF_SLND_DICE%SIAF_POP2_DROF%IAF_SGLC_SWAV</COMPSET>
 <COMPSET sname="C_NORMAL_YEAR_ECOSYS" alias="CECO" >1850_DATM%NYF_SLND_DICE%SSMI_POP2%ECO_DROF%NYF_SGLC_SWAV</COMPSET>
 
-<COMPSET sname="C_MPAS"               alias="CMPAS" support_level="Experimental, under development" >2000_DATM%NYF_SLND_DICE%SSMI_MPAS_SROF%NYF_SGLC_SWAV</COMPSET>
+<COMPSET sname="C_MPAS_NORMAL_YEAR"   alias="CMPASO-NYF" support_level="Experimental, under development" >2000_DATM%NYF_SLND_DICE%SSMI_MPASO_DROF%NYF_SGLC_SWAV</COMPSET>
+<COMPSET sname="C_MPAS_INTERANNUAL"        alias="CMPASO-IAF" support_level="Experimental, under development" >2000_DATM%IAF_SLND_DICE%SIAF_MPASO_DROF%IAF_SGLC_SWAV</COMPSET>
 
 <!-- D compsets -->
 

--- a/scripts/ccsm_utils/Case.template/config_grid.xml
+++ b/scripts/ccsm_utils/Case.template/config_grid.xml
@@ -1229,6 +1229,9 @@ do not use scientific experiments; use the T62_g16 resolution instead:
 <gridmap rof_grid="rx1" ocn_grid="tx0.1v2" >
   <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_tx0.1v2_e1000r200_090624.nc</ROF2OCN_RMAPNAME>
 </gridmap>
+<gridmap rof_grid="rx1" ocn_grid="mpas120" >
+  <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_mpas120_nn_131217.nc</ROF2OCN_RMAPNAME>
+</gridmap>
 
 <gridmap rof_grid="r05" ocn_grid="gx3v7" >
   <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</ROF2OCN_RMAPNAME>


### PR DESCRIPTION
Updating the normal year forcing MPAS-O compset (C_MPAS_NORMAL_YEAR) and
defining the interannual forcing MPAS-O compset (C_MPAS_INTERANNUAL).

Also adding the correct runoff mapping file for the mpas120 grid.
