### PR TITLE
Edison env cleanup

### DIFF
--- a/scripts/ccsm_utils/Machines/env_mach_specific.edison
+++ b/scripts/ccsm_utils/Machines/env_mach_specific.edison
@@ -4,85 +4,65 @@
 # Modules and library paths
 #-------------------------------------------------------------------------------
 
-if (-e /opt/modules/default/init/csh) then
-  source /opt/modules/default/init/csh
-  module rm PrgEnv-intel
-  module rm PrgEnv-cray 
-  module rm PrgEnv-gnu
-  module rm intel
-  module rm cce
-  module rm cray-parallel-netcdf
-  module rm cray-parallel-hdf5 
-  module rm cray-hdf5-parallel
-  module rm cray-netcdf-parallel
-  module rm pmi
-  module rm cray-libsci
-  module rm cray-mpich2
-  module rm cray-mpich
-  module rm cray-netcdf
-  module rm cray-hdf5
-  module rm cray-netcdf-hdf5parallel
-  module rm craype-sandybridge
-  module rm craype-ivybridge
-  module rm craype
-endif
+if ! $?ACME_ENV_SETUP then
+    setenv ACME_ENV_SETUP True
 
-if ( $COMPILER == "intel" ) then
-    module load PrgEnv-intel 
-    module rm cray-libsci
-    setenv MKL "-mkl=cluster"
-    module use /global/project/projectdirs/ccsm1/modulefiles/edison
-    if( $DEBUG == "TRUE" ) then
-         module load esmf/6.2.0-defio-mpi-g
+    source /opt/modules/default/init/csh
+    module purge
+    module load torque/5.0.1
+    module load python_base/2.7.9
+
+    if ( $COMPILER == "intel" ) then
+        module load PrgEnv-intel
+        module rm cray-libsci
+        setenv MKL "-mkl=cluster"
+    endif    
+    if ( $COMPILER == "cray" ) then
+        module load PrgEnv-cray
+        module switch cce      cce/8.1.9
+    endif    
+    if ( $COMPILER == "gnu" ) then
+        module load PrgEnv-gnu
+        module switch gcc       gcc/4.8.0
+    endif    
+
+    module swap craype craype/2.1.1
+    module load craype-ivybridge
+    if( $COMPILER != "intel" ) then
+        module load cray-libsci/12.2.0
+    endif
+    module load cray-mpich/7.2.1
+    module load pmi/5.0.3-1.0000.9981.128.2.ari
+
+    if ( $MPILIB == "mpi-serial") then
+        module load cray-hdf5/1.8.11
+        module load cray-netcdf/4.3.0
     else
-         module load esmf/6.2.0-defio-mpi-O
-    endif  
-endif    
-if ( $COMPILER == "cray" ) then
-    module load PrgEnv-cray
-    module switch cce      cce/8.1.9
-endif    
-if ( $COMPILER == "gnu" ) then
-    module load PrgEnv-gnu
-    module switch gcc       gcc/4.8.0
-endif    
+        module load cray-netcdf-hdf5parallel/4.3.0
+        module load cray-hdf5-parallel/1.8.11
+        module load cray-parallel-netcdf/1.3.1.1
+    endif
 
-module swap craype craype/2.1.1
-module load craype-ivybridge
-if( $COMPILER != "intel" ) then
-  module load cray-libsci/12.2.0
+    module load cmake/2.8.11.2
+    module list >& software_environment.txt
+
+    #-------------------------------------------------------------------------------
+    # Runtime environment variables
+    #-------------------------------------------------------------------------------
+
+    limit coredumpsize unlimited
+    limit stacksize unlimited
+
+    # The environment variable below increase the stack size, which is necessary for
+    # CICE to run threaded on this machine.  
+    setenv OMP_STACKSIZE 64M
+
+    # Capture logical to physics PE assignment and active environment variable 
+    # settings
+    setenv MPICH_ENV_DISPLAY 1
+    setenv MPICH_VERSION_DISPLAY 1
+    setenv MPICH_CPUMASK_DISPLAY 1
+    # setenv MPICH_RANK_REORDER_DISPLAY 1
+
 endif
-module load cray-mpich/7.2.1
-module load pmi/5.0.3-1.0000.9981.128.2.ari
-
-if ( $MPILIB == "mpi-serial") then
-  module load cray-hdf5/1.8.11
-  module load cray-netcdf/4.3.0
-else
-  module load cray-netcdf-hdf5parallel/4.3.0
-  module load cray-hdf5-parallel/1.8.11
-  module load cray-parallel-netcdf/1.3.1.1
-endif
-
-module load cmake/2.8.11.2
-module list >& software_environment.txt
-
-
-#-------------------------------------------------------------------------------
-# Runtime environment variables
-#-------------------------------------------------------------------------------
-
-limit coredumpsize unlimited
-limit stacksize unlimited
-
-# The environment variable below increase the stack size, which is necessary for
-# CICE to run threaded on this machine.  
-setenv OMP_STACKSIZE 64M
-
-# Capture logical to physics PE assignment and active environment variable 
-# settings
-setenv MPICH_ENV_DISPLAY 1
-setenv MPICH_VERSION_DISPLAY 1
-setenv MPICH_CPUMASK_DISPLAY 1
-# setenv MPICH_RANK_REORDER_DISPLAY 1
 


### PR DESCRIPTION
Do a purge in the env mach file to remove differences between different
user's modules. We need to ensure all ACME users get a consistent env on
edison for running ACME.

For ACME to work on edison, the module cray-libsci must NOT be loaded;
however, the intel PrgEnv module loads the cray-libsci module, so
cray-libsci must be unloaded after the PrgEnv load. The problem is,
the following sequence is broken on edison:

```
module load PrgEnv-intel
module unload cray-libsci
module purge
module load PrgEnv-intel
module unload cray-libsci
```

The second time through, the cray-libsci is not successfully unloaded
and remains in the env to cause trouble. The old system that did not
use a purge could sometimes worked depending on the users' module
setup.

To address this:

```
* Env_specific.edison now has a guard, like a C++ include file, so that it is not sourced multiple times
* Env_specific.edison does a purge at the beginning of the file so that all users experience get the same env when using ACME
```

[BFB]
