### PR TITLE
Adds new compsets with updated tuning for ne120 atmos

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -597,6 +597,7 @@
       <value compset="^2000.+AV1C-L"				>368.865</value>
       <value compset="^2000.+AV1C-H01A"				>368.865</value>
       <value compset="^2000.+AV1C-H01B"				>368.865</value>
+      <value compset="^2000.+AV1C-H01C"				>368.865</value>
       <value compset="^1850.+CMIP6"                             >284.317</value>
       <value compset="^1950.+CMIP6"                             >312.821</value>
       <!-- Override values based on CAM (WACCM) chemistry -->

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01c.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01c.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Solar constant from Lean (via Caspar Ammann) -->
+<solar_data_file>atm/cam/solar/spectral_irradiance_Lean_1850_cntl_c100407.nc</solar_data_file>
+<solar_data_ymd>18500101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 1850 GHG values from AR5 (from ghg_hist_1765-2012_c130501.nc) -->
+<!-- <co2vmr>284.725e-6</co2vmr> Set by CCSM_CO2_PPMV in config_compset.xml -->
+<ch4vmr>790.9792e-9</ch4vmr>
+<n2ovmr>275.425e-9</n2ovmr>
+<f11vmr>33.432e-12</f11vmr>
+<f12vmr>0.0</f12vmr>
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc>.true.</use_hetfrz_classnuc>
+<use_preexisting_ice>.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc>.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep>.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning>.true.</sscav_tuning>
+<convproc_do_aer>.true.</convproc_do_aer>
+<convproc_do_gas>.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc>.true.</demott_ice_nuc>
+<liqcf_fix>.true.</liqcf_fix>
+<regen_fix>.true.</regen_fix>
+<resus_fix>.true.</resus_fix>
+<mam_amicphys_optaa>1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning>.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
+<clubb_liq_sh>       10.e-6 </clubb_liq_sh>
+<clubb_C2rt>         1.75D0 </clubb_C2rt>
+<effgw_oro>          0.25    </effgw_oro>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<clubb_gamma_coef>   0.32   </clubb_gamma_coef>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<clubb_c_K10>        0.3    </clubb_c_K10>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add       >0.8D0</zmconv_tiedke_add>
+<zmconv_cape_cin         >1</zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   >2</zmconv_mx_bot_lyr_adj>
+<taubgnd                 >2.5D-3 </taubgnd>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<se_ftype                >2</se_ftype>
+<relvar_fix              >.true.</relvar_fix>
+<mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+
+
+<!-- Parameters further tuned for ne120 L72 configuration based on AV1C-04P2 -->
+
+<clubb_ice_deep>     12.e-6 </clubb_ice_deep>
+<so4_sz_thresh_icenuc>0.050e-6</so4_sz_thresh_icenuc>
+<dust_emis_fact>     2.50D0 </dust_emis_fact>
+<zmconv_alfa         >0.2D0</zmconv_alfa>
+<zmconv_c0_lnd       >0.0035D0</zmconv_c0_lnd>
+<zmconv_c0_ocn       >0.0043D0</zmconv_c0_ocn>
+<zmconv_dmpdz        >-0.2e-3</zmconv_dmpdz>
+<zmconv_ke           >6.0E-6</zmconv_ke>
+<cldfrc_dp1          >0.039D0</cldfrc_dp1>
+<clubb_C1            >1.50D0</clubb_C1>
+<clubb_C8            >4.73D0</clubb_C8>
+<clubb_C14           >1.75D0</clubb_C14>
+<se_nsplit           >6</se_nsplit>
+<rsplit              >2</rsplit>
+<qsplit              >1</qsplit>
+<cld_macmic_num_steps>3</cld_macmic_num_steps>
+
+<!-- 1850 ozone data is from Jean-Francois Lamarque -->
+<!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->
+<prescribed_ozone_datapath>atm/cam/ozone</prescribed_ozone_datapath>
+<prescribed_ozone_file>ozone_1.9x2.5_L26_1850clim_c090420.nc</prescribed_ozone_file>
+<prescribed_ozone_name>O3</prescribed_ozone_name>
+<prescribed_ozone_type>CYCLICAL</prescribed_ozone_type>
+<prescribed_ozone_cycle_yr>1850</prescribed_ozone_cycle_yr>
+
+<!-- External forcing for BAM or MAM -->
+<ext_frc_type>CYCLICAL</ext_frc_type>
+<ext_frc_cycle_yr>1850</ext_frc_cycle_yr>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_so2_elev_1850_c160310.nc</so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_1850_c160507.nc</soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_bc_elev_1850_c160310.nc</bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam4_num_a1_elev_1850_c160310.nc</mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_num_a2_elev_1850_c160310.nc</num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam4_num_a4_elev_1850_c160310.nc</mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_pom_elev_1850_c160310.nc</pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_so4_a1_elev_1850_c160310.nc</so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_so4_a2_elev_1850_c160310.nc</so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4 -->
+<srf_emis_type>CYCLICAL</srf_emis_type>
+<srf_emis_cycle_yr>1850</srf_emis_cycle_yr>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_so2_surf_1850_c160310.nc</so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_bc_surf_1850_c160310.nc</bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam4_num_a1_surf_1850_c160310.nc</mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_num_a2_surf_1850_c160310.nc</num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam4_num_a4_surf_1850_c160310.nc</mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_pom_surf_1850_c160310.nc</pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_so4_a1_surf_1850_c160310.nc</so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/1850ar5/ar5_mam3_so4_a2_surf_1850_c160310.nc</so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr>1855</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2005_c091123.nc</tracer_cnst_file>
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/EESC_1850-2100_c090603.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
+<linoz_data_file            >linoz1800-2100_2006jpl_climo_1.9x2.5_26L_extended.c160204.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+</namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01c.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01c.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Solar constant from Lean (via Caspar Ammann): SOLAR_TSI_Lean_1610-2140_annual_c100301.nc -->
+<solar_data_file>atm/cam/solar/spectral_irradiance_Lean_1976-2007_ave_c20160517.nc</solar_data_file>
+<solar_data_ymd>20000101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 2000 GHG values from AR5 (from ghg_hist_1765-2012_c130501.nc) -->
+<!-- <co2vmr>368.865e-6</co2vmr> Set by CCSM_CO2_PPMV in config_compset.xml -->
+<ch4vmr>1751.022e-9</ch4vmr>
+<n2ovmr>315.85e-9</n2ovmr>
+<f11vmr>676.0526e-12</f11vmr>
+<f12vmr>537.05e-12</f12vmr>
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc>.true.</use_hetfrz_classnuc>
+<use_preexisting_ice>.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc>.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep>.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning>.true.</sscav_tuning>
+<convproc_do_aer>.true.</convproc_do_aer>
+<convproc_do_gas>.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc>.true.</demott_ice_nuc>
+<liqcf_fix>.true.</liqcf_fix>
+<regen_fix>.true.</regen_fix>
+<resus_fix>.true.</resus_fix>
+<mam_amicphys_optaa>1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning>.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
+<clubb_liq_sh>       10.e-6 </clubb_liq_sh>
+<clubb_C2rt>         1.75D0 </clubb_C2rt>
+<effgw_oro>          0.25    </effgw_oro>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<clubb_gamma_coef>   0.32   </clubb_gamma_coef>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<clubb_c_K10>        0.3    </clubb_c_K10>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add       >0.8D0</zmconv_tiedke_add>
+<zmconv_cape_cin         >1</zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   >2</zmconv_mx_bot_lyr_adj>
+<taubgnd                 >2.5D-3 </taubgnd>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<se_ftype                >2</se_ftype>
+<relvar_fix              >.true.</relvar_fix>
+<mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+
+
+<!-- Parameters further tuned for ne120 L72 configuration based on AV1C-04P2 -->
+
+<clubb_ice_deep>     12.e-6 </clubb_ice_deep>
+<so4_sz_thresh_icenuc>0.050e-6</so4_sz_thresh_icenuc>
+<dust_emis_fact>     2.50D0 </dust_emis_fact>
+<zmconv_alfa         >0.2D0</zmconv_alfa>
+<zmconv_c0_lnd       >0.0035D0</zmconv_c0_lnd>
+<zmconv_c0_ocn       >0.0043D0</zmconv_c0_ocn>
+<zmconv_dmpdz        >-0.2e-3</zmconv_dmpdz>
+<zmconv_ke           >6.0E-6</zmconv_ke>
+<cldfrc_dp1          >0.039D0</cldfrc_dp1>
+<clubb_C1            >1.50D0</clubb_C1>
+<clubb_C8            >4.73D0</clubb_C8>
+<clubb_C14           >1.75D0</clubb_C14>
+<se_nsplit           >6</se_nsplit>
+<rsplit              >2</rsplit>
+<qsplit              >1</qsplit>
+<cld_macmic_num_steps>3</cld_macmic_num_steps>
+
+<!-- External forcing for BAM or MAM -->
+<soag_ext_file	 ver="mam" >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_2000_c160427.nc</soag_ext_file>
+
+<!-- Surface emissions for MAM4 -->
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2000.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160226.nc</dms_emis_file>
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/EESC_1850-2100_c090603.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >20000101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >2000</linoz_data_cycle_yr>
+<linoz_data_file            >linoz1800-2100_2006jpl_climo_1.9x2.5_26L_extended.c160204.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>2000</sim_year>
+
+</namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01c.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01c.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!-- Solar constant from Lean (via Caspar Ammann) -->
+<solar_data_file>atm/cam/solar/spectral_irradiance_Lean_1610-2140_ann_c100408.nc</solar_data_file>
+<solar_data_type>SERIAL</solar_data_type>
+
+<!-- 1850 GHG values from AR5 (from ghg_hist_1765-2012_c130501.nc) -->
+<!-- <co2vmr>284.725e-6</co2vmr> Set by CCSM_CO2_PPMV in config_compset.xml -->
+<bndtvghg>atm/cam/ggas/ghg_hist_1765-2012_c130501.nc</bndtvghg>
+<scenario_ghg>RAMPED</scenario_ghg>
+
+<!-- volcanic aerosols in the stratosphere -->
+<prescribed_volcaero_datapath>'atm/cam/volc'                          </prescribed_volcaero_datapath>  
+<prescribed_volcaero_file>    'CCSM4_volcanic_1850-3009_prototype1.nc'</prescribed_volcaero_file>    
+<prescribed_volcaero_type>    'SERIAL'				      </prescribed_volcaero_type>    
+
+<!-- Sea Surface Temperatures (SST) are specified using SSTICE in config_compsets.xml -->
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc>.true.</use_hetfrz_classnuc>
+<use_preexisting_ice>.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc>.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep>.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning>.true.</sscav_tuning>
+<convproc_do_aer>.true.</convproc_do_aer>
+<convproc_do_gas>.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc>.true.</demott_ice_nuc>
+<liqcf_fix>.true.</liqcf_fix>
+<regen_fix>.true.</regen_fix>
+<resus_fix>.true.</resus_fix>
+<mam_amicphys_optaa>1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning>.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
+<clubb_liq_sh>       10.e-6 </clubb_liq_sh>
+<clubb_C2rt>         1.75D0 </clubb_C2rt>
+<effgw_oro>          0.25    </effgw_oro>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<clubb_gamma_coef>   0.32   </clubb_gamma_coef>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<clubb_c_K10>        0.3    </clubb_c_K10>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add       >0.8D0</zmconv_tiedke_add>
+<zmconv_cape_cin         >1</zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   >2</zmconv_mx_bot_lyr_adj>
+<taubgnd                 >2.5D-3 </taubgnd>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<se_ftype                >2</se_ftype>
+<relvar_fix              >.true.</relvar_fix>
+<mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+
+
+<!-- Parameters further tuned for ne120 L72 configuration based on AV1C-04P2 -->
+
+<clubb_ice_deep>     12.e-6 </clubb_ice_deep>
+<so4_sz_thresh_icenuc>0.050e-6</so4_sz_thresh_icenuc>
+<dust_emis_fact>     2.50D0 </dust_emis_fact>
+<zmconv_alfa         >0.2D0</zmconv_alfa>
+<zmconv_c0_lnd       >0.0035D0</zmconv_c0_lnd>
+<zmconv_c0_ocn       >0.0043D0</zmconv_c0_ocn>
+<zmconv_dmpdz        >-0.2e-3</zmconv_dmpdz>
+<zmconv_ke           >6.0E-6</zmconv_ke>
+<cldfrc_dp1          >0.039D0</cldfrc_dp1>
+<clubb_C1            >1.50D0</clubb_C1>
+<clubb_C8            >4.73D0</clubb_C8>
+<clubb_C14           >1.75D0</clubb_C14>
+<se_nsplit           >6</se_nsplit>
+<rsplit              >2</rsplit>
+<qsplit              >1</qsplit>
+<cld_macmic_num_steps>3</cld_macmic_num_steps>
+
+<!-- 1850 ozone data is from Jean-Francois Lamarque -->
+<!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->
+<prescribed_ozone_datapath>atm/cam/ozone</prescribed_ozone_datapath>
+<prescribed_ozone_file>ozone_1.9x2.5_L26_1850-2005_c090803.nc</prescribed_ozone_file>
+<prescribed_ozone_name>O3</prescribed_ozone_name>
+<prescribed_ozone_type>INTERP_MISSING_MONTHS</prescribed_ozone_type>
+
+<!-- External forcing for BAM or MAM -->
+<ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so2_elev_1850-2005_c090804.nc</so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_1850-2000_c160727.nc</soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_1850-2005_c090804.nc</bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam4_num_a1_elev_1850-2005_c150205.nc</mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_num_a2_elev_1850-2005_c090804.nc</num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam4_num_a4_elev_1850-2005_c150205.nc</mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_pom_elev_1850-2005_c130424.nc</pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so4_a1_elev_1850-2005_c090804.nc</so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so4_a2_elev_1850-2005_c090804.nc</so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4 -->
+<srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so2_surf_1850-2005_c090804.nc</so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_surf_1850-2005_c090804.nc</bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/ar5_mam4_num_a1_surf_1850-2005_c150205.nc</mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_num_a2_surf_1850-2005_c090804.nc</num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/ar5_mam4_num_a4_surf_1850-2005_c150205.nc</mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_pom_surf_1850-2005_c130424.nc</pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so4_a1_surf_1850-2005_c090804.nc</so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_so4_a2_surf_1850-2005_c090804.nc</so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2005_c091123.nc</tracer_cnst_file>
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/EESC_1850-2100_c090603.nc</chlorine_loading_file>
+<chlorine_loading_type      >SERIAL</chlorine_loading_type>
+<linoz_data_file            >linoz1800-2100_2006jpl_climo_1.9x2.5_26L_extended.c160204.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850-2000</sim_year>
+
+</namelist_defaults>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -55,6 +55,7 @@
       <value compset="_CAM5%AV1C-L"   >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1C-H01A">-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1C-H01B">-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
