### PR TITLE
create_test: Loosen permissions on generated namelist baselines

### DIFF
--- a/cime/scripts-acme/create_test_impl.py
+++ b/cime/scripts-acme/create_test_impl.py
@@ -332,7 +332,11 @@ class CreateTest(object):
                 shutil.rmtree(baseline_casedocs)
             shutil.copytree(casedoc_dir, baseline_casedocs)
             os.chmod(baseline_casedocs, stat.S_IRWXU | stat.S_IRWXG | stat.S_IXOTH | stat.S_IROTH)
+            for item in glob.glob("%s/*" % baseline_casedocs):
+                os.chmod(item, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
+
             for item in glob.glob(os.path.join(test_dir, "user_nl*")):
+                os.remove(os.path.join(baseline_dir, os.path.basename(item)))
                 shutil.copy2(item, baseline_dir)
 
         # Always mark as passed unless we hit exception


### PR DESCRIPTION
We need multiple users to be able to work with these baselines
concurrently.

[BFB]
