### PR TITLE
Properly reset alarms for restart streams for MPAS components

### DIFF
--- a/components/mpas-o/driver/ocn_comp_mct.F
+++ b/components/mpas-o/driver/ocn_comp_mct.F
@@ -842,8 +842,8 @@ contains
          call ocn_analysis_restart(domain_ptr, ierr) 
          call ocn_analysis_write(domain_ptr, ierr)
 
-         ! Reset the restart alarm to prevent restart files being written without the coupler requesting it.
-         call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', ierr=ierr)
+         ! Reset any restart alarms to prevent restart files being written without the coupler requesting it.
+         call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT_OUTPUT, ierr=ierr)
 
          call mpas_stream_mgr_write(domain % streamManager, streamID='output', ierr=ierr)
          call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='output', ierr=ierr)

--- a/components/mpasli/driver/glc_comp_mct.F
+++ b/components/mpasli/driver/glc_comp_mct.F
@@ -868,8 +868,8 @@ contains
          ! ===
          call mpas_timer_start("write output")
 
-         ! Reset the restart alarm to prevent restart files being written without the coupler requesting it.
-         call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', ierr=err_tmp)
+         ! Reset any restart alarms to prevent restart files being written without the coupler requesting it.
+         call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT_OUTPUT, ierr=err_tmp)
          err = ior(err, err_tmp)
 
          ! These calls will handle ALL output streams that need writing.


### PR DESCRIPTION
This merge properly resets the output alarms for restart streams within
the MPAS-O and MPASLI components. This helps to prevent analysis members
from writing restart files unless the coupler asks for a restart file.

Fixes #719
