### PR TITLE
Enable performance data archiving on Theta

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -1587,6 +1587,7 @@
     <DOUT_L_MSROOT>$CIME_OUTPUT_ROOT/csm/$CASE</DOUT_L_MSROOT>
     <BASELINE_ROOT>/projects/$PROJECT/acme/baselines</BASELINE_ROOT>
     <CCSM_CPRNC>/projects/$PROJECT/acme/tools/cprnc/cprnc</CCSM_CPRNC>
+    <SAVE_TIMING_DIR>/projects/OceanClimate</SAVE_TIMING_DIR>
     <OS>CNL</OS>
     <BATCH_SYSTEM>cobalt_theta</BATCH_SYSTEM>
     <SUPPORTED_BY>acme</SUPPORTED_BY>
@@ -1607,6 +1608,9 @@
       </arguments>
     </mpirun>
     <environment_variables>
+      <env name="MPICH_ENV_DISPLAY">1</env>
+      <env name="MPICH_VERSION_DISPLAY">1</env>
+      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
       <env name="SMP_VARS"></env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">

--- a/cime/config/acme/machines/syslog.theta
+++ b/cime/config/acme/machines/syslog.theta
@@ -1,0 +1,69 @@
+#!/bin/csh -f
+# theta syslog script: 
+#  mach_syslog <sampling interval (in seconds)> <job identifier> <timestamp> <run directory> <timing directory> <output directory> 
+
+set sample_interval = $1
+set jid = $2
+set lid = $3
+set run = $4
+set timing = $5
+set dir = $6
+
+# Wait until some model output appears before saving output file.
+# Target length was determined empirically (more lines than number of MPICH environment variables), 
+#  so it may need to be adjusted in the future.
+# (Note that calling script 'touch'es the acme log file before spawning this script, so that 'wc' does not fail.)
+set outtarget = 130
+set outlth = 0
+while ($outlth < $outtarget)
+  sleep 10
+  set outlth = `wc \-l $run/acme.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
+end
+
+set TimeRemaining = `qstat -l --header TimeRemaining $jid | grep -F TimeRemaining | sed 's/^ *TimeRemaining *: *\([0-9]*:[0-9]*:[0-9]*\) */\1/' `
+set rem_hours     = `echo $TimeRemaining | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
+set rem_mins      = `echo $TimeRemaining | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
+set rem_secs      = `echo $TimeRemaining | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
+if ("X$rem_hours" == "X") set rem_hours = 0
+if ("X$rem_mins" == "X")  set rem_mins  = 0
+if ("X$rem_secs" == "X")  set rem_secs  = 0
+@ remaining = 3600 * $rem_hours + 60 * $rem_mins + $rem_secs
+cat > $run/Walltime.Remaining <<EOF1
+$remaining $sample_interval
+EOF1
+/bin/cp --preserve=timestamps $run/acme.log.$lid $dir/acme.log.$lid.$remaining
+xtnodestat > $dir/xtnodestat.$lid.$remaining
+
+while ($remaining > 0)
+  echo "Wallclock time remaining: $remaining" >> $dir/atm.log.$lid.step
+  grep -Fa -e "nstep" -e "model date" $run/*atm.log.$lid | tail -n 4 >> $dir/atm.log.$lid.step
+  echo "Wallclock time remaining: $remaining" >> $dir/lnd.log.$lid.step
+  grep -Fa -e "timestep" -e "model date" $run/*lnd.log.$lid | tail -n 4 >> $dir/lnd.log.$lid.step
+  echo "Wallclock time remaining: $remaining" >> $dir/ocn.log.$lid.step
+  grep -Fa -e "timestep" -e "Step number" -e "model date" $run/*ocn.log.$lid | tail -n 4 >> $dir/ocn.log.$lid.step
+  echo "Wallclock time remaining: $remaining" >> $dir/ice.log.$lid.step
+  grep -Fa -e "timestep" -e "istep" -e "model date" $run/*ice.log.$lid | tail -n 4 >> $dir/ice.log.$lid.step
+  echo "Wallclock time remaining: $remaining" >> $dir/rof.log.$lid.step
+  grep -Fa "model date" $run/*rof.log.$lid | tail -n 4 >> $dir/rof.log.$lid.step
+  grep -Fa "model date" $run/*cpl.log.$lid  > $dir/cpl.log.$lid.step-all
+  echo "Wallclock time remaining: $remaining" >> $dir/cpl.log.$lid.step
+  tail -n 4 $dir/cpl.log.$lid.step-all >> $dir/cpl.log.$lid.step
+  /bin/cp --preserve=timestamps -u $timing/* $dir
+  xtnodestat > $dir/xtnodestat.$lid.$remaining
+  qstat --header JobID:State:Nodes:Location | grep -Fa -e "running" -e "State" -e "starting" -e "exiting" > $dir/qstatn.$lid.$remaining
+  qstat --header JobID:JobName:User:Project:WallTime:RunTime:TimeRemaining:Nodes:State:StartTime:attrs | grep -Fa -e "running" -e "State" -e "starting" -e "exiting" > $dir/qstatr.$lid.$remaining
+  chmod a+r $dir/*
+  sleep $sample_interval
+  set TimeRemaining = `qstat -l --header TimeRemaining $jid | grep -F TimeRemaining | sed 's/^ *TimeRemaining *: *\([0-9]*:[0-9]*:[0-9]*\) */\1/' `
+  set rem_hours     = `echo $TimeRemaining | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
+  set rem_mins      = `echo $TimeRemaining | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
+  set rem_secs      = `echo $TimeRemaining | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
+  if ("X$rem_hours" == "X") set rem_hours = 0
+  if ("X$rem_mins" == "X")  set rem_mins  = 0
+  if ("X$rem_secs" == "X")  set rem_secs  = 0
+  @ remaining = 3600 * $rem_hours + 60 * $rem_mins + $rem_secs
+  cat > $run/Walltime.Remaining << EOF2
+$remaining $sample_interval
+EOF2
+
+end


### PR DESCRIPTION
Added support for archiving performance data and associated provenance
of E3SM jobs on theta. If the user is a member of the OceanClimate
group then the data will be saved in performance_archive/ in
/projects/OceanClimate . Otherwise the performance data archiving
logic is disabled.

[BFB]