### PR TITLE
Swap mem highwater and usage logs for memleak tests

### DIFF
--- a/cime/src/drivers/mct/main/cesm_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cesm_comp_mod.F90
@@ -3831,7 +3831,7 @@ end subroutine cesm_init
             call shr_mem_getusage(msize,mrss,.true.)
 
             write(logunit,105) ' memory_write: model date = ',ymd,tod, &
-                 ' memory = ',mrss,' MB (usage)    ',msize,' MB (highwater)', &
+                 ' memory = ',msize,' MB (highwater)    ',mrss,' MB (usage)', &
                  '  (pe=',iam_GLOID,' comps=',trim(complist)//')'
          endif
       endif


### PR DESCRIPTION
This is needed for correct parsing of mem highwater values from cpl.log. Previously, memory resident set size was getting parsed while checking for memleaks.

[BFB]
Fixes ACME-Climate/ACME#1636 