### PR TITLE
Add jobmax and jobmin to the Titan's batch queue

### DIFF
--- a/cime/config/acme/machines/config_batch.xml
+++ b/cime/config/acme/machines/config_batch.xml
@@ -393,7 +393,7 @@
      </directives>
      <queues>
        <queue walltimemax="02:00:00" jobmin="0" jobmax="299008" default="true">batch</queue>
-       <queue walltimemax="01:00:00" jobmin="0" jobmax="64" strict="true">debug</queue>
+       <queue walltimemax="01:00:00" jobmin="0" jobmax="299008" strict="true">debug</queue>
      </queues>
    </batch_system>
 


### PR DESCRIPTION
Add the jobmin=0 and jobmax=299008 to the Titan's default batch queue in
config_batch.xml. The number of 299008 is total physical cores in Titan.

This addition will let all jobs run in the default batch queue and avoid
the failure caused by putting more than one job into the debug queue
simultaneously as only 1 debug job is allowed in Titan.

This fix is a better solution than that in the reverted PR #1534

[BFB]