### PR TITLE
Fixed a minor bug related to the RRTMG bug fix 

### DIFF
--- a/components/cam/src/physics/cam/micro_mg_cam.F90
+++ b/components/cam/src/physics/cam/micro_mg_cam.F90
@@ -2343,7 +2343,7 @@ subroutine micro_mg_cam_tend(state, ptend, dtime, pbuf)
             cldfsnow(i,k) = 0._r8
          end if
          ! If no cloud and snow, then set to 0.25
-         if( ( cldfsnow(i,k) .lt. 1.e-4_r8 ) .and. ( qsout(i,k) .gt. 1.e-6_r8 ) ) then
+         if( ( cldfsnow(i,k) .le. 1.e-4_r8 ) .and. ( qsout(i,k) .gt. 1.e-6_r8 ) ) then
             cldfsnow(i,k) = 0.25_r8
          end if
          ! Calculate in-cloud snow water path


### PR DESCRIPTION
 if( ( cldfsnow(i,k) .lt. 1.e-4_r8 ) .and. ( qsout(i,k) .gt. 1.e-6_r8 ) ) then

=>

 if( ( cldfsnow(i,k) .le. 1.e-4_r8 ) .and. ( qsout(i,k) .gt. 1.e-6_r8 ) ) then

It will change the model result only when cldfsnow(i,k) = 1.e-4 and qsout(i,k) > 1.e-6.
Originally we thought since the calculation is in double precision, the chance to have an exact number of 1.e-4_r8 is pretty small. Further investigation of the code shows that the variable "cldfsnow" is set to "cld", which has a minimum value of 1.e-4 (prescribed in another subroutine). So the bugfix indeed will make a difference (NBFB expected). This PR is on hold until the evaluation is done. 

This bug was fixed at NCAR together with the RRTMG bug fix. 

[non-BFB]