### PR TITLE
 Fix retranslocation P flux bug

### DIFF
--- a/components/clm/src/biogeochem/CNAllocationMod.F90
+++ b/components/clm/src/biogeochem/CNAllocationMod.F90
@@ -4241,8 +4241,8 @@ contains
     ! if lai greater than laimax then no allocation to leaf; leaf allocation goes to stem or fine root
     if (laindex > laimax) then 
        if (woody == 1.0_r8) then
-          alloc_stem = alloc_stem + alloc_leaf/2.0 - 0.005_r8
-          alloc_froot = alloc_froot + alloc_leaf/2.0 - 0.005_r8
+          alloc_stem = alloc_stem + alloc_leaf/2._r8 - 0.005_r8
+          alloc_froot = alloc_froot + alloc_leaf/2._r8 - 0.005_r8
        else
           alloc_froot = alloc_froot + alloc_leaf - 0.01_r8
        end if

--- a/components/clm/src/biogeochem/CNAllocationMod.F90
+++ b/components/clm/src/biogeochem/CNAllocationMod.F90
@@ -3039,6 +3039,8 @@ contains
          grain_flag                   => cnstate_vars%grain_flag_patch                         , &
          cn_scalar                    => cnstate_vars%cn_scalar                                , &
          cp_scalar                    => cnstate_vars%cp_scalar                                , &
+         cn_scalar_runmean            => cnstate_vars%cn_scalar_runmean                        , &
+         cp_scalar_runmean            => cnstate_vars%cp_scalar_runmean                        , &
          annmax_retransp              => cnstate_vars%annmax_retransp_patch                    , &
          cpool_to_xsmrpool            => carbonflux_vars%cpool_to_xsmrpool_patch               , &
          w_scalar                     => carbonflux_vars%w_scalar_col                          , &
@@ -3288,8 +3290,8 @@ contains
              ! 'ECA' or 'MIC' mode
              ! dynamic allocation based on light limitation (more woody growth) vs nutrient limitations (more fine root growth)
              ! set allocation coefficients
-             N_lim_factor(p) = cn_scalar(p) ! N stress factor
-             P_lim_factor(p) = cp_scalar(p) ! P stress factor
+             N_lim_factor(p) = cn_scalar_runmean(p) ! N stress factor
+             P_lim_factor(p) = cp_scalar_runmean(p) ! P stress factor
 
              if (cnallocate_carbon_only()) then
                  N_lim_factor(p) = 0.0_r8
@@ -4239,7 +4241,8 @@ contains
     ! if lai greater than laimax then no allocation to leaf; leaf allocation goes to stem or fine root
     if (laindex > laimax) then 
        if (woody == 1.0_r8) then
-          alloc_stem = alloc_stem + alloc_leaf - 0.01_r8
+          alloc_stem = alloc_stem + alloc_leaf/2.0 - 0.005_r8
+          alloc_froot = alloc_froot + alloc_leaf/2.0 - 0.005_r8
        else
           alloc_froot = alloc_froot + alloc_leaf - 0.01_r8
        end if

--- a/components/clm/src/biogeochem/CNAnnualUpdateMod.F90
+++ b/components/clm/src/biogeochem/CNAnnualUpdateMod.F90
@@ -74,6 +74,10 @@ contains
              cnstate_vars%annmax_retransn_patch(p)  = cnstate_vars%tempmax_retransn_patch(p)
              cnstate_vars%tempmax_retransn_patch(p) = 0._r8
 
+             ! update annual total P retranslocation accumulator
+             cnstate_vars%annmax_retransp_patch(p)  = cnstate_vars%tempmax_retransp_patch(p)
+             cnstate_vars%tempmax_retransp_patch(p) = 0._r8
+
              ! update annual average 2m air temperature accumulator
              cnstate_vars%annavg_t2m_patch(p)  = cnstate_vars%tempavg_t2m_patch(p)
              cnstate_vars%tempavg_t2m_patch(p) = 0._r8

--- a/components/clm/src/biogeochem/CNC14DecayMod.F90
+++ b/components/clm/src/biogeochem/CNC14DecayMod.F90
@@ -116,7 +116,7 @@ contains
             do j = 1, nlevdecomp
                do fc = 1,num_soilc
                   c = filter_soilc(fc)
-                  if (spinup_term .eq. 1 .and. yr .ge. 40 .and. nu_com .eq. 'RD') then
+                  if (spinup_term > 1._r8 .and. yr .ge. 40) then
                       decomp_cpools_vr(c,j,l) = decomp_cpools_vr(c,j,l) * (1._r8 - decay_const * &
                           (spinup_term / cnstate_vars%scalaravg_col(c,j)) * dt)
                   else

