### PR TITLE
Minor fixes to ALM for XLF compiler

### DIFF
--- a/components/clm/src/biogeochem/CNAllocationMod.F90
+++ b/components/clm/src/biogeochem/CNAllocationMod.F90
@@ -379,6 +379,36 @@ contains
     real(r8):: temp_sminn_to_plant(bounds%begc:bounds%endc)
     real(r8):: temp_sminp_to_plant(bounds%begc:bounds%endc)
 
+    real(r8), pointer :: sminp_to_plant_patch         (:)
+    real(r8), pointer :: desorb_to_solutionp_vr       (:,:)
+    real(r8), pointer :: primp_to_labilep_vr_col      (:,:)
+    real(r8), pointer :: biochem_pmin_vr_col          (:,:)
+    real(r8), pointer :: secondp_to_labilep_vr_col    (:,:)
+    real(r8), pointer :: labilep_to_secondp_vr_col    (:,:)
+    real(r8), pointer :: adsorb_to_labilep_vr         (:,:)
+    real(r8), pointer :: plant_pdemand_vr_patch       (:,:)
+    real(r8), pointer :: plant_n_uptake_flux          (:)
+
+    real(r8), pointer :: labilep_vr                   (:,:)
+    real(r8), pointer :: secondp_vr                   (:,:)
+    real(r8), pointer :: actual_leafcp                (:)
+    real(r8), pointer :: actual_frootcp               (:)
+    real(r8), pointer :: actual_livewdcp              (:)
+    real(r8), pointer :: actual_deadwdcp              (:)
+    real(r8), pointer :: leafp                        (:)
+    real(r8), pointer :: plant_p_uptake_flux          (:)
+
+    real(r8), pointer :: col_plant_ndemand_vr         (:,:)
+    real(r8), pointer :: col_plant_nh4demand_vr       (:,:)
+    real(r8), pointer :: col_plant_no3demand_vr       (:,:)
+    real(r8), pointer :: col_plant_pdemand_vr         (:,:)
+    real(r8), pointer :: plant_nh4demand_vr_patch     (:,:)
+    real(r8), pointer :: plant_no3demand_vr_patch     (:,:)
+    real(r8), pointer :: plant_ndemand_vr_patch       (:,:)
+    real(r8), pointer :: actual_immob_no3             (:)
+    real(r8), pointer :: actual_immob_nh4             (:)
+    real(r8), pointer :: benefit_pgpp_pleafc          (:)
+
     !-----------------------------------------------------------------------
 
     associate(                                                                                   &
@@ -612,37 +642,39 @@ contains
          smin_no3_to_plant_patch      => nitrogenflux_vars%smin_no3_to_plant_patch             , &
          sminn_to_plant_patch         => nitrogenflux_vars%sminn_to_plant_patch                , &
          pnup_pfrootc                 => nitrogenstate_vars%pnup_pfrootc_patch                 , &
-         leafn                        => nitrogenstate_vars%leafn_patch                        , &
-         sminp_to_plant_patch         => phosphorusflux_vars%sminp_to_plant_patch              , &
-         secondp_vr                   => phosphorusstate_vars%secondp_vr_col                   , &               
-         actual_leafcp                => phosphorusstate_vars%actual_leafcp                    , &
-         actual_frootcp               => phosphorusstate_vars%actual_frootcp                   , &
-         actual_livewdcp              => phosphorusstate_vars%actual_livewdcp                  , &
-         actual_deadwdcp              => phosphorusstate_vars%actual_deadwdcp                  , &
-         leafp                        => phosphorusstate_vars%leafp_patch                      , &
-         col_plant_ndemand_vr         => nitrogenflux_vars%col_plant_ndemand_vr                , &
-         col_plant_nh4demand_vr       => nitrogenflux_vars%col_plant_nh4demand_vr              , &
-         col_plant_no3demand_vr       => nitrogenflux_vars%col_plant_no3demand_vr              , &
-         col_plant_pdemand_vr         => nitrogenflux_vars%col_plant_pdemand_vr                , &
-         plant_nh4demand_vr_patch     => nitrogenflux_vars%plant_nh4demand_vr_patch            , &
-         plant_no3demand_vr_patch     => nitrogenflux_vars%plant_no3demand_vr_patch            , &
-         plant_ndemand_vr_patch       => nitrogenflux_vars%plant_ndemand_vr_patch              , &
-         plant_pdemand_vr_patch       => phosphorusflux_vars%plant_pdemand_vr_patch            , &
-         actual_immob_no3             => nitrogenflux_vars%actual_immob_no3_col                , &
-         actual_immob_nh4             => nitrogenflux_vars%actual_immob_nh4_col                , &
-         adsorb_to_labilep_vr         => phosphorusflux_vars%adsorb_to_labilep_vr              , &
-         desorb_to_solutionp_vr       => phosphorusflux_vars%desorb_to_solutionp_vr            , &
-         primp_to_labilep_vr_col      => phosphorusflux_vars%primp_to_labilep_vr_col           , &
-         biochem_pmin_vr_col          => phosphorusflux_vars%biochem_pmin_vr_col               , &
-         secondp_to_labilep_vr_col    => phosphorusflux_vars%secondp_to_labilep_vr_col         , &
-         labilep_to_secondp_vr_col    => phosphorusflux_vars%labilep_to_secondp_vr_col         , &
-         labilep_vr                   => phosphorusstate_vars%labilep_vr_col                   , &
-         benefit_pgpp_pleafc          => nitrogenstate_vars%benefit_pgpp_pleafc_patch          , &
-         
-         ! for debug
-         plant_n_uptake_flux	      => nitrogenflux_vars%plant_n_uptake_flux	               , &
-         plant_p_uptake_flux	      => phosphorusflux_vars%plant_p_uptake_flux	         &
+         leafn                        => nitrogenstate_vars%leafn_patch                          &
          )
