### PR TITLE
Minor fixes to run scripts for sierra

### DIFF
--- a/cime/machines-acme/config_batch.xml
+++ b/cime/machines-acme/config_batch.xml
@@ -112,12 +112,7 @@
      <batch_submit>sbatch</batch_submit>
      <batch_directive>#MSUB</batch_directive>
      <jobid_pattern>(\d+)$</jobid_pattern>
-     <depend_string> --dependency=afterok:jobid</depend_string>
-     <submit_args>
-       <arg flag="-q" name="queue"/>
-       <arg flag="-l" name="wall_time"/>
-       <arg flag="-A" name="project"/>
-     </submit_args>
+     <depend_string> -l depend=jobid</depend_string>
      <directives>
        <directive>-V</directive>
        <directive>-q {{ queue }}</directive>

--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -638,8 +638,8 @@
          <RUNDIR>/p/lscratche/$CCSMUSER/ACME/$CASE/run</RUNDIR>
          <EXEROOT>/p/lscratche/$CCSMUSER/$CASE/bld</EXEROOT>
          <CESMSCRATCHROOT>/p/lscratche/$USER</CESMSCRATCHROOT>
-         <DIN_LOC_ROOT>/p/lscratchd/ma21/ccsm3data/inputdata</DIN_LOC_ROOT>
-         <DIN_LOC_ROOT_CLMFORC>/p/lscratchd/ma21/ccsm3data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+         <DIN_LOC_ROOT>/usr/gdata/climdat/ccsm3data/inputdata</DIN_LOC_ROOT>
+         <DIN_LOC_ROOT_CLMFORC>/usr/gdata/climdat/ccsm3data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/p/lscratche/$CCSMUSER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_HTAR>FALSE</DOUT_L_HTAR>
          <DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>


### PR DESCRIPTION
Changed depend_string for sierra in config_batch.xml because the previous version had a bug and wouldn't run. Also removed submit_args for sierra because they overwrote values in $CASE.run, which are much easier to modify to get simulations running. Also changed location of inputdata in config_machines.xml from one user's value to a location that everyone can read and write to/from. 

[BFB]
