### PR TITLE
Fixes land energy imbalance and applies post deck CPP directive

### DIFF
--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -399,7 +399,11 @@ contains
 
           if (do_capsnow(c)) then
              dz_snowf = 0._r8
+#ifdef APPLY_POST_DECK_BUGFIXES
+             newsnow(c) = qflx_snow_grnd_col(c) * dtime
+#else
              newsnow(c) = (1._r8 - frac_h2osfc(c)) * qflx_snow_grnd_col(c) * dtime
+#endif
              frac_sno(c)=1._r8
              int_snow(c) = 5.e2_r8
           else
@@ -411,8 +415,13 @@ contains
                 bifall=50._r8
              end if
 
+#ifdef APPLY_POST_DECK_BUGFIXES
+             ! all snow falls on ground, no snow on h2osfc
+             newsnow(c) = qflx_snow_grnd_col(c) * dtime
+#else
              ! newsnow is all snow that doesn't fall on h2osfc
              newsnow(c) = (1._r8 - frac_h2osfc(c)) * qflx_snow_grnd_col(c) * dtime
+#endif
 
              ! update int_snow
              int_snow(c) = max(int_snow(c),h2osno(c)) !h2osno could be larger due to frost
@@ -507,8 +516,13 @@ contains
                 endif
              endif ! end of h2osno > 0
 
+#ifdef APPLY_POST_DECK_BUGFIXES
+             ! no snow on surface water
+             qflx_snow_h2osfc(c) = 0._r8
+#else
              ! snow directly falling on surface water melts, increases h2osfc
              qflx_snow_h2osfc(c) = frac_h2osfc(c)*qflx_snow_grnd_col(c)
+#endif
 
              ! update h2osno for new snow
              h2osno(c) = h2osno(c) + newsnow(c) 

--- a/components/clm/src/biogeophys/EnergyFluxType.F90
+++ b/components/clm/src/biogeophys/EnergyFluxType.F90
@@ -19,6 +19,9 @@ module EnergyFluxType
   type, public :: energyflux_type
 
      ! Fluxes
+#ifdef APPLY_POST_DECK_BUGFIXES
+     real(r8), pointer :: eflx_h2osfc_to_snow_col (:)   ! col snow melt to h2osfc heat flux (W/m**2)
+#endif
      real(r8), pointer :: eflx_sh_grnd_patch      (:)   ! patch sensible heat flux from ground (W/m**2) [+ to atm]
      real(r8), pointer :: eflx_sh_veg_patch       (:)   ! patch sensible heat flux from leaves (W/m**2) [+ to atm]
      real(r8), pointer :: eflx_sh_snow_patch      (:)   ! patch sensible heat flux from snow (W/m**2) [+ to atm]
@@ -170,6 +173,9 @@ contains
     begl = bounds%begl; endl= bounds%endl
     begg = bounds%begg; endg= bounds%endg
 
+#ifdef APPLY_POST_DECK_BUGFIXES
+    allocate( this%eflx_h2osfc_to_snow_col (begc:endc))             ; this%eflx_h2osfc_to_snow_col (:)   = nan
+#endif
     allocate( this%eflx_sh_snow_patch      (begp:endp))             ; this%eflx_sh_snow_patch      (:)   = nan
     allocate( this%eflx_sh_soil_patch      (begp:endp))             ; this%eflx_sh_soil_patch      (:)   = nan
     allocate( this%eflx_sh_h2osfc_patch    (begp:endp))             ; this%eflx_sh_h2osfc_patch    (:)   = nan

--- a/components/clm/src/biogeophys/SnowHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SnowHydrologyMod.F90
@@ -430,8 +430,13 @@ contains
 
          qflx_top_soil(c) = (qout(c) / dtime) &
               + (1.0_r8 - frac_sno_eff(c)) * qflx_rain_grnd(c)
+#ifdef APPLY_POST_DECK_BUGFIXES
+         int_snow(c) = int_snow(c) + frac_sno_eff(c) &
+                       * (qflx_dew_snow(c) + qflx_dew_grnd(c) + qflx_rain_grnd(c)) * dtime
+#else
          int_snow(c) = int_snow(c) + frac_sno_eff(c) * qflx_dew_snow(c)  * dtime &
                                    + frac_sno_eff(c) * qflx_rain_grnd(c) * dtime
