### PR TITLE
Add option to pass all cloud as stratiform to COSP (CMDV-MCS branch)

### DIFF
--- a/cime/cime_config/acme/machines/config_machines.xml
+++ b/cime/cime_config/acme/machines/config_machines.xml
@@ -783,7 +783,7 @@
   <COMPILERS>intel</COMPILERS>
   <MPILIBS>openmpi</MPILIBS>
   <OS>LINUX</OS>
-  <CESMSCRATCHROOT>/gscratch/$USER/acme_scratch/skybridge</CESMSCRATCHROOT>
+  <CESMSCRATCHROOT>/gscratch/$USER/acme_scratch/ghost</CESMSCRATCHROOT>
   <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
   <DIN_LOC_ROOT>/projects/ccsm/inputdata</DIN_LOC_ROOT>

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -2104,6 +2104,19 @@ This default logical is set in cospsimulator_intr.F90
 Default: FALSE
 </entry>
 
+<entry id="cosp_separate_convection" type="logical"  category="cosp"
+       group="cospsimulator_nl" valid_values="">
+Whether or not to distinguish between convective and stratiform clouds when
+generating subcolumns for COSP. If false, all cloud properties are passed as
+stratiform. If true, stratiform and convective cloud properties are passed
+separately, and SCOPS will maximally overlap convective cloud and apply
+maximum-random overlap to the stratiform cloud. We set the default to true to
+preserve backwards compatibility, and if convective cloud properties are not
+found then the code will set this to false and throw a warning.
+Default: TRUE 
+</entry>
+
+
 <!-- Cloud Macro/Micro-physics -->
 
 <entry id="cld_macmic_num_steps" type="integer" category="conv"


### PR DESCRIPTION
Add option to pass all cloud and precipitation properties as stratiform
to COSP. This is needed when the deep convective scheme is turned off,
because the convective fields are only defined in within the deep
convective scheme. So when we want to run CLUBB-SILHS with
deep_scheme='off', then runs with COSP will fail when it tries to look
for these. The new behavior is to look for the presence of these fields,
and if they do not exist then all cloud properties will be passed as
stratiform. A namelist variable is added (cosp_separate_convection) to
control this in runs that do have deep_scheme on for debugging purposes.