### PR TITLE
Update MCT subtree to MCT_2.10.beta

### DIFF
--- a/cime/src/externals/mct/mct/Makefile
+++ b/cime/src/externals/mct/mct/Makefile
@@ -31,6 +31,7 @@ SRCS_F90	= m_MCTWorld.F90		\
 		  m_SparseMatrixPlus.F90	\
 		  m_Router.F90			\
 		  m_Rearranger.F90        	\
+		  m_SPMDutils.F90               \
 		  m_Transfer.F90
 
 OBJS_ALL	= $(SRCS_F90:.F90=.o)
@@ -82,6 +83,7 @@ m_GlobalMap.o:
 m_GlobalSegMap.o:
 m_GlobalSegMapComms.o: m_GlobalSegMap.o
 m_Navigator.o:
+m_SPMDutils.o:
 m_AttrVectComms.o: m_AttrVect.o m_GlobalMap.o
 m_AttrVectReduce.o: m_AttrVect.o
 m_AccumulatorComms.o: m_AttrVect.o m_GlobalMap.o m_AttrVectComms.o
@@ -91,7 +93,7 @@ m_GeneralGridComms.o: m_AttrVect.o m_GeneralGrid.o m_AttrVectComms.o m_GlobalMap
 m_MatAttrVectMul.o: m_AttrVect.o m_SparseMatrix.o m_GlobalMap.o m_GlobalSegMap.o m_SparseMatrixPlus.o m_Rearranger.o
 m_Merge.o: m_AttrVect.o m_GeneralGrid.o
 m_Router.o: m_GlobalToLocal.o m_MCTWorld.o m_GlobalSegMap.o m_ExchangeMaps.o
-m_Rearranger.o: m_Router.o m_MCTWorld.o m_GlobalSegMap.o m_AttrVect.o
+m_Rearranger.o: m_Router.o m_MCTWorld.o m_GlobalSegMap.o m_AttrVect.o m_SPMDutils.o
 m_GlobalToLocal.o: m_GlobalSegMap.o
 m_ExchangeMaps.o: m_GlobalMap.o m_GlobalSegMap.o m_MCTWorld.o m_ConvertMaps.o
 m_ConvertMaps.o: m_GlobalMap.o m_GlobalSegMap.o m_MCTWorld.o

--- a/cime/src/externals/mct/mct/m_Rearranger.F90
+++ b/cime/src/externals/mct/mct/m_Rearranger.F90
@@ -531,7 +531,8 @@
 !
 ! !INTERFACE:
 
- subroutine rearrange_(SourceAVin,TargetAV,InRearranger,Tag,Sum,Vector,AlltoAll)
+ subroutine rearrange_(SourceAVin,TargetAV,InRearranger,Tag,Sum,&
+                       Vector,AlltoAll,HandShake,ISend,MaxReq)
 
 !
 ! !USES:
@@ -548,6 +549,7 @@
    use m_AttrVect,  only : nIAttr,nRAttr
    use m_AttrVect,  only : Permute,Unpermute
    use m_Router,    only : Router
+   use m_SPMDutils, only : m_swapm_int, m_swapm_FP
    use m_realkinds, only : FP
    use m_mpif90
    use m_die
@@ -567,6 +569,9 @@
    logical,          optional, intent(in)      :: Sum
    logical,          optional, intent(in)      :: Vector
    logical,          optional, intent(in)      :: AlltoAll
+   logical,          optional, intent(in)      :: HandShake
+   logical,          optional, intent(in)      :: ISend
+   integer,          optional, intent(in)      :: MaxReq
 
 ! !REVISION HISTORY:
 ! 31Jan02 - E.T. Ong <eong@mcs.anl.gov> - initial prototype
@@ -581,6 +586,8 @@
 ! 14Oct06 - R. Jacob <jacob@mcs.anl.gov> - check value of Sum argument.
 ! 25Jan08 - R. Jacob <jacob@mcs.anl.gov> - Permute/unpermute if the internal
 !           routers permarr is defined.
+! 29Sep16 - P. Worley <worleyph@gmail.com> - added swapm variant of
+!           alltoall option
 !EOP ___________________________________________________________________
 
   character(len=*),parameter :: myname_=myname//'::Rearrange_'
@@ -591,11 +598,11 @@
   integer ::    mp_Type_rp
   integer ::    mytag
   integer ::    ISendSize, RSendSize, IRecvSize, RRecvSize
-  logical ::    usevector, usealltoall
+  logical ::    usevector, usealltoall, useswapm
   logical ::    DoSum
   logical ::    Sendunordered
   logical ::    Recvunordered
-  real(FP) ::  realtyp
+  real(FP)::    realtyp
 !-----------------------------------------------------------------------
 
    ! DECLARE STRUCTURES FOR MPI ARGUMENTS.
@@ -633,6 +640,10 @@
    integer,dimension(:),allocatable  :: IRecvBuf
    real(FP),dimension(:),allocatable :: RRecvBuf
 
+   ! declare arrays to hold MPI data types for m_swapm_XXX calls
+   integer :: ITypes(0:max_nprocs-1)
+   integer :: RTypes(0:max_nprocs-1)
+
    ! Structure to hold MPI request information for sends
    integer :: send_ireqs(max_nprocs)
    integer :: send_rreqs(max_nprocs)
@@ -653,6 +664,16 @@
    type(Router), pointer :: SendRout, RecvRout
    type(AttrVect),pointer :: SourceAv
    type(AttrVect),target  :: SourceAvtmp
+
+   ! local swapm protocol variables and defaults
+   logical,parameter :: DEF_SWAPM_HS     = .true.
+   logical swapm_hs
+
+   logical,parameter :: DEF_SWAPM_ISEND  = .false.
+   logical swapm_isend
+
+   integer,parameter :: DEF_SWAPM_MAXREQ = 512
+   integer swapm_maxreq
 
 !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -708,8 +729,44 @@
    endif
 
    usealltoall=.false.
-   if(present(Alltoall)) then
-    if(Alltoall) usealltoall=.true.
+   if(present(AlltoAll)) then
+    if(AlltoAll) usealltoall=.true.
+   endif
+!pw++
+   ! forcing use of alltoall protocol until additional tuning
+   ! capabilities are added to calling routines
+!pw   usealltoall=.true.
+!pw--
+
+   useswapm=.false.
+   if (usealltoall) then
+    ! if any swapm-related optional parameters are present,
+    ! enable swapm variant of alltoall
+
+    swapm_hs = DEF_SWAPM_HS
+    if(present(HandShake)) then
+     if(HandShake) swapm_hs=.true.
+     useswapm=.true.
+    endif
+
+    swapm_isend = DEF_SWAPM_ISEND
+    if(present(ISend)) then
+     if(ISend) swapm_isend=.true.
+     useswapm=.true.
+    endif
+
+    swapm_maxreq = DEF_SWAPM_MAXREQ
+    if(present(MaxReq)) then
+     swapm_maxreq=MaxReq
+     useswapm=.true.
+    endif
+
+!pw++
+    ! forcing use of swapm variant of alltoall protocol
+    ! until additional tuning capabilities are added to
+    ! calling routines
+!pw    useswapm=.true.
+!pw--
    endif
 
    DoSum=.false.
@@ -855,6 +912,10 @@
            RRdispls(pe)  = RRecvLoc(proc) - 1
         endif
      enddo
+
+     ! SET MPI DATA TYPES
+     ITypes(:) = MP_INTEGER
+     RTypes(:) = mp_Type_rp
   endif
 
 !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -1090,6 +1151,26 @@ endif  ! end of else for if(usealltoall)
 
 if (usealltoall) then
 
+ if (useswapm) then
+
+  if (numi .ge. 1) then
+     call m_swapm_int(max_pe, myPid,                                    &
+                      ISendBuf, ISendSize, ISendCnts, ISdispls, ITypes, &
+                      IRecvBuf, IRecvSize, IRecvCnts, IRdispls, ITypes, &
+                      ThisMCTWorld%MCT_comm,                            &
+                      swapm_hs, swapm_isend, swapm_maxreq               )
+  endif
+
+  if (numr .ge. 1) then
+     call m_swapm_FP (max_pe, myPid,                                    &
+                      RSendBuf, RSendSize, RSendCnts, RSdispls, RTypes, &
+                      RRecvBuf, RRecvSize, RRecvCnts, RRdispls, RTypes, &
+                      ThisMCTWorld%MCT_comm,                            &
+                      swapm_hs, swapm_isend, swapm_maxreq               )
+  endif
+
+ else
+
   if (numi .ge. 1) then
      call MPI_Alltoallv(ISendBuf, ISendCnts, ISdispls, MP_INTEGER, &
                         IRecvBuf, IRecvCnts, IRdispls, MP_INTEGER, &
@@ -1101,6 +1182,8 @@ if (usealltoall) then
                         RRecvBuf, RRecvCnts, RRdispls, mp_Type_rp, &
                         ThisMCTWorld%MCT_comm,ier)
   endif
+
+ endif
 
 else
 

--- a/cime/src/externals/mct/mct/m_Router.F90
+++ b/cime/src/externals/mct/mct/m_Router.F90
@@ -268,6 +268,8 @@
 !           increasing.  Instead, permute it to increasing and proceed.
 ! 07Sep12 - T. Craig <tcraig@ucar.edu> - Replace a double loop with a single
 !           to improve speed for large proc and segment counts.
+! 12Nov16 - P. Worley <worleyph@gmail.com> - eliminate iterations in nested
+!           loop that can be determined to be unnecessary
 !EOP -------------------------------------------------------------------
 
   character(len=*),parameter :: myname_=myname//'::initp_'
@@ -281,24 +283,30 @@
 
   integer :: my_left        ! Left point in local segment (global memory)
   integer :: my_right       ! Right point in local segment (global memory)
+  integer :: my_leftmost    ! Leftmost point in local segments (global memory)
+  integer :: my_rightmost   ! Rightmost point in local segments (global memory)
   integer :: r_left         ! Left point in remote segment (global memory)
   integer :: r_right        ! Right point in remote segment (global memory)
