### PR TITLE
Fix multi-instance specifier string

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -79,6 +79,7 @@ _TESTS = {
 		           ("SMS_D_Ld1.ne30_oECv3_ICG.A_WCYCL1850S_CMIP6","allactive-v1cmip6"),
                            "ERS_Ln9.ne4_ne4.FC5AV1C-L",
                           #"ERT_Ld31.ne16_g37.B1850C5",#add this line back in with the new correct compset
+                           "NCK.ne4_oQU240.A_WCYCL1850",
                            ("PET.f19_g16.X","allactive-mach-pet"),
                            ("PET.f45_g37_rx1.A","allactive-mach-pet"),
                            ("PET_Ln9_PS.ne30_oECv3_ICG.A_WCYCL1850S","allactive-mach-pet"),

--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -128,7 +128,7 @@ def buildnml(case, caseroot, compname):
 
         inst_string = ""
         if ninst_atm > 1:
-            inst_string = "{0:04d}".format(inst_counter)
+            inst_string = "_{0:04d}".format(inst_counter)
 
             # If multi-instance case does not have restart file, use single-case restart
             # for each instance

--- a/components/cice/cime_config/buildnml
+++ b/components/cice/cime_config/buildnml
@@ -113,7 +113,7 @@ def buildnml(case, caseroot, compname):
         # -----------------------------------------------------
 
         if ninst_ice > 1:
-            inst_string = "{0:04d}".format(inst_counter)
+            inst_string = "_{0:04d}".format(inst_counter)
 
             # If multi-instance case does not have restart file, use single-case restart
             # for each instance

--- a/components/clm/cime_config/buildnml
+++ b/components/clm/cime_config/buildnml
@@ -121,7 +121,7 @@ def buildnml(case, caseroot, compname):
 
         inst_string = ""
         if ninst_lnd > 1:
-            inst_string = "{0:04d}".format(inst_counter)
+            inst_string = "_{0:04d}".format(inst_counter)
 
             # If multi-instance case does not have restart file, use single-case restart
             # for each instance

--- a/components/mosart/cime_config/buildnml
+++ b/components/mosart/cime_config/buildnml
@@ -64,7 +64,7 @@ def buildnml(case, caseroot, compname):
 
         inst_string = ""
         if ninst_rof > 1:
-            inst_string = "{0:04d}".format(inst_counter)
+            inst_string = "_{0:04d}".format(inst_counter)
 
             # If multi-instance case does not have restart file, use single-case restart
             # for each instance

--- a/components/mpas-albany-landice/cime_config/buildnml
+++ b/components/mpas-albany-landice/cime_config/buildnml
@@ -92,7 +92,7 @@ def buildnml(case, caseroot, compname):
 
         inst_string = ""
         if ninst_glc > 1:
-            inst_string = "{0:04d}".format(inst_counter)
+            inst_string = "_{0:04d}".format(inst_counter)
 
             # If multi-instance case does not have restart file, use single-case restart
             # for each instance

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -227,7 +227,7 @@ def buildnml(case, caseroot, compname):
 
         inst_string = ""
         if ninst_ocn > 1:
-            inst_string = "{0:04d}".format(inst_counter)
+            inst_string = "_{0:04d}".format(inst_counter)
 
             # If multi-instance case does not have restart file, use single-case restart
             # for each instance

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -194,7 +194,7 @@ def buildnml(case, caseroot, compname):
 
         inst_string = ""
         if ninst_ice > 1:
-            inst_string = "{0:04d}".format(inst_counter)
+            inst_string = "_{0:04d}".format(inst_counter)
 
             # If multi-instance case does not have restart file, use single-case restart
             # for each instance


### PR DESCRIPTION
The pythonization of the pearl `components/*/cime_config/buildnml` scripts changed the multi-instance specifier string from `_NINST`  to `NINST`.  This leads to unexpected file names, like `atm_in0001` instead of `atm_in_0001`, and errors like:

```
FIO-F-209/OPEN/unit=97/'OLD' specified for file which does not exist.            
File name = atm_in_0001
In source file $E3SM/components/cam/src/control/runtime_opts.F90, at line number 394
```
when using the multi-instance capability. 

Importantly, the bug was only found in the active components, not the data models, so the multi-instance test `NCK.f19_g16_rx1.A` in the `e3sm_developer` test set did not pick it up. I've added `NCK.ne4_oQU240.A_WCYCL1850` to the `e3sm_integration` set, which is an all-active compset and should catch issues with any of the multi-instance components. (Note, because there is a `buildnml` script per component, we need an all-active test to test them all.) 

Fixes #2427

[B4B]