### PR TITLE
Improve default PE layouts on Edison

### DIFF
--- a/cime/cime_config/acme/allactive/config_pesall.xml
+++ b/cime/cime_config/acme/allactive/config_pesall.xml
@@ -5542,43 +5542,6 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30np4">
-    <mach name="edison">
-      <pes compset="CAM5.+CLM45.+CICE.+DOCN.+RTM.+SGLC.+SWAV" pesize="any">
-        <comment>"PMC - 114 node hyperthreaded F-compset gets 7.8 SYPD"</comment>
-        <ntasks>
-          <ntasks_atm>1350</ntasks_atm>
-          <ntasks_lnd>984</ntasks_lnd>
-          <ntasks_rof>984</ntasks_rof>
-          <ntasks_ice>384</ntasks_ice>
-          <ntasks_ocn>256</ntasks_ocn>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_wav>384</ntasks_wav>
-          <ntasks_cpl>984</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>4</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>384</rootpe_lnd>
-          <rootpe_rof>384</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>384</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>384</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="any">
     <mach name="cori-haswell">
       <pes compset="CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">


### PR DESCRIPTION
Replaces existing generic, poor-performing ne30 PE layouts on Edison with better values. 173 node and 375 node A_WCYCL1850 layouts were created by @worleyph a year or so ago and the 114 node F-compset layout was created by @PeterCaldwell.