### PR TITLE
jenkins_script: Bash wrapper to preserve output

### DIFF
--- a/scripts/acme/jenkins_script
+++ b/scripts/acme/jenkins_script
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+#
+# Wrapper around jenkins_generic_job that will allow output
+# from that script to always be printed to the screen and
+# recoverable if Jenkins is forced to kill the job. This is the
+# script that should be used from Jenkins.
+#
+
+set -o pipefail
+
+SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
+DATE_STAMP=$(date "+%Y-%m-%d_%H%M%S")
+
+$SCRIPT_DIR/jenkins_generic_job "$@" 2>&1 | tee JENKINS_$DATE_STAMP


### PR DESCRIPTION
Add a new wrapper around jenkins_generic_job that will ensure
that output and errput are printed to screen and archived. This
should make debugging timed-out Jenkins jobs easier

[BFB]

SEG-117
