### PR TITLE
separate variable declaration into clm_instMod

### DIFF
--- a/components/clm/src/cpl/lnd_comp_esmf.F90
+++ b/components/clm/src/cpl/lnd_comp_esmf.F90
@@ -17,7 +17,7 @@ module lnd_comp_esmf
   use domainMod         , only : ldomain
   use decompMod         , only : ldecomp, bounds_type, get_proc_bounds
   use clm_varctl        , only : iulog
-  use clm_initializeMod , only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
+  use clm_instMod       , only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
   use clm_cpl_indices
   use lnd_import_export
   !
@@ -77,7 +77,8 @@ contains
     use shr_file_mod     , only : shr_file_getLogUnit, shr_file_getLogLevel
     use shr_file_mod     , only : shr_file_getUnit, shr_file_setIO
     use clm_time_manager , only : get_nstep, get_step_size, set_timemgr_init, set_nextsw_cday
-    use clm_initializeMod, only : initialize1, initialize2, initialize3, lnd2atm_vars, lnd2glc_vars
+    use clm_initializeMod, only : initialize1, initialize2, initialize3
+    use clm_instMod      , only : lnd2atm_vars, lnd2glc_vars
     use clm_varctl       , only : finidat,single_column, clm_varctl_set, noland
     use clm_varctl       , only : inst_index, inst_suffix, inst_name
     use clm_varctl       , only : nsrStartup, nsrContinue, nsrBranch
@@ -457,7 +458,7 @@ contains
     use shr_file_mod      , only : shr_file_setLogUnit, shr_file_setLogLevel
     use shr_file_mod      , only : shr_file_getLogUnit, shr_file_getLogLevel
     use shr_orb_mod       , only : shr_orb_decl
-    use clm_initializeMod , only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
+    use clm_instMod       , only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
     use clm_driver        , only : clm_drv
     use clm_varorb        , only : eccen, obliqr, lambm0, mvelpp
     use clm_time_manager  , only : get_curr_date, get_nstep, get_curr_calday, get_step_size

--- a/components/clm/src/cpl/lnd_comp_mct.F90
+++ b/components/clm/src/cpl/lnd_comp_mct.F90
@@ -41,7 +41,8 @@ contains
     ! !USES:
     use abortutils       , only : endrun
     use clm_time_manager , only : get_nstep, get_step_size, set_timemgr_init, set_nextsw_cday
-    use clm_initializeMod, only : initialize1, initialize2, initialize3, lnd2atm_vars, lnd2glc_vars
+    use clm_initializeMod, only : initialize1, initialize2, initialize3
+    use clm_instMod      , only : lnd2atm_vars, lnd2glc_vars
     use clm_varctl       , only : finidat,single_column, clm_varctl_set, iulog, noland
     use clm_varctl       , only : inst_index, inst_suffix, inst_name
     use clm_varorb       , only : eccen, obliqr, lambm0, mvelpp
@@ -299,7 +300,7 @@ contains
     !
     ! !USES:
     use shr_kind_mod    ,  only : r8 => shr_kind_r8
-    use clm_initializeMod, only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
+    use clm_instMod     , only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
     use clm_driver      ,  only : clm_drv
     use clm_time_manager,  only : get_curr_date, get_nstep, get_curr_calday, get_step_size
     use clm_time_manager,  only : advance_timestep, set_nextsw_cday,update_rad_dtime

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -81,42 +81,42 @@ module clm_driver
   use DaylengthMod           , only : UpdateDaylength
   use perf_mod
   !
