### PR TITLE
Update edison pe-layouts for A_WCYCL compsets

### DIFF
--- a/cime/config/acme/allactive/config_pesall.xml
+++ b/cime/config/acme/allactive/config_pesall.xml
@@ -5469,13 +5469,13 @@
   <grid name="a%ne30np4">
     <mach name="edison">
       <pes compset="CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
-        <comment>"143 node version gets 6 SYPD. This will be the default and M size"</comment>
+        <comment>"133 node version gets 6 SYPD. This will be the default and M size"</comment>
         <ntasks>
           <ntasks_atm>2700</ntasks_atm>
           <ntasks_lnd>312</ntasks_lnd>
           <ntasks_rof>312</ntasks_rof>
           <ntasks_ice>2400</ntasks_ice>
-          <ntasks_ocn>720</ntasks_ocn>
+          <ntasks_ocn>480</ntasks_ocn>
           <ntasks_glc>312</ntasks_glc>
           <ntasks_wav>2400</ntasks_wav>
           <ntasks_cpl>2400</ntasks_cpl>


### PR DESCRIPTION
This PR updates the edison M and L pe-layouts for A_WCYCL compsets and ne30_oEC60to30 grids, to match the improved layouts described in [Issue #1387](https://github.com/ACME-Climate/ACME/issues/1387).  It also adds a S pe-layout for the same configuration that gets just over 2 sypd on 39 nodes.

Tested with:
* -compset A_WCYCL1850S -mach edison -res ne30np4_oEC60to30v3_ICG -pecount S
* -compset A_WCYCL1850S -mach edison -res ne30np4_oEC60to30v3_ICG -pecount M
* -compset A_WCYCL1850S -mach edison -res ne30np4_oEC60to30v3_ICG -pecount L

[BFB]