### PR TITLE
Fix adding the qos queue option to the edison queue settings

### DIFF
--- a/run_acme.template.csh
+++ b/run_acme.template.csh
@@ -1054,12 +1054,12 @@ endif
 set machine = `lowercase $machine`
 
 ### Only specially authorized people can use the special_acme qos on Cori or Edison. Don't uncomment unless you're one.
-if ( `lowercase $debug_queue` == false && ( $machine == core || $machine == edison ) ) then
-  set update_run = ${case_run_exe}.updated
-  awk '/--account/{print; print "#SBATCH --qos=special_acme";next}1' ${case_run_exe} > ${update_run}
-  mv ${update_run} ${case_run_exe}
-  unset update_run
-endif
+#if ( `lowercase $debug_queue` == false && $machine == edison ) then
+#  set update_run = ${case_run_exe}.updated
+#  awk '/--account/{print; print "#SBATCH --qos=special_acme";next}1' ${case_run_exe} > ${update_run}
+#  mv ${update_run} ${case_run_exe}
+#  unset update_run
+#endif
 
 #============================================
 # SETUP SHORT AND LONG TERM ARCHIVING


### PR DESCRIPTION
Moves the point where qos queue options are supposed to be added to after the addition of the accounts line