### PR TITLE
Rework ACME scripts testing

### DIFF
--- a/cime/machines-acme/template.cesmrun
+++ b/cime/machines-acme/template.cesmrun
@@ -364,7 +364,7 @@ sub postRun()
         print $CS "Run FAILED $sdate\n";
         exit(-1);
     }
-	elsif( -e "$config{'RUNDIR'}/$cpllogfile")
+    elsif( -e "$config{'RUNDIR'}/$cpllogfile")
     {
         open my $CPLLOG, "<", "$config{'RUNDIR'}/$cpllogfile" or warn "could not open $config{'RUNDIR'}/$cpllogfile, $!";
         my @cpllines = <$CPLLOG>;

--- a/cime/scripts-acme/create_test
+++ b/cime/scripts-acme/create_test
@@ -176,50 +176,13 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
         args.clean, args.compare, args.generate, args.baseline_name, args.namelists_only, args.project, args.test_id, args.old, args.parallel_jobs
 
 ###############################################################################
-def get_tests_from_args(testargs, machine, compiler):
-###############################################################################
-    """
-    Return full test names in the form:
-    TESTCASE.GRID.COMPSET.MACHINE_COMPILER.TESTMODS
-    Testmods are optional
-
-    # TODO - Unit test
-    """
-    acme_test_suites = update_acme_tests.get_test_suites()
-
-    tests_to_run = set()
-    negations = set()
-
-    for testarg in testargs:
-        if (testarg.startswith("^")):
-            negations.add(testarg)
-        elif (testarg in acme_test_suites):
-            for test, testmod in update_acme_tests.get_test_suite(testarg):
-                tests_to_run.add(acme_util.get_full_test_name(test, machine, compiler, testmod))
-        else:
-            tests_to_run.add(acme_util.get_full_test_name(testarg, machine, compiler))
-
-    for negation in negations:
-        if (negation in acme_test_suites):
-            for test, testmod in update_acme_tests.get_test_suite(negation):
-                fullname = acme_util.get_full_test_name(test, machine, compiler, testmod)
-                if (fullname in tests_to_run):
-                    tests_to_run.remove(fullname)
-        else:
-            fullname = acme_util.get_full_test_name(negation, machine, compiler)
-            if (fullname in tests_to_run):
-                tests_to_run.remove(fullname)
-
-    return list(sorted(tests_to_run))
-
-###############################################################################
 def create_test(testargs, compiler, no_run, no_build, no_batch, test_root,
                 baseline_root, clean, compare, generate,
                 baseline_name, namelists_only, project, test_id, old, parallel_jobs):
 ###############################################################################
     machine = acme_util.probe_machine_name()
 
-    tests_to_run = get_tests_from_args(testargs, machine, compiler)
+    tests_to_run = update_acme_tests.get_full_test_names(testargs, machine, compiler)
 
     if (parallel_jobs is None):
         parallel_jobs = min(len(tests_to_run), int(acme_util.get_machine_info("MAX_TASKS_PER_NODE")))
@@ -228,12 +191,12 @@ def create_test(testargs, compiler, no_run, no_build, no_batch, test_root,
 
     if (not old):
         impl = create_test_impl.CreateTest(tests_to_run,
-                                           no_run, no_build, no_batch,
-                                           test_root, test_id,
-                                           baseline_root, baseline_name,
-                                           clean,
-                                           compare, generate, namelists_only,
-                                           project, parallel_jobs)
+                                           no_run=no_run, no_build=no_build, no_batch=no_batch,
+                                           test_root=test_root, test_id=test_id,
+                                           baseline_root=baseline_root, baseline_name=baseline_name,
+                                           clean=clean, compiler=compiler,
+                                           compare=compare, generate=generate, namelists_only=namelists_only,
+                                           project=project, parallel_jobs=parallel_jobs)
         return 0 if impl.create_test() else 1
     else:
 

--- a/cime/scripts-acme/create_test_impl.py
+++ b/cime/scripts-acme/create_test_impl.py
@@ -24,29 +24,33 @@ class CreateTest(object):
 
     ###########################################################################
     def __init__(self, test_names,
-                 no_run, no_build, no_batch,
-                 test_root, test_id,
-                 baseline_root, baseline_name,
-                 clean,
-                 compare, generate, namelists_only,
-                 project, parallel_jobs):
+                 no_run=False, no_build=False, no_batch=None,
+                 test_root=None, test_id=None,
+                 compiler=None,
+                 baseline_root=None, baseline_name=None,
+                 clean=False,
+                 compare=False, generate=False, namelists_only=False,
+                 project=None, parallel_jobs=None):
     ###########################################################################
