### PR TITLE
Jenkins died again on the submodule handling

### DIFF
--- a/cime/scripts-acme/jenkins_script
+++ b/cime/scripts-acme/jenkins_script
@@ -17,3 +17,7 @@ $SCRIPT_DIR/jenkins_generic_job "$@" >& JENKINS_$DATE_STAMP
 for SUB in $(git submodule status | awk '{print $2}'); do
     git submodule deinit ${SUB}
 done
+
+git config --remove-section submodule.mpas-o
+git config --remove-section submodule.mpas-cice
+git config --remove-section submodule.mpas-li


### PR DESCRIPTION
I've noticed that fresh clones seem to work, so I'm
going to remove the submodule url configuration that gets
added by the Jenkins jobs.

[BFB]
