### PR TITLE
Updates compiler for Lawrencium L2 and L3.

### DIFF
--- a/scripts/ccsm_utils/Machines/env_mach_specific.lawrencium-lr2
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.lawrencium-lr2
@@ -6,7 +6,7 @@ module load cmake
 module load perl xml-libxml switch
 
 if ( $COMPILER == "intel" ) then
-    module load intel
+    module load intel/2015.0.090
     module load openmpi
     module load netcdf/4.3.2-intel-p
     module load mkl

--- a/scripts/ccsm_utils/Machines/env_mach_specific.lawrencium-lr3
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.lawrencium-lr3
@@ -6,7 +6,7 @@ module load cmake
 module load perl xml-libxml switch
 
 if ( $COMPILER == "intel" ) then
-    module load intel
+    module load intel/2015.0.090
     module load openmpi
     module load netcdf/4.3.2-intel-p
     module load mkl


### PR DESCRIPTION
The default compiler for Lawrencium is now intel/2015.0.090.

[BFB]
