### PR TITLE
Add E3SM-ARRM (Arctic refined) grid configuration

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -2571,6 +2571,7 @@
     <gridmap ocn_grid="oQU480" rof_grid="r05">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oQU480_nn.180702.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oQU480_nn.180702.nc</map>
+    </gridmap>
 
     <gridmap ocn_grid="oQU240" rof_grid="r05">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oQU240_nn.160714.nc</map>

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -359,6 +359,26 @@
       <mask>oRRS15to5</mask>
     </model_grid>
 
+    <model_grid alias="T62_oARRM60to10" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oARRM60to10</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oARRM60to10</mask>
+    </model_grid>
+
+    <model_grid alias="T62_oARRM60to6" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oARRM60to6</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oARRM60to6</mask>
+    </model_grid>
+
     <!-- finite volume grids -->
 
     <model_grid alias="f02_g16">
@@ -1381,6 +1401,8 @@
       <file grid="atm|lnd" mask="oRRS18to6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS18to6.160831.nc</file>
       <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS18to6v3.170111.nc</file>
       <file grid="atm|lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS15to5.150722.nc</file>
+      <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to10.180716.nc</file>
+      <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to6.180803.nc</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
@@ -1609,6 +1631,20 @@
       <ny>1</ny>
       <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS18to6v3.170111.nc</file>
       <desc>oRRS18to6v3_ICG is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 18 km gridcells at low and 6 km gridcells at high latitudes.  This version of initial conditions is spun-up from a G compset run:</desc>
+    </domain>
+
+    <domain name="oARRM60to10">
+      <nx>619264</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oARRM60to10.180716.nc</file>
+      <desc>oARRM60to10 is an Arctic-Region-Refined MPAS ocean grid with 30 km gridcells at -90 deg latitude, 60 km gridcells at -40 deg latitude, 30 km gridcells at the equator, and 10 km gridcells at 90 deg latitude; North Atlantic and North Pacific have different resolution between 0 and 60 deg latitudes:</desc>
+    </domain>
+
+    <domain name="oARRM60to6">
+      <nx>1208625</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oARRM60to6.180803.nc</file>
+      <desc>oARRM60to6 is an Arctic-Region-Refined MPAS ocean grid with 30 km gridcells at -90 deg latitude, 60 km gridcells at -40 deg latitude, 30 km gridcells at the equator, and 6 km gridcells at 90 deg latitude; North Atlantic and North Pacific have different resolution between 0 and 60 deg latitudes:</desc>
     </domain>
 
     <!-- ROF (river) grids-->
@@ -2194,6 +2230,22 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_TO_T62_aave.150722.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="T62" ocn_grid="oARRM60to10">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to10_aave.180715.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to10_blin.180715.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to10_patc.180715.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to10/map_oARRM60to10_TO_T62_aave.180715.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to10/map_oARRM60to10_TO_T62_aave.180715.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="T62" ocn_grid="oARRM60to6">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to6_aave.180803.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to6_blin.180803.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to6_patc.180803.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_TO_T62_aave.180803.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_TO_T62_aave.180803.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="T31" ocn_grid="gx3v7">
       <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_T31_to_gx3v7_aave_da_090903.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</map>
@@ -2506,10 +2558,19 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS15to5_nn.160527.nc</map>
     </gridmap>
 
+    <gridmap ocn_grid="oARRM60to10" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oARRM60to10_smoothed.r150e300.180718.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oARRM60to10_smoothed.r150e300.180718.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="oARRM60to6" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oARRM60to6_smoothed.r150e300.180816.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oARRM60to6_smoothed.r150e300.180816.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="oQU480" rof_grid="r05">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oQU480_nn.180702.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oQU480_nn.180702.nc</map>
-    </gridmap>
 
     <gridmap ocn_grid="oQU240" rof_grid="r05">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oQU240_nn.160714.nc</map>

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -232,10 +232,10 @@
       <arg flag="--account" name="$PROJECT"/>
     </submit_args>
     <directives>
-      <directive> --job-name={{ job_id }}</directive>
-      <directive> --nodes={{ num_nodes }}</directive>
-      <directive> --output={{ job_id }}.%j </directive>
-      <directive> --exclusive </directive>
+      <directive>--job-name={{ job_id }}</directive>
+      <directive>--nodes={{ num_nodes }}</directive>
+      <directive>--output={{ job_id }}.%j </directive>
+      <directive>--exclusive </directive>
     </directives>
   </batch_system>
 
@@ -258,10 +258,10 @@
       <arg flag="--account" name="$PROJECT"/>
     </submit_args>
     <directives>
-      <directive> --job-name={{ job_id }}</directive>
-      <directive> --nodes={{ num_nodes }}</directive>
-      <directive> --output={{ job_id }}.%j </directive>
-      <directive> --exclusive </directive>
+      <directive>--job-name={{ job_id }}</directive>
+      <directive>--nodes={{ num_nodes }}</directive>
+      <directive>--output={{ job_id }}.%j </directive>
+      <directive>--exclusive </directive>
     </directives>
   </batch_system>
 
@@ -419,6 +419,17 @@
     <directives>
       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
     </directives>
+  </batch_system>
+
+  <batch_system MACH="badger" type="slurm" >
+	<directives>
+		<directive>--nodes={{ num_nodes }}</directive>
+		<directive>--ntasks-per-node={{ tasks_per_node }}</directive>
+		<directive>--qos=standard </directive>
+	</directives>
+	<queues>
+		<queue walltimemax="16:00:00" default="true">standard</queue>
+	</queues>
   </batch_system>
 
   <batch_system MACH="grizzly" type="slurm" >

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -425,10 +425,10 @@
 	<directives>
 		<directive>--nodes={{ num_nodes }}</directive>
 		<directive>--ntasks-per-node={{ tasks_per_node }}</directive>
-		<directive>--qos=standard </directive>
+		<directive>--qos=interactive</directive>
 	</directives>
 	<queues>
