### PR TITLE
Default and MPI-OpenMP PE Layouts for ne4 on Anvil

### DIFF
--- a/cime/cime_config/acme/allactive/config_pesall.xml
+++ b/cime/cime_config/acme/allactive/config_pesall.xml
@@ -5949,8 +5949,6 @@
     <mach name="anvil">
       <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
         <comment> -compset A_WCYCL* -res ne4_oQU240 on 7 nodes pure-MPI </comment>
-        <PES_PER_NODE>36</PES_PER_NODE>
-        <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>96</ntasks_atm>
           <ntasks_lnd>32</ntasks_lnd>
@@ -5984,8 +5982,6 @@
       </pes>
       <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="L">
         <comment> -compset A_WCYCL2000 -res ne4_oQU240 on 24 nodes MPI-OpenMP </comment>
-        <PES_PER_NODE>36</PES_PER_NODE>
-        <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>96</ntasks_atm>
           <ntasks_lnd>32</ntasks_lnd>


### PR DESCRIPTION
Added a default PE layout for A_WCYCL2000 ne4_Qu240 and a MPI-OpenMP 'L' layout
for Anvil.

This PR requires #1223, since the *_NCPL are not all compatible.

[BFB]