### PR TITLE
Add capability to read CO2 flux for all grids and grid resolutions

### DIFF
--- a/components/cam/src/chemistry/utils/tracer_data.F90
+++ b/components/cam/src/chemistry/utils/tracer_data.F90
@@ -601,27 +601,6 @@ contains
 
 !-----------------------------------------------------------------------
 ! Reads more data if needed and interpolates data to current model time 
-
-! Update (04/19/2018): state and pbuf2d are now optional variables. state 
-! variable was used for the following purposes:
-! 1. obtaining ncol value for each chunk 
-! 2. veritcal interpolation (getting zi and pmid for each grid cell)
-! 3. Single column model 
-!
-! "get_ncols_p" can be used to get ncol values. For interpolating surface 
-! flux fields (i.e. vertical interpolation not needed), state is not required.
-!
-! This change is made to accomodate CO2 flux interpolation where 
-! interpolation routines (e.g. co2_time_interp_fuel) are called from a 
-! point in the code (atm_import_export.F90) where state and pbuf2d are 
-! not readily accessible
-!
-! pbuf2d is used for getting pbuf index for a pbuf field, which again is 
-! not always the case. 
-!
-! In case somebody inadvertently accesses state and pbuf2d when they are 
-! not passed as an argument, ENDRUN calls are added to stop the model and
-! display an error message.
 !-----------------------------------------------------------------------
   subroutine advance_trcdata( flds, file, state, pbuf2d )
     use physics_types,only : physics_state

--- a/components/cam/src/chemistry/utils/tracer_data.F90
+++ b/components/cam/src/chemistry/utils/tracer_data.F90
@@ -608,8 +608,8 @@ contains
 ! 2. veritcal interpolation (getting zi and pmid for each grid cell)
 ! 3. Single column model 
 !
-! For interpolating surface flux fields, state is not required. 
-! get_ncols_p is now used to get ncol values. 
+! "get_ncols_p" can be used to get ncol values. For interpolating surface 
+! flux fields (i.e. vertical interpolation not needed), state is not required.
 !
 ! This change is made to accomodate CO2 flux interpolation where 
 ! interpolation routines (e.g. co2_time_interp_fuel) are called from a 

--- a/components/cam/src/cpl/atm_import_export.F90
+++ b/components/cam/src/cpl/atm_import_export.F90
@@ -156,7 +156,7 @@ contains
              else if (co2_readFlux_ocn) then 
                 ! convert from molesCO2/m2/s to kgCO2/m2/s
                 cam_in(c)%cflx(i,c_i(1)) = &
-                     -data_flux_ocn%co2flx(i,c)*(1._r8- cam_in(c)%landfrac(i)) &
+                     -data_flux_ocn(i,c)*(1._r8- cam_in(c)%landfrac(i)) &
                      *mwco2*1.0e-3_r8
              else
                 cam_in(c)%cflx(i,c_i(1)) = 0._r8
@@ -164,7 +164,7 @@ contains
              
              ! co2 flux from fossil fuel
              if (co2_readFlux_fuel) then
-                cam_in(c)%cflx(i,c_i(2)) = data_flux_fuel%co2flx(i,c)
+                cam_in(c)%cflx(i,c_i(2)) = data_flux_fuel(i,c)
              else
                 cam_in(c)%cflx(i,c_i(2)) = 0._r8
              end if

--- a/components/cam/src/cpl/atm_import_export.F90
+++ b/components/cam/src/cpl/atm_import_export.F90
@@ -156,7 +156,7 @@ contains
              else if (co2_readFlux_ocn) then 
                 ! convert from molesCO2/m2/s to kgCO2/m2/s
                 cam_in(c)%cflx(i,c_i(1)) = &
-                     -data_flux_ocn(i,c)*(1._r8- cam_in(c)%landfrac(i)) &
+                     -data_flux_ocn%co2flx(i,c)*(1._r8- cam_in(c)%landfrac(i)) &
                      *mwco2*1.0e-3_r8
              else
                 cam_in(c)%cflx(i,c_i(1)) = 0._r8
@@ -164,7 +164,7 @@ contains
              
              ! co2 flux from fossil fuel
              if (co2_readFlux_fuel) then
-                cam_in(c)%cflx(i,c_i(2)) = data_flux_fuel(i,c)
+                cam_in(c)%cflx(i,c_i(2)) = data_flux_fuel%co2flx(i,c)
              else
                 cam_in(c)%cflx(i,c_i(2)) = 0._r8
              end if

--- a/components/cam/src/physics/cam/co2_cycle.F90
+++ b/components/cam/src/physics/cam/co2_cycle.F90
@@ -245,10 +245,16 @@ subroutine co2_init (state, pbuf2d )
 !
 !-----------------------------------------------------------------------
 
+   use time_manager,   only: is_first_step
+
    if (.not. co2_flag) return
  
    if (co2_readFlux_ocn)  then
-      call interp_time_flux ( data_flux_ocn)
+      if (is_first_step()) then
+         call interp_time_flux ( data_flux_ocn,  prev_timestep=.true.  )
+      else
+         call interp_time_flux ( data_flux_ocn,  prev_timestep=.false. )
+      end if
    endif
  
   end subroutine co2_time_interp_ocn
@@ -264,10 +270,16 @@ subroutine co2_init (state, pbuf2d )
 !
 !-----------------------------------------------------------------------
 
+   use time_manager,   only: is_first_step
+
    if (.not. co2_flag) return
  
    if (co2_readFlux_fuel) then
-      call interp_time_flux ( data_flux_fuel)
+      if (is_first_step()) then
+         call interp_time_flux ( data_flux_fuel, prev_timestep=.true.  )
+      else
+         call interp_time_flux ( data_flux_fuel, prev_timestep=.false. )
+      endif
    endif
  
   end subroutine co2_time_interp_fuel

--- a/components/cam/src/physics/cam/co2_cycle.F90
+++ b/components/cam/src/physics/cam/co2_cycle.F90
@@ -24,6 +24,8 @@ use constituents,   only: cnst_add, cnst_get_ind, cnst_name, cnst_longname, sflx
 use chem_surfvals,  only: chem_surfvals_get
 use co2_data_flux
 use cam_abortutils,     only: endrun
+use physics_types,  only: physics_state
+use physics_buffer, only: physics_buffer_desc
 
 implicit none
 private
@@ -186,7 +188,7 @@ function co2_implements_cnst(name)
   end function co2_implements_cnst
 
 !===============================================================================  
-subroutine co2_init
+subroutine co2_init (state, pbuf2d )
 
 !----------------------------------------------------------------------- 
 ! 
@@ -197,8 +199,12 @@ subroutine co2_init
 !
 !-----------------------------------------------------------------------
 
-    use cam_history, only: addfld, horiz_only, add_default
- 
+    use cam_history,    only: addfld, horiz_only, add_default
+
+    type(physics_state), pointer       :: state(:)
+    type(physics_buffer_desc), pointer :: pbuf2d(:,:)
+
+
     integer :: m, mm
       
     if (.not. co2_flag) return
@@ -221,11 +227,11 @@ subroutine co2_init
  
     ! Read flux data
     if (co2_readFlux_ocn) then
-       call read_data_flux ( co2flux_ocn_file,  data_flux_ocn )
+       call read_data_flux ( co2flux_ocn_file,  data_flux_ocn, state, pbuf2d )
     end if
  
     if (co2_readFlux_fuel) then
-       call read_data_flux ( co2flux_fuel_file, data_flux_fuel )
+       call read_data_flux ( co2flux_fuel_file, data_flux_fuel, state, pbuf2d )
     end if
  
   end subroutine co2_init

