### PR TITLE
Changes to use module craype-mic-knl to build/run on KNL nodes of Cori.

### DIFF
--- a/cime/cime_config/acme/machines/config_compilers.xml
+++ b/cime/cime_config/acme/machines/config_compilers.xml
@@ -586,8 +586,6 @@ for mct, etc.
 </compiler>
 
 <compiler COMPILER="intel" MACH="cori-knl">
-  <ADD_FFLAGS> -xMIC-AVX512 -diag-disable 10121</ADD_FFLAGS>
-  <ADD_CFLAGS> -axMIC-AVX512 -xCORE-AVX2 </ADD_CFLAGS>
   <ADD_FFLAGS DEBUG="FALSE"> -O2 -qno-opt-dynamic-align</ADD_FFLAGS>
   <ADD_CFLAGS DEBUG="FALSE"> -O2  </ADD_CFLAGS>
   <ADD_CFLAGS compile_threaded="true"> -qopenmp </ADD_CFLAGS>
@@ -596,8 +594,7 @@ for mct, etc.
   <ADD_LDFLAGS compile_threaded="true"> -qopenmp </ADD_LDFLAGS>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <ADD_SLIBS> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </ADD_SLIBS>
-  <ADD_SLIBS> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </ADD_SLIBS>
-  <!--ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS-->
+  <ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS>
 
   <ADD_GPTL_CPPDEFS> -DHAVE_PAPI </ADD_GPTL_CPPDEFS>
   <ADD_CPPDEFS>  -DHAVE_SLASHPROC </ADD_CPPDEFS>

--- a/cime/cime_config/acme/machines/config_machines.xml
+++ b/cime/cime_config/acme/machines/config_machines.xml
@@ -406,8 +406,7 @@
 	<command name="rm">craype</command>
 	<command name="load">craype/2.5.7</command>
 
-	<command name="load">craype-haswell</command>
-	<!--command name="load">craype-mic-knl</command-->
+	<command name="load">craype-mic-knl</command>
 
 	<command name="load">cray-mpich/7.4.4</command>
       </modules>


### PR DESCRIPTION
Changes to use module craype-mic-knl to build/run on KNL nodes of Cori.
Including simplifying our MKL link flags on cori-knl only for now.