### PR TITLE
Update the ICG files for the oRRS18to6v3 configuration

### DIFF
--- a/components/mpas-cice/cime_config/buildnml
+++ b/components/mpas-cice/cime_config/buildnml
@@ -123,7 +123,7 @@ if ( $ICE_GRID eq 'oEC60to30' ) {
 	$decomp_date .= '170111';
 	$decomp_prefix .= 'mpas-cice.graph.info.';
 } elsif ( $ICE_GRID eq 'oRRS18to6v3_ICG' ) {
-	$grid_date .= '170622';
+	$grid_date .= '170719';
 	$grid_prefix .= 'seaice.RRS18to6v3.restartFrom_titan0228';
 	$decomp_date .= '170111';
 	$decomp_prefix .= 'mpas-cice.graph.info.';

--- a/components/mpas-o/cime_config/buildnml
+++ b/components/mpas-o/cime_config/buildnml
@@ -135,7 +135,7 @@ if ( $OCN_GRID eq 'oEC60to30' ) {
 } elsif ( $OCN_GRID eq 'oRRS18to6v3_ICG' ) {
 	$grid_date .= '170111';
 	$grid_prefix .= 'oRRS18to6v3';
-	$ic_date .= '170622';
+	$ic_date .= '170719';
 	$ic_prefix .= 'oRRS18to6v3.restartFrom_titan0228';
 	$decomp_prefix .= 'mpas-o.graph.info.';
 } elsif ( $OCN_GRID eq 'oRRS15to5' ) {


### PR DESCRIPTION
DO NOT MERGE! Needs a different set of ICG files

This PR updates the ocean and seaice initial condition files used for the oRRS18to6v3_ICG configuration. The new files were created from year 56 of the high-res G-case spinup on titan. The current default set of files were pulled from a La Nina year and have a cold tongue that biases results, so this updates to a more normal time in the CORE forcing. The files are already available through the svn inputdata sever.

This configuration is not currently part of the automated test system, so it should not change test results -- but will not be BFB for high-res runs.

[non-BFB] for high-res cases with full ocean.