### PR TITLE
Fix coupling intervals for new oRRS18to6 high-res ocean grid.

### DIFF
--- a/cime/scripts/Tools/config_compsets.xml
+++ b/cime/scripts/Tools/config_compsets.xml
@@ -1973,8 +1973,8 @@ DOCN%COPY => docn copy mode
 <ATM_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</ATM_NCPL>
 <LND_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</LND_NCPL>
 <ICE_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</ICE_NCPL>
-<OCN_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4.*oi%oRRS18to6">48</OCN_NCPL>
-<OCN_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4.*oi%oRRS15to5">96</OCN_NCPL>
+<OCN_NCPL compset="_CAM.*_CLM.*MPASO" grid="oi%oRRS18to6">48</OCN_NCPL>
+<OCN_NCPL compset="_CAM.*_CLM.*MPASO" grid="oi%oRRS15to5">96</OCN_NCPL>
 <GLC_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">1</GLC_NCPL>
 <ROF_NCPL compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">8</ROF_NCPL>
 


### PR DESCRIPTION
This pull request fixes the default coupling intervals for the oRRS18to6 ocean high-res grid, which has an ocean timestep of 6-min and requires a 30-minute coupling interval.

[BFB]
