### PR TITLE
Implement short-term time step convergence test.

### DIFF
--- a/models/atm/cam/bld/namelist_files/namelist_definition.xml
+++ b/models/atm/cam/bld/namelist_files/namelist_definition.xml
@@ -2038,6 +2038,74 @@ Goff and Gratch (1946); 'MurphyKoop' for Murphy & Koop (2005)
 Default: GoffGratch
 </entry>
 
+<!-- Switches for turning on/off individual parameterizations -->
+
+<entry id="l_tracer_aero" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Turn on aerosol related processes (emissions, chemistry, deposition, etc.)
+Default: TRUE
+</entry>
+
+<entry id="l_vdiff" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Calculate turbulent transport.
+Default: TRUE
+</entry>
+
+<entry id="l_rayleigh" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Calculate Rayleigh friction.
+Default: TRUE
+</entry>
+
+<entry id="l_gw_drag" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Calculate gravity wave drag.
+Default: TRUE
+</entry>
+
+<entry id="l_ac_energy_chk" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Turn on energy budget checks in tphysac.
+Default: TRUE
+</entry>
+
+<entry id="l_bc_energy_fix" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Turn on energy fixer in tphysbc.
+Default: TRUE
+</entry>
+
+<entry id="l_dry_adj" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Calculate dry adjustment.
+Default: TRUE
+</entry>
+
+<entry id="l_st_mac" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Calculate stratiform cloud macrophysics.
+When the CAM4 Rasch-Kristjansson scheme is in use, 
+l_st_mac = .true. also swiches on the microphysics. 
+Default: TRUE
+</entry>
+
+<entry id="l_st_mic" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Calculate stratiform cloud microphysics. Note that this switch 
+is implemented only for the Morrison-Gettelman scheme. 
+For Rasch-Kristjansson, the mac-only option has not been implemented 
+(i.e., depending on what is chosen for l_st_mac,
+macro and microphysics are either both on or both off.)
+Default: TRUE
+</entry>
+
+<entry id="l_rad" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Do radiative transfer and heating/cooling calculation.
+Default: TRUE
+</entry>
+
 <!-- Physics sub-column switches -->
 
 <entry id="use_subcol_microp" type="logical" category="conv"
@@ -2154,7 +2222,7 @@ Default: FALSE
 </entry>
 
 <entry id="shallow_scheme" type="char*16" category="conv"
-       group="phys_ctl_nl" valid_values="Hack,UW,CLUBB_SGS" >
+       group="phys_ctl_nl" valid_values="off,Hack,UW,CLUBB_SGS" >
 Type of shallow convection scheme employed.  'Hack' for Hack shallow convection;
 'UW' for original McCaa UW pbl scheme, modified by Sungsu Park; 'CLUBB_SGS'
 for CLUBB_SGS.

