### PR TITLE
Update melvin gcc to 5.3.0

### DIFF
--- a/cime/cime_config/acme/machines/config_machines.xml
+++ b/cime/cime_config/acme/machines/config_machines.xml
@@ -546,7 +546,7 @@
         <command name="load">sems-env</command>
         <command name="load">sems-git</command>
         <command name="load">sems-python/2.7.9</command>
-        <command name="load">sems-gcc/5.1.0</command>
+        <command name="load">sems-gcc/5.3.0</command>
         <command name="load">sems-openmpi/1.8.7</command>
         <command name="load">sems-cmake/2.8.12</command>
         <command name="load">sems-netcdf/4.3.2/parallel</command>


### PR DESCRIPTION
Fixes build failure in ERP_Ln9.ne30_ne30.FC5.melvin_gnu.cam-outfrq9s

[BFB]