### PR TITLE
Fix gamma terms multiplication bug in mo_strato_rates.F90

### DIFF
--- a/components/cam/src/chemistry/mozart/mo_strato_rates.F90
+++ b/components/cam/src/chemistry/mozart/mo_strato_rates.F90
@@ -565,7 +565,7 @@ has_sadsulf : &
                      term1         = exp( -1374._r8*T_limiti )
                      Gamma_s       = 66.12_r8*H_cnt*M_hcl*term1
 		     if( pHCl_atm > 0._r8 ) then
-                        term1      = .612_r8*(Gamma_s*Gamma_b_hcl)* pCNT_atm/pHCl_atm
+                        term1      = .612_r8*(Gamma_s+Gamma_b_hcl)* pCNT_atm/pHCl_atm
                         Fhcl       = 1._r8/(1._r8 + term1)
 		     else
                         Fhcl       = 1._r8


### PR DESCRIPTION
In cam5_4_91 tag, a bug was fixed in mo_strato_rates.F90 regarding
gamma terms. In the current model,the gamma terms are multiplied
together but they needed to be added. This change should not
affect current F compsets.

[BFB] - Bit-For-Bit
