### PR TITLE
Update fsnowoptics file for high-res compsets

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01a.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01a.xml
@@ -40,7 +40,7 @@
 <history_aero_optics>.true.</history_aero_optics>
 
 <!-- File for BC dep in snow feature -->
-<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c140303.nc</fsnowoptics>
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
 
 <!-- Radiation bugfix -->
 <use_rad_dt_cosz>.true.</use_rad_dt_cosz>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01b.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01b.xml
@@ -40,7 +40,7 @@
 <history_aero_optics>.true.</history_aero_optics>
 
 <!-- File for BC dep in snow feature -->
-<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c140303.nc</fsnowoptics>
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
 
 <!-- Radiation bugfix -->
 <use_rad_dt_cosz>.true.</use_rad_dt_cosz>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01a.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01a.xml
@@ -45,7 +45,7 @@
 <history_aero_optics>.true.</history_aero_optics>
 
 <!-- File for BC dep in snow feature -->
-<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c140303.nc</fsnowoptics>
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
 
 <!-- Radiation bugfix -->
 <use_rad_dt_cosz>.true.</use_rad_dt_cosz>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01b.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01b.xml
@@ -45,7 +45,7 @@
 <history_aero_optics>.true.</history_aero_optics>
 
 <!-- File for BC dep in snow feature -->
-<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c140303.nc</fsnowoptics>
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
 
 <!-- Radiation bugfix -->
 <use_rad_dt_cosz>.true.</use_rad_dt_cosz>


### PR DESCRIPTION
Comparing 1850_cam5_av1c-h0* against 1850_cam5_av1c-0* (i.e.
high-res vs low res versions of the 1850 F and B compsets)
revealed that high-res compsets were using an older version
of the fsnowoptics file, which had been updated by Hailong for
black-carbon-on-snow improvements. Hailong confirmed that the
new file should always be used, so this update makes that happen.

	modified:   1850_cam5_av1c-h01a.xml
	modified:   1850_cam5_av1c-h01b.xml
	modified:   20TR_cam5_av1c-h01a.xml
	modified:   20TR_cam5_av1c-h01b.xml

Non-BFB for affected (h01*) compsets only