### PR TITLE
Significant refactor to support titan in our ACME scripts.

### DIFF
--- a/scripts/acme/acme_bisect
+++ b/scripts/acme/acme_bisect
@@ -17,7 +17,7 @@ from acme_util import expect, warning, verbose_print, run_cmd
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n%s <testname> <testroot> <project> [--compare=<baseline-id>] [--no-submit]  [--verbose]
+        usage="""\n%s <testname> [--compare=<baseline-id>] [--no-batch]  [--verbose]
 OR
 %s --help
 OR
@@ -36,13 +36,20 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
+    default_compiler, _, _, default_project, default_testroot, _, _ = acme_util.get_machine_info(raw=True)
+
     parser.add_argument("testname", help="Name of failing test.")
 
-    parser.add_argument("testroot", help="Path to testroot to use for testcases for bisect.")
+    parser.add_argument("-r", "--test-root", action="store", dest="testroot", default=default_testroot,
+                        help="Path to testroot to use for testcases for bisect.")
 
-    parser.add_argument("project", help="Project to be given to create_test.")
+    parser.add_argument("-c", "--compiler", action="store", dest="compiler", default=default_compiler,
+                        help="What compiler to use to build ACME")
 
-    parser.add_argument("-c", "--compare", action="store", dest="compare", default=None,
+    parser.add_argument("-p", "--project", action="store", dest="project", default=default_project,
+                        help="Project to be given to create_test.")
+
+    parser.add_argument("-b", "--baseline-name", action="store", dest="baseline_name", default=None,
                         help="Baseline id for comparing baselines. Not specifying means no comparisons will be done.")
 
     parser.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False,
@@ -58,16 +65,19 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="Consider a commit to be broken if memory check fails (fail if tests footprint grows)")
 
     parser.add_argument("--no-batch", action="store_true", dest="no_batch", default=False,
-                        help="Do not submit job to queue, run locally. Will default to whatever is standard on your machine")
+                        help="Force scripts to not submit tests as batch jobs. Default will be to do whatever is standard on the current machine")
 
     args = parser.parse_args(args[1:])
 
     acme_util.set_verbosity(args.verbose)
 
-    return args.testname, args.testroot, args.project, args.compare, args.check_namelists, args.check_throughput, args.check_memory, args.no_batch
+    if (args.test_root == default_testroot):
+        args.test_root = acme_util.get_machine_info(project=args.project)
+
+    return args.testname, args.testroot, args.compiler, args.project, args.baseline_name, args.check_namelists, args.check_throughput, args.check_memory, args.no_batch
 
 ###############################################################################
-def acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, check_memory, no_batch):
+def acme_bisect(testname, testroot, compiler, project, baseline_name, check_namelists, check_throughput, check_memory, no_batch):
 ###############################################################################
     expect(os.path.exists("scripts/acme/create_test"), "Please run from root of repository")
 
@@ -80,9 +90,9 @@ def acme_bisect(testname, testroot, project, compare, check_namelists, check_thr
     # Formulate and run create_test command
 
     extra_args = "--no-batch" if no_batch else ""
-    compare_args = "-c -b %s" % compare if compare is not None else ""
-    create_test_cmd = "scripts/acme/create_test %s --test-root %s -t %s -p %s %s %s" % \
-                      (testname, testroot, current_sha, project, compare_args, extra_args)
+    compare_args = "-c -b %s" % baseline_name if baseline_name is not None else ""
+    create_test_cmd = "scripts/acme/create_test %s --test-root %s --compiler %s -t %s -p %s %s %s" % \
+                      (testname, testroot, compiler, current_sha, project, compare_args, extra_args)
     run_cmd(create_test_cmd)
 
     # Find testcase area
@@ -119,11 +129,11 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    testname, testroot, project, compare, check_namelists, check_throughput, check_memory, no_batch = \
+    testname, testroot, compiler, project, baseline_name, check_namelists, check_throughput, check_memory, no_batch = \
         parse_command_line(sys.argv, description)
 
     try:
-        rv = acme_bisect(testname, testroot, project, compare, check_namelists, check_throughput, check_memory, no_batch)
+        rv = acme_bisect(testname, testroot, compiler, project, baseline_name, check_namelists, check_throughput, check_memory, no_batch)
     except:
         print >> sys.stderr, "Exception in script, aborting bisect entirely:"
         e = sys.exc_info()[1]

--- a/scripts/acme/acme_util.py
+++ b/scripts/acme/acme_util.py
@@ -83,9 +83,9 @@ MACHINE_INFO = {
         "pgi",
         "acme_integration",
         True,
-        "cli112",
+        "cli115",
         "/lustre/atlas/scratch/<USER>/<PROJECT>",
-        "/lustre/atlas1/cli900/world-shared/cesm/baselines",
+        "/lustre/atlas1/cli900/world-shared/cesm/acme/baselines",
         None
     ),
     "mira"     : (
@@ -369,7 +369,7 @@ def get_batch_system_info(batch_system=None):
     return BATCH_INFO[batch_system]
 
 ###############################################################################
-def get_machine_info(machine=None, user=None, project=None):
+def get_machine_info(machine=None, user=None, project=None, raw=False):
 ###############################################################################
     """
     Return information on machine. If no arg provided, probe for machine.
@@ -378,17 +378,24 @@ def get_machine_info(machine=None, user=None, project=None):
     (compiler, test_suite, use_batch, project, testroot, baseline_root, proxy)
     """
     import getpass
+    user = getpass.getuser() if user is None else user
+
     if (machine is None):
         machine = probe_machine_name()
     expect(machine is not None, "Failed to probe machine")
     expect(machine in MACHINE_INFO, "No info for machine '%s'" % machine)
-    user = getpass.getuser() if user is None else user
-    project = project if project is not None else MACHINE_INFO[machine][3]
 
-    return [item.replace("<USER>", user).replace("<PROJECT>", project) if type(item) is str else item for item in MACHINE_INFO[machine]]
+    machine_info_copy = list(MACHINE_INFO[machine])
+    machine_info_copy[3] = project if project is not None else machine_info_copy[3]
+    project = machine_info_copy[3]
+
+    if (raw):
+        return machine_info_copy
+    else:
+        return [item.replace("<USER>", user).replace("<PROJECT>", project) if type(item) is str else item for item in machine_info_copy]
 
 ###############################################################################
-def get_utc_timestamp(format="%Y%m%d_%H%M%S"):
+def get_utc_timestamp(timestamp_format="%Y%m%d_%H%M%S"):
 ###############################################################################
     """
     Get a string representing the current UTC time in format: YYMMDD_HHMMSS
