### PR TITLE
Fix PMT and PET tests to run once

### DIFF
--- a/cime/scripts/Testing/Testcases/PET_build.csh
+++ b/cime/scripts/Testing/Testcases/PET_build.csh
@@ -61,7 +61,8 @@ cp -f env_mach_pes.xml env_mach_pes.xml.1
 
 # Since possibly changed the PE layout as above - must run cesm_setup -clean WITHOUT the -testmode flag
 # in order for the $CASE.test script to be regenerated with the correct batch processor settings
-./cesm_setup -clean 
+./cesm_setup -clean
+rm *.testdriver # ./cesm_setup will regenerate, instead of appending to the existing testdriver
 ./cesm_setup 
 
 ./$CASE.build

--- a/cime/scripts/Testing/Testcases/PMT_build.csh
+++ b/cime/scripts/Testing/Testcases/PMT_build.csh
@@ -115,13 +115,10 @@ if ($NTHRDS_WAV == 1) then
 endif
 
 # Build with half the tasks and double the threads
-./cesm_setup -clean -testmode
-./cesm_setup
-./xmlchange -file env_build.xml -id SMP_BUILD -val 0
-
 ./cesm_setup -clean
+rm *.testdriver # ./cesm_setup appends, so remove the existing testdriver
 ./cesm_setup
-./$CASE.clean_build -all 
+./$CASE.clean_build all
 
 ./$CASE.build
 if ($status != 0) then


### PR DESCRIPTION
The testdriver script is generated by cesm_setup, which appends
instead of overwriting an existing testdriver. This avoids
duplication.

[BFB] - Bit-For-Bit