-		<queue walltimemax="16:00:00" default="true">standard</queue>
+		<queue walltimemax="4:00:00" default="true">standard</queue>
 	</queues>
   </batch_system>
 

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1990,9 +1990,13 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SFC>gfortran</SFC>
         <SCC>gcc</SCC>
         <SCXX>g++</SCXX>
-        <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
-        <ADD_SLIBS> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</ADD_SLIBS>
-        <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
+        <SLIBS>
+          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+	  <append> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</append>
+	</SLIBS>
+        <CXX_LIBS>
+	  <base>-lstdc++ -lmpi_cxx</base>
+	</CXX_LIBS>
 </compiler>
 
 <compiler MACH="badger" COMPILER="intel">
@@ -2003,12 +2007,24 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SFC>ifort</SFC>
         <SCC>icc</SCC>
         <SCXX>icpc</SCXX>
-        <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
-        <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
-        <ADD_CFLAGS compile_threaded="true"> -qopenmp </ADD_CFLAGS>
-        <ADD_FFLAGS compile_threaded="true"> -qopenmp </ADD_FFLAGS>
-        <ADD_LDFLAGS compile_threaded="true"> -qopenmp </ADD_LDFLAGS>
-        <ADD_FFLAGS_NOOPT compile_threaded="true"> -qopenmp </ADD_FFLAGS_NOOPT>
+        <SLIBS>
+          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+	</SLIBS>
+        <CXX_LIBS>
+	  <base>-lstdc++ -lmpi_cxx</base>
+	</CXX_LIBS>
+        <CFLAGS>
+	  <base> compile_threaded="true"> -qopenmp </base>
+        </CFLAGS>
+        <FFLAGS>
+	  <base> compile_threaded="true"> -qopenmp </base>
+	</FFLAGS>
+	<LDFLAGS>
+	  <base> compile_threaded="true"> -qopenmp </base>
+	</LDFLAGS>
+	<FFLAGS_NOOPT>
+	  <base> compile_threaded="true"> -qopenmp </base>
+	</FFLAGS_NOOPT>
 </compiler>
 
 <compiler MACH="grizzly" COMPILER="gnu">
@@ -2019,9 +2035,13 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SFC>gfortran</SFC>
         <SCC>gcc</SCC>
         <SCXX>g++</SCXX>
-        <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
-        <ADD_SLIBS> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</ADD_SLIBS>
-        <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
+        <SLIBS>
+          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+	  <append> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</append>
+	</SLIBS>
+        <CXX_LIBS>
+	  <base>-lstdc++ -lmpi_cxx</base>
+	</CXX_LIBS>
 </compiler>
 
 <compiler MACH="grizzly" COMPILER="intel">
@@ -2032,20 +2052,63 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SFC>ifort</SFC>
         <SCC>icc</SCC>
         <SCXX>icpc</SCXX>
-        <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
-        <ADD_SLIBS> -mkl -lpthread </ADD_SLIBS>
-        <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
+        <SLIBS>
+          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+	  <append> -mkl -lpthread </append>
+	</SLIBS>
+        <CXX_LIBS>
+	  <base>-lstdc++ -lmpi_cxx</base>
+	</CXX_LIBS>
 </compiler>
 
 <compiler MACH="wolf" COMPILER="pgi">
-	<MPICC>mpicc</MPICC>
-	<MPIFC>mpif90</MPIFC>
-	<MPICXX>mpic++</MPICXX>
-	<SFC>pgfortran</SFC>
-	<SCC>pgcc</SCC>
-	<SCXX>pgc++</SCXX>
-	<ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
-	<TRILINOS_PATH>$(TRILINOS_PATH)</TRILINOS_PATH>
+        <MPICC>mpicc</MPICC>
+        <MPIFC>mpif90</MPIFC>
+        <MPICXX>mpic++</MPICXX>
+        <SFC>pgfortran</SFC>
+        <SCC>pgcc</SCC>
+        <SCXX>pgc++</SCXX>
+        <SLIBS>
+          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+	</SLIBS>
+        <TRILINOS_PATH>$(TRILINOS_PATH)</TRILINOS_PATH>
+</compiler>
+
+<compiler MACH="wolf" COMPILER="intel">
+        <MPICC>mpicc</MPICC>
+        <MPIFC>mpif90</MPIFC>
+        <MPICXX>mpic++</MPICXX>
+        <SFC>ifort</SFC>
+        <SCC>icc</SCC>
+        <SCXX>icpc</SCXX>
+        <TRILINOS_PATH>$(TRILINOS_PATH)</TRILINOS_PATH>
+        <SLIBS>
+          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+	  <append> MPILIB="mpich"> -mkl=cluster </append>
+	  <append> MPILIB="mpich2"> -mkl=cluster </append>
+	  <append> MPILIB="mpt"> -mkl=cluster </append>
+	  <append> MPILIB="openmpi"> -mkl=cluster </append>
+	  <append> MPILIB="mvapich"> -mkl=cluster </append>
+	  <append> MPILIB="impi"> -mkl=cluster </append>
+	  <append> MPILIB="mpi-serial"> -mkl </append>
+	</SLIBS>
+</compiler>
+
+<compiler MACH="wolf" COMPILER="gnu">
+        <MPICC>mpicc</MPICC>
+        <MPIFC>mpif90</MPIFC>
+        <MPICXX>mpic++</MPICXX>
+        <SFC>gfortran</SFC>
+        <SCC>gcc</SCC>
+        <SCXX>g++</SCXX>
+        <SLIBS>
+          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+	</SLIBS>
+        <CXX_LIBS>
+	  <base>-lstdc++ -lmpi_cxx</base>
+	</CXX_LIBS>
+        <TRILINOS_PATH>$(TRILINOS_PATH)</TRILINOS_PATH>
+        <ALBANY_PATH>$(ALBANY_PATH)</ALBANY_PATH>
 </compiler>
 
 <compiler MACH="userdefined">
@@ -2063,56 +2126,6 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <SLIBS>
     <append># USERDEFINED $SHELL{$NETCDF_PATH/bin/nf-config --flibs}</append>
   </SLIBS>
