### PR TITLE
Improve mpi-serial support on NERSC machines (edison,cori).

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -379,7 +379,7 @@
 	<command name="rm">cray-mpich2</command>
 	<command name="rm">cray-mpich</command>
 	<command name="rm">cray-netcdf</command>
-	<!--command name="rm">cray-hdf5</command-->
+	<command name="rm">cray-hdf5</command>
 	<command name="rm">cray-netcdf-hdf5parallel</command>
 	<command name="rm">craype-sandybridge</command>
 	<command name="rm">craype-ivybridge</command>
@@ -441,7 +441,6 @@
 	<command name="load">cmake/3.3.2</command>
 	<command name="load">pmi/5.0.10-1.0000.11069.183.8.ari</command>
 	<command name="load">zlib/1.2.8</command>
-	<!--command name="load">cray-petsc/3.7.0.0</command-->
       </modules>
     </module_system>
 


### PR DESCRIPTION
Explicitly remove parallel netcdf/hdf modules before loading serial modules.