### PR TITLE
Add MVK climate reproducibility test

### DIFF
--- a/cime/config/config_tests.xml
+++ b/cime/config/config_tests.xml
@@ -542,6 +542,16 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <MULTI_DRIVER>TRUE</MULTI_DRIVER>
   </test>
 
+  <test NAME="MVK">
+    <DESC>climate reproducibility test using the multivariate K-S test</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>none</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+  </test>
+
   <test NAME="NCK">
     <DESC>multi-instance validation vs single instance (default length)</DESC>
     <INFO_DBUG>1</INFO_DBUG>

--- a/cime/config/config_tests.xml
+++ b/cime/config/config_tests.xml
@@ -547,6 +547,8 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <INFO_DBUG>1</INFO_DBUG>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <STOP_OPTION>ndays</STOP_OPTION>
+    <STOP_N>400</STOP_N>
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>

--- a/cime/config/config_tests.xml
+++ b/cime/config/config_tests.xml
@@ -547,11 +547,13 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <INFO_DBUG>1</INFO_DBUG>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <STOP_OPTION>ndays</STOP_OPTION>
-    <STOP_N>400</STOP_N>
-    <REST_OPTION>none</REST_OPTION>
+    <STOP_OPTION>nmonths</STOP_OPTION>
+    <STOP_N>7</STOP_N>
+    <REST_OPTION>$STOP_OPTION</REST_OPTION>
+    <REST_N>$STOP_N</REST_N>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
+    <RESUBMIT>1</RESUBMIT>
   </test>
 
   <test NAME="NCK">

--- a/cime/config/config_tests.xml
+++ b/cime/config/config_tests.xml
@@ -548,12 +548,12 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <STOP_OPTION>nmonths</STOP_OPTION>
-    <STOP_N>7</STOP_N>
+    <STOP_N>2</STOP_N>
     <REST_OPTION>$STOP_OPTION</REST_OPTION>
     <REST_N>$STOP_N</REST_N>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <RESUBMIT>1</RESUBMIT>
+    <RESUBMIT>6</RESUBMIT>
   </test>
 
   <test NAME="NCK">

