### PR TITLE
Define ne30np4_oEC60to30 as an available grid

### DIFF
--- a/cime/scripts/Tools/config_grid.xml
+++ b/cime/scripts/Tools/config_grid.xml
@@ -1512,7 +1512,7 @@ do not use scientific experiments; use the T62_g16 resolution instead:
   <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_QU120km_nn_151110.nc</ROF2OCN_RMAPNAME>
 </gridmap>
 <gridmap rof_grid="r05" ocn_grid="oEC60to30" >
-  <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_TO_oEC60to30_nn.151209.nc</ROF2OCN_RMAPNAME>
+  <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30_nn.160113.nc</ROF2OCN_RMAPNAME>
 </gridmap>
 <gridmap rof_grid="r05" ocn_grid="tx1v1" >
   <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</ROF2OCN_RMAPNAME>


### PR DESCRIPTION
Define ne30np4_oEC60to30 with alias ne30_oEC as a possible grid for
building a case. This is the grid for the v1 BGC experiment.
Also define mapping files for a2o, o2a and r2o.

Ran for 5 days on blues, intel with  -res ne30_oEC -compset A_B1850CN

[BFB]
CSG-111
