### PR TITLE
Added crop harvest and yield calculator

### DIFF
--- a/models/lnd/clm/bld/CLMBuildNamelist.pm
+++ b/models/lnd/clm/bld/CLMBuildNamelist.pm
@@ -1766,7 +1766,7 @@ sub setup_logic_params_file {
 
   if ( $physv->as_long() >= $physv->as_long("clm4_5") ) {
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'paramfile', 
-                'use_ed'=>$nl_flags->{'use_ed'} );
+                'use_ed'=>$nl_flags->{'use_ed'} , 'use_crop'=>$nl_flags->{'use_crop'} );
   } else {
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fpftcon');
   }

--- a/models/lnd/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/models/lnd/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -72,7 +72,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Plant function types (relative to {csmdata}) -->
 <paramfile                 >lnd/clm2/paramdata/clm_params.c140423.nc</paramfile>
 <paramfile use_ed=".true." >lnd/clm2/paramdata/clm_params.ED.c140115.nc</paramfile>
-
+<paramfile use_crop=".true." >lnd/clm2/paramdata/clm_params.c150330.nc</paramfile>
 <!--
 
      Original initial condition file at 1 degree resolution

--- a/models/lnd/clm/src/biogeochem/CNCStateUpdate2Mod.F90
+++ b/models/lnd/clm/src/biogeochem/CNCStateUpdate2Mod.F90
@@ -12,6 +12,8 @@ module CNCStateUpdate2Mod
   use clm_varpar       , only : nlevdecomp, i_met_lit, i_cel_lit, i_lig_lit, i_cwd
   use CNCarbonStateType, only : carbonstate_type
   use CNCarbonFluxType , only : carbonflux_type
+  use PatchType        , only : pft
+  use pftvarcon        , only : npcropmin
   !
   implicit none
   save
@@ -131,6 +133,7 @@ contains
     !-----------------------------------------------------------------------
 
     associate(                   & 
+         ivt => pft%itype      , & ! Input:  [integer (:)]  pft vegetation type
          cf => carbonflux_vars , &
          cs => carbonstate_vars  &
          )
@@ -171,6 +174,13 @@ contains
          cs%deadstemc_patch(p)           = cs%deadstemc_patch(p)          - cf%hrv_deadstemc_to_prod100c_patch(p)        * dt
          cs%livecrootc_patch(p)          = cs%livecrootc_patch(p)         - cf%hrv_livecrootc_to_litter_patch(p)         * dt
          cs%deadcrootc_patch(p)          = cs%deadcrootc_patch(p)         - cf%hrv_deadcrootc_to_litter_patch(p)         * dt
+
+         ! crops
+         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+             cs%livestemc_patch(p)       = cs%livestemc_patch(p)          - cf%hrv_livestemc_to_prod1c_patch(p)          *dt
+             cs%leafc_patch(p)           = cs%leafc_patch(p)              - cf%hrv_leafc_to_prod1c_patch(p)              *dt
+             cs%grainc_patch(p)          = cs%grainc_patch(p)             - cf%hrv_grainc_to_prod1c_patch(p)             *dt
+         end if
 
          ! xsmrpool
          cs%xsmrpool_patch(p)            = cs%xsmrpool_patch(p)           - cf%hrv_xsmrpool_to_atm_patch(p)              * dt

