### PR TITLE
wait_for_tests: add support for uploading files

### DIFF
--- a/cime/scripts-acme/wait_for_tests.py
+++ b/cime/scripts-acme/wait_for_tests.py
@@ -1,4 +1,4 @@
-import os, doctest, time, threading, Queue, socket, signal, distutils.spawn
+import os, doctest, time, threading, Queue, socket, signal, distutils.spawn, shutil, glob
 
 import xml.etree.ElementTree as xmlet
 
@@ -40,7 +40,7 @@ def set_up_signal_handlers():
 def get_test_time(test_path):
 ###############################################################################
     cmd = "grep TIME %s" % os.path.join(test_path, TEST_STATUS_FILENAME)
-    stat, output, errput = acme_util.run_cmd(cmd, ok_to_fail=True, verbose=True)
+    stat, output, _ = acme_util.run_cmd(cmd, ok_to_fail=True, verbose=True)
     if (stat == 0):
         return int(output.split()[-1])
     else:
@@ -58,78 +58,16 @@ def get_test_output(test_path):
         return ""
 
 ###############################################################################
-def create_cdash_xml(results, cdash_build_name, cdash_project, cdash_build_group):
+def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname):
 ###############################################################################
-
-    #
-    # Create dart config file
-    #
-
-    # Pretending current time is our start time gives us the maximum window (24 hours)
-    # in which these test results will be displayed on the Cdash front-page
-    # dashboard. Cdash removes things from the dashboard after 24 hours from
-    # the NightlyStartTime.
-    current_time = time.time()
-
-    utc_time_tuple = time.gmtime(current_time)
-    cdash_timestamp = time.strftime("%H:%M:%S", utc_time_tuple)
-
     git_commit = acme_util.get_current_commit(repo=acme_util.get_cime_root())
 
-    hostname = acme_util.probe_machine_name()
-    if (hostname is None):
-        hostname = socket.gethostname().split(".")[0]
-        warning("Could not convert hostname '%s' into an ACME machine name" % (hostname))
-
-    dart_config = \
-"""
-SourceDirectory: %s
-BuildDirectory: %s
-
-# Site is something like machine.domain, i.e. pragmatic.crd
-Site: %s
-
-# Build name is osname-revision-compiler, i.e. Linux-2.4.2-2smp-c++
-BuildName: %s
-
-# Submission information
-IsCDash: TRUE
-CDashVersion:
-QueryCDashVersion:
-DropSite: my.cdash.org
-DropLocation: /submit.php?project=%s
-DropSiteUser:
-DropSitePassword:
-DropSiteMode:
-DropMethod: http
-TriggerSite:
-ScpCommand: %s
-
-# Dashboard start time
-NightlyStartTime: %s UTC
-""" % (os.getcwd(), os.getcwd(), hostname,
-       cdash_build_name, cdash_project, distutils.spawn.find_executable("scp"), cdash_timestamp)
-
-    with open("DartConfiguration.tcl", "w") as dart_fd:
-        dart_fd.write(dart_config)
-
-    # Make necessary dirs
-    subdir_name = time.strftime('%Y%m%d-%H%M', utc_time_tuple)
-    data_rel_path = os.path.join("Testing", subdir_name)
-    os.makedirs(data_rel_path)
-
-    # Make tag file
-    with open("Testing/TAG", "w") as tag_fd:
-        tag_fd.write("%s\n%s\n" % (subdir_name, cdash_build_group))
-
-    #
-    # Make XML
-    #
+    data_rel_path = os.path.join("Testing", utc_time)
 
     site_elem = xmlet.Element("Site")
 
     site_elem.attrib["BuildName"] = cdash_build_name
-    site_elem.attrib["BuildStamp"] = "%s-%s" % (subdir_name, cdash_build_group)
+    site_elem.attrib["BuildStamp"] = "%s-%s" % (utc_time, cdash_build_group)
     site_elem.attrib["Name"] = hostname
     site_elem.attrib["OSName"] = "Linux"
     site_elem.attrib["Hostname"] = hostname
@@ -202,6 +140,130 @@ NightlyStartTime: %s UTC
     etree = xmlet.ElementTree(site_elem)
 
     etree.write(os.path.join(data_rel_path, "Test.xml"))
