### PR TITLE
create_test: Fix race condition with PEND state in TestStatus

### DIFF
--- a/cime/scripts-acme/create_test_impl.py
+++ b/cime/scripts-acme/create_test_impl.py
@@ -314,6 +314,11 @@ class CreateTest(object):
         for phase in PHASES[0:made_it_to_phase+1]:
             str_to_write += "%s %s %s\n" % (self._get_test_status(test_name, phase), test_name, phase)
 
+        if (not self._no_run and not self._is_broken(test_name)):
+            # Ensure PEND state always gets added to TestStatus file if we are
+            # about to run test
+            str_to_write += "%s %s %s\n" % (TEST_PENDING_STATUS, test_name, RUN_PHASE)
+
         try:
             test_status_file = os.path.join(self._get_test_dir(test_name), TEST_STATUS_FILENAME)
             with open(test_status_file, "w") as fd:

--- a/cime/scripts/Tools/testcase_setup
+++ b/cime/scripts/Tools/testcase_setup
@@ -263,7 +263,6 @@ my $testcase_begin = <<'END_BEGIN';
     set TESTSTATUS_LOG          = $CASEROOT/TestStatus.log
     set TESTSTATUS_OUT_NLCOMP   = $CASEROOT/TestStatus.nlcomp
 
-    echo "PEND ${CASEBASEID} RUN" >>&! $TESTSTATUS_OUT
     touch $TESTSTATUS_LOG
 
     set sdate = `date +"%Y-%m-%d %H:%M:%S"`


### PR DESCRIPTION
Move the PEND state addition from testcase_setup to create_test_impl.
This will ensure it gets created before wait_for_tests is run.

[BFB]
