### PR TITLE
symlink branch run files in run_acme

### DIFF
--- a/run_acme.template.csh
+++ b/run_acme.template.csh
@@ -917,6 +917,10 @@ cat <<EOF >> user_nl_cam
  mfilt  = $records_per_atm_output_file
 EOF
 
+cat <<EOF >> user_nl_clm
+! finidat=''
+EOF
+
 ### NOTES ON COMMON NAMELIST OPTIONS ###
 
 ### ATMOSPHERE NAMELIST ###


### PR DESCRIPTION
This implements fixes to branch runs to make running them faster and easier.
It also prepends machine to the case name again.