### PR TITLE
bugfix specific to A_WCYCL1950S_CMIP6_LRtunedHR compset

### DIFF
--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -75,7 +75,6 @@
       <value compset="20TR_CAM5%CMIP6_CLM">20thC_CMIP6_transient</value>
       <value compset="20TR_CAM5%CMIP6_CLM45.*_BGC%BCRC">20thC_CMIP6bgc_transient</value> 
       <value compset="20TR.*_CLM45%[^_]*BGC">20thC_bgc_transient</value>
-      <value compset="1950_CAM5%CMIP6.*_CLM">1950_CMIP6_control</value>
       <value compset="1950_CAM5%CMIP6-LR*_CLM">1950_CMIP6LR_control</value>
       <value compset="1950_CAM5%CMIP6-HR_CLM">1950_CMIP6HR_control</value>
     </values>


### PR DESCRIPTION
The A_WCYCL1950S_CMIP6_LRtunedHR wouldn't run because of strange behavior in components/clm/cime_config/config_component.xml causing a non-existent xml file to be called. Deleting the strange line fixed the problem.

Additional info: the strange line was:
      <value compset="1950_CAM5%CMIP6.*_CLM">1950_CMIP6_control</value>
1950_CMIP6_control.xml does not exist (it was a remnant of earlier work which wasn't completely cleaned up apparently), but I expected this line to never be called because the following line is:
      <value compset="1950_CAM5%CMIP6-LR*_CLM">1950_CMIP6LR_control</value>
which should catch LRtunedHR (and does when the previous line is deleted). 