### PR TITLE
Fixed broken polar mods due to clubbe integration into ZM conv scheme

### DIFF
--- a/components/cam/src/physics/cam/convect_deep.F90
+++ b/components/cam/src/physics/cam/convect_deep.F90
@@ -281,7 +281,8 @@ subroutine convect_deep_tend( &
           rliq    , &
           ztodt   , &
           jctop, jcbot , &
-          state   ,ptend   ,landfrac, pbuf)
+          state   ,ptend   ,landfrac, pbuf, mu, eu, &
+          du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath)
 
 
   end select
@@ -341,7 +342,8 @@ subroutine convect_deep_tend_2( state,  ptend,  ztodt, pbuf, mu, eu, &
    integer, intent(in) :: species_class(:)
 
    if ( deep_scheme .eq. 'ZM' ) then  !    1 ==> Zhang-McFarlane (default)
-      call zm_conv_tend_2( state,   ptend,  ztodt,  pbuf, species_class) 
+      call zm_conv_tend_2( state,   ptend,  ztodt,  pbuf,mu, eu, &
+     du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath, species_class) 
    else
       call physics_ptend_init(ptend, state%psetcols, 'convect_deep')
    end if


### PR DESCRIPTION
This commit fixes broken Polar mods implementation.This happened due
to the incorporation of a newer version of ZM ssubroutines brought in by
CLUBBe merge.

Some variables which were required by the polar mods were not passed
in correctly in the ZM scheme. The branch fixes those variables. I
have tested the model with intel (w and w/o debug flags) and NAG
compiler with debug flags. The code runs fine and passes FC5PLMOD test
in the testing suite.

[BFB]

AG-391
