### PR TITLE
Change default stride to 64 on cori-knl

### DIFF
--- a/cime/config/acme/machines/config_pio.xml
+++ b/cime/config/acme/machines/config_pio.xml
@@ -23,6 +23,7 @@
       <value>$PES_PER_NODE</value>
       <value mach="yellowstone" grid="a%ne120.+oi%gx1">60</value>
       <value mach="mira|cetus">128</value>
+      <value mach="cori-knl">64</value>
     </values>
   </entry>
 


### PR DESCRIPTION
Newer cimes added a default stride as $PES_PER_NODE which might not work with cori-knl.  Ideally it would at least not hang, which is what I was seeing.  Setting it to 64 seems to solve the problem, so I'm adding this here.

[BFB]