+
+###############################################################################
+def create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_time, hostname):
+###############################################################################
+
+    data_rel_path = os.path.join("Testing", utc_time)
+
+    try:
+        log_dir = "%s_logs" % cdash_build_name
+
+        need_to_upload = False
+
+        for test_name, test_data in results.iteritems():
+            test_path, test_status = test_data
+
+            if (test_status not in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS]):
+                full_results = parse_test_status_file(test_path)[0]
+
+                if (full_results["BUILD"] != TEST_PASS_STATUS or
+                    full_results["RUN"]   != TEST_PASS_STATUS):
+
+                    param = "EXEROOT" if full_results["BUILD"] != TEST_PASS_STATUS else "RUNDIR"
+                    src_dir = acme_util.run_cmd("./xmlquery %s -value" % param, from_dir=os.path.dirname(test_path))
+                    log_dst_dir = os.path.join(log_dir, "%s_%s_logs" % (test_name, param))
+                    os.makedirs(log_dst_dir)
+                    for log_file in glob.glob(os.path.join(src_dir, "*log*")):
+                        shutil.copy(log_file, log_dst_dir)
+
+                    need_to_upload = True
+
+        if (need_to_upload):
+
+            tarball = "%s.tar.gz" % log_dir
+            if (os.path.exists(tarball)):
+                os.remove(tarball)
+
+            acme_util.run_cmd("tar -cf - %s | gzip -c > %s" % (log_dir, tarball))
+            base64 = acme_util.run_cmd("base64 %s" % tarball)
+
+            xml_text = \
+r"""<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="Dart/Source/Server/XSL/Build.xsl <file:///Dart/Source/Server/XSL/Build.xsl> "?>
+<Site BuildName="%s" BuildStamp="%s-%s" Name="%s" Generator="ctest3.0.0">
+<Upload>
+<File filename="%s">
+<Content encoding="base64">
+%s
+</Content>
+</File>
+</Upload>
+</Site>
+""" % (cdash_build_name, utc_time, cdash_build_group, hostname, os.path.abspath(tarball), base64)
+
+            with open(os.path.join(data_rel_path, "Upload.xml"), "w") as fd:
+                fd.write(xml_text)
+
+    finally:
+        if (os.path.isdir(log_dir)):
+            shutil.rmtree(log_dir)
+
+###############################################################################
+def create_cdash_xml(results, cdash_build_name, cdash_project, cdash_build_group):
+###############################################################################
+
+    #
+    # Create dart config file
+    #
+
+    # Pretending current time is our start time gives us the maximum window (24 hours)
+    # in which these test results will be displayed on the Cdash front-page
+    # dashboard. Cdash removes things from the dashboard after 24 hours from
+    # the NightlyStartTime.
+    current_time = time.time()
+
+    utc_time_tuple = time.gmtime(current_time)
+    cdash_timestamp = time.strftime("%H:%M:%S", utc_time_tuple)
+
+    hostname = acme_util.probe_machine_name()
+    if (hostname is None):
+        hostname = socket.gethostname().split(".")[0]
+        warning("Could not convert hostname '%s' into an ACME machine name" % (hostname))
+
+    dart_config = \
+"""
+SourceDirectory: %s
+BuildDirectory: %s
+
+# Site is something like machine.domain, i.e. pragmatic.crd
+Site: %s
+
+# Build name is osname-revision-compiler, i.e. Linux-2.4.2-2smp-c++
+BuildName: %s
+
+# Submission information
+IsCDash: TRUE
+CDashVersion:
+QueryCDashVersion:
+DropSite: my.cdash.org
+DropLocation: /submit.php?project=%s
+DropSiteUser:
+DropSitePassword:
+DropSiteMode:
+DropMethod: http
+TriggerSite:
+ScpCommand: %s
+
+# Dashboard start time
+NightlyStartTime: %s UTC
+""" % (os.getcwd(), os.getcwd(), hostname,
+       cdash_build_name, cdash_project, distutils.spawn.find_executable("scp"), cdash_timestamp)
+
+    with open("DartConfiguration.tcl", "w") as dart_fd:
+        dart_fd.write(dart_config)
+
+    utc_time = time.strftime('%Y%m%d-%H%M', utc_time_tuple)
+    os.makedirs(os.path.join("Testing", utc_time))
+
+    # Make tag file
+    with open("Testing/TAG", "w") as tag_fd:
+        tag_fd.write("%s\n%s\n" % (utc_time, cdash_build_group))
+
+    create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname)
+
+    create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_time, hostname)
 
     acme_util.run_cmd("ctest -VV -D NightlySubmit", verbose=True)
 


### PR DESCRIPTION
Whenever a test has a build failure or run failure, the build/run
logs for the test will be copied into a directory, and, along with
all the other logs of failing tests, will be zipped and uploaded to
the CDash page.

SEG-194

[BFB]
