### PR TITLE
Makes default the post deck bug fixes enabled via CPP for 1950 compsets

### DIFF
--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -60,7 +60,6 @@
       <value compset="_CAM5%CMIP6-HR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6-LR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6-LRtunedHR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
-      <value compset="1950_CAM5%CMIP6-[LH]R"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -cppdefs -DAPPLY_POST_DECK_BUGFIXES -nlev 72</value>
       <value compset="_CAM5%AV1F"     >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1F-00"  >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1F-01"  >-clubb_sgs -microphys mg2 -chem trop_mam4_resus_soag -rain_evap_to_coarse_aero -nlev 72</value>

--- a/components/cam/src/physics/cosp/MODIS_simulator/modis_simulator.F90
+++ b/components/cam/src/physics/cosp/MODIS_simulator/modis_simulator.F90
@@ -676,7 +676,6 @@ contains
     g(:) = 0; w0(:) = 0. 
     tau(:) = ice_tau(:) + water_tau(:) + snow_tau(:) !+JEK 
     where (tau(:) > 0) 
-#ifdef APPLY_POST_DECK_BUGFIXES
       w0(:) = (water_tau(:) * water_w0(:)  + &
                  ice_tau(:) * ice_w0(:)    + &
                 snow_tau(:) * snow_w0(:) ) / &
@@ -685,16 +684,6 @@ contains
                 ice_tau(:) * ice_g(:)   * ice_w0(:)    + &
                snow_tau(:) * snow_g(:)  * snow_w0(:) ) / &
                (w0(:) * tau(:))
-#else
-      g(:)  = (water_tau(:) * water_g(:) + &
-                 ice_tau(:) *   ice_g(:) + &
-                snow_tau(:) *  snow_g(:) ) / &
-              tau(:) !+JEK
-      w0(:) = (water_tau(:) * water_g(:) * water_w0(:) + &
-                 ice_tau(:) *   ice_g(:) *   ice_w0(:) + &
-                snow_tau(:) *  snow_g(:) *  snow_w0(:) ) / &
-              (g(:) * tau(:)) !+JEK
-#endif
     end where
     
     compute_nir_reflectance = compute_toa_reflectace(tau, g, w0)

--- a/components/cam/src/physics/rrtmg/ext/rrtmg_lw/rrtmg_lw_setcoef.f90
+++ b/components/cam/src/physics/rrtmg/ext/rrtmg_lw/rrtmg_lw_setcoef.f90
@@ -245,11 +245,7 @@
             jp(lay) = 58
          endif
          jp1 = jp(lay) + 1
-#ifdef APPLY_POST_DECK_BUGFIXES
          fp = min(3._r8, max(-2._r8, 5._r8 *(preflog(jp(lay)) - plog)))