--- a/components/clm/src/biogeochem/CNEcosystemDynMod.F90
+++ b/components/clm/src/biogeochem/CNEcosystemDynMod.F90
@@ -173,10 +173,10 @@ contains
                 call t_stopf('PBiochemMin')
              else
                 ! nu_com_phosphatase is true
-                call t_startf('PBiochemMin')
-                call PBiochemMin_balance(bounds,num_soilc, filter_soilc, &
-                     cnstate_vars,nitrogenstate_vars,phosphorusstate_vars,phosphorusflux_vars)
-                call t_stopf('PBiochemMin')
+                !call t_startf('PBiochemMin')
+                !call PBiochemMin_balance(bounds,num_soilc, filter_soilc, &
+                !     cnstate_vars,nitrogenstate_vars,phosphorusstate_vars,phosphorusflux_vars)
+                !call t_stopf('PBiochemMin')
              end if
        !end if
        

--- a/components/clm/src/biogeochem/PDynamicsMod.F90
+++ b/components/clm/src/biogeochem/PDynamicsMod.F90
@@ -648,6 +648,7 @@ contains
     ! set initial values for potential C and N fluxes
     biochem_pmin_ppools_vr_col(bounds%begc : bounds%endc, :, :) = 0._r8
     biochem_pmin_to_plant_vr_patch(bounds%begp:bounds%endp,1:nlevdecomp) = 0._r8
+    biochem_pmin_to_plant_patch(bounds%begp:bounds%endp) = 0._r8
       
     do j = 1,nlevdecomp
         do fc = 1,num_soilc
@@ -746,7 +747,7 @@ contains
        c = filter_soilc(fc)
        do p = col_pp%pfti(c), col_pp%pftf(c)
         if (veg_pp%active(p).and. (veg_pp%itype(p) .ne. noveg)) then
-          biochem_pmin_to_plant_patch(p) = 0._r8
+          !biochem_pmin_to_plant_patch(p) = 0._r8
           do j = 1,nlevdecomp
              biochem_pmin_to_plant_patch(p) = biochem_pmin_to_plant_patch(p) + &
                                               biochem_pmin_to_plant_vr_patch(p,j) * col_pp%dz(c,j)
@@ -762,6 +763,15 @@ contains
           enddo
        end do
     end if
+
+    do j = 1, nlevdecomp
+       do fc = 1,num_soilc
+          c = filter_soilc(fc)
+          do l = 1, ndecomp_pools
+             decomp_ppools_vr_col(c,j,l) = decomp_ppools_vr_col(c,j,l)- biochem_pmin_ppools_vr_col(c,j,l)*dt
+          end do
+       end do
+    end do
 
     end associate
 

--- a/components/clm/src/biogeochem/PStateUpdate3Mod.F90
+++ b/components/clm/src/biogeochem/PStateUpdate3Mod.F90
@@ -210,6 +210,7 @@ contains
            enddo
          end if
 
+         if (nu_com .eq. 'RD') then
           do j = 1, nlevdecomp
              do fc = 1,num_soilc
                 c = filter_soilc(fc)
@@ -220,6 +221,7 @@ contains
                 end do
              end do
           end do
+         end if
 
          do j = 1, nlevdecomp
             do fc = 1,num_soilc

--- a/components/clm/src/data_types/CNStateType.F90
+++ b/components/clm/src/data_types/CNStateType.F90
@@ -158,6 +158,8 @@ module CNStateType
      real(r8), pointer :: cp_scalar                    (:)     ! cp scaling factor for root p uptake kinetics (no units)
      real(r8), pointer :: np_scalar                    (:)     ! np scaling factor for root n/p uptake kinetics (no units)
      real(r8), pointer :: cost_ben_scalar              (:)     ! cost benefit analysis scaling factor for root n uptake kinetics (no units)
+     real(r8), pointer :: cn_scalar_runmean            (:)     ! long term average of cn scaling factor for root n uptake kinetics (no units) 
+     real(r8), pointer :: cp_scalar_runmean            (:)     ! long term average of cp scaling factor for root p uptake kinetics (no units)
 
      real(r8), pointer :: frac_loss_lit_to_fire_col        (:)
      real(r8), pointer :: frac_loss_cwd_to_fire_col        (:)
@@ -179,6 +181,9 @@ module CNStateType
      procedure, private :: InitAllocate
      procedure, private :: InitHistory  
      procedure, private :: InitCold     
