### PR TITLE
Adds water budget in the land model

### DIFF
--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1721,4 +1721,96 @@ Runtime flag to turn on/off PETSc based thermal model.
 Runtime flag to turn on/off variable soil thickness.
 </entry>
 
+<!-- ========================================================================================  -->
+<!-- Namelist options for performing water and energy budgets                                  -->
+<!-- ========================================================================================  -->
+<entry id="do_budgets"
+       type="logical"
+       category="budget"
+       group="clm_inparm"
+       valid_values=".true.,.false."
+       value=".false.">
+logical that turns on diagnostic budgets, false means budgets will never be written
+</entry>
+
+<entry id="budget_inst"
+       type="integer"
+       category="budget"
+       group="clm_inparm"
+       valid_values="0,1"
+       value="0">
+sets the diagnotics level of the instantaneous budgets. [0,1],
+written only if BUDGETS variable is true
+0=none,
+1=+net summary budgets,
+default: 0
+</entry>
+
+<entry id="budget_daily"
+       type="integer"
+       category="budget"
+       group="clm_inparm"
+       valid_values="0,1"
+       value="0">
+sets the diagnotics level of the daily budgets. [0,1],
+written only if do_budgets variable is .true.,
+0=none,
+1=+net summary budgets,
+default: 0
+</entry>
+
+<entry id="budget_month"
+       type="integer"
+       category="budget"
+       group="clm_inparm"
+       valid_values="0,1"
+       value="1">
+sets the diagnotics level of the monthy budgets. [0,1],
+written only if do_budgets variable is .true.,
+0=none,
+1=+net summary budgets,
+default: 1
+</entry>
+
+<entry id="budget_ann"
+       type="integer"
+       category="budget"
+       group="clm_inparm"
+       valid_values="0,1"
+       value="1">
+sets the diagnotics level of the annual budgets. [0,1],
+written only if do_budgets variable is .true.,
+0=none,
+1=+net summary budgets,
+default: 1
+</entry>
+
+<entry id="budget_ltann"
+       type="integer"
+       category="budget"
+       group="clm_inparm"
+       valid_values="0,1"
+       value="1">
+sets the diagnotics level of the longterm budgets written at the end
+of the year. [0,1],
+written only if do_budgets variable is .true.,
+0=none,
+1=+net summary budgets,
+default: 1
+</entry>
+
+<entry id="budget_ltend"
+       type="integer"
+       category="budget"
+       group="clm_inparm"
+       valid_values="0,1"
+       value="0">
+sets the diagnotics level of the longterm budgets written at the end
+of each run. [0,1],
+written only if do_budgets variable is .true.,
+0=none,
+1=+net summary budgets,
+default: 0
+  </entry>
+
 </namelist_definition>

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -95,12 +95,12 @@ contains
       	    wa(c) = 0._r8                ! Made 0 for variable soil thickness
 	 end do
       else
-	 do f = 1, num_hydrologyc
-            c = filter_hydrologyc(f)
-            if (zwt(c) <= zi(c,nlevsoi)) then
-               wa(c) = 5000._r8
-	    end if
-         end do
+	 !do f = 1, num_hydrologyc
+         !   c = filter_hydrologyc(f)
+         !   if (zwt(c) <= zi(c,nlevsoi)) then
+         !      wa(c) = 5000._r8
+	 !   end if
+         !end do
       end if
       
       do f = 1, num_nolakec

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -47,10 +47,12 @@ contains
     ! Initialize column-level water balance at beginning of time step
     !
     ! !USES:
-    use subgridAveMod , only : p2c
-    use clm_varpar    , only : nlevgrnd, nlevsoi, nlevurb
-    use column_varcon , only : icol_roof, icol_sunwall, icol_shadewall 
-    use column_varcon , only : icol_road_perv, icol_road_imperv
+    use subgridAveMod    , only : p2c, c2g
+    use clm_varpar       , only : nlevgrnd, nlevsoi, nlevurb
+    use clm_varcon       , only : spval
+    use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall 
+    use column_varcon    , only : icol_road_perv, icol_road_imperv
+    use clm_time_manager , only : get_curr_date, get_prev_date, get_nstep
     !
     ! !ARGUMENTS:
     type(bounds_type)         , intent(in)    :: bounds     
@@ -66,6 +68,7 @@ contains
     ! !LOCAL VARIABLES:
     integer :: c, p, f, j, fc                  ! indices
     real(r8):: h2osoi_vol
+    integer :: year, mon, day, sec
     !-----------------------------------------------------------------------
 
     associate(                                                         & 
@@ -79,7 +82,8 @@ contains
          zwt                    =>    soilhydrology_vars%zwt_col                 , & ! Input:  [real(r8) (:)   ]  water table depth (m)                   
          wa                     =>    soilhydrology_vars%wa_col                  , & ! Output: [real(r8) (:)   ]  water in the unconfined aquifer (mm)    
          h2ocan_col             =>    waterstate_vars%h2ocan_col                 , & ! Output: [real(r8) (:)   ]  canopy water (mm H2O) (column level)    
-         begwb                  =>    waterstate_vars%begwb_col                    & ! Output: [real(r8) (:)   ]  water mass begining of the time step    
+         begwb                  =>    waterstate_vars%begwb_col                  , & ! Output: [real(r8) (:)   ]  water mass begining of the time step
+         tws_month_beg_grc      =>    waterstate_vars%tws_month_beg_grc            & ! Output: [real(r8) (:)   ]  grid-level water mass at the begining of a month
          )
 
       ! Determine beginning water balance for time step
@@ -142,7 +146,17 @@ contains
          begwb(c) = h2osno(c)
       end do
 
