### PR TITLE
Adds a land test for 20th-century transient

### DIFF
--- a/cime/scripts/lib/update_acme_tests.py
+++ b/cime/scripts/lib/update_acme_tests.py
@@ -65,6 +65,7 @@ _TEST_SUITES = {
     "acme_land_developer" : ("acme_runoff_developer", "0:45:00",
                              ("ERS.f19_f19.I1850CLM45CN",
                               "ERS.f09_g16.I1850CLM45CN",
+                              "ERS.f19_f19.I20TRCLM45CN",
                               "SMS_Ld1.hcru_hcru.I1850CRUCLM45CN",
                              ("ERS.f19_g16.I1850CNECACNTBC" ,"clm-eca"),
                              ("ERS.f19_g16.I1850CNECACTCBC" ,"clm-eca"),


### PR DESCRIPTION
A test with active land BGC for the 20th-century transient is added.
This test will ensure the dynamic PFT capability in ALM will be protected.

[BFB]