### PR TITLE
Fixes namelist definition of landuse dataset

### DIFF
--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -41,6 +41,7 @@ _TEST_SUITES = {
     "acme_land_developer" : ("acme_runoff_developer",
                              ("ERS.f19_f19.I1850CLM45CN",
                               "ERS.f09_g16.I1850CLM45CN",
+                              "ERS.f09_g16.I20TRCLM45",
                               "SMS.hcru_hcru.I1850CRUCLM45CN",
                               "ERS.f09_g16.IMCLM45BC")
                              ),

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1495,12 +1495,6 @@ List of possible MEGAN compounds to use
 <!-- Namelist options controlling prescribed subgrid dynamics                                  -->
 <!-- ========================================================================================  -->
 
-<entry id="flanduse_timeseries" type="char*256" category="datasets"
-       input_pathname="abs" group="dynamic_subgrid" valid_values="" >
-Full pathname of time varying landuse data file. This causes the land-use types of
-the initial surface dataset to vary over time.
-</entry>
-
 <entry id="do_transient_pfts" type="logical" category="physics"
        group="dynamic_subgrid" valid_values="" >
 If TRUE, apply transient natural PFTs from flanduse_timeseries file.


### PR DESCRIPTION
- `flanduse_timeseries` is now defined under `clm_inparm`.
- Adds a land test for I20TRCLM45 compset, which uses
  transient landuse dataset.

Fixes #990

[NML]
