### PR TITLE
Update skybridge config to 16 tasks per core

### DIFF
--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -101,7 +101,7 @@
         <BATCHSUBMIT>sbatch &lt;</BATCHSUBMIT>
         <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
         <GMAKE_J>4</GMAKE_J>
-        <MAX_TASKS_PER_NODE>8 </MAX_TASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>16 </MAX_TASKS_PER_NODE>
 </machine>
 
 <machine MACH="bluewaters">


### PR DESCRIPTION
Unlike redsky, skybrige CPUs have 8 cores and each node
has 2 processors.

[BFB] [NML]
