### PR TITLE
Update constance MPILIBS and default queue

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -702,7 +702,7 @@
          <DESC>PNL Haswell cluster, OS is Linux, batch system is SLURM</DESC>
          <OS>LINUX</OS>
          <COMPILERS>pgi,intel</COMPILERS>
-         <MPILIBS>mpich</MPILIBS>
+         <MPILIBS>mpich,mpi-serial</MPILIBS>
 	 <NODENAME_REGEX>constance</NODENAME_REGEX>
          <RUNDIR>/pic/scratch/$CCSMUSER/csmruns/$CASE/run</RUNDIR>
          <EXEROOT>/pic/scratch/$CCSMUSER/csmruns/$CASE/bld</EXEROOT>
@@ -721,10 +721,10 @@
 	 <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
 	 <batch_system type="slurm" version="x.y">
 	   <queues>
-	     <queue jobmin="1" jobmax="9999" default="true">batch</queue>
+	     <queue jobmin="1" jobmax="9999" default="true">slurm</queue>
 	   </queues>
 	   <walltimes>
-	     <walltime default="true">0:59:00</walltime>
+	     <walltime default="true">0:30:00</walltime>
 	   </walltimes>
 	 </batch_system>
 	 <mpirun mpilib="mpich">


### PR DESCRIPTION
This commit changes the default queue for constance from "batch" (which doesn't exist) to "slurm", and the default runtime to 30 minutes.

Also, this commit adds mpi-serial to the list of MPILIB options.
