### PR TITLE
Remove batch-job cleanup from jenkins_generic_job

### DIFF
--- a/cime/scripts/lib/jenkins_generic_job.py
+++ b/cime/scripts/lib/jenkins_generic_job.py
@@ -4,21 +4,6 @@ from CIME.utils import expect
 import os, shutil, glob, signal, logging
 
 ###############################################################################
-def cleanup_queue(set_of_jobs_we_created):
-###############################################################################
-    """
-    Delete all jobs left in the queue
-    """
-    current_jobs = set(CIME.utils.get_my_queued_jobs())
-    jobs_to_delete = set_of_jobs_we_created & current_jobs
-
-    if (jobs_to_delete):
-        logging.warning("Found leftover batch jobs that need to be deleted: %s" % ", ".join(jobs_to_delete))
-        success = CIME.utils.delete_jobs(jobs_to_delete)
-        if not success:
-            logging.warning("FAILED to clean up leftover jobs!")
-
-###############################################################################
 def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
                         baseline_name,
                         arg_cdash_build_name, cdash_project,
@@ -80,14 +65,6 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
             os.remove(old_file)
 
     #
-    # Make note of things already in the queue so we know not to delete
-    # them if we timeout
-    #
-    preexisting_queued_jobs = []
-    if (use_batch):
-        preexisting_queued_jobs = CIME.utils.get_my_queued_jobs()
-
-    #
     # Set up create_test command and run it
     #
 
@@ -120,16 +97,6 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
         expect(create_test_stat in [0, CIME.utils.TESTS_FAILED_ERR_CODE, -signal.SIGTERM],
                "Create_test script FAILED with error code '%d'!" % create_test_stat)
 
-    if (use_batch):
-        # This is not fullproof. Any jobs that happened to be
-        # submitted by this user while create_test was running will be
-        # potentially deleted. This is still a big improvement over the
-        # previous implementation which just assumed all queued jobs for this
-        # user came from create_test.
-        # TODO: change this to probe test_root for jobs ids
-        #
-        our_jobs = set(CIME.utils.get_my_queued_jobs()) - set(preexisting_queued_jobs)
-
     #
     # Wait for tests
     #
@@ -152,8 +119,5 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
                                                  cdash_build_name=cdash_build_name,
                                                  cdash_project=cdash_project,
                                                  cdash_build_group=cdash_build_group)
-    if (not tests_passed and use_batch and CIME.wait_for_tests.SIGNAL_RECEIVED):
-        # Cleanup
-        cleanup_queue(our_jobs)
 
     return tests_passed


### PR DESCRIPTION
This was another potential conflict point between simultaneous
runs of jenkins. Also, there's really no need for it because the
directory cleanup (case, run, bld dirs) will surely cause any
stale jobs from older runs to die, so there's little risk of unlimited
build-up of batch jobs unless the jobs are not even being started.

New CIME updates are needed for analyzing job info per-case.

[BFB]