+
+
+      sminp_to_plant_patch         => phosphorusflux_vars%sminp_to_plant_patch
+      secondp_vr                   => phosphorusstate_vars%secondp_vr_col
+      actual_leafcp                => phosphorusstate_vars%actual_leafcp
+      actual_frootcp               => phosphorusstate_vars%actual_frootcp
+      actual_livewdcp              => phosphorusstate_vars%actual_livewdcp
+      actual_deadwdcp              => phosphorusstate_vars%actual_deadwdcp
+      leafp                        => phosphorusstate_vars%leafp_patch
+      col_plant_ndemand_vr         => nitrogenflux_vars%col_plant_ndemand_vr
+      col_plant_nh4demand_vr       => nitrogenflux_vars%col_plant_nh4demand_vr
+      col_plant_no3demand_vr       => nitrogenflux_vars%col_plant_no3demand_vr
+      col_plant_pdemand_vr         => nitrogenflux_vars%col_plant_pdemand_vr
+      plant_nh4demand_vr_patch     => nitrogenflux_vars%plant_nh4demand_vr_patch
+      plant_no3demand_vr_patch     => nitrogenflux_vars%plant_no3demand_vr_patch
+      plant_ndemand_vr_patch       => nitrogenflux_vars%plant_ndemand_vr_patch
+      plant_pdemand_vr_patch       => phosphorusflux_vars%plant_pdemand_vr_patch
+      actual_immob_no3             => nitrogenflux_vars%actual_immob_no3_col
+      actual_immob_nh4             => nitrogenflux_vars%actual_immob_nh4_col
+      adsorb_to_labilep_vr         => phosphorusflux_vars%adsorb_to_labilep_vr
+      desorb_to_solutionp_vr       => phosphorusflux_vars%desorb_to_solutionp_vr
+      primp_to_labilep_vr_col      => phosphorusflux_vars%primp_to_labilep_vr_col
+      biochem_pmin_vr_col          => phosphorusflux_vars%biochem_pmin_vr_col
+      secondp_to_labilep_vr_col    => phosphorusflux_vars%secondp_to_labilep_vr_col
+      labilep_to_secondp_vr_col    => phosphorusflux_vars%labilep_to_secondp_vr_col
+      labilep_vr                   => phosphorusstate_vars%labilep_vr_col
+      benefit_pgpp_pleafc          => nitrogenstate_vars%benefit_pgpp_pleafc_patch
+
+      ! for debug
+      plant_n_uptake_flux          => nitrogenflux_vars%plant_n_uptake_flux
+      plant_p_uptake_flux          => phosphorusflux_vars%plant_p_uptake_flux
 
       ! set time steps
       dt = real( get_step_size(), r8 )
@@ -3219,7 +3251,7 @@ contains
 
                      plant_palloc(p) = plant_nalloc(p) * (p_allometry(p)/n_allometry(p))
 
