### PR TITLE
Remove MG2 nsubr conservation limiter.

### DIFF
--- a/components/cam/src/physics/cam/micro_mg2_0.F90
+++ b/components/cam/src/physics/cam/micro_mg2_0.F90
@@ -1707,9 +1707,7 @@ subroutine micro_mg_tend ( &
 
         ! Add evaporation of rain number.
         if (pre(i,k) < 0._r8) then
-           dum = pre(i,k)*deltat/qr(i,k)
-           dum = max(-1._r8,dum)
-           nsubr(i,k) = dum*nr(i,k)/deltat
+           nsubr(i,k) = pre(i,k)*nr(i,k)/qr(i,k)
         else
            nsubr(i,k) = 0._r8
         end if

--- a/components/cam/src/physics/cam/micro_mg2_0.F90
+++ b/components/cam/src/physics/cam/micro_mg2_0.F90
@@ -1707,6 +1707,9 @@ subroutine micro_mg_tend ( &
 
         ! Add evaporation of rain number.
         if (pre(i,k) < 0._r8) then
+	   ! We would normally divide qr and nr by precip_frac for an in-precip
+	   ! calculation, since they are grid cell averages, but that is
+	   ! unnecessary here because the two factors of precip_frac cancel.
            nsubr(i,k) = pre(i,k)*nr(i,k)/qr(i,k)
         else
            nsubr(i,k) = 0._r8


### PR DESCRIPTION
Removes a limiter that (a) was incorrectly coded, and (b) would have
been redundant if correctly coded.

The original code contained three lines that:

1. Calculated the fraction of rain mass being evaporated in the current
   time step.
2. Limited that fraction to no more than 1.
3. Evaporated the same fraction of the rain number.

Unfortunately, these lines did not use the precipitation fraction to
convert between in-precip and grid-mean quantities. In any case, the
limiter is redundant with both the mass conservation limiter above it,
and the number conservation limiter below it. When the limiter is
removed and the code is simplified, the number evaporation rate is
simply set to remove the same fraction of rain number as the mass
evaporation removes from the rain mass.

This change is potentially climate changing, since it systematically
increases rain drop size.

Fixes #2415.

[CC]