### PR TITLE
Fix bug in implementation of I/O updates in CLUBB

### DIFF
--- a/components/cam/src/physics/cam/clubb_intr.F90
+++ b/components/cam/src/physics/cam/clubb_intr.F90
@@ -2700,7 +2700,7 @@ end function diag_ustar
     use stats_sfc_module,       only: nvarmax_sfc, stats_init_sfc ! 
     use error_code,             only: clubb_at_least_debug_level ! 
     use constants_clubb,        only: fstderr, var_length !     
-    use cam_history,            only: addfld
+    use cam_history,            only: addfld, horiz_only
     use namelist_utils,         only: find_group_name
     use units,                  only: getunit, freeunit
     use cam_abortutils,         only: endrun


### PR DESCRIPTION
Updates to the CAM I/O infrastructure introduced a bug in CLUBB.  This
commit fixes the bug by adding horiz_only to a USE statement where it
was missing.

[BFB]
FIxes #606 
