### PR TITLE
Use approved CIME case value for threadedness check

### DIFF
--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -76,7 +76,7 @@ if ($BUILD_COMPLETE eq 'FALSE') {
     my $spmd = '-spmd';
     if ($MPILIB eq 'mpi-serial') {$spmd = "-nospmd";}
     my $smp = '-smp';
-    if (($SMP_PRESET eq 'FALSE')) {$smp = "-nosmp";}
+    if (($SMP_PRESENT eq 'FALSE')) {$smp = "-nosmp";}
 
     # The ocean component setting is only used by CAM to do attribute matching for
     # setting default tuning parameter values.  In SOM mode we want to use the same

--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -41,7 +41,6 @@ my $RUN_REFDATE	        = `./xmlquery  RUN_REFDATE		-value`;
 my $RUN_REFTOD	        = `./xmlquery  RUN_REFTOD		-value`;
 my $UTILROOT		= `./xmlquery  UTILROOT			-value`;
 my $COMPILER		= `./xmlquery  COMPILER                 -value`; # for chem preprocessor 
-my $SMP_PRESENT         = `./xmlquery  SMP_PRESENT		-value`;
 my $FORCE_BUILD_SMP     = `./xmlquery  FORCE_BUILD_SMP		-value`;
 my $OS                  = lc `./xmlquery OS                     -value`;
 

--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -42,6 +42,7 @@ my $RUN_REFTOD	        = `./xmlquery  RUN_REFTOD		-value`;
 my $UTILROOT		= `./xmlquery  UTILROOT			-value`;
 my $COMPILER		= `./xmlquery  COMPILER                 -value`; # for chem preprocessor 
 my $SMP_PRESENT         = `./xmlquery  SMP_PRESENT		-value`;
+my $FORCE_BUILD_SMP     = `./xmlquery  FORCE_BUILD_SMP		-value`;
 my $OS                  = lc `./xmlquery OS                     -value`;
 
 my @dirs = ("$CIMEROOT/utils/perl5lib");
@@ -76,7 +77,7 @@ if ($BUILD_COMPLETE eq 'FALSE') {
     my $spmd = '-spmd';
     if ($MPILIB eq 'mpi-serial') {$spmd = "-nospmd";}
     my $smp = '-smp';
-    if ($SMP_PRESENT eq 'FALSE') {$smp = "-nosmp";}
+    if (($NTHRDS_ATM == 1) && ($FORCE_BUILD_SMP eq 'FALSE')) {$smp = "-nosmp";}
 
     # The ocean component setting is only used by CAM to do attribute matching for
     # setting default tuning parameter values.  In SOM mode we want to use the same

--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -41,7 +41,7 @@ my $RUN_REFDATE	        = `./xmlquery  RUN_REFDATE		-value`;
 my $RUN_REFTOD	        = `./xmlquery  RUN_REFTOD		-value`;
 my $UTILROOT		= `./xmlquery  UTILROOT			-value`;
 my $COMPILER		= `./xmlquery  COMPILER                 -value`; # for chem preprocessor 
-my $BUILD_THREADED      = `./xmlquery  BUILD_THREADED		-value`;
+my $SMP_PRESENT         = `./xmlquery  SMP_PRESENT		-value`;
 my $OS                  = lc `./xmlquery OS                     -value`;
 
 my @dirs = ("$CIMEROOT/utils/perl5lib");
@@ -76,7 +76,7 @@ if ($BUILD_COMPLETE eq 'FALSE') {
     my $spmd = '-spmd';
     if ($MPILIB eq 'mpi-serial') {$spmd = "-nospmd";}
     my $smp = '-smp';
-    if (($NTHRDS_ATM == 1) && ($BUILD_THREADED eq 'FALSE')) {$smp = "-nosmp";}
+    if (($SMP_PRESET eq 'FALSE')) {$smp = "-nosmp";}
 
     # The ocean component setting is only used by CAM to do attribute matching for
     # setting default tuning parameter values.  In SOM mode we want to use the same

--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -76,7 +76,7 @@ if ($BUILD_COMPLETE eq 'FALSE') {
     my $spmd = '-spmd';
     if ($MPILIB eq 'mpi-serial') {$spmd = "-nospmd";}
     my $smp = '-smp';
-    if (($SMP_PRESENT eq 'FALSE')) {$smp = "-nosmp";}
+    if ($SMP_PRESENT eq 'FALSE') {$smp = "-nosmp";}
 
     # The ocean component setting is only used by CAM to do attribute matching for
     # setting default tuning parameter values.  In SOM mode we want to use the same


### PR DESCRIPTION
Use approved CIME case value for threadedness check

BUILD_THREADED no longer exists. FORCE_BUILD_SMP is now the variable to control forcing threaded builds.

[BFB]