### PR TITLE
Fixes wrong qsize_d in dimension_mod.F90

### DIFF
--- a/components/homme/src/share/dimensions_mod.F90
+++ b/components/homme/src/share/dimensions_mod.F90
@@ -27,9 +27,9 @@ module dimensions_mod
 #endif
 #else
 #ifdef QSIZE_D
-  integer, parameter         :: qsize_d=50
+  integer, parameter         :: qsize_d=QSIZE_D
 #else
-  integer, parameter         :: qsize_d=50
+  integer, parameter         :: qsize_d=4
 #endif
   integer, parameter         :: ntrac_d=4          ! fvm tracers
 #endif


### PR DESCRIPTION
Previously set to 50, now set to default to 4 like it was before and to use QSIZE_D if provided. This only affects standalone HOMME inside ACME.