--- a/models/atm/cam/src/physics/cam/convect_deep.F90
+++ b/models/atm/cam/src/physics/cam/convect_deep.F90
@@ -262,16 +262,16 @@ subroutine convect_deep_tend( &
     call pbuf_get_field(pbuf, prec_dp_idx,     prec )
     call pbuf_get_field(pbuf, snow_dp_idx,     snow )
 
+   !cld = 0  !!HuiWan 2014-05. Bugfix. cld is an input variable to zm_conv_tend.
+    ql = 0
+    rprd = 0
+    fracis = 0
+    evapcdp = 0
     prec=0
     snow=0
 
     jctop = pver
     jcbot = 1._r8
-    cld = 0
-    ql = 0
-    rprd = 0
-    fracis = 0
-    evapcdp = 0
 
   case('ZM') !    1 ==> Zhang-McFarlane (default)
      call pbuf_get_field(pbuf, pblh_idx,  pblh)

--- a/models/atm/cam/src/physics/cam/phys_control.F90
+++ b/models/atm/cam/src/physics/cam/phys_control.F90
@@ -97,6 +97,31 @@ logical, public, protected :: use_gw_front = .false.
 ! Convective
 logical, public, protected :: use_gw_convect = .false.
 
+! Switches that turn on/off individual parameterizations.
+!
+! Comment by Hui Wan (PNNL, 2014-12):
+! This set of switches were implemeted in a very simplistic way
+! for a short-term time-step convergence test performed 
+! with the "standard" CAM5 as of 2014. 
+! The purpose was to identify which moist processes 
+! were responsible for the poor convergence of the full model. 
+! We did not make any attempt to test details of MAM
+! or the non-standard model configurations/components such as 
+! WACCM, CLUBB, CARMA. It is unlikely that the switches will work
+! for those configurations. 
+
+logical :: l_tracer_aero   = .true.
+logical :: l_vdiff         = .true.
+logical :: l_rayleigh      = .true.
+logical :: l_gw_drag       = .true.
+logical :: l_ac_energy_chk = .true.
+logical :: l_bc_energy_fix = .true.
+logical :: l_dry_adj       = .true.
+logical :: l_st_mac        = .true.
+logical :: l_st_mic        = .true.
+logical :: l_rad           = .true.
+
+
 !======================================================================= 
 contains
 !======================================================================= 
@@ -120,7 +145,9 @@ subroutine phys_ctl_readnl(nlfile)
       conv_water_in_rad, do_clubb_sgs, do_tms, state_debug_checks, &
       use_gw_oro, use_gw_front, use_gw_convect, fix_g1_err_ndrop, &
       ssalt_tuning, resus_fix, convproc_do_aer, convproc_do_gas, convproc_method_activate, & !BSINGH(09/16/2014):Added ssalt_tuning,resus_fix,convproc_do_aer,convproc_do_gas
-      liqcf_fix, regen_fix, demott_ice_nuc                                                   !BSINGH(09/16/2014):liqcf_fix,regen_fix,demott_ice_nuc
+      liqcf_fix, regen_fix, demott_ice_nuc, &                                                !BSINGH(09/16/2014):liqcf_fix,regen_fix,demott_ice_nuc
+      l_tracer_aero, l_vdiff, l_rayleigh, l_gw_drag, l_ac_energy_chk, &
+      l_bc_energy_fix, l_dry_adj, l_st_mac, l_st_mic, l_rad
    !-----------------------------------------------------------------------------
 
    if (masterproc) then
@@ -175,6 +202,16 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(liqcf_fix,                       1 , mpilog,  0, mpicom)!BSINGH - liq cld fraction fix calc.
    call mpibcast(regen_fix,                       1 , mpilog,  0, mpicom)!BSINGH - aerosol regeneration bug fix for ndrop.F90   
    call mpibcast(demott_ice_nuc,                  1 , mpilog,  0, mpicom)!BSINGH - use DeMott ice nucleation treatment in microphysics  
+   call mpibcast(l_tracer_aero,                   1 , mpilog,  0, mpicom)
+   call mpibcast(l_vdiff,                         1 , mpilog,  0, mpicom)
+   call mpibcast(l_rayleigh,                      1 , mpilog,  0, mpicom)
+   call mpibcast(l_gw_drag,                       1 , mpilog,  0, mpicom)
+   call mpibcast(l_ac_energy_chk,                 1 , mpilog,  0, mpicom)
+   call mpibcast(l_bc_energy_fix,                 1 , mpilog,  0, mpicom)
+   call mpibcast(l_dry_adj,                       1 , mpilog,  0, mpicom)
+   call mpibcast(l_st_mac,                        1 , mpilog,  0, mpicom)
+   call mpibcast(l_st_mic,                        1 , mpilog,  0, mpicom)
+   call mpibcast(l_rad,                           1 , mpilog,  0, mpicom)
 #endif
 
    ! Error checking:
@@ -187,7 +224,8 @@ subroutine phys_ctl_readnl(nlfile)
       write(iulog,*)'waccm: illegal value of waccmx_opt:', waccmx_opt
       call endrun('waccm: illegal value of waccmx_opt')
    endif
-   if (.not. (shallow_scheme .eq. 'Hack' .or. shallow_scheme .eq. 'UW' .or. shallow_scheme .eq. 'CLUBB_SGS')) then
+   if (.not. (shallow_scheme .eq. 'Hack' .or. shallow_scheme .eq. 'UW' .or. shallow_scheme .eq. 'CLUBB_SGS' &
+       .or. shallow_scheme.eq.'off')) then
       write(iulog,*)'phys_setopts: illegal value of shallow_scheme:', shallow_scheme
       call endrun('phys_setopts: illegal value of shallow_scheme')
    endif
@@ -288,7 +326,10 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
                         do_clubb_sgs_out, do_tms_out, state_debug_checks_out, fix_g1_err_ndrop_out,     & !BSINGH - bugfix for ndrop.F90
                         ssalt_tuning_out,resus_fix_out,convproc_do_aer_out,  & !BSINGH added ssalt_tuning,resus_fix,convproc_do_aer
                         convproc_do_gas_out, convproc_method_activate_out,   & !BSINGH added convproc_do_gas,convproc_method_activate_out
-                        liqcf_fix_out, regen_fix_out,demott_ice_nuc_out      ) !BSINGH added cliqcf_fix,regen_fix,demott_ice_nuc
+                        liqcf_fix_out, regen_fix_out,demott_ice_nuc_out      & !BSINGH added cliqcf_fix,regen_fix,demott_ice_nuc
+                       ,l_tracer_aero_out, l_vdiff_out, l_rayleigh_out, l_gw_drag_out, l_ac_energy_chk_out  &
+                       ,l_bc_energy_fix_out, l_dry_adj_out, l_st_mac_out, l_st_mic_out, l_rad_out  &
+                        )
 !-----------------------------------------------------------------------
 ! Purpose: Return runtime settings
 !          deep_scheme_out   : deep convection scheme