+      <value compset="_CAM5%AV1C-H01C">-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6-HR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6-LR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
@@ -169,6 +170,7 @@
       <value compset="1850_CAM5.*AV1C-L" >1850_cam5_av1c-04p2</value>
       <value compset="1850_CAM5.*AV1C-H01A">1850_cam5_av1c-h01a</value>
       <value compset="1850_CAM5.*AV1C-H01B">1850_cam5_av1c-h01b</value>
+      <value compset="1850_CAM5.*AV1C-H01C">1850_cam5_av1c-h01c</value>
       <value compset="1850_CAM5.*CMIP6"  >1850_cam5_CMIP6</value>
       <value compset="1950_CAM5.*CMIP6-LR"  >1950_cam5_CMIP6-LR</value>
       <value compset="1950_CAM5.*CMIP6-HR"  >1950_cam5_CMIP6-HR</value>
@@ -184,6 +186,7 @@
       <value compset="2000_CAM5.*AV1C-L.*_BGC%B" >2000_cam5_av1c-04p2_bgc</value>
       <value compset="2000_CAM5.*AV1C-H01A">2000_cam5_av1c-h01a</value>
       <value compset="2000_CAM5.*AV1C-H01B">2000_cam5_av1c-h01b</value>
+      <value compset="2000_CAM5.*AV1C-H01C">2000_cam5_av1c-h01c</value>
       <value compset="2000_CAM5.*AV1F"   >2000_cam5_av1f</value>
       <value compset="2000_CAM5.*AV1F-00">2000_cam5_av1f-00</value>
       <value compset="2000_CAM5.*AV1F-01">2000_cam5_av1f-01</value>
