### PR TITLE
Update output of MPAS model components

### DIFF
--- a/components/mpas-cice/driver/ice_comp_mct.F
+++ b/components/mpas-cice/driver/ice_comp_mct.F
@@ -793,7 +793,13 @@ contains
         call cice_analysis_write(domain, ierr)
 
         ! Reset the restart alarm to prevent restart files being written without the coupler requesting it.
-        call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT_OUTPUT, ierr=ierr)
+        call mpas_stream_mgr_begin_iteration(domain % streamManager)
+        do while ( mpas_stream_mgr_get_next_stream(domain % streamManager, streamID=streamName, &
+                   directionProperty=streamDirection, activeProperty=streamActive) )
+           if ( streamActive .and. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) then
+              call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID=streamName, ierr=ierr)
+           end if
+        end do
 
         call mpas_stream_mgr_write(domain % streamManager, streamID='output', ierr=ierr)
         call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='output', ierr=ierr)

--- a/components/mpas-o/driver/ocn_comp_mct.F
+++ b/components/mpas-o/driver/ocn_comp_mct.F
@@ -843,7 +843,15 @@ contains
          call ocn_analysis_write(domain_ptr, ierr)
 
          ! Reset any restart alarms to prevent restart files being written without the coupler requesting it.
-         call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT_OUTPUT, ierr=ierr)
+         call mpas_stream_mgr_begin_iteration(domain % streamManager)
+
+         do while ( mpas_stream_mgr_get_next_stream( domain % streamManager, streamID=streamName, &
+                    directionProperty=streamDirection, activeProperty=streamActive ) )
+
+            if ( streamActive .and. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) then
+               call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID=streamName, ierr=ierr)
+            end if
+         end do
 
          call mpas_stream_mgr_write(domain % streamManager, streamID='output', ierr=ierr)
          call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID='output', ierr=ierr)

--- a/components/mpasli/driver/glc_comp_mct.F
+++ b/components/mpasli/driver/glc_comp_mct.F
@@ -869,7 +869,16 @@ contains
          call mpas_timer_start("write output")
 
          ! Reset any restart alarms to prevent restart files being written without the coupler requesting it.
-         call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT_OUTPUT, ierr=err_tmp)
+         call mpas_stream_mgr_begin_iteration(domain % streamManager)
+
+         do while ( mpas_stream_mgr_get_next_stream( domain % streamManager, streamID=streamName, &
+                    directionProperty=streamDirection, activeProperty=streamActive ) )
+
+            if ( streamActive .and. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) then
+               call mpas_stream_mgr_reset_alarms(domain % streamManager, streamID=streamName, ierr=err_tmp)
+               err = ior(err,err_tmp)
+            end if
+         end do
          err = ior(err, err_tmp)
 
          ! These calls will handle ALL output streams that need writing.


### PR DESCRIPTION
This merge updates the output portion of the drivers for the MPAS
components to ensure that alarms are only reset for input/output streams
to prevent output streams from having their alarms reset when resetting
restart stream alarms.
