### PR TITLE
Initializes root moisture stress formulation in ALM

### DIFF
--- a/components/clm/src/main/init_hydrology.F90
+++ b/components/clm/src/main/init_hydrology.F90
@@ -32,5 +32,7 @@ implicit none
   call init_soilwater_movement
   
   call init_soil_stress
+
+  call init_root_moist_stress()
   
 end subroutine init_hydrology


### PR DESCRIPTION
Adds the missing call to root moisture stress formulation during
land initialization

Fixes #1374 
[BFB]