-  use clm_initializeMod      , only : ch4_vars
-  use clm_initializeMod      , only : carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars
-  use clm_initializeMod      , only : carbonflux_vars, c13_carbonflux_vars, c14_carbonflux_vars
-  use clm_initializeMod      , only : nitrogenstate_vars
-  use clm_initializeMod      , only : nitrogenflux_vars
-  use clm_initializeMod      , only : phosphorusstate_vars
-  use clm_initializeMod      , only : phosphorusflux_vars
-  use clm_initializeMod      , only : dgvs_vars
-  use clm_initializeMod      , only : crop_vars
-  use clm_initializeMod      , only : cnstate_vars
-  use clm_initializeMod      , only : dust_vars
-  use clm_initializeMod      , only : vocemis_vars
-  use clm_initializeMod      , only : drydepvel_vars
-  use clm_initializeMod      , only : aerosol_vars
-  use clm_initializeMod      , only : canopystate_vars
-  use clm_initializeMod      , only : energyflux_vars
-  use clm_initializeMod      , only : frictionvel_vars
-  use clm_initializeMod      , only : lakestate_vars
-  use clm_initializeMod      , only : photosyns_vars
-  use clm_initializeMod      , only : soilstate_vars
-  use clm_initializeMod      , only : soilhydrology_vars
-  use clm_initializeMod      , only : solarabs_vars
-  use clm_initializeMod      , only : soilhydrology_vars
-  use clm_initializeMod      , only : surfalb_vars
-  use clm_initializeMod      , only : surfrad_vars
-  use clm_initializeMod      , only : temperature_vars
-  use clm_initializeMod      , only : urbanparams_vars
-  use clm_initializeMod      , only : waterflux_vars
-  use clm_initializeMod      , only : waterstate_vars
-  use clm_initializeMod      , only : atm2lnd_vars
-  use clm_initializeMod      , only : lnd2atm_vars
-  use clm_initializeMod      , only : glc2lnd_vars
-  use clm_initializeMod      , only : lnd2glc_vars
-  use clm_initializeMod      , only : EDbio_vars
-  use clm_initializeMod      , only : soil_water_retention_curve
-  use clm_initializeMod      , only : chemstate_vars
+  use clm_instMod            , only : ch4_vars
+  use clm_instMod            , only : carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars
+  use clm_instMod            , only : carbonflux_vars, c13_carbonflux_vars, c14_carbonflux_vars
+  use clm_instMod            , only : nitrogenstate_vars
+  use clm_instMod            , only : nitrogenflux_vars
+  use clm_instMod            , only : phosphorusstate_vars
+  use clm_instMod            , only : phosphorusflux_vars
+  use clm_instMod            , only : dgvs_vars
+  use clm_instMod            , only : crop_vars
+  use clm_instMod            , only : cnstate_vars
+  use clm_instMod            , only : dust_vars
+  use clm_instMod            , only : vocemis_vars
+  use clm_instMod            , only : drydepvel_vars
+  use clm_instMod            , only : aerosol_vars
+  use clm_instMod            , only : canopystate_vars
+  use clm_instMod            , only : energyflux_vars
+  use clm_instMod            , only : frictionvel_vars
+  use clm_instMod            , only : lakestate_vars
+  use clm_instMod            , only : photosyns_vars
+  use clm_instMod            , only : soilstate_vars
+  use clm_instMod            , only : soilhydrology_vars
+  use clm_instMod            , only : solarabs_vars
+  use clm_instMod            , only : soilhydrology_vars
+  use clm_instMod            , only : surfalb_vars
+  use clm_instMod            , only : surfrad_vars
+  use clm_instMod            , only : temperature_vars
+  use clm_instMod            , only : urbanparams_vars
+  use clm_instMod            , only : waterflux_vars
+  use clm_instMod            , only : waterstate_vars
+  use clm_instMod            , only : atm2lnd_vars
+  use clm_instMod            , only : lnd2atm_vars
+  use clm_instMod            , only : glc2lnd_vars
+  use clm_instMod            , only : lnd2glc_vars
+  use clm_instMod            , only : EDbio_vars
+  use clm_instMod            , only : soil_water_retention_curve
+  use clm_instMod            , only : chemstate_vars
   use betr_initializeMod     , only : betrtracer_vars
   use betr_initializeMod     , only : tracercoeff_vars
   use betr_initializeMod     , only : tracerflux_vars
@@ -138,7 +138,7 @@ module clm_driver
   !!----------------------------------------------------------------------------
   !! bgc interface & pflotran:
   use clm_varctl             , only : use_bgc_interface
-  use clm_initializeMod      , only : clm_bgc_data
+  use clm_instMod            , only : clm_bgc_data
   use clm_bgc_interfaceMod   , only : get_clm_bgc_data
   !! (1) clm_bgc through interface
   use clm_varctl             , only : use_clm_bgc

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -21,109 +21,17 @@ module clm_initializeMod
   !-----------------------------------------
   ! Definition of component types
   !-----------------------------------------
-  use AerosolType            , only : aerosol_type
-  use CanopyStateType        , only : canopystate_type
-  use ch4Mod                 , only : ch4_type
-  use CNCarbonFluxType       , only : carbonflux_type
-  use CNCarbonStateType      , only : carbonstate_type
-  use CNDVType               , only : dgvs_type
-  use CNStateType            , only : cnstate_type
-  use CNNitrogenFluxType     , only : nitrogenflux_type
-  use CNNitrogenStateType    , only : nitrogenstate_type
-
-  use PhosphorusFluxType     , only : phosphorusflux_type
-  use PhosphorusStateType    , only : phosphorusstate_type
-
-  use CropType               , only : crop_type
-  use DryDepVelocity         , only : drydepvel_type
-  use DUSTMod                , only : dust_type
-  use EnergyFluxType         , only : energyflux_type
-  use FrictionVelocityType   , only : frictionvel_type
-  use LakeStateType          , only : lakestate_type
-  use PhotosynthesisType     , only : photosyns_type
-  use SoilHydrologyType      , only : soilhydrology_type  
-  use SoilStateType          , only : soilstate_type
-  use SolarAbsorbedType      , only : solarabs_type
-  use SurfaceRadiationMod    , only : surfrad_type
-  use SurfaceAlbedoMod       , only : SurfaceAlbedoInitTimeConst !TODO - can this be merged into the type?
-  use SurfaceAlbedoType      , only : surfalb_type
-  use TemperatureType        , only : temperature_type
-  use WaterfluxType          , only : waterflux_type
-  use WaterstateType         , only : waterstate_type
-  use UrbanParamsType        , only : urbanparams_type
-  use VOCEmissionMod         , only : vocemis_type
-  use atm2lndType            , only : atm2lnd_type
-  use lnd2atmType            , only : lnd2atm_type
-  use lnd2glcMod             , only : lnd2glc_type 
-  use glc2lndMod             , only : glc2lnd_type
-  use glcDiagnosticsMod      , only : glc_diagnostics_type
-  use SoilWaterRetentionCurveMod, only : soil_water_retention_curve_type
-  use UrbanParamsType        , only : urbanparams_type   ! Constants 
-  use CNDecompCascadeConType , only : decomp_cascade_con ! Constants 
-  use CNDVType               , only : dgv_ecophyscon     ! Constants 
-  use EcophysConType         , only : ecophyscon         ! Constants 
-  use SoilorderConType       , only : soilordercon         ! Constants 
   use GridcellType           , only : grc
   use TopounitType           , only : top_pp, top_es, top_ws
   use LandunitType           , only : lun                
   use ColumnType             , only : col                
   use PatchType              , only : pft                
