### PR TITLE
Changed grids from FV to SE for 6 tests in acme integration test suite

### DIFF
--- a/scripts/acme/update_acme_tests.py
+++ b/scripts/acme/update_acme_tests.py
@@ -29,17 +29,17 @@ __TEST_SUITES = {
                          'SMS.f19_f19.I1850CLM45CN']
                         ),
     "acme_integration" : ("acme_developer",
-                          ["ERB.f19_g16.B1850C5",
+                          ["ERB.ne16_g37.B1850C5",
                            "ERB.f45_g37.B1850C5",
                            "ERH.f45_g37.B1850C5",
-                           "ERS.f09_g16.B1850C5",
+                           "ERS.ne30_g16.B1850C5",
                            "ERS.f19_f19.FAMIPC5",
-                           "ERS.f19_g16.B1850C5",
+                           "ERS.ne16_g37.B1850C5",
                            "ERS_D.f45_g37.B1850C5",
                            "ERS_IOP_Ld3.f19_f19.FAMIPC5",
-                           "ERS_Ld3.f19_g16.FC5",
+                           "ERS_Ld3.ne16_g37.FC5",
                            "ERS_Ld3.ne30_ne30.FC5",
-                           "ERT.f19_g16.B1850C5",
+                           "ERT.ne16_g37.B1850C5",
                            "PET_PT.f19_g16.X",
                            "PET_PT.f45_g37_rx1.A",
                            "PFS.ne30_ne30.FC5",
@@ -47,7 +47,7 @@ __TEST_SUITES = {
                            "SEQ_PFC.f45_g37.B1850C5",
                            "SMS.ne16_ne16.FC5AQUAP",
                            "SMS_D.f19_g16.B20TRC5",
-                           "SMS_D_Ld3.f19_f19.FC5"]
+                           "SMS_D_Ld3.ne16_ne16.FC5"]
                           ),
 }
 

--- a/scripts/ccsm_utils/Machines/mkbatch.cascade
+++ b/scripts/ccsm_utils/Machines/mkbatch.cascade
@@ -17,8 +17,8 @@ if ( $ntasks % ${MAX_TASKS_PER_NODE} > 0) then
 endif
 @ taskpernode = ${MAX_TASKS_PER_NODE} / ${maxthrds}
 set qname = batch
-set tlimit = "00:59:00"
-if ($CCSM_ESTCOST > 2) set tlimit = "00:59:00"
+set tlimit = "07:59:00"
+if ($CCSM_ESTCOST > 2) set tlimit = "07:59:00"
 
 if ($?TESTMODE) then
  set file = $CASEROOT/${CASE}.test 

--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -1220,85 +1220,13 @@
     </grid>
     <grid name="f09_g16">
       <test name="ERS">
-        <machine compiler="gnu" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
-        <machine compiler="intel" testtype="acme_integration">cascade</machine>
-        <machine compiler="nag" testtype="acme_integration">cascade</machine>
-        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
-        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">eos</machine>
-        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
-        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
-        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
-        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
-        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
-        <machine compiler="intel" testtype="acme_integration">hopper</machine>
-        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
-        <machine compiler="intel" testtype="acme_integration">janus</machine>
-        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
-        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
-        <machine compiler="gnu" testtype="acme_integration">mac</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
-        <machine compiler="gnu" testtype="acme_integration">penn</machine>
-        <machine compiler="intel" testtype="acme_integration">redsky</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="pgi" testtype="aux_cam">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
       </test>
     </grid>
     <grid name="f19_g16">
       <test name="ERB">
-        <machine compiler="gnu" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
-        <machine compiler="intel" testtype="acme_integration">cascade</machine>
-        <machine compiler="nag" testtype="acme_integration">cascade</machine>
-        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
-        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">eos</machine>
-        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
-        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
-        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
-        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
-        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
-        <machine compiler="intel" testtype="acme_integration">hopper</machine>
-        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
-        <machine compiler="intel" testtype="acme_integration">janus</machine>
-        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
-        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
-        <machine compiler="gnu" testtype="acme_integration">mac</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
-        <machine compiler="gnu" testtype="acme_integration">penn</machine>
-        <machine compiler="intel" testtype="acme_integration">redsky</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="pgi" testtype="aux_cam">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
       </test>
