### PR TITLE
Fix bless_test_results which broke after CIME update

### DIFF
--- a/cime/scripts/lib/CIME/bless_test_results.py
+++ b/cime/scripts/lib/CIME/bless_test_results.py
@@ -1,6 +1,6 @@
 import CIME.compare_namelists, CIME.simple_compare
 from CIME.test_scheduler import NAMELIST_PHASE
-from CIME.utils import run_cmd, expect, get_scripts_root, get_model
+from CIME.utils import run_cmd, expect, get_scripts_root, get_model, EnvironmentContext
 from CIME.test_status import *
 from CIME.hist_utils import generate_baseline, compare_baseline
 from CIME.case import Case
@@ -43,33 +43,35 @@ def bless_namelists(test_name, test_dir, report_only, force, baseline_name, base
 def bless_history(test_name, test_dir, baseline_name, baseline_root, report_only, force):
 ###############################################################################
     with Case(test_dir) as case:
-        if baseline_name is None:
-            baseline_name = case.get_value("BASELINE_NAME_CMP")
-            if not baseline_name:
-                baseline_name = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
+        real_user = case.get_value("REALUSER")
+        with EnvironmentContext(USER=real_user):
+            if baseline_name is None:
+                baseline_name = case.get_value("BASELINE_NAME_CMP")
+                if not baseline_name:
+                    baseline_name = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
 
-        if baseline_root is None:
-            baseline_root = case.get_value("BASELINE_ROOT")
+            if baseline_root is None:
+                baseline_root = case.get_value("BASELINE_ROOT")
 
-        baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
+            baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
 
-        cmp_result, cmp_comments = compare_baseline(case, baseline_dir=baseline_full_dir, outfile_suffix=None)
-        if cmp_result:
-            logger.info("Diff appears to have been already resolved.")
-            return True, None
-        else:
-            logger.info(cmp_comments)
-            if (not report_only and
-                (force or six.moves.input("Update this diff (y/n)? ").upper() in ["Y", "YES"])):
-                gen_result, gen_comments = generate_baseline(case, baseline_dir=baseline_full_dir)
-                if not gen_result:
-                    logger.warning("Hist file bless FAILED for test {}".format(test_name))
-                    return False, "Generate baseline failed: {}".format(gen_comments)
-                else:
-                    logger.info(gen_comments)
-                    return True, None
-            else:
+            cmp_result, cmp_comments = compare_baseline(case, baseline_dir=baseline_full_dir, outfile_suffix=None)
+            if cmp_result:
+                logger.info("Diff appears to have been already resolved.")
                 return True, None
+            else:
+                logger.info(cmp_comments)
+                if (not report_only and
+                    (force or six.moves.input("Update this diff (y/n)? ").upper() in ["Y", "YES"])):
+                    gen_result, gen_comments = generate_baseline(case, baseline_dir=baseline_full_dir)
+                    if not gen_result:
+                        logger.warning("Hist file bless FAILED for test {}".format(test_name))
+                        return False, "Generate baseline failed: {}".format(gen_comments)
+                    else:
+                        logger.info(gen_comments)
+                        return True, None
+                else:
+                    return True, None
 
 ###############################################################################
 def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, namelists_only=False, hist_only=False,
@@ -85,7 +87,7 @@ def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_i
         ts = TestStatus(test_dir=test_dir)
         test_name = ts.get_name()
         if test_name is None:
-            case_dir = os.path.basename(os.path.dirname(test_status_file))
+            case_dir = os.path.basename(test_dir)
             test_name = CIME.utils.normalize_case_id(case_dir)
             if (bless_tests in [[], None] or CIME.utils.match_any(test_name, bless_tests)):
                 broken_blesses.append((test_name, "test had invalid TestStatus file: '{}'".format(test_status_file)))
@@ -129,6 +131,7 @@ def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_i
 
                 logger.info("###############################################################################")
                 logger.info("Blessing results for test: {}, most recent result: {}".format(test_name, overall_result))
+                logger.info("Case dir: {}".format(test_dir))
                 logger.info("###############################################################################")
                 if not force:
                     time.sleep(2)

--- a/cime/scripts/lib/CIME/case.py
+++ b/cime/scripts/lib/CIME/case.py
@@ -895,6 +895,8 @@ class Case(object):
             else:
                 self._check_testlists(compset_alias, grid_name, files)
 
+        self.set_value("REALUSER", os.environ["USER"])
+
         # Set project id
         if project is None:
             project = get_project(machobj)

--- a/cime/scripts/lib/CIME/compare_test_results.py
+++ b/cime/scripts/lib/CIME/compare_test_results.py
@@ -1,5 +1,5 @@
 import CIME.compare_namelists, CIME.simple_compare
-from CIME.utils import expect, append_status
+from CIME.utils import expect, append_status, EnvironmentContext
 from CIME.test_status import *
 from CIME.hist_utils import compare_baseline
 from CIME.case_cmpgen_namelists import case_cmpgen_namelists
@@ -27,17 +27,19 @@ def compare_namelists(case, baseline_name, baseline_root, logfile_name):
 ###############################################################################
 def compare_history(case, baseline_name, baseline_root, log_id):
 ###############################################################################
-    baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
+    real_user = case.get_value("REALUSER")
+    with EnvironmentContext(USER=real_user):
+        baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
 
-    outfile_suffix = "{}.{}".format(baseline_name, log_id)
-    try:
-        result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
-                                            outfile_suffix=outfile_suffix)
-    except IOError:
-        result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
-                                            outfile_suffix=None)
+        outfile_suffix = "{}.{}".format(baseline_name, log_id)
+        try:
+            result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
+                                                outfile_suffix=outfile_suffix)
+        except IOError:
+            result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
+                                                outfile_suffix=None)
 
