### PR TITLE
Implement use of decomp_prefix in setting name of default partition files

### DIFF
--- a/components/mpas-o/bld/build-namelist
+++ b/components/mpas-o/bld/build-namelist
@@ -48,6 +48,7 @@ OPTIONS
      -ocn_forcing          variable for defining if the ocn model is forced with an active atm
                            or using CORE forcing.  
                            Options are: active_atm, core_forced, core_forced_restoring
+     -decomp_prefix        decomp_prefix variable
      -date_stamp           date_stamp variable
      -cfg_grid             Directory containing MPAS-O configuration scripts.
                            If not defined, location is set as \$ProgDir or \$cwd
@@ -88,42 +89,44 @@ if ($ProgDir) {
 
 # Process command-line options.
 
-my %opts = ( help        => 0,
-             test        => 0,
-             verbose     => 0,
-             preview     => 0,
-             caseroot    => undef,
-             casebuild   => undef,
-             cimeroot    => undef,
-             inst_string => undef,
-             ocn_grid    => undef,
-             ocn_forcing => undef,
-             date_stamp  => undef,
-             ocn_bgc     => undef,
+my %opts = ( help          => 0,
+             test          => 0,
+             verbose       => 0,
+             preview       => 0,
+             caseroot      => undef,
+             casebuild     => undef,
+             cimeroot      => undef,
+             inst_string   => undef,
+             ocn_grid      => undef,
+             ocn_forcing   => undef,
+             decomp_prefix => undef,
+             date_stamp    => undef,
+             ocn_bgc       => undef,
              ocn_co2_type      => undef,
              atm_co2_const_val => undef,
-             ice_bgc     => undef,
-             cfg_dir     => $cfgdir,
+             ice_bgc       => undef,
+             cfg_dir       => $cfgdir,
            );
 
 GetOptions(
-    "h|help"        => \$opts{'help'},
-    "infile=s"      => \$opts{'infile'},
-    "namelist=s"    => \$opts{'namelist'},
-    "v|verbose"     => \$opts{'verbose'},
-    "caseroot=s"    => \$opts{'caseroot'},
-    "casebuild=s"   => \$opts{'casebuild'},
-    "cimeroot=s"    => \$opts{'cimeroot'},
-    "inst_string=s" => \$opts{'inst_string'},	   
-    "ocn_grid=s"    => \$opts{'ocn_grid'},
-    "ocn_forcing=s" => \$opts{'ocn_forcing'},
-    "date_stamp=s"  => \$opts{'date_stamp'},
-    "ocn_bgc=s"     => \$opts{'ocn_bgc'},
+    "h|help"          => \$opts{'help'},
+    "infile=s"        => \$opts{'infile'},
+    "namelist=s"      => \$opts{'namelist'},
+    "v|verbose"       => \$opts{'verbose'},
+    "caseroot=s"      => \$opts{'caseroot'},
+    "casebuild=s"     => \$opts{'casebuild'},
+    "cimeroot=s"      => \$opts{'cimeroot'},
+    "inst_string=s"   => \$opts{'inst_string'},	   
+    "ocn_grid=s"      => \$opts{'ocn_grid'},
+    "ocn_forcing=s"   => \$opts{'ocn_forcing'},
+    "decomp_prefix=s" => \$opts{'decomp_prefix'},
+    "date_stamp=s"    => \$opts{'date_stamp'},
+    "ocn_bgc=s"       => \$opts{'ocn_bgc'},
     "ocn_co2_type=s"      => \$opts{'ocn_co2_type'},
     "atm_co2_const_val=s" => \$opts{'atm_co2_const_val'},
-    "ice_bgc=s"     => \$opts{'ice_bgc'},
-    "cfg_dir=s"     => \$opts{'cfg_dir'},
-    "preview"       => \$opts{'preview'},
+    "ice_bgc=s"       => \$opts{'ice_bgc'},
+    "cfg_dir=s"       => \$opts{'cfg_dir'},
+    "preview"         => \$opts{'preview'},
 )  or usage();
 
 # Give usage message.
@@ -147,18 +150,19 @@ my $eol = "\n";
 
 if ($print>=2) { print "Setting MPAS-O configuration script directory to $cfgdir$eol"; }
 
-my $CASEROOT    = $opts{'caseroot'};
-my $CASEBUILD   = $opts{'casebuild'};
-my $CIMEROOT    = $opts{'cimeroot'};
-my $inst_string = $opts{'inst_string'};
-my $OCN_GRID    = $opts{'ocn_grid'};
-my $OCN_FORCING = $opts{'ocn_forcing'};
-my $date_stamp  = $opts{'date_stamp'};
-my $ocn_bgc     = $opts{'ocn_bgc'};
+my $CASEROOT      = $opts{'caseroot'};
+my $CASEBUILD     = $opts{'casebuild'};
+my $CIMEROOT      = $opts{'cimeroot'};
+my $inst_string   = $opts{'inst_string'};
+my $OCN_GRID      = $opts{'ocn_grid'};
+my $OCN_FORCING   = $opts{'ocn_forcing'};
+my $decomp_prefix = $opts{'decomp_prefix'};
+my $date_stamp    = $opts{'date_stamp'};
+my $ocn_bgc       = $opts{'ocn_bgc'};
 my $ocn_co2_type      = $opts{'ocn_co2_type'};
 my $atm_co2_const_val = $opts{'atm_co2_const_val'};
-my $ice_bgc     = $opts{'ice_bgc'};
-$cfgdir         = $opts{'cfg_dir'};
+my $ice_bgc       = $opts{'ice_bgc'};
+$cfgdir           = $opts{'cfg_dir'};
 
 my $CIMEROOT;
 if ( defined $opts{'cimeroot'} ) {
@@ -177,6 +181,7 @@ print $fh  <<"EOF";
 <?xml version="1.0"?>
 <config_definition>
 <entry id="ocn_grid" value="$OCN_GRID">
+<entry id="decomp_prefix" value="$decomp_prefix">
 <entry id="date_stamp" value="$date_stamp">
 </config_definition>
 EOF
@@ -469,7 +474,7 @@ add_default($nl, 'config_pio_stride');
 #################################
 
 add_default($nl, 'config_num_halos');
-add_default($nl, 'config_block_decomp_file_prefix', 'val'=>"'${DIN_LOC_ROOT}/ocn/mpas-o/${OCN_GRID}/mpas-o.graph.info.${date_stamp}.part.'");
+add_default($nl, 'config_block_decomp_file_prefix', 'val'=>"'${DIN_LOC_ROOT}/ocn/mpas-o/${OCN_GRID}/${decomp_prefix}${date_stamp}.part.'");
 add_default($nl, 'config_number_of_blocks');
 add_default($nl, 'config_explicit_proc_decomp');
 add_default($nl, 'config_proc_decomp_file_prefix');

--- a/components/mpas-o/cime_config/buildnml
+++ b/components/mpas-o/cime_config/buildnml
@@ -237,6 +237,7 @@ while ($inst_counter <= $NINST_OCN) {
 	$sysmod .= " -casebuild $CASEBUILD";
 	$sysmod .= " -cimeroot $CIMEROOT";
 	$sysmod .= " -inst_string '$inst_string'";
+	$sysmod .= " -decomp_prefix '$decomp_prefix'";
 	$sysmod .= " -date_stamp '$decomp_date'";
 	$sysmod .= " -ocn_grid '$OCN_MASK'";
 	$sysmod .= " -ocn_forcing '$OCN_FORCING'";

--- a/components/mpasli/bld/build-namelist
+++ b/components/mpasli/bld/build-namelist
@@ -43,8 +43,9 @@ OPTIONS
      -verbose              Turn on verbose echoing of informational messages.
      -caseroot             CASEROOT directory variable
      -casebuild            CASEBUILD directory variable          
-     -cimeroot          CIMEROOT directory variable
+     -cimeroot             CIMEROOT directory variable
      -glc_grid             GLC_GRID variable
+     -decomp_prefix        decomp_prefix variable
      -date_stamp           date_stamp variable
      -cfg_grid             Directory containing MPASLI configuration scripts.
                            If not defined, location is set as \$ProgDir or \$cwd
@@ -81,32 +82,34 @@ if ($ProgDir) {
 
 # Process command-line options.
 
-my %opts = ( help        => 0,
-             test        => 0,
-             verbose     => 0,
-             preview     => 0,
-             caseroot    => undef,
-             casebuild   => undef,
-             cimeroot => undef,
-             inst_string => undef,
-             glc_grid    => undef,
-             date_stamp  => undef,
-             cfg_dir     => $cfgdir,
+my %opts = ( help          => 0,
+             test          => 0,
+             verbose       => 0,
+             preview       => 0,
+             caseroot      => undef,
+             casebuild     => undef,
+             cimeroot      => undef,
+             inst_string   => undef,
+             glc_grid      => undef,
+             decomp_prefix => undef,
+             date_stamp    => undef,
+             cfg_dir       => $cfgdir,
            );
 
 GetOptions(
-    "h|help"        => \$opts{'help'},
-    "infile=s"      => \$opts{'infile'},
-    "namelist=s"    => \$opts{'namelist'},
-    "v|verbose"     => \$opts{'verbose'},
-    "caseroot=s"    => \$opts{'caseroot'},
-    "casebuild=s"   => \$opts{'casebuild'},
-    "cimeroot=s" => \$opts{'cimeroot'},
-    "inst_string=s" => \$opts{'inst_string'},	   
-    "glc_grid=s"    => \$opts{'glc_grid'},
-    "date_stamp=s"  => \$opts{'date_stamp'},
-    "cfg_dir=s"     => \$opts{'cfg_dir'},
-    "preview"       => \$opts{'preview'},
+    "h|help"          => \$opts{'help'},
+    "infile=s"        => \$opts{'infile'},
+    "namelist=s"      => \$opts{'namelist'},
+    "v|verbose"       => \$opts{'verbose'},
+    "caseroot=s"      => \$opts{'caseroot'},
+    "casebuild=s"     => \$opts{'casebuild'},
+    "cimeroot=s"      => \$opts{'cimeroot'},
+    "inst_string=s"   => \$opts{'inst_string'},	   
+    "glc_grid=s"      => \$opts{'glc_grid'},
+    "decomp_prefix=s" => \$opts{'decomp_prefix'},
+    "date_stamp=s"    => \$opts{'date_stamp'},
+    "cfg_dir=s"       => \$opts{'cfg_dir'},
+    "preview"         => \$opts{'preview'},
 )  or usage();
 
 # Give usage message.
@@ -130,13 +133,14 @@ my $eol = "\n";
 
 if ($print>=2) { print "Setting MPASLI configuration script directory to $cfgdir$eol"; }
 
-my $CASEROOT    = $opts{'caseroot'};
-my $CASEBUILD   = $opts{'casebuild'};
-my $CIMEROOT = $opts{'cimeroot'};
-my $inst_string = $opts{'inst_string'};
-my $GLC_GRID    = $opts{'glc_grid'};
-my $date_stamp  = $opts{'date_stamp'};
-$cfgdir         = $opts{'cfg_dir'};
+my $CASEROOT      = $opts{'caseroot'};
+my $CASEBUILD     = $opts{'casebuild'};
+my $CIMEROOT      = $opts{'cimeroot'};
+my $inst_string   = $opts{'inst_string'};
+my $GLC_GRID      = $opts{'glc_grid'};
+my $decomp_prefix = $opts{'decomp_prefix'};
+my $date_stamp    = $opts{'date_stamp'};
+$cfgdir           = $opts{'cfg_dir'};
 
 my $CIMEROOT;
 if ( defined $opts{'cimeroot'} ) {
@@ -157,6 +161,7 @@ print $fh  <<"EOF";
 <?xml version="1.0"?>
 <config_definition>
 <entry id="glc_grid" value="$GLC_GRID">
+<entry id="decomp_prefix" value="$decomp_prefix">
 <entry id="date_stamp" value="$date_stamp">
 </config_definition>
 EOF
@@ -513,7 +518,7 @@ add_default($nl, 'config_write_albany_ascii_mesh');
 #################################
 
 add_default($nl, 'config_num_halos');
-add_default($nl, 'config_block_decomp_file_prefix', 'val'=>"'${DIN_LOC_ROOT}/glc/mpasli/${GLC_GRID}/mpasli.graph.info.${date_stamp}.part.'");
+add_default($nl, 'config_block_decomp_file_prefix', 'val'=>"'${DIN_LOC_ROOT}/glc/mpasli/${GLC_GRID}/${decomp_prefix}${date_stamp}.part.'");
 add_default($nl, 'config_number_of_blocks');
 add_default($nl, 'config_explicit_proc_decomp');
 add_default($nl, 'config_proc_decomp_file_prefix');

--- a/components/mpasli/cime_config/buildnml
+++ b/components/mpasli/cime_config/buildnml
@@ -117,6 +117,7 @@ while ($inst_counter <= $NINST_GLC) {
 	$sysmod .= " -casebuild $CASEBUILD";
 	$sysmod .= " -cimeroot $CIMEROOT";
 	$sysmod .= " -inst_string '$inst_string'";
+	$sysmod .= " -decomp_prefix '$decomp_prefix'";
 	$sysmod .= " -date_stamp '$grid_date'";
 	$sysmod .= " -glc_grid '$GLC_GRID'";
 


### PR DESCRIPTION
This PR implements a fix to the build scripts for mpas-o and mpasli to use the "decomp_prefix" variable in determining the name and location of default partition ("graph") files. The variable has been in the scripts for some time but had not been implemented. This change has already been made in mpas-seaice in PR #2085.

Tested with:
* SMS_D.T62_oQU120_ais20.MPAS_LISIO_TEST.anvil_intel

[BFB]