### PR TITLE
Redefine atm part of WCYCL and CRYO compsets

### DIFF
--- a/cime/scripts/Tools/config_compsets.xml
+++ b/cime/scripts/Tools/config_compsets.xml
@@ -77,11 +77,11 @@ value of RUN_STARTDATE will be date2.
 <!-- ================================================================================== -->
 
 <!-- ACME v1 science compsets -->
-<COMPSET sname="ACME_WCYCL2000"                alias="A_WCYCL2000" >2000_CAM5%AV1C_CLM45%SPBC_MPASCICE%SSMI_MPASO_MOSART_SGLC_SWAV</COMPSET>
-<COMPSET sname="ACME_WCYCL1850"                alias="A_WCYCL1850" >1850_CAM5%AV1C_CLM45%SPBC_MPASCICE%SSMI_MPASO_MOSART_SGLC_SWAV</COMPSET>
-<COMPSET sname="ACME_WCYCL20TR"                alias="A_WCYCL20TR" >20TR_CAM5%AV1C_CLM45%SPBC_MPASCICE%SSMI_MPASO_MOSART_SGLC_SWAV</COMPSET>
+<COMPSET sname="ACME_WCYCL2000"                alias="A_WCYCL2000" >2000_CAM5%AV1C-L_CLM45%SPBC_MPASCICE%SSMI_MPASO_MOSART_SGLC_SWAV</COMPSET>
+<COMPSET sname="ACME_WCYCL1850"                alias="A_WCYCL1850" >1850_CAM5%AV1C-L_CLM45%SPBC_MPASCICE%SSMI_MPASO_MOSART_SGLC_SWAV</COMPSET>
+<COMPSET sname="ACME_WCYCL20TR"                alias="A_WCYCL20TR" >20TR_CAM5%AV1C-L_CLM45%SPBC_MPASCICE%SSMI_MPASO_MOSART_SGLC_SWAV</COMPSET>
 
-<COMPSET sname="ACME_CRYO"                alias="A_CRYO" >2000_CAM5%AV1C_CLM45%SPBC_MPASCICE%SSMI_MPASO_RTM_MPASLIALB_SWAV</COMPSET>
+<COMPSET sname="ACME_CRYO"                alias="A_CRYO" >2000_CAM5%AV1C-L_CLM45%SPBC_MPASCICE%SSMI_MPASO_RTM_MPASLIALB_SWAV</COMPSET>
 
 
 <!-- compset A assumes an rx1 grid -->
@@ -232,6 +232,7 @@ value of RUN_STARTDATE will be date2.
 <COMPSET sname="F_2000_CAM5_AV1C"           alias="FC5AV1C"         >2000_CAM5%AV1C_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_AV1C-00"       alias="FC5AV1C-00"     >2000_CAM5%AV1C-00_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_AV1C-01"       alias="FC5AV1C-01"     >2000_CAM5%AV1C-01_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
+<COMPSET sname="F_2000_CAM5_AV1C-L"        alias="FC5AV1C-L"     >2000_CAM5%AV1C-L_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_AV1F"           alias="FC5AV1F"         >2000_CAM5%AV1F_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_AV1F-00"       alias="FC5AV1F-00"     >2000_CAM5%AV1F-00_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
 <COMPSET sname="F_2000_CAM5_AV1F-01"       alias="FC5AV1F-01"     >2000_CAM5%AV1F-01_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</COMPSET>
@@ -640,6 +641,7 @@ GEOS => GEOS5 meteorology for "stand-alone" CAM
 <CAM_CONFIG_OPTS compset="_CAM5%AV1C"     >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom -rain_evap_to_coarse_aero -nlev 72</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%AV1C-00"     >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom -rain_evap_to_coarse_aero -nlev 72</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%AV1C-01"   >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</CAM_CONFIG_OPTS>
+<CAM_CONFIG_OPTS compset="_CAM5%AV1C-L"   >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%AV1F"     >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%AV1F-00"     >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</CAM_CONFIG_OPTS>
 <CAM_CONFIG_OPTS compset="_CAM5%AV1F-01"   >-clubb_sgs -microphys mg2 -chem trop_mam4_resus_soag -rain_evap_to_coarse_aero -nlev 72</CAM_CONFIG_OPTS>
@@ -735,6 +737,7 @@ GEOS => GEOS5 meteorology for "stand-alone" CAM
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1C"  >2000_cam5_av1c</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-00">2000_cam5_av1c-00</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-01">2000_cam5_av1c-01</CAM_NML_USE_CASE>
+<CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-L">2000_cam5_av1c-01</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1F"  >2000_cam5_av1f</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1F-00">2000_cam5_av1f-00</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1F-01">2000_cam5_av1f-01</CAM_NML_USE_CASE>


### PR DESCRIPTION
Change atm part of WCYCL and CRYO compsets to use
CAM5%AV1C-L instead of CAM5%AV1C.  AV1C-L is the "latest"
version of the AV1C configuration that should be used in ACME coupled cases.

In this commit, AV1C-L = AV1C-01

Also define an FC5AV1C-L compset.

[CC] for WCYCL and CRYO compsets
