### PR TITLE
Fix alias for ne30np4_oEC60to30v3 grid

### DIFF
--- a/cime/cime_config/acme/config_grids.xml
+++ b/cime/cime_config/acme/config_grids.xml
@@ -725,7 +725,7 @@
     <grid>
       <sname>ne30np4_oEC60to30v3</sname>
       <lname>a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_m%oEC60to30v3_g%null_w%null</lname>
-      <alias>ne30_oEC</alias>
+      <alias>ne30_oECv3</alias>
     </grid>
 
     <grid>


### PR DESCRIPTION
This PR fixes the alias for the new ne30np4_oEC60to30v3 grid