### PR TITLE
Fix misnamed bgc config logical in ice_comp_mct driver

### DIFF
--- a/components/mpas-cice/driver/ice_comp_mct.F
+++ b/components/mpas-cice/driver/ice_comp_mct.F
@@ -1378,7 +1378,7 @@ contains
       configs => block_ptr % configs
       call mpas_pool_get_config(configs, "config_thermodynamics_type", config_thermodynamics_type)
       call mpas_pool_get_config(configs, "config_use_aerosols", config_use_aerosols)
-      call mpas_pool_get_config(configs, "config_use_modal_aerosols", config_use_aerosols)
+      call mpas_pool_get_config(configs, "config_use_modal_aerosols", config_use_modal_aerosols)
       call mpas_pool_get_config(configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
 
       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)


### PR DESCRIPTION
One of the bgc config flags was misnamed, but it was deeper in code that
would only be accessed when more high-level BGC flags were set, and
only uncovered during initial BGC implementation. This change will not impact
any current testing, since there are no BGC tests at present.

[BFB]
[FCC]
