### PR TITLE
Add more timestamps to cime events before and after model execution

### DIFF
--- a/cime/scripts/lib/CIME/case/case_run.py
+++ b/cime/scripts/lib/CIME/case/case_run.py
@@ -62,14 +62,14 @@ def _pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
     # This needs to be done everytime the LID changes in order for log files to be set up correctly
     # The following also needs to be called in case a user changes a user_nl_xxx file OR an env_run.xml
     # variable while the job is in the queue
-    logger.info("{} NAME CREATION BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
+    logger.info("{} NAMELIST CREATION BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
     if skip_pnl:
         case.create_namelists(component='cpl')
     else:
         logger.info("Generating namelists for {}".format(caseroot))
         case.create_namelists()
 
-    logger.info("{} NAME CREATION HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
+    logger.info("{} NAMELIST CREATION HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
 
     logger.info("-------------------------------------------------------------------------")
     logger.info(" - Prestage required restarts into {}".format(rundir))

--- a/cime/scripts/lib/CIME/case/case_run.py
+++ b/cime/scripts/lib/CIME/case/case_run.py
@@ -62,11 +62,14 @@ def _pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
     # This needs to be done everytime the LID changes in order for log files to be set up correctly
     # The following also needs to be called in case a user changes a user_nl_xxx file OR an env_run.xml
     # variable while the job is in the queue
+    logger.info("{} NAME CREATION BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
     if skip_pnl:
         case.create_namelists(component='cpl')
     else:
         logger.info("Generating namelists for {}".format(caseroot))
         case.create_namelists()
+
+    logger.info("{} NAME CREATION HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
 
     logger.info("-------------------------------------------------------------------------")
     logger.info(" - Prestage required restarts into {}".format(rundir))

--- a/cime/scripts/lib/CIME/case/case_run.py
+++ b/cime/scripts/lib/CIME/case/case_run.py
@@ -298,9 +298,9 @@ def case_run(self, skip_pnl=False, set_continue_run=False, submit_resubmits=Fals
         logger.info("{} RUN_MODEL HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
 
         if self.get_value("CHECK_TIMING") or self.get_value("SAVE_TIMING"):
-            logger.info("{} GET TIMING BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
+            logger.info("{} GET_TIMING BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
             get_timing(self, lid)     # Run the getTiming script
-            logger.info("{} GET TIMING HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
+            logger.info("{} GET_TIMING HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
 
         if data_assimilation:
             logger.info("{} DO_DATA_ASSIMILATION BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))

--- a/cime/scripts/lib/CIME/case/preview_namelists.py
+++ b/cime/scripts/lib/CIME/case/preview_namelists.py
@@ -5,7 +5,7 @@ create_dirs and create_namelists are members of Class case from file case.py
 
 from CIME.XML.standard_module_setup import *
 from CIME.utils import run_sub_or_cmd, safe_copy
-import glob
+import time, glob
 logger = logging.getLogger(__name__)
 
 def create_dirs(self):
@@ -70,6 +70,7 @@ def create_namelists(self, component=None):
     models += [models.pop(0)]
     for model in models:
         model_str = model.lower()
+        logger.info("  {} {}".format(time.strftime("%Y-%m-%d %H:%M:%S"),model_str))
         config_file = self.get_value("CONFIG_{}_FILE".format(model_str.upper()))
         config_dir = os.path.dirname(config_file)
         if model_str == "cpl":


### PR DESCRIPTION
Single process operations within CIME before and after model execution
can take significant time on some systems, for example, on Cori-KNL.
logger.info calls with timestamps are added to improve the ability to
diagnose where these costs are occurring.

[BFB]