### PR TITLE
Move timing library customizations from perf_mod to GPTL

### DIFF
--- a/cime/scripts/lib/CIME/get_timing.py
+++ b/cime/scripts/lib/CIME/get_timing.py
@@ -65,13 +65,13 @@ class _TimingParser:
 
         heading = '"' + heading_padded.strip() + '"'
         for line in self.finlines:
-            m = re.match(r'\s*{}\s*(\d+)\s*\d+\s*(\S+)'.format(heading), line)
+            m = re.match(r'\s*{}\s+\S\s+(\d+)\s*\d+\s*(\S+)'.format(heading), line)
             if m:
                 nprocs = int(float(m.groups()[0]))
                 ncount = int(float(m.groups()[1]))
                 return (nprocs, ncount)
             else:
-                m = re.match(r'\s*{}\s+(\d+)\s'.format(heading), line)
+                m = re.match(r'\s*{}\s+\S\s+(\d+)\s'.format(heading), line)
                 if m:
                     nprocs = 1
                     ncount = int(float(m.groups()[0]))
@@ -85,7 +85,7 @@ class _TimingParser:
         maxval = 0
 
         for line in self.finlines:
-            m = re.match(r'\s*{}\s*\d+\s*\d+\s*\S+\s*\S+\s*(\d*\.\d+)\s*\(.*\)\s*(\d*\.\d+)\s*\(.*\)'.format(heading), line)
+            m = re.match(r'\s*{}\s+\S\s+\d+\s*\d+\s*\S+\s*\S+\s*(\d*\.\d+)\s*\(.*\)\s*(\d*\.\d+)\s*\(.*\)'.format(heading), line)
             if m:
                 maxval = float(m.groups()[0])
                 minval = float(m.groups()[1])

--- a/cime/src/share/timing/ChangeLog
+++ b/cime/src/share/timing/ChangeLog
@@ -1,3 +1,7 @@
+timing_180911: Moved detail to end of timer name when specify
+               profile_add_detail (so that will not interfere with
+               planned move of the prefix logic into gptl.c)
+               [Patrick Worley]
 timing_180910: Removed addition of double quotes to timer names in
                perf_mod.F90 and added this as an output option in 
                gptl.c (so internally the names do not have the quotes)

--- a/cime/src/share/timing/ChangeLog
+++ b/cime/src/share/timing/ChangeLog
@@ -1,3 +1,7 @@
+timing_180910: Removed addition of double quotes to timer names in
+               perf_mod.F90 and added this as an output option in 
+               gptl.c (so internally the names do not have the quotes)
+               [Patrick Worley]
 timing_180822: Fixed perf_mod.F90 bug that prevents PAPI derived events 
                from being recognized.
                [Patrick Worley]

--- a/cime/src/share/timing/ChangeLog
+++ b/cime/src/share/timing/ChangeLog
@@ -1,3 +1,7 @@
+timing_180912: Moved prefix support from perf_mod.F90 to gptl.c
+               and also added support for setting prefixes in
+               threaded regions.
+               [Patrick Worley]
 timing_180911: Moved detail to end of timer name when specify
                profile_add_detail (so that will not interfere with
                planned move of the prefix logic into gptl.c)

--- a/cime/src/share/timing/ChangeLog
+++ b/cime/src/share/timing/ChangeLog
@@ -1,3 +1,12 @@
+timing_180731: Refactored implementation of append/write modes; tweaked
+               "running processes" logic and output format
+               [Patrick Worley]
+timing_180730: Added support for setting GPTLmaxthreads. Cleaned up white space.
+               Added SEQUENTIAL to fortran open, to avoid problems on some systems.
+               Added timing overhead measurement to perf_mod. Fixed errors in
+               f_wrappers.c in definition of gptlpr_query_append and 
+               gptlpr_XXX_write.
+               [Patrick Worley (some from Jim Rosinksi)]
 timing_180403: Added GPTLstartstop_val(f) to gptl.h, to provide explicit
                typing and eliminate compile-time warning for some compilers.
                Also do not define the CPP tokens HAVE_COMM_F2C and 

