### PR TITLE
Summit: IBM and PGI compiler fixes

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1072,7 +1072,7 @@ for mct, etc.
   <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
   <ADD_FFLAGS> -qzerosize -qfree=f90 -qxlf2003=polymorphic</ADD_FFLAGS>
   <ADD_FFLAGS_NOOPT> -O0 -g -qfree=f90  </ADD_FFLAGS_NOOPT>
-  <ADD_LDFLAGS>-lxlfmath -lxlf90_r -lxlopt -lxl -lxlsmp -L$(NETCDF_C_PATH)/lib -lnetcdf -L$(NETCDF_FORTRAN_PATH)/lib -lnetcdff -L$(ESSL_PATH)/lib64 -lessl -L$(NETLIB_LAPACK_PATH)/lib -llapack</ADD_LDFLAGS>
+  <ADD_LDFLAGS>-lxlopt -lxl -lxlsmp -L$(NETCDF_C_PATH)/lib -lnetcdf -L$(NETCDF_FORTRAN_PATH)/lib -lnetcdff -L$(ESSL_PATH)/lib64 -lessl -L$(NETLIB_LAPACK_PATH)/lib -llapack</ADD_LDFLAGS>
   <ADD_LDFLAGS MPILIB="!mpi-serial"> -L$(PNETCDF_PATH)/lib -lpnetcdf -L$(HDF5_PATH)/lib -lhdf5_hl -lhdf5 </ADD_LDFLAGS>
   <ADD_FFLAGS> -qspillsize=2500 -qextname=flush </ADD_FFLAGS>
   <ADD_CPPDEFS> -DLINUX  </ADD_CPPDEFS>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -162,7 +162,7 @@ for mct, etc.
 
 
   <ADD_CPPDEFS> -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRPGI </ADD_CPPDEFS>
-  <CFLAGS> -gopt -Mlist  -time </CFLAGS>
+  <CFLAGS> -gopt -time </CFLAGS>
 
   <ADD_CFLAGS compile_threaded="false"> </ADD_CFLAGS>
   <ADD_FFLAGS compile_threaded="false"> </ADD_FFLAGS>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -230,13 +230,12 @@ for mct, etc.
   <!--                     * inv: invalid operands         -->
   <!--                     * divz divide by zero           -->
   <!--                     * ovf: floating point overflow   -->
-  <!--  -Mlist          => Create a listing file             -->
   <!--  -F              => leaves file.f for each preprocessed file.F file  -->
   <!--  -time           => Print execution time for each compiler step  -->
 
 
   <ADD_CPPDEFS> -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DUSE_CUDA_FORTRAN -DCPRPGI </ADD_CPPDEFS>
-  <CFLAGS> -Mlist -time </CFLAGS>
+  <CFLAGS> -time </CFLAGS>
 
   <ADD_CFLAGS compile_threaded="false"> </ADD_CFLAGS>
   <ADD_FFLAGS compile_threaded="false"> </ADD_FFLAGS>
@@ -249,7 +248,7 @@ for mct, etc.
   <FREEFLAGS> -Mfree </FREEFLAGS>
   <FC_AUTO_R8> -r8 </FC_AUTO_R8>
 
-  <FFLAGS>  -i4 -Mlist  -time -Mstack_arrays -Mextend -byteswapio -Mflushz -Kieee  </FFLAGS>
+  <FFLAGS>  -i4 -time -Mstack_arrays -Mextend -byteswapio -Mflushz -Kieee  </FFLAGS>
   <ADD_FFLAGS MODEL="cam"> </ADD_FFLAGS>
   <FFLAGS_NOOPT> -O0 -g -Ktrap=fp -Mbounds -Kieee  </FFLAGS_NOOPT>
   <ADD_FFLAGS_NOOPT compile_threaded="false"> </ADD_FFLAGS_NOOPT>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2922,7 +2922,7 @@
         <command name="load">pgi/18.3</command>
       </modules>
       <modules compiler="ibm">
-        <command name="load">xl/20180406-beta</command>
+        <command name="load">xl/20180502</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">gcc/6.4.0</command>
@@ -2935,17 +2935,17 @@
       <!-- mpi lib settings -->
 	  <!-- Sometimes,same versions of libraries are not available for different compilers, hence the split below -->
       <modules compiler="ibm" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.2.0.0-20180406</command>
+        <command name="load">spectrum-mpi/10.2.0.0-20180508</command>
         <command name="load">parallel-netcdf/1.8.0</command>
         <command name="load">hdf5/1.10.0-patch1</command>
       </modules>
-      <modules compiler="pgi*" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.2.0.0-20180406</command>
+      <modules compiler="pgiacc" mpilib="!mpi-serial">
+        <command name="load">spectrum-mpi/10.2.0.0-20180508</command>
         <command name="load">parallel-netcdf/1.8.0</command>
         <command name="load">hdf5/1.10.0-patch1</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.2.0.0-20180406</command>
+        <command name="load">spectrum-mpi/10.2.0.0-20180508</command>
         <command name="load">parallel-netcdf/1.8.0</command>
         <command name="load">hdf5/1.10.0-patch1</command>
       </modules>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2918,7 +2918,7 @@
 		<command name="load">netlib-lapack/3.6.1</command>
       </modules>
       <!-- List of modules elements, executing commands if compiler and mpilib condition applies -->
-      <modules compiler="pgi">
+      <modules compiler="pgi.*">
         <command name="load">pgi/18.3</command>
       </modules>
       <modules compiler="ibm">
@@ -2939,7 +2939,7 @@
         <command name="load">parallel-netcdf/1.8.0</command>
         <command name="load">hdf5/1.10.0-patch1</command>
       </modules>
-      <modules compiler="pgiacc" mpilib="!mpi-serial">
+      <modules compiler="pgi.*" mpilib="!mpi-serial">
         <command name="load">spectrum-mpi/10.2.0.0-20180508</command>
         <command name="load">parallel-netcdf/1.8.0</command>
         <command name="load">hdf5/1.10.0-patch1</command>


### PR DESCRIPTION
Resolves the following compiler issues for building with IBM and PGI compilers by updating relevant flags.

- IBM: Update LDFLAGS to fix missing libraries
First encountered configure errors in MCT with IBM compilers. Tracked it
down to missing libraries from `-lxlfmath -lxlf90_r` LDFLAGS.
Fixes #2333.

- PGI: Encountered compiler crash for GPTL's perf_utils.F90 when using pgiacc
on Summit. PGI's -Mlist option appears to be the root cause for internal
buffer overflow in compiler.
-- Removed -Mlist from pgiacc as it is no longer present in PGI compilers
on Summit.
Fixes #2366.

- PGI: Use the proper regular expression (pgi.*) to refer to
pgi and pgiacc compilers in machine files.
Fixes #2368.

- IBM: Update IBM and Spectrum-mpi modules.

[BFB]