### PR TITLE
Update PE layouts for cori-knl for F & coupled compsets

### DIFF
--- a/cime/config/acme/allactive/config_pesall.xml
+++ b/cime/config/acme/allactive/config_pesall.xml
@@ -6340,7 +6340,7 @@
         </rootpe>
       </pes>
       <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.*" pesize="T">
-        <comment>"cori-knl ne30 coupled compest on 17 nodes, 67x4, (kmod017) sypd="</comment>
+        <comment>"cori-knl ne30 coupled compest on 17 nodes, 67x4, (kmod017) sypd=1.1"</comment>
         <MAX_MPITASKS_PER_NODE>67</MAX_MPITASKS_PER_NODE>
         <MAX_TASKS_PER_NODE>268</MAX_TASKS_PER_NODE>
         <ntasks>


### PR DESCRIPTION
Improving default PE layouts for cori-knl.
These are the best I could do without making `testmods` which I will consider next.

```
F-compsets
             before           after
ne120 X                  675 64x2 1.95
ne120 L                  323 67x4 1.17           
ne120 A  675 64x2 1.92   162 67x4 0.67
ne120 S                   81 67x4 0.35

ne30 L    80 68x1 5.2     81 67x1 6.08
ne30 A    40 68x2 4.05    41 33x4 4.53         
ne30 S     4 68x2 0.52    21 33x4 2.35
ne30 T                     4 34x8 0.61

ne16  A    3 68x2 1.16     6 67x4 2.85

ne11  A                    6 67x2 11.1

ne4   A    2 64x1 18.8     2 60x1 20.2


coupled hires
       nodes   sypd
Tiny    131    0.25
Small   207    0.32
Any     448    0.56
Large  1025    0.93

coupled lowres
        nodes   sypd
Tiny     17     1.11
Small    31     1.85
Any      60     2.82
Large   125     4.12
```