### PR TITLE
Change to have clubb tunable parameters vary in sync via namelist

### DIFF
--- a/components/cam/src/physics/clubb/parameters_tunable.F90
+++ b/components/cam/src/physics/clubb/parameters_tunable.F90
@@ -808,7 +808,7 @@ module parameters_tunable
     if (clubb_C2rt /= init_value) then
        C2rt = clubb_C2rt
        C2thl = C2rt
-       C2rtthl = C2rt*1.3_r8
+        C2rtthl = C2rt*1.3_core_rknd
     end if
     if (clubb_C6rt /= init_value) then
        C6rt = clubb_C6rt


### PR DESCRIPTION
A number of clubb tunable parameters are suggested to vary in sync
with those controlled via namelist. The parameters to be synchronized are

```
 gamma_coefb = gamma_coef
 c2thl = c2rt
 c2rtthl = 1.3_r8*c2rt
 c1b = c1
 c6thl = c6rt

With those on the right hand side specified via namelist using prefix 'clubb_'
```

Since c2thl and c2rtthl now also vary with c2rt, this PR is:
[CC] for FC5AV1C-01 and derivatives (e.g., FC5AV1C-L, WCYCL) according to testing by Po-Lun Ma,, and for FC5AV1F-01
