### PR TITLE
Machine file change for Livermore Computing compatability with new CIME

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -1358,14 +1358,14 @@
 	   <cmd_path lang="sh">use</cmd_path>
 	   <cmd_path lang="csh">use</cmd_path>
 	   <modules compiler="pgi">
-	     <command name="q">pgi-14.3</command>
-	     <command name="q">mvapich2-pgi-1.7</command>
-	     <command name="q">netcdf-pgi-4.1.3</command>
+	     <command name="-q">pgi-14.3</command>
+	     <command name="-q">mvapich2-pgi-1.7</command>
+	     <command name="-q">netcdf-pgi-4.1.3</command>
 	   </modules>
 	   <modules compiler="intel">
-	     <command name="q">ic-17.0.174</command>
-	     <command name="q">mvapich2-intel-2.1</command>
-	     <command name="q">netcdf-intel-4.1.3</command>
+	     <command name="-q">ic-17.0.174</command>
+	     <command name="-q">mvapich2-intel-2.1</command>
+	     <command name="-q">netcdf-intel-4.1.3</command>
 	   </modules>
 	 </module_system>
 	 <environment_variables compiler="pgi">
@@ -1414,14 +1414,14 @@
 	   <cmd_path lang="sh">use</cmd_path>
 	   <cmd_path lang="csh">use</cmd_path>
 	   <modules compiler="pgi">
-	     <command name="q">pgi-14.3</command>
-	     <command name="q">mvapich2-pgi-1.7</command>
-	     <command name="q">netcdf-pgi-4.1.3</command>
+	     <command name="-q">pgi-14.3</command>
+	     <command name="-q">mvapich2-pgi-1.7</command>
+	     <command name="-q">netcdf-pgi-4.1.3</command>
 	   </modules>
 	   <modules compiler="intel">
-	     <command name="q">ic-17.0.174</command>
-	     <command name="q">mvapich2-intel-2.1</command>
-	     <command name="q">netcdf-intel-4.1.3</command>
+	     <command name="-q">ic-17.0.174</command>
+	     <command name="-q">mvapich2-intel-2.1</command>
+	     <command name="-q">netcdf-intel-4.1.3</command>
 	   </modules>
 	 </module_system>
 	 <environment_variables compiler="pgi">


### PR DESCRIPTION
Makes changes to config_machines.xml file for the Livermore Computing
cluseter Cab and Syrah to be compatible with the new updates to CIME.

[BFB] - Bit-For-Bit

See confluence for a more detailed description about these tags.