### PR TITLE
Add support for mira and cetus to acme python scripts

### DIFF
--- a/scripts/acme/acme_util.py
+++ b/scripts/acme/acme_util.py
@@ -12,6 +12,9 @@ MACHINE_NODENAMES = [
     ("melvin", re.compile(r"melvin")),
     ("edison", re.compile(r"edison")),
     ("blues", re.compile(r"blogin")),
+    ("titan", re.compile(r"titan")),
+    ("mira", re.compile(r"mira")),
+    ("cetus", re.compile(r"cetus")),
 ]
 
 # batch-system-name -> ( cmd-to-list-all-jobs-for-user, cmd-to-delete-job )
@@ -75,6 +78,31 @@ MACHINE_INFO = {
         "/lcrc/project/ACME/<USER>/acme_scratch",
         "/lcrc/group/earthscience/acme_baselines",
         None
+    ),
+    "titan"    : (
+        "pgi",
+        "acme_integration",
+        True,
+        "cli112",
+        "/lustre/atlas/scratch/<USER>/<PROJECT>",
+        "/lustre/atlas1/cli900/world-shared/cesm/baselines",
+        None
+    ),
+    "mira"     : (
+        "ibm",
+        "acme_integration",
+        True,
+        "HiRes_EarthSys",
+        "/projects/<PROJECT>/<USER>",
+        "/projects/ccsm/ccsm_baselines"
+    ),
+    "cetus"     : (
+        "ibm",
+        "acme_integration",
+        True,
+        "HiRes_EarthSys",
+        "/projects/<PROJECT>/<USER>",
+        "/projects/ccsm/ccsm_baselines"
     ),
 }
 
@@ -335,7 +363,7 @@ def get_batch_system_info(batch_system=None):
     return BATCH_INFO[batch_system]
 
 ###############################################################################
-def get_machine_info(machine=None, user=None):
+def get_machine_info(machine=None, user=None, project=None):
 ###############################################################################
     """
     Return information on machine. If no arg provided, probe for machine.
@@ -349,8 +377,9 @@ def get_machine_info(machine=None, user=None):
     expect(machine is not None, "Failed to probe machine")
     expect(machine in MACHINE_INFO, "No info for machine '%s'" % machine)
     user = getpass.getuser() if user is None else user
+    project = project if project is not None else MACHINE_INFO[machine][3]
 
-    return [item.replace("<USER>", user) if type(item) is str else item for item in MACHINE_INFO[machine]]
+    return [item.replace("<USER>", user).replace("<PROJECT>", project) if type(item) is str else item for item in MACHINE_INFO[machine]]
 
 ###############################################################################
 def get_utc_timestamp(format="%Y%m%d_%H%M%S"):

--- a/scripts/acme/create_test
+++ b/scripts/acme/create_test
@@ -127,7 +127,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                "You did not specify a machine name and one could not be probed")
 
     compiler, _, use_batch, project, testroot, baseline_root, _ = \
-        acme_util.get_machine_info(args.machine)
+        acme_util.get_machine_info(args.machine, project=args.project)
 
     if (args.compiler is None):
         args.compiler = compiler
@@ -197,7 +197,7 @@ def create_test(testargs, compiler, machine, no_run=False, no_build=False, no_ba
 
     create_test_cmd = "./create_test -input_list %s -mach %s" % (testlist_file, machine)
     if (no_run):
-        expect(False, "--no-run not currently supported")
+        create_test_cmd = "%s -autosubmit off" % create_test_cmd
     if (no_build):
         create_test_cmd = "%s -nobuild on" % create_test_cmd
     if (test_root):


### PR DESCRIPTION
Just needed to add data for these machines into acme_util.

Also, support the no-build option for acme/create_test

Fixes #279

[BFB]
