### PR TITLE
acme_util: Auto-strip output coming from run_cmd

### DIFF
--- a/scripts/acme/acme_util.py
+++ b/scripts/acme/acme_util.py
@@ -162,6 +162,7 @@ def run_cmd(cmd, ok_to_fail=False, input_str=None, from_dir=None, verbose=None,
                             stdin=stdin,
                             cwd=from_dir)
     output, errput = proc.communicate(input_str)
+    output = output.strip() if output is not None else output
     stat = proc.wait()
 
     verbose_print("  stat: %d\n" % stat, verbose)
@@ -227,7 +228,7 @@ def get_current_branch(repo=None):
         return branch
     else:
         output = run_cmd("git symbolic-ref HEAD", from_dir=repo)
-        return output.replace("refs/heads/", "").strip()
+        return output.replace("refs/heads/", "")
 
 ###############################################################################
 def get_current_commit(short=False, repo=None):
@@ -236,7 +237,7 @@ def get_current_commit(short=False, repo=None):
     Return the sha1 of the current HEAD commit
     """
     output = run_cmd("git rev-parse %s HEAD" % ("--short" if short else ""), from_dir=repo)
-    return output.strip()
+    return output
 
 ###############################################################################
 def get_source_repo():

--- a/scripts/acme/bless_test_results
+++ b/scripts/acme/bless_test_results
@@ -123,7 +123,7 @@ def bless_test_results(baseline_branch=None, namelists_only=False, report_only=F
                 case = os.path.basename(testcase_dir_for_test)
 
                 # Get user that test was run as (affects loc of hist files)
-                user = run_cmd(r"""grep CCSMUSER %s/env_case.xml | sed -E 's/.+value="(.+)".+/\1/g'""" % testcase_dir_for_test).strip()
+                user = run_cmd(r"""grep CCSMUSER %s/env_case.xml | sed -E 's/.+value="(.+)".+/\1/g'""" % testcase_dir_for_test)
                 acme_root = acme_util.get_machine_info(acme_machine, user=user)[4]
 
                 # Find files of various types

--- a/scripts/acme/cime_merge_helper
+++ b/scripts/acme/cime_merge_helper
@@ -97,7 +97,7 @@ def merge_acme_changes(acme_path, subdir):
     stat = run_cmd("git remote add acme %s" % acme_path, ok_to_fail=True)[0]
     if (stat != 0):
         # May already exist
-        config_url = run_cmd("git config --get remote.acme.url").strip()
+        config_url = run_cmd("git config --get remote.acme.url")
         if (config_url != acme_path):
             print >> sys.stderr, "Warning: Changing URL of acme remote"
             run_cmd("git remote set-url acme %s" % acme_path)


### PR DESCRIPTION
Most commands print a trailing newline for the benefit of users
using a shell, but when gathering command output from python,
this newline is almost never useful and frequently a source of
confusion. Auto-strip will take care of this for us.

[BFB]