--- a/components/cam/src/physics/cam/co2_cycle.F90
+++ b/components/cam/src/physics/cam/co2_cycle.F90
@@ -17,14 +17,12 @@ module co2_cycle
 
 use shr_kind_mod,   only: r8 => shr_kind_r8
 use spmd_utils,     only: masterproc
-use ppgrid,         only: begchunk, endchunk, pcols
 use physics_types,  only: physics_state, physics_ptend, physics_ptend_init
 use physconst,      only: mwdry, mwco2, gravit, cpair
 use constituents,   only: cnst_add, cnst_get_ind, cnst_name, cnst_longname, sflxnam
 use chem_surfvals,  only: chem_surfvals_get
-use co2_data_flux,  only: read_data_flux, interp_time_flux
+use co2_data_flux,  only: read_interp, read_data_flux, interp_time_flux
 use cam_abortutils, only: endrun
-use tracer_data,    only: trfld, trfile
 
 implicit none
 private
@@ -44,18 +42,14 @@ public co2_time_interp_fuel          ! time interpolate co2 flux
  
 public data_flux_ocn                 ! data read in for co2 flux from ocn
 public data_flux_fuel                ! data read in for co2 flux from fuel
+ 
+TYPE(read_interp) :: data_flux_ocn                  
+TYPE(read_interp) :: data_flux_fuel
                          
 public c_i                           ! global index for new constituents
 public co2_readFlux_ocn              ! read co2 flux from data file 
 public co2_readFlux_fuel             ! read co2 flux from data file 
 
-
-
-type(trfld), pointer :: fields_ocn(:), fields_fuel(:)
-type(trfile)         :: file_ocn, file_fuel
-
-real(r8), allocatable :: data_flux_ocn(:,:)                  
-real(r8), allocatable :: data_flux_fuel(:,:)
 
 ! Namelist variables
 logical :: co2_flag            = .false.      ! true => turn on co2 code, namelist variable
@@ -205,13 +199,11 @@ subroutine co2_init (state, pbuf2d )
     use cam_history,    only: addfld, horiz_only, add_default
     use physics_types,  only: physics_state
     use physics_buffer, only: physics_buffer_desc
-    use error_messages, only: alloc_err
 
     type(physics_state), pointer       :: state(:)
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
 
-
-    integer :: m, mm, istat
+    integer :: m, mm
       
     if (.not. co2_flag) return
  
@@ -233,15 +225,11 @@ subroutine co2_init (state, pbuf2d )
  
     ! Read flux data
     if (co2_readFlux_ocn) then
-       allocate(data_flux_ocn(pcols,begchunk:endchunk), stat=istat )
-       call alloc_err( istat, 'co2_init', 'data_flux_ocn', pcols*(endchunk-begchunk+1) )
-       call read_data_flux ( fields_ocn, file_ocn, co2flux_ocn_file,  state, pbuf2d )
+       call read_data_flux ( co2flux_ocn_file,  data_flux_ocn, state, pbuf2d )
     end if
-    
+ 
     if (co2_readFlux_fuel) then
-       allocate(data_flux_fuel(pcols,begchunk:endchunk), stat=istat )
-       call alloc_err( istat, 'co2_init', 'data_flux_fuel', pcols*(endchunk-begchunk+1) )
-       call read_data_flux ( fields_fuel, file_fuel, co2flux_fuel_file, state, pbuf2d )
+       call read_data_flux ( co2flux_fuel_file, data_flux_fuel, state, pbuf2d )
     end if
  
   end subroutine co2_init
@@ -260,7 +248,7 @@ subroutine co2_init (state, pbuf2d )
    if (.not. co2_flag) return
  
    if (co2_readFlux_ocn)  then
-      call interp_time_flux ( fields_ocn, file_ocn, data_flux_ocn)
+      call interp_time_flux ( data_flux_ocn)
    endif
  
   end subroutine co2_time_interp_ocn
@@ -279,7 +267,7 @@ subroutine co2_init (state, pbuf2d )
    if (.not. co2_flag) return
  
    if (co2_readFlux_fuel) then
-      call interp_time_flux ( fields_fuel, file_fuel, data_flux_fuel)
+      call interp_time_flux ( data_flux_fuel)
    endif
  
   end subroutine co2_time_interp_fuel

--- a/components/cam/src/physics/cam/co2_data_flux.F90
+++ b/components/cam/src/physics/cam/co2_data_flux.F90
@@ -14,6 +14,7 @@ module co2_data_flux
   use netcdf
   use error_messages, only : handle_ncerr  
   use cam_logfile,    only : iulog
+  use tracer_data,  only : trfld, trfile, trcdata_init, advance_trcdata
   
 #if ( defined SPMD )
   use mpishorthand, only: mpicom, mpiint, mpir8
@@ -35,6 +36,9 @@ module co2_data_flux
 ! private data
 
   private
+  type(trfld), pointer :: fields(:)
+  type(trfile)         :: file
+
 !  integer,  parameter :: totsz=2000           ! number greater than data time sample
   real(r8), parameter :: daysperyear = 365.0_r8  ! Number of days in a year         
   integer :: lonsiz  ! size of longitude dimension, dataset is 2d(lat,lon), in CAM grid
@@ -67,7 +71,7 @@ contains
  
 !===============================================================================
 
-subroutine read_data_flux (input_file, xin)
+subroutine read_data_flux (input_file, xin, state, pbuf2d)
  
 !-------------------------------------------------------------------------------              
 ! Do initial read of time-varying 2d(lat,lon NetCDF dataset, 
@@ -77,6 +81,8 @@ subroutine read_data_flux (input_file, xin)
   use time_manager, only : get_curr_date, get_curr_calday, &
                            is_perpetual, get_perp_date, get_step_size, is_first_step
   use ioFileMod,    only : getfil
+  use physics_types,  only: physics_state
+  use physics_buffer, only: physics_buffer_desc
 
   implicit none
  
@@ -84,6 +90,8 @@ subroutine read_data_flux (input_file, xin)
 ! Dummy arguments
   character(len=*),   intent(in)    :: input_file
   TYPE(read_interp),  intent(inout) :: xin   
+  type(physics_state), pointer       :: state(:)
+  type(physics_buffer_desc), pointer :: pbuf2d(:,:)
  
   integer lonid                 ! netcdf id for longitude variable
   integer latid                 ! netcdf id for latitude variable
@@ -105,6 +113,8 @@ subroutine read_data_flux (input_file, xin)
   real(r8) calday               ! calendar day (includes yr if no cycling)
   real(r8) caldayloc            ! calendar day (includes yr if no cycling)
  
+  character(len=32)  :: specifier(1) = ''
+
   xin%nm_f = 1
   xin%np_f = 2
  
@@ -119,146 +129,15 @@ subroutine read_data_flux (input_file, xin)
        pcols*(endchunk-begchunk+1)*2 )
  
 ! SPMD: Master does all the work.
- 
-  if (masterproc) then
-!
-! Use year information only if not cycling sst dataset
-!
-     if (is_first_step()) then
-        dtime = get_step_size()
-        dtime = -dtime
-        calday = get_curr_calday(offset=dtime)
-     else
-        calday = get_curr_calday()
-     endif
-     if ( is_perpetual() ) then
-        call get_perp_date(yr, mon, day, ncsec)
-     else
-        if (is_first_step()) then
-           call get_curr_date(yr, mon, day, ncsec,offset=dtime)
-        else
-           call get_curr_date(yr, mon, day, ncsec)
-        endif
-     end if
- 
-     ncdate = yr*10000 + mon*100 + day
- 
-     caldayloc = calday + yr*daysperyear
- 
-! Open NetCDF File
- 
-     call getfil(input_file, xin%locfn)
-     call handle_ncerr( nf90_open(xin%locfn, 0, xin%ncid_f),&
-       'co2_data_flux.F90:154')
-     write(iulog,*)'CO2FLUX_READ: NCOPN returns id ',xin%ncid_f,' for file ',trim(xin%locfn)
- 
-! Get and check dimension info
- 
-     call handle_ncerr( nf90_inq_dimid( xin%ncid_f, 'lon', londimid ),&
-       'co2_data_flux.F90:160')
-     call handle_ncerr( nf90_inq_dimid( xin%ncid_f, 'lat', latdimid ),&
-       'co2_data_flux.F90:162')
-     call handle_ncerr( nf90_inq_dimid( xin%ncid_f, 'time',  timeid ),&
-       'co2_data_flux.F90:164')
 
