### PR TITLE
Add option to build with Intel version 18 (beta) on cori-knl

### DIFF
--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -594,7 +594,7 @@ for mct, etc.
 
 <compiler COMPILER="intel18" MACH="cori-knl">
   <!-- need base intel settings as well those for cori-knl -->
-  <ADD_CPPDEFS> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL</ADD_CPPDEFS>
+  <ADD_CPPDEFS> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL </ADD_CPPDEFS>
   <FREEFLAGS> -free </FREEFLAGS>
   <FIXEDFLAGS> -fixed -132 </FIXEDFLAGS>
   <ADD_FFLAGS DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </ADD_FFLAGS>

--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -393,7 +393,6 @@
 	<command name="load">craype/2.5.10</command>
 	<command name="rm">cray-mpich</command>
 	<command name="load">cray-mpich/7.5.5</command>
-        <command name="load">craype-hugepages2M</command>
       </modules>
 
       <modules compiler="cray">


### PR DESCRIPTION
The tests behave in similar way as Intel 17 on this machine.
