### PR TITLE
Changes to get acme scripts regression tests working again

### DIFF
--- a/scripts/acme/bless_test_results
+++ b/scripts/acme/bless_test_results
@@ -59,17 +59,23 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-t", "--test-root",
                         help="Instead of looking at last night's Jenkins results, use a custom test area")
 
+    parser.add_argument("-f", "--force", action="store_true",
+                        help="Update every diff without asking. VERY DANGEROUS. Should only be used within testing scripts.")
+
     parser.add_argument("bless_tests", nargs="*",
                         help="When blessing, limit the bless to tests matching these regex")
 
     args = parser.parse_args(args[1:])
 
+    expect(not (args.report_only and args.force),
+           "Makes no sense to use -r and -f simultaneously")
+
     acme_util.set_verbosity(args.verbose)
 
-    return args.branch, args.namelists_only, args.report_only, args.test_root, args.bless_tests
+    return args.branch, args.namelists_only, args.report_only, args.test_root, args.force, args.bless_tests
 
 ###############################################################################
-def bless_test_results(baseline_branch=None, namelists_only=False, report_only=False, test_root=None, bless_tests=None):
+def bless_test_results(baseline_branch=None, namelists_only=False, report_only=False, test_root=None, force=False, bless_tests=None):
 ###############################################################################
     acme_machine = acme_util.probe_machine_name()
     expect(acme_machine is not None,
@@ -140,18 +146,16 @@ def bless_test_results(baseline_branch=None, namelists_only=False, report_only=F
                                 if (not compare_namelists.compare_namelist_files(baseline_file, testcase_file, test_name)):
                                     print "Namelist files '%s' and '%s' did not match" % (baseline_file, testcase_file)
                                     print
-                                    if (not report_only):
-                                        user = raw_input("Update this file (y/n)? ")
-                                        if (user.upper() in ["Y", "YES"]):
-                                            namelist_files.append((rel_file, rel_file))
+                                    if (not report_only and
+                                        (force or raw_input("Update this file (y/n)? ").upper() in ["Y", "YES"])):
+                                        namelist_files.append((rel_file, rel_file))
                             else:
                                 if (not simple_compare.compare_files(baseline_file, testcase_file, test_name)):
                                     print "Simple files '%s' and '%s' did not match" % (baseline_file, testcase_file)
                                     print
-                                    if (not report_only):
-                                        user = raw_input("Update this file (y/n)? ")
-                                        if (user.upper() in ["Y", "YES"]):
-                                            namelist_files.append((rel_file, rel_file))
+                                    if (not report_only and
+                                        (force or raw_input("Update this file (y/n)? ").upper() in ["Y", "YES"])):
+                                        namelist_files.append((rel_file, rel_file))
 
                         elif (not namelists_only and test_result != wait_for_tests.NAMELIST_FAIL_STATUS):
                             # For now, just do this hist file
@@ -169,10 +173,9 @@ def bless_test_results(baseline_branch=None, namelists_only=False, report_only=F
                                 if (stat != 0):
                                     print "Hist files '%s' and '%s' did not match" % (baseline_file, hist_file)
                                     print
-                                    if (not report_only):
-                                        user = raw_input("Update this file (y/n)? ")
-                                        if (user.upper() in ["Y", "YES"]):
-                                            other_files.append((hist_file, rel_file))
+                                    if (not report_only and
+                                        (force or raw_input("Update this file (y/n)? ").upper() in ["Y", "YES"])):
+                                        other_files.append((hist_file, rel_file))
 
                 # Update namelist files
                 if (namelist_files):
@@ -191,10 +194,10 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    baseline_branch, namelists_only, report_only, test_root, bless_tests = \
+    baseline_branch, namelists_only, report_only, test_root, force, bless_tests = \
         parse_command_line(sys.argv, description)
 
-    bless_test_results(baseline_branch, namelists_only, report_only, test_root, bless_tests)
+    bless_test_results(baseline_branch, namelists_only, report_only, test_root, force, bless_tests)
 
 ###############################################################################
 

--- a/scripts/acme/tests/scripts_regression_tests
+++ b/scripts/acme/tests/scripts_regression_tests
@@ -7,6 +7,9 @@ sys.path.append(SCRIPT_DIR)
 from acme_util import run_cmd
 import acme_util
 
+DART_CONFIG = "DartConfiguration.tcl"
+DART_BACKUP = "temp_dart_backup"
+
 ###############################################################################
 class RunUnitTests(unittest.TestCase):
 ###############################################################################
@@ -107,6 +110,10 @@ class TestWaitForTests(unittest.TestCase):
 
         self._thread_error = None
 
+        # wait_for_tests could blow away our dart config, need to back it up
+        if (os.path.exists(DART_CONFIG)):
+            shutil.move(DART_CONFIG, DART_BACKUP)
+
     ###########################################################################
     def tearDown(self):
     ###########################################################################
@@ -118,6 +125,9 @@ class TestWaitForTests(unittest.TestCase):
 
         if (self._unset_proxy):
             del os.environ["http_proxy"]
+
+        if (os.path.exists(DART_BACKUP)):
+            shutil.move(DART_BACKUP, DART_CONFIG)
 
     ###########################################################################
     def simple_test(self, testdir, expected_results, extra_args=""):
@@ -257,6 +267,10 @@ class TestJenkinsGenericJob(unittest.TestCase):
         self._unset_proxy       = setup_proxy()
         self._baseline_name     = "fake_testing_only_%s" % acme_util.get_utc_timestamp()
 
+        # wait_for_tests could blow away our dart config, need to back it up
+        if (os.path.exists(DART_CONFIG)):
+            shutil.move(DART_CONFIG, DART_BACKUP)
+
     ###########################################################################
     def tearDown(self):
     ###########################################################################
@@ -272,6 +286,9 @@ class TestJenkinsGenericJob(unittest.TestCase):
         baselines = os.path.join(baseline_area, self._baseline_name)
         if (os.path.isdir(baselines)):
             shutil.rmtree(baselines)
+
+        if (os.path.exists(DART_BACKUP)):
+            shutil.move(DART_BACKUP, DART_CONFIG)
 
     ###########################################################################
     def simple_test(self, expect_works, extra_args):
@@ -367,7 +384,7 @@ class TestJenkinsGenericJob(unittest.TestCase):
         self.simple_test(False, "-n --branch %s" % self._baseline_name)
 
         # Bless
-        stat, output, errput = run_cmd("%s/bless_test_results -n -b %s" % (SCRIPT_DIR, self._baseline_name), ok_to_fail=True)
+        stat, output, errput = run_cmd("%s/bless_test_results -n -f -b %s" % (SCRIPT_DIR, self._baseline_name), ok_to_fail=True)
         self.assertEqual(stat, 0, msg="bless_test_results output:\n%s\n\nerrput:\n%s" % (output, errput))
 
         # Basic namelist compare should now pass again


### PR DESCRIPTION
Recent changes broke the tests are were not caught due to a bug
that caused the regression test report to get sent to the ACME_test
project instead of ACME_Climate.

Add --force option to bless_test_results so it will work when
being scripted (non-interactive).

Regression tests now preserve any DartConfiguration files instead
of letting wait_for_tests blow it away. This was the cause of results
being sent to the wrong dashboard.

[BFB]
