### PR TITLE
Fix config on blues for Albany build

### DIFF
--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -1185,6 +1185,8 @@ for mct, etc.
   <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
   <GPTL_CPPDEFS> -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY</GPTL_CPPDEFS>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
+  <CXX_LIBS>-lstdc++</CXX_LIBS>
+  <ALBANY_PATH>/soft/climate/AlbanyTrilinos_06262017/Albany/build/install</ALBANY_PATH>
 </compiler>
 
 <compiler COMPILER="nag" MACH="blues">


### PR DESCRIPTION
This fixes the failing MPASLIALB test on Blues, according to my tests.

I just ran the MPASLIALB test using create_test. This will not influence any other test.

BFB (except to clear up one fail on blues)