### PR TITLE
configurations to build on blake and white, Skylake and P100 testbeds…

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -517,6 +517,18 @@
      </queues>
    </batch_system>
 
+   <batch_system MACH="snl-white" type="lsf" >
+     <queues>
+       <queue walltimemax="02:00" default="true">rhel7G</queue>
+     </queues>
+   </batch_system>
+
+   <batch_system MACH="snl-blake" type="slurm" >
+     <queues>
+       <queue walltimemax="02:00" default="true">blake</queue>
+     </queues>
+   </batch_system>
+
    <batch_system MACH="lawrencium-lr2" type="slurm" >
      <directives>
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1444,6 +1444,65 @@ for mct, etc.
   </SLIBS>
 </compiler>
 
+<compiler COMPILER="gnu" MACH="snl-white">
+  <MPICXX>/ascldap/users/mdeakin/tpl-sources/kokkos/bin/nvcc_wrapper</MPICXX>
+  <KOKKOS_PATH>/ascldap/users/mdeakin/white/kokkos-release</KOKKOS_PATH>
+  <CXXFLAGS>
+    <append>-expt-extended-lambda -DCUDA_BUILD</append>
+  </CXXFLAGS>
+</compiler>
+
+<compiler COMPILER="intel18" MACH="snl-blake">
+  <CPPDEFS>
+    <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL </append>
+  </CPPDEFS>
+  <CFLAGS>
+    <base> -xCORE_AVX512 -mkl -std=gnu99 </base>
+    <append DEBUG="FALSE"> -O3 -g -debug minimal </append>
+    <append DEBUG="TRUE"> -O0 -g </append>
+  </CFLAGS>
+  <CXXFLAGS>
+    <base> -xCORE_AVX512 -mkl -std=c++11 </base>
+    <append DEBUG="FALSE"> -O3 -g -debug minimal </append>
+    <append DEBUG="TRUE"> -O0 -g </append>
+    <append compile_threaded="true"> -qopenmp </append>
+  </CXXFLAGS>
+  <FFLAGS>
+    <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -xCORE_AVX512 -mkl </base>
+    <append compile_threaded="true"> -qopenmp </append>
+    <append DEBUG="FALSE"> -O3 -g -debug minimal </append>
+    <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
+  </FFLAGS>
+  <LDFLAGS>
+    <base> -mkl </base>
+    <append compile_threaded="true"> -qopenmp </append>
+    <append MODEL="driver">-L$(NETCDF_FORTRAN_PATH)/lib64</append>
+  </LDFLAGS>
+  <FFLAGS_NOOPT>
+    <base> -O0 </base>
+    <append compile_threaded="true"> -qopenmp </append>
+  </FFLAGS_NOOPT>
+  <FIXEDFLAGS>
+    <base> -fixed -132 </base>
+  </FIXEDFLAGS>
+  <FREEFLAGS>
+    <base> -free </base>
+  </FREEFLAGS>
+  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
+  <FC_AUTO_R8>
+    <base> -r8 </base>
+  </FC_AUTO_R8>
+  <SFC> ifort </SFC>
+  <SCC> icc </SCC>
+  <SCXX> icpc </SCXX>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <CXX_LDFLAGS>
+    <base> -cxxlib </base>
+  </CXX_LDFLAGS>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <KOKKOS_PATH>/ascldap/users/mdeakin/blake/kokkos-release</KOKKOS_PATH>
+</compiler>
+
 <compiler MACH="mesabi" COMPILER="intel">
   <CFLAGS>
     <base> -O2 -fp-model precise -I/soft/intel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/inc

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -728,6 +728,95 @@
     </environment_variables>
 </machine>
 
