### PR TITLE
Config updates for sandia clusters.

### DIFF
--- a/scripts/acme/acme_util.py
+++ b/scripts/acme/acme_util.py
@@ -36,7 +36,7 @@ MACHINE_INFO = {
         "acme_integration",
         True,
         "fy150001",
-        "/gscratch1/<USER>/acme_scratch",
+        "/gscratch/<USER>/acme_scratch",
         "/projects/ccsm/ccsm_baselines",
         "wwwproxy.sandia.gov:80"
     ),
@@ -45,7 +45,7 @@ MACHINE_INFO = {
         "acme_integration",
         True,
         "fy150001",
-        "/gscratch1/<USER>/acme_scratch/skybridge",
+        "/gscratch/<USER>/acme_scratch/skybridge",
         "/projects/ccsm/ccsm_baselines",
         "wwwproxy.sandia.gov:80"
     ),

--- a/scripts/ccsm_utils/Machines/config_compilers.xml
+++ b/scripts/ccsm_utils/Machines/config_compilers.xml
@@ -310,7 +310,7 @@ for mct, etc.
   <NETCDF_PATH>$(NETCDFROOT)</NETCDF_PATH>
   <PNETCDF_PATH>$(PNETCDFROOT)</PNETCDF_PATH>
   <ESMF_LIBDIR>/projects/ccsm/esmf-6.3.0rp1/lib/libO/Linux.intel.64.openmpi.default</ESMF_LIBDIR>
-  <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -L/projects/ccsm/BLAS-intel -lblas_LINUX</ADD_SLIBS>
+  <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -lblas -llapack </ADD_SLIBS>
   <ADD_CPPFLAGS> -DHAVE_COMM_F2C </ADD_CPPFLAGS>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
 </compiler>

--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -67,7 +67,7 @@
         <OS>LINUX</OS>                              <!-- LINUX,Darwin,CNL,AIX,BGL,BGP -->
         <COMPILERS>intel</COMPILERS>     <!-- intel,ibm,pgi,pathscale,gnu,cray,lahey -->
         <MPILIBS>openmpi,mpi-serial</MPILIBS>                <!-- openmpi, mpich, ibm, mpi-serial -->
-        <CESMSCRATCHROOT>/gscratch1/$USER/acme_scratch</CESMSCRATCHROOT>
+        <CESMSCRATCHROOT>/gscratch/$USER/acme_scratch</CESMSCRATCHROOT>
         <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
         <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
         <DIN_LOC_ROOT>/projects/ccsm/inputdata</DIN_LOC_ROOT>
@@ -88,7 +88,7 @@
         <OS>LINUX</OS>                              <!-- LINUX,Darwin,CNL,AIX,BGL,BGP -->
         <COMPILERS>intel</COMPILERS>     <!-- intel,ibm,pgi,pathscale,gnu,cray,lahey -->
         <MPILIBS>openmpi,mpi-serial</MPILIBS>                <!-- openmpi, mpich, ibm, mpi-serial -->
-        <CESMSCRATCHROOT>/gscratch1/$USER/acme_scratch/skybridge</CESMSCRATCHROOT>
+        <CESMSCRATCHROOT>/gscratch/$USER/acme_scratch/skybridge</CESMSCRATCHROOT>
         <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
         <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
         <DIN_LOC_ROOT>/projects/ccsm/inputdata</DIN_LOC_ROOT>


### PR DESCRIPTION
The gscratch1 filesystem is going away soon, replaced
with gscratch. This commit updates all redsky/skybridge
configs to use gscratch.

Also, updates link flags for redsky the same as was done
for skybridge yesterday.

[BFB]
