### PR TITLE
Swaps the test from crop model

### DIFF
--- a/cime/scripts-acme/update_acme_tests.py
+++ b/cime/scripts-acme/update_acme_tests.py
@@ -42,7 +42,7 @@ _TEST_SUITES = {
                              ("ERS.f19_f19.I1850CLM45CN",
                               "ERS.f09_g16.I1850CLM45CN",
                               "SMS.hcru_hcru.I1850CRUCLM45CN",
-                              ("SMS_Ly3.1x1_smallvilleIA.ICLM45BGCCROP", "force_netcdf_pio"),
+                              ("SMS_Ly3.1x1_smallvilleIA.ICLM45CNCROP", "force_netcdf_pio"),
                               "ERS.ne11_qu240.I20TRCLM45",
                               "ERS.f09_g16.IMCLM45BC")
                              ),


### PR DESCRIPTION
Updates the test for crop model to use ICLM45CNCROP
instead of ICLM45BGCCROP

Fixes #1008