@@ -1306,84 +1234,12 @@
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
       </test>
       <test name="ERS">
-        <machine compiler="gnu" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
-        <machine compiler="intel" testtype="acme_integration">cascade</machine>
-        <machine compiler="nag" testtype="acme_integration">cascade</machine>
-        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
-        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">eos</machine>
-        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
-        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
-        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
-        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
-        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
-        <machine compiler="intel" testtype="acme_integration">hopper</machine>
-        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
-        <machine compiler="intel" testtype="acme_integration">janus</machine>
-        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
-        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
-        <machine compiler="gnu" testtype="acme_integration">mac</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
-        <machine compiler="gnu" testtype="acme_integration">penn</machine>
-        <machine compiler="intel" testtype="acme_integration">redsky</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="pgi" testtype="aux_cam">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
         <machine compiler="intel" testtype="aux_science">yellowstone</machine>
       </test>
       <test name="ERT">
-        <machine compiler="gnu" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
-        <machine compiler="intel" testtype="acme_integration">cascade</machine>
-        <machine compiler="nag" testtype="acme_integration">cascade</machine>
-        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
-        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">eos</machine>
-        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
-        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
-        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
-        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
-        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
-        <machine compiler="intel" testtype="acme_integration">hopper</machine>
-        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
-        <machine compiler="intel" testtype="acme_integration">janus</machine>
-        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
-        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
-        <machine compiler="gnu" testtype="acme_integration">mac</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
-        <machine compiler="gnu" testtype="acme_integration">penn</machine>
-        <machine compiler="intel" testtype="acme_integration">redsky</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
         <machine compiler="pgi" testtype="aux_cam">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cam">yellowstone</machine>
         <machine compiler="intel" testtype="aux_cice">yellowstone</machine>
       </test>
@@ -1657,6 +1513,162 @@
     <grid name="ne120_t12">
       <test name="SBN">
         <machine compiler="null" testtype="null">null</machine>
