### PR TITLE
Update Bebop for Albany build

### DIFF
--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -1217,6 +1217,8 @@ for mct, etc.
   <MPIFC> mpiifort </MPIFC>
   <MPICC> mpiicc  </MPICC>
   <MPICXX> mpiicpc </MPICXX>
+  <CXX_LIBS>-lstdc++</CXX_LIBS>
+  <ALBANY_PATH>/soft/climate/AlbanyTrilinos_06262017/Albany/buildintel/install</ALBANY_PATH>
 </compiler>
 
 <compiler COMPILER="pgi" MACH="eastwind">


### PR DESCRIPTION
Added path to new Albany install for Bebop machine.

This will get the MPASLIALB test to pass on Bebop.

Ran test manually

BFB except fixes failing MPASLIALB test on Bebop