### PR TITLE
Use intel erf function implementation on knl and some EAM routines

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -2040,6 +2040,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <FFLAGS>
     <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent</base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align -fp-speculation=off</append>
+    <append> -DHAVE_ERF_INTRINSICS </append>
   </FFLAGS>
   <SCC> icc </SCC>
   <SCXX> icpc </SCXX>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1125,6 +1125,7 @@ for mct, etc.
     <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml </base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align</append>
     <append MPILIB="impi"> -xMIC-AVX512 </append>
+    <append> -DHAVE_ERF_INTRINSICS </append>
   </FFLAGS>
   <MPICC MPILIB="impi"> mpiicc </MPICC>
   <MPICXX MPILIB="impi"> mpiicpc </MPICXX>

--- a/cime/src/share/util/shr_spfn_mod.F90
+++ b/cime/src/share/util/shr_spfn_mod.F90
@@ -11,7 +11,7 @@
 ! Intel also has them (and Cray), but as of mid-2015, our implementation is
 ! actually faster, in part because they do not properly vectorize, so we
 ! pretend that the compiler version doesn't exist.
-#if defined CPRIBM || defined __GFORTRAN__ || defined CPRINTEL
+#if defined CPRIBM || defined __GFORTRAN__
 #define HAVE_GAMMA_INTRINSICS
 #define HAVE_ERF_INTRINSICS
 #endif

--- a/cime/src/share/util/shr_spfn_mod.F90
+++ b/cime/src/share/util/shr_spfn_mod.F90
@@ -11,7 +11,7 @@
 ! Intel also has them (and Cray), but as of mid-2015, our implementation is
 ! actually faster, in part because they do not properly vectorize, so we
 ! pretend that the compiler version doesn't exist.
-#if defined CPRIBM || defined __GFORTRAN__
+#if defined CPRIBM || defined __GFORTRAN__ || defined CPRINTEL
 #define HAVE_GAMMA_INTRINSICS
 #define HAVE_ERF_INTRINSICS
 #endif

--- a/components/cam/src/physics/cam/hetfrz_classnuc.F90
+++ b/components/cam/src/physics/cam/hetfrz_classnuc.F90
@@ -22,7 +22,9 @@ module hetfrz_classnuc
 
 use shr_kind_mod,  only: r8 => shr_kind_r8
 use wv_saturation, only: svp_water, svp_ice
+#ifndef HAVE_ERF_INTRINSICS
 use shr_spfn_mod,  only: erf => shr_spfn_erf
+#endif
 
 implicit none
 private

--- a/components/cam/src/physics/cam/ndrop.F90
+++ b/components/cam/src/physics/cam/ndrop.F90
@@ -22,7 +22,9 @@ use physics_buffer,   only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
 use wv_saturation,    only: qsat
 use phys_control,     only: phys_getopts
 use ref_pres,         only: top_lev => trop_cloud_top_lev
+#if !defined(CPRINTEL)
 use shr_spfn_mod,     only: erf => shr_spfn_erf
+#endif
 use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num, rad_cnst_get_aer_mmr, &
                             rad_cnst_get_aer_props, rad_cnst_get_mode_props,                &
                             rad_cnst_get_mam_mmr_idx, rad_cnst_get_mode_num_idx

--- a/components/cam/src/physics/cam/ndrop.F90
+++ b/components/cam/src/physics/cam/ndrop.F90
@@ -22,7 +22,7 @@ use physics_buffer,   only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
 use wv_saturation,    only: qsat
 use phys_control,     only: phys_getopts
 use ref_pres,         only: top_lev => trop_cloud_top_lev
-#if !defined(CPRINTEL)
+#ifndef HAVE_ERF_INTRINSICS
 use shr_spfn_mod,     only: erf => shr_spfn_erf
 #endif
 use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num, rad_cnst_get_aer_mmr, &

--- a/components/cam/src/physics/cam/ndrop_bam.F90
+++ b/components/cam/src/physics/cam/ndrop_bam.F90
@@ -14,9 +14,10 @@ use physconst,        only: gravit, rair, tmelt, cpair, rh2o, &
      r_universal, mwh2o, rhoh2o, latvap
 
 use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_aer_props
-
+#ifndef HAVE_ERF_INTRINSICS
 use shr_spfn_mod,     only: erf => shr_spfn_erf, &
                             erfc => shr_spfn_erfc
+#endif
 use wv_saturation,    only: qsat
 use cam_history,      only: addfld, add_default, outfld 
 use cam_logfile,      only: iulog

--- a/components/cam/src/physics/cam/nucleate_ice_cam.F90
+++ b/components/cam/src/physics/cam/nucleate_ice_cam.F90
@@ -24,8 +24,9 @@ use cam_history,    only: addfld, add_default, outfld
 
 use ref_pres,       only: top_lev => trop_cloud_top_lev
 use wv_saturation,  only: qsat_water
+#ifndef HAVE_ERF_INTRINSICS
 use shr_spfn_mod,   only: erf => shr_spfn_erf
-
+#endif
 use cam_logfile,    only: iulog
 use cam_abortutils, only: endrun
 

--- a/components/cam/src/physics/cam/unicon.F90
+++ b/components/cam/src/physics/cam/unicon.F90
@@ -26,7 +26,9 @@ module unicon
 
 use shr_kind_mod,    only : r8 => shr_kind_r8, i4 => shr_kind_i4
 use cam_history,     only : outfld
+#ifndef HAVE_ERF_INTRINSICS
 use shr_spfn_mod,    only : erfc => shr_spfn_erfc
+#endif
 use time_manager,    only : get_nstep
 use cam_abortutils,  only : endrun
 use cam_logfile,     only : iulog

--- a/components/cam/src/physics/cam/uwshcu.F90
+++ b/components/cam/src/physics/cam/uwshcu.F90
@@ -2,7 +2,9 @@
 module uwshcu
 
   use cam_history,    only: outfld, addfld
+#ifndef HAVE_ERF_INTRINSICS
   use shr_spfn_mod,   only: erfc => shr_spfn_erfc
+#endif
   use cam_logfile,    only: iulog
   use ppgrid,         only: pcols, pver, pverp
   use cam_abortutils,     only: endrun


### PR DESCRIPTION
Currently, the intel erf implementation is disabled. As described in
cime/src/share/util/shr_spfn_mod.F90, this is due to its slow
performance. But now, the test case, such as
SMS_PS_Ld2.ne120_ne120.FC5AV1C-H01A, indicate using intel implementation
on KNL is much faster. The timer "dropmixnuc" time has been reduced 1/3 (from
67 seconds to 45 seconds).

[non-BFB] for any atmosphere case on KNL with Intel.