### PR TITLE
jenkins_generic_job: Don't process test results or wait_for_tests if --n...

### DIFF
--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -202,6 +202,10 @@ def jenkins_generic_job(generate_baselines, submit_to_dashboard,
 
     acme_util.run_cmd(create_test_cmd, verbose=True, arg_stdout=None, arg_stderr=None)
 
+    # TODO: the testing scripts should produce all PASS when only generating namelists
+    if (namelists_only and generate_baselines):
+        return True
+
     if (use_batch):
         # This is not fullproof. Any jobs that happened to be
         # submitted by this user while create_test was running will be


### PR DESCRIPTION
...amelists-only

For some reason, when -nlcompareonly is passed to create_test, tests are
being left in the RUN state instead of PASS. This is causing Jenkins to report
namelist generation jobs as failing even though they are working fine. For now,
skip all test-result processing if we are only generating namelists.

[BFB]