--- a/models/lnd/clm/src/biogeochem/CNCropHarvestPoolsMod.F90
+++ b/models/lnd/clm/src/biogeochem/CNCropHarvestPoolsMod.F90
@@ -1,0 +1,125 @@
+module CNCropHarvestPoolsMod
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Calculate loss fluxes from crop harvest pools, and update product pool state variables
+  !
+  ! !USES:
+  use shr_kind_mod        , only : r8 => shr_kind_r8
+  use decompMod           , only : get_proc_bounds
+  use spmdMod             , only : masterproc
+  use landunit_varcon     , only : istsoil
+  use clm_time_manager    , only : get_step_size
+  use clm_varctl          , only : use_c13, use_c14
+  use CNCarbonStateType   , only : carbonstate_type
+  use CNCarbonFluxType    , only : carbonflux_type
+  use CNNitrogenStateType , only : nitrogenstate_type
+  use CNNitrogenFluxType  , only : nitrogenflux_type
+  !
+  implicit none
+  save
+  private
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public:: CNCropHarvestPools
+  !-----------------------------------------------------------------------
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine CNCropHarvestPools(num_soilc, filter_soilc, &
+       carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, nitrogenstate_vars, &
+       carbonflux_vars, c13_carbonflux_vars, c14_carbonflux_vars, nitrogenflux_vars)
+    !
+    ! !DESCRIPTION:
+    ! Update all loss fluxes from crop harvest pools, and update harvest pool state variables
+    ! for both loss and gain terms. GAin terms are calculated in CNCropHarvestPools() for gains
+    ! associated with crop harvest. 
+    !
+    ! !ARGUMENTS:
+    integer                  , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                  , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    type(carbonstate_type)   , intent(in)    :: carbonstate_vars
+    type(carbonstate_type)   , intent(in)    :: c13_carbonstate_vars
+    type(carbonstate_type)   , intent(in)    :: c14_carbonstate_vars
+    type(nitrogenstate_type) , intent(in)    :: nitrogenstate_vars
+    type(carbonflux_type)    , intent(inout) :: carbonflux_vars
+    type(carbonflux_type)    , intent(inout) :: c13_carbonflux_vars
+    type(carbonflux_type)    , intent(inout) :: c14_carbonflux_vars
+    type(nitrogenflux_type)  , intent(inout) :: nitrogenflux_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer :: fc        ! lake filter indices
+    integer :: c         ! indices
+    real(r8):: dt        ! time step (seconds)
+    real(r8) :: kprod1       ! decay constant for 1-year product pool
+    !-----------------------------------------------------------------------
+
+
+    ! calculate column-level losses from product pools
+    ! the following (1/s) rate constants result in ~90% loss of initial state over 1 year,
+    ! using a discrete-time fractional decay algorithm.
+    kprod1 = 7.2e-9
+
+    do fc = 1,num_soilc
+       c = filter_soilc(fc)
+
+       ! calculate fluxes (1/sec)
+       carbonflux_vars%prod1c_loss_col(c)    = carbonstate_vars%prod1c_col(c)    * kprod1
+
+       if ( use_c13 ) then
+          c13_carbonflux_vars%prod1c_loss_col(c)  = c13_carbonstate_vars%prod1c_col(c)  * kprod1
+       endif
+
+       if ( use_c14 ) then
+          c14_carbonflux_vars%prod1c_loss_col(c)  = c14_carbonstate_vars%prod1c_col(c)  * kprod1
+       endif
+
+       nitrogenflux_vars%prod1n_loss_col(c)    = nitrogenstate_vars%prod1n_col(c)    * kprod1
+    end do
+
+    ! set time steps
+    dt = real( get_step_size(), r8 )
+
+    ! update wood product state variables
+    do fc = 1,num_soilc
+       c = filter_soilc(fc)
+
+       ! fluxes into wood product pools, from harvest
+       carbonstate_vars%prod1c_col(c)    = carbonstate_vars%prod1c_col(c)    + &
+            carbonflux_vars%hrv_cropc_to_prod1c_col(c)*dt
+
+       if ( use_c13 ) then
+          c13_carbonstate_vars%prod1c_col(c)  = c13_carbonstate_vars%prod1c_col(c)  + &
+               c13_carbonflux_vars%hrv_cropc_to_prod1c_col(c)*dt
+       endif
+
+       if ( use_c14 ) then
+          c14_carbonstate_vars%prod1c_col(c)  = c14_carbonstate_vars%prod1c_col(c)  + &
+               c14_carbonflux_vars%hrv_cropc_to_prod1c_col(c)*dt
+       endif
+
+       nitrogenstate_vars%prod1n_col(c)    = nitrogenstate_vars%prod1n_col(c)    + &
+            nitrogenflux_vars%hrv_cropn_to_prod1n_col(c)*dt
+
+       ! fluxes out of wood product pools, from decomposition
+       carbonstate_vars%prod1c_col(c)    = carbonstate_vars%prod1c_col(c)    - &
+            carbonflux_vars%prod1c_loss_col(c)*dt
+
+       if ( use_c13 ) then
+          c13_carbonstate_vars%prod1c_col(c)  = c13_carbonstate_vars%prod1c_col(c)  - &
+               c13_carbonflux_vars%prod1c_loss_col(c)*dt
+       endif
+
+       if ( use_c14 ) then
+          c14_carbonstate_vars%prod1c_col(c)  = c14_carbonstate_vars%prod1c_col(c)  - &
+               c14_carbonflux_vars%prod1c_loss_col(c)*dt
+       endif
+
+       nitrogenstate_vars%prod1n_col(c)    = nitrogenstate_vars%prod1n_col(c)    - &
+            nitrogenflux_vars%prod1n_loss_col(c)*dt
+
+    end do ! end of column loop
+
+  end subroutine CNCropHarvestPools
+
+end module CNCropHarvestPoolsMod

