### PR TITLE
Keep MPAS SCRATCH files open during init, run and finalization

### DIFF
--- a/components/mpas-cice/driver/ice_comp_mct.F
+++ b/components/mpas-cice/driver/ice_comp_mct.F
@@ -294,7 +294,7 @@ contains
        write (scratchFName,'(a,i9.9)') 'scratch_ice_',iam
        open(stdout_shr, file=trim(scratchFName), iostat=ioerr)
        if (ioerr /= 0) then
-          write (ioerrstr,'(a,i6,a,i3,a,i3)') 'rank=',iam,'unit=',stdout_shr,'iostat=',ioerr
+          write (ioerrstr,'(a,i9,a,i6,a,i9)') 'rank=',iam,',unit=',stdout_shr,',iostat=',ioerr
           call mpas_dmpar_global_abort('ERROR in ice_init_mct open stdout_shr '//trim(ioerrstr))
        endif
     else
@@ -967,8 +967,8 @@ contains
     if ( iam /= 0 ) then
        close(iceStdErrUnit, status='DELETE', iostat=ioerr)
        if (ioerr /= 0) then
-          write (ioerrstr,'(a,i6,a,i3,a,i3)') 'rank=',iam,'unit=',iceStdErrUnit,'iostat=',ioerr
-          call mpas_dmpar_global_abort('ERROR in ice_final_mct close iceStdErrUnit'//trim(ioerrstr))
+          write (ioerrstr,'(a,i9,a,i6,a,i9)') 'rank=',iam,',unit=',iceStdErrUnit,',iostat=',ioerr
+          call mpas_dmpar_global_abort('ERROR in ice_final_mct close iceStdErrUnit '//trim(ioerrstr))
        endif
     end if
 #endif

--- a/components/mpas-o/driver/ocn_comp_mct.F
+++ b/components/mpas-o/driver/ocn_comp_mct.F
@@ -300,8 +300,8 @@ contains
        write (scratchFName,'(a,i9.9)') 'scratch_ocn_',iam
        open(stdout_shr, file=trim(scratchFName), iostat=ioerr)
        if (ioerr /= 0) then
-          write (ioerrstr,'(a,i6,a,i3,a,i3)') 'rank=',iam,'unit=',stdout_shr,'iostat=',ioerr
-          call mpas_dmpar_global_abort('ERROR in ocn_init_mct open stdout_shr'//trim(ioerrstr))
+          write (ioerrstr,'(a,i9,a,i6,a,i9)') 'rank=',iam,',unit=',stdout_shr,',iostat=',ioerr
+          call mpas_dmpar_global_abort('ERROR in ocn_init_mct open stdout_shr '//trim(ioerrstr))
        endif
     else
        inquire(file='ocn_modelio.nml'//trim(inst_suffix),exist=exists)
@@ -1022,8 +1022,8 @@ contains
     if ( iam /= 0 ) then
        close(ocnStdErrUnit, status='DELETE', iostat=ioerr)
        if (ioerr /= 0) then
-          write (ioerrstr,'(a,i6,a,i3,a,i3)') 'rank=',iam,'unit=',ocnStdErrUnit,'iostat=',ioerr
-          call mpas_dmpar_global_abort('ERROR in ocn_final_mct close ocnStdErrUnit'//trim(ioerrstr))
+          write (ioerrstr,'(a,i9,a,i6,a,i9)') 'rank=',iam,',unit=',ocnStdErrUnit,',iostat=',ioerr
+          call mpas_dmpar_global_abort('ERROR in ocn_final_mct close ocnStdErrUnit '//trim(ioerrstr))
        endif
     end if
 #endif

--- a/components/mpasli/driver/glc_comp_mct.F
+++ b/components/mpasli/driver/glc_comp_mct.F
@@ -291,8 +291,8 @@ contains
        write (scratchFName,'(a,i9.9)') 'scratch_glc_',iam
        open(stdout_shr, file=trim(scratchFName), iostat=ioerr)
        if (ioerr /= 0) then
-          write (ioerrstr,'(a,i6,a,i3,a,i3)') 'rank=',iam,'unit=',stdout_shr,'iostat=',ioerr
-          call mpas_dmpar_global_abort('ERROR in glc_init_mct open stdout_shr'//trim(ioerrstr))
+          write (ioerrstr,'(a,i9,a,i6,a,i9)') 'rank=',iam,',unit=',stdout_shr,',iostat=',ioerr
+          call mpas_dmpar_global_abort('ERROR in glc_init_mct open stdout_shr '//trim(ioerrstr))
        endif
     else
        inquire(file='glc_modelio.nml'//trim(inst_suffix),exist=exists)
@@ -1058,8 +1058,8 @@ contains
     if ( iam /= 0 ) then
        close(glcStdErrUnit, status='DELETE', iostat=ioerr)
        if (ioerr /= 0) then
-          write (ioerrstr,'(a,i6,a,i3,a,i3)') 'rank=',iam,'unit=',glcStdErrUnit,'iostat=',ioerr
-          call mpas_dmpar_global_abort('ERROR in glc_final_mct close glcStdErrUnit'//trim(ioerrstr))
+          write (ioerrstr,'(a,i9,a,i6,a,i9)') 'rank=',iam,',unit=',glcStdErrUnit,',iostat=',ioerr
+          call mpas_dmpar_global_abort('ERROR in glc_final_mct close glcStdErrUnit '//trim(ioerrstr))
        endif
     end if
 #endif


### PR DESCRIPTION
Previously, SCRATCH files were opened and closed in each init_mct, run_mct and
final_mct call. With large number of MPI ranks that may
overwhelm a file system. This will instead open per-process temporary
files once in init_mct call and close once in final_mct call, keeping them
open in each run_mct call.

Fixes #1106 
[BFB]
