### PR TITLE
Bug fixes for dynamic root model

### DIFF
--- a/components/clm/src/biogeochem/CNEcosystemDynBetrMod.F90
+++ b/components/clm/src/biogeochem/CNEcosystemDynBetrMod.F90
@@ -294,8 +294,8 @@ module CNEcosystemDynBetrMod
           call t_startf('CNRootDyn')
 
           call CNRootDyn(bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, &
-               carbonstate_vars, nitrogenstate_vars, carbonflux_vars,  &
-               cnstate_vars, crop_vars,  soilstate_vars)
+               canopystate_vars, carbonstate_vars, nitrogenstate_vars, carbonflux_vars,  &
+               cnstate_vars, crop_vars, energyflux_vars, soilstate_vars)
           call t_stopf('CNRootDyn')
        end if
 

--- a/components/clm/src/biogeochem/CNEcosystemDynMod.F90
+++ b/components/clm/src/biogeochem/CNEcosystemDynMod.F90
@@ -629,8 +629,8 @@ contains
           call t_startf('CNRootDyn')
 
           call CNRootDyn(bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, &
-               carbonstate_vars, nitrogenstate_vars, carbonflux_vars,  &
-               cnstate_vars, crop_vars,  soilstate_vars)
+               canopystate_vars, carbonstate_vars, nitrogenstate_vars, carbonflux_vars,  &
+               cnstate_vars, crop_vars, energyflux_vars, soilstate_vars)
           call t_stopf('CNRootDyn')
        end if
 

--- a/components/clm/src/biogeochem/CNRootDynMod.F90
+++ b/components/clm/src/biogeochem/CNRootDynMod.F90
@@ -11,16 +11,19 @@ module CNRootDynMod
   use clm_varpar          , only : nlevsoi, nlevgrnd
   use clm_varctl          , only : use_vertsoilc
   use decompMod           , only : bounds_type
-  use pftvarcon           , only : noveg, npcropmin, roota_par, rootb_par,root_dmx
+  use pftvarcon           , only : noveg, npcropmin, roota_par, rootb_par, root_dmx, evergreen
   use ColumnType          , only : col_pp 
-  use VegetationType           , only : veg_pp
+  use VegetationType      , only : veg_pp
+  use CanopyStateType     , only: canopystate_type
   use CNStateType         , only : cnstate_type
   use CNCarbonStateType   , only : carbonstate_type
   use CNCarbonFluxType    , only : carbonflux_type
   use CNNitrogenStateType , only : nitrogenstate_type
+  use EnergyFluxType      , only: energyflux_type
   use SoilStateType       , only : soilstate_type
   use CropType            , only : crop_type
   use SimpleMathMod       , only : array_normalization
+  use RootBiophysMod      , only : init_vegrootfr
 
   ! !PUBLIC TYPES:
   implicit none
@@ -34,8 +37,8 @@ contains
   !-----------------------------------------------------------------------
   !
   subroutine CNRootDyn(bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, &
-       carbonstate_vars, nitrogenstate_vars, carbonflux_vars,                    &
-       cnstate_vars, crop_vars,  soilstate_vars)
+       canopystate_vars, carbonstate_vars, nitrogenstate_vars, carbonflux_vars,  &
+       cnstate_vars, crop_vars,  energyflux_vars, soilstate_vars)
     !
     ! !DESCRIPTION:
     ! This routine determine the fine root distribution
@@ -52,11 +55,13 @@ contains
     integer                  , intent(in)    :: filter_soilc(:)
     integer                  , intent(in)    :: num_soilp          ! number of soil pfts in filter
     integer                  , intent(in)    :: filter_soilp(:)    ! filter for soil pfts
+    type(canopystate_type)   , intent(in)    :: canopystate_vars
     type(cnstate_type)       , intent(in)    :: cnstate_vars
     type(carbonstate_type)   , intent(in)    :: carbonstate_vars
     type(carbonflux_type)    , intent(in)    :: carbonflux_vars
     type(nitrogenstate_type) , intent(in)    :: nitrogenstate_vars !
     type(crop_type)          , intent(in)    :: crop_vars
