### PR TITLE
Fix a bug in the FC5AV1C-01 compset

### DIFF
--- a/components/cam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/cam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -159,7 +159,7 @@ contains
      inv_ndx_cnst_o3 = get_inv_ndx( 'cnst_O3' ) ! prescribed O3 oxidant field
      inv_ndx_m       = get_inv_ndx( 'M' )        ! airmass.  Elsewhere this variable is known as m_ndx
      
-     if ( chem_name == 'linoz_mam3'.or.chem_name == 'linoz_mam4_resus'.or.chem_name == 'linoz_mam4_resus_mom' ) then
+     if ( chem_name == 'linoz_mam3'.or.chem_name == 'linoz_mam4_resus'.or.chem_name == 'linoz_mam4_resus_mom'.or.chem_name == 'linoz_mam4_resus_mom_soag' ) then
        if ( inv_ndx_cnst_o3 < 1 ) then
           call endrun('ERROR: chem_name = '//trim(chem_name)//' requies cnst_O3 fixed oxidant field. Use cnst_O3:O3 in namelist tracer_cnst_specifier')
        end if
@@ -483,7 +483,7 @@ contains
     !-----------------------------------------------------------------------      
     !        ... set tropospheric ozone for Linoz_MAM  (pjc, 2015)
     !-----------------------------------------------------------------------
-    if ( chem_name == 'linoz_mam3'.or.chem_name == 'linoz_mam4_resus'.or.chem_name == 'linoz_mam4_resus_mom' ) then
+    if ( chem_name == 'linoz_mam3'.or.chem_name == 'linoz_mam4_resus'.or.chem_name == 'linoz_mam4_resus_mom' .or.chem_name == 'linoz_mam4_resus_mom_soag') then
 !     write(iulog,*) 'Set tropospheric ozone for linoz_mam: inv_ndx_cnst_o3 =',inv_ndx_cnst_o3
       do k = 1, pver                !Following loop logic from below.  However, reordering loops can get rid of IF statement.
          do i = 1, ncol
@@ -735,7 +735,7 @@ contains
     enddo
 
     if ( has_linoz_data .and. .not. &
-       (chem_name == 'linoz_mam3'.or.chem_name == 'linoz_mam4_resus'.or.chem_name == 'linoz_mam4_resus_mom') ) then
+       (chem_name == 'linoz_mam3'.or.chem_name == 'linoz_mam4_resus'.or.chem_name == 'linoz_mam4_resus_mom'.or.chem_name == 'linoz_mam4_resus_mom_soag') ) then
        ltrop_sol(:ncol) = troplev(:ncol)
     else
        ltrop_sol(:ncol) = 0 ! apply solver to all levels


### PR DESCRIPTION
This PR fixes a bug in the FCAV1C-01 compset by adding
missing 'linoz_mam4_resus_mom_soag' chem pkg statements in a few if
conditions.

[BFB]
[FCC]
