### PR TITLE
Add gnu modules to env for redsky and skybridge

### DIFF
--- a/cime/machines-acme/env_mach_specific.redsky
+++ b/cime/machines-acme/env_mach_specific.redsky
@@ -14,6 +14,7 @@ if (-e /usr/share/Modules/init/csh) then
   if ($COMPILER == "intel") then
     module unload intel
     module unload openmpi-intel
+    module load gnu/4.9.2
     module load intel/intel-15.0.3.187
     module load openmpi-intel/1.6
     module load libraries/intel-mkl-15.0.2.164

--- a/cime/machines-acme/env_mach_specific.skybridge
+++ b/cime/machines-acme/env_mach_specific.skybridge
@@ -14,6 +14,7 @@ if (-e /usr/share/Modules/init/csh) then
   if ($COMPILER == "intel") then
     module unload intel
     module unload openmpi-intel
+    module load gnu/4.9.2
     module load intel/intel-15.0.3.187
     module load openmpi-intel/1.6
     module load libraries/intel-mkl-15.0.2.164


### PR DESCRIPTION
Intel compiler uses gcc for its stdlib. Older stdlibs no longer
work with Albany.

Confirmed that SMS.f09_g16_a.MPASLIALB_ONLY now gets past the
build step with these changes.

[BFB]
