### PR TITLE
Changed default compiler for blues to gnu

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -445,7 +445,7 @@
          <DESC>ANL/LCRC Linux Cluster</DESC>
          <NODENAME_REGEX>blogin</NODENAME_REGEX>
          <TESTS>acme_integration</TESTS>
-         <COMPILERS>pgi,intel,gnu,nag</COMPILERS>
+         <COMPILERS>gnu,pgi,intel,nag</COMPILERS>
          <MPILIBS>mvapich,mpich,openmpi,mpi-serial</MPILIBS>
          <CESMSCRATCHROOT>/lcrc/project/$PROJECT/$USER/acme_scratch</CESMSCRATCHROOT>
          <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>


### PR DESCRIPTION
Changed default compiler from pgi to gnu (gcc 5.2) for blues

[BFB]
