### PR TITLE
Enforce MG2 precondition for 'in_cloud' method.

### DIFF
--- a/components/cam/src/physics/cam/micro_mg2_0.F90
+++ b/components/cam/src/physics/cam/micro_mg2_0.F90
@@ -1238,6 +1238,11 @@ subroutine micro_mg_tend ( &
 
      if (trim(micro_mg_precip_frac_method) == 'in_cloud') then
 
+        ! If cloud mass exists, keep precip_frac = cldm (precipitation
+        ! only present in cloud). If not, use the max of cloud fraction
+        ! and fraction from the level above (precip is originating from
+        ! above in this case, but we need to use the max because MG2 can't
+        ! handle precip_frac < cldm correctly).
         if (k /= 1) then
            where (qc(:,k) < qsmall .and. qi(:,k) < qsmall)
               precip_frac(:,k) = max(precip_frac(:,k-1),precip_frac(:,k))


### PR DESCRIPTION
Add a limiter that requires the precipitation fraction calculated by
MG2's 'in_cloud' method to be at least as great as the cloud fraction.

As currently written, MG2 assumes that the fraction of a level
containing cloud is a subset of the fraction of a level containing
precipitation. Therefore we should require the precipitation fraction
to be greater than or equal to the current cloud fraction for
consistency.

While the previous behavior should be considered a bug, the effect of
this change is expected to be negligible for several reasons:

1) The inconsistent state (in this case, precip_frac < cldm) is only
   possible if there is a significant cloud fraction in a level that has
   negligible cloud mass. Depending on the model configuration, this
   might be either rare or impossible. (In the latter case, this change
   is bit-for-bit.)

2) Even if the precipitation fraction does drop below the cloud
   fraction, the two values will likely be similar.

3) Processes that involve interactions between precipitation and clouds
   will be shut off if there is no cloud mass.

4) The code controlling evaporation/sublimation code, while it does use
   both the precipitation and cloud fractions, contains a limiter that
   causes it to ignore the cloud fraction when the cloud mass is small.

[non-BFB]