### PR TITLE
Support for a generic linux machine

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -346,6 +346,18 @@
     <GMAKE_J>4</GMAKE_J>
     <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>2</PES_PER_NODE>
+    <batch_system type="none" version="x.y">
+      <queues>
+      </queues>
+      <walltimes>
+      </walltimes>
+    </batch_system>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks"> -np {{ num_tasks }}</arg>
+      </arguments>
+    </mpirun>
 </machine>
 
 <machine MACH="melvin">


### PR DESCRIPTION
Adding support for a generic linux machine (laptop) in cime.
The user can set the locations for the NetCDF and PnetCDF
libraries via the NETCDF (default /usr/lib) and PNETCDF
(no default) environment variables.

[BFB]
SEG-81
