### PR TITLE
Change EC60to30v3 timestep from 15m to 30m

### DIFF
--- a/components/mpas-o/bld/namelist_files/namelist_defaults_mpas-o.xml
+++ b/components/mpas-o/bld/namelist_files/namelist_defaults_mpas-o.xml
@@ -47,8 +47,8 @@
 <config_dt ocn_grid="oQU240">'01:00:00'</config_dt>
 <config_dt ocn_grid="oQU240wLI">'02:00:00'</config_dt>
 <config_dt ocn_grid="oQU120">'00:30:00'</config_dt>
-<config_dt ocn_grid="oEC60to30">'00:15:00'</config_dt>
-<config_dt ocn_grid="oEC60to30v3">'00:15:00'</config_dt>
+<config_dt ocn_grid="oEC60to30">'00:30:00'</config_dt>
+<config_dt ocn_grid="oEC60to30v3">'00:30:00'</config_dt>
 <config_dt ocn_grid="oEC60to30wLI">'00:30:00'</config_dt>
 <config_dt ocn_grid="oRRS30to10">'00:06:00'</config_dt>
 <config_dt ocn_grid="oRRS30to10v3">'00:10:00'</config_dt>


### PR DESCRIPTION
In our performance and testing work, we found that the EC60to30 may be
run with a 30 minute timestep, from 15 minutes previously.  This will
nearly double the speed of the ocean component.

[non-BFB]