### PR TITLE
Add new ACME version of create_test

### DIFF
--- a/scripts/acme/acme_bisect
+++ b/scripts/acme/acme_bisect
@@ -54,19 +54,19 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-t", "--check-throughput", action="store_true", dest="check_throughput", default=False,
                         help="Consider a commit to be broken if throughput check fails (fail if tests slow down)")
 
-    parser.add_argument("--no-submit", action="store_true", dest="no_submit", default=False,
-                        help="Do not submit job to queue, run locally.")
+    parser.add_argument("--no-batch", action="store_true", dest="no_batch", default=False,
+                        help="Do not submit job to queue, run locally. Will default to whatever is standard on your machine")
 
     args = parser.parse_args(args[1:])
 
     acme_util.set_verbosity(args.verbose)
 
-    return args.testname, args.testroot, args.project, args.compare, args.check_namelists, args.check_throughput, args.no_submit
+    return args.testname, args.testroot, args.project, args.compare, args.check_namelists, args.check_throughput, args.no_batch
 
 ###############################################################################
-def acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, no_submit):
+def acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, no_batch):
 ###############################################################################
-    expect(os.path.exists("scripts/create_test"), "Please run from root of repository")
+    expect(os.path.exists("scripts/acme/create_test"), "Please run from root of repository")
 
     current_sha = acme_util.get_current_commit(short=True)
 
@@ -76,11 +76,11 @@ def acme_bisect(testname, testroot, project, compare, check_namelists, check_thr
 
     # Formulate and run create_test command
 
-    extra_args = "-autosubmit off -nobatch on" if no_submit else ""
-    compare_args = "-compare %s" % compare if compare is not None else ""
-    create_test_cmd = "./create_test -testname %s -testroot %s -testid %s -project %s %s %s" % \
+    extra_args = "--no-batch" if no_batch else ""
+    compare_args = "-c -b %s" % compare if compare is not None else ""
+    create_test_cmd = "scripts/acme/create_test %s --test-root %s -t %s -p %s %s %s" % \
                       (testname, testroot, current_sha, project, compare_args, extra_args)
-    run_cmd(create_test_cmd, from_dir="./scripts")
+    run_cmd(create_test_cmd)
 
     # Find testcase area
     glob_matches = glob.glob("%s/%s*%s" % (testroot, testname, current_sha))
@@ -100,10 +100,10 @@ def acme_bisect(testname, testroot, project, compare, check_namelists, check_thr
 
     # Wait for test
     return wait_for_tests.wait_for_tests([os.path.join(testarea, "TestStatus")],
-                                         no_submit, # wait if using batch
-                                         check_throughput,
-                                         not check_namelists, # inverse due to opposite defaults
-                                         None # don't do cdash stuff
+                                         no_wait=no_batch, # wait if using batch
+                                         check_throughput=check_throughput,
+                                         ignore_namelists=not check_namelists, # inverse due to opposite defaults
+                                         cdash_build_name=None # don't do cdash stuff
                                          )
 
 ###############################################################################
@@ -115,11 +115,11 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    testname, testroot, project, compare, check_namelists, check_throughput, no_submit = \
+    testname, testroot, project, compare, check_namelists, check_throughput, no_batch = \
         parse_command_line(sys.argv, description)
 
     try:
-        rv = acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, no_submit)
+        rv = acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, no_batch)
     except:
         print >> sys.stderr, "Exception in script, aborting bisect entirely:"
         e = sys.exc_info()[1]

--- a/scripts/acme/acme_util.py
+++ b/scripts/acme/acme_util.py
@@ -72,7 +72,7 @@ MACHINE_INFO = {
         "acme_developer",
         True,
         "ACME",
-        "/lcrc/project/<PROJECT>/<USER>/acme_scratch",
+        "/lcrc/project/ACME/<USER>/acme_scratch",
         "/lcrc/group/earthscience/acme_baselines",
         None
     ),
