### PR TITLE
Update default settings for the regionalStatistics analysis member.

### DIFF
--- a/components/mpas-cice/bld/namelist_files/namelist_defaults_mpas-cice.xml
+++ b/components/mpas-cice/bld/namelist_files/namelist_defaults_mpas-cice.xml
@@ -355,7 +355,7 @@
 
 <!-- AM_regionalStatistics -->
 <config_AM_regionalStatistics_enable>true</config_AM_regionalStatistics_enable>
-<config_AM_regionalStatistics_compute_interval>'0000-00-00_01:00:00'</config_AM_regionalStatistics_compute_interval>
+<config_AM_regionalStatistics_compute_interval>'0000-00-01_00:00:00'</config_AM_regionalStatistics_compute_interval>
 <config_AM_regionalStatistics_output_stream>'regionalStatisticsOutput'</config_AM_regionalStatistics_output_stream>
 <config_AM_regionalStatistics_compute_on_startup>true</config_AM_regionalStatistics_compute_on_startup>
 <config_AM_regionalStatistics_write_on_startup>true</config_AM_regionalStatistics_write_on_startup>

--- a/components/mpas-cice/cime_config/buildnml
+++ b/components/mpas-cice/cime_config/buildnml
@@ -348,9 +348,9 @@ if ( -e "$CASEROOT/SourceMods/src.mpascice/$STREAM_NAME" ) {
 	print $stream_file '' . "\n";
 	print $stream_file '<stream name="regionalStatisticsOutput"' . "\n";
 	print $stream_file '        type="output"' . "\n";
-	print $stream_file '        filename_template="mpascice.hist.am.regionalStatistics.$Y.nc"' . "\n";
-	print $stream_file '        filename_interval="01-00-00_00:00:00"' . "\n";
-	print $stream_file '        output_interval="00-00-00_01:00:00"' . "\n";
+	print $stream_file '        filename_template="mpascice.hist.am.regionalStatistics.$Y.$M.nc"' . "\n";
+	print $stream_file '        filename_interval="00-01-00_00:00:00"' . "\n";
+	print $stream_file '        output_interval="00-00-01_00:00:00"' . "\n";
 	print $stream_file '        clobber_mode="truncate"' . "\n";
 	print $stream_file '        packages="regionalStatisticsAMPKG">' . "\n";
 	print $stream_file '' . "\n";


### PR DESCRIPTION
This PR updates the default setting for the mpas-seaice regionalStatistics analysis member to be computed and written out at more reasonable time intervals.  On some tests, this analysis member was taking 15-20% of the entire mpas-seaice runtime, and these changes bring its impact to more like 1%.

Tested on SMS.ne30np4_oEC60to30v3_ICG.A_WCYCL2000S.edison_intel

[BFB]
[NML]