### PR TITLE
Updates land IC for 1850 at ne30_g16

### DIFF
--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -146,9 +146,8 @@ ic_tod="0" sim_year="1850"  glc_nec="0" use_crop=".false." >lnd/clm2/initdata_ma
 <!-- HOMME grid ne30 resolution -->
 
 <!-- Initial condition file with CLM45BGC -->
-<!-- Note that we use a BGC initial file even for SP cases (since we haven't bothered to make an SP version at this resolution -->
 <finidat hgrid="ne30np4"   maxpft="17"  mask="gx1v6" use_cn=".false." ic_ymd="18500101" more_vertlayers=".false."
-ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.I1850CRUCLM45BGC.0241-01-01.ne30np4_g1v6_simyr1850_c140111.nc
+ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.I1850CLM45.ne30_g16.e61c667.clm2.r.0021-01-01-00000.nc
 </finidat>
 
 <!-- Initial condition file with CLM45BGC (also works for no-cent, Vertical layers and Nitrification/Denitrification NEED to be on) -->


### PR DESCRIPTION
The default land IC for 1850 at ne30_g16 is now
obtained from a 20-year I1850CLM45 simulation.

[NML]
[non-BFB]
