### PR TITLE
Make output for acme python scripts unbuffered

### DIFF
--- a/scripts/acme/acme_bisect
+++ b/scripts/acme/acme_bisect
@@ -113,6 +113,8 @@ def _main_func(description):
         wait_for_tests.run_unit_tests()
         return
 
+    acme_util.stop_buffering_output()
+
     testname, testroot, project, compare, check_namelists, check_throughput, no_submit = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/acme/acme_util.py
+++ b/scripts/acme/acme_util.py
@@ -138,3 +138,22 @@ def get_current_commit(short=False, repo=None):
     """
     output = run_cmd("git rev-parse %s HEAD" % ("--short" if short else ""), from_dir=repo)
     return output.strip()
+
+###############################################################################
+def stop_buffering_output():
+###############################################################################
+    """
+    All stdout, stderr will not be buffered after this is called.
+    """
+    sys.stdout.flush()
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+
+###############################################################################
+def start_buffering_output():
+###############################################################################
+    """
+    All stdout, stderr will be buffered after this is called. This is python's
+    default behavior.
+    """
+    sys.stdout.flush()
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w')

--- a/scripts/acme/cime_merge_helper
+++ b/scripts/acme/cime_merge_helper
@@ -146,6 +146,8 @@ def _main_func(description):
         doctest.testmod(verbose=True)
         return
 
+    acme_util.stop_buffering_output()
+
     acme_path, subdir = parse_command_line(sys.argv, description)
 
     sys.exit(0 if merge_acme_changes(acme_path, subdir) else 1)

--- a/scripts/acme/compare_namelists
+++ b/scripts/acme/compare_namelists
@@ -305,6 +305,8 @@ def _main_func(description):
         doctest.testmod(verbose=True)
         return
 
+    acme_util.stop_buffering_output()
+
     gold_file, compare_file, case = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -247,6 +247,8 @@ def _main_func(description):
         doctest.testmod(verbose=True)
         return
 
+    acme_util.stop_buffering_output()
+
     generate_baselines, submit_to_dashboard, baseline_branch, namelists_only = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/acme/simple_compare
+++ b/scripts/acme/simple_compare
@@ -147,6 +147,8 @@ def _main_func(description):
         doctest.testmod(verbose=True)
         return
 
+    acme_util.stop_buffering_output()
+
     gold_file, compare_file, case = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/acme/update_acme_tests
+++ b/scripts/acme/update_acme_tests
@@ -165,6 +165,8 @@ def _main_func(description):
     expect(args.platform is None or len(args.platform.split(",")) == 2,
            "-p value must be in format: 'machine,compiler'")
 
+    acme_util.stop_buffering_output()
+
     update_acme_test(args.test_list_path, args.category, args.platform)
 
 if __name__ == "__main__":

--- a/scripts/acme/wait_for_tests
+++ b/scripts/acme/wait_for_tests
@@ -70,6 +70,8 @@ def _main_func(description):
         acme_util.run_cmd("python -m doctest %s/wait_for_tests.py -v" % os.path.dirname(sys.argv[0]), arg_stdout=None, arg_stderr=None)
         return
 
+    acme_util.stop_buffering_output()
+
     test_paths, no_wait, check_throughput, ignore_namelist_diffs, cdash_build_name = \
         parse_command_line(sys.argv, description)
 


### PR DESCRIPTION
Interaction with python print statements and output from shell
commands was not working as intended. In many cases, the python output
was buffered and then a shell command with a lot of output was executed
resulting in a long delay before the python prints would appear.
In some cases, this made it harder to find/debug problems.

[BFB]

SEG-87
