### PR TITLE
bless_test_results: Try to get it working post-CIME

### DIFF
--- a/cime/scripts-acme/bless_test_results
+++ b/cime/scripts-acme/bless_test_results
@@ -91,7 +91,8 @@ def bless_test_results(baseline_name, test_root, compiler, namelists_only=False,
                                                    False) # don't ignore namelist diffs
 
     baseline_root = acme_util.get_machine_info("CCSM_BASELINE")
-    baseline_area = os.path.join(baseline_root, compiler, baseline_name)
+    baseline_tag  = os.path.join(compiler, baseline_name)
+    baseline_area = os.path.join(baseline_root, baseline_tag)
 
     for test_name, test_data in test_results.iteritems():
         if (bless_tests in [[], None] or acme_util.match_any(test_name, bless_tests)):
@@ -123,7 +124,6 @@ def bless_test_results(baseline_name, test_root, compiler, namelists_only=False,
 
                 # Find files of various types
                 namelist_files = []
-                other_files = []
                 for root, _, files in os.walk(baseline_dir_for_test):
                     if (root == baseline_dir_for_test):
                         rel_root = ""
@@ -152,33 +152,31 @@ def bless_test_results(baseline_name, test_root, compiler, namelists_only=False,
                                         (force or raw_input("Update this file (y/n)? ").upper() in ["Y", "YES"])):
                                         namelist_files.append((rel_file, rel_file))
 
-                        elif (not namelists_only and test_result != wait_for_tests.NAMELIST_FAIL_STATUS):
-                            # For now, just do this hist file
-                            if (file_ == "cpl.hi.nc"):
-                                # Hist file will have different name in testcase, need to find it
-                                hist_files = glob.glob("%s/run/%s*.cpl.hi*nc" % (os.path.join(acme_root, case), case))
-                                if (len(hist_files) != 1):
-                                    warning("Expected to find one hist file, instead found: %s" % ", ".join(hist_files))
-                                    warning("This can happen if test failed before running")
-                                    warning("Skipping hist files for this test")
-                                    continue
-                                hist_file = hist_files[0]
-                                hist_compare_script = os.path.join(acme_util.get_cime_root(), "scripts", "Tools", "hist_compare.csh")
-                                stat = run_cmd("%s %s %s" % (hist_compare_script, hist_file, baseline_file), arg_stdout=None, arg_stderr=None, ok_to_fail=True)[0]
-                                if (stat != 0):
-                                    print "Hist files '%s' and '%s' did not match" % (baseline_file, hist_file)
-                                    print
-                                    if (not report_only and
-                                        (force or raw_input("Update this file (y/n)? ").upper() in ["Y", "YES"])):
-                                        other_files.append((hist_file, rel_file))
+                if (not namelists_only and test_result != wait_for_tests.NAMELIST_FAIL_STATUS):
+                    cime_root = acme_util.get_cime_root()
+                    compgen = os.path.join(cime_root, "scripts", "Tools", "component_compgen_baseline.sh")
+                    machine_env = os.path.join(cime_root, "machines-acme", "env_mach_specific.%s" % acme_util.probe_machine_name())
+                    run_dir = os.path.join(acme_root, case, "run")
+                    cprnc_loc = acme_util.get_machine_info("CPRNC_ROOT")
+                    compgen_cmd = "tcsh -c 'source %s && %s -baseline_dir %s -testcase %s -testcase_base %s -test_dir %s -cprnc_exe %s -generate_tag %s'" % \
+                        (machine_env, compgen, baseline_dir_for_test, case, test_name, testcase_dir_for_test, cprnc_loc, baseline_tag)
+
+                    check_compare = os.path.join(cime_root, "scripts", "Tools", "component_write_comparefail.pl")
+                    stat, out, err = run_cmd("%s %s 2>&1" % (check_compare, run_dir), ok_to_fail=True)
+
+                    if (stat != 0):
+                        # found diff, offer rebless
+                        print out
+
+                        if (not report_only and
+                            (force or raw_input("Update this diff (y/n)? ").upper() in ["Y", "YES"])):
+                            stat, out, err = run_cmd(compgen_cmd, ok_to_fail=True, verbose=True)
+                            if (stat != 0):
+                                warning("Hist file bless FAILED for test %s" % test_name)
 
                 # Update namelist files
                 if (namelist_files):
                     acme_util.safe_copy(testcase_dir_for_test, baseline_dir_for_test, namelist_files)
-
-                # Update other files
-                if (other_files):
-                    acme_util.safe_copy(testcase_dir_for_test, baseline_dir_for_test, other_files)
 
 ###############################################################################
 def _main_func(description):

--- a/cime/scripts-acme/wait_for_tests.py
+++ b/cime/scripts-acme/wait_for_tests.py
@@ -250,7 +250,10 @@ def parse_test_status_file(file_contents, status_file_path=None):
             status, curr_test_name, phase = line.split()
             if (test_name is None):
                 test_name = curr_test_name
-            rv[phase] = status
+            if (phase in rv):
+                rv[phase] = reduce_stati([status, rv[phase]])
+            else:
+                rv[phase] = status
         else:
             warning("In '%s', line '%s' not in expected format" % (status_file_path, line))
 

--- a/cime/scripts/Tools/component_compgen_baseline.sh
+++ b/cime/scripts/Tools/component_compgen_baseline.sh
@@ -328,9 +328,21 @@ if [ -n "$compare_tag" ]; then
     else
 	print_status "$overall_compare_status" "$compare_info : baseline compare summary ($msg)" "${testcase_base}" compare
     fi
+
+    if [[ $overall_compare_status == PASS ]]; then
+        exit 0
+    else
+        exit 2
+    fi
 fi
 if [ -n "$generate_tag" ]; then
     print_status "$overall_generate_status" "$generate_info : baseline generate summary" "${testcase_base}" generate
+
+    if [[ $overall_generate_status == PASS ]]; then
+        exit 0
+    else
+        exit 2
+    fi
 fi
 
 

--- a/cime/scripts/Tools/component_write_comparefail.pl
+++ b/cime/scripts/Tools/component_write_comparefail.pl
@@ -2,14 +2,13 @@
 use strict;
 
 if ($#ARGV == -1) {
-    die " ERROR component_write_comparefail: must specify a caseroot and testlog input arguments";
+    die " ERROR component_write_comparefail: must specify a caseroot";
 }
-my ($rundir, $testlog) = @ARGV;
+my $rundir = $ARGV[0];
 
-open(fhout, '>>', $testlog) or die "Could not open output testlog $testlog' $!";
+print "---summarizing more details of test failures if any: --- \n\n" ;
 
-print fhout "---summarizing more details of test failures if any: --- \n\n" ;
-
+my $rv = 0;
 my @cprnc_files = glob("$rundir/*cprnc.out");
 foreach my $file (@cprnc_files) {
 
@@ -17,15 +16,15 @@ foreach my $file (@cprnc_files) {
     my $nfilldiffs = `grep FILLDIFF $file | wc -l`;
 
     if (($ndiffs > 0) || ($nfilldiffs > 0)) {
-	print fhout "$file had the following fields that are NOT b4b  \n";
-	print fhout "\n";
+	print "$file had the following fields that are NOT b4b  \n\n";
+        $rv = 1;
     }
     
     if ($ndiffs > 0) {
 	open(fhin, "<$file") or die "Could not open file $file to read";
 	while (my $line = <fhin>) {
 	    if ($line =~ /RMS\s+(\S+)\s+(\S+)/) {
-		print fhout"  $line "; 
+		print "  $line ";
 	    }
 	}
 	close(fhin);
@@ -35,7 +34,7 @@ foreach my $file (@cprnc_files) {
 	open(fhin, "<$file") or die "Could not open file $file to read";
 	while (my $line = <fhin>) {
 	    if ($line =~ /FILLDIFF\s+(\S+)/) {
-		print fhout"  $line "; 
+		print "  $line ";
 	    }
 	}
 	close(fhin);
@@ -44,9 +43,7 @@ foreach my $file (@cprnc_files) {
 
 my $sdate = `date +"%Y-%m-%d %H:%M:%S"`;
 
-print fhout "\n---finished summarizing more details of test failures: ---- \n\n ";
-print fhout "test completed $sdate"; 
+print "\n---finished summarizing more details of test failures: ---- \n\n ";
+print "test completed $sdate\n"; 
 
-close (fhout);
-
-exit(0);
+exit($rv);

--- a/cime/scripts/Tools/testcase_setup
+++ b/cime/scripts/Tools/testcase_setup
@@ -520,7 +520,7 @@ my $testcase_end = <<'END_TEST';
 
    #
    # summarize failed differences if any
-   ${SCRIPTSROOT}/Tools/component_write_comparefail.pl $RUNDIR $TESTSTATUS_LOG
+   ${SCRIPTSROOT}/Tools/component_write_comparefail.pl $RUNDIR >>& $TESTSTATUS_LOG
 
    # determine and output test time
    @ testend_sec = `date -u +%s`


### PR DESCRIPTION
Sane error codes from key compare programs. No reason to
component_write_comparefail.pl to insist output go to filename
provided by argument. Just print output and let user redirect
if they want.

Component_compare can now be run in a testcase directory
for which the user does not have write permissions.

[BFB]
