### PR TITLE
Fixes XLF compiler error for CNFireMod

### DIFF
--- a/components/clm/src/biogeochem/CNAllocationMod.F90
+++ b/components/clm/src/biogeochem/CNAllocationMod.F90
@@ -378,6 +378,50 @@ contains
 
     real(r8):: temp_sminn_to_plant(bounds%begc:bounds%endc)
     real(r8):: temp_sminp_to_plant(bounds%begc:bounds%endc)
+
+   real(r8), pointer :: leafc_storage(:)
+   real(r8), pointer :: leafc_xfer(:)
+
+   real(r8), pointer :: col_plant_ndemand_vr(:,:)
+   real(r8), pointer :: col_plant_nh4demand_vr(:,:)
+   real(r8), pointer :: col_plant_no3demand_vr(:,:)
+   real(r8), pointer :: col_plant_pdemand_vr(:,:)
+   real(r8), pointer :: plant_nh4demand_vr_patch(:,:)
+   real(r8), pointer :: plant_no3demand_vr_patch(:,:)
+   real(r8), pointer :: plant_ndemand_vr_patch(:,:)
+   real(r8), pointer :: actual_immob_no3(:)
+   real(r8), pointer :: actual_immob_nh4(:)
+   real(r8), pointer :: smin_nh4_to_plant_patch(:)
+   real(r8), pointer :: smin_no3_to_plant_patch(:)
+   real(r8), pointer :: sminn_to_plant_patch(:)
+   real(r8), pointer :: pnup_pfrootc(:)
+   real(r8), pointer :: pgpp_pleafc(:)
+   real(r8), pointer :: pgpp_pleafn(:)
+   real(r8), pointer :: pgpp_pleafp(:)
+   real(r8), pointer :: plant_n_uptake_flux(:)
+
+   real(r8), pointer :: leafn(:)
+   real(r8), pointer :: leafn_storage(:)
+   real(r8), pointer :: leafn_xfer(:)
+
+   real(r8), pointer :: labilep_vr(:,:)
+   real(r8), pointer :: secondp_vr(:,:)
+   real(r8), pointer :: actual_leafcp(:)
+   real(r8), pointer :: actual_frootcp(:)
+   real(r8), pointer :: actual_livewdcp(:)
+   real(r8), pointer :: actual_deadwdcp(:)
+   real(r8), pointer :: leafp(:)
+
+   real(r8), pointer :: plant_pdemand_vr_patch(:,:)
+   real(r8), pointer :: plant_p_uptake_flux(:)
+   real(r8), pointer :: sminp_to_plant_patch(:)
+   real(r8), pointer :: adsorb_to_labilep_vr(:,:)
+   real(r8), pointer :: desorb_to_solutionp_vr(:,:)
+   real(r8), pointer :: primp_to_labilep_vr_col(:,:)
+   real(r8), pointer :: biochem_pmin_vr_col(:,:)
+   real(r8), pointer :: secondp_to_labilep_vr_col(:,:)
+   real(r8), pointer :: labilep_to_secondp_vr_col(:,:)
+
     !-----------------------------------------------------------------------
 
     associate(                                                                                   &
@@ -606,48 +650,53 @@ contains
          km_den                       => ecophyscon%km_den                                     , &
          decompmicc_patch_vr          => ecophyscon%decompmicc_patch_vr                        , &
          t_scalar                     => carbonflux_vars%t_scalar_col                          , &
-         w_scalar                     => carbonflux_vars%w_scalar_col                          , &
-         smin_nh4_to_plant_patch      => nitrogenflux_vars%smin_nh4_to_plant_patch             , &                                   
-         smin_no3_to_plant_patch      => nitrogenflux_vars%smin_no3_to_plant_patch             , &
-         sminn_to_plant_patch         => nitrogenflux_vars%sminn_to_plant_patch                , &
-         pnup_pfrootc                 => nitrogenflux_vars%pnup_pfrootc_patch                  , &
-         pgpp_pleafc                  => nitrogenflux_vars%pgpp_pleafc_patch                   , &
-         pgpp_pleafn                  => nitrogenflux_vars%pgpp_pleafn_patch                   , &
-         pgpp_pleafp                  => nitrogenflux_vars%pgpp_pleafp_patch                   , &
-         leafn                        => nitrogenstate_vars%leafn_patch                        , &
-         sminp_to_plant_patch         => phosphorusflux_vars%sminp_to_plant_patch              , &
-         secondp_vr                   => phosphorusstate_vars%secondp_vr_col                   , &               
-         actual_leafcp                => phosphorusstate_vars%actual_leafcp                    , &
-         actual_frootcp               => phosphorusstate_vars%actual_frootcp                   , &
-         actual_livewdcp              => phosphorusstate_vars%actual_livewdcp                  , &
-         actual_deadwdcp              => phosphorusstate_vars%actual_deadwdcp                  , &
-         leafp                        => phosphorusstate_vars%leafp_patch                      , &
-         col_plant_ndemand_vr         => nitrogenflux_vars%col_plant_ndemand_vr                , &
-         col_plant_nh4demand_vr       => nitrogenflux_vars%col_plant_nh4demand_vr              , &
-         col_plant_no3demand_vr       => nitrogenflux_vars%col_plant_no3demand_vr              , &
-         col_plant_pdemand_vr         => nitrogenflux_vars%col_plant_pdemand_vr                , &
-         plant_nh4demand_vr_patch     => nitrogenflux_vars%plant_nh4demand_vr_patch            , &
-         plant_no3demand_vr_patch     => nitrogenflux_vars%plant_no3demand_vr_patch            , &
-         plant_ndemand_vr_patch       => nitrogenflux_vars%plant_ndemand_vr_patch              , &
-         plant_pdemand_vr_patch       => phosphorusflux_vars%plant_pdemand_vr_patch            , &
-         actual_immob_no3             => nitrogenflux_vars%actual_immob_no3_col                , &
-         actual_immob_nh4             => nitrogenflux_vars%actual_immob_nh4_col                , &
-         adsorb_to_labilep_vr         => phosphorusflux_vars%adsorb_to_labilep_vr              , &
-         desorb_to_solutionp_vr       => phosphorusflux_vars%desorb_to_solutionp_vr            , &
-         primp_to_labilep_vr_col      => phosphorusflux_vars%primp_to_labilep_vr_col           , &
-         biochem_pmin_vr_col          => phosphorusflux_vars%biochem_pmin_vr_col               , &
-         secondp_to_labilep_vr_col    => phosphorusflux_vars%secondp_to_labilep_vr_col         , &
-         labilep_to_secondp_vr_col    => phosphorusflux_vars%labilep_to_secondp_vr_col         , &
-         labilep_vr                   => phosphorusstate_vars%labilep_vr_col                   , &
-         
-         ! for debug
-         plant_n_uptake_flux	      => nitrogenflux_vars%plant_n_uptake_flux	               , &
-         plant_p_uptake_flux	      => phosphorusflux_vars%plant_p_uptake_flux	       , &
-         leafc_storage                => carbonstate_vars%leafc_storage_patch    	       , &
-         leafc_xfer                   => carbonstate_vars%leafc_xfer_patch       	       , &
-         leafn_storage                => nitrogenstate_vars%leafn_storage_patch		       , &
-         leafn_xfer                   => nitrogenstate_vars%leafn_xfer_patch       		 &
+         w_scalar                     => carbonflux_vars%w_scalar_col                            &
          )
