### PR TITLE
Slightly loosen the XSD xml specification for env_mach_specific

### DIFF
--- a/cime/config/xml_schemas/env_mach_specific.xsd
+++ b/cime/config/xml_schemas/env_mach_specific.xsd
@@ -81,7 +81,7 @@
 
   <xs:element name="command">
     <xs:complexType mixed="true">
-      <xs:attribute name="name" use="required" type="xs:NCName"/>
+      <xs:attribute name="name" use="required" type="xs:string"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="environment_variables">


### PR DESCRIPTION
Allow any string for a module command name instead of requiring it
to be a proper name. This allows us to support module systems that
pass options (-XXX) instead of just arguments.

[BFB]