### PR TITLE
Enable physics load balancing for CAM-SE by default

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1245,7 +1245,7 @@
 <iopfile dyn="eul">atm/cam/scam/iop/ARM95_4scam.nc</iopfile>
 
 <!-- physics loadbalance -->
-<phys_loadbalance dyn="se"> 0 </phys_loadbalance>
+<phys_loadbalance dyn="se"> 2 </phys_loadbalance>
 <phys_loadbalance dyn="eul"> 3 </phys_loadbalance>
 
 <!-- Control output to history file(s) -->

--- a/components/cam/src/physics/cam/phys_grid.F90
+++ b/components/cam/src/physics/cam/phys_grid.F90
@@ -301,7 +301,7 @@ module phys_grid
    integer, private, parameter :: modmin_alltoall = 11
    integer, private, parameter :: modmax_alltoall = 13
 # endif
-   integer, private, parameter :: def_alltoall = -1                ! default
+   integer, private, parameter :: def_alltoall = 1                ! default
    integer, private :: phys_alltoall = def_alltoall
 
 contains


### PR DESCRIPTION
Recent ACME experiments across all target platforms, mesh sizes,
and process and thread counts indicate that performance
is improved (or, at least, not degraded) by using physics load
balancing option 2 with the point-to-point implementation of
the load balancing communication operator (phys_alltoall == 1).
This changes the defaults to these option settings. Other options,
including the original defaults, can be set in user_nl_cam.

This is bit-for-bit compared to not using physics load balancing
if the BFBFLAG in env_run.xml is TRUE, which is the current ACME
default.

[BFB]