### PR TITLE
Order of operation changes to HOMME

### DIFF
--- a/components/homme/src/preqx/share/prim_advance_mod.F90
+++ b/components/homme/src/preqx/share/prim_advance_mod.F90
@@ -1180,7 +1180,7 @@ contains
 ! dont thread this because of k-1 dependence:
      p(:,:,1)=hvcoord%hyai(1)*hvcoord%ps0 + dp(:,:,1)/2
      do k=2,nlev
-        p(:,:,k)=p(:,:,k-1) + dp(:,:,k-1)/2 + dp(:,:,k)/2
+        p(:,:,k)=p(:,:,k-1) + (dp(:,:,k-1) + dp(:,:,k))/2
      enddo
 
 #if (defined COLUMN_OPENMP)
@@ -1377,13 +1377,13 @@ contains
 
               vtens1(i,j,k) =   - v_vadv(i,j,1,k)                           &
                    + v2*(elem(ie)%fcor(i,j) + vort(i,j,k))        &
-                   - vtemp(i,j,1) - glnps1
+                   - (vtemp(i,j,1) + glnps1)
               !
               ! phl: add forcing term to zonal wind u
               !
               vtens2(i,j,k) =   - v_vadv(i,j,2,k)                            &
                    - v1*(elem(ie)%fcor(i,j) + vort(i,j,k))        &
-                   - vtemp(i,j,2) - glnps2
+                   - (vtemp(i,j,2) + glnps2)
               !
               ! phl: add forcing term to meridional wind v
               !

--- a/components/homme/src/share/cube_mod.F90
+++ b/components/homme/src/share/cube_mod.F90
@@ -461,7 +461,10 @@ contains
        elem%D = elem%D * sqrt(alpha)
        elem%Dinv = elem%Dinv / sqrt(alpha)
        elem%metdet = elem%metdet * alpha
-       elem%rmetdet = elem%rmetdet / alpha
+       ! replace "elem%rmetdet = elem%rmetdet / alpha" with the one below,
+       ! to ensure that elem%rmetdet = 1/elem%metdet
+       ! elem%rmetdet = elem%rmetdet / alpha
+       elem%rmetdet = 1.0D0/elem%metdet
        elem%met = elem%met * alpha
        elem%metinv = elem%metinv / alpha
     elseif( cubed_sphere_map == 2 ) then
@@ -471,7 +474,7 @@ contains
            elem%D(i,j,:,:) = elem%D(i,j,:,:) * sqrt(alpha)
            elem%Dinv(i,j,:,:) = elem%Dinv(i,j,:,:) / sqrt(alpha)
            elem%metdet(i,j) = elem%metdet(i,j) * alpha
-           elem%rmetdet(i,j) = elem%rmetdet(i,j) / alpha
+           elem%rmetdet(i,j) = 1.0D0/elem%metdet(i,j)
            elem%met(i,j,:,:) = elem%met(i,j,:,:) * alpha
            elem%metinv(i,j,:,:) = elem%metinv(i,j,:,:) / alpha
          enddo

--- a/components/homme/src/share/derivative_mod_base.F90
+++ b/components/homme/src/share/derivative_mod_base.F90
@@ -500,9 +500,9 @@ contains
 !DIR$ UNROLL(NP)
           do j=1,np
              ! phi(n)_y  sum over second index, 1st index fixed at m
-             dscontra(m,n,1)=dscontra(m,n,1)-(elem%mp(m,j)*s(m,j)*deriv%Dvv(n,j) )*rrearth
+             dscontra(m,n,1)=dscontra(m,n,1)-(elem%mp(m,j)*s(m,j)*deriv%Dvv(n,j) )
              ! phi(m)_x  sum over first index, second index fixed at n
-             dscontra(m,n,2)=dscontra(m,n,2)+(elem%mp(j,n)*s(j,n)*deriv%Dvv(m,j) )*rrearth
+             dscontra(m,n,2)=dscontra(m,n,2)+(elem%mp(j,n)*s(j,n)*deriv%Dvv(m,j) )
           enddo
        enddo
     enddo
