### PR TITLE
Fix associate() statement in CAM for PGI/titan

### DIFF
--- a/components/cam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/cam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -607,8 +607,8 @@ subroutine hetfrz_classnuc_cam_calc( &
       lchnk => state%lchnk,             &
       ncol  => state%ncol,              &
       t     => state%t,                 &
-      qc    => state%q(:,:,cldliq_idx), &
-      nc    => state%q(:,:,numliq_idx), &
+      qc    => state%q(:pcols,:pver,cldliq_idx), &
+      nc    => state%q(:pcols,:pver,numliq_idx), &
       pmid  => state%pmid               )
 
    itim_old = pbuf_old_tim_idx()

--- a/components/cam/src/physics/cam/microp_aero.F90
+++ b/components/cam/src/physics/cam/microp_aero.F90
@@ -459,9 +459,9 @@ subroutine microp_aero_run ( &
       lchnk => state%lchnk,             &
       ncol  => state%ncol,              &
       t     => state%t,                 &
-      qc    => state%q(:,:,cldliq_idx), &
-      qi    => state%q(:,:,cldice_idx), &
-      nc    => state%q(:,:,numliq_idx), &
+      qc    => state%q(:pcols,:pver,cldliq_idx), &
+      qi    => state%q(:pcols,:pver,cldice_idx), &
+      nc    => state%q(:pcols,:pver,numliq_idx), &
       pmid  => state%pmid               )
 
    itim_old = pbuf_old_tim_idx()


### PR DESCRIPTION
associate() statment has an issue with PGI compiler (specific version).
Fixes #402

[BFB]
AG-386
