### PR TITLE
Default PE layout for F-compsets on Edison

### DIFF
--- a/cime/config/acme/allactive/config_pesall.xml
+++ b/cime/config/acme/allactive/config_pesall.xml
@@ -5691,7 +5691,7 @@
 <grid name="a%ne30np4">
     <mach name="edison">
       <pes compset="CAM5.+CLM45.+CICE.+DOCN.+RTM.+SGLC.+SWAV" pesize="any">
-        <comment>"PMC - 114 node F-compset gets around 6.6 SYPD"</comment>
+        <comment>"PMC - 114 node F-compset gets around 7.4 SYPD"</comment>
         <PES_PER_NODE>24</PES_PER_NODE>
         <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
         <ntasks>


### PR DESCRIPTION
Currently, unless you explicitly specify a custom PE layout on Edison, F-compset runs will default to 192 tasks + 4 threads (=32 total nodes), yielding <2 SYPD. This PR specifies a reasonable default for ne30 F compsets. 

Note that what is proposed here isn't an *optimal* layout. Hyperthreading can increase SYPD by 1 or more, but it isn't turned on by default any more. This layout was chosen simply because it works and isn't horrible.  just allows newbies or people who forget to specify the PE layout to get something that isn't totally useless. Efforts to get a faster PE layout would be useful.

Note that this is a second attempt to do this. https://github.com/ACME-Climate/ACME/pull/1241 also proposed a similar F PE layout but failed to pass tests for unrelated issues documented here: https://github.com/ACME-Climate/ACME/issues/1263