### PR TITLE
preview_namelists.create_namelists wasn't re-creating dirs

### DIFF
--- a/cime/utils/python/CIME/case_setup.py
+++ b/cime/utils/python/CIME/case_setup.py
@@ -214,15 +214,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 
         logger.info("If an old case build already exists, might want to run \'case.build --clean\' before building")
 
-        # Create test script if appropriate
-        # Short term fix to be removed when csh tests are removed
-        if os.path.exists("env_test.xml"):
-            if not os.path.exists("case.test"):
-                logger.info("Starting testcase.setup")
-                run_cmd_no_fail("./testcase.setup -caseroot %s" % caseroot)
-                logger.info("Finished testcase.setup")
-
-        # Some tests need namelists created here (ERP) - so do this if are in test mode
+        # Some tests need namelists created here (ERP) - so do this if we are in test mode
         if test_mode or get_model() == "acme":
             logger.info("Generating component namelists as part of setup")
             create_namelists(case)

--- a/cime/utils/python/CIME/preview_namelists.py
+++ b/cime/utils/python/CIME/preview_namelists.py
@@ -18,7 +18,6 @@ def create_dirs(case):
     rundir = case.get_value("RUNDIR")
     caseroot = case.get_value("CASEROOT")
 
-
     docdir = os.path.join(caseroot, "CaseDocs")
     dirs_to_make = []
     models = case.get_values("COMP_CLASSES")
@@ -46,6 +45,11 @@ def create_namelists(case):
     Create component namelists
     """
     case.flush()
+
+    # Needed in case user did case.build --clean-all
+    exeroot = case.get_value("EXEROOT")
+    if not os.path.exists(exeroot):
+        create_dirs(case)
 
     casebuild = case.get_value("CASEBUILD")
     caseroot = case.get_value("CASEROOT")
@@ -100,8 +104,8 @@ def create_namelists(case):
             logger.info(output)
             # refresh case xml object from file
             case.read_xml()
-    logger.info("Finished creating component namelists")
 
+    logger.info("Finished creating component namelists")
 
     # Save namelists to docdir
     if (not os.path.isdir(docdir)):
@@ -111,7 +115,6 @@ def create_namelists(case):
                 fd.write(" CESM Resolved Namelist Files\n   For documentation only DO NOT MODIFY\n")
         except (OSError, IOError) as e:
             expect(False, "Failed to write %s/README: %s" % (docdir, e))
-
 
     for cpglob in ["*_in_[0-9]*", "*modelio*", "*_in",
                    "*streams*txt*", "*stxt", "*maps.rc", "*cism.config*"]:


### PR DESCRIPTION
... and therefore did not handle the case where the user
called case.build --clean-all. For most components, it didn't
matter, but it did for CAM.

Fixes #1390 

[BFB]