### PR TITLE
Jinyuntang/lnd/ch4 zero bugfix

### DIFF
--- a/components/clm/src/biogeochem/CNCarbonFluxType.F90
+++ b/components/clm/src/biogeochem/CNCarbonFluxType.F90
@@ -7,17 +7,17 @@ module CNCarbonFluxType
   use clm_varpar             , only : crop_prog
   use clm_varpar             , only : nlevdecomp_full, nlevgrnd, nlevdecomp
   use clm_varcon             , only : spval, ispval, dzsoi_decomp
-  use landunit_varcon        , only : istsoil, istcrop, istdlak
-  use clm_varctl             , only : use_cndv, use_c13, use_ed
+  use landunit_varcon        , only : istsoil, istcrop, istdlak 
+  use clm_varctl             , only : use_cndv, use_c13, use_ed 
   use ch4varcon              , only : allowlakeprod
   use pftvarcon              , only : npcropmin
   use CNDecompCascadeConType , only : decomp_cascade_con
-  use PatchType              , only : pft
-  use ColumnType             , only : col
+  use PatchType              , only : pft                
+  use ColumnType             , only : col                
   use LandunitType           , only : lun
   ! bgc interface & pflotran
   use clm_varctl             , only : use_bgc_interface, use_pflotran, pf_cmode, use_vertsoilc
-  !
+  ! 
   ! !PUBLIC TYPES:
   implicit none
   save
@@ -30,7 +30,7 @@ module CNCarbonFluxType
   ! junk that should always be overwritten by the namelist or init function!
   !
   ! (days) time over which to exponentially relax the npp flux for N fixation term
-  real(r8), public :: nfix_timeconst = -1.2345_r8
+  real(r8), public :: nfix_timeconst = -1.2345_r8 
   !
   type, public :: carbonflux_type
 
@@ -85,51 +85,51 @@ module CNCarbonFluxType
      real(r8), pointer :: hrv_grainc_to_prod1c_patch                (:)     ! crop grain harvested (gC/m2/s)
      real(r8), pointer :: hrv_cropc_to_prod1c_patch                 (:)     ! total amount of crop C harvested (gC/m2/s)
 
-     ! fire C fluxes
-     real(r8), pointer :: m_leafc_to_fire_patch                     (:)     ! (gC/m2/s) fire C emissions from leafc
-     real(r8), pointer :: m_leafc_storage_to_fire_patch             (:)     ! (gC/m2/s) fire C emissions from leafc_storage
+     ! fire C fluxes 
+     real(r8), pointer :: m_leafc_to_fire_patch                     (:)     ! (gC/m2/s) fire C emissions from leafc 
+     real(r8), pointer :: m_leafc_storage_to_fire_patch             (:)     ! (gC/m2/s) fire C emissions from leafc_storage             
      real(r8), pointer :: m_leafc_xfer_to_fire_patch                (:)     ! (gC/m2/s) fire C emissions from leafc_xfer
      real(r8), pointer :: m_livestemc_to_fire_patch                 (:)     ! (gC/m2/s) fire C emissions from livestemc
-     real(r8), pointer :: m_livestemc_storage_to_fire_patch         (:)     ! (gC/m2/s) fire C emissions from livestemc_storage
+     real(r8), pointer :: m_livestemc_storage_to_fire_patch         (:)     ! (gC/m2/s) fire C emissions from livestemc_storage       
      real(r8), pointer :: m_livestemc_xfer_to_fire_patch            (:)     ! (gC/m2/s) fire C emissions from livestemc_xfer
      real(r8), pointer :: m_deadstemc_to_fire_patch                 (:)     ! (gC/m2/s) fire C emissions from deadstemc_xfer
-     real(r8), pointer :: m_deadstemc_storage_to_fire_patch         (:)     ! (gC/m2/s) fire C emissions from deadstemc_storage
+     real(r8), pointer :: m_deadstemc_storage_to_fire_patch         (:)     ! (gC/m2/s) fire C emissions from deadstemc_storage         
      real(r8), pointer :: m_deadstemc_xfer_to_fire_patch            (:)     ! (gC/m2/s) fire C emissions from deadstemc_xfer
      real(r8), pointer :: m_frootc_to_fire_patch                    (:)     ! (gC/m2/s) fire C emissions from frootc
      real(r8), pointer :: m_frootc_storage_to_fire_patch            (:)     ! (gC/m2/s) fire C emissions from frootc_storage
      real(r8), pointer :: m_frootc_xfer_to_fire_patch               (:)     ! (gC/m2/s) fire C emissions from frootc_xfer
      real(r8), pointer :: m_livecrootc_to_fire_patch                (:)     ! (gC/m2/s) fire C emissions from livecrootc
-     real(r8), pointer :: m_livecrootc_storage_to_fire_patch        (:)     ! (gC/m2/s) fire C emissions from livecrootc_storage
+     real(r8), pointer :: m_livecrootc_storage_to_fire_patch        (:)     ! (gC/m2/s) fire C emissions from livecrootc_storage     
      real(r8), pointer :: m_livecrootc_xfer_to_fire_patch           (:)     ! (gC/m2/s) fire C emissions from livecrootc_xfer
      real(r8), pointer :: m_deadcrootc_to_fire_patch                (:)     ! (gC/m2/s) fire C emissions from deadcrootc
-     real(r8), pointer :: m_deadcrootc_storage_to_fire_patch        (:)     ! (gC/m2/s) fire C emissions from deadcrootc_storage
+     real(r8), pointer :: m_deadcrootc_storage_to_fire_patch        (:)     ! (gC/m2/s) fire C emissions from deadcrootc_storage 
      real(r8), pointer :: m_deadcrootc_xfer_to_fire_patch           (:)     ! (gC/m2/s) fire C emissions from deadcrootc_xfer
-     real(r8), pointer :: m_gresp_storage_to_fire_patch             (:)     ! (gC/m2/s) fire C emissions from gresp_storage
+     real(r8), pointer :: m_gresp_storage_to_fire_patch             (:)     ! (gC/m2/s) fire C emissions from gresp_storage 
      real(r8), pointer :: m_gresp_xfer_to_fire_patch                (:)     ! (gC/m2/s) fire C emissions from gresp_xfer
      real(r8), pointer :: m_leafc_to_litter_fire_patch              (:)     ! (gC/m2/s) from leafc to litter c due to fire
-     real(r8), pointer :: m_leafc_storage_to_litter_fire_patch      (:)     ! (gC/m2/s) from leafc_storage to litter C  due to fire
-     real(r8), pointer :: m_leafc_xfer_to_litter_fire_patch         (:)     ! (gC/m2/s) from leafc_xfer to litter C  due to fire
-     real(r8), pointer :: m_livestemc_to_litter_fire_patch          (:)     ! (gC/m2/s) from livestemc to litter C  due to fire
-     real(r8), pointer :: m_livestemc_storage_to_litter_fire_patch  (:)     ! (gC/m2/s) from livestemc_storage to litter C due to fire
-     real(r8), pointer :: m_livestemc_xfer_to_litter_fire_patch     (:)     ! (gC/m2/s) from livestemc_xfer to litter C due to fire
-     real(r8), pointer :: m_livestemc_to_deadstemc_fire_patch       (:)     ! (gC/m2/s) from livestemc to deadstemc due to fire
-     real(r8), pointer :: m_deadstemc_to_litter_fire_patch          (:)     ! (gC/m2/s) from deadstemc to litter C due to fire
-     real(r8), pointer :: m_deadstemc_storage_to_litter_fire_patch  (:)     ! (gC/m2/s) from deadstemc_storage to litter C due to fire
-     real(r8), pointer :: m_deadstemc_xfer_to_litter_fire_patch     (:)     ! (gC/m2/s) from deadstemc_xfer to litter C due to fire
-     real(r8), pointer :: m_frootc_to_litter_fire_patch             (:)     ! (gC/m2/s) from frootc to litter C due to fire
-     real(r8), pointer :: m_frootc_storage_to_litter_fire_patch     (:)     ! (gC/m2/s) from frootc_storage to litter C due to fire
-     real(r8), pointer :: m_frootc_xfer_to_litter_fire_patch        (:)     ! (gC/m2/s) from frootc_xfer to litter C due to fire
-     real(r8), pointer :: m_livecrootc_to_litter_fire_patch         (:)     ! (gC/m2/s) from livecrootc to litter C due to fire
-     real(r8), pointer :: m_livecrootc_storage_to_litter_fire_patch (:)     ! (gC/m2/s) from livecrootc_storage to litter C due to fire
-     real(r8), pointer :: m_livecrootc_xfer_to_litter_fire_patch    (:)     ! (gC/m2/s) from livecrootc_xfer to litter C due to fire
-     real(r8), pointer :: m_livecrootc_to_deadcrootc_fire_patch     (:)     ! (gC/m2/s) from livecrootc to deadstemc due to fire
-     real(r8), pointer :: m_deadcrootc_to_litter_fire_patch         (:)     ! (gC/m2/s) from deadcrootc to litter C due to fire
-     real(r8), pointer :: m_deadcrootc_storage_to_litter_fire_patch (:)     ! (gC/m2/s) from deadcrootc_storage to litter C due to fire
-     real(r8), pointer :: m_deadcrootc_xfer_to_litter_fire_patch    (:)     ! (gC/m2/s) from deadcrootc_xfer to litter C due to fire
-     real(r8), pointer :: m_gresp_storage_to_litter_fire_patch      (:)     ! (gC/m2/s) from gresp_storage to litter C due to fire
-     real(r8), pointer :: m_gresp_xfer_to_litter_fire_patch         (:)     ! (gC/m2/s) from gresp_xfer to litter C due to fire
+     real(r8), pointer :: m_leafc_storage_to_litter_fire_patch      (:)     ! (gC/m2/s) from leafc_storage to litter C  due to fire               
+     real(r8), pointer :: m_leafc_xfer_to_litter_fire_patch         (:)     ! (gC/m2/s) from leafc_xfer to litter C  due to fire               
+     real(r8), pointer :: m_livestemc_to_litter_fire_patch          (:)     ! (gC/m2/s) from livestemc to litter C  due to fire               
+     real(r8), pointer :: m_livestemc_storage_to_litter_fire_patch  (:)     ! (gC/m2/s) from livestemc_storage to litter C due to fire      
+     real(r8), pointer :: m_livestemc_xfer_to_litter_fire_patch     (:)     ! (gC/m2/s) from livestemc_xfer to litter C due to fire      
+     real(r8), pointer :: m_livestemc_to_deadstemc_fire_patch       (:)     ! (gC/m2/s) from livestemc to deadstemc due to fire       
+     real(r8), pointer :: m_deadstemc_to_litter_fire_patch          (:)     ! (gC/m2/s) from deadstemc to litter C due to fire      
+     real(r8), pointer :: m_deadstemc_storage_to_litter_fire_patch  (:)     ! (gC/m2/s) from deadstemc_storage to litter C due to fire               
+     real(r8), pointer :: m_deadstemc_xfer_to_litter_fire_patch     (:)     ! (gC/m2/s) from deadstemc_xfer to litter C due to fire               
+     real(r8), pointer :: m_frootc_to_litter_fire_patch             (:)     ! (gC/m2/s) from frootc to litter C due to fire               
+     real(r8), pointer :: m_frootc_storage_to_litter_fire_patch     (:)     ! (gC/m2/s) from frootc_storage to litter C due to fire               
+     real(r8), pointer :: m_frootc_xfer_to_litter_fire_patch        (:)     ! (gC/m2/s) from frootc_xfer to litter C due to fire               
+     real(r8), pointer :: m_livecrootc_to_litter_fire_patch         (:)     ! (gC/m2/s) from livecrootc to litter C due to fire                     
+     real(r8), pointer :: m_livecrootc_storage_to_litter_fire_patch (:)     ! (gC/m2/s) from livecrootc_storage to litter C due to fire                     
+     real(r8), pointer :: m_livecrootc_xfer_to_litter_fire_patch    (:)     ! (gC/m2/s) from livecrootc_xfer to litter C due to fire                     
+     real(r8), pointer :: m_livecrootc_to_deadcrootc_fire_patch     (:)     ! (gC/m2/s) from livecrootc to deadstemc due to fire        
+     real(r8), pointer :: m_deadcrootc_to_litter_fire_patch         (:)     ! (gC/m2/s) from deadcrootc to litter C due to fire                       
+     real(r8), pointer :: m_deadcrootc_storage_to_litter_fire_patch (:)     ! (gC/m2/s) from deadcrootc_storage to litter C due to fire                       
+     real(r8), pointer :: m_deadcrootc_xfer_to_litter_fire_patch    (:)     ! (gC/m2/s) from deadcrootc_xfer to litter C due to fire                       
+     real(r8), pointer :: m_gresp_storage_to_litter_fire_patch      (:)     ! (gC/m2/s) from gresp_storage to litter C due to fire                       
+     real(r8), pointer :: m_gresp_xfer_to_litter_fire_patch         (:)     ! (gC/m2/s) from gresp_xfer to litter C due to fire                       
 
-     ! phenology fluxes from transfer pools
+     ! phenology fluxes from transfer pools                     
      real(r8), pointer :: grainc_xfer_to_grainc_patch               (:)     ! grain C growth from storage for prognostic crop(gC/m2/s)
      real(r8), pointer :: leafc_xfer_to_leafc_patch                 (:)     ! leaf C growth from storage (gC/m2/s)
      real(r8), pointer :: frootc_xfer_to_frootc_patch               (:)     ! fine root C growth from storage (gC/m2/s)
@@ -138,13 +138,13 @@ module CNCarbonFluxType
      real(r8), pointer :: livecrootc_xfer_to_livecrootc_patch       (:)     ! live coarse root C growth from storage (gC/m2/s)
      real(r8), pointer :: deadcrootc_xfer_to_deadcrootc_patch       (:)     ! dead coarse root C growth from storage (gC/m2/s)
 
-     ! leaf and fine root litterfall fluxes
+     ! leaf and fine root litterfall fluxes                          
      real(r8), pointer :: leafc_to_litter_patch                     (:)     ! leaf C litterfall (gC/m2/s)
      real(r8), pointer :: frootc_to_litter_patch                    (:)     ! fine root C litterfall (gC/m2/s)
      real(r8), pointer :: livestemc_to_litter_patch                 (:)     ! live stem C litterfall (gC/m2/s)
      real(r8), pointer :: grainc_to_food_patch                      (:)     ! grain C to food for prognostic crop(gC/m2/s)
 
-     ! maintenance respiration fluxes
+     ! maintenance respiration fluxes                          
      real(r8), pointer :: leaf_mr_patch                             (:)     ! leaf maintenance respiration (gC/m2/s)
      real(r8), pointer :: froot_mr_patch                            (:)     ! fine root maintenance respiration (gC/m2/s)
      real(r8), pointer :: livestem_mr_patch                         (:)     ! live stem maintenance respiration (gC/m2/s)
@@ -161,11 +161,11 @@ module CNCarbonFluxType
      real(r8), pointer :: livecroot_xsmr_patch                      (:)     ! live coarse root maintenance respiration from storage (gC/m2/s)
      real(r8), pointer :: grain_xsmr_patch                          (:)     ! crop grain or organs maint. respiration from storage (gC/m2/s)
 
-     ! photosynthesis fluxes
+     ! photosynthesis fluxes                                   
      real(r8), pointer :: psnsun_to_cpool_patch                     (:)     ! C fixation from sunlit canopy (gC/m2/s)
      real(r8), pointer :: psnshade_to_cpool_patch                   (:)     ! C fixation from shaded canopy (gC/m2/s)
 
-     ! allocation fluxes, from current GPP
+     ! allocation fluxes, from current GPP                     
      real(r8), pointer :: cpool_to_xsmrpool_patch                   (:)     ! allocation to maintenance respiration storage pool (gC/m2/s)
      real(r8), pointer :: cpool_to_grainc_patch                     (:)     ! allocation to grain C for prognostic crop(gC/m2/s)
      real(r8), pointer :: cpool_to_grainc_storage_patch             (:)     ! allocation to grain C storage for prognostic crop(gC/m2/s)
@@ -183,7 +183,7 @@ module CNCarbonFluxType
      real(r8), pointer :: cpool_to_deadcrootc_storage_patch         (:)     ! allocation to dead coarse root C storage (gC/m2/s)
      real(r8), pointer :: cpool_to_gresp_storage_patch              (:)     ! allocation to growth respiration storage (gC/m2/s)
 
-     ! growth respiration fluxes
+     ! growth respiration fluxes                               
      real(r8), pointer :: xsmrpool_to_atm_patch                     (:)     ! excess MR pool harvest mortality (gC/m2/s)
      real(r8), pointer :: cpool_leaf_gr_patch                       (:)     ! leaf growth respiration (gC/m2/s)
      real(r8), pointer :: cpool_leaf_storage_gr_patch               (:)     ! leaf growth respiration to storage (gC/m2/s)
@@ -209,7 +209,7 @@ module CNCarbonFluxType
      real(r8), pointer :: cpool_grain_storage_gr_patch              (:)     ! grain growth respiration to storage (gC/m2/s)
      real(r8), pointer :: transfer_grain_gr_patch                   (:)     ! grain growth respiration from storage (gC/m2/s)
 
-     ! annual turnover of storage to transfer pools
+     ! annual turnover of storage to transfer pools            
      real(r8), pointer :: grainc_storage_to_xfer_patch              (:)     ! grain C shift storage to transfer for prognostic crop model (gC/m2/s)
      real(r8), pointer :: leafc_storage_to_xfer_patch               (:)     ! leaf C shift storage to transfer (gC/m2/s)
      real(r8), pointer :: frootc_storage_to_xfer_patch              (:)     ! fine root C shift storage to transfer (gC/m2/s)
@@ -224,7 +224,7 @@ module CNCarbonFluxType
      real(r8), pointer :: livecrootc_to_deadcrootc_patch            (:)     ! live coarse root C turnover (gC/m2/s)
 
      ! summary (diagnostic) flux variables, not involved in mass balance
-     real(r8), pointer :: gpp_patch                                 (:)     ! (gC/m2/s) gross primary production
+     real(r8), pointer :: gpp_patch                                 (:)     ! (gC/m2/s) gross primary production 
      real(r8), pointer :: gpp_before_downreg_patch                  (:)     ! (gC/m2/s) gross primary production before down regulation
      real(r8), pointer :: mr_patch                                  (:)     ! (gC/m2/s) maintenance respiration
      real(r8), pointer :: current_gr_patch                          (:)     ! (gC/m2/s) growth resp for new growth displayed in this timestep
@@ -259,7 +259,7 @@ module CNCarbonFluxType
      real(r8), pointer :: woodc_loss_patch                          (:)     ! (gC/m2/s) patch-level wood C loss
 
      ! fire code
-     real(r8), pointer :: fire_closs_patch                          (:)     ! (gC/m2/s) total patch-level fire C loss
+     real(r8), pointer :: fire_closs_patch                          (:)     ! (gC/m2/s) total patch-level fire C loss 
 
      ! For aerenchyma calculations in CH4 code
      real(r8), pointer :: annavg_agnpp_patch                        (:)     ! (gC/m2/s) annual average aboveground NPP
@@ -268,7 +268,7 @@ module CNCarbonFluxType
      real(r8), pointer :: tempavg_bgnpp_patch                       (:)     ! (gC/m2/s) temp. average belowground NPP
 
      !----------------------------------------------------
-     ! column carbon flux variables
+     ! column carbon flux variables  
      !----------------------------------------------------
 
      ! phenology: litterfall and crop fluxes
@@ -292,21 +292,21 @@ module CNCarbonFluxType
      real(r8), pointer :: harvest_c_to_cwdc_col                     (:,:)   ! C fluxes associated with harvest to CWD pool (gC/m3/s)
 
      ! new variables for CN code
-     real(r8), pointer :: hrv_deadstemc_to_prod10c_col              (:)     ! dead stem C harvest mortality to 10-year product pool (gC/m2/s)
-     real(r8), pointer :: hrv_deadstemc_to_prod100c_col             (:)     ! dead stem C harvest mortality to 100-year product pool (gC/m2/s)
+     real(r8), pointer :: hrv_deadstemc_to_prod10c_col              (:)     ! dead stem C harvest mortality to 10-year product pool (gC/m2/s)        
+     real(r8), pointer :: hrv_deadstemc_to_prod100c_col             (:)     ! dead stem C harvest mortality to 100-year product pool (gC/m2/s)        
      real(r8), pointer :: hrv_cropc_to_prod1c_col                   (:)     ! crop C harvest mortality to 1-year product pool (gC/m2/s)
 
      ! column-level fire fluxes
      real(r8), pointer :: m_decomp_cpools_to_fire_vr_col            (:,:,:) ! vertically-resolved decomposing C fire loss (gC/m3/s)
      real(r8), pointer :: m_decomp_cpools_to_fire_col               (:,:)   ! vertically-integrated (diagnostic) decomposing C fire loss (gC/m2/s)
