### PR TITLE
Add two new compiler options for cori-knl to make it easier for testing.

### DIFF
--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -638,6 +638,76 @@ for mct, etc.
   <PETSC_PATH>$(PETSC_DIR)</PETSC_PATH>
 </compiler>
 
+<compiler COMPILER="intel18" MACH="cori-knl">
+
+  <!--ADD_CFLAGS> -restrict </ADD_CFLAGS-->
+  <ADD_CPPDEFS> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL</ADD_CPPDEFS>
+  <ADD_CFLAGS compile_threaded="true"> -qopenmp </ADD_CFLAGS>
+  <ADD_FFLAGS compile_threaded="true"> -qopenmp </ADD_FFLAGS>
+  <ADD_FFLAGS_NOOPT compile_threaded="true"> -qopenmp </ADD_FFLAGS_NOOPT>
+  <ADD_LDFLAGS compile_threaded="true"> -qopenmp </ADD_LDFLAGS>
+  <FREEFLAGS> -free </FREEFLAGS>
+  <FIXEDFLAGS> -fixed -132 </FIXEDFLAGS>
+  <ADD_FFLAGS DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -qno-opt-dynamic-align </ADD_FFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </ADD_FFLAGS>
+  <ADD_CFLAGS DEBUG="FALSE"> -O2 -debug minimal </ADD_CFLAGS>
+  <ADD_CFLAGS DEBUG="TRUE"> -O0 -g </ADD_CFLAGS>
+  <FFLAGS>  -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source </FFLAGS>
+  <CFLAGS> -O2 -fp-model precise -std=gnu99 </CFLAGS>
+  <FFLAGS_NOOPT> -O0 </FFLAGS_NOOPT>
+  <ADD_FFLAGS_NOOPT compile_threaded="true"> -openmp </ADD_FFLAGS_NOOPT>
+  <FC_AUTO_R8> -r8 </FC_AUTO_R8>
+  <SFC> ifort </SFC>
+  <SCC> icc </SCC>
+  <SCXX> icpc </SCXX>
+  <MPIFC> ftn </MPIFC>
+  <MPICC> cc </MPICC>
+  <MPICXX> CC </MPICXX>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <CXX_LDFLAGS> -cxxlib </CXX_LDFLAGS>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
+  <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
+  <ADD_SLIBS> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </ADD_SLIBS>
+  <ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS>
+  <ADD_CPPDEFS> -DARCH_MIC_KNL -DHAVE_SLASHPROC </ADD_CPPDEFS>
+  <PETSC_PATH>$(PETSC_DIR)</PETSC_PATH>
+</compiler>
+
+<compiler COMPILER="intel-impi" MACH="cori-knl">
+  <ADD_CPPDEFS> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL</ADD_CPPDEFS>
+  <ADD_CFLAGS compile_threaded="true"> -qopenmp </ADD_CFLAGS>
+  <ADD_FFLAGS compile_threaded="true"> -qopenmp </ADD_FFLAGS>
+  <ADD_FFLAGS_NOOPT compile_threaded="true"> -qopenmp </ADD_FFLAGS_NOOPT>
+  <ADD_LDFLAGS compile_threaded="true"> -qopenmp </ADD_LDFLAGS>
+  <FREEFLAGS> -free </FREEFLAGS>
+  <FIXEDFLAGS> -fixed -132 </FIXEDFLAGS>
+  <ADD_FFLAGS DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -qno-opt-dynamic-align </ADD_FFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </ADD_FFLAGS>
+  <ADD_CFLAGS DEBUG="FALSE"> -O2 -debug minimal </ADD_CFLAGS>
+  <ADD_CFLAGS DEBUG="TRUE"> -O0 -g </ADD_CFLAGS>
+  <FFLAGS>  -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source -xMIC-AVX512 </FFLAGS>
+  <CFLAGS> -O2 -fp-model precise -std=gnu99 -xMIC-AVX512 </CFLAGS>
+  <FFLAGS_NOOPT> -O0 </FFLAGS_NOOPT>
+  <ADD_FFLAGS_NOOPT compile_threaded="true"> -openmp </ADD_FFLAGS_NOOPT>
+  <FC_AUTO_R8> -r8 </FC_AUTO_R8>
+  <SFC> ifort </SFC>
+  <SCC> icc </SCC>
+  <SCXX> icpc </SCXX>
+  <MPIFC> mpiifort </MPIFC>
+  <MPICC> mpiicc </MPICC>
+  <MPICXX> mpiicpc </MPICXX>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <CXX_LDFLAGS> -cxxlib </CXX_LDFLAGS>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
+  <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
+  <ADD_SLIBS> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </ADD_SLIBS>
+  <ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS>
+  <ADD_CPPDEFS> -DARCH_MIC_KNL -DHAVE_SLASHPROC </ADD_CPPDEFS>
+  <PETSC_PATH>$(PETSC_DIR)</PETSC_PATH>
+</compiler>
+
 <compiler COMPILER="intel" MACH="eos">
   <ADD_FFLAGS DEBUG="FALSE"> -O2  </ADD_FFLAGS>
   <ADD_FFLAGS DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </ADD_FFLAGS>

