### PR TITLE
Archive any file that starts with Macros

### DIFF
--- a/cime/scripts/lib/CIME/provenance.py
+++ b/cime/scripts/lib/CIME/provenance.py
@@ -164,7 +164,7 @@ def _save_prerun_timing_acme(case, lid):
         "*.xml",
         "user_nl_*",
         "*env_mach_specific*",
-        "Macros",
+        "Macros*",
         "README.case",
         "Depends.%s" % mach,
         "Depends.%s" % compiler,


### PR DESCRIPTION
Instead of only files with exact name 'Macros'

Should allow us to catch all Macros regardless of the format.

Fixes #1725 

[BFB]