### PR TITLE
Fix PIO error in CICE

### DIFF
--- a/components/cice/src/drivers/cpl/ice_history_write.F90
+++ b/components/cice/src/drivers/cpl/ice_history_write.F90
@@ -459,16 +459,16 @@
       title = 'CF-1.0'
       status =  &
            pio_put_att(File,pio_global,'conventions',title)
-
+      if (my_task == master_task) then
       call date_and_time(date=current_date, time=current_time)
-      write(start_time,1000) current_date(1:4), current_date(5:6), &
+        write(start_time,1000) current_date(1:4), current_date(5:6), &
            current_date(7:8), current_time(1:2), &
            current_time(3:4)
-1000  format('This dataset was created on ', &
+1000    format('This dataset was created on ', &
            a,'-',a,'-',a,' at ',a,':',a)
-
+      end if
+      call broadcast_scalar(start_time, my_task)
       status = pio_put_att(File,pio_global,'history',start_time)
-
       !-----------------------------------------------------------------
       ! end define mode
       !-----------------------------------------------------------------


### PR DESCRIPTION
  Time stamp in components/cice/src/drivers/cpl/ice_history_write.F90
  was not synchronized across processors. This can lead to PIO error
  "File header is inconsistent among processes" on occasions.
  This PR broadcast the time stamp from masterproc to other processors
  to fix the issue. (issue #952)

Fixes #952 
Fixes #1198 
  [BFB]