### PR TITLE
add istanbul CPU target for two files in CAM

### DIFF
--- a/cime/config/e3sm/machines/Depends.titan.pgi
+++ b/cime/config/e3sm/machines/Depends.titan.pgi
@@ -27,3 +27,8 @@ modal_aer_opt.o: modal_aer_opt.F90
 zm_conv.o: zm_conv.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -target-cpu=istanbul $<
 
+check_energy.o: check_energy.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -target-cpu=istanbul $<
+
+read_volc_radiation_data.o: read_volc_radiation_data.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -target-cpu=istanbul $<


### PR DESCRIPTION
Add rules for the CAM files check_energy.F90 and
read_volc_radiation_data.F90 to Depends.titan.pgi that specify
the istanbul CPU target. This is necessary for reproducibility
with respect to thread count for the CMIP6 compsets when using
the PGI compiler on Titan.

Fixes #2227

This is BFB for all systems except Titan when using PGI.
On Titan when using PGI, this is BFB for all compsets not using prescribed volcanic aerosols and not using the new energy fixer in CAM. For compsets using these, the current master is not reproducible with respect to thread count in CAM.
