### PR TITLE
Turn on FORT_BUFFERED on Edison

### DIFF
--- a/cime/cime_config/acme/machines/config_machines.xml
+++ b/cime/cime_config/acme/machines/config_machines.xml
@@ -173,8 +173,8 @@
     <env name="MPICH_ENV_DISPLAY">1</env>
     <env name="MPICH_VERSION_DISPLAY">1</env>
     <env name="MPICH_CPUMASK_DISPLAY">1</env>
-
     <env name="OMP_STACKSIZE">64M</env>
+    <env name="FORT_BUFFERED" compiler="intel">yes</env>
   </environment_variables>
 
 </machine>


### PR DESCRIPTION
This variable used to be set and was removed on 2017-03-16, because Intel v17 was failing when it was set. When it is not set, throughput with Edison's Intel v15 suffers.

Addresses #1387 
[BFB]