### PR TITLE
Clean-ups of Titan machinefiles

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -867,27 +867,31 @@ for mct, etc.
   <ADD_FFLAGS DEBUG="FALSE"> -O2 </ADD_FFLAGS>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) </ADD_SLIBS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
-  <ADD_SLIBS MPILIB="mpich"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="mpich2"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="mpt"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="openmpi"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="mvapich"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="impi"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="mpi-serial"> -mkl </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mpich"> $(shell nf-config --flibs) -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mpich2">$(shell nf-config --flibs)  -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mpt"> $(shell nf-config --flibs) -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="openmpi"> $(shell nf-config --flibs) -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mvapich"> $(shell nf-config --flibs) -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="impi"> $(shell nf-config --flibs) -mkl=cluster </ADD_SLIBS>
+  <!-- mx: the cray-netcdf has wrong configuration on titan, so have to specify the lib path explicitly  -->
+  <ADD_SLIBS MPILIB="mpi-serial"> -L/opt/cray/netcdf/4.4.1.1.3/INTEL/16.0/lib -lnetcdff -L/opt/cray/hdf5/1.10.0.3/GNU/4.9/lib -lnetcdf -mkl </ADD_SLIBS>
 </compiler>
 
 <compiler COMPILER="pgi" MACH="titan">
   <ADD_CFLAGS DEBUG="FALSE"> -O2 </ADD_CFLAGS>
   <ADD_FFLAGS DEBUG="FALSE"> -O2 </ADD_FFLAGS>
   <ADD_FFLAGS MODEL="glc"> -target-cpu=istanbul </ADD_FFLAGS>
-  <NETCDF_PATH>$(NETCDFROOT)</NETCDF_PATH>
-  <PNETCDF_PATH>$(PNETCDFROOT)</PNETCDF_PATH>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <ADD_SLIBS> $(shell nf-config --flibs) </ADD_SLIBS>
-  <TRILINOS_PATH>/lustre/atlas/world-shared/cli900/cesm/software/Trilinos/Trilinos-11.10.2_gptl/titan-pgi-ci-nophal/install</TRILINOS_PATH>
+  <ADD_SLIBS MPILIB="mpich"> $(shell nf-config --flibs) </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mpich2"> $(shell nf-config --flibs) </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mpt"> $(shell nf-config --flibs) </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="openmpi"> $(shell nf-config --flibs) </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mvapich"> $(shell nf-config --flibs) </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="impi"> $(shell nf-config --flibs) </ADD_SLIBS>
+  <!-- mx: the cray-netcdf has wrong configuration on titan, so have to specify the lib path explicitly  -->
+  <ADD_SLIBS MPILIB="mpi-serial"> -L/opt/cray/netcdf/4.4.1.1.3/PGI/15.3/lib -lnetcdff -L/opt/cray/hdf5/1.10.0.3/GNU/4.9/lib -lnetcdf </ADD_SLIBS>
   <CXX_LIBS> -lfmpich -lmpichf90_pgi $(PGI_PATH)/linux86-64/$(PGI_VERSION)/lib/f90main.o /opt/gcc/default/snos/lib64/libstdc++.a  </CXX_LIBS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
   <MPIFC> ftn </MPIFC>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1971,27 +1971,13 @@
     <PROJECT>cli115</PROJECT>
     <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+
     <mpirun mpilib="default">
       <executable>aprun</executable>
-      <arguments>
-	<!-- <arg name="hyperthreading" default="2"> -j {{ hyperthreading }}</arg>
-        <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
-        <arg name="num_tasks" > -n $TOTALPES</arg>
-        <arg name="tasks_per_node" > -N $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
-        <arg name="numa_node" > -cc numa_node </arg>
-	-->
-	<arg name="aprun"> {{ aprun }}</arg>
-      </arguments>
-
     </mpirun>
 
     <mpirun mpilib="mpi-serial">
       <executable>aprun</executable>
-      <arguments>
-        <arg name="aprun"> {{ aprun }}</arg>
-      </arguments>
-
     </mpirun>
 
     <module_system type="module">
@@ -2011,7 +1997,7 @@
       <modules>
         <command name="load">python/2.7.9</command>
         <command name="unload">subversion</command>
-        <command name="load">subversion/1.8.3</command>
+        <command name="load">subversion/1.9.3</command>
         <command name="unload">cmake</command>
         <command name="load">cmake3/3.6.0</command>
       </modules>
@@ -2061,7 +2047,6 @@
         <command name="rm">cray-mpich</command>
         <command name="rm">atp</command>
         <command name="load">intel/18.0.0.128</command>
-        <command name="load">cray-libsci/16.11.1</command>
         <command name="load">cray-mpich/7.6.3</command>
         <command name="load">atp/2.1.1</command>
       </modules>
@@ -2078,9 +2063,13 @@
       </modules>
       <!-- mpi lib settings -->
       <modules mpilib="mpi-serial">
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="load">cray-netcdf/4.4.1.1.3</command>
       </modules>
       <modules mpilib="!mpi-serial">
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
         <command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
@@ -2094,31 +2083,6 @@
         <env name="MPICH_CPUMASK_DISPLAY">1</env>
         <env name="MPSTKZ">128M</env>
         <env name="OMP_STACKSIZE">128M</env>
-      </environment_variables>
-      <environment_variables compiler="pgi" mpilib="mpi-serial">
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
-      </environment_variables>
-      <environment_variables compiler="pgi" mpilib="!mpi-serial">
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1.3/PGI/15.3/</env>
-	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.8.1.3/PGI/15.3</env>
-      </environment_variables>
-      <environment_variables compiler="pgiacc">
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1.3/PGI/15.3/</env>
-      </environment_variables>
-      <environment_variables compiler="pgiacc" mpilib="!mpi-serial">
-	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.8.1.3/PGI/15.3</env>
-      </environment_variables>
-      <environment_variables compiler="intel">
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1.3/INTEL/16.0/</env>
-      </environment_variables>
-      <environment_variables compiler="intel" mpilib="!mpi-serial">
-	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.8.1.3/INTEL/16.0</env>
-      </environment_variables>
-      <environment_variables compiler="cray">
-	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1.3/CRAY/8.6/</env>
-      </environment_variables>
-      <environment_variables compiler="cray" mpilib="!mpi-serial">
-	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.8.1.3/CRAY/8.6</env>
       </environment_variables>
 
       <!-- Set if compiler and mpilib  -->


### PR DESCRIPTION
Try to clean up obsolete and redundant items in Titan machinefiles:

     - config_machine.xml:	
        * delete the NETCDFROOT environment variable because it is redundant and 
          the cray netcdf path is used to set the NETCDF_PATH if the OS is CNL.
        * delete the argument subsection under mpirun section because it will give the warning of 
          "could not replace variable 'aprun'" during a job submission. 
        * update subversion from 1.8.3 to 1.9.3 because the version 1.8.3 was removed yesterday on titan. 
        * not load the cray-libsci for intel compiler because MKL should be used for intel compiler.

     - config_compiler.xml:
        * delete the NETCDF_PATH, same reason for deleting NETCDFROOT.
        * delete the obsolete TRILINOS_PATH because it pointed to a dead link and 
          it is not used anymore.
        * explicitly define the netcdf libraries to link for a
          mpi-serial program and by using "nf-config" for a mpi program, because the cray-netcdf was 
          installed incorrectly on titan and it linked to a parallel HDF5 version.