### PR TITLE
Fix for hdf5 dynamic loading problem on Edison.

### DIFF
--- a/scripts/ccsm_utils/Machines/env_mach_specific.edison
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.edison
@@ -27,7 +27,6 @@ endif
 
 if ( $COMPILER == "intel" ) then
     module load PrgEnv-intel 
-    module switch intel      intel/13.1.3.192  
     module rm cray-libsci
     setenv MKL "-mkl=cluster"
     module use /global/project/projectdirs/ccsm1/modulefiles/edison


### PR DESCRIPTION
Since Edison's update, we need to use the more recent Intel compiler. Switching to the new compiler fixes all but a couple of the acme_developer tests, which still need some investigating.

[BFB]

SEG-34
