### PR TITLE
Bug fix for histaux_a2x3hr output.

### DIFF
--- a/models/drv/driver/seq_hist_mod.F90
+++ b/models/drv/driver/seq_hist_mod.F90
@@ -1005,6 +1005,16 @@ subroutine seq_hist_writeaux(infodata, EClock_d, comp, flow, aname, dname, &
       endif
    enddo
 
+   if (iamin_CPLID) then 
+      if (flow == 'c2x') then
+         av => component_get_c2x_cx(comp)
+      else if (flow == 'x2c') then
+         av => component_get_x2c_cx(comp)
+      end if
+      dom   => component_get_dom_cx(comp)
+      gsmap => component_get_gsmap_cx(comp)
+   end if
+
    if (first_call) then
       ntout = ntout + 1
       if (ntout > maxout) then
@@ -1024,9 +1034,6 @@ subroutine seq_hist_writeaux(infodata, EClock_d, comp, flow, aname, dname, &
    endif
 
    if (iamin_CPLID) then !>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-
-      dom   => component_get_dom_cx(comp)
-      gsmap => component_get_gsmap_cx(comp)
 
       samples_per_file = nt      
 


### PR DESCRIPTION
When "histaux_a2x3hr=.true." is defined in user_nl_cpl, the
code crashes. This bug was identified by CSEG as Bug-2090
and fixed in drvseq5_1_02.

Fixes #241

[BFB]