+     procedure, public  :: InitAccBuffer
+     procedure, public  :: InitAccVars
+     procedure, public  :: UpdateAccVars
 
   end type cnstate_type
   !------------------------------------------------------------------------
@@ -339,6 +344,8 @@ contains
     allocate(this%cp_scalar                   (begp:endp))                   ; this%cp_scalar     (:) = 0.0
     allocate(this%np_scalar                   (begp:endp))                   ; this%np_scalar     (:) = 0.0
     allocate(this%cost_ben_scalar             (begp:endp))                   ; this%cost_ben_scalar(:) = 0.0
+    allocate(this%cn_scalar_runmean           (begp:endp))                   ; this%cn_scalar_runmean (:) = 0.0
+    allocate(this%cp_scalar_runmean           (begp:endp))                   ; this%cp_scalar_runmean (:) = 0.0
     allocate(this%frac_loss_lit_to_fire_col       (begc:endc))               ; this%frac_loss_lit_to_fire_col(:) =0._r8
     allocate(this%frac_loss_cwd_to_fire_col       (begc:endc))               ; this%frac_loss_cwd_to_fire_col(:) =0._r8
     allocate(fert_type                        (begc:endc))                   ; fert_type     (:) = 0
@@ -665,6 +672,16 @@ contains
     call hist_addfld1d (fname='cp_scalar', units='', &
        avgflag='A', long_name='P limitation factor', &
        ptr_patch=this%cp_scalar, default='active')
+
+    this%cn_scalar_runmean(begp:endp) = spval
+    call hist_addfld1d (fname='nlim_m', units='', &
+       avgflag='A', long_name='runmean N limitation factor', &
+       ptr_patch=this%cn_scalar_runmean, default='active')
+
+    this%cp_scalar_runmean(begp:endp) = spval
+    call hist_addfld1d (fname='plim_m', units='', &
+       avgflag='A', long_name='runmean P limitation factor', &
+       ptr_patch=this%cp_scalar_runmean, default='active')
 
     this%r_mort_cal_patch(begp:endp) = spval
     call hist_addfld1d (fname='R_MORT_CAL', units='none', &
@@ -1109,7 +1126,7 @@ contains
     use fileutils  , only : getfil
     !
     ! !ARGUMENTS:
-    class(cnstate_type) :: this
+    class(cnstate_type)              :: this
     type(bounds_type), intent(in)    :: bounds 
     type(file_desc_t), intent(inout) :: ncid   
     character(len=*) , intent(in)    :: flag   
@@ -1432,7 +1449,131 @@ contains
             dim1name='pft', long_name='cp_scalar', units='-', &
             interpinic_flag='interp', readvar=readvar, data=this%cp_scalar)
 
+    call restartvar(ncid=ncid, flag=flag, varname='nlim_m', xtype=ncd_double,  &
+            dim1name='pft', long_name='cn_scalar_runmean', units='-', &
+            interpinic_flag='interp', readvar=readvar, data=this%cn_scalar_runmean)
+    call restartvar(ncid=ncid, flag=flag, varname='plim_m', xtype=ncd_double,  &
+            dim1name='pft', long_name='cp_scalar_runmean', units='-', &
+            interpinic_flag='interp', readvar=readvar, data=this%cp_scalar_runmean)
+
   end subroutine Restart
