### PR TITLE
Update moab and LANL IC machines to use project

### DIFF
--- a/cime/machines-acme/config_batch.xml
+++ b/cime/machines-acme/config_batch.xml
@@ -99,6 +99,7 @@
       <directive> -N {{ job_id }}</directive>
       <directive> -l walltime={{ wall_time }}</directive>
       <directive> -j oe </directive>
+      <directive> -A {{ project }} </directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
       <directive default="ae"  > -m {{ mail_options }} </directive>
       <directive default="/bin/bash" > -S {{ shell }}</directive>

--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -915,6 +915,7 @@
 	</mpirun>
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
+	<PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	<SUPPORTED_BY>jacobsen.douglas -at- gmail.com</SUPPORTED_BY>
 </machine>
 
@@ -967,6 +968,7 @@
 	</mpirun>
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
+	<PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	<SUPPORTED_BY>jacobsen.douglas -at- gmail.com</SUPPORTED_BY>
 </machine>
 


### PR DESCRIPTION
This merge updates the definition of the moab batch system to correctly
use a project, and updates the LANL IC machines to require a project be
specified when setting up a case.
