### PR TITLE
Update modules on edison after maintenance

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -690,7 +690,6 @@ for mct, etc.
   </FFLAGS>
 </compiler>
 
-<!-- Intel v18 is default on cori-knl and cori-haswell -->
 <compiler MACH="anlworkstation" COMPILER="gnu">
   <ALBANY_PATH>/projects/install/rhel6-x86_64/ACME/AlbanyTrilinos/Albany/build/install</ALBANY_PATH>
   <CFLAGS>
@@ -1129,6 +1128,7 @@ for mct, etc.
     <base> --host=Linux </base>
   </CONFIG_ARGS>
   <FFLAGS>
+    <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml </base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
   </FFLAGS>
   <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
@@ -1141,7 +1141,7 @@ for mct, etc.
   </SLIBS>
 </compiler>
 
-<!-- Edison still uses v17, but has an intel18 compiler option -->
+<!-- Edison still has intel18 compiler option for backward compat -->
 <compiler MACH="edison" COMPILER="intel18">
   <CFLAGS>
     <base> -O2 -fp-model precise -std=gnu99 </base>
@@ -1193,7 +1193,6 @@ for mct, etc.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
-<!-- Use Intel MPI with intel compiler on cori-knl -->
 <compiler MACH="eos" COMPILER="intel">
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -126,10 +126,10 @@
 
     <modules>
       <command name="rm">craype</command>
-      <command name="load">craype/2.5.12</command>
+      <command name="load">craype/2.5.14</command>
       <command name="load">craype-ivybridge</command>
       <command name="rm">pmi</command>
-      <command name="load">pmi/5.0.12</command>
+      <command name="load">pmi/5.0.13</command>
       <command name="rm">cray-mpich</command>
       <command name="load">cray-mpich/7.7.0</command>
     </modules>
@@ -137,7 +137,7 @@
     <modules compiler="intel">
       <command name="load">PrgEnv-intel/6.0.4</command>
       <command name="rm">intel</command>
-      <command name="load">intel/17.0.2.174</command>
+      <command name="load">intel/18.0.1.163</command>
       <command name="rm">cray-libsci</command>
     </modules>
 
@@ -152,9 +152,9 @@
       <command name="rm">PrgEnv-intel</command>
       <command name="load">PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
-      <command name="load">gcc/6.3.0</command>
+      <command name="load">gcc/7.3.0</command>
       <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/17.06.1</command>
+      <command name="load">cray-libsci/18.03.1</command>
     </modules>
 
     <modules compiler="gnu7">


### PR DESCRIPTION
Two real changes:

The GCC verion we were using is no longer available, and this updates to 7.3 (though currently can use 7.3 via --compiler=gnu7)

This change also increases the Intel version from 17 to 18 (and adjusts the compiler flags to be consistent with how we build with Intel 18)

