### PR TITLE
Update default river routing file for high-res runs

### DIFF
--- a/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
+++ b/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
@@ -28,7 +28,7 @@ for the CLM data in the CESM distribution
 
 <!-- River Transport Model river routing file (relative to {csmdata}) -->
 
-<frivinp_rtm rof_grid="r0125" >rof/mosart/MOSART_Global_8th_20160716a.nc</frivinp_rtm>
+<frivinp_rtm rof_grid="r0125" >rof/mosart/MOSART_global_8th_20180211b.nc</frivinp_rtm>
 <frivinp_rtm rof_grid="r05" >rof/mosart/MOSART_Global_half_20161014c.nc</frivinp_rtm>
 <frivinp_rtm rof_grid="NLDAS" >rof/mosart/MOSART_NLDAS_8th.nc</frivinp_rtm>
 


### PR DESCRIPTION
This PR changes the default river routing file for the 1/8-degree high-res mosart configuration. It has been tested for a year in a A_WCYCL1950S_CMIP6_HR.ne120_oRRS18v3_ICG run on theta, and significantly reduced the observed salinity issues in the ocean.

This PR will change namelists and results but only for high-res ne120_oRRS18to6v3 runs, which are not currently tested.

[non-BFB] only for cases with ne120_oRRS18to6v3 grid configuration