### PR TITLE
Added git to modules for cori

### DIFF
--- a/cime/cime_config/acme/machines/config_machines.xml
+++ b/cime/cime_config/acme/machines/config_machines.xml
@@ -290,6 +290,7 @@
       </modules>
 
       <modules>
+        <command name="load">git</command>
 	<command name="load">cmake/3.3.2</command>
 	<command name="load">pmi/5.0.10-1.0000.11050.0.0.ari</command>
 	<command name="load">papi/5.4.3.2</command>
@@ -424,6 +425,7 @@
 	<command name="load">cray-parallel-netcdf/1.7.0</command>
       </modules>
       <modules>
+        <command name="load">git</command>
 	<command name="load">cmake/3.3.2</command>
 	<command name="load">pmi/5.0.10-1.0000.11050.0.0.ari</command>
 	<command name="load">papi/5.4.3.2</command>


### PR DESCRIPTION
When trying to run acme on cori-haswell or cori-knl we get an error about git
not being in the path. To mitigate this I added a module load git to the
machines file for cori-*.

[BFB]