### PR TITLE
Control number of threads in CAM-SE through a namelist option

### DIFF
--- a/components/cam/bld/cam.buildnml
+++ b/components/cam/bld/cam.buildnml
@@ -156,6 +156,7 @@ while ($inst_counter <= $NINST_ATM) {
     $infile_text .= " dtime = $dtime \n";
     $infile_text .= " co2vmr = ${CCSM_CO2_PPMV}e-6\n";
     $infile_text .= " start_ymd = $start_ymd";
+    $infile_text .= " nthreads = $NTHRDS_ATM\n";
     if ($ncdata)          {$infile_text .= " ncdata = $ncdata \n";}
     if ($cam_branch_file) {$infile_text .= " cam_branch_file = $cam_branch_file \n";}
     if ($DEBUG eq 'TRUE') {$infile_text .= " state_debug_checks = .true. \n"}

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -5606,6 +5606,11 @@ Default: Set by build-namelist.
 Default: Set by build-namelist.
 </entry>
 
+<entry id="nthreads" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Total number of threads per MPI task.
+Default: 1.
+</entry>
 
 
 <!-- CAM I/O  -->

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -232,6 +232,7 @@ module namelist_mod
                      se_topology,      &
                      se_ne,            &
                      se_limiter_option, &
+                     nthreads,      &       ! Total number of threads per process
 #else
                      qsize,         &       ! number of SE tracers
                      ntrac,         &       ! number of fvm tracers
@@ -407,6 +408,7 @@ module namelist_mod
     se_phys_tscale=0
     se_nsplit = 1
     qsize = qsize_d
+    nthreads = 1
 #else
     ndays         = 0
     nmax          = 12
@@ -766,6 +768,7 @@ module namelist_mod
     phys_tscale = se_phys_tscale
     limiter_option  = se_limiter_option
     nsplit = se_nsplit
+    call MPI_bcast(nthreads  ,1,MPIinteger_t,par%root,par%comm,ierr)
 #else
     call MPI_bcast(omega     ,1,MPIreal_t   ,par%root,par%comm,ierr)
     call MPI_bcast(pertlim   ,1,MPIreal_t   ,par%root,par%comm,ierr)
@@ -1138,6 +1141,7 @@ module namelist_mod
        if (npdg>0) write(iulog,*)"readnl: npdg       = ",npdg
        write(iulog,*)"readnl: partmethod    = ",PARTMETHOD
        write(iulog,*)'readnl: nmpi_per_node = ',nmpi_per_node
+       write(iulog,*)"readnl: nthreads      = ",nthreads
        write(iulog,*)'readnl: multilevel    = ',multilevel
        write(iulog,*)'readnl: useframes     = ',useframes
        write(iulog,*)'readnl: nnodes        = ',nnodes


### PR DESCRIPTION
A new CAM-SE ctl_nl namelist variable nthreads is added that gets it
value from NTHRDS_ATM in env_mach_pes.xml. CAM-SE dynamics timesteps
are threaded with nthreads for number of threads.

[BFB] - Bit-For-Bit
Fixes #717 
