### PR TITLE
Fixes land simulation with active c14

### DIFF
--- a/components/clm/src/biogeochem/CNC14DecayMod.F90
+++ b/components/clm/src/biogeochem/CNC14DecayMod.F90
@@ -101,7 +101,7 @@ contains
          seedc(c) = seedc(c) *  (1._r8 - decay_const * dt)
       end do ! end of columns loop
 
-      if (is_active_betr_bgc) then
+      if (.not. is_active_betr_bgc) then
          do l = 1, ndecomp_pools
             if ( spinup_state .eq. 1) then
                ! speed up radioactive decay by the same factor as decomposition so tat SOM ages prematurely in all respects


### PR DESCRIPTION
This fix ensures c14 in soil organic matter pools are correctly enabled
when radiocarbon is on for BGC simulations. The change will be non-BFB
for land BGC simulations with active radiocarbon dynamics, non-C14
simulations will be BFB.

Fixes #1755
[non-BFB]