### PR TITLE
Add three tests for new atmospheric compsets

### DIFF
--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -80,7 +80,7 @@ _TEST_SUITES = {
                          "ERS.f09_g16_g.MPASLI_ONLY",
                          "SMS.T62_mpas120_gis20.MPAS_LISIO_TEST",
                          "SMS.f09_g16_a.IGCLM45_MLI",
-                         "SMS_D_Ln20.ne30_ne30.FC5AV1C",
+                         "SMS_D_Ln1.ne30_ne30.FC5AV1C",
                          "SMS_D_Ld1.ne16_ne16.FC5ATMMOD")
                         ),
 


### PR DESCRIPTION
Add three smoke tests for new atmospheric compsets. Currently the
model runs very slowly with ne30L72 configuration so adding an ERS
test was not possible as it takes a lot of time to run.

[BFB]
