### PR TITLE
Titan config fixes for latest cime

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -1768,7 +1768,7 @@
     <PROJECT>cli115</PROJECT>
     <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
     <mpirun mpilib="default">
-      <executable args="default">aprun</executable>
+      <executable>aprun</executable>
       <arguments>
 	<!-- <arg name="hyperthreading" default="2"> -j {{ hyperthreading }}</arg>
         <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
@@ -1874,58 +1874,56 @@
         <command name="load">cray-netcdf-hdf5parallel/4.4.1.1</command>
         <command name="load">cray-parallel-netcdf/1.7.0</command>
       </modules>
-
-      <!-- Default -->
-      <environment_variables>
-        <env name="COMPILER">$COMPILER</env>
-        <env name="MPILIB">$MPILIB</env>
-        <env name="MPICH_ENV_DISPLAY">1</env>
-        <env name="MPICH_VERSION_DISPLAY">1</env>
-        <env name="MPICH_CPUMASK_DISPLAY">1</env>
-        <env name="MPSTKZ">128M</env>
-        <env name="OMP_STACKSIZE">128M</env>
-      </environment_variables>
-
-      <!-- Set if compiler and mpilib  -->
-      <environment_variables compiler="pgiacc">
-        <!-- NOTE(wjs, 2015-03-12) The following line is needed for bit-for-bit reproducibility -->
-        <env name="CRAY_CPU_TARGET">istanbul</env>
-        <env name="CRAY_CUDA_MPS">1</env>
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
-      </environment_variables>
-
-      <environment_variables compiler="pgiacc" mpilib="!mpi-serial">
-	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/PGI/15.3</env>
-      </environment_variables>
-
-      <environment_variables compiler="pgi" >
-        <!-- NOTE(wjs, 2015-03-12) The following line is needed for bit-for-bit reproducibility -->
-        <env name="CRAY_CPU_TARGET">istanbul</env>
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
-      </environment_variables>
-
-      <environment_variables compiler="pgi" mpilib="!mpi-serial">
-	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/PGI/15.3</env>
-      </environment_variables>
-
-      <environment_variables compiler="intel">
-        <env name="CRAYPE_LINK_TYPE">dynamic</env>
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/INTEL/15.0/</env>
-      </environment_variables>
-
-      <environment_variables compiler="intel" mpilib="!mpi-serial">
-	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/INTEL/15.0</env>
-      </environment_variables>
-
-      <environment_variables compiler="cray">
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/CRAY/8.3/</env>
-      </environment_variables>
-
-      <environment_variables compiler="cray" mpilib="!mpi-serial">
-	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/CRAY/8.3</env>
-      </environment_variables>
-
     </module_system>
+    <!-- Default -->
+    <environment_variables>
+      <env name="COMPILER">$COMPILER</env>
+      <env name="MPILIB">$MPILIB</env>
+      <env name="MPICH_ENV_DISPLAY">1</env>
+      <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="MPICH_CPUMASK_DISPLAY">1</env>
+      <env name="MPSTKZ">128M</env>
+      <env name="OMP_STACKSIZE">128M</env>
+    </environment_variables>
+
+    <!-- Set if compiler and mpilib  -->
+    <environment_variables compiler="pgiacc">
+      <!-- NOTE(wjs, 2015-03-12) The following line is needed for bit-for-bit reproducibility -->
+      <env name="CRAY_CPU_TARGET">istanbul</env>
+      <env name="CRAY_CUDA_MPS">1</env>
+<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
+    </environment_variables>
+
+    <environment_variables compiler="pgiacc" mpilib="!mpi-serial">
+<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/PGI/15.3</env>
+    </environment_variables>
+
+    <environment_variables compiler="pgi" >
+      <!-- NOTE(wjs, 2015-03-12) The following line is needed for bit-for-bit reproducibility -->
+      <env name="CRAY_CPU_TARGET">istanbul</env>
+<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
+    </environment_variables>
+
+    <environment_variables compiler="pgi" mpilib="!mpi-serial">
+<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/PGI/15.3</env>
+    </environment_variables>
+
+    <environment_variables compiler="intel">
+      <env name="CRAYPE_LINK_TYPE">dynamic</env>
+<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/INTEL/15.0/</env>
+    </environment_variables>
+
+    <environment_variables compiler="intel" mpilib="!mpi-serial">
+<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/INTEL/15.0</env>
+    </environment_variables>
+
+    <environment_variables compiler="cray">
+<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/CRAY/8.3/</env>
+    </environment_variables>
+
+    <environment_variables compiler="cray" mpilib="!mpi-serial">
+<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/CRAY/8.3</env>
+    </environment_variables>
 </machine>
 
 <machine MACH="eos">


### PR DESCRIPTION
The following changes are required to be compliant with the latest
CIME XML syntax. Without these changes create_newcase fails with
latest CIME with xmllint errors.

* Removing args attribute in the executable tag
* Moving environment_variables block outside the module_system
  block

(Note: The changes above should also work with the current version
of CIME on master)

Fixes #1675 
[BFB]