### PR TITLE
update_acme_tests: Minor fixes and usability improvements

### DIFF
--- a/scripts/acme/update_acme_tests
+++ b/scripts/acme/update_acme_tests
@@ -18,7 +18,7 @@ import sys, argparse, os
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-usage="""\n%s <Test category> testlist.xml [--verbose]
+usage="""\n%s testlist.xml [<test category> <test category> ...] [--verbose]
 OR
 %s --help
 OR
@@ -36,13 +36,13 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    parser.add_argument("category", choices=update_acme_tests.get_test_suites(),
-                        help="The test category to update")
-
     parser.add_argument("test_list_path", help="The path to test lists XML file")
 
+    parser.add_argument("categories", nargs="*",
+                        help="The test categories to update. Default will update all. Test categories: %s" % (", ".join(update_acme_tests.get_test_suites())))
+
     parser.add_argument("-p", "--platform", action="store", default=None, dest="platform",
-                        help="Only add tests for a specific platform, format=machine,compiler")
+                        help="Only add tests for a specific platform, format=machine,compiler. Useful for adding new platforms.")
 
     parser.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False,
                         help="Print extra information")
@@ -57,7 +57,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     expect(args.platform is None or len(args.platform.split(",")) == 2,
            "-p value must be in format: 'machine,compiler'")
 
-    return args.category, args.test_list_path, args.platform
+    if (not args.categories):
+        args.categories = update_acme_tests.get_test_suites()
+
+    return args.categories, args.test_list_path, args.platform
 
 ###############################################################################
 def _main_func(description):
@@ -66,11 +69,11 @@ def _main_func(description):
         acme_util.run_cmd("python -m doctest %s/update_acme_tests.py -v" % os.path.dirname(sys.argv[0]), arg_stdout=None, arg_stderr=None)
         return
 
-    category, test_list_path, platform = parse_command_line(sys.argv, description)
+    categories, test_list_path, platform = parse_command_line(sys.argv, description)
 
     acme_util.stop_buffering_output()
 
-    update_acme_tests.update_acme_test(test_list_path, category, platform)
+    update_acme_tests.update_acme_test(test_list_path, categories, platform)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/acme/update_acme_tests.py
+++ b/scripts/acme/update_acme_tests.py
@@ -71,15 +71,14 @@ def get_test_suites():
 ###############################################################################
 def find_all_supported_platforms():
 ###############################################################################
