### PR TITLE
Turn on baseline comparison for redsky

### DIFF
--- a/cime/scripts-acme/jenkins_generic_job
+++ b/cime/scripts-acme/jenkins_generic_job
@@ -18,7 +18,7 @@ from acme_util import expect, warning, verbose_print
 SENTINEL_FILE = "ONGOING_TEST"
 
 # Don't know if this belongs here longterm
-MACHINES_THAT_MAINTAIN_BASELINES = ("redksy", "melvin", "skybridge")
+MACHINES_THAT_MAINTAIN_BASELINES = ("redsky", "melvin", "skybridge")
 
 ###############################################################################
 def parse_command_line(args, description):


### PR DESCRIPTION
It was supposed to be on already, but there was a typo in
jenkins_generic_job that resulted in it being off.

[BFB]
