### PR TITLE
Removes all F compsets using CLM40

### DIFF
--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 
 <compsets>
+   <help>
+   Compset format is explained in cime/config/e3sm/allactive/config_compsets.xml
+   or in the CIME documenation
+   </help>
 
   <compset>
     <alias>F1850C5L45BGC</alias>


### PR DESCRIPTION
CLM40 has been removed from the source code. This PR removes all F
compsets which use CLM40.

[BFB] - Bit-For-Bit