### PR TITLE
Mrnorman/machine files/titan update modules

### DIFF
--- a/cime/machines-acme/env_mach_specific.titan
+++ b/cime/machines-acme/env_mach_specific.titan
@@ -29,11 +29,10 @@ if (-e /opt/modules/default/init/csh) then
   module add DefApps site-aprun
   module add aprun-usage altd
   ##################################################################3#########
-
-  # Clear out the PGI and cray-libsci libraries
   
   #Add based on COMPILER specification
   if ($COMPILER == "pgi_acc") then
+      setenv MODULEPATH ${MODULEPATH}:/ccs/home/norton/.modules
       module switch pgi pgi/15.9.lustre
       module switch cray-mpich cray-mpich/7.2.5
       module switch cray-libsci cray-libsci/13.2.0


### PR DESCRIPTION
Taking off the mass module rm commands, and replacing them with a module purge + reset of default login environment.

Update cray-libsci to 13.2.0, atp to 1.8.3, specified the cce version, cray-parallel-netcdf to 1.6.1, and specified subversion version.
