### PR TITLE
Few bug fixes in ALM VSFM

### DIFF
--- a/components/clm/src/biogeophys/vsfm/RichardsMod.F90
+++ b/components/clm/src/biogeophys/vsfm/RichardsMod.F90
@@ -158,10 +158,10 @@ contains
 
     dist_gravity = (dist_up + dist_dn)*udist_dot_ugrav
 
-    den_ave      = upweight*den_up + (1-upweight)*den_dn
+    den_ave      = upweight*den_up + (1.d0-upweight)*den_dn
 
     ! gravityterm = (rho*g*z)
-    gravityterm  = (upweight*den_up + (1.0 - upweight)*den_dn)*FMWH2O*dist_gravity;
+    gravityterm  = (upweight*den_up + (1.d0 - upweight)*den_dn)*FMWH2O*dist_gravity;
 
     dphi         = Pres_up - Pres_dn + gravityterm;
 
@@ -184,13 +184,13 @@ contains
     if (compute_deriv) then
 
        dden_ave_dP_up       = upweight*dden_dP_up
-       dden_ave_dP_dn       = upweight*dden_dP_dn
+       dden_ave_dP_dn       = (1.d0 - upweight)*dden_dP_dn
 
        dgravityterm_dden_up = upweight*dist_gravity*FMWH2O
-       dgravityterm_dden_dn = (1.0-upweight)*dist_gravity*FMWH2O
+       dgravityterm_dden_dn = (1.d0-upweight)*dist_gravity*FMWH2O
 
-       dphi_dP_up           =  1.0 + dgravityterm_dden_up*dden_ave_dP_up;
-       dphi_dP_dn           = -1.0 + dgravityterm_dden_dn*dden_ave_dP_dn;
+       dphi_dP_up           =  1.d0 + dgravityterm_dden_up*dden_dP_up;
+       dphi_dP_dn           = -1.d0 + dgravityterm_dden_dn*dden_dP_dn;
 
        if (dphi>=0) then
           dukvr_dP_up = dkr_dP_up/vis_up - kr_up/(vis_up*vis_up)*dvis_dP_up
@@ -207,8 +207,8 @@ contains
           dflux_dP_up = 0.d0
           dflux_dP_dn = 0.d0
        else
-          dflux_dP_up = (dq_dp_up*den_ave + q*dden_ave_dp_up);
-          dflux_dP_dn = (dq_dp_dn*den_ave + q*dden_ave_dp_dn);
+          dflux_dP_up = (dq_dp_up*den_ave - q*dden_ave_dp_up);
+          dflux_dP_dn = (dq_dp_dn*den_ave - q*dden_ave_dp_dn);
        endif
 
     endif

--- a/components/clm/src/biogeophys/vsfm/SysofeqnsVSFMType.F90
+++ b/components/clm/src/biogeophys/vsfm/SysofeqnsVSFMType.F90
@@ -874,6 +874,7 @@ contains
     PetscErrorCode                  :: ierr
 
     call VecCopy(this%soln, this%soln_prev,ierr); CHKERRQ(ierr)
+    call VSFMSOEUpdateAuxVarsODE(this, this%soln)
 
     select case (this%itype)
     case(SOE_RE_ODE)
@@ -884,6 +885,8 @@ contains
           select type(cur_goveq)
              class is (goveqn_richards_ode_pressure_type)
 
+             call cur_goveq%GetFromSOEAuxVarsIntrn(this%aux_vars_in, 0)
+             call cur_goveq%UpdateAuxVarsIntrn()
              call cur_goveq%SetDataInSOEAuxVar(AUXVAR_INTERNAL, this%aux_vars_in)
 
           end select
@@ -1045,6 +1048,7 @@ contains
     PetscErrorCode                :: ierr
 
     call VecCopy(this%soln_prev_clm, this%soln_prev, ierr); CHKERRQ(ierr)
+    call VecCopy(this%soln_prev_clm, this%soln     , ierr); CHKERRQ(ierr)
 
   end subroutine VSFMSPreStepDT
 


### PR DESCRIPTION
1. Corrects the jacobian computation
2. Fixes initial condition when solver restarts
3. Updates auxvars when linesearch rejects a
   full Newton step on the last iteration.

Fixes: #944 
Fixes: #945
Fixes: #947

[non-BFB]
