### PR TITLE
Read adiabatic or ideal_phys option from atmosphere namelist

### DIFF
--- a/components/cam/src/control/cam_control_mod.F90
+++ b/components/cam/src/control/cam_control_mod.F90
@@ -53,4 +53,37 @@ module cam_control_mod
 
       integer :: magfield_fix_year = 1995
 
+contains
+
+subroutine cam_ctrl_set_physics_type(phys_package)
+  use cam_abortutils, only : endrun
+  use spmd_utils,     only: masterproc
+
+  ! Dummy argument
+  character(len=*), intent(in) :: phys_package
+  ! Local variable
+  character(len=*), parameter :: subname = 'cam_ctrl_set_physics_type'
+
+  adiabatic = trim(phys_package) == 'adiabatic'
+  ideal_phys = trim(phys_package) == 'held_suarez'
+  moist_physics = .not. (adiabatic .or. ideal_phys)
+  if (adiabatic .and. ideal_phys) then
+    call endrun (subname//': FATAL: Only one of ADIABATIC or HELD_SUAREZ can be .true.')
+  end if
+
+  if ((.not. moist_physics) .and. aqua_planet) then
+    call endrun (subname//': FATAL: AQUA_PLANET not compatible with dry physics package, ('//trim(phys_package)//')')
+  end if
+
+  if (masterproc) then
+    if (adiabatic) then
+      write(iulog,*) 'Run model ADIABATICALLY (i.e. no physics)'
+    end if
+    if (ideal_phys) then
+      write(iulog,*) 'Run model with Held-Suarez physics forcing'
+    end if
+  end if
+
+end subroutine cam_ctrl_set_physics_type
+
 end module cam_control_mod

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -23,7 +23,7 @@ module atm_comp_mct
   use atm_import_export
   use cam_comp
   use cam_instance     , only: cam_instance_init, inst_suffix
-  use cam_control_mod  , only: nsrest, adiabatic, ideal_phys, aqua_planet, eccen, obliqr, lambm0, mvelpp
+  use cam_control_mod  , only: nsrest, aqua_planet, eccen, obliqr, lambm0, mvelpp
   use radiation        , only: radiation_do, radiation_nextsw_cday
   use phys_grid        , only: get_ncols_p, ngcols, get_gcol_p, get_rlat_all_p, &
 	                       get_rlon_all_p, get_area_all_p
@@ -204,8 +204,6 @@ CONTAINS
        call seq_infodata_GetData( infodata,                                           &
             case_name=caseid, case_desc=ctitle,                                       &
             start_type=starttype,                                                     &
-            atm_adiabatic=adiabatic,                                                  &
-            atm_ideal_phys=ideal_phys,                                                &
             aqua_planet=aqua_planet,                                                  &
             brnch_retain_casename=brnch_retain_casename,                              &
             single_column=single_column, scmlat=scmlat, scmlon=scmlon,                &

--- a/components/cam/src/physics/cam/phys_control.F90
+++ b/components/cam/src/physics/cam/phys_control.F90
@@ -155,6 +155,7 @@ subroutine phys_ctl_readnl(nlfile)
    use namelist_utils,  only: find_group_name
    use units,           only: getunit, freeunit
    use mpishorthand
+   use cam_control_mod, only: cam_ctrl_set_physics_type
 
    character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
 
@@ -256,6 +257,8 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(prc_exp1,                        1 , mpir8,   0, mpicom)
    call mpibcast(cld_sed,                         1 , mpir8,   0, mpicom)
 #endif
+
+   call cam_ctrl_set_physics_type(cam_physpkg)
 
    ! Error checking:
 


### PR DESCRIPTION
Currently, the driver tells the atmosphere model if it is to use
an adiabatic or ideal physics (modified Held-Suarez) option.
However, this is not the driver's responsibility and this functionality
is going to be removed from CIME. This commit redirects the atmosphere
model to read this information from its own namelist.
Note that this commit should be merged before the CIME change is
imported. Note that this change is NOT in CIME 5.1.

[BFB]
