### PR TITLE
update_acme_tests: Copy test list to avoid modifying the global value

### DIFF
--- a/cime/scripts-acme/tests/scripts_regression_tests
+++ b/cime/scripts-acme/tests/scripts_regression_tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest, sys, os, tempfile, shutil, re, threading, time, signal, glob, stat
+import unittest, sys, os, tempfile, shutil, re, threading, time, signal, glob, stat, traceback
 
 SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(SCRIPT_DIR)
@@ -505,6 +505,7 @@ class TestUpdateACMETests(unittest.TestCase):
         try:
             update_acme_tests.update_acme_tests(self._testlist_allactive, update_acme_tests.get_test_suites())
         except:
+            traceback.print_tb(sys.exc_info()[2])
             self.assertTrue(False, str(sys.exc_info()[1]))
 
         stat = run_cmd("grep 'test/test_mod' %s" % self._testlist_allactive, ok_to_fail=True)[0]

--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -64,10 +64,12 @@ def get_test_suite(suite):
 ###############################################################################
     expect(suite in _TEST_SUITES, "Unknown test suite: '%s'" % suite)
     inherits_from, tests = _TEST_SUITES[suite]
+    tests = list(tests)
     if (inherits_from is not None):
         inherited_tests = get_test_suite(inherits_from)
+
         expect(len(set(tests) & set(inherited_tests)) == 0,
-               "Tests %s defined in multiple suites" % ", ".join(set(tests) & set(inherited_tests)))
+               "Tests %s defined in multiple suites" % ", ".join(set(item[0] for item in tests) & set(item[0] for item in inherited_tests)))
         tests.extend(inherited_tests)
     return tests
 


### PR DESCRIPTION
Inherited tests were being added to the global data structure, corrupting it.

[BFB]
