### PR TITLE
Upgrade default PGI from 15.7 to 17.5 on Titan

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -1868,7 +1868,7 @@
         <command name="rm">PrgEnv-intel</command>
         <command name="rm">PrgEnv-pathscale</command>
         <command name="load">PrgEnv-pgi</command>
-        <command name="switch">pgi pgi/15.9.lustre</command>
+        <command name="switch">pgi 17.5.lustre</command>
         <command name="rm">cray-mpich</command>
         <command name="rm">cray-libsci</command>
         <command name="rm">atp</command>
@@ -1881,12 +1881,13 @@
         <command name="load">cudatoolkit</command>
       </modules>
       <modules compiler="pgi">
+        <command name="use">/ccs/home/norton/.modules</command>
         <command name="rm">PrgEnv-cray</command>
         <command name="rm">PrgEnv-gnu</command>
         <command name="rm">PrgEnv-intel</command>
         <command name="rm">PrgEnv-pathscale</command>
         <command name="load">PrgEnv-pgi</command>
-        <command name="switch">pgi pgi/15.7.0</command>
+        <command name="switch">pgi pgi/17.5.lustre</command>
         <command name="rm">cray-mpich</command>
         <command name="rm">cray-libsci</command>
         <command name="rm">atp</command>


### PR DESCRIPTION
The results of the acme developer test suite using PGI/17.5 on Titan
are exactly same as those reported in cdash using PGI/15.7. So the
default PGI version was upgraded from 15.7 to 17.5 on Titan.

[Non-BFB]