-    end associate 
+      ! If this is the beginning of a month, save grid-level total water storage
+      call get_prev_date(year, mon, day, sec);
+
+      if (day == 1 .and. sec == 0) then
+         call c2g( bounds, &
+              begwb(bounds%begc:bounds%endc), &
+              tws_month_beg_grc(bounds%begg:bounds%endg), &
+              c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      endif
+
+    end associate
 
    end subroutine BeginWaterBalance
 
@@ -175,6 +189,7 @@ contains
      use clm_initializeMod , only : surfalb_vars
      use CanopyStateType   , only : canopystate_type
      use subgridAveMod
+     use clm_time_manager  , only : get_curr_date, get_nstep
      !
      ! !ARGUMENTS:
      type(bounds_type)     , intent(in)    :: bounds  
@@ -196,6 +211,7 @@ contains
      integer  :: indexp,indexc,indexl,indexg            ! index of first found in search loop
      real(r8) :: forc_rain_col(bounds%begc:bounds%endc) ! column level rain rate [mm/s]
      real(r8) :: forc_snow_col(bounds%begc:bounds%endc) ! column level snow rate [mm/s]
+     integer  :: year, mon, day, sec
      !-----------------------------------------------------------------------
 
      associate(                                                                         & 
@@ -285,13 +301,25 @@ contains
           ftid                       =>    surfalb_vars%ftid_patch                    , & ! Input:  [real(r8) (:,:)]  down diffuse flux below canopy per unit direct flux
           ftii                       =>    surfalb_vars%ftii_patch                    , & ! Input:  [real(r8) (:,:)]  down diffuse flux below canopy per unit diffuse flux
 
-          netrad                     =>    energyflux_vars%netrad_patch                 & ! Output: [real(r8) (:)   ]  net radiation (positive downward) (W/m**2)
+          netrad                     =>    energyflux_vars%netrad_patch               , & ! Output: [real(r8) (:)   ]  net radiation (positive downward) (W/m**2)
+          tws_month_end_grc          =>    waterstate_vars%tws_month_end_grc            & ! Output: [real(r8) (:)   ]  water mass at the end of a month
           )
 
        ! Get step size and time step
 
        nstep = get_nstep()
        dtime = get_step_size()
+
+       ! If this is the end of a month, save grid-level total water storage
+       call get_curr_date(year, mon, day, sec);
+       if (nstep >= 1 .and. (day == 1 .and. sec == 0)) then
+          call c2g( bounds, &
+               endwb(bounds%begc:bounds%endc), &
+               tws_month_end_grc(bounds%begg:bounds%endg), &
+               c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+       else
+          tws_month_end_grc(bounds%begg:bounds%endg) = spval
+       end if
 
        ! Determine column level incoming snow and rain
        ! Assume no incident precipitation on urban wall columns (as in CanopyHydrologyMod.F90).

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -95,13 +95,6 @@ contains
             c = filter_hydrologyc(f)
       	    wa(c) = 0._r8                ! Made 0 for variable soil thickness
 	 end do
-      else
-	 !do f = 1, num_hydrologyc
-         !   c = filter_hydrologyc(f)
-         !   if (zwt(c) <= zi(c,nlevsoi)) then
-         !      wa(c) = 5000._r8
-	 !   end if
-         !end do
       end if
       
       do f = 1, num_nolakec

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -52,7 +52,6 @@ contains
     use clm_varcon       , only : spval
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall 
     use column_varcon    , only : icol_road_perv, icol_road_imperv
-    use clm_time_manager , only : get_curr_date, get_prev_date, get_nstep
     !
     ! !ARGUMENTS:
     type(bounds_type)         , intent(in)    :: bounds     
@@ -68,7 +67,6 @@ contains
     ! !LOCAL VARIABLES:
     integer :: c, p, f, j, fc                  ! indices
     real(r8):: h2osoi_vol
-    integer :: year, mon, day, sec
     !-----------------------------------------------------------------------
 
     associate(                                                         & 
@@ -82,8 +80,7 @@ contains
          zwt                    =>    soilhydrology_vars%zwt_col                 , & ! Input:  [real(r8) (:)   ]  water table depth (m)                   
          wa                     =>    soilhydrology_vars%wa_col                  , & ! Output: [real(r8) (:)   ]  water in the unconfined aquifer (mm)    
          h2ocan_col             =>    waterstate_vars%h2ocan_col                 , & ! Output: [real(r8) (:)   ]  canopy water (mm H2O) (column level)    
-         begwb                  =>    waterstate_vars%begwb_col                  , & ! Output: [real(r8) (:)   ]  water mass begining of the time step
-         tws_month_beg_grc      =>    waterstate_vars%tws_month_beg_grc            & ! Output: [real(r8) (:)   ]  grid-level water mass at the begining of a month
+         begwb                  =>    waterstate_vars%begwb_col                    & ! Output: [real(r8) (:)   ]  water mass begining of the time step
          )
 
       ! Determine beginning water balance for time step
@@ -146,16 +143,6 @@ contains
          begwb(c) = h2osno(c)
       end do
 
-      ! If this is the beginning of a month, save grid-level total water storage
-      call get_prev_date(year, mon, day, sec);
-
-      if (day == 1 .and. sec == 0) then
-         call c2g( bounds, &
-              begwb(bounds%begc:bounds%endc), &
-              tws_month_beg_grc(bounds%begg:bounds%endg), &
-              c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      endif
-
     end associate
 
    end subroutine BeginWaterBalance
@@ -211,7 +198,6 @@ contains
      integer  :: indexp,indexc,indexl,indexg            ! index of first found in search loop
      real(r8) :: forc_rain_col(bounds%begc:bounds%endc) ! column level rain rate [mm/s]
      real(r8) :: forc_snow_col(bounds%begc:bounds%endc) ! column level snow rate [mm/s]
-     integer  :: year, mon, day, sec
      !-----------------------------------------------------------------------
 
      associate(                                                                         & 
@@ -301,25 +287,13 @@ contains
           ftid                       =>    surfalb_vars%ftid_patch                    , & ! Input:  [real(r8) (:,:)]  down diffuse flux below canopy per unit direct flux
           ftii                       =>    surfalb_vars%ftii_patch                    , & ! Input:  [real(r8) (:,:)]  down diffuse flux below canopy per unit diffuse flux
 
-          netrad                     =>    energyflux_vars%netrad_patch               , & ! Output: [real(r8) (:)   ]  net radiation (positive downward) (W/m**2)
-          tws_month_end_grc          =>    waterstate_vars%tws_month_end_grc            & ! Output: [real(r8) (:)   ]  water mass at the end of a month
+          netrad                     =>    energyflux_vars%netrad_patch                 & ! Output: [real(r8) (:)   ]  net radiation (positive downward) (W/m**2)
           )
 
        ! Get step size and time step
 
        nstep = get_nstep()
        dtime = get_step_size()
-
-       ! If this is the end of a month, save grid-level total water storage
-       call get_curr_date(year, mon, day, sec);
-       if (nstep >= 1 .and. (day == 1 .and. sec == 0)) then
-          call c2g( bounds, &
-               endwb(bounds%begc:bounds%endc), &
-               tws_month_end_grc(bounds%begg:bounds%endg), &
-               c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-       else
-          tws_month_end_grc(bounds%begg:bounds%endg) = spval
-       end if
 
        ! Determine column level incoming snow and rain
        ! Assume no incident precipitation on urban wall columns (as in CanopyHydrologyMod.F90).
@@ -895,13 +869,33 @@ contains
          enddo
       end do
 
-      call c2g(bounds, begwb_col             , begwb_grc          , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, wa_local_col          , beg_wa_grc         , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2ocan_col            , beg_h2ocan_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2osno                , beg_h2osno_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2osfc                , beg_h2osfc_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2osoi_liq_depth_intg , beg_h2osoi_liq_grc , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2osoi_ice_depth_intg , beg_h2osoi_ice_grc , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, begwb_col(bounds%begc:bounds%endc), &
+           begwb_grc(bounds%begg:bounds%endg), &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, wa_local_col(bounds%begc:bounds%endc), &
+           beg_wa_grc(bounds%begg:bounds%endg), &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2ocan_col(bounds%begc:bounds%endc), &
+           beg_h2ocan_grc(bounds%begg:bounds%endg), &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2osno(bounds%begc:bounds%endc), &
+           beg_h2osno_grc(bounds%begg:bounds%endg), &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2osfc(bounds%begc:bounds%endc), &
+           beg_h2osfc_grc(bounds%begg:bounds%endg), &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2osoi_liq_depth_intg(bounds%begc:bounds%endc), &
+           beg_h2osoi_liq_grc(bounds%begg:bounds%endg), &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2osoi_ice_depth_intg(bounds%begc:bounds%endc), &
+           beg_h2osoi_ice_grc(bounds%begg:bounds%endg), &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
       
     end associate
 
@@ -1091,14 +1085,37 @@ contains
 
       end do
 
-      call c2g(bounds, endwb_col             , endwb_grc          , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, wa_local_col          , end_wa_grc         , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2ocan_col            , end_h2ocan_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2osno_col            , end_h2osno_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2osfc_col            , end_h2osfc_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2osoi_liq_depth_intg , end_h2osoi_liq_grc , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, h2osoi_ice_depth_intg , end_h2osoi_ice_grc , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
-      call c2g(bounds, errh2o                , errh2o_grc         , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, endwb_col(bounds%begc:bounds%endc)             , &
+           endwb_grc(bounds%begg:bounds%endg)                         , &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, wa_local_col(bounds%begc:bounds%endc)          , &
+           end_wa_grc(bounds%begg:bounds%endg)                        , &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2ocan_col(bounds%begc:bounds%endc)            , &
+           end_h2ocan_grc(bounds%begg:bounds%endg)                    , &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2osno_col(bounds%begc:bounds%endc)            , &
+           end_h2osno_grc(bounds%begg:bounds%endg)                    , &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2osfc_col(bounds%begc:bounds%endc)            , &
+           end_h2osfc_grc(bounds%begg:bounds%endg)                    , &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2osoi_liq_depth_intg(bounds%begc:bounds%endc) , &
+           end_h2osoi_liq_grc(bounds%begg:bounds%endg)                , &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, h2osoi_ice_depth_intg(bounds%begc:bounds%endc) , &
+           end_h2osoi_ice_grc(bounds%begg:bounds%endg)                , &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+
+      call c2g(bounds, errh2o(bounds%begc:bounds%endc)                , &
+           errh2o_grc(bounds%begg:bounds%endg)                        , &
+           c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
 
     end associate
 

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -857,7 +857,7 @@ contains
             h2ocan_patch(bounds%begp:bounds%endp), &
             h2ocan_col(bounds%begc:bounds%endc))
 
-      wa_local_col(:) = wa(:)
+      wa_local_col(bounds%begc:bounds%endc) = wa(bounds%begc:bounds%endc)
 
       do f = 1, num_nolakec
          c = filter_nolakec(f)
@@ -1053,7 +1053,7 @@ contains
 
        dtime = get_step_size()
 
-       wa_local_col(:) = wa(:)
+       wa_local_col(bounds%begc:bounds%endc) = wa(bounds%begc:bounds%endc)
 
        do c = bounds%begc,bounds%endc
           g = col_pp%gridcell(c)

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -943,6 +943,7 @@ contains
           begwb_col                  =>    waterstate_vars%begwb_col                  , & ! Input:  [real(r8) (:)   ]  water mass begining of the time step    
           begwb_grc                  =>    waterstate_vars%begwb_grc                  , & ! Input:  [real(r8) (:)   ]  water mass begining of the time step    
           errh2o                     =>    waterstate_vars%errh2o_col                 , & ! Output: [real(r8) (:)   ]  water conservation error (mm H2O)       
+          errh2o_grc                 =>    waterstate_vars%errh2o_grc                 , & ! Output: [real(r8) (:)   ]  water conservation error (mm H2O)
           errh2osno                  =>    waterstate_vars%errh2osno_col              , & ! Output: [real(r8) (:)   ]  error in h2osno (kg m-2)                
           endwb_col                  =>    waterstate_vars%endwb_col                  , & ! Output: [real(r8) (:)   ]  water mass end of the time step         
           endwb_grc                  =>    waterstate_vars%endwb_grc                  , & ! Output: [real(r8) (:)   ]  water mass end of the time step         
@@ -1071,6 +1072,7 @@ contains
       call c2g(bounds, h2osfc_col            , end_h2osfc_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
       call c2g(bounds, h2osoi_liq_depth_intg , end_h2osoi_liq_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
       call c2g(bounds, h2osoi_ice_depth_intg , end_h2osoi_ice_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, errh2o                , errh2o_grc         , c2l_scale_type= 'unity', l2g_scale_type='unity' )
 
     end associate
 

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -789,23 +789,37 @@ contains
     real(r8) :: h2osoi_vol
     real(r8) :: h2ocan_col(bounds%begc:bounds%endc)
     real(r8) :: begwb_col (bounds%begc:bounds%endc)
+    real(r8) :: h2osoi_liq_depth_intg(bounds%begc:bounds%endc)
+    real(r8) :: h2osoi_ice_depth_intg(bounds%begc:bounds%endc)
 
-    associate(                                                                     &
-         zi                     =>    col_pp%zi                                  , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
-         h2ocan_patch           =>    waterstate_vars%h2ocan_patch               , & ! Input:  [real(r8) (:)   ]  canopy water (mm H2O) (pft-level)
-         h2osfc                 =>    waterstate_vars%h2osfc_col                 , & ! Input:  [real(r8) (:)   ]  surface water (mm)
-         h2osno                 =>    waterstate_vars%h2osno_col                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
-         h2osoi_ice             =>    waterstate_vars%h2osoi_ice_col             , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
-         h2osoi_liq             =>    waterstate_vars%h2osoi_liq_col             , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
-         total_plant_stored_h2o =>    waterstate_vars%total_plant_stored_h2o_col , & ! Input:  [real(r8) (:)   ]  dynamic water stored in plants
-         zwt                    =>    soilhydrology_vars%zwt_col                 , & ! Input:  [real(r8) (:)   ]  water table depth (m)
-         wa                     =>    soilhydrology_vars%wa_col                  , & ! Output: [real(r8) (:)   ]  water in the unconfined aquifer (mm)    
-         begwb_grc              =>    waterstate_vars%begwb_grc                    & ! Output: [real(r8) (:)   ]  water mass begining of the time step
+    associate(                                                                        &
+         zi                        =>    col_pp%zi                                  , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
+         h2ocan_patch              =>    waterstate_vars%h2ocan_patch               , & ! Input:  [real(r8) (:)   ]  canopy water (mm H2O) (pft-level)
+         h2osfc                    =>    waterstate_vars%h2osfc_col                 , & ! Input:  [real(r8) (:)   ]  surface water (mm)
+         h2osno                    =>    waterstate_vars%h2osno_col                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
+         h2osoi_ice                =>    waterstate_vars%h2osoi_ice_col             , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         h2osoi_liq                =>    waterstate_vars%h2osoi_liq_col             , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
+         total_plant_stored_h2o    =>    waterstate_vars%total_plant_stored_h2o_col , & ! Input:  [real(r8) (:)   ]  dynamic water stored in plants
+         zwt                       =>    soilhydrology_vars%zwt_col                 , & ! Input:  [real(r8) (:)   ]  water table depth (m)
+         wa                        =>    soilhydrology_vars%wa_col                  , & ! Output: [real(r8) (:)   ]  water in the unconfined aquifer (mm)
+         beg_wa_grc                =>    soilhydrology_vars%beg_wa_grc              , & ! Output: [real(r8) (:)   ]  grid-level water in the unconfined aquifer at begining of the time step (mm)
+         begwb_grc                 =>    waterstate_vars%begwb_grc                  , & ! Output: [real(r8) (:)   ]  grid-level water mass at begining of the time step (mm)
+         beg_h2ocan_grc            =>    waterstate_vars%beg_h2ocan_grc             , & ! Output: [real(r8) (:)   ]  grid-level canopy water at begining of the time step (mm)
+         beg_h2osno_grc            =>    waterstate_vars%beg_h2osno_grc             , & ! Output: [real(r8) (:)   ]  grid-level snow at begining of the time step (mm)
+         beg_h2osfc_grc            =>    waterstate_vars%beg_h2osfc_grc             , & ! Output: [real(r8) (:)   ]  grid-level surface water at begining of the time step (mm)
+         beg_h2osoi_liq_grc        =>    waterstate_vars%beg_h2osoi_liq_grc         , & ! Output: [real(r8) (:)   ]  grid-level depth integrated liquid soil water at begining of the time step (mm)
+         beg_h2osoi_ice_grc        =>    waterstate_vars%beg_h2osoi_ice_grc         , & ! Output: [real(r8) (:)   ]  grid-level depth integrated ice soil water at begining of the time step (mm)
+         h2osoi_liq_depth_intg_col =>    waterstate_vars%h2osoi_liq_depth_intg_col  , &
+         h2osoi_ice_depth_intg_col =>    waterstate_vars%h2osoi_ice_depth_intg_col    &
          )
 
       ! Set to zero
       begwb_col (bounds%begc:bounds%endc) = 0._r8
       h2ocan_col(bounds%begc:bounds%endc) = 0._r8
+      h2osoi_liq_depth_intg(bounds%begc:bounds%endc) = 0._r8
+      h2osoi_ice_depth_intg(bounds%begc:bounds%endc) = 0._r8
+      h2osoi_liq_depth_intg_col(bounds%begc:bounds%endc) = 0._r8
+      h2osoi_ice_depth_intg_col(bounds%begc:bounds%endc) = 0._r8
 
       ! Determine beginning water balance for time step
       ! pft-level canopy water averaged to column
@@ -846,6 +860,8 @@ contains
                  .or. col_pp%itype(c) == icol_roof) .and. j > nlevurb) then
             else
                begwb_col(c) = begwb_col(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+               h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
+               h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j)
             end if
          end do
       end do
@@ -855,11 +871,18 @@ contains
          begwb_col(c) = h2osno(c)
          do j = 1, nlevgrnd
             begwb_col(c) = begwb_col(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+            h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
+            h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j)
          enddo
       end do
 
-      call c2g(bounds, begwb_col, begwb_grc, &
-           c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, begwb_col             , begwb_grc          , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, wa                    , beg_wa_grc         , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2ocan_col            , beg_h2ocan_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2osno                , beg_h2osno_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2osfc                , beg_h2osfc_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2osoi_liq_depth_intg , beg_h2osoi_liq_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2osoi_ice_depth_intg , beg_h2osoi_ice_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
       
     end associate
 
@@ -868,7 +891,7 @@ contains
    !-----------------------------------------------------------------------
    subroutine GridBalanceCheck( bounds, num_do_smb_c, filter_do_smb_c, &
         atm2lnd_vars, glc2lnd_vars, solarabs_vars, waterflux_vars, &
-        waterstate_vars, energyflux_vars, canopystate_vars)
+        waterstate_vars, energyflux_vars, canopystate_vars, soilhydrology_vars)
      !
      ! !DESCRIPTION:
      !
@@ -894,12 +917,12 @@ contains
      type(waterstate_type) , intent(inout) :: waterstate_vars
      type(energyflux_type) , intent(inout) :: energyflux_vars
      type(canopystate_type), intent(inout) :: canopystate_vars
+     type(soilhydrology_type), intent(inout) :: soilhydrology_vars
      !
      ! !LOCAL VARIABLES:
      integer  :: p,c,l,g,fc                             ! indices
      real(r8) :: dtime                                  ! land model time step (sec)
      real(r8) :: qflx_net_col (bounds%begc:bounds%endc)
-     real(r8) :: qflx_net_grc (bounds%begg:bounds%endg)
      real(r8) :: forc_rain_col(bounds%begc:bounds%endc) ! column level rain rate [mm/s]
      real(r8) :: forc_snow_col(bounds%begc:bounds%endc) ! column level snow rate [mm/s]
 
@@ -913,7 +936,7 @@ contains
           glc_dyn_runoff_routing     =>    glc2lnd_vars%glc_dyn_runoff_routing_grc    , & ! Input:  [real(r8) (:)   ]  whether we're doing runoff routing appropriate for having a dynamic icesheet
 
           do_capsnow                 =>    waterstate_vars%do_capsnow_col             , & ! Input:  [logical (:)    ]  true => do snow capping                  
-          h2osno                     =>    waterstate_vars%h2osno_col                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)                     
+          h2osno_col                 =>    waterstate_vars%h2osno_col                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
           h2osno_old                 =>    waterstate_vars%h2osno_old_col             , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O) at previous time step
           frac_sno_eff               =>    waterstate_vars%frac_sno_eff_col           , & ! Input:  [real(r8) (:)   ]  effective snow fraction                 
           frac_sno                   =>    waterstate_vars%frac_sno_col               , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by snow (0 to 1)
@@ -992,7 +1015,19 @@ contains
           ftid                       =>    surfalb_vars%ftid_patch                    , & ! Input:  [real(r8) (:,:)]  down diffuse flux below canopy per unit direct flux
           ftii                       =>    surfalb_vars%ftii_patch                    , & ! Input:  [real(r8) (:,:)]  down diffuse flux below canopy per unit diffuse flux
 
-          netrad                     =>    energyflux_vars%netrad_patch                 & ! Output: [real(r8) (:)   ]  net radiation (positive downward) (W/m**2)
+          netrad                     =>    energyflux_vars%netrad_patch               , & ! Output: [real(r8) (:)   ]  net radiation (positive downward) (W/m**2)
+          h2ocan_patch               =>    waterstate_vars%h2ocan_patch               , & ! Input:  [real(r8) (:)   ]  canopy water (mm H2O) (pft-level)
+          wa                         =>    soilhydrology_vars%wa_col                  , & ! Output: [real(r8) (:)   ]  water in the unconfined aquifer (mm)
+          h2ocan_col                 =>    waterstate_vars%h2ocan_col                 , & ! Input:  [real(r8) (:)   ]  canopy water (mm H2O)
+          h2osfc_col                 =>    waterstate_vars%h2osfc_col                 , & ! Input:  [real(r8) (:)   ]  surface water (mm)
+          h2osoi_liq_depth_intg      =>    waterstate_vars%h2osoi_liq_depth_intg_col  , & ! Input:  [real(r8) (:)   ]  depth integrated liquid soil water (kg/m**2)
+          h2osoi_ice_depth_intg      =>    waterstate_vars%h2osoi_ice_depth_intg_col  , & ! Input:  [real(r8) (:)   ]  depth integrated ice soil water (kg/m**2)
+          end_wa_grc                 =>    soilhydrology_vars%end_wa_grc              , & ! Output: [real(r8) (:)   ]  grid-level water in the unconfined aquifer at end of the time step (mm)
+          end_h2ocan_grc             =>    waterstate_vars%end_h2ocan_grc             , & ! Output: [real(r8) (:)   ]  grid-level canopy water at end of the time step (mm)
+          end_h2osno_grc             =>    waterstate_vars%end_h2osno_grc             , & ! Output: [real(r8) (:)   ]  grid-level snow at end of the time step (mm)
+          end_h2osfc_grc             =>    waterstate_vars%end_h2osfc_grc             , & ! Output: [real(r8) (:)   ]  grid-level surface water at end of the time step (mm)
+          end_h2osoi_liq_grc         =>    waterstate_vars%end_h2osoi_liq_grc         , & ! Output: [real(r8) (:)   ]  grid-level depth integrated liquid soil water at end of the time step (mm)
+          end_h2osoi_ice_grc         =>    waterstate_vars%end_h2osoi_ice_grc           & ! Output: [real(r8) (:)   ]  grid-level depth integrated liquid soil water at end of the time step (mm)
           )
 
        dtime = get_step_size()
@@ -1029,11 +1064,13 @@ contains
 
       end do
 
-      call c2g(bounds, endwb_col, endwb_grc, &
-           c2l_scale_type= 'unity', l2g_scale_type='unity' )
-
-      call c2g(bounds, qflx_net_col, qflx_net_grc, &
-           c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, endwb_col             , endwb_grc          , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, wa                    , end_wa_grc         , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2ocan_col            , end_h2ocan_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2osno_col            , end_h2osno_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2osfc_col            , end_h2osfc_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2osoi_liq_depth_intg , end_h2osoi_liq_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, h2osoi_ice_depth_intg , end_h2osoi_ice_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
 
     end associate
 

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -829,20 +829,6 @@ contains
             h2ocan_patch(bounds%begp:bounds%endp), &
             h2ocan_col(bounds%begc:bounds%endc))
 
-      if (use_var_soil_thick) then
-	 do f = 1, num_hydrologyc
-            c = filter_hydrologyc(f)
-      	    wa(c) = 0._r8
-	 end do
-      else
-	 do f = 1, num_hydrologyc
-            c = filter_hydrologyc(f)
-            if (zwt(c) <= zi(c,nlevsoi)) then
-               wa(c) = 5000._r8
-	    end if
-         end do
-      end if
-
       wa_local_col(:) = wa(:)
 
       do f = 1, num_nolakec

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -31,6 +31,8 @@ module BalanceCheckMod
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: BeginWaterBalance  ! Initialize water balance check
   public :: BalanceCheck       ! Water and energy balance check
+  public :: BeginGridWaterBalance
+  public :: GridBalanceCheck
   !-----------------------------------------------------------------------
 
 contains
@@ -111,6 +113,7 @@ contains
          end if
          
       end do
+
       do j = 1, nlevgrnd
          do f = 1, num_nolakec
             c = filter_nolakec(f)
@@ -755,4 +758,285 @@ contains
 
    end subroutine BalanceCheck
 
-end module BalanceCheckMod
+  !-----------------------------------------------------------------------
+  subroutine BeginGridWaterBalance(bounds, &
+       num_nolakec, filter_nolakec, num_lakec, filter_lakec, &
+       num_hydrologyc, filter_hydrologyc, &
+       soilhydrology_vars, waterstate_vars)
+    !
+    ! !DESCRIPTION:
+    ! Initialize column-level water balance at beginning of time step
+    !
+    ! !USES:
+    use subgridAveMod , only : p2c,c2g
+    use clm_varpar    , only : nlevgrnd, nlevsoi, nlevurb
+    use column_varcon , only : icol_roof, icol_sunwall, icol_shadewall
+    use column_varcon , only : icol_road_perv, icol_road_imperv
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)         , intent(in)    :: bounds
+    integer                   , intent(in)    :: num_nolakec          ! number of column non-lake points in column filter
+    integer                   , intent(in)    :: filter_nolakec(:)    ! column filter for non-lake points
+    integer                   , intent(in)    :: num_lakec            ! number of column non-lake points in column filter
+    integer                   , intent(in)    :: filter_lakec(:)      ! column filter for non-lake points
+    integer                   , intent(in)    :: num_hydrologyc       ! number of column soil points in column filter
+    integer                   , intent(in)    :: filter_hydrologyc(:) ! column filter for soil points
+    type(soilhydrology_type)  , intent(inout) :: soilhydrology_vars
+    type(waterstate_type)     , intent(inout) :: waterstate_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c, p, f, j, fc                  ! indices
+    real(r8) :: h2osoi_vol
+    real(r8) :: h2ocan_col(bounds%begc:bounds%endc)
+    real(r8) :: begwb_col (bounds%begc:bounds%endc)
+
+    associate(                                                                     &
+         zi                     =>    col_pp%zi                                  , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
+         h2ocan_patch           =>    waterstate_vars%h2ocan_patch               , & ! Input:  [real(r8) (:)   ]  canopy water (mm H2O) (pft-level)
+         h2osfc                 =>    waterstate_vars%h2osfc_col                 , & ! Input:  [real(r8) (:)   ]  surface water (mm)
+         h2osno                 =>    waterstate_vars%h2osno_col                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
+         h2osoi_ice             =>    waterstate_vars%h2osoi_ice_col             , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         h2osoi_liq             =>    waterstate_vars%h2osoi_liq_col             , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
+         total_plant_stored_h2o =>    waterstate_vars%total_plant_stored_h2o_col , & ! Input:  [real(r8) (:)   ]  dynamic water stored in plants
+         zwt                    =>    soilhydrology_vars%zwt_col                 , & ! Input:  [real(r8) (:)   ]  water table depth (m)
+         wa                     =>    soilhydrology_vars%wa_col                  , & ! Output: [real(r8) (:)   ]  water in the unconfined aquifer (mm)    
+         begwb_grc              =>    waterstate_vars%begwb_grc                    & ! Output: [real(r8) (:)   ]  water mass begining of the time step
+         )
+
+      ! Set to zero
+      begwb_col (bounds%begc:bounds%endc) = 0._r8
+      h2ocan_col(bounds%begc:bounds%endc) = 0._r8
+
+      ! Determine beginning water balance for time step
+      ! pft-level canopy water averaged to column
+
+      call p2c(bounds, num_nolakec, filter_nolakec, &
+            h2ocan_patch(bounds%begp:bounds%endp), &
+            h2ocan_col(bounds%begc:bounds%endc))
+
+      if (use_var_soil_thick) then
+	 do f = 1, num_hydrologyc
+            c = filter_hydrologyc(f)
+      	    wa(c) = 0._r8
+	 end do
+      else
+	 do f = 1, num_hydrologyc
+            c = filter_hydrologyc(f)
+            if (zwt(c) <= zi(c,nlevsoi)) then
+               wa(c) = 5000._r8
+	    end if
+         end do
+      end if
+
+      do f = 1, num_nolakec
+         c = filter_nolakec(f)
+         if (col_pp%itype(c) == icol_roof .or. col_pp%itype(c) == icol_sunwall &
+              .or. col_pp%itype(c) == icol_shadewall .or. col_pp%itype(c) == icol_road_imperv) then
+            begwb_col(c) = h2ocan_col(c) + h2osno(c)
+         else
+            begwb_col(c) = h2ocan_col(c) + h2osno(c) + h2osfc(c) + wa(c)
+         end if
+         begwb_col(c) = begwb_col(c) + total_plant_stored_h2o(c)
+      end do
+
+      do j = 1, nlevgrnd
+         do f = 1, num_nolakec
+            c = filter_nolakec(f)
+            if ((col_pp%itype(c) == icol_sunwall .or. col_pp%itype(c) == icol_shadewall &
+                 .or. col_pp%itype(c) == icol_roof) .and. j > nlevurb) then
+            else
+               begwb_col(c) = begwb_col(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+            end if
+         end do
+      end do
+
+      do f = 1, num_lakec
+         c = filter_lakec(f)
+         begwb_col(c) = h2osno(c)
+         do j = 1, nlevgrnd
+            begwb_col(c) = begwb_col(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+         enddo
+      end do
+
+      call c2g(bounds, begwb_col, begwb_grc, &
+           c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      
+    end associate
+
+  end subroutine BeginGridWaterBalance
+
+   !-----------------------------------------------------------------------
+   subroutine GridBalanceCheck( bounds, num_do_smb_c, filter_do_smb_c, &
+        atm2lnd_vars, glc2lnd_vars, solarabs_vars, waterflux_vars, &
+        waterstate_vars, energyflux_vars, canopystate_vars)
+     !
+     ! !DESCRIPTION:
+     !
+     ! !USES:
+     use clm_varcon        , only : spval
+     use column_varcon     , only : icol_roof, icol_sunwall, icol_shadewall
+     use column_varcon     , only : icol_road_perv, icol_road_imperv
+     use landunit_varcon   , only : istice_mec, istdlak, istsoil,istcrop,istwet
+     use clm_varctl        , only : create_glacier_mec_landunit
+     use clm_time_manager  , only : get_step_size, get_nstep
+     use clm_initializeMod , only : surfalb_vars
+     use CanopyStateType   , only : canopystate_type
+     use subgridAveMod
+     !
+     ! !ARGUMENTS:
+     type(bounds_type)     , intent(in)    :: bounds  
+     integer               , intent(in)    :: num_do_smb_c        ! number of columns in filter_do_smb_c
+     integer               , intent(in)    :: filter_do_smb_c (:) ! column filter for points where SMB calculations are done
+     type(atm2lnd_type)    , intent(in)    :: atm2lnd_vars
+     type(glc2lnd_type)    , intent(in)    :: glc2lnd_vars
+     type(solarabs_type)   , intent(in)    :: solarabs_vars
+     type(waterflux_type)  , intent(inout) :: waterflux_vars
+     type(waterstate_type) , intent(inout) :: waterstate_vars
+     type(energyflux_type) , intent(inout) :: energyflux_vars
+     type(canopystate_type), intent(inout) :: canopystate_vars
+     !
+     ! !LOCAL VARIABLES:
+     integer  :: p,c,l,g,fc                             ! indices
+     real(r8) :: dtime                                  ! land model time step (sec)
+     real(r8) :: qflx_net_col (bounds%begc:bounds%endc)
+     real(r8) :: qflx_net_grc (bounds%begg:bounds%endg)
+     real(r8) :: forc_rain_col(bounds%begc:bounds%endc) ! column level rain rate [mm/s]
+     real(r8) :: forc_snow_col(bounds%begc:bounds%endc) ! column level snow rate [mm/s]
+
+     associate(                                                                         & 
+          volr                       =>    atm2lnd_vars%volr_grc                      , & ! Input:  [real(r8) (:)   ]  river water storage (m3)                 
+          forc_solad                 =>    atm2lnd_vars%forc_solad_grc                , & ! Input:  [real(r8) (:,:) ]  direct beam radiation (vis=forc_sols , nir=forc_soll )
+          forc_solai                 =>    atm2lnd_vars%forc_solai_grc                , & ! Input:  [real(r8) (:,:) ]  diffuse radiation     (vis=forc_solsd, nir=forc_solld)
+          forc_rain                  =>    atm2lnd_vars%forc_rain_downscaled_col      , & ! Input:  [real(r8) (:)   ]  rain rate [mm/s]
+          forc_snow                  =>    atm2lnd_vars%forc_snow_downscaled_col      , & ! Input:  [real(r8) (:)   ]  snow rate [mm/s]
+          forc_lwrad                 =>    atm2lnd_vars%forc_lwrad_downscaled_col     , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)
+          glc_dyn_runoff_routing     =>    glc2lnd_vars%glc_dyn_runoff_routing_grc    , & ! Input:  [real(r8) (:)   ]  whether we're doing runoff routing appropriate for having a dynamic icesheet
+
+          do_capsnow                 =>    waterstate_vars%do_capsnow_col             , & ! Input:  [logical (:)    ]  true => do snow capping                  
+          h2osno                     =>    waterstate_vars%h2osno_col                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)                     
+          h2osno_old                 =>    waterstate_vars%h2osno_old_col             , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O) at previous time step
+          frac_sno_eff               =>    waterstate_vars%frac_sno_eff_col           , & ! Input:  [real(r8) (:)   ]  effective snow fraction                 
+          frac_sno                   =>    waterstate_vars%frac_sno_col               , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by snow (0 to 1)
+          begwb_col                  =>    waterstate_vars%begwb_col                  , & ! Input:  [real(r8) (:)   ]  water mass begining of the time step    
+          begwb_grc                  =>    waterstate_vars%begwb_grc                  , & ! Input:  [real(r8) (:)   ]  water mass begining of the time step    
+          errh2o                     =>    waterstate_vars%errh2o_col                 , & ! Output: [real(r8) (:)   ]  water conservation error (mm H2O)       
+          errh2osno                  =>    waterstate_vars%errh2osno_col              , & ! Output: [real(r8) (:)   ]  error in h2osno (kg m-2)                
+          endwb_col                  =>    waterstate_vars%endwb_col                  , & ! Output: [real(r8) (:)   ]  water mass end of the time step         
+          endwb_grc                  =>    waterstate_vars%endwb_grc                  , & ! Output: [real(r8) (:)   ]  water mass end of the time step         
+          total_plant_stored_h2o_col =>    waterstate_vars%total_plant_stored_h2o_col , & ! Input: [real(r8) (:)   ]  water mass in plant tissues (kg m-2)
+          dwb                        =>    waterflux_vars%dwb_col                     , & ! Output: [real(r8) (:)   ]  change of water mass within the time step [kg/m2/s]
+          qflx_rain_grnd_col         =>    waterflux_vars%qflx_rain_grnd_col          , & ! Input:  [real(r8) (:)   ]  rain on ground after interception (mm H2O/s) [+]
+          qflx_snow_grnd_col         =>    waterflux_vars%qflx_snow_grnd_col          , & ! Input:  [real(r8) (:)   ]  snow on ground after interception (mm H2O/s) [+]
+          qflx_evap_soi              =>    waterflux_vars%qflx_evap_soi_col           , & ! Input:  [real(r8) (:)   ]  soil evaporation (mm H2O/s) (+ = to atm)
+          qflx_irrig                 =>    waterflux_vars%qflx_irrig_col              , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)             
+          qflx_snwcp_ice             =>    waterflux_vars%qflx_snwcp_ice_col          , & ! Input:  [real(r8) (:)   ]  excess snowfall due to snow capping (mm H2O /s) [+]`
+          qflx_evap_tot              =>    waterflux_vars%qflx_evap_tot_col           , & ! Input:  [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg
+          qflx_dew_snow              =>    waterflux_vars%qflx_dew_snow_col           , & ! Input:  [real(r8) (:)   ]  surface dew added to snow pack (mm H2O /s) [+]
+          qflx_sub_snow              =>    waterflux_vars%qflx_sub_snow_col           , & ! Input:  [real(r8) (:)   ]  sublimation rate from snow pack (mm H2O /s) [+]
+          qflx_evap_grnd             =>    waterflux_vars%qflx_evap_grnd_col          , & ! Input:  [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]
+          qflx_dew_grnd              =>    waterflux_vars%qflx_dew_grnd_col           , & ! Input:  [real(r8) (:)   ]  ground surface dew formation (mm H2O /s) [+]
+          qflx_prec_grnd             =>    waterflux_vars%qflx_prec_grnd_col          , & ! Input:  [real(r8) (:)   ]  water onto ground including canopy runoff [kg/(m2 s)]
+          qflx_snwcp_liq             =>    waterflux_vars%qflx_snwcp_liq_col          , & ! Input:  [real(r8) (:)   ]  excess liquid water due to snow capping (mm H2O /s) [+]`
+          qflx_snow_h2osfc           =>    waterflux_vars%qflx_snow_h2osfc_col        , & ! Input:  [real(r8) (:)   ]  snow falling on surface water (mm/s)    
+          qflx_h2osfc_to_ice         =>    waterflux_vars%qflx_h2osfc_to_ice_col      , & ! Input:  [real(r8) (:)   ]  conversion of h2osfc to ice             
+          qflx_drain_perched         =>    waterflux_vars%qflx_drain_perched_col      , & ! Input:  [real(r8) (:)   ]  sub-surface runoff (mm H2O /s)          
+          qflx_floodc                =>    waterflux_vars%qflx_floodc_col             , & ! Input:  [real(r8) (:)   ]  total runoff due to flooding            
+          qflx_h2osfc_surf           =>    waterflux_vars%qflx_h2osfc_surf_col        , & ! Input:  [real(r8) (:)   ]  surface water runoff (mm/s)              
+          qflx_snow_melt             =>    waterflux_vars%qflx_snow_melt_col          , & ! Input:  [real(r8) (:)   ]  snow melt (net)                         
+          qflx_surf                  =>    waterflux_vars%qflx_surf_col               , & ! Input:  [real(r8) (:)   ]  surface runoff (mm H2O /s)              
+          qflx_qrgwl                 =>    waterflux_vars%qflx_qrgwl_col              , & ! Input:  [real(r8) (:)   ]  qflx_surf at glaciers, wetlands, lakes  
+          qflx_drain                 =>    waterflux_vars%qflx_drain_col              , & ! Input:  [real(r8) (:)   ]  sub-surface runoff (mm H2O /s)          
+          qflx_runoff                =>    waterflux_vars%qflx_runoff_col             , & ! Input:  [real(r8) (:)   ]  total runoff (mm H2O /s)                
+          qflx_glcice                =>    waterflux_vars%qflx_glcice_col             , & ! Input:  [real(r8) (:)   ]  flux of new glacier ice (mm H2O /s) [+ if ice grows]
+          qflx_glcice_melt           =>    waterflux_vars%qflx_glcice_melt_col        , & ! Input:  [real(r8) (:)   ]  ice melt (mm H2O/s)              
+          qflx_glcice_frz            =>    waterflux_vars%qflx_glcice_frz_col         , & ! Input:  [real(r8) (:)   ]  ice growth (mm H2O/s) [+]               
+          qflx_top_soil              =>    waterflux_vars%qflx_top_soil_col           , & ! Input:  [real(r8) (:)   ]  net water input into soil from top (mm/s)
+          qflx_sl_top_soil           =>    waterflux_vars%qflx_sl_top_soil_col        , & ! Input:  [real(r8) (:)   ]  liquid water + ice from layer above soil to top soil layer or sent to qflx_qrgwl (mm H2O/s)
+          qflx_liq_dynbal            =>    waterflux_vars%qflx_liq_dynbal_grc         , & ! Input:  [real(r8) (:)   ]  liq runoff due to dynamic land cover change (mm H2O /s)
+          qflx_ice_dynbal            =>    waterflux_vars%qflx_ice_dynbal_grc         , & ! Input:  [real(r8) (:)   ]  ice runoff due to dynamic land cover change (mm H2O /s)
+          snow_sources               =>    waterflux_vars%snow_sources_col            , & ! Output: [real(r8) (:)   ]  snow sources (mm H2O /s)  
+          snow_sinks                 =>    waterflux_vars%snow_sinks_col              , & ! Output: [real(r8) (:)   ]  snow sinks (mm H2O /s)    
+          qflx_lateral               =>    waterflux_vars%qflx_lateral_col            , & ! Input:  [real(r8) (:)   ]  lateral flux of water to neighboring column (mm H2O /s)
+
+          eflx_lwrad_out             =>    energyflux_vars%eflx_lwrad_out_patch       , & ! Input:  [real(r8) (:)   ]  emitted infrared (longwave) radiation (W/m**2)
+          eflx_lwrad_net             =>    energyflux_vars%eflx_lwrad_net_patch       , & ! Input:  [real(r8) (:)   ]  net infrared (longwave) rad (W/m**2) [+ = to atm]
+          eflx_sh_tot                =>    energyflux_vars%eflx_sh_tot_patch          , & ! Input:  [real(r8) (:)   ]  total sensible heat flux (W/m**2) [+ to atm]
+          eflx_lh_tot                =>    energyflux_vars%eflx_lh_tot_patch          , & ! Input:  [real(r8) (:)   ]  total latent heat flux (W/m8*2)  [+ to atm]
+          eflx_soil_grnd             =>    energyflux_vars%eflx_soil_grnd_patch       , & ! Input:  [real(r8) (:)   ]  soil heat flux (W/m**2) [+ = into soil] 
+          eflx_wasteheat_patch       =>    energyflux_vars%eflx_wasteheat_patch       , & ! Input:  [real(r8) (:)   ]  sensible heat flux from urban heating/cooling sources of waste heat (W/m**2)
+          eflx_heat_from_ac_patch    =>    energyflux_vars%eflx_heat_from_ac_patch    , & ! Input:  [real(r8) (:)   ]  sensible heat flux put back into canyon due to removal by AC (W/m**2)
+          eflx_traffic_patch         =>    energyflux_vars%eflx_traffic_patch         , & ! Input:  [real(r8) (:)   ]  traffic sensible heat flux (W/m**2)     
+          eflx_dynbal                =>    energyflux_vars%eflx_dynbal_grc            , & ! Input:  [real(r8) (:)   ]  energy conversion flux due to dynamic land cover change(W/m**2) [+ to atm]
+
+          sabg_soil                  =>    solarabs_vars%sabg_soil_patch              , & ! Input:  [real(r8) (:)   ]  solar radiation absorbed by soil (W/m**2)
+          sabg_snow                  =>    solarabs_vars%sabg_snow_patch              , & ! Input:  [real(r8) (:)   ]  solar radiation absorbed by snow (W/m**2)
+          sabg_chk                   =>    solarabs_vars%sabg_chk_patch               , & ! Input:  [real(r8) (:)   ]  sum of soil/snow using current fsno, for balance check
+          fsa                        =>    solarabs_vars%fsa_patch                    , & ! Input:  [real(r8) (:)   ]  solar radiation absorbed (total) (W/m**2)
+          fsr                        =>    solarabs_vars%fsr_patch                    , & ! Input:  [real(r8) (:)   ]  solar radiation reflected (W/m**2)      
+          sabv                       =>    solarabs_vars%sabv_patch                   , & ! Input:  [real(r8) (:)   ]  solar radiation absorbed by vegetation (W/m**2)
+          sabg                       =>    solarabs_vars%sabg_patch                   , & ! Input:  [real(r8) (:)   ]  solar radiation absorbed by ground (W/m**2)
+          
+          errsoi_col                 =>    energyflux_vars%errsoi_col                 , & ! Output: [real(r8) (:)   ]  column-level soil/lake energy conservation error (W/m**2)
+          errsol                     =>    energyflux_vars%errsol_patch               , & ! Output: [real(r8) (:)   ]  solar radiation conservation error (W/m**2)
+          errseb                     =>    energyflux_vars%errseb_patch               , & ! Output: [real(r8) (:)   ]  surface energy conservation error (W/m**2)
+          errlon                     =>    energyflux_vars%errlon_patch               , & ! Output: [real(r8) (:)   ]  longwave radiation conservation error (W/m**2)
+
+          fabd                       =>    surfalb_vars%fabd_patch                    , & ! Input:  [real(r8) (:,:)]  flux absorbed by canopy per unit direct flux
+          fabi                       =>    surfalb_vars%fabi_patch                    , & ! Input:  [real(r8) (:,:)]  flux absorbed by canopy per unit indirect flux
+          elai                       =>    canopystate_vars%elai_patch                , & ! Input:  [real(r8) (:,:)]  
+          esai                       =>    canopystate_vars%esai_patch                , & ! Input:  [real(r8) (:,:)]  
+
+          albd                       =>    surfalb_vars%albd_patch                    , & ! Output: [real(r8) (:,:)]  surface albedo (direct)
+          albi                       =>    surfalb_vars%albi_patch                    , & ! Output: [real(r8) (:,:)]  surface albedo (diffuse)
+          ftdd                       =>    surfalb_vars%ftdd_patch                    , & ! Input:  [real(r8) (:,:)]  down direct flux below canopy per unit direct flux
+          ftid                       =>    surfalb_vars%ftid_patch                    , & ! Input:  [real(r8) (:,:)]  down diffuse flux below canopy per unit direct flux
+          ftii                       =>    surfalb_vars%ftii_patch                    , & ! Input:  [real(r8) (:,:)]  down diffuse flux below canopy per unit diffuse flux
+
+          netrad                     =>    energyflux_vars%netrad_patch                 & ! Output: [real(r8) (:)   ]  net radiation (positive downward) (W/m**2)
+          )
+
+       dtime = get_step_size()
+
+       do c = bounds%begc,bounds%endc
+          g = col_pp%gridcell(c)
+          l = col_pp%landunit(c)       
+
+          if (col_pp%itype(c) == icol_sunwall .or.  col_pp%itype(c) == icol_shadewall) then
+             forc_rain_col(c) = 0.
+             forc_snow_col(c) = 0.
+          else
+             forc_rain_col(c) = forc_rain(c)
+             forc_snow_col(c) = forc_snow(c)
+          end if
+       end do
+
+      do c = bounds%begc, bounds%endc
+
+         ! add qflx_drain_perched and qflx_flood
+         if (col_pp%active(c)) then
+
+            qflx_net_col(c) = &
+                 - forc_rain_col(c) - forc_snow_col(c)  - qflx_floodc(c) - qflx_irrig(c) &
+                 + qflx_evap_tot(c) + qflx_surf(c)  + qflx_h2osfc_surf(c) &
+                 + qflx_qrgwl(c) + qflx_drain(c) + qflx_drain_perched(c) + qflx_snwcp_ice(c) &
+                 + qflx_lateral(c)
+
+         else
+
+            qflx_net_col(c) = 0.0_r8
+
+         end if
+
+      end do
+
+      call c2g(bounds, endwb_col, endwb_grc, &
+           c2l_scale_type= 'unity', l2g_scale_type='unity' )
+
+      call c2g(bounds, qflx_net_col, qflx_net_grc, &
+           c2l_scale_type= 'unity', l2g_scale_type='unity' )
+
+    end associate
+
+    end subroutine GridBalanceCheck
+
+ end module BalanceCheckMod

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -785,12 +785,13 @@ contains
     type(waterstate_type)     , intent(inout) :: waterstate_vars
     !
     ! !LOCAL VARIABLES:
-    integer  :: c, p, f, j, fc                  ! indices
+    integer  :: c, p, f, j, fc,g                  ! indices
     real(r8) :: h2osoi_vol
     real(r8) :: h2ocan_col(bounds%begc:bounds%endc)
     real(r8) :: begwb_col (bounds%begc:bounds%endc)
     real(r8) :: h2osoi_liq_depth_intg(bounds%begc:bounds%endc)
     real(r8) :: h2osoi_ice_depth_intg(bounds%begc:bounds%endc)
+    real(r8) :: wa_local_col(bounds%begc:bounds%endc)
 
     associate(                                                                        &
          zi                        =>    col_pp%zi                                  , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
@@ -842,11 +843,15 @@ contains
          end do
       end if
 
+      wa_local_col(:) = wa(:)
+
       do f = 1, num_nolakec
          c = filter_nolakec(f)
+         g = col_pp%gridcell(c)
          if (col_pp%itype(c) == icol_roof .or. col_pp%itype(c) == icol_sunwall &
               .or. col_pp%itype(c) == icol_shadewall .or. col_pp%itype(c) == icol_road_imperv) then
             begwb_col(c) = h2ocan_col(c) + h2osno(c)
+            wa_local_col(c) = 0._r8
          else
             begwb_col(c) = h2ocan_col(c) + h2osno(c) + h2osfc(c) + wa(c)
          end if
@@ -876,13 +881,13 @@ contains
          enddo
       end do
 
-      call c2g(bounds, begwb_col             , begwb_grc          , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, wa                    , beg_wa_grc         , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2ocan_col            , beg_h2ocan_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2osno                , beg_h2osno_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2osfc                , beg_h2osfc_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2osoi_liq_depth_intg , beg_h2osoi_liq_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2osoi_ice_depth_intg , beg_h2osoi_ice_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, begwb_col             , begwb_grc          , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, wa_local_col          , beg_wa_grc         , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2ocan_col            , beg_h2ocan_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2osno                , beg_h2osno_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2osfc                , beg_h2osfc_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2osoi_liq_depth_intg , beg_h2osoi_liq_grc , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2osoi_ice_depth_intg , beg_h2osoi_ice_grc , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
       
     end associate
 
@@ -925,6 +930,7 @@ contains
      real(r8) :: qflx_net_col (bounds%begc:bounds%endc)
      real(r8) :: forc_rain_col(bounds%begc:bounds%endc) ! column level rain rate [mm/s]
      real(r8) :: forc_snow_col(bounds%begc:bounds%endc) ! column level snow rate [mm/s]
+     real(r8) :: wa_local_col(bounds%begc:bounds%endc)
 
      associate(                                                                         & 
           volr                       =>    atm2lnd_vars%volr_grc                      , & ! Input:  [real(r8) (:)   ]  river water storage (m3)                 
@@ -1033,6 +1039,8 @@ contains
 
        dtime = get_step_size()
 
+       wa_local_col(:) = wa(:)
+
        do c = bounds%begc,bounds%endc
           g = col_pp%gridcell(c)
           l = col_pp%landunit(c)       
@@ -1043,6 +1051,10 @@ contains
           else
              forc_rain_col(c) = forc_rain(c)
              forc_snow_col(c) = forc_snow(c)
+          end if
+          if (col_pp%itype(c) == icol_roof .or. col_pp%itype(c) == icol_sunwall &
+               .or. col_pp%itype(c) == icol_shadewall .or. col_pp%itype(c) == icol_road_imperv) then
+             wa_local_col(c) = 0._r8
           end if
        end do
 
@@ -1065,14 +1077,14 @@ contains
 
       end do
 
-      call c2g(bounds, endwb_col             , endwb_grc          , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, wa                    , end_wa_grc         , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2ocan_col            , end_h2ocan_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2osno_col            , end_h2osno_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2osfc_col            , end_h2osfc_grc     , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2osoi_liq_depth_intg , end_h2osoi_liq_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, h2osoi_ice_depth_intg , end_h2osoi_ice_grc , c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      call c2g(bounds, errh2o                , errh2o_grc         , c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      call c2g(bounds, endwb_col             , endwb_grc          , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, wa_local_col          , end_wa_grc         , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2ocan_col            , end_h2ocan_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2osno_col            , end_h2osno_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2osfc_col            , end_h2osfc_grc     , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2osoi_liq_depth_intg , end_h2osoi_liq_grc , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, h2osoi_ice_depth_intg , end_h2osoi_ice_grc , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+      call c2g(bounds, errh2o                , errh2o_grc         , c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
 
     end associate
 

--- a/components/clm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/clm/src/biogeophys/HydrologyDrainageMod.F90
@@ -89,6 +89,8 @@ contains
 
          wa                     => soilhydrology_vars%wa_col                  , & ! Input:  [real(r8) (:)   ]  water in the unconfined aquifer (mm)              
          
+         h2osoi_liq_depth_intg  => waterstate_vars%h2osoi_liq_depth_intg_col  , & ! Output: [real(r8) (:)   ]  grid-level depth integrated liquid soil water
+         h2osoi_ice_depth_intg  => waterstate_vars%h2osoi_ice_depth_intg_col  , & ! Output: [real(r8) (:)   ]  grid-level depth integrated ice soil water
          h2ocan                 => waterstate_vars%h2ocan_col                 , & ! Input:  [real(r8) (:)   ]  canopy water (mm H2O)                             
          h2osfc                 => waterstate_vars%h2osfc_col                 , & ! Input:  [real(r8) (:)   ]  surface water (mm)                                
          h2osno                 => waterstate_vars%h2osno_col                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)                               
@@ -178,6 +180,8 @@ contains
 
             else
                endwb(c) = endwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+               h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
+               h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j)
             end if
          end do
       end do

--- a/components/clm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/clm/src/biogeophys/LakeHydrologyMod.F90
@@ -143,6 +143,8 @@ contains
          do_capsnow           =>  waterstate_vars%do_capsnow_col        , & ! Input:  [logical  (:)   ]  true => do snow capping                  
          begwb                =>  waterstate_vars%begwb_col             , & ! Input:  [real(r8) (:)   ]  water mass begining of the time step    
          endwb                =>  waterstate_vars%endwb_col             , & ! Output: [real(r8) (:)   ]  water mass end of the time step         
+         h2osoi_liq_depth_intg=> waterstate_vars%h2osoi_liq_depth_intg_col, & ! Output: [real(r8) (:)   ]  grid-level depth integrated liquid soil water
+         h2osoi_ice_depth_intg=> waterstate_vars%h2osoi_ice_depth_intg_col, & ! Output: [real(r8) (:)   ]  grid-level depth integrated ice soil water
          snw_rds              =>  waterstate_vars%snw_rds_col           , & ! Output: [real(r8) (:,:) ]  effective snow grain radius (col,lyr) [microns, m^-6] 
          snw_rds_top          =>  waterstate_vars%snw_rds_top_col       , & ! Output: [real(r8) (:)   ]  effective snow grain size, top layer [microns] 
          h2osno_top           =>  waterstate_vars%h2osno_top_col        , & ! Output: [real(r8) (:)   ]  mass of snow in top layer [kg]    
@@ -216,6 +218,8 @@ contains
          do fc = 1, num_lakec
             c = filter_lakec(fc)
             begwb(c) = begwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+            h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
+            h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j)
          end do
       end do
 

--- a/components/clm/src/biogeophys/SoilHydrologyType.F90
+++ b/components/clm/src/biogeophys/SoilHydrologyType.F90
@@ -34,6 +34,8 @@ Module SoilHydrologyType
      real(r8), pointer :: zwts_col          (:)     ! col water table depth, the shallower of the two water depths     
      real(r8), pointer :: zwt_perched_col   (:)     ! col perched water table depth
      real(r8), pointer :: wa_col            (:)     ! col water in the unconfined aquifer (mm)
+     real(r8), pointer :: beg_wa_grc        (:)     ! grid-level water in the unconfined aquifer at beginning of the time step (mm)
+     real(r8), pointer :: end_wa_grc        (:)     ! grid-level water in the unconfined aquifer at end of the time step (mm)
      real(r8), pointer :: qflx_bot_col      (:)
      real(r8), pointer :: qcharge_col       (:)     ! col aquifer recharge rate (mm/s) 
      real(r8), pointer :: fracice_col       (:,:)   ! col fractional impermeability (-)
@@ -121,6 +123,8 @@ contains
     allocate(this%zwts_col          (begc:endc))                 ; this%zwts_col          (:)     = nan
 
     allocate(this%wa_col            (begc:endc))                 ; this%wa_col            (:)     = nan
+    allocate(this%beg_wa_grc        (begg:endg))                 ; this%beg_wa_grc        (:)     = nan
+    allocate(this%end_wa_grc        (begg:endg))                 ; this%end_wa_grc        (:)     = nan
     allocate(this%qcharge_col       (begc:endc))                 ; this%qcharge_col       (:)     = nan
     allocate(this%fracice_col       (begc:endc,nlevgrnd))        ; this%fracice_col       (:,:)   = nan
     allocate(this%icefrac_col       (begc:endc,nlevgrnd))        ; this%icefrac_col       (:,:)   = nan

--- a/components/clm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/clm/src/biogeophys/WaterBudgetMod.F90
@@ -107,10 +107,10 @@ module WaterBudgetMod
   character(*),parameter :: FA0= "('    ',12x,(3x,a10,2x),' | ',(3x,a10,2x))"
   character(*),parameter :: FF = "('    ',a12,f15.8,' | ',f15.8)"
   character(*),parameter :: FF2= "('    ',a12,a15,' | ',f15.8)"
-  character(*),parameter :: FS = "('    ',a12,6(f18.8),18x,' | ',(f18.8))"
+  character(*),parameter :: FS = "('    ',a12,6(f18.2),18x,' | ',(f18.2))"
   character(*),parameter :: FS0= "('    ',12x,7(a18),' | ',(a18))"
-  character(*),parameter :: FS2= "('    ',a12,54x,f18.8,54x,' | ',f18.8)"
-  character(*),parameter :: FS3= "('    ',a12,7(f18.8),' | ',(f18.8))"
+  character(*),parameter :: FS2= "('    ',a12,54x,f18.2,54x,' | ',f18.2)"
+  character(*),parameter :: FS3= "('    ',a12,7(f18.2),' | ',(f18.2))"
 
 contains
 
@@ -258,8 +258,8 @@ contains
           nf = s_wsliq_end ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
           nf = s_wsice_end ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
           nf = s_wwa_end   ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
-          nf = s_w_errh2o  ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
        endif
+       nf = s_w_errh2o  ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + budg_stateL(nf, p_inst)
     end do
     budg_fluxN(:,:) = budg_fluxN(:,:) + 1
     

--- a/components/clm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/clm/src/biogeophys/WaterBudgetMod.F90
@@ -208,7 +208,7 @@ contains
 !-----------------------------------------------------------------------
   subroutine WaterBudget_Accum()
     !
-    use clm_time_manager, only : get_curr_date, get_prev_date
+    use clm_time_manager, only : get_curr_date, get_prev_date, get_nstep
     !
     implicit none
     !
@@ -237,6 +237,7 @@ contains
           if (sec_prev == 0 .and. day_prev == 1 .and. month_prev == 1) update_state_beg = .true.
           if (sec_curr == 0 .and. day_curr == 1 .and. month_curr == 1) update_state_end = .true.
        case (p_inf)
+          if (get_nstep() == 1) update_state_beg = .true.
           update_state_end = .true.
        end select
 

--- a/components/clm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/clm/src/biogeophys/WaterBudgetMod.F90
@@ -457,11 +457,11 @@ contains
              write(iulog,FA0)'kg/m2s*1e6','kg/m2*1e6'
              write(iulog,'(32("-"),"|",20("-"))')
              do f = 1, f_size
-                write(iulog,FF)fname(f),budg_fluxGpr(f,ip),budg_fluxG(f,ip)*unit_conversion
+                write(iulog,FF)fname(f),budg_fluxGpr(f,ip),budg_fluxG(f,ip)*unit_conversion*get_step_size()
              end do
              write(iulog,'(32("-"),"|",20("-"))')
              write(iulog,FF)'   *SUM*', &
-                  sum(budg_fluxGpr(:,ip)), sum(budg_fluxG(:,ip))*unit_conversion
+                  sum(budg_fluxGpr(:,ip)), sum(budg_fluxG(:,ip))*unit_conversion*get_step_size()
              write(iulog,FF2)'*EXP CHANGE*', &
                   '            ',sum(budg_fluxG(:,ip))*unit_conversion*get_step_size()
              write(iulog,'(32("-"),"|",20("-"))')

--- a/components/clm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/clm/src/biogeophys/WaterBudgetMod.F90
@@ -428,9 +428,6 @@ contains
        if (ip==p_inf .and. mon==1 .and. day==1 .and. sec==0) then
           plev = max(plev,budg_print_ltann)
        endif
-       if (ip==p_inf) then
-          plev = max(plev,budg_print_ltend)
-       endif
 
        if (plev > 0) then
           unit_conversion = 1.d0/(4.0_r8*shr_const_pi)*1.0e6_r8
@@ -445,6 +442,7 @@ contains
           if (ip == p_day .and. get_nstep() == 1) cycle
           if (ip == p_mon .and. get_nstep() == 1) cycle
           if (ip == p_ann .and. get_nstep() == 1) cycle
+          if (ip == p_inf .and. get_nstep() == 1) cycle
 
           if (masterproc) then
              write(iulog,*)''
@@ -509,7 +507,6 @@ contains
                   -budg_stateG(s_w_errh2o ,ip) *unit_conversion, &
                   (budg_stateG(s_w_end     ,ip) - budg_stateG(s_w_beg     ,ip))*unit_conversion
              write(iulog,'(143("-"),"|",23("-"))')
-             !stop
           end if
        end if
     end do

--- a/components/clm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/clm/src/biogeophys/WaterBudgetMod.F90
@@ -323,7 +323,7 @@ contains
          nf = f_roff; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) &
               - qflx_rofliq_qsur(g)*af - qflx_rofliq_qsurp(g)*af &
               - qflx_rofliq_qsub(g)*af - qflx_rofliq_qsubp(g)*af &
-              - qflx_rofliq_qgwl(g)
+              - qflx_rofliq_qgwl(g)*af
          nf = f_ioff; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - qflx_rofice(g)*af
 
          nf = s_w_beg     ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + begwb_grc(g)          *af

--- a/components/clm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/clm/src/biogeophys/WaterBudgetMod.F90
@@ -581,6 +581,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     real(r8) :: budg_fluxGtmp(f_size,p_size) ! temporary sum
+    real(r8) :: budg_stateGtmp(s_size,p_size) ! temporary sum
     real(r8) :: budg_fluxG_1D (f_size*p_size)
     real(r8) :: budg_fluxN_1D (f_size*p_size)
     real(r8) :: budg_stateG_1D(s_size*p_size)
@@ -588,6 +589,7 @@ contains
     character(*),parameter :: subName = '(WaterBudget_Restart_Write) '
 
     call shr_mpi_sum(budg_fluxL, budg_fluxGtmp, mpicom, subName)
+    call shr_mpi_sum(budg_stateL, budg_stateGtmp, mpicom, subName)
 
     ! Copy data from 2D into 1D array
     count = 0
@@ -604,7 +606,7 @@ contains
     do s = 1, s_size
        do p = 1, p_size
           count = count + 1
-          budg_stateG_1D(count) = budg_stateG(s,p)
+          budg_stateG_1D(count) = budg_stateGtmp(s,p)
        end do
     end do
 
@@ -647,16 +649,15 @@ contains
     end do
 
     ! Copy data from 1D into 2D array
-    count = 0
-    do s = 1, s_size
-       do p = 1, p_size
-          count = count + 1
-          budg_stateG(s,p) = budg_stateG_1D(count)
-          if (masterproc) then
+    if (masterproc) then
+       count = 0
+       do s = 1, s_size
+          do p = 1, p_size
+             count = count + 1
              budg_stateL(s,p) = budg_stateG_1D(count)
-          end if
+          end do
        end do
-    end do
+    end if
 
   end subroutine WaterBudget_Restart_Read
 

--- a/components/clm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/clm/src/biogeophys/WaterBudgetMod.F90
@@ -463,8 +463,6 @@ contains
              write(iulog,'(32("-"),"|",20("-"))')
              write(iulog,FF)'   *SUM*', &
                   sum(budg_fluxGpr(:,ip)), sum(budg_fluxG(:,ip))*unit_conversion*get_step_size()
-             write(iulog,FF2)'*EXP CHANGE*', &
-                  '            ',sum(budg_fluxG(:,ip))*unit_conversion*get_step_size()
              write(iulog,'(32("-"),"|",20("-"))')
 
              write(iulog,*)''

--- a/components/clm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/clm/src/biogeophys/WaterBudgetMod.F90
@@ -105,7 +105,7 @@ module WaterBudgetMod
 
   !----- formats -----
   character(*),parameter :: FA0= "('    ',12x,(3x,a10,2x),' | ',(3x,a10,2x))"
-  character(*),parameter :: FF = "('    ',a12,f15.8,' | ',f15.8)"
+  character(*),parameter :: FF = "('    ',a12,f15.8,' | ',f18.2)"
   character(*),parameter :: FF2= "('    ',a12,a15,' | ',f18.2)"
   character(*),parameter :: FS = "('    ',a12,6(f18.2),18x,' | ',(f18.2))"
   character(*),parameter :: FS0= "('    ',12x,7(a18),' | ',(a18))"

--- a/components/clm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/clm/src/biogeophys/WaterBudgetMod.F90
@@ -106,7 +106,7 @@ module WaterBudgetMod
   !----- formats -----
   character(*),parameter :: FA0= "('    ',12x,(3x,a10,2x),' | ',(3x,a10,2x))"
   character(*),parameter :: FF = "('    ',a12,f15.8,' | ',f15.8)"
-  character(*),parameter :: FF2= "('    ',a12,a15,' | ',f15.8)"
+  character(*),parameter :: FF2= "('    ',a12,a15,' | ',f18.2)"
   character(*),parameter :: FS = "('    ',a12,6(f18.2),18x,' | ',(f18.2))"
   character(*),parameter :: FS0= "('    ',12x,7(a18),' | ',(a18))"
   character(*),parameter :: FS2= "('    ',a12,54x,f18.2,54x,' | ',f18.2)"

--- a/components/clm/src/biogeophys/WaterStateType.F90
+++ b/components/clm/src/biogeophys/WaterStateType.F90
@@ -104,6 +104,21 @@ module WaterstateType
      real(r8), pointer :: errh2o_col             (:)   ! water conservation error (mm H2O)
      real(r8), pointer :: errh2osno_col          (:)   ! snow water conservation error(mm H2O)
 
+     real(r8), pointer :: h2osoi_liq_depth_intg_col(:) ! grid-level depth integrated liquid soil water
+     real(r8), pointer :: h2osoi_ice_depth_intg_col(:) ! grid-level depth integrated ice soil water
+
+     real(r8), pointer :: beg_h2ocan_grc         (:)   ! grid-level canopy water at begining of the time step (mm H2O)
+     real(r8), pointer :: beg_h2osno_grc         (:)   ! grid-level snow water at begining of the time step (mm H2O)
+     real(r8), pointer :: beg_h2osfc_grc         (:)   ! grid-level surface water at begining of the time step (mm H2O)
+     real(r8), pointer :: beg_h2osoi_liq_grc     (:)   ! grid-level liquid water at begining of the time step (kg/m2)
+     real(r8), pointer :: beg_h2osoi_ice_grc     (:)   ! grid-level ice lens at begining of the time step (kg/m2)
+
+     real(r8), pointer :: end_h2ocan_grc         (:)   ! grid-level canopy water at end of the time step (mm H2O)
+     real(r8), pointer :: end_h2osno_grc         (:)   ! grid-level snow water at end of the time step (mm H2O)
+     real(r8), pointer :: end_h2osfc_grc         (:)   ! grid-level surface water at end of the time step (mm H2O)
+     real(r8), pointer :: end_h2osoi_liq_grc     (:)   ! grid-level liquid water at end of the time step (kg/m2)
+     real(r8), pointer :: end_h2osoi_ice_grc     (:)   ! grid-level ice lens at end of the time step (kg/m2)
+
      ! For VSFM
      real(r8), pointer :: vsfm_fliq_col_1d       (:)   ! fraction of liquid saturation for VSFM [-]
      real(r8), pointer :: vsfm_sat_col_1d        (:)   ! liquid saturation from VSFM [-]
@@ -250,6 +265,21 @@ contains
     allocate(this%errh2o_patch           (begp:endp))                     ; this%errh2o_patch           (:)   = nan
     allocate(this%errh2o_col             (begc:endc))                     ; this%errh2o_col             (:)   = nan
     allocate(this%errh2osno_col          (begc:endc))                     ; this%errh2osno_col          (:)   = nan
+
+    allocate(this%h2osoi_liq_depth_intg_col(begc:endc))                   ; this%h2osoi_liq_depth_intg_col(:) = nan
+    allocate(this%h2osoi_ice_depth_intg_col(begc:endc))                   ; this%h2osoi_ice_depth_intg_col(:) = nan
+
+    allocate(this%beg_h2ocan_grc          (begg:endg))                    ; this%beg_h2ocan_grc         (:)   = nan
+    allocate(this%beg_h2osno_grc          (begg:endg))                    ; this%beg_h2osno_grc         (:)   = nan
+    allocate(this%beg_h2osfc_grc          (begg:endg))                    ; this%beg_h2osfc_grc         (:)   = nan
+    allocate(this%beg_h2osoi_liq_grc      (begg:endg))                    ; this%beg_h2osoi_liq_grc     (:)   = nan
+    allocate(this%beg_h2osoi_ice_grc      (begg:endg))                    ; this%beg_h2osoi_ice_grc     (:)   = nan
+
+    allocate(this%end_h2ocan_grc          (begg:endg))                    ; this%end_h2ocan_grc         (:)   = nan
+    allocate(this%end_h2osno_grc          (begg:endg))                    ; this%end_h2osno_grc         (:)   = nan
+    allocate(this%end_h2osfc_grc          (begg:endg))                    ; this%end_h2osfc_grc         (:)   = nan
+    allocate(this%end_h2osoi_liq_grc      (begg:endg))                    ; this%end_h2osoi_liq_grc     (:)   = nan
+    allocate(this%end_h2osoi_ice_grc      (begg:endg))                    ; this%end_h2osoi_ice_grc     (:)   = nan
 
     ncells = (endc - begc + 1)*nlevgrnd
     allocate(this%vsfm_fliq_col_1d(          ncells))                     ; this%vsfm_fliq_col_1d       (:)   = nan

--- a/components/clm/src/biogeophys/WaterStateType.F90
+++ b/components/clm/src/biogeophys/WaterStateType.F90
@@ -102,6 +102,7 @@ module WaterstateType
      real(r8), pointer :: endwb_grc              (:)   ! water mass end of the time step
      real(r8), pointer :: errh2o_patch           (:)   ! water conservation error (mm H2O)
      real(r8), pointer :: errh2o_col             (:)   ! water conservation error (mm H2O)
+     real(r8), pointer :: errh2o_grc             (:)   ! water conservation error (mm H2O)
      real(r8), pointer :: errh2osno_col          (:)   ! snow water conservation error(mm H2O)
 
      real(r8), pointer :: h2osoi_liq_depth_intg_col(:) ! grid-level depth integrated liquid soil water
@@ -264,6 +265,7 @@ contains
     allocate(this%endwb_grc              (begg:endg))                     ; this%endwb_grc              (:)   = nan
     allocate(this%errh2o_patch           (begp:endp))                     ; this%errh2o_patch           (:)   = nan
     allocate(this%errh2o_col             (begc:endc))                     ; this%errh2o_col             (:)   = nan
+    allocate(this%errh2o_grc             (begg:endg))                     ; this%errh2o_grc             (:)   = nan
     allocate(this%errh2osno_col          (begc:endc))                     ; this%errh2osno_col          (:)   = nan
 
     allocate(this%h2osoi_liq_depth_intg_col(begc:endc))                   ; this%h2osoi_liq_depth_intg_col(:) = nan

--- a/components/clm/src/biogeophys/WaterStateType.F90
+++ b/components/clm/src/biogeophys/WaterStateType.F90
@@ -96,8 +96,10 @@ module WaterstateType
 
      real(r8), pointer :: begwb_patch            (:)   ! water mass begining of the time step
      real(r8), pointer :: begwb_col              (:)   ! water mass begining of the time step
+     real(r8), pointer :: begwb_grc              (:)   ! water mass begining of the time step
      real(r8), pointer :: endwb_patch            (:)   ! water mass end of the time step
      real(r8), pointer :: endwb_col              (:)   ! water mass end of the time step
+     real(r8), pointer :: endwb_grc              (:)   ! water mass end of the time step
      real(r8), pointer :: errh2o_patch           (:)   ! water conservation error (mm H2O)
      real(r8), pointer :: errh2o_col             (:)   ! water conservation error (mm H2O)
      real(r8), pointer :: errh2osno_col          (:)   ! snow water conservation error(mm H2O)
@@ -241,8 +243,10 @@ contains
 
     allocate(this%begwb_patch            (begp:endp))                     ; this%begwb_patch            (:)   = nan
     allocate(this%begwb_col              (begc:endc))                     ; this%begwb_col              (:)   = nan
+    allocate(this%begwb_grc              (begg:endg))                     ; this%begwb_grc              (:)   = nan
     allocate(this%endwb_patch            (begp:endp))                     ; this%endwb_patch            (:)   = nan
     allocate(this%endwb_col              (begc:endc))                     ; this%endwb_col              (:)   = nan
+    allocate(this%endwb_grc              (begg:endg))                     ; this%endwb_grc              (:)   = nan
     allocate(this%errh2o_patch           (begp:endp))                     ; this%errh2o_patch           (:)   = nan
     allocate(this%errh2o_col             (begc:endc))                     ; this%errh2o_col             (:)   = nan
     allocate(this%errh2osno_col          (begc:endc))                     ; this%errh2osno_col          (:)   = nan

--- a/components/clm/src/biogeophys/WaterStateType.F90
+++ b/components/clm/src/biogeophys/WaterStateType.F90
@@ -57,7 +57,8 @@ module WaterstateType
      real(r8), pointer :: ice1_grc               (:)   ! grc initial gridcell total h2o ice content
      real(r8), pointer :: ice2_grc               (:)   ! grc post land cover change total ice content
      real(r8), pointer :: tws_grc                (:)   ! grc total water storage (mm H2O)
-
+     real(r8), pointer :: tws_month_beg_grc      (:)   ! grc total water storage at the beginning of a month
+     real(r8), pointer :: tws_month_end_grc      (:)   ! grc total water storage at the end of a month
 
      real(r8), pointer :: total_plant_stored_h2o_col(:) ! col water that is bound in plants, including roots, sapwood, leaves, etc
                                                         ! in most cases, the vegetation scheme does not have a dynamic
@@ -228,6 +229,8 @@ contains
     allocate(this%ice1_grc               (begg:endg))                     ; this%ice1_grc               (:)   = nan
     allocate(this%ice2_grc               (begg:endg))                     ; this%ice2_grc               (:)   = nan
     allocate(this%tws_grc                (begg:endg))                     ; this%tws_grc                (:)   = nan
+    allocate(this%tws_month_beg_grc      (begg:endg))                     ; this%tws_month_beg_grc      (:)   = nan
+    allocate(this%tws_month_end_grc      (begg:endg))                     ; this%tws_month_end_grc      (:)   = nan
 
     allocate(this%total_plant_stored_h2o_col(begc:endc))                  ; this%total_plant_stored_h2o_col(:) = nan
 
@@ -393,6 +396,16 @@ contains
     call hist_addfld1d (fname='TWS',  units='mm',  &
          avgflag='A', long_name='total water storage', &
          ptr_lnd=this%tws_grc)
+
+    this%tws_month_beg_grc(begg:endg) = spval
+    call hist_addfld1d (fname='TWS_MONTH_BEGIN',  units='mm',  &
+         avgflag='I', long_name='total water storage at the beginning of a month', &
+         ptr_lnd=this%tws_month_beg_grc)
+
+    this%tws_month_end_grc(begg:endg) = spval
+    call hist_addfld1d (fname='TWS_MONTH_END',  units='mm',  &
+         avgflag='I', long_name='total water storage at the end of a month', &
+         ptr_lnd=this%tws_month_end_grc)
 
     ! Humidity
 
@@ -827,6 +840,7 @@ contains
     use clm_varctl       , only : bound_h2osoi
     use ncdio_pio        , only : file_desc_t, ncd_io, ncd_double
     use restUtilMod
+    use subgridAveMod    , only : c2g
     !
     ! !ARGUMENTS:
     class(waterstate_type) :: this
@@ -1031,6 +1045,17 @@ contains
             dim1name='column', &
             long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%wf_col) 
+    end if
+
+    call restartvar(ncid=ncid, flag=flag, varname='TWS_MONTH_BEGIN', xtype=ncd_double,  &
+         dim1name='gridcell', &
+         long_name='surface watertotal water storage at the beginning of a month', units='mm', &
+          interpinic_flag='interp', readvar=readvar, data=this%tws_month_beg_grc)
+
+    if (flag=='read') then
+       if (.not. readvar) then
+          this%tws_month_beg_grc(bounds%begg:bounds%endg) = 0.0_r8
+       end if
     end if
 
   end subroutine Restart

--- a/components/clm/src/biogeophys/WaterStateType.F90
+++ b/components/clm/src/biogeophys/WaterStateType.F90
@@ -1052,11 +1052,9 @@ contains
          long_name='surface watertotal water storage at the beginning of a month', units='mm', &
           interpinic_flag='interp', readvar=readvar, data=this%tws_month_beg_grc)
 
-    if (flag=='read') then
-       if (.not. readvar) then
-          this%tws_month_beg_grc(bounds%begg:bounds%endg) = 0.0_r8
-       end if
-    end if
+    call restartvar(ncid=ncid, flag=flag, varname='ENDWB_COL', xtype=ncd_double, &
+         dim1name='column', long_name='col-level water mass end of the time step', &
+         units='mm', interpinic_flag='interp', readvar=readvar, data=this%endwb_col)
 
   end subroutine Restart
 

--- a/components/clm/src/biogeophys/WaterfluxType.F90
+++ b/components/clm/src/biogeophys/WaterfluxType.F90
@@ -461,61 +461,45 @@ contains
          avgflag='A', long_name='excess snowfall due to snow capping not including correction for land use change', &
          ptr_col=this%qflx_snwcp_ice_col, c2l_scale_type='urbanf')
 
-    if (use_cn) then
-       this%qflx_rain_grnd_patch(begp:endp) = spval
-       call hist_addfld1d (fname='QFLX_RAIN_GRND', units='mm H2O/s', &
-            avgflag='A', long_name='rain on ground after interception', &
-            ptr_patch=this%qflx_rain_grnd_patch, default='inactive', c2l_scale_type='urbanf')
-    end if
+    this%qflx_rain_grnd_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QFLX_RAIN_GRND', units='mm H2O/s', &
+         avgflag='A', long_name='rain on ground after interception', &
+         ptr_patch=this%qflx_rain_grnd_patch, default='inactive', c2l_scale_type='urbanf')
 
-    if (use_cn) then
-       this%qflx_snow_grnd_patch(begp:endp) = spval
-       call hist_addfld1d (fname='QFLX_SNOW_GRND', units='mm H2O/s', &
-            avgflag='A', long_name='snow on ground after interception', &
-            ptr_patch=this%qflx_snow_grnd_patch, default='inactive', c2l_scale_type='urbanf')
-    end if
+    this%qflx_snow_grnd_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QFLX_SNOW_GRND', units='mm H2O/s', &
+         avgflag='A', long_name='snow on ground after interception', &
+         ptr_patch=this%qflx_snow_grnd_patch, default='inactive', c2l_scale_type='urbanf')
 
-    if (use_cn) then
-       this%qflx_evap_grnd_patch(begp:endp) = spval
-       call hist_addfld1d (fname='QFLX_EVAP_GRND', units='mm H2O/s', &
-            avgflag='A', long_name='ground surface evaporation', &
-            ptr_patch=this%qflx_evap_grnd_patch, default='inactive', c2l_scale_type='urbanf')
-    end if
+    this%qflx_evap_grnd_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QFLX_EVAP_GRND', units='mm H2O/s', &
+         avgflag='A', long_name='ground surface evaporation', &
+         ptr_patch=this%qflx_evap_grnd_patch, default='inactive', c2l_scale_type='urbanf')
 