+        self._cime_root      = acme_util.get_cime_root()
         self._test_names     = test_names
-        self._no_run         = no_run
-        self._no_build       = no_build
-        self._no_batch       = no_batch
-        self._test_root      = test_root
-        self._test_id        = test_id
-        self._baseline_root  = baseline_root
-        self._baseline_name  = baseline_name
+        self._no_build       = no_build      if not namelists_only else True
+        self._no_run         = no_run        if not self._no_build else True
+        self._no_batch       = no_batch      if no_batch is not None else not acme_util.does_machine_have_batch()
+        self._test_root      = test_root     if test_root is not None else acme_util.get_machine_info("CESMSCRATCHROOT")
+        self._test_id        = test_id       if test_id is not None else acme_util.get_utc_timestamp()
+        self._project        = project       if project is not None else acme_util.get_machine_project()
+        self._baseline_root  = baseline_root if baseline_root is not None else acme_util.get_machine_info("CCSM_BASELINE", project=self._project)
+        self._compiler       = compiler      if compiler is not None else acme_util.get_machine_info("COMPILERS")[0]
+        self._baseline_name  = baseline_name if baseline_name is not None else os.path.join(self._compiler, acme_util.get_current_branch(repo=self._cime_root))
         self._clean          = clean
         self._compare        = compare
         self._generate       = generate
         self._namelists_only = namelists_only
-        self._project        = project
-        self._parallel_jobs  = parallel_jobs
+        self._parallel_jobs  = parallel_jobs if parallel_jobs is not None else min(len(self._test_names), int(acme_util.get_machine_info("MAX_TASKS_PER_NODE")))
 
-        self._cime_root      = acme_util.get_cime_root()
+        if (not self._baseline_name.startswith("%s/" % self._compiler)):
+            self._baseline_name = os.path.join(self._compiler, self._baseline_name)
 
         # Oversubscribe by 1/4
         pes = int(acme_util.get_machine_info("MAX_TASKS_PER_NODE"))
@@ -107,15 +111,12 @@ class CreateTest(object):
         return os.path.join(self._test_root, self._get_case_id(test_name))
 
     ###########################################################################
-    def _get_test_data(self, test_name, idx=None):
+    def _get_test_data(self, test_name):
     ###########################################################################
         assert self._mutex.locked()
 
         state_idx = self._test_names.index(test_name)
-        if (idx is None):
-            return self._test_states[state_idx]
-        else:
-            return self._test_states[state_idx][idx]
+        return self._test_states[state_idx]
 
     ###########################################################################
     def _is_broken(self, test_name):
@@ -135,7 +136,7 @@ class CreateTest(object):
         if (phase == NAMELIST_PHASE and test_name in self._tests_with_nl_problems):
             return NAMELIST_FAIL_STATUS
         elif (phase is None or phase == self._get_test_phase(test_name)):
-            return self._get_test_data(test_name, 1)
+            return self._get_test_data(test_name)[1]
         else:
             expect(phase is None or self._phases.index(phase) < self._phases.index(self._get_test_phase(test_name)),
                    "Tried to see the future")
@@ -145,7 +146,7 @@ class CreateTest(object):
     ###########################################################################
     def _get_test_phase(self, test_name):
     ###########################################################################
-        return self._get_test_data(test_name, 0)
+        return self._get_test_data(test_name)[0]
 
     ###########################################################################
     def _update_test_status(self, test_name, phase, status):
@@ -164,6 +165,8 @@ class CreateTest(object):
         else:
             expect(old_status in CONTINUE,
                    "Why did we move on to next phase when prior phase did not pass?")
+            expect(status == TEST_PENDING_STATUS,
+                   "New phase should be set to pending status")
             expect(self._phases.index(old_phase) == phase_idx - 1,
                    "Skipped phase?")
 
@@ -199,6 +202,8 @@ class CreateTest(object):
         test_dir = self._get_test_dir(test_name)
 
         test_case, case_opts, grid, compset, machine, compiler, test_mods = acme_util.parse_test_name(test_name)
