### PR TITLE
Init uninitialized launch_wave array

### DIFF
--- a/components/cam/src/physics/cam/gw_front.F90
+++ b/components/cam/src/physics/cam/gw_front.F90
@@ -163,6 +163,7 @@ subroutine gw_cm_src(ncol, ngwv, kbot, u, v, frontgf, &
   !-----------------------------------------------------------------------
 
   tau = 0._r8
+  launch_wave = .false.
 
   ! GW generation depends on frontogenesis at specified level (may be below
   ! actual source level).


### PR DESCRIPTION
Initialize the `launch_wave` array prior to its use in a loop affecting gravity waves.

[BFB]
