### PR TITLE
Fix default coupling intervals for C- and G-compsets

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component_acme.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_acme.xml
@@ -222,7 +222,7 @@
       <value compset="_DLND.*_CISM\d">year</value>
       <value compset="_DLND.*_MPASLI">year</value>
       <value compset="_SLND.*SOCN.*_MPASLI">day</value>
-      <value compset="_MPASO"       >hour</value>
+      <value compset="_MPASO"       >day</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MPASLI">day</value>
       <value compset="_CAM.*_CLM.*MPASO">day</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">day</value>
@@ -256,6 +256,16 @@
       <value compset="_DLND.*_MPASLI">1</value>
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MPASLI">24</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oQU240">12</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oQU240wLI">12</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oQU120">24</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oEC60to30">48</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oEC60to30v3">48</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oEC60to30wLI">48</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oRRS30to10v3">96</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oRRS30to10wLI">96</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oRRS18to6v3">96</value>
+      <value compset="_DATM.*_SLND.*MPASO" grid="oi%oRRS15to5">96</value>
       <value compset="_CAM.*_CLM.*MPASO">48</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</value>
@@ -315,10 +325,7 @@
       <value compset="_DLND.*_MPASLI">1</value>
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MPASLI">24</value>
-      <value compset="_CAM.*_CLM.*MPASO">48</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne4np4">$ATM_NCPL</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</value>
+      <value compset="_CAM.*_CLM.*MPASO">$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -344,11 +351,17 @@
       <value compset="_DLND.*_MPASLI">1</value>
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MPASLI">24</value>
-      <value compset="_CAM.*_CLM.*MPASO">48</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne4np4">$ATM_NCPL</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="oi%oRRS18to6">48</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="oi%oRRS15to5">96</value>
+      <value compset="_MPASO" grid="oi%oQU240">12</value>
+      <value compset="_MPASO" grid="oi%oQU240wLI">12</value>
+      <value compset="_MPASO" grid="oi%oQU120">24</value>
+      <value compset="_MPASO" grid="oi%oEC60to30">48</value>
+      <value compset="_MPASO" grid="oi%oEC60to30v3">48</value>
+      <value compset="_MPASO" grid="oi%oEC60to30wLI">48</value>
+      <value compset="_MPASO" grid="oi%oRRS30to10v3">48</value>
+      <value compset="_MPASO" grid="oi%oRRS30to10wLI">48</value>
+      <value compset="_MPASO" grid="oi%oRRS18to6v3">48</value>
+      <value compset="_MPASO" grid="oi%oRRS15to5">96</value>
+
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
This PR fixes the default coupling intervals for C- and G-compsets for all supported ice/ocn grids, based on ice/ocn timestep values.

Setup tested for consistency with:
      -compset GMPAS-IAF -res T62_oQU240
      -compset GMPAS-IAF -res T62_oQU120
      -compset GMPAS-IAF -res T62_oEC60to30v3
      -compset GMPAS-IAF -res T62_oRRS30to10v3
      -compset GMPAS-IAF -res T62_oRRS18to6v3

[NML]
[BFB]