### PR TITLE
Fix jenkins_generic_job when user selects specific machines.

### DIFF
--- a/cime/scripts/lib/jenkins_generic_job.py
+++ b/cime/scripts/lib/jenkins_generic_job.py
@@ -143,6 +143,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
     else:
         cdash_build_name = None
 
+    os.environ["CIME_MACHINE"] = machine.get_machine_name()
     tests_passed = CIME.wait_for_tests.wait_for_tests(glob.glob("%s/*%s/TestStatus" % (test_root, test_id)),
                                                  no_wait=not use_batch, # wait if using queue
                                                  check_throughput=False, # don't check throughput


### PR DESCRIPTION
Need to make sure wait_for_tests is aware of the custom machine so
that batch submission goes to correct machine.

This should fix cori-knl reporting.

[BFB]