### PR TITLE
Clean-up e3sm config_grids by removing cism grids and some pop grids

### DIFF
--- a/cime/config/acme/config_grids.xml
+++ b/cime/config/acme/config_grids.xml
@@ -399,6 +399,24 @@
       <alias>armx8v3_armx8v3</alias>
     </grid>
 
+    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
+      <sname>ne0np4_conus_x4v1_lowcon_ne0np4_conus_x4v1_lowcon</sname>
+      <lname>    a%ne0np4_conus_x4v1_lowcon_l%ne0np4_conus_x4v1_lowcon_oi%ne0np4_conus_x4v1_lowcon_r%null_m%tx0.1v2_g%null_w%null</lname>
+      <alias>conusx4v1_conusx4v1</alias>
+    </grid>
+
+    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
+      <sname>ne0np4_svalbard_x8v1_lowcon_ne0np4_svalbard_x8v1_lowcon</sname>
+      <lname>    a%ne0np4_svalbard_x8v1_lowcon_l%ne0np4_svalbard_x8v1_lowcon_oi%ne0np4_svalbard_x8v1_lowcon_r%null_m%tx0.1v2_g%null_w%null</lname>
+      <alias>svalbardx8v1_svalbardx8v1</alias>
+    </grid>
+
+    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
+      <sname>ne0np4_sooberingoa_x4x8v1_lowcon_ne0np4_sooberingoa_x4x8v1_lowcon</sname>
+      <lname>    a%ne0np4_sooberingoa_x4x8v1_lowcon_l%ne0np4_sooberingoa_x4x8v1_lowcon_oi%ne0np4_sooberingoa_x4x8v1_lowcon_r%null_m%tx0.1v2_g%null_w%null</lname>
+      <alias>sooberingoax4x8v1_sooberingoax4x8v1</alias>
+    </grid>
+
     <!-- ENA RRM grid (all components) -->
     <grid compset="(DOCN|XOCN|SOCN|AQP1)">
       <sname>ne0np4_enax4v1_ne0np4_enax4v1</sname>


### PR DESCRIPTION
Clean up the config_grid.xml file for E3SM, removing all definitions of CISM grids as well as references to POP grids other than g16 and g37. Specifically, it removes the following grids:
* POP grids other than g16 and g37:
    T85_0.9x1.25_tx0.1v2
    T341_0.23x0.31_tx0.1v2
    T62_tx1v1
    T62_tx0.1v2
    0.23x0.31_tx0.1v2
    0.47x0.63_tx0.1v2
    ne120np4_tx0.1v2
    ne240np4_tx0.1v2
* CISM grids:
    T31_gx3v7_gland4
    T31_gx3v7_gland10
    T31_gx3v7_gland20
    0.9x1.25_gx1v6_gland4
    0.9x1.25_gx1v6_gland10
    0.9x1.25_gx1v6_gland20
    1.9x2.5_gx1v6_gland4
    1.9x2.5_1.9x2.5_gland10

[BFB]