### PR TITLE
Fixes cflx so that model restarts BFB

### DIFF
--- a/components/cam/src/cpl/atm_import_export.F90
+++ b/components/cam/src/cpl/atm_import_export.F90
@@ -49,17 +49,20 @@ contains
        ncols = get_ncols_p(c) 
 
        ! initialize constituent surface fluxes to zero
-       cam_in(c)%cflx(:,:) = 0._r8 
+       ! NOTE:overwrite_flds is .FALSE. for the first restart
+       ! time step making cflx(:,1)=0.0 for the first restart time step.
+       ! cflx(:,1) should not be zeroed out, start the second index of cflx from 2.
+       cam_in(c)%cflx(:,2:) = 0._r8 
                                                
        do i =1,ncols                                                               
           if (overwrite_flds) then
-           ! Prior to this change, "overwrite_flds" was always .true. therefore wsx and wsy were always updated.
-		   ! Now, overwrite_flds is .false. for the first time step of the restart run. Move wsx and wsy out of 
-		   ! this if-condition so that they are still updated everytime irrespective of the value of overwrite_flds.
+             ! Prior to this change, "overwrite_flds" was always .true. therefore wsx and wsy were always updated.
+             ! Now, overwrite_flds is .false. for the first time step of the restart run. Move wsx and wsy out of 
+             ! this if-condition so that they are still updated everytime irrespective of the value of overwrite_flds.
 
-           ! Move lhf to this if-block so that it is not overwritten to ensure BFB restarts when qneg4 correction 
-		   ! occurs at the restart time step
-           ! Modified by Wuyin Lin
+             ! Move lhf to this if-block so that it is not overwritten to ensure BFB restarts when qneg4 correction 
+             ! occurs at the restart time step
+             ! Modified by Wuyin Lin
              cam_in(c)%shf(i)    = -x2a(index_x2a_Faxx_sen, ig)     
              cam_in(c)%cflx(i,1) = -x2a(index_x2a_Faxx_evap,ig)                
              cam_in(c)%lhf(i)    = -x2a(index_x2a_Faxx_lat, ig)     


### PR DESCRIPTION
Short explanation:
cam_in%cflx(:,1) was zeroed out at the first restart time step in the model. This caused the model to produce non-BFB restarts whenever cflx(:,1) was used within the atmospheric model. Instead of being set to zero, cam_in%cflx(:,1) should use the value obtained from the atmosphere restart file.  This PR fixes that and allows cflx(:,1) to retain its value at the restart time step.

Longer explanation:
With the exception of cflx(:,1), all the other cflx data is received from the coupler, not the atmosphere restart file. For this other cflx data, the the array is zeroed out, because later on in the subroutine values are accumulated into the array.

Note that only fluxes that are modified by the tphysac (via QNEG3/QNEG4) need to be in the restart file, so that on a restart run we get the modified values (for use in tphysbc) instead of the original values. This is currently just three fields (shf, lhf, cflx(:,1)) in the overwrite_flds code block.

So, in general, any flux from the coupler that is modified in tphysac() needs to be added to the atmosphere restart file, and, on a restart run, atm_import_export.F90 needs to be told to use the data in the restart file and ignore the data from the coupler for those fields.

In the future, if code is added that modifies another element of cflx (cflx(i,2) for example), a similar procedure will need to be applied.

Fixes #1040
[BFB] - Bit-For-Bit
