### PR TITLE
Update redsky configuration

### DIFF
--- a/cime/cime_config/acme/allactive/config_pesall.xml
+++ b/cime/cime_config/acme/allactive/config_pesall.xml
@@ -891,14 +891,14 @@
       <pes compset="any" pesize="any">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>256</ntasks_atm>
-          <ntasks_lnd>256</ntasks_lnd>
-          <ntasks_rof>256</ntasks_rof>
-          <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>256</ntasks_ocn>
-          <ntasks_glc>256</ntasks_glc>
-          <ntasks_wav>256</ntasks_wav>
-          <ntasks_cpl>256</ntasks_cpl>
+          <ntasks_atm>512</ntasks_atm>
+          <ntasks_lnd>512</ntasks_lnd>
+          <ntasks_rof>512</ntasks_rof>
+          <ntasks_ice>512</ntasks_ice>
+          <ntasks_ocn>512</ntasks_ocn>
+          <ntasks_glc>512</ntasks_glc>
+          <ntasks_wav>512</ntasks_wav>
+          <ntasks_cpl>512</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>

--- a/cime/cime_config/acme/machines/config_batch.xml
+++ b/cime/cime_config/acme/machines/config_batch.xml
@@ -250,7 +250,7 @@
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue jobmin="1" jobmax="480" default="true">ec</queue>
+      <queue jobmin="1" jobmax="512" default="true">ec</queue>
     </queues>
     <walltimes>
       <walltime default="true">2:00:00</walltime>
@@ -264,7 +264,7 @@
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue jobmin="1" jobmax="480" default="true">ec</queue>
+      <queue jobmin="1" jobmax="512" default="true">ec</queue>
     </queues>
     <walltimes>
       <walltime default="true">4:00:00</walltime>


### PR DESCRIPTION
ERP_Ld3.ne30_oEC.A_WCYCL2000 was getting killed on redsky due to running
out of memory. This PR doubles the number of tasks for this grid on
redsky and also increases the jobmax for the ec queue for both
redsky and skybridge.

[BFB]