+
+
+         leafc_storage                => carbonstate_vars%leafc_storage_patch
+         leafc_xfer                   => carbonstate_vars%leafc_xfer_patch
+
+         col_plant_ndemand_vr         => nitrogenflux_vars%col_plant_ndemand_vr
+         col_plant_nh4demand_vr       => nitrogenflux_vars%col_plant_nh4demand_vr
+         col_plant_no3demand_vr       => nitrogenflux_vars%col_plant_no3demand_vr
+         col_plant_pdemand_vr         => nitrogenflux_vars%col_plant_pdemand_vr
+         plant_nh4demand_vr_patch     => nitrogenflux_vars%plant_nh4demand_vr_patch
+         plant_no3demand_vr_patch     => nitrogenflux_vars%plant_no3demand_vr_patch
+         plant_ndemand_vr_patch       => nitrogenflux_vars%plant_ndemand_vr_patch
+         actual_immob_no3             => nitrogenflux_vars%actual_immob_no3_col
+         actual_immob_nh4             => nitrogenflux_vars%actual_immob_nh4_col
+         smin_nh4_to_plant_patch      => nitrogenflux_vars%smin_nh4_to_plant_patch
+         smin_no3_to_plant_patch      => nitrogenflux_vars%smin_no3_to_plant_patch
+         sminn_to_plant_patch         => nitrogenflux_vars%sminn_to_plant_patch
+         pnup_pfrootc                 => nitrogenflux_vars%pnup_pfrootc_patch
+         pgpp_pleafc                  => nitrogenflux_vars%pgpp_pleafc_patch
+         pgpp_pleafn                  => nitrogenflux_vars%pgpp_pleafn_patch
+         pgpp_pleafp                  => nitrogenflux_vars%pgpp_pleafp_patch
+         plant_n_uptake_flux          => nitrogenflux_vars%plant_n_uptake_flux
+
+         leafn                        => nitrogenstate_vars%leafn_patch
+         leafn_storage                => nitrogenstate_vars%leafn_storage_patch
+         leafn_xfer                   => nitrogenstate_vars%leafn_xfer_patch
+
+         labilep_vr                   => phosphorusstate_vars%labilep_vr_col
+         secondp_vr                   => phosphorusstate_vars%secondp_vr_col
+         actual_leafcp                => phosphorusstate_vars%actual_leafcp
+         actual_frootcp               => phosphorusstate_vars%actual_frootcp
+         actual_livewdcp              => phosphorusstate_vars%actual_livewdcp
+         actual_deadwdcp              => phosphorusstate_vars%actual_deadwdcp
+         leafp                        => phosphorusstate_vars%leafp_patch
+
+         plant_pdemand_vr_patch       => phosphorusflux_vars%plant_pdemand_vr_patch
+         plant_p_uptake_flux          => phosphorusflux_vars%plant_p_uptake_flux
+         sminp_to_plant_patch         => phosphorusflux_vars%sminp_to_plant_patch
+         adsorb_to_labilep_vr         => phosphorusflux_vars%adsorb_to_labilep_vr
+         desorb_to_solutionp_vr       => phosphorusflux_vars%desorb_to_solutionp_vr
+         primp_to_labilep_vr_col      => phosphorusflux_vars%primp_to_labilep_vr_col
+         biochem_pmin_vr_col          => phosphorusflux_vars%biochem_pmin_vr_col
+         secondp_to_labilep_vr_col    => phosphorusflux_vars%secondp_to_labilep_vr_col
+         labilep_to_secondp_vr_col    => phosphorusflux_vars%labilep_to_secondp_vr_col
+
 
       ! set time steps
       dt = real( get_step_size(), r8 )

