### PR TITLE
Add lost code to set variable based on ic_mode, for ICG compsets.

### DIFF
--- a/components/mpas-cice/bld/build-namelist
+++ b/components/mpas-cice/bld/build-namelist
@@ -480,7 +480,11 @@ add_default($nl, 'config_nSnowLayers');
 # Namelist group: initialize #
 ##############################
 
-add_default($nl, 'config_initial_condition_type');
+if ($ic_mode eq 'spunup') {
+        add_default($nl, 'config_initial_condition_type', 'val'=>"restart");
+} else {
+        add_default($nl, 'config_initial_condition_type');
+}
 add_default($nl, 'config_initial_ice_area');
 add_default($nl, 'config_initial_ice_volume');
 add_default($nl, 'config_initial_snow_volume');


### PR DESCRIPTION
This PR will add back some coding to set the mpas-cice config_initial_condition_type based on the IC_MODE in build-namelist.  This is required for ICG compsets and was somehow lost.

[BFB]