### PR TITLE
Adds endrun calls if singular matrices are detected by CLUBB routines

### DIFF
--- a/components/cam/src/physics/clubb/error_code.F90
+++ b/components/cam/src/physics/clubb/error_code.F90
@@ -63,6 +63,7 @@ module error_code
 
     use constants_clubb, only: & 
         fstderr ! Variable(s)
+    use cam_abortutils, only: endrun
 
     implicit none
 
@@ -75,30 +76,39 @@ module error_code
 
     case ( clubb_no_error )
       write(fstderr,*) "No errors reported."
+      return
 
     case ( clubb_var_less_than_zero )
       write(fstderr,*) "Variable in CLUBB is less than zero."
+      call endrun()
 
     case ( clubb_singular_matrix )
       write(fstderr,*) "Singular Matrix in CLUBB."
+      call endrun()
 
     case ( clubb_var_equals_NaN )
       write(fstderr,*) "Variable in CLUBB is NaN."
+      call endrun()
 
     case ( clubb_bad_lapack_arg )
       write(fstderr,*) "Argument passed to a LAPACK procedure is invalid."
+      call endrun()
 
     case ( clubb_rtm_level_not_found )
       write(fstderr,*) "rtm level not found"
+      call endrun()
 
     case ( clubb_var_out_of_bounds )
       write(fstderr,*) "Input variable is out of bounds."
+      call endrun()
 
     case ( clubb_var_out_of_range )
       write(fstderr,*) "A CLUBB variable had a value outside the valid range."
+      call endrun()
 
     case default
       write(fstderr,*) "Unknown error: ", err_code
+      call endrun()
 
     end select
 

--- a/components/cam/src/physics/clubb/lapack_wrap.F90
+++ b/components/cam/src/physics/clubb/lapack_wrap.F90
@@ -24,6 +24,8 @@ module lapack_wrap
     core_rknd, & ! Variable(s)
     dp
 
+  use cam_abortutils, only: endrun
+
   implicit none
 
   ! Simple routines
@@ -527,6 +529,7 @@ module lapack_wrap
         write(fstderr,*) trim( solve_type )// & 
           " band solver: singular matrix"
         err_code = clubb_singular_matrix
+        call endrun ('lapack_wrap.F90: Singular matrix detected in band_solvex')
       end if
 
     end select
@@ -692,6 +695,7 @@ module lapack_wrap
       err_code = clubb_singular_matrix
 
       solution = -999._core_rknd
+      call endrun ('lapack_wrap.F90: Singular matrix detected in band_solve')
 
     end select
 


### PR DESCRIPTION
This PR also adds endrun calls if other errors are detected by the CLUBB
 routines.

[BFB] - Bit-For-Bit

Fixes #1292