### PR TITLE
Make replacements for cs.status and cs.submit

### DIFF
--- a/cime/scripts-acme/cs.status.template
+++ b/cime/scripts-acme/cs.status.template
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+<PATH>/cs_status *.<TESTID>/TestStatus

--- a/cime/scripts-acme/cs.submit.template
+++ b/cime/scripts-acme/cs.submit.template
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+for item in $(\ls -1 *.<TESTID>/TestStatus); do
+    cd $(dirname $item)
+    <BUILD_CMD> && <RUN_CMD>
+    cd -
+done

--- a/cime/scripts-acme/cs_status
+++ b/cime/scripts-acme/cs_status
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+"""
+List test results based on TestStatus files. Returns True if
+no errors occured (not based on test statuses).
+"""
+
+import acme_util
+acme_util.check_minimum_python_version(2, 7)
+import wait_for_tests
+
+import argparse, sys, os
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+usage="""\n%s <Glob of TestStatus> [<Path/Glob to TestStatus> ...]  [--verbose]
+OR
+%s --help
+OR
+%s --test
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Wait for all tests in a test area\033[0m
+    > %s path/to/testarea/*/TestStatus
+""" % ((os.path.basename(args[0]), ) * 4),
+
+description=description,
+
+formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+    parser.add_argument("paths", nargs="+", help="Paths to TestStatus files.")
+
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print extra information")
+
+    args = parser.parse_args(args[1:])
+
+    acme_util.set_verbosity(args.verbose)
+
+    return args.paths
+
+###############################################################################
+def cs_status(test_paths):
+###############################################################################
+    for test_path in test_paths:
+        statuses, test_name = wait_for_tests.parse_test_status_file(open(test_path, "r").read(), test_path)
+        summary = wait_for_tests.reduce_stati(statuses.values())
+        print "%s (Overall: %s), details:" % (test_name, summary)
+        for phase, status in statuses.iteritems():
+            print "  %s %s" % (status, phase)
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    acme_util.stop_buffering_output()
+
+    test_paths = parse_command_line(sys.argv, description)
+
+    cs_status(test_paths)
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/cime/scripts-acme/list_acme_tests
+++ b/cime/scripts-acme/list_acme_tests
@@ -25,11 +25,11 @@ OR
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# List all tested compsets \033[0m
-    > %s testlist.xml compset
+    > %s compset
     \033[1;32m# List all compsets tested by acme_developer \033[0m
-    > %s testlist.xml compset acme_developer
+    > %s compset acme_developer
     \033[1;32m# List all grids tested by acme_developer \033[0m
-    > %s testlist.xml grid acme_developer
+    > %s grid acme_developer
 """ % ((os.path.basename(args[0]), ) * 6),
 
 description=description,

--- a/cime/scripts-acme/wait_for_tests
+++ b/cime/scripts-acme/wait_for_tests
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 """
-Wait for a queued ACME test to finish by watching the TestStatus file.
-If the test passes, 0 is returned, otherwise a non-zero error code
-is returned.
+Wait for a queued set of ACME tests to finish by watching the
+TestStatus files.  If all tests pass, 0 is returned, otherwise a
+non-zero error code is returned.
 
 The easiest way to test this script is to keep a set of create_test
 results laying around somewhere so you don't have to wait for tests

--- a/cime/scripts-acme/wait_for_tests.py
+++ b/cime/scripts-acme/wait_for_tests.py
@@ -4,6 +4,7 @@ import xml.etree.ElementTree as xmlet
 
 import acme_util
 from acme_util import expect, warning, verbose_print
+from collections import OrderedDict
 
 TEST_STATUS_FILENAME      = "TestStatus"
 TEST_PENDING_STATUS       = "PEND"
@@ -241,7 +242,7 @@ def reduce_stati(stati):
 ###############################################################################
 def parse_test_status_file(file_contents, status_file_path=None):
 ###############################################################################
-    rv = {}
+    rv = OrderedDict()
     test_name = None
     for line in file_contents.splitlines():
         if (line.split()[0] == COMMENT_STATUS):
@@ -344,7 +345,7 @@ def get_test_results(test_paths, no_wait=False, check_throughput=False, check_me
     while threading.active_count() > 1:
         time.sleep(1)
 
-    test_results = dict()
+    test_results = {}
     completed_test_paths = []
     while (not results.empty()):
         test_name, test_path, test_status = results.get()


### PR DESCRIPTION
Without the need for testspec.xml since we're using wait_for_tests
and not testreporter.pl, there are much simpler ways to acheive
what these scripts were doing.

These scripts both receive a suffix that matches the test-id.

[BFB]
