### PR TITLE
Fixes ALM for mpi-serial

### DIFF
--- a/components/clm/src/main/decompInitMod.F90
+++ b/components/clm/src/main/decompInitMod.F90
@@ -1210,7 +1210,8 @@ contains
 
     ! Determine the cell id offset on each processor
     cell_id_offset = 0
-    call MPI_Exscan(ncells_loc, cell_id_offset, 1, MPIU_INTEGER, MPI_SUM, mpicom, ierr)
+    call MPI_Scan(ncells_loc, cell_id_offset, 1, MPIU_INTEGER, MPI_SUM, mpicom, ierr)
+    cell_id_offset = cell_id_offset - ncells_loc
 
     ! Determine the total number of grid cells
     call MPI_Allreduce(ncells_loc, ncells_tot, 1, MPIU_INTEGER, MPI_SUM, mpicom, ierr)
@@ -1375,8 +1376,8 @@ contains
     procinfo%ncells = ncells_owned
 
     offset = 0
-    call MPI_Exscan(ncells_owned, offset, 1, MPIU_INTEGER, MPI_SUM, mpicom, ierr)
-    procinfo%begg = offset + 1
+    call MPI_Scan(ncells_owned, offset, 1, MPIU_INTEGER, MPI_SUM, mpicom, ierr)
+    procinfo%begg = offset + 1 - ncells_owned
 
     offset = 0
     call MPI_scan(ncells_owned, offset, 1, MPIU_INTEGER, MPI_SUM, mpicom, ierr)

--- a/components/clm/src/main/surfrdMod.F90
+++ b/components/clm/src/main/surfrdMod.F90
@@ -955,15 +955,15 @@ contains
     ! be saved
     ibeg_c = 0
     iend_c = 0
-    call MPI_Exscan(nCells_loc, ibeg_c, 1, MPI_INTEGER, MPI_SUM, mpicom, ier)
+    call MPI_Scan(nCells_loc, ibeg_c, 1, MPI_INTEGER, MPI_SUM, mpicom, ier)
     call MPI_Scan(  nCells_loc, iend_c, 1, MPI_INTEGER, MPI_SUM, mpicom, ier)
-    ibeg_c = ibeg_c + 1
+    ibeg_c = ibeg_c + 1 - nCells_loc
 
     ibeg_e = 0
     iend_e = 0
-    call MPI_Exscan(nEdges_loc, ibeg_e, 1, MPI_INTEGER, MPI_SUM, mpicom, ier)
+    call MPI_Scan(nEdges_loc, ibeg_e, 1, MPI_INTEGER, MPI_SUM, mpicom, ier)
     call MPI_Scan(  nEdges_loc, iend_e, 1, MPI_INTEGER, MPI_SUM, mpicom, ier)
-    ibeg_e = ibeg_e + 1
+    ibeg_e = ibeg_e + 1 - nEdges_loc
 
     ! Allocate memory
     allocate(cellsOnCell   (maxEdges, nCells_loc))


### PR DESCRIPTION
Since there is no stub for MPI_Exscan in mpi-serial, the MPI_Exscan
calls are converted to MPI_Scan

Fixes #1590
[BFB]