### PR TITLE
Shorten SMS.hcru_hcru.I1850CRUCLM45CN test

### DIFF
--- a/cime/scripts/lib/update_acme_tests.py
+++ b/cime/scripts/lib/update_acme_tests.py
@@ -65,7 +65,7 @@ _TEST_SUITES = {
     "acme_land_developer" : ("acme_runoff_developer", "0:45:00",
                              ("ERS.f19_f19.I1850CLM45CN",
                               "ERS.f09_g16.I1850CLM45CN",
-                              "SMS.hcru_hcru.I1850CRUCLM45CN",
+                              "SMS_Ld1.hcru_hcru.I1850CRUCLM45CN",
                              ("ERS.f19_g16.I1850CNECACNTBC" ,"clm-eca"),
                              ("ERS.f19_g16.I1850CNECACTCBC" ,"clm-eca"),
                              ("SMS_Ly2_P1x1.1x1_smallvilleIA.ICLM45CNCROP", "force_netcdf_pio"),


### PR DESCRIPTION
Shorten SMS.hcru_hcru.I1850CRUCLM45CN test to run for 1 day.
This reduces the run time to under 10 minutes on supported machines.

Fixes #1648 
[BFB]