### PR TITLE
Fixing NAG build issues with PIO on blues

### DIFF
--- a/cime/machines-acme/env_mach_specific.blues
+++ b/cime/machines-acme/env_mach_specific.blues
@@ -92,6 +92,7 @@ if ( $COMPILER == "nag" ) then
   soft add +gcc-4.7.2
 #  soft add +netcdf-4.3.1-serial-nag
   setenv NETCDFROOT /home/jacob/netcdf-4.3.3.1nag6
+  setenv NETCDF_PATH $NETCDFROOT
   # Get newer netcdf
   setenv PATH $NETCDFROOT/bin:$PATH
   setenv LD_LIBRARY_PATH $NETCDFROOT/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Adding the NETCDF lib path correctly for NAG on blues. Without
this fix PIO builds fail with the NAG compiler on blues.

Fixes #448 
[BFB]
SEG-182
