### PR TITLE
Add two missing runoff fields to clm export.

### DIFF
--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -1066,8 +1066,10 @@ contains
        ! hierarchy of atm/glc/lnd/rof/ice/ocn.  so water sent from land to rof is positive
 
        l2x(index_l2x_Flrl_rofi,i) = lnd2atm_vars%qflx_rofice_grc(g)
-       l2x(index_l2x_Flrl_rofsur,i) = lnd2atm_vars%qflx_rofliq_qsur_grc(g)
-       l2x(index_l2x_Flrl_rofsub,i) = lnd2atm_vars%qflx_rofliq_qsub_grc(g)
+       l2x(index_l2x_Flrl_rofsur,i) = lnd2atm_vars%qflx_rofliq_qsur_grc(g) &
+                                    + lnd2atm_vars%qflx_rofliq_qsurp_grc(g)   !  surface ponding
+       l2x(index_l2x_Flrl_rofsub,i) = lnd2atm_vars%qflx_rofliq_qsub_grc(g) &
+                                    + lnd2atm_vars%qflx_rofliq_qsubp_grc(g)   !  perched drainiage
        l2x(index_l2x_Flrl_rofgwl,i) = lnd2atm_vars%qflx_rofliq_qgwl_grc(g)
 
        ! glc coupling

