### PR TITLE
Remove the oic2 machine

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -438,16 +438,6 @@
       </queues>
     </batch_system>
 
-   <batch_system MACH="oic2" type="pbs" >
-         <directives>
-                 <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
-		 <directive>-q esd08q</directive>
-         </directives>
-         <queues>
-           <queue default="true">esd08q</queue>
-         </queues>
-   </batch_system>
-
    <batch_system MACH="oic5" type="pbs" >
          <directives>
                  <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -867,20 +867,6 @@ for mct, etc.
   <ADD_LDFLAGS> -llapack -lblas</ADD_LDFLAGS>
 </compiler>
 
-<compiler MACH="oic2" COMPILER="gnu">
-  <NETCDF_PATH>/projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4/</NETCDF_PATH>
-  <ADD_SLIBS>-L/user/lib64 -llapack -lblas -lnetcdff </ADD_SLIBS>
-  <SFC>/projects/cesm/devtools/gcc-4.8.1/bin/gfortran</SFC>
-  <SCC>/projects/cesm/devtools/gcc-4.8.1/bin/gcc</SCC>
-  <SCXX>/projects/cesm/devtools/gcc-4.8.1/bin/g++</SCXX>
-  <MPICC>/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpicc</MPICC>
-  <MPIFC>/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpif90</MPIFC>
-</compiler>
-
-<compiler MACH="oic2" COMPILER="pgi">
-  <NETCDF_PATH>/home/zdr/opt/netcdf-4.1.3_pgf95</NETCDF_PATH>
-</compiler>
-
 <compiler MACH="oic5" COMPILER="gnu">
   <NETCDF_PATH>/projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4/</NETCDF_PATH>
   <ADD_SLIBS>-L/user/lib64 -llapack -lblas -lnetcdff </ADD_SLIBS>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1918,53 +1918,6 @@
 	 </environment_variables>
 </machine>
 
-<machine MACH="oic2">
-         <DESC>ORNL XK6, os is Linux, 8 pes/node, batch system is PBS</DESC>
-         <NODENAME_REGEX>oic2</NODENAME_REGEX>
-         <TESTS>e3sm_developer</TESTS>
-         <COMPILERS>gnu</COMPILERS>
-         <MPILIBS>mpich,openmpi</MPILIBS>
-         <RUNDIR>/home/$USER/models/ACME/run/$CASE/run</RUNDIR>
-         <EXEROOT>/home/$USER/models/ACME/run/$CASE/bld</EXEROOT>
-         <CIME_OUTPUT_ROOT>/home/$USER/models/ACME</CIME_OUTPUT_ROOT>
-         <DIN_LOC_ROOT>/home/zdr/models/ccsm_inputdata</DIN_LOC_ROOT>
-         <DIN_LOC_ROOT_CLMFORC>/home/zdr/models/ccsm_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-         <DOUT_S_ROOT>/home/$USER/models/ACME/run/archive/$CASE</DOUT_S_ROOT>
-         <OS>LINUX</OS>
-	 <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
-         <SUPPORTED_BY>dmricciuto</SUPPORTED_BY>
-         <GMAKE_J>8</GMAKE_J>
-	 <MAX_MPITASKS_PER_NODE>8</MAX_MPITASKS_PER_NODE>
-         <MAX_TASKS_PER_NODE>8</MAX_TASKS_PER_NODE>
-         <mpirun mpilib="mpich">
-              <executable args="default">/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpirun </executable>
-	      <arguments>
-			<arg name="num_tasks"> -np {{ total_tasks }}</arg>
-			<arg name="machine_file">--hostfile $ENV{PBS_NODEFILE}</arg>
-	      </arguments>
-         </mpirun>
-         <mpirun mpilib = "mpi-serial">
-              <executable> </executable>
-         </mpirun>
-	 <module_system type="module">
-	   <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
-	   <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
-	   <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
-	   <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
-	   <cmd_path lang="sh">module</cmd_path>
-	   <cmd_path lang="csh">module</cmd_path>
-	   <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
-	   <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
-
-	   <environment_variables>
-	     <env name="MPICH_ENV_DISPLAY">1</env>
-	     <env name="MPICH_VERSION_DISPLAY">1</env>
-	     <!-- This increases the stack size, which is necessary
-		  for CICE to run threaded on this machine -->
-	     <env name="OMP_STACKSIZE">64M</env>
-	   </environment_variables>
-	 </module_system>
-</machine>
 
 <machine MACH="oic5">
          <DESC>ORNL XK6, os is Linux, 32 pes/node, batch system is PBS</DESC>

--- a/cime/config/e3sm/machines/config_pio.xml
+++ b/cime/config/e3sm/machines/config_pio.xml
@@ -52,7 +52,6 @@
       <value mach="sooty">netcdf</value>
       <value mach="pleiades.*">netcdf</value>
       <value mach="hobart" compiler="pgi">netcdf</value>
-      <value mach="oic2">netcdf</value>
       <value mach="oic5">netcdf</value>
       <value mach="lawrencium-lr2">netcdf</value>
       <value mach="lawrencium-lr3">netcdf</value>


### PR DESCRIPTION
The oic2 at ORNL was decomissioned long time ago, so it is removed
from the machine files.

Fixes: issue #2295

[BFB]