### PR TITLE
Upgrade the intel 18 compiler version for NERSC machines (for --compiler=intel18)

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -142,7 +142,7 @@
     <modules compiler="intel18">
       <command name="load">PrgEnv-intel</command>
       <command name="rm">intel</command>
-      <command name="load">intel/2018.beta</command>
+      <command name="load">intel/18.0.0.128</command>
       <command name="rm">cray-libsci</command>
     </modules>
 
@@ -273,7 +273,7 @@
     <modules compiler="intel18">
       <command name="load">PrgEnv-intel</command>
       <command name="rm">intel</command>
-      <command name="load">intel/2018.beta</command>
+      <command name="load">intel/18.0.0.128</command>
     </modules>
 
     <modules compiler="gnu">
@@ -419,7 +419,7 @@
     <modules compiler="intel18">
       <command name="load">PrgEnv-intel</command>
       <command name="rm">intel</command>
-      <command name="load">intel/2018.beta</command>
+      <command name="load">intel/18.0.0.128</command>
     </modules>
 
     <modules compiler="gnu">


### PR DESCRIPTION
Upgrade the intel 18 compiler version for NERSC machines when using the --compiler=intel18 option.
Instead of using a beta version, use the official release:  18.0.0.128
