### PR TITLE
Turn on the vertsoilc flag for CN compset

### DIFF
--- a/models/lnd/clm/bld/CLMBuildNamelist.pm
+++ b/models/lnd/clm/bld/CLMBuildNamelist.pm
@@ -812,6 +812,9 @@ sub setup_cmdl_bgc {
           }
           $nl_flags->{$var} = $nl->get_value($var);
        }
+       if ($var eq "use_vertsoilc") {
+	  $nl_flags->{$var} = ".true.";
+       }
        $val = $nl_flags->{$var};
        my $group = $definition->get_group_name($var);
        $nl->set_variable_value($group, $var, $val);


### PR DESCRIPTION
Turn on the vertsoilc flag for CN compset as default

[NML] 

SEG-67
