### PR TITLE
Fix issues with A_WCYCL1850S and A_WCYCL2000S introduced in CIME5.

### DIFF
--- a/components/mpas-cice/cime_config/buildnml
+++ b/components/mpas-cice/cime_config/buildnml
@@ -8,11 +8,11 @@ if ($#ARGV == -1) {
 my ($CASEROOT) = @ARGV;
 chdir "${CASEROOT}";
 
-my $CIMEROOT            = `./xmlquery  CIMEROOT            -value`;
+my $CIMEROOT        = `./xmlquery  CIMEROOT             -value`;
 my $CASEROOT        = `./xmlquery  CASEROOT		-value`;
 my $CASEBUILD       = `./xmlquery  CASEBUILD		-value`;
 my $COMPSET         = `./xmlquery  CCSM_COMPSET         -value`;
-my $SRCROOT        = `./xmlquery  SRCROOT              -value`;
+my $SRCROOT         = `./xmlquery  SRCROOT              -value`;
 my $OBJROOT         = `./xmlquery  OBJROOT		-value`;
 my $SCRIPTSROOT	    = `./xmlquery  SCRIPTSROOT		-value`;
 my $COMP_INTERFACE  = `./xmlquery  COMP_INTERFACE	-value`;
@@ -52,8 +52,8 @@ if ( $ICE_GRID eq 'oEC60to30' ) {
 	$decomp_date .= '151020';
 	$decomp_prefix .= 'mpas-cice.graph.info.';
 } elsif ( $ICE_GRID eq 'oEC60to30_ICG' ) {
-        $grid_date = '160827';
-	$grid_prefix = 'cice.EC60to30km.restartFrom_eos1b';
+        $grid_date .= '160827';
+	$grid_prefix .= 'cice.EC60to30km.restartFrom_eos1b';
 	$decomp_date .= '151020';
 	$decomp_prefix .= 'mpas-cice.graph.info.';
 } elsif ( $ICE_GRID eq 'oEC60to30wLI' ) {

--- a/components/mpas-cice/cime_config/config_component.xml
+++ b/components/mpas-cice/cime_config/config_component.xml
@@ -19,7 +19,7 @@
         <default_value>cold_start</default_value>
         <values>
            <value compset="MPASCICE_">cold_start</value> 
-           <value compset="_MPASCICE%SPINUP">spunup</value> 
+           <value compset="_MPASCICE%SPUNUP">spunup</value> 
         </values>
         <group>case_comp</group>
         <file>env_case.xml</file>


### PR DESCRIPTION
This PR fixes a mis-spelling in the mpas-cice component configuration set by compsets that specify using initial condition files for ocn/ice start-up.  It also includes minor clean-up in the buildnml file.  Fixes #1234 .

[BFB]