### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,20 @@
+# Object files
+*.lo
+*.o
+
+# Fortran module files
+*.mod
+
+# Static libraries
+*.la
+*.a
+
+# Executables
+*.exe
+
+# Logs
+*.log
+
 # Ignore netCDF files.
 *.nc
 


### PR DESCRIPTION
Update gitignore to ignore typical Fortran object files, libraries etc.
Usually, our builds happen outside the source tree.
This is a reasonable default to have in our repo to reduce clutter
in corner cases.

[BFB]