### PR TITLE
Specifying a concrete default timelimit for all jobs on Cetus

### DIFF
--- a/scripts/ccsm_utils/Machines/mkbatch.cetus
+++ b/scripts/ccsm_utils/Machines/mkbatch.cetus
@@ -76,8 +76,11 @@ echo "mthrds = \${mthrds}"
 
 if ( \${?COBALT_JOBID} == 0 && \$MPILIB != "mpi-serial" ) then
     echo "COBALT_JOBID not set, submitting job"
-    echo "qsub -n \${nodes} -t 0 --mode script \$0 -backend"
-    qsub -n \${nodes} -t 0 --mode script \$0 -backend
+    # FIXME: Currently the weights for the jobs are ignored
+    # and all jobs default to max timelimit = 59m (1hr is
+    # the max timelimit allowed on the default queue)
+    echo "qsub -n \${nodes} -t 59 --mode script \$0 -backend"
+    qsub -n \${nodes} -t 59 --mode script \$0 -backend
     exit 0
 else
     echo "COBALT_JOBID detected, assuming back-end invocation"


### PR DESCRIPTION
A zero timelimit should ideally (as per qsub man pages) represent
the maximum allowed walltime for the job's queue. For the default
job queue on Cetus this timelimit is 1hr. However due to a bug
in qsub (and issues with ALCF job queue policy enforcement) we
 can no longer specify a 0 timelimit. So specifying a concrete
timelimit of 59min for now.

Also see Issue #137

SEG-81
