### PR TITLE
Generate a meaningful error msg when endrun called with no parameters

### DIFF
--- a/components/cam/src/utils/cam_abortutils.F90
+++ b/components/cam/src/utils/cam_abortutils.F90
@@ -1,11 +1,75 @@
 module cam_abortutils
 
-  use shr_sys_mod, only: endrun => shr_sys_abort
+!----------------------------------------------------------------------- 
+! 
+! Purpose: This module provides CAM an interface to the model
+!          stopping mechanisms.
+! 
+!-----------------------------------------------------------------------
 
+!-----------------------------------------------------------------------
+!- use statements ------------------------------------------------------
+!-----------------------------------------------------------------------
+  use shr_kind_mod, only: shr_kind_in
+  use shr_sys_mod,  only: shr_sys_abort
+
+!-----------------------------------------------------------------------
+!- module boilerplate --------------------------------------------------
+!-----------------------------------------------------------------------
   implicit none
   private
   save
 
-  public :: endrun
+!-----------------------------------------------------------------------
+! Public interfaces ----------------------------------------------------
+!-----------------------------------------------------------------------
+  public endrun
+
+!-----------------------------------------------------------------------
+! Subroutines and functions --------------------------------------------
+!-----------------------------------------------------------------------
+contains
+
+!========================================================================
+
+   subroutine endrun(string,rc)
+    !--------------------------------------------------------------------
+    ! 
+    ! Purpose: CAM interface to consistent stopping mechanism
+    ! 
+    ! Method: Calls shr_sys_abort
+    ! 
+    !--------------------------------------------------------------------
+
+    implicit none
+
+    !
+    ! Arguments
+    !
+    character(len=*)    , intent(in), optional :: string ! error message 
+                                                         ! string
+    integer(shr_kind_in), intent(in), optional :: rc     ! error code
+    !
+    ! Local workspace
+    !
+    character(len=*), parameter :: &
+      cam_string = "See atm.log for error description" ! generic string
+    !--------------------------------------------------------------------
+
+    if (present(string)) then
+      if (present(rc)) then
+        call shr_sys_abort(string,rc)
+      else
+        call shr_sys_abort(string)
+      endif
+    else
+      if (present(rc)) then
+        call shr_sys_abort(cam_string,rc)
+      else
+        call shr_sys_abort(cam_string)
+      endif
+    endif
+
+   end subroutine
 
 end module cam_abortutils

--- a/components/cam/src/utils/cam_abortutils.F90
+++ b/components/cam/src/utils/cam_abortutils.F90
@@ -32,7 +32,7 @@ contains
 
 !========================================================================
 
-   subroutine endrun(string,rc)
+   subroutine endrun(string)
     !--------------------------------------------------------------------
     ! 
     ! Purpose: CAM interface to consistent stopping mechanism
@@ -46,28 +46,19 @@ contains
     !
     ! Arguments
     !
-    character(len=*)    , intent(in), optional :: string ! error message 
-                                                         ! string
-    integer(shr_kind_in), intent(in), optional :: rc     ! error code
+    character(len=*), intent(in), optional :: string   ! error message
+
     !
     ! Local workspace
     !
     character(len=*), parameter :: &
-      cam_string = "See atm.log for error description" ! generic string
+      cam_string = "See atm.log for error description" ! generic message
     !--------------------------------------------------------------------
 
     if (present(string)) then
-      if (present(rc)) then
-        call shr_sys_abort(string,rc)
-      else
-        call shr_sys_abort(string)
-      endif
+      call shr_sys_abort(string)
     else
-      if (present(rc)) then
-        call shr_sys_abort(cam_string,rc)
-      else
-        call shr_sys_abort(cam_string)
-      endif
+      call shr_sys_abort(cam_string)
     endif
 
    end subroutine


### PR DESCRIPTION
There are two general ways that endrun is called in CAM, one with a
string argument that describes the error causing the abort and one
without any parameters, but with an explicit write describing
the error that precedes the call to endrun. Examples of the two are as follows.

     if (pcols < maxblksiz) then
        write(iulog,*) 'pcols = ',pcols, ' maxblksiz=',maxblksiz
        call endrun ('PHYS_GRID_INIT error: phys_loadbalance -1 specified but PCOLS < MAXBLKSIZ')
     endif

and

     else
        if (masterproc) then
           write(iulog,*) "PHYS_GRID_INIT error: opt", opt, "specified, ", &
              "but could not divide processes into pairs."
        endif
        call endrun()
     endif

endrun is just a rename of shr_sys_abort, which itself is just a rename
of shr_abort_abort. When endrun (or shr_abort_abort) is called without a
parameter it outputs the following string:

  ERROR: Unknown error submitted to shr_abort_abort.

This occurs for each process calling endrun.

When endrun is called in the second fashion, a meaningful message is written
to atm.log by masterproc, but then shr_abort_abort prints out npes-1 copies
of the "Unknown error" message to e3sm.log and one copy to atm.log. Unless
the user is familiar with this behavior, they may not think to look for
a "real" error message in one of the component logs.

It would be nice if a call to endrun without a parameter would not produce
any output, since there is already an explicit error being output. This would
require a change to shr_abort_abort and would affect the whole model, so
will require further investigation. This PR instead modifies endrun, a
CAM-specific routine, to instead pass the string

     "See atm.log for error description"

to the shr_sys_abort routine when endrun is called with no parameters.

Fixes #2498

[BFB]