### PR TITLE
Fix a floating invalid that we found with certain PE layouts and Intel v17.02

### DIFF
--- a/components/cam/src/physics/cam/micro_mg_cam.F90
+++ b/components/cam/src/physics/cam/micro_mg_cam.F90
@@ -2405,7 +2405,7 @@ subroutine micro_mg_cam_tend(state, ptend, dtime, pbuf)
       ! Cloud fraction for purposes of precipitation is maximum cloud
       ! fraction out of all the layers that the precipitation may be
       ! falling down from.
-      cldmax = max(mincld, ast)
+      cldmax(:ncol,top_lev:pver) = max(mincld, ast(:ncol,top_lev:pver))
       do k = top_lev+1, pver
          where (state_loc%q(:ncol,k-1,ixrain) >= qsmall .or. &
               state_loc%q(:ncol,k-1,ixsnow) >= qsmall)


### PR DESCRIPTION
Restrict computations to only be over sections of arrays desired to avoid floating invalid.

cldmax(:ncol,top_lev:pver) = max(mincld, ast(:ncol,top_lev:pver))

Fixes #1478