### PR TITLE
Limit titan to acme_developer for now

### DIFF
--- a/scripts/acme/acme_util.py
+++ b/scripts/acme/acme_util.py
@@ -81,7 +81,7 @@ MACHINE_INFO = {
     ),
     "titan"    : (
         "pgi",
-        "acme_integration",
+        "acme_developer",
         True,
         "cli115",
         "/lustre/atlas/scratch/<USER>/<PROJECT>",


### PR DESCRIPTION
Due to very slow turnaround times on titan, let's limit titan
to running acme_developer while we're trying to stand up testing.

[BFB]
