### PR TITLE
Fixes to get acme_bisect working again.

### DIFF
--- a/cime/scripts-acme/acme_bisect
+++ b/cime/scripts-acme/acme_bisect
@@ -97,8 +97,9 @@ def acme_bisect(testname, good, bad, testroot, compiler, project, baseline_name,
     # Formulate the create_test command
 
     compare_args = "-c -b %s" % baseline_name if baseline_name is not None else ""
-    bisect_cmd = "/bin/rm -rf %s/*acme_bisect && %s %s --test-root %s -t acme_bisect --compiler %s -p %s %s" % \
-        (testroot, create_test_rel, testname, testroot, compiler, project, compare_args)
+    project_args = "-p %s" % project if project else ""
+    bisect_cmd = "/bin/rm -rf %s/*acme_bisect && %s %s --test-root %s -t acme_bisect --compiler %s %s %s" % \
+        (testroot, create_test_rel, testname, testroot, compiler, project_args, compare_args)
 
     is_batch = acme_util.does_machine_have_batch()
     if (is_batch):

--- a/cime/scripts-acme/acme_util.py
+++ b/cime/scripts-acme/acme_util.py
@@ -40,7 +40,7 @@ _MACHINE_PROJECTS = {
 }
 
 # Return this error code if the scripts worked but tests failed
-TESTS_FAILED_ERR_CODE = 165
+TESTS_FAILED_ERR_CODE = 100
 
 ###############################################################################
 def expect(condition, error_msg):


### PR DESCRIPTION
Return code on test failures needs to be below 128.

Fix create_test cmd formation.

[BFB]
