### PR TITLE
Initialize KE,IE,PE arrays to avoid possible NaNs in reprosum calls

### DIFF
--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -458,6 +458,9 @@ contains
        elem(ie)%accum%Qvar=0
        elem(ie)%accum%Qmass=0
        elem(ie)%accum%Q1mass=0
+       elem(ie)%accum%KEner=0
+       elem(ie)%accum%IEner=0
+       elem(ie)%accum%PEner=0
 
        elem(ie)%derived%Omega_p=0
        elem(ie)%state%dp3d=0


### PR DESCRIPTION
Initialize KE,IE,PE arrays to avoid possible NaNs in reprosum calls

Fixes ACME-Climate/ACME#2004
[BFB]