-</compiler>
-
-<compiler MACH="wolf" COMPILER="gnu">
-  <ALBANY_PATH>$ENV{ALBANY_PATH}</ALBANY_PATH>
-  <CXX_LIBS>
-    <base>-lstdc++ -lmpi_cxx</base>
-  </CXX_LIBS>
-  <MPICC>mpicc</MPICC>
-  <MPICXX>mpic++</MPICXX>
-  <MPIFC>mpif90</MPIFC>
-  <SCC>gcc</SCC>
-  <SCXX>g++</SCXX>
-  <SFC>gfortran</SFC>
-  <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
-  </SLIBS>
-  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
-</compiler>
-
-<compiler MACH="wolf" COMPILER="intel">
-  <MPICC>mpicc</MPICC>
-  <MPICXX>mpic++</MPICXX>
-  <MPIFC>mpif90</MPIFC>
-  <SCC>icc</SCC>
-  <SCXX>icpc</SCXX>
-  <SFC>ifort</SFC>
-  <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
-    <append MPILIB="mpich"> -mkl=cluster </append>
-    <append MPILIB="mpich2"> -mkl=cluster </append>
-    <append MPILIB="mpt"> -mkl=cluster </append>
-    <append MPILIB="openmpi"> -mkl=cluster </append>
-    <append MPILIB="mvapich"> -mkl=cluster </append>
-    <append MPILIB="impi"> -mkl=cluster </append>
-    <append MPILIB="mpi-serial"> -mkl </append>
-  </SLIBS>
-  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
-</compiler>
-
-<compiler MACH="wolf" COMPILER="pgi">
-  <MPICC>mpicc</MPICC>
-  <MPICXX>mpic++</MPICXX>
-  <MPIFC>mpif90</MPIFC>
-  <SCC>pgcc</SCC>
-  <SCXX>pgc++</SCXX>
-  <SFC>pgfortran</SFC>
-  <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
-  </SLIBS>
-  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 </config_compilers>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1991,8 +1991,8 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SCC>gcc</SCC>
         <SCXX>g++</SCXX>
         <SLIBS>
-          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
-	  <append> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</append>
+          <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
+	  <append>$ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</append>
 	</SLIBS>
         <CXX_LIBS>
 	  <base>-lstdc++ -lmpi_cxx</base>
@@ -2008,22 +2008,22 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SCC>icc</SCC>
         <SCXX>icpc</SCXX>
         <SLIBS>
-          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+          <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
 	</SLIBS>
         <CXX_LIBS>
 	  <base>-lstdc++ -lmpi_cxx</base>
 	</CXX_LIBS>
         <CFLAGS>
-	  <base> compile_threaded="true"> -qopenmp </base>
+	  <base>compile_threaded="true"> -qopenmp</base>
         </CFLAGS>
         <FFLAGS>
-	  <base> compile_threaded="true"> -qopenmp </base>
+	  <base>compile_threaded="true"> -qopenmp</base>
 	</FFLAGS>
 	<LDFLAGS>
-	  <base> compile_threaded="true"> -qopenmp </base>
+	  <base>compile_threaded="true"> -qopenmp</base>
 	</LDFLAGS>
 	<FFLAGS_NOOPT>
-	  <base> compile_threaded="true"> -qopenmp </base>
+	  <base>compile_threaded="true"> -qopenmp</base>
 	</FFLAGS_NOOPT>
 </compiler>
 
@@ -2036,8 +2036,8 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SCC>gcc</SCC>
         <SCXX>g++</SCXX>
         <SLIBS>
-          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
-	  <append> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</append>
+	  <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
+	  <append>$ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</append>
 	</SLIBS>
         <CXX_LIBS>
 	  <base>-lstdc++ -lmpi_cxx</base>
@@ -2053,8 +2053,8 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SCC>icc</SCC>
         <SCXX>icpc</SCXX>
         <SLIBS>
-          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
-	  <append> -mkl -lpthread </append>
+          <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
+	  <append>-mkl -lpthread</append>
 	</SLIBS>
         <CXX_LIBS>
 	  <base>-lstdc++ -lmpi_cxx</base>
@@ -2069,9 +2069,9 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SCC>pgcc</SCC>
         <SCXX>pgc++</SCXX>
         <SLIBS>
-          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+          <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
 	</SLIBS>
-        <TRILINOS_PATH>$(TRILINOS_PATH)</TRILINOS_PATH>
+        <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 <compiler MACH="wolf" COMPILER="intel">
@@ -2081,16 +2081,16 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SFC>ifort</SFC>
         <SCC>icc</SCC>
         <SCXX>icpc</SCXX>
-        <TRILINOS_PATH>$(TRILINOS_PATH)</TRILINOS_PATH>
+        <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
         <SLIBS>
-          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
-	  <append> MPILIB="mpich"> -mkl=cluster </append>
-	  <append> MPILIB="mpich2"> -mkl=cluster </append>
-	  <append> MPILIB="mpt"> -mkl=cluster </append>
-	  <append> MPILIB="openmpi"> -mkl=cluster </append>
-	  <append> MPILIB="mvapich"> -mkl=cluster </append>
-	  <append> MPILIB="impi"> -mkl=cluster </append>
-	  <append> MPILIB="mpi-serial"> -mkl </append>
+          <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
+	  <append>MPILIB="mpich"> -mkl=cluster</append>
+	  <append>MPILIB="mpich2"> -mkl=cluster</append>
+	  <append>MPILIB="mpt"> -mkl=cluster</append>
+	  <append>MPILIB="openmpi"> -mkl=cluster</append>
+	  <append>MPILIB="mvapich"> -mkl=cluster</append>
+	  <append>MPILIB="impi"> -mkl=cluster</append>
+	  <append>MPILIB="mpi-serial"> -mkl</append>
 	</SLIBS>
 </compiler>
 
@@ -2102,13 +2102,13 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SCC>gcc</SCC>
         <SCXX>g++</SCXX>
         <SLIBS>
