### PR TITLE
bless_test_results: Fix bug

### DIFF
--- a/cime/scripts-acme/bless_test_results
+++ b/cime/scripts-acme/bless_test_results
@@ -195,7 +195,7 @@ def bless_test_results(baseline_name, test_root, compiler, namelists_only=False,
                         run_dir = os.path.join(acme_root, case, "run")
                         cprnc_loc = acme_util.get_machine_info("CPRNC_ROOT")
                         compgen_cmd = "tcsh -c 'source %s && %s -baseline_dir %s -testcase %s -testcase_base %s -test_dir %s -cprnc_exe %s -generate_tag %s'" % \
-                            (machine_env, compgen, baseline_dir_for_test, case, test_name, testcase_dir_for_test, cprnc_loc, baseline_tag)
+                            (machine_env, compgen, baseline_dir_for_test, case, test_name, run_dir, cprnc_loc, baseline_tag)
 
                         check_compare = os.path.join(cime_root, "scripts", "Tools", "component_write_comparefail.pl")
                         stat, out, _ = run_cmd("%s %s 2>&1" % (check_compare, run_dir), ok_to_fail=True)

--- a/cime/scripts/Tools/component_generate.sh
+++ b/cime/scripts/Tools/component_generate.sh
@@ -201,7 +201,7 @@ if [ -z "$test_hist" ]; then
     status="GFAIL_NA"
     info="no history file in test case"
     print_result $status "$info"
-    exit 0
+    exit 1
 fi
 
 #----------------------------------------------------------------------
@@ -212,7 +212,7 @@ if [ $? -ne 0 ]; then
     status="GFAIL"
     info="error creating baseline directory"
     print_result $status "$info"
-    exit 0
+    exit 1
 fi
 chmod ug+w,a+rx $baseline_dir
 chmod ug+w,a+rx $baseline_dir/..
@@ -220,12 +220,12 @@ chmod ug+w,a+rx $baseline_dir/..
 #----------------------------------------------------------------------
 # Copy history file to baseline directory
 #----------------------------------------------------------------------
-cp $test_dir/$test_hist $baseline_dir/$baseline_hist
+cp -f $test_dir/$test_hist $baseline_dir/$baseline_hist
 if [ $? -ne 0 ]; then
     status="GFAIL"
     info="error copying history file to baseline directory"
     print_result $status "$info"
-    exit 0
+    exit 1
 fi
 chmod ug+w,a+r $baseline_dir/$baseline_hist
 


### PR DESCRIPTION
Was passing the testcase directory instead of the run directory
to component_compgen_baseline.sh. It was telling me PASS so I
thought it was working.

[BFB]
