### PR TITLE
create_test: Be careful what you tell user about test status

### DIFF
--- a/cime/scripts-acme/bless_test_results
+++ b/cime/scripts-acme/bless_test_results
@@ -22,7 +22,7 @@ from acme_util import expect, warning, verbose_print, run_cmd
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-usage="""\n%s [-r] [-n] [-t <TESTROOT>] [<TEST> <TEST> ...] [--verbose]
+usage="""\n%s [-n] [-r <TESTROOT>] [-t <TESTID>] [<TEST> <TEST> ...] [--verbose]
 OR
 %s --help
 OR
@@ -37,7 +37,9 @@ OR
     > %s foo bar
     \033[1;32m# From most recent run, bless only namelist changes to test foo and bar only \033[0m
     > %s -n foo bar
-""" % ((os.path.basename(args[0]), ) * 7),
+    \033[1;32m# From most recent run of jenkins, bless history changes for next \033[0m
+    > %s -r /home/jenkins/acme/scratch/jenkins -b next -t jenkins_next_20151218_083102 --hist-only
+""" % ((os.path.basename(args[0]), ) * 8),
 
 description=description,
 

--- a/cime/scripts-acme/wait_for_tests.py
+++ b/cime/scripts-acme/wait_for_tests.py
@@ -353,10 +353,12 @@ def interpret_status(file_contents, check_throughput=False, check_memory=False, 
     ('testname', 'DIFF')
     """
     statuses, test_name = parse_test_status(file_contents)
-    if (RUN_PHASE not in statuses.keys()):
-        warning("Waiting for test '%s' that has no run phase!" % test_name)
+    reduced_status = reduce_stati(statuses, check_throughput, check_memory, ignore_namelists)
 
-    return test_name, reduce_stati(statuses, check_throughput, check_memory, ignore_namelists)
+    if (RUN_PHASE not in statuses.keys() and reduced_status != TEST_FAIL_STATUS):
+        warning("Very odd: Waiting for test '%s' that has no run phase but did not fail?!?!" % test_name)
+
+    return test_name, reduced_status
 
 ###############################################################################
 def interpret_status_file(file_name, check_throughput=False, check_memory=False, ignore_namelists=False):


### PR DESCRIPTION
Do not tell a user that a test has passed if it has diffed. Even
though create_test is not directly involved in the comparison
phase, it still needs to report things correctly.

[BFB]
