### PR TITLE
Restore optimized num nodes.

### DIFF
--- a/cime/utils/python/CIME/case_setup.py
+++ b/cime/utils/python/CIME/case_setup.py
@@ -163,7 +163,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             # create batch files
             logger.info("Creating batch script case.run")
             env_batch = case.get_env("batch")
-            num_nodes = env_mach_pes.get_total_nodes(pestot, thread_count)
+            num_nodes = case.num_nodes
             tasks_per_node = env_mach_pes.get_tasks_per_node(pestot, thread_count)
             for job in env_batch.get_jobs():
                 input_batch_script  = os.path.join(case.get_value("MACHDIR"), env_batch.get_value('template', subgroup=job))


### PR DESCRIPTION
On titan, the aprun command is now correct but num_nodes was
incorrect due to not using the 'optimized' num nodes that task maker
was programmed to use with aprun long ago. This commit restores
that capability.

Fixes #1255 

[BFB]