### PR TITLE
Add ne120 compsetis based on AV1C-04P2

### DIFF
--- a/cime/driver_cpl/cime_config/config_component_acme.xml
+++ b/cime/driver_cpl/cime_config/config_component_acme.xml
@@ -539,6 +539,8 @@
       <value compset="^2000.+AV1C-04P"				>368.865</value>
       <value compset="^2000.+AV1C-04P2"				>368.865</value>
       <value compset="^2000.+AV1C-L"				>368.865</value>
+      <value compset="^2000.+AV1C-H01A"				>368.865</value>
+      <value compset="^2000.+AV1C-H01B"				>368.865</value>
       <!-- Override values based on CAM (WACCM) chemistry -->
       <value compset="CAM[45]%W"				>0.000001</value>
       <value compset="CAM[45]%SSOA"				>0.000001</value>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01a.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01a.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Solar constant from Lean (via Caspar Ammann): SOLAR_TSI_Lean_1610-2140_annual_c100301.nc -->
+<solar_data_file>atm/cam/solar/spectral_irradiance_Lean_1976-2007_ave_c20160517.nc</solar_data_file>
+<solar_data_ymd>20000101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 2000 GHG values from AR5 (from ghg_hist_1765-2012_c130501.nc) -->
+<!-- <co2vmr>368.865e-6</co2vmr> Set by CCSM_CO2_PPMV in config_compset.xml -->
+<ch4vmr>1751.022e-9</ch4vmr>
+<n2ovmr>315.85e-9</n2ovmr>
+<f11vmr>676.0526e-12</f11vmr>
+<f12vmr>537.05e-12</f12vmr>
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc>.true.</use_hetfrz_classnuc>
+<use_preexisting_ice>.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc>.true.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep>.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning>.true.</sscav_tuning>
+<convproc_do_aer>.true.</convproc_do_aer>
+<convproc_do_gas>.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc>.true.</demott_ice_nuc>
+<liqcf_fix>.true.</liqcf_fix>
+<regen_fix>.true.</regen_fix>
+<resus_fix>.true.</resus_fix>
+<mam_amicphys_optaa>1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning>.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c140303.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<clubb_ice_deep>     16.e-6 </clubb_ice_deep>
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
+<clubb_liq_sh>       10.e-6 </clubb_liq_sh>
+<clubb_C2rt>         1.75D0 </clubb_C2rt>
+<effgw_oro>          0.25    </effgw_oro>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<dust_emis_fact>     2.05D0 </dust_emis_fact>
+<clubb_gamma_coef>   0.32   </clubb_gamma_coef>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<clubb_c_K10>        0.3    </clubb_c_K10>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<so4_sz_thresh_icenuc>0.075e-6</so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add       >0.8D0</zmconv_tiedke_add>
+<zmconv_cape_cin         >1</zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   >2</zmconv_mx_bot_lyr_adj>
+<taubgnd                 >2.5D-3 </taubgnd>
+<clubb_C1                >1.335</clubb_C1>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<se_ftype                >2</se_ftype>
+<relvar_fix              >.true.</relvar_fix>
+<mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+
+
+<!-- Parameters further tuned for ne120 L72 configuration based on AV1C-04P2 -->
+
+<zmconv_alfa         >0.2D0</zmconv_alfa>
+<zmconv_c0_lnd       >0.0035D0</zmconv_c0_lnd>
+<zmconv_c0_ocn       >0.0043D0</zmconv_c0_ocn>
+<zmconv_dmpdz        >-0.2e-3</zmconv_dmpdz>
+<zmconv_ke           >5.0E-6</zmconv_ke>
+<cldfrc_dp1          >0.030D0</cldfrc_dp1>
+<clubb_C8            >4.73D0</clubb_C8>
+<clubb_C14           >1.75D0</clubb_C14>
+<se_nsplit           >6</se_nsplit>
+<rsplit              >2</rsplit>
+<qsplit              >1</qsplit>
+<cld_macmic_num_steps>3</cld_macmic_num_steps>
+
+<!-- External forcing for BAM or MAM -->
+<soag_ext_file	 ver="mam" >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_2000_c160427.nc</soag_ext_file>
+
+<!-- Surface emissions for MAM4 -->
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2000.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160226.nc</dms_emis_file>
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/EESC_1850-2100_c090603.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >20000101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >2000</linoz_data_cycle_yr>
+<linoz_data_file            >linoz1800-2100_2006jpl_climo_1.9x2.5_26L_extended.c160204.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>2000</sim_year>
+
+</namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01b.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01b.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Solar constant from Lean (via Caspar Ammann): SOLAR_TSI_Lean_1610-2140_annual_c100301.nc -->
+<solar_data_file>atm/cam/solar/spectral_irradiance_Lean_1976-2007_ave_c20160517.nc</solar_data_file>
+<solar_data_ymd>20000101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 2000 GHG values from AR5 (from ghg_hist_1765-2012_c130501.nc) -->
+<!-- <co2vmr>368.865e-6</co2vmr> Set by CCSM_CO2_PPMV in config_compset.xml -->
+<ch4vmr>1751.022e-9</ch4vmr>
+<n2ovmr>315.85e-9</n2ovmr>
+<f11vmr>676.0526e-12</f11vmr>
+<f12vmr>537.05e-12</f12vmr>
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc>.true.</use_hetfrz_classnuc>
+<use_preexisting_ice>.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc>.true.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep>.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning>.true.</sscav_tuning>
+<convproc_do_aer>.true.</convproc_do_aer>
+<convproc_do_gas>.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc>.true.</demott_ice_nuc>
+<liqcf_fix>.true.</liqcf_fix>
+<regen_fix>.true.</regen_fix>
+<resus_fix>.true.</resus_fix>
+<mam_amicphys_optaa>1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning>.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c140303.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<clubb_ice_deep>     16.e-6 </clubb_ice_deep>
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
+<clubb_liq_sh>       10.e-6 </clubb_liq_sh>
+<clubb_C2rt>         1.75D0 </clubb_C2rt>
+<effgw_oro>          0.25    </effgw_oro>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<dust_emis_fact>     2.05D0 </dust_emis_fact>
+<clubb_gamma_coef>   0.32   </clubb_gamma_coef>
+<clubb_C8>           4.3    </clubb_C8>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<clubb_c_K10>        0.3    </clubb_c_K10>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<so4_sz_thresh_icenuc>0.075e-6</so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add       >0.8D0</zmconv_tiedke_add>
+<zmconv_cape_cin         >1</zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   >2</zmconv_mx_bot_lyr_adj>
+<taubgnd                 >2.5D-3 </taubgnd>
+<clubb_C1                >1.335</clubb_C1>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<se_ftype                >2</se_ftype>
+<relvar_fix              >.true.</relvar_fix>
+<mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+
+<!-- Parameters further tuned for ne120 L72 configuration based on AV1C-04P2 -->
+
+<zmconv_alfa         >0.25D0</zmconv_alfa>
+<zmconv_c0_lnd       >0.0035D0</zmconv_c0_lnd>
+<zmconv_c0_ocn       >0.0043D0</zmconv_c0_ocn>
+<zmconv_dmpdz        >-0.2e-3</zmconv_dmpdz>
+<zmconv_ke           >5.0E-6</zmconv_ke>
+<cldfrc_dp1          >0.030D0</cldfrc_dp1>
+<clubb_C14           >1.41D0</clubb_C14>
+<clubb_gamma_coefb   >0.37D0</clubb_gamma_coefb>
+<se_nsplit           >6</se_nsplit>
+<rsplit              >2</rsplit>
+<qsplit              >1</qsplit>
+<cld_macmic_num_steps>3</cld_macmic_num_steps>
+
+
+<!-- External forcing for BAM or MAM -->
+<soag_ext_file	 ver="mam" >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_2000_c160427.nc</soag_ext_file>
+
+<!-- Surface emissions for MAM4 -->
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2000.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160226.nc</dms_emis_file>
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/EESC_1850-2100_c090603.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >20000101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >2000</linoz_data_cycle_yr>
+<linoz_data_file            >linoz1800-2100_2006jpl_climo_1.9x2.5_26L_extended.c160204.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>2000</sim_year>
+
+</namelist_defaults>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -53,6 +53,8 @@
       <value compset="_CAM5%AV1C-04P" >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1C-04P2" >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1C-L"   >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
