### PR TITLE
Remove initialization of tbot to posinf

### DIFF
--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -32,7 +32,6 @@ module physpkg
   use zm_conv,          only: trigmem
   use scamMod,          only: single_column, scm_crm_mode
   use flux_avg,         only: flux_avg_init
-  use infnan,           only: posinf, assignment(=)
 #ifdef SPMD
   use mpishorthand
 #endif
@@ -458,10 +457,6 @@ subroutine phys_inidat( cam_out, pbuf2d )
        call pbuf_set_field(pbuf2d, m, tptr, start=(/1,n/), kount=(/pcols,1/))
     end do
     deallocate(tptr)
-
-    do lchnk=begchunk,endchunk
-       cam_out(lchnk)%tbot(:) = posinf
-    end do
 
     !
     ! 3-D fields


### PR DESCRIPTION
According to Brian Eaton, this code was added (a long time ago)
to replace code that was supposed to be trying to initialize
TBOT from the initial data file, but was actually broken and doing
nothing. This replacement code, setting tbot to posinf, was assumed
to do no harm. It was recently noticed that setting INFO_DBUG > 1
causes seq_diag_avect_mct to attempt to sum TBOT while it is still
a vector of INFs, which can cause the code to abort in certain
circumstances. Commenting out these lines eliminates this issue.
Note that TBOT is already initialized, to zero, along with all
the other surface state variables in camsrfexch.F90, so summation
of TBOT when INFO_DBUG > 1 is now a vector of zeroes.

At some point TBOT must be reset to something other than posinf,
as the posinf values do not cause problems in the simulation.
In particular, with this change (leaving TBOT with the
initialization to zero), nothing changes in the simulation.

Fixes #2403 

[BFB]