### PR TITLE
Change the project for chama back to original value

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -801,7 +801,7 @@
   <PES_PER_NODE>16</PES_PER_NODE>
   <PIO_BUFFER_SIZE_LIMIT>1</PIO_BUFFER_SIZE_LIMIT>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-  <PROJECT>fy150001P</PROJECT>
+  <PROJECT>fy150001</PROJECT>
 
   <mpirun mpilib="default">
     <executable>mpiexec</executable>


### PR DESCRIPTION
Our special WCID (project) for chama had expired without any
notice from the HPC admins. We need to go back to a working
WCID for now.

[BFB]