### PR TITLE
Update to decrease default ocean output for production runs.

### DIFF
--- a/components/mpas-o/cime_config/buildnml
+++ b/components/mpas-o/cime_config/buildnml
@@ -768,6 +768,7 @@ if ( -e "$CASEROOT/SourceMods/src.mpaso/$STREAM_NAME" ) {
 	print $stream_file '    <var name="rainFlux"/>' . "\n";
 	print $stream_file '    <var name="snowFlux"/>' . "\n";
 	print $stream_file '    <var name="vertNonLocalFlux"/>' . "\n";
+	print $stream_file '    <var_array name="activeTracersTend"/>' . "\n";
 	print $stream_file '    <var name="salinitySurfaceRestoringTendency"/>' . "\n";
         print $stream_file '    <var_array name="activeTracerHorizontalAdvectionTendency"/>' . "\n";
         print $stream_file '    <var_array name="activeTracerVerticalAdvectionTendency"/>' . "\n";


### PR DESCRIPTION
This PR brings in changes to decrease the amount of output the mpas-o model creates by default. The  intent is to significantly decrease the amount of IO that must be saved for the upcoming production runs. Tested to make sure a-prime analysis still works with the output.

[BFB]