### PR TITLE
update to fates tag sci1.12.1 api3.1.0

### DIFF
--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -103,7 +103,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
-<fates_paramfile >lnd/clm2/paramdata/fates_params_2troppftclones.c171010.nc</fates_paramfile>
+<fates_paramfile >lnd/clm2/paramdata/fates_params_2trop.c180413.nc</fates_paramfile>
 
 
 <!-- soil order related parameters (relative to {csmdata}) -->


### PR DESCRIPTION
This updates the submodule pointer to a new fates tag:  sci1.12.1 api3.1.0. 
The minor API version number indicates an update in how fates interprets
the parameter file, and its format.  A new file has been loaded to blues and 
the default file has been updated.

[non-BFB]