### PR TITLE
Fix for the change in mpas' cice component name change

### DIFF
--- a/cime/config/e3sm/config_archive.xml
+++ b/cime/config/e3sm/config_archive.xml
@@ -71,7 +71,7 @@
     </rpointer>
   </comp_archive_spec>
 
-  <comp_archive_spec compname="mpassi" compclass="ice">
+  <comp_archive_spec compname="mpas-cice" compclass="ice">
     <rest_file_extension>rst</rest_file_extension>
     <hist_file_extension>hist</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>


### PR DESCRIPTION
I'm still testing this, but it should fix the st-archive name change made in PR 2229