### PR TITLE
Fixed bug where model seg faults for dyn_npes<npes

### DIFF
--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -50,6 +50,8 @@ Module dyn_comp
   ! !REVISION HISTORY:
   !
   !  JPE  06.05.31:  created
+  !  Aaron Donahue 17.04.11: Fixed bug in write_grid_mapping which caused 
+  !       a segmentation fault when dyn_npes<npes
   !
   !----------------------------------------------------------------------
 
@@ -444,7 +446,9 @@ CONTAINS
        ierr = pio_def_var(nc, 'element_corners', PIO_INT, (/dim1,dim2/),vid)
     
        ierr = pio_enddef(nc)
-       call createmetadata(par, elem, subelement_corners)
+       if (iam<par%nprocs) then
+          call createmetadata(par, elem, subelement_corners)
+       end if
 
        jj=0
        do cc=0,3


### PR DESCRIPTION
Fixed a bug which resulted in a segmentation fault for simulations with
fewer dynamics processors (dyn_npes) than total processors (npes).
- Fix skips a call to createmetadata subroutine which is associated
          with a certain type of mapping file in ESMF for processors not 
          doing dynamics.
- Slightly related fix to gravity_wave_sources code which called boundary
          exchange for processors not neccesarily associated with dynamics.

Fixes #1192 
[BFB] - Bit-For-Bit