### PR TITLE
Major upgrades to acme script testing

### DIFF
--- a/scripts/acme/compare_namelists
+++ b/scripts/acme/compare_namelists
@@ -69,9 +69,46 @@ def parse_namelists(namelist_lines, filename):
     ...           'three -> four',
     ...           'five -> six'
     ...   nval = 1850
+    ... /
+    ...
+    ... # Hello
+    ...
+    ...   &nml2
+    ...   val2 = .false.
+    ... /
+    ... '''
+    >>> parse_namelists(teststr.splitlines(), 'foo')
+    {'nml': {'dval': {'three': 'four', 'one': 'two'}, 'val': "'foo'", 'maval': ["'one'", "'two'", "'three'", "'four'"], 'aval': ["'one'", "'two'", "'three'"], 'nval': '1850', 'mdval': {'five': 'six', 'three': 'four', 'one': 'two'}}, 'nml2': {'val2': '.false.'}}
+    >>> parse_namelists('blah', 'foo')
+    Traceback (most recent call last):
+        ...
+    SystemExit: FAIL: File 'foo' does not appear to be a namelist file, skipping
+
+    >>> teststr = '''&nml
+    ... val = 'one', 'two',
+    ... val2 = 'three'
     ... /'''
     >>> parse_namelists(teststr.splitlines(), 'foo')
-    {'nml': {'dval': {'three': 'four', 'one': 'two'}, 'val': "'foo'", 'maval': ["'one'", "'two'", "'three'", "'four'"], 'aval': ["'one'", "'two'", "'three'"], 'nval': '1850', 'mdval': {'five': 'six', 'three': 'four', 'one': 'two'}}}
+    Traceback (most recent call last):
+        ...
+    SystemExit: FAIL: In file 'foo', Incomplete multiline variable: 'val'
+
+    >>> teststr = '''&nml
+    ... val = 'one', 'two',
+    ... /'''
+    >>> parse_namelists(teststr.splitlines(), 'foo')
+    Traceback (most recent call last):
+        ...
+    SystemExit: FAIL: In file 'foo', Incomplete multiline variable: 'val'
+
+    >>> teststr = '''&nml
+    ... val = 'one', 'two',
+    ...       'three -> four'
+    ... /'''
+    >>> parse_namelists(teststr.splitlines(), 'foo')
+    Traceback (most recent call last):
+        ...
+    SystemExit: FAIL: In file 'foo', multiline list variable 'val' had dict entries
     """
 
     comment_re = re.compile(r'^[#!]')
@@ -82,7 +119,7 @@ def parse_namelists(namelist_lines, filename):
 
     rv = {}
     current_namelist = None
-    current_name = None
+    multiline_variable = None # (name, value)
     for line in namelist_lines:
 
         line = line.strip()
@@ -92,8 +129,8 @@ def parse_namelists(namelist_lines, filename):
 
         if (current_namelist is None):
             # Must start a namelist
-            expect(current_name is None,
-                   "In file %s, Incomplete multiline variable: '%s'" % (filename, current_name[0] if current_name is not None else ""))
+            expect(multiline_variable is None,
+                   "In file '%s', Incomplete multiline variable: '%s'" % (filename, multiline_variable[0] if multiline_variable is not None else ""))
 
             # Unfornately, other tools were using the old compare_namelists.pl script
             # to compare files that are not namelist files. We need a special error
@@ -102,69 +139,71 @@ def parse_namelists(namelist_lines, filename):
                 expect(rv != {},
                        "File '%s' does not appear to be a namelist file, skipping" % filename)
                 expect(False,
-                       "In file %s, Line '%s' did not begin a namelist as expected" % (filename, line))
+                       "In file '%s', Line '%s' did not begin a namelist as expected" % (filename, line))
 
             current_namelist = namelist_re.match(line).groups()[0]
             expect(current_namelist not in rv,
-                   "In file %s, Duplicate namelist '%s'" % (filename, current_namelist))
+                   "In file '%s', Duplicate namelist '%s'" % (filename, current_namelist))
 
             rv[current_namelist] = {}
 
         elif (line == "/"):
             # Ends a namelist
-            expect(current_name is None,
-                   "In file %s, Incomplete multiline variable: '%s'" % (filename, current_name[0] if current_name is not None else ""))
+            expect(multiline_variable is None,
+                   "In file '%s', Incomplete multiline variable: '%s'" % (filename, multiline_variable[0] if multiline_variable is not None else ""))
             current_namelist = None
 
         elif (name_re.match(line)):
+            expect(multiline_variable is None,
+                   "In file '%s', Incomplete multiline variable: '%s'" % (filename, multiline_variable[0] if multiline_variable is not None else ""))
+
             # Defining a variable (AKA name)
             name, value = name_re.match(line).groups()
-            expect(name not in rv[current_namelist], "In file %s, Duplicate name: '%s'" % (filename, name))
+            expect(name not in rv[current_namelist], "In file '%s', Duplicate name: '%s'" % (filename, name))
 
+            tokens = [item.strip() for item in comma_re.split(value) if item.strip() != ""]
             if ("->" in value):
                 # dict
-                tokens = comma_re.split(value)
                 rv[current_namelist][name] = {}
                 for token in tokens:
-                    if (token.strip() != ""):
-                        m = dict_re.match(token)
-                        expect(m is not None, "In file %s, Dict entry '%s' does not match expected format" % (filename, token))
-                        k, v = m.groups()
-                        rv[current_namelist][name][k] = v
+                    m = dict_re.match(token)
+                    expect(m is not None, "In file '%s', Dict entry '%s' does not match expected format" % (filename, token))
+                    k, v = m.groups()
+                    rv[current_namelist][name][k] = v
 
             elif ("," in value):
                 # list
-                rv[current_namelist][name] = [item for item in comma_re.split(value) if item.strip() != ""]
+                rv[current_namelist][name] = tokens
 
             else:
                 rv[current_namelist][name] = value
 
             if (line.endswith(",")):
                 # Value will continue on in subsequent lines
-                current_name = (name, rv[current_namelist][name])
+                multiline_variable = (name, rv[current_namelist][name])
 
-        elif (current_name is not None):
+        elif (multiline_variable is not None):
             # Continuation of list or dict variable
-            current_value = current_name[1]
-            tokens = comma_re.split(line)
+            current_value = multiline_variable[1]
+            tokens = [item.strip() for item in comma_re.split(line) if item.strip() != ""]
             if (type(current_value) is list):
+                expect("->" not in line, "In file '%s', multiline list variable '%s' had dict entries" % (filename, multiline_variable[0]))
                 current_value.extend([item for item in tokens if item.strip() != ""])
             elif (type(current_value) is dict):
                 for token in tokens:
-                    if (token.strip() != ""):
-                        m = dict_re.match(token)
-                        expect(m is not None, "In file %s, Dict entry '%s' does not match expected format" % (filename, token))
-                        k, v = m.groups()
-                        current_value[k] = v
+                    m = dict_re.match(token)
+                    expect(m is not None, "In file '%s', Dict entry '%s' does not match expected format" % (filename, token))
+                    k, v = m.groups()
+                    current_value[k] = v
             else:
-                expect(False, "In file %s, Continuation should have been for list or dict, instead it was: '%s'" % (filename, type(current_value)))
+                expect(False, "In file '%s', Continuation should have been for list or dict, instead it was: '%s'" % (filename, type(current_value)))
 
             if (not line.endswith(",")):
                 # Completed
-                current_name = None
+                multiline_variable = None
 
         else:
-            expect(False, "In file %s, Unrecognized line: '%s'" % (filename, line))
+            expect(False, "In file '%s', Unrecognized line: '%s'" % (filename, line))
 
     return rv
 
@@ -202,7 +241,7 @@ def normalize_string_value(name, value, case):
 def compare_values(namelist, name, gold_value, comp_value, case):
 ###############################################################################
     """
-    TODO - Unit test
+    Compare values for a specific variable in a namelist.
     """
     if (type(gold_value) != type(comp_value)):
         print "In namelist '%s', variable '%s' did not have expected type '%s', instead is type '%s'" % \
@@ -258,6 +297,54 @@ def compare_namelists(gold_namelists, comp_namelists, case):
 
     Expect args in form: {namelist -> {key -> value} }.
       value can be an int, string, list, or dict
+
+    >>> teststr = '''&nml
+    ...   val = 'foo'
+    ...   aval = 'one','two', 'three'
+    ...   maval = 'one', 'two', 'three', 'four'
+    ...   dval = 'one -> two', 'three -> four'
+    ...   mdval = 'one -> two', 'three -> four', 'five -> six'
+    ...   nval = 1850
+    ... /
+    ... &nml2
+    ...   val2 = .false.
+    ... /
+    ... '''
+    >>> compare_namelists(parse_namelists(teststr.splitlines(), 'foo'), parse_namelists(teststr.splitlines(), 'bar'), None)
+    True
+
+    >>> teststr1 = '''&nml1
+    ...   val11 = 'foo'
+    ... /
+    ... &nml2
+    ...   val21 = 'foo'
+    ...   val22 = 'foo', 'bar', 'baz'
+    ...   val23 = 'baz'
+    ...   val24 = '1 -> 2', '2 -> 3', '3 -> 4'
+    ... /'''
+    >>> teststr2 = '''&nml01
+    ...   val11 = 'foo'
+    ... /
+    ... &nml2
+    ...   val21 = 'foo0'
+    ...   val22 = 'foo', 'bar0', 'baz'
+    ...   val230 = 'baz'
+    ...   val24 = '1 -> 20', '2 -> 3', '30 -> 4'
+    ... /'''
+    >>> compare_namelists(parse_namelists(teststr1.splitlines(), 'foo'), parse_namelists(teststr2.splitlines(), 'bar'), None)
+    In namelist 'nml2', 'val22 list item 1' has inequivalent values 'bar' != 'bar0'
+      NORMALIZED: 'bar' != 'bar0'
+    In namelist 'nml2', missing variable: 'val23'
+    In namelist 'nml2', 'val21' has inequivalent values 'foo' != 'foo0'
+      NORMALIZED: 'foo' != 'foo0'
+    In namelist 'nml2', 'val24 dict item 1' has inequivalent values 2 != 20
+      NORMALIZED: 2 != 20
+    In namelist 'nml2', dict variable 'val24' missing key 3
+    In namelist 'nml2', dict variable 'val24' has extra key 30
+    In namelist 'nml2', found extra variable: 'val230'
+    Missing namelist: nml1
+    Found extra namelist: nml01
+    False
     """
     rv = True
 

--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -53,8 +53,14 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-g", "--generate-baselines", action="store_true", dest="generate_baselines", default=False,
                         help="Generate baselines")
 
-    parser.add_argument("-d", "--submit-to-dashboard", action="store_true", dest="submit_to_dashboard", default=False,
-                        help="Send results to Cdash")
+    parser.add_argument("-d", "--submit-to-cdash", action="store_true", dest="submit_to_cdash", default=False,
+                        help="Send results to CDash")
+
+    parser.add_argument("-c", "--cdash-build-name", action="store", dest="cdash_build_name", default=None,
+                        help="Build name to use for CDash submission. Default will be <TEST_SUITE>_<BRANCH>_<COMPILER>")
+
+    parser.add_argument("-p", "--cdash-project", action="store", dest="cdash_project", default=wait_for_tests.ACME_MAIN_CDASH,
+                        help="The name of the CDash project where results should be uploaded")
 
     parser.add_argument("-n", "--namelists-only", action="store_true", dest="namelists_only", default=False,
                         help="Only compare/generate namelists. Useful for quickly blessing namelist changes")
@@ -68,9 +74,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-t", "--test-suite", action="store", dest="test_suite", default=None,
                         help="Override default acme test suite that will be run")
 
-    parser.add_argument("-p", "--cdash-project", action="store", dest="cdash_project", default=wait_for_tests.ACME_MAIN_CDASH,
-                        help="The name of the CDash project where results should be uploaded")
-
     parser.add_argument("bless_tests", nargs="*",
                         help="When blessing, limit the bless to tests matching these regex")
 
@@ -80,14 +83,18 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     expect(not (args.generate_baselines and args.bless),
            "Does not make sense to use -g and -r together")
-    expect(not (args.submit_to_dashboard and args.generate_baselines),
+    expect(not (args.submit_to_cdash and args.generate_baselines),
            "Does not make sense to use -g and -d together")
-    expect(not (args.submit_to_dashboard and args.bless),
+    expect(not (args.submit_to_cdash and args.bless),
            "Does not make sense to use -r and -d together")
+    expect(not (args.cdash_build_name is not None and not args.submit_to_cdash),
+           "Does not make sense to use --cdash-build-name without -d")
+    expect(not (args.cdash_project is not wait_for_tests.ACME_MAIN_CDASH and not args.submit_to_cdash),
+           "Does not make sense to use -p without -d")
     expect(not (len(args.bless_tests) > 0 and not args.bless),
            "Providing specific test names only makes sense with -r")
 
-    return args.generate_baselines, args.submit_to_dashboard, args.branch, args.namelists_only, args.bless, args.test_suite, args.cdash_project, args.bless_tests
+    return args.generate_baselines, args.submit_to_cdash, args.cdash_build_name, args.cdash_project, args.branch, args.namelists_only, args.bless, args.test_suite, args.bless_tests
 
 ###############################################################################
 def cleanup_queue(set_of_jobs_we_created, batch_system):
@@ -164,9 +171,10 @@ def bless_test_results(casearea, baseline_root, git_branch, namelists_only, bles
                     acme_util.safe_copy(testcase_dir_for_test, baseline_dir_for_test, other_files)
 
 ###############################################################################
-def jenkins_generic_job(generate_baselines, submit_to_dashboard,
+def jenkins_generic_job(generate_baselines, submit_to_cdash,
+                        arg_cdash_build_name=None, cdash_project=None,
                         baseline_branch=None, namelists_only=False, bless=False,
-                        arg_test_suite=None, cdash_project=None, bless_tests=None):
+                        arg_test_suite=None, bless_tests=None):
 ###############################################################################
     acme_machine = acme_util.probe_machine_name()
     expect(acme_machine is not None,
@@ -195,7 +203,7 @@ def jenkins_generic_job(generate_baselines, submit_to_dashboard,
     # Env changes
     #
 
-    if (submit_to_dashboard and proxy is not None):
+    if (submit_to_cdash and proxy is not None):
         os.environ["http_proxy"] = proxy
 
     #
@@ -276,7 +284,11 @@ def jenkins_generic_job(generate_baselines, submit_to_dashboard,
         # Wait for tests
         #
 
-        cdash_build_name = "_".join([test_suite, git_branch, compiler]) if submit_to_dashboard else None
+        if (submit_to_cdash):
+            cdash_build_name = "_".join([test_suite, git_branch, compiler]) if arg_cdash_build_name is None else arg_cdash_build_name
+        else:
+            cdash_build_name = None
+
         tests_passed = wait_for_tests.wait_for_tests(glob.glob("%s/*/TestStatus" % casearea),
                                                      not use_batch, # wait if using queue
                                                      False, # don't check throughput
@@ -301,10 +313,10 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    generate_baselines, submit_to_dashboard, baseline_branch, namelists_only, bless, test_suite, cdash_project, bless_tests = \
+    generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, bless, test_suite, bless_tests = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_dashboard, baseline_branch, namelists_only, bless, test_suite, cdash_project, bless_tests) else 1)
+    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, bless, test_suite, bless_tests) else 1)
 
 ###############################################################################
 

--- a/scripts/acme/simple_compare
+++ b/scripts/acme/simple_compare
@@ -74,8 +74,11 @@ def normalize_string_value(value, case):
 ###############################################################################
 def skip_comments_and_whitespace(lines, idx):
 ###############################################################################
+    """
+    Starting at idx, return next valid idx of lines that contains real data
+    """
     if (idx == len(lines)):
-        return
+        return idx
 
     comment_re = re.compile(r'^[#!]')
 
@@ -93,7 +96,30 @@ def skip_comments_and_whitespace(lines, idx):
 def compare_data(gold_lines, comp_lines, case):
 ###############################################################################
     """
-    TODO: Unit test
+    >>> teststr = '''
+    ... data1
+    ... data2 data3
+    ... data4 data5 data6
+    ...
+    ... # Comment
+    ... data7 data8 data9 data10
+    ... '''
+    >>> compare_data(teststr.splitlines(), teststr.splitlines(), None)
+    True
+
+    >>> teststr2 = '''
+    ... data1
+    ... data2 data30
+    ... data4 data5 data6
+    ... data7 data8 data9 data10
+    ... data00
+    ... '''
+    >>> compare_data(teststr.splitlines(), teststr2.splitlines(), None)
+    Inequivalent lines data2 data3 != data2 data30
+      NORMALIZED: data2 data3 != data2 data30
+    Found extra lines
+    data00
+    False
     """
     rv = True
     gidx, cidx = 0, 0

--- a/scripts/acme/tests/scripts_regression_tests
+++ b/scripts/acme/tests/scripts_regression_tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest, sys, os, tempfile, shutil, re, threading, time, signal
+import unittest, sys, os, tempfile, shutil, re, threading, time, signal, glob, stat
 
 SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(SCRIPT_DIR)
@@ -51,6 +51,44 @@ def parse_test_status(line):
     return m.groups()
 
 ###############################################################################
+def kill_subprocesses(name=None, sig=signal.SIGKILL, expected_num_killed=None, tester=None):
+###############################################################################
+    # Kill all subprocesses
+    proc_ids = acme_util.find_proc_id(proc_name=name, children_only=True)
+    if (expected_num_killed is not None):
+        tester.assertEqual(len(proc_ids), expected_num_killed,
+                           msg="Expected to find %d processes to kill, found %d" % (expected_num_killed, len(proc_ids)))
+    for proc_id in proc_ids:
+        try:
+            os.kill(proc_id, sig)
+        except OSError:
+            pass
+
+###############################################################################
+def kill_python_subprocesses(sig=signal.SIGKILL, expected_num_killed=None, tester=None):
+###############################################################################
+    kill_subprocesses("[Pp]ython", sig, expected_num_killed, tester)
+
+###############################################################################
+def setup_proxy():
+###############################################################################
+    if ("http_proxy" not in os.environ):
+        machine = acme_util.probe_machine_name()
+        if (machine is not None):
+            proxy = acme_util.get_machine_info(machine)[6]
+            if (proxy is not None):
+                os.environ["http_proxy"] = proxy
+                return True
+
+    return False
+
+###############################################################################
+def generate_utc_timestamp():
+###############################################################################
+    utc_time_tuple = time.gmtime()
+    return time.strftime("%Y%m%d_%H%M%S", utc_time_tuple)
+
+###############################################################################
 class TestWaitForTests(unittest.TestCase):
 ###############################################################################
 
@@ -71,16 +109,9 @@ class TestWaitForTests(unittest.TestCase):
             make_fake_teststatus(os.path.join(self._testdir_unfinished, "TestStatus_%d" % r), "Test_%d" % r, "RUN" if r == 5 else "PASS")
 
         # Set up proxy if possible
-        self._unset_proxy = False
-        if ("http_proxy" not in os.environ):
-            machine = acme_util.probe_machine_name()
-            if (machine is not None):
-                proxy = acme_util.get_machine_info(machine)[6]
-                if (proxy is not None):
-                    os.environ["http_proxy"] = proxy
-                    self._unset_proxy = True
+        self._unset_proxy = setup_proxy()
 
-        self._threadError = None
+        self._thread_error = None
 
     ###########################################################################
     def tearDown(self):
@@ -89,13 +120,7 @@ class TestWaitForTests(unittest.TestCase):
         shutil.rmtree(self._testdir_with_fail)
         shutil.rmtree(self._testdir_unfinished)
 
-        # Kill all subprocesses
-        proc_ids = acme_util.find_proc_id("[Pp]ython", children_only=True)
-        for proc_id in proc_ids:
-            try:
-                os.kill(proc_id, signal.SIGKILL)
-            except OSError:
-                pass
+        kill_subprocesses()
 
         if (self._unset_proxy):
             del os.environ["http_proxy"]
@@ -118,7 +143,7 @@ class TestWaitForTests(unittest.TestCase):
                 self.assertEqual(testname, "Test_%d" % idx)
 
         except AssertionError as e:
-            self._threadError = str(e)
+            self._thread_error = str(e)
 
     ###########################################################################
     def test_wait_for_test_all_pass(self):
@@ -154,7 +179,7 @@ class TestWaitForTests(unittest.TestCase):
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
-        self.assertTrue(self._threadError is None, msg="Thread had failure: %s" % self._threadError)
+        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
     ###########################################################################
     def test_wait_for_test_wait_kill(self):
@@ -168,17 +193,13 @@ class TestWaitForTests(unittest.TestCase):
 
         self.assertTrue(run_thread.isAlive(), msg="wait_for_tests should have waited")
 
-        proc_ids = acme_util.find_proc_id("[Pp]ython", children_only=True)
-        self.assertEqual(1, len(proc_ids), "Expected to find 1 process, found '%s'" % proc_ids)
-        proc_id = proc_ids[0]
-
-        os.kill(proc_id, signal.SIGTERM)
+        kill_python_subprocesses(signal.SIGTERM, expected_num_killed=1, tester=self)
 
         run_thread.join(timeout=30)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
-        self.assertTrue(self._threadError is None, msg="Thread had failure: %s" % self._threadError)
+        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
     ###########################################################################
     def test_wait_for_test_cdash_pass(self):
@@ -192,7 +213,7 @@ class TestWaitForTests(unittest.TestCase):
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
-        self.assertTrue(self._threadError is None, msg="Thread had failure: %s" % self._threadError)
+        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
     ###########################################################################
     def test_wait_for_test_cdash_kill(self):
@@ -206,17 +227,13 @@ class TestWaitForTests(unittest.TestCase):
 
         self.assertTrue(run_thread.isAlive(), msg="wait_for_tests should have waited")
 
-        proc_ids = acme_util.find_proc_id("[Pp]ython", children_only=True)
-        self.assertEqual(1, len(proc_ids), "Expected to find 1 process, found '%s'" % proc_ids)
-        proc_id = proc_ids[0]
-
-        os.kill(proc_id, signal.SIGTERM)
+        kill_python_subprocesses(signal.SIGTERM, expected_num_killed=1, tester=self)
 
         run_thread.join(timeout=30)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
-        self.assertTrue(self._threadError is None, msg="Thread had failure: %s" % self._threadError)
+        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
         cdash_result_dir = os.path.join(self._testdir_unfinished, "Testing")
         tag_file         = os.path.join(cdash_result_dir, "TAG")
@@ -241,52 +258,124 @@ class TestJenkinsGenericJob(unittest.TestCase):
     ###########################################################################
     def setUp(self):
     ###########################################################################
-        self._threadError = None
+        self._thread_error      = None
+        self._wget_file         = tempfile.mktemp()
+        self._unset_proxy       = setup_proxy()
+        self._baseline_name     = "fake_testing_only_%s" % generate_utc_timestamp()
 
     ###########################################################################
-    def simple_test(self, expect_works):
+    def tearDown(self):
+    ###########################################################################
+        kill_subprocesses()
+
+        if (os.path.isfile(self._wget_file)):
+            os.remove(self._wget_file)
+
+        if (self._unset_proxy):
+            del os.environ["http_proxy"]
+
+        baseline_area = acme_util.get_machine_info()[5]
+        baselines = os.path.join(baseline_area, self._baseline_name)
+        if (os.path.isdir(baselines)):
+            shutil.rmtree(baselines)
+
+    ###########################################################################
+    def simple_test(self, expect_works, extra_args):
     ###########################################################################
         try:
-            stat, output, errput = run_cmd("%s/jenkins_generic_job -p ACME_test -t acme_tiny -d --branch master" % SCRIPT_DIR, ok_to_fail=True)
+            stat, output, errput = run_cmd("%s/jenkins_generic_job -t acme_tiny %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
             if (expect_works):
                 self.assertEqual(stat, 0, msg="jenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
             else:
                 self.assertNotEqual(stat, 0, msg="jenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
 
         except AssertionError as e:
-            self._threadError = str(e)
+            self._thread_error = str(e)
+
+    ###########################################################################
+    def assert_dashboard_has_build(self, build_name):
+    ###########################################################################
+        time.sleep(10) # Give chance for cdash to update
+
+        run_cmd("wget http://my.cdash.org/index.php?project=ACME_test -O %s" % self._wget_file)
+
+        stat = run_cmd("grep %s %s" % (build_name, self._wget_file), ok_to_fail=True)[0]
+        self.assertEqual(stat, 0, msg="Dashboard did not have build '%s'" % build_name)
+
+    ###########################################################################
+    def assert_no_sentinel(self):
+    ###########################################################################
+        testroot = acme_util.get_machine_info()[4]
+        self.assertFalse(os.path.isfile(os.path.join(testroot, "ONGOING_TEST")),
+                         "job did not cleanup successfully")
 
     ###########################################################################
     def test_jenkins_generic_job(self):
     ###########################################################################
-        self.simple_test(True)
+        # Unfortunately, this test is very long-running
 
-        testroot = acme_util.get_machine_info()[4]
-        self.assertFalse(os.path.isfile(os.path.join(testroot, "ONGOING_TEST")),
-                         "job did not cleanup successfully")
+        build_name = "jenkins_generic_job_pass_%s" % generate_utc_timestamp()
+        self.simple_test(True, "-p ACME_test --branch master -d -c %s" % build_name)
+
+        self.assert_no_sentinel()
+        self.assert_dashboard_has_build(build_name)
+        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
     ###########################################################################
     def test_jenkins_generic_job_kill(self):
     ###########################################################################
-        run_thread = threading.Thread(target=self.simple_test, args=(False,))
+        build_name = "jenkins_generic_job_kill_%s" % generate_utc_timestamp()
+        run_thread = threading.Thread(target=self.simple_test, args=(False, "-p ACME_test --branch master -d -c %s" % build_name))
         run_thread.daemon = True
         run_thread.start()
 
-        time.sleep(30)
+        time.sleep(60)
 
-        proc_ids = acme_util.find_proc_id(children_only=True)
-        for proc_id in proc_ids:
-            os.kill(proc_id, signal.SIGTERM)
+        kill_subprocesses(sig=signal.SIGTERM)
 
         run_thread.join(timeout=30)
 
-        self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
+        self.assertFalse(run_thread.isAlive(), msg="jenkins_generic_job should have finished")
+        self.assert_no_sentinel()
+        self.assert_dashboard_has_build(build_name)
+        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
-        testroot = acme_util.get_machine_info()[4]
-        self.assertFalse(os.path.isfile(os.path.join(testroot, "ONGOING_TEST")),
-                         "job did not cleanup successfully")
+    ###############################################################################
+    def test_jenkins_generic_job_rebless_namelist(self):
+    ###############################################################################
+        # Generate some namelist baselines
+        self.simple_test(True, "-g -n --branch %s" % self._baseline_name)
 
-        self.assertTrue(self._threadError is None, msg="Thread had failure: %s" % self._threadError)
+        # Basic namelist compare
+        self.simple_test(True, "-n --branch %s" % self._baseline_name)
+
+        # Modify namelist
+        fake_nl = """
+ &fake_nml
+   fake_item = 'fake'
+   fake = .true.
+/"""
+        baseline_area = acme_util.get_machine_info()[5]
+        baseline_glob = glob.glob(os.path.join(baseline_area, self._baseline_name, "ERS*"))
+        self.assertEqual(len(baseline_glob), 1, msg="Expected one match, got:\n%s" % "\n".join(baseline_glob))
+
+        baseline_dir = baseline_glob[0]
+        nl_path = os.path.join(baseline_dir, "CaseDocs", "datm_in")
+        self.assertTrue(os.path.isfile(nl_path), msg="Missing file %s" % nl_path)
+
+        os.chmod(nl_path, stat.S_IRUSR | stat.S_IWUSR)
+        nl_file = open(nl_path, "a")
+        nl_file.write(fake_nl)
+        nl_file.close()
+
+        # Basic namelist compare should now fail
+        self.simple_test(False, "-n --branch %s" % self._baseline_name)
+
+        # Bless
+        self.simple_test(True, "-b -n --branch %s" % self._baseline_name)
+
+        # Basic namelist compare should now pass again
+        self.simple_test(True, "-n --branch %s" % self._baseline_name)
 
 ###########################################################################
 


### PR DESCRIPTION
- Significant cleanup to regression tests:
- Add new namelist rebless test
- Add capability to confirm cdash upload via wget and grep
- Add option to specify cdash build name for jenkins_generic_job
- Minor cleanup and fixes to compare_namelists
- Much better unit testing of compare_namelists
- Bug fix to simple_compare
- Unit testing for simple_compare

[BFB]

SEG-117
