### PR TITLE
Switch atmospheric forcing variables to topounit subgrid level

### DIFF
--- a/cime/config/e3sm/allactive/config_compsets.xml
+++ b/cime/config/e3sm/allactive/config_compsets.xml
@@ -303,36 +303,4 @@
   <lname>20TR_CAM5_CLM45%CNECACTCBC_CICE_DOCN%SOM_MOSART_SGLC_SWAV</lname>
 </compset>
 
-<entries>
-
-  <entry id="RUN_STARTDATE">
-    <values>
-      <value  compset="20TR_CAM">1850-01-01</value>
-    </values>
-  </entry>
-
-  <entry id="RUN_REFDATE">
-     <values match="first">
-       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_g%null_w%null_m%oEC60to30v3"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >0331-01-01</value>
-      </values>
-  </entry>
-
-  <entry id="RUN_TYPE">
-     <values match="first">
-       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_g%null_w%null_m%oEC60to30v3"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >hybrid</value>
-      </values>
-  </entry>
-
-  <entry id="RUN_REFCASE">
-     <values match="first">
-       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_g%null_w%null_m%oEC60to30v3"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >20171228.beta3rc13_1850.ne30_oECv3_ICG.edison</value>
-      </values>
-  </entry>
-
-  <entry id="RUN_REFDIR">
-     <values match="first">
-       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_g%null_w%null_m%oEC60to30v3"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >e3sm_init</value>
-      </values>
-  </entry>
-</entries>
 </compsets>

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -113,17 +113,17 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- HOMME grid ne4 resolution -->
 
 <finidat hgrid="ne4np4"   maxpft="17"  mask="oQU240" use_cn=".false." ic_ymd="18500101" more_vertlayers=".false."
- ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.I1850CLM45.ne4_qu240.5712d76.clm2.r.0021-01-01-00000.nc
+ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.I1850CLM45.ne4_oQU240.67a0f98.0021-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="ne4np4"   maxpft="17"  mask="oQU240" use_cn=".false." ic_ymd="20000101" more_vertlayers=".false."
- ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICRUCLM45.ne4_oQU240.1155ba0.clm2.r.nc
+ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICRUCLM45.ne4_oQU240.67a0f98.0001-01-04-00000.nc
 </finidat>
 
 <!-- HOMME grid ne11 resolution -->
 
 <finidat hgrid="ne11np4"   maxpft="17"  mask="oQU240" use_cn=".false." ic_ymd="18500101" more_vertlayers=".false."
- ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.I1850CLM45.ne11_oQU240.1155ba0.clm2.r.nc
+ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.I1850CLM45.ne11_oQU240.67a0f98.1850-01-07-00000.nc
 </finidat>
 
 <finidat hgrid="ne11np4"   maxpft="17"  mask="oQU240" use_cn=".false." ic_ymd="20000101" more_vertlayers=".false."
@@ -190,7 +190,7 @@ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".true." irrigate=".true." nu_co
 <!-- RRM CONUS, ARM, and ENA resolutions.  maxxpft, mask, bgc unknown -->
 <finidat hgrid="ne0np4_arm_x8v3_lowcon"  ic_ymd="101" sim_year="2000">lnd/clm2/initdata/clmi.armx8v3.1850-01-01.nc</finidat>
 <finidat hgrid="ne0np4_conus_x4v1_lowcon" ic_ymd="101" sim_year="1850">lnd/clm2/initdata_map/clmi.I1850CLM45.conusx4v1.74e105b.clm2.r.0021-01-01-00000.nc</finidat>
-<finidat hgrid="ne0np4_conus_x4v1_lowcon" ic_ymd="101" sim_year="2000">lnd/clm2/initdata_map/clmi.ICRUCLM45.0021-01-01.conusx4v1.0ac6464_simyr2000_c161130.nc</finidat>
+<finidat hgrid="ne0np4_conus_x4v1_lowcon" ic_ymd="101" sim_year="2000">lnd/clm2/initdata_map/clmi.ICRUCLM45.conusx4v1_conusx4v1.67a0f98.2000-01-01-00000.nc</finidat>
 <finidat hgrid="ne0np4_enax4v1" sim_year="2000">lnd/clm2/initdata_map/clmi.ICRUCLM45SP.2000-01-01.enax4v1_oRRS18to6_simyr2000_c170621.nc</finidat>
 <finidat hgrid="ne0np4_twpx4v1" ic_ymd="101" sim_year="2000">lnd/clm2/initdata_map/clmi.ICRUCLM45SP.2000-01-01.twpx4v1_oRRS18to6v3_simyr2000_c170712.nc</finidat>
 

--- a/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
@@ -33,6 +33,5 @@
       
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
-<finidat>lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
 
 </namelist_defaults>

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I1850GSWCNPRDCTCBC/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I1850GSWCNPRDCTCBC/user_nl_clm
@@ -1,2 +1,2 @@
-finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I1850GSWCNPRDCTCBC.f19_g16.0401-01-01-00000.nc'
+finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I1850GSWCNPRDCTCBC.f19_g16.67a0f98.0401-01-01-00000.nc'
 

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I20TRGSWCNPRDCTCBC/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/ctc_f19_g16_I20TRGSWCNPRDCTCBC/user_nl_clm
@@ -1,2 +1,2 @@
-finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I20TRGSWCNPRDCTCBC.f19_g16.0401-01-01-00000.nc'
+finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I20TRGSWCNPRDCTCBC.f19_g16.67a0f98.0401-01-01-00000.nc'
 

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I1850GSWCNPECACNTBC/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I1850GSWCNPECACNTBC/user_nl_clm
@@ -1,3 +1,3 @@
-finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I1850GSWCNPECACNTBC.f19_g16.0201-01-01-00000.nc'
+finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I1850GSWCNPECACNTBC.f19_g16.67a0f98.0201-01-01-00000.nc'
 NFIX_PTASE_plant = .true.
 

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I20TRGSWCNPECACNTBC/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/eca_f19_g16_I20TRGSWCNPECACNTBC/user_nl_clm
@@ -1,2 +1,2 @@
-finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I1850GSWCNPECACNTBC.f19_g16.0201-01-01-00000.nc'
+finidat             = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.I1850GSWCNPECACNTBC.f19_g16.67a0f98.0201-01-01-00000.nc'
 

--- a/components/clm/src/biogeochem/CNFireMod.F90
+++ b/components/clm/src/biogeochem/CNFireMod.F90
@@ -44,7 +44,7 @@ module CNFireMod
   use TemperatureType        , only : temperature_type
   use WaterstateType         , only : waterstate_type
   use GridcellType           , only : grc_pp
-  use TopounitType           , only : top_as  
+  use TopounitType           , only : top_as, top_af ! atmospheric state and flux variables  
   use ColumnType             , only : col_pp                
   use VegetationType         , only : veg_pp                
   use mct_mod
@@ -194,8 +194,8 @@ contains
          forc_rh            =>    top_as%rhbot                              , & ! Input:  [real(r8) (:)     ]  relative humidity                                 
          forc_wind          =>    top_as%windbot                            , & ! Input:  [real(r8) (:)     ]  atmospheric wind speed (m/s)                       
          forc_t             =>    top_as%tbot                               , & ! Input:  [real(r8) (:)     ]  atmospheric temperature (Kelvin)                  
-         forc_rain          =>    atm2lnd_vars%forc_rain_downscaled_col     , & ! Input:  [real(r8) (:)     ]  downscaled rain                                              
-         forc_snow          =>    atm2lnd_vars%forc_snow_downscaled_col     , & ! Input:  [real(r8) (:)     ]  downscaled snow                                              
+         forc_rain          =>    top_af%rain                               , & ! Input:  [real(r8) (:)     ]  rain rate (kg H2O/m**2/s, or mm liquid H2O/s)                                              
+         forc_snow          =>    top_af%snow                               , & ! Input:  [real(r8) (:)     ]  snow rate (kg H2O/m**2/s, or mm liquid H2O/s)                                            
 #ifdef CPL_BYPASS
          forc_hdm           =>    atm2lnd_vars%forc_hdm                     , & ! Input:  [real(r8) (:)     ]  population density
          forc_lnfm          =>    atm2lnd_vars%forc_lnfm                    , & ! Input:  [real(r8) (:)     ]  ligntning data 
@@ -506,7 +506,7 @@ contains
               p = col_pp%pfti(c) + pi - 1
               ! For crop
               if( forc_t(t)  >=  SHR_CONST_TKFRZ .and. veg_pp%itype(p)  >  nc4_grass .and.  &
-                   kmo == abm_lf(c) .and. forc_rain(c)+forc_snow(c) == 0._r8  .and. &
+                   kmo == abm_lf(c) .and. forc_rain(t)+forc_snow(t) == 0._r8  .and. &
                    burndate(p) >= 999 .and. veg_pp%wtcol(p)  >  0._r8 )then ! catch  crop burn time
 
                  ! calculate human density impact on ag. fire
@@ -623,7 +623,7 @@ contains
                     cli = (max(0._r8,min(1._r8,(cri-prec60_col(c)*secspday)/cri))**0.5)* &
                          (max(0._r8,min(1._r8,(cri-prec10_col(c)*secspday)/cri))**0.5)* &
                          max(0.0005_r8,min(1._r8,19._r8*dtrotr_col(c)*dayspyr*secspday/dt-0.001_r8))* &
-                         max(0._r8,min(1._r8,(0.25_r8-(forc_rain(c)+forc_snow(c))*secsphr)/0.25_r8))
+                         max(0._r8,min(1._r8,(0.25_r8-(forc_rain(t)+forc_snow(t))*secsphr)/0.25_r8))
                     farea_burned(c) = cli*(cli_scale/secspday)+baf_crop(c)+baf_peatf(c)
                     ! burned area out of conversion region due to land use fire
                     fbac1(c) = max(0._r8,cli*(cli_scale/secspday) - 2.0_r8*lfc(c)/dt)   

--- a/components/clm/src/biogeochem/CNFireMod.F90
+++ b/components/clm/src/biogeochem/CNFireMod.F90
@@ -192,7 +192,7 @@ contains
          is_cwd             =>    decomp_cascade_con%is_cwd                 , & ! Input:  [logical  (:)     ]  TRUE => pool is a cwd pool                         
          
          forc_rh            =>    atm2lnd_vars%forc_rh_grc                  , & ! Input:  [real(r8) (:)     ]  relative humidity                                 
-         forc_wind          =>    atm2lnd_vars%forc_wind_grc                , & ! Input:  [real(r8) (:)     ]  atmospheric wind speed (m/s)                       
+         forc_wind          =>    top_as%windbot                            , & ! Input:  [real(r8) (:)     ]  atmospheric wind speed (m/s)                       
          forc_t             =>    top_as%tbot                               , & ! Input:  [real(r8) (:)     ]  atmospheric temperature (Kelvin)                  
          forc_rain          =>    atm2lnd_vars%forc_rain_downscaled_col     , & ! Input:  [real(r8) (:)     ]  downscaled rain                                              
          forc_snow          =>    atm2lnd_vars%forc_snow_downscaled_col     , & ! Input:  [real(r8) (:)     ]  downscaled snow                                              
@@ -595,7 +595,7 @@ contains
               fs       = 1._r8-(0.01_r8+0.98_r8*exp(-0.025_r8*hdmlf))
               ig       = (lh+forc_lnfm(g)/(5.16_r8+2.16_r8*cos(3._r8*grc_pp%lat(g)))*0.25_r8)*(1._r8-fs)*(1._r8-cropf_col(c)) 
               nfire(c) = ig/secsphr*fb*fire_m*lgdp_col(c) !fire counts/km2/sec
-              Lb_lf    = 1._r8+10.0_r8*(1._r8-EXP(-0.06_r8*forc_wind(g)))
+              Lb_lf    = 1._r8+10.0_r8*(1._r8-EXP(-0.06_r8*forc_wind(t)))
               if ( wtlf(c) > 0.0_r8 )then
                  spread_m = (1.0_r8 - max(0._r8,min(1._r8,(btran_col(c)/wtlf(c)-0.3_r8)/ &
                       (0.7_r8-0.3_r8))))*(1.0_r8-max(0._r8, &

--- a/components/clm/src/biogeochem/CNFireMod.F90
+++ b/components/clm/src/biogeochem/CNFireMod.F90
@@ -191,7 +191,7 @@ contains
     associate(                                                                & 
          is_cwd             =>    decomp_cascade_con%is_cwd                 , & ! Input:  [logical  (:)     ]  TRUE => pool is a cwd pool                         
          
-         forc_rh            =>    atm2lnd_vars%forc_rh_grc                  , & ! Input:  [real(r8) (:)     ]  relative humidity                                 
+         forc_rh            =>    top_as%rhbot                              , & ! Input:  [real(r8) (:)     ]  relative humidity                                 
          forc_wind          =>    top_as%windbot                            , & ! Input:  [real(r8) (:)     ]  atmospheric wind speed (m/s)                       
          forc_t             =>    top_as%tbot                               , & ! Input:  [real(r8) (:)     ]  atmospheric temperature (Kelvin)                  
          forc_rain          =>    atm2lnd_vars%forc_rain_downscaled_col     , & ! Input:  [real(r8) (:)     ]  downscaled rain                                              
@@ -589,7 +589,7 @@ contains
               fb       = max(0.0_r8,min(1.0_r8,(fuelc(c)-lfuel)/(ufuel-lfuel)))
               m        = max(0._r8,wf(c))
               fire_m   = exp(-SHR_CONST_PI *(m/0.69_r8)**2)*(1.0_r8 - max(0._r8, &
-                   min(1._r8,(forc_rh(g)-30._r8)/(80._r8-30._r8))))*  &
+                   min(1._r8,(forc_rh(t)-30._r8)/(80._r8-30._r8))))*  &
                    min(1._r8,exp(SHR_CONST_PI*(forc_t(t)-SHR_CONST_TKFRZ)/10._r8))
               lh       = 0.0035_r8*6.8_r8*hdmlf**(0.43_r8)/30._r8/24._r8
               fs       = 1._r8-(0.01_r8+0.98_r8*exp(-0.025_r8*hdmlf))
@@ -599,7 +599,7 @@ contains
               if ( wtlf(c) > 0.0_r8 )then
                  spread_m = (1.0_r8 - max(0._r8,min(1._r8,(btran_col(c)/wtlf(c)-0.3_r8)/ &
                       (0.7_r8-0.3_r8))))*(1.0_r8-max(0._r8, &
-                      min(1._r8,(forc_rh(g)-30._r8)/(80._r8-30._r8))))
+                      min(1._r8,(forc_rh(t)-30._r8)/(80._r8-30._r8))))
               else
                  spread_m = 0.0_r8
               end if

--- a/components/clm/src/biogeochem/CNPhenologyMod.F90
+++ b/components/clm/src/biogeochem/CNPhenologyMod.F90
@@ -30,9 +30,10 @@ module CNPhenologyMod
   use atm2lndType         , only : atm2lnd_type
   use TemperatureType     , only : temperature_type
   use WaterstateType      , only : waterstate_type
-  use ColumnType          , only : col_pp                
+  use ColumnType          , only : col_pp 
+  use TopounitType        , only : top_af  
   use GridcellType        , only : grc_pp                
-  use VegetationType           , only : veg_pp                
+  use VegetationType      , only : veg_pp                
   use PhosphorusFluxType  , only : phosphorusflux_type
   use PhosphorusStateType , only : phosphorusstate_type
   use clm_varctl          , only : nu_com 
@@ -901,7 +902,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     real(r8),parameter :: secspqtrday = secspday / 4  ! seconds per quarter day
-    integer :: g,c,p           ! indices
+    integer :: g,t,c,p           ! indices
     integer :: fp              ! lake filter pft index
     real(r8):: dayspyr         ! days per year
     real(r8):: crit_onset_gdd  ! degree days for onset trigger
@@ -922,7 +923,7 @@ contains
          
          t_soisno                            =>    temperature_vars%t_soisno_col                         , & ! Input:  [real(r8)  (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevgrnd)
          
-         prec10                              =>    atm2lnd_vars%prec10_patch                             , & ! Input:  [real(r8) (:)    ]  10-day running mean precipitation
+         prec10                              =>    top_af%prec10d                                        , & ! Input:  [real(r8) (:)    ]  10-day running mean precipitation, mm H2O/s
          dormant_flag                        =>    cnstate_vars%dormant_flag_patch                       , & ! Output:  [real(r8) (:)   ]  dormancy flag                                     
          days_active                         =>    cnstate_vars%days_active_patch                        , & ! Output:  [real(r8) (:)   ]  number of days since last dormancy                
          onset_flag                          =>    cnstate_vars%onset_flag_patch                         , & ! Output:  [real(r8) (:)   ]  onset flag                                        
@@ -1032,6 +1033,7 @@ contains
       do fp = 1,num_soilp
          p = filter_soilp(fp)
          c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
          g = veg_pp%gridcell(p)
 
          if (stress_decid(ivt(p)) == 1._r8) then
@@ -1175,7 +1177,7 @@ contains
                end if
                ! Require cumulative precipitation threshold for onset 
                ! Dahlin et al., Biogeosciences 2015.
-               if (prec10(p) * 86400._r8 * 10._r8 < cumprec_onset .and. nu_com .eq. 'RD') then
+               if (prec10(t) * 86400._r8 * 10._r8 < cumprec_onset .and. nu_com .eq. 'RD') then
                   onset_flag(p) = 0._r8
                end if
 

--- a/components/clm/src/biogeochem/DUSTMod.F90
+++ b/components/clm/src/biogeochem/DUSTMod.F90
@@ -212,7 +212,7 @@ contains
 
     !
     ! !LOCAL VARIABLES
-    integer  :: fp,p,c,l,g,m,n      ! indices
+    integer  :: fp,p,c,l,t,g,m,n      ! indices
     real(r8) :: liqfrac             ! fraction of total water that is liquid
     real(r8) :: wnd_frc_rat         ! [frc] Wind friction threshold over wind friction
     real(r8) :: wnd_frc_slt_dlt     ! [m s-1] Friction velocity increase from saltatn
@@ -242,7 +242,7 @@ contains
     !------------------------------------------------------------------------
 
     associate(                                                         & 
-         forc_rho            => atm2lnd_vars%forc_rho_downscaled_col , & ! Input:  [real(r8) (:)   ]  downscaled density (kg/m**3)                                 
+         forc_rho            => top_as%rhobot                        , & ! Input:  [real(r8) (:)   ]  air density (kg/m**3)                                 
          
          gwc_thr             => soilstate_vars%gwc_thr_col           , & ! Input:  [real(r8) (:)   ]  threshold gravimetric soil moisture based on clay content
          mss_frc_cly_vld     => soilstate_vars%mss_frc_cly_vld_col   , & ! Input:  [real(r8) (:)   ]  [frc] Mass fraction clay limited to 0.20          
@@ -351,6 +351,7 @@ contains
          p = filter_nolakep(fp)
          c = veg_pp%column(p)
          l = veg_pp%landunit(p)
+         t = veg_pp%topounit(p)
          g = veg_pp%gridcell(p)
 
          ! only perform the following calculations if lnd_frc_mbl is non-zero 
@@ -387,7 +388,7 @@ contains
             !          subr. wnd_frc_thr_slt_get which computes dry threshold
             !          friction velocity for saltation
 
-            wnd_frc_thr_slt = tmp1 / sqrt(forc_rho(c)) * frc_thr_wet_fct * frc_thr_rgh_fct
+            wnd_frc_thr_slt = tmp1 / sqrt(forc_rho(t)) * frc_thr_wet_fct * frc_thr_rgh_fct
 
             ! reset these variables which will be updated in the following if-block
 
@@ -415,7 +416,7 @@ contains
 
             if (wnd_frc_slt > wnd_frc_thr_slt) then
                wnd_frc_rat = wnd_frc_thr_slt / wnd_frc_slt
-               flx_mss_hrz_slt_ttl = cst_slt * forc_rho(c) * (wnd_frc_slt**3.0_r8) * &
+               flx_mss_hrz_slt_ttl = cst_slt * forc_rho(t) * (wnd_frc_slt**3.0_r8) * &
                     (1.0_r8 - wnd_frc_rat) * (1.0_r8 + wnd_frc_rat) * (1.0_r8 + wnd_frc_rat) / grav
 
                ! the following loop originates from subr. dst_mbl
@@ -512,7 +513,7 @@ contains
 
     associate(                                                   & 
          forc_pbot =>    top_as%pbot                           , & ! Input:  [real(r8)  (:)   ]  atm pressure (Pa)                                 
-         forc_rho  =>    atm2lnd_vars%forc_rho_downscaled_col  , & ! Input:  [real(r8)  (:)   ]  atm density (kg/m**3)                             
+         forc_rho  =>    top_as%rhobot                         , & ! Input:  [real(r8)  (:)   ]  atm density (kg/m**3)                             
          forc_t    =>    top_as%tbot                           , & ! Input:  [real(r8)  (:)   ]  atm temperature (K)                               
          
          ram1      =>    frictionvel_vars%ram1_patch           , & ! Input:  [real(r8)  (:)   ]  aerodynamical resistance (s/m)                    
@@ -542,7 +543,7 @@ contains
                  (forc_t(t)+120.0_r8)      ![kg m-1 s-1] RoY94 p. 102
             mfp_atm = 2.0_r8 * vsc_dyn_atm(p) / &   ![m] SeP97 p. 455
                  (forc_pbot(t)*sqrt(8.0_r8/(SHR_CONST_PI*SHR_CONST_RDAIR*forc_t(t))))
-            vsc_knm_atm(p) = vsc_dyn_atm(p) / forc_rho(c) ![m2 s-1] Kinematic viscosity of air
+            vsc_knm_atm(p) = vsc_dyn_atm(p) / forc_rho(t) ![m2 s-1] Kinematic viscosity of air
 
             do m = 1, ndst
                slp_crc(p,m) = 1.0_r8 + 2.0_r8 * mfp_atm * &

--- a/components/clm/src/biogeochem/DUSTMod.F90
+++ b/components/clm/src/biogeochem/DUSTMod.F90
@@ -30,7 +30,7 @@ module DUSTMod
   use TopounitType         , only : top_as
   use LandunitType         , only : lun_pp
   use ColumnType           , only : col_pp
-  use VegetationType            , only : veg_pp
+  use VegetationType       , only : veg_pp
   !  
   ! !PUBLIC TYPES
   implicit none
@@ -511,7 +511,7 @@ contains
     !------------------------------------------------------------------------
 
     associate(                                                   & 
-         forc_pbot =>    atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8)  (:)   ]  atm pressure (Pa)                                 
+         forc_pbot =>    top_as%pbot                           , & ! Input:  [real(r8)  (:)   ]  atm pressure (Pa)                                 
          forc_rho  =>    atm2lnd_vars%forc_rho_downscaled_col  , & ! Input:  [real(r8)  (:)   ]  atm density (kg/m**3)                             
          forc_t    =>    top_as%tbot                           , & ! Input:  [real(r8)  (:)   ]  atm temperature (K)                               
          
@@ -541,7 +541,7 @@ contains
             vsc_dyn_atm(p) = 1.72e-5_r8 * ((forc_t(t)/273.0_r8)**1.5_r8) * 393.0_r8 / &
                  (forc_t(t)+120.0_r8)      ![kg m-1 s-1] RoY94 p. 102
             mfp_atm = 2.0_r8 * vsc_dyn_atm(p) / &   ![m] SeP97 p. 455
-                 (forc_pbot(c)*sqrt(8.0_r8/(SHR_CONST_PI*SHR_CONST_RDAIR*forc_t(t))))
+                 (forc_pbot(t)*sqrt(8.0_r8/(SHR_CONST_PI*SHR_CONST_RDAIR*forc_t(t))))
             vsc_knm_atm(p) = vsc_dyn_atm(p) / forc_rho(c) ![m2 s-1] Kinematic viscosity of air
 
             do m = 1, ndst

--- a/components/clm/src/biogeochem/DryDepVelocity.F90
+++ b/components/clm/src/biogeochem/DryDepVelocity.F90
@@ -218,7 +218,7 @@ CONTAINS
          forc_solai =>    atm2lnd_vars%forc_solai_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
          forc_solad =>    atm2lnd_vars%forc_solad_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
          forc_t     =>    top_as%tbot                           , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)                   
-         forc_q     =>    atm2lnd_vars%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric specific humidity (kg/kg)              
+         forc_q     =>    top_as%qbot                           , & ! Input:  [real(r8) (:)   ] atmospheric specific humidity (kg/kg)              
          forc_psrf  =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ] surface pressure (Pa)                              
          forc_rain  =>    atm2lnd_vars%forc_rain_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled rain rate [mm/s]                                   
 
@@ -254,7 +254,7 @@ CONTAINS
             !solar_flux = forc_lwrad  !rename CLM variables to fit with Dry Dep variables 
 
             pg         = forc_psrf(t)  
-            spec_hum   = forc_q(c)
+            spec_hum   = forc_q(t)
             rain       = forc_rain(c) 
             sfc_temp   = forc_t(t) 
             solar_flux = forc_solad(g,1) 

--- a/components/clm/src/biogeochem/DryDepVelocity.F90
+++ b/components/clm/src/biogeochem/DryDepVelocity.F90
@@ -61,7 +61,8 @@ Module DryDepVelocity
   use FrictionVelocityType , only : frictionvel_type
   use PhotosynthesisType   , only : photosyns_type
   use WaterstateType       , only : waterstate_type
-  use GridcellType         , only : grc_pp                
+  use GridcellType         , only : grc_pp
+  use TopounitType         , only : top_as  
   use LandunitType         , only : lun_pp                
   use VegetationType            , only : veg_pp                
   !
@@ -154,7 +155,7 @@ CONTAINS
     ! !LOCAL VARIABLES:
     integer  :: c
     real(r8) :: soilw, var_soilw, fact_h2, dv_soil_h2
-    integer  :: pi,g, l
+    integer  :: pi,g,t,l
     integer  :: ispec 
     integer  :: length 
     integer  :: wesveg       !wesely vegegation index  
@@ -216,7 +217,7 @@ CONTAINS
     associate(                                                    & 
          forc_solai =>    atm2lnd_vars%forc_solai_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
          forc_solad =>    atm2lnd_vars%forc_solad_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
-         forc_t     =>    atm2lnd_vars%forc_t_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric temperature (Kelvin)                   
+         forc_t     =>    top_as%tbot                           , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)                   
          forc_q     =>    atm2lnd_vars%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric specific humidity (kg/kg)              
          forc_psrf  =>    atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled surface pressure (Pa)                              
          forc_rain  =>    atm2lnd_vars%forc_rain_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled rain rate [mm/s]                                   
@@ -248,13 +249,14 @@ CONTAINS
          active: if (veg_pp%active(pi)) then
 
             c = veg_pp%column(pi)
+            t = veg_pp%topounit(pi)
             g = veg_pp%gridcell(pi)
             !solar_flux = forc_lwrad  !rename CLM variables to fit with Dry Dep variables 
 
             pg         = forc_psrf(c)  
             spec_hum   = forc_q(c)
             rain       = forc_rain(c) 
-            sfc_temp   = forc_t(c) 
+            sfc_temp   = forc_t(t) 
             solar_flux = forc_solad(g,1) 
             lat        = grc_pp%latdeg(g) 
             lon        = grc_pp%londeg(g) 

--- a/components/clm/src/biogeochem/DryDepVelocity.F90
+++ b/components/clm/src/biogeochem/DryDepVelocity.F90
@@ -64,7 +64,7 @@ Module DryDepVelocity
   use GridcellType         , only : grc_pp
   use TopounitType         , only : top_as  
   use LandunitType         , only : lun_pp                
-  use VegetationType            , only : veg_pp                
+  use VegetationType       , only : veg_pp                
   !
   implicit none 
   save 
@@ -219,7 +219,7 @@ CONTAINS
          forc_solad =>    atm2lnd_vars%forc_solad_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
          forc_t     =>    top_as%tbot                           , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)                   
          forc_q     =>    atm2lnd_vars%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric specific humidity (kg/kg)              
-         forc_psrf  =>    atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled surface pressure (Pa)                              
+         forc_psrf  =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ] surface pressure (Pa)                              
          forc_rain  =>    atm2lnd_vars%forc_rain_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled rain rate [mm/s]                                   
 
          h2osoi_vol =>    waterstate_vars%h2osoi_vol_col        , & ! Input:  [real(r8) (:,:) ] volumetric soil water (0<=h2osoi_vol<=watsat)   
@@ -253,7 +253,7 @@ CONTAINS
             g = veg_pp%gridcell(pi)
             !solar_flux = forc_lwrad  !rename CLM variables to fit with Dry Dep variables 
 
-            pg         = forc_psrf(c)  
+            pg         = forc_psrf(t)  
             spec_hum   = forc_q(c)
             rain       = forc_rain(c) 
             sfc_temp   = forc_t(t) 

--- a/components/clm/src/biogeochem/DryDepVelocity.F90
+++ b/components/clm/src/biogeochem/DryDepVelocity.F90
@@ -62,7 +62,7 @@ Module DryDepVelocity
   use PhotosynthesisType   , only : photosyns_type
   use WaterstateType       , only : waterstate_type
   use GridcellType         , only : grc_pp
-  use TopounitType         , only : top_as  
+  use TopounitType         , only : top_as, top_af ! atmospheric state and flux variables  
   use LandunitType         , only : lun_pp                
   use VegetationType       , only : veg_pp                
   !
@@ -220,7 +220,7 @@ CONTAINS
          forc_t     =>    top_as%tbot                           , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)                   
          forc_q     =>    top_as%qbot                           , & ! Input:  [real(r8) (:)   ] atmospheric specific humidity (kg/kg)              
          forc_psrf  =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ] surface pressure (Pa)                              
-         forc_rain  =>    atm2lnd_vars%forc_rain_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled rain rate [mm/s]                                   
+         forc_rain  =>    top_af%rain                           , & ! Input:  [real(r8) (:)   ] rain rate (kg H2O/m**2/s, or mm liquid H2O/s)                                   
 
          h2osoi_vol =>    waterstate_vars%h2osoi_vol_col        , & ! Input:  [real(r8) (:,:) ] volumetric soil water (0<=h2osoi_vol<=watsat)   
          snow_depth =>    waterstate_vars%snow_depth_col        , & ! Input:  [real(r8) (:)   ] snow height (m)                                   
@@ -255,7 +255,7 @@ CONTAINS
 
             pg         = forc_psrf(t)  
             spec_hum   = forc_q(t)
-            rain       = forc_rain(c) 
+            rain       = forc_rain(t) 
             sfc_temp   = forc_t(t) 
             solar_flux = forc_solad(g,1) 
             lat        = grc_pp%latdeg(g) 

--- a/components/clm/src/biogeochem/DryDepVelocity.F90
+++ b/components/clm/src/biogeochem/DryDepVelocity.F90
@@ -215,8 +215,8 @@ CONTAINS
     if ( n_drydep == 0 .or. drydep_method /= DD_XLND ) return
 
     associate(                                                    & 
-         forc_solai =>    atm2lnd_vars%forc_solai_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
-         forc_solad =>    atm2lnd_vars%forc_solad_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
+         forc_solai =>    top_af%solai                          , & ! Input:  [real(r8) (:,:) ] direct beam radiation (W/m**2)          
+         forc_solad =>    top_af%solad                          , & ! Input:  [real(r8) (:,:) ] diffuse beam radiation (W/m**2)             
          forc_t     =>    top_as%tbot                           , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)                   
          forc_q     =>    top_as%qbot                           , & ! Input:  [real(r8) (:)   ] atmospheric specific humidity (kg/kg)              
          forc_psrf  =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ] surface pressure (Pa)                              
