### PR TITLE
Add SCM test to acme developer test suite based on ARM97 case

### DIFF
--- a/cime/scripts/lib/CIME/test_scheduler.py
+++ b/cime/scripts/lib/CIME/test_scheduler.py
@@ -506,7 +506,24 @@ class TestScheduler(object):
                     envtest.set_test_parameter("STOP_N", opti)
                     logger.debug (" STOP_OPTION set to %s" %stop_option[opt])
                     logger.debug (" STOP_N      set to %s" %opti)
-
+		    
+		elif opt.startswith('R'):
+                    # R option is for testing in PTS_MODE or Single Column Model 
+                    #  (SCM) mode
+                    envtest.set_test_parameter("PTS_MODE", "TRUE")
+		    
+                    # For PTS_MODE, compile with mpi-serial
+                    envtest.set_test_parameter("MPILIB", "mpi-serial")
+                    comps=["ATM","LND","ICE","OCN","CPL","GLC","ROF","WAV"]
+                    for comp in comps:
+                        envtest.set_test_parameter("NTASKS_"+comp,"1") 
+		    
+                    # Set latitude and longitude for the appropriate case
+                    # Below for ARM97, default SCM test case
+                    if 'A97' in test:
+                        envtest.set_test_parameter("PTS_LAT", "36.6")
+                        envtest.set_test_parameter("PTS_LON", "262.5")
+		    
                 elif opt.startswith('M'):
                     # M option handled by create newcase
                     continue

--- a/cime/scripts/lib/update_acme_tests.py
+++ b/cime/scripts/lib/update_acme_tests.py
@@ -124,7 +124,8 @@ _TEST_SUITES = {
                          "SMS_D_Ln5.ne16_ne16.F20TRC5AV1C-03",
                          "SMS_D_Ln5.ne16_ne16.FC5AV1C-04P",
                          "SMS_D_Ln5.ne4_ne4.FC5AV1C-04P2",
-                         "SMS_D_Ld1.ne16_ne16.FC5ATMMOD")
+                         "SMS_D_Ld1.ne16_ne16.FC5ATMMOD",
+                         "SMS_R_Ld5.T42_T42.FSCM5A97")
                         ),
 
     "acme_integration" : ("acme_developer", "03:00:00",


### PR DESCRIPTION
Adds a test for the ACME single column model (SCM) to the acme developer test suite.  The test is based on the ARM97 case (run for five days in length), thus changes to this compset have been added for successful test completion.  