### PR TITLE
Add -no-opt-dynamic-align to Cori Intel FFlags

### DIFF
--- a/cime/machines-acme/config_compilers.xml
+++ b/cime/machines-acme/config_compilers.xml
@@ -562,7 +562,7 @@ for mct, etc.
 </compiler>
 
 <compiler COMPILER="intel" MACH="corip1">
-  <ADD_FFLAGS DEBUG="FALSE"> -O2  </ADD_FFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O2 -no-opt-dynamic-align </ADD_FFLAGS>
   <ADD_CFLAGS DEBUG="FALSE"> -O2  </ADD_CFLAGS>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <ADD_SLIBS> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </ADD_SLIBS>


### PR DESCRIPTION
Enforce same code to be executed regardless of data alignment with
-no-opt-dynamic-align. By default, the compiler may generate multiple
code paths to execute depending on the alignment of data in order to
improve performance which may affect the consistency of floating-point
calculations. To disable this behavior, use -no-opt-dynamic-align.

This fixes ERS tests that were previously failing on Cori:
- ERS_Ld7.ne30_oEC.A_WCYCL2000.corip1_intel: issue #774 
- ERS_Ld5.T62_oQU120.C_MPAS_NORMAL_YEAR.corip1_intel: part of acme_developer tests that never worked on Cori

Fixes #774