@@ -257,7 +257,7 @@ CONTAINS
             spec_hum   = forc_q(t)
             rain       = forc_rain(t) 
             sfc_temp   = forc_t(t) 
-            solar_flux = forc_solad(g,1) 
+            solar_flux = forc_solad(t,1) 
             lat        = grc_pp%latdeg(g) 
             lon        = grc_pp%londeg(g) 
             clmveg     = veg_pp%itype(pi) 

--- a/components/clm/src/biogeochem/VOCEmissionMod.F90
+++ b/components/clm/src/biogeochem/VOCEmissionMod.F90
@@ -29,7 +29,7 @@ module VOCEmissionMod
   use SoilStateType      , only : soilstate_type
   use SolarAbsorbedType  , only : solarabs_type
   use TemperatureType    , only : temperature_type
-  use TopounitType       , only : top_as
+  use TopounitType       , only : top_as, top_af
   use VegetationType     , only : veg_pp                
   !
   ! !PUBLIC TYPES:
@@ -475,8 +475,8 @@ contains
          !h2osoi_vol   => waterstate_vars%h2osoi_vol_col        , & ! Input:  [real(r8) (:,:) ]  volumetric soil water (m3/m3)                   
          !h2osoi_ice   => waterstate_vars%h2osoi_ice_col        , & ! Input:  [real(r8) (:,:) ]  ice soil content (kg/m3)                        
          
-         forc_solad    => atm2lnd_vars%forc_solad_grc           , & ! Input:  [real(r8) (:,:) ]  direct beam radiation (visible only)            
-         forc_solai    => atm2lnd_vars%forc_solai_grc           , & ! Input:  [real(r8) (:,:) ]  diffuse radiation     (visible only)            
+         forc_solad    => top_af%solad                          , & ! Input:  [real(r8) (:,:) ]  direct beam radiation (W/m**2)            
+         forc_solai    => top_af%solai                          , & ! Input:  [real(r8) (:,:) ]  diffuse radiation     (W/m**2)            
          forc_pbot     => top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  downscaled atmospheric pressure (Pa)                          
          forc_solad24  => atm2lnd_vars%fsd24_patch              , & ! Input:  [real(r8) (:)   ]  direct beam radiation last 24hrs  (visible only)  
          forc_solad240 => atm2lnd_vars%fsd240_patch             , & ! Input:  [real(r8) (:)   ]  direct beam radiation last 240hrs (visible only)  
@@ -547,12 +547,12 @@ contains
           ! Calculate PAR: multiply w/m2 by 4.6 to get umol/m2/s for par (added 8/14/02)
           !------------------------
           ! SUN:
-          par_sun    = (forc_solad(g,1)  + fsun(p)    * forc_solai(g,1))  * 4.6_r8
+          par_sun    = (forc_solad(t,1)  + fsun(p)    * forc_solai(t,1))  * 4.6_r8
           par24_sun  = (forc_solad24(p)  + fsun24(p)  * forc_solai24(p))  * 4.6_r8
           par240_sun = (forc_solad240(p) + fsun240(p) * forc_solai240(p)) * 4.6_r8
 
           ! SHADE:
-          par_sha    = ((1._r8 - fsun(p))    * forc_solai(g,1))  * 4.6_r8
+          par_sha    = ((1._r8 - fsun(p))    * forc_solai(t,1))  * 4.6_r8
           par24_sha  = ((1._r8 - fsun24(p))  * forc_solai24(p))  * 4.6_r8
           par240_sha = ((1._r8 - fsun240(p)) * forc_solai240(p)) * 4.6_r8
 

--- a/components/clm/src/biogeochem/VOCEmissionMod.F90
+++ b/components/clm/src/biogeochem/VOCEmissionMod.F90
@@ -29,7 +29,8 @@ module VOCEmissionMod
   use SoilStateType      , only : soilstate_type
   use SolarAbsorbedType  , only : solarabs_type
   use TemperatureType    , only : temperature_type
-  use VegetationType          , only : veg_pp                
+  use TopounitType       , only : top_as
+  use VegetationType     , only : veg_pp                
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -419,7 +420,7 @@ contains
     !                           and read in MEGAN factors from file.
     !
     ! !LOCAL VARIABLES:
-    integer  :: fp,p,g,c                ! indices
+    integer  :: fp,p,g,t,c              ! indices
     real(r8) :: epsilon                 ! emission factor [ug m-2 h-1]
     real(r8) :: gamma                   ! activity factor (accounting for light, T, age, LAI conditions)
     real(r8) :: gamma_p                 ! activity factor for PPFD
@@ -476,7 +477,7 @@ contains
          
          forc_solad    => atm2lnd_vars%forc_solad_grc           , & ! Input:  [real(r8) (:,:) ]  direct beam radiation (visible only)            
          forc_solai    => atm2lnd_vars%forc_solai_grc           , & ! Input:  [real(r8) (:,:) ]  diffuse radiation     (visible only)            
-         forc_pbot     => atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ]  downscaled atmospheric pressure (Pa)                          
+         forc_pbot     => top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  downscaled atmospheric pressure (Pa)                          
          forc_solad24  => atm2lnd_vars%fsd24_patch              , & ! Input:  [real(r8) (:)   ]  direct beam radiation last 24hrs  (visible only)  
          forc_solad240 => atm2lnd_vars%fsd240_patch             , & ! Input:  [real(r8) (:)   ]  direct beam radiation last 240hrs (visible only)  
          forc_solai24  => atm2lnd_vars%fsi24_patch              , & ! Input:  [real(r8) (:)   ]  diffuse radiation  last 24hrs     (visible only)  
@@ -529,6 +530,7 @@ contains
     do fp = 1,num_soilp
        p = filter_soilp(fp)
        g = veg_pp%gridcell(p)
+       t = veg_pp%topounit(p)
        c = veg_pp%column(p)
 
        ! initialize EF
@@ -594,7 +596,7 @@ contains
 
              ! Activity factor for CO2 (only for isoprene)
              if (trim(meg_cmp%name) == 'isoprene') then 
-                gamma_c = get_gamma_C(cisun_z(p,1),cisha_z(p,1),forc_pbot(c),fsun(p))
+                gamma_c = get_gamma_C(cisun_z(p,1),cisha_z(p,1),forc_pbot(t),fsun(p))
              else
                 gamma_c = 1._r8
              end if

--- a/components/clm/src/biogeochem/VOCEmissionMod.F90
+++ b/components/clm/src/biogeochem/VOCEmissionMod.F90
@@ -478,10 +478,10 @@ contains
          forc_solad    => top_af%solad                          , & ! Input:  [real(r8) (:,:) ]  direct beam radiation (W/m**2)            
          forc_solai    => top_af%solai                          , & ! Input:  [real(r8) (:,:) ]  diffuse radiation     (W/m**2)            
          forc_pbot     => top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  downscaled atmospheric pressure (Pa)                          
-         forc_solad24  => atm2lnd_vars%fsd24_patch              , & ! Input:  [real(r8) (:)   ]  direct beam radiation last 24hrs  (visible only)  
-         forc_solad240 => atm2lnd_vars%fsd240_patch             , & ! Input:  [real(r8) (:)   ]  direct beam radiation last 240hrs (visible only)  
-         forc_solai24  => atm2lnd_vars%fsi24_patch              , & ! Input:  [real(r8) (:)   ]  diffuse radiation  last 24hrs     (visible only)  
-         forc_solai240 => atm2lnd_vars%fsi240_patch             , & ! Input:  [real(r8) (:)   ]  diffuse radiation  last 240hrs    (visible only)  
+         forc_solad24  => top_af%fsd24h                         , & ! Input:  [real(r8) (:)   ]  direct beam radiation last 24hrs  (visible only)  
+         forc_solad240 => top_af%fsd240h                        , & ! Input:  [real(r8) (:)   ]  direct beam radiation last 240hrs (visible only)  
+         forc_solai24  => top_af%fsi24h                         , & ! Input:  [real(r8) (:)   ]  diffuse radiation  last 24hrs     (visible only)  
+         forc_solai240 => top_af%fsi240h                        , & ! Input:  [real(r8) (:)   ]  diffuse radiation  last 240hrs    (visible only)  
 
          fsun          => canopystate_vars%fsun_patch           , & ! Input:  [real(r8) (:)   ]  sunlit fraction of canopy                         
          fsun24        => canopystate_vars%fsun24_patch         , & ! Input:  [real(r8) (:)   ]  sunlit fraction of canopy last 24 hrs             
@@ -548,13 +548,13 @@ contains
           !------------------------
           ! SUN:
           par_sun    = (forc_solad(t,1)  + fsun(p)    * forc_solai(t,1))  * 4.6_r8
-          par24_sun  = (forc_solad24(p)  + fsun24(p)  * forc_solai24(p))  * 4.6_r8
-          par240_sun = (forc_solad240(p) + fsun240(p) * forc_solai240(p)) * 4.6_r8
+          par24_sun  = (forc_solad24(t)  + fsun24(p)  * forc_solai24(t))  * 4.6_r8
+          par240_sun = (forc_solad240(t) + fsun240(p) * forc_solai240(t)) * 4.6_r8
 
           ! SHADE:
           par_sha    = ((1._r8 - fsun(p))    * forc_solai(t,1))  * 4.6_r8
-          par24_sha  = ((1._r8 - fsun24(p))  * forc_solai24(p))  * 4.6_r8
-          par240_sha = ((1._r8 - fsun240(p)) * forc_solai240(p)) * 4.6_r8
+          par24_sha  = ((1._r8 - fsun24(p))  * forc_solai24(t))  * 4.6_r8
+          par240_sha = ((1._r8 - fsun240(p)) * forc_solai240(t)) * 4.6_r8
 
           ! Activity factor for LAI (Guenther et al., 2006): all species
           gamma_l = get_gamma_L(fsun240(p), elai(p))
@@ -585,7 +585,7 @@ contains
 
              ! Activity factor for PPFD
              gamma_p = get_gamma_P(par_sun, par24_sun, par240_sun, par_sha, par24_sha, par240_sha, &
-                  fsun(p), fsun240(p), forc_solad240(p),forc_solai240(p), LDF(class_num), cp, alpha)
+                  fsun(p), fsun240(p), forc_solad240(t),forc_solai240(t), LDF(class_num), cp, alpha)
 
              ! Activity factor for T
              gamma_t = get_gamma_T(t_veg240(p), t_veg24(p),t_veg(p), ct1(class_num), ct2(class_num),&

--- a/components/clm/src/biogeochem/ch4Mod.F90
+++ b/components/clm/src/biogeochem/ch4Mod.F90
@@ -1343,7 +1343,7 @@ contains
          forc_t               =>   top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                  
          forc_pbot            =>   top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
          forc_po2             =>   atm2lnd_vars%forc_po2_grc                 , & ! Input:  [real(r8) (:)   ]  O2 partial pressure (Pa)                          
-         forc_pco2            =>   atm2lnd_vars%forc_pco2_grc                , & ! Input:  [real(r8) (:)   ]  CO2 partial pressure (Pa)                         
+         forc_pco2            =>   top_as%pco2bot                            , & ! Input:  [real(r8) (:)   ]  CO2 partial pressure (Pa)                         
          forc_pch4            =>   atm2lnd_vars%forc_pch4_grc                , & ! Input:  [real(r8) (:)   ]  CH4 partial pressure (Pa)                         
 
          zwt                  =>   soilhydrology_vars%zwt_col                , & ! Input:  [real(r8) (:)   ]  water table depth (m) 
@@ -1447,7 +1447,7 @@ contains
          end if
          c_atm(g,1) =  forc_pch4(g) / rgasm / forc_t(t) ! [mol/m3 air]
          c_atm(g,2) =  forc_po2(g)  / rgasm / forc_t(t) ! [mol/m3 air]
-         c_atm(g,3) =  forc_pco2(g) / rgasm / forc_t(t) ! [mol/m3 air]
+         c_atm(g,3) =  forc_pco2(t) / rgasm / forc_t(t) ! [mol/m3 air]
       end do
 
       ! Initialize CH4 balance and calculate finundated
@@ -1586,7 +1586,7 @@ contains
          t = grc_pp%topi(g)
          c_atm(g,1) =  forc_pch4(g) / rgasm / forc_t(t) ! [mol/m3 air]
          c_atm(g,2) =  forc_po2(g)  / rgasm / forc_t(t) ! [mol/m3 air]
-        !c_atm(g,3) =  forc_pco2(g) / rgasm / forc_t(t) ! [mol/m3 air] - Not currently used
+        !c_atm(g,3) =  forc_pco2(t) / rgasm / forc_t(t) ! [mol/m3 air] - Not currently used
       enddo
 
       !-------------------------------------------------

--- a/components/clm/src/biogeochem/ch4Mod.F90
+++ b/components/clm/src/biogeochem/ch4Mod.F90
@@ -1344,7 +1344,7 @@ contains
          forc_pbot            =>   top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
          forc_po2             =>   atm2lnd_vars%forc_po2_grc                 , & ! Input:  [real(r8) (:)   ]  O2 partial pressure (Pa)                          
          forc_pco2            =>   top_as%pco2bot                            , & ! Input:  [real(r8) (:)   ]  CO2 partial pressure (Pa)                         
-         forc_pch4            =>   atm2lnd_vars%forc_pch4_grc                , & ! Input:  [real(r8) (:)   ]  CH4 partial pressure (Pa)                         
+         forc_pch4            =>   top_as%pch4bot                            , & ! Input:  [real(r8) (:)   ]  CH4 partial pressure (Pa)                         
 
          zwt                  =>   soilhydrology_vars%zwt_col                , & ! Input:  [real(r8) (:)   ]  water table depth (m) 
          zwt_perched          =>   soilhydrology_vars%zwt_perched_col        , & ! Input:  [real(r8) (:)   ]  perched water table depth (m)                     
@@ -1436,16 +1436,16 @@ contains
          ! topounit level
          t = grc_pp%topi(g)
          if (ch4offline) then
-            forc_pch4(g) = atmch4*forc_pbot(t)
+            forc_pch4(t) = atmch4*forc_pbot(t)
          else
-            if (forc_pch4(g) == 0._r8) then
+            if (forc_pch4(t) == 0._r8) then
                write(iulog,*)'not using ch4offline, but methane concentration not passed from the atmosphere', &
                     'to land model! CLM Model is stopping.'
                call endrun(msg=' ERROR: Methane not being passed to atmosphere'//&
                     errMsg(__FILE__, __LINE__))
             end if
          end if
-         c_atm(g,1) =  forc_pch4(g) / rgasm / forc_t(t) ! [mol/m3 air]
+         c_atm(g,1) =  forc_pch4(t) / rgasm / forc_t(t) ! [mol/m3 air]
          c_atm(g,2) =  forc_po2(g)  / rgasm / forc_t(t) ! [mol/m3 air]
          c_atm(g,3) =  forc_pco2(t) / rgasm / forc_t(t) ! [mol/m3 air]
       end do
@@ -1584,7 +1584,7 @@ contains
          ! PET 8/10/2018 - replace this later once gas concentrations (c_atm) are also being tracked at
          ! topounit level
          t = grc_pp%topi(g)
-         c_atm(g,1) =  forc_pch4(g) / rgasm / forc_t(t) ! [mol/m3 air]
+         c_atm(g,1) =  forc_pch4(t) / rgasm / forc_t(t) ! [mol/m3 air]
          c_atm(g,2) =  forc_po2(g)  / rgasm / forc_t(t) ! [mol/m3 air]
         !c_atm(g,3) =  forc_pco2(t) / rgasm / forc_t(t) ! [mol/m3 air] - Not currently used
       enddo

--- a/components/clm/src/biogeochem/ch4Mod.F90
+++ b/components/clm/src/biogeochem/ch4Mod.F90
@@ -1342,7 +1342,7 @@ contains
 
          forc_t               =>   top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                  
          forc_pbot            =>   top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
-         forc_po2             =>   atm2lnd_vars%forc_po2_grc                 , & ! Input:  [real(r8) (:)   ]  O2 partial pressure (Pa)                          
+         forc_po2             =>   top_as%po2bot                             , & ! Input:  [real(r8) (:)   ]  O2 partial pressure (Pa)                          
          forc_pco2            =>   top_as%pco2bot                            , & ! Input:  [real(r8) (:)   ]  CO2 partial pressure (Pa)                         
          forc_pch4            =>   top_as%pch4bot                            , & ! Input:  [real(r8) (:)   ]  CH4 partial pressure (Pa)                         
 
@@ -1446,7 +1446,7 @@ contains
             end if
          end if
          c_atm(g,1) =  forc_pch4(t) / rgasm / forc_t(t) ! [mol/m3 air]
-         c_atm(g,2) =  forc_po2(g)  / rgasm / forc_t(t) ! [mol/m3 air]
+         c_atm(g,2) =  forc_po2(t)  / rgasm / forc_t(t) ! [mol/m3 air]
          c_atm(g,3) =  forc_pco2(t) / rgasm / forc_t(t) ! [mol/m3 air]
       end do
 
@@ -1585,7 +1585,7 @@ contains
          ! topounit level
          t = grc_pp%topi(g)
          c_atm(g,1) =  forc_pch4(t) / rgasm / forc_t(t) ! [mol/m3 air]
-         c_atm(g,2) =  forc_po2(g)  / rgasm / forc_t(t) ! [mol/m3 air]
+         c_atm(g,2) =  forc_po2(t)  / rgasm / forc_t(t) ! [mol/m3 air]
         !c_atm(g,3) =  forc_pco2(t) / rgasm / forc_t(t) ! [mol/m3 air] - Not currently used
       enddo
 

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -191,18 +191,18 @@ contains
      real(r8) :: dtime                                  ! land model time step (sec)
      integer  :: nstep                                  ! time step number
      logical  :: found                                  ! flag in search loop
-     integer  :: indexp,indexc,indexl,indexg            ! index of first found in search loop
+     integer  :: indexp,indexc,indexl,indext,indexg     ! index of first found in search loop
      real(r8) :: forc_rain_col(bounds%begc:bounds%endc) ! column level rain rate [mm/s]
      real(r8) :: forc_snow_col(bounds%begc:bounds%endc) ! column level snow rate [mm/s]
      !-----------------------------------------------------------------------
 
      associate(                                                                         & 
           volr                       =>    atm2lnd_vars%volr_grc                      , & ! Input:  [real(r8) (:)   ]  river water storage (m3)                 
-          forc_solad                 =>    atm2lnd_vars%forc_solad_grc                , & ! Input:  [real(r8) (:,:) ]  direct beam radiation (vis=forc_sols , nir=forc_soll )
-          forc_solai                 =>    atm2lnd_vars%forc_solai_grc                , & ! Input:  [real(r8) (:,:) ]  diffuse radiation     (vis=forc_solsd, nir=forc_solld)
+          forc_solad                 =>    top_af%solad                               , & ! Input:  [real(r8) (:,:) ]  direct beam radiation (vis=forc_sols , nir=forc_soll) (W/m**2)
+          forc_solai                 =>    top_af%solai                               , & ! Input:  [real(r8) (:,:) ]  diffuse radiation     (vis=forc_solsd, nir=forc_solld) (W/m**2)
           forc_rain                  =>    top_af%rain                                , & ! Input:  [real(r8) (:)   ]  rain rate (kg H2O/m**2/s, or mm liquid H2O/s)
           forc_snow                  =>    top_af%snow                                , & ! Input:  [real(r8) (:)   ]  snow rate (kg H2O/m**2/s, or mm liquid H2O/s)
-          forc_lwrad                 =>    atm2lnd_vars%forc_lwrad_downscaled_col     , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)
+          forc_lwrad                 =>    top_af%lwrad                               , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)
           glc_dyn_runoff_routing     =>    glc2lnd_vars%glc_dyn_runoff_routing_grc    , & ! Input:  [real(r8) (:)   ]  whether we're doing runoff routing appropriate for having a dynamic icesheet
 
           do_capsnow                 =>    waterstate_vars%do_capsnow_col             , & ! Input:  [logical (:)    ]  true => do snow capping                  
@@ -535,6 +535,7 @@ contains
           if (veg_pp%active(p)) then
              c = veg_pp%column(p)
              l = veg_pp%landunit(p)
+             t = veg_pp%topounit(p)
              g = veg_pp%gridcell(p)
 
              ! Solar radiation energy balance
@@ -543,7 +544,7 @@ contains
              ! in the urban radiation module
              if (.not. lun_pp%urbpoi(l)) then
                 errsol(p) = fsa(p) + fsr(p) &
-                     - (forc_solad(g,1) + forc_solad(g,2) + forc_solai(g,1) + forc_solai(g,2))
+                     - (forc_solad(t,1) + forc_solad(t,2) + forc_solai(t,1) + forc_solai(t,2))
              else
                 errsol(p) = spval
              end if
@@ -553,7 +554,7 @@ contains
              ! level because of interactions between columns and since a separate check is done
              ! in the urban radiation module
              if (.not. lun_pp%urbpoi(l)) then
-                errlon(p) = eflx_lwrad_out(p) - eflx_lwrad_net(p) - forc_lwrad(c)
+                errlon(p) = eflx_lwrad_out(p) - eflx_lwrad_net(p) - forc_lwrad(t)
              else
                 errlon(p) = spval
              end if
@@ -565,7 +566,7 @@ contains
              ! and a separate check is done above for these terms.
 
              if (.not. lun_pp%urbpoi(l)) then
-                errseb(p) = sabv(p) + sabg_chk(p) + forc_lwrad(c) - eflx_lwrad_out(p) &
+                errseb(p) = sabv(p) + sabg_chk(p) + forc_lwrad(t) - eflx_lwrad_out(p) &
                      - eflx_sh_tot(p) - eflx_lh_tot(p) - eflx_soil_grnd(p)
              else
                 errseb(p) = sabv(p) + sabg(p) &
@@ -586,6 +587,7 @@ contains
              if ( (errsol(p) /= spval) .and. (abs(errsol(p)) > 1.e-7_r8) ) then
                 found = .true.
                 indexp = p
+                indext = veg_pp%topounit(indexp)
                 indexg = veg_pp%gridcell(indexp)
              end if
           end if
@@ -598,12 +600,12 @@ contains
              write(iulog,*)'clm model is stopping - error is greater than 1e-5 (W/m2)'
              write(iulog,*)'fsa           = ',fsa(indexp)
              write(iulog,*)'fsr           = ',fsr(indexp)
-             write(iulog,*)'forc_solad(1) = ',forc_solad(indexg,1)
-             write(iulog,*)'forc_solad(2) = ',forc_solad(indexg,2)
-             write(iulog,*)'forc_solai(1) = ',forc_solai(indexg,1)
-             write(iulog,*)'forc_solai(2) = ',forc_solai(indexg,2)
-             write(iulog,*)'forc_tot      = ',forc_solad(indexg,1)+forc_solad(indexg,2) &
-               +forc_solai(indexg,1)+forc_solai(indexg,2)
+             write(iulog,*)'forc_solad(1) = ',forc_solad(indext,1)
+             write(iulog,*)'forc_solad(2) = ',forc_solad(indext,2)
+             write(iulog,*)'forc_solai(1) = ',forc_solai(indext,1)
+             write(iulog,*)'forc_solai(2) = ',forc_solai(indext,2)
+             write(iulog,*)'forc_tot      = ',forc_solad(indext,1)+forc_solad(indext,2) &
+               +forc_solai(indext,1)+forc_solai(indext,2)
              write(iulog,*)'clm model is stopping'
              call endrun(decomp_index=indexp, clmlevel=namep, msg=errmsg(__FILE__, __LINE__))
           end if
@@ -639,6 +641,7 @@ contains
                 found = .true.
                 indexp = p
                 indexc = veg_pp%column(indexp)
+                indext = veg_pp%topounit(indexp)
              end if
           end if
        end do
@@ -653,8 +656,8 @@ contains
              write(iulog,*)'sabg           = ' ,sabg(indexp), ((1._r8- frac_sno(indexc))*sabg_soil(indexp) + &
                   frac_sno(indexc)*sabg_snow(indexp)),sabg_chk(indexp)
 
-             write(iulog,*)'forc_tot      = '  ,forc_solad(indexg,1) + forc_solad(indexg,2) + &
-                  forc_solai(indexg,1) + forc_solai(indexg,2)
+             write(iulog,*)'forc_tot      = '  ,forc_solad(indext,1) + forc_solad(indext,2) + &
+                  forc_solai(indext,1) + forc_solai(indext,2)
 
              write(iulog,*)'eflx_lwrad_net = ' ,eflx_lwrad_net(indexp)
              write(iulog,*)'eflx_sh_tot    = ' ,eflx_sh_tot(indexp)

--- a/components/clm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/clm/src/biogeophys/BareGroundFluxesMod.F90
@@ -118,7 +118,7 @@ contains
          forc_th          =>    top_as%thbot                          , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
          forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
          forc_rho         =>    atm2lnd_vars%forc_rho_downscaled_col  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
-         forc_q           =>    atm2lnd_vars%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 
+         forc_q           =>    top_as%qbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 
 
          forc_hgt_u_patch =>    frictionvel_vars%forc_hgt_u_patch     , & ! Input:
 
@@ -211,8 +211,8 @@ contains
 
          ur(p)    = max(1.0_r8,sqrt(forc_u(g)*forc_u(g)+forc_v(g)*forc_v(g)))
          dth(p)   = thm(p)-t_grnd(c)
-         dqh(p)   = forc_q(c) - qg(c)
-         dthv     = dth(p)*(1._r8+0.61_r8*forc_q(c))+0.61_r8*forc_th(t)*dqh(p)
+         dqh(p)   = forc_q(t) - qg(c)
+         dthv     = dth(p)*(1._r8+0.61_r8*forc_q(t))+0.61_r8*forc_th(t)*dqh(p)
          zldis(p) = forc_hgt_u_patch(p)
 
          ! Copy column roughness to local pft-level arrays
@@ -249,7 +249,7 @@ contains
             qstar = temp2(p)*dqh(p)
             z0hg_patch(p) = z0mg_patch(p)/exp(0.13_r8 * (ustar(p)*z0mg_patch(p)/1.5e-5_r8)**0.45_r8)
             z0qg_patch(p) = z0hg_patch(p)
-            thvstar = tstar*(1._r8+0.61_r8*forc_q(c)) + 0.61_r8*forc_th(t)*qstar
+            thvstar = tstar*(1._r8+0.61_r8*forc_q(t)) + 0.61_r8*forc_th(t)*qstar
             zeta = zldis(p)*vkc*grav*thvstar/(ustar(p)**2*thv(c))
 
             if (zeta >= 0._r8) then                   !stable
@@ -321,15 +321,15 @@ contains
          qflx_evap_tot(p)  = qflx_evap_soi(p)
 
          ! compute latent heat fluxes individually
-         qflx_ev_snow(p)   = -raiw*(forc_q(c) - qg_snow(c))
-         qflx_ev_soil(p)   = -raiw*(forc_q(c) - qg_soil(c))
-         qflx_ev_h2osfc(p) = -raiw*(forc_q(c) - qg_h2osfc(c))
+         qflx_ev_snow(p)   = -raiw*(forc_q(t) - qg_snow(c))
+         qflx_ev_soil(p)   = -raiw*(forc_q(t) - qg_soil(c))
+         qflx_ev_h2osfc(p) = -raiw*(forc_q(t) - qg_h2osfc(c))
 
          ! 2 m height air temperature
          t_ref2m(p) = thm(p) + temp1(p)*dth(p)*(1._r8/temp12m(p) - 1._r8/temp1(p))
 
          ! 2 m height specific humidity
-         q_ref2m(p) = forc_q(c) + temp2(p)*dqh(p)*(1._r8/temp22m(p) - 1._r8/temp2(p))
+         q_ref2m(p) = forc_q(t) + temp2(p)*dqh(p)*(1._r8/temp22m(p) - 1._r8/temp2(p))
 
          ! 2 m height relative humidity
          call QSat(t_ref2m(p), forc_pbot(t), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)

--- a/components/clm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/clm/src/biogeophys/BareGroundFluxesMod.F90
@@ -116,7 +116,7 @@ contains
          forc_v           =>    top_as%vbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)
          forc_th          =>    top_as%thbot                          , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)
          forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)
-         forc_rho         =>    atm2lnd_vars%forc_rho_downscaled_col  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)
+         forc_rho         =>    top_as%rhobot                         , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)
          forc_q           =>    top_as%qbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)
 
          forc_hgt_u_patch =>    frictionvel_vars%forc_hgt_u_patch     , & ! Input:
@@ -276,7 +276,7 @@ contains
          ram  = 1._r8/(ustar(p)*ustar(p)/um(p))
          rah  = 1._r8/(temp1(p)*ustar(p))
          raw  = 1._r8/(temp2(p)*ustar(p))
-         raih = forc_rho(c)*cpair/rah
+         raih = forc_rho(t)*cpair/rah
          if (use_lch4) then
             grnd_ch4_cond(p) = 1._r8/raw
          end if
@@ -287,11 +287,11 @@ contains
 
          !changed by K.Sakaguchi. Soilbeta is used for evaporation
          if (dqh(p) > 0._r8) then  !dew  (beta is not applied, just like rsoil used to be)
-            raiw = forc_rho(c)/(raw)
+            raiw = forc_rho(t)/(raw)
          else
             if(do_soilevap_beta())then
                ! Lee and Pielke 1992 beta is applied
-               raiw    = soilbeta(c)*forc_rho(c)/(raw)
+               raiw    = soilbeta(c)*forc_rho(t)/(raw)
             endif
          end if
 
@@ -305,8 +305,8 @@ contains
 
          ! Surface fluxes of momentum, sensible and latent heat
          ! using ground temperatures from previous time step
-         taux(p)          = -forc_rho(c)*forc_u(t)/ram
-         tauy(p)          = -forc_rho(c)*forc_v(t)/ram
+         taux(p)          = -forc_rho(t)*forc_u(t)/ram
+         tauy(p)          = -forc_rho(t)*forc_v(t)/ram
          eflx_sh_grnd(p)  = -raih*dth(p)
          eflx_sh_tot(p)   = eflx_sh_grnd(p)
 

--- a/components/clm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/clm/src/biogeophys/BareGroundFluxesMod.F90
@@ -20,7 +20,7 @@ module BareGroundFluxesMod
   use TopounitType         , only : top_as
   use LandunitType         , only : lun_pp                
   use ColumnType           , only : col_pp                
-  use VegetationType            , only : veg_pp                
+  use VegetationType       , only : veg_pp                
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -116,7 +116,7 @@ contains
          forc_u           =>    atm2lnd_vars%forc_u_grc               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)                        
          forc_v           =>    atm2lnd_vars%forc_v_grc               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
          forc_th          =>    top_as%thbot                          , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
-         forc_pbot        =>    atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
+         forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
          forc_rho         =>    atm2lnd_vars%forc_rho_downscaled_col  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
          forc_q           =>    atm2lnd_vars%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 
 
@@ -269,6 +269,7 @@ contains
          p = filterp(f)
          c = veg_pp%column(p)
          g = veg_pp%gridcell(p)
+         t = veg_pp%topounit(p)
          l = veg_pp%landunit(p)
 
          ! Determine aerodynamic resistances
