### PR TITLE
Completion of F1850C5AV1C-03 Compset

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-03.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-03.xml
@@ -61,9 +61,9 @@
 <zmconv_dmpdz>      -0.75e-3</zmconv_dmpdz>
 <zmconv_ke>          0.5E-6 </zmconv_ke>
 <effgw_oro>          0.25   </effgw_oro>
-<seasalt_emis_scale> 0.87   </seasalt_emis_scale>
+<seasalt_emis_scale> 1.05   </seasalt_emis_scale>
 <dust_emis_fact>     2.05D0 </dust_emis_fact>
-<clubb_gamma_coef>   0.25   </clubb_gamma_coef>
+<clubb_gamma_coef>   0.29   </clubb_gamma_coef>
 <clubb_C8>           5.2    </clubb_C8>
 <cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
 <clubb_c_K10>        0.3    </clubb_c_K10>


### PR DESCRIPTION
The PR (#889) for F1850C5AV1C-03 was pushed to master before the configuration had been finalized.  This commit implements the changes for the chosen configuration (vc10):

clubb_gamma_coef   = 0.29
seasalt_emis_scale = 1.05

[NML]  [AG-435]

WARNING (bug found after this PR was pushed to master):  clubb_gamma_coef was accidentally specified twice in the use_case file (1850_cam5_av1c-03.xml), and the wrong number (0.32) ended up in atm_in. Now provides the correct value (0.29).  This is fixed in PR #896.