-  use EDEcophysConType       , only : EDecophyscon       ! ED Constants
-  use EDBioType              , only : EDbio_type         ! ED type used to interact with CLM variables
   use EDVecPatchType         , only : EDpft                   
   use EDVecCohortType        , only : coh                ! unique to ED, used for domain decomp
-  use clm_bgc_interface_data , only : clm_bgc_interface_data_type
-  use ChemStateType          , only : chemstate_type     ! structure for chemical indices of the soil, such as pH and Eh
+  use clm_instMod
   !
   implicit none
   save
-  public   ! By default everything is public 
-  !
-  !-----------------------------------------
-  ! Instances of component types
-  !-----------------------------------------
-  !
-  type(ch4_type)              :: ch4_vars
-  type(carbonstate_type)      :: carbonstate_vars
-  type(carbonstate_type)      :: c13_carbonstate_vars
-  type(carbonstate_type)      :: c14_carbonstate_vars
-  type(carbonflux_type)       :: carbonflux_vars
-  type(carbonflux_type)       :: c13_carbonflux_vars
-  type(carbonflux_type)       :: c14_carbonflux_vars
-  type(nitrogenstate_type)    :: nitrogenstate_vars
-  type(nitrogenflux_type)     :: nitrogenflux_vars
-  type(dgvs_type)             :: dgvs_vars
-  type(crop_type)             :: crop_vars
-  type(cnstate_type)          :: cnstate_vars
-  type(dust_type)             :: dust_vars
-  type(vocemis_type)          :: vocemis_vars
-  type(drydepvel_type)        :: drydepvel_vars
-  type(aerosol_type)          :: aerosol_vars
-  type(canopystate_type)      :: canopystate_vars
-  type(energyflux_type)       :: energyflux_vars
-  type(frictionvel_type)      :: frictionvel_vars
-  type(lakestate_type)        :: lakestate_vars
-  type(photosyns_type)        :: photosyns_vars
-  type(soilstate_type)        :: soilstate_vars
-  type(soilhydrology_type)    :: soilhydrology_vars
-  type(solarabs_type)         :: solarabs_vars
-  type(surfalb_type)          :: surfalb_vars
-  type(surfrad_type)          :: surfrad_vars
-  type(temperature_type)      :: temperature_vars
-  type(urbanparams_type)      :: urbanparams_vars
-  type(waterflux_type)        :: waterflux_vars
-  type(waterstate_type)       :: waterstate_vars
-  type(atm2lnd_type)          :: atm2lnd_vars
-  type(glc2lnd_type)          :: glc2lnd_vars
-  type(lnd2atm_type)          :: lnd2atm_vars
-  type(lnd2glc_type)          :: lnd2glc_vars
-  type(glc_diagnostics_type)  :: glc_diagnostics_vars
-  class(soil_water_retention_curve_type), allocatable :: soil_water_retention_curve
-  type(EDbio_type)            :: EDbio_vars
-  type(phosphorusstate_type)    :: phosphorusstate_vars
-  type(phosphorusflux_type)     :: phosphorusflux_vars
-  type(clm_bgc_interface_data_type) :: clm_bgc_data
-  type(chemstate_type)        :: chemstate_vars  
   !
   public :: initialize1  ! Phase one initialization
   public :: initialize2  ! Phase two initialization
@@ -378,7 +286,7 @@ contains
     use shr_scam_mod          , only : shr_scam_getCloseLatLon
     use seq_drydep_mod        , only : n_drydep, drydep_method, DD_XLND
     use clm_varpar            , only : nlevsno, numpft, crop_prog, nlevsoi    
-    use clm_varcon            , only : h2osno_max, bdsno, c13ratio, c14ratio, spval
+    use clm_varcon            , only : h2osno_max, bdsno, spval
     use landunit_varcon       , only : istice, istice_mec, istsoil
     use clm_varctl            , only : finidat, finidat_interp_source, finidat_interp_dest, fsurdat
     use clm_varctl            , only : use_century_decomp, single_column, scmlat, scmlon, use_cn, use_ed
@@ -396,7 +304,7 @@ contains
     use dynSubgridDriverMod   , only : dynSubgrid_init
     use reweightMod           , only : reweight_wrapup
     use subgridWeightsMod     , only : init_subgrid_weights_mod
-    use histFileMod           , only : hist_htapes_build, htapes_fieldlist, hist_printflds
+    use histFileMod           , only : hist_htapes_build, htapes_fieldlist
     use histFileMod           , only : hist_addfld1d, hist_addfld2d, no_snow_normal
     use restFileMod           , only : restFile_getfile, restFile_open, restFile_close
     use restFileMod           , only : restFile_read, restFile_write 
@@ -553,145 +461,7 @@ contains
          avgflag='A', long_name='convective boundary height', &
          ptr_col=col%zii, default='inactive')
 