+#endif
       end do
 
       do fc = 1, num_nosnowc

--- a/components/clm/src/biogeophys/SoilFluxesMod.F90
+++ b/components/clm/src/biogeophys/SoilFluxesMod.F90
@@ -82,7 +82,10 @@ contains
     real(r8) :: fsno_eff
     !-----------------------------------------------------------------------
 
-    associate(                                                                & 
+    associate(                                                                &
+#ifdef APPLY_POST_DECK_BUGFIXES
+         eflx_h2osfc_to_snow_col => energyflux_vars%eflx_h2osfc_to_snow_col , & ! Input:  [real(r8) (:)   ]  col snow melt to h2osfc heat flux (W/m**2)
+#endif
          forc_lwrad              => atm2lnd_vars%forc_lwrad_downscaled_col  , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)
 
          frac_veg_nosno          => canopystate_vars%frac_veg_nosno_patch   , & ! Input:  [integer (:)    ]  fraction of veg not covered by snow (0/1 now) [-]
@@ -369,6 +372,10 @@ contains
          errsoi_patch(p) = eflx_soil_grnd(p) - xmf(c) - xmf_h2osfc(c) &
               - frac_h2osfc(c)*(t_h2osfc(c)-t_h2osfc_bef(c)) &
               *(c_h2osfc(c)/dtime)
+
+#ifdef APPLY_POST_DECK_BUGFIXES
+         errsoi_patch(p) =  errsoi_patch(p)+eflx_h2osfc_to_snow_col(c)
+#endif
 
          ! For urban sunwall, shadewall, and roof columns, the "soil" energy balance check
          ! must include the heat flux from the interior of the building.

--- a/components/clm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/clm/src/biogeophys/SoilTemperatureMod.F90
@@ -109,6 +109,9 @@ module SoilTemperatureMod
   integer, parameter :: default_thermal_model  = 0
   integer, parameter :: petsc_thermal_model    = 1
   integer            :: thermal_model
+#ifdef APPLY_POST_DECK_BUGFIXES
+  real(r8), private, parameter :: thin_sfclayer = 1.0e-6_r8   ! Threshold for thin surface layer
+#endif
   !-----------------------------------------------------------------------
 
 contains
@@ -413,8 +416,18 @@ contains
 
       do fc = 1,num_nolakec
          c = filter_nolakec(fc)
+#ifdef APPLY_POST_DECK_BUGFIXES
+         if ( (h2osfc(c) > thin_sfclayer) .and. (frac_h2osfc(c) > thin_sfclayer) ) then
+            c_h2osfc(c)  = max(thin_sfclayer, cpliq*h2osfc(c)/frac_h2osfc(c)  )
+            dz_h2osfc(c) = max(thin_sfclayer, 1.0e-3*h2osfc(c)/frac_h2osfc(c) )
+         else
+            c_h2osfc(c)  = thin_sfclayer
+            dz_h2osfc(c) = thin_sfclayer
+         endif
+#else
          dz_h2osfc(c) = max(1.0e-6_r8,1.0e-3*h2osfc(c))
          c_h2osfc(c)  = cpliq*denh2o*dz_h2osfc(c) !"areametric" heat capacity [J/K/m^2]
+#endif
       enddo
 
       ! initialize initial temperature vector
@@ -626,7 +639,11 @@ contains
 
       call PhaseChangeH2osfc (bounds, num_nolakec, filter_nolakec, &
            dhsdT(bounds%begc:bounds%endc), &
+#ifdef APPLY_POST_DECK_BUGFIXES
+           waterstate_vars, waterflux_vars, temperature_vars, energyflux_vars)
+#else
            waterstate_vars, waterflux_vars, temperature_vars)