-#else
-         fp = 5._r8 *(preflog(jp(lay)) - plog)
-#endif
 
 !  Determine, for each reference pressure (JP and JP1), which
 !  reference temperature (these are different for each  
@@ -264,22 +260,14 @@
          elseif (jt(lay) .gt. 4) then
             jt(lay) = 4
          endif
-#ifdef APPLY_POST_DECK_BUGFIXES
          ft = min(3._r8, max(-2._r8, ((tavel(lay)-tref(jp(lay)))/15._r8) - float(jt(lay)-3)))
-#else
-         ft = ((tavel(lay)-tref(jp(lay)))/15._r8) - float(jt(lay)-3)
-#endif
          jt1(lay) = int(3._r8 + (tavel(lay)-tref(jp1))/15._r8)
          if (jt1(lay) .lt. 1) then
             jt1(lay) = 1
          elseif (jt1(lay) .gt. 4) then
             jt1(lay) = 4
          endif
-#ifdef APPLY_POST_DECK_BUGFIXES
          ft1 = min(3._r8, max(-2._r8, ((tavel(lay)-tref(jp1))/15._r8) - float(jt1(lay)-3)))
-#else
-         ft1 = ((tavel(lay)-tref(jp1))/15._r8) - float(jt1(lay)-3)
-#endif
          water = wkl(1,lay)/coldry(lay)
          scalefac = pavel(lay) * stpfac / tavel(lay)
 
@@ -291,22 +279,14 @@
          forfac(lay) = scalefac / (1.+water)
          factor = (332.0_r8-tavel(lay))/36.0_r8
          indfor(lay) = min(2, max(1, int(factor)))
-#ifdef APPLY_POST_DECK_BUGFIXES
          forfrac(lay) = min(3._r8, max(-2._r8, factor - float(indfor(lay))))
-#else
-         forfrac(lay) = factor - float(indfor(lay))
-#endif
 
 !  Set up factors needed to separately include the water vapor
 !  self-continuum in the calculation of absorption coefficient.
          selffac(lay) = water * forfac(lay)
          factor = (tavel(lay)-188.0_r8)/7.2_r8
          indself(lay) = min(9, max(1, int(factor)-7))
-#ifdef APPLY_POST_DECK_BUGFIXES
          selffrac(lay) = min(3._r8, max(-2._r8, factor - float(indself(lay) + 7)))
-#else
-         selffrac(lay) = factor - float(indself(lay) + 7)
-#endif
 
 !  Set up factors needed to separately include the minor gases
 !  in the calculation of absorption coefficient
@@ -315,11 +295,7 @@
              *(wbroad(lay)/(coldry(lay)+wkl(1,lay)))
          factor = (tavel(lay)-180.8_r8)/7.2_r8
          indminor(lay) = min(18, max(1, int(factor)))
-#ifdef APPLY_POST_DECK_BUGFIXES
          minorfrac(lay) = min(3._r8, max(-2._r8, factor - float(indminor(lay))))
-#else
-         minorfrac(lay) = factor - float(indminor(lay))
-#endif
 
 !  Setup reference ratio to be used in calculation of binary
 !  species parameter in lower atmosphere.
@@ -360,11 +336,7 @@
          forfac(lay) = scalefac / (1.+water)
          factor = (tavel(lay)-188.0_r8)/36.0_r8
          indfor(lay) = 3
-#ifdef APPLY_POST_DECK_BUGFIXES
          forfrac(lay) = min(3._r8, max(-2._r8, factor - 1.0_r8))
-#else
-         forfrac(lay) = factor - 1.0_r8
-#endif
 
 !  Set up factors needed to separately include the water vapor
 !  self-continuum in the calculation of absorption coefficient.
@@ -377,11 +349,7 @@
              * (wbroad(lay)/(coldry(lay)+wkl(1,lay)))
          factor = (tavel(lay)-180.8_r8)/7.2_r8
          indminor(lay) = min(18, max(1, int(factor)))
-#ifdef APPLY_POST_DECK_BUGFIXES
          minorfrac(lay) = min(3._r8, max(-2._r8, factor - float(indminor(lay))))
-#else
-         minorfrac(lay) = factor - float(indminor(lay))
-#endif
 
 !  Setup reference ratio to be used in calculation of binary
 !  species parameter in upper atmosphere.

--- a/components/cam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
+++ b/components/cam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
@@ -417,9 +417,7 @@
 !               zomco(jk) = zomco(jk) / ztauo(jk)
 
 ! Clear-sky optical parameters including aerosols
-#ifdef APPLY_POST_DECK_BUGFIXES
                if (ztaug(ikl,iw) .lt. 0.0_r8) ztaug(ikl,iw) = 0.0_r8
-#endif
 
                ztauc(jk) = ztaur(ikl,iw) + ztaug(ikl,iw) + ptaua(ikl,ibm)
                zomcc(jk) = ztaur(ikl,iw) * 1.0_r8 + ptaua(ikl,ibm) * pomga(ikl,ibm)

--- a/components/cam/src/physics/rrtmg/ext/rrtmg_sw/rrtmg_sw_reftra.f90
+++ b/components/cam/src/physics/rrtmg/ext/rrtmg_sw/rrtmg_sw_reftra.f90
@@ -174,15 +174,10 @@
 ! collimated beam
 
                ze1 = min ( zto1 / prmuz , 500._r8)
-#ifdef APPLY_POST_DECK_BUGFIXES
                ze2 = exp( -ze1 )
-#else
-!              ze2 = exp( -ze1 )
-#endif
 
 ! Use exponential lookup table for transmittance, or expansion of 
 ! exponential for low tau
-#ifdef APPLY_POST_DECK_BUGFIXES
 !              if (ze1 .le. od_lo) then 
 !                 ze2 = 1._r8 - ze1 + 0.5_r8 * ze1 * ze1
 !              else
@@ -190,15 +185,6 @@
 !                 itind = tblint * tblind + 0.5_r8
 !                 ze2 = exp_tbl(itind)
 !              endif
-#else
-               if (ze1 .le. od_lo) then 
-                  ze2 = 1._r8 - ze1 + 0.5_r8 * ze1 * ze1
-               else
-                  tblind = ze1 / (bpade + ze1)
-                  itind = tblint * tblind + 0.5_r8
-                  ze2 = exp_tbl(itind)
-               endif
-#endif
 
                pref(jk) = (zgt - za1 * (1._r8 - ze2)) / (1._r8 + zgt)
                ptra(jk) = 1._r8 - pref(jk)
@@ -254,21 +240,13 @@
 !              zem2 = exp(-ze2 )
 !
 ! Revised original, to reduce exponentials
-#ifdef APPLY_POST_DECK_BUGFIXES
                zep1 = exp( ze1 )
                zem1 = 1._r8 / zep1
                zep2 = exp( ze2 )
                zem2 = 1._r8 / zep2
-#else
-!              zep1 = exp( ze1 )
-!              zem1 = 1._r8 / zep1
-!              zep2 = exp( ze2 )
-!              zem2 = 1._r8 / zep2
-#endif
 !
 ! Use exponential lookup table for transmittance, or expansion of 
 ! exponential for low tau
-#ifdef APPLY_POST_DECK_BUGFIXES
 !              if (ze1 .le. od_lo) then 
 !                 zem1 = 1._r8 - ze1 + 0.5_r8 * ze1 * ze1
 !                 zep1 = 1._r8 / zem1
@@ -288,27 +266,6 @@
 !                 zem2 = exp_tbl(itind)
 !                 zep2 = 1._r8 / zem2
 !              endif
-#else
-               if (ze1 .le. od_lo) then 
-                  zem1 = 1._r8 - ze1 + 0.5_r8 * ze1 * ze1
-                  zep1 = 1._r8 / zem1
-               else
-                  tblind = ze1 / (bpade + ze1)
-                  itind = tblint * tblind + 0.5_r8
-                  zem1 = exp_tbl(itind)
-                  zep1 = 1._r8 / zem1
-               endif
-
-               if (ze2 .le. od_lo) then 
-                  zem2 = 1._r8 - ze2 + 0.5_r8 * ze2 * ze2
-                  zep2 = 1._r8 / zem2
-               else
-                  tblind = ze2 / (bpade + ze2)
-                  itind = tblint * tblind + 0.5_r8
-                  zem2 = exp_tbl(itind)
-                  zep2 = 1._r8 / zem2
-               endif
-#endif
 
 ! collimated beam
 

--- a/components/cam/src/physics/rrtmg/ext/rrtmg_sw/rrtmg_sw_setcoef.f90
+++ b/components/cam/src/physics/rrtmg/ext/rrtmg_sw/rrtmg_sw_setcoef.f90
@@ -157,11 +157,7 @@
             jp(lay) = 58
          endif
          jp1 = jp(lay) + 1
-#ifdef APPLY_POST_DECK_BUGFIXES
          fp = min(3._r8, max(-2._r8, 5._r8 * (preflog(jp(lay)) - plog)))
-#else
-         fp = 5._r8 * (preflog(jp(lay)) - plog)
-#endif
 
 ! Determine, for each reference pressure (JP and JP1), which
 ! reference temperature (these are different for each  
@@ -177,22 +173,14 @@
          elseif (jt(lay) .gt. 4) then
             jt(lay) = 4
          endif
-#ifdef APPLY_POST_DECK_BUGFIXES
          ft = min(3._r8, max(-2._r8, ((tavel(lay)-tref(jp(lay)))/15._r8) - float(jt(lay)-3)))
-#else
-         ft = ((tavel(lay)-tref(jp(lay)))/15._r8) - float(jt(lay)-3)
-#endif
          jt1(lay) = int(3._r8 + (tavel(lay)-tref(jp1))/15._r8)
          if (jt1(lay) .lt. 1) then
             jt1(lay) = 1
          elseif (jt1(lay) .gt. 4) then
             jt1(lay) = 4
          endif
-#ifdef APPLY_POST_DECK_BUGFIXES
          ft1 = min(3._r8, max(-2._r8, ((tavel(lay)-tref(jp1))/15._r8) - float(jt1(lay)-3)))
-#else
-         ft1 = ((tavel(lay)-tref(jp1))/15._r8) - float(jt1(lay)-3)
-#endif
 
          water = wkl(1,lay)/coldry(lay)
          scalefac = pavel(lay) * stpfac / tavel(lay)
@@ -210,11 +198,7 @@
          forfac(lay) = scalefac / (1.+water)
          factor = (332.0_r8-tavel(lay))/36.0_r8
          indfor(lay) = min(2, max(1, int(factor)))
-#ifdef APPLY_POST_DECK_BUGFIXES
          forfrac(lay) = min(3._r8, max(-2._r8, factor - float(indfor(lay))))
-#else
-         forfrac(lay) = factor - float(indfor(lay))
-#endif
 
 ! Set up factors needed to separately include the water vapor
 ! self-continuum in the calculation of absorption coefficient.
@@ -222,11 +206,7 @@
          selffac(lay) = water * forfac(lay)
          factor = (tavel(lay)-188.0_r8)/7.2_r8
          indself(lay) = min(9, max(1, int(factor)-7))
-#ifdef APPLY_POST_DECK_BUGFIXES
          selffrac(lay) = min(3._r8, max(-2._r8, factor - float(indself(lay) + 7)))
-#else
-         selffrac(lay) = factor - float(indself(lay) + 7)
-#endif
 
 ! Calculate needed column amounts.
 
@@ -264,11 +244,7 @@
          forfac(lay) = scalefac / (1.+water)
          factor = (tavel(lay)-188.0_r8)/36.0_r8
          indfor(lay) = 3
-#ifdef APPLY_POST_DECK_BUGFIXES
          forfrac(lay) = min(3._r8, max(-2._r8, factor - 1.0_r8))
-#else
-         forfrac(lay) = factor - 1.0_r8
-#endif
 
 ! Calculate needed column amounts.
 

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -24,7 +24,6 @@
       <value compset="_CLM45"                >-phys clm4_5</value>
       <value compset="_CLM50"                >-phys clm5_0</value>
       <value compset="_CLM45%[^_]*BC" >-phys clm4_5 -cppdefs -DMODAL_AER</value>
-      <value compset="1950_CAM5%CMIP6-[LH]R[^_]*_CLM45%[^_]*BC"                >-phys clm4_5 -cppdefs '-DMODAL_AER -DAPPLY_POST_DECK_BUGFIXES'</value>
     </values>
     <group>build_component_clm</group>
     <file>env_build.xml</file>

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -580,11 +580,7 @@ contains
        found = .false.
        do p = bounds%begp, bounds%endp
           if (veg_pp%active(p)) then
-#ifdef APPLY_POST_DECK_BUGFIXES
              if ( (errsol(p) /= spval) .and. (abs(errsol(p)) > 1.e-7_r8) ) then
-#else
-             if ( (errsol(p) /= spval) .and. (abs(errsol(p)) > 1.e-3_r8) ) then
-#endif
                 found = .true.
                 indexp = p
                 indexg = veg_pp%gridcell(indexp)
@@ -595,7 +591,6 @@ contains
           write(iulog,*)'WARNING:: BalanceCheck, solar radiation balance error (W/m2)'
           write(iulog,*)'nstep         = ',nstep
           write(iulog,*)'errsol        = ',errsol(indexp)
-#ifdef APPLY_POST_DECK_BUGFIXES
           if (abs(errsol(indexp)) > 1.e-5_r8 ) then
              write(iulog,*)'clm model is stopping - error is greater than 1e-5 (W/m2)'
              write(iulog,*)'fsa           = ',fsa(indexp)
@@ -609,18 +604,6 @@ contains
              write(iulog,*)'clm model is stopping'
              call endrun(decomp_index=indexp, clmlevel=namep, msg=errmsg(__FILE__, __LINE__))
           end if
-#else
-          write(iulog,*)'fsa           = ',fsa(indexp)
-          write(iulog,*)'fsr           = ',fsr(indexp)
-          write(iulog,*)'forc_solad(1) = ',forc_solad(indexg,1)
-          write(iulog,*)'forc_solad(2) = ',forc_solad(indexg,2)
-          write(iulog,*)'forc_solai(1) = ',forc_solai(indexg,1)
-          write(iulog,*)'forc_solai(2) = ',forc_solai(indexg,2)
-          write(iulog,*)'forc_tot      = ',forc_solad(indexg,1)+forc_solad(indexg,2) &
-            +forc_solai(indexg,1)+forc_solai(indexg,2)
-          write(iulog,*)'clm model is stopping'
-          call endrun(decomp_index=indexp, clmlevel=namep, msg=errmsg(__FILE__, __LINE__))
-#endif
        end if
 
        ! Longwave radiation energy balance check
@@ -628,11 +611,7 @@ contains
        found = .false.
        do p = bounds%begp, bounds%endp
           if (veg_pp%active(p)) then
-#ifdef APPLY_POST_DECK_BUGFIXES
              if ( (errlon(p) /= spval) .and. (abs(errlon(p)) > 1.e-7_r8) ) then
-#else
-             if ( (errlon(p) /= spval) .and. (abs(errlon(p)) > 1.e-3_r8) ) then
-#endif
                 found = .true.
                 indexp = p
              end if
@@ -642,14 +621,10 @@ contains
           write(iulog,*)'WARNING: BalanceCheck: longwave energy balance error (W/m2)' 
           write(iulog,*)'nstep        = ',nstep 
           write(iulog,*)'errlon       = ',errlon(indexp)
-#ifdef APPLY_POST_DECK_BUGFIXES
           if (abs(errlon(indexp)) > 1.e-5_r8 ) then
              write(iulog,*)'clm model is stopping - error is greater than 1e-5 (W/m2)'
              call endrun(decomp_index=indexp, clmlevel=namep, msg=errmsg(__FILE__, __LINE__))
           end if
-#else
-          call endrun(decomp_index=indexp, clmlevel=namep, msg=errmsg(__FILE__, __LINE__))
-#endif
        end if
 
        ! Surface energy balance check
@@ -657,11 +632,7 @@ contains
        found = .false.
        do p = bounds%begp, bounds%endp
           if (veg_pp%active(p)) then
-#ifdef APPLY_POST_DECK_BUGFIXES
              if (abs(errseb(p)) > 1.e-7_r8 ) then
-#else
-             if (abs(errseb(p)) > 1.e-3_r8 ) then
-#endif
                 found = .true.
                 indexp = p
                 indexc = veg_pp%column(indexp)
@@ -672,7 +643,6 @@ contains
           write(iulog,*)'WARNING: BalanceCheck: surface flux energy balance error (W/m2)'
           write(iulog,*)'nstep          = ' ,nstep
           write(iulog,*)'errseb         = ' ,errseb(indexp)
-#ifdef APPLY_POST_DECK_BUGFIXES
           if (abs(errseb(indexp)) > 1.e-5_r8 ) then
              write(iulog,*)'clm model is stopping - error is greater than 1e-5 (W/m2)'
              write(iulog,*)'sabv           = ' ,sabv(indexp)
@@ -695,27 +665,6 @@ contains
              write(iulog,*)'clm model is stopping'
              call endrun(decomp_index=indexp, clmlevel=namep, msg=errmsg(__FILE__, __LINE__))
           end if
-#else
-          write(iulog,*)'sabv           = ' ,sabv(indexp)
-
-          write(iulog,*)'sabg           = ' ,sabg(indexp), ((1._r8- frac_sno(indexc))*sabg_soil(indexp) + &
-               frac_sno(indexc)*sabg_snow(indexp)),sabg_chk(indexp)
-
-          write(iulog,*)'forc_tot      = '  ,forc_solad(indexg,1) + forc_solad(indexg,2) + &
-               forc_solai(indexg,1) + forc_solai(indexg,2)
-
-          write(iulog,*)'eflx_lwrad_net = ' ,eflx_lwrad_net(indexp)
-          write(iulog,*)'eflx_sh_tot    = ' ,eflx_sh_tot(indexp)
-          write(iulog,*)'eflx_lh_tot    = ' ,eflx_lh_tot(indexp)
-          write(iulog,*)'eflx_soil_grnd = ' ,eflx_soil_grnd(indexp)
-          write(iulog,*)'fsa fsr = '        ,fsa(indexp),    fsr(indexp)
-          write(iulog,*)'fabd fabi = '      ,fabd(indexp,:), fabi(indexp,:)
-          write(iulog,*)'albd albi = '      ,albd(indexp,:), albi(indexp,:)
-          write(iulog,*)'ftii ftdd ftid = ' ,ftii(indexp,:), ftdd(indexp,:),ftid(indexp,:)
-          write(iulog,*)'elai esai = '      ,elai(indexp),   esai(indexp)      
-          write(iulog,*)'clm model is stopping'
-          call endrun(decomp_index=indexp, clmlevel=namep, msg=errmsg(__FILE__, __LINE__))
-#endif
        end if
 
        ! Soil energy balance check
@@ -723,11 +672,7 @@ contains
        found = .false.
        do c = bounds%begc,bounds%endc
           if (col_pp%active(c)) then
-#ifdef APPLY_POST_DECK_BUGFIXES
              if (abs(errsoi_col(c)) > 1.0e-6_r8 ) then
-#else
-             if (abs(errsoi_col(c)) > 1.0e-7_r8 ) then
-#endif
                 found = .true.
                 indexc = c
              end if
@@ -737,18 +682,10 @@ contains
           write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
           write(iulog,*)'nstep         = ',nstep
           write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)
-#ifdef APPLY_POST_DECK_BUGFIXES
           if (abs(errsoi_col(indexc)) > 1.e-4_r8 .and. (nstep > 2) ) then
              write(iulog,*)'clm model is stopping'
              call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(__FILE__, __LINE__))
           end if
