### PR TITLE
Output MPI task to compute node mapping

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1675,13 +1675,11 @@
     <environment_variables>
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
+      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
       <env name="MPAS_TOOL_DIR">/projects/ccsm/acme/tools/mpas</env>
       <env name="HDF5_DISABLE_VERSION_CHECK">2</env>
       <env name="labeling"> </env>
       <env name="SMP_VARS"> </env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
-      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="intel">
       <env name="SMP_VARS">-e OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS} -e OMP_STACKSIZE=128M -e KMP_AFFINITY=granularity=thread,scatter</env>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -183,7 +183,7 @@
   <environment_variables>
     <env name="MPICH_ENV_DISPLAY">1</env>
     <env name="MPICH_VERSION_DISPLAY">1</env>
-    <env name="MPICH_CPUMASK_DISPLAY">1</env>
+    <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
 
     <env name="OMP_STACKSIZE">64M</env>
     <env name="OMP_PROC_BIND">spread</env>
@@ -327,7 +327,7 @@
 
     <env name="MPICH_ENV_DISPLAY">1</env>
     <env name="MPICH_VERSION_DISPLAY">1</env>
-    <env name="MPICH_CPUMASK_DISPLAY">1</env>
+    <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
 
     <env name="OMP_STACKSIZE">128M</env>
     <env name="OMP_PROC_BIND">spread</env>
@@ -483,7 +483,7 @@
   <environment_variables>
     <env name="MPICH_ENV_DISPLAY">1</env>
     <env name="MPICH_VERSION_DISPLAY">1</env>
-    <env name="MPICH_CPUMASK_DISPLAY">1</env>
+    <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
 
     <env name="OMP_STACKSIZE">128M</env>
     <env name="OMP_PROC_BIND">spread</env>
@@ -1245,7 +1245,7 @@
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" mpilib="mvapich">
       <!--e.g. 6 threads: MV2_CPU_MAPPING=0-5:6-11:12-17:18-23:24-29:30-35: -->
-      <env name="MV2_CPU_MAPPING">$SHELL{t=$ENV{OMP_NUM_THREADS};b=0;r=$[36/$t];while [ $r -gt 0 ];do printf "$b-$[$b+$t-1]:";((r--));((b=b+t));done;}</env>
+      <!--env name="MV2_CPU_MAPPING">$SHELL{t=$ENV{OMP_NUM_THREADS};b=0;r=$[36/$t];while [ $r -gt 0 ];do printf "$b-$[$b+$t-1]:";((r--));((b=b+t));done;}</env-->
     </environment_variables>
     <environment_variables DEBUG="TRUE" mpilib="mvapich">
       <env name="MV2_SHOW_CPU_BINDING">1</env>
@@ -1681,7 +1681,7 @@
       <env name="SMP_VARS"> </env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
-      <env name="MPICH_CPUMASK_DISPLAY">1</env>
+      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="intel">
       <env name="SMP_VARS">-e OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS} -e OMP_STACKSIZE=128M -e KMP_AFFINITY=granularity=thread,scatter</env>
@@ -2247,7 +2247,7 @@
         <env name="MPILIB">$MPILIB</env>
         <env name="MPICH_ENV_DISPLAY">1</env>
         <env name="MPICH_VERSION_DISPLAY">1</env>
-        <env name="MPICH_CPUMASK_DISPLAY">1</env>
+        <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
         <env name="MPSTKZ">128M</env>
         <env name="OMP_STACKSIZE">128M</env>
       </environment_variables>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1245,7 +1245,7 @@
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" mpilib="mvapich">
       <!--e.g. 6 threads: MV2_CPU_MAPPING=0-5:6-11:12-17:18-23:24-29:30-35: -->
-      <!--env name="MV2_CPU_MAPPING">$SHELL{t=$ENV{OMP_NUM_THREADS};b=0;r=$[36/$t];while [ $r -gt 0 ];do printf "$b-$[$b+$t-1]:";((r--));((b=b+t));done;}</env-->
+      <env name="MV2_CPU_MAPPING">$SHELL{t=$ENV{OMP_NUM_THREADS};b=0;r=$[36/$t];while [ $r -gt 0 ];do printf "$b-$[$b+$t-1]:";((r--));((b=b+t));done;}</env>
     </environment_variables>
     <environment_variables DEBUG="TRUE" mpilib="mvapich">
       <env name="MV2_SHOW_CPU_BINDING">1</env>

