### PR TITLE
Fix module issue on cori 

### DIFF
--- a/cime/config/acme/machines/config_machines.xml
+++ b/cime/config/acme/machines/config_machines.xml
@@ -304,8 +304,11 @@
     </modules>
 
     <modules>
-      <command name="load">git/2.9.1</command>
+      <command name="rm">git</command>
+      <command name="load">git/2.15.1</command>
+      <command name="rm">cmake</command>
       <command name="load">cmake/3.3.2</command>
+      <command name="rm">zlib</command>
       <command name="load">zlib/1.2.8</command>
     </modules>
   </module_system>
@@ -448,8 +451,11 @@
       <command name="load">cray-parallel-netcdf/1.8.1.3</command>
     </modules>
     <modules>
-      <command name="load">git/2.9.1</command>
+      <command name="rm">git</command>
+      <command name="load">git/2.15.1</command>
+      <command name="rm">cmake</command>
       <command name="load">cmake/3.3.2</command>
+      <command name="rm">zlib</command>
       <command name="load">zlib/1.2.8</command>
     </modules>
 


### PR DESCRIPTION
For cori-knl and cori-haswell, first remove 3 modules before adding them with specific versions.

The `git`, `cmake`, and `zlib` modules were being added with specific versions without first removing any existing loaded module.  This could result in a module conflict error, which would stop the build.
This was happening for git as the default version changed on the system.
Also, update the specific git version to the current default.

This does not affect edison as we are apparently not needing to load git/cmake/zlib there.

[BFB]