### PR TITLE
Reordering input files for cprnc in homme.

### DIFF
--- a/components/homme/test/reg_test/run_tests/testing-utils.sh
+++ b/components/homme/test/reg_test/run_tests/testing-utils.sh
@@ -359,7 +359,7 @@ createAllRunScripts() {
 
         echo "# Running cprnc to difference ${baseFilename} against baseline " >> $thisRunScript
         #echo "$cmd > $diffStdout 2> $diffStderr" >> $thisRunScript
-        cmd="${CPRNC_BINARY} ${newFile} ${repoFile} > $diffStdout 2> $diffStderr"
+        cmd="${CPRNC_BINARY} ${repoFile} ${newFile} > $diffStdout 2> $diffStderr"
         #echo "  $cmd"
         serExecLine $thisRunScript "$cmd"
         echo "" >> $thisRunScript # blank line
@@ -396,7 +396,7 @@ createAllRunScripts() {
         diffStderr=${TEST_NAME}.ref.${baseFilename}.err
 
         echo "# Running cprnc to difference ${baseFilename} against reference " >> $thisRunScript
-        cmd="${CPRNC_BINARY} ${newFile} ${refFile} > $diffStdout 2> $diffStderr"
+        cmd="${CPRNC_BINARY} ${refFile} ${newFile} > $diffStdout 2> $diffStderr"
         serExecLine $thisRunScript "$cmd"
         echo "" >> $thisRunScript # blank line
         let COUNT+=1
@@ -564,12 +564,12 @@ diffCprnc() {
     #repoFile=${HOMME_NC_RESULTS_DIR}/${TEST_NAME}/${baseFilename}
     repoFile=${HOMME_BASELINE_DIR}/${TEST_NAME}/movies/${baseFilename}
 
-    if [ ! -f "${newFile}" ] ; then
+    if [ ! -f "${repoFile}" ] ; then
       echo "ERROR: The repo file ${repoFile} does not exist exiting" 
       exit -10
     fi
 
-    cmd="${CPRNC_BINARY} ${newFile} ${repoFile}"
+    cmd="${CPRNC_BINARY} ${repoFile} ${newFile}"
 
     diffStdout=${TEST_NAME}.${baseFilename}.out
     diffStderr=${TEST_NAME}.${baseFilename}.err


### PR DESCRIPTION
Currently, if one runs command 'cprnc #file1 #file2' then if file1 has only 1 time frame (which is most likely frame for T=0) and file2 has T=0 frame and other ones, then cprnc output will be that files are identical. If file1 is the new file and came from a broken commit, cprnc won't detect anything. This PR reorders inputs for cprnc in homme, assuming that a baseline file is the file to trust.