### PR TITLE
Explicitly initialize clubb_do_adv and clubb_do_deep

### DIFF
--- a/components/cam/src/physics/cam/clubb_intr.F90
+++ b/components/cam/src/physics/cam/clubb_intr.F90
@@ -387,6 +387,8 @@ end subroutine clubb_init_cnst
     do_rainturb        = .false.   ! Initialize to false
     do_expldiff        = .false.   ! Initialize to false
     relvar_fix         = .false.   ! Initialize to false
+    clubb_do_adv       = .false.   ! Initialize to false
+    clubb_do_deep      = .false.   ! Initialize to false
 
     !  Read namelist to determine if CLUBB history should be called
     if (masterproc) then


### PR DESCRIPTION
This is to explicitly initialize clubb_do_adv and clubb_do_deep to false,
which is the current default.

modified:   components/cam/src/physics/cam/clubb_intr.F90

[BFB]