### PR TITLE
Fix bug in seasalt_model tracer loop

### DIFF
--- a/components/cam/src/chemistry/modal_aero/seasalt_model.F90
+++ b/components/cam/src/chemistry/modal_aero/seasalt_model.F90
@@ -596,6 +596,8 @@ end subroutine ocean_data_readnl
        endif
        enddo section_loop_sslt_mass
 
+enddo tracer_loop
+
 #if ( defined MODAL_AERO_9MODE || defined MODAL_AERO_4MODE_MOM )
 
 add_om_species: if ( has_mam_mom ) then
@@ -645,10 +647,6 @@ add_om_species: if ( has_mam_mom ) then
        end if
        m = om_num_ind(m_om)
        mn=seasalt_indices(nslt+nslt_om+m)
-
-       if (m > nslt) then
-          cflx(:ncol,mn)=0.0_r8
-       end if
 
           ! add number tracers for organics-only modes
           if (emit_this_mode(m_om)) then
@@ -733,8 +731,6 @@ add_om_species: if ( has_mam_mom ) then
 
  end if add_om_species
 #endif
-
-  enddo tracer_loop
 
   end subroutine seasalt_emis
 


### PR DESCRIPTION
Fix a bug in the seasalt_model tracer loop.  A do-loop was ended in
the wrong place, resulting in an unintended multiple-counting of
emitted sea spray number added by internally-mixed marine organic
matter.

Additionally, when externally-mixed marine sea spray emissions were
used, the POM emission flux was first reset to zero within this
module, which it should not have been.

[CC] - Climate Changing for compsets that use marine organics code
       (includes ATMMOD, ATMMODCOSP, WCYCL, and FC5AV1C compsets).
