### PR TITLE
Add ne4_oQU480 and T62_oQU480 configurations

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -513,6 +513,16 @@
 
     <!--  spectral element grids -->
 
+    <model_grid alias="ne4_oQU480">
+      <grid name="atm">ne4np4</grid>
+      <grid name="lnd">ne4np4</grid>
+      <grid name="ocnice">oQU480</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU480</mask>
+    </model_grid>
+
     <model_grid alias="ne4_oQU240">
       <grid name="atm">ne4np4</grid>
       <grid name="lnd">ne4np4</grid>
@@ -991,6 +1001,16 @@
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="T62_oQU480" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oQU480</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU480</mask>
+    </model_grid>
+
     <model_grid alias="T62_oQU240" compset="(DATM|XATM|SATM)">
       <grid name="atm">T62</grid>
       <grid name="lnd">T62</grid>
@@ -1346,6 +1366,7 @@
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx1v6.090320.nc</file>
       <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx3v7.090911.nc</file>
       <file grid="atm|lnd" mask="mpasgx1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_mpasgx1.150903.nc</file>
+      <file grid="atm|lnd" mask="oQU480">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU480.151209.nc</file>
       <file grid="atm|lnd" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240.151209.nc</file>
       <file grid="atm|lnd" mask="oQU240wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240wLI_mask.160929.nc</file>
       <file grid="atm|lnd" mask="oQU120">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU120.151209.nc</file>
@@ -1380,7 +1401,9 @@
     <domain name="ne4np4">
       <nx>866</nx>
       <ny>1</ny>
+      <file grid="atm|lnd" mask="oQU480">$DIN_LOC_ROOT/share/domains/domain.lnd.ne4np4_oQU480.180702.nc</file>
       <file grid="atm|lnd" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.lnd.ne4np4_oQU240.160614.nc</file>
+      <file grid="ice|ocn" mask="oQU480">$DIN_LOC_ROOT/share/domains/domain.ocn.ne4np4_oQU480.180702.nc</file>
       <file grid="ice|ocn" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.ocn.ne4np4_oQU240.160614.nc</file>
       <desc>ne4np4 is Spectral Elem  7.5-deg grid:</desc>
     </domain>
@@ -1694,6 +1717,13 @@
       <desc>tx0.1v2 is an old mask used for CONUS:</desc>
     </domain>
 
+    <domain name="oQU480">
+      <nx>1791</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oQU480.151209.nc</file>
+      <desc>oQU480 is an MPAS ocean mesh with quasi-uniform 480 km grid cells, nominally 4 degree resolution:</desc>
+    </domain>
+
     <domain name="oQU240">
       <nx>7153</nx>
       <ny>1</ny>
@@ -1817,6 +1847,14 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne4np4/</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx3v7/</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx3v7/</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne4np4" ocn_grid="oQU480">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne4np4/map_ne4np4_to_oQU480_aave.180702.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne4np4/map_ne4np4_to_oQU480_conserve.180702.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne4np4/map_ne4np4_to_oQU480_conserve.180702.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU480/map_oQU480_to_ne4np4_aave.180702.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU480/map_oQU480_to_ne4np4_aave.180702.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne4np4" ocn_grid="oQU240">
@@ -2034,6 +2072,14 @@
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_mpasgx1_blin.150827.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/mpasgx1/map_mpasgx1_TO_T62_aave.150827.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/mpasgx1/map_mpasgx1_TO_T62_aave.150827.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="T62" ocn_grid="oQU480">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU480_aave.151209.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU480_patc.151209.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU480_blin.151209.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU480/map_oQU480_TO_T62_aave.151209.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU480/map_oQU480_TO_T62_aave.151209.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oQU240">
@@ -2385,6 +2431,11 @@
 
     <!--- current MPAS grids -->
 
+    <gridmap ocn_grid="oQU480" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oQU480_nn_151209.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oQU480_nn_151209.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="oQU240" rof_grid="rx1">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oQU240_nn.160527.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oQU240_nn.160527.nc</map>
@@ -2453,6 +2504,11 @@
     <gridmap ocn_grid="oRRS15to5" rof_grid="rx1">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS15to5_nn.160527.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS15to5_nn.160527.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="oQU480" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oQU480_nn.180702.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oQU480_nn.180702.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oQU240" rof_grid="r05">

--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -279,6 +279,7 @@
       <value compset="_DLND.*_MALI">1</value>
       <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">24</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%oQU480">12</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oQU240">12</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oQU240wLI">12</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oQU120">24</value>
@@ -376,6 +377,7 @@
       <value compset="_DLND.*_MALI">1</value>
       <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">24</value>
+      <value compset="_MPASO" grid="oi%oQU480">6</value>
       <value compset="_MPASO" grid="oi%oQU240">12</value>
       <value compset="_MPASO" grid="oi%oQU240wLI">12</value>
       <value compset="_MPASO" grid="oi%oQU120">24</value>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1180,7 +1180,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*20" category="default_settings"
        group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,oRRS18to6,oRRS18to6v3,oRRS15to5,mp120v1,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,tx0.1v2">
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,oRRS18to6,oRRS18to6v3,oRRS15to5,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,tx0.1v2">
 Land mask description
 </entry> 
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -44,6 +44,7 @@
 <config_iterative_init_variable>'landIcePressure'</config_iterative_init_variable>
 
 <!-- time_integration -->
