### PR TITLE
Update x2l index name to fix issue with IGCLM45_MLI tests.

### DIFF
--- a/components/clm/src/cpl/clm_cpl_indices.F90
+++ b/components/clm/src/cpl/clm_cpl_indices.F90
@@ -265,7 +265,7 @@ contains
     do num = 0,glc_nec_max 
     
        write(cnum,'(i2.2)') num
-       name = 'Sg_frac' // cnum
+       name = 'Sg_ice_covered' // cnum
        index_x2l_Sg_frac(num)   = mct_avect_indexra(x2l,trim(name),perrwith='quiet') 
        name = 'Sg_topo' // cnum
        index_x2l_Sg_topo(num)   = mct_avect_indexra(x2l,trim(name),perrwith='quiet')


### PR DESCRIPTION
This PR updates the name of an x2l index name to match changes made in the cpl several months ago. This index is used only when create_glacier_mec_landunit is true, and fixes an issue that was causing IGCLM45_MLI to fail. Note that cime and its cpl code continue to change to support the CESM GLC model, and keeping up with those changes will require attention.

Fixes [#2051](https://github.com/ACME-Climate/ACME/issues/2051)

BFB for all tested configurations except IGCLM45_MLI, which has been failing