--- a/cime/src/share/timing/ChangeLog
+++ b/cime/src/share/timing/ChangeLog
@@ -1,5 +1,8 @@
-timing_180731: Refactored implementation of append/write modes; tweaked
-               "running processes" logic and output format
+timing_180822: Fixed perf_mod.F90 bug that prevents PAPI derived events 
+               from being recognized.
+               [Patrick Worley]
+timing_180731: Refactored implementation of append/write modes;
+               collected and output "on" events for global statistics
                [Patrick Worley]
 timing_180730: Added support for setting GPTLmaxthreads. Cleaned up white space.
                Added SEQUENTIAL to fortran open, to avoid problems on some systems.

--- a/cime/src/share/timing/f_wrappers.c
+++ b/cime/src/share/timing/f_wrappers.c
@@ -22,6 +22,8 @@
 #define gptlpr_summary GPTLPR_SUMMARY
 #define gptlpr_summary_FILE GPTLPR_SUMMARY_FILE
 #define gptlbarrier GPTLBARRIER
+#define gptlprefix_set GPTLPREFIX_SET
+#define gptlprefix_unset GPTLPREFIX_UNSET
 #define gptlreset GPTLRESET
 #define gptlstamp GPTLSTAMP
 #define gptlstart GPTLSTART
@@ -56,6 +58,8 @@
 #define gptlpr_summary              FCI_GLOBAL(gptlpr_summary,GPTLPR_SUMMARY)
 #define gptlpr_summary_file         FCI_GLOBAL(gptlpr_summary_file,GPTLPR_SUMMARY_FILE)
 #define gptlbarrier                 FCI_GLOBAL(gptlbarrier,GPTLBARRIER)
+#define gptlprefix_set              FCI_GLOBAL(gptlprefix_set,GPTLPREFIX_SET)
+#define gptlprefix_unset            FCI_GLOBAL(gptlprefix_unset,GPTLPREFIX_UNSET)
 #define gptlreset                   FCI_GLOBAL(gptlreset,GPTLRESET)
 #define gptlstamp                   FCI_GLOBAL(gptlstamp,GPTLSTAMP)
 #define gptlstart                   FCI_GLOBAL(gptlstart,GPTLSTART)
@@ -90,6 +94,8 @@
 #define gptlpr_summary gptlpr_summary_
 #define gptlpr_summary_file gptlpr_summary_file_
 #define gptlbarrier gptlbarrier_
+#define gptlprefix_set gptlprefix_set_
+#define gptlprefix_unset gptlprefix_unset_
 #define gptlreset gptlreset_
 #define gptlstamp gptlstamp_
 #define gptlstart gptlstart_
@@ -124,6 +130,8 @@
 #define gptlpr_summary gptlpr_summary__
 #define gptlpr_summary_file gptlpr_summary_file__
 #define gptlbarrier gptlbarrier__
+#define gptlprefix_set gptlprefix_set__
+#define gptlprefix_unset gptlprefix_unset__
 #define gptlreset gptlreset__
 #define gptlstamp gptlstamp__
 #define gptlstart gptlstart__
@@ -162,6 +170,8 @@ int gptlpr_file (char *file, int nc1);
 int gptlpr_summary (int *fcomm);
 int gptlpr_summary_file (int *fcomm, char *name, int nc1);
 int gptlbarrier (int *fcomm, char *name, int nc1);
+int gptlprefix_set (char *name, int nc1);
+int gptlprefix_unset (void);
 int gptlreset (void);
 int gptlstamp (double *wall, double *usr, double *sys);
 int gptlstart (char *name, int nc1);
@@ -312,6 +322,23 @@ int gptlbarrier (int *fcomm, char *name, int nc1)
   }
   cname[numchars] = '\0';
   return GPTLbarrier (ccomm, cname);
+}
+
+int gptlprefix_set (char *name, int nc1)
+{
+  /*  char cname[MAX_CHARS+1]; */
+  /*  int numchars; */
+
+  /*  numchars = MIN (nc1, MAX_CHARS);*/
+  /*  strncpy (cname, name, numchars);*/
+  /*  cname[numchars] = '\0';*/
+  /*  return GPTLprefix_set (cname);*/
+  return GPTLprefix_setf (name, nc1);
+}
+
+int gptlprefix_unset (void)
+{
+  return GPTLprefix_unset ();
 }
 
 int gptlreset (void)