+#endif
 
       call Phasechange_beta (bounds, num_nolakec, filter_nolakec, &
            dhsdT(bounds%begc:bounds%endc), &
@@ -1049,7 +1066,15 @@ end subroutine SolveTemperature
          do fc = 1,num_nolakec
             c = filter_nolakec(fc)
             if (snl(c)+1 < 1 .and. j >= snl(c)+1) then
+#ifdef APPLY_POST_DECK_BUGFIXES
+               if (frac_sno(c) > 0._r8) then
+                  cv(c,j) = max(thin_sfclayer, (cpliq*h2osoi_liq(c,j) + cpice*h2osoi_ice(c,j))/frac_sno(c))
+               else
+                  cv(c,j) = thin_sfclayer
+               end if
+#else
                cv(c,j) = cpliq*h2osoi_liq(c,j) + cpice*h2osoi_ice(c,j)
+#endif
             end if
          end do
       end do
@@ -1061,14 +1086,22 @@ end subroutine SolveTemperature
 
   !-----------------------------------------------------------------------
   subroutine PhaseChangeH2osfc (bounds, num_nolakec, filter_nolakec, &
+#ifdef APPLY_POST_DECK_BUGFIXES
+       dhsdT, waterstate_vars, waterflux_vars, temperature_vars, energyflux_vars)
+#else
        dhsdT, waterstate_vars, waterflux_vars, temperature_vars)
+#endif
     !
     ! !DESCRIPTION:
     ! Only freezing is considered.  When water freezes, move ice to bottom snow layer.
     !
     ! !USES:
     use clm_time_manager , only : get_step_size
+#ifdef APPLY_POST_DECK_BUGFIXES
+    use clm_varcon       , only : tfrz, hfus, grav, denice, cnfac, cpice, cpliq
+#else
     use clm_varcon       , only : tfrz, hfus, grav, denice, cnfac, cpice
+#endif
     use clm_varpar       , only : nlevsno, nlevgrnd
     use clm_varctl       , only : iulog
     !
@@ -1080,12 +1113,17 @@ end subroutine SolveTemperature
     type(waterstate_type)  , intent(inout) :: waterstate_vars
     type(waterflux_type)   , intent(inout) :: waterflux_vars
     type(temperature_type) , intent(inout) :: temperature_vars
+#ifdef APPLY_POST_DECK_BUGFIXES
+    type(energyflux_type)  , intent(inout) :: energyflux_vars
+#endif
     !
     ! !LOCAL VARIABLES:
     integer  :: j,c,g                       !do loop index
     integer  :: fc                          !lake filtered column indices
     real(r8) :: dtime                       !land model time step (sec)
+#ifndef APPLY_POST_DECK_BUGFIXES
     real(r8) :: heatr                       !energy residual or loss after melting or freezing
+#endif
     real(r8) :: temp1                       !temporary variables [kg/m2                    ]
     real(r8) :: hm(bounds%begc:bounds%endc) !energy residual [W/m2                         ]
     real(r8) :: xm(bounds%begc:bounds%endc) !melting or freezing within a time step [kg/m2 ]
@@ -1093,12 +1131,16 @@ end subroutine SolveTemperature
     real(r8) :: smp                         !frozen water potential (mm)
     real(r8) :: rho_avg
     real(r8) :: z_avg
-    real(r8) :: dcv(bounds%begc:bounds%endc) 
+#ifdef APPLY_POST_DECK_BUGFIXES
+    !real(r8) :: dcv(bounds%begc:bounds%endc)!change in cv due to additional ice
+#else
+    real(r8) :: dcv(bounds%begc:bounds%endc)
     real(r8) :: t_h2osfc_new
-    real(r8) :: c1
-    real(r8) :: c2
     real(r8) :: h_excess
     real(r8) :: c_h2osfc_ice
+#endif
+    real(r8) :: c1
+    real(r8) :: c2
     !-----------------------------------------------------------------------
 
     call t_startf( 'PhaseChangeH2osfc' )
@@ -1120,6 +1162,10 @@ end subroutine SolveTemperature
          
          qflx_h2osfc_to_ice        =>    waterflux_vars%qflx_h2osfc_to_ice_col , & ! Output: [real(r8) (:)   ] conversion of h2osfc to ice             
          