-    return result, comments
+        return result, comments
 
 ###############################################################################
 def compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, compare_tests=None, namelists_only=False, hist_only=False):

--- a/cime/scripts/lib/CIME/hist_utils.py
+++ b/cime/scripts/lib/CIME/hist_utils.py
@@ -415,7 +415,7 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
         shutil.copyfile(newestcpllogfile,
                     os.path.join(basegen_dir, "cpl.log.gz"))
 
-    expect(num_gen > 0, "Could not generate any hist files for case '{}', something is seriously wrong".format(testcase))
+    expect(num_gen > 0, "Could not generate any hist files for case '{}', something is seriously wrong".format(os.path.join(rundir, testcase)))
     #make sure permissions are open in baseline directory
     for root, _, files in os.walk(basegen_dir):
         for name in files:

--- a/cime/scripts/lib/CIME/utils.py
+++ b/cime/scripts/lib/CIME/utils.py
@@ -57,6 +57,37 @@ def redirect_logger(new_target, logger_name):
         root_log.handlers = orig_root_loggers
         log.handlers = orig_handlers
 
+class EnvironmentContext(object):
+    """
+    Context manager for environment variables
+    Usage:
+        os.environ['MYVAR'] = 'oldvalue'
+        with EnvironmentContex(MYVAR='myvalue', MYVAR2='myvalue2'):
+            print os.getenv('MYVAR')    # Should print myvalue.
+            print os.getenv('MYVAR2')    # Should print myvalue2.
+        print os.getenv('MYVAR')        # Should print oldvalue.
+        print os.getenv('MYVAR2')        # Should print None.
+
+    CREDIT: https://github.com/sakurai-youhei/envcontext
+    """
+
+    def __init__(self, **kwargs):
+        self.envs = kwargs
+        self.old_envs = {}
+
+    def __enter__(self):
+        self.old_envs = {}
+        for k, v in self.envs.items():
+            self.old_envs[k] = os.environ.get(k)
+            os.environ[k] = v
+
+    def __exit__(self, *args):
+        for k, v in self.old_envs.items():
+            if v:
+                os.environ[k] = v
+            else:
+                del os.environ[k]
+
 def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR:"):
     """
     Similar to assert except doesn't generate an ugly stacktrace. Useful for

--- a/cime/src/drivers/mct/cime_config/config_component.xml
+++ b/cime/src/drivers/mct/cime_config/config_component.xml
@@ -160,6 +160,14 @@
     <desc>case user name</desc>
   </entry>
 
+  <entry id="REALUSER">
+    <type>char</type>
+    <default_value>$ENV{USER}</default_value>
+    <group>case_desc</group>
+    <file>env_case.xml</file>
+    <desc>username of user who created case</desc>
+  </entry>
+
   <!-- ===================================================================== -->
   <!-- definitions runtimes -->
   <!-- ===================================================================== -->


### PR DESCRIPTION
xmlquery gives wrong info if you run as a different user
than the one who made the case.

Use a new case env xml value to store the real user and use
this info to fix bless_test_results and compare_test_results.

[BFB]