### PR TITLE
Improvements to testing scripts

### DIFF
--- a/cime/scripts-acme/acme_bisect
+++ b/cime/scripts-acme/acme_bisect
@@ -36,7 +36,7 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
-    default_compiler, _, _, default_project, default_testroot, _, _ = acme_util.get_machine_info(raw=True)
+    default_compiler, _, _, default_project, default_testroot, _, _, _ = acme_util.get_machine_info(raw=True)
 
     parser.add_argument("testname", help="Name of failing test.")
 
@@ -72,14 +72,14 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     acme_util.set_verbosity(args.verbose)
 
     if (args.test_root == default_testroot):
-        args.test_root = acme_util.get_machine_info(project=args.project)
+        args.test_root = acme_util.get_machine_info(project=args.project)[4]
 
     return args.testname, args.testroot, args.compiler, args.project, args.baseline_name, args.check_namelists, args.check_throughput, args.check_memory, args.no_batch
 
 ###############################################################################
 def acme_bisect(testname, testroot, compiler, project, baseline_name, check_namelists, check_throughput, check_memory, no_batch):
 ###############################################################################
-    create_test_rel = os.path.join(get_acme_scripts_location_within_acme(), "create_test")
+    create_test_rel = os.path.join(acme_util.get_acme_scripts_location_within_acme(), "create_test")
     expect(create_test_rel, "Please run from root of repository")
 
     current_sha = acme_util.get_current_commit(short=True)

--- a/cime/scripts-acme/acme_util.py
+++ b/cime/scripts-acme/acme_util.py
@@ -32,7 +32,7 @@ BATCH_INFO = \
 
 # TODO: Get these values from ACME XML files instead of duplicating here.
 
