### PR TITLE
Update oEC60to30v3_ICG initial condition files for ocn/ice.

### DIFF
--- a/components/mpas-cice/cime_config/buildnml
+++ b/components/mpas-cice/cime_config/buildnml
@@ -62,8 +62,8 @@ if ( $ICE_GRID eq 'oEC60to30' ) {
 	$decomp_date .= '161222';
 	$decomp_prefix .= 'mpas-cice.graph.info.';
 } elsif ( $ICE_GRID eq 'oEC60to30v3_ICG' ) {
-	$grid_date .= '170301';
-	$grid_prefix .= 'seaice.EC60to30v3.restartFrom_anvil0221';
+	$grid_date .= '170331';
+	$grid_prefix .= 'seaice.EC60to30v3.restartFrom_anvil0320';
 	$decomp_date .= '161222';
 	$decomp_prefix .= 'mpas-cice.graph.info.';
 } elsif ( $ICE_GRID eq 'oEC60to30wLI' ) {

--- a/components/mpas-o/cime_config/buildnml
+++ b/components/mpas-o/cime_config/buildnml
@@ -64,8 +64,8 @@ if ( $OCN_GRID eq 'oEC60to30' ) {
 } elsif ( $OCN_GRID eq 'oEC60to30v3_ICG' ) {
         $grid_date .= '161222';
         $grid_prefix .= 'oEC60to30v3';
-        $ic_date .= '170301';
-        $ic_prefix .= 'oEC60to30v3.restartFrom_anvil0221';
+        $ic_date .= '170331';
+        $ic_prefix .= 'oEC60to30v3.restartFrom_anvil0320';
         $decomp_prefix .= 'mpas-o.graph.info.';
 } elsif ( $OCN_GRID eq 'oEC60to30wLI' ) {
         $grid_date .= '160830';


### PR DESCRIPTION
This PR updates the oEC60to30v3_ICG initial condition files pointed to by the buildnml scripts for mpas-o and mpas-seaice.  The ocean changed a couple of variables in restart files and this update is necessary for consistency.  It implements the most recent set of files provided to the coupled model group for its low-res runs.  This PR will change answers for ne30np4-oEC60to30v3_ICG runs, though we current do not test that configuration.

Tested with A_WCYCL1850S.ne30np4_oEC60to30v3_ICG on edison

[NML]
[non-BFB] 