### PR TITLE
jenkins_script: Turn off quit-on-failure mode

### DIFF
--- a/cime/scripts-acme/jenkins_script
+++ b/cime/scripts-acme/jenkins_script
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 #
 # Wrapper around jenkins_generic_job that will allow output
@@ -6,8 +6,6 @@
 # recoverable if Jenkins is forced to kill the job. This is the
 # script that should be used from Jenkins.
 #
-
-set -o pipefail
 
 SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
 DATE_STAMP=$(date "+%Y-%m-%d_%H%M%S")


### PR DESCRIPTION
jenkins_generic_job returns non-zero if there were failing tests.
This was causing the jenkins bash wrapper to terminate before it
could restore the state of the submodule URLs.

[BFB]
