### PR TITLE
Fixes momentum flux in gustiness parameter

### DIFF
--- a/cime/src/share/util/shr_flux_mod.F90
+++ b/cime/src/share/util/shr_flux_mod.F90
@@ -282,7 +282,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
         ! old version
         !vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
 
-        !--- vmag+ugust (convective gustiness) Limit to a max precip 6 cm/day = 0.00069444 mm/s.
+        !--- vmag+ugust (convective gustiness) Limit to a max precip 6 cm/day = 0.00069444 m/s.
         !--- reverts to original formula if gust_fac=0 
 
         !PMA saves vmag_old for taux tauy computation 


### PR DESCRIPTION
This bug and its fix is found by Po-Lun Ma. The original code has a
bug,which makes the gustiness effect on momentum flux smaller than
what it should be. The effects of the bug on clouds and precipitation
are small, but has an important effect on the westerly anomalies in
tropical Pacific which is relevant to ENSO. The bug fix enhances the
momentum flux in the tropics, weakening the prevailing easterlies so
that the cold tongue won't extend too far into the west. The largest
signal comes from TWP, so it might also improve WWB to help ENSO.

[BFB] - Bit-For-Bit