### PR TITLE
Smart archiving of old test results from jenkins

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -671,6 +671,7 @@
     <SAVE_TIMING_DIR>/sems-data-store/ACME/timings</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
     <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build.new/cprnc</CCSM_CPRNC>
+    <MAX_GB_OLD_TEST_DATA>100</MAX_GB_OLD_TEST_DATA> <!-- do not push this, bump to 1TB -->
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
 <!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
     <GMAKE_J>32</GMAKE_J>

--- a/cime/scripts/Tools/xmlquery
+++ b/cime/scripts/Tools/xmlquery
@@ -330,10 +330,11 @@ def _main_func(description):
         wrapper=textwrap.TextWrapper()
         wrapper.subsequent_indent = "\t\t\t"
         wrapper.fix_sentence_endings = True
+
+    cnt = 0
     for group in sorted(iter(results)):
         if (len(variables) > 1 or len(results) > 1 or full) and not get_group and not value:
             print("\nResults in group {}".format(group))
-        cnt = 0
         for var in variables:
             if var in results[group]:
                 if raw:
@@ -344,6 +345,7 @@ def _main_func(description):
                     if cnt > 0:
                         sys.stdout.write(",")
                     sys.stdout.write("{}".format(results[group][var]['value']))
+                    cnt += 1
                 elif description:
                     if results[group][var]['desc'][0] is not None:
                         desc_text = ' '.join(results[group][var]['desc'][0].split())
@@ -366,7 +368,6 @@ def _main_func(description):
                     print("\t\tfile: {}".format(results[group][var]['file'][0]))
                 else:
                     print("\t{}: {}".format(var, results[group][var]['value']))
-            cnt += 1
 
 if (__name__ == "__main__"):
     _main_func(__doc__)

--- a/cime/scripts/lib/CIME/provenance.py
+++ b/cime/scripts/lib/CIME/provenance.py
@@ -437,7 +437,7 @@ def get_recommended_test_time_based_on_past(baseline_root, test, raw=False):
                 return convert_to_babylonian_time(best_walltime)
         except:
             # We NEVER want a failure here to kill the run
-            logger.warning("Failed to read test time: {}".format(sys.exc_info()[0]))
+            logger.warning("Failed to read test time: {}".format(sys.exc_info()[1]))
 
     return None
 
@@ -453,4 +453,4 @@ def save_test_time(baseline_root, test, time_seconds):
                 fd.write("{}\n".format(int(time_seconds)))
         except:
             # We NEVER want a failure here to kill the run
-            logger.warning("Failed to store test time: {}".format(sys.exc_info()[0]))
+            logger.warning("Failed to store test time: {}".format(sys.exc_info()[1]))

--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -645,6 +645,14 @@
     If set to on, this component set/ grid specification is scientifically supported</desc>
   </entry>
 
+  <entry id="MAX_GB_OLD_TEST_DATA">
+    <type>integer</type>
+    <default_value>500</default_value>
+    <group>case_def</group>
+    <file>env_case.xml</file>
+    <desc>How much old test to allow</desc>
+  </entry>
+
   <entry id="GLC_NEC">
     <type>integer</type>
     <valid_values>0,1,3,5,10,36</valid_values>


### PR DESCRIPTION
This PR implements "smart" archiving of old jenkins test results.

The previous implementation simply deleted any result that looked like it came from a previous jenkins run of the same job.

The new implementation will scan these old results, populating the directories
$CIME_OUTPUT_ROOT/old_test_archive/old_cases
$CIME_OUTPUT_ROOT/old_test_archive/old_builds
$CIME_OUTPUT_ROOT/old_test_archive/old_runs
$CIME_OUTPUT_ROOT/old_test_archive/old_archives
... with the appropriate directories from previous runs.

The system will allow this old_test_archive directory to fill up until it reaches MAX_GB_OLD_TEST_DATA of data. Once that happens, old job data will be delete in chronological order until we are under MAX_GB worth of data. This MAX_GB is a new per-machine setting for e3sm.

[BFB]