-     call handle_ncerr( nf90_inquire_dimension( xin%ncid_f, londimid, len=lonsiz     ),&
-       'co2_data_flux.F90:167')
-     call handle_ncerr( nf90_inquire_dimension( xin%ncid_f, latdimid, len=latsiz     ),&
-       'co2_data_flux.F90:169')
-     call handle_ncerr( nf90_inquire_dimension( xin%ncid_f, timeid,   len=xin%timesz ),&
-       'co2_data_flux.F90:171')
 
-     allocate(xin%date_f(xin%timesz), xin%sec_f(xin%timesz))
-! Get data id
-        
-     call handle_ncerr( nf90_inq_varid( xin%ncid_f, 'date',     dateid     ),&
-       'co2_data_flux.F90:192')
-     call handle_ncerr( nf90_inq_varid( xin%ncid_f, 'datesec',  secid      ),&
-       'co2_data_flux.F90:194')
-     call handle_ncerr( nf90_inq_varid( xin%ncid_f, 'CO2_flux', xin%fluxid ),&
-       'co2_data_flux.F90:196')
- 
-! Retrieve entire date and sec variables.
- 
-     call handle_ncerr( nf90_get_var ( xin%ncid_f, dateid, xin%date_f ),&
-       'co2_data_flux.F90:201')
-     call handle_ncerr( nf90_get_var ( xin%ncid_f, secid,  xin%sec_f  ),&
-       'co2_data_flux.F90:203')
-
-! initialize
- 
-     strt3(1) = 1
-     strt3(2) = 1
-     strt3(3) = 1
-     cnt3(1)  = lonsiz
-     cnt3(2)  = latsiz
-     cnt3(3)  = 1
-
-  endif
-
-#ifdef SPMD
-  call mpibcast( cnt3, 2,     mpiint, 0, mpicom )
-#endif
-  allocate(xin%xvar(cnt3(1),cnt3(2),2))
-  if (masterproc) then
-! Normal interpolation between consecutive time slices.
-
-     do n=1,xin%timesz-1
-
-        xin%np1_f = n + 1
- 
-        call bnddyi(xin%date_f(n  ),       xin%sec_f(n  ),       xin%cdayfm)
-        call bnddyi(xin%date_f(xin%np1_f), xin%sec_f(xin%np1_f), xin%cdayfp)
- 
-        yr         = xin%date_f(n)/10000
-        xin%cdayfm = xin%cdayfm + yr*daysperyear
-
-        yr         = xin%date_f(xin%np1_f)/10000
-        xin%cdayfp = xin%cdayfp + yr*daysperyear
- 
-!       read 2 time sample bracketing ncdate
-
-        if ( caldayloc > xin%cdayfm .and. caldayloc <= xin%cdayfp ) then
- 
-           strt3(3) = n
-           call handle_ncerr( nf90_get_var ( xin%ncid_f, xin%fluxid, xin%xvar(:,:,xin%nm_f), strt3, cnt3), &
-             'co2_data_flux.F90:235')
-           strt3(3) = xin%np1_f                                      
-           call handle_ncerr( nf90_get_var ( xin%ncid_f, xin%fluxid, xin%xvar(:,:,xin%np_f), strt3, cnt3),&
-             'co2_data_flux.F90:238')
-
-           goto 10
-
-        end if
- 
-     end do
-
-     write(iulog,*)'CO2FLUX_READ: Failed to find dates bracketing ncdate, ncsec=', ncdate, ncsec
-     call endrun
- 
-10   continue
-     write(iulog,*)'CO2FLUX_READ: Read ', trim(xin%locfn), ' for dates ', xin%date_f(n), xin%sec_f(n), &
-          ' and ', xin%date_f(xin%np1_f), xin%sec_f(xin%np1_f)
- 
-#if (defined SPMD )
-     call mpibcast( xin%timesz, 1,     mpiint, 0, mpicom )
-     call mpibcast( xin%date_f, xin%timesz, mpiint, 0, mpicom )
-     call mpibcast( xin%sec_f,  xin%timesz, mpiint, 0, mpicom )
-     call mpibcast( xin%cdayfm, 1,     mpir8 , 0, mpicom )
-     call mpibcast( xin%cdayfp, 1,     mpir8,  0, mpicom )
-     call mpibcast( xin%np1_f,  1,     mpiint, 0, mpicom )
-  else
-     call mpibcast( xin%timesz, 1,     mpiint, 0, mpicom )
-     allocate(xin%date_f(xin%timesz), xin%sec_f(xin%timesz))
-     call mpibcast( xin%date_f, xin%timesz, mpiint, 0, mpicom )
-     call mpibcast( xin%sec_f,  xin%timesz, mpiint, 0, mpicom )
-     call mpibcast( xin%cdayfm, 1,     mpir8 , 0, mpicom )
-     call mpibcast( xin%cdayfp, 1,     mpir8,  0, mpicom )
-     call mpibcast( xin%np1_f,  1,     mpiint, 0, mpicom )
-#endif
-  end if
-
-  call scatter_field_to_chunk ( 1,1,2,cnt3(1), xin%xvar, xin%co2bdy )
+  !call trcdata_init( specifier, filename, filelist, datapath, fields, file, &
+  !                     rmv_file, cycle_yr, fixed_ymd, fixed_tod, datatype)
+  allocate (file%in_pbuf(1))
+  file%in_pbuf(1) = .false.
+  specifier(1) = 'CO2_flux:CO2_flux'
+  call trcdata_init( specifier ,input_file , '', '', fields, file, &
+       .false., 0, 0, 0, 'SERIAL' )
 
   return
 end subroutine read_data_flux
@@ -298,106 +177,16 @@ subroutine interp_time_flux (xin, prev_timestep)
   logical :: co2cyc=.false.
  
 !-----------------------------------------------------------------------
- 
-! SPMD: Master does all the work.  Sends needed info to slaves
- 
-! Use year information only if a multiyear dataset
- 
-     if ( .not. present(prev_timestep) ) then
-        previous = .false.
-     else
-        previous = prev_timestep
-     end if
- 
-     if (previous .and. is_first_step()) then
-        dtime = get_step_size()
-        dtime = -dtime
-        calday = get_curr_calday(offset=dtime)
-     else
-        calday = get_curr_calday()
-     endif
- 
-     if ( is_perpetual() ) then
-        call get_perp_date(yr, mon, day, ncsec)
-     else
-        if (previous .and. is_first_step()) then
-           call get_curr_date(yr, mon, day, ncsec,offset=dtime)
-        else
-           call get_curr_date(yr, mon, day, ncsec)
-        endif
-     end if
- 
-     ncdate = yr*10000 + mon*100 + day
- 
-     caldayloc = calday + yr*daysperyear
 
-     if (masterproc) then
 
-        strt3(1) = 1
-        strt3(2) = 1
-        strt3(3) = 1
-        cnt3(1)  = lonsiz
-        cnt3(2)  = latsiz
-        cnt3(3)  = 1
+  call advance_trcdata( fields, file)
 
