### PR TITLE
Correct MG2 ice number sublimation tendency.

### DIFF
--- a/components/cam/src/physics/cam/micro_mg2_0.F90
+++ b/components/cam/src/physics/cam/micro_mg2_0.F90
@@ -1531,11 +1531,7 @@ subroutine micro_mg_tend ( &
 
         berg(:,k)=berg(:,k)*micro_mg_berg_eff_factor
 
-        where (vap_dep(:,k) < 0._r8 .and. qi(:,k) > qsmall .and. icldm(:,k) > mincld)
-           nsubi(:,k) = vap_dep(:,k) / qi(:,k) * ni(:,k) / icldm(:,k)
-        elsewhere
-           nsubi(:,k) = 0._r8
-        end where
+        nsubi(:,k) = ice_sublim(:,k) / qi(:,k) * ni(:,k) / icldm(:,k)
 
         ! bergeron process should not reduce nc unless
         ! all ql is removed (which is handled elsewhere)


### PR DESCRIPTION
Calculate the effect of sublimation on cloud ice number based on the
variable `ice_sublim` rather than `vap_dep`. Cloud ice number should be
affected by sublimation of ice particles, not by the deposition of ice
onto existing particles.

In addition, the various conditions used to determine whether `nsubi`
should be set are unnecessary and have been removed.

As a historical note, in an early version of the code, the effects of
both deposition and sublimation were included in `vap_dep`. When the
`ice_sublim` variable was introduced, the two processes were split
apart, but the calculation of `nsubi`, the sublimation of cloud ice
number, was not changed to match. The effect of this bug was to set
`nsubi` to zero, effectively turning off the sublimation of ice number.
This commit is simply fixing that mistake.

[non-BFB]