--- a/cime/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/cime/src/drivers/mct/shr/seq_comm_mct.F90
@@ -224,6 +224,7 @@ contains
     integer, pointer :: comps(:) ! array with component ids
     integer, pointer :: comms(:) ! array with mpicoms
     integer :: nu
+    character(len=8) :: c_global_numpes ! global number of pes
     character(len=seq_comm_namelen) :: valid_comps(ncomps)
 
     integer :: &
@@ -295,8 +296,9 @@ contains
 
     ! output task-to-node mapping
     if (mype == 0) then
-       write(logunit,100) global_numpes
-100    format(//,i7,' pes participating in computation of coupled model')
+       write(c_global_numpes,'(i8)') global_numpes
+       write(logunit,100) trim(adjustl(c_global_numpes))
+100    format(/,a,' pes participating in computation of coupled model')
        call shr_sys_flush(logunit)
     endif
     call t_startf("shr_taskmap_write")

--- a/cime/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/cime/src/drivers/mct/shr/seq_comm_mct.F90
@@ -16,12 +16,14 @@ module seq_comm_mct
 !!! the namelist).  ARE OTHER PROTECTIONS/CHECKS NEEDED???
 
 
-  use mct_mod     , only : mct_world_init, mct_world_clean, mct_die
-  use shr_sys_mod , only : shr_sys_abort, shr_sys_flush
-  use shr_mpi_mod , only : shr_mpi_chkerr, shr_mpi_bcast, shr_mpi_max
-  use shr_file_mod, only : shr_file_getUnit, shr_file_freeUnit
-  use esmf        , only : ESMF_LogKind_Flag, ESMF_LOGKIND_NONE
-  use esmf        , only : ESMF_LOGKIND_SINGLE, ESMF_LOGKIND_MULTI
+  use mct_mod        , only : mct_world_init, mct_world_clean, mct_die
+  use shr_sys_mod    , only : shr_sys_abort, shr_sys_flush
+  use shr_mpi_mod    , only : shr_mpi_chkerr, shr_mpi_bcast, shr_mpi_max
+  use shr_file_mod   , only : shr_file_getUnit, shr_file_freeUnit
+  use shr_taskmap_mod, only : shr_taskmap_write
+  use perf_mod       , only : t_startf, t_stopf
+  use esmf           , only : ESMF_LogKind_Flag, ESMF_LOGKIND_NONE
+  use esmf           , only : ESMF_LOGKIND_SINGLE, ESMF_LOGKIND_MULTI
 
   implicit none
 
