### PR TITLE
Revise EC.60-30.km files from 60 layer to 100 layer

### DIFF
--- a/cime/scripts/Tools/config_grid.xml
+++ b/cime/scripts/Tools/config_grid.xml
@@ -374,7 +374,7 @@ do not use scientific experiments; use the T62_g16 resolution instead:
 
 <gridhorz name="oEC60to30">
   <support_level>Experimental, under development</support_level>
-  <nx>234095</nx>  <ny>1</ny>  
+  <nx>234988</nx>  <ny>1</ny>  
   <desc>oEC60to30 is a MPAS ocean grid generated with the eddy closure density function that is roughly comparable to the pop 1 degree resolution:</desc>
 </gridhorz>
 
@@ -501,8 +501,8 @@ do not use scientific experiments; use the T62_g16 resolution instead:
 </griddom>
 
 <griddom grid="oEC60to30" mask="oEC60to30">
-  <ICE_DOMAIN_FILE>domain.ocn.oEC60to30.150107.nc</ICE_DOMAIN_FILE>
-  <OCN_DOMAIN_FILE>domain.ocn.oEC60to30.150107.nc</OCN_DOMAIN_FILE>
+  <ICE_DOMAIN_FILE>domain.ocn.oEC60to30.150616.nc</ICE_DOMAIN_FILE>
+  <OCN_DOMAIN_FILE>domain.ocn.oEC60to30.150616.nc</OCN_DOMAIN_FILE>
 </griddom>
 
 <!-- ======================================================== -->
@@ -1111,8 +1111,8 @@ do not use scientific experiments; use the T62_g16 resolution instead:
 </griddom>
 
 <griddom grid="T62" mask="oEC60to30"> <!--- datm/slnd/drof only -->
-  <ATM_DOMAIN_FILE>domain.lnd.T62_oEC60to30.150107.nc</ATM_DOMAIN_FILE>
-  <LND_DOMAIN_FILE>domain.lnd.T62_oEC60to30.150107.nc</LND_DOMAIN_FILE>
+  <ATM_DOMAIN_FILE>domain.lnd.T62_oEC60to30.150616.nc</ATM_DOMAIN_FILE>
+  <LND_DOMAIN_FILE>domain.lnd.T62_oEC60to30.150616.nc</LND_DOMAIN_FILE>
 </griddom>
 
 <gridmap atm_grid="T62" ocn_grid="gx3v7">
@@ -1164,11 +1164,11 @@ do not use scientific experiments; use the T62_g16 resolution instead:
 </gridmap>
 
 <gridmap atm_grid="T62" ocn_grid="oEC60to30">
-  <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30_aave.150107.nc</ATM2OCN_FMAPNAME>
-  <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30_aave.150107.nc</ATM2OCN_SMAPNAME>
-  <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30_aave.150107.nc</ATM2OCN_VMAPNAME>
-  <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_T62_aave.150107.nc</OCN2ATM_FMAPNAME>
-  <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_T62_aave.150107.nc</OCN2ATM_SMAPNAME>
+  <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30_aave.150615.nc</ATM2OCN_FMAPNAME>
+  <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30_bilin.150804.nc</ATM2OCN_SMAPNAME>
+  <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30_patc.150804.nc</ATM2OCN_VMAPNAME>
+  <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_T62_aave.150615.nc</OCN2ATM_FMAPNAME>
+  <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_T62_aave.150615.nc</OCN2ATM_SMAPNAME>
 </gridmap>
 
 <!-- ====================  -->
@@ -1410,7 +1410,7 @@ do not use scientific experiments; use the T62_g16 resolution instead:
   <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_mpas120_nn_131217.nc</ROF2OCN_RMAPNAME>
 </gridmap>
 <gridmap rof_grid="rx1" ocn_grid="oEC60to30" >
-  <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30_nn_150107.nc</ROF2OCN_RMAPNAME>
+  <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30_nn_150615.nc</ROF2OCN_RMAPNAME>
 </gridmap>
 
 <gridmap rof_grid="r05" ocn_grid="gx3v7" >

--- a/components/mpas-o/bld/mpas-o.buildnml
+++ b/components/mpas-o/bld/mpas-o.buildnml
@@ -42,9 +42,9 @@ my $decomp_prefix = '';
 my $ic_prefix = '';
 
 if ( $OCN_GRID eq 'oEC60to30' ) {
-	$grid_date .= '150107';
-	$grid_prefix .= 'ocean.EC.60-30km';
-	$ic_prefix .= 'ocean.EC.60-30km';
+	$grid_date .= '150729';
+	$grid_prefix .= 'oEC60to30';
+	$ic_prefix .= 'oEC60to30';
 	$decomp_prefix .= 'mpas-o.graph.info.';
 } elsif ( $OCN_GRID eq 'mpas120' ) {
 	$grid_date .= '121116';


### PR DESCRIPTION
This updates the file names for the lower-resolution ocean mesh, the Eddy Closure 60-30, with gridcells of 60 km at high latitudes and 30 km at the equator.  The associated files were uploaded to the Oak Ridge input data repo with revision 307.