-    if (use_cn) then
-       this%qflx_evap_veg_patch(begp:endp) = spval
-       call hist_addfld1d (fname='QFLX_EVAP_VEG', units='mm H2O/s', &
-            avgflag='A', long_name='vegetation evaporation', &
-            ptr_patch=this%qflx_evap_veg_patch, default='inactive', c2l_scale_type='urbanf')
-    end if
+    this%qflx_evap_veg_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QFLX_EVAP_VEG', units='mm H2O/s', &
+         avgflag='A', long_name='vegetation evaporation', &
+         ptr_patch=this%qflx_evap_veg_patch, default='inactive', c2l_scale_type='urbanf')
 
-    if (use_cn) then
-       this%qflx_evap_tot_patch(begp:endp) = spval
-       call hist_addfld1d (fname='QFLX_EVAP_TOT', units='mm H2O/s', &
-            avgflag='A', long_name='qflx_evap_soi + qflx_evap_can + qflx_tran_veg', &
-            ptr_patch=this%qflx_evap_tot_patch, default='inactive', c2l_scale_type='urbanf')
-    end if
+    this%qflx_evap_tot_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QFLX_EVAP_TOT', units='mm H2O/s', &
+         avgflag='A', long_name='qflx_evap_soi + qflx_evap_can + qflx_tran_veg', &
+         ptr_patch=this%qflx_evap_tot_patch, c2l_scale_type='urbanf')
 