-    """Returns a set of all ACME supported platforms as defined in the 
+    """Returns a set of all ACME supported platforms as defined in the
 XML configuration file config_machines.xml in the ACME source tree. A platform
 is defined by a triple (machine name, compiler, mpi library)."""
     import xml.etree.ElementTree as ET
-    import os.path
     config_machines_xml = os.path.join(acme_util.get_source_repo(), 'scripts', 'ccsm_utils', 'Machines', 'config_machines.xml')
     tree = ET.parse(config_machines_xml)
     root = tree.getroot()
-    expect(root.tag == 'config_machines', 
+    expect(root.tag == 'config_machines',
            'The given XML file is not a valid list of machine configurations.')
     platform_set = set()
     # Each child of this root is a machine entry.
@@ -142,9 +141,9 @@ def generate_acme_test_entries(category, platforms):
     return name
 
 ###############################################################################
-def update_acme_test(xml_file, category, platform):
+def update_acme_test(xml_file, categories, platform):
 ###############################################################################
-    # Retrieve all supported ACME platforms, killing the third entry (MPI lib) 
+    # Retrieve all supported ACME platforms, killing the third entry (MPI lib)
     # for the moment.
     supported_platforms = [p[:2] for p in find_all_supported_platforms()]
 
@@ -161,22 +160,28 @@ def update_acme_test(xml_file, category, platform):
     platforms = [p for p in platforms if p in supported_platforms]
 
     # Try to find the manage_xml_entries script. Assume sibling of xml_file
-    manage_xml_entries = os.path.join(os.path.dirname(xml_file), "manage_xml_entries")
+    if (os.path.dirname(xml_file) == ""):
+        manage_xml_entries = os.path.join(".", "manage_xml_entries")
+    else:
+        manage_xml_entries = os.path.join(os.path.dirname(xml_file), "manage_xml_entries")
     expect(os.path.isfile(manage_xml_entries),
            "Couldn't find manage_xml_entries, expect sibling of '%s'" % xml_file)
 
-    # Remove any existing acme test category from the file.
-    if (platform is None):
-        output = acme_util.run_cmd('%s -removetests -category %s' % (manage_xml_entries, category))
-    else:
-        output = acme_util.run_cmd('%s -removetests -category %s -machine %s -compiler %s'
-                                   % (manage_xml_entries, category, platforms[0][0], platforms[0][1]))
-    replace_testlist_xml(output, xml_file)
+    for category in categories:
+        # Remove any existing acme test category from the file.
+        if (platform is None):
+            output = acme_util.run_cmd('%s -removetests -category %s' % (manage_xml_entries, category), verbose=True)
+        else:
+            output = acme_util.run_cmd('%s -removetests -category %s -machine %s -compiler %s'
+                                       % (manage_xml_entries, category, platforms[0][0], platforms[0][1]), verbose=True)
+        replace_testlist_xml(output, xml_file)
 
-    # Generate a list of test entries corresponding to our suite at the top
-    # of the file.
-    new_test_file = generate_acme_test_entries(category, platforms)
-    output = acme_util.run_cmd("%s -addlist -file %s -category %s" %
-                               (manage_xml_entries, new_test_file, category))
-    os.unlink(new_test_file)
-    replace_testlist_xml(output, xml_file)
+        # Generate a list of test entries corresponding to our suite at the top
+        # of the file.
+        new_test_file = generate_acme_test_entries(category, platforms)
+        output = acme_util.run_cmd("%s -addlist -file %s -category %s" %
+                                   (manage_xml_entries, new_test_file, category), verbose=True)
+        os.unlink(new_test_file)
+        replace_testlist_xml(output, xml_file)
+
+    print "SUCCESS"

--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -88,7 +88,6 @@
         <machine compiler="intel" testtype="acme_developer">edison</machine>
         <machine compiler="intel" testtype="acme_integration">edison</machine>
         <machine compiler="intel" testtype="acme_tiny">edison</machine>
-        <machine compiler="intel " testtype="acme_tiny">edison</machine>
         <machine compiler="intel" testtype="acme_developer">eos</machine>
         <machine compiler="intel" testtype="acme_integration">eos</machine>
         <machine compiler="intel" testtype="acme_tiny">eos</machine>
@@ -102,7 +101,6 @@
         <machine compiler="nag" testtype="acme_integration">goldbach</machine>
         <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
         <machine compiler="intel" testtype="acme_tiny">goldbach</machine>
-        <machine compiler="lahey" testtype="acme_tiny">goldbach</machine>
         <machine compiler="nag" testtype="acme_tiny">goldbach</machine>
         <machine compiler="pgi" testtype="acme_tiny">goldbach</machine>
         <machine compiler="gnu" testtype="acme_developer">hopper</machine>
@@ -114,7 +112,6 @@
         <machine compiler="gnu" testtype="acme_tiny">hopper</machine>
         <machine compiler="intel" testtype="acme_tiny">hopper</machine>
         <machine compiler="pgi" testtype="acme_tiny">hopper</machine>
-        <machine compiler="ibm" testtype="acme_tiny">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="intel" testtype="acme_integration">janus</machine>
         <machine compiler="intel" testtype="acme_tiny">janus</machine>
@@ -139,7 +136,6 @@
         <machine compiler="intel" testtype="acme_integration">mustang</machine>
         <machine compiler="gnu" testtype="acme_tiny">mustang</machine>
         <machine compiler="intel" testtype="acme_tiny">mustang</machine>
-        <machine compiler="null" testtype="acme_tiny">null</machine>
         <machine compiler="pgi" testtype="acme_developer">olympus</machine>
         <machine compiler="pgi" testtype="acme_integration">olympus</machine>
         <machine compiler="pgi" testtype="acme_tiny">olympus</machine>
@@ -172,7 +168,6 @@
         <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
         <machine compiler="gnu" testtype="acme_tiny">yellowstone</machine>
         <machine compiler="intel" testtype="acme_tiny">yellowstone</machine>
-        <machine compiler="intel " testtype="acme_tiny">yellowstone</machine>
         <machine compiler="pgi" testtype="acme_tiny">yellowstone</machine>
       </test>
       <test name="ERS_D">
@@ -449,7 +444,6 @@
         <machine compiler="intel" testtype="acme_developer">edison</machine>
         <machine compiler="intel" testtype="acme_integration">edison</machine>
         <machine compiler="intel" testtype="acme_tiny">edison</machine>
-        <machine compiler="intel " testtype="acme_tiny">edison</machine>
         <machine compiler="intel" testtype="acme_developer">eos</machine>
         <machine compiler="intel" testtype="acme_integration">eos</machine>
         <machine compiler="intel" testtype="acme_tiny">eos</machine>
@@ -463,7 +457,6 @@
         <machine compiler="nag" testtype="acme_integration">goldbach</machine>
         <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
         <machine compiler="intel" testtype="acme_tiny">goldbach</machine>
-        <machine compiler="lahey" testtype="acme_tiny">goldbach</machine>
         <machine compiler="nag" testtype="acme_tiny">goldbach</machine>
         <machine compiler="pgi" testtype="acme_tiny">goldbach</machine>
         <machine compiler="intel" testtype="prebeta">goldbach</machine>
@@ -478,7 +471,6 @@
         <machine compiler="intel" testtype="acme_tiny">hopper</machine>
         <machine compiler="pgi" testtype="acme_tiny">hopper</machine>
         <machine compiler="pgi" testtype="prerelease">hopper</machine>
-        <machine compiler="ibm" testtype="acme_tiny">intrepid</machine>
         <machine compiler="ibm" testtype="prerelease">intrepid</machine>
         <machine compiler="intel" testtype="acme_developer">janus</machine>
         <machine compiler="intel" testtype="acme_integration">janus</machine>
@@ -505,7 +497,6 @@
         <machine compiler="intel" testtype="acme_integration">mustang</machine>
         <machine compiler="gnu" testtype="acme_tiny">mustang</machine>
         <machine compiler="intel" testtype="acme_tiny">mustang</machine>
-        <machine compiler="null" testtype="acme_tiny">null</machine>
         <machine compiler="pgi" testtype="acme_developer">olympus</machine>
         <machine compiler="pgi" testtype="acme_integration">olympus</machine>
         <machine compiler="pgi" testtype="acme_tiny">olympus</machine>
@@ -539,7 +530,6 @@
         <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
         <machine compiler="gnu" testtype="acme_tiny">yellowstone</machine>
         <machine compiler="intel" testtype="acme_tiny">yellowstone</machine>
-        <machine compiler="intel " testtype="acme_tiny">yellowstone</machine>
         <machine compiler="pgi" testtype="acme_tiny">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>


### PR DESCRIPTION
Script would crash when user ran in the same directory as testlist.xml
if user did not have "." in their PATH. This is now fixed.

By default, update all ACME test suites.

Be a little more verbose about what's happening under the hood.

[BFB]