--- a/cime/src/share/timing/f_wrappers.c
+++ b/cime/src/share/timing/f_wrappers.c
@@ -15,10 +15,8 @@
 
 #define gptlinitialize GPTLINITIALIZE
 #define gptlfinalize GPTLFINALIZE
-#define gptlpr_set_append GPTLPR_SET_APPEND
-#define gptlpr_query_append GPTLPR_QUERY_APPEND
-#define gptlpr_set_write GPTLPR_SET_WRITE
-#define gptlpr_query_write GPTLPR_QUERY_WRITE
+#define gptlprint_mode_query GPTLPRINT_MODE_QUERY
+#define gptlprint_mode_set GPTLPRINT_MODE_SET
 #define gptlpr GPTLPR
 #define gptlpr_file GPTLPR_FILE
 #define gptlpr_summary GPTLPR_SUMMARY
@@ -51,10 +49,8 @@
 
 #define gptlinitialize              FCI_GLOBAL(gptlinitialize,GPTLINITIALIZE)
 #define gptlfinalize                FCI_GLOBAL(gptlfinalize,GPTLFINALIZE)
-#define gptlpr_set_append           FCI_GLOBAL(gptlpr_set_append,GPTLPR_SET_APPEND)
-#define gptlpr_query_append         FCI_GLOBAL(gptlpr_query_append,GPTLPR_QUERY_APPEND)
-#define gptlpr_set_write            FCI_GLOBAL(gptlpr_set_write,GPTLPR_SET_WRITE)
-#define gptlpr_query_write          FCI_GLOBAL(gptlpr_query_write,GPTLPR_QUERY_WRITE)
+#define gptlprint_mode_query        FCI_GLOBAL(gptlprint_mode_query,GPTLPRINT_MODE_QUERY)
+#define gptlprint_mode_set          FCI_GLOBAL(gptlprint_mode_set,GPTLPRINT_MODE_SET)
 #define gptlpr                      FCI_GLOBAL(gptlpr,GPTLPR)
 #define gptlpr_file                 FCI_GLOBAL(gptlpr_file,GPTLPR_FILE)
 #define gptlpr_summary              FCI_GLOBAL(gptlpr_summary,GPTLPR_SUMMARY)
@@ -87,10 +83,8 @@
 
 #define gptlinitialize gptlinitialize_
 #define gptlfinalize gptlfinalize_
-#define gptlpr_set_append gptlpr_set_append_
-#define gptlpr_query_append gptlpr_query_append_
-#define gptlpr_set_write gptlpr_set_write_
-#define gptlpr_query_write gptlpr_query_write_
+#define gptlprint_mode_query gptlprint_mode_query_
+#define gptlprint_mode_set gptlprint_mode_set_
 #define gptlpr gptlpr_
 #define gptlpr_file gptlpr_file_
 #define gptlpr_summary gptlpr_summary_
@@ -123,10 +117,8 @@
 
 #define gptlinitialize gptlinitialize__
 #define gptlfinalize gptlfinalize__
-#define gptlpr_set_append gptlpr_set_append__
-#define gptlpr_query_append gptlpr_query_append__
-#define gptlpr_set_write gptlpr_set_write__
-#define gptlpr_query_write gptlpr_query_write__
+#define gptlprint_mode_query gptlprint_mode_query__
+#define gptlprint_mode_set gptlprint_mode_set__
 #define gptlpr gptlpr__
 #define gptlpr_file gptlpr_file__
 #define gptlpr_summary gptlpr_summary__
@@ -163,10 +155,8 @@
 
 int gptlinitialize (void);
 int gptlfinalize (void);
-int gptlpr_set_append (void);
-int gptlpr_query_append (void);
-int gptlpr_set_write (void);
-int gptlpr_query_write (void);
+int gptlprint_mode_query (void);
+int gptlprint_mode_set (int *pr_mode);
 int gptlpr (int *procid);
 int gptlpr_file (char *file, int nc1);
 int gptlpr_summary (int *fcomm);
@@ -214,24 +204,14 @@ int gptlfinalize (void)
   return GPTLfinalize ();
 }
 
-int gptlpr_set_append (void)
+int gptlprint_mode_query (void)
 {
-  return GPTLpr_set_append ();
+  return GPTLprint_mode_query ();
 }
 
