### PR TITLE
Update RSF files to latest version.

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -662,8 +662,6 @@
 <xs_short_file chem="trop_mam3">atm/waccm/phot/xs_short_jpl06_c080930.nc</xs_short_file>
 <xs_long_file  chem="trop_mam3">atm/waccm/phot/temp_prs_GT200nm_jpl06_c080930.nc</xs_long_file>
 <rsf_file                     >atm/waccm/phot/RSF_GT200nm_v3.0_c080811.nc</rsf_file>
-<rsf_file     chem="trop_mam3">atm/waccm/phot/RSF_GT200nm_v3.0_c080416.nc</rsf_file>
-<rsf_file     chem="trop_mam4">atm/waccm/phot/RSF_GT200nm_v3.0_c080416.nc</rsf_file>
 <exo_coldens_file>atm/cam/chem/trop_mozart/phot/exo_coldens.nc</exo_coldens_file>
 
 <!-- WACCM Upper boundary conditions -->


### PR DESCRIPTION
rsf_file defaults are defined in namelist_defaults_cam.xml for
different chemistry options.  After consulting with Doug Kinnison at
NCAR, it was determined that the MAM configurations previously used an
older RSF file to be able to reproduce older runs, but now should be
updated to use the most recent (default) RSF file.

[Non-BFB]
[NML]
