### PR TITLE
Fix incorrect CMPASO and GMPAS compsets in CIME5

### DIFF
--- a/components/mpas-o/cime_config/config_compsets.xml
+++ b/components/mpas-o/cime_config/config_compsets.xml
@@ -43,19 +43,24 @@
 
   <compset>
     <alias>CMPASO-NYF</alias>
-    <lname>2000_DATM%NYF_SLND_MPASCICE_MPASO_DROF%NYF_SGLC_SWAV</lname>
+    <lname>2000_DATM%NYF_SLND_DICE%SSMI_MPASO_DROF%NYF_SGLC_SWAV</lname>
     <support_level>"Experimental, under development"</support_level>
   </compset>
 
   <compset>
     <alias>CMPASO-IAF</alias>
-    <lname>2000_DATM%IAF_SLND_MPASCICE_MPASO_DROF%IAF_SGLC_SWAV</lname>
+    <lname>2000_DATM%IAF_SLND_DICE%SIAF_MPASO_DROF%IAF_SGLC_SWAV</lname>
     <support_level>Experimental, under development</support_level>
   </compset>
 
   <compset>
-    <alias>GMPAS</alias>
+    <alias>GMPAS-NYF</alias>
     <lname>2000_DATM%NYF_SLND_MPASCICE_MPASO_DROF%NYF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GMPAS-IAF</alias>
+    <lname>2000_DATM%IAF_SLND_MPASCICE_MPASO_DROF%IAF_SGLC_SWAV</lname>
   </compset>
 
 </compsets>


### PR DESCRIPTION
CIME5 has incorrect definitions for CMPASO and GMPAS compsets

In moving from CIME2 to CIME5, the MPAS compsets were incorrectly translated and need to be fixed. The CMPASO compsets are currently defined to include active MPAS-CICE (which makes them G compsets) instead of DICE, while one of the GMAS compsets is missing and the other is misnamed.  The results will not be BFB but only for CMPASO tests, since the components used will change back to the correct set.  This should not impact fully-coupled results. Resolves Issue #1208 .

[non-BFB]
[FCC]

