### PR TITLE
create_test: Dodge 'bad interpreter' error in build phase

### DIFF
--- a/cime/scripts-acme/create_test_impl.py
+++ b/cime/scripts-acme/create_test_impl.py
@@ -172,15 +172,24 @@ class CreateTest(object):
     ###########################################################################
     def _run_phase_command(self, test_name, cmd, phase, from_dir=None):
     ###########################################################################
-        rc, output, errput = run_cmd(cmd, ok_to_fail=True, from_dir=from_dir)
-        if (rc != 0):
-            self._log_output(test_name,
-                             "%s FAILED for test '%s'.\nCommand: %s\nOutput: %s\n\nErrput: %s" %
-                             (phase, test_name, cmd, output, errput))
-        else:
-            self._log_output(test_name,
-                             "%s PASSED for test '%s'.\nCommand: %s\nOutput: %s\n\nErrput: %s" %
-                             (phase, test_name, cmd, output, errput))
+        while (True):
+            rc, output, errput = run_cmd(cmd, ok_to_fail=True, from_dir=from_dir)
+            if (rc != 0):
+                self._log_output(test_name,
+                                 "%s FAILED for test '%s'.\nCommand: %s\nOutput: %s\n\nErrput: %s" %
+                                 (phase, test_name, cmd, output, errput))
+                # Temporary hack to get around odd file descriptor use by
+                # buildnml scripts.
+                if ("bad interpreter" in errput):
+                    time.sleep(1)
+                    continue
+                else:
+                    break
+            else:
+                self._log_output(test_name,
+                                 "%s PASSED for test '%s'.\nCommand: %s\nOutput: %s\n\nErrput: %s" %
+                                 (phase, test_name, cmd, output, errput))
+                break
 
         return rc == 0
 


### PR DESCRIPTION
This error is only generated when the filesystem is modifying
the script as it's trying to be run. We dodge this error by
simply re-running until this error goes away.

Debugging by dumping all processes that are touching the test_build
script revealed that buildnml scripts are allegedly touching
test_build scripts in other cases. A visual inspection of the code
did not indicate any place were this might be happening.

One thing that is clear is that the buildnml scripts are wastefully
forking a huge number of processes to read/write XML. We could probably
greatly simply and speed up these scripts.

[BFB]
