### PR TITLE
wait_for_tests: In CDash, segregate namelist failures from real failures

### DIFF
--- a/scripts/acme/cime_merge_helper
+++ b/scripts/acme/cime_merge_helper
@@ -143,7 +143,7 @@ def merge_acme_changes(acme_path, subdir):
 def _main_func(description):
 ###############################################################################
     if ("--test" in sys.argv):
-        doctest.testmod()
+        doctest.testmod(verbose=True)
         return
 
     acme_path, subdir = parse_command_line(sys.argv, description)

--- a/scripts/acme/compare_namelists
+++ b/scripts/acme/compare_namelists
@@ -302,7 +302,7 @@ def compare_namelist_files(gold_file, compare_file, case):
 def _main_func(description):
 ###############################################################################
     if ("--test" in sys.argv):
-        doctest.testmod()
+        doctest.testmod(verbose=True)
         return
 
     gold_file, compare_file, case = \

--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -244,7 +244,7 @@ def jenkins_generic_job(generate_baselines, submit_to_dashboard,
 def _main_func(description):
 ###############################################################################
     if ("--test" in sys.argv):
-        doctest.testmod()
+        doctest.testmod(verbose=True)
         return
 
     generate_baselines, submit_to_dashboard, baseline_branch, namelists_only = \

--- a/scripts/acme/simple_compare
+++ b/scripts/acme/simple_compare
@@ -144,7 +144,7 @@ def compare_files(gold_file, compare_file, case):
 def _main_func(description):
 ###############################################################################
     if ("--test" in sys.argv):
-        doctest.testmod()
+        doctest.testmod(verbose=True)
         return
 
     gold_file, compare_file, case = \

--- a/scripts/acme/wait_for_tests
+++ b/scripts/acme/wait_for_tests
@@ -4,13 +4,17 @@
 Wait for a queued ACME test to finish by watching the TestStatus file.
 If the test passes, 0 is returned, otherwise a non-zero error code
 is returned.
+
+The easiest way to test this script is to keep a set of create_test
+results laying around somewhere so you don't have to wait for tests
+to run to test this script.
 """
 
 import acme_util
 acme_util.check_minimum_python_version(2, 7)
 import wait_for_tests
 
-import argparse, sys
+import argparse, sys, os
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -63,7 +67,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def _main_func(description):
 ###############################################################################
     if ("--test" in sys.argv):
-        wait_for_tests.run_unit_tests()
+        acme_util.run_cmd("python -m doctest %s/wait_for_tests.py -v" % os.path.dirname(sys.argv[0]), arg_stdout=None, arg_stderr=None)
         return
 
     test_paths, no_wait, check_throughput, ignore_namelist_diffs, cdash_build_name = \


### PR DESCRIPTION
Frequent namelist diffs hid a real BFB change in our tests. This
commit assigns tests that only had a namelist change to the 'notrun'
status. This is a bit confusing, but it's the only other option than
pass or fail.

Also, change doctest unit tests to always be verbose.

[BFB]

SEG-92