+        if (compiler != self._compiler):
+            raise StandardError("Test '%s' has compiler that does not match instance compliler '%s'" % (test_name, self._compiler))
         if (self._parallel_jobs == 1):
             scratch_dir = acme_util.get_machine_info("CESMSCRATCHROOT", machine=machine, project=self._project)
             sharedlibroot = os.path.join(scratch_dir, "sharedlibroot.%s" % self._test_id)

--- a/cime/scripts-acme/tests/scripts_regression_tests
+++ b/cime/scripts-acme/tests/scripts_regression_tests
@@ -5,7 +5,7 @@ import unittest, sys, os, tempfile, shutil, re, threading, time, signal, glob, s
 SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(SCRIPT_DIR)
 from acme_util import run_cmd
-import acme_util, update_acme_tests
+import acme_util, update_acme_tests, create_test_impl, wait_for_tests
 
 DART_CONFIG = "DartConfiguration.tcl"
 DART_BACKUP = "temp_dart_backup"
@@ -287,79 +287,7 @@ class TestWaitForTests(unittest.TestCase):
         # TODO: Any further checking of xml output worth doing?
 
 ###############################################################################
-class TestCreateTest(unittest.TestCase):
-###############################################################################
-
-    ###########################################################################
-    def setUp(self):
-    ###########################################################################
-        self._baseline_name = "fake_testing_only_%s" % acme_util.get_utc_timestamp()
-
-    ###########################################################################
-    def tearDown(self):
-    ###########################################################################
-        baseline_area = acme_util.get_machine_info("CCSM_BASELINE")
-        compiler      = acme_util.get_machine_info("COMPILERS")[0]
-        baselines = os.path.join(baseline_area, compiler, self._baseline_name)
-        if (os.path.isdir(baselines)):
-            shutil.rmtree(baselines)
-
-    ###########################################################################
-    def simple_test(self, expect_works, extra_args):
-    ###########################################################################
-        stat, output, errput = run_cmd("%s/create_test acme_tiny %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
-        if (expect_works):
-            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s" % (output, errput))
-        else:
-            self.assertNotEqual(stat, 0, msg="COMMAND SHOULD HAVE FAILED\ncreate_test output:\n%s\n\nerrput:\n%s" % (output, errput))
-
-    ###############################################################################
-    def test_create_test_rebless_namelist(self):
-    ###############################################################################
-        # Generate some namelist baselines
-        self.simple_test(True, "-g -n -b %s" % self._baseline_name)
-
-        # Basic namelist compare
-        self.simple_test(True, "-c -n -b %s" % self._baseline_name)
-
-        # Modify namelist
-        fake_nl = """
- &fake_nml
-   fake_item = 'fake'
-   fake = .true.
-/"""
-        baseline_area = acme_util.get_machine_info("CCSM_BASELINE")
-        compiler      = acme_util.get_machine_info("COMPILERS")[0]
-        baseline_glob = glob.glob(os.path.join(baseline_area, compiler, self._baseline_name, "ERS*"))
-        self.assertEqual(len(baseline_glob), 1, msg="Expected one match, got:\n%s" % "\n".join(baseline_glob))
-
-        baseline_dir = baseline_glob[0]
-        nl_path = os.path.join(baseline_dir, "CaseDocs", "datm_in")
-        self.assertTrue(os.path.isfile(nl_path), msg="Missing file %s" % nl_path)
-
-        import stat
-        os.chmod(nl_path, stat.S_IRUSR | stat.S_IWUSR)
-        with open(nl_path, "a") as nl_file:
-            nl_file.write(fake_nl)
-
-        # Basic namelist compare should now fail
-        self.simple_test(False, "-c -n -b %s" % self._baseline_name)
-
-        # Regen
-        self.simple_test(True, "-g -n -b %s" % self._baseline_name)
-
-        # Basic namelist compare should now pass again
-        self.simple_test(True, "-c -n -b %s" % self._baseline_name)
-
-    ###########################################################################
-    def test_create_test_failed_test(self):
-    ###########################################################################
-        # TODO
-        # Need to ensure that TestStatus not being left in RUN/PEND state
-        pass
-
-###############################################################################
-class TestJenkinsGenericJob(unittest.TestCase):
+class TestCreateTestCommon(unittest.TestCase):
 ###############################################################################
 
     ###########################################################################
@@ -368,8 +296,11 @@ class TestJenkinsGenericJob(unittest.TestCase):
         self._thread_error      = None
         self._unset_proxy       = setup_proxy()
         self._baseline_name     = "fake_testing_only_%s" % acme_util.get_utc_timestamp()
+        self._baseline_area      = acme_util.get_machine_info("CCSM_BASELINE")
         self._testroot          = acme_util.get_machine_info("CESMSCRATCHROOT")
         self._jenkins_root      = os.path.join(self._testroot, "jenkins")
+        self._machine           = acme_util.probe_machine_name()
+        self._compiler          = acme_util.get_machine_info("COMPILERS")[0]
 
         # wait_for_tests could blow away our dart config, need to back it up
         if (os.path.exists(DART_CONFIG)):
@@ -383,9 +314,7 @@ class TestJenkinsGenericJob(unittest.TestCase):
         if (self._unset_proxy):
             del os.environ["http_proxy"]
 
-        baseline_area = acme_util.get_machine_info("CCSM_BASELINE")
-        compiler      = acme_util.get_machine_info("COMPILERS")[0]
-        baselines = os.path.join(baseline_area, compiler, self._baseline_name)
+        baselines = os.path.join(self._baseline_area, self._compiler, self._baseline_name)
         if (os.path.isdir(baselines)):
             shutil.rmtree(baselines)
 
@@ -399,10 +328,168 @@ class TestJenkinsGenericJob(unittest.TestCase):
         if (os.path.exists(DART_BACKUP)):
             shutil.move(DART_BACKUP, DART_CONFIG)
 
+###############################################################################
+class TestCreateTest(TestCreateTestCommon):
+###############################################################################
+
     ###########################################################################
     def simple_test(self, expect_works, extra_args):
     ###########################################################################
-        stat, output, errput = run_cmd("%s/jenkins_generic_job -t acme_tiny %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
+        stat, output, errput = run_cmd("%s/create_test acme_test_only_pass %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
+        if (expect_works):
+            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s" % (output, errput))
+        else:
+            self.assertNotEqual(stat, 0, msg="COMMAND SHOULD HAVE FAILED\ncreate_test output:\n%s\n\nerrput:\n%s" % (output, errput))
+
+    ###############################################################################
+    def test_create_test_rebless_namelist(self):
+    ###############################################################################
+        # Generate some namelist baselines
+        self.simple_test(True, "-g -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, acme_util.get_utc_timestamp()))
+
+        # Basic namelist compare
+        self.simple_test(True, "-c -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, acme_util.get_utc_timestamp()))
+
+        # Modify namelist
+        fake_nl = """
+ &fake_nml
+   fake_item = 'fake'
+   fake = .true.
+/"""
+        baseline_area = acme_util.get_machine_info("CCSM_BASELINE")
+        compiler      = acme_util.get_machine_info("COMPILERS")[0]
+        baseline_glob = glob.glob(os.path.join(baseline_area, compiler, self._baseline_name, "TEST*"))
+        self.assertEqual(len(baseline_glob), 3, msg="Expected three matches, got:\n%s" % "\n".join(baseline_glob))
+
+        baseline_dir = baseline_glob[0]
+        nl_path = os.path.join(baseline_dir, "CaseDocs", "datm_in")
+        self.assertTrue(os.path.isfile(nl_path), msg="Missing file %s" % nl_path)
+
+        import stat
+        os.chmod(nl_path, stat.S_IRUSR | stat.S_IWUSR)
+        with open(nl_path, "a") as nl_file:
+            nl_file.write(fake_nl)
+
+        # Basic namelist compare should now fail
+        self.simple_test(False, "-c -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, acme_util.get_utc_timestamp()))
+
+        # Regen
+        self.simple_test(True, "-g -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, acme_util.get_utc_timestamp()))
+
+        # Basic namelist compare should now pass again
+        self.simple_test(True, "-c -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, acme_util.get_utc_timestamp()))
+
+###############################################################################
+class TestCreateTestImpl(TestCreateTestCommon):
+###############################################################################
+
+    ###########################################################################
+    def test_phases(self):
+    ###########################################################################
+        tests = update_acme_tests.get_full_test_names(["acme_test_only"], self._machine, self._compiler)
+        ct = create_test_impl.CreateTest(tests)
+
+        build_fail_test = tests[0]
+        run_fail_test   = tests[1]
+        pass_test       = tests[2]
+
+        self.assertTrue("BUILDFAIL" in build_fail_test, msg="Wrong test '%s'" % build_fail_test)
+        self.assertTrue("RUNFAIL" in run_fail_test, msg="Wrong test '%s'" % run_fail_test)
+        self.assertTrue("RUNPASS" in pass_test, msg="Wrong test '%s'" % pass_test)
+
+        with ct._mutex:
+            for idx, phase in enumerate(ct._phases):
+                for test in tests:
+                    if (phase == create_test_impl.INITIAL_PHASE):
+                        continue
+
+                    elif (phase == create_test_impl.BUILD_PHASE):
+                        ct._update_test_status(test, phase, wait_for_tests.TEST_PENDING_STATUS)
+
+                        if (test == build_fail_test):
+                            ct._update_test_status(test, phase, wait_for_tests.TEST_FAIL_STATUS)
+                            self.assertTrue(ct._is_broken(test))
+                            self.assertFalse(ct._work_remains(test))
+                        else:
+                            ct._update_test_status(test, phase, wait_for_tests.TEST_PASS_STATUS)
+                            self.assertFalse(ct._is_broken(test))
+                            self.assertTrue(ct._work_remains(test))
+
+                    elif (phase == create_test_impl.RUN_PHASE):
+                        if (test == build_fail_test):
+                            with self.assertRaises(SystemExit):
+                                ct._update_test_status(test, phase, wait_for_tests.TEST_PENDING_STATUS)
+                        else:
+                            ct._update_test_status(test, phase, wait_for_tests.TEST_PENDING_STATUS)
+                            self.assertFalse(ct._work_remains(test))
+
+                            if (test == run_fail_test):
+                                ct._update_test_status(test, phase, wait_for_tests.TEST_FAIL_STATUS)
+                                self.assertTrue(ct._is_broken(test))
+                            else:
+                                ct._update_test_status(test, phase, wait_for_tests.TEST_PASS_STATUS)
+                                self.assertFalse(ct._is_broken(test))
+
+                        self.assertFalse(ct._work_remains(test))
+
+                    else:
+                        with self.assertRaises(SystemExit):
+                            ct._update_test_status(test, ct._phases[idx+1], wait_for_tests.TEST_PENDING_STATUS)
+
+                        with self.assertRaises(SystemExit):
+                            ct._update_test_status(test, phase, wait_for_tests.TEST_PASS_STATUS)
+
+                        ct._update_test_status(test, phase, wait_for_tests.TEST_PENDING_STATUS)
+                        self.assertFalse(ct._is_broken(test))
+                        self.assertTrue(ct._work_remains(test))
+
+                        with self.assertRaises(SystemExit):
+                            ct._update_test_status(test, phase, wait_for_tests.TEST_PENDING_STATUS)
+
+                        ct._update_test_status(test, phase, wait_for_tests.TEST_PASS_STATUS)
+
+                        with self.assertRaises(SystemExit):
+                            ct._update_test_status(test, phase, wait_for_tests.TEST_FAIL_STATUS)
+
+                        self.assertFalse(ct._is_broken(test))
+                        self.assertTrue(ct._work_remains(test))
+
+    ###########################################################################
+    def test_full(self):
+    ###########################################################################
+        tests = update_acme_tests.get_full_test_names(["acme_test_only"], self._machine, self._compiler)
+        test_id="%s-%s" % (self._baseline_name, acme_util.get_utc_timestamp())
+        ct = create_test_impl.CreateTest(tests, test_id=test_id)
+
+        build_fail_test = tests[0]
+        run_fail_test   = tests[1]
+        pass_test       = tests[2]
+
+        ct.create_test()
+        if (acme_util.does_machine_have_batch()):
+            run_cmd("%s/wait_for_tests *%s*/TestStatus*" % (SCRIPT_DIR, test_id), ok_to_fail=True, from_dir=self._testroot)
+
+        test_statuses = glob.glob("%s/*%s*/TestStatus" % (self._testroot, test_id))
+        self.assertEqual(len(tests), len(test_statuses))
+
+        for test_status in test_statuses:
+            status, test_name = wait_for_tests.parse_test_status_file(test_status)
+            if (test_name == build_fail_test):
+                self.assertEqual(status[create_test_impl.BUILD_PHASE], wait_for_tests.TEST_FAIL_STATUS)
+            elif (test_name == run_fail_test):
+                self.assertEqual(status[create_test_impl.RUN_PHASE], wait_for_tests.TEST_FAIL_STATUS)
+            else:
+                self.assertEqual(test_name, pass_test)
+                self.assertEqual(status[create_test_impl.RUN_PHASE], wait_for_tests.TEST_PASS_STATUS)
+
+###############################################################################
+class TestJenkinsGenericJob(TestCreateTestCommon):
+###############################################################################
+
+    ###########################################################################
+    def simple_test(self, expect_works, extra_args):
+    ###########################################################################
+        stat, output, errput = run_cmd("%s/jenkins_generic_job -t acme_test_only_pass %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
         if (expect_works):
             self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
         else:
@@ -429,7 +516,7 @@ class TestJenkinsGenericJob(unittest.TestCase):
         # the testroot (bld/run dump area) and jenkins root
         if (test_id is None):
             test_id = self._baseline_name
-        num_tests_in_tiny = len(update_acme_tests.get_test_suite("acme_tiny"))
+        num_tests_in_tiny = len(update_acme_tests.get_test_suite("acme_test_only_pass"))
 
         jenkins_dirs = glob.glob("%s/*%s*/" % (self._jenkins_root, test_id))
         scratch_dirs = glob.glob("%s/*%s*/" % (self._testroot, test_id))
@@ -454,7 +541,7 @@ class TestJenkinsGenericJob(unittest.TestCase):
 
         build_name = "jenkins_generic_job_pass_%s" % acme_util.get_utc_timestamp()
         self.simple_test(True, "-p ACME_test -b %s -d -c %s --cdash-build-group=Nightly" % (self._baseline_name, build_name))
-        self.assert_num_leftovers()
+        self.assert_num_leftovers() # jenkins_generic_job should have automatically cleaned up leftovers from prior run
         self.assert_no_sentinel()
         assert_dashboard_has_build(self, build_name)
 
@@ -497,7 +584,7 @@ class TestUpdateACMETests(unittest.TestCase):
     def test_update_acme_tests(self):
     ###########################################################################
         # Add some BS to acme tests
-        update_acme_tests._TEST_SUITES["acme_test_only"] = \
+        update_acme_tests._TEST_SUITES["acme_tiny"] = \
             (None, [("ERS.f19_g16_rx1.A", "test/test_mod"),
                     ("NCK.f19_g16_rx1.A", "test/test_mod")]
              )

--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -11,11 +11,25 @@ _TEST_SUITES = {
                    [("ERS.f19_g16_rx1.A", None),
                     ("NCK.f19_g16_rx1.A", None)]
                    ),
+
+    "acme_test_only_pass" : (None,
+                   [("TESTRUNPASS_P1.f19_g16_rx1.A", None),
+                    ("TESTRUNPASS_P1.ne30_g16_rx1.A", None),
+                    ("TESTRUNPASS_P1.f45_g37_rx1.A", None)]
+                   ),
+
+    "acme_test_only" : (None,
+                   [("TESTBUILDFAIL.f19_g16_rx1.A", None),
+                    ("TESTRUNFAIL_P1.f19_g16_rx1.A", None),
+                    ("TESTRUNPASS_P1.f19_g16_rx1.A", None)]
+                   ),
+
     "acme_land_developer" : (None,
                              [("SMS.f19_f19.I1850CLM45CN", None),
                               ("SMS.f09_g16.I1850CLM45CN", None),
                               ("SMS.hcru_hcru.I1850CRUCLM45CN", None)]
                              ),
+
     "acme_developer" : ("acme_land_developer",
                         [("ERS.f19_g16_rx1.A", None),
                          ("ERS.f45_g37_rx1.DTEST", None),
@@ -37,6 +51,7 @@ _TEST_SUITES = {
                          ("SMS.T62_mpas120_gis20.MPAS_LISIO_TEST", None),
                          ("SMS.f09_g16_a.IGCLM45_MLI", None)]
                         ),
+
     "acme_integration" : ("acme_developer",
                           [("ERS.ne30_g16.B1850C5", None),
                            ("ERS.f19_f19.FAMIPC5", None),
@@ -77,6 +92,55 @@ def get_test_suite(suite):
 def get_test_suites():
 ###############################################################################
     return _TEST_SUITES.keys()
+
+###############################################################################
+def get_full_test_names(testargs, machine, compiler):
+###############################################################################
+    """
+    Return full test names in the form:
+    TESTCASE.GRID.COMPSET.MACHINE_COMPILER.TESTMODS
+    Testmods are optional
+
+    Testargs can be categories or test names and support the NOT symbol '^'
+
+    >>> get_full_test_names(["acme_tiny"], "melvin", "gnu")
+    ['ERS.f19_g16_rx1.A.melvin_gnu', 'NCK.f19_g16_rx1.A.melvin_gnu']
+
+    >>> get_full_test_names(["acme_tiny", "PEA_P1_M.f45_g37_rx1.A"], "melvin", "gnu")
+    ['ERS.f19_g16_rx1.A.melvin_gnu', 'NCK.f19_g16_rx1.A.melvin_gnu', 'PEA_P1_M.f45_g37_rx1.A.melvin_gnu']
+
+    >>> get_full_test_names(['ERS.f19_g16_rx1.A', 'NCK.f19_g16_rx1.A', 'PEA_P1_M.f45_g37_rx1.A'], "melvin", "gnu")
+    ['ERS.f19_g16_rx1.A.melvin_gnu', 'NCK.f19_g16_rx1.A.melvin_gnu', 'PEA_P1_M.f45_g37_rx1.A.melvin_gnu']
+
+    >>> get_full_test_names(["acme_tiny", "^NCK.f19_g16_rx1.A"], "melvin", "gnu")
+    ['ERS.f19_g16_rx1.A.melvin_gnu']
+    """
+    acme_test_suites = get_test_suites()
+
+    tests_to_run = set()
+    negations = set()
+
+    for testarg in testargs:
+        if (testarg.startswith("^")):
+            negations.add(testarg[1:])
+        elif (testarg in acme_test_suites):
+            for test, testmod in get_test_suite(testarg):
+                tests_to_run.add(acme_util.get_full_test_name(test, machine, compiler, testmod))
+        else:
+            tests_to_run.add(acme_util.get_full_test_name(testarg, machine, compiler))
+
+    for negation in negations:
+        if (negation in acme_test_suites):
+            for test, testmod in get_test_suite(negation):
+                fullname = acme_util.get_full_test_name(test, machine, compiler, testmod)
+                if (fullname in tests_to_run):
+                    tests_to_run.remove(fullname)
+        else:
+            fullname = acme_util.get_full_test_name(negation, machine, compiler)
+            if (fullname in tests_to_run):
+                tests_to_run.remove(fullname)
+
+    return list(sorted(tests_to_run))
 
 ###############################################################################
 def find_all_supported_platforms():

--- a/cime/scripts/Testing/Testcases/TESTBUILDFAIL_build.csh
+++ b/cime/scripts/Testing/Testcases/TESTBUILDFAIL_build.csh
@@ -1,0 +1,10 @@
+#!/bin/csh -f
+
+./Tools/check_lockedfiles || exit -1
+
+set EXEROOT  = `./xmlquery EXEROOT -value`
+set TESTID   = `./xmlquery TEST_TESTID -value`
+
+echo "ERROR: Intentional fail for testing infrastructure" | tee $EXEROOT/cesm.bldlog.$TESTID
+
+exit -1

--- a/cime/scripts/Testing/Testcases/TESTBUILDFAIL_script
+++ b/cime/scripts/Testing/Testcases/TESTBUILDFAIL_script
@@ -1,0 +1,2 @@
+# Should never make it here
+exit -1

--- a/cime/scripts/Testing/Testcases/TESTRUNFAIL_build.csh
+++ b/cime/scripts/Testing/Testcases/TESTRUNFAIL_build.csh
@@ -1,0 +1,22 @@
+#!/bin/csh -f
+
+./Tools/check_lockedfiles || exit -1
+
+set EXEROOT  = `./xmlquery EXEROOT -value`
+set RUNDIR   = `./xmlquery RUNDIR -value`
+set TESTID   = `./xmlquery TEST_TESTID -value`
+
+echo "#! /bin/bash" > $EXEROOT/cesm.exe
+echo "echo Insta fail" >> $EXEROOT/cesm.exe
+echo "echo Insta fail > $RUNDIR/cpl.log.$TESTID" >> $EXEROOT/cesm.exe
+echo "exit -1" >> $EXEROOT/cesm.exe
+
+chmod +x $EXEROOT/cesm.exe
+
+echo "Build phase complete, just made simple script for cesm.exe" | tee $EXEROOT/cesm.bldlog.$TESTID
+
+./xmlchange -noecho -file env_build.xml -id BUILD_COMPLETE -val TRUE
+
+rm -rf LockedFiles/*
+
+exit 0

--- a/cime/scripts/Testing/Testcases/TESTRUNFAIL_script
+++ b/cime/scripts/Testing/Testcases/TESTRUNFAIL_script
@@ -1,0 +1,10 @@
+
+cd $CASEROOT
+
+./$CASE.run
+if ($status != 0) then
+    echo " ERROR: $CASE.run failed" >>& $TESTSTATUS_LOG
+    exit -1
+endif
+
+set CplLogFile = `ls -1t $RUNDIR/cpl.log* | head -1`

--- a/cime/scripts/Testing/Testcases/TESTRUNPASS_build.csh
+++ b/cime/scripts/Testing/Testcases/TESTRUNPASS_build.csh
@@ -1,0 +1,21 @@
+#!/bin/csh -f
+
+./Tools/check_lockedfiles || exit -1
+
+set EXEROOT  = `./xmlquery EXEROOT -value`
+set RUNDIR   = `./xmlquery RUNDIR -value`
+set TESTID   = `./xmlquery TEST_TESTID -value`
+
+echo "#! /bin/bash" > $EXEROOT/cesm.exe
+echo "echo Insta pass" >> $EXEROOT/cesm.exe
+echo "echo SUCCESSFUL TERMINATION > $RUNDIR/cpl.log.$TESTID" >> $EXEROOT/cesm.exe
+
+chmod +x $EXEROOT/cesm.exe
+
+echo "Build phase complete, just made simple script for cesm.exe" | tee $EXEROOT/cesm.bldlog.$TESTID
+
+./xmlchange -noecho -file env_build.xml -id BUILD_COMPLETE -val TRUE
+
+rm -rf LockedFiles/*
+
+exit 0

--- a/cime/scripts/Testing/Testcases/TESTRUNPASS_script
+++ b/cime/scripts/Testing/Testcases/TESTRUNPASS_script
@@ -1,0 +1,10 @@
+
+cd $CASEROOT
+
+./$CASE.run
+if ($status != 0) then
+    echo " ERROR: $CASE.run failed" >>& $TESTSTATUS_LOG
+    exit -1
+endif
+
+set CplLogFile = `ls -1t $RUNDIR/cpl.log* | head -1`

--- a/cime/scripts/Testing/Testcases/config_tests.xml
+++ b/cime/scripts/Testing/Testcases/config_tests.xml
@@ -44,6 +44,33 @@
           STOP_N="11"
           DOUT_S="FALSE" />
 
+<ccsmtest NAME="TESTBUILDFAIL"
+          DESC="For testing infra only. Insta-fail build step."
+          INFO_DBUG="1"
+          CCSM_TCOST="0"
+          STOP_OPTION="ndays"
+          STOP_N="11"
+          CHECK_TIMING="FALSE"
+          DOUT_S="FALSE" />
+
+<ccsmtest NAME="TESTRUNFAIL"
+          DESC="For testing infra only. Insta-fail run step."
+          INFO_DBUG="1"
+          CCSM_TCOST="0"
+          STOP_OPTION="ndays"
+          STOP_N="11"
+          CHECK_TIMING="FALSE"
+          DOUT_S="FALSE" />
+
+<ccsmtest NAME="TESTRUNPASS"
+          DESC="For testing infra only. Insta-pass run step."
+          INFO_DBUG="1"
+          CCSM_TCOST="0"
+          STOP_OPTION="ndays"
+          STOP_N="11"
+          CHECK_TIMING="FALSE"
+          DOUT_S="FALSE" />
+
 <ccsmtest NAME="ERT"
           DESC="exact restart from startup, default 2 month + 1 month (ERS with info dbug = 1)"
           INFO_DBUG="1"


### PR DESCRIPTION
1) Make create_test_impl.CreateTest more user friendly when not
   being used from create_test

2) Cleanup regression tests for create_test/jenkins_generic_job
- Use super class to define common setup/cleanup routines
- Fixes so that regression testing directories are always cleaned up

3) Add regression tests for create_test_impl
- Check phase iteration, full test

4) Define new test-only testcases and test categories.
   Regression testing was taking over 30 minutes due to extremely
   slow build times. To address this, test cases were made that
   instantly pass/fail build phase and run phase. This reduced test
   time down to 10 minutes.

[BFB]
