### PR TITLE
Fix phosphatase profile calculation

### DIFF
--- a/components/clm/src/biogeochem/PDynamicsMod.F90
+++ b/components/clm/src/biogeochem/PDynamicsMod.F90
@@ -662,14 +662,18 @@ contains
             c = filter_soilc(fc)
             sop_tot = 0._r8
             do l = 1,ndecomp_pools
+              if (is_soil(l)) then
                 sop_tot = sop_tot + decomp_ppools_vr_col(c,j,l)
+              end if
             end do
             do l = 1,ndecomp_pools
+              if (is_soil(l)) then
                 if (sop_tot > 1e-12) then 
                     sop_profile(l) = decomp_ppools_vr_col(c,j,l)/sop_tot
                 else
                     sop_profile(l) = 0._r8
                 end if
+              end if
             end do
             do l = 1,ndecomp_pools
                 if (is_soil(l)) then


### PR DESCRIPTION
Limit the profile calculation to soil phosphorus only, exclude litter and coarse woody debris

Fixes #2362
[BFB]