### PR TITLE
Fix for model crashes on Mira when compiled with O3 optimization

### DIFF
--- a/cime/machines-acme/Depends.mira
+++ b/cime/machines-acme/Depends.mira
@@ -26,6 +26,11 @@ wetdep.o
 ifeq ($(DEBUG),FALSE)
   $(PERFOBJS): %.o: %.F90
 	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -qnostrict  $<
+#Model crashes if these files are compiled with O3(default) optimizations
+  seasalt_model.o: seasalt_model.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O2 $<
+  linoz_data.o: linoz_data.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O2 $<
 endif
 
 ### These files take long time to compile with default optimization flags.


### PR DESCRIPTION
The PR lowers the optimization to -O2 for two F90 files:
- seasalt_model.F90
- linoz_data.F90

in Depends.mira so that the model runs fine on Mira with O3 (default)
optimizations level.

This PR partially fixes issue #871. F-compsets with ne16 grid are still
crashing with a different runtime error.

[BFB]
