### PR TITLE
Fix negative leaf intracellular CO2 computed in PhotosynthesisMod

### DIFF
--- a/components/clm/src/biogeophys/PhotosynthesisMod.F90
+++ b/components/clm/src/biogeophys/PhotosynthesisMod.F90
@@ -1393,10 +1393,6 @@ contains
       ! Net photosynthesis. Exit iteration if an < 0
 
       an(p,iv) = ag(p,iv) - lmr_z
-!      if (an(p,iv) < 0._r8) then
-!         fval = 0._r8
-!         return
-!      endif
       ! Quadratic gs_mol calculation with an known. Valid for an >= 0.
       ! With an <= 0, then gs_mol = bbb
       if(an(p,iv)<=0.0)then


### PR DESCRIPTION
The current PhotosynthesisMod returns negative ci (intracellular CO2) in exiting
the photosynthesis solver, because the mathematical formulation of photosynthesis
and stomata conductance does not guarantee a solution. This fix ensures that ci 
is always positive by forcing the solver to converge in cases when no solution is available.  

[Non BFB] not- Bit-For-Bit
Fixes #1233 
