### PR TITLE
Set RTM grid to NULL for RRM grids

### DIFF
--- a/cime/config/acme/config_grids.xml
+++ b/cime/config/acme/config_grids.xml
@@ -469,14 +469,14 @@
     <!-- ENA RRM grid (all components) -->
     <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
       <sname>ne0np4_enax4v1_ne0np4_enax4v1</sname>
-      <lname>a%ne0np4_enax4v1_l%ne0np4_enax4v1_oi%ne0np4_enax4v1_r%r01_m%oRRS18to6_g%null_w%null</lname>
+      <lname>a%ne0np4_enax4v1_l%ne0np4_enax4v1_oi%ne0np4_enax4v1_r%null_m%oRRS18to6_g%null_w%null</lname>
       <alias>enax4v1_enax4v1</alias>
     </grid>
 
     <!-- ENA RRM grid (land on ne30) -->
     <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
       <sname>ne0np4_enax4v1_ne30np4_ne0np4_enax4v1</sname>
-      <lname>a%ne0np4_enax4v1_l%ne30np4_oi%ne0np4_enax4v1_r%r01_m%oRRS18to6_g%null_w%null</lname>
+      <lname>a%ne0np4_enax4v1_l%ne30np4_oi%ne0np4_enax4v1_r%null_m%oRRS18to6_g%null_w%null</lname>
       <alias>enax4v1_ne30_enax4v1</alias>
     </grid>
 


### PR DESCRIPTION
Set RTM grid to NULL (inactive) for all existing RRM grids. These grids were originally created before RTM was active by default, so the required input files do not exist to run these grids with RTM active. While this will be fixed by #1705 (which sets RTM to NULL for all F compsets), it is worth redefining the grid longnames for the RRM grids so these configurations will not be broken in the future if the default for F compsets changes, or if these grids are setup in the future to run other compsets. 

Fixes ACME-Climate/ACME#1694.
[BFB]