### PR TITLE
Change cori default queue

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -212,10 +212,10 @@
     <PES_PER_NODE>32</PES_PER_NODE>
     <batch_system type="slurm" version="x.y">
       <queues>
-        <queue walltimemax="00:06:00" jobmin="1" jobmax="16384" >regular</queue>
+        <queue walltimemax="00:06:00" jobmin="1" jobmax="16384" default="true">regular</queue>
         <queue walltimemax="00:04:00" jobmin="16385" jobmax="32768" >regular</queue>
         <queue walltimemax="00:02:00" jobmin="32769" jobmax="52096" >regular</queue>
-	<queue walltimemax="00:30:00" jobmin="1" jobmax="4096" default="true">debug</queue>
+	<queue walltimemax="00:30:00" jobmin="1" jobmax="4096">debug</queue>
       </queues>
       <walltimes>
         <walltime default="true">00:30:00</walltime>

--- a/cime/utils/perl5lib/Batch/BatchMaker.pm
+++ b/cime/utils/perl5lib/Batch/BatchMaker.pm
@@ -486,9 +486,17 @@ sub setQueue()
 	# specifiy the queue directly. 
 	if(@defaultqueue)
 	{
-        my $defelement = $defaultqueue[0];
-        $self->{'queue'} = $defelement->textContent();
-	}
+            my $defelement = $defaultqueue[0];
+            $self->{'queue'} = $defelement->textContent();
+
+            my $jobmin = $defelement->getAttribute('jobmin');
+            my $jobmax = $defelement->getAttribute('jobmax');
+            # if the fullsum is between the min and max # jobs, then use this queue.
+            if(defined $jobmin && defined $jobmax && $self->{'fullsum'} >= $jobmin && $self->{'fullsum'} <= $jobmax)
+            {
+                return;
+            }
+        }
 
 	# We may have a default queue at this point, but if there is a queue that our job's node count
 	# falls in between, then we should use that queue. 
@@ -496,10 +504,9 @@ sub setQueue()
 	foreach my $qelem(@qelems)
 	{
 		# get the minimum/maximum # nodes allowed for each queue.  
-		my $jobmin = undef;
-		my $jobmax = undef;
-		$jobmin = $qelem->getAttribute('jobmin');
-		$jobmax = $qelem->getAttribute('jobmax');
+
+		my $jobmin = $qelem->getAttribute('jobmin');
+		my $jobmax = $qelem->getAttribute('jobmax');
 
 		# if the fullsum is between the min and max # jobs, then use this queue.  
 		if(defined $jobmin && defined $jobmax && $self->{'fullsum'} >= $jobmin && $self->{'fullsum'} <= $jobmax)


### PR DESCRIPTION
The previous queue (debug) should probably not be the default queue
because it can't run acme_developer via create_test (creates too many
jobs in the queue). This commit changes the default to the regular
queue.

Also, change BatchMaker to prefer the default queue if that queue
mathes the job specs.

[BFB]
