### PR TITLE
Fix uninitialized function variable and add testing on its return

### DIFF
--- a/components/cice/src/source/ice_spacecurve.F90
+++ b/components/cice/src/source/ice_spacecurve.F90
@@ -1139,6 +1139,7 @@ contains
        integer (int_kind) :: i
 
        found = .false.
+       res = 0
        i=1
        do while (i<=fac%numfact .and. (.not. found))
           if(fac%used(i) == 0) then
@@ -1189,8 +1190,10 @@ contains
 
       val1 = FirstFactor(fac1)
 !JMD      print *,'Matchfactor: found value: ',val1
-      found = FindandMark(fac2,val1,.true.)
-      tmp = FindandMark(fac1,val1,found)
+      if (val1.ge.1) then
+        found = FindandMark(fac2,val1,.true.)
+        tmp = FindandMark(fac1,val1,found)
+      endif
       if (found) then
         val = val1
       else


### PR DESCRIPTION
This PR fixes an uninitialized variable in function FirstFactor in ice_spacecurve.F90 and adds testing of its returned value in the calling routine.   It resolves Issue #880 , though not exactly in the manner suggested by the reporter.   The uninitialized variable, res, is initialized to 0, which would be an invalid return value for this variable, because it represents the index of a particular value in a derived type array:
      res = 0
       i=1
       do while (i<=fac%numfact .and. (.not. found))
          if(fac%used(i) == 0) then
                res = fac%factors(i)
                found = .true.
          endif
          i=i+1
        enddo
This function is only called by one subroutine, so in the calling routine a check is added to make sure the returned value is valid before using it.

Tested with SMS_D.f19_f19.FC5.edison_intel

[BFB]