### PR TITLE
Optionally further compress task-to-node mapping output

### DIFF
--- a/cime/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/cime/src/drivers/mct/shr/seq_comm_mct.F90
@@ -302,7 +302,7 @@ contains
        call shr_sys_flush(logunit)
     endif
     call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(logunit, GLOBAL_COMM_IN, 'GLOBAL')
+    call shr_taskmap_write(logunit, GLOBAL_COMM_IN, 'GLOBAL', verbose=.true.)
     call t_stopf("shr_taskmap_write")
 
     ! Initialize gloiam on all IDs


### PR DESCRIPTION
Often the output from shr_taskmap_write contains a run of sequential
MPI tasks ids. The default for shr_taskmap_write is modified to
reduce these runs from, for example, 0 1 2 3 4 5 to 0-5 to further
reduce the space required to record the task-to-node mapping
information. The original format, enumerating each task id
explicitly, is retained as an option enabled by including the
optional parameter 'verbose' and setting this to .true. .

The call to shr_taskmap_write for the GLOBAL communicator
in seq_comm_init is also modified to include 'verbose=.true.'
so as to retain the current format.

Finally, a new option to shr_taskmap_write is added to not
output the task-to-node mapping. This is meant to be used
when the calculation of the task-to-node mapping is needed,
for example, in CAM, but the output may not be desired. To
disable the output the new optional parameter 'no_output'
should be included and set to '.false.'.

[BFB]