### PR TITLE
Update maint-1.1 machine files

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -371,7 +371,9 @@
 	<directive>--error=slurm.err</directive>
       </directives>
       <queues>
-	<queue walltimemax="00:30:00" default="true">large</queue>
+	<queue walltimemax="00:59:00" nodemin="1"  nodemax="15"  >small</queue>
+	<queue walltimemax="00:59:00" nodemin="16" nodemax="127" >medium</queue>
+	<queue walltimemax="00:59:00" nodemin="128" default="true" >large</queue>
       </queues>
     </batch_system>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -367,10 +367,11 @@
 
     <batch_system MACH="cascade" type="slurm">
       <directives>
-	<directive>--mail-user=email@pnnl.gov</directive>
+	<directive>--output=slurm.out</directive>
+	<directive>--error=slurm.err</directive>
       </directives>
       <queues>
-	<queue walltimemax="00:30:00" default="true">small</queue>
+	<queue walltimemax="00:30:00" default="true">large</queue>
       </queues>
     </batch_system>
 

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -690,7 +690,6 @@ for mct, etc.
   </FFLAGS>
 </compiler>
 
-<!-- Intel v18 is default on cori-knl and cori-haswell -->
 <compiler MACH="anlworkstation" COMPILER="gnu">
   <ALBANY_PATH>/projects/install/rhel6-x86_64/ACME/AlbanyTrilinos/Albany/build/install</ALBANY_PATH>
   <CFLAGS>
@@ -1168,6 +1167,7 @@ for mct, etc.
     <base> --host=Linux </base>
   </CONFIG_ARGS>
   <FFLAGS>
+    <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml </base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
   </FFLAGS>
   <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
@@ -1180,7 +1180,7 @@ for mct, etc.
   </SLIBS>
 </compiler>
 
-<!-- Edison still uses v17, but has an intel18 compiler option -->
+<!-- Edison still has intel18 compiler option for backward compat -->
 <compiler MACH="edison" COMPILER="intel18">
   <CFLAGS>
     <base> -O2 -fp-model precise -std=gnu99 </base>
@@ -1232,7 +1232,6 @@ for mct, etc.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
-<!-- Use Intel MPI with intel compiler on cori-knl -->
 <compiler MACH="eos" COMPILER="intel">
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -959,7 +959,7 @@ for mct, etc.
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
-    <base> -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -lpmi -L$ENV{MKL_PATH}/lib/intel64 -lmkl_rt </base>
+    <base> -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64 -lmkl_rt </base>
     <append MPILIB="mpich2"> -mkl=cluster </append>
     <append MPILIB="mpi-serial"> -mkl </append>
   </SLIBS>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -126,10 +126,10 @@
 
     <modules>
       <command name="rm">craype</command>
-      <command name="load">craype/2.5.12</command>
+      <command name="load">craype/2.5.14</command>
       <command name="load">craype-ivybridge</command>
       <command name="rm">pmi</command>
-      <command name="load">pmi/5.0.12</command>
+      <command name="load">pmi/5.0.13</command>
       <command name="rm">cray-mpich</command>
       <command name="load">cray-mpich/7.7.0</command>
     </modules>
@@ -137,7 +137,7 @@
     <modules compiler="intel">
       <command name="load">PrgEnv-intel/6.0.4</command>
       <command name="rm">intel</command>
-      <command name="load">intel/17.0.2.174</command>
+      <command name="load">intel/18.0.1.163</command>
       <command name="rm">cray-libsci</command>
     </modules>
 
@@ -152,9 +152,9 @@
       <command name="rm">PrgEnv-intel</command>
       <command name="load">PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
-      <command name="load">gcc/6.3.0</command>
+      <command name="load">gcc/7.3.0</command>
       <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/17.06.1</command>