-#else
-          if (abs(errsoi_col(indexc)) > 1.e-3_r8 .and. (nstep > 2) ) then
-             write(iulog,*)'clm model is stopping'
-          !  endrun commented out  though printing "clm model is stopping"
-          !  call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(__FILE__, __LINE__))
-          end if
-#endif
        end if
 
      end associate

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -399,11 +399,7 @@ contains
 
           if (do_capsnow(c)) then
              dz_snowf = 0._r8
-#ifdef APPLY_POST_DECK_BUGFIXES
              newsnow(c) = qflx_snow_grnd_col(c) * dtime
-#else
-             newsnow(c) = (1._r8 - frac_h2osfc(c)) * qflx_snow_grnd_col(c) * dtime
-#endif
              frac_sno(c)=1._r8
              int_snow(c) = 5.e2_r8
           else
@@ -415,13 +411,8 @@ contains
                 bifall=50._r8
              end if
 
-#ifdef APPLY_POST_DECK_BUGFIXES
              ! all snow falls on ground, no snow on h2osfc
              newsnow(c) = qflx_snow_grnd_col(c) * dtime
-#else
-             ! newsnow is all snow that doesn't fall on h2osfc
-             newsnow(c) = (1._r8 - frac_h2osfc(c)) * qflx_snow_grnd_col(c) * dtime
-#endif
 
              ! update int_snow
              int_snow(c) = max(int_snow(c),h2osno(c)) !h2osno could be larger due to frost
