### PR TITLE
Fixing single threaded builds on Cetus

### DIFF
--- a/scripts/ccsm_utils/Machines/Depends.cetus
+++ b/scripts/ccsm_utils/Machines/Depends.cetus
@@ -6,9 +6,9 @@ shr_reprosum_mod.o: shr_reprosum_mod.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(QSMPFLAGS) $<
 
 mo_sethet.o: mo_sethet.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -qsmp=noauto:noomp $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(QSMPFLAGS) $<
 mo_drydep.o: mo_drydep.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -qsmp=noauto:noomp $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(QSMPFLAGS) $<
 time_management.o: time_management.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -qsmp=noauto:noomp $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(QSMPFLAGS) $<
 


### PR DESCRIPTION
Fixing build time issues with single threaded builds
on Cetus. Without the fix a single threaded build would fail
due to mixing of single threaded and multi threaded (openmp)
compiler options.

Fixes #288
[BFB]