+    type(energyflux_type)    , intent(in)    :: energyflux_vars
     type(soilstate_type)     , intent(inout) :: soilstate_vars
 
     !
@@ -71,30 +76,46 @@ contains
     real(r8) :: sumrsmn(bounds%begp:bounds%endp)               ! scaling  soil mineral N availability in each soil layer
     real(r8) :: frootc_dz(bounds%begp:bounds%endp, 1:nlevgrnd) ! root carbon in each soil layer (gC)
     real(r8) :: sumfrootc(bounds%begp:bounds%endp)             ! fine root carbon total before turnover in each step
+    real(r8) :: rootfr_coarse(bounds%begp:bounds%endp, 1:nlevgrnd) ! coarse root distribution
     real(r8) :: psi                                            ! soil moisture potential
     real(r8) :: maxpsi                                         ! maximum soil moisture potential
-    real(r8) :: new_growth                                     ! new carbon allocated to roots this timestep
+    real(r8) :: new_growth, new_croot_growth                   ! new carbon allocated to roots this timestep
     real(r8), parameter :: minpsi = -1.5_r8                    ! minimum soil moisture potential - permanent wilting point (MPa)
+    real(r8), parameter :: soil_water_factor_min = 0.9_r8
+    real(r8), parameter :: exp_decay_factor = 3._r8
 
     !-----------------------------------------------------------------------
     ! Assign local pointers to derived type arrays (in)
     associate(&
-         ivt                    => veg_pp%itype                                   , & ! Input  :  [integer (:)]  pft vegetation type
-         pcolumn                => veg_pp%column                                  , & ! Input  :  [integer (:)]  pft's column index
-         croplive               => crop_vars%croplive_patch                 , & ! Input  :  [logical (:)]  flag, true if planted, not harvested
+         ivt                    => veg_pp%itype                                , & ! Input  :  [integer (:)]  pft vegetation type
+         pcolumn                => veg_pp%column                               , & ! Input  :  [integer (:)]  pft's column index
+         croplive               => crop_vars%croplive_patch                    , & ! Input  :  [logical (:)]  flag, true if planted, not harvested
          cpool_to_frootc        => carbonflux_vars%cpool_to_frootc_patch       , & ! Input  :  [real(r8) (:)] allocation to fine root C (gC/m2/s)
+         cpool_to_frootc_storage=> carbonflux_vars%cpool_to_frootc_storage_patch, & ! Input:  [real(r8) (:)] allocation to fine root C storage (gC/m2/s)
          frootc_xfer_to_frootc  => carbonflux_vars%frootc_xfer_to_frootc_patch , & ! Input  :  [real(r8) (:)] fine root C growth from storage (gC/m2/s)
+         onset_flag             => cnstate_vars%onset_flag_patch               , & ! Input  :  [real(r8) (:)] onset flag
          dormant_flag           => cnstate_vars%dormant_flag_patch             , & ! Input  :  [real(r8) (:)]  dormancy flag
          root_depth             => soilstate_vars%root_depth_patch             , & ! InOut  :  [real(r8) (:)] current root depth
-         dz                     => col_pp%dz                                      , & ! Input  :  layer thickness (m)  (-nlevsno+1:nlevgrnd)
-         zi                     => col_pp%zi                                      , & ! Input  :  interface level below a "z" level (m) (-nlevsno+0:nlevgrnd)
+         dz                     => col_pp%dz                                   , & ! Input  :  layer thickness (m)  (-nlevsno+1:nlevgrnd)
+         zi                     => col_pp%zi                                   , & ! Input  :  interface level below a "z" level (m) (-nlevsno+0:nlevgrnd)
+         nlevbed                => col_pp%nlevbed                              , & ! Input  :  # levels to bedrock
          rootfr                 => soilstate_vars%rootfr_patch                 , & ! Output :  [real(r8) (:,:)]  fraction of roots in each soil layer
          sucsat                 => soilstate_vars%sucsat_col                   , & ! Input  :  minimum soil suction (mm)
          soilpsi                => soilstate_vars%soilpsi_col                  , & ! Input  :  soil water potential in each soil layer (MPa)
+         rresis                 => energyflux_vars%rresis_patch                , & ! Input  :  [real(r8) (:,:) ]  root soil water stress (resistance) by layer (0-1)
          sminn_vr               => nitrogenstate_vars%sminn_vr_col             , & ! Iniput :  [real(r8) (:,:)]  (gN/m3) soil mineral N
          frootc                 => carbonstate_vars%frootc_patch               , & ! Input  :  [real(r8) (:)]  (gC/m2) fine root C
          hui                    => crop_vars%gddplant_patch                    , & ! Input  :  [real(r8) (:)]  =gdd since planting (gddplant)
-         huigrain               => cnstate_vars%huigrain_patch                   & ! Input  :  [real(r8) (:)]  same to reach vegetative maturity
+         huigrain               => cnstate_vars%huigrain_patch                 , & ! Input  :  [real(r8) (:)]  same to reach vegetative maturity
+         livecrootc             => carbonstate_vars%livecrootc_patch           , & !
+         deadcrootc             => carbonstate_vars%deadcrootc_patch           , &
+         cpool_to_livecrootc    => carbonflux_vars%cpool_to_livecrootc_patch   , & ! Input  :  [real(r8) (:)] allocation to coarse root C (gC/m2/s)
+         cpool_to_livecrootc_storage => carbonflux_vars%cpool_to_livecrootc_storage_patch, & ! Input:  [real(r8) (:)] allocation to coarse root C storage (gC/m2/s)
+         cpool_to_deadcrootc    => carbonflux_vars%cpool_to_deadcrootc_patch   , & ! Input  :  [real(r8) (:)] allocation to dead coarse root C (gC/m2/s)
+         cpool_to_deadcrootc_storage => carbonflux_vars%cpool_to_deadcrootc_storage_patch, & ! Input:  [real(r8) (:)] allocation to dead coarse root C storage (gC/m2/s)
+         livecrootc_xfer_to_livecrootc => carbonflux_vars%livecrootc_xfer_to_livecrootc_patch , & ! Input  :  [real(r8) (:)] coarse root C growth from storage (gC/m2/s)
+         deadcrootc_xfer_to_deadcrootc => carbonflux_vars%deadcrootc_xfer_to_deadcrootc_patch ,  & ! Input  :  [real(r8) (:)] dead coarse root C growth from storage (gC/m2/s)
+         altmax_lastyear         => canopystate_vars%altmax_lastyear_col         & ! Input: [real(r8) (:)   ]  maximum annual depth of thaw
          )
 
       ! set time steps