+  integer :: r_leftmost     ! Leftmost point and rightmost point
+  integer :: r_rightmost    !  in remote segments in given process (global memory)
   integer :: nsegs_overlap  ! Number of segments that overlap between two procs
 
 
   integer :: ngseg, nlseg
   integer :: myseg, rseg
-  integer :: prev_right         ! Rightmost local point in previous overlapped segment
+  integer :: rseg_leftbase, rseg_start
+  integer :: prev_right     ! Rightmost local point in previous overlapped segment
   integer :: local_left, local_right
   integer,allocatable  :: mygs_lb(:),mygs_ub(:),mygs_len(:),mygs_lstart(:)
   integer :: r_ngseg
-  integer :: r_max_nlseg   ! max number of local segments in RGSMap
   integer,allocatable  :: rgs_count(:),rgs_lb(:,:),rgs_ub(:,:)
   integer,allocatable  :: nsegs_overlap_arr(:)
 
   integer :: overlap_left, overlap_right, overlap_diff
 
   integer :: proc, nprocs
+  integer :: feas_proc, feas_nprocs
+  integer,allocatable  :: feas_procs(:), inv_feas_procs(:)
 
   integer :: max_rgs_count, max_overlap_segs
   type(GlobalSegMap)	:: GSMap
@@ -416,71 +424,109 @@
     call zeit_co(trim(tagname))
   endif
 
-
 !!
-!! determine the segments in RGSMap that are local to each proc
+!! determine the possibly overlapping segments
+!! in RGSMap that are local to each proc
 !!
-
   nprocs=ThisMCTWorld%nprocspid(othercomp)
   r_ngseg = GlobalSegMap_ngseg(RGSMap)
 
-  !! original size of rgs_lb()/ub() was (r_ngseg,nprocs)
-  !! at the cost of looping to compute it (within GlobalSegMap_max_nlseg),
-  !!   reduced size to (r_max_nlseg,nprocs)
-  !! further reduction could be made by flattening it to one dimension
-  !!   of size (r_ngseg) and allocating another array to index into it.
-  !!   would not improve overall mem use unless this were also done for
-  !!   tmpsegstart()/count() and possibly seg_starts()/lengths (the
-  !!   latter would be a major change).
+  if (nlseg > 0) then
+    my_leftmost  = mygs_lb(1)
+    my_rightmost = mygs_ub(nlseg)
 
-  if(present(name)) then
-    tagname='04'//name//'rloop'
-    call zeit_ci(trim(tagname))
-  endif
-  r_max_nlseg = GlobalSegMap_max_nlseg(RGSMap)
-
-  allocate( rgs_count(nprocs) , &
-            rgs_lb(r_max_nlseg,nprocs), rgs_ub(r_max_nlseg,nprocs), &
-            nsegs_overlap_arr(nprocs), stat=ier )
-  if(ier/=0) call die(myname_,'allocate rgs, nsegs',ier)
-
-! tcraig, updated loop
-  rgs_count = 0                !! number of segments in RGSMap local to proc
-
-  do i=1,r_ngseg
-     proc = RGSMap%pe_loc(i) + 1
-!     if (proc < 1 .or. proc > nprocs) then
-!        write(stderr,*) myname_,"proc pe_loc error",i,proc
-!        call die(myname_,'pe_loc error',0)
-!     endif
-     rgs_count(proc) = rgs_count(proc) +1
-     rgs_lb( rgs_count(proc) , proc )=RGSMap%start(i)
-     rgs_ub( rgs_count(proc) , proc )=RGSMap%start(i) + RGSMap%length(i) -1
-  enddo
-
-  if(present(name)) then
-    call zeit_co(trim(tagname))
-  endif
-
-!!!
-!!! this is purely for error checking
-
-  if(present(name)) then
-    tagname='05'//name//'erchck'
-    call zeit_ci(trim(tagname))
-  endif
-  do proc = 1, nprocs
-    if (rgs_count(proc) > r_max_nlseg) then
-      write(stderr,*) myname_,"overflow on rgs array",proc,rgs_count(proc)
-      call die(myname_,'overflow on rgs',0)
+!!
+!!  count number of potentially overlapping remote segments
+!!  and which and how many processes hold these
+!!
+    if(present(name)) then
+      tagname='04'//name//'rloop'
+      call zeit_ci(trim(tagname))
     endif
-  enddo
-  if(present(name)) then
-    call zeit_co(trim(tagname))
+
+    !! number of potentially overlapping segments in RGSMap local to proc
+    !! and mapping from processes that hold these to actual process id
+    allocate( rgs_count(nprocs), feas_procs(nprocs), &
+              inv_feas_procs(nprocs), stat=ier )
+    if(ier/=0) call die(myname_,'allocate rgs_count, feas_procs',ier)
+
+    rgs_count = 0
+    do i=1,r_ngseg
+      r_left  = RGSMap%start(i)
+      r_right = RGSMap%start(i) + RGSMap%length(i) - 1
+
+      if (.not. (my_rightmost < r_left   .or.          & ! potential overlap
+                 my_leftmost  > r_right       ) ) then
+        proc = RGSMap%pe_loc(i) + 1
+!        if (proc < 1 .or. proc > nprocs) then
+!          write(stderr,*) myname_,"proc pe_loc error",i,proc
+!          call die(myname_,'pe_loc error',0)
+!        endif
+        rgs_count(proc) = rgs_count(proc) + 1
+      endif
+
+    enddo
+
+    feas_nprocs   = 0
+    feas_procs    = -1
+    inv_feas_procs = -1
+    do proc=1,nprocs
+      if (rgs_count(proc) > 0) then
+        feas_nprocs = feas_nprocs + 1
+        feas_procs(feas_nprocs) = proc
+        inv_feas_procs(proc) = feas_nprocs
+      endif
+    enddo
+
+!!
+!!  build list of potentially overlapping remote segments
+!!
+    !! original size of rgs_lb()/ub() was (r_ngseg,nprocs)
+    !! at the cost of looping to compute it (within GlobalSegMap_max_nlseg),
+    !!   reduced size to (r_max_nlseg,nprocs)
+    !! then further reduced to (max_rgs_count,feas_nprocs)
+
+    max_rgs_count=0
+    do proc=1,nprocs
+      max_rgs_count = max( max_rgs_count, rgs_count(proc) )
+    enddo
+
+    allocate( rgs_lb(max_rgs_count,feas_nprocs), &
+              rgs_ub(max_rgs_count,feas_nprocs), &
+              nsegs_overlap_arr(feas_nprocs), stat=ier )
+    if(ier/=0) call die(myname_,'allocate rgs, nsegs',ier)
+
+    !! (note: redefining rgs_count to be indexed as 1:feas_nprocs
+    !!  instead of as 1:nprocs)
+    rgs_count = 0
+    do i=1,r_ngseg
+      r_left  = RGSMap%start(i)
+      r_right = RGSMap%start(i) + RGSMap%length(i) -1
+
+      if (.not. (my_rightmost < r_left   .or.  &     ! potential overlap
+                 my_leftmost  > r_right)     ) then
+        proc = RGSMap%pe_loc(i) + 1
+        feas_proc = inv_feas_procs(proc)
+        rgs_count(feas_proc) = rgs_count(feas_proc) + 1
+        rgs_lb( rgs_count(feas_proc) , feas_proc ) = RGSMap%start(i)
+        rgs_ub( rgs_count(feas_proc) , feas_proc ) = RGSMap%start(i) + RGSMap%length(i) -1
+      endif
+
+    enddo
+
+    deallocate(inv_feas_procs,stat=ier)
+    if(ier/=0) call die(myname_,'deallocate inv_feas_procs',ier)
+
+    if(present(name)) then
+      call zeit_co(trim(tagname))
+    endif
+
+  else
+
+    max_rgs_count = 0
+    feas_nprocs = 0
+
   endif
-
-!!!
-
 
 !!!!!!!!!!!!!!!!!!
 
@@ -492,85 +538,96 @@
     tagname='06'//name//'loop2'
     call zeit_ci(trim(tagname))
   endif
-  max_rgs_count=0
-  do proc=1,nprocs
-    max_rgs_count = max( max_rgs_count, rgs_count(proc) )
-  enddo
 
   max_overlap_segs = max(nlseg,max_rgs_count)
 
-  allocate(tmpsegcount(ThisMCTWorld%nprocspid(othercomp), max_overlap_segs),&
-           tmpsegstart(ThisMCTWorld%nprocspid(othercomp), max_overlap_segs),&
- 	   tmppe_list(ThisMCTWorld%nprocspid(othercomp)),stat=ier)
+  allocate(tmpsegcount(feas_nprocs, max_overlap_segs),&
+           tmpsegstart(feas_nprocs, max_overlap_segs),&
+ 	   tmppe_list(feas_nprocs),stat=ier)
   if(ier/=0)  &
     call die( myname_,'allocate tmpsegcount etc. size ', &
-              ThisMCTWorld%nprocspid(othercomp), &
-              ' by ',max_overlap_segs)
+              feas_nprocs, ' by ',max_overlap_segs)
 
-
-  tmpsegcount=0
-  tmpsegstart=0
+  if (feas_nprocs > 0) then
+    tmpsegcount=0
+    tmpsegstart=0
+  endif
   count =0
   maxsegcount=0
 
 !!!!!!!!!!!!!!!!!!
 
-
-  do proc = 1, nprocs
+  do feas_proc = 1, feas_nprocs
     nsegs_overlap = 0
-    tmppe_list(proc) = .FALSE.         ! no overlaps with proc yet
+    tmppe_list(feas_proc) = .FALSE.          ! no overlaps with proc yet
 
-    if ( rgs_count(proc) > 0 ) then
-      do myseg = 1, nlseg                  ! loop over local segs on 'myPID'
+    r_leftmost  = rgs_lb(1,feas_proc)
+    r_rightmost = rgs_ub(rgs_count(feas_proc),feas_proc)
 
-        my_left = mygs_lb(myseg)
-        my_right= mygs_ub(myseg)
+    rseg_leftbase = 0
+    do myseg = 1, nlseg                      ! loop over local segs on 'myPID'
 
-        do rseg = 1, rgs_count(proc)       !   loop over remote segs on 'proc'
+      my_left = mygs_lb(myseg)
+      my_right= mygs_ub(myseg)
 
