### PR TITLE
Bugfix for the IEFLX output

### DIFF
--- a/components/cam/src/physics/cam/check_energy.F90
+++ b/components/cam/src/physics/cam/check_energy.F90
@@ -666,7 +666,6 @@ subroutine ieflx_gmean(state, tend, pbuf2d, cam_in, cam_out, nstep)
 
 !- 
     ieflx_glob = 0._r8
-    ieflx      = 0._r8 
 
     qflx = 0._r8 
     rain = 0._r8 

--- a/components/cam/src/physics/cam/check_energy.F90
+++ b/components/cam/src/physics/cam/check_energy.F90
@@ -713,7 +713,7 @@ subroutine ieflx_gmean(state, tend, pbuf2d, cam_in, cam_out, nstep)
 
        ieflx(:ncol) = ieflx_glob
 
-       call outfld('IEFLX', ieflx(:ncol), pcols, lchnk)
+       call outfld('IEFLX', ieflx, pcols, lchnk)
 
     end do
 

--- a/components/cam/src/physics/cam/check_energy.F90
+++ b/components/cam/src/physics/cam/check_energy.F90
@@ -666,6 +666,7 @@ subroutine ieflx_gmean(state, tend, pbuf2d, cam_in, cam_out, nstep)
 
 !- 
     ieflx_glob = 0._r8
+    ieflx      = 0._r8 
 
     qflx = 0._r8 
     rain = 0._r8 
@@ -711,7 +712,7 @@ subroutine ieflx_gmean(state, tend, pbuf2d, cam_in, cam_out, nstep)
 !DIR$ CONCURRENT
     do lchnk = begchunk, endchunk
 
-       ieflx(:ncol) = ieflx_glob
+       ieflx = ieflx_glob
 
        call outfld('IEFLX', ieflx, pcols, lchnk)
 


### PR DESCRIPTION
"ieflx(:ncol)" should be "ieflx" in the outfld call. On machines where pcols is not equal to ncol, a machine-dependent value (zero or NaN) will be assigned to a certain grid boxes.  This resulted in a bfb diff when c636144 was merged and the chunk assignments changed. 

This bug will not affect the simulation. It will only affect the IEFLX output.

[BFB] when ieflx_opt = 0 
[NBFB] when ieflx_opt > 0, and only for the IEFLX output (all other variables BFB). 

Fixes #2548