### PR TITLE
Minor ALM code modifications to avoid compilation error on Cetus

### DIFF
--- a/components/clm/src/betr/BetrBGCMod.F90
+++ b/components/clm/src/betr/BetrBGCMod.F90
@@ -1003,8 +1003,8 @@ contains
 
                            if(tracer_conc_mobile_col(c,l,trcid)<0._r8)then
                               !write error message and stop
-                              write(iulog,*),tracernames(trcid),c,l
-                              write(iulog,*),tracer_conc_mobile_col(c,l,trcid),dtracer(c,l,k),dtime_loc(c)
+                              write(iulog,*)tracernames(trcid),c,l
+                              write(iulog,*)tracer_conc_mobile_col(c,l,trcid),dtracer(c,l,k),dtime_loc(c)
                               call endrun('stopped '//trim(subname)//errMsg(__FILE__, __LINE__))
                            endif
 
@@ -1078,7 +1078,7 @@ contains
                            tracer_flx_dif(c,volatileid(trcid)) = tracer_flx_dif(c,volatileid(trcid)) - diff_surf(c,k) * dtime_loc(c)
                         endif
                      else
-                        write(iulog,*),'mass bal error dif '//tracernames(trcid), mass1,'col=',c,get_cntheta()
+                        write(iulog,*)'mass bal error dif '//tracernames(trcid), mass1,'col=',c,get_cntheta()
                         write(iulog,*)'err=',err_tracer(c,k),dmass(c,k), ' dif=',diff_surf(c,k)*dtime_loc(c), ' prod=',dot_sum(x=local_source(c,jtops(c):ubj,k),y=dz(c,jtops(c):ubj))*dtime_loc(c)
                         call endrun('mass balance error for tracer '//tracernames(trcid)//' in ' &
                            //trim(subname)//errMsg(__FILE__, __LINE__))

--- a/components/clm/src/betr/betr_core/TracerFluxType.F90
+++ b/components/clm/src/betr/betr_core/TracerFluxType.F90
@@ -644,13 +644,13 @@ contains
       !lateral drainage, vertical leaching
       !for volatile tracers, this includes surface emission surface three different pathways
       write(iulog,*)tracernames(jj)
-      write(iulog,*),'infl=',this%tracer_flx_infl_col(c,jj),' drain=',  this%tracer_flx_drain_col(c,jj),    &
+      write(iulog,*)'infl=',this%tracer_flx_infl_col(c,jj),' drain=',  this%tracer_flx_drain_col(c,jj),    &
            ' surfrun=',this%tracer_flx_surfrun_col(c,jj),' vtrans=', this%tracer_flx_vtrans_col(c,jj),&
            ' leaching=', this%tracer_flx_leaching_col(c,jj)
 
       if(is_volatile(jj))then
          kk = volatileid(jj)
-         write(iulog,*),'tpartm=', this%tracer_flx_tparchm_col(c,kk),' dif=', this%tracer_flx_dif_col(c,kk),  &
+         write(iulog,*)'tpartm=', this%tracer_flx_tparchm_col(c,kk),' dif=', this%tracer_flx_dif_col(c,kk),  &
               ' ebu=',this%tracer_flx_ebu_col(c,kk)
       endif
 


### PR DESCRIPTION
Removes comma immediately following the write statement. Without this fix
 B20TRC5 + clm 4.5 does not build on Mira/Cetus.

Fixes #493

[BFB]
SEG-81
