### PR TITLE
Check for NaNs and INFs in input to shr_reprosum_calc

### DIFF
--- a/cime/src/share/util/shr_reprosum_mod.F90
+++ b/cime/src/share/util/shr_reprosum_mod.F90
@@ -339,7 +339,7 @@ module shr_reprosum_mod
       logical :: validate                ! flag indicating need to
                                          !  verify gmax and max_levels
                                          !  are accurate/sufficient
-      integer :: nan_check, inf_check    ! flag on whether there are
+      logical :: nan_check, inf_check    ! flag on whether there are
                                          !  NaNs and INFs in input array
 
       integer :: num_nans, num_infs      ! count of NaNs and INFs in


### PR DESCRIPTION
In recent development NaNs and INFs are often first
identified when passed to the shr_reprosum_calc routine,
where they either lead to segmentation faults or to
very slow performance (due to the interaction of NaNs and
INFs with the reproducible sum logic). To more readily
identify this error condition (and to prevent false
attributions of error to shr_reprosum_calc), the input array
is checked for the presence of NaNs and INFs. If found,
an appropriate error message is output and the job is
terminated.

[BFB]
