### PR TITLE
Print MPI process labels only in debugging mode

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1478,7 +1478,7 @@
       <env name="MPICH_VERSION_DISPLAY">1</env>
       <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
       <env name="MPAS_TOOL_DIR">/projects/ccsm/acme/tools/mpas</env>
-      <env name="labeling">-e PMI_LABEL_ERROUT=1</env>
+      <env name="labeling"></env>
       <env name="SMP_VARS"></env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="intel">
@@ -1486,6 +1486,9 @@
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="!intel">
       <env name="SMP_VARS">-e OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS} -e OMP_STACKSIZE=128M -e OMP_PROC_BIND=spread -e OMP_PLACES=threads</env>
+    </environment_variables>
+    <environment_variables DEBUG="TRUE">
+      <env name="labeling">-e PMI_LABEL_ERROUT=1</env>
     </environment_variables>
     <module_system type="module">
       <init_path lang="perl">/opt/modules/default/init/perl.pm</init_path>


### PR DESCRIPTION
The PMI daemon that prints process IDs can lead to seg-faults at the end of a run preventing CIME scripts from completing post-processing tasks.

[BFB]
Fixes ACME-Climate/ACME#2122