### PR TITLE
Add low-resolution ocean meshes.

### DIFF
--- a/cime/scripts/Tools/config_grid.xml
+++ b/cime/scripts/Tools/config_grid.xml
@@ -49,7 +49,6 @@ Each grid is associated with five names
 <GRID sname="T62_tx1v1"   alias="T62_s11" compset="(DATM|XATM|SATM)">a%T62_l%T62_oi%tx1v1_r%rx1_m%tx1v1_g%null_w%null</GRID>
 <GRID sname="T62_tx0.1v2" alias="T62_t12" compset="(DATM|XATM|SATM)">a%T62_l%T62_oi%tx0.1v2_r%rx1_m%tx0.1v2_g%null_w%null</GRID>
 <GRID sname="T62_gx1v6"   alias="T62_g16" compset="(DATM|XATM|SATM)">a%T62_l%T62_oi%gx1v6_r%rx1_m%gx1v6_g%null_w%null</GRID>
-<GRID sname="T62_oQU480" alias="T62_m480" compset="(DATM|XATM|SATM)">a%T62_l%T62_oi%oQU480_r%rx1_m%oQU480_g%null_w%null</GRID>
 <GRID sname="T62_oQU240" alias="T62_m240" compset="(DATM|XATM|SATM)">a%T62_l%T62_oi%oQU240_r%rx1_m%oQU240_g%null_w%null</GRID>
 <GRID sname="T62_oQU120" alias="T62_m120" compset="(DATM|XATM|SATM)">a%T62_l%T62_oi%oQU120_r%rx1_m%oQU120_g%null_w%null</GRID>
 <GRID sname="T62_mpas120" alias="T62_m120" compset="(DATM|XATM|SATM)">a%T62_l%T62_oi%mpas120_r%rx1_m%mpas120_g%null_w%null</GRID>
@@ -375,12 +374,6 @@ do not use scientific experiments; use the T62_g16 resolution instead:
   <desc>mpasgx1 is a MPAS cice grid that is roughly 1 degree resolution:</desc>
 </gridhorz>
 
-<gridhorz name="oQU480">
-  <support_level>Experimental, under development</support_level>
-  <nx>1793</nx>  <ny>1</ny>  
-  <desc>oQU480 is an MPAS ocean mesh with quasi-uniform 480 km grid cells, nominally 4 degree resolution:</desc>
-</gridhorz>
-
 <gridhorz name="oQU240">
   <support_level>Experimental, under development</support_level>
   <nx>7153</nx>  <ny>1</ny>  
@@ -536,11 +529,6 @@ do not use scientific experiments; use the T62_g16 resolution instead:
 <griddom grid="mp120v1" mask="mp120v1">
   <ICE_DOMAIN_FILE>domain.ocn.mp120v1.111018.nc</ICE_DOMAIN_FILE>
   <OCN_DOMAIN_FILE>domain.ocn.mp120v1.111018.nc</OCN_DOMAIN_FILE>
-</griddom>
-
-<griddom grid="oQU480" mask="oQU480">
-  <ICE_DOMAIN_FILE>domain.ocn.oQU480.151209.nc</ICE_DOMAIN_FILE>
-  <OCN_DOMAIN_FILE>domain.ocn.oQU480.151209.nc</OCN_DOMAIN_FILE>
 </griddom>
 
 <griddom grid="oQU240" mask="oQU240">
@@ -1198,11 +1186,6 @@ do not use scientific experiments; use the T62_g16 resolution instead:
   <LND_DOMAIN_FILE>domain.lnd.T62_mpasgx1.150903.nc</LND_DOMAIN_FILE>
 </griddom>
 
-<griddom grid="T62" mask="oQU480"> <!--- datm/slnd/drof only -->
-  <ATM_DOMAIN_FILE>domain.lnd.T62_oQU480.151209.nc</ATM_DOMAIN_FILE>
-  <LND_DOMAIN_FILE>domain.lnd.T62_oQU480.151209.nc</LND_DOMAIN_FILE>
-</griddom>
-
 <griddom grid="T62" mask="oQU240"> <!--- datm/slnd/drof only -->
   <ATM_DOMAIN_FILE>domain.lnd.T62_oQU240.151209.nc</ATM_DOMAIN_FILE>
   <LND_DOMAIN_FILE>domain.lnd.T62_oQU240.151209.nc</LND_DOMAIN_FILE>