+<machine MACH="snl-white">
+    <DESC>IBM Power 8 Testbed machine</DESC>
+    <NODENAME_REGEX>white</NODENAME_REGEX>
+    <BATCH_SYSTEM>lsf</BATCH_SYSTEM>
+    <OS>LINUX</OS>
+    <TESTS>e3sm_developer</TESTS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>openmpi</MPILIBS>
+    <RUNDIR>$ENV{HOME}/projects/e3sm/scratch/$CASE/run</RUNDIR>
+    <EXEROOT>$ENV{HOME}/projects/e3sm/scratch/$CASE/bld</EXEROOT>
+    <DIN_LOC_ROOT>$ENV{HOME}/projects/e3sm/cesm-inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/projects/e3sm/ptclm-data</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$ENV{HOME}/projects/e3sm/scratch/archive/$CASE</DOUT_S_ROOT>
+    <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
+    <CIME_OUTPUT_ROOT>$ENV{HOME}/projects/e3sm/scratch</CIME_OUTPUT_ROOT>
+    <BASELINE_ROOT>$ENV{HOME}/projects/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
+    <SUPPORTED_BY>mdeakin at sandia dot gov</SUPPORTED_BY>
+    <GMAKE_J>32</GMAKE_J>
+    <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>1</MAX_MPITASKS_PER_NODE>
+    <module_system type="module" allow_error="true">
+      <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
+      <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="python">module</cmd_path>
+      <modules>
+	<command name="load">cuda/9.0.176</command>
+	<command name="load">gcc/7.2.0</command>
+	<command name="load">zlib/1.2.8</command>
+	<command name="load">openblas/0.2.20/gcc/7.2.0</command>
+	<command name="load">openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176</command>
+	<command name="load">netcdf-exo/4.4.1.1/openmpi/2.1.2/gcc/7.2.0/cuda/9.0.176</command>
+      </modules>
+    </module_system>
+    <environment_variables>
+      <env name="NETCDF_C_PATH">$ENV{NETCDF_ROOT}</env>
+      <env name="NETCDF_FORTRAN_PATH">$ENV{NETCDFF_ROOT}</env>
+    </environment_variables>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments></arguments>
+    </mpirun>
+</machine>
+
+<machine MACH="snl-blake">
+    <DESC>Skylake Testbed machine</DESC>
+    <NODENAME_REGEX>blake</NODENAME_REGEX>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <OS>LINUX</OS>
+    <TESTS>e3sm_developer</TESTS>
+    <COMPILERS>intel18</COMPILERS>
+    <MPILIBS>openmpi</MPILIBS>
+    <RUNDIR>$ENV{HOME}/projects/e3sm/scratch/$CASE/run</RUNDIR>
+    <EXEROOT>$ENV{HOME}/projects/e3sm/scratch/$CASE/bld</EXEROOT>
+    <DIN_LOC_ROOT>$ENV{HOME}/projects/e3sm/cesm-inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/projects/e3sm/ptclm-data</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$ENV{HOME}/projects/e3sm/scratch/archive/$CASE</DOUT_S_ROOT>
+    <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
+    <CIME_OUTPUT_ROOT>$ENV{HOME}/projects/e3sm/scratch</CIME_OUTPUT_ROOT>
+    <BASELINE_ROOT>$ENV{HOME}/projects/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
+    <SUPPORTED_BY>mdeakin at sandia dot gov</SUPPORTED_BY>
+    <GMAKE_J>48</GMAKE_J>
+    <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>48</MAX_MPITASKS_PER_NODE>
+    <module_system type="module" allow_error="true">
+      <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
+      <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="python">module</cmd_path>
+      <modules>
+	<command name="load">zlib/1.2.11</command>
+	<command name="load">intel/compilers/18.1.163</command>
+	<command name="load">openmpi/2.1.2/intel/18.1.163</command>
+	<command name="load">hdf5/1.10.1/openmpi/2.1.2/intel/18.1.163</command>
+	<command name="load">netcdf-exo/4.4.1.1/openmpi/2.1.2/intel/18.1.163</command>
+      </modules>
+    </module_system>
+    <environment_variables>
+      <env name="NETCDF_C_PATH">$ENV{NETCDF_ROOT}</env>
+      <env name="NETCDF_FORTRAN_PATH">$ENV{NETCDFF_ROOT}</env>
+    </environment_variables>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments></arguments>
+    </mpirun>
+</machine>
+
 <machine MACH="anlworkstation">
     <DESC>Linux workstation for ANL</DESC>
     <NODENAME_REGEX>compute.*mcs.anl.gov</NODENAME_REGEX>

--- a/cime/config/xml_schemas/config_compilers_v2.xsd
+++ b/cime/config/xml_schemas/config_compilers_v2.xsd
@@ -141,6 +141,7 @@
     <xs:choice>
       <xs:element name="ALBANY_PATH" type="systemPath"/>
       <xs:element name="CFLAGS" type="flagsVar"/>
+      <xs:element name="CXXFLAGS" type="flagsVar"/>
       <xs:element name="CMAKE_OPTS" type="flagsVar"/>
       <xs:element name="CONFIG_ARGS" type="flagsVar"/>
       <xs:element name="CONFIG_SHELL" type="systemPath"/>
@@ -157,6 +158,7 @@
       <xs:element name="FREEFLAGS" type="flagsVar"/>
       <xs:element name="HAS_F2008_CONTIGUOUS" type="upperBoolean"/>
       <xs:element name="HDF5_PATH" type="systemPath"/>
+      <xs:element name="KOKKOS_PATH" type="systemPath"/>
       <xs:element name="LAPACK_LIBDIR" type="systemPath"/>
       <xs:element name="LD" type="systemPath"/>
       <xs:element name="LDFLAGS" type="flagsVar"/>

--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -180,7 +180,7 @@ ifdef NETCDF_C_PATH
     LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
   endif
   ifndef LIB_NETCDF_FORTRAN
-    LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
+    LIB_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/lib
   endif
  else ifdef NETCDF_FORTRAN_PATH
   $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")


### PR DESCRIPTION
… respectively.

Currently this fails to run on blake, and I can't test on white since the P100 nodes are down.
This also has a fix for building with separate netcdf-c and netcdf-fortran libraries

blake failure:
```
 Failed to open file idmap
 ERROR: (shr_mct_sMatReaddnc)No such file or directory
Image              PC                Routine            Line        Source             
e3sm.exe           000000000092A926  Unknown               Unknown  Unknown
e3sm.exe           0000000000556522  shr_abort_mod_mp_         114  shr_abort_mod.F90
e3sm.exe           000000000063B940  shr_mct_mod_mp_sh         513  shr_mct_mod.F90
e3sm.exe           0000000000640B00  shr_mct_mod_mp_sh         349  shr_mct_mod.F90
e3sm.exe           00000000004E6AA1  seq_map_mod_mp_se         143  seq_map_mod.F90
e3sm.exe           0000000000472DB3  prep_ocn_mod_mp_p         308  prep_ocn_mod.F90
e3sm.exe           0000000000429E03  cime_comp_mod_mp_        1626  cime_comp_mod.F90
e3sm.exe           0000000000431207  MAIN__                     92  cime_driver.F90
e3sm.exe           00000000004149DE  Unknown               Unknown  Unknown
libc-2.17.so       00002B53A4B0CC05  __libc_start_main     Unknown  Unknown
e3sm.exe           00000000004148E9  Unknown               Unknown  Unknown
```