### PR TITLE
Batch Arguments for CIME

### DIFF
--- a/cime/scripts/Tools/case.submit
+++ b/cime/scripts/Tools/case.submit
@@ -45,13 +45,16 @@ OR
     parser.add_argument("--resubmit", action="store_true",
                         help="Used with tests only, to continue rather than restart a test. ")
 
+    parser.add_argument("--batchargs",
+                        help="Used to pass additional arguments to batch system. ")
+
     args = parser.parse_args(args[1:])
 
     CIME.utils.expect(args.prereq is None, "--prereq not currently supported")
 
     CIME.utils.handle_standard_logging_options(args)
 
-    return args.caseroot, args.job, args.no_batch, args.resubmit
+    return args.caseroot, args.job, args.no_batch, args.resubmit, args.batchargs
 
 ###############################################################################
 def _main_func(description):
@@ -60,9 +63,9 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, job, no_batch, resubmit = parse_command_line(sys.argv, description)
+    caseroot, job, no_batch, resubmit, batchargs = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        submit(case, job=job, no_batch=no_batch, resubmit=resubmit)
+        submit(case, job=job, no_batch=no_batch, resubmit=resubmit, batchargs=batchargs)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/cime/utils/python/CIME/XML/env_batch.py
+++ b/cime/utils/python/CIME/XML/env_batch.py
@@ -349,7 +349,7 @@ class EnvBatch(EnvBase):
 
         return submitargs
 
-    def submit_jobs(self, case, no_batch=False, job=None):
+    def submit_jobs(self, case, no_batch=False, job=None, batchargs=None):
         alljobs = self.get_jobs()
         startindex = 0
         jobs = []
@@ -394,11 +394,11 @@ class EnvBatch(EnvBase):
                 jobid = None
 
             logger.warn("job is %s"%job)
-            depid[job] = self.submit_single_job(case, job, jobid, no_batch=no_batch)
+            depid[job] = self.submit_single_job(case, job, jobid, no_batch=no_batch, batchargs=batchargs)
             if self.batchtype == "cobalt":
                 break
 
-    def submit_single_job(self, case, job, depid=None, no_batch=False):
+    def submit_single_job(self, case, job, depid=None, no_batch=False, batchargs=None):
         logger.warn("Submit job %s"%job)
         caseroot = case.get_value("CASEROOT")
         batch_system = self.get_value("BATCH_SYSTEM", subgroup=None)
@@ -431,6 +431,9 @@ class EnvBatch(EnvBase):
             dep_string = self.get_value("depend_string", subgroup=None)
             dep_string = dep_string.replace("jobid",depid.strip()) # pylint: disable=maybe-no-member
             submitargs += " " + dep_string
+
+        if batchargs is not None:
+            submitargs += " " + batchargs
 
         batchsubmit = self.get_value("batch_submit", subgroup=None)
         expect(batchsubmit is not None,

--- a/cime/utils/python/CIME/case.py
+++ b/cime/utils/python/CIME/case.py
@@ -922,6 +922,6 @@ class Case(object):
 
         return newcase
 
-    def submit_jobs(self, no_batch=False, job=None):
+    def submit_jobs(self, no_batch=False, job=None, batchargs=None):
         env_batch = self.get_env('batch')
-        env_batch.submit_jobs(self, no_batch=no_batch, job=job)
+        env_batch.submit_jobs(self, no_batch=no_batch, job=job, batchargs=batchargs)

--- a/cime/utils/python/CIME/case_submit.py
+++ b/cime/utils/python/CIME/case_submit.py
@@ -13,7 +13,7 @@ from CIME.check_lockedfiles        import check_lockedfiles
 
 logger = logging.getLogger(__name__)
 
-def submit(case, job=None, resubmit=False, no_batch=False):
+def submit(case, job=None, resubmit=False, no_batch=False, batchargs=None):
     caseroot = case.get_value("CASEROOT")
     if job is None:
         if case.get_value("TEST"):
@@ -67,7 +67,7 @@ def submit(case, job=None, resubmit=False, no_batch=False):
     case.flush()
 
     logger.warn("submit_jobs %s"%job)
-    case.submit_jobs(no_batch=no_batch, job=job)
+    case.submit_jobs(no_batch=no_batch, job=job, batchargs=batchargs)
 
 def check_case(case, caseroot):
     check_lockedfiles(caseroot)


### PR DESCRIPTION
Added a simple method to pass arguments from case.submit to the batch system.
The user simply uses the --batchargs argument when running case.submit and then
provide the argument after, e.g.

case.submit --batchargs '--mail-user=user@server.com --mail-type=END'

[BFB]

This fixes #1179.