### PR TITLE
Add dyn_npes to atm_in namelist

### DIFF
--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -3977,6 +3977,14 @@ if ($cfg->get('dyn') =~ /se/) {
     my $hgrid = $cfg->get('hgrid');
     if ($hgrid =~ /ne(.*)np/) {
 	add_default($nl, 'se_ne', 'val'=>$1);
+        if ($1 > 0) { # not ne0 grid
+          my $dyn_npes = $nl->get_value('dyn_npes');
+          if (defined $dyn_npes) {
+            add_default($nl, 'dyn_npes', 'val'=>$dyn_npes);
+          } else { # request max
+            add_default($nl, 'dyn_npes', 'val'=>$1*$1*6);
+          }
+        }
     }
     else {
 	die "$ProgName - ERROR: Horizontal grid name can NOT be correctly parsed: hgrid = $hgrid. \n";

--- a/components/cam/src/dynamics/se/spmd_dyn.F90
+++ b/components/cam/src/dynamics/se/spmd_dyn.F90
@@ -78,7 +78,8 @@ CONTAINS
                   ' error condition for spmd_dyn_inparm' )
           end if
        end if
-       if (dyn_npes .lt. 1 .or. dyn_npes .gt. npes) then
+       if (dyn_npes .gt. npes) dyn_npes = npes
+       if (dyn_npes .lt. 1) then
           call endrun( subname//':: namelist read returns a'// &
                ' bad value for dyn_npes' )
        endif


### PR DESCRIPTION
Set the number of tasks used by dynamics to `max(nelem,npes_atm)`.
If dyn_npes is set in user_nl_cam, set dyn_npes to `max(dyn_npes,npes_atm)`.

Fixes #1192 
[NML] - adds, to `atm_in` namelist file, the `spmd_dyn_inparm` namelist group with `dyn_npes` variable in it