### PR TITLE
Change default sequencing option to CESM1_MOD

### DIFF
--- a/cime/scripts/Tools/config_compsets.xml
+++ b/cime/scripts/Tools/config_compsets.xml
@@ -1739,7 +1739,7 @@ DOCN%COPY => docn copy mode
 <CPL_SEQ_OPTION compset="_DATM.*_DLND.*_DICE.*_DOCN">CESM1_MOD</CPL_SEQ_OPTION>
 <CPL_SEQ_OPTION compset="_XATM.*_XLND.*_XICE.*_XOCN">CESM1_MOD</CPL_SEQ_OPTION>
 <CPL_SEQ_OPTION compset="_SOCN"                     >CESM1_MOD</CPL_SEQ_OPTION>
-<CPL_SEQ_OPTION compset="_MPASO"                    >CESM1_MOD_TIGHT</CPL_SEQ_OPTION>
+<CPL_SEQ_OPTION compset="_MPASO"                    >CESM1_MOD</CPL_SEQ_OPTION>
 
 <ROF_NCPL compset=".+"  >8</ROF_NCPL> 
 <ROF_NCPL compset="_DATM.*_POP2"            >$ATM_NCPL</ROF_NCPL>


### PR DESCRIPTION
This merge changes the default coupler sequencing option from
CESM1_MOD_TIGHT to CESM1_MOD, since it performs better and has been
tested more than CESM1_MOD_TIGHT.

(Not a bug fix PR per se, but does address the question and concerns raised in Issue #655.)

[Non-BFB]
Fixes #655 
SEG-214
