### PR TITLE
Cleanup blues config and upgrade gnu to 5.3.0

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -874,10 +874,19 @@
         <command name="add">+python-2.7</command>
       </modules>
       <modules compiler="gnu">
+        <command name="add">+gcc-5.3.0</command>
+        <command name="add">+hdf5-1.10.0-gcc-5.3.0-serial</command>
+        <command name="add">+netcdf-c-4.4.0-f77-4.4.3-gcc-5.3.0-serial</command>
+      </modules>
+      <modules compiler="gnu-5.2">
 	<command name="add">+gcc-5.2</command>
 	<command name="add">+netcdf-4.3.3.1-gnu5.2-serial</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich">
+        <command name="add">+mvapich2-2.2b-gcc-5.3.0</command>
+        <command name="add">+pnetcdf-1.6.1-gcc-5.3.0-mvapich2-2.2b</command>
+      </modules>
+      <modules compiler="gnu-5.2" mpilib="mvapich">
 	<command name="add">+mvapich2-2.2b-gcc-5.2</command>
       </modules>
       <modules compiler="intel">


### PR DESCRIPTION
This PR includes some cleanup for the blues config,
* Load modules based on the choice (compiler+mpilib) made by the user
  Compilers : gnu, pgi, nag
  MPI libs : mvapich, mpi-serial
* Remove custom paths for NetCDF and PnetCDF
* Upgrade compiler from gnu 5.2 to gnu 5.3.0

Fixes #1700

[BFB] 
  