### PR TITLE
Fixes a misplaced xml block in config_machines.xml for eos machine

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -2332,15 +2332,15 @@
 	     <command name="load">cmake3/3.2.3</command>
 	     <command name="load">python/2.7.9</command>
 	   </modules>
-	   <environment_variables>
-	     <env name="MPICH_ENV_DISPLAY">1</env>
-	     <env name="MPICH_VERSION_DISPLAY">1</env>
-	     <!-- This increases the stack size, which is necessary
-		  for CICE to run threaded on this machine -->
-	     <env name="OMP_STACKSIZE">64M</env>
-
-	   </environment_variables>
 	 </module_system>
+	 <environment_variables>
+	   <env name="MPICH_ENV_DISPLAY">1</env>
+	   <env name="MPICH_VERSION_DISPLAY">1</env>
+	   <!-- This increases the stack size, which is necessary
+		for CICE to run threaded on this machine -->
+	   <env name="OMP_STACKSIZE">64M</env>
+	   
+	 </environment_variables>
 </machine>
 
 <machine MACH="grizzly">


### PR DESCRIPTION
This PR fixes a misplaced xml tag so that the setup process completes
without errors on eos machine.

[BFB] - Bit-For-Bit