@@ -516,13 +507,8 @@ contains
                 endif
              endif ! end of h2osno > 0
 
-#ifdef APPLY_POST_DECK_BUGFIXES
              ! no snow on surface water
              qflx_snow_h2osfc(c) = 0._r8
-#else
-             ! snow directly falling on surface water melts, increases h2osfc
-             qflx_snow_h2osfc(c) = frac_h2osfc(c)*qflx_snow_grnd_col(c)
-#endif
 
              ! update h2osno for new snow
              h2osno(c) = h2osno(c) + newsnow(c) 

--- a/components/clm/src/biogeophys/EnergyFluxType.F90
+++ b/components/clm/src/biogeophys/EnergyFluxType.F90
@@ -19,9 +19,7 @@ module EnergyFluxType
   type, public :: energyflux_type
 
      ! Fluxes
-#ifdef APPLY_POST_DECK_BUGFIXES
      real(r8), pointer :: eflx_h2osfc_to_snow_col (:)   ! col snow melt to h2osfc heat flux (W/m**2)
-#endif
      real(r8), pointer :: eflx_sh_grnd_patch      (:)   ! patch sensible heat flux from ground (W/m**2) [+ to atm]
      real(r8), pointer :: eflx_sh_veg_patch       (:)   ! patch sensible heat flux from leaves (W/m**2) [+ to atm]
      real(r8), pointer :: eflx_sh_snow_patch      (:)   ! patch sensible heat flux from snow (W/m**2) [+ to atm]
