### PR TITLE
Adding flags to GNU DEBUG=TRUE builds

### DIFF
--- a/cime/cime_config/acme/machines/config_compilers.xml
+++ b/cime/cime_config/acme/machines/config_compilers.xml
@@ -404,9 +404,9 @@ for mct, etc.
   <ADD_CMAKE_OPTS MODEL="cism"> -D CISM_GNU=ON </ADD_CMAKE_OPTS>
   <FIXEDFLAGS>  -ffixed-form </FIXEDFLAGS>
   <FREEFLAGS> -ffree-form </FREEFLAGS>
-  <ADD_FFLAGS DEBUG="TRUE"> -g -Wall </ADD_FFLAGS>
+  <ADD_FFLAGS DEBUG="TRUE"> -g -Wall -Og -fbacktrace -fcheck=bounds -ffpe-trap=invalid,zero,overflow</ADD_FFLAGS>
   <ADD_FFLAGS DEBUG="FALSE"> -O </ADD_FFLAGS>
-  <ADD_CFLAGS DEBUG="TRUE"> -g -Wall </ADD_CFLAGS>
+  <ADD_CFLAGS DEBUG="TRUE"> -g -Wall -Og -fbacktrace -fcheck=bounds -ffpe-trap=invalid,zero,overflow</ADD_CFLAGS>
   <ADD_CFLAGS DEBUG="FALSE"> -O </ADD_CFLAGS>
   <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS
        so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->


### PR DESCRIPTION
Adding flags to GNU DEBUG=TRUE builds
-Og -fbacktrace -fcheck=bounds -ffpe-trap=invalid,zero,overflow

Fixes #1231 