### PR TITLE
Change default for env_run.xml::DOUT_S to FALSE

### DIFF
--- a/cime/scripts/Tools/config_definition.xml
+++ b/cime/scripts/Tools/config_definition.xml
@@ -3425,7 +3425,7 @@
   <entry id="DOUT_S" 
 	 type="logical"
 	 valid_values="TRUE,FALSE"  
-	 value="TRUE" 
+	 value="FALSE" 
 	 group="run_dout"
 	 sdesc="logical to turn on short term archiving"
 	 ldesc="


### PR DESCRIPTION
By default, do not run the short term archiving script after each run.
This makes the default behavoir match how the high resolution simulations are run, where all data
from the simulation will accumulate in the run directory.

In addition, the short term archiving script shoud not be enabled until it is updated to correctly
handle new types of output from the MPAS components.

Users that want to enable short term archiving (even though it is currently broken) can do
so by editing env_run.xml for each case.

Fixes #514 
BFB