+#ifdef APPLY_POST_DECK_BUGFIXES
+         eflx_h2osfc_to_snow_col   =>    energyflux_vars%eflx_h2osfc_to_snow_col  , & ! Output: [real(r8) (:)   ] col snow melt to h2osfc heat flux (W/m**2)
+#endif
+
          fact                      =>    temperature_vars%fact_col      , &
          c_h2osfc                  =>    temperature_vars%c_h2osfc_col  , &
          xmf_h2osfc                =>    temperature_vars%xmf_h2osfc_col, &
@@ -1135,28 +1181,46 @@ end subroutine SolveTemperature
 
       do fc = 1,num_nolakec
          c = filter_nolakec(fc)
-         xmf_h2osfc(c) = 0._r8
-         hm(c) = 0._r8
-         xm(c) = 0._r8
-         qflx_h2osfc_to_ice(c) = 0._r8
+
+         xmf_h2osfc(c)              = 0._r8
+         hm(c)                      = 0._r8
+         xm(c)                      = 0._r8
+         qflx_h2osfc_to_ice(c)      = 0._r8
+#ifdef APPLY_POST_DECK_BUGFIXES
+         eflx_h2osfc_to_snow_col(c) = 0._r8
+#endif
       end do
 
       ! Freezing identification
       do fc = 1,num_nolakec
          c = filter_nolakec(fc)
+
          ! If liquid exists below melt point, freeze some to ice.
          if ( frac_h2osfc(c) > 0._r8 .AND. t_h2osfc(c) <= tfrz) then
+#ifdef APPLY_POST_DECK_BUGFIXES
+            tinc = tfrz - t_h2osfc(c)
+            t_h2osfc(c) = tfrz
+
+            ! energy absorbed beyond freezing temperature
+            hm(c) = frac_h2osfc(c)*(dhsdT(c)*tinc - tinc*c_h2osfc(c)/dtime)
+
+            ! mass of water converted from liquid to ice
+            xm(c) = hm(c)*dtime/hfus  
+            temp1 = h2osfc(c) + xm(c)
+#else
             tinc = t_h2osfc(c)-tfrz
             t_h2osfc(c) = tfrz
+
             ! energy absorbed beyond freezing temperature
             hm(c) = dhsdT(c)*tinc - tinc*c_h2osfc(c)/dtime
 
             ! mass of water converted from liquid to ice
             xm(c) = hm(c)*dtime/hfus  
-            temp1 = h2osfc(c) - xm(c)    
+            temp1 = h2osfc(c) - xm(c)
 
             ! compute change in cv due to additional ice
             dcv(c)=cpice*min(xm(c),h2osfc(c))
+#endif
 
             z_avg=frac_sno(c)*snow_depth(c)
             if (z_avg > 0._r8) then 
@@ -1167,7 +1231,20 @@ end subroutine SolveTemperature
 
             !=====================  xm < h2osfc  ====================================
             if(temp1 >= 0._r8) then ! add some frozen water to snow column
+
                ! add ice to snow column
+#ifdef APPLY_POST_DECK_BUGFIXES
+               h2osno(c) = h2osno(c) - xm(c)
+               int_snow(c) = int_snow(c) - xm(c)
+
+               if(snl(c) < 0) h2osoi_ice(c,0) = h2osoi_ice(c,0) - xm(c)
+
+               ! remove ice from h2osfc
+               h2osfc(c) = h2osfc(c) + xm(c)
+
+               xmf_h2osfc(c) = hm(c)
+               qflx_h2osfc_to_ice(c) = -xm(c)/dtime
+#else
                h2osno(c) = h2osno(c) + xm(c)
                int_snow(c) = int_snow(c) + xm(c)
 
@@ -1179,6 +1256,7 @@ end subroutine SolveTemperature
                xmf_h2osfc(c) = -frac_h2osfc(c)*hm(c)
 
                qflx_h2osfc_to_ice(c) = xm(c)/dtime
+#endif
 
                ! update snow depth
                if (frac_sno(c) > 0 .and. snl(c) < 0) then 
