### PR TITLE
Support for nersc_slurm queue type

### DIFF
--- a/cime/scripts/tests/run_e3sm_ctest/runE3smTest_template.sh
+++ b/cime/scripts/tests/run_e3sm_ctest/runE3smTest_template.sh
@@ -73,7 +73,7 @@ elif [ "$batchsystem" == "pbs" ]; then
     do sleep 5
   done
 
-elif [ "$batchsystem" == "slurm" ]; then
+elif [[ "$batchsystem" = *"slurm"* ]]; then
   echo "BATCH_SYSTEM = slurm ; Waiting for batch job to finish"
   while [ `squeue -j ${jobid} | wc -l` -eq 2 ]
     do sleep 5


### PR DESCRIPTION
This fixes the CTest script for machines with nersc_slurm queue types.
An alternative (and potentially preferred) fix would be to figure out how to create a subtype of the slurm queue in the xml and just use that.