### PR TITLE
Fix for PIO link error on Titan with the intel compiler and cmake 2.8.10.2

### DIFF
--- a/cime/machines-acme/env_mach_specific.titan
+++ b/cime/machines-acme/env_mach_specific.titan
@@ -102,7 +102,7 @@ setenv MPSTKZ 128M
 setenv OMP_STACKSIZE 128M
 
 if ( $COMPILER == "intel" ) then
-  setenv XTPE_LINK_TYPE dynamic
+  setenv CRAYPE_LINK_TYPE dynamic
 endif 
 if ( $?PERL ) then
   printenv


### PR DESCRIPTION
Using CRAYPE_LINK_TYPE instead of XTPE_LINK_TYPE to indicate
dynamic linking when building ACME on Titan with the intel
compiler (XTPE_LINK_TYPE is obsolete now).

Without this fix cmake adds the "-rdynamic" flag to the linker
flags and aborts with the following error message,

"/usr/bin/ld: dynamic STT_GNU_IFUNC symbol strcmp' with pointer equality
in/usr/lib64/gcc/x86_64-suse-linux/4.3/../../../../lib64/libc.a(strcmp.o)'
can not be used when making an executable; recompile with -fPIE and
relink with -pi"

This issue did not occur with cmake 2.8.11.2 . However it occurs with
older (cmake 2.8.10.2 - the default on titan) and newer (cmake 3.2.3)
versions.

Fixes #995

[BFB]
