### PR TITLE
ne4ne4 defaults for ATM

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -593,8 +593,8 @@
 <nox_emis_file  chem="waccm_mozart_mam3">atm/cam/chem/emis/1992-2010/emissions.NO.surface.1.9x2.5_c110426.nc</nox_emis_file>
 <co_emis_file   chem="waccm_mozart_mam3">atm/cam/chem/emis/1992-2010/emissions.CO.surface.1.9x2.5_c110426.nc</co_emis_file>
 <ch2o_emis_file chem="waccm_mozart_mam3">atm/cam/chem/emis/1992-2010/emissions.CH2O.surface.1.9x2.5_c110426.nc</ch2o_emis_file>
-<dms_emis_file  chem="waccm_mozart_mam3">atm/cam/chem/trop_mozart_aero/emis/aerocom_mam3_dms_surf_2000_c120315.nc</dms_emis_file>
-<so2_emis_file  chem="waccm_mozart_mam3">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so2_surf_2000_c120315.nc</so2_emis_file>
+<dms_emis_file	chem="waccm_mozart_mam3">atm/cam/chem/trop_mozart_aero/emis/aerocom_mam3_dms_surf_2000_c120315.nc</dms_emis_file>
+<so2_emis_file	chem="waccm_mozart_mam3">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so2_surf_2000_c120315.nc</so2_emis_file>
 
 <nox_emis_file  chem="waccm_mozart_sulfur">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_NOx_1850-2000_1.9x2.5.c090728.nc</nox_emis_file>
 <co_emis_file   chem="waccm_mozart_sulfur">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_CO_1850-2000_1.9x2.5.c090728.nc</co_emis_file>
@@ -602,7 +602,7 @@
 <so2_emis_file  chem="waccm_mozart_sulfur">atm/cam/chem/1850-2000_emis/IPCC_emissions_houw_SO2_1850-2000_1.9x2.5.c090522.nc</so2_emis_file> 
 
 <!-- super_fast Chemistry emissions -->
-<ch2o_emis_file    chem="super_fast_llnl">atm/cam/chem/trop_mozart/emis/emissions.CH2O.surface.T42LR.nc</ch2o_emis_file>
+<ch2o_emis_file	   chem="super_fast_llnl">atm/cam/chem/trop_mozart/emis/emissions.CH2O.surface.T42LR.nc</ch2o_emis_file>
 <co_emis_file      chem="super_fast_llnl">atm/cam/chem/trop_mozart/emis/emissions.CO.surface.T42LR.nc</co_emis_file>
 <dms_emis_file     chem="super_fast_llnl">atm/cam/chem/trop_mozart/emis/emissions.DMS.surface.T42LR.nc</dms_emis_file>
 <nox_emis_file     chem="super_fast_llnl">atm/cam/chem/trop_mozart/emis/emissions.NO.surface.T42LR.nc</nox_emis_file>
@@ -621,9 +621,9 @@
 
 <!-- modal aerosol emissions -->
 <nh3_emis_file     ver="mam">atm/cam/chem/trop_mozart_aero/emis/emis_NH3_2000_c111014.nc</nh3_emis_file>
-<dms_emis_file     ver="mam">atm/cam/chem/trop_mozart_aero/emis/aerocom_mam3_dms_surf_2000_c120315.nc</dms_emis_file>
-<so2_emis_file     ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so2_surf_2000_c120315.nc</so2_emis_file>
-<soag_emis_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_soag_1.5_surf_2000_c130422.nc</soag_emis_file>
+<dms_emis_file	   ver="mam">atm/cam/chem/trop_mozart_aero/emis/aerocom_mam3_dms_surf_2000_c120315.nc</dms_emis_file>
+<so2_emis_file	   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so2_surf_2000_c120315.nc</so2_emis_file>
+<soag_emis_file	   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_soag_1.5_surf_2000_c130422.nc</soag_emis_file>
 <bc_a1_emis_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_surf_2000_c120315.nc</bc_a1_emis_file>
 <bc_a3_emis_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_surf_2000_c120315.nc</bc_a3_emis_file>
 <bc_a4_emis_file   ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_surf_2000_c120315.nc</bc_a4_emis_file>
@@ -916,7 +916,7 @@
 
 <!-- dust emission tuning factor -->
 <dust_emis_fact                                                         >2.76D0</dust_emis_fact>
-<dust_emis_fact                                         chem="trop_bam" >4.2D0 </dust_emis_fact>
+<dust_emis_fact                                         chem="trop_bam"	>4.2D0 </dust_emis_fact>
 <dust_emis_fact                            phys="cam5"                  >0.35D0</dust_emis_fact>
 <dust_emis_fact          hgrid="0.47x0.63" phys="cam5"                  >0.45D0</dust_emis_fact>
 <dust_emis_fact          hgrid="0.23x0.31" phys="cam5"                  >0.45D0</dust_emis_fact>
@@ -1176,8 +1176,8 @@
 <zmconv_c0_ocn                   hgrid="256x512"  phys="cam4"         > 0.0040D0 </zmconv_c0_ocn>
 <zmconv_c0_ocn                   hgrid="512x1024" phys="cam4"         > 0.0040D0 </zmconv_c0_ocn>
 
-<zmconv_tau                       > 3600</zmconv_tau>
-<zmconv_alfa                        > 0.1</zmconv_alfa>
+<zmconv_tau			                                                      > 3600</zmconv_tau>
+<zmconv_alfa			                                                      > 0.1</zmconv_alfa>
 
 <zmconv_ke                                                            > 3.0E-6 </zmconv_ke>
 <zmconv_ke      dyn="fv"                                              > 1.0E-6 </zmconv_ke>


### PR DESCRIPTION
I have worked out a combination of parameters which allowed for FC5AV1C-04 to
run with an ne4ne4 mesh. Many of the default namelist parameters were missing
for this mesh: this includes viscosity, physics timesteps, coupler timesteps,
etc. being adjusted. This commit fixes #1076 .

Fixes #1076 
[BFB]
