### PR TITLE
Changes for post-cime ACME to run on LC Sierra

### DIFF
--- a/cime/machines-acme/config_batch.xml
+++ b/cime/machines-acme/config_batch.xml
@@ -106,6 +106,30 @@
     </directives>
   </batch_system>
 
+  <!-- for Sierra.llnl -->
+   <batch_system type="sierra_slurm" version="x.y">
+     <batch_query>squeue</batch_query>
+     <batch_submit>sbatch</batch_submit>
+     <batch_directive>#MSUB</batch_directive>
+     <jobid_pattern>(\d+)$</jobid_pattern>
+     <depend_string> --dependency=afterok:jobid</depend_string>
+     <submit_args>
+       <arg flag="-q" name="queue"/>
+       <arg flag="-l" name="wall_time"/>
+       <arg flag="-A" name="project"/>
+     </submit_args>
+     <directives>
+       <directive>-V</directive>
+       <directive>-q {{ queue }}</directive>
+       <directive>-N {{ job_id }}</directive>
+       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
+       <directive>-l {{ wall_time }}</directive>
+       <directive>-o {{ output_error_path }}.out</directive>
+       <directive>-e {{ output_error_path }}.err</directive>
+       <directive>-m be</directive>
+     </directives>
+   </batch_system>
+
    <batch_system type="slurm" version="x.y">
      <batch_query>squeue</batch_query>
      <batch_submit>sbatch</batch_submit>

--- a/cime/machines-acme/config_compilers.xml
+++ b/cime/machines-acme/config_compilers.xml
@@ -658,6 +658,28 @@ for mct, etc.
   <ADD_CPPFLAGS> -DHAVE_COMM_F2C </ADD_CPPFLAGS>
 </compiler>
 
+<compiler COMPILER="pgi" MACH="sierra">
+  <NETCDF_PATH>/usr/local/tools/netcdf-pgi-4.1.3</NETCDF_PATH>
+  <MPI_PATH>/usr/local/tools/mvapich2-pgi-1.7/</MPI_PATH>
+  <MPI_LIB_NAME> mpich</MPI_LIB_NAME>
+  <ADD_CPPDEFS> -DNO_SHR_VMATH -DCNL </ADD_CPPDEFS>
+  <ADD_SLIBS>$(shell /usr/local/tools/netcdf-pgi-4.1.3/bin/nc-config --flibs)</ADD_SLIBS>
+  <ADD_LDFLAGS> -Wl,-rpath /usr/local/tools/netcdf-pgi-4.1.3/lib -llapack -lblas</ADD_LDFLAGS>
+</compiler>
+
+<compiler COMPILER="intel" MACH="sierra">
+  <ADD_CFLAGS DEBUG="FALSE"> -O2 </ADD_CFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O2 </ADD_FFLAGS>
+  <NETCDF_PATH>/usr/local/tools/netcdf-intel-4.1.3</NETCDF_PATH>
+  <PNETCDF_PATH>/usr/local/tools/parallel-netcdf-intel-1.6.1</PNETCDF_PATH>
+  <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
+  <MPI_PATH>/usr/local/tools/mvapich2-intel-2.1/</MPI_PATH>
+  <MPI_LIB_NAME> mpich</MPI_LIB_NAME>
+  <ADD_CPPDEFS> -DNO_SHR_VMATH -DCNL </ADD_CPPDEFS>
+  <ADD_FFLAGS DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </ADD_FFLAGS>
+  <ADD_SLIBS>$(shell /usr/local/tools/netcdf-intel-4.1.3/bin/nc-config --flibs)</ADD_SLIBS>
+  <ADD_LDFLAGS> -llapack -lblas</ADD_LDFLAGS>
+</compiler>
 <compiler>
   <ADD_CPPDEFS MODEL="pop"> -D_USE_FLOW_CONTROL </ADD_CPPDEFS>
 </compiler>

--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -555,6 +555,46 @@
     <PES_PER_NODE>2</PES_PER_NODE>
 </machine>
 