--- a/components/clm/src/biogeochem/CNDecompCascadeCNMod.F90
+++ b/components/clm/src/biogeochem/CNDecompCascadeCNMod.F90
@@ -954,8 +954,9 @@ contains
          !as a first test, use level 4 (10cm) - this is used to cacluate location-specific acceleration factors
 	 do fc=1,num_soilc
 	   c = filter_soilc(fc) 
-             cnstate_vars%scalaravg_col(c) = max(cnstate_vars%scalaravg_col(c) + &
-               (t_scalar(c,4) * w_scalar(c,4) * o_scalar(c,4) ) * dt / (86400 * 365 * 20._r8), 1e-2)
+             cnstate_vars%scalaravg_col(c) = cnstate_vars%scalaravg_col(c) + &
+                  (t_scalar(c,4) * w_scalar(c,4) * o_scalar(c,4) ) * dt / (86400._r8 * 365._r8 * 20._r8)
+             if (cnstate_vars%scalaravg_col(c) < 1.0e-2) cnstate_vars%scalaravg_col(c) = 1.0e-2
          end do
        else if (year < 20) then 
           do fc=1,num_soilc

--- a/components/clm/src/biogeochem/CNDecompMod.F90
+++ b/components/clm/src/biogeochem/CNDecompMod.F90
@@ -563,13 +563,13 @@ contains
                    soil_n_immob_flux(c) = soil_n_immob_flux(c) + pmnf_decomp_cascade(c,j,k)*dzsoi_decomp(j)
                    soil_n_immob_flux_vr(c,j) = soil_n_immob_flux_vr(c,j) + pmnf_decomp_cascade(c,j,k)
                else
-                   soil_n_grossmin_flux(c) = soil_n_grossmin_flux(c) + -1.0*pmnf_decomp_cascade(c,j,k)*dzsoi_decomp(j)
+                   soil_n_grossmin_flux(c) = soil_n_grossmin_flux(c) -1.0_r8*pmnf_decomp_cascade(c,j,k)*dzsoi_decomp(j)
                end if
                if (pmpf_decomp_cascade(c,j,k) > 0._r8) then 
                    soil_p_immob_flux(c) = soil_p_immob_flux(c) + pmpf_decomp_cascade(c,j,k)*dzsoi_decomp(j)
                    soil_p_immob_flux_vr(c,j) = soil_p_immob_flux_vr(c,j) + pmpf_decomp_cascade(c,j,k)
                else
