### PR TITLE
Add lapack link flag to melvin compiler config.

### DIFF
--- a/scripts/ccsm_utils/Machines/config_compilers.xml
+++ b/scripts/ccsm_utils/Machines/config_compilers.xml
@@ -585,7 +585,7 @@ for mct, etc.
 <compiler COMPILER="gnu" MACH="melvin">
   <NETCDF_PATH>$(NETCDFROOT)</NETCDF_PATH>
   <PNETCDF_PATH>$(PNETCDFROOT)</PNETCDF_PATH>
-  <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -L/home/jgfouca/BLAS -lblas_LINUX</ADD_SLIBS>
+  <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -lblas -llapack</ADD_SLIBS>
   <ADD_CPPFLAGS> -DHAVE_COMM_F2C </ADD_CPPFLAGS>
 </compiler>
  


### PR DESCRIPTION
New land test SMS.f19_f19.I1850CLM45CN requires some lapack symbols
and melvin was not able to build this testcase without adding
-llapack to the link line.

[BFB]