--- a/models/lnd/clm/src/biogeochem/CNEcosystemDynMod.F90
+++ b/models/lnd/clm/src/biogeochem/CNEcosystemDynMod.F90
@@ -105,6 +105,7 @@ contains
     use CNCIsoFluxMod          , only: CIsoFlux1, CIsoFlux2, CIsoFlux2h, CIsoFlux3
     use CNC14DecayMod          , only: C14Decay, C14BombSpike
     use CNWoodProductsMod      , only: CNWoodProducts
+    use CNCropHarvestPoolsMod  , only: CNCropHarvestPools
     use CNSoilLittVertTranspMod, only: CNSoilLittVertTransp
     use CNDecompCascadeBGCMod  , only: decomp_rate_constants_bgc
     use CNDecompCascadeCNMod   , only: decomp_rate_constants_cn
@@ -136,7 +137,7 @@ contains
     type(canopystate_type)   , intent(in)    :: canopystate_vars
     type(soilstate_type)     , intent(in)    :: soilstate_vars
     type(temperature_type)   , intent(inout) :: temperature_vars
-    type(crop_type)          , intent(in)    :: crop_vars
+    type(crop_type)          , intent(inout) :: crop_vars
     type(ch4_type)           , intent(in)    :: ch4_vars
     type(dgvs_type)          , intent(inout) :: dgvs_vars
     type(photosyns_type)     , intent(in)    :: photosyns_vars
@@ -389,6 +390,10 @@ contains
             nitrogenflux_vars, nitrogenstate_vars)
 
        call CNWoodProducts(num_soilc, filter_soilc, &
+            carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, nitrogenstate_vars, &
+            carbonflux_vars, c13_carbonflux_vars, c14_carbonflux_vars, nitrogenflux_vars)
+
+       call CNCropHarvestPools(num_soilc, filter_soilc, &
             carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, nitrogenstate_vars, &
             carbonflux_vars, c13_carbonflux_vars, c14_carbonflux_vars, nitrogenflux_vars)
 

--- a/models/lnd/clm/src/biogeochem/CNNStateUpdate2Mod.F90
+++ b/models/lnd/clm/src/biogeochem/CNNStateUpdate2Mod.F90
@@ -12,6 +12,8 @@ module CNNStateUpdate2Mod
   use clm_varctl          , only : iulog
   use CNNitrogenStateType , only : nitrogenstate_type
   use CNNitrogenFLuxType  , only : nitrogenflux_type
+  use PatchType           , only : pft
+  use pftvarcon           , only : npcropmin
   !
   implicit none
   save
@@ -135,6 +137,7 @@ contains
     !-----------------------------------------------------------------------
 
     associate(                      & 
+         ivt => pft%itype         , & ! Input:  [integer  (:) ]  pft vegetation type
          nf => nitrogenflux_vars  , &
          ns => nitrogenstate_vars   &
          )
@@ -172,6 +175,12 @@ contains
          ns%livecrootn_patch(p) = ns%livecrootn_patch(p) - nf%hrv_livecrootn_to_litter_patch(p) * dt
          ns%deadcrootn_patch(p) = ns%deadcrootn_patch(p) - nf%hrv_deadcrootn_to_litter_patch(p) * dt
          ns%retransn_patch(p)   = ns%retransn_patch(p)   - nf%hrv_retransn_to_litter_patch(p)   * dt
