### PR TITLE
Fixes land BGC computation for a threaded simulation

### DIFF
--- a/components/clm/src/biogeochem/CNAllocationMod.F90
+++ b/components/clm/src/biogeochem/CNAllocationMod.F90
@@ -3883,8 +3883,8 @@ contains
       
           else     ! use_nitrif_denitrif
 
-              temp_sminn_to_plant = sminn_to_plant
-              temp_sminp_to_plant = sminp_to_plant
+              temp_sminn_to_plant(bounds%begc:bounds%endc) = sminn_to_plant(bounds%begc:bounds%endc)
+              temp_sminp_to_plant(bounds%begc:bounds%endc) = sminp_to_plant(bounds%begc:bounds%endc)
 
               call p2c(bounds,num_soilc,filter_soilc, &
                   sminn_to_npool(bounds%begp:bounds%endp), &
@@ -3959,8 +3959,8 @@ contains
   
         if( .not.cnallocate_carbonphosphorus_only().and. .not.cnallocate_carbonnitrogen_only().and. .not.cnallocate_carbon_only() )then
 
-          temp_sminn_to_plant = sminn_to_plant
-          temp_sminp_to_plant = sminp_to_plant
+          temp_sminn_to_plant(bounds%begc:bounds%endc) = sminn_to_plant(bounds%begc:bounds%endc)
+          temp_sminp_to_plant(bounds%begc:bounds%endc) = sminp_to_plant(bounds%begc:bounds%endc)
 
           call p2c(bounds,num_soilc,filter_soilc, &
                 sminn_to_npool(bounds%begp:bounds%endp), &
@@ -3996,7 +3996,7 @@ contains
 
         if( cnallocate_carbonnitrogen_only() )then
 
-          temp_sminp_to_plant = sminp_to_plant
+          temp_sminp_to_plant(bounds%begc:bounds%endc) = sminp_to_plant(bounds%begc:bounds%endc)
 
           call p2c(bounds,num_soilc,filter_soilc, &
                 sminp_to_ppool(bounds%begp:bounds%endp), &


### PR DESCRIPTION
When nthreads > 1, the size of local variable (e.g. temp_sminp_to_plant)
is not equal to the global variable (e.g. phosphorusflux_vars%sminp_to_plant_col).

Fixes #1379
Fixes #1368 
[BFB]
