### PR TITLE
Increase jobmax on redsky

### DIFF
--- a/cime/cime_config/acme/machines/config_batch.xml
+++ b/cime/cime_config/acme/machines/config_batch.xml
@@ -245,7 +245,7 @@
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue jobmin="1" jobmax="480" walltimemax="01:00:00" default="true">ec</queue>
+      <queue jobmin="1" jobmax="1024" walltimemax="06:00:00" default="true">ec</queue>
     </queues>
   </batch_system>
 
@@ -254,7 +254,7 @@
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue jobmin="1" jobmax="480" walltimemax="01:00:00" default="true">ec</queue>
+      <queue jobmin="1" jobmax="1024" walltimemax="06:00:00" default="true">ec</queue>
     </queues>
   </batch_system>
 


### PR DESCRIPTION
Some of our tests were asking for more than the 480 max. This
meant that no queue satisfied the need and the null queue was selected
which is not valid on redsky.

[BFB]