### PR TITLE
Default layouts for G 30to10 on cori/edison

### DIFF
--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -8139,7 +8139,7 @@
           <nthrds_ocn>2</nthrds_ocn>
           <nthrds_glc>1</nthrds_glc>
           <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_cpl>2</nthrds_cpl>
         </nthrds>
         <rootpe>
           <rootpe_atm>0</rootpe_atm>


### PR DESCRIPTION
As a MPAS G case test with 30to10 resolution (which is in between our low and high res) was added to nightly testing, we needed a default layout for NERSC machines.