### PR TITLE
Fix get_tests on some platforms

### DIFF
--- a/cime/scripts/lib/get_tests.py
+++ b/cime/scripts/lib/get_tests.py
@@ -6,7 +6,7 @@ import six, sys, os
 # Expect that, if a model wants to use python-based test lists, they will have a file
 # config/$model/tests.py , containing a test dictionary called _TESTS
 
-sys.path.append(os.path.join(get_cime_root(), "config", get_model()))
+sys.path.insert(0, os.path.join(get_cime_root(), "config", get_model()))
 _ALL_TESTS = {}
 try:
     from tests import _TESTS # pylint: disable=import-error


### PR DESCRIPTION
The name 'tests' is fairly generic. Prepend instead of append the path
to our tests.py to ensure we pick up our first.

Fixes #2285 

[BFB]