### PR TITLE
For edison, add command "module load pe_archive" to allow using older modules, such as cray-mpich/7.6.0

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -130,6 +130,7 @@
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.12</command>
       <command name="rm">cray-mpich</command>
+      <command name="load">pe_archive</command>
       <command name="load">cray-mpich/7.6.0</command>
     </modules>
 


### PR DESCRIPTION
For edison, add command "module load pe_archive" to allow using older modules, such as cray-mpich/7.6.0 that was recently removed from the default view of modules.

Fixes #2463
