### PR TITLE
MKL Bug fix: Update Intel compiler version on Titan

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2124,7 +2124,7 @@
         <command name="rm">cray-libsci</command>
         <command name="rm">cray-mpich</command>
         <command name="rm">atp</command>
-        <command name="load">intel/18.0.0.128</command>
+        <command name="load">intel/18.0.1.163</command>
         <command name="load">cray-mpich/7.6.3</command>
         <command name="load">atp/2.1.1</command>
       </modules>


### PR DESCRIPTION
Resolves an application crash due to a MKL bug.

Application crash was first reported by Balwinder while running
SMS_D_Ln1.ne30_ne30.FC5AV1C-L.titan_intel.

Pat identified the root cause: MKL routine vdln() along with DEBUG
flag -fpe0.  Note that this works fine with -fpe1 or higher. It also
works fine if 'cnt' (the vector length) is < 10 in the following
source, and fails if 'cnt" is >= 10.
A reproducer was sent to OLCF to isolate the issue.

OLCF suggested latest compiler version which fixed this issue.

Tests: E3SM test SMS_D_Ln1.ne30_ne30.FC5AV1C-L works with Intel version 18.0.1163. I tested both statically and dynamically linked versions. 

[BFB]