+<machine MACH="sierra">
+         <DESC>LLNL Linux Cluster, Linux (pgi), 12 pes/node, batch system is Moab</DESC>
+         <COMPILERS>intel, pgi</COMPILERS>
+         <MPILIBS>mpich,mpi-serial</MPILIBS>
+         <RUNDIR>/p/lscratche/$CCSMUSER/ACME/$CASE/run</RUNDIR>
+         <EXEROOT>/p/lscratche/$CCSMUSER/$CASE/bld</EXEROOT>
+         <CESMSCRATCHROOT>/p/lscratche/$USER</CESMSCRATCHROOT>
+         <DIN_LOC_ROOT>/p/lscratchd/ma21/ccsm3data/inputdata</DIN_LOC_ROOT>
+         <DIN_LOC_ROOT_CLMFORC>/p/lscratchd/ma21/ccsm3data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+         <DOUT_S_ROOT>/p/lscratche/$CCSMUSER/archive/$CASE</DOUT_S_ROOT>
+         <DOUT_L_HTAR>FALSE</DOUT_L_HTAR>
+         <DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
+         <CCSM_BASELINE>/p/lscratchd/$CCSMUSER/ccsm_baselines</CCSM_BASELINE>
+         <CCSM_CPRNC>/p/lscratchd/ma21/ccsm3data/tools/cprnc/cprnc</CCSM_CPRNC>
+         <OS>LINUX</OS>
+         <BATCHQUERY>mshow</BATCHQUERY>
+         <BATCHSUBMIT>msub</BATCHSUBMIT>
+	 <BATCHREDIRECT></BATCHREDIRECT>
+         <SUPPORTED_BY>wlin -at- bnl.gov</SUPPORTED_BY>
+         <GMAKE_J>8</GMAKE_J>
+         <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
+	 <batch_system type="sierra_slurm" version="x.y">
+	   <queues>
+	     <queue jobmin="1" jobmax="9999" default="true">pbatch</queue>
+	   </queues>
+	   <walltimes>
+	     <walltime default="true">walltime=01:00:00</walltime>
+	   </walltimes>
+	 </batch_system>
+	 <mpirun mpilib="mpich">
+	   <executable>srun</executable>
+	   <arguments>
+	     <arg name="num_nodes"> -N {{ num_nodes }}</arg>
+	   </arguments>
+	 </mpirun>
+	 <mpirun mpilib="mpi-serial">
+           <executable></executable>
+	 </mpirun>
+</machine>
+
 <machine MACH="mira">
          <DESC>ANL IBM BG/Q, os is BGP, 16 pes/node, batch system is cobalt</DESC>
          <NODENAME_REGEX>mira</NODENAME_REGEX>

--- a/cime/machines-acme/env_mach_specific.sierra
+++ b/cime/machines-acme/env_mach_specific.sierra
@@ -1,10 +1,22 @@
 #! /bin/csh -f
 
 source /usr/global/tools/dotkit/init.csh
-use -q pgi-11.1
+if ( $COMPILER == "pgi") then
+use -q pgi-14.3
 use -q mvapich2-pgi-1.7
 use -q netcdf-pgi-4.1.3
 setenv NETCDF /usr/local/tools/netcdf-pgi-4.1.3/
+setenv PNETCDF_PATH /usr/local/tools/parallel-netcdf-pgi-1.6.1/
+endif
+
+if ( $COMPILER == "intel") then
+use -q intel-14.0
+use -q mvapich2-intel-2.1
+use -q netcdf-intel-4.1.3
+setenv NETCDF /usr/local/tools/netcdf-intel-4.1.3/
+setenv PNETCDF_PATH /usr/local/tools/parallel-netcdf-intel-1.6.1/
+endif
+
 if ( $?PERL ) then
   printenv
 endif


### PR DESCRIPTION
Post-Cime model cannot build on LC sierra. No working batch job script can be generated either.
Changes are made on the following files in order for post-cime model to enable.
The default compiler sets to intel.

   cime/machines-acme/config_batch.xml
   cime/machines-acme/config_compilers.xml
   cime/machines-acme/config_machines.xml
   cime/machines-acme/env_mach_specific.sierra

[BFB]
