### PR TITLE
Adds tests for land BGC

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -21,6 +21,10 @@ _TESTS = {
                              ("ERS.f09_g16.I1850CLM45CN","clm-bgcinterface"),
                               "ERS.ne11_oQU240.I20TRCLM45",
                              ("ERS.f19_g16.I1850CNRDCTCBC","clm-rd"),
+                             ("ERS.f19_g16.I1850GSWCNPECACNTBC","clm-eca_f19_g16_I1850GSWCNPECACNTBC"),
+                             ("ERS.f19_g16.I20TRGSWCNPECACNTBC","clm-eca_f19_g16_I20TRGSWCNPECACNTBC"),
+                             ("ERS.f19_g16.I1850GSWCNPRDCTCBC","clm-ctc_f19_g16_I1850GSWCNPRDCTCBC"),
+                             ("ERS.f19_g16.I20TRGSWCNPRDCTCBC","clm-ctc_f19_g16_I20TRGSWCNPRDCTCBC"),
                               "ERS.f09_g16.ICLM45BC")
                              ),
 

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I1850GSWCNPRDCTCBC/shell_commands
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I1850GSWCNPRDCTCBC/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange DATM_CLMNCEP_YR_END=1901

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I1850GSWCNPRDCTCBC/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I1850GSWCNPRDCTCBC/user_nl_clm
@@ -1,0 +1,2 @@
+finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I1850GSWCNPRDCTCBC.f19_g16.0401-01-01-00000.nc'
+

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I20TRGSWCNPRDCTCBC/shell_commands
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I20TRGSWCNPRDCTCBC/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange DATM_CLMNCEP_YR_END=1901

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I20TRGSWCNPRDCTCBC/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I20TRGSWCNPRDCTCBC/user_nl_clm
@@ -1,0 +1,2 @@
+finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I20TRGSWCNPRDCTCBC.f19_g16.0401-01-01-00000.nc'
+

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I1850GSWCNPECACNTBC/shell_commands
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I1850GSWCNPECACNTBC/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange DATM_CLMNCEP_YR_END=1901

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I1850GSWCNPECACNTBC/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I1850GSWCNPECACNTBC/user_nl_clm
@@ -1,0 +1,3 @@
+finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I1850GSWCNPECACNTBC.f19_g16.0201-01-01-00000.nc'
+NFIX_PTASE_plant = .true.
+

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I20TRGSWCNPECACNTBC/shell_commands
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I20TRGSWCNPECACNTBC/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange DATM_CLMNCEP_YR_END=1901

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I20TRGSWCNPECACNTBC/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I20TRGSWCNPECACNTBC/user_nl_clm
@@ -1,0 +1,2 @@
+finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I1850GSWCNPECACNTBC.f19_g16.0201-01-01-00000.nc'
+


### PR DESCRIPTION
Adds ERS test for ECA and CTS for 1850 and 20-th century transient
at f19_g16 resolution with spun up initial conditions

Fixes #2465
[BFB]
