### PR TITLE
Don't load zlib module on Cori 

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -267,6 +267,7 @@
       <command name="rm">cmake</command>
       <command name="rm">cray-petsc</command>
       <command name="rm">esmf</command>
+      <command name="rm">zlib</command>
     </modules>
 
     <modules>
@@ -316,8 +317,6 @@
       <command name="load">git</command>
       <command name="rm">cmake</command>
       <command name="load">cmake/3.3.2</command>
-      <command name="rm">zlib</command>
-      <command name="load">zlib/1.2.8</command>
     </modules>
   </module_system>
 
@@ -405,6 +404,7 @@
       <command name="rm">cmake</command>
       <command name="rm">cray-petsc</command>
       <command name="rm">esmf</command>
+      <command name="rm">zlib</command>
 
       <!-- first load basic defaults, then remove/swap/load as necessary -->
       <command name="load">craype</command>
@@ -471,8 +471,6 @@
       <command name="load">git</command>
       <command name="rm">cmake</command>
       <command name="load">cmake/3.3.2</command>
-      <command name="rm">zlib</command>
-      <command name="load">zlib/1.2.8</command>
     </modules>
 
     <!--command name="list">&gt;&amp; ml.txt</command-->


### PR DESCRIPTION
Don't load zlib module on Cori (was causing module errors and may no longer be needed)

Fixes #2328
[BFB]