### PR TITLE
Change test-id used by jenkins nightly process

### DIFF
--- a/cime/scripts-acme/jenkins_generic_job
+++ b/cime/scripts-acme/jenkins_generic_job
@@ -159,7 +159,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
         if (os.path.isdir("Testing")):
             shutil.rmtree("Testing")
 
-        test_id_root = "jenkins_testid"
+        test_id_root = "jenkins_%s" % baseline_name
         for old_dir in glob.glob("%s/*%s*" % (testroot, test_id_root)):
             shutil.rmtree(old_dir)
 


### PR DESCRIPTION
Include branch name so that, if running two versions each night,
like is happening on melvin, the second one does not blow away all
the case directories created by the first.

[BFB]
