### PR TITLE
Making pgi default instead of pgi_acc

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -778,7 +778,7 @@
          <DESC>ORNL XK6, os is CNL, 16 pes/node, batch system is PBS</DESC>
          <NODENAME_REGEX>titan</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
-	 <COMPILERS>pgi_acc,pgi,intel,cray</COMPILERS>
+	 <COMPILERS>pgi,pgi_acc,intel,cray</COMPILERS>
 	 <MPILIBS>mpich,mpi-serial</MPILIBS>
          <CESMSCRATCHROOT>$ENV{HOME}/acme_scratch/$PROJECT</CESMSCRATCHROOT>
          <RUNDIR>$ENV{MEMBERWORK}/$PROJECT/$CASE/run</RUNDIR>


### PR DESCRIPTION
There's a new error on Titan causing the PGI openacc compiler to fail. While it's being worked out, I'm reverting back to pgi as default on Titan.

Fixes #694
