### PR TITLE
More progress on signal issues with Jenkins

### DIFF
--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -214,6 +214,11 @@ def jenkins_generic_job(generate_baselines, submit_to_dashboard,
 
     try:
 
+        # Important, need to set up signal handlers before we officially
+        # kick off tests. We don't want this process getting killed outright
+        # since it's critical that the cleanup in the finally block gets run
+        wait_for_tests.set_up_signal_handlers()
+
         if (os.path.isdir("Testing")):
             shutil.rmtree("Testing")
 
@@ -247,7 +252,10 @@ def jenkins_generic_job(generate_baselines, submit_to_dashboard,
         if (not use_batch):
             create_test_cmd += " -autosubmit off -nobatch on"
 
-        acme_util.run_cmd(create_test_cmd, verbose=True, arg_stdout=None, arg_stderr=None)
+        if (not wait_for_tests.SIGNAL_RECEIVED):
+            create_test_stat = acme_util.run_cmd(create_test_cmd, verbose=True, arg_stdout=None, arg_stderr=None, ok_to_fail=True)[0]
+            if (create_test_stat != 0):
+                warning("create_test FAILED!")
 
         os.chdir("../..")
 
@@ -275,11 +283,11 @@ def jenkins_generic_job(generate_baselines, submit_to_dashboard,
                                                      False, # don't ignore namelist diffs
                                                      cdash_build_name,
                                                      cdash_project)
-        if (not tests_passed and use_batch):
+        if (not tests_passed and use_batch and wait_for_tests.SIGNAL_RECEIVED):
             # Cleanup
             cleanup_queue(our_jobs, batch_system)
 
-        return tests_passed
+        return tests_passed and create_test_stat == 0
     finally:
         expect(os.path.isfile(sentinel_path), "Missing sentinel file")
         os.remove(sentinel_path)

--- a/scripts/acme/jenkins_script
+++ b/scripts/acme/jenkins_script
@@ -12,4 +12,4 @@ set -o pipefail
 SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
 DATE_STAMP=$(date "+%Y-%m-%d_%H%M%S")
 
-$SCRIPT_DIR/jenkins_generic_job "$@" 2>&1 | tee JENKINS_$DATE_STAMP
+$SCRIPT_DIR/jenkins_generic_job "$@" >& JENKINS_$DATE_STAMP

--- a/scripts/acme/tests/scripts_regression_tests
+++ b/scripts/acme/tests/scripts_regression_tests
@@ -54,7 +54,9 @@ def parse_test_status(line):
 class TestWaitForTests(unittest.TestCase):
 ###############################################################################
 
+    ###########################################################################
     def setUp(self):
+    ###########################################################################
         self._testdir_all_pass     = tempfile.mkdtemp()
         self._testdir_with_fail    = tempfile.mkdtemp()
         self._testdir_unfinished   = tempfile.mkdtemp()
@@ -80,7 +82,9 @@ class TestWaitForTests(unittest.TestCase):
 
         self._threadError = None
 
+    ###########################################################################
     def tearDown(self):
+    ###########################################################################
         shutil.rmtree(self._testdir_all_pass)
         shutil.rmtree(self._testdir_with_fail)
         shutil.rmtree(self._testdir_unfinished)
@@ -88,12 +92,17 @@ class TestWaitForTests(unittest.TestCase):
         # Kill all subprocesses
         proc_ids = acme_util.find_proc_id("[Pp]ython", children_only=True)
         for proc_id in proc_ids:
-           os.kill(proc_id, signal.SIGKILL)
+            try:
+                os.kill(proc_id, signal.SIGKILL)
+            except OSError:
+                pass
 
         if (self._unset_proxy):
             del os.environ["http_proxy"]
 
+    ###########################################################################
     def simple_test(self, testdir, expected_results, extra_args=""):
+    ###########################################################################
         try:
             stat, output, errput = run_cmd("%s/wait_for_tests -p ACME_test TestStatus* %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True, from_dir=testdir)
             if (expected_results == ["PASS"]*len(expected_results)):
@@ -111,18 +120,26 @@ class TestWaitForTests(unittest.TestCase):
         except AssertionError as e:
             self._threadError = str(e)
 
+    ###########################################################################
     def test_wait_for_test_all_pass(self):
+    ###########################################################################
         self.simple_test(self._testdir_all_pass, ["PASS"] * 10)
 
+    ###########################################################################
     def test_wait_for_test_with_fail(self):
+    ###########################################################################
         expected_results = ["PASS" if item % 2 == 0 else "FAIL" for item in range(10)]
         self.simple_test(self._testdir_with_fail, expected_results)
 
+    ###########################################################################
     def test_wait_for_test_no_wait(self):
+    ###########################################################################
         expected_results = ["RUN" if item == 5 else "PASS" for item in range(10)]
         self.simple_test(self._testdir_unfinished, expected_results, "-n")
 
+    ###########################################################################
     def test_wait_for_test_wait(self):
+    ###########################################################################
         run_thread = threading.Thread(target=self.simple_test, args=(self._testdir_unfinished, ["PASS"] * 10))
         run_thread.daemon = True
         run_thread.start()
@@ -133,13 +150,15 @@ class TestWaitForTests(unittest.TestCase):
 
         make_fake_teststatus(os.path.join(self._testdir_unfinished, "TestStatus_5"), "Test_5", "PASS")
 
-        run_thread.join(timeout=5)
+        run_thread.join(timeout=30)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
         self.assertTrue(self._threadError is None, msg="Thread had failure: %s" % self._threadError)
 
+    ###########################################################################
     def test_wait_for_test_wait_kill(self):
+    ###########################################################################
         expected_results = ["RUN" if item == 5 else "PASS" for item in range(10)]
         run_thread = threading.Thread(target=self.simple_test, args=(self._testdir_unfinished, expected_results))
         run_thread.daemon = True
@@ -155,25 +174,29 @@ class TestWaitForTests(unittest.TestCase):
 
         os.kill(proc_id, signal.SIGTERM)
 
-        run_thread.join(timeout=5)
+        run_thread.join(timeout=30)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
         self.assertTrue(self._threadError is None, msg="Thread had failure: %s" % self._threadError)
 
+    ###########################################################################
     def test_wait_for_test_cdash_pass(self):
+    ###########################################################################
         expected_results = ["PASS"] * 10
         run_thread = threading.Thread(target=self.simple_test, args=(self._testdir_all_pass, expected_results, "-d regression_test_pass"))
         run_thread.daemon = True
         run_thread.start()
 
-        run_thread.join(timeout=5)
+        run_thread.join(timeout=30)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
         self.assertTrue(self._threadError is None, msg="Thread had failure: %s" % self._threadError)
 
+    ###########################################################################
     def test_wait_for_test_cdash_kill(self):
+    ###########################################################################
         expected_results = ["RUN" if item == 5 else "PASS" for item in range(10)]
         run_thread = threading.Thread(target=self.simple_test, args=(self._testdir_unfinished, expected_results, "-d regression_test_kill"))
         run_thread.daemon = True
@@ -189,7 +212,7 @@ class TestWaitForTests(unittest.TestCase):
 
         os.kill(proc_id, signal.SIGTERM)
 
-        run_thread.join(timeout=5)
+        run_thread.join(timeout=30)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
@@ -215,9 +238,57 @@ class TestWaitForTests(unittest.TestCase):
 class TestJenkinsGenericJob(unittest.TestCase):
 ###############################################################################
 
+    ###########################################################################
+    def setUp(self):
+    ###########################################################################
+        self._threadError = None
+
+    ###########################################################################
+    def simple_test(self, expect_works):
+    ###########################################################################
+        try:
+            stat, output, errput = run_cmd("%s/jenkins_generic_job -p ACME_test -t acme_tiny -d --branch master" % SCRIPT_DIR, ok_to_fail=True)
+            if (expect_works):
+                self.assertEqual(stat, 0, msg="jenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
+            else:
+                self.assertNotEqual(stat, 0, msg="jenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
+
+        except AssertionError as e:
+            self._threadError = str(e)
+
+    ###########################################################################
     def test_jenkins_generic_job(self):
-        stat, output, errput = run_cmd("%s/jenkins_generic_job -p ACME_test -t acme_tiny -d --branch master" % SCRIPT_DIR, ok_to_fail=True)
-        self.assertEqual(stat, 0, msg="jenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
+    ###########################################################################
+        self.simple_test(True)
+
+        testroot = acme_util.get_machine_info()[4]
+        self.assertFalse(os.path.isfile(os.path.join(testroot, "ONGOING_TEST")),
+                         "job did not cleanup successfully")
+
+    ###########################################################################
+    def test_jenkins_generic_job_kill(self):
+    ###########################################################################
+        run_thread = threading.Thread(target=self.simple_test, args=(False,))
+        run_thread.daemon = True
+        run_thread.start()
+
+        time.sleep(30)
+
+        proc_ids = acme_util.find_proc_id(children_only=True)
+        for proc_id in proc_ids:
+            os.kill(proc_id, signal.SIGTERM)
+
+        run_thread.join(timeout=30)
+
+        self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
+
+        testroot = acme_util.get_machine_info()[4]
+        self.assertFalse(os.path.isfile(os.path.join(testroot, "ONGOING_TEST")),
+                         "job did not cleanup successfully")
+
+        self.assertTrue(self._threadError is None, msg="Thread had failure: %s" % self._threadError)
+
+###########################################################################
 
 if (__name__ == "__main__"):
     unittest.main()

--- a/scripts/acme/wait_for_tests.py
+++ b/scripts/acme/wait_for_tests.py
@@ -25,6 +25,12 @@ def signal_handler(*_):
     SIGNAL_RECEIVED = True
 
 ###############################################################################
+def set_up_signal_handlers():
+###############################################################################
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
+###############################################################################
 def get_test_time(test_path):
 ###############################################################################
     cmd = "grep 'TOT Run Time' /dev/null $(find %s -name 'ccsm_timing*') || true" % test_path
@@ -362,8 +368,7 @@ def wait_for_tests(test_paths,
 ###############################################################################
     # Set up signal handling, we want to print results before the program
     # is terminated
-    signal.signal(signal.SIGTERM, signal_handler)
-    signal.signal(signal.SIGINT, signal_handler)
+    set_up_signal_handlers()
 
     if (cdash_build_name):
         start_time = time.time()


### PR DESCRIPTION
- jenkins_generic_job must not allow itself to be terminated by signal
  so cleanup code has a chance to run
- don't try to cleanup batch jobs unless we got hit with signal
- jenkins script cannot use tee because jenkins tries to kill all child
  processes including tee. A simple redirect is probably the best we can
  do here. This will allow all output to always be saved but you won't be
  able to watch the test run from Jenkins.
- Add a signal test for jenkins_generic_job

[BFB]