-     real(r8), pointer :: m_c_to_litr_met_fire_col                  (:,:)   ! C from leaf, froot, xfer and storage C to litter labile C by fire (gC/m3/s)
-     real(r8), pointer :: m_c_to_litr_cel_fire_col                  (:,:)   ! C from leaf, froot, xfer and storage C to litter cellulose C by fire (gC/m3/s)
-     real(r8), pointer :: m_c_to_litr_lig_fire_col                  (:,:)   ! C from leaf, froot, xfer and storage C to litter lignin C by fire (gC/m3/s)
+     real(r8), pointer :: m_c_to_litr_met_fire_col                  (:,:)   ! C from leaf, froot, xfer and storage C to litter labile C by fire (gC/m3/s) 
+     real(r8), pointer :: m_c_to_litr_cel_fire_col                  (:,:)   ! C from leaf, froot, xfer and storage C to litter cellulose C by fire (gC/m3/s) 
+     real(r8), pointer :: m_c_to_litr_lig_fire_col                  (:,:)   ! C from leaf, froot, xfer and storage C to litter lignin C by fire (gC/m3/s) 
      real(r8), pointer :: lf_conv_cflux_col                         (:)     ! (gC/m2/s) conversion C flux due to BET and BDT area decreasing (immediate loss to atm)
      real(r8), pointer :: somc_fire_col                             (:)     ! (gC/m2/s) carbon emissions due to peat burning
 
      ! decomposition fluxes
-     real(r8), pointer :: decomp_cpools_sourcesink_col              (:,:,:) ! change in decomposing c pools. Used to update concentrations concurrently with vertical transport (gC/m3/timestep)
+     real(r8), pointer :: decomp_cpools_sourcesink_col              (:,:,:) ! change in decomposing c pools. Used to update concentrations concurrently with vertical transport (gC/m3/timestep)  
      real(r8), pointer :: decomp_cascade_hr_vr_col                  (:,:,:) ! vertically-resolved het. resp. from decomposing C pools (gC/m3/s)
      real(r8), pointer :: decomp_cascade_hr_col                     (:,:)   ! vertically-integrated (diagnostic) het. resp. from decomposing C pools (gC/m2/s)
      real(r8), pointer :: decomp_cascade_ctransfer_vr_col           (:,:,:) ! vertically-resolved C transferred along deomposition cascade (gC/m3/s)
@@ -346,7 +346,7 @@ module CNCarbonFluxType
      real(r8), pointer :: product_closs_col                         (:)     ! (gC/m2/s) total wood product carbon loss
 
      ! summary (diagnostic) flux variables, not involved in mass balance
-     real(r8), pointer :: lithr_col                                 (:)     ! (gC/m2/s) litter heterotrophic respiration
+     real(r8), pointer :: lithr_col                                 (:)     ! (gC/m2/s) litter heterotrophic respiration 
      real(r8), pointer :: somhr_col                                 (:)     ! (gC/m2/s) soil organic matter heterotrophic respiration
      real(r8), pointer :: hr_col                                    (:)     ! (gC/m2/s) total heterotrophic respiration
      real(r8), pointer :: sr_col                                    (:)     ! (gC/m2/s) total soil respiration (HR + root resp)
@@ -367,14 +367,14 @@ module CNCarbonFluxType
      real(r8), pointer :: bgc_cpool_ext_loss_vr_col                 (:, :, :)  ! col-level extneral organic carbon loss gC/m3 /time step
      ! patch averaged to column variables - to remove need for pcf_a instance
      real(r8), pointer :: rr_col                                    (:)     ! column (gC/m2/s) root respiration (fine root MR + total root GR) (p2c)
-     real(r8), pointer :: ar_col                                    (:)     ! column (gC/m2/s) autotrophic respiration (MR + GR) (p2c)
-     real(r8), pointer :: gpp_col                                   (:)     ! column (gC/m2/s) GPP flux before downregulation  (p2c)
-     real(r8), pointer :: npp_col                                   (:)     ! column (gC/m2/s) net primary production (p2c)
+     real(r8), pointer :: ar_col                                    (:)     ! column (gC/m2/s) autotrophic respiration (MR + GR) (p2c)      
+     real(r8), pointer :: gpp_col                                   (:)     ! column (gC/m2/s) GPP flux before downregulation  (p2c)         
+     real(r8), pointer :: npp_col                                   (:)     ! column (gC/m2/s) net primary production (p2c)                  
      real(r8), pointer :: fire_closs_p2c_col                        (:)     ! column (gC/m2/s) patch2col averaged column-level fire C loss (p2c)
-     real(r8), pointer :: fire_closs_col                            (:)     ! column (gC/m2/s) total patch-level fire C loss
-     real(r8), pointer :: litfall_col                               (:)     ! column (gC/m2/s) total patch-level litterfall C loss (p2c)
+     real(r8), pointer :: fire_closs_col                            (:)     ! column (gC/m2/s) total patch-level fire C loss 
+     real(r8), pointer :: litfall_col                               (:)     ! column (gC/m2/s) total patch-level litterfall C loss (p2c)       
      real(r8), pointer :: vegfire_col                               (:)     ! column (gC/m2/s) patch-level fire loss (obsolete, mark for removal) (p2c)
-     real(r8), pointer :: wood_harvestc_col                         (:)     ! column (p2c)
+     real(r8), pointer :: wood_harvestc_col                         (:)     ! column (p2c)                                                  
      real(r8), pointer :: hrv_xsmrpool_to_atm_col                   (:)     ! column excess MR pool harvest mortality (gC/m2/s) (p2c)
 
      ! Temporary and annual sums
@@ -384,7 +384,7 @@ module CNCarbonFluxType
      real(r8), pointer :: annsum_npp_patch            (:) ! patch annual sum of NPP (gC/m2/yr)
      real(r8), pointer :: annsum_npp_col              (:) ! col annual sum of NPP, averaged from pft-level (gC/m2/yr)
      real(r8), pointer :: lag_npp_col                 (:) ! col lagged net primary production (gC/m2/s)
-
+     
      ! debug
      real(r8), pointer :: plant_to_litter_cflux		  (:) ! for the purpose of mass balance check
 	 real(r8), pointer :: plant_to_cwd_cflux		  (:) ! for the purpose of mass balance check
@@ -400,14 +400,14 @@ module CNCarbonFluxType
 
    contains
 
-     procedure , public  :: Init
+     procedure , public  :: Init   
      procedure , public  :: Restart
      procedure , public  :: SetValues
      procedure , public  :: ZeroDWT
      procedure , public  :: Summary
      procedure , public  :: summary_rr
      procedure , public  :: hr_summary_for_ch4
-     procedure , private :: InitAllocate
+     procedure , private :: InitAllocate 
      procedure , private :: InitHistory
      procedure , private :: InitCold
      ! bgc & pflotran interface
@@ -416,12 +416,12 @@ module CNCarbonFluxType
   !------------------------------------------------------------------------
 
 contains
-
+   
   !------------------------------------------------------------------------
   subroutine Init(this, bounds, carbon_type)
 
      class(carbonflux_type) :: this
-     type(bounds_type), intent(in) :: bounds
+     type(bounds_type), intent(in) :: bounds  
      character(len=3) , intent(in) :: carbon_type ! one of ['c12', c13','c14']
 
      call this%InitAllocate ( bounds)
@@ -434,8 +434,8 @@ contains
    subroutine InitAllocate(this, bounds)
      !
      ! !ARGUMENTS:
-     class (carbonflux_type) :: this
-     type(bounds_type), intent(in)    :: bounds
+     class (carbonflux_type) :: this 
+     type(bounds_type), intent(in)    :: bounds 
      !
      ! !LOCAL VARIABLES:
      integer           :: begp,endp
@@ -641,7 +641,7 @@ contains
      allocate(this%leafc_alloc_patch                         (begp:endp)) ; this%leafc_alloc_patch                         (:) = nan
      allocate(this%leafc_loss_patch                          (begp:endp)) ; this%leafc_loss_patch                          (:) = nan
      allocate(this%woodc_alloc_patch                         (begp:endp)) ; this%woodc_alloc_patch                         (:) = nan
-     allocate(this%woodc_loss_patch                          (begp:endp)) ; this%woodc_loss_patch                          (:) = nan
+     allocate(this%woodc_loss_patch                          (begp:endp)) ; this%woodc_loss_patch                          (:) = nan          
 
      allocate(this%tempavg_agnpp_patch               (begp:endp))                  ; this%tempavg_agnpp_patch (:) = spval
      allocate(this%tempavg_bgnpp_patch               (begp:endp))                  ; this%tempavg_bgnpp_patch (:) = spval
@@ -669,8 +669,8 @@ contains
      allocate(this%harvest_c_to_litr_cel_c_col       (begc:endc,1:nlevdecomp_full)); this%harvest_c_to_litr_cel_c_col  (:,:)=nan
      allocate(this%harvest_c_to_litr_lig_c_col       (begc:endc,1:nlevdecomp_full)); this%harvest_c_to_litr_lig_c_col  (:,:)=nan
      allocate(this%harvest_c_to_cwdc_col             (begc:endc,1:nlevdecomp_full)); this%harvest_c_to_cwdc_col        (:,:)=nan
-     allocate(this%phr_vr_col                        (begc:endc,1:nlevdecomp_full)); this%phr_vr_col                   (:,:)=nan
-     allocate(this%fphr_col                          (begc:endc,1:nlevgrnd))       ; this%fphr_col                     (:,:)=nan
+     allocate(this%phr_vr_col                        (begc:endc,1:nlevdecomp_full)); this%phr_vr_col                   (:,:)=nan 
+     allocate(this%fphr_col                          (begc:endc,1:nlevgrnd))       ; this%fphr_col                     (:,:)=nan 
 
      allocate(this%dwt_frootc_to_litr_met_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_met_c_col (:,:)=nan
      allocate(this%dwt_frootc_to_litr_cel_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_cel_c_col (:,:)=nan
@@ -695,7 +695,7 @@ contains
 
      allocate(this%bgc_cpool_ext_inputs_vr_col       (begc:endc, 1:nlevdecomp_full,ndecomp_pools));this%bgc_cpool_ext_inputs_vr_col (:,:,:) = nan
      allocate(this%bgc_cpool_ext_loss_vr_col         (begc:endc, 1:nlevdecomp_full,ndecomp_pools));this%bgc_cpool_ext_loss_vr_col   (:,:,:) = nan
-
+     
      allocate(this%lf_conv_cflux_col                 (begc:endc))                  ; this%lf_conv_cflux_col         (:)  =nan
      allocate(this%lithr_col                         (begc:endc))                  ; this%lithr_col                 (:)  =nan
      allocate(this%somhr_col                         (begc:endc))                  ; this%somhr_col                 (:)  =nan
@@ -721,45 +721,45 @@ contains
      allocate(this%litfall_col                       (begc:endc))                  ; this%litfall_col               (:)  =nan
      allocate(this%vegfire_col                       (begc:endc))                  ; this%vegfire_col               (:)  =nan
      allocate(this%wood_harvestc_col                 (begc:endc))                  ; this%wood_harvestc_col         (:)  =nan
-     allocate(this%hrv_xsmrpool_to_atm_col           (begc:endc))                  ; this%hrv_xsmrpool_to_atm_col   (:)  =nan
+     allocate(this%hrv_xsmrpool_to_atm_col           (begc:endc))                  ; this%hrv_xsmrpool_to_atm_col   (:)  =nan 
 
-     allocate(this%hrv_deadstemc_to_prod10c_col(begc:endc))
+     allocate(this%hrv_deadstemc_to_prod10c_col(begc:endc))                                                    
      this%hrv_deadstemc_to_prod10c_col(:)= nan
 
-     allocate(this%hrv_deadstemc_to_prod100c_col(begc:endc))
+     allocate(this%hrv_deadstemc_to_prod100c_col(begc:endc))                                                   
      this%hrv_deadstemc_to_prod100c_col(:)= nan
-
+ 
      allocate(this%hrv_cropc_to_prod1c_col(begc:endc))
      this%hrv_cropc_to_prod1c_col(:) = nan
 
-     allocate(this%m_decomp_cpools_to_fire_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))
+     allocate(this%m_decomp_cpools_to_fire_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))                
      this%m_decomp_cpools_to_fire_vr_col(:,:,:)= nan
 
-     allocate(this%m_decomp_cpools_to_fire_col(begc:endc,1:ndecomp_pools))
+     allocate(this%m_decomp_cpools_to_fire_col(begc:endc,1:ndecomp_pools))                                     
      this%m_decomp_cpools_to_fire_col(:,:)= nan
 
-     allocate(this%decomp_cpools_sourcesink_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))
+     allocate(this%decomp_cpools_sourcesink_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))                  
      this%decomp_cpools_sourcesink_col(:,:,:)= nan
 
-     allocate(this%decomp_cascade_hr_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_cascade_transitions))
+     allocate(this%decomp_cascade_hr_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_cascade_transitions))        
      this%decomp_cascade_hr_vr_col(:,:,:)= spval
 
-     allocate(this%decomp_cascade_hr_col(begc:endc,1:ndecomp_cascade_transitions))
+     allocate(this%decomp_cascade_hr_col(begc:endc,1:ndecomp_cascade_transitions))                             
      this%decomp_cascade_hr_col(:,:)= nan
 
-     allocate(this%decomp_cascade_ctransfer_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_cascade_transitions))
+     allocate(this%decomp_cascade_ctransfer_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_cascade_transitions)) 
      this%decomp_cascade_ctransfer_vr_col(:,:,:)= nan
 
-     allocate(this%decomp_cascade_ctransfer_col(begc:endc,1:ndecomp_cascade_transitions))
+     allocate(this%decomp_cascade_ctransfer_col(begc:endc,1:ndecomp_cascade_transitions))                      
      this%decomp_cascade_ctransfer_col(:,:)= nan
 
-     allocate(this%decomp_k_col(begc:endc,1:nlevdecomp_full,1:ndecomp_cascade_transitions))
+     allocate(this%decomp_k_col(begc:endc,1:nlevdecomp_full,1:ndecomp_cascade_transitions))                    
      this%decomp_k_col(:,:,:)= spval
 
-     allocate(this%decomp_cpools_leached_col(begc:endc,1:ndecomp_pools))
+     allocate(this%decomp_cpools_leached_col(begc:endc,1:ndecomp_pools))              
      this%decomp_cpools_leached_col(:,:)= nan
 
-     allocate(this%decomp_cpools_transport_tendency_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))
+     allocate(this%decomp_cpools_transport_tendency_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))          
      this%decomp_cpools_transport_tendency_col(:,:,:)= nan
 
 
@@ -769,7 +769,7 @@ contains
      allocate(this%annsum_litfall_patch  (begp:endp)) ; this%annsum_litfall_patch  (:) = nan
      allocate(this%annsum_npp_col        (begc:endc)) ; this%annsum_npp_col        (:) = nan
      allocate(this%lag_npp_col           (begc:endc)) ; this%lag_npp_col           (:) = spval
-
+     
      ! debug
      allocate(this%plant_to_litter_cflux (begc:endc)) ;	this%plant_to_litter_cflux (:) = nan
      allocate(this%plant_to_cwd_cflux    (begc:endc)) ;	this%plant_to_cwd_cflux	   (:) = nan
@@ -781,7 +781,7 @@ contains
      allocate(this%f_co2_soil_vr_col             (begc:endc,1:nlevdecomp_full));                 this%f_co2_soil_vr_col             (:,:)   = nan
      allocate(this%f_co2_soil_col                (begc:endc))                  ;                 this%f_co2_soil_col                (:)     = nan
      !------------------------------------------------------------------------
-   end subroutine InitAllocate;
+   end subroutine InitAllocate; 
 
    !------------------------------------------------------------------------
    subroutine InitHistory(this, bounds, carbon_type)
@@ -793,17 +793,17 @@ contains
      use clm_varpar , only : ndecomp_cascade_transitions, ndecomp_pools
      use clm_varpar , only : nlevdecomp, nlevdecomp_full, crop_prog, nlevgrnd
      use clm_varctl , only : hist_wrtch4diag
-     use histFileMod, only : hist_addfld1d, hist_addfld2d, hist_addfld_decomp
+     use histFileMod, only : hist_addfld1d, hist_addfld2d, hist_addfld_decomp 
      use tracer_varcon    , only : is_active_betr_bgc
      use clm_varctl,  only : get_carbontag
     !
      ! !ARGUMENTS:
-     class(carbonflux_type) :: this
-     type(bounds_type)         , intent(in) :: bounds
+     class(carbonflux_type) :: this    
+     type(bounds_type)         , intent(in) :: bounds 
      character(len=3)          , intent(in) :: carbon_type ! one of ['c12', c13','c14']
      !
      ! !LOCAL VARIABLES:
-     integer           :: k,l,ii,jj
+     integer           :: k,l,ii,jj 
      character(8)      :: vr_suffix
      character(10)     :: active
      integer           :: begp,endp
@@ -820,7 +820,7 @@ contains
 
      if (nlevdecomp > 1) then
         vr_suffix = "_vr"
-     else
+     else 
         vr_suffix = ""
      endif
 
@@ -1188,7 +1188,7 @@ contains
         this%m_gresp_xfer_to_litter_fire_patch(begp:endp) = spval
         call hist_addfld1d (fname='M_GRESP_XFER_TO_LITTER_FIRE', units='gC/m^2/s', &
              avgflag='A', long_name='growth respiration transfer fire mortality to litter', &
-             ptr_patch=this%m_gresp_xfer_to_litter_fire_patch, default='inactive')
+             ptr_patch=this%m_gresp_xfer_to_litter_fire_patch, default='inactive')   
 
         this%leafc_xfer_to_leafc_patch(begp:endp) = spval
         call hist_addfld1d (fname='LEAFC_XFER_TO_LEAFC', units='gC/m^2/s', &
@@ -2685,7 +2685,7 @@ contains
      endif
 
      !-------------------------------
-     ! C flux variables - native to column
+     ! C flux variables - native to column 
      !-------------------------------
 
      ! add history fields for all CLAMP CN variables
@@ -2733,7 +2733,7 @@ contains
         this%lf_conv_cflux_col(begc:endc) = spval
         call hist_addfld1d (fname='LF_CONV_CFLUX', units='gC/m^2/s', &
              avgflag='A', long_name='conversion carbon due to BET and BDT area decreasing', &
-             ptr_col=this%lf_conv_cflux_col, default='inactive')
+             ptr_col=this%lf_conv_cflux_col, default='inactive')   
 
         this%somc_fire_col(begc:endc) = spval
         call hist_addfld1d (fname='SOMC_FIRE', units='gC/m^2/s', &
@@ -2812,8 +2812,8 @@ contains
                    ptr_col=data1dptr)
            endif
 
-           ! output the vertically resolved fluxes
-           if ( nlevdecomp_full > 1 ) then
+           ! output the vertically resolved fluxes 
+           if ( nlevdecomp_full > 1 ) then  
               !-- HR fluxes (none from CWD)
               if ( .not. decomp_cascade_con%is_cwd(decomp_cascade_con%cascade_donor_pool(l)) ) then
                  data2dptr => this%decomp_cascade_hr_vr_col(:,:,l)
@@ -2856,7 +2856,7 @@ contains
 
           end do
         endif
-
+        
         this%t_scalar_col(begc:endc,:) = spval
         call hist_addfld_decomp (fname='T_SCALAR', units='unitless',  type2d='levdcmp', &
              avgflag='A', long_name='temperature inhibition of decomposition', &
@@ -2877,7 +2877,7 @@ contains
              avgflag='A', long_name='total flux of C from SOM pools due to leaching', &
              ptr_col=this%som_c_leached_col)!, default='inactive')
 
-        if(.not. is_active_betr_bgc)then
+        if(.not. is_active_betr_bgc)then     
           this%decomp_cpools_leached_col(begc:endc,:) = spval
           this%decomp_cpools_transport_tendency_col(begc:endc,:,:) = spval
           do k = 1, ndecomp_pools
@@ -3077,7 +3077,7 @@ contains
 
      ctag=get_carbontag(carbon_type)
      do k = 1, ndecomp_pools
-       this%bgc_cpool_ext_inputs_vr_col(begc:endc, :, k) = spval
+       this%bgc_cpool_ext_inputs_vr_col(begc:endc, :, k) = spval    
        data2dptr => this%bgc_cpool_ext_inputs_vr_col(:,:,k)
        fieldname='BGC_'//trim(ctag)//'POOL_EINPUT_'//trim(decomp_cascade_con%decomp_pool_name_history(k))//'_vr'
        longname=trim(ctag)//' input to '//trim(decomp_cascade_con%decomp_pool_name_history(k))
