### PR TITLE
Cori Intel environment fix

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -266,6 +266,7 @@
 
       <modules compiler="intel">
 	<command name="load">PrgEnv-intel</command>
+	<command name="load">gcc/4.9.3</command>
 	<command name="rm">intel</command>
 	<command name="load">intel/17.0.2.174</command>
       </modules>


### PR DESCRIPTION
This is needed to update the gcc environment used by intel so libimf can be found. The Intel compiler depends on the environment provided by gcc; and apparently the environment provided by the gcc without a module loaded is insufficient.

Fixes #1670 