### PR TITLE
HOMME test only: Change compiler flag for Intel from -fp-model precise to -fp-model source

### DIFF
--- a/components/homme/cmake/SetCompilerFlags.cmake
+++ b/components/homme/cmake/SetCompilerFlags.cmake
@@ -21,7 +21,7 @@ ELSE ()
     SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -extend-source")
   ELSEIF (CMAKE_Fortran_COMPILER_ID STREQUAL Intel)
     SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume byterecl")
-    SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model precise -ftz")
+    SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model source -ftz")
     #SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model fast -qopt-report=5 -ftz")
     #SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -mP2OPT_hpo_matrix_opt_framework=0 -fp-model fast -qopt-report=5 -ftz")
 


### PR DESCRIPTION
Change compiler flag for intel from -fp-model precise to -fp-model source.

This allows me to build with Intel v17 on edison AND is more consistent with the flags used by ACME.

Should only affect HOMME test.  The HOMME fortran that is used by ACME is built with ACME flags, which already uses -fp-model source.

Stating BFB, but possible the homme test may be a hair different.
[BFB]