### PR TITLE
edgeVunpackVert() bugfix

### DIFF
--- a/components/homme/src/share/edge_mod.F90
+++ b/components/homme/src/share/edge_mod.F90
@@ -1060,6 +1060,8 @@ endif
     !call t_adj_detailf(-2)
 
   end subroutine edgeVunpack
+
+
   subroutine edgeVunpackVert(edge,v,ielem)
     use control_mod, only : north, south, east, west, neast, nwest, seast, swest
     use dimensions_mod, only : np, max_corner_elem, ne
@@ -1071,7 +1073,7 @@ endif
 
     ! Local
     logical, parameter :: UseUnroll = .TRUE.
-    integer :: i,k,l
+    integer :: i,k,l, nce
     integer :: is,ie,in,iw,ine,inw,isw,ise
 
     threadsafe=.false.
@@ -1093,102 +1095,102 @@ endif
     ! N+S
     do i=1,np/2
        ! North
-       !kptr = 0
-       !iptr=np*(kptr+k-1)+in
-       ! iptr = np*(k-1)+in
+       ! kptr = 0
+       ! iptr=np*(kptr+k-1)+in
   
-!       v(3,i ,np)%x = edge%buf(1,in+i) 
-       ! iptr = np*(1-1)+in 
-       v(3,i ,np)%x = edge%buf(in+i) 
+!      iptr = np*(1-1)+in 
+!      v(3,i ,np)%x = edge%receive(1,in+i) 
+       v(3,i ,np)%x = edge%receive(in+i) 
 
-!       v(3,i ,np)%y = edge%buf(2,in+i) 
-       ! iptr = np*(2-1)+in 
-!       iptr = np+in
-       v(3,i ,np)%y = edge%buf(np+in+i) 
+!      iptr = np*(2-1)+in 
+!      v(3,i ,np)%y = edge%receive(2,in+i) 
+       v(3,i ,np)%y = edge%receive(np+in+i) 
 
-!       v(3,i ,np)%z = edge%buf(3,in+i) 
-!       iptr = np*(3-1)+in 
-!       iptr = 2*np+in
-       v(3,i ,np)%z = edge%buf(2*np+in+i) 
+!      iptr = np*(3-1)+in 
+!      v(3,i ,np)%z = edge%receive(3,in+i) 
+       v(3,i ,np)%z = edge%receive(2*np+in+i) 
 
        ! South
-       ! v(2,i ,1)%x  = edge%buf(1,is+i) 
-       v(2,i ,1)%x  = edge%buf(is+i) 
-       ! v(2,i ,1)%y  = edge%buf(2,is+i) 
-       v(2,i ,1)%y  = edge%buf(np+is+i) 
-       ! v(2,i ,1)%y  = edge%buf(3,is+i) 
-       v(2,i ,1)%z  = edge%buf(2*np+is+i) 
+       ! v(2,i ,1)%x  = edge%receive(1,is+i) 
+       v(2,i ,1)%x  = edge%receive(is+i) 
+
+       ! v(2,i ,1)%y  = edge%receive(2,is+i) 
+       v(2,i ,1)%y  = edge%receive(np+is+i) 
+
+       ! v(2,i ,1)%z  = edge%receive(3,is+i) 
+       v(2,i ,1)%z  = edge%receive(2*np+is+i) 
     enddo
 
     do i=np/2+1,np
        ! North
-       ! v(4,i ,np)%x = edge%buf(1,in+i) 
-       v(4,i ,np)%x = edge%buf(in+i) 
+       ! v(4,i ,np)%x = edge%receive(1,in+i) 
+       v(4,i ,np)%x = edge%receive(in+i) 
 
-       ! v(4,i ,np)%y = edge%buf(2,in+i) 
-       v(4,i ,np)%y = edge%buf(np+in+i) 
+       ! v(4,i ,np)%y = edge%receive(2,in+i) 
+       v(4,i ,np)%y = edge%receive(np+in+i) 
 
-       ! v(4,i ,np)%z = edge%buf(3,in+i) 
-       v(4,i ,np)%z = edge%buf(2*np+in+i) 
+       ! v(4,i ,np)%z = edge%receive(3,in+i) 
+       v(4,i ,np)%z = edge%receive(2*np+in+i) 
        ! South
-       ! v(1,i ,1)%x  = edge%buf(1,is+i) 
-       v(1,i ,1)%x  = edge%buf(is+i) 
-       ! v(1,i ,1)%y  = edge%buf(2,is+i) 
-       v(1,i ,1)%y  = edge%buf(np+is+i) 
-       ! v(1,i ,1)%z  = edge%buf(3,is+i)        
-       v(1,i ,1)%z  = edge%buf(2*np+is+i)        
+       ! v(1,i ,1)%x  = edge%receive(1,is+i) 
+       v(1,i ,1)%x  = edge%receive(is+i) 
+       ! v(1,i ,1)%y  = edge%receive(2,is+i) 
+       v(1,i ,1)%y  = edge%receive(np+is+i) 
+       ! v(1,i ,1)%z  = edge%receive(3,is+i)        
+       v(1,i ,1)%z  = edge%receive(2*np+is+i)        
     enddo
 
     do i=1,np/2
        ! East
