### PR TITLE
Fix typos in clubb namelist settings for FC5AV* compsets.

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-00.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-00.xml
@@ -39,8 +39,8 @@
 <ice_sed_ai>         500.0  </ice_sed_ai>
 <cldfrc_dp1>         0.05D0 </cldfrc_dp1>
 <clubb_ice_deep>     20.e-6 </clubb_ice_deep>
-<clubb_ice_sh>       50.e-6 </clubb_ice_sh
-<clubb_liq_deep>     8.e-6  </clubb_liq_deep  
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
 <clubb_liq_sh>       10.e-6 </clubb_liq_sh>
 <zmconv_c0_lnd>      0.005  </zmconv_c0_lnd>
 <zmconv_c0_ocn>      0.005  </zmconv_c0_ocn>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-01.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-01.xml
@@ -39,8 +39,8 @@
 <ice_sed_ai>         500.0  </ice_sed_ai>
 <cldfrc_dp1>         0.05D0 </cldfrc_dp1>
 <clubb_ice_deep>     20.e-6 </clubb_ice_deep>
-<clubb_ice_sh>       50.e-6 </clubb_ice_sh
-<clubb_liq_deep>     8.e-6  </clubb_liq_deep  
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
 <clubb_liq_sh>       10.e-6 </clubb_liq_sh>
 <clubb_C2rt>         0.75D0 </clubb_C2rt>
 <zmconv_c0_lnd>      0.005  </zmconv_c0_lnd>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c.xml
@@ -35,8 +35,8 @@
 <ice_sed_ai>         500.0  </ice_sed_ai>
 <cldfrc_dp1>         0.05D0 </cldfrc_dp1>
 <clubb_ice_deep>     20.e-6 </clubb_ice_deep>
-<clubb_ice_sh>       50.e-6 </clubb_ice_sh
-<clubb_liq_deep>     8.e-6  </clubb_liq_deep  
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
 <clubb_liq_sh>       10.e-6 </clubb_liq_sh>
 <zmconv_c0_lnd>      0.005  </zmconv_c0_lnd>
 <zmconv_c0_ocn>      0.005  </zmconv_c0_ocn>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1f-00.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1f-00.xml
@@ -42,8 +42,8 @@
 <ice_sed_ai>         500.0  </ice_sed_ai>
 <cldfrc_dp1>         0.05D0 </cldfrc_dp1>
 <clubb_ice_deep>     20.e-6 </clubb_ice_deep>
-<clubb_ice_sh>       50.e-6 </clubb_ice_sh
-<clubb_liq_deep>     8.e-6  </clubb_liq_deep  
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
 <clubb_liq_sh>       10.e-6 </clubb_liq_sh>
 <zmconv_c0_lnd>      0.005  </zmconv_c0_lnd>
 <zmconv_c0_ocn>      0.005  </zmconv_c0_ocn>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1f-01.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1f-01.xml
@@ -42,8 +42,8 @@
 <ice_sed_ai>         500.0  </ice_sed_ai>
 <cldfrc_dp1>         0.05D0 </cldfrc_dp1>
 <clubb_ice_deep>     20.e-6 </clubb_ice_deep>
-<clubb_ice_sh>       50.e-6 </clubb_ice_sh
-<clubb_liq_deep>     8.e-6  </clubb_liq_deep  
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
 <clubb_liq_sh>       10.e-6 </clubb_liq_sh>
 <clubb_C2rt>         0.75D0 </clubb_C2rt>
 <zmconv_c0_lnd>      0.005  </zmconv_c0_lnd>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1f.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1f.xml
@@ -35,8 +35,8 @@
 <ice_sed_ai>         500.0  </ice_sed_ai>
 <cldfrc_dp1>         0.05D0 </cldfrc_dp1>
 <clubb_ice_deep>     20.e-6 </clubb_ice_deep>
-<clubb_ice_sh>       50.e-6 </clubb_ice_sh
-<clubb_liq_deep>     8.e-6  </clubb_liq_deep  
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
 <clubb_liq_sh>       10.e-6 </clubb_liq_sh>
 <zmconv_c0_lnd>      0.005  </zmconv_c0_lnd>
 <zmconv_c0_ocn>      0.005  </zmconv_c0_ocn>


### PR DESCRIPTION
Fix typos in clubb namelist settings for FC5AV1\* compsets.

[BFB]
