### PR TITLE
Fix domain specification for T42

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1367,7 +1367,7 @@
       <nx>128</nx>
       <ny>64</ny>
       <file grid="atm|lnd" mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.T42_USGS.111004.nc</file>
-      <file grid="ocn" mask="usgs">$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.64x128_USGS_070807.nc</file>
+      <file grid="ice|ocn" mask="usgs">$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.64x128_USGS_070807.nc</file>
       <desc>T42 is Gaussian grid:</desc>
     </domain>
 


### PR DESCRIPTION
Fix domain specification for T42 configuration. This previously omitted
the ice domain, so when trying to build a T42_T42 grid configuration,
the ice domain would remain unset. This is relevant to the single column
model, which uses the T42 grid by default.