### PR TITLE
Update PIO_TYPENAME default for LANL IC machine wolf.

### DIFF
--- a/cime/config/acme/machines/config_pio.xml
+++ b/cime/config/acme/machines/config_pio.xml
@@ -59,6 +59,7 @@
       <value mach="lawrencium-lr3">netcdf</value>
       <value mach="cades">netcdf</value>
       <value mach="grizzly">netcdf</value>
+      <value mach="wolf">netcdf</value>
       <value mpilib="mpi-serial">netcdf</value>
     </values>
   </entry>


### PR DESCRIPTION
This PR updates the default PIO_TYPENAME setting for the LANL IC machine to netcdf.  Testing indicates that pnetcdf is much slower for the resolutions we typically run on this machine.

[BFB]
[NML]