### PR TITLE
Fixes the data type for eddyProduct output

### DIFF
--- a/components/mpas-o/cime_config/buildnml
+++ b/components/mpas-o/cime_config/buildnml
@@ -609,7 +609,11 @@ if ( -e "$CASEROOT/SourceMods/src.mpaso/$STREAM_NAME" ) {
 	print $stream_file '' . "\n";
 	print $stream_file '<stream name="eddyProductVariablesOutput"' . "\n";
 	print $stream_file '        type="output"' . "\n";
-	print $stream_file '        io_type="' . "$OCN_PIO_TYPENAME" . '"' . "\n";
+	if ( $OCN_GRID =~ m/^oRRS1/ ) {
+        	print $stream_file '        io_type="pnetcdf,cdf5"' . "\n";
+        } else {
+		print $stream_file '        io_type="' . "$OCN_PIO_TYPENAME" . '"' . "\n";
+        }
 	print $stream_file '        filename_template="mpaso.hist.am.eddyProductVariables.$Y-$M-$D.nc"' . "\n";
 	print $stream_file '        filename_interval="00-01-00_00:00:00"' . "\n";
 	print $stream_file '        reference_time="01-01-01_00:00:00"' . "\n";


### PR DESCRIPTION
When the eddy Product analysis is enabled for the 18to6v3 grid, the
io_type did not select cdf5, which is required for a valid netcdf file
to be written.