### PR TITLE
Adds tests for FC5AV1C-04P2 compset

### DIFF
--- a/cime/utils/python/update_acme_tests.py
+++ b/cime/utils/python/update_acme_tests.py
@@ -111,6 +111,7 @@ _TEST_SUITES = {
                          "SMS_D_Ln5.ne16_ne16.F1850C5AV1C-04",
                          "SMS_D_Ln5.ne16_ne16.F20TRC5AV1C-03",
                          "SMS_D_Ln5.ne16_ne16.FC5AV1C-04P",
+                         "SMS_D_Ln5.ne4_ne4.FC5AV1C-04P2",
                          "SMS_D_Ld1.ne16_ne16.FC5ATMMOD")
                         ),
 
@@ -145,6 +146,7 @@ _TEST_SUITES = {
                            "ERS_Ld5.ne30_oEC.F1850C5AV1C-02",
                            "ERS_Ld5.ne16_ne16.F1850C5AV1C-04",
                            "ERS_Ld5.ne16_ne16.F20TRC5AV1C-03",
+                           "ERP_Ld5_P8x4.ne4_ne4.FC5AV1C-04P2",
                            "SMS_D_Ld1.ne16_ne16.FC5ATMMODCOSP")
                           ),
 }


### PR DESCRIPTION
This PR adds SMS_D_Ln5 and ERP_Ld5_P8x4 tests for FC5AV1C-04P2 to the acme testing suites.

These tests are using ne4 grid resolution.

[BFB] - Bit-For-Bit