### PR TITLE
Cleanup debug flags on Mira/Cetus

### DIFF
--- a/cime/machines-acme/config_compilers.xml
+++ b/cime/machines-acme/config_compilers.xml
@@ -107,9 +107,8 @@ for mct, etc.
   <FFLAGS> -g -qfullpath -qmaxmem=-1 </FFLAGS>
   <ADD_FFLAGS DEBUG="FALSE"> -O2 -qstrict -Q </ADD_FFLAGS>
   <ADD_CFLAGS DEBUG="FALSE"> -O3  </ADD_CFLAGS>
-  <ADD_FFLAGS compile_threaded="true"> -qsmp=omp </ADD_FFLAGS>
-  <ADD_CFLAGS compile_threaded="true"> -qsmp=omp </ADD_CFLAGS>
-  <!--ADD_LDFLAGS compile_threaded="true"> -qsmp=omp </ADD_LDFLAGS-->
+  <ADD_FFLAGS DEBUG="FALSE" compile_threaded="true"> -qsmp=omp </ADD_FFLAGS>
+  <ADD_CFLAGS DEBUG="FALSE" compile_threaded="true"> -qsmp=omp </ADD_CFLAGS>
   <FC_AUTO_R8> -qrealsize=8 </FC_AUTO_R8>
   <ADD_FFLAGS DEBUG="TRUE"> -qinitauto=7FF7FFFF -qflttrap=ov:zero:inv:en </ADD_FFLAGS>
   <ADD_FFLAGS DEBUG="TRUE" compile_threaded="true"> -qsmp=omp:noopt </ADD_FFLAGS>


### PR DESCRIPTION
Previously, when debug=true and threaded=true, build flags contained
both -qsmp=omp:noopt and -qsmp=omp in this order. The second
occurrence of -qsmp overrides the noopt suboption, which is needed
by debuggers. This commit removes the second occurrence by
specializing the ADD_FLAGS tags with DEBUG="FALSE" condition.

[BFB] - Bit-For-Bit