@@ -1258,14 +1241,6 @@ do not use scientific experiments; use the T62_g16 resolution instead:
   <ATM2OCN_VMAPNAME>cpl/cpl6/map_T62_to_tx0.1v2_bilin_da_090220.nc</ATM2OCN_VMAPNAME>
   <OCN2ATM_FMAPNAME>cpl/cpl6/map_tx0.1v2_to_T62_aave_da_090220.nc</OCN2ATM_FMAPNAME>
   <OCN2ATM_SMAPNAME>cpl/cpl6/map_tx0.1v2_to_T62_aave_da_090220.nc</OCN2ATM_SMAPNAME>
-</gridmap>
-
-<gridmap atm_grid="T62" ocn_grid="oQU480">
-  <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU480_aave.151209.nc</ATM2OCN_FMAPNAME>
-  <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU480_blin.151209.nc</ATM2OCN_SMAPNAME>
-  <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU480_patc.151209.nc</ATM2OCN_VMAPNAME>
-  <OCN2ATM_FMAPNAME>cpl/gridmaps/oQU480/map_oQU480_TO_T62_aave.151209.nc</OCN2ATM_FMAPNAME>
-  <OCN2ATM_SMAPNAME>cpl/gridmaps/oQU480/map_oQU480_TO_T62_aave.151209.nc</OCN2ATM_SMAPNAME>
 </gridmap>
 
 <gridmap atm_grid="T62" ocn_grid="oQU240">
@@ -1550,9 +1525,6 @@ do not use scientific experiments; use the T62_g16 resolution instead:
 </gridmap>
 <gridmap rof_grid="rx1" ocn_grid="mpasgx1" >
   <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_mpasgx1_nn_150910.nc</ROF2OCN_RMAPNAME>
-</gridmap>
-<gridmap rof_grid="rx1" ocn_grid="oQU480" >
-  <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oQU480_nn_151209.nc</ROF2OCN_RMAPNAME>
 </gridmap>
 <gridmap rof_grid="rx1" ocn_grid="oQU240" >
   <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oQU240_nn_151209.nc</ROF2OCN_RMAPNAME>

--- a/components/mpas-o/bld/mpas-o.buildnml
+++ b/components/mpas-o/bld/mpas-o.buildnml
@@ -46,11 +46,6 @@ if ( $OCN_GRID eq 'oEC60to30' ) {
 	$grid_prefix .= 'oEC60to30';
 	$ic_prefix .= 'oEC60to30';
 	$decomp_prefix .= 'mpas-o.graph.info.';
-} elsif ( $OCN_GRID eq 'oQU480' ) {
-	$grid_date .= '151209';
-	$grid_prefix .= 'ocean.QU.480km';
-	$ic_prefix .= 'ocean.QU.480km';
-	$decomp_prefix .= 'mpas-o.graph.info.';
 } elsif ( $OCN_GRID eq 'oQU240' ) {
 	$grid_date .= '151209';
 	$grid_prefix .= 'ocean.QU.240km';

--- a/components/mpas-o/bld/namelist_files/namelist_defaults_mpas-o.xml
+++ b/components/mpas-o/bld/namelist_files/namelist_defaults_mpas-o.xml
@@ -41,7 +41,6 @@
 <config_1dCVTgenerator_dzSeed>1.2</config_1dCVTgenerator_dzSeed>
 
 <!-- time_integration -->
-<config_dt ocn_grid="oQU480">'01:00:00'</config_dt>
 <config_dt ocn_grid="oQU240">'01:00:00'</config_dt>
 <config_dt ocn_grid="oQU120">'00:30:00'</config_dt>
 <config_dt ocn_grid="mpas120">'00:30:00'</config_dt>
@@ -72,7 +71,6 @@
 <config_check_ssh_consistency>.true.</config_check_ssh_consistency>
 
 <!-- hmix -->
-<config_hmix_scaleWithMesh ocn_grid="oQU480">.false.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oQU240">.false.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oQU120">.false.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="mpas120">.false.</config_hmix_scaleWithMesh>
@@ -90,7 +88,6 @@
 <!-- hmix_del4 -->
 <config_use_mom_del4>.true.</config_use_mom_del4>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
-<config_mom_del4 ocn_grid="oQU480">1.6e15</config_mom_del4>
 <config_mom_del4 ocn_grid="oQU240">2.0e14</config_mom_del4>
 <config_mom_del4 ocn_grid="oQU120">2.6e13</config_mom_del4>
 <config_mom_del4 ocn_grid="mpas120">5.0e12</config_mom_del4>


### PR DESCRIPTION
Add mpas-ocean grid and mapping file settings for oQU480, oQU240,
oQU120 quasi-uniform meshes.  This was tested with
  -compset CMPASO-IAF -res T62_oQU120
on LANL mustang.  The oQU120 is identical to the mpas120, and was added
for uniform naming.
