### PR TITLE
Better use of return codes in key ACME tools.

### DIFF
--- a/cime/scripts-acme/acme_util.py
+++ b/cime/scripts-acme/acme_util.py
@@ -39,6 +39,9 @@ _MACHINE_PROJECTS = {
     "cetus"     : "HiRes_EarthSys",
 }
 
+# Return this error code if the scripts worked but tests failed
+TESTS_FAILED_ERR_CODE = 165
+
 ###############################################################################
 def expect(condition, error_msg):
 ###############################################################################

--- a/cime/scripts-acme/create_test
+++ b/cime/scripts-acme/create_test
@@ -197,7 +197,7 @@ def create_test(testargs, compiler, no_run, no_build, no_batch, test_root,
                                            clean=clean, compiler=compiler,
                                            compare=compare, generate=generate, namelists_only=namelists_only,
                                            project=project, parallel_jobs=parallel_jobs)
-        return 0 if impl.create_test() else 1
+        return 0 if impl.create_test() else acme_util.TESTS_FAILED_ERR_CODE
     else:
 
         # Delete everything below

--- a/cime/scripts-acme/create_test_impl.py
+++ b/cime/scripts-acme/create_test_impl.py
@@ -541,6 +541,8 @@ class CreateTest(object):
     ###########################################################################
         """
         Main API for this class.
+
+        Return True if all tests passed.
         """
         start_time = time.time()
 

--- a/cime/scripts-acme/jenkins_generic_job
+++ b/cime/scripts-acme/jenkins_generic_job
@@ -11,7 +11,7 @@ import acme_util
 acme_util.check_minimum_python_version(2, 7)
 import wait_for_tests
 
-import argparse, sys, os, shutil, glob, doctest, time
+import argparse, sys, os, shutil, glob, doctest, time, signal
 
 from acme_util import expect, warning, verbose_print
 
@@ -109,6 +109,9 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
                         arg_test_suite,
                         cdash_build_group, baseline_compare):
 ###############################################################################
+    """
+    Return True if all tests passed
+    """
     start_time = time.time()
 
     use_batch = acme_util.does_machine_have_batch()
@@ -205,8 +208,9 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
         if (not wait_for_tests.SIGNAL_RECEIVED):
             create_test_stat = acme_util.run_cmd(create_test_cmd, from_dir=acme_util.get_acme_scripts_root(),
                                                  verbose=True, arg_stdout=None, arg_stderr=None, ok_to_fail=True)[0]
-            if (create_test_stat != 0):
-                warning("create_test FAILED!")
+            # Create_test should have either passed, detected failing tests, or timed out
+            expect(create_test_stat in [0, acme_util.TESTS_FAILED_ERR_CODE, -signal.SIGTERM],
+                   "Create_test script FAILED with error code '%d'!" % create_test_stat)
 
         if (use_batch):
             # This is not fullproof. Any jobs that happened to be
@@ -239,7 +243,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
             # Cleanup
             cleanup_queue(our_jobs)
 
-        return tests_passed and create_test_stat == 0
+        return tests_passed
     finally:
         expect(os.path.isfile(sentinel_path), "Missing sentinel file")
         os.remove(sentinel_path)
@@ -256,7 +260,8 @@ def _main_func(description):
     generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, test_suite, cdash_build_group, no_baseline_compare = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, test_suite, cdash_build_group, no_baseline_compare) else 1)
+    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, cdash_build_name, cdash_project, baseline_branch, test_suite, cdash_build_group, no_baseline_compare)
+             else acme_util.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################
 

--- a/cime/scripts-acme/tests/scripts_regression_tests
+++ b/cime/scripts-acme/tests/scripts_regression_tests
@@ -159,7 +159,8 @@ class TestWaitForTests(unittest.TestCase):
         if (expected_results == ["PASS"]*len(expected_results)):
             self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\nwait_for_tests output:\n%s\n\nerrput:\n%s" % (output, errput))
         else:
