### PR TITLE
Fix of *_NCPL for B Compsets with ne4_oQU240 Resolution

### DIFF
--- a/cime/driver_cpl/cime_config/config_component_acme.xml
+++ b/cime/driver_cpl/cime_config/config_component_acme.xml
@@ -287,6 +287,7 @@
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MPASLI">24</value>
       <value compset="_CAM.*_CLM.*MPASO">48</value>
+      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne4np4">$ATM_NCPL</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</value>
     </values>
@@ -306,6 +307,7 @@
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MPASLI">24</value>
       <value compset="_CAM.*_CLM.*MPASO">48</value>
+      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne4np4">$ATM_NCPL</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</value>
     </values>
@@ -334,6 +336,7 @@
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MPASLI">24</value>
       <value compset="_CAM.*_CLM.*MPASO">48</value>
+      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne4np4">$ATM_NCPL</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="oi%oRRS18to6">48</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="oi%oRRS15to5">96</value>
@@ -379,6 +382,7 @@
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MPASLI">24</value>
       <value compset="_CAM.*_CLM.*MPASO">8</value>
+      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne4np4">6</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">4</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">8</value>
     </values>


### PR DESCRIPTION
The ROF_NCPL was not compatible with ATM_NCPL, and the other NCPL settings were
not set correctly for B compsets with ne4_oQU240 resolution. This fixes these issues.

[BFB]