### PR TITLE
Turn off mpas-seaice history files by default

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -376,7 +376,7 @@
 <config_AM_regionalStatistics_ice_extent_limit>0.15</config_AM_regionalStatistics_ice_extent_limit>
 
 <!-- AM_ridgingDiagnostics -->
-<config_AM_ridgingDiagnostics_enable>true</config_AM_ridgingDiagnostics_enable>
+<config_AM_ridgingDiagnostics_enable>false</config_AM_ridgingDiagnostics_enable>
 <config_AM_ridgingDiagnostics_compute_interval>'dt'</config_AM_ridgingDiagnostics_compute_interval>
 <config_AM_ridgingDiagnostics_output_stream>'output'</config_AM_ridgingDiagnostics_output_stream>
 <config_AM_ridgingDiagnostics_compute_on_startup>true</config_AM_ridgingDiagnostics_compute_on_startup>
@@ -391,7 +391,7 @@
 <config_AM_conservationCheck_write_to_logfile>true</config_AM_conservationCheck_write_to_logfile>
 
 <!-- AM_geographicalVectors -->
-<config_AM_geographicalVectors_enable>true</config_AM_geographicalVectors_enable>
+<config_AM_geographicalVectors_enable>false</config_AM_geographicalVectors_enable>
 <config_AM_geographicalVectors_compute_interval>'dt'</config_AM_geographicalVectors_compute_interval>
 <config_AM_geographicalVectors_output_stream>'output'</config_AM_geographicalVectors_output_stream>
 <config_AM_geographicalVectors_compute_on_startup>true</config_AM_geographicalVectors_compute_on_startup>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -326,7 +326,7 @@ def buildnml(case, caseroot, compname):
         lines.append('        filename_interval="00-01-00_00:00:00"')
         lines.append('        clobber_mode="truncate"')
         lines.append('        reference_time="01-01-01_00:00:00"')
-        lines.append('        output_interval="00-01-00_00:00:00">')
+        lines.append('        output_interval="none">')
         lines.append('')
         lines.append('    <stream name="mesh"/>')
         lines.append('    <var name="xtime"/>')


### PR DESCRIPTION
This PR changes the mpas-seaice default streams file to no longer output history files by default. It previously had history output on, but the files contained only grid information and were completely redundant.

Fixes #2477 

[NML]
[BFB]