### PR TITLE
Removing pinned attribute from Titan pgiacc

### DIFF
--- a/cime/config/acme/machines/Depends.titan.pgiacc
+++ b/cime/config/acme/machines/Depends.titan.pgiacc
@@ -7,52 +7,52 @@ microp_aero.o: microp_aero.F90
 
 
 bndry_mod.o: bndry_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 derivative_mod.o: derivative_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 edge_mod.o: edge_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 element_mod.o: element_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 element_state.o: element_state.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 openacc_utils_mod.o: openacc_utils_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 prim_advance_mod.o: prim_advance_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 prim_advection_mod.o: prim_advection_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 prim_si_mod.o: prim_si_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 model_init_mod.o: model_init_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 vertremap_mod.o: vertremap_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 viscosity_mod.o: viscosity_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 prim_driver_mod.o: prim_driver_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 prim_driver_base.o: prim_driver_base.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 physics_mod.o: physics_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 physconst.o: physconst.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -acc -ta=tesla,pinned,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -DUSE_OPENACC=1 -ta=nvidia,cc35,cuda7.5,ptxinfo -Minfo=accel $(FREEFLAGS) $<
 
 
 #uwshcu.o: uwshcu.F90

--- a/cime/config/acme/machines/config_compilers.xml
+++ b/cime/config/acme/machines/config_compilers.xml
@@ -904,7 +904,7 @@ for mct, etc.
   <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) </ADD_SLIBS>
   <CXX_LIBS> -lfmpich -lmpichf90_pgi $(PGI_PATH)/linux86-64/$(PGI_VERSION)/lib/f90main.o </CXX_LIBS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
-  <ADD_LDFLAGS>-ta=tesla,pinned,cuda7.5,cc35</ADD_LDFLAGS>
+  <ADD_LDFLAGS>-ta=nvidia,cc35,cuda7.5</ADD_LDFLAGS>
 </compiler>
 
 <compiler COMPILER="ibm" OS="AIX">


### PR DESCRIPTION
Removes the pinned attribute from the pgiacc compiler on Titan to work around a compiler bug.

Fixes #2074 