### PR TITLE
jenkins_generic_job: Fix wait_for_tests call

### DIFF
--- a/cime/scripts-acme/jenkins_generic_job
+++ b/cime/scripts-acme/jenkins_generic_job
@@ -225,7 +225,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
         else:
             cdash_build_name = None
 
-        tests_passed = wait_for_tests.wait_for_tests(glob.glob("%s/*/TestStatus" % casearea),
+        tests_passed = wait_for_tests.wait_for_tests(glob.glob("%s/*%s*/TestStatus" % (casearea, test_id)),
                                                      not use_batch, # wait if using queue
                                                      False, # don't check throughput
                                                      False, # don't check memory


### PR DESCRIPTION
Was waiting for all tests in the case area instead of just
tests with the right test-id.

[BFB]
