### PR TITLE
Disable performance archiving if timing dir. cannot be written into

### DIFF
--- a/cime/scripts/lib/CIME/provenance.py
+++ b/cime/scripts/lib/CIME/provenance.py
@@ -107,13 +107,13 @@ def _save_prerun_timing_acme(case, lid):
     base_case = case.get_value("CASE")
     full_timing_dir = os.path.join(timing_dir, "performance_archive", getpass.getuser(), base_case, lid)
     if os.path.exists(full_timing_dir):
-        logger.warning("{} already exists. Skipping archive of timing data and associated provenance".format(full_timing_dir))
+        logger.warning("{} already exists. Skipping archive of timing data and associated provenance.".format(full_timing_dir))
         return
 
     try:
         os.makedirs(full_timing_dir)
     except OSError:
-        logger.warning("{} cannot be created. Skipping archive of timing data and associated provenance".format(full_timing_dir))
+        logger.warning("{} cannot be created. Skipping archive of timing data and associated provenance.".format(full_timing_dir))
         return
 
     mach = case.get_value("MACH")


### PR DESCRIPTION
Currently, if the directory where performance data and associated
provenance data are to be saved already exists or cannot be created
or populated, then the job aborts. This change allows the job to proceed,
simply disabling the performance data archiving. This will allow the use of
default locations for saving the performance data that are legal for
users in the E3SM project but which will not be legal for E3SM users who
are not part of the project. These external users can define alternative
locations in their job cases.

BFB

Fixes #1816 
