### PR TITLE
Add support for ORNL OIC phase 5 cluster, updates for OIC phase 2

### DIFF
--- a/scripts/ccsm_utils/Machines/config_compilers.xml
+++ b/scripts/ccsm_utils/Machines/config_compilers.xml
@@ -646,7 +646,7 @@ for mct, etc.
 
 <compiler MACH="oic2" COMPILER="gnu">
   <NETCDF_PATH>/projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4/</NETCDF_PATH>
-  <ADD_SLIBS>-L/user/lib64 -llapack -lblas -lnetcdf -lnetcdff </ADD_SLIBS>
+  <ADD_SLIBS>-L/user/lib64 -llapack -lblas -lnetcdff </ADD_SLIBS>
   <INC_NETCDF>/projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4/include</INC_NETCDF>
   <LIB_NETCDF>/projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4/lib</LIB_NETCDF>
   <SFC>/projects/cesm/devtools/gcc-4.8.1/bin/gfortran</SFC>
@@ -656,6 +656,17 @@ for mct, etc.
   <MPIFC>/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpif90</MPIFC>
 </compiler>
 
+<compiler MACH="oic5" COMPILER="gnu">
+  <NETCDF_PATH>/projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4/</NETCDF_PATH>
+  <ADD_SLIBS>-L/user/lib64 -llapack -lblas -lnetcdff </ADD_SLIBS>
+  <INC_NETCDF>/projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4/include</INC_NETCDF>
+  <LIB_NETCDF>/projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4/lib</LIB_NETCDF>
+  <SFC>/projects/cesm/devtools/gcc-4.8.1/bin/gfortran</SFC>
+  <SCC>/projects/cesm/devtools/gcc-4.8.1/bin/gcc</SCC>
+  <SCXX>/projects/cesm/devtools/gcc-4.8.1/bin/g++</SCXX>
+  <MPICC>/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpicc</MPICC>
+  <MPIFC>/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpif90</MPIFC>
+</compiler>
  
 <compiler COMPILER="intel" MACH="titan">
   <ADD_CFLAGS DEBUG="FALSE"> -O2 </ADD_CFLAGS>

--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -805,6 +805,24 @@
          <MAX_TASKS_PER_NODE>8</MAX_TASKS_PER_NODE>
 </machine>
 
+<machine MACH="oic5">
+         <DESC>ORNL XK6, os is Linux, 8 pes/node, batch system is PBS</DESC>
+         <COMPILERS>gnu</COMPILERS>
+         <MPILIBS>mpich,mpi-serial,openmpi</MPILIBS>
+         <RUNDIR>/home/$USER/models/ACME/run/$CASE/run</RUNDIR>
+         <EXEROOT>/home/$USER/models/ACME/run/$CASE/bld</EXEROOT>
+         <CESMSCRATCHROOT>/home/$USER/models/ACME</CESMSCRATCHROOT>
+         <DIN_LOC_ROOT>/home/zdr/models/ccsm_inputdata</DIN_LOC_ROOT>
+         <DIN_LOC_ROOT_CLMFORC>/home/zdr/models/ccsm_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+         <DOUT_S_ROOT>/home/$USER/models/ACME/run/archive/$CASE</DOUT_S_ROOT>
+         <OS>LINUX</OS>
+         <BATCHQUERY>qstat -f</BATCHQUERY>
+         <BATCHSUBMIT>qsub</BATCHSUBMIT>
+         <SUPPORTED_BY>dmricciuto</SUPPORTED_BY>
+         <GMAKE_J>32</GMAKE_J>
+         <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+</machine>
+
 <machine MACH="titan">
          <DESC>ORNL XK6, os is CNL, 16 pes/node, batch system is PBS</DESC>
 	 <COMPILERS>pgi,pgicuda,intel,cray</COMPILERS>

--- a/scripts/ccsm_utils/Machines/env_mach_specific.oic5
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.oic5
@@ -1,0 +1,42 @@
+#! /bin/csh -f
+
+#===============================================================================
+# Titan machine specific settings
+#===============================================================================
+
+#-------------------------------------------------------------------------------
+# Modules
+#-------------------------------------------------------------------------------
+
+if (-e /opt/modules/default/init/csh) then
+  source /opt/modules/default/init/csh
+#  module switch PGI PGI/2013-64bit
+#  module switch mpi mpi/openmpi-1.4.3-pgi 
+# module list
+endif
+#-------------------------------------------------------------------------------
+# Runtime environment variables
+#-------------------------------------------------------------------------------
+#ulimit -d unlimited 
+setenv MPICH_ENV_DISPLAY 1
+setenv MPICH_VERSION_DISPLAY 1
+setenv MPICH_CPUMASK_DISPLAY 1
+setenv MPICH_RANK_REORDER_DISPLAY 1
+#setenv LD_LIBRARY_PATH /usr/lib64:${LD_LIBRARY_PATH}
+if ( $COMPILER == "gnu" ) then
+  setenv INC_NETCDF /projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4-nonetcdf/include
+  setenv LIB_NETCDF /projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4-nonetcdf/lib
+endif
+if ( $COMPILER == "pgi" ) then
+  setenv INC_NETCDF /home/zdr/opt/netcdf-4.1.3_pgf95/include
+  setenv LIB_NETCDF /home/zdr/opt/netcdf-4.1.3_pgf95/lib
+endif
+
+limit coredumpsize unlimited
+limit stacksize unlimited
+# The environment variable below increase the stack size, which is necessary for
+# CICE to run threaded on this machine. 
+setenv MPSTKZ 64M
+setenv OMP_STACKSIZE 64M
+#
+

