### PR TITLE
Shortens the simulation length of a crop model test

### DIFF
--- a/cime/scripts/lib/update_acme_tests.py
+++ b/cime/scripts/lib/update_acme_tests.py
@@ -67,7 +67,7 @@ _TEST_SUITES = {
                               "SMS.hcru_hcru.I1850CRUCLM45CN",
                              ("ERS.f19_g16.I1850CNECACNTBC" ,"clm-eca"),
                              ("ERS.f19_g16.I1850CNECACTCBC" ,"clm-eca"),
-                             ("SMS_Ly3_P1x1.1x1_smallvilleIA.ICLM45CNCROP", "force_netcdf_pio"),
+                             ("SMS_Ly2_P1x1.1x1_smallvilleIA.ICLM45CNCROP", "force_netcdf_pio"),
                              ("ERS.f19_g16.I1850CLM45","clm-betr"),
                               "ERS.ne11_oQU240.I20TRCLM45",
                               "ERS.f09_g16.IMCLM45BC")


### PR DESCRIPTION
The 3-years long test for the crop model is reduced to 2-years long,
so the test finishes within 1:00:00 wallclock time on Cetus.
The test needs to be longer than 1-year because crops are planted
in the second year.

Fixes #1418
[BFB]