### PR TITLE
Add PEM_Ld3.ne30_oECv3_ICG.A_WCYCL1850S test to acme_int

### DIFF
--- a/cime/scripts/lib/update_acme_tests.py
+++ b/cime/scripts/lib/update_acme_tests.py
@@ -140,7 +140,7 @@ _TEST_SUITES = {
                            "PET.f19_g16.X",
                            "PET.f45_g37_rx1.A",
                            "PET_Ln9.ne30_oECv3_ICG.A_WCYCL1850S",
-                           "PEM_Ld3.ne30_oECv3_ICG.A_WCYCL1850S",
+                           "PEM_Ln9.ne30_oECv3_ICG.A_WCYCL1850S",
                            "ERP_Ld3.ne30_oECv3_ICG.A_WCYCL1850S",
                            "SEQ_IOP.f19_g16.X",
                            "SMS.ne30_oECv3_ICG.A_WCYCL1850S",


### PR DESCRIPTION
Add PEM_Ld3.ne30_oECv3_ICG.A_WCYCL1850S test to acme_integration.

This test would have caught the ocean decomposition bug where, for
only the oEC60to30 grid, some partitions did not have a 3-cell-wide
halo resulting in BFB differences when you changed mpi-tasks.
It requires 2 initial runs with different ranks to see it which
is why ERP didn't catch it.

[BFB]