### PR TITLE
remove PAPI for cori-haswell and cori-knl

### DIFF
--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -610,7 +610,6 @@ for mct, etc.
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <ADD_SLIBS> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </ADD_SLIBS>
   <ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS>
-  <ADD_GPTL_CPPDEFS> -DHAVE_PAPI </ADD_GPTL_CPPDEFS>
   <ADD_CPPDEFS> -DHAVE_SLASHPROC </ADD_CPPDEFS>
   <MPIFC> ftn </MPIFC>
   <MPICC> cc </MPICC>
@@ -631,7 +630,6 @@ for mct, etc.
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <ADD_SLIBS> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </ADD_SLIBS>
   <ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS>
-  <ADD_GPTL_CPPDEFS> -DHAVE_PAPI </ADD_GPTL_CPPDEFS>
   <ADD_CPPDEFS> -DARCH_MIC_KNL -DHAVE_SLASHPROC </ADD_CPPDEFS>
   <MPIFC> ftn </MPIFC>
   <MPICC> cc </MPICC>

--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -299,7 +299,6 @@
         <command name="load">git/2.9.1</command>
 	<command name="load">cmake/3.3.2</command>
 	<command name="load">pmi/5.0.10-1.0000.11069.183.8.ari</command>
-	<command name="load">papi/5.4.3.2</command>
 	<command name="load">zlib/1.2.8</command>
       </modules>
     </module_system>
@@ -432,7 +431,6 @@
         <command name="load">git/2.9.1</command>
 	<command name="load">cmake/3.3.2</command>
 	<command name="load">pmi/5.0.10-1.0000.11069.183.8.ari</command>
-	<command name="load">papi/5.4.3.2</command>
 	<command name="load">zlib/1.2.8</command>
 	<!--command name="load">cray-petsc/3.7.0.0</command-->
       </modules>


### PR DESCRIPTION
Remove PAPI from cori-haswell and cori-knl -- remove build option to turn it on as well as commands to load the module.

Fixes https://github.com/ACME-Climate/ACME/issues/1632