@@ -290,6 +292,16 @@ contains
        write(logunit,*) trim(subname),' ERROR: numpes driver: ', numpes, ' should divide global_numpes: ',global_numpes
        call shr_sys_abort(trim(subname)//' ERROR decomposition error ')
     endif
+
+    ! output task-to-node mapping
+    if (mype == 0) then
+       write(logunit,100) global_numpes
+100    format(//,i7,' pes participating in computation of coupled model')
+       call shr_sys_flush(logunit)
+    endif
+    call t_startf("shr_taskmap_write")
+    call shr_taskmap_write(logunit, GLOBAL_COMM_IN, 'GLOBAL')
+    call t_stopf("shr_taskmap_write")
 
     ! Initialize gloiam on all IDs
 

--- a/cime/src/share/util/shr_taskmap_mod.F90
+++ b/cime/src/share/util/shr_taskmap_mod.F90
@@ -100,6 +100,13 @@ module shr_taskmap_mod
       ! node names without duplicates
       character(len=mpi_max_processor_name), allocatable :: node_names(:)  
 
+      ! string versions of numerical values
+      character(len=8) :: c_npes       ! number of MPI tasks
+      character(len=8) :: c_nnodes     ! number of nodes
+      character(len=8) :: c_nodeid     ! node id
+      character(len=8) :: c_node_npes  ! number of MPI tasks for a given node
+      character(len=8) :: c_taskid     ! MPI task id
+
       ! routine name, for error reporting
       character(*),parameter :: subname = "(shr_taskmap_write)"
 
@@ -254,19 +261,30 @@ module shr_taskmap_mod
          ! Output node/task mapping
          !
          write(unit_num,100) '--------------------------------------------------------------'
-100 format(a)
-         write(unit_num,101) trim(comm_name),nnodes,npes
-101 format(a,' communicator : ',I6,' nodes, ',I7,' MPI tasks')
+100      format(a)
+
+         write(c_npes,'(i8)') npes
+         write(c_nnodes,'(i8)') nnodes
+         write(unit_num,101) trim(comm_name), trim(adjustl(c_nnodes)), trim(adjustl(c_npes))
+101      format(a,' communicator : ',a,' nodes, ',a,' MPI tasks')
+
          write(unit_num,100) 'COMMUNICATOR NODE # [NODE NAME] : (# OF MPI TASKS) TASK # LIST'
+
          do j=0,nnodes-1
-            write(unit_num,102,advance='no') trim(comm_name),j,trim(node_names(j)), node_task_cnt(j)
-102 format(a,' NODE ',I6,' [ ',a,' ] : ( ',I7,' MPI TASKS )')
+            write(c_nodeid,'(i8)') j
+            write(c_node_npes,'(i8)') node_task_cnt(j)
+            write(unit_num,102,advance='no') trim(comm_name), trim(adjustl(c_nodeid)), &
+                                             trim(node_names(j)), trim(adjustl(c_node_npes))
+102         format(a,' NODE ',a,' [ ',a,' ] : ( ',a,' MPI TASKS )')
+
             do i=node_task_offset(j),node_task_offset(j)+node_task_cnt(j)-1
-               write(unit_num,103,advance='no') node_task_map(i)
+               write(c_taskid,'(i8)') node_task_map(i)
+               write(unit_num,103,advance='no') trim(adjustl(c_taskid))
+103            format(' ',a)
             enddo
-103 format(I7, " ")
+
             write(unit_num,104,advance='no')
-104 format(/)
+104         format(/)
          enddo
          write(unit_num,100) '--------------------------------------------------------------'
 

--- a/cime/src/share/util/shr_taskmap_mod.F90
+++ b/cime/src/share/util/shr_taskmap_mod.F90
@@ -253,20 +253,22 @@ module shr_taskmap_mod
          !
          ! Output node/task mapping
          !
-         write(unit_num,*) '-----------------------------------'
-         write(unit_num,*) trim(comm_name),': ',nnodes,' NODES, ',npes,' MPI TASKS'
-         write(unit_num,*) 'NODE NAME : ',trim(comm_name),' TASK #'
+         write(unit_num,100) '--------------------------------------------------------------'
+100 format(a)
+         write(unit_num,101) trim(comm_name),nnodes,npes
+101 format(a,' communicator : ',I6,' nodes, ',I7,' MPI tasks')
+         write(unit_num,100) 'COMMUNICATOR NODE # [NODE NAME] : (# OF MPI TASKS) TASK # LIST'
          do j=0,nnodes-1
-            write(unit_num,101,advance='no') trim(node_names(j))
-101 format(a," : ")
+            write(unit_num,102,advance='no') trim(comm_name),j,trim(node_names(j)), node_task_cnt(j)
+102 format(a,' NODE ',I6,' [ ',a,' ] : ( ',I7,' MPI TASKS )')
             do i=node_task_offset(j),node_task_offset(j)+node_task_cnt(j)-1
-               write(unit_num,102,advance='no') node_task_map(i)
+               write(unit_num,103,advance='no') node_task_map(i)
             enddo
-102 format(I7, " ")
-            write(unit_num,103,advance='no')
-103 format(/)
+103 format(I7, " ")
+            write(unit_num,104,advance='no')
+104 format(/)
          enddo
-         write(unit_num,*) '-----------------------------------'
+         write(unit_num,100) '--------------------------------------------------------------'
 
          if (broadcast_nnodes) then
             save_nnodes = nnodes


### PR DESCRIPTION
Currently MPI task to compute node mapping information is
output in two locations, once in CAM, where it is
truncated after the first 256 MPI tasks, and once in CLM,
where it is truncated after the first 100 MPI tasks,
both only for these two components. This is not useful in current
production runs. The use of environment variables, such as
MPICH_CPUMASK_DISPLAY on Cray systems, generate data that are
unnecessarily verbose for our needs. Here a share routine is
introduced that writes out one line per compute node. Each line
contains the compute node name and the list of MPI tasks assigned
to that node for a given communicator. This is then called
in the driver and writes out the task-to-node mapping for the
entire coupled model. Separate branches will then introduce
this into the individual components, replacing the current logic
in both CAM and CLM, for example.

The share routine also optionally returns the number of compute
nodes and the task-to-node mapping, which is needed in the
internal CAM load balancing.

With the call to the shr_taskmap_write routine in the
driver, the mapping data generated by the system when setting
the corresponding environment variable is redundant. This
is removed for the systems currently setting the variable.

Fixes #2457

BFB
