### PR TITLE
Added non-negativity constraints for CB aerosols

### DIFF
--- a/components/cam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/cam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -948,9 +948,9 @@ main_i_loop: &
 
       do lmz = 1, gas_pcnst
          if (lmapcc_all(lmz) > 0) then
-            q(i,k,lmz) = qgcm4(lmz)
+            q(i,k,lmz) = max(qgcm4(lmz),0.0_r8)  ! HW, to ensure non-negative
             if (lmapcc_all(lmz) >= lmapcc_val_aer) then
-               qqcw(i,k,lmz) = qqcwgcm4(lmz)
+               qqcw(i,k,lmz) = max(qqcwgcm4(lmz),0.0_r8)  !HW, to ensure non-negative
             end if
          end if
       end do

--- a/components/cam/src/physics/cam/ndrop.F90
+++ b/components/cam/src/physics/cam/ndrop.F90
@@ -1058,7 +1058,7 @@ subroutine dropmixnuc( &
                ptend%q(i,:,lptr) = 0.0_r8
                ptend%q(i,top_lev:pver,lptr) = raertend(top_lev:pver)           ! set tendencies for interstitial aerosol
                qqcw(mm)%fld(i,:) = 0.0_r8
-               qqcw(mm)%fld(i,top_lev:pver) = raercol_cw(top_lev:pver,mm,nnew) ! update cloud-borne aerosol
+               qqcw(mm)%fld(i,top_lev:pver) = max(raercol_cw(top_lev:pver,mm,nnew),0.0_r8) ! update cloud-borne aerosol; HW: ensure non-negative
             end do
          end do
 


### PR DESCRIPTION
Added non-negativity constraints for cloud-borne aerosol mass and number in two modules. This attempts to solve the recent problem of negative mass concentration of cloud-borne coarse-mode aerosol in a simulation on Mira. The answer should be BFB on most machines that don't produce negative masses in the first place. 

[BFB]