@@ -3085,17 +3085,17 @@ contains
          avgflag='A', long_name=longname, &
          ptr_col=data2dptr, default='inactive')
 
-       this%bgc_cpool_ext_loss_vr_col(begc:endc, :, k) = spval
+       this%bgc_cpool_ext_loss_vr_col(begc:endc, :, k) = spval    
        data2dptr => this%bgc_cpool_ext_loss_vr_col(:,:,k)
        fieldname='BGC_'//trim(ctag)//'POOL_ELOSS_'//trim(decomp_cascade_con%decomp_pool_name_history(k))//'_vr'
        longname=trim(ctag)//' loss of '//trim(decomp_cascade_con%decomp_pool_name_history(k))
        call hist_addfld_decomp (fname=fieldname, units='g'//ctag//'/m^3',  type2d='levdcmp', &
          avgflag='A', long_name=longname, &
          ptr_col=data2dptr, default='inactive')
-
+         
      enddo
      !-------------------------------
-     ! C13 flux variables - native to column
+     ! C13 flux variables - native to column 
      !-------------------------------
 
      if ( carbon_type == 'c13' ) then
@@ -3167,7 +3167,7 @@ contains
            endif
           end do
         endif
-
+        
         this%lithr_col(begc:endc) = spval
         call hist_addfld1d (fname='C13_LITHR', units='gC13/m^2/s', &
              avgflag='A', long_name='C13 fine root C litterfall to litter 3 C', &
@@ -3300,7 +3300,7 @@ contains
      endif
 
      !-------------------------------
-     ! C14 flux variables - native to column
+     ! C14 flux variables - native to column 
      !-------------------------------
 
      if (carbon_type == 'c14') then
@@ -3372,7 +3372,7 @@ contains
            endif
           end do
         endif
-
+        
         this%lithr_col(begc:endc) = spval
         call hist_addfld1d (fname='C14_LITHR', units='gC14/m^2/s', &
              avgflag='A', long_name='C14 fine root C litterfall to litter 3 C', &
@@ -3503,7 +3503,7 @@ contains
              avgflag='A', long_name='C14 total carbon loss from wood product pools', &
              ptr_col=this%product_closs_col)
      endif
-
+     
      if (carbon_type == 'c13') then
         this%xsmrpool_c13ratio_patch(begp:endp) = spval
         call hist_addfld1d (fname='XSMRPOOL_C13RATIO', units='proportion', &
@@ -3518,7 +3518,7 @@ contains
     !
     ! !ARGUMENTS:
     class(carbonflux_type) :: this
-    type(bounds_type), intent(in) :: bounds
+    type(bounds_type), intent(in) :: bounds  
     !
     ! !LOCAL VARIABLES:
     integer :: p, c, l, j
@@ -3600,7 +3600,7 @@ contains
 
        this%fphr_col(c,nlevdecomp+1:nlevgrnd) = 0._r8 !used to be in ch4Mod
        if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
-          this%fphr_col(c,nlevdecomp+1:nlevgrnd) = 0._r8
+          this%fphr_col(c,nlevdecomp+1:nlevgrnd) = 0._r8 
        else if (lun%itype(l) == istdlak .and. allowlakeprod) then
           this%fphr_col(c,:) = spval
        else  ! Inactive CH4 columns
@@ -3627,7 +3627,7 @@ contains
              this%dwt_deadcrootc_to_cwdc_col(c,j)   = 0._r8
           end do
           this%dwt_closs_col(c)  = 0._r8
-          this%annsum_npp_col(c) = 0._r8
+          this%annsum_npp_col(c) = 0._r8   
        end if
     end do
 
@@ -3635,7 +3635,7 @@ contains
 
     do fc = 1,num_special_col
        c = special_col(fc)
-
+       
        this%dwt_closs_col(c)   = 0._r8
        this%landuseflux_col(c) = 0._r8
        this%landuptake_col(c)  = 0._r8
@@ -3652,7 +3652,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine Restart ( this, bounds, ncid, flag )
     !
-    ! !DESCRIPTION:
+    ! !DESCRIPTION: 
     ! Read/write CN restart data for carbon state
     !
     ! !USES:
@@ -3668,7 +3668,7 @@ contains
     !
     ! !ARGUMENTS:
     class (carbonflux_type) :: this
-    type(bounds_type) , intent(in)    :: bounds
+    type(bounds_type) , intent(in)    :: bounds 
     type(file_desc_t) , intent(inout) :: ncid   ! netcdf id
     character(len=*)  , intent(in)    :: flag   !'read' or 'write'
     !
@@ -3741,17 +3741,17 @@ contains
             dim1name='pft',&
             long_name='Temp. Average AGNPP',units='gC/m^2/s', &
             readvar=readvar, interpinic_flag='interp', data=this%tempavg_agnpp_patch)
-
+       
        call restartvar(ncid=ncid, flag=flag, varname='tempavg_bgnpp', xtype=ncd_double,  &
             dim1name='pft',&
             long_name='Temp. Average BGNPP',units='gC/m^2/s', &
             readvar=readvar, interpinic_flag='interp', data=this%tempavg_bgnpp_patch)
-
+       
        call restartvar(ncid=ncid, flag=flag, varname='annavg_agnpp', xtype=ncd_double,  &
             dim1name='pft',&
             long_name='Ann. Average AGNPP',units='gC/m^2/s', &
             readvar=readvar, interpinic_flag='interp', data=this%annavg_agnpp_patch)
-
+       
        call restartvar(ncid=ncid, flag=flag, varname='annavg_bgnpp', xtype=ncd_double,  &
             dim1name='pft',&
             long_name='Ann. Average BGNPP',units='gC/m^2/s', &
@@ -3761,57 +3761,57 @@ contains
     call restartvar(ncid=ncid, flag=flag, varname='gpp_pepv', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%gpp_before_downreg_patch)
+         interpinic_flag='interp', readvar=readvar, data=this%gpp_before_downreg_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='availc', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%availc_patch)
+         interpinic_flag='interp', readvar=readvar, data=this%availc_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='xsmrpool_recover', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_recover_patch)
+         interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_recover_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='plant_calloc', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%plant_calloc_patch)
+         interpinic_flag='interp', readvar=readvar, data=this%plant_calloc_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='excess_cflux', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%excess_cflux_patch)
+         interpinic_flag='interp', readvar=readvar, data=this%excess_cflux_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='prev_leafc_to_litter', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%prev_leafc_to_litter_patch)
+         interpinic_flag='interp', readvar=readvar, data=this%prev_leafc_to_litter_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='prev_frootc_to_litter', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%prev_frootc_to_litter_patch)
+         interpinic_flag='interp', readvar=readvar, data=this%prev_frootc_to_litter_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='tempsum_npp', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%tempsum_npp_patch)
-
+         interpinic_flag='interp', readvar=readvar, data=this%tempsum_npp_patch) 
+ 
     call restartvar(ncid=ncid, flag=flag, varname='annsum_npp', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%annsum_npp_patch)
+         interpinic_flag='interp', readvar=readvar, data=this%annsum_npp_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='col_lag_npp', xtype=ncd_double,  &
          dim1name='column', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%lag_npp_col)
+         interpinic_flag='interp', readvar=readvar, data=this%lag_npp_col) 
 
     call restartvar(ncid=ncid, flag=flag, varname='cannsum_npp', xtype=ncd_double,  &
          dim1name='column', &
          long_name='', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%annsum_npp_col)
