### PR TITLE
Remove PEA_P1_M.f45_g37_rx1.A from acme_dev tests

### DIFF
--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -75,7 +75,6 @@ _TEST_SUITES = {
                          ("ERP_Ln9.ne30_ne30.FC5", "cam-outfrq9s"),
                          "HOMME_P24.f19_g16_rx1.A",
                          "NCK.f19_g16_rx1.A",
-                         "PEA_P1_M.f45_g37_rx1.A",
                          "SMS.ne30_f19_g16_rx1.A",
                          "ERS_Ld5.T62_oQU120.C_MPAS_NORMAL_YEAR",
                          "ERS.f09_g16_g.MPASLI_ONLY",


### PR DESCRIPTION
This test performs single pe bfb test between a run with
mpi and a run with mpiserial. The mpiserial library is not 
supported yet on production machines (Mira, Titan). So
removing this test from the acme_developer test suite.

[BFB]