@@ -335,12 +335,13 @@ def get_machine_info(machine=None):
     Info returned as tuple:
     (compiler, test_suite, use_batch, project, testroot, baseline_root, proxy)
     """
+    import getpass
     if (machine is None):
         machine = probe_machine_name()
     expect(machine is not None, "Failed to probe machine")
     expect(machine in MACHINE_INFO, "No info for machine '%s'" % machine)
 
-    return MACHINE_INFO[machine]
+    return [item.replace("<USER>", getpass.getuser()) if type(item) is str else item for item in MACHINE_INFO[machine]]
 
 ###############################################################################
 def get_utc_timestamp(format="%Y%m%d_%H%M%S"):

--- a/scripts/acme/create_test
+++ b/scripts/acme/create_test
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+
+"""
+Script to run ACME tests.
+
+Runs single tests or test suites based on either the input list or the testname.
+
+This is currently a wrapper around CESM's create_test, but this will eventually replace
+that tool entirely.
+"""
+
+import acme_util
+acme_util.check_minimum_python_version(2, 7)
+
+import argparse, sys, os, doctest, tempfile
+import update_acme_tests
+from acme_util import expect, warning, verbose_print, run_cmd
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n%s <TEST|SUITE> [<TEST|SUITE> ...] [--verbose]
+OR
+%s --help
+OR
+%s --test
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Run single test \033[0m
+    > %s <TESTNAME>
+
+    \033[1;32m# Run test suite \033[0m
+    > %s <SUITE>
+
+    \033[1;32m# Run two tests \033[0m
+    > %s <TESTNAME1> <TESTNAME2>
+
+    \033[1;32m# Run two suites \033[0m
+    > %s <SUITE1> <SUITE2>
+
+    \033[1;32m# Run all tests in a suite except for one \033[0m
+    > %s <SUITE> ^<TESTNAME>
+
+    \033[1;32m# Run all tests in a suite except for tests that are in another suite \033[0m
+    > %s <SUITE1> ^<SUITE2>
+""" % ((os.path.basename(args[0]), ) * 9),
+
+description=description,
+
+formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+    parser.add_argument("testargs", nargs="+", help="Tests or test suites to run. Testnames expect in form CASE.GRID.COMPSET")
+
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print extra information")
+
+    parser.add_argument("--no-run", action="store_true",
+                        help="Do not run generated tests")
+
+    parser.add_argument("--no-build", action="store_true",
+                        help="Do not build generated tests, implies --no-run")
+
+    parser.add_argument("--no-batch", action="store_true",
+                        help="Do not submit jobs to batch system, run locally. Will default to machine setting.")
+
+    parser.add_argument("-r", "--test-root",
+                        help="Where test cases will be created. Will default to scratch root XML machine file")
+
+    parser.add_argument("--baseline-root",
+                        help="Specifies an alternate root directory for baseline"
+                        "datasets used for Bit-for-bit generate/compare"
+                        "testing. If this argument is not supplied, the"
+                        "default baselineroot will be used from the XML machine file.")
+
+    parser.add_argument("--clean", action="store_true",
+                        help="Specifies if tests should be cleaned after run. If set, "
+                        "all object executables, and data files will be removed after tests are run")
+
+    parser.add_argument("-c", "--compare", action="store_true",
+                        help="While testing, compare baselines")
+
+    parser.add_argument("-g", "--generate", action="store_true",
+                        help="While testing, generate baselines")
+
+    parser.add_argument("-b", "--baseline-name",
+                        help="If comparing or generating baselines, use this directory under baseline root. "
+                        "Default will be current branch name")
+
+    parser.add_argument("--compiler",
+                        help="Force tests to use this compiler; otherwise, default compiler for this machine will be used.")
+
+    parser.add_argument("-m", "--machine",
+                        help="Instead of probing for machine, force scripts to use this machine.")
+
+    parser.add_argument("-n", "--namelists-only", action="store_true",
+                        help="Only perform namelist actions for tests")
+
+    parser.add_argument("-p", "--project",
+                        help="Specify a project id for the case (optional)."
+                        "Used for accounting when on a batch system."
+                        "The default is user-specified environment variable PROJECT or ACCOUNT,"
+                        "or read from ~/.cesm_proj or ~/.ccsm_proj")
+
+    parser.add_argument("-t", "--test-id",
+                        help="Specify an 'id' for the test. This is simply a"
+                        "string that is appended to the end of a test name."
+                        "If no testid is specified, then a time stamp will be"
+                        "used.")
+
+    args = parser.parse_args(args[1:])
+
+    acme_util.set_verbosity(args.verbose)
+
+    expect(not (args.generate and args.compare),
+           "Cannot generate and compare baselines at the same time")
+    expect(not (args.baseline_name is not None and (not args.compare and not args.generate)),
+           "Provided baseline name but did not specify compare or generate")
+
+    if (args.no_build):
+        args.no_run = True
+
+    if (args.machine is None):
+        args.machine = acme_util.probe_machine_name()
+        expect(args.machine is not None,
+               "You did not specify a machine name and one could not be probed")
+
+    compiler, _, use_batch, project, testroot, baseline_root, _ = \
+        acme_util.get_machine_info(args.machine)
+
+    if (args.compiler is None):
+        args.compiler = compiler
+
+    if (args.project is None):
+        args.project = project
+
+    if (not args.no_batch and not use_batch):
+        args.no_batch = True
+
+    if (args.test_root is None):
+        args.test_root = testroot
+
+    if (args.baseline_root is None):
+        args.baseline_root = baseline_root
+
+    if (args.baseline_name is None):
+        args.baseline_name = acme_util.get_current_branch()
+
+    return args.testargs, args.compiler, args.machine, args.no_run, args.no_build, args.no_batch, args.test_root, args.baseline_root, \
+        args.clean, args.compare, args.generate, args.baseline_name, args.namelists_only, args.project, args.test_id
+
+###############################################################################
+def get_tests_from_args(testargs):
+###############################################################################
+    acme_test_suites = dict(update_acme_tests.TEST_SUITES)
+
+    tests_to_run = set()
+    negations = set()
+
+    for testarg in testargs:
+        if (testarg.startswith("^")):
+            negations.add(testarg)
+        elif (testarg in acme_test_suites):
+            tests_to_run.update(acme_test_suites[testarg])
+        elif (testarg.count(".") == 2):
+            tests_to_run.add(testarg)
+        else:
+            expect(False, "Could not handle argument '%s'" % testarg)
+
+    for negation in negations:
+        if (negation in acme_test_suites):
+            tests_to_run.difference_update(acme_test_suites[negation])
+        elif (negation.count(".") == 2):
+            tests_to_run.remove(negation)
+        else:
+            expect(False, "Could not handle argument '%s'" % negation)
+
+    return tests_to_run
+
+###############################################################################
+def create_test(testargs, compiler, machine, no_run=False, no_build=False, no_batch=False, test_root=None,
+                baseline_root=None, clean=False, compare=False, generate=False,
+                baseline_name=None, namelists_only=False, project=None, test_id=None):
+###############################################################################
+    tests_to_run = get_tests_from_args(testargs)
+
+    expect(len(tests_to_run) > 0, "No tests to run")
+
+    full_test_names = ["%s.%s_%s\n" % (item, machine, compiler) for item in tests_to_run]
+
+    testlist_file = tempfile.mktemp()
+
+    fd = open(testlist_file, "w")
+    fd.writelines(full_test_names)
+    fd.close()
+
+    create_test_cmd = "./create_test -input_list %s -mach %s" % (testlist_file, machine)
+    if (no_run):
+        expect(False, "--no-run not currently supported")
+    if (no_build):
+        create_test_cmd = "%s -nobuild on" % create_test_cmd
+    if (test_root):
+        create_test_cmd = "%s -testroot %s" % (create_test_cmd, test_root)
+    if (baseline_root):
+        create_test_cmd = "%s -baselineroot %s" % (create_test_cmd, baseline_root)
+    if (clean):
+        create_test_cmd = "%s -clean on" % create_test_cmd
+    if (compare):
+        create_test_cmd = "%s -compare %s" % (create_test_cmd, baseline_name)
+    if (generate):
+        create_test_cmd = "%s -generate %s" % (create_test_cmd, baseline_name)
+    if (namelists_only):
+        create_test_cmd = "%s -nlcompareonly" % create_test_cmd
+    if (project):
+        create_test_cmd = "%s -project %s" % (create_test_cmd, project)
+    if (test_id):
+        create_test_cmd = "%s -testid %s" % (create_test_cmd, test_id)
+    if (no_batch):
+        create_test_cmd = "%s -autosubmit off -nobatch on" % create_test_cmd
+
+    stat = acme_util.run_cmd(create_test_cmd,
+                             from_dir=os.path.join(os.path.dirname(__file__), ".."),
+                             ok_to_fail=True,
+                             verbose=True,
+                             arg_stdout=None, arg_stderr=None)[0]
+
+    os.remove(testlist_file)
+
+    return stat
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    if ("--test" in sys.argv):
+        test_results = doctest.testmod(verbose=True)
+        sys.exit(1 if test_results.failed > 0 else 0)
+
+    acme_util.stop_buffering_output()
+
+    testargs, compiler, machine, no_run, no_build, no_batch, test_root, baseline_root, clean, \
+        compare, generate, baseline_name, namelists_only, project, test_id = \
+        parse_command_line(sys.argv, description)
+
+    sys.exit(create_test(testargs, compiler, machine, no_run, no_build, no_batch, test_root, baseline_root, clean,
+                         compare, generate, baseline_name, namelists_only, project, test_id))
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -9,7 +9,7 @@ import acme_util
 acme_util.check_minimum_python_version(2, 7)
 import wait_for_tests
 
