### PR TITLE
Bug fix to F1850C5AV1C-03  (error in clubb_gamma_coef value)

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-03.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-03.xml
@@ -55,7 +55,6 @@
 <clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
 <clubb_liq_sh>       10.e-6 </clubb_liq_sh>
 <clubb_C2rt>         1.75D0 </clubb_C2rt>
-<clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <zmconv_c0_lnd>      0.007  </zmconv_c0_lnd>
 <zmconv_c0_ocn>      0.007  </zmconv_c0_ocn>
 <zmconv_dmpdz>      -0.75e-3</zmconv_dmpdz>


### PR DESCRIPTION
clubb_gamma_coef was accidentally specified twice in the use_case file (1850_cam5_av1c-03.xml), and the wrong number (0.32) ended up in atm_in. Now provides the correct value (0.29)

[NML] [BFB unless using F1850C5AV1C-03]  AG-435
