### PR TITLE
wait_for_tests: reduce parent thread sleep duration

### DIFF
--- a/scripts/acme/tests/scripts_regression_tests
+++ b/scripts/acme/tests/scripts_regression_tests
@@ -179,7 +179,7 @@ class TestWaitForTests(unittest.TestCase):
 
         make_fake_teststatus(os.path.join(self._testdir_unfinished, "TestStatus_5"), "Test_5", "PASS")
 
-        run_thread.join(timeout=30)
+        run_thread.join(timeout=130)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
@@ -199,7 +199,7 @@ class TestWaitForTests(unittest.TestCase):
 
         kill_python_subprocesses(signal.SIGTERM, expected_num_killed=1, tester=self)
 
-        run_thread.join(timeout=30)
+        run_thread.join(timeout=130)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
@@ -213,7 +213,7 @@ class TestWaitForTests(unittest.TestCase):
         run_thread.daemon = True
         run_thread.start()
 
-        run_thread.join(timeout=30)
+        run_thread.join(timeout=130)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
@@ -233,7 +233,7 @@ class TestWaitForTests(unittest.TestCase):
 
         kill_python_subprocesses(signal.SIGTERM, expected_num_killed=1, tester=self)
 
-        run_thread.join(timeout=30)
+        run_thread.join(timeout=130)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
@@ -344,7 +344,7 @@ class TestJenkinsGenericJob(unittest.TestCase):
 
         kill_subprocesses(sig=signal.SIGTERM)
 
-        run_thread.join(timeout=30)
+        run_thread.join(timeout=130)
 
         self.assertFalse(run_thread.isAlive(), msg="jenkins_generic_job should have finished")
         self.assert_no_sentinel()

--- a/scripts/acme/wait_for_tests.py
+++ b/scripts/acme/wait_for_tests.py
@@ -334,7 +334,7 @@ def get_test_results(test_paths, no_wait=False, check_throughput=False, check_me
         t.start()
 
     while threading.active_count() > 1:
-        time.sleep(SLEEP_INTERVAL_SEC)
+        time.sleep(1)
 
     test_results = dict()
     completed_test_paths = []


### PR DESCRIPTION
A long sleep interval for the parent threaded added no safety
so that has been reduced back to one second.

Also, bump up the timeouts for the regression test now that wait_for_tests
is much less respondive due to long sleep intervals in the test-monitoring
threads.

[BFB]
