### PR TITLE
Create A_WCYCL1850S_v0atm and A_WCYCL2000S_v0atm compsets

### DIFF
--- a/cime/config/acme/allactive/config_compsets.xml
+++ b/cime/config/acme/allactive/config_compsets.xml
@@ -120,6 +120,17 @@
  <lname>2000_CAM5_CLM45%SP_MPASCICE_MPASO_MOSART_SGLC_SWAVi</lname>
 </compset>
 
+<compset>
+ <alias>A_WCYCL1850S_v0atm</alias> 
+ <lname>1850_CAM5_CLM45%SP_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
+ <alias>A_WCYCL2000S_v0atm</alias>
+ <lname>2000_CAM5_CLM45%SP_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAVi</lname>
+</compset>
+
+
 <!-- ACME BG compsets -->
 
 <compset>


### PR DESCRIPTION
There are already compsets for running beta1 MPAS components with the v0 atmos on master, but not for initializing with spunup ocean and sea ice. This PR just adds a few lines of code to config_compsets.xml to enable this.