@@ -331,6 +372,17 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
    logical,           intent(out), optional :: demott_ice_nuc_out  !BSINGH - use DeMott ice nucleation treatment in microphysics   
 
 
+   logical,           intent(out), optional :: l_tracer_aero_out
+   logical,           intent(out), optional :: l_vdiff_out
+   logical,           intent(out), optional :: l_rayleigh_out
+   logical,           intent(out), optional :: l_gw_drag_out
+   logical,           intent(out), optional :: l_ac_energy_chk_out
+   logical,           intent(out), optional :: l_bc_energy_fix_out
+   logical,           intent(out), optional :: l_dry_adj_out
+   logical,           intent(out), optional :: l_st_mac_out
+   logical,           intent(out), optional :: l_st_mic_out
+   logical,           intent(out), optional :: l_rad_out
+
    if ( present(deep_scheme_out         ) ) deep_scheme_out          = deep_scheme
    if ( present(shallow_scheme_out      ) ) shallow_scheme_out       = shallow_scheme
    if ( present(eddy_scheme_out         ) ) eddy_scheme_out          = eddy_scheme
@@ -363,6 +415,17 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, mi
    if ( present(liqcf_fix_out           ) ) liqcf_fix_out            = liqcf_fix      !BSINGH - liq cld fraction fix calc.
    if ( present(regen_fix_out           ) ) regen_fix_out            = regen_fix      !BSINGH -  aerosol regeneration bug fix for ndrop.F90 
    if ( present(demott_ice_nuc_out      ) ) demott_ice_nuc_out       = demott_ice_nuc !BSINGH - use DeMott ice nucleation treatment in microphysics  
+   if ( present(l_tracer_aero_out       ) ) l_tracer_aero_out     = l_tracer_aero
+   if ( present(l_vdiff_out             ) ) l_vdiff_out           = l_vdiff
+   if ( present(l_rayleigh_out          ) ) l_rayleigh_out        = l_rayleigh
+   if ( present(l_gw_drag_out           ) ) l_gw_drag_out         = l_gw_drag
+   if ( present(l_ac_energy_chk_out     ) ) l_ac_energy_chk_out   = l_ac_energy_chk
+   if ( present(l_bc_energy_fix_out     ) ) l_bc_energy_fix_out   = l_bc_energy_fix
+   if ( present(l_dry_adj_out           ) ) l_dry_adj_out         = l_dry_adj
+   if ( present(l_st_mac_out            ) ) l_st_mac_out          = l_st_mac
+   if ( present(l_st_mic_out            ) ) l_st_mic_out          = l_st_mic
+   if ( present(l_rad_out               ) ) l_rad_out             = l_rad
+
 end subroutine phys_getopts
 
 !===============================================================================

--- a/models/atm/cam/src/physics/cam/vertical_diffusion.F90
+++ b/models/atm/cam/src/physics/cam/vertical_diffusion.F90
@@ -343,7 +343,7 @@ contains
         if( masterproc ) write(iulog,*) &
              'vertical_diffusion_init: eddy_diffusivity scheme: UW Moist Turbulence Scheme by Bretherton and Park'
         ! Check compatibility of eddy and shallow scheme
-        if( shallow_scheme .ne. 'UW' ) then
+        if( shallow_scheme .ne. 'UW' .and. shallow_scheme .ne. 'off' ) then
             write(iulog,*) 'ERROR: shallow convection scheme ', shallow_scheme,' is incompatible with eddy scheme ', eddy_scheme
             call endrun( 'convect_shallow_init: shallow_scheme and eddy_scheme are incompatible' )
         endif


### PR DESCRIPTION
Add a number of namelist variables (type logical) for switching on/off
individual/group of physics parameterizations in CAM.
Default values are .true., meaning the processes are switched on (as
in the standard model).

[BFB] [NML]

AG-36
