### PR TITLE
Change the -c flag for edison to 2.

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -85,7 +85,7 @@
     <arguments>
       <arg name="label"> --label</arg>
       <arg name="num_tasks" > -n $TOTALPES</arg>
-      <arg name="thread_count" > -c $ENV{OMP_NUM_THREADS}</arg>
+      <arg name="thread_count" > -c 2</arg>
     </arguments>
   </mpirun>
   <module_system type="module">


### PR DESCRIPTION
For edison only.
Instead of `srun -n mpi_tasks -c {num_threads} ...` use `srun -n mpi_tasks -c 2 ...`
This essentially says, "do not use hyper-threading"
Previously we set this to the number of threads, which would not be correct (however,
runs with no threading should still have spread the MPI's evenly over the node).
The new way to think of the -c flag to srun is the number of hardware threads to reserve for each MPI and is important for ensuring that the MPI's and threads get evenly spread out.
Since edison has 48 hardware threads per node, a value of 2 requests that each MPI reserve 2.
This should not change results or performance for no threading.  It may also not change performance when using threading.

I ran acme_developer with intel and intel17.  I got the same failures as before (and as CDASH currently reports)