### PR TITLE
Fix reference to unassigned variable.

### DIFF
--- a/cime/scripts-acme/create_test_impl.py
+++ b/cime/scripts-acme/create_test_impl.py
@@ -426,7 +426,8 @@ class CreateTest(object):
             # TODO: What to do here? This failure is very severe because the
             # only way for test results to be communicated is by the TestStatus
             # file.
-            warning("VERY BAD! Could not handle TestStatus file '%s': '%s'" % (test_status_file, str(e)))
+            warning("VERY BAD! Could not handle TestStatus file '%s': '%s'" %
+                    (os.path.join(self._get_test_dir(test_name), TEST_STATUS_FILENAME), str(e)))
             thread.interrupt_main()
 
     ###########################################################################


### PR DESCRIPTION
Was trying to use potentially unassigned variable in generation of
a certain error message. Pylint did not catch this mistake because
the variable is assigned for some code paths.

[BFB]
