### PR TITLE
Adding machines files for a generic linux machine (laptop)

### DIFF
--- a/scripts/ccsm_utils/Machines/config_compilers.xml
+++ b/scripts/ccsm_utils/Machines/config_compilers.xml
@@ -559,6 +559,12 @@ for mct, etc.
   <ADD_SLIBS>-L$(NETCDF_PATH)/lib -lnetcdff -lnetcdf</ADD_SLIBS>
 </compiler>
 
+<compiler COMPILER="gnu" MACH="linux-generic">
+  <NETCDF_PATH> $(NETCDF_PATH)</NETCDF_PATH>
+  <PNETCDF_PATH> $(PNETCDF_PATH)</PNETCDF_PATH>
+  <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nc-config --flibs) </ADD_SLIBS>
+</compiler>
+
 <compiler COMPILER="gnu" MACH="melvin">
   <NETCDF_PATH>$(NETCDFROOT)</NETCDF_PATH>
   <PNETCDF_PATH>$(PNETCDFROOT)</PNETCDF_PATH>

--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -462,6 +462,30 @@
     <PES_PER_NODE>2</PES_PER_NODE>
 </machine>
 
+<machine MACH="linux-generic">
+    <DESC>Linux workstation or laptop</DESC>
+    <OS>Linux</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
+    <RUNDIR>$ENV{HOME}/projects/acme/scratch/$CASE/run</RUNDIR>
+    <EXEROOT>$ENV{HOME}/projects/acme/scratch/$CASE/bld</EXEROOT>
+    <DIN_LOC_ROOT>$ENV{HOME}/projects/acme/cesm-inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/projects/acme/ptclm-data</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$ENV{HOME}/projects/acme/scratch/archive/$CASE</DOUT_S_ROOT>
+    <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
+    <CESMSCRATCHROOT>$ENV{HOME}/projects/acme/scratch</CESMSCRATCHROOT>
+    <CCSM_BASELINE>$ENV{HOME}/projects/acme/baselines</CCSM_BASELINE>
+    <!-- cmake -DCMAKE_Fortran_COMPILER=/opt/local/bin/mpif90-mpich-gcc48 -DHDF5_DIR=/opt/local -DNetcdf_INCLUDE_DIR=/opt/local/include .. -->>
+    <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
+    <BATCHQUERY></BATCHQUERY>
+    <BATCHSUBMIT></BATCHSUBMIT>
+    <SUPPORTED_BY>jayesh at mcs dot anl dot gov</SUPPORTED_BY>
+<!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
+    <GMAKE_J>4</GMAKE_J>
+    <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
+    <PES_PER_NODE>2</PES_PER_NODE>
+</machine>
+
 <machine MACH="melvin">
     <DESC>Linux workstation for Jenkins testing</DESC>
     <OS>LINUX</OS>

--- a/scripts/ccsm_utils/Machines/env_mach_specific.linux-generic
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.linux-generic
@@ -1,0 +1,23 @@
+#! /bin/csh -cvf
+
+# -------------------------------------------------------------------------
+# Linux
+# This file sets env for ACME to be built on a Linux m/c
+# NETCDF : Environment variable that points to the NetCDF installation 
+#          directory
+#          (If not set, we assume NetCDF is installed in /usr )
+# -------------------------------------------------------------------------
+
+if $?NETCDF then
+  setenv NETCDF_PATH $NETCDF
+  setenv NETCDF_DIR $NETCDF
+else
+  echo 'WARNING: The $NETCDF environment variable is not defined assuming /usr .'
+  setenv NETCDF_PATH "/usr"
+  setenv NETCDF_DIR "/usr"
+endif
+
+if $?PNETCDF then
+  setenv PNETCDF_PATH $PNETCDF
+  setenv PNETCDF_DIR $PNETCDF
+endif

