### PR TITLE
XML file changes to topo grid name for CONUS case

### DIFF
--- a/models/atm/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/models/atm/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -206,9 +206,9 @@
 <bnd_topo hgrid="ne240np4"  >atm/cam/topo/USGS_gtopo30_0.23x0.31_smooth1000-50_ne240np4_c061107.nc</bnd_topo>
 
 <bnd_topo hgrid="ne0np4_arm_x8v3_lowcon"  >atm/cam/inic/homme/USGS-gtopo30_arm_x8v3_lowcon_tensor12xconsistentSGH.nc</bnd_topo>
-<bnd_topo hgrid="ne0np4_conus_x4v1_lowcon"  >atm/cam/topo/USGS-gtopo30_0.9x1.25_remap_conusx4v1_c051027.nc</bnd_topo>
-<bnd_topo hgrid="ne0np4_svalbard_x8v1_lowcon"  >atm/cam/topo/USGS-gtopo30_0.9x1.25_remap_svalbardx8v1_c051027.nc</bnd_topo>
-<bnd_topo hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  >atm/cam/topo/USGS-gtopo30_0.9x1.25_remap_sooberingoax4x8v1_c051027.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4_conus_x4v1_lowcon"  >atm/cam/topo/USGS_conusx4v1-tensor12x_c150612.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4_svalbard_x8v1_lowcon"  >atm/cam/topo/USGS_svalbardx8v1-tensor12x_c150612.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  >atm/cam/topo/USGS_sooberingoax4x8v1-tensor12x_c150612.nc</bnd_topo>
 
 <!-- Bulk aerosol physical properties (includes optics) -->
 


### PR DESCRIPTION
It was discovered that the topo file used for the CONUS test case was
erroneous and had the too coarse of topogrpahy in the CONUS region.
A new CONUS topo grid has been added to the ACME inputdata repo, and
when building this case, the user will download the new topo file.
 On branch eroesler/ATM/RRM-conustopofilefix
 Changes to be committed:
    modified:   ../../models/atm/cam/bld/namelist_files/namelist_defaults_cam.xml

[NML]

AG-296