+<config_dt ocn_grid="oQU480">'02:00:00'</config_dt>
 <config_dt ocn_grid="oQU240">'01:00:00'</config_dt>
 <config_dt ocn_grid="oQU240wLI">'02:00:00'</config_dt>
 <config_dt ocn_grid="oQU120">'00:30:00'</config_dt>
@@ -81,6 +82,7 @@
 <config_min_pbc_fraction>0.10</config_min_pbc_fraction>
 
 <!-- hmix -->
+<config_hmix_scaleWithMesh ocn_grid="oQU480">.false.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oQU240">.false.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oQU240wLI">.false.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oQU120">.false.</config_hmix_scaleWithMesh>
@@ -107,6 +109,7 @@
 <!-- hmix_del4 -->
 <config_use_mom_del4>.true.</config_use_mom_del4>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
+<config_mom_del4 ocn_grid="oQU480">2.0e15</config_mom_del4>
 <config_mom_del4 ocn_grid="oQU240">2.0e14</config_mom_del4>
 <config_mom_del4 ocn_grid="oQU240wLI">2.0e14</config_mom_del4>
 <config_mom_del4 ocn_grid="oQU120">2.6e13</config_mom_del4>
@@ -131,6 +134,7 @@
 <config_Leith_visc2_max>2.5e3</config_Leith_visc2_max>
 
 <!-- mesoscale_eddy_parameterization -->
+<config_use_standardGM ocn_grid="oQU480">.true.</config_use_standardGM>
 <config_use_standardGM ocn_grid="oQU240">.true.</config_use_standardGM>
 <config_use_standardGM ocn_grid="oQU240wLI">.true.</config_use_standardGM>
 <config_use_standardGM ocn_grid="oQU120">.true.</config_use_standardGM>
@@ -327,6 +331,7 @@
 <config_n_bcl_iter_mid>2</config_n_bcl_iter_mid>
 <config_n_bcl_iter_end>2</config_n_bcl_iter_end>
 <config_btr_dt>'0000_00:00:15'</config_btr_dt>
+<config_btr_dt ocn_grid="oQU480">'0000_00:05:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU240">'0000_00:03:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU240wLI">'0000_00:03:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU120">'0000_00:01:30'</config_btr_dt>
@@ -793,6 +798,7 @@
 <config_AM_eddyProductVariables_write_on_startup>.false.</config_AM_eddyProductVariables_write_on_startup>
 
 <!-- AM_mocStreamfunction -->
+<config_AM_mocStreamfunction_enable ocn_grid="oQU480">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="oQU240">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="oQU240wLI">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="oQU120">.false.</config_AM_mocStreamfunction_enable>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -116,6 +116,11 @@ def buildnml(case, caseroot, compname):
         decomp_prefix += 'mpas-o.graph.info.'
         restoring_file += 'sss.monthlyClimatology.PHC2_salx.EC60to30v3wLI.170328.nc'
         analysis_mask_file += 'masks_SingleRegionAtlanticWTransportTransects_EC60to30v3wLI_171116.nc'
+    elif ocn_grid == 'oQU480':
+        ic_date += '151209'
+        ic_prefix += 'ocean.QU.480km'
+        decomp_date += '151209'
+        decomp_prefix += 'mpas-o.graph.info.'
     elif ocn_grid == 'oQU240':
         ic_date += '151209'
         ic_prefix += 'ocean.QU.240km'

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -5,6 +5,7 @@
 
 <!-- seaice_model -->
 <config_dt>1800.0</config_dt>
+<config_dt ice_grid="oQU480">7200.0</config_dt>
 <config_dt ice_grid="oQU240">7200.0</config_dt>
 <config_dt ice_grid="oQU240wLI">7200.0</config_dt>
 <config_dt ice_grid="oQU120">3600.0</config_dt>
@@ -93,6 +94,7 @@
 
 <!-- velocity_solver -->
 <config_dynamics_subcycle_number>1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="oQU480">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="oQU240">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="oQU120">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="mpas120">1</config_dynamics_subcycle_number>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -118,6 +118,11 @@ def buildnml(case, caseroot, compname):
         grid_prefix += 'cice.QU240wLI'
         decomp_date += '160929'
         decomp_prefix += 'mpas-cice.graph.info.'
+    elif ice_grid == 'oQU480':
+        grid_date += '180705'
+        grid_prefix += 'seaice.oQU480'
+        decomp_date += '180705'
+        decomp_prefix += 'mpas-seaice.graph.legacy.'
     elif ice_grid == 'mpasgx1':
         grid_date += '121116'
         grid_prefix += 'grid_gx1'


### PR DESCRIPTION
This PR brings in necessary script modifications to support an ultra-low ocn/ice testing configuration, using ne4np4_oQU480 for fully-coupled testing and T62_oQU480 for ocn/ice testing. This capability had been requested for faster testing - but it should be stressed that neither of these is suitable for scientific results. All necessary files are on the lcrc disk. A test G-case on one anvil node got ~200 sypd and a B-case using four nodes ran at ~50 sypd.

Tested with:
* A_WCYCL1850.ne4_oQU480.anvil
* T62_oQU480.GMPAS-IAF.anvil
* A_WCYCL1850.ne4_oQU480.edison

[BFB]