### PR TITLE
Fixes incorrect memory access in ALM

### DIFF
--- a/components/clm/src/biogeophys/SoilStateType.F90
+++ b/components/clm/src/biogeophys/SoilStateType.F90
@@ -232,7 +232,7 @@ contains
     end if
 
     if (use_dynroot) then
-       this%root_depth_patch(begc:endc) = spval
+       this%root_depth_patch(begp:endp) = spval
        call hist_addfld1d (fname='ROOT_DEPTH', units="m", &
             avgflag='A', long_name='rooting depth', &
             ptr_patch=this%root_depth_patch, default='inactive' )


### PR DESCRIPTION
root_depth_patch is allocated for begp:endp, while memory is
being accessed for begc:endc

Fixes #395

[BFB]