@@ -1187,8 +1265,34 @@ end subroutine SolveTemperature
                   snow_depth(c)=h2osno(c)/denice
                endif
 
+#ifdef APPLY_POST_DECK_BUGFIXES
+               ! adjust temperature of lowest snow layer to account for addition of ice
+               if (snl(c) == 0) then
+                  !initialize for next time step
+                  t_soisno(c,0) = t_h2osfc(c)
+                  eflx_h2osfc_to_snow_col(c) = 0._r8
+               else
+                  if (snl(c) == -1)then
+                     c1=frac_sno(c)*(dtime/fact(c,0) - dhsdT(c)*dtime)
+                  else
+                     c1=frac_sno(c)/fact(c,0)*dtime
+                  end if
+                  if ( frac_h2osfc(c) /= 0.0_r8 )then
+                     c2=(-cpliq*xm(c) - frac_h2osfc(c)*dhsdT(c)*dtime)
+                  else
+                     c2=0.0_r8
+                  end if
+                  t_soisno(c,0) = (c1*t_soisno(c,0)+ c2*t_h2osfc(c)) &
+                       /(c1 + c2)
+                  eflx_h2osfc_to_snow_col(c) =(t_h2osfc(c)-t_soisno(c,0))*c2/dtime
+               endif
+
+               !=========================  xm > h2osfc  =============================
+            else !all h2osfc converted to ice
+#else
                !=========================  xm > h2osfc  =============================
             else !all h2osfc converted to ice, apply residual heat to top soil layer
+#endif
 
                rho_avg=(h2osno(c)*rho_avg + h2osfc(c)*denice)/(h2osno(c) + h2osfc(c))
                h2osno(c) = h2osno(c) + h2osfc(c)
@@ -1199,6 +1303,46 @@ end subroutine SolveTemperature
                ! excess energy is used to cool ice layer
                if(snl(c) < 0) h2osoi_ice(c,0) = h2osoi_ice(c,0) + h2osfc(c)
 
+#ifdef APPLY_POST_DECK_BUGFIXES
+               ! NOTE: should compute and then use the heat capacity of frozen h2osfc layer
+               !       rather than using heat capacity of the liquid layer. But this causes
+               !       balance check errors as it doesn't know about it.
+               ! compute heat capacity of frozen h2osfc layer
+
+               ! cool frozen h2osfc layer with extra heat
+               t_h2osfc(c) = t_h2osfc(c) - temp1*hfus/(dtime*dhsdT(c) - c_h2osfc(c))
+
+               xmf_h2osfc(c) = (hm(c) - frac_h2osfc(c)*temp1*hfus/dtime)
+
+               ! next, determine equilibrium temperature of combined ice/snow layer
+               if (snl(c) == 0) then
+                  !initialize for next time step
+                  t_soisno(c,0) = t_h2osfc(c)
+               else if (snl(c) == -1) then
+                  c1=frac_sno(c)*(dtime/fact(c,0) - dhsdT(c)*dtime)
+
+                  if ( frac_h2osfc(c) /= 0.0_r8 )then
+                     c2=frac_h2osfc(c)*(c_h2osfc(c) - dtime*dhsdT(c))
+                  else
+                     c2=0.0_r8
+                  end if
+                  ! account for the change in t_soisno(c,0) via xmf_h2osfc(c)
+                  t_soisno(c,0) = (c1*t_soisno(c,0)+ c2*t_h2osfc(c)) &
+                       /(c1 + c2)
+                  t_h2osfc(c) = t_soisno(c,0)
+
+               else
+                  c1=frac_sno(c)/fact(c,0)*dtime
+                  if ( frac_h2osfc(c) /= 0.0_r8 )then
+                     c2=frac_h2osfc(c)*(c_h2osfc(c) - dtime*dhsdT(c))
+                  else
+                     c2=0.0_r8
+                  end if
+                  t_soisno(c,0) = (c1*t_soisno(c,0)+ c2*t_h2osfc(c)) &
+                       /(c1 + c2)
+                  t_h2osfc(c) = t_soisno(c,0)
+               endif
+#else
                ! compute heat capacity of frozen h2osfc layer
                c_h2osfc_ice=cpice*denice*(1.0e-3*h2osfc(c)) !h2osfc in [m]
 