+         interpinic_flag='interp', readvar=readvar, data=this%annsum_npp_col) 
 
     if (use_cndv) then
        call restartvar(ncid=ncid, flag=flag, varname='tempsum_litfall', xtype=ncd_double,  &
@@ -3902,31 +3902,31 @@ contains
        this%m_deadcrootc_to_litter_patch(i)              = value_patch
        this%m_gresp_storage_to_litter_patch(i)           = value_patch
        this%m_gresp_xfer_to_litter_patch(i)              = value_patch
-       this%hrv_leafc_to_litter_patch(i)                 = value_patch
-       this%hrv_leafc_storage_to_litter_patch(i)         = value_patch
-       this%hrv_leafc_xfer_to_litter_patch(i)            = value_patch
-       this%hrv_frootc_to_litter_patch(i)                = value_patch
-       this%hrv_frootc_storage_to_litter_patch(i)        = value_patch
-       this%hrv_frootc_xfer_to_litter_patch(i)           = value_patch
-       this%hrv_livestemc_to_litter_patch(i)             = value_patch
-       this%hrv_livestemc_storage_to_litter_patch(i)     = value_patch
-       this%hrv_livestemc_xfer_to_litter_patch(i)        = value_patch
-       this%hrv_deadstemc_to_prod10c_patch(i)            = value_patch
-       this%hrv_deadstemc_to_prod100c_patch(i)           = value_patch
+       this%hrv_leafc_to_litter_patch(i)                 = value_patch             
+       this%hrv_leafc_storage_to_litter_patch(i)         = value_patch     
+       this%hrv_leafc_xfer_to_litter_patch(i)            = value_patch        
+       this%hrv_frootc_to_litter_patch(i)                = value_patch            
+       this%hrv_frootc_storage_to_litter_patch(i)        = value_patch    
+       this%hrv_frootc_xfer_to_litter_patch(i)           = value_patch       
+       this%hrv_livestemc_to_litter_patch(i)             = value_patch         
+       this%hrv_livestemc_storage_to_litter_patch(i)     = value_patch 
+       this%hrv_livestemc_xfer_to_litter_patch(i)        = value_patch    
+       this%hrv_deadstemc_to_prod10c_patch(i)            = value_patch        
+       this%hrv_deadstemc_to_prod100c_patch(i)           = value_patch       
        this%hrv_leafc_to_prod1c_patch(i)                 = value_patch
        this%hrv_livestemc_to_prod1c_patch(i)             = value_patch
        this%hrv_grainc_to_prod1c_patch(i)                = value_patch
        this%hrv_cropc_to_prod1c_patch(i)                 = value_patch
-       this%hrv_deadstemc_storage_to_litter_patch(i)     = value_patch
-       this%hrv_deadstemc_xfer_to_litter_patch(i)        = value_patch
-       this%hrv_livecrootc_to_litter_patch(i)            = value_patch
+       this%hrv_deadstemc_storage_to_litter_patch(i)     = value_patch 
+       this%hrv_deadstemc_xfer_to_litter_patch(i)        = value_patch    
+       this%hrv_livecrootc_to_litter_patch(i)            = value_patch        
        this%hrv_livecrootc_storage_to_litter_patch(i)    = value_patch
-       this%hrv_livecrootc_xfer_to_litter_patch(i)       = value_patch
-       this%hrv_deadcrootc_to_litter_patch(i)            = value_patch
+       this%hrv_livecrootc_xfer_to_litter_patch(i)       = value_patch   
+       this%hrv_deadcrootc_to_litter_patch(i)            = value_patch        
        this%hrv_deadcrootc_storage_to_litter_patch(i)    = value_patch
-       this%hrv_deadcrootc_xfer_to_litter_patch(i)       = value_patch
-       this%hrv_gresp_storage_to_litter_patch(i)         = value_patch
-       this%hrv_gresp_xfer_to_litter_patch(i)            = value_patch
+       this%hrv_deadcrootc_xfer_to_litter_patch(i)       = value_patch   
+       this%hrv_gresp_storage_to_litter_patch(i)         = value_patch     
+       this%hrv_gresp_xfer_to_litter_patch(i)            = value_patch        
        this%hrv_xsmrpool_to_atm_patch(i)                 = value_patch
 
        this%m_leafc_to_fire_patch(i)                     = value_patch
@@ -4053,7 +4053,7 @@ contains
        this%rr_patch(i)                                  = value_patch
        if (.not. use_ed) then
           !TODO - fix this when use_cn and use_ed are truly separate
-          this%npp_patch(i)                              = value_patch
+          this%npp_patch(i)                              = value_patch 
        end if
        this%agnpp_patch(i)                               = value_patch
        this%bgnpp_patch(i)                               = value_patch
@@ -4102,13 +4102,13 @@ contains
 
           this%fire_mortality_c_to_cwdc_col(i,j)      = value_column
           this%m_c_to_litr_met_fire_col(i,j)          = value_column
-          this%m_c_to_litr_cel_fire_col(i,j)          = value_column
+          this%m_c_to_litr_cel_fire_col(i,j)          = value_column  
           this%m_c_to_litr_lig_fire_col(i,j)          = value_column
 
-          this%harvest_c_to_litr_met_c_col(i,j)       = value_column
-          this%harvest_c_to_litr_cel_c_col(i,j)       = value_column
-          this%harvest_c_to_litr_lig_c_col(i,j)       = value_column
-          this%harvest_c_to_cwdc_col(i,j)             = value_column
+          this%harvest_c_to_litr_met_c_col(i,j)       = value_column             
+          this%harvest_c_to_litr_cel_c_col(i,j)       = value_column             
+          this%harvest_c_to_litr_lig_c_col(i,j)       = value_column             
+          this%harvest_c_to_cwdc_col(i,j)             = value_column          
 
           this%hr_vr_col(i,j)                         = value_column
        end do
@@ -4156,10 +4156,10 @@ contains
     do fi = 1,num_column
        i = filter_column(fi)
 
-       this%hrv_deadstemc_to_prod10c_col(i)  = value_column
-       this%hrv_deadstemc_to_prod100c_col(i) = value_column
+       this%hrv_deadstemc_to_prod10c_col(i)  = value_column        
+       this%hrv_deadstemc_to_prod100c_col(i) = value_column  
        this%hrv_cropc_to_prod1c_col(i)       = value_column
-       this%somc_fire_col(i)                 = value_column
+       this%somc_fire_col(i)                 = value_column  
        this%prod1c_loss_col(i)               = value_column
        this%prod10c_loss_col(i)              = value_column
        this%prod100c_loss_col(i)             = value_column
@@ -4182,14 +4182,14 @@ contains
        this%som_c_leached_col(i)             = value_column
 
        ! Zero p2c column fluxes
-       this%rr_col(i)                    = value_column
-       this%ar_col(i)                    = value_column
-       this%gpp_col(i)                   = value_column
-       this%npp_col(i)                   = value_column
-       this%fire_closs_col(i)            = value_column
-       this%litfall_col(i)               = value_column
-       this%vegfire_col(i)               = value_column
-       this%wood_harvestc_col(i)         = value_column
+       this%rr_col(i)                    = value_column  
+       this%ar_col(i)                    = value_column  
+       this%gpp_col(i)                   = value_column 
+       this%npp_col(i)                   = value_column 
+       this%fire_closs_col(i)            = value_column 
+       this%litfall_col(i)               = value_column       
+       this%vegfire_col(i)               = value_column       
+       this%wood_harvestc_col(i)         = value_column 
        this%hrv_xsmrpool_to_atm_col(i)   = value_column
     end do
 
@@ -4197,7 +4197,7 @@ contains
        do j = 1, nlevdecomp_full
           do fi = 1,num_column
              i = filter_column(fi)
-             this%decomp_cpools_sourcesink_col(i,j,k) = value_column
+             this%decomp_cpools_sourcesink_col(i,j,k) = value_column  
           end do
        end do
     end do
@@ -4241,7 +4241,7 @@ contains
     !
     ! !ARGUMENTS:
     class(carbonflux_type) :: this
-    type(bounds_type), intent(in)  :: bounds
+    type(bounds_type), intent(in)  :: bounds 
     !
     ! !LOCAL VARIABLES:
     integer  :: c, j          ! indices
@@ -4270,8 +4270,6 @@ contains
     end do
 
   end subroutine ZeroDwt
-
-
     !-----------------------------------------------------------------------
 
   subroutine hr_summary_for_ch4( this, bounds, num_soilp, filter_soilp, num_soilc, filter_soilc )
@@ -4310,9 +4308,6 @@ contains
               this%decomp_cascade_hr_col(c,k) + &
               this%decomp_cascade_hr_vr_col(c,j,k) * dzsoi_decomp(j)
 
-           this%decomp_cascade_ctransfer_col(c,k) = &
-              this%decomp_cascade_ctransfer_col(c,k) + &
-              this%decomp_cascade_ctransfer_vr_col(c,j,k) * dzsoi_decomp(j)
         end do
      end do
     end do
@@ -4363,6 +4358,7 @@ contains
     call this%summary_rr(bounds, num_soilp, filter_soilp, num_soilc, filter_soilc)
     end associate
   end subroutine hr_summary_for_ch4
+
   !-----------------------------------------------------------------------
   subroutine Summary(this, bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, &
        isotope)
@@ -4381,12 +4377,12 @@ contains
     !
     ! !ARGUMENTS:
     class(carbonflux_type)                 :: this
-    type(bounds_type)      , intent(in)    :: bounds
+    type(bounds_type)      , intent(in)    :: bounds          
     integer                , intent(in)    :: num_soilc       ! number of soil columns in filter
     integer                , intent(in)    :: filter_soilc(:) ! filter for soil columns
     integer                , intent(in)    :: num_soilp       ! number of soil patches in filter
     integer                , intent(in)    :: filter_soilp(:) ! filter for soil patches
-    character(len=*)       , intent(in)    :: isotope
+    character(len=*)       , intent(in)    :: isotope   
     !
     ! !LOCAL VARIABLES:
     real(r8) :: nfixlags, dtime ! temp variables for making lagged npp
@@ -4395,10 +4391,10 @@ contains
     real(r8) :: maxdepth        ! depth to integrate soil variables
     !-----------------------------------------------------------------------
 
-   associate(&
+   associate(& 
         is_litter =>    decomp_cascade_con%is_litter , & ! Input:  [logical (:) ]  TRUE => pool is a litter pool
-        is_soil   =>    decomp_cascade_con%is_soil   , & ! Input:  [logical (:) ]  TRUE => pool is a soil pool
-        is_cwd    =>    decomp_cascade_con%is_cwd      & ! Input:  [logical (:) ]  TRUE => pool is a cwd pool
+        is_soil   =>    decomp_cascade_con%is_soil   , & ! Input:  [logical (:) ]  TRUE => pool is a soil pool  
+        is_cwd    =>    decomp_cascade_con%is_cwd      & ! Input:  [logical (:) ]  TRUE => pool is a cwd pool   
         )
 
     ! patch loop
@@ -4497,8 +4493,8 @@ contains
             this%gpp_patch(p) - &
             this%ar_patch(p)
 
-       ! update the annual NPP accumulator, for use in allocation code
-       if (trim(isotope) == 'bulk') then
+       ! update the annual NPP accumulator, for use in allocation code 
+       if (trim(isotope) == 'bulk') then      
           this%tempsum_npp_patch(p) = &
                this%tempsum_npp_patch(p) + &
                this%npp_patch(p)
@@ -4555,7 +4551,7 @@ contains
             this%m_deadcrootc_xfer_to_litter_patch(p)         + &
             this%m_gresp_storage_to_litter_patch(p)           + &
             this%m_gresp_xfer_to_litter_patch(p)              + &
-
+            
             this%m_leafc_to_litter_fire_patch(p)              + &
             this%m_leafc_storage_to_litter_fire_patch(p)      + &
             this%m_leafc_xfer_to_litter_fire_patch(p)         + &
@@ -4576,7 +4572,7 @@ contains
             this%m_deadcrootc_xfer_to_litter_fire_patch(p)    + &
             this%m_gresp_storage_to_litter_fire_patch(p)      + &
             this%m_gresp_xfer_to_litter_fire_patch(p)         + &
-
+            
             this%hrv_leafc_to_litter_patch(p)                 + &
             this%hrv_leafc_storage_to_litter_patch(p)         + &
             this%hrv_leafc_xfer_to_litter_patch(p)            + &
@@ -4658,7 +4654,7 @@ contains
        ! (FROOTC_ALLOC) - fine root C allocation
        this%frootc_alloc_patch(p) = &
             this%frootc_xfer_to_frootc_patch(p)    + &
-            this%cpool_to_frootc_patch(p)
+            this%cpool_to_frootc_patch(p)     
 
        ! (FROOTC_LOSS) - fine root C loss changed by F. Li and S. Levis
        this%frootc_loss_patch(p) = &
@@ -4667,11 +4663,11 @@ contains
             this%m_frootc_to_litter_fire_patch(p)  + &
             this%hrv_frootc_to_litter_patch(p)     + &
             this%frootc_to_litter_patch(p)
-
+       
        ! (LEAFC_ALLOC) - leaf C allocation
        this%leafc_alloc_patch(p) = &
             this%leafc_xfer_to_leafc_patch(p)    + &
-            this%cpool_to_leafc_patch(p)
+            this%cpool_to_leafc_patch(p)     
 
        ! (LEAFC_LOSS) - leaf C loss changed by F. Li and S. Levis
        this%leafc_loss_patch(p) = &
@@ -4721,7 +4717,7 @@ contains
             this%hrv_livecrootc_xfer_to_litter_patch(p)    + &
             this%hrv_deadcrootc_to_litter_patch(p)         + &
             this%hrv_deadcrootc_storage_to_litter_patch(p) + &
-            this%hrv_deadcrootc_xfer_to_litter_patch(p)
+            this%hrv_deadcrootc_xfer_to_litter_patch(p)   
         ! putting the harvested crop stem and grain in the wood loss bdrewniak
         if ( crop_prog .and. pft%itype(p) >= npcropmin )then
              this%woodc_loss_patch(p) = &
@@ -4801,15 +4797,14 @@ contains
        this%cwdc_loss_col(c)          = 0._r8
        this%som_c_leached_col(c)      = 0._r8
     end do
-
+    
     if ( (.not. is_active_betr_bgc           ) .and. &
          (.not. (use_pflotran .and. pf_cmode))) then
-      do k = 1, ndecomp_cascade_transitions
 
+      do k = 1, ndecomp_cascade_transitions
        do j = 1,nlevdecomp
           do fc = 1,num_soilc
              c = filter_soilc(fc)
-
              this%decomp_cascade_hr_col(c,k) = 0._r8
           enddo
        enddo
@@ -4823,11 +4818,11 @@ contains
 
              this%decomp_cascade_hr_col(c,k) = &
                   this%decomp_cascade_hr_col(c,k) + &
-                  this%decomp_cascade_hr_vr_col(c,j,k) * dzsoi_decomp(j)
+                  this%decomp_cascade_hr_vr_col(c,j,k) * dzsoi_decomp(j) 
 
              this%decomp_cascade_ctransfer_col(c,k) = &
                   this%decomp_cascade_ctransfer_col(c,k) + &
-                  this%decomp_cascade_ctransfer_vr_col(c,j,k) * dzsoi_decomp(j)
+                  this%decomp_cascade_ctransfer_vr_col(c,j,k) * dzsoi_decomp(j) 
           end do
        end do
       end do
@@ -4887,10 +4882,10 @@ contains
 
        do fc = 1, num_soilc
         c = filter_soilc(fc)
-        this%hr_col(c) = dot_sum(this%hr_vr_col(c,1:nlevdecomp),dzsoi_decomp(1:nlevdecomp))
+        this%hr_col(c) = dot_sum(this%hr_vr_col(c,1:nlevdecomp),dzsoi_decomp(1:nlevdecomp)) 
       enddo
     endif
-
+    
 
     ! bgc interface & pflotran:
     !----------------------------------------------------------------
@@ -4899,7 +4894,7 @@ contains
     end if
     !! CSummary_interface: hr_col(c) will be used below
     !----------------------------------------------------------------
-
+     
     do fc = 1,num_soilc
        c = filter_soilc(fc)
        ! total soil respiration, heterotrophic + root respiration (SR)
@@ -4918,7 +4913,7 @@ contains
        ! total product loss
        this%product_closs_col(c) = &
             this%prod10c_loss_col(c)  + &
-            this%prod100c_loss_col(c) + &
+            this%prod100c_loss_col(c) + & 
             this%prod1c_loss_col(c)
 
        ! soil organic matter fire losses (SOMFIRE)
@@ -4947,7 +4942,7 @@ contains
     do fc = 1,num_soilc
        c = filter_soilc(fc)
 
-       this%fire_closs_col(c) = this%fire_closs_p2c_col(c)
+       this%fire_closs_col(c) = this%fire_closs_p2c_col(c) 
        do l = 1, ndecomp_pools
           this%fire_closs_col(c) = &
                this%fire_closs_col(c) + &
@@ -5024,10 +5019,10 @@ contains
        end if
     end do
 
-    ! (LITTERC_LOSS) - litter C loss
+    ! (LITTERC_LOSS) - litter C loss      
     do fc = 1,num_soilc
        c = filter_soilc(fc)
-       this%litterc_loss_col(c) = this%lithr_col(c)
+       this%litterc_loss_col(c) = this%lithr_col(c)  
     end do
     do l = 1, ndecomp_pools
        if ( is_litter(l) ) then
@@ -5039,8 +5034,8 @@ contains
           end do
        end if
     end do
-
-
+    
+ 
       do k = 1, ndecomp_cascade_transitions
        if ( is_litter(decomp_cascade_con%cascade_donor_pool(k)) ) then
           do fc = 1,num_soilc
@@ -5076,7 +5071,7 @@ contains
        end do
       end do
     endif
-
+    
     ! debug
     do fc = 1,num_soilc
         c = filter_soilc(fc)
@@ -5100,7 +5095,7 @@ contains
                 this%fire_mortality_c_to_cwdc_col(c,j)* dzsoi_decomp(j)
         end do
     end do
-
+    
   end associate
   end subroutine Summary
 
@@ -5310,16 +5305,16 @@ subroutine CSummary_interface(this, bounds, num_soilc, filter_soilc)
 end subroutine CSummary_interface
 !!-------------------------------------------------------------------------------------------------
 
-  !------------------------------------------------------------
+  !------------------------------------------------------------  
   subroutine summary_rr(this, bounds, num_soilp, filter_soilp, num_soilc, filter_soilc)
   !
   ! description
   ! summarize root respiration
 
   use subgridAveMod    , only: p2c
-  class(carbonflux_type) :: this
+  class(carbonflux_type) :: this  
 
-  type(bounds_type), intent(in) :: bounds
+  type(bounds_type), intent(in) :: bounds  
   integer, intent(in) :: num_soilp
   integer, intent(in) :: filter_soilp(:)
   integer, intent(in) :: num_soilc
@@ -5327,7 +5322,7 @@ end subroutine CSummary_interface
   integer :: fp, p
    ! patch loop
   do fp = 1,num_soilp
-    p = filter_soilp(fp)
+    p = filter_soilp(fp)  
     ! root respiration (RR)
     this%rr_patch(p) = &
     this%froot_mr_patch(p) + &
@@ -5340,12 +5335,12 @@ end subroutine CSummary_interface
     this%cpool_froot_storage_gr_patch(p) + &
     this%cpool_livecroot_storage_gr_patch(p) + &
     this%cpool_deadcroot_storage_gr_patch(p)
-  enddo
+  enddo  
     call p2c(bounds, num_soilc, filter_soilc, &
          this%rr_patch(bounds%begp:bounds%endp), &
          this%rr_col(bounds%begc:bounds%endc))
-
+         
   end subroutine summary_rr
-
-
+  
+  
 end module CNCarbonFluxType

--- a/components/clm/src/biogeochem/ch4Mod.F90
+++ b/components/clm/src/biogeochem/ch4Mod.F90
@@ -29,15 +29,15 @@ module ch4Mod
   use EnergyFluxType     , only : energyflux_type
   use LakeStateType      , only : lakestate_type
   use lnd2atmType        , only : lnd2atm_type
-  use SoilHydrologyType  , only : soilhydrology_type
+  use SoilHydrologyType  , only : soilhydrology_type  
   use SoilStateType      , only : soilstate_type
   use TemperatureType    , only : temperature_type
   use WaterfluxType      , only : waterflux_type
   use WaterstateType     , only : waterstate_type
-  use GridcellType       , only : grc
-  use LandunitType       , only : lun
-  use ColumnType         , only : col
-  use PatchType          , only : pft
+  use GridcellType       , only : grc                
+  use LandunitType       , only : lun                
+  use ColumnType         , only : col                
+  use PatchType          , only : pft                
   !
   implicit none
   save
@@ -76,7 +76,7 @@ module ch4Mod
 
      ! ch4 oxidation constants
      real(r8) :: vmax_ch4_oxid        ! oxidation rate constant (= 45.e-6_r8 * 1000._r8 / 3600._r8) [mol/m3-w/s];
-     real(r8) :: k_m                  ! Michaelis-Menten oxidation rate constant for CH4 concentration
+     real(r8) :: k_m                  ! Michaelis-Menten oxidation rate constant for CH4 concentration 
      real(r8) :: q10_ch4oxid          ! Q10 oxidation constant
      real(r8) :: smp_crit             ! Critical soil moisture potential
      real(r8) :: k_m_o2               ! Michaelis-Menten oxidation rate constant for O2 concentration
@@ -90,7 +90,7 @@ module ch4Mod
      real(r8) :: scale_factor_aere    ! scale factor on the aerenchyma area for sensitivity tests
      real(r8) :: nongrassporosratio   ! Ratio of root porosity in non-grass to grass, used for aerenchyma transport
      real(r8) :: unsat_aere_ratio     ! Ratio to multiply upland vegetation aerenchyma porosity by compared to inundated systems (= 0.05_r8 / 0.3_r8)
-     real(r8) :: porosmin             ! minimum aerenchyma porosity (unitless)(= 0.05_r8)
+     real(r8) :: porosmin             ! minimum aerenchyma porosity (unitless)(= 0.05_r8) 
 
      ! ch4 ebbulition constants
      real(r8) :: vgc_max              ! ratio of saturation pressure triggering ebullition
@@ -104,7 +104,7 @@ module ch4Mod
      ! additional constants
      real(r8) :: f_sat                ! volumetric soil water defining top of water table or where production is allowed (=0.95)
      real(r8) :: qflxlagd             ! days to lag qflx_surf_lag in the tropics (days) ( = 30._r8)
-     real(r8) :: highlatfact          ! multiple of qflxlagd for high latitudes	(= 2._r8)
+     real(r8) :: highlatfact          ! multiple of qflxlagd for high latitudes	(= 2._r8)	
      real(r8) :: q10lakebase          ! (K) base temperature for lake CH4 production (= 298._r8)
      real(r8) :: atmch4               ! Atmospheric CH4 mixing ratio to prescribe if not provided by the atmospheric model (= 1.7e-6_r8) (mol/mol)
      real(r8) :: rob                  ! ratio of root length to vertical depth ("root obliquity") (= 3._r8)
@@ -188,11 +188,11 @@ module ch4Mod
 
    contains
 
-     procedure, public  :: Init
+     procedure, public  :: Init 
      procedure, private :: InitAllocate
-     procedure, private :: InitHistory
-     procedure, private :: InitCold
-     procedure, public  :: Restart
+     procedure, private :: InitHistory  
+     procedure, private :: InitCold     
+     procedure, public  :: Restart         
 
   end type ch4_type
   !------------------------------------------------------------------------
@@ -203,7 +203,7 @@ contains
   subroutine Init( this, bounds, cellorg_col )
 
     class(ch4_type)               :: this
-    type(bounds_type), intent(in) :: bounds
+    type(bounds_type), intent(in) :: bounds  
     real(r8)         , intent(in) :: cellorg_col (bounds%begc:, 1:)
 
     call this%InitAllocate (bounds)
@@ -226,7 +226,7 @@ contains
     !
     ! !ARGUMENTS:
     class(ch4_type) :: this
-    type(bounds_type), intent(in) :: bounds
+    type(bounds_type), intent(in) :: bounds  
     !
     ! !LOCAL VARIABLES:
     integer  :: begp, endp
@@ -269,25 +269,25 @@ contains
     allocate(this%ch4_surf_ebul_lake_col     (begc:endc))            ;  this%ch4_surf_ebul_lake_col     (:)   = nan
     allocate(this%conc_ch4_sat_col           (begc:endc,1:nlevgrnd)) ;  this%conc_ch4_sat_col           (:,:) = spval ! detect file input
     allocate(this%conc_ch4_unsat_col         (begc:endc,1:nlevgrnd)) ;  this%conc_ch4_unsat_col         (:,:) = spval ! detect file input
-    allocate(this%conc_ch4_lake_col          (begc:endc,1:nlevgrnd)) ;  this%conc_ch4_lake_col          (:,:) = nan
+    allocate(this%conc_ch4_lake_col          (begc:endc,1:nlevgrnd)) ;  this%conc_ch4_lake_col          (:,:) = nan 
     allocate(this%ch4_surf_diff_sat_col      (begc:endc))            ;  this%ch4_surf_diff_sat_col      (:)   = nan
     allocate(this%ch4_surf_diff_unsat_col    (begc:endc))            ;  this%ch4_surf_diff_unsat_col    (:)   = nan
     allocate(this%ch4_surf_diff_lake_col     (begc:endc))            ;  this%ch4_surf_diff_lake_col     (:)   = nan
-    allocate(this%conc_o2_lake_col           (begc:endc,1:nlevgrnd)) ;  this%conc_o2_lake_col           (:,:) = nan
+    allocate(this%conc_o2_lake_col           (begc:endc,1:nlevgrnd)) ;  this%conc_o2_lake_col           (:,:) = nan 
     allocate(this%ch4_dfsat_flux_col         (begc:endc))            ;  this%ch4_dfsat_flux_col         (:)   = nan
     allocate(this%zwt_ch4_unsat_col          (begc:endc))            ;  this%zwt_ch4_unsat_col          (:)   = nan
     allocate(this%fsat_bef_col               (begc:endc))            ;  this%fsat_bef_col               (:)   = nan
     allocate(this%lake_soilc_col             (begc:endc,1:nlevgrnd)) ;  this%lake_soilc_col             (:,:) = spval !first time-step
     allocate(this%totcolch4_col              (begc:endc))            ;  this%totcolch4_col              (:)   = nan
-    allocate(this%annsum_counter_col         (begc:endc))            ;  this%annsum_counter_col         (:)   = nan
+    allocate(this%annsum_counter_col         (begc:endc))            ;  this%annsum_counter_col         (:)   = nan 
     allocate(this%tempavg_somhr_col          (begc:endc))            ;  this%tempavg_somhr_col          (:)   = nan
-    allocate(this%annavg_somhr_col           (begc:endc))            ;  this%annavg_somhr_col           (:)   = nan
+    allocate(this%annavg_somhr_col           (begc:endc))            ;  this%annavg_somhr_col           (:)   = nan 
     allocate(this%tempavg_finrw_col          (begc:endc))            ;  this%tempavg_finrw_col          (:)   = nan
-    allocate(this%annavg_finrw_col           (begc:endc))            ;  this%annavg_finrw_col           (:)   = nan
+    allocate(this%annavg_finrw_col           (begc:endc))            ;  this%annavg_finrw_col           (:)   = nan 
     allocate(this%sif_col                    (begc:endc))            ;  this%sif_col                    (:)   = nan
     allocate(this%ch4stress_unsat_col        (begc:endc,1:nlevgrnd)) ;  this%ch4stress_unsat_col        (:,:) = nan
-    allocate(this%ch4stress_sat_col          (begc:endc,1:nlevgrnd)) ;  this%ch4stress_sat_col          (:,:) = nan
-    allocate(this%qflx_surf_lag_col          (begc:endc))            ;  this%qflx_surf_lag_col          (:)   = nan
+    allocate(this%ch4stress_sat_col          (begc:endc,1:nlevgrnd)) ;  this%ch4stress_sat_col          (:,:) = nan    
+    allocate(this%qflx_surf_lag_col          (begc:endc))            ;  this%qflx_surf_lag_col          (:)   = nan 
     allocate(this%finundated_lag_col         (begc:endc))            ;  this%finundated_lag_col         (:)   = nan
     allocate(this%layer_sat_lag_col          (begc:endc,1:nlevgrnd)) ;  this%layer_sat_lag_col          (:,:) = nan
     allocate(this%zwt0_col                   (begc:endc))            ;  this%zwt0_col                   (:)   = nan
@@ -300,12 +300,12 @@ contains
     allocate(this%ch4co2f_grc                (begg:endg))            ;  this%ch4co2f_grc                (:)   = nan
     allocate(this%ch4prodg_grc               (begg:endg))            ;  this%ch4prodg_grc               (:)   = nan
 
-    allocate(this%finundated_col             (begc:endc))            ;  this%finundated_col             (:)   = nan
-    allocate(this%o2stress_unsat_col         (begc:endc,1:nlevgrnd)) ;  this%o2stress_unsat_col         (:,:) = nan
-    allocate(this%o2stress_sat_col           (begc:endc,1:nlevgrnd)) ;  this%o2stress_sat_col           (:,:) = nan
+    allocate(this%finundated_col             (begc:endc))            ;  this%finundated_col             (:)   = nan          
+    allocate(this%o2stress_unsat_col         (begc:endc,1:nlevgrnd)) ;  this%o2stress_unsat_col         (:,:) = nan          
+    allocate(this%o2stress_sat_col           (begc:endc,1:nlevgrnd)) ;  this%o2stress_sat_col           (:,:) = nan          
     allocate(this%conc_o2_sat_col            (begc:endc,1:nlevgrnd)) ;  this%conc_o2_sat_col            (:,:) = nan
     allocate(this%conc_o2_unsat_col          (begc:endc,1:nlevgrnd)) ;  this%conc_o2_unsat_col          (:,:) = nan
-    allocate(this%o2_decomp_depth_sat_col    (begc:endc,1:nlevgrnd)) ;  this%o2_decomp_depth_sat_col    (:,:) = nan
+    allocate(this%o2_decomp_depth_sat_col    (begc:endc,1:nlevgrnd)) ;  this%o2_decomp_depth_sat_col    (:,:) = nan          
     allocate(this%o2_decomp_depth_unsat_col  (begc:endc,1:nlevgrnd)) ;  this%o2_decomp_depth_unsat_col  (:,:) = nan
     allocate(this%ch4_surf_flux_tot_col      (begc:endc))            ;  this%ch4_surf_flux_tot_col      (:)   = nan
 
@@ -325,13 +325,13 @@ contains
     !
     ! !ARGUMENTS:
     class(ch4_type) :: this
-    type(bounds_type), intent(in)    :: bounds
+    type(bounds_type), intent(in)    :: bounds  
     !
     ! !LOCAL VARIABLES:
     character(8)  :: vr_suffix
     character(10) :: active
     integer       :: begc,endc
-    integer       :: begg,endg
+    integer       :: begg,endg 
     !---------------------------------------------------------------------
 
     begc = bounds%begc; endc = bounds%endc
@@ -339,7 +339,7 @@ contains
 
     if (nlevdecomp > 1) then
        vr_suffix = "_vr"
-    else
+    else 
        vr_suffix = ""
     endif
 
@@ -664,11 +664,11 @@ contains
     ! !DESCRIPTION:
     ! - Sets cold start values for time varying values.
     ! Initializes the following time varying variables:
-    ! conc_ch4_sat, conc_ch4_unsat, conc_o2_sat, conc_o2_unsat,
+    ! conc_ch4_sat, conc_ch4_unsat, conc_o2_sat, conc_o2_unsat, 
     ! lake_soilc, o2stress, finunduated
-    ! - Sets variables for ch4 code that will not be input
-    ! from restart/inic file.
-    ! - Sets values for inactive CH4 columns to spval so that they will
+    ! - Sets variables for ch4 code that will not be input 
+    ! from restart/inic file. 
+    ! - Sets values for inactive CH4 columns to spval so that they will 
     ! not be averaged in history file.
     !
     ! !USES:
@@ -679,21 +679,21 @@ contains
     use ch4varcon       , only : allowlakeprod, usephfact, fin_use_fsat
     use spmdMod         , only : masterproc
     use fileutils       , only : getfil
-    use ncdio_pio
+    use ncdio_pio       
     !
     ! !ARGUMENTS:
     class(ch4_type) :: this
-    type(bounds_type) , intent(in) :: bounds
+    type(bounds_type) , intent(in) :: bounds  
     real(r8)          , intent(in) :: cellorg_col (bounds%begc:, 1:)
     !
     ! !LOCAL VARIABLES:
     integer               :: j ,g, l,c,p ! indices
     type(file_desc_t)     :: ncid        ! netcdf id
-    real(r8)     ,pointer :: zwt0_in (:) ! read in - zwt0
-    real(r8)     ,pointer :: f0_in (:)   ! read in - f0
-    real(r8)     ,pointer :: p3_in (:)   ! read in - p3
-    real(r8)     ,pointer :: pH_in (:)   ! read in - pH
-    logical               :: readvar
+    real(r8)     ,pointer :: zwt0_in (:) ! read in - zwt0 
+    real(r8)     ,pointer :: f0_in (:)   ! read in - f0 
+    real(r8)     ,pointer :: p3_in (:)   ! read in - p3 
+    real(r8)     ,pointer :: pH_in (:)   ! read in - pH 
+    logical               :: readvar 
     !-----------------------------------------------------------------------
 
     SHR_ASSERT_ALL((ubound(cellorg_col) == (/bounds%endc, nlevsoi/)), errMsg(__FILE__, __LINE__))
@@ -759,13 +759,13 @@ contains
     do c = bounds%begc,bounds%endc
 
        ! To detect first time-step
-       this%fsat_bef_col       (c) = spval
+       this%fsat_bef_col       (c) = spval 
        this%annsum_counter_col (c) = spval
-       this%totcolch4_col      (c) = spval
+       this%totcolch4_col      (c) = spval 
 
        ! To detect first year
-       this%annavg_somhr_col(c)   = spval
-       this%annavg_finrw_col(c)   = spval
+       this%annavg_somhr_col(c)   = spval 
+       this%annavg_finrw_col(c)   = spval 
 
        ! To detect file input
        this%qflx_surf_lag_col  (c)   = spval
@@ -773,13 +773,13 @@ contains
        this%layer_sat_lag_col  (c,:) = spval
        this%conc_ch4_sat_col   (c,:) = spval
        this%conc_ch4_unsat_col (c,:) = spval
-       this%conc_o2_sat_col    (c,:) = spval
-       this%conc_o2_unsat_col  (c,:) = spval
+       this%conc_o2_sat_col    (c,:) = spval 
+       this%conc_o2_unsat_col  (c,:) = spval 
        this%o2stress_sat_col   (c,:) = spval
        this%o2stress_unsat_col (c,:) = spval
        this%ch4stress_sat_col  (c,:) = spval
        this%ch4stress_unsat_col(c,:) = spval
-       this%lake_soilc_col     (c,:) = spval
+       this%lake_soilc_col     (c,:) = spval 
 
        ! To detect first time-step for denitrification code
        this%o2_decomp_depth_unsat_col(c,:)= spval
@@ -797,7 +797,7 @@ contains
           this%qflx_surf_lag_col  (c)           = 0._r8
           this%finundated_lag_col (c)           = 0._r8
           this%finundated_col(c)                = 0._r8
-          ! finundated will be used to calculate soil decomposition if anoxia is used
+          ! finundated will be used to calculate soil decomposition if anoxia is used 
           ! Note that finundated will be overwritten with this%fsat_bef_col upon reading
           ! a restart file - either in a continuation, branch or startup spun-up case
 
@@ -931,7 +931,7 @@ contains
 
           ! totcolch4 Set to zero for inactive columns so that this can be used
           ! as an appropriate area-weighted gridcell average soil methane content.
-          this%totcolch4_col              (c)   = 0._r8
+          this%totcolch4_col              (c)   = 0._r8  
 
        end if
     end do
@@ -945,14 +945,14 @@ contains
     ! Read/Write biogeophysics information to/from restart file.
     !
     ! !USES:
-    use ncdio_pio , only : ncd_double
+    use ncdio_pio , only : ncd_double 
     use pio       , only : file_desc_t
     use decompMod , only : bounds_type
     use restUtilMod
     !
     ! !ARGUMENTS:
     class(ch4_type) :: this
-    type(bounds_type), intent(in)    :: bounds
+    type(bounds_type), intent(in)    :: bounds 
     type(file_desc_t), intent(inout) :: ncid   ! netcdf id
     character(len=*),  intent(in)    :: flag   ! 'read' or 'write'
     !
@@ -1078,7 +1078,7 @@ contains
         if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
         CH4ParamsInst%aereoxid=tempr
      else
-        ! value should never be used.
+        ! value should never be used.  
         CH4ParamsInst%aereoxid=nan
      endif
 
@@ -1126,7 +1126,7 @@ contains
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%pHmax=tempr
-
+   
      tString='pHmin'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
@@ -1150,21 +1150,21 @@ contains
      CH4ParamsInst%k_m= 5.e-6_r8 * 1000._r8
      ! FIX(FIX(SPM,032414),032414) can't be read off of param file.  not bfb since it is a divide
      !CH4ParamsInst%k_m=tempr
-
+   
      tString='q10_ch4oxid'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%q10_ch4oxid=tempr
-
+   
      tString='smp_crit'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%smp_crit=tempr
-
+ 
      tString='k_m_o2'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
-     CH4ParamsInst%k_m_o2  = 20.e-6_r8 * 1000._r8
+     CH4ParamsInst%k_m_o2  = 20.e-6_r8 * 1000._r8 
      ! FIX(FIX(SPM,032414),032414) can't be read off of param file.  not bfb since it is a divide
      !CH4ParamsInst%k_m_o2=tempr
 
@@ -1185,17 +1185,17 @@ contains
      tString='scale_factor_aere'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
-     CH4ParamsInst%scale_factor_aere=tempr
-
+     CH4ParamsInst%scale_factor_aere=tempr 
+   
      tString='nongrassporosratio'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
-     CH4ParamsInst%nongrassporosratio=tempr
+     CH4ParamsInst%nongrassporosratio=tempr 
 
      tString='unsat_aere_ratio'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
-     CH4ParamsInst%unsat_aere_ratio= 0.05_r8 / 0.3_r8
+     CH4ParamsInst%unsat_aere_ratio= 0.05_r8 / 0.3_r8 
      ! FIX(FIX(SPM,032414),032414) can't be read off of param file.  not bfb since it is a divide
      !CH4ParamsInst%unsat_aere_ratio=tempr
 
@@ -1203,12 +1203,12 @@ contains
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%porosmin=tempr
-
+   
      tString='vgc_max'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%vgc_max=tempr
-
+ 
      tString='satpow'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
@@ -1217,7 +1217,7 @@ contains
      tString='scale_factor_gasdiff'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
-     CH4ParamsInst%scale_factor_gasdiff=tempr
+     CH4ParamsInst%scale_factor_gasdiff=tempr   
 
      tString='scale_factor_liqdiff'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
@@ -1228,7 +1228,7 @@ contains
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%f_sat=tempr
-
+   
      tString='qflxlagd'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
@@ -1238,27 +1238,27 @@ contains
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%highlatfact=tempr
-
+   
      tString='q10lakebase'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%q10lakebase=tempr
-
+   
      tString='atmch4'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%atmch4=tempr
-
+   
      tString='rob'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
-     CH4ParamsInst%rob=tempr
+     CH4ParamsInst%rob=tempr   
 
      tString='capthick'
      call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
      if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
      CH4ParamsInst%capthick=tempr
-
+   
   end subroutine readCH4Params
 
   !-----------------------------------------------------------------------
@@ -1281,7 +1281,7 @@ contains
     use clm_varcon         , only : secspday
     !
     ! !ARGUMENTS:
-    type(bounds_type)        , intent(in)    :: bounds
+    type(bounds_type)        , intent(in)    :: bounds   
     integer                  , intent(in)    :: num_soilc          ! number of column soil points in column filter
     integer                  , intent(in)    :: filter_soilc(:)    ! column filter for soil points
     integer                  , intent(in)    :: num_lakec          ! number of column lake points in column filter
@@ -1317,13 +1317,13 @@ contains
     real(r8) :: totalsat
     real(r8) :: totalunsat
     real(r8) :: dfsat
-    real(r8) :: rootfraction(bounds%begp:bounds%endp, 1:nlevgrnd)
+    real(r8) :: rootfraction(bounds%begp:bounds%endp, 1:nlevgrnd) 
     real(r8) :: totcolch4_bef(bounds%begc:bounds%endc) ! g C / m^2
     real(r8) :: errch4                                 ! g C / m^2
     real(r8) :: zwt_actual
     real(r8) :: qflxlags                               ! Time to lag qflx_surf_lag (s)
-    real(r8) :: redoxlag                               ! Redox time lag
-    real(r8) :: redoxlag_vertical                      ! Vertical redox lag time
+    real(r8) :: redoxlag                               ! Redox time lag 
+    real(r8) :: redoxlag_vertical                      ! Vertical redox lag time 
     real(r8) :: atmch4                                 ! Atmospheric CH4 mixing ratio to
                                                        ! prescribe if not provided by the atmospheric model (= 1.7e-6_r8) (mol/mol)
     real(r8) :: redoxlags                              ! Redox time lag in s
@@ -1334,43 +1334,43 @@ contains
     character(len=32) :: subname='ch4'                 ! subroutine name
     !-----------------------------------------------------------------------
 
-    associate(                                                                 &
-         dz                   =>   col%dz                                    , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
-         zi                   =>   col%zi                                    , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
-         z                    =>   col%z                                     , & ! Input:  [real(r8) (:,:) ]  layer depth (m) (-nlevsno+1:nlevsoi)
+    associate(                                                                 & 
+         dz                   =>   col%dz                                    , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevsoi)       
+         zi                   =>   col%zi                                    , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)           
+         z                    =>   col%z                                     , & ! Input:  [real(r8) (:,:) ]  layer depth (m) (-nlevsno+1:nlevsoi)            
 
-         forc_t               =>   atm2lnd_vars%forc_t_not_downscaled_grc    , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)
-         forc_pbot            =>   atm2lnd_vars%forc_pbot_not_downscaled_grc , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)
-         forc_po2             =>   atm2lnd_vars%forc_po2_grc                 , & ! Input:  [real(r8) (:)   ]  O2 partial pressure (Pa)
-         forc_pco2            =>   atm2lnd_vars%forc_pco2_grc                , & ! Input:  [real(r8) (:)   ]  CO2 partial pressure (Pa)
-         forc_pch4            =>   atm2lnd_vars%forc_pch4_grc                , & ! Input:  [real(r8) (:)   ]  CH4 partial pressure (Pa)
+         forc_t               =>   atm2lnd_vars%forc_t_not_downscaled_grc    , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                  
+         forc_pbot            =>   atm2lnd_vars%forc_pbot_not_downscaled_grc , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
+         forc_po2             =>   atm2lnd_vars%forc_po2_grc                 , & ! Input:  [real(r8) (:)   ]  O2 partial pressure (Pa)                          
+         forc_pco2            =>   atm2lnd_vars%forc_pco2_grc                , & ! Input:  [real(r8) (:)   ]  CO2 partial pressure (Pa)                         
+         forc_pch4            =>   atm2lnd_vars%forc_pch4_grc                , & ! Input:  [real(r8) (:)   ]  CH4 partial pressure (Pa)                         
 