-                   soil_p_grossmin_flux(c) = soil_p_grossmin_flux(c) + -1.0*pmpf_decomp_cascade(c,j,k)*dzsoi_decomp(j)
+                   soil_p_grossmin_flux(c) = soil_p_grossmin_flux(c) -1.0_r8*pmpf_decomp_cascade(c,j,k)*dzsoi_decomp(j)
                end if
           	end do
           end do

--- a/components/clm/src/biogeochem/CNFireMod.F90
+++ b/components/clm/src/biogeochem/CNFireMod.F90
@@ -695,6 +695,59 @@ contains
    real(r8):: f                    ! rate for fire effects (1/s)
    real(r8):: dt                   ! time step variable (s)
    real(r8):: dayspyr              ! days per year
+
+   real(r8), pointer :: m_leafn_to_litter_fire                  (:)
+   real(r8), pointer :: m_leafn_storage_to_litter_fire          (:)
+   real(r8), pointer :: m_leafn_xfer_to_litter_fire             (:)
+   real(r8), pointer :: m_livestemn_to_litter_fire              (:)
+   real(r8), pointer :: m_livestemn_storage_to_litter_fire      (:)
+   real(r8), pointer :: m_livestemn_xfer_to_litter_fire         (:)
+   real(r8), pointer :: m_livestemn_to_deadstemn_fire           (:)
+   real(r8), pointer :: m_deadstemn_to_litter_fire              (:)
+   real(r8), pointer :: m_deadstemn_storage_to_litter_fire      (:)
+   real(r8), pointer :: m_deadstemn_xfer_to_litter_fire         (:)
+   real(r8), pointer :: m_frootn_to_litter_fire                 (:)
+   real(r8), pointer :: m_frootn_storage_to_litter_fire         (:)
+   real(r8), pointer :: m_frootn_xfer_to_litter_fire            (:)
+   real(r8), pointer :: m_livecrootn_to_litter_fire             (:)
+   real(r8), pointer :: m_livecrootn_storage_to_litter_fire     (:)
+   real(r8), pointer :: m_livecrootn_xfer_to_litter_fire        (:)
+   real(r8), pointer :: m_livecrootn_to_deadcrootn_fire         (:)
+   real(r8), pointer :: m_deadcrootn_to_litter_fire             (:)
+   real(r8), pointer :: m_deadcrootn_storage_to_litter_fire     (:)
+   real(r8), pointer :: m_deadcrootn_xfer_to_litter_fire        (:)
+   real(r8), pointer :: m_retransn_to_litter_fire               (:)
+   real(r8), pointer :: m_decomp_npools_to_fire_vr              (:,:,:)
+   real(r8), pointer :: m_n_to_litr_met_fire                    (:,:)
+   real(r8), pointer :: m_n_to_litr_cel_fire                    (:,:)
+   real(r8), pointer :: m_n_to_litr_lig_fire                    (:,:)
+
+   real(r8), pointer :: m_leafp_to_litter_fire                  (:)
+   real(r8), pointer :: m_leafp_storage_to_litter_fire          (:)
+   real(r8), pointer :: m_leafp_xfer_to_litter_fire             (:)
+   real(r8), pointer :: m_livestemp_to_litter_fire              (:)
+   real(r8), pointer :: m_livestemp_storage_to_litter_fire      (:)
+   real(r8), pointer :: m_livestemp_xfer_to_litter_fire         (:)
+   real(r8), pointer :: m_livestemp_to_deadstemp_fire           (:)
+   real(r8), pointer :: m_deadstemp_to_litter_fire              (:)
+   real(r8), pointer :: m_deadstemp_storage_to_litter_fire      (:)
+   real(r8), pointer :: m_deadstemp_xfer_to_litter_fire         (:)
+   real(r8), pointer :: m_frootp_to_litter_fire                 (:)
+   real(r8), pointer :: m_frootp_storage_to_litter_fire         (:)
+   real(r8), pointer :: m_frootp_xfer_to_litter_fire            (:)
+   real(r8), pointer :: m_livecrootp_to_litter_fire             (:)
+   real(r8), pointer :: m_livecrootp_storage_to_litter_fire     (:)
+   real(r8), pointer :: m_livecrootp_xfer_to_litter_fire        (:)
+   real(r8), pointer :: m_livecrootp_to_deadcrootp_fire         (:)
+   real(r8), pointer :: m_deadcrootp_to_litter_fire             (:)
+   real(r8), pointer :: m_deadcrootp_storage_to_litter_fire     (:)
+   real(r8), pointer :: m_deadcrootp_xfer_to_litter_fire        (:)
+   real(r8), pointer :: m_retransp_to_litter_fire               (:)
+   real(r8), pointer :: m_decomp_ppools_to_fire_vr              (:,:,:)
+   real(r8), pointer :: m_p_to_litr_met_fire                    (:,:)
+   real(r8), pointer :: m_p_to_litr_cel_fire                    (:,:)
+   real(r8), pointer :: m_p_to_litr_lig_fire                    (:,:)
+
    !-----------------------------------------------------------------------
 
    ! NOTE: VR      = Vertically Resolved