@@ -173,9 +171,7 @@ contains
     begl = bounds%begl; endl= bounds%endl
     begg = bounds%begg; endg= bounds%endg
 
-#ifdef APPLY_POST_DECK_BUGFIXES
     allocate( this%eflx_h2osfc_to_snow_col (begc:endc))             ; this%eflx_h2osfc_to_snow_col (:)   = nan
-#endif
     allocate( this%eflx_sh_snow_patch      (begp:endp))             ; this%eflx_sh_snow_patch      (:)   = nan
     allocate( this%eflx_sh_soil_patch      (begp:endp))             ; this%eflx_sh_soil_patch      (:)   = nan
     allocate( this%eflx_sh_h2osfc_patch    (begp:endp))             ; this%eflx_sh_h2osfc_patch    (:)   = nan

--- a/components/clm/src/biogeophys/SnowHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SnowHydrologyMod.F90
@@ -430,13 +430,8 @@ contains
 
          qflx_top_soil(c) = (qout(c) / dtime) &
               + (1.0_r8 - frac_sno_eff(c)) * qflx_rain_grnd(c)
-#ifdef APPLY_POST_DECK_BUGFIXES
          int_snow(c) = int_snow(c) + frac_sno_eff(c) &
                        * (qflx_dew_snow(c) + qflx_dew_grnd(c) + qflx_rain_grnd(c)) * dtime
