### PR TITLE
fix config file for anlworkstation. Removed PROXY tag.

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -687,7 +687,6 @@
 <machine MACH="anlworkstation">
     <DESC>Linux workstation for ANL</DESC>
     <NODENAME_REGEX>compute.*mcs.anl.gov</NODENAME_REGEX>
-    <PROXY></PROXY>
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu</COMPILERS>


### PR DESCRIPTION
The empty <PROXY></PROXY> tag in anlworkstation machine config is causing an error in create_newcase
ERROR: No variable PROXY found in case

Removing the tag fixes the problem.