-import argparse, sys, os, getpass, socket, shutil, glob, doctest
+import argparse, sys, os, socket, shutil, glob, doctest
 
 from acme_util import expect, warning, verbose_print
 
@@ -187,7 +187,6 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash,
     compiler, default_test_suite, use_batch, project, testroot, baseline_root, proxy = \
         acme_util.get_machine_info(acme_machine)
     test_suite = default_test_suite if arg_test_suite is None else arg_test_suite
-    testroot = testroot.replace("<USER>", getpass.getuser()).replace("<PROJECT>", project)
     casearea = os.path.join(testroot, "jenkins")
     git_branch = acme_util.get_current_branch(repo=acme_repo) if baseline_branch is None else baseline_branch
 
@@ -257,25 +256,20 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash,
         # Set up create_test command and run it
         #
 
-        os.chdir(os.path.join(acme_repo, "scripts"))
         git_branch = acme_util.get_current_branch() if baseline_branch is None else baseline_branch
-        baseline_action = "-generate" if generate_baselines else "-compare"
+        baseline_action = "-g" if generate_baselines else "-c"
         test_id = "%s_%s" % (test_id_root, acme_util.get_utc_timestamp())
-        create_test_cmd = "./create_test -xml_mach %s -xml_compiler %s -xml_category %s -testroot %s -project %s -testid %s %s %s" % \
-                          (acme_machine, compiler, test_suite, casearea, project, test_id, baseline_action, git_branch)
+        create_test_cmd = "scripts/acme/create_test %s --test-root %s -p %s -t %s %s -b %s" % \
+                          (test_suite, casearea, project, test_id, baseline_action, git_branch)
 
         if (namelists_only):
