### PR TITLE
Removes global index in ALM's error message

### DIFF
--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -341,7 +341,7 @@ contains
           write(iulog,*)'WARNING:  water balance error ',&
                ' nstep= ',nstep, &
                ' local indexc= ',indexc,&
-               ' global indexc= ',GetGlobalIndex(decomp_index=indexc, clmlevel=namec), &
+               !' global indexc= ',GetGlobalIndex(decomp_index=indexc, clmlevel=namec), &
                ' errh2o= ',errh2o(indexc)
 
           if ((col%itype(indexc) == icol_roof .or. &
@@ -472,7 +472,7 @@ contains
           write(iulog,*)'WARNING:  snow balance error '
           write(iulog,*)'nstep= ',nstep, &
                ' local indexc= ',indexc, &
-               ' global indexc= ',GetGlobalIndex(decomp_index=indexc, clmlevel=namec), &
+               !' global indexc= ',GetGlobalIndex(decomp_index=indexc, clmlevel=namec), &
                ' col%itype= ',col%itype(indexc), &
                ' lun%itype= ',lun%itype(col%landunit(indexc)), &
                ' errh2osno= ',errh2osno(indexc)


### PR DESCRIPTION
This shortcut avoids code to crash when a thread attempts to write
an error message for a run in which land is assigned multiple threads.

[BFB]