-       ! v(3,np,i)%x = edge%buf(1,ie+i)
-       v(3,np,i)%x = edge%buf(ie+i)
-       ! v(3,np,i)%y = edge%buf(2,ie+i)
-       v(3,np,i)%y = edge%buf(np+ie+i)
-       ! v(3,np,i)%z = edge%buf(3,ie+i)       
-       v(3,np,i)%z = edge%buf(2*np+ie+i)       
+       ! v(3,np,i)%x = edge%receive(1,ie+i)
+       v(3,np,i)%x = edge%receive(ie+i)
+       ! v(3,np,i)%y = edge%receive(2,ie+i)
+       v(3,np,i)%y = edge%receive(np+ie+i)
+       ! v(3,np,i)%z = edge%receive(3,ie+i)       
+       v(3,np,i)%z = edge%receive(2*np+ie+i)       
        ! West
-       ! v(4,1,i)%x  = edge%buf(1,iw+i)
-       v(4,1,i)%x  = edge%buf(iw+i)
-       ! v(4,1,i)%y  = edge%buf(2,iw+i)
-       v(4,1,i)%y  = edge%buf(np+iw+i)
-       ! v(4,1,i)%z  = edge%buf(3,iw+i)
-       v(4,1,i)%z  = edge%buf(2*np+iw+i)
+       ! v(4,1,i)%x  = edge%receive(1,iw+i)
+       v(4,1,i)%x  = edge%receive(iw+i)
+       ! v(4,1,i)%y  = edge%receive(2,iw+i)
+       v(4,1,i)%y  = edge%receive(np+iw+i)
+       ! v(4,1,i)%z  = edge%receive(3,iw+i)
+       v(4,1,i)%z  = edge%receive(2*np+iw+i)
     end do
 
     do i=np/2+1,np
        ! East
-       ! v(2,np,i)%x = edge%buf(1,ie+i)
-       v(2,np,i)%x = edge%buf(ie+i)
+       ! v(2,np,i)%x = edge%receive(1,ie+i)
+       v(2,np,i)%x = edge%receive(ie+i)
 
-       ! v(2,np,i)%y = edge%buf(2,ie+i)
-       v(2,np,i)%y = edge%buf(np+ie+i)
+       ! v(2,np,i)%y = edge%receive(2,ie+i)
+       v(2,np,i)%y = edge%receive(np+ie+i)
 
-       ! v(2,np,i)%z = edge%buf(3,ie+i)       
-       v(2,np,i)%z = edge%buf(2*np+ie+i)       
+       ! v(2,np,i)%z = edge%receive(3,ie+i)       
+       v(2,np,i)%z = edge%receive(2*np+ie+i)       
        ! West
 
-       ! v(1,1,i)%x  = edge%buf(1,iw+i)
-       v(1,1,i)%x  = edge%buf(iw+i)
+       ! v(1,1,i)%x  = edge%receive(1,iw+i)
+       v(1,1,i)%x  = edge%receive(iw+i)
 
-       ! v(1,1,i)%y  = edge%buf(2,iw+i)
-       v(1,1,i)%y  = edge%buf(np+iw+i)
+       ! v(1,1,i)%y  = edge%receive(2,iw+i)
+       v(1,1,i)%y  = edge%receive(np+iw+i)
 
-       ! v(1,1,i)%z  = edge%buf(3,iw+i)
-       v(1,1,i)%z  = edge%buf(2*np+iw+i)
+       ! v(1,1,i)%z  = edge%receive(3,iw+i)
+       v(1,1,i)%z  = edge%receive(2*np+iw+i)
     end do
 
 ! SWEST
+    nce = max_corner_elem
     do l=swest,swest+max_corner_elem-1
        ! find the one active corner, then exist
         isw=edge%getmap(l,ielem)
         if(isw /= -1) then 
-            ! v(1,1,1)%x=edge%buf(1,desc%getmapP(l)+1)
-            v(1,1,1)%x=edge%buf(isw+1)
-            ! v(1,1,1)%y=edge%buf(2,desc%getmapP(l)+1)
-            v(1,1,1)%y=edge%buf(np+isw+1)
-            ! v(1,1,1)%z=edge%buf(3,desc%getmapP(l)+1)
-            v(1,1,1)%z=edge%buf(2*np+isw+1)
+            ! v(1,1,1)%x=edge%receive(1,desc%getmapP(l)+1)
+            v(1,1,1)%x=edge%receive(isw+1)
+            ! v(1,1,1)%y=edge%receive(2,desc%getmapP(l)+1)
+            v(1,1,1)%y=edge%receive(nce+isw+1)
+            ! v(1,1,1)%z=edge%receive(3,desc%getmapP(l)+1)
+            v(1,1,1)%z=edge%receive(2*nce+isw+1)
             exit 
         else
             v(1,1,1)%x=0_real_kind
