### PR TITLE
Changing jobmin to 1 for batch q on blues

### DIFF
--- a/cime/config/acme/machines/config_batch.xml
+++ b/cime/config/acme/machines/config_batch.xml
@@ -159,7 +159,7 @@
       </directives>
       <queues>
 	<queue walltimemax="01:00:00" jobmin="1" jobmax="64">shared</queue>
-	<queue walltimemax="03:00:00" jobmin="64" jobmax="4096" default="true">batch</queue>
+	<queue walltimemax="03:00:00" jobmin="1" jobmax="4096" default="true">batch</queue>
       </queues>
     </batch_system>
 


### PR DESCRIPTION
Setting jobmin to 1 for blues+batch queue so that longer jobs
that don't fit in the shared/debug queue fit the batch queue.

Fixes #1484
[BFB]