### PR TITLE
Fix CPL_ALBAV setting for DATM/MPASO configurations.

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component_acme.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_acme.xml
@@ -452,7 +452,6 @@
     <default_value>FALSE</default_value>
     <values>
       <value compset="DATM.+POP\d">TRUE</value>
-      <value compset="DATM.*_MPASO">TRUE</value>
       <value compset="DATM.+DOCN%IAF">TRUE</value>
     </values>
     <group>run_component_cpl</group>


### PR DESCRIPTION
This PR fixes the setting for CPL_ALBAV for configurations with DATM and MPASO. It was incorrectly set in CIME5 development.

It will change answers for C and G cases. However, 10-year tests of
     -compset GMPAS-IAF -mach anvil -res T62_oEC60to30v3
with this variable true and false show the effect is not climate-changing. 

[non-BFB]