### PR TITLE
Add more script support for the mosart 1/8-degree grid.

### DIFF
--- a/cime/scripts/Tools/config_grid.xml
+++ b/cime/scripts/Tools/config_grid.xml
@@ -428,6 +428,11 @@ do not use scientific experiments; use the T62_g16 resolution instead:
   <desc>r05 is 1/2 degree river routing grid:</desc>
 </gridhorz>
 
+<gridhorz name="r0125">
+  <nx>2880</nx> <ny>1440</ny>  
+  <desc>r0125 is 1/8 degree river routing grid:</desc>
+</gridhorz>
+
 <gridhorz name="r01">
   <support_level>For experimental use by high resolution grids</support_level>
   <nx>3600</nx> <ny>1800</ny> 

--- a/components/mosart/bld/mosart.buildnml
+++ b/components/mosart/bld/mosart.buildnml
@@ -42,7 +42,7 @@ chdir "$CASEBUILD/mosartconf";
 #--------------------------------------------------------------------
 
 my $check_grid = "fail";
-my @rof_grid_supported = ("null", "r05", "r01");
+my @rof_grid_supported = ("null", "r05", "r0125", "r01");
 foreach my $grid (@rof_grid_supported) {
     if (${ROF_GRID} eq $grid) {
 	$check_grid = "OK";
@@ -50,7 +50,7 @@ foreach my $grid (@rof_grid_supported) {
 }
 if (${check_grid} ne "OK") {
     print " ROF_GRID=${ROF_GRID} not supported in mosart";
-    die " mosart only support on null (for single point runs), r05 and r01 ROF_GRIDs only \n";
+    die " mosart only support on null (for single point runs), r05, r0125, and r01 ROF_GRIDs only \n";
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
This pull request brings in additional support for the mosart 1/8-degree grid.

The config_grid.xml file has been modified to include the r0125 grid as an option for runoff.
The mosart buildnml script is also changed to recognize the r0125 grid as an option.

CSG-134