@@ -892,62 +945,62 @@ contains
         m_decomp_cpools_to_fire_vr          =>    carbonflux_vars%m_decomp_cpools_to_fire_vr_col              , & ! Output: [real(r8) (:,:,:) ]  (gC/m3/s) VR decomp. C fire loss
         m_c_to_litr_met_fire                =>    carbonflux_vars%m_c_to_litr_met_fire_col                    , & ! Output: [real(r8) (:,:)   ]                                                  
         m_c_to_litr_cel_fire                =>    carbonflux_vars%m_c_to_litr_cel_fire_col                    , & ! Output: [real(r8) (:,:)   ]                                                  
-        m_c_to_litr_lig_fire                =>    carbonflux_vars%m_c_to_litr_lig_fire_col                    , & ! Output: [real(r8) (:,:)   ]                                                  
-        
-        m_leafn_to_litter_fire              =>    nitrogenflux_vars%m_leafn_to_litter_fire_patch              , & ! Output: [real(r8) (:)     ]                                                    
-        m_leafn_storage_to_litter_fire      =>    nitrogenflux_vars%m_leafn_storage_to_litter_fire_patch      , & ! Output: [real(r8) (:)     ]                                                    
-        m_leafn_xfer_to_litter_fire         =>    nitrogenflux_vars%m_leafn_xfer_to_litter_fire_patch         , & ! Output: [real(r8) (:)     ]                                                    
-        m_livestemn_to_litter_fire          =>    nitrogenflux_vars%m_livestemn_to_litter_fire_patch          , & ! Output: [real(r8) (:)     ]                                                    
-        m_livestemn_storage_to_litter_fire  =>    nitrogenflux_vars%m_livestemn_storage_to_litter_fire_patch  , & ! Output: [real(r8) (:)     ]                                                    
-        m_livestemn_xfer_to_litter_fire     =>    nitrogenflux_vars%m_livestemn_xfer_to_litter_fire_patch     , & ! Output: [real(r8) (:)     ]                                                    
-        m_livestemn_to_deadstemn_fire       =>    nitrogenflux_vars%m_livestemn_to_deadstemn_fire_patch       , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadstemn_to_litter_fire          =>    nitrogenflux_vars%m_deadstemn_to_litter_fire_patch          , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadstemn_storage_to_litter_fire  =>    nitrogenflux_vars%m_deadstemn_storage_to_litter_fire_patch  , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadstemn_xfer_to_litter_fire     =>    nitrogenflux_vars%m_deadstemn_xfer_to_litter_fire_patch     , & ! Output: [real(r8) (:)     ]                                                    
-        m_frootn_to_litter_fire             =>    nitrogenflux_vars%m_frootn_to_litter_fire_patch             , & ! Output: [real(r8) (:)     ]                                                    
-        m_frootn_storage_to_litter_fire     =>    nitrogenflux_vars%m_frootn_storage_to_litter_fire_patch     , & ! Output: [real(r8) (:)     ]                                                    
-        m_frootn_xfer_to_litter_fire        =>    nitrogenflux_vars%m_frootn_xfer_to_litter_fire_patch        , & ! Output: [real(r8) (:)     ]                                                    
-        m_livecrootn_to_litter_fire         =>    nitrogenflux_vars%m_livecrootn_to_litter_fire_patch         , & ! Output: [real(r8) (:)     ]                                                    
-        m_livecrootn_storage_to_litter_fire =>    nitrogenflux_vars%m_livecrootn_storage_to_litter_fire_patch , & ! Output: [real(r8) (:)     ]                                                    
-        m_livecrootn_xfer_to_litter_fire    =>    nitrogenflux_vars%m_livecrootn_xfer_to_litter_fire_patch    , & ! Output: [real(r8) (:)     ]                                                    
-        m_livecrootn_to_deadcrootn_fire     =>    nitrogenflux_vars%m_livecrootn_to_deadcrootn_fire_patch     , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadcrootn_to_litter_fire         =>    nitrogenflux_vars%m_deadcrootn_to_litter_fire_patch         , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadcrootn_storage_to_litter_fire =>    nitrogenflux_vars%m_deadcrootn_storage_to_litter_fire_patch , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadcrootn_xfer_to_litter_fire    =>    nitrogenflux_vars%m_deadcrootn_xfer_to_litter_fire_patch    , & ! Output: [real(r8) (:)     ]                                                    
-        m_retransn_to_litter_fire           =>    nitrogenflux_vars%m_retransn_to_litter_fire_patch           , & ! Output: [real(r8) (:)     ]                                                    
-        m_decomp_npools_to_fire_vr          =>    nitrogenflux_vars%m_decomp_npools_to_fire_vr_col            , & ! Output: [real(r8) (:,:,:) ]  VR decomp. N fire loss (gN/m3/s)
-        m_n_to_litr_met_fire                =>    nitrogenflux_vars%m_n_to_litr_met_fire_col                  , & ! Output: [real(r8) (:,:)   ]                                                  
-        m_n_to_litr_cel_fire                =>    nitrogenflux_vars%m_n_to_litr_cel_fire_col                  , & ! Output: [real(r8) (:,:)   ]                                                  
-        m_n_to_litr_lig_fire                =>    nitrogenflux_vars%m_n_to_litr_lig_fire_col                  ,  & ! Output: [real(r8) (:,:)   ]                                                  
-
-
-        m_leafp_to_litter_fire              =>    phosphorusflux_vars%m_leafp_to_litter_fire_patch              , & ! Output: [real(r8) (:)     ]                                                    
-        m_leafp_storage_to_litter_fire      =>    phosphorusflux_vars%m_leafp_storage_to_litter_fire_patch      , & ! Output: [real(r8) (:)     ]                                                    
-        m_leafp_xfer_to_litter_fire         =>    phosphorusflux_vars%m_leafp_xfer_to_litter_fire_patch         , & ! Output: [real(r8) (:)     ]                                                    
-        m_livestemp_to_litter_fire          =>    phosphorusflux_vars%m_livestemp_to_litter_fire_patch          , & ! Output: [real(r8) (:)     ]                                                    
-        m_livestemp_storage_to_litter_fire  =>    phosphorusflux_vars%m_livestemp_storage_to_litter_fire_patch  , & ! Output: [real(r8) (:)     ]                                                    
-        m_livestemp_xfer_to_litter_fire     =>    phosphorusflux_vars%m_livestemp_xfer_to_litter_fire_patch     , & ! Output: [real(r8) (:)     ]                                                    
-        m_livestemp_to_deadstemp_fire       =>    phosphorusflux_vars%m_livestemp_to_deadstemp_fire_patch       , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadstemp_to_litter_fire          =>    phosphorusflux_vars%m_deadstemp_to_litter_fire_patch          , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadstemp_storage_to_litter_fire  =>    phosphorusflux_vars%m_deadstemp_storage_to_litter_fire_patch  , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadstemp_xfer_to_litter_fire     =>    phosphorusflux_vars%m_deadstemp_xfer_to_litter_fire_patch     , & ! Output: [real(r8) (:)     ]                                                    
-        m_frootp_to_litter_fire             =>    phosphorusflux_vars%m_frootp_to_litter_fire_patch             , & ! Output: [real(r8) (:)     ]                                                    
-        m_frootp_storage_to_litter_fire     =>    phosphorusflux_vars%m_frootp_storage_to_litter_fire_patch     , & ! Output: [real(r8) (:)     ]                                                    
-        m_frootp_xfer_to_litter_fire        =>    phosphorusflux_vars%m_frootp_xfer_to_litter_fire_patch        , & ! Output: [real(r8) (:)     ]                                                    
-        m_livecrootp_to_litter_fire         =>    phosphorusflux_vars%m_livecrootp_to_litter_fire_patch         , & ! Output: [real(r8) (:)     ]                                                    
-        m_livecrootp_storage_to_litter_fire =>    phosphorusflux_vars%m_livecrootp_storage_to_litter_fire_patch , & ! Output: [real(r8) (:)     ]                                                    
-        m_livecrootp_xfer_to_litter_fire    =>    phosphorusflux_vars%m_livecrootp_xfer_to_litter_fire_patch    , & ! Output: [real(r8) (:)     ]                                                    
-        m_livecrootp_to_deadcrootp_fire     =>    phosphorusflux_vars%m_livecrootp_to_deadcrootp_fire_patch     , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadcrootp_to_litter_fire         =>    phosphorusflux_vars%m_deadcrootp_to_litter_fire_patch         , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadcrootp_storage_to_litter_fire =>    phosphorusflux_vars%m_deadcrootp_storage_to_litter_fire_patch , & ! Output: [real(r8) (:)     ]                                                    
-        m_deadcrootp_xfer_to_litter_fire    =>    phosphorusflux_vars%m_deadcrootp_xfer_to_litter_fire_patch    , & ! Output: [real(r8) (:)     ]                                                    
-        m_retransp_to_litter_fire           =>    phosphorusflux_vars%m_retransp_to_litter_fire_patch           , & ! Output: [real(r8) (:)     ]                                                    
-        m_decomp_ppools_to_fire_vr          =>    phosphorusflux_vars%m_decomp_ppools_to_fire_vr_col            , & ! Output: [real(r8) (:,:,:) ]  VR decomp. N fire loss (gN/m3/s)
-        m_p_to_litr_met_fire                =>    phosphorusflux_vars%m_p_to_litr_met_fire_col                  , & ! Output: [real(r8) (:,:)   ]                                                  
-        m_p_to_litr_cel_fire                =>    phosphorusflux_vars%m_p_to_litr_cel_fire_col                  , & ! Output: [real(r8) (:,:)   ]                                                  
-        m_p_to_litr_lig_fire                =>    phosphorusflux_vars%m_p_to_litr_lig_fire_col                    & ! Output: [real(r8) (:,:)   ]                                                  
+        m_c_to_litr_lig_fire                =>    carbonflux_vars%m_c_to_litr_lig_fire_col                      & ! Output: [real(r8) (:,:)   ]
 
         )