@@ -1234,6 +1378,7 @@ end subroutine SolveTemperature
                        /(c1 + c2)             
                   xmf_h2osfc(c) = xmf_h2osfc(c) - c1*t_soisno(c,0)
                endif
+#endif
 
                ! set h2osfc to zero (all liquid converted to ice)
                h2osfc(c) = 0._r8
@@ -1475,7 +1620,15 @@ end subroutine SolveTemperature
 
                      !==================================================================
                      if (j == snl(c)+1) then ! top layer                   
+#ifdef APPLY_POST_DECK_BUGFIXES
+                        if(j > 0) then
+                           hm(c,j) = dhsdT(c)*tinc(c,j) - tinc(c,j)/fact(c,j)
+                        else
+                           hm(c,j) = frac_sno_eff(c)*(dhsdT(c)*tinc(c,j) - tinc(c,j)/fact(c,j))
+                        endif
+#else
                         hm(c,j) = dhsdT(c)*tinc(c,j) - tinc(c,j)/fact(c,j)
+#endif
 
                         if ( j==1 .and. frac_h2osfc(c) /= 0.0_r8 ) then
                            hm(c,j) = hm(c,j) - frac_h2osfc(c)*(dhsdT(c)*tinc(c,j))
@@ -1484,7 +1637,15 @@ end subroutine SolveTemperature
                         hm(c,j) = (1.0_r8 - frac_sno_eff(c) - frac_h2osfc(c)) &
                              *dhsdT(c)*tinc(c,j) - tinc(c,j)/fact(c,j)
                      else ! non-interfacial snow/soil layers                   
+#ifdef APPLY_POST_DECK_BUGFIXES
+                        if(j < 1) then
+                           hm(c,j) = - frac_sno_eff(c)*(tinc(c,j)/fact(c,j))
+                        else
+                           hm(c,j) = - tinc(c,j)/fact(c,j)
+                        endif
+#else
                         hm(c,j) = - tinc(c,j)/fact(c,j)
+#endif
                      endif
                   endif
 
@@ -1553,8 +1714,13 @@ end subroutine SolveTemperature
                               t_soisno(c,j) = t_soisno(c,j) + fact(c,j)*heatr &
                                    /(1._r8-(1.0_r8 - frac_h2osfc(c))*fact(c,j)*dhsdT(c))
                            else
+#ifdef APPLY_POST_DECK_BUGFIXES
+                              t_soisno(c,j) = t_soisno(c,j) + (fact(c,j)/frac_sno_eff(c))*heatr &
+                                   /(1._r8-fact(c,j)*dhsdT(c))
+#else
                               t_soisno(c,j) = t_soisno(c,j) + fact(c,j)*heatr &
                                    /(1._r8-fact(c,j)*dhsdT(c))
+#endif
                            endif
 
                         else if (j == 1) then
@@ -1562,7 +1728,15 @@ end subroutine SolveTemperature
                            t_soisno(c,j) = t_soisno(c,j) + fact(c,j)*heatr &
                                 /(1._r8-(1.0_r8 - frac_sno_eff(c) - frac_h2osfc(c))*fact(c,j)*dhsdT(c))
                         else
+#ifdef APPLY_POST_DECK_BUGFIXES
+                           if(j > 0) then
+                              t_soisno(c,j) = t_soisno(c,j) + fact(c,j)*heatr
+                           else
+                              if(frac_sno_eff(c) > 0._r8) t_soisno(c,j) = t_soisno(c,j) + (fact(c,j)/frac_sno_eff(c))*heatr
+                           endif
+#else
                            t_soisno(c,j) = t_soisno(c,j) + fact(c,j)*heatr
+#endif
                         endif
 
                         if (j <= 0) then    ! snow
@@ -1573,7 +1747,11 @@ end subroutine SolveTemperature
                      if (j >= 1) then 
                         xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
                      else
