### PR TITLE
Remove -fp-model fast optimization for Theta

### DIFF
--- a/cime/config/e3sm/machines/Depends.theta.intel
+++ b/cime/config/e3sm/machines/Depends.theta.intel
@@ -1,0 +1,44 @@
+#
+PERFOBJS=\
+prim_advection_base.o \
+vertremap_base.o \
+edge_mod_base.o \
+derivative_mod_base.o \
+bndry_mod_base.o \
+prim_advance_mod.o \
+viscosity_preqx_base.o \
+viscosity_base.o \
+viscosity_theta.o \
+eos.o \
+hevi_mod.o \
+uwshcu.o
+
+# shr_wv_sat_mod does not need to have better than ~0.1% precision, and benefits
+# enormously from a lower precision in the vector functions.
+REDUCED_PRECISION_OBJS=\
+shr_wv_sat_mod.o
+
+SHR_RANDNUM_FORT_OBJS=\
+kissvec_mod.o \
+mersennetwister_mod.o \
+dSFMT_interface.o \
+shr_RandNum_mod.o
+
+SHR_RANDNUM_C_OBJS=\
+dSFMT.o \
+dSFMT_utils.o \
+kissvec.o
+
+# Note: FFLAGS contains flags such as -fp-model consistent (and -fimf-use-svml for intel version 18)
+# The -fp-model fast flags below will effectively override other -fp-model settings.
+
+ifeq ($(DEBUG),FALSE)
+  $(PERFOBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -O3 -no-prec-div $<
+  $(REDUCED_PRECISION_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -fimf-precision=low -fp-model fast $<
+  $(SHR_RANDNUM_FORT_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -fp-model fast -no-prec-div -no-prec-sqrt -qoverride-limits $<
+  $(SHR_RANDNUM_C_OBJS): %.o: %.c
+	  $(CC) -c $(INCLDIR) $(INCS) $(CFLAGS) -O3 -fp-model fast $<
+endif


### PR DESCRIPTION
Remove "-fp-model fast" optimization from compile flags of some objects in Depends.theta.intel.

[BFB]

Addresses ACME-Climate/ACME#2252