### PR TITLE
Fixed a bug in CLM to avoid failure when using intel14.x on Titan

### DIFF
--- a/models/lnd/clm/src/biogeochem/VOCEmissionMod.F90
+++ b/models/lnd/clm/src/biogeochem/VOCEmissionMod.F90
@@ -196,7 +196,6 @@ contains
           call hist_addfld1d ( fname='MEG_'//trim(meg_cmp%name), units='kg/m2/sec',  &
                avgflag='A', long_name='MEGAN flux', &
                ptr_patch=meg_out(imeg)%flux_out, set_lake=0._r8, set_urb=0._r8 )
-          meg_out(imeg)%flux_out(begp:endp) = 0._r8
 
           meg_cmp => meg_cmp%next_megcomp
        enddo


### PR DESCRIPTION
This commit resolves #142. The bug was fixed in clm4_5_1_r091 tag:
"-- remove duplicate assignment of 0_r8 to meg_out(imeg)%flux_out"

An ICLM45BGC case ran successfully after this fix on Titan.

[BFB]

SEG-96
