### PR TITLE
Remove acme_test_me suite

### DIFF
--- a/cime/scripts/lib/update_acme_tests.py
+++ b/cime/scripts/lib/update_acme_tests.py
@@ -142,10 +142,6 @@ _TEST_SUITES = {
                         ,("SMS_P12x2.ne4_oQU240.A_WCYCL1850","mach_mods")
                         )),
 
-    "acme_test_me" : (None, "01:00:00",
-                      ("ERP_Ld3.ne30_oECv3_ICG.A_WCYCL1850S",
-                      )),
-
     "acme_integration" : (("acme_developer", "acme_atm_integration"),"03:00:00",
                           ("ERS.ne11_oQU240.A_WCYCL1850",
                            "ERS_Ln9.ne4_ne4.FC5AV1C-L",


### PR DESCRIPTION
It was only for debugging a problem with Jenkins which
turned out to be caused by long file paths. The presense
of this suite was causing the test it contained to get
too-short of a walltime allocation.

[BFB]