### PR TITLE
Fix incorrect merge conflict resolution for blues+pgi env

### DIFF
--- a/cime/machines-acme/env_mach_specific.blues
+++ b/cime/machines-acme/env_mach_specific.blues
@@ -59,7 +59,7 @@ if ( $COMPILER == "intel" ) then
   endif
 endif
 
-if ( $COMPILER == "pgi13" ) then
+if ( $COMPILER == "pgi-13" ) then
   soft add +pgi-13.9
 #  soft add +netcdf-4.3.1-serial-pgi
   setenv NETCDFROOT /home/jacob/netcdf-4.3.3.1pg13.9
@@ -86,7 +86,7 @@ if ( $COMPILER == "pgi13" ) then
   endif
 endif
 
-if ( $COMPILER == "pgi-13" ) then
+if ( $COMPILER == "pgi" ) then
   soft add +pgi-15.10
   setenv NETCDFROOT /soft/climate/netcdf/4.3.3.1c-4.2cxx-4.4.2f-serial/pgi-15.10
   setenv PATH $NETCDFROOT/bin:$PATH


### PR DESCRIPTION
This commit fixes the incorrect merge resolution in #e45fc33
that modified the pgi build environment added in #d006da9
for blues (pgi 15.0).

Renaming the pgi 15.0 build configuration to "pgi" (default)
and renaming the older (pgi 13*) configuration to "pgi-13"

This incorrect merge resolution is currently only present on
next and not on master. So this change should only be merged
to next (The integrator would take care to resolve conflicts
to preserve the pgi build env when merging to master, so this
change does not have to go to the master).

Note: THIS CHANGE SHOULD NOT BE MERGED TO MASTER

[BFB]
SEG-81
