### PR TITLE
Fix constance PGI compiler settings and make Intel the default compiler

### DIFF
--- a/cime/machines-acme/config_compilers.xml
+++ b/cime/machines-acme/config_compilers.xml
@@ -995,8 +995,8 @@ for mct, etc.
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <ADD_CPPDEFS> -DLINUX </ADD_CPPDEFS>
-  <ADD_FFLAGS DEBUG="TRUE">-C -Mbounds -traceback -Mchkfpstk -Mchkstk -Mdalign  -Mdepchk  -Mextend -Miomutex -Mrecursive -Msave -Ktrap=fp -O0 -g -byteswapio -Meh_frame</ADD_FFLAGS>
-  <SLIBS> -L$(NETCDF_PATH)/lib -lnetcdf -lnetcdff -lpmi -L$(MKL_PATH) -lmkl_rt -L$(MPI_LIB) -lmpich</SLIBS>
+  <ADD_FFLAGS DEBUG="TRUE">-C -Mbounds -traceback -Mchkfpstk -Mchkstk -Mdalign  -Mdepchk  -Mextend -Miomutex -Mrecursive  -Ktrap=fp -O0 -g -byteswapio -Meh_frame</ADD_FFLAGS>
+  <SLIBS> -L$(NETCDF_PATH)/lib -lnetcdf -lnetcdff -lpmi -L$(MPI_LIB) -lmpich</SLIBS>
 </compiler>
 
 <compiler COMPILER="intel" MACH="constance">

--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -699,7 +699,7 @@
 <machine MACH="constance">
          <DESC>PNL Haswell cluster, OS is Linux, batch system is SLURM</DESC>
          <OS>LINUX</OS>
-         <COMPILERS>pgi,intel</COMPILERS>
+         <COMPILERS>intel,pgi</COMPILERS>
          <MPILIBS>mpich,mpi-serial</MPILIBS>
 	 <NODENAME_REGEX>constance</NODENAME_REGEX>
          <RUNDIR>/pic/scratch/$CCSMUSER/csmruns/$CASE/run</RUNDIR>

--- a/cime/machines-acme/env_mach_specific.constance
+++ b/cime/machines-acme/env_mach_specific.constance
@@ -33,11 +33,11 @@ if ( $COMPILER == "pgi") then
     module load mvapich2/2.1
     module load netcdf/4.3.2
 
-    module load pnetcdf/1.6.1
-    setenv PNETCDFROOT $NETCDF_LIB/../
+    setenv MPI_LIB $MPI_ROOT/lib
 
-    module load mkl/15.0.1
-    setenv MKL_PATH $MLIB_LIB
+    module load pnetcdf/1.6.1
+    setenv PNETCDFROOT $PNETCDF_LIB/../
+
     setenv NETCDF_HOME $NETCDF_LIB/../
 endif
 


### PR DESCRIPTION
This PR fixes machines files of the  PGI compiler so that ACME can
compile and run with the PGI compiler on Constance

The default compiler is also switched from PGI to Intel

[BFB]
