### PR TITLE
Fix CAM build-namelist by excluding variables not required in RK MP

### DIFF
--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -3392,9 +3392,9 @@ if ($cfg->get('microphys') =~ /^mg/) {
     add_default($nl, 'cld_macmic_num_steps');
     add_default($nl, 'micro_mg_precip_frac_method');
     add_default($nl, 'micro_mg_berg_eff_factor');
+    add_default($nl, 'micro_mg_dcs');
+    add_default($nl, 'ice_sed_ai');
 }
-add_default($nl, 'micro_mg_dcs');
-add_default($nl, 'ice_sed_ai');
 
 # Sub-column switches for physics packages
 # Check that a subcol_scheme is specified if use_subcol_microp is turned on (true)


### PR DESCRIPTION
The code crashes in build-namelist if run using BM1850CN compset.
This compset uses RK microphysics (MP) for which micro_mg_dcs is not
defined. build-namelist script tries to add this variable to the
namelist and crashes as this variable is not defined for RK
microphyics. This PR moves this variable (along with ice_sed_ai)
to an "mg" microphysics if block so that they are not added to the
namelist when RK microphysics is selected.

Fixes #887
[BFB]