@@ -396,4 +403,4 @@ def get_utc_timestamp(format="%Y%m%d_%H%M%S"):
     The format can be changed if needed.
     """
     utc_time_tuple = time.gmtime()
-    return time.strftime(format, utc_time_tuple)
+    return time.strftime(timestamp_format, utc_time_tuple)

--- a/scripts/acme/bless_test_results
+++ b/scripts/acme/bless_test_results
@@ -13,7 +13,7 @@ with versions of the files that you should not bless.
 import acme_util
 acme_util.check_minimum_python_version(2, 7)
 
-import argparse, sys, os, socket, shutil, glob, doctest
+import argparse, sys, os, glob, doctest
 
 import wait_for_tests, compare_namelists, simple_compare
 from acme_util import expect, warning, verbose_print, run_cmd
@@ -44,20 +44,28 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
+    default_baseline_name = acme_util.get_current_branch(repo=acme_util.get_source_repo())
+
+    default_compiler, _, _, _, acme_root, _, _ = acme_util.get_machine_info()
+    default_testroot = os.path.join(acme_root, "jenkins")
+
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra information")
 
     parser.add_argument("-n", "--namelists-only", action="store_true",
                         help="Only analyze namelists.")
 
-    parser.add_argument("-b", "--branch",
-                        help="Force us to use baselines for a specific branch instead of the current branch.")
+    parser.add_argument("-b", "--baseline-name", default=default_baseline_name,
+                        help="Name of baselines to use.")
+
+    parser.add_argument("-c", "--compiler", default=default_compiler,
+                        help="Compiler of run you want to bless")
 
     parser.add_argument("-r", "--report-only", action="store_true",
                         help="Only report what files will be overwritten and why. Caution is a good thing when updating baselines")
 
-    parser.add_argument("-t", "--test-root",
-                        help="Instead of looking at last night's Jenkins results, use a custom test area")
+    parser.add_argument("-t", "--test-root", default=default_testroot,
+                        help="Path to test results that are being blessed")
 
     parser.add_argument("-f", "--force", action="store_true",
                         help="Update every diff without asking. VERY DANGEROUS. Should only be used within testing scripts.")
@@ -72,31 +80,18 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     acme_util.set_verbosity(args.verbose)
 
-    return args.branch, args.namelists_only, args.report_only, args.test_root, args.force, args.bless_tests
+    return args.baseline_name, args.test_root, args.compiler, args.namelists_only, args.report_only, args.force, args.bless_tests
 
 ###############################################################################
-def bless_test_results(baseline_branch=None, namelists_only=False, report_only=False, test_root=None, force=False, bless_tests=None):
+def bless_test_results(baseline_name, test_root, compiler, namelists_only=False, report_only=False, force=False, bless_tests=None):
 ###############################################################################
-    acme_machine = acme_util.probe_machine_name()
-    expect(acme_machine is not None,
-           "Did not recognize current machine '%s'" % socket.gethostname())
-
-    acme_repo = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-    expect(os.path.isdir(os.path.join(acme_repo, ".git")),
-           "Expected '%s' to be a git repository" % acme_repo)
-
-    _, _, _, _, acme_root, baseline_root, _ = acme_util.get_machine_info(acme_machine)
-    if (test_root is None):
-        test_root = os.path.join(acme_root, "jenkins")
-
-    git_branch = acme_util.get_current_branch(repo=acme_repo) if baseline_branch is None else baseline_branch
-
     test_results = wait_for_tests.get_test_results(glob.glob("%s/*/TestStatus" % test_root),
                                                    True, # no wait
                                                    False, # don't check throughput
                                                    False) # don't ignore namelist diffs
 
-    baseline_area = os.path.join(baseline_root, git_branch)
+    baseline_root = acme_util.get_machine_info()[5]
+    baseline_area = os.path.join(baseline_root, compiler, baseline_name)
 
     for test_name, test_data in test_results.iteritems():
         if (bless_tests in [[], None] or acme_util.match_any(test_name, bless_tests)):
@@ -124,7 +119,7 @@ def bless_test_results(baseline_branch=None, namelists_only=False, report_only=F
 
                 # Get user that test was run as (affects loc of hist files)
                 user = run_cmd(r"""grep CCSMUSER %s/env_case.xml | sed -E 's/.+value="(.+)".+/\1/g'""" % testcase_dir_for_test).strip()
-                acme_root = acme_util.get_machine_info(acme_machine, user=user)[4]
+                acme_root = acme_util.get_machine_info(user=user)[4]
 
                 # Find files of various types
                 namelist_files = []
@@ -168,7 +163,7 @@ def bless_test_results(baseline_branch=None, namelists_only=False, report_only=F
                                     warning("Skipping hist files for this test")
                                     continue
                                 hist_file = hist_files[0]
-                                hist_compare_script = os.path.join(os.path.dirname(__file__), "..", "ccsm_utils", "Tools", "hist_compare.csh")
+                                hist_compare_script = os.path.join(acme_util.get_source_repo(), "scripts", "ccsm_utils", "Tools", "hist_compare.csh")
                                 stat = run_cmd("%s %s %s" % (hist_compare_script, hist_file, baseline_file), arg_stdout=None, arg_stderr=None, ok_to_fail=True)[0]
                                 if (stat != 0):
                                     print "Hist files '%s' and '%s' did not match" % (baseline_file, hist_file)
@@ -194,10 +189,10 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    baseline_branch, namelists_only, report_only, test_root, force, bless_tests = \
+    baseline_name, test_root, compiler, namelists_only, report_only, force, bless_tests = \
         parse_command_line(sys.argv, description)
 
-    bless_test_results(baseline_branch, namelists_only, report_only, test_root, force, bless_tests)
+    bless_test_results(baseline_name, test_root, compiler, namelists_only, report_only, force, bless_tests)
 
 ###############################################################################
 

--- a/scripts/acme/create_test
+++ b/scripts/acme/create_test
@@ -51,6 +51,12 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
+    default_compiler, _, _, default_project, default_testroot, default_baseline_root, _ = acme_util.get_machine_info(raw=True)
+    if ("PROJECT" in os.environ):
+        default_project = os.environ["PROJECT"]
+
+    default_baseline_name = acme_util.get_current_branch(repo=acme_util.get_source_repo())
+
     parser.add_argument("testargs", nargs="+", help="Tests or test suites to run. Testnames expect in form CASE.GRID.COMPSET")
 
     parser.add_argument("-v", "--verbose", action="store_true",
@@ -63,16 +69,15 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="Do not build generated tests, implies --no-run")
 
     parser.add_argument("--no-batch", action="store_true",
-                        help="Do not submit jobs to batch system, run locally. Will default to machine setting.")
+                        help="Do not submit jobs to batch system, run locally. If false, will default to machine setting.")
 
-    parser.add_argument("-r", "--test-root",
+    parser.add_argument("-r", "--test-root", default=default_testroot,
                         help="Where test cases will be created. Will default to scratch root XML machine file")
 
-    parser.add_argument("--baseline-root",
-                        help="Specifies an alternate root directory for baseline"
+    parser.add_argument("--baseline-root", default=default_baseline_root,
+                        help="Specifies an root directory for baseline"
                         "datasets used for Bit-for-bit generate/compare"
-                        "testing. If this argument is not supplied, the"
-                        "default baselineroot will be used from the XML machine file.")
+                        "testing.")
 
     parser.add_argument("--clean", action="store_true",
                         help="Specifies if tests should be cleaned after run. If set, "
@@ -84,24 +89,20 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-g", "--generate", action="store_true",
                         help="While testing, generate baselines")
 
-    parser.add_argument("-b", "--baseline-name",
+    parser.add_argument("-b", "--baseline-name", default=default_baseline_name,
                         help="If comparing or generating baselines, use this directory under baseline root. "
                         "Default will be current branch name")
 
-    parser.add_argument("--compiler",
-                        help="Force tests to use this compiler; otherwise, default compiler for this machine will be used.")
-
-    parser.add_argument("-m", "--machine",
-                        help="Instead of probing for machine, force scripts to use this machine.")
+    parser.add_argument("--compiler", default=default_compiler,
+                        help="Compiler to use to build ACME.")
 
     parser.add_argument("-n", "--namelists-only", action="store_true",
                         help="Only perform namelist actions for tests")
 
-    parser.add_argument("-p", "--project",
+    parser.add_argument("-p", "--project", default=default_project,
                         help="Specify a project id for the case (optional)."
                         "Used for accounting when on a batch system."
-                        "The default is user-specified environment variable PROJECT or ACCOUNT,"
-                        "or read from ~/.cesm_proj or ~/.ccsm_proj")
+                        "The default is user-specified environment variable PROJECT")
 
     parser.add_argument("-t", "--test-id",
                         help="Specify an 'id' for the test. This is simply a"
@@ -121,33 +122,21 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     if (args.no_build):
         args.no_run = True
 
-    if (args.machine is None):
-        args.machine = acme_util.probe_machine_name()
-        expect(args.machine is not None,
-               "You did not specify a machine name and one could not be probed")
-
-    compiler, _, use_batch, project, testroot, baseline_root, _ = \
-        acme_util.get_machine_info(args.machine, project=args.project)
-
-    if (args.compiler is None):
-        args.compiler = compiler
-
-    if (args.project is None):
-        args.project = project
+    _, _, use_batch, _, testroot, baseline_root, _ = \
+        acme_util.get_machine_info(project=args.project)
 
     if (not args.no_batch and not use_batch):
         args.no_batch = True
 
-    if (args.test_root is None):
+    # Couple defaults might need fixup because their values were dependent on
+    # information that can't be determined until after args are parsed
+    if (args.test_root == default_testroot):
         args.test_root = testroot
 
-    if (args.baseline_root is None):
+    if (args.baseline_root == default_baseline_root):
         args.baseline_root = baseline_root
 
-    if (args.baseline_name is None):
-        args.baseline_name = acme_util.get_current_branch()
-
-    return args.testargs, args.compiler, args.machine, args.no_run, args.no_build, args.no_batch, args.test_root, args.baseline_root, \
+    return args.testargs, args.compiler, args.no_run, args.no_build, args.no_batch, args.test_root, args.baseline_root, \
         args.clean, args.compare, args.generate, args.baseline_name, args.namelists_only, args.project, args.test_id
 
 ###############################################################################
@@ -179,11 +168,13 @@ def get_tests_from_args(testargs):
     return tests_to_run
 
 ###############################################################################
-def create_test(testargs, compiler, machine, no_run=False, no_build=False, no_batch=False, test_root=None,
+def create_test(testargs, compiler, no_run=False, no_build=False, no_batch=False, test_root=None,
                 baseline_root=None, clean=False, compare=False, generate=False,
                 baseline_name=None, namelists_only=False, project=None, test_id=None):
 ###############################################################################
     tests_to_run = get_tests_from_args(testargs)
+
+    machine = acme_util.probe_machine_name()
 
     expect(len(tests_to_run) > 0, "No tests to run")
 
@@ -207,9 +198,9 @@ def create_test(testargs, compiler, machine, no_run=False, no_build=False, no_ba
     if (clean):
         create_test_cmd = "%s -clean on" % create_test_cmd
     if (compare):
-        create_test_cmd = "%s -compare %s" % (create_test_cmd, baseline_name)
+        create_test_cmd = "%s -compare %s/%s" % (create_test_cmd, compiler, baseline_name)
     if (generate):
-        create_test_cmd = "%s -generate %s" % (create_test_cmd, baseline_name)
+        create_test_cmd = "%s -generate %s/%s" % (create_test_cmd, compiler, baseline_name)
     if (namelists_only):
         create_test_cmd = "%s -nlcompareonly" % create_test_cmd
     if (project):
@@ -220,7 +211,7 @@ def create_test(testargs, compiler, machine, no_run=False, no_build=False, no_ba
         create_test_cmd = "%s -autosubmit off -nobatch on" % create_test_cmd
 
     stat = acme_util.run_cmd(create_test_cmd,
-                             from_dir=os.path.join(os.path.dirname(__file__), ".."),
+                             from_dir=os.path.join(acme_util.get_source_repo(), "scripts"),
                              ok_to_fail=True,
                              verbose=True,
                              arg_stdout=None, arg_stderr=None)[0]
@@ -238,11 +229,11 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    testargs, compiler, machine, no_run, no_build, no_batch, test_root, baseline_root, clean, \
+    testargs, compiler, no_run, no_build, no_batch, test_root, baseline_root, clean, \
         compare, generate, baseline_name, namelists_only, project, test_id = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(create_test(testargs, compiler, machine, no_run, no_build, no_batch, test_root, baseline_root, clean,
+    sys.exit(create_test(testargs, compiler, no_run, no_build, no_batch, test_root, baseline_root, clean,
                          compare, generate, baseline_name, namelists_only, project, test_id))
 
 ###############################################################################

--- a/scripts/acme/jenkins_generic_job
+++ b/scripts/acme/jenkins_generic_job
@@ -11,7 +11,7 @@ import acme_util
 acme_util.check_minimum_python_version(2, 7)
 import wait_for_tests
 
-import argparse, sys, os, socket, shutil, glob, doctest
+import argparse, sys, os, shutil, glob, doctest
 
 from acme_util import expect, warning, verbose_print
 
@@ -41,6 +41,8 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
+    default_test_suite = acme_util.get_machine_info()[1]
+
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra information")
 
@@ -59,11 +61,14 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-n", "--namelists-only", action="store_true",
                         help="Only compare/generate namelists. Useful for quick namelist-only operations")
 
-    parser.add_argument("--branch",
-                        help="Force baseline actions (compare/generate) to use baselines for a specific branch instead of the current branch. Also impacts dashboard job name. Useful for testing a branch other than next or master")
+    parser.add_argument("-b", "--baseline-name", default=acme_util.get_current_branch(repo=acme_util.get_source_repo()),
+                        help="Baseline name for baselines to use. Also impacts dashboard job name. Useful for testing a branch other than next or master")
 
-    parser.add_argument("-t", "--test-suite",
+    parser.add_argument("-t", "--test-suite", default=default_test_suite,
                         help="Override default acme test suite that will be run")
+
+    parser.add_argument("--cdash-build-group", default=wait_for_tests.CDASH_DEFAULT_BUILD_GROUP,
+                        help="The build group to be used to display results on the CDash dashboard.")
 
     args = parser.parse_args(args[1:])
 
@@ -76,7 +81,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     expect(not (args.cdash_project is not wait_for_tests.ACME_MAIN_CDASH and not args.submit_to_cdash),
            "Does not make sense to use -p without -d")
 
-    return args.generate_baselines, args.submit_to_cdash, args.cdash_build_name, args.cdash_project, args.branch, args.namelists_only, args.test_suite
+    return args.generate_baselines, args.submit_to_cdash, args.baseline_name, args.cdash_build_name, args.cdash_project, args.namelists_only, args.test_suite, args.cdash_build_group
 
 ###############################################################################
 def cleanup_queue(set_of_jobs_we_created, batch_system):
@@ -97,24 +102,15 @@ def cleanup_queue(set_of_jobs_we_created, batch_system):
             warning("Deleted leftover job: %s" % job_to_delete)
 
 ###############################################################################
-def jenkins_generic_job(generate_baselines, submit_to_cdash,
-                        arg_cdash_build_name=None, cdash_project=None,
-                        baseline_branch=None, namelists_only=False,
-                        arg_test_suite=None):
+def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
+                        arg_cdash_build_name, cdash_project,
+                        namelists_only, arg_test_suite,
+                        cdash_build_group):
 ###############################################################################
-    acme_machine = acme_util.probe_machine_name()
-    expect(acme_machine is not None,
-           "Did not recognize current machine '%s'" % socket.gethostname())
-
-    acme_repo = acme_util.get_source_repo()
-    expect(os.path.isdir(os.path.join(acme_repo, ".git")),
-           "Expected '%s' to be a git repository" % acme_repo)
-
-    compiler, default_test_suite, use_batch, project, testroot, baseline_root, proxy = \
-        acme_util.get_machine_info(acme_machine)
-    test_suite = default_test_suite if arg_test_suite is None else arg_test_suite
+    compiler, test_suite, use_batch, project, testroot, _, proxy = \
+        acme_util.get_machine_info()
+    test_suite = test_suite if arg_test_suite is None else arg_test_suite
     casearea = os.path.join(testroot, "jenkins")
-    git_branch = acme_util.get_current_branch(repo=acme_repo) if baseline_branch is None else baseline_branch
 
     if (use_batch):
         batch_system = acme_util.probe_batch_system()
@@ -178,18 +174,17 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash,
         # Set up create_test command and run it
         #
 
-        git_branch = acme_util.get_current_branch() if baseline_branch is None else baseline_branch
         baseline_action = "-g" if generate_baselines else "-c"
         test_id = "%s_%s" % (test_id_root, acme_util.get_utc_timestamp())
         create_test_cmd = "scripts/acme/create_test %s --test-root %s -p %s -t %s %s -b %s" % \
-                          (test_suite, casearea, project, test_id, baseline_action, git_branch)
+                          (test_suite, casearea, project, test_id, baseline_action, baseline_name)
 
         if (namelists_only):
             create_test_cmd += " -n"
 
         if (not wait_for_tests.SIGNAL_RECEIVED):
-            create_test_stat = acme_util.run_cmd(create_test_cmd,
-                                                 verbose=True, arg_stdout=None, arg_stderr=None, ok_to_fail=True, from_dir=acme_repo)[0]
+            create_test_stat = acme_util.run_cmd(create_test_cmd, from_dir=acme_util.get_source_repo(),
+                                                 verbose=True, arg_stdout=None, arg_stderr=None, ok_to_fail=True)[0]
             if (create_test_stat != 0):
                 warning("create_test FAILED!")
 
@@ -211,7 +206,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash,
         #
 
         if (submit_to_cdash):
-            cdash_build_name = "_".join([test_suite, git_branch, compiler]) if arg_cdash_build_name is None else arg_cdash_build_name
+            cdash_build_name = "_".join([test_suite, baseline_name, compiler]) if arg_cdash_build_name is None else arg_cdash_build_name
         else:
             cdash_build_name = None
 
@@ -221,7 +216,8 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash,
                                                      False, # don't check memory
                                                      False, # don't ignore namelist diffs
                                                      cdash_build_name,
-                                                     cdash_project)
+                                                     cdash_project,
+                                                     cdash_build_group)
         if (not tests_passed and use_batch and wait_for_tests.SIGNAL_RECEIVED):
             # Cleanup
             cleanup_queue(our_jobs, batch_system)
@@ -240,10 +236,10 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, test_suite = \
+    generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, test_suite, cdash_build_group = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, test_suite) else 1)
+    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, test_suite, cdash_build_group) else 1)
 
 ###############################################################################
 

--- a/scripts/acme/tests/scripts_regression_tests
+++ b/scripts/acme/tests/scripts_regression_tests
@@ -72,6 +72,22 @@ def kill_python_subprocesses(sig=signal.SIGKILL, expected_num_killed=None, teste
 ###############################################################################
     kill_subprocesses("[Pp]ython", sig, expected_num_killed, tester)
 
+###########################################################################
+def assert_dashboard_has_build(tester, build_name, expected_count=1):
+###########################################################################
+    time.sleep(10) # Give chance for cdash to update
+
+    wget_file = tempfile.mktemp()
+
+    run_cmd("wget http://my.cdash.org/index.php?project=ACME_test -O %s" % wget_file)
+
+    raw_text = open(wget_file, "r").read()
+    os.remove(wget_file)
+
+    num_found = raw_text.count(build_name)
+    tester.assertEqual(num_found, expected_count,
+                       msg="Dashboard did not have expected num occurances of build name '%s'. Expected %s, found %s" % (build_name, expected_count, num_found))
+
 ###############################################################################
 def setup_proxy():
 ###############################################################################
@@ -132,20 +148,24 @@ class TestWaitForTests(unittest.TestCase):
     ###########################################################################
     def simple_test(self, testdir, expected_results, extra_args=""):
     ###########################################################################
+        stat, output, errput = run_cmd("%s/wait_for_tests -p ACME_test TestStatus* %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True, from_dir=testdir)
+        if (expected_results == ["PASS"]*len(expected_results)):
+            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\nwait_for_tests output:\n%s\n\nerrput:\n%s" % (output, errput))
+        else:
+            self.assertNotEqual(stat, 0, msg="COMMAND SHOULD HAVE FAILED\nwait_for_tests output:\n%s\n\nerrput:\n%s" % (output, errput))
+
+        lines = [line for line in output.splitlines() if line.startswith("Test '")]
+        self.assertEqual(len(lines), 10)
+        for idx, line in enumerate(lines):
+            testname, status = parse_test_status(line)
+            self.assertEqual(status, expected_results[idx])
+            self.assertEqual(testname, "Test_%d" % idx)
+
+    ###########################################################################
+    def threaded_test(self, testdir, expected_results, extra_args=""):
+    ###########################################################################
         try:
-            stat, output, errput = run_cmd("%s/wait_for_tests -p ACME_test TestStatus* %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True, from_dir=testdir)
-            if (expected_results == ["PASS"]*len(expected_results)):
-                self.assertEqual(stat, 0, msg="wait_for_tests output:\n%s\n\nerrput:\n%s" % (output, errput))
-            else:
-                self.assertNotEqual(stat, 0, msg="wait_for_tests output:\n%s\n\nerrput:\n%s" % (output, errput))
-
-            lines = [line for line in output.splitlines() if line.startswith("Test '")]
-            self.assertEqual(len(lines), 10)
-            for idx, line in enumerate(lines):
-                testname, status = parse_test_status(line)
-                self.assertEqual(status, expected_results[idx])
-                self.assertEqual(testname, "Test_%d" % idx)
-
+            self.simple_test(testdir, expected_results, extra_args)
         except AssertionError as e:
             self._thread_error = str(e)
 
@@ -169,7 +189,7 @@ class TestWaitForTests(unittest.TestCase):
     ###########################################################################
     def test_wait_for_test_wait(self):
     ###########################################################################
-        run_thread = threading.Thread(target=self.simple_test, args=(self._testdir_unfinished, ["PASS"] * 10))
+        run_thread = threading.Thread(target=self.threaded_test, args=(self._testdir_unfinished, ["PASS"] * 10))
         run_thread.daemon = True
         run_thread.start()
 
@@ -189,7 +209,7 @@ class TestWaitForTests(unittest.TestCase):
     def test_wait_for_test_wait_kill(self):
     ###########################################################################
         expected_results = ["RUN" if item == 5 else "PASS" for item in range(10)]
-        run_thread = threading.Thread(target=self.simple_test, args=(self._testdir_unfinished, expected_results))
+        run_thread = threading.Thread(target=self.threaded_test, args=(self._testdir_unfinished, expected_results))
         run_thread.daemon = True
         run_thread.start()
 
@@ -209,7 +229,7 @@ class TestWaitForTests(unittest.TestCase):
     def test_wait_for_test_cdash_pass(self):
     ###########################################################################
         expected_results = ["PASS"] * 10
-        run_thread = threading.Thread(target=self.simple_test, args=(self._testdir_all_pass, expected_results, "-d regression_test_pass"))
+        run_thread = threading.Thread(target=self.threaded_test, args=(self._testdir_all_pass, expected_results, "-d regression_test_pass"))
         run_thread.daemon = True
         run_thread.start()
 
@@ -217,13 +237,15 @@ class TestWaitForTests(unittest.TestCase):
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
+        assert_dashboard_has_build(self, "regression_test_pass")
+
         self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
     ###########################################################################
     def test_wait_for_test_cdash_kill(self):
     ###########################################################################
         expected_results = ["RUN" if item == 5 else "PASS" for item in range(10)]
-        run_thread = threading.Thread(target=self.simple_test, args=(self._testdir_unfinished, expected_results, "-d regression_test_kill"))
+        run_thread = threading.Thread(target=self.threaded_test, args=(self._testdir_unfinished, expected_results, "-d regression_test_kill"))
         run_thread.daemon = True
         run_thread.start()
 
@@ -236,6 +258,8 @@ class TestWaitForTests(unittest.TestCase):
         run_thread.join(timeout=130)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
+
+        assert_dashboard_has_build(self, "regression_test_kill")
 
         self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
@@ -263,7 +287,6 @@ class TestJenkinsGenericJob(unittest.TestCase):
     def setUp(self):
     ###########################################################################
         self._thread_error      = None
-        self._wget_file         = tempfile.mktemp()
         self._unset_proxy       = setup_proxy()
         self._baseline_name     = "fake_testing_only_%s" % acme_util.get_utc_timestamp()
 
@@ -275,9 +298,6 @@ class TestJenkinsGenericJob(unittest.TestCase):
     def tearDown(self):
     ###########################################################################
         kill_subprocesses()
-
-        if (os.path.isfile(self._wget_file)):
-            os.remove(self._wget_file)
 
         if (self._unset_proxy):
             del os.environ["http_proxy"]
@@ -293,25 +313,19 @@ class TestJenkinsGenericJob(unittest.TestCase):
     ###########################################################################
     def simple_test(self, expect_works, extra_args):
     ###########################################################################
-        try:
-            stat, output, errput = run_cmd("%s/jenkins_generic_job -t acme_tiny %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
-            if (expect_works):
-                self.assertEqual(stat, 0, msg="jenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
-            else:
-                self.assertNotEqual(stat, 0, msg="jenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
+        stat, output, errput = run_cmd("%s/jenkins_generic_job -t acme_tiny %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
+        if (expect_works):
+            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
+        else:
+            self.assertNotEqual(stat, 0, msg="COMMAND SHOULD HAVE FAILED\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
 
+    ###########################################################################
+    def threaded_test(self, expect_works, extra_args):
+    ###########################################################################
+        try:
+            self.simple_test(expect_works, extra_args)
         except AssertionError as e:
             self._thread_error = str(e)
-
-    ###########################################################################
-    def assert_dashboard_has_build(self, build_name):
-    ###########################################################################
-        time.sleep(10) # Give chance for cdash to update
-
-        run_cmd("wget http://my.cdash.org/index.php?project=ACME_test -O %s" % self._wget_file)
-
-        stat = run_cmd("grep %s %s" % (build_name, self._wget_file), ok_to_fail=True)[0]
-        self.assertEqual(stat, 0, msg="Dashboard did not have build '%s'" % build_name)
 
     ###########################################################################
     def assert_no_sentinel(self):
@@ -326,17 +340,16 @@ class TestJenkinsGenericJob(unittest.TestCase):
         # Unfortunately, this test is very long-running
 
         build_name = "jenkins_generic_job_pass_%s" % acme_util.get_utc_timestamp()
-        self.simple_test(True, "-p ACME_test --branch master -d -c %s" % build_name)
+        self.simple_test(True, "-p ACME_test -b master -d -c %s --cdash-build-group=Nightly" % build_name)
 
         self.assert_no_sentinel()
-        self.assert_dashboard_has_build(build_name)
-        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
+        assert_dashboard_has_build(self, build_name)
 
     ###########################################################################
     def test_jenkins_generic_job_kill(self):
     ###########################################################################
         build_name = "jenkins_generic_job_kill_%s" % acme_util.get_utc_timestamp()
-        run_thread = threading.Thread(target=self.simple_test, args=(False, "-p ACME_test --branch master -d -c %s" % build_name))
+        run_thread = threading.Thread(target=self.threaded_test, args=(False, "-p ACME_test -b master -d -c %s --cdash-build-group=Nightly" % build_name))
         run_thread.daemon = True
         run_thread.start()
 
@@ -348,17 +361,17 @@ class TestJenkinsGenericJob(unittest.TestCase):
 
         self.assertFalse(run_thread.isAlive(), msg="jenkins_generic_job should have finished")
         self.assert_no_sentinel()
-        self.assert_dashboard_has_build(build_name)
+        assert_dashboard_has_build(self, build_name)
         self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
     ###############################################################################
     def test_jenkins_generic_job_rebless_namelist(self):
     ###############################################################################
         # Generate some namelist baselines
-        self.simple_test(True, "-g -n --branch %s" % self._baseline_name)
+        self.simple_test(True, "-g -n -b %s" % self._baseline_name)
 
         # Basic namelist compare
-        self.simple_test(True, "-n --branch %s" % self._baseline_name)
+        self.simple_test(True, "-n -b %s" % self._baseline_name)
 
         # Modify namelist
         fake_nl = """
