### PR TITLE
wait_for_tests: By default, do not fail a test if only a memcomp chec…

### DIFF
--- a/scripts/acme/acme_bisect
+++ b/scripts/acme/acme_bisect
@@ -54,6 +54,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-t", "--check-throughput", action="store_true", dest="check_throughput", default=False,
                         help="Consider a commit to be broken if throughput check fails (fail if tests slow down)")
 
+    parser.add_argument("-m", "--check-memory", action="store_true", dest="check_memory", default=False,
+                        help="Consider a commit to be broken if memory check fails (fail if tests footprint grows)")
+
     parser.add_argument("--no-batch", action="store_true", dest="no_batch", default=False,
                         help="Do not submit job to queue, run locally. Will default to whatever is standard on your machine")
 
@@ -61,10 +64,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     acme_util.set_verbosity(args.verbose)
 
-    return args.testname, args.testroot, args.project, args.compare, args.check_namelists, args.check_throughput, args.no_batch
+    return args.testname, args.testroot, args.project, args.compare, args.check_namelists, args.check_throughput, args.check_memory, args.no_batch
 
 ###############################################################################
-def acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, no_batch):
+def acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, check_memory, no_batch):
 ###############################################################################
     expect(os.path.exists("scripts/acme/create_test"), "Please run from root of repository")
 
@@ -102,6 +105,7 @@ def acme_bisect(testname, testroot, project, compare, check_namelists, check_thr
     return wait_for_tests.wait_for_tests([os.path.join(testarea, "TestStatus")],
                                          no_wait=no_batch, # wait if using batch
                                          check_throughput=check_throughput,
+                                         check_memory=check_memory,
                                          ignore_namelists=not check_namelists, # inverse due to opposite defaults
                                          cdash_build_name=None # don't do cdash stuff
                                          )
@@ -115,11 +119,11 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    testname, testroot, project, compare, check_namelists, check_throughput, no_batch = \
+    testname, testroot, project, compare, check_namelists, check_throughput, check_memory, no_batch = \
         parse_command_line(sys.argv, description)
 
     try:
-        rv = acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, no_batch)
+        rv = acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, check_memory, no_batch)
     except:
         print >> sys.stderr, "Exception in script, aborting bisect entirely:"
         e = sys.exc_info()[1]

--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -218,6 +218,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash,
         tests_passed = wait_for_tests.wait_for_tests(glob.glob("%s/*/TestStatus" % casearea),
                                                      not use_batch, # wait if using queue
                                                      False, # don't check throughput
+                                                     False, # don't check memory
                                                      False, # don't ignore namelist diffs
                                                      cdash_build_name,
                                                      cdash_project)

--- a/scripts/acme/wait_for_tests
+++ b/scripts/acme/wait_for_tests
@@ -51,6 +51,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-t", "--check-throughput", action="store_true", dest="check_throughput", default=False,
                         help="Fail if throughput check fails (fail if tests slow down)")
 
+    parser.add_argument("-m", "--check-memory", action="store_true", dest="check_memory", default=False,
+                        help="Fail if memory check fails (fail if tests footprint grows)")
+
     parser.add_argument("-i", "--ignore-namelist-diffs", action="store_true", dest="ignore_namelist_diffs", default=False,
                         help="Do not fail a test if the only problem is diffing namelists")
 
@@ -64,7 +67,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     acme_util.set_verbosity(args.verbose)
 
-    return args.paths, args.no_wait, args.check_throughput, args.ignore_namelist_diffs, args.cdash_build_name, args.cdash_project
+    return args.paths, args.no_wait, args.check_throughput, args.check_memory, args.ignore_namelist_diffs, args.cdash_build_name, args.cdash_project
 
 ###############################################################################
 def _main_func(description):
@@ -75,10 +78,10 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    test_paths, no_wait, check_throughput, ignore_namelist_diffs, cdash_build_name, cdash_project = \
+    test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, cdash_build_name, cdash_project = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if wait_for_tests.wait_for_tests(test_paths, no_wait, check_throughput, ignore_namelist_diffs, cdash_build_name, cdash_project) else 1)
+    sys.exit(0 if wait_for_tests.wait_for_tests(test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, cdash_build_name, cdash_project) else 1)
 
 ###############################################################################
 


### PR DESCRIPTION
…k failed

Adds an option to fail memcomp failures.

On blues, the memcomp checks are not reliably passing, even when generating
results and comparing against the same commit. This was causing a lot of
problems in the nightlies.

Going forward, only tests that are specifically for performance
should check throughput and memory.

[BFB]
