### PR TITLE
Fix the initialization for clubb_c_K10

### DIFF
--- a/components/cam/src/physics/clubb/parameters_tunable.F90
+++ b/components/cam/src/physics/clubb/parameters_tunable.F90
@@ -357,6 +357,7 @@ module parameters_tunable
     clubb_gamma_coef = init_value
     clubb_mu = init_value
     clubb_nu1 = init_value
+    clubb_c_K10 = init_value
 
     if (masterproc) then
       iunit = getunit()


### PR DESCRIPTION
Fix the initialization for clubb_c_K10

clubb_c_K10 in parameters_tunables.F90 needs to be initializted with
init_value but was not.

[BFB]

modified:   components/cam/src/physics/clubb/parameters_tunable.F90
