### PR TITLE
fix some memory leaks

### DIFF
--- a/components/homme/src/share/edge_mod_base.F90
+++ b/components/homme/src/share/edge_mod_base.F90
@@ -3,7 +3,10 @@
 #endif
 
 module edge_mod_base
-
+!
+! Revisions
+!   2018/3 Mark Taylor:  update FreeEdgeBuffer to fix memory leak
+!
   use kinds, only : int_kind, log_kind, real_kind
   use dimensions_mod, only : max_neigh_edges, nelemd
   use perf_mod, only: t_startf, t_stopf, t_adj_detailf ! _EXTERNAL
@@ -434,6 +437,16 @@ endif
     deallocate(edge%putmap)
     deallocate(edge%getmap)
     deallocate(edge%reverse)
+
+    deallocate(edge%moveLength)
+    deallocate(edge%movePtr)
+
+    deallocate(edge%Srequest)
+    deallocate(edge%Rrequest)
+    deallocate(edge%status)
+
+
+
 #if (defined HORIZ_OPENMP)
 !$OMP END MASTER
 #endif

--- a/components/homme/src/share/ll_mod.F90
+++ b/components/homme/src/share/ll_mod.F90
@@ -4,8 +4,8 @@
 
 module ll_mod
 !
-!
-! Updated 2018/3 Mark Taylor, fix memory leak
+! Revisions:
+! 2018/3 Mark Taylor, fix memory leak
 !
   implicit none
   private

--- a/components/homme/src/share/ll_mod.F90
+++ b/components/homme/src/share/ll_mod.F90
@@ -3,6 +3,10 @@
 #endif
 
 module ll_mod
+!
+!
+! Updated 2018/3 Mark Taylor, fix memory leak
+!
   implicit none
   private
   type :: node_t
@@ -75,7 +79,8 @@ contains
        deallocate(temp_node%next)
        temp_node => temp_node%prev
     enddo
-
+    deallocate(List%first)
+    
   end subroutine LLFree
 
   subroutine LLInsertEdge(EdgeList,src,dest,eNum)

--- a/components/homme/src/share/metagraph_mod.F90
+++ b/components/homme/src/share/metagraph_mod.F90
@@ -5,6 +5,10 @@
 !************************metagraph_mod.F****************************************
 
 module metagraph_mod
+!
+!  Revisions:
+!  Mark Taylor 2018/3  fix memory leak
+!
   use kinds, only : int_kind, iulog
   use gridgraph_mod, only : gridvertex_t, gridedge_t, &
        allocate_gridvertex_nbrs, assignment ( = )
@@ -339,16 +343,18 @@ contains
     if(Debug) write(iulog,*)'initMetagraph: point #4.1 i,MetaVertex%nmembers',i,MetaVertex%nmembers
     allocate(MetaVertex%members(MetaVertex%nmembers))
 
-    do j=1, MetaVertex%nmembers
-       call allocate_gridvertex_nbrs(MetaVertex%members(j))
-    end do
-
+    ! dont allocate %members - struct will be allocated in the overloaded assignement
+    ! operation below
+!    do j=1, MetaVertex%nmembers
+!       call allocate_gridvertex_nbrs(MetaVertex%members(j))
+!    end do
+    
     if(Debug) write(iulog,*)'initMetagraph: point #5'
 
     !  Set the identity of the members of the MetaVertices
     ic=1
     do j=1,nelem
-       if( GridVertex(j)%processor_number .eq. ThisProcessorNumber) then 
+       if( GridVertex(j)%processor_number .eq. ThisProcessorNumber) then
           MetaVertex%members(ic) = GridVertex(j)
           ic=ic+1
        endif

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -488,10 +488,10 @@ contains
        call deallocate_gridvertex_nbrs(MetaVertex(1)%members(j))
     end do
     do j = 1, MetaVertex(1)%nedges
