### PR TITLE
Minor improvement to jenkins_generic_job robustness

### DIFF
--- a/cime/scripts/Tools/jenkins_generic_job
+++ b/cime/scripts/Tools/jenkins_generic_job
@@ -42,7 +42,8 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     CIME.utils.setup_standard_logging_options(parser)
 
     default_baseline = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
-    default_baseline = default_baseline.replace(".", "_").replace("/", "_") # Dots or slashes will mess things up
+    if default_baseline is not None:
+        default_baseline = default_baseline.replace(".", "_").replace("/", "_") # Dots or slashes will mess things up
 
     parser.add_argument("-g", "--generate-baselines", action="store_true",
                         help="Generate baselines")
@@ -118,6 +119,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     args.baseline_compare = default_maintain_baselines if args.baseline_compare is None else args.baseline_compare == "yes"
     args.scratch_root = machine.get_value("CIME_OUTPUT_ROOT") if args.scratch_root is None else args.scratch_root
     args.compiler = machine.get_default_compiler() if args.compiler is None else args.compiler
+
+    expect(args.baseline_name is not None,
+           "Failed to probe baseline_name from git branch, please provide one. It is essential for formulating the test-id even if baseline comparisons are not being done")
 
     if args.override_baseline_name is None:
         args.override_baseline_name = args.baseline_name


### PR DESCRIPTION
It's ok if default_baseline cannot be computed due to git problems
if the user has provided one.

[BFB]