### PR TITLE
Avoid divide-by-zero in MG2 ice sublimation.

### DIFF
--- a/components/cam/src/physics/cam/micro_mg2_0.F90
+++ b/components/cam/src/physics/cam/micro_mg2_0.F90
@@ -1531,7 +1531,11 @@ subroutine micro_mg_tend ( &
 
         berg(:,k)=berg(:,k)*micro_mg_berg_eff_factor
 
-        nsubi(:,k) = ice_sublim(:,k) / qi(:,k) * ni(:,k) / icldm(:,k)
+        where (qi(:,k) >= qsmall)
+           nsubi(:,k) = ice_sublim(:,k) / qi(:,k) * ni(:,k) / icldm(:,k)
+        elsewhere
+           nsubi(:,k) = 0._r8
+        end where
 
         ! bergeron process should not reduce nc unless
         ! all ql is removed (which is handled elsewhere)


### PR DESCRIPTION
The variable `nsubi` in MG2 is calculated by dividing by `qi`. This
means that we need to check for (near-)zero values to avoid triggering a
floating-point exception. It appears that the resulting NaN values are
filtered out by limiters, so this commit may not end up changing
answers, but that is unclear at this time.

Note that this bug was just introduced in #1765.