### PR TITLE
Corrects the intent of an argument in ALM-BeTR

### DIFF
--- a/components/clm/src/betr/bgc_century/BGCCenturySubMod.F90
+++ b/components/clm/src/betr/bgc_century/BGCCenturySubMod.F90
@@ -38,7 +38,7 @@ contains
     ! !ARGUMENTS:
     integer                       , intent(in)  :: nstvars
     integer                       , intent(in)  :: nreactions
-    type(centurybgc_type)         , intent(in)  :: centurybgc_vars
+    type(centurybgc_type)         , intent(inout):: centurybgc_vars
     real(r8)                      , intent(in)  :: cn_ratios(centurybgc_vars%nom_pools)
     real(r8)                      , intent(in)  :: cp_ratios(centurybgc_vars%nom_pools)
     real(r8)                      , intent(in)  :: n2_n2o_ratio_denit                             !ratio of n2 to n2o during denitrification


### PR DESCRIPTION
Fix a bug regarding intent of an argument that only Intel 13.1 on Blues complained about.

Fixes #471

[BFB]
