### PR TITLE
Cleanup config_grids.xml file

### DIFF
--- a/cime/cime_config/acme/config_grids.xml
+++ b/cime/cime_config/acme/config_grids.xml
@@ -487,7 +487,7 @@
     <grid compset="(CAM5.+CLM.+MPASO%SPUNUP)">
       <sname>ne30np4_oEC60to30v3_ICG</sname>
       <lname>a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_m%oEC60to30v3_g%null_w%null</lname>
-      <alias>ne30_oEC_ICG</alias>
+      <alias>ne30_oECv3_ICG</alias>
     </grid>
 
     <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
@@ -1830,8 +1830,8 @@
     </gridmap>
     <gridmap atm_grid="T62" ocn_grid="oRRS18to6">
       <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6_aave.160831.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6_patc.160831.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6_blin.160831.nc</ATM2OCN_SMAPNAME>
+      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6_patch.160831.nc</ATM2OCN_VMAPNAME>
+      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6_bilin.160831.nc</ATM2OCN_SMAPNAME>
       <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_T62_aave.160831.nc</OCN2ATM_FMAPNAME>
       <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_T62_aave.160831.nc</OCN2ATM_SMAPNAME>
     </gridmap>
@@ -2054,99 +2054,155 @@
     <gridmap rof_grid="rx1" ocn_grid="gx3v7" >
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</ROF2OCN_RMAPNAME>
     </gridmap>
+
     <gridmap rof_grid="rx1" ocn_grid="gx1v6" >
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</ROF2OCN_RMAPNAME>
     </gridmap>
+
     <gridmap rof_grid="rx1" ocn_grid="tx1v1" >
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_tx1v1_e1000r300_090318.nc</ROF2OCN_RMAPNAME>
     </gridmap>
+
     <gridmap rof_grid="rx1" ocn_grid="tx0.1v2" >
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_tx0.1v2_e1000r200_090624.nc</ROF2OCN_RMAPNAME>
     </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="mpasgx1" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_mpasgx1_nn_150910.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="mpas120" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_mpas120_nn_131217.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="oQU240wLI" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oQU240wLI_nn.160929.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="oEC60to30" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30_nn.160527.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="oEC60to30v3" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="oEC60to30wLI" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30wLI_nn.160830.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10_nn.160527.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10v3" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10v3_smoothed.r150e300.161221.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10wLI" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10wLI_smoothed.r500e1000.160930.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="oRRS18to6" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS18to6_nn.160830.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="rx1" ocn_grid="oRRS18to6v3" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS18to6v3_smoothed.r100e200.170111.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
+
     <gridmap rof_grid="r05" ocn_grid="gx3v7" >
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</ROF2OCN_RMAPNAME>
     </gridmap>
+
     <gridmap rof_grid="r05" ocn_grid="gx1v6" >
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_gx1v6_e1000r300_090226.nc</ROF2OCN_RMAPNAME>
     </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="mpas120" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_QU120km_nn_151110.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="oQU240wLI" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oQU240wLI_nn.160929.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30_ICG" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30v3" >
-      <ROF2OCN_FMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_FMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30v3_ICG" >
-      <ROF2OCN_FMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_FMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30wLI" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30wLI_nn.160926.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="oRRS30to10" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10_nn.160718.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="oRRS30to10wLI" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10wLI_nn.160930.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
+
     <gridmap rof_grid="r05" ocn_grid="tx1v1" >
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</ROF2OCN_RMAPNAME>
     </gridmap>
