### PR TITLE
Update GNU compiler on Theta

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1183,6 +1183,8 @@ for mct, etc.
 <compiler COMPILER="gnu" MACH="theta">
   <ADD_SLIBS>$(shell nf-config --flibs)</ADD_SLIBS>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O2 </ADD_FFLAGS>
+  <ADD_CFLAGS DEBUG="FALSE"> -O2 </ADD_CFLAGS>
 </compiler>
 
 <compiler COMPILER="pgi" MACH="blues">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1636,7 +1636,7 @@
         <command name="load">PrgEnv-cray/6.0.4</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gcc/6.3.0</command>
+        <command name="load">gcc/7.3.0</command>
         <command name="load">PrgEnv-gnu/6.0.4</command>
       </modules>
       <modules compiler="!intel">


### PR DESCRIPTION
Also increase optimization from default -O to -O2.

Fixes E3SM-Project/E3SM#1998

[BFB] except for baselines generated with GNU compiler