+
+       if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+           ns%livestemn_patch(p)= ns%livestemn_patch(p)  - nf%hrv_livestemn_to_prod1n_patch(p)  * dt
+           ns%leafn_patch(p)    = ns%leafn_patch(p)      - nf%hrv_leafn_to_prod1n_patch(p)      * dt
+           ns%grainn_patch(p)   = ns%grainn_patch(p)     - nf%hrv_grainn_to_prod1n_patch(p)     * dt
+       end if
 
          ! storage pools
          ns%leafn_storage_patch(p)      = ns%leafn_storage_patch(p)      - nf%hrv_leafn_storage_to_litter_patch(p)      * dt

--- a/models/lnd/clm/src/biogeochem/CNNitrogenFluxType.F90
+++ b/models/lnd/clm/src/biogeochem/CNNitrogenFluxType.F90
@@ -72,6 +72,12 @@ module CNNitrogenFluxType
      real(r8), pointer :: harvest_n_to_litr_cel_n_col               (:,:)   ! col N fluxes associated with harvest to litter cellulose pool (gN/m3/s)
      real(r8), pointer :: harvest_n_to_litr_lig_n_col               (:,:)   ! col N fluxes associated with harvest to litter lignin pool (gN/m3/s)
      real(r8), pointer :: harvest_n_to_cwdn_col                     (:,:)   ! col N fluxes associated with harvest to CWD pool (gN/m3/s)
+     ! crop harvest
+     real(r8), pointer :: hrv_leafn_to_prod1n_patch                 (:)     ! crop leaf N harvested (gN/m2/s)
+     real(r8), pointer :: hrv_livestemn_to_prod1n_patch             (:)     ! crop stem N harvested (gN/m2/s)
+     real(r8), pointer :: hrv_grainn_to_prod1n_patch                (:)     ! crop grain N harvested (gN/m2/s)
+     real(r8), pointer :: hrv_cropn_to_prod1n_patch                 (:)     ! total amount of crop N harvested (gN/m2/s)
+     real(r8), pointer :: hrv_cropn_to_prod1n_col                   (:)     ! crop N harvest mortality to 1-yr product pool (gN/m2/s)
 
      ! fire N fluxes 
      real(r8), pointer :: m_decomp_npools_to_fire_vr_col            (:,:,:) ! col vertically-resolved decomposing N fire loss (gN/m3/s)
@@ -298,6 +304,7 @@ module CNNitrogenFluxType
      real(r8), pointer :: dwt_nloss_col                             (:)     ! col (gN/m2/s) total nitrogen loss from product pools and conversion
 
      ! wood product pool loss fluxes
+     real(r8), pointer :: prod1n_loss_col                           (:)     ! col (gN/m2/s) decomposition loss from 1-yr crop product pool
      real(r8), pointer :: prod10n_loss_col                          (:)     ! col (gN/m2/s) decomposition loss from 10-yr wood product pool
      real(r8), pointer :: prod100n_loss_col                         (:)     ! col (gN/m2/s) decomposition loss from 100-yr wood product pool
      real(r8), pointer :: product_nloss_col                         (:)     ! col (gN/m2/s) total wood product nitrogen loss
@@ -402,6 +409,10 @@ contains
     allocate(this%hrv_livestemn_to_litter_patch             (begp:endp)) ; this%hrv_livestemn_to_litter_patch             (:) = nan
     allocate(this%hrv_deadstemn_to_prod10n_patch            (begp:endp)) ; this%hrv_deadstemn_to_prod10n_patch            (:) = nan
     allocate(this%hrv_deadstemn_to_prod100n_patch           (begp:endp)) ; this%hrv_deadstemn_to_prod100n_patch           (:) = nan
+    allocate(this%hrv_leafn_to_prod1n_patch                 (begp:endp)) ; this%hrv_leafn_to_prod1n_patch                 (:) = nan
+    allocate(this%hrv_livestemn_to_prod1n_patch             (begp:endp)) ; this%hrv_livestemn_to_prod1n_patch             (:) = nan
+    allocate(this%hrv_grainn_to_prod1n_patch                (begp:endp)) ; this%hrv_grainn_to_prod1n_patch                (:) = nan
+    allocate(this%hrv_cropn_to_prod1n_patch                 (begp:endp)) ; this%hrv_cropn_to_prod1n_patch                 (:) = nan
     allocate(this%hrv_livecrootn_to_litter_patch            (begp:endp)) ; this%hrv_livecrootn_to_litter_patch            (:) = nan
     allocate(this%hrv_deadcrootn_to_litter_patch            (begp:endp)) ; this%hrv_deadcrootn_to_litter_patch            (:) = nan
     allocate(this%hrv_retransn_to_litter_patch              (begp:endp)) ; this%hrv_retransn_to_litter_patch              (:) = nan
