### PR TITLE
Add aprun for the jobs that are compiled in mpi-serial on Titan

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -1990,6 +1990,14 @@
 
     </mpirun>
 
+    <mpirun mpilib="mpi-serial">
+      <executable>aprun</executable>
+      <arguments>
+        <arg name="aprun"> {{ aprun }}</arg>
+      </arguments>
+
+    </mpirun>
+
     <module_system type="module">
       <!-- list of init_path elements, one per supported language e.g. sh, perl, python-->
       <init_path lang="sh">/opt/modules/default/init/sh</init_path>


### PR DESCRIPTION
Because the CPU processors in Titan's login, service and compute nodes
are different, the "aprun" command is always required even if the
model is compiled in mpi-serial. This PR is to add the "aprun" command
before "acme.exe" in the batch script on Titan when the model is compiled
in mpi-serial. It will fix the issue #2022

[BFB] - Bit-For-Bit