### PR TITLE
Changes default setting for dynamic root option in ELM

### DIFF
--- a/components/clm/bld/CLMBuildNamelist.pm
+++ b/components/clm/bld/CLMBuildNamelist.pm
@@ -1034,11 +1034,7 @@ sub setup_cmdl_bgc {
     $var = "use_dynroot";
     $val = $nl_flags->{$var};
     if ( ! defined($nl->get_value($var))) {
-      if ( $nl_flags->{'bgc_mode'} ne "sp") {
-        $val = ".true.";
-      } else {
-        $val = ".false.";
-      }
+      $val = ".false.";
     } else {
       $nl_flags->{$var} = $nl->get_value($var);
       $val = $nl_flags->{$var};


### PR DESCRIPTION
The default setting of dynamic root option is set to false when
BGC is turned on.

[non-BFB]