### PR TITLE
Removes dlapqc.f from sources built into libglimmer. Fixes #85.

### DIFF
--- a/models/glc/cism/glimmer-cism/CMakeLists.txt
+++ b/models/glc/cism/glimmer-cism/CMakeLists.txt
@@ -270,7 +270,8 @@ LIST(REMOVE_ITEM FORTRANSOURCES
    ${GLIMMER_SOURCE_DIR}/libglimmer/test_integrate.F90
    ${GLIMMER_SOURCE_DIR}/libglimmer/test_ts.F90
    ${GLIMMER_SOURCE_DIR}/libglimmer/test_writestats.F90
-   ${GLIMMER_SOURCE_DIR}/libglimmer/nc2config.F90 )
+   ${GLIMMER_SOURCE_DIR}/libglimmer/nc2config.F90 
+   ${GLIMMER_SOURCE_DIR}/libglimmer-solve/SLAP/dlapqc.f )
 
 
 IF ((NOT ${NO_TRILINOS}) OR CISM_MPI_MODE)


### PR DESCRIPTION
dlapqc.f contains a program, which produces a duplicate "main" symbol that prevents a successful build of the glimmer-cism library on Macs. This change simply removes that file from the list of sources to be built into the library.

[BFB]
