### PR TITLE
Update CAM's nosmp configure option

### DIFF
--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -42,6 +42,7 @@ my $RUN_REFTOD	        = `./xmlquery  RUN_REFTOD		-value`;
 my $UTILROOT		= `./xmlquery  UTILROOT			-value`;
 my $DOCN_MODE		= `./xmlquery  DOCN_MODE		-value`;
 my $COMPILER		= `./xmlquery  COMPILER                 -value`; # for chem preprocessor 
+my $BUILD_THREADED      = `./xmlquery  BUILD_THREADED		-value`;
 
 my @dirs = ("$CIMEROOT/utils/perl5lib");
 unshift @INC, @dirs;
@@ -75,7 +76,7 @@ if ($BUILD_COMPLETE eq 'FALSE') {
     my $spmd = '-spmd';
     if ($MPILIB eq 'mpi-serial') {$spmd = "-nospmd";}
     my $smp = '-smp';
-    if ($NTHRDS_ATM == 1) {$smp = "-nosmp";}
+    if (($NTHRDS_ATM == 1) && ($BUILD_THREADED eq 'FALSE')) {$smp = "-nosmp";}
 
     # The ocean component setting is only used by CAM to do attribute matching for
     # setting default tuning parameter values.  In SOM mode we want to use the same


### PR DESCRIPTION
Turn smp off when both `NTHRDS_ATM==1` and `BUILD_THREADED==FALSE`. If
`BUILD_THREADED==TRUE`, then run CAM in single-threaded mode with
`HORIZ_OPENMP` CPP macro turned on.

Fixes https://github.com/ACME-Climate/ACME/issues/1382
[BFB]