### PR TITLE
Adds bugfix for CLM 1D output from clm4_5_1_r091

### DIFF
--- a/models/lnd/clm/src/main/histFileMod.F90
+++ b/models/lnd/clm/src/main/histFileMod.F90
@@ -1700,6 +1700,7 @@ contains
     integer :: numl                ! total number of landunits across all processors
     integer :: numg                ! total number of gridcells across all processors
     integer :: numa                ! total number of atm cells across all processors
+    logical :: avoid_pnetcdf       ! whether we should avoid using pnetcdf
     logical :: lhistrest           ! local history restart flag
     type(file_desc_t) :: lnfid     ! local file id
     character(len=  8) :: curdate  ! current date
@@ -1724,6 +1725,17 @@ contains
     ! define output write precsion for tape
 
     ncprec = tape(t)%ncprec
+    
+    ! BUG(wjs, 2014-10-20, bugz 1730) Workaround for
+    ! http://bugs.cgd.ucar.edu/show_bug.cgi?id=1730
+    ! - 1-d hist files have problems with pnetcdf. A better workaround in terms of
+    ! performance is to keep pnetcdf, but set PIO_BUFFER_SIZE_LIMIT=0, but that can't be
+    ! done on a per-file basis.
+    if (.not. tape(t)%dov2xy) then
+       avoid_pnetcdf = .true.
+    else
+       avoid_pnetcdf = .false.
+    end if
 
     ! Create new netCDF file. It will be in define mode
 
@@ -1733,7 +1745,7 @@ contains
                                       trim(locfnh(t))
           call shr_sys_flush(iulog)
        end if
-       call ncd_pio_createfile(lnfid, trim(locfnh(t)))
+       call ncd_pio_createfile(lnfid, trim(locfnh(t)), avoid_pnetcdf=avoid_pnetcdf)
        call ncd_putatt(lnfid, ncd_global, 'title', 'CLM History file information' )
        call ncd_putatt(lnfid, ncd_global, 'comment', &
           "NOTE: None of the variables are weighted by land fraction!" )
@@ -1743,7 +1755,7 @@ contains
                                       trim(locfnhr(t))
           call shr_sys_flush(iulog)
        end if
-       call ncd_pio_createfile(lnfid, trim(locfnhr(t)))
+       call ncd_pio_createfile(lnfid, trim(locfnhr(t)), avoid_pnetcdf=avoid_pnetcdf)
        call ncd_putatt(lnfid, ncd_global, 'title', &
           'CLM Restart History information, required to continue a simulation' )
        call ncd_putatt(lnfid, ncd_global, 'comment', &

--- a/models/lnd/clm/src/main/ncdio_pio.F90.in
+++ b/models/lnd/clm/src/main/ncdio_pio.F90.in
@@ -210,20 +210,46 @@ contains
   end subroutine ncd_pio_closefile
 
   !-----------------------------------------------------------------------
-  subroutine ncd_pio_createfile(file, fname)
+  subroutine ncd_pio_createfile(file, fname, avoid_pnetcdf)
     !
     ! !DESCRIPTION:
     ! Create a new NetCDF file with PIO
     !
+    ! !USES:
+    use pio, only : pio_iotype_pnetcdf, pio_iotype_netcdf
+    !
     ! !ARGUMENTS:
     class(file_desc_t), intent(inout) :: file    ! PIO file descriptor
     character(len=*) ,  intent(in)    :: fname   ! File name to create
+
+    ! BUG(wjs, 2014-10-20, bugz 1730) Workaround for
+    ! http://bugs.cgd.ucar.edu/show_bug.cgi?id=1730
+    logical, intent(in), optional     :: avoid_pnetcdf
     !
     ! !LOCAL VARIABLES:
+    logical :: l_avoid_pnetcdf  ! local version of avoid_pnetcdf
+    integer :: my_io_type
     integer :: ierr
     !-----------------------------------------------------------------------
 
-    ierr = pio_createfile(pio_subsystem, file, io_type, fname, ior(PIO_CLOBBER,PIO_64BIT_OFFSET))
+    l_avoid_pnetcdf = .false.
+    if (present(avoid_pnetcdf)) then
+       l_avoid_pnetcdf = avoid_pnetcdf
+    end if
+
+    my_io_type = io_type
+    if (l_avoid_pnetcdf) then
+       if (my_io_type == pio_iotype_pnetcdf) then
+          my_io_type = pio_iotype_netcdf
+          if (pio_subsystem%io_rank==0) then
+             write(iulog,*) 'Workaround for bugz 1730: creating'
+             write(iulog,*) trim(fname)
+             write(iulog,*) 'with type netcdf instead of pnetcdf'
+          end if
+       end if
+    end if
+
+    ierr = pio_createfile(pio_subsystem, file, my_io_type, fname, ior(PIO_CLOBBER,PIO_64BIT_OFFSET))
 
     if(ierr/= PIO_NOERR) then
        call shr_sys_abort( ' ncd_pio_createfile ERROR: Failed to open file to write: '//trim(fname))


### PR DESCRIPTION
- This bug was identified by CSEG as [bug-1730](http://bugs.cgd.ucar.edu/show_bug.cgi?id=1730)
  and fixed in clm4_5_1_r091 tag.
- Bugfix recipe:
  cd [path-to-acme]
  cp [path-to-clm4_5_1_r091]/models/lnd/clm/src/main/histFileMod.F90 models/lnd/clm/src/main
  cp [path-to-clm4_5_1_r091]/models/lnd/clm/src/main/ncdio_pio.F90 models/lnd/clm/src/main
  cp [path-to-clm4_5_1_r091]/models/lnd/clm/src/main/ncdio_pio.F90.in models/lnd/clm/src/main

Fixes #190

[BFB]
