### PR TITLE
Fix pnetcdf logic with mpi-serial on skybridge, redsky

### DIFF
--- a/cime/machines-acme/env_mach_specific.redsky
+++ b/cime/machines-acme/env_mach_specific.redsky
@@ -37,14 +37,13 @@ if ( $MPILIB == "mpi-serial") then
     setenv NETCDFROOT /projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/base
 else
     setenv NETCDFROOT /projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5
+    setenv PNETCDFROOT $NETCDFROOT
 endif
 
 setenv PATH $NETCDFROOT/bin:$PATH
 setenv LD_LIBRARY_PATH $NETCDFROOT/lib:$LD_LIBRARY_PATH
 setenv NETCDF_INCLUDES $NETCDFROOT/include
 setenv NETCDF_LIBS $NETCDFROOT/lib
-
-setenv PNETCDFROOT $NETCDFROOT
 
 if ( $?PERL ) then
    printenv

--- a/cime/machines-acme/env_mach_specific.skybridge
+++ b/cime/machines-acme/env_mach_specific.skybridge
@@ -37,14 +37,13 @@ if ( $MPILIB == "mpi-serial") then
     setenv NETCDFROOT /projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/base
 else
     setenv NETCDFROOT /projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5
+    setenv PNETCDFROOT $NETCDFROOT
 endif
 
 setenv PATH $NETCDFROOT/bin:$PATH
 setenv LD_LIBRARY_PATH $NETCDFROOT/lib:$LD_LIBRARY_PATH
 setenv NETCDF_INCLUDES $NETCDFROOT/include
 setenv NETCDF_LIBS $NETCDFROOT/lib
-
-setenv PNETCDFROOT $NETCDFROOT
 
 if ( $?PERL ) then
    printenv


### PR DESCRIPTION
No longer define PNETCDFROOT variable for mpi-serial builds,
for these 2 machines.

By not defining this variable, "-lpnetcdf" is not added to the link line,
as is appropriate for serial builds. Before this fix, there was a build
error of libpnetcdf.a not found.

This should fix failing acme_integration test
  PEA_P1_M.f45_g37_rx1.A
on skybridge and redsky.

[BFB] - Bit-For-Bit
