### PR TITLE
Correct MPI shorthand error for trigmem in zm_conv.F90

### DIFF
--- a/components/cam/src/physics/cam/zm_conv.F90
+++ b/components/cam/src/physics/cam/zm_conv.F90
@@ -137,7 +137,7 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(ke,                1, mpir8,  0, mpicom)
    call mpibcast(tau,               1, mpir8,  0, mpicom)
    call mpibcast(dmpdz,             1, mpir8,  0, mpicom)
-   call mpibcast(trigmem,           1, mpir8,  0, mpicom)
+   call mpibcast(trigmem,           1, mpilog, 0, mpicom)
 #endif
 
 end subroutine zmconv_readnl


### PR DESCRIPTION
trigmem is a logical variable but the "call mpibroadcast" line used "mpir8". Changed to "mpilog" in this commit. Test runs were performed using PGI and Intel on Titan. Code after bug fix produced BFB results.

[BFB]