-#else
-         int_snow(c) = int_snow(c) + frac_sno_eff(c) * qflx_dew_snow(c)  * dtime &
-                                   + frac_sno_eff(c) * qflx_rain_grnd(c) * dtime
-#endif
       end do
 
       do fc = 1, num_nosnowc

--- a/components/clm/src/biogeophys/SoilFluxesMod.F90
+++ b/components/clm/src/biogeophys/SoilFluxesMod.F90
@@ -83,9 +83,7 @@ contains
     !-----------------------------------------------------------------------
 
     associate(                                                                &
-#ifdef APPLY_POST_DECK_BUGFIXES
          eflx_h2osfc_to_snow_col => energyflux_vars%eflx_h2osfc_to_snow_col , & ! Input:  [real(r8) (:)   ]  col snow melt to h2osfc heat flux (W/m**2)
-#endif
          forc_lwrad              => atm2lnd_vars%forc_lwrad_downscaled_col  , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)
 
          frac_veg_nosno          => canopystate_vars%frac_veg_nosno_patch   , & ! Input:  [integer (:)    ]  fraction of veg not covered by snow (0/1 now) [-]
@@ -373,9 +371,7 @@ contains
               - frac_h2osfc(c)*(t_h2osfc(c)-t_h2osfc_bef(c)) &
               *(c_h2osfc(c)/dtime)
 
