### PR TITLE
jenkins_generic_job: testroot bug fix

### DIFF
--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -212,12 +212,16 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash,
     # should be happening for the current user. A sentinel file helps
     # enforce this.
     #
+    # Very tiny race window here, not going to sweat it
+    #
 
     sentinel_path = os.path.join(testroot, SENTINEL_FILE)
     expect(not os.path.isfile(sentinel_path),
            "Tests were already in progress, cannot start more!")
 
-    # Very tiny race window here, not going to sweat it
+    if (not os.path.isdir(testroot)):
+        os.makedirs(testroot)
+
     open(sentinel_path, 'w').close()
 
     try:


### PR DESCRIPTION
jenkins_generic_job should still work if the machine's
testroot directory doesn't exist as long as the script can
create the directory.

[BFB]
