### PR TITLE
Output component MPI task to compute node mappings

### DIFF
--- a/components/clm/src/utils/spmdMod.F90
+++ b/components/clm/src/utils/spmdMod.F90
@@ -15,8 +15,7 @@ module spmdMod
 !EOP
 !-----------------------------------------------------------------------
 
-  use shr_kind_mod, only: r8 => shr_kind_r8
-  use clm_varctl  , only: iulog
+  use shr_kind_mod   , only: r8 => shr_kind_r8
   implicit none
 
   private
@@ -82,12 +81,6 @@ contains
 !EOP
     integer :: i,j         ! indices
     integer :: ier         ! return error status
-    integer :: mylength    ! my processor length
-    logical :: mpi_running ! temporary
-    integer, allocatable :: length(:)
-    integer, allocatable :: displ(:)
-    character*(MPI_MAX_PROCESSOR_NAME), allocatable :: procname(:)
-    character*(MPI_MAX_PROCESSOR_NAME)              :: myprocname
 !-----------------------------------------------------------------------
 
     ! Initialize mpi communicator group
@@ -108,34 +101,6 @@ contains
     ! Get number of processors
 
     call mpi_comm_size(mpicom, npes, ier)
-
-    ! Get my processor names
-
-    allocate (length(0:npes-1), displ(0:npes-1), procname(0:npes-1))
-
-    call mpi_get_processor_name (myprocname, mylength, ier)
-    call mpi_allgather(mylength,1,MPI_INTEGER,length,1,MPI_INTEGER,mpicom,ier)
-
-    do i = 0,npes-1
-       displ(i)=i*MPI_MAX_PROCESSOR_NAME
-    end do
-    call mpi_gatherv (myprocname,mylength,MPI_CHARACTER, &
-                      procname,length,displ,MPI_CHARACTER,0,mpicom,ier)
-    if (masterproc) then
-       write(iulog,100)npes
-       write(iulog,200)
-       write(iulog,220)
-       do i=0,min(100,npes-1)
-          write(iulog,250)i,(procname((i))(j:j),j=1,length(i))
-       end do
-    endif
-
-    deallocate (length, displ, procname)
-
-100 format(//,i7," pes participating in computation for CLM")
-200 format(/,35('-'))
-220 format(/,"NODE#",2x,"NAME")
-250 format("(",i5,")",2x,100a1,//)
 
   end subroutine spmd_init
 

--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -24,6 +24,7 @@ module glc_comp_mct
   use shr_file_mod
   use shr_cal_mod,       only : shr_cal_date2ymd
   use shr_sys_mod
+  use shr_taskmap_mod,   only : shr_taskmap_write
   use shr_pio_mod
   use perf_mod
 
@@ -134,12 +135,13 @@ contains
     character(len=StrKIND) :: cpl_seq_option
 
     type (MPAS_Time_Type) :: currTime
-    integer :: iam, ierr, ierr_local
+    integer :: iam, npes, ierr, ierr_local
     integer :: iyear0, imonth0
     character(len=StrKIND)  :: starttype          ! infodata start type
     character(len=StrKIND)  :: timeStamp
     character(len=StrKIND)  :: nml_filename
     character(len=16) :: inst_suffix
+    integer :: inst_index
     integer :: lbnum
 
     type (MPAS_Time_Type) :: alarmStartTime
@@ -166,6 +168,8 @@ contains
     character(kind=c_char), dimension(StrKIND+1) :: c_ref_time_temp
     character(kind=c_char), dimension(StrKIND+1) :: c_filename_interval_temp
     character(kind=c_char), dimension(StrKIND+1) :: c_iotype
+    character(len=8) :: c_inst_index ! instance number
+    character(len=8) :: c_npes       ! number of pes
     type (MPAS_Time_type) :: start_time
     type (MPAS_Time_type) :: ref_time
     type (MPAS_TimeInterval_type) :: filename_interval
@@ -282,6 +286,24 @@ contains
     if (iam==0) write(glcLogUnit,'(a,i6)') '=== Beginning glc_init_mct: rank=',iam
 
     call mpas_framework_init_phase1(domain % dminfo, mpicom_g)
+
+    ! Identify SMP nodes and process/SMP mapping for this instance
+    ! (Assume that processor names are SMP node names on SMP clusters.)
+    call MPI_comm_size(mpicom_g,npes,ierr)
+    write(c_npes,'(i8)') npes
+
+    inst_index = seq_comm_inst(glcID)
+    write(c_inst_index,'(i8)') inst_index
+
+    if (iam==0) then
+       write(glcLogUnit,100) trim(adjustl(c_npes)), trim(adjustl(c_inst_index))
+100    format(/,a,' pes participating in computation of MPAS-ALBANY-LANDICE instance #',a)
+       call flush(glcLogUnit)
+    endif
+
+    call t_startf("shr_taskmap_write")
+    call shr_taskmap_write(glcLogUnit, mpicom_g, 'GLC #'//trim(adjustl(c_inst_index)))
+    call t_stopf("shr_taskmap_write")
 
     ! Setup function pointers for MALI core and domain types
     call li_setup_core(corelist)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -19,6 +19,7 @@ module ocn_comp_mct
    use shr_file_mod 
    use shr_cal_mod,       only : shr_cal_date2ymd
    use shr_sys_mod
+   use shr_taskmap_mod,   only : shr_taskmap_write
    use shr_pio_mod
    use perf_mod
 
@@ -145,12 +146,13 @@ contains
     character(len=StrKIND) :: cpl_seq_option
 
     type (MPAS_Time_Type) :: currTime
-    integer :: iam, ierr, ierr_local
+    integer :: iam, npes, ierr, ierr_local
     integer :: iyear0, imonth0
     character(len=StrKIND)  :: starttype          ! infodata start type
     character(len=StrKIND)  :: timeStamp
     character(len=StrKIND)  :: nml_filename
     character(len=16) :: inst_suffix
+    integer :: inst_index
     integer :: lbnum
 
     type (MPAS_Time_Type) :: alarmStartTime
@@ -177,6 +179,8 @@ contains
     character(kind=c_char), dimension(StrKIND+1) :: c_ref_time_temp
     character(kind=c_char), dimension(StrKIND+1) :: c_filename_interval_temp
     character(kind=c_char), dimension(StrKIND+1) :: c_iotype
+    character(len=8) :: c_inst_index ! instance number
+    character(len=8) :: c_npes       ! number of pes
     type (MPAS_Time_type) :: start_time
     type (MPAS_Time_type) :: ref_time
     type (MPAS_TimeInterval_type) :: filename_interval
@@ -314,6 +318,24 @@ contains
     if (iam==0) write(ocnLogUnit,'(a,i6)') '=== Beginning ocn_init_mct: rank=',iam
 
     call mpas_framework_init_phase1(domain % dminfo, mpicom_o)
+
+    ! Identify SMP nodes and process/SMP mapping for this instance
+    ! (Assume that processor names are SMP node names on SMP clusters.)
+    call MPI_comm_size(mpicom_o,npes,ierr)
+    write(c_npes,'(i8)') npes
+
+    inst_index = seq_comm_inst(ocnID)
+    write(c_inst_index,'(i8)') inst_index
+
+    if (iam==0) then
+       write(ocnLogUnit,100) trim(adjustl(c_npes)), trim(adjustl(c_inst_index))
+100    format(/,a,' pes participating in computation of MPAS-OCEAN instance #',a)
+       call flush(ocnLogUnit)
+    endif
+
+    call t_startf("shr_taskmap_write")
+    call shr_taskmap_write(ocnLogUnit, mpicom_o, 'OCN #'//trim(adjustl(c_inst_index)))
+    call t_stopf("shr_taskmap_write")
 
     ! Setup function pointers for MPASO core and domain types
     call ocn_setup_core(corelist)

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -20,6 +20,7 @@ module ice_comp_mct
    use shr_file_mod 
    use shr_cal_mod,       only : shr_cal_date2ymd
    use shr_sys_mod
+   use shr_taskmap_mod,   only : shr_taskmap_write
    use shr_pio_mod
    use perf_mod
 
@@ -146,12 +147,13 @@ contains
     character(len=StrKIND) :: cpl_seq_option
 
     type (MPAS_Time_Type) :: currTime
-    integer :: iam, ierr, ierr_local
+    integer :: iam, npes, ierr, ierr_local
     integer :: iyear0, imonth0
     character(len=StrKIND)  :: starttype          ! infodata start type
     character(len=StrKIND)  :: timeStamp
     character(len=StrKIND)  :: nml_filename
     character(len=16) :: inst_suffix
+    integer :: inst_index
     integer :: lbnum
 
     type (MPAS_Time_Type) :: alarmStartTime
@@ -176,6 +178,8 @@ contains
     character(kind=c_char), dimension(StrKIND+1) :: c_ref_time_temp
     character(kind=c_char), dimension(StrKIND+1) :: c_filename_interval_temp
     character(kind=c_char), dimension(StrKIND+1) :: c_iotype
+    character(len=8) :: c_inst_index ! instance number
+    character(len=8) :: c_npes       ! number of pes
     type (MPAS_Time_type) :: start_time
     type (MPAS_Time_type) :: ref_time
     type (MPAS_TimeInterval_type) :: filename_interval
@@ -296,6 +300,24 @@ contains
     if (iam==0) write(iceLogUnit,'(a,i6)') '=== Beginning ice_init_mct: rank=',iam
 
     call mpas_framework_init_phase1(domain % dminfo, mpicom_i)
+
+    ! Identify SMP nodes and process/SMP mapping for this instance
+    ! (Assume that processor names are SMP node names on SMP clusters.)
+    call MPI_comm_size(mpicom_i,npes,ierr)
+    write(c_npes,'(i8)') npes
+
+    inst_index = seq_comm_inst(iceID)
+    write(c_inst_index,'(i8)') inst_index
+
+    if (iam==0) then
+       write(iceLogUnit,100) trim(adjustl(c_npes)), trim(adjustl(c_inst_index))
+100    format(/,a,' pes participating in computation of MPAS-SEAICE instance #',a)
+       call flush(iceLogUnit)
+    endif
+
+    call t_startf("shr_taskmap_write")
+    call shr_taskmap_write(iceLogUnit, mpicom_i, 'ICE #'//trim(adjustl(c_inst_index)))
+    call t_stopf("shr_taskmap_write")
 
     ! Setup function pointers for MPASSI core and domain types
     call seaice_setup_core(corelist)


### PR DESCRIPTION
Use shr_taskmap_write in CAM, CLM, Mosart, mpas-albany-landice, mpas-ocean, mpas-seaice to write out all task-to-node mapping information in the new more compact representation, and redirect the output to the associated component log file.

a) Output CAM MPI task to compute node mapping using share routine

MPI task to compute node mapping information in CAM
is output one line per task, and only for the first 256 MPI
tasks. A new share routine in CIME (shr_taskmap_write) is available
that writes out one line per compute node. Each line
contains the compute node name and the list of MPI tasks assigned
to that node for a given communicator. This share routine also
optionally returns the number of compute nodes and the
task-to-node mapping, information that is needed in the
internal CAM load balancing. Here the CAM logic in spmdinit (in
spmd_utils.F90) is removed and a call to shr_taskmap_write in
atm_init_mct (in atm_comp_mct.F90) is added, recording information for
all MPI tasks and in a more compact representation for each CAM
instance.

b) Output CLM MPI task to compute node mapping using share routine

MPI task to compute node mapping information in CLM
is output one line per task, and only for the first 100 MPI
tasks. A new share routine in CIME (shr_taskmap_write) is available
that writes out one line per compute node. Each line
contains the compute node name and the list of MPI tasks assigned
to that node for a given communicator. Here the CLM logic in spmd_init
(in spmdMod.F90) is removed and a call to shr_taskmap_write in
lnd_init_mct (in lnd_comp_mct.F90) is added, recording information for
all MPI tasks and in a more compact representation for each CLM
instance.

c) Output Mosart MPI task to compute node mapping using share routine

MPI task to node mapping information is output for ROF instances
using the new share routine shr_taskmap_write. The call is added to the
routine rof_init_mct in rof_comp_mct.F90.

d) Output mpas-albany-landice MPI task to compute node mapping

MPI task to node mapping information is output for mpas-albany-landglc instances
using the new share routine shr_taskmap_write. The call is added to the
routine glc_init_mct in glc_comp_mct.F.

e) Output mpas-ocean MPI task to compute node mapping using share routine

MPI task to node mapping information is output for mpas-ocean instances
using the new share routine shr_taskmap_write. The call is added to the
routine ocn_init_mct in ocn_comp_mct.F.

f) Output mpas-seaice MPI task to compute node mapping using share routine

MPI task to node mapping information is output for mpas-seaice instances
using the new share routine shr_taskmap_write. The call is added to the
routine ice_init_mct in ice_comp_mct.F.

Fixes #2485 

[BFB]