@@ -109,6 +130,7 @@ contains
       rsmn(bounds%begp:bounds%endp,1:nlevgrnd)      = 0._r8
       frootc_dz(bounds%begp:bounds%endp,1:nlevgrnd) = 0._r8
       root_depth(bounds%begp:bounds%endp)           = 0._r8
+      rootfr_coarse(bounds%begp:bounds%endp,1:nlevgrnd) = 0._r8
 
       !---------------------------------------------------------------
       ! Set root depth, dynamic for crops, fixed for other vegetation
@@ -124,7 +146,7 @@ contains
                end if
             else
                ! this can be changed to any depth (i.e. the maximum soil depth)
-               root_depth(p) = zi(c,nlevsoi)
+               root_depth(p) = min(altmax_lastyear(c), min(zi(c,nlevsoi), root_dmx(ivt(p))))
             end if
          else
             root_depth(p) = 0._r8
@@ -137,18 +159,10 @@ contains
       ! This will be used to weight the temperature and water potential scalars
       ! for decomposition control.
 
-      ! calculate the rate constant scalar for soil water content.
-      ! Uses the log relationship with water potential given in
-      ! Andren, O., and K. Paustian, 1987. Barley straw decomposition in the field:
-      ! a comparison of models. Ecology, 68(5):1190-1200.
-      ! and supported by data in
-      ! Orchard, V.A., and F.J. Cook, 1983. Relationship between soil respiration
-      ! and soil moisture. Soil Biol. Biochem., 15(4):447-453.
-
-      do j = 1,nlevsoi
-         do f = 1,num_soilp
-            p = filter_soilp(f)
-            c = pcolumn(p)
+      do f = 1,num_soilp
+         p = filter_soilp(f)
+         c = pcolumn(p)
+         do j = 1,nlevsoi
             maxpsi = sucsat(c,j) * (-9.8e-6_r8)
             psi = min(soilpsi(c,j),maxpsi)
             if (psi > minpsi) then