@@ -510,8 +510,8 @@ contains
     ! convert contra -> latlon 
     do j=1,np
        do i=1,np
-          ds(i,j,1)=(elem%D(i,j,1,1)*dscontra(i,j,1) + elem%D(i,j,1,2)*dscontra(i,j,2))
-          ds(i,j,2)=(elem%D(i,j,2,1)*dscontra(i,j,1) + elem%D(i,j,2,2)*dscontra(i,j,2))
+          ds(i,j,1)=(elem%D(i,j,1,1)*dscontra(i,j,1) + elem%D(i,j,1,2)*dscontra(i,j,2))*rrearth
+          ds(i,j,2)=(elem%D(i,j,2,1)*dscontra(i,j,1) + elem%D(i,j,2,2)*dscontra(i,j,2))*rrearth
        enddo
     enddo
     end function curl_sphere_wk_testcov
@@ -564,20 +564,20 @@ contains
              dscontra(m,n,1)=dscontra(m,n,1)-(&
                   (elem%mp(j,n)*elem%metinv(m,n,1,1)*elem%metdet(m,n)*s(j,n)*deriv%Dvv(m,j) ) +&
                   (elem%mp(m,j)*elem%metinv(m,n,2,1)*elem%metdet(m,n)*s(m,j)*deriv%Dvv(n,j) ) &
-                  ) *rrearth
+                  )
 
              dscontra(m,n,2)=dscontra(m,n,2)-(&
                   (elem%mp(j,n)*elem%metinv(m,n,1,2)*elem%metdet(m,n)*s(j,n)*deriv%Dvv(m,j) ) +&
                   (elem%mp(m,j)*elem%metinv(m,n,2,2)*elem%metdet(m,n)*s(m,j)*deriv%Dvv(n,j) ) &
-                  ) *rrearth
+                  )
           enddo
        enddo
     enddo
     ! convert contra -> latlon 
     do j=1,np
        do i=1,np
-          ds(i,j,1)=(elem%D(i,j,1,1)*dscontra(i,j,1) + elem%D(i,j,1,2)*dscontra(i,j,2))
-          ds(i,j,2)=(elem%D(i,j,2,1)*dscontra(i,j,1) + elem%D(i,j,2,2)*dscontra(i,j,2))
+          ds(i,j,1)=(elem%D(i,j,1,1)*dscontra(i,j,1) + elem%D(i,j,1,2)*dscontra(i,j,2)) *rrearth
+          ds(i,j,2)=(elem%D(i,j,2,1)*dscontra(i,j,1) + elem%D(i,j,2,2)*dscontra(i,j,2)) *rrearth
        enddo
     enddo
 

--- a/components/homme/src/share/prim_si_mod.F90
+++ b/components/homme/src/share/prim_si_mod.F90
@@ -335,45 +335,29 @@ contains
 
     !---------------------------Local workspace-----------------------------
     integer i,j,k                         ! longitude, level indices
-    real(kind=real_kind) term             ! one half of basic term in omega/p summation 
-    real(kind=real_kind) Ckk,Ckl          ! diagonal term of energy conversion matrix
     real(kind=real_kind) suml(np,np)      ! partial sum over l = (1, k-1)
     !-----------------------------------------------------------------------
 
 #if (defined COLUMN_OPENMP)
-!$omp parallel do private(k,j,i,ckk,term,ckl)
+!$omp parallel do private(k,j,i)
 #endif
        do j=1,np   !   Loop inversion (AAM)
 
           do i=1,np
-             ckk = 0.5d0/p(i,j,1)
-             term = divdp(i,j,1)
-!             omega_p(i,j,1) = hvcoord%hybm(1)*vgrad_ps(i,j,1)/p(i,j,1)
-             omega_p(i,j,1) = vgrad_p(i,j,1)/p(i,j,1)
-             omega_p(i,j,1) = omega_p(i,j,1) - ckk*term
-             suml(i,j) = term
+             omega_p(i,j,1) = (vgrad_p(i,j,1) - 0.5*divdp(i,j,1)) / p(i,j,1)
+             suml(i,j) = divdp(i,j,1)
           end do
 
           do k=2,nlev-1
              do i=1,np
