### PR TITLE
Restore LR time substepping in compset using LRtunedHR

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-HR.xml
@@ -9,7 +9,7 @@
 <solar_data_ymd>19500101</solar_data_ymd>
 <solar_data_type>FIXED</solar_data_type>
 
-<!-- 1850 GHG values from CMIP6 input4MIPS -->
+<!-- 1950 GHG values from CMIP6 input4MIPS -->
 <!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in cime/src/drivers/mct/cime_config/config_component_acme.xml -->
 <ch4vmr>1163.821e-9</ch4vmr>
 <n2ovmr>289.739e-9</n2ovmr>
@@ -163,7 +163,7 @@
 <sim_year>1955</sim_year>
 
 <!-- land datasets -->
-<!-- Set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+<!-- Set in components/clm/bld/namelist_files/use_cases/1950_CMIP6HR_control.xml -->
 
 
 </namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LR.xml
@@ -9,7 +9,7 @@
 <solar_data_ymd>19500101</solar_data_ymd>
 <solar_data_type>FIXED</solar_data_type>
 
-<!-- 1850 GHG values from CMIP6 input4MIPS -->
+<!-- 1950 GHG values from CMIP6 input4MIPS -->
 <!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in cime/src/drivers/mct/cime_config/config_component_acme.xml -->
 <ch4vmr>1163.821e-9</ch4vmr>
 <n2ovmr>289.739e-9</n2ovmr>
@@ -155,7 +155,7 @@
 <sim_year>1955</sim_year>
 
 <!-- land datasets -->
-<!-- Set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+<!-- Set in components/clm/bld/namelist_files/use_cases/1950_CMIP6LR_control.xml -->
 
 
 </namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
@@ -9,7 +9,7 @@
 <solar_data_ymd>19500101</solar_data_ymd>
 <solar_data_type>FIXED</solar_data_type>
 
-<!-- 1850 GHG values from CMIP6 input4MIPS -->
+<!-- 1950 GHG values from CMIP6 input4MIPS -->
 <!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in cime/src/drivers/mct/cime_config/config_component_acme.xml -->
 <ch4vmr>1163.821e-9</ch4vmr>
 <n2ovmr>289.739e-9</n2ovmr>
@@ -159,7 +159,7 @@
 <sim_year>1955</sim_year>
 
 <!-- land datasets -->
-<!-- Set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+<!-- Set in components/clm/bld/namelist_files/use_cases/1950_CMIP6LR_control.xml -->
 
 
 </namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
@@ -98,10 +98,6 @@
 <cldfrc_dp1          >0.039D0</cldfrc_dp1>
 <clubb_C8            >4.73D0</clubb_C8>
 <clubb_C14           >1.75D0</clubb_C14>
-<se_nsplit           >6</se_nsplit>
-<rsplit              >2</rsplit>
-<qsplit              >1</qsplit>
-<cld_macmic_num_steps>3</cld_macmic_num_steps>
 
 <!-- Energy fixer options -->
 <l_ieflx_fix> .true.</l_ieflx_fix>


### PR DESCRIPTION
Time substepping used in compset like A_WCYCL1950S_CMIP6_LRtunedHR, 
including time splitting for dynamics (ser_nsplit, rsplit, qsplit) and coupling 
frequency between cloud macrophysics (CLUBB) and microphyscs (MG2), 
cld_macmic_num_steps, took the values from the compset for ne120.

LRtunedHR is intended for low resolution (LR) configuration. This PR removes 
the specifications in compset file 1950_cam5_CMIP6-LRtunedHR.xml,
thus restores the default parameter values for LR (ne30) for these namelist variables,
as specified in namelist_defaults_cam.xml.

Also fixed comments in 1950 cam use cases.

[BFB] except for compsets using LRtunedHR