### PR TITLE
Fix an error in COSP 1.4 MODIS simulator

### DIFF
--- a/components/cam/src/physics/cosp/MODIS_simulator/modis_simulator.F90
+++ b/components/cam/src/physics/cosp/MODIS_simulator/modis_simulator.F90
@@ -676,14 +676,25 @@ contains
     g(:) = 0; w0(:) = 0. 
     tau(:) = ice_tau(:) + water_tau(:) + snow_tau(:) !+JEK 
     where (tau(:) > 0) 
+#ifdef APPLY_POST_DECK_BUGFIXES
       w0(:) = (water_tau(:) * water_w0(:)  + &
                  ice_tau(:) * ice_w0(:)    + &
                 snow_tau(:) * snow_w0(:) ) / &
                 tau(:)
-      g(:) = (water_tau(:) * water_g(:) * water_w0(:)  +  &
-                ice_tau(:) * ice_g(:)   * ice_w0(:)      +  &
+      g(:) = (water_tau(:) * water_g(:) * water_w0(:)  + &
+                ice_tau(:) * ice_g(:)   * ice_w0(:)    + &
                snow_tau(:) * snow_g(:)  * snow_w0(:) ) / &
                (w0(:) * tau(:))
+#else
+      g(:)  = (water_tau(:) * water_g(:) + &
+                 ice_tau(:) *   ice_g(:) + &
+                snow_tau(:) *  snow_g(:) ) / &
+              tau(:) !+JEK
+      w0(:) = (water_tau(:) * water_g(:) * water_w0(:) + &
+                 ice_tau(:) *   ice_g(:) *   ice_w0(:) + &
+                snow_tau(:) *  snow_g(:) *  snow_w0(:) ) / &
+              (g(:) * tau(:)) !+JEK
+#endif
     end where
     
     compute_nir_reflectance = compute_toa_reflectace(tau, g, w0)


### PR DESCRIPTION
 This update fixes an error in the calculation of NIR reflectance that affects cloud fields derived from MODIS simulator.  As a tentative arrangement, the fixes are only effective when the CPP directive 
 -DAPPLY_POST_DECK_BUGFIXES is applied to  CAM_CONFIG_OPTS, which can be specified in compsets of interest in components/cam/cie_config/config_components.xml.

The impact is generally small.

 Modified:   components/cam/src/physics/cosp/MODIS_simulator/modis_simulator.F90

 [non-BFB] for COSP-MODIS simulator diagnostics output when the CPP directive is defined
 [BFB] all else