### PR TITLE
CIME: small upgrade to FindNetCDF.cmake

### DIFF
--- a/cime/src/externals/pio2/cmake/FindNetCDF.cmake
+++ b/cime/src/externals/pio2/cmake/FindNetCDF.cmake
@@ -46,11 +46,9 @@ foreach (NCDFcomp IN LISTS NetCDF_FIND_VALID_COMPONENTS)
             initialize_paths (NetCDF_${NCDFcomp}_PATHS
                               INCLUDE_DIRECTORIES ${MPI_${NCDFcomp}_INCLUDE_PATH}
                               LIBRARIES ${MPI_${NCDFcomp}_LIBRARIES})
-            find_package_component(NetCDF COMPONENT ${NCDFcomp}
-                                   PATHS ${NetCDF_${NCDFcomp}_PATHS})
-        else ()
-            find_package_component(NetCDF COMPONENT ${NCDFcomp})
         endif ()
+        find_package_component(NetCDF COMPONENT ${NCDFcomp}
+                               PATHS ${NetCDF_${NCDFcomp}_PATHS})
 
         # Continue only if component found
         if (NetCDF_${NCDFcomp}_FOUND)


### PR DESCRIPTION
This PR addresses #2572 

Currently, FindNetCDF.cmake only uses ${NetCDF_${NCDFcomp}_PATHS} if ${MPI_${NCDFcomp}_FOUND} is true. There's no need for that. We should always allow the user to pass hints to find_package for where to find the libraries (and some users may have those libraries installed in different folders).

[BFB]