### PR TITLE
Eliminate compile-time warnings when building GPTL

### DIFF
--- a/cime/src/share/timing/ChangeLog
+++ b/cime/src/share/timing/ChangeLog
@@ -1,3 +1,9 @@
+timing_180403: Added GPTLstartstop_val(f) to gptl.h, to provide explicit
+               typing and eliminate compile-time warning for some compilers.
+               Also do not define the CPP tokens HAVE_COMM_F2C and 
+               HAVE_GETTIMEOFDAY in private.h if they have already been
+               defined, also eliminating compile-time warnings.
+               [Patrick Worley]
 timing_171028: Backported GPTLstartstop_val from a more recent version
                of GPTL, added a callcount parameter, and renamed it
                GPTLstartstop_vals. Also added a version for non-null

--- a/cime/src/share/timing/gptl.h
+++ b/cime/src/share/timing/gptl.h
@@ -15,7 +15,9 @@
 
 /* following block for camtimers only */
 #ifndef NO_GETTIMEOFDAY
+#ifndef HAVE_GETTIMEOFDAY
 #define HAVE_GETTIMEOFDAY
+#endif
 #endif
 
 #ifdef SPMD
@@ -124,6 +126,8 @@ extern int GPTLstop (const char *);
 extern int GPTLstopf (const char *, const int);
 extern int GPTLstop_handle (const char *, void **);
 extern int GPTLstopf_handle (const char *, const int, void **);
+extern int GPTLstartstop_vals (const char *, double, int);
+extern int GPTLstartstop_valsf (const char *, const int, double, int);
 extern int GPTLstamp (double *, double *, double *);
 extern int GPTLpr_set_append (void);
 extern int GPTLpr_query_append (void);

--- a/cime/src/share/timing/private.h
+++ b/cime/src/share/timing/private.h
@@ -10,7 +10,9 @@
 #include <sys/time.h>
 
 #ifndef NO_COMM_F2C
+#ifndef HAVE_COMM_F2C
 #define HAVE_COMM_F2C
+#endif
 #endif
 
 #ifndef MIN


### PR DESCRIPTION
Building the timing library generates a number of compiler
warnings. While innocuous, these changes eliminate the warnings.

Details:

a) Added GPTLstartstop_val and GPTLstartstop_valf to gptl.h,
   to declare return type for these routines when called from
   f_wrappers.c. This was a bug, but did not cause any problems,
   and only a few compilers complained about the subsequent
   'implicit' typing.

b) The calls to the gptl makefile define the CPP tokens
   HAVE_COMM_F2C and HAVE_GETTIMEOFDAY for many systems. These
   are also defined by default in private.h and gptl.h, respectively.
   This change checks whether they are already defined before
   trying to define them again. This eliminates corresponding
   compile-time warnings.

Partly fixes #2247 

[BFB]