### PR TITLE
Update the ocn/ice IC files for oRRS18to6v3_ICG configuration

### DIFF
--- a/components/mpas-cice/cime_config/buildnml
+++ b/components/mpas-cice/cime_config/buildnml
@@ -123,7 +123,7 @@ if ( $ICE_GRID eq 'oEC60to30' ) {
 	$decomp_date .= '170111';
 	$decomp_prefix .= 'mpas-cice.graph.info.';
 } elsif ( $ICE_GRID eq 'oRRS18to6v3_ICG' ) {
-	$grid_date .= '170321';
+	$grid_date .= '170622';
 	$grid_prefix .= 'seaice.RRS18to6v3.restartFrom_titan0228';
 	$decomp_date .= '170111';
 	$decomp_prefix .= 'mpas-cice.graph.info.';

--- a/components/mpas-o/cime_config/buildnml
+++ b/components/mpas-o/cime_config/buildnml
@@ -135,7 +135,7 @@ if ( $OCN_GRID eq 'oEC60to30' ) {
 } elsif ( $OCN_GRID eq 'oRRS18to6v3_ICG' ) {
 	$grid_date .= '170111';
 	$grid_prefix .= 'oRRS18to6v3';
-	$ic_date .= '170321';
+	$ic_date .= '170622';
 	$ic_prefix .= 'oRRS18to6v3.restartFrom_titan0228';
 	$decomp_prefix .= 'mpas-o.graph.info.';
 } elsif ( $OCN_GRID eq 'oRRS15to5' ) {


### PR DESCRIPTION
This PR updates the ocean and seaice initial condition files used for the oRRS18to6v3_ICG configuration. The new files were created from high-res G-case spinup on titan, and were created with a recent version of netcdf/pnetcdf that correctly handles large arrays. These new files should help with initialization issues for the high-res A_WCYCLXXXXS tests. This configuration is not currently part of the automated test system, so it should not change test results -- but will not be BFB for high-res runs.

[non-BFB]