### PR TITLE
remove thetanh-c-TC test since this code is no longer maintained

### DIFF
--- a/components/homme/test/reg_test/run_tests/test-list.cmake
+++ b/components/homme/test/reg_test/run_tests/test-list.cmake
@@ -16,7 +16,6 @@ SET(HOMME_TESTS
   thetanh-test22.cmake
   thetah-TC.cmake
   thetanh-TC.cmake
-  thetanh-c-TC.cmake
   thetanhwet-TC.cmake
   templates.cmake
 )


### PR DESCRIPTION
recent upgrades to the HOMME DCMIP2016 test cases broke the outdated collocated theta model.
remove this test for now. not sure if it is worth while to fix the collocated theta model.   

[BFB]