@@ -331,7 +332,7 @@ contains
          q_ref2m(p) = forc_q(c) + temp2(p)*dqh(p)*(1._r8/temp22m(p) - 1._r8/temp2(p))
 
          ! 2 m height relative humidity
-         call QSat(t_ref2m(p), forc_pbot(c), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
+         call QSat(t_ref2m(p), forc_pbot(t), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
 
          rh_ref2m(p) = min(100._r8, q_ref2m(p) / qsat_ref2m * 100._r8)
 

--- a/components/clm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/clm/src/biogeophys/BareGroundFluxesMod.F90
@@ -115,7 +115,6 @@ contains
          forc_u           =>    atm2lnd_vars%forc_u_grc               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)                        
          forc_v           =>    atm2lnd_vars%forc_v_grc               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
          forc_th          =>    atm2lnd_vars%forc_th_downscaled_col   , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
-         forc_t           =>    atm2lnd_vars%forc_t_downscaled_col    , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin) 
          forc_pbot        =>    atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
          forc_rho         =>    atm2lnd_vars%forc_rho_downscaled_col  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
          forc_q           =>    atm2lnd_vars%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 

--- a/components/clm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/clm/src/biogeophys/BareGroundFluxesMod.F90
@@ -18,9 +18,9 @@ module BareGroundFluxesMod
   use WaterfluxType        , only : waterflux_type
   use WaterstateType       , only : waterstate_type
   use TopounitType         , only : top_as
-  use LandunitType         , only : lun_pp                
-  use ColumnType           , only : col_pp                
-  use VegetationType       , only : veg_pp                
+  use LandunitType         , only : lun_pp
+  use ColumnType           , only : col_pp
+  use VegetationType       , only : veg_pp
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -53,7 +53,7 @@ contains
     use SurfaceResistanceMod , only : do_soilevap_beta
     !
     ! !ARGUMENTS:
-    type(bounds_type)      , intent(in)    :: bounds  
+    type(bounds_type)      , intent(in)    :: bounds
     integer                , intent(in)    :: num_nolakeurbanp          ! number of pft non-lake, non-urban points in pft filter
     integer                , intent(in)    :: filter_nolakeurbanp(:)    ! patch filter for non-lake, non-urban points
     type(atm2lnd_type)     , intent(in)    :: atm2lnd_vars
@@ -104,86 +104,85 @@ contains
     real(r8) :: e_ref2m                ! 2 m height surface saturated vapor pressure [Pa]
     real(r8) :: de2mdT                 ! derivative of 2 m height surface saturated vapor pressure on t_ref2m
     real(r8) :: qsat_ref2m             ! 2 m height surface saturated specific humidity [kg/kg]
-    real(r8) :: dqsat2mdT              ! derivative of 2 m height surface saturated specific humidity on t_ref2m 
+    real(r8) :: dqsat2mdT              ! derivative of 2 m height surface saturated specific humidity on t_ref2m
     real(r8) :: www                    ! surface soil wetness [-]
     !------------------------------------------------------------------------------
 
-    associate(                                                          & 
-         snl              =>    col_pp%snl                               , & ! Input:  [integer  (:)   ]  number of snow layers                                                  
-         dz               =>    col_pp%dz                                , & ! Input:  [real(r8) (:,:) ]  layer depth (m)                                                     
-         zii              =>    col_pp%zii                               , & ! Input:  [real(r8) (:)   ]  convective boundary height [m]                                        
-
-         forc_u           =>    atm2lnd_vars%forc_u_grc               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)                        
-         forc_v           =>    atm2lnd_vars%forc_v_grc               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
-         forc_th          =>    top_as%thbot                          , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
-         forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
-         forc_rho         =>    atm2lnd_vars%forc_rho_downscaled_col  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
-         forc_q           =>    top_as%qbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 
+    associate(                                                          &
+         snl              =>    col_pp%snl                            , & ! Input:  [integer  (:)   ]  number of snow layers
+         dz               =>    col_pp%dz                             , & ! Input:  [real(r8) (:,:) ]  layer depth (m)
+         zii              =>    col_pp%zii                            , & ! Input:  [real(r8) (:)   ]  convective boundary height [m]
+         forc_u           =>    top_as%ubot                           , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)
+         forc_v           =>    top_as%vbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)
+         forc_th          =>    top_as%thbot                          , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)
+         forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)
+         forc_rho         =>    atm2lnd_vars%forc_rho_downscaled_col  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)
+         forc_q           =>    top_as%qbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)
 
          forc_hgt_u_patch =>    frictionvel_vars%forc_hgt_u_patch     , & ! Input:
 
          frac_veg_nosno   =>    canopystate_vars%frac_veg_nosno_patch , & ! Input:  [logical  (:)   ]  true=> pft is bare ground (elai+esai = zero)
 
-         htvp             =>    energyflux_vars%htvp_col              , & ! Input:  [real(r8) (:)   ]  latent heat of evaporation (/sublimation) [J/kg]                      
+         htvp             =>    energyflux_vars%htvp_col              , & ! Input:  [real(r8) (:)   ]  latent heat of evaporation (/sublimation) [J/kg]
 
-         watsat           =>    soilstate_vars%watsat_col             , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)                      
-         soilbeta         =>    soilstate_vars%soilbeta_col           , & ! Input:  [real(r8) (:)   ]  soil wetness relative to field capacity                               
+         watsat           =>    soilstate_vars%watsat_col             , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)
+         soilbeta         =>    soilstate_vars%soilbeta_col           , & ! Input:  [real(r8) (:)   ]  soil wetness relative to field capacity
 
-         t_soisno         =>    temperature_vars%t_soisno_col         , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)                                           
-         t_grnd           =>    temperature_vars%t_grnd_col           , & ! Input:  [real(r8) (:)   ]  ground surface temperature [K]                                        
-         thv              =>    temperature_vars%thv_col              , & ! Input:  [real(r8) (:)   ]  virtual potential temperature (kelvin)                                
-         thm              =>    temperature_vars%thm_patch            , & ! Input:  [real(r8) (:)   ]  intermediate variable (forc_t+0.0098*forc_hgt_t_patch)                  
-         t_h2osfc         =>    temperature_vars%t_h2osfc_col         , & ! Input:  [real(r8) (:)   ]  surface water temperature                                             
-         beta             =>    temperature_vars%beta_col             , & ! Input:  [real(r8) (:)   ]  coefficient of conective velocity [-]                                 
+         t_soisno         =>    temperature_vars%t_soisno_col         , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)
+         t_grnd           =>    temperature_vars%t_grnd_col           , & ! Input:  [real(r8) (:)   ]  ground surface temperature [K]
+         thv              =>    temperature_vars%thv_col              , & ! Input:  [real(r8) (:)   ]  virtual potential temperature (kelvin)
+         thm              =>    temperature_vars%thm_patch            , & ! Input:  [real(r8) (:)   ]  intermediate variable (forc_t+0.0098*forc_hgt_t_patch)
+         t_h2osfc         =>    temperature_vars%t_h2osfc_col         , & ! Input:  [real(r8) (:)   ]  surface water temperature
+         beta             =>    temperature_vars%beta_col             , & ! Input:  [real(r8) (:)   ]  coefficient of conective velocity [-]
 
-         frac_sno         =>    waterstate_vars%frac_sno_col          , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by snow (0 to 1)                           
-         qg_snow          =>    waterstate_vars%qg_snow_col           , & ! Input:  [real(r8) (:)   ]  specific humidity at snow surface [kg/kg]                             
-         qg_soil          =>    waterstate_vars%qg_soil_col           , & ! Input:  [real(r8) (:)   ]  specific humidity at soil surface [kg/kg]                             
-         qg_h2osfc        =>    waterstate_vars%qg_h2osfc_col         , & ! Input:  [real(r8) (:)   ]  specific humidity at h2osfc surface [kg/kg]                           
-         qg               =>    waterstate_vars%qg_col                , & ! Input:  [real(r8) (:)   ]  specific humidity at ground surface [kg/kg]                           
-         dqgdT            =>    waterstate_vars%dqgdT_col             , & ! Input:  [real(r8) (:)   ]  temperature derivative of "qg"                                        
-         h2osoi_ice       =>    waterstate_vars%h2osoi_ice_col        , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)                                                    
-         h2osoi_liq       =>    waterstate_vars%h2osoi_liq_col        , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)                                                
-         
+         frac_sno         =>    waterstate_vars%frac_sno_col          , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by snow (0 to 1)
+         qg_snow          =>    waterstate_vars%qg_snow_col           , & ! Input:  [real(r8) (:)   ]  specific humidity at snow surface [kg/kg]
+         qg_soil          =>    waterstate_vars%qg_soil_col           , & ! Input:  [real(r8) (:)   ]  specific humidity at soil surface [kg/kg]
+         qg_h2osfc        =>    waterstate_vars%qg_h2osfc_col         , & ! Input:  [real(r8) (:)   ]  specific humidity at h2osfc surface [kg/kg]
+         qg               =>    waterstate_vars%qg_col                , & ! Input:  [real(r8) (:)   ]  specific humidity at ground surface [kg/kg]
+         dqgdT            =>    waterstate_vars%dqgdT_col             , & ! Input:  [real(r8) (:)   ]  temperature derivative of "qg"
+         h2osoi_ice       =>    waterstate_vars%h2osoi_ice_col        , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         h2osoi_liq       =>    waterstate_vars%h2osoi_liq_col        , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
+
          grnd_ch4_cond    =>    ch4_vars%grnd_ch4_cond_patch          , & ! Output: [real(r8) (:)   ]  tracer conductance for boundary layer [m/s]
 
-         eflx_sh_snow     =>    energyflux_vars%eflx_sh_snow_patch    , & ! Output: [real(r8) (:)   ]  sensible heat flux from snow (W/m**2) [+ to atm]                      
-         eflx_sh_soil     =>    energyflux_vars%eflx_sh_soil_patch    , & ! Output: [real(r8) (:)   ]  sensible heat flux from soil (W/m**2) [+ to atm]                      
-         eflx_sh_h2osfc   =>    energyflux_vars%eflx_sh_h2osfc_patch  , & ! Output: [real(r8) (:)   ]  sensible heat flux from soil (W/m**2) [+ to atm]                      
-         eflx_sh_grnd     =>    energyflux_vars%eflx_sh_grnd_patch    , & ! Output: [real(r8) (:)   ]  sensible heat flux from ground (W/m**2) [+ to atm]                    
-         eflx_sh_tot      =>    energyflux_vars%eflx_sh_tot_patch     , & ! Output: [real(r8) (:)   ]  total sensible heat flux (W/m**2) [+ to atm]                          
-         taux             =>    energyflux_vars%taux_patch            , & ! Output: [real(r8) (:)   ]  wind (shear) stress: e-w (kg/m/s**2)                                  
-         tauy             =>    energyflux_vars%tauy_patch            , & ! Output: [real(r8) (:)   ]  wind (shear) stress: n-s (kg/m/s**2)                                  
-         dlrad            =>    energyflux_vars%dlrad_patch           , & ! Output: [real(r8) (:)   ]  downward longwave radiation below the canopy [W/m2]                   
-         ulrad            =>    energyflux_vars%ulrad_patch           , & ! Output: [real(r8) (:)   ]  upward longwave radiation above the canopy [W/m2]                     
-         cgrnds           =>    energyflux_vars%cgrnds_patch          , & ! Output: [real(r8) (:)   ]  deriv, of soil sensible heat flux wrt soil temp [w/m2/k]              
-         cgrndl           =>    energyflux_vars%cgrndl_patch          , & ! Output: [real(r8) (:)   ]  deriv of soil latent heat flux wrt soil temp [w/m**2/k]               
-         cgrnd            =>    energyflux_vars%cgrnd_patch           , & ! Output: [real(r8) (:)   ]  deriv. of soil energy flux wrt to soil temp [w/m2/k]                  
+         eflx_sh_snow     =>    energyflux_vars%eflx_sh_snow_patch    , & ! Output: [real(r8) (:)   ]  sensible heat flux from snow (W/m**2) [+ to atm]
+         eflx_sh_soil     =>    energyflux_vars%eflx_sh_soil_patch    , & ! Output: [real(r8) (:)   ]  sensible heat flux from soil (W/m**2) [+ to atm]
+         eflx_sh_h2osfc   =>    energyflux_vars%eflx_sh_h2osfc_patch  , & ! Output: [real(r8) (:)   ]  sensible heat flux from soil (W/m**2) [+ to atm]
+         eflx_sh_grnd     =>    energyflux_vars%eflx_sh_grnd_patch    , & ! Output: [real(r8) (:)   ]  sensible heat flux from ground (W/m**2) [+ to atm]
+         eflx_sh_tot      =>    energyflux_vars%eflx_sh_tot_patch     , & ! Output: [real(r8) (:)   ]  total sensible heat flux (W/m**2) [+ to atm]
+         taux             =>    energyflux_vars%taux_patch            , & ! Output: [real(r8) (:)   ]  wind (shear) stress: e-w (kg/m/s**2)
+         tauy             =>    energyflux_vars%tauy_patch            , & ! Output: [real(r8) (:)   ]  wind (shear) stress: n-s (kg/m/s**2)
+         dlrad            =>    energyflux_vars%dlrad_patch           , & ! Output: [real(r8) (:)   ]  downward longwave radiation below the canopy [W/m2]
+         ulrad            =>    energyflux_vars%ulrad_patch           , & ! Output: [real(r8) (:)   ]  upward longwave radiation above the canopy [W/m2]
+         cgrnds           =>    energyflux_vars%cgrnds_patch          , & ! Output: [real(r8) (:)   ]  deriv, of soil sensible heat flux wrt soil temp [w/m2/k]
+         cgrndl           =>    energyflux_vars%cgrndl_patch          , & ! Output: [real(r8) (:)   ]  deriv of soil latent heat flux wrt soil temp [w/m**2/k]
+         cgrnd            =>    energyflux_vars%cgrnd_patch           , & ! Output: [real(r8) (:)   ]  deriv. of soil energy flux wrt to soil temp [w/m2/k]
 
-         t_ref2m          =>    temperature_vars%t_ref2m_patch        , & ! Output: [real(r8) (:)   ]  2 m height surface air temperature (Kelvin)                           
-         t_ref2m_r        =>    temperature_vars%t_ref2m_r_patch      , & ! Output: [real(r8) (:)   ]  Rural 2 m height surface air temperature (Kelvin)                     
+         t_ref2m          =>    temperature_vars%t_ref2m_patch        , & ! Output: [real(r8) (:)   ]  2 m height surface air temperature (Kelvin)
+         t_ref2m_r        =>    temperature_vars%t_ref2m_r_patch      , & ! Output: [real(r8) (:)   ]  Rural 2 m height surface air temperature (Kelvin)
 
-         q_ref2m          =>    waterstate_vars%q_ref2m_patch         , & ! Output: [real(r8) (:)   ]  2 m height surface specific humidity (kg/kg)                          
-         rh_ref2m_r       =>    waterstate_vars%rh_ref2m_r_patch      , & ! Output: [real(r8) (:)   ]  Rural 2 m height surface relative humidity (%)                        
-         rh_ref2m         =>    waterstate_vars%rh_ref2m_patch        , & ! Output: [real(r8) (:)   ]  2 m height surface relative humidity (%)                              
+         q_ref2m          =>    waterstate_vars%q_ref2m_patch         , & ! Output: [real(r8) (:)   ]  2 m height surface specific humidity (kg/kg)
+         rh_ref2m_r       =>    waterstate_vars%rh_ref2m_r_patch      , & ! Output: [real(r8) (:)   ]  Rural 2 m height surface relative humidity (%)
+         rh_ref2m         =>    waterstate_vars%rh_ref2m_patch        , & ! Output: [real(r8) (:)   ]  2 m height surface relative humidity (%)
 
-         z0mg_col         =>    frictionvel_vars%z0mg_col             , & ! Output: [real(r8) (:)   ]  roughness length, momentum [m]                                        
-         z0hg_col         =>    frictionvel_vars%z0hg_col             , & ! Output: [real(r8) (:)   ]  roughness length, sensible heat [m]                                   
-         z0qg_col         =>    frictionvel_vars%z0qg_col             , & ! Output: [real(r8) (:)   ]  roughness length, latent heat [m]                                     
-         ram1             =>    frictionvel_vars%ram1_patch           , & ! Output: [real(r8) (:)   ]  aerodynamical resistance (s/m)                                        
+         z0mg_col         =>    frictionvel_vars%z0mg_col             , & ! Output: [real(r8) (:)   ]  roughness length, momentum [m]
+         z0hg_col         =>    frictionvel_vars%z0hg_col             , & ! Output: [real(r8) (:)   ]  roughness length, sensible heat [m]
+         z0qg_col         =>    frictionvel_vars%z0qg_col             , & ! Output: [real(r8) (:)   ]  roughness length, latent heat [m]
+         ram1             =>    frictionvel_vars%ram1_patch           , & ! Output: [real(r8) (:)   ]  aerodynamical resistance (s/m)
 
-         qflx_ev_snow     =>    waterflux_vars%qflx_ev_snow_patch     , & ! Output: [real(r8) (:)   ]  evaporation flux from snow (W/m**2) [+ to atm]                        
-         qflx_ev_soil     =>    waterflux_vars%qflx_ev_soil_patch     , & ! Output: [real(r8) (:)   ]  evaporation flux from soil (W/m**2) [+ to atm]                        
-         qflx_ev_h2osfc   =>    waterflux_vars%qflx_ev_h2osfc_patch   , & ! Output: [real(r8) (:)   ]  evaporation flux from h2osfc (W/m**2) [+ to atm]                      
-         qflx_evap_soi    =>    waterflux_vars%qflx_evap_soi_patch    , & ! Output: [real(r8) (:)   ]  soil evaporation (mm H2O/s) (+ = to atm)                              
-         qflx_evap_tot    =>    waterflux_vars%qflx_evap_tot_patch    , & ! Output: [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg                         
+         qflx_ev_snow     =>    waterflux_vars%qflx_ev_snow_patch     , & ! Output: [real(r8) (:)   ]  evaporation flux from snow (W/m**2) [+ to atm]
+         qflx_ev_soil     =>    waterflux_vars%qflx_ev_soil_patch     , & ! Output: [real(r8) (:)   ]  evaporation flux from soil (W/m**2) [+ to atm]
+         qflx_ev_h2osfc   =>    waterflux_vars%qflx_ev_h2osfc_patch   , & ! Output: [real(r8) (:)   ]  evaporation flux from h2osfc (W/m**2) [+ to atm]
+         qflx_evap_soi    =>    waterflux_vars%qflx_evap_soi_patch    , & ! Output: [real(r8) (:)   ]  soil evaporation (mm H2O/s) (+ = to atm)
+         qflx_evap_tot    =>    waterflux_vars%qflx_evap_tot_patch    , & ! Output: [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg
          begp             =>    bounds%begp                           , &
          endp             =>    bounds%endp                             &
          )
 
-      !--------------------------------------------------- 
+      !---------------------------------------------------
       ! Filter patches where frac_veg_nosno IS ZERO
-      !--------------------------------------------------- 
+      !---------------------------------------------------
 
       fn = 0
       do fp = 1,num_nolakeurbanp
@@ -209,7 +208,7 @@ contains
          dlrad(p)  = 0._r8
          ulrad(p)  = 0._r8
 
-         ur(p)    = max(1.0_r8,sqrt(forc_u(g)*forc_u(g)+forc_v(g)*forc_v(g)))
+         ur(p)    = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
          dth(p)   = thm(p)-t_grnd(c)
          dqh(p)   = forc_q(t) - qg(c)
          dthv     = dth(p)*(1._r8+0.61_r8*forc_q(t))+0.61_r8*forc_th(t)*dqh(p)
@@ -287,7 +286,7 @@ contains
          www = min(max(www,0.0_r8),1._r8)
 
          !changed by K.Sakaguchi. Soilbeta is used for evaporation
-         if (dqh(p) > 0._r8) then  !dew  (beta is not applied, just like rsoil used to be) 
+         if (dqh(p) > 0._r8) then  !dew  (beta is not applied, just like rsoil used to be)
             raiw = forc_rho(c)/(raw)
          else
             if(do_soilevap_beta())then
@@ -306,8 +305,8 @@ contains
 
          ! Surface fluxes of momentum, sensible and latent heat
          ! using ground temperatures from previous time step
-         taux(p)          = -forc_rho(c)*forc_u(g)/ram
-         tauy(p)          = -forc_rho(c)*forc_v(g)/ram
+         taux(p)          = -forc_rho(c)*forc_u(t)/ram
+         tauy(p)          = -forc_rho(c)*forc_v(t)/ram
          eflx_sh_grnd(p)  = -raih*dth(p)
          eflx_sh_tot(p)   = eflx_sh_grnd(p)
 

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -331,8 +331,8 @@ contains
          forc_t               => top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                                      
          forc_u               => top_as%ubot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)                        
          forc_v               => top_as%vbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
-         forc_pco2            => atm2lnd_vars%forc_pco2_grc                , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
-         forc_pc13o2          => atm2lnd_vars%forc_pc13o2_grc              , & ! Input:  [real(r8) (:)   ]  partial pressure c13o2 (Pa)                                           
+         forc_pco2            => top_as%pco2bot                            , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
+         forc_pc13o2          => top_as%pc13o2bot                          , & ! Input:  [real(r8) (:)   ]  partial pressure c13o2 (Pa)                                           
          forc_po2             => atm2lnd_vars%forc_po2_grc                 , & ! Input:  [real(r8) (:)   ]  partial pressure o2 (Pa)                                              
 
          dleaf                => veg_vp%dleaf                          , & ! Input:  [real(r8) (:)   ]  characteristic leaf dimension (m)                                     
@@ -688,11 +688,11 @@ contains
 
          ! Determine atmospheric co2 and o2
 
-         co2(p) = forc_pco2(g)
+         co2(p) = forc_pco2(t)
          o2(p)  = forc_po2(g)
 
          if ( use_c13 ) then
-            c13o2(p) = forc_pc13o2(g)
+            c13o2(p) = forc_pc13o2(t)
          end if
 
          ! Initialize flux profile

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -326,7 +326,7 @@ contains
          forc_lwrad           => atm2lnd_vars%forc_lwrad_downscaled_col    , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)                       
          forc_q               => atm2lnd_vars%forc_q_downscaled_col        , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 
          forc_pbot            => atm2lnd_vars%forc_pbot_downscaled_col     , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
-         forc_th              => atm2lnd_vars%forc_th_downscaled_col       , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
+         forc_th              => top_as%thbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
          forc_rho             => atm2lnd_vars%forc_rho_downscaled_col      , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
          forc_t               => top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                                      
          forc_u               => atm2lnd_vars%forc_u_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)                        
@@ -671,6 +671,7 @@ contains
       do f = 1, fn
          p = filterp(f)
          c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
          g = veg_pp%gridcell(p)
 
          ! Net absorbed longwave radiation by canopy and ground
@@ -705,7 +706,7 @@ contains
          dth(p) = thm(p)-taf(p)
          dqh(p) = forc_q(c)-qaf(p)
          delq(p) = qg(c) - qaf(p)
-         dthv(p) = dth(p)*(1._r8+0.61_r8*forc_q(c))+0.61_r8*forc_th(c)*dqh(p)
+         dthv(p) = dth(p)*(1._r8+0.61_r8*forc_q(c))+0.61_r8*forc_th(t)*dqh(p)
          zldis(p) = forc_hgt_u_patch(p) - displa(p)
 
          ! Check to see if the forcing height is below the canopy height
@@ -898,6 +899,7 @@ contains
          do f = 1, fn
             p = filterp(f)
             c = veg_pp%column(p)
+            t = veg_pp%topounit(p)
             g = veg_pp%gridcell(p)
 
             ! Sensible heat conductance for air, leaf and ground
@@ -1066,7 +1068,7 @@ contains
             tstar = temp1(p)*dth(p)
             qstar = temp2(p)*dqh(p)
 
-            thvstar = tstar*(1._r8+0.61_r8*forc_q(c)) + 0.61_r8*forc_th(c)*qstar
+            thvstar = tstar*(1._r8+0.61_r8*forc_q(c)) + 0.61_r8*forc_th(t)*qstar
             zeta = zldis(p)*vkc*grav*thvstar/(ustar(p)**2*thv(c))
 
             if (zeta >= 0._r8) then     !stable

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -333,7 +333,7 @@ contains
          forc_v               => top_as%vbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
          forc_pco2            => top_as%pco2bot                            , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
          forc_pc13o2          => top_as%pc13o2bot                          , & ! Input:  [real(r8) (:)   ]  partial pressure c13o2 (Pa)                                           
-         forc_po2             => atm2lnd_vars%forc_po2_grc                 , & ! Input:  [real(r8) (:)   ]  partial pressure o2 (Pa)                                              
+         forc_po2             => top_as%po2bot                             , & ! Input:  [real(r8) (:)   ]  partial pressure o2 (Pa)                                              
 
          dleaf                => veg_vp%dleaf                          , & ! Input:  [real(r8) (:)   ]  characteristic leaf dimension (m)                                     
          smpso                => veg_vp%smpso                          , & ! Input:  [real(r8) (:)   ]  soil water potential at full stomatal opening (mm)                    
@@ -689,7 +689,7 @@ contains
          ! Determine atmospheric co2 and o2
 
          co2(p) = forc_pco2(t)
-         o2(p)  = forc_po2(g)
+         o2(p)  = forc_po2(t)
 
          if ( use_c13 ) then
             c13o2(p) = forc_pc13o2(t)

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -37,7 +37,8 @@ module CanopyFluxesMod
   use WaterstateType        , only : waterstate_type
   use ch4Mod                , only : ch4_type
   use PhotosynthesisType    , only : photosyns_type
-  use GridcellType          , only : grc_pp                
+  use GridcellType          , only : grc_pp 
+  use TopounitType          , only : top_as  
   use ColumnType            , only : col_pp                
   use VegetationType        , only : veg_pp                
   use PhosphorusStateType   , only : phosphorusstate_type
@@ -262,6 +263,7 @@ contains
     integer  :: p                                    ! patch index
     integer  :: c                                    ! column index
     integer  :: l                                    ! landunit index
+    integer  :: t                                    ! topounit index
     integer  :: g                                    ! gridcell index
     integer  :: fp                                   ! lake filter pft index
     integer  :: fn_noveg                             ! number of values in bare ground pft filter
@@ -326,7 +328,7 @@ contains
          forc_pbot            => atm2lnd_vars%forc_pbot_downscaled_col     , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
          forc_th              => atm2lnd_vars%forc_th_downscaled_col       , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
          forc_rho             => atm2lnd_vars%forc_rho_downscaled_col      , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
-         forc_t               => atm2lnd_vars%forc_t_downscaled_col        , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                                      
+         forc_t               => top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                                      
          forc_u               => atm2lnd_vars%forc_u_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)                        
          forc_v               => atm2lnd_vars%forc_v_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
          forc_pco2            => atm2lnd_vars%forc_pco2_grc                , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
@@ -449,9 +451,10 @@ contains
       do fp = 1,num_nolakeurbanp
          p = filter_nolakeurbanp(fp)
          c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
          if (frac_veg_nosno(p) == 0) then
             btran(p) = 0._r8     
-            t_veg(p) = forc_t(c) 
+            t_veg(p) = forc_t(t) 
             cf_bare  = forc_pbot(c)/(SHR_CONST_RGAS*0.001_r8*thm(p))*1.e06_r8
             rssun(p) = 1._r8/1.e15_r8 * cf_bare
             rssha(p) = 1._r8/1.e15_r8 * cf_bare

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -329,8 +329,8 @@ contains
          forc_th              => top_as%thbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
          forc_rho             => atm2lnd_vars%forc_rho_downscaled_col      , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
          forc_t               => top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                                      
-         forc_u               => atm2lnd_vars%forc_u_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)                        
-         forc_v               => atm2lnd_vars%forc_v_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
+         forc_u               => top_as%ubot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)                        
+         forc_v               => top_as%vbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
          forc_pco2            => atm2lnd_vars%forc_pco2_grc                , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
          forc_pc13o2          => atm2lnd_vars%forc_pc13o2_grc              , & ! Input:  [real(r8) (:)   ]  partial pressure c13o2 (Pa)                                           
          forc_po2             => atm2lnd_vars%forc_po2_grc                 , & ! Input:  [real(r8) (:)   ]  partial pressure o2 (Pa)                                              
@@ -702,7 +702,7 @@ contains
          taf(p) = (t_grnd(c) + thm(p))/2._r8
          qaf(p) = (forc_q(t)+qg(c))/2._r8
 
-         ur(p) = max(1.0_r8,sqrt(forc_u(g)*forc_u(g)+forc_v(g)*forc_v(g)))
+         ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
          dth(p) = thm(p)-taf(p)
          dqh(p) = forc_q(t)-qaf(p)
          delq(p) = qg(c) - qaf(p)
@@ -1139,8 +1139,8 @@ contains
          ! Fluxes from ground to canopy space
 
          delt    = wtal(p)*t_grnd(c)-wtl0(p)*t_veg(p)-wta0(p)*thm(p)
-         taux(p) = -forc_rho(c)*forc_u(g)/ram1(p)
-         tauy(p) = -forc_rho(c)*forc_v(g)/ram1(p)
+         taux(p) = -forc_rho(c)*forc_u(t)/ram1(p)
+         tauy(p) = -forc_rho(c)*forc_v(t)/ram1(p)
          eflx_sh_grnd(p) = cpair*forc_rho(c)*wtg(p)*delt
 
          ! compute individual sensible heat fluxes

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -23,7 +23,7 @@ module CanopyFluxesMod
   use SoilMoistStressMod    , only : calc_root_moist_stress, set_perchroot_opt
   use SimpleMathMod         , only : array_div_vector
   use SurfaceResistanceMod  , only : do_soilevap_beta
-   use VegetationPropertiesType        , only : veg_vp
+  use VegetationPropertiesType        , only : veg_vp
   use atm2lndType           , only : atm2lnd_type
   use CanopyStateType       , only : canopystate_type
   use CNStateType           , only : cnstate_type
@@ -325,7 +325,7 @@ contains
 
          forc_lwrad           => atm2lnd_vars%forc_lwrad_downscaled_col    , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)                       
          forc_q               => atm2lnd_vars%forc_q_downscaled_col        , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 
-         forc_pbot            => atm2lnd_vars%forc_pbot_downscaled_col     , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
+         forc_pbot            => top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
          forc_th              => top_as%thbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
          forc_rho             => atm2lnd_vars%forc_rho_downscaled_col      , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
          forc_t               => top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                                      
@@ -455,7 +455,7 @@ contains
          if (frac_veg_nosno(p) == 0) then
             btran(p) = 0._r8     
             t_veg(p) = forc_t(t) 
-            cf_bare  = forc_pbot(c)/(SHR_CONST_RGAS*0.001_r8*thm(p))*1.e06_r8
+            cf_bare  = forc_pbot(t)/(SHR_CONST_RGAS*0.001_r8*thm(p))*1.e06_r8
             rssun(p) = 1._r8/1.e15_r8 * cf_bare
             rssha(p) = 1._r8/1.e15_r8 * cf_bare
             lbl_rsc_h2o(p)=0._r8
@@ -684,7 +684,7 @@ contains
          ! Saturated vapor pressure, specific humidity, and their derivatives
          ! at the leaf surface
 