-            self.assertNotEqual(stat, 0, msg="COMMAND SHOULD HAVE FAILED\nwait_for_tests output:\n%s\n\nerrput:\n%s" % (output, errput))
+            self.assertEqual(stat, acme_util.TESTS_FAILED_ERR_CODE,
+                             msg="COMMAND SHOULD HAVE DETECTED FAILED TESTS\nwait_for_tests output:\n%s\n\nerrput:\n%s" % (output, errput))
 
         lines = [line for line in output.splitlines() if line.startswith("Test '")]
         self.assertEqual(len(lines), 10)
@@ -244,9 +245,9 @@ class TestWaitForTests(unittest.TestCase):
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
 
-        assert_dashboard_has_build(self, "regression_test_pass")
-
         self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
+
+        assert_dashboard_has_build(self, "regression_test_pass")
 
     ###########################################################################
     def test_wait_for_test_cdash_kill(self):
@@ -265,10 +266,9 @@ class TestWaitForTests(unittest.TestCase):
         run_thread.join(timeout=10)
 
         self.assertFalse(run_thread.isAlive(), msg="wait_for_tests should have finished")
+        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
         assert_dashboard_has_build(self, "regression_test_kill")
-
-        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
         cdash_result_dir = os.path.join(self._testdir_unfinished, "Testing")
         tag_file         = os.path.join(cdash_result_dir, "TAG")
@@ -337,9 +337,9 @@ class TestCreateTest(TestCreateTestCommon):
     ###########################################################################
         stat, output, errput = run_cmd("%s/create_test acme_test_only_pass %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
         if (expect_works):
-            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s" % (output, errput))
+            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
         else:
-            self.assertNotEqual(stat, 0, msg="COMMAND SHOULD HAVE FAILED\ncreate_test output:\n%s\n\nerrput:\n%s" % (output, errput))
+            self.assertEqual(stat, acme_util.TESTS_FAILED_ERR_CODE, msg="COMMAND SHOULD HAVE DETECTED FAILED TESTS\ncreate_test output:\n%s\n\nerrput:\n%ss\n\ncode: %d" % (output, errput, stat))
 
     ###############################################################################
     def test_create_test_rebless_namelist(self):
@@ -492,7 +492,7 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
         if (expect_works):
             self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
         else:
-            self.assertNotEqual(stat, 0, msg="COMMAND SHOULD HAVE FAILED\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
+            self.assertEqual(stat, acme_util.TESTS_FAILED_ERR_CODE, msg="COMMAND SHOULD HAVE DETECTED FAILED TESTS\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
 
     ###########################################################################
     def threaded_test(self, expect_works, extra_args):
@@ -559,9 +559,9 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
         run_thread.join(timeout=10)
 
         self.assertFalse(run_thread.isAlive(), msg="jenkins_generic_job should have finished")
+        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
         self.assert_no_sentinel()
         assert_dashboard_has_build(self, build_name)
-        self.assertTrue(self._thread_error is None, msg="Thread had failure: %s" % self._thread_error)
 
 ###############################################################################
 class TestUpdateACMETests(unittest.TestCase):

--- a/cime/scripts-acme/wait_for_tests
+++ b/cime/scripts-acme/wait_for_tests
@@ -84,7 +84,9 @@ def _main_func(description):
     test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, cdash_build_name, cdash_project, cdash_build_group = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if wait_for_tests.wait_for_tests(test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, cdash_build_name, cdash_project, cdash_build_group) else 1)
+    sys.exit(0 if wait_for_tests.wait_for_tests(test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs,
+                                                cdash_build_name, cdash_project, cdash_build_group)
+             else acme_util.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################
 


### PR DESCRIPTION
Create_test, wait_for_tests, and jenkins_generic_job all returned
a non-zero error code when they detected failing tests.
Before, there was no way to distinguish between a program crash
(abnormal behavior) and failed tests if you only looked at error
code. This was hiding real errors in the regression tests.

[BFB]
