### PR TITLE
Correct double t_startf for modal_aero_amicphys timer in aero_model

### DIFF
--- a/components/cam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/cam/src/chemistry/modal_aero/aero_model.F90
@@ -2561,7 +2561,7 @@ do_lphase2_conditional: &
 !           wetdens_host,                            &
 !           qaerwat                                  )
 
-       call t_startf('modal_aero_amicphys')
+       call t_stopf('modal_aero_amicphys')
 
     endif ! (mam_amicphys_optaa <= 0 OR > 0)
 


### PR DESCRIPTION
The call to modal_aero_amicphys_intr in aero_model_gasaerexch in
aero_model.F90 was surrounded by (at lines 2529 and 2564):

   call t_startf('modal_aero_amicphys')
 ...
   call t_startf('modal_aero_amicphys')

instead of

   call t_startf('modal_aero_amicphys')
 ...
   call t_stopf('modal_aero_amicphys')

This interferes with the timing logic and timing output.  This bug was
reported by Pat Worley, and is fixed by this commit.

Fixes #767

[BFB]

See confluence for a more detailed description about these tags.
