### PR TITLE
Increases length of land htape name

### DIFF
--- a/components/clm/src/main/histFileMod.F90
+++ b/components/clm/src/main/histFileMod.F90
@@ -149,7 +149,7 @@ module histFileMod
   ! !PRIVATE TYPES:
   ! Constants
   !
-  integer, parameter :: max_chars = 128        ! max chars for char variables
+  integer, parameter :: max_chars = 256        ! max chars for char variables
   integer, parameter :: max_subs = 100         ! max number of subscripts
   integer            :: num_subs = 0           ! actual number of subscripts
   character(len=32)  :: subs_name(max_subs)    ! name of subscript


### PR DESCRIPTION
Length of filename for land history tape is increased
from 128 to 256 characters.

[BFB]