### PR TITLE
config_machines.xml: redsky and skybridge need their own baseline areas

### DIFF
--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -74,7 +74,7 @@
         <DIN_LOC_ROOT_CLMFORC>/glade/proj2/cgd/tss</DIN_LOC_ROOT_CLMFORC>
         <DOUT_S_ROOT>$CESMSCRATCHROOT/archive/$CASE</DOUT_S_ROOT>               <!-- complete path to a short term archiving directory -->
         <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>           <!-- complete path to a long term archiving directory -->
-        <CCSM_BASELINE>/projects/ccsm/ccsm_baselines</CCSM_BASELINE>
+        <CCSM_BASELINE>/projects/ccsm/ccsm_baselines/redsky</CCSM_BASELINE>
         <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
         <BATCHQUERY>qstat</BATCHQUERY>
         <BATCHSUBMIT>sbatch &lt;</BATCHSUBMIT>
@@ -95,7 +95,7 @@
         <DIN_LOC_ROOT_CLMFORC>/glade/proj2/cgd/tss</DIN_LOC_ROOT_CLMFORC>
         <DOUT_S_ROOT>$CESMSCRATCHROOT/archive/$CASE</DOUT_S_ROOT>               <!-- complete path to a short term archiving directory -->
         <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>           <!-- complete path to a long term archiving directory -->
-        <CCSM_BASELINE>/projects/ccsm/ccsm_baselines</CCSM_BASELINE>
+        <CCSM_BASELINE>/projects/ccsm/ccsm_baselines/skybridge</CCSM_BASELINE>
         <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
         <BATCHQUERY>qstat</BATCHQUERY>
         <BATCHSUBMIT>sbatch &lt;</BATCHSUBMIT>


### PR DESCRIPTION
We got away with using the same area because redsky was running master
and skybrige was running next. As far as I know, there's no guarantee
that skybridge will produce the exact same results as redsky, so the
baseline areas will need to be distinct.

[BFB]
