### PR TITLE
Update component config files to support 1950 F compsets

### DIFF
--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -167,6 +167,7 @@
       <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
+      <value compset="1950_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_1950_clim_c20180910.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -82,6 +82,21 @@
   </compset>
 
   <compset>
+    <alias>F1950C5-CMIP6-LR</alias>
+    <lname>1950_CAM5%CMIP6-LR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F1950C5-CMIP6-HR</alias>
+    <lname>1950_CAM5%CMIP6-HR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F1950C5-CMIP6-LRtunedHR</alias>
+    <lname>1950_CAM5%CMIP6-LRtunedHR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>FC5AV1C-01</alias>
     <lname>2000_CAM5%AV1C-01_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -75,8 +75,7 @@
       <value compset="20TR_CAM5%CMIP6_CLM">20thC_CMIP6_transient</value>
       <value compset="20TR_CAM5%CMIP6_CLM45.*_BGC%BCRC">20thC_CMIP6bgc_transient</value> 
       <value compset="20TR.*_CLM45%[^_]*BGC">20thC_bgc_transient</value>
-      <value compset="1950_CAM5%CMIP6-LR*_CLM">1950_CMIP6LR_control</value>
-      <value compset="1950_CAM5%CMIP6-LRtunedHR_CLM">1950_CMIP6LR_control</value>
+      <value compset="1950_CAM5%CMIP6-LR.*_CLM">1950_CMIP6LR_control</value>
       <value compset="1950_CAM5%CMIP6-HR_CLM">1950_CMIP6HR_control</value>
     </values>
     <group>run_component_clm</group>

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -76,6 +76,7 @@
       <value compset="20TR_CAM5%CMIP6_CLM45.*_BGC%BCRC">20thC_CMIP6bgc_transient</value> 
       <value compset="20TR.*_CLM45%[^_]*BGC">20thC_bgc_transient</value>
       <value compset="1950_CAM5%CMIP6-LR*_CLM">1950_CMIP6LR_control</value>
+      <value compset="1950_CAM5%CMIP6-LRtunedHR_CLM">1950_CMIP6LR_control</value>
       <value compset="1950_CAM5%CMIP6-HR_CLM">1950_CMIP6HR_control</value>
     </values>
     <group>run_component_clm</group>


### PR DESCRIPTION
Config files for CAM and data ocean components are updated to allow creation
of 1950 F compsets: F1950C5-CMIP6-LR, F1950C5-CMIP6-LRtunedHR and F1950C5-CMIP6-HR.
Use case files for CAM and CLM already exist from corresponding B-cases.

This update is to make the use cases recognized in F-case configuration.

New 1950 SSTICE climatology is introduced: sst_ice_CMIP6_DECK_E3SM_1x1_1950_clim_c20180910.nc

CLM's config_component.xml is also updated to recognize the specification of finidat
for F1950C5-CMIP6-LRtunedHR compset.

 modified:   cime/src/components/data_comps/docn/cime_config/config_component.xml
 modified:   components/cam/cime_config/config_compsets.xml
 modified:   components/clm/cime_config/config_component.xml

[BFB]