-    ! Note: h2osno_col and snow_depth_col are initialized as local variable 
-    ! since they are needed to initialize vertical data structures  
-
-    begp = bounds_proc%begp; endp = bounds_proc%endp 
-    begc = bounds_proc%begc; endc = bounds_proc%endc 
-    begl = bounds_proc%begl; endl = bounds_proc%endl 
-
-    allocate (h2osno_col(begc:endc))
-    allocate (snow_depth_col(begc:endc))
-
-    ! snow water
-    ! Note: Glacier_mec columns are initialized with half the maximum snow cover.
-    ! This gives more realistic values of qflx_glcice sooner in the simulation
-    ! for columns with net ablation, at the cost of delaying ice formation
-    ! in columns with net accumulation.
-    do c = begc,endc
-       l = col%landunit(c)
-       g = col%gridcell(c)
-
-       if (lun%itype(l)==istice) then
-          h2osno_col(c) = h2osno_max
-       elseif (lun%itype(l)==istice_mec .or. &
-              (lun%itype(l)==istsoil .and. ldomain%glcmask(g) > 0._r8)) then 
-          ! Initialize a non-zero snow thickness where the ice sheet can/potentially operate.
-          ! Using glcmask to capture all potential vegetated points around GrIS (ideally
-          ! we would use icemask from CISM, but that isn't available until after initialization.)
-          h2osno_col(c) = 1.0_r8 * h2osno_max   ! start with full snow column so +SMB can begin immediately
-       else
-          h2osno_col(c) = 0._r8
-       endif
-       snow_depth_col(c)  = h2osno_col(c) / bdsno
-    end do
-
-    ! Initialize urban constants
-
-    call urbanparams_vars%Init(bounds_proc)
-
-    ! Initialize ecophys constants
-
-    call ecophysconInit()
-    if (use_ed) then
-       call EDecophysconInit( EDpftvarcon_Inst, numpft)
-    end if
-
-    ! Initialize soil order related constants
-
-    call soilorderconInit()
-
-    ! Initialize lake constants
-
-    call LakeConInit()
-
-    ! Initialize surface albedo constants
-
-    call SurfaceAlbedoInitTimeConst(bounds_proc)
-
-    ! Initialize vertical data components 
-
-    call initVertical(bounds_proc,               &
-         snow_depth_col(begc:endc),              &
-         urbanparams_vars%thick_wall(begl:endl), &
-         urbanparams_vars%thick_roof(begl:endl))
-
-    ! Initialize clm->drv and drv->clm data structures
-
-    call atm2lnd_vars%Init( bounds_proc )
-    call lnd2atm_vars%Init( bounds_proc )
-
-    ! Initialize glc2lnd and lnd2glc even if running without create_glacier_mec_landunit,
-    ! because at least some variables (such as the icemask) are referred to in code that
-    ! is executed even when running without glc_mec.
-    call glc2lnd_vars%Init( bounds_proc )
-    call lnd2glc_vars%Init( bounds_proc )
-
-    ! If single-column determine closest latitude and longitude
-
-    if (single_column) then
-       call getfil (fsurdat, locfn, 0)
-       call shr_scam_getCloseLatLon(locfn, scmlat, scmlon, &
-            closelat, closelon, closelatidx, closelonidx)
-    end if
-
-    ! Initialization of public data types
-
-    call temperature_vars%init(bounds_proc,      &
-         urbanparams_vars%em_roof(begl:endl),    &
-         urbanparams_vars%em_wall(begl:endl),    &
-         urbanparams_vars%em_improad(begl:endl), &
-         urbanparams_vars%em_perroad(begl:endl))
-
-    call canopystate_vars%init(bounds_proc)
-
-    call soilstate_vars%init(bounds_proc)
-
-    call waterstate_vars%init(bounds_proc,         &
-         h2osno_col(begc:endc),                    &
-         snow_depth_col(begc:endc),                &
-         soilstate_vars%watsat_col(begc:endc, 1:), &
-         temperature_vars%t_soisno_col(begc:endc, -nlevsno+1:) )
-
-    
-    call waterflux_vars%init(bounds_proc)
-
-    call chemstate_vars%Init(bounds_proc)    
-    ! WJS (6-24-14): Without the following write statement, the assertion in
-    ! energyflux_vars%init fails with pgi 13.9 on yellowstone. So for now, I'm leaving
-    ! this write statement in place as a workaround for this problem.
-    call energyflux_vars%init(bounds_proc, temperature_vars%t_grnd_col(begc:endc))
-
-    call aerosol_vars%Init(bounds_proc)
-
-    call frictionvel_vars%Init(bounds_proc)
-
-    call lakestate_vars%Init(bounds_proc)
-
-    call photosyns_vars%Init(bounds_proc)
-
-    call soilhydrology_vars%Init(bounds_proc, nlfilename)
-
-    call solarabs_vars%Init(bounds_proc)
-
-    call surfalb_vars%Init(bounds_proc)
-
-    call surfrad_vars%Init(bounds_proc)
-
-    call dust_vars%Init(bounds_proc)
-
-    call glc_diagnostics_vars%Init(bounds_proc)
-
-    ! Once namelist options are added to control the soil water retention curve method,
-    ! we'll need to either pass the namelist file as an argument to this routine, or pass
-    ! the namelist value itself (if the namelist is read elsewhere).
-    allocate(soil_water_retention_curve, &
-         source=create_soil_water_retention_curve())
-
-
-    ! --------------------------------------------------------------
-    ! Initialise the BeTR 
-    ! --------------------------------------------------------------
+    call clm_inst_biogeophys(bounds_proc)
 
     if(use_betr)then
       !state variables will be initialized inside betr_initialize
@@ -702,16 +472,6 @@ contains
 
     call SnowAge_init( )    ! SNICAR aging   parameters:
 
-    ! Note - always initialize the memory for ch4_vars
-    call ch4_vars%Init(bounds_proc, soilstate_vars%cellorg_col(begc:endc, 1:))
-
-    ! Note - always initialize the memory for cnstate_vars (used in biogeophys/)
-    call cnstate_vars%Init(bounds_proc)
-
-    if (use_voc ) then
-       call vocemis_vars%Init(bounds_proc)
-    end if
-
     ! ------------------------------------------------------------------------
     ! Read in private parameters files, this should be preferred for mulitphysics
     ! implementation, jinyun Tang, Feb. 11, 2015
@@ -721,7 +481,7 @@ contains
     endif
     !read bgc implementation specific parameters when needed
     call readPrivateParameters()
-    
+
     if (use_cn) then
        if (.not. is_active_betr_bgc)then
           if (use_century_decomp) then
@@ -732,75 +492,9 @@ contains
              call init_decompcascade_cn(bounds_proc, cnstate_vars)
           end if
        endif
-
-       ! Note - always initialize the memory for the c13_carbonstate_vars and
-       ! c14_carbonstate_vars data structure so that they can be used in 
-       ! associate statements (nag compiler complains otherwise)
-
-       call carbonstate_vars%Init(bounds_proc, carbon_type='c12', ratio=1._r8) 
-       if (use_c13) then
-          call c13_carbonstate_vars%Init(bounds_proc, carbon_type='c13', ratio=c13ratio, &
-               c12_carbonstate_vars=carbonstate_vars)
-       end if
-       if (use_c14) then
-          call c14_carbonstate_vars%Init(bounds_proc, carbon_type='c14', ratio=c14ratio, &
-               c12_carbonstate_vars=carbonstate_vars)
-       end if
-
-       ! Note - always initialize the memory for the c13_carbonflux_vars and
-       ! c14_carbonflux_vars data structure so that they can be used in 
-       ! associate statements (nag compiler complains otherwise)
-
-       call carbonflux_vars%Init(bounds_proc, carbon_type='c12') 
-       if (use_c13) then
-          call c13_carbonflux_vars%Init(bounds_proc, carbon_type='c13')
-       end if
-       if (use_c14) then
-          call c14_carbonflux_vars%Init(bounds_proc, carbon_type='c14')
-       end if
-
-       call nitrogenstate_vars%Init(bounds_proc,                      &
-            carbonstate_vars%leafc_patch(begp:endp),                  &
-            carbonstate_vars%leafc_storage_patch(begp:endp),          &
-            carbonstate_vars%frootc_patch(begp:endp),                 &
-            carbonstate_vars%frootc_storage_patch(begp:endp),         &
-            carbonstate_vars%deadstemc_patch(begp:endp),              &
-            carbonstate_vars%decomp_cpools_vr_col(begc:endc, 1:, 1:), &
-            carbonstate_vars%decomp_cpools_col(begc:endc, 1:),        &
-            carbonstate_vars%decomp_cpools_1m_col(begc:endc, 1:))
-
-       call nitrogenflux_vars%Init(bounds_proc) 
-
-
-       call phosphorusstate_vars%Init(bounds_proc,                    &
-            carbonstate_vars%leafc_patch(begp:endp),                  &
-            carbonstate_vars%leafc_storage_patch(begp:endp),          &
-            carbonstate_vars%frootc_patch(begp:endp),                 &
-            carbonstate_vars%frootc_storage_patch(begp:endp),         &
-            carbonstate_vars%deadstemc_patch(begp:endp),              &
-            carbonstate_vars%decomp_cpools_vr_col(begc:endc, 1:, 1:), &
-            carbonstate_vars%decomp_cpools_col(begc:endc, 1:),        &
-            carbonstate_vars%decomp_cpools_1m_col(begc:endc, 1:))
-
-       call phosphorusflux_vars%Init(bounds_proc) 
-
-       ! Note - always initialize the memory for the dgvs_vars data structure so
-       ! that it can be used in associate statements (nag compiler complains otherwise)
-       call dgvs_vars%Init(bounds_proc)
-
-       call crop_vars%Init(bounds_proc)
-       
-    end if
-
-    if ( use_ed ) then
-       call EDbio_vars%Init(bounds_proc)
-    end if
-
-    call hist_printflds()
-
-    deallocate (h2osno_col)
-    deallocate (snow_depth_col)
-
+    endif
+     
+    call clm_inst_biogeochem(bounds_proc)
     ! ------------------------------------------------------------------------
     ! Initialize accumulated fields
     ! ------------------------------------------------------------------------
@@ -1381,5 +1075,6 @@ contains
     call t_stopf('clm_init3')
 
   end subroutine initialize3
+
 
 end module clm_initializeMod

--- a/components/clm/src/main/clm_instMod.F90
+++ b/components/clm/src/main/clm_instMod.F90
@@ -1,0 +1,402 @@
+module clm_instMod
+  !-----------------------------------------------------------------------
+  ! initialize clm data types
+  !
+  use shr_kind_mod               , only : r8 => shr_kind_r8
+  use shr_log_mod                , only : errMsg => shr_log_errMsg
+  use decompMod                  , only : bounds_type, get_proc_bounds
+  use clm_varctl                 , only : use_cn, use_voc, use_c13, use_c14, use_ed
+  !-----------------------------------------
+  ! Definition of component types
+  !-----------------------------------------
+  use AerosolType                , only : aerosol_type
+  use CanopyStateType            , only : canopystate_type
+  use ch4Mod                     , only : ch4_type
+  use CNCarbonFluxType           , only : carbonflux_type
+  use CNCarbonStateType          , only : carbonstate_type
+  use CNDVType                   , only : dgvs_type
+  use CNStateType                , only : cnstate_type
+  use CNNitrogenFluxType         , only : nitrogenflux_type
+  use CNNitrogenStateType        , only : nitrogenstate_type
+
+  use PhosphorusFluxType         , only : phosphorusflux_type
+  use PhosphorusStateType        , only : phosphorusstate_type
+
+  use CropType                   , only : crop_type
+  use DryDepVelocity             , only : drydepvel_type
+  use DUSTMod                    , only : dust_type
+  use EnergyFluxType             , only : energyflux_type
+  use FrictionVelocityType       , only : frictionvel_type
+  use LakeStateType              , only : lakestate_type
+  use PhotosynthesisType         , only : photosyns_type
+  use SoilHydrologyType          , only : soilhydrology_type
+  use SoilStateType              , only : soilstate_type
+  use SolarAbsorbedType          , only : solarabs_type
+  use SurfaceRadiationMod        , only : surfrad_type
+  use SurfaceAlbedoMod           , only : SurfaceAlbedoInitTimeConst !TODO - can this be merged into the type?
+  use SurfaceAlbedoType          , only : surfalb_type
+  use TemperatureType            , only : temperature_type
+  use WaterfluxType              , only : waterflux_type
+  use WaterstateType             , only : waterstate_type
+  use UrbanParamsType            , only : urbanparams_type
+  use VOCEmissionMod             , only : vocemis_type
+  use atm2lndType                , only : atm2lnd_type
+  use lnd2atmType                , only : lnd2atm_type
+  use lnd2glcMod                 , only : lnd2glc_type
+  use glc2lndMod                 , only : glc2lnd_type
+  use glcDiagnosticsMod          , only : glc_diagnostics_type
+  use SoilWaterRetentionCurveMod , only : soil_water_retention_curve_type
+  use UrbanParamsType            , only : urbanparams_type   ! Constants
+
+  use EcophysConType             , only : ecophyscon         ! Constants
+  use SoilorderConType           , only : soilordercon         ! Constants
+
+  use LandunitType               , only : lun
+  use ColumnType                 , only : col
+  use PatchType                  , only : pft
+  use EDEcophysConType           , only : EDecophyscon       ! ED Constants
+
+  use EDBioType                  , only : EDbio_type         ! ED type used to interact with CLM variables
+  use EDVecPatchType             , only : EDpft
+  use EDVecCohortType            , only : coh                ! unique to ED, used for domain decomp
+  use clm_bgc_interface_data     , only : clm_bgc_interface_data_type
+  use ChemStateType              , only : chemstate_type     ! structure for chemical indices of the soil, such as pH and Eh
+  !
+  implicit none
+  save
+
+ public   ! By default everything is public
+  !
+  !-----------------------------------------
+  ! Instances of component types
+  !-----------------------------------------
+  !
+  type(ch4_type)                                      :: ch4_vars
+  type(carbonstate_type)                              :: carbonstate_vars
+  type(carbonstate_type)                              :: c13_carbonstate_vars
+  type(carbonstate_type)                              :: c14_carbonstate_vars
+  type(carbonflux_type)                               :: carbonflux_vars
+  type(carbonflux_type)                               :: c13_carbonflux_vars
+  type(carbonflux_type)                               :: c14_carbonflux_vars
+  type(nitrogenstate_type)                            :: nitrogenstate_vars
+  type(nitrogenflux_type)                             :: nitrogenflux_vars
+  type(dgvs_type)                                     :: dgvs_vars
+  type(crop_type)                                     :: crop_vars
+  type(cnstate_type)                                  :: cnstate_vars
+  type(dust_type)                                     :: dust_vars
+  type(vocemis_type)                                  :: vocemis_vars
+  type(drydepvel_type)                                :: drydepvel_vars
+  type(aerosol_type)                                  :: aerosol_vars
+  type(canopystate_type)                              :: canopystate_vars
+  type(energyflux_type)                               :: energyflux_vars
+  type(frictionvel_type)                              :: frictionvel_vars
+  type(lakestate_type)                                :: lakestate_vars
+  type(photosyns_type)                                :: photosyns_vars
+  type(soilstate_type)                                :: soilstate_vars
+  type(soilhydrology_type)                            :: soilhydrology_vars
+  type(solarabs_type)                                 :: solarabs_vars
+  type(surfalb_type)                                  :: surfalb_vars
+  type(surfrad_type)                                  :: surfrad_vars
+  type(temperature_type)                              :: temperature_vars
+  type(urbanparams_type)                              :: urbanparams_vars
+  type(waterflux_type)                                :: waterflux_vars
+  type(waterstate_type)                               :: waterstate_vars
+  type(atm2lnd_type)                                  :: atm2lnd_vars
+  type(glc2lnd_type)                                  :: glc2lnd_vars
+  type(lnd2atm_type)                                  :: lnd2atm_vars
+  type(lnd2glc_type)                                  :: lnd2glc_vars
+  type(glc_diagnostics_type)                          :: glc_diagnostics_vars
+  class(soil_water_retention_curve_type), allocatable :: soil_water_retention_curve
+  type(EDbio_type)                                    :: EDbio_vars
+  type(phosphorusstate_type)                          :: phosphorusstate_vars
+  type(phosphorusflux_type)                           :: phosphorusflux_vars
+  type(clm_bgc_interface_data_type)                   :: clm_bgc_data
+  type(chemstate_type)                                :: chemstate_vars
+
+  public :: clm_inst_biogeochem
+  public :: clm_inst_biogeophys
+
+contains
+
+
+  !-----------------------------------------------------------------------
+  subroutine clm_inst_biogeochem(bounds_proc)
+
+    !
+    ! DESCRIPTION
+    ! initialize biogeochemical variables
+    use clm_varcon            , only : c13ratio, c14ratio
+    use histFileMod           , only : hist_printflds
+    implicit none
+    type(bounds_type), intent(in) :: bounds_proc
+
+    integer               :: begp, endp
+    integer               :: begc, endc
+    integer               :: begl, endl
+
+    begp = bounds_proc%begp; endp = bounds_proc%endp
+    begc = bounds_proc%begc; endc = bounds_proc%endc
+    begl = bounds_proc%begl; endl = bounds_proc%endl
+
+
+    if (use_voc ) then
+       call vocemis_vars%Init(bounds_proc)
+    end if
+    if (use_cn) then
+
+       ! Note - always initialize the memory for the c13_carbonstate_vars and
+       ! c14_carbonstate_vars data structure so that they can be used in
+       ! associate statements (nag compiler complains otherwise)
+
+       call carbonstate_vars%Init(bounds_proc, carbon_type='c12', ratio=1._r8)
+       if (use_c13) then
+          call c13_carbonstate_vars%Init(bounds_proc, carbon_type='c13', ratio=c13ratio, &
+               c12_carbonstate_vars=carbonstate_vars)
+       end if
+       if (use_c14) then
+          call c14_carbonstate_vars%Init(bounds_proc, carbon_type='c14', ratio=c14ratio, &
+               c12_carbonstate_vars=carbonstate_vars)
+       end if
+
+       ! Note - always initialize the memory for the c13_carbonflux_vars and
+       ! c14_carbonflux_vars data structure so that they can be used in
+       ! associate statements (nag compiler complains otherwise)
+
+       call carbonflux_vars%Init(bounds_proc, carbon_type='c12')
+       if (use_c13) then
+          call c13_carbonflux_vars%Init(bounds_proc, carbon_type='c13')
+       end if
+       if (use_c14) then
+          call c14_carbonflux_vars%Init(bounds_proc, carbon_type='c14')
+       end if
+
+       call nitrogenstate_vars%Init(bounds_proc,                      &
+            carbonstate_vars%leafc_patch(begp:endp),                  &
+            carbonstate_vars%leafc_storage_patch(begp:endp),          &
+            carbonstate_vars%frootc_patch(begp:endp),                 &
+            carbonstate_vars%frootc_storage_patch(begp:endp),         &
+            carbonstate_vars%deadstemc_patch(begp:endp),              &
+            carbonstate_vars%decomp_cpools_vr_col(begc:endc, 1:, 1:), &
+            carbonstate_vars%decomp_cpools_col(begc:endc, 1:),        &
+            carbonstate_vars%decomp_cpools_1m_col(begc:endc, 1:))
+
+       call nitrogenflux_vars%Init(bounds_proc)
+
+       call phosphorusstate_vars%Init(bounds_proc,                    &
+            carbonstate_vars%leafc_patch(begp:endp),                  &
+            carbonstate_vars%leafc_storage_patch(begp:endp),          &
+            carbonstate_vars%frootc_patch(begp:endp),                 &
+            carbonstate_vars%frootc_storage_patch(begp:endp),         &
+            carbonstate_vars%deadstemc_patch(begp:endp),              &
+            carbonstate_vars%decomp_cpools_vr_col(begc:endc, 1:, 1:), &
+            carbonstate_vars%decomp_cpools_col(begc:endc, 1:),        &
+            carbonstate_vars%decomp_cpools_1m_col(begc:endc, 1:))
+
+       call phosphorusflux_vars%Init(bounds_proc)
+
+       ! Note - always initialize the memory for the dgvs_vars data structure so
+       ! that it can be used in associate statements (nag compiler complains otherwise)
+       call dgvs_vars%Init(bounds_proc)
+
+       call crop_vars%Init(bounds_proc)
+
+    end if
+
+    if ( use_ed ) then
+       call EDbio_vars%Init(bounds_proc)
+    end if
+
+    call hist_printflds()
+
+  end subroutine clm_inst_biogeochem
+
+
+  !-----------------------------------------------------------------------
+
+    subroutine clm_inst_biogeophys(bounds_proc)
+    !
+    ! DESCRIPTION
+    ! initialize biogeophysical variables
+    !
+    use shr_scam_mod                      , only : shr_scam_getCloseLatLon
+    use landunit_varcon                   , only : istice, istice_mec, istsoil
+    use clm_varcon                        , only : h2osno_max, bdsno
+    use domainMod                         , only : ldomain
+    use EDPftVarcon                       , only : EDpftvarcon_inst
+    use clm_varpar                        , only : nlevsno, numpft
+    use clm_varctl                        , only : single_column, fsurdat, scmlat, scmlon
+    use controlMod                        , only : nlfilename
+    use SoilWaterRetentionCurveFactoryMod , only : create_soil_water_retention_curve
+    use fileutils                         , only : getfil
+    use EcophysConType                    , only : ecophysconInit
+    use EDEcophysConType                  , only : EDecophysconInit
+    use SoilorderConType                  , only : soilorderconInit
+    use LakeCon                           , only : LakeConInit
+    use initVerticalMod                   , only : initVertical
+    ! !ARGUMENTS
+    implicit none
+    type(bounds_type), intent(in) :: bounds_proc
+    ! LOCAL VARIABLES
+    integer               :: c,i,g,j,k,l,p! indices
+    integer               :: begp, endp
+    integer               :: begc, endc
+    integer               :: begl, endl
+    integer               :: closelatidx,closelonidx
+    real(r8)              :: closelat,closelon
+    real(r8), allocatable :: h2osno_col(:)
+    real(r8), allocatable :: snow_depth_col(:)
+    character(len=256)    :: locfn        ! local file name
+
+
+    ! Note: h2osno_col and snow_depth_col are initialized as local variable
+    ! since they are needed to initialize vertical data structures
+    begp = bounds_proc%begp; endp = bounds_proc%endp
+    begc = bounds_proc%begc; endc = bounds_proc%endc
+    begl = bounds_proc%begl; endl = bounds_proc%endl
+
+    allocate (h2osno_col(begc:endc))
+    allocate (snow_depth_col(begc:endc))
+
+    ! snow water
+    ! Note: Glacier_mec columns are initialized with half the maximum snow cover.
+    ! This gives more realistic values of qflx_glcice sooner in the simulation
+    ! for columns with net ablation, at the cost of delaying ice formation
+    ! in columns with net accumulation.
+    do c = begc,endc
+       l = col%landunit(c)
+       g = col%gridcell(c)
+
+       if (lun%itype(l)==istice) then
+          h2osno_col(c) = h2osno_max
+       elseif (lun%itype(l)==istice_mec .or. &
+              (lun%itype(l)==istsoil .and. ldomain%glcmask(g) > 0._r8)) then
+          ! Initialize a non-zero snow thickness where the ice sheet can/potentially operate.
+          ! Using glcmask to capture all potential vegetated points around GrIS (ideally
+          ! we would use icemask from CISM, but that isn't available until after initialization.)
+          h2osno_col(c) = 1.0_r8 * h2osno_max   ! start with full snow column so +SMB can begin immediately
+       else
+          h2osno_col(c) = 0._r8
+       endif
+       snow_depth_col(c)  = h2osno_col(c) / bdsno
+    end do
+
+   ! Initialize urban constants
+
+    call urbanparams_vars%Init(bounds_proc)
+
+    ! Initialize ecophys constants
+
+    call ecophysconInit()
+    if (use_ed) then
+       call EDecophysconInit( EDpftvarcon_Inst, numpft)
+    end if
+
+    ! Initialize soil order related constants
+
+    call soilorderconInit()
+
+    ! Initialize lake constants
+
+    call LakeConInit()
+
+    ! Initialize surface albedo constants
+
+    call SurfaceAlbedoInitTimeConst(bounds_proc)
+
+    ! Initialize vertical data components
+
+    call initVertical(bounds_proc,               &
+         snow_depth_col(begc:endc),              &
+         urbanparams_vars%thick_wall(begl:endl), &
+         urbanparams_vars%thick_roof(begl:endl))
+
+    ! Initialize clm->drv and drv->clm data structures
+
+    call atm2lnd_vars%Init( bounds_proc )
+    call lnd2atm_vars%Init( bounds_proc )
+
+    ! Initialize glc2lnd and lnd2glc even if running without create_glacier_mec_landunit,
+    ! because at least some variables (such as the icemask) are referred to in code that
+    ! is executed even when running without glc_mec.
+    call glc2lnd_vars%Init( bounds_proc )
+    call lnd2glc_vars%Init( bounds_proc )
+
+    ! If single-column determine closest latitude and longitude
+
+    if (single_column) then
+       call getfil (fsurdat, locfn, 0)
+       call shr_scam_getCloseLatLon(locfn, scmlat, scmlon, &
+            closelat, closelon, closelatidx, closelonidx)
+    end if
+
+    ! Initialization of public data types
+
+    call temperature_vars%init(bounds_proc,      &
+         urbanparams_vars%em_roof(begl:endl),    &
+         urbanparams_vars%em_wall(begl:endl),    &
+         urbanparams_vars%em_improad(begl:endl), &
+         urbanparams_vars%em_perroad(begl:endl))
+
+    call canopystate_vars%init(bounds_proc)
+
+    call soilstate_vars%init(bounds_proc)
+
+    call waterstate_vars%init(bounds_proc,         &
+         h2osno_col(begc:endc),                    &
+         snow_depth_col(begc:endc),                &
+         soilstate_vars%watsat_col(begc:endc, 1:), &
+         temperature_vars%t_soisno_col(begc:endc, -nlevsno+1:) )
+
+
+    call waterflux_vars%init(bounds_proc)
+
+    call chemstate_vars%Init(bounds_proc)
+    ! WJS (6-24-14): Without the following write statement, the assertion in
+    ! energyflux_vars%init fails with pgi 13.9 on yellowstone. So for now, I'm leaving
+    ! this write statement in place as a workaround for this problem.
+    call energyflux_vars%init(bounds_proc, temperature_vars%t_grnd_col(begc:endc))
+
+    call aerosol_vars%Init(bounds_proc)
+
+    call frictionvel_vars%Init(bounds_proc)
+
+    call lakestate_vars%Init(bounds_proc)
+
+    call photosyns_vars%Init(bounds_proc)
+
+    call soilhydrology_vars%Init(bounds_proc, nlfilename)
+
+    call solarabs_vars%Init(bounds_proc)
+
+    call surfalb_vars%Init(bounds_proc)
+
+    call surfrad_vars%Init(bounds_proc)
+
+    call dust_vars%Init(bounds_proc)
+
+    call glc_diagnostics_vars%Init(bounds_proc)
+
+    ! Once namelist options are added to control the soil water retention curve method,
+    ! we'll need to either pass the namelist file as an argument to this routine, or pass
+    ! the namelist value itself (if the namelist is read elsewhere).
+    allocate(soil_water_retention_curve, &
+         source=create_soil_water_retention_curve())
+
+
+    ! Note - always initialize the memory for ch4_vars
+    call ch4_vars%Init(bounds_proc, soilstate_vars%cellorg_col(begc:endc, 1:))
+
+    ! Note - always initialize the memory for cnstate_vars (used in biogeophys/)
+    call cnstate_vars%Init(bounds_proc)
+    ! --------------------------------------------------------------
+    ! Initialise the BeTR
+    ! --------------------------------------------------------------
+
+    deallocate (h2osno_col)
+    deallocate (snow_depth_col)
+
+    end subroutine clm_inst_biogeophys
+
+
+end module clm_instMod
+


### PR DESCRIPTION
This separates the variable declarion from clm_initializeMod into
clm_instMod to avoid circular dependence which would arise with
the revised BeTR.

[BFB]
