### PR TITLE
Summit updates to fix runtime errors and env changes.

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -491,8 +491,8 @@
    <batch_system MACH="summit" type="lsf" >
      <directives>
        <directive>-P {{ project }}</directive>
-       <directive>-alloc_flags gpumps</directive>
-       <directive>-alloc_flags smt2</directive>
+       <directive compiler="!pgiacc">-alloc_flags smt2</directive>
+       <directive compiler="pgiacc">-alloc_flags "gpumps smt2"</directive>
      </directives>
      <queues>
        <queue walltimemax="02:00" default="true">batch</queue>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2916,15 +2916,15 @@
 		<command name="load">subversion/1.9.3</command>
 		<command name="load">git/2.13.0</command>
 		<command name="load">cmake/3.9.2</command>
-		<command name="load">essl/6.1.0-prpq</command>
+		<command name="load">essl/6.1.0-20180406</command>
 		<command name="load">netlib-lapack/3.6.1</command>
       </modules>
       <!-- List of modules elements, executing commands if compiler and mpilib condition applies -->
       <modules compiler="pgi">
-        <command name="load">pgi/18.1</command>
+        <command name="load">pgi/18.3</command>
       </modules>
       <modules compiler="ibm">
-        <command name="load">xl/20180223-beta</command>
+        <command name="load">xl/20180406-beta</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">gcc/6.4.0</command>
@@ -2937,17 +2937,17 @@
       <!-- mpi lib settings -->
 	  <!-- Sometimes,same versions of libraries are not available for different compilers, hence the split below -->
       <modules compiler="ibm" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.2.0.0-20180110</command>
+        <command name="load">spectrum-mpi/10.2.0.0-20180406</command>
         <command name="load">parallel-netcdf/1.8.0</command>
         <command name="load">hdf5/1.10.0-patch1</command>
       </modules>
       <modules compiler="pgi*" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.2.0.0-20180110</command>
+        <command name="load">spectrum-mpi/10.2.0.0-20180406</command>
         <command name="load">parallel-netcdf/1.8.0</command>
         <command name="load">hdf5/1.10.0-patch1</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.2.0.0-20180110</command>
+        <command name="load">spectrum-mpi/10.2.0.0-20180406</command>
         <command name="load">parallel-netcdf/1.8.0</command>
         <command name="load">hdf5/1.10.0-patch1</command>
       </modules>


### PR DESCRIPTION
Various software modules have been removed/updated as part of a major
update.

This addresses runtime issues with JSM identified by @worleyph.
spectrum-mpi/10.2.0.0-20180406 is the only supported version.
  * PGI compilers updated to 18.3
  * XL updated to xl/20180406-beta.
  * Conditional batch directives used for gmumps, smt2 options. Refer #1906 
  * Discussion about Summit task placement at
  https://acme-climate.atlassian.net/wiki/spaces/PERF/pages/645234702/Summit+Task+Placement

Limited testing with FC5AV1C-ne4 and PGI.

Note: XL compilers still have a build issue with mct but this is the
only XL version with compatible MPI module. Ongoing work to identify root
cause.

[BFB]