### PR TITLE
Updates land tests

### DIFF
--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -34,14 +34,15 @@ _TEST_SUITES = {
                    ),
 
     "acme_runoff_developer" : (None,
-                             ("SMS.f19_f19.IM1850CLM45CN",
-                              "SMS.f19_f19.IMCLM45")
+                             ("ERS.f19_f19.IM1850CLM45CN",
+                              "ERS.f19_f19.IMCLM45")
                              ),
 
     "acme_land_developer" : ("acme_runoff_developer",
-                             ("SMS.f19_f19.I1850CLM45CN",
-                              "SMS.f09_g16.I1850CLM45CN",
-                              "SMS.hcru_hcru.I1850CRUCLM45CN")
+                             ("ERS.f19_f19.I1850CLM45CN",
+                              "ERS.f09_g16.I1850CLM45CN",
+                              "SMS.hcru_hcru.I1850CRUCLM45CN",
+                              "ERS.f09_g16.IMCLM45BC")
                              ),
 
     "acme_atm_developer" : (None,


### PR DESCRIPTION
- Except one, all previous SMS tests are changed
  to ERS. (The test at hcru_hcru resolution is not
  changed to ERS).
- Adds a new ERS tests for IMCLM45BC at f09_g16

[BFB]
