### PR TITLE
Variable name change to MAX_MPITASKS_PER_NODE for edison

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -85,8 +85,8 @@
     <arguments>
       <arg name="label"> --label</arg>
       <arg name="num_tasks" > -n $TOTALPES</arg>
-      <arg name="thread_count"> -c $SHELL{echo 48/`./xmlquery --value MAX_TASKS_PER_NODE`*$ENV{OMP_NUM_THREADS} | bc }</arg>
-      <arg name="binding"> $SHELL{if [ 24 -ge `./xmlquery --value MAX_TASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads"; fi} </arg>
+      <arg name="thread_count"> -c $SHELL{echo 48/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
+      <arg name="binding"> $SHELL{if [ 24 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
     </arguments>
   </mpirun>
   <module_system type="module">


### PR DESCRIPTION
For edison only: 
Variable name change to MAX_MPITASKS_PER_NODE
And modify -c flag to account for threads.  If using hyper-threads, make sure to change MAX_TASKS_PER_NODE.
No change if not using threads.
[BFB]