-          r_left  = rgs_lb(rseg,proc)
-          r_right = rgs_ub(rseg,proc)
+      ! determine whether any overlap
+      if (.not. (my_right < r_leftmost   .or.  &
+                 my_left  > r_rightmost)       ) then
 
-          if (.not. (my_right < r_left   .or.  &     ! overlap
-                     my_left  > r_right) ) then
+        rseg_start = rseg_leftbase + 1       ! rseg loop index to start searching from
 
-             if (nsegs_overlap == 0) then        ! first overlap w/this proc
-               count = count + 1
-               tmppe_list(proc) = .TRUE.
-               prev_right = -9999
-             else
-               prev_right = local_right
-             endif
+        ! loop over candidate overlapping remote segs on 'feas_proc'
+        do rseg = rseg_start, rgs_count(feas_proc)
 
-             overlap_left=max(my_left, r_left)
-             overlap_right=min(my_right, r_right)
-             overlap_diff= overlap_right - overlap_left
+          r_right = rgs_ub(rseg,feas_proc)
+          if (r_right < my_left ) then       ! to the left
+            rseg_leftbase = rseg             ! remember to start to the right of
+                                             !  this for next myseg
+            cycle                            ! try the next remote segment
+          endif
 
-             local_left  = mygs_lstart(myseg) + (overlap_left - my_left)
-             local_right = local_left + overlap_diff
+          r_left  = rgs_lb(rseg,feas_proc)
+          if (r_left  > my_right) exit       ! to the right, so no more segments
+                                             !  need to be examined
 
-                                                   ! non-contiguous w/prev one
-             if (local_left /= (prev_right+1) ) then
-               nsegs_overlap = nsegs_overlap + 1
-               tmpsegstart(count, nsegs_overlap) = local_left
-             endif
+          ! otherwise, overlaps
+          if (nsegs_overlap == 0) then       ! first overlap w/this proc
+            count = count + 1
+            tmppe_list(feas_proc) = .TRUE.
+            prev_right = -9999
+          else
+            prev_right = local_right
+          endif
 
-             tmpsegcount(count, nsegs_overlap) = &
-               tmpsegcount(count, nsegs_overlap) + overlap_diff + 1
+          overlap_left=max(my_left, r_left)
+          overlap_right=min(my_right, r_right)
+          overlap_diff= overlap_right - overlap_left
 
-           endif
+          local_left  = mygs_lstart(myseg) + (overlap_left - my_left)
+          local_right = local_left + overlap_diff
+
+          ! non-contiguous w/prev one
+          if (local_left /= (prev_right+1) ) then
+            nsegs_overlap = nsegs_overlap + 1
+            tmpsegstart(count, nsegs_overlap) = local_left
+          endif
+
+          tmpsegcount(count, nsegs_overlap) = &
+            tmpsegcount(count, nsegs_overlap) + overlap_diff + 1
+
         enddo
-      enddo
-    endif
 
-    nsegs_overlap_arr(proc)=nsegs_overlap
+      endif
+
+    enddo
+
+    nsegs_overlap_arr(feas_proc)=nsegs_overlap
   enddo
 
   !! pull this out of the loop to vectorize
-  do proc=1,nprocs
-    maxsegcount=max(maxsegcount,nsegs_overlap_arr(proc))
+  do feas_proc = 1, feas_nprocs
+    maxsegcount=max(maxsegcount,nsegs_overlap_arr(feas_proc))
   enddo
