### PR TITLE
Fixed issues on Titan with craype-interlagos

### DIFF
--- a/scripts/ccsm_utils/Machines/env_mach_specific.titan
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.titan
@@ -33,25 +33,26 @@ if (-e /opt/modules/default/init/csh) then
 
   if ($COMPILER == "pgicuda") then
     module load PrgEnv-pgi
-#    module switch pgi pgi/14.2.0
+#   module switch pgi pgi/14.2.0
     module switch pgi pgi/14.10.home
     module load cray-mpich/6.3.0
     module load cray-libsci/12.1.3
     module switch xt-asyncpe xt-asyncpe/5.27
     module load esmf/5.2.0rp2
-
     module add cudatoolkit
     setenv CRAY_CUDA_PROXY 1
+    setenv XTPE_INTERLAGOS_ENABLED OFF
   endif
 
   if ( $COMPILER == "pgi" ) then
     module load PrgEnv-pgi
-#    module switch pgi pgi/14.2.0
+#   module switch pgi pgi/14.2.0
     module switch pgi pgi/14.10.home
     module load cray-mpich/6.3.0
     module load cray-libsci/12.1.3
     module switch xt-asyncpe xt-asyncpe/5.27
     module load esmf/5.2.0rp2
+    setenv XTPE_INTERLAGOS_ENABLED OFF
   endif
 
   if ( $COMPILER == "intel" ) then


### PR DESCRIPTION
The craype-interlagos module on Titan was changed to specify "-tp=bulldozer" in the compiler flags for PGI, as the omission of this was a performance bug, and the wrappers should be targetting the AMD interlagos architecture. However, there is a bug in PGI 14.2 and 14.10 ( possibly others ), which breaks reproducibility tests in ACME. I have unset the environment variable that adds this flag, so reproducibility is restored on Titan with this fix. I hope to find out what is leading to the issue, isolate the file(s) in Depends.pgi, and get things working with the correct architecture target soon. But in the interim, this allows the developer's test suite on Titan to pass.