-          <append> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas </append>
+          <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
 	</SLIBS>
         <CXX_LIBS>
 	  <base>-lstdc++ -lmpi_cxx</base>
 	</CXX_LIBS>
-        <TRILINOS_PATH>$(TRILINOS_PATH)</TRILINOS_PATH>
-        <ALBANY_PATH>$(ALBANY_PATH)</ALBANY_PATH>
+        <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
+        <ALBANY_PATH>$ENV{ALBANY_PATH}</ALBANY_PATH>
 </compiler>
 
 <compiler MACH="userdefined">

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1241,39 +1241,6 @@ for mct, etc.
   </SLIBS>
 </compiler>
 
-<compiler MACH="grizzly" COMPILER="gnu">
-  <CXX_LIBS>
-    <base>-lstdc++ -lmpi_cxx</base>
-  </CXX_LIBS>
-  <MPICC>mpicc</MPICC>
-  <MPICXX>mpic++</MPICXX>
-  <MPIFC>mpif90</MPIFC>
-  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <SCC>gcc</SCC>
-  <SCXX>g++</SCXX>
-  <SFC>gfortran</SFC>
-  <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
-    <append> $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</append>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="grizzly" COMPILER="intel">
-  <CXX_LIBS>
-    <base>-lstdc++ -lmpi_cxx</base>
-  </CXX_LIBS>
-  <MPICC>mpicc</MPICC>
-  <MPICXX>mpic++</MPICXX>
-  <MPIFC>mpif90</MPIFC>
-  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <SCC>icc</SCC>
-  <SCXX>icpc</SCXX>
-  <SFC>ifort</SFC>
-  <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
-  </SLIBS>
-</compiler>
-
 <compiler MACH="itasca" COMPILER="intel">
   <CFLAGS>
     <base> -O2 -fp-model precise -I/soft/intel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
@@ -2013,6 +1980,60 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} </append>
   </SLIBS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+</compiler>
+
+<compiler MACH="badger" COMPILER="gnu">
+	<PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+        <MPICC>mpicc</MPICC>
+        <MPIFC>mpif90</MPIFC>
+        <MPICXX>mpic++</MPICXX>
+        <SFC>gfortran</SFC>
+        <SCC>gcc</SCC>
+        <SCXX>g++</SCXX>
+        <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
+        <ADD_SLIBS> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</ADD_SLIBS>
+        <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
+</compiler>
+
+<compiler MACH="badger" COMPILER="intel">
+	<PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+        <MPICC>mpicc</MPICC>
+        <MPIFC>mpif90</MPIFC>
+        <MPICXX>mpic++</MPICXX>
+        <SFC>ifort</SFC>
+        <SCC>icc</SCC>
+        <SCXX>icpc</SCXX>
+        <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
+        <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
+</compiler>
+
+<compiler MACH="grizzly" COMPILER="gnu">
+	<PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+        <MPICC>mpicc</MPICC>
+        <MPIFC>mpif90</MPIFC>
+        <MPICXX>mpic++</MPICXX>
+        <SFC>gfortran</SFC>
+        <SCC>gcc</SCC>
+        <SCXX>g++</SCXX>
+        <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
+        <ADD_SLIBS> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -z muldefs</ADD_SLIBS>
+        <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
+</compiler>
+
+<compiler MACH="grizzly" COMPILER="intel">
+  <CXX_LIBS>
+    <base>-lstdc++ -lmpi_cxx</base>
+  </CXX_LIBS>
+  <MPICC>mpicc</MPICC>
+  <MPICXX>mpic++</MPICXX>
+  <MPIFC>mpif90</MPIFC>
+  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+  <SCC>icc</SCC>
+  <SCXX>icpc</SCXX>
+  <SFC>ifort</SFC>
+  <SLIBS>
+    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
+  </SLIBS>
 </compiler>
 
 <compiler MACH="userdefined">

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -2005,6 +2005,10 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
         <SCXX>icpc</SCXX>
         <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
         <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
+        <ADD_CFLAGS compile_threaded="true"> -qopenmp </ADD_CFLAGS>
+        <ADD_FFLAGS compile_threaded="true"> -qopenmp </ADD_FFLAGS>
+        <ADD_LDFLAGS compile_threaded="true"> -qopenmp </ADD_LDFLAGS>
+        <ADD_FFLAGS_NOOPT compile_threaded="true"> -qopenmp </ADD_FFLAGS_NOOPT>
 </compiler>
 
 <compiler MACH="grizzly" COMPILER="gnu">
@@ -2021,19 +2025,27 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
 </compiler>
 
 <compiler MACH="grizzly" COMPILER="intel">
-  <CXX_LIBS>
-    <base>-lstdc++ -lmpi_cxx</base>
-  </CXX_LIBS>
-  <MPICC>mpicc</MPICC>
-  <MPICXX>mpic++</MPICXX>
-  <MPIFC>mpif90</MPIFC>
-  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <SCC>icc</SCC>
-  <SCXX>icpc</SCXX>
-  <SFC>ifort</SFC>
-  <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
-  </SLIBS>
+	<PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+        <MPICC>mpicc</MPICC>
+        <MPIFC>mpif90</MPIFC>
+        <MPICXX>mpic++</MPICXX>
+        <SFC>ifort</SFC>
+        <SCC>icc</SCC>
+        <SCXX>icpc</SCXX>
+        <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
+        <ADD_SLIBS> -mkl -lpthread </ADD_SLIBS>
+        <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
+</compiler>
+
+<compiler MACH="wolf" COMPILER="pgi">
+	<MPICC>mpicc</MPICC>
+	<MPIFC>mpif90</MPIFC>
+	<MPICXX>mpic++</MPICXX>
+	<SFC>pgfortran</SFC>
+	<SCC>pgcc</SCC>
+	<SCXX>pgc++</SCXX>
+	<ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -llapack -lblas</ADD_SLIBS>
+	<TRILINOS_PATH>$(TRILINOS_PATH)</TRILINOS_PATH>
 </compiler>
 
 <compiler MACH="userdefined">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2306,7 +2306,7 @@
         <NODENAME_REGEX>ba-fe.*.lanl.gov</NODENAME_REGEX>
         <TESTS>e3sm_developer</TESTS>
         <COMPILERS>gnu,intel</COMPILERS>
