### PR TITLE
Adds reading of drainage parameter from land surface dataset

### DIFF
--- a/components/clm/src/biogeophys/SoilHydrologyType.F90
+++ b/components/clm/src/biogeophys/SoilHydrologyType.F90
@@ -262,6 +262,7 @@ contains
     real(r8) ,pointer  :: zisoifl    (:)   ! original soil interface depth 
     real(r8) ,pointer  :: zsoifl     (:)   ! original soil midpoint 
     real(r8) ,pointer  :: dzsoifl    (:)   ! original soil thickness 
+    real(r8) ,pointer  :: fdrain     (:)   ! top-model drainage parameter
     !-----------------------------------------------------------------------
 
     ! -----------------------------------------------------------------
@@ -518,6 +519,15 @@ contains
 
     end if ! end of if use_vichydro
 
+    allocate(fdrain(bounds%begg:bounds%endg))
+    call getfil (fsurdat, locfn, 0)
+    call ncd_pio_openfile (ncid, locfn, 0)
+    call ncd_io(ncid=ncid, varname='fdrain', flag='read', data=fdrain, dim1name=grlnd, readvar=readvar)
+    if (.not. readvar) then
+       fdrain(:) = 2.5_r8
+    end if
+    call ncd_pio_closefile(ncid)
+
     associate(micro_sigma => col_pp%micro_sigma)
       do c = bounds%begc, bounds%endc
          
@@ -548,6 +558,8 @@ contains
 
       end do
     end associate
+
+    deallocate(fdrain)
 
   end subroutine InitCold
 


### PR DESCRIPTION
If 'fdrain' is present in the land surface dataset, use it.
Otherwise, use default value of fdrain = 2.5 m^{-1}.

[BFB]