### PR TITLE
Specify version number for the programming environment module (edison/cori)

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -281,7 +281,7 @@
     <modules compiler="intel">
       <command name="load">PrgEnv-intel/6.0.4</command>
       <command name="rm">intel</command>
-      <command name="load">intel/18.0.2.199</command>
+      <command name="load">intel/18.0.1.163</command>
     </modules>
 
     <modules compiler="gnu">
@@ -425,7 +425,7 @@
     <modules compiler="intel">
       <command name="load">PrgEnv-intel/6.0.4</command>
       <command name="rm">intel</command>
-      <command name="load">intel/18.0.2.199</command>
+      <command name="load">intel/18.0.1.163</command>
     </modules>
 
     <modules compiler="gnu">


### PR DESCRIPTION
The programming environment module (PrgEnv-intel and PrgEnv-gnu) did not have a specific version number. This change specifies `PrgEnv-intel/6.0.4 and PrgEnv-gnu/6.0.4` which is currently the default, so there will be no change.

For edison only (when using `--compiler=intel18`), there is now a slightly updated version of  intel 18 compiler at NERSC, so we now get `intel/18.0.2.199` from `intel/18.0.1.163`

Remove specific version for the git module command.

[BFB]