-        <MPILIBS>mvapich,openmpi</MPILIBS>
+        <MPILIBS>openmpi,mvapich</MPILIBS>
 	<OS>LINUX</OS>
 	<RUNDIR>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/cases/$CASE/run</RUNDIR>
 	<EXEROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/cases/$CASE/bld</EXEROOT>
@@ -2337,7 +2337,7 @@
 			<command name="load">gcc/6.4.0</command>
 		</modules>
 		<modules compiler="intel">
-			<command name="load">intel/18.0.2</command>
+			<command name="load">intel/17.0.4</command>
 		</modules>
 		<modules mpilib="openmpi">
 			<command name="load">openmpi/2.1.2</command>
@@ -2355,6 +2355,10 @@
 	<environment_variables>
 		<env name="PNETCDF_HINTS">romio_ds_write=disable;romio_ds_read=disable;romio_cb_write=enable;romio_cb_read=enable</env>
 	</environment_variables>
+
+        <environment_variables compiler="gnu">
+		<env name="MKLROOT">/opt/intel/17.0/mkl</env>
+        </environment_variables>
 
 	<BATCH_SYSTEM>slurm</BATCH_SYSTEM>
 	<mpirun mpilib="default">
@@ -2436,10 +2440,17 @@
 		<modules>
 			<command name="load">parallel-netcdf/1.5.0</command>
 		</modules>
+		<modules>
+			<command name="load">mkl</command>
+		</modules>
 	</module_system>
 	<environment_variables>
 		<env name="PNETCDF_HINTS">romio_ds_write=disable;romio_ds_read=disable;romio_cb_write=enable;romio_cb_read=enable</env>
 	</environment_variables>
+
+        <environment_variables compiler="gnu">
+		<env name="MKLROOT">/opt/intel/17.0/mkl</env>
+        </environment_variables>
 
 	<BATCH_SYSTEM>slurm</BATCH_SYSTEM>
 	<mpirun mpilib="default">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -666,12 +666,12 @@
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-    <DIN_LOC_ROOT>/sems-data-store/ACME/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/sems-data-store/ACME/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT>/sems-data-store/E3SM/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/sems-data-store/E3SM/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-    <BASELINE_ROOT>/sems-data-store/ACME/baselines/$COMPILER</BASELINE_ROOT>
-    <SAVE_TIMING_DIR>/sems-data-store/ACME/timings</SAVE_TIMING_DIR>
+    <BASELINE_ROOT>/sems-data-store/E3SM/baselines/$COMPILER</BASELINE_ROOT>
+    <SAVE_TIMING_DIR>/sems-data-store/E3SM/timings</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
     <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build.new/cprnc</CCSM_CPRNC>
     <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
@@ -1045,8 +1045,8 @@
 	 <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
          <DIN_LOC_ROOT>/home/ccsm-data/inputdata</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-         <DOUT_S_ROOT>/lcrc/project/ACME/$USER/archive/$CASE</DOUT_S_ROOT>
-         <DOUT_L_MSROOT>/lcrc/project/ACME/$USER/archive/$CASE</DOUT_L_MSROOT>
+         <DOUT_S_ROOT>/lcrc/project/E3SM/$USER/archive/$CASE</DOUT_S_ROOT>
+         <DOUT_L_MSROOT>/lcrc/project/E3SM/$USER/archive/$CASE</DOUT_L_MSROOT>
          <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/blues/$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/home/ccsm-data/tools/cprnc</CCSM_CPRNC>
          <OS>LINUX</OS>
@@ -1056,7 +1056,7 @@
          <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
 	 <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
          <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-	 <PROJECT>ACME</PROJECT>
+	 <PROJECT>E3SM</PROJECT>
          <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
          <mpirun mpilib="mvapich">
            <executable>mpiexec</executable>
@@ -1150,7 +1150,7 @@
          <DIN_LOC_ROOT>/home/ccsm-data/inputdata</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/lcrc/group/acme/$USER/archive/$CASE</DOUT_S_ROOT>
-         <DOUT_L_MSROOT>/lcrc/project/ACME/$USER/archive/$CASE</DOUT_L_MSROOT>
+         <DOUT_L_MSROOT>/lcrc/project/E3SM/$USER/archive/$CASE</DOUT_L_MSROOT>
          <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/home/ccsm-data/tools/cprnc</CCSM_CPRNC>
          <OS>LINUX</OS>
@@ -1160,7 +1160,7 @@
          <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
 	 <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
          <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-	 <PROJECT>ACME</PROJECT>
+	 <PROJECT>E3SM</PROJECT>
          <mpirun mpilib="openmpi">
            <executable>mpiexec</executable>
            <arguments>
@@ -1461,7 +1461,7 @@
          <DESC>LLNL Linux Cluster, Linux (pgi), 36 pes/node, batch system is Slurm</DESC>
          <COMPILERS>intel</COMPILERS>
          <MPILIBS>mpich</MPILIBS>
-         <RUNDIR>/p/lscratchh/$CCSMUSER/ACME/$CASE/run</RUNDIR>
+         <RUNDIR>/p/lscratchh/$CCSMUSER/E3SM/$CASE/run</RUNDIR>
          <EXEROOT>/p/lscratchh/$CCSMUSER/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/p/lscratchh/$USER</CIME_OUTPUT_ROOT>
          <DIN_LOC_ROOT>/usr/gdata/climdat/ccsm3data/inputdata</DIN_LOC_ROOT>
@@ -1962,12 +1962,12 @@
          <TESTS>e3sm_developer</TESTS>
          <COMPILERS>gnu</COMPILERS>
          <MPILIBS>mpich,openmpi</MPILIBS>
