### PR TITLE
Better and safer test cleanup

### DIFF
--- a/scripts/acme/acme_util.py
+++ b/scripts/acme/acme_util.py
@@ -2,7 +2,7 @@
 Common functions used by acme python scripts
 """
 
-import sys, socket, re, os
+import sys, socket, re, os, time
 
 _VERBOSE = False
 
@@ -341,3 +341,14 @@ def get_machine_info(machine=None):
     expect(machine in MACHINE_INFO, "No info for machine '%s'" % machine)
 
     return MACHINE_INFO[machine]
+
+###############################################################################
+def get_utc_timestamp(format="%Y%m%d_%H%M%S"):
+###############################################################################
+    """
+    Get a string representing the current UTC time in format: YYMMDD_HHMMSS
+
+    The format can be changed if needed.
+    """
+    utc_time_tuple = time.gmtime()
+    return time.strftime(format, utc_time_tuple)

--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -227,10 +227,15 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash,
         # since it's critical that the cleanup in the finally block gets run
         wait_for_tests.set_up_signal_handlers()
 
+        #
+        # Clean up leftovers from previous run of jenkins_generic_job
+        #
+
         if (os.path.isdir("Testing")):
             shutil.rmtree("Testing")
 
-        for old_dir in glob.glob("%s/*%s*" % (testroot, acme_machine)):
+        test_id_root = "jenkins_testid"
+        for old_dir in glob.glob("%s/*%s*" % (testroot, test_id_root)):
             shutil.rmtree(old_dir)
 
         if (os.path.isdir(casearea)):
@@ -251,8 +256,9 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash,
         os.chdir(os.path.join(acme_repo, "scripts"))
         git_branch = acme_util.get_current_branch() if baseline_branch is None else baseline_branch
         baseline_action = "-generate" if generate_baselines else "-compare"
-        create_test_cmd = "./create_test -xml_mach %s -xml_compiler %s -xml_category %s -testroot %s -project %s %s %s" % \
-                          (acme_machine, compiler, test_suite, casearea, project, baseline_action, git_branch)
+        test_id = "%s_%s" % (test_id_root, acme_util.get_utc_timestamp())
+        create_test_cmd = "./create_test -xml_mach %s -xml_compiler %s -xml_category %s -testroot %s -project %s -testid %s %s %s" % \
+                          (acme_machine, compiler, test_suite, casearea, project, test_id, baseline_action, git_branch)
 
         if (namelists_only):
             create_test_cmd += " -nlcompareonly"

--- a/scripts/acme/tests/scripts_regression_tests
+++ b/scripts/acme/tests/scripts_regression_tests
@@ -83,12 +83,6 @@ def setup_proxy():
     return False
 
 ###############################################################################
-def generate_utc_timestamp():
-###############################################################################
-    utc_time_tuple = time.gmtime()
-    return time.strftime("%Y%m%d_%H%M%S", utc_time_tuple)
-
-###############################################################################
 class TestWaitForTests(unittest.TestCase):
 ###############################################################################
 
@@ -261,7 +255,7 @@ class TestJenkinsGenericJob(unittest.TestCase):
         self._thread_error      = None
         self._wget_file         = tempfile.mktemp()
         self._unset_proxy       = setup_proxy()
-        self._baseline_name     = "fake_testing_only_%s" % generate_utc_timestamp()
+        self._baseline_name     = "fake_testing_only_%s" % acme_util.get_utc_timestamp()
 
     ###########################################################################
     def tearDown(self):
@@ -314,7 +308,7 @@ class TestJenkinsGenericJob(unittest.TestCase):
     ###########################################################################
         # Unfortunately, this test is very long-running
 
-        build_name = "jenkins_generic_job_pass_%s" % generate_utc_timestamp()
+        build_name = "jenkins_generic_job_pass_%s" % acme_util.get_utc_timestamp()
         self.simple_test(True, "-p ACME_test --branch master -d -c %s" % build_name)
 
         self.assert_no_sentinel()
@@ -324,7 +318,7 @@ class TestJenkinsGenericJob(unittest.TestCase):
     ###########################################################################
     def test_jenkins_generic_job_kill(self):
     ###########################################################################
-        build_name = "jenkins_generic_job_kill_%s" % generate_utc_timestamp()
+        build_name = "jenkins_generic_job_kill_%s" % acme_util.get_utc_timestamp()
         run_thread = threading.Thread(target=self.simple_test, args=(False, "-p ACME_test --branch master -d -c %s" % build_name))
         run_thread.daemon = True
         run_thread.start()


### PR DESCRIPTION
Leverage the testid capability for create_test to make it
easy to determine which files in a machine's testroot were generated
by jenkins. The previous implementation removed <testroot>/_machine_
which was dangerous as it could clobber any ongoing ACME testing
that was happening outside of Jenkins and also failed to remove old
sharedlibroot directories which were starting to build-up on our testing
machines.

[BFB]
