### PR TITLE
Fix a PGI Fortran if short circuit bug on Titan

### DIFF
--- a/components/clm/src/biogeophys/SurfaceResistanceMod.F90
+++ b/components/clm/src/biogeophys/SurfaceResistanceMod.F90
@@ -154,9 +154,10 @@ contains
                 else   !when water content of ths top layer is more than that at F.C.
                    soilbeta(c) = 1._r8
                 end if
-                if ( use_vsfm .and. &
-                     ((wx < watmin(c,1)) .or. (soilp_col(c,1) < sucmin(c,1)))) then
-                   soilbeta(c) = 0._r8
+                if ( use_vsfm ) then 
+                   if ((wx < watmin(c,1)) .or. (soilp_col(c,1) < sucmin(c,1))) then
+                      soilbeta(c) = 0._r8
+                   end if
                 end if
              else if (col_pp%itype(c) == icol_road_perv) then
                 if (.not. use_vsfm) then


### PR DESCRIPTION
On Titan, the if short circuit is valid for the PGI Fortran, in a
debug mode with an option 'Ktrap=fp', however, it is invalid. This bug
caused a floating point error from the clm 'SurfaceResistanceMod.F90'
in the debug test of 'SMS_D_Ln5.ne4_ne4.FC5AV1C-L', because the values of
'soilp_col' are NaNs in the if statement at line 157.

Fixes: issue #2104

[BFB] - Bit-For-Bit