+      </test>
+    </grid>
+    <grid name="ne16_g37">
+      <test name="ERB">
+        <machine compiler="gnu" testtype="acme_integration">blues</machine>
+        <machine compiler="intel" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
+        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
+        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
+        <machine compiler="intel" testtype="acme_integration">edison</machine>
+        <machine compiler="intel" testtype="acme_integration">eos</machine>
+        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
+        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
+        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">hopper</machine>
+        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">janus</machine>
+        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
+        <machine compiler="gnu" testtype="acme_integration">mac</machine>
+        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
+        <machine compiler="ibm" testtype="acme_integration">mira</machine>
+        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
+        <machine compiler="intel" testtype="acme_integration">mustang</machine>
+        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
+        <machine compiler="gnu" testtype="acme_integration">penn</machine>
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
+        <machine compiler="intel" testtype="acme_integration">titan</machine>
+        <machine compiler="pgi" testtype="acme_integration">titan</machine>
+        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
+        <machine compiler="intel" testtype="acme_integration">wolf</machine>
+        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
+      </test>
+      <test name="ERS">
+        <machine compiler="gnu" testtype="acme_integration">blues</machine>
+        <machine compiler="intel" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
+        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
+        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
+        <machine compiler="intel" testtype="acme_integration">edison</machine>
+        <machine compiler="intel" testtype="acme_integration">eos</machine>
+        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
+        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
+        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">hopper</machine>
+        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">janus</machine>
+        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
+        <machine compiler="gnu" testtype="acme_integration">mac</machine>
+        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
+        <machine compiler="ibm" testtype="acme_integration">mira</machine>
+        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
+        <machine compiler="intel" testtype="acme_integration">mustang</machine>
+        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
+        <machine compiler="gnu" testtype="acme_integration">penn</machine>
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
+        <machine compiler="intel" testtype="acme_integration">titan</machine>
+        <machine compiler="pgi" testtype="acme_integration">titan</machine>
+        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
+        <machine compiler="intel" testtype="acme_integration">wolf</machine>
+        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
+      </test>
+      <test name="ERT">
+        <machine compiler="gnu" testtype="acme_integration">blues</machine>
+        <machine compiler="intel" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
+        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
+        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
+        <machine compiler="intel" testtype="acme_integration">edison</machine>
+        <machine compiler="intel" testtype="acme_integration">eos</machine>
+        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
+        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
+        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">hopper</machine>
+        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">janus</machine>
+        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
+        <machine compiler="gnu" testtype="acme_integration">mac</machine>
+        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
+        <machine compiler="ibm" testtype="acme_integration">mira</machine>
+        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
+        <machine compiler="intel" testtype="acme_integration">mustang</machine>
+        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
+        <machine compiler="gnu" testtype="acme_integration">penn</machine>
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
+        <machine compiler="intel" testtype="acme_integration">titan</machine>
+        <machine compiler="pgi" testtype="acme_integration">titan</machine>
+        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
+        <machine compiler="intel" testtype="acme_integration">wolf</machine>
+        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
+      </test>
+    </grid>
+    <grid name="ne30_g16">
+      <test name="ERS">
+        <machine compiler="gnu" testtype="acme_integration">blues</machine>
+        <machine compiler="intel" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
+        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
+        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
+        <machine compiler="intel" testtype="acme_integration">edison</machine>
+        <machine compiler="intel" testtype="acme_integration">eos</machine>
+        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
+        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
+        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">hopper</machine>
+        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">janus</machine>
+        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
+        <machine compiler="gnu" testtype="acme_integration">mac</machine>
+        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
+        <machine compiler="ibm" testtype="acme_integration">mira</machine>
+        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
+        <machine compiler="intel" testtype="acme_integration">mustang</machine>
+        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
+        <machine compiler="gnu" testtype="acme_integration">penn</machine>
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
+        <machine compiler="intel" testtype="acme_integration">titan</machine>
+        <machine compiler="pgi" testtype="acme_integration">titan</machine>
+        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
+        <machine compiler="intel" testtype="acme_integration">wolf</machine>
+        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
       </test>
     </grid>
   </compset>
@@ -3471,52 +3483,36 @@
         <machine compiler="intel" testtype="csltiming">yellowstone</machine>
       </test>
       <test name="SMS_D_Ld3">
-        <machine compiler="gnu" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">blues</machine>
-        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
-        <machine compiler="intel" testtype="acme_integration">cascade</machine>
-        <machine compiler="nag" testtype="acme_integration">cascade</machine>
-        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
-        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">eos</machine>
-        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
-        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
-        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
-        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
-        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
-        <machine compiler="intel" testtype="acme_integration">hopper</machine>
-        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="pgi" testtype="prerelease">hopper</machine>
         <machine compiler="ibm" testtype="prerelease">intrepid</machine>
-        <machine compiler="intel" testtype="acme_integration">janus</machine>
         <machine compiler="intel" testtype="prebeta">janus</machine>
-        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
-        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
-        <machine compiler="gnu" testtype="acme_integration">mac</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
-        <machine compiler="gnu" testtype="acme_integration">penn</machine>
-        <machine compiler="intel" testtype="acme_integration">redsky</machine>
         <machine compiler="intel" testtype="prebeta">redsky</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
       </test>
     </grid>
     <grid name="f19_g16">
+      <test name="ERS_Ld3">
+        <machine compiler="intel" testtype="prebeta">goldbach</machine>
+        <machine compiler="pgi" testtype="prebeta">goldbach</machine>
+        <machine compiler="intel" testtype="prealpha">janus</machine>
+        <machine compiler="intel" testtype="prebeta">janus</machine>
+        <machine compiler="intel" testtype="prebeta">redsky</machine>
+        <machine compiler="gnu" testtype="prealpha">yellowstone</machine>
+        <machine compiler="intel" testtype="prealpha">yellowstone</machine>
+        <machine compiler="pgi" testtype="prealpha">yellowstone</machine>
+        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
+        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
+        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
+      </test>
+    </grid>
+    <grid name="ne120_ne120">
+      <test name="PFS">
+        <machine compiler="intel" testtype="csltiming">yellowstone</machine>
+      </test>
+    </grid>
+    <grid name="ne16_g37">
       <test name="ERS_Ld3">
         <machine compiler="gnu" testtype="acme_integration">blues</machine>
         <machine compiler="intel" testtype="acme_integration">blues</machine>
