### PR TITLE
Fixes a bug in cice model so that model can write cice history files

### DIFF
--- a/components/cice/src/drivers/cpl/ice_history_write.F90
+++ b/components/cice/src/drivers/cpl/ice_history_write.F90
@@ -467,7 +467,7 @@
 1000    format('This dataset was created on ', &
            a,'-',a,'-',a,' at ',a,':',a)
       end if
-      call broadcast_scalar(start_time, my_task)
+      call broadcast_scalar(start_time, master_task)
       status = pio_put_att(File,pio_global,'history',start_time)
       !-----------------------------------------------------------------
       ! end define mode


### PR DESCRIPTION
This bug would cause the model to abort while writing monthly history
files. Part of the error message was:

MPIDI_CH3U_Request_unpack_uebuf(595): Message truncated; 80 bytes
received but buffer size is 11

That is, buffer size at the receiving end differs from the chracter
string being sent.

[BFB] - Bit-For-Bit

Fixes #1323 