@@ -504,6 +515,7 @@ contains
     allocate(this%soyfixn_to_sminn_col          (begc:endc))    ; this%soyfixn_to_sminn_col          (:) = nan
     allocate(this%hrv_deadstemn_to_prod10n_col  (begc:endc))    ; this%hrv_deadstemn_to_prod10n_col  (:) = nan
     allocate(this%hrv_deadstemn_to_prod100n_col (begc:endc))    ; this%hrv_deadstemn_to_prod100n_col (:) = nan
+    allocate(this%hrv_cropn_to_prod1n_col       (begc:endc))    ; this%hrv_cropn_to_prod1n_col       (:) = nan
     allocate(this%sminn_to_plant_col            (begc:endc))    ; this%sminn_to_plant_col	     (:) = nan
     allocate(this%potential_immob_col           (begc:endc))    ; this%potential_immob_col           (:) = nan
     allocate(this%actual_immob_col              (begc:endc))    ; this%actual_immob_col              (:) = nan
@@ -511,6 +523,7 @@ contains
     allocate(this%net_nmin_col                  (begc:endc))    ; this%net_nmin_col                  (:) = nan
     allocate(this%denit_col                     (begc:endc))    ; this%denit_col		     (:) = nan
     allocate(this%supplement_to_sminn_col       (begc:endc))    ; this%supplement_to_sminn_col       (:) = nan
+    allocate(this%prod1n_loss_col               (begc:endc))    ; this%prod1n_loss_col               (:) = nan
     allocate(this%prod10n_loss_col              (begc:endc))    ; this%prod10n_loss_col              (:) = nan
     allocate(this%prod100n_loss_col             (begc:endc))    ; this%prod100n_loss_col	     (:) = nan
     allocate(this%product_nloss_col             (begc:endc))    ; this%product_nloss_col	     (:) = nan
@@ -1656,6 +1669,11 @@ contains
          avgflag='A', long_name='loss from 100-yr wood product pool', &
          ptr_col=this%prod100n_loss_col)
 