--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -320,7 +320,7 @@
     <DESC>Cori. XC40 Cray system at NERSC. KNL partition. os is CNL, 68 pes/node (for now only use 64), batch system is SLURM</DESC>
     <NODENAME_REGEX>cori-knl-haswell-is-default</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
-    <COMPILERS>intel,gnu,cray</COMPILERS>
+    <COMPILERS>intel,intel18,intel-impi,gnu,cray</COMPILERS>
     <MPILIBS>mpt,mpi-serial</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/cori-knl</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -336,8 +336,8 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>acme</SUPPORTED_BY>
     <GMAKE_J>8</GMAKE_J>
-    <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+    <PES_PER_NODE>272</PES_PER_NODE>
     <PROJECT>acme</PROJECT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
@@ -387,6 +387,29 @@
 	<command name="load">PrgEnv-intel</command>
 	<command name="rm">intel</command>
 	<command name="load">intel/17.0.2.174</command>
+	<command name="rm">craype</command>
+	<command name="load">craype/2.5.7</command>
+	<command name="load">cray-mpich/7.4.4</command>
+      </modules>
+
+      <modules compiler="intel18">
+	<command name="load">PrgEnv-intel</command>
+	<command name="rm">intel</command>
+	<command name="load">intel/2018.beta</command>
+	<command name="rm">craype</command>
+	<command name="load">craype/2.5.10</command>
+	<command name="rm">cray-mpich</command>
+	<command name="load">cray-mpich/7.5.5</command>
+      </modules>
+
+      <modules compiler="intel-impi">
+	<command name="load">PrgEnv-intel</command>
+	<command name="rm">intel</command>
+	<command name="load">intel/17.0.2.174</command>
+	<command name="rm">craype</command>
+	<command name="load">craype/2.5.7</command>
+	<command name="rm">cray-mpich</command>
+	<command name="load">impi/2017.up2</command>
       </modules>
 
       <modules compiler="cray">
@@ -394,25 +417,26 @@
 	<command name="load">PrgEnv-cray</command>
 	<command name="rm">cce</command>
 	<command name="load">cce/8.5.4</command>
+	<command name="load">cray-libsci/16.09.1</command>
+	<command name="rm">craype</command>
+	<command name="load">craype/2.5.7</command>
+	<command name="load">cray-mpich/7.4.4</command>
       </modules>
+
       <modules compiler="gnu">
 	<command name="rm">PrgEnv-intel</command>
 	<command name="load">PrgEnv-gnu</command>
 	<command name="rm">gcc</command>
 	<command name="load">gcc/6.3.0</command>
-      </modules>
-      <modules compiler="!intel">
 	<command name="load">cray-libsci/16.09.1</command>
+	<command name="rm">craype</command>
+	<command name="load">craype/2.5.7</command>
+	<command name="load">cray-mpich/7.4.4</command>
       </modules>
 
       <modules>
-	<command name="rm">craype</command>
-	<command name="load">craype/2.5.7</command>
-
 	<command name="rm">craype-haswell</command>
 	<command name="load">craype-mic-knl</command>
-
-	<command name="load">cray-mpich/7.4.4</command>
       </modules>
 
       <modules mpilib="mpi-serial">
@@ -445,6 +469,13 @@
       <env name="OMP_PLACES">threads</env>
 
       <env name="FORT_BUFFERED" compiler="intel">yes</env>
+      <env name="FORT_BUFFERED" compiler="intel18">yes</env>
+      <env name="FORT_BUFFERED" compiler="intel-impi">yes</env>
+
+      <env name="I_MPI_FABRICS" compiler="intel-impi">ofi</env>
+      <env name="I_MPI_OFI_PROVIDER" compiler="intel-impi">gni</env>
+      <env name="I_MPI_OFI_LIBRARY" compiler="intel-impi">/global/common/cori/software/libfabric/1.4.2/gnu/lib/libfabric.so</env>
+      <env name="I_MPI_PMI_LIBRARY" compiler="intel-impi">/usr/lib64/slurmpmi/libpmi.so</env>
       </environment_variables>
 </machine>
 


### PR DESCRIPTION
--compiler=intel18 to use the beta version of Intel v18
--compiler=intel-impi to use the Intel MPI (with the default Intel compiler)