### PR TITLE
Improve wait_for_tests name parsing/reporting

### DIFF
--- a/scripts/acme/wait_for_tests.py
+++ b/scripts/acme/wait_for_tests.py
@@ -278,8 +278,12 @@ def parse_test_status_file(file_contents, status_file_path, check_throughput=Fal
     for line in file_contents.splitlines():
         if (len(line.split()) == 2):
             status, test_name = line.split()
+            # just take the first one
             if (real_test_name is None):
-                real_test_name = test_name # just take the first one
+                try:
+                    real_test_name = acme_util.normalize_case_id(test_name)
+                except:
+                    real_test_name = test_name
 
             verbose_print("Test: '%s' has status '%s'" % (test_name, status))
 


### PR DESCRIPTION
In some cases, the casenames in the TestStatus file contain
the full casename (with .[GC].testid), other times it's just
the testcase. This commit changes wait_for_tests so that it
always just reports the basic casename which should be consistent
from run to run.

[BFB]
