### PR TITLE
Fix uninitialized outfld arrays in hetfrz_classnuc_cam

### DIFF
--- a/components/cam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/cam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -684,6 +684,24 @@ subroutine hetfrz_classnuc_cam_calc( &
    na500                      = 0._r8
    tot_na500                  = 0._r8
 
+   ! initializ diagnostic arrays, otherwise uninitialized for k < top_lev
+   nnuccc_dst(:ncol,:) = 0._r8
+   nnucct_dst(:ncol,:) = 0._r8
+   nnudep_dst(:ncol,:) = 0._r8
+
+   nnuccc_bc(:ncol,:) = 0._r8
+   nnucct_bc(:ncol,:) = 0._r8
+   nnudep_bc(:ncol,:) = 0._r8
+
+   niimm_bc(:ncol,:) = 0._r8
+   nicnt_bc(:ncol,:) = 0._r8
+   nidep_bc(:ncol,:) = 0._r8
+
+   niimm_dst(:ncol,:) = 0._r8
+   nicnt_dst(:ncol,:) = 0._r8
+   nidep_dst(:ncol,:) = 0._r8
+
+
    ! output aerosols as reference information for heterogeneous freezing
    do i = 1, ncol
       do k = top_lev, pver


### PR DESCRIPTION
 A number of local diagnostic arrays for number concentrations are never assigned values
 for levels above top_lev. For L72 model, this cause the arrays to carry junk values on 
machines such as Mira. Although it has no impact on the results, the run would fail if 
namelist parameter hist_hetfrz_classnuc = .true. is set to have PIO output these fields.

 The fix is to always initialize the whole arrays to zeroes.

 Modified:   components/cam/src/physics/cam/hetfrz_classnuc_cam.F90

Fixes #602

 [BFB]
