### PR TITLE
Fix snow compaction bug that was resulting in sporatic unphysical snow depths

### DIFF
--- a/components/clm/src/biogeophys/SnowHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SnowHydrologyMod.F90
@@ -635,10 +635,12 @@ contains
                          ddz3 = max(0._r8,min(1._r8,(swe_old(c,j) - wx)/wx))
 
                          ! 2nd term is delta fsno over fsno, allowing for negative values for ddz3
-                         wsum = sum(h2osoi_liq(c,snl(c)+1:0)+h2osoi_ice(c,snl(c)+1:0))
-                         fsno_melt = 1. - (acos(2.*min(1._r8,wsum/int_snow(c)) - 1._r8)/rpi)**(n_melt(c))
+                         if ((swe_old(c,j) - wx) > 0._r8) then
+                            wsum = sum(h2osoi_liq(c,snl(c)+1:0)+h2osoi_ice(c,snl(c)+1:0))
+                            fsno_melt = 1. - (acos(2.*min(1._r8,wsum/int_snow(c)) - 1._r8)/rpi)**(n_melt(c))
 
-                         ddz3 = ddz3 - max(0._r8,(fsno_melt - frac_sno(c))/frac_sno(c))
+                            ddz3 = ddz3 - max(0._r8,(fsno_melt - frac_sno(c))/frac_sno(c))
+                         endif
                          ddz3 = -1._r8/dtime * ddz3
                       else
                          ddz3 = - 1._r8/dtime * max(0._r8,(frac_iceold(c,j) - fi)/frac_iceold(c,j))


### PR DESCRIPTION
This PR adds a fix to a bug in the snow compaction routine. It was discovered during analysis of the DECK runs, which showed snow depths of up to 1800m that did not persist. The fix is from the CESM version of CLM and was tested in a 16-year A_WCYCL1850S_CMIP6.ne30_oECv3_ICG run on anvil, which was mostly looking to see if it fixes our known water budget issues. It does not appear to be the root cause of the water drawdown from the land model, but should be fixed nonetheless.

Fixes #2546 

[non-BFB]