### PR TITLE
Add -finit-local-zero flag on Melvin to force local var initialization

### DIFF
--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -619,6 +619,7 @@ for mct, etc.
 </compiler>
 
 <compiler COMPILER="gnu" MACH="melvin">
+  <ADD_FFLAGS> -finit-local-zero  </ADD_FFLAGS>
   <ADD_FFLAGS DEBUG="FALSE"> -O2  </ADD_FFLAGS>
   <ADD_CFLAGS DEBUG="FALSE"> -O2  </ADD_CFLAGS>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>


### PR DESCRIPTION
Uninitialized local variables are not set to zero by default with gnu compiler 
on Melvin. 
Add -finit-local-zero flag so Melvin behaves similarly as other test machines
in term of local variable initialization. 

[non-BFB] 