### PR TITLE
two bugfixes for the cam tool that makes srf files

### DIFF
--- a/components/cam/tools/mkatmsrffile/mkatmsrffile.F90
+++ b/components/cam/tools/mkatmsrffile/mkatmsrffile.F90
@@ -97,7 +97,7 @@ program mkatmsrffile
   call openfile_and_initdecomp(iosystem, atmfilename, npes, iam, gsmap_atm, atmnx, atmnxg)
 
  
-  call shr_mct_queryConfigFile(MPI_COMM_WORLD, "mkatmsrffile.rc",
+  call shr_mct_queryConfigFile(MPI_COMM_WORLD, "mkatmsrffile.rc", &
        "srf2atmFmapname:",mapname,"srf2atmFmaptype:",maptype)
     
   call shr_mct_sMatPInitnc(sMatP,gsmap_srf, gsmap_atm, &
@@ -244,7 +244,7 @@ program mkatmsrffile
      do j=1,npft
         total_land=total_land+apft(j)%fld(i)
      end do
-     fraction_soilw = total_land - (alake(i)+wetland(i))
+     fraction_soilw = total_land - (alake(i)+awetland(i))
      if(total_land < 1.0_r8) then
         alake(i) = alake(i) + (1.0_r8 - total_land)
      end if


### PR DESCRIPTION
Fix two bugfixes for the cam tool that makes srf files
The first is a typo which prevents the code from compiling.
The second is a typo which leads to segfaults on some meshes.  (wetland(i) instead of awetland(i))
As this is a tool from the CESM, MT reported this bug on the CESM bug tracking system.

MT regenerated ne30 and ne120 atmsrf data sets with the bug fixed code and they were
identical to the old data sets, so when the bug does not segfault, it appears to be harmless.

no impact on ACME. 
BFB
