### PR TITLE
Add node name regex for constance

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -691,6 +691,7 @@
          <OS>LINUX</OS>
          <COMPILERS>pgi,intel</COMPILERS>
          <MPILIBS>mpich</MPILIBS>
+	 <NODENAME_REGEX>constance</NODENAME_REGEX>
          <RUNDIR>/pic/scratch/$CCSMUSER/csmruns/$CASE/run</RUNDIR>
          <EXEROOT>/pic/scratch/$CCSMUSER/csmruns/$CASE/bld</EXEROOT>
          <CESMSCRATCHROOT>/pic/scratch/$USER</CESMSCRATCHROOT>


### PR DESCRIPTION
Adds node name regular expression to constance machine files.  This allows for automatic detection of the machine name by scripts such as cime/scripts-acme/create_test.

[BFB]
