### PR TITLE
Updating modules and compiler flags for cori-haswell.

### DIFF
--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -562,8 +562,6 @@ for mct, etc.
 </compiler>
 
 <compiler COMPILER="intel" MACH="cori-haswell">
-  <ADD_FFLAGS> -xCORE-AVX2 </ADD_FFLAGS>
-  <ADD_CFLAGS> -xCORE-AVX2 </ADD_CFLAGS>
   <ADD_FFLAGS DEBUG="FALSE"> -O2 -qno-opt-dynamic-align </ADD_FFLAGS>
   <ADD_CFLAGS DEBUG="FALSE"> -O2  </ADD_CFLAGS>
   <ADD_CFLAGS compile_threaded="true"> -qopenmp </ADD_CFLAGS>
@@ -572,8 +570,7 @@ for mct, etc.
   <ADD_LDFLAGS compile_threaded="true"> -qopenmp </ADD_LDFLAGS>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <ADD_SLIBS> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </ADD_SLIBS>
-  <ADD_SLIBS> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </ADD_SLIBS>
-  <!--ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS-->
+  <ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS>
   <ADD_GPTL_CPPDEFS> -DHAVE_PAPI </ADD_GPTL_CPPDEFS>
   <ADD_CPPDEFS> -DHAVE_SLASHPROC </ADD_CPPDEFS>
   <MPIFC> ftn </MPIFC>

--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -211,7 +211,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-        <!--NOTE: hard-coding -c 2 for now, which is only correct when using full node with no hyper-threading.  need updates from cime5.2 to fix.  (ndk) -->
+        <!--NOTE: hard-coding -c 2 for now, which is only optimal when using full node with no hyper-threading. (ndk) -->
 	<arg name="thread_count" > -c 2 </arg>
 	<!--arg name="binding" > dash-dash-cpu_bind=cores</arg-->
       </arguments>
@@ -256,24 +256,23 @@
 	<command name="load">craype/2.5.7</command>
 	<command name="load">craype-haswell</command>
 
-	<command name="load">cray-mpich/7.4.4</command>
+	<!--command name="load">cray-mpich/7.4.4</command-->
+	<command name="load">cray-mpich/7.5.3</command>
       </modules>
 
       <modules compiler="intel">
 	<command name="load">PrgEnv-intel</command>
 	<command name="rm">intel</command>
-	<!--command name="load">intel/16.0.3.210</command-->
-	<!--command name="load">intel/17.0.0.098</command-->
-	<command name="load">intel/17.0.1.132</command>
+	<command name="load">intel/17.0.2.174</command>
       </modules>
 
       <modules compiler="cray">
 	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.5.0</command>
+	<command name="switch">cce cce/8.5.4</command>
       </modules>
       <modules compiler="gnu">
 	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/6.2.0</command>
+	<command name="switch">gcc gcc/6.3.0</command>
       </modules>
 
       <modules compiler="!intel">
@@ -292,12 +291,11 @@
       </modules>
 
       <modules>
-        <command name="load">git</command>
+        <command name="load">git/2.9.1</command>
 	<command name="load">cmake/3.3.2</command>
-	<command name="load">pmi/5.0.10-1.0000.11050.0.0.ari</command>
+	<command name="load">pmi/5.0.10-1.0000.11069.183.8.ari</command>
 	<command name="load">papi/5.4.3.2</command>
-	<command name="load">zlib</command>
-	<!--command name="load">cray-petsc/3.7.0.0</command-->
+	<command name="load">zlib/1.2.8</command>
       </modules>
     </module_system>
 
@@ -310,7 +308,7 @@
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
-
+      <env name="FORT_BUFFERED" compiler="intel">yes</env>
     </environment_variables>
 </machine>
 
@@ -345,7 +343,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-        <!--NOTE: hard-coding -c 4 for now, which is only correct when using full node with no hyper-threading.  need updates from cime5.2 to fix.  (ndk) -->
+        <!--NOTE: hard-coding -c 4 for now, which is only optimal when using full node with no hyper-threading.  (ndk) -->
 	<arg name="thread_count" > -c 4 </arg>
 	<arg name="binding" > --cpu_bind=cores</arg>
       </arguments>
@@ -436,7 +434,6 @@
     </module_system>
 
     <environment_variables>
-
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
       <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
@@ -445,9 +442,8 @@
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
 
-      <env name="FORT_BUFFERED">yes</env>
-
-    </environment_variables>
+      <env name="FORT_BUFFERED" compiler="intel">yes</env>
+      </environment_variables>
 </machine>
 
 


### PR DESCRIPTION
More consistent with cori-knl.
Moves to intel 17.02, mpich 7.5.3, gcc 6.3.0.  Uses simplified mkl linking.  Removes unneeded compiler flag when using craype-haswell module.  Set FORT_BUFFERED for Intel.