### PR TITLE
adding phosphorus cycle dynamics into ACME land model

### DIFF
--- a/models/lnd/clm/bld/CLMBuildNamelist.pm
+++ b/models/lnd/clm/bld/CLMBuildNamelist.pm
@@ -1767,6 +1767,8 @@ sub setup_logic_params_file {
   if ( $physv->as_long() >= $physv->as_long("clm4_5") ) {
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'paramfile', 
                 'use_ed'=>$nl_flags->{'use_ed'} );
+    add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fsoilordercon', 
+                );
   } else {
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fpftcon');
   }

--- a/models/lnd/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/models/lnd/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -70,8 +70,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile                 >lnd/clm2/paramdata/clm_params.c140423.nc</paramfile>
+<paramfile                 >lnd/clm2/paramdata/clm_params.c150521.nc</paramfile>
 <paramfile use_ed=".true." >lnd/clm2/paramdata/clm_params.ED.c140115.nc</paramfile>
+
+<!-- soil order related parameters (relative to {csmdata}) -->
+<fsoilordercon             >/lustre/atlas1/cli900/world-shared/cesm/inputdata/lnd/clm2/paramdata/CNP_parameters_c131108.nc</fsoilordercon> 
 
 <!--
 
@@ -222,14 +225,15 @@ lnd/clm2/surfdata_map/surfdata_1x1_urbanc_alpha_simyr2000_c130927.nc</fsurdat>
 
 <!-- for pre-industrial simulations - year 1850 -->
 <fsurdat hgrid="360x720cru"   sim_year="1850" use_crop=".false."                           >
-lnd/clm2/surfdata_map/surfdata_360x720cru_simyr1850_c130927.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_360x720_simyr1850_c150414.nc</fsurdat>
 <fsurdat hgrid="48x96"        sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_48x96_simyr1850_c130927.nc</fsurdat>
 
 <fsurdat hgrid="0.9x1.25"     sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_0.9x1.25_simyr1850_c130927.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_0.9x1.25_simyr1850_c150327.nc</fsurdat>
+
 <fsurdat hgrid="1.9x2.5"      sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_1.9x2.5_simyr1850_c130927.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_1.9x2.5_simyr1850_c130412.nc</fsurdat>
 <fsurdat hgrid="10x15"        sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_10x15_simyr1850_c130927.nc</fsurdat>
 

--- a/models/lnd/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/models/lnd/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -87,6 +87,15 @@ over-productive.
     ALL            = Supplemental Nitrogen is active for all vegetation types
 </entry>
 
+<entry id="suplphos" type="char*15" category="clm_physics"
+       group="clm_inparm" valid_values="NONE,ALL" >
+Supplemental Phosphorus mode and for what type of vegetation it's turned on for. 
+In this mode Phosphorus is unlimited rather than prognosed and in general vegetation is 
+over-productive.
+    NONE           = No vegetation types get supplemental Phosphorus
+    ALL            = Supplemental Phosphorus is active for all vegetation types
+</entry>
+
 <entry id="create_crop_landunit" type="logical" category="clm_physics"
        group="clm_inparm" valid_values="" >
 If TRUE, separate the vegetated landunit into a crop landunit and a natural vegetation landunit
@@ -207,6 +216,11 @@ Full pathname datafile with plant function type (PFT) constants combined with
 constants for biogeochem modules
 </entry>
 
+<entry id="fsoilordercon" type="char*256" category="datasets"
+       input_pathname="abs" group="clm_inparm" valid_values="" >
+       Full pathname datafile with soil order dependent constants
+</entry>
+       
 <entry id="flanduse_timeseries" type="char*256" category="datasets"
        input_pathname="abs" group="clm_inparm" valid_values="" >
 Full pathname of time varying PFT data file. This causes the land-use types of

--- a/models/lnd/clm/src/biogeochem/CNDecompCascadeCNMod.F90
+++ b/models/lnd/clm/src/biogeochem/CNDecompCascadeCNMod.F90
@@ -40,6 +40,16 @@ module CNDecompCascadeCNMod
      real(r8):: cn_s3_cn        !C:N for SOM 3
      real(r8):: cn_s4_cn        !C:N for SOM 4
 
+     real(r8):: np_s1_new_cn        !C:P for SOM 1
+     real(r8):: np_s2_new_cn        !C:P for SOM 2
+     real(r8):: np_s3_new_cn        !C:P for SOM 3
+     real(r8):: np_s4_new_cn        !C:P for SOM 4
+
+     real(r8):: cp_s1_new_cn        !C:P for SOM 1
+     real(r8):: cp_s2_new_cn        !C:P for SOM 2
+     real(r8):: cp_s3_new_cn        !C:P for SOM 3
+     real(r8):: cp_s4_new_cn        !C:P for SOM 4
+
      real(r8):: rf_l1s1_cn      !respiration fraction litter 1 -> SOM 1
      real(r8):: rf_l2s2_cn      !respiration fraction litter 2 -> SOM 2
      real(r8):: rf_l3s3_cn      !respiration fraction litter 3 -> SOM 3
@@ -121,6 +131,27 @@ contains
     call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
     CNDecompCnParamsInst%cn_s4_cn=tempr
+
+!!! read in phosphorus variables - X. YANG
+    tString='np_s1_new'
+    call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    CNDecompCnParamsInst%np_s1_new_cn=tempr
+
+    tString='np_s2_new'
+    call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    CNDecompCnParamsInst%np_s2_new_cn=tempr
+
+    tString='np_s3_new'
+    call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    CNDecompCnParamsInst%np_s3_new_cn=tempr
+
+    tString='np_s4_new'
+    call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    CNDecompCnParamsInst%np_s4_new_cn=tempr
 
     tString='rf_l1s1'
     call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
@@ -234,6 +265,10 @@ contains
     real(r8) :: cn_s2
     real(r8) :: cn_s3
     real(r8) :: cn_s4
+    real(r8) :: np_s1_new
+    real(r8) :: np_s2_new
+    real(r8) :: np_s3_new
+    real(r8) :: np_s4_new
 
     integer :: i_litr1
     integer :: i_litr2
@@ -262,6 +297,7 @@ contains
          cascade_donor_pool             =>    decomp_cascade_con%cascade_donor_pool             , & ! Output:   [integer           (:)     ]  which pool is C taken from for a given decomposition step 
          cascade_receiver_pool          =>    decomp_cascade_con%cascade_receiver_pool          , & ! Output:   [integer           (:)     ]  which pool is C added to for a given decomposition step   
          floating_cn_ratio_decomp_pools =>    decomp_cascade_con%floating_cn_ratio_decomp_pools , & ! Output:   [logical           (:)     ]  TRUE => pool has fixed C:N ratio                          
+         floating_cp_ratio_decomp_pools =>    decomp_cascade_con%floating_cp_ratio_decomp_pools , & ! Output:   [logical           (:)     ]  TRUE => pool has fixed C:N ratio                          
          decomp_pool_name_restart       =>    decomp_cascade_con%decomp_pool_name_restart       , & ! Output:   [character(len=8)  (:)     ]  name of pool for restart files                   
          decomp_pool_name_history       =>    decomp_cascade_con%decomp_pool_name_history       , & ! Output:   [character(len=8)  (:)     ]  name of pool for history files                   
          decomp_pool_name_long          =>    decomp_cascade_con%decomp_pool_name_long          , & ! Output:   [character(len=20) (:)     ]  name of pool for netcdf long names              
@@ -270,6 +306,7 @@ contains
          is_soil                        =>    decomp_cascade_con%is_soil                        , & ! Output:   [logical           (:)     ]  TRUE => pool is a soil pool                               
          is_cwd                         =>    decomp_cascade_con%is_cwd                         , & ! Output:   [logical           (:)     ]  TRUE => pool is a cwd pool                                
          initial_cn_ratio               =>    decomp_cascade_con%initial_cn_ratio               , & ! Output:   [real(r8)          (:)     ]  c:n ratio for initialization of pools                    
+         initial_cp_ratio               =>    decomp_cascade_con%initial_cp_ratio               , & ! Output:   [real(r8)          (:)     ]  c:n ratio for initialization of pools                    
          initial_stock                  =>    decomp_cascade_con%initial_stock                  , & ! Output:   [real(r8)          (:)     ]  initial concentration for seeding at spinup              
          is_metabolic                   =>    decomp_cascade_con%is_metabolic                   , & ! Output:   [logical           (:)     ]  TRUE => pool is metabolic material                        
          is_cellulose                   =>    decomp_cascade_con%is_cellulose                   , & ! Output:   [logical           (:)     ]  TRUE => pool is cellulose                                 
@@ -283,6 +320,12 @@ contains
       cn_s2=CNDecompCnParamsInst%cn_s2_cn
       cn_s3=CNDecompCnParamsInst%cn_s3_cn
       cn_s4=CNDecompCnParamsInst%cn_s4_cn
+       
+      ! set soil organic matter C:P ratios -X. YANG 
+      np_s1_new=CNDecompCnParamsInst%np_s1_new_cn
+      np_s2_new=CNDecompCnParamsInst%np_s2_new_cn
+      np_s3_new=CNDecompCnParamsInst%np_s3_new_cn
+      np_s4_new=CNDecompCnParamsInst%np_s4_new_cn
 
       ! set respiration fractions for fluxes between compartments
       ! (from Biome-BGC v4.2.0)
@@ -301,6 +344,7 @@ contains
 
       i_litr1 = i_met_lit
       floating_cn_ratio_decomp_pools(i_litr1) = .true.
+      floating_cp_ratio_decomp_pools(i_litr1) = .true.
       decomp_pool_name_restart(i_litr1) = 'litr1'
       decomp_pool_name_history(i_litr1) = 'LITR1'
       decomp_pool_name_long(i_litr1) = 'litter 1'
@@ -309,6 +353,7 @@ contains
       is_soil(i_litr1) = .false.
       is_cwd(i_litr1) = .false.
       initial_cn_ratio(i_litr1) = 90._r8
+      initial_cp_ratio(i_litr1) = 900._r8
       initial_stock(i_litr1) = 0._r8
       is_metabolic(i_litr1) = .true.
       is_cellulose(i_litr1) = .false.
@@ -316,6 +361,7 @@ contains
 
       i_litr2 = i_cel_lit
       floating_cn_ratio_decomp_pools(i_litr2) = .true.
+      floating_cp_ratio_decomp_pools(i_litr2) = .true.
       decomp_pool_name_restart(i_litr2) = 'litr2'
       decomp_pool_name_history(i_litr2) = 'LITR2'
       decomp_pool_name_long(i_litr2) = 'litter 2'
@@ -324,6 +370,7 @@ contains
       is_soil(i_litr2) = .false.
       is_cwd(i_litr2) = .false.
       initial_cn_ratio(i_litr2) = 90._r8
+      initial_cp_ratio(i_litr2) = 900._r8
       initial_stock(i_litr2) = 0._r8
       is_metabolic(i_litr2) = .false.
       is_cellulose(i_litr2) = .true.
@@ -331,6 +378,7 @@ contains
 
       i_litr3 = i_lig_lit
       floating_cn_ratio_decomp_pools(i_litr3) = .true.
+      floating_cp_ratio_decomp_pools(i_litr3) = .true.
       decomp_pool_name_restart(i_litr3) = 'litr3'
       decomp_pool_name_history(i_litr3) = 'LITR3'
       decomp_pool_name_long(i_litr3) = 'litter 3'
@@ -339,12 +387,14 @@ contains
       is_soil(i_litr3) = .false.
       is_cwd(i_litr3) = .false.
       initial_cn_ratio(i_litr3) = 90._r8
+      initial_cp_ratio(i_litr3) = 900._r8
       initial_stock(i_litr3) = 0._r8
       is_metabolic(i_litr3) = .false.
       is_cellulose(i_litr3) = .false.
       is_lignin(i_litr3) = .true.
 
       floating_cn_ratio_decomp_pools(i_cwd) = .true.
+      floating_cp_ratio_decomp_pools(i_cwd) = .true.
       decomp_pool_name_restart(i_cwd) = 'cwd'
       decomp_pool_name_history(i_cwd) = 'CWD'
       decomp_pool_name_long(i_cwd) = 'coarse woody debris'
@@ -353,6 +403,7 @@ contains
       is_soil(i_cwd) = .false.
       is_cwd(i_cwd) = .true.
       initial_cn_ratio(i_cwd) = 500._r8
+      initial_cp_ratio(i_cwd) = 5000._r8
       initial_stock(i_cwd) = 0._r8
       is_metabolic(i_cwd) = .false.
       is_cellulose(i_cwd) = .false.
@@ -360,6 +411,7 @@ contains
 
       i_soil1 = 5
       floating_cn_ratio_decomp_pools(i_soil1) = .false.
+      floating_cp_ratio_decomp_pools(i_soil1) = .true.
       decomp_pool_name_restart(i_soil1) = 'soil1'
       decomp_pool_name_history(i_soil1) = 'SOIL1'
       decomp_pool_name_long(i_soil1) = 'soil 1'
@@ -368,6 +420,7 @@ contains
       is_soil(i_soil1) = .true.
       is_cwd(i_soil1) = .false.
       initial_cn_ratio(i_soil1) = cn_s1
+      initial_cp_ratio(i_soil1) = cn_s1*np_s1_new 
       initial_stock(i_soil1) = 0._r8
       is_metabolic(i_soil1) = .false.
       is_cellulose(i_soil1) = .false.
@@ -375,6 +428,7 @@ contains
 
       i_soil2 = 6
       floating_cn_ratio_decomp_pools(i_soil2) = .false.
+      floating_cp_ratio_decomp_pools(i_soil2) = .true.
       decomp_pool_name_restart(i_soil2) = 'soil2'
       decomp_pool_name_history(i_soil2) = 'SOIL2'
       decomp_pool_name_long(i_soil2) = 'soil 2'
@@ -383,6 +437,7 @@ contains
       is_soil(i_soil2) = .true.
       is_cwd(i_soil2) = .false.
       initial_cn_ratio(i_soil2) = cn_s2
+      initial_cp_ratio(i_soil2) = cn_s2*np_s2_new
       initial_stock(i_soil2) = 0._r8
       is_metabolic(i_soil2) = .false.
       is_cellulose(i_soil2) = .false.
@@ -390,6 +445,7 @@ contains
 
       i_soil3 = 7
       floating_cn_ratio_decomp_pools(i_soil3) = .false.
+      floating_cp_ratio_decomp_pools(i_soil3) = .true.
       decomp_pool_name_restart(i_soil3) = 'soil3'
       decomp_pool_name_history(i_soil3) = 'SOIL3'
       decomp_pool_name_long(i_soil3) = 'soil 3'
@@ -398,6 +454,7 @@ contains
       is_soil(i_soil3) = .true.
       is_cwd(i_soil3) = .false.
       initial_cn_ratio(i_soil3) = cn_s3
+      initial_cp_ratio(i_soil3) = cn_s3*np_s3_new
       initial_stock(i_soil3) = 0._r8
       is_metabolic(i_soil3) = .false.
       is_cellulose(i_soil3) = .false.
@@ -405,6 +462,7 @@ contains
 
       i_soil4 = 8
       floating_cn_ratio_decomp_pools(i_soil4) = .false.
+      floating_cp_ratio_decomp_pools(i_soil4) = .true.
       decomp_pool_name_restart(i_soil4) = 'soil4'
       decomp_pool_name_history(i_soil4) = 'SOIL4'
       decomp_pool_name_long(i_soil4) = 'soil 4'
@@ -413,6 +471,7 @@ contains
       is_soil(i_soil4) = .true.
       is_cwd(i_soil4) = .false.
       initial_cn_ratio(i_soil4) = cn_s4
+      initial_cp_ratio(i_soil4) = cn_s4*np_s4_new
       initial_stock(i_soil4) = 10._r8
       is_metabolic(i_soil4) = .false.
       is_cellulose(i_soil4) = .false.
@@ -420,6 +479,7 @@ contains
 
       i_atm = 0  !! for terminal pools (i.e. 100% respiration)
       floating_cn_ratio_decomp_pools(i_atm) = .false.
+      floating_cp_ratio_decomp_pools(i_atm) = .false.
       decomp_pool_name_restart(i_atm) = 'atmosphere'
       decomp_pool_name_history(i_atm) = 'atmosphere'
       decomp_pool_name_long(i_atm) = 'atmosphere'
@@ -428,6 +488,7 @@ contains
       is_soil(i_atm) = .false.
       is_cwd(i_atm) = .false.
       initial_cn_ratio(i_atm) = 0._r8
+      initial_cp_ratio(i_atm) = 0._r8
       initial_stock(i_atm) = 0._r8
       is_metabolic(i_atm) = .false.
       is_cellulose(i_atm) = .false.

--- a/models/lnd/clm/src/biogeochem/CNDecompCascadeConType.F90
+++ b/models/lnd/clm/src/biogeochem/CNDecompCascadeConType.F90
@@ -25,6 +25,7 @@ module CNDecompCascadeConType
 
      !-- properties of each decomposing pool
      logical           , pointer  :: floating_cn_ratio_decomp_pools(:) ! TRUE => pool has fixed C:N ratio
+     logical           , pointer  :: floating_cp_ratio_decomp_pools(:) ! TRUE => pool has fixed C:P ratio
      character(len=8)  , pointer  :: decomp_pool_name_restart(:)       ! name of pool for restart files
      character(len=8)  , pointer  :: decomp_pool_name_history(:)       ! name of pool for history files
      character(len=20) , pointer  :: decomp_pool_name_long(:)          ! name of pool for netcdf long names
@@ -33,6 +34,7 @@ module CNDecompCascadeConType
      logical           , pointer  :: is_soil(:)                        ! TRUE => pool is a soil pool
      logical           , pointer  :: is_cwd(:)                         ! TRUE => pool is a cwd pool
      real(r8)          , pointer  :: initial_cn_ratio(:)               ! c:n ratio for initialization of pools
+     real(r8)          , pointer  :: initial_cp_ratio(:)               ! c:p ratio for initialization of pools
      real(r8)          , pointer  :: initial_stock(:)                  ! initial concentration for seeding at spinup
      logical           , pointer  :: is_metabolic(:)                   ! TRUE => pool is metabolic material
      logical           , pointer  :: is_cellulose(:)                   ! TRUE => pool is cellulose
@@ -59,6 +61,7 @@ contains
 
     !-- properties of each decomposing pool
     allocate(decomp_cascade_con%floating_cn_ratio_decomp_pools(0:ndecomp_pools))
+    allocate(decomp_cascade_con%floating_cp_ratio_decomp_pools(0:ndecomp_pools))
     allocate(decomp_cascade_con%decomp_pool_name_restart(0:ndecomp_pools))
     allocate(decomp_cascade_con%decomp_pool_name_history(0:ndecomp_pools))
     allocate(decomp_cascade_con%decomp_pool_name_long(0:ndecomp_pools))
@@ -67,6 +70,7 @@ contains
     allocate(decomp_cascade_con%is_soil(0:ndecomp_pools))
     allocate(decomp_cascade_con%is_cwd(0:ndecomp_pools))
     allocate(decomp_cascade_con%initial_cn_ratio(0:ndecomp_pools))
+    allocate(decomp_cascade_con%initial_cp_ratio(0:ndecomp_pools))
     allocate(decomp_cascade_con%initial_stock(0:ndecomp_pools))
     allocate(decomp_cascade_con%is_metabolic(0:ndecomp_pools))
     allocate(decomp_cascade_con%is_cellulose(0:ndecomp_pools))
@@ -80,6 +84,7 @@ contains
 
     !-- first initialization of properties of each decomposing pool
     decomp_cascade_con%floating_cn_ratio_decomp_pools(0:ndecomp_pools) = .false.
+    decomp_cascade_con%floating_cp_ratio_decomp_pools(0:ndecomp_pools) = .false.
     decomp_cascade_con%decomp_pool_name_history(0:ndecomp_pools)       = ''
     decomp_cascade_con%decomp_pool_name_restart(0:ndecomp_pools)       = ''
     decomp_cascade_con%decomp_pool_name_long(0:ndecomp_pools)          = ''
@@ -88,6 +93,7 @@ contains
     decomp_cascade_con%is_soil(0:ndecomp_pools)                        = .false.
     decomp_cascade_con%is_cwd(0:ndecomp_pools)                         = .false.
     decomp_cascade_con%initial_cn_ratio(0:ndecomp_pools)               = nan
+    decomp_cascade_con%initial_cp_ratio(0:ndecomp_pools)               = nan
     decomp_cascade_con%initial_stock(0:ndecomp_pools)                  = nan
     decomp_cascade_con%is_metabolic(0:ndecomp_pools)                   = .false.
     decomp_cascade_con%is_cellulose(0:ndecomp_pools)                   = .false.

--- a/models/lnd/clm/src/biogeochem/CNWoodProductsMod.F90
+++ b/models/lnd/clm/src/biogeochem/CNWoodProductsMod.F90
@@ -14,6 +14,10 @@ module CNWoodProductsMod
   use CNCarbonFluxType    , only : carbonflux_type
   use CNNitrogenStateType , only : nitrogenstate_type
   use CNNitrogenFluxType  , only : nitrogenflux_type
+
+  use PhosphorusFluxType  , only : phosphorusflux_type
+  use PhosphorusStateType , only : phosphorusstate_type
+
   !
   implicit none
   save
@@ -28,7 +32,8 @@ contains
   !-----------------------------------------------------------------------
   subroutine CNWoodProducts(num_soilc, filter_soilc, &
        carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, nitrogenstate_vars, &
-       carbonflux_vars, c13_carbonflux_vars, c14_carbonflux_vars, nitrogenflux_vars)
+       carbonflux_vars, c13_carbonflux_vars, c14_carbonflux_vars, nitrogenflux_vars,&
+       phosphorusstate_vars,phosphorusflux_vars)
     !
     ! !DESCRIPTION:
     ! Update all loss fluxes from wood product pools, and update product pool state variables
@@ -46,6 +51,10 @@ contains
     type(carbonflux_type)    , intent(inout) :: c13_carbonflux_vars
     type(carbonflux_type)    , intent(inout) :: c14_carbonflux_vars
     type(nitrogenflux_type)  , intent(inout) :: nitrogenflux_vars
+
+    type(phosphorusstate_type) , intent(in) :: phosphorusstate_vars
+    type(phosphorusflux_type)  , intent(inout) :: phosphorusflux_vars
+
     !
     ! !LOCAL VARIABLES:
     integer :: fc        ! lake filter indices
@@ -81,6 +90,9 @@ contains
 
        nitrogenflux_vars%prod10n_loss_col(c)    = nitrogenstate_vars%prod10n_col(c)    * kprod10
        nitrogenflux_vars%prod100n_loss_col(c)   = nitrogenstate_vars%prod100n_col(c)   * kprod100
+
+       phosphorusflux_vars%prod10p_loss_col(c)    = phosphorusstate_vars%prod10p_col(c)    * kprod10
+       phosphorusflux_vars%prod100p_loss_col(c)   = phosphorusstate_vars%prod100p_col(c)   * kprod100
     end do
 
     ! set time steps
@@ -115,6 +127,13 @@ contains
        nitrogenstate_vars%prod100n_col(c)   = nitrogenstate_vars%prod100n_col(c)   + &
             nitrogenflux_vars%dwt_prod100n_gain_col(c)*dt
 
+
+       phosphorusstate_vars%prod10p_col(c)    = phosphorusstate_vars%prod10p_col(c)    + &
+            phosphorusflux_vars%dwt_prod10p_gain_col(c)*dt
+       phosphorusstate_vars%prod100p_col(c)   = phosphorusstate_vars%prod100p_col(c)   + &
+            phosphorusflux_vars%dwt_prod100p_gain_col(c)*dt
+
+
        ! fluxes into wood product pools, from harvest
        carbonstate_vars%prod10c_col(c)    = carbonstate_vars%prod10c_col(c)    + &
             carbonflux_vars%hrv_deadstemc_to_prod10c_col(c)*dt
@@ -140,6 +159,14 @@ contains
        nitrogenstate_vars%prod100n_col(c)   = nitrogenstate_vars%prod100n_col(c)   + &
             nitrogenflux_vars%hrv_deadstemn_to_prod100n_col(c)*dt
 
+
+
+       phosphorusstate_vars%prod10p_col(c)    = phosphorusstate_vars%prod10p_col(c)    + &
+            phosphorusflux_vars%hrv_deadstemp_to_prod10p_col(c)*dt
+       phosphorusstate_vars%prod100p_col(c)   = phosphorusstate_vars%prod100p_col(c)   + &
+            phosphorusflux_vars%hrv_deadstemp_to_prod100p_col(c)*dt
+
+
        ! fluxes out of wood product pools, from decomposition
        carbonstate_vars%prod10c_col(c)    = carbonstate_vars%prod10c_col(c)    - &
             carbonflux_vars%prod10c_loss_col(c)*dt
@@ -164,6 +191,13 @@ contains
             nitrogenflux_vars%prod10n_loss_col(c)*dt
        nitrogenstate_vars%prod100n_col(c)   = nitrogenstate_vars%prod100n_col(c)   - &
             nitrogenflux_vars%prod100n_loss_col(c)*dt
+
+
+       phosphorusstate_vars%prod10p_col(c)    = phosphorusstate_vars%prod10p_col(c)    - &
+            phosphorusflux_vars%prod10p_loss_col(c)*dt
+       phosphorusstate_vars%prod100p_col(c)   = phosphorusstate_vars%prod100p_col(c)   - &
+            phosphorusflux_vars%prod100p_loss_col(c)*dt
+
 
     end do ! end of column loop
 

--- a/models/lnd/clm/src/biogeochem/PDynamicsMod.F90
+++ b/models/lnd/clm/src/biogeochem/PDynamicsMod.F90
@@ -1,0 +1,564 @@
+module PDynamicsMod
+
+  !-----------------------------------------------------------------------
+  ! !MODULE: PDynamicsMod
+  !
+  ! !DESCRIPTION:
+  ! Module for inorganic phosphorus dynamics
+  ! for coupled carbon-nitrogen-phosphorus code.
+  ! X.YANG
+  !
+  ! !USES:
+  use shr_kind_mod        , only : r8 => shr_kind_r8
+  use decompMod           , only : bounds_type
+  use clm_varcon          , only : dzsoi_decomp, zisoi
+  use subgridAveMod       , only : p2c
+  use atm2lndType         , only : atm2lnd_type
+  use CNCarbonFluxType    , only : carbonflux_type, nfix_timeconst
+  
+  use clm_varpar          , only : nlevdecomp
+  use clm_varctl          , only : use_vertsoilc
+  use PhosphorusFluxType  , only : phosphorusflux_type
+  use PhosphorusStateType , only : phosphorusstate_type
+  
+
+  use CNStateType         , only : cnstate_type
+  use WaterStateType      , only : waterstate_type
+  use WaterFluxType       , only : waterflux_type
+  use CropType            , only : crop_type
+  use ColumnType          , only : col
+  use PatchType           , only : pft
+  !
+  implicit none
+  save
+  private
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public :: PWeathering
+  public :: PAdsorption
+  public :: PDesorption
+  public :: POcclusion
+  public :: PBiochemMin
+  public :: PLeaching
+
+  !-----------------------------------------------------------------------
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine PWeathering(num_soilc, filter_soilc, &
+       cnstate_vars,phosphorusstate_vars,phosphorusflux_vars)
+    !
+    !
+    ! !USES:
+    use clm_time_manager , only : get_days_per_year, get_step_size
+    use shr_sys_mod      , only : shr_sys_flush
+    use clm_varcon       , only : secspday, spval
+    use soilorder_varcon, only: r_weather
+    !
+    ! !ARGUMENTS:
+    integer                 , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                 , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    type(cnstate_type)       , intent(in)    :: cnstate_vars
+    type(phosphorusstate_type), intent(in) ::  phosphorusstate_vars
+    type(phosphorusflux_type) , intent(inout) :: phosphorusflux_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c,fc                  ! indices
+    real(r8) :: t                     ! temporary
+    real(r8) :: dayspyr               ! days per year
+
+!   !OTHER LOCAL VARIABLES
+    real(r8)     :: r_weather_c
+    real(r8)     :: rr
+    real(r8):: dt           !decomp timestep (seconds)
+    real(r8):: dtd          !decomp timestep (days)
+    integer :: j
+
+    !-----------------------------------------------------------------------
+
+    associate(&
+
+         isoilorder     => cnstate_vars%isoilorder                 ,&
+         primp          => phosphorusstate_vars%primp_vr_col       ,& 
+         primp_to_labilep => phosphorusflux_vars%primp_to_labilep_vr_col  &         
+
+         )
+
+      dayspyr = get_days_per_year()
+
+      ! set time steps
+      dt = real( get_step_size(), r8 )
+      dtd = dt/(30._r8*secspday)
+   
+      do j = 1,nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+      
+            !! read in monthly rate is converted to that in half hour
+            r_weather_c = r_weather( isoilorder(c) )
+            rr=-log(1._r8-r_weather_c)
+            r_weather_c=1._r8-exp(-rr*dtd)
+      
+      !      primp_to_labilep(c) = primp(c)*r_weather/dt
+            primp_to_labilep(c,j) = 0.005_r8/(365._r8*24._r8*3600._r8)
+!             primp_to_labilep(c,j) = 0._r8       
+         end do
+      enddo
+    end associate
+
+  end subroutine PWeathering
+  !-----------------------------------------------------------------------
+
+
+
+  !-----------------------------------------------------------------------
+  subroutine PAdsorption(num_soilc, filter_soilc, &
+       cnstate_vars,phosphorusstate_vars,phosphorusflux_vars)
+    !
+    !
+    ! !USES:
+    use clm_time_manager , only : get_days_per_year, get_step_size
+    use shr_sys_mod      , only : shr_sys_flush
+    use clm_varcon       , only : secspday, spval
+    use soilorder_varcon , only : r_adsorp
+    !
+    ! !ARGUMENTS:
+    integer                 , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                 , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    type(cnstate_type)       , intent(in)    :: cnstate_vars
+    type(phosphorusstate_type), intent(in) ::  phosphorusstate_vars
+    type(phosphorusflux_type) , intent(inout) :: phosphorusflux_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c,fc                  ! indices
+    real(r8) :: t                     ! temporary
+    real(r8) :: dayspyr               ! days per year
+
+!   !OTHER LOCAL VARIABLES
+    real(r8)     :: r_adsorp_c
+    real(r8)     :: rr
+    real(r8):: dt           !decomp timestep (seconds)
+    real(r8):: dtd          !decomp timestep (days)
+    integer :: j
+
+    !-----------------------------------------------------------------------
+
+    associate(&
+
+         isoilorder     => cnstate_vars%isoilorder                 ,&
+         solutionp   => phosphorusstate_vars%solutionp_vr_col      ,&
+         labilep     => phosphorusstate_vars%labilep_vr_col        ,&
+         labilep_to_secondp => phosphorusflux_vars%labilep_to_secondp_vr_col &
+
+         )
+
+      dayspyr = get_days_per_year()
+
+      ! set time steps
+      dt = real( get_step_size(), r8 )
+      dtd = dt/(30._r8*secspday)
+   
+      do j = 1,nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+   
+            ! calculate rate at half-hour time step
+            r_adsorp_c = r_adsorp( isoilorder(c) )
+            rr=-log(1._r8-r_adsorp_c)
+            r_adsorp_c = 1._r8-exp(-rr*dtd)
+
+            if(labilep(c,j) > 0._r8)then
+               labilep_to_secondp(c,j) = ( labilep(c,j) )*r_adsorp_c/dt
+            else
+               labilep_to_secondp(c,j) = 0._r8
+            end if
+
+         end do
+       end do
+    end associate
+
+  end subroutine PAdsorption
+
+
+  !-----------------------------------------------------------------------
+  subroutine PDesorption(num_soilc, filter_soilc, &
+       cnstate_vars,phosphorusstate_vars,phosphorusflux_vars)
+    !
+    !
+    ! !USES:
+    use clm_time_manager , only : get_days_per_year, get_step_size
+    use shr_sys_mod      , only : shr_sys_flush
+    use clm_varcon       , only : secspday, spval
+    use soilorder_varcon , only : r_desorp
+    !
+    ! !ARGUMENTS:
+    integer                 , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                 , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    type(cnstate_type)       , intent(in)    :: cnstate_vars
+    type(phosphorusstate_type), intent(in) ::  phosphorusstate_vars
+    type(phosphorusflux_type) , intent(inout) :: phosphorusflux_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c,fc                  ! indices
+    real(r8) :: t                     ! temporary
+    real(r8) :: dayspyr               ! days per year
+
+!   !OTHER LOCAL VARIABLES
+    real(r8)     :: r_desorp_c
+    real(r8)     :: rr
+    real(r8):: dt           !decomp timestep (seconds)
+    real(r8):: dtd          !decomp timestep (days)
+    integer :: j
+
+    !-----------------------------------------------------------------------
+
+    associate(&
+
+         isoilorder     => cnstate_vars%isoilorder              ,&
+         secondp     => phosphorusstate_vars%secondp_vr_col     ,&
+         secondp_to_labilep => phosphorusflux_vars%secondp_to_labilep_vr_col &
+
+         )
+
+      dayspyr = get_days_per_year()
+
+      ! set time steps
+      dt = real( get_step_size(), r8 )
+      dtd = dt/(30._r8*secspday)
+   
+      do j = 1,nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+   
+            ! calculate rate at half-hour time step
+            r_desorp_c = r_desorp( isoilorder(c) )
+            rr=-log(1._r8-r_desorp_c)
+            r_desorp_c = 1._r8-exp(-rr*dtd)
+    
+            if(secondp(c,j) > 0._r8)then
+              secondp_to_labilep(c,j) = secondp(c,j)*r_desorp_c/dt
+            else
+              secondp_to_labilep(c,j) = 0._r8
+            endif
+
+         end do
+       end do
+    end associate
+
+  end subroutine PDesorption
+
+
+
+  !-----------------------------------------------------------------------
+  subroutine POcclusion(num_soilc, filter_soilc, &
+       cnstate_vars,phosphorusstate_vars,phosphorusflux_vars)
+    !
+    !
+    ! !USES:
+    use clm_time_manager , only : get_days_per_year, get_step_size
+    use shr_sys_mod      , only : shr_sys_flush
+    use clm_varcon       , only : secspday, spval
+    use soilorder_varcon , only : r_occlude
+    !
+    ! !ARGUMENTS:
+    integer                 , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                 , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    type(cnstate_type)       , intent(in)    :: cnstate_vars
+    type(phosphorusstate_type), intent(in) ::  phosphorusstate_vars
+    type(phosphorusflux_type) , intent(inout) :: phosphorusflux_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c,fc                  ! indices
+    real(r8) :: t                     ! temporary
+    real(r8) :: dayspyr               ! days per year
+
+!   !OTHER LOCAL VARIABLES
+    real(r8)     :: r_occlude_c
+    real(r8)     :: rr
+    real(r8):: dt           !decomp timestep (seconds)
+    real(r8):: dtd          !decomp timestep (days)
+    integer :: j
+ 
+    !-----------------------------------------------------------------------
+
+    associate(&
+
+         isoilorder     => cnstate_vars%isoilorder                      ,&
+         secondp     => phosphorusstate_vars%secondp_vr_col             ,&
+         secondp_to_occlp => phosphorusflux_vars%secondp_to_occlp_vr_col &
+
+         )
+
+      dayspyr = get_days_per_year()
+
+      ! set time steps
+      dt = real( get_step_size(), r8 )
+      dtd = dt/(30._r8*secspday)
+   
+      do j = 1,nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+   
+
+            ! calculate rate at half-hour time step
+            r_occlude_c = r_occlude( isoilorder(c) )
+            rr=-log(1._r8-r_occlude_c)
+            r_occlude_c = 1._r8-exp(-rr*dtd)
+    
+            if(secondp(c,j) > 0._r8)then
+               secondp_to_occlp(c,j) = secondp(c,j)*r_occlude_c/dt
+            else
+               secondp_to_occlp(c,j) =0._r8
+            endif
+
+         end do
+       end do
+    end associate
+
+  end subroutine POcclusion
+
+  !-----------------------------------------------------------------------
+
+
+  !-----------------------------------------------------------------------
+  subroutine PLeaching(bounds, num_soilc, filter_soilc, &
+       waterstate_vars, waterflux_vars, phosphorusstate_vars, phosphorusflux_vars)
+    !
+    ! !DESCRIPTION:
+    ! On the radiation time step, update the phosphorus leaching rate
+    ! as a function of solution P and total soil water outflow.
+    !
+    ! !USES:
+    use clm_varpar       , only : nlevsoi
+    use clm_time_manager , only : get_step_size
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)        , intent(in)    :: bounds
+    integer                  , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                  , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    type(waterstate_type)    , intent(in)    :: waterstate_vars
+    type(waterflux_type)     , intent(in)    :: waterflux_vars
+    type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+    type(phosphorusflux_type)  , intent(inout) :: phosphorusflux_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: j,c,fc                                 ! indices
+    real(r8) :: dt                                     ! radiation time step(seconds)
+    real(r8) :: disp_conc                              ! dissolved mineral N concentration (gP/kg water)
+    real(r8) :: tot_water(bounds%begc:bounds%endc)     ! total column liquid water (kg water/m2)
+    real(r8) :: surface_water(bounds%begc:bounds%endc) ! liquid water to shallow surface depth (kg water/m2)
+    real(r8) :: drain_tot(bounds%begc:bounds%endc)     ! total drainage flux (mmH2O /s)
+    real(r8), parameter :: depth_runoff_Ploss = 0.05   ! (m) depth over which runoff mixes with soil water for P loss to runoff
+    !-----------------------------------------------------------------------
+
+    associate(&
+         h2osoi_liq          => waterstate_vars%h2osoi_liq_col            , & !Input:  [real(r8) (:,:) ]  liquid water (kg/m2) (new) (-nlevsno+1:nlevgrnd)
+
+         qflx_drain          => waterflux_vars%qflx_drain_col             , & !Input:  [real(r8) (:)   ]  sub-surface runoff (mm H2O /s)                    
+         qflx_surf           => waterflux_vars%qflx_surf_col              , & !Input:  [real(r8) (:)   ]  surface runoff (mm H2O /s)                        
+
+         solutionp_vr            => phosphorusstate_vars%solutionp_vr_col           , & !Input:  [real(r8) (:,:) ]  (gP/m3) soil mineral N                          
+         sminp_leached_vr    => phosphorusflux_vars%sminp_leached_vr_col     & !Output: [real(r8) (:,:) ]  rate of mineral N leaching (gP/m3/s)            
+         )
+
+      ! set time steps
+      dt = real( get_step_size(), r8 )
+
+      ! calculate the total soil water
+      tot_water(bounds%begc:bounds%endc) = 0._r8
+      do j = 1,nlevsoi
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            tot_water(c) = tot_water(c) + h2osoi_liq(c,j)
+         end do
+      end do
+
+      ! for runoff calculation; calculate total water to a given depth
+      surface_water(bounds%begc:bounds%endc) = 0._r8
+      do j = 1,nlevsoi
+         if ( zisoi(j) <= depth_runoff_Ploss)  then
+            do fc = 1,num_soilc
+               c = filter_soilc(fc)
+               surface_water(c) = surface_water(c) + h2osoi_liq(c,j)
+            end do
+         elseif ( zisoi(j-1) < depth_runoff_Ploss)  then
+            do fc = 1,num_soilc
+               c = filter_soilc(fc)
+               surface_water(c) = surface_water(c) + h2osoi_liq(c,j) * ((depth_runoff_Ploss - zisoi(j-1)) / col%dz(c,j))
+            end do
+         endif
+      end do
+
+      ! Loop through columns
+      do fc = 1,num_soilc
+         c = filter_soilc(fc)
+         drain_tot(c) = qflx_drain(c)
+      end do
+
+         do j = 1,nlevdecomp
+            ! Loop through columns
+            do fc = 1,num_soilc
+               c = filter_soilc(fc)
+
+               if (.not. use_vertsoilc) then
+                  disp_conc = 0._r8
+                  if (tot_water(c) > 0._r8) then
+                     disp_conc = ( solutionp_vr(c,j) ) / tot_water(c)
+                  end if
+
+                  ! calculate the P leaching flux as a function of the dissolved
+                  ! concentration and the sub-surface drainage flux
+                  sminp_leached_vr(c,j) = disp_conc * drain_tot(c)
+               else
+                  disp_conc = 0._r8
+                  if (h2osoi_liq(c,j) > 0._r8) then
+                     disp_conc = (solutionp_vr(c,j) * col%dz(c,j))/(h2osoi_liq(c,j) )
+                  end if
+
+                  ! calculate the P leaching flux as a function of the dissolved
+                  ! concentration and the sub-surface drainage flux
+                  sminp_leached_vr(c,j) = disp_conc * drain_tot(c) *h2osoi_liq(c,j) / ( tot_water(c) * col%dz(c,j) )
+
+               end if
+               ! limit the flux based on current sminp state
+               ! only let at most the assumed soluble fraction
+               ! of sminp be leached on any given timestep
+               sminp_leached_vr(c,j) = min(sminp_leached_vr(c,j), (solutionp_vr(c,j))/dt)
+
+               ! limit the flux to a positive value
+               sminp_leached_vr(c,j) = max(sminp_leached_vr(c,j), 0._r8)
+            end do
+         end do
+
+    end associate
+  end subroutine PLeaching
+
+
+  !-----------------------------------------------------------------------
+
+
+  !-----------------------------------------------------------------------
+
+
+  subroutine PBiochemMin(bounds,num_soilc, filter_soilc, &
+       cnstate_vars, phosphorusstate_vars, phosphorusflux_vars)
+    !
+    ! !DESCRIPTION:
+    ! On the radiation time step, update the phosphorus leaching rate
+    ! as a function of solution P and total soil water outflow.
+    !
+    ! !USES:
+    use clm_varpar       , only : nlevsoi
+    use clm_varpar       , only : ndecomp_pools
+    use clm_time_manager , only : get_step_size
+    use soilorder_varcon , only:k_s1_biochem,k_s2_biochem,k_s3_biochem,k_s4_biochem
+    use clm_varcon       , only : secspday, spval
+
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)        , intent(in)    :: bounds
+    integer                  , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                  , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    type(cnstate_type)         , intent(in)    :: cnstate_vars
+    type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+    type(phosphorusflux_type)  , intent(inout) :: phosphorusflux_vars
+    !
+    integer  :: c,fc,j,l
+    real(r8) :: rr
+    real(r8):: dt           !decomp timestep (seconds)
+    real(r8):: dtd          !decomp timestep (days)
+    real(r8):: k_s1_biochem_c         !specfic biochemical rate constant SOM 1
+    real(r8):: k_s2_biochem_c         !specfic biochemical rate constant SOM 1
+    real(r8):: k_s3_biochem_c         !specfic biochemical rate constant SOM 1
+    real(r8):: k_s4_biochem_c         !specfic biochemical rate constant SOM 1
+    real(r8):: r_bc
+
+    !-----------------------------------------------------------------------
+    !!!!  decomp_ppools_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools)
+
+    associate(&
+
+         isoilorder     => cnstate_vars%isoilorder                            ,&
+         decomp_ppools_vr_col => phosphorusstate_vars%decomp_ppools_vr_col    ,&
+  
+         biochem_pmin_ppools_vr_col  => phosphorusflux_vars%biochem_pmin_ppools_vr_col  ,&
+         biochem_pmin_vr_col  => phosphorusflux_vars%biochem_pmin_vr_col      ,&
+         biochem_pmin_col     => phosphorusflux_vars%biochem_pmin_col         , & 
+         fpi_vr_col           => cnstate_vars%fpi_vr_col                      ,&
+         fpi_p_vr_col           => cnstate_vars%fpi_p_vr_col                   &
+         )
+
+      dt = real( get_step_size(), r8 )
+      dtd = dt/(30._r8*secspday)
+      r_bc = -5._r8
+
+      ! set initial values for potential C and N fluxes
+      biochem_pmin_ppools_vr_col(bounds%begc : bounds%endc, :, :) = 0._r8
+
+      do l = 1, ndecomp_pools
+         do j = 1,nlevdecomp
+            do fc = 1,num_soilc
+               c = filter_soilc(fc)
+
+               k_s1_biochem_c = k_s1_biochem( isoilorder(c) )
+               k_s2_biochem_c = k_s2_biochem( isoilorder(c) )
+               k_s3_biochem_c = k_s3_biochem( isoilorder(c) )
+               k_s4_biochem_c = k_s4_biochem( isoilorder(c) )
+         
+               rr=-log(1._r8-k_s1_biochem_c)
+               k_s1_biochem_c = 1-exp(-rr*dtd)
+         
+               rr=-log(1-k_s2_biochem_c)
+               k_s2_biochem_c = 1-exp(-rr*dtd)
+         
+               rr=-log(1-k_s3_biochem_c)
+               k_s3_biochem_c = 1-exp(-rr*dtd)
+         
+               rr=-log(1-k_s4_biochem_c)
+               k_s4_biochem_c = 1-exp(-rr*dtd)
+
+               if ( decomp_ppools_vr_col(c,j,l) > 0._r8 ) then
+
+                 biochem_pmin_ppools_vr_col(c,j,l) = decomp_ppools_vr_col(c,j,l)* &
+                                     k_s1_biochem_c * fpi_vr_col(c,j)*&
+                                     (1._r8-exp(r_bc*(1-fpi_p_vr_col(c,j)) ) )/dt
+
+               endif 
+
+            end do
+         end do
+      end do
+
+      
+      do j = 1,nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            biochem_pmin_vr_col(c,j)=0._r8
+            do l = 1, ndecomp_pools
+               biochem_pmin_vr_col(c,j) = biochem_pmin_vr_col(c,j)+ &
+                                          biochem_pmin_ppools_vr_col(c,j,l)
+            enddo
+         enddo
+      enddo 
+
+
+      
+    end associate
+
+  end subroutine PBiochemMin
+
+end module PDynamicsMod
+               
+                
+     
+
+      
+
+
+
+
+
+
+
+

--- a/models/lnd/clm/src/biogeochem/PStateUpdate1Mod.F90
+++ b/models/lnd/clm/src/biogeochem/PStateUpdate1Mod.F90
@@ -1,0 +1,283 @@
+module PStateUpdate1Mod
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Module for phosphorus state variable updates, non-mortality fluxes.
+  ! X.YANG
+  ! !USES:
+  use shr_kind_mod           , only: r8 => shr_kind_r8
+  use clm_time_manager       , only : get_step_size
+  use clm_varpar             , only : nlevdecomp, ndecomp_pools, ndecomp_cascade_transitions
+  use clm_varpar             , only : crop_prog, i_met_lit, i_cel_lit, i_lig_lit, i_cwd
+  use clm_varctl             , only : iulog, use_nitrif_denitrif
+  use clm_varcon             , only : nitrif_n2o_loss_frac
+  use pftvarcon              , only : npcropmin, nc3crop
+  use soilorder_varcon       , only : smax,ks_sorption
+  use EcophysconType         , only : ecophyscon
+  use CNDecompCascadeConType , only : decomp_cascade_con
+  use CNStateType            , only : cnstate_type
+  use PhosphorusFluxType     , only : phosphorusflux_type
+  use PhosphorusStateType    , only : phosphorusstate_type
+  use PatchType              , only : pft                
+  !
+  implicit none
+  save
+  private
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public:: PStateUpdate1
+  !-----------------------------------------------------------------------
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine PStateUpdate1(num_soilc, filter_soilc, num_soilp, filter_soilp, &
+       cnstate_vars, phosphorusflux_vars, phosphorusstate_vars)
+    !
+    ! !DESCRIPTION:
+    ! On the radiation time step, update all the prognostic phosphorus state
+    ! variables (except for gap-phase mortality and fire fluxes)
+    !
+    ! !ARGUMENTS:
+    integer                  , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                  , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    integer                  , intent(in)    :: num_soilp       ! number of soil patches in filter
+    integer                  , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    type(cnstate_type)       , intent(in)    :: cnstate_vars
+    type(phosphorusflux_type)  , intent(inout) :: phosphorusflux_vars
+    type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer :: c,p,j,l,k ! indices
+    integer :: fp,fc     ! lake filter indices
+    real(r8):: dt        ! radiation time step (seconds)
+
+
+    !-----------------------------------------------------------------------
+
+    associate(                                                                                           & 
+         ivt                   => pft%itype                                , & ! Input:  [integer  (:)     ]  pft vegetation type                                
+
+         woody                 => ecophyscon%woody                         , & ! Input:  [real(r8) (:)     ]  binary flag for woody lifeform (1=woody, 0=not woody)
+
+         cascade_donor_pool    => decomp_cascade_con%cascade_donor_pool    , & ! Input:  [integer  (:)     ]  which pool is C taken from for a given decomposition step
+         cascade_receiver_pool => decomp_cascade_con%cascade_receiver_pool , & ! Input:  [integer  (:)     ]  which pool is C added to for a given decomposition step
+
+         !!! N deposition profile, will weathering profile be needed?  -X.YANG
+!         ndep_prof             => cnstate_vars%ndep_prof_col               , & ! Input:  [real(r8) (:,:)   ]  profile over which N deposition is distributed through column (1/m)
+!         nfixation_prof        => cnstate_vars%nfixation_prof_col          , & ! Input:  [real(r8) (:,:)   ]  profile over which N fixation is distributed through column (1/m)
+         
+         pf                    => phosphorusflux_vars                        , &
+         ps                    => phosphorusstate_vars &
+         )
+
+      ! set time steps
+      dt = real( get_step_size(), r8 )
+
+      ! column-level fluxes
+
+      ! seeding fluxes, from dynamic landcover
+      do fc = 1,num_soilc
+         c = filter_soilc(fc)
+         ps%seedp_col(c) = ps%seedp_col(c) - pf%dwt_seedp_to_leaf_col(c) * dt
+         ps%seedp_col(c) = ps%seedp_col(c) - pf%dwt_seedp_to_deadstem_col(c) * dt
+      end do
+
+      do j = 1, nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+
+            ! plant to litter fluxes
+            ! phenology and dynamic landcover fluxes
+            pf%decomp_ppools_sourcesink_col(c,j,i_met_lit) = &
+                 ( pf%phenology_p_to_litr_met_p_col(c,j) + pf%dwt_frootp_to_litr_met_p_col(c,j) ) * dt
+
+            pf%decomp_ppools_sourcesink_col(c,j,i_cel_lit) = &
+                 ( pf%phenology_p_to_litr_cel_p_col(c,j) + pf%dwt_frootp_to_litr_cel_p_col(c,j) ) * dt
+
+            pf%decomp_ppools_sourcesink_col(c,j,i_lig_lit) = &
+                 ( pf%phenology_p_to_litr_lig_p_col(c,j) + pf%dwt_frootp_to_litr_lig_p_col(c,j) ) * dt
+
+            pf%decomp_ppools_sourcesink_col(c,j,i_cwd)     = &
+                 ( pf%dwt_livecrootp_to_cwdp_col(c,j)    + pf%dwt_deadcrootp_to_cwdp_col(c,j) )   * dt
+
+         end do
+      end do
+
+
+      ! decomposition fluxes
+      do k = 1, ndecomp_cascade_transitions
+         do j = 1, nlevdecomp
+            ! column loop
+            do fc = 1,num_soilc
+               c = filter_soilc(fc)
+
+               pf%decomp_ppools_sourcesink_col(c,j,cascade_donor_pool(k)) = &
+                    pf%decomp_ppools_sourcesink_col(c,j,cascade_donor_pool(k)) - &
+                    pf%decomp_cascade_ptransfer_vr_col(c,j,k) * dt
+            end do
+         end do
+      end do
+      do k = 1, ndecomp_cascade_transitions
+         if ( cascade_receiver_pool(k) /= 0 ) then  ! skip terminal transitions
+            do j = 1, nlevdecomp
+               ! column loop
+               do fc = 1,num_soilc
+                  c = filter_soilc(fc)
+
+                  pf%decomp_ppools_sourcesink_col(c,j,cascade_receiver_pool(k)) = &
+                       pf%decomp_ppools_sourcesink_col(c,j,cascade_receiver_pool(k)) + &
+                       (pf%decomp_cascade_ptransfer_vr_col(c,j,k) + pf%decomp_cascade_sminp_flux_vr_col(c,j,k)) * dt
+               end do
+            end do
+         else  ! terminal transitions
+            do j = 1, nlevdecomp
+               ! column loop
+               do fc = 1,num_soilc
+                  c = filter_soilc(fc)
+                  pf%decomp_ppools_sourcesink_col(c,j,cascade_donor_pool(k)) = &
+                       pf%decomp_ppools_sourcesink_col(c,j,cascade_donor_pool(k)) - &
+                       pf%decomp_cascade_sminp_flux_vr_col(c,j,k) * dt
+               end do
+            end do
+         end if
+      end do
+
+
+
+
+      ! patch loop
+
+      do fp = 1,num_soilp
+         p = filter_soilp(fp)
+
+         ! phenology: transfer growth fluxes
+         ps%leafp_patch(p)       = ps%leafp_patch(p)       + pf%leafp_xfer_to_leafp_patch(p)*dt
+         ps%leafp_xfer_patch(p)  = ps%leafp_xfer_patch(p)  - pf%leafp_xfer_to_leafp_patch(p)*dt
+         ps%frootp_patch(p)      = ps%frootp_patch(p)      + pf%frootp_xfer_to_frootp_patch(p)*dt
+         ps%frootp_xfer_patch(p) = ps%frootp_xfer_patch(p) - pf%frootp_xfer_to_frootp_patch(p)*dt
+
+         if (woody(ivt(p)) == 1.0_r8) then
+            ps%livestemp_patch(p)       = ps%livestemp_patch(p)       + pf%livestemp_xfer_to_livestemp_patch(p)*dt
+            ps%livestemp_xfer_patch(p)  = ps%livestemp_xfer_patch(p)  - pf%livestemp_xfer_to_livestemp_patch(p)*dt
+            ps%deadstemp_patch(p)       = ps%deadstemp_patch(p)       + pf%deadstemp_xfer_to_deadstemp_patch(p)*dt
+            ps%deadstemp_xfer_patch(p)  = ps%deadstemp_xfer_patch(p)  - pf%deadstemp_xfer_to_deadstemp_patch(p)*dt
+            ps%livecrootp_patch(p)      = ps%livecrootp_patch(p)      + pf%livecrootp_xfer_to_livecrootp_patch(p)*dt
+            ps%livecrootp_xfer_patch(p) = ps%livecrootp_xfer_patch(p) - pf%livecrootp_xfer_to_livecrootp_patch(p)*dt
+            ps%deadcrootp_patch(p)      = ps%deadcrootp_patch(p)      + pf%deadcrootp_xfer_to_deadcrootp_patch(p)*dt
+            ps%deadcrootp_xfer_patch(p) = ps%deadcrootp_xfer_patch(p) - pf%deadcrootp_xfer_to_deadcrootp_patch(p)*dt
+         end if
+
+         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+            ! lines here for consistency; the transfer terms are zero
+            ps%livestemp_patch(p)       = ps%livestemp_patch(p)      + pf%livestemp_xfer_to_livestemp_patch(p)*dt
+            ps%livestemp_xfer_patch(p)  = ps%livestemp_xfer_patch(p) - pf%livestemp_xfer_to_livestemp_patch(p)*dt
+            ps%grainp_patch(p)          = ps%grainp_patch(p)         + pf%grainp_xfer_to_grainp_patch(p)*dt
+            ps%grainp_xfer_patch(p)     = ps%grainp_xfer_patch(p)    - pf%grainp_xfer_to_grainp_patch(p)*dt
+         end if
+
+         ! phenology: litterfall and retranslocation fluxes
+         ps%leafp_patch(p)    = ps%leafp_patch(p)    - pf%leafp_to_litter_patch(p)*dt
+         ps%frootp_patch(p)   = ps%frootp_patch(p)   - pf%frootp_to_litter_patch(p)*dt
+         ps%leafp_patch(p)    = ps%leafp_patch(p)    - pf%leafp_to_retransp_patch(p)*dt
+         ps%retransp_patch(p) = ps%retransp_patch(p) + pf%leafp_to_retransp_patch(p)*dt
+
+         ! live wood turnover and retranslocation fluxes
+         if (woody(ivt(p)) == 1._r8) then
+            ps%livestemp_patch(p)  = ps%livestemp_patch(p)  - pf%livestemp_to_deadstemp_patch(p)*dt
+            ps%deadstemp_patch(p)  = ps%deadstemp_patch(p)  + pf%livestemp_to_deadstemp_patch(p)*dt
+            ps%livestemp_patch(p)  = ps%livestemp_patch(p)  - pf%livestemp_to_retransp_patch(p)*dt
+            ps%retransp_patch(p)   = ps%retransp_patch(p)   + pf%livestemp_to_retransp_patch(p)*dt
+            ps%livecrootp_patch(p) = ps%livecrootp_patch(p) - pf%livecrootp_to_deadcrootp_patch(p)*dt
+            ps%deadcrootp_patch(p) = ps%deadcrootp_patch(p) + pf%livecrootp_to_deadcrootp_patch(p)*dt
+            ps%livecrootp_patch(p) = ps%livecrootp_patch(p) - pf%livecrootp_to_retransp_patch(p)*dt
+            ps%retransp_patch(p)   = ps%retransp_patch(p)   + pf%livecrootp_to_retransp_patch(p)*dt
+         end if
+         if (ivt(p) >= npcropmin) then ! Beth adds retrans from froot
+            ps%frootp_patch(p)     = ps%frootp_patch(p)     - pf%frootp_to_retransp_patch(p)*dt
+            ps%retransp_patch(p)   = ps%retransp_patch(p)   + pf%frootp_to_retransp_patch(p)*dt
+            ps%livestemp_patch(p)  = ps%livestemp_patch(p)  - pf%livestemp_to_litter_patch(p)*dt
+            ps%livestemp_patch(p)  = ps%livestemp_patch(p)  - pf%livestemp_to_retransp_patch(p)*dt
+            ps%retransp_patch(p)   = ps%retransp_patch(p)   + pf%livestemp_to_retransp_patch(p)*dt
+            ps%grainp_patch(p)     = ps%grainp_patch(p)     - pf%grainp_to_food_patch(p)*dt
+         end if
+
+         ! uptake from soil mineral N pool
+         ps%ppool_patch(p) = &
+              ps%ppool_patch(p) + pf%sminp_to_ppool_patch(p)*dt
+
+         ! deployment from retranslocation pool
+         ps%ppool_patch(p)    = ps%ppool_patch(p)    + pf%retransp_to_ppool_patch(p)*dt
+         ps%retransp_patch(p) = ps%retransp_patch(p) - pf%retransp_to_ppool_patch(p)*dt
+
+         ! allocation fluxes
+         ps%ppool_patch(p)           = ps%ppool_patch(p)          - pf%ppool_to_leafp_patch(p)*dt
+         ps%leafp_patch(p)           = ps%leafp_patch(p)          + pf%ppool_to_leafp_patch(p)*dt
+         ps%ppool_patch(p)           = ps%ppool_patch(p)          - pf%ppool_to_leafp_storage_patch(p)*dt
+         ps%leafp_storage_patch(p)   = ps%leafp_storage_patch(p)  + pf%ppool_to_leafp_storage_patch(p)*dt
+         ps%ppool_patch(p)           = ps%ppool_patch(p)          - pf%ppool_to_frootp_patch(p)*dt
+         ps%frootp_patch(p)          = ps%frootp_patch(p)         + pf%ppool_to_frootp_patch(p)*dt
+         ps%ppool_patch(p)           = ps%ppool_patch(p)          - pf%ppool_to_frootp_storage_patch(p)*dt
+         ps%frootp_storage_patch(p)  = ps%frootp_storage_patch(p) + pf%ppool_to_frootp_storage_patch(p)*dt
+
+         if (woody(ivt(p)) == 1._r8) then
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_livestemp_patch(p)*dt
+            ps%livestemp_patch(p)          = ps%livestemp_patch(p)          + pf%ppool_to_livestemp_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_livestemp_storage_patch(p)*dt
+            ps%livestemp_storage_patch(p)  = ps%livestemp_storage_patch(p)  + pf%ppool_to_livestemp_storage_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_deadstemp_patch(p)*dt
+            ps%deadstemp_patch(p)          = ps%deadstemp_patch(p)          + pf%ppool_to_deadstemp_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_deadstemp_storage_patch(p)*dt
+            ps%deadstemp_storage_patch(p)  = ps%deadstemp_storage_patch(p)  + pf%ppool_to_deadstemp_storage_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_livecrootp_patch(p)*dt
+            ps%livecrootp_patch(p)         = ps%livecrootp_patch(p)         + pf%ppool_to_livecrootp_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_livecrootp_storage_patch(p)*dt
+            ps%livecrootp_storage_patch(p) = ps%livecrootp_storage_patch(p) + pf%ppool_to_livecrootp_storage_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_deadcrootp_patch(p)*dt
+            ps%deadcrootp_patch(p)         = ps%deadcrootp_patch(p)         + pf%ppool_to_deadcrootp_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_deadcrootp_storage_patch(p)*dt
+            ps%deadcrootp_storage_patch(p) = ps%deadcrootp_storage_patch(p) + pf%ppool_to_deadcrootp_storage_patch(p)*dt
+         end if
+
+         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_livestemp_patch(p)*dt
+            ps%livestemp_patch(p)          = ps%livestemp_patch(p)          + pf%ppool_to_livestemp_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_livestemp_storage_patch(p)*dt
+            ps%livestemp_storage_patch(p)  = ps%livestemp_storage_patch(p)  + pf%ppool_to_livestemp_storage_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_grainp_patch(p)*dt
+            ps%grainp_patch(p)             = ps%grainp_patch(p)             + pf%ppool_to_grainp_patch(p)*dt
+            ps%ppool_patch(p)              = ps%ppool_patch(p)              - pf%ppool_to_grainp_storage_patch(p)*dt
+            ps%grainp_storage_patch(p)     = ps%grainp_storage_patch(p)     + pf%ppool_to_grainp_storage_patch(p)*dt
+         end if
+
+         ! move storage pools into transfer pools
+         ps%leafp_storage_patch(p)  = ps%leafp_storage_patch(p)  - pf%leafp_storage_to_xfer_patch(p)*dt
+         ps%leafp_xfer_patch(p)     = ps%leafp_xfer_patch(p)     + pf%leafp_storage_to_xfer_patch(p)*dt
+         ps%frootp_storage_patch(p) = ps%frootp_storage_patch(p) - pf%frootp_storage_to_xfer_patch(p)*dt
+         ps%frootp_xfer_patch(p)    = ps%frootp_xfer_patch(p)    + pf%frootp_storage_to_xfer_patch(p)*dt
+
+         if (woody(ivt(p)) == 1._r8) then
+            ps%livestemp_storage_patch(p)  = ps%livestemp_storage_patch(p)  - pf%livestemp_storage_to_xfer_patch(p)*dt
+            ps%livestemp_xfer_patch(p)     = ps%livestemp_xfer_patch(p)     + pf%livestemp_storage_to_xfer_patch(p)*dt
+            ps%deadstemp_storage_patch(p)  = ps%deadstemp_storage_patch(p)  - pf%deadstemp_storage_to_xfer_patch(p)*dt
+            ps%deadstemp_xfer_patch(p)     = ps%deadstemp_xfer_patch(p)     + pf%deadstemp_storage_to_xfer_patch(p)*dt
+            ps%livecrootp_storage_patch(p) = ps%livecrootp_storage_patch(p) - pf%livecrootp_storage_to_xfer_patch(p)*dt
+            ps%livecrootp_xfer_patch(p)    = ps%livecrootp_xfer_patch(p)    + pf%livecrootp_storage_to_xfer_patch(p)*dt
+            ps%deadcrootp_storage_patch(p) = ps%deadcrootp_storage_patch(p) - pf%deadcrootp_storage_to_xfer_patch(p)*dt
+            ps%deadcrootp_xfer_patch(p)    = ps%deadcrootp_xfer_patch(p)    + pf%deadcrootp_storage_to_xfer_patch(p)*dt
+         end if
+
+         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+            ! lines here for consistency; the transfer terms are zero
+            ps%livestemp_storage_patch(p)  = ps%livestemp_storage_patch(p) - pf%livestemp_storage_to_xfer_patch(p)*dt
+            ps%livestemp_xfer_patch(p)     = ps%livestemp_xfer_patch(p)    + pf%livestemp_storage_to_xfer_patch(p)*dt
+            ps%grainp_storage_patch(p)     = ps%grainp_storage_patch(p)    - pf%grainp_storage_to_xfer_patch(p)*dt
+            ps%grainp_xfer_patch(p)        = ps%grainp_xfer_patch(p)       + pf%grainp_storage_to_xfer_patch(p)*dt
+         end if
+
+      end do
+
+    end associate
+
+  end subroutine PStateUpdate1
+
+end module PStateUpdate1Mod

--- a/models/lnd/clm/src/biogeochem/PStateUpdate2Mod.F90
+++ b/models/lnd/clm/src/biogeochem/PStateUpdate2Mod.F90
@@ -1,0 +1,198 @@
+module PStateUpdate2Mod
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Module for phosphorus state variable update, mortality fluxes.
+  ! X.YANG
+  ! !USES:
+  use shr_kind_mod        , only : r8 => shr_kind_r8
+  use clm_time_manager    , only : get_step_size
+  use clm_varpar          , only : nlevsoi, nlevdecomp
+  use clm_varpar          , only : i_met_lit, i_cel_lit, i_lig_lit, i_cwd
+  use clm_varctl          , only : iulog
+  use PhosphorusStateType , only : phosphorusstate_type
+  use PhosphorusFLuxType  , only : phosphorusflux_type
+  !
+  implicit none
+  save
+  private
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public:: PStateUpdate2
+  public:: PStateUpdate2h
+  !-----------------------------------------------------------------------
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine PStateUpdate2(num_soilc, filter_soilc, num_soilp, filter_soilp, &
+       phosphorusflux_vars, phosphorusstate_vars)
+    !
+    ! !DESCRIPTION:
+    ! On the radiation time step, update all the prognostic phosporus state
+    ! variables affected by gap-phase mortality fluxes
+    ! NOTE - associate statements have been removed where there are
+    ! no science equations. This increases readability and maintainability
+    !
+    ! !ARGUMENTS:
+    integer                  , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                  , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    integer                  , intent(in)    :: num_soilp       ! number of soil patches in filter
+    integer                  , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    type(phosphorusflux_type)  , intent(in)    :: phosphorusflux_vars
+    type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c,p,j,l ! indices
+    integer  :: fp,fc   ! lake filter indices
+    real(r8) :: dt      ! radiation time step (seconds)
+    !-----------------------------------------------------------------------
+
+    associate(                      & 
+         pf => phosphorusflux_vars  , &
+         ps => phosphorusstate_vars   &
+         )
+
+      ! set time steps
+      dt = real( get_step_size(), r8 )
+
+      ! column-level phosporus fluxes from gap-phase mortality
+
+      do j = 1, nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+
+            ps%decomp_ppools_vr_col(c,j,i_met_lit) = &
+                 ps%decomp_ppools_vr_col(c,j,i_met_lit) + pf%gap_mortality_p_to_litr_met_p_col(c,j) * dt
+            ps%decomp_ppools_vr_col(c,j,i_cel_lit) = &
+                 ps%decomp_ppools_vr_col(c,j,i_cel_lit) + pf%gap_mortality_p_to_litr_cel_p_col(c,j) * dt
+            ps%decomp_ppools_vr_col(c,j,i_lig_lit) = &
+                 ps%decomp_ppools_vr_col(c,j,i_lig_lit) + pf%gap_mortality_p_to_litr_lig_p_col(c,j) * dt
+            ps%decomp_ppools_vr_col(c,j,i_cwd)     = &
+                 ps%decomp_ppools_vr_col(c,j,i_cwd)     + pf%gap_mortality_p_to_cwdp_col(c,j)       * dt
+         end do
+      end do
+
+
+      ! patch -level phosporus fluxes from gap-phase mortality
+
+      do fp = 1,num_soilp
+         p = filter_soilp(fp)
+
+         ! displayed pools
+         ps%leafp_patch(p)              =  ps%leafp_patch(p)      - pf%m_leafp_to_litter_patch(p)      * dt
+         ps%frootp_patch(p)             =  ps%frootp_patch(p)     - pf%m_frootp_to_litter_patch(p)     * dt
+         ps%livestemp_patch(p)          =  ps%livestemp_patch(p)  - pf%m_livestemp_to_litter_patch(p)  * dt
+         ps%deadstemp_patch(p)          =  ps%deadstemp_patch(p)  - pf%m_deadstemp_to_litter_patch(p)  * dt
+         ps%livecrootp_patch(p)         =  ps%livecrootp_patch(p) - pf%m_livecrootp_to_litter_patch(p) * dt
+         ps%deadcrootp_patch(p)         =  ps%deadcrootp_patch(p) - pf%m_deadcrootp_to_litter_patch(p) * dt
+         ps%retransp_patch(p)           =  ps%retransp_patch(p)   - pf%m_retransp_to_litter_patch(p)   * dt
+
+         ! storage pools
+         ps%leafp_storage_patch(p)      =  ps%leafp_storage_patch(p)      - pf%m_leafp_storage_to_litter_patch(p)      * dt
+         ps%frootp_storage_patch(p)     =  ps%frootp_storage_patch(p)     - pf%m_frootp_storage_to_litter_patch(p)     * dt
+         ps%livestemp_storage_patch(p)  =  ps%livestemp_storage_patch(p)  - pf%m_livestemp_storage_to_litter_patch(p)  * dt
+         ps%deadstemp_storage_patch(p)  =  ps%deadstemp_storage_patch(p)  - pf%m_deadstemp_storage_to_litter_patch(p)  * dt
+         ps%livecrootp_storage_patch(p) =  ps%livecrootp_storage_patch(p) - pf%m_livecrootp_storage_to_litter_patch(p) * dt
+         ps%deadcrootp_storage_patch(p) =  ps%deadcrootp_storage_patch(p) - pf%m_deadcrootp_storage_to_litter_patch(p) * dt
+
+         ! transfer pools
+         ps%leafp_xfer_patch(p)         =  ps%leafp_xfer_patch(p)      - pf%m_leafp_xfer_to_litter_patch(p)      * dt
+         ps%frootp_xfer_patch(p)        =  ps%frootp_xfer_patch(p)     - pf%m_frootp_xfer_to_litter_patch(p)     * dt
+         ps%livestemp_xfer_patch(p)     =  ps%livestemp_xfer_patch(p)  - pf%m_livestemp_xfer_to_litter_patch(p)  * dt
+         ps%deadstemp_xfer_patch(p)     =  ps%deadstemp_xfer_patch(p)  - pf%m_deadstemp_xfer_to_litter_patch(p)  * dt
+         ps%livecrootp_xfer_patch(p)    =  ps%livecrootp_xfer_patch(p) - pf%m_livecrootp_xfer_to_litter_patch(p) * dt
+         ps%deadcrootp_xfer_patch(p)    =  ps%deadcrootp_xfer_patch(p) - pf%m_deadcrootp_xfer_to_litter_patch(p) * dt
+
+      end do
+
+    end associate
+
+  end subroutine PStateUpdate2
+
+  !-----------------------------------------------------------------------
+  subroutine PStateUpdate2h(num_soilc, filter_soilc, num_soilp, filter_soilp, &
+       phosphorusflux_vars, phosphorusstate_vars)
+    !
+    ! !DESCRIPTION:
+    ! Update all the prognostic phosphorus state
+    ! variables affected by harvest mortality fluxes
+    ! NOTE - associate statements have been removed where there are
+    ! no science equations. This increases readability and maintainability
+    !
+    ! !ARGUMENTS:
+    integer                  , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                  , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    integer                  , intent(in)    :: num_soilp       ! number of soil patches in filter
+    integer                  , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    type(phosphorusflux_type)  , intent(in)    :: phosphorusflux_vars
+    type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer :: c,p,j,l ! indices
+    integer :: fp,fc   ! lake filter indices
+    real(r8):: dt      ! radiation time step (seconds)
+    !-----------------------------------------------------------------------
+
+    associate(                      & 
+         pf => phosphorusflux_vars  , &
+         ps => phosphorusstate_vars   &
+         )
+
+      ! set time steps
+      dt = real( get_step_size(), r8 )
+
+      ! column-level phosporus fluxes from harvest mortality
+
+      do j = 1,nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            ps%decomp_ppools_vr_col(c,j,i_met_lit) = &
+                 ps%decomp_ppools_vr_col(c,j,i_met_lit) + pf%harvest_p_to_litr_met_p_col(c,j) * dt
+            ps%decomp_ppools_vr_col(c,j,i_cel_lit) = &
+                 ps%decomp_ppools_vr_col(c,j,i_cel_lit) + pf%harvest_p_to_litr_cel_p_col(c,j) * dt
+            ps%decomp_ppools_vr_col(c,j,i_lig_lit) = &
+                 ps%decomp_ppools_vr_col(c,j,i_lig_lit) + pf%harvest_p_to_litr_lig_p_col(c,j) * dt
+            ps%decomp_ppools_vr_col(c,j,i_cwd)     = &
+                 ps%decomp_ppools_vr_col(c,j,i_cwd)     + pf%harvest_p_to_cwdp_col(c,j)       * dt
+         end do
+      end do
+
+      ! patch-level phosporus fluxes from harvest mortality
+
+      do fp = 1,num_soilp
+         p = filter_soilp(fp)
+
+         ! displayed pools
+         ps%leafp_patch(p)      = ps%leafp_patch(p)      - pf%hrv_leafp_to_litter_patch(p)      * dt
+         ps%frootp_patch(p)     = ps%frootp_patch(p)     - pf%hrv_frootp_to_litter_patch(p)     * dt
+         ps%livestemp_patch(p)  = ps%livestemp_patch(p)  - pf%hrv_livestemp_to_litter_patch(p)  * dt
+         ps%deadstemp_patch(p)  = ps%deadstemp_patch(p)  - pf%hrv_deadstemp_to_prod10p_patch(p) * dt
+         ps%deadstemp_patch(p)  = ps%deadstemp_patch(p)  - pf%hrv_deadstemp_to_prod100p_patch(p)* dt
+         ps%livecrootp_patch(p) = ps%livecrootp_patch(p) - pf%hrv_livecrootp_to_litter_patch(p) * dt
+         ps%deadcrootp_patch(p) = ps%deadcrootp_patch(p) - pf%hrv_deadcrootp_to_litter_patch(p) * dt
+         ps%retransp_patch(p)   = ps%retransp_patch(p)   - pf%hrv_retransp_to_litter_patch(p)   * dt
+
+         ! storage pools
+         ps%leafp_storage_patch(p)      = ps%leafp_storage_patch(p)      - pf%hrv_leafp_storage_to_litter_patch(p)      * dt
+         ps%frootp_storage_patch(p)     = ps%frootp_storage_patch(p)     - pf%hrv_frootp_storage_to_litter_patch(p)     * dt
+         ps%livestemp_storage_patch(p)  = ps%livestemp_storage_patch(p)  - pf%hrv_livestemp_storage_to_litter_patch(p)  * dt
+         ps%deadstemp_storage_patch(p)  = ps%deadstemp_storage_patch(p)  - pf%hrv_deadstemp_storage_to_litter_patch(p)  * dt
+         ps%livecrootp_storage_patch(p) = ps%livecrootp_storage_patch(p) - pf%hrv_livecrootp_storage_to_litter_patch(p) * dt
+         ps%deadcrootp_storage_patch(p) = ps%deadcrootp_storage_patch(p) - pf%hrv_deadcrootp_storage_to_litter_patch(p) * dt
+
+         ! transfer pools
+         ps%leafp_xfer_patch(p)      = ps%leafp_xfer_patch(p)      - pf%hrv_leafp_xfer_to_litter_patch(p)      *dt
+         ps%frootp_xfer_patch(p)     = ps%frootp_xfer_patch(p)     - pf%hrv_frootp_xfer_to_litter_patch(p)     *dt
+         ps%livestemp_xfer_patch(p)  = ps%livestemp_xfer_patch(p)  - pf%hrv_livestemp_xfer_to_litter_patch(p)  *dt
+         ps%deadstemp_xfer_patch(p)  = ps%deadstemp_xfer_patch(p)  - pf%hrv_deadstemp_xfer_to_litter_patch(p)  *dt
+         ps%livecrootp_xfer_patch(p) = ps%livecrootp_xfer_patch(p) - pf%hrv_livecrootp_xfer_to_litter_patch(p) *dt
+         ps%deadcrootp_xfer_patch(p) = ps%deadcrootp_xfer_patch(p) - pf%hrv_deadcrootp_xfer_to_litter_patch(p) *dt
+
+      end do
+
+    end associate
+
+  end subroutine PStateUpdate2h
+
+end module PStateUpdate2Mod

--- a/models/lnd/clm/src/biogeochem/PStateUpdate3Mod.F90
+++ b/models/lnd/clm/src/biogeochem/PStateUpdate3Mod.F90
@@ -1,0 +1,235 @@
+module PStateUpdate3Mod
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Module for phosphorus state variable update, mortality fluxes.
+  ! Also, sminn leaching flux.
+  ! X.YANG
+  ! !USES:
+  use shr_kind_mod        , only: r8 => shr_kind_r8
+  use decompMod           , only : bounds_type
+  use clm_varpar          , only: nlevdecomp,ndecomp_pools,ndecomp_cascade_transitions
+  use clm_time_manager    , only : get_step_size
+  use clm_varctl          , only : iulog, use_nitrif_denitrif
+  use clm_varpar          , only : i_cwd, i_met_lit, i_cel_lit, i_lig_lit
+  use CNDecompCascadeConType , only : decomp_cascade_con
+  use CNStateType         , only : cnstate_type
+  use PhosphorusStateType , only : phosphorusstate_type
+  use PhosphorusFLuxType  , only : phosphorusflux_type
+  use soilorder_varcon    , only : smax,ks_sorption
+  !
+  implicit none
+  save
+  private
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public:: PStateUpdate3
+  !-----------------------------------------------------------------------
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine PStateUpdate3(bounds,num_soilc, filter_soilc, num_soilp, filter_soilp, &
+       cnstate_vars,phosphorusflux_vars, phosphorusstate_vars)
+    !
+    ! !DESCRIPTION:
+    ! On the radiation time step, update all the prognostic phosphorus state
+    ! variables affected by gap-phase mortality fluxes. Also the Sminn leaching flux.
+    ! NOTE - associate statements have been removed where there are
+    ! no science equatiops. This increases readability and maintainability.
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)        , intent(in)    :: bounds
+    integer                  , intent(in)    :: num_soilc       ! number of soil columps in filter
+    integer                  , intent(in)    :: filter_soilc(:) ! filter for soil columps
+    integer                  , intent(in)    :: num_soilp       ! number of soil patches in filter
+    integer                  , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    type(phosphorusflux_type)  , intent(in)    :: phosphorusflux_vars
+    type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+    type(cnstate_type)         , intent(in)    :: cnstate_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer :: c,p,j,l,k        ! indices
+    integer :: fp,fc      ! lake filter indices
+    real(r8):: dt         ! radiation time step (seconds)
+
+   real(r8):: smax_c       ! parameter(gP/m2), maximum amount of sorbed P in equilibrium with solution P
+   real(r8):: ks_sorption_c ! parameter(gP/m2), empirical constant for sorbed P in equilibrium with solution P 
+   real(r8):: flux_mineralization(bounds%begc:bounds%endc,1:nlevdecomp)   !! local temperary variable
+   real(r8):: temp_solutionp(bounds%begc:bounds%endc,1:nlevdecomp)
+
+
+    !-----------------------------------------------------------------------
+
+    associate(& 
+         isoilorder     => cnstate_vars%isoilorder ,&
+         cascade_receiver_pool => decomp_cascade_con%cascade_receiver_pool ,&
+         pf => phosphorusflux_vars  , &
+         ps => phosphorusstate_vars   &
+         )
+
+      ! set time steps
+      dt = real( get_step_size(), r8 )
+
+
+      !! immobilization/mineralization in litter-to-SOM and SOM-to-SOM fluxes
+      !! - X.YANG
+      do j = 1, nlevdecomp
+         ! column loop
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            flux_mineralization(c,j) = 0._r8
+         enddo
+      enddo
+
+      do k = 1, ndecomp_cascade_transitions
+         if ( cascade_receiver_pool(k) /= 0 ) then  ! skip terminal transitions
+            do j = 1, nlevdecomp
+               ! column loop
+               do fc = 1,num_soilc
+                  c = filter_soilc(fc)
+                    flux_mineralization(c,j) = flux_mineralization(c,j) - &
+                                               pf%decomp_cascade_sminp_flux_vr_col(c,j,k)*dt
+               end do
+            end do
+         else
+            do j = 1, nlevdecomp
+               ! column loop
+               do fc = 1,num_soilc
+                  c = filter_soilc(fc)
+                    flux_mineralization(c,j) = flux_mineralization(c,j) + &
+                                               pf%decomp_cascade_sminp_flux_vr_col(c,j,k)*dt
+
+               end do
+            end do
+         endif
+      end do
+
+
+      do j = 1, nlevdecomp
+              ! column loop
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            flux_mineralization(c,j) = flux_mineralization(c,j) + &
+                                       pf%biochem_pmin_vr_col(c,j)
+
+         end do
+      end do
+
+
+      do j = 1, nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            ! assign read in parameter values
+            smax_c = smax( isoilorder(c) )
+            ks_sorption_c = ks_sorption( isoilorder(c) )
+            temp_solutionp(c,j) = ps%solutionp_vr_col(c,j)
+            ps%solutionp_vr_col(c,j)      = ps%solutionp_vr_col(c,j)  + ( flux_mineralization(c,j) + pf%primp_to_labilep_vr_col(c,j)*dt &
+                                + pf%secondp_to_labilep_vr_col(c,j)*dt &
+                                + pf%supplement_to_sminp_vr_col(c,j)*dt - pf%sminp_to_plant_vr_col(c,j)*dt&
+                                - pf%labilep_to_secondp_vr_col(c,j)*dt - pf%sminp_leached_vr_col(c,j)*dt ) / &
+                                (1._r8+(smax_c*ks_sorption_c)/(ks_sorption_c+ps%solutionp_vr_col(c,j))**2._r8)
+
+            ps%labilep_vr_col(c,j) = ps%labilep_vr_col(c,j) + ((smax_c*ks_sorption_c)/(ks_sorption_c+temp_solutionp(c,j))**2._r8 ) * &
+                             ( flux_mineralization(c,j) + pf%primp_to_labilep_vr_col(c,j)*dt + pf%secondp_to_labilep_vr_col(c,j)*dt &
+                             + pf%supplement_to_sminp_vr_col(c,j)*dt - pf%sminp_to_plant_vr_col(c,j)*dt &
+                             - pf%labilep_to_secondp_vr_col(c,j)*dt - pf%sminp_leached_vr_col(c,j)*dt ) / &
+                             ( 1._r8+(smax_c*ks_sorption_c)/(ks_sorption_c+temp_solutionp(c,j))**2._r8 )
+
+            ps%secondp_vr_col(c,j) = ps%secondp_vr_col(c,j) + ( pf%labilep_to_secondp_vr_col(c,j) - pf%secondp_to_labilep_vr_col(c,j) &
+                                     - pf%secondp_to_occlp_vr_col(c,j) )*dt
+
+            ps%occlp_vr_col(c,j)   = ps%occlp_vr_col(c,j) + ( pf%secondp_to_occlp_vr_col(c,j) ) * dt
+
+            ps%primp_vr_col(c,j)   = ps%primp_vr_col(c,j) - ( pf%primp_to_labilep_vr_col(c,j) )*dt
+         end do
+      enddo
+
+      do j = 1, nlevdecomp
+         ! column loop
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+
+            ! column level phosphorus fluxes from fire
+            ! pft-level wood to column-level CWD (uncombusted wood)
+            ps%decomp_ppools_vr_col(c,j,i_cwd) = ps%decomp_ppools_vr_col(c,j,i_cwd) + pf%fire_mortality_p_to_cwdp_col(c,j) * dt
+
+            ! pft-level wood to column-level litter (uncombusted wood)
+            ps%decomp_ppools_vr_col(c,j,i_met_lit) = ps%decomp_ppools_vr_col(c,j,i_met_lit) + pf%m_p_to_litr_met_fire_col(c,j)* dt
+            ps%decomp_ppools_vr_col(c,j,i_cel_lit) = ps%decomp_ppools_vr_col(c,j,i_cel_lit) + pf%m_p_to_litr_cel_fire_col(c,j)* dt
+            ps%decomp_ppools_vr_col(c,j,i_lig_lit) = ps%decomp_ppools_vr_col(c,j,i_lig_lit) + pf%m_p_to_litr_lig_fire_col(c,j)* dt
+         end do ! end of column loop
+      end do
+
+      ! litter and CWD losses to fire
+      do l = 1, ndecomp_pools
+         do j = 1, nlevdecomp
+            ! column loop
+            do fc = 1,num_soilc
+               c = filter_soilc(fc)
+               ps%decomp_ppools_vr_col(c,j,l) = ps%decomp_ppools_vr_col(c,j,l) - pf%m_decomp_ppools_to_fire_vr_col(c,j,l) * dt
+            end do
+         end do
+      end do
+
+      ! patch-level phosphorus fluxes 
+
+      do fp = 1,num_soilp
+         p = filter_soilp(fp)
+
+         !from fire displayed pools
+         ps%leafp_patch(p)              =  ps%leafp_patch(p)      - pf%m_leafp_to_fire_patch(p)      * dt
+         ps%frootp_patch(p)             =  ps%frootp_patch(p)     - pf%m_frootp_to_fire_patch(p)     * dt
+         ps%livestemp_patch(p)          =  ps%livestemp_patch(p)  - pf%m_livestemp_to_fire_patch(p)  * dt
+         ps%deadstemp_patch(p)          =  ps%deadstemp_patch(p)  - pf%m_deadstemp_to_fire_patch(p)  * dt
+         ps%livecrootp_patch(p)         =  ps%livecrootp_patch(p) - pf%m_livecrootp_to_fire_patch(p) * dt
+         ps%deadcrootp_patch(p)         =  ps%deadcrootp_patch(p) - pf%m_deadcrootp_to_fire_patch(p) * dt
+
+         ps%leafp_patch(p)              =  ps%leafp_patch(p)      - pf%m_leafp_to_litter_fire_patch(p)           * dt
+         ps%frootp_patch(p)             =  ps%frootp_patch(p)     - pf%m_frootp_to_litter_fire_patch(p)          * dt
+         ps%livestemp_patch(p)          =  ps%livestemp_patch(p)  - pf%m_livestemp_to_litter_fire_patch(p)       * dt
+         ps%deadstemp_patch(p)          =  ps%deadstemp_patch(p)  - pf%m_deadstemp_to_litter_fire_patch(p)       * dt
+         ps%livecrootp_patch(p)         =  ps%livecrootp_patch(p) - pf%m_livecrootp_to_litter_fire_patch(p)      * dt
+         ps%deadcrootp_patch(p)         =  ps%deadcrootp_patch(p) - pf%m_deadcrootp_to_litter_fire_patch(p)      * dt
+
+         ! storage pools
+         ps%leafp_storage_patch(p)      =  ps%leafp_storage_patch(p)      - pf%m_leafp_storage_to_fire_patch(p)      * dt
+         ps%frootp_storage_patch(p)     =  ps%frootp_storage_patch(p)     - pf%m_frootp_storage_to_fire_patch(p)     * dt
+         ps%livestemp_storage_patch(p)  =  ps%livestemp_storage_patch(p)  - pf%m_livestemp_storage_to_fire_patch(p)  * dt
+         ps%deadstemp_storage_patch(p)  =  ps%deadstemp_storage_patch(p)  - pf%m_deadstemp_storage_to_fire_patch(p)  * dt
+         ps%livecrootp_storage_patch(p) =  ps%livecrootp_storage_patch(p) - pf%m_livecrootp_storage_to_fire_patch(p) * dt
+         ps%deadcrootp_storage_patch(p) =  ps%deadcrootp_storage_patch(p) - pf%m_deadcrootp_storage_to_fire_patch(p) * dt
+
+         ps%leafp_storage_patch(p)      =  ps%leafp_storage_patch(p)      - pf%m_leafp_storage_to_litter_fire_patch(p)      * dt
+         ps%frootp_storage_patch(p)     =  ps%frootp_storage_patch(p)     - pf%m_frootp_storage_to_litter_fire_patch(p)     * dt
+         ps%livestemp_storage_patch(p)  =  ps%livestemp_storage_patch(p)  - pf%m_livestemp_storage_to_litter_fire_patch(p)  * dt
+         ps%deadstemp_storage_patch(p)  =  ps%deadstemp_storage_patch(p)  - pf%m_deadstemp_storage_to_litter_fire_patch(p)  * dt
+         ps%livecrootp_storage_patch(p) =  ps%livecrootp_storage_patch(p) - pf%m_livecrootp_storage_to_litter_fire_patch(p) * dt
+         ps%deadcrootp_storage_patch(p) =  ps%deadcrootp_storage_patch(p) - pf%m_deadcrootp_storage_to_litter_fire_patch(p) * dt
+
+
+         ! trapsfer pools
+         ps%leafp_xfer_patch(p)         =  ps%leafp_xfer_patch(p)      - pf%m_leafp_xfer_to_fire_patch(p)      * dt
+         ps%frootp_xfer_patch(p)        =  ps%frootp_xfer_patch(p)     - pf%m_frootp_xfer_to_fire_patch(p)     * dt
+         ps%livestemp_xfer_patch(p)     =  ps%livestemp_xfer_patch(p)  - pf%m_livestemp_xfer_to_fire_patch(p)  * dt
+         ps%deadstemp_xfer_patch(p)     =  ps%deadstemp_xfer_patch(p)  - pf%m_deadstemp_xfer_to_fire_patch(p)  * dt
+         ps%livecrootp_xfer_patch(p)    =  ps%livecrootp_xfer_patch(p) - pf%m_livecrootp_xfer_to_fire_patch(p) * dt
+         ps%deadcrootp_xfer_patch(p)    =  ps%deadcrootp_xfer_patch(p) - pf%m_deadcrootp_xfer_to_fire_patch(p) * dt
+
+         ps%leafp_xfer_patch(p)         =  ps%leafp_xfer_patch(p)      - pf%m_leafp_xfer_to_litter_fire_patch(p)      * dt
+         ps%frootp_xfer_patch(p)        =  ps%frootp_xfer_patch(p)     - pf%m_frootp_xfer_to_litter_fire_patch(p)     * dt
+         ps%livestemp_xfer_patch(p)     =  ps%livestemp_xfer_patch(p)  - pf%m_livestemp_xfer_to_litter_fire_patch(p)  * dt
+         ps%deadstemp_xfer_patch(p)     =  ps%deadstemp_xfer_patch(p)  - pf%m_deadstemp_xfer_to_litter_fire_patch(p)  * dt
+         ps%livecrootp_xfer_patch(p)    =  ps%livecrootp_xfer_patch(p) - pf%m_livecrootp_xfer_to_litter_fire_patch(p) * dt
+         ps%deadcrootp_xfer_patch(p)    =  ps%deadcrootp_xfer_patch(p) - pf%m_deadcrootp_xfer_to_litter_fire_patch(p) * dt
+
+         ! retranslocated N pool
+         ps%retransp_patch(p)           =  ps%retransp_patch(p) - pf%m_retransp_to_fire_patch(p)        * dt
+         ps%retransp_patch(p)           =  ps%retransp_patch(p) - pf%m_retransp_to_litter_fire_patch(p) * dt
+      end do
+
+    end associate 
+
+  end subroutine PStateUpdate3
+
+end module PStateUpdate3Mod

--- a/models/lnd/clm/src/biogeochem/PhosphorusFluxType.F90
+++ b/models/lnd/clm/src/biogeochem/PhosphorusFluxType.F90
@@ -1,0 +1,2122 @@
+module PhosphorusFluxType
+
+  use shr_kind_mod           , only : r8 => shr_kind_r8
+  use shr_infnan_mod         , only : nan => shr_infnan_nan, assignment(=)
+  use shr_log_mod            , only : errMsg => shr_log_errMsg
+  use clm_varpar             , only : ndecomp_cascade_transitions, ndecomp_pools
+  use clm_varpar             , only : nlevdecomp_full, nlevdecomp, crop_prog
+  use clm_varcon             , only : spval, ispval, dzsoi_decomp
+  use decompMod              , only : bounds_type
+  use clm_varctl             , only : use_nitrif_denitrif, use_vertsoilc
+  use CNDecompCascadeConType , only : decomp_cascade_con
+  use abortutils             , only : endrun
+  use LandunitType           , only : lun                
+  use ColumnType             , only : col                
+  use PatchType              , only : pft                
+  ! 
+  ! !PUBLIC TYPES:
+  implicit none
+  save
+  private
+  !
+  type, public :: phosphorusflux_type
+
+     ! gap mortality fluxes
+     real(r8), pointer :: m_leafp_to_litter_patch                   (:)     ! patch leaf P mortality (gP/m2/s)
+     real(r8), pointer :: m_frootp_to_litter_patch                  (:)     ! patch fine root P mortality (gP/m2/s)
+     real(r8), pointer :: m_leafp_storage_to_litter_patch           (:)     ! patch leaf P storage mortality (gP/m2/s)
+     real(r8), pointer :: m_frootp_storage_to_litter_patch          (:)     ! patch fine root P storage mortality (gP/m2/s)
+     real(r8), pointer :: m_livestemp_storage_to_litter_patch       (:)     ! patch live stem P storage mortality (gP/m2/s)
+     real(r8), pointer :: m_deadstemp_storage_to_litter_patch       (:)     ! patch dead stem P storage mortality (gP/m2/s)
+     real(r8), pointer :: m_livecrootp_storage_to_litter_patch      (:)     ! patch live coarse root P storage mortality (gP/m2/s)
+     real(r8), pointer :: m_deadcrootp_storage_to_litter_patch      (:)     ! patch dead coarse root P storage mortality (gP/m2/s)
+     real(r8), pointer :: m_leafp_xfer_to_litter_patch              (:)     ! patch leaf P transfer mortality (gP/m2/s)
+     real(r8), pointer :: m_frootp_xfer_to_litter_patch             (:)     ! patch fine root P transfer mortality (gP/m2/s)
+     real(r8), pointer :: m_livestemp_xfer_to_litter_patch          (:)     ! patch live stem P transfer mortality (gP/m2/s)
+     real(r8), pointer :: m_deadstemp_xfer_to_litter_patch          (:)     ! patch dead stem P transfer mortality (gP/m2/s)
+     real(r8), pointer :: m_livecrootp_xfer_to_litter_patch         (:)     ! patch live coarse root P transfer mortality (gP/m2/s)
+     real(r8), pointer :: m_deadcrootp_xfer_to_litter_patch         (:)     ! patch dead coarse root P transfer mortality (gP/m2/s)
+     real(r8), pointer :: m_livestemp_to_litter_patch               (:)     ! patch live stem P mortality (gP/m2/s)
+     real(r8), pointer :: m_deadstemp_to_litter_patch               (:)     ! patch dead stem P mortality (gP/m2/s)
+     real(r8), pointer :: m_livecrootp_to_litter_patch              (:)     ! patch live coarse root P mortality (gP/m2/s)
+     real(r8), pointer :: m_deadcrootp_to_litter_patch              (:)     ! patch dead coarse root P mortality (gP/m2/s)
+     real(r8), pointer :: m_retransp_to_litter_patch                (:)     ! patch retranslocated P pool mortality (gP/m2/s)
+
+     ! harvest fluxes
+     real(r8), pointer :: hrv_leafp_to_litter_patch                 (:)     ! patch leaf P harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_frootp_to_litter_patch                (:)     ! patch fine root P harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_leafp_storage_to_litter_patch         (:)     ! patch leaf P storage harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_frootp_storage_to_litter_patch        (:)     ! patch fine root P storage harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_livestemp_storage_to_litter_patch     (:)     ! patch live stem P storage harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_deadstemp_storage_to_litter_patch     (:)     ! patch dead stem P storage harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_livecrootp_storage_to_litter_patch    (:)     ! patch live coarse root P storage harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_deadcrootp_storage_to_litter_patch    (:)     ! patch dead coarse root P storage harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_leafp_xfer_to_litter_patch            (:)     ! patch leaf P transfer harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_frootp_xfer_to_litter_patch           (:)     ! patch fine root P transfer harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_livestemp_xfer_to_litter_patch        (:)     ! patch live stem P transfer harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_deadstemp_xfer_to_litter_patch        (:)     ! patch dead stem P transfer harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_livecrootp_xfer_to_litter_patch       (:)     ! patch live coarse root P transfer harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_deadcrootp_xfer_to_litter_patch       (:)     ! patch dead coarse root P transfer harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_livestemp_to_litter_patch             (:)     ! patch live stem P harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_deadstemp_to_prod10p_patch            (:)     ! patch dead stem P harvest to 10-year product pool (gP/m2/s)
+     real(r8), pointer :: hrv_deadstemp_to_prod100p_patch           (:)     ! patch dead stem P harvest to 100-year product pool (gP/m2/s)
+     real(r8), pointer :: hrv_livecrootp_to_litter_patch            (:)     ! patch live coarse root P harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_deadcrootp_to_litter_patch            (:)     ! patch dead coarse root P harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_retransp_to_litter_patch              (:)     ! patch retranslocated P pool harvest mortality (gP/m2/s)
+     real(r8), pointer :: hrv_deadstemp_to_prod10p_col              (:)     ! col dead stem P harvest mortality to 10-year product pool (gP/m2/s)
+     real(r8), pointer :: hrv_deadstemp_to_prod100p_col             (:)     ! col dead stem P harvest mortality to 100-year product pool (gP/m2/s)
+     real(r8), pointer :: m_p_to_litr_met_fire_col                  (:,:)   ! col P from leaf, froot, xfer and storage P to litter labile P by fire (gP/m3/s) 
+     real(r8), pointer :: m_p_to_litr_cel_fire_col                  (:,:)   ! col P from leaf, froot, xfer and storage P to litter cellulose P by fire (gP/m3/s) 
+     real(r8), pointer :: m_p_to_litr_lig_fire_col                  (:,:)   ! col P from leaf, froot, xfer and storage P to litter lignin P by fire (gP/m3/s) 
+     real(r8), pointer :: harvest_p_to_litr_met_p_col               (:,:)   ! col P fluxes associated with harvest to litter metabolic pool (gP/m3/s)
+     real(r8), pointer :: harvest_p_to_litr_cel_p_col               (:,:)   ! col P fluxes associated with harvest to litter cellulose pool (gP/m3/s)
+     real(r8), pointer :: harvest_p_to_litr_lig_p_col               (:,:)   ! col P fluxes associated with harvest to litter lignin pool (gP/m3/s)
+     real(r8), pointer :: harvest_p_to_cwdp_col                     (:,:)   ! col P fluxes associated with harvest to CWD pool (gP/m3/s)
+
+     ! fire P fluxes 
+     real(r8), pointer :: m_decomp_ppools_to_fire_vr_col            (:,:,:) ! col vertically-resolved decomposing P fire loss (gP/m3/s)
+     real(r8), pointer :: m_decomp_ppools_to_fire_col               (:,:)   ! col vertically-integrated (diagnostic) decomposing P fire loss (gP/m2/s)
+     real(r8), pointer :: m_leafp_to_fire_patch                     (:)     ! patch (gP/m2/s) fire P emissions from leafp 
+     real(r8), pointer :: m_leafp_storage_to_fire_patch             (:)     ! patch (gP/m2/s) fire P emissions from leafp_storage            
+     real(r8), pointer :: m_leafp_xfer_to_fire_patch                (:)     ! patch (gP/m2/s) fire P emissions from leafp_xfer     
+     real(r8), pointer :: m_livestemp_to_fire_patch                 (:)     ! patch (gP/m2/s) fire P emissions from livestemp 
+     real(r8), pointer :: m_livestemp_storage_to_fire_patch         (:)     ! patch (gP/m2/s) fire P emissions from livestemp_storage      
+     real(r8), pointer :: m_livestemp_xfer_to_fire_patch            (:)     ! patch (gP/m2/s) fire P emissions from livestemp_xfer
+     real(r8), pointer :: m_deadstemp_to_fire_patch                 (:)     ! patch (gP/m2/s) fire P emissions from deadstemp
+     real(r8), pointer :: m_deadstemp_storage_to_fire_patch         (:)     ! patch (gP/m2/s) fire P emissions from deadstemp_storage         
+     real(r8), pointer :: m_deadstemp_xfer_to_fire_patch            (:)     ! patch (gP/m2/s) fire P emissions from deadstemp_xfer
+     real(r8), pointer :: m_frootp_to_fire_patch                    (:)     ! patch (gP/m2/s) fire P emissions from frootp
+     real(r8), pointer :: m_frootp_storage_to_fire_patch            (:)     ! patch (gP/m2/s) fire P emissions from frootp_storage
+     real(r8), pointer :: m_frootp_xfer_to_fire_patch               (:)     ! patch (gP/m2/s) fire P emissions from frootp_xfer
+     real(r8), pointer :: m_livecrootp_to_fire_patch                (:)     ! patch (gP/m2/s) fire P emissions from m_livecrootp_to_fire
+     real(r8), pointer :: m_livecrootp_storage_to_fire_patch        (:)     ! patch (gP/m2/s) fire P emissions from livecrootp_storage     
+     real(r8), pointer :: m_livecrootp_xfer_to_fire_patch           (:)     ! patch (gP/m2/s) fire P emissions from livecrootp_xfer
+     real(r8), pointer :: m_deadcrootp_to_fire_patch                (:)     ! patch (gP/m2/s) fire P emissions from deadcrootp
+     real(r8), pointer :: m_deadcrootp_storage_to_fire_patch        (:)     ! patch (gP/m2/s) fire P emissions from deadcrootp_storage  
+     real(r8), pointer :: m_deadcrootp_xfer_to_fire_patch           (:)     ! patch (gP/m2/s) fire P emissions from deadcrootp_xfer
+     real(r8), pointer :: m_retransp_to_fire_patch                  (:)     ! patch (gP/m2/s) fire P emissions from retransp
+     real(r8), pointer :: m_leafp_to_litter_fire_patch              (:)     ! patch (gP/m2/s) from leafp to litter P  due to fire               
+     real(r8), pointer :: m_leafp_storage_to_litter_fire_patch      (:)     ! patch (gP/m2/s) from leafp_storage to litter P  due to fire                              
+     real(r8), pointer :: m_leafp_xfer_to_litter_fire_patch         (:)     ! patch (gP/m2/s) from leafp_xfer to litter P  due to fire                              
+     real(r8), pointer :: m_livestemp_to_litter_fire_patch          (:)     ! patch (gP/m2/s) from livestemp to litter P  due to fire                              
+     real(r8), pointer :: m_livestemp_storage_to_litter_fire_patch  (:)     ! patch (gP/m2/s) from livestemp_storage to litter P  due to fire                                     
+     real(r8), pointer :: m_livestemp_xfer_to_litter_fire_patch     (:)     ! patch (gP/m2/s) from livestemp_xfer to litter P  due to fire                                     
+     real(r8), pointer :: m_livestemp_to_deadstemp_fire_patch       (:)     ! patch (gP/m2/s) from livestemp to deadstemp P  due to fire                                     
+     real(r8), pointer :: m_deadstemp_to_litter_fire_patch          (:)     ! patch (gP/m2/s) from deadstemp to litter P  due to fire                                     
+     real(r8), pointer :: m_deadstemp_storage_to_litter_fire_patch  (:)     ! patch (gP/m2/s) from deadstemp_storage to litter P  due to fire                                               
+     real(r8), pointer :: m_deadstemp_xfer_to_litter_fire_patch     (:)     ! patch (gP/m2/s) from deadstemp_xfer to litter P  due to fire                                               
+     real(r8), pointer :: m_frootp_to_litter_fire_patch             (:)     ! patch (gP/m2/s) from frootp to litter P  due to fire                                               
+     real(r8), pointer :: m_frootp_storage_to_litter_fire_patch     (:)     ! patch (gP/m2/s) from frootp_storage to litter P  due to fire                                               
+     real(r8), pointer :: m_frootp_xfer_to_litter_fire_patch        (:)     ! patch (gP/m2/s) from frootp_xfer to litter P  due to fire                                               
+     real(r8), pointer :: m_livecrootp_to_litter_fire_patch         (:)     ! patch (gP/m2/s) from livecrootp to litter P  due to fire                                               
+     real(r8), pointer :: m_livecrootp_storage_to_litter_fire_patch (:)     ! patch (gP/m2/s) from livecrootp_storage to litter P  due to fire                                                     
+     real(r8), pointer :: m_livecrootp_xfer_to_litter_fire_patch    (:)     ! patch (gP/m2/s) from livecrootp_xfer to litter P  due to fire                                                     
+     real(r8), pointer :: m_livecrootp_to_deadcrootp_fire_patch     (:)     ! patch (gP/m2/s) from livecrootp_xfer to deadcrootp due to fire                                                     
+     real(r8), pointer :: m_deadcrootp_to_litter_fire_patch         (:)     ! patch (gP/m2/s) from deadcrootp to deadcrootp due to fire                                                       
+     real(r8), pointer :: m_deadcrootp_storage_to_litter_fire_patch (:)     ! patch (gP/m2/s) from deadcrootp_storage to deadcrootp due to fire                                                        
+     real(r8), pointer :: m_deadcrootp_xfer_to_litter_fire_patch    (:)     ! patch (gP/m2/s) from deadcrootp_xfer to deadcrootp due to fire                                                         
+     real(r8), pointer :: m_retransp_to_litter_fire_patch           (:)     ! patch (gP/m2/s) from retransp to deadcrootp due to fire                                                         
+     real(r8), pointer :: fire_ploss_patch                          (:)     ! patch total pft-level fire P loss (gP/m2/s) 
+     real(r8), pointer :: fire_ploss_col                            (:)     ! col total column-level fire P loss (gP/m2/s)
+     real(r8), pointer :: fire_ploss_p2c_col                        (:)     ! col patch2col column-level fire P loss (gP/m2/s) (p2c)
+     real(r8), pointer :: fire_mortality_p_to_cwdp_col              (:,:)   ! col P fluxes associated with fire mortality to CWD pool (gP/m3/s)
+
+     ! phenology fluxes from transfer pool
+     real(r8), pointer :: grainp_xfer_to_grainp_patch               (:)     ! patch grain P growth from storage for prognostic crop model (gP/m2/s)
+     real(r8), pointer :: leafp_xfer_to_leafp_patch                 (:)     ! patch leaf P growth from storage (gP/m2/s)
+     real(r8), pointer :: frootp_xfer_to_frootp_patch               (:)     ! patch fine root P growth from storage (gP/m2/s)
+     real(r8), pointer :: livestemp_xfer_to_livestemp_patch         (:)     ! patch live stem P growth from storage (gP/m2/s)
+     real(r8), pointer :: deadstemp_xfer_to_deadstemp_patch         (:)     ! patch dead stem P growth from storage (gP/m2/s)
+     real(r8), pointer :: livecrootp_xfer_to_livecrootp_patch       (:)     ! patch live coarse root P growth from storage (gP/m2/s)
+     real(r8), pointer :: deadcrootp_xfer_to_deadcrootp_patch       (:)     ! patch dead coarse root P growth from storage (gP/m2/s)
+
+     ! litterfall fluxes
+     real(r8), pointer :: livestemp_to_litter_patch                 (:)     ! patch livestem P to litter (gP/m2/s)
+     real(r8), pointer :: grainp_to_food_patch                      (:)     ! patch grain P to food for prognostic crop (gP/m2/s)
+     real(r8), pointer :: leafp_to_litter_patch                     (:)     ! patch leaf P litterfall (gP/m2/s)
+     real(r8), pointer :: leafp_to_retransp_patch                   (:)     ! patch leaf P to retranslocated P pool (gP/m2/s)
+     real(r8), pointer :: frootp_to_retransp_patch                  (:)     ! patch fine root P to retranslocated P pool (gP/m2/s)
+     real(r8), pointer :: frootp_to_litter_patch                    (:)     ! patch fine root P litterfall (gP/m2/s)
+
+     ! allocation fluxes
+     real(r8), pointer :: retransp_to_ppool_patch                   (:)     ! patch deployment of retranslocated P (gP/m2/s)       
+     real(r8), pointer :: sminp_to_ppool_patch                      (:)     ! patch deployment of soil mineral P uptake (gP/m2/s)
+     real(r8), pointer :: ppool_to_grainp_patch                     (:)     ! patch allocation to grain P for prognostic crop (gP/m2/s)
+     real(r8), pointer :: ppool_to_grainp_storage_patch             (:)     ! patch allocation to grain P storage for prognostic crop (gP/m2/s)
+     real(r8), pointer :: ppool_to_leafp_patch                      (:)     ! patch allocation to leaf P (gP/m2/s)
+     real(r8), pointer :: ppool_to_leafp_storage_patch              (:)     ! patch allocation to leaf P storage (gP/m2/s)
+     real(r8), pointer :: ppool_to_frootp_patch                     (:)     ! patch allocation to fine root P (gP/m2/s)
+     real(r8), pointer :: ppool_to_frootp_storage_patch             (:)     ! patch allocation to fine root P storage (gP/m2/s)
+     real(r8), pointer :: ppool_to_livestemp_patch                  (:)     ! patch allocation to live stem P (gP/m2/s)
+     real(r8), pointer :: ppool_to_livestemp_storage_patch          (:)     ! patch allocation to live stem P storage (gP/m2/s)
+     real(r8), pointer :: ppool_to_deadstemp_patch                  (:)     ! patch allocation to dead stem P (gP/m2/s)
+     real(r8), pointer :: ppool_to_deadstemp_storage_patch          (:)     ! patch allocation to dead stem P storage (gP/m2/s)
+     real(r8), pointer :: ppool_to_livecrootp_patch                 (:)     ! patch allocation to live coarse root P (gP/m2/s)
+     real(r8), pointer :: ppool_to_livecrootp_storage_patch         (:)     ! patch allocation to live coarse root P storage (gP/m2/s)
+     real(r8), pointer :: ppool_to_deadcrootp_patch                 (:)     ! patch allocation to dead coarse root P (gP/m2/s)
+     real(r8), pointer :: ppool_to_deadcrootp_storage_patch         (:)     ! patch allocation to dead coarse root P storage (gP/m2/s)
+
+     ! annual turnover of storage to transfer pools           
+     real(r8), pointer :: grainp_storage_to_xfer_patch              (:)     ! patch grain P shift storage to transfer for prognostic crop (gP/m2/s)
+     real(r8), pointer :: leafp_storage_to_xfer_patch               (:)     ! patch leaf P shift storage to transfer (gP/m2/s)
+     real(r8), pointer :: frootp_storage_to_xfer_patch              (:)     ! patch fine root P shift storage to transfer (gP/m2/s)
+     real(r8), pointer :: livestemp_storage_to_xfer_patch           (:)     ! patch live stem P shift storage to transfer (gP/m2/s)
+     real(r8), pointer :: deadstemp_storage_to_xfer_patch           (:)     ! patch dead stem P shift storage to transfer (gP/m2/s)
+     real(r8), pointer :: livecrootp_storage_to_xfer_patch          (:)     ! patch live coarse root P shift storage to transfer (gP/m2/s)
+     real(r8), pointer :: deadcrootp_storage_to_xfer_patch          (:)     ! patch dead coarse root P shift storage to transfer (gP/m2/s)
+     real(r8), pointer :: fert_p_patch                                (:)     ! patch applied fertilizer (gP/m2/s)
+     real(r8), pointer :: fert_counter_patch                        (:)     ! patch >0 fertilize; <=0 not
+
+     ! turnover of livewood to deadwood, with retranslocation 
+     real(r8), pointer :: livestemp_to_deadstemp_patch              (:)     ! patch live stem P turnover (gP/m2/s)
+     real(r8), pointer :: livestemp_to_retransp_patch               (:)     ! patch live stem P to retranslocated P pool (gP/m2/s)
+     real(r8), pointer :: livecrootp_to_deadcrootp_patch            (:)     ! patch live coarse root P turnover (gP/m2/s)
+     real(r8), pointer :: livecrootp_to_retransp_patch              (:)     ! patch live coarse root P to retranslocated P pool (gP/m2/s)
+
+     ! summary (diagnostic) flux variables, not involved in mass balance
+     real(r8), pointer :: pdeploy_patch                             (:)     ! patch total P deployed to growth and storage (gP/m2/s)
+     real(r8), pointer :: pinputs_patch                             (:)     ! patch total P inputs to pft-level (gP/m2/s)
+     real(r8), pointer :: poutputs_patch                            (:)     ! patch total P outputs from pft-level (gP/m2/s)
+     real(r8), pointer :: wood_harvestp_patch                       (:)     ! patch total P losses to wood product pools (gP/m2/s)
+     real(r8), pointer :: wood_harvestp_col                         (:)     ! col total P losses to wood product pools (gP/m2/s) (p2c)
+
+     ! deposition fluxes
+     real(r8), pointer :: pdep_to_sminp_col                         (:)     ! col atmospheric P deposition to soil mineral P (gP/m2/s)
+     real(r8), pointer :: fert_p_to_sminp_col                            (:)     ! col fertilizer P to soil mineral P (gP/m2/s)
+
+     ! phenology: litterfall and crop fluxes
+     real(r8), pointer :: phenology_p_to_litr_met_p_col             (:,:)   ! col P fluxes associated with phenology (litterfall and crop) to litter metabolic pool (gP/m3/s)
+     real(r8), pointer :: phenology_p_to_litr_cel_p_col             (:,:)   ! col P fluxes associated with phenology (litterfall and crop) to litter cellulose pool (gP/m3/s)
+     real(r8), pointer :: phenology_p_to_litr_lig_p_col             (:,:)   ! col P fluxes associated with phenology (litterfall and crop) to litter lignin pool (gP/m3/s)
+
+     ! gap mortality fluxes
+     real(r8), pointer :: gap_mortality_p_to_litr_met_p_col         (:,:)   ! col P fluxes associated with gap mortality to litter metabolic pool (gP/m3/s)
+     real(r8), pointer :: gap_mortality_p_to_litr_cel_p_col         (:,:)   ! col P fluxes associated with gap mortality to litter cellulose pool (gP/m3/s)
+     real(r8), pointer :: gap_mortality_p_to_litr_lig_p_col         (:,:)   ! col P fluxes associated with gap mortality to litter lignin pool (gP/m3/s)
+     real(r8), pointer :: gap_mortality_p_to_cwdp_col               (:,:)   ! col P fluxes associated with gap mortality to CWD pool (gP/m3/s)
+
+     ! decomposition fluxes
+     real(r8), pointer :: decomp_cascade_ptransfer_vr_col           (:,:,:) ! col vert-res transfer of P from donor to receiver pool along decomp. cascade (gP/m3/s)
+     real(r8), pointer :: decomp_cascade_ptransfer_col              (:,:)   ! col vert-int (diagnostic) transfer of P from donor to receiver pool along decomp. cascade (gP/m2/s)
+     real(r8), pointer :: decomp_cascade_sminp_flux_vr_col          (:,:,:) ! col vert-res mineral P flux for transition along decomposition cascade (gP/m3/s)
+     real(r8), pointer :: decomp_cascade_sminp_flux_col             (:,:)   ! col vert-int (diagnostic) mineral P flux for transition along decomposition cascade (gP/m2/s)
+                                                                            ! Used to update concentrations concurrently with vertical transport
+     ! vertically-resolved immobilization fluxes
+     real(r8), pointer :: potential_immob_p_vr_col                    (:,:)   ! col vertically-resolved potential P immobilization (gP/m3/s) at each level
+     real(r8), pointer :: potential_immob_p_col                       (:)     ! col vert-int (diagnostic) potential P immobilization (gP/m2/s)
+     real(r8), pointer :: actual_immob_p_vr_col                       (:,:)   ! col vertically-resolved actual P immobilization (gP/m3/s) at each level
+     real(r8), pointer :: actual_immob_p_col                          (:)     ! col vert-int (diagnostic) actual P immobilization (gP/m2/s)
+     real(r8), pointer :: sminp_to_plant_vr_col                     (:,:)   ! col vertically-resolved plant uptake of soil mineral P (gP/m3/s)
+     real(r8), pointer :: sminp_to_plant_col                        (:)     ! col vert-int (diagnostic) plant uptake of soil mineral P (gP/m2/s)
+     real(r8), pointer :: supplement_to_sminp_vr_col                (:,:)   ! col vertically-resolved supplemental P supply (gP/m3/s)
+     real(r8), pointer :: supplement_to_sminp_col                   (:)     ! col vert-int (diagnostic) supplemental P supply (gP/m2/s)
+     real(r8), pointer :: gross_pmin_vr_col                         (:,:)   ! col vertically-resolved gross rate of P mineralization (gP/m3/s)
+     real(r8), pointer :: gross_pmin_col                            (:)     ! col vert-int (diagnostic) gross rate of P mineralization (gP/m2/s)
+     real(r8), pointer :: net_pmin_vr_col                           (:,:)   ! col vertically-resolved net rate of P mineralization (gP/m3/s)
+     real(r8), pointer :: net_pmin_col                              (:)     ! col vert-int (diagnostic) net rate of P mineralization (gP/m2/s)
+
+     real(r8), pointer :: biochem_pmin_ppools_vr_col                (:,:,:) ! col vertically-resolved biochemical P mineralization for each soi pool (gP/m3/s)
+     real(r8), pointer :: biochem_pmin_vr_col                       (:,:)   ! col vertically-resolved total biochemical P mineralization (gP/m3/s)
+     real(r8), pointer :: biochem_pmin_col                          (:)   ! col vert-int (diagnostic) total biochemical P mineralization (gP/m3/s)
+
+
+     ! new variables for phosphorus code
+     ! inorganic P transformation fluxes
+     real(r8), pointer :: primp_to_labilep_vr_col                     (:,:)   ! col (gP/m3/s) flux of P from primary mineral to labile 
+     real(r8), pointer :: primp_to_labilep_col                        (:)     ! col (gP/m3/s) flux of P from primary mineral to labile 
+     real(r8), pointer :: labilep_to_secondp_vr_col                   (:,:)   ! col (gP/m3/s) flux of labile P to secondary mineral P 
+     real(r8), pointer :: labilep_to_secondp_col                      (:)     ! col (gP/m3/s) flux of labile P to secondary mineral P 
+     real(r8), pointer :: secondp_to_labilep_vr_col                   (:,:)   ! col (gP/m3/s) flux of the desorption of secondary mineral P to labile P
+     real(r8), pointer :: secondp_to_labilep_col                      (:)     ! col (gP/m3/s) flux of the desorption of secondary mineral P to labile P
+     real(r8), pointer :: secondp_to_occlp_vr_col                     (:,:)   ! col (gP/m3/s) flux of the occlusion of secondary P to occluded P
+     real(r8), pointer :: secondp_to_occlp_col                        (:)     ! col (gP/m3/s) flux of the occlusion of secondary P to occluded P
+
+
+     ! leaching fluxes
+     real(r8), pointer :: sminp_leached_vr_col                      (:,:)   ! col vertically-resolved soil mineral P pool loss to leaching (gP/m3/s)
+     real(r8), pointer :: sminp_leached_col                         (:)     ! col soil mineral P pool loss to leaching (gP/m2/s)
+
+     ! dynamic landcover fluxes
+     real(r8), pointer :: dwt_seedp_to_leaf_col                     (:)     ! col (gP/m2/s) seed source to PFT-level
+     real(r8), pointer :: dwt_seedp_to_deadstem_col                 (:)     ! col (gP/m2/s) seed source to PFT-level
+     real(r8), pointer :: dwt_conv_pflux_col                        (:)     ! col (gP/m2/s) conversion P flux (immediate loss to atm)
+     real(r8), pointer :: dwt_prod10p_gain_col                      (:)     ! col (gP/m2/s) addition to 10-yr wood product pool
+     real(r8), pointer :: dwt_prod100p_gain_col                     (:)     ! col (gP/m2/s) addition to 100-yr wood product pool
+     real(r8), pointer :: dwt_frootp_to_litr_met_p_col              (:,:)   ! col (gP/m3/s) fine root to litter due to landcover change
+     real(r8), pointer :: dwt_frootp_to_litr_cel_p_col              (:,:)   ! col (gP/m3/s) fine root to litter due to landcover change
+     real(r8), pointer :: dwt_frootp_to_litr_lig_p_col              (:,:)   ! col (gP/m3/s) fine root to litter due to landcover change
+     real(r8), pointer :: dwt_livecrootp_to_cwdp_col                (:,:)   ! col (gP/m3/s) live coarse root to CWD due to landcover change
+     real(r8), pointer :: dwt_deadcrootp_to_cwdp_col                (:,:)   ! col (gP/m3/s) dead coarse root to CWD due to landcover change
+     real(r8), pointer :: dwt_ploss_col                             (:)     ! col (gP/m2/s) total phosphorus loss from product pools and conversion
+
+     ! wood product pool loss fluxes
+     real(r8), pointer :: prod10p_loss_col                          (:)     ! col (gP/m2/s) decomposition loss from 10-yr wood product pool
+     real(r8), pointer :: prod100p_loss_col                         (:)     ! col (gP/m2/s) decomposition loss from 100-yr wood product pool
+     real(r8), pointer :: product_ploss_col                         (:)     ! col (gP/m2/s) total wood product phosphorus loss
+
+
+     ! summary (diagnostic) flux variables, not involved in mass balance
+     real(r8), pointer :: pinputs_col                               (:)     ! col column-level P inputs (gP/m2/s)
+     real(r8), pointer :: poutputs_col                              (:)     ! col column-level P outputs (gP/m2/s)
+     real(r8), pointer :: som_p_leached_col                         (:)     ! col total SOM P loss from vertical transport (gP/m^2/s)
+     real(r8), pointer :: decomp_ppools_leached_col                 (:,:)   ! col P loss from vertical transport from each decomposing P pool (gP/m^2/s)
+     real(r8), pointer :: decomp_ppools_transport_tendency_col      (:,:,:) ! col P tendency due to vertical transport in decomposing P pools (gP/m^3/s)
+
+     ! all n pools involved in decomposition
+     real(r8), pointer :: decomp_ppools_sourcesink_col              (:,:,:) ! col (gP/m3) change in decomposing n pools 
+                                                                            !     (sum of all additions and subtractions from stateupdate1).  
+
+     ! Misc
+     real(r8), pointer :: plant_pdemand_patch                       (:)     ! P flux required to support initial GPP (gP/m2/s)
+     real(r8), pointer :: avail_retransp_patch                      (:)     ! P flux available from retranslocation pool (gP/m2/s)
+     real(r8), pointer :: plant_palloc_patch                        (:)     ! total allocated P flux (gP/m2/s)
+
+   contains
+
+     procedure , public  :: Init   
+     procedure , public  :: Restart
+     procedure , public  :: SetValues
+     procedure , public  :: ZeroDWT
+     procedure , public  :: Summary
+     procedure , private :: InitAllocate 
+     procedure , private :: InitHistory
+     procedure , private :: InitCold
+
+  end type phosphorusflux_type
+  !------------------------------------------------------------------------
+
+contains
+
+  !------------------------------------------------------------------------
+  subroutine Init(this, bounds)
+
+    class(phosphorusflux_type) :: this
+    type(bounds_type), intent(in) :: bounds  
+
+    call this%InitAllocate (bounds)
+    call this%InitHistory (bounds)
+    call this%InitCold (bounds)
+
+  end subroutine Init
+
+  !------------------------------------------------------------------------
+  subroutine InitAllocate(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Initialize pft phosphorus flux
+    !
+    ! !ARGUMENTS:
+    class (phosphorusflux_type) :: this
+    type(bounds_type) , intent(in) :: bounds  
+    !
+    ! !LOCAL VARIABLES:
+    integer           :: begp,endp
+    integer           :: begc,endc
+    !------------------------------------------------------------------------
+
+    begp = bounds%begp; endp = bounds%endp
+    begc = bounds%begc; endc = bounds%endc
+
+    allocate(this%m_leafp_to_litter_patch                   (begp:endp)) ; this%m_leafp_to_litter_patch                   (:) = nan
+    allocate(this%m_frootp_to_litter_patch                  (begp:endp)) ; this%m_frootp_to_litter_patch                  (:) = nan
+    allocate(this%m_leafp_storage_to_litter_patch           (begp:endp)) ; this%m_leafp_storage_to_litter_patch           (:) = nan
+    allocate(this%m_frootp_storage_to_litter_patch          (begp:endp)) ; this%m_frootp_storage_to_litter_patch          (:) = nan
+    allocate(this%m_livestemp_storage_to_litter_patch       (begp:endp)) ; this%m_livestemp_storage_to_litter_patch       (:) = nan
+    allocate(this%m_deadstemp_storage_to_litter_patch       (begp:endp)) ; this%m_deadstemp_storage_to_litter_patch       (:) = nan
+    allocate(this%m_livecrootp_storage_to_litter_patch      (begp:endp)) ; this%m_livecrootp_storage_to_litter_patch      (:) = nan
+    allocate(this%m_deadcrootp_storage_to_litter_patch      (begp:endp)) ; this%m_deadcrootp_storage_to_litter_patch      (:) = nan
+    allocate(this%m_leafp_xfer_to_litter_patch              (begp:endp)) ; this%m_leafp_xfer_to_litter_patch              (:) = nan
+    allocate(this%m_frootp_xfer_to_litter_patch             (begp:endp)) ; this%m_frootp_xfer_to_litter_patch             (:) = nan
+    allocate(this%m_livestemp_xfer_to_litter_patch          (begp:endp)) ; this%m_livestemp_xfer_to_litter_patch          (:) = nan
+    allocate(this%m_deadstemp_xfer_to_litter_patch          (begp:endp)) ; this%m_deadstemp_xfer_to_litter_patch          (:) = nan
+    allocate(this%m_livecrootp_xfer_to_litter_patch         (begp:endp)) ; this%m_livecrootp_xfer_to_litter_patch         (:) = nan
+    allocate(this%m_deadcrootp_xfer_to_litter_patch         (begp:endp)) ; this%m_deadcrootp_xfer_to_litter_patch         (:) = nan
+    allocate(this%m_livestemp_to_litter_patch               (begp:endp)) ; this%m_livestemp_to_litter_patch               (:) = nan
+    allocate(this%m_deadstemp_to_litter_patch               (begp:endp)) ; this%m_deadstemp_to_litter_patch               (:) = nan
+    allocate(this%m_livecrootp_to_litter_patch              (begp:endp)) ; this%m_livecrootp_to_litter_patch              (:) = nan
+    allocate(this%m_deadcrootp_to_litter_patch              (begp:endp)) ; this%m_deadcrootp_to_litter_patch              (:) = nan
+    allocate(this%m_retransp_to_litter_patch                (begp:endp)) ; this%m_retransp_to_litter_patch                (:) = nan
+    allocate(this%hrv_leafp_to_litter_patch                 (begp:endp)) ; this%hrv_leafp_to_litter_patch                 (:) = nan
+    allocate(this%hrv_frootp_to_litter_patch                (begp:endp)) ; this%hrv_frootp_to_litter_patch                (:) = nan
+    allocate(this%hrv_leafp_storage_to_litter_patch         (begp:endp)) ; this%hrv_leafp_storage_to_litter_patch         (:) = nan
+    allocate(this%hrv_frootp_storage_to_litter_patch        (begp:endp)) ; this%hrv_frootp_storage_to_litter_patch        (:) = nan
+    allocate(this%hrv_livestemp_storage_to_litter_patch     (begp:endp)) ; this%hrv_livestemp_storage_to_litter_patch     (:) = nan
+    allocate(this%hrv_deadstemp_storage_to_litter_patch     (begp:endp)) ; this%hrv_deadstemp_storage_to_litter_patch     (:) = nan
+    allocate(this%hrv_livecrootp_storage_to_litter_patch    (begp:endp)) ; this%hrv_livecrootp_storage_to_litter_patch    (:) = nan
+    allocate(this%hrv_deadcrootp_storage_to_litter_patch    (begp:endp)) ; this%hrv_deadcrootp_storage_to_litter_patch    (:) = nan
+    allocate(this%hrv_leafp_xfer_to_litter_patch            (begp:endp)) ; this%hrv_leafp_xfer_to_litter_patch            (:) = nan
+    allocate(this%hrv_frootp_xfer_to_litter_patch           (begp:endp)) ; this%hrv_frootp_xfer_to_litter_patch           (:) = nan
+    allocate(this%hrv_livestemp_xfer_to_litter_patch        (begp:endp)) ; this%hrv_livestemp_xfer_to_litter_patch        (:) = nan
+    allocate(this%hrv_deadstemp_xfer_to_litter_patch        (begp:endp)) ; this%hrv_deadstemp_xfer_to_litter_patch        (:) = nan
+    allocate(this%hrv_livecrootp_xfer_to_litter_patch       (begp:endp)) ; this%hrv_livecrootp_xfer_to_litter_patch       (:) = nan
+    allocate(this%hrv_deadcrootp_xfer_to_litter_patch       (begp:endp)) ; this%hrv_deadcrootp_xfer_to_litter_patch       (:) = nan
+    allocate(this%hrv_livestemp_to_litter_patch             (begp:endp)) ; this%hrv_livestemp_to_litter_patch             (:) = nan
+    allocate(this%hrv_deadstemp_to_prod10p_patch            (begp:endp)) ; this%hrv_deadstemp_to_prod10p_patch            (:) = nan
+    allocate(this%hrv_deadstemp_to_prod100p_patch           (begp:endp)) ; this%hrv_deadstemp_to_prod100p_patch           (:) = nan
+    allocate(this%hrv_livecrootp_to_litter_patch            (begp:endp)) ; this%hrv_livecrootp_to_litter_patch            (:) = nan
+    allocate(this%hrv_deadcrootp_to_litter_patch            (begp:endp)) ; this%hrv_deadcrootp_to_litter_patch            (:) = nan
+    allocate(this%hrv_retransp_to_litter_patch              (begp:endp)) ; this%hrv_retransp_to_litter_patch              (:) = nan
+
+    allocate(this%m_leafp_to_fire_patch                     (begp:endp)) ; this%m_leafp_to_fire_patch                     (:) = nan
+    allocate(this%m_leafp_storage_to_fire_patch             (begp:endp)) ; this%m_leafp_storage_to_fire_patch             (:) = nan
+    allocate(this%m_leafp_xfer_to_fire_patch                (begp:endp)) ; this%m_leafp_xfer_to_fire_patch                (:) = nan
+    allocate(this%m_livestemp_to_fire_patch                 (begp:endp)) ; this%m_livestemp_to_fire_patch                 (:) = nan
+    allocate(this%m_livestemp_storage_to_fire_patch         (begp:endp)) ; this%m_livestemp_storage_to_fire_patch         (:) = nan
+    allocate(this%m_livestemp_xfer_to_fire_patch            (begp:endp)) ; this%m_livestemp_xfer_to_fire_patch            (:) = nan
+    allocate(this%m_deadstemp_to_fire_patch                 (begp:endp)) ; this%m_deadstemp_to_fire_patch                 (:) = nan
+    allocate(this%m_deadstemp_storage_to_fire_patch         (begp:endp)) ; this%m_deadstemp_storage_to_fire_patch         (:) = nan
+    allocate(this%m_deadstemp_xfer_to_fire_patch            (begp:endp)) ; this%m_deadstemp_xfer_to_fire_patch            (:) = nan
+    allocate(this%m_frootp_to_fire_patch                    (begp:endp)) ; this%m_frootp_to_fire_patch                    (:) = nan
+    allocate(this%m_frootp_storage_to_fire_patch            (begp:endp)) ; this%m_frootp_storage_to_fire_patch            (:) = nan
+    allocate(this%m_frootp_xfer_to_fire_patch               (begp:endp)) ; this%m_frootp_xfer_to_fire_patch               (:) = nan
+    allocate(this%m_livecrootp_to_fire_patch                (begp:endp)) ;     
+    allocate(this%m_livecrootp_storage_to_fire_patch        (begp:endp)) ; this%m_livecrootp_storage_to_fire_patch        (:) = nan
+    allocate(this%m_livecrootp_xfer_to_fire_patch           (begp:endp)) ; this%m_livecrootp_xfer_to_fire_patch           (:) = nan
+    allocate(this%m_deadcrootp_to_fire_patch                (begp:endp)) ; this%m_deadcrootp_to_fire_patch                (:) = nan
+    allocate(this%m_deadcrootp_storage_to_fire_patch        (begp:endp)) ; this%m_deadcrootp_storage_to_fire_patch        (:) = nan
+    allocate(this%m_deadcrootp_xfer_to_fire_patch           (begp:endp)) ; this%m_deadcrootp_xfer_to_fire_patch           (:) = nan
+    allocate(this%m_retransp_to_fire_patch                  (begp:endp)) ; this%m_retransp_to_fire_patch                  (:) = nan
+
+    allocate(this%m_leafp_to_litter_fire_patch              (begp:endp)) ; this%m_leafp_to_litter_fire_patch              (:) = nan
+    allocate(this%m_leafp_storage_to_litter_fire_patch      (begp:endp)) ; this%m_leafp_storage_to_litter_fire_patch      (:) = nan
+    allocate(this%m_leafp_xfer_to_litter_fire_patch         (begp:endp)) ; this%m_leafp_xfer_to_litter_fire_patch         (:) = nan
+    allocate(this%m_livestemp_to_litter_fire_patch          (begp:endp)) ; this%m_livestemp_to_litter_fire_patch          (:) = nan
+    allocate(this%m_livestemp_storage_to_litter_fire_patch  (begp:endp)) ; this%m_livestemp_storage_to_litter_fire_patch  (:) = nan
+    allocate(this%m_livestemp_xfer_to_litter_fire_patch     (begp:endp)) ; this%m_livestemp_xfer_to_litter_fire_patch     (:) = nan
+    allocate(this%m_livestemp_to_deadstemp_fire_patch       (begp:endp)) ; this%m_livestemp_to_deadstemp_fire_patch       (:) = nan
+    allocate(this%m_deadstemp_to_litter_fire_patch          (begp:endp)) ; this%m_deadstemp_to_litter_fire_patch          (:) = nan
+    allocate(this%m_deadstemp_storage_to_litter_fire_patch  (begp:endp)) ; this%m_deadstemp_storage_to_litter_fire_patch  (:) = nan
+    allocate(this%m_deadstemp_xfer_to_litter_fire_patch     (begp:endp)) ; this%m_deadstemp_xfer_to_litter_fire_patch     (:) = nan
+    allocate(this%m_frootp_to_litter_fire_patch             (begp:endp)) ; this%m_frootp_to_litter_fire_patch             (:) = nan
+    allocate(this%m_frootp_storage_to_litter_fire_patch     (begp:endp)) ; this%m_frootp_storage_to_litter_fire_patch     (:) = nan
+    allocate(this%m_frootp_xfer_to_litter_fire_patch        (begp:endp)) ; this%m_frootp_xfer_to_litter_fire_patch        (:) = nan
+    allocate(this%m_livecrootp_to_litter_fire_patch         (begp:endp)) ; this%m_livecrootp_to_litter_fire_patch         (:) = nan
+    allocate(this%m_livecrootp_storage_to_litter_fire_patch (begp:endp)) ; this%m_livecrootp_storage_to_litter_fire_patch (:) = nan
+    allocate(this%m_livecrootp_xfer_to_litter_fire_patch    (begp:endp)) ; this%m_livecrootp_xfer_to_litter_fire_patch    (:) = nan
+    allocate(this%m_livecrootp_to_deadcrootp_fire_patch     (begp:endp)) ; this%m_livecrootp_to_deadcrootp_fire_patch     (:) = nan
+    allocate(this%m_deadcrootp_to_litter_fire_patch         (begp:endp)) ; this%m_deadcrootp_to_litter_fire_patch         (:) = nan
+    allocate(this%m_deadcrootp_storage_to_litter_fire_patch (begp:endp)) ; this%m_deadcrootp_storage_to_litter_fire_patch (:) = nan
+    allocate(this%m_deadcrootp_xfer_to_litter_fire_patch    (begp:endp)) ; this%m_deadcrootp_xfer_to_litter_fire_patch    (:) = nan
+    allocate(this%m_retransp_to_litter_fire_patch           (begp:endp)) ; this%m_retransp_to_litter_fire_patch           (:) = nan
+
+    allocate(this%leafp_xfer_to_leafp_patch                 (begp:endp)) ; this%leafp_xfer_to_leafp_patch                 (:) = nan
+    allocate(this%frootp_xfer_to_frootp_patch               (begp:endp)) ; this%frootp_xfer_to_frootp_patch               (:) = nan
+    allocate(this%livestemp_xfer_to_livestemp_patch         (begp:endp)) ; this%livestemp_xfer_to_livestemp_patch         (:) = nan
+    allocate(this%deadstemp_xfer_to_deadstemp_patch         (begp:endp)) ; this%deadstemp_xfer_to_deadstemp_patch         (:) = nan
+    allocate(this%livecrootp_xfer_to_livecrootp_patch       (begp:endp)) ; this%livecrootp_xfer_to_livecrootp_patch       (:) = nan
+    allocate(this%deadcrootp_xfer_to_deadcrootp_patch       (begp:endp)) ; this%deadcrootp_xfer_to_deadcrootp_patch       (:) = nan
+    allocate(this%leafp_to_litter_patch                     (begp:endp)) ; this%leafp_to_litter_patch                     (:) = nan
+    allocate(this%leafp_to_retransp_patch                   (begp:endp)) ; this%leafp_to_retransp_patch                   (:) = nan
+    allocate(this%frootp_to_retransp_patch                  (begp:endp)) ; this%frootp_to_retransp_patch                  (:) = nan
+    allocate(this%frootp_to_litter_patch                    (begp:endp)) ; this%frootp_to_litter_patch                    (:) = nan
+    allocate(this%retransp_to_ppool_patch                   (begp:endp)) ; this%retransp_to_ppool_patch                   (:) = nan
+    allocate(this%sminp_to_ppool_patch                      (begp:endp)) ; this%sminp_to_ppool_patch                      (:) = nan
+
+    allocate(this%ppool_to_leafp_patch              (begp:endp)) ; this%ppool_to_leafp_patch              (:) = nan
+    allocate(this%ppool_to_leafp_storage_patch      (begp:endp)) ; this%ppool_to_leafp_storage_patch      (:) = nan
+    allocate(this%ppool_to_frootp_patch             (begp:endp)) ; this%ppool_to_frootp_patch             (:) = nan
+    allocate(this%ppool_to_frootp_storage_patch     (begp:endp)) ; this%ppool_to_frootp_storage_patch     (:) = nan
+    allocate(this%ppool_to_livestemp_patch          (begp:endp)) ; this%ppool_to_livestemp_patch          (:) = nan
+    allocate(this%ppool_to_livestemp_storage_patch  (begp:endp)) ; this%ppool_to_livestemp_storage_patch  (:) = nan
+    allocate(this%ppool_to_deadstemp_patch          (begp:endp)) ; this%ppool_to_deadstemp_patch          (:) = nan
+    allocate(this%ppool_to_deadstemp_storage_patch  (begp:endp)) ; this%ppool_to_deadstemp_storage_patch  (:) = nan
+    allocate(this%ppool_to_livecrootp_patch         (begp:endp)) ; this%ppool_to_livecrootp_patch         (:) = nan
+    allocate(this%ppool_to_livecrootp_storage_patch (begp:endp)) ; this%ppool_to_livecrootp_storage_patch (:) = nan
+    allocate(this%ppool_to_deadcrootp_patch         (begp:endp)) ; this%ppool_to_deadcrootp_patch         (:) = nan
+    allocate(this%ppool_to_deadcrootp_storage_patch (begp:endp)) ; this%ppool_to_deadcrootp_storage_patch (:) = nan
+    allocate(this%leafp_storage_to_xfer_patch       (begp:endp)) ; this%leafp_storage_to_xfer_patch       (:) = nan
+    allocate(this%frootp_storage_to_xfer_patch      (begp:endp)) ; this%frootp_storage_to_xfer_patch      (:) = nan
+    allocate(this%livestemp_storage_to_xfer_patch   (begp:endp)) ; this%livestemp_storage_to_xfer_patch   (:) = nan
+    allocate(this%deadstemp_storage_to_xfer_patch   (begp:endp)) ; this%deadstemp_storage_to_xfer_patch   (:) = nan
+    allocate(this%livecrootp_storage_to_xfer_patch  (begp:endp)) ; this%livecrootp_storage_to_xfer_patch  (:) = nan
+    allocate(this%deadcrootp_storage_to_xfer_patch  (begp:endp)) ; this%deadcrootp_storage_to_xfer_patch  (:) = nan
+    allocate(this%livestemp_to_deadstemp_patch      (begp:endp)) ; this%livestemp_to_deadstemp_patch      (:) = nan
+    allocate(this%livestemp_to_retransp_patch       (begp:endp)) ; this%livestemp_to_retransp_patch       (:) = nan
+    allocate(this%livecrootp_to_deadcrootp_patch    (begp:endp)) ; this%livecrootp_to_deadcrootp_patch    (:) = nan
+    allocate(this%livecrootp_to_retransp_patch      (begp:endp)) ; this%livecrootp_to_retransp_patch      (:) = nan
+    allocate(this%pdeploy_patch                     (begp:endp)) ; this%pdeploy_patch                     (:) = nan
+    allocate(this%pinputs_patch                     (begp:endp)) ; this%pinputs_patch                     (:) = nan
+    allocate(this%poutputs_patch                    (begp:endp)) ; this%poutputs_patch                    (:) = nan
+    allocate(this%wood_harvestp_patch               (begp:endp)) ; this%wood_harvestp_patch               (:) = nan
+    allocate(this%fire_ploss_patch                  (begp:endp)) ; this%fire_ploss_patch                  (:) = nan
+    allocate(this%ppool_to_grainp_patch             (begp:endp)) ; this%ppool_to_grainp_patch             (:) = nan
+    allocate(this%ppool_to_grainp_storage_patch     (begp:endp)) ; this%ppool_to_grainp_storage_patch     (:) = nan
+    allocate(this%livestemp_to_litter_patch         (begp:endp)) ; this%livestemp_to_litter_patch         (:) = nan
+    allocate(this%grainp_to_food_patch              (begp:endp)) ; this%grainp_to_food_patch              (:) = nan
+    allocate(this%grainp_xfer_to_grainp_patch       (begp:endp)) ; this%grainp_xfer_to_grainp_patch       (:) = nan
+    allocate(this%grainp_storage_to_xfer_patch      (begp:endp)) ; this%grainp_storage_to_xfer_patch      (:) = nan
+    allocate(this%fert_p_patch                      (begp:endp)) ; this%fert_p_patch                      (:) = nan
+    allocate(this%fert_counter_patch                (begp:endp)) ; this%fert_counter_patch                (:) = nan
+
+    allocate(this%pdep_to_sminp_col             (begc:endc))    ; this%pdep_to_sminp_col	     (:) = nan
+    allocate(this%fert_p_to_sminp_col             (begc:endc))    ; this%fert_p_to_sminp_col	     (:) = nan
+    allocate(this%hrv_deadstemp_to_prod10p_col  (begc:endc))    ; this%hrv_deadstemp_to_prod10p_col  (:) = nan
+    allocate(this%hrv_deadstemp_to_prod100p_col (begc:endc))    ; this%hrv_deadstemp_to_prod100p_col (:) = nan
+    allocate(this%sminp_to_plant_col            (begc:endc))    ; this%sminp_to_plant_col	     (:) = nan
+    allocate(this%potential_immob_p_col           (begc:endc))    ; this%potential_immob_p_col           (:) = nan
+    allocate(this%actual_immob_p_col              (begc:endc))    ; this%actual_immob_p_col              (:) = nan
+    allocate(this%gross_pmin_col                (begc:endc))    ; this%gross_pmin_col                (:) = nan
+    allocate(this%net_pmin_col                  (begc:endc))    ; this%net_pmin_col                  (:) = nan
+    allocate(this%supplement_to_sminp_col       (begc:endc))    ; this%supplement_to_sminp_col       (:) = nan
+    allocate(this%prod10p_loss_col              (begc:endc))    ; this%prod10p_loss_col              (:) = nan
+    allocate(this%prod100p_loss_col             (begc:endc))    ; this%prod100p_loss_col	     (:) = nan
+    allocate(this%product_ploss_col             (begc:endc))    ; this%product_ploss_col	     (:) = nan
+    allocate(this%pinputs_col                   (begc:endc))    ; this%pinputs_col                   (:) = nan
+    allocate(this%poutputs_col                  (begc:endc))    ; this%poutputs_col                  (:) = nan
+    allocate(this%fire_ploss_col                (begc:endc))    ; this%fire_ploss_col                (:) = nan
+    allocate(this%fire_ploss_p2c_col            (begc:endc))    ; this%fire_ploss_p2c_col            (:) = nan
+    allocate(this%som_p_leached_col             (begc:endc))    ; this%som_p_leached_col	     (:) = nan
+
+    allocate(this%m_p_to_litr_met_fire_col   (begc:endc,1:nlevdecomp_full)) ; this%m_p_to_litr_met_fire_col   (:,:) = nan
+    allocate(this%m_p_to_litr_cel_fire_col   (begc:endc,1:nlevdecomp_full)) ; this%m_p_to_litr_cel_fire_col   (:,:) = nan
+    allocate(this%m_p_to_litr_lig_fire_col   (begc:endc,1:nlevdecomp_full)) ; this%m_p_to_litr_lig_fire_col   (:,:) = nan
+    allocate(this%potential_immob_p_vr_col   (begc:endc,1:nlevdecomp_full)) ; this%potential_immob_p_vr_col     (:,:) = nan
+    allocate(this%actual_immob_p_vr_col      (begc:endc,1:nlevdecomp_full)) ; this%actual_immob_p_vr_col        (:,:) = nan
+    allocate(this%sminp_to_plant_vr_col      (begc:endc,1:nlevdecomp_full)) ; this%sminp_to_plant_vr_col      (:,:) = nan
+    allocate(this%supplement_to_sminp_vr_col (begc:endc,1:nlevdecomp_full)) ; this%supplement_to_sminp_vr_col (:,:) = nan
+    allocate(this%gross_pmin_vr_col          (begc:endc,1:nlevdecomp_full)) ; this%gross_pmin_vr_col          (:,:) = nan
+    allocate(this%net_pmin_vr_col            (begc:endc,1:nlevdecomp_full)) ; this%net_pmin_vr_col            (:,:) = nan
+
+    allocate(this%biochem_pmin_ppools_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))
+    allocate(this%biochem_pmin_vr_col       (begc:endc,1:nlevdecomp_full))
+    allocate(this%biochem_pmin_col          (begc:endc))
+
+    this%biochem_pmin_ppools_vr_col  (:,:,:) = nan
+    this%biochem_pmin_vr_col         (:,:) = nan
+    this%biochem_pmin_col            (:) = nan
+
+    allocate(this%dwt_seedp_to_leaf_col      (begc:endc))                   ; this%dwt_seedp_to_leaf_col      (:)   = nan
+    allocate(this%dwt_seedp_to_deadstem_col  (begc:endc))                   ; this%dwt_seedp_to_deadstem_col  (:)   = nan
+    allocate(this%dwt_conv_pflux_col         (begc:endc))                   ; this%dwt_conv_pflux_col         (:)   = nan
+    allocate(this%dwt_prod10p_gain_col       (begc:endc))                   ; this%dwt_prod10p_gain_col       (:)   = nan
+    allocate(this%dwt_prod100p_gain_col      (begc:endc))                   ; this%dwt_prod100p_gain_col      (:)   = nan
+    allocate(this%dwt_ploss_col              (begc:endc))                   ; this%dwt_ploss_col              (:)   = nan
+    allocate(this%wood_harvestp_col          (begc:endc))                   ; this%wood_harvestp_col          (:)   = nan
+
+    allocate(this%dwt_frootp_to_litr_met_p_col(begc:endc,1:nlevdecomp_full)) ; this%dwt_frootp_to_litr_met_p_col     (:,:) = nan
+    allocate(this%dwt_frootp_to_litr_cel_p_col(begc:endc,1:nlevdecomp_full)) ; this%dwt_frootp_to_litr_cel_p_col     (:,:) = nan
+    allocate(this%dwt_frootp_to_litr_lig_p_col(begc:endc,1:nlevdecomp_full)) ; this%dwt_frootp_to_litr_lig_p_col     (:,:) = nan
+    allocate(this%dwt_livecrootp_to_cwdp_col  (begc:endc,1:nlevdecomp_full)) ; this%dwt_livecrootp_to_cwdp_col       (:,:) = nan
+    allocate(this%dwt_deadcrootp_to_cwdp_col  (begc:endc,1:nlevdecomp_full)) ; this%dwt_deadcrootp_to_cwdp_col       (:,:) = nan
+
+
+    allocate(this%decomp_cascade_ptransfer_vr_col   (begc:endc,1:nlevdecomp_full,1:ndecomp_cascade_transitions ))
+    allocate(this%decomp_cascade_sminp_flux_vr_col  (begc:endc,1:nlevdecomp_full,1:ndecomp_cascade_transitions ))
+    allocate(this%m_decomp_ppools_to_fire_vr_col    (begc:endc,1:nlevdecomp_full,1:ndecomp_pools               ))
+    allocate(this%decomp_cascade_ptransfer_col      (begc:endc,1:ndecomp_cascade_transitions                   ))
+    allocate(this%decomp_cascade_sminp_flux_col     (begc:endc,1:ndecomp_cascade_transitions                   ))
+    allocate(this%m_decomp_ppools_to_fire_col       (begc:endc,1:ndecomp_pools                                 ))
+
+    this%decomp_cascade_ptransfer_vr_col  (:,:,:) = nan
+    this%decomp_cascade_sminp_flux_vr_col (:,:,:) = nan
+    this%m_decomp_ppools_to_fire_vr_col   (:,:,:) = nan
+    this%m_decomp_ppools_to_fire_col      (:,:)   = nan
+    this%decomp_cascade_ptransfer_col     (:,:)   = nan
+    this%decomp_cascade_sminp_flux_col    (:,:)   = nan
+
+    allocate(this%phenology_p_to_litr_met_p_col     (begc:endc, 1:nlevdecomp_full))
+    allocate(this%phenology_p_to_litr_cel_p_col     (begc:endc, 1:nlevdecomp_full))
+    allocate(this%phenology_p_to_litr_lig_p_col     (begc:endc, 1:nlevdecomp_full))
+    allocate(this%gap_mortality_p_to_litr_met_p_col (begc:endc, 1:nlevdecomp_full))
+    allocate(this%gap_mortality_p_to_litr_cel_p_col (begc:endc, 1:nlevdecomp_full))
+    allocate(this%gap_mortality_p_to_litr_lig_p_col (begc:endc, 1:nlevdecomp_full))
+    allocate(this%gap_mortality_p_to_cwdp_col       (begc:endc, 1:nlevdecomp_full))
+    allocate(this%fire_mortality_p_to_cwdp_col      (begc:endc, 1:nlevdecomp_full))
+    allocate(this%harvest_p_to_litr_met_p_col       (begc:endc, 1:nlevdecomp_full))
+    allocate(this%harvest_p_to_litr_cel_p_col       (begc:endc, 1:nlevdecomp_full))
+    allocate(this%harvest_p_to_litr_lig_p_col       (begc:endc, 1:nlevdecomp_full))
+    allocate(this%harvest_p_to_cwdp_col             (begc:endc, 1:nlevdecomp_full))
+
+    this%phenology_p_to_litr_met_p_col     (:,:) = nan
+    this%phenology_p_to_litr_cel_p_col     (:,:) = nan
+    this%phenology_p_to_litr_lig_p_col     (:,:) = nan
+    this%gap_mortality_p_to_litr_met_p_col (:,:) = nan
+    this%gap_mortality_p_to_litr_cel_p_col (:,:) = nan
+    this%gap_mortality_p_to_litr_lig_p_col (:,:) = nan
+    this%gap_mortality_p_to_cwdp_col       (:,:) = nan
+    this%fire_mortality_p_to_cwdp_col      (:,:) = nan
+    this%harvest_p_to_litr_met_p_col       (:,:) = nan
+    this%harvest_p_to_litr_cel_p_col       (:,:) = nan
+    this%harvest_p_to_litr_lig_p_col       (:,:) = nan
+    this%harvest_p_to_cwdp_col             (:,:) = nan
+
+
+    
+    allocate(this%primp_to_labilep_vr_col                 (begc:endc,1:nlevdecomp_full                               ))
+    allocate(this%primp_to_labilep_col                    (begc:endc                                                 ))
+    allocate(this%labilep_to_secondp_vr_col                 (begc:endc,1:nlevdecomp_full                               ))
+    allocate(this%labilep_to_secondp_col                    (begc:endc                                                 ))
+    allocate(this%secondp_to_labilep_vr_col                 (begc:endc,1:nlevdecomp_full                               ))
+    allocate(this%secondp_to_labilep_col                    (begc:endc                                                 ))
+    allocate(this%secondp_to_occlp_vr_col                 (begc:endc,1:nlevdecomp_full                               ))
+    allocate(this%secondp_to_occlp_col                    (begc:endc                                                 ))
+
+    this%primp_to_labilep_vr_col                 (:,:)   = nan
+    this%primp_to_labilep_col                    (:)     = nan
+    this%labilep_to_secondp_vr_col                 (:,:)   = nan
+    this%labilep_to_secondp_col                    (:)     = nan
+    this%secondp_to_labilep_vr_col                 (:,:)   = nan
+    this%secondp_to_labilep_col                    (:)     = nan
+    this%secondp_to_occlp_vr_col                 (:,:)   = nan
+    this%secondp_to_occlp_col                    (:)     = nan
+
+    allocate(this%sminp_leached_vr_col                 (begc:endc,1:nlevdecomp_full                               ))
+    allocate(this%sminp_leached_col                    (begc:endc                                                 ))
+    allocate(this%decomp_ppools_leached_col            (begc:endc,1:ndecomp_pools                                 ))
+    allocate(this%decomp_ppools_transport_tendency_col (begc:endc,1:nlevdecomp_full,1:ndecomp_pools               ))
+
+    this%sminp_leached_vr_col                 (:,:)   = nan
+    this%sminp_leached_col                    (:)     = nan
+    this%decomp_ppools_leached_col            (:,:)   = nan
+    this%decomp_ppools_transport_tendency_col (:,:,:) = nan  
+
+    allocate(this%decomp_ppools_sourcesink_col (begc:endc,1:nlevdecomp_full,1:ndecomp_pools))
+    this%decomp_ppools_sourcesink_col (:,:,:) = nan
+
+    allocate(this%plant_pdemand_patch         (begp:endp)) ;    this%plant_pdemand_patch         (:) = nan
+    allocate(this%avail_retransp_patch        (begp:endp)) ;    this%avail_retransp_patch        (:) = nan
+    allocate(this%plant_palloc_patch          (begp:endp)) ;    this%plant_palloc_patch          (:) = nan
+
+  end subroutine InitAllocate
+
+  !------------------------------------------------------------------------
+  subroutine InitHistory(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Initialize module data structure
+    !
+    ! !USES:
+    use shr_infnan_mod , only : nan => shr_infnan_nan, assignment(=)
+    use clm_varpar     , only : nlevsno, nlevgrnd, crop_prog 
+    use histFileMod    , only : hist_addfld1d, hist_addfld2d, hist_addfld_decomp
+    !
+    ! !ARGUMENTS:
+    class(phosphorusflux_type) :: this
+    type(bounds_type), intent(in) :: bounds  
+    !
+    ! !LOCAL VARIABLES:
+    integer        :: k,l
+    integer        :: begp, endp
+    integer        :: begc, endc
+    character(10)  :: active
+    character(24)  :: fieldname
+    character(100) :: longname
+    character(8)   :: vr_suffix
+    character(1)   :: aa 
+    real(r8), pointer :: data2dptr(:,:), data1dptr(:) ! temp. pointers for slicing larger arrays
+    !------------------------------------------------------------------------
+
+    begp = bounds%begp; endp= bounds%endp
+    begc = bounds%begc; endc= bounds%endc
+
+    ! add suffix if number of soil decomposition depths is greater than 1
+    if (nlevdecomp > 1) then
+       vr_suffix = "_vr"
+    else 
+       vr_suffix = ""
+    endif
+
+    this%m_leafp_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LEAFP_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P mortality', &
+         ptr_patch=this%m_leafp_to_litter_patch, default='inactive')
+
+    this%m_frootp_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_FROOTP_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='fine root P mortality', &
+         ptr_patch=this%m_frootp_to_litter_patch, default='inactive')
+
+    this%m_leafp_storage_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LEAFP_STORAGE_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P storage mortality', &
+         ptr_patch=this%m_leafp_storage_to_litter_patch, default='inactive')
+
+    this%m_frootp_storage_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_FROOTP_STORAGE_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='fine root P storage mortality', &
+         ptr_patch=this%m_frootp_storage_to_litter_patch, default='inactive')
+
+    this%m_livestemp_storage_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVESTEMP_STORAGE_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P storage mortality', &
+         ptr_patch=this%m_livestemp_storage_to_litter_patch, default='inactive')
+
+    this%m_deadstemp_storage_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADSTEMP_STORAGE_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='dead stem P storage mortality', &
+         ptr_patch=this%m_deadstemp_storage_to_litter_patch, default='inactive')
+
+    this%m_livecrootp_storage_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVECROOTP_STORAGE_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P storage mortality', &
+         ptr_patch=this%m_livecrootp_storage_to_litter_patch, default='inactive')
+
+    this%m_deadcrootp_storage_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADCROOTP_STORAGE_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='dead coarse root P storage mortality', &
+         ptr_patch=this%m_deadcrootp_storage_to_litter_patch, default='inactive')
+
+    this%m_leafp_xfer_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LEAFP_XFER_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P transfer mortality', &
+         ptr_patch=this%m_leafp_xfer_to_litter_patch, default='inactive')
+
+    this%m_frootp_xfer_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_FROOTP_XFER_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='fine root P transfer mortality', &
+         ptr_patch=this%m_frootp_xfer_to_litter_patch, default='inactive')
+
+    this%m_livestemp_xfer_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVESTEMP_XFER_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P transfer mortality', &
+         ptr_patch=this%m_livestemp_xfer_to_litter_patch, default='inactive')
+
+    this%m_deadstemp_xfer_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADSTEMP_XFER_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='dead stem P transfer mortality', &
+         ptr_patch=this%m_deadstemp_xfer_to_litter_patch, default='inactive')
+
+    this%m_livecrootp_xfer_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVECROOTP_XFER_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P transfer mortality', &
+         ptr_patch=this%m_livecrootp_xfer_to_litter_patch, default='inactive')
+
+    this%m_deadcrootp_xfer_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADCROOTP_XFER_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='dead coarse root P transfer mortality', &
+         ptr_patch=this%m_deadcrootp_xfer_to_litter_patch, default='inactive')
+
+    this%m_livestemp_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVESTEMP_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P mortality', &
+         ptr_patch=this%m_livestemp_to_litter_patch, default='inactive')
+
+    this%m_deadstemp_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADSTEMP_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='dead stem P mortality', &
+         ptr_patch=this%m_deadstemp_to_litter_patch, default='inactive')
+
+    this%m_livecrootp_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVECROOTP_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P mortality', &
+         ptr_patch=this%m_livecrootp_to_litter_patch, default='inactive')
+
+    this%m_deadcrootp_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADCROOTP_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='dead coarse root P mortality', &
+         ptr_patch=this%m_deadcrootp_to_litter_patch, default='inactive')
+
+    this%m_retransp_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_RETRANSP_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='retranslocated P pool mortality', &
+         ptr_patch=this%m_retransp_to_litter_patch, default='inactive')
+
+    this%m_leafp_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LEAFP_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P fire loss', &
+         ptr_patch=this%m_leafp_to_fire_patch, default='inactive')
+
+    this%m_frootp_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_FROOTP_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='fine root P fire loss ', &
+         ptr_patch=this%m_frootp_to_fire_patch, default='inactive')
+
+    this%m_leafp_storage_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LEAFP_STORAGE_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P storage fire loss', &
+         ptr_patch=this%m_leafp_storage_to_fire_patch, default='inactive')
+
+    this%m_frootp_storage_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_FROOTP_STORAGE_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='fine root P storage fire loss', &
+         ptr_patch=this%m_frootp_storage_to_fire_patch, default='inactive')
+
+    this%m_livestemp_storage_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVESTEMP_STORAGE_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P storage fire loss', &
+         ptr_patch=this%m_livestemp_storage_to_fire_patch, default='inactive')
+
+    this%m_deadstemp_storage_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADSTEMP_STORAGE_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='dead stem P storage fire loss', &
+         ptr_patch=this%m_deadstemp_storage_to_fire_patch, default='inactive')
+
+    this%m_livecrootp_storage_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVECROOTP_STORAGE_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P storage fire loss', &
+         ptr_patch=this%m_livecrootp_storage_to_fire_patch, default='inactive')
+
+    this%m_deadcrootp_storage_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADCROOTP_STORAGE_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='dead coarse root P storage fire loss', &
+         ptr_patch=this%m_deadcrootp_storage_to_fire_patch, default='inactive')
+
+    this%m_leafp_xfer_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LEAFP_XFER_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P transfer fire loss', &
+         ptr_patch=this%m_leafp_xfer_to_fire_patch, default='inactive')
+
+    this%m_frootp_xfer_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_FROOTP_XFER_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='fine root P transfer fire loss', &
+         ptr_patch=this%m_frootp_xfer_to_fire_patch, default='inactive')
+
+    this%m_livestemp_xfer_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVESTEMP_XFER_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P transfer fire loss', &
+         ptr_patch=this%m_livestemp_xfer_to_fire_patch, default='inactive')
+
+    this%m_deadstemp_xfer_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADSTEMP_XFER_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='dead stem P transfer fire loss', &
+         ptr_patch=this%m_deadstemp_xfer_to_fire_patch, default='inactive')
+
+    this%m_livecrootp_xfer_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVECROOTP_XFER_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P transfer fire loss', &
+         ptr_patch=this%m_livecrootp_xfer_to_fire_patch, default='inactive')
+
+    this%m_deadcrootp_xfer_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADCROOTP_XFER_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='dead coarse root P transfer fire loss', &
+         ptr_patch=this%m_deadcrootp_xfer_to_fire_patch, default='inactive')
+
+    this%m_livestemp_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVESTEMP_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P fire loss', &
+         ptr_patch=this%m_livestemp_to_fire_patch, default='inactive')
+
+    this%m_deadstemp_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADSTEMP_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='dead stem P fire loss', &
+         ptr_patch=this%m_deadstemp_to_fire_patch, default='inactive')
+
+    this%m_deadstemp_to_litter_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADSTEMP_TO_LITTER_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='dead stem P fire mortality to litter', &
+         ptr_patch=this%m_deadstemp_to_litter_fire_patch, default='inactive')
+
+    this%m_livecrootp_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVECROOTP_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P fire loss', &
+         ptr_patch=this%m_livecrootp_to_fire_patch, default='inactive')
+
+    this%m_deadcrootp_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADCROOTP_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='dead coarse root P fire loss', &
+         ptr_patch=this%m_deadcrootp_to_fire_patch, default='inactive')
+
+    this%m_deadcrootp_to_litter_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_DEADCROOTP_TO_LITTER_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='dead coarse root P fire mortality to litter', &
+         ptr_patch=this%m_deadcrootp_to_litter_fire_patch, default='inactive')
+
+    this%m_retransp_to_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_RETRANSP_TO_FIRE', units='gP/m^2/s', &
+         avgflag='A', long_name='retranslocated P pool fire loss', &
+         ptr_patch=this%m_retransp_to_fire_patch, default='inactive')
+
+    this%leafp_xfer_to_leafp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LEAFP_XFER_TO_LEAFP', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P growth from storage', &
+         ptr_patch=this%leafp_xfer_to_leafp_patch, default='inactive')
+
+    this%frootp_xfer_to_frootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='FROOTP_XFER_TO_FROOTP', units='gP/m^2/s', &
+         avgflag='A', long_name='fine root P growth from storage', &
+         ptr_patch=this%frootp_xfer_to_frootp_patch, default='inactive')
+
+    this%livestemp_xfer_to_livestemp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMP_XFER_TO_LIVESTEMP', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P growth from storage', &
+         ptr_patch=this%livestemp_xfer_to_livestemp_patch, default='inactive')
+
+    this%deadstemp_xfer_to_deadstemp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADSTEMP_XFER_TO_DEADSTEMP', units='gP/m^2/s', &
+         avgflag='A', long_name='dead stem P growth from storage', &
+         ptr_patch=this%deadstemp_xfer_to_deadstemp_patch, default='inactive')
+
+    this%livecrootp_xfer_to_livecrootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVECROOTP_XFER_TO_LIVECROOTP', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P growth from storage', &
+         ptr_patch=this%livecrootp_xfer_to_livecrootp_patch, default='inactive')
+
+    this%deadcrootp_xfer_to_deadcrootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADCROOTP_XFER_TO_DEADCROOTP', units='gP/m^2/s', &
+         avgflag='A', long_name='dead coarse root P growth from storage', &
+         ptr_patch=this%deadcrootp_xfer_to_deadcrootp_patch, default='inactive')
+
+    this%leafp_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LEAFP_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P litterfall', &
+         ptr_patch=this%leafp_to_litter_patch, default='inactive')
+
+    this%leafp_to_retransp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LEAFP_TO_RETRANSP', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P to retranslocated P pool', &
+         ptr_patch=this%leafp_to_retransp_patch, default='inactive')
+
+    this%frootp_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='FROOTP_TO_LITTER', units='gP/m^2/s', &
+         avgflag='A', long_name='fine root P litterfall', &
+         ptr_patch=this%frootp_to_litter_patch, default='inactive')
+
+    this%retransp_to_ppool_patch(begp:endp) = spval
+    call hist_addfld1d (fname='RETRANSP_TO_PPOOL', units='gP/m^2/s', &
+         avgflag='A', long_name='deployment of retranslocated P', &
+         ptr_patch=this%retransp_to_ppool_patch)
+
+    this%sminp_to_ppool_patch(begp:endp) = spval
+    call hist_addfld1d (fname='SMIPP_TO_NPOOL', units='gP/m^2/s', &
+         avgflag='A', long_name='deployment of soil mineral P uptake', &
+         ptr_patch=this%sminp_to_ppool_patch)
+
+    this%ppool_to_leafp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_LEAFP', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to leaf P', &
+         ptr_patch=this%ppool_to_leafp_patch, default='inactive')
+
+    this%ppool_to_leafp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_LEAFP_STORAGE', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to leaf P storage', &
+         ptr_patch=this%ppool_to_leafp_storage_patch, default='inactive')
+
+    this%ppool_to_frootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_FROOTP', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to fine root P', &
+         ptr_patch=this%ppool_to_frootp_patch, default='inactive')
+
+    this%ppool_to_frootp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_FROOTP_STORAGE', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to fine root P storage', &
+         ptr_patch=this%ppool_to_frootp_storage_patch, default='inactive')
+
+    this%ppool_to_livestemp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_LIVESTEMP', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to live stem P', &
+         ptr_patch=this%ppool_to_livestemp_patch, default='inactive')
+
+    this%ppool_to_livestemp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_LIVESTEMP_STORAGE', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to live stem P storage', &
+         ptr_patch=this%ppool_to_livestemp_storage_patch, default='inactive')
+
+    this%ppool_to_deadstemp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_DEADSTEMP', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to dead stem P', &
+         ptr_patch=this%ppool_to_deadstemp_patch, default='inactive')
+
+    this%ppool_to_deadstemp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_DEADSTEMP_STORAGE', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to dead stem P storage', &
+         ptr_patch=this%ppool_to_deadstemp_storage_patch, default='inactive')
+
+    this%ppool_to_livecrootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_LIVECROOTP', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to live coarse root P', &
+         ptr_patch=this%ppool_to_livecrootp_patch, default='inactive')
+
+    this%ppool_to_livecrootp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_LIVECROOTP_STORAGE', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to live coarse root P storage', &
+         ptr_patch=this%ppool_to_livecrootp_storage_patch, default='inactive')
+
+    this%ppool_to_deadcrootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_DEADCROOTP', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to dead coarse root P', &
+         ptr_patch=this%ppool_to_deadcrootp_patch, default='inactive')
+
+    this%ppool_to_deadcrootp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL_TO_DEADCROOTP_STORAGE', units='gP/m^2/s', &
+         avgflag='A', long_name='allocation to dead coarse root P storage', &
+         ptr_patch=this%ppool_to_deadcrootp_storage_patch, default='inactive')
+
+    this%leafp_storage_to_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LEAFP_STORAGE_TO_XFER', units='gP/m^2/s', &
+         avgflag='A', long_name='leaf P shift storage to transfer', &
+         ptr_patch=this%leafp_storage_to_xfer_patch, default='inactive')
+
+    this%frootp_storage_to_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='FROOTP_STORAGE_TO_XFER', units='gP/m^2/s', &
+         avgflag='A', long_name='fine root P shift storage to transfer', &
+         ptr_patch=this%frootp_storage_to_xfer_patch, default='inactive')
+
+    this%livestemp_storage_to_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMP_STORAGE_TO_XFER', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P shift storage to transfer', &
+         ptr_patch=this%livestemp_storage_to_xfer_patch, default='inactive')
+
+    this%deadstemp_storage_to_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADSTEMP_STORAGE_TO_XFER', units='gP/m^2/s', &
+         avgflag='A', long_name='dead stem P shift storage to transfer', &
+         ptr_patch=this%deadstemp_storage_to_xfer_patch, default='inactive')
+
+    this%livecrootp_storage_to_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVECROOTP_STORAGE_TO_XFER', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P shift storage to transfer', &
+         ptr_patch=this%livecrootp_storage_to_xfer_patch, default='inactive')
+
+    this%deadcrootp_storage_to_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADCROOTP_STORAGE_TO_XFER', units='gP/m^2/s', &
+         avgflag='A', long_name='dead coarse root P shift storage to transfer', &
+         ptr_patch=this%deadcrootp_storage_to_xfer_patch, default='inactive')
+
+    this%livestemp_to_deadstemp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMP_TO_DEADSTEMP', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P turnover', &
+         ptr_patch=this%livestemp_to_deadstemp_patch, default='inactive')
+
+    this%livestemp_to_retransp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMP_TO_RETRANSP', units='gP/m^2/s', &
+         avgflag='A', long_name='live stem P to retranslocated P pool', &
+         ptr_patch=this%livestemp_to_retransp_patch, default='inactive')
+
+    this%livecrootp_to_deadcrootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVECROOTP_TO_DEADCROOTP', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P turnover', &
+         ptr_patch=this%livecrootp_to_deadcrootp_patch, default='inactive')
+
+    this%livecrootp_to_retransp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVECROOTP_TO_RETRANSP', units='gP/m^2/s', &
+         avgflag='A', long_name='live coarse root P to retranslocated N pool', &
+         ptr_patch=this%livecrootp_to_retransp_patch, default='inactive')
+
+    this%pdeploy_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PDEPLOY', units='gP/m^2/s', &
+         avgflag='A', long_name='total P deployed in new growth', &
+         ptr_patch=this%pdeploy_patch)
+
+    this%wood_harvestp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='WOOD_HARVESTP', units='gP/m^2/s', &
+         avgflag='A', long_name='wood harvest P (to product pools)', &
+         ptr_patch=this%wood_harvestp_patch)
+
+    this%fire_ploss_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PFT_FIRE_PLOSS', units='gP/m^2/s', &
+         avgflag='A', long_name='total pft-level fire P loss', &
+         ptr_patch=this%fire_ploss_patch)
+
+    if (crop_prog) then
+       this%fert_p_patch(begp:endp) = spval
+       call hist_addfld1d (fname='FERT_P', units='gP/m^2/s', &
+            avgflag='A', long_name='fertilizer P added', &
+            ptr_patch=this%fert_p_patch)
+    end if
+
+
+    if (crop_prog) then
+       this%fert_counter_patch(begp:endp) = spval
+       call hist_addfld1d (fname='FERT_COUNTER', units='seconds', &
+            avgflag='A', long_name='time left to fertilize', &
+            ptr_patch=this%fert_counter_patch)
+    end if
+
+    !-------------------------------
+    ! P flux variables - native to column
+    !-------------------------------
+
+    this%pdep_to_sminp_col(begc:endc) = spval
+    call hist_addfld1d (fname='PDEP_TO_SMINP', units='gP/m^2/s', &
+         avgflag='A', long_name='atmospheric P deposition to soil mineral P', &
+         ptr_col=this%pdep_to_sminp_col)
+
+
+    do k = 1, ndecomp_pools
+       if ( decomp_cascade_con%is_litter(k) .or. decomp_cascade_con%is_cwd(k) ) then
+          this%m_decomp_ppools_to_fire_col(begc:endc,k) = spval
+          data1dptr => this%m_decomp_ppools_to_fire_col(:,k)
+          fieldname = 'M_'//trim(decomp_cascade_con%decomp_pool_name_history(k))//'P_TO_FIRE'
+          longname =  trim(decomp_cascade_con%decomp_pool_name_long(k))//' P fire loss'
+          call hist_addfld1d (fname=fieldname, units='gP/m^2',  &
+               avgflag='A', long_name=longname, &
+               ptr_col=data1dptr, default='inactive')
+
+          if ( nlevdecomp_full > 1 ) then
+             this%m_decomp_ppools_to_fire_vr_col(begc:endc,:,k) = spval
+             data2dptr => this%m_decomp_ppools_to_fire_vr_col(:,:,k)
+             fieldname = 'M_'//trim(decomp_cascade_con%decomp_pool_name_history(k))//'P_TO_FIRE'//trim(vr_suffix)
+             longname =  trim(decomp_cascade_con%decomp_pool_name_long(k))//' P fire loss'
+             call hist_addfld_decomp (fname=fieldname, units='gP/m^3',  type2d='levdcmp', &
+                  avgflag='A', long_name=longname, &
+                  ptr_col=data2dptr, default='inactive')
+          endif
+       endif
+
+       !! biochemical P mineralization for each soil pool at each soil level for
+       !! each column
+       if ( k >= 5 )then
+
+          if ( nlevdecomp_full > 1 ) then
+             this%biochem_pmin_ppools_vr_col(begc:endc,:,k) = spval
+             data2dptr => this%biochem_pmin_ppools_vr_col(:,:,k)
+             write(aa,'(i1)') k 
+             fieldname = 'BIOCHEM_PMIN_PPOOL'//aa//trim(vr_suffix)
+             longname  = 'Biochemical mineralization of ppool'//aa
+             call hist_addfld_decomp (fname=fieldname, units='gP/m^2/s',type2d='levdcmp', &
+                  avgflag='A', long_name=longname, &
+                  ptr_col=data2dptr, default='inactive')
+          endif
+       endif
+    end do
+
+    do l = 1, ndecomp_cascade_transitions
+       ! vertically integrated fluxes
+       !-- mineralization/immobilization fluxes (none from CWD)
+       if ( .not. decomp_cascade_con%is_cwd(decomp_cascade_con%cascade_donor_pool(l)) ) then
+          this%decomp_cascade_sminp_flux_col(begc:endc,l) = spval
+          data1dptr => this%decomp_cascade_sminp_flux_col(:,l)
+          if ( decomp_cascade_con%cascade_receiver_pool(l) /= 0 ) then
+             fieldname = 'SMINP_TO_'//&
+                  trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_receiver_pool(l)))//'P_'//&
+                  trim(decomp_cascade_con%decomp_pool_name_short(decomp_cascade_con%cascade_donor_pool(l)))
+             longname =  'mineral P flux for decomp. of '&
+                  //trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_donor_pool(l)))//&
+                  'to '//trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_receiver_pool(l)))
+          else
+             fieldname = trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_donor_pool(l)))&
+                  //'P_TO_SMINP'
+             longname =  'mineral P flux for decomp. of '&
+                  //trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_donor_pool(l)))
+          endif
+          call hist_addfld1d (fname=fieldname, units='gP/m^2', &
+               avgflag='A', long_name=longname, &
+               ptr_col=data1dptr)
+       end if
+
+       !-- transfer fluxes (none from terminal pool, if present)
+       if ( decomp_cascade_con%cascade_receiver_pool(l) /= 0 ) then
+          this%decomp_cascade_ptransfer_col(begc:endc,l) = spval
+          data1dptr => this%decomp_cascade_ptransfer_col(:,l)
+          fieldname = trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_donor_pool(l)))//'P_TO_'//&
+               trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_receiver_pool(l)))//'P'
+          longname =  'decomp. of '//trim(decomp_cascade_con%decomp_pool_name_long(decomp_cascade_con%cascade_donor_pool(l)))//&
+               ' P to '//trim(decomp_cascade_con%decomp_pool_name_long(decomp_cascade_con%cascade_receiver_pool(l)))//' N'
+          call hist_addfld1d (fname=fieldname, units='gP/m^2',  &
+               avgflag='A', long_name=longname, &
+               ptr_col=data1dptr)
+       end if
+
+       ! vertically resolved fluxes
+       if ( nlevdecomp_full > 1 ) then
+          !-- mineralization/immobilization fluxes (none from CWD)
+          if ( .not. decomp_cascade_con%is_cwd(decomp_cascade_con%cascade_donor_pool(l)) ) then
+             this%decomp_cascade_sminp_flux_vr_col(begc:endc,:,l) = spval
+             data2dptr => this%decomp_cascade_sminp_flux_vr_col(:,:,l)
+             if ( decomp_cascade_con%cascade_receiver_pool(l) /= 0 ) then
+                fieldname = 'SMINP_TO_'&
+                     //trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_receiver_pool(l)))//'P_'//&
+                     trim(decomp_cascade_con%decomp_pool_name_short(decomp_cascade_con%cascade_donor_pool(l)))//trim(vr_suffix)
+                longname =  'mineral P flux for decomp. of '&
+                     //trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_donor_pool(l)))//&
+                     'to '//trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_receiver_pool(l)))
+             else
+                fieldname = trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_donor_pool(l)))&
+                     //'P_TO_SMINP'//trim(vr_suffix)
+                longname =  'mineral P flux for decomp. of '&
+                     //trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_donor_pool(l)))
+             endif
+             call hist_addfld_decomp (fname=fieldname, units='gP/m^3',  type2d='levdcmp', &
+                  avgflag='A', long_name=longname, &
+                  ptr_col=data2dptr, default='inactive')
+          endif
+
+          !-- transfer fluxes (none from terminal pool, if present)
+          if ( decomp_cascade_con%cascade_receiver_pool(l) /= 0 ) then
+             this%decomp_cascade_ptransfer_vr_col(begc:endc,:,l) = spval
+             data2dptr => this%decomp_cascade_ptransfer_vr_col(:,:,l)
+             fieldname = trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_donor_pool(l)))//'P_TO_'//&
+                  trim(decomp_cascade_con%decomp_pool_name_history(decomp_cascade_con%cascade_receiver_pool(l)))&
+                  //'P'//trim(vr_suffix)
+             longname =  'decomp. of '&
+                  //trim(decomp_cascade_con%decomp_pool_name_long(decomp_cascade_con%cascade_donor_pool(l)))//&
+                  ' P to '//trim(decomp_cascade_con%decomp_pool_name_long(decomp_cascade_con%cascade_receiver_pool(l)))//' P'
+             call hist_addfld_decomp (fname=fieldname, units='gP/m^3',  type2d='levdcmp', &
+                  avgflag='A', long_name=longname, &
+                  ptr_col=data2dptr, default='inactive')
+          endif
+
+       endif
+    end do
+
+    this%som_p_leached_col(begc:endc) = spval
+    call hist_addfld1d (fname='SOM_P_LEACHED', units='gP/m^2/s', &
+         avgflag='A', long_name='total flux of P from SOM pools due to leaching', &
+         ptr_col=this%som_p_leached_col, default='inactive')
+
+    do k = 1, ndecomp_pools
+       if ( .not. decomp_cascade_con%is_cwd(k) ) then
+          this%decomp_ppools_leached_col(begc:endc,k) = spval
+          data1dptr => this%decomp_ppools_leached_col(:,k)
+          fieldname = 'M_'//trim(decomp_cascade_con%decomp_pool_name_history(k))//'P_TO_LEACHING'
+          longname =  trim(decomp_cascade_con%decomp_pool_name_long(k))//' P leaching loss'
+          call hist_addfld1d (fname=fieldname, units='gP/m^2/s', &
+               avgflag='A', long_name=longname, &
+               ptr_col=data1dptr, default='inactive')
+
+          this%decomp_ppools_transport_tendency_col(begc:endc,:,k) = spval
+          data2dptr => this%decomp_ppools_transport_tendency_col(:,:,k)
+          fieldname = trim(decomp_cascade_con%decomp_pool_name_history(k))//'P_TNDNCY_VERT_TRANSPORT'
+          longname =  trim(decomp_cascade_con%decomp_pool_name_long(k))//' P tendency due to vertical transport'
+          call hist_addfld_decomp (fname=fieldname, units='gP/m^3/s',  type2d='levdcmp', &
+               avgflag='A', long_name=longname, &
+               ptr_col=data2dptr)
+       end if
+    end do
+
+    this%primp_to_labilep_col(begc:endc) = spval
+    call hist_addfld1d (fname='PRIMP_TO_LABILEP', units='gP/m^2/s',   &
+         avgflag='A', long_name='PRIMARY MINERAL P TO LABILE P', &
+         ptr_col=this%primp_to_labilep_col)
+
+    if ( nlevdecomp_full > 1 ) then  
+       this%primp_to_labilep_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='PRIMP_TO_LABILEP'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='PRIMARY MINERAL P TO LABILE P', &
+            ptr_col=this%primp_to_labilep_vr_col, default='inactive')
+    endif
+
+    this%labilep_to_secondp_col(begc:endc) = spval
+    call hist_addfld1d (fname='LABILEP_TO_SECONDP', units='gP/m^2/s',   &
+         avgflag='A', long_name='LABILE P TO SECONDARY MINERAL P', &
+         ptr_col=this%labilep_to_secondp_col)
+
+    if ( nlevdecomp_full > 1 ) then  
+       this%labilep_to_secondp_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='LABILEP_TO_SECONDP'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='LABILE P TO SECONDARY MINERAL P', &
+            ptr_col=this%labilep_to_secondp_vr_col, default='inactive')
+    endif
+
+
+    this%secondp_to_labilep_col(begc:endc) = spval
+    call hist_addfld1d (fname='SECONDP_TO_LABILEP', units='gP/m^2/s',   &
+         avgflag='A', long_name='SECONDARY MINERAL P TO LABILE P', &
+         ptr_col=this%secondp_to_labilep_col)
+
+    if ( nlevdecomp_full > 1 ) then  
+       this%secondp_to_labilep_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='SECONDP_TO_LABILEP'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='SECONDARY MINERAL P TO LABILE P', &
+            ptr_col=this%secondp_to_labilep_vr_col, default='inactive')
+    endif
+
+    this%secondp_to_occlp_col(begc:endc) = spval
+    call hist_addfld1d (fname='SECONDP_TO_OCCLP', units='gP/m^2/s',   &
+         avgflag='A', long_name='SECONDARY MINERAL P TO OCCLUDED P', &
+         ptr_col=this%secondp_to_occlp_col)
+
+    if ( nlevdecomp_full > 1 ) then  
+       this%secondp_to_occlp_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='SECONDP_TO_OCCLP'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='SECONDARY MINERAL P TO OCCLUDED P', &
+            ptr_col=this%secondp_to_occlp_vr_col, default='inactive')
+    endif
+
+    this%sminp_leached_col(begc:endc) = spval
+    call hist_addfld1d (fname='SMINP_LEACHED', units='gP/m^2/s',   &
+         avgflag='A', long_name='soil mineral P pool loss to leaching', &
+         ptr_col=this%sminp_leached_col)
+
+    if ( nlevdecomp_full > 1 ) then  
+       this%sminp_leached_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='SMINP_LEACHED'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='soil mineral P pool loss to leaching', &
+            ptr_col=this%sminp_leached_vr_col, default='inactive')
+    endif
+
+
+    if ( nlevdecomp_full > 1 ) then
+       this%potential_immob_p_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='POTENTIAL_IMMOB_P'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='potential P immobilization', &
+            ptr_col=this%potential_immob_p_vr_col, default='inactive')
+    end if
+
+    if ( nlevdecomp_full > 1 ) then
+       this%actual_immob_p_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='ACTUAL_IMMOB_P'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='actual P immobilization', &
+            ptr_col=this%actual_immob_p_vr_col, default='inactive')
+    end if
+
+    if ( nlevdecomp_full > 1 ) then
+       this%sminp_to_plant_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='SMINP_TO_PLANT'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='plant uptake of soil mineral P', &
+            ptr_col=this%sminp_to_plant_vr_col, default='inactive')
+    end if
+
+    if ( nlevdecomp_full > 1 ) then
+       this%supplement_to_sminp_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='SUPPLEMENT_TO_SMINP'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='supplemental P supply', &
+            ptr_col=this%supplement_to_sminp_vr_col, default='inactive')
+    end if
+
+    if ( nlevdecomp_full > 1 ) then
+       this%gross_pmin_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='GROSS_PMIN'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='gross rate of P mineralization', &
+            ptr_col=this%gross_pmin_vr_col, default='inactive')
+    end if
+
+    if ( nlevdecomp_full > 1 ) then
+       this%net_pmin_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='NET_PMIN'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='net rate of P mineralization', &
+            ptr_col=this%net_pmin_vr_col, default='inactive')
+    end if
+
+
+    if ( nlevdecomp_full > 1 ) then
+       this%biochem_pmin_vr_col(begc:endc,:) = spval
+       call hist_addfld_decomp (fname='BIOCHEM_PMIN'//trim(vr_suffix), units='gP/m^3/s',  type2d='levdcmp', &
+            avgflag='A', long_name='biochemical rate of P mineralization', &
+            ptr_col=this%biochem_pmin_vr_col, default='inactive')
+    end if
+
+    this%potential_immob_p_col(begc:endc) = spval
+    call hist_addfld1d (fname='POTENTIAL_IMMOB_P', units='gP/m^2/s', &
+         avgflag='A', long_name='potential P immobilization', &
+         ptr_col=this%potential_immob_p_col)
+
+    this%actual_immob_p_col(begc:endc) = spval
+    call hist_addfld1d (fname='ACTUAL_IMMOB_P', units='gP/m^2/s', &
+         avgflag='A', long_name='actual P immobilization', &
+         ptr_col=this%actual_immob_p_col)
+
+    this%sminp_to_plant_col(begc:endc) = spval
+    call hist_addfld1d (fname='SMINP_TO_PLANT', units='gP/m^2/s', &
+         avgflag='A', long_name='plant uptake of soil mineral P', &
+         ptr_col=this%sminp_to_plant_col)
+
+    this%supplement_to_sminp_col(begc:endc) = spval
+    call hist_addfld1d (fname='SUPPLEMENT_TO_SMINP', units='gP/m^2/s', &
+         avgflag='A', long_name='supplemental P supply', &
+         ptr_col=this%supplement_to_sminp_col)
+
+    this%gross_pmin_col(begc:endc) = spval
+    call hist_addfld1d (fname='GROSS_PMIN', units='gP/m^2/s', &
+         avgflag='A', long_name='gross rate of P mineralization', &
+         ptr_col=this%gross_pmin_col)
+
+    this%net_pmin_col(begc:endc) = spval
+    call hist_addfld1d (fname='NET_PMIN', units='gP/m^2/s', &
+         avgflag='A', long_name='net rate of P mineralization', &
+         ptr_col=this%net_pmin_col)
+
+    this%biochem_pmin_col(begc:endc) = spval
+    call hist_addfld1d (fname='BIOCHEM_PMIN', units='gP/m^2/s', &
+         avgflag='A', long_name='biochemical rate of P mineralization', &
+         ptr_col=this%biochem_pmin_col)
+
+    this%fire_ploss_col(begc:endc) = spval
+    call hist_addfld1d (fname='COL_FIRE_PLOSS', units='gP/m^2/s', &
+         avgflag='A', long_name='total column-level fire P loss', &
+         ptr_col=this%fire_ploss_col)
+
+    this%dwt_seedp_to_leaf_col(begc:endc) = spval
+    call hist_addfld1d (fname='DWT_SEEDP_TO_LEAF', units='gP/m^2/s', &
+         avgflag='A', long_name='seed source to PFT-level leaf', &
+         ptr_col=this%dwt_seedp_to_leaf_col)
+
+    this%dwt_seedp_to_deadstem_col(begc:endc) = spval
+    call hist_addfld1d (fname='DWT_SEEDP_TO_DEADSTEM', units='gP/m^2/s', &
+         avgflag='A', long_name='seed source to PFT-level deadstem', &
+         ptr_col=this%dwt_seedp_to_deadstem_col)
+
+    this%dwt_conv_pflux_col(begc:endc) = spval
+    call hist_addfld1d (fname='DWT_CONV_PFLUX', units='gP/m^2/s', &
+         avgflag='A', long_name='conversion P flux (immediate loss to atm)', &
+         ptr_col=this%dwt_conv_pflux_col)
+
+    this%dwt_prod10p_gain_col(begc:endc) = spval
+    call hist_addfld1d (fname='DWT_PROD10P_GAIN', units='gP/m^2/s', &
+         avgflag='A', long_name='addition to 10-yr wood product pool', &
+         ptr_col=this%dwt_prod10p_gain_col)
+
+    this%prod10p_loss_col(begc:endc) = spval
+    call hist_addfld1d (fname='PROD10P_LOSS', units='gP/m^2/s', &
+         avgflag='A', long_name='loss from 10-yr wood product pool', &
+         ptr_col=this%prod10p_loss_col)
+
+    this%dwt_prod100p_gain_col(begc:endc) = spval
+    call hist_addfld1d (fname='DWT_PROD100P_GAIN', units='gP/m^2/s', &
+         avgflag='A', long_name='addition to 100-yr wood product pool', &
+         ptr_col=this%dwt_prod100p_gain_col)
+
+    this%prod100p_loss_col(begc:endc) = spval
+    call hist_addfld1d (fname='PROD100P_LOSS', units='gP/m^2/s', &
+         avgflag='A', long_name='loss from 100-yr wood product pool', &
+         ptr_col=this%prod100p_loss_col)
+
+    this%product_ploss_col(begc:endc) = spval
+    call hist_addfld1d (fname='PRODUCT_PLOSS', units='gP/m^2/s', &
+         avgflag='A', long_name='total P loss from wood product pools', &
+         ptr_col=this%product_ploss_col)
+
+    this%dwt_frootp_to_litr_met_p_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='DWT_FROOTP_TO_LITR_MET_P', units='gP/m^2/s',  type2d='levdcmp', &
+         avgflag='A', long_name='fine root to litter due to landcover change', &
+         ptr_col=this%dwt_frootp_to_litr_met_p_col, default='inactive')
+
+    this%dwt_frootp_to_litr_cel_p_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='DWT_FROOTP_TO_LITR_CEL_P', units='gP/m^2/s',  type2d='levdcmp', &
+         avgflag='A', long_name='fine root to litter due to landcover change', &
+         ptr_col=this%dwt_frootp_to_litr_cel_p_col, default='inactive')
+
+    this%dwt_frootp_to_litr_lig_p_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='DWT_FROOTP_TO_LITR_LIG_P', units='gP/m^2/s',  type2d='levdcmp', &
+         avgflag='A', long_name='fine root to litter due to landcover change', &
+         ptr_col=this%dwt_frootp_to_litr_lig_p_col, default='inactive')
+
+    this%dwt_livecrootp_to_cwdp_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='DWT_LIVECROOTP_TO_CWDP', units='gP/m^2/s',  type2d='levdcmp', &
+         avgflag='A', long_name='live coarse root to CWD due to landcover change', &
+         ptr_col=this%dwt_livecrootp_to_cwdp_col, default='inactive')
+
+    this%dwt_deadcrootp_to_cwdp_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='DWT_DEADCROOTP_TO_CWDP', units='gP/m^2/s',  type2d='levdcmp', &
+         avgflag='A', long_name='dead coarse root to CWD due to landcover change', &
+         ptr_col=this%dwt_deadcrootp_to_cwdp_col, default='inactive')
+
+    this%dwt_ploss_col(begc:endc) = spval
+    call hist_addfld1d (fname='DWT_PLOSS', units='gP/m^2/s', &
+         avgflag='A', long_name='total phosphorus loss from landcover conversion', &
+         ptr_col=this%dwt_ploss_col)
+
+    if (crop_prog) then
+       this%fert_p_to_sminp_col(begc:endc) = spval
+       call hist_addfld1d (fname='FERT_TO_LABILEP', units='gP/m^2/s', &
+            avgflag='A', long_name='fertilizer to soil mineral P', &
+            ptr_col=this%fert_p_to_sminp_col)
+    end if
+
+
+    this%plant_pdemand_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PLANT_PDEMAND', units='gP/m^2/s', &
+         avgflag='A', long_name='P flux required to support initial GPP', &
+         ptr_patch=this%plant_pdemand_patch)
+
+    this%avail_retransp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='AVAIL_RETRANSP', units='gP/m^2/s', &
+         avgflag='A', long_name='P flux available from retranslocation pool', &
+         ptr_patch=this%avail_retransp_patch, default='inactive')
+
+    this%plant_palloc_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PLANT_PALLOC', units='gP/m^2/s', &
+         avgflag='A', long_name='total allocated P flux', &
+         ptr_patch=this%plant_palloc_patch, default='inactive')
+
+  end subroutine InitHistory
+
+  !-----------------------------------------------------------------------
+  subroutine InitCold(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Initializes time varying variables used only in coupled carbon-phosphorus mode (CN):
+    !
+    ! !USES:
+    use clm_varpar      , only : crop_prog
+    use landunit_varcon , only : istsoil, istcrop
+    !
+    ! !ARGUMENTS:
+    class(phosphorusflux_type) :: this 
+    type(bounds_type), intent(in) :: bounds  
+    !
+    ! !LOCAL VARIABLES:
+    integer :: p,c,l
+    integer :: fp, fc                                    ! filter indices
+    integer :: num_special_col                           ! number of good values in special_col filter
+    integer :: num_special_patch                         ! number of good values in special_patch filter
+    integer :: special_col(bounds%endc-bounds%begc+1)    ! special landunit filter - columns
+    integer :: special_patch(bounds%endp-bounds%begp+1)  ! special landunit filter - patches
+    !---------------------------------------------------------------------
+
+    ! Set column filters
+
+    num_special_col = 0
+    do c = bounds%begc, bounds%endc
+       l = col%landunit(c)
+       if (lun%ifspecial(l)) then
+          num_special_col = num_special_col + 1
+          special_col(num_special_col) = c
+       end if
+    end do
+
+    ! Set patch filters
+
+    num_special_patch = 0
+    do p = bounds%begp,bounds%endp
+       l = pft%landunit(p)
+       if (lun%ifspecial(l)) then
+          num_special_patch = num_special_patch + 1
+          special_patch(num_special_patch) = p
+       end if
+    end do
+
+    !-----------------------------------------------
+    ! initialize phosphorus flux variables
+    !-----------------------------------------------
+
+    do p = bounds%begp,bounds%endp
+       l = pft%landunit(p)
+
+       if ( crop_prog )then
+          this%fert_counter_patch(p)  = spval
+          this%fert_p_patch(p)          = 0._r8 
+       end if
+
+       if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
+          this%fert_counter_patch(p)  = 0._r8
+       end if
+
+       if (lun%ifspecial(l)) then
+          this%plant_pdemand_patch(p)  = spval
+          this%avail_retransp_patch(p) = spval
+          this%plant_palloc_patch(p)   = spval
+       end if
+    end do
+
+    ! initialize fields for special filters
+
+    do fc = 1,num_special_col
+       c = special_col(fc)
+       this%dwt_ploss_col(c) = 0._r8
+    end do
+
+    call this%SetValues (&
+         num_patch=num_special_patch, filter_patch=special_patch, value_patch=0._r8, &
+         num_column=num_special_col, filter_column=special_col, value_column=0._r8)
+
+  end subroutine InitCold
+
+  !-----------------------------------------------------------------------
+  subroutine Restart (this,  bounds, ncid, flag )
+    !
+    ! !DESCRIPTION: 
+    ! Read/write CN restart data for carbon state
+    !
+    ! !USES:
+    use clm_varpar, only : crop_prog
+    use restUtilMod
+    use ncdio_pio
+    !
+    ! !ARGUMENTS:
+    class (phosphorusflux_type) :: this
+    type(bounds_type) , intent(in)    :: bounds 
+    type(file_desc_t) , intent(inout) :: ncid   ! netcdf id
+    character(len=*)  , intent(in)    :: flag   !'read' or 'write'
+    !
+    ! !LOCAL VARIABLES:
+    integer :: j,c ! indices
+    logical :: readvar      ! determine if variable is on initial file
+    real(r8), pointer :: ptr2d(:,:) ! temp. pointers for slicing larger arrays
+    real(r8), pointer :: ptr1d(:)   ! temp. pointers for slicing larger arrays
+    !------------------------------------------------------------------------
+
+    if (crop_prog) then
+       call restartvar(ncid=ncid, flag=flag, varname='fert_counter', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%fert_counter_patch)
+
+       call restartvar(ncid=ncid, flag=flag, varname='fert_p', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%fert_p_patch)
+    end if
+
+    if (crop_prog) then
+       call restartvar(ncid=ncid, flag=flag,  varname='grainp_xfer_to_grainp', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='grain P growth from storage', units='gP/m2/s', &
+            interpinic_flag='interp', readvar=readvar, data=this%grainp_xfer_to_grainp_patch)
+    end if
+
+    if (crop_prog) then
+       call restartvar(ncid=ncid, flag=flag,  varname='livestemp_to_litter', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='livestem P to litter', units='gP/m2/s', &
+            interpinic_flag='interp', readvar=readvar, data=this%livestemp_to_litter_patch)
+    end if
+
+    if (crop_prog) then
+       call restartvar(ncid=ncid, flag=flag,  varname='grainp_to_food', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='grain P to food', units='gP/m2/s', &
+            interpinic_flag='interp', readvar=readvar, data=this%grainp_to_food_patch)
+    end if
+
+    if (crop_prog) then
+       call restartvar(ncid=ncid, flag=flag,  varname='ppool_to_grainp', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='allocation to grain P', units='gP/m2/s', &
+            interpinic_flag='interp', readvar=readvar, data=this%ppool_to_grainp_patch)
+    end if
+
+    if (crop_prog) then
+       call restartvar(ncid=ncid, flag=flag,  varname='ppool_to_grainp_storage', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='allocation to grain P storage', units='gP/m2/s', &
+            interpinic_flag='interp', readvar=readvar, data=this%ppool_to_grainp_storage_patch)
+    end if
+
+    if (crop_prog) then
+       call restartvar(ncid=ncid, flag=flag, varname='grainp_storage_to_xfer', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='grain P shift storage to transfer', units='gP/m2/s', &
+            interpinic_flag='interp', readvar=readvar, data=this%grainp_storage_to_xfer_patch)
+    end if
+
+    call restartvar(ncid=ncid, flag=flag, varname='plant_pdemand', xtype=ncd_double,  &
+         dim1name='pft', &
+         long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%plant_pdemand_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='avail_retransp', xtype=ncd_double,  &
+         dim1name='pft', &
+         long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%avail_retransp_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='plant_palloc', xtype=ncd_double,  &
+         dim1name='pft', &
+         long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%plant_palloc_patch) 
+
+  end subroutine Restart
+
+  !-----------------------------------------------------------------------
+  subroutine SetValues ( this, &
+       num_patch, filter_patch, value_patch, &
+       num_column, filter_column, value_column)
+    !
+    ! !DESCRIPTION:
+    ! Set phosphorus flux variables
+    !
+    ! !ARGUMENTS:
+    ! !ARGUMENTS:
+    class (phosphorusflux_type) :: this
+    integer , intent(in) :: num_patch
+    integer , intent(in) :: filter_patch(:)
+    real(r8), intent(in) :: value_patch
+    integer , intent(in) :: num_column
+    integer , intent(in) :: filter_column(:)
+    real(r8), intent(in) :: value_column
+    !
+    ! !LOCAL VARIABLES:
+    integer :: fi,i,j,k,l     ! loop index
+    !------------------------------------------------------------------------
+
+    do fi = 1,num_patch
+       i=filter_patch(fi)
+
+       this%m_leafp_to_litter_patch(i)                   = value_patch
+       this%m_frootp_to_litter_patch(i)                  = value_patch
+       this%m_leafp_storage_to_litter_patch(i)           = value_patch
+       this%m_frootp_storage_to_litter_patch(i)          = value_patch
+       this%m_livestemp_storage_to_litter_patch(i)       = value_patch
+       this%m_deadstemp_storage_to_litter_patch(i)       = value_patch
+       this%m_livecrootp_storage_to_litter_patch(i)      = value_patch
+       this%m_deadcrootp_storage_to_litter_patch(i)      = value_patch
+       this%m_leafp_xfer_to_litter_patch(i)              = value_patch
+       this%m_frootp_xfer_to_litter_patch(i)             = value_patch
+       this%m_livestemp_xfer_to_litter_patch(i)          = value_patch
+       this%m_deadstemp_xfer_to_litter_patch(i)          = value_patch
+       this%m_livecrootp_xfer_to_litter_patch(i)         = value_patch
+       this%m_deadcrootp_xfer_to_litter_patch(i)         = value_patch
+       this%m_livestemp_to_litter_patch(i)               = value_patch
+       this%m_deadstemp_to_litter_patch(i)               = value_patch
+       this%m_livecrootp_to_litter_patch(i)              = value_patch
+       this%m_deadcrootp_to_litter_patch(i)              = value_patch
+       this%m_retransp_to_litter_patch(i)                = value_patch
+       this%hrv_leafp_to_litter_patch(i)                 = value_patch             
+       this%hrv_frootp_to_litter_patch(i)                = value_patch            
+       this%hrv_leafp_storage_to_litter_patch(i)         = value_patch     
+       this%hrv_frootp_storage_to_litter_patch(i)        = value_patch    
+       this%hrv_livestemp_storage_to_litter_patch(i)     = value_patch 
+       this%hrv_deadstemp_storage_to_litter_patch(i)     = value_patch 
+       this%hrv_livecrootp_storage_to_litter_patch(i)    = value_patch
+       this%hrv_deadcrootp_storage_to_litter_patch(i)    = value_patch
+       this%hrv_leafp_xfer_to_litter_patch(i)            = value_patch        
+       this%hrv_frootp_xfer_to_litter_patch(i)           = value_patch       
+       this%hrv_livestemp_xfer_to_litter_patch(i)        = value_patch    
+       this%hrv_deadstemp_xfer_to_litter_patch(i)        = value_patch    
+       this%hrv_livecrootp_xfer_to_litter_patch(i)       = value_patch   
+       this%hrv_deadcrootp_xfer_to_litter_patch(i)       = value_patch   
+       this%hrv_livestemp_to_litter_patch(i)             = value_patch         
+       this%hrv_deadstemp_to_prod10p_patch(i)            = value_patch        
+       this%hrv_deadstemp_to_prod100p_patch(i)           = value_patch       
+       this%hrv_livecrootp_to_litter_patch(i)            = value_patch        
+       this%hrv_deadcrootp_to_litter_patch(i)            = value_patch        
+       this%hrv_retransp_to_litter_patch(i)              = value_patch    
+
+       this%m_leafp_to_fire_patch(i)                     = value_patch
+       this%m_leafp_storage_to_fire_patch(i)             = value_patch
+       this%m_leafp_xfer_to_fire_patch(i)                = value_patch
+       this%m_livestemp_to_fire_patch(i)                 = value_patch
+       this%m_livestemp_storage_to_fire_patch(i)         = value_patch
+       this%m_livestemp_xfer_to_fire_patch(i)            = value_patch
+       this%m_deadstemp_to_fire_patch(i)                 = value_patch
+       this%m_deadstemp_storage_to_fire_patch(i)         = value_patch
+       this%m_deadstemp_xfer_to_fire_patch(i)            = value_patch
+       this%m_frootp_to_fire_patch(i)                    = value_patch
+       this%m_frootp_storage_to_fire_patch(i)            = value_patch
+       this%m_frootp_xfer_to_fire_patch(i)               = value_patch
+       this%m_livecrootp_to_fire_patch(i)                = value_patch
+       this%m_livecrootp_storage_to_fire_patch(i)        = value_patch
+       this%m_livecrootp_xfer_to_fire_patch(i)           = value_patch
+       this%m_deadcrootp_to_fire_patch(i)                = value_patch
+       this%m_deadcrootp_storage_to_fire_patch(i)        = value_patch
+       this%m_deadcrootp_xfer_to_fire_patch(i)           = value_patch
+       this%m_retransp_to_fire_patch(i)                  = value_patch
+
+
+       this%m_leafp_to_litter_fire_patch(i)              = value_patch
+       this%m_leafp_storage_to_litter_fire_patch(i)      = value_patch
+       this%m_leafp_xfer_to_litter_fire_patch(i)         = value_patch
+       this%m_livestemp_to_litter_fire_patch(i)          = value_patch
+       this%m_livestemp_storage_to_litter_fire_patch(i)  = value_patch
+       this%m_livestemp_xfer_to_litter_fire_patch(i)     = value_patch
+       this%m_livestemp_to_deadstemp_fire_patch(i)       = value_patch
+       this%m_deadstemp_to_litter_fire_patch(i)          = value_patch
+       this%m_deadstemp_storage_to_litter_fire_patch(i)  = value_patch
+       this%m_deadstemp_xfer_to_litter_fire_patch(i)     = value_patch
+       this%m_frootp_to_litter_fire_patch(i)             = value_patch
+       this%m_frootp_storage_to_litter_fire_patch(i)     = value_patch
+       this%m_frootp_xfer_to_litter_fire_patch(i)        = value_patch
+       this%m_livecrootp_to_litter_fire_patch(i)         = value_patch
+       this%m_livecrootp_storage_to_litter_fire_patch(i) = value_patch
+       this%m_livecrootp_xfer_to_litter_fire_patch(i)    = value_patch
+       this%m_livecrootp_to_deadcrootp_fire_patch(i)     = value_patch
+       this%m_deadcrootp_to_litter_fire_patch(i)         = value_patch
+       this%m_deadcrootp_storage_to_litter_fire_patch(i) = value_patch
+       this%m_deadcrootp_xfer_to_litter_fire_patch(i)    = value_patch
+       this%m_retransp_to_litter_fire_patch(i)           = value_patch
+
+       this%leafp_xfer_to_leafp_patch(i)                 = value_patch
+       this%frootp_xfer_to_frootp_patch(i)               = value_patch
+       this%livestemp_xfer_to_livestemp_patch(i)         = value_patch
+       this%deadstemp_xfer_to_deadstemp_patch(i)         = value_patch
+       this%livecrootp_xfer_to_livecrootp_patch(i)       = value_patch
+       this%deadcrootp_xfer_to_deadcrootp_patch(i)       = value_patch
+       this%leafp_to_litter_patch(i)                     = value_patch
+       this%leafp_to_retransp_patch(i)                   = value_patch
+       this%frootp_to_litter_patch(i)                    = value_patch
+       this%retransp_to_ppool_patch(i)                   = value_patch
+       this%sminp_to_ppool_patch(i)                      = value_patch
+       this%ppool_to_leafp_patch(i)                      = value_patch
+       this%ppool_to_leafp_storage_patch(i)              = value_patch
+       this%ppool_to_frootp_patch(i)                     = value_patch
+       this%ppool_to_frootp_storage_patch(i)             = value_patch
+       this%ppool_to_livestemp_patch(i)                  = value_patch
+       this%ppool_to_livestemp_storage_patch(i)          = value_patch
+       this%ppool_to_deadstemp_patch(i)                  = value_patch
+       this%ppool_to_deadstemp_storage_patch(i)          = value_patch
+       this%ppool_to_livecrootp_patch(i)                 = value_patch
+       this%ppool_to_livecrootp_storage_patch(i)         = value_patch
+       this%ppool_to_deadcrootp_patch(i)                 = value_patch
+       this%ppool_to_deadcrootp_storage_patch(i)         = value_patch
+       this%leafp_storage_to_xfer_patch(i)               = value_patch
+       this%frootp_storage_to_xfer_patch(i)              = value_patch
+       this%livestemp_storage_to_xfer_patch(i)           = value_patch
+       this%deadstemp_storage_to_xfer_patch(i)           = value_patch
+       this%livecrootp_storage_to_xfer_patch(i)          = value_patch
+       this%deadcrootp_storage_to_xfer_patch(i)          = value_patch
+       this%livestemp_to_deadstemp_patch(i)              = value_patch
+       this%livestemp_to_retransp_patch(i)               = value_patch
+       this%livecrootp_to_deadcrootp_patch(i)            = value_patch
+       this%livecrootp_to_retransp_patch(i)              = value_patch
+       this%pdeploy_patch(i)                             = value_patch
+       this%pinputs_patch(i)                             = value_patch
+       this%poutputs_patch(i)                            = value_patch
+       this%wood_harvestp_patch(i)                       = value_patch
+       this%fire_ploss_patch(i)                          = value_patch
+    end do
+
+    if ( crop_prog )then
+       do fi = 1,num_patch
+          i = filter_patch(fi)
+          this%livestemp_to_litter_patch(i)              = value_patch
+          this%grainp_to_food_patch(i)                   = value_patch
+          this%grainp_xfer_to_grainp_patch(i)            = value_patch
+          this%ppool_to_grainp_patch(i)                  = value_patch
+          this%ppool_to_grainp_storage_patch(i)          = value_patch
+          this%grainp_storage_to_xfer_patch(i)           = value_patch
+          this%frootp_to_retransp_patch(i)               = value_patch
+       end do
+    end if
+
+    do j = 1, nlevdecomp_full
+       do fi = 1,num_column
+          i = filter_column(fi)
+
+          ! phenology: litterfall and crop fluxes associated wit
+          this%phenology_p_to_litr_met_p_col(i,j)        = value_column
+          this%phenology_p_to_litr_cel_p_col(i,j)        = value_column
+          this%phenology_p_to_litr_lig_p_col(i,j)        = value_column
+
+          ! gap mortality
+          this%gap_mortality_p_to_litr_met_p_col(i,j)    = value_column
+          this%gap_mortality_p_to_litr_cel_p_col(i,j)    = value_column
+          this%gap_mortality_p_to_litr_lig_p_col(i,j)    = value_column
+          this%gap_mortality_p_to_cwdp_col(i,j)          = value_column
+
+          ! fire
+          this%fire_mortality_p_to_cwdp_col(i,j)         = value_column
+          this%m_p_to_litr_met_fire_col(i,j)             = value_column
+          this%m_p_to_litr_cel_fire_col(i,j)             = value_column  
+          this%m_p_to_litr_lig_fire_col(i,j)             = value_column
+
+          ! harvest
+          this%harvest_p_to_litr_met_p_col(i,j)          = value_column             
+          this%harvest_p_to_litr_cel_p_col(i,j)          = value_column             
+          this%harvest_p_to_litr_lig_p_col(i,j)          = value_column             
+          this%harvest_p_to_cwdp_col(i,j)                = value_column  
+
+          this%primp_to_labilep_vr_col(i,j)                 = value_column
+          this%labilep_to_secondp_vr_col(i,j)                 = value_column
+          this%secondp_to_labilep_vr_col(i,j)                 = value_column
+          this%secondp_to_occlp_vr_col(i,j)                 = value_column
+
+          this%sminp_leached_vr_col(i,j)                 = value_column
+
+          this%potential_immob_p_vr_col(i,j)             = value_column
+          this%actual_immob_p_vr_col(i,j)                = value_column
+          this%sminp_to_plant_vr_col(i,j)                = value_column
+          this%supplement_to_sminp_vr_col(i,j)           = value_column
+          this%gross_pmin_vr_col(i,j)                    = value_column
+          this%net_pmin_vr_col(i,j)                      = value_column
+          this%biochem_pmin_vr_col(i,j)                  = value_column
+       end do
+    end do
+
+    do fi = 1,num_column
+       i = filter_column(fi)
+
+       this%pdep_to_sminp_col(i)             = value_column
+       this%fert_p_to_sminp_col(i)             = value_column
+       this%hrv_deadstemp_to_prod10p_col(i)  = value_column        
+       this%hrv_deadstemp_to_prod100p_col(i) = value_column      
+       this%prod10p_loss_col(i)              = value_column
+       this%prod100p_loss_col(i)             = value_column
+       this%product_ploss_col(i)             = value_column
+       this%potential_immob_p_col(i)           = value_column
+       this%actual_immob_p_col(i)              = value_column
+       this%sminp_to_plant_col(i)            = value_column
+       this%supplement_to_sminp_col(i)       = value_column
+       this%gross_pmin_col(i)                = value_column
+       this%net_pmin_col(i)                  = value_column
+       this%biochem_pmin_col(i)                  = value_column
+       this%primp_to_labilep_col(i)          = value_column
+       this%labilep_to_secondp_col(i)          = value_column
+       this%secondp_to_labilep_col(i)          = value_column
+       this%secondp_to_occlp_col(i)          = value_column
+       this%sminp_leached_col(i)          = value_column
+       this%pinputs_col(i)                   = value_column
+       this%poutputs_col(i)                  = value_column
+       this%fire_ploss_col(i)                = value_column
+       this%som_p_leached_col(i)             = value_column
+
+       ! Zero p2c column fluxes
+       this%fire_ploss_col(i) = value_column
+       this%wood_harvestp_col(i) = value_column
+    end do
+
+    do k = 1, ndecomp_pools
+       do fi = 1,num_column
+          i = filter_column(fi)
+          this%decomp_ppools_leached_col(i,k) = value_column
+          this%m_decomp_ppools_to_fire_col(i,k) = value_column
+       end do
+    end do
+
+    do k = 1, ndecomp_pools
+       do j = 1, nlevdecomp_full
+          do fi = 1,num_column
+             i = filter_column(fi)
+             this%m_decomp_ppools_to_fire_vr_col(i,j,k) = value_column
+             this%decomp_ppools_transport_tendency_col(i,j,k) = value_column
+          end do
+       end do
+    end do
+
+    do l = 1, ndecomp_cascade_transitions
+       do fi = 1,num_column
+          i = filter_column(fi)
+          this%decomp_cascade_ptransfer_col(i,l) = value_column
+          this%decomp_cascade_sminp_flux_col(i,l) = value_column
+       end do
+    end do
+
+    do l = 1, ndecomp_cascade_transitions
+       do j = 1, nlevdecomp_full
+          do fi = 1,num_column
+             i = filter_column(fi)
+             this%decomp_cascade_ptransfer_vr_col(i,j,l) = value_column
+             this%decomp_cascade_sminp_flux_vr_col(i,j,l) = value_column
+          end do
+       end do
+    end do
+
+    do k = 1, ndecomp_pools
+       do j = 1, nlevdecomp_full
+          do fi = 1,num_column
+             i = filter_column(fi)
+             this%decomp_ppools_sourcesink_col(i,j,k) = value_column
+          end do
+       end do
+    end do
+
+  end subroutine SetValues
+
+  !-----------------------------------------------------------------------
+  subroutine ZeroDwt( this, bounds )
+    !
+    ! !DESCRIPTION
+    ! Initialize flux variables needed for dynamic land use.
+    !
+    ! !ARGUMENTS:
+    class(phosphorusflux_type) :: this
+    type(bounds_type), intent(in)  :: bounds 
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c, j          ! indices
+    !-----------------------------------------------------------------------
+
+    do c = bounds%begc,bounds%endc
+       this%dwt_seedp_to_leaf_col(c)     = 0._r8
+       this%dwt_seedp_to_deadstem_col(c) = 0._r8
+       this%dwt_conv_pflux_col(c)        = 0._r8
+       this%dwt_prod10p_gain_col(c)      = 0._r8
+       this%dwt_prod100p_gain_col(c)     = 0._r8
+    end do
+
+    do j = 1, nlevdecomp_full
+       do c = bounds%begc,bounds%endc
+          this%dwt_frootp_to_litr_met_p_col(c,j) = 0._r8
+          this%dwt_frootp_to_litr_cel_p_col(c,j) = 0._r8
+          this%dwt_frootp_to_litr_lig_p_col(c,j) = 0._r8
+          this%dwt_livecrootp_to_cwdp_col(c,j)   = 0._r8
+          this%dwt_deadcrootp_to_cwdp_col(c,j)   = 0._r8
+       end do
+    end do
+
+  end subroutine ZeroDwt
+
+ !-----------------------------------------------------------------------
+  subroutine Summary(this, bounds, num_soilc, filter_soilc, num_soilp, filter_soilp)
+    !
+    ! !USES:
+    use clm_varpar    , only: nlevdecomp,ndecomp_cascade_transitions,ndecomp_pools
+    use clm_varctl    , only: use_nitrif_denitrif
+    use subgridAveMod , only: p2c 
+    !
+    ! !ARGUMENTS:
+    class (phosphorusflux_type) :: this
+    type(bounds_type) , intent(in) :: bounds  
+    integer           , intent(in) :: num_soilc       ! number of soil columns in filter
+    integer           , intent(in) :: filter_soilc(:) ! filter for soil columns
+    integer           , intent(in) :: num_soilp       ! number of soil patches in filter
+    integer           , intent(in) :: filter_soilp(:) ! filter for soil patches
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c,p,j,k,l   ! indices
+    integer  :: fp,fc       ! lake filter indices
+    real(r8) :: maxdepth    ! depth to integrate soil variables
+    !-----------------------------------------------------------------------
+
+    do fp = 1,num_soilp
+       p = filter_soilp(fp)
+
+       ! total N deployment (from sminn and retranslocated N pool) (NDEPLOY)
+       this%pdeploy_patch(p) = &
+            this%sminp_to_ppool_patch(p) + &
+            this%retransp_to_ppool_patch(p)
+
+       ! pft-level wood harvest
+       this%wood_harvestp_patch(p) = &
+            this%hrv_deadstemp_to_prod10p_patch(p) + &
+            this%hrv_deadstemp_to_prod100p_patch(p)
+
+       ! total pft-level fire N losses
+       this%fire_ploss_patch(p) = &
+            this%m_leafp_to_fire_patch(p)               + &
+            this%m_leafp_storage_to_fire_patch(p)       + &
+            this%m_leafp_xfer_to_fire_patch(p)          + &
+            this%m_frootp_to_fire_patch(p)              + &
+            this%m_frootp_storage_to_fire_patch(p)      + &
+            this%m_frootp_xfer_to_fire_patch(p)         + &
+            this%m_livestemp_to_fire_patch(p)           + &
+            this%m_livestemp_storage_to_fire_patch(p)   + &
+            this%m_livestemp_xfer_to_fire_patch(p)      + &
+            this%m_deadstemp_to_fire_patch(p)           + &
+            this%m_deadstemp_storage_to_fire_patch(p)   + &
+            this%m_deadstemp_xfer_to_fire_patch(p)      + &
+            this%m_livecrootp_to_fire_patch(p)          + &
+            this%m_livecrootp_storage_to_fire_patch(p)  + &
+            this%m_livecrootp_xfer_to_fire_patch(p)     + &
+            this%m_deadcrootp_to_fire_patch(p)          + &
+            this%m_deadcrootp_storage_to_fire_patch(p)  + &
+            this%m_deadcrootp_xfer_to_fire_patch(p)     + &
+            this%m_retransp_to_fire_patch(p)
+
+    end do
+
+
+    call p2c(bounds, num_soilc, filter_soilc, &
+         this%fire_ploss_patch(bounds%begp:bounds%endp), &
+         this%fire_ploss_p2c_col(bounds%begc:bounds%endc))
+
+    call p2c(bounds, num_soilc, filter_soilc, &
+         this%wood_harvestp_patch(bounds%begp:bounds%endp), &
+         this%wood_harvestp_col(bounds%begc:bounds%endc))
+
+    do fc = 1,num_soilc
+       c = filter_soilc(fc)
+       this%supplement_to_sminp_col(c) = 0._r8
+       this%som_p_leached_col(c)       = 0._r8
+    end do
+
+    ! vertically integrate decomposing P cascade fluxes and soil mineral P fluxes associated with decomposition cascade
+    do k = 1, ndecomp_cascade_transitions
+       do j = 1,nlevdecomp
+          do fc = 1,num_soilc
+             c = filter_soilc(fc)
+
+             this%decomp_cascade_ptransfer_col(c,k) = &
+                  this%decomp_cascade_ptransfer_col(c,k) + &
+                  this%decomp_cascade_ptransfer_vr_col(c,j,k) * dzsoi_decomp(j) 
+
+             this%decomp_cascade_sminp_flux_col(c,k) = &
+                  this%decomp_cascade_sminp_flux_col(c,k) + &
+                  this%decomp_cascade_sminp_flux_vr_col(c,j,k) * dzsoi_decomp(j) 
+          end do
+       end do
+    end do
+
+    ! vertically integrate inorganic P flux
+    do j = 1, nlevdecomp
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          this%primp_to_labilep_col(c) = &
+               this%primp_to_labilep_col(c) + &
+               this%primp_to_labilep_vr_col(c,j) * dzsoi_decomp(j)
+       end do
+    end do
+
+    do j = 1, nlevdecomp
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          this%labilep_to_secondp_col(c) = &
+               this%labilep_to_secondp_col(c) + &
+               this%labilep_to_secondp_vr_col(c,j) * dzsoi_decomp(j)
+       end do
+    end do
+
+    do j = 1, nlevdecomp
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          this%secondp_to_labilep_col(c) = &
+               this%secondp_to_labilep_col(c) + &
+               this%secondp_to_labilep_vr_col(c,j) * dzsoi_decomp(j)
+       end do
+    end do
+
+    do j = 1, nlevdecomp
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          this%secondp_to_occlp_col(c) = &
+               this%secondp_to_occlp_col(c) + &
+               this%secondp_to_occlp_vr_col(c,j) * dzsoi_decomp(j)
+       end do
+    end do
+
+
+    ! vertically integrate leaching flux
+    do j = 1, nlevdecomp
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          this%sminp_leached_col(c) = &
+               this%sminp_leached_col(c) + &
+               this%sminp_leached_vr_col(c,j) * dzsoi_decomp(j)
+       end do
+    end do
+
+    ! vertically integrate column-level fire P losses
+    do k = 1, ndecomp_pools
+       do j = 1, nlevdecomp
+          do fc = 1,num_soilc
+             c = filter_soilc(fc)
+             this%m_decomp_ppools_to_fire_col(c,k) = &
+                  this%m_decomp_ppools_to_fire_col(c,k) + &
+                  this%m_decomp_ppools_to_fire_vr_col(c,j,k) * dzsoi_decomp(j)
+          end do
+       end do
+    end do
+
+    ! total column-level fire P losses
+    do fc = 1,num_soilc
+       c = filter_soilc(fc)
+       this%fire_ploss_col(c) = this%fire_ploss_p2c_col(c)
+    end do
+    do k = 1, ndecomp_pools
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          this%fire_ploss_col(c) = &
+               this%fire_ploss_col(c) + &
+               this%m_decomp_ppools_to_fire_col(c,k)
+       end do
+    end do
+
+    ! supplementary P supplement_to_sminp
+    do j = 1, nlevdecomp
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          this%supplement_to_sminp_col(c) = &
+               this%supplement_to_sminp_col(c) + &
+               this%supplement_to_sminp_vr_col(c,j) * dzsoi_decomp(j)
+       end do
+    end do
+
+    do fc = 1,num_soilc
+       c = filter_soilc(fc)
+
+       ! column-level P losses due to landcover change
+       this%dwt_ploss_col(c) = &
+            this%dwt_conv_pflux_col(c)
+
+       ! total wood product P loss
+       this%product_ploss_col(c) = &
+            this%prod10p_loss_col(c) + &
+            this%prod100p_loss_col(c) 
+    end do
+
+    ! add up all vertical transport tendency terms and calculate total som leaching loss as the sum of these
+    do l = 1, ndecomp_pools
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          this%decomp_ppools_leached_col(c,l) = 0._r8
+       end do
+
+       do j = 1, nlevdecomp
+          do fc = 1,num_soilc
+             c = filter_soilc(fc)
+             this%decomp_ppools_leached_col(c,l) = &
+                  this%decomp_ppools_leached_col(c,l) + &
+                  this%decomp_ppools_transport_tendency_col(c,j,l) * dzsoi_decomp(j)
+          end do
+       end do
+
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          this%som_p_leached_col(c) = &
+               this%som_p_leached_col(c) + &
+               this%decomp_ppools_leached_col(c,l)
+       end do
+    end do
+
+  end subroutine Summary
+
+end module PhosphorusFluxType
+

--- a/models/lnd/clm/src/biogeochem/PhosphorusStateType.F90
+++ b/models/lnd/clm/src/biogeochem/PhosphorusStateType.F90
@@ -1,0 +1,1599 @@
+module PhosphorusStateType
+
+#include "shr_assert.h"
+
+  use shr_kind_mod           , only : r8 => shr_kind_r8
+  use shr_infnan_mod         , only : nan => shr_infnan_nan, assignment(=)
+  use shr_log_mod            , only : errMsg => shr_log_errMsg
+  use clm_varpar             , only : ndecomp_cascade_transitions, ndecomp_pools, nlevcan
+  use clm_varpar             , only : nlevdecomp_full, nlevdecomp, crop_prog
+  use clm_varcon             , only : spval, ispval, dzsoi_decomp, zisoi
+  use landunit_varcon        , only : istcrop, istsoil 
+  use clm_varctl             , only : use_nitrif_denitrif, use_vertsoilc, use_century_decomp
+  use clm_varctl             , only : iulog, override_bgc_restart_mismatch_dump, spinup_state
+  use decompMod              , only : bounds_type
+  use pftvarcon              , only : npcropmin
+  use CNDecompCascadeConType , only : decomp_cascade_con
+  use EcophysConType         , only : ecophyscon
+  use abortutils             , only : endrun
+  use spmdMod                , only : masterproc 
+  use LandunitType           , only : lun                
+  use ColumnType             , only : col                
+  use PatchType              , only : pft                
+  ! 
+  ! !PUBLIC TYPES:
+  implicit none
+  save
+  private
+
+  type, public :: phosphorusstate_type
+
+     real(r8), pointer :: grainp_patch                 (:)     ! patch (gP/m2) grain P (crop)
+     real(r8), pointer :: grainp_storage_patch         (:)     ! patch (gP/m2) grain P storage (crop)
+     real(r8), pointer :: grainp_xfer_patch            (:)     ! patch (gP/m2) grain P transfer (crop)
+     real(r8), pointer :: leafp_patch                  (:)     ! patch (gP/m2) leaf P 
+     real(r8), pointer :: leafp_storage_patch          (:)     ! patch (gP/m2) leaf P storage
+     real(r8), pointer :: leafp_xfer_patch             (:)     ! patch (gP/m2) leaf P transfer
+     real(r8), pointer :: frootp_patch                 (:)     ! patch (gP/m2) fine root P
+     real(r8), pointer :: frootp_storage_patch         (:)     ! patch (gP/m2) fine root P storage
+     real(r8), pointer :: frootp_xfer_patch            (:)     ! patch (gP/m2) fine root P transfer
+     real(r8), pointer :: livestemp_patch              (:)     ! patch (gP/m2) live stem P
+     real(r8), pointer :: livestemp_storage_patch      (:)     ! patch (gP/m2) live stem P storage
+     real(r8), pointer :: livestemp_xfer_patch         (:)     ! patch (gP/m2) live stem P transfer
+     real(r8), pointer :: deadstemp_patch              (:)     ! patch (gP/m2) dead stem P
+     real(r8), pointer :: deadstemp_storage_patch      (:)     ! patch (gP/m2) dead stem P storage
+     real(r8), pointer :: deadstemp_xfer_patch         (:)     ! patch (gP/m2) dead stem P transfer
+     real(r8), pointer :: livecrootp_patch             (:)     ! patch (gP/m2) live coarse root P
+     real(r8), pointer :: livecrootp_storage_patch     (:)     ! patch (gP/m2) live coarse root P storage
+     real(r8), pointer :: livecrootp_xfer_patch        (:)     ! patch (gP/m2) live coarse root P transfer
+     real(r8), pointer :: deadcrootp_patch             (:)     ! patch (gP/m2) dead coarse root P
+     real(r8), pointer :: deadcrootp_storage_patch     (:)     ! patch (gP/m2) dead coarse root P storage
+     real(r8), pointer :: deadcrootp_xfer_patch        (:)     ! patch (gP/m2) dead coarse root P transfer
+     real(r8), pointer :: retransp_patch               (:)     ! patch (gP/m2) plant pool of retranslocated P
+     real(r8), pointer :: ppool_patch                  (:)     ! patch (gP/m2) temporary plant P pool
+     real(r8), pointer :: ptrunc_patch                 (:)     ! patch (gP/m2) pft-level sink for P truncation
+
+     real(r8), pointer :: decomp_ppools_vr_col         (:,:,:)     ! col (gP/m3) vertically-resolved decomposing (litter, cwd, soil) P pools 
+     real(r8), pointer :: solutionp_vr_col             (:,:)       ! col (gP/m3) vertically-resolved soil solution P
+     real(r8), pointer :: labilep_vr_col               (:,:)       ! col (gP/m3) vertically-resolved soil labile mineral P
+     real(r8), pointer :: secondp_vr_col               (:,:)       ! col (gP/m3) vertically-resolved soil secondary mineralP
+     real(r8), pointer :: occlp_vr_col                 (:,:)       ! col (gP/m3) vertically-resolved soil occluded mineral P
+     real(r8), pointer :: primp_vr_col                 (:,:)       ! col (gP/m3) vertically-resolved soil parimary mineral P
+     real(r8), pointer :: sminp_vr_col                 (:,:)       ! col (gP/m3) vertically-resolved soil parimary mineral P
+     real(r8), pointer :: ptrunc_vr_col                (:,:)       ! col (gP/m3) vertically-resolved column-level sink for P truncation
+
+     ! wood product pools, for dynamic landcover
+     real(r8), pointer :: seedp_col                    (:)     ! col (gP/m2) column-level pool for seeding new Patches
+     real(r8), pointer :: prod10p_col                  (:)     ! col (gP/m2) wood product P pool, 10-year lifespan
+     real(r8), pointer :: prod100p_col                 (:)     ! col (gP/m2) wood product P pool, 100-year lifespan
+     real(r8), pointer :: totprodp_col                 (:)     ! col (gP/m2) total wood product P
+
+     ! summary (diagnostic) state variables, not involved in mass balance
+     real(r8), pointer :: dispvegp_patch               (:)     ! patch (gP/m2) displayed veg phosphorus, excluding storage
+     real(r8), pointer :: storvegp_patch               (:)     ! patch (gP/m2) stored vegetation phosphorus
+     real(r8), pointer :: totvegp_patch                (:)     ! patch (gP/m2) total vegetation phosphorus
+     real(r8), pointer :: totpftp_patch                (:)     ! patch (gP/m2) total pft-level phosphorus
+     real(r8), pointer :: decomp_ppools_col            (:,:)   ! col (gP/m2)  decomposing (litter, cwd, soil) P pools
+     real(r8), pointer :: decomp_ppools_1m_col         (:,:)   ! col (gP/m2)  diagnostic: decomposing (litter, cwd, soil) P pools to 1 meter
+     real(r8), pointer :: sminp_col                    (:)     ! col (gP/m2) soil mineral P
+     real(r8), pointer :: solutionp_col                (:)         ! col (gP/m2) soil solution P
+     real(r8), pointer :: labilep_col                  (:)         ! col (gP/m2) soil labile mineral P
+     real(r8), pointer :: secondp_col                  (:)         ! col (gP/m2) soil secondary mineralP
+     real(r8), pointer :: occlp_col                    (:)         ! col (gP/m2) soil occluded mineral P
+     real(r8), pointer :: primp_col                    (:)         ! col (gP/m2) soil parimary mineral P
+     real(r8), pointer :: ptrunc_col                   (:)     ! col (gP/m2) column-level sink for P truncation
+     real(r8), pointer :: cwdp_col                     (:)     ! col (gP/m2) Diagnostic: coarse woody debris P
+     real(r8), pointer :: totlitp_col                  (:)     ! col (gP/m2) total litter phosphorus
+     real(r8), pointer :: totsomp_col                  (:)     ! col (gP/m2) total soil organic matter phosphorus
+     real(r8), pointer :: totlitp_1m_col               (:)     ! col (gP/m2) total litter phosphorus to 1 meter
+     real(r8), pointer :: totsomp_1m_col               (:)     ! col (gP/m2) total soil organic matter phosphorus to 1 meter
+     real(r8), pointer :: totecosysp_col               (:)     ! col (gP/m2) total ecosystem phosphorus, incl veg 
+     real(r8), pointer :: totcolp_col                  (:)     ! col (gP/m2) total column phosphorus, incl veg
+
+     ! patch averaged to column variables 
+     real(r8), pointer :: totvegp_col                  (:)     ! col (gP/m2) total vegetation phosphorus (p2c)
+     real(r8), pointer :: totpftp_col                  (:)     ! col (gP/m2) total pft-level phosphorus (p2c)
+
+     ! col balance checks
+     real(r8), pointer :: begpb_patch                  (:)     ! patch phosphorus mass, beginning of time step (gP/m**2)
+     real(r8), pointer :: endpb_patch                  (:)     ! patch phosphorus mass, end of time step (gP/m**2)
+     real(r8), pointer :: errpb_patch                  (:)     ! patch phosphorus balance error for the timestep (gP/m**2)
+     real(r8), pointer :: begpb_col                    (:)     ! col phosphorus mass, beginning of time step (gP/m**2)
+     real(r8), pointer :: endpb_col                    (:)     ! col phosphorus mass, end of time step (gP/m**2)
+     real(r8), pointer :: errpb_col                    (:)     ! colphosphorus balance error for the timestep (gP/m**2)
+
+   contains
+
+     procedure , public  :: Init   
+     procedure , public  :: Restart
+     procedure , public  :: SetValues
+     procedure , public  :: ZeroDWT
+     procedure , public  :: Summary
+     procedure , private :: InitAllocate 
+     procedure , private :: InitHistory  
+     procedure , private :: InitCold     
+
+  end type phosphorusstate_type
+  !------------------------------------------------------------------------
+
+contains
+
+  !------------------------------------------------------------------------
+  subroutine Init(this, bounds,                           &
+       leafc_patch, leafc_storage_patch, deadstemc_patch, &
+       decomp_cpools_vr_col, decomp_cpools_col, decomp_cpools_1m_col)
+
+    class(phosphorusstate_type)         :: this
+    type(bounds_type) , intent(in)    :: bounds  
+    real(r8)          , intent(in)    :: leafc_patch          (bounds%begp:)
+    real(r8)          , intent(in)    :: leafc_storage_patch  (bounds%begp:)
+    real(r8)          , intent(in)    :: deadstemc_patch      (bounds%begp:)
+    real(r8)          , intent(in)    :: decomp_cpools_vr_col (bounds%begc:, 1:, 1:)
+    real(r8)          , intent(in)    :: decomp_cpools_col    (bounds%begc:, 1:)
+    real(r8)          , intent(in)    :: decomp_cpools_1m_col (bounds%begc:, 1:)
+
+    call this%InitAllocate (bounds )
+
+    call this%InitHistory (bounds)
+
+    call this%InitCold ( bounds, leafc_patch, leafc_storage_patch, deadstemc_patch, &
+         decomp_cpools_vr_col, decomp_cpools_col, decomp_cpools_1m_col)
+
+  end subroutine Init
+
+  !------------------------------------------------------------------------
+  subroutine InitAllocate(this, bounds)
+    !
+    ! !ARGUMENTS:
+    class (phosphorusstate_type) :: this
+    type(bounds_type) , intent(in) :: bounds  
+    !
+    ! !LOCAL VARIABLES:
+    integer           :: begp,endp
+    integer           :: begc,endc
+    !------------------------------------------------------------------------
+
+    begp = bounds%begp; endp = bounds%endp
+    begc = bounds%begc; endc = bounds%endc
+
+    allocate(this%grainp_patch             (begp:endp))                   ; this%grainp_patch             (:)   = nan     
+    allocate(this%grainp_storage_patch     (begp:endp))                   ; this%grainp_storage_patch     (:)   = nan
+    allocate(this%grainp_xfer_patch        (begp:endp))                   ; this%grainp_xfer_patch        (:)   = nan     
+    allocate(this%leafp_patch              (begp:endp))                   ; this%leafp_patch              (:)   = nan
+    allocate(this%leafp_storage_patch      (begp:endp))                   ; this%leafp_storage_patch      (:)   = nan     
+    allocate(this%leafp_xfer_patch         (begp:endp))                   ; this%leafp_xfer_patch         (:)   = nan     
+    allocate(this%frootp_patch             (begp:endp))                   ; this%frootp_patch             (:)   = nan
+    allocate(this%frootp_storage_patch     (begp:endp))                   ; this%frootp_storage_patch     (:)   = nan     
+    allocate(this%frootp_xfer_patch        (begp:endp))                   ; this%frootp_xfer_patch        (:)   = nan     
+    allocate(this%livestemp_patch          (begp:endp))                   ; this%livestemp_patch          (:)   = nan
+    allocate(this%livestemp_storage_patch  (begp:endp))                   ; this%livestemp_storage_patch  (:)   = nan
+    allocate(this%livestemp_xfer_patch     (begp:endp))                   ; this%livestemp_xfer_patch     (:)   = nan
+    allocate(this%deadstemp_patch          (begp:endp))                   ; this%deadstemp_patch          (:)   = nan
+    allocate(this%deadstemp_storage_patch  (begp:endp))                   ; this%deadstemp_storage_patch  (:)   = nan
+    allocate(this%deadstemp_xfer_patch     (begp:endp))                   ; this%deadstemp_xfer_patch     (:)   = nan
+    allocate(this%livecrootp_patch         (begp:endp))                   ; this%livecrootp_patch         (:)   = nan
+    allocate(this%livecrootp_storage_patch (begp:endp))                   ; this%livecrootp_storage_patch (:)   = nan
+    allocate(this%livecrootp_xfer_patch    (begp:endp))                   ; this%livecrootp_xfer_patch    (:)   = nan
+    allocate(this%deadcrootp_patch         (begp:endp))                   ; this%deadcrootp_patch         (:)   = nan
+    allocate(this%deadcrootp_storage_patch (begp:endp))                   ; this%deadcrootp_storage_patch (:)   = nan
+    allocate(this%deadcrootp_xfer_patch    (begp:endp))                   ; this%deadcrootp_xfer_patch    (:)   = nan
+    allocate(this%retransp_patch           (begp:endp))                   ; this%retransp_patch           (:)   = nan
+    allocate(this%ppool_patch              (begp:endp))                   ; this%ppool_patch              (:)   = nan
+    allocate(this%ptrunc_patch             (begp:endp))                   ; this%ptrunc_patch             (:)   = nan
+    allocate(this%dispvegp_patch           (begp:endp))                   ; this%dispvegp_patch           (:)   = nan
+    allocate(this%storvegp_patch           (begp:endp))                   ; this%storvegp_patch           (:)   = nan
+    allocate(this%totvegp_patch            (begp:endp))                   ; this%totvegp_patch            (:)   = nan
+    allocate(this%totpftp_patch            (begp:endp))                   ; this%totpftp_patch            (:)   = nan
+
+    allocate(this%ptrunc_vr_col            (begc:endc,1:nlevdecomp_full)) ; this%ptrunc_vr_col            (:,:) = nan
+    
+    allocate(this%solutionp_vr_col         (begc:endc,1:nlevdecomp_full)) ; this%solutionp_vr_col         (:,:) = nan  
+    allocate(this%labilep_vr_col           (begc:endc,1:nlevdecomp_full)) ; this%labilep_vr_col           (:,:) = nan  
+    allocate(this%secondp_vr_col           (begc:endc,1:nlevdecomp_full)) ; this%secondp_vr_col           (:,:) = nan  
+    allocate(this%occlp_vr_col             (begc:endc,1:nlevdecomp_full)) ; this%occlp_vr_col             (:,:) = nan  
+    allocate(this%primp_vr_col             (begc:endc,1:nlevdecomp_full)) ; this%primp_vr_col             (:,:) = nan  
+    allocate(this%sminp_vr_col             (begc:endc,1:nlevdecomp_full)) ; this%sminp_vr_col             (:,:) = nan  
+
+    allocate(this%solutionp_col            (begc:endc))                   ; this%solutionp_col            (:)   = nan
+    allocate(this%labilep_col              (begc:endc))                   ; this%labilep_col              (:)   = nan
+    allocate(this%secondp_col              (begc:endc))                   ; this%secondp_col              (:)   = nan
+    allocate(this%occlp_col                (begc:endc))                   ; this%occlp_col                (:)   = nan
+    allocate(this%primp_col                (begc:endc))                   ; this%primp_col                (:)   = nan
+    allocate(this%cwdp_col                 (begc:endc))                   ; this%cwdp_col                 (:)   = nan
+    allocate(this%sminp_col                (begc:endc))                   ; this%sminp_col                (:)   = nan
+    allocate(this%ptrunc_col               (begc:endc))                   ; this%ptrunc_col               (:)   = nan
+    allocate(this%seedp_col                (begc:endc))                   ; this%seedp_col                (:)   = nan
+    allocate(this%prod10p_col              (begc:endc))                   ; this%prod10p_col              (:)   = nan
+    allocate(this%prod100p_col             (begc:endc))                   ; this%prod100p_col             (:)   = nan
+    allocate(this%totprodp_col             (begc:endc))                   ; this%totprodp_col             (:)   = nan
+    allocate(this%totlitp_col              (begc:endc))                   ; this%totlitp_col              (:)   = nan
+    allocate(this%totsomp_col              (begc:endc))                   ; this%totsomp_col              (:)   = nan
+    allocate(this%totlitp_1m_col           (begc:endc))                   ; this%totlitp_1m_col           (:)   = nan
+    allocate(this%totsomp_1m_col           (begc:endc))                   ; this%totsomp_1m_col           (:)   = nan
+    allocate(this%totecosysp_col           (begc:endc))                   ; this%totecosysp_col           (:)   = nan
+    allocate(this%totcolp_col              (begc:endc))                   ; this%totcolp_col              (:)   = nan
+    allocate(this%decomp_ppools_col        (begc:endc,1:ndecomp_pools))   ; this%decomp_ppools_col        (:,:) = nan
+    allocate(this%decomp_ppools_1m_col     (begc:endc,1:ndecomp_pools))   ; this%decomp_ppools_1m_col     (:,:) = nan
+    allocate(this%totpftp_col              (begc:endc))                   ; this%totpftp_col              (:)   = nan
+    allocate(this%totvegp_col              (begc:endc))                   ; this%totvegp_col              (:)   = nan
+
+    allocate(this%decomp_ppools_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools));
+    this%decomp_ppools_vr_col(:,:,:)= nan
+
+    allocate(this%begpb_patch (begp:endp));     this%begpb_patch (:) =nan
+    allocate(this%begpb_col   (begc:endc));     this%begpb_col   (:) =nan
+    allocate(this%endpb_patch (begp:endp));     this%endpb_patch (:) =nan
+    allocate(this%endpb_col   (begc:endc));     this%endpb_col   (:) =nan
+    allocate(this%errpb_patch (begp:endp));     this%errpb_patch (:) =nan
+    allocate(this%errpb_col   (begc:endc));     this%errpb_col   (:) =nan 
+
+  end subroutine InitAllocate
+
+  !------------------------------------------------------------------------
+  subroutine InitHistory(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! add history fields for all CN variables, always set as default='inactive'
+    !
+    ! !USES:
+    use clm_varpar , only : ndecomp_cascade_transitions, ndecomp_pools
+    use clm_varpar , only : nlevdecomp, nlevdecomp_full,crop_prog, nlevgrnd
+    use histFileMod, only : hist_addfld1d, hist_addfld2d, hist_addfld_decomp 
+    use decompMod  , only : bounds_type
+    !
+    ! !ARGUMENTS:
+    class(phosphorusstate_type) :: this
+    type(bounds_type)         , intent(in) :: bounds 
+    !
+    ! !LOCAL VARIABLES:
+    integer           :: k,l,ii,jj 
+    character(10)     :: active
+    character(8)      :: vr_suffix
+    integer           :: begp,endp
+    integer           :: begc,endc
+    integer           :: begg,endg 
+    character(24)     :: fieldname
+    character(100)    :: longname
+    real(r8), pointer :: data1dptr(:)   ! temp. pointer for slicing larger arrays
+    real(r8), pointer :: data2dptr(:,:) ! temp. pointer for slicing larger arrays
+    !---------------------------------------------------------------------
+
+    begp = bounds%begp; endp = bounds%endp
+    begc = bounds%begc; endc = bounds%endc
+    begg = bounds%begg; endg = bounds%endg
+
+    !-------------------------------
+    ! P state variables - native to PFT
+    !-------------------------------
+    
+    if (crop_prog) then
+       this%grainp_patch(begp:endp) = spval
+       call hist_addfld1d (fname='GRAINP', units='gP/m^2', &
+            avgflag='A', long_name='grain P', &
+            ptr_patch=this%grainp_patch)
+    end if
+
+    this%leafp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LEAFP', units='gP/m^2', &
+         avgflag='A', long_name='leaf P', &
+         ptr_patch=this%leafp_patch)
+
+    this%leafp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LEAFP_STORAGE', units='gP/m^2', &
+         avgflag='A', long_name='leaf P storage', &
+         ptr_patch=this%leafp_storage_patch, default='inactive')
+
+    this%leafp_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LEAFP_XFER', units='gP/m^2', &
+         avgflag='A', long_name='leaf P transfer', &
+         ptr_patch=this%leafp_xfer_patch, default='inactive')
+
+    this%frootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='FROOTP', units='gP/m^2', &
+         avgflag='A', long_name='fine root P', &
+         ptr_patch=this%frootp_patch)
+
+    this%frootp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='FROOTP_STORAGE', units='gP/m^2', &
+         avgflag='A', long_name='fine root P storage', &
+         ptr_patch=this%frootp_storage_patch, default='inactive')
+
+    this%frootp_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='FROOTP_XFER', units='gP/m^2', &
+         avgflag='A', long_name='fine root P transfer', &
+         ptr_patch=this%frootp_xfer_patch, default='inactive')
+
+    this%livestemp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMP', units='gP/m^2', &
+         avgflag='A', long_name='live stem P', &
+         ptr_patch=this%livestemp_patch)
+
+    this%livestemp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMP_STORAGE', units='gP/m^2', &
+         avgflag='A', long_name='live stem P storage', &
+         ptr_patch=this%livestemp_storage_patch, default='inactive')
+
+    this%livestemp_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMP_XFER', units='gP/m^2', &
+         avgflag='A', long_name='live stem P transfer', &
+         ptr_patch=this%livestemp_xfer_patch, default='inactive')
+
+    this%deadstemp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADSTEMP', units='gP/m^2', &
+         avgflag='A', long_name='dead stem P', &
+         ptr_patch=this%deadstemp_patch)
+
+    this%deadstemp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADSTEMP_STORAGE', units='gP/m^2', &
+         avgflag='A', long_name='dead stem P storage', &
+         ptr_patch=this%deadstemp_storage_patch, default='inactive')
+
+    this%deadstemp_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADSTEMP_XFER', units='gP/m^2', &
+         avgflag='A', long_name='dead stem P transfer', &
+         ptr_patch=this%deadstemp_xfer_patch, default='inactive')
+
+    this%livecrootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVECROOTP', units='gP/m^2', &
+         avgflag='A', long_name='live coarse root P', &
+         ptr_patch=this%livecrootp_patch)
+
+    this%livecrootp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVECROOTP_STORAGE', units='gP/m^2', &
+         avgflag='A', long_name='live coarse root P storage', &
+         ptr_patch=this%livecrootp_storage_patch, default='inactive')
+
+    this%livecrootp_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVECROOTP_XFER', units='gP/m^2', &
+         avgflag='A', long_name='live coarse root P transfer', &
+         ptr_patch=this%livecrootp_xfer_patch, default='inactive')
+
+    this%deadcrootp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADCROOTP', units='gP/m^2', &
+         avgflag='A', long_name='dead coarse root P', &
+         ptr_patch=this%deadcrootp_patch)
+
+    this%deadcrootp_storage_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADCROOTP_STORAGE', units='gP/m^2', &
+         avgflag='A', long_name='dead coarse root P storage', &
+         ptr_patch=this%deadcrootp_storage_patch, default='inactive')
+
+    this%deadcrootp_xfer_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DEADCROOTP_XFER', units='gP/m^2', &
+         avgflag='A', long_name='dead coarse root P transfer', &
+         ptr_patch=this%deadcrootp_xfer_patch, default='inactive')
+
+    this%retransp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='RETRANSP', units='gP/m^2', &
+         avgflag='A', long_name='plant pool of retranslocated P', &
+         ptr_patch=this%retransp_patch)
+
+    this%ppool_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PPOOL', units='gP/m^2', &
+         avgflag='A', long_name='temporary plant P pool', &
+         ptr_patch=this%ppool_patch, default='inactive')
+
+    this%ptrunc_patch(begp:endp) = spval
+    call hist_addfld1d (fname='PFT_PTRUNC', units='gP/m^2', &
+         avgflag='A', long_name='pft-level sink for P truncation', &
+         ptr_patch=this%ptrunc_patch)
+
+    this%dispvegp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='DISPVEGP', units='gP/m^2', &
+         avgflag='A', long_name='displayed vegetation phosphorus', &
+         ptr_patch=this%dispvegp_patch)
+
+    this%storvegp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='STORVEGP', units='gP/m^2', &
+         avgflag='A', long_name='stored vegetation phosphorus', &
+         ptr_patch=this%storvegp_patch)
+
+    this%totvegp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='TOTVEGP', units='gP/m^2', &
+         avgflag='A', long_name='total vegetation phosphorus', &
+         ptr_patch=this%totvegp_patch)
+
+    this%totpftp_patch(begp:endp) = spval
+    call hist_addfld1d (fname='TOTPFTP', units='gP/m^2', &
+         avgflag='A', long_name='total PFT-level phosphorus', &
+         ptr_patch=this%totpftp_patch)
+
+    !-------------------------------
+    ! P state variables - native to column
+    !-------------------------------
+
+    if ( nlevdecomp_full > 1 ) then
+       this%decomp_ppools_vr_col(begc:endc,:,:) = spval
+       this%decomp_ppools_1m_col(begc:endc,:) = spval
+    end if
+    this%decomp_ppools_col(begc:endc,:) = spval
+    do l  = 1, ndecomp_pools
+       if ( nlevdecomp_full > 1 ) then
+          data2dptr => this%decomp_ppools_vr_col(:,:,l)
+          fieldname = trim(decomp_cascade_con%decomp_pool_name_history(l))//'P_vr'
+          longname =  trim(decomp_cascade_con%decomp_pool_name_history(l))//' P (vertically resolved)'
+          call hist_addfld2d (fname=fieldname, units='gP/m^3',  type2d='levdcmp', &
+               avgflag='A', long_name=longname, &
+               ptr_col=data2dptr)
+       endif
+
+       data1dptr => this%decomp_ppools_col(:,l)
+       fieldname = trim(decomp_cascade_con%decomp_pool_name_history(l))//'P'
+       longname =  trim(decomp_cascade_con%decomp_pool_name_history(l))//' P'
+       call hist_addfld1d (fname=fieldname, units='gP/m^2', &
+            avgflag='A', long_name=longname, &
+            ptr_col=data1dptr)
+
+       if ( nlevdecomp_full > 1 ) then
+          data1dptr => this%decomp_ppools_1m_col(:,l)
+          fieldname = trim(decomp_cascade_con%decomp_pool_name_history(l))//'P_1m'
+          longname =  trim(decomp_cascade_con%decomp_pool_name_history(l))//' P to 1 meter'
+          call hist_addfld1d (fname=fieldname, units='gP/m^2', &
+               avgflag='A', long_name=longname, &
+               ptr_col=data1dptr, default = 'inactive')
+       endif
+    end do
+
+
+    if ( nlevdecomp_full > 1 ) then
+
+       this%sminp_col(begc:endc) = spval
+       call hist_addfld1d (fname='SMINP', units='gP/m^2', &
+            avgflag='A', long_name='soil mineral P', &
+            ptr_col=this%sminp_col)
+
+       this%totlitp_1m_col(begc:endc) = spval
+       call hist_addfld1d (fname='TOTLITP_1m', units='gP/m^2', &
+            avgflag='A', long_name='total litter P to 1 meter', &
+            ptr_col=this%totlitp_1m_col)
+
+       this%totsomp_1m_col(begc:endc) = spval
+       call hist_addfld1d (fname='TOTSOMP_1m', units='gP/m^2', &
+            avgflag='A', long_name='total soil organic matter P to 1 meter', &
+            ptr_col=this%totsomp_1m_col)
+    endif
+
+    this%ptrunc_col(begc:endc) = spval
+    call hist_addfld1d (fname='COL_PTRUNC', units='gP/m^2',  &
+         avgflag='A', long_name='column-level sink for P truncation', &
+         ptr_col=this%ptrunc_col)
+
+    ! add suffix if number of soil decomposition depths is greater than 1
+    if (nlevdecomp > 1) then
+       vr_suffix = "_vr"
+    else 
+       vr_suffix = ""
+    endif
+
+    this%solutionp_vr_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='SOLUTIONP'//trim(vr_suffix), units='gp/m^3',  type2d='levdcmp', &
+         avgflag='A', long_name='soil solution P (vert. res.)', &
+         ptr_col=this%solutionp_vr_col)
+
+    this%labilep_vr_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='LABILEP'//trim(vr_suffix), units='gp/m^3',  type2d='levdcmp', &
+         avgflag='A', long_name='soil labile P (vert. res.)', &
+         ptr_col=this%labilep_vr_col)
+
+    this%secondp_vr_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='SECONDP'//trim(vr_suffix), units='gp/m^3',  type2d='levdcmp', &
+         avgflag='A', long_name='soil secondary P (vert. res.)', &
+         ptr_col=this%secondp_vr_col)
+
+    this%occlp_vr_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='OCCLP'//trim(vr_suffix), units='gp/m^3',  type2d='levdcmp', &
+         avgflag='A', long_name='soil occluded P (vert. res.)', &
+         ptr_col=this%occlp_vr_col)
+
+    this%primp_vr_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='PRIMP'//trim(vr_suffix), units='gp/m^3',  type2d='levdcmp', &
+         avgflag='A', long_name='soil primary P (vert. res.)', &
+         ptr_col=this%primp_vr_col)
+
+    this%sminp_vr_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='SMINP'//trim(vr_suffix), units='gp/m^3',  type2d='levdcmp', &
+         avgflag='A', long_name='soil mineral P (vert. res.)', &
+         ptr_col=this%sminp_vr_col)
+
+    if ( nlevdecomp_full > 1 ) then
+
+       this%solutionp_col(begc:endc) = spval
+       call hist_addfld1d (fname='SOLUTIONP', units='gP/m^2', &
+            avgflag='A', long_name='soil solution P', &
+            ptr_col=this%solutionp_col)
+
+       this%labilep_col(begc:endc) = spval
+       call hist_addfld1d (fname='LABILEP', units='gP/m^2', &
+            avgflag='A', long_name='soil Labile P', &
+            ptr_col=this%labilep_col)
+
+       this%secondp_col(begc:endc) = spval
+       call hist_addfld1d (fname='SECONDP', units='gP/m^2', &
+            avgflag='A', long_name='soil secondary P', &
+            ptr_col=this%secondp_col)
+
+       this%occlp_col(begc:endc) = spval
+       call hist_addfld1d (fname='OCCLP', units='gP/m^2', &
+            avgflag='A', long_name='soil occluded P', &
+            ptr_col=this%occlp_col)
+
+       this%primp_col(begc:endc) = spval
+       call hist_addfld1d (fname='PRIMP', units='gP/m^2', &
+            avgflag='A', long_name='soil primary P', &
+            ptr_col=this%primp_col)
+    endif
+
+    this%totlitp_col(begc:endc) = spval
+    call hist_addfld1d (fname='TOTLITP', units='gP/m^2', &
+         avgflag='A', long_name='total litter P', &
+         ptr_col=this%totlitp_col)
+
+    this%totsomp_col(begc:endc) = spval
+    call hist_addfld1d (fname='TOTSOMP', units='gP/m^2', &
+         avgflag='A', long_name='total soil organic matter P', &
+         ptr_col=this%totsomp_col)
+
+    this%totecosysp_col(begc:endc) = spval
+    call hist_addfld1d (fname='TOTECOSYSP', units='gP/m^2', &
+         avgflag='A', long_name='total ecosystem P', &
+         ptr_col=this%totecosysp_col)
+
+    this%totcolp_col(begc:endc) = spval
+    call hist_addfld1d (fname='TOTCOLP', units='gP/m^2', &
+         avgflag='A', long_name='total column-level P', &
+         ptr_col=this%totcolp_col)
+
+    this%seedp_col(begc:endc) = spval
+    call hist_addfld1d (fname='SEEDP', units='gP/m^2', &
+         avgflag='A', long_name='P pool for seeding new PFTs ', &
+         ptr_col=this%seedp_col)
+
+    this%prod10p_col(begc:endc) = spval
+    call hist_addfld1d (fname='PROD10P', units='gP/m^2', &
+         avgflag='A', long_name='10-yr wood product P', &
+         ptr_col=this%prod10p_col)
+
+    this%prod100p_col(begc:endc) = spval
+    call hist_addfld1d (fname='PROD100P', units='gP/m^2', &
+         avgflag='A', long_name='100-yr wood product P', &
+         ptr_col=this%prod100p_col)
+
+    this%totprodp_col(begc:endc) = spval
+    call hist_addfld1d (fname='TOTPRODP', units='gP/m^2', &
+         avgflag='A', long_name='total wood product P', &
+         ptr_col=this%totprodp_col)
+
+  end subroutine InitHistory
+
+  !-----------------------------------------------------------------------
+  subroutine InitCold(this, bounds, &
+       leafc_patch, leafc_storage_patch, deadstemc_patch, &
+       decomp_cpools_vr_col, decomp_cpools_col, decomp_cpools_1m_col)
+    !
+    ! !DESCRIPTION:
+    ! Initializes time varying variables used only in coupled carbon-phosphorus mode (CN):
+    !
+    ! !USES:
+    use clm_varpar     , only : crop_prog
+    use decompMod      , only : bounds_type
+    use pftvarcon      , only : noveg, npcropmin
+    !
+    ! !ARGUMENTS:
+    class(phosphorusstate_type)      :: this
+    type(bounds_type) , intent(in) :: bounds  
+    real(r8)          , intent(in) :: leafc_patch(bounds%begp:)
+    real(r8)          , intent(in) :: leafc_storage_patch(bounds%begp:)
+    real(r8)          , intent(in) :: deadstemc_patch(bounds%begp:)
+    real(r8)          , intent(in) :: decomp_cpools_vr_col(bounds%begc:,:,:)
+    real(r8)          , intent(in) :: decomp_cpools_col(bounds%begc:,:)
+    real(r8)          , intent(in) :: decomp_cpools_1m_col(bounds%begc:,:)
+    !
+    ! !LOCAL VARIABLES:
+    integer :: fc,fp,g,l,c,p,j,k                       ! indices
+    integer :: num_special_col                         ! number of good values in special_col filter
+    integer :: num_special_patch                         ! number of good values in special_patch filter
+    integer :: special_col   (bounds%endc-bounds%begc+1) ! special landunit filter - columns
+    integer :: special_patch (bounds%endp-bounds%begp+1) ! special landunit filter - patches
+    !------------------------------------------------------------------------
+
+    SHR_ASSERT_ALL((ubound(leafc_patch)          == (/bounds%endp/)),                               errMsg(__FILE__, __LINE__))
+    SHR_ASSERT_ALL((ubound(leafc_storage_patch)  == (/bounds%endp/)),                               errMsg(__FILE__, __LINE__))
+    SHR_ASSERT_ALL((ubound(deadstemc_patch)      == (/bounds%endp/)),                               errMsg(__FILE__, __LINE__))
+    SHR_ASSERT_ALL((ubound(decomp_cpools_col)    == (/bounds%endc,ndecomp_pools/)),                 errMsg(__FILE__, __LINE__))
+    SHR_ASSERT_ALL((ubound(decomp_cpools_1m_col) == (/bounds%endc,ndecomp_pools/)),                 errMsg(__FILE__, __LINE__))
+    SHR_ASSERT_ALL((ubound(decomp_cpools_vr_col) == (/bounds%endc,nlevdecomp_full,ndecomp_pools/)), errMsg(__FILE__, __LINE__))
+
+    ! Set column filters
+
+    num_special_patch = 0
+    do p = bounds%begp,bounds%endp
+       l = pft%landunit(p)
+       if (lun%ifspecial(l)) then
+          num_special_patch = num_special_patch + 1
+          special_patch(num_special_patch) = p
+       end if
+    end do
+
+    ! Set patch filters
+
+    num_special_col = 0
+    do c = bounds%begc, bounds%endc
+       l = col%landunit(c)
+       if (lun%ifspecial(l)) then
+          num_special_col = num_special_col + 1
+          special_col(num_special_col) = c
+       end if
+    end do
+
+    !-------------------------------------------
+    ! initialize pft-level variables
+    !-------------------------------------------
+
+    do p = bounds%begp,bounds%endp
+
+       l = pft%landunit(p)
+       if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
+
+          if (pft%itype(p) == noveg) then
+             this%leafp_patch(p) = 0._r8
+             this%leafp_storage_patch(p) = 0._r8
+          else
+             this%leafp_patch(p)         = leafc_patch(p)         / ecophyscon%leafcp(pft%itype(p))
+             this%leafp_storage_patch(p) = leafc_storage_patch(p) / ecophyscon%leafcp(pft%itype(p))
+          end if
+
+          this%leafp_xfer_patch(p)        = 0._r8
+          if ( crop_prog )then
+             this%grainp_patch(p)         = 0._r8
+             this%grainp_storage_patch(p) = 0._r8
+             this%grainp_xfer_patch(p)    = 0._r8
+          end if
+          this%frootp_patch(p)            = 0._r8
+          this%frootp_storage_patch(p)    = 0._r8
+          this%frootp_xfer_patch(p)       = 0._r8
+          this%livestemp_patch(p)         = 0._r8
+          this%livestemp_storage_patch(p) = 0._r8
+          this%livestemp_xfer_patch(p)    = 0._r8
+
+          ! tree types need to be initialized with some stem mass so that
+          ! roughness length is not zero in canopy flux calculation
+
+          if (ecophyscon%woody(pft%itype(p)) == 1._r8) then
+             this%deadstemp_patch(p) = deadstemc_patch(p) / ecophyscon%deadwdcp(pft%itype(p))
+          else
+             this%deadstemp_patch(p) = 0._r8
+          end if
+
+          this%deadstemp_storage_patch(p)  = 0._r8
+          this%deadstemp_xfer_patch(p)     = 0._r8
+          this%livecrootp_patch(p)         = 0._r8
+          this%livecrootp_storage_patch(p) = 0._r8
+          this%livecrootp_xfer_patch(p)    = 0._r8
+          this%deadcrootp_patch(p)         = 0._r8
+          this%deadcrootp_storage_patch(p) = 0._r8
+          this%deadcrootp_xfer_patch(p)    = 0._r8
+          this%retransp_patch(p)           = 0._r8
+          this%ppool_patch(p)              = 0._r8
+          this%ptrunc_patch(p)             = 0._r8
+          this%dispvegp_patch(p)           = 0._r8
+          this%storvegp_patch(p)           = 0._r8
+          this%totvegp_patch(p)            = 0._r8
+          this%totpftp_patch(p)            = 0._r8
+       end if
+    end do
+
+    !-------------------------------------------
+    ! initialize column-level variables
+    !-------------------------------------------
+
+    do c = bounds%begc, bounds%endc
+       l = col%landunit(c)
+       if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
+
+          ! column phosphorus state variables
+          this%ptrunc_col(c) = 0._r8
+          this%sminp_col(c) = 0._r8
+          do j = 1, nlevdecomp
+             do k = 1, ndecomp_pools
+                this%decomp_ppools_vr_col(c,j,k) = decomp_cpools_vr_col(c,j,k) / decomp_cascade_con%initial_cp_ratio(k)
+             end do
+             this%sminp_vr_col(c,j) = 0._r8
+             this%ptrunc_vr_col(c,j) = 0._r8
+          end do
+          if ( nlevdecomp > 1 ) then
+             do j = nlevdecomp+1, nlevdecomp_full
+                do k = 1, ndecomp_pools
+                   this%decomp_ppools_vr_col(c,j,k) = 0._r8
+                end do
+                this%sminp_vr_col(c,j) = 0._r8
+                this%ptrunc_vr_col(c,j) = 0._r8
+             end do
+          end if
+          do k = 1, ndecomp_pools
+             this%decomp_ppools_col(c,k)    = decomp_cpools_col(c,k)    / decomp_cascade_con%initial_cp_ratio(k)
+             this%decomp_ppools_1m_col(c,k) = decomp_cpools_1m_col(c,k) / decomp_cascade_con%initial_cp_ratio(k)
+          end do
+
+          do j = 1, nlevdecomp_full
+             this%solutionp_vr_col(c,j) = 0._r8
+             this%labilep_vr_col(c,j)   = 0._r8
+             this%secondp_vr_col(c,j)   = 0._r8
+             this%occlp_vr_col(c,j)     = 0._r8
+             this%primp_vr_col(c,j)     = 0._r8
+             this%sminp_vr_col(c,j) = 0._r8
+          end do
+          this%solutionp_col(c) = 0._r8
+          this%labilep_col(c)   = 0._r8
+          this%secondp_col(c)   = 0._r8
+          this%occlp_col(c)     = 0._r8
+          this%primp_col(c)     = 0._r8
+
+          this%totlitp_col(c)    = 0._r8
+          this%totsomp_col(c)    = 0._r8
+          this%totlitp_1m_col(c) = 0._r8
+          this%totsomp_1m_col(c) = 0._r8
+          this%totecosysp_col(c) = 0._r8
+          this%totcolp_col(c)    = 0._r8
+          this%cwdp_col(c)       = 0._r8
+
+          ! dynamic landcover state variables
+          this%seedp_col(c)         = 0._r8
+          this%prod10p_col(c)       = 0._r8
+          this%prod100p_col(c)      = 0._r8
+          this%totprodp_col(c)      = 0._r8
+       end if
+    end do
+
+    ! now loop through special filters and explicitly set the variables that
+    ! have to be in place for biogeophysics
+
+    do fc = 1,num_special_col
+       c = special_col(fc)
+
+       this%seedp_col(c)    = 0._r8
+       this%prod10p_col(c)  = 0._r8	  
+       this%prod100p_col(c) = 0._r8	  
+       this%totprodp_col(c) = 0._r8	  
+    end do
+
+    ! initialize fields for special filters
+
+    call this%SetValues (&
+         num_patch=num_special_patch, filter_patch=special_patch, value_patch=0._r8, &
+         num_column=num_special_col, filter_column=special_col, value_column=0._r8)
+
+  end subroutine InitCold
+
+  !-----------------------------------------------------------------------
+  subroutine Restart ( this,  bounds, ncid, flag )
+    !
+    ! !DESCRIPTION: 
+    ! Read/write CN restart data for carbon state
+    !
+    ! !USES:
+    use shr_infnan_mod      , only : isnan => shr_infnan_isnan, nan => shr_infnan_nan, assignment(=)
+    use clm_time_manager    , only : is_restart, get_nstep
+    use restUtilMod
+    use ncdio_pio
+    !
+    ! !ARGUMENTS:
+    class (phosphorusstate_type) :: this
+    type(bounds_type)          , intent(in)    :: bounds 
+    type(file_desc_t)          , intent(inout) :: ncid   
+    character(len=*)           , intent(in)    :: flag   !'read' or 'write' or 'define'
+    !
+    ! !LOCAL VARIABLES:
+    integer            :: i,j,k,l,c
+    logical            :: readvar
+    integer            :: idata
+    logical            :: exit_spinup = .false.
+    logical            :: enter_spinup = .false.
+    real(r8)           :: m          ! multiplier for the exit_spinup code
+    real(r8), pointer  :: ptr2d(:,:) ! temp. pointers for slicing larger arrays
+    real(r8), pointer  :: ptr1d(:)   ! temp. pointers for slicing larger arrays
+    character(len=128) :: varname    ! temporary
+    integer            :: itemp      ! temporary 
+    integer , pointer  :: iptemp(:)  ! pointer to memory to be allocated
+    ! spinup state as read from restart file, for determining whether to enter or exit spinup mode.
+    integer            :: restart_file_spinup_state 
+    ! flags for comparing the model and restart decomposition cascades
+    integer            :: decomp_cascade_state, restart_file_decomp_cascade_state 
+    !------------------------------------------------------------------------
+
+    !--------------------------------
+    ! patch phosphorus state variables
+    !--------------------------------
+
+    call restartvar(ncid=ncid, flag=flag, varname='leafp', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%leafp_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='leafp_storage', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%leafp_storage_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='leafp_xfer', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%leafp_xfer_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='frootp', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%frootp_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='frootp_storage', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%frootp_storage_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='frootp_xfer', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%frootp_xfer_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='livestemp', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%livestemp_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='livestemp_storage', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%livestemp_storage_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='livestemp_xfer', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%livestemp_xfer_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='deadstemp', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%deadstemp_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='deadstemp_storage', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%deadstemp_storage_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='deadstemp_xfer', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%deadstemp_xfer_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='livecrootp', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%livecrootp_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='livecrootp_storage', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%livecrootp_storage_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='livecrootp_xfer', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%livecrootp_xfer_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='deadcrootp', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%deadcrootp_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='deadcrootp_storage', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%deadcrootp_storage_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='deadcrootp_xfer', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%deadcrootp_xfer_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='retransp', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%retransp_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='ppool', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%ppool_patch) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='pft_ptrunc', xtype=ncd_double,  &
+         dim1name='pft', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%ptrunc_patch) 
+
+    if (crop_prog) then
+       call restartvar(ncid=ncid, flag=flag,  varname='grainp', xtype=ncd_double,  &
+            dim1name='pft',    long_name='grain P', units='gP/m2', &
+            interpinic_flag='interp', readvar=readvar, data=this%grainp_patch)
+
+       call restartvar(ncid=ncid, flag=flag,  varname='grainp_storage', xtype=ncd_double,  &
+            dim1name='pft',    long_name='grain P storage', units='gP/m2', &
+            interpinic_flag='interp', readvar=readvar, data=this%grainp_storage_patch)
+
+       call restartvar(ncid=ncid, flag=flag,  varname='grainp_xfer', xtype=ncd_double,  &
+            dim1name='pft',    long_name='grain P transfer', units='gP/m2', &
+            interpinic_flag='interp', readvar=readvar, data=this%grainp_xfer_patch)
+    end if
+
+    !--------------------------------
+    ! column phosphorus state variables
+    !--------------------------------
+
+    ! sminn
+    if (use_vertsoilc) then
+       ptr2d => this%solutionp_vr_col
+       call restartvar(ncid=ncid, flag=flag, varname="solutionp_vr", xtype=ncd_double,  &
+            dim1name='column', dim2name='levgrnd', switchdim=.true., &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp', readvar=readvar, data=ptr2d)
+       ptr2d => this%labilep_vr_col
+       call restartvar(ncid=ncid, flag=flag, varname="labilep_vr", xtype=ncd_double,  &
+            dim1name='column', dim2name='levgrnd', switchdim=.true., &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp', readvar=readvar, data=ptr2d)
+       ptr2d => this%secondp_vr_col
+       call restartvar(ncid=ncid, flag=flag, varname="secondp_vr", xtype=ncd_double,  &
+            dim1name='column', dim2name='levgrnd', switchdim=.true., &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp', readvar=readvar, data=ptr2d)
+       ptr2d => this%occlp_vr_col
+       call restartvar(ncid=ncid, flag=flag, varname="occlp_vr", xtype=ncd_double,  &
+            dim1name='column', dim2name='levgrnd', switchdim=.true., &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp', readvar=readvar, data=ptr2d)
+       ptr2d => this%primp_vr_col
+       call restartvar(ncid=ncid, flag=flag, varname="primp_vr", xtype=ncd_double,  &
+            dim1name='column', dim2name='levgrnd', switchdim=.true., &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp', readvar=readvar, data=ptr2d)
+    else
+
+       ptr1d => this%solutionp_vr_col(:,1)
+       call restartvar(ncid=ncid, flag=flag, varname="solutionp", xtype=ncd_double,&
+            dim1name='column', &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp' , readvar=readvar, data=ptr1d)
+
+       ptr1d => this%labilep_vr_col(:,1)
+       call restartvar(ncid=ncid, flag=flag, varname="labilep", xtype=ncd_double,&
+            dim1name='column', &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp' , readvar=readvar, data=ptr1d)
+
+       ptr1d => this%secondp_vr_col(:,1)
+       call restartvar(ncid=ncid, flag=flag, varname="secondp", xtype=ncd_double,&
+            dim1name='column', &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp' , readvar=readvar, data=ptr1d)
+
+       ptr1d => this%occlp_vr_col(:,1)
+       call restartvar(ncid=ncid, flag=flag, varname="occlp", xtype=ncd_double,&
+            dim1name='column', &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp' , readvar=readvar, data=ptr1d)
+
+       ptr1d => this%primp_vr_col(:,1)
+       call restartvar(ncid=ncid, flag=flag, varname="primp", xtype=ncd_double,&
+            dim1name='column', &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp' , readvar=readvar, data=ptr1d)
+
+    end if
+    if (flag=='read' .and. .not. readvar) then
+       call endrun(msg='ERROR::'//trim(varname)//' is required on an initialization dataset'//&
+            errMsg(__FILE__, __LINE__))
+    end if
+
+    ! decomposing P pools
+    do k = 1, ndecomp_pools
+       varname=trim(decomp_cascade_con%decomp_pool_name_restart(k))//'p'
+       if (use_vertsoilc) then
+          ptr2d => this%decomp_ppools_vr_col(:,:,k)
+          call restartvar(ncid=ncid, flag=flag, varname=trim(varname)//"_vr", xtype=ncd_double, &
+               dim1name='column', dim2name='levgrnd', switchdim=.true., &
+               long_name='', units='', &
+               interpinic_flag='interp', readvar=readvar, data=ptr2d) 
+       else
+          ptr1d => this%decomp_ppools_vr_col(:,1,k)
+          call restartvar(ncid=ncid, flag=flag, varname=varname, xtype=ncd_double,  &
+               dim1name='column', &
+               long_name='',  units='', fill_value=spval, &
+               interpinic_flag='interp' , readvar=readvar, data=ptr1d)
+       end if
+       if (flag=='read' .and. .not. readvar) then
+          call endrun(msg='ERROR:: '//trim(varname)//' is required on an initialization dataset'//&
+               errMsg(__FILE__, __LINE__))
+       end if
+    end do
+
+    if (use_vertsoilc) then
+       ptr2d => this%ptrunc_vr_col
+       call restartvar(ncid=ncid, flag=flag, varname="col_ptrunc_vr", xtype=ncd_double,  &
+            dim1name='column', dim2name='levgrnd', switchdim=.true., &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp', readvar=readvar, data=ptr2d)
+    else
+       ptr1d => this%ptrunc_vr_col(:,1)
+       call restartvar(ncid=ncid, flag=flag, varname="col_ptrunc", xtype=ncd_double,  &
+            dim1name='column', &
+            long_name='',  units='', fill_value=spval, &
+            interpinic_flag='interp' , readvar=readvar, data=ptr1d)
+    end if
+
+
+
+    call restartvar(ncid=ncid, flag=flag, varname='totcolp', xtype=ncd_double,  &
+         dim1name='column', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%totcolp_col) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='seedp', xtype=ncd_double,  &
+         dim1name='column', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%seedp_col) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='prod10p', xtype=ncd_double,  &
+         dim1name='column', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%prod10p_col) 
+
+    call restartvar(ncid=ncid, flag=flag, varname='prod100p', xtype=ncd_double,  &
+         dim1name='column', long_name='', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%prod100p_col) 
+
+    ! decomp_cascade_state - the purpose of this is to check to make sure the bgc used 
+    ! matches what the restart file was generated with.  
+    ! add info about the SOM decomposition cascade
+
+!    if (use_century_decomp) then
+!       decomp_cascade_state = 1
+!    else
+!       decomp_cascade_state = 0
+!    end if
+    ! add info about the nitrification / denitrification state
+!    if (use_nitrif_denitrif) then
+!       decomp_cascade_state = decomp_cascade_state + 10
+!    end if
+!    if (flag == 'write') itemp = decomp_cascade_state    
+!    call restartvar(ncid=ncid, flag=flag, varname='decomp_cascade_state', xtype=ncd_int,  &
+!         long_name='BGC of the model that wrote this restart file:' &
+!         // '  1s column: 0 = CLM-CN cascade, 1 = Century cascade;' &
+!         // ' 10s column: 0 = CLM-CN denitrification, 10 = Century denitrification', units='', &
+!         interpinic_flag='skip', readvar=readvar, data=itemp)
+!    if (flag=='read') then
+!       if (.not. readvar) then
+!          ! assume, for sake of backwards compatibility, that if decomp_cascade_state 
+!          ! is not in the restart file, then the current model state is the same as 
+!          ! the prior model state
+!          restart_file_decomp_cascade_state = decomp_cascade_state
+!          if ( masterproc ) write(iulog,*) ' CNRest: WARNING!  Restart file does not ' &
+!               // ' contain info on decomp_cascade_state used to generate the restart file.  '
+!          if ( masterproc ) write(iulog,*) '   Assuming the same as current setting: ', decomp_cascade_state
+!       else
+!          restart_file_decomp_cascade_state = itemp  
+!          if (decomp_cascade_state /= restart_file_decomp_cascade_state ) then
+!             if ( masterproc ) then
+!                write(iulog,*) 'CNRest: ERROR--the decomposition cascade differs between the current ' &
+!                     // ' model state and the model that wrote the restart file. '
+!                write(iulog,*) 'The model will be horribly out of equilibrium until after a lengthy spinup. '
+!                write(iulog,*) 'Stopping here since this is probably an error in configuring the run. '
+!                write(iulog,*) 'If you really wish to proceed, then override by setting '
+!                write(iulog,*) 'override_bgc_restart_mismatch_dump to .true. in the namelist'
+!                if ( .not. override_bgc_restart_mismatch_dump ) then
+!                   call endrun(msg= ' CNRest: Stopping. Decomposition cascade mismatch error.'//&
+!                        errMsg(__FILE__, __LINE__))
+!                endif
+!             endif
+!          endif
+!       end if
+!    end if
+
+    !--------------------------------
+    ! Spinup state
+    !--------------------------------
+
+    ! Do nothing for write
+    ! Note that the call to write spinup_state out was done in CNCarbonStateType and
+    ! cannot be called again because it will try to define the variable twice
+    ! when the flag below is set to define
+    if (flag == 'read') then
+       call restartvar(ncid=ncid, flag=flag, varname='spinup_state', xtype=ncd_int,  &
+            long_name='Spinup state of the model that wrote this restart file: ' &
+            // ' 0 = normal model mode, 1 = AD spinup', units='', &
+            interpinic_flag='copy', readvar=readvar,  data=idata)
+       if (readvar) then
+          restart_file_spinup_state = idata
+       else
+          ! assume, for sake of backwards compatibility, that if spinup_state is not in 
+          ! the restart file then current model state is the same as prior model state
+          restart_file_spinup_state = spinup_state
+          if ( masterproc ) then
+             write(iulog,*) ' WARNING!  Restart file does not contain info ' &
+                  // ' on spinup state used to generate the restart file. '
+             write(iulog,*) '   Assuming the same as current setting: ', spinup_state
+          end if
+       end if
+    end if
+
+    ! now compare the model and restart file spinup states, and either take the 
+    ! model into spinup mode or out of it if they are not identical
+    ! taking model out of spinup mode requires multiplying each decomposing pool 
+    ! by the associated AD factor.
+    ! putting model into spinup mode requires dividing each decomposing pool 
+    ! by the associated AD factor.
+    ! only allow this to occur on first timestep of model run.
+
+    if (flag == 'read' .and. spinup_state /= restart_file_spinup_state ) then
+       if (spinup_state == 0 .and. restart_file_spinup_state == 1 ) then
+          if ( masterproc ) write(iulog,*) ' NitrogenStateType Restart: taking SOM pools out of AD spinup mode'
+          exit_spinup = .true.
+       else if (spinup_state == 1 .and. restart_file_spinup_state == 0 ) then
+          if ( masterproc ) write(iulog,*) ' NitrogenStateType Restart: taking SOM pools into AD spinup mode'
+          enter_spinup = .true.
+       else
+          call endrun(msg=' Error in entering/exiting spinup.  spinup_state ' &
+               // ' != restart_file_spinup_state, but do not know what to do'//&
+               errMsg(__FILE__, __LINE__))
+       end if
+       if (get_nstep() >= 2) then
+          call endrun(msg=' Error in entering/exiting spinup - should occur only when nstep = 1'//&
+               errMsg(__FILE__, __LINE__))
+       endif
+       do k = 1, ndecomp_pools
+          if ( exit_spinup ) then
+             m = decomp_cascade_con%spinup_factor(k)
+          else if ( enter_spinup ) then
+             m = 1. / decomp_cascade_con%spinup_factor(k)
+          end if
+          do c = bounds%begc, bounds%endc
+             do j = 1, nlevdecomp
+                this%decomp_ppools_vr_col(c,j,k) = this%decomp_ppools_vr_col(c,j,k) * m
+             end do
+          end do
+       end do
+    end if
+
+  end subroutine Restart
+
+  !-----------------------------------------------------------------------
+  subroutine SetValues ( this, &
+       num_patch, filter_patch, value_patch, &
+       num_column, filter_column, value_column)
+    !
+    ! !DESCRIPTION:
+    ! Set phosphorus state variables
+    !
+    ! !ARGUMENTS:
+    class (phosphorusstate_type) :: this
+    integer , intent(in) :: num_patch
+    integer , intent(in) :: filter_patch(:)
+    real(r8), intent(in) :: value_patch
+    integer , intent(in) :: num_column
+    integer , intent(in) :: filter_column(:)
+    real(r8), intent(in) :: value_column
+    !
+    ! !LOCAL VARIABLES:
+    integer :: fi,i     ! loop index
+    integer :: j,k      ! indices
+    !------------------------------------------------------------------------
+
+    do fi = 1,num_patch
+       i = filter_patch(fi)
+
+       this%leafp_patch(i)              = value_patch
+       this%leafp_storage_patch(i)      = value_patch
+       this%leafp_xfer_patch(i)         = value_patch
+       this%frootp_patch(i)             = value_patch
+       this%frootp_storage_patch(i)     = value_patch
+       this%frootp_xfer_patch(i)        = value_patch
+       this%livestemp_patch(i)          = value_patch
+       this%livestemp_storage_patch(i)  = value_patch
+       this%livestemp_xfer_patch(i)     = value_patch
+       this%deadstemp_patch(i)          = value_patch
+       this%deadstemp_storage_patch(i)  = value_patch
+       this%deadstemp_xfer_patch(i)     = value_patch
+       this%livecrootp_patch(i)         = value_patch
+       this%livecrootp_storage_patch(i) = value_patch
+       this%livecrootp_xfer_patch(i)    = value_patch
+       this%deadcrootp_patch(i)         = value_patch
+       this%deadcrootp_storage_patch(i) = value_patch
+       this%deadcrootp_xfer_patch(i)    = value_patch
+       this%retransp_patch(i)           = value_patch
+       this%ppool_patch(i)              = value_patch
+       this%ptrunc_patch(i)             = value_patch
+       this%dispvegp_patch(i)           = value_patch
+       this%storvegp_patch(i)           = value_patch
+       this%totvegp_patch(i)            = value_patch
+       this%totpftp_patch(i)            = value_patch
+    end do
+
+    if ( crop_prog )then
+       do fi = 1,num_patch
+          i = filter_patch(fi)
+          this%grainp_patch(i)          = value_patch
+          this%grainp_storage_patch(i)  = value_patch
+          this%grainp_xfer_patch(i)     = value_patch   
+       end do
+    end if
+
+    do fi = 1,num_column
+       i = filter_column(fi)
+
+       this%sminp_col(i)       = value_column
+       this%solutionp_col(i)   = value_column
+       this%labilep_col(i)     = value_column
+       this%secondp_col(i)     = value_column
+       this%occlp_col(i)       = value_column
+       this%primp_col(i)       = value_column
+       this%ptrunc_col(i)      = value_column
+       this%cwdp_col(i)        = value_column
+       this%totlitp_col(i)     = value_column
+       this%totsomp_col(i)     = value_column
+       this%totecosysp_col(i)  = value_column
+       this%totcolp_col(i)     = value_column
+       this%totsomp_1m_col(i)  = value_column
+       this%totlitp_1m_col(i)  = value_column
+    end do
+
+    do j = 1,nlevdecomp_full
+       do fi = 1,num_column
+          i = filter_column(fi)
+          this%sminp_vr_col(i,j)       = value_column
+          this%solutionp_vr_col(i,j)   = value_column
+          this%labilep_vr_col(i,j)     = value_column
+          this%secondp_vr_col(i,j)     = value_column
+          this%occlp_vr_col(i,j)       = value_column
+          this%primp_vr_col(i,j)       = value_column
+          this%ptrunc_vr_col(i,j)      = value_column
+       end do
+    end do
+
+    ! column and decomp_pools
+    do k = 1, ndecomp_pools
+       do fi = 1,num_column
+          i = filter_column(fi)
+          this%decomp_ppools_col(i,k)    = value_column
+          this%decomp_ppools_1m_col(i,k) = value_column
+       end do
+    end do
+
+    ! column levdecomp, and decomp_pools
+    do j = 1,nlevdecomp_full
+       do k = 1, ndecomp_pools
+          do fi = 1,num_column
+             i = filter_column(fi)
+             this%decomp_ppools_vr_col(i,j,k) = value_column
+          end do
+       end do
+    end do
+
+  end subroutine SetValues
+
+  !-----------------------------------------------------------------------
+  subroutine ZeroDwt( this, bounds )
+    !
+    ! !DESCRIPTION
+    ! Initialize variables needed for dynamic land use.
+    !
+    ! !ARGUMENTS:
+    class(phosphorusstate_type) :: this
+    type(bounds_type), intent(in)  :: bounds 
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: p          ! indices
+    !-----------------------------------------------------------------------
+
+    do p = bounds%begp,bounds%endp
+       this%dispvegp_patch(p) = 0._r8
+       this%storvegp_patch(p) = 0._r8
+       this%totvegp_patch(p)  = 0._r8
+       this%totpftp_patch(p)  = 0._r8
+    end do
+
+  end subroutine ZeroDwt
+
+  !-----------------------------------------------------------------------
+  subroutine Summary(this, bounds, num_soilc, filter_soilc, num_soilp, filter_soilp)
+    !
+    ! !USES:
+    use clm_varpar    , only: nlevdecomp,ndecomp_cascade_transitions,ndecomp_pools
+    use clm_varctl    , only: use_nitrif_denitrif
+    use subgridAveMod , only: p2c
+    !
+    ! !ARGUMENTS:
+    class (phosphorusstate_type) :: this
+    type(bounds_type) , intent(in) :: bounds  
+    integer           , intent(in) :: num_soilc       ! number of soil columns in filter
+    integer           , intent(in) :: filter_soilc(:) ! filter for soil columns
+    integer           , intent(in) :: num_soilp       ! number of soil patches in filter
+    integer           , intent(in) :: filter_soilp(:) ! filter for soil patches
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c,p,j,k,l   ! indices
+    integer  :: fp,fc       ! lake filter indices
+    real(r8) :: maxdepth    ! depth to integrate soil variables
+    !-----------------------------------------------------------------------
+
+    do fp = 1,num_soilp
+       p = filter_soilp(fp)
+
+       ! displayed vegetation phosphorus, excluding storage (DISPVEGN)
+       this%dispvegp_patch(p) = &
+            this%leafp_patch(p)      + &
+            this%frootp_patch(p)     + &
+            this%livestemp_patch(p)  + &
+            this%deadstemp_patch(p)  + &
+            this%livecrootp_patch(p) + &
+            this%deadcrootp_patch(p)
+       
+      ! stored vegetation phosphorus, including retranslocated N pool (STORVEGN)
+      this%storvegp_patch(p) = &
+           this%leafp_storage_patch(p)      + &
+           this%frootp_storage_patch(p)     + &
+           this%livestemp_storage_patch(p)  + &
+           this%deadstemp_storage_patch(p)  + &
+           this%livecrootp_storage_patch(p) + &
+           this%deadcrootp_storage_patch(p) + &
+           this%leafp_xfer_patch(p)         + &
+           this%frootp_xfer_patch(p)        + &
+           this%livestemp_xfer_patch(p)     + &
+           this%deadstemp_xfer_patch(p)     + &
+           this%livecrootp_xfer_patch(p)    + &
+           this%deadcrootp_xfer_patch(p)    + &
+           this%ppool_patch(p)              + &
+           this%retransp_patch(p)
+
+      if ( crop_prog .and. pft%itype(p) >= npcropmin )then
+         this%dispvegp_patch(p) = &
+              this%dispvegp_patch(p) + &
+              this%grainp_patch(p)
+
+         this%storvegp_patch(p) = &
+              this%storvegp_patch(p) + &
+              this%grainp_storage_patch(p)     + &
+              this%grainp_xfer_patch(p)
+      end if
+
+      ! total vegetation phosphorus (TOTVEGN)
+      this%totvegp_patch(p) = &
+           this%dispvegp_patch(p) + &
+           this%storvegp_patch(p)
+
+      ! total pft-level carbon (add pft_ntrunc)
+      this%totpftp_patch(p) = &
+           this%totvegp_patch(p) + &
+           this%ptrunc_patch(p)
+
+   end do
+
+   call p2c(bounds, num_soilc, filter_soilc, &
+        this%totvegp_patch(bounds%begp:bounds%endp), &
+        this%totvegp_col(bounds%begc:bounds%endc))
+
+   call p2c(bounds, num_soilc, filter_soilc, &
+        this%totpftp_patch(bounds%begp:bounds%endp), &
+        this%totpftp_col(bounds%begc:bounds%endc))
+
+   ! vertically integrate soil mineral P pools
+
+   do fc = 1,num_soilc
+      c = filter_soilc(fc)
+      this%solutionp_col(c) =0._r8
+      this%labilep_col(c)   =0._r8
+      this%secondp_col(c)   =0._r8
+      this%occlp_col(c)     =0._r8
+      this%primp_col(c)     =0._r8
+   end do
+
+
+   do j = 1, nlevdecomp
+      do fc = 1,num_soilc
+         c = filter_soilc(fc)
+         this%solutionp_col(c) = &
+              this%solutionp_col(c) + &
+              this%solutionp_vr_col(c,j) * dzsoi_decomp(j)
+         this%labilep_col(c) = &
+              this%labilep_col(c) + &
+              this%labilep_vr_col(c,j) * dzsoi_decomp(j)
+         this%secondp_col(c) = &
+              this%secondp_col(c) + &
+              this%secondp_vr_col(c,j) * dzsoi_decomp(j)
+         this%occlp_col(c) = &
+              this%occlp_col(c) + &
+              this%occlp_vr_col(c,j) * dzsoi_decomp(j)
+         this%primp_col(c) = &
+              this%primp_col(c) + &
+              this%primp_vr_col(c,j) * dzsoi_decomp(j)
+      end do 
+   end do
+
+
+   ! vertically integrate each of the decomposing P pools
+   do l = 1, ndecomp_pools
+      do fc = 1,num_soilc
+         c = filter_soilc(fc)
+         this%decomp_ppools_col(c,l) = 0._r8
+      end do
+      do j = 1, nlevdecomp
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            this%decomp_ppools_col(c,l) = &
+                 this%decomp_ppools_col(c,l) + &
+                 this%decomp_ppools_vr_col(c,j,l) * dzsoi_decomp(j)
+         end do
+      end do
+   end do
+
+   ! for vertically-resolved soil biogeochemistry, calculate some diagnostics of carbon pools to a given depth
+   if ( nlevdecomp > 1) then
+
+      do l = 1, ndecomp_pools
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            this%decomp_ppools_1m_col(c,l) = 0._r8
+         end do
+      end do
+
+      ! vertically integrate each of the decomposing n pools to 1 meter
+      maxdepth = 1._r8
+      do l = 1, ndecomp_pools
+         do j = 1, nlevdecomp
+            if ( zisoi(j) <= maxdepth ) then
+               do fc = 1,num_soilc
+                  c = filter_soilc(fc)
+                  this%decomp_ppools_1m_col(c,l) = &
+                       this%decomp_ppools_1m_col(c,l) + &
+                       this%decomp_ppools_vr_col(c,j,l) * dzsoi_decomp(j)
+               end do
+            elseif ( zisoi(j-1) < maxdepth ) then
+               do fc = 1,num_soilc
+                  c = filter_soilc(fc)
+                  this%decomp_ppools_1m_col(c,l) = &
+                       this%decomp_ppools_1m_col(c,l) + &
+                       this%decomp_ppools_vr_col(c,j,l) * (maxdepth - zisoi(j-1))
+               end do
+            endif
+         end do
+      end do
+      
+      ! total litter phosphorus to 1 meter (TOTLITN_1m)
+      do fc = 1,num_soilc
+         c = filter_soilc(fc)
+         this%totlitp_1m_col(c) = 0._r8
+      end do
+      do l = 1, ndecomp_pools
+         if ( decomp_cascade_con%is_litter(l) ) then
+            do fc = 1,num_soilc
+               c = filter_soilc(fc)
+               this%totlitp_1m_col(c) = &
+                    this%totlitp_1m_col(c) + &
+                    this%decomp_ppools_1m_col(c,l)
+            end do
+         end if
+      end do
+      
+      ! total soil organic matter phosphorus to 1 meter (TOTSOMN_1m)
+      do fc = 1,num_soilc
+         c = filter_soilc(fc)
+         this%totsomp_1m_col(c) = 0._r8
+      end do
+      do l = 1, ndecomp_pools
+         if ( decomp_cascade_con%is_soil(l) ) then
+            do fc = 1,num_soilc
+               c = filter_soilc(fc)
+               this%totsomp_1m_col(c) = &
+                    this%totsomp_1m_col(c) + &
+                    this%decomp_ppools_1m_col(c,l)
+            end do
+         end if
+      end do
+      
+   endif
+   
+   ! total litter phosphorus (TOTLITN)
+   do fc = 1,num_soilc
+      c = filter_soilc(fc)
+      this%totlitp_col(c)    = 0._r8
+   end do
+   do l = 1, ndecomp_pools
+      if ( decomp_cascade_con%is_litter(l) ) then
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            this%totlitp_col(c) = &
+                 this%totlitp_col(c) + &
+                 this%decomp_ppools_col(c,l)
+         end do
+      end if
+   end do
+   
+   ! total soil organic matter phosphorus (TOTSOMN)
+   do fc = 1,num_soilc
+      c = filter_soilc(fc)
+      this%totsomp_col(c)    = 0._r8
+   end do
+   do l = 1, ndecomp_pools
+      if ( decomp_cascade_con%is_soil(l) ) then
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            this%totsomp_col(c) = &
+                 this%totsomp_col(c) + &
+                 this%decomp_ppools_col(c,l)
+         end do
+      end if
+   end do
+   
+   ! total cwdn
+   do fc = 1,num_soilc
+      c = filter_soilc(fc)
+      this%cwdp_col(c) = 0._r8
+   end do
+   do l = 1, ndecomp_pools
+      if ( decomp_cascade_con%is_cwd(l) ) then
+         do fc = 1,num_soilc
+            c = filter_soilc(fc)
+            this%cwdp_col(c) = &
+                 this%cwdp_col(c) + &
+                 this%decomp_ppools_col(c,l)
+         end do
+      end if
+   end do
+
+   ! total sminp
+   do fc = 1,num_soilc
+      c = filter_soilc(fc)
+      this%sminp_col(c)      = 0._r8
+   end do
+   do j = 1, nlevdecomp
+      do fc = 1,num_soilc
+         c = filter_soilc(fc)
+         this%sminp_vr_col(c,j) = this%solutionp_vr_col(c,j)+ &
+                                  this%labilep_vr_col(c,j)+ &
+                                  this%secondp_vr_col(c,j)
+!                                  this%occlp_vr_col(c,j)+ &
+!                                  this%primp_vr_col(c,j)
+      end do
+   end do
+   do j = 1, nlevdecomp
+      do fc = 1,num_soilc
+         c = filter_soilc(fc)
+         this%sminp_col(c) =  this%sminp_col(c) + &
+         this%sminp_vr_col(c,j) * dzsoi_decomp(j)
+      end do
+   end do
+
+
+   ! total col_ntrunc
+   do fc = 1,num_soilc
+      c = filter_soilc(fc)
+      this%ptrunc_col(c) = 0._r8
+   end do
+   do j = 1, nlevdecomp
+      do fc = 1,num_soilc
+         c = filter_soilc(fc)
+         this%ptrunc_col(c) = &
+              this%ptrunc_col(c) + &
+              this%ptrunc_vr_col(c,j) * dzsoi_decomp(j)
+      end do
+   end do
+
+   do fc = 1,num_soilc
+      c = filter_soilc(fc)
+
+      ! total wood product phosphorus
+      this%totprodp_col(c) = &
+           this%prod10p_col(c) + &
+           this%prod100p_col(c)	 
+
+      ! total ecosystem phosphorus, including veg (TOTECOSYSP)
+      this%totecosysp_col(c) = &
+           this%cwdp_col(c) + &
+           this%totlitp_col(c) + &
+           this%totsomp_col(c) + &
+           this%solutionp_col(c) + &
+           this%labilep_col(c) + &
+           this%secondp_col(c) + &
+           this%primp_col(c) + &
+           this%occlp_col(c) + &
+           this%totprodp_col(c) + &
+           this%totvegp_col(c)
+
+      ! total column phosphorus, including pft (TOTCOLP)
+      this%totcolp_col(c) = &
+           this%totpftp_col(c) + &
+           this%cwdp_col(c) + &
+           this%totlitp_col(c) + &
+           this%totsomp_col(c) + &
+           this%solutionp_col(c) + &
+           this%labilep_col(c) + &
+           this%secondp_col(c) + &
+           this%totprodp_col(c) + &
+           this%seedp_col(c) 
+   end do
+
+ end subroutine Summary
+
+end module PhosphorusStateType

--- a/models/lnd/clm/src/main/EcophysConType.F90
+++ b/models/lnd/clm/src/main/EcophysConType.F90
@@ -76,6 +76,15 @@ module EcophysConType
      real(r8), allocatable :: fleafcn       (:)   ! C:N during grain fill; leaf (crop)
      real(r8), allocatable :: ffrootcn      (:)   ! C:N during grain fill; froot (crop)
      real(r8), allocatable :: fstemcn       (:)   ! C:N during grain fill; stem (crop)
+
+
+     real(r8), allocatable :: leafcp        (:)   ! leaf C:P (gC/gP)
+     real(r8), allocatable :: lflitcp       (:)   ! leaf litter C:P (gC/gP)
+     real(r8), allocatable :: frootcp       (:)   ! fine root C:P (gC/gP)
+     real(r8), allocatable :: livewdcp      (:)   ! live wood (phloem and ray parenchyma) C:P (gC/gP)
+     real(r8), allocatable :: deadwdcp      (:)   ! dead wood (xylem and heartwood) C:P (gC/gP)
+     real(r8), allocatable :: graincp       (:)   ! grain C:P (gC/gP) for prognostic crop model
+
   end type Ecophyscon_type
 
   type(ecophyscon_type), public :: ecophyscon ! patch ecophysiological constants structure
@@ -94,6 +103,7 @@ contains
     use pftvarcon , only : flivewd, fcur, lf_flab, lf_fcel, lf_flig, fr_flab, fr_fcel, fr_flig
     use pftvarcon , only : leaf_long, evergreen, stress_decid, season_decid
     use pftvarcon , only : fertnitro, graincn, fleafcn, ffrootcn, fstemcn, dwood
+    use pftvarcon , only : leafcp,lflitcp, frootcp, livewdcp, deadwdcp,graincp
     !
     ! !LOCAL VARIABLES:
     integer :: m, ib
@@ -148,6 +158,14 @@ contains
     allocate(ecophyscon%ffrootcn      (0:numpft))        ; ecophyscon%ffrootcn     (:)   =nan
     allocate(ecophyscon%fstemcn       (0:numpft))        ; ecophyscon%fstemcn      (:)   =nan
 
+
+    allocate(ecophyscon%leafcp        (0:numpft))        ; ecophyscon%leafcp       (:)   =nan
+    allocate(ecophyscon%lflitcp       (0:numpft))        ; ecophyscon%lflitcp      (:)   =nan
+    allocate(ecophyscon%frootcp       (0:numpft))        ; ecophyscon%frootcp      (:)   =nan
+    allocate(ecophyscon%livewdcp      (0:numpft))        ; ecophyscon%livewdcp     (:)   =nan
+    allocate(ecophyscon%deadwdcp      (0:numpft))        ; ecophyscon%deadwdcp     (:)   =nan
+    allocate(ecophyscon%graincp       (0:numpft))        ; ecophyscon%graincp      (:)   =nan
+
     do m = 0,numpft
 
        if (m <= ntree) then
@@ -201,6 +219,14 @@ contains
        ecophyscon%fleafcn(m)      = fleafcn(m)
        ecophyscon%ffrootcn(m)     = ffrootcn(m)
        ecophyscon%fstemcn(m)      = fstemcn(m)
+
+       ecophyscon%leafcp(m)       = leafcp(m)
+       ecophyscon%lflitcp(m)      = lflitcp(m)
+       ecophyscon%frootcp(m)      = frootcp(m)
+       ecophyscon%livewdcp(m)     = livewdcp(m)
+       ecophyscon%deadwdcp(m)     = deadwdcp(m)
+       ecophyscon%graincp(m)      = graincp(m)
+
     end do
   end subroutine ecophysconInit
 

--- a/models/lnd/clm/src/main/SoilorderConType.F90
+++ b/models/lnd/clm/src/main/SoilorderConType.F90
@@ -1,0 +1,83 @@
+module SoilorderConType
+
+  ! !USES:
+  use shr_kind_mod   , only : r8 => shr_kind_r8
+  use shr_log_mod    , only : errMsg => shr_log_errMsg
+  use shr_infnan_mod , only : nan => shr_infnan_nan, assignment(=)
+  use abortutils     , only : endrun
+  !
+  implicit none
+  save
+  public
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public :: soilorderconInit
+  !
+  ! !PUBLIC TYPES:
+  type, public :: soilordercon_type
+     real(r8), allocatable :: smax(:)
+     real(r8), allocatable :: ks_sorption(:)
+     real(r8), allocatable :: r_weather(:)
+     real(r8), allocatable :: r_adsorp(:)
+     real(r8), allocatable :: r_desorp(:)
+     real(r8), allocatable :: r_occlude(:)
+     real(r8), allocatable :: k_s1_biochem(:)
+     real(r8), allocatable :: k_s2_biochem(:)
+     real(r8), allocatable :: k_s3_biochem(:)
+     real(r8), allocatable :: k_s4_biochem(:)
+
+
+  end type soilordercon_type
+
+  type(soilordercon_type), public :: soilordercon ! soil order constants
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine soilorderconInit()
+    !
+    ! !USES:
+    use clm_varpar, only : nsoilorder
+    use soilorder_varcon, only : smax
+    use soilorder_varcon, only : ks_sorption
+    use soilorder_varcon, only : r_weather,r_adsorp,r_desorp,r_occlude
+    use soilorder_varcon, only : k_s1_biochem,k_s2_biochem,k_s3_biochem,k_s4_biochem
+    !
+    ! !LOCAL VARIABLES:
+    integer :: m, ib
+    !------------------------------------------------------------------------
+
+
+    allocate(soilordercon%smax           (0:nsoilorder))        ; soilordercon%smax(:)        =nan
+    allocate(soilordercon%ks_sorption    (0:nsoilorder))        ; soilordercon%ks_sorption(:) =nan
+    allocate(soilordercon%r_weather      (0:nsoilorder))        ; soilordercon%r_weather(:)   =nan
+    allocate(soilordercon%r_adsorp       (0:nsoilorder))        ; soilordercon%r_adsorp(:)    =nan
+    allocate(soilordercon%r_desorp       (0:nsoilorder))        ; soilordercon%r_desorp(:)    =nan
+    allocate(soilordercon%r_occlude      (0:nsoilorder))        ; soilordercon%r_occlude(:)    =nan
+
+    allocate(soilordercon%k_s1_biochem      (0:nsoilorder))        ; soilordercon%k_s1_biochem(:)    =nan
+    allocate(soilordercon%k_s2_biochem      (0:nsoilorder))        ; soilordercon%k_s2_biochem(:)    =nan
+    allocate(soilordercon%k_s3_biochem      (0:nsoilorder))        ; soilordercon%k_s3_biochem(:)    =nan
+    allocate(soilordercon%k_s4_biochem      (0:nsoilorder))        ; soilordercon%k_s4_biochem(:)    =nan
+
+
+    do m = 0,nsoilorder
+
+
+       soilordercon%smax(m)         = smax(m)
+       soilordercon%ks_sorption(m)         = ks_sorption(m)
+       soilordercon%r_weather(m)         = r_weather(m)
+       soilordercon%r_adsorp(m)         = r_adsorp(m)
+       soilordercon%r_desorp(m)         = r_desorp(m)
+       soilordercon%r_occlude(m)         = r_occlude(m)
+       soilordercon%k_s1_biochem(m)         = k_s1_biochem(m)
+       soilordercon%k_s2_biochem(m)         = k_s2_biochem(m)
+       soilordercon%k_s3_biochem(m)         = k_s3_biochem(m)
+       soilordercon%k_s4_biochem(m)         = k_s4_biochem(m)
+
+
+    end do
+  end subroutine soilorderconInit
+
+end module SoilorderConType
+                               

--- a/models/lnd/clm/src/main/clm_varctl.F90
+++ b/models/lnd/clm/src/main/clm_varctl.F90
@@ -13,6 +13,10 @@ module clm_varctl
   public :: clm_varctl_set    ! Set variables
   public :: cnallocate_carbon_only_set
   public :: cnallocate_carbon_only
+  public :: cnallocate_carbonnitrogen_only_set
+  public :: cnallocate_carbonnitrogen_only
+  public :: cnallocate_carbonphosphorus_only_set
+  public :: cnallocate_carbonphosphorus_only
   !
   private
   save
@@ -94,6 +98,9 @@ module clm_varctl
   character(len=fname_len), public :: fsnowoptics  = ' '      ! snow optical properties file name
   character(len=fname_len), public :: fsnowaging   = ' '      ! snow aging parameters file name
 
+ !! X. YANG  : add soil order dependent parameter file
+  character(len=fname_len), public :: fsoilordercon    = ' '  ! ASCII data file with soil order dependent  constants
+
   !----------------------------------------------------------
   ! Flag to turn on MEGAN VOC's
   !----------------------------------------------------------
@@ -153,6 +160,8 @@ module clm_varctl
 
   ! Set in CNAllocationInit (TODO - had to move it here to avoid circular dependency)
   logical, private:: carbon_only      
+  logical, private:: carbonnitrogen_only      
+  logical, private:: carbonphosphorus_only      
 
   !----------------------------------------------------------
   ! Physics
@@ -333,5 +342,31 @@ contains
   logical function CNAllocate_Carbon_only()
     cnallocate_carbon_only = carbon_only
   end function CNAllocate_Carbon_only
+
+
+  ! Set module carbonnitrogen_only flag
+  subroutine cnallocate_carbonnitrogen_only_set(carbonnitrogen_only_in)
+    logical, intent(in) :: carbonnitrogen_only_in
+    carbonnitrogen_only = carbonnitrogen_only_in
+  end subroutine cnallocate_carbonnitrogen_only_set
+
+  ! Get module carbonnitrogen_only flag
+  logical function CNAllocate_CarbonNitrogen_only()
+    cnallocate_carbonnitrogen_only = carbonnitrogen_only
+  end function CNAllocate_CarbonNitrogen_only
+
+
+  ! Set module carbonphosphorus_only flag
+  subroutine cnallocate_carbonphosphorus_only_set(carbonphosphorus_only_in)
+    logical, intent(in) :: carbonphosphorus_only_in
+    carbonphosphorus_only = carbonphosphorus_only_in
+  end subroutine cnallocate_carbonphosphorus_only_set
+
+  ! Get module carbonphosphorus_only flag
+  logical function CNAllocate_CarbonPhosphorus_only()
+    cnallocate_carbonphosphorus_only = carbonphosphorus_only
+  end function CNAllocate_CarbonPhosphorus_only
+
+
 
 end module clm_varctl

--- a/models/lnd/clm/src/main/clm_varpar.F90
+++ b/models/lnd/clm/src/main/clm_varpar.F90
@@ -57,6 +57,8 @@ module clm_varpar
 
   integer :: maxpatch_pft        ! max number of plant functional types in naturally vegetated landunit (namelist setting)
 
+  integer, parameter :: nsoilorder  =  15     ! number of soil orders
+
   ! constants for decomposition cascade
 
   integer :: i_met_lit 

--- a/models/lnd/clm/src/main/pftvarcon.F90
+++ b/models/lnd/clm/src/main/pftvarcon.F90
@@ -78,8 +78,16 @@ module pftvarcon
   real(r8), allocatable :: grpnow(:)      !growth respiration parameter
   real(r8), allocatable :: rootprof_beta(:) !CLM rooting distribution parameter for C and N inputs [unitless]
 
+  ! add pft dependent parameters for phosphorus -X.YANG
+  real(r8), allocatable :: leafcp(:)      !leaf C:P [gC/gP]
+  real(r8), allocatable :: lflitcp(:)     !leaf litter C:P (gC/gP)
+  real(r8), allocatable :: frootcp(:)     !fine root C:P (gC/gP)
+  real(r8), allocatable :: livewdcp(:)    !live wood (phloem and ray parenchyma) C:P (gC/gP)
+  real(r8), allocatable :: deadwdcp(:)    !dead wood (xylem and heartwood) C:P (gC/gP)
+
   ! for crop
   real(r8), allocatable :: graincn(:)      !grain C:N (gC/gN)
+  real(r8), allocatable :: graincp(:)      !grain C:N (gC/gN)
   real(r8), allocatable :: mxtmp(:)        !parameter used in accFlds
   real(r8), allocatable :: baset(:)        !parameter used in accFlds
   real(r8), allocatable :: declfact(:)     !parameter used in CNAllocation
@@ -268,10 +276,19 @@ contains
     allocate( frootcn       (0:mxpft) )      
     allocate( livewdcn      (0:mxpft) )     
     allocate( deadwdcn      (0:mxpft) )     
+
+    ! add phosphorus 
+    allocate( leafcp        (0:mxpft) )      
+    allocate( lflitcp       (0:mxpft) )      
+    allocate( frootcp       (0:mxpft) )      
+    allocate( livewdcp      (0:mxpft) )     
+    allocate( deadwdcp      (0:mxpft) )     
+
     allocate( grperc        (0:mxpft) )       
     allocate( grpnow        (0:mxpft) )       
     allocate( rootprof_beta (0:mxpft) )
     allocate( graincn       (0:mxpft) )      
+    allocate( graincp       (0:mxpft) )      
     allocate( mxtmp         (0:mxpft) )        
     allocate( baset         (0:mxpft) )        
     allocate( declfact      (0:mxpft) )     
@@ -405,6 +422,20 @@ contains
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('deadwdcn',deadwdcn, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+
+
+    call ncd_io('leafcp',leafcp, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+    call ncd_io('lflitcp',lflitcp, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+    call ncd_io('frootcp',frootcp, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+    call ncd_io('livewdcp',livewdcp, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+    call ncd_io('deadwdcp',deadwdcp, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+
+
     call ncd_io('grperc',grperc, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('grpnow',grpnow, 'read', ncid, readvar=readv, posNOTonfile=.true.)
@@ -472,6 +503,8 @@ contains
     call ncd_io('pprod100',pprod100, 'read', ncid, readvar=readv)  
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('graincn',graincn, 'read', ncid, readvar=readv)  
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
+    call ncd_io('graincp',graincp, 'read', ncid, readvar=readv)  
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('mxtmp',mxtmp, 'read', ncid, readvar=readv)  
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))

--- a/models/lnd/clm/src/main/restFileMod.F90
+++ b/models/lnd/clm/src/main/restFileMod.F90
@@ -28,6 +28,10 @@ module restFileMod
   use CNStateType          , only : cnstate_type
   use CNNitrogenFluxType   , only : nitrogenflux_type
   use CNNitrogenStateType  , only : nitrogenstate_type
+
+  use PhosphorusFluxType     , only : phosphorusflux_type
+  use PhosphorusStateType    , only : phosphorusstate_type
+
   use AerosolType          , only : aerosol_type
   use CanopyStateType      , only : canopystate_type
   use EnergyFluxType       , only : energyflux_type
@@ -89,7 +93,8 @@ contains
        ch4_vars, dgvs_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
        nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
        soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,   &
-       waterflux_vars, waterstate_vars, EDbio_vars, rdate, noptr)
+       waterflux_vars, waterstate_vars, EDbio_vars, &
+       phosphorusstate_vars,phosphorusflux_vars,rdate,noptr)
     !
     ! !DESCRIPTION:
     ! Define/write CLM restart file.
@@ -121,6 +126,10 @@ contains
     type(waterstate_type)    , intent(inout) :: waterstate_vars  ! due to EDrest call
     type(waterflux_type)     , intent(in)    :: waterflux_vars
     type(EDbio_type)         , intent(inout) :: EDbio_vars       ! due to EDrest call
+
+    type(phosphorusstate_type),intent(inout)    :: phosphorusstate_vars
+    type(phosphorusflux_type) ,intent(in)     :: phosphorusflux_vars
+
     character(len=*)         , intent(in), optional :: rdate     ! restart file time stamp for name
     logical                  , intent(in), optional :: noptr     ! if should NOT write to the restart pointer file
     !
@@ -206,6 +215,9 @@ contains
        call carbonflux_vars%restart(bounds, ncid, flag='define')
        call nitrogenflux_vars%Restart(bounds, ncid, flag='define')
        call nitrogenstate_vars%Restart(bounds, ncid, flag='define')
+
+       call phosphorusflux_vars%Restart(bounds, ncid, flag='define')
+       call phosphorusstate_vars%Restart(bounds, ncid, flag='define')
 
        call cnstate_vars%Restart(bounds, ncid, flag='define')
 
@@ -293,6 +305,9 @@ contains
        call nitrogenflux_vars%Restart(bounds, ncid, flag='write')
        call nitrogenstate_vars%Restart(bounds, ncid, flag='write')
 
+       call phosphorusflux_vars%Restart(bounds, ncid, flag='write')
+       call phosphorusstate_vars%Restart(bounds, ncid, flag='write')
+
        call cnstate_vars%Restart(bounds, ncid, flag='write')
 
     end if
@@ -340,7 +355,8 @@ contains
        ch4_vars, dgvs_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
        nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
        soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,   &
-       waterflux_vars, waterstate_vars, EDbio_vars)
+       waterflux_vars, waterstate_vars, EDbio_vars,&
+       phosphorusstate_vars,phosphorusflux_vars)
     !
     ! !DESCRIPTION:
     ! Read a CLM restart file.
@@ -377,6 +393,10 @@ contains
     type(waterstate_type)    , intent(inout) :: waterstate_vars
     type(waterflux_type)     , intent(inout) :: waterflux_vars
     type(EDbio_type)         , intent(inout) :: EDbio_vars
+
+    type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+    type(phosphorusflux_type)  , intent(inout) :: phosphorusflux_vars
+
     !
     ! !LOCAL VARIABLES:
     type(file_desc_t) :: ncid ! netcdf id
@@ -454,6 +474,9 @@ contains
 
        call nitrogenflux_vars%Restart(bounds, ncid, flag='read')
        call nitrogenstate_vars%Restart(bounds, ncid, flag='read')
+
+       call phosphorusflux_vars%Restart(bounds, ncid, flag='read')
+       call phosphorusstate_vars%Restart(bounds, ncid, flag='read')
 
        call cnstate_vars%Restart(bounds, ncid, flag='read')
 

--- a/models/lnd/clm/src/main/soilorder_varcon.F90
+++ b/models/lnd/clm/src/main/soilorder_varcon.F90
@@ -1,0 +1,182 @@
+module soilorder_varcon
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Module containing vegetation constants and method to
+  ! read and initialize vegetation (PFT) constants.
+  !
+  ! !USES:
+  use shr_kind_mod, only : r8 => shr_kind_r8
+  use shr_log_mod , only : errMsg => shr_log_errMsg
+  use abortutils  , only : endrun
+  use clm_varpar  , only : nsoilorder
+  use clm_varctl  , only : iulog, use_cndv, use_vertsoilc
+  !
+  ! !PUBLIC TYPES:
+  implicit none
+  save
+
+!
+! Soil order  constants
+!
+  character(len=40) soilordername(0:nsoilorder)    ! soil order description
+  integer :: Water
+  integer :: Andisols
+  integer :: Gelisols
+  integer :: Histosols
+  integer :: Entisols
+  integer :: Inceptisols
+  integer :: Aridsols
+  integer :: Vertisols
+  integer :: Mollisols
+  integer :: Alfisols
+  integer :: Spodosols
+  integer :: Ultisols
+  integer :: Oxisols
+  integer :: Shifting_sand
+  integer :: rock_land
+  integer :: Ice_Glacier
+
+  real(r8), allocatable :: smax(:)
+  real(r8), allocatable :: ks_sorption(:)
+  real(r8), allocatable :: r_weather(:)
+  real(r8), allocatable :: r_adsorp(:)
+  real(r8), allocatable :: r_desorp(:)
+  real(r8), allocatable :: r_occlude(:)
+  real(r8), allocatable :: k_s1_biochem(:)
+  real(r8), allocatable :: k_s2_biochem(:)
+  real(r8), allocatable :: k_s3_biochem(:)
+  real(r8), allocatable :: k_s4_biochem(:)
+
+
+
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public :: soilorder_conrd ! Read and initialize soil order dependent  constants
+  !
+  ! !REVISION HISTORY:
+  ! Created by X.YANG 01/12/2015
+  !-----------------------------------------------------------------------
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine soilorder_conrd
+    !
+    ! !DESCRIPTION:
+    ! Read and initialize soil order dependent constants
+    !
+    ! !USES:
+    use fileutils ,  only : getfil
+    use ncdio_pio ,  only : ncd_io, ncd_pio_closefile, ncd_pio_openfile,file_desc_t, &
+                            ncd_inqdid, ncd_inqdlen
+    use clm_varctl,  only : fsoilordercon
+    use spmdMod   ,  only : masterproc
+
+    ! !ARGUMENTS:
+    implicit none
+    !
+    ! !REVISION HISTORY:
+    ! Created by Gordon Bonan
+    ! F. Li and S. Levis (11/06/12)
+    !
+    ! !LOCAL VARIABLES:
+    character(len=256) :: locfn ! local file name
+    integer :: i,n              ! loop indices
+    integer :: ier              ! error code
+    type(file_desc_t) :: ncid   ! pio netCDF file id
+    integer :: dimid            ! netCDF dimension id
+    integer :: nsoil             ! number of pfts on pft-physiology file
+    logical :: readv            ! read variable in or not
+    character(len=32) :: subname = 'soilorder_conrd'              ! subroutine name
+
+    ! Expected soil order names: The names expected on the  file and the order
+    ! they are expected to be in.
+    !
+    character(len=40), parameter :: expected_soilnames(0:nsoilorder) = (/ &
+                 'Water                      '  &
+               , 'Andisols                   '  &
+               , 'Gelisols                   '  &
+               , 'Histosols                  '  &
+               , 'Entisols                   '  &
+               , 'Inceptisols                '  &
+               , 'Aridsols                   '  &
+               , 'Vertisols                  '  &
+               , 'Mollisols                  '  &
+               , 'Alfisols                   '  &
+               , 'Spodosols                  '  &
+               , 'Ultisols                   '  &
+               , 'Oxisols                    '  &
+               , 'shiftingsand               '  &
+               , 'rockland                   '  &
+               , 'iceglacier                 '  &
+    /)
+!-----------------------------------------------------------------------
+
+    allocate( smax        (0:nsoilorder) )
+    allocate( ks_sorption (0:nsoilorder) )
+    allocate( r_weather   (0:nsoilorder) )
+    allocate( r_adsorp    (0:nsoilorder) )
+    allocate( r_desorp    (0:nsoilorder) )
+    allocate( r_occlude   (0:nsoilorder) )
+    allocate(k_s1_biochem (0:nsoilorder) )
+    allocate(k_s2_biochem (0:nsoilorder) )
+    allocate(k_s3_biochem (0:nsoilorder) )
+    allocate(k_s4_biochem (0:nsoilorder) )
+
+   ! Set specific soil order values
+
+    if (masterproc) then
+       write(iulog,*) 'Attempting to read soil order dependent parameters .....'
+    end if
+    call getfil (fsoilordercon, locfn, 0)
+    call ncd_pio_openfile (ncid, trim(locfn), 0)
+    call ncd_inqdid(ncid,'soilorder',dimid)
+    call ncd_inqdlen(ncid,dimid,nsoil)
+
+    call ncd_io('soilordername',soilordername, 'read', ncid, readvar=readv,posNOTonfile=.true.)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('r_weather',r_weather, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('r_adsorp',r_adsorp, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('r_desorp',r_desorp, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('r_occlude',r_occlude, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('k_s1_biochem',k_s1_biochem, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('k_s2_biochem',k_s2_biochem, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('k_s3_biochem',k_s3_biochem, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('k_s4_biochem',k_s4_biochem, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('smax',smax, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+    call ncd_io('ks_sorption',ks_sorption, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order parameter'//errMsg(__FILE__, __LINE__))
+
+    call ncd_pio_closefile(ncid)
+
+
+
+    do i = 1,nsoilorder
+
+       if ( trim(adjustl(soilordername(i))) /= trim(expected_soilnames(i)) )then
+          write(iulog,*)'soilorder_conrd: soil order name is NOT what is expected, name = ', &
+                        trim(soilordername(i)), ', expected name = ',trim(expected_soilnames(i))
+          call endrun( 'soilorder_conrd: bad name for soil order onfsoilordercon dataset' )
+       end if
+
+    enddo
+
+    if (masterproc) then
+       write(iulog,*) 'Successfully read PFT physiological data'
+       write(iulog,*)
+    end if
+
+   end subroutine soilorder_conrd
+
+
+end module soilorder_varcon
+


### PR DESCRIPTION
 Adding phosphorus cycle dynamics into ACME land model

These code modifications are for implementing phosphorus cycle dynamics into ACME land model.
One new variable (SOIL_ORDER) was added to the surface data at three resolutions (1.9x2.5, 0.9x1.25, 360x720)
Ten new parameters related to phosphorus dynamics were added to the clm_param file
A new parameter file including soil order dependent parameters
were added

[CC] [NML]

LG-41
