### PR TITLE
Remove POP-based B-cases from acme_integration

### DIFF
--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -112,7 +112,6 @@ _TEST_SUITES = {
                            "SEQ_IOP_PFC.f19_g16.X",
                            "SMS.ne30_oEC.A_WCYCL2000",
                            "SMS.ne16_ne16.FC5AQUAP",
-                           "SMS_D.f19_g16.B20TRC5",
                            "SMS_D_Ld3.ne16_ne16.FC5",
                            "SMS.f09_g16_a.MPASLIALB_ONLY",
                            "ERS.ne16_ne16.FC5ATMMOD",


### PR DESCRIPTION
Remove 5 B1850C5 cases from acme_integration.  These cases
uses 3 models we aren't supporting: POP2, CICE and CLM40.
We now have low-resolution coupled grids to replace them with A_WCYCL1850
versions.

[BFB]  just removes tests.