+    this%prod1n_loss_col(begc:endc) = spval
+    call hist_addfld1d (fname='PROD1N_LOSS', units='gN/m^2/s', &
+         avgflag='A', long_name='loss from 1-yr crop product pool', &
+         ptr_col=this%prod1n_loss_col)
+
     this%product_nloss_col(begc:endc) = spval
     call hist_addfld1d (fname='PRODUCT_NLOSS', units='gN/m^2/s', &
          avgflag='A', long_name='total N loss from wood product pools', &
@@ -2001,6 +2019,10 @@ contains
        this%hrv_livestemn_to_litter_patch(i)             = value_patch         
        this%hrv_deadstemn_to_prod10n_patch(i)            = value_patch        
        this%hrv_deadstemn_to_prod100n_patch(i)           = value_patch       
+       this%hrv_leafn_to_prod1n_patch(i)                 = value_patch
+       this%hrv_livestemn_to_prod1n_patch(i)             = value_patch
+       this%hrv_grainn_to_prod1n_patch(i)                = value_patch
+       this%hrv_cropn_to_prod1n_patch(i)                 = value_patch
        this%hrv_livecrootn_to_litter_patch(i)            = value_patch        
        this%hrv_deadcrootn_to_litter_patch(i)            = value_patch        
        this%hrv_retransn_to_litter_patch(i)              = value_patch    
@@ -2185,8 +2207,10 @@ contains
        this%soyfixn_to_sminn_col(i)          = value_column
        this%hrv_deadstemn_to_prod10n_col(i)  = value_column        
        this%hrv_deadstemn_to_prod100n_col(i) = value_column      
+       this%hrv_cropn_to_prod1n_col(i)       = value_column
        this%prod10n_loss_col(i)              = value_column
        this%prod100n_loss_col(i)             = value_column
+       this%prod1n_loss_col(i)               = value_column
        this%product_nloss_col(i)             = value_column
        this%potential_immob_col(i)           = value_column
        this%actual_immob_col(i)              = value_column
@@ -2311,7 +2335,8 @@ contains
     ! !USES:
     use clm_varpar    , only: nlevdecomp,ndecomp_cascade_transitions,ndecomp_pools
     use clm_varctl    , only: use_nitrif_denitrif
-    use subgridAveMod , only: p2c 
+    use subgridAveMod , only: p2c
+    use pftvarcon     , only : npcropmin 
     !
     ! !ARGUMENTS:
     class (nitrogenflux_type) :: this
@@ -2339,6 +2364,11 @@ contains
        this%wood_harvestn_patch(p) = &
             this%hrv_deadstemn_to_prod10n_patch(p) + &
             this%hrv_deadstemn_to_prod100n_patch(p)
+       if ( crop_prog .and. pft%itype(p) >= npcropmin )then
+            this%wood_harvestn_patch(p) = &
+            this%wood_harvestn_patch(p) + &
+            this%hrv_cropn_to_prod1n_patch(p)
+       end if
 
        ! total pft-level fire N losses
        this%fire_nloss_patch(p) = &
@@ -2537,7 +2567,8 @@ contains
        ! total wood product N loss
        this%product_nloss_col(c) = &
             this%prod10n_loss_col(c) + &
-            this%prod100n_loss_col(c) 
+            this%prod100n_loss_col(c)+ &
+            this%prod1n_loss_col(c) 
     end do
 
     ! add up all vertical transport tendency terms and calculate total som leaching loss as the sum of these

--- a/models/lnd/clm/src/biogeochem/CNNitrogenStateType.F90
+++ b/models/lnd/clm/src/biogeochem/CNNitrogenStateType.F90
@@ -65,6 +65,7 @@ module CNNitrogenStateType
 
      ! wood product pools, for dynamic landcover
      real(r8), pointer :: seedn_col                    (:)     ! col (gN/m2) column-level pool for seeding new Patches
+     real(r8), pointer :: prod1n_col                   (:)     ! col (gN/m2) crop product N pool, 1-year lifespan
      real(r8), pointer :: prod10n_col                  (:)     ! col (gN/m2) wood product N pool, 10-year lifespan
      real(r8), pointer :: prod100n_col                 (:)     ! col (gN/m2) wood product N pool, 100-year lifespan
      real(r8), pointer :: totprodn_col                 (:)     ! col (gN/m2) total wood product N
@@ -191,6 +192,7 @@ contains
     allocate(this%sminn_col                (begc:endc))                   ; this%sminn_col                (:)   = nan
     allocate(this%ntrunc_col               (begc:endc))                   ; this%ntrunc_col               (:)   = nan
     allocate(this%seedn_col                (begc:endc))                   ; this%seedn_col                (:)   = nan
+    allocate(this%prod1n_col               (begc:endc))                   ; this%prod1n_col               (:)   = nan
     allocate(this%prod10n_col              (begc:endc))                   ; this%prod10n_col              (:)   = nan
     allocate(this%prod100n_col             (begc:endc))                   ; this%prod100n_col             (:)   = nan
     allocate(this%totprodn_col             (begc:endc))                   ; this%totprodn_col             (:)   = nan
@@ -522,6 +524,11 @@ contains
          avgflag='A', long_name='100-yr wood product N', &
          ptr_col=this%prod100n_col)
 
+    this%prod1n_col(begc:endc) = spval
+    call hist_addfld1d (fname='PROD1N', units='gN/m^2', &
+         avgflag='A', long_name='1-yr crop product N', &
+         ptr_col=this%prod1n_col)
+
     this%totprodn_col(begc:endc) = spval
     call hist_addfld1d (fname='TOTPRODN', units='gN/m^2', &
          avgflag='A', long_name='total wood product N', &
@@ -696,6 +703,7 @@ contains
 
           ! dynamic landcover state variables
           this%seedn_col(c)         = 0._r8
+          this%prod1n_col(c)        = 0._r8
           this%prod10n_col(c)       = 0._r8
           this%prod100n_col(c)      = 0._r8
           this%totprodn_col(c)      = 0._r8
@@ -709,6 +717,7 @@ contains
        c = special_col(fc)
 
        this%seedn_col(c)    = 0._r8
+       this%prod1n_col(c)   = 0._r8
        this%prod10n_col(c)  = 0._r8	  
        this%prod100n_col(c) = 0._r8	  
        this%totprodn_col(c) = 0._r8	  
@@ -986,6 +995,10 @@ contains
     call restartvar(ncid=ncid, flag=flag, varname='prod100n', xtype=ncd_double,  &
          dim1name='column', long_name='', units='', &
          interpinic_flag='interp', readvar=readvar, data=this%prod100n_col) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='prod1n', xtype=ncd_double,  &
+         dim1name='column', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%prod1n_col)
 
     ! decomp_cascade_state - the purpose of this is to check to make sure the bgc used 
     ! matches what the restart file was generated with.  
