### PR TITLE
Fix race condition in jenkins old test archiving

### DIFF
--- a/cime/scripts/lib/jenkins_generic_job.py
+++ b/cime/scripts/lib/jenkins_generic_job.py
@@ -22,16 +22,17 @@ def cleanup_queue(test_root, test_id):
             case.cancel_batch_jobs(jobkills)
 
 ###############################################################################
-def delete_old_test_data(mach_comp, test_id_root, scratch_root, test_root, run_area, build_area, archive_area):
+def delete_old_test_data(mach_comp, test_id_root, scratch_root, test_root, run_area, build_area, archive_area, avoid_test_id):
 ###############################################################################
     # Remove old dirs
     for clutter_area in [scratch_root, test_root, run_area, build_area, archive_area]:
         for old_file in glob.glob("{}/*{}*{}*".format(clutter_area, mach_comp, test_id_root)):
-            logging.info("Removing {}".format(old_file))
-            if (os.path.isdir(old_file)):
-                shutil.rmtree(old_file)
-            else:
-                os.remove(old_file)
+            if avoid_test_id not in old_file:
+                logging.info("TEST ARCHIVER: Removing {}".format(old_file))
+                if (os.path.isdir(old_file)):
+                    shutil.rmtree(old_file)
+                else:
+                    os.remove(old_file)
 
 ###############################################################################
 def scan_for_test_ids(old_test_archive, mach_comp, test_id_root):
@@ -48,18 +49,19 @@ def scan_for_test_ids(old_test_archive, mach_comp, test_id_root):
     return list(results)
 
 ###############################################################################
-def archive_old_test_data(machine, mach_comp, test_id_root, scratch_root, test_root, old_test_archive):
+def archive_old_test_data(machine, mach_comp, test_id_root, scratch_root, test_root, old_test_archive, avoid_test_id):
 ###############################################################################
 
     # Remove old cs.status, cs.submit. I don't think there's any value to leaving these around
     # or archiving them
     for old_cs_file in glob.glob("{}/cs.*".format(scratch_root)):
-        logging.info("Removing {}".format(old_cs_file))
-        os.remove(old_cs_file)
+        if avoid_test_id not in old_cs_file:
+            logging.info("TEST ARCHIVER: Removing {}".format(old_cs_file))
+            os.remove(old_cs_file)
 
     # Remove the old CTest XML, same reason as above
     if (os.path.isdir("Testing")):
-        logging.info("Removing {}".format(os.path.join(os.getcwd(), "Testing")))
+        logging.info("TEST ARCHIVER: Removing {}".format(os.path.join(os.getcwd(), "Testing")))
         shutil.rmtree("Testing")
 
     if not os.path.exists(old_test_archive):
