### PR TITLE
Keep MPAS-O and MPAS-CICE single-threaded in PET and PMT tests

### DIFF
--- a/cime/scripts/Testing/Testcases/PET_build.csh
+++ b/cime/scripts/Testing/Testcases/PET_build.csh
@@ -36,14 +36,14 @@ if ( $NTHRDS_ROF <= 1) then
   echo "WARNING: component ROF is not threaded, changing NTHRDS_ROF to 2" 
   ./xmlchange -file env_mach_pes.xml -id NTHRDS_ROF -val 2
 endif
-if ( $NTHRDS_ICE <= 1) then
-  echo "WARNING: component ICE is not threaded, changing NTHRDS_ICE to 2" 
-  ./xmlchange -file env_mach_pes.xml -id NTHRDS_ICE -val 2
-endif
-if ( $NTHRDS_OCN <= 1) then
-  echo "WARNING: component OCN is not threaded, changing NTHRDS_OCN to 2" 
-  ./xmlchange -file env_mach_pes.xml -id NTHRDS_OCN -val 2
-endif
+#if ( $NTHRDS_ICE <= 1) then
+#  echo "WARNING: component ICE is not threaded, changing NTHRDS_ICE to 2"
+#  ./xmlchange -file env_mach_pes.xml -id NTHRDS_ICE -val 2
+#endif
+#if ( $NTHRDS_OCN <= 1) then
+#  echo "WARNING: component OCN is not threaded, changing NTHRDS_OCN to 2"
+#  ./xmlchange -file env_mach_pes.xml -id NTHRDS_OCN -val 2
+#endif
 if ( $NTHRDS_GLC <= 1) then
   echo "WARNING: component GLC is not threaded, changing NTHRDS_GOC to 2" 
   ./xmlchange -file env_mach_pes.xml -id NTHRDS_GLC -val 2

--- a/cime/scripts/Testing/Testcases/PMT_build.csh
+++ b/cime/scripts/Testing/Testcases/PMT_build.csh
@@ -89,14 +89,14 @@ if ($NTHRDS_LND == 1) then
     @ nthrd = $NTHRDS_LND * 2
     ./xmlchange -file env_mach_pes.xml -id NTHRDS_LND -val $nthrd
 endif
-if ($NTHRDS_ICE == 1) then
-    @ nthrd = $NTHRDS_ICE * 2
-    ./xmlchange -file env_mach_pes.xml -id NTHRDS_ICE -val $nthrd
-endif
-if ($NTHRDS_OCN == 1) then
-    @ nthrd = $NTHRDS_OCN * 2
-    ./xmlchange -file env_mach_pes.xml -id NTHRDS_OCN -val $nthrd
-endif
+#if ($NTHRDS_ICE == 1) then
+#    @ nthrd = $NTHRDS_ICE * 2
+#    ./xmlchange -file env_mach_pes.xml -id NTHRDS_ICE -val $nthrd
+#endif
+#if ($NTHRDS_OCN == 1) then
+#    @ nthrd = $NTHRDS_OCN * 2
+#    ./xmlchange -file env_mach_pes.xml -id NTHRDS_OCN -val $nthrd
+#endif
 if ($NTHRDS_CPL == 1) then
     @ nthrd = $NTHRDS_CPL * 2
     ./xmlchange -file env_mach_pes.xml -id NTHRDS_CPL -val $nthrd


### PR DESCRIPTION
[BFB] - Bit-For-Bit
