### PR TITLE
Adding a check for -DHORIZ_OPENMP in threaded runs

### DIFF
--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -149,6 +149,9 @@ CONTAINS
        write(iulog,*) "dyn_init1: number of OpenMP threads = ", nthreads
        write(iulog,*) " "
     endif
+#ifndef HORIZ_OPENMP
+    call endrun('Error: threaded runs require -DHORIZ_OPENMP')
+#endif
 #ifdef COLUMN_OPENMP
     call omp_set_nested(.true.)
     if (vthreads > nthreads .or. vthreads < 1) &


### PR DESCRIPTION
This adds a sanity check for CPP macros in threaded runs.

Fixes #1197 
[BFB] - Bit-For-Bit