-         <RUNDIR>/home/$USER/models/ACME/run/$CASE/run</RUNDIR>
-         <EXEROOT>/home/$USER/models/ACME/run/$CASE/bld</EXEROOT>
-         <CIME_OUTPUT_ROOT>/home/$USER/models/ACME</CIME_OUTPUT_ROOT>
+         <RUNDIR>/home/$USER/models/E3SM/run/$CASE/run</RUNDIR>
+         <EXEROOT>/home/$USER/models/E3SM/run/$CASE/bld</EXEROOT>
+         <CIME_OUTPUT_ROOT>/home/$USER/models/E3SM</CIME_OUTPUT_ROOT>
          <DIN_LOC_ROOT>/home/zdr/models/ccsm_inputdata</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/home/zdr/models/ccsm_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-         <DOUT_S_ROOT>/home/$USER/models/ACME/run/archive/$CASE</DOUT_S_ROOT>
+         <DOUT_S_ROOT>/home/$USER/models/E3SM/run/archive/$CASE</DOUT_S_ROOT>
          <OS>LINUX</OS>
 	 <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
          <SUPPORTED_BY>dmricciuto</SUPPORTED_BY>
@@ -1999,8 +1999,8 @@
       <CIME_OUTPUT_ROOT>/lustre/or-hydra/cades-ccsi/scratch/$USER</CIME_OUTPUT_ROOT>
       <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
       <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-      <DIN_LOC_ROOT>/lustre/or-hydra/cades-ccsi/proj-shared/project_acme/ACME_inputdata</DIN_LOC_ROOT>
-      <DIN_LOC_ROOT_CLMFORC>/lustre/or-hydra/cades-ccsi/proj-shared/project_acme/ACME_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+      <DIN_LOC_ROOT>/lustre/or-hydra/cades-ccsi/proj-shared/project_acme/E3SM_inputdata</DIN_LOC_ROOT>
+      <DIN_LOC_ROOT_CLMFORC>/lustre/or-hydra/cades-ccsi/proj-shared/project_acme/E3SM_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
       <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
       <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
       <BASELINE_ROOT>/lustre/or-hydra/cades-ccsi/proj-shared/project_acme/baselines/$COMPILER</BASELINE_ROOT>
@@ -2301,6 +2301,91 @@
 	 </environment_variables>
 </machine>
 
+<machine MACH="badger">
+	<DESC>LANL Linux Cluster, 36 pes/node, batch system slurm</DESC>
+        <NODENAME_REGEX>ba-fe.*.lanl.gov</NODENAME_REGEX>
+        <TESTS>e3sm_developer</TESTS>
+        <COMPILERS>gnu,intel</COMPILERS>
+        <MPILIBS>mvapich,openmpi</MPILIBS>
+	<OS>LINUX</OS>
+	<RUNDIR>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/cases/$CASE/run</RUNDIR>
+	<EXEROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/cases/$CASE/bld</EXEROOT>
+	<DIN_LOC_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data</DIN_LOC_ROOT>
+	<DIN_LOC_ROOT_CLMFORC>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+	<DOUT_S_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/archive/$CASE</DOUT_S_ROOT>
+	<DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
+	<BASELINE_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data/ccsm_baselines/$COMPILER</BASELINE_ROOT>
+	<CIME_OUTPUT_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/scratch</CIME_OUTPUT_ROOT>
+	<CCSM_CPRNC>/turquoise/usr/projects/climate/SHARED_CLIMATE/software/wolf/cprnc/v0.40/cprnc</CCSM_CPRNC>
+	<module_system type="module">
+		<init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
+		<init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+		<init_path lang="sh">/etc/profile.d/z00_lmod.sh</init_path>
+		<init_path lang="csh">/etc/profile.d/z00_lmod.csh</init_path>
+		<cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
+		<cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+		<cmd_path lang="sh">module</cmd_path>
+		<cmd_path lang="csh">module</cmd_path>
+
+		<modules>
+			<command name="purge"/>
+			<command name="use">/usr/projects/climate/SHARED_CLIMATE/modulefiles/all</command>
+			<command name="load">python/anaconda-2.7-climate</command>
+		</modules>
+
+		<modules compiler="gnu">
+			<command name="load">gcc/6.4.0</command>
+		</modules>
+		<modules compiler="intel">
+			<command name="load">intel/18.0.2</command>
+		</modules>
+		<modules mpilib="openmpi">
+			<command name="load">openmpi/2.1.2</command>
+		</modules>
+		<modules mpilib="mvapich">
+			<command name="load">mvapich2/2.2</command>
+		</modules>
+		<modules>
+			<command name="load">netcdf/4.4.1.1</command>
+		</modules>
+		<modules>
+			<command name="load">parallel-netcdf/1.8.1</command>
+		</modules>
+	</module_system>
+	<environment_variables>
+		<env name="PNETCDF_HINTS">romio_ds_write=disable;romio_ds_read=disable;romio_cb_write=enable;romio_cb_read=enable</env>
+	</environment_variables>
+
+	<BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+	<mpirun mpilib="default">
+		<executable>mpirun</executable>
+		<arguments>
+			<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+		</arguments>
+	</mpirun>
+	<mpirun mpilib="mvapich">
+		<executable>srun</executable>
+		<arguments>
+			<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+		</arguments>
+	</mpirun>
+	<mpirun mpilib="openmpi">
+		<executable>mpirun</executable>
+		<arguments>
+			<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+		</arguments>
+	</mpirun>
+	<mpirun mpilib="mpi-serial">
+		<executable></executable>
+	</mpirun>
+	<GMAKE_J>4</GMAKE_J>
+	<MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
+	<MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
+	<PROJECT>climateacme</PROJECT>
+    	<PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+        <SUPPORTED_BY>e3sm</SUPPORTED_BY>
+</machine>
+
 <machine MACH="grizzly">
 	<DESC>LANL Linux Cluster, 36 pes/node, batch system slurm</DESC>
         <NODENAME_REGEX>gr-fe.*.lanl.gov</NODENAME_REGEX>
@@ -2308,18 +2393,19 @@
         <COMPILERS>gnu,intel</COMPILERS>
         <MPILIBS>mvapich,openmpi</MPILIBS>
 	<OS>LINUX</OS>