-                     sminp_to_ppool(p) = max(plant_palloc(p) - retransp_to_ppool(p),0.0) ! in case of strong N limitation, and plant_palloc(p) < retransp_to_ppool(p)
+                     sminp_to_ppool(p) = max(plant_palloc(p) - retransp_to_ppool(p),0.0_r8) ! in case of strong N limitation, and plant_palloc(p) < retransp_to_ppool(p)
                      
                      retransp_to_ppool(p) = min(plant_palloc(p) , retransp_to_ppool(p)) ! in case of strong N limitation, and plant_palloc(p) < retransp_to_ppool(p)
                  else
@@ -3227,7 +3259,7 @@ contains
 
                      plant_nalloc(p) = plant_palloc(p) * (n_allometry(p)/p_allometry(p))
 
-                     sminn_to_npool(p) = max(plant_nalloc(p) - retransn_to_npool(p), 0.0) ! in case of strong P limitation, and plant_nalloc(p) < retransn_to_npool(p)
+                     sminn_to_npool(p) = max(plant_nalloc(p) - retransn_to_npool(p), 0.0_r8) ! in case of strong P limitation, and plant_nalloc(p) < retransn_to_npool(p)
                      
                      retransn_to_npool(p) = min(plant_nalloc(p) , retransn_to_npool(p)) ! in case of strong P limitation, and plant_nalloc(p) < retransn_to_npool(p)
                  endif

--- a/components/clm/src/biogeochem/CNDecompMod.F90
+++ b/components/clm/src/biogeochem/CNDecompMod.F90
@@ -570,14 +570,14 @@ contains
                    soil_n_immob_flux_vr(c,j) = soil_n_immob_flux_vr(c,j) + pmnf_decomp_cascade(c,j,k)
                else
                    soil_n_grossmin_flux(c) = soil_n_grossmin_flux(c) -1.0_r8*pmnf_decomp_cascade(c,j,k)*dzsoi_decomp(j)
-                   gross_nmin_vr(c,j) = gross_nmin_vr(c,j) + -1.0*pmnf_decomp_cascade(c,j,k)
+                   gross_nmin_vr(c,j) = gross_nmin_vr(c,j) - 1.0_r8*pmnf_decomp_cascade(c,j,k)
                end if
                if (pmpf_decomp_cascade(c,j,k) > 0._r8) then 
                    soil_p_immob_flux(c) = soil_p_immob_flux(c) + pmpf_decomp_cascade(c,j,k)*dzsoi_decomp(j)
                    soil_p_immob_flux_vr(c,j) = soil_p_immob_flux_vr(c,j) + pmpf_decomp_cascade(c,j,k)
                else
                    soil_p_grossmin_flux(c) = soil_p_grossmin_flux(c) -1.0_r8*pmpf_decomp_cascade(c,j,k)*dzsoi_decomp(j)
-                   gross_pmin_vr(c,j) = gross_pmin_vr(c,j) + -1.0*pmpf_decomp_cascade(c,j,k)
+                   gross_pmin_vr(c,j) = gross_pmin_vr(c,j) - 1.0_r8*pmpf_decomp_cascade(c,j,k)
                end if
              end do
           end do

--- a/components/clm/src/biogeochem/CNPhenologyMod.F90
+++ b/components/clm/src/biogeochem/CNPhenologyMod.F90
@@ -2438,13 +2438,13 @@ contains
                     !leafp_to_retransp(p) = max(min((prev_leafp_to_litter(p)  + t1*(leafp(p)  - prev_leafp_to_litter(p)*offset_counter(p))),leafp(p)),0.0)*0.65_r8
                     !frootp_to_litter(p) = max(min(prev_frootp_to_litter(p) + t1*(frootp(p) - prev_frootp_to_litter(p)*offset_counter(p)),frootp(p)),0.0)
                     
-                    leafn_to_litter(p)  = leafc_to_litter(p) / max(leafc(p), 1e-20) * leafn(p) * 0.38_r8
-                    leafn_to_retransn(p) = leafc_to_litter(p) / max(leafc(p), 1e-20) * leafn(p) * 0.62_r8
-                    frootn_to_litter(p) = frootc_to_litter(p) /  max(frootc(p), 1e-20) * frootn(p)
+                    leafn_to_litter(p)  = leafc_to_litter(p) / max(leafc(p), 1.e-20_r8) * leafn(p) * 0.38_r8
+                    leafn_to_retransn(p) = leafc_to_litter(p) / max(leafc(p), 1.e-20_r8) * leafn(p) * 0.62_r8
+                    frootn_to_litter(p) = frootc_to_litter(p) /  max(frootc(p), 1.e-20_r8) * frootn(p)
                     