@@ -195,6 +198,7 @@
       <value compset="20TR_CAM5.*AV1C-L.*_BGC%B">20TR_cam5_av1c-04p2_bgc</value>
       <value compset="20TR_CAM5.*AV1C-H01A">20TR_cam5_av1c-h01a</value>
       <value compset="20TR_CAM5.*AV1C-H01B">20TR_cam5_av1c-h01b</value>
+      <value compset="20TR_CAM5.*AV1C-H01C">20TR_cam5_av1c-h01c</value>
       <value compset="20TR_CAM5.*CMIP6"  >20TR_cam5_CMIP6</value>
       <value compset="20TR_CAM5.*CMIP6*_BGC%B"  >20TR_cam5_CMIP6_bgc</value>
       <value compset="2000_CAM5%COSP"   >2000_cam5_cosp</value>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -72,6 +72,11 @@
   </compset>
 
   <compset>
+    <alias>F1850C5AV1C-H01C</alias>
+    <lname>1850_CAM5%AV1C-H01C_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>F1850C5-CMIP6</alias>
     <lname>1850_CAM5%CMIP6_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
@@ -122,6 +127,11 @@
   </compset>
 
   <compset>
+    <alias>FC5AV1C-H01C</alias>
+    <lname>2000_CAM5%AV1C-H01C_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>FC5AV1F</alias>
     <lname>2000_CAM5%AV1F_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
@@ -169,6 +179,11 @@
   <compset>
    <alias>F20TRC5AV1C-H01B</alias>
    <lname>20TR_CAM5%AV1C-H01B_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+   <alias>F20TRC5AV1C-H01C</alias>
+   <lname>20TR_CAM5%AV1C-H01C_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>


### PR DESCRIPTION
The new compsets have the updated tunings for ne120 atmos.
They are based on compset H01A but retuned after MG2 fixes introduced after H01A and H01B were created.
Simulations with the new F-2000 case have TOA net imbalance consistent with the expected values
for both present day and pre-industrial conditions. The climatology is broadly consistent with that of H01A

Three compsets are added: F-2000, F-1850, and 20th century transient. They are provided as an alternative for performing ne120 simulations.

[BFB]