--- a/scripts/ccsm_utils/Machines/mkbatch.linux-generic
+++ b/scripts/ccsm_utils/Machines/mkbatch.linux-generic
@@ -1,0 +1,120 @@
+#! /bin/tcsh -f
+
+#################################################################################
+if ($PHASE == set_batch) then
+#################################################################################
+source ./Tools/ccsm_getenv || exit -1
+
+# Determine tasks and threads for batch queue 
+
+
+
+set maxthrds = 0
+set minthrds = $MAX_TASKS_PER_NODE
+@ n = 0
+foreach model ($MODELS)
+  @ n = $n + 1
+  if ($NTHRDS[$n] > $MAX_TASKS_PER_NODE ) then
+     echo "ERROR, NTHRDS maximum is $MAX_TASKS_PER_NODE"
+     echo "you have set NTHRDS = ( $NTHRDS[$n] ) - must reset"
+     exit 1
+  endif   
+  if ($NTHRDS[$n] > $maxthrds) then
+     set maxthrds = $NTHRDS[$n]
+  endif
+  if ($NTHRDS[$n] < $minthrds) then
+     set minthrds = $NTHRDS[$n]
+  endif
+end
+
+
+./xmlchange -file env_mach_pes.xml -id COST_PES -val 0
+# This is the maximum number of mpi tasks we want on a node.
+@ ptile = ${MAX_TASKS_PER_NODE} / 2
+set ntasks_tot = `${CASEROOT}/Tools/taskmaker.pl -sumtasks`
+
+if ($maxthrds > $minthrds) then
+# We don't need this if all we are doing is exploiting hyperthreading
+  if ( $maxthrds > 2) then
+    set task_geo   = `${CASEROOT}/Tools/taskmaker.pl`
+  endif
+  set thrd_geo   = `${CASEROOT}/Tools/taskmaker.pl -thrdgeom`
+else
+  if ($maxthrds > 1) then
+    @ ptile = $MAX_TASKS_PER_NODE / $maxthrds
+  endif 
+endif
+
+@ nodes = ${ntasks_tot} / ${ptile}
+if ( ${ntasks_tot} % ${ptile} > 0) then
+  @ nodes = $nodes + 1
+endif
+# costpes is the number of nodes used * the number of cores per node
+# or the total number of cores used, that needs to be set for cost
+@ costpes = ${nodes} * ${PES_PER_NODE}
+
+./xmlchange -file env_mach_pes.xml -id COST_PES -val ${costpes}
+
+if ($?TESTMODE) then
+ set file = $CASEROOT/${CASE}.test 
+else
+ set file = $CASEROOT/${CASE}.run 
+endif
+
+cat >! $file << EOF1
+#! /bin/tcsh -f
+EOF1
+
+#################################################################################
+else if ($PHASE == set_exe) then
+#################################################################################
+    source ./Tools/ccsm_getenv || exit -1
+
+    set maxthrds = `${CASEROOT}/Tools/taskmaker.pl -maxthrds`
+    set maxtasks = `${CASEROOT}/Tools/taskmaker.pl -sumtasks`
+
+    cat >> ${CASEROOT}/${CASE}.run << EOF1
+# -------------------------------------------------------------------------
+# Run the model
+# -------------------------------------------------------------------------
+
+set maxthrds = $maxthrds
+set maxtasks = $maxtasks
+
+cd \$RUNDIR
+echo "\`date\` -- CSM EXECUTION BEGINS HERE" 
+setenv MP_LABELIO yes
+setenv OMP_NUM_THREADS \$maxthrds
+if ( "\$MPILIB" == "mpi-serial" ) then
+    \$EXEROOT/cesm.exe >&! cesm.log.\$LID
+else
+    mpirun -np \$maxtasks \$EXEROOT/cesm.exe >&! cesm.log.\$LID
+endif
+
+wait
+echo "\`date\` -- CSM EXECUTION HAS FINISHED" 
+
+# -------------------------------------------------------------------------
+# For Postprocessing
+# -------------------------------------------------------------------------
+EOF1
+
+
+#################################################################################
+else if ($PHASE == set_larch) then
+#################################################################################
+
+    echo " Archiving not supported on this machine."
+
+#################################################################################
+else
+#################################################################################
+
+    echo "  PHASE setting of $PHASE is not an accepted value"
+    echo "  accepted values are set_batch, set_exe and set_larch"
+    exit 1
+
+#################################################################################
+endif
+#################################################################################
+

--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -80,6 +80,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -118,6 +119,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -158,6 +160,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -196,6 +199,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -252,6 +256,7 @@
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="intel" testtype="prebeta">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -347,6 +352,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -417,6 +423,7 @@
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="intel" testtype="prebeta">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -463,6 +470,7 @@
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
         <machine compiler="pgi" testtype="prebeta">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -503,6 +511,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -543,6 +552,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -581,6 +591,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -783,6 +794,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -820,6 +832,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -1965,6 +1978,7 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -2001,6 +2015,7 @@
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="intel" testtype="prebeta">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
@@ -4813,14 +4828,15 @@
         <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="pgi" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="ibm" testtype="acme_developer">mira</machine>
         <machine compiler="null" testtype="acme_developer">null</machine>
         <machine compiler="pgi" testtype="acme_developer">olympus</machine>
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
-        <machine compiler="intel" testtype="prebeta">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="intel" testtype="prebeta">redsky</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="acme_developer">yellowstone</machine>


### PR DESCRIPTION
This commit adds the machines files, configuration files and the
developer tests (acme_developer suite) for a generic linux
machine (desktop, laptop) that does not have a batch system.
1. This change allows running the acme developer suite on a linux
   laptop/desktop
2. The user can set the $NETCDF and $PNETCDF environment variables
   to specify the installation path to the NetCDF and pNetCDF
   libraries. If $NETCDF is not set, the scripts assume that the
   NetCDF libraries are installed in "/usr". If the $PNETCDF env
   variable is not set, the scripts assume that pNetCDF is not
   available on the system.

[BFB]
