### PR TITLE
Update atmosphere developer compsets and test suite

### DIFF
--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -44,10 +44,15 @@ _TEST_SUITES = {
                              "ERS.ne16_ne16.FC5PLMOD",
                              "ERS.ne16_ne16.FC5CLBMG2",
                              "ERS.ne16_ne16.FC5CLBMG2MAM4",
+                             "ERS.ne16_ne16.FC5CLBMG2MAM4MOM",
                              "ERS.ne16_ne16.FC5CLBMG2MAM4RESUS",
+                             "ERS.ne16_ne16.FC5CLBMG2LINMAM4RESUSMOM",
                              "ERS.f19_g16.FC5CLBMG2MAM4RESUSBC",
                              "ERS.f19_g16.FC5CLBMG2MAM4RESUSMOMBC",
-                             "ERS.f19_g16.FC5ATMMOD")
+                             "ERS.f19_g16.FC5ATMMOD",
+                             "SMS.f19_g16.FC5ATMMOD",
+                             "SMS.f19_g16.FC5ATMMODCOSP",
+                             "SMS_D.f19_g16.FC5ATMMODCOSP")
                             ),
 
     "acme_developer" : ("acme_land_developer",

--- a/cime/scripts/Tools/config_compsets.xml
+++ b/cime/scripts/Tools/config_compsets.xml
@@ -215,6 +215,7 @@ value of RUN_STARTDATE will be date2.
 <COMPSET sname="F_2000_CAM5_PLMOD"          alias="FC5PLMOD"        >2000_CAM5%MAM4%PLMOD_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_RESUS"          alias="FC5RESUS"        >2000_CAM5%MAM4%RESUS_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_ATMMOD"         alias="FC5ATMMOD"       >2000_CAM5%ATMMOD_CLM45%BC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
+<COMPSET sname="F_2000_CAM5_ATMMODCOSP"     alias="FC5ATMMODCOSP    >2000_CAM5%ATMMODCOSP_CLM45%BC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_COSP"           alias="FC5COSP"         >2000_CAM5%COSP_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_C5UNI"         alias="FC5UNI"     >2000_CAM5%UNI_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_AMIP"                     alias="FAMIP"           >AMIP_CAM4_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
@@ -233,6 +234,7 @@ value of RUN_STARTDATE will be date2.
 <COMPSET sname="F_2000_CAM5_CLBMG2"          alias="FC5CLBMG2"      >2000_CAM5%CLBMG2_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_CLBMG2LINMAM4RESUSBC"       alias="FC5CLBMG2LINMAM4RESUSBC" >2000_CAM5%CLBMG2LINMAM4RESUS_CLM45%BC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_CLBMG2LINMAM4RESUSMOM"      alias="FC5CLBMG2LINMAM4RESUSMOM">2000_CAM5%CLBMG2LINMAM4RESUSMOM_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
+<COMPSET sname="F_2000_CAM5_CLBMG2MAM4MOM"      alias="FC5CLBMG2MAM4MOM">2000_CAM5%CLBMG2MAM4MOM_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_CLBMG2MAM4"          alias="FC5CLBMG2MAM4"    >2000_CAM5%CLBMG2MAM4_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_CLBMG2MAM4RESUS"          alias="FC5CLBMG2MAM4RESUS"    >2000_CAM5%CLBMG2MAM4RESUS_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_CLBMG2MAM4RESUSMOM"          alias="FC5CLBMG2MAM4RESUSMOM"    >2000_CAM5%CLBMG2MAM4RESUSMOM_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
@@ -242,6 +244,7 @@ value of RUN_STARTDATE will be date2.
 <COMPSET sname="F_2000_CAM5_CLBMG2MAM4RESUSMOMBC"          alias="FC5CLBMG2MAM4RESUSMOMBC"    >2000_CAM5%CLBMG2MAM4RESUSMOM_CLM45%BC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_CLBMG2MAM4RESUSCOSPBC"          alias="FC5CLBMG2MAM4RESUSCOSPBC"    >2000_CAM5%CLBMG2MAM4RESUSCOSP_CLM45%BC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_CLBMG2MAM4RESUSMOMCOSPBC"          alias="FC5CLBMG2MAM4RESUSMOMCOSPBC"    >2000_CAM5%CLBMG2MAM4RESUSMOMCOSP_CLM45%BC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
+<COMPSET sname="F_2000_CAM5_CLBMG2LINMAM4RESUSMOMCOSPBC"          alias="FC5CLBMG2LINMAM4RESUSMOMCOSPBC"    >2000_CAM5%CLBMG2MAM4RESUSMOMCOSP_CLM45%BC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_1850_CAM5_PM"             alias="F1850C5PM"       >1850_CAM5%PM_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_PM"             alias="FC5PM"           >2000_CAM5%PM_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_1850_WACCM"               alias="F1850W"          >1850_CAM4%WCCM_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
@@ -610,6 +613,7 @@ GEOS => GEOS5 meteorology for "stand-alone" CAM
 <CAM_CONFIG_OPTS compset="_CAM5"          >-phys cam5</CAM_CONFIG_OPTS> 
 <CAM_CONFIG_OPTS compset="_CAM5%MAM4"     >-chem trop_mam4</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%ATMMOD"   >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom -rain_evap_to_coarse_aero</CAM_CONFIG_OPTS>
+<CAM_CONFIG_OPTS compset="_CAM5%ATMMODCOSP"   >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom -rain_evap_to_coarse_aero -cosp</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%COSP"     >-cosp</CAM_CONFIG_OPTS> 
 <CAM_CONFIG_OPTS compset="_CAM5%CLB"      >-clubb_sgs</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%MG2"      >-microphys mg2</CAM_CONFIG_OPTS>
@@ -617,10 +621,12 @@ GEOS => GEOS5 meteorology for "stand-alone" CAM
 <CAM_CONFIG_OPTS compset="_CAM5%CLBMG2LINMAM4RESUS" >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus -rain_evap_to_coarse_aero</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%CLBMG2LINMAM4RESUSMOM" >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom -rain_evap_to_coarse_aero</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%CLBMG2MAM4"   >-clubb_sgs -microphys mg2 -chem trop_mam4</CAM_CONFIG_OPTS>
+<CAM_CONFIG_OPTS compset="_CAM5%CLBMG2MAM4MOM"   >-clubb_sgs -microphys mg2 -chem trop_mam4_mom</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%CLBMG2MAM4RESUS"   >-clubb_sgs -microphys mg2 -chem trop_mam4 -rain_evap_to_coarse_aero</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%CLBMG2MAM4RESUSMOM"   >-clubb_sgs -microphys mg2 -chem trop_mam4_resus_mom -rain_evap_to_coarse_aero</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%CLBMG2MAM4RESUSCOSP"   >-clubb_sgs -microphys mg2 -chem trop_mam4 -rain_evap_to_coarse_aero -cosp</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%CLBMG2MAM4RESUSMOMCOSP"   >-clubb_sgs -microphys mg2 -chem trop_mam4_resus_mom -rain_evap_to_coarse_aero -cosp</CAM_CONFIG_OPTS>
+<CAM_CONFIG_OPTS compset="_CAM5%CLBMG2LINMAM4RESUSMOMCOSP" >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom -rain_evap_to_coarse_aero -cosp</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%UNI"      >-unicon -cppdefs -DMODIFY_ACTIVATE</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM4%TBAM"     >-chem trop_bam</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM4%TMOZ"     >-chem trop_mozart</CAM_CONFIG_OPTS>
@@ -688,9 +694,10 @@ GEOS => GEOS5 meteorology for "stand-alone" CAM
 <CAM_NML_USE_CASE compset="2000_CAM5%MOZM"   >2000_cam5_trop_moz_mam3</CAM_NML_USE_CASE> 
 <CAM_NML_USE_CASE compset="1850_CAM5%PM"     >1850_cam5_pm</CAM_NML_USE_CASE> 
 <CAM_NML_USE_CASE compset="2000_CAM5.*PLMOD" >2000_cam5_plmod</CAM_NML_USE_CASE>
+<CAM_NML_USE_CASE compset="2000_CAM5%CLBMG2MAM4MOM">2000_cam5_plmod</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5%CLBMG2MAM4RESUS*">2000_cam5_plmod_plus_resus</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5%CLBMG2LINMAM4RESUS*">2000_cam5_linoz_plmod_plus_resus</CAM_NML_USE_CASE>
-<CAM_NML_USE_CASE compset="2000_CAM5.*ATMMOD">2000_cam5_atmmod</CAM_NML_USE_CASE>
+<CAM_NML_USE_CASE compset="2000_CAM5.*ATMMOD*">2000_cam5_atmmod</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5%COSP"   >2000_cam5_cosp</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM4%WCMX"   >waccmx_2000_cam4</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="1996_CAM4%WCMX"   >waccmx_1996_cam4</CAM_NML_USE_CASE>
@@ -750,16 +757,19 @@ GEOS => GEOS5 meteorology for "stand-alone" CAM
 <desc compset="_CAM5.*PLMOD" >CAM with all polar mods:</desc>
 <desc compset="_CAM5.*RESUS" >CAM with polar mods, MAM4 and resuspension:</desc>
 <desc compset="_CAM5.*ATMMOD">CAM with all ACME atmosphere mods:</desc>
+<desc compset="_CAM5.*ATMMODCOSP">CAM with all ACME atmosphere mods and COSP:</desc>
 <desc compset="_CAM5%CLB"    >CAM CLUBB:</desc>
 <desc compset="_CAM5%MG2"    >CAM MG2:</desc>
 <desc compset="_CAM5%CLBMG2"    >CAM CLUBB MG2:</desc>
 <desc compset="_CAM5%CLBMG2LINMAM4RESUS"    >CAM CLUBB MG2 Linoz2 MAM4 resuspension:</desc>
 <desc compset="_CAM5%CLBMG2LINMAM4RESUSMOM" >CAM CLUBB MG2 Linoz2 MAM4 resuspension MOM:</desc>
 <desc compset="_CAM5%CLBMG2MAM4"    >CAM CLUBB MG2 MAM4:</desc>
+<desc compset="_CAM5%CLBMG2MAM4MOM"    >CAM CLUBB MG2 MAM4 MOM:</desc>
 <desc compset="_CAM5%CLBMG2MAM4RESUS"    >CAM CLUBB MG2 MAM4 resuspension:</desc>
 <desc compset="_CAM5%CLBMG2MAM4RESUSMOM"    >CAM CLUBB MG2 MAM4 resuspension MOM:</desc>
 <desc compset="_CAM5%CLBMG2MAM4RESUSCOSP"    >CAM CLUBB MG2 MAM4 resuspension COSP:</desc>
 <desc compset="_CAM5%CLBMG2MAM4RESUSMOMCOSP"    >CAM CLUBB MG2 MAM4 resuspension MOM COSP:</desc>
+<desc compset="_CAM5%CLBMG2LINMAM4RESUSMOMCOSP" >CAM CLUBB MG2 Linoz2 MAM4 resuspension MOM COSP:</desc>
 <desc compset="_CAM5%PM"     >CAM prescribed modal aerosols:</desc>
 <desc compset="_CAM[45]%WCCM">CAM WACCM with daily solar data and SPEs:</desc>
 <desc compset="_CAM[45]%WCMX">CAM WACCM-X:</desc>


### PR DESCRIPTION
Update atmosphere developer compset definitions and the acme_atm_developer test suite.

Add compset definitions for FC5CLBMG2MAM4MOM and FC5ATMMODCOSP, plus some additional tweaks / corrections.

[BFB]
