### PR TITLE
Building HOMME without preqx bugfix

### DIFF
--- a/components/homme/test_execs/CMakeLists.txt
+++ b/components/homme/test_execs/CMakeLists.txt
@@ -164,12 +164,9 @@ ENDIF()
 IF(${BUILD_HOMME_PREQX})
   ADD_SUBDIRECTORY(baroC)
   ADD_SUBDIRECTORY(baroCam)
-ENDIF()
-
-IF(${BUILD_HOMME_PREQX_ACC} AND ${BUILD_HOMME_PREQX})
-  ADD_SUBDIRECTORY(baroCam-acc)
-  # add a test dependency here:
-  set_property(TEST baroCamMoist-acc APPEND PROPERTY DEPENDS baroCamMoist)
+  IF(${BUILD_HOMME_PREQX_ACC})
+    ADD_SUBDIRECTORY(baroCam-acc)
+  ENDIF()
 ENDIF()
 
 # Add the test exec subdirs for the prim executable
@@ -188,6 +185,11 @@ INCLUDE(${HOMME_SOURCE_DIR}/test/reg_test/run_tests/test-list.cmake)
 #  replaceBaselineResults target
 SET(TEST_DIR_LIST "")
 createTests(HOMME_TESTS)
+
+IF(${BUILD_HOMME_PREQX} AND ${BUILD_HOMME_PREQX_ACC})
+  # add a test dependency here:
+  set_property(TEST baroCamMoist-acc APPEND PROPERTY DEPENDS baroCamMoist)
+ENDIF()
 
 # End the file with the total number of test files
 FILE (APPEND ${HOMME_TEST_LIST} "\n")


### PR DESCRIPTION
Bugfix for the issue preventing compilation of HOMME without PREQX and PREQX_ACC.
The baroCamMoist_acc test was being built without verifying that PREQX_ACC was being built, causing failures. This test depends on PREQX, so it is now only built when both dependencies are met.
BFB, or it should be, assuming the fails I get on Skybridge master for acme_developer aren't hiding anything... 