@@ -156,12 +170,13 @@ contains
                ! First calculate water in the root zone
                if (root_depth(p) >  zi(c,3) .and. (zi(c,j) <= root_depth(p) .or. &
                     (zi(c,j-1) < root_depth(p) .and. zi(c,j) > root_depth(p)))) then
-                  w_limit(p) = w_limit(p) + max(0._r8,log(minpsi/psi)/log(minpsi/maxpsi))*rootfr(p,j)
+                  w_limit(p) = w_limit(p) + max(rresis(p,j)*rootfr(p,j),0._r8)
+                  w_limit(p) = min(soil_water_factor_min,w_limit(p))
                end if
                ! Calculate the water in each soil layer
                if (root_depth(p) >= zi(c,j) .or. &
                     (zi(c,j-1) < root_depth(p) .and. zi(c,j) > root_depth(p))) then
-                  rswa(p,j) = max(0._r8, (log(minpsi/psi)/log(minpsi/maxpsi)))
+                  rswa(p,j) = max(0._r8, rresis(p,j))*dz(c,j)
                end if
             end if
             sumrswa(p) = sumrswa(p) + rswa(p,j)
@@ -170,14 +185,9 @@ contains
             ! For now, the profile for each PFT is equivilent to the
             ! column profile, in the future, this could be changed to a weighted profile
             if (use_vertsoilc) then !for vertical soil profile
-               rsmn(p,j) = sminn_vr(c,j)
-            else ! need to calculate a profile, top three layers are constant, and decrease linearly
-               if (j <= 3) then
-                  rsmn(p,j) = dz(c,j)
-               end if
-               if (j > 3) then
-                  rsmn(p,j) = dz(c,j) * (zi(c,10) - zi(c,j)) / (zi(c,10) - zi(c,3))
-               end if
+               rsmn(p,j) = sminn_vr(c,j)*dz(c,j)
+            else ! need to calculate a profile, an exponential decay
+               rsmn(p,j) = dz(c,j)*exp(-exp_decay_factor*zi(c,j))
             end if
             if (root_depth(p) >= zi(c,j).or. &
                  (zi(c,j-1) < root_depth(p) .and. zi(c,j) > root_depth(p))) then
@@ -186,29 +196,42 @@ contains
          end do
       end do
 
+      !------------------------------------------------------------------
+      ! Calculate coarse root fraction from standard root distribution
+      !------------------------------------------------------------------
+
+      call init_vegrootfr(bounds, nlevsoi, nlevgrnd, &
+                   nlevbed(bounds%begc:bounds%endc), &
+                   rootfr_coarse(bounds%begp:bounds%endp,1:nlevgrnd))
 
       !--------------------------------------------------------------------
       ! Now calculate the density of roots in each soil layer for each pft
       ! based on this timesteps growth
       !--------------------------------------------------------------------
-      do lev = 1, nlevgrnd
 
