### PR TITLE
Set PIO_ROOT defaults to be zero instead of one

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component.xml
+++ b/cime/src/drivers/mct/cime_config/config_component.xml
@@ -2351,15 +2351,15 @@
     <file>env_run.xml</file>
     <desc>pio root processor relative to component root</desc>
     <values>
-      <value component="ATM">1</value>
-      <value component="CPL">1</value>
-      <value component="OCN">1</value>
-      <value component="WAV">1</value>
-      <value component="GLC">1</value>
-      <value component="ICE">1</value>
-      <value component="ROF">1</value>
-      <value component="LND">1</value>
-      <value component="ESP">1</value>
+      <value component="ATM">0</value>
+      <value component="CPL">0</value>
+      <value component="OCN">0</value>
+      <value component="WAV">0</value>
+      <value component="GLC">0</value>
+      <value component="ICE">0</value>
+      <value component="ROF">0</value>
+      <value component="LND">0</value>
+      <value component="ESP">0</value>
     </values>
   </entry>
 


### PR DESCRIPTION
High MPI overhead occurs on some systems the first time that
two processes communicate. In typical usage there are two types
of nonlocal message patterns: one based off of the root of each
component and one (in PIO) based off of root+1. By changing
the default for PIO_ROOT from one to zero, this start-up overhead
is approximately halved.

Using a PIO_ROOT value of zero also allows the default performance
timing settings to better capture PIO performance. Finally,
logically a PIO_ROOT value of one has no special advantage over
zero with current multi- and many-core processor architectures.
This has been verified in recent performance benchmarking on multiple
system and multiple cases, with a PIO_ROOT value of zero performing
better than a PIO_ROOT of one even in the RUN LOOP.

[BFB]
[NML]

This addresses issue #1578, but that issue can never really be solved, only mitigated against. There may be more workarounds that are appropriate yet to come.