### PR TITLE
Set bfbflag=true by default

### DIFF
--- a/cime/driver_cpl/cime_config/config_component.xml
+++ b/cime/driver_cpl/cime_config/config_component.xml
@@ -3500,7 +3500,7 @@
   <entry id="BFBFLAG">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
+    <default_value>TRUE</default_value>
     <group>run_flags</group>
     <file>env_run.xml</file>
     <desc>turns on coupler bit-for-bit reproducibility with varying pe counts</desc>


### PR DESCRIPTION
Changes 1 line of CIME code in order to make bfbflag true by default. bfbflag=true means the coupled model will be bfb reproducible when rerun using different core count and thread number. This was not the default behavior in the past because it was thought to be slower. @worleyph recently demonstrated that bfbflag=true does not seem to have a noticable performance penalty. @golaz requested this change. I tested that this change worked on Edison. 