@@ -1503,6 +1516,7 @@ contains
 
       ! total wood product nitrogen
       this%totprodn_col(c) = &
+           this%prod1n_col(c) + &
            this%prod10n_col(c) + &
            this%prod100n_col(c)	 
 

--- a/models/lnd/clm/src/biogeochem/CropType.F90
+++ b/models/lnd/clm/src/biogeochem/CropType.F90
@@ -25,6 +25,8 @@ module CropType
   type, public :: crop_type
      real(r8), pointer :: gddplant_patch          (:)   ! patch accum gdd past planting date for crop       (ddays)
      real(r8), pointer :: gddtsoi_patch           (:)   ! patch growing degree-days from planting (top two soil layers) (ddays)
+     real(r8), pointer :: crpyld_patch            (:)   ! patch crop yield (bu/acre)
+     real(r8), pointer :: dmyield_patch           (:)   ! patch crop yield (t/ha)
 
    contains
      procedure, public  :: Init
@@ -77,6 +79,8 @@ contains
 
     allocate(this%gddplant_patch           (begp:endp))                      ; this%gddplant_patch           (:)   = spval
     allocate(this%gddtsoi_patch            (begp:endp))                      ; this%gddtsoi_patch            (:)   = spval
+    allocate(this%crpyld_patch             (begp:endp))                      ; this%crpyld_patch             (:)   = spval
+    allocate(this%dmyield_patch            (begp:endp))                      ; this%dmyield_patch            (:)   = spval
     
   end subroutine InitAllocate
 
@@ -107,6 +111,16 @@ contains
     call hist_addfld1d (fname='GDDTSOI', units='ddays', &
          avgflag='A', long_name='Growing degree-days from planting (top two soil layers)', &
          ptr_patch=this%gddtsoi_patch, default='inactive')
+
+    this%crpyld_patch(begp:endp) = spval
+    call hist_addfld1d (fname='CRPYLD', units='bu/acre', &
+         avgflag='X', long_name='Crop yield (bu/acre)', &
+         ptr_patch=this%crpyld_patch)
+
+    this%dmyield_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DMYIELD', units='t/ha', &
+         avgflag='X', long_name='Crop yield (t/ha)', &
+         ptr_patch=this%dmyield_patch)
 
   end subroutine InitHistory
 

--- a/models/lnd/clm/src/main/EcophysConType.F90
+++ b/models/lnd/clm/src/main/EcophysConType.F90
@@ -76,6 +76,9 @@ module EcophysConType
      real(r8), allocatable :: fleafcn       (:)   ! C:N during grain fill; leaf (crop)
      real(r8), allocatable :: ffrootcn      (:)   ! C:N during grain fill; froot (crop)
      real(r8), allocatable :: fstemcn       (:)   ! C:N during grain fill; stem (crop)
+     real(r8), allocatable :: presharv      (:)   ! porportion of residue harvested (crop)
+     real(r8), allocatable :: convfact      (:)   ! converstion factor to bu/acre (crop)
+     real(r8), allocatable :: fyield        (:)   ! fraction of grain that is actually harvested (crop)
   end type Ecophyscon_type
 
   type(ecophyscon_type), public :: ecophyscon ! patch ecophysiological constants structure
@@ -94,6 +97,7 @@ contains
     use pftvarcon , only : flivewd, fcur, lf_flab, lf_fcel, lf_flig, fr_flab, fr_fcel, fr_flig
     use pftvarcon , only : leaf_long, evergreen, stress_decid, season_decid
     use pftvarcon , only : fertnitro, graincn, fleafcn, ffrootcn, fstemcn, dwood