-    if (use_cn) then
-       this%qflx_dew_grnd_patch(begp:endp) = spval
-       call hist_addfld1d (fname='QFLX_DEW_GRND', units='mm H2O/s', &
-            avgflag='A', long_name='ground surface dew formation', &
-            ptr_patch=this%qflx_dew_grnd_patch, default='inactive', c2l_scale_type='urbanf')
-    end if
+    this%qflx_dew_grnd_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QFLX_DEW_GRND', units='mm H2O/s', &
+         avgflag='A', long_name='ground surface dew formation', &
+         ptr_patch=this%qflx_dew_grnd_patch, default='inactive', c2l_scale_type='urbanf')
 
-    if (use_cn) then
-       this%qflx_sub_snow_patch(begp:endp) = spval
-       call hist_addfld1d (fname='QFLX_SUB_SNOW', units='mm H2O/s', &
-            avgflag='A', long_name='sublimation rate from snow pack', &
-            ptr_patch=this%qflx_sub_snow_patch, default='inactive', c2l_scale_type='urbanf')
-    end if
+    this%qflx_sub_snow_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QFLX_SUB_SNOW', units='mm H2O/s', &
+         avgflag='A', long_name='sublimation rate from snow pack', &
+         ptr_patch=this%qflx_sub_snow_patch, default='inactive', c2l_scale_type='urbanf')
 