-         zwt                  =>   soilhydrology_vars%zwt_col                , & ! Input:  [real(r8) (:)   ]  water table depth (m)
-         zwt_perched          =>   soilhydrology_vars%zwt_perched_col        , & ! Input:  [real(r8) (:)   ]  perched water table depth (m)
+         zwt                  =>   soilhydrology_vars%zwt_col                , & ! Input:  [real(r8) (:)   ]  water table depth (m) 
+         zwt_perched          =>   soilhydrology_vars%zwt_perched_col        , & ! Input:  [real(r8) (:)   ]  perched water table depth (m)                     
 
          rootfr               =>   soilstate_vars%rootfr_patch               , & ! Input:  [real(r8) (:,:) ]  fraction of roots in each soil layer  (nlevgrnd)
          rootfr_col           =>   soilstate_vars%rootfr_col                 , & ! Output: [real(r8) (:,:) ]  fraction of roots in each soil layer  (nlevgrnd) (p2c)
 
          frac_h2osfc          =>   waterstate_vars%frac_h2osfc_col           , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by surface water (0 to 1)
-         qflx_surf            =>   waterflux_vars%qflx_surf_col              , & ! Input:  [real(r8) (:)   ]  surface runoff (mm H2O /s)
+         qflx_surf            =>   waterflux_vars%qflx_surf_col              , & ! Input:  [real(r8) (:)   ]  surface runoff (mm H2O /s)                        
 
-         conc_o2_sat          =>   ch4_vars%conc_o2_sat_col                  , & ! Input:  [real(r8) (:,:) ]  O2 conc  in each soil layer (mol/m3) (nlevsoi)
-         zwt0                 =>   ch4_vars%zwt0_col                         , & ! Input:  [real(r8) (:)   ]  decay factor for finundated (m)
-         f0                   =>   ch4_vars%f0_col                           , & ! Input:  [real(r8) (:)   ]  maximum gridcell fractional inundated area
+         conc_o2_sat          =>   ch4_vars%conc_o2_sat_col                  , & ! Input:  [real(r8) (:,:) ]  O2 conc  in each soil layer (mol/m3) (nlevsoi)  
+         zwt0                 =>   ch4_vars%zwt0_col                         , & ! Input:  [real(r8) (:)   ]  decay factor for finundated (m)                   
+         f0                   =>   ch4_vars%f0_col                           , & ! Input:  [real(r8) (:)   ]  maximum gridcell fractional inundated area        
          p3                   =>   ch4_vars%p3_col                           , & ! Input:  [real(r8) (:)   ]  coefficient for qflx_surf_lag for finunated (s/mm)
 
-         grnd_ch4_cond_patch  =>   ch4_vars%grnd_ch4_cond_patch              , & ! Input:  [real(r8) (:)   ]  tracer conductance for boundary layer [m/s]
-         grnd_ch4_cond_col    =>   ch4_vars%grnd_ch4_cond_col                , & ! Output: [real(r8) (:)   ]  tracer conductance for boundary layer [m/s] (p2c)
+         grnd_ch4_cond_patch  =>   ch4_vars%grnd_ch4_cond_patch              , & ! Input:  [real(r8) (:)   ]  tracer conductance for boundary layer [m/s]       
+         grnd_ch4_cond_col    =>   ch4_vars%grnd_ch4_cond_col                , & ! Output: [real(r8) (:)   ]  tracer conductance for boundary layer [m/s] (p2c)      
 
-         ch4_surf_diff_sat    =>   ch4_vars%ch4_surf_diff_sat_col            , & ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)
-         ch4_surf_diff_unsat  =>   ch4_vars%ch4_surf_diff_unsat_col          , & ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)
-         ch4_surf_diff_lake   =>   ch4_vars%ch4_surf_diff_lake_col           , & ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)
-         ch4_surf_ebul_sat    =>   ch4_vars%ch4_surf_ebul_sat_col            , & ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)
-         ch4_surf_ebul_unsat  =>   ch4_vars%ch4_surf_ebul_unsat_col          , & ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)
-         ch4_surf_ebul_lake   =>   ch4_vars%ch4_surf_ebul_lake_col           , & ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)
-         ch4_surf_aere_sat    =>   ch4_vars%ch4_surf_aere_sat_col            , & ! Output: [real(r8) (:)   ]  Total column CH4 aerenchyma (mol/m2/s)
-         ch4_surf_aere_unsat  =>   ch4_vars%ch4_surf_aere_unsat_col          , & ! Output: [real(r8) (:)   ]  Total column CH4 aerenchyma (mol/m2/s)
-         fsat_bef             =>   ch4_vars%fsat_bef_col                     , & ! Output: [real(r8) (:)   ]  finundated from previous timestep
+         ch4_surf_diff_sat    =>   ch4_vars%ch4_surf_diff_sat_col            , & ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)                       
+         ch4_surf_diff_unsat  =>   ch4_vars%ch4_surf_diff_unsat_col          , & ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)                       
+         ch4_surf_diff_lake   =>   ch4_vars%ch4_surf_diff_lake_col           , & ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)                       
+         ch4_surf_ebul_sat    =>   ch4_vars%ch4_surf_ebul_sat_col            , & ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)           
+         ch4_surf_ebul_unsat  =>   ch4_vars%ch4_surf_ebul_unsat_col          , & ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)           
+         ch4_surf_ebul_lake   =>   ch4_vars%ch4_surf_ebul_lake_col           , & ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)           
+         ch4_surf_aere_sat    =>   ch4_vars%ch4_surf_aere_sat_col            , & ! Output: [real(r8) (:)   ]  Total column CH4 aerenchyma (mol/m2/s)            
+         ch4_surf_aere_unsat  =>   ch4_vars%ch4_surf_aere_unsat_col          , & ! Output: [real(r8) (:)   ]  Total column CH4 aerenchyma (mol/m2/s)            
+         fsat_bef             =>   ch4_vars%fsat_bef_col                     , & ! Output: [real(r8) (:)   ]  finundated from previous timestep                 
          ch4_oxid_depth_sat   =>   ch4_vars%ch4_oxid_depth_sat_col           , & ! Output: [real(r8) (:,:) ]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          ch4_oxid_depth_unsat =>   ch4_vars%ch4_oxid_depth_unsat_col         , & ! Output: [real(r8) (:,:) ]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          ch4_oxid_depth_lake  =>   ch4_vars%ch4_oxid_depth_lake_col          , & ! Output: [real(r8) (:,:) ]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
@@ -1378,21 +1378,21 @@ contains
          ch4_prod_depth_unsat =>   ch4_vars%ch4_prod_depth_unsat_col         , & ! Output: [real(r8) (:,:) ]  production of CH4 in each soil layer (nlevsoi) (mol/m3/s)
          ch4_prod_depth_lake  =>   ch4_vars%ch4_prod_depth_lake_col          , & ! Output: [real(r8) (:,:) ]  production of CH4 in each soil layer (nlevsoi) (mol/m3/s)
          lake_soilc           =>   ch4_vars%lake_soilc_col                   , & ! Output: [real(r8) (:,:) ]  total soil organic matter found in level (g C / m^3) (nlevsoi)
-         conc_ch4_sat         =>   ch4_vars%conc_ch4_sat_col                 , & ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
-         conc_ch4_unsat       =>   ch4_vars%conc_ch4_unsat_col               , & ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
-         conc_ch4_lake        =>   ch4_vars%conc_ch4_lake_col                , & ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
-         conc_o2_lake         =>   ch4_vars%conc_o2_lake_col                 , & ! Output: [real(r8) (:,:) ]  O2 conc  in each soil layer (mol/m3) (nlevsoi)
+         conc_ch4_sat         =>   ch4_vars%conc_ch4_sat_col                 , & ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
+         conc_ch4_unsat       =>   ch4_vars%conc_ch4_unsat_col               , & ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
+         conc_ch4_lake        =>   ch4_vars%conc_ch4_lake_col                , & ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
+         conc_o2_lake         =>   ch4_vars%conc_o2_lake_col                 , & ! Output: [real(r8) (:,:) ]  O2 conc  in each soil layer (mol/m3) (nlevsoi)  
          ch4_dfsat_flux       =>   ch4_vars%ch4_dfsat_flux_col               , & ! Output: [real(r8) (:)   ]  CH4 flux to atm due to decreasing finundated (kg C/m^2/s) [+]
-         zwt_ch4_unsat        =>   ch4_vars%zwt_ch4_unsat_col                , & ! Output: [real(r8) (:)   ]  depth of water table for unsaturated fraction (m)
-         totcolch4            =>   ch4_vars%totcolch4_col                    , & ! Output: [real(r8) (:)   ]  total methane in soil column (g C / m^2)
+         zwt_ch4_unsat        =>   ch4_vars%zwt_ch4_unsat_col                , & ! Output: [real(r8) (:)   ]  depth of water table for unsaturated fraction (m) 
+         totcolch4            =>   ch4_vars%totcolch4_col                    , & ! Output: [real(r8) (:)   ]  total methane in soil column (g C / m^2)          
          finundated           =>   ch4_vars%finundated_col                   , & ! Output: [real(r8) (:)   ]  fractional inundated area in soil column (excluding dedicated wetland columns)
-         qflx_surf_lag        =>   ch4_vars%qflx_surf_lag_col                , & ! Output: [real(r8) (:)   ]  time-lagged surface runoff (mm H2O /s)
-         finundated_lag       =>   ch4_vars%finundated_lag_col               , & ! Output: [real(r8) (:)   ]  time-lagged fractional inundated area
+         qflx_surf_lag        =>   ch4_vars%qflx_surf_lag_col                , & ! Output: [real(r8) (:)   ]  time-lagged surface runoff (mm H2O /s)            
+         finundated_lag       =>   ch4_vars%finundated_lag_col               , & ! Output: [real(r8) (:)   ]  time-lagged fractional inundated area             
          layer_sat_lag        =>   ch4_vars%layer_sat_lag_col                , & ! Output: [real(r8) (:,:) ]  Lagged saturation status of soil layer in the unsaturated zone (1 = sat)
-         c_atm                =>   ch4_vars%c_atm_grc                        , & ! Output: [real(r8) (:,:) ]  CH4, O2, CO2 atmospheric conc  (mol/m3)
+         c_atm                =>   ch4_vars%c_atm_grc                        , & ! Output: [real(r8) (:,:) ]  CH4, O2, CO2 atmospheric conc  (mol/m3)         
          ch4co2f              =>   ch4_vars%ch4co2f_grc                      , & ! Output: [real(r8) (:)   ]  gridcell CO2 production from CH4 oxidation (g C/m**2/s)
-         ch4prodg             =>   ch4_vars%ch4prodg_grc                     , & ! Output: [real(r8) (:)   ]  gridcell average CH4 production (g C/m^2/s)
-         ch4_surf_flux_tot    =>   ch4_vars%ch4_surf_flux_tot_col            , & ! Output: [real(r8) (:)   ]  col CH4 flux to atm. (kg C/m**2/s)
+         ch4prodg             =>   ch4_vars%ch4prodg_grc                     , & ! Output: [real(r8) (:)   ]  gridcell average CH4 production (g C/m^2/s)       
+         ch4_surf_flux_tot    =>   ch4_vars%ch4_surf_flux_tot_col            , & ! Output: [real(r8) (:)   ]  col CH4 flux to atm. (kg C/m**2/s)          
 
          nem_grc              =>   lnd2atm_vars%nem_grc                      , & ! Output: [real(r8) (:)   ]  gridcell average net methane correction to CO2 flux (g C/m^2/s)
 
