### PR TITLE
Fix tmp_array size to avoid array mismatch found by GNU

### DIFF
--- a/components/cam/src/physics/cam/clubb_intr.F90
+++ b/components/cam/src/physics/cam/clubb_intr.F90
@@ -1147,7 +1147,7 @@ end subroutine clubb_init_cnst
    real(r8) :: es(pcols,pver)
    real(r8) :: qs(pcols,pver)
    real(r8) :: gam(pcols,pver)
-   real(r8) :: tmp_array(pcols,pverp)
+   real(r8) :: tmp_array(state%ncol,pverp)
    real(r8) :: bfact, orgparam, delpavg
    character(len=6) :: choice_radf
    

--- a/components/cam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/cam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -729,7 +729,7 @@ subroutine hetfrz_classnuc_cam_calc( &
    real(r8) :: numice10s(pcols,pver)
    real(r8) :: numice10s_imm_dst(pcols,pver)
    real(r8) :: numice10s_imm_bc(pcols,pver)
-   real(r8) :: tmp_array(pcols,pver)
+   real(r8) :: tmp_array(state%ncol,pver)
 
    real(r8) :: na500(pcols,pver)
    real(r8) :: tot_na500(pcols,pver)


### PR DESCRIPTION
In the fix for another issue, the tmp_array was allocated to be to large and the GNU compiler stopped with an array mismatch.  Reduce the size of the allocated tmp_array by changing the size to be state%ncol, not pcol

This is a redo of PR #1501 
Fixes #1263 