### PR TITLE
Replace low-res (half-degree) MOSART file

### DIFF
--- a/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
+++ b/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
@@ -29,7 +29,7 @@ for the CLM data in the CESM distribution
 <!-- River Transport Model river routing file (relative to {csmdata}) -->
 
 <frivinp_rtm rof_grid="r0125" >rof/mosart/MOSART_global_8th_20180211b.nc</frivinp_rtm>
-<frivinp_rtm rof_grid="r05" >rof/mosart/MOSART_Global_half_20161014c.nc</frivinp_rtm>
+<frivinp_rtm rof_grid="r05" >rof/mosart/MOSART_global_half_20180721a.nc</frivinp_rtm>
 <frivinp_rtm rof_grid="NLDAS" >rof/mosart/MOSART_NLDAS_8th.nc</frivinp_rtm>
 
 </namelist_defaults>


### PR DESCRIPTION
This PR replaces the default half-degree MOSART file with a new one that treats the Caspian and Black Seas more consistently as the other components. Previously, MOSART had considered those inland seas to be ocean, while the other components did not.

[NML]
[non-BFB]