@@ -67,28 +69,29 @@ def archive_old_test_data(machine, mach_comp, test_id_root, scratch_root, test_r
 
     # Archive old data by looking at old test cases
     for old_case in glob.glob("{}/*{}*{}*".format(test_root, mach_comp, test_id_root)):
-        logging.info("arching case {}".format(old_case))
-        exeroot, rundir, archdir = run_cmd_no_fail("./xmlquery EXEROOT RUNDIR DOUT_S_ROOT --value", from_dir=old_case).split(",")
+        if avoid_test_id not in old_case:
+            logging.info("TEST ARCHIVER: archiving case {}".format(old_case))
+            exeroot, rundir, archdir = run_cmd_no_fail("./xmlquery EXEROOT RUNDIR DOUT_S_ROOT --value", from_dir=old_case).split(",")
 
-        for the_dir, target_area in [(exeroot, "old_builds"), (rundir, "old_runs"), (archdir, "old_archives"), (old_case, "old_cases")]:
-            if os.path.exists(the_dir):
-                logging.info("  archiving {} to {}".format(the_dir, os.path.join(old_test_archive, target_area)))
-                if not os.path.exists(os.path.join(old_test_archive, target_area)):
-                    os.mkdir(os.path.join(old_test_archive, target_area))
+            for the_dir, target_area in [(exeroot, "old_builds"), (rundir, "old_runs"), (archdir, "old_archives"), (old_case, "old_cases")]:
+                if os.path.exists(the_dir):
+                    logging.info("TEST ARCHIVER:   archiving {} to {}".format(the_dir, os.path.join(old_test_archive, target_area)))
+                    if not os.path.exists(os.path.join(old_test_archive, target_area)):
+                        os.mkdir(os.path.join(old_test_archive, target_area))
 
-                os.rename(the_dir, os.path.join(old_test_archive, target_area, os.path.basename(old_case)))
+                    os.rename(the_dir, os.path.join(old_test_archive, target_area, os.path.basename(old_case)))
 
     # Check size of archive
     bytes_of_old_test_data = int(run_cmd_no_fail("du -sb {}".format(old_test_archive)).split()[0])
     bytes_allowed = machine.get_value("MAX_GB_OLD_TEST_DATA") * 1000000000
     if bytes_of_old_test_data > bytes_allowed:
-        logging.info("Too much test data, {}GB (actual) > {}GB (limit)".format(bytes_of_old_test_data / 1000000000, bytes_allowed / 1000000000))
+        logging.info("TEST ARCHIVER: Too much test data, {}GB (actual) > {}GB (limit)".format(bytes_of_old_test_data / 1000000000, bytes_allowed / 1000000000))
         old_test_ids = scan_for_test_ids(old_test_archive, mach_comp, test_id_root)
         for old_test_id in sorted(old_test_ids):
-            logging.info(" Removing old data for test {}".format(old_test_id))
+            logging.info("TEST ARCHIVER:   Removing old data for test {}".format(old_test_id))
             for item in ["old_cases", "old_builds", "old_runs", "old_archives"]:
                 for dir_to_rm in glob.glob("{}/{}/*{}*{}*".format(old_test_archive, item, mach_comp, old_test_id)):
-                    logging.info("   Removing {}".format(dir_to_rm))
+                    logging.info("TEST ARCHIVER:     Removing {}".format(dir_to_rm))
                     shutil.rmtree(dir_to_rm)
 
             bytes_of_old_test_data = int(run_cmd_no_fail("du -sb {}".format(old_test_archive)).split()[0])
@@ -96,11 +99,11 @@ def archive_old_test_data(machine, mach_comp, test_id_root, scratch_root, test_r
                 break
 
     else:
-        logging.info("Test data is with accepted bounds, {}GB (actual) < {}GB (limit)".format(bytes_of_old_test_data / 1000000000, bytes_allowed / 1000000000))
+        logging.info("TEST ARCHIVER: Test data is with accepted bounds, {}GB (actual) < {}GB (limit)".format(bytes_of_old_test_data / 1000000000, bytes_allowed / 1000000000))
 
 
 ###############################################################################
-def handle_old_test_data(machine, compiler, test_id_root, scratch_root, test_root):
+def handle_old_test_data(machine, compiler, test_id_root, scratch_root, test_root, avoid_test_id):
 ###############################################################################
     run_area = os.path.dirname(os.path.dirname(machine.get_value("RUNDIR"))) # Assumes XXX/$CASE/run
     build_area = os.path.dirname(os.path.dirname(machine.get_value("EXEROOT"))) # Assumes XXX/$CASE/build
@@ -110,10 +113,10 @@ def handle_old_test_data(machine, compiler, test_id_root, scratch_root, test_roo
     mach_comp = "{}_{}".format(machine.get_machine_name(), compiler)
 
     try:
-        archive_old_test_data(machine, mach_comp, test_id_root, scratch_root, test_root, old_test_archive)
+        archive_old_test_data(machine, mach_comp, test_id_root, scratch_root, test_root, old_test_archive, avoid_test_id)
     except:
-        logging.warning("Archiving of old test data FAILED: {}\nDeleting data instead".format(sys.exc_info()[1]))
-        delete_old_test_data(mach_comp, test_id_root, scratch_root, test_root, run_area, build_area, archive_area)
+        logging.warning("TEST ARCHIVER: Archiving of old test data FAILED: {}\nDeleting data instead".format(sys.exc_info()[1]))
+        delete_old_test_data(mach_comp, test_id_root, scratch_root, test_root, run_area, build_area, archive_area, avoid_test_id)
 
 ###############################################################################
 def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
@@ -159,14 +162,14 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
     #
 
     test_id_root = "J{}{}".format(baseline_name.capitalize(), test_suite.replace("e3sm_", "").capitalize())
-    archiver_thread = threading.Thread(target=handle_old_test_data, args=(machine, compiler, test_id_root, scratch_root, test_root))
+    test_id = "%s%s" % (test_id_root, CIME.utils.get_timestamp())
+    archiver_thread = threading.Thread(target=handle_old_test_data, args=(machine, compiler, test_id_root, scratch_root, test_root, test_id))
     archiver_thread.start()
 
     #
     # Set up create_test command and run it
     #
 
-    test_id = "%s%s" % (test_id_root, CIME.utils.get_timestamp())
     create_test_args = [test_suite, "--test-root %s" % test_root, "-t %s" % test_id, "--machine %s" % machine.get_machine_name(), "--compiler %s" % compiler]
     if (generate_baselines):
         create_test_args.append("-g -b " + real_baseline_name)
@@ -220,9 +223,9 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
                                                  cdash_project=cdash_project,
                                                  cdash_build_group=cdash_build_group)
 
-    logging.info("Waiting for archiver thread")
+    logging.info("TEST ARCHIVER: Waiting for archiver thread")
     archiver_thread.join()
-    logging.info("Waiting for archiver finished")
+    logging.info("TEST ARCHIVER: Waiting for archiver finished")
 
     if use_batch and CIME.wait_for_tests.SIGNAL_RECEIVED:
         # Cleanup


### PR DESCRIPTION
Certain event sequences could cause the archiver to operate on
current tests. Precautions are needed to avoid that situation.

[BFB]