### PR TITLE
Fix PIO stride at Mira+Cetus to 128 to avoid OOM errors

### DIFF
--- a/cime/cime_config/acme/machines/config_machines.xml
+++ b/cime/cime_config/acme/machines/config_machines.xml
@@ -1062,7 +1062,6 @@
       <env name="MPI_TYPE_MAX">100000</env>
       <env name="OMP_DYNAMIC">FALSE</env>
       <env name="OMP_STACKSIZE">64M</env>
-      <env name="HDF5">/soft/libraries/hdf5/1.8.14/cnk-xl/current</env>
     </environment_variables>
 </machine>
 
@@ -1185,7 +1184,6 @@
       <env name="MPI_TYPE_MAX">10000</env>
       <env name="OMP_DYNAMIC">FALSE</env>
       <env name="OMP_STACKSIZE">64M</env>
-      <env name="HDF5">/soft/libraries/hdf5/1.8.14/cnk-xl/current</env>
     </environment_variables>
 </machine>
 

--- a/cime/cime_config/acme/machines/config_pio.xml
+++ b/cime/cime_config/acme/machines/config_pio.xml
@@ -22,7 +22,7 @@
     <values>
       <value>$PES_PER_NODE</value>
       <value mach="yellowstone" grid="a%ne120.+oi%gx1">60</value>
-      <value mach="mira">64</value>
+      <value mach="mira|cetus">128</value>
     </values>
   </entry>
 


### PR DESCRIPTION
Fix PIO stride at Mira+Cetus to 128 to avoid OOM errors

[BFB] - Bit-For-Bit