### PR TITLE
Update edison to use cray-mpich 7.7.0 from 7.6.0 

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -130,7 +130,7 @@
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.12</command>
       <command name="rm">cray-mpich</command>
-      <command name="load">cray-mpich/7.6.0</command>
+      <command name="load">cray-mpich/7.7.0</command>
     </modules>
 
     <modules compiler="intel">


### PR DESCRIPTION
After software maintenance, the version of mpich we were using on edison was removed. This change simply uses the default version of the machine which is now 7.7.0 (previously 7.6.0).

Fixes #2471 