### PR TITLE
Update WCYCL to AV1C-04P and fix alias for spunup

### DIFF
--- a/cime/scripts/Tools/config_compsets.xml
+++ b/cime/scripts/Tools/config_compsets.xml
@@ -80,9 +80,9 @@ value of RUN_STARTDATE will be date2.
 <COMPSET sname="ACME_WCYCL2000"                alias="A_WCYCL2000" >2000_CAM5%AV1C-L_CLM45%SPBC_MPASCICE_MPASO_MOSART_SGLC_SWAV</COMPSET>
 <COMPSET sname="ACME_WCYCL2000S"               alias="A_WCYCL2000S">2000_CAM5%AV1C-L_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</COMPSET>
 <COMPSET sname="ACME_WCYCL1850"                alias="A_WCYCL1850" >1850_CAM5%AV1C-L_CLM45%SPBC_MPASCICE_MPASO_MOSART_SGLC_SWAV</COMPSET>
-<COMPSET sname="ACME_WCYCL1850S"               alias="A_WCYCL1850" >1850_CAM5%AV1C-L_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</COMPSET>
+<COMPSET sname="ACME_WCYCL1850S"               alias="A_WCYCL1850S" >1850_CAM5%AV1C-L_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</COMPSET>
 <COMPSET sname="ACME_WCYCL20TR"                alias="A_WCYCL20TR" >20TR_CAM5%AV1C-L_CLM45%SPBC_MPASCICE_MPASO_MOSART_SGLC_SWAV</COMPSET>
-<COMPSET sname="ACME_WCYCL20TRS"               alias="A_WCYCL20TR" >20TR_CAM5%AV1C-L_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</COMPSET>
+<COMPSET sname="ACME_WCYCL20TRS"               alias="A_WCYCL20TRS" >20TR_CAM5%AV1C-L_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</COMPSET>
 
 <!-- ACME backup compsets -->
 <COMPSET sname="ACME_WCYCL1850_v0atm"          alias="A_WCYCL1850_v0atm" >1850_CAM5_CLM45%SP_MPASCICE_MPASO_MOSART_SGLC_SWAV</COMPSET>
@@ -806,20 +806,20 @@ GEOS => GEOS5 meteorology for "stand-alone" CAM
 <CAM_NML_USE_CASE compset="1850_CAM5.*AV1C-03">1850_cam5_av1c-03</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="1850_CAM5.*AV1C-04">1850_cam5_av1c-04</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="1850_CAM5.*AV1C-04P">1850_cam5_av1c-04p</CAM_NML_USE_CASE>
-<CAM_NML_USE_CASE compset="1850_CAM5.*AV1C-L" >1850_cam5_av1c-04</CAM_NML_USE_CASE>
+<CAM_NML_USE_CASE compset="1850_CAM5.*AV1C-L" >1850_cam5_av1c-04p</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-01">2000_cam5_av1c-01</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-02">2000_cam5_av1c-02</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-03">2000_cam5_av1c-03</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-04">2000_cam5_av1c-04</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-04P">2000_cam5_av1c-04p</CAM_NML_USE_CASE>
-<CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-L" >2000_cam5_av1c-04</CAM_NML_USE_CASE>
+<CAM_NML_USE_CASE compset="2000_CAM5.*AV1C-L" >2000_cam5_av1c-04p</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1F"   >2000_cam5_av1f</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1F-00">2000_cam5_av1f-00</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5.*AV1F-01">2000_cam5_av1f-01</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="20TR_CAM5.*AV1C-03">20TR_cam5_av1c-03</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="20TR_CAM5.*AV1C-04">20TR_cam5_av1c-04</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="20TR_CAM5.*AV1C-04P">20TR_cam5_av1c-04p</CAM_NML_USE_CASE>
-<CAM_NML_USE_CASE compset="20TR_CAM5.*AV1C-L" >20TR_cam5_av1c-04</CAM_NML_USE_CASE>
+<CAM_NML_USE_CASE compset="20TR_CAM5.*AV1C-L" >20TR_cam5_av1c-04p</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM5%COSP"   >2000_cam5_cosp</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="2000_CAM4%WCMX"   >waccmx_2000_cam4</CAM_NML_USE_CASE>
 <CAM_NML_USE_CASE compset="1996_CAM4%WCMX"   >waccmx_1996_cam4</CAM_NML_USE_CASE>
@@ -886,7 +886,7 @@ GEOS => GEOS5 meteorology for "stand-alone" CAM
 <desc compset="_CAM5.*AV1C-03"  >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- v03:</desc>
 <desc compset="_CAM5.*AV1C-04"  >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- v04:</desc>
 <desc compset="_CAM5.*AV1C-04P" >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- v04p:</desc>
-<desc compset="_CAM5.*AV1C-L"   >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- v03:</desc>
+<desc compset="_CAM5.*AV1C-L"   >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- v04p:</desc>
 <desc compset="_CAM5.*AV1F"  >CAM with familiar set of ACME atmospheric mods for V1 (72 Layers model):</desc>
 <desc compset="_CAM5.*AV1F-00"  >CAM with familiar set of ACME atmospheric mods for V1 (72 Layers model)- v00:</desc>
 <desc compset="_CAM5.*AV1F-01"  >CAM with familiar set of ACME atmospheric mods for V1 (72 Layers model) and ACES4BGC SOAG emissions- v01:</desc>


### PR DESCRIPTION
Update the WCYCL atmosphere AV1C-L to use the AV1C-04P CAM configurations.

Also fix a bug in the alias names for new compsets using SPUNUP versions of MPAS ocean and sea-ice.

Fixes #1062 

[CC] for any case with WCYCL or AV1C-L
