### PR TITLE
Port acme_developer suite to hopper

### DIFF
--- a/scripts/ccsm_utils/Machines/env_mach_specific.hopper
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.hopper
@@ -56,7 +56,7 @@ else
   module load cray-parallel-netcdf/1.5.0
 endif
 
-module load cmake
+module load cmake/3.1.3
 
 module use /global/project/projectdirs/ccsm1/modulefiles/hopper
 if( $DEBUG == "TRUE" ) then
@@ -68,18 +68,18 @@ endif
 
 
 module list >& software_environment.txt
-#-------------------------------------------------------------------------------                                           
-# Runtime environment variables                                                                                            
-#-------------------------------------------------------------------------------                                           
+#-------------------------------------------------------------------------------
+# Runtime environment variables
+#-------------------------------------------------------------------------------
 
 limit coredumpsize unlimited
 limit stacksize unlimited
 
-# The environment variable below increase the stack size, which is necessary for                                           
-# CICE to run threaded on this machine.                                                                                    
+# The environment variable below increase the stack size, which is necessary for
+# CICE to run threaded on this machine.  
 setenv OMP_STACKSIZE 64M
 
-# Capture logical to physics PE assignment and active environment variable                                                 
+# Capture logical to physics PE assignment and active environment variable 
 # settings                                                                                                                 
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1


### PR DESCRIPTION
This updates the machine file for Hopper so that it can run the acme_developer suite. We have realized that Hopper is a platform on which ACME scientists are doing work.

[BFB]

SEG-93