-#ifdef APPLY_POST_DECK_BUGFIXES
          errsoi_patch(p) =  errsoi_patch(p)+eflx_h2osfc_to_snow_col(c)
-#endif
 
          ! For urban sunwall, shadewall, and roof columns, the "soil" energy balance check
          ! must include the heat flux from the interior of the building.

--- a/components/clm/src/biogeophys/SurfaceAlbedoMod.F90
+++ b/components/clm/src/biogeophys/SurfaceAlbedoMod.F90
@@ -11,11 +11,7 @@ module SurfaceAlbedoMod
   use shr_log_mod       , only : errMsg => shr_log_errMsg
   use abortutils        , only : endrun
   use decompMod         , only : bounds_type
-#ifdef APPLY_POST_DECK_BUGFIXES
   use landunit_varcon   , only : istsoil, istcrop, istdlak
-#else
-  use landunit_varcon   , only : istsoil, istcrop
-#endif
   use clm_varcon        , only : grlnd, namep
   use clm_varpar        , only : numrad, nlevcan, nlevsno, nlevcan
   use clm_varctl        , only : fsurdat, iulog, subgridflag, use_snicar_frc, use_ed  
@@ -674,11 +670,7 @@ contains
              !  weight snow layer radiative absorption factors based on snow fraction and soil albedo
              !  (NEEDED FOR ENERGY CONSERVATION)
              do i = -nlevsno+1,1,1