-    if (use_cn) then
-       this%qflx_dew_snow_patch(begp:endp) = spval
-       call hist_addfld1d (fname='QFLX_DEW_SNOW', units='mm H2O/s', &
-            avgflag='A', long_name='surface dew added to snow pacK', &
-            ptr_patch=this%qflx_dew_snow_patch, default='inactive', c2l_scale_type='urbanf')
-    end if
+    this%qflx_dew_snow_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QFLX_DEW_SNOW', units='mm H2O/s', &
+         avgflag='A', long_name='surface dew added to snow pacK', &
+         ptr_patch=this%qflx_dew_snow_patch, default='inactive', c2l_scale_type='urbanf')
 
     this%qflx_h2osfc_surf_col(begc:endc) = spval
     call hist_addfld1d (fname='QH2OSFC',  units='mm/s',  &

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -142,6 +142,8 @@ module clm_driver
   use clm_interface_pflotranMod   , only : clm_pf_finalize
   !----------------------------------------------------------------------------
   use WaterBudgetMod              , only : WaterBudget_Reset, WaterBudget_Run, WaterBudget_Accum, WaterBudget_Print
+  use WaterBudgetMod              , only : WaterBudget_SetBeginningMonthlyStates
+  use WaterBudgetMod              , only : WaterBudget_SetEndingMonthlyStates
   use clm_varctl                  , only : do_budgets, budget_inst, budget_daily, budget_month
   use clm_varctl                  , only : budget_ann, budget_ltann, budget_ltend
 
@@ -385,6 +387,9 @@ contains
             filter(nc)%num_hydrologyc, filter(nc)%hydrologyc, &
             soilhydrology_vars, waterstate_vars)
        call t_stopf('begwbal')
