### PR TITLE
Adding general PE layouts for ultra-low resolution

### DIFF
--- a/cime/config/acme/allactive/config_pesall.xml
+++ b/cime/config/acme/allactive/config_pesall.xml
@@ -6023,7 +6023,7 @@
   </grid>
   <grid name="a%ne4np4_l%ne4np4_oi%oQU240.*_r%r05_m%oQU240.*_g%null_w%null">
     <mach name="anvil">
-      <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
+      <pes compset="any" pesize="any">
         <comment> -compset A_WCYCL* -res ne4_oQU240 on 7 nodes pure-MPI </comment>
         <ntasks>
           <ntasks_atm>96</ntasks_atm>
@@ -6201,8 +6201,111 @@
     </mach>
   </grid>
   <grid name="a%ne4np4_l%ne4np4_oi%oQU240_r%r05_m%oQU240_g%null_w%null">
+    <mach name="any">
+      <pes compset="any" pesize="S">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>32</ntasks_atm>
+          <ntasks_lnd>32</ntasks_lnd>
+          <ntasks_rof>32</ntasks_rof>
+          <ntasks_ice>32</ntasks_ice>
+          <ntasks_ocn>32</ntasks_ocn>
+          <ntasks_glc>32</ntasks_glc>
+          <ntasks_wav>32</ntasks_wav>
+          <ntasks_cpl>32</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+      <pes compset="any"  pesize="M">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_lnd>48</ntasks_lnd>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_ice>48</ntasks_ice>
+          <ntasks_ocn>48</ntasks_ocn>
+          <ntasks_glc>48</ntasks_glc>
+          <ntasks_wav>48</ntasks_wav>
+          <ntasks_cpl>48</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_glc>2</nthrds_glc>
+          <nthrds_wav>2</nthrds_wav>
+          <nthrds_cpl>2</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+      <pes compset="any"  pesize="L">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>96</ntasks_atm>
+          <ntasks_lnd>96</ntasks_lnd>
+          <ntasks_rof>96</ntasks_rof>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>96</ntasks_ocn>
+          <ntasks_glc>96</ntasks_glc>
+          <ntasks_wav>96</ntasks_wav>
+          <ntasks_cpl>96</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>4</nthrds_atm>
+          <nthrds_lnd>4</nthrds_lnd>
+          <nthrds_rof>4</nthrds_rof>
+          <nthrds_ice>4</nthrds_ice>
+          <nthrds_ocn>4</nthrds_ocn>
+          <nthrds_glc>4</nthrds_glc>
+          <nthrds_wav>4</nthrds_wav>
+          <nthrds_cpl>4</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne4np4_l%ne4np4_oi%oQU240_r%r05_m%oQU240_g%null_w%null">
     <mach name="skybridge">
-      <pes compset="CAM5.+CLM.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV"  pesize="S">
+      <pes compset="any"  pesize="S">
         <comment>none</comment>
         <ntasks>
           <ntasks_atm>32</ntasks_atm>
@@ -6235,10 +6338,6 @@
           <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne4np4_l%ne4np4_oi%oQU240_r%r05_m%oQU240_g%null_w%null">
-    <mach name="skybridge">
       <pes compset="CAM5.+CLM.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV"  pesize="M">
         <comment>none</comment>
         <ntasks>
@@ -6272,10 +6371,6 @@
           <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne4np4_l%ne4np4_oi%oQU240_r%r05_m%oQU240_g%null_w%null">
-    <mach name="skybridge">
       <pes compset=".+CAM5.+CLM.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV"  pesize="L">
         <comment>none</comment>
         <ntasks>
@@ -6313,7 +6408,7 @@
   </grid>
   <grid name="a%ne4np4_l%ne4np4_oi%oQU240_r%r05_m%oQU240_g%null_w%null">
     <mach name="melvin">
-      <pes compset="CAM5.+CLM.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV"  pesize="any">
+      <pes compset="any"  pesize="any">
         <comment>none</comment>
         <ntasks>
           <ntasks_atm>32</ntasks_atm>


### PR DESCRIPTION
There was no optimized PE layout for edison with ne4_oQU240 grid, so I added a
small and large grid. Additionally, I combined some skybridge layouts into a
single mesh single machine logic.

[BFB]

This PR is related to #1389.