@@ -1202,12 +1204,12 @@ endif
        ! find the one active corner, then exist
         ise=edge%getmap(l,ielem)
         if(ise /= -1) then 
-            ! v(2,np,1)%x=edge%buf(1,desc%getmapP(l)+1)
-            v(2,np,1)%x=edge%buf(ise+1)
-            ! v(2,np,1)%y=edge%buf(2,desc%getmapP(l)+1)
-            v(2,np,1)%y=edge%buf(np+ise+1)
-            ! v(2,np,1)%z=edge%buf(3,desc%getmapP(l)+1)
-            v(2,np,1)%z=edge%buf(2*np+ise+1)
+            ! v(2,np,1)%x=edge%receive(1,desc%getmapP(l)+1)
+            v(2,np,1)%x=edge%receive(ise+1)
+            ! v(2,np,1)%y=edge%receive(2,desc%getmapP(l)+1)
+            v(2,np,1)%y=edge%receive(nce+ise+1)
+            ! v(2,np,1)%z=edge%receive(3,desc%getmapP(l)+1)
+            v(2,np,1)%z=edge%receive(2*nce+ise+1)
             exit
         else
             v(2,np,1)%x=0_real_kind
@@ -1221,9 +1223,9 @@ endif
        ! find the one active corner, then exist
         ine=edge%getmap(l,ielem)
         if(ine /= -1) then 
-            v(3,np,np)%x=edge%buf(ine+1)
-            v(3,np,np)%y=edge%buf(np+ine+1)
-            v(3,np,np)%z=edge%buf(2*np+ine+1)
+            v(3,np,np)%x=edge%receive(ine+1)
+            v(3,np,np)%y=edge%receive(nce+ine+1)
+            v(3,np,np)%z=edge%receive(2*nce+ine+1)
             exit
         else
             v(3,np,np)%x=0_real_kind
@@ -1237,9 +1239,9 @@ endif
        ! find the one active corner, then exist
         inw = edge%getmap(l,ielem)
         if(inw/= -1) then 
-            v(4,1,np)%x=edge%buf(inw+1)
-            v(4,1,np)%y=edge%buf(np+inw+1)
-            v(4,1,np)%z=edge%buf(2*np+inw+1)
+            v(4,1,np)%x=edge%receive(inw+1)
+            v(4,1,np)%y=edge%receive(nce+inw+1)
+            v(4,1,np)%z=edge%receive(2*nce+inw+1)
             exit
         else
             v(4,1,np)%x=0_real_kind
@@ -1295,6 +1297,9 @@ endif
     end do
 
   end subroutine edgeVunpackVert
+
+
+
   ! ========================================
   ! edgeDGVunpack:
   !

--- a/components/homme/src/surfaces_mod.F90
+++ b/components/homme/src/surfaces_mod.F90
@@ -1909,6 +1909,7 @@ subroutine construct_cv_gll(elem,hybrid,nets,nete)
                    stop 'bad value of nvert'
                 endif
                 if (.not. corner) then
+                   print *,'non-corner node with only 3 verticies'
                    print *,'ie,i,j,nvert,corner=',ie,i,j,nvert,corner
                    print *,cvlist(ie)%vert(1,i,j)%x
                    print *,cvlist(ie)%vert(2,i,j)%x
@@ -1921,6 +1922,27 @@ subroutine construct_cv_gll(elem,hybrid,nets,nete)
                    !enddo
                    stop 'ERROR: corner point should have nvert=3'
                 endif
+                ! nvert=3.  we are at a cube corner.  One of the control volume
+                ! nodes from the 'missing' corner element should be all zeros:
+                if (cvlist(ie)%vert(1,i,j)%x==0) then
+                   ! ok
+                else if (cvlist(ie)%vert(2,i,j)%x==0) then
+                   ! ok
+                else if (cvlist(ie)%vert(3,i,j)%x==0) then
+                   ! ok
+                else if (cvlist(ie)%vert(4,i,j)%x==0) then
+                   ! ok
+                else
+                   print *,'cube corner node with 4 neighbors'
+                   print *,'ie,i,j,nvert,corner=',ie,i,j,nvert,corner
+                   print *,cvlist(ie)%vert(1,i,j)%x
+                   print *,cvlist(ie)%vert(2,i,j)%x
+                   print *,cvlist(ie)%vert(3,i,j)%x
+                   print *,cvlist(ie)%vert(4,i,j)%x
+                   stop 'control volume at cube corner should be a triangle'
+                endif
+                
+
              endif
           enddo
        enddo


### PR DESCRIPTION
code crashes when computing GLL node dual grid coordinates. These
coordinates are used to produce grid 'template' files needed by ESMF
to generate mapping files.

Mark T: identified and traced bug to changes in edgeVunpackVert
(introduced in HOMME NCAR SVN repo revision 4097 and inherited by
ACME). Bug fixed by John Dennis 12/2015

Fixes #532 