@@ -3532,14 +3528,10 @@
         <machine compiler="intel" testtype="acme_integration">goldbach</machine>
         <machine compiler="nag" testtype="acme_integration">goldbach</machine>
         <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
-        <machine compiler="intel" testtype="prebeta">goldbach</machine>
-        <machine compiler="pgi" testtype="prebeta">goldbach</machine>
         <machine compiler="gnu" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="acme_integration">hopper</machine>
         <machine compiler="pgi" testtype="acme_integration">hopper</machine>
         <machine compiler="intel" testtype="acme_integration">janus</machine>
-        <machine compiler="intel" testtype="prealpha">janus</machine>
-        <machine compiler="intel" testtype="prebeta">janus</machine>
         <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
         <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
         <machine compiler="gnu" testtype="acme_integration">mac</machine>
@@ -3550,7 +3542,6 @@
         <machine compiler="pgi" testtype="acme_integration">olympus</machine>
         <machine compiler="gnu" testtype="acme_integration">penn</machine>
         <machine compiler="intel" testtype="acme_integration">redsky</machine>
-        <machine compiler="intel" testtype="prebeta">redsky</machine>
         <machine compiler="intel" testtype="acme_integration">skybridge</machine>
         <machine compiler="intel" testtype="acme_integration">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
@@ -3559,17 +3550,46 @@
         <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
         <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
         <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
-        <machine compiler="gnu" testtype="prealpha">yellowstone</machine>
-        <machine compiler="intel" testtype="prealpha">yellowstone</machine>
-        <machine compiler="pgi" testtype="prealpha">yellowstone</machine>
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
       </test>
     </grid>
-    <grid name="ne120_ne120">
-      <test name="PFS">
-        <machine compiler="intel" testtype="csltiming">yellowstone</machine>
+    <grid name="ne16_ne16">
+      <test name="SMS_D_Ld3">
+        <machine compiler="gnu" testtype="acme_integration">blues</machine>
+        <machine compiler="intel" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
+        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
+        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
+        <machine compiler="intel" testtype="acme_integration">edison</machine>
+        <machine compiler="intel" testtype="acme_integration">eos</machine>
+        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
+        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
+        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">hopper</machine>
+        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">janus</machine>
+        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
+        <machine compiler="gnu" testtype="acme_integration">mac</machine>
+        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
+        <machine compiler="ibm" testtype="acme_integration">mira</machine>
+        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
+        <machine compiler="intel" testtype="acme_integration">mustang</machine>
+        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
+        <machine compiler="gnu" testtype="acme_integration">penn</machine>
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
+        <machine compiler="intel" testtype="acme_integration">titan</machine>
+        <machine compiler="pgi" testtype="acme_integration">titan</machine>
+        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
+        <machine compiler="intel" testtype="acme_integration">wolf</machine>
+        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
       </test>
     </grid>
     <grid name="ne30_ne30">


### PR DESCRIPTION
This commit changes grids from FV to SE dycore for all machines and
compiler combinations using update_acme_tests.py script. Tests moved
to the SE dycore takes more time to run than the FV dycore. Following
is the run time for each test case which was moved from FV to SE dycore:

ERB B1850C5 (f19_g16 = 26m; ne16_g37 = 1h 35m)
ERS B1850C5 (f09_g16 = 26m; ne30_g16 = 35m)
ERS B1850C5 (f19_g16 = 15m; ne16_g37 = 55m)
ERT B1850C5 (f19_g16 = 1h 35m; ne16_g37 = 6h 34m)
ERS_Ld3 FC5 (f19_g16 = 5m; ne16_g37 = 15m)
SMS_D_Ld3 FC5 (f19_f19 = 24m;ne16_ne16 = 2h 38m)

[non-BFB]
AG-334
