### PR TITLE
Change ACME BFBFLAG default to TRUE

### DIFF
--- a/cime/driver_cpl/cime_config/config_component_acme.xml
+++ b/cime/driver_cpl/cime_config/config_component_acme.xml
@@ -42,7 +42,7 @@
   <entry id="BFBFLAG">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
+    <default_value>TRUE</default_value>
     <group>run_flags</group>
     <file>env_run.xml</file>
     <desc>turns on coupler bit-for-bit reproducibility with varying pe counts</desc>


### PR DESCRIPTION
Change ACME BFBFLAG default to TRUE.

This will allow coupled runs on different numbers of processors to be BFB.  But the change from FALSE to TRUE is itself a non-BFB change.

[non-BFB]
[NML]