### PR TITLE
Make sure clean <COMPONENT> cleans up obj dir

### DIFF
--- a/cime/config/acme/machines/Makefile
+++ b/cime/config/acme/machines/Makefile
@@ -867,7 +867,7 @@ cleanrof:
 
 cleanlnd:
 	$(RM) -f $(LIBROOT)/liblnd.a
-	$(RM) -fr $(LNDOBJDIR)
+	$(RM) -fr $(EXEROOT)/lnd/obj
 
 cleancsmshare:
 	$(RM) -f $(CSMSHARELIB)


### PR DESCRIPTION
When user runs "./case.build --clean atm" some files
(Srcfiles, Depends etc) still remain in the atm build
directory.

This change was missed (changes in cesm Makefile was not ported to
the acme Makefile) in ESMCI/cime#1140

Fixes #1474
[BFB]