@@ -1403,6 +1403,7 @@ contains
          begp                 =>   bounds%begp                               , &
          endp                 =>   bounds%endp                                 &
          )
+
       !calculate incoming carbon fluxes needed for methane production
       call carbonflux_vars%hr_summary_for_ch4( bounds, num_soilp, filter_soilp, num_soilc, filter_soilc )
 
@@ -1536,7 +1537,7 @@ contains
 
       if (nlevdecomp == 1) then
 
-         ! Set rootfraction to spval for non-veg points, unless pft%wtcol > 0.99,
+         ! Set rootfraction to spval for non-veg points, unless pft%wtcol > 0.99, 
          ! in which case set it equal to uniform dist.
          do j=1, nlevsoi
             do fp = 1, num_soilp
@@ -1557,7 +1558,7 @@ contains
               rootfraction(bounds%begp:bounds%endp, :), &
               rootfr_col(bounds%begc:bounds%endc, :), &
               'unity')
-
+         
          do j=1, nlevsoi
             do fc = 1, num_soilc
                c = filter_soilc(fc)
@@ -1655,7 +1656,7 @@ contains
               atm2lnd_vars, temperature_vars, lakestate_vars, soilstate_vars, waterstate_vars, &
               ch4_vars)
 
-         ! Solve CH4 reaction/diffusion equation
+         ! Solve CH4 reaction/diffusion equation 
          ! Competition for oxygen will occur here.
          call ch4_tran (bounds, &
               num_soilc, filter_soilc, &
@@ -1704,7 +1705,7 @@ contains
               atm2lnd_vars, temperature_vars, lakestate_vars, soilstate_vars, waterstate_vars, &
               ch4_vars)
 
-         ! Solve CH4 reaction/diffusion equation
+         ! Solve CH4 reaction/diffusion equation 
          ! Competition for oxygen will occur here.
          call ch4_tran (bounds, &
               num_lakec, filter_lakec, &
@@ -1894,7 +1895,7 @@ contains
     use pftvarcon          , only: noveg
     !
     ! !ARGUMENTS:
-    type(bounds_type)       , intent(in)    :: bounds
+    type(bounds_type)       , intent(in)    :: bounds              
     integer                 , intent(in)    :: num_methc           ! number of column soil points in column filter
     integer                 , intent(in)    :: filter_methc(:)     ! column filter for soil points
     integer                 , intent(in)    :: num_methp           ! number of soil points in pft filter
@@ -1919,16 +1920,16 @@ contains
     real(r8) :: q10lakebase      ! (K) base temperature for lake CH4 production
     real(r8) :: partition_z
     real(r8) :: mino2lim         ! minimum anaerobic decomposition rate as a fraction of potential aerobic rate
-    real(r8) :: q10ch4           ! additional Q10 for methane production ABOVE the soil decomposition temperature relationship
+    real(r8) :: q10ch4           ! additional Q10 for methane production ABOVE the soil decomposition temperature relationship  
     real(r8) :: q10ch4base       ! temperature at which the effective f_ch4 actually equals the constant f_ch4
     real(r8) :: f_ch4            ! ratio of CH4 production to total C mineralization
     real(r8) :: rootlitfrac      ! Fraction of soil organic matter associated with roots
     real(r8) :: cnscalefactor    ! scale factor on CN decomposition for assigning methane flux
     real(r8) :: lake_decomp_fact ! Base decomposition rate (1/s) at 25C
 
-    ! added by Lei Meng to account for pH influence of CH4 production
-    real(r8) :: pHmax
-    real(r8) :: pHmin
+    ! added by Lei Meng to account for pH influence of CH4 production 
+    real(r8) :: pHmax 
+    real(r8) :: pHmin 
     real(r8) :: pH_fact_ch4      ! pH factor in methane production
 
     ! Factors for methanogen temperature dependence being greater than soil aerobes
@@ -1951,46 +1952,46 @@ contains
     ! Enforce expected array sizes
     SHR_ASSERT_ALL((ubound(jwt) == (/bounds%endc/)), errMsg(__FILE__, __LINE__))
 
-    associate(                                                     &
-         wtcol          =>    pft%wtcol                          , & ! Input:  [real(r8) (:)    ]  weight (relative to column)
-         dz             =>    col%dz                             , & ! Input:  [real(r8) (:,:)  ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
-         z              =>    col%z                              , & ! Input:  [real(r8) (:,:)  ]  layer depth (m) (-nlevsno+1:nlevsoi)
-         zi             =>    col%zi                             , & ! Input:  [real(r8) (:,:)  ]  interface level below a "z" level (m)
+    associate(                                                     & 
+         wtcol          =>    pft%wtcol                          , & ! Input:  [real(r8) (:)    ]  weight (relative to column)                       
+         dz             =>    col%dz                             , & ! Input:  [real(r8) (:,:)  ]  layer thickness (m)  (-nlevsno+1:nlevsoi)       
+         z              =>    col%z                              , & ! Input:  [real(r8) (:,:)  ]  layer depth (m) (-nlevsno+1:nlevsoi)            
+         zi             =>    col%zi                             , & ! Input:  [real(r8) (:,:)  ]  interface level below a "z" level (m)           
 
-         t_soisno       =>    temperature_vars%t_soisno_col      , & ! Input:  [real(r8) (:,:)  ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi)
+         t_soisno       =>    temperature_vars%t_soisno_col      , & ! Input:  [real(r8) (:,:)  ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi) 
 
          h2osoi_vol     =>    waterstate_vars%h2osoi_vol_col     , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
 
          rr             =>    carbonflux_vars%rr_patch           , & ! Input:  [real(r8) (:)    ]  (gC/m2/s) root respiration (fine root MR + total root GR)
          somhr          =>    carbonflux_vars%somhr_col          , & ! Input:  [real(r8) (:)    ]  (gC/m2/s) soil organic matter heterotrophic respiration
-         lithr          =>    carbonflux_vars%lithr_col          , & ! Input:  [real(r8) (:)    ]  (gC/m2/s) litter heterotrophic respiration
+         lithr          =>    carbonflux_vars%lithr_col          , & ! Input:  [real(r8) (:)    ]  (gC/m2/s) litter heterotrophic respiration        
          hr_vr          =>    carbonflux_vars%hr_vr_col          , & ! Input:  [real(r8) (:,:)  ]  total vertically-resolved het. resp. from decomposing C pools (gC/m3/s)
          o_scalar       =>    carbonflux_vars%o_scalar_col       , & ! Input:  [real(r8) (:,:)  ]  fraction by which decomposition is limited by anoxia
          col_rr         =>    carbonflux_vars%rr_col             , & ! Input:  [real(r8) (:)    ]  (gC/m2/s) root respiration (fine root MR + total root GR)
-         fphr           =>    carbonflux_vars%fphr_col           , & ! Input:  [real(r8) (:,:)  ]  fraction of potential heterotrophic respiration
+         fphr           =>    carbonflux_vars%fphr_col           , & ! Input:  [real(r8) (:,:)  ]  fraction of potential heterotrophic respiration 
 
-         pot_f_nit_vr   =>    nitrogenflux_vars%pot_f_nit_vr_col , & ! Input:  [real(r8) (:,:)  ]  (gN/m3/s) potential soil nitrification flux
+         pot_f_nit_vr   =>    nitrogenflux_vars%pot_f_nit_vr_col , & ! Input:  [real(r8) (:,:)  ]  (gN/m3/s) potential soil nitrification flux     
 
-         watsat         =>    soilstate_vars%watsat_col          , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water at saturation (porosity)
-         rootfr         =>    soilstate_vars%rootfr_patch        , & ! Input:  [real(r8) (:,:)  ]  fraction of roots in each soil layer  (nlevsoi)
-         rootfr_col     =>    soilstate_vars%rootfr_col          , & ! Input:  [real(r8) (:,:)  ]  fraction of roots in each soil layer  (nlevsoi)
-
-         finundated     =>    ch4_vars%finundated_col            , & ! Input:  [real(r8) (:)    ]  fractional inundated area in soil column
-         pH             =>    ch4_vars%pH_col                    , & ! Input:  [real(r8) (:)    ]  soil water pH
+         watsat         =>    soilstate_vars%watsat_col          , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water at saturation (porosity)  
+         rootfr         =>    soilstate_vars%rootfr_patch        , & ! Input:  [real(r8) (:,:)  ]  fraction of roots in each soil layer  (nlevsoi) 
+         rootfr_col     =>    soilstate_vars%rootfr_col          , & ! Input:  [real(r8) (:,:)  ]  fraction of roots in each soil layer  (nlevsoi) 
+         
+         finundated     =>    ch4_vars%finundated_col            , & ! Input:  [real(r8) (:)    ]  fractional inundated area in soil column           
+         pH             =>    ch4_vars%pH_col                    , & ! Input:  [real(r8) (:)    ]  soil water pH                                     
          lake_soilc     =>    ch4_vars%lake_soilc_col            , & ! Input:  [real(r8) (:,:)  ]  total soil organic matter found in level (g C / m^3) (nlevsoi)
-         annavg_finrw   =>    ch4_vars%annavg_finrw_col          , & ! Input:  [real(r8) (:)    ]  respiration-weighted annual average of finundated
-         finundated_lag =>    ch4_vars%finundated_lag_col        , & ! Input:  [real(r8) (:)    ]  time-lagged fractional inundated area
+         annavg_finrw   =>    ch4_vars%annavg_finrw_col          , & ! Input:  [real(r8) (:)    ]  respiration-weighted annual average of finundated 
+         finundated_lag =>    ch4_vars%finundated_lag_col        , & ! Input:  [real(r8) (:)    ]  time-lagged fractional inundated area             
          layer_sat_lag  =>    ch4_vars%layer_sat_lag_col         , & ! Input:  [real(r8) (: ,:) ]  Lagged saturation status of soil layer in the unsaturated zone (1 = sat)
          sif            =>    ch4_vars%sif_col                     & ! Output: [real(r8) (:)    ]  (unitless) ratio applied to sat. prod. to account for seasonal inundation
          )
 
       if (sat == 0) then                                    ! unsaturated
-         conc_o2          => ch4_vars%conc_o2_unsat_col          ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)
+         conc_o2          => ch4_vars%conc_o2_unsat_col          ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)   
          ch4_prod_depth   => ch4_vars%ch4_prod_depth_unsat_col   ! Output: [real(r8) (:,:)]  production of CH4 in each soil layer (nlevsoi) (mol/m3/s)
          o2_decomp_depth  => ch4_vars%o2_decomp_depth_unsat_col  ! Output: [real(r8) (:,:)]  O2 consumption during decomposition in each soil layer (nlevsoi) (mol/m3/s)
          co2_decomp_depth => ch4_vars%co2_decomp_depth_unsat_col ! Output: [real(r8) (:,:)]  CO2 production during decomposition in each soil layer (nlevsoi) (mol/m3/s)
       else                                                  ! saturated
-         conc_o2          => ch4_vars%conc_o2_sat_col            ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)
+         conc_o2          => ch4_vars%conc_o2_sat_col            ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)   
          ch4_prod_depth   => ch4_vars%ch4_prod_depth_sat_col     ! Output: [real(r8) (:,:)]  production of CH4 in each soil layer (nlevsoi) (mol/m3/s)
          o2_decomp_depth  => ch4_vars%o2_decomp_depth_sat_col    ! Output: [real(r8) (:,:)]  O2 consumption during decomposition in each soil layer (nlevsoi) (mol/m3/s)
          co2_decomp_depth => ch4_vars%co2_decomp_depth_sat_col   ! Output: [real(r8) (:,:)]  CO2 production during decomposition in each soil layer (nlevsoi) (mol/m3/s)
@@ -2135,7 +2136,7 @@ contains
             ! If switched on, use pH factor for production based on spatial pH data defined in surface data.
             if (.not. lake .and. usephfact .and. pH(c) >  pHmin .and.pH(c) <  pHmax) then
                pH_fact_ch4 = 10._r8**(-0.2235_r8*pH(c)*pH(c) + 2.7727_r8*pH(c) - 8.6_r8)
-               ! fitted function using data from Dunfield et al. 1993
+               ! fitted function using data from Dunfield et al. 1993  
                ! Strictly less than one, with optimum at 6.5
                ! From Lei Meng
                f_ch4_adj = f_ch4_adj * pH_fact_ch4
@@ -2221,12 +2222,12 @@ contains
     ! !DESCRIPTION:
     ! Oxidation is based on double Michaelis-Mentin kinetics, and is adjusted for low soil moisture.
     ! Oxidation will be limited by available oxygen in ch4_tran.
-
+    
     ! !USES:
     use clm_time_manager, only : get_step_size
     !
     ! !ARGUMENTS:
-    type(bounds_type)      , intent(in) :: bounds
+    type(bounds_type)      , intent(in) :: bounds    
     integer                , intent(in) :: num_methc           ! number of column soil points in column filter
     integer                , intent(in) :: filter_methc(:)     ! column filter for soil points
     integer                , intent(in) :: jwt( bounds%begc: ) ! index of the soil layer right above the water table (-) [col]
@@ -2254,46 +2255,46 @@ contains
     real(r8):: vmax_eff                       ! effective vmax
                                               ! ch4 oxidation parameters
     real(r8) :: vmax_ch4_oxid                 ! oxidation rate constant (= 45.e-6_r8 * 1000._r8 / 3600._r8) [mol/m3-w/s];
-    real(r8) :: k_m 			      ! Michaelis-Menten oxidation rate constant for CH4 concentration
+    real(r8) :: k_m 			      ! Michaelis-Menten oxidation rate constant for CH4 concentration 
     real(r8) :: q10_ch4oxid                   ! Q10 oxidation constant
     real(r8) :: smp_crit                      ! Critical soil moisture potential
     real(r8) :: k_m_o2                        ! Michaelis-Menten oxidation rate constant for O2 concentration
     real(r8) :: k_m_unsat                     ! Michaelis-Menten oxidation rate constant for CH4 concentration
-    real(r8) :: vmax_oxid_unsat               ! (= 45.e-6_r8 * 1000._r8 / 3600._r8 / 10._r8) [mol/m3-w/s]
+    real(r8) :: vmax_oxid_unsat               ! (= 45.e-6_r8 * 1000._r8 / 3600._r8 / 10._r8) [mol/m3-w/s]   
     !
-    real(r8), pointer :: ch4_oxid_depth(:,:)
-    real(r8), pointer :: o2_oxid_depth(:,:)
-    real(r8), pointer :: co2_oxid_depth(:,:)
-    real(r8), pointer :: o2_decomp_depth(:,:)
-    real(r8), pointer :: conc_o2(:,:)
-    real(r8), pointer :: conc_ch4(:,:)
+    real(r8), pointer :: ch4_oxid_depth(:,:)  
+    real(r8), pointer :: o2_oxid_depth(:,:)   
+    real(r8), pointer :: co2_oxid_depth(:,:)  
+    real(r8), pointer :: o2_decomp_depth(:,:) 
+    real(r8), pointer :: conc_o2(:,:)         
+    real(r8), pointer :: conc_ch4(:,:)        
     !-----------------------------------------------------------------------
 
     ! Enforce expected array sizes
     SHR_ASSERT_ALL((ubound(jwt) == (/bounds%endc/)), errMsg(__FILE__, __LINE__))
 
