### PR TITLE
Implements changes requested by @cameronsmith1 and @PeterCaldwell

### DIFF
--- a/run_acme.template.csh
+++ b/run_acme.template.csh
@@ -422,7 +422,7 @@ if ( `lowercase $case_build_dir` != default && -d $case_build_dir ) then
   if ( ${seconds_before_delete_bld_dir} >= 0 ) then
     set num_seconds_until_delete = $seconds_before_delete_bld_dir
     acme_newline
-    acme_print 'Removing old $case_build_dir directory '${case_name}' in '${num_seconds_until_delete}' seconds.'
+    acme_print 'Removing old $case_build_dir directory for '${case_name}' in '${num_seconds_until_delete}' seconds.'
     acme_print 'To abort, press ctrl-C'
     while ( ${num_seconds_until_delete} > 0 )
       acme_print ' '${num_seconds_until_delete}'  seconds until deletion.'


### PR DESCRIPTION
Restored functionality to delete of run and build directories, and reuse other builds while still allowing CIME defaults to be used.
Merged in PMC's changes from 3.0.4. Enabled using CIME defaults for more functionality.
Renamed 'print' and 'newline' to 'acme_print' and 'acme_newline' to disambiguate them from system commands.
BFB, passes tests by hand