### PR TITLE
add support for additional timing library namelist variables 

### DIFF
--- a/models/drv/bld/build-namelist
+++ b/models/drv/bld/build-namelist
@@ -669,6 +669,18 @@ add_default($nl, 'profile_single_file');
 add_default($nl, 'profile_detail_limit');
 # add_default($nl, 'profile_outpe_stride',  'val'=>"16");
 add_default($nl, 'profile_barrier');
+add_default($nl, 'profile_outpe_num');
+add_default($nl, 'profile_papi_enable');
+
+#############################################
+# namelist group: papi_inparm               #
+#   in utils/timing/perf_mod.F90            #
+#############################################
+
+add_default($nl, 'papi_ctr1_str');
+add_default($nl, 'papi_ctr2_str');
+add_default($nl, 'papi_ctr3_str');
+add_default($nl, 'papi_ctr4_str');
 
 #############################################
 # namelist group: pio_default_inparm        #
@@ -703,6 +715,7 @@ my @groups = qw(seq_cplflds_inparm
 		seq_timemgr_inparm
  		ccsm_pes
 		prof_inparm
+		papi_inparm
                 pio_default_inparm);
 
 my $outfile = "./drv_in";

--- a/models/drv/bld/namelist_files/namelist_defaults_drv.xml
+++ b/models/drv/bld/namelist_files/namelist_defaults_drv.xml
@@ -128,6 +128,17 @@
 <profile_detail_limit TIMER_DETAIL="pos">$TIMER_DETAIL</profile_detail_limit>
 
 <profile_ovhd_measurement>.false.</profile_ovhd_measurement>
+<profile_outpe_num>1</profile_outpe_num>
+<profile_papi_enable>.false.</profile_papi_enable>
+
+<!-- =========================================  -->
+<!--- prof_inparm                               -->
+<!-- =========================================  -->
+
+<papi_ctr1_str>PAPI_FP_OPS</papi_ctr1_str>
+<papi_ctr2_str>PAPI_NO_CTR</papi_ctr2_str>
+<papi_ctr3_str>PAPI_NO_CTR</papi_ctr3_str>
+<papi_ctr4_str>PAPI_NO_CTR</papi_ctr4_str>
 
 <!-- =========================================  -->
 <!--- pio_default_inparm                        -->

--- a/models/drv/bld/namelist_files/namelist_definition_drv.xml
+++ b/models/drv/bld/namelist_files/namelist_definition_drv.xml
@@ -1686,6 +1686,53 @@ category="performance"
 group="prof_inparm">
 </entry>
 
+<entry 
+id="profile_outpe_num"
+type="integer"
+category="performance" 
+group="prof_inparm">
+</entry>
+
+<entry 
+id="profile_papi_enable"
+type="logical"
+category="performance" 
+group="prof_inparm">
+</entry>
+
+<!-- =========================== -->
+<!-- group papi_inparm           -->
+<!--  in perf_mod.F90            -->
+<!-- =========================== -->
+
+<entry 
+id="papi_ctr1_str"
+type="char*64"
+category="performance" 
+group="papi_inparm">
+</entry>
+
+<entry 
+id="papi_ctr2_str"
+type="char*64"
+category="performance" 
+group="papi_inparm">
+</entry>
+
+<entry 
+id="papi_ctr3_str"
+type="char*64"
+category="performance" 
+group="papi_inparm">
+</entry>
+
+<entry 
+id="papi_ctr4_str"
+type="char*64"
+category="performance" 
+group="papi_inparm">
+</entry>
+
 <!-- =========================== -->
 <!-- group pio_default_inparm    -->
 <!-- =========================== -->


### PR DESCRIPTION
A number of capabilities of the timing library are not available from ACME. The following modifications allow the defaults for the following timing library namelist variables to be overridden in user_nl_cpl.

profile_outpe_num:
  maximum number of processes writing out timing data
  (for a given component communicator); the default is 1.
profile_papi_enable:
  flag indicating whether the PAPI namelist should be read
  and HW performance counters used in profiling;
  default is .false.
papi_ctr1_str, papi_ctr2_str, papi_ctr3, papi_ctr4_str:
  strings indicating which PAPI counters to sample (up to 4 supported);
  defaults are: PAPI_FP_OPS for ctr1, and nothing for the other three.

Note that to use PAPI also requires modifying the Macro file to add

-DHAVE_PAPI

to CPPDEFS, and to modify env_mach_specific to add, for Cray systems,

module load papi

in the local case directory.

Ran the developer's test suite on Titan with PGI. All cases passed except PEA_P1_M.f45_g37_rx1.A, but this is failing with master as well, and it fails for the identical reason (see GitHub issue #274). Am using the PAPI counters and outpe_num to look at performance and load (im)balance for the MPAS-O C case using these changes, and everything is working as expected. 

NML
PG-187
