### PR TITLE
HOMME Intel/17 compiler bug workaround.  

### DIFF
--- a/components/homme/src/preqx/share/prim_advance_mod.F90
+++ b/components/homme/src/preqx/share/prim_advance_mod.F90
@@ -942,8 +942,13 @@ contains
               do j=1,np
                  do i=1,np
                     ! update v first (gives better results than updating v after heating)
-                    elem(ie)%state%v(i,j,:,k,nt)=elem(ie)%state%v(i,j,:,k,nt) + &
-                         vtens(i,j,:,k,ie)
+                    ! intel/17 compiler bug on Edison produces incorrect results with this:
+                    !elem(ie)%state%v(i,j,:,k,nt)=elem(ie)%state%v(i,j,:,k,nt) + &
+                    !     vtens(i,j,:,k,ie)
+                    elem(ie)%state%v(i,j,1,k,nt)=elem(ie)%state%v(i,j,1,k,nt) + &
+                         vtens(i,j,1,k,ie)
+                    elem(ie)%state%v(i,j,2,k,nt)=elem(ie)%state%v(i,j,2,k,nt) + &
+                         vtens(i,j,2,k,ie)
 
                     v1=elem(ie)%state%v(i,j,1,k,nt)
                     v2=elem(ie)%state%v(i,j,2,k,nt)


### PR DESCRIPTION
Fixes #1680

HOMME bug with Intel17 on Edison.
using the baro2d test case:

Edison:  (Ivy Bridge)
Intel/16.0.3.210   PASS
intel/17.0.1.132   FAIL
intel/17.0.2.174   FAIL  (pass with -O1)
intel/17.0.4           FAIL  (module from Brian Dobbins)
intel/18.0.0.128   PASS

Anvil (Haswell system at ANL)
Intel 17.0.0   PASS

The workaround in this PR fixes the problem.  The arrays in the
changed code are actually correct - it's some other arrays that get
corrupted without this workaround.  One guess is that the compiler is getting the indices
for the ":" array syntax incorrect and overflowing into other state
variables.

[non-BFB] - only for cases run with Intel17 and a full atmosphere.