### PR TITLE
Fix aprun cmd

### DIFF
--- a/cime/scripts/lib/CIME/case/case.py
+++ b/cime/scripts/lib/CIME/case/case.py
@@ -1259,7 +1259,7 @@ class Case(object):
         if executable is not None and "aprun" in executable and not "theta" in self.get_value("MACH"):
             aprun_args, num_nodes = get_aprun_cmd_for_case(self, run_exe)[0:2]
             expect( (num_nodes + self.spare_nodes) == self.num_nodes, "Not using optimized num nodes")
-            return executable + aprun_args + " " + run_misc_suffix
+            return self.get_resolved_value(executable + aprun_args + " " + run_misc_suffix, allow_unresolved_envvars=allow_unresolved_envvars)
 
         else:
             mpi_arg_string = " ".join(mpi_arg_list)


### PR DESCRIPTION
The returned value from the case.get_mpirun_cmd function is expected
to be fully resolved, but that was not the case for aprun.

Fixes #2265 

[BFB]