### PR TITLE
Add a walltime flag to jenkins_generic_job

### DIFF
--- a/cime/scripts/Tools/jenkins_generic_job
+++ b/cime/scripts/Tools/jenkins_generic_job
@@ -84,6 +84,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="Number of tasks create_test should perform simultaneously. Default "
                         "will be min(num_cores, num_tests).")
 
+    parser.add_argument("--walltime",
+                        help="Force a specific walltime for all tests.")
+
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
@@ -95,7 +98,8 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     expect(not (args.cdash_project is not CIME.wait_for_tests.ACME_MAIN_CDASH and not args.submit_to_cdash),
            "Does not make sense to use --cdash-project without --submit-to-cdash")
 
-    return args.generate_baselines, args.submit_to_cdash, args.no_batch, args.baseline_name, args.cdash_build_name, args.cdash_project, args.test_suite, args.cdash_build_group, args.baseline_compare, args.scratch_root, args.parallel_jobs
+    return args.generate_baselines, args.submit_to_cdash, args.no_batch, args.baseline_name, args.cdash_build_name, \
+        args.cdash_project, args.test_suite, args.cdash_build_group, args.baseline_compare, args.scratch_root, args.parallel_jobs, args.walltime
 
 ###############################################################################
 def _main_func(description):
@@ -104,10 +108,10 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    generate_baselines, submit_to_cdash, no_batch, cdash_build_name, cdash_project, baseline_branch, test_suite, cdash_build_group, no_baseline_compare, scratch_root, parallel_jobs = \
+    generate_baselines, submit_to_cdash, no_batch, cdash_build_name, cdash_project, baseline_branch, test_suite, cdash_build_group, no_baseline_compare, scratch_root, parallel_jobs, walltime = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch, cdash_build_name, cdash_project, baseline_branch, test_suite, cdash_build_group, no_baseline_compare, scratch_root, parallel_jobs)
+    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch, cdash_build_name, cdash_project, baseline_branch, test_suite, cdash_build_group, no_baseline_compare, scratch_root, parallel_jobs, walltime)
              else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/cime/utils/python/jenkins_generic_job.py
+++ b/cime/utils/python/jenkins_generic_job.py
@@ -27,7 +27,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
                         arg_cdash_build_name, cdash_project,
                         arg_test_suite,
                         cdash_build_group, baseline_compare,
-                        scratch_root, parallel_jobs):
+                        scratch_root, parallel_jobs, walltime):
 ###############################################################################
     """
     Return True if all tests passed
@@ -106,10 +106,11 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
 
     batch_args = "--no-batch" if no_batch else ""
     pjob_arg = "" if parallel_jobs is None else "-j %d" % parallel_jobs
+    walltime_arg = "" if walltime is None else " --walltime %s" % walltime
 
     test_id = "%s_%s" % (test_id_root, CIME.utils.get_timestamp())
-    create_test_cmd = "./create_test %s --test-root %s -t %s %s %s %s" % \
-                      (test_suite, test_root, test_id, baseline_args, batch_args, pjob_arg)
+    create_test_cmd = "./create_test %s --test-root %s -t %s %s %s %s %s" % \
+                      (test_suite, test_root, test_id, baseline_args, batch_args, pjob_arg, walltime_arg)
 
     if (not CIME.wait_for_tests.SIGNAL_RECEIVED):
         create_test_stat = CIME.utils.run_cmd(create_test_cmd, from_dir=CIME.utils.get_scripts_root(),


### PR DESCRIPTION
Forces all tests run by it to use this walltime. This is
for cetus since it's much slower than other machines.

[BFB]