--- a/components/clm/src/main/lnd2atmMod.F90
+++ b/components/clm/src/main/lnd2atmMod.F90
@@ -288,8 +288,18 @@ contains
          c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
 
     call c2g( bounds, &
+         waterflux_vars%qflx_h2osfc_surf_col (bounds%begc:bounds%endc), &
+         lnd2atm_vars%qflx_rofliq_qsurp_grc  (bounds%begg:bounds%endg), &
+         c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+    call c2g( bounds, &
          waterflux_vars%qflx_drain_col (bounds%begc:bounds%endc), &
          lnd2atm_vars%qflx_rofliq_qsub_grc   (bounds%begg:bounds%endg), &
+         c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+    call c2g( bounds, &
+         waterflux_vars%qflx_drain_perched_col (bounds%begc:bounds%endc), &
+         lnd2atm_vars%qflx_rofliq_qsubp_grc  (bounds%begg:bounds%endg), &
          c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
 
     call c2g( bounds, &

--- a/components/clm/src/main/lnd2atmType.F90
+++ b/components/clm/src/main/lnd2atmType.F90
@@ -50,11 +50,13 @@ module lnd2atmType
      real(r8), pointer :: flxvoc_grc         (:,:) => null() ! VOC flux (size bins)
      real(r8), pointer :: flux_ch4_grc       (:)   => null() ! net CH4 flux (kg C/m**2/s) [+ to atm]
      ! lnd->rof
-     real(r8), pointer :: qflx_rofliq_grc    (:)   => null() ! rof liq forcing
-     real(r8), pointer :: qflx_rofliq_qsur_grc(:)  => null() ! rof liq -- surface runoff component
-     real(r8), pointer :: qflx_rofliq_qsub_grc(:)  => null() ! rof liq -- subsurface runoff component
-     real(r8), pointer :: qflx_rofliq_qgwl_grc(:)  => null() ! rof liq -- glacier, wetland and lakes water balance residual component
-     real(r8), pointer :: qflx_rofice_grc    (:)   => null() ! rof ice forcing
+     real(r8), pointer :: qflx_rofliq_grc      (:) => null() ! rof liq forcing
+     real(r8), pointer :: qflx_rofliq_qsur_grc (:) => null() ! rof liq -- surface runoff component
+     real(r8), pointer :: qflx_rofliq_qsurp_grc(:) => null() ! rof liq -- surface ponding runoff component
+     real(r8), pointer :: qflx_rofliq_qsub_grc (:) => null() ! rof liq -- subsurface runoff component
+     real(r8), pointer :: qflx_rofliq_qsubp_grc(:) => null() ! rof liq -- perched subsurface runoff component
+     real(r8), pointer :: qflx_rofliq_qgwl_grc (:) => null() ! rof liq -- glacier, wetland and lakes water balance residual component
+     real(r8), pointer :: qflx_rofice_grc      (:) => null() ! rof ice forcing
 
    contains
 
@@ -95,32 +97,34 @@ contains
 
     begg = bounds%begg; endg= bounds%endg
 
-    allocate(this%t_rad_grc          (begg:endg))            ; this%t_rad_grc          (:)   =ival
-    allocate(this%t_ref2m_grc        (begg:endg))            ; this%t_ref2m_grc        (:)   =ival
-    allocate(this%q_ref2m_grc        (begg:endg))            ; this%q_ref2m_grc        (:)   =ival
-    allocate(this%u_ref10m_grc       (begg:endg))            ; this%u_ref10m_grc       (:)   =ival
-    allocate(this%h2osno_grc         (begg:endg))            ; this%h2osno_grc         (:)   =ival
-    allocate(this%h2osoi_vol_grc     (begg:endg,1:nlevgrnd)) ; this%h2osoi_vol_grc     (:,:) =ival
-    allocate(this%albd_grc           (begg:endg,1:numrad))   ; this%albd_grc           (:,:) =ival
-    allocate(this%albi_grc           (begg:endg,1:numrad))   ; this%albi_grc           (:,:) =ival
-    allocate(this%taux_grc           (begg:endg))            ; this%taux_grc           (:)   =ival
-    allocate(this%tauy_grc           (begg:endg))            ; this%tauy_grc           (:)   =ival
-    allocate(this%eflx_lwrad_out_grc (begg:endg))            ; this%eflx_lwrad_out_grc (:)   =ival
-    allocate(this%eflx_sh_tot_grc    (begg:endg))            ; this%eflx_sh_tot_grc    (:)   =ival
-    allocate(this%eflx_lh_tot_grc    (begg:endg))            ; this%eflx_lh_tot_grc    (:)   =ival
-    allocate(this%qflx_evap_tot_grc  (begg:endg))            ; this%qflx_evap_tot_grc  (:)   =ival
-    allocate(this%fsa_grc            (begg:endg))            ; this%fsa_grc            (:)   =ival
-    allocate(this%nee_grc            (begg:endg))            ; this%nee_grc            (:)   =ival
-    allocate(this%nem_grc            (begg:endg))            ; this%nem_grc            (:)   =ival
-    allocate(this%ram1_grc           (begg:endg))            ; this%ram1_grc           (:)   =ival
-    allocate(this%fv_grc             (begg:endg))            ; this%fv_grc             (:)   =ival
-    allocate(this%flxdst_grc         (begg:endg,1:ndst))     ; this%flxdst_grc         (:,:) =ival
-    allocate(this%flux_ch4_grc       (begg:endg))            ; this%flux_ch4_grc       (:)   =ival
-    allocate(this%qflx_rofliq_grc    (begg:endg))            ; this%qflx_rofliq_grc    (:)   =ival
-    allocate(this%qflx_rofliq_qsur_grc(begg:endg))           ; this%qflx_rofliq_qsur_grc(:)  =ival
-    allocate(this%qflx_rofliq_qsub_grc(begg:endg))           ; this%qflx_rofliq_qsub_grc(:)  =ival
-    allocate(this%qflx_rofliq_qgwl_grc(begg:endg))           ; this%qflx_rofliq_qgwl_grc(:)  =ival
-    allocate(this%qflx_rofice_grc    (begg:endg))            ; this%qflx_rofice_grc    (:)   =ival
+    allocate(this%t_rad_grc            (begg:endg))            ; this%t_rad_grc            (:) =ival
+    allocate(this%t_ref2m_grc          (begg:endg))            ; this%t_ref2m_grc          (:) =ival
+    allocate(this%q_ref2m_grc          (begg:endg))            ; this%q_ref2m_grc          (:) =ival
+    allocate(this%u_ref10m_grc         (begg:endg))            ; this%u_ref10m_grc         (:) =ival
+    allocate(this%h2osno_grc           (begg:endg))            ; this%h2osno_grc           (:) =ival
+    allocate(this%h2osoi_vol_grc       (begg:endg,1:nlevgrnd)) ; this%h2osoi_vol_grc     (:,:) =ival
+    allocate(this%albd_grc             (begg:endg,1:numrad))   ; this%albd_grc           (:,:) =ival
+    allocate(this%albi_grc             (begg:endg,1:numrad))   ; this%albi_grc           (:,:) =ival
+    allocate(this%taux_grc             (begg:endg))            ; this%taux_grc             (:) =ival
+    allocate(this%tauy_grc             (begg:endg))            ; this%tauy_grc             (:) =ival
+    allocate(this%eflx_lwrad_out_grc   (begg:endg))            ; this%eflx_lwrad_out_grc   (:) =ival
+    allocate(this%eflx_sh_tot_grc      (begg:endg))            ; this%eflx_sh_tot_grc      (:) =ival
+    allocate(this%eflx_lh_tot_grc      (begg:endg))            ; this%eflx_lh_tot_grc      (:) =ival
+    allocate(this%qflx_evap_tot_grc    (begg:endg))            ; this%qflx_evap_tot_grc    (:) =ival
+    allocate(this%fsa_grc              (begg:endg))            ; this%fsa_grc              (:) =ival
+    allocate(this%nee_grc              (begg:endg))            ; this%nee_grc              (:) =ival
+    allocate(this%nem_grc              (begg:endg))            ; this%nem_grc              (:) =ival
+    allocate(this%ram1_grc             (begg:endg))            ; this%ram1_grc             (:) =ival
+    allocate(this%fv_grc               (begg:endg))            ; this%fv_grc               (:) =ival
+    allocate(this%flxdst_grc           (begg:endg,1:ndst))     ; this%flxdst_grc         (:,:) =ival
+    allocate(this%flux_ch4_grc         (begg:endg))            ; this%flux_ch4_grc         (:) =ival
+    allocate(this%qflx_rofliq_grc      (begg:endg))            ; this%qflx_rofliq_grc      (:) =ival
+    allocate(this%qflx_rofliq_qsur_grc (begg:endg))            ; this%qflx_rofliq_qsur_grc (:) =ival
+    allocate(this%qflx_rofliq_qsurp_grc(begg:endg))            ; this%qflx_rofliq_qsurp_grc(:) =ival
+    allocate(this%qflx_rofliq_qsub_grc (begg:endg))            ; this%qflx_rofliq_qsub_grc (:) =ival
+    allocate(this%qflx_rofliq_qsubp_grc(begg:endg))            ; this%qflx_rofliq_qsubp_grc(:) =ival
+    allocate(this%qflx_rofliq_qgwl_grc (begg:endg))            ; this%qflx_rofliq_qgwl_grc (:) =ival
+    allocate(this%qflx_rofice_grc      (begg:endg))            ; this%qflx_rofice_grc      (:) =ival
 
     if (shr_megan_mechcomps_n>0) then
        allocate(this%flxvoc_grc(begg:endg,1:shr_megan_mechcomps_n));  this%flxvoc_grc(:,:)=ival


### PR DESCRIPTION
Add two missing runoff fields, surface ponding water and perched 
water drainage, to the fields already sent to the coupler for input to
the river model.  Instead of being sent as separate fields, they are 
included with the surface and sub-surface fluxes, respectively.  
There are also modifications to make these fields available to the export 
routine and averaged in the same way as other coupled fluxes.

Fixes: #1045
[non-BFB]
