### PR TITLE
Updates timestep for the EC60to30 mesh

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -48,10 +48,10 @@
 <config_dt ocn_grid="oQU240">'01:00:00'</config_dt>
 <config_dt ocn_grid="oQU240wLI">'02:00:00'</config_dt>
 <config_dt ocn_grid="oQU120">'00:30:00'</config_dt>
-<config_dt ocn_grid="oEC60to30">'00:10:00'</config_dt>
-<config_dt ocn_grid="oEC60to30v3">'00:10:00'</config_dt>
-<config_dt ocn_grid="oEC60to30wLI">'00:10:00'</config_dt>
-<config_dt ocn_grid="oEC60to30v3wLI">'00:10:00'</config_dt>
+<config_dt ocn_grid="oEC60to30">'00:30:00'</config_dt>
+<config_dt ocn_grid="oEC60to30v3">'00:30:00'</config_dt>
+<config_dt ocn_grid="oEC60to30wLI">'00:30:00'</config_dt>
+<config_dt ocn_grid="oEC60to30v3wLI">'00:30:00'</config_dt>
 <config_dt ocn_grid="oRRS30to10">'00:06:00'</config_dt>
 <config_dt ocn_grid="oRRS30to10v3">'00:10:00'</config_dt>
 <config_dt ocn_grid="oRRS30to10wLI">'00:10:00'</config_dt>
@@ -102,8 +102,16 @@
 
 <!-- hmix_del2 -->
 <config_use_mom_del2>.false.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="oEC60to30">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="oEC60to30v3">.true.</config_use_mom_del2> 
+<config_use_mom_del2 ocn_grid="oEC60to30wLI">.true.</config_use_mom_del2> 
+<config_use_mom_del2 ocn_grid="oEC60to30v3wLI">.true.</config_use_mom_del2> 
 <config_use_tracer_del2>.false.</config_use_tracer_del2>
 <config_mom_del2>10.0</config_mom_del2>
+<config_mom_del2 ocn_grid="oEC60to30">1000.0</config_mom_del2>
+<config_mom_del2 ocn_grid="oEC60to30v3">1000.0</config_mom_del2>
+<config_mom_del2 ocn_grid="oEC60to30wLI">1000.0</config_mom_del2>
+<config_mom_del2 ocn_grid="oEC60to30v3wLI">1000.0</config_mom_del2>
 <config_tracer_del2>10.0</config_tracer_del2>
 
 <!-- hmix_del4 -->
@@ -113,10 +121,10 @@
 <config_mom_del4 ocn_grid="oQU240">2.0e14</config_mom_del4>
 <config_mom_del4 ocn_grid="oQU240wLI">2.0e14</config_mom_del4>
 <config_mom_del4 ocn_grid="oQU120">2.6e13</config_mom_del4>
-<config_mom_del4 ocn_grid="oEC60to30">1.2e12</config_mom_del4>
-<config_mom_del4 ocn_grid="oEC60to30v3">1.2e12</config_mom_del4>
-<config_mom_del4 ocn_grid="oEC60to30wLI">1.2e12</config_mom_del4>
-<config_mom_del4 ocn_grid="oEC60to30v3wLI">1.2e12</config_mom_del4>
+<config_mom_del4 ocn_grid="oEC60to30">1.2e11</config_mom_del4>
+<config_mom_del4 ocn_grid="oEC60to30v3">1.2e11</config_mom_del4>
+<config_mom_del4 ocn_grid="oEC60to30wLI">1.2e11</config_mom_del4>
+<config_mom_del4 ocn_grid="oEC60to30v3wLI">1.2e11</config_mom_del4>
 <config_mom_del4 ocn_grid="oRRS30to10">1.5e10</config_mom_del4>
 <config_mom_del4 ocn_grid="oRRS30to10v3">1.5e10</config_mom_del4>
 <config_mom_del4 ocn_grid="oRRS30to10wLI">1.5e10</config_mom_del4>
@@ -335,10 +343,10 @@
 <config_btr_dt ocn_grid="oQU240">'0000_00:03:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU240wLI">'0000_00:03:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU120">'0000_00:01:30'</config_btr_dt>
-<config_btr_dt ocn_grid="oEC60to30">'0000_00:00:40'</config_btr_dt>
-<config_btr_dt ocn_grid="oEC60to30v3">'0000_00:00:40'</config_btr_dt>
-<config_btr_dt ocn_grid="oEC60to30wLI">'0000_00:00:40'</config_btr_dt>
-<config_btr_dt ocn_grid="oEC60to30v3wLI">'0000_00:00:40'</config_btr_dt>
+<config_btr_dt ocn_grid="oEC60to30">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="oEC60to30v3">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="oEC60to30wLI">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="oEC60to30v3wLI">'0000_00:01:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS30to10">'0000_00:00:18'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS30to10v3">'0000_00:00:24'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS30to10wLI">'0000_00:00:18'</config_btr_dt>


### PR DESCRIPTION
This commit updates the timestep from 10 -> 30 minutes for any EC60to30
configuration.  To allow for this change a number of other parameters
are also changed: e.g., del4 and del2 viscosity.  Commit is climate changing.