### PR TITLE
This PR changes the ne11_ne11 and ne4_ne4 configuration to QU240 mask

### DIFF
--- a/cime/scripts/Tools/config_grid.xml
+++ b/cime/scripts/Tools/config_grid.xml
@@ -96,8 +96,8 @@ Each grid is associated with five names
 <GRID sname="ne240np4_0.23x0.31_gx1v6"   alias="ne240_f02_g16" support_level="For testing high resolution tri-grid" >a%ne240np4_l%0.23x0.31_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</GRID>
 <GRID sname="ne240np4_tx0.1v2"           alias="ne240_t12"    >a%ne240np4_l%ne240np4_oi%tx0.1v2_r%r05_m%tx0.1v2_g%null_w%null</GRID>
 
-<GRID sname="ne4np4_ne4np4"         alias="ne4_ne4"      compset="(DOCN|XOCN|SOCN|AQUAP)">a%ne4np4_l%ne4np4_oi%ne4np4_r%r05_m%gx3v7_g%null_w%null</GRID>
-<GRID sname="ne11np4_ne11np4"       alias="ne11_ne11"    compset="(DOCN|XOCN|SOCN|AQUAP)">a%ne11np4_l%ne11np4_oi%ne11np4_r%r05_m%gx3v7_g%null_w%null</GRID>
+<GRID sname="ne4np4_ne4np4"         alias="ne4_ne4"      compset="(DOCN|XOCN|SOCN|AQUAP)">a%ne4np4_l%ne4np4_oi%ne4np4_r%r05_m%oQU240_g%null_w%null</GRID>
+<GRID sname="ne11np4_ne11np4"       alias="ne11_ne11"    compset="(DOCN|XOCN|SOCN|AQUAP)">a%ne11np4_l%ne11np4_oi%ne11np4_r%r05_m%oQU240_g%null_w%null</GRID>
 <GRID sname="ne16np4_ne16np4"       alias="ne16_ne16"    compset="(DOCN|XOCN|SOCN|AQUAP)">a%ne16np4_l%ne16np4_oi%ne16np4_r%r05_m%gx3v7_g%null_w%null</GRID>
 <GRID sname="ne30np4_ne30np4"       alias="ne30_ne30"    compset="(DOCN|XOCN|SOCN|AQUAP)">a%ne30np4_l%ne30np4_oi%ne30np4_r%r05_m%gx1v6_g%null_w%null</GRID>
 <GRID sname="ne60np4_ne60np4"       alias="ne60_ne60"    compset="(DOCN|XOCN|SOCN|AQUAP)">a%ne60np4_l%ne60np4_oi%ne60np4_r%r05_m%gx1v6_g%null_w%null</GRID>


### PR DESCRIPTION
  There are no domain files for atmosphere/land with gx3v7 ocean and so
  ne11_ne11 and ne4_ne4 don't work. To address this issue the ne11_ne11 and
  ne4_ne4  configurations have been switched from gx3v7 ocean mask to QU240
  mask.

  Fixes #939

  [BFB]