-	<RUNDIR>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/run</RUNDIR>
-	<EXEROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/bld</EXEROOT>
-	<DIN_LOC_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data</DIN_LOC_ROOT>
-	<DIN_LOC_ROOT_CLMFORC>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-	<DOUT_S_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/archive/$CASE</DOUT_S_ROOT>
+	<RUNDIR>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/cases/$CASE/run</RUNDIR>
+	<EXEROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/cases/$CASE/bld</EXEROOT>
+	<DIN_LOC_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data</DIN_LOC_ROOT>
+	<DIN_LOC_ROOT_CLMFORC>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+	<DOUT_S_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/archive/$CASE</DOUT_S_ROOT>
 	<DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
-	<BASELINE_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/ccsm_baselines/$COMPILER</BASELINE_ROOT>
-	<CIME_OUTPUT_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/scratch</CIME_OUTPUT_ROOT>
+	<BASELINE_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data/ccsm_baselines/$COMPILER</BASELINE_ROOT>
+	<CIME_OUTPUT_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/scratch</CIME_OUTPUT_ROOT>
 	<CCSM_CPRNC>/turquoise/usr/projects/climate/SHARED_CLIMATE/software/wolf/cprnc/v0.40/cprnc</CCSM_CPRNC>
 	<module_system type="module">
 		<init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
 		<init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+		<init_path lang="sh">/etc/profile.d/z00_lmod.sh</init_path>
 		<init_path lang="csh">/etc/profile.d/z00_lmod.csh</init_path>
 		<cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
 		<cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
@@ -2391,10 +2477,10 @@
     <TESTS>e3sm_developer</TESTS>
 	<COMPILERS>intel,gnu</COMPILERS>
 	<MPILIBS>openmpi,mvapich</MPILIBS>
-	<CIME_OUTPUT_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/scratch</CIME_OUTPUT_ROOT>
-	<RUNDIR>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/run</RUNDIR>
-	<EXEROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/bld</EXEROOT>
-	<DOUT_S_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/archive/$CASE</DOUT_S_ROOT>
+	<CIME_OUTPUT_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/scratch</CIME_OUTPUT_ROOT>
+	<RUNDIR>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/cases/$CASE/run</RUNDIR>
+	<EXEROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/cases/$CASE/bld</EXEROOT>
+	<DOUT_S_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/archive/$CASE</DOUT_S_ROOT>
 	<DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
 	<OS>LINUX</OS>
 	<BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -2404,9 +2490,9 @@
 	<MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
 	<PROJECT>climateacme</PROJECT>
 	<PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-	<DIN_LOC_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data</DIN_LOC_ROOT>
-	<DIN_LOC_ROOT_CLMFORC>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-	<BASELINE_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/ccsm_baselines/$COMPILER</BASELINE_ROOT>
+	<DIN_LOC_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data</DIN_LOC_ROOT>
+	<DIN_LOC_ROOT_CLMFORC>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+	<BASELINE_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data/ccsm_baselines/$COMPILER</BASELINE_ROOT>
 	<CCSM_CPRNC>/turquoise/usr/projects/climate/SHARED_CLIMATE/software/wolf/cprnc/v0.40/cprnc</CCSM_CPRNC>
 	<mpirun mpilib="default">
 		<executable>mpirun</executable>
@@ -2863,7 +2949,7 @@
 	 <MAX_TASKS_PER_NODE>84</MAX_TASKS_PER_NODE>
 	 <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	 <PROJECT>csc190</PROJECT>
-	 <CHARGE_ACCOUNT>CSC190ACME</CHARGE_ACCOUNT>
+	 <CHARGE_ACCOUNT>CSC190E3SM</CHARGE_ACCOUNT>
 	 <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
 
 	 <mpirun mpilib="spectrum-mpi">

--- a/cime/config/e3sm/machines/config_pio.xml
+++ b/cime/config/e3sm/machines/config_pio.xml
@@ -56,6 +56,7 @@
       <value mach="lawrencium-lr2">netcdf</value>
       <value mach="lawrencium-lr3">netcdf</value>
       <value mach="cades">netcdf</value>
+      <value mach="badger">netcdf</value>
       <value mach="grizzly">netcdf</value>
       <value mach="wolf">netcdf</value>
       <value mpilib="mpi-serial">netcdf</value>

--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -290,6 +290,8 @@
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS30to10wLI">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS18to6v3">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS15to5">96</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to10">96</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to6">96</value>
       <value compset="_CAM.*_CLM.*MPASO">48</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</value>
@@ -388,6 +390,8 @@
       <value compset="_MPASO" grid="oi%oRRS30to10wLI">48</value>
       <value compset="_MPASO" grid="oi%oRRS18to6v3">48</value>
       <value compset="_MPASO" grid="oi%oRRS15to5">96</value>
+      <value compset="_MPASO" grid="oi%oARRM60to10">48</value>
+      <value compset="_MPASO" grid="oi%oARRM60to6">48</value>
 
     </values>
     <group>run_coupling</group>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1180,7 +1180,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*20" category="default_settings"
        group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,oRRS18to6,oRRS18to6v3,oRRS15to5,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,tx0.1v2">
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,tx0.1v2">
 Land mask description
 </entry> 
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -59,6 +59,8 @@
 <config_dt ocn_grid="oRRS18to6">'00:06:00'</config_dt>
 <config_dt ocn_grid="oRRS18to6v3">'00:06:00'</config_dt>
 <config_dt ocn_grid="oRRS15to5">'00:03:45'</config_dt>
+<config_dt ocn_grid="oARRM60to10">'00:10:00'</config_dt>
+<config_dt ocn_grid="oARRM60to6">'00:05:00'</config_dt>
 <config_time_integrator>'split_explicit'</config_time_integrator>
 
 <!-- ALE_vertical_grid -->