-                    leafp_to_litter(p)  = leafc_to_litter(p) / max(leafc(p), 1e-20) * leafp(p) * 0.35_r8
-                    leafp_to_retransp(p) = leafc_to_litter(p) / max(leafc(p), 1e-20) * leafp(p) * 0.65_r8
-                    frootp_to_litter(p) = frootc_to_litter(p) /  max(frootc(p), 1e-20) * frootp(p)
+                    leafp_to_litter(p)  = leafc_to_litter(p) / max(leafc(p), 1.e-20_r8) * leafp(p) * 0.35_r8
+                    leafp_to_retransp(p) = leafc_to_litter(p) / max(leafc(p), 1.e-20_r8) * leafp(p) * 0.65_r8
+                    frootp_to_litter(p) = frootc_to_litter(p) /  max(frootc(p), 1.e-20_r8) * frootp(p)
                 end if
                 ! save the current litterfall fluxes
                 !prev_leafn_to_litter(p)  = leafn_to_litter(p)

--- a/components/clm/src/biogeophys/PhotosynthesisMod.F90
+++ b/components/clm/src/biogeophys/PhotosynthesisMod.F90
@@ -462,7 +462,7 @@ contains
                   ! from m2 ground to m2 leaf; dividing by sum_nscaler to
                   ! convert total leaf N to leaf N at canopy top
                   lnc(p) = leafn(p) / (total_lai * sum_nscaler)
-                  lnc(p) = min(max(lnc(p),0.0),3.0) ! based on TRY database, doi: 10.1002/ece3.1173
+                  lnc(p) = min(max(lnc(p),0.0_r8),3.0_r8) ! based on TRY database, doi: 10.1002/ece3.1173
                else                                                                    
                   lnc(p) = 0.0_r8                                                      
                end if
@@ -504,17 +504,17 @@ contains
                      ! convert total leaf N to leaf N at canopy top
                      lnc(p) = leafn(p) / (total_lai * sum_nscaler)
                      lpc(p) = leafp(p) / (total_lai * sum_nscaler)
-                     lnc(p) = min(max(lnc(p),0.0),3.0) ! based on TRY database, doi: 10.1002/ece3.1173
-                     lpc(p) = min(max(lpc(p),0.0),0.5) ! based on TRY database, doi: 10.1002/ece3.1173
+                     lnc(p) = min(max(lnc(p),0.0_r8),3.0_r8) ! based on TRY database, doi: 10.1002/ece3.1173
+                     lpc(p) = min(max(lpc(p),0.0_r8),0.5_r8) ! based on TRY database, doi: 10.1002/ece3.1173
                   else
                      lnc(p) = 0.0_r8
                      lpc(p) = 0.0_r8
                   end if
 
-                  if (lnc(p) >= 0.1 .and. lnc(p) <=3.0 .and. lpc(p) >= 0.05 .and. lpc(p) <= 0.5) then
-                     vcmax25top = exp(3.946 + 0.921*log(lnc(p)) + 0.121*log(lpc(p)) + 0.282*log(lnc(p))*log(lpc(p))) * dayl_factor(p)
-                     jmax25top = exp(1.246 + 0.886*log(vcmax25top) + 0.089*log(lpc(p))) * dayl_factor(p)
-                  else if (lnc(p) < 0.1 .or. lpc(p) < 0.05) then
+                  if (lnc(p) >= 0.1_r8 .and. lnc(p) <=3.0_r8 .and. lpc(p) >= 0.05_r8 .and. lpc(p) <= 0.5_r8) then
+                     vcmax25top = exp(3.946_r8 + 0.921_r8*log(lnc(p)) + 0.121_r8*log(lpc(p)) + 0.282_r8*log(lnc(p))*log(lpc(p))) * dayl_factor(p)
+                     jmax25top = exp(1.246_r8 + 0.886_r8*log(vcmax25top) + 0.089_r8*log(lpc(p))) * dayl_factor(p)
+                  else if (lnc(p) < 0.1_r8 .or. lpc(p) < 0.05_r8) then
                      vcmax25top = 10.0_r8
                      jmax25top  = 10.0_r8
                   else


### PR DESCRIPTION
- Limits the number of variables in associate construct,
- Corrects max/min computation to include `_r8`

Fixes #988

[BFB]