-     endif
-
-#ifdef SPMD
-     call mpibcast(cnt3, 2, mpiint, 0, mpicom)
-#endif
- 
-! If model time is past current forward data timeslice, read in the next
-! timeslice for time interpolation. 
- 
-     if ( caldayloc > xin%cdayfp .and. .not. (xin%np1_f==1 .and. caldayloc > xin%cdayfm) ) then
- 
-        xin%np1_f = xin%np1_f + 1
- 
-        if ( xin%np1_f > xin%timesz ) then
-           call endrun ('CO2FLUX_INTERP: Attempt to read past end of dataset')
-        end if
- 
-        xin%cdayfm = xin%cdayfp
- 
-        call bnddyi( xin%date_f(xin%np1_f), xin%sec_f(xin%np1_f), xin%cdayfp )
-
-        yr = xin%date_f(xin%np1_f)/10000
-        xin%cdayfp = xin%cdayfp + yr*daysperyear
-
-        if ( .not. (xin%np1_f == 1 .or. caldayloc <= xin%cdayfp) ) then
-         
-           if (masterproc) then
-              write(iulog,*)'CO2FLUX_INTERP: Input data for date', xin%date_f(xin%np1_f), ' sec ', xin%sec_f(xin%np1_f), &
-                        ' does not exceed model date', ncdate, ' sec ', ncsec, ' Stopping.'
-           end if
-           call endrun ()
-        end if
-
-        ntmp     = xin%nm_f
-        xin%nm_f = xin%np_f
-        xin%np_f = ntmp
- 
-        if (masterproc) then
-           strt3(3) = xin%np1_f
-           call handle_ncerr( nf90_get_var ( xin%ncid_f, xin%fluxid, xin%xvar(:,:,xin%np_f), strt3, cnt3 ),&
-             'co2_data_flux.F90:391')
-           write(iulog,*)'CO2FLUX_INTERP: Read ', trim(xin%locfn),' for date (yyyymmdd) ', xin%date_f(xin%np1_f), &
-                     ' sec ', xin%sec_f(xin%np1_f)
-        endif
- 
-        call scatter_field_to_chunk ( 1,1,2,cnt3(1), xin%xvar, xin%co2bdy )
-     end if
- 
-! Determine time interpolation factors.
- 
-     call get_timeinterp_factors ( co2cyc, xin%np1_f, xin%cdayfm, xin%cdayfp, caldayloc, fact1, fact2, 'CO2FLUX_INTERP:' )
-
-     do lchnk=begchunk,endchunk
-        ncol = get_ncols_p(lchnk)
-        do i=1,ncol
-           xin%co2flx(i,lchnk) = xin%co2bdy(i,lchnk,xin%nm_f)*fact1 + xin%co2bdy(i,lchnk,xin%np_f)*fact2
-        end do
+  do lchnk=begchunk,endchunk
+     ncol = get_ncols_p(lchnk)
+     do i=1,ncol
+        xin%co2flx(i,lchnk) = fields(1)%data(i,1,lchnk)
      end do
+  end do
 
   return
 end subroutine interp_time_flux

--- a/components/cam/src/physics/cam/co2_data_flux.F90
+++ b/components/cam/src/physics/cam/co2_data_flux.F90
@@ -6,25 +6,69 @@ module co2_data_flux
 !------------------------------------------------------------------------------------------------
 
   use shr_kind_mod,   only : r8 => shr_kind_r8
+  use spmd_utils,     only : masterproc
   use ppgrid,         only : begchunk, endchunk, pcols
-  use error_messages, only : alloc_err
+  use phys_grid,      only : scatter_field_to_chunk, get_ncols_p
+  use error_messages, only : alloc_err, handle_ncerr, handle_err
+  use cam_abortutils,     only : endrun
+  use netcdf,         only : nf90_inq_dimid, nf90_inquire_dimension, nf90_inq_varid, nf90_get_var, nf90_open
+  use cam_logfile,    only : iulog
+#ifdef CO2_BILIN_REGRID
   use tracer_data,    only : trfld, trfile, trcdata_init, advance_trcdata
+#endif
+  
+#if ( defined SPMD )
+  use mpishorthand, only: mpicom, mpiint, mpir8
+#endif
 
   implicit none
 
+! public data
+
+! public type
+
   public read_interp
+
+! public interface
+
   public read_data_flux
   public interp_time_flux
 
+! private data
+
   private
+!  integer,  parameter :: totsz=2000           ! number greater than data time sample
+  real(r8), parameter :: daysperyear = 365.0_r8  ! Number of days in a year         
+  integer :: lonsiz  ! size of longitude dimension, dataset is 2d(lat,lon), in CAM grid
+  integer :: latsiz  ! size of latitude dimension
+ 
 !--------------------------------------------------------------------------------------------------
 TYPE :: read_interp          
-  real(r8),     pointer, dimension(:,:) :: co2flx
+      
+  real(r8), pointer, dimension(:,:)   :: co2flx
+                       ! Interpolated output (pcols,begchunk:endchunk)
+  real(r8), pointer, dimension(:,:,:) :: co2bdy
+                       ! bracketing data     (pcols,begchunk:endchunk,2)
+  real(r8) :: cdayfm   ! Calendar day for prv. month read in
+  real(r8) :: cdayfp   ! Calendar day for nxt. month read in
+  integer :: nm_f      ! Array indices for prv. month data
+  integer :: np_f      ! Array indices for nxt. month data
+  integer :: np1_f     ! current forward time index of dataset
+  integer :: timesz    ! size of time dimension on dataset
+  integer, pointer :: date_f(:)      ! Date on dataset (YYYYMMDD)
+  integer, pointer :: sec_f(:)       ! seconds of date on dataset (0-86399) 
+  character(len=256) :: locfn   ! dataset name
+  integer :: ncid_f             ! netcdf id for dataset       
+  integer :: fluxid             ! netcdf id for dataset flux      
+  real(r8), pointer :: xvar(:,:,:) ! work space for dataset  
+#ifdef CO2_BILIN_REGRID
   type(trfld),  pointer, dimension(:)   :: fields
   type(trfile)                          :: file
+#endif
+ 
 END TYPE read_interp
 !-------------------------------------------------------------------------------------------------
- 
+                       
 contains
  
 !===============================================================================
@@ -32,9 +76,14 @@ contains
 subroutine read_data_flux (input_file, xin, state, pbuf2d)
  
 !-------------------------------------------------------------------------------              