-# machine -> defaults (compiler, test_suite, use_batch, project, testroot, baseline_root, proxy)
+# machine -> defaults (compiler, test_suite, use_batch, project, testroot, baseline_root, proxy, maintain_baselines)
 MACHINE_INFO = {
     "redsky"    : (
         "intel",
@@ -41,7 +41,8 @@ MACHINE_INFO = {
         "fy150001",
         "/gscratch/<USER>/acme_scratch",
         "/projects/ccsm/ccsm_baselines",
-        "wwwproxy.sandia.gov:80"
+        "wwwproxy.sandia.gov:80",
+        True,
     ),
     "skybridge" : (
         "intel",
@@ -50,7 +51,8 @@ MACHINE_INFO = {
         "fy150001",
         "/gscratch/<USER>/acme_scratch/skybridge",
         "/projects/ccsm/ccsm_baselines",
-        "wwwproxy.sandia.gov:80"
+        "wwwproxy.sandia.gov:80",
+        True,
     ),
     "melvin"    : (
         "gnu",
@@ -59,16 +61,18 @@ MACHINE_INFO = {
         "ignore",
         "/home/<USER>/acme/scratch",
         "/home/jgfouca/acme/baselines",
-        "sonproxy.sandia.gov:80"
+        "sonproxy.sandia.gov:80",
+        True,
     ),
     "edison"    : (
         "intel",
-        "acme_integration",
+        "acme_developer",
         True,
         "acme",
         "/scratch1/scratchdirs/<USER>/acme_scratch",
         "/project/projectdirs/acme/baselines",
-        None
+        None,
+        False,
     ),
     "blues"    : (
         "pgi",
@@ -77,7 +81,8 @@ MACHINE_INFO = {
         "ACME",
         "/lcrc/project/ACME/<USER>/acme_scratch",
         "/lcrc/group/earthscience/acme_baselines",
-        None
+        None,
+        False,
     ),
     "titan"    : (
         "pgi",
@@ -86,25 +91,28 @@ MACHINE_INFO = {
         "cli115",
         "/lustre/atlas/scratch/<USER>/<PROJECT>",
         "/lustre/atlas1/cli900/world-shared/cesm/acme/baselines",
-        None
+        None,
+        False,
     ),
     "mira"     : (
         "ibm",
-        "acme_integration",
+        "acme_developer",
         True,
         "HiRes_EarthSys",
         "/projects/<PROJECT>/<USER>",
         "/projects/ccsm/ccsm_baselines",
-        None
+        None,
+        False,
     ),
     "cetus"     : (
         "ibm",
-        "acme_integration",
+        "acme_developer",
         True,
         "HiRes_EarthSys",
         "/projects/<PROJECT>/<USER>",
         "/projects/ccsm/ccsm_baselines",
-        None
+        None,
+        False,
     ),
 }
 

--- a/cime/scripts-acme/bless_test_results
+++ b/cime/scripts-acme/bless_test_results
@@ -46,7 +46,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     default_baseline_name = acme_util.get_current_branch(repo=acme_util.get_cime_root())
 
-    default_compiler, _, _, _, acme_root, _, _ = acme_util.get_machine_info()
+    default_compiler, _, _, _, acme_root, _, _, _ = acme_util.get_machine_info()
     default_testroot = os.path.join(acme_root, "jenkins")
 
     parser.add_argument("-v", "--verbose", action="store_true",

--- a/cime/scripts-acme/create_test
+++ b/cime/scripts-acme/create_test
@@ -51,7 +51,7 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
-    default_compiler, _, _, default_project, default_testroot, default_baseline_root, _ = acme_util.get_machine_info(raw=True)
+    default_compiler, _, _, default_project, default_testroot, default_baseline_root, _, _ = acme_util.get_machine_info(raw=True)
     if ("PROJECT" in os.environ):
         default_project = os.environ["PROJECT"]
 
@@ -122,7 +122,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     if (args.no_build):
         args.no_run = True
 
-    _, _, use_batch, _, testroot, baseline_root, _ = \
+    _, _, use_batch, _, testroot, baseline_root, _, _ = \
         acme_util.get_machine_info(project=args.project)
 
     if (not args.no_batch and not use_batch):

--- a/cime/scripts-acme/jenkins_generic_job
+++ b/cime/scripts-acme/jenkins_generic_job
@@ -42,12 +42,16 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
     default_test_suite = acme_util.get_machine_info()[1]
+    default_maintain_baselines = acme_util.get_machine_info()[7]
 
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra information")
 
     parser.add_argument("-g", "--generate-baselines", action="store_true",
                         help="Generate baselines")
+
+    parser.add_argument("--baseline-compare", action="store", choices=("yes", "no"), default=("yes" if default_maintain_baselines else "no"),
+                        help="Do baseline comparisons")
 
     parser.add_argument("-d", "--submit-to-cdash", action="store_true",
                         help="Send results to CDash")
@@ -81,7 +85,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     expect(not (args.cdash_project is not wait_for_tests.ACME_MAIN_CDASH and not args.submit_to_cdash),
            "Does not make sense to use -p without -d")
 
-    return args.generate_baselines, args.submit_to_cdash, args.baseline_name, args.cdash_build_name, args.cdash_project, args.namelists_only, args.test_suite, args.cdash_build_group
+    return args.generate_baselines, args.submit_to_cdash, args.baseline_name, args.cdash_build_name, args.cdash_project, args.namelists_only, args.test_suite, args.cdash_build_group, args.baseline_compare
 
 ###############################################################################
 def cleanup_queue(set_of_jobs_we_created, batch_system):
@@ -105,9 +109,9 @@ def cleanup_queue(set_of_jobs_we_created, batch_system):
 def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
                         arg_cdash_build_name, cdash_project,
                         namelists_only, arg_test_suite,
-                        cdash_build_group):
+                        cdash_build_group, baseline_compare):
 ###############################################################################
-    compiler, test_suite, use_batch, project, testroot, _, proxy = \
+    compiler, test_suite, use_batch, project, testroot, _, proxy, _ = \
         acme_util.get_machine_info()
     test_suite = test_suite if arg_test_suite is None else arg_test_suite
     casearea = os.path.join(testroot, "jenkins")
@@ -174,10 +178,15 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
         # Set up create_test command and run it
         #
 
-        baseline_action = "-g" if generate_baselines else "-c"
+        baseline_args = ""
+        if (generate_baselines):
+            baseline_args = "-g -b %s" % baseline_name
+        elif (baseline_compare == "yes"):
+            baseline_args = "-c -b %s" % baseline_name
+
         test_id = "%s_%s" % (test_id_root, acme_util.get_utc_timestamp())
-        create_test_cmd = "./create_test %s --test-root %s -p %s -t %s %s -b %s" % \
-                          (test_suite, casearea, project, test_id, baseline_action, baseline_name)
+        create_test_cmd = "./create_test %s --test-root %s -p %s -t %s %s" % \
+                          (test_suite, casearea, project, test_id, baseline_args)
 
         if (namelists_only):
             create_test_cmd += " -n"
@@ -236,10 +245,10 @@ def _main_func(description):
 
     acme_util.stop_buffering_output()
 
-    generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, test_suite, cdash_build_group = \
+    generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, test_suite, cdash_build_group, no_baseline_compare = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, test_suite, cdash_build_group) else 1)
+    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, namelists_only, test_suite, cdash_build_group, no_baseline_compare) else 1)
 
 ###############################################################################
 


### PR DESCRIPTION
By default, all new test machines have been set to only test
acme_developer and to not maintain baselines. We can ramp-up
the rigor of the testing as the machine proves useful and low
latency. Edison testing is scaled-back due to incredible latency.

Jenkins driver can now specify whether to do baselines comparisons.

This work was inspired by the idea that maintaining baselines on 6
different machines for the same tests is somewhat redudant. The small
chance of a test diffing on one platform and not another is not
worth the cost. High latency machines make this even worse as the
feedback time on a diff is extremely slow. We basically just want
to make sure that ACME works on these machines for now.

[BFB]
