### PR TITLE
Fixed the settings of pgi compiler on Titan

### DIFF
--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -262,7 +262,7 @@ for mct, etc.
   <ADD_FFLAGS MODEL="dwav"> -Mnovect </ADD_FFLAGS>
   <ADD_FFLAGS MODEL="dice"> -Mnovect </ADD_FFLAGS>
   <ADD_FFLAGS MODEL="docn"> -Mnovect </ADD_FFLAGS>
-  <LDFLAGS> -time -Wl,--allow-multiple-definition -acc -ta=tesla,pin,cuda7.5,cc35 </LDFLAGS>
+  <LDFLAGS> -time -Wl,--allow-multiple-definition -acc -ta=tesla,pinned,cuda7.5,cc35 </LDFLAGS>
   <SCC> pgcc </SCC>
   <SFC> pgf95 </SFC>
   <SCXX> pgc++ </SCXX>

--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -2028,13 +2028,12 @@
       </modules>
 
       <modules compiler="pgiacc"> <!-- changing pgi_acc to pgiacc -->
-        <command name="use">/ccs/home/norton/.modules</command>
         <command name="rm">PrgEnv-cray</command>
         <command name="rm">PrgEnv-gnu</command>
         <command name="rm">PrgEnv-intel</command>
         <command name="rm">PrgEnv-pathscale</command>
         <command name="load">PrgEnv-pgi</command>
-        <command name="switch">pgi 17.5.lustre</command>
+        <command name="switch">pgi pgi/17.5.0</command>
         <command name="rm">cray-mpich</command>
         <command name="rm">cray-libsci</command>
         <command name="rm">atp</command>
@@ -2047,13 +2046,12 @@
         <command name="load">cudatoolkit</command>
       </modules>
       <modules compiler="pgi">
-        <command name="use">/ccs/home/norton/.modules</command>
         <command name="rm">PrgEnv-cray</command>
         <command name="rm">PrgEnv-gnu</command>
         <command name="rm">PrgEnv-intel</command>
         <command name="rm">PrgEnv-pathscale</command>
         <command name="load">PrgEnv-pgi</command>
-        <command name="switch">pgi pgi/17.5.lustre</command>
+        <command name="switch">pgi pgi/17.5.0</command>
         <command name="rm">cray-mpich</command>
         <command name="rm">cray-libsci</command>
         <command name="rm">atp</command>


### PR DESCRIPTION
This is a part of PR #1767 submitted by Pat Worley, focusing on the
changes of the settings of pgi compiler in Titan.

As stated in PR #1767:
"Changes including removing the dependence on the version of pgi/17.5.0
installed in Dave Norton's directories, moving instead
to the now official OLCF installation. Also fixed a typo in the
module switch command for the PGI version used with PGIACC, and
changed the 'pin' flag to 'pinned' for PGIACC, as 'pin' is no
longer legal."

[BFB]