### PR TITLE
Fixes a clubb-only test added for running convergence tests

### DIFF
--- a/components/cam/src/physics/cam/convect_deep.F90
+++ b/components/cam/src/physics/cam/convect_deep.F90
@@ -294,7 +294,7 @@ subroutine convect_deep_tend( &
   end select
 
   ! If we added this, set it.
-  if (ttend_dp_idx > 0) then
+  if (ttend_dp_idx > 0 .and. allocated(ptend%s)) then
      call pbuf_get_field(pbuf, ttend_dp_idx, ttend_dp)
      ttend_dp(:state%ncol,:pver) = ptend%s(:state%ncol,:pver)/cpair
   end if

--- a/components/cam/src/physics/cam/convect_deep.F90
+++ b/components/cam/src/physics/cam/convect_deep.F90
@@ -294,9 +294,13 @@ subroutine convect_deep_tend( &
   end select
 
   ! If we added this, set it.
-  if (ttend_dp_idx > 0 .and. allocated(ptend%s)) then
+  if (ttend_dp_idx > 0) then
      call pbuf_get_field(pbuf, ttend_dp_idx, ttend_dp)
-     ttend_dp(:state%ncol,:pver) = ptend%s(:state%ncol,:pver)/cpair
+     if ( allocated(ptend%s) ) then
+        ttend_dp(:state%ncol,:pver) = ptend%s(:state%ncol,:pver)/cpair
+     else
+        ttend_dp(:state%ncol,:pver) = 0.0_r8
+     endif
   end if
 
   call outfld( 'ICWMRDP ', ql  , pcols, state%lchnk )


### PR DESCRIPTION
Allocation for ptend%s is tested before fetching its value. This ensures
 that the code works even in cases where deep_scheme is set to OFF,
CLUBB_SGS or UNICON

[BFB] - Bit-For-Bit

Fixes #2420