### PR TITLE
Change syntax so that it compiles with GNU

### DIFF
--- a/components/cam/src/utils/cam_map_utils.F90
+++ b/components/cam/src/utils/cam_map_utils.F90
@@ -1195,11 +1195,12 @@ end if
     if (present(num_mapped)) then
       if (this%num_elem() > 0) then
         ! Total number of mapped elements
-        allocate(indices(this%num_elem()))
-        indices = [ (i, i = 1, size(indices)) ]
-        tmp_size = COUNT(this%is_mapped(indices))
-        deallocate(indices)
-        nullify(indices)
+        tmp_size=0
+        do i = 1, this%num_elem()
+          if (this%is_mapped(i)) then
+            tmp_size = tmp_size + 1
+          end if
+        end do
       else
         tmp_size = 0
       end if


### PR DESCRIPTION
This block of code to compute tmp_size does not compile
with current gfortran. It appears to be a compiler bug
that will be fixed in future versions.

Changed code to compute tmp_size a different (equivalent) way.

[BFB] - Bit-For-Bit
