### PR TITLE
Cuda moved to 7.5; OpenACC flags applied in Depends, not Macros

### DIFF
--- a/cime/machines-acme/Depends.titan.pgi_acc
+++ b/cime/machines-acme/Depends.titan.pgi_acc
@@ -1,6 +1,54 @@
 dyn_comp.o: dyn_comp.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS_NOOPT) $(FREEFLAGS) $<
 
+microp_aero.o: microp_aero.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS_NOOPT) $(FREEFLAGS) $<
+
+
+
+bndry_mod.o: bndry_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+derivative_mod.o: derivative_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+edge_mod.o: edge_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+element_mod.o: element_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+openacc_utils_mod.o: openacc_utils_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+prim_advance_mod.o: prim_advance_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+prim_advection_mod.o: prim_advection_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+prim_si_mod.o: prim_si_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+solver_init_mod.o: solver_init_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+vertremap_mod.o: vertremap_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+viscosity_mod.o: viscosity_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+prim_driver_mod.o: prim_driver_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+physics_mod.o: physics_mod.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+physconst.o: physconst.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pin,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+
+
 #uwshcu.o: uwshcu.F90
 #	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS_NOOPT) $(FREEFLAGS) $<
 

--- a/cime/machines-acme/config_compilers.xml
+++ b/cime/machines-acme/config_compilers.xml
@@ -238,7 +238,7 @@ for mct, etc.
   <FC_AUTO_R8> -r8 </FC_AUTO_R8>
 
   <FFLAGS>  -i4 -Mlist  -time -Mstack_arrays -Mextend -byteswapio -Mflushz -Kieee  </FFLAGS>
-  <ADD_FFLAGS MODEL="cam"> -acc -ta=tesla,pin,cuda7.0,cc35,ptxinfo -Minfo=accel -DUSE_OPENACC=1 </ADD_FFLAGS>
+  <ADD_FFLAGS MODEL="cam">  </ADD_FFLAGS>
   <FFLAGS_NOOPT> -O0 -g -Ktrap=fp -Mbounds -Kieee  </FFLAGS_NOOPT>
   <ADD_FFLAGS_NOOPT compile_threaded="false"> </ADD_FFLAGS_NOOPT>
   <ADD_FFLAGS_NOOPT compile_threaded="true"> -mp </ADD_FFLAGS_NOOPT>
@@ -250,7 +250,7 @@ for mct, etc.
   <ADD_FFLAGS MODEL="dwav"> -Mnovect </ADD_FFLAGS>
   <ADD_FFLAGS MODEL="dice"> -Mnovect </ADD_FFLAGS>
   <ADD_FFLAGS MODEL="docn"> -Mnovect </ADD_FFLAGS>
-  <LDFLAGS> -time -Wl,--allow-multiple-definition -acc -ta=tesla,pin,cuda7.0,cc35,ptxinfo </LDFLAGS>
+  <LDFLAGS> -time -Wl,--allow-multiple-definition -acc -ta=tesla,pin,cuda7.5,cc35 </LDFLAGS>
   <SCC> pgcc </SCC>
   <SFC> pgf95 </SFC>
   <SCXX> pgc++ </SCXX>


### PR DESCRIPTION
The OpenACC flags for pgi_acc compiler on Titan are now applied only to the files that use them in Depends.titan.pgi_acc instead of to all of CAM in Macros.

The LD flags in Macros are left the same, but the CAM FFLAGS additions are removed.

[BFB] - Bit-For-Bit
