### PR TITLE
Move graph file specifications from streams to build-namelists

### DIFF
--- a/components/mpas-cice/bld/build-namelist
+++ b/components/mpas-cice/bld/build-namelist
@@ -1127,8 +1127,23 @@ my $outfile = "./mpas-cice_in";
 $nl->write($outfile, 'groups'=>\@groups);
 if ($print>=2) { print "Writing mpas-cice ice component namelist to $outfile $eol"; }
 
+#--------------------------------------------------------------------
+# Append namelist specified files to input data file
+#     currently just the graph file -- which is complicated because the prefix
+#     is set in the namelist and the suffix comes from the number of tasks
+#--------------------------------------------------------------------
+
+open(my $input_list, ">>", "$CASEBUILD/mpas-cice.input_data_list") or
+     die "** can't open filepath file: mpas-cice.input_data_list\n";
+my $block_decomp_file_prefix = $nl->get_value( 'config_block_decomp_file_prefix' );
+# remove quotes for concatenation
+$block_decomp_file_prefix =~ s/['"]//g;
+my $block_decomp_file = $block_decomp_file_prefix . $NTASKS_ICE;
+print $input_list "graph$NTASKS_ICE = $block_decomp_file\n";
+$input_list->close;
+
 # Write input dataset list.
-check_input_files($DIN_LOC_ROOT, "../mpas-cice.input_data_list");
+check_input_files($DIN_LOC_ROOT, "$CASEBUILD/mpas-cice.input_data_list");
 
 #-----------------------------------------------------------------------------------------------
 # END OF MAIN SCRIPT

--- a/components/mpas-cice/cime_config/buildnml
+++ b/components/mpas-cice/cime_config/buildnml
@@ -144,13 +144,11 @@ if ( $ICE_GRID eq 'oEC60to30' ) {
 chdir "$CASEBUILD/mpas-ciceconf";
 
 #--------------------------------------------------------------------
-# Generate input data file
+# Generate input data file with stream-specified files
 #--------------------------------------------------------------------
 
 open(my $input_list, "+>", "$CASEBUILD/mpas-cice.input_data_list");
 print $input_list "mesh = $DIN_LOC_ROOT/ice/mpas-cice/$ICE_MASK/$grid_prefix.$grid_date.nc\n";
-#print $input_list "full_graph = $DIN_LOC_ROOT/ice/mpas-cice/$ICE_GRID/$decomp_prefix$grid_date\n";
-print $input_list "graph$NTASKS_ICE = $DIN_LOC_ROOT/ice/mpas-cice/$ICE_MASK/$decomp_prefix$decomp_date.part.$NTASKS_ICE\n";
 close($input_list);
 
 #--------------------------------------------------------------------

--- a/components/mpas-o/bld/build-namelist
+++ b/components/mpas-o/bld/build-namelist
@@ -1491,13 +1491,28 @@ for my $var ($nl->get_variable_names('derived')) {
   $nl->set_variable_value($broken[1], $broken[0], $val);
 }
 
-# Write out all groups  to mpas-o_in
+# Write out all groups to mpas-o_in
 my $outfile = "./mpas-o_in";
 $nl->write($outfile, 'groups'=>\@groups);
 if ($print>=2) { print "Writing mpas-o ocean component namelist to $outfile $eol"; }
 
+#--------------------------------------------------------------------
+# Append namelist specified files to input data file
+#     currently just the graph file -- which is complicated because the prefix
+#     is set in the namelist and the suffix comes from the number of tasks
+#--------------------------------------------------------------------
+
+open(my $input_list, ">>", "$CASEBUILD/mpas-o.input_data_list") or
+     die "** can't open filepath file: mpas-o.input_data_list\n";
+my $block_decomp_file_prefix = $nl->get_value( 'config_block_decomp_file_prefix' );
+# remove quotes for concatenation
+$block_decomp_file_prefix =~ s/['"]//g;
+my $block_decomp_file = $block_decomp_file_prefix . $NTASKS_OCN;
+print $input_list "graph$NTASKS_OCN = $block_decomp_file\n";
+$input_list->close;
+
 # Write input dataset list.
-check_input_files($DIN_LOC_ROOT, "../mpas-o.input_data_list");
+check_input_files($DIN_LOC_ROOT, "$CASEBUILD/mpas-o.input_data_list");
 
 #-----------------------------------------------------------------------------------------------
 # END OF MAIN SCRIPT

--- a/components/mpas-o/cime_config/buildnml
+++ b/components/mpas-o/cime_config/buildnml
@@ -159,7 +159,7 @@ if ($OCN_FORCING eq 'core_forced') {
 }
 
 #--------------------------------------------------------------------
-# Generate input data file
+# Generate input data file with stream-specified files
 #--------------------------------------------------------------------
 
 open(my $input_list, "+>", "$CASEBUILD/mpas-o.input_data_list");
@@ -171,8 +171,6 @@ if ($moc_mask_file ne '') {
 if ( $OCN_FORCING eq 'core_forced_restoring' ) {
 	print $input_list "sss = $DIN_LOC_ROOT/ocn/mpas-o/$OCN_MASK/$restoring_file\n";
 }
-#print $input_list "full_graph = $DIN_LOC_ROOT/ocn/mpas-o/$OCN_MASK/$decomp_prefix$decomp_date\n";
-print $input_list "graph$NTASKS_OCN = $DIN_LOC_ROOT/ocn/mpas-o/$OCN_MASK/$decomp_prefix$decomp_date.part.$NTASKS_OCN\n";
 close($input_list);
 
 #--------------------------------------------------------------------

--- a/components/mpasli/bld/build-namelist
+++ b/components/mpasli/bld/build-namelist
@@ -610,8 +610,23 @@ my $outfile = "./mpasli_in";
 $nl->write($outfile, 'groups'=>\@groups);
 if ($print>=2) { print "Writing mpasli glc component namelist to $outfile $eol"; }
 
+#--------------------------------------------------------------------
+# Append namelist specified files to input data file
+#     currently just the graph file -- which is complicated because the prefix
+#     is set in the namelist and the suffix comes from the number of tasks
+#--------------------------------------------------------------------
+
+open(my $input_list, ">>", "$CASEBUILD/mpasli.input_data_list") or
+     die "** can't open filepath file: mpasli.input_data_list\n";
+my $block_decomp_file_prefix = $nl->get_value( 'config_block_decomp_file_prefix' );
+# remove quotes for concatenation
+$block_decomp_file_prefix =~ s/['"]//g;
+my $block_decomp_file = $block_decomp_file_prefix . $NTASKS_GLC;
+print $input_list "graph$NTASKS_GLC = $block_decomp_file\n";
+$input_list->close;
+
 # Write input dataset list.
-check_input_files($DIN_LOC_ROOT, "../mpasli.input_data_list");
+check_input_files($DIN_LOC_ROOT, "$CASEBUILD/mpasli.input_data_list");
 
 #-----------------------------------------------------------------------------------------------
 # END OF MAIN SCRIPT

--- a/components/mpasli/cime_config/buildnml
+++ b/components/mpasli/cime_config/buildnml
@@ -58,13 +58,11 @@ if ( $GLC_GRID eq 'mpas.gis20km' ) {
 chdir "$CASEBUILD/mpasliconf";
 
 #--------------------------------------------------------------------
-# Generate input data file
+# Generate input data file with stream-specified files
 #--------------------------------------------------------------------
 
 open(my $input_list, "+>", "$CASEBUILD/mpasli.input_data_list");
 print $input_list "mesh = $DIN_LOC_ROOT/glc/mpasli/$GLC_GRID/$grid_prefix.$grid_date.nc\n";
-#print $input_list "full_graph = $DIN_LOC_ROOT/glc/mpasli/$GLC_GRID/$decomp_prefix$grid_date\n";
-print $input_list "graph$NTASKS_GLC = $DIN_LOC_ROOT/glc/mpasli/$GLC_GRID/$decomp_prefix$grid_date.part.$NTASKS_GLC\n";
 close($input_list);
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
This PR moves the MPAS graph file specification for all three E3SM components from the scripts that build the associated streams files to the build-namelist scripts. This allows users to point to different graph file locations via the user_nl files to set "config_block_decomp_file_prefix" -- and then use or test different graph files without committing them to the inputdata repo.

Fixes #1276 
Fixes #1651 

[BFB]