-! Do initial read of time-varying 2d(lat,lon NetCDF dataset)
+! Do initial read of time-varying 2d(lat,lon NetCDF dataset, 
+! reading two data bracketing current timestep
 !-------------------------------------------------------------------------------
  
+  use time_manager, only : get_curr_date, get_curr_calday, &
+                           is_perpetual, get_perp_date, get_step_size, is_first_step
+  use ioFileMod,    only : getfil
+  
   use physics_types,  only: physics_state
   use physics_buffer, only: physics_buffer_desc
 
@@ -42,20 +91,42 @@ subroutine read_data_flux (input_file, xin, state, pbuf2d)
  
 !---------------------------Common blocks-------------------------------
 ! Dummy arguments
-  character(len=*),   intent(in)     :: input_file
-  TYPE(read_interp),  intent(inout)  :: xin   
+  character(len=*),   intent(in)    :: input_file
+  TYPE(read_interp),  intent(inout) :: xin   
   type(physics_state),       pointer :: state(:)
   type(physics_buffer_desc), pointer :: pbuf2d(:,:)
  
-  integer istat                 ! error return
-  character(len=32)  :: specifier(1) = ''
-
+  integer lonid                 ! netcdf id for longitude variable
+  integer latid                 ! netcdf id for latitude variable
+  integer timeid                ! netcdf id for time variable
+  integer dateid                ! netcdf id for date variable
+  integer secid                 ! netcdf id for seconds variable
+  integer londimid              ! netcdf id for longitude variable
+  integer latdimid              ! netcdf id for latitude variable
  
+  integer dtime                 ! timestep size [seconds]
+  integer cnt3(3)               ! array of counts for each dimension
+  integer strt3(3)              ! array of starting indices
+  integer n                     ! indices
+  integer j                     ! latitude index
+  integer istat                 ! error return
+  integer  :: yr, mon, day      ! components of a date
+  integer  :: ncdate            ! current date in integer format [yyyymmdd]
+  integer  :: ncsec             ! current time of day [seconds]
+  real(r8) calday               ! calendar day (includes yr if no cycling)
+  real(r8) caldayloc            ! calendar day (includes yr if no cycling)
+#ifdef CO2_BILIN_REGRID
+  character(len=32)  :: specifier(1) = ''
+#endif
+
 ! Allocate space for data.
  
   allocate( xin%co2flx(pcols,begchunk:endchunk), stat=istat )
-  call alloc_err( istat, 'CO2FLUX_READ', 'co2flx', pcols*(endchunk-begchunk+1) )
+  call alloc_err( istat, 'CO2FLUX_READ', 'co2flx', &
+       pcols*(endchunk-begchunk+1) )
 
+
+#ifdef CO2_BILIN_REGRID
   allocate (xin%file%in_pbuf(1))
   xin%file%in_pbuf(1) = .false.
 
@@ -66,26 +137,201 @@ subroutine read_data_flux (input_file, xin, state, pbuf2d)
 ! if need be.
   call trcdata_init(specifier, input_file , '', '', xin%fields, xin%file, .false., 0, 0, 0, 'SERIAL')
 
+#else
+ 
+  xin%nm_f = 1
+  xin%np_f = 2
+ 
+ 
+  allocate( xin%co2bdy(pcols,begchunk:endchunk,2), stat=istat )
+  call alloc_err( istat, 'CO2FLUX_READ', 'co2bdy', &
+       pcols*(endchunk-begchunk+1)*2 )
+ 
+! SPMD: Master does all the work.
+ 
+  if (masterproc) then
+!
+! Use year information only if not cycling sst dataset
+!
+     if (is_first_step()) then
+        dtime = get_step_size()
+        dtime = -dtime
+        calday = get_curr_calday(offset=dtime)
+     else
+        calday = get_curr_calday()
+     endif
+     if ( is_perpetual() ) then
+        call get_perp_date(yr, mon, day, ncsec)
+     else
+        if (is_first_step()) then
+           call get_curr_date(yr, mon, day, ncsec,offset=dtime)
+        else
+           call get_curr_date(yr, mon, day, ncsec)
+        endif
+     end if
+ 
+     ncdate = yr*10000 + mon*100 + day
+ 
+     caldayloc = calday + yr*daysperyear
+ 
+! Open NetCDF File
+ 
+     call getfil(input_file, xin%locfn)
+     call handle_ncerr( nf90_open(xin%locfn, 0, xin%ncid_f),&
+       'co2_data_flux.F90:154')
+     write(iulog,*)'CO2FLUX_READ: NCOPN returns id ',xin%ncid_f,' for file ',trim(xin%locfn)
+ 
+! Get and check dimension info
+ 
+     call handle_ncerr( nf90_inq_dimid( xin%ncid_f, 'lon', londimid ),&
+       'co2_data_flux.F90:160')
+     call handle_ncerr( nf90_inq_dimid( xin%ncid_f, 'lat', latdimid ),&
+       'co2_data_flux.F90:162')
+     call handle_ncerr( nf90_inq_dimid( xin%ncid_f, 'time',  timeid ),&
+       'co2_data_flux.F90:164')
+
+     call handle_ncerr( nf90_inquire_dimension( xin%ncid_f, londimid, len=lonsiz     ),&
+       'co2_data_flux.F90:167')
+     call handle_ncerr( nf90_inquire_dimension( xin%ncid_f, latdimid, len=latsiz     ),&
+       'co2_data_flux.F90:169')
+     call handle_ncerr( nf90_inquire_dimension( xin%ncid_f, timeid,   len=xin%timesz ),&
+       'co2_data_flux.F90:171')
+
+     allocate(xin%date_f(xin%timesz), xin%sec_f(xin%timesz))
+! Get data id
+        
+     call handle_ncerr( nf90_inq_varid( xin%ncid_f, 'date',     dateid     ),&
+       'co2_data_flux.F90:192')
+     call handle_ncerr( nf90_inq_varid( xin%ncid_f, 'datesec',  secid      ),&
+       'co2_data_flux.F90:194')
+     call handle_ncerr( nf90_inq_varid( xin%ncid_f, 'CO2_flux', xin%fluxid ),&
+       'co2_data_flux.F90:196')
+ 
+! Retrieve entire date and sec variables.
+ 
+     call handle_ncerr( nf90_get_var ( xin%ncid_f, dateid, xin%date_f ),&
+       'co2_data_flux.F90:201')
+     call handle_ncerr( nf90_get_var ( xin%ncid_f, secid,  xin%sec_f  ),&
+       'co2_data_flux.F90:203')
+
+! initialize
+ 
+     strt3(1) = 1
+     strt3(2) = 1
+     strt3(3) = 1
+     cnt3(1)  = lonsiz
+     cnt3(2)  = latsiz
+     cnt3(3)  = 1
+
+  endif
+
+#ifdef SPMD
+  call mpibcast( cnt3, 2,     mpiint, 0, mpicom )
+#endif
+  allocate(xin%xvar(cnt3(1),cnt3(2),2))
+  if (masterproc) then
+! Normal interpolation between consecutive time slices.
+
+     do n=1,xin%timesz-1
+
+        xin%np1_f = n + 1
+ 
+        call bnddyi(xin%date_f(n  ),       xin%sec_f(n  ),       xin%cdayfm)
+        call bnddyi(xin%date_f(xin%np1_f), xin%sec_f(xin%np1_f), xin%cdayfp)
+ 
+        yr         = xin%date_f(n)/10000
+        xin%cdayfm = xin%cdayfm + yr*daysperyear
+
+        yr         = xin%date_f(xin%np1_f)/10000
+        xin%cdayfp = xin%cdayfp + yr*daysperyear
+ 
+!       read 2 time sample bracketing ncdate
+
+        if ( caldayloc > xin%cdayfm .and. caldayloc <= xin%cdayfp ) then
+ 
+           strt3(3) = n
+           call handle_ncerr( nf90_get_var ( xin%ncid_f, xin%fluxid, xin%xvar(:,:,xin%nm_f), strt3, cnt3), &
+             'co2_data_flux.F90:235')
+           strt3(3) = xin%np1_f                                      
+           call handle_ncerr( nf90_get_var ( xin%ncid_f, xin%fluxid, xin%xvar(:,:,xin%np_f), strt3, cnt3),&
+             'co2_data_flux.F90:238')
+
+           goto 10
+
+        end if
+ 
+     end do
+
+     write(iulog,*)'CO2FLUX_READ: Failed to find dates bracketing ncdate, ncsec=', ncdate, ncsec
+     call endrun
+ 
+10   continue
+     write(iulog,*)'CO2FLUX_READ: Read ', trim(xin%locfn), ' for dates ', xin%date_f(n), xin%sec_f(n), &
+          ' and ', xin%date_f(xin%np1_f), xin%sec_f(xin%np1_f)
+ 
+#if (defined SPMD )
+     call mpibcast( xin%timesz, 1,     mpiint, 0, mpicom )
+     call mpibcast( xin%date_f, xin%timesz, mpiint, 0, mpicom )
+     call mpibcast( xin%sec_f,  xin%timesz, mpiint, 0, mpicom )
+     call mpibcast( xin%cdayfm, 1,     mpir8 , 0, mpicom )
+     call mpibcast( xin%cdayfp, 1,     mpir8,  0, mpicom )
+     call mpibcast( xin%np1_f,  1,     mpiint, 0, mpicom )
+  else
+     call mpibcast( xin%timesz, 1,     mpiint, 0, mpicom )
+     allocate(xin%date_f(xin%timesz), xin%sec_f(xin%timesz))
+     call mpibcast( xin%date_f, xin%timesz, mpiint, 0, mpicom )
+     call mpibcast( xin%sec_f,  xin%timesz, mpiint, 0, mpicom )
+     call mpibcast( xin%cdayfm, 1,     mpir8 , 0, mpicom )
+     call mpibcast( xin%cdayfp, 1,     mpir8,  0, mpicom )
+     call mpibcast( xin%np1_f,  1,     mpiint, 0, mpicom )
+#endif
+  end if
+
+  call scatter_field_to_chunk ( 1,1,2,cnt3(1), xin%xvar, xin%co2bdy )
+
+#endif
   return
 end subroutine read_data_flux
  
 !===============================================================================
 
-subroutine interp_time_flux (xin)
+subroutine interp_time_flux (xin, prev_timestep)
  
 !-----------------------------------------------------------------------
 ! Time interpolate data to current time.
 ! Reading in new monthly data if necessary.
 !
 !-----------------------------------------------------------------------
-  use phys_grid,      only : get_ncols_p
-
+ 
+  use time_manager, only : get_curr_date, get_curr_calday, &
+                          is_perpetual, get_perp_date, get_step_size, is_first_step
+  use interpolate_data,   only : get_timeinterp_factors
+#ifdef CO2_BILIN_REGRID
+  use ppgrid,           only: pver, pverp
+#endif
+ 
+  logical, intent(in), optional     :: prev_timestep ! If using previous timestep, set to true
   TYPE(read_interp),  intent(inout) :: xin
 
 !---------------------------Local variables-----------------------------
-  integer :: icol, lchnk      ! indices
-  integer :: ncol             ! number of columns in current chunk
-!-----------------------------------------------------------------------
+  integer dtime          ! timestep size [seconds]
+  integer cnt3(3)        ! array of counts for each dimension
+  integer strt3(3)       ! array of starting indices
+  integer i,j,lchnk      ! indices
+  integer ncol           ! number of columns in current chunk
+  integer ntmp           ! temporary
+  real(r8) fact1, fact2  ! time interpolation factors
+  integer :: yr, mon, day! components of a date
+  integer :: ncdate      ! current date in integer format [yyyymmdd]
+  integer :: ncsec       ! current time of day [seconds]
+  real(r8) :: calday     ! current calendar day
+  real(r8) caldayloc     ! calendar day (includes yr if no cycling)
+  real(r8) deltat        ! time (days) between interpolating data
+  logical :: previous
+  logical :: co2cyc=.false.
+ 
+#ifdef CO2_BILIN_REGRID
+  integer :: icol      ! indices
 
   !Read next data if needed and interpolate (space and time)
   call advance_trcdata( xin%fields, xin%file)
@@ -98,8 +344,114 @@ subroutine interp_time_flux (xin)
      end do
   end do
 
+#else
+!-----------------------------------------------------------------------
+ 
+! SPMD: Master does all the work.  Sends needed info to slaves
+ 
+! Use year information only if a multiyear dataset
+ 
+     if ( .not. present(prev_timestep) ) then
+        previous = .false.
+     else
+        previous = prev_timestep
+     end if
+ 
+     if (previous .and. is_first_step()) then
+        dtime = get_step_size()
+        dtime = -dtime
+        calday = get_curr_calday(offset=dtime)
+     else
+        calday = get_curr_calday()
+     endif
+ 
+     if ( is_perpetual() ) then
+        call get_perp_date(yr, mon, day, ncsec)
+     else
+        if (previous .and. is_first_step()) then
+           call get_curr_date(yr, mon, day, ncsec,offset=dtime)
+        else
+           call get_curr_date(yr, mon, day, ncsec)
+        endif
+     end if
+ 
+     ncdate = yr*10000 + mon*100 + day
+ 
+     caldayloc = calday + yr*daysperyear
+
+     if (masterproc) then
+
+        strt3(1) = 1
+        strt3(2) = 1
+        strt3(3) = 1
+        cnt3(1)  = lonsiz
+        cnt3(2)  = latsiz
+        cnt3(3)  = 1
+
+     endif
+
+#ifdef SPMD
+     call mpibcast(cnt3, 2, mpiint, 0, mpicom)
+#endif
+ 
+! If model time is past current forward data timeslice, read in the next
+! timeslice for time interpolation. 
+ 
+     if ( caldayloc > xin%cdayfp .and. .not. (xin%np1_f==1 .and. caldayloc > xin%cdayfm) ) then
+ 
+        xin%np1_f = xin%np1_f + 1
+ 
+        if ( xin%np1_f > xin%timesz ) then
+           call endrun ('CO2FLUX_INTERP: Attempt to read past end of dataset')
+        end if
+ 
+        xin%cdayfm = xin%cdayfp
+ 
+        call bnddyi( xin%date_f(xin%np1_f), xin%sec_f(xin%np1_f), xin%cdayfp )
+
+        yr = xin%date_f(xin%np1_f)/10000
+        xin%cdayfp = xin%cdayfp + yr*daysperyear
+
+        if ( .not. (xin%np1_f == 1 .or. caldayloc <= xin%cdayfp) ) then
+         
+           if (masterproc) then
+              write(iulog,*)'CO2FLUX_INTERP: Input data for date', xin%date_f(xin%np1_f), ' sec ', xin%sec_f(xin%np1_f), &
+                        ' does not exceed model date', ncdate, ' sec ', ncsec, ' Stopping.'
+           end if
+           call endrun ()
+        end if
+
+        ntmp     = xin%nm_f
+        xin%nm_f = xin%np_f
+        xin%np_f = ntmp
+ 
+        if (masterproc) then
+           strt3(3) = xin%np1_f
+           call handle_ncerr( nf90_get_var ( xin%ncid_f, xin%fluxid, xin%xvar(:,:,xin%np_f), strt3, cnt3 ),&
+             'co2_data_flux.F90:391')
+           write(iulog,*)'CO2FLUX_INTERP: Read ', trim(xin%locfn),' for date (yyyymmdd) ', xin%date_f(xin%np1_f), &
+                     ' sec ', xin%sec_f(xin%np1_f)
+        endif
+ 
+        call scatter_field_to_chunk ( 1,1,2,cnt3(1), xin%xvar, xin%co2bdy )
+     end if
+ 
+! Determine time interpolation factors.
+ 
+     call get_timeinterp_factors ( co2cyc, xin%np1_f, xin%cdayfm, xin%cdayfp, caldayloc, fact1, fact2, 'CO2FLUX_INTERP:' )
+
+     do lchnk=begchunk,endchunk
+        ncol = get_ncols_p(lchnk)
+        do i=1,ncol
+           xin%co2flx(i,lchnk) = xin%co2bdy(i,lchnk,xin%nm_f)*fact1 + xin%co2bdy(i,lchnk,xin%np_f)*fact2
+        end do
+     end do
+
+#endif
   return
 end subroutine interp_time_flux
 
 !============================================================================================================
+
 end module co2_data_flux
+

--- a/components/cam/src/physics/cam/co2_data_flux.F90
+++ b/components/cam/src/physics/cam/co2_data_flux.F90
@@ -5,23 +5,31 @@ module co2_data_flux
 ! for data reading and interpolation                                           
 !------------------------------------------------------------------------------------------------
 
-  use shr_kind_mod, only : r8 => shr_kind_r8
-  use tracer_data,  only : trfld, trfile, trcdata_init, advance_trcdata
+  use shr_kind_mod,   only : r8 => shr_kind_r8
+  use ppgrid,         only : begchunk, endchunk, pcols
+  use error_messages, only : alloc_err
+  use tracer_data,    only : trfld, trfile, trcdata_init, advance_trcdata
 
   implicit none
 
-! public 
+  public read_interp
   public read_data_flux
   public interp_time_flux
 
-! private
   private
+!--------------------------------------------------------------------------------------------------
+TYPE :: read_interp          
+  real(r8),     pointer, dimension(:,:) :: co2flx
+  type(trfld),  pointer, dimension(:)   :: fields
+  type(trfile)                          :: file
+END TYPE read_interp
+!-------------------------------------------------------------------------------------------------
  
 contains
  
 !===============================================================================
 
-subroutine read_data_flux (fields, file, input_file, state, pbuf2d)
+subroutine read_data_flux (input_file, xin, state, pbuf2d)
  
 !-------------------------------------------------------------------------------              
 ! Do initial read of time-varying 2d(lat,lon NetCDF dataset)
@@ -34,31 +42,36 @@ subroutine read_data_flux (fields, file, input_file, state, pbuf2d)
  
 !---------------------------Common blocks-------------------------------
 ! Dummy arguments
-  type(trfld),               pointer :: fields(:)
-  type(trfile),    intent(out)       :: file
-  character(len=*),intent(in)        :: input_file
+  character(len=*),   intent(in)     :: input_file
+  TYPE(read_interp),  intent(inout)  :: xin   
   type(physics_state),       pointer :: state(:)
   type(physics_buffer_desc), pointer :: pbuf2d(:,:)
  
+  integer istat                 ! error return
   character(len=32)  :: specifier(1) = ''
 
  
-! Initialize variables needed for tracer_data routines
-  allocate (file%in_pbuf(1))
-  file%in_pbuf(1) = .false.
+! Allocate space for data.
+ 
+  allocate( xin%co2flx(pcols,begchunk:endchunk), stat=istat )
+  call alloc_err( istat, 'CO2FLUX_READ', 'co2flx', pcols*(endchunk-begchunk+1) )
+
+  allocate (xin%file%in_pbuf(1))
+  xin%file%in_pbuf(1) = .false.
+
   specifier(1)    = 'CO2_flux' !name of variable to read from file
 
 ! Open file and initialize "fields" and "file" derived types
 ! Some of the arguments passed here are hardwired which can be replaced with variables
 ! if need be.
-  call trcdata_init(specifier, input_file , '', '', fields, file, .false., 0, 0, 0, 'SERIAL')
+  call trcdata_init(specifier, input_file , '', '', xin%fields, xin%file, .false., 0, 0, 0, 'SERIAL')
 
   return
 end subroutine read_data_flux
  
 !===============================================================================
 
-subroutine interp_time_flux (fields, file, data_flux)
+subroutine interp_time_flux (xin)
  
 !-----------------------------------------------------------------------
 ! Time interpolate data to current time.
@@ -66,11 +79,8 @@ subroutine interp_time_flux (fields, file, data_flux)
 !
 !-----------------------------------------------------------------------
   use phys_grid,      only : get_ncols_p
-  use ppgrid,         only : begchunk, endchunk
 
-  type(trfld),               pointer :: fields(:)
-  type(trfile), intent(inout)        :: file
-  real(r8),     intent(inout)        :: data_flux(:,:)
+  TYPE(read_interp),  intent(inout) :: xin
 
 !---------------------------Local variables-----------------------------
   integer :: icol, lchnk      ! indices
@@ -78,13 +88,13 @@ subroutine interp_time_flux (fields, file, data_flux)
 !-----------------------------------------------------------------------
 
   !Read next data if needed and interpolate (space and time)
-  call advance_trcdata( fields, file)
+  call advance_trcdata( xin%fields, xin%file)
 
   !Assign 
   do lchnk   = begchunk, endchunk
      ncol    = get_ncols_p(lchnk)
      do icol = 1, ncol
-        data_flux(icol, lchnk) = fields(1)%data(icol, 1, lchnk)
+        xin%co2flx(icol,lchnk) = xin%fields(1)%data(icol, 1,lchnk)
      end do
   end do
 

--- a/components/cam/src/physics/cam/co2_data_flux.F90
+++ b/components/cam/src/physics/cam/co2_data_flux.F90
@@ -5,82 +5,28 @@ module co2_data_flux
 ! for data reading and interpolation                                           
 !------------------------------------------------------------------------------------------------
 
-  use shr_kind_mod,   only : r8 => shr_kind_r8
-  use spmd_utils,     only : masterproc
-  use ppgrid,         only : begchunk, endchunk, pcols
-  use phys_grid,      only : scatter_field_to_chunk, get_ncols_p
-  use error_messages, only : alloc_err, handle_ncerr, handle_err
-  use cam_abortutils,     only : endrun
-  use netcdf
-  use error_messages, only : handle_ncerr  
-  use cam_logfile,    only : iulog
+  use shr_kind_mod, only : r8 => shr_kind_r8
   use tracer_data,  only : trfld, trfile, trcdata_init, advance_trcdata
-  
-#if ( defined SPMD )
-  use mpishorthand, only: mpicom, mpiint, mpir8
-#endif
 
   implicit none
 
-! public data
-
-! public type
-
-  public read_interp
-
-! public interface
-
+! public 
   public read_data_flux
   public interp_time_flux
 
-! private data
-
+! private
   private
-  type(trfld), pointer :: fields(:)
-  type(trfile)         :: file
-
-!  integer,  parameter :: totsz=2000           ! number greater than data time sample
-  real(r8), parameter :: daysperyear = 365.0_r8  ! Number of days in a year         
-  integer :: lonsiz  ! size of longitude dimension, dataset is 2d(lat,lon), in CAM grid
-  integer :: latsiz  ! size of latitude dimension
  
-!--------------------------------------------------------------------------------------------------
-TYPE :: read_interp          
-      
-  real(r8), pointer, dimension(:,:)   :: co2flx
-                       ! Interpolated output (pcols,begchunk:endchunk)
-  real(r8), pointer, dimension(:,:,:) :: co2bdy
-                       ! bracketing data     (pcols,begchunk:endchunk,2)
-  real(r8) :: cdayfm   ! Calendar day for prv. month read in
-  real(r8) :: cdayfp   ! Calendar day for nxt. month read in
-  integer :: nm_f      ! Array indices for prv. month data
-  integer :: np_f      ! Array indices for nxt. month data
-  integer :: np1_f     ! current forward time index of dataset
-  integer :: timesz    ! size of time dimension on dataset
-  integer, pointer :: date_f(:)      ! Date on dataset (YYYYMMDD)
-  integer, pointer :: sec_f(:)       ! seconds of date on dataset (0-86399) 
-  character(len=256) :: locfn   ! dataset name
-  integer :: ncid_f             ! netcdf id for dataset       
-  integer :: fluxid             ! netcdf id for dataset flux      
-  real(r8), pointer :: xvar(:,:,:) ! work space for dataset  
- 
-END TYPE read_interp
-!-------------------------------------------------------------------------------------------------
-                       
 contains
  
 !===============================================================================
 
-subroutine read_data_flux (input_file, xin, state, pbuf2d)
+subroutine read_data_flux (fields, file, input_file, state, pbuf2d)
  
 !-------------------------------------------------------------------------------              
-! Do initial read of time-varying 2d(lat,lon NetCDF dataset, 
-! reading two data bracketing current timestep
+! Do initial read of time-varying 2d(lat,lon NetCDF dataset)
 !-------------------------------------------------------------------------------
  
-  use time_manager, only : get_curr_date, get_curr_calday, &
-                           is_perpetual, get_perp_date, get_step_size, is_first_step
-  use ioFileMod,    only : getfil
   use physics_types,  only: physics_state
   use physics_buffer, only: physics_buffer_desc
 
@@ -88,103 +34,57 @@ subroutine read_data_flux (input_file, xin, state, pbuf2d)
  
 !---------------------------Common blocks-------------------------------
 ! Dummy arguments
-  character(len=*),   intent(in)    :: input_file
-  TYPE(read_interp),  intent(inout) :: xin   
-  type(physics_state), pointer       :: state(:)
+  type(trfld),               pointer :: fields(:)
+  type(trfile),    intent(out)       :: file
+  character(len=*),intent(in)        :: input_file
+  type(physics_state),       pointer :: state(:)
   type(physics_buffer_desc), pointer :: pbuf2d(:,:)
- 
-  integer lonid                 ! netcdf id for longitude variable
-  integer latid                 ! netcdf id for latitude variable
-  integer timeid                ! netcdf id for time variable
-  integer dateid                ! netcdf id for date variable
-  integer secid                 ! netcdf id for seconds variable
-  integer londimid              ! netcdf id for longitude variable
-  integer latdimid              ! netcdf id for latitude variable
- 
-  integer dtime                 ! timestep size [seconds]
-  integer cnt3(3)               ! array of counts for each dimension
-  integer strt3(3)              ! array of starting indices
-  integer n                     ! indices
-  integer j                     ! latitude index
-  integer istat                 ! error return
-  integer  :: yr, mon, day      ! components of a date
-  integer  :: ncdate            ! current date in integer format [yyyymmdd]
-  integer  :: ncsec             ! current time of day [seconds]
-  real(r8) calday               ! calendar day (includes yr if no cycling)
-  real(r8) caldayloc            ! calendar day (includes yr if no cycling)
  
   character(len=32)  :: specifier(1) = ''
 
-  xin%nm_f = 1
-  xin%np_f = 2
  
-! Allocate space for data.
- 
-  allocate( xin%co2flx(pcols,begchunk:endchunk), stat=istat )
-  call alloc_err( istat, 'CO2FLUX_READ', 'co2flx', &
-       pcols*(endchunk-begchunk+1) )
- 
-  allocate( xin%co2bdy(pcols,begchunk:endchunk,2), stat=istat )
-  call alloc_err( istat, 'CO2FLUX_READ', 'co2bdy', &
-       pcols*(endchunk-begchunk+1)*2 )
- 
-! SPMD: Master does all the work.
-
-
-  !call trcdata_init( specifier, filename, filelist, datapath, fields, file, &
-  !                     rmv_file, cycle_yr, fixed_ymd, fixed_tod, datatype)
+! Initialize variables needed for tracer_data routines
   allocate (file%in_pbuf(1))
   file%in_pbuf(1) = .false.
-  specifier(1) = 'CO2_flux:CO2_flux'
-  call trcdata_init( specifier ,input_file , '', '', fields, file, &
-       .false., 0, 0, 0, 'SERIAL' )
+  specifier(1)    = 'CO2_flux' !name of variable to read from file
+
+! Open file and initialize "fields" and "file" derived types
+! Some of the arguments passed here are hardwired which can be replaced with variables
+! if need be.
+  call trcdata_init(specifier, input_file , '', '', fields, file, .false., 0, 0, 0, 'SERIAL')
 
   return
 end subroutine read_data_flux
  
 !===============================================================================
 
-subroutine interp_time_flux (xin, prev_timestep)
+subroutine interp_time_flux (fields, file, data_flux)
  
 !-----------------------------------------------------------------------
 ! Time interpolate data to current time.
 ! Reading in new monthly data if necessary.
 !
 !-----------------------------------------------------------------------
- 
-  use time_manager, only : get_curr_date, get_curr_calday, &
-                          is_perpetual, get_perp_date, get_step_size, is_first_step
-  use interpolate_data,   only : get_timeinterp_factors
- 
-  logical, intent(in), optional     :: prev_timestep ! If using previous timestep, set to true
-  TYPE(read_interp),  intent(inout) :: xin
+  use phys_grid,      only : get_ncols_p
+  use ppgrid,         only : begchunk, endchunk
+
+  type(trfld),               pointer :: fields(:)
+  type(trfile), intent(inout)        :: file
+  real(r8),     intent(inout)        :: data_flux(:,:)
 
 !---------------------------Local variables-----------------------------
-  integer dtime          ! timestep size [seconds]
-  integer cnt3(3)        ! array of counts for each dimension
-  integer strt3(3)       ! array of starting indices
-  integer i,j,lchnk      ! indices
-  integer ncol           ! number of columns in current chunk
-  integer ntmp           ! temporary
-  real(r8) fact1, fact2  ! time interpolation factors
-  integer :: yr, mon, day! components of a date
-  integer :: ncdate      ! current date in integer format [yyyymmdd]
-  integer :: ncsec       ! current time of day [seconds]
-  real(r8) :: calday     ! current calendar day
-  real(r8) caldayloc     ! calendar day (includes yr if no cycling)
-  real(r8) deltat        ! time (days) between interpolating data
-  logical :: previous
-  logical :: co2cyc=.false.
- 
+  integer :: icol, lchnk      ! indices
+  integer :: ncol             ! number of columns in current chunk
 !-----------------------------------------------------------------------
 
-
+  !Read next data if needed and interpolate (space and time)
   call advance_trcdata( fields, file)
 
-  do lchnk=begchunk,endchunk
-     ncol = get_ncols_p(lchnk)
-     do i=1,ncol
-        xin%co2flx(i,lchnk) = fields(1)%data(i,1,lchnk)
+  !Assign 
+  do lchnk   = begchunk, endchunk
+     ncol    = get_ncols_p(lchnk)
+     do icol = 1, ncol
+        data_flux(icol, lchnk) = fields(1)%data(icol, 1, lchnk)
      end do
   end do
 
@@ -192,6 +92,4 @@ subroutine interp_time_flux (xin, prev_timestep)
 end subroutine interp_time_flux
 
 !============================================================================================================
-
 end module co2_data_flux
-

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -815,7 +815,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
 
     ! co2 cycle            
     if (co2_transport()) then
-       call co2_init()
+       call co2_init(phys_state, pbuf2d)
     end if
 
     ! CAM3 prescribed ozone


### PR DESCRIPTION
This PR adds code to read CO2 flux (fuel and ocean) for all grids and grid resolutions. To activate the new code,  append "-cppdefs -DCO2_BILIN_REGRID" string to the "CAM_CONFIG_OPTS" variable in env_build.xml (the original code is still the default). The original code was not able to interpolate read-in lat-lon grid data on to an SE grid. New code has been added so that lat-lon data can be interpolated (bilinear interpolation) on any kind of grid. The new codes use the existing tracer_data.F90 routines (where netcdf files are read and interpolated) to be consistent with rest of the code.

tracer_data.F90 is modified so that state and pbuf2d variables are now optional. The primary reason to make this change was to accommodate CO2 flux interpolation where interpolation routines (e.g. co2_time_interp_fuel) are called from a  point in the code (atm_import_export.F90) where state and pbuf2d are not readily accessible	

[BFB]