### PR TITLE
Set the default value of DOUT_S_SAVE_INTERIM_RESTART_FILES to TRUE

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component.xml
+++ b/cime/src/drivers/mct/cime_config/config_component.xml
@@ -490,12 +490,12 @@
   <entry id="DOUT_S_SAVE_INTERIM_RESTART_FILES">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
+    <default_value>TRUE</default_value>
     <group>run_data_archive</group>
     <file>env_run.xml</file>
     <desc>Logical to archive all interim restart files, not just those at eor
     If TRUE, perform short term archiving on all interim restart files,
-    not just those at the end of the run. By default, this value is FALSE.
+    not just those at the end of the run. By default, this value is TRUE.
     The restart files are saved under the specific component directory
     ($DOUT_S_ROOT/$CASE/$COMPONENT/rest rather than the top-level $DOUT_S_ROOT/$CASE/rest directory).
     Interim restart files are created using the REST_N and REST_OPTION variables.


### PR DESCRIPTION
Ensure that all restart files are archived by default

passes the acme_developer test suite
[BFB]

Fixes #1489 