### PR TITLE
Fix the MPICXX path in Titan

### DIFF
--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -936,7 +936,7 @@ for mct, etc.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
   <MPIFC> ftn </MPIFC>
   <MPICC> cc </MPICC>
-  <MPICXX> /opt/cray/craype/2.4.0/bin/CC </MPICXX>
+  <MPICXX> CC </MPICXX>
   <ALBANY_PATH>/ccs/proj/cli106/AlbanyTrilinos/Albany/build/install</ALBANY_PATH>
 </compiler>
 


### PR DESCRIPTION
The old MPICXX path pointed to a very old craype version that does not
exist in Titan any more. The new MPICXX path follows the directory of
craype that is set in env_mach_specific.xml.

Since only MPAS-LI uses MPICXX, any compsets containing MPAS-LI will
fail in compiling in Titan. This fixing will solve the failures (Issue #1522).