### PR TITLE
NETCDF (instead of PNETCDF) as default for constance

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -818,7 +818,7 @@
 	 <NODENAME_REGEX>constance</NODENAME_REGEX>
          <RUNDIR>/pic/scratch/$CCSMUSER/csmruns/$CASE/run</RUNDIR>
          <EXEROOT>/pic/scratch/$CCSMUSER/csmruns/$CASE/bld</EXEROOT>
-         <CESMSCRATCHROOT>/pic/scratch/$USER</CESMSCRATCHROOT>
+         <CESMSCRATCHROOT>/pic/scratch/$USER/csmruns</CESMSCRATCHROOT>
          <DIN_LOC_ROOT>/pic/projects/climate/csmdata/</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/pic/projects/climate/csmdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/pic/scratch/$CCSMUSER/archive/$CASE</DOUT_S_ROOT>

--- a/cime/machines-acme/config_pes.xml
+++ b/cime/machines-acme/config_pes.xml
@@ -1435,5 +1435,10 @@
     <NTASKS_WAV>1</NTASKS_WAV> <NTHRDS_WAV>1</NTHRDS_WAV> <ROOTPE_WAV>0</ROOTPE_WAV>
 </pes>
 
+<!-- Currently constance doesn't perform well with pnetcdf, resetting it to use netcdf  -->
+<pes MACH="constance">
+    <PIO_NUMTASKS>-1</PIO_NUMTASKS><PIO_STRIDE>-1</PIO_STRIDE> <PIO_TYPENAME>netcdf</PIO_TYPENAME> <PIO_ROOT>1</PIO_ROOT>
+</pes>
+
 
 </pesinfo>


### PR DESCRIPTION
PNETCDF is slow on Constance. This PR makes NETCDF the default.
This PR also modifies CESMSCRATCHROOT in machine files for Constance.

[BFB] - Bit-For-Bit
