### PR TITLE
Update versions of modules for netcdf/hdf5 at NERSC

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -169,12 +169,12 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
+      <command name="load">cray-netcdf/4.4.1.1.6</command>
       <command name="load">cray-hdf5/1.10.1.1</command>
-      <command name="load">cray-netcdf/4.4.1.1.3</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
       <command name="load">cray-hdf5-parallel/1.10.1.1</command>
       <command name="load">cray-parallel-netcdf/1.8.1.3</command>
     </modules>
@@ -189,7 +189,8 @@
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
 
-    <env name="HDF5_DISABLE_VERSION_CHECK">2</env>
+    <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
+    <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
   </environment_variables>
   <environment_variables compiler="intel">
     <env name="FORT_BUFFERED">yes</env>
@@ -304,13 +305,13 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-hdf5/1.10.0.3</command>
-      <command name="load">cray-netcdf/4.4.1.1.3</command>
+      <command name="load">cray-netcdf/4.4.1.1.6</command>
+      <command name="load">cray-hdf5/1.10.1.1</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
-      <command name="load">cray-hdf5-parallel/1.10.0.3</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
+      <command name="load">cray-hdf5-parallel/1.10.1.1</command>
       <command name="load">cray-parallel-netcdf/1.8.1.3</command>
     </modules>
 
@@ -326,11 +327,12 @@
 
     <env name="MPICH_ENV_DISPLAY">1</env>
     <env name="MPICH_VERSION_DISPLAY">1</env>
-    <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
+    <env name="MPICH_CPUMASK_DISPLAY">1</env>
 
     <env name="OMP_STACKSIZE">128M</env>
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
+    <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
   </environment_variables>
   <environment_variables compiler="intel">
     <env name="FORT_BUFFERED">yes</env>
@@ -458,13 +460,13 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-hdf5/1.10.0.3</command>
-      <command name="load">cray-netcdf/4.4.1.1.3</command>
+      <command name="load">cray-netcdf/4.4.1.1.6</command>
+      <command name="load">cray-hdf5/1.10.1.1</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
-      <command name="load">cray-hdf5-parallel/1.10.0.3</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
+      <command name="load">cray-hdf5-parallel/1.10.1.1</command>
       <command name="load">cray-parallel-netcdf/1.8.1.3</command>
     </modules>
     <modules>
@@ -481,11 +483,12 @@
   <environment_variables>
     <env name="MPICH_ENV_DISPLAY">1</env>
     <env name="MPICH_VERSION_DISPLAY">1</env>
-    <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
+    <env name="MPICH_CPUMASK_DISPLAY">1</env>
 
     <env name="OMP_STACKSIZE">128M</env>
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
+    <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
   </environment_variables>
 
   <environment_variables mpilib="mpt">


### PR DESCRIPTION
For all 3 NERSC machines (cori-knl, cori-haswell, edison), update the version of netcdf/hdf5.
Use cray-netcdf-hdf5parallel/4.4.1.1.6 and cray-hdf5-parallel/1.10.1.1
This avoids issues when reading netcdf4 files.

Also turn off file locking HDF5_USE_FILE_LOCKING=FALSE.
This does not appear necessary for tests to pass, but documentation suggests it is good idea to turn off file locking for GPFS filesystems (where our inputdata exists).

On edison, remove the variable that was disabling the HDF version check as it is no longer needed.

Turn on logging of MPI rank and compute node information for Cori, which adds a lot to e3sm.log*.

Fixes #2413 
