### PR TITLE
Adds two land regression tests in acme_integration

### DIFF
--- a/scripts/acme/update_acme_tests.py
+++ b/scripts/acme/update_acme_tests.py
@@ -37,6 +37,7 @@ __TEST_SUITES = {
                            "ERS.ne30_g16.B1850C5",
                            "ERS.f19_f19.FAMIPC5",
                            "ERS.ne16_g37.B1850C5",
+                           "ERS.f09_g16.ICLM45VIC",
                            "ERS_D.f45_g37.B1850C5",
                            "ERS_IOP_Ld3.f19_f19.FAMIPC5",
                            "ERS_Ld3.ne16_g37.FC5",
@@ -47,6 +48,7 @@ __TEST_SUITES = {
                            "PFS.ne30_ne30.FC5",
                            "SEQ_IOP_PFC.f19_g16.X",
                            "SEQ_PFC.f45_g37.B1850C5",
+                           "SMS.f09_g16.ICRUCLM45",
                            "SMS.ne16_ne16.FC5AQUAP",
                            "SMS_D.f19_g16.B20TRC5",
                            "SMS_D_Ld3.ne16_ne16.FC5"]

--- a/scripts/ccsm_utils/Testlistxml/testlist.xml
+++ b/scripts/ccsm_utils/Testlistxml/testlist.xml
@@ -5400,7 +5400,43 @@
   <compset name="ICLM45VIC">
     <grid name="f09_g16">
       <test name="ERS">
+        <machine compiler="gnu" testtype="acme_integration">blues</machine>
+        <machine compiler="intel" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
+        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
+        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
+        <machine compiler="intel" testtype="acme_integration">edison</machine>
         <machine compiler="intel" testtype="aux_clm_ys_pgi" testmods="clm/vrtlay">edison</machine>
+        <machine compiler="intel" testtype="acme_integration">eos</machine>
+        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
+        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
+        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">hopper</machine>
+        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">janus</machine>
+        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
+        <machine compiler="gnu" testtype="acme_integration">mac</machine>
+        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
+        <machine compiler="ibm" testtype="acme_integration">mira</machine>
+        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
+        <machine compiler="intel" testtype="acme_integration">mustang</machine>
+        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
+        <machine compiler="gnu" testtype="acme_integration">penn</machine>
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
+        <machine compiler="intel" testtype="acme_integration">titan</machine>
+        <machine compiler="pgi" testtype="acme_integration">titan</machine>
+        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
+        <machine compiler="intel" testtype="acme_integration">wolf</machine>
+        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
         <machine compiler="pgi" testtype="aux_clm45" testmods="clm/vrtlay">yellowstone</machine>
       </test>
       <test name="ERS_D">
@@ -5523,7 +5559,43 @@
   <compset name="ICRUCLM45">
     <grid name="f09_g16">
       <test name="SMS">
+        <machine compiler="gnu" testtype="acme_integration">blues</machine>
+        <machine compiler="intel" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">blues</machine>
+        <machine compiler="pgi" testtype="acme_integration">bluewaters</machine>
+        <machine compiler="intel" testtype="acme_integration">cascade</machine>
+        <machine compiler="nag" testtype="acme_integration">cascade</machine>
+        <machine compiler="ibm" testtype="acme_integration">cetus</machine>
+        <machine compiler="pgi" testtype="acme_integration">eastwind</machine>
+        <machine compiler="intel" testtype="acme_integration">edison</machine>
+        <machine compiler="intel" testtype="acme_integration">eos</machine>
+        <machine compiler="intel" testtype="acme_integration">evergreen</machine>
+        <machine compiler="intel" testtype="acme_integration">goldbach</machine>
+        <machine compiler="nag" testtype="acme_integration">goldbach</machine>
+        <machine compiler="pgi" testtype="acme_integration">goldbach</machine>
         <machine compiler="nag" testtype="aux_clm45" testmods="clm/af_bias_v5">goldbach</machine>
+        <machine compiler="gnu" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">hopper</machine>
+        <machine compiler="pgi" testtype="acme_integration">hopper</machine>
+        <machine compiler="intel" testtype="acme_integration">janus</machine>
+        <machine compiler="intel" testtype="acme_integration">lawrencium-lr2</machine>
+        <machine compiler="gnu" testtype="acme_integration">linux-generic</machine>
+        <machine compiler="gnu" testtype="acme_integration">mac</machine>
+        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
+        <machine compiler="ibm" testtype="acme_integration">mira</machine>
+        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
+        <machine compiler="intel" testtype="acme_integration">mustang</machine>
+        <machine compiler="pgi" testtype="acme_integration">olympus</machine>
+        <machine compiler="gnu" testtype="acme_integration">penn</machine>
+        <machine compiler="intel" testtype="acme_integration">redsky</machine>
+        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
+        <machine compiler="intel" testtype="acme_integration">titan</machine>
+        <machine compiler="pgi" testtype="acme_integration">titan</machine>
+        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
+        <machine compiler="intel" testtype="acme_integration">wolf</machine>
+        <machine compiler="gnu" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="intel" testtype="acme_integration">yellowstone</machine>
+        <machine compiler="pgi" testtype="acme_integration">yellowstone</machine>
         <machine compiler="intel" testtype="aux_clm45" testmods="clm/af_bias_v5">yellowstone</machine>
       </test>
     </grid>


### PR DESCRIPTION
ERS.f09_g16.ICLM45VIC and SMS.f09_g16.ICRUCLM45 added to
acme_integration test suite.

[BFB]
LG-9 and SEG-174
