### PR TITLE
Add LC machines dependency option and debug queue.

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -182,11 +182,13 @@
 
   <!-- for lawrence livermore computing -->
   <batch_system type="lc_slurm">
+    <batch_query per_job_arg="-j">squeue</batch_query>
     <batch_submit>sbatch</batch_submit>
     <batch_cancel>scancel</batch_cancel>
     <batch_directive>#SBATCH</batch_directive>
     <jobid_pattern>(\d+)$</jobid_pattern>
-    <depend_string> -l depend=jobid</depend_string>
+    <depend_string>--dependency=afterok:jobid</depend_string>
+    <depend_allow_string>--dependency=afterany:jobid</depend_allow_string>
     <depend_separator>:</depend_separator>
     <walltime_format>%H:%M:%S</walltime_format>
     <batch_mail_flag>--mail-user</batch_mail_flag>
@@ -205,6 +207,7 @@
     </directives>
     <queues>
       <queue walltimemax="01:00:00" nodemax="270" default="true">pbatch</queue>
+      <queue walltimemax="00:30:00">pdebug</queue>
     </queues>
   </batch_system>
   <!-- for lawrence livermore computing -->


### PR DESCRIPTION
The LC machines' version of the "slurm" batch system uses the same
commands/options to queue up a dependent job as other slurm systems, but
this information was out of date or missing, so the relevant parts of
config_batch.xml had to be copied to the lc_slurm section.

This update also adds the "pdebug" queue, which is used for small
debugging and test runs.

[BFB]