+#ifdef APPLY_POST_DECK_BUGFIXES
+                        xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
+#else
                         xmf(c) = xmf(c) + frac_sno_eff(c)*hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
+#endif
                      endif
 
                      if (imelt(c,j) == 1 .AND. j < 1) then

--- a/components/clm/src/biogeophys/SurfaceAlbedoMod.F90
+++ b/components/clm/src/biogeophys/SurfaceAlbedoMod.F90
@@ -11,7 +11,11 @@ module SurfaceAlbedoMod
   use shr_log_mod       , only : errMsg => shr_log_errMsg
   use abortutils        , only : endrun
   use decompMod         , only : bounds_type
+#ifdef APPLY_POST_DECK_BUGFIXES
+  use landunit_varcon   , only : istsoil, istcrop, istdlak
+#else
   use landunit_varcon   , only : istsoil, istcrop
+#endif
   use clm_varcon        , only : grlnd, namep
   use clm_varpar        , only : numrad, nlevcan, nlevsno, nlevcan
   use clm_varctl        , only : fsurdat, iulog, subgridflag, use_snicar_frc, use_ed  
@@ -670,7 +674,11 @@ contains
              !  weight snow layer radiative absorption factors based on snow fraction and soil albedo
              !  (NEEDED FOR ENERGY CONSERVATION)
              do i = -nlevsno+1,1,1
+#ifdef APPLY_POST_DECK_BUGFIXES
+              if (subgridflag == 0 .or. lun_pp%itype(col_pp%landunit(c)) == istdlak) then
+#else
               if (subgridflag == 0) then
+#endif
                 if (ib == 1) then
                    flx_absdv(c,i) = flx_absd_snw(c,i,ib)*frac_sno(c) + &
                         ((1.-frac_sno(c))*(1-albsod(c,ib))*(flx_absd_snw(c,i,ib)/(1.-albsnd(c,ib))))

--- a/components/clm/src/biogeophys/SurfaceRadiationMod.F90
+++ b/components/clm/src/biogeophys/SurfaceRadiationMod.F90
@@ -19,7 +19,12 @@ module SurfaceRadiationMod
   use GridcellType      , only : grc_pp                
   use LandunitType      , only : lun_pp                
   use ColumnType        , only : col_pp                
-  use VegetationType    , only : veg_pp                
+#ifdef APPLY_POST_DECK_BUGFIXES
+  use VegetationType    , only : veg_pp
+  use landunit_varcon   , only : istdlak
+#else
+  use VegetationType    , only : veg_pp
+#endif
 
   !
   ! !PRIVATE TYPES:
@@ -547,7 +552,11 @@ contains
                 sabg_soil(p) = sabg(p)
              endif
              ! if no subgrid fluxes, make sure to set both components equal to weighted average
-             if (subgridflag == 0) then 
+#ifdef APPLY_POST_DECK_BUGFIXES
+             if (subgridflag == 0 .or. lun_pp%itype(l) == istdlak) then 
+#else
+             if (subgridflag == 0) then
+#endif
                 sabg_snow(p) = sabg(p)
                 sabg_soil(p) = sabg(p)
              endif
@@ -639,7 +648,11 @@ contains
 
              ! If shallow snow depth, all solar radiation absorbed in top or top two snow layers
              ! to prevent unrealistic timestep soil warming 
-             if (subgridflag == 0) then 
+#ifdef APPLY_POST_DECK_BUGFIXES
+             if (subgridflag == 0 .or. lun_pp%itype(l) == istdlak) then 
+#else
+             if (subgridflag == 0) then
+#endif
                 if (snow_depth(c) < 0.10_r8) then
                    if (snl(c) == 0) then
                       sabg_lyr(p,-4:0) = 0._r8


### PR DESCRIPTION
Incorporates bug fixes from CLM5 associated with surface water and
lakes. The bug fixes incorporated here are from CLM include:

- clm4_5_1_r087, and
- ESCOMP/ctsm#307

The bug fixes are added with CPP directive APPLY_POST_DECK_BUGFIXES

 [BFB]