### PR TITLE
Fixed a bug in CLM related to NaNs when using PGI on Titan.

### DIFF
--- a/models/lnd/clm/src/biogeophys/TemperatureType.F90
+++ b/models/lnd/clm/src/biogeophys/TemperatureType.F90
@@ -515,10 +515,10 @@ contains
     ! !ARGUMENTS:
     class(temperature_type)        :: this
     type(bounds_type) , intent(in) :: bounds  
-    real(r8)          , intent(in) :: em_roof_lun(bounds%begl:)
-    real(r8)          , intent(in) :: em_wall_lun(bounds%begl:)
-    real(r8)          , intent(in) :: em_improad_lun(bounds%begl:)
-    real(r8)          , intent(in) :: em_perroad_lun(bounds%begl:)
+    real(r8)          , intent(in) :: em_roof_lun(bounds%begl:bounds%endl)
+    real(r8)          , intent(in) :: em_wall_lun(bounds%begl:bounds%endl)
+    real(r8)          , intent(in) :: em_improad_lun(bounds%begl:bounds%endl)
+    real(r8)          , intent(in) :: em_perroad_lun(bounds%begl:bounds%endl)
     !
     ! !LOCAL VARIABLES:
     integer  :: j,l,c,p ! indices


### PR DESCRIPTION
A B1850C5L45BGC and ICLM45BGC case ran successfully after this fix on Titan,
when compiled with PGI. This commit resolves #165.

[BFB]
