### PR TITLE
Misc fixes to ACME testing tools

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -308,7 +308,7 @@
            <walltimes>
              <walltime default="true">0:50:00</walltime>
              <walltime ccsm_estcost="0">1:50:00</walltime>
-             <walltime ccsm_estcost="1">10:00:00</walltime>
+             <walltime ccsm_estcost="1">5:00:00</walltime>
            </walltimes>
          </batch_system>
          <mpirun mpilib="default">

--- a/cime/scripts-acme/update_acme_tests
+++ b/cime/scripts-acme/update_acme_tests
@@ -28,11 +28,11 @@ OR
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Update all acme test suites for all platforms \033[0m
-    > %s testlist.xml
+    > %s ../scripts/Testing/Testlistxml/testlist_allactive.xml
     \033[1;32m# Update acme_developer tests for all platforms \033[0m
-    > %s testlist.xml acme_developer
+    > %s ../scripts/Testing/Testlistxml/testlist_allactive.xml acme_developer
     \033[1;32m# Add acme_developer tests for a new platform \033[0m
-    > %s testlist.xml acme_developer -p machine,compiler
+    > %s ../scripts/Testing/Testlistxml/testlist_allactive.xml acme_developer -p machine,compiler
 """ % ((os.path.basename(args[0]), ) * 6),
 
 description=description,

--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -13,7 +13,6 @@ _TEST_SUITES = {
                    ),
     "acme_developer" : (None,
                         [("ERS.f19_g16_rx1.A", None),
-                         ("ERS.f45_g37.B1850C5", None),
                          ("ERS.f45_g37_rx1.DTEST", None),
                          ("ERS.ne30_g16_rx1.A", None),
                          ("ERS_IOP.f19_g16_rx1.A", None),
@@ -38,6 +37,7 @@ _TEST_SUITES = {
                           [("ERS.ne30_g16.B1850C5", None),
                            ("ERS.f19_f19.FAMIPC5", None),
                            ("ERS.ne16_g37.B1850C5", None),
+                           ("ERS.f45_g37.B1850C5", None),
                            ("ERS_D.f45_g37.B1850C5", None),
                            ("ERS_IOP_Ld3.f19_f19.FAMIPC5", None),
                            ("ERS_Ld3.ne16_g37.FC5", None),
@@ -151,16 +151,16 @@ def update_acme_tests(xml_file, categories, platform=None):
     for category in categories:
         # Remove any existing acme test category from the file.
         if (platform is None):
-            acme_util.run_cmd("%s -component allactive -removetests -category %s" % (manage_xml_entries, category), verbose=True)
+            acme_util.run_cmd("%s -component allactive -removetests -category %s" % (manage_xml_entries, category))
         else:
             acme_util.run_cmd("%s -component allactive -removetests -category %s -machine %s -compiler %s"
-                              % (manage_xml_entries, category, platforms[0][0], platforms[0][1]), verbose=True)
+                              % (manage_xml_entries, category, platforms[0][0], platforms[0][1]))
 
         # Generate a list of test entries corresponding to our suite at the top
         # of the file.
         new_test_file = generate_acme_test_entries(category, platforms)
         acme_util.run_cmd("%s -component allactive -addlist -file %s -category %s" %
-                          (manage_xml_entries, new_test_file, category), verbose=True)
+                          (manage_xml_entries, new_test_file, category))
         os.unlink(new_test_file)
 
     print "SUCCESS"

--- a/cime/scripts/Testing/Testlistxml/testlist_allactive.xml
+++ b/cime/scripts/Testing/Testlistxml/testlist_allactive.xml
@@ -3,13 +3,9 @@
   <compset name="A">
     <grid name="f19_g16_rx1">
       <test name="ERS">
-        <machine compiler="intel15" testtype="acme_tiny">babbageKnc</machine>
-        <machine compiler="pgi" testtype="acme_tiny">bluewaters</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
         <machine compiler="intel" testtype="acme_integration">edison</machine>
         <machine compiler="intel" testtype="acme_tiny">edison</machine>
-        <machine compiler="intel" testtype="acme_tiny">eos</machine>
-        <machine compiler="intel" testtype="acme_tiny">janus</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="gnu" testtype="acme_integration">melvin</machine>
         <machine compiler="gnu" testtype="acme_tiny">melvin</machine>
@@ -20,6 +16,8 @@
         <machine compiler="intel" testtype="acme_developer">mustang</machine>
         <machine compiler="gnu" testtype="acme_integration">mustang</machine>
         <machine compiler="intel" testtype="acme_integration">mustang</machine>
+        <machine compiler="gnu" testtype="acme_tiny">mustang</machine>
+        <machine compiler="intel" testtype="acme_tiny">mustang</machine>
         <machine compiler="intel" testtype="acme_developer">skybridge</machine>
         <machine compiler="intel" testtype="acme_integration">skybridge</machine>
         <machine compiler="intel" testtype="acme_tiny">skybridge</machine>
@@ -30,9 +28,8 @@
         <machine compiler="intel" testtype="acme_developer">wolf</machine>
         <machine compiler="gnu" testtype="acme_integration">wolf</machine>
         <machine compiler="intel" testtype="acme_integration">wolf</machine>
-        <machine compiler="gnu" testtype="acme_tiny">yellowstone</machine>
-        <machine compiler="intel" testtype="acme_tiny">yellowstone</machine>
-        <machine compiler="pgi" testtype="acme_tiny">yellowstone</machine>
+        <machine compiler="gnu" testtype="acme_tiny">wolf</machine>
+        <machine compiler="intel" testtype="acme_tiny">wolf</machine>
       </test>
       <test name="ERS_IOP">
         <machine compiler="intel" testtype="acme_developer">edison</machine>
@@ -95,13 +92,9 @@
         <machine compiler="intel" testtype="acme_integration">wolf</machine>
       </test>
       <test name="NCK">
-        <machine compiler="intel15" testtype="acme_tiny">babbageKnc</machine>
-        <machine compiler="pgi" testtype="acme_tiny">bluewaters</machine>
         <machine compiler="intel" testtype="acme_developer">edison</machine>
         <machine compiler="intel" testtype="acme_integration">edison</machine>
         <machine compiler="intel" testtype="acme_tiny">edison</machine>
-        <machine compiler="intel" testtype="acme_tiny">eos</machine>
-        <machine compiler="intel" testtype="acme_tiny">janus</machine>
         <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="gnu" testtype="acme_integration">melvin</machine>
         <machine compiler="gnu" testtype="acme_tiny">melvin</machine>
@@ -112,6 +105,8 @@
         <machine compiler="intel" testtype="acme_developer">mustang</machine>
         <machine compiler="gnu" testtype="acme_integration">mustang</machine>
         <machine compiler="intel" testtype="acme_integration">mustang</machine>
+        <machine compiler="gnu" testtype="acme_tiny">mustang</machine>
+        <machine compiler="intel" testtype="acme_tiny">mustang</machine>
         <machine compiler="intel" testtype="acme_developer">skybridge</machine>
         <machine compiler="intel" testtype="acme_integration">skybridge</machine>
         <machine compiler="intel" testtype="acme_tiny">skybridge</machine>
@@ -122,9 +117,8 @@
         <machine compiler="intel" testtype="acme_developer">wolf</machine>
         <machine compiler="gnu" testtype="acme_integration">wolf</machine>
         <machine compiler="intel" testtype="acme_integration">wolf</machine>
-        <machine compiler="gnu" testtype="acme_tiny">yellowstone</machine>
-        <machine compiler="intel" testtype="acme_tiny">yellowstone</machine>
-        <machine compiler="pgi" testtype="acme_tiny">yellowstone</machine>
+        <machine compiler="gnu" testtype="acme_tiny">wolf</machine>
+        <machine compiler="intel" testtype="acme_tiny">wolf</machine>
       </test>
     </grid>
     <grid name="f45_g37_rx1">
@@ -309,22 +303,13 @@
     </grid>
     <grid name="f45_g37">
       <test name="ERS">
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
         <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
         <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
         <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
         <machine compiler="gnu" testtype="acme_integration">mustang</machine>
         <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
         <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
         <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
         <machine compiler="gnu" testtype="acme_integration">wolf</machine>
         <machine compiler="intel" testtype="acme_integration">wolf</machine>
       </test>


### PR DESCRIPTION
1) Reduce skybridge expensive test time from 10 hours to 5 hours.
This should help get us through the queue faster. The tests being
SIGTERM'd were not in that state due to timeout.
2) Update the update_acme_tests documentation to point to the XML
file that we use.
3) Demote ERS.f45_g37.B1850C5 test from acme_developer to acme_integration.
It had PIO problems on melvin that aren't worth the time to debug.
4) Make commands in update_acme_tests non-verbose unless user asks for verbose.

[BFB]