-int gptlpr_query_append (void)
+int gptlprint_mode_set (int *pr_mode)
 {
-  return GPTLpr_set_append ();
-}
-
-int gptlpr_set_write (void)
-{
-  return GPTLpr_set_append ();
-}
-
-int gptlpr_query_write (void)
-{
-  return GPTLpr_set_append ();
+  return GPTLprint_mode_set (*pr_mode);
 }
 
 int gptlpr (int *procid)

--- a/cime/src/share/timing/gptl.h
+++ b/cime/src/share/timing/gptl.h
@@ -79,9 +79,10 @@ typedef enum {
   GPTL_LSTPL2M       = 25, /* Load-stores per L2 miss */
   GPTL_L3MRT         = 26, /* L3 read miss rate (fraction) */
   /*
-  ** New ACME option for GPTL
+  ** New ESMF options for GPTL
   */
-  GPTLprofile_ovhd   = 27  /* Direct measurement of profiling overhead (false) */
+  GPTLprofile_ovhd   = 27, /* Direct measurement of profiling overhead (false) */
+  GPTLdopr_quotes    = 28  /* Add double quotes to timer names on output (false) */
 } Option;
 
 /*

--- a/cime/src/share/timing/gptl.h
+++ b/cime/src/share/timing/gptl.h
@@ -62,7 +62,9 @@ typedef enum {
   GPTLdopr_collision  = 15, /* Print hastable collision info (true) */
   GPTLprint_method    = 16, /* Tree print method: first parent, last parent
 			       most frequent, or full tree (most frequent) */
-  GPTLtablesize       = 50, /* per-thread size of hash table (1024) */
+  GPTLprint_mode      = 50, /* Write mode for output file (overwrite, append) */
+  GPTLtablesize       = 51, /* per-thread size of hash table (1024) */
+  GPTLmaxthreads      = 52, /* maximum number of threads */
   /*
   ** These are derived counters based on PAPI counters. All default to false
   */
@@ -109,6 +111,15 @@ typedef enum {
 } Method;
 
 /*
+** Whether to overwrite or append to output file
+*/
+
+typedef enum {
+  GPTLprint_write   = 1,  /* overwrite */
+  GPTLprint_append  = 2,  /* append */
+} PRMode;
+
+/*
 ** Function prototypes
 */
 
@@ -129,10 +140,8 @@ extern int GPTLstopf_handle (const char *, const int, void **);
 extern int GPTLstartstop_vals (const char *, double, int);
 extern int GPTLstartstop_valsf (const char *, const int, double, int);
 extern int GPTLstamp (double *, double *, double *);
-extern int GPTLpr_set_append (void);
-extern int GPTLpr_query_append (void);
-extern int GPTLpr_set_write (void);
-extern int GPTLpr_query_write (void);
+extern int GPTLprint_mode_query (void);
+extern int GPTLprint_mode_set (const int);
 extern int GPTLpr (const int);
 extern int GPTLpr_file (const char *);
 

