### PR TITLE
Update Anvil's MAX_TASKS_PER_NODE to use all cores

### DIFF
--- a/cime/machines-acme/config_machines.xml
+++ b/cime/machines-acme/config_machines.xml
@@ -576,7 +576,7 @@
          <BATCHREDIRECT></BATCHREDIRECT>
          <SUPPORTED_BY>acme</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
-         <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+         <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
          <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
          <batch_system type="pbs" version="x.y">
             <queues>


### PR DESCRIPTION
Anvil nodes have 2 sockets with 18 cores/socket for a total of 36 cores. This will enable the use of all 36 cores.

[NML]