+    use pftvarcon , only : presharv, convfact, fyield
     !
     ! !LOCAL VARIABLES:
     integer :: m, ib
@@ -147,6 +151,9 @@ contains
     allocate(ecophyscon%fleafcn       (0:numpft))        ; ecophyscon%fleafcn      (:)   =nan
     allocate(ecophyscon%ffrootcn      (0:numpft))        ; ecophyscon%ffrootcn     (:)   =nan
     allocate(ecophyscon%fstemcn       (0:numpft))        ; ecophyscon%fstemcn      (:)   =nan
+    allocate(ecophyscon%presharv      (0:numpft))        ; ecophyscon%presharv     (:)   =nan
+    allocate(ecophyscon%convfact      (0:numpft))        ; ecophyscon%convfact     (:)   =nan
+    allocate(ecophyscon%fyield        (0:numpft))        ; ecophyscon%fyield       (:)   =nan
 
     do m = 0,numpft
 
@@ -201,6 +208,9 @@ contains
        ecophyscon%fleafcn(m)      = fleafcn(m)
        ecophyscon%ffrootcn(m)     = ffrootcn(m)
        ecophyscon%fstemcn(m)      = fstemcn(m)
+       ecophyscon%presharv(m)     = presharv(m)
+       ecophyscon%convfact(m)     = convfact(m)
+       ecophyscon%fyield(m)       = fyield(m)
     end do
   end subroutine ecophysconInit
 

--- a/models/lnd/clm/src/main/pftvarcon.F90
+++ b/models/lnd/clm/src/main/pftvarcon.F90
@@ -143,6 +143,9 @@ module pftvarcon
   real(r8), allocatable :: fleafcn(:)      !C:N during grain fill; leaf
   real(r8), allocatable :: ffrootcn(:)     !C:N during grain fill; fine root
   real(r8), allocatable :: fstemcn(:)      !C:N during grain fill; stem
+  real(r8), allocatable :: presharv(:)     !porportion of residue harvested
+  real(r8), allocatable :: convfact(:)     !conversion factor to bu/acre
+  real(r8), allocatable :: fyield(:)       !fraction of grain that is actually harvested
 
   ! pft parameters for CNDV code
   ! from LPJ subroutine pftparameters
@@ -187,6 +190,7 @@ contains
     use ncdio_pio ,  only : ncd_io, ncd_pio_closefile, ncd_pio_openfile, file_desc_t, &
                             ncd_inqdid, ncd_inqdlen
     use clm_varctl,  only : paramfile, use_ed
+    use clm_varctl,  only : use_crop
     use clm_varcon,  only : tfrz
     use spmdMod   ,  only : masterproc
     use EDPftvarcon, only : EDpftconrd
@@ -332,7 +336,10 @@ contains
     allocate( fertnitro     (0:mxpft) )
     allocate( fleafcn       (0:mxpft) )  
     allocate( ffrootcn      (0:mxpft) ) 
-    allocate( fstemcn       (0:mxpft) )  
+    allocate( fstemcn       (0:mxpft) )
+    allocate( presharv      (0:mxpft) )
+    allocate( convfact      (0:mxpft) )
+    allocate( fyield        (0:mxpft) )  
     allocate( pftpar20      (0:mxpft) )   
     allocate( pftpar28      (0:mxpft) )   
     allocate( pftpar29      (0:mxpft) )   
@@ -459,6 +466,14 @@ contains
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('fstemcn',fstemcn, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+    if (use_crop) then
+       call ncd_io('presharv',presharv, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+       if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+       call ncd_io('convfact',convfact, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+       if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+       call ncd_io('fyield',fyield, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+       if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+    endif
     if (use_vertsoilc) then
        call ncd_io('rootprof_beta',rootprof_beta, 'read', ncid, readvar=readv, posNOTonfile=.true.)
        if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))


### PR DESCRIPTION
These code modifications include yield calculation in bu/acre and
dry matter (t/ha) and allow harvest of grain to a product pool
analogous to the wood product pools, but with a 1-yr turnover.
An option to harvest percent of residue is allowed but currently
residue harvest is set to 0.

Three new parameters are in the clm_params file for the yield and
residue harvest. The new parameter file (clm_params.crop.c150330.nc)
will be used only when the crop model is active

[CC]

LG-71
