### PR TITLE
Changing RTM -> SROF broke default PE layouts

### DIFF
--- a/cime/config/acme/allactive/config_pesall.xml
+++ b/cime/config/acme/allactive/config_pesall.xml
@@ -5968,8 +5968,8 @@
   </grid>
 <grid name="a%ne30np4">
     <mach name="edison">
-      <pes compset="CAM5.+CLM45.+CICE.+DOCN.+SROF.+SGLC.+SWAV" pesize="any">
-        <comment>"PMC - 114 node F-compset gets around 7.4 SYPD"</comment>
+      <pes compset="CAM.+CLM.+DOCN." pesize="any">
+        <comment>"PMC - 114 node F-compset gets around 10.5 SYPD"</comment>
         <PES_PER_NODE>24</PES_PER_NODE>
         <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
         <ntasks>


### PR DESCRIPTION
Switch RTM to SROF wherever it occurs in config_pesall.xml.

Default PE layouts are determined in $CODE_ROOT/cime/config/acme/allactive/config_pesall.xml based on the requested grid,
machine, compset, etc. Layouts for F compsets on some machines specify every component used, and therefore quit working
when 'RTM' was replaced by 'SROF' in PR #1705.

It would probably be more robust to replace these complex compset specifications with just the components needed to  
specify an F case: "CAM.+CLM.+DOCN.".  This change made for Edison case, but didn't make it in the ~5 other cases.

[BFB]