+       if (do_budgets) then
+          call WaterBudget_SetBeginningMonthlyStates(bounds_clump, waterstate_vars)
+       endif
     end do
     !$OMP END PARALLEL DO
 
@@ -1106,6 +1111,8 @@ contains
             waterstate_vars, energyflux_vars, canopystate_vars        , &
             soilhydrology_vars)
        call t_stopf('gridbalchk')
+
+       call WaterBudget_SetEndingMonthlyStates(bounds_proc, waterstate_vars)
 
        if (.not. use_ed)then
           if (use_cn) then

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -1294,6 +1294,17 @@ contains
     end if
 
     ! ============================================================================
+    ! Compute water budget
+    ! ============================================================================
+    if (get_nstep()>0 .and. do_budgets) then
+       call WaterBudget_Run(bounds_proc, atm2lnd_vars, lnd2atm_vars, waterstate_vars, &
+            soilhydrology_vars)
+       call WaterBudget_Accum()
+       call WaterBudget_Print(budget_inst,  budget_daily,  budget_month,  &
+            budget_ann,  budget_ltann,  budget_ltend)
+    endif
+
+    ! ============================================================================
     ! History/Restart output
     ! ============================================================================
 
@@ -1350,14 +1361,6 @@ contains
        call t_stopf('clm_drv_io')
 
     end if
