### PR TITLE
Fix a bug to enable BC/dust deposition on snow/ice with marine organics

### DIFF
--- a/components/cam/src/chemistry/utils/modal_aero_deposition.F90
+++ b/components/cam/src/chemistry/utils/modal_aero_deposition.F90
@@ -136,7 +136,7 @@ subroutine modal_aero_deposition_init(bc1_ndx,pom1_ndx,soa1_ndx,soa2_ndx,dst1_nd
    ! is needed for MAM7 prognostic fluxes to be active
    bin_fluxes = .true.  
 
-#ifdef MODAL_AERO_7MODE
+#if( (defined MODAL_AERO_7MODE) || (defined MODAL_AERO_9MODE) )
       ! assign additional indices for MAM7 species:
       call cnst_get_ind('bc_a3',  idx_bc3)
       call cnst_get_ind('pom_a3', idx_pom3)
@@ -273,7 +273,7 @@ subroutine set_srf_wetdep(aerdepwetis, aerdepwetcw, cam_out)
 
 #endif
 
-#ifdef MODAL_AERO_7MODE
+#if( (defined MODAL_AERO_7MODE) || (defined MODAL_AERO_9MODE) )
       ! MAM7
       
       ! in SNICAR+MAM, bcphiwet represents BC mixed internally within hydrometeors
@@ -486,7 +486,7 @@ subroutine set_srf_drydep(aerdepdryis, aerdepdrycw, cam_out)
 #endif
 
 
-#ifdef MODAL_AERO_7MODE
+#if( (defined MODAL_AERO_7MODE) || (defined MODAL_AERO_9MODE) )
       ! MAM7
 
       ! in SNICAR+MAM, bcphodry represents BC mixed external to hydrometeors


### PR DESCRIPTION
The new marine organic aerosol chemistry option is enabled with a new
preprocessor directive, and the new treatment of BC deposition to
ice/snow uses chemistry preprocessor directives to determine which
scheme to use.  The preprocessor directive enabling the marine organic
aerosol option, MODAL_AERO_4MODE_MOM, was missing from the code, such
that BC/dust deposition to ice would not be treated in simulations
with marine organic aerosol enabled.  This commit adds the
pre-processor directive so that they will both be active at the same
time.

[CC] for configurations that enable both marine organics and BC/dust
deposition in snow/ice, including the FC5AV1C, WCYCL, and CRYO
compsets.
