### PR TITLE
Fixing an infinte loop in check_exactrestart.pl

### DIFF
--- a/scripts/ccsm_utils/Tools/check_exactrestart.pl
+++ b/scripts/ccsm_utils/Tools/check_exactrestart.pl
@@ -113,11 +113,11 @@ sub compare{
         #print "skip line2 $line2\n";
         $line2 = shift @line2;
         chomp $line2;
-		if ( !defined($line2) ) {
-            print "ERROR: Reached end of $f2 without finding the comm_diag token. Exiting...\n";
-            print "FAIL \n";
-            die;
-		}
+        if ( !defined($line2) ) {
+          print "ERROR: Reached end of $f2 without finding the comm_diag token. Exiting...\n";
+          print "FAIL \n";
+          die;
+        }
       }
       if($line1 eq $line2) {
 	  $good_cnt++;


### PR DESCRIPTION
This commit fixes an infinite loop in check_exactrestart.pl that is
caused when the second file passed into check_exactrestart.pl does not
contain the comm_diag token.

Fixes #120