--- a/scripts/ccsm_utils/Machines/mkbatch.oic5
+++ b/scripts/ccsm_utils/Machines/mkbatch.oic5
@@ -1,0 +1,103 @@
+#! /bin/csh -f
+
+
+#################################################################################
+if ($PHASE == set_batch) then
+#################################################################################
+
+source ./Tools/ccsm_getenv || exit -1
+
+set mppsize = `${CASEROOT}/Tools/taskmaker.pl -sumonly`
+echo $mppsize
+@ mppnodes = $mppsize / ${MAX_TASKS_PER_NODE}
+if ( $mppsize < ${MAX_TASKS_PER_NODE} ) then 
+  set ppn = $mppsize
+else
+  set ppn = ${MAX_TASKS_PER_NODE}
+endif
+
+if ( $mppsize % ${MAX_TASKS_PER_NODE} > 0) then
+  @ mppnodes = $mppnodes + 1
+  @ mppsize = $mppnodes * ${MAX_TASKS_PER_NODE}
+endif
+
+#--- Job name is first fifteen characters of case name ---
+set jobname = `echo ${CASE} | cut -c1-15`
+set walltime = "48:00:00"
+
+if ($?TESTMODE) then
+ set file = $CASEROOT/${CASE}.test 
+else
+ set file = $CASEROOT/${CASE}.run 
+endif
+
+cat >! $file << EOF1
+#!/bin/csh -f
+#PBS -N ${jobname}
+#PBS -q esd13q
+#PBS -l nodes=${mppnodes}:ppn=$ppn
+#PBS -l walltime=${walltime}
+#PBS -j oe
+#PBS -S /bin/csh -V
+EOF1
+
+
+#################################################################################
+else if ($PHASE == set_exe) then
+#################################################################################
+
+set maxthrds = `${CASEROOT}/Tools/taskmaker.pl -maxthrds`
+set myaprun = `${CASEROOT}/Tools/taskmaker.pl -mpirun`
+
+set mppsize = `${CASEROOT}/Tools/taskmaker.pl -sumonly`
+echo $mppsize
+cat >> ${CASEROOT}/${CASE}.run << EOF1
+sleep 25
+cd \$RUNDIR
+echo "\`date\` -- CSM EXECUTION BEGINS HERE" 
+setenv OMP_NUM_THREADS ${maxthrds}
+echo \$PBS_NODEFILE -np ${mppsize}
+if (\$MPILIB != "mpi-serial") then
+   /projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpirun -f \$PBS_NODEFILE -np ${mppsize} \$EXEROOT/cesm.exe >&! cesm.log.\$LID
+else
+   \$EXEROOT/cesm.exe >&! cesm.log.\$LID
+endif
+wait
+echo "\`date\` -- CSM EXECUTION HAS FINISHED" 
+EOF1
+
+
+#################################################################################
+else if ($PHASE == set_larch) then
+#################################################################################
+
+cat >! $CASEROOT/${CASE}.l_archive << EOF1
+#! /bin/csh -f
+#PBS -N ${CASE}.l_archive
+#PBS -q esd13q
+#PBS -l nodes=1
+#PBS -l walltime=01:30:00
+#PBS -j oe
+#PBS -S /bin/csh -V
+
+cd $CASEROOT 
+source ./Tools/ccsm_getenv || exit -1
+cd \$DOUT_S_ROOT
+$CASEROOT/Tools/lt_archive.sh -m copy_dirs_hsi
+exit 0
+
+EOF1
+chmod 775 ${CASEROOT}/${CASE}.l_archive
+
+
+#################################################################################
+else
+#################################################################################
+
+    echo "  PHASE setting of $PHASE is not an accepted value"
+    echo "  accepted values are set_batch, set_exe and set_larch"
+    exit 1
+
+#################################################################################
+endif
+#################################################################################


### PR DESCRIPTION
Adds support for ORNL local OIC cluster, phase 5 (oic5)
Also corrects a problem in the original OIC phase 2 machine file where netcdf libraries were not being linked properly, somehow resulting in a "too many open files" error after ~10 model simulation years (It had passed previous tests because those are only short runs).
Tested I1850CLM45CN cases on OIC.

Needed for SEG-77
