### PR TITLE
Remove hardcoded mail option for PBS

### DIFF
--- a/cime/config/acme/machines/config_batch.xml
+++ b/cime/config/acme/machines/config_batch.xml
@@ -35,27 +35,27 @@
     </directives>
   </batch_system>
 
-   <batch_system type="cobalt" >
-     <batch_query>qstat</batch_query>
-     <batch_submit>qsub</batch_submit>
-     <batch_cancel>qdel</batch_cancel>
-     <batch_env>-v</batch_env>
-     <batch_directive></batch_directive>
-     <jobid_pattern>(\d+)</jobid_pattern>
-     <depend_string> --dependencies</depend_string>
-     <walltime_format>%H:%M:%s</walltime_format>
-     <batch_mail_flag>-M</batch_mail_flag>
-     <batch_mail_type_flag></batch_mail_type_flag>
-     <batch_mail_type></batch_mail_type>
-     <submit_args>
-       <arg flag="--cwd" name="CASEROOT"/>
-       <arg flag="-A" name="PROJECT"/>
-       <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
-       <arg flag="-n" name=" ($TOTALPES + $MAX_MPITASKS_PER_NODE - 1)/$MAX_MPITASKS_PER_NODE"/>
-       <arg flag="-q" name="JOB_QUEUE"/>
-       <arg flag="--mode script"/>
-     </submit_args>
-   </batch_system>
+  <batch_system type="cobalt" >
+    <batch_query>qstat</batch_query>
+    <batch_submit>qsub</batch_submit>
+    <batch_cancel>qdel</batch_cancel>
+    <batch_env>-v</batch_env>
+    <batch_directive></batch_directive>
+    <jobid_pattern>(\d+)</jobid_pattern>
+    <depend_string> --dependencies</depend_string>
+    <walltime_format>%H:%M:%s</walltime_format>
+    <batch_mail_flag>-M</batch_mail_flag>
+    <batch_mail_type_flag></batch_mail_type_flag>
+    <batch_mail_type></batch_mail_type>
+    <submit_args>
+      <arg flag="--cwd" name="CASEROOT"/>
+      <arg flag="-A" name="PROJECT"/>
+      <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
+      <arg flag="-n" name=" ($TOTALPES + $MAX_MPITASKS_PER_NODE - 1)/$MAX_MPITASKS_PER_NODE"/>
+      <arg flag="-q" name="JOB_QUEUE"/>
+      <arg flag="--mode script"/>
+    </submit_args>
+  </batch_system>
 
   <batch_system type="cobalt_theta" >
     <batch_query>qstat</batch_query>


### PR DESCRIPTION
Machines with these batch systems should use the standard way to setup mailing options
(flags to case.submit) instead of hardcoding it into config_batch.

[BFB]