### PR TITLE
Updates definition of I-compsets using GSW

### DIFF
--- a/components/clm/cime_config/config_compsets.xml
+++ b/components/clm/cime_config/config_compsets.xml
@@ -784,244 +784,244 @@
    <!---I GSWP3 compsets-->
   <compset>
     <alias>IGSWCLM45</alias>
-    <lname>2000_DATM%GSW_CLM45_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWCN</alias>
-    <lname>2000_DATM%GSW_CLM40%CN_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM40%CN_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
 
   <compset>
     <alias>I1850GSWCLM45CN</alias>
-    <lname>1850_DATM%GSW_CLM45%CN_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>1850_DATM%GSWP3v1_CLM45%CN_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>I1850GSWCLM45BGCDV</alias>
-    <lname>1850_DATM%GSW_CLM45%BGCDV_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>1850_DATM%GSWP3v1_CLM45%BGCDV_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWCLM45BGCCROP</alias>
-    <lname>2000_DATM%GSW_CLM45%BGC-CROP_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%BGC-CROP_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWCLM45BGCTEST</alias>
-    <lname>2003_DATM%GSW_CLM45%BGC_SICE_SOCN_RTM_SGLC_SWAV_TEST</lname>
+    <lname>2003_DATM%GSWP3v1_CLM45%BGC_SICE_SOCN_RTM_SGLC_SWAV_TEST</lname>
   </compset>
 
   <compset>
     <alias>IGSWCLM45BGC</alias>
-    <lname>2000_DATM%GSW_CLM45%BGC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%BGC_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>I1850GSWCLM45BGC</alias>
-    <lname>1850_DATM%GSW_CLM45%BGC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>1850_DATM%GSWP3v1_CLM45%BGC_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>I20TRCRUCLM45BGC</alias>
-    <lname>20TR_DATM%GSW_CLM45%BGC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>20TR_DATM%GSWP3v1_CLM45%BGC_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWCRDCTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWCNRDCTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CNRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CNRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWCNPRDCTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CNPRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CNPRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWCNECACTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CNECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CNECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWCNPECACTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CNPECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CNPECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWM2000CRDCTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWM2000CNRDCTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWM2000CNPRDCTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWM2000CNECACTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CNECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CNECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IGSWM2000CNPECACTCBC</alias>
-    <lname>2000_DATM%GSW_CLM45%CNPECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM45%CNPECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
 
   <compset>
     <alias>IGSWCLM50BGC</alias>
-    <lname>2000_DATM%GSW_CLM50%BGC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>2000_DATM%GSWP3v1_CLM50%BGC_SICE_SOCN_RTM_SGLC_SWAV</lname>
   </compset>
 
    <compset>
      <alias>I1850GSWCNPECACNTBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNPECACNTBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNPECACNTBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
     <alias>IM1850GSWCNPECACTCBC</alias>
-    <lname>1850_DATM%GSW_CLM45%CNPECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>1850_DATM%GSWP3v1_CLM45%CNPECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>IM1850GSWCNPECACTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNPECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNPECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>I1850GSWCNECACTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
     <alias>IM1850GSWCNECACTCBC</alias>
-    <lname>1850_DATM%GSW_CLM45%CNECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>1850_DATM%GSWP3v1_CLM45%CNECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>IM1850GSWCNECACTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
     <alias>I1850GSWCNPECACTCBC</alias>
-    <lname>1850_DATM%GSW_CLM45%CNPECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>1850_DATM%GSWP3v1_CLM45%CNPECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>I1850GSWCNPECACTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNPECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNPECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>IM1850GSWCNPECACNTBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
     <alias>I1850GSWCECACTCBC</alias>
-    <lname>1850_DATM%GSW_CLM45%CECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>1850_DATM%GSWP3v1_CLM45%CECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>IM1850GSWCNECACNTBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>I1850GSWCNECACNTBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNECACNTBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNECACNTBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>IM20TRGSWCNECACTCBC</alias>
-     <lname>20TR_DATM%GSW_CLM45%CNECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>20TR_DATM%GSWP3v1_CLM45%CNECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>I20TRGSWCNPECACTCBC</alias>
-     <lname>20TR_DATM%GSW_CLM45%CNPECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>20TR_DATM%GSWP3v1_CLM45%CNPECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>IM20TRGSWCNPECACTCBC</alias>
-     <lname>20TR_DATM%GSW_CLM45%CNPECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>20TR_DATM%GSWP3v1_CLM45%CNPECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>I20TRGSWCNPECACNTBC</alias>
-     <lname>20TR_DATM%GSW_CLM45%CNPECACNTBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>20TR_DATM%GSWP3v1_CLM45%CNPECACNTBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>I20TRGSWCNECACNTBC</alias>
-     <lname>20TR_DATM%GSW_CLM45%CNECACNTBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>20TR_DATM%GSWP3v1_CLM45%CNECACNTBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>I20TRGSWCNECACTCBC</alias>
-     <lname>20TR_DATM%GSW_CLM45%CNECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>20TR_DATM%GSWP3v1_CLM45%CNECACTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>IM20TRGSWCNPECACNTBC</alias>
-     <lname>20TR_DATM%GSW_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>20TR_DATM%GSWP3v1_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
      <alias>IM20TRGSWCNECACNTBC</alias>
-     <lname>20TR_DATM%GSW_CLM45%CNECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>20TR_DATM%GSWP3v1_CLM45%CNECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
    <compset>
      <alias>I1850GSWCNRDCTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
 
    <compset>
     <alias>I1850GSWCNPRDCTCBC</alias>
-    <lname>1850_DATM%GSW_CLM45%CNPRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>1850_DATM%GSWP3v1_CLM45%CNPRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
 
    <compset>
      <alias>IM1850GSWCNRDCTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
    <compset>
      <alias>IM1850GSWCNPRDCTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
    <compset>
      <alias>I20TRGSWCNRDCTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
 
    <compset>
     <alias>I20TRGSWCNPRDCTCBC</alias>
-    <lname>1850_DATM%GSW_CLM45%CNPRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <lname>1850_DATM%GSWP3v1_CLM45%CNPRDCTCBC_SICE_SOCN_RTM_SGLC_SWAV</lname>
    </compset>
 
    <compset>
      <alias>IM20TRGSWCNRDCTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
    <compset>
      <alias>IM20TRGSWCNPRDCTCBC</alias>
-     <lname>1850_DATM%GSW_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>1850_DATM%GSWP3v1_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
    
   <!---I compset system tests -->


### PR DESCRIPTION
Following changes made to CIME in 289bb76, I-compsets definition using
GSW is updated to use GSWP3v1 dataset.

Fixes #2140
[NML]