### PR TITLE
Allow SCM to run in a single MPI task

### DIFF
--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -1204,16 +1204,6 @@ if ($scam eq 'ON' and $dyn_pkg ne 'eul') {
 EOF
 }
 
-# Check that model is configured for serial execution.  Note that configuring with spmd
-# and running with 1 task doesn't work because the EUL dycore expects at least 2 tasks.
-# The model should run if built for threading.
-if ($scam eq 'ON' and $spmd ne 'OFF') {
-    die <<"EOF";
-**  ERROR: SCAM mode assumes a serial build.
-**         Requested parallel modes are: spmd=$spmd  smp=$smp
-EOF
-}
-
 if ($print>=2) { print "CAM single column mode (SCAM): $scam$eol"; }
 
 #-----------------------------------------------------------------------------------------------

--- a/components/cam/src/dynamics/eul/spmd_dyn.F90
+++ b/components/cam/src/dynamics/eul/spmd_dyn.F90
@@ -267,6 +267,7 @@ contains
 !-----------------------------------------------------------------------
       use comspe, only: numm
       use spmd_utils
+      use scamMod, only: single_column
 #if (defined MODCM_DP_TRANSPOSE)
       use parutilitiesmodule, only : parinit
 #endif
@@ -363,8 +364,10 @@ contains
 !
       call factor (plat, m2, m3, m5)
 
-      if (m2 < 1) then
-         call endrun ('SPMDINIT_DYN: Problem size is not divisible by 2')
+      if (.not. single_column) then
+        if (m2 < 1) then
+          call endrun ('SPMDINIT_DYN: Problem size is not divisible by 2')
+        end if
       end if
 
       if (masterproc) then
@@ -383,11 +386,13 @@ contains
          dyn_npes_stride = 1
       endif
 
-      if ((dyn_equi_by_col) .and. (mod(tot_cols,2) /= 0)) then
-         write(iulog,*)'SPMDINIT_DYN: Total number of columns(', &
+      if (.not. single_column) then
+        if ((dyn_equi_by_col) .and. (mod(tot_cols,2) /= 0)) then
+          write(iulog,*)'SPMDINIT_DYN: Total number of columns(', &
                    tot_cols,') must be a multiple of 2'
-         call endrun
-      end if
+          call endrun
+        end if
+      endif
 !
 !  Initialization for inactive processes
 !


### PR DESCRIPTION
Modifications to allow the E3SM SCM to run in a single MPI task.  Previously it was only allowed to be configured with the -nospmd flag.  Tests performed on Blues, Edison, and Titan verify the SCM successfully builds and runs (b4b) with this new setup.  All e3sm_developer tests pass.  

Fixes #2095

[b4b]