### PR TITLE
Don't define PNETCDF_PATH for mpi-serial+anvil

### DIFF
--- a/cime/cime_config/acme/machines/config_machines.xml
+++ b/cime/cime_config/acme/machines/config_machines.xml
@@ -998,7 +998,7 @@
     </module_system>
     <environment_variables>
       <env name="NETCDF_PATH">`which nc-config | xargs dirname | xargs dirname`</env>
-      <env name="PNETCDF_PATH">`which pnetcdf_version | xargs dirname | xargs dirname`</env>
+      <env name="PNETCDF_PATH" mpilib="!mpi-serial">`which pnetcdf_version | xargs dirname | xargs dirname`</env>
     </environment_variables>
     <environment_variables>
       <env name="OMP_STACKSIZE">256M</env>


### PR DESCRIPTION
Making sure that we don't define PNETCDF_PATH when using mpi-serial
on Anvil.

Without the fix if PNETCDF_PATH is defined for mpi-serial builds
it gets "undefine"d in the Makefile. However older versions of
the make utility do not recognize the "undefine" directive. This
causes mpi-serial builds to fail.

Fixes #1340

[BFB]