### PR TITLE
Titan modules: better way to preserve b4b

### DIFF
--- a/scripts/ccsm_utils/Machines/env_mach_specific.titan
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.titan
@@ -12,7 +12,7 @@ if (-e /opt/modules/default/init/csh) then
   source /opt/modules/default/init/csh
   setenv  MODULEPATH ${MODULEPATH}:/ccs/home/norton/.modules
   module rm PrgEnv-intel
-  echo "Please ignore the error message immediately following this."
+  module rm pgi
   module rm PrgEnv-pgi
   module rm PrgEnv-cray
   module rm PrgEnv-gnu
@@ -34,28 +34,26 @@ if (-e /opt/modules/default/init/csh) then
 
   if ($COMPILER == "pgicuda") then
     module load PrgEnv-pgi
-#   module switch pgi pgi/14.2.0
-    module switch pgi pgi/14.10.home
-    module switch cray-mpich/7.0.4
-    module switch cray-libsci/13.0.1
-#   module switch xt-asyncpe xt-asyncpe/5.27
+    module switch pgi pgi/14.2.0
+#   module switch pgi pgi/14.10.home
+    module switch cray-mpich cray-mpich/7.0.4
+    module switch cray-libsci cray-libsci/13.0.1
     module load esmf/5.2.0rp2
     module switch atp atp/1.7.5
     module add cudatoolkit
     setenv CRAY_CUDA_PROXY 1
-    module rm craype-interlagos
+    setenv CRAY_CPU_TARGET istanbul
   endif
 
   if ( $COMPILER == "pgi" ) then
     module load PrgEnv-pgi
 #   module switch pgi pgi/14.2.0
     module switch pgi pgi/14.10.home
-    module switch cray-mpich/7.0.4
-    module switch cray-libsci/13.0.1
-#   module switch xt-asyncpe xt-asyncpe/5.27
+    module switch cray-mpich cray-mpich/7.0.4
+    module switch cray-libsci cray-libsci/13.0.1
     module load esmf/5.2.0rp2
     module switch atp atp/1.7.5
-    module rm craype-interlagos
+    setenv CRAY_CPU_TARGET istanbul
   endif
 
   if ( $COMPILER == "intel" ) then
@@ -74,8 +72,6 @@ if (-e /opt/modules/default/init/csh) then
   else
     module load cray-netcdf-hdf5parallel/4.3.2
     module load cray-parallel-netcdf/1.5.0
-#   module load cray-hdf5-parallel
-#   module swap cray-hdf5-parallel cray-hdf5-parallel/1.8.12
   endif
 
   module load subversion


### PR DESCRIPTION
Instead of removing the craype-interlagos, the script is now setting the CPU target environment variable to istanbul, which allows some target-specific optimizations but evidently not the interlagos-specific ones that break reproducibility. Also, the complaint from PrgEnv-pgi being removed has been fixed.