-         do f = 1, num_soilp
-            p = filter_soilp(f) 
-            c = pcolumn(p)
-
+      do f = 1, num_soilp
+         p = filter_soilp(f) 
+         c = pcolumn(p)
+         new_growth = 0._r8
+         new_croot_growth = 0._r8
+         if (onset_flag(p) == 0._r8) then
             new_growth = (cpool_to_frootc(p) + frootc_xfer_to_frootc(p))*dt
-            if (zi(c,lev) <= root_depth(p) .or. &
-                 (zi(c,lev-1) < root_depth(p) .and. zi(c,lev) > root_depth(p))) then
-               if (sumrswa(p) <= 0._r8 .or. sumrsmn(p) <= 0._r8) then
-                  ! when sumrswa or sumrsmn are less than or equal to 0 rootfr will not be updated
-               else
-                  frootc_dz(p,lev) = (frootc(p))*rootfr(p,lev) &
-                       + new_growth * ((1._r8 - w_limit(p)) * rswa(p,lev) / sumrswa(p) &
-                       + w_limit(p) * rsmn(p,lev) / sumrsmn(p))
-               end if
+            new_croot_growth = (cpool_to_livecrootc(p) + cpool_to_deadcrootc(p) + &
+                                deadcrootc_xfer_to_deadcrootc(p) + livecrootc_xfer_to_livecrootc(p))*dt
+         end if
+         if (evergreen(ivt(p)) == 0._r8) then
+            new_growth = new_growth + cpool_to_frootc_storage(p)*dt
+            new_croot_growth = new_croot_growth + (cpool_to_livecrootc_storage(p) + &
+                                                   cpool_to_deadcrootc_storage(p))*dt
+         end if
+         do lev=1,nlevsoi
+            if (sumrswa(p) <= 0._r8 .or. sumrsmn(p) <= 0._r8) then
+               ! when sumrswa or sumrsmn are less than or equal to 0 rootfr will not be updated
             else
-               frootc_dz(p,lev) = 0._r8
+               frootc_dz(p,lev) = (livecrootc(p) + deadcrootc(p) + frootc(p))*rootfr(p,lev) &
+                    + new_croot_growth * rootfr_coarse(p,lev) &
+                    + new_growth * ((1._r8 - w_limit(p)) * rswa(p,lev) / sumrswa(p) &
+                    + w_limit(p) * rsmn(p,lev) / sumrsmn(p))
             end if
 
             sumfrootc(p) = sumfrootc(p) + frootc_dz(p,lev)
@@ -222,29 +245,12 @@ contains
 
       ! normalize the root fraction for each pft
 
-      do lev = 1, nlevgrnd
-         do f = 1, num_soilp
-            p = filter_soilp(f)
-            c = pcolumn(p)
+      do f = 1, num_soilp
+         p = filter_soilp(f)
+         c = pcolumn(p)
+         do lev = 1, nlevgrnd
             if (sumfrootc(p) > 0._r8) then
                rootfr(p,lev) = frootc_dz(p,lev)/sumfrootc(p)
-            end if
-            if (ivt(p) >= npcropmin .and. .not. croplive(p)) then
-               ! CROPS are dormant, there are no roots!
-               ! but, need an initial frootr so crops can start root production
-               ! default is just the exponential over the top two soil layers
-               if (lev <  2) then
-                  rootfr(p,lev) = .5_r8*( exp(-roota_par(veg_pp%itype(p)) * zi(c,lev-1))  &
-                       + exp(-rootb_par(veg_pp%itype(p)) * zi(c,lev-1))  &
-                       - exp(-roota_par(veg_pp%itype(p)) * zi(c,lev  ))  &
-                       - exp(-rootb_par(veg_pp%itype(p)) * zi(c,lev  )) )
-               elseif (lev == 2) then
-                  rootfr(p,lev) = .5_r8*( exp(-roota_par(veg_pp%itype(p)) * zi(c,lev-1))  &
-                       + exp(-rootb_par(veg_pp%itype(p)) * zi(c,lev-1)) )
-               else
-                  rootfr(p,lev) =  0.0_r8
-               end if
-
             end if
          end do
       end do

