### PR TITLE
For cori-haswell only, enable flag to bind tasks to cores.

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -221,7 +221,7 @@
 	<arg name="num_tasks" > -n $TOTALPES</arg>
         <!--NOTE: hard-coding -c 2 for now, which is only optimal when using full node with no hyper-threading. (ndk) -->
 	<arg name="thread_count" > -c 2 </arg>
-	<!--arg name="binding" > dash-dash-cpu_bind=cores</arg-->
+	<arg name="binding" > --cpu_bind=cores</arg>
       </arguments>
     </mpirun>
     <module_system type="module">


### PR DESCRIPTION
For cori-haswell only, enable flag to bind tasks to cores.
Uncomment line to add --cpu_bind=cores to srun command.
This will automatically generate masks binding tasks to cores