### PR TITLE
Fix greater-then-roundoff diffs in cos zen calc

### DIFF
--- a/cime/src/share/util/shr_orb_mod.F90
+++ b/cime/src/share/util/shr_orb_mod.F90
@@ -78,10 +78,8 @@ real(SHR_KIND_R8) pure FUNCTION shr_orb_cosz(jday,lat,lon,declin,dt_avg)
       shr_orb_cosz =  shr_orb_avg_cosz(jday, lat, lon, declin, dt_avg)
    else
       shr_orb_cosz = sin(lat)*sin(declin) - &
-      &              cos(lat)*cos(declin)*cos(jday*2.0_SHR_KIND_R8*pi + lon)
-! RLJ old version above.  Restore more accurate version below in separate PR
-!           cos(lat)*cos(declin) * &
-!           cos((jday-floor(jday))*2.0_SHR_KIND_R8*pi + lon)
+            cos(lat)*cos(declin) * &
+            cos((jday-floor(jday))*2.0_SHR_KIND_R8*pi + lon)
    end if
 
 END FUNCTION shr_orb_cosz


### PR DESCRIPTION
For jday larger than one, the argument (jday x 2 x pi + lon) for cos() in the shr_orb_cosz 
calculation will be reduced by the cos function, and as a result, some accuracy will be
lost.  The reduction is different for different machines and results in
greater-then-roundoff differences between machines for the same case.
Solution is to change argument to ((jday-floor(jday)) x 2 x pi + lon)

Fixes #1163 

[non-BFB]