### PR TITLE
Correct MG2 rain number conservation limiter

### DIFF
--- a/components/cam/src/physics/cam/micro_mg2_0.F90
+++ b/components/cam/src/physics/cam/micro_mg2_0.F90
@@ -1686,7 +1686,7 @@ subroutine micro_mg_tend ( &
              nprc(i,k)*lcldm(i,k))*deltat
 
         if (dum.gt.nr(i,k)) then
-           ratio = (nr(i,k)/deltat+nprc(i,k)*lcldm(i,k)/precip_frac(i,k))/ &
+           ratio = (nr(i,k)/deltat+nprc(i,k)*lcldm(i,k))/precip_frac(i,k)/ &
                 (-nsubr(i,k)+npracs(i,k)+nnuccr(i,k)+nnuccri(i,k)-nragg(i,k))*omsm
 
            nragg(i,k)=nragg(i,k)*ratio


### PR DESCRIPTION
Fixes an incorrectly positioned parenthesis that caused the rain number
conservation code to reduce process rates by too much.

The rain number conservation code contained the following lines:

    ratio = (nr(i,k)/deltat+nprc(i,k)*lcldm(i,k)/precip_frac(i,k))/ &
      (-nsubr(i,k)+npracs(i,k)+nnuccr(i,k)+nnuccri(i,k)-nragg(i,k))*omsm

The values in the denominator (second line) represent concentrations in
the fraction of the grid cell where precipitation is present, while the
values `nr(i,k)` and `nprc(i,k)*lcldm(i,k)` in the numerator represent
mean concentrations over the entire grid cell.

In order to compare the two, the *entire* numerator should be divided by
the precipitation fraction, not just the `nprc` term. Thus this commit
moves the factor of `precip_frac(i,k)` outside of that set of
parentheses.

The precise impact of this change is not quite clear yet, but it is
potentially climate-changing, since fixing this bug will most likely
cause average drop size to increase, and therefore increase the rate of
precipitation. This has been demonstrated using an offline driver for
MG2, using a test case for which this bug is known to have a
particularly strong effect.

[CC]