### PR TITLE
Fix a bug so that amicphys codes run with marine organics aerosols

### DIFF
--- a/components/cam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/cam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -92,21 +92,31 @@
 
 #if ( defined MODAL_AERO_3MODE )
   integer, parameter :: max_gas = nsoa + 1
+  ! the +3 in max_aer are dst, ncl, so4
   integer, parameter :: max_aer = nsoa + npoa + nbc + 3
-#elif (( defined MODAL_AERO_4MODE ) || ( defined MODAL_AERO_4MODE_MOM ))
+#elif ( defined MODAL_AERO_4MODE )
   integer, parameter :: max_gas = nsoa + 1
+  ! the +3 in max_aer are dst, ncl, so4
   integer, parameter :: max_aer = nsoa + npoa + nbc + 3
+#elif ( defined MODAL_AERO_4MODE_MOM )
+  integer, parameter :: max_gas = nsoa + 1
+  ! the +4 in max_aer are dst, ncl, so4, mom
+  integer, parameter :: max_aer = nsoa + npoa + nbc + 4
 #elif ( ( defined MODAL_AERO_7MODE ) && ( defined MOSAIC_SPECIES ) )
   integer, parameter :: max_gas = nsoa + 4
+  ! the +8 in max_aer are dst, ncl(=na), so4, no3, cl, nh4, ca, co3 
   integer, parameter :: max_aer = nsoa + npoa + nbc + 8
 #elif ( defined MODAL_AERO_7MODE )
   integer, parameter :: max_gas = nsoa + 2
+  ! the +4 in max_aer are dst, ncl, so4, nh4
   integer, parameter :: max_aer = nsoa + npoa + nbc + 4
 #elif ( defined MODAL_AERO_8MODE )
   integer, parameter :: max_gas = nsoa + 2
+  ! the +4 in max_aer are dst, ncl, so4, mom ???
   integer, parameter :: max_aer = nsoa + npoa + nbc + 4
 #elif ( defined MODAL_AERO_9MODE )
   integer, parameter :: max_gas = nsoa + 2
+  ! the +4+5 in max_aer are dst, ncl, so4, nh4 and 5 marine organics
   integer, parameter :: max_aer = nsoa + npoa + nbc + 4 + 5
 #endif
 
@@ -153,7 +163,7 @@
   !    when nbc  > 1, iaer_bc  is index of the first bc  species
   !    when npom > 1, iaer_pom is index of the first pom species
   integer :: iaer_bc, iaer_dst, iaer_ncl, iaer_nh4, iaer_pom, iaer_soa, iaer_so4, &
-             iaer_mpoly, iaer_mprot, iaer_mlip, iaer_mhum, iaer_mproc, &
+             iaer_mpoly, iaer_mprot, iaer_mlip, iaer_mhum, iaer_mproc, iaer_mom, &
              iaer_no3, iaer_cl, iaer_ca, iaer_co3
   integer :: i_agepair_pca, i_agepair_macc, i_agepair_mait
   integer :: lmap_gas(max_gas)
@@ -5181,7 +5191,7 @@ implicit none
       iaer_ca  = 0 ; iaer_co3 = 0 
       iaer_mpoly = 0 ; iaer_mprot = 0 
       iaer_mlip  = 0 ; iaer_mhum = 0 
-      iaer_mproc = 0 ;
+      iaer_mproc = 0 ; iaer_mom = 0
 
       if (nsoa == 1) then
          name_gas(1) = 'SOAG'
@@ -5278,6 +5288,12 @@ implicit none
       naer = naer + 1
       name_aerpfx(naer) = 'co3'
       iaer_co3 = naer
+#endif
+
+#if ( defined MODAL_AERO_4MODE_MOM )
+      naer = naer + 1
+      name_aerpfx(naer) = 'mom'
+      iaer_mom = naer
 #endif
 
       if (ntot_amode==9) then
@@ -5617,8 +5633,8 @@ implicit none
            'iaer_pom, iaer_bc, iaer_ncl, iaer_dst, iaer_ca, iaer_co3', &
             iaer_pom, iaer_bc, iaer_ncl, iaer_dst, iaer_ca, iaer_co3
          write(iulog,'(/a56,10i5)') &
-           'iaer_mpoly, iaer_mprot, iaer_mlip, iaer_mhum, iaer_mproc', &
-            iaer_mpoly, iaer_mprot, iaer_mlip, iaer_mhum, iaer_mproc
+           'iaer_mom, ...mpoly, ...mprot, ...mlip, ...mhum, ...mproc', &
+            iaer_mom, iaer_mpoly, iaer_mprot, iaer_mlip, iaer_mhum, iaer_mproc
          write(iulog,'(/a)') &
            'fac_eqvso4hyg_aer(1:naer)'
          write(iulog,'(4(a,1pe10.3,3x))') &


### PR DESCRIPTION
Fix a bug in amicphys initialization so that model runs with
marine organic aerosols turned on.

[BFB]
