### PR TITLE
Increased length of caseid variable

### DIFF
--- a/components/cam/src/control/filenames.F90
+++ b/components/cam/src/control/filenames.F90
@@ -24,7 +24,7 @@ character(shr_kind_cl), public :: bnd_topo = 'bnd_topo'   ! full pathname for to
 
 character(shr_kind_cl), public :: absems_data = 'absems_data' ! full pathname for time-invariant absorption dataset
 
-character(shr_kind_cs), public :: caseid = ' '  ! Case identifier
+character(shr_kind_cl), public :: caseid = ' '  ! Case identifier
 logical, public :: brnch_retain_casename = .false.
 
 integer, parameter :: nlen = shr_kind_cl                ! String length


### PR DESCRIPTION
Some of the tests in the testing suites were failing beacuse of the
folowing error:

"CASEID must not exceed 79 characters"

This PR addresses this by increasing the length of variable "caseid"
so that casenames can be longer than 79 characters. A smoke test
with FC5 compset works fine with a long casename which otherwise
would crash with the error message shown above.

Fixes #689
[BFB]
SEG-211