+
+     m_leafn_to_litter_fire              =>    nitrogenflux_vars%m_leafn_to_litter_fire_patch              
+     m_leafn_storage_to_litter_fire      =>    nitrogenflux_vars%m_leafn_storage_to_litter_fire_patch      
+     m_leafn_xfer_to_litter_fire         =>    nitrogenflux_vars%m_leafn_xfer_to_litter_fire_patch         
+     m_livestemn_to_litter_fire          =>    nitrogenflux_vars%m_livestemn_to_litter_fire_patch          
+     m_livestemn_storage_to_litter_fire  =>    nitrogenflux_vars%m_livestemn_storage_to_litter_fire_patch  
+     m_livestemn_xfer_to_litter_fire     =>    nitrogenflux_vars%m_livestemn_xfer_to_litter_fire_patch     
+     m_livestemn_to_deadstemn_fire       =>    nitrogenflux_vars%m_livestemn_to_deadstemn_fire_patch       
+     m_deadstemn_to_litter_fire          =>    nitrogenflux_vars%m_deadstemn_to_litter_fire_patch          
+     m_deadstemn_storage_to_litter_fire  =>    nitrogenflux_vars%m_deadstemn_storage_to_litter_fire_patch  
+     m_deadstemn_xfer_to_litter_fire     =>    nitrogenflux_vars%m_deadstemn_xfer_to_litter_fire_patch     
+     m_frootn_to_litter_fire             =>    nitrogenflux_vars%m_frootn_to_litter_fire_patch             
+     m_frootn_storage_to_litter_fire     =>    nitrogenflux_vars%m_frootn_storage_to_litter_fire_patch     
+     m_frootn_xfer_to_litter_fire        =>    nitrogenflux_vars%m_frootn_xfer_to_litter_fire_patch        
+     m_livecrootn_to_litter_fire         =>    nitrogenflux_vars%m_livecrootn_to_litter_fire_patch         
+     m_livecrootn_storage_to_litter_fire =>    nitrogenflux_vars%m_livecrootn_storage_to_litter_fire_patch 
+     m_livecrootn_xfer_to_litter_fire    =>    nitrogenflux_vars%m_livecrootn_xfer_to_litter_fire_patch    
+     m_livecrootn_to_deadcrootn_fire     =>    nitrogenflux_vars%m_livecrootn_to_deadcrootn_fire_patch     
+     m_deadcrootn_to_litter_fire         =>    nitrogenflux_vars%m_deadcrootn_to_litter_fire_patch         
+     m_deadcrootn_storage_to_litter_fire =>    nitrogenflux_vars%m_deadcrootn_storage_to_litter_fire_patch 
+     m_deadcrootn_xfer_to_litter_fire    =>    nitrogenflux_vars%m_deadcrootn_xfer_to_litter_fire_patch    
+     m_retransn_to_litter_fire           =>    nitrogenflux_vars%m_retransn_to_litter_fire_patch           
+     m_decomp_npools_to_fire_vr          =>    nitrogenflux_vars%m_decomp_npools_to_fire_vr_col            
+     m_n_to_litr_met_fire                =>    nitrogenflux_vars%m_n_to_litr_met_fire_col                  
+     m_n_to_litr_cel_fire                =>    nitrogenflux_vars%m_n_to_litr_cel_fire_col                  
+     m_n_to_litr_lig_fire                =>    nitrogenflux_vars%m_n_to_litr_lig_fire_col                  
+
+
+     m_leafp_to_litter_fire              =>    phosphorusflux_vars%m_leafp_to_litter_fire_patch              
+     m_leafp_storage_to_litter_fire      =>    phosphorusflux_vars%m_leafp_storage_to_litter_fire_patch      
+     m_leafp_xfer_to_litter_fire         =>    phosphorusflux_vars%m_leafp_xfer_to_litter_fire_patch         
+     m_livestemp_to_litter_fire          =>    phosphorusflux_vars%m_livestemp_to_litter_fire_patch          
+     m_livestemp_storage_to_litter_fire  =>    phosphorusflux_vars%m_livestemp_storage_to_litter_fire_patch  
+     m_livestemp_xfer_to_litter_fire     =>    phosphorusflux_vars%m_livestemp_xfer_to_litter_fire_patch     
+     m_livestemp_to_deadstemp_fire       =>    phosphorusflux_vars%m_livestemp_to_deadstemp_fire_patch       
+     m_deadstemp_to_litter_fire          =>    phosphorusflux_vars%m_deadstemp_to_litter_fire_patch          
+     m_deadstemp_storage_to_litter_fire  =>    phosphorusflux_vars%m_deadstemp_storage_to_litter_fire_patch  
+     m_deadstemp_xfer_to_litter_fire     =>    phosphorusflux_vars%m_deadstemp_xfer_to_litter_fire_patch     
+     m_frootp_to_litter_fire             =>    phosphorusflux_vars%m_frootp_to_litter_fire_patch             
+     m_frootp_storage_to_litter_fire     =>    phosphorusflux_vars%m_frootp_storage_to_litter_fire_patch     
+     m_frootp_xfer_to_litter_fire        =>    phosphorusflux_vars%m_frootp_xfer_to_litter_fire_patch        
+     m_livecrootp_to_litter_fire         =>    phosphorusflux_vars%m_livecrootp_to_litter_fire_patch         
+     m_livecrootp_storage_to_litter_fire =>    phosphorusflux_vars%m_livecrootp_storage_to_litter_fire_patch 
+     m_livecrootp_xfer_to_litter_fire    =>    phosphorusflux_vars%m_livecrootp_xfer_to_litter_fire_patch    
+     m_livecrootp_to_deadcrootp_fire     =>    phosphorusflux_vars%m_livecrootp_to_deadcrootp_fire_patch     
+     m_deadcrootp_to_litter_fire         =>    phosphorusflux_vars%m_deadcrootp_to_litter_fire_patch         
+     m_deadcrootp_storage_to_litter_fire =>    phosphorusflux_vars%m_deadcrootp_storage_to_litter_fire_patch 
+     m_deadcrootp_xfer_to_litter_fire    =>    phosphorusflux_vars%m_deadcrootp_xfer_to_litter_fire_patch    
+     m_retransp_to_litter_fire           =>    phosphorusflux_vars%m_retransp_to_litter_fire_patch           
+     m_decomp_ppools_to_fire_vr          =>    phosphorusflux_vars%m_decomp_ppools_to_fire_vr_col            
+     m_p_to_litr_met_fire                =>    phosphorusflux_vars%m_p_to_litr_met_fire_col                  
+     m_p_to_litr_cel_fire                =>    phosphorusflux_vars%m_p_to_litr_cel_fire_col                  
+     m_p_to_litr_lig_fire                =>    phosphorusflux_vars%m_p_to_litr_lig_fire_col                  
 
      ! Get model step size
      ! calculate burned area fraction per sec


### PR DESCRIPTION
The XLF compiler fails to compile CNFireMod.F90 and produces
the following error message:

"Number of characters in source statement exceeds 
 allowable maximum.  Remainder of statement is ignored."

The fix to avoid the compiler failure is same as 515d693c9203f7766337f04443f591624a6ce8ac

Fixes #500

[BFB]
SEG-81
