### PR TITLE
Fix bug in array syntax in ice_itd.F90

### DIFF
--- a/components/cice/src/source/ice_itd.F90
+++ b/components/cice/src/source/ice_itd.F90
@@ -476,9 +476,9 @@
       call compute_tracers (nx_block,     ny_block,   &
                             icells,   indxi,   indxj, &
                             ntrcr,    trcr_depend,    &
-                            atrcr(:,:), aice(:,:),    &
-                            vice (:,:),   vsno(:,:),  &
-                            trcr(:,:,:))
+                            atrcr, aice,    &
+                            vice,   vsno,  &
+                            trcr)
 
       deallocate (atrcr)
 


### PR DESCRIPTION
Fixes an error encountered when compiling with intel DEBUG mode on
edison.  In this bug, the code fails at runtime in ice_itd.F90 with a
message stating:

"Subscript #1 of the array ATRCR has value 1 which is greater than the
upper bound of 0"

This is fixed as described on DiscussCESM
(https://bb.cgd.ucar.edu/error-running-compset-fsdwsf-ert), by
removing the explicit array syntax in the call to compute_tracers().

Fixes #339

[BFB]
