### PR TITLE
Adding missing scratch root for blues

### DIFF
--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -559,6 +559,7 @@
          <DESC>ANL/LCRC Linux Cluster</DESC>
          <COMPILERS>intel,gnu,pgi</COMPILERS>
          <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
+         <CESMSCRATCHROOT>/lcrc/project/$PROJECT/$CCSMUSER</CESMSCRATCHROOT>
          <RUNDIR>/lcrc/project/$PROJECT/$CCSMUSER/$CASE/run</RUNDIR>
          <EXEROOT>/lcrc/project/$PROJECT/$CCSMUSER/$CASE/bld</EXEROOT>
          <DIN_LOC_ROOT>/home/ccsm-data/inputdata</DIN_LOC_ROOT>


### PR DESCRIPTION
CESMSCRATCHROOT is not defined in the blues configuration. So
users need to specify "-sharedlibroot" when trying to build
and run tests using create_test. If the user misses the
"-sharedlibroot" argument the build fails. This commit fixes
this issue by explicitly specifying the scratch root for blues.

Also see Issue #154

SEG-29
