### PR TITLE
Set jobmax to follow the Titan debug queue policy

### DIFF
--- a/cime/config/acme/machines/config_batch.xml
+++ b/cime/config/acme/machines/config_batch.xml
@@ -361,7 +361,7 @@
      </directives>
      <queues>
        <queue walltimemax="02:00:00" default="true">batch</queue>
-       <queue walltimemax="01:00:00" jobmin="0" jobmax="64">debug</queue>
+       <queue walltimemax="01:00:00" jobmin="0" jobmax="1">debug</queue>
      </queues>
    </batch_system>
 


### PR DESCRIPTION
Change the maximum number of jobs (jobmax) that can be submitted
to the Titan debug queue to 1 to observe the Titan policy.

[BFB]