### PR TITLE
Lower the netcdf-hdf5parallel version for mpiserial on Titan

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -2069,7 +2069,7 @@
       </modules>
       <!-- mpi lib settings -->
       <modules mpilib="mpi-serial">
-        <command name="load">cray-netcdf/4.4.1.1.3</command>
+        <command name="load">cray-netcdf/4.4.1.1</command>
       </modules>
       <modules mpilib="!mpi-serial">
         <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
@@ -2086,10 +2086,11 @@
         <env name="MPSTKZ">128M</env>
         <env name="OMP_STACKSIZE">128M</env>
       </environment_variables>
-      <environment_variables compiler="pgi">
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1.3/PGI/15.3/</env>
+      <environment_variables compiler="pgi" mpilib="mpi-serial">
+	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
       </environment_variables>
       <environment_variables compiler="pgi" mpilib="!mpi-serial">
+	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1.3/PGI/15.3/</env>
 	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.8.1.3/PGI/15.3</env>
       </environment_variables>
       <environment_variables compiler="pgiacc">


### PR DESCRIPTION
The netcdf-hdf5parallel version was lowered from 4.4.1.1.3 to 4.4.1.1 for
MPI-serial.

The netcdf library builds depend on hdf5. Although MPI-serial builds 
should not depend on the hdf5 parallel library (should depend on hdf5 
serial library instead) this change allows us to build with mpi-serial. 

The netcdf library used for mpi-serial builds will be updated when cray
installs serial netcdf builds (that depend on a serial build of hdf5) on Titan.

Fixes #2079

[BFB]