-
-    if (get_nstep()>0 .and. do_budgets) then
-       call WaterBudget_Run(bounds_proc, atm2lnd_vars, lnd2atm_vars, waterstate_vars, &
-            soilhydrology_vars)
-       call WaterBudget_Accum()
-       call WaterBudget_Print(budget_inst,  budget_daily,  budget_month,  &
-            budget_ann,  budget_ltann,  budget_ltend)
-    endif
 
     if (use_pflotran .and. nstep>=nestep) then
        call clm_pf_finalize()

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -1112,7 +1112,7 @@ contains
             soilhydrology_vars)
        call t_stopf('gridbalchk')
 
-       call WaterBudget_SetEndingMonthlyStates(bounds_proc, waterstate_vars)
+       call WaterBudget_SetEndingMonthlyStates(bounds_clump, waterstate_vars)
 
        if (.not. use_ed)then
           if (use_cn) then

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -1103,7 +1103,8 @@ contains
        call GridBalanceCheck(bounds_clump                             , &
             filter(nc)%num_do_smb_c, filter(nc)%do_smb_c              , &
             atm2lnd_vars, glc2lnd_vars, solarabs_vars, waterflux_vars , &
-            waterstate_vars, energyflux_vars, canopystate_vars)
+            waterstate_vars, energyflux_vars, canopystate_vars        , &
+            soilhydrology_vars)
        call t_stopf('gridbalchk')
 
        if (.not. use_ed)then
