### PR TITLE
Allow jenkins to run multiple machines/compilers from the same test root

### DIFF
--- a/cime/scripts/Tools/jenkins_generic_job
+++ b/cime/scripts/Tools/jenkins_generic_job
@@ -122,10 +122,10 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    generate_baselines, submit_to_cdash, no_batch, cdash_build_name, cdash_project, baseline_branch, test_suite, cdash_build_group, no_baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler = \
+    generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch, cdash_build_name, cdash_project, baseline_branch, test_suite, cdash_build_group, no_baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler)
+    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler)
              else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/cime/scripts/lib/jenkins_generic_job.py
+++ b/cime/scripts/lib/jenkins_generic_job.py
@@ -61,17 +61,19 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
     # the Jenkins jobs with timeouts to avoid this.
     #
 
+    mach_comp = "{}_{}".format(machine.get_machine_name(), compiler)
+
     # Remove the old CTest XML
     if (os.path.isdir("Testing")):
         shutil.rmtree("Testing")
 
     # Remove the old build/run dirs
     test_id_root = "jenkins_%s" % baseline_name
-    for old_dir in glob.glob("%s/*%s*" % (scratch_root, test_id_root)):
+    for old_dir in glob.glob("%s/*%s*%s*" % (scratch_root, mach_comp, test_id_root)):
         shutil.rmtree(old_dir)
 
     # Remove the old cases
-    for old_file in glob.glob("%s/*%s*" % (test_root, test_id_root)):
+    for old_file in glob.glob("%s/*%s*%s*" % (test_root, mach_comp, test_id_root)):
         if (os.path.isdir(old_file)):
             shutil.rmtree(old_file)
         else:


### PR DESCRIPTION
Only required a minor tweak to the clean-up code to only clean up
results for matching compiler, machine, and branch.

[BFB]