### PR TITLE
Improve runtime of PET_Ln9.ne30_oECv3_ICG.A_WCYCL1850S integration test

### DIFF
--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -1278,6 +1278,43 @@
     </mach>
   </grid>
   <grid name="any">
+    <mach name="sandiatoss3">
+      <pes compset="any" pesize="S">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>64</ntasks_atm>
+          <ntasks_lnd>64</ntasks_lnd>
+          <ntasks_rof>64</ntasks_rof>
+          <ntasks_ice>64</ntasks_ice>
+          <ntasks_ocn>64</ntasks_ocn>
+          <ntasks_glc>64</ntasks_glc>
+          <ntasks_wav>64</ntasks_wav>
+          <ntasks_cpl>64</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="any">
     <mach name="anlworkstation">
       <pes compset="any" pesize="any">
         <comment>none</comment>

--- a/cime/scripts/lib/update_e3sm_tests.py
+++ b/cime/scripts/lib/update_e3sm_tests.py
@@ -148,7 +148,7 @@ _TEST_SUITES = {
                           #"ERT_Ld31.ne16_g37.B1850C5",#add this line back in with the new correct compset
                            ("PET.f19_g16.X","mach-pet"),
                            ("PET.f45_g37_rx1.A","mach-pet"),
-                           ("PET_Ln9.ne30_oECv3_ICG.A_WCYCL1850S","mach-pet"),
+                           ("PET_Ln9_PS.ne30_oECv3_ICG.A_WCYCL1850S","mach-pet"),
                            "PEM_Ln9.ne30_oECv3_ICG.A_WCYCL1850S",
                            "ERP_Ld3.ne30_oECv3_ICG.A_WCYCL1850S",
                            "SEQ_IOP.f19_g16.X",


### PR DESCRIPTION
This test is typically, by far, the slowest of our integration tests
to complete. Since we are only doing a Ln9 run, it makes no sense to
use a large peylayout. A much better approach is to use the PS test option
to force a smaller layout so we can get in the queue faster.

This PR also defined a small grid layout for sandiatoss3.

This PR allows both phases of the above test to fit into the sandiatoss3
"short" queue.

[BFB]