### PR TITLE
Let HOMME acme_dev tests run in generate mode by default

### DIFF
--- a/cime/scripts/Testing/Testcases/HOMME_script
+++ b/cime/scripts/Testing/Testcases/HOMME_script
@@ -18,8 +18,7 @@ if ($GEN == "TRUE") then
 else if ($COMP == "TRUE") then
    make -j 4 check  >& $LOG || exit -1
 else
-   echo "HOMME tests current must compare or generate" >& $LOG
-   exit -1
+   make -j 4 baseline >& $LOG || exit -1
 endif
 
 cd -


### PR DESCRIPTION
Previously, the tests were exiting when neither `-g` nor `-c` (generate/compare) option was provided.

[BFB] - Bit-For-Bit
