### PR TITLE
Minor update for PE layout descriptor in ELM

### DIFF
--- a/components/clm/src/utils/spmdMod.F90
+++ b/components/clm/src/utils/spmdMod.F90
@@ -132,7 +132,7 @@ contains
 
     deallocate (length, displ, procname)
 
-100 format(//,i3," pes participating in computation for CLM")
+100 format(//,i7," pes participating in computation for CLM")
 200 format(/,35('-'))
 220 format(/,"NODE#",2x,"NAME")
 250 format("(",i5,")",2x,100a1,//)


### PR DESCRIPTION
As suggested by Azamat Mametjanov, increases the maximum number of 
MPI tasks given to the land model from i3 to i7 format.

Fixes #2196

[BFB]