-    associate(                                          &
+    associate(                                          & 
          h2osoi_vol => waterstate_vars%h2osoi_vol_col , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
 
-         smp_l      => soilstate_vars%smp_l_col       , & ! Input:  [real(r8) (: ,:) ]  soil matrix potential [mm]
-         watsat     => soilstate_vars%watsat_col      , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water at saturation (porosity)
+         smp_l      => soilstate_vars%smp_l_col       , & ! Input:  [real(r8) (: ,:) ]  soil matrix potential [mm]                      
+         watsat     => soilstate_vars%watsat_col      , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water at saturation (porosity)  
 
-         t_soisno   => temperature_vars%t_soisno_col    & ! Input:  [real(r8) (:,:)  ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi)
+         t_soisno   => temperature_vars%t_soisno_col    & ! Input:  [real(r8) (:,:)  ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi) 
          )
 
       if (sat == 0) then                                   ! unsaturated
          ch4_oxid_depth   => ch4_vars%ch4_oxid_depth_unsat_col  ! Output: [real(r8) (:,:)]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          o2_oxid_depth    => ch4_vars%o2_oxid_depth_unsat_col   ! Output: [real(r8) (:,:)]  O2 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          co2_oxid_depth   => ch4_vars%co2_oxid_depth_unsat_col  ! Output: [real(r8) (:,:)]  CO2 production rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
-         conc_ch4         => ch4_vars%conc_ch4_unsat_col        ! Input:  [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
-         conc_o2          => ch4_vars%conc_o2_unsat_col         ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)
+         conc_ch4         => ch4_vars%conc_ch4_unsat_col        ! Input:  [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
+         conc_o2          => ch4_vars%conc_o2_unsat_col         ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)   
          o2_decomp_depth  => ch4_vars%o2_decomp_depth_unsat_col ! Output: [real(r8) (:,:)]  O2 consumption during decomposition in each soil layer (nlevsoi) (mol/m3/s)
       else                                                 ! saturated
          ch4_oxid_depth   => ch4_vars%ch4_oxid_depth_sat_col    ! Output: [real(r8) (:,:)]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          o2_oxid_depth    => ch4_vars%o2_oxid_depth_sat_col     ! Output: [real(r8) (:,:)]  O2 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          co2_oxid_depth   => ch4_vars%co2_oxid_depth_sat_col    ! Output: [real(r8) (:,:)]  CO2 production rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
-         conc_ch4         => ch4_vars%conc_ch4_sat_col          ! Input:  [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
-         conc_o2          => ch4_vars%conc_o2_sat_col           ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)
+         conc_ch4         => ch4_vars%conc_ch4_sat_col          ! Input:  [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
+         conc_o2          => ch4_vars%conc_o2_sat_col           ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)   
          o2_decomp_depth  => ch4_vars%o2_decomp_depth_sat_col   ! Output: [real(r8) (:,:)]  O2 consumption during decomposition in each soil layer (nlevsoi) (mol/m3/s)
       endif
 
@@ -2387,7 +2388,7 @@ contains
     use ch4varcon        , only : transpirationloss, usefrootc, use_aereoxid_prog
     !
     ! !ARGUMENTS:
-    type(bounds_type)      , intent(in)    :: bounds
+    type(bounds_type)      , intent(in)    :: bounds    
     integer                , intent(in)    :: num_methc           ! number of column soil points in column filter
     integer                , intent(in)    :: filter_methc(:)     ! column filter for soil points
     integer                , intent(in)    :: num_methp           ! number of soil points in pft filter
@@ -2410,9 +2411,9 @@ contains
     integer  :: fc,fp                  ! soil filter column index
     real(r8) :: f_oxid                 ! fraction of CH4 oxidized in oxic zone around roots
     real(r8) :: diffus_aere            ! gas diffusivity through aerenchyma (m^2/s)
-    real(r8) :: m_tiller
-    real(r8) :: n_tiller
-    real(r8) :: poros_tiller
+    real(r8) :: m_tiller 
+    real(r8) :: n_tiller 
+    real(r8) :: poros_tiller 
     real(r8) :: rob                    ! root obliquity, e.g. csc of root angle relative to vertical
                                        ! (ratio of root total length to depth)
     real(r8) :: area_tiller            ! cross-sectional area of tillers (m^2/m^2)
@@ -2421,7 +2422,7 @@ contains
     real(r8) :: k_h_cc, k_h_inv, dtime, oxdiffus, anpp, nppratio, h2osoi_vol_min, conc_ch4_wat
     real(r8) :: aerecond               ! aerenchyma conductance (m/s)
     ! ch4 aerenchyma parameters
-    real(r8) :: aereoxid               ! fraction of methane flux entering aerenchyma rhizosphere
+    real(r8) :: aereoxid               ! fraction of methane flux entering aerenchyma rhizosphere 
     real(r8) :: scale_factor_aere      ! scale factor on the aerenchyma area for sensitivity tests
     real(r8) :: nongrassporosratio     ! Ratio of root porosity in non-grass to grass, used for aerenchyma transport
     real(r8) :: unsat_aere_ratio       ! Ratio to multiply upland vegetation aerenchyma porosity by compared to inundated systems (= 0.05_r8 / 0.3_r8)
@@ -2429,47 +2430,47 @@ contains
 
     real(r8), parameter :: smallnumber = 1.e-12_r8
 
-    real(r8), pointer :: ch4_aere_depth(:,:)
-    real(r8), pointer :: ch4_tran_depth(:,:)
-    real(r8), pointer :: o2_aere_depth(:,:)
-    real(r8), pointer :: co2_aere_depth(:,:)
-    real(r8), pointer :: ch4_oxid_depth(:,:)
-    real(r8), pointer :: ch4_prod_depth(:,:)
-    real(r8), pointer :: conc_o2(:,:)
-    real(r8), pointer :: conc_ch4(:,:)
+    real(r8), pointer :: ch4_aere_depth(:,:) 
+    real(r8), pointer :: ch4_tran_depth(:,:) 
+    real(r8), pointer :: o2_aere_depth(:,:)  
+    real(r8), pointer :: co2_aere_depth(:,:) 
+    real(r8), pointer :: ch4_oxid_depth(:,:) 
+    real(r8), pointer :: ch4_prod_depth(:,:) 
+    real(r8), pointer :: conc_o2(:,:)        
+    real(r8), pointer :: conc_ch4(:,:)       
     !-----------------------------------------------------------------------
 
     ! Enforce expected array sizes
     SHR_ASSERT_ALL((ubound(jwt) == (/bounds%endc/)), errMsg(__FILE__, __LINE__))
 
-    associate(                                                     &
-         z             =>    col%z                               , & ! Input:  [real(r8) (:,:)  ]  layer depth (m) (-nlevsno+1:nlevsoi)
-         dz            =>    col%dz                              , & ! Input:  [real(r8) (:,:)  ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
-         wtcol         =>    pft%wtcol                           , & ! Input:  [real(r8) (:)    ]  weight (relative to column)
+    associate(                                                     & 
+         z             =>    col%z                               , & ! Input:  [real(r8) (:,:)  ]  layer depth (m) (-nlevsno+1:nlevsoi)            
+         dz            =>    col%dz                              , & ! Input:  [real(r8) (:,:)  ]  layer thickness (m)  (-nlevsno+1:nlevsoi)       
+         wtcol         =>    pft%wtcol                           , & ! Input:  [real(r8) (:)    ]  weight (relative to column)                       
 
-         elai          =>    canopystate_vars%elai_patch         , & ! Input:  [real(r8) (:)    ]  one-sided leaf area index with burying by snow
+         elai          =>    canopystate_vars%elai_patch         , & ! Input:  [real(r8) (:)    ]  one-sided leaf area index with burying by snow    
 
-         annsum_npp    =>    carbonflux_vars%annsum_npp_patch    , & ! Input:  [real(r8) (:)    ]  annual sum NPP (gC/m2/yr)
+         annsum_npp    =>    carbonflux_vars%annsum_npp_patch    , & ! Input:  [real(r8) (:)    ]  annual sum NPP (gC/m2/yr)                         
 
-         t_soisno      =>    temperature_vars%t_soisno_col       , & ! Input:  [real(r8) (:,:)  ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi)
+         t_soisno      =>    temperature_vars%t_soisno_col       , & ! Input:  [real(r8) (:,:)  ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi) 
 
-         watsat        =>    soilstate_vars%watsat_col           , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water at saturation (porosity)
+         watsat        =>    soilstate_vars%watsat_col           , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water at saturation (porosity)   
          rootr         =>    soilstate_vars%rootr_patch          , & ! Input:  [real(r8) (:,:)  ]  effective fraction of roots in each soil layer  (nlevgrnd)
-         rootfr        =>    soilstate_vars%rootfr_patch         , & ! Input:  [real(r8) (:,:)  ]  fraction of roots in each soil layer  (nlevsoi)
+         rootfr        =>    soilstate_vars%rootfr_patch         , & ! Input:  [real(r8) (:,:)  ]  fraction of roots in each soil layer  (nlevsoi) 
 
          h2osoi_vol    =>    waterstate_vars%h2osoi_vol_col      , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
 
-         qflx_tran_veg =>    waterflux_vars%qflx_tran_veg_patch  , & ! Input:  [real(r8) (:)    ]  vegetation transpiration (mm H2O/s) (+ = to atm)
+         qflx_tran_veg =>    waterflux_vars%qflx_tran_veg_patch  , & ! Input:  [real(r8) (:)    ]  vegetation transpiration (mm H2O/s) (+ = to atm)  
 
-         canopy_cond   =>    energyflux_vars%canopy_cond_patch   , & ! Input:  [real(r8) (:)    ]  tracer conductance for canopy [m/s]
+         canopy_cond   =>    energyflux_vars%canopy_cond_patch   , & ! Input:  [real(r8) (:)    ]  tracer conductance for canopy [m/s]               
 
-         frootc        =>    carbonstate_vars%frootc_patch       , & ! Input:  [real(r8) (:)    ]  (gC/m2) fine root C
+         frootc        =>    carbonstate_vars%frootc_patch       , & ! Input:  [real(r8) (:)    ]  (gC/m2) fine root C                               
 
-         annavg_agnpp  =>    carbonflux_vars%annavg_agnpp_patch  , & ! Input:  [real(r8) (:)    ]  (gC/m2/s) annual average aboveground NPP
-         annavg_bgnpp  =>    carbonflux_vars%annavg_bgnpp_patch  , & ! Input:  [real(r8) (:)    ]  (gC/m2/s) annual average belowground NPP
+         annavg_agnpp  =>    carbonflux_vars%annavg_agnpp_patch  , & ! Input:  [real(r8) (:)    ]  (gC/m2/s) annual average aboveground NPP          
+         annavg_bgnpp  =>    carbonflux_vars%annavg_bgnpp_patch  , & ! Input:  [real(r8) (:)    ]  (gC/m2/s) annual average belowground NPP          
 
-         grnd_ch4_cond =>    ch4_vars%grnd_ch4_cond_patch        , & ! Input:  [real(r8) (:)    ]  tracer conductance for boundary layer [m/s]
-         c_atm         =>    ch4_vars%c_atm_grc                    & ! Input:  [real(r8) (: ,:) ]  CH4, O2, CO2 atmospheric conc  (mol/m3)
+         grnd_ch4_cond =>    ch4_vars%grnd_ch4_cond_patch        , & ! Input:  [real(r8) (:)    ]  tracer conductance for boundary layer [m/s]       
+         c_atm         =>    ch4_vars%c_atm_grc                    & ! Input:  [real(r8) (: ,:) ]  CH4, O2, CO2 atmospheric conc  (mol/m3)         
          )
 
       if (sat == 0) then                                   ! unsaturated
@@ -2477,8 +2478,8 @@ contains
          ch4_tran_depth   =>  ch4_vars%ch4_tran_depth_unsat_col ! Output: [real(r8) (:,:)]  CH4 loss rate via transpiration in each soil layer (mol/m3/s) (nlevsoi)
          o2_aere_depth    =>  ch4_vars%o2_aere_depth_unsat_col  ! Output: [real(r8) (:,:)]  O2 gain rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
          co2_aere_depth   =>  ch4_vars%co2_aere_depth_unsat_col ! Output: [real(r8) (:,:)]  CO2 loss rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
-         conc_ch4         =>  ch4_vars%conc_ch4_unsat_col       ! Input:  [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
-         conc_o2          =>  ch4_vars%conc_o2_unsat_col        ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)
+         conc_ch4         =>  ch4_vars%conc_ch4_unsat_col       ! Input:  [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
+         conc_o2          =>  ch4_vars%conc_o2_unsat_col        ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)   
          ch4_oxid_depth   =>  ch4_vars%ch4_oxid_depth_unsat_col ! Input:  [real(r8) (:,:)]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          ch4_prod_depth   =>  ch4_vars%ch4_prod_depth_unsat_col ! Input:  [real(r8) (:,:)]  production of CH4 in each soil layer (nlevsoi) (mol/m3/s)
       else                                                 ! saturated
@@ -2486,8 +2487,8 @@ contains
          ch4_tran_depth   =>  ch4_vars%ch4_tran_depth_sat_col   ! Output: [real(r8) (:,:)]  CH4 loss rate via transpiration in each soil layer (mol/m3/s) (nlevsoi)
          o2_aere_depth    =>  ch4_vars%o2_aere_depth_sat_col    ! Output: [real(r8) (:,:)]  O2 gain rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
          co2_aere_depth   =>  ch4_vars%co2_aere_depth_sat_col   ! Output: [real(r8) (:,:)]  CO2 loss rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
-         conc_ch4         =>  ch4_vars%conc_ch4_sat_col         ! Input:  [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
-         conc_o2          =>  ch4_vars%conc_o2_sat_col          ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)
+         conc_ch4         =>  ch4_vars%conc_ch4_sat_col         ! Input:  [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
+         conc_o2          =>  ch4_vars%conc_o2_sat_col          ! Input:  [real(r8) (:,:)]  O2 conc in each soil layer (mol/m3) (nlevsoi)   
          ch4_oxid_depth   =>  ch4_vars%ch4_oxid_depth_sat_col   ! Input:  [real(r8) (:,:)]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          ch4_prod_depth   =>  ch4_vars%ch4_prod_depth_sat_col   ! Input:  [real(r8) (:,:)]  production of CH4 in each soil layer (nlevsoi) (mol/m3/s)
       endif
@@ -2499,7 +2500,7 @@ contains
       scale_factor_aere  = CH4ParamsInst%scale_factor_aere
       nongrassporosratio = CH4ParamsInst%nongrassporosratio
       unsat_aere_ratio   = CH4ParamsInst%unsat_aere_ratio
-      porosmin           = CH4ParamsInst%porosmin
+      porosmin           = CH4ParamsInst%porosmin	
       rob                = CH4ParamsInst%rob
 
       ! Initialize ch4_aere_depth
@@ -2634,17 +2635,17 @@ contains
        ch4_vars)
     !
     ! !DESCRIPTION:
-    ! Bubbling is based on temperature & pressure dependent solubility (k_h_cc),
+    ! Bubbling is based on temperature & pressure dependent solubility (k_h_cc), 
     ! with assumed proportion of bubbles
     ! which are CH4, and assumed early nucleation at vgc_max sat (Wania).
     ! Bubbles are released to the water table surface in ch4_tran.
 
     ! !USES:
     use clm_time_manager   , only : get_step_size
-    use LakeCon
+    use LakeCon           
     !
     ! !ARGUMENTS:
-    type(bounds_type)      , intent(in)    :: bounds
+    type(bounds_type)      , intent(in)    :: bounds    
     integer                , intent(in)    :: num_methc           ! number of column soil points in column filter
     integer                , intent(in)    :: filter_methc(:)     ! column filter for soil points
     integer                , intent(in)    :: jwt( bounds%begc: ) ! index of the soil layer right above the water table (-) [col]
@@ -2652,7 +2653,7 @@ contains
     logical                , intent(in)    :: lake             ! function called with lake filter
     type(atm2lnd_type)     , intent(in)    :: atm2lnd_vars
     type(temperature_type) , intent(in)    :: temperature_vars
-    type(lakestate_type)   , intent(in)    :: lakestate_vars
+    type(lakestate_type)   , intent(in)    :: lakestate_vars 
     type(soilstate_type)   , intent(in)    :: soilstate_vars
     type(waterstate_type)  , intent(in)    :: waterstate_vars
     type(ch4_type)         , intent(inout) :: ch4_vars
@@ -2664,9 +2665,9 @@ contains
     real(r8) :: dtime   ! land model time step (sec)
     real(r8) :: vgc     ! volumetric CH4 content (m3 CH4/m3 pore air)
     real(r8) :: vgc_min ! minimum aqueous CH4 content when ebullition ceases
-    real(r8) :: k_h_inv !
-    real(r8) :: k_h     !
-    real(r8) :: k_h_cc  !
+    real(r8) :: k_h_inv ! 
+    real(r8) :: k_h     ! 
+    real(r8) :: k_h_cc  ! 
     real(r8) :: pressure! sum atmospheric and hydrostatic pressure
     real(r8) :: bubble_f! CH4 content in gas bubbles (Kellner et al. 2006)
     real(r8) :: ebul_timescale
@@ -2681,35 +2682,35 @@ contains
     ! Enforce expected array sizes
     SHR_ASSERT_ALL((ubound(jwt) == (/bounds%endc/)), errMsg(__FILE__, __LINE__))
 
-    associate(                                                      &
-         z            =>    col%z                                 , & ! Input:  [real(r8) (:,:) ]  soil layer depth (m)
-         dz           =>    col%dz                                , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
-         zi           =>    col%zi                                , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
-         lakedepth    =>    col%lakedepth                         , & ! Input:  [real(r8) (:)   ]  column lake depth (m)
+    associate(                                                      & 
+         z            =>    col%z                                 , & ! Input:  [real(r8) (:,:) ]  soil layer depth (m)                            
+         dz           =>    col%dz                                , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevsoi)       
+         zi           =>    col%zi                                , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)           
+         lakedepth    =>    col%lakedepth                         , & ! Input:  [real(r8) (:)   ]  column lake depth (m)                             
 
-         forc_pbot    =>    atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)
+         forc_pbot    =>    atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
 
-         t_soisno     =>    temperature_vars%t_soisno_col         , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi)
+         t_soisno     =>    temperature_vars%t_soisno_col         , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi) 
 
-         lake_icefrac =>    lakestate_vars%lake_icefrac_col       , & ! Input:  [real(r8) (:,:) ]  mass fraction of lake layer that is frozen
+         lake_icefrac =>    lakestate_vars%lake_icefrac_col       , & ! Input:  [real(r8) (:,:) ]  mass fraction of lake layer that is frozen      
 
-         watsat       =>    soilstate_vars%watsat_col             , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)
+         watsat       =>    soilstate_vars%watsat_col             , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)  
 
          h2osoi_vol   =>    waterstate_vars%h2osoi_vol_col        , & ! Input:  [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
-         h2osfc       =>    waterstate_vars%h2osfc_col            , & ! Input:  [real(r8) (:)   ]  surface water (mm)
+         h2osfc       =>    waterstate_vars%h2osfc_col            , & ! Input:  [real(r8) (:)   ]  surface water (mm)                                
          frac_h2osfc  =>    waterstate_vars%frac_h2osfc_col         & ! Input:  [real(r8) (:)   ]  fraction of ground covered by surface water (0 to 1)
          )
 
       if (sat == 0) then                                   ! unsaturated
          ch4_ebul_depth =>    ch4_vars%ch4_ebul_depth_unsat_col ! Output: [real(r8) (:,:)]  CH4 loss rate via ebullition in each soil layer (mol/m3/s) (nlevsoi)
-         ch4_ebul_total =>    ch4_vars%ch4_ebul_total_unsat_col ! Output: [real(r8) (:)]  Total column CH4 ebullition (mol/m2/s)
-         conc_ch4       =>    ch4_vars%conc_ch4_unsat_col       ! Output: [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
+         ch4_ebul_total =>    ch4_vars%ch4_ebul_total_unsat_col ! Output: [real(r8) (:)]  Total column CH4 ebullition (mol/m2/s)            
+         conc_ch4       =>    ch4_vars%conc_ch4_unsat_col       ! Output: [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
          ch4_aere_depth =>    ch4_vars%ch4_aere_depth_unsat_col ! Input:  [real(r8) (:,:)]  CH4 loss rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
          ch4_oxid_depth =>    ch4_vars%ch4_oxid_depth_unsat_col ! Input:  [real(r8) (:,:)]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
       else                                                 ! saturated
          ch4_ebul_depth =>    ch4_vars%ch4_ebul_depth_sat_col   ! Output: [real(r8) (:,:)]  CH4 loss rate via ebullition in each soil layer (mol/m3/s) (nlevsoi)
-         ch4_ebul_total =>    ch4_vars%ch4_ebul_total_sat_col   ! Output: [real(r8) (:)]  Total column CH4 ebullition (mol/m2/s)
-         conc_ch4       =>    ch4_vars%conc_ch4_sat_col         ! Output: [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
+         ch4_ebul_total =>    ch4_vars%ch4_ebul_total_sat_col   ! Output: [real(r8) (:)]  Total column CH4 ebullition (mol/m2/s)            
+         conc_ch4       =>    ch4_vars%conc_ch4_sat_col         ! Output: [real(r8) (:,:)]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
          ch4_aere_depth =>    ch4_vars%ch4_aere_depth_sat_col   ! Input:  [real(r8) (:,:)]  CH4 loss rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
          ch4_oxid_depth =>    ch4_vars%ch4_oxid_depth_sat_col   ! Input:  [real(r8) (:,:)]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
       endif
@@ -2731,7 +2732,7 @@ contains
 
                k_h_inv = exp(-c_h_inv(1) * (1._r8 / t_soisno(c,j) - 1._r8 / kh_tbase) + log (kh_theta(1))) ! (4.12 Wania) (atm.L/mol)
                k_h = 1._r8 / k_h_inv ! (mol/L.atm)
-               k_h_cc = t_soisno(c,j) * k_h * rgasLatm ! (4.21) Wania [(mol/m3w) / (mol/m3g)]
+               k_h_cc = t_soisno(c,j) * k_h * rgasLatm ! (4.21) Wania [(mol/m3w) / (mol/m3g)] 
 
                if (.not. lake) then
                   pressure = forc_pbot(c) + denh2o * grav * (z(c,j)-zi(c,jwt(c))) ! (Pa)
@@ -2789,7 +2790,7 @@ contains
     use ch4varcon          , only : ch4frzout, use_aereoxid_prog
     !
     ! !ARGUMENTS:
-    type(bounds_type)      , intent(in)    :: bounds
+    type(bounds_type)      , intent(in)    :: bounds    
     integer                , intent(in)    :: num_methc           ! number of column soil points in column filter
     integer                , intent(in)    :: filter_methc(:)     ! column filter for soil points
     integer                , intent(in)    :: jwt( bounds%begc: ) ! index of the soil layer right above the water table (-) [col]
@@ -2817,7 +2818,7 @@ contains
     real(r8) :: diffus (bounds%begc:bounds%endc,0:nlevsoi)                 ! diffusivity (m2/s)
     real(r8) :: k_h_inv                                                    ! 1/Henry's Law Constant in Latm/mol
     real(r8) :: k_h_cc(bounds%begc:bounds%endc,0:nlevsoi,ngases)           ! ratio of mol/m3 in liquid to mol/m3 in gas
-    real(r8) :: dzj                                                        !
+    real(r8) :: dzj                                                        ! 
     real(r8) :: dp1_zp1 (bounds%begc:bounds%endc,0:nlevsoi)                ! diffusivity/delta_z for next j
     real(r8) :: dm1_zm1 (bounds%begc:bounds%endc,0:nlevsoi)                ! diffusivity/delta_z for previous j
     real(r8) :: t_soisno_c                                                 ! soil temperature (C)  (-nlevsno+1:nlevsoi)
@@ -2852,24 +2853,24 @@ contains
     real(r8) :: scale_factor_gasdiff                                       ! For sensitivity tests; convection would allow this to be > 1
     real(r8) :: scale_factor_liqdiff                                       ! For sensitivity tests; convection would allow this to be > 1
     real(r8) :: organic_max                                                ! organic matter content (kg/m3) where soil is assumed to act like peat
-    real(r8) :: aereoxid                                                   ! fraction of methane flux entering aerenchyma rhizosphere
+    real(r8) :: aereoxid                                                   ! fraction of methane flux entering aerenchyma rhizosphere 
 
-    real(r8), pointer :: ch4_prod_depth   (:,:)
-    real(r8), pointer :: ch4_oxid_depth   (:,:)
-    real(r8), pointer :: ch4_aere_depth   (:,:)
-    real(r8), pointer :: ch4_surf_aere    (:)
-    real(r8), pointer :: ch4_ebul_depth   (:,:)
-    real(r8), pointer :: ch4_ebul_total   (:)
-    real(r8), pointer :: ch4_surf_ebul    (:)
-    real(r8), pointer :: ch4_surf_diff    (:)
-    real(r8), pointer :: o2_oxid_depth    (:,:)
-    real(r8), pointer :: o2_decomp_depth  (:,:)
-    real(r8), pointer :: o2_aere_depth    (:,:)
-    real(r8), pointer :: o2stress         (:,:)
-    real(r8), pointer :: ch4stress        (:,:)
+    real(r8), pointer :: ch4_prod_depth   (:,:)  
+    real(r8), pointer :: ch4_oxid_depth   (:,:)  
+    real(r8), pointer :: ch4_aere_depth   (:,:)  
+    real(r8), pointer :: ch4_surf_aere    (:)     
+    real(r8), pointer :: ch4_ebul_depth   (:,:)  
+    real(r8), pointer :: ch4_ebul_total   (:)    
+    real(r8), pointer :: ch4_surf_ebul    (:)     
+    real(r8), pointer :: ch4_surf_diff    (:)     
+    real(r8), pointer :: o2_oxid_depth    (:,:)   
+    real(r8), pointer :: o2_decomp_depth  (:,:) 
+    real(r8), pointer :: o2_aere_depth    (:,:)   
+    real(r8), pointer :: o2stress         (:,:)        
+    real(r8), pointer :: ch4stress        (:,:)       
     real(r8), pointer :: co2_decomp_depth (:,:)
-    real(r8), pointer :: conc_o2          (:,:)
-    real(r8), pointer :: conc_ch4         (:,:)
+    real(r8), pointer :: conc_o2          (:,:)         
+    real(r8), pointer :: conc_ch4         (:,:)        
 
     integer  :: nstep                       ! time step number
     character(len=32) :: subname='ch4_tran' ! subroutine name
@@ -2877,31 +2878,31 @@ contains
 
     SHR_ASSERT_ALL((ubound(jwt) == (/bounds%endc/)), errMsg(__FILE__, __LINE__))
 
-    associate(                                                 &
-         z             =>    col%z                           , & ! Input:  [real(r8) (:,:) ]  soil layer depth (m)
-         dz            =>    col%dz                          , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
-         zi            =>    col%zi                          , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
-         snl           =>    col%snl                         , & ! Input:  [integer  (:)   ]  negative of number of snow layers
+    associate(                                                 & 
+         z             =>    col%z                           , & ! Input:  [real(r8) (:,:) ]  soil layer depth (m)                            
+         dz            =>    col%dz                          , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevsoi)       
+         zi            =>    col%zi                          , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)           
+         snl           =>    col%snl                         , & ! Input:  [integer  (:)   ]  negative of number of snow layers                  
 
-         bsw           =>    soilstate_vars%bsw_col          , & ! Input:  [real(r8) (:,:) ]  Clapp and Hornberger "b" (nlevgrnd)
-         watsat        =>    soilstate_vars%watsat_col       , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)
+         bsw           =>    soilstate_vars%bsw_col          , & ! Input:  [real(r8) (:,:) ]  Clapp and Hornberger "b" (nlevgrnd)             
+         watsat        =>    soilstate_vars%watsat_col       , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)  
          cellorg       =>    soilstate_vars%cellorg_col      , & ! Input:  [real(r8) (:,:) ]  column 3D org (kg/m^3 organic matter) (nlevgrnd)
 
-         t_soisno      =>    temperature_vars%t_soisno_col   , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi)
-         t_grnd        =>    temperature_vars%t_grnd_col     , & ! Input:  [real(r8) (:)   ]  ground temperature (Kelvin)
-         t_h2osfc      =>    temperature_vars%t_h2osfc_col   , & ! Input:  [real(r8) (:)   ]  surface water temperature
+         t_soisno      =>    temperature_vars%t_soisno_col   , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi) 
+         t_grnd        =>    temperature_vars%t_grnd_col     , & ! Input:  [real(r8) (:)   ]  ground temperature (Kelvin)                       
+         t_h2osfc      =>    temperature_vars%t_h2osfc_col   , & ! Input:  [real(r8) (:)   ]  surface water temperature               
 
          frac_h2osfc   =>    waterstate_vars%frac_h2osfc_col , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by surface water (0 to 1)
