### PR TITLE
Fix MPAS drivers not correctly getting the ACME RUN_STARTDATE

### DIFF
--- a/components/mpas-cice/driver/ice_comp_mct.F
+++ b/components/mpas-cice/driver/ice_comp_mct.F
@@ -358,7 +358,7 @@ contains
 
         ! Setup start time. Will be over written later when clocks are synchronized
         call mpas_pool_get_config(domain % configs, "config_start_time", tempCharConfig)
-        tempCharConfig = "0001-01-01_00:00:00"
+        tempCharConfig = trim(tempCharConfig) // "0:00:00"
 
         ! Setup run duration. Will be ignored in coupled run, since coupler defines how long the run is.
         call mpas_pool_get_config(domain % configs, "config_run_duration", tempCharConfig)

--- a/components/mpas-o/driver/ocn_comp_mct.F
+++ b/components/mpas-o/driver/ocn_comp_mct.F
@@ -360,7 +360,7 @@ contains
 
         ! Setup start time. Will be over written later when clocks are synchronized
         call mpas_pool_get_config(domain_ptr % configs, "config_start_time", tempCharConfig)
-        tempCharConfig = "0001-01-01_00:00:00"
+        tempCharConfig = trim(tempCharConfig) // "0:00:00"
 
         ! Setup run duration. Will be ignored in coupled run, since coupler defines how long the run is.
         call mpas_pool_get_config(domain_ptr % configs, "config_run_duration", tempCharConfig)

--- a/components/mpasli/driver/glc_comp_mct.F
+++ b/components/mpasli/driver/glc_comp_mct.F
@@ -354,7 +354,7 @@ contains
 
         ! Setup start time. Will be over written later when clocks are synchronized
         call mpas_pool_get_config(domain % configs, "config_start_time", tempCharConfig)
-        tempCharConfig = "0001-01-01_00:00:00"
+        tempCharConfig = trim(tempCharConfig) // "0:00:00"
 
         ! Setup run duration. Will be ignored in coupled run, since coupler defines how long the run is.
         call mpas_pool_get_config(domain % configs, "config_run_duration", tempCharConfig)


### PR DESCRIPTION
This pull request fixes #1144 .  All three MPAS component drivers had been hardwired to use a start_time of "0001-01-01_00:00:00", and had issues -- either hangs, failures, or extremely long processing times -- when realistic RUN_STARTDATE's were specified in the ACME env_run.xml file.  This PR removes that hard-wiring and adds code to correct the resulting time string format.  It has been tested with ERS.T62_oQU120_ais20.MPAS_LISIO_TEST.anvil_intel runs using RUN_STARTDATE's of both "0001-01-01" and "1850-01-01".

[BFB]