### PR TITLE
Extends the platforms on which an I1850CLM45CN test is supported.

### DIFF
--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -4305,11 +4305,46 @@
         <machine compiler="pgi" testtype="prebeta">goldbach</machine>
       </test>
     </grid>
-  </compset>
-  <compset name="I1850CLM45CN">
     <grid name="f19_f19">
       <test name="SMS">
+        <machine compiler="gnu" testtype="acme_developer">blues</machine>
+        <machine compiler="intel" testtype="acme_developer">blues</machine>
+        <machine compiler="pgi" testtype="acme_developer">blues</machine>
+        <machine compiler="pgi" testtype="acme_developer">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_developer">cascade</machine>
+        <machine compiler="nag" testtype="acme_developer">cascade</machine>
+        <machine compiler="ibm" testtype="acme_developer">cetus</machine>
+        <machine compiler="pgi" testtype="acme_developer">eastwind</machine>
+        <machine compiler="intel" testtype="acme_developer">edison</machine>
+        <machine compiler="intel" testtype="acme_developer">eos</machine>
+        <machine compiler="intel" testtype="acme_developer">evergreen</machine>
+        <machine compiler="intel" testtype="acme_developer">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_developer">goldbach</machine>
+        <machine compiler="nag" testtype="acme_developer">goldbach</machine>
+        <machine compiler="lahey" testtype="acme_developer">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_developer">hopper</machine>
+        <machine compiler="intel" testtype="acme_developer">hopper</machine>
+        <machine compiler="pgi" testtype="acme_developer">hopper</machine>
+        <machine compiler="ibm" testtype="acme_developer">intrepid</machine>
+        <machine compiler="intel" testtype="acme_developer">janus</machine>
+        <machine compiler="intel" testtype="acme_developer">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_developer">linux-generic</machine>
+        <machine compiler="gnu" testtype="acme_developer">mac</machine>
+        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
+        <machine compiler="ibm" testtype="acme_developer">mira</machine>
+        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
+        <machine compiler="intel" testtype="acme_developer">mustang</machine>
+        <machine compiler="pgi" testtype="acme_developer">olympus</machine>
+        <machine compiler="gnu" testtype="acme_developer">penn</machine>
+        <machine compiler="intel" testtype="acme_developer">redsky</machine>
+        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
+        <machine compiler="intel" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_developer">titan</machine>
+        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
+        <machine compiler="intel" testtype="acme_developer">wolf</machine>
+        <machine compiler="gnu" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_developer">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_developer">yellowstone</machine>
       </test>
     </grid>
   </compset>


### PR DESCRIPTION
The I1850CLM45CN test is part of the acme_developer test suite.

[BFB]

SEG-124
