### PR TITLE
Update module versions for edison after maintenance.

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -125,7 +125,7 @@
 
     <modules>
       <command name="rm">craype</command>
-      <command name="load">craype/2.5.12.3</command>
+      <command name="load">craype/2.5.12</command>
       <command name="load">craype-ivybridge</command>
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.12</command>
@@ -160,23 +160,23 @@
       <command name="rm">PrgEnv-intel</command>
       <command name="load">PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
-      <command name="load">gcc/7.2.0</command>
+      <command name="load">gcc/7.3.0</command>
       <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/17.12.1</command>
+      <command name="load">cray-libsci/18.03.1</command>
     </modules>
 
     <modules mpilib="mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-hdf5/1.8.16</command>
-      <command name="load">cray-netcdf/4.4.0</command>
+      <command name="load">cray-hdf5/1.10.1.1</command>
+      <command name="load">cray-netcdf/4.4.1.1.3</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.0</command>
-      <command name="load">cray-hdf5-parallel/1.8.16</command>
-      <command name="load">cray-parallel-netcdf/1.6.1</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
+      <command name="load">cray-hdf5-parallel/1.10.1.1</command>
+      <command name="load">cray-parallel-netcdf/1.8.1.3</command>
     </modules>
   </module_system>
 


### PR DESCRIPTION
Update the module versions for craype, netcdf, and hdf5 on edison after maintenance. The versions we were using are no longer available. Tested e3sm_developer with intel,intel18,gnu,gnu7.
