### PR TITLE
Update rof=>ocn map for high-res configuration.

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -2160,13 +2160,13 @@
     </gridmap>
 
     <gridmap rof_grid="r0125" ocn_grid="oRRS18to6v3" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_LIQ_RMAPNAME>
+      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r25e50.180305.nc</ROF2OCN_ICE_RMAPNAME>
+      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r25e50.180305.nc</ROF2OCN_LIQ_RMAPNAME>
     </gridmap>
 
     <gridmap rof_grid="r0125" ocn_grid="oRRS18to6v3_ICG" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_LIQ_RMAPNAME>
+      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r25e50.180305.nc</ROF2OCN_ICE_RMAPNAME>
+      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r25e50.180305.nc</ROF2OCN_LIQ_RMAPNAME>
     </gridmap>
 
     <gridmap rof_grid="r0125" ocn_grid="oRRS15to5" >


### PR DESCRIPTION
Do not merge - still in testing

This PR points to an updated high-res rof=>ocn file for the r0125 and oRRS18to6v3 combination. The new mapping file only uses mosart masked cells as source for the map, which decreases the size of the resultant file by about 70%. The intention is to decrease the initialization time (especially on knl platforms) of the fully-coupled high-res model due to the huge number of required seg-maps.

The file in testing has not been smoothed in the same way as the one it replaces, so it will not be BFB. But if the system can tolerate this approach, we will also test with one smoothed using the same parameters.