--- a/cime/scripts/climate_reproducibility/README.md
+++ b/cime/scripts/climate_reproducibility/README.md
@@ -1,0 +1,234 @@
+Climate reproducibility testing
+===============================
+
+Requiring model changes to pass stringent tests before being accepted as part of E3SM’s main development 
+branch is critical for quickly and efficiently producing a trustworthy model.  Depending on their
+impacts on model output, code modifications can be classified into three types:
+
+1. Technical changes that continue to produce bit-for-bit identical solutions
+2. Changes that cause the model solution to differ,  yet produce a statistically identical climate when
+   averaged over a sufficiently long time
+3. Changes that lead to a different model climate
+
+Only (3) impacts model climate, and changes of this type should only be implemented within the code 
+after an in-depth demonstration of improvement. However, distinguishing between (2) and (3) requires
+a comprehensive analysis of both a baseline climate and the currently produced climate.   
+
+Through the CMDV Software project, we've provided a set of climate reproducibility tests to determine
+whether or not non-bit-for-bit (nb4b) model changes are climate changing. The current tests provided are:
+
+* **MVK** --  This tests the null hypothesis that the baseline (n) and modified (m) model Short Independent 
+  Simulation Ensembles (SISE) represent the same climate state, based on the equality of distribution 
+  of each variable's annual global average in the standard monthly model output between the two 
+  simulations. The (per variable) null hypothesis uses the non-parametric, two-sample (n and m) 
+  Kolmogorov-Smirnov test as the univariate test of of equality of distribution of global means.
+ 
+ 
+Running the tests
+-----------------
+
+These tests are built into E3SM-CIME as system tests and will be launched using the `create_test` scripts. 
+*However*, since these tests use high level statistics, they have additional python dependencies which
+need to be installed on your system and accessible via the compute nodes (if you're on a batch machine).
+Primarily, the statistical analysis of the climates is done through [EVV](https://github.com/LIVVkit/evv4esm) 
+(confluence page: [EVV](https://acme-climate.atlassian.net/wiki/spaces/EIDMG/pages/774177270/EVV)) which will
+generate a portable test website to describe the results (pass or fail) in detail (see the extended output 
+section below). The full set of additional requirements are listed in the `requirements.txt` file in this directory. To install these
+dependencies, make sure a python version `> 2.7` is loaded/installed, and then use `pip` like: 
+
+```
+pip install --user -r requirements.txt
+``` 
+
+*NOTE: Work is underway to include all of these dependencies in the* `e3sm_unified` *conda environment,
+and allow CIME to optionally load and use this environment for these tests. Once this is done, you will
+not have to manage these dependencies yourself. If you run into problems with getting these dependencies
+working on your machine, please open an issue on E3SM's Github and tag @jhkennedy, or send 
+Joseph H. Kennedy <kennedyjh@ornl.gov> an email.*
+
+After the dependencies are installed, change to the `$E3SM/cime/scripts` directory (where `$E3SM` is the 
+directory containing E3SM). Then to run one of the tests, you will use the `create_test` script like normal. 
+To run the `MVK` test and generate a baseline, you would run a command like: 
+
+```
+./create_test MVK_PL.ne4_oQU240.FC5AV1C-04P2 -g --baseline-root "/PATH/TO/BASELINE" 
+```
+
+And to compare to the baseline, you would run a command like: 
+
+
+```
+./create_test MVK_PL.ne4_oQU240.FC5AV1C-04P2 -c --baseline-root "/PATH/TO/BASELINE" 
+```
+
+Importantly, these tests run a 20 member ensemble for at least 13 months (using the last 12 for the 
+statistical tests) and, depending on the machine, may take some fiddling to execute within a particular 
+queue's wallclock time limit. You may want to over-ride the requested walltime using `--walltime HH:MM:SS` 
+option to `create_test`. Additionally, if messing with the wallclock time isn't enough, you can adjust the 
+`STOP_N` and `RESUBMIT` setting for the tests in `$E3SM/cime/config/config_tests.xml`. For example, the
+MVK test is setup like:   
+
+```xml
+  <test NAME="MVK">
+    <DESC>climate reproducibility test using the multivariate K-S test</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <STOP_OPTION>nmonths</STOP_OPTION>
+    <STOP_N>2</STOP_N>
+    <REST_OPTION>$STOP_OPTION</REST_OPTION>
+    <REST_N>$STOP_N</REST_N>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+    <RESUBMIT>6</RESUBMIT>
+  </test>
+```  
+
+which will submit a job to run for two months, stop, and then resubmit itself 6 more times (continuing from 
+where it left off), leading to 14 months of simulation time. These settings, combined with the 
+`--walltime 02:00:00` option, allowed this test to run successfully on OLCF's Titan machine. The full set of
+commands to run the MVK test used on titan are:
+
+*Install dependencies (only need to do once):*
+```
+module load python
+cd $E3SM/cime/scripts/climate_reproducibility
+python pip --user -r requirements.txt
+``` 
+
+*Generate a baseline:*
+```
+module load python  # need python 2.7; default is 2.6
+cd $E3SM/cime/scripts
+./create_test MVK_PL.ne4_oQU240.FC5AV1C-04P2 --baseline-root "${PROJWORK}/cli115/${USER}/baselines" -g --walltime 02:00:00
+```
+
+*Compare to a baseline:*
+```
+module load python  # need python 2.7; default is 2.6
+cd $E3SM/cime/scripts
+./create_test MVK_PL.ne4_oQU240.FC5AV1C-04P2 --baseline-root "${PROJWORK}/cli115/${USER}/baselines" -c --walltime 02:00:00
+```
+
+Test pass/fail and extended output
+----------------------------------
+
+When you launch these tests, CIME will ouput the location of the case directory, which will look 
+something like this:
+
+```
+# On titan:
+./create_test MVK_PL.ne4_oQU240.FC5AV1C-04P2 --baseline-root "${PROJWORK}/cli115/${USER}/baselines" -c --walltime 02:00:00
+    Creating test directory /ccs/home/$USER/acme_scratch/cli115/MVK_PL.ne4_oQU240.FC5AV1C-04P2.titan_pgi.C.YYYYMMDD_HHMMSS_RANDOMID
+```
+
+Let's call that directory `$CASE_DIR`. Once all the jobs are finished, navigate to that directory and 
+you can `cat TestStatus` to determine if the test passed or failed by looking at the `BASELINE` status:  
+
+```
+cd $CASE_DIR
+view TestStatus
+    ...
+    PASS MVK_PL.ne4_oQU240.FC5AV1C-04P2.titan_pgi BASELINE
+    ...
+
+```
+
+To get some basic summary statistics about the test that was run, look in the output of the final job 
+submission for EVV's analysis:
+
+ ```
+view MVK_PL.ne4_oQU240.FC5AV1C-04P2.titan_pgi.C.YYYYMMDD_HHMMSS_RANDOMID.test.oJOBID
+    ...
+    -------------------------------------------------------------------- 
+                       ______  __      __ __      __                     
+                      |  ____| \ \    / / \ \    / /                     
+                      | |__     \ \  / /   \ \  / /                      
+                      |  __|     \ \/ /     \ \/ /                       
+                      | |____     \  /       \  /                        
+                      |______|     \/         \/                         
+                                                                         
+        Extended Verification and Validation for Earth System Models     
+    -------------------------------------------------------------------- 
+     
+      Current run: 2018-08-02 23:24:26 
+      User: kennedy 
+      OS Type: Linux 3.0.101-0.46.1_1.0502.8871-cray_gem_s 
+      Machine: titan-batch7 
+       
+    ------------------------------------------------------------------- 
+     ----------------------------------------------------------------- 
+       Beginning extensions test suite  
+     ----------------------------------------------------------------- 
+     
+        Kolmogorov-Smirnov Test: YYYYMMDD_HHMMSS_RANDOMID 
+          Variables analyzed: 378 
+          Rejecting: 9 
+          Critical value: 13.0 
+          Ensembles: identical 
+     
+     ----------------------------------------------------------------- 
+       Extensions test suite complete  
+     ----------------------------------------------------------------- 
+     
+    ------------------------------------------------------------------- 
+     Done!  Results can be seen in a web browser at: 
+       /lustre/atlas/proj-shared/cli115/$USER/MVK_PL.ne4_oQU240.FC5AV1C-04P2.titan_pgi.C.YYYYMMDD_HHMMSS_RANDOMID/run/MVK_PL.ne4_oQU240.FC5AV1C-04P2.titan_pgi.C.YYYYMMDD_HHMMSS_RANDOMID.eve/index.html 
+    -------------------------------------------------------------------
+    ...
+```
+
+EVV also prints the location of the output website where you can see the details of the analysis. For 
+the MVK test, you will be able to view per variable Q-Q plots, P-P plots, the K-S test statistic, and 
+whether it rejects or accepts the null hypothesis, as well as a description of the test itself -- you 
+can see an example of the output website [here](http://livvkit.github.io/evv4esm/).
+
+Please note: the output website uses some JavaScript to render elements of the page (especially figures), 
+and opening up the `index.html` file using the `file://` protocol in a web browser will likely not work 
+well (most browser have stopped allowing access to "local resources" like JavaScript through the `file://` 
+protocol). You can view the website by either copying it to a hosted location (`~/WWW` which is hosted at 
+`http://users.nccs.gov/~user` on Titan, for example) or copying it to your local machine and running a 
+local http server (included in python!) and viewing it through an address like `http://0.0.0.0:8000/index.html`.  
+
+**For the easiest viewing** we recommend copying the website to your local machine, and using EVV to 
+view it. you can install EVV locally by running this command (will work with both python and anaconda 
+environments):
+
+```
+pip install evv4esm
+``` 
+
+Then, copy the website to your local machine, and view it: 
+
+
+```
+# on your local machine
+scp -r /lustre/atlas/proj-shared/cli115/$USER/MVK_PL.ne4_oQU240.FC5AV1C-04P2.titan_pgi.C.YYYYMMDD_HHMMSS_RANDOMID/run/MVK_PL.ne4_oQU240.FC5AV1C-04P2.titan_pgi.C.YYYYMMDD_HHMMSS_RANDOMID.eve . 
+evv -o MVK_PL.ne4_oQU240.FC5AV1C-04P2.titan_pgi.C.YYYYMMDD_HHMMSS_RANDOMID.eve -s
+    --------------------------------------------------------------------
+                       ______  __      __ __      __                    
+                      |  ____| \ \    / / \ \    / /                    
+                      | |__     \ \  / /   \ \  / /                     
+                      |  __|     \ \/ /     \ \/ /                      
+                      | |____     \  /       \  /                       
+                      |______|     \/         \/                        
+                                                                        
+        Extended Verification and Validation for Earth System Models    
+    --------------------------------------------------------------------
+    
+      Current run: 2018-08-06 15:15:03
+      User: fjk
+      OS Type: Linux 4.15.0-29-generic
+      Machine: pc0101123
+      
+    
+    Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/)
+    
+    View the generated website by navigating to:
+    
+        http://0.0.0.0:8000/MVK_PL.ne4_oQU240.FC5AV1C-04P2.titan_pgi.C.YYYYMMDD_HHMMSS_RANDOMID.eve/index.html
+    
+    Exit by pressing `ctrl+c` to send a keyboard interrupt.
+    
+```
+

--- a/cime/scripts/climate_reproducibility/requirements.txt
+++ b/cime/scripts/climate_reproducibility/requirements.txt
@@ -4,5 +4,6 @@ scipy
 pandas
 netCDF4
 matplotlib
+evv4esm>=0.1.1
 livvkit>=2.1.6
 json_tricks==3.11.0

--- a/cime/scripts/climate_reproducibility/requirements.txt
+++ b/cime/scripts/climate_reproducibility/requirements.txt
@@ -1,0 +1,8 @@
+six
+numpy
+scipy
+pandas
+netCDF4
+matplotlib
+livvkit>=2.1.6
+json_tricks==3.11.0

--- a/cime/scripts/lib/CIME/SystemTests/mvk.py
+++ b/cime/scripts/lib/CIME/SystemTests/mvk.py
@@ -1,0 +1,115 @@
+"""
+Multivariate test for climate reproducibility using the Kolmogrov-Smirnov (K-S)
+test and based on The CESM/E3SM model's multi-instance capability is used to
+conduct an ensemble of simulations starting from different initial conditions.
+
+This class inherits from SystemTestsCommon.
+"""
+
+from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.case_setup import case_setup
+from CIME.build import post_build
+# import CIME.utils
+# from CIME.check_lockedfiles import *
+
+logger = logging.getLogger(__name__)
+
+
+class MVK(SystemTestsCommon):
+
+    def __init__(self, case):
+        """
+        initialize an object interface to the MVK test
+        """
+        SystemTestsCommon.__init__(self, case)
+
+
+    def build_phase(self, sharedlib_only=False, model_only=False):
+
+        # Build executable with multiple instances
+        ninst = 30
+
+        # BSINGH: For debugging only - Building the model can take
+        # significant amount of time. Setting fake_bld to True can save
+        # that time
+        fake_bld = False
+
+        # Only want this to happen once. It will impact the sharedlib build
+        # so it has to happen there.
+        if not model_only:
+            logging.warn('Starting to build multi-instance exe')
+            for comp in ['ATM', 'OCN', 'WAV', 'GLC', 'ICE', 'ROF', 'LND']:
+                ntasks = self._case.get_value("NTASKS_{}".format(comp))
+                self._case.set_value('ROOTPE_{}'.format(comp), 0)
+                self._case.set_value('NINST_{}'.format(comp), ninst)
+                self._case.set_value('NTASKS_{}'.format(comp), ntasks*ninst)
+
+            self._case.set_value('ROOTPE_CPL', 0)
+            self._case.set_value('NTASKS_CPL', ntasks*ninst)
+            self._case.flush()
+
+            case_setup(self._case, test_mode=False, reset=True)
+
+        # BSINGH: Faking a bld can save the time code spend in building the model components
+        if fake_bld:
+            if not sharedlib_only:
+                post_build(self._case, [])
+        else:
+            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+
+        # =================================================================
+        # Run-time settings.
+        # Do this already in build_phase so that we can check the xml and
+        # namelist files before job starts running.
+        # =================================================================
+
+        # namelist specifications for each instance
+        data_root = self._case.get_value("DIN_LOC_ROOT")
+        for iinst in range(1, ninst+1):
+            with open('user_nl_cam_{:04d}'.format(iinst), 'w') as nl_atm_file:
+                nl_atm_file.write("fincl2 = 'TS:A','TSMN:M','TSMX:X','PRECT:A','PRECTMX:X'")
+                nl_atm_file.write('mfilt = 1,30')
+                nl_atm_file.write('nhtfrq = 0,-24')
+
+                nl_atm_file.write('cldfrc_rhminl = 0.9100')
+                nl_atm_file.write('zmconv_c0_ocn = 0.0110')
+
+                nl_atm_file.write("rsf_file = '{}/atm/waccm/phot/RSF_GT200nm_v3.0_c080416.nc'".format(data_root))
+                nl_atm_file.write("bnd_topo = '{}/atm/cam/topo/USGS-gtopo30_1.9x2.5_smooth500-50_ne16np4_c050602.nc'".format(data_root))
+
+                nl_atm_file.write('phys_loadbalance = 0')
+                nl_atm_file.write('new_random = .true.')
+                nl_atm_file.write('pertlim = 1.0e-10')
+                nl_atm_file.write('seed_custom = {}'.format(iinst))
+
+            with open('user_nl_clm_{:04d}'.format(iinst), 'w') as nl_clm_file:
+                nl_clm_file.write("finidat = '/lustre/atlas/proj-shared/cli106/salil/archive/A_F.1850c5.ne16_g37.l2/rest/0100-11-01-00000/A_F.1850c5.ne16_g37.l2.clm2.r.0100-11-01-00000.nc'")
+
+
+# ------
+# Notes:
+# ------
+# Follow setup of cases in: /autofs/nccs-svm1_home1/salil/acme_cases/ne16_F1850C5_master/
+# User_nl_* changes:
+#   CAM:
+#       fincl2 = 'TS:A','TSMN:M','TSMX:X','PRECT:A','PRECTMX:X'
+#       mfilt = 1,30
+#       nhtfrq = 0,-24
+#
+#       cldfrc_rhminl = 0.9100
+#       zmconv_c0_ocn = 0.0110
+#
+#       rsf_file = '/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/waccm/phot/RSF_GT200nm_v3.0_c080416.nc'
+#       bnd_topo = '/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/cam/topo/USGS-gtopo30_1.9x2.5_smooth500-50_ne16np4_c050602.nc'
+#
+#       phys_loadbalance = 0
+#       new_random = .true.
+#       pertlim = 1.e-10
+#       seed_custom = 2
+#
+#   CLM:
+#       finidat = '/lustre/atlas/proj-shared/cli106/salil/archive/A_F.1850c5.ne16_g37.l2/rest/0100-11-01-00000/A_F.1850c5.ne16_g37.l2.clm2.r.0100-11-01-00000.nc'
+
+# Original case setup:
+# ./create_newcase -mach titan -compiler pgi -res ne16_g37 -compset F1850C5 -case /ccs/home/salil/acme_cases/F1850C5_08162017_master -project cli106

--- a/cime/scripts/lib/CIME/SystemTests/mvk.py
+++ b/cime/scripts/lib/CIME/SystemTests/mvk.py
@@ -9,9 +9,25 @@ This class inherits from SystemTestsCommon.
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case_setup import case_setup
-from CIME.build import post_build
-# import CIME.utils
-# from CIME.check_lockedfiles import *
+
+import CIME.test_status
+
+from livvkit.util import functions as lfn
+# FIXME: this is python2 only. Python 2 and 3 compatible is much hard, esp. if
+#        python 3.0--3.4 need to be supported
+# try:
+#     import livvkit
+# except ImportError:
+#     import pip
+#     pip.main(['install', '--user', 'livvkit'])
+#     import site
+#     reload(site)
+#     import livvkit
+
+# FIXME: remove once eve is a package, or inc. eve into CIME/SystemTest/Test_utils
+eve_lib_dir = '/ccs/home/kennedy/EVE/eve'
+sys.path.append(eve_lib_dir)
+import eve
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +39,8 @@ class MVK(SystemTestsCommon):
         initialize an object interface to the MVK test
         """
         SystemTestsCommon.__init__(self, case)
+
+        logger.info('MVK:INIT: {}'.format(self._compare_baseline()))
 
 
     def build_phase(self, sharedlib_only=False, model_only=False):
@@ -41,7 +59,7 @@ class MVK(SystemTestsCommon):
                 self._case.set_value('NTHRDS_{}'.format(comp), 1)
 
                 ntasks = self._case.get_value("NTASKS_{}".format(comp))
-                print('MVK:NTASKS_{}: {}'.format(comp, ntasks))
+                logger.info('MVK:NTASKS_{}: {}'.format(comp, ntasks))
                 self._case.set_value('NTASKS_{}'.format(comp), ntasks*scale_ntasks*ninst)
                 if comp != 'CPL':
                     self._case.set_value('NINST_{}'.format(comp), ninst)
@@ -49,7 +67,6 @@ class MVK(SystemTestsCommon):
             self._case.flush()
 
             case_setup(self._case, test_mode=False, reset=True)
-
 
         self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -60,7 +77,6 @@ class MVK(SystemTestsCommon):
         # =================================================================
 
         # namelist specifications for each instance
-        data_root = self._case.get_value("DIN_LOC_ROOT")
         for iinst in range(1, ninst+1):
             with open('user_nl_cam_{:04d}'.format(iinst), 'w') as nl_atm_file:
                 nl_atm_file.write("fincl2 = 'TS:A','TSMN:M','TSMX:X','PRECT:A','PRECTMX:X'\n")
@@ -71,19 +87,47 @@ class MVK(SystemTestsCommon):
                 nl_atm_file.write('zmconv_c0_ocn = 0.0074D0\n')
                 nl_atm_file.write('dtime = 5400\n')
 
-                # nl_atm_file.write("rsf_file = '{}/atm/waccm/phot/RSF_GT200nm_v3.0_c080416.nc'\n".format(data_root))
-                # nl_atm_file.write("bnd_topo = '{}/atm/cam/topo/USGS-gtopo30_1.9x2.5_smooth500-50_ne16np4_c050602.nc'\n".format(data_root))
-
                 # nl_atm_file.write('phys_loadbalance = 0\n')
                 nl_atm_file.write('new_random = .true.\n')
                 nl_atm_file.write('pertlim = 1.0e-10\n')
                 nl_atm_file.write('seed_custom = {}\n'.format(iinst))
 
-            # with open('user_nl_clm_{:04d}'.format(iinst), 'w') as nl_clm_file:
-            #     # nl_clm_file.write("finidat = '{}/lnd/clm2/initdata_map/clmi.I1850CLM45.ne30_g16.1155ba0.clm2.r.nc'\n".format(data_root))
-            #     nl_clm_file.write("finidat = '{}/lnd/clm2/initdata_map/clmi.I1850CLM45.ne16_qu240.d02c96d.clm2.r.0021-01-01-00000.nc'\n".format(data_root))
-
 
     def run_phase(self):
 
         self.run_indv()
+
+
+    # def _generate_baseline(self):
+    #     run_dir = self._case.get_value("RUNDIR")
+    #     basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))
+    #     logger.info('MVK:GENDIR: {}'.format(basegen_dir))
+    #
+    #     with self._test_status:
+    #         self._test_status.set_status(CIME.test_status.GENERATE_PHASE, CIME.test_status.TEST_PASS_STATUS)
+
+
+    def _compare_baseline(self):
+        logger.info('MVK:CMPR: {}'.format(self._case.get_value("COMPARE_BASELINE")))
+        logger.info('MVK:CMPR: {}'.format(type(self._case.get_value("COMPARE_BASELINE"))))
+
+        run_dir = self._case.get_value("RUNDIR")
+        case_name = self._case.get_value("CASE")
+        basegen_case = self._case.get_value("BASEGEN_CASE")
+        basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))
+
+        eve_config = {
+            "MVK_{}".format(case_name): {
+                "module": os.path.join(eve_lib_dir, "extensions/ks.py"),
+                "case1": case_name,
+                "dir1": run_dir,
+                "case2": basegen_case,
+                "dir2": basegen_dir,
+                "ninst": 30,
+                "critical": 13
+            }
+        }
+        logger.info('MVK:EVECONFIG: {}'.format(eve_config))
+
+        with self._test_status:
+            self._test_status.set_status(CIME.test_status.BASELINE_PHASE, CIME.test_status.TEST_PASS_STATUS)

--- a/cime/scripts/lib/CIME/SystemTests/mvk.py
+++ b/cime/scripts/lib/CIME/SystemTests/mvk.py
@@ -29,34 +29,29 @@ class MVK(SystemTestsCommon):
 
         # Build executable with multiple instances
         ninst = 30
-
-        # BSINGH: For debugging only - Building the model can take
-        # significant amount of time. Setting fake_bld to True can save
-        # that time
-        fake_bld = False
+        # The default NTASKS seem to be much lower than we'd need, so scale it
+        scale_ntasks = 1
 
         # Only want this to happen once. It will impact the sharedlib build
         # so it has to happen there.
         if not model_only:
             logging.warn('Starting to build multi-instance exe')
-            for comp in ['ATM', 'OCN', 'WAV', 'GLC', 'ICE', 'ROF', 'LND']:
-                ntasks = self._case.get_value("NTASKS_{}".format(comp))
+            for comp in self._case.get_values("COMP_CLASSES"):
                 self._case.set_value('ROOTPE_{}'.format(comp), 0)
-                self._case.set_value('NINST_{}'.format(comp), ninst)
-                self._case.set_value('NTASKS_{}'.format(comp), ntasks*ninst)
+                self._case.set_value('NTHRDS_{}'.format(comp), 1)
 
-            self._case.set_value('ROOTPE_CPL', 0)
-            self._case.set_value('NTASKS_CPL', ntasks*ninst)
+                ntasks = self._case.get_value("NTASKS_{}".format(comp))
+                print('MVK:NTASKS_{}: {}'.format(comp, ntasks))
+                self._case.set_value('NTASKS_{}'.format(comp), ntasks*scale_ntasks*ninst)
+                if comp != 'CPL':
+                    self._case.set_value('NINST_{}'.format(comp), ninst)
+
             self._case.flush()
 
             case_setup(self._case, test_mode=False, reset=True)
 
-        # BSINGH: Faking a bld can save the time code spend in building the model components
-        if fake_bld:
-            if not sharedlib_only:
-                post_build(self._case, [])
-        else:
-            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+
+        self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
         # =================================================================
         # Run-time settings.
@@ -68,48 +63,27 @@ class MVK(SystemTestsCommon):
         data_root = self._case.get_value("DIN_LOC_ROOT")
         for iinst in range(1, ninst+1):
             with open('user_nl_cam_{:04d}'.format(iinst), 'w') as nl_atm_file:
-                nl_atm_file.write("fincl2 = 'TS:A','TSMN:M','TSMX:X','PRECT:A','PRECTMX:X'")
-                nl_atm_file.write('mfilt = 1,30')
-                nl_atm_file.write('nhtfrq = 0,-24')
+                nl_atm_file.write("fincl2 = 'TS:A','TSMN:M','TSMX:X','PRECT:A','PRECTMX:X'\n")
+                nl_atm_file.write('mfilt = 1,30\n')
+                nl_atm_file.write('nhtfrq = 0,-24\n')
 
-                nl_atm_file.write('cldfrc_rhminl = 0.9100')
-                nl_atm_file.write('zmconv_c0_ocn = 0.0110')
+                # nl_atm_file.write('cldfrc_rhminl = 0.9100\n')
+                nl_atm_file.write('zmconv_c0_ocn = 0.0074D0\n')
+                nl_atm_file.write('dtime = 5400\n')
 
-                nl_atm_file.write("rsf_file = '{}/atm/waccm/phot/RSF_GT200nm_v3.0_c080416.nc'".format(data_root))
-                nl_atm_file.write("bnd_topo = '{}/atm/cam/topo/USGS-gtopo30_1.9x2.5_smooth500-50_ne16np4_c050602.nc'".format(data_root))
+                # nl_atm_file.write("rsf_file = '{}/atm/waccm/phot/RSF_GT200nm_v3.0_c080416.nc'\n".format(data_root))
+                # nl_atm_file.write("bnd_topo = '{}/atm/cam/topo/USGS-gtopo30_1.9x2.5_smooth500-50_ne16np4_c050602.nc'\n".format(data_root))
 
-                nl_atm_file.write('phys_loadbalance = 0')
-                nl_atm_file.write('new_random = .true.')
-                nl_atm_file.write('pertlim = 1.0e-10')
-                nl_atm_file.write('seed_custom = {}'.format(iinst))
+                # nl_atm_file.write('phys_loadbalance = 0\n')
+                nl_atm_file.write('new_random = .true.\n')
+                nl_atm_file.write('pertlim = 1.0e-10\n')
+                nl_atm_file.write('seed_custom = {}\n'.format(iinst))
 
-            with open('user_nl_clm_{:04d}'.format(iinst), 'w') as nl_clm_file:
-                nl_clm_file.write("finidat = '/lustre/atlas/proj-shared/cli106/salil/archive/A_F.1850c5.ne16_g37.l2/rest/0100-11-01-00000/A_F.1850c5.ne16_g37.l2.clm2.r.0100-11-01-00000.nc'")
+            # with open('user_nl_clm_{:04d}'.format(iinst), 'w') as nl_clm_file:
+            #     # nl_clm_file.write("finidat = '{}/lnd/clm2/initdata_map/clmi.I1850CLM45.ne30_g16.1155ba0.clm2.r.nc'\n".format(data_root))
+            #     nl_clm_file.write("finidat = '{}/lnd/clm2/initdata_map/clmi.I1850CLM45.ne16_qu240.d02c96d.clm2.r.0021-01-01-00000.nc'\n".format(data_root))
 
 
-# ------
-# Notes:
-# ------
-# Follow setup of cases in: /autofs/nccs-svm1_home1/salil/acme_cases/ne16_F1850C5_master/
-# User_nl_* changes:
-#   CAM:
-#       fincl2 = 'TS:A','TSMN:M','TSMX:X','PRECT:A','PRECTMX:X'
-#       mfilt = 1,30
-#       nhtfrq = 0,-24
-#
-#       cldfrc_rhminl = 0.9100
-#       zmconv_c0_ocn = 0.0110
-#
-#       rsf_file = '/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/waccm/phot/RSF_GT200nm_v3.0_c080416.nc'
-#       bnd_topo = '/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/cam/topo/USGS-gtopo30_1.9x2.5_smooth500-50_ne16np4_c050602.nc'
-#
-#       phys_loadbalance = 0
-#       new_random = .true.
-#       pertlim = 1.e-10
-#       seed_custom = 2
-#
-#   CLM:
-#       finidat = '/lustre/atlas/proj-shared/cli106/salil/archive/A_F.1850c5.ne16_g37.l2/rest/0100-11-01-00000/A_F.1850c5.ne16_g37.l2.clm2.r.0100-11-01-00000.nc'
+    def run_phase(self):
 
-# Original case setup:
-# ./create_newcase -mach titan -compiler pgi -res ne16_g37 -compset F1850C5 -case /ccs/home/salil/acme_cases/F1850C5_08162017_master -project cli106
+        self.run_indv()

--- a/cime/scripts/lib/CIME/SystemTests/mvk.py
+++ b/cime/scripts/lib/CIME/SystemTests/mvk.py
@@ -6,20 +6,24 @@ conduct an ensemble of simulations starting from different initial conditions.
 This class inherits from SystemTestsCommon.
 """
 
+import os
+import re
 import stat
 import json
 import shutil
+import logging
 
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case.case_setup import case_setup
 from CIME.hist_utils import _get_all_hist_files, BLESS_LOG_NAME
 from CIME.utils import append_testlog, get_current_commit, get_timestamp, get_model
-from CIME.test_status import *
+from CIME.utils import expect
 
 import CIME.test_status
 
 import evv4esm
 from evv4esm.__main__ import main as evv
+
 
 evv_lib_dir = os.path.abspath(os.path.dirname(evv4esm.__file__))
 logger = logging.getLogger(__name__)
@@ -77,11 +81,6 @@ class MVK(SystemTestsCommon):
                 nl_atm_file.write('new_random = .true.\n')
                 nl_atm_file.write('pertlim = 1.0e-10\n')
                 nl_atm_file.write('seed_custom = {}\n'.format(iinst))
-
-
-    def run_phase(self):
-
-        self.run_indv()
 
 
     def _generate_baseline(self):
@@ -148,9 +147,10 @@ class MVK(SystemTestsCommon):
             # END: modified CIME.hist_utils.generate_baseline
 
             append_testlog(comments)
-            status = TEST_PASS_STATUS
+            status = CIME.test_status.TEST_PASS_STATUS
             baseline_name = self._case.get_value("BASEGEN_CASE")
-            self._test_status.set_status("{}".format(GENERATE_PHASE), status, comments=os.path.dirname(baseline_name))
+            self._test_status.set_status("{}".format(CIME.test_status.GENERATE_PHASE), status,
+                                         comments=os.path.dirname(baseline_name))
             basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))
             # copy latest cpl log to baseline
             # drop the date so that the name is generic

--- a/cime/scripts/lib/CIME/SystemTests/mvk.py
+++ b/cime/scripts/lib/CIME/SystemTests/mvk.py
@@ -6,30 +6,33 @@ conduct an ensemble of simulations starting from different initial conditions.
 This class inherits from SystemTestsCommon.
 """
 
+import subprocess
+import importlib
+
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
-from CIME.case_setup import case_setup
+from CIME.case.case_setup import case_setup
 
 import CIME.test_status
 
-from livvkit.util import functions as lfn
-# FIXME: this is python2 only. Python 2 and 3 compatible is much hard, esp. if
-#        python 3.0--3.4 need to be supported
-# try:
-#     import livvkit
-# except ImportError:
-#     import pip
-#     pip.main(['install', '--user', 'livvkit'])
-#     import site
-#     reload(site)
-#     import livvkit
+
+logger = logging.getLogger(__name__)
+
+try:
+    import livvkit
+except ImportError:
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'livvkit'])
+    livvkit = importlib.import_module('livvkit')
+    logger.info('Installed LIVVkit v{} via pip.'.format(livvkit.__version__))
 
 # FIXME: remove once eve is a package, or inc. eve into CIME/SystemTest/Test_utils
 eve_lib_dir = '/ccs/home/kennedy/EVE/eve'
 sys.path.append(eve_lib_dir)
 import eve
 
-logger = logging.getLogger(__name__)
+
+# Build executable with multiple instances
+ninst = 20
 
 
 class MVK(SystemTestsCommon):
@@ -44,25 +47,21 @@ class MVK(SystemTestsCommon):
 
 
     def build_phase(self, sharedlib_only=False, model_only=False):
-
-        # Build executable with multiple instances
-        ninst = 30
-        # The default NTASKS seem to be much lower than we'd need, so scale it
-        scale_ntasks = 1
-
         # Only want this to happen once. It will impact the sharedlib build
         # so it has to happen there.
         if not model_only:
             logging.warn('Starting to build multi-instance exe')
             for comp in self._case.get_values("COMP_CLASSES"):
-                self._case.set_value('ROOTPE_{}'.format(comp), 0)
                 self._case.set_value('NTHRDS_{}'.format(comp), 1)
 
                 ntasks = self._case.get_value("NTASKS_{}".format(comp))
                 logger.info('MVK:NTASKS_{}: {}'.format(comp, ntasks))
-                self._case.set_value('NTASKS_{}'.format(comp), ntasks*scale_ntasks*ninst)
+
+                self._case.set_value('NTASKS_{}'.format(comp), ntasks*ninst)
                 if comp != 'CPL':
                     self._case.set_value('NINST_{}'.format(comp), ninst)
+
+            self._case.set_value('ATM_NCPL', 18)
 
             self._case.flush()
 
@@ -79,15 +78,6 @@ class MVK(SystemTestsCommon):
         # namelist specifications for each instance
         for iinst in range(1, ninst+1):
             with open('user_nl_cam_{:04d}'.format(iinst), 'w') as nl_atm_file:
-                nl_atm_file.write("fincl2 = 'TS:A','TSMN:M','TSMX:X','PRECT:A','PRECTMX:X'\n")
-                nl_atm_file.write('mfilt = 1,30\n')
-                nl_atm_file.write('nhtfrq = 0,-24\n')
-
-                # nl_atm_file.write('cldfrc_rhminl = 0.9100\n')
-                nl_atm_file.write('zmconv_c0_ocn = 0.0074D0\n')
-                nl_atm_file.write('dtime = 5400\n')
-
-                # nl_atm_file.write('phys_loadbalance = 0\n')
                 nl_atm_file.write('new_random = .true.\n')
                 nl_atm_file.write('pertlim = 1.0e-10\n')
                 nl_atm_file.write('seed_custom = {}\n'.format(iinst))
@@ -107,27 +97,27 @@ class MVK(SystemTestsCommon):
     #         self._test_status.set_status(CIME.test_status.GENERATE_PHASE, CIME.test_status.TEST_PASS_STATUS)
 
 
-    def _compare_baseline(self):
-        logger.info('MVK:CMPR: {}'.format(self._case.get_value("COMPARE_BASELINE")))
-        logger.info('MVK:CMPR: {}'.format(type(self._case.get_value("COMPARE_BASELINE"))))
-
-        run_dir = self._case.get_value("RUNDIR")
-        case_name = self._case.get_value("CASE")
-        basegen_case = self._case.get_value("BASEGEN_CASE")
-        basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))
-
-        eve_config = {
-            "MVK_{}".format(case_name): {
-                "module": os.path.join(eve_lib_dir, "extensions/ks.py"),
-                "case1": case_name,
-                "dir1": run_dir,
-                "case2": basegen_case,
-                "dir2": basegen_dir,
-                "ninst": 30,
-                "critical": 13
-            }
-        }
-        logger.info('MVK:EVECONFIG: {}'.format(eve_config))
-
-        with self._test_status:
-            self._test_status.set_status(CIME.test_status.BASELINE_PHASE, CIME.test_status.TEST_PASS_STATUS)
+    # def _compare_baseline(self):
+    #     logger.info('MVK:CMPR: {}'.format(self._case.get_value("COMPARE_BASELINE")))
+    #     logger.info('MVK:CMPR: {}'.format(type(self._case.get_value("COMPARE_BASELINE"))))
+    #
+    #     run_dir = self._case.get_value("RUNDIR")
+    #     case_name = self._case.get_value("CASE")
+    #     basegen_case = self._case.get_value("BASEGEN_CASE")
+    #     basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))
+    #
+    #     eve_config = {
+    #         "MVK_{}".format(case_name): {
+    #             "module": os.path.join(eve_lib_dir, "extensions/ks.py"),
+    #             "case1": case_name,
+    #             "dir1": run_dir,
+    #             "case2": basegen_case,
+    #             "dir2": basegen_dir,
+    #             "ninst": ninst,
+    #             "critical": 13
+    #         }
+    #     }
+    #     logger.info('MVK:EVECONFIG: {}'.format(eve_config))
+    #
+    #     with self._test_status:
+    #         self._test_status.set_status(CIME.test_status.BASELINE_PHASE, CIME.test_status.TEST_PASS_STATUS)

--- a/cime/scripts/lib/CIME/SystemTests/mvk.py
+++ b/cime/scripts/lib/CIME/SystemTests/mvk.py
@@ -52,7 +52,6 @@ class MVK(SystemTestsCommon):
                 self._case.set_value('NTHRDS_{}'.format(comp), 1)
 
                 ntasks = self._case.get_value("NTASKS_{}".format(comp))
-                logger.info('MVK:NTASKS_{}: {}'.format(comp, ntasks))
 
                 self._case.set_value('NTASKS_{}'.format(comp), ntasks*ninst)
                 if comp != 'CPL':
@@ -166,9 +165,7 @@ class MVK(SystemTestsCommon):
 
     def _compare_baseline(self):
         with self._test_status:
-            resubmit = int(self._case.get_value("RESUBMIT"))
-            logger.info('MVK:CMPR: Resubmits: {}'.format(resubmit))
-            if resubmit > 0:
+            if int(self._case.get_value("RESUBMIT")) > 0:
                 # This is here because the comparison is run for each submission
                 # and we only want to compare once the whole run is finished. We
                 # need to return a pass here to continue the submission process.
@@ -181,7 +178,6 @@ class MVK(SystemTestsCommon):
             case_name = self._case.get_value("CASE")
             basecmp_case = self._case.get_value("BASECMP_CASE")
             base_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), basecmp_case)
-            # base_name = os.path.basename(basecmp_case)
 
             test_name = "{}".format(case_name.split('.')[-1])
             evv_config = {


### PR DESCRIPTION
Motivation:
--------------

Requiring model changes to pass stringent tests before being accepted as part of E3SM’s main development branch is critical for quickly and efficiently producing a trustworthy model. Depending on their impacts on model output, code modifications can be classified into three types:

1. Technical changes that continue to produce bit-for-bit identical solutions
2. Changes that cause the model solution to differ, yet produce a statistically identical climate when averaged over a sufficiently long time
3. Changes that lead to a different model climate

Only (3) impacts model climate, and changes of this type should only be implemented within the code after an in-depth demonstration of improvement. However, distinguishing between (2) and (3) requires a comprehensive analysis of both a baseline climate and the currently produced climate.

This PR: 
-----------

MVK, a E3SM-CIME `SystemTest` has been added that will launch a multivariate climate reproducibility test based on the Kolmogorov-Smirnov test. This test will be launched using the `create_test` scripts, *however*, since these tests use high level statistics, they have additional python dependencies which
need to be installed on your system and accessible via the compute nodes (if you're on a batch machine).

A `README.md` describing the usage of this test and a `requirements.txt` file describing the dependencies has been added into the new `cime/scripts/climate_reporducibility` directory. For more detail see the [README.md](https://github.com/E3SM-Project/E3SM/tree/jhkennedy/cime/mvk/cime/scripts/climate_reproducibility). 


[B4B]