### PR TITLE
Added missing namelist variable 'l_ieflx_fix'

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -1122,6 +1122,13 @@ IEFLX fixer options
 Default: 0
 </entry>
 
+<entry id="l_ieflx_fix" type="logical"  category="fixers"
+       group="phys_ctl_nl" valid_values="">
+Whether or not to turn on IEFLX fixer
+Default: false
+</entry>
+
+
 <!-- Gravity Wave Drag -->
 
 <entry id="use_gw_oro" type="logical" category="gw_drag"


### PR DESCRIPTION
Add the logical namelist flag 'l_ieflx_fix' to activate the energy fixer.
This was not defined in 'namelist_definition.xml'.

Fixes #1789 

[BFB]