### PR TITLE
Update high-res 1/8-degree rof to oRRS18to6v3 ocn map to smoothed

### DIFF
--- a/cime/config/acme/config_grids.xml
+++ b/cime/config/acme/config_grids.xml
@@ -2080,13 +2080,13 @@
     </gridmap>
 
     <gridmap rof_grid="r0125" ocn_grid="oRRS18to6v3" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_nn.170111.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_nn.170111.nc</ROF2OCN_LIQ_RMAPNAME>
+      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_ICE_RMAPNAME>
+      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_LIQ_RMAPNAME>
     </gridmap>
 
     <gridmap rof_grid="r0125" ocn_grid="oRRS18to6v3_ICG" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_nn.170111.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_nn.170111.nc</ROF2OCN_LIQ_RMAPNAME>
+      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_ICE_RMAPNAME>
+      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_LIQ_RMAPNAME>
     </gridmap>
 
     <gridmap rof_grid="r0125" ocn_grid="oRRS15to5" >


### PR DESCRIPTION
This PR updates the mapping file used by the high-res water-cycle compsets from nearest-neighbor to smoothed. The nearest-neighbor mapping was causing issues with the ocean, so some smoothing is required. This new mapping file has been tested in a series of high-res runs on cori-knl and appears to solve the problem. The new file has been uploaded to the svn inputdata server. 

Note: this PR is BFB for all currently tested configurations, but will change answers for the high-res water-cycle compsets. 

[NML]
