### PR TITLE
Fix failing regression test. Change melvin config.

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -371,12 +371,12 @@
     <CESMSCRATCHROOT>$ENV{HOME}/acme/scratch</CESMSCRATCHROOT>
     <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
-    <DIN_LOC_ROOT>/home/jgfouca/acme/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/home/jgfouca/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT>/sems-data-store/ACME/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/sems-data-store/ACME/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CESMSCRATCHROOT/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-    <CCSM_BASELINE>/home/jgfouca/acme/baselines</CCSM_BASELINE>
-    <CCSM_CPRNC>/home/jgfouca/acme/cprnc/build/cprnc</CCSM_CPRNC>
+    <CCSM_BASELINE>/sems-data-store/ACME/baselines</CCSM_BASELINE>
+    <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build/cprnc</CCSM_CPRNC>
     <BATCHQUERY></BATCHQUERY>
     <BATCHSUBMIT></BATCHSUBMIT>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>

--- a/cime/scripts-acme/tests/scripts_regression_tests
+++ b/cime/scripts-acme/tests/scripts_regression_tests
@@ -206,7 +206,7 @@ class TestWaitForTests(unittest.TestCase):
 
         make_fake_teststatus(os.path.join(self._testdir_unfinished, "TestStatus_5"), "Test_5", "PASS", "PHASE_5")
 
-        run_thread.join(timeout=130)
+        run_thread.join(timeout=10)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
@@ -226,7 +226,7 @@ class TestWaitForTests(unittest.TestCase):
 
         kill_python_subprocesses(signal.SIGTERM, expected_num_killed=1, tester=self)
 
-        run_thread.join(timeout=130)
+        run_thread.join(timeout=10)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
@@ -240,7 +240,7 @@ class TestWaitForTests(unittest.TestCase):
         run_thread.daemon = True
         run_thread.start()
 
-        run_thread.join(timeout=130)
+        run_thread.join(timeout=10)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
@@ -262,7 +262,7 @@ class TestWaitForTests(unittest.TestCase):
 
         kill_python_subprocesses(signal.SIGTERM, expected_num_killed=1, tester=self)
 
-        run_thread.join(timeout=130)
+        run_thread.join(timeout=10)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
@@ -488,7 +488,7 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
     ###########################################################################
     def simple_test(self, expect_works, extra_args):
     ###########################################################################
