### PR TITLE
IOP Profile bug fixes for the single column model (SCM) simulations

### DIFF
--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -949,13 +949,14 @@ endif !scm_observed_aero
 !      with capital T defined in cam
 !
 
+!!!!!!!force fill_end to be .true in getinterpncdata () for temperature !!!!!!!!
      if ( use_camiop ) then
        call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx,'t', have_tsair, &
-          tsair(1), fill_ends, scm_crm_mode, &
+          tsair(1), .true. , scm_crm_mode, &
           dplevs, nlev, psobs, hyam, hybm, tobs, status )
      else
        call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx,'T', have_tsair, &
-          tsair(1), fill_ends, scm_crm_mode, &
+          tsair(1), .true. , scm_crm_mode, &
           dplevs, nlev, psobs, hyam, hybm, tobs, status )
      endif
      if ( status .ne. nf90_noerr ) then
@@ -982,8 +983,9 @@ endif !scm_observed_aero
        have_srf = .true.
      endif
 !
+!!!!!!!force fill_end to be .true in getinterpncdata () for humidity!!!!!!!!
      call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx,  'q', have_srf, &
-       srf(1), fill_ends, scm_crm_mode, &
+       srf(1), .true., scm_crm_mode, &
        dplevs, nlev,psobs, hyam, hybm, qobs, status )
      if ( status .ne. nf90_noerr ) then
        have_q = .false.
@@ -1299,8 +1301,9 @@ endif !scm_observed_aero
        have_srf = .true.
      endif
 
+!!!!!!!force fill_end to be .true in getinterpncdata () for u-wind !!!!!!!!
      call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, &
-       'u', have_srf, srf(1), fill_ends, scm_crm_mode, &
+       'u', have_srf, srf(1), .true. , scm_crm_mode, &
        dplevs, nlev,psobs, hyam, hybm, uobs, status )
      if ( status .ne. nf90_noerr ) then
        have_u = .false.
@@ -1316,8 +1319,9 @@ endif !scm_observed_aero
        have_srf = .true.
      endif
 
+!!!!!!!force fill_end to be .true in getinterpncdata () for v-wind !!!!!!!!
      call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, &
-       'v', have_srf, srf(1), fill_ends, scm_crm_mode, &
+       'v', have_srf, srf(1), .true. , scm_crm_mode, &
        dplevs, nlev,psobs, hyam, hybm, vobs, status )
      if ( status .ne. nf90_noerr ) then
        have_v = .false.


### PR DESCRIPTION
E3SM version 1 uses a pressure-based terrain-following vertical coordinate with 72 layers, with the model top located at about 0.1 hPa. The profiles in the IOP files, however, often do not reach that high. In the E3SM code till July 2018, when reading IOP data and filling model arrays, the model layers above the IOP profile top get either zeros or some kind of model-calculated values, depending on which physical quantity is being imported from the IOP files. Having zero values for u (zonal wind) and v (meridional wind) can be problematic because the wind speed in the top-levels of the IOP profiles can be rather high; the sudden drop to zero effectively introduces a very strong (artificial) wind shear which can consequently trigger strong turbulence in CLUBB and eventually affect the solution in the lower troposphere as well. 
More information about this bug can be found at: https://acme-climate.atlassian.net/wiki/spaces/SC/pages/772407534/2.+Impact+of+IOP+Profile+Bug

This PR fixes this bug by assigning the value at the top of the IOP profile to model layers aloft, for u, v, T (temperature), and qv (water vapor concentration).

[BFB]