--- a/cime/src/share/timing/gptl.h
+++ b/cime/src/share/timing/gptl.h
@@ -130,6 +130,9 @@ extern "C" {
 
 extern int GPTLsetoption (const int, const int);
 extern int GPTLinitialize (void);
+extern int GPTLprefix_set (const char *);
+extern int GPTLprefix_setf (const char *, const int);
+extern int GPTLprefix_unset (void);
 extern int GPTLstart (const char *);
 extern int GPTLstart_handle (const char *, void **);
 extern int GPTLstartf (const char *, const int);

--- a/cime/src/share/timing/gptl.inc
+++ b/cime/src/share/timing/gptl.inc
@@ -39,6 +39,7 @@
       integer GPTL_L3MRT
 
       integer GPTLprofile_ovhd
+      integer GPTLdopr_quotes
 
       integer GPTLnanotime
       integer GPTLmpiwtime
@@ -87,6 +88,7 @@
       parameter (GPTL_L3MRT         = 26)
 
       parameter (GPTLprofile_ovhd   = 27)
+      parameter (GPTLdopr_quotes    = 28)
 
       parameter (GPTLgettimeofday   = 1)
       parameter (GPTLnanotime       = 2)

--- a/cime/src/share/timing/gptl.inc
+++ b/cime/src/share/timing/gptl.inc
@@ -23,7 +23,9 @@
       integer GPTLdopr_multparent
       integer GPTLdopr_collision
       integer GPTLprint_method
+      integer GPTLprint_mode
       integer GPTLtablesize
+      integer GPTLmaxthreads
 
       integer GPTL_IPC
       integer GPTL_CI
@@ -50,6 +52,9 @@
       integer GPTLmost_frequent
       integer GPTLfull_tree
 
+      integer GPTLprint_write
+      integer GPTLprint_append
+
       parameter (GPTLsync_mpi       = 0)
       parameter (GPTLwall           = 1)
       parameter (GPTLcpu            = 2)
@@ -66,7 +71,9 @@
       parameter (GPTLdopr_multparent= 14)
       parameter (GPTLdopr_collision = 15)
       parameter (GPTLprint_method   = 16)
-      parameter (GPTLtablesize      = 50)
+      parameter (GPTLprint_mode     = 50)
+      parameter (GPTLtablesize      = 51)
+      parameter (GPTLmaxthreads     = 52)
 
       parameter (GPTL_IPC           = 17)
       parameter (GPTL_CI            = 18)
@@ -93,6 +100,9 @@
       parameter (GPTLmost_frequent  = 3)
       parameter (GPTLfull_tree      = 4)
 
+      parameter (GPTLprint_write    = 1)
+      parameter (GPTLprint_append   = 2)
+
 ! Externals
 
       integer gptlsetoption
@@ -108,10 +118,8 @@
       integer gptlstartstop_vals
       integer gptlstartstop_valsf
       integer gptlstamp
-      integer gptlpr_set_append
-      integer gptlpr_query_append
-      integer gptlpr_set_write
-      integer gptlpr_query_write
+      integer gptlprint_mode_query
+      integer gptlprint_mode_set
       integer gptlpr
       integer gptlpr_file
       integer gptlpr_summary
@@ -147,10 +155,8 @@
       external gptlstartstop_vals
       external gptlstartstop_valsf
       external gptlstamp
-      external gptlpr_set_append
-      external gptlpr_query_append
-      external gptlpr_set_write
-      external gptlpr_query_write
+      external gptlprint_mode_query
+      external gptlprint_mode_set
       external gptlpr
       external gptlpr_file
       external gptlpr_summary

--- a/cime/src/share/timing/gptl.inc
+++ b/cime/src/share/timing/gptl.inc
@@ -109,6 +109,9 @@
 
       integer gptlsetoption
       integer gptlinitialize
+      integer gptlprefix_set
+      integer gptlprefix_setf
+      integer gptlprefix_unset
       integer gptlstart
       integer gptlstart_handle
       integer gptlstartf
@@ -146,6 +149,9 @@
 
       external gptlsetoption
       external gptlinitialize
+      external gptlprefix_set
+      external gptlprefix_setf
+      external gptlprefix_unset
       external gptlstart
       external gptlstart_handle
       external gptlstartf

--- a/cime/src/share/timing/perf_mod.F90
+++ b/cime/src/share/timing/perf_mod.F90
@@ -541,32 +541,16 @@ contains
    if ( .not. timing_initialized ) then
 
       if ( present(papi_ctr1_in) ) then
-         if (papi_ctr1_in < 0) then
-            papi_ctr1 = papi_ctr1_in
-         else
-            papi_ctr1 = PAPI_NULL
-         endif
+         papi_ctr1 = papi_ctr1_in
       endif
       if ( present(papi_ctr2_in) ) then
-         if (papi_ctr2_in < 0) then
-            papi_ctr2 = papi_ctr2_in
-         else
-            papi_ctr2 = PAPI_NULL
-         endif
+         papi_ctr2 = papi_ctr2_in
       endif
       if ( present(papi_ctr3_in) ) then
-         if (papi_ctr3_in < 0) then
-            papi_ctr3 = papi_ctr3_in
-         else
-            papi_ctr3 = PAPI_NULL
-         endif
+         papi_ctr3 = papi_ctr3_in
       endif
       if ( present(papi_ctr4_in) ) then
-         if (papi_ctr4_in < 0) then
-            papi_ctr4 = papi_ctr4_in
-         else
-            papi_ctr4 = PAPI_NULL
-         endif
+         papi_ctr4 = papi_ctr4_in
       endif
 !
 #ifdef DEBUG

--- a/cime/src/share/timing/perf_mod.F90
+++ b/cime/src/share/timing/perf_mod.F90
@@ -751,22 +751,22 @@ contains
       if (prefix_len > 0) then
          str_length = min(SHR_KIND_CM-prefix_len-5,len_trim(event))
          ierr = GPTLstart( &
-            '"'//cdetail//'_'//event_prefix(1:prefix_len)// &
-            event(1:str_length)//'"')
+            cdetail//'_'//event_prefix(1:prefix_len)// &
+            event(1:str_length))
       else
          str_length = min(SHR_KIND_CM-5,len_trim(event))
-         ierr = GPTLstart('"'//cdetail//'_'//event(1:str_length)//'"')
+         ierr = GPTLstart(cdetail//'_'//event(1:str_length))
       endif
 
    else
 
       if (prefix_len > 0) then
          str_length = min(SHR_KIND_CM-prefix_len-2,len_trim(event))
-         ierr = GPTLstart('"'//event_prefix(1:prefix_len)// &
-              event(1:str_length)//'"')
+         ierr = GPTLstart(event_prefix(1:prefix_len)// &
+              event(1:str_length))
       else
          str_length = min(SHR_KIND_CM-2,len_trim(event))
-         ierr = GPTLstart('"'//event(1:str_length)//'"')
+         ierr = GPTLstart(event(1:str_length))
       endif
 
 !pw   if ( present (handle) ) then
@@ -841,22 +841,22 @@ contains
       if (prefix_len > 0) then
          str_length = min(SHR_KIND_CM-prefix_len-5,len_trim(event))
          ierr = GPTLstop( &
-              '"'//cdetail//'_'//event_prefix(1:prefix_len)// &
-              event(1:str_length)//'"')
+              cdetail//'_'//event_prefix(1:prefix_len)// &
+              event(1:str_length))
       else
          str_length = min(SHR_KIND_CM-5,len_trim(event))
-         ierr = GPTLstop('"'//cdetail//'_'//event(1:str_length)//'"')
+         ierr = GPTLstop(cdetail//'_'//event(1:str_length))
       endif
 
    else
 
       if (prefix_len > 0) then
          str_length = min(SHR_KIND_CM-prefix_len-2,len_trim(event))
-         ierr = GPTLstop('"'//event_prefix(1:prefix_len)// &
-              event(1:str_length)//'"')
+         ierr = GPTLstop(event_prefix(1:prefix_len)// &
+              event(1:str_length))
      else
          str_length = min(SHR_KIND_CM-2,len_trim(event))
-         ierr = GPTLstop('"'//event(1:str_length)//'"')
+         ierr = GPTLstop(event(1:str_length))
      endif
 
 !pw   if ( present (handle) ) then
@@ -955,23 +955,23 @@ contains
       if (prefix_len > 0) then
          str_length = min(SHR_KIND_CM-prefix_len-5,len_trim(event))
          ierr = GPTLstartstop_vals( &
-            '"'//cdetail//'_'//event_prefix(1:prefix_len)// &
-            event(1:str_length)//'"', wtime, callcnt)
+            cdetail//'_'//event_prefix(1:prefix_len)// &
+            event(1:str_length), wtime, callcnt)
       else
          str_length = min(SHR_KIND_CM-5,len_trim(event))
          ierr = GPTLstartstop_vals( &
-            '"'//cdetail//'_'//event(1:str_length)//'"', wtime, callcnt)
+            cdetail//'_'//event(1:str_length), wtime, callcnt)
       endif
 
    else
 
       if (prefix_len > 0) then
          str_length = min(SHR_KIND_CM-prefix_len-2,len_trim(event))
-         ierr = GPTLstartstop_vals('"'//event_prefix(1:prefix_len)// &
-              event(1:str_length)//'"', wtime, callcnt)
+         ierr = GPTLstartstop_vals(event_prefix(1:prefix_len)// &
+              event(1:str_length), wtime, callcnt)
       else
          str_length = min(SHR_KIND_CM-2,len_trim(event))
-         ierr = GPTLstartstop_vals('"'//trim(event)//'"', wtime, callcnt)
+         ierr = GPTLstartstop_vals(trim(event), wtime, callcnt)
       endif
 
 !pw   if ( present (handle) ) then
@@ -1750,7 +1750,12 @@ contains
    !
    if (gptlsetoption (gptlcpu, 0) < 0) call shr_sys_abort (subname//':: gptlsetoption')
    !
+   ! Enable addition of double quotes to the output of timer names
    !
+   if (gptlsetoption (gptldopr_quotes, 1) < 0) &
+     call shr_sys_abort (subname//':: gptlsetoption')
+   !
+   ! Set maximum number of threads
    !
    if ( present(MaxThreads) ) then
       if (gptlsetoption (gptlmaxthreads, MaxThreads) < 0) &

--- a/cime/src/share/timing/perf_mod.F90
+++ b/cime/src/share/timing/perf_mod.F90
@@ -147,8 +147,8 @@ module perf_mod
 
    logical, parameter :: def_perf_add_detail = .false.         ! default
    logical, private   :: perf_add_detail = def_perf_add_detail
-                         ! flag indicating whether to prefix the
-                         ! timer name with the current detail level.
+                         ! flag indicating whether to add the current 
+                         ! detail level as a suffix to the timer name.
                          ! This requires that even t_startf/t_stopf
                          ! calls do not cross detail level changes
 
@@ -288,7 +288,7 @@ contains
    logical, intent(out), optional :: perf_papi_enable_out
    ! measure overhead of profiling directly
    logical, intent(out), optional :: perf_ovhd_measurement_out
-   ! prefix timer name with current detail level
+   ! 'suffix' timer name with current detail level
    logical, intent(out), optional :: perf_add_detail_out
 !-----------------------------------------------------------------------
    if ( present(timing_disable_out) ) then
@@ -379,7 +379,7 @@ contains
    logical, intent(in), optional :: perf_papi_enable_in
    ! measure overhead of profiling directly
    logical, intent(in), optional :: perf_ovhd_measurement_in
-   ! prefix timer name with current detail level
+   ! 'suffix' timer name with current detail level
    logical, intent(in), optional :: perf_add_detail_in
 !
 !---------------------------Local workspace-----------------------------
@@ -722,7 +722,7 @@ contains
 !
    integer  ierr                          ! GPTL error return
    integer  str_length, i                 ! support for adding
-                                          !  detail prefix
+                                          !  detail suffix
    character(len=2) cdetail               ! char variable for detail
    real(shr_kind_r8) ovhd_start, ovhd_stop, usr, sys
                                           ! for overhead calculation
@@ -751,11 +751,11 @@ contains
       if (prefix_len > 0) then
          str_length = min(SHR_KIND_CM-prefix_len-5,len_trim(event))
          ierr = GPTLstart( &
-            cdetail//'_'//event_prefix(1:prefix_len)// &
-            event(1:str_length))
+            event_prefix(1:prefix_len)// &
+            event(1:str_length)//'_'//cdetail)
       else
          str_length = min(SHR_KIND_CM-5,len_trim(event))
-         ierr = GPTLstart(cdetail//'_'//event(1:str_length))
+         ierr = GPTLstart(event(1:str_length)//'_'//cdetail)
       endif
 
    else
@@ -812,7 +812,7 @@ contains
 !
    integer  ierr                          ! GPTL error return
    integer  str_length, i                 ! support for adding
-                                          !  detail prefix
+                                          !  detail suffix
    character(len=2) cdetail               ! char variable for detail
    real(shr_kind_r8) ovhd_start, ovhd_stop, usr, sys
                                           ! for overhead calculation
@@ -841,11 +841,11 @@ contains
       if (prefix_len > 0) then
          str_length = min(SHR_KIND_CM-prefix_len-5,len_trim(event))
          ierr = GPTLstop( &
-              cdetail//'_'//event_prefix(1:prefix_len)// &
-              event(1:str_length))
+              event_prefix(1:prefix_len)// &
+              event(1:str_length)//'_'//cdetail)
       else
          str_length = min(SHR_KIND_CM-5,len_trim(event))
-         ierr = GPTLstop(cdetail//'_'//event(1:str_length))
+         ierr = GPTLstop(event(1:str_length)//'_'//cdetail)
       endif
 
    else
@@ -908,7 +908,7 @@ contains
 !
    integer  ierr                          ! GPTL error return
    integer  str_length, i                 ! support for adding 
-                                          !  detail prefix
+                                          !  detail suffix
    character(len=2) cdetail               ! char variable for detail
    integer  callcnt                       ! call count increment
    real(shr_kind_r8) wtime                ! walltime increment (seconds)
@@ -955,12 +955,12 @@ contains
       if (prefix_len > 0) then
          str_length = min(SHR_KIND_CM-prefix_len-5,len_trim(event))
          ierr = GPTLstartstop_vals( &
-            cdetail//'_'//event_prefix(1:prefix_len)// &
-            event(1:str_length), wtime, callcnt)
+            event_prefix(1:prefix_len)// &
+            event(1:str_length)//'_'//cdetail, wtime, callcnt)
       else
          str_length = min(SHR_KIND_CM-5,len_trim(event))
          ierr = GPTLstartstop_vals( &
-            cdetail//'_'//event(1:str_length), wtime, callcnt)
+            event(1:str_length)//'_'//cdetail, wtime, callcnt)
       endif
 
    else


### PR DESCRIPTION
With the inclusion of C/C++ native code in the model
(e.g. PIO2) there will be a need to call GPTL routines directly
and not just via perf_mod.F90 . Since many of the customizations
for E3SM/CESM are implemented in perf_mod.F90, direct calls
to the GPTL routines will circumvent the customizations. The
following changes address in particular support for surrounding
timer names with quotes and with adding/removing timer name
prefixes.

a) Update timing library with a collection of small changes

In the process of evaluating moving some of the timing library
customizations implemented in perf_mod into gptl.c,
a number of small improvements to the existing
timing library were identified (and implemented), as follows.

* Refactor implementation of interface for setting/querying
  write modes (append/write) to be more consistent
  with the rest of the timing library.
* Add support for setting GPTLmaxthreads (re-enabling capability
  already in GPTL)
* Add SEQUENTIAL to fortran open, to avoid problems on some systems.
* Add timing overhead measurement to perf_mod.
* Record whether events are 'on' or not as part of the global
  statisitics data collection and include in output. This requires
  a small change to the regular expression used to extract
  performance data in get_timing.py.
* Clean up white space.

b) Enable output of data for PAPI derived events.

A bug was introduced in perf_mod.F90 (a long time ago) that
marked PAPI derived events (as defined in GPTL) as being illegal,
and then ignored them. This restores the ability to report
the GPTL-supported derived events when using PAPI.

c) Move addition of double quotes to timer names to GPTL.

The double quoting of timer names is currently implemented only
in perf_mod.F90, and timer names when using the GPTL start/stop
routines directly will not have the quotes added. This commit
removes the logic adding double quotes to timer names in
perf_mod.F90 and adds it as an option for the output of timer
names in gptl.c . Thus internally the timer names do not have
the double quotes. This option is set during the timing library
initialization with perf_mod.F90.

d) Move detail information to end of the timer name

Setting the option profile_add_detail to .true. adds the detail
number associated with a timing event to the timer name (used
for detail debugging, evaluation, and planning). Currently this
is prepended to the timer name within perf_mod.F90. With the
move of the timer prefix logic to GPTL, this would place
the detail information between the prefix and the rest of the
timer name. This commit moves the detail number to the end of
the timer name, to make it easier to identify.

e) Move prefix support from perf_mod.F90 to GPTL

This commit moves the prefix support logic from perf_mod.F90
into gptl.c, so that a prefix set in the model will also modify
timer names for timing events defined using GPTLstart/stop,
for example.

This commit also adds support for defining a prefix in a threaded
region, where the prefix applies only to the particular thread.
The current design preserves a prefix defined in a serial region
and appends the prefix defined in a threaded region for that thread.
There are some subtleties in using this, e.g. if a prefix set in
a threaded region for thread 0 is not explicitly unset, it will
continue to be used for thread 0 events outside of the the threaded
region. Thread-specific prefixes is implemented only for OpenMP
threading.

BFB