@@ -1351,7 +1352,8 @@ contains
     end if
 
     if (get_nstep()>0 .and. do_budgets) then
-       call WaterBudget_Run(bounds_proc, atm2lnd_vars, lnd2atm_vars, waterstate_vars)
+       call WaterBudget_Run(bounds_proc, atm2lnd_vars, lnd2atm_vars, waterstate_vars, &
+            soilhydrology_vars)
        call WaterBudget_Accum()
        call WaterBudget_Print(budget_inst,  budget_daily,  budget_month,  &
             budget_ann,  budget_ltann,  budget_ltend)

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -24,6 +24,7 @@ module clm_driver
   !
   use dynSubgridDriverMod    , only : dynSubgrid_driver
   use BalanceCheckMod        , only : BeginWaterBalance, BalanceCheck
+  use BalanceCheckMod        , only : BeginGridWaterBalance, GridBalanceCheck
   !
   use CanopyTemperatureMod   , only : CanopyTemperature ! (formerly Biogeophysics1Mod)
   use SoilTemperatureMod     , only : SoilTemperature
@@ -140,6 +141,9 @@ module clm_driver
   use clm_interface_pflotranMod   , only : clm_pf_run, clm_pf_write_restart
   use clm_interface_pflotranMod   , only : clm_pf_finalize
   !----------------------------------------------------------------------------
+  use WaterBudgetMod              , only : WaterBudget_Reset, WaterBudget_Run, WaterBudget_Accum, WaterBudget_Print
+  use clm_varctl                  , only : do_budgets, budget_inst, budget_daily, budget_month
+  use clm_varctl                  , only : budget_ann, budget_ltann, budget_ltend
 
   !
   ! !PUBLIC TYPES:
@@ -208,6 +212,8 @@ contains
 
     call get_proc_bounds(bounds_proc)
     nclumps = get_proc_clumps()
+    
+    if (do_budgets) call WaterBudget_Reset()
 
     ! Update time-related info
 
@@ -286,6 +292,14 @@ contains
     !$OMP PARALLEL DO PRIVATE (nc,bounds_clump)
     do nc = 1,nclumps
        call get_clump_bounds(nc, bounds_clump)
+
+       call t_startf('beggridwbal')
+       call BeginGridWaterBalance(bounds_clump,               &
+            filter(nc)%num_nolakec, filter(nc)%nolakec,       &
+            filter(nc)%num_lakec, filter(nc)%lakec,           &
+            filter(nc)%num_hydrologyc, filter(nc)%hydrologyc, &
+            soilhydrology_vars, waterstate_vars)
+       call t_stopf('beggridwbal')
 
        if (use_betr) then
          dtime=get_step_size(); nstep=get_nstep()
@@ -1085,6 +1099,13 @@ contains
             waterstate_vars, energyflux_vars, canopystate_vars)
        call t_stopf('balchk')
 
+       call t_startf('gridbalchk')
+       call GridBalanceCheck(bounds_clump                             , &
+            filter(nc)%num_do_smb_c, filter(nc)%do_smb_c              , &
+            atm2lnd_vars, glc2lnd_vars, solarabs_vars, waterflux_vars , &
+            waterstate_vars, energyflux_vars, canopystate_vars)
+       call t_stopf('gridbalchk')
+
        if (.not. use_ed)then
           if (use_cn) then
              nstep = get_nstep()
@@ -1328,6 +1349,13 @@ contains
        call t_stopf('clm_drv_io')
 
     end if
+
+    if (get_nstep()>0 .and. do_budgets) then
+       call WaterBudget_Run(bounds_proc, atm2lnd_vars, lnd2atm_vars, waterstate_vars)
+       call WaterBudget_Accum()
+       call WaterBudget_Print(budget_inst,  budget_daily,  budget_month,  &
+            budget_ann,  budget_ltann,  budget_ltend)
+    endif
 
     if (use_pflotran .and. nstep>=nestep) then
        call clm_pf_finalize()

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -30,6 +30,8 @@ module clm_initializeMod
   use ColumnType             , only : col_pp                
   use VegetationType         , only : veg_pp                
   use clm_instMod
+  use WaterBudgetMod         , only : WaterBudget_Reset
+  use clm_varctl             , only : do_budgets
   !
   implicit none
   save
@@ -466,6 +468,8 @@ contains
     !----------------------------------------------------------------------
 
     call t_startf('clm_init2')
+
+    if (do_budgets) call WaterBudget_Reset('all')
 
     ! ------------------------------------------------------------------------
     ! Determine processor bounds and clumps for this processor

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -370,6 +370,16 @@ module clm_varctl
    character(len=fname_len), public :: aero_file      = ' '    ! aerosol deposition file for CPL_BYPASS mode
 
 
+  !----------------------------------------------------------
+  ! Budgets
+  !----------------------------------------------------------
+   logical, public :: do_budgets   = .false.
+   integer, public :: budget_inst  = 0
+   integer, public :: budget_daily = 0
+   integer, public :: budget_month = 1
+   integer, public :: budget_ann   = 1
+   integer, public :: budget_ltann = 1
+   integer, public :: budget_ltend = 0
 contains
 
   !---------------------------------------------------------------------------

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -265,6 +265,10 @@ contains
     namelist /clm_inparm/ &
          use_petsc_thermal_model
 
+    namelist /clm_inparm/ &
+         do_budgets, budget_inst, budget_daily, budget_month, &
+         budget_ann, budget_ltann, budget_ltend
+
     ! ----------------------------------------------------------------------
     ! Default values
     ! ----------------------------------------------------------------------
@@ -767,6 +771,15 @@ contains
 
     ! PETSc-based thermal model
     call mpi_bcast (use_petsc_thermal_model, 1, MPI_LOGICAL, 0, mpicom, ier)
+
+    ! Budget
+    call mpi_bcast (do_budgets   , 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (budget_inst  , 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (budget_daily , 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (budget_month , 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (budget_ann   , 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (budget_ltann , 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (budget_ltend , 1, MPI_INTEGER, 0, mpicom, ier)
 
   end subroutine control_spmd
 

--- a/components/clm/src/main/restFileMod.F90
+++ b/components/clm/src/main/restFileMod.F90
@@ -109,6 +109,7 @@ contains
     ! Define/write CLM restart file.
     !
     use WaterBudgetMod, only : WaterBudget_Restart
+    use clm_varctl    , only : do_budgets
     !
     implicit none
     !
@@ -274,7 +275,9 @@ contains
        call hist_restart_ncd (bounds, ncid, flag='define', rdate=rdate )
     end if
 
-    call WaterBudget_Restart(bounds, ncid, flag='define')
+    if (do_budgets) then
+       call WaterBudget_Restart(bounds, ncid, flag='define')
+    end if
 
     call restFile_enddef( ncid )
 
@@ -384,7 +387,9 @@ contains
 
     call hist_restart_ncd (bounds, ncid, flag='write' )
 
-    call WaterBudget_Restart(bounds, ncid, flag='write')
+    if (do_budgets) then
+       call WaterBudget_Restart(bounds, ncid, flag='write')
+    end if
 
     ! --------------------------------------------
     ! Close restart file and write restart pointer file

--- a/components/clm/src/main/restFileMod.F90
+++ b/components/clm/src/main/restFileMod.F90
@@ -108,6 +108,10 @@ contains
     ! !DESCRIPTION:
     ! Define/write CLM restart file.
     !
+    use WaterBudgetMod, only : WaterBudget_Restart
+    !
+    implicit none
+    !
     ! !ARGUMENTS:
     type(bounds_type)              , intent(in)    :: bounds          
     character(len=*)               , intent(in)    :: file             ! output netcdf restart file
@@ -270,6 +274,8 @@ contains
        call hist_restart_ncd (bounds, ncid, flag='define', rdate=rdate )
     end if
 
+    call WaterBudget_Restart(bounds, ncid, flag='define')
+
     call restFile_enddef( ncid )
 
     ! --------------------------------------------
@@ -378,6 +384,8 @@ contains
 
     call hist_restart_ncd (bounds, ncid, flag='write' )
 
+    call WaterBudget_Restart(bounds, ncid, flag='write')
+
     ! --------------------------------------------
     ! Close restart file and write restart pointer file
     ! --------------------------------------------
@@ -421,6 +429,7 @@ contains
     use decompMod        , only : get_proc_clumps, get_clump_bounds
     use decompMod        , only : bounds_type
     use reweightMod      , only : reweight_wrapup
+    use WaterBudgetMod   , only : WaterBudget_Restart
     !
     ! !ARGUMENTS:
     character(len=*)               , intent(in)    :: file  ! output netcdf restart file
@@ -585,6 +594,8 @@ contains
     endif
         
     call hist_restart_ncd (bounds, ncid, flag='read')
+
+    call WaterBudget_Restart(bounds, ncid, flag='read')
 
     ! Do error checking on file
     
@@ -848,6 +859,8 @@ contains
     use clm_varpar           , only : cft_lb, cft_ub, maxpatch_glcmec
     use dynSubgridControlMod , only : get_flanduse_timeseries
     use decompMod            , only : get_proc_global
+    use clm_varctl           , only : do_budgets
+    use WaterBudgetMod       , only : f_size, s_size, p_size
     !
     ! !ARGUMENTS:
     type(file_desc_t), intent(inout) :: ncid
@@ -889,6 +902,11 @@ contains
     call ncd_defdim(ncid , 'levtrc'  , nlevtrc_full   ,  dimid)    
     if (create_glacier_mec_landunit) then
        call ncd_defdim(ncid , 'glc_nec', maxpatch_glcmec, dimid)
+    end if
+
+    if (do_budgets) then
+       call ncd_defdim(ncid , 'budg_flux' , f_size*p_size,  dimid)
+       call ncd_defdim(ncid , 'budg_state', s_size*p_size,  dimid)
     end if
 
     ! Define global attributes


### PR DESCRIPTION
Following improvements to the water budget in the land model are added:
- Fixes the incorrect update of water state of unconfined aquifer at the beginning
   of the land driver. This fix improves the net water budget in the fully coupled
   simulation.
- Calculation of a grid-level water budget is now included.
- Diagnostics about water budget can be now outputted in the land logfiles
   by setting `do_budgets=.true.` in usr_nl_clm. The diagnostics includes:
   - Temporally integrated water fluxes over a given period (e.g. instantaneus,
      daily, monthly, annual, all-time). This diagnostic information is similar to
      the information outputted in the coupler logfile if `BUDGETS=TRUE` in
      env_run.xml.
   - Water states at the beginning and end of the integration period. This diagnostic
      information includes water stored in various land components (i.e. soil moisture, 
     canopy storage, etc).
- Additional data is saved in land monthly history tapes to recreate the land
  water diagnostics from model output.
- Additional data is saved in land restart file to support output of land water
   diagnostics when a simulation restarts in the middle of a month.

[non-BFB]