### PR TITLE
update_acme_tests: Remove long running test from acme_developer

### DIFF
--- a/scripts/acme/update_acme_tests
+++ b/scripts/acme/update_acme_tests
@@ -21,7 +21,6 @@ TEST_SUITES = {
          'ERS.f45_g37.B1850C5',
          'ERS.f45_g37_rx1.DTEST',
          'ERS.ne30_g16_rx1.A',
-         'ERS_D.f45_g37.B1850C5',
          'ERS_IOP.f19_g16_rx1.A',
          'ERS_IOP.f45_g37_rx1.DTEST',
          'ERS_IOP.ne30_g16_rx1.A',

--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -87,6 +87,7 @@
         <machine compiler="null" testtype="acme_developer">null</machine>
         <machine compiler="pgi" testtype="acme_developer">olympus</machine>
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
@@ -149,6 +150,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -216,6 +218,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -281,6 +284,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -364,6 +368,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -486,6 +491,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -609,6 +615,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -659,6 +666,7 @@
         <machine compiler="null" testtype="acme_developer">null</machine>
         <machine compiler="pgi" testtype="acme_developer">olympus</machine>
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
@@ -723,6 +731,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -790,6 +799,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -855,6 +865,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -1242,6 +1253,7 @@
         <machine compiler="pgi" testtype="acme_integration">olympus</machine>
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -1255,63 +1267,32 @@
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
       </test>
       <test name="ERS_D">
-        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
         <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
-        <machine compiler="intel" testtype="acme_developer">cascade</machine>
-        <machine compiler="nag" testtype="acme_developer">cascade</machine>
         <machine compiler="intel" testtype="acme_integration">cascade</machine>
         <machine compiler="nag" testtype="acme_integration">cascade</machine>
-        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
         <machine compiler="ibm" testtype="acme_integration">cetus</machine>
-        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
         <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel " testtype="acme_developer">edison</machine>
         <machine compiler="intel" testtype="acme_integration">edison</machine>
         <machine compiler="intel " testtype="acme_integration">edison</machine>
-        <machine compiler="intel" testtype="acme_developer">eos</machine>
         <machine compiler="intel" testtype="acme_integration">eos</machine>
-        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
         <machine compiler="intel" testtype="acme_integration">evergreen</machine>
-        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
-        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
-        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
-        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
         <machine compiler="intel" testtype="acme_integration">goldbach</machine>
         <machine compiler="lahey" testtype="acme_integration">goldbach</machine>
         <machine compiler="nag" testtype="acme_integration">goldbach</machine>
         <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
-        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
-        <machine compiler="intel" testtype="acme_developer">hopper</machine>
-        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
         <machine compiler="gnu" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="acme_integration">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
-        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
         <machine compiler="ibm" testtype="acme_integration">intrepid</machine>
-        <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="intel" testtype="acme_integration">janus</machine>
-        <machine compiler="intel" testtype="acme_developer">lawrencium-lr2</machine>
         <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
-        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
-        <machine compiler="gnu" testtype="acme_developer">mac</machine>
         <machine compiler="gnu" testtype="acme_integration">mac</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
         <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="null" testtype="acme_developer">null</machine>
         <machine compiler="null" testtype="acme_integration">null</machine>
-        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
         <machine compiler="pgi" testtype="acme_integration">olympus</machine>
-        <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
-        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
-        <machine compiler="intel " testtype="acme_developer">yellowstone</machine>
-        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
         <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
         <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
         <machine compiler="intel " testtype="acme_integration">yellowstone</machine>
@@ -2508,6 +2489,7 @@
         <machine compiler="null" testtype="acme_developer">null</machine>
         <machine compiler="pgi" testtype="acme_developer">olympus</machine>
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
         <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
@@ -2568,6 +2550,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
@@ -5592,6 +5575,7 @@
         <machine compiler="intel" testtype="acme_developer">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>


### PR DESCRIPTION
ERS_D.f45_g37.B1850C5 is a very long-running test and should therefore
not be in our 'quick' test suite, acme_developer. This commits removes it
from the data structure in update_acme_tests and updates testlist.xml.

[BFB]
