### PR TITLE
Initialize all elements of COSP's cv_reffliq/cv_reffice arrays

### DIFF
--- a/components/cam/src/physics/cam/micro_mg_cam.F90
+++ b/components/cam/src/physics/cam/micro_mg_cam.F90
@@ -2789,8 +2789,8 @@ subroutine micro_mg_cam_tend(state, ptend, dtime, pbuf)
       end do
    end do
 
-   mgreffrain_grid(:ngrdcol,top_lev:pver) = reff_rain_grid(:ngrdcol,top_lev:pver)
-   mgreffsnow_grid(:ngrdcol,top_lev:pver) = reff_snow_grid(:ngrdcol,top_lev:pver)
+   mgreffrain_grid(:ngrdcol,:pver) = reff_rain_grid(:ngrdcol,:pver)
+   mgreffsnow_grid(:ngrdcol,:pver) = reff_snow_grid(:ngrdcol,:pver)
 
    ! ------------------------------------- !
    ! Precipitation efficiency Calculation  !


### PR DESCRIPTION
Initialize all elements of COSP's cv_reffliq/cv_reffice arrays.
This avoids NaNs in debug runs.

[BFB]
Fixes ACME-Climate/ACME#2133
