### PR TITLE
Titan Intel changed from 14 to 15

### DIFF
--- a/cime/machines-acme/env_mach_specific.titan
+++ b/cime/machines-acme/env_mach_specific.titan
@@ -69,7 +69,7 @@ if (-e /opt/modules/default/init/csh) then
 
   if ( $COMPILER == "intel" ) then
       module load PrgEnv-intel 
-      module switch intel intel/14.0.2.144
+      module switch intel intel/15.0.2.164
       module switch cray-libsci cray-libsci/13.0.4
       module switch cray-mpich cray-mpich/7.2.5
       module switch atp atp/1.7.5


### PR DESCRIPTION
Changing Titan's Intel from 14 to 15 because of qneg warnings associated with Intel 14 that go away with Intel 15. Currently testing an ERS case on Titan with the intel compiler before committing to next and master.
