### PR TITLE
New env_mach_specific for 3-10-2015 Titan Upgrade

### DIFF
--- a/scripts/ccsm_utils/Machines/env_mach_specific.titan
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.titan
@@ -12,6 +12,7 @@ if (-e /opt/modules/default/init/csh) then
   source /opt/modules/default/init/csh
   setenv  MODULEPATH ${MODULEPATH}:/ccs/home/norton/.modules
   module rm PrgEnv-intel
+  echo "Please ignore the error message immediately following this."
   module rm PrgEnv-pgi
   module rm PrgEnv-cray
   module rm PrgEnv-gnu
@@ -23,7 +24,7 @@ if (-e /opt/modules/default/init/csh) then
   module rm parallel-netcdf
   module rm netcdf
   module rm cmake
-  module rm cray-mpich
+# module rm cray-mpich
   module rm cray-mpich2
   module rm cray-libsci
   module rm xt-libsci
@@ -35,42 +36,46 @@ if (-e /opt/modules/default/init/csh) then
     module load PrgEnv-pgi
 #   module switch pgi pgi/14.2.0
     module switch pgi pgi/14.10.home
-    module load cray-mpich/6.3.0
-    module load cray-libsci/12.1.3
-    module switch xt-asyncpe xt-asyncpe/5.27
+    module switch cray-mpich/7.0.4
+    module switch cray-libsci/13.0.1
+#   module switch xt-asyncpe xt-asyncpe/5.27
     module load esmf/5.2.0rp2
+    module switch atp atp/1.7.5
     module add cudatoolkit
     setenv CRAY_CUDA_PROXY 1
-    setenv XTPE_INTERLAGOS_ENABLED OFF
+    module rm craype-interlagos
   endif
 
   if ( $COMPILER == "pgi" ) then
     module load PrgEnv-pgi
 #   module switch pgi pgi/14.2.0
     module switch pgi pgi/14.10.home
-    module load cray-mpich/6.3.0
-    module load cray-libsci/12.1.3
-    module switch xt-asyncpe xt-asyncpe/5.27
+    module switch cray-mpich/7.0.4
+    module switch cray-libsci/13.0.1
+#   module switch xt-asyncpe xt-asyncpe/5.27
     module load esmf/5.2.0rp2
-    setenv XTPE_INTERLAGOS_ENABLED OFF
+    module switch atp atp/1.7.5
+    module rm craype-interlagos
   endif
 
   if ( $COMPILER == "intel" ) then
     module load PrgEnv-intel
-    module load cray-mpich
+    module swap cray-mpich cray-mpich/7.0.4
   endif
 
   if ( $COMPILER == "cray" ) then
     module load PrgEnv-cray
     module load cce
-    module load cray-mpich
+    module swap cray-mpich cray-mpich/7.0.4
   endif
 
   if ( $MPILIB == "mpi-serial") then
     module load cray-netcdf/4.3.0
   else
-    module load cray-netcdf-hdf5parallel/4.3.0
-    module load cray-parallel-netcdf/1.3.1.1
+    module load cray-netcdf-hdf5parallel/4.3.2
+    module load cray-parallel-netcdf/1.5.0
+#   module load cray-hdf5-parallel
+#   module swap cray-hdf5-parallel cray-hdf5-parallel/1.8.12
   endif
 
   module load subversion


### PR DESCRIPTION
New modules that are compatible with the new software environment as of 3-10-2015. All developers tests pass except one, ERS_Ly21.f09_g16.TG, which has a CFAIL.
