### PR TITLE
Handle times better in nightly testing infrastructure.

### DIFF
--- a/cime/scripts-acme/jenkins_generic_job
+++ b/cime/scripts-acme/jenkins_generic_job
@@ -11,7 +11,7 @@ import acme_util
 acme_util.check_minimum_python_version(2, 7)
 import wait_for_tests
 
-import argparse, sys, os, shutil, glob, doctest, time, signal
+import argparse, sys, os, shutil, glob, doctest, signal
 
 from acme_util import expect, warning, verbose_print
 
@@ -112,8 +112,6 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
     """
     Return True if all tests passed
     """
-    start_time = time.time()
-
     use_batch = acme_util.does_machine_have_batch()
     compilers, test_suite, scratch_root, proxy = \
         acme_util.get_machine_info(["COMPILERS", "TESTS", "CESMSCRATCHROOT", "PROXY"])
@@ -237,8 +235,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
                                                      False, # don't ignore namelist diffs
                                                      cdash_build_name,
                                                      cdash_project,
-                                                     cdash_build_group,
-                                                     start_time)
+                                                     cdash_build_group)
         if (not tests_passed and use_batch and wait_for_tests.SIGNAL_RECEIVED):
             # Cleanup
             cleanup_queue(our_jobs)

--- a/cime/scripts-acme/jenkins_script
+++ b/cime/scripts-acme/jenkins_script
@@ -9,6 +9,7 @@
 
 SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
 DATE_STAMP=$(date "+%Y-%m-%d_%H%M%S")
+export JENKINS_START_TIME=$(date "+%s")
 
 $SCRIPT_DIR/jenkins_generic_job "$@" >& JENKINS_$DATE_STAMP
 

--- a/cime/scripts-acme/wait_for_tests.py
+++ b/cime/scripts-acme/wait_for_tests.py
@@ -58,7 +58,7 @@ def get_test_output(test_path):
         return ""
 
 ###############################################################################
-def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, start_time, hostname):
+def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname):
 ###############################################################################
     git_commit = acme_util.get_current_commit(repo=acme_util.get_cime_root())
 
@@ -66,20 +66,25 @@ def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time
 
     site_elem = xmlet.Element("Site")
 
+    if ("JENKINS_START_TIME" in os.environ):
+        time_info_str = "Total testing time: %d seconds" % (current_time - int(os.environ["JENKINS_START_TIME"]))
+    else:
+        time_info_str = ""
+
     site_elem.attrib["BuildName"] = cdash_build_name
     site_elem.attrib["BuildStamp"] = "%s-%s" % (utc_time, cdash_build_group)
     site_elem.attrib["Name"] = hostname
     site_elem.attrib["OSName"] = "Linux"
     site_elem.attrib["Hostname"] = hostname
-    site_elem.attrib["OSVersion"] = "Commit: %s, Total testing time: %d seconds" % (git_commit, time.time() - start_time)
+    site_elem.attrib["OSVersion"] = "Commit: %s%s" % (git_commit, time_info_str)
 
     testing_elem = xmlet.SubElement(site_elem, "Testing")
 
     start_date_time_elem = xmlet.SubElement(testing_elem, "StartDateTime")
-    start_date_time_elem.text = time.ctime(start_time)
+    start_date_time_elem.text = time.ctime(current_time)
 
     start_test_time_elem = xmlet.SubElement(testing_elem, "StartTestTime")
-    start_test_time_elem.text = str(int(start_time))
+    start_test_time_elem.text = str(int(current_time))
 
     test_list_elem = xmlet.SubElement(testing_elem, "TestList")
     for test_name in sorted(results):
@@ -202,18 +207,16 @@ r"""<?xml version="1.0" encoding="UTF-8"?>
             shutil.rmtree(log_dir)
 
 ###############################################################################
-def create_cdash_xml(results, cdash_build_name, cdash_project, cdash_build_group, start_time):
+def create_cdash_xml(results, cdash_build_name, cdash_project, cdash_build_group):
 ###############################################################################
 
     #
     # Create dart config file
     #
 
-    if (start_time is None):
-        warning("No valid start_time provided, using current time instead")
-        start_time = time.time()
+    current_time = time.time()
 
-    utc_time_tuple = time.gmtime(start_time)
+    utc_time_tuple = time.gmtime(current_time)
     cdash_timestamp = time.strftime("%H:%M:%S", utc_time_tuple)
 
     hostname = acme_util.probe_machine_name()
@@ -260,7 +263,7 @@ NightlyStartTime: %s UTC
     with open("Testing/TAG", "w") as tag_fd:
         tag_fd.write("%s\n%s\n" % (utc_time, cdash_build_group))
 
-    create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, start_time, hostname)
+    create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname)
 
     create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_time, hostname)
 
@@ -436,8 +439,7 @@ def wait_for_tests(test_paths,
                    ignore_namelists=False,
                    cdash_build_name=None,
                    cdash_project=ACME_MAIN_CDASH,
-                   cdash_build_group=CDASH_DEFAULT_BUILD_GROUP,
-                   start_time=None):
+                   cdash_build_group=CDASH_DEFAULT_BUILD_GROUP):
 ###############################################################################
     # Set up signal handling, we want to print results before the program
     # is terminated
@@ -453,6 +455,6 @@ def wait_for_tests(test_paths,
         all_pass &= test_status == TEST_PASS_STATUS
 
     if (cdash_build_name):
-        create_cdash_xml(test_results, cdash_build_name, cdash_project, cdash_build_group, start_time)
+        create_cdash_xml(test_results, cdash_build_name, cdash_project, cdash_build_group)
 
     return all_pass


### PR DESCRIPTION
On some machines, the time gap between when tests started and when
they finished was so long that CTest was getting confused during
the submit phase and ignoring the results we wanted to submit.

This commit changes the timestamp of the results from the time tests
start to the time when they finish. It also leverages a new environment
variable in jenkins_script to provide a much more accurate estimate of
the total time spent in the test.

[BFB]