-       deallocate(MetaVertex(1)%edges(j)%members
-       deallocate(MetaVertex(1)%edges(j)%edgeptrP
-       deallocate(MetaVertex(1)%edges(j)%edgeptrS
-       deallocate(MetaVertex(1)%edges(j)%edgeptrP_ghost
+       deallocate(MetaVertex(1)%edges(j)%members)
+       deallocate(MetaVertex(1)%edges(j)%edgeptrP)
+       deallocate(MetaVertex(1)%edges(j)%edgeptrS)
+       deallocate(MetaVertex(1)%edges(j)%edgeptrP_ghost)
     end do
     deallocate(MetaVertex(1)%edges)
     deallocate(MetaVertex(1)%members)

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -2,7 +2,7 @@
 ! prim_driver_mod: 
 !
 ! 08/2016: O. Guba Inserting code for "espilon bubble" reference element map
-!
+! 03/2018: M. Taylor  fix memory leak
 !
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -487,6 +487,8 @@ contains
     do j = 1, MetaVertex(1)%nmembers
        call deallocate_gridvertex_nbrs(MetaVertex(1)%members(j))
     end do
+    deallocate(MetaVertex(1)%edges)
+    deallocate(MetaVertex(1)%members)
     deallocate(MetaVertex)
     deallocate(TailPartition)
     deallocate(HeadPartition)

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -487,6 +487,12 @@ contains
     do j = 1, MetaVertex(1)%nmembers
        call deallocate_gridvertex_nbrs(MetaVertex(1)%members(j))
     end do
+    do j = 1, MetaVertex(1)%nedges
+       deallocate(MetaVertex(1)%edges(j)%members
+       deallocate(MetaVertex(1)%edges(j)%edgeptrP
+       deallocate(MetaVertex(1)%edges(j)%edgeptrS
+       deallocate(MetaVertex(1)%edges(j)%edgeptrP_ghost
+    end do
     deallocate(MetaVertex(1)%edges)
     deallocate(MetaVertex(1)%members)
     deallocate(MetaVertex)

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -1,6 +1,7 @@
 ! ------------------------------------------------------------------------------------------------
 ! prim_driver_mod: 
 !
+! Revisions:
 ! 08/2016: O. Guba Inserting code for "espilon bubble" reference element map
 ! 03/2018: M. Taylor  fix memory leak
 !

--- a/components/homme/src/share/schedule_mod.F90
+++ b/components/homme/src/share/schedule_mod.F90
@@ -248,10 +248,6 @@ contains
        ig                  = MetaVertex%members(ie)%number
        elem(ie)%GlobalId   = ig
        elem(ie)%LocalId    = ie  
-#if 0
-       call LLInsertEdge(eroot,ig,jmd)
-       !DBG write(iulog,*)'After call to LLInsertEdge in schedule: ie,ig ',ie,ig,jmd
-#endif
     enddo
 
     deallocate(Global2Local)

--- a/components/homme/src/share/spacecurve_mod.F90
+++ b/components/homme/src/share/spacecurve_mod.F90
@@ -5,6 +5,7 @@
 module spacecurve_mod
 !
 !
+! Revisions:
 ! Mark Taylor: 2018/3  Remove memory leaks, make most routines private
 !
   use kinds, only : iulog

--- a/components/homme/src/share/spacecurve_mod.F90
+++ b/components/homme/src/share/spacecurve_mod.F90
@@ -3,6 +3,10 @@
 #endif
 
 module spacecurve_mod
+!
+!
+! Mark Taylor: 2018/3  Remove memory leaks, make most routines private
+!
   use kinds, only : iulog
   implicit none
   private
@@ -21,16 +25,10 @@ module spacecurve_mod
   integer,public                              :: vcnt   ! visitation count
   logical,private                             :: verbose=.FALSE. 
 
-  type (factor_t),  public                      :: fact
+  type (factor_t), private                  :: fact
 
-  !JMD new addition
   SAVE:: fact
-  public :: map 
-  public :: hilbert_old
-  public :: PeanoM,hilbert, Cinco
-  public :: GenCurve
   public :: GenSpaceCurve
-  public :: log2,Factor
   public :: PrintCurve
   public :: IsFactorable,IsLoadBalanced
   public :: genspacepart
@@ -899,6 +897,9 @@ contains
   end function GenCurve
   !---------------------------------------------------------
   function Factor(num) result(res)
+  ! note: this function is allocating memory in the 'fact' struct
+  ! to avoid memory leaks, the calling program needs to deallocate
+  ! this array.  poor design choice. 
 
     implicit none
     integer,intent(in)  :: num
@@ -988,7 +989,8 @@ contains
     else
        IsFactorable = .FALSE.
     endif
-
+    deallocate(fact%factors)
+    
   end function IsFactorable
   !------------------------------------------------
   subroutine map(l)
@@ -1033,7 +1035,9 @@ contains
        !  The array ordered will contain the visitation order
        ordered(:,:) = 0
 
-       call map(level) 
+       call map(level)
+       deallocate(fact%factors)
+
 
        Mesh(:,:) = ordered(:,:)
 


### PR DESCRIPTION
Fix many of the memory leaks reported by address sanitizer.

The leaks were relatively harmess: only allocated once so the memory usage would not grow during the simulation.  But deallocating them will reduce the memory footprint.

Some of the other memory leaks found I believe are allocated arrays that are needed for the entire simulation.  deallocating them at the end of the simulation wont save any memory, but will produce fewer false alarms when looking for memory leaks.  

Addresses #1991