### PR TITLE
Hack component_comare_test.sh to not do the POP restart check

### DIFF
--- a/cime/scripts/Tools/component_compare_test.sh
+++ b/cime/scripts/Tools/component_compare_test.sh
@@ -222,6 +222,10 @@ for model in ${models[*]}; do
 	extensions=(h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 hs)
     elif [ "$model" = "pop" ]; then
 	extensions=(h)
+        if [ "$suffix2" = "rest" ]; then
+            # Skip restart checks for pop! Temporary hack until MPAS goes in!
+            continue
+        fi
     fi
 
     #------------------------------------------------------------------


### PR DESCRIPTION
This is temporarily needed to dodge the broken POP restart
checking that occurred when we updated to CIME, which checks POP restarts
 in an ERS test but POP had not been updated to work with CIME.  Once we have
all the compsets using MPAS, we can throw this away.

[BFB]
