### PR TITLE
Update blues pgi to pgi 15.10

### DIFF
--- a/cime/machines-acme/config_compilers.xml
+++ b/cime/machines-acme/config_compilers.xml
@@ -804,9 +804,11 @@ for mct, etc.
   <NETCDF_PATH>$(NETCDFROOT)</NETCDF_PATH>
   <MPI_PATH MPILIB="openmpi">/soft/openmpi/1.8.2/pgi-13.9</MPI_PATH>
   <MPI_PATH MPILIB="mpich">/soft/mpich2/1.4.1-pgi-13.9/</MPI_PATH>
+  <MPI_LIB_NAME MPILIB="mvapich"> mpi</MPI_LIB_NAME>
   <MPI_LIB_NAME MPILIB="openmpi"> mpi</MPI_LIB_NAME>
   <MPI_LIB_NAME MPILIB="mpich">mpich</MPI_LIB_NAME>
   <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nc-config --flibs) -llapack -lblas</ADD_SLIBS>
+  <ADD_SLIBS> -rpath $(NETCDFROOT)/lib </ADD_SLIBS>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
 </compiler>
 

--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -491,7 +491,7 @@
          <NODENAME_REGEX>blogin</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>pgi,intel,gnu,nag</COMPILERS>
-         <MPILIBS>mpich,mvapich,openmpi,mpi-serial</MPILIBS>
+         <MPILIBS>mvapich,mpich,openmpi,mpi-serial</MPILIBS>
          <CESMSCRATCHROOT>/lcrc/project/$PROJECT/$USER/acme_scratch</CESMSCRATCHROOT>
          <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
          <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>

--- a/cime/machines-acme/env_mach_specific.blues
+++ b/cime/machines-acme/env_mach_specific.blues
@@ -36,7 +36,7 @@ if ( $COMPILER == "intel" ) then
   endif
 endif
 
-if ( $COMPILER == "pgi" ) then
+if ( $COMPILER == "pgi-13" ) then
   soft add +pgi-13.9
 #  soft add +netcdf-4.3.1-serial-pgi
   setenv NETCDFROOT /home/jacob/netcdf-4.3.3.1pg13.9
@@ -60,6 +60,25 @@ if ( $COMPILER == "pgi" ) then
    soft add +mpich2-1.4.1-pgi-13.9
    soft add +pnetcdf-1.5.0-mpich2-pgi-13.9
    setenv PNETCDFROOT /soft/pnetcdf/1.5.0/pgi-13.9/mpich2-1.4.1
+  endif
+endif
+
+if ( $COMPILER == "pgi" ) then
+  soft add +pgi-15.10
+  setenv NETCDFROOT /soft/climate/netcdf/4.3.3.1c-4.2cxx-4.4.2f-serial/pgi-15.10
+  setenv PATH $NETCDFROOT/bin:$PATH
+  setenv LD_LIBRARY_PATH $NETCDFROOT/lib:$LD_LIBRARY_PATH
+  setenv NETCDF_INCLUDES $NETCDFROOT/include
+  setenv NETCDF_LIBS $NETCDFROOT/lib
+  if ( $MPILIB == "mpi-serial") then
+   setenv PNETCDFROOT ""
+  else if ( $MPILIB == "mvapich") then
+   soft add +mvapich2-2.2b-pgi-15.10
+   setenv PNETCDFROOT /soft/climate/pnetcdf/1.6.1/pgi-15.10/mvapich2-2.2b-pgi-15.10
+  else
+   # default - mvapich+pnetcdf
+   soft add +mvapich2-2.2b-pgi-15.10
+   setenv PNETCDFROOT /soft/climate/pnetcdf/1.6.1/pgi-15.10/mvapich2-2.2b-pgi-15.10
   endif
 endif
 


### PR DESCRIPTION
Upgrading the default pgi compiler on blues from 13.9 to 15.10.
The older default pgi compiler configuration has been renamed
to "pgi-13"

mvapich is currently the only MPI library for pgi-15.10 (pgi)
(non-BFB for older version of pgi)

[BFB]