@@ -97,6 +99,8 @@
 <config_hmix_scaleWithMesh ocn_grid="oRRS18to6">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oRRS18to6v3">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oRRS15to5">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="oARRM60to10">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="oARRM60to6">.true.</config_hmix_scaleWithMesh>
 <config_maxMeshDensity>-1.0</config_maxMeshDensity>
 <config_apvm_scale_factor>0.0</config_apvm_scale_factor>
 
@@ -124,6 +128,8 @@
 <config_mom_del4 ocn_grid="oRRS18to6">3.2e09</config_mom_del4>
 <config_mom_del4 ocn_grid="oRRS18to6v3">3.2e09</config_mom_del4>
 <config_mom_del4 ocn_grid="oRRS15to5">1.9e09</config_mom_del4>
+<config_mom_del4 ocn_grid="oARRM60to10">1.5e10</config_mom_del4>
+<config_mom_del4 ocn_grid="oARRM60to6">3.2e09</config_mom_del4>
 <config_mom_del4_div_factor>1.0</config_mom_del4_div_factor>
 <config_tracer_del4>0.0</config_tracer_del4>
 
@@ -149,6 +155,8 @@
 <config_use_standardGM ocn_grid="oRRS18to6">.false.</config_use_standardGM>
 <config_use_standardGM ocn_grid="oRRS18to6v3">.false.</config_use_standardGM>
 <config_use_standardGM ocn_grid="oRRS15to5">.false.</config_use_standardGM>
+<config_use_standardGM ocn_grid="oARRM60to10">.false.</config_use_standardGM>
+<config_use_standardGM ocn_grid="oARRM60to6">.false.</config_use_standardGM>
 <config_use_Redi_surface_layer_tapering>.false.</config_use_Redi_surface_layer_tapering>
 <config_Redi_surface_layer_tapering_extent>0.0</config_Redi_surface_layer_tapering_extent>
 <config_use_Redi_bottom_layer_tapering>.false.</config_use_Redi_bottom_layer_tapering>
@@ -346,6 +354,8 @@
 <config_btr_dt ocn_grid="oRRS18to6">'0000_00:00:12'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS18to6v3">'0000_00:00:12'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS15to5">'0000_00:00:11.25'</config_btr_dt>
+<config_btr_dt ocn_grid="oARRM60to10">'0000_00:00:24'</config_btr_dt>
+<config_btr_dt ocn_grid="oARRM60to6">'0000_00:00:10'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>
@@ -813,6 +823,8 @@
 <config_AM_mocStreamfunction_enable ocn_grid="oRRS18to6">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="oRRS18to6v3">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="oRRS15to5">.false.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="oARRM60to10">.false.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="oARRM60to6">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_compute_interval>'0000-00-00_01:00:00'</config_AM_mocStreamfunction_compute_interval>
 <config_AM_mocStreamfunction_output_stream>'mocStreamfunctionOutput'</config_AM_mocStreamfunction_output_stream>
 <config_AM_mocStreamfunction_compute_on_startup>.true.</config_AM_mocStreamfunction_compute_on_startup>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -183,6 +183,16 @@ def buildnml(case, caseroot, compname):
         ic_prefix += 'ocean.RRS.15-5km'
         decomp_date += '151209'
         decomp_prefix += 'mpas-o.graph.info.'
+    elif ocn_grid == 'oARRM60to10':
+        ic_date += '180715'
+        ic_prefix += 'ocean.ARRM60to10'
+        decomp_date += '180723'
+        decomp_prefix += 'mpas-o.graph.info.'
+    elif ocn_grid == 'oARRM60to6':
+        ic_date += '180803'
+        ic_prefix += 'ocean.ARRM60to6'
+        decomp_date += '180820'
+        decomp_prefix += 'mpas-o.graph.info.'
 
     #--------------------------------------------------------------------
     # Set OCN_FORCING = core_forced_restoring if restoring file is available

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -21,6 +21,8 @@
 <config_dt ice_grid="oRRS18to6">900.0</config_dt>
 <config_dt ice_grid="oRRS18to6v3">900.0</config_dt>
 <config_dt ice_grid="oRRS15to5">900.0</config_dt>
+<config_dt ice_grid="oARRM60to10">900.0</config_dt>
+<config_dt ice_grid="oARRM60to6">900.0</config_dt>
 <config_calendar_type>'gregorian_noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
@@ -108,6 +110,8 @@
 <config_dynamics_subcycle_number ice_grid="oRRS18to6">2</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="oRRS18to6v3">2</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="oRRS15to5">2</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="oARRM60to10">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="oARRM60to6">2</config_dynamics_subcycle_number>
 <config_rotate_cartesian_grid>true</config_rotate_cartesian_grid>
 <config_include_metric_terms>true</config_include_metric_terms>
 <config_elastic_subcycle_number>120</config_elastic_subcycle_number>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -168,6 +168,16 @@ def buildnml(case, caseroot, compname):
         grid_prefix += 'seaice.RRS.15to5km'
         decomp_date += '151209'
         decomp_prefix += 'mpas-cice.graph.info.'
+    elif ice_grid == 'oARRM60to10':
+        grid_date += '180715'
+        grid_prefix += 'seaice.ARRM60to10'
+        decomp_date += '180723'
+        decomp_prefix += 'mpas-cice.graph.info.'
+    elif ice_grid == 'oARRM60to6':
+        grid_date += '180803'
+        grid_prefix += 'seaice.ARRM60to6'
+        decomp_date += '180820'
+        decomp_prefix += 'mpas-cice.graph.info.'
 
     #--------------------------------------------------------------------
     # Set the initial file, changing to a restart file for branch and hybrid runs


### PR DESCRIPTION
This PR adds the MPAS-O and MPAS-SI meshes and other configuration files necessary to run a G-case of two E3SM-ARRM (Arctic refined) configurations:
1) the first, lower resolution grid, is EC60to30 in the Southern hemisphere and then transitions from 30 to 10 km in the Northern hemisphere (10km resolution over the whole Arctic);
2) the second, higher resolution grid, is similar to the one in 1), but transitions to 6 km in the Arctic.

Testing has been done on the LANL machine grizzly and on edison. One test ran successfully for 10 years.