### PR TITLE
Changing default batch walltime from 24 hours to 2 hours on Titan

### DIFF
--- a/cime/cime_config/acme/machines/config_batch.xml
+++ b/cime/cime_config/acme/machines/config_batch.xml
@@ -329,7 +329,7 @@
        <directive>-l nodes={{ num_nodes }}</directive>
      </directives>
      <queues>
-       <queue walltimemax="24:00:00" default="true">batch</queue>
+       <queue walltimemax="02:00:00" default="true">batch</queue>
        <queue walltimemax="01:00:00" jobmin="0" jobmax="64">debug</queue>
      </queues>
    </batch_system>


### PR DESCRIPTION
[BFB] - Bit-For-Bit

Resolving https://github.com/ACME-Climate/ACME/issues/1352