+      <command name="load">cray-libsci/18.03.1</command>
     </modules>
 
     <modules compiler="gnu7">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -88,6 +88,7 @@
       <arg name="num_tasks" > -n {{ total_tasks }}</arg>
       <arg name="thread_count"> -c $SHELL{echo 48/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
       <arg name="binding"> $SHELL{if [ 24 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
+      <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
     </arguments>
   </mpirun>
   <module_system type="module">
@@ -235,6 +236,7 @@
       <arg name="num_tasks" > -n {{ total_tasks }}</arg>
       <arg name="thread_count">-c $SHELL{echo 64/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
       <arg name="binding"> $SHELL{if [ 32 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
+      <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
     </arguments>
   </mpirun>
   <module_system type="module">
@@ -374,6 +376,7 @@
       <arg name="num_tasks" > -n {{ total_tasks }}</arg>
       <arg name="thread_count">-c $SHELL{echo 272/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
       <arg name="binding"> $SHELL{if [ 68 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
+      <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
     </arguments>
   </mpirun>
   <module_system type="module">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1865,10 +1865,10 @@
       </arguments>
     </mpirun>
     <module_system type="module">
-      <init_path lang="python">/opt/lmod/5.0.1/init/env_modules_python.py</init_path>
+      <init_path lang="python">/opt/lmod/7.3.28/init/env_modules_python.py</init_path>
       <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
       <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
-      <cmd_path lang="python">/opt/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="python">/opt/lmod/7.3.28/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1823,21 +1823,20 @@
   </machine>
 
   <machine MACH="cascade">
-    <DESC>PNL Intel KNC cluster, OS is Linux, batch system is SLURM</DESC>
+    <DESC>PNNL Intel KNC cluster, OS is Linux, batch system is SLURM</DESC>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
-    <MPILIBS>mvapich2</MPILIBS>
+    <MPILIBS>impi,mvapich2</MPILIBS>
     <NODENAME_REGEX>glogin</NODENAME_REGEX>
-    <CESMSCRATCHROOT>/dtemp/$USER</CESMSCRATCHROOT>
-    <RUNDIR>/dtemp/$USER/csmruns/$CASE/run</RUNDIR>
-    <EXEROOT>/dtemp/$USER/csmruns/$CASE/bld</EXEROOT>
-    <CIME_OUTPUT_ROOT>/dtemp/$USER</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/dtemp/sing201/acme/inputdata/</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/dtemp/sing201/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>/dtemp/sing201/$USER/archive/$CASE</DOUT_S_ROOT>
+    <CIME_OUTPUT_ROOT>/dtemp/$PROJECT/$USER</CIME_OUTPUT_ROOT>
+    <RUNDIR>$CIME_OUTPUT_ROOT/csmruns/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/csmruns/$CASE/bld</EXEROOT>
+    <DIN_LOC_ROOT>/dtemp/st49401/sing201/acme/inputdata/</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/dtemp/st49401/sing201/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
-    <CCSM_BASELINE>/dtemp/sing201/acme/acme_baselines</CCSM_BASELINE>
-    <CCSM_CPRNC>/dtemp/sing201/acme/acme_baselines/cprnc/cprnc</CCSM_CPRNC>
+    <BASELINE_ROOT>$CIME_OUTPUT_ROOT/acme/acme_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>$CIME_OUTPUT_ROOT/acme/acme_baselines/cprnc/cprnc</CCSM_CPRNC>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>balwinder.singh -at- pnnl.gov</SUPPORTED_BY>
     <GMAKE_J>8</GMAKE_J>
@@ -1846,6 +1845,12 @@
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="mpi-serial">
       <executable></executable>
+    </mpirun>
+    <mpirun mpilib="impi">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+      </arguments>
     </mpirun>
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
@@ -1870,8 +1875,11 @@
 	<command name="load">python/2.7.9</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/15.0.090</command>
+	<command name="load">intel/ips_18</command>
 	<command name="load">mkl/14.0</command>
+      </modules>
+      <modules mpilib="impi">
+        <command name="load">impi/4.1.2.040</command>
       </modules>
       <modules mpilib="mvapich2">
 	<command name="load">mvapich2/1.9</command>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2332,7 +2332,7 @@
 	     <command name="rm">netcdf</command>
 	   </modules>
 	   <modules compiler="intel">
-	     <command name="load">intel/16.0.1.150</command>
+	     <command name="load">intel/18.0.1.163</command>
 	     <command name="load">papi</command>
 	   </modules>
 	   <modules compiler="cray">


### PR DESCRIPTION
This PR brings in machine file updates cherry-picked from:

#2524 - Updates cascade's Intel's compiler version to 18 (BFB)
#2530 - For NERSC machines, add srun flag to place MPI's in a packed fashion (-m plane) (BFB)
#2541 - Update modules on edison after maintenance (BFB?)
#2552 - Some machine updates for cascade at PNNL (BFB)
#2563 - Updates EOS's Intel compiler version to 18 (BFB)

We had one more on our list to include that was already in the codebase:
#2442 - Update module versions for Cori (haswell and KNL) after software maintenance

[BFB]