### PR TITLE
Update MPAS drivers to write all restarts at the same time

### DIFF
--- a/components/mpas-cice/driver/ice_comp_mct.F
+++ b/components/mpas-cice/driver/ice_comp_mct.F
@@ -704,9 +704,10 @@ contains
       character(len=strKIND), pointer :: xtime
 
       type (MPAS_Time_Type) :: currTime
-      character(len=StrKIND) :: timeStamp
+      character(len=StrKIND) :: timeStamp, streamName
       type (MPAS_timeInterval_type) :: timeStep
-      integer :: ierr
+      integer :: ierr, streamDirection
+      logical :: streamActive
       logical, pointer :: config_write_output_on_startup
       logical, save :: first=.true.
       character (len=StrKIND), pointer :: config_restart_timestamp_name
@@ -792,7 +793,7 @@ contains
         call cice_analysis_write(domain, ierr)
 
         ! Reset the restart alarm to prevent restart files being written without the coupler requesting it.
-        call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', ierr=ierr)
+        call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT_OUTPUT, ierr=ierr)
 
         call mpas_stream_mgr_write(domain % streamManager, streamID='output', ierr=ierr)
         call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='output', ierr=ierr)
@@ -806,14 +807,20 @@ contains
       ! Check if coupler wants us to write a restart file.
       ! We only write restart files at the end of a coupling interval
       if (seq_timemgr_RestartAlarmIsOn(EClock)) then
+         ! Write a restart file, because the coupler asked for it.
+         call mpas_stream_mgr_begin_iteration(domain % streamManager)
+         do while ( mpas_stream_mgr_get_next_stream(domain % streamManager, streamID=streamName, &
+                    directionProperty=streamDirection, activeProperty=streamActive) )
+            if ( streamActive .and. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) then
+               call mpas_stream_mgr_write(domain % streamManager, forceWriteNow=.true., streamID=streamName, iErr=iErr)
+            end if
+         end do
+
          if ( domain % dminfo % my_proc_id == 0 ) then
             open(22, file=config_restart_timestamp_name, form='formatted', status='replace')
             write(22, *) trim(timeStamp)
             close(22)
          end if
-
-         ! Write a restart file, because the coupler asked for it.
-         call mpas_stream_mgr_write(domain % streamManager, forceWriteNow=.true., streamID='restart', ierr=ierr)
       end if
 
       ! Export state to coupler

--- a/components/mpas-o/bld/mpas-o.buildnml
+++ b/components/mpas-o/bld/mpas-o.buildnml
@@ -581,7 +581,7 @@ if ( -e "$CASEROOT/SourceMods/src.mpas-o/$STREAM_NAME" ) {
 	print $stream_file '        reference_time="0000-01-01_00:00:00"' . "\n";
 	print $stream_file '        clobber_mode="truncate"' . "\n";
 	print $stream_file '        input_interval="initial_only"' . "\n";
-	print $stream_file '        output_interval="00-01-00_00:00:00"/>' . "\n";
+	print $stream_file '        output_interval="stream:restart:output_interval"/>' . "\n";
 	print $stream_file '' . "\n";
 	print $stream_file '<!--' . "\n";
 	print $stream_file 'All streams below this line are auxiliary streams. They are provided as' . "\n";

--- a/components/mpas-o/driver/ocn_comp_mct.F
+++ b/components/mpas-o/driver/ocn_comp_mct.F
@@ -746,9 +746,10 @@ contains
 
       type (MPAS_Time_Type) :: currTime
       type (domain_type), pointer :: domain_ptr
-      character(len=StrKIND) :: timeStamp
+      character(len=StrKIND) :: timeStamp, streamName
       type (MPAS_timeInterval_type) :: timeStep
-      integer :: ierr
+      integer :: ierr, streamDirection
+      logical :: streamActive
       logical, pointer :: config_write_output_on_startup
       character (len=StrKIND), pointer :: config_restart_timestamp_name
 
@@ -856,14 +857,22 @@ contains
       ! Check if coupler wants us to write a restart file.
       ! We only write restart files at the end of a coupling interval
       if (seq_timemgr_RestartAlarmIsOn(EClock)) then
+         ! Write a restart file, because the coupler asked for it.
+         call mpas_stream_mgr_begin_iteration(domain % streamManager)
+
+         do while ( mpas_stream_mgr_get_next_stream( domain % streamManager, streamID=streamName, &
+                    directionProperty=streamDirection, activeProperty=streamActive ) )
+
+            if ( streamActive .and. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) then
+               call mpas_stream_mgr_write(domain % streamManager, forceWriteNow=.true., streamID=streamName, ierr=ierr)
+            end if
+         end do
+
          if ( domain_ptr % dminfo % my_proc_id == 0 ) then
             open(22, file=config_restart_timestamp_name, form='formatted', status='replace')
             write(22, *) trim(timeStamp)
             close(22)
          end if
-
-         ! Write a restart file, because the coupler asked for it.
-         call mpas_stream_mgr_write(domain % streamManager, forceWriteNow=.true., streamID='restart', ierr=ierr)
       end if
 
       ! Export state to coupler

--- a/components/mpasli/driver/glc_comp_mct.F
+++ b/components/mpasli/driver/glc_comp_mct.F
@@ -770,9 +770,9 @@ contains
       character(len=StrKIND), pointer :: config_restart_timestamp_name
 
       type (MPAS_Time_Type) :: currTime
-      character(len=StrKIND) :: timeStamp
-      integer :: err, err_tmp, globalErr
-      logical :: solveVelo
+      character(len=StrKIND) :: timeStamp, streamName
+      integer :: err, err_tmp, globalErr, streamDirection
+      logical :: solveVelo, streamActive
 
       call mpas_io_units_set_stdout(glcStdOutUnit)
       call mpas_io_units_set_stderr(glcStdErrUnit)
@@ -920,15 +920,24 @@ contains
       ! Check if coupler wants us to write a restart file.
       ! We only write restart files at the end of a coupling interval
       if (seq_timemgr_RestartAlarmIsOn(EClock)) then
+
+         ! Write a restart file, because the coupler asked for it.
+         call mpas_stream_mgr_begin_iteration(domain % streamManager)
+
+         do while ( mpas_stream_mgr_get_next_stream( domain % streamManager, streamID=streamName, &
+                    directionProperty=streamDirection, activeProperty=streamActive ) )
+
+            if ( streamActive .and. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) then
+               call mpas_stream_mgr_write(domain % streamManager, forceWriteNow=.true., streamID=streamName, ierr=err_tmp)
+               err = ior(err,err_tmp)
+            end if
+         end do
+
          if ( domain % dminfo % my_proc_id == 0 ) then
             open(22, file=config_restart_timestamp_name, form='formatted', status='replace')
             write(22, *) trim(timeStamp)
             close(22)
          end if
-
-         ! Write a restart file, because the coupler asked for it.
-         call mpas_stream_mgr_write(domain % streamManager, forceWriteNow=.true., streamID='restart', ierr=err_tmp)
-         err = ior(err,err_tmp)
       end if
 
       ! Normalize time averaged fields


### PR DESCRIPTION
This merge updates the MPAS drivers to handle analysis member
restart files the same way it handles the forward model restart file,
in that writing of restart files is controlled by ACME rather than
MPAS.

Fixes #705
