### PR TITLE
Add mam_mom_mixing_state parameter to FC5AV1C-01 compset

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-01.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-01.xml
@@ -50,7 +50,8 @@
 <seasalt_emis_scale> 0.5    </seasalt_emis_scale>
 <dust_emis_fact>     0.40D0 </dust_emis_fact>
 
-
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>2</mam_mom_mixing_state>
 
 <!-- Stratospheric ozone (Linoz) -->
 <chlorine_loading_file      chem="linoz_mam3">atm/cam/chem/trop_mozart/ub/EESC_1850-2100_c090603.nc</chlorine_loading_file>


### PR DESCRIPTION
Specify a non-default value of the mam_mom_mixing state parameter in
the atmosphere namelist for the FC5AV1C-01 compset.

[BFB]
[FCC]
[NML]
