### PR TITLE
Upgrade NERSC netcdf/hdf modules for maint-1.0

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -170,12 +170,12 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
+      <command name="load">cray-netcdf/4.4.1.1.6</command>
       <command name="load">cray-hdf5/1.10.1.1</command>
-      <command name="load">cray-netcdf/4.4.1.1.3</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
       <command name="load">cray-hdf5-parallel/1.10.1.1</command>
       <command name="load">cray-parallel-netcdf/1.8.1.3</command>
     </modules>
@@ -190,7 +190,8 @@
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
 
-    <env name="HDF5_DISABLE_VERSION_CHECK">2</env>
+    <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
+    <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
   </environment_variables>
   <environment_variables compiler="intel">
     <env name="FORT_BUFFERED">yes</env>
@@ -304,13 +305,13 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-hdf5/1.10.0.3</command>
-      <command name="load">cray-netcdf/4.4.1.1.3</command>
+      <command name="load">cray-netcdf/4.4.1.1.6</command>
+      <command name="load">cray-hdf5/1.10.1.1</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
-      <command name="load">cray-hdf5-parallel/1.10.0.3</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
+      <command name="load">cray-hdf5-parallel/1.10.1.1</command>
       <command name="load">cray-parallel-netcdf/1.8.1.3</command>
     </modules>
 
@@ -333,6 +334,7 @@
     <env name="OMP_STACKSIZE">128M</env>
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
+    <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
   </environment_variables>
   <environment_variables compiler="intel">
     <env name="FORT_BUFFERED">yes</env>
@@ -460,13 +462,13 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-hdf5/1.10.0.3</command>
-      <command name="load">cray-netcdf/4.4.1.1.3</command>
+      <command name="load">cray-netcdf/4.4.1.1.6</command>
+      <command name="load">cray-hdf5/1.10.1.1</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
-      <command name="load">cray-hdf5-parallel/1.10.0.3</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
+      <command name="load">cray-hdf5-parallel/1.10.1.1</command>
       <command name="load">cray-parallel-netcdf/1.8.1.3</command>
     </modules>
     <modules>
@@ -490,6 +492,7 @@
     <env name="OMP_STACKSIZE">128M</env>
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
+    <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
   </environment_variables>
 
   <environment_variables mpilib="mpt">
@@ -499,7 +502,7 @@
     <env name="I_MPI_FABRICS">ofi</env>
     <env name="I_MPI_OFI_PROVIDER">gni</env>
     <env name="I_MPI_PRINT_VERSION">yes</env>
-    <env name="I_MPI_OFI_LIBRARY">/global/common/cori/software/libfabric/1.5.0/gnu/lib/libfabric.so</env>
+    <env name="I_MPI_OFI_LIBRARY">/global/common/cori/software/libfabric/1.6.1/gnu/lib/libfabric.so</env>
     <env name="I_MPI_PMI_LIBRARY">/usr/lib64/slurmpmi/libpmi.so</env>
   </environment_variables>
   <environment_variables compiler="intel">


### PR DESCRIPTION
On NERSC macchines:
Upgrade to cray-netcdf-hdf5parallel/4.4.1.1.6 and cray-hdf5-parallel/1.10.1.1
Add env variable to disable file locking: HDF5_USE_FILE_LOCKING=FALSE

Note, on Edison, we were already using cray-hdf5-parallel/1.10.1.1

Fixes #2413