### PR TITLE
Add Python v2.7 to Cori builds

### DIFF
--- a/cime/machines-acme/env_mach_specific.corip1
+++ b/cime/machines-acme/env_mach_specific.corip1
@@ -76,6 +76,7 @@ else
 endif
 
 #module load perl/5.20.0
+module load python
 module load cmake
 module load cray-petsc
 module load cray-libsci


### PR DESCRIPTION
Cori's default python is v2.6 and ACME requires at least v2.7.

[BFB]
