### PR TITLE
Bug fixes from NCAR:dyn(int to real),mem alloc fixes for modal aerosols

### DIFF
--- a/models/atm/cam/src/chemistry/utils/modal_aero_calcsize.F90
+++ b/models/atm/cam/src/chemistry/utils/modal_aero_calcsize.F90
@@ -1237,9 +1237,9 @@ subroutine modal_aero_calcsize_diag(state, pbuf, list_idx_in, dgnum_m)
          call endrun('modal_aero_calcsize_diag called for'// &
                      'diagnostic list but dgnum_m pointer not present')
       end if
-      allocate(dgnum_m(pcols,pver,nmodes), stat=stat)
-      if (stat > 0) then
-         call endrun('modal_aero_calcsize_diag: allocation FAILURE: dgnum_m')
+      if (.not. associated(dgnum_m)) then
+         call endrun('modal_aero_calcsize_diag called for'// &
+            'diagnostic list but dgnum_m not associated')
       end if
    end if
 

--- a/models/atm/cam/src/dynamics/eul/restart_dynamics.F90
+++ b/models/atm/cam/src/dynamics/eul/restart_dynamics.F90
@@ -315,7 +315,7 @@ subroutine init_restart_dynamics(File, hdimids, dyn_out)
 
 
     do t=1,ptimelevels
-       time = ndcur+(real(nscur,kind=r8)+ (t-2)*dtime)/86400_r8
+       time = ndcur+(real(nscur,kind=r8)+ (t-2)*dtime)/86400._r8
        ierr = pio_put_var(File,timedesc%varid, (/int(t)/), time)
     end do
     do i=1,restartvarcnt

--- a/models/atm/cam/src/dynamics/fv/restart_dynamics.F90
+++ b/models/atm/cam/src/dynamics/fv/restart_dynamics.F90
@@ -323,7 +323,7 @@ CONTAINS
 
     ierr = pio_put_var(File, tmass0desc, (/tmass0/))
 
-    time = ndcur+(real(nscur,kind=r8))/86400_r8
+    time = ndcur+(real(nscur,kind=r8))/86400._r8
     ierr = pio_put_var(File,timedesc%varid, time)
 
     do i=1,restartvarcnt

--- a/models/atm/cam/src/dynamics/se/restart_dynamics.F90
+++ b/models/atm/cam/src/dynamics/se/restart_dynamics.F90
@@ -182,7 +182,7 @@ CONTAINS
 
     tl = timelevel%n0
     call TimeLevel_Qdp(timelevel, qsplit, tlQdp)
-    time = ndcur+real(nscur,kind=r8)/86400_r8
+    time = ndcur+real(nscur,kind=r8)/86400._r8
 
     ierr = pio_put_var(File,timedesc%varid, (/int(t)/), time)
 

--- a/models/atm/cam/src/dynamics/sld/restart_dynamics.F90
+++ b/models/atm/cam/src/dynamics/sld/restart_dynamics.F90
@@ -338,7 +338,7 @@ CONTAINS
     ierr = pio_put_var(File, lnpstardesc, lnpstar)
 
     do t=1,ptimelevels
-       time = ndcur+(real(nscur,kind=r8)+ (t-2)*dtime)/86400_r8
+       time = ndcur+(real(nscur,kind=r8)+ (t-2)*dtime)/86400._r8
        ierr = pio_put_var(File,timedesc%varid, (/int(t)/), time)
     end do
     do i=1,restartvarcnt

--- a/models/atm/cam/src/physics/cam/modal_aer_opt.F90
+++ b/models/atm/cam/src/physics/cam/modal_aer_opt.F90
@@ -330,6 +330,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
    integer :: ncol                     ! number of active columns in the chunk
    integer :: nmodes
    integer :: nspec
+   integer :: istat
 
    real(r8) :: mass(pcols,pver)        ! layer mass
    real(r8) :: air_density(pcols,pver) ! (kg/m3)
@@ -483,6 +484,11 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
    else
       ! If doing a diagnostic calculation then need to calculate the wet radius
       ! and water uptake for the diagnostic modes
+      allocate(dgnumdry_m(pcols,pver,nmodes), dgnumwet_m(pcols,pver,nmodes), &
+               qaerwat_m(pcols,pver,nmodes),  wetdens_m(pcols,pver,nmodes), stat=istat)
+      if (istat > 0) then
+         call endrun('modal_aero_sw: allocation FAILURE: arrays for diagnostic calcs')
+      end if
       call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m)  
       call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
                                      qaerwat_m, wetdens_m)
@@ -938,6 +944,7 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
    integer :: ncol                     ! number of active columns in the chunk
    integer :: nmodes
    integer :: nspec
+   integer :: istat
 
    real(r8), pointer :: dgnumwet(:,:)  ! wet number mode diameter (m)
    real(r8), pointer :: qaerwat(:,:)   ! aerosol water (g/g)
@@ -1001,6 +1008,11 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
    else
       ! If doing a diagnostic calculation then need to calculate the wet radius
       ! and water uptake for the diagnostic modes
+      allocate(dgnumdry_m(pcols,pver,nmodes), dgnumwet_m(pcols,pver,nmodes), &
+               qaerwat_m(pcols,pver,nmodes),  wetdens_m(pcols,pver,nmodes), stat=istat)
+      if (istat > 0) then
+         call endrun('modal_aero_lw: allocation FAILURE: arrays for diagnostic calcs')
+      end if
       call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m)  
       call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
                                      qaerwat_m, wetdens_m)


### PR DESCRIPTION
This commit fixes the following bugs reported by NCAR:
- All dynamic cores had an int in the denominator of an equation which
  should be real.
- There were memory allocation bugs in modal aerosol files which are
  fixed. NCAR had a lot of other changes in these files. I took only the
  changes which are relevant to ACME codes.

See issues #293 and #292 for more details

Fixes #292, Fixes #293
[BFB]
AG-331, AG-332
