### PR TITLE
Restore Makefile for gptl

### DIFF
--- a/cime/src/share/timing/Makefile
+++ b/cime/src/share/timing/Makefile
@@ -4,6 +4,14 @@
 
 VPATH := $(GPTL_DIR)
 
+# Determine whether to compile threaded or not
+ifeq ($(strip $(BUILD_THREADED)),TRUE)
+   compile_threaded = true
+endif
+ifeq ($(strip $(SMP)),TRUE)
+   compile_threaded = true
+endif
+
 ifndef MOD_SUFFIX
    MOD_SUFFIX := mod
 endif


### PR DESCRIPTION
Will now pass openmpi flags.

Fixes #1945 

[BFB]