-            create_test_cmd += " -nlcompareonly"
-
-        if (not use_batch):
-            create_test_cmd += " -autosubmit off -nobatch on"
+            create_test_cmd += " -n"
 
         if (not wait_for_tests.SIGNAL_RECEIVED):
-            create_test_stat = acme_util.run_cmd(create_test_cmd, verbose=True, arg_stdout=None, arg_stderr=None, ok_to_fail=True)[0]
+            create_test_stat = acme_util.run_cmd(create_test_cmd,
+                                                 verbose=True, arg_stdout=None, arg_stderr=None, ok_to_fail=True, from_dir=acme_repo)[0]
             if (create_test_stat != 0):
                 warning("create_test FAILED!")
-
-        os.chdir("../..")
 
         # TODO: the testing scripts should produce all PASS when only generating namelists
         if (namelists_only and generate_baselines):

--- a/scripts/acme/update_acme_tests
+++ b/scripts/acme/update_acme_tests
@@ -7,68 +7,12 @@ this file to create new test entries, and then inserts these entries
 into the XML file."""
 
 import acme_util
+from acme_util import expect
 acme_util.check_minimum_python_version(2, 7)
 
-import sys, argparse, os, shutil, tempfile, doctest
+import update_acme_tests
 
-from acme_util import expect, warning
-
-# Here are the tests belonging to acme suites. Format is
-# <test>.<grid>.<compset>
-TEST_SUITES = {
-    "acme_tiny" :
-        ["ERS.f19_g16_rx1.A",
-         "NCK.f19_g16_rx1.A"],
-    "acme_developer" :
-        ['ERS.f19_g16_rx1.A',
-         'ERS.f45_g37.B1850C5',
-         'ERS.f45_g37_rx1.DTEST',
-         'ERS.ne30_g16_rx1.A',
-         'ERS_IOP.f19_g16_rx1.A',
-         'ERS_IOP.f45_g37_rx1.DTEST',
-         'ERS_IOP.ne30_g16_rx1.A',
-         'ERS_IOP4c.f19_g16_rx1.A',
-         'ERS_IOP4c.ne30_g16_rx1.A',
-         'ERS_IOP4p.f19_g16_rx1.A',
-         'ERS_IOP4p.ne30_g16_rx1.A',
-         'ERS_Ly21.f09_g16.TG',
-         'NCK.f19_g16_rx1.A',
-         'PEA_P1_M.f45_g37_rx1.A',
-         'SMS.ne30_f19_g16_rx1.A',
-         'SMS.f19_f19.I1850CLM45CN'],
-    "acme_integration" :
-        ["ERB.f19_g16.B1850C5",
-         "ERB.f45_g37.B1850C5",
-         "ERH.f45_g37.B1850C5",
-         "ERS.f09_g16.B1850C5",
-         "ERS.f19_f19.FAMIPC5",
-         "ERS.f19_g16.B1850C5",
-         "ERS.f45_g37.B1850C5",
-         "ERS_D.f45_g37.B1850C5",
-         "ERS_IOP.f19_g16_rx1.A",
-         "ERS_IOP.f45_g37_rx1.DTEST",
-         "ERS_IOP.ne30_g16_rx1.A",
-         "ERS_IOP4c.f19_g16_rx1.A",
-         "ERS_IOP4c.ne30_g16_rx1.A",
-         "ERS_IOP4p.f19_g16_rx1.A",
-         "ERS_IOP4p.ne30_g16_rx1.A",
-         "ERS_IOP_Ld3.f19_f19.FAMIPC5",
-         "ERS_Ld3.f19_g16.FC5",
-         "ERS_Ld3.ne30_ne30.FC5",
-         "ERS_Ly21.f09_g16.TG",
-         "ERT.f19_g16.B1850C5",
-         "NCK.f19_g16_rx1.A",
-         "PEA_P1_M.f45_g37_rx1.A",
-         "PET_PT.f19_g16.X",
-         "PET_PT.f45_g37_rx1.A",
-         "PFS.ne30_ne30.FC5",
-         "SEQ_IOP_PFC.f19_g16.X",
-         "SEQ_PFC.f45_g37.B1850C5",
-         "SMS.ne16_ne16.FC5AQUAP",
-         "SMS.ne30_f19_g16_rx1.A",
-         "SMS_D.f19_g16.B20TRC5",
-         "SMS_D_Ld3.f19_f19.FC5"]
-}
+import sys, argparse, os
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -111,90 +55,17 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     return args.category, args.test_list_path, args.platform
 
 ###############################################################################
-def find_all_platforms(xml_file):
-###############################################################################
-    f = open(xml_file, 'r')
-    lines = f.readlines()
-    f.close()
-    platform_set = set()
-
-    for line in lines:
-        if '<machine' in line:
-            i1 = line.index('compiler') + len('compiler="')
-            i2 = line.index('"', i1)
-            compiler = line[i1:i2]
-            j1 = line.index('>') + 1
-            j2 = line.index('<', j1)
-            machine = line[j1:j2]
-            platform_set.add((machine, compiler))
-
-    return list(platform_set)
-
-###############################################################################
-def replace_testlist_xml(output, xml_file):
-###############################################################################
-    # manage_xml_entries creates a temporary file intended for people to manually check the
-    # changes. This made sense before revision control, but not anymore.
-    if 'now writing the new test list to' in output:
-        i1 = output.index('now writing') + len('now writing the new test list to ')
-        i2 = output.index('xml') + 3
-        new_xml_file = output[i1:i2]
-        shutil.move(new_xml_file, xml_file)
-
-###############################################################################
-def generate_acme_test_entries(category, platforms):
-###############################################################################
-    tests = TEST_SUITES[category]
-    test_file = tempfile.NamedTemporaryFile(mode='w', delete = False)
-    for test in tests:
-        for machine, compiler in platforms:
-            test_file.write('%s.%s_%s\n'%(test, machine, compiler))
-    name = test_file.name
-    test_file.close()
-    return name
-
-###############################################################################
-def update_acme_test(xml_file, category, platform):
-###############################################################################
-    # Fish all of the existing machine/compiler combos out of the XML file.
-    if (platform is not None):
-        platforms = [tuple(platform.split(","))]
-    else:
-        platforms = find_all_platforms(xml_file)
-
-    # Try to find the manage_xml_entries script. Assume sibling of xml_file
-    manage_xml_entries = os.path.join(os.path.dirname(xml_file), "manage_xml_entries")
-    expect(os.path.isfile(manage_xml_entries),
-           "Couldn't find manage_xml_entries, expect sibling of '%s'" % xml_file)
-
-    # Remove any existing acme test category from the file.
-    if (platform is None):
-        output = acme_util.run_cmd('%s -removetests -category %s' % (manage_xml_entries, category))
-    else:
-        output = acme_util.run_cmd('%s -removetests -category %s -machine %s -compiler %s'
-                                   % (manage_xml_entries, category, platforms[0][0], platforms[0][1]))
-    replace_testlist_xml(output, xml_file)
-
-    # Generate a list of test entries corresponding to our suite at the top
-    # of the file.
-    new_test_file = generate_acme_test_entries(category, platforms)
-    output = acme_util.run_cmd("%s -addlist -file %s -category %s" %
-                               (manage_xml_entries, new_test_file, category))
-    os.unlink(new_test_file)
-    replace_testlist_xml(output, xml_file)
-
-###############################################################################
 def _main_func(description):
 ###############################################################################
     if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
+        acme_util.run_cmd("python -m doctest %s/update_acme_tests.py -v" % os.path.dirname(sys.argv[0]), arg_stdout=None, arg_stderr=None)
+        return
 
     category, test_list_path, platform = parse_command_line(sys.argv, description)
 
     acme_util.stop_buffering_output()
 
-    update_acme_test(test_list_path, category, platform)
+    update_acme_tests.update_acme_test(test_list_path, category, platform)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/acme/update_acme_tests.py
+++ b/scripts/acme/update_acme_tests.py
@@ -1,0 +1,134 @@
+import os, shutil, tempfile
+
+import acme_util
+from acme_util import expect, warning
+
+# Here are the tests belonging to acme suites. Format is
+# <test>.<grid>.<compset>
+TEST_SUITES = {
+    "acme_tiny" :
+        ["ERS.f19_g16_rx1.A",
+         "NCK.f19_g16_rx1.A"],
+    "acme_developer" :
+        ['ERS.f19_g16_rx1.A',
+         'ERS.f45_g37.B1850C5',
+         'ERS.f45_g37_rx1.DTEST',
+         'ERS.ne30_g16_rx1.A',
+         'ERS_IOP.f19_g16_rx1.A',
+         'ERS_IOP.f45_g37_rx1.DTEST',
+         'ERS_IOP.ne30_g16_rx1.A',
+         'ERS_IOP4c.f19_g16_rx1.A',
+         'ERS_IOP4c.ne30_g16_rx1.A',
+         'ERS_IOP4p.f19_g16_rx1.A',
+         'ERS_IOP4p.ne30_g16_rx1.A',
+         'ERS_Ly21.f09_g16.TG',
+         'NCK.f19_g16_rx1.A',
+         'PEA_P1_M.f45_g37_rx1.A',
+         'SMS.ne30_f19_g16_rx1.A',
+         'SMS.f19_f19.I1850CLM45CN'],
+    "acme_integration" :
+        ["ERB.f19_g16.B1850C5",
+         "ERB.f45_g37.B1850C5",
+         "ERH.f45_g37.B1850C5",
+         "ERS.f09_g16.B1850C5",
+         "ERS.f19_f19.FAMIPC5",
+         "ERS.f19_g16.B1850C5",
+         "ERS.f45_g37.B1850C5",
+         "ERS_D.f45_g37.B1850C5",
+         "ERS_IOP.f19_g16_rx1.A",
+         "ERS_IOP.f45_g37_rx1.DTEST",
+         "ERS_IOP.ne30_g16_rx1.A",
+         "ERS_IOP4c.f19_g16_rx1.A",
+         "ERS_IOP4c.ne30_g16_rx1.A",
+         "ERS_IOP4p.f19_g16_rx1.A",
+         "ERS_IOP4p.ne30_g16_rx1.A",
+         "ERS_IOP_Ld3.f19_f19.FAMIPC5",
+         "ERS_Ld3.f19_g16.FC5",
+         "ERS_Ld3.ne30_ne30.FC5",
+         "ERS_Ly21.f09_g16.TG",
+         "ERT.f19_g16.B1850C5",
+         "NCK.f19_g16_rx1.A",
+         "PEA_P1_M.f45_g37_rx1.A",
+         "PET_PT.f19_g16.X",
+         "PET_PT.f45_g37_rx1.A",
+         "PFS.ne30_ne30.FC5",
+         "SEQ_IOP_PFC.f19_g16.X",
+         "SEQ_PFC.f45_g37.B1850C5",
+         "SMS.ne16_ne16.FC5AQUAP",
+         "SMS.ne30_f19_g16_rx1.A",
+         "SMS_D.f19_g16.B20TRC5",
+         "SMS_D_Ld3.f19_f19.FC5"]
+}
+
+###############################################################################
+def find_all_platforms(xml_file):
+###############################################################################
+    f = open(xml_file, 'r')
+    lines = f.readlines()
+    f.close()
+    platform_set = set()
+
+    for line in lines:
+        if '<machine' in line:
+            i1 = line.index('compiler') + len('compiler="')
+            i2 = line.index('"', i1)
+            compiler = line[i1:i2]
+            j1 = line.index('>') + 1
+            j2 = line.index('<', j1)
+            machine = line[j1:j2]
+            platform_set.add((machine, compiler))
+
+    return list(platform_set)
+
+###############################################################################
+def replace_testlist_xml(output, xml_file):
+###############################################################################
+    # manage_xml_entries creates a temporary file intended for people to manually check the
+    # changes. This made sense before revision control, but not anymore.
+    if 'now writing the new test list to' in output:
+        i1 = output.index('now writing') + len('now writing the new test list to ')
+        i2 = output.index('xml') + 3
+        new_xml_file = output[i1:i2]
+        shutil.move(new_xml_file, xml_file)
+
+###############################################################################
+def generate_acme_test_entries(category, platforms):
+###############################################################################
+    tests = TEST_SUITES[category]
+    test_file = tempfile.NamedTemporaryFile(mode='w', delete = False)
+    for test in tests:
+        for machine, compiler in platforms:
+            test_file.write('%s.%s_%s\n'%(test, machine, compiler))
+    name = test_file.name
+    test_file.close()
+    return name
+
+###############################################################################
+def update_acme_test(xml_file, category, platform):
+###############################################################################
+    # Fish all of the existing machine/compiler combos out of the XML file.
+    if (platform is not None):
+        platforms = [tuple(platform.split(","))]
+    else:
+        platforms = find_all_platforms(xml_file)
+
+    # Try to find the manage_xml_entries script. Assume sibling of xml_file
+    manage_xml_entries = os.path.join(os.path.dirname(xml_file), "manage_xml_entries")
+    expect(os.path.isfile(manage_xml_entries),
+           "Couldn't find manage_xml_entries, expect sibling of '%s'" % xml_file)
+
+    # Remove any existing acme test category from the file.
+    if (platform is None):
+        output = acme_util.run_cmd('%s -removetests -category %s' % (manage_xml_entries, category))
+    else:
+        output = acme_util.run_cmd('%s -removetests -category %s -machine %s -compiler %s'
+                                   % (manage_xml_entries, category, platforms[0][0], platforms[0][1]))
+    replace_testlist_xml(output, xml_file)
+
+    # Generate a list of test entries corresponding to our suite at the top
+    # of the file.
+    new_test_file = generate_acme_test_entries(category, platforms)
+    output = acme_util.run_cmd("%s -addlist -file %s -category %s" %
+                               (manage_xml_entries, new_test_file, category))
+    os.unlink(new_test_file)
+    replace_testlist_xml(output, xml_file)

--- a/scripts/acme/wait_for_tests.py
+++ b/scripts/acme/wait_for_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os, doctest, time, threading, Queue, socket, signal, distutils.spawn
 
 import xml.etree.ElementTree as xmlet


### PR DESCRIPTION
Currently, just a wrapper around the CESM version of this
script that presents an improved interface.

It also allows for convenient creation of sets of tests to run
on the fly.

Uses posix compliant options.

Change other acme tools to use this create_test instead of old one.

Eventually, I'd like this script to fully replace CESM's create_test.

[BFB]