@@ -367,7 +380,8 @@ class TestJenkinsGenericJob(unittest.TestCase):
    fake = .true.
 /"""
         baseline_area = acme_util.get_machine_info()[5]
-        baseline_glob = glob.glob(os.path.join(baseline_area, self._baseline_name, "ERS*"))
+        compiler = acme_util.get_machine_info()[0]
+        baseline_glob = glob.glob(os.path.join(baseline_area, compiler, self._baseline_name, "ERS*"))
         self.assertEqual(len(baseline_glob), 1, msg="Expected one match, got:\n%s" % "\n".join(baseline_glob))
 
         baseline_dir = baseline_glob[0]
@@ -381,14 +395,14 @@ class TestJenkinsGenericJob(unittest.TestCase):
         nl_file.close()
 
         # Basic namelist compare should now fail
-        self.simple_test(False, "-n --branch %s" % self._baseline_name)
+        self.simple_test(False, "-n -b %s" % self._baseline_name)
 
         # Bless
         stat, output, errput = run_cmd("%s/bless_test_results -n -f -b %s" % (SCRIPT_DIR, self._baseline_name), ok_to_fail=True)
         self.assertEqual(stat, 0, msg="bless_test_results output:\n%s\n\nerrput:\n%s" % (output, errput))
 
         # Basic namelist compare should now pass again
-        self.simple_test(True, "-n --branch %s" % self._baseline_name)
+        self.simple_test(True, "-n -b %s" % self._baseline_name)
 
 ###########################################################################
 

--- a/scripts/acme/wait_for_tests
+++ b/scripts/acme/wait_for_tests
@@ -42,32 +42,35 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     parser.add_argument("paths", default=".", nargs="*", help="Paths to test directories or status file. Pwd default.")
 
-    parser.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False,
+    parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra information")
 
-    parser.add_argument("-n", "--no-wait", action="store_true", dest="no_wait", default=False,
+    parser.add_argument("-n", "--no-wait", action="store_true",
                         help="Do not wait for tests to finish")
 
-    parser.add_argument("-t", "--check-throughput", action="store_true", dest="check_throughput", default=False,
+    parser.add_argument("-t", "--check-throughput", action="store_true",
                         help="Fail if throughput check fails (fail if tests slow down)")
 
-    parser.add_argument("-m", "--check-memory", action="store_true", dest="check_memory", default=False,
+    parser.add_argument("-m", "--check-memory", action="store_true",
                         help="Fail if memory check fails (fail if tests footprint grows)")
 
-    parser.add_argument("-i", "--ignore-namelist-diffs", action="store_true", dest="ignore_namelist_diffs", default=False,
+    parser.add_argument("-i", "--ignore-namelist-diffs", action="store_true",
                         help="Do not fail a test if the only problem is diffing namelists")
 
-    parser.add_argument("-d", "--cdash-build-name", action="store", dest="cdash_build_name", default=None,
+    parser.add_argument("-d", "--cdash-build-name",
                         help="Build name, implies you want results send to Cdash")
 
-    parser.add_argument("-p", "--cdash-project", action="store", dest="cdash_project", default=wait_for_tests.ACME_MAIN_CDASH,
+    parser.add_argument("-p", "--cdash-project", default=wait_for_tests.ACME_MAIN_CDASH,
                         help="The name of the CDash project where results should be uploaded")
+
+    parser.add_argument("-g", "--cdash-build-group", default=wait_for_tests.CDASH_DEFAULT_BUILD_GROUP,
+                        help="The build group to be used to display results on the CDash dashboard.")
 
     args = parser.parse_args(args[1:])
 
     acme_util.set_verbosity(args.verbose)
 
-    return args.paths, args.no_wait, args.check_throughput, args.check_memory, args.ignore_namelist_diffs, args.cdash_build_name, args.cdash_project
+    return args.paths, args.no_wait, args.check_throughput, args.check_memory, args.ignore_namelist_diffs, args.cdash_build_name, args.cdash_project, args.cdash_build_group
 
 ###############################################################################
 def _main_func(description):
@@ -78,10 +81,10 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, cdash_build_name, cdash_project = \
+    test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, cdash_build_name, cdash_project, cdash_build_group = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if wait_for_tests.wait_for_tests(test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, cdash_build_name, cdash_project) else 1)
+    sys.exit(0 if wait_for_tests.wait_for_tests(test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, cdash_build_name, cdash_project, cdash_build_group) else 1)
 
 ###############################################################################
 

--- a/scripts/acme/wait_for_tests.py
+++ b/scripts/acme/wait_for_tests.py
@@ -5,17 +5,18 @@ import xml.etree.ElementTree as xmlet
 import acme_util
 from acme_util import expect, warning, verbose_print
 
-TEST_STATUS_FILENAME     = "TestStatus"
-TEST_NOT_FINISHED_STATUS = ["GEN", "BUILD", "RUN", "PEND"]
-TEST_PASSED_STATUS       = "PASS"
-NAMELIST_FAIL_STATUS     = "NLFAIL"
-BUILD_FAIL_STATUS        = "CFAIL"
-SLEEP_INTERVAL_SEC       = 60
-THROUGHPUT_TEST_STR      = ".tputcomp."
-MEMORY_TEST_STR         = ".memcomp."
-NAMELIST_TEST_STR        = ".nlcomp"
-SIGNAL_RECEIVED          = False
-ACME_MAIN_CDASH          = "ACME_Climate"
+TEST_STATUS_FILENAME      = "TestStatus"
+TEST_NOT_FINISHED_STATUS  = ["GEN", "BUILD", "RUN", "PEND"]
+TEST_PASSED_STATUS        = "PASS"
+NAMELIST_FAIL_STATUS      = "NLFAIL"
+BUILD_FAIL_STATUS         = "CFAIL"
+SLEEP_INTERVAL_SEC        = 60
+THROUGHPUT_TEST_STR       = ".tputcomp."
+MEMORY_TEST_STR           = ".memcomp."
+NAMELIST_TEST_STR         = ".nlcomp"
+SIGNAL_RECEIVED           = False
+ACME_MAIN_CDASH           = "ACME_Climate"
+CDASH_DEFAULT_BUILD_GROUP = "ACME_Latest"
 
 ###############################################################################
 def signal_handler(*_):
@@ -66,7 +67,7 @@ def get_test_output(test_path):
         return ""
 
 ###############################################################################
-def create_cdash_xml(results, cdash_build_name, cdash_project):
+def create_cdash_xml(results, cdash_build_name, cdash_project, cdash_build_group):
 ###############################################################################
 
     #
@@ -130,7 +131,7 @@ NightlyStartTime: %s UTC
 
     # Make tag file
     tag_fd = open("Testing/TAG", "w")
-    tag_fd.write("%s\nACME_Latest" % subdir_name)
+    tag_fd.write("%s\n%s" % (subdir_name, cdash_build_group))
     tag_fd.close()
 
     #
@@ -140,7 +141,7 @@ NightlyStartTime: %s UTC
     site_elem = xmlet.Element("Site")
 
     site_elem.attrib["BuildName"] = cdash_build_name
-    site_elem.attrib["BuildStamp"] = "%s-ACME_Latest" % subdir_name
+    site_elem.attrib["BuildStamp"] = "%s-%s" % (subdir_name, cdash_build_group)
     site_elem.attrib["Name"] = hostname
     site_elem.attrib["OSName"] = "Linux"
     site_elem.attrib["Hostname"] = hostname
@@ -364,7 +365,8 @@ def wait_for_tests(test_paths,
                    check_memory=False,
                    ignore_namelists=False,
                    cdash_build_name=None,
-                   cdash_project=ACME_MAIN_CDASH):
+                   cdash_project=ACME_MAIN_CDASH,
+                   cdash_build_group=CDASH_DEFAULT_BUILD_GROUP):
 ###############################################################################
     # Set up signal handling, we want to print results before the program
     # is terminated
@@ -380,6 +382,6 @@ def wait_for_tests(test_paths,
         all_pass &= test_status == TEST_PASSED_STATUS
 
     if (cdash_build_name):
-        create_cdash_xml(test_results, cdash_build_name, cdash_project)
+        create_cdash_xml(test_results, cdash_build_name, cdash_project, cdash_build_group)
 
     return all_pass

--- a/scripts/ccsm_utils/Machines/config_machines.xml
+++ b/scripts/ccsm_utils/Machines/config_machines.xml
@@ -834,7 +834,7 @@
          <DIN_LOC_ROOT_CLMFORC>/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>$CESMSCRATCHROOT/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-         <CCSM_BASELINE>/lustre/atlas1/cli900/world-shared/cesm/baselines</CCSM_BASELINE>
+         <CCSM_BASELINE>/lustre/atlas1/cli900/world-shared/cesm/acme/baselines</CCSM_BASELINE>
          <CCSM_CPRNC>/lustre/atlas1/cli900/world-shared/cesm/tools/cprnc.frontend/cprnc.titan</CCSM_CPRNC>
          <SAVE_TIMING_DIR>$ENV{PROJWORK}/$PROJECT</SAVE_TIMING_DIR>
          <OS>CNL</OS>

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -1413,7 +1413,12 @@ sub testcaseSetup
   {
     $test->{'status'}="GEN";
     open my $TESTSTATUS, ">", "$caseroot/TestStatus" or warn $!;
-    print $TESTSTATUS "GEN ".$test->{'case'}."\n";
+    if ( defined $opts{'nlcompareonly'}) {
+        print $TESTSTATUS "PASS ".$test->{'case'}."\n";
+    }
+    else {
+        print $TESTSTATUS "GEN ".$test->{'case'}."\n";
+    }
     close $TESTSTATUS;
   }
   
@@ -1715,9 +1720,7 @@ sub namelistCompare
 		$nlcompoutput .= $output;
 	    }
 	}
-
-
-
+    
 
 	# print the compare_namelist results to TestStatus.out 
     if(defined $nlcompoutput && length $nlcompoutput > 0) 
@@ -1858,25 +1861,27 @@ sub main
 	}
 	writeTestListXML(\@testspec, $cfg_ref);
 	namelistCompareSuite(@testspec);
-	testBuildSubmit();
-	if($opts{'compare'} or $opts{'generate'}){
-	    my $cnt=0;
-	    my $pass=0;
-	    my $sfail=0;
-	    my $fail=0;
-	    my $gen=0;
-	    foreach my $test (@testspec){
-		$cnt++;
-		$sfail++ if($test->{status} eq "SFAIL");
-		$fail++ if($test->{status} eq "FAIL");
-		$pass++ if($test->{status} eq "PASS");
-		$gen++ if($test->{status} eq "GEN");
-	    }
-	    if($opts{'compare'}){
-		print "Summary: $cnt tests were run, $pass passed, $fail failed, $sfail failed to configure\n";
-	    }else{
-		print "Summary: $cnt tests were run, $gen baselines were generated, $sfail failed to configure\n" ;
-	    }
+        if( ! defined $opts{'nlcompareonly'}) {
+            testBuildSubmit();
+            if($opts{'compare'} or $opts{'generate'}){
+                my $cnt=0;
+                my $pass=0;
+                my $sfail=0;
+                my $fail=0;
+                my $gen=0;
+                foreach my $test (@testspec){
+                    $cnt++;
+                    $sfail++ if($test->{status} eq "SFAIL");
+                    $fail++ if($test->{status} eq "FAIL");
+                    $pass++ if($test->{status} eq "PASS");
+                    $gen++ if($test->{status} eq "GEN");
+                }
+                if($opts{'compare'}){
+                    print "Summary: $cnt tests were run, $pass passed, $fail failed, $sfail failed to configure\n";
+                }else{
+                    print "Summary: $cnt tests were run, $gen baselines were generated, $sfail failed to configure\n" ;
+                }
+            }
 	}
     }else{ #Create a single test. 
 	# check the options for a single test. 


### PR DESCRIPTION
1) Add more informative defaults where possible. Instead of defaulting to
None and computing the real default later, try to compute the real default
before options are parsed so it can be presented.
2) Compiler now needs to be taken as an options for most ACME scripts
since it affects where baselines are.
3) The subdirectory from baseline_root where baselines live is now
$ROOT/$COMPILER/$BRANCH instead of $ROOT/$BRANCH. This will make
life much easier on machines that have several supported compilers for
ACME.
4) Change default project for titan to cli115. The default should match
what the acmetest account uses to run ACME.
5) Fix significant problems in acme scripts regression tests.
5.a) Errors were being hidden due to trying to supported threaded and
non-threaded execution of a subprocess within the same function. These
have been split out so this doesn't happen again.
5.b) Check dashboard results in wait_for_tests regr tests.
5.c) Slight changes to jenkins_generic_job testing due to recent
change to CDash build groups.
6) Changes to CESG create_test to have better support for namelist-only
mode.

Baselines on all ACME machines will need to be moved.

[BFB]