-         call QSat (t_veg(p), forc_pbot(c), el(p), deldT, qsatl(p), qsatldT(p))
+         call QSat (t_veg(p), forc_pbot(t), el(p), deldT, qsatl(p), qsatldT(p))
 
          ! Determine atmospheric co2 and o2
 
@@ -757,6 +757,7 @@ contains
          do f = 1, fn
             p = filterp(f)
             c = veg_pp%column(p)
+            t = veg_pp%topounit(p)
             g = veg_pp%gridcell(p)
 
             tlbef(p) = t_veg(p)
@@ -822,7 +823,7 @@ contains
             ! Done each iteration to account for differences in eah, tv.
 
             svpts(p) = el(p)                         ! pa
-            eah(p) = forc_pbot(c) * qaf(p) / 0.622_r8   ! pa
+            eah(p) = forc_pbot(t) * qaf(p) / 0.622_r8   ! pa
             rhaf(p) = eah(p)/svpts(p)
          end do
 
@@ -1049,7 +1050,7 @@ contains
             ! Re-calculate saturated vapor pressure, specific humidity, and their
             ! derivatives at the leaf surface
 
-            call QSat(t_veg(p), forc_pbot(c), el(p), deldT, qsatl(p), qsatldT(p))
+            call QSat(t_veg(p), forc_pbot(t), el(p), deldT, qsatl(p), qsatldT(p))
 
             ! Update vegetation/ground surface temperature, canopy air
             ! temperature, canopy vapor pressure, aerodynamic temperature, and
@@ -1122,6 +1123,7 @@ contains
       do f = 1, fn
          p = filterp(f)
          c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
          g = veg_pp%gridcell(p)
 
          ! Energy balance check in canopy
@@ -1173,7 +1175,7 @@ contains
 
          ! 2 m height relative humidity
 
-         call QSat(t_ref2m(p), forc_pbot(c), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
+         call QSat(t_ref2m(p), forc_pbot(t), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
          rh_ref2m(p) = min(100._r8, q_ref2m(p) / qsat_ref2m * 100._r8)
          rh_ref2m_r(p) = rh_ref2m(p)
 

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -324,7 +324,7 @@ contains
          max_dayl             => grc_pp%max_dayl                              , & ! Input:  [real(r8) (:)   ]  maximum daylength for this grid cell (s)
 
          forc_lwrad           => atm2lnd_vars%forc_lwrad_downscaled_col    , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)                       
-         forc_q               => atm2lnd_vars%forc_q_downscaled_col        , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 
+         forc_q               => top_as%qbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 
          forc_pbot            => top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
          forc_th              => top_as%thbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
          forc_rho             => atm2lnd_vars%forc_rho_downscaled_col      , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
@@ -700,13 +700,13 @@ contains
          nmozsgn(p) = 0
 
          taf(p) = (t_grnd(c) + thm(p))/2._r8
-         qaf(p) = (forc_q(c)+qg(c))/2._r8
+         qaf(p) = (forc_q(t)+qg(c))/2._r8
 
          ur(p) = max(1.0_r8,sqrt(forc_u(g)*forc_u(g)+forc_v(g)*forc_v(g)))
          dth(p) = thm(p)-taf(p)
-         dqh(p) = forc_q(c)-qaf(p)
+         dqh(p) = forc_q(t)-qaf(p)
          delq(p) = qg(c) - qaf(p)
-         dthv(p) = dth(p)*(1._r8+0.61_r8*forc_q(c))+0.61_r8*forc_th(t)*dqh(p)
+         dthv(p) = dth(p)*(1._r8+0.61_r8*forc_q(t))+0.61_r8*forc_th(t)*dqh(p)
          zldis(p) = forc_hgt_u_patch(p) - displa(p)
 
          ! Check to see if the forcing height is below the canopy height
@@ -987,7 +987,7 @@ contains
             dc2 = hvap*forc_rho(c)*wtlq
 
             efsh   = dc1*(wtga*t_veg(p)-wtg0*t_grnd(c)-wta0(p)*thm(p))
-            efe(p) = dc2*(wtgaq*qsatl(p)-wtgq0*qg(c)-wtaq0(p)*forc_q(c))
+            efe(p) = dc2*(wtgaq*qsatl(p)-wtgq0*qg(c)-wtaq0(p)*forc_q(t))
 
             ! Evaporation flux from foliage
 
@@ -1024,7 +1024,7 @@ contains
             ! "efe + dc2*wtgaq*qsatdt_veg"
 
             efpot = forc_rho(c)*wtl*(wtgaq*(qsatl(p)+qsatldT(p)*dt_veg(p)) &
-                 -wtgq0*qg(c)-wtaq0(p)*forc_q(c))
+                 -wtgq0*qg(c)-wtaq0(p)*forc_q(t))
             qflx_evap_veg(p) = rpp*efpot
 
             ! Calculation of evaporative potentials (efpot) and
@@ -1057,19 +1057,19 @@ contains
             ! Monin-Obukhov stability parameter for next iteration.
 
             taf(p) = wtg0*t_grnd(c) + wta0(p)*thm(p) + wtl0(p)*t_veg(p)
-            qaf(p) = wtlq0(p)*qsatl(p) + wtgq0*qg(c) + forc_q(c)*wtaq0(p)
+            qaf(p) = wtlq0(p)*qsatl(p) + wtgq0*qg(c) + forc_q(t)*wtaq0(p)
 
             ! Update Monin-Obukhov length and wind speed including the
             ! stability effect
 
             dth(p) = thm(p)-taf(p)
-            dqh(p) = forc_q(c)-qaf(p)
-            delq(p) = wtalq(p)*qg(c)-wtlq0(p)*qsatl(p)-wtaq0(p)*forc_q(c)
+            dqh(p) = forc_q(t)-qaf(p)
+            delq(p) = wtalq(p)*qg(c)-wtlq0(p)*qsatl(p)-wtaq0(p)*forc_q(t)
 
             tstar = temp1(p)*dth(p)
             qstar = temp2(p)*dqh(p)
 
-            thvstar = tstar*(1._r8+0.61_r8*forc_q(c)) + 0.61_r8*forc_th(t)*qstar
+            thvstar = tstar*(1._r8+0.61_r8*forc_q(t)) + 0.61_r8*forc_th(t)*qstar
             zeta = zldis(p)*vkc*grav*thvstar/(ustar(p)**2*thv(c))
 
             if (zeta >= 0._r8) then     !stable
@@ -1155,13 +1155,13 @@ contains
          qflx_evap_soi(p) = forc_rho(c)*wtgq(p)*delq(p)
 
          ! compute individual latent heat fluxes
-         delq_snow = wtalq(p)*qg_snow(c)-wtlq0(p)*qsatl(p)-wtaq0(p)*forc_q(c)
+         delq_snow = wtalq(p)*qg_snow(c)-wtlq0(p)*qsatl(p)-wtaq0(p)*forc_q(t)
          qflx_ev_snow(p) = forc_rho(c)*wtgq(p)*delq_snow
 
-         delq_soil = wtalq(p)*qg_soil(c)-wtlq0(p)*qsatl(p)-wtaq0(p)*forc_q(c)
+         delq_soil = wtalq(p)*qg_soil(c)-wtlq0(p)*qsatl(p)-wtaq0(p)*forc_q(t)
          qflx_ev_soil(p) = forc_rho(c)*wtgq(p)*delq_soil
 
-         delq_h2osfc = wtalq(p)*qg_h2osfc(c)-wtlq0(p)*qsatl(p)-wtaq0(p)*forc_q(c)
+         delq_h2osfc = wtalq(p)*qg_h2osfc(c)-wtlq0(p)*qsatl(p)-wtaq0(p)*forc_q(t)
          qflx_ev_h2osfc(p) = forc_rho(c)*wtgq(p)*delq_h2osfc
 
          ! 2 m height air temperature
@@ -1171,7 +1171,7 @@ contains
 
          ! 2 m height specific humidity
 
-         q_ref2m(p) = forc_q(c) + temp2(p)*dqh(p)*(1._r8/temp22m(p) - 1._r8/temp2(p))
+         q_ref2m(p) = forc_q(t) + temp2(p)*dqh(p)*(1._r8/temp22m(p) - 1._r8/temp2(p))
 
          ! 2 m height relative humidity
 

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -38,7 +38,7 @@ module CanopyFluxesMod
   use ch4Mod                , only : ch4_type
   use PhotosynthesisType    , only : photosyns_type
   use GridcellType          , only : grc_pp 
-  use TopounitType          , only : top_as  
+  use TopounitType          , only : top_as, top_af  
   use ColumnType            , only : col_pp                
   use VegetationType        , only : veg_pp                
   use PhosphorusStateType   , only : phosphorusstate_type
@@ -323,7 +323,7 @@ contains
          dayl                 => grc_pp%dayl                                  , & ! Input:  [real(r8) (:)   ]  daylength (s)
          max_dayl             => grc_pp%max_dayl                              , & ! Input:  [real(r8) (:)   ]  maximum daylength for this grid cell (s)
 
-         forc_lwrad           => atm2lnd_vars%forc_lwrad_downscaled_col    , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)                       
+         forc_lwrad           => top_af%lwrad                              , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)                       
          forc_q               => top_as%qbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)                                 
          forc_pbot            => top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
          forc_th              => top_as%thbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
@@ -677,7 +677,7 @@ contains
          ! Net absorbed longwave radiation by canopy and ground
          ! =air+bir*t_veg**4+cir*t_grnd(c)**4
 
-         air(p) =   emv(p) * (1._r8+(1._r8-emv(p))*(1._r8-emg(c))) * forc_lwrad(c)
+         air(p) =   emv(p) * (1._r8+(1._r8-emv(p))*(1._r8-emg(c))) * forc_lwrad(t)
          bir(p) = - (2._r8-emv(p)*(1._r8-emg(c))) * emv(p) * sb
          cir(p) =   emv(p)*emg(c)*sb
 
@@ -1182,12 +1182,12 @@ contains
 
          ! Downward longwave radiation below the canopy
 
-         dlrad(p) = (1._r8-emv(p))*emg(c)*forc_lwrad(c) + &
+         dlrad(p) = (1._r8-emv(p))*emg(c)*forc_lwrad(t) + &
               emv(p)*emg(c)*sb*tlbef(p)**3*(tlbef(p) + 4._r8*dt_veg(p))
 
          ! Upward longwave radiation above the canopy
 
-         ulrad(p) = ((1._r8-emg(c))*(1._r8-emv(p))*(1._r8-emv(p))*forc_lwrad(c) &
+         ulrad(p) = ((1._r8-emg(c))*(1._r8-emv(p))*(1._r8-emv(p))*forc_lwrad(t) &
               + emv(p)*(1._r8+(1._r8-emg(c))*(1._r8-emv(p)))*sb*tlbef(p)**3*(tlbef(p) + &
               4._r8*dt_veg(p)) + emg(c)*(1._r8-emv(p))*sb*lw_grnd)
 

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -23,6 +23,7 @@ module CanopyHydrologyMod
   use TemperatureType , only : temperature_type
   use WaterfluxType   , only : waterflux_type
   use WaterstateType  , only : waterstate_type
+  use TopounitType    , only : top_as
   use ColumnType      , only : col_pp                
   use VegetationType       , only : veg_pp                
   !
@@ -135,6 +136,7 @@ contains
      integer  :: p                                            ! patch index
      integer  :: c                                            ! column index
      integer  :: l                                            ! landunit index
+     integer  :: t                                            ! topounit index
      integer  :: g                                            ! gridcell index
      integer  :: newnode                                      ! flag when new snow node is set, (1=yes, 0=no)
      real(r8) :: dtime                                        ! land model time step (sec)
@@ -182,7 +184,7 @@ contains
 
           forc_rain            => atm2lnd_vars%forc_rain_downscaled_col    , & ! Input:  [real(r8) (:)   ]  rain rate [mm/s]                        
           forc_snow            => atm2lnd_vars%forc_snow_downscaled_col    , & ! Input:  [real(r8) (:)   ]  snow rate [mm/s]                        
-          forc_t               => atm2lnd_vars%forc_t_downscaled_col       , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)        
+          forc_t               => top_as%tbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)        
           qflx_floodg          => atm2lnd_vars%forc_flood_grc              , & ! Input:  [real(r8) (:)   ]  gridcell flux of flood water from RTM   
 
           dewmx                => canopystate_vars%dewmx_patch             , & ! Input:  [real(r8) (:)   ]  Maximum allowed dew [mm]                
@@ -380,6 +382,7 @@ contains
        do f = 1, num_nolakec
           c = filter_nolakec(f)
           l = clandunit(c)
+          t = col_pp%topounit(c)
           g = cgridcell(c)
 
           ! Use Alta relationship, Anderson(1976); LaChapelle(1961),
@@ -403,10 +406,10 @@ contains
              frac_sno(c)=1._r8
              int_snow(c) = 5.e2_r8
           else
-             if (forc_t(c) > tfrz + 2._r8) then
+             if (forc_t(t) > tfrz + 2._r8) then
                 bifall=50._r8 + 1.7_r8*(17.0_r8)**1.5_r8
-             else if (forc_t(c) > tfrz - 15._r8) then
-                bifall=50._r8 + 1.7_r8*(forc_t(c) - tfrz + 15._r8)**1.5_r8
+             else if (forc_t(t) > tfrz - 15._r8) then
+                bifall=50._r8 + 1.7_r8*(forc_t(t) - tfrz + 15._r8)**1.5_r8
              else
                 bifall=50._r8
              end if
@@ -546,7 +549,7 @@ contains
              dz(c,0) = snow_depth(c)                       ! meter
              z(c,0) = -0.5_r8*dz(c,0)
              zi(c,-1) = -dz(c,0)
-             t_soisno(c,0) = min(tfrz, forc_t(c))      ! K
+             t_soisno(c,0) = min(tfrz, forc_t(t))      ! K
              h2osoi_ice(c,0) = h2osno(c)               ! kg/m2
              h2osoi_liq(c,0) = 0._r8                   ! kg/m2
              frac_iceold(c,0) = 1._r8

--- a/components/clm/src/biogeophys/CanopyTemperatureMod.F90
+++ b/components/clm/src/biogeophys/CanopyTemperatureMod.F90
@@ -140,8 +140,7 @@ contains
          forc_pbot        =>    atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ] atmospheric pressure (Pa)                
          forc_q           =>    atm2lnd_vars%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ] atmospheric specific humidity (kg/kg)    
          forc_t           =>    top_as%tbot                           , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)         
-         forc_th          =>    atm2lnd_vars%forc_th_downscaled_col   , & ! Input:  [real(r8) (:)   ] atmospheric potential temperature (Kelvin)
-
+         forc_th          =>    top_as%thbot                          , & ! Input:  [real(r8) (:)   ] atmospheric potential temperature (Kelvin)
 
          frac_h2osfc      =>    waterstate_vars%frac_h2osfc_col       , & ! Input:  [real(r8) (:)   ] fraction of ground covered by surface water (0 to 1)
          frac_sno_eff     =>    waterstate_vars%frac_sno_eff_col      , & ! Input:  [real(r8) (:)   ] eff. fraction of ground covered by snow (0 to 1)
@@ -233,6 +232,7 @@ contains
       do fc = 1,num_nolakec
          c = filter_nolakec(fc)
          l = col_pp%landunit(c)
+         t = col_pp%topounit(c)
 
          if (col_pp%itype(c) == icol_road_perv) then
             hr_road_perv = 0._r8
@@ -395,7 +395,7 @@ contains
 
          beta(c) = 1._r8
          zii(c)  = 1000._r8
-         thv(c)  = forc_th(c)*(1._r8+0.61_r8*forc_q(c))
+         thv(c)  = forc_th(t)*(1._r8+0.61_r8*forc_q(c))
 
       end do ! (end of columns loop)
 

--- a/components/clm/src/biogeophys/CanopyTemperatureMod.F90
+++ b/components/clm/src/biogeophys/CanopyTemperatureMod.F90
@@ -138,7 +138,7 @@ contains
          forc_hgt_u       =>    atm2lnd_vars%forc_hgt_u_grc           , & ! Input:  [real(r8) (:)   ] observational height of wind [m]         
          forc_hgt_q       =>    atm2lnd_vars%forc_hgt_q_grc           , & ! Input:  [real(r8) (:)   ] observational height of specific humidity [m]
          forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ] atmospheric pressure (Pa)                
-         forc_q           =>    atm2lnd_vars%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ] atmospheric specific humidity (kg/kg)    
+         forc_q           =>    top_as%qbot                           , & ! Input:  [real(r8) (:)   ] atmospheric specific humidity (kg/kg)    
          forc_t           =>    top_as%tbot                           , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)         
          forc_th          =>    top_as%thbot                          , & ! Input:  [real(r8) (:)   ] atmospheric potential temperature (Kelvin)
 
@@ -312,8 +312,8 @@ contains
          if (lun_pp%itype(l) == istsoil .or. lun_pp%itype(l) == istcrop) then
 
             call QSat(t_soisno(c,snl(c)+1), forc_pbot(t), eg, degdT, qsatg, qsatgdT)
-            if (qsatg > forc_q(c) .and. forc_q(c) > qsatg) then
-               qsatg = forc_q(c)
+            if (qsatg > forc_q(t) .and. forc_q(t) > qsatg) then
+               qsatg = forc_q(t)
                qsatgdT = 0._r8
             end if
 
@@ -321,8 +321,8 @@ contains
             dqgdT(c) = frac_sno(c)*qsatgdT
 
             call QSat(t_soisno(c,1) , forc_pbot(t), eg, degdT, qsatg, qsatgdT)
-            if (qsatg > forc_q(c) .and. forc_q(c) > hr*qsatg) then
-               qsatg = forc_q(c)
+            if (qsatg > forc_q(t) .and. forc_q(t) > hr*qsatg) then
+               qsatg = forc_q(t)
                qsatgdT = 0._r8
             end if
             qg_soil(c) = hr*qsatg
@@ -336,8 +336,8 @@ contains
             endif
 
             call QSat(t_h2osfc(c), forc_pbot(t), eg, degdT, qsatg, qsatgdT)
-            if (qsatg > forc_q(c) .and. forc_q(c) > qsatg) then
-               qsatg = forc_q(c)
+            if (qsatg > forc_q(t) .and. forc_q(t) > qsatg) then
+               qsatg = forc_q(t)
                qsatgdT = 0._r8
             end if
             qg_h2osfc(c) = qsatg
@@ -352,8 +352,8 @@ contains
             qg(c) = qred*qsatg
             dqgdT(c) = qred*qsatgdT
 
-            if (qsatg > forc_q(c) .and. forc_q(c) > qred*qsatg) then
-               qg(c) = forc_q(c)
+            if (qsatg > forc_q(t) .and. forc_q(t) > qred*qsatg) then
+               qg(c) = forc_q(t)
                dqgdT(c) = 0._r8
             end if
 
@@ -395,7 +395,7 @@ contains
 
          beta(c) = 1._r8
          zii(c)  = 1000._r8
-         thv(c)  = forc_th(t)*(1._r8+0.61_r8*forc_q(c))
+         thv(c)  = forc_th(t)*(1._r8+0.61_r8*forc_q(t))
 
       end do ! (end of columns loop)
 

--- a/components/clm/src/biogeophys/CanopyTemperatureMod.F90
+++ b/components/clm/src/biogeophys/CanopyTemperatureMod.F90
@@ -132,9 +132,9 @@ contains
          z0mr             =>    veg_vp%z0mr                           , & ! Input:  [real(r8) (:)   ] ratio of momentum roughness length to canopy top height (-)
          displar          =>    veg_vp%displar                        , & ! Input:  [real(r8) (:)   ] ratio of displacement height to canopy top height (-)
    
-         forc_hgt_t       =>    atm2lnd_vars%forc_hgt_t_grc           , & ! Input:  [real(r8) (:)   ] observational height of temperature [m]  
-         forc_hgt_u       =>    atm2lnd_vars%forc_hgt_u_grc           , & ! Input:  [real(r8) (:)   ] observational height of wind [m]         
-         forc_hgt_q       =>    atm2lnd_vars%forc_hgt_q_grc           , & ! Input:  [real(r8) (:)   ] observational height of specific humidity [m]
+         forc_hgt_t       =>    top_as%zbot                           , & ! Input:  [real(r8) (:)   ] observational height of temperature [m]  
+         forc_hgt_u       =>    top_as%zbot                           , & ! Input:  [real(r8) (:)   ] observational height of wind [m]         
+         forc_hgt_q       =>    top_as%zbot                           , & ! Input:  [real(r8) (:)   ] observational height of specific humidity [m]
          forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ] atmospheric pressure (Pa)                
          forc_q           =>    top_as%qbot                           , & ! Input:  [real(r8) (:)   ] atmospheric specific humidity (kg/kg)    
          forc_t           =>    top_as%tbot                           , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)         
@@ -460,32 +460,33 @@ contains
       do p = bounds%begp,bounds%endp
          if (veg_pp%active(p)) then
             g = veg_pp%gridcell(p)
+            t = veg_pp%topounit(p)
             l = veg_pp%landunit(p)
             c = veg_pp%column(p)
             if (lun_pp%itype(l) == istsoil .or. lun_pp%itype(l) == istcrop) then
                if (frac_veg_nosno(p) == 0) then
-                  forc_hgt_u_patch(p) = forc_hgt_u(g) + z0mg(c) + displa(p)
-                  forc_hgt_t_patch(p) = forc_hgt_t(g) + z0mg(c) + displa(p)
-                  forc_hgt_q_patch(p) = forc_hgt_q(g) + z0mg(c) + displa(p)
+                  forc_hgt_u_patch(p) = forc_hgt_u(t) + z0mg(c) + displa(p)
+                  forc_hgt_t_patch(p) = forc_hgt_t(t) + z0mg(c) + displa(p)
+                  forc_hgt_q_patch(p) = forc_hgt_q(t) + z0mg(c) + displa(p)
                else
-                  forc_hgt_u_patch(p) = forc_hgt_u(g) + z0m(p) + displa(p)
-                  forc_hgt_t_patch(p) = forc_hgt_t(g) + z0m(p) + displa(p)
-                  forc_hgt_q_patch(p) = forc_hgt_q(g) + z0m(p) + displa(p)
+                  forc_hgt_u_patch(p) = forc_hgt_u(t) + z0m(p) + displa(p)
+                  forc_hgt_t_patch(p) = forc_hgt_t(t) + z0m(p) + displa(p)
+                  forc_hgt_q_patch(p) = forc_hgt_q(t) + z0m(p) + displa(p)
                end if
             else if (lun_pp%itype(l) == istwet .or. lun_pp%itype(l) == istice      &
                  .or. lun_pp%itype(l) == istice_mec) then
-               forc_hgt_u_patch(p) = forc_hgt_u(g) + z0mg(c)
-               forc_hgt_t_patch(p) = forc_hgt_t(g) + z0mg(c)
-               forc_hgt_q_patch(p) = forc_hgt_q(g) + z0mg(c)
+               forc_hgt_u_patch(p) = forc_hgt_u(t) + z0mg(c)
+               forc_hgt_t_patch(p) = forc_hgt_t(t) + z0mg(c)
+               forc_hgt_q_patch(p) = forc_hgt_q(t) + z0mg(c)
                ! Appropriate momentum roughness length will be added in LakeFLuxesMod.
             else if (lun_pp%itype(l) == istdlak) then
-               forc_hgt_u_patch(p) = forc_hgt_u(g)
-               forc_hgt_t_patch(p) = forc_hgt_t(g)
-               forc_hgt_q_patch(p) = forc_hgt_q(g)
+               forc_hgt_u_patch(p) = forc_hgt_u(t)
+               forc_hgt_t_patch(p) = forc_hgt_t(t)
+               forc_hgt_q_patch(p) = forc_hgt_q(t)
             else if (urbpoi(l)) then
-               forc_hgt_u_patch(p) = forc_hgt_u(g) + z_0_town(l) + z_d_town(l)
-               forc_hgt_t_patch(p) = forc_hgt_t(g) + z_0_town(l) + z_d_town(l)
-               forc_hgt_q_patch(p) = forc_hgt_q(g) + z_0_town(l) + z_d_town(l)
+               forc_hgt_u_patch(p) = forc_hgt_u(t) + z_0_town(l) + z_d_town(l)
+               forc_hgt_t_patch(p) = forc_hgt_t(t) + z_0_town(l) + z_d_town(l)
+               forc_hgt_q_patch(p) = forc_hgt_q(t) + z_0_town(l) + z_d_town(l)
             end if
          end if
       end do

--- a/components/clm/src/biogeophys/CanopyTemperatureMod.F90
+++ b/components/clm/src/biogeophys/CanopyTemperatureMod.F90
@@ -29,6 +29,7 @@ module CanopyTemperatureMod
   use TemperatureType      , only : temperature_type
   use WaterfluxType        , only : waterflux_type
   use WaterstateType       , only : waterstate_type
+  use TopounitType         , only : top_as
   use LandunitType         , only : lun_pp                
   use ColumnType           , only : col_pp                
   use VegetationType       , only : veg_pp
@@ -96,7 +97,7 @@ contains
     type(hlm_fates_interface_type) , intent(inout) :: alm_fates
     !
     ! !LOCAL VARIABLES:
-    integer  :: g,l,c,p      ! indices
+    integer  :: g,t,l,c,p    ! indices
     integer  :: nlevbed      ! number of layers to bedrock
     integer  :: j            ! soil/snow level index
     integer  :: fp           ! lake filter pft index
@@ -138,7 +139,7 @@ contains
          forc_hgt_q       =>    atm2lnd_vars%forc_hgt_q_grc           , & ! Input:  [real(r8) (:)   ] observational height of specific humidity [m]
          forc_pbot        =>    atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ] atmospheric pressure (Pa)                
          forc_q           =>    atm2lnd_vars%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ] atmospheric specific humidity (kg/kg)    
-         forc_t           =>    atm2lnd_vars%forc_t_downscaled_col    , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)         
+         forc_t           =>    top_as%tbot                           , & ! Input:  [real(r8) (:)   ] atmospheric temperature (Kelvin)         
          forc_th          =>    atm2lnd_vars%forc_th_downscaled_col   , & ! Input:  [real(r8) (:)   ] atmospheric potential temperature (Kelvin)
 
 
@@ -494,8 +495,9 @@ contains
       do fp = 1,num_nolakep
          p = filter_nolakep(fp)
          c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
 
-         thm(p)  = forc_t(c) + 0.0098_r8*forc_hgt_t_patch(p)
+         thm(p)  = forc_t(t) + 0.0098_r8*forc_hgt_t_patch(p)
       end do
 
     end associate

--- a/components/clm/src/biogeophys/CanopyTemperatureMod.F90
+++ b/components/clm/src/biogeophys/CanopyTemperatureMod.F90
@@ -133,8 +133,6 @@ contains
          displar          =>    veg_vp%displar                        , & ! Input:  [real(r8) (:)   ] ratio of displacement height to canopy top height (-)
    
          forc_hgt_t       =>    atm2lnd_vars%forc_hgt_t_grc           , & ! Input:  [real(r8) (:)   ] observational height of temperature [m]  
-         forc_u           =>    atm2lnd_vars%forc_u_grc               , & ! Input:  [real(r8) (:)   ] atmospheric wind speed in east direction (m/s)
-         forc_v           =>    atm2lnd_vars%forc_v_grc               , & ! Input:  [real(r8) (:)   ] atmospheric wind speed in north direction (m/s)
          forc_hgt_u       =>    atm2lnd_vars%forc_hgt_u_grc           , & ! Input:  [real(r8) (:)   ] observational height of wind [m]         
          forc_hgt_q       =>    atm2lnd_vars%forc_hgt_q_grc           , & ! Input:  [real(r8) (:)   ] observational height of specific humidity [m]
          forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ] atmospheric pressure (Pa)                

--- a/components/clm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/clm/src/biogeophys/HydrologyDrainageMod.F90
@@ -16,6 +16,7 @@ module HydrologyDrainageMod
   use TemperatureType   , only : temperature_type
   use WaterfluxType     , only : waterflux_type
   use WaterstateType    , only : waterstate_type
+  use topounitType      , only : top_af ! atmospheric flux variables
   use LandunitType      , only : lun_pp                
   use ColumnType        , only : col_pp                
   use VegetationType    , only : veg_pp                
@@ -73,7 +74,7 @@ contains
     class(betr_simulation_alm_type), intent(inout) :: ep_betr
     !
     ! !LOCAL VARIABLES:
-    integer  :: g,l,c,j,fc                 ! indices
+    integer  :: g,t,l,c,j,fc               ! indices
     real(r8) :: dtime                      ! land model time step (sec)
     !-----------------------------------------------------------------------
     
@@ -82,8 +83,8 @@ contains
          ctype                  => col_pp%itype                                  , & ! Input:  [integer  (:)   ]  column type                                        
 
          qflx_floodg            => atm2lnd_vars%forc_flood_grc                , & ! Input:  [real(r8) (:)   ]  gridcell flux of flood water from RTM             
-         forc_rain              => atm2lnd_vars%forc_rain_downscaled_col      , & ! Input:  [real(r8) (:)   ]  rain rate [mm/s]                                  
-         forc_snow              => atm2lnd_vars%forc_snow_downscaled_col      , & ! Input:  [real(r8) (:)   ]  snow rate [mm/s]                                  
+         forc_rain              => top_af%rain                                , & ! Input:  [real(r8) (:)   ]  rain rate (kg H2O/m**2/s, or mm liquid H2O/s)                                  
+         forc_snow              => top_af%snow                                , & ! Input:  [real(r8) (:)   ]  snow rate (kg H2O/m**2/s, or mm liquid H2O/s)                                  
 
          glc_dyn_runoff_routing => glc2lnd_vars%glc_dyn_runoff_routing_grc    , & ! Input:  [real(r8) (:)   ]  whether we're doing runoff routing appropriate for having a dynamic icesheet
 
@@ -224,6 +225,7 @@ contains
       do fc = 1,num_nolakec
          c = filter_nolakec(fc)
          l = col_pp%landunit(c)
+         t = col_pp%topounit(c)
          g = col_pp%gridcell(c)
 
          if (lun_pp%itype(l)==istwet .or. lun_pp%itype(l)==istice      &
@@ -234,7 +236,7 @@ contains
             qflx_h2osfc_surf(c)   = 0._r8
             qflx_surf(c)          = 0._r8
             qflx_infl(c)          = 0._r8
-            qflx_qrgwl(c) = forc_rain(c) + forc_snow(c) + qflx_floodg(g) - qflx_evap_tot(c) - qflx_snwcp_ice(c) - &
+            qflx_qrgwl(c) = forc_rain(t) + forc_snow(t) + qflx_floodg(g) - qflx_evap_tot(c) - qflx_snwcp_ice(c) - &
                  (endwb(c)-begwb(c))/dtime
 
             ! With glc_dyn_runoff_routing = false (the less realistic way, typically used

--- a/components/clm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/clm/src/biogeophys/LakeFluxesMod.F90
@@ -153,8 +153,8 @@ contains
          lakedepth        =>    col_pp%lakedepth                          , & ! Input:  [real(r8) (:)   ]  variable lake depth (m)                           
          
          forc_t           =>    top_as%tbot                            , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                  
-         forc_pbot        =>    atm2lnd_vars%forc_pbot_downscaled_col  , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
          forc_th          =>    top_as%thbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)        
+         forc_pbot        =>    top_as%pbot                            , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
          forc_q           =>    atm2lnd_vars%forc_q_downscaled_col     , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
          forc_rho         =>    atm2lnd_vars%forc_rho_downscaled_col   , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                 
          forc_lwrad       =>    atm2lnd_vars%forc_lwrad_downscaled_col , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)   
