### PR TITLE
jenkins_script: deinit submodules post-run

### DIFF
--- a/cime/scripts-acme/jenkins_script
+++ b/cime/scripts-acme/jenkins_script
@@ -13,3 +13,7 @@ SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
 DATE_STAMP=$(date "+%Y-%m-%d_%H%M%S")
 
 $SCRIPT_DIR/jenkins_generic_job "$@" >& JENKINS_$DATE_STAMP
+
+for SUB in $(git submodule status | awk '{print $2}'); do
+    git submodule deinit ${SUB}
+done


### PR DESCRIPTION
Jenkins randomly fails to fetch with populated submodules, even
with the 'do not process submodules' flag checked. This change will
force jenkins to deinitialize submodules at the end of each run which
should ensure that the subsequent fetch for the next night's run will
work. The initialization is happens in jenkins_generic_job.

This implementation won't work for timed-out jobs, but that hasn't
been a problem lately and we should be getting a better fix for
submodules on Jenkins soon.

[BFB]