-                ckk = 0.5d0/p(i,j,k)
-                ckl = 2*ckk
-                term = divdp(i,j,k)
-!                omega_p(i,j,k) = hvcoord%hybm(k)*vgrad_ps(i,j,k)/p(i,j,k)
-                omega_p(i,j,k) = vgrad_p(i,j,k)/p(i,j,k)
-                omega_p(i,j,k) = omega_p(i,j,k) - ckl*suml(i,j) - ckk*term
-                suml(i,j) = suml(i,j) + term
+                omega_p(i,j,k) = (vgrad_p(i,j,k) - (suml(i,j) + 0.5*divdp(i,j,k))) / p(i,j,k)
+                suml(i,j) = suml(i,j) + divdp(i,j,k)
 
              end do
           end do
 
           do i=1,np
-             ckk = 0.5d0/p(i,j,nlev)
-             ckl = 2*ckk
-             term = divdp(i,j,nlev)
-!             omega_p(i,j,nlev) = hvcoord%hybm(nlev)*vgrad_ps(i,j,nlev)/p(i,j,nlev)
-             omega_p(i,j,nlev) = vgrad_p(i,j,nlev)/p(i,j,nlev)
-             omega_p(i,j,nlev) = omega_p(i,j,nlev) - ckl*suml(i,j) - ckk*term
+             omega_p(i,j,nlev) = (vgrad_p(i,j,nlev) - (suml(i,j) + 0.5*divdp(i,j,nlev))) / p(i,j,nlev)
           end do
 
        end do

--- a/components/homme/src/share/vertremap_base.F90
+++ b/components/homme/src/share/vertremap_base.F90
@@ -706,7 +706,8 @@ function compute_ppm( a , dx )    result(coefs)
     !Computed these coefficients from the edge values and cell mean in Maple. Assumes normalized coordinates: xi=(x-x0)/dx
     coefs(0,j) = 1.5 * a(j) - ( al + ar ) / 4.
     coefs(1,j) = ar - al
-    coefs(2,j) = -6. * a(j) + 3. * ( al + ar )
+    ! coefs(2,j) = -6. * a(j) + 3. * ( al + ar )
+    coefs(2,j) = 3. * (-2. * a(j) + ( al + ar ))
   enddo
 
   !If vert_remap_q_alg == 2, use piecewise constant in the boundaries, and don't use ghost cells.
@@ -729,7 +730,7 @@ function integrate_parabola( a , x1 , x2 )    result(mass)
   real(kind=real_kind), intent(in) :: x1      !lower domain bound for integration
   real(kind=real_kind), intent(in) :: x2      !upper domain bound for integration
   real(kind=real_kind)             :: mass
-  mass = a(0) * (x2 - x1) + a(1) * (x2 ** 2 - x1 ** 2) / 0.2D1 + a(2) * (x2 ** 3 - x1 ** 3) / 0.3D1
+  mass = a(0) * (x2 - x1) + a(1) * (x2 * x2 - x1 * x1) / 0.2D1 + a(2) * (x2 * x2 * x2 - x1 * x1 * x1) / 0.3D1
 end function integrate_parabola
 
 


### PR DESCRIPTION
Introduce some non-BFB order of operation changes to HOMME. The reason behind this is to allow the merge of another upcoming PR, containing the integration of kokkos targets (so far only preqx) in the homme multimodel framework. The point is that the kokkos version performs some arithmetic operations in a particular order (yet formally equivalent to the current one in homme), in order to optimize registers usage (and sometimes flops count), particularly on GPU.

These mods are _non-mods_ in exact arithmetic. They rely on mathematical properties such as associative, commutative, or distributive. They do NOT change the solution in mathematical terms, but they can (and usually do) cause roundoff differences.