### PR TITLE
Removes asterisk(wildcard char) from xml tag of an ocean domain file

### DIFF
--- a/cime/scripts/Tools/config_grid.xml
+++ b/cime/scripts/Tools/config_grid.xml
@@ -593,6 +593,11 @@ do not use scientific experiments; use the T62_g16 resolution instead:
   <OCN_DOMAIN_FILE>domain.ocn.oEC60to30.150616.nc</OCN_DOMAIN_FILE>
 </griddom>
 
+<griddom grid="oEC60to30_ICG" mask="oEC60to30">
+  <ICE_DOMAIN_FILE>domain.ocn.oEC60to30.150616.nc</ICE_DOMAIN_FILE>
+  <OCN_DOMAIN_FILE>domain.ocn.oEC60to30.150616.nc</OCN_DOMAIN_FILE>
+</griddom>
+
 <griddom grid="oRRS30to10" mask="oRRS30to10">
   <ICE_DOMAIN_FILE>domain.ocn.oRRS30to10.150722.nc</ICE_DOMAIN_FILE>
   <OCN_DOMAIN_FILE>domain.ocn.oRRS30to10.150722.nc</OCN_DOMAIN_FILE>


### PR DESCRIPTION
This PR removes wildcard character (*) from xml tag of an ocean
domain file in config_grid.xml. Removing this character let the
tests run with ne30_oEC grid pick up the right ocean domain file.

PR #1053 introduced this wildcard character.

[BFB] - Bit-For-Bit