+
     <gridmap rof_grid="r05" ocn_grid="tx0.1v2" >
       <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_tx0.1v2_r500e1000_080620.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r0125" ocn_grid="oRRS18to6" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6_nn.160831.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r0125" ocn_grid="oRRS18to6v3" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_nn.170111.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-    <gridmap rof_grid="r0125" ocn_grid="oRRS15to5" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS15to5_nn.160720.nc</ROF2OCN_RMAPNAME>
     </gridmap>
 
     <gridmap rof_grid="r01" ocn_grid="gx1v6" >
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_r01_to_gx1v6_120711.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <!--- deprecated MPAS grids -->
+    <gridmap rof_grid="rx1" ocn_grid="mpasgx1" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_mpasgx1_nn_150910.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="mpas120" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_mpas120_nn_131217.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="mpas120" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_QU120km_nn_151110.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <!--- current MPAS grids -->
+    <gridmap rof_grid="rx1" ocn_grid="oQU240" >
+      <ROF2OCN_RMAPNAME>cpl/cpl6/map_rx1_to_oQU240_nn.160527.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oQU240wLI" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oQU240wLI_nn.160929.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oQU120" >
+      <ROF2OCN_RMAPNAME>cpl/cpl6/map_rx1_to_oQU120_nn.160527.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oEC60to30" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30_nn.160527.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oEC60to30v3" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oEC60to30wLI" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30wLI_nn.160830.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10_nn.160527.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10v3" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10v3_smoothed.r150e300.161221.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10wLI" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10wLI_smoothed.r150e300.160930.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oRRS18to6" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS18to6_nn.160830.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oRRS18to6v3" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS18to6v3_smoothed.r100e200.170111.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="rx1" ocn_grid="oRRS15to5" >
+      <ROF2OCN_RMAPNAME>cpl/cpl6/map_rx1_to_oRRS15to5_nn.160527.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oQU240" >
+      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oQU240_nn.160714.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oQU240wLI" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oQU240wLI_nn.160929.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oQU120" >
+      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oQU120_nn.160718.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oEC60to30" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oEC60to30_ICG" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oEC60to30v3" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oEC60to30v3_ICG" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oEC60to30wLI" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30wLI_smoothed.r300e600.160926.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oRRS30to10" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10_nn.160718.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oRRS30to10wLI" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10wLI_nn.160930.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r05" ocn_grid="oRRS15to5" >
+      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oRRS15to5_nn.160203.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r0125" ocn_grid="oRRS18to6" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6_nn.160831.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r0125" ocn_grid="oRRS18to6v3" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_nn.170111.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+
+    <gridmap rof_grid="r0125" ocn_grid="oRRS15to5" >
+      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS15to5_nn.160720.nc</ROF2OCN_RMAPNAME>
     </gridmap>
 
     <!--- river flooding variables -->
@@ -2481,78 +2537,6 @@
     <gridmap lnd_grid="48x96" rof_grid="r05">
       <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/48x96/map_48x96_nomask_to_0.5x0.5_nomask_aave_da_c110822.nc</LND2ROF_FMAPNAME>
       <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/48x96/map_0.5x0.5_nomask_to_48x96_nomask_aave_da_c110822.nc</ROF2LND_FMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oQU240" rof_grid="rx1">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_rx1_to_oQU240_nn.160527.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oQU240" rof_grid="r05">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oQU240_nn.160714.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oQU120" rof_grid="rx1">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_rx1_to_oQU120_nn.160527.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oQU120" rof_grid="r05">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oQU120_nn.160718.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oEC60to30" rof_grid="r05">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oEC60to30_ICG" rof_grid="r05">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oEC60to30v3" rof_grid="r05">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oEC60to30v3_ICG" rof_grid="r05">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS30to10" rof_grid="rx1">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oRRS30to10_nn.160718.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS30to10" rof_grid="r05">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oRRS30to10_nn.160718.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS30to10v3" rof_grid="rx1">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_rx1_to_oRRS30to10v3_smoothed.r150e300.161221.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS18to6" rof_grid="rx1">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_rx1_to_oRRS18to6_nn.160830.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS18to6" rof_grid="r0125">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r0125_to_oRRS18to6_nn.160831.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS18to6v3" rof_grid="rx1">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_rx1_to_oRRS18to6v3_smoothed.r100e200.170111.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS18to6v3" rof_grid="r0125">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r0125_to_oRRS18to6v3_nn.170111.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS15to5" rof_grid="rx1">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_rx1_to_oRRS15to5_nn.160527.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS15to5" rof_grid="r05">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_oRRS15to5_nn.160203.nc</ROF2OCN_RMAPNAME>
-    </gridmap>
-
-    <gridmap ocn_grid="oRRS15to5" rof_grid="r0125">
-      <ROF2OCN_RMAPNAME>cpl/cpl6/map_r0125_to_oRRS15to5_nn.160720.nc</ROF2OCN_RMAPNAME>
     </gridmap>
 
     <gridmap glc_grid="gland4" lnd_grid="48x96">


### PR DESCRIPTION
This PR will clean up the config_grids.xml file to:
* remove duplicate entries for rof=>ocn maps that had previously been in two places;
* remove unused rof2ocn_fmapname settings;
* fix discrepancies in file naming (described in issue 1178); and
* fix cut-and-paste error in compset alias name.

[BFB]