-
 
   if (maxsegcount > max_overlap_segs) &
     call die( myname_,'overran max_overlap_segs =', &
@@ -581,17 +638,19 @@
 !                  'mysize =',mysize
 
 
-  deallocate( mygs_lb, mygs_ub, mygs_len, mygs_lstart, &
-              rgs_count, rgs_lb, rgs_ub, &
-              nsegs_overlap_arr, stat=ier)
-  if(ier/=0) call die(myname_,'deallocate mygs,rgs,nsegs',ier)
+  deallocate( mygs_lb, mygs_ub, mygs_len, mygs_lstart, stat=ier)
+  if(ier/=0) call die(myname_,'deallocate mygs,nsegs',ier)
 
+  if (nlseg > 0) then
+    deallocate( rgs_count, rgs_lb, rgs_ub, &
+                nsegs_overlap_arr, stat=ier)
+    if(ier/=0) call die(myname_,'deallocate p_rgs, nsegs',ier)
+  endif
 
 !  call shr_timer_stop(t_loop2)    ! rml timers
   if(present(name)) then
     call zeit_co(trim(tagname))
   endif
-
 
 
 !.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
@@ -631,42 +690,44 @@
   allocate(Rout%rp1(count),stat=ier)
   if(ier/=0) call die(myname_,'allocate(rp1)',ier)
 
-
-
   m=0
-  do i=1,ThisMCTWorld%nprocspid(othercomp)
-      if(tmppe_list(i))then
+  do i=1,feas_nprocs
+    if(tmppe_list(i))then
       m=m+1
       ! load processor rank in MCT_comm
-      Rout%pe_list(m)=ThisMCTWorld%idGprocid(othercomp,i-1)
+      proc = feas_procs(i)
+      Rout%pe_list(m)=ThisMCTWorld%idGprocid(othercomp,proc-1)
+    endif
+  enddo
+
+  lmaxsize=0
+  do i=1,count
+    totallength=0
+    do j=1,maxsegcount
+      if(tmpsegcount(i,j) /= 0) then
+	Rout%num_segs(i)=j
+ 	Rout%seg_starts(i,j)=tmpsegstart(i,j)
+	Rout%seg_lengths(i,j)=tmpsegcount(i,j)
+	totallength=totallength+Rout%seg_lengths(i,j)
       endif
     enddo
+    Rout%locsize(i)=totallength
+    lmaxsize=MAX(lmaxsize,totallength)
+  enddo
 
-    lmaxsize=0
-    do i=1,count
-      totallength=0
-      do j=1,maxsegcount
-	if(tmpsegcount(i,j) /= 0) then
-	 Rout%num_segs(i)=j
- 	 Rout%seg_starts(i,j)=tmpsegstart(i,j)
-	 Rout%seg_lengths(i,j)=tmpsegcount(i,j)
-	 totallength=totallength+Rout%seg_lengths(i,j)
-	endif
-      enddo
-      Rout%locsize(i)=totallength
-      lmaxsize=MAX(lmaxsize,totallength)
-    enddo
+  Rout%maxsize=lmaxsize
+  Rout%lAvsize=mysize
 
-    Rout%maxsize=lmaxsize
-    Rout%lAvsize=mysize
-
+  if (nlseg > 0) then
+    deallocate(feas_procs,stat=ier)
+    if(ier/=0) call die(myname_,'deallocate feas_procs',ier)
+  endif
 
   deallocate(tmpsegstart,tmpsegcount,tmppe_list,stat=ier)
-  if(ier/=0) call die(myname_,'deallocate()',ier)
+  if(ier/=0) call die(myname_,'deallocate tmp',ier)
 
   call GlobalSegMap_clean(RGSMap)
   call GlobalSegMap_clean(GSMap)
-
 
   if(present(name)) then
     call zeit_co(trim(tagname))

--- a/cime/src/externals/mct/mct/m_SPMDutils.F90
+++ b/cime/src/externals/mct/mct/m_SPMDutils.F90
@@ -1,0 +1,1148 @@
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!    Math and Computer Science Division, Argonne National Laboratory   !
+!-----------------------------------------------------------------------
+! CVS $Id$
+! CVS $Name$
+!BOP -------------------------------------------------------------------
+!
+! !MODULE: m_SPMDutils -- Communication operators to address performance
+!                         issues for specific communication patterns
+!
+! !DESCRIPTION:
+! This module provides the swapm equivalent to MPI_Alltoallv that
+! has proven to be more robust with respect to performance than the
+! MPI collective or the native MCT communication algorithms when the
+! communication pattern is sparse and when load imbalance or send/receive
+! asymmetry leads some processes to be flooded by unexpected messages.
+!
+! Based on algorithms implemented in CAM, but this version modelled after
+! pio_spmd_utils.F90 in PIO1
+!
+! !SEE ALSO:
+!  m_Rearranger
+!
+!
+! !INTERFACE:
+
+! Disable the use of the MPI ready send protocol by default, to
+! address recurrent issues with poor performance or incorrect
+! functionality in MPI libraries. When support is known to be robust,
+! or for experimentation, can be re-enabled by defining the CPP token
+! _USE_MPI_RSEND during the build process.
+!
+#ifndef _USE_MPI_RSEND
+#define MPI_RSEND MPI_SEND
+#define mpi_rsend mpi_send
+#define MPI_IRSEND MPI_ISEND
+#define mpi_irsend mpi_isend
+#endif
+
+ module m_SPMDutils
+
+      implicit none
+
+      private	! except
+
+! !PUBLIC MEMBER FUNCTIONS:
+
+      public :: m_swapm_int  ! swapm alternative to MPI_AlltoallV for integer data
+      public :: m_swapm_FP   ! swapm alternative to MPI_AlltoallV for FP data
+
+! !DEFINED PARAMETERS:
+
+  character(len=*), parameter :: myname='MCT::m_SPMDutils'
+
+! !REVISION HISTORY:
+! 28Sep16 - P. Worley <worleyph@gmail.com> - initial prototype
+!EOP ___________________________________________________________________
+
+ contains
+
+!========================================================================
+!
+
+   integer function pair(np,p,k)
+
+      integer np,p,k,q
+      q = ieor(p,k)
+      if(q.gt.np-1) then
+         pair = -1
+      else
+         pair = q
+      endif
+      return
+
+   end function pair
+
+!
+!========================================================================
+!
+
+  integer function ceil2(n)
+     integer n,p
+     p=1
+     do while(p.lt.n)
+        p=p*2
+     enddo
+     ceil2=p
+     return
+  end function ceil2
+
+!
+!========================================================================
+!
+   subroutine m_swapm_int ( nprocs, mytask,      &
+      sndbuf, sbuf_siz, sndlths, sdispls, stypes,  &
+      rcvbuf, rbuf_siz, rcvlths, rdispls, rtypes,  &
+      comm, comm_hs, comm_isend, comm_maxreq       )
+
+!-----------------------------------------------------------------------
+!
+!> Purpose:
+!!   Reduced version of original swapm (for swap of multiple messages
+!!   using MPI point-to-point routines), more efficiently implementing a
+!!   subset of the swap protocols.
+!!
+!! Method:
+!! comm_protocol:
+!!  comm_isend == .true.: use nonblocking send, else use blocking send
+!!  comm_hs == .true.: use handshaking protocol
+!! comm_maxreq:
+!!  =-1,0: do not limit number of outstanding send/receive requests
+!!     >0: do not allow more than min(comm_maxreq, steps) outstanding
+!!         nonblocking send requests or nonblocking receive requests
+!!
+!! Author of original version:  P. Worley
+!! Ported from PIO1: P. Worley, September 2016
+!<
+!-----------------------------------------------------------------------
+!-----------------------------------------------------------------------
+   use m_mpif90
+   use m_realkinds, only : FP
+   use m_die,       only : MP_perr_die
+
+   implicit none
+!---------------------------Input arguments--------------------------
+!
+   integer, intent(in)   :: nprocs             ! size of communicator
+   integer, intent(in)   :: mytask             ! MPI task id with communicator
+   integer, intent(in)   :: sbuf_siz           ! size of send buffer
+   integer, intent(in)   :: rbuf_siz           ! size of receive buffer
+
+   integer, intent(in)   :: sndlths(0:nprocs-1)! length of outgoing message
+   integer, intent(in)   :: sdispls(0:nprocs-1)! offset from beginning of send
+                                               !  buffer where outgoing messages
+                                               !  should be sent from
+   integer, intent(in)   :: stypes(0:nprocs-1) ! MPI data types
+   integer, intent(in)   :: rcvlths(0:nprocs-1)! length of incoming messages
+   integer, intent(in)   :: rdispls(0:nprocs-1)! offset from beginning of receive
+                                               !  buffer where incoming messages
+                                               !  should be placed
+   integer, intent(in)   :: rtypes(0:nprocs-1) ! MPI data types
+   integer, intent(in)   :: sndbuf(sbuf_siz)   ! outgoing message buffer
+
+   integer, intent(in)   :: comm               ! MPI communicator
+   logical, intent(in)   :: comm_hs            ! handshaking protocol?
+   logical, intent(in)   :: comm_isend         ! nonblocking send protocol?
+   integer, intent(in)   :: comm_maxreq        ! maximum number of outstanding
+                                               !  nonblocking requests
+
+!---------------------------Output arguments--------------------------
+!
+   integer, intent(out)  :: rcvbuf(rbuf_siz)   ! incoming message buffer
+
+!
+!---------------------------Local workspace-------------------------------------------
+!
+   character(len=*), parameter :: subName=myname//'::m_swapm_int'
+
+   integer :: steps                            ! number of swaps to initiate
+   integer :: swapids(nprocs)                  ! MPI process id of swap partners
+   integer :: p                                ! process index
+   integer :: istep                            ! loop index
+   integer :: tag                              ! MPI message tag
+   integer :: offset_t                         ! MPI message tag offset, for addressing
+                                               !  message conflict bug (if necessary)
+   integer :: offset_s                         ! index of message beginning in
+                                               !  send buffer
+   integer :: offset_r                         ! index of message beginning in
+                                               !  receive buffer
+   integer :: sndids(nprocs)                   ! send request ids
+   integer :: rcvids(nprocs)                   ! receive request ids
+   integer :: hs_rcvids(nprocs)                ! handshake receive request ids
+
+   integer :: maxreq, maxreqh                  ! maximum number of outstanding
+                                               !  nonblocking requests (and half)
+   integer :: hs                               ! handshake variable
+   integer :: rstep                            ! "receive" step index
+
+   logical :: handshake, sendd                 ! protocol option flags
+
+   integer :: ier                              ! return error status
+   integer :: status(MP_STATUS_SIZE)           ! MPI status
+!
+!-------------------------------------------------------------------------------------
+!
+#ifdef _NO_M_SWAPM_TAG_OFFSET
+   offset_t = 0
+#else
+   offset_t = nprocs
+#endif
+!
+   ! if necessary, send to self
+   if (sndlths(mytask) > 0) then
+      tag = mytask + offset_t
+
+      offset_r = rdispls(mytask)+1
+      call mpi_irecv( rcvbuf(offset_r), rcvlths(mytask), rtypes(mytask), &
+                      mytask, tag, comm, rcvids(1), ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+      offset_s = sdispls(mytask)+1
+      call mpi_send( sndbuf(offset_s), sndlths(mytask), stypes(mytask), &
+                     mytask, tag, comm, ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+
+      call mpi_wait( rcvids(1), status, ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+   endif
+
+   ! calculate swap partners and communication ordering
+   steps = 0
+   do istep=1,ceil2(nprocs)-1
+      p = pair(nprocs,istep,mytask)
+      if (p >= 0) then
+         if (sndlths(p) > 0 .or. rcvlths(p) > 0) then
+            steps = steps + 1
+            swapids(steps) = p
+         end if
+      end if
+   end do
+
+   if (steps .eq. 0) return
+
+   ! identify communication protocol
+   if (comm_isend) then
+      sendd = .false.
+   else
+      sendd = .true.
+   endif
+   handshake = comm_hs
+
+   ! identify maximum number of outstanding nonblocking requests to permit
+   if (steps .eq. 1) then
+      maxreq  = 1
+      maxreqh = 1
+   else
+      if (comm_maxreq >= -1) then
+         maxreq = comm_maxreq
+      else
+         maxreq = steps
+      endif
+
+      if ((maxreq .le. steps) .and. (maxreq > 0)) then
+         if (maxreq > 1) then
+            maxreqh = maxreq/2
+         else
+            maxreq  = 2
+            maxreqh = 1
+         endif
+      else
+         maxreq  = steps
+         maxreqh = steps
+      endif
+   endif
+
+! Four protocol options:
+!  (1) handshaking + blocking sends
+   if ((handshake) .and. (sendd)) then
+
+      ! Initialize hs variable
+      hs = 1
+
+      ! Post initial handshake receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+            call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                            hs_rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+
+      ! Post initial receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+            call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new rsend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_wait  ( hs_rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+
+            call mpi_rsend ( sndbuf(offset_s), sndlths(p), stypes(p), &
+                             p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_RSEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+
+               ! Submit a new handshake irecv request
+               if (sndlths(p) > 0) then
+                  tag = mytask + offset_t
+                  call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                                  hs_rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+
+               ! Submit a new irecv request
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+                  call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+               endif
+            endif
+
+         endif
+!
+      enddo
+
+      ! wait for rest of receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (2) handshaking + nonblocking sends
+   elseif ((handshake) .and. (.not. sendd)) then
+
+      ! Initialize hs variable
+      hs = 1
+
+      ! Post initial handshake receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+            call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                            hs_rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+
+      ! Post initial receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+            call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new irsend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_wait  ( hs_rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+
+            call mpi_irsend( sndbuf(offset_s), sndlths(p), stypes(p), &
+                             p, tag, comm, sndids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRSEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+
+               ! Submit a new handshake irecv request
+               if (sndlths(p) > 0) then
+                  tag = mytask + offset_t
+                  call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                                  hs_rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+
+               ! Submit a new irecv request
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+                  call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+               endif
+            endif
+
+            ! Wait for outstanding i(r)send request to complete
+            p = swapids(istep-maxreqh)
+            if (sndlths(p) > 0) then
+               call mpi_wait( sndids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+         if (sndlths(p) > 0) then
+            call mpi_wait( sndids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (3) no handshaking + blocking sends
+   elseif ((.not. handshake) .and. (sendd)) then
+
+      ! Post receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new send request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_send( sndbuf(offset_s), sndlths(p), stypes(p), &
+                           p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            ! Submit a new irecv request
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (4) no handshaking + nonblocking sends
+   elseif ((.not. handshake) .and. (.not. sendd)) then
+
+      ! Post receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new isend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_isend( sndbuf(offset_s), sndlths(p), stypes(p), &
+                            p, tag, comm, sndids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_ISEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            ! Submit a new irecv request
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+            endif
+
+            ! Wait for outstanding i(r)send request to complete
+            p = swapids(istep-maxreqh)
+            if (sndlths(p) > 0) then
+               call mpi_wait( sndids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+         if (sndlths(p) > 0) then
+            call mpi_wait( sndids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+   endif
+
+   return
+
+   end subroutine m_swapm_int
+
+!
+!========================================================================
+!
+   subroutine m_swapm_FP ( nprocs, mytask,   &
+      sndbuf, sbuf_siz, sndlths, sdispls, stypes,  &
+      rcvbuf, rbuf_siz, rcvlths, rdispls, rtypes,  &
+      comm, comm_hs, comm_isend, comm_maxreq       )
+
+!-----------------------------------------------------------------------
+!
+!> Purpose:
+!!   Reduced version of original swapm (for swap of multiple messages
+!!   using MPI point-to-point routines), more efficiently implementing a
+!!   subset of the swap protocols.
+!!
+!! Method:
+!! comm_protocol:
+!!  comm_isend == .true.: use nonblocking send, else use blocking send
+!!  comm_hs == .true.: use handshaking protocol
+!! comm_maxreq:
+!!  =-1,0: do not limit number of outstanding send/receive requests
+!!     >0: do not allow more than min(comm_maxreq, steps) outstanding
+!!         nonblocking send requests or nonblocking receive requests
+!!
+!! Author of original version:  P. Worley
+!! Ported from PIO1: P. Worley, September 2016
+!<
+!-----------------------------------------------------------------------
+!-----------------------------------------------------------------------
+   use m_mpif90
+   use m_realkinds, only : FP
+   use m_die,       only : MP_perr_die
+
+   implicit none
+!---------------------------Input arguments--------------------------
+!
+   integer, intent(in)   :: nprocs             ! size of communicator
+   integer, intent(in)   :: mytask             ! MPI task id with communicator
+   integer, intent(in)   :: sbuf_siz           ! size of send buffer
+   integer, intent(in)   :: rbuf_siz           ! size of receive buffer
+
+   integer, intent(in)   :: sndlths(0:nprocs-1)! length of outgoing message
+   integer, intent(in)   :: sdispls(0:nprocs-1)! offset from beginning of send
+                                               !  buffer where outgoing messages
+                                               !  should be sent from
+   integer, intent(in)   :: stypes(0:nprocs-1) ! MPI data types
+   integer, intent(in)   :: rcvlths(0:nprocs-1)! length of incoming messages
+   integer, intent(in)   :: rdispls(0:nprocs-1)! offset from beginning of receive
+                                               !  buffer where incoming messages
+                                               !  should be placed
+   integer, intent(in)   :: rtypes(0:nprocs-1) ! MPI data types
+   real(FP),intent(in)   :: sndbuf(sbuf_siz)   ! outgoing message buffer
+
+   integer, intent(in)   :: comm               ! MPI communicator
+   logical, intent(in)   :: comm_hs            ! handshaking protocol?
+   logical, intent(in)   :: comm_isend         ! nonblocking send protocol?
+   integer, intent(in)   :: comm_maxreq        ! maximum number of outstanding
+                                               !  nonblocking requests
+
+!---------------------------Output arguments--------------------------
+!
+   real(FP), intent(out)  :: rcvbuf(rbuf_siz)   ! incoming message buffer
+
+!
+!---------------------------Local workspace-------------------------------------------
+!
+   character(len=*), parameter :: subName=myname//'::m_swapm_FP'
+
+   integer :: steps                            ! number of swaps to initiate
+   integer :: swapids(nprocs)                  ! MPI process id of swap partners
+   integer :: p                                ! process index
+   integer :: istep                            ! loop index
+   integer :: tag                              ! MPI message tag
+   integer :: offset_t                         ! MPI message tag offset, for addressing
+                                               !  message conflict bug (if necessary)
+   integer :: offset_s                         ! index of message beginning in
+                                               !  send buffer
+   integer :: offset_r                         ! index of message beginning in
+                                               !  receive buffer
+   integer :: sndids(nprocs)                   ! send request ids
+   integer :: rcvids(nprocs)                   ! receive request ids
+   integer :: hs_rcvids(nprocs)                ! handshake receive request ids
+
+   integer :: maxreq, maxreqh                  ! maximum number of outstanding
+                                               !  nonblocking requests (and half)
+   integer :: hs                               ! handshake variable
+   integer :: rstep                            ! "receive" step index
+
+   logical :: handshake, sendd                 ! protocol option flags
+
+   integer :: ier                              ! return error status
+   integer :: status(MP_STATUS_SIZE)           ! MPI status
+!
+!-------------------------------------------------------------------------------------
+!
+#ifdef _NO_M_SWAPM_TAG_OFFSET
+   offset_t = 0
+#else
+   offset_t = nprocs
+#endif
+!
+   ! if necessary, send to self
+   if (sndlths(mytask) > 0) then
+      tag = mytask + offset_t
+
+      offset_r = rdispls(mytask)+1
+      call mpi_irecv( rcvbuf(offset_r), rcvlths(mytask), rtypes(mytask), &
+                      mytask, tag, comm, rcvids(1), ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+      offset_s = sdispls(mytask)+1
+      call mpi_send( sndbuf(offset_s), sndlths(mytask), stypes(mytask), &
+                     mytask, tag, comm, ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+
+      call mpi_wait( rcvids(1), status, ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+   endif
+
+   ! calculate swap partners and communication ordering
+   steps = 0
+   do istep=1,ceil2(nprocs)-1
+      p = pair(nprocs,istep,mytask)
+      if (p >= 0) then
+         if (sndlths(p) > 0 .or. rcvlths(p) > 0) then
+            steps = steps + 1
+            swapids(steps) = p
+         end if
+      end if
+   end do
+
+   if (steps .eq. 0) return
+
+   ! identify communication protocol
+   if (comm_isend) then
+      sendd = .false.
+   else
+      sendd = .true.
+   endif
+   handshake = comm_hs
+
+   ! identify maximum number of outstanding nonblocking requests to permit
+   if (steps .eq. 1) then
+      maxreq  = 1
+      maxreqh = 1
+   else
+      if (comm_maxreq >= -1) then
+         maxreq = comm_maxreq
+      else
+         maxreq = steps
+      endif
+
+      if ((maxreq .le. steps) .and. (maxreq > 0)) then
+         if (maxreq > 1) then
+            maxreqh = maxreq/2
+         else
+            maxreq  = 2
+            maxreqh = 1
+         endif
+      else
+         maxreq  = steps
+         maxreqh = steps
+      endif
+   endif
+
+! Four protocol options:
+!  (1) handshaking + blocking sends
+   if ((handshake) .and. (sendd)) then
+
+      ! Initialize hs variable
+      hs = 1
+
+      ! Post initial handshake receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+            call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                            hs_rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+
+      ! Post initial receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+            call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new rsend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_wait  ( hs_rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+
+            call mpi_rsend ( sndbuf(offset_s), sndlths(p), stypes(p), &
+                             p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_RSEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+
+               ! Submit a new handshake irecv request
+               if (sndlths(p) > 0) then
+                  tag = mytask + offset_t
+                  call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                                  hs_rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+
+               ! Submit a new irecv request
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+                  call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+               endif
+            endif
+
+         endif
+!
+      enddo
+
+      ! wait for rest of receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (2) handshaking + nonblocking sends
+   elseif ((handshake) .and. (.not. sendd)) then
+
+      ! Initialize hs variable
+      hs = 1
+
+      ! Post initial handshake receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+            call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                            hs_rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+
+      ! Post initial receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+            call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new irsend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_wait  ( hs_rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+
+            call mpi_irsend( sndbuf(offset_s), sndlths(p), stypes(p), &
+                             p, tag, comm, sndids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRSEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+
+               ! Submit a new handshake irecv request
+               if (sndlths(p) > 0) then
+                  tag = mytask + offset_t
+                  call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                                  hs_rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+
+               ! Submit a new irecv request
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+                  call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+               endif
+            endif
+
+            ! Wait for outstanding i(r)send request to complete
+            p = swapids(istep-maxreqh)
+            if (sndlths(p) > 0) then
+               call mpi_wait( sndids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+         if (sndlths(p) > 0) then
+            call mpi_wait( sndids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (3) no handshaking + blocking sends
+   elseif ((.not. handshake) .and. (sendd)) then
+
+      ! Post receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new send request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_send( sndbuf(offset_s), sndlths(p), stypes(p), &
+                           p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            ! Submit a new irecv request
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (4) no handshaking + nonblocking sends
+   elseif ((.not. handshake) .and. (.not. sendd)) then
+
+      ! Post receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new isend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_isend( sndbuf(offset_s), sndlths(p), stypes(p), &
+                            p, tag, comm, sndids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_ISEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            ! Submit a new irecv request
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+            endif
+
+            ! Wait for outstanding i(r)send request to complete
+            p = swapids(istep-maxreqh)
+            if (sndlths(p) > 0) then
+               call mpi_wait( sndids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+         if (sndlths(p) > 0) then
+            call mpi_wait( sndids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+   endif
+
+   return
+
+   end subroutine m_swapm_FP
+
+end module m_SPMDutils
+
+
+
+
+

--- a/cime/src/externals/mct/mpeu/m_FcComms.F90
+++ b/cime/src/externals/mct/mpeu/m_FcComms.F90
@@ -13,10 +13,13 @@
 !
 ! !INTERFACE:
 !
-! Workaround for performance issue with rsend on cray systems with
-! gemini interconnect
+! Disable the use of the MPI ready send protocol by default, to
+! address recurrent issues with poor performance or incorrect
+! functionality in MPI libraries. When support is known to be robust,
+! or for experimentation, can be re-enabled by defining the CPP token
+! _USE_MPI_RSEND during the build process.
 !
-#ifdef _NO_MPI_RSEND
+#ifndef _USE_MPI_RSEND
 #define MPI_RSEND MPI_SEND
 #define mpi_rsend mpi_send
 #define MPI_IRSEND MPI_ISEND

--- a/cime/src/externals/mct/mpi-serial/Makefile
+++ b/cime/src/externals/mct/mpi-serial/Makefile
@@ -18,6 +18,8 @@ SRCS_C		= mpi.c \
 		  list.c \
 		  handles.c \
                   comm.c \
+		  error.c \
+                  ic_merge.c \
                   group.c \
                   time.c \
                   pack.c \

--- a/cime/src/externals/mct/mpi-serial/README
+++ b/cime/src/externals/mct/mpi-serial/README
@@ -64,6 +64,9 @@ List of MPI calls supported
       mpi_abort
       mpi_error_string
       mpi_initialized
+      mpi_get_processor_name
+      mpi_get_library_version
+      mpi_wtime
 
     comm and group ops
       mpi_comm_free
@@ -74,17 +77,36 @@ List of MPI calls supported
       mpi_comm_split
       mpi_comm_group
       mpi_group_incl
+      mpi_group_range_incl
+      mpi_group_union
+      mpi_group_intersection
+      mpi_group_difference
+      mpi_group_translate_ranks
       mpi_group_free
+      mpi_cart_create
+      mpi_cart_coords
+      mpi_dims_create
 
     send/receive ops
       mpi_irecv
       mpi_recv
       mpi_test
+      mpi_testany
+      mpi_testall
+      mpi_testsome
       mpi_wait
       mpi_waitany
       mpi_waitall
+      mpi_waitsome
       mpi_isend
       mpi_send
+      mpi_ssend
+      mpi_rsend
+      mpi_irsend
+      mpi_sendrecv
+      mpi_iprobe
+      mpi_probe
+      mpi_request_free
 
     collective operations
       mpi_barrier
@@ -92,11 +114,27 @@ List of MPI calls supported
       mpi_gather
       mpi_gatherv
       mpi_allgather
+      mpi_scatter
       mpi_scatterv
       mpi_reduce
       mpi_allreduce
+      mpi_reduce_scatter
+      mpi_scan
+      mpi_alltoall
+      mpi_alltoallv
+      mpi_alltoallw
+      mpi_op_create
+      mpi_op_free
 
-
+    data types and info objects
+      mpi_get_count
+      mpi_get_elements
+      mpi_pack
+      mpi_pack_size
+      mpi_unpack
+      mpi_info_create
+      mpi_info_set
+      mpi_info_free
 
 -----
 EOF

--- a/cime/src/externals/mct/mpi-serial/collective.c
+++ b/cime/src/externals/mct/mpi-serial/collective.c
@@ -488,27 +488,6 @@ int MPI_Alltoallw(void *sendbuf, int *sendcounts,
 }
 
 
-/*********/
-
-
-FC_FUNC( mpi_op_create , MPI_OP_CREATE )
-  ( void *function, int *commute, int *op, int *ierror )
-{
-  *ierror=MPI_Op_create(function,*commute,op);
-}
-
-
-
-int MPI_Op_create(MPI_User_function *function, int commute, MPI_Op *op)
-{
-  *op=MPI_OP_NULL;
-
-  return(MPI_SUCCESS);
-
-}
-
-
-
 
 /*********/
 

--- a/cime/src/externals/mct/mpi-serial/error.c
+++ b/cime/src/externals/mct/mpi-serial/error.c
@@ -1,0 +1,13 @@
+
+#include "mpiP.h"
+
+/*
+ * Error handling code
+ * Just a stub for now to support the MPI interface without actually
+ * doing anything
+ */
+
+ int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler handle)
+ {
+   return(MPI_SUCCESS);
+ }

--- a/cime/src/externals/mct/mpi-serial/ic_merge.c
+++ b/cime/src/externals/mct/mpi-serial/ic_merge.c
@@ -1,0 +1,15 @@
+
+#include "mpiP.h"
+
+/*
+ * MPI_Intercomm_merge - Creates an intracommunicator from an intercommunicator
+ * This is just a stub for now to support mpi function calls even in Serial
+ * applications. In the case of a serial program, this function is a no-op and
+ * only ever returns MPI_SUCCESS
+ */
+
+int MPI_Intercomm_merge( MPI_Comm intercomm, int high, MPI_Comm *newintracomm )
+{
+  newintracomm = (MPI_Comm *)intercomm;
+  return(MPI_SUCCESS);
+}

--- a/cime/src/externals/mct/mpi-serial/mpi.h
+++ b/cime/src/externals/mct/mpi-serial/mpi.h
@@ -1,4 +1,3 @@
-
 #ifndef _MPI_H_
 #define _MPI_H_
 
@@ -47,7 +46,6 @@ typedef int MPI_Group;
 #define MPI_PENDING        (-1)
 #define MPI_ERR_IN_STATUS  (-1)
 #define MPI_ERR_LASTCODE   (-1)
-
 
 /*
  * MPI_UNDEFINED
@@ -191,6 +189,14 @@ typedef struct                  /* Fortran: INTEGER status(MPI_STATUS_SIZE) */
 #define MPI_STATUSES_IGNORE  ((MPI_Status *)0)
 
 
+/*
+ * MPI Errhandling stubs (Not functional currently)
+ */
+typedef int MPI_Errhandler;
+
+#define MPI_ERRORS_ARE_FATAL ((MPI_Errhandler)0)
+#define MPI_ERRORS_RETURN    ((MPI_Errhandler)-1)
+
 
 /*
  * Collective operations
@@ -246,7 +252,8 @@ typedef int MPI_Info;         /* handle */
 extern int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
                           MPI_Comm peer_comm, int remote_leader,
                           int tag, MPI_Comm *newintercomm);
-
+extern int MPI_Intercomm_merge(MPI_Comm intercomm, int high,
+			       MPI_Comm *newintercomm);
 extern int MPI_Cart_create(MPI_Comm comm_old, int ndims, int *dims,
                         int *periods, int reorder, MPI_Comm *comm_cart);
 extern int MPI_Cart_get(MPI_Comm comm, int maxdims, int *dims,
@@ -389,6 +396,9 @@ extern int MPI_Iprobe(int source, int tag, MPI_Comm comm,
 
 extern int MPI_Pack_size(int incount, MPI_Datatype type, MPI_Comm comm, MPI_Aint * size);
 
+/* Error handling stub, not currently functional */
+extern int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler handle);
+
 /* new type functions */
 extern int MPI_Get_count(MPI_Status *status, MPI_Datatype datatype, int *count);
 extern int MPI_Get_elements(MPI_Status *status, MPI_Datatype datatype, int *count);
@@ -398,6 +408,9 @@ extern int MPI_Type_vector(int count, int blocklen, int stride, MPI_Datatype old
                            MPI_Datatype *newtype);
 
 extern int MPI_Type_hvector(int count, int blocklen, MPI_Aint stride,
+                            MPI_Datatype oldtype, MPI_Datatype *newtype);
+
+extern int MPI_Type_create_hvector(int count, int blocklen, MPI_Aint stride,
                             MPI_Datatype oldtype, MPI_Datatype *newtype);
 
 extern int MPI_Type_indexed(int count, int *blocklens, int *displacements,

--- a/cime/src/externals/mct/mpi-serial/mpif.h
+++ b/cime/src/externals/mct/mpi-serial/mpif.h
@@ -1,334 +1,327 @@
 
-!!!
-!!!   NOTE: The files mpif.realXdoubleY.h are generated from
-!!!   mpif.master.h using make-mpif and later copied to mpif.h
-!!!   during the library make.  All modifications should be
-!!!   made to mpif.master.h
-!!!
-
-
 !
 ! MPI_COMM_WORLD
 !
 
-	INTEGER MPI_COMM_WORLD
-        parameter (mpi_comm_world=1)
+INTEGER MPI_COMM_WORLD
+parameter (mpi_comm_world=1)
 
 !
 !
 !
 
-        integer MPI_BOTTOM
-        parameter (MPI_BOTTOM=0)
+integer MPI_BOTTOM
+parameter (MPI_BOTTOM=0)
 
 
 !
 ! source,tag
-!
+  !
 
-	integer MPI_ANY_SOURCE, MPI_ANY_TAG
-        parameter (mpi_any_source=-1, mpi_any_tag= -1)
+  integer MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_TAG_UB
+  parameter (mpi_any_source=-1, mpi_any_tag= -1, mpi_tag_ub=1681915906)
 
-        integer MPI_PROC_NULL, MPI_ROOT
-        parameter (MPI_PROC_NULL=-2, MPI_ROOT=-3)
+  integer MPI_PROC_NULL, MPI_ROOT
+  parameter (MPI_PROC_NULL=-2, MPI_ROOT=-3)
 
-        integer MPI_COMM_NULL, MPI_REQUEST_NULL
-        parameter (MPI_COMM_NULL=0, MPI_REQUEST_NULL=0)
+  integer MPI_COMM_NULL, MPI_REQUEST_NULL
+  parameter (MPI_COMM_NULL=0, MPI_REQUEST_NULL=0)
 
-        integer MPI_GROUP_NULL, MPI_GROUP_EMPTY
-        parameter (MPI_GROUP_NULL=0, MPI_GROUP_EMPTY= -1)
+  integer MPI_GROUP_NULL, MPI_GROUP_EMPTY
+  parameter (MPI_GROUP_NULL=0, MPI_GROUP_EMPTY= -1)
 
-        integer MPI_MAX_ERROR_STRING
-        parameter (MPI_MAX_ERROR_STRING=128)
+  integer MPI_MAX_ERROR_STRING
+  parameter (MPI_MAX_ERROR_STRING=128)
 
-        integer MPI_MAX_PROCESSOR_NAME
-        parameter (MPI_MAX_PROCESSOR_NAME=128)
+  integer MPI_MAX_PROCESSOR_NAME
+  parameter (MPI_MAX_PROCESSOR_NAME=128)
 
-!
-! Return codes
-!
+  !
+  ! Return codes
+  !
 
-        integer MPI_SUCCESS
-        parameter (MPI_SUCCESS=0)
+  integer MPI_SUCCESS
+  parameter (MPI_SUCCESS=0)
 
-        integer MPI_ERR_BUFFER
-        parameter (MPI_ERR_BUFFER= -1)
+  integer MPI_ERR_BUFFER
+  parameter (MPI_ERR_BUFFER= -1)
 
-        integer MPI_ERR_COUNT
-        parameter (MPI_ERR_COUNT= -1)
+  integer MPI_ERR_COUNT
+  parameter (MPI_ERR_COUNT= -1)
 
-        integer MPI_ERR_TYPE
-        parameter (MPI_ERR_TYPE= -1)
+  integer MPI_ERR_TYPE
+  parameter (MPI_ERR_TYPE= -1)
 
-        integer MPI_ERR_TAG
-        parameter (MPI_ERR_TAG= -1)
+  integer MPI_ERR_TAG
+  parameter (MPI_ERR_TAG= -1)
 
-        integer MPI_ERR_COMM
-        parameter (MPI_ERR_COMM= -1)
+  integer MPI_ERR_COMM
+  parameter (MPI_ERR_COMM= -1)
 
-        integer MPI_ERR_RANK
-        parameter (MPI_ERR_RANK= -1)
+  integer MPI_ERR_RANK
+  parameter (MPI_ERR_RANK= -1)
 
-        integer MPI_ERR_REQUEST
-        parameter (MPI_ERR_REQUEST= -1)
+  integer MPI_ERR_REQUEST
+  parameter (MPI_ERR_REQUEST= -1)
 
-        integer MPI_ERR_ROOT
-        parameter (MPI_ERR_ROOT= -1)
+  integer MPI_ERR_ROOT
+  parameter (MPI_ERR_ROOT= -1)
 
-        integer MPI_ERR_GROUP
-        parameter (MPI_ERR_GROUP= -1)
+  integer MPI_ERR_GROUP
+  parameter (MPI_ERR_GROUP= -1)
 
-        integer MPI_ERR_OP
-        parameter (MPI_ERR_OP= -1)
+  integer MPI_ERR_OP
+  parameter (MPI_ERR_OP= -1)
 
-        integer MPI_ERR_TOPOLOGY
-        parameter (MPI_ERR_TOPOLOGY= -1)
+  integer MPI_ERR_TOPOLOGY
+  parameter (MPI_ERR_TOPOLOGY= -1)
 
-        integer MPI_ERR_DIMS
-        parameter (MPI_ERR_DIMS= -1)
+  integer MPI_ERR_DIMS
+  parameter (MPI_ERR_DIMS= -1)
 
-        integer MPI_ERR_ARG
-        parameter (MPI_ERR_ARG= -1)
+  integer MPI_ERR_ARG
+  parameter (MPI_ERR_ARG= -1)
 
-        integer MPI_ERR_UNKNOWN
-        parameter (MPI_ERR_UNKNOWN= -1)
+  integer MPI_ERR_UNKNOWN
+  parameter (MPI_ERR_UNKNOWN= -1)
 
-        integer MPI_ERR_TRUNCATE
-        parameter (MPI_ERR_TRUNCATE= -1)
+  integer MPI_ERR_TRUNCATE
+  parameter (MPI_ERR_TRUNCATE= -1)
 
-        integer MPI_ERR_OTHER
-        parameter (MPI_ERR_OTHER= -1)
+  integer MPI_ERR_OTHER
+  parameter (MPI_ERR_OTHER= -1)
 
-        integer MPI_ERR_INTERN
-        parameter (MPI_ERR_INTERN= -1)
+  integer MPI_ERR_INTERN
+  parameter (MPI_ERR_INTERN= -1)
 
-        integer MPI_PENDING
-        parameter (MPI_PENDING= -1)
+  integer MPI_PENDING
+  parameter (MPI_PENDING= -1)
 
-        integer MPI_ERR_IN_STATUS
-        parameter (MPI_ERR_IN_STATUS= -1)
+  integer MPI_ERR_IN_STATUS
+  parameter (MPI_ERR_IN_STATUS= -1)
 
-        integer MPI_ERR_LASTCODE
-        parameter (MPI_ERR_LASTCODE= -1)
+  integer MPI_ERR_LASTCODE
+  parameter (MPI_ERR_LASTCODE= -1)
 
-!
-!
+  integer MPI_ERRORS_RETURN
+  parameter (MPI_ERRORS_RETURN= -1)
 
+  !
+  !
 
-        integer MPI_UNDEFINED
-        parameter (MPI_UNDEFINED= -1)
 
+  integer MPI_UNDEFINED
+  parameter (MPI_UNDEFINED= -1)
 
-!
-! MPI_Status
-!
-! The values in this section MUST match the struct definition
-! in mpi.h
-!
 
+  !
+  ! MPI_Status
+  !
+  ! The values in this section MUST match the struct definition
+  ! in mpi.h
+  !
 
-        INTEGER MPI_STATUS_SIZE
-        PARAMETER (MPI_STATUS_SIZE=4)
 
-        INTEGER MPI_SOURCE, MPI_TAG, MPI_ERROR
-        PARAMETER(MPI_SOURCE=1, MPI_TAG=2, MPI_ERROR=3)
-        ! There is a 4th value only used internally
+  INTEGER MPI_STATUS_SIZE
+  PARAMETER (MPI_STATUS_SIZE=4)
 
-        INTEGER MPI_STATUS_IGNORE(MPI_STATUS_SIZE)
-        INTEGER MPI_STATUSES_IGNORE(MPI_STATUS_SIZE,1)
-        COMMON /MPISERIAL/ MPI_STATUS_IGNORE
-        COMMON /MPISERIAL/ MPI_STATUSES_IGNORE
+  INTEGER MPI_SOURCE, MPI_TAG, MPI_ERROR
+  PARAMETER(MPI_SOURCE=1, MPI_TAG=2, MPI_ERROR=3)
+  ! There is a 4th value only used internally
 
-!
-! MPI_IN_PLACE
-!
+  INTEGER MPI_STATUS_IGNORE(MPI_STATUS_SIZE)
+  INTEGER MPI_STATUSES_IGNORE(MPI_STATUS_SIZE,1)
+  COMMON /MPISERIAL/ MPI_STATUS_IGNORE
+  COMMON /MPISERIAL/ MPI_STATUSES_IGNORE
 
-        INTEGER MPI_IN_PLACE
-        COMMON /MPISERIAL/ MPI_IN_PLACE
+  !
+  ! MPI_IN_PLACE
+  !
 
-        SAVE   /MPISERIAL/   ! Technically needed in case goes out of scope
+  INTEGER MPI_IN_PLACE
+  COMMON /MPISERIAL/ MPI_IN_PLACE
 
+  SAVE   /MPISERIAL/   ! Technically needed in case goes out of scope
 
-!
-! MPI_Datatype values
-!
-!  New datatype values
-!  Type constants represent integer handles, matching up to the index of the
-!  type array equal to the absolute value of the constant plus one.  For
-!  example, MPI_BYTE=-12, corresponding to type index 11.
-!  (Array in type_const.c)
-!
 
+  !
+  ! MPI_Datatype values
+  !
+  !  New datatype values
+  !  Type constants represent integer handles, matching up to the index of the
+  !  type array equal to the absolute value of the constant plus one.  For
+  !  example, MPI_BYTE=-12, corresponding to type index 11.
+  !  (Array in type_const.c)
+  !
 
-        INTEGER MPI_DATATYPE_NULL
-        PARAMETER (MPI_DATATYPE_NULL=0)
 
-        INTEGER MPI_BYTE
-	PARAMETER (MPI_BYTE=-12)
+  INTEGER MPI_DATATYPE_NULL
+  PARAMETER (MPI_DATATYPE_NULL=0)
 
-	INTEGER MPI_PACKED
-	PARAMETER (MPI_PACKED=-13)
+  INTEGER MPI_BYTE
+  PARAMETER (MPI_BYTE=-12)
 
-	INTEGER MPI_LB
-	PARAMETER (MPI_LB=-14)
+  INTEGER MPI_PACKED
+  PARAMETER (MPI_PACKED=-13)
 
-	INTEGER MPI_UB
-	PARAMETER (MPI_UB=-15)
+  INTEGER MPI_LB
+  PARAMETER (MPI_LB=-14)
 
-	INTEGER MPI_INTEGER
-	PARAMETER (MPI_INTEGER=-16)
+  INTEGER MPI_UB
+  PARAMETER (MPI_UB=-15)
 
-	INTEGER MPI_REAL
-	PARAMETER (MPI_REAL=-17)
+  INTEGER MPI_INTEGER
+  PARAMETER (MPI_INTEGER=-16)
 
-	INTEGER MPI_DOUBLE_PRECISION
-	PARAMETER (MPI_DOUBLE_PRECISION=-18)
+  INTEGER MPI_REAL
+  PARAMETER (MPI_REAL=-17)
 
-	INTEGER MPI_COMPLEX
-	PARAMETER (MPI_COMPLEX=-19)
+  INTEGER MPI_DOUBLE_PRECISION
+  PARAMETER (MPI_DOUBLE_PRECISION=-18)
 
-	INTEGER MPI_DOUBLE_COMPLEX
-	PARAMETER (MPI_DOUBLE_COMPLEX=-20)
+  INTEGER MPI_COMPLEX
+  PARAMETER (MPI_COMPLEX=-19)
 
-	INTEGER MPI_LOGICAL
-	PARAMETER (MPI_LOGICAL=-21)
+  INTEGER MPI_DOUBLE_COMPLEX
+  PARAMETER (MPI_DOUBLE_COMPLEX=-20)
 
-	INTEGER MPI_CHARACTER
-	PARAMETER (MPI_CHARACTER=-22)
+  INTEGER MPI_LOGICAL
+  PARAMETER (MPI_LOGICAL=-21)
 
-        integer MPI_2REAL
-        parameter (MPI_2REAL= -23)
+  INTEGER MPI_CHARACTER
+  PARAMETER (MPI_CHARACTER=-22)
 
-        integer MPI_2DOUBLE_PRECISION
-        parameter (MPI_2DOUBLE_PRECISION= -24)
+  integer MPI_2REAL
+  parameter (MPI_2REAL= -23)
 
-        integer MPI_2INTEGER
-        parameter (MPI_2INTEGER= -25)
+  integer MPI_2DOUBLE_PRECISION
+  parameter (MPI_2DOUBLE_PRECISION= -24)
 
+  integer MPI_2INTEGER
+  parameter (MPI_2INTEGER= -25)
 
-!
-! Size-specific types
-!
 
-        INTEGER MPI_INTEGER1
-        PARAMETER (MPI_INTEGER1= -32 )
+  !
+  ! Size-specific types
+  !
 
-        INTEGER MPI_INTEGER2
-        PARAMETER (MPI_INTEGER2= -33 )
+  INTEGER MPI_INTEGER1
+  PARAMETER (MPI_INTEGER1= -32 )
 
-        INTEGER MPI_INTEGER4
-        PARAMETER (MPI_INTEGER4= -34 )
+  INTEGER MPI_INTEGER2
+  PARAMETER (MPI_INTEGER2= -33 )
 
-        INTEGER MPI_INTEGER8
-        PARAMETER (MPI_INTEGER8= -35 )
+  INTEGER MPI_INTEGER4
+  PARAMETER (MPI_INTEGER4= -34 )
 
-        INTEGER MPI_INTEGER16
-        PARAMETER (MPI_INTEGER16= -36 )
+  INTEGER MPI_INTEGER8
+  PARAMETER (MPI_INTEGER8= -35 )
 
+  INTEGER MPI_INTEGER16
+  PARAMETER (MPI_INTEGER16= -36 )
 
-        INTEGER MPI_REAL4
-        PARAMETER (MPI_REAL4= -37 )
 
-        INTEGER MPI_REAL8
-        PARAMETER (MPI_REAL8= -38 )
+  INTEGER MPI_REAL4
+  PARAMETER (MPI_REAL4= -37 )
 
-        INTEGER MPI_REAL16
-        PARAMETER (MPI_REAL16= -39 )
+  INTEGER MPI_REAL8
+  PARAMETER (MPI_REAL8= -38 )
 
+  INTEGER MPI_REAL16
+  PARAMETER (MPI_REAL16= -39 )
 
-        integer MPI_COMPLEX8
-        parameter (MPI_COMPLEX8= -40 )
 
-        integer MPI_COMPLEX16
-        parameter (MPI_COMPLEX16= -41 )
+  integer MPI_COMPLEX8
+  parameter (MPI_COMPLEX8= -40 )
 
-        integer MPI_COMPLEX32
-        parameter (MPI_COMPLEX32= -42 )
+  integer MPI_COMPLEX16
+  parameter (MPI_COMPLEX16= -41 )
 
-        integer MPI_LONG_LONG_INT
-        parameter (MPI_LONG_LONG_INT= -43)
+  integer MPI_COMPLEX32
+  parameter (MPI_COMPLEX32= -42 )
 
-        integer MPI_LONG_LONG
-        parameter (MPI_LONG_LONG= MPI_LONG_LONG_INT)
+  integer MPI_LONG_LONG_INT
+  parameter (MPI_LONG_LONG_INT= -43)
 
-        integer MPI_UNSIGNED_LONG_LONG
-        parameter (MPI_UNSIGNED_LONG_LONG= -44)
+  integer MPI_LONG_LONG
+  parameter (MPI_LONG_LONG= MPI_LONG_LONG_INT)
 
-        integer MPI_OFFSET
-        parameter (MPI_OFFSET= -45)
+  integer MPI_UNSIGNED_LONG_LONG
+  parameter (MPI_UNSIGNED_LONG_LONG= -44)
 
-!
-! MPI_Op values
-!
-! (All are handled as no-op so no value is necessary; but provide one
-! anyway just in case.)
-!
+  integer MPI_OFFSET
+  parameter (MPI_OFFSET= -45)
 
-        INTEGER MPI_SUM
-        PARAMETER (MPI_SUM=0)
-        INTEGER MPI_MAX
-        PARAMETER (MPI_MAX=0)
-        INTEGER MPI_MIN
-        PARAMETER (MPI_MIN=0)
-        INTEGER MPI_PROD
-        PARAMETER (MPI_PROD=0)
-        INTEGER MPI_LAND
-        PARAMETER (MPI_LAND=0)
-        INTEGER MPI_BAND
-        PARAMETER (MPI_BAND=0)
-        INTEGER MPI_LOR
-        PARAMETER (MPI_LOR=0)
-        INTEGER MPI_BOR
-        PARAMETER (MPI_BOR=0)
-        INTEGER MPI_LXOR
-        PARAMETER (MPI_LXOR=0)
-        INTEGER MPI_BXOR
-        PARAMETER (MPI_BXOR=0)
-        INTEGER MPI_MINLOC
-        PARAMETER (MPI_MINLOC=0)
-        INTEGER MPI_MAXLOC
-        PARAMETER (MPI_MAXLOC=0)
-        INTEGER MPI_OP_NULL
-        PARAMETER (MPI_OP_NULL=0)
+  !
+  ! MPI_Op values
+  !
+  ! (All are handled as no-op so no value is necessary; but provide one
+     ! anyway just in case.)
+  !
 
-!
-! MPI_Wtime
-!
+  INTEGER MPI_SUM
+  PARAMETER (MPI_SUM=0)
+  INTEGER MPI_MAX
+  PARAMETER (MPI_MAX=0)
+  INTEGER MPI_MIN
+  PARAMETER (MPI_MIN=0)
+  INTEGER MPI_PROD
+  PARAMETER (MPI_PROD=0)
+  INTEGER MPI_LAND
+  PARAMETER (MPI_LAND=0)
+  INTEGER MPI_BAND
+  PARAMETER (MPI_BAND=0)
+  INTEGER MPI_LOR
+  PARAMETER (MPI_LOR=0)
+  INTEGER MPI_BOR
+  PARAMETER (MPI_BOR=0)
+  INTEGER MPI_LXOR
+  PARAMETER (MPI_LXOR=0)
+  INTEGER MPI_BXOR
+  PARAMETER (MPI_BXOR=0)
+  INTEGER MPI_MINLOC
+  PARAMETER (MPI_MINLOC=0)
+  INTEGER MPI_MAXLOC
+  PARAMETER (MPI_MAXLOC=0)
+  INTEGER MPI_OP_NULL
+  PARAMETER (MPI_OP_NULL=0)
 
-        DOUBLE PRECISION MPI_WTIME
-        EXTERNAL MPI_WTIME
+  !
+  ! MPI_Wtime
+  !
 
+  DOUBLE PRECISION MPI_WTIME
+  EXTERNAL MPI_WTIME
 
-!
-! Kinds
-!
 
-	INTEGER MPI_OFFSET_KIND
-	PARAMETER (MPI_OFFSET_KIND=selected_int_kind(13))
+  !
+  ! Kinds
+  !
 
-	INTEGER MPI_MODE_RDONLY
-	PARAMETER (MPI_MODE_RDONLY=0)
+  INTEGER MPI_OFFSET_KIND
+  PARAMETER (MPI_OFFSET_KIND=selected_int_kind(13))
 
-        INTEGER MPI_MODE_CREATE
-        PARAMETER (MPI_MODE_CREATE=1)
+  INTEGER MPI_MODE_RDONLY
+  PARAMETER (MPI_MODE_RDONLY=0)
 
-        INTEGER MPI_MODE_RDWR
-        PARAMETER (MPI_MODE_RDWR=2)
+  INTEGER MPI_MODE_CREATE
+  PARAMETER (MPI_MODE_CREATE=1)
 
+  INTEGER MPI_MODE_RDWR
+  PARAMETER (MPI_MODE_RDWR=2)
 
-!
-! Info
-!
 
-        INTEGER MPI_INFO_NULL
-        PARAMETER (MPI_INFO_NULL=0)
+  !
+  ! Info
+  !
 
+  INTEGER MPI_INFO_NULL
+  PARAMETER (MPI_INFO_NULL=0)
 
-!
-! Library version string (must match C value)
-!
 
-        INTEGER MPI_MAX_LIBRARY_VERSION_STRING
-        PARAMETER (MPI_MAX_LIBRARY_VERSION_STRING=80)
+  !
+  ! Library version string (must match C value)
+  !
 
-
+  INTEGER MPI_MAX_LIBRARY_VERSION_STRING
+  PARAMETER (MPI_MAX_LIBRARY_VERSION_STRING=80)

--- a/cime/src/externals/mct/mpi-serial/tests/ftest_old.F90
+++ b/cime/src/externals/mct/mpi-serial/tests/ftest_old.F90
@@ -99,7 +99,7 @@
 
 	call mpi_waitall(5,rreq,status,ier)
 	print *,'recvs on MPI_COMM_WORLD done'
-
+	
 	do i=1,5
           print *, 'Status source=',status(MPI_SOURCE,i), &
                    '  tag=',status(MPI_TAG,i)
@@ -137,13 +137,13 @@
                            MPI_COMM_WORLD)
           print *,temp
         end do
-
+        
         do i=1,5
           if (rbuf(i) .ne. sbuf(i)) then
             errcount = errcount + 1
             print *,"Error for pack/send/unpack"
             print *,"found ",rbuf(i)," should be ",sbuf(i)
-          end if
+          end if 
         end do
 !
 
@@ -160,6 +160,6 @@
         else
           print *,"No errors"
         end if
-
+          
  	end
 

--- a/cime/src/externals/mct/mpi-serial/type.c
+++ b/cime/src/externals/mct/mpi-serial/type.c
@@ -448,6 +448,23 @@ int MPI_Type_hvector(int count, int blocklen, MPI_Aint stride,
   return Type_hvector(count, blocklen, stride, old_ptr, new_ptr);
 }
 
+FC_FUNC( mpi_type_create_hvector, MPI_TYPE_CREATE_HVECTOR )
+         (int * count,   long * blocklen, long * stride,
+          int * oldtype, int * newtype,   int * ierr)
+{
+  *ierr = MPI_Type_create_hvector(*count, *blocklen, *stride, *oldtype, newtype);
+}
+
+int MPI_Type_create_hvector(int count, int blocklen, MPI_Aint stride,
+                     MPI_Datatype oldtype, MPI_Datatype * newtype)
+{
+  Datatype old_ptr = *(Datatype*) mpi_handle_to_datatype(oldtype);
+  Datatype * new_ptr;
+
+  mpi_alloc_handle(newtype, (void**) &new_ptr);
+  return Type_hvector(count, blocklen, stride, old_ptr, new_ptr);
+}
+
 
 int Type_hvector(int count, int blocklen, MPI_Aint stride,
                       Datatype oldtype, Datatype *newtype)

--- a/cime/src/externals/mct/testsystem/testall/ReadSparseMatrixAsc.F90
+++ b/cime/src/externals/mct/testsystem/testall/ReadSparseMatrixAsc.F90
@@ -25,6 +25,7 @@
       use m_List,         only : List_init => init
       use m_List,         only : List_clean => clean
 
+      use m_AttrVect,     only : Attrvect_zero => zero
       use m_SparseMatrix, only : SparseMatrix
       use m_SparseMatrix, only : SparseMatrix_Init => init
       use m_SparseMatrix, only : SparseMatrix_Clean => clean
@@ -155,6 +156,7 @@
   nRows = dst_dims(1) * dst_dims(2)
   nColumns = src_dims(1) * src_dims(2)
   call SparseMatrix_init(sMat, nRows, nColumns, num_elements)
+  call AttrVect_zero(sMat%data)
 
        ! ...and store them.
 

--- a/cime/src/externals/mct/testsystem/testall/cpl.F90
+++ b/cime/src/externals/mct/testsystem/testall/cpl.F90
@@ -875,7 +875,7 @@ if(myProc==0)write(stdout,*) cplname, ":: Done with init of output vector"
   call zeit_co('COcnRouterInit')
 
 ! rml print router info
-  call MCT_Router_print(Atm2Cpl,CPL_World,90)
+  if(myProc==0)call MCT_Router_print(Atm2Cpl,CPL_World,90)
   close(90)
 
   call Router_test(Atm2Cpl,"CPL::Atm2Cpl",7000+myProc)


### PR DESCRIPTION
Update MCT with performance improvements from Pat and Az.   These are needed for high-resolution simulations.

Threading and vectorization updates to AttrVect and MatAttrVectMul
Disable RSEND by default
Decrease serial complexity of initp_ algorithm to speed it up.
Speed up peLocs at the cost of some increased memory.
Import swapm implementation of MPI_AlltoallV from PIO and use in Rearranger
Reduce complexity of active_pes_
Also add some mpi-serial features

[BFB]