-#ifdef APPLY_POST_DECK_BUGFIXES
               if (subgridflag == 0 .or. lun_pp%itype(col_pp%landunit(c)) == istdlak) then
-#else
-              if (subgridflag == 0) then
-#endif
                 if (ib == 1) then
                    flx_absdv(c,i) = flx_absd_snw(c,i,ib)*frac_sno(c) + &
                         ((1.-frac_sno(c))*(1-albsod(c,ib))*(flx_absd_snw(c,i,ib)/(1.-albsnd(c,ib))))

--- a/components/clm/src/biogeophys/SurfaceRadiationMod.F90
+++ b/components/clm/src/biogeophys/SurfaceRadiationMod.F90
@@ -19,12 +19,8 @@ module SurfaceRadiationMod
   use GridcellType      , only : grc_pp                
   use LandunitType      , only : lun_pp                
   use ColumnType        , only : col_pp                
-#ifdef APPLY_POST_DECK_BUGFIXES
   use VegetationType    , only : veg_pp
   use landunit_varcon   , only : istdlak
-#else
-  use VegetationType    , only : veg_pp
-#endif
 
   !
   ! !PRIVATE TYPES:
@@ -552,11 +548,7 @@ contains
                 sabg_soil(p) = sabg(p)
              endif
              ! if no subgrid fluxes, make sure to set both components equal to weighted average
-#ifdef APPLY_POST_DECK_BUGFIXES
              if (subgridflag == 0 .or. lun_pp%itype(l) == istdlak) then 
-#else
-             if (subgridflag == 0) then
-#endif
                 sabg_snow(p) = sabg(p)
                 sabg_soil(p) = sabg(p)
              endif
@@ -648,11 +640,7 @@ contains
 
              ! If shallow snow depth, all solar radiation absorbed in top or top two snow layers
              ! to prevent unrealistic timestep soil warming 
-#ifdef APPLY_POST_DECK_BUGFIXES
              if (subgridflag == 0 .or. lun_pp%itype(l) == istdlak) then 
-#else
-             if (subgridflag == 0) then
-#endif
                 if (snow_depth(c) < 0.10_r8) then
                    if (snl(c) == 0) then
                       sabg_lyr(p,-4:0) = 0._r8


### PR DESCRIPTION
Bug fixes for COSP MODIS, for RRTMG limiters and  for clm radiation were made effective for 1950 compsets before the v1 release using CPP directive -DAPPLY_POST_DECK_BUGFIXES.  Make those bug fixes default for all configurations. 

The CPP directive and the companion switching blocks are removed. The specifications of CPP directive for 1950 compsets through CAM or CLM CONFIG_OPTS (PR #2222) are also removed. 

The RRTMG files involved that were previously renamed from .f90 to .F90, in order to let Fortran compilers (such as Intel on cori) invoke preprocessor, are renamed back to .f90.

[non-BFB] except for 1950 compsets