### PR TITLE
jenkins_generic_job: print how to do a dashboard resubmit in the log

### DIFF
--- a/cime/scripts/lib/jenkins_generic_job.py
+++ b/cime/scripts/lib/jenkins_generic_job.py
@@ -138,6 +138,10 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
         cdash_build_name = None
 
     os.environ["CIME_MACHINE"] = machine.get_machine_name()
+
+    if submit_to_cdash:
+        logging.info("To resubmit to dashboard: wait_for_tests {}/*{}/TestStatus -b {}".format(test_root, test_id, cdash_build_name))
+
     tests_passed = CIME.wait_for_tests.wait_for_tests(glob.glob("%s/*%s/TestStatus" % (test_root, test_id)),
                                                  no_wait=not use_batch, # wait if using queue
                                                  check_throughput=False, # don't check throughput


### PR DESCRIPTION
A common failure is for the nightly submission to the dashboard to
fail. This change will print the command needed to resubmit to make
it easier for to do the resubmission if we need it.

[BFB]