--- a/components/clm/src/biogeochem/CNVerticalProfileMod.F90
+++ b/components/clm/src/biogeochem/CNVerticalProfileMod.F90
@@ -126,7 +126,7 @@ contains
          cinput_rootfr(begp:endp, :)     = 0._r8
          col_cinput_rootfr(begc:endc, :) = 0._r8
 
-         if ( exponential_rooting_profile .and. .not. use_dynroot ) then
+         if ( exponential_rooting_profile ) then
             if ( .not. pftspecific_rootingprofile ) then
                ! define rooting profile from exponential parameters
                do j = 1, nlevdecomp

--- a/components/clm/src/biogeophys/SoilStateType.F90
+++ b/components/clm/src/biogeophys/SoilStateType.F90
@@ -839,28 +839,31 @@ contains
     !
     ! !LOCAL VARIABLES:
     logical          :: readvar   ! determine if variable is on initial file
+    logical          :: readrootfr = .false.
     !-----------------------------------------------------------------------
 
-if(use_dynroot) then
-    call restartvar(ncid=ncid, flag=flag, varname='root_depth', xtype=ncd_double,  &
-         dim1name='pft', &
-         long_name='root depth', units='m', &
-         interpinic_flag='interp', readvar=readvar, data=this%root_depth_patch)
+    if(use_dynroot) then
+       call restartvar(ncid=ncid, flag=flag, varname='root_depth', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='root depth', units='m', &
+            interpinic_flag='interp', readvar=readvar, data=this%root_depth_patch)
 
-    call restartvar(ncid=ncid, flag=flag, varname='rootfr', xtype=ncd_double,  &
-         dim1name='pft', dim2name='levgrnd', switchdim=.true., &
-         long_name='root fraction', units='', &
-         interpinic_flag='interp', readvar=readvar, data=this%rootfr_patch)
-    if (flag=='read' .and. .not. readvar) then
+       call restartvar(ncid=ncid, flag=flag, varname='rootfr', xtype=ncd_double,  &
+            dim1name='pft', dim2name='levgrnd', switchdim=.true., &
+            long_name='root fraction', units='', &
+            interpinic_flag='interp', readvar=readrootfr, data=this%rootfr_patch)
+    else
+       readrootfr = .false.
+    end if
+    if (flag=='read' .and. .not. readrootfr) then
        if (masterproc) then
           write(iulog,*) "can't find rootfr in restart (or initial) file..."
           write(iulog,*) "Initialize rootfr to default"
        end if
        call init_vegrootfr(bounds, nlevsoi, nlevgrnd, &
             col_pp%nlevbed(bounds%begc:bounds%endc), &
-       	    this%rootfr_patch(bounds%begp:bounds%endp,1:nlevgrnd))
+            this%rootfr_patch(bounds%begp:bounds%endp,1:nlevgrnd))
     end if
-end if
   end subroutine Restart
 
 

--- a/components/clm/src/main/pftvarcon.F90
+++ b/components/clm/src/main/pftvarcon.F90
@@ -663,7 +663,7 @@ contains
        call ncd_io('fyield',fyield, 'read', ncid, readvar=readv, posNOTonfile=.true.)
        if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     endif
-    if(use_crop .and. use_dynroot)then
+    if(use_dynroot)then
        call ncd_io('root_dmx',root_dmx, 'read', ncid, readvar=readv, posNOTonfile=.true.)
        if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     endif


### PR DESCRIPTION
This commit updates the dynamic root model to fix the
spinup delay in the tropics. The updates included a revised
water profile that matches btran, an exponential N profile when
vertical profiles are not on, and allows changes to the root profile
during the growing season rather than just the onset period for
stress and seasonal deciduous vegetation. The dynamic roots also
maintain the coarse root distribution.

Fixes #1027 
[non-BFB] when use_dynroot = .true.