### PR TITLE
Add environment variable to cori-knl to disable MPICH_GNI_DYNAMIC_CONN (which speeds up initialization)

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -471,9 +471,10 @@
     <env name="OMP_STACKSIZE">128M</env>
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
+  </environment_variables>
 
+  <environment_variables mpilib="mpt">
     <env name="MPICH_GNI_DYNAMIC_CONN">disabled</env>
-
   </environment_variables>
   <environment_variables mpilib="impi">
     <env name="I_MPI_FABRICS">ofi</env>


### PR DESCRIPTION
Add environment variable to cori-knl 
setenv MPICH_GNI_DYNAMIC_CONN=disabled
Only for mpilib=mpt (not for Intel MPI)
This has shown to reduce initialization time -- especially in the atmosphere init.
It may also benefit other machines, but starting with cori-knl.
[BFB]