### PR TITLE
Updates to BUILD_THREADED

### DIFF
--- a/cime/scripts/Tools/cesm_build.pl
+++ b/cime/scripts/Tools/cesm_build.pl
@@ -540,6 +540,8 @@ sub buildModel()
 		   rof => $COMP_ROF);
     my $model;
 
+    my $prev_smp = $ENV{'SMP'};
+
     foreach $model(@modelsbuildorder) {
 
 	my $comp = $models{$model};
@@ -547,6 +549,15 @@ sub buildModel()
 	my $objdir = "";
 	my $libdir = ""; 
 	my $bldroot = "";
+
+        chdir "$CASEROOT";
+        my $comp_uc = 'NTHRDS_'.uc $model;
+        my $NTHRDS   = `./xmlquery $comp_uc -value `;
+        if ($NTHRDS > 1 or $ENV{'BUILD_THREADED'} eq 'TRUE') {
+          $ENV{'SMP'} = 'TRUE';
+        } else {
+          $ENV{'SMP'} = 'FALSE';
+        }
 
 	if ("$comp" eq "clm") {
 
@@ -604,6 +615,8 @@ sub buildModel()
 	    copy($mod, $INCROOT);
 	}
     }
+
+    $ENV{'SMP'} = $prev_smp;
 
     my $file_build = "$EXEROOT/cesm.bldlog.$LID";
     my $now = localtime;

--- a/cime/scripts/Tools/cesm_setup
+++ b/cime/scripts/Tools/cesm_setup
@@ -163,9 +163,6 @@ if (! $clean ) {
 		die "ERROR cesm_setup: $comp NINST value greater than $comp NTASKS";
 	    }
 	}
-	if($xmlvars{$nthrds} > 1){
-	    $build_threaded = "TRUE";
-	}
     }
 
     if ($build_threaded eq "TRUE" and $xmlvars{"COMPILER"} eq "nag") {


### PR DESCRIPTION
If BUILD_THREADED=FALSE and a component's NTHRDS=1, then don't build
that component threaded. Previously if any component had NTHRDS > 1
all components were built threaded.
If BUILD_THREADED=TRUE all components are built threaded (no change
in behavior)

[Non-BFB] for threaded builds where not all components are threaded
Fixes #590
