### PR TITLE
Updates the ALM's timestepping message in the logfile

### DIFF
--- a/components/clm/src/utils/clm_time_manager.F90
+++ b/components/clm/src/utils/clm_time_manager.F90
@@ -26,6 +26,7 @@ module clm_time_manager
         get_rad_step_size,        &! return radiation step size in seconds
         get_nstep,                &! return timestep number
         get_curr_date,            &! return date components at end of current timestep
+        get_curr_time_string,     &! return current time
         get_prev_date,            &! return date components at beginning of current timestep
         get_start_date,           &! return components of the start date
         get_driver_start_ymd,     &! return year/month/day (as integer in YYYYMMDD format) of driver start date
@@ -953,6 +954,27 @@ contains
     call chkrc(rc, sub//': error return from ESMF_TimeGet')
 
   end subroutine get_curr_date
+
+  !=========================================================================================
+
+  subroutine get_curr_time_string(dateTimeString)
+
+    !-----------------------------------------------------------------------------------------
+    ! Returns the current time
+    character(len=*), intent(out) :: dateTimeString
+
+    type(ESMF_Time) :: date
+    integer :: rc
+    character(len=*), parameter :: sub = 'clm::get_curr_time_string'
+    !-----------------------------------------------------------------------------------------
+
+    call ESMF_ClockGet( tm_clock, currTime=date, rc=rc )
+    call chkrc(rc, sub//': error return from ESMF_ClockGet')
+
+    call ESMF_TimeGet(date, timeString=dateTimeString, rc=rc)
+    call chkrc(rc, sub//': error return from ESMF_TimeGet')
+
+  end subroutine get_curr_time_string
 
   !=========================================================================================
 


### PR DESCRIPTION
In order to debug which component causes the failure of the
coupled, the land model now outputs information at the
start and end of a timestep.

Issue: #743 

[BFB]