+      <value compset="_CAM5%AV1C-H01A" >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
+      <value compset="_CAM5%AV1C-H01B" >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1F"     >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1F-00"  >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1F-01"  >-clubb_sgs -microphys mg2 -chem trop_mam4_resus_soag -rain_evap_to_coarse_aero -nlev 72</value>
@@ -167,6 +169,8 @@
       <value compset="2000_CAM5.*AV1C-04P">2000_cam5_av1c-04p</value>
       <value compset="2000_CAM5.*AV1C-04P2">2000_cam5_av1c-04p2</value>
       <value compset="2000_CAM5.*AV1C-L" >2000_cam5_av1c-04p2</value>
+      <value compset="2000_CAM5.*AV1C-H01A">2000_cam5_av1c-h01a</value>
+      <value compset="2000_CAM5.*AV1C-H01B">2000_cam5_av1c-h01b</value>
       <value compset="2000_CAM5.*AV1F"   >2000_cam5_av1f</value>
       <value compset="2000_CAM5.*AV1F-00">2000_cam5_av1f-00</value>
       <value compset="2000_CAM5.*AV1F-01">2000_cam5_av1f-01</value>
@@ -257,6 +261,8 @@
     <desc compset="_CAM5.*AV1C-04P"  >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- v04p:</desc>
     <desc compset="_CAM5.*AV1C-04P2"  >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- v04p2:</desc>
     <desc compset="_CAM5.*AV1C-L"   >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- v04p2:</desc>
+    <desc compset="_CAM5.*AV1C-H01A"  >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- vh01a:</desc>
+    <desc compset="_CAM5.*AV1C-H01B"  >CAM with complete set of ACME atmospheric mods for V1 (72 layers model) and ACES4BGC SOAG emissions- vh01b:</desc>
     <desc compset="_CAM5.*AV1F"  >CAM with familiar set of ACME atmospheric mods for V1 (72 Layers model):</desc>
     <desc compset="_CAM5.*AV1F-00"  >CAM with familiar set of ACME atmospheric mods for V1 (72 Layers model)- v00:</desc>
     <desc compset="_CAM5.*AV1F-01"  >CAM with familiar set of ACME atmospheric mods for V1 (72 Layers model) and ACES4BGC SOAG emissions- v01:</desc>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -165,6 +165,16 @@
   </compset>
 
   <compset>
+    <alias>FC5AV1C-H01A</alias>
+    <lname>2000_CAM5%AV1C-H01A_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>FC5AV1C-H01B</alias>
+    <lname>2000_CAM5%AV1C-H01B_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>FC5AV1F</alias>
     <lname>2000_CAM5%AV1F_CLM45%SPBC_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
   </compset>


### PR DESCRIPTION
Two ne120 compsets are added, based on up-to-present tuning runs of R5 and R6.
FC5AV1C-H01A corresponds to R5 and FC5AV1C-H01B to R6.

  modified:   cime/driver_cpl/cime_config/config_component_acme.xml
  new file:   components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01a.xml
  new file:   components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01b.xml
  modified:   components/cam/cime_config/config_component.xml
  modified:   components/cam/cime_config/config_compsets.xml

[BFB]