### PR TITLE
fix to race condition as in #2515

### DIFF
--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -952,6 +952,12 @@ contains
        nsize_use = nelemd
     endif
     if (nvars .gt. nrepro_vars) call abortmp('repro_sum_buffer_size exceeded')
+
+#if (defined HORIZ_OPENMP)
+!$OMP BARRIER
+!$OMP MASTER
+#endif
+
 #ifndef CAM
     ! CAM already does this, no need to do it twice
     do n=1,nvars
@@ -963,12 +969,6 @@ contains
 #endif    
 
 ! Repro_sum contains its own OpenMP, so only one thread should call it (AAM)
-
-#if (defined HORIZ_OPENMP)
-!$OMP BARRIER
-!$OMP MASTER
-#endif
-
     call repro_sum(global_shared_buf, global_shared_sum, nsize_use, nelemd, nvars, commid=comm)
 
 #if (defined HORIZ_OPENMP)


### PR DESCRIPTION
This fix makes sure threads do not perform the same != operation on the shared buffer, but only master does so. I would get rig of nsize variable as well, since in homme calls to wrap_repro_sum are not using nsize, but there is 1 call to wrap_repro_sum in cam/src/dynamics/se/native_mapping where nsize=1. I believe that call is not affected by this change either. this intends to fix #2515 .


Homme standalone tests are running now...