### PR TITLE
Fix defaults to support ultra-low-res ne11-oQU240 testing configuration.

### DIFF
--- a/cime/scripts/Tools/config_compsets.xml
+++ b/cime/scripts/Tools/config_compsets.xml
@@ -1914,6 +1914,15 @@ DOCN%COPY => docn copy mode
 <GLC_NCPL compset="_CAM.*_CLM.*MPASO">1</GLC_NCPL>
 <ROF_NCPL compset="_CAM.*_CLM.*MPASO">8</ROF_NCPL>
 
+<!-- coupler intervals for CAM, CLM, and MPASO ultra low-res testing compset -->
+<NCPL_BASE_PERIOD compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">day  </NCPL_BASE_PERIOD>
+<ATM_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</ATM_NCPL>
+<LND_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</LND_NCPL>
+<ICE_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</ICE_NCPL>
+<OCN_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</OCN_NCPL>
+<GLC_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">1</GLC_NCPL>
+<ROF_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">4</ROF_NCPL>
+
 <!-- coupler intervals for CAM, CLM, and MPASO high-res compset -->
 <NCPL_BASE_PERIOD compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">day  </NCPL_BASE_PERIOD>
 <ATM_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</ATM_NCPL>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1353,7 +1353,7 @@
 <rsplit hgrid="ne240np4">  3 </rsplit>
 
 <se_nsplit>                   2 </se_nsplit>
-<se_nsplit hgrid="ne11np4" >  1 </se_nsplit>
+<se_nsplit hgrid="ne11np4" >  4 </se_nsplit>
 <se_nsplit hgrid="ne16np4" >  1 </se_nsplit>
 <se_nsplit hgrid="ne30np4" >  2 </se_nsplit>
 <se_nsplit hgrid="ne60np4" >  4 </se_nsplit>

--- a/components/mpas-cice/bld/namelist_files/namelist_defaults_mpas-cice.xml
+++ b/components/mpas-cice/bld/namelist_files/namelist_defaults_mpas-cice.xml
@@ -5,7 +5,7 @@
 
 <!-- cice_model -->
 <config_dt>1800.0</config_dt>
-<config_dt ice_grid="oQU240">3600.0</config_dt>
+<config_dt ice_grid="oQU240">7200.0</config_dt>
 <config_dt ice_grid="oQU120">3600.0</config_dt>
 <config_dt ice_grid="mpas120">3600.0</config_dt>
 <config_dt ice_grid="oEC60to30">1800.0</config_dt>


### PR DESCRIPTION
This commit modifies namelist defaults to support an ultra-low-res ne11-oQU240 configuration for testing purposes.  It changes defaults in the following files:
- cime/scripts/Tools/config_compsets.xml
- components/cam/bld/namelist_files/namelist_defaults_cam.xml
- components/mpas-cice/bld/namelist_files/namelist_defaults_mpas-cice.xml
  but only for this specific resolution.

[BFB]
[NML]