+
+  !-----------------------------------------------------------------------
+  subroutine InitAccBuffer (this, bounds)
+    ! !USES
+    use accumulMod       , only : init_accum_field
+    !
+    ! !ARGUMENTS:
+    class(cnstate_type)           :: this
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+
+    this%cn_scalar_runmean(bounds%begp:bounds%endp) = spval
+    call init_accum_field (name='nlim_m', units='-',                                              &
+         desc='runing average of N limitation strength',  accum_type='runmean', accum_period=-7300,    &
+         subgrid_type='pft', numlev=1, init_value=0._r8)
+
+    this%cp_scalar_runmean(bounds%begp:bounds%endp) = spval
+    call init_accum_field (name='plim_m', units='-',                                              &
+         desc='runing average of P limitation strength',  accum_type='runmean', accum_period=-7300,    &
+         subgrid_type='pft', numlev=1, init_value=0._r8)
+
+  end subroutine InitAccBuffer
+
+  !-----------------------------------------------------------------------
+  subroutine InitAccVars(this, bounds)
+
+    ! !USES
+    use accumulMod       , only : init_accum_field, extract_accum_field
+    use clm_time_manager , only : get_nstep
+    use clm_varctl       , only : nsrest
+    use abortutils       , only : endrun
+    !
+    ! !ARGUMENTS:
+    class(cnstate_type)           :: this
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: begp, endp
+    integer  :: nstep
+    integer  :: ier
+    real(r8), pointer :: rbufslp(:)  ! temporary
+    !---------------------------------------------------------------------
+
+    begp = bounds%begp; endp = bounds%endp
+
+    ! Allocate needed dynamic memory for single level pft field
+    allocate(rbufslp(begp:endp), stat=ier)
+    if (ier/=0) then
+       write(iulog,*)' in '
+       call endrun(msg="extract_accum_hist allocation error for rbufslp"//&
+            errMsg(__FILE__, __LINE__))
+    endif
+
+    ! Determine time step
+    nstep = get_nstep()
+
+    call extract_accum_field ('nlim_m', rbufslp, nstep)
+    this%cn_scalar_runmean(begp:endp) = rbufslp(begp:endp)
+
+    call extract_accum_field ('plim_m', rbufslp, nstep)
+    this%cp_scalar_runmean(begp:endp) = rbufslp(begp:endp)
+  
+  end subroutine InitAccVars
+
+  !-----------------------------------------------------------------------
+  subroutine UpdateAccVars (this, bounds)
+    !
+    ! USES
+    use clm_time_manager , only : get_step_size, get_nstep, is_end_curr_day, get_curr_date
+    use accumulMod       , only : update_accum_field, extract_accum_field
+    !
+    ! !ARGUMENTS:
+    class(cnstate_type)                    :: this
+    type(bounds_type)      , intent(in)    :: bounds
+    !
+    ! !LOCAL VARIABLES:
+    integer :: m,g,l,c,p                 ! indices
+    integer :: ier                       ! error status
+    integer :: dtime                     ! timestep size [seconds]
+    integer :: nstep                     ! timestep number
+    integer :: year                      ! year (0, ...) for nstep
+    integer :: month                     ! month (1, ..., 12) for nstep
+    integer :: day                       ! day of month (1, ..., 31) for nstep
+    integer :: secs                      ! seconds into current date for nstep
+    logical :: end_cd                    ! temporary for is_end_curr_day() value
+    integer :: begp, endp
+    real(r8), pointer :: rbufslp(:)      ! temporary single level - pft level
+    !---------------------------------------------------------------------
+
+    begp = bounds%begp; endp = bounds%endp
+
+    dtime = get_step_size()
+    nstep = get_nstep()
+    call get_curr_date (year, month, day, secs)
+
+    ! Allocate needed dynamic memory for single level pft field
+
+    allocate(rbufslp(begp:endp), stat=ier)
+    if (ier/=0) then
+       write(iulog,*)'update_accum_hist allocation error for rbuf1dp'
+       call endrun(msg=errMsg(__FILE__, __LINE__))
+    endif
+
+    ! Accumulate and extract
+    do p = begp,endp
+       rbufslp(p) = this%cn_scalar(p)
+    end do
+    call update_accum_field  ('nlim_m' , rbufslp             , nstep)
+    call extract_accum_field ('nlim_m' , this%cn_scalar_runmean  , nstep)
+    do p = begp,endp
+       rbufslp(p) = this%cp_scalar(p)
+    end do
+    call update_accum_field  ('plim_m' , rbufslp             , nstep)
+    call extract_accum_field ('plim_m' , this%cp_scalar_runmean  , nstep)
+
+  end subroutine UpdateAccVars
 
   !-----------------------------------------------------------------------
   subroutine CropRestIncYear (this)

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -1223,6 +1223,8 @@ contains
        if (crop_prog) then
           call crop_vars%UpdateAccVars(bounds_proc, temperature_vars)
        end if
+
+       call cnstate_vars%UpdateAccVars(bounds_proc)
        
        call t_stopf('accum')
 

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -619,6 +619,8 @@ contains
        call crop_vars%initAccBuffer(bounds_proc)
     end if
 
+    call cnstate_vars%initAccBuffer(bounds_proc)
+
     call print_accum_fields()
 
     call t_stopf('init_accflds')
@@ -831,6 +833,7 @@ contains
     if (crop_prog) then
        call crop_vars%initAccVars(bounds_proc)
     end if
+    call cnstate_vars%initAccVars(bounds_proc)
 
     !------------------------------------------------------------       
     ! Read monthly vegetation


### PR DESCRIPTION
- fix P retranslocation bug
- phosphatase subroutine inconsistently called twice, removed one
- enhance the numerical stability of C allocation, by considering running average of environmental limiters. 
- enable 14C spinup for ECA coupler bypass run

[non-BFB] for ECA
[BFB] for CTC