### PR TITLE
create_test: When user passes -generate, update namelists

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -1786,14 +1786,13 @@ sub namelistCompare
     if($opts{'generate'}){
 	my $genpath = "$baseroot/".$opts{'generate'}."/$basename";
 	if(-d $genpath){
-	    warn "Baseline directory $genpath already exist - will not overwrite.";
+	    warn "Baseline directory $genpath already exists";
 	}else{
 	    umask 0000;
 	    mkpath $genpath, 1, 0775;
-	    system("cp -r $buildconfpath $genpath"); 
-	    system("cp $buildconfpath/../user_nl* $genpath") ;
-	    warn "Couldnt create Baseline directory $genpath" unless -d "$genpath/CaseDocs"; 
-	}
+        }
+        system("cp -rf $buildconfpath $genpath");
+        system("cp -f $buildconfpath/../user_nl* $genpath") ;
     }
 }
 


### PR DESCRIPTION
Without this capability, namelists can only be updated by hand
which is very inconvenient. Also, it now makes -generate consistent
with all the data that gets compared with -compare.

[BFB]

SEG-92
