### PR TITLE
Add wallclock output to timestep output in ocean and sea-ice

### DIFF
--- a/components/mpas-cice/driver/ice_comp_mct.F
+++ b/components/mpas-cice/driver/ice_comp_mct.F
@@ -737,8 +737,9 @@ contains
       type (MPAS_Pool_type), pointer :: &
             shortwave
 
+      real (kind=RKIND) :: current_wallclock_time
       type (MPAS_Time_Type) :: currTime
-      character(len=StrKIND) :: timeStamp, streamName
+      character(len=StrKIND) :: timeStamp, streamName, WCstring
       type (MPAS_timeInterval_type) :: timeStep
       integer :: ierr, streamDirection, iam
       logical :: streamActive, debugOn
@@ -817,7 +818,9 @@ contains
         currTime = mpas_get_clock_time(domain % clock, MPAS_NOW, ierr)
         call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=ierr)
         ! write time stamp on every step
-        call mpas_log_write('Doing timestep ' // trim(timeStamp))
+        call mpas_dmpar_get_time(current_wallclock_time)
+        write (WCstring,'(F18.3)') current_wallclock_time
+        call mpas_log_write(trim(timeStamp) // '  WC time:' // WCstring)
 
         ! pre-timestep analysis computation
         if (debugOn) call mpas_log_write('   Starting analysis precompute', masterOnly=.true.)

--- a/components/mpas-o/driver/ocn_comp_mct.F
+++ b/components/mpas-o/driver/ocn_comp_mct.F
@@ -811,14 +811,15 @@ contains
       integer :: ymd, tod, ihour, iminute, isecond
       integer :: iyear, imonth, iday, curr_ymd, curr_tod
       integer :: shrloglev, shrlogunit
-      real (kind=RKIND) :: dt
+      real (kind=RKIND) :: dt, current_wallclock_time
+
       type (block_type), pointer :: block_ptr
 
       type (mpas_pool_type), pointer :: meshPool, statePool, diagnosticsPool, forcingPool, averagePool, scratchPool
 
       type (MPAS_Time_Type) :: currTime
       type (domain_type), pointer :: domain_ptr
-      character(len=StrKIND) :: timeStamp, streamName
+      character(len=StrKIND) :: timeStamp, streamName, WCstring
       type (MPAS_timeInterval_type) :: timeStep
       integer :: iam, ierr, streamDirection
       logical :: streamActive, debugOn
@@ -897,7 +898,9 @@ contains
          currTime = mpas_get_clock_time(domain_ptr % clock, MPAS_NOW, ierr)
          call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=ierr)
          ! write time stamp at every step
-         call mpas_log_write('Doing timestep ' // trim(timeStamp))
+         call mpas_dmpar_get_time(current_wallclock_time)
+         write (WCstring,'(F18.3)') current_wallclock_time
+         call mpas_log_write(trim(timeStamp) // '  WC time:' // WCstring)
 
          ! Build forcing arrays.
          if (debugOn) call mpas_log_write('   Building forcing arrays')


### PR DESCRIPTION
Right now, wall clock time output is limited to once per simulated day. This adds WC time output on each time step so we can monitor machine variability and i/o delays.
Fixes #1905
[BFB]