### PR TITLE
Fix module cleanup in env_mach_specific.edison

### DIFF
--- a/scripts/ccsm_utils/Machines/env_mach_specific.edison
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.edison
@@ -13,6 +13,8 @@ if (-e /opt/modules/default/init/csh) then
   module rm cce
   module rm cray-parallel-netcdf
   module rm cray-parallel-hdf5 
+  module rm cray-hdf5-parallel
+  module rm cray-netcdf-parallel
   module rm pmi
   module rm cray-libsci
   module rm cray-mpich2


### PR DESCRIPTION
The test scripts source the env_mach_specific file, and then
children processes re-source this same file for some testcases.
This means you need to be careful to avoid module conflicts and
enviroment problems.

In this case, the wrong modules were being cleaned up which left
some modules loaded to later conflict with other modules the env_mach
file was trying to load.

This commit fixes this issue.

[BFB]
