### PR TITLE
Add phosphorous deposition stream file to ALM

### DIFF
--- a/models/lnd/clm/bld/CLMBuildNamelist.pm
+++ b/models/lnd/clm/bld/CLMBuildNamelist.pm
@@ -22,6 +22,7 @@
 # 2012-07-01  Kluzek           Add some common CESM namelist options
 # 2013-12     Andre            Refactor everything into subroutines
 # 2013-12     Muszala          Add Ecosystem Demography functionality
+# 2015-09-30  X.Shi            Add pdep streams capability 
 #--------------------------------------------------------------------------------------------
 
 package CLMBuildNamelist;
@@ -1435,6 +1436,11 @@ sub process_namelist_inline_logic {
   # namelist group: ndepdyn_nml #
   ###############################
   setup_logic_nitrogen_deposition($opts->{'test'}, $nl_flags, $definition, $defaults, $nl, $physv);
+  
+  ###############################
+  # namelist group: pdepdyn_nml #
+  ###############################
+  setup_logic_phosphorus_deposition($opts->{'test'}, $nl_flags, $definition, $defaults, $nl, $physv);
 
   #################################
   # namelist group: popd_streams  #
@@ -2258,6 +2264,67 @@ sub setup_logic_nitrogen_deposition {
 
 #-------------------------------------------------------------------------------
 
+sub setup_logic_phosphorus_deposition {
+  my ($test_files, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
+
+  #
+  # Phosphorus deposition for bgc=CN
+  #
+
+ # if ( $physv->as_long() == $physv->as_long("clm4_0") && $nl_flags->{'bgc_mode'} ne "none" ) {
+ #   add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'pdepmapalgo', 'phys'=>$nl_flags->{'phys'},
+ #               'bgc'=>$nl_flags->{'bgc_mode'}, 'hgrid'=>$nl_flags->{'res'} );
+ #   add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_first_pdep', 'phys'=>$nl_flags->{'phys'},
+ #               'bgc'=>$nl_flags->{'bgc_mode'}, 'sim_year'=>$nl_flags->{'sim_year'},
+ #               'sim_year_range'=>$nl_flags->{'sim_year_range'});
+ #   add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_last_pdep', 'phys'=>$nl_flags->{'phys'},
+ #               'bgc'=>$nl_flags->{'bgc_mode'}, 'sim_year'=>$nl_flags->{'sim_year'},
+ #               'sim_year_range'=>$nl_flags->{'sim_year_range'});
+
+    # Set align year, if first and last years are different
+ #   if ( $nl->get_value('stream_year_first_pdep') != $nl->get_value('stream_year_last_pdep') ) {
+ #     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'model_year_align_pdep', 'sim_year'=>$nl_flags->{'sim_year'},
+ #                 'sim_year_range'=>$nl_flags->{'sim_year_range'});
+ #   }
+
+ #   add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_fldfilename_pdep', 'phys'=>$nl_flags->{'phys'},
+ #               'bgc'=>$nl_flags->{'bgc_mode'}, 'rcp'=>$nl_flags->{'rcp'},
+ #               'hgrid'=>"1.9x2.5" );
+
+ # } elsif ( $physv->as_long() >= $physv->as_long("clm4_5") && $nl_flags->{'bgc_mode'} ne "sp" ) {
+    if ( $physv->as_long() >= $physv->as_long("clm4_5") && $nl_flags->{'bgc_mode'} ne "sp" ) {
+    add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'pdepmapalgo', 'phys'=>$nl_flags->{'phys'},
+                'use_cn'=>$nl_flags->{'use_cn'}, 'hgrid'=>$nl_flags->{'res'} );
+    add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_first_pdep', 'phys'=>$nl_flags->{'phys'},
+                'use_cn'=>$nl_flags->{'use_cn'}, 'sim_year'=>$nl_flags->{'sim_year'},
+                'sim_year_range'=>$nl_flags->{'sim_year_range'});
+    add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_last_pdep', 'phys'=>$nl_flags->{'phys'},
+                'use_cn'=>$nl_flags->{'use_cn'}, 'sim_year'=>$nl_flags->{'sim_year'},
+                'sim_year_range'=>$nl_flags->{'sim_year_range'});
+    # Set align year, if first and last years are different
+    if ( $nl->get_value('stream_year_first_pdep') != $nl->get_value('stream_year_last_pdep') ) {
+      add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'model_year_align_pdep', 'sim_year'=>$nl_flags->{'sim_year'},
+                  'sim_year_range'=>$nl_flags->{'sim_year_range'});
+    }
+    add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_fldfilename_pdep', 'phys'=>$nl_flags->{'phys'},
+                'use_cn'=>$nl_flags->{'use_cn'}, 'rcp'=>$nl_flags->{'rcp'},
+                'hgrid'=>"1.9x2.5" );
+   } else {
+    # If bgc is NOT CN/CNDV then make sure none of the pdep settings are set!
+    if ( defined($nl->get_value('stream_year_first_pdep')) ||
+         defined($nl->get_value('stream_year_last_pdep'))  ||
+         defined($nl->get_value('model_year_align_pdep'))  ||
+         defined($nl->get_value('stream_fldfilename_pdep'))
+       ) {
+      fatal_error("When bgc is NOT CN or CNDV none of: stream_year_first_pdep," .
+                  "stream_year_last_pdep, model_year_align_pdep, nor stream_fldfilename_pdep" .
+                  " can be set!\n");
+    }
+  }
+}
+
+#-------------------------------------------------------------------------------
+
 sub setup_logic_popd_streams {
   # population density streams require clm4_5/clm5_0 and CN/BGC
   my ($test_files, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
@@ -2432,9 +2499,10 @@ sub write_output_files {
     # Eventually only list namelists that are actually used when CN on
     #if ( $nl_flags->{'bgc_mode'}  eq "cn" ) {
       push @groups, "ndepdyn_nml";
+      push @groups, "pdepdyn_nml";
     #}
   } else {
-    @groups = qw(clm_inparm ndepdyn_nml popd_streams light_streams lai_streams clm_canopyhydrology_inparm 
+    @groups = qw(clm_inparm ndepdyn_nml pdepdyn_nml popd_streams light_streams lai_streams clm_canopyhydrology_inparm 
                  clm_soilhydrology_inparm finidat_consistency_checks dynpft_consistency_checks);
     #@groups = qw(clm_inparm clm_canopyhydrology_inparm clm_soilhydrology_inparm 
     #             finidat_consistency_checks dynpft_consistency_checks);

--- a/models/lnd/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/models/lnd/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -395,6 +395,48 @@ lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_c130927.nc</fsurdat>
 <ndepmapalgo use_cn=".true."   hgrid="1x1_tropicAtl"       >nn</ndepmapalgo>
 <ndepmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</ndepmapalgo>
 
+<!-- Phosphorus deposition streams namelist defaults -->
+<stream_year_first_pdep use_cn=".true."   sim_year="2000" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="2000" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="1850" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="1850" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="1000" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="1000" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >1850</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >1850</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >2100</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2100</stream_year_last_pdep>
+
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   >lnd/clm2/pdepdata/fpdep_clm_hist_simyr2000_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   rcp="8.5" >lnd/clm2/pdepdata/fpdep_clm_hist_simyr2000_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   rcp="6"   >lnd/clm2/pdepdata/fpdep_clm_hist_simyr2000_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   rcp="4.5" >lnd/clm2/pdepdata/fpdep_clm_hist_simyr2000_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   rcp="2.6" >lnd/clm2/pdepdata/fpdep_clm_hist_simyr2000_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+
+<pdepmapalgo use_cn=".true."                               >bilinear</pdepmapalgo>
+
+<pdepmapalgo use_cn=".true."   hgrid="1x1_brazil"          >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_mexicocityMEX"   >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_vancouverCAN"    >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_urbanc_alpha"    >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_camdenNJ"        >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_asphaltjungleNJ" >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_tropicAtl"       >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</pdepmapalgo>
+
 <!-- LAI streams namelist defaults -->
 <use_lai_streams        >.false.</use_lai_streams>
 <stream_year_first_lai  >2001</stream_year_first_lai>

--- a/models/lnd/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/models/lnd/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -845,6 +845,42 @@ Mapping method from Nitrogen deposition input file to the model resolution
 </entry>
 
 <!-- ========================================================================================  -->
+<!-- pdepdyn streams Namelist (only used when bgc=cn/cndv)                                     -->
+<!-- ========================================================================================  -->
+
+<entry id="stream_year_first_pdep" type="integer" category="datasets"
+       group="pdepdyn_nml" valid_values="" >
+First year to loop over for Phosphorus Deposition data
+</entry>
+
+<entry id="stream_year_last_pdep" type="integer" category="datasets"
+       group="pdepdyn_nml" valid_values="" >
+Last year to loop over for Phosphorus Deposition data
+</entry>
+
+<entry id="model_year_align_pdep" type="integer" category="datasets"
+       group="pdepdyn_nml" valid_values="" >
+Simulation year that aligns with stream_year_first_pdep value
+</entry>
+
+<entry id="stream_fldfilename_pdep" type="char*256" category="datasets"
+       input_pathname="abs" group="pdepdyn_nml" valid_values="" >
+Filename of input stream data for Phosphorus Deposition
+</entry>
+
+<entry id="pdepmapalgo" type="char*256" category="datasets"
+       group="pdepdyn_nml" valid_values="bilinear,nn,nnoni,nnonj,spval,copy" >
+Mapping method from Phosphorus deposition input file to the model resolution
+    bilinear = bilinear interpolation
+    nn       = nearest neighbor
+    nnoni    = nearest neighbor on the "i" (longitude) axis
+    nnonj    = nearest neighbor on the "j" (latitude) axis
+    spval    = set to special value
+    copy     = copy using the same indices
+</entry>
+
+
+<!-- ========================================================================================  -->
 <!-- lai_streams streams Namelist (when phys = CLM4_5)                              -->
 <!-- ========================================================================================  -->
 

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp2.6_glacierMEC_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp2.6_glacierMEC_transient.xml
@@ -42,6 +42,10 @@
 <stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true." >2000</model_year_align_pdep>
+
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp2.6_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp2.6_transient.xml
@@ -34,6 +34,10 @@
 <stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true." >2000</model_year_align_pdep>
+
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp4.5_glacierMEC_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp4.5_glacierMEC_transient.xml
@@ -46,6 +46,10 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." ndepsrc="stream" >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2000</model_year_align_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp4.5_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp4.5_transient.xml
@@ -38,6 +38,10 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." ndepsrc="stream" >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." pdepsrc="stream" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." pdepsrc="stream" >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true." pdepsrc="stream" >2000</model_year_align_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp6_glacierMEC_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp6_glacierMEC_transient.xml
@@ -46,6 +46,10 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true."  >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true."  >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true."  >2000</model_year_align_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp6_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp6_transient.xml
@@ -40,6 +40,10 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true."  >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true."  >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true."  >2000</model_year_align_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp8.5_glacierMEC_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp8.5_glacierMEC_transient.xml
@@ -46,6 +46,11 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true." >2000</model_year_align_pdep>
+
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp8.5_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850-2100_rcp8.5_transient.xml
@@ -38,6 +38,10 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true."  >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true."  >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true."  >2000</model_year_align_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850_control.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850_control.xml
@@ -20,6 +20,9 @@
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2000</stream_year_last_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_popdens>
 

--- a/models/lnd/clm/bld/namelist_files/use_cases/1850_glacierMEC_control.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/1850_glacierMEC_control.xml
@@ -22,6 +22,9 @@
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." pdepsrc="stream" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." pdepsrc="stream" >2000</stream_year_last_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_popdens>
 

--- a/models/lnd/clm/bld/namelist_files/use_cases/2000-2100_rcp8.5_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/2000-2100_rcp8.5_transient.xml
@@ -37,6 +37,10 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >2000</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true." >2000</model_year_align_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >2000</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >2000</model_year_align_popdens>

--- a/models/lnd/clm/bld/namelist_files/use_cases/2000_control.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/2000_control.xml
@@ -20,6 +20,9 @@
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." ndepsrc="stream" >2000</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." ndepsrc="stream" >2000</stream_year_last_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." pdepsrc="stream" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." pdepsrc="stream" >2000</stream_year_last_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_popdens>
 

--- a/models/lnd/clm/bld/namelist_files/use_cases/2000_glacierMEC_control.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/2000_glacierMEC_control.xml
@@ -22,6 +22,9 @@
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." ndepsrc="stream" >2000</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." ndepsrc="stream" >2000</stream_year_last_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2000</stream_year_last_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_popdens>
 

--- a/models/lnd/clm/bld/namelist_files/use_cases/20thC_glacierMEC_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/20thC_glacierMEC_transient.xml
@@ -40,6 +40,10 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true."   >2005</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true."   >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true."   >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true."   >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true."   >2000</model_year_align_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>

--- a/models/lnd/clm/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/models/lnd/clm/bld/namelist_files/use_cases/20thC_transient.xml
@@ -31,6 +31,10 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true."   >2005</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true."   >1850</model_year_align_ndep>
 
+<stream_year_first_pdep phys="clm4_5" use_cn=".true."   >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true."   >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true."   >2000</model_year_align_pdep>
+
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>

--- a/models/lnd/clm/bld/test_build_namelist/t/input/namelist_defaults_clm4_5_test.xml
+++ b/models/lnd/clm/bld/test_build_namelist/t/input/namelist_defaults_clm4_5_test.xml
@@ -370,9 +370,50 @@ lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_c130927.nc</fsurdat>
 <ndepmapalgo use_cn=".true."   hgrid="1x1_camdenNJ"        >nn</ndepmapalgo>
 <ndepmapalgo use_cn=".true."   hgrid="1x1_asphaltjungleNJ" >nn</ndepmapalgo>
 <ndepmapalgo use_cn=".true."   hgrid="1x1_tropicAtl"       >nn</ndepmapalgo>
-<ndepmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</ndepmapalgo>
+<5ndepmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</ndepmapalgo>
 
-<!-- lightning streams namelist defaults -->
+<!-- Phosphorus deposition streams namelist defaults -->
+<stream_year_first_pdep use_cn=".true."   sim_year="2000" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="2000" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="1850" >1850</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="1850" >1850</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="1000" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="1000" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >1850</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >2000</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >1850</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >2100</stream_year_last_pdep>
+
+<stream_year_first_pdep use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2100</stream_year_last_pdep>
+
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   >lnd/clm2/pdepdata/fpdep_clm_hist_simyr2000_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   rcp="8.5" >lnd/clm2/pdepdata/fpdep_clm_rcp8.5_simyr1849-2106_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   rcp="6"   >lnd/clm2/pdepdata/fpdep_clm_rcp6.0_simyr1849-2106_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   rcp="4.5" >lnd/clm2/pdepdata/fpdep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+<stream_fldfilename_pdep hgrid="1.9x2.5"   use_cn=".true."   rcp="2.6" >lnd/clm2/pdepdata/fpdep_clm_rcp2.6_simyr1849-2106_1.9x2.5_c150929.nc</stream_fldfilename_pdep>
+
+<pdepmapalgo use_cn=".true."                               >bilinear</pdepmapalgo>
+
+<pdepmapalgo use_cn=".true."   hgrid="1x1_mexicocityMEX"   >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_vancouverCAN"    >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_urbanc_alpha"    >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_camdenNJ"        >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_asphaltjungleNJ" >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="1x1_tropicAtl"       >nn</pdepmapalgo>
+<pdepmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</pdepmapalgo> 
+
+<!--lightning streams namelist defaults -->
 <stream_year_first_lightng use_cn=".true."   >0001</stream_year_first_lightng>
 <stream_year_last_lightng  use_cn=".true."   >0001</stream_year_last_lightng>
 

--- a/models/lnd/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
+++ b/models/lnd/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
@@ -786,6 +786,41 @@ Mapping method from Nitrogen deposition input file to the model resolution
     copy     = copy using the same indices
 </entry>
 
+<!-- pdepdyn streams Namelist (only used when bgc=cn/cndv)                                     -->
+<!-- ========================================================================================  -->
+
+<entry id="stream_year_first_pdep" type="integer" category="datasets"
+       group="pdepdyn_nml" valid_values="" >
+First year to loop over for Phosphorus Deposition data
+</entry>
+
+<entry id="stream_year_last_pdep" type="integer" category="datasets"
+       group="pdepdyn_nml" valid_values="" >
+Last year to loop over for Phosphorus Deposition data
+</entry>
+
+<entry id="model_year_align_pdep" type="integer" category="datasets"
+       group="pdepdyn_nml" valid_values="" >
+Simulation year that aligns with stream_year_first_pdep value
+</entry>
+
+<entry id="stream_fldfilename_pdep" type="char*256" category="datasets"
+       input_pathname="abs" group="pdepdyn_nml" valid_values="" >
+Filename of input stream data for Phosphorus Deposition
+</entry>
+
+<entry id="pdepmapalgo" type="char*256" category="datasets"
+       group="pdepdyn_nml" valid_values="bilinear,nn,nnoni,nnonj,spval,copy" >
+Mapping method from Phosphorus deposition input file to the model resolution
+    bilinear = bilinear interpolation
+    nn       = nearest neighbor
+    nnoni    = nearest neighbor on the "i" (longitude) axis
+    nnonj    = nearest neighbor on the "j" (latitude) axis
+    spval    = set to special value
+    copy     = copy using the same indices
+</entry>
+
+
 <!-- ========================================================================================  -->
 <!-- light_streams streams Namelist (when CN an CLM4_5 is active)                              -->
 <!-- ========================================================================================  -->

--- a/models/lnd/clm/src/biogeochem/CNEcosystemDynMod.F90
+++ b/models/lnd/clm/src/biogeochem/CNEcosystemDynMod.F90
@@ -95,6 +95,7 @@ contains
     !
     ! !USES:
     use CNNDynamicsMod         , only: CNNDeposition,CNNFixation, CNNFert, CNSoyfix
+    use PDynamicsMod           , only: PDeposition   
     use CNMRespMod             , only: CNMResp
     use CNDecompMod            , only: CNDecompAlloc
     use CNPhenologyMod         , only: CNPhenology
@@ -221,6 +222,15 @@ contains
             canopystate_vars, soilstate_vars, temperature_vars, photosyns_vars, &
             carbonflux_vars, nitrogenstate_vars)
        call t_stopf('CNMResp')
+
+       ! --------------------------------------------------
+       ! Phosphorus Deposition ! X.SHI
+       ! --------------------------------------------------
+
+       call t_startf('PDeposition')
+       call PDeposition(bounds, &
+            atm2lnd_vars, phosphorusflux_vars)
+       call t_stopf('PDeposition')
 
 
        call t_startf('CNDecompAlloc')

--- a/models/lnd/clm/src/biogeochem/CNStateType.F90
+++ b/models/lnd/clm/src/biogeochem/CNStateType.F90
@@ -76,7 +76,8 @@ module CNStateType
      real(r8) , pointer :: rf_decomp_cascade_col       (:,:,:) ! col respired fraction in decomposition step (frac)
      real(r8) , pointer :: pathfrac_decomp_cascade_col (:,:,:) ! col what fraction of C leaving a given pool passes through a given transition (frac) 
      real(r8) , pointer :: nfixation_prof_col          (:,:)   ! col (1/m) profile for N fixation additions 
-     real(r8) , pointer :: ndep_prof_col               (:,:)   ! col (1/m) profile for N fixation additions 
+     real(r8) , pointer :: ndep_prof_col               (:,:)   ! col (1/m) profile for N fixation additions
+     real(r8) , pointer :: pdep_prof_col               (:,:)   ! col (1/m) profile for P deposition additions 
      real(r8) , pointer :: som_adv_coef_col            (:,:)   ! col SOM advective flux (m/s) 
      real(r8) , pointer :: som_diffus_coef_col         (:,:)   ! col SOM diffusivity due to bio/cryo-turbation (m2/s) 
 
@@ -238,6 +239,7 @@ contains
 
     allocate(this%nfixation_prof_col  (begc:endc,1:nlevdecomp_full)) ; this%nfixation_prof_col  (:,:) = spval
     allocate(this%ndep_prof_col       (begc:endc,1:nlevdecomp_full)) ; this%ndep_prof_col       (:,:) = spval
+    allocate(this%pdep_prof_col       (begc:endc,1:nlevdecomp_full)) ; this%pdep_prof_col       (:,:) = spval
     allocate(this%som_adv_coef_col    (begc:endc,1:nlevdecomp_full)) ; this%som_adv_coef_col    (:,:) = spval
     allocate(this%som_diffus_coef_col (begc:endc,1:nlevdecomp_full)) ; this%som_diffus_coef_col (:,:) = spval
 
@@ -360,6 +362,12 @@ contains
     call hist_addfld_decomp (fname='NDEP_PROF', units='1/m',  type2d='levdcmp', &
          avgflag='A', long_name='profile for atmospheric N  deposition', &
          ptr_col=this%ndep_prof_col, default='inactive')
+
+    this%pdep_prof_col(begc:endc,:) = spval
+    call hist_addfld_decomp (fname='PDEP_PROF', units='1/m',  type2d='levdcmp', &
+         avgflag='A', long_name='profile for atmospheric P  deposition', &
+         ptr_col=this%pdep_prof_col, default='inactive')
+
 
     this%som_adv_coef_col(begc:endc,:) = spval
     call hist_addfld_decomp (fname='SOM_ADV_COEF', units='m/s',  type2d='levdcmp', &
@@ -760,6 +768,7 @@ contains
           ! initialize the profiles for converting to vertically resolved carbon pools
           this%nfixation_prof_col(c,1:nlevdecomp_full)  = 0._r8 
           this%ndep_prof_col(c,1:nlevdecomp_full)       = 0._r8 
+          this%pdep_prof_col(c,1:nlevdecomp_full)       = 0._r8  
        end if
     end do
 

--- a/models/lnd/clm/src/biogeochem/CNVerticalProfileMod.F90
+++ b/models/lnd/clm/src/biogeochem/CNVerticalProfileMod.F90
@@ -81,6 +81,7 @@ contains
     real(r8) :: stem_prof_sum
     real(r8) :: ndep_prof_sum
     real(r8) :: nfixation_prof_sum
+    real(r8) :: pdep_prof_sum
     real(r8) :: delta = 1.e-10
     character(len=32) :: subname = 'decomp_vertprofiles'
     !-----------------------------------------------------------------------
@@ -91,7 +92,8 @@ contains
          altmax_lastyear_indx => canopystate_vars%altmax_lastyear_indx_col , & ! Input:  [integer   (:)   ]  frost table depth (m)                              
          
          nfixation_prof       => cnstate_vars%nfixation_prof_col           , & ! Input:  [real(r8)  (:,:) ]  (1/m) profile for N fixation additions          
-         ndep_prof            => cnstate_vars%ndep_prof_col                , & ! Input:  [real(r8)  (:,:) ]  (1/m) profile for N fixation additions          
+         ndep_prof            => cnstate_vars%ndep_prof_col                , & ! Input:  [real(r8)  (:,:) ]  (1/m) profile for N fixation additions
+         pdep_prof            => cnstate_vars%pdep_prof_col                , & ! Input:  [real(r8)  (:,:) ]  (1/m) profile for P depostition additions          
          
          leaf_prof            => cnstate_vars%leaf_prof_patch              , & ! Output:  [real(r8) (:,:) ]  (1/m) profile of leaves                         
          froot_prof           => cnstate_vars%froot_prof_patch             , & ! Output:  [real(r8) (:,:) ]  (1/m) profile of fine roots                     
@@ -119,6 +121,7 @@ contains
          stem_prof(begp:endp, :)      = 0._r8
          nfixation_prof(begc:endc, :) = 0._r8
          ndep_prof(begc:endc, :)      = 0._r8
+         pdep_prof(begc:endc, :)      = 0._r8
 
          cinput_rootfr(begp:endp, :)     = 0._r8
          col_cinput_rootfr(begc:endc, :) = 0._r8
@@ -218,10 +221,12 @@ contains
                do j = 1,  min(max(altmax_lastyear_indx(c), 1), nlevdecomp)
                   nfixation_prof(c,j) = col_cinput_rootfr(c,j) / rootfr_tot
                   ndep_prof(c,j) = surface_prof(j)/ surface_prof_tot
+                  pdep_prof(c,j) = surface_prof(j)/ surface_prof_tot
                end do
             else
                nfixation_prof(c,1) = 1./dzsoi_decomp(1)
                ndep_prof(c,1) = 1./dzsoi_decomp(1)
+               pdep_prof(c,1) = 1./dzsoi_decomp(1) 
             endif
          end do
 
@@ -234,6 +239,7 @@ contains
          stem_prof(begp:endp, :) = 1._r8
          nfixation_prof(begc:endc, :) = 1._r8
          ndep_prof(begc:endc, :) = 1._r8
+         pdep_prof(begc:endc, :) = 1._r8
 
       end if
 
@@ -243,16 +249,19 @@ contains
          c = filter_soilc(fc)
          ndep_prof_sum = 0.
          nfixation_prof_sum = 0.
+         pdep_prof_sum = 0.
          do j = 1, nlevdecomp
             ndep_prof_sum = ndep_prof_sum + ndep_prof(c,j) *  dzsoi_decomp(j)
             nfixation_prof_sum = nfixation_prof_sum + nfixation_prof(c,j) *  dzsoi_decomp(j)
+            pdep_prof_sum = pdep_prof_sum + pdep_prof(c,j) *  dzsoi_decomp(j)
          end do
-         if ( ( abs(ndep_prof_sum - 1._r8) > delta ) .or.  ( abs(nfixation_prof_sum - 1._r8) > delta ) ) then
-            write(iulog, *) 'profile sums: ', ndep_prof_sum, nfixation_prof_sum
+         if ( ( abs(ndep_prof_sum - 1._r8) > delta ) .or.  ( abs(nfixation_prof_sum - 1._r8) > delta ) .or. ( abs(pdep_prof_sum - 1._r8) > delta )  ) then
+            write(iulog, *) 'profile sums: ', ndep_prof_sum, nfixation_prof_sum, pdep_prof_sum
             write(iulog, *) 'c: ', c
             write(iulog, *) 'altmax_lastyear_indx: ', altmax_lastyear_indx(c)
             write(iulog, *) 'nfixation_prof: ', nfixation_prof(c,:)
             write(iulog, *) 'ndep_prof: ', ndep_prof(c,:)
+            write(iulog, *) 'pdep_prof: ', pdep_prof(c,:)
             write(iulog, *) 'cinput_rootfr: ', cinput_rootfr(c,:)
             write(iulog, *) 'dzsoi_decomp: ', dzsoi_decomp(:)
             write(iulog, *) 'surface_prof: ', surface_prof(:)

--- a/models/lnd/clm/src/biogeochem/PDynamicsMod.F90
+++ b/models/lnd/clm/src/biogeochem/PDynamicsMod.F90
@@ -34,6 +34,7 @@ module PDynamicsMod
   private
   !
   ! !PUBLIC MEMBER FUNCTIONS:
+  public :: PDeposition
   public :: PWeathering
   public :: PAdsorption
   public :: PDesorption
@@ -44,6 +45,40 @@ module PDynamicsMod
   !-----------------------------------------------------------------------
 
 contains
+  !-----------------------------------------------------------------------
+  subroutine PDeposition( bounds, &
+       atm2lnd_vars, phosphorusflux_vars )
+    ! BY X. SHI
+    ! !DESCRIPTION:
+    ! On the radiation time step, update the phosphorus deposition rate
+    ! from atmospheric forcing. For now it is assumed that all the atmospheric
+    ! P deposition goes to the soil mineral P pool.
+    ! This could be updated later to divide the inputs between mineral P absorbed
+    ! directly into the canopy and mineral P entering the soil pool.
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)        , intent(in)    :: bounds
+    type(atm2lnd_type)       , intent(in)    :: atm2lnd_vars
+    type(phosphorusflux_type) , intent(inout) :: phosphorusflux_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer :: g,c                    ! indices
+    !-----------------------------------------------------------------------
+
+    associate(&
+         forc_pdep     =>  atm2lnd_vars%forc_pdep_grc           , & ! Input:  [real(r8) (:)]  Phosphorus deposition rate (gP/m2/s)                
+         pdep_to_sminp =>  phosphorusflux_vars%pdep_to_sminp_col   & ! Output: [real(r8) (:)]                                                    
+         )
+
+      ! Loop through columns
+      do c = bounds%begc, bounds%endc
+         g = col%gridcell(c)
+         pdep_to_sminp(c) = forc_pdep(g)
+      end do
+
+    end associate
+
+  end subroutine PDeposition
 
   !-----------------------------------------------------------------------
   subroutine PWeathering(num_soilc, filter_soilc, &

--- a/models/lnd/clm/src/biogeochem/PStateUpdate3Mod.F90
+++ b/models/lnd/clm/src/biogeochem/PStateUpdate3Mod.F90
@@ -64,6 +64,7 @@ contains
     associate(& 
          isoilorder     => cnstate_vars%isoilorder ,&
          cascade_receiver_pool => decomp_cascade_con%cascade_receiver_pool ,&
+         pdep_prof             => cnstate_vars%pdep_prof_col               , & ! Input:  [real(r8) (:,:)   ]  profile over which P deposition is distributed through column 1/m)
          pf => phosphorusflux_vars  , &
          ps => phosphorusstate_vars   &
          )
@@ -141,7 +142,7 @@ contains
 
             ps%occlp_vr_col(c,j)   = ps%occlp_vr_col(c,j) + ( pf%secondp_to_occlp_vr_col(c,j) ) * dt
 
-            ps%primp_vr_col(c,j)   = ps%primp_vr_col(c,j) - ( pf%primp_to_labilep_vr_col(c,j) )*dt
+            ps%primp_vr_col(c,j)   = ps%primp_vr_col(c,j) - ( pf%primp_to_labilep_vr_col(c,j) )*dt + pf%pdep_to_sminp_col(c)*dt * pdep_prof(c,j)
          end do
       enddo
 

--- a/models/lnd/clm/src/main/atm2lndType.F90
+++ b/models/lnd/clm/src/main/atm2lndType.F90
@@ -53,6 +53,7 @@ module atm2lndType
      real(r8), pointer :: forc_solai_grc                (:,:) => null() ! diffuse radiation (numrad) (vis=forc_solsd, nir=forc_solld)
      real(r8), pointer :: forc_solar_grc                (:)   => null() ! incident solar radiation
      real(r8), pointer :: forc_ndep_grc                 (:)   => null() ! nitrogen deposition rate (gN/m2/s)
+     real(r8), pointer :: forc_pdep_grc                 (:)   => null() ! phosphorus deposition rate (gP/m2/s)
      real(r8), pointer :: forc_pc13o2_grc               (:)   => null() ! C13O2 partial pressure (Pa)
      real(r8), pointer :: forc_po2_grc                  (:)   => null() ! O2 partial pressure (Pa)
      real(r8), pointer :: forc_aer_grc                  (:,:) => null() ! aerosol deposition array
@@ -169,6 +170,7 @@ contains
     allocate(this%forc_solai_grc                (begg:endg,numrad)) ; this%forc_solai_grc                (:,:) = ival
     allocate(this%forc_solar_grc                (begg:endg))        ; this%forc_solar_grc                (:)   = ival
     allocate(this%forc_ndep_grc                 (begg:endg))        ; this%forc_ndep_grc                 (:)   = ival
+    allocate(this%forc_pdep_grc                 (begg:endg))        ; this%forc_pdep_grc                 (:)   = ival
     allocate(this%forc_pc13o2_grc               (begg:endg))        ; this%forc_pc13o2_grc               (:)   = ival
     allocate(this%forc_po2_grc                  (begg:endg))        ; this%forc_po2_grc                  (:)   = ival
     allocate(this%forc_aer_grc                  (begg:endg,14))     ; this%forc_aer_grc                  (:,:) = ival

--- a/models/lnd/clm/src/main/clm_driver.F90
+++ b/models/lnd/clm/src/main/clm_driver.F90
@@ -56,6 +56,7 @@ module clm_driver
   use CNDVDriverMod          , only : CNDVDriver, CNDVHIST
   use SatellitePhenologyMod  , only : SatellitePhenology, interpMonthlyVeg
   use ndepStreamMod          , only : ndep_interp
+  use pdepStreamMod          , only : pdep_interp
   use ActiveLayerMod         , only : alt_calc
   use ch4Mod                 , only : ch4
   use DUSTMod                , only : DustDryDep, DustEmission
@@ -346,6 +347,19 @@ contains
        call CNFireInterp(bounds_proc)
        call t_stopf('ndep_interp')
     end if
+    ! ============================================================================
+    ! Update dynamic P deposition field, on albedo timestep
+    ! currently being done outside clumps loop, but no reason why it couldn't be
+    ! re-written to go inside.
+    ! ============================================================================
+
+    if (use_cn) then
+       call t_startf('pdnep_interp')
+       ! PET: switching CN timestep
+       call pdep_interp(bounds_proc, atm2lnd_vars)
+       call t_stopf('pdep_interp')
+    end if
+
 
     ! ============================================================================
     ! Initialize variables from previous time step, downscale atm forcings, and

--- a/models/lnd/clm/src/main/clm_initializeMod.F90
+++ b/models/lnd/clm/src/main/clm_initializeMod.F90
@@ -391,6 +391,7 @@ contains
     use restFileMod           , only : restFile_read, restFile_write 
     use accumulMod            , only : print_accum_fields 
     use ndepStreamMod         , only : ndep_init, ndep_interp
+    use pdepStreamMod         , only : pdep_init, pdep_interp
     use CNEcosystemDynMod     , only : CNEcosystemDynInit 
     use CNDecompCascadeBGCMod , only : init_decompcascade_bgc
     use CNDecompCascadeCNMod  , only : init_decompcascade_cn
@@ -945,6 +946,18 @@ contains
        call ndep_interp(bounds_proc, atm2lnd_vars)
        call t_stopf('init_ndep')
     end if
+    
+    ! ------------------------------------------------------------------------
+    ! Initialize phosphorus deposition
+    ! ------------------------------------------------------------------------
+
+    if (use_cn) then
+       call t_startf('init_pdep')
+       call pdep_init(bounds_proc)
+       call pdep_interp(bounds_proc, atm2lnd_vars)
+       call t_stopf('init_pdep')
+    end if
+ 
 
     ! ------------------------------------------------------------------------
     ! Initialize active history fields. 

--- a/models/lnd/clm/src/main/pdepStreamMod.F90
+++ b/models/lnd/clm/src/main/pdepStreamMod.F90
@@ -1,0 +1,276 @@
+module pdepStreamMod
+
+  !----------------------------------------------------------------------- 
+  ! !DESCRIPTION: 
+  ! Contains methods for reading in phosphorus deposition data file
+  ! Also includes functions for dynamic pdep file handling and 
+  ! interpolation.
+  ! X.SHI
+  ! !USES
+  use shr_kind_mod, only: r8 => shr_kind_r8, CL => shr_kind_cl
+  use shr_strdata_mod
+  use shr_stream_mod
+  use shr_string_mod
+  use shr_sys_mod
+  use shr_mct_mod
+  use mct_mod
+  use spmdMod     , only: mpicom, masterproc, comp_id, iam
+  use clm_varctl  , only: iulog
+  use controlMod  , only: NLFilename
+  use abortutils  , only: endrun
+  use fileutils   , only: getavu, relavu
+  use decompMod   , only: bounds_type, ldecomp, gsmap_lnd_gdc2glo 
+  use domainMod   , only: ldomain
+
+  ! !PUBLIC TYPES:
+  implicit none
+  private
+  save
+
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public :: pdep_init      ! position datasets for dynamic pdep
+  public :: pdep_interp    ! interpolates between two years of pdep file data
+  public :: clm_domain_mct ! Sets up MCT domain for this resolution
+
+  ! ! PRIVATE TYPES
+  type(shr_strdata_type)  :: sdat         ! input data stream
+  integer :: stream_year_first_pdep       ! first year in stream to use
+  integer :: stream_year_last_pdep        ! last year in stream to use
+  integer :: model_year_align_pdep        ! align stream_year_firstpdep with 
+  !==============================================================================
+
+contains
+
+  !==============================================================================
+
+  subroutine pdep_init(bounds)
+   !    
+   ! Initialize data stream information.  
+   !
+   ! Uses:
+   use clm_varctl       , only : inst_name
+   use clm_time_manager , only : get_calendar
+   use ncdio_pio        , only : pio_subsystem
+   use shr_pio_mod      , only : shr_pio_getiotype
+   use shr_nl_mod       , only : shr_nl_find_group_name
+   use shr_log_mod      , only : errMsg => shr_log_errMsg
+   !
+   ! arguments
+   implicit none
+   type(bounds_type), intent(in) :: bounds  
+   !
+   ! local variables
+   integer            :: nu_nml    ! unit for namelist file
+   integer            :: nml_error ! namelist i/o error flag
+   type(mct_ggrid)    :: dom_clm   ! domain information 
+   character(len=CL)  :: stream_fldFileName_pdep
+   character(len=CL)  :: pdepmapalgo = 'bilinear'
+   character(*), parameter :: shr_strdata_unset = 'NOT_SET'
+   character(*), parameter :: subName = "('pdepdyn_init')"
+   character(*), parameter :: F00 = "('(pdepdyn_init) ',4a)"
+   !-----------------------------------------------------------------------
+
+   namelist /pdepdyn_nml/        &
+        stream_year_first_pdep,  &
+	stream_year_last_pdep,   &
+        model_year_align_pdep,   &
+        pdepmapalgo,             &
+        stream_fldFileName_pdep
+
+   ! Default values for namelist
+    stream_year_first_pdep  = 1                ! first year in stream to use
+    stream_year_last_pdep   = 1                ! last  year in stream to use
+    model_year_align_pdep   = 1                ! align stream_year_first_pdep with this model year
+    stream_fldFileName_pdep = ' '
+
+   ! Read pdepdyn_nml namelist
+   if (masterproc) then
+      nu_nml = getavu()
+      open( nu_nml, file=trim(NLFilename), status='old', iostat=nml_error )
+      call shr_nl_find_group_name(nu_nml, 'pdepdyn_nml', status=nml_error)
+      if (nml_error == 0) then
+         read(nu_nml, nml=pdepdyn_nml,iostat=nml_error)
+         if (nml_error /= 0) then
+            call endrun(msg=' ERROR reading pdepdyn_nml namelist'//errMsg(__FILE__, __LINE__))
+         end if
+      end if
+      close(nu_nml)
+      call relavu( nu_nml )
+   endif
+
+   call shr_mpi_bcast(stream_year_first_pdep, mpicom)
+   call shr_mpi_bcast(stream_year_last_pdep, mpicom)
+   call shr_mpi_bcast(model_year_align_pdep, mpicom)
+   call shr_mpi_bcast(stream_fldFileName_pdep, mpicom)
+
+   if (masterproc) then
+      write(iulog,*) ' '
+      write(iulog,*) 'pdepdyn stream settings:'
+      write(iulog,*) '  stream_year_first_pdep  = ',stream_year_first_pdep  
+      write(iulog,*) '  stream_year_last_pdep   = ',stream_year_last_pdep   
+      write(iulog,*) '  model_year_align_pdep   = ',model_year_align_pdep   
+      write(iulog,*) '  stream_fldFileName_pdep = ',stream_fldFileName_pdep
+      write(iulog,*) ' '
+   endif
+
+   call clm_domain_mct (bounds, dom_clm)
+
+   call shr_strdata_create(sdat,name="clmpdep",    &
+        pio_subsystem=pio_subsystem,               & 
+        pio_iotype=shr_pio_getiotype(inst_name),   &
+        mpicom=mpicom, compid=comp_id,             &
+        gsmap=gsmap_lnd_gdc2glo, ggrid=dom_clm,    &
+        nxg=ldomain%ni, nyg=ldomain%nj,            &
+        yearFirst=stream_year_first_pdep,          &
+        yearLast=stream_year_last_pdep,            &
+        yearAlign=model_year_align_pdep,           &
+        offset=0,                                  &
+        domFilePath='',                            &
+        domFileName=trim(stream_fldFileName_pdep), &
+        domTvarName='time',                        &
+        domXvarName='lon' ,                        &
+        domYvarName='lat' ,                        &  
+        domAreaName='area',                        &
+        domMaskName='mask',                        &
+        filePath='',                               &
+        filename=(/trim(stream_fldFileName_pdep)/),&
+        fldListFile='PDEP_year',                   &
+        fldListModel='PDEP_year',                  &
+        fillalgo='none',                           &
+        mapalgo=pdepmapalgo,                       &
+        calendar=get_calendar(),                   &
+	taxmode='extend'                           )
+
+   if (masterproc) then
+      call shr_strdata_print(sdat,'CLMPDEP data')
+   endif
+
+ end subroutine pdep_init
+  
+ !================================================================
+ subroutine pdep_interp(bounds, atm2lnd_vars)
+
+   !-----------------------------------------------------------------------
+   use clm_time_manager, only : get_curr_date, get_days_per_year
+   use clm_varcon      , only : secspday
+   use atm2lndType     , only : atm2lnd_type
+   !
+   ! Arguments
+   type(bounds_type) , intent(in)    :: bounds  
+   type(atm2lnd_type), intent(inout) :: atm2lnd_vars
+   !
+   ! Local variables
+   integer :: g, ig 
+   integer :: year    ! year (0, ...) for nstep+1
+   integer :: mon     ! month (1, ..., 12) for nstep+1
+   integer :: day     ! day of month (1, ..., 31) for nstep+1
+   integer :: sec     ! seconds into current date for nstep+1
+   integer :: mcdate  ! Current model date (yyyymmdd)
+   integer :: dayspyr ! days per year
+   !-----------------------------------------------------------------------
+
+   call get_curr_date(year, mon, day, sec)
+   mcdate = year*10000 + mon*100 + day
+
+   call shr_strdata_advance(sdat, mcdate, sec, mpicom, 'pdepdyn')
+
+   ig = 0
+   dayspyr = get_days_per_year( )
+   do g = bounds%begg,bounds%endg
+      ig = ig+1
+      atm2lnd_vars%forc_pdep_grc(g) = sdat%avs(1)%rAttr(1,ig) / (secspday * dayspyr)
+   end do
+   
+ end subroutine pdep_interp
+
+ !==============================================================================
+  subroutine clm_domain_mct(bounds, dom_clm)
+
+    !-------------------------------------------------------------------
+    ! Set domain data type for internal clm grid
+    use clm_varcon  , only : re
+    use domainMod   , only : ldomain
+    use seq_flds_mod
+    implicit none
+    ! 
+    ! arguments
+    type(bounds_type), intent(in) :: bounds  
+    type(mct_ggrid), intent(out)   :: dom_clm     ! Output domain information for land model
+    !
+    ! local variables
+    integer :: g,i,j              ! index
+    integer :: lsize              ! land model domain data size
+    real(r8), pointer :: data(:)  ! temporary
+    integer , pointer :: idata(:) ! temporary
+    !-------------------------------------------------------------------
+    !
+    ! Initialize mct domain type
+    ! lat/lon in degrees,  area in radians^2, mask is 1 (land), 0 (non-land)
+    ! Note that in addition land carries around landfrac for the purposes of domain checking
+    ! 
+    lsize = mct_gsMap_lsize(gsmap_lnd_gdc2glo, mpicom)
+    call mct_gGrid_init( GGrid=dom_clm, CoordChars=trim(seq_flds_dom_coord), &
+                         OtherChars=trim(seq_flds_dom_other), lsize=lsize )
+    !
+    ! Allocate memory
+    !
+    allocate(data(lsize))
+    !
+    ! Determine global gridpoint number attribute, GlobGridNum, which is set automatically by MCT
+    !
+    call mct_gsMap_orderedPoints(gsmap_lnd_gdc2glo, iam, idata)
+    call mct_gGrid_importIAttr(dom_clm,'GlobGridNum',idata,lsize)
+    !
+    ! Determine domain (numbering scheme is: West to East and South to North to South pole)
+    ! Initialize attribute vector with special value
+    !
+    data(:) = -9999.0_R8 
+    call mct_gGrid_importRAttr(dom_clm,"lat"  ,data,lsize) 
+    call mct_gGrid_importRAttr(dom_clm,"lon"  ,data,lsize) 
+    call mct_gGrid_importRAttr(dom_clm,"area" ,data,lsize) 
+    call mct_gGrid_importRAttr(dom_clm,"aream",data,lsize) 
+    data(:) = 0.0_R8     
+    call mct_gGrid_importRAttr(dom_clm,"mask" ,data,lsize) 
+    !
+    ! Determine bounds
+    !
+    ! Fill in correct values for domain components
+    ! Note aream will be filled in in the atm-lnd mapper
+    !
+    do g = bounds%begg,bounds%endg
+       i = 1 + (g - bounds%begg)
+       data(i) = ldomain%lonc(g)
+    end do
+    call mct_gGrid_importRattr(dom_clm,"lon",data,lsize) 
+
+    do g = bounds%begg,bounds%endg
+       i = 1 + (g - bounds%begg)
+       data(i) = ldomain%latc(g)
+    end do
+    call mct_gGrid_importRattr(dom_clm,"lat",data,lsize) 
+
+    do g = bounds%begg,bounds%endg
+       i = 1 + (g - bounds%begg)
+       data(i) = ldomain%area(g)/(re*re)
+    end do
+    call mct_gGrid_importRattr(dom_clm,"area",data,lsize) 
+
+    do g = bounds%begg,bounds%endg
+       i = 1 + (g - bounds%begg)
+       data(i) = real(ldomain%mask(g), r8)
+    end do
+    call mct_gGrid_importRattr(dom_clm,"mask",data,lsize) 
+
+    do g = bounds%begg,bounds%endg
+       i = 1 + (g - bounds%begg)
+       data(i) = real(ldomain%frac(g), r8)
+    end do
+    call mct_gGrid_importRattr(dom_clm,"frac",data,lsize) 
+
+    deallocate(data)
+    deallocate(idata)
+
+  end subroutine clm_domain_mct
+    
+end module PdepStreamMod
+


### PR DESCRIPTION
This commit adds phosphorus deposition stream file to ALM land surface model. 
This procedure is similar to add nitrogen deposition stream file. 
It is turned on by default, and will not change the result due to the 
phosphorus cycle turned off by default. 
It will change the result if the phosphorus cycle turned on.

[NML] 
[BFB]