@@ -257,7 +257,7 @@ contains
 
          if (t_grnd(c) > tfrz) then   ! for unfrozen lake
             z0mg(p) = z0mg_col(c)
-            kva = kva0 * (t_grnd(c)/kva0temp)**1.5_r8 * kva0pres/forc_pbot(c) ! kinematic viscosity of air
+            kva = kva0 * (t_grnd(c)/kva0temp)**1.5_r8 * kva0pres/forc_pbot(t) ! kinematic viscosity of air
             sqre0 = (max(z0mg(p)*ust_lake(c)/kva,0.1_r8))**0.5_r8   ! Square root of roughness Reynolds number
             z0hg(p) = z0mg(p) * exp( -vkc/prn*( 4._r8*sqre0 - 3.2_r8) ) ! SH roughness length
             z0qg(p) = z0mg(p) * exp( -vkc/sch*( 4._r8*sqre0 - 4.2_r8) ) ! LH roughness length
@@ -301,7 +301,7 @@ contains
          ! Saturated vapor pressure, specific humidity and their derivatives
          ! at lake surface
 
-         call QSat(t_grnd(c), forc_pbot(c), eg, degdT, qsatg(c), qsatgdT(c))
+         call QSat(t_grnd(c), forc_pbot(t), eg, degdT, qsatg(c), qsatgdT(c))
 
          ! Potential, virtual potential temperature, and wind speed at the
          ! reference height
@@ -435,7 +435,7 @@ contains
             ! Re-calculate saturated vapor pressure, specific humidity and their
             ! derivatives at lake surface
 
-            call QSat(t_grnd(c), forc_pbot(c), eg, degdT, qsatg(c), qsatgdT(c))
+            call QSat(t_grnd(c), forc_pbot(t), eg, degdT, qsatg(c), qsatgdT(c))
 
             dth(p)=thm(p)-t_grnd(c)
             dqh(p)=forc_q(c)-qsatg(c)
@@ -477,7 +477,7 @@ contains
                end if
 
 
-               kva = kva0 * (t_grnd(c)/kva0temp)**1.5_r8 * kva0pres/forc_pbot(c) ! kinematic viscosity of air
+               kva = kva0 * (t_grnd(c)/kva0temp)**1.5_r8 * kva0pres/forc_pbot(t) ! kinematic viscosity of air
                z0mg(p) = max(cus*kva/max(ustar(p),1.e-4_r8), cur*ustar(p)*ustar(p)/grav) ! momentum roughness length
                ! This lower limit on ustar is just to prevent floating point exceptions and
                ! should not be important
@@ -520,6 +520,7 @@ contains
       do fp = 1, num_lakep
          p = filter_lakep(fp)
          c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
          g = veg_pp%gridcell(p)
 
          ! If there is snow on the ground or lake is frozen and t_grnd > tfrz: reset t_grnd = tfrz.
@@ -587,7 +588,7 @@ contains
 
          ! 2 m height relative humidity
 
-         call QSat(t_ref2m(p), forc_pbot(c), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
+         call QSat(t_ref2m(p), forc_pbot(t), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
          rh_ref2m(p) = min(100._r8, q_ref2m(p) / qsat_ref2m * 100._r8)
 
 

--- a/components/clm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/clm/src/biogeophys/LakeFluxesMod.F90
@@ -18,7 +18,7 @@ module LakeFluxesMod
   use WaterfluxType        , only : waterflux_type
   use WaterstateType       , only : waterstate_type
   use GridcellType         , only : grc_pp   
-  use TopounitType         , only : top_as  
+  use TopounitType         , only : top_as, top_af ! atmospheric state and flux variables  
   use ColumnType           , only : col_pp                
   use VegetationType       , only : veg_pp                
   !    
@@ -158,8 +158,8 @@ contains
          forc_q           =>    top_as%qbot                            , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
          forc_rho         =>    top_as%rhobot                          , & ! Input:  [real(r8) (:)   ]  air density (kg/m**3)                                 
          forc_lwrad       =>    atm2lnd_vars%forc_lwrad_downscaled_col , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)   
-         forc_snow        =>    atm2lnd_vars%forc_snow_downscaled_col  , & ! Input:  [real(r8) (:)   ]  snow rate [mm/s]                                  
-         forc_rain        =>    atm2lnd_vars%forc_rain_downscaled_col  , & ! Input:  [real(r8) (:)   ]  rain rate [mm/s]                                  
+         forc_snow        =>    top_af%snow                            , & ! Input:  [real(r8) (:)   ]  snow rate (kg H2O/m**2/s, or mm liquid H2O/s)                                  
+         forc_rain        =>    top_af%rain                            , & ! Input:  [real(r8) (:)   ]  rain rate (kg H2O/m**2/s, or mm liquid H2O/s)                                  
          forc_u           =>    top_as%ubot                            , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)    
          forc_v           =>    top_as%vbot                            , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)   
          
@@ -626,7 +626,7 @@ contains
          
          t_veg(p) = forc_t(t)
          eflx_lwrad_net(p)  = eflx_lwrad_out(p) - forc_lwrad(c)
-         qflx_prec_grnd(p) = forc_rain(c) + forc_snow(c)
+         qflx_prec_grnd(p) = forc_rain(t) + forc_snow(t)
 
          ! Because they will be used in pft2col initialize here.
          ! This will be overwritten in LakeHydrology

--- a/components/clm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/clm/src/biogeophys/LakeFluxesMod.F90
@@ -154,7 +154,7 @@ contains
          
          forc_t           =>    top_as%tbot                            , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                  
          forc_pbot        =>    atm2lnd_vars%forc_pbot_downscaled_col  , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
-         forc_th          =>    atm2lnd_vars%forc_th_downscaled_col    , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)        
+         forc_th          =>    top_as%thbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)        
          forc_q           =>    atm2lnd_vars%forc_q_downscaled_col     , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
          forc_rho         =>    atm2lnd_vars%forc_rho_downscaled_col   , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                 
          forc_lwrad       =>    atm2lnd_vars%forc_lwrad_downscaled_col , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)   
@@ -307,7 +307,7 @@ contains
          ! reference height
 
          thm(p) = forc_t(t) + 0.0098_r8*forc_hgt_t_patch(p)   ! intermediate variable
-         thv(c) = forc_th(c)*(1._r8+0.61_r8*forc_q(c))     ! virtual potential T
+         thv(c) = forc_th(t)*(1._r8+0.61_r8*forc_q(c))     ! virtual potential T
       end do
 
 
@@ -315,6 +315,7 @@ contains
       do fp = 1, num_lakep
          p = filter_lakep(fp)
          c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
          g = veg_pp%gridcell(p)
 
          nmozsgn(p) = 0
@@ -335,7 +336,7 @@ contains
          ur(p)    = max(1.0_r8,sqrt(forc_u(g)*forc_u(g)+forc_v(g)*forc_v(g)))
          dth(p)   = thm(p)-t_grnd(c)
          dqh(p)   = forc_q(c)-qsatg(c)
-         dthv     = dth(p)*(1._r8+0.61_r8*forc_q(c))+0.61_r8*forc_th(c)*dqh(p)
+         dthv     = dth(p)*(1._r8+0.61_r8*forc_q(c))+0.61_r8*forc_th(t)*dqh(p)
          zldis(p) = forc_hgt_u_patch(p) - 0._r8
 
          ! Initialize Monin-Obukhov length and wind speed
@@ -364,6 +365,7 @@ contains
          do fp = 1, fncopy
             p = fpcopy(fp)
             c = veg_pp%column(p)
+            t = veg_pp%topounit(p)
             g = veg_pp%gridcell(p)
 
             tgbef(c) = t_grnd(c)
@@ -441,7 +443,7 @@ contains
             tstar = temp1(p)*dth(p)
             qstar = temp2(p)*dqh(p)
 
-            thvstar=tstar*(1._r8+0.61_r8*forc_q(c)) + 0.61_r8*forc_th(c)*qstar
+            thvstar=tstar*(1._r8+0.61_r8*forc_q(c)) + 0.61_r8*forc_th(t)*qstar
             zeta=zldis(p)*vkc * grav*thvstar/(ustar(p)**2*thv(c))
 
             if (zeta >= 0._r8) then     !stable

--- a/components/clm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/clm/src/biogeophys/LakeFluxesMod.F90
@@ -157,7 +157,7 @@ contains
          forc_pbot        =>    top_as%pbot                            , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
          forc_q           =>    top_as%qbot                            , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
          forc_rho         =>    top_as%rhobot                          , & ! Input:  [real(r8) (:)   ]  air density (kg/m**3)                                 
-         forc_lwrad       =>    atm2lnd_vars%forc_lwrad_downscaled_col , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)   
+         forc_lwrad       =>    top_af%lwrad                           , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)   
          forc_snow        =>    top_af%snow                            , & ! Input:  [real(r8) (:)   ]  snow rate (kg H2O/m**2/s, or mm liquid H2O/s)                                  
          forc_rain        =>    top_af%rain                            , & ! Input:  [real(r8) (:)   ]  rain rate (kg H2O/m**2/s, or mm liquid H2O/s)                                  
          forc_u           =>    top_as%ubot                            , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)    
@@ -404,7 +404,7 @@ contains
             ! Changed surface temperature from t_lake(c,1) to tsur(c).
             ! Also adjusted so that if there are snow layers present, the top layer absorption
             ! from SNICAR is assigned to the surface skin.
-            ax  = betaprime(c)*sabg(p) + emg_lake*forc_lwrad(c) + 3._r8*stftg3(p)*tgbef(c) &
+            ax  = betaprime(c)*sabg(p) + emg_lake*forc_lwrad(t) + 3._r8*stftg3(p)*tgbef(c) &
                  + forc_rho(t)*cpair/rah(p)*thm(p) &
                  - htvp(c)*forc_rho(t)/raw(p)*(qsatg(c)-qsatgdT(c)*tgbef(c) - forc_q(t)) &
                  + tksur(c)*tsur(c)/dzsur(c)
@@ -559,11 +559,11 @@ contains
          ! eflx_lwrad_out(p) = (1._r8-emg_lake)*forc_lwrad(c) + stftg3(p)*(-3._r8*tgbef(c)+4._r8*t_grnd(c))
          ! What is tgbef doing in this equation? Can't it be exact now? --Zack Subin, 4/14/09
 
-         eflx_lwrad_out(p) = (1._r8-emg_lake)*forc_lwrad(c) + emg_lake*sb*t_grnd(c)**4._r8
+         eflx_lwrad_out(p) = (1._r8-emg_lake)*forc_lwrad(t) + emg_lake*sb*t_grnd(c)**4._r8
 
          ! Ground heat flux
 
-         eflx_soil_grnd(p) = sabg(p) + forc_lwrad(c) - eflx_lwrad_out(p) - &
+         eflx_soil_grnd(p) = sabg(p) + forc_lwrad(t) - eflx_lwrad_out(p) - &
               eflx_sh_grnd(p) - htvp(c)*qflx_evap_soi(p)
          ! The original code in Biogeophysiclake had a bug that calculated incorrect fluxes but conserved energy.
          ! This is kept as the full sabg (not just that absorbed at surface) so that the energy balance check will be correct.
@@ -595,7 +595,7 @@ contains
          ! Energy residual used for melting snow
          ! Effectively moved to LakeTemp
 
-         eflx_gnet(p) = betaprime(c) * sabg(p) + forc_lwrad(c) - (eflx_lwrad_out(p) + &
+         eflx_gnet(p) = betaprime(c) * sabg(p) + forc_lwrad(t) - (eflx_lwrad_out(p) + &
               eflx_sh_tot(p) + eflx_lh_tot(p))
          ! This is the actual heat flux from the ground interface into the lake, not including
          ! the light that penetrates the surface.
@@ -625,7 +625,7 @@ contains
          t = veg_pp%topounit(p)
          
          t_veg(p) = forc_t(t)
-         eflx_lwrad_net(p)  = eflx_lwrad_out(p) - forc_lwrad(c)
+         eflx_lwrad_net(p)  = eflx_lwrad_out(p) - forc_lwrad(t)
          qflx_prec_grnd(p) = forc_rain(t) + forc_snow(t)
 
          ! Because they will be used in pft2col initialize here.

--- a/components/clm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/clm/src/biogeophys/LakeFluxesMod.F90
@@ -160,8 +160,8 @@ contains
          forc_lwrad       =>    atm2lnd_vars%forc_lwrad_downscaled_col , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)   
          forc_snow        =>    atm2lnd_vars%forc_snow_downscaled_col  , & ! Input:  [real(r8) (:)   ]  snow rate [mm/s]                                  
          forc_rain        =>    atm2lnd_vars%forc_rain_downscaled_col  , & ! Input:  [real(r8) (:)   ]  rain rate [mm/s]                                  
-         forc_u           =>    atm2lnd_vars%forc_u_grc                , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)    
-         forc_v           =>    atm2lnd_vars%forc_v_grc                , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)   
+         forc_u           =>    top_as%ubot                            , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)    
+         forc_v           =>    top_as%vbot                            , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)   
          
          fsds_nir_d       =>    solarabs_vars%fsds_nir_d_patch         , & ! Input:  [real(r8) (:)   ]  incident direct beam nir solar radiation (W/m**2) 
          fsds_nir_i       =>    solarabs_vars%fsds_nir_i_patch         , & ! Input:  [real(r8) (:)   ]  incident diffuse nir solar radiation (W/m**2)     
@@ -333,7 +333,7 @@ contains
 
          ! Initialize stability variables
 
-         ur(p)    = max(1.0_r8,sqrt(forc_u(g)*forc_u(g)+forc_v(g)*forc_v(g)))
+         ur(p)    = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
          dth(p)   = thm(p)-t_grnd(c)
          dqh(p)   = forc_q(t)-qsatg(c)
          dthv     = dth(p)*(1._r8+0.61_r8*forc_q(t))+0.61_r8*forc_th(t)*dqh(p)
@@ -572,8 +572,8 @@ contains
          ! The variable eflx_gnet will be used to pass the actual heat flux
          !from the ground interface into the lake.
 
-         taux(p) = -forc_rho(c)*forc_u(g)/ram(p)
-         tauy(p) = -forc_rho(c)*forc_v(g)/ram(p)
+         taux(p) = -forc_rho(c)*forc_u(t)/ram(p)
+         tauy(p) = -forc_rho(c)*forc_v(t)/ram(p)
 
          eflx_sh_tot(p)   = eflx_sh_grnd(p)
          qflx_evap_tot(p) = qflx_evap_soi(p)

--- a/components/clm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/clm/src/biogeophys/LakeHydrologyMod.F90
@@ -19,8 +19,9 @@ module LakeHydrologyMod
   ! ! USES
   use shr_kind_mod         , only : r8 => shr_kind_r8
   use decompMod            , only : bounds_type
+  use TopounitType         , only : top_as            ! atmospheric state variables at topounit level
   use ColumnType           , only : col_pp                
-  use VegetationType            , only : veg_pp                
+  use VegetationType       , only : veg_pp                
   use atm2lndType          , only : atm2lnd_type
   use AerosolType          , only : aerosol_type
   use EnergyFluxType       , only : energyflux_type
@@ -95,7 +96,7 @@ contains
     type(lakestate_type)   , intent(inout) :: lakestate_vars
     !
     ! !LOCAL VARIABLES:
-    integer  :: p,fp,g,l,c,j,fc,jtop                            ! indices
+    integer  :: p,fp,g,t,l,c,j,fc,jtop                          ! indices
     real(r8) :: dtime                                           ! land model time step (sec)
     integer  :: newnode                                         ! flag when new snow node is set, (1=yes, 0=no)
     real(r8) :: dz_snowf                                        ! layer thickness rate change due to precipitation [mm/s]
@@ -129,7 +130,7 @@ contains
 
          forc_rain            =>  atm2lnd_vars%forc_rain_downscaled_col , & ! Input:  [real(r8) (:)   ]  rain rate [mm/s]                        
          forc_snow            =>  atm2lnd_vars%forc_snow_downscaled_col , & ! Input:  [real(r8) (:)   ]  snow rate [mm/s]                        
-         forc_t               =>  atm2lnd_vars%forc_t_downscaled_col    , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)        
+         forc_t               =>  top_as%tbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)        
          qflx_floodg          =>  atm2lnd_vars%forc_flood_grc           , & ! Input:  [real(r8) (:)   ]  gridcell flux of flood water from RTM   
 
          watsat               =>  soilstate_vars%watsat_col             , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)
@@ -251,6 +252,7 @@ contains
 
       do fc = 1, num_lakec
          c = filter_lakec(fc)
+         t = col_pp%topounit(c)
 
          ! Use Alta relationship, Anderson(1976); LaChapelle(1961),
          ! U.S.Department of Agriculture Forest Service, Project F,
@@ -259,10 +261,10 @@ contains
          if (do_capsnow(c)) then
             dz_snowf = 0._r8
          else
-            if (forc_t(c) > tfrz + 2._r8) then
+            if (forc_t(t) > tfrz + 2._r8) then
                bifall=50._r8 + 1.7_r8*(17.0_r8)**1.5_r8
-            else if (forc_t(c) > tfrz - 15._r8) then
-               bifall=50._r8 + 1.7_r8*(forc_t(c) - tfrz + 15._r8)**1.5_r8
+            else if (forc_t(t) > tfrz - 15._r8) then
+               bifall=50._r8 + 1.7_r8*(forc_t(t) - tfrz + 15._r8)**1.5_r8
             else
                bifall=50._r8
             end if
@@ -282,7 +284,7 @@ contains
             dz(c,0) = snow_depth(c)                       ! meter
             z(c,0) = -0.5_r8*dz(c,0)
             zi(c,-1) = -dz(c,0)
-            t_soisno(c,0) = min(tfrz, forc_t(c))      ! K
+            t_soisno(c,0) = min(tfrz, forc_t(t))      ! K
             h2osoi_ice(c,0) = h2osno(c)               ! kg/m2
             h2osoi_liq(c,0) = 0._r8                   ! kg/m2
             frac_iceold(c,0) = 1._r8

--- a/components/clm/src/biogeophys/PhotosynthesisMod.F90
+++ b/components/clm/src/biogeophys/PhotosynthesisMod.F90
@@ -33,7 +33,8 @@ module  PhotosynthesisMod
   use clm_varctl          , only : cnallocate_carbonphosphorus_only
   use clm_varctl          , only : iulog
   use pftvarcon           , only : noveg
-  use CNSharedParamsMod   , only : CNParamsShareInst      
+  use CNSharedParamsMod   , only : CNParamsShareInst
+  use TopounitType        , only : top_as  
   !
   implicit none
   save
@@ -148,7 +149,7 @@ contains
     real(r8) :: theta_ip          ! empirical curvature parameter for ap photosynthesis co-limitation
 
     ! Other
-    integer  :: f,p,c,iv          ! indices
+    integer  :: f,p,c,t,iv        ! indices
     real(r8) :: cf                ! s m**2/umol -> s/m
     real(r8) :: rsmax0            ! maximum stomatal resistance [s/m]
     real(r8) :: gb                ! leaf boundary layer conductance (m/s)
@@ -236,7 +237,7 @@ contains
          fnitr         => veg_vp%fnitr                         , & ! Input:  [real(r8) (:)   ]  foliage nitrogen limitation factor (-)                                
          slatop        => veg_vp%slatop                        , & ! Input:  [real(r8) (:)   ]  specific leaf area at top of canopy, projected area basis [m^2/gC]    
 
-         forc_pbot     => atm2lnd_vars%forc_pbot_downscaled_col    , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
+         forc_pbot     => top_as%pbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
 
          t_veg         => temperature_vars%t_veg_patch             , & ! Input:  [real(r8) (:)   ]  vegetation temperature (Kelvin)                                       
          t10           => temperature_vars%t_a10_patch             , & ! Input:  [real(r8) (:)   ]  10-day running mean of the 2 m temperature (K)                        
@@ -321,6 +322,7 @@ contains
       do f = 1, fn
          p = filterp(f)
          c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
 
          ! vcmax25 parameters, from CN
 
@@ -392,8 +394,8 @@ contains
          ! cp to account for variation in O2 using cp = 0.5 O2 / sco
          !
 
-         kc25 = (404.9_r8 / 1.e06_r8) * forc_pbot(c)
-         ko25 = (278.4_r8 / 1.e03_r8) * forc_pbot(c)
+         kc25 = (404.9_r8 / 1.e06_r8) * forc_pbot(t)
+         ko25 = (278.4_r8 / 1.e03_r8) * forc_pbot(t)
          sco  = 0.5_r8 * 0.209_r8 / (42.75_r8 / 1.e06_r8)
          cp25 = 0.5_r8 * oair(p) / sco
 
@@ -665,10 +667,11 @@ contains
       do f = 1, fn
          p = filterp(f)
          c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
 
          ! Leaf boundary layer conductance, umol/m**2/s
 
-         cf = forc_pbot(c)/(rgas*1.e-3_r8*tgcm(p))*1.e06_r8
+         cf = forc_pbot(t)/(rgas*1.e-3_r8*tgcm(p))*1.e06_r8
          gb = 1._r8/rb(p)
          gb_mol(p) = gb * cf
 
@@ -726,7 +729,7 @@ contains
                ciold = ci_z(p,iv)
 
                !find ci and stomatal conductance
