### PR TITLE
Fix st_archive template.

### DIFF
--- a/cime/config/acme/machines/template.st_archive
+++ b/cime/config/acme/machines/template.st_archive
@@ -64,9 +64,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--force-move", default=False, action="store_true",
                         help="Move the files even if it's unsafe to do so")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)


### PR DESCRIPTION
Not sure how we didn't catch this before.

The st_archive was using an outdated way of handling the command line arguments.

Fixes #1691 

[BFB]