### PR TITLE
Add bld/run log data to TestStatus.log

### DIFF
--- a/cime/scripts-acme/create_test_impl.py
+++ b/cime/scripts-acme/create_test_impl.py
@@ -333,7 +333,20 @@ class CreateTest(object):
     ###########################################################################
         case_id = self._get_case_id(test_name)
         test_dir = self._get_test_dir(test_name)
-        return self._run_phase_command(test_name, "./%s.test_build" % case_id, BUILD_PHASE, from_dir=test_dir)
+        success = self._run_phase_command(test_name, "./%s.test_build" % case_id, BUILD_PHASE, from_dir=test_dir)
+
+        if (not success):
+            bld_dir = acme_util.get_machine_info("EXEROOT", project=self._project, case=case_id)
+            stat, output, _ = run_cmd("grep -l ERROR %s/*log*" % bld_dir, ok_to_fail=True)
+            if (stat == 0):
+                for filename in output.splitlines():
+                    self._log_output(test_name, "###############################################################################")
+                    self._log_output(test_name, "Log data for broken build from '%s'" % filename)
+                    self._log_output(test_name, open(filename, "r").read())
+            else:
+                warning("Build failed but no ERROR appeared in logs")
+
+        return success
 
     ###########################################################################
     def _run_phase(self, test_name):

--- a/cime/scripts/Tools/testcase_setup
+++ b/cime/scripts/Tools/testcase_setup
@@ -182,6 +182,13 @@ print $tfwfh "mv -f $caseroot/TestStatus.new $caseroot/TestStatus$eol";
 
 print $tfwfh "if (\$testrc != 0) then$eol";
 print $tfwfh "  echo 'FAIL $casebaseid RUN' >> $caseroot/TestStatus$eol";
+
+print $tfwfh "  foreach logfile ($rundir/*log*)$eol";
+print $tfwfh "    echo '###############################################################################' >> $caseroot/TestStatus.log$eol";
+print $tfwfh "    echo 'Log data for broken run from ' \$logfile >> $caseroot/TestStatus.log$eol";
+print $tfwfh "    cat \$logfile >> $caseroot/TestStatus.log$eol";
+print $tfwfh "  end$eol";
+
 print $tfwfh "else$eol";
 print $tfwfh "  echo 'PASS $casebaseid RUN' >> $caseroot/TestStatus$eol";
 print $tfwfh "endif$eol";


### PR DESCRIPTION
This will allow anyone to see bld/run log data from CDash, although
it will make this file quite long. The browser search function should
be used to look for things. Build logs are only added if there's a build
failure and only the failing model should be added. Run logs are added
only if ACME did not complete. Unlike the build logs, ALL run logs will
be added if the run failed.

[BFB]
