### PR TITLE
Add smoke test of I1850CLM45CN into acme_developer

### DIFF
--- a/scripts/acme/update_acme_tests
+++ b/scripts/acme/update_acme_tests
@@ -31,7 +31,8 @@ TEST_SUITES = {
          'ERS_Ly21.f09_g16.TG',
          'NCK.f19_g16_rx1.A',
          'PEA_P1_M.f45_g37_rx1.A',
-         'SMS.ne30_f19_g16_rx1.A'],
+         'SMS.ne30_f19_g16_rx1.A',
+         'SMS.f19_f19.I1850CLM45CN'],
     "acme_integration" :
         ["ERB.f19_g16.B1850C5",
          "ERB.f45_g37.B1850C5",

--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -5953,4 +5953,11 @@
       </test>
     </grid>
   </compset>
+  <compset name="I1850CLM45CN">
+    <grid name="f19_f19">
+      <test name="SMS">
+        <machine compiler="pgi" testtype="acme_developer">titan</machine>
+      </test>
+    </grid>
+  </compset>
 </testlist>


### PR DESCRIPTION
I1850CLM45CN is a test case for offline ALM development. On Titan, it is configured to run on 64 core for 5 days.   
