### PR TITLE
Make SVN check less strict.

### DIFF
--- a/cime/scripts/lib/CIME/check_input_data.py
+++ b/cime/scripts/lib/CIME/check_input_data.py
@@ -34,6 +34,15 @@ def download_if_in_repo(svn_loc, input_data_root, rel_path):
     rel_path = rel_path.strip('/')
     full_url = os.path.join(svn_loc, rel_path)
 
+    err = run_cmd("svn --non-interactive --trust-server-cert ls {}".format(svn_loc))[0]
+    if err != 0:
+        logging.warning(
+"""
+Could not connect to svn repo '{0}'
+This is most likely either a credential, proxy, or network issue .
+To check connection and store your credential run 'svn ls {0}' and permanently store your password""".format(svn_loc))
+        return False
+
     full_path = os.path.join(input_data_root, rel_path)
     logging.info("Trying to download file: '%s' to path '%s'" % (full_url, full_path))
     # Make sure local path exists, create if it does not
@@ -125,12 +134,6 @@ def check_input_data(case, svn_loc=None, input_data_root=None, data_list_dir="Bu
     """
     # Fill in defaults as needed
     svn_loc = SVN_LOCS[get_model()] if svn_loc is None else svn_loc
-    err = run_cmd("svn --non-interactive --trust-server-cert ls %s" % svn_loc)[0]
-    expect(err == 0,
-"""
-Could not connect to svn repo '%s'
-This is most likely either a credential, proxy, or network issue .
-To check connection and store your credential run 'svn ls %s' and permanently store your password""" % (svn_loc, svn_loc))
 
     input_data_root = case.get_value("DIN_LOC_ROOT") if input_data_root is None else input_data_root
 


### PR DESCRIPTION
check_input_data should not care if it cannot connect to SVN
if it already has the files it needs. Downgrade SVN connection
problem from error to warning.

[BFB]