### PR TITLE
Changes the units of water flux between root and soil in ALM

### DIFF
--- a/components/clm/src/betr/BetrBGCMod.F90
+++ b/components/clm/src/betr/BetrBGCMod.F90
@@ -717,7 +717,7 @@ contains
             qflx_adv_local(c,jtops(c)-1) = safe_div(qflx_adv(c,jtops(c)-1),aqu2bulkcef_mobile_col(c,jtops(c),j),eps=loc_eps)
             do l = jtops(c), ubj
                qflx_adv_local(c,l)     = safe_div(qflx_adv(c,l),aqu2bulkcef_mobile_col(c,l,j),eps=loc_eps)
-               qflx_rootsoi_local(c,l) = safe_div(qflx_rootsoi(c,l),aqu2bulkcef_mobile_col(c,l,j),eps=loc_eps)
+               qflx_rootsoi_local(c,l) = safe_div(qflx_rootsoi(c,l)*1.e-3_r8,aqu2bulkcef_mobile_col(c,l,j),eps=loc_eps)
             enddo
          enddo
 

--- a/components/clm/src/betr/betr_core/TracerParamsMod.F90
+++ b/components/clm/src/betr/betr_core/TracerParamsMod.F90
@@ -1368,7 +1368,7 @@ contains
        if(j==nlevsoi)then
          qflx_adv(c,j) = qcharge(c) * 1.e-3_r8
        else
-         qflx_adv(c,j) = 1.e-3_r8 * (h2osoi_liq(c,j+1)-h2osoi_liq_copy(c,j+1))/dtime + qflx_adv(c,j+1) + qflx_rootsoi(c,j+1)
+         qflx_adv(c,j) = 1.e-3_r8 * (h2osoi_liq(c,j+1)-h2osoi_liq_copy(c,j+1))/dtime + qflx_adv(c,j+1) + qflx_rootsoi(c,j+1)*1.e-3_r8
        endif
 
      enddo
@@ -1380,7 +1380,7 @@ contains
      c = filter_hydrologyc(fc)
 
      !obtain the corrected infiltration
-     qflx_infl(c) = (h2osoi_liq(c,1)-h2osoi_liq_copy(c,1))/dtime + (qflx_rootsoi(c,1)+qflx_adv(c,1))*1.e3_r8
+     qflx_infl(c) = (h2osoi_liq(c,1)-h2osoi_liq_copy(c,1))/dtime + qflx_rootsoi(c,1) + qflx_adv(c,1)*1.e3_r8
      !the predicted net infiltration
      infl_tmp=qflx_gross_infl_soil(c)-qflx_gross_evap_soil(c)
      diff=qflx_infl(c)-infl_tmp

--- a/components/clm/src/biogeophys/SoilWaterMovementMod.F90
+++ b/components/clm/src/biogeophys/SoilWaterMovementMod.F90
@@ -355,7 +355,7 @@ contains
          qflx_infl         =>    waterflux_vars%qflx_infl_col       , & ! Input:  [real(r8) (:)   ]  infiltration (mm H2O /s)                          
          qflx_tran_veg_col =>    waterflux_vars%qflx_tran_veg_col   , & ! Input:  [real(r8) (:)   ]  vegetation transpiration (mm H2O/s) (+ = to atm)  
          qflx_tran_veg_pft =>    waterflux_vars%qflx_tran_veg_patch , & ! Input:  [real(r8) (:)   ]  vegetation transpiration (mm H2O/s) (+ = to atm)  
-         qflx_rootsoi      =>    waterflux_vars%qflx_rootsoi_col    , & ! Output: [real(r8) (:,:) ]  vegetation/soil water exchange (m H2O/s) (+ = to atm)
+         qflx_rootsoi      =>    waterflux_vars%qflx_rootsoi_col    , & ! Output: [real(r8) (:,:) ]  vegetation/soil water exchange (mm H2O/s) (+ = to atm)
 
          t_soisno          =>    temperature_vars%t_soisno_col        & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)                       
          )
@@ -786,7 +786,7 @@ contains
       do j = 1, nlevsoi
          do fc = 1, num_hydrologyc
             c = filter_hydrologyc(fc)
-            qflx_rootsoi(c,j) = qflx_tran_veg_col(c) * rootr_col(c,j) * 1.e-3_r8       ![m H2O/s]
+            qflx_rootsoi(c,j) = qflx_tran_veg_col(c) * rootr_col(c,j)
          enddo
       enddo
 


### PR DESCRIPTION
The units flux from root and soil are changed from [m H2O/s] to
[mm H2O/s], so it is consistent units of other fluxes defined in
waterflux_type.

Fixes #1371 
[BFB]