### PR TITLE
Dodge filepath length issues

### DIFF
--- a/cime/scripts/lib/CIME/utils.py
+++ b/cime/scripts/lib/CIME/utils.py
@@ -753,7 +753,7 @@ def find_proc_id(proc_name=None,
 
 def get_timestamp(timestamp_format="%Y%m%d_%H%M%S", utc_time=False):
     """
-    Get a string representing the current UTC time in format: YYMMDD_HHMMSS
+    Get a string representing the current UTC time in format: YYYYMMDD_HHMMSS
 
     The format can be changed if needed.
     """

--- a/cime/scripts/lib/jenkins_generic_job.py
+++ b/cime/scripts/lib/jenkins_generic_job.py
@@ -37,7 +37,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
     test_suite = machine.get_value("TESTS")
     proxy = machine.get_value("PROXY")
     test_suite = test_suite if arg_test_suite is None else arg_test_suite
-    test_root = os.path.join(scratch_root, "jenkins")
+    test_root = os.path.join(scratch_root, "J")
     run_area = os.path.dirname(os.path.dirname(machine.get_value("RUNDIR")))
 
     if (use_batch):
@@ -72,7 +72,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
         shutil.rmtree("Testing")
 
     # Remove old dirs
-    test_id_root = "jenkins_{}_{}".format(baseline_name, test_suite)
+    test_id_root = "J{}{}".format(baseline_name.capitalize(), test_suite.replace("acme_", "").capitalize())
     for clutter_area in [scratch_root, test_root, run_area]:
         for old_file in glob.glob("{}/*{}*{}*".format(clutter_area, mach_comp, test_id_root)):
             if (os.path.isdir(old_file)):
@@ -84,7 +84,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
     # Set up create_test command and run it
     #
 
-    test_id = "%s_%s" % (test_id_root, CIME.utils.get_timestamp())
+    test_id = "%s%s" % (test_id_root, CIME.utils.get_timestamp())
     create_test_args = [test_suite, "--test-root %s" % test_root, "-t %s" % test_id, "--machine %s" % machine.get_machine_name(), "--compiler %s" % compiler]
     if (generate_baselines):
         create_test_args.append("-g -b " + real_baseline_name)

--- a/cime/scripts/tests/scripts_regression_tests.py
+++ b/cime/scripts/tests/scripts_regression_tests.py
@@ -1090,11 +1090,11 @@ class P_TestJenkinsGenericJob(TestCreateTestCommon):
 
         # Need to run in a subdir in order to not have CTest clash. Name it
         # such that it should be cleaned up by the parent tearDown
-        self._testdir = os.path.join(self._testroot, "jenkins_generic_test_subdir_%s" % self._baseline_name)
+        self._testdir = os.path.join(self._testroot, "jenkins_test_%s" % self._baseline_name)
         os.makedirs(self._testdir)
 
         # Change root to avoid clashing with other jenkins_generic_jobs
-        self._jenkins_root = os.path.join(self._testdir, "jenkins")
+        self._jenkins_root = os.path.join(self._testdir, "J")
 
     ###########################################################################
     def simple_test(self, expect_works, extra_args, build_name=None):
@@ -1118,15 +1118,13 @@ class P_TestJenkinsGenericJob(TestCreateTestCommon):
             self._thread_error = str(e)
 
     ###########################################################################
-    def assert_num_leftovers(self, test_id=None):
+    def assert_num_leftovers(self):
     ###########################################################################
         # There should only be two directories matching the test_id in both
         # the testroot (bld/run dump area) and jenkins root
-        if (test_id is None):
-            test_id = self._baseline_name
         num_tests_in_tiny = len(update_acme_tests.get_test_suite("cime_test_only_pass"))
 
-        jenkins_dirs = glob.glob("%s/*%s*/" % (self._jenkins_root, test_id)) # case dirs
+        jenkins_dirs = glob.glob("%s/*%s*/" % (self._jenkins_root, self._baseline_name.capitalize())) # case dirs
         # scratch_dirs = glob.glob("%s/*%s*/" % (self._testroot, test_id)) # blr/run dirs
 
         self.assertEqual(num_tests_in_tiny, len(jenkins_dirs),


### PR DESCRIPTION
By significantly shortening the length of test-ids used by
Jenkins.

This should fix a number of failures on sandiatoss3 nightly testing.

[BFB]