### PR TITLE
Update CNP parameter file for RD compsets

### DIFF
--- a/components/clm/bld/CLMBuildNamelist.pm
+++ b/components/clm/bld/CLMBuildNamelist.pm
@@ -2335,7 +2335,7 @@ sub setup_logic_params_file {
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'paramfile', 
                 'use_fates'=>$nl_flags->{'use_fates'}, 'use_crop'=>$nl_flags->{'use_crop'},'nu_com'=>$nl_flags->{'nu_com'} );
    add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fsoilordercon',
-                );   
+                'use_fates'=>$nl_flags->{'use_fates'}, 'use_crop'=>$nl_flags->{'use_crop'},'nu_com'=>$nl_flags->{'nu_com'} );   
   } else {
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fpftcon');
   }

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -97,7 +97,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <paramfile                 >lnd/clm2/paramdata/clm_params_c180301.nc</paramfile>
 <paramfile use_crop=".true." >lnd/clm2/paramdata/clm_params_c180301.nc</paramfile>
 <paramfile nu_com="ECA"    >lnd/clm2/paramdata/clm_params.c180403.nc</paramfile>
-<paramfile nu_com="RD" use_crop=".false." >lnd/clm2/paramdata/clm_params_c180312.nc</paramfile>
+<paramfile nu_com="RD" use_crop=".false." >lnd/clm2/paramdata/clm_params_c180524.nc</paramfile>
 
 
 <!-- ================================================================== -->
@@ -108,7 +108,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <!-- soil order related parameters (relative to {csmdata}) -->
 <fsoilordercon             >lnd/clm2/paramdata/CNP_parameters_c131108.nc</fsoilordercon> 
-<fsoilordercon nu_com="RD" >lnd/clm2/paramdata/CNP_parameters_c180312.nc</fsoilordercon> 
+<fsoilordercon nu_com="RD" >lnd/clm2/paramdata/CNP_parameters_c180529.nc</fsoilordercon> 
 
 <!-- HOMME grid ne4 resolution -->
 


### PR DESCRIPTION
The default CNP parameter file had been changed for RD compsets, 
but the logic for applying this change to only RD compsets in the 
buildnamelist perl script was not updated.  This resulted in the old 
v0 CNP parameter file being used erroneously.  

Fixes #2338 #2370 
[NML] 
[non-BFB] for RD compsets only