-        stat, output, errput = run_cmd("%s/jenkins_generic_job -t acme_test_only_pass %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
+        stat, output, errput = run_cmd("%s/jenkins_generic_job %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
         if (expect_works):
             self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
         else:
@@ -535,11 +535,11 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
 
         # Generate fresh baselines so that this test is not impacted by
         # unresolved diffs
-        self.simple_test(True, "-g -b %s" % self._baseline_name)
+        self.simple_test(True, "-t acme_test_only_pass -g -b %s" % self._baseline_name)
         self.assert_num_leftovers()
 
         build_name = "jenkins_generic_job_pass_%s" % acme_util.get_utc_timestamp()
-        self.simple_test(True, "-p ACME_test -b %s -d -c %s --cdash-build-group=Nightly" % (self._baseline_name, build_name))
+        self.simple_test(True, "-t acme_test_only_pass -p ACME_test -b %s -d -c %s --cdash-build-group=Nightly" % (self._baseline_name, build_name))
         self.assert_num_leftovers() # jenkins_generic_job should have automatically cleaned up leftovers from prior run
         self.assert_no_sentinel()
         assert_dashboard_has_build(self, build_name)
@@ -548,7 +548,7 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
     def test_jenkins_generic_job_kill(self):
     ###########################################################################
         build_name = "jenkins_generic_job_kill_%s" % acme_util.get_utc_timestamp()
-        run_thread = threading.Thread(target=self.threaded_test, args=(False, "-p ACME_test -b master -d -c %s --cdash-build-group=Nightly" % build_name))
+        run_thread = threading.Thread(target=self.threaded_test, args=(False, " -t acme_test_only_slow_pass -p ACME_test -b master --baseline-compare=no -d -c %s --cdash-build-group=Nightly" % build_name))
         run_thread.daemon = True
         run_thread.start()
 
@@ -556,7 +556,7 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
 
         kill_subprocesses(sig=signal.SIGTERM)
 
-        run_thread.join(timeout=130)
+        run_thread.join(timeout=10)
 
         self.assertFalse(run_thread.isAlive(), msg="jenkins_generic_job should have finished")
         self.assert_no_sentinel()

--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -21,6 +21,12 @@ _TEST_SUITES = {
                     "TESTRUNPASS_P1.f45_g37_rx1.A")
                    ),
 
+    "acme_test_only_slow_pass" : (None,
+                   ("TESTRUNSLOWPASS_P1.f19_g16_rx1.A",
+                    "TESTRUNSLOWPASS_P1.ne30_g16_rx1.A",
+                    "TESTRUNSLOWPASS_P1.f45_g37_rx1.A")
+                   ),
+
     "acme_test_only" : (None,
                    ("TESTBUILDFAIL.f19_g16_rx1.A",
                     "TESTRUNFAIL_P1.f19_g16_rx1.A",

--- a/cime/scripts/Testing/Testcases/TESTRUNSLOWPASS_build.csh
+++ b/cime/scripts/Testing/Testcases/TESTRUNSLOWPASS_build.csh
@@ -1,0 +1,22 @@
+#!/bin/csh -f
+
+./Tools/check_lockedfiles || exit -1
+
+set EXEROOT  = `./xmlquery EXEROOT -value`
+set RUNDIR   = `./xmlquery RUNDIR -value`
+set TESTID   = `./xmlquery TEST_TESTID -value`
+
+echo "#! /bin/bash" > $EXEROOT/cesm.exe
+echo "sleep 300" >> $EXEROOT/cesm.exe
+echo "echo Slow pass" >> $EXEROOT/cesm.exe
+echo "echo SUCCESSFUL TERMINATION > $RUNDIR/cpl.log.$TESTID" >> $EXEROOT/cesm.exe
+
+chmod +x $EXEROOT/cesm.exe
+
+echo "Build phase complete, just made simple script for cesm.exe" | tee $EXEROOT/cesm.bldlog.$TESTID
+
+./xmlchange -noecho -file env_build.xml -id BUILD_COMPLETE -val TRUE
+
+rm -rf LockedFiles/*
+
+exit 0

--- a/cime/scripts/Testing/Testcases/TESTRUNSLOWPASS_script
+++ b/cime/scripts/Testing/Testcases/TESTRUNSLOWPASS_script
@@ -1,0 +1,10 @@
+
+cd $CASEROOT
+
+./$CASE.run
+if ($status != 0) then
+    echo " ERROR: $CASE.run failed" >>& $TESTSTATUS_LOG
+    exit -1
+endif
+
+set CplLogFile = `ls -1t $RUNDIR/cpl.log* | head -1`

--- a/cime/scripts/Testing/Testcases/config_tests.xml
+++ b/cime/scripts/Testing/Testcases/config_tests.xml
@@ -71,6 +71,15 @@
           CHECK_TIMING="FALSE"
           DOUT_S="FALSE" />
 
+<ccsmtest NAME="TESTRUNSLOWPASS"
+          DESC="For testing infra only. After 5 minutes of sleep, pass run step."
+          INFO_DBUG="1"
+          CCSM_TCOST="0"
+          STOP_OPTION="ndays"
+          STOP_N="11"
+          CHECK_TIMING="FALSE"
+          DOUT_S="FALSE" />
+
 <ccsmtest NAME="ERT"
           DESC="exact restart from startup, default 2 month + 1 month (ERS with info dbug = 1)"
           INFO_DBUG="1"


### PR DESCRIPTION
Added new TESTRUNSLOWPASS testcase. This will be useful for simulating
a long running test, which is useful for testing timeout and kill behavior.

Change melvin config to use sems-data-store for ACME input data and baselines.

[BFB]