-               call hybrid(ciold, p, iv, c, gb_mol(p), je, cair(p), oair(p), &
+               call hybrid(ciold, p, iv, c, t, gb_mol(p), je, cair(p), oair(p), &
                     lmr_z(p,iv), par_z(p,iv), rh_can, gs_mol(p,iv), niter, &
                     atm2lnd_vars, photosyns_vars)
 
@@ -736,9 +739,9 @@ contains
 
                ! Final estimates for cs and ci (needed for early exit of ci iteration when an < 0)
 
-               cs = cair(p) - 1.4_r8/gb_mol(p) * an(p,iv) * forc_pbot(c)
+               cs = cair(p) - 1.4_r8/gb_mol(p) * an(p,iv) * forc_pbot(t)
                cs = max(cs,1.e-06_r8)
-               ci_z(p,iv) = cair(p) - an(p,iv) * forc_pbot(c) * (1.4_r8*gs_mol(p,iv)+1.6_r8*gb_mol(p)) / (gb_mol(p)*gs_mol(p,iv))
+               ci_z(p,iv) = cair(p) - an(p,iv) * forc_pbot(t) * (1.4_r8*gs_mol(p,iv)+1.6_r8*gb_mol(p)) / (gb_mol(p)*gs_mol(p,iv))
 
                ! Convert gs_mol (umol H2O/m**2/s) to gs (m/s) and then to rs (s/m)
 
@@ -773,7 +776,7 @@ contains
 
                hs = (gb_mol(p)*ceair + gs_mol(p,iv)*esat_tv(p)) / ((gb_mol(p)+gs_mol(p,iv))*esat_tv(p))
                rh_leaf(p) = hs
-               gs_mol_err = mbb(p)*max(an(p,iv), 0._r8)*hs/cs*forc_pbot(c) + bbb(p)
+               gs_mol_err = mbb(p)*max(an(p,iv), 0._r8)*hs/cs*forc_pbot(t) + bbb(p)
 
                if (abs(gs_mol(p,iv)-gs_mol_err) > 1.e-01_r8) then
                   write (iulog,*) 'Ball-Berry error check - stomatal conductance error:'
@@ -946,16 +949,16 @@ contains
     ! !LOCAL VARIABLES:
     real(r8) , pointer :: par_z (:,:)   ! needed for backwards compatiblity
     real(r8) , pointer :: alphapsn (:)  ! needed for backwards compatiblity
-    integer  :: f,p,c,g,iv              ! indices
+    integer  :: f,p,c,t,g,iv            ! indices
     real(r8) :: co2(bounds%begp:bounds%endp)  ! atmospheric co2 partial pressure (pa)
     real(r8) :: ci
     !------------------------------------------------------------------------------
 
     associate(                                                  & 
-         forc_pbot   => atm2lnd_vars%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
+         forc_pbot   => top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
          forc_pco2   => atm2lnd_vars%forc_pco2_grc            , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
 
-         c3psn       => veg_vp%c3psn                      , & ! Input:  [real(r8) (:)   ]  photosynthetic pathway: 0. = c4, 1. = c3                              
+         c3psn       => veg_vp%c3psn                          , & ! Input:  [real(r8) (:)   ]  photosynthetic pathway: 0. = c4, 1. = c3
 
          nrad        => surfalb_vars%nrad_patch               , & ! Input:  [integer  (:)   ]  number of canopy layers, above snow for radiative transfer             
 
@@ -976,8 +979,9 @@ contains
 
       do f = 1, fn
          p = filterp(f)
-         c= veg_pp%column(p)
-         g= veg_pp%gridcell(p)
+         c = veg_pp%column(p)
+         t = veg_pp%topounit(p)
+         g = veg_pp%gridcell(p)
 
          co2(p) = forc_pco2(g)
          do iv = 1,nrad(p)
@@ -985,7 +989,7 @@ contains
                alphapsn(p) = 1._r8
             else                                     ! day time
                ci = co2(p) - ((an(p,iv) * (1._r8-downreg(p)) ) * &
-                    forc_pbot(c) * &
+                    forc_pbot(t) * &
                     (1.4_r8*gs_mol(p,iv)+1.6_r8*gb_mol(p)) / (gb_mol(p)*gs_mol(p,iv)))
                alphapsn(p) = 1._r8 + (((c3psn(veg_pp%itype(p)) * &
                     (4.4_r8 + (22.6_r8*(ci/co2(p))))) + &
@@ -999,7 +1003,7 @@ contains
   end subroutine Fractionation
 
   !-------------------------------------------------------------------------------
-  subroutine hybrid(x0, p, iv, c, gb_mol, je, cair, oair, lmr_z, par_z,&
+  subroutine hybrid(x0, p, iv, c, t, gb_mol, je, cair, oair, lmr_z, par_z,&
        rh_can, gs_mol,iter, &
        atm2lnd_vars, photosyns_vars)
     !
@@ -1026,7 +1030,7 @@ contains
     real(r8), intent(in) :: je                 ! electron transport rate (umol electrons/m**2/s)
     real(r8), intent(in) :: cair               ! Atmospheric CO2 partial pressure (Pa)
     real(r8), intent(in) :: oair               ! Atmospheric O2 partial pressure (Pa)
-    integer,  intent(in) :: p, iv, c           ! pft, c3/c4, and column index
+    integer,  intent(in) :: p, iv, c, t        ! pft, c3/c4, column, and topounit index
     real(r8), intent(out) :: gs_mol            ! leaf stomatal conductance (umol H2O/m**2/s)
     integer,  intent(out) :: iter              !number of iterations used, for record only   
     type(atm2lnd_type)  , intent(in)    :: atm2lnd_vars
@@ -1042,7 +1046,7 @@ contains
     integer,  parameter :: itmax = 40          !maximum number of iterations
     real(r8) :: tol,minx,minf
 
-    call ci_func(x0, f0, p, iv, c, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
+    call ci_func(x0, f0, p, iv, c, t, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
          atm2lnd_vars, photosyns_vars)
 
     if(f0 == 0._r8)return
@@ -1051,7 +1055,7 @@ contains
     minf=f0
     x1 = x0 * 0.99_r8
 
-    call ci_func(x1,f1, p, iv, c, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
+    call ci_func(x1,f1, p, iv, c, t, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
          atm2lnd_vars, photosyns_vars)
 
     if(f1==0._r8)then
@@ -1078,7 +1082,7 @@ contains
        f0 = f1
        x1 = x   
 
-       call ci_func(x1,f1, p, iv, c, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
+       call ci_func(x1,f1, p, iv, c, t, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
             atm2lnd_vars, photosyns_vars)
 
        if(f1<minf)then
@@ -1093,7 +1097,7 @@ contains
        !if a root zone is found, use the brent method for a robust backup strategy
        if(f1 * f0 < 0._r8)then
 
-          call brent(x, x0,x1,f0,f1, tol, p, iv, c, gb_mol, je, cair, oair, &
+          call brent(x, x0,x1,f0,f1, tol, p, iv, c, t, gb_mol, je, cair, oair, &
                lmr_z, par_z, rh_can, gs_mol, &
                atm2lnd_vars, photosyns_vars)
 
@@ -1106,7 +1110,7 @@ contains
           !this happens because of some other issues besides the stomatal conductance calculation
           !and it happens usually in very dry places and more likely with c4 plants.
 
-          call ci_func(minx,f1, p, iv, c, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
+          call ci_func(minx,f1, p, iv, c, t, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
                atm2lnd_vars, photosyns_vars)
 
           exit
@@ -1116,7 +1120,7 @@ contains
   end subroutine hybrid
 
   !------------------------------------------------------------------------------
-  subroutine brent(x, x1,x2,f1, f2, tol, ip, iv, ic, gb_mol, je, cair, oair,&
+  subroutine brent(x, x1,x2,f1, f2, tol, ip, iv, ic, it, gb_mol, je, cair, oair,&
        lmr_z, par_z, rh_can, gs_mol, &
        atm2lnd_vars, photosyns_vars)
     !
@@ -1138,7 +1142,7 @@ contains
     real(r8), intent(in) :: cair              ! Atmospheric CO2 partial pressure (Pa)
     real(r8), intent(in) :: oair              ! Atmospheric O2 partial pressure (Pa)
     real(r8), intent(in) :: rh_can            ! inside canopy relative humidity 
-    integer,  intent(in) :: ip, iv, ic        ! pft, c3/c4, and column index
+    integer,  intent(in) :: ip, iv, ic, it    ! pft, c3/c4, column, and topounit index
     real(r8), intent(out) :: gs_mol           ! leaf stomatal conductance (umol H2O/m**2/s)
     type(atm2lnd_type)  , intent(in)    :: atm2lnd_vars
     type(photosyns_type), intent(inout) :: photosyns_vars
@@ -1216,7 +1220,7 @@ contains
           b=b+sign(tol1,xm)
        endif
 
-       call ci_func(b, fb, ip, iv, ic, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
+       call ci_func(b, fb, ip, iv, ic, it, gb_mol, je, cair, oair, lmr_z, par_z, rh_can, gs_mol, &
          atm2lnd_vars, photosyns_vars)
 
        if(fb==0._r8)exit
@@ -1306,7 +1310,7 @@ contains
   end function fth25
 
   !------------------------------------------------------------------------------
-  subroutine ci_func(ci, fval, p, iv, c, gb_mol, je, cair, oair, lmr_z, par_z,&
+  subroutine ci_func(ci, fval, p, iv, c, t, gb_mol, je, cair, oair, lmr_z, par_z,&
        rh_can, gs_mol, atm2lnd_vars, photosyns_vars)
     !
     !! DESCRIPTION:
@@ -1327,7 +1331,7 @@ contains
     real(r8)             , intent(in)    :: cair     ! Atmospheric CO2 partial pressure (Pa)
     real(r8)             , intent(in)    :: oair     ! Atmospheric O2 partial pressure (Pa)
     real(r8)             , intent(in)    :: rh_can   ! canopy air realtive humidity
-    integer              , intent(in)    :: p, iv, c ! pft, vegetation type and column indexes
+    integer              , intent(in)    :: p,iv,c,t ! pft, vegetation type, column, and topounit indexes
     real(r8)             , intent(out)   :: fval     ! return function of the value f(ci)
     real(r8)             , intent(out)   :: gs_mol   ! leaf stomatal conductance (umol H2O/m**2/s)
     type(atm2lnd_type)   , intent(in)    :: atm2lnd_vars
@@ -1345,7 +1349,7 @@ contains
     !------------------------------------------------------------------------------
 
     associate(& 
-         forc_pbot  => atm2lnd_vars%forc_pbot_downscaled_col   , & ! Output: [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
+         forc_pbot  => top_as%pbot                             , & ! Output: [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
          c3flag     => photosyns_vars%c3flag_patch             , & ! Output: [logical  (:)   ]  true if C3 and false if C4                                             
          ac         => photosyns_vars%ac_patch                 , & ! Output: [real(r8) (:,:) ]  Rubisco-limited gross photosynthesis (umol CO2/m**2/s)              
          aj         => photosyns_vars%aj_patch                 , & ! Output: [real(r8) (:,:) ]  RuBP-limited gross photosynthesis (umol CO2/m**2/s)                 
@@ -1388,7 +1392,7 @@ contains
          aj(p,iv) = qe(p) * par_z * 4.6_r8
 
          ! C4: PEP carboxylase-limited (CO2-limited)
-         ap(p,iv) = kp_z(p,iv) * max(ci, 0._r8) / forc_pbot(c)
+         ap(p,iv) = kp_z(p,iv) * max(ci, 0._r8) / forc_pbot(t)
 
       end if
 
@@ -1416,17 +1420,17 @@ contains
       ! Quadratic gs_mol calculation with an known. Valid for an >= 0.
       ! With an <= 0, then gs_mol = bbb
 
-      cs = cair - 1.4_r8/gb_mol * an(p,iv) * forc_pbot(c)
+      cs = cair - 1.4_r8/gb_mol * an(p,iv) * forc_pbot(t)
       cs = max(cs,1.e-06_r8)
       aquad = cs
-      bquad = cs*(gb_mol - bbb(p)) - mbb(p)*an(p,iv)*forc_pbot(c)
-      cquad = -gb_mol*(cs*bbb(p) + mbb(p)*an(p,iv)*forc_pbot(c)*rh_can)
+      bquad = cs*(gb_mol - bbb(p)) - mbb(p)*an(p,iv)*forc_pbot(t)
+      cquad = -gb_mol*(cs*bbb(p) + mbb(p)*an(p,iv)*forc_pbot(t)*rh_can)
       call quadratic (aquad, bquad, cquad, r1, r2)
       gs_mol = max(r1,r2)
 
       ! Derive new estimate for ci
 
-      fval =ci - cair + an(p,iv) * forc_pbot(c) * (1.4_r8*gs_mol+1.6_r8*gb_mol) / (gb_mol*gs_mol)
+      fval =ci - cair + an(p,iv) * forc_pbot(t) * (1.4_r8*gs_mol+1.6_r8*gb_mol) / (gb_mol*gs_mol)
 
     end associate
 

--- a/components/clm/src/biogeophys/PhotosynthesisMod.F90
+++ b/components/clm/src/biogeophys/PhotosynthesisMod.F90
@@ -853,12 +853,12 @@ contains
     type(photosyns_type)   , intent(inout) :: photosyns_vars
     !
     ! !LOCAL VARIABLES:
-    integer :: f,fp,p,l,g               ! indices
+    integer :: f,fp,p,l,t,g               ! indices
     !-----------------------------------------------------------------------
 
     associate(                                             &
-         forc_pco2   => atm2lnd_vars%forc_pco2_grc       , & ! Input:  [real(r8) (:) ]  partial pressure co2 (Pa)                                             
-         forc_pc13o2 => atm2lnd_vars%forc_pc13o2_grc     , & ! Input:  [real(r8) (:) ]  partial pressure c13o2 (Pa)                                           
+         forc_pco2   => top_as%pco2bot                   , & ! Input:  [real(r8) (:) ]  partial pressure co2 (Pa)                                             
+         forc_pc13o2 => top_as%pc13o2bot                 , & ! Input:  [real(r8) (:) ]  partial pressure c13o2 (Pa)                                           
          forc_po2    => atm2lnd_vars%forc_po2_grc        , & ! Input:  [real(r8) (:) ]  partial pressure o2 (Pa)                                              
 
          rc14_atm    => cnstate_vars%rc14_atm_patch      , & ! Input : [real(r8) (:) ]  C14O2/C12O2 in atmosphere 
@@ -892,6 +892,7 @@ contains
       do f = 1, fn
          p = filterp(f)
          g = veg_pp%gridcell(p)
+         t = veg_pp%topounit(p)
 
          if (.not.use_fates) then
             fpsn(p)    = psnsun(p)   *laisun(p) + psnsha(p)   *laisha(p)
@@ -902,7 +903,7 @@ contains
 
          if (use_cn) then
             if ( use_c13 ) then
-               rc13_canair(p) = forc_pc13o2(g)/(forc_pco2(g) - forc_pc13o2(g))
+               rc13_canair(p) = forc_pc13o2(t)/(forc_pco2(t) - forc_pc13o2(t))
                rc13_psnsun(p) = rc13_canair(p)/alphapsnsun(p)
                rc13_psnsha(p) = rc13_canair(p)/alphapsnsha(p)
                c13_psnsun(p)  = psnsun(p) * (rc13_psnsun(p)/(1._r8+rc13_psnsun(p)))
@@ -956,7 +957,7 @@ contains
 
     associate(                                                  & 
          forc_pbot   => top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
-         forc_pco2   => atm2lnd_vars%forc_pco2_grc            , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
+         forc_pco2   => top_as%pco2bot                        , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
 
          c3psn       => veg_vp%c3psn                          , & ! Input:  [real(r8) (:)   ]  photosynthetic pathway: 0. = c4, 1. = c3
 
@@ -983,7 +984,7 @@ contains
          t = veg_pp%topounit(p)
          g = veg_pp%gridcell(p)
 
-         co2(p) = forc_pco2(g)
+         co2(p) = forc_pco2(t)
          do iv = 1,nrad(p)
             if (par_z(p,iv) <= 0._r8) then           ! night time
                alphapsn(p) = 1._r8

--- a/components/clm/src/biogeophys/PhotosynthesisMod.F90
+++ b/components/clm/src/biogeophys/PhotosynthesisMod.F90
@@ -859,7 +859,7 @@ contains
     associate(                                             &
          forc_pco2   => top_as%pco2bot                   , & ! Input:  [real(r8) (:) ]  partial pressure co2 (Pa)                                             
          forc_pc13o2 => top_as%pc13o2bot                 , & ! Input:  [real(r8) (:) ]  partial pressure c13o2 (Pa)                                           
-         forc_po2    => atm2lnd_vars%forc_po2_grc        , & ! Input:  [real(r8) (:) ]  partial pressure o2 (Pa)                                              
+         forc_po2    => top_as%po2bot                    , & ! Input:  [real(r8) (:) ]  partial pressure o2 (Pa)                                              
 
          rc14_atm    => cnstate_vars%rc14_atm_patch      , & ! Input : [real(r8) (:) ]  C14O2/C12O2 in atmosphere 
 

--- a/components/clm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/clm/src/biogeophys/UrbanFluxesMod.F90
@@ -26,7 +26,7 @@ module UrbanFluxesMod
   use TopounitType         , only : top_as  
   use LandunitType         , only : lun_pp                
   use ColumnType           , only : col_pp                
-  use VegetationType            , only : veg_pp                
+  use VegetationType       , only : veg_pp                
   use SurfaceResistanceMod , only : do_soilevap_beta
   !
   ! !PUBLIC TYPES:
@@ -195,7 +195,7 @@ contains
          forc_th             =>   top_as%thbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (K)             
          forc_rho            =>   atm2lnd_vars%forc_rho_not_downscaled_grc  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                 
          forc_q              =>   atm2lnd_vars%forc_q_not_downscaled_grc    , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
-         forc_pbot           =>   atm2lnd_vars%forc_pbot_not_downscaled_grc , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
+         forc_pbot           =>   top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
          forc_u              =>   atm2lnd_vars%forc_u_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)    
          forc_v              =>   atm2lnd_vars%forc_v_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)   
 
@@ -899,7 +899,7 @@ contains
 
          ! 2 m height relative humidity
 
-         call QSat(t_ref2m(p), forc_pbot(g), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
+         call QSat(t_ref2m(p), forc_pbot(t), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
          rh_ref2m(p) = min(100._r8, q_ref2m(p) / qsat_ref2m * 100._r8)
          rh_ref2m_u(p) = rh_ref2m(p)
 

--- a/components/clm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/clm/src/biogeophys/UrbanFluxesMod.F90
@@ -193,7 +193,7 @@ contains
 
          forc_t              =>   top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (K)                       
          forc_th             =>   top_as%thbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (K)             
-         forc_rho            =>   atm2lnd_vars%forc_rho_not_downscaled_grc  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                 
+         forc_rho            =>   top_as%rhobot                             , & ! Input:  [real(r8) (:)   ]  air density (kg/m**3)                                 
          forc_q              =>   top_as%qbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
          forc_pbot           =>   top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
          forc_u              =>   top_as%ubot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)    
@@ -394,6 +394,7 @@ contains
 
          do fl = 1, num_urbanl
             l = filter_urbanl(fl)
+            t = lun_pp%topounit(l)
             g = lun_pp%gridcell(l)
 
             ! Determine aerodynamic resistance to fluxes from urban canopy air to
@@ -413,7 +414,7 @@ contains
             ! shaded walls) to urban canopy air, since it is only dependent on wind speed
             ! Also from Masson 2000.
 
-            canyon_resistance(l) = cpair * forc_rho(g) / (11.8_r8 + 4.2_r8*canyon_wind(l))
+            canyon_resistance(l) = cpair * forc_rho(t) / (11.8_r8 + 4.2_r8*canyon_wind(l))
 
          end do
 
@@ -688,33 +689,33 @@ contains
          ! ground temperature
 
          if (ctype(c) == icol_roof) then
-            cgrnds(p) = forc_rho(g) * cpair * (wtas(l) + wtus_road_perv(l) +  &
+            cgrnds(p) = forc_rho(t) * cpair * (wtas(l) + wtus_road_perv(l) +  &
                  wtus_road_imperv(l) + wtus_sunwall(l) + wtus_shadewall(l)) * &
                  (wtus_roof_unscl(l)/wts_sum(l))
-            cgrndl(p) = forc_rho(g) * (wtaq(l) + wtuq_road_perv(l) +  &
+            cgrndl(p) = forc_rho(t) * (wtaq(l) + wtuq_road_perv(l) +  &
                  wtuq_road_imperv(l) + wtuq_sunwall(l) + wtuq_shadewall(l)) * &
                  (wtuq_roof_unscl(l)/wtq_sum(l))*dqgdT(c)
          else if (ctype(c) == icol_road_perv) then
-            cgrnds(p) = forc_rho(g) * cpair * (wtas(l) + wtus_roof(l) +  &
+            cgrnds(p) = forc_rho(t) * cpair * (wtas(l) + wtus_roof(l) +  &
                  wtus_road_imperv(l) + wtus_sunwall(l) + wtus_shadewall(l)) * &
                  (wtus_road_perv_unscl(l)/wts_sum(l))
-            cgrndl(p) = forc_rho(g) * (wtaq(l) + wtuq_roof(l) +  &
+            cgrndl(p) = forc_rho(t) * (wtaq(l) + wtuq_roof(l) +  &
                  wtuq_road_imperv(l) + wtuq_sunwall(l) + wtuq_shadewall(l)) * &
                  (wtuq_road_perv_unscl(l)/wtq_sum(l))*dqgdT(c)
          else if (ctype(c) == icol_road_imperv) then
-            cgrnds(p) = forc_rho(g) * cpair * (wtas(l) + wtus_roof(l) +  &
+            cgrnds(p) = forc_rho(t) * cpair * (wtas(l) + wtus_roof(l) +  &
                  wtus_road_perv(l) + wtus_sunwall(l) + wtus_shadewall(l)) * &
                  (wtus_road_imperv_unscl(l)/wts_sum(l))
-            cgrndl(p) = forc_rho(g) * (wtaq(l) + wtuq_roof(l) +  &
+            cgrndl(p) = forc_rho(t) * (wtaq(l) + wtuq_roof(l) +  &
                  wtuq_road_perv(l) + wtuq_sunwall(l) + wtuq_shadewall(l)) * &
                  (wtuq_road_imperv_unscl(l)/wtq_sum(l))*dqgdT(c)
          else if (ctype(c) == icol_sunwall) then
-            cgrnds(p) = forc_rho(g) * cpair * (wtas(l) + wtus_roof(l) +  &
+            cgrnds(p) = forc_rho(t) * cpair * (wtas(l) + wtus_roof(l) +  &
                  wtus_road_perv(l) + wtus_road_imperv(l) + wtus_shadewall(l)) * &
                  (wtus_sunwall_unscl(l)/wts_sum(l))
             cgrndl(p) = 0._r8
          else if (ctype(c) == icol_shadewall) then
-            cgrnds(p) = forc_rho(g) * cpair * (wtas(l) + wtus_roof(l) +  &
+            cgrnds(p) = forc_rho(t) * cpair * (wtas(l) + wtus_roof(l) +  &
                  wtus_road_perv(l) + wtus_road_imperv(l) + wtus_sunwall(l)) * &
                  (wtus_shadewall_unscl(l)/wts_sum(l))
             cgrndl(p) = 0._r8
@@ -723,34 +724,34 @@ contains
 
          ! Surface fluxes of momentum, sensible and latent heat
 
-         taux(p)          = -forc_rho(g)*forc_u(t)/ramu(l)
-         tauy(p)          = -forc_rho(g)*forc_v(t)/ramu(l)
+         taux(p)          = -forc_rho(t)*forc_u(t)/ramu(l)
+         tauy(p)          = -forc_rho(t)*forc_v(t)/ramu(l)
 
          ! Use new canopy air temperature
          dth(l) = taf(l) - t_grnd(c)
 
          if (ctype(c) == icol_roof) then
-            eflx_sh_grnd(p)  = -forc_rho(g)*cpair*wtus_roof_unscl(l)*dth(l)
+            eflx_sh_grnd(p)  = -forc_rho(t)*cpair*wtus_roof_unscl(l)*dth(l)
             eflx_sh_snow(p)  = 0._r8
             eflx_sh_soil(p)  = 0._r8
             eflx_sh_h2osfc(p)= 0._r8
          else if (ctype(c) == icol_road_perv) then
-            eflx_sh_grnd(p)  = -forc_rho(g)*cpair*wtus_road_perv_unscl(l)*dth(l)
+            eflx_sh_grnd(p)  = -forc_rho(t)*cpair*wtus_road_perv_unscl(l)*dth(l)
             eflx_sh_snow(p)  = 0._r8
             eflx_sh_soil(p)  = 0._r8
             eflx_sh_h2osfc(p)= 0._r8
          else if (ctype(c) == icol_road_imperv) then
-            eflx_sh_grnd(p)  = -forc_rho(g)*cpair*wtus_road_imperv_unscl(l)*dth(l)
+            eflx_sh_grnd(p)  = -forc_rho(t)*cpair*wtus_road_imperv_unscl(l)*dth(l)
             eflx_sh_snow(p)  = 0._r8
             eflx_sh_soil(p)  = 0._r8
             eflx_sh_h2osfc(p)= 0._r8
          else if (ctype(c) == icol_sunwall) then
-            eflx_sh_grnd(p)  = -forc_rho(g)*cpair*wtus_sunwall_unscl(l)*dth(l)
+            eflx_sh_grnd(p)  = -forc_rho(t)*cpair*wtus_sunwall_unscl(l)*dth(l)
             eflx_sh_snow(p)  = 0._r8
             eflx_sh_soil(p)  = 0._r8
             eflx_sh_h2osfc(p)= 0._r8
          else if (ctype(c) == icol_shadewall) then
-            eflx_sh_grnd(p)  = -forc_rho(g)*cpair*wtus_shadewall_unscl(l)*dth(l)
+            eflx_sh_grnd(p)  = -forc_rho(t)*cpair*wtus_shadewall_unscl(l)*dth(l)
             eflx_sh_snow(p)  = 0._r8
             eflx_sh_soil(p)  = 0._r8
             eflx_sh_h2osfc(p)= 0._r8
@@ -762,21 +763,21 @@ contains
          dqh(l) = qaf(l) - qg(c)
 
          if (ctype(c) == icol_roof) then
-            qflx_evap_soi(p) = -forc_rho(g)*wtuq_roof_unscl(l)*dqh(l)
+            qflx_evap_soi(p) = -forc_rho(t)*wtuq_roof_unscl(l)*dqh(l)
          else if (ctype(c) == icol_road_perv) then
             ! Evaporation assigned to soil term if dew or snow
             ! or if no liquid water available in soil column
             if (dqh(l) > 0._r8 .or. frac_sno(c) > 0._r8 .or. soilalpha_u(c) <= 0._r8) then
-               qflx_evap_soi(p) = -forc_rho(g)*wtuq_road_perv_unscl(l)*dqh(l)
+               qflx_evap_soi(p) = -forc_rho(t)*wtuq_road_perv_unscl(l)*dqh(l)
                qflx_tran_veg(p) = 0._r8
                ! Otherwise, evaporation assigned to transpiration term
             else
                qflx_evap_soi(p) = 0._r8
-               qflx_tran_veg(p) = -forc_rho(g)*wtuq_road_perv_unscl(l)*dqh(l)
+               qflx_tran_veg(p) = -forc_rho(t)*wtuq_road_perv_unscl(l)*dqh(l)
             end if
             qflx_evap_veg(p) = qflx_tran_veg(p)
          else if (ctype(c) == icol_road_imperv) then
-            qflx_evap_soi(p) = -forc_rho(g)*wtuq_road_imperv_unscl(l)*dqh(l)
+            qflx_evap_soi(p) = -forc_rho(t)*wtuq_road_imperv_unscl(l)*dqh(l)
          else if (ctype(c) == icol_sunwall) then
             qflx_evap_soi(p) = 0._r8
          else if (ctype(c) == icol_shadewall) then
@@ -784,8 +785,8 @@ contains
          end if
 
          ! SCALED sensible and latent heat flux for error check
-         eflx_sh_grnd_scale(p)  = -forc_rho(g)*cpair*wtus(c)*dth(l)
-         qflx_evap_soi_scale(p) = -forc_rho(g)*wtuq(c)*dqh(l)
+         eflx_sh_grnd_scale(p)  = -forc_rho(t)*cpair*wtus(c)*dth(l)
+         qflx_evap_soi_scale(p) = -forc_rho(t)*wtuq(c)*dqh(l)
 
       end do
 
@@ -795,8 +796,8 @@ contains
          l = filter_urbanl(fl)
          t = lun_pp%topounit(l)
          g = lun_pp%gridcell(l)
-         eflx(l)       = -(forc_rho(g)*cpair/rahu(l))*(thm_g(l) - taf(l))
-         qflx(l)       = -(forc_rho(g)/rawu(l))*(forc_q(t) - qaf(l))
+         eflx(l)       = -(forc_rho(t)*cpair/rahu(l))*(thm_g(l) - taf(l))
+         qflx(l)       = -(forc_rho(t)/rawu(l))*(forc_q(t) - qaf(l))
          eflx_scale(l) = sum(eflx_sh_grnd_scale(lun_pp%pfti(l):lun_pp%pftf(l)))
          qflx_scale(l) = sum(qflx_evap_soi_scale(lun_pp%pfti(l):lun_pp%pftf(l)))
          eflx_err(l)   = eflx_scale(l) - eflx(l)

--- a/components/clm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/clm/src/biogeophys/UrbanFluxesMod.F90
@@ -196,8 +196,8 @@ contains
          forc_rho            =>   atm2lnd_vars%forc_rho_not_downscaled_grc  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                 
          forc_q              =>   top_as%qbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
          forc_pbot           =>   top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
-         forc_u              =>   atm2lnd_vars%forc_u_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)    
-         forc_v              =>   atm2lnd_vars%forc_v_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)   
+         forc_u              =>   top_as%ubot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)    
+         forc_v              =>   top_as%vbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)   
 
          wind_hgt_canyon     =>   urbanparams_vars%wind_hgt_canyon          , & ! Input:  [real(r8) (:)   ]  height above road at which wind in canyon is to be computed (m)
          eflx_traffic_factor =>   urbanparams_vars%eflx_traffic_factor      , & ! Input:  [real(r8) (:)   ]  multiplicative urban traffic factor for sensible heat flux
@@ -284,6 +284,7 @@ contains
       do fl = 1, num_urbanl
          l = filter_urbanl(fl)
          g = lun_pp%gridcell(l)
+         t = lun_pp%topounit(l)
 
          local_secp1(l)        = secs + nint((grc_pp%londeg(g)/degpsec)/dtime)*dtime
          local_secp1(l)        = mod(local_secp1(l),isecspday)
@@ -309,7 +310,7 @@ contains
 
          ! Magnitude of atmospheric wind
 
-         ur(l) = max(1.0_r8,sqrt(forc_u(g)*forc_u(g)+forc_v(g)*forc_v(g)))
+         ur(l) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
 
          ! Canyon top wind
 
@@ -673,6 +674,7 @@ contains
          p = filter_urbanp(f)
          c = veg_pp%column(p)
          g = veg_pp%gridcell(p)
+         t = veg_pp%topounit(p)
          l = veg_pp%landunit(p)
 
          ram1(p) = ramu(l)  !pass value to global variable
@@ -721,8 +723,8 @@ contains
 
          ! Surface fluxes of momentum, sensible and latent heat
 
-         taux(p)          = -forc_rho(g)*forc_u(g)/ramu(l)
-         tauy(p)          = -forc_rho(g)*forc_v(g)/ramu(l)
+         taux(p)          = -forc_rho(g)*forc_u(t)/ramu(l)
+         tauy(p)          = -forc_rho(g)*forc_v(t)/ramu(l)
 
          ! Use new canopy air temperature
          dth(l) = taf(l) - t_grnd(c)

--- a/components/clm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/clm/src/biogeophys/UrbanFluxesMod.F90
@@ -194,7 +194,7 @@ contains
          forc_t              =>   top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (K)                       
          forc_th             =>   top_as%thbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (K)             
          forc_rho            =>   atm2lnd_vars%forc_rho_not_downscaled_grc  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                 
-         forc_q              =>   atm2lnd_vars%forc_q_not_downscaled_grc    , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
+         forc_q              =>   top_as%qbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
          forc_pbot           =>   top_as%pbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
          forc_u              =>   atm2lnd_vars%forc_u_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)    
          forc_v              =>   atm2lnd_vars%forc_v_grc                   , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)   
@@ -341,10 +341,10 @@ contains
          g = lun_pp%gridcell(l)
 
          thm_g(l) = forc_t(t) + lapse_rate*forc_hgt_t_patch(lun_pp%pfti(l))
-         thv_g(l) = forc_th(t)*(1._r8+0.61_r8*forc_q(g))
+         thv_g(l) = forc_th(t)*(1._r8+0.61_r8*forc_q(t))
          dth(l)   = thm_g(l)-taf(l)
-         dqh(l)   = forc_q(g)-qaf(l)
-         dthv     = dth(l)*(1._r8+0.61_r8*forc_q(g))+0.61_r8*forc_th(t)*dqh(l)
+         dqh(l)   = forc_q(t)-qaf(l)
+         dthv     = dth(l)*(1._r8+0.61_r8*forc_q(t))+0.61_r8*forc_th(t)*dqh(l)
          zldis(l) = forc_hgt_u_patch(lun_pp%pfti(l)) - z_d_town(l)
 
          ! Initialize Monin-Obukhov length and wind speed including convective velocity
@@ -420,11 +420,12 @@ contains
          ! and specific humidity (numerator) and is a landunit quantity
          do fl = 1, num_urbanl
             l = filter_urbanl(fl)
+            t = lun_pp%topounit(l)
             g = lun_pp%gridcell(l)
 
             taf_numer(l) = thm_g(l)/rahu(l)
             taf_denom(l) = 1._r8/rahu(l)
-            qaf_numer(l) = forc_q(g)/rawu(l)
+            qaf_numer(l) = forc_q(t)/rawu(l)
             qaf_denom(l) = 1._r8/rawu(l)
 
             ! First term needed for derivative of heat fluxes
@@ -640,10 +641,10 @@ contains
             g = lun_pp%gridcell(l)
 
             dth(l) = thm_g(l)-taf(l)
-            dqh(l) = forc_q(g)-qaf(l)
+            dqh(l) = forc_q(t)-qaf(l)
             tstar = temp1(l)*dth(l)
             qstar = temp2(l)*dqh(l)
-            thvstar = tstar*(1._r8+0.61_r8*forc_q(g)) + 0.61_r8*forc_th(t)*qstar
+            thvstar = tstar*(1._r8+0.61_r8*forc_q(t)) + 0.61_r8*forc_th(t)*qstar
             zeta = zldis(l)*vkc*grav*thvstar/(ustar(l)**2*thv_g(l))
 
             if (zeta >= 0._r8) then                   !stable
@@ -790,9 +791,10 @@ contains
       ! the scaled heat fluxes above
       do fl = 1, num_urbanl
          l = filter_urbanl(fl)
+         t = lun_pp%topounit(l)
          g = lun_pp%gridcell(l)
          eflx(l)       = -(forc_rho(g)*cpair/rahu(l))*(thm_g(l) - taf(l))
-         qflx(l)       = -(forc_rho(g)/rawu(l))*(forc_q(g) - qaf(l))
+         qflx(l)       = -(forc_rho(g)/rawu(l))*(forc_q(t) - qaf(l))
          eflx_scale(l) = sum(eflx_sh_grnd_scale(lun_pp%pfti(l):lun_pp%pftf(l)))
          qflx_scale(l) = sum(qflx_evap_soi_scale(lun_pp%pfti(l):lun_pp%pftf(l)))
          eflx_err(l)   = eflx_scale(l) - eflx(l)

--- a/components/clm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/clm/src/biogeophys/UrbanFluxesMod.F90
@@ -192,7 +192,7 @@ contains
          wtroad_perv         =>   lun_pp%wtroad_perv                           , & ! Input:  [real(r8) (:)   ]  weight of pervious road wrt total road            
 
          forc_t              =>   top_as%tbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (K)                       
-         forc_th             =>   atm2lnd_vars%forc_th_not_downscaled_grc   , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (K)             
+         forc_th             =>   top_as%thbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (K)             
          forc_rho            =>   atm2lnd_vars%forc_rho_not_downscaled_grc  , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                 
          forc_q              =>   atm2lnd_vars%forc_q_not_downscaled_grc    , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)             
          forc_pbot           =>   atm2lnd_vars%forc_pbot_not_downscaled_grc , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                         
@@ -341,10 +341,10 @@ contains
          g = lun_pp%gridcell(l)
 
          thm_g(l) = forc_t(t) + lapse_rate*forc_hgt_t_patch(lun_pp%pfti(l))
-         thv_g(l) = forc_th(g)*(1._r8+0.61_r8*forc_q(g))
+         thv_g(l) = forc_th(t)*(1._r8+0.61_r8*forc_q(g))
          dth(l)   = thm_g(l)-taf(l)
          dqh(l)   = forc_q(g)-qaf(l)
-         dthv     = dth(l)*(1._r8+0.61_r8*forc_q(g))+0.61_r8*forc_th(g)*dqh(l)
+         dthv     = dth(l)*(1._r8+0.61_r8*forc_q(g))+0.61_r8*forc_th(t)*dqh(l)
          zldis(l) = forc_hgt_u_patch(lun_pp%pfti(l)) - z_d_town(l)
 
          ! Initialize Monin-Obukhov length and wind speed including convective velocity
@@ -636,13 +636,14 @@ contains
          ! TODO: Some of these constants replicate what is in FrictionVelocity and BareGround fluxes should consildate. EBK
          do fl = 1, num_urbanl
             l = filter_urbanl(fl)
+            t = lun_pp%topounit(l)
             g = lun_pp%gridcell(l)
 
             dth(l) = thm_g(l)-taf(l)
             dqh(l) = forc_q(g)-qaf(l)
             tstar = temp1(l)*dth(l)
             qstar = temp2(l)*dqh(l)
-            thvstar = tstar*(1._r8+0.61_r8*forc_q(g)) + 0.61_r8*forc_th(g)*qstar
+            thvstar = tstar*(1._r8+0.61_r8*forc_q(g)) + 0.61_r8*forc_th(t)*qstar
             zeta = zldis(l)*vkc*grav*thvstar/(ustar(l)**2*thv_g(l))
 
             if (zeta >= 0._r8) then                   !stable

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -1012,6 +1012,12 @@ contains
             top_as%pc13o2bot(topo) = top_as%pco2bot(topo) * c13ratio;
          end if
        end do
+       ! CH4
+       if (index_x2l_Sa_methane /= 0) then
+          do topo = grc_pp%topi(g), grc_pp%topf(g)
+            top_as%pch4bot(topo) = x2l(index_x2l_Sa_methane,i)
+          end do
+       endif
         
          
 

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -64,6 +64,7 @@ contains
     real(r8) :: a0,a1,a2,a3,a4,a5,a6 ! coefficients for esat over water
     real(r8) :: b0,b1,b2,b3,b4,b5,b6 ! coefficients for esat over ice
     real(r8) :: tdc, t               ! Kelvins to Celcius function and its input
+    real(r8) :: vp                   ! water vapor pressure (Pa)
     integer  :: num, nu_nml, nml_error                 
     real(r8) :: swndf, swndr, swvdf, swvdr, ratio_rvrf, frac, q
     real(r8) :: thiscosz, avgcosz, szenith
@@ -989,8 +990,11 @@ contains
          end if
          qsat           = 0.622_r8*e / (top_as%pbot(topo) - 0.378_r8*e)
          top_as%rhbot(topo) = 100.0_r8*(top_as%qbot(topo) / qsat)
-         ! partial pressure of oxygen
+         ! partial pressure of oxygen (Pa)
          top_as%po2bot(topo) = o2_molar_const * top_as%pbot(topo)
+         ! air density (kg/m**3) - uses a temporary calculation of water vapor pressure (Pa)
+         vp = top_as%qbot(topo) * top_as%pbot(topo)  / (0.622_r8 + 0.378_r8 * top_as%qbot(topo))
+         top_as%rhobot(topo) = (top_as%pbot(topo) - 0.378_r8 * vp) / (rair * top_as%tbot(topo))
        end do
          
 #endif

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -6,7 +6,9 @@ module lnd_import_export
   use lnd2atmType  , only: lnd2atm_type
   use lnd2glcMod   , only: lnd2glc_type
   use atm2lndType  , only: atm2lnd_type
-  use glc2lndMod   , only: glc2lnd_type 
+  use glc2lndMod   , only: glc2lnd_type
+  use GridcellType , only: grc_pp         ! for access to gridcell topology
+  use TopounitType , only: top_as         ! atmospheric state forcings at topounit level  
   use clm_cpl_indices
   use mct_mod
   !
@@ -43,7 +45,7 @@ contains
     type(glc2lnd_type) , intent(inout) :: glc2lnd_vars      ! clm internal input data type
     !
     ! !LOCAL VARIABLES:
-    integer  :: g,i,m,thism,nstep,ier  ! indices, number of steps, and error code
+    integer  :: g,topo,i,m,thism,nstep,ier  ! indices, number of steps, and error code
     real(r8) :: forc_rainc           ! rainxy Atm flux mm/s
     real(r8) :: e, ea                ! vapor pressure (Pa)
     real(r8) :: qsat                 ! saturation specific humidity (kg/kg)
@@ -966,6 +968,13 @@ contains
        atm2lnd_vars%forc_aer_grc(g,12) =  x2l(index_x2l_Faxa_dstdry3,i)
        atm2lnd_vars%forc_aer_grc(g,13) =  x2l(index_x2l_Faxa_dstwet4,i)
        atm2lnd_vars%forc_aer_grc(g,14) =  x2l(index_x2l_Faxa_dstdry4,i)
+       
+       !set the topounit-level atmospheric state forcings
+       do topo = grc_pp%topi(g), grc_pp%topf(g)
+         top_as%tbot(topo)  = x2l(index_x2l_Sa_tbot,i)      ! forc_txy  Atm state K
+         top_as%thbot(topo) = x2l(index_x2l_Sa_ptem,i)      ! forc_thxy Atm state K
+       end do
+         
 #endif
 
        ! Determine optional receive fields

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -978,6 +978,8 @@ contains
          top_as%ubot(topo)    = x2l(index_x2l_Sa_u,i)         ! forc_uxy  Atm state m/s
          top_as%vbot(topo)    = x2l(index_x2l_Sa_v,i)         ! forc_vxy  Atm state m/s
          top_as%zbot(topo)    = x2l(index_x2l_Sa_z,i)         ! zgcmxy    Atm state m
+         ! assign the forcing fields derived from other inputs
+         top_as%windbot(topo) = sqrt(top_as%ubot(topo)**2 + top_as%vbot(topo)**2)
        end do
          
 #endif

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -989,6 +989,8 @@ contains
          end if
          qsat           = 0.622_r8*e / (top_as%pbot(topo) - 0.378_r8*e)
          top_as%rhbot(topo) = 100.0_r8*(top_as%qbot(topo) / qsat)
+         ! partial pressure of oxygen
+         top_as%po2bot(topo) = o2_molar_const * top_as%pbot(topo)
        end do
          
 #endif

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -971,8 +971,9 @@ contains
        
        !set the topounit-level atmospheric state forcings
        do topo = grc_pp%topi(g), grc_pp%topf(g)
-         top_as%tbot(topo)  = x2l(index_x2l_Sa_tbot,i)      ! forc_txy  Atm state K
-         top_as%thbot(topo) = x2l(index_x2l_Sa_ptem,i)      ! forc_thxy Atm state K
+         top_as%tbot(topo)    = x2l(index_x2l_Sa_tbot,i)      ! forc_txy  Atm state K
+         top_as%thbot(topo)   = x2l(index_x2l_Sa_ptem,i)      ! forc_thxy Atm state K
+         top_as%pbot(topo)    = x2l(index_x2l_Sa_pbot,i)      ! ptcmxy    Atm state Pa
        end do
          
 #endif

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -974,6 +974,7 @@ contains
          top_as%tbot(topo)    = x2l(index_x2l_Sa_tbot,i)      ! forc_txy  Atm state K
          top_as%thbot(topo)   = x2l(index_x2l_Sa_ptem,i)      ! forc_thxy Atm state K
          top_as%pbot(topo)    = x2l(index_x2l_Sa_pbot,i)      ! ptcmxy    Atm state Pa
+         top_as%qbot(topo)    = x2l(index_x2l_Sa_shum,i)      ! forc_qxy  Atm state kg/kg
        end do
          
 #endif

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -998,8 +998,16 @@ contains
          top_as%rhobot(topo) = (top_as%pbot(topo) - 0.378_r8 * vp) / (rair * top_as%tbot(topo))
          
          ! second, all the flux forcings
-         top_af%rain(topo) = forc_rainc + forc_rainl   ! sum of convective and large-scale rain
-         top_af%snow(topo) = forc_snowc + forc_snowl   ! sum of convective and large-scale snow
+         top_af%rain(topo)    = forc_rainc + forc_rainl       ! sum of convective and large-scale rain
+         top_af%snow(topo)    = forc_snowc + forc_snowl       ! sum of convective and large-scale snow
+         top_af%solad(topo,2) = x2l(index_x2l_Faxa_swndr,i)   ! forc_sollxy  Atm flux  W/m^2
+         top_af%solad(topo,1) = x2l(index_x2l_Faxa_swvdr,i)   ! forc_solsxy  Atm flux  W/m^2
+         top_af%solai(topo,2) = x2l(index_x2l_Faxa_swndf,i)   ! forc_solldxy Atm flux  W/m^2
+         top_af%solai(topo,1) = x2l(index_x2l_Faxa_swvdf,i)   ! forc_solsdxy Atm flux  W/m^2
+         top_af%lwrad(topo)   = x2l(index_x2l_Faxa_lwdn,i)    ! flwdsxy Atm flux  W/m^2
+         ! derived flux forcings
+         top_af%solar(topo) = top_af%solad(topo,2) + top_af%solad(topo,1) + &
+                              top_af%solai(topo,2) + top_af%solai(topo,1)
        end do
          
 #endif

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -983,6 +983,26 @@ contains
 #endif
 
        ! Determine optional receive fields
+       ! CO2 (and C13O2) concentration: constant, prognostic, or diagnostic
+       if (co2_type_idx == 0) then                    ! CO2 constant, value from namelist
+         co2_ppmv_val = co2_ppmv
+       else if (co2_type_idx == 1) then               ! CO2 prognostic, value from coupler field
+         co2_ppmv_val = x2l(index_x2l_Sa_co2prog,i)
+       else if (co2_type_idx == 2) then               ! CO2 diagnostic, value from coupler field
+         co2_ppmv_val = x2l(index_x2l_Sa_co2diag,i)
+       else
+         call endrun( sub//' ERROR: Invalid co2_type_idx, must be 0, 1, or 2 (constant, prognostic, or diagnostic)' )
+       end if
+       ! Assign to topounits, with conversion from ppmv to partial pressure (Pa)
+       ! If using C13, then get the c13ratio from clm_varcon (constant value for pre-industrial atmosphere)
+       do topo = grc_pp%topi(g), grc_pp%topf(g)
+         top_as%pco2bot(topo) = co2_ppmv_val * 1.e-6_r8 * top_as%pbot(topo)
+         if (use_c13) then
+            top_as%pc13o2bot(topo) = top_as%pco2bot(topo) * c13ratio;
+         end if
+       end do
+        
+         
 
        if (index_x2l_Sa_co2prog /= 0) then
           co2_ppmv_prog = x2l(index_x2l_Sa_co2prog,i)   ! co2 atm state prognostic

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -977,6 +977,7 @@ contains
          top_as%qbot(topo)    = x2l(index_x2l_Sa_shum,i)      ! forc_qxy  Atm state kg/kg
          top_as%ubot(topo)    = x2l(index_x2l_Sa_u,i)         ! forc_uxy  Atm state m/s
          top_as%vbot(topo)    = x2l(index_x2l_Sa_v,i)         ! forc_vxy  Atm state m/s
+         top_as%zbot(topo)    = x2l(index_x2l_Sa_z,i)         ! zgcmxy    Atm state m
        end do
          
 #endif

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -975,6 +975,8 @@ contains
          top_as%thbot(topo)   = x2l(index_x2l_Sa_ptem,i)      ! forc_thxy Atm state K
          top_as%pbot(topo)    = x2l(index_x2l_Sa_pbot,i)      ! ptcmxy    Atm state Pa
          top_as%qbot(topo)    = x2l(index_x2l_Sa_shum,i)      ! forc_qxy  Atm state kg/kg
+         top_as%ubot(topo)    = x2l(index_x2l_Sa_u,i)         ! forc_uxy  Atm state m/s
+         top_as%vbot(topo)    = x2l(index_x2l_Sa_v,i)         ! forc_vxy  Atm state m/s
        end do
          
 #endif

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -979,7 +979,16 @@ contains
          top_as%vbot(topo)    = x2l(index_x2l_Sa_v,i)         ! forc_vxy  Atm state m/s
          top_as%zbot(topo)    = x2l(index_x2l_Sa_z,i)         ! zgcmxy    Atm state m
          ! assign the forcing fields derived from other inputs
+         ! Horizontal windspeed (m/s)
          top_as%windbot(topo) = sqrt(top_as%ubot(topo)**2 + top_as%vbot(topo)**2)
+         ! Relative humidity (percent)
+         if (top_as%tbot(topo) > SHR_CONST_TKFRZ) then
+            e = esatw(tdc(top_as%tbot(topo)))
+         else
+            e = esati(tdc(top_as%tbot(topo)))
+         end if
+         qsat           = 0.622_r8*e / (top_as%pbot(topo) - 0.378_r8*e)
+         top_as%rhbot(topo) = 100.0_r8*(top_as%qbot(topo) / qsat)
        end do
          
 #endif

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -58,9 +58,7 @@ module TopounitType
     procedure, public :: Clean => clean_top_pp  
   end type topounit_physical_properties
     
-  ! Define the data structure that passes atmospheric state information to the land model.
-  ! Primary point of exchange is assumed to be at the topounit level, where the influences
-  ! of topography can be represented
+  ! Define the data structure where land model receives atmospheric state information.
   type, public :: topounit_atmospheric_state
     real(r8), pointer :: tbot       (:) => null() ! temperature of air at atmospheric forcing height (K)
     real(r8), pointer :: thbot      (:) => null() ! potential temperature of air at atmospheric forcing height (K)
@@ -80,6 +78,19 @@ module TopounitType
     procedure, public :: Init  => init_top_as
     procedure, public :: Clean => clean_top_as
   end type topounit_atmospheric_state
+
+  ! Define the data structure that where land model receives atmospheric flux information.
+  type, public :: topounit_atmospheric_flux
+    real(r8), pointer :: rain       (:) => null() ! rain rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    real(r8), pointer :: snow       (:) => null() ! snow rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    real(r8), pointer :: prec24h    (:) => null() ! 24-hour mean precip rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    real(r8), pointer :: prec10d    (:) => null() ! 10-day mean precip rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    real(r8), pointer :: prec60d    (:) => null() ! 60-day mean precip rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    
+  contains
+    procedure, public :: Init  => init_top_af
+    procedure, public :: Clean => clean_top_af
+  end type topounit_atmospheric_flux
   
   ! Define the data structure that holds energy state information for land at the level of topographic unit.
   type, public :: topounit_energy_state
@@ -92,6 +103,7 @@ module TopounitType
   ! declare the public instances of topounit types
   type(topounit_physical_properties),  public, target :: top_pp
   type(topounit_atmospheric_state),    public, target :: top_as
+  type(topounit_atmospheric_flux),     public, target :: top_af
   type(topounit_energy_state),         public, target :: top_es
   
   contains
@@ -204,6 +216,40 @@ module TopounitType
     deallocate(this%pc13o2bot)
     deallocate(this%pch4bot)
   end subroutine clean_top_as
+
+  subroutine init_top_af(this, begt, endt)
+    class(topounit_atmospheric_flux) :: this
+    integer, intent(in) :: begt   ! beginning topographic unit index
+    integer, intent(in) :: endt   ! ending topographic unit index
+   
+    ! Allocate for atmospheric flux forcing variables, initialize to special value
+    allocate(this%rain     (begt:endt)) ; this%rain      (:) = spval
+    allocate(this%snow     (begt:endt)) ; this%snow      (:) = spval
+    allocate(this%prec24h  (begt:endt)) ; this%prec24h   (:) = spval
+    allocate(this%prec10d  (begt:endt)) ; this%prec10d   (:) = spval
+    allocate(this%prec60d  (begt:endt)) ; this%prec60d   (:) = spval
+    
+    ! Set history fields for atmospheric flux forcing variables
+    !call hist_addfld1d (fname='TBOT', units='K',  &
+    !     avgflag='A', long_name='temperature of air at atmospheric forcing height', &
+    !     ptr_lnd=this%tbot)
+
+    !call hist_addfld1d (fname='THBOT', units='K',  &
+    !     avgflag='A', long_name='potential temperature of air at atmospheric forcing height', &
+    !     ptr_lnd=this%thbot)
+  end subroutine init_top_af
+
+  subroutine clean_top_af(this, begt, endt)
+    class(topounit_atmospheric_flux) :: this
+    integer, intent(in) :: begt   ! beginning topographic unit index
+    integer, intent(in) :: endt   ! ending topographic unit index
+
+    deallocate(this%rain)
+    deallocate(this%snow)
+    deallocate(this%prec24h)
+    deallocate(this%prec10d)
+    deallocate(this%prec60d)
+  end subroutine clean_top_af
 
   subroutine init_top_es(this, begt, endt)
     class(topounit_energy_state) :: this

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -71,6 +71,7 @@ module TopounitType
     real(r8), pointer :: vbot       (:) => null() ! wind speed in V (north) direction at atmospheric forcing height (m/s)
     real(r8), pointer :: windbot    (:) => null() ! horizontal component of wind at atmospheric forcing height (m/s)
     real(r8), pointer :: zbot       (:) => null() ! atmospheric forcing height (m)
+    real(r8), pointer :: po2bot     (:) => null() ! partial pressure of O2 at atmospheric forcing height (Pa)
     real(r8), pointer :: pco2bot    (:) => null() ! partial pressure of CO2 at atmospheric forcing height (Pa) 
     real(r8), pointer :: pc13o2bot  (:) => null() ! partial pressure of C13O2 at atmospheric forcing height (Pa) 
     real(r8), pointer :: pch4bot    (:) => null() ! partial pressure of CH4 at atmospheric forcing height (Pa) 
@@ -166,6 +167,7 @@ module TopounitType
     allocate(this%vbot     (begt:endt)) ; this%vbot      (:) = spval
     allocate(this%windbot  (begt:endt)) ; this%windbot   (:) = spval
     allocate(this%zbot     (begt:endt)) ; this%zbot      (:) = spval
+    allocate(this%po2bot   (begt:endt)) ; this%po2bot    (:) = spval
     allocate(this%pco2bot  (begt:endt)) ; this%pco2bot   (:) = spval
     allocate(this%pc13o2bot(begt:endt)) ; this%pc13o2bot (:) = spval
     allocate(this%pch4bot  (begt:endt)) ; this%pch4bot   (:) = spval
@@ -194,6 +196,7 @@ module TopounitType
     deallocate(this%vbot)
     deallocate(this%windbot)
     deallocate(this%zbot)
+    deallocate(this%po2bot)
     deallocate(this%pco2bot)
     deallocate(this%pc13o2bot)
     deallocate(this%pch4bot)

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -64,6 +64,7 @@ module TopounitType
   type, public :: topounit_atmospheric_state
     real(r8), pointer :: tbot       (:) => null() ! temperature of air at atmospheric forcing height (K)
     real(r8), pointer :: thbot      (:) => null() ! potential temperature of air at atmospheric forcing height (K)
+    real(r8), pointer :: pbot       (:) => null() ! air pressure at atmospheric forcing height (Pa)
   contains
     procedure, public :: Init  => init_top_as
     procedure, public :: Clean => clean_top_as
@@ -160,6 +161,7 @@ module TopounitType
     ! Allocate for atmospheric state forcing variables, initialize to special value
     allocate(this%tbot    (begt:endt)) ; this%tbot   (:) = spval
     allocate(this%thbot   (begt:endt)) ; this%thbot  (:) = spval
+    allocate(this%pbot    (begt:endt)) ; this%pbot   (:) = spval
     
     ! Set history fields for atmospheric state forcing variables
     !call hist_addfld1d (fname='TBOT', units='K',  &
@@ -178,6 +180,7 @@ module TopounitType
 
     deallocate(this%tbot)
     deallocate(this%thbot)
+    deallocate(this%pbot)
   end subroutine clean_top_as
 
   subroutine init_top_es(this, begt, endt)

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -68,6 +68,7 @@ module TopounitType
     real(r8), pointer :: qbot       (:) => null() ! specific humidity at atmospheric forcing height (kg H2O/kg moist air)
     real(r8), pointer :: ubot       (:) => null() ! wind speed in U (east) direction at atmospheric forcing height (m/s)
     real(r8), pointer :: vbot       (:) => null() ! wind speed in V (north) direction at atmospheric forcing height (m/s)
+    real(r8), pointer :: zbot       (:) => null() ! atmospheric forcing height (m)
   contains
     procedure, public :: Init  => init_top_as
     procedure, public :: Clean => clean_top_as
@@ -168,6 +169,7 @@ module TopounitType
     allocate(this%qbot    (begt:endt)) ; this%qbot   (:) = spval
     allocate(this%ubot    (begt:endt)) ; this%ubot   (:) = spval
     allocate(this%vbot    (begt:endt)) ; this%vbot   (:) = spval
+    allocate(this%zbot    (begt:endt)) ; this%zbot   (:) = spval
     
     ! Set history fields for atmospheric state forcing variables
     !call hist_addfld1d (fname='TBOT', units='K',  &
@@ -190,6 +192,7 @@ module TopounitType
     deallocate(this%qbot)
     deallocate(this%ubot)
     deallocate(this%vbot)
+    deallocate(this%zbot)
   end subroutine clean_top_as
 
   subroutine init_top_es(this, begt, endt)

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -69,6 +69,8 @@ module TopounitType
     real(r8), pointer :: ubot       (:) => null() ! wind speed in U (east) direction at atmospheric forcing height (m/s)
     real(r8), pointer :: vbot       (:) => null() ! wind speed in V (north) direction at atmospheric forcing height (m/s)
     real(r8), pointer :: zbot       (:) => null() ! atmospheric forcing height (m)
+    real(r8), pointer :: pco2bot    (:) => null() ! partial pressure of CO2 at atmospheric forcing height (Pa) 
+    real(r8), pointer :: pc13o2bot  (:) => null() ! partial pressure of C13O2 at atmospheric forcing height (Pa) 
   contains
     procedure, public :: Init  => init_top_as
     procedure, public :: Clean => clean_top_as
@@ -163,13 +165,15 @@ module TopounitType
     integer, intent(in) :: endt   ! ending topographic unit index
    
     ! Allocate for atmospheric state forcing variables, initialize to special value
-    allocate(this%tbot    (begt:endt)) ; this%tbot   (:) = spval
-    allocate(this%thbot   (begt:endt)) ; this%thbot  (:) = spval
-    allocate(this%pbot    (begt:endt)) ; this%pbot   (:) = spval
-    allocate(this%qbot    (begt:endt)) ; this%qbot   (:) = spval
-    allocate(this%ubot    (begt:endt)) ; this%ubot   (:) = spval
-    allocate(this%vbot    (begt:endt)) ; this%vbot   (:) = spval
-    allocate(this%zbot    (begt:endt)) ; this%zbot   (:) = spval
+    allocate(this%tbot     (begt:endt)) ; this%tbot      (:) = spval
+    allocate(this%thbot    (begt:endt)) ; this%thbot     (:) = spval
+    allocate(this%pbot     (begt:endt)) ; this%pbot      (:) = spval
+    allocate(this%qbot     (begt:endt)) ; this%qbot      (:) = spval
+    allocate(this%ubot     (begt:endt)) ; this%ubot      (:) = spval
+    allocate(this%vbot     (begt:endt)) ; this%vbot      (:) = spval
+    allocate(this%zbot     (begt:endt)) ; this%zbot      (:) = spval
+    allocate(this%pco2bot  (begt:endt)) ; this%pco2bot   (:) = spval
+    allocate(this%pc13o2bot(begt:endt)) ; this%pc13o2bot (:) = spval
     
     ! Set history fields for atmospheric state forcing variables
     !call hist_addfld1d (fname='TBOT', units='K',  &
@@ -193,6 +197,8 @@ module TopounitType
     deallocate(this%ubot)
     deallocate(this%vbot)
     deallocate(this%zbot)
+    deallocate(this%pco2bot)
+    deallocate(this%pc13o2bot)
   end subroutine clean_top_as
 
   subroutine init_top_es(this, begt, endt)

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -65,6 +65,7 @@ module TopounitType
     real(r8), pointer :: tbot       (:) => null() ! temperature of air at atmospheric forcing height (K)
     real(r8), pointer :: thbot      (:) => null() ! potential temperature of air at atmospheric forcing height (K)
     real(r8), pointer :: pbot       (:) => null() ! air pressure at atmospheric forcing height (Pa)
+    real(r8), pointer :: rhobot     (:) => null() ! air density at atmospheric forcing height (kg/m**3)
     real(r8), pointer :: qbot       (:) => null() ! specific humidity at atmospheric forcing height (kg H2O/kg moist air)
     real(r8), pointer :: rhbot      (:) => null() ! relative humidity at atmospheric forcing height (%)
     real(r8), pointer :: ubot       (:) => null() ! wind speed in U (east) direction at atmospheric forcing height (m/s)
@@ -161,6 +162,7 @@ module TopounitType
     allocate(this%tbot     (begt:endt)) ; this%tbot      (:) = spval
     allocate(this%thbot    (begt:endt)) ; this%thbot     (:) = spval
     allocate(this%pbot     (begt:endt)) ; this%pbot      (:) = spval
+    allocate(this%rhobot   (begt:endt)) ; this%rhobot    (:) = spval
     allocate(this%qbot     (begt:endt)) ; this%qbot      (:) = spval
     allocate(this%rhbot    (begt:endt)) ; this%rhbot     (:) = spval
     allocate(this%ubot     (begt:endt)) ; this%ubot      (:) = spval
@@ -190,6 +192,7 @@ module TopounitType
     deallocate(this%tbot)
     deallocate(this%thbot)
     deallocate(this%pbot)
+    deallocate(this%rhobot)
     deallocate(this%qbot)
     deallocate(this%rhbot)
     deallocate(this%ubot)

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -88,11 +88,16 @@ module TopounitType
   !-----------------------------------------------------------------------
   ! Define the data structure that where land model receives atmospheric flux information.
   type, public :: topounit_atmospheric_flux
-    real(r8), pointer :: rain       (:) => null() ! rain rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
-    real(r8), pointer :: snow       (:) => null() ! snow rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
-    real(r8), pointer :: prec24h    (:) => null() ! 24-hour mean precip rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
-    real(r8), pointer :: prec10d    (:) => null() ! 10-day mean precip rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
-    real(r8), pointer :: prec60d    (:) => null() ! 60-day mean precip rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    real(r8), pointer :: rain       (:)   => null() ! rain rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    real(r8), pointer :: snow       (:)   => null() ! snow rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    real(r8), pointer :: solad      (:,:) => null() ! direct beam radiation (numrad) (vis=forc_sols , nir=forc_soll) (W/m**2)
+    real(r8), pointer :: solai      (:,:) => null() ! diffuse radiation (numrad) (vis=forc_solsd, nir=forc_solld) (W/m**2)
+    real(r8), pointer :: solar      (:)   => null() ! incident solar radiation (W/m**2)
+    real(r8), pointer :: lwrad      (:)   => null() ! atm downwrd IR longwave radiation (W/m**2) 
+    ! Accumulated fields
+    real(r8), pointer :: prec24h    (:)   => null() ! 24-hour mean precip rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    real(r8), pointer :: prec10d    (:)   => null() ! 10-day mean precip rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
+    real(r8), pointer :: prec60d    (:)   => null() ! 60-day mean precip rate (kg H2O/m**2/s, equivalent to mm liquid H2O/s)
     
   contains
     procedure, public :: Init  => init_top_af
@@ -240,8 +245,12 @@ module TopounitType
     integer, intent(in) :: endt   ! ending topographic unit index
    
     ! Allocate for atmospheric flux forcing variables, initialize to special value
-    allocate(this%rain     (begt:endt)) ; this%rain      (:) = spval
-    allocate(this%snow     (begt:endt)) ; this%snow      (:) = spval
+    allocate(this%rain     (begt:endt))          ; this%rain      (:) = spval
+    allocate(this%snow     (begt:endt))          ; this%snow      (:) = spval
+    allocate(this%solad    (begt:endt, numrad))  ; this%solad     (:,:) = spval
+    allocate(this%solai    (begt:endt, numrad))  ; this%solai     (:,:) = spval
+    allocate(this%solar    (begt:endt))          ; this%solar     (:) = spval
+    allocate(this%lwrad    (begt:endt))          ; this%lwrad     (:) = spval
     if (use_fates) then
       allocate(this%prec24h  (begt:endt)) ; this%prec24h   (:) = spval
     end if
@@ -268,6 +277,10 @@ module TopounitType
 
     deallocate(this%rain)
     deallocate(this%snow)
+    deallocate(this%solad)
+    deallocate(this%solai)
+    deallocate(this%solar)
+    deallocate(this%lwrad)
     if (use_fates) then
       deallocate(this%prec24h)
     end if

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -66,6 +66,7 @@ module TopounitType
     real(r8), pointer :: thbot      (:) => null() ! potential temperature of air at atmospheric forcing height (K)
     real(r8), pointer :: pbot       (:) => null() ! air pressure at atmospheric forcing height (Pa)
     real(r8), pointer :: qbot       (:) => null() ! specific humidity at atmospheric forcing height (kg H2O/kg moist air)
+    real(r8), pointer :: rhbot      (:) => null() ! relative humidity at atmospheric forcing height (%)
     real(r8), pointer :: ubot       (:) => null() ! wind speed in U (east) direction at atmospheric forcing height (m/s)
     real(r8), pointer :: vbot       (:) => null() ! wind speed in V (north) direction at atmospheric forcing height (m/s)
     real(r8), pointer :: windbot    (:) => null() ! horizontal component of wind at atmospheric forcing height (m/s)
@@ -85,21 +86,10 @@ module TopounitType
     procedure, public :: Clean => clean_top_es
   end type topounit_energy_state
 
-  type, public :: topounit_water_state
-    real(r8), pointer :: vp_atm     (:) => null() ! vapor pressure of air at atmospheric forcing height (Pa)
-    real(r8), pointer :: q_atm      (:) => null() ! specific humidity of air at atmopspheric forcing height (kg H2O/ kg dry air)
-    real(r8), pointer :: rh_atm     (:) => null() ! relative humidity of air at atmospheric forcing height (0 to 1)
-    ! glacier ice mass here? 
-  contains
-    procedure, public :: Init   => init_top_ws
-    procedure, public :: Clean  => clean_top_ws
-  end type topounit_water_state
-
   ! declare the public instances of topounit types
   type(topounit_physical_properties),  public, target :: top_pp
   type(topounit_atmospheric_state),    public, target :: top_as
   type(topounit_energy_state),         public, target :: top_es
-  type(topounit_water_state),          public, target :: top_ws
   
   contains
   
@@ -170,6 +160,7 @@ module TopounitType
     allocate(this%thbot    (begt:endt)) ; this%thbot     (:) = spval
     allocate(this%pbot     (begt:endt)) ; this%pbot      (:) = spval
     allocate(this%qbot     (begt:endt)) ; this%qbot      (:) = spval
+    allocate(this%rhbot    (begt:endt)) ; this%rhbot     (:) = spval
     allocate(this%ubot     (begt:endt)) ; this%ubot      (:) = spval
     allocate(this%vbot     (begt:endt)) ; this%vbot      (:) = spval
     allocate(this%windbot  (begt:endt)) ; this%windbot   (:) = spval
@@ -196,6 +187,7 @@ module TopounitType
     deallocate(this%thbot)
     deallocate(this%pbot)
     deallocate(this%qbot)
+    deallocate(this%rhbot)
     deallocate(this%ubot)
     deallocate(this%vbot)
     deallocate(this%windbot)
@@ -220,24 +212,5 @@ module TopounitType
     deallocate(this%t_rad    )
   end subroutine clean_top_es
   
-  subroutine init_top_ws(this, begt, endt)
-    class(topounit_water_state) :: this
-    integer, intent(in) :: begt   ! beginning topographic unit index
-    integer, intent(in) :: endt   ! ending topographic unit index
-
-    allocate(this%vp_atm  (begt:endt))  ; this%vp_atm   (:) = nan
-    allocate(this%q_atm   (begt:endt))  ; this%q_atm    (:) = nan
-    allocate(this%rh_atm  (begt:endt))  ; this%rh_atm   (:) = nan
-  end subroutine init_top_ws
-  
-  subroutine clean_top_ws(this, begt, endt)
-    class(topounit_water_state) :: this
-    integer, intent(in) :: begt   ! beginning topographic unit index
-    integer, intent(in) :: endt   ! ending topographic unit index
-    
-    deallocate(this%vp_atm  )
-    deallocate(this%q_atm   )
-    deallocate(this%rh_atm  )
-  end subroutine clean_top_ws
     
 end module TopounitType

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -65,7 +65,9 @@ module TopounitType
     real(r8), pointer :: tbot       (:) => null() ! temperature of air at atmospheric forcing height (K)
     real(r8), pointer :: thbot      (:) => null() ! potential temperature of air at atmospheric forcing height (K)
     real(r8), pointer :: pbot       (:) => null() ! air pressure at atmospheric forcing height (Pa)
-    real(r8), pointer :: qbot       (:) => null() ! specific humidity at atmospheric forcing height (kg H2O / kg moist air)
+    real(r8), pointer :: qbot       (:) => null() ! specific humidity at atmospheric forcing height (kg H2O/kg moist air)
+    real(r8), pointer :: ubot       (:) => null() ! wind speed in U (east) direction at atmospheric forcing height (m/s)
+    real(r8), pointer :: vbot       (:) => null() ! wind speed in V (north) direction at atmospheric forcing height (m/s)
   contains
     procedure, public :: Init  => init_top_as
     procedure, public :: Clean => clean_top_as
@@ -164,6 +166,8 @@ module TopounitType
     allocate(this%thbot   (begt:endt)) ; this%thbot  (:) = spval
     allocate(this%pbot    (begt:endt)) ; this%pbot   (:) = spval
     allocate(this%qbot    (begt:endt)) ; this%qbot   (:) = spval
+    allocate(this%ubot    (begt:endt)) ; this%ubot   (:) = spval
+    allocate(this%vbot    (begt:endt)) ; this%vbot   (:) = spval
     
     ! Set history fields for atmospheric state forcing variables
     !call hist_addfld1d (fname='TBOT', units='K',  &
@@ -184,6 +188,8 @@ module TopounitType
     deallocate(this%thbot)
     deallocate(this%pbot)
     deallocate(this%qbot)
+    deallocate(this%ubot)
+    deallocate(this%vbot)
   end subroutine clean_top_as
 
   subroutine init_top_es(this, begt, endt)

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -65,6 +65,7 @@ module TopounitType
     real(r8), pointer :: tbot       (:) => null() ! temperature of air at atmospheric forcing height (K)
     real(r8), pointer :: thbot      (:) => null() ! potential temperature of air at atmospheric forcing height (K)
     real(r8), pointer :: pbot       (:) => null() ! air pressure at atmospheric forcing height (Pa)
+    real(r8), pointer :: qbot       (:) => null() ! specific humidity at atmospheric forcing height (kg H2O / kg moist air)
   contains
     procedure, public :: Init  => init_top_as
     procedure, public :: Clean => clean_top_as
@@ -162,6 +163,7 @@ module TopounitType
     allocate(this%tbot    (begt:endt)) ; this%tbot   (:) = spval
     allocate(this%thbot   (begt:endt)) ; this%thbot  (:) = spval
     allocate(this%pbot    (begt:endt)) ; this%pbot   (:) = spval
+    allocate(this%qbot    (begt:endt)) ; this%qbot   (:) = spval
     
     ! Set history fields for atmospheric state forcing variables
     !call hist_addfld1d (fname='TBOT', units='K',  &
@@ -181,6 +183,7 @@ module TopounitType
     deallocate(this%tbot)
     deallocate(this%thbot)
     deallocate(this%pbot)
+    deallocate(this%qbot)
   end subroutine clean_top_as
 
   subroutine init_top_es(this, begt, endt)

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -73,6 +73,7 @@ module TopounitType
     real(r8), pointer :: zbot       (:) => null() ! atmospheric forcing height (m)
     real(r8), pointer :: pco2bot    (:) => null() ! partial pressure of CO2 at atmospheric forcing height (Pa) 
     real(r8), pointer :: pc13o2bot  (:) => null() ! partial pressure of C13O2 at atmospheric forcing height (Pa) 
+    real(r8), pointer :: pch4bot    (:) => null() ! partial pressure of CH4 at atmospheric forcing height (Pa) 
   contains
     procedure, public :: Init  => init_top_as
     procedure, public :: Clean => clean_top_as
@@ -167,6 +168,7 @@ module TopounitType
     allocate(this%zbot     (begt:endt)) ; this%zbot      (:) = spval
     allocate(this%pco2bot  (begt:endt)) ; this%pco2bot   (:) = spval
     allocate(this%pc13o2bot(begt:endt)) ; this%pc13o2bot (:) = spval
+    allocate(this%pch4bot  (begt:endt)) ; this%pch4bot   (:) = spval
     
     ! Set history fields for atmospheric state forcing variables
     !call hist_addfld1d (fname='TBOT', units='K',  &
@@ -194,6 +196,7 @@ module TopounitType
     deallocate(this%zbot)
     deallocate(this%pco2bot)
     deallocate(this%pc13o2bot)
+    deallocate(this%pch4bot)
   end subroutine clean_top_as
 
   subroutine init_top_es(this, begt, endt)

--- a/components/clm/src/data_types/TopounitType.F90
+++ b/components/clm/src/data_types/TopounitType.F90
@@ -68,6 +68,7 @@ module TopounitType
     real(r8), pointer :: qbot       (:) => null() ! specific humidity at atmospheric forcing height (kg H2O/kg moist air)
     real(r8), pointer :: ubot       (:) => null() ! wind speed in U (east) direction at atmospheric forcing height (m/s)
     real(r8), pointer :: vbot       (:) => null() ! wind speed in V (north) direction at atmospheric forcing height (m/s)
+    real(r8), pointer :: windbot    (:) => null() ! horizontal component of wind at atmospheric forcing height (m/s)
     real(r8), pointer :: zbot       (:) => null() ! atmospheric forcing height (m)
     real(r8), pointer :: pco2bot    (:) => null() ! partial pressure of CO2 at atmospheric forcing height (Pa) 
     real(r8), pointer :: pc13o2bot  (:) => null() ! partial pressure of C13O2 at atmospheric forcing height (Pa) 
@@ -171,6 +172,7 @@ module TopounitType
     allocate(this%qbot     (begt:endt)) ; this%qbot      (:) = spval
     allocate(this%ubot     (begt:endt)) ; this%ubot      (:) = spval
     allocate(this%vbot     (begt:endt)) ; this%vbot      (:) = spval
+    allocate(this%windbot  (begt:endt)) ; this%windbot   (:) = spval
     allocate(this%zbot     (begt:endt)) ; this%zbot      (:) = spval
     allocate(this%pco2bot  (begt:endt)) ; this%pco2bot   (:) = spval
     allocate(this%pc13o2bot(begt:endt)) ; this%pc13o2bot (:) = spval
@@ -196,6 +198,7 @@ module TopounitType
     deallocate(this%qbot)
     deallocate(this%ubot)
     deallocate(this%vbot)
+    deallocate(this%windbot)
     deallocate(this%zbot)
     deallocate(this%pco2bot)
     deallocate(this%pc13o2bot)

--- a/components/clm/src/external_models/emi/src/elm_types/EMI_Atm2LndType_ExchangeMod.F90
+++ b/components/clm/src/external_models/emi/src/elm_types/EMI_Atm2LndType_ExchangeMod.F90
@@ -7,6 +7,8 @@ module EMI_Atm2LndType_ExchangeMod
   use ExternalModelInterfaceDataMod         , only : emi_data_list, emi_data
   use ExternalModelIntefaceDataDimensionMod , only : emi_data_dimension_list_type
   use Atm2LndType                           , only : atm2lnd_type
+  use TopounitType                          , only : top_as
+  use ColumnType                            , only : col_pp
   use EMI_Atm2LndType_Constants
   use EMI_CanopyStateType_Constants
   use EMI_ChemStateType_Constants
@@ -48,7 +50,7 @@ contains
     type(atm2lnd_type)     , intent(in) :: atm2lndtype_vars
     !
     ! !LOCAL_VARIABLES:
-    integer                             :: fc,c,j
+    integer                             :: fc,t,c,j
     class(emi_data), pointer            :: cur_data
     logical                             :: need_to_pack
     integer                             :: istage
@@ -56,7 +58,7 @@ contains
 
     associate(& 
          forc_pbot_downscaled => atm2lndtype_vars%forc_pbot_downscaled_col , &
-         forc_t_downscaled    => atm2lndtype_vars%forc_t_downscaled_col      &
+         forc_t_downscaled    => top_as%tbot                                 &
          )
 
     count = 0
@@ -87,7 +89,8 @@ contains
           case (L2E_STATE_FORC_T_DOWNSCALED)
              do fc = 1, num_filter
                 c = filter(fc)
-                cur_data%data_real_1d(c) = forc_t_downscaled(c)
+                t = col_pp%topounit(c)
+                cur_data%data_real_1d(c) = forc_t_downscaled(t)
              enddo
              cur_data%is_set = .true.
 

--- a/components/clm/src/external_models/emi/src/elm_types/EMI_Atm2LndType_ExchangeMod.F90
+++ b/components/clm/src/external_models/emi/src/elm_types/EMI_Atm2LndType_ExchangeMod.F90
@@ -57,8 +57,8 @@ contains
     integer                             :: count
 
     associate(& 
-         forc_pbot_downscaled => atm2lndtype_vars%forc_pbot_downscaled_col , &
-         forc_t_downscaled    => top_as%tbot                                 &
+         forc_pbot_downscaled => top_as%pbot , &
+         forc_t_downscaled    => top_as%tbot   &
          )
 
     count = 0
@@ -82,7 +82,8 @@ contains
           case (L2E_STATE_FORC_PBOT_DOWNSCALED)
              do fc = 1, num_filter
                 c = filter(fc)
-                cur_data%data_real_1d(c) = forc_pbot_downscaled(c)
+                t = col_pp%topounit(c)
+                cur_data%data_real_1d(c) = forc_pbot_downscaled(t)
              enddo
              cur_data%is_set = .true.
 

--- a/components/clm/src/main/accumulMod.F90
+++ b/components/clm/src/main/accumulMod.F90
@@ -50,7 +50,7 @@ module accumulMod
      character(len=128) :: desc     !field description
      character(len=  8) :: units    !field units
      character(len=  8) :: acctype  !accumulation type: ["timeavg","runmean","runaccum"]
-     character(len=  8) :: type1d   !subgrid type: ["gridcell","landunit","column" or "pft"]
+     character(len=  8) :: type1d   !subgrid type: ["gridcell","topounit","landunit","column" or "pft"]
      character(len=  8) :: type2d   !type2d ('','levsoi','numrad',..etc. )
      integer            :: beg1d    !subgrid type beginning index
      integer            :: end1d    !subgrid type ending index
@@ -96,7 +96,7 @@ contains
     character(len=*), intent(in)           :: desc         !field description
     character(len=*), intent(in)           :: accum_type   !field type: tavg, runm, runa, ins
     integer , intent(in)                   :: accum_period !field accumulation period
-    character(len=*), intent(in)           :: subgrid_type !["gridcell","landunit","column" or "pft"]
+    character(len=*), intent(in)           :: subgrid_type !["gridcell","topounit","landunit","column" or "pft"]
     integer , intent(in)                   :: numlev       !number of vertical levels
     real(r8), intent(in)                   :: init_value   !field initial or reset value
     character(len=*), intent(in), optional :: type2d       !level type (optional) - needed if numlev > 1
@@ -154,6 +154,10 @@ contains
        beg1d = begg
        end1d = endg
        num1d = numg
+    case ('topounit')
+       beg1d = begt
+       end1d = endt
+       num1d = numt
     case ('landunit')
        beg1d = begl
        end1d = endl

--- a/components/clm/src/main/atm2lndType.F90
+++ b/components/clm/src/main/atm2lndType.F90
@@ -70,7 +70,6 @@ module atm2lndType
      real(r8), pointer :: forc_hgt_q_grc                (:)   => null() ! obs height of humidity [m] (new)
      real(r8), pointer :: forc_vp_grc                   (:)   => null() ! atmospheric vapor pressure (Pa)
      real(r8), pointer :: forc_rh_grc                   (:)   => null() ! atmospheric relative humidity (%)
-     real(r8), pointer :: forc_psrf_grc                 (:)   => null() ! surface pressure (Pa)
      real(r8), pointer :: forc_pco2_grc                 (:)   => null() ! CO2 partial pressure (Pa)
      real(r8), pointer :: forc_solad_grc                (:,:) => null() ! direct beam radiation (numrad) (vis=forc_sols , nir=forc_soll )
      real(r8), pointer :: forc_solai_grc                (:,:) => null() ! diffuse radiation (numrad) (vis=forc_solsd, nir=forc_solld)
@@ -217,7 +216,6 @@ contains
     allocate(this%forc_hgt_t_grc                (begg:endg))        ; this%forc_hgt_t_grc                (:)   = ival
     allocate(this%forc_hgt_q_grc                (begg:endg))        ; this%forc_hgt_q_grc                (:)   = ival
     allocate(this%forc_vp_grc                   (begg:endg))        ; this%forc_vp_grc                   (:)   = ival
-    allocate(this%forc_psrf_grc                 (begg:endg))        ; this%forc_psrf_grc                 (:)   = ival
     allocate(this%forc_pco2_grc                 (begg:endg))        ; this%forc_pco2_grc                 (:)   = ival
     allocate(this%forc_solad_grc                (begg:endg,numrad)) ; this%forc_solad_grc                (:,:) = ival
     allocate(this%forc_solai_grc                (begg:endg,numrad)) ; this%forc_solai_grc                (:,:) = ival

--- a/components/clm/src/main/atm2lndType.F90
+++ b/components/clm/src/main/atm2lndType.F90
@@ -698,6 +698,7 @@ contains
 
        do p = bounds%begp,bounds%endp
           c = veg_pp%column(p)
+          g = veg_pp%gridcell(p)
           rbufslp(p) = this%forc_wind_grc(g) 
        end do
        call update_accum_field  ('WIND24', rbufslp, nstep)
@@ -705,6 +706,7 @@ contains
 
        do p = bounds%begp,bounds%endp
           c = veg_pp%column(p)
+          g = veg_pp%gridcell(p)
           rbufslp(p) = this%forc_rh_grc(g) 
        end do
        call update_accum_field  ('RH24', rbufslp, nstep)

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -550,7 +550,7 @@ contains
        ! over the patch index range defined by bounds_clump%begp:bounds_proc%endp
        
        if(use_fates) then
-          call alm_fates%wrap_sunfrac(bounds_clump,atm2lnd_vars, canopystate_vars)
+          call alm_fates%wrap_sunfrac(bounds_clump, top_af, canopystate_vars)
        else
           call CanopySunShadeFractions(filter(nc)%num_nourbanp, filter(nc)%nourbanp,    &
                                        atm2lnd_vars, surfalb_vars, canopystate_vars,    &

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -125,7 +125,7 @@ module clm_driver
   use tracer_varcon          , only : is_active_betr_bgc
   use CNEcosystemDynBetrMod  , only : CNEcosystemDynBetr, CNFluxStateBetrSummary
   use GridcellType           , only : grc_pp
-  use TopounitType           , only : top_af  
+  use TopounitType           , only : top_as, top_af  
   use LandunitType           , only : lun_pp                
   use ColumnType             , only : col_pp                
   use VegetationType         , only : veg_pp
@@ -1101,7 +1101,7 @@ contains
                 write(iulog,*)  'clm: calling FATES model ', get_nstep()
              end if
              
-             call alm_fates%dynamics_driv( bounds_clump,                  &
+             call alm_fates%dynamics_driv( bounds_clump, top_as,          &
                   top_af, atm2lnd_vars, soilstate_vars, temperature_vars, &
                   waterstate_vars, canopystate_vars, carbonflux_vars,     &
                   frictionvel_vars)
@@ -1296,6 +1296,8 @@ contains
        call t_startf('accum')
        
        call atm2lnd_vars%UpdateAccVars(bounds_proc)
+       
+       call top_as%UpdateAccVars(bounds_proc)
        
        call top_af%UpdateAccVars(bounds_proc)
        

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -124,7 +124,8 @@ module clm_driver
   use clm_instMod            , only : PlantMicKinetics_vars
   use tracer_varcon          , only : is_active_betr_bgc
   use CNEcosystemDynBetrMod  , only : CNEcosystemDynBetr, CNFluxStateBetrSummary
-  use GridcellType           , only : grc_pp                
+  use GridcellType           , only : grc_pp
+  use TopounitType           , only : top_af  
   use LandunitType           , only : lun_pp                
   use ColumnType             , only : col_pp                
   use VegetationType         , only : veg_pp
@@ -1100,9 +1101,9 @@ contains
                 write(iulog,*)  'clm: calling FATES model ', get_nstep()
              end if
              
-             call alm_fates%dynamics_driv( bounds_clump,               &
-                  atm2lnd_vars, soilstate_vars, temperature_vars,     &
-                  waterstate_vars, canopystate_vars, carbonflux_vars, &
+             call alm_fates%dynamics_driv( bounds_clump,                  &
+                  top_af, atm2lnd_vars, soilstate_vars, temperature_vars, &
+                  waterstate_vars, canopystate_vars, carbonflux_vars,     &
                   frictionvel_vars)
 
              
@@ -1295,6 +1296,8 @@ contains
        call t_startf('accum')
        
        call atm2lnd_vars%UpdateAccVars(bounds_proc)
+       
+       call top_af%UpdateAccVars(bounds_proc)
        
        call temperature_vars%UpdateAccVars(bounds_proc)
        

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -25,7 +25,7 @@ module clm_initializeMod
   ! Definition of component types
   !-----------------------------------------
   use GridcellType           , only : grc_pp
-  use TopounitType           , only : top_pp, top_as, top_es, top_ws
+  use TopounitType           , only : top_pp, top_as, top_es
   use LandunitType           , only : lun_pp                
   use ColumnType             , only : col_pp                
   use VegetationType         , only : veg_pp                
@@ -295,7 +295,6 @@ contains
     call top_pp%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! topology and physical properties
     call top_as%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! atmospheric state variables (forcings)
     call top_es%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! energy state
-    call top_ws%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! water state
     
     ! Initialize the landunit data types
     call lun_pp%Init (bounds_proc%begl_all, bounds_proc%endl_all)

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -25,7 +25,7 @@ module clm_initializeMod
   ! Definition of component types
   !-----------------------------------------
   use GridcellType           , only : grc_pp
-  use TopounitType           , only : top_pp, top_as, top_es
+  use TopounitType           , only : top_pp, top_as, top_af, top_es
   use LandunitType           , only : lun_pp                
   use ColumnType             , only : col_pp                
   use VegetationType         , only : veg_pp                
@@ -294,6 +294,7 @@ contains
     ! Initialize the topographic unit data types
     call top_pp%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! topology and physical properties
     call top_as%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! atmospheric state variables (forcings)
+    call top_af%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! atmospheric flux variables (forcings)
     call top_es%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! energy state
     
     ! Initialize the landunit data types

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -617,6 +617,8 @@ contains
 
     call atm2lnd_vars%initAccBuffer(bounds_proc)
     
+    call top_as%InitAccBuffer(bounds_proc)
+    
     call top_af%InitAccBuffer(bounds_proc)
 
     call temperature_vars%initAccBuffer(bounds_proc)
@@ -837,6 +839,7 @@ contains
     ! must be called after the restart file is read 
 
     call atm2lnd_vars%initAccVars(bounds_proc)
+    call top_as%InitAccVars(bounds_proc)
     call top_af%InitAccVars(bounds_proc)
     call temperature_vars%initAccVars(bounds_proc)
     call canopystate_vars%initAccVars(bounds_proc)

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -616,6 +616,8 @@ contains
     call t_startf('init_accflds')
 
     call atm2lnd_vars%initAccBuffer(bounds_proc)
+    
+    call top_af%InitAccBuffer(bounds_proc)
 
     call temperature_vars%initAccBuffer(bounds_proc)
 
@@ -835,6 +837,7 @@ contains
     ! must be called after the restart file is read 
 
     call atm2lnd_vars%initAccVars(bounds_proc)
+    call top_af%InitAccVars(bounds_proc)
     call temperature_vars%initAccVars(bounds_proc)
     call canopystate_vars%initAccVars(bounds_proc)
     if (use_cndv) then

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -25,7 +25,7 @@ module clm_initializeMod
   ! Definition of component types
   !-----------------------------------------
   use GridcellType           , only : grc_pp
-  use TopounitType           , only : top_pp, top_es, top_ws
+  use TopounitType           , only : top_pp, top_as, top_es, top_ws
   use LandunitType           , only : lun_pp                
   use ColumnType             , only : col_pp                
   use VegetationType         , only : veg_pp                
@@ -293,6 +293,7 @@ contains
     
     ! Initialize the topographic unit data types
     call top_pp%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! topology and physical properties
+    call top_as%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! atmospheric state variables (forcings)
     call top_es%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! energy state
     call top_ws%Init (bounds_proc%begt_all, bounds_proc%endt_all) ! water state
     

--- a/components/clm/src/main/clmfates_interfaceMod.F90
+++ b/components/clm/src/main/clmfates_interfaceMod.F90
@@ -1283,7 +1283,7 @@ contains
 
    ! ======================================================================================
    
-   subroutine wrap_sunfrac(this,bounds_clump,atm2lnd_inst,canopystate_inst)
+   subroutine wrap_sunfrac(this,bounds_clump,top_af_inst,canopystate_inst)
          
       ! ---------------------------------------------------------------------------------
       ! This interface function is a wrapper call on ED_SunShadeFracs. The only
@@ -1298,7 +1298,7 @@ contains
       type(bounds_type)              , intent(in)    :: bounds_clump
       
       ! direct and diffuse downwelling radiation (W/m2)
-      type(atm2lnd_type),intent(in)        :: atm2lnd_inst
+      type(topounit_atmospheric_flux),intent(in)     :: top_af_inst
       
       ! Input/Output Arguments to CLM
       type(canopystate_type),intent(inout) :: canopystate_inst
@@ -1306,6 +1306,7 @@ contains
       ! Local Variables
       integer  :: p                           ! global index of the host patch
       integer  :: g                           ! global index of the host gridcell
+      integer  :: t                           ! global index of the host topounit
       integer  :: c                           ! global index of the host column
 
       integer  :: s                           ! FATES site index
@@ -1317,8 +1318,8 @@ contains
       type(ed_patch_type), pointer :: cpatch  ! c"urrent" patch  INTERF-TODO: SHOULD
                                               ! BE HIDDEN AS A FATES PRIVATE
 
-      associate( forc_solad => atm2lnd_inst%forc_solad_grc, &
-                 forc_solai => atm2lnd_inst%forc_solai_grc, &
+      associate( forc_solad => top_af_inst%solad, &
+                 forc_solai => top_af_inst%solai, &
                  fsun       => canopystate_inst%fsun_patch, &
                  laisun     => canopystate_inst%laisun_patch, &               
                  laisha     => canopystate_inst%laisha_patch )
@@ -1331,6 +1332,7 @@ contains
 
         do s = 1, this%fates(nc)%nsites
            c = this%f2hmap(nc)%fcolumn(s)
+           t = col_pp%topounit(c)
            g = col_pp%gridcell(c)
 
            do ifp = 1, this%fates(nc)%sites(s)%youngest_patch%patchno
@@ -1338,8 +1340,8 @@ contains
 
               p = ifp+col_pp%pfti(c)
 
-              this%fates(nc)%bc_in(s)%solad_parb(ifp,:) = forc_solad(g,:)
-              this%fates(nc)%bc_in(s)%solai_parb(ifp,:) = forc_solai(g,:)
+              this%fates(nc)%bc_in(s)%solad_parb(ifp,:) = forc_solad(t,:)
+              this%fates(nc)%bc_in(s)%solai_parb(ifp,:) = forc_solai(t,:)
 
            end do
         end do

--- a/components/clm/src/main/clmfates_interfaceMod.F90
+++ b/components/clm/src/main/clmfates_interfaceMod.F90
@@ -65,7 +65,7 @@ module CLMFatesInterfaceMod
    use clm_varpar        , only : nlevdecomp_full
    use clm_varpar        , only : i_met_lit, i_cel_lit, i_lig_lit
    use PhotosynthesisType , only : photosyns_type
-   Use TopounitType      , only : topounit_atmospheric_flux
+   Use TopounitType      , only : topounit_atmospheric_flux, topounit_atmospheric_state
    use atm2lndType       , only : atm2lnd_type
    use SurfaceAlbedoType , only : surfalb_type
    use SolarAbsorbedType , only : solarabs_type
@@ -538,7 +538,7 @@ contains
 
    ! ------------------------------------------------------------------------------------
 
-   subroutine dynamics_driv(this, bounds_clump,                       &
+   subroutine dynamics_driv(this, bounds_clump, top_as_inst,          &
          top_af_inst, atm2lnd_inst, soilstate_inst, temperature_inst, &
          waterstate_inst, canopystate_inst, carbonflux_inst,          &
          frictionvel_inst )
@@ -551,7 +551,8 @@ contains
       implicit none
       class(hlm_fates_interface_type), intent(inout) :: this
       type(bounds_type),intent(in)                   :: bounds_clump
-      type(topounit_atmospheric_flux), intent(in)    :: top_af_inst
+      type(topounit_atmospheric_state), intent(in)   :: top_as_inst
+      type(topounit_atmospheric_flux),  intent(in)   :: top_af_inst
       type(atm2lnd_type)      , intent(in)           :: atm2lnd_inst
       type(soilstate_type)    , intent(in)           :: soilstate_inst
       type(temperature_type)  , intent(in)           :: temperature_inst
@@ -639,10 +640,10 @@ contains
                   top_af_inst%prec24h(t)
 
             this%fates(nc)%bc_in(s)%relhumid24_pa(ifp) = &
-                  atm2lnd_inst%rh24_patch(p)
+                  top_as_inst%rh24h(t)
 
             this%fates(nc)%bc_in(s)%wind24_pa(ifp) = &
-                  atm2lnd_inst%wind24_patch(p)
+                  top_as_inst%wind24h(t)
 
          end do
 

--- a/components/clm/src/main/clmfates_interfaceMod.F90
+++ b/components/clm/src/main/clmfates_interfaceMod.F90
@@ -85,7 +85,8 @@ module CLMFatesInterfaceMod
    use decompMod         , only : get_proc_bounds,   &
                                   get_proc_clumps,   &
                                   get_clump_bounds
-   use GridCellType      , only : grc_pp
+   use GridcellType      , only : grc_pp
+   use TopounitType      , only : top_as
    use ColumnType        , only : col_pp
    use LandunitType      , only : lun_pp
    use landunit_varcon   , only : istsoil
@@ -1611,7 +1612,7 @@ contains
     type(photosyns_type)   , intent(inout)         :: photosyns_inst
 
     integer                                        :: nlevsoil
-    integer                                        :: s,c,p,ifp,j,icp,nc
+    integer                                        :: s,t,c,p,ifp,j,icp,nc
     real(r8)                                       :: dtime
 
     call t_startf('edpsn')
@@ -1619,10 +1620,10 @@ contains
           t_soisno  => temperature_inst%t_soisno_col , &
           t_veg     => temperature_inst%t_veg_patch  , &
           tgcm      => temperature_inst%thm_patch    , &
-          forc_pbot => atm2lnd_inst%forc_pbot_downscaled_col, &
-          rssun     => photosyns_inst%rssun_patch  , &
-          rssha     => photosyns_inst%rssha_patch,   &
-          psnsun    => photosyns_inst%psnsun_patch,  &
+          forc_pbot => top_as%pbot                   , &
+          rssun     => photosyns_inst%rssun_patch    , &
+          rssha     => photosyns_inst%rssha_patch    , &
+          psnsun    => photosyns_inst%psnsun_patch   , &
           psnsha    => photosyns_inst%psnsha_patch)
       
 
@@ -1631,12 +1632,14 @@ contains
       do s = 1, this%fates(nc)%nsites
          
          c = this%f2hmap(nc)%fcolumn(s)
+         t = col_pp%topounit(c)
+
          nlevsoil = this%fates(nc)%bc_in(s)%nlevsoil
 
          do j = 1,nlevsoil
             this%fates(nc)%bc_in(s)%t_soisno_sl(j)   = t_soisno(c,j)  ! soil temperature (Kelvin)
          end do
-         this%fates(nc)%bc_in(s)%forc_pbot           = forc_pbot(c)   ! atmospheric pressure (Pa)
+         this%fates(nc)%bc_in(s)%forc_pbot           = forc_pbot(t)   ! atmospheric pressure (Pa)
 
          do ifp = 1, this%fates(nc)%sites(s)%youngest_patch%patchno
             

--- a/components/clm/src/main/clmfates_interfaceMod.F90
+++ b/components/clm/src/main/clmfates_interfaceMod.F90
@@ -65,6 +65,7 @@ module CLMFatesInterfaceMod
    use clm_varpar        , only : nlevdecomp_full
    use clm_varpar        , only : i_met_lit, i_cel_lit, i_lig_lit
    use PhotosynthesisType , only : photosyns_type
+   Use TopounitType      , only : topounit_atmospheric_flux
    use atm2lndType       , only : atm2lnd_type
    use SurfaceAlbedoType , only : surfalb_type
    use SolarAbsorbedType , only : solarabs_type
@@ -537,9 +538,9 @@ contains
 
    ! ------------------------------------------------------------------------------------
 
-   subroutine dynamics_driv(this, bounds_clump,              &
-         atm2lnd_inst, soilstate_inst, temperature_inst,     &
-         waterstate_inst, canopystate_inst, carbonflux_inst, &
+   subroutine dynamics_driv(this, bounds_clump,                       &
+         top_af_inst, atm2lnd_inst, soilstate_inst, temperature_inst, &
+         waterstate_inst, canopystate_inst, carbonflux_inst,          &
          frictionvel_inst )
     
       ! This wrapper is called daily from clm_driver
@@ -550,6 +551,7 @@ contains
       implicit none
       class(hlm_fates_interface_type), intent(inout) :: this
       type(bounds_type),intent(in)                   :: bounds_clump
+      type(topounit_atmospheric_flux), intent(in)    :: top_af_inst
       type(atm2lnd_type)      , intent(in)           :: atm2lnd_inst
       type(soilstate_type)    , intent(in)           :: soilstate_inst
       type(temperature_type)  , intent(in)           :: temperature_inst
@@ -561,6 +563,7 @@ contains
       ! !LOCAL VARIABLES:
       integer  :: s                        ! site index
       integer  :: c                        ! column index (HLM)
+      integer  :: t                        ! topounit index (HLM)
       integer  :: ifp                      ! patch index
       integer  :: p                        ! HLM patch index
       integer  :: nc                       ! clump index
@@ -614,6 +617,7 @@ contains
       do s=1,this%fates(nc)%nsites
 
          c = this%f2hmap(nc)%fcolumn(s)
+         t = col_pp%topounit(c)
 
          nlevsoil = this%fates(nc)%bc_in(s)%nlevsoil
 
@@ -632,7 +636,7 @@ contains
                  temperature_inst%t_veg24_patch(p)
 
             this%fates(nc)%bc_in(s)%precip24_pa(ifp) = &
-                  atm2lnd_inst%prec24_patch(p)
+                  top_af_inst%prec24h(t)
 
             this%fates(nc)%bc_in(s)%relhumid24_pa(ifp) = &
                   atm2lnd_inst%rh24_patch(p)

--- a/components/clm/src/main/restFileMod.F90
+++ b/components/clm/src/main/restFileMod.F90
@@ -18,7 +18,7 @@ module restFileMod
   use clm_varctl           , only : use_cn, use_c13, use_c14, use_lch4, use_cndv, use_fates, use_betr
   use clm_varctl           , only : create_glacier_mec_landunit, iulog 
   use clm_varcon           , only : c13ratio, c14ratio
-  use clm_varcon           , only : nameg, namel, namec, namep, nameCohort
+  use clm_varcon           , only : nameg, namet, namel, namec, namep, nameCohort
   use ch4Mod               , only : ch4_type
   use CNCarbonFluxType     , only : carbonflux_type
   use CNCarbonStateType    , only : carbonstate_type
@@ -855,6 +855,7 @@ contains
     ! !LOCAL VARIABLES:
     integer :: dimid               ! netCDF dimension id
     integer :: numg                ! total number of gridcells across all processors
+    integer :: numt                ! total number of topounits across all processors
     integer :: numl                ! total number of landunits across all processors
     integer :: numc                ! total number of columns across all processors
     integer :: nump                ! total number of pfts across all processors
@@ -867,11 +868,12 @@ contains
     character(len= 32) :: subname='restFile_dimset' ! subroutine name
     !------------------------------------------------------------------------
 
-    call get_proc_global(ng=numg, nl=numl, nc=numc, np=nump, nCohorts=numCohort)
+    call get_proc_global(ng=numg, nt=numt, nl=numl, nc=numc, np=nump, nCohorts=numCohort)
 
     ! Define dimensions
 
     call ncd_defdim(ncid , nameg      , numg           ,  dimid)
+    call ncd_defdim(ncid , namet      , numt           ,  dimid)
     call ncd_defdim(ncid , namel      , numl           ,  dimid)
     call ncd_defdim(ncid , namec      , numc           ,  dimid)
     call ncd_defdim(ncid , namep      , nump           ,  dimid)
@@ -1031,6 +1033,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     integer :: numg      ! total number of gridcells across all processors
+    integer :: numt      ! total number of topounits across all processors
     integer :: numl      ! total number of landunits across all processors
     integer :: numc      ! total number of columns across all processors
     integer :: nump      ! total number of pfts across all processors
@@ -1041,8 +1044,9 @@ contains
     ! Get relevant sizes
 
     if ( .not. single_column .or. nsrest /= nsrStartup )then
-       call get_proc_global(ng=numg, nl=numl, nc=numc, np=nump, nCohorts=numCohort)
+       call get_proc_global(ng=numg, nt=numt, nl=numl, nc=numc, np=nump, nCohorts=numCohort)
        call check_dim(ncid, nameg, numg)
+       call check_dim(ncid, namet, numt)
        call check_dim(ncid, namel, numl)
        call check_dim(ncid, namec, numc)
        call check_dim(ncid, namep, nump)


### PR DESCRIPTION
Moves atmospheric forcing variables from the gridcell level down to the topographic unit sub-grid level. Replaces the atm2lnd data structure with state and flux variables defined at the topographic unit. Includes all the fundamental state and flux variables, as well as the variables derived directly from them, and the accumulated variables based on them. Includes a bug fix for harmless bug.

All tests expected to pass BFB except tests that use a non-null land finidat file. Because dimensionality of accumulated variables has changed, these tests using specified finidat files will fail.

[non-BFB]

Fixes #2547