### PR TITLE
Forced BFBFLAG flag to TRUE for PNNL Cascade machine

### DIFF
--- a/scripts/ccsm_utils/Machines/config_compilers.xml
+++ b/scripts/ccsm_utils/Machines/config_compilers.xml
@@ -860,9 +860,8 @@ for mct, etc.
   <NETCDF_PATH> $(NETCDF_LIB)/..</NETCDF_PATH>
   <CONFIG_ARGS> --host=Linux --enable-filesystem-hints=lustre</CONFIG_ARGS>
   <ADD_CPPDEFS> -DLINUX </ADD_CPPDEFS>
-  <ADD_FFLAGS DEBUG="TRUE"> -g -O0 </ADD_FFLAGS>
-  <SLIBS> -L$(NETCDF_PATH)/lib -lnetcdf -lpmi </SLIBS>
-  <ADD_SLIBS> -L$(NETCDF_PATH)/lib -lnetcdff  </ADD_SLIBS>
+  <ADD_FFLAGS DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </ADD_FFLAGS>
+  <SLIBS> -L$(NETCDF_PATH)/lib -lnetcdf -lnetcdff -lpmi </SLIBS>
 </compiler>
  
 <compiler COMPILER="nag" MACH="cascade">
@@ -870,6 +869,13 @@ for mct, etc.
  <MPI_PATH MPILIB="mvapich2"> $(MPI_LIB)</MPI_PATH >
  <ADD_CPPDEFS> -DnoI8 </ADD_CPPDEFS>
  <ADD_LDFLAGS compile_threaded="true">  </ADD_LDFLAGS>
+ <!--  -C=Undefined flag doesn't work as it requires MPI and NETCDF to be 
+      compiled with this flag, which is not available now. NAG has the following debug flags
+      <ADD_FFLAGS DEBUG="TRUE">  -gline  -C=all  -g  -C=undefined -C=recursion -nan -O0 -v  </ADD_FFLAGS>
+      "-nan" is an important flag. currently, it doesn't work for pio, it is only used for "cam" model. 
+ -->
+ <ADD_FFLAGS DEBUG="TRUE" >  -gline  -C=all  -g  -O0 -v  </ADD_FFLAGS>
+ <ADD_FFLAGS DEBUG="TRUE" MODEL="cam">  -gline  -C=all  -g  -nan -O0 -v  </ADD_FFLAGS>
  <ADD_SLIBS> -L$(NETCDF_ROOT)/lib -lnetcdf -lnetcdff</ADD_SLIBS>
 </compiler> 
 

--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -601,14 +601,14 @@
          <DESC>PNL cluster, os is Linux (pgi), batch system is SLURM</DESC>
          <OS>LINUX</OS>
          <COMPILERS>intel,nag</COMPILERS>
-         <MPILIBS>mvapich2</MPILIBS>
+         <MPILIBS>mpich</MPILIBS>
          <RUNDIR>/dtemp/$CCSMUSER/csmruns/$CASE/run</RUNDIR>
          <EXEROOT>/dtemp/$CCSMUSER/csmruns/$CASE/bld</EXEROOT>
          <DIN_LOC_ROOT>/dtemp/sing201/inputdata/CAM/CSMDATA_CAM/aerocom/csmdata</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/dtemp/sing201/inputdata/CAM/CSMDATA_CAM/aerocom/csmdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/dtemp/$CCSMUSER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-         <CCSM_BASELINE>/dtemp/sing201/ACME_testing/acme_baselines/</CCSM_BASELINE>
+         <CCSM_BASELINE>/dtemp/sing201/acme_testing/acme_baselines/</CCSM_BASELINE>
 	     <CESMSCRATCHROOT>/dtemp/$USER/csmruns</CESMSCRATCHROOT>
          <CCSM_CPRNC>/home/sing201/CAM/cprnc/cprnc</CCSM_CPRNC>
          <BATCHQUERY>showq</BATCHQUERY>

--- a/scripts/ccsm_utils/Machines/mkbatch.cascade
+++ b/scripts/ccsm_utils/Machines/mkbatch.cascade
@@ -5,6 +5,8 @@ if ($PHASE == set_batch) then
 #################################################################################
 
 source ./Tools/ccsm_getenv || exit -1
+#BSINGH - set BFBFLAG to TRUE so that tests using "create_test" and "create_prod_test" scripts pass
+./xmlchange -file env_run.xml   -id BFBFLAG          -val TRUE
 
 set ntasks  = `${CASEROOT}/Tools/taskmaker.pl -sumonly`
 set maxthrds = `${CASEROOT}/Tools/taskmaker.pl -maxthrds`

--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -62,6 +62,8 @@
       </test>
       <test name="ERS">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -95,6 +97,10 @@
       </test>
       <test name="ERS_IOP">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -131,6 +137,10 @@
       </test>
       <test name="ERS_IOP4c">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -165,6 +175,10 @@
       </test>
       <test name="ERS_IOP4p">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -212,6 +226,10 @@
       </test>
       <test name="NCK">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -308,6 +326,10 @@
       </test>
       <test name="PEA_P1_M">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -343,6 +365,8 @@
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
       </test>
       <test name="PET_PT">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="pgi" testtype="prerelease">hopper</machine>
         <machine compiler="ibm" testtype="prerelease">intrepid</machine>
@@ -368,6 +392,10 @@
       </test>
       <test name="SMS">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -414,6 +442,8 @@
     <grid name="ne30_g16_rx1">
       <test name="ERS">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -452,6 +482,10 @@
       </test>
       <test name="ERS_IOP">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -488,6 +522,10 @@
       </test>
       <test name="ERS_IOP4c">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -522,6 +560,10 @@
       </test>
       <test name="ERS_IOP4p">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -648,6 +690,8 @@
     </grid>
     <grid name="f09_g16">
       <test name="ERS">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="pgi" testtype="aux_cam">titan</machine>
@@ -656,6 +700,8 @@
     </grid>
     <grid name="f19_g16">
       <test name="ERB">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="pgi" testtype="aux_cam">titan</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
@@ -665,6 +711,8 @@
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
       </test>
       <test name="ERS">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="pgi" testtype="aux_cam">titan</machine>
@@ -672,6 +720,8 @@
         <machine compiler="intel" testtype="aux_science">yellowstone</machine>
       </test>
       <test name="ERT">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="pgi" testtype="aux_cam">titan</machine>
@@ -698,16 +748,24 @@
     </grid>
     <grid name="f45_g37">
       <test name="ERB">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
       </test>
       <test name="ERH">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
       </test>
       <test name="ERS">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -741,6 +799,10 @@
       </test>
       <test name="ERS_D">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -777,6 +839,8 @@
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
       </test>
       <test name="SEQ_PFC">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
@@ -1235,6 +1299,8 @@
         <machine compiler="pgi" testtype="prerelease">titan</machine>
       </test>
       <test name="SMS_D">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="intel" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
@@ -1881,6 +1947,8 @@
       </test>
       <test name="ERS">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -1911,6 +1979,10 @@
       </test>
       <test name="ERS_IOP">
         <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -2250,6 +2322,8 @@
     </grid>
     <grid name="f19_f19">
       <test name="ERS">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta" testmods="cam/cosp">redsky</machine>
@@ -2257,6 +2331,8 @@
         <machine compiler="intel" testtype="prebeta" testmods="cam/cosp">yellowstone</machine>
       </test>
       <test name="ERS_IOP_Ld3">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="prebeta">janus</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
@@ -2422,6 +2498,8 @@
         <machine compiler="intel" testtype="csltiming">yellowstone</machine>
       </test>
       <test name="SMS_D_Ld3">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="pgi" testtype="prerelease">hopper</machine>
         <machine compiler="ibm" testtype="prerelease">intrepid</machine>
@@ -2435,6 +2513,8 @@
     </grid>
     <grid name="f19_g16">
       <test name="ERS_Ld3">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="intel" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
@@ -2457,6 +2537,8 @@
     </grid>
     <grid name="ne30_ne30">
       <test name="ERS_Ld3">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="intel" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
@@ -2472,6 +2554,8 @@
       </test>
       <test name="PFS">
         <machine compiler="pgi" testtype="prebeta">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="ibm" testtype="prebeta">cetus</machine>
         <machine compiler="intel" testtype="prebeta">edison</machine>
         <machine compiler="intel" testtype="prebeta">eos</machine>
@@ -2515,6 +2599,8 @@
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
       </test>
       <test name="SMS">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
@@ -4863,6 +4949,8 @@
         <machine compiler="intel" testtype="aux_scripts">yellowstone</machine>
       </test>
       <test name="PET_PT">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="intel" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
@@ -4879,6 +4967,8 @@
         <machine compiler="intel" testtype="aux_scripts">yellowstone</machine>
       </test>
       <test name="SEQ_IOP_PFC">
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
         <machine compiler="intel" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="prebeta">goldbach</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>


### PR DESCRIPTION
All the test cases in acme_developer test suite were failing on PNNL's
Cascade machine. BFBFLAG is set to TRUE in env_run.xml (using xmlchange
command in mkbatch.cascade machine file) to make sure that the test
cases pass. Machine files are also updated with new compiler flags for
NAG and INTEL compilers. acme_developer and acme_integration test
suites are now available for Cascade for both INTEL and NAG compilers