-         snow_depth    =>    waterstate_vars%snow_depth_col  , & ! Input:  [real(r8) (:)   ]  snow height (m)
+         snow_depth    =>    waterstate_vars%snow_depth_col  , & ! Input:  [real(r8) (:)   ]  snow height (m)                                   
          h2osoi_vol    =>    waterstate_vars%h2osoi_vol_col  , & ! Input:  [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
-         h2osoi_liq    =>    waterstate_vars%h2osoi_liq_col  , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2) [for snow & soil layers]
-         h2osoi_ice    =>    waterstate_vars%h2osoi_ice_col  , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2) [for snow & soil layers]
-         h2osno        =>    waterstate_vars%h2osno_col      , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
-         h2osfc        =>    waterstate_vars%h2osfc_col      , & ! Input:  [real(r8) (:)   ]  surface water (mm)
+         h2osoi_liq    =>    waterstate_vars%h2osoi_liq_col  , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2) [for snow & soil layers]   
+         h2osoi_ice    =>    waterstate_vars%h2osoi_ice_col  , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2) [for snow & soil layers]       
+         h2osno        =>    waterstate_vars%h2osno_col      , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)                               
+         h2osfc        =>    waterstate_vars%h2osfc_col      , & ! Input:  [real(r8) (:)   ]  surface water (mm)                                
 
-         c_atm         =>    ch4_vars%c_atm_grc              , & ! Input:  [real(r8) (:,:) ]  CH4, O2, CO2 atmospheric conc  (mol/m3)
+         c_atm         =>    ch4_vars%c_atm_grc              , & ! Input:  [real(r8) (:,:) ]  CH4, O2, CO2 atmospheric conc  (mol/m3)         
 
-         grnd_ch4_cond =>    ch4_vars%grnd_ch4_cond_col        & ! Output: [real(r8) (:)   ]  tracer conductance for boundary layer [m/s]
+         grnd_ch4_cond =>    ch4_vars%grnd_ch4_cond_col        & ! Output: [real(r8) (:)   ]  tracer conductance for boundary layer [m/s]       
          )
 
       if (sat == 0) then                                    ! unsaturated
@@ -2910,34 +2911,34 @@ contains
          ch4_oxid_depth   => ch4_vars%ch4_oxid_depth_unsat_col   ! Output: [real(r8) (:,:) ]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          ch4_prod_depth   => ch4_vars%ch4_prod_depth_unsat_col   ! Output: [real(r8) (:,:) ]  CH4 production rate from methanotrophs (mol/m3/s) (nlevsoi)
          ch4_aere_depth   => ch4_vars%ch4_aere_depth_unsat_col   ! Output: [real(r8) (:,:) ]  CH4 loss rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
-         ch4_surf_aere    => ch4_vars%ch4_surf_aere_unsat_col    ! Output: [real(r8) (:)   ]  Total column CH4 aerenchyma (mol/m2/s)
+         ch4_surf_aere    => ch4_vars%ch4_surf_aere_unsat_col    ! Output: [real(r8) (:)   ]  Total column CH4 aerenchyma (mol/m2/s)            
          ch4_ebul_depth   => ch4_vars%ch4_ebul_depth_unsat_col   ! Output: [real(r8) (:,:) ]  CH4 loss rate via ebullition in each soil layer (mol/m3/s) (nlevsoi)
-         ch4_ebul_total   => ch4_vars%ch4_ebul_total_unsat_col   ! Output: [real(r8) (:)   ]  Total column CH4 ebullition (mol/m2/s)
-         ch4_surf_ebul    => ch4_vars%ch4_surf_ebul_unsat_col    ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)
-         ch4_surf_diff    => ch4_vars%ch4_surf_diff_unsat_col    ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)
+         ch4_ebul_total   => ch4_vars%ch4_ebul_total_unsat_col   ! Output: [real(r8) (:)   ]  Total column CH4 ebullition (mol/m2/s)            
+         ch4_surf_ebul    => ch4_vars%ch4_surf_ebul_unsat_col    ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)           
+         ch4_surf_diff    => ch4_vars%ch4_surf_diff_unsat_col    ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)                       
          o2_oxid_depth    => ch4_vars%o2_oxid_depth_unsat_col    ! Output: [real(r8) (:,:) ]  O2 loss rate via ebullition in each soil layer (mol/m3/s) (nlevsoi)
          o2_aere_depth    => ch4_vars%o2_aere_depth_unsat_col    ! Output: [real(r8) (:,:) ]  O2 gain rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
          ch4stress        => ch4_vars%ch4stress_unsat_col        ! Output: [real(r8) (:,:) ]  Ratio of methane available to the total per-timestep methane sinks (nlevsoi)
          co2_decomp_depth => ch4_vars%co2_decomp_depth_unsat_col ! Output: [real(r8) (:,:) ]  CO2 production during decomposition in each soil layer (nlevsoi) (mol/m3/s)
-         conc_ch4         => ch4_vars%conc_ch4_unsat_col         ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
-         conc_o2          => ch4_vars%conc_o2_unsat_col          ! Output: [real(r8) (:,:) ]  O2 conc in each soil layer (mol/m3) (nlevsoi)
+         conc_ch4         => ch4_vars%conc_ch4_unsat_col         ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
+         conc_o2          => ch4_vars%conc_o2_unsat_col          ! Output: [real(r8) (:,:) ]  O2 conc in each soil layer (mol/m3) (nlevsoi)   
       else                                                  ! saturated
          o2_decomp_depth  => ch4_vars%o2_decomp_depth_sat_col    ! Output: [real(r8) (:,:) ]  O2 consumption during decomposition in each soil layer (nlevsoi) (mol/m3/s)
          o2stress         => ch4_vars%o2stress_sat_col           ! Output: [real(r8) (:,:) ]  Ratio of oxygen available to that demanded by roots, aerobes, & methanotrophs (nlevsoi)
          ch4_oxid_depth   => ch4_vars%ch4_oxid_depth_sat_col     ! Output: [real(r8) (:,:) ]  CH4 consumption rate via oxidation in each soil layer (mol/m3/s) (nlevsoi)
          ch4_prod_depth   => ch4_vars%ch4_prod_depth_sat_col     ! Output: [real(r8) (:,:) ]  CH4 production rate from methanotrophs (mol/m3/s) (nlevsoi)
          ch4_aere_depth   => ch4_vars%ch4_aere_depth_sat_col     ! Output: [real(r8) (:,:) ]  CH4 loss rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
-         ch4_surf_aere    => ch4_vars%ch4_surf_aere_sat_col      ! Output: [real(r8) (:)   ]  Total column CH4 aerenchyma (mol/m2/s)
+         ch4_surf_aere    => ch4_vars%ch4_surf_aere_sat_col      ! Output: [real(r8) (:)   ]  Total column CH4 aerenchyma (mol/m2/s)            
          ch4_ebul_depth   => ch4_vars%ch4_ebul_depth_sat_col     ! Output: [real(r8) (:,:) ]  CH4 loss rate via ebullition in each soil layer (mol/m3/s) (nlevsoi)
-         ch4_ebul_total   => ch4_vars%ch4_ebul_total_sat_col     ! Output: [real(r8) (:)   ]  Total column CH4 ebullition (mol/m2/s)
-         ch4_surf_ebul    => ch4_vars%ch4_surf_ebul_sat_col      ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)
-         ch4_surf_diff    => ch4_vars%ch4_surf_diff_sat_col      ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)
+         ch4_ebul_total   => ch4_vars%ch4_ebul_total_sat_col     ! Output: [real(r8) (:)   ]  Total column CH4 ebullition (mol/m2/s)            
+         ch4_surf_ebul    => ch4_vars%ch4_surf_ebul_sat_col      ! Output: [real(r8) (:)   ]  CH4 ebullition to atmosphere (mol/m2/s)           
+         ch4_surf_diff    => ch4_vars%ch4_surf_diff_sat_col      ! Output: [real(r8) (:)   ]  CH4 surface flux (mol/m2/s)                       
          o2_oxid_depth    => ch4_vars%o2_oxid_depth_sat_col      ! Output: [real(r8) (:,:) ]  O2 loss rate via ebullition in each soil layer (mol/m3/s) (nlevsoi)
          o2_aere_depth    => ch4_vars%o2_aere_depth_sat_col      ! Output: [real(r8) (:,:) ]  O2 gain rate via aerenchyma in each soil layer (mol/m3/s) (nlevsoi)
          ch4stress        => ch4_vars%ch4stress_sat_col          ! Output: [real(r8) (:,:) ]  Ratio of methane available to the total per-timestep methane sinks (nlevsoi)
          co2_decomp_depth => ch4_vars%co2_decomp_depth_sat_col   ! Output: [real(r8) (:,:) ]  CO2 production during decomposition in each soil layer (nlevsoi) (mol/m3/s)
-         conc_ch4         => ch4_vars%conc_ch4_sat_col           ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)
-         conc_o2          => ch4_vars%conc_o2_sat_col            ! Output: [real(r8) (:,:) ]  O2 conc in each soil layer (mol/m3) (nlevsoi)
+         conc_ch4         => ch4_vars%conc_ch4_sat_col           ! Output: [real(r8) (:,:) ]  CH4 conc in each soil layer (mol/m3) (nlevsoi)  
+         conc_o2          => ch4_vars%conc_o2_sat_col            ! Output: [real(r8) (:,:) ]  O2 conc in each soil layer (mol/m3) (nlevsoi)   
       endif
 
       ! Get land model time step
@@ -2948,7 +2949,7 @@ contains
       satpow               = CH4ParamsInst%satpow
       scale_factor_gasdiff = CH4ParamsInst%scale_factor_gasdiff
       scale_factor_liqdiff = CH4ParamsInst%scale_factor_liqdiff
-      capthick             = CH4ParamsInst%capthick
+      capthick             = CH4ParamsInst%capthick 
       aereoxid             = CH4ParamsInst%aereoxid
 
       ! Set shared constant
@@ -3032,7 +3033,7 @@ contains
          do fc = 1, num_methc
             c = filter_methc (fc)
 
-            do s=1,2
+            do s=1,2         
                if (j == 0) then
                   k_h_inv = exp(-c_h_inv(s) * (1._r8 / t_grnd(c) - 1._r8 / kh_tbase) + log (kh_theta(s)))
                   ! (4.12) Wania (L atm/mol)
@@ -3241,7 +3242,7 @@ contains
 
                if (j <= jwt(c)) then  ! Above the WT
                   f_a = 1._r8 - h2osoi_vol_min(c,j) / watsat(c,j)
-                  ! Provisionally calculate diffusivity as linear combination of the Millington-Quirk
+                  ! Provisionally calculate diffusivity as linear combination of the Millington-Quirk 
                   ! expression in Wania (for peat) & Moldrup (for mineral soil)
                   eps =  watsat(c,j)-h2osoi_vol_min(c,j) ! Air-filled fraction of total soil volume
                   if (organic_max > 0._r8) then
@@ -3578,7 +3579,7 @@ contains
     ! Finds the first unsaturated layer going up. Also allows a perched water table over ice.
     !
     ! !ARGUMENTS:
-    type(bounds_type)      , intent(in)  :: bounds
+    type(bounds_type)      , intent(in)  :: bounds    
     integer                , intent(in)  :: num_methc           ! number of column soil points in column filter
     integer                , intent(in)  :: filter_methc(:)     ! column filter for soil points
     integer                , intent(out) :: jwt( bounds%begc: ) ! index of the soil layer right above the water table (-) [col]
@@ -3594,10 +3595,10 @@ contains
 
     SHR_ASSERT_ALL((ubound(jwt) == (/bounds%endc/)), errMsg(__FILE__, __LINE__))
 
-    associate(                                          &
-         watsat     => soilstate_vars%watsat_col      , & ! Input:  [real(r8) (:,:)  ] volumetric soil water at saturation (porosity)
+    associate(                                          & 
+         watsat     => soilstate_vars%watsat_col      , & ! Input:  [real(r8) (:,:)  ] volumetric soil water at saturation (porosity)   
          h2osoi_vol => waterstate_vars%h2osoi_vol_col , & ! Input:  [real(r8) (:,:)  ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
-         t_soisno   => temperature_vars%t_soisno_col    & ! Input:  [real(r8) (: ,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi)
+         t_soisno   => temperature_vars%t_soisno_col    & ! Input:  [real(r8) (: ,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevsoi) 
          )
 
       f_sat = CH4ParamsInst%f_sat
@@ -3648,7 +3649,7 @@ contains
     use clm_varcon      , only: secspday
     !
     ! !ARGUMENTS:
-    type(bounds_type)      , intent(in)    :: bounds
+    type(bounds_type)      , intent(in)    :: bounds  
     integer                , intent(in)    :: num_methc         ! number of soil columns in filter
     integer                , intent(in)    :: filter_methc(:)   ! filter for soil columns
     integer                , intent(in)    :: num_methp         ! number of soil points in pft filter
@@ -3665,21 +3666,21 @@ contains
     logical :: newrun
     !-----------------------------------------------------------------------
 
-    associate(                                                      &
-         agnpp          =>    carbonflux_vars%agnpp_patch         , & ! Input:  [real(r8) (:) ]  (gC/m2/s) aboveground NPP
-         bgnpp          =>    carbonflux_vars%bgnpp_patch         , & ! Input:  [real(r8) (:) ]  (gC/m2/s) belowground NPP
+    associate(                                                      & 
+         agnpp          =>    carbonflux_vars%agnpp_patch         , & ! Input:  [real(r8) (:) ]  (gC/m2/s) aboveground NPP                         
+         bgnpp          =>    carbonflux_vars%bgnpp_patch         , & ! Input:  [real(r8) (:) ]  (gC/m2/s) belowground NPP                         
          somhr          =>    carbonflux_vars%somhr_col           , & ! Input:  [real(r8) (:) ]  (gC/m2/s) soil organic matter heterotrophic respiration
-         tempavg_agnpp  =>    carbonflux_vars%tempavg_agnpp_patch , & ! Output: [real(r8) (:) ]  temporary average above-ground NPP (gC/m2/s)
-         annavg_agnpp   =>    carbonflux_vars%annavg_agnpp_patch  , & ! Output: [real(r8) (:) ]  annual average above-ground NPP (gC/m2/s)
-         tempavg_bgnpp  =>    carbonflux_vars%tempavg_bgnpp_patch , & ! Output: [real(r8) (:) ]  temporary average below-ground NPP (gC/m2/s)
-         annavg_bgnpp   =>    carbonflux_vars%annavg_bgnpp_patch  , & ! Output: [real(r8) (:) ]  annual average below-ground NPP (gC/m2/s)
-
-         finundated     =>    ch4_vars%finundated_col             , & ! Input:  [real(r8) (:) ]  fractional inundated area in soil column
-         annsum_counter =>    ch4_vars%annsum_counter_col         , & ! Output: [real(r8) (:) ]  seconds since last annual accumulator turnover
+         tempavg_agnpp  =>    carbonflux_vars%tempavg_agnpp_patch , & ! Output: [real(r8) (:) ]  temporary average above-ground NPP (gC/m2/s)      
+         annavg_agnpp   =>    carbonflux_vars%annavg_agnpp_patch  , & ! Output: [real(r8) (:) ]  annual average above-ground NPP (gC/m2/s)         
+         tempavg_bgnpp  =>    carbonflux_vars%tempavg_bgnpp_patch , & ! Output: [real(r8) (:) ]  temporary average below-ground NPP (gC/m2/s)      
+         annavg_bgnpp   =>    carbonflux_vars%annavg_bgnpp_patch  , & ! Output: [real(r8) (:) ]  annual average below-ground NPP (gC/m2/s)         
+         
+         finundated     =>    ch4_vars%finundated_col             , & ! Input:  [real(r8) (:) ]  fractional inundated area in soil column          
+         annsum_counter =>    ch4_vars%annsum_counter_col         , & ! Output: [real(r8) (:) ]  seconds since last annual accumulator turnover    
          tempavg_somhr  =>    ch4_vars%tempavg_somhr_col          , & ! Output: [real(r8) (:) ]  temporary average SOM heterotrophic resp. (gC/m2/s)
-         annavg_somhr   =>    ch4_vars%annavg_somhr_col           , & ! Output: [real(r8) (:) ]  annual average SOM heterotrophic resp. (gC/m2/s)
-         tempavg_finrw  =>    ch4_vars%tempavg_finrw_col          , & ! Output: [real(r8) (:) ]  respiration-weighted annual average of finundated
-         annavg_finrw   =>    ch4_vars%annavg_finrw_col             & ! Output: [real(r8) (:) ]  respiration-weighted annual average of finundated
+         annavg_somhr   =>    ch4_vars%annavg_somhr_col           , & ! Output: [real(r8) (:) ]  annual average SOM heterotrophic resp. (gC/m2/s)  
+         tempavg_finrw  =>    ch4_vars%tempavg_finrw_col          , & ! Output: [real(r8) (:) ]  respiration-weighted annual average of finundated 
+         annavg_finrw   =>    ch4_vars%annavg_finrw_col             & ! Output: [real(r8) (:) ]  respiration-weighted annual average of finundated 
          )
 
       ! set time steps
@@ -3763,3 +3764,4 @@ contains
   end subroutine ch4_annualupdate
 
 end module ch4Mod
+


### PR DESCRIPTION
This fixes the bug that leads to zero methane production when call ch4(). The problem is related to that fluxes like somhr, lithr, rr_col and etc were calculated after ch4() is called. The fix properly calculates these variables and feeds into the ch4 subroutine for methane production. 
 The fix is not bfb for all ch4 related simulations. 
