### PR TITLE
Prepare jenkins scripts to add blues to CI testing

### DIFF
--- a/scripts/acme/acme_util.py
+++ b/scripts/acme/acme_util.py
@@ -11,6 +11,7 @@ MACHINE_NODENAMES = [
     ("skybridge", re.compile(r"skybridge-login")),
     ("melvin", re.compile(r"melvin")),
     ("edison", re.compile(r"edison")),
+    ("blues", re.compile(r"blogin")),
 ]
 
 ###############################################################################

--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -60,6 +60,14 @@ MACHINE_INFO = {
         "/scratch1/scratchdirs/<USER>/acme_scratch",
         None
     ),
+    "blues"    : (
+        "pgi",
+        "acme_developer",
+        True,
+        "ACME",
+        "/lcrc/project/$PROJECT/$CCSMUSER/acme_scratch",
+        None
+    ),
 }
 
 ###############################################################################

--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -582,8 +582,9 @@
          <DESC>ANL/LCRC Linux Cluster</DESC>
          <COMPILERS>intel,gnu,pgi</COMPILERS>
          <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
-         <RUNDIR>/lcrc/project/$PROJECT/$CCSMUSER/$CASE/run</RUNDIR>
-         <EXEROOT>/lcrc/project/$PROJECT/$CCSMUSER/$CASE/bld</EXEROOT>
+         <CESMSCRATCHROOT>/lcrc/project/$PROJECT/$CCSMUSER/acme_scratch</CESMSCRATCHROOT>
+         <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
+         <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
          <DIN_LOC_ROOT>/home/ccsm-data/inputdata</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/lcrc/project/$PROJECT/$CCSMUSER/archive/$CASE</DOUT_S_ROOT>


### PR DESCRIPTION
Prepare jenkins scripts to add blues to CI testing.  Also minor modifcations to blues machine config.

CESMSCRATCHROOT was not defined in the blues configuration. So users need to specify 
"-sharedlibroot" when trying to build and run tests using create_test. If the user misses the 
"-sharedlibroot" argument the build fails. This commit fixes this issue by explicitly specifying the scratch root for blues.

Fixes #154 

[BFB]
