### PR TITLE
  fix bugs for C14 and C14 configurations

### DIFF
--- a/components/clm/src/biogeochem/CNCarbonFluxType.F90
+++ b/components/clm/src/biogeochem/CNCarbonFluxType.F90
@@ -3478,24 +3478,26 @@ contains
             avgflag='A', long_name='C13 seed source to patch-level leaf', &
             ptr_gcell=this%dwt_seedc_to_leaf_grc, default='inactive')
 
-       this%dwt_seedc_to_leaf_patch(begp:endp) = spval
-       call hist_addfld1d (fname='C13_DWT_SEEDC_TO_LEAF_PATCH', units='gC13/m^2/s', &
-            avgflag='A', &
-            long_name='C13 patch-level seed source to patch-level leaf ' // &
-            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-            ptr_patch=this%dwt_seedc_to_leaf_patch, default='inactive')
+!      removing duplicated C13 variables 
+!       this%dwt_seedc_to_leaf_patch(begp:endp) = spval
+!       call hist_addfld1d (fname='C13_DWT_SEEDC_TO_LEAF_PATCH', units='gC13/m^2/s', &
+!            avgflag='A', &
+!           long_name='C13 patch-level seed source to patch-level leaf ' // &
+!            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+!            ptr_patch=this%dwt_seedc_to_leaf_patch, default='inactive')
 
        this%dwt_seedc_to_deadstem_grc(begg:endg) = spval
        call hist_addfld1d (fname='C13_DWT_SEEDC_TO_DEADSTEM_GRC', units='gC13/m^2/s', &
             avgflag='A', long_name='C13 seed source to patch-level deadstem', &
             ptr_gcell=this%dwt_seedc_to_deadstem_grc, default='inactive')
 
-       this%dwt_seedc_to_deadstem_patch(begp:endp) = spval
-       call hist_addfld1d (fname='C13_DWT_SEEDC_TO_DEADSTEM_PATCH', units='gC13/m^2/s', &
-            avgflag='A', &
-            long_name='C13 patch-level seed source to patch-level deadstem ' // &
-            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-            ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
+!      removing duplicated C13 variables 
+!       this%dwt_seedc_to_deadstem_patch(begp:endp) = spval
+!       call hist_addfld1d (fname='C13_DWT_SEEDC_TO_DEADSTEM_PATCH', units='gC13/m^2/s', &
+!            avgflag='A', &
+!            long_name='C13 patch-level seed source to patch-level deadstem ' // &
+!            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+!            ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
 
        this%dwt_conv_cflux_grc(begg:endg) = spval
        call hist_addfld1d (fname='C13_DWT_CONV_CFLUX_GRC', units='gC13/m^2/s', &
@@ -3548,14 +3550,15 @@ contains
        call hist_addfld1d (fname='C13_DWT_SEEDC_TO_DEADSTEM_PATCH', units='gC13/m^2/s', &
             avgflag='A', &
             long_name='patch-level C13 seed source to patch-level deadstem ' // &
-            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+           '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
             ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
 
-       this%dwt_conv_cflux_grc(begg:endg) = spval
-       call hist_addfld1d (fname='C13_DWT_CONV_CFLUX', units='gC13/m^2/s', &
-            avgflag='A', long_name='C13 conversion C flux (immediate loss to atm) ' // &
-            '(0 at all times except first timestep of year)', &
-            ptr_gcell=this%dwt_conv_cflux_grc)
+!      removing duplicated C13 variables 
+!       this%dwt_conv_cflux_grc(begg:endg) = spval
+!       call hist_addfld1d (fname='C13_DWT_CONV_CFLUX', units='gC13/m^2/s', &
+!            avgflag='A', long_name='C13 conversion C flux (immediate loss to atm) ' // &
+!            '(0 at all times except first timestep of year)', &
+!            ptr_gcell=this%dwt_conv_cflux_grc)
 
        this%dwt_conv_cflux_col(begc:endc) = spval
        call hist_addfld1d (fname='C13_DWT_CONV_CFLUX', units='gC13/m^2/s', &
@@ -3783,24 +3786,26 @@ contains
             avgflag='A', long_name='C14 seed source to patch-level leaf', &
             ptr_gcell=this%dwt_seedc_to_leaf_grc, default='inactive')
 
-       this%dwt_seedc_to_leaf_patch(begp:endp) = spval
-       call hist_addfld1d (fname='C14_DWT_SEEDC_TO_LEAF_PATCH', units='gC14/m^2/s', &
-            avgflag='A', &
-            long_name='C14 patch-level seed source to patch-level leaf ' // &
-            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-            ptr_patch=this%dwt_seedc_to_leaf_patch, default='inactive')
+!      removing duplicated C14 variables 
+!       this%dwt_seedc_to_leaf_patch(begp:endp) = spval
+!       call hist_addfld1d (fname='C14_DWT_SEEDC_TO_LEAF_PATCH', units='gC14/m^2/s', &
+!            avgflag='A', &
+!            long_name='C14 patch-level seed source to patch-level leaf ' // &
+!            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+!            ptr_patch=this%dwt_seedc_to_leaf_patch, default='inactive')
 
        this%dwt_seedc_to_deadstem_grc(begg:endg) = spval
        call hist_addfld1d (fname='C14_DWT_SEEDC_TO_DEADSTEM_GRC', units='gC14/m^2/s', &
             avgflag='A', long_name='C14 seed source to patch-level deadstem', &
             ptr_gcell=this%dwt_seedc_to_deadstem_grc, default='inactive')
 
-       this%dwt_seedc_to_deadstem_patch(begp:endp) = spval
-       call hist_addfld1d (fname='C14_DWT_SEEDC_TO_DEADSTEM_PATCH', units='gC14/m^2/s', &
-            avgflag='A', &
-            long_name='C14 patch-level seed source to patch-level deadstem ' // &
-            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-            ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
+!      removing duplicated C14 variables 
+!       this%dwt_seedc_to_deadstem_patch(begp:endp) = spval
+!       call hist_addfld1d (fname='C14_DWT_SEEDC_TO_DEADSTEM_PATCH', units='gC14/m^2/s', &
+!            avgflag='A', &
+!            long_name='C14 patch-level seed source to patch-level deadstem ' // &
+!            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+!            ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
 
        this%dwt_conv_cflux_grc(begg:endg) = spval
        call hist_addfld1d (fname='C14_DWT_CONV_CFLUX_GRC', units='gC14/m^2/s', &
@@ -3856,11 +3861,12 @@ contains
             '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
             ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
 
-       this%dwt_conv_cflux_grc(begg:endg) = spval
-       call hist_addfld1d (fname='C14_DWT_CONV_CFLUX', units='gC14/m^2/s', &
-            avgflag='A', long_name='C14 conversion C flux (immediate loss to atm) ' // &
-            '(0 at all times except first timestep of year)', &
-            ptr_gcell=this%dwt_conv_cflux_grc)
+!      removing duplicated C14 variables 
+!       this%dwt_conv_cflux_grc(begg:endg) = spval
+!       call hist_addfld1d (fname='C14_DWT_CONV_CFLUX', units='gC14/m^2/s', &
+!            avgflag='A', long_name='C14 conversion C flux (immediate loss to atm) ' // &
+!            '(0 at all times except first timestep of year)', &
+!            ptr_gcell=this%dwt_conv_cflux_grc)
 
        this%dwt_conv_cflux_col(begc:endc) = spval
        call hist_addfld1d (fname='C14_DWT_CONV_CFLUX', units='gC14/m^2/s', &

--- a/components/clm/src/biogeochem/CNCarbonFluxType.F90
+++ b/components/clm/src/biogeochem/CNCarbonFluxType.F90
@@ -3478,26 +3478,10 @@ contains
             avgflag='A', long_name='C13 seed source to patch-level leaf', &
             ptr_gcell=this%dwt_seedc_to_leaf_grc, default='inactive')
 
-!      removing duplicated C13 variables 
-!       this%dwt_seedc_to_leaf_patch(begp:endp) = spval
-!       call hist_addfld1d (fname='C13_DWT_SEEDC_TO_LEAF_PATCH', units='gC13/m^2/s', &
-!            avgflag='A', &
-!           long_name='C13 patch-level seed source to patch-level leaf ' // &
-!            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-!            ptr_patch=this%dwt_seedc_to_leaf_patch, default='inactive')
-
        this%dwt_seedc_to_deadstem_grc(begg:endg) = spval
        call hist_addfld1d (fname='C13_DWT_SEEDC_TO_DEADSTEM_GRC', units='gC13/m^2/s', &
             avgflag='A', long_name='C13 seed source to patch-level deadstem', &
             ptr_gcell=this%dwt_seedc_to_deadstem_grc, default='inactive')
-
-!      removing duplicated C13 variables 
-!       this%dwt_seedc_to_deadstem_patch(begp:endp) = spval
-!       call hist_addfld1d (fname='C13_DWT_SEEDC_TO_DEADSTEM_PATCH', units='gC13/m^2/s', &
-!            avgflag='A', &
-!            long_name='C13 patch-level seed source to patch-level deadstem ' // &
-!            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-!            ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
 
        this%dwt_conv_cflux_grc(begg:endg) = spval
        call hist_addfld1d (fname='C13_DWT_CONV_CFLUX_GRC', units='gC13/m^2/s', &
@@ -3552,13 +3536,6 @@ contains
             long_name='patch-level C13 seed source to patch-level deadstem ' // &
            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
             ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
-
-!      removing duplicated C13 variables 
-!       this%dwt_conv_cflux_grc(begg:endg) = spval
-!       call hist_addfld1d (fname='C13_DWT_CONV_CFLUX', units='gC13/m^2/s', &
-!            avgflag='A', long_name='C13 conversion C flux (immediate loss to atm) ' // &
-!            '(0 at all times except first timestep of year)', &
-!            ptr_gcell=this%dwt_conv_cflux_grc)
 
        this%dwt_conv_cflux_col(begc:endc) = spval
        call hist_addfld1d (fname='C13_DWT_CONV_CFLUX', units='gC13/m^2/s', &
@@ -3786,26 +3763,10 @@ contains
             avgflag='A', long_name='C14 seed source to patch-level leaf', &
             ptr_gcell=this%dwt_seedc_to_leaf_grc, default='inactive')
 
-!      removing duplicated C14 variables 
-!       this%dwt_seedc_to_leaf_patch(begp:endp) = spval
-!       call hist_addfld1d (fname='C14_DWT_SEEDC_TO_LEAF_PATCH', units='gC14/m^2/s', &
-!            avgflag='A', &
-!            long_name='C14 patch-level seed source to patch-level leaf ' // &
-!            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-!            ptr_patch=this%dwt_seedc_to_leaf_patch, default='inactive')
-
        this%dwt_seedc_to_deadstem_grc(begg:endg) = spval
        call hist_addfld1d (fname='C14_DWT_SEEDC_TO_DEADSTEM_GRC', units='gC14/m^2/s', &
             avgflag='A', long_name='C14 seed source to patch-level deadstem', &
             ptr_gcell=this%dwt_seedc_to_deadstem_grc, default='inactive')
-
-!      removing duplicated C14 variables 
-!       this%dwt_seedc_to_deadstem_patch(begp:endp) = spval
-!       call hist_addfld1d (fname='C14_DWT_SEEDC_TO_DEADSTEM_PATCH', units='gC14/m^2/s', &
-!            avgflag='A', &
-!            long_name='C14 patch-level seed source to patch-level deadstem ' // &
-!            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-!            ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
 
        this%dwt_conv_cflux_grc(begg:endg) = spval
        call hist_addfld1d (fname='C14_DWT_CONV_CFLUX_GRC', units='gC14/m^2/s', &
@@ -3860,13 +3821,6 @@ contains
             long_name='patch-level C14 seed source to patch-level deadstem ' // &
             '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
             ptr_patch=this%dwt_seedc_to_deadstem_patch, default='inactive')
-
-!      removing duplicated C14 variables 
-!       this%dwt_conv_cflux_grc(begg:endg) = spval
-!       call hist_addfld1d (fname='C14_DWT_CONV_CFLUX', units='gC14/m^2/s', &
-!            avgflag='A', long_name='C14 conversion C flux (immediate loss to atm) ' // &
-!            '(0 at all times except first timestep of year)', &
-!            ptr_gcell=this%dwt_conv_cflux_grc)
 
        this%dwt_conv_cflux_col(begc:endc) = spval
        call hist_addfld1d (fname='C14_DWT_CONV_CFLUX', units='gC14/m^2/s', &

--- a/components/clm/src/biogeochem/CNCarbonStateType.F90
+++ b/components/clm/src/biogeochem/CNCarbonStateType.F90
@@ -1018,11 +1018,6 @@ contains
              avgflag='A', long_name='C13 total wood product C', &
              ptr_col=this%totprodc_col)
 
-!       this%seedc_grc(begg:endg) = spval
-!       call hist_addfld1d (fname='C13_SEEDC', units='gC13/m^2', &
-!            avgflag='A', long_name='C13 pool for seeding new PFTs via dynamic landcover', &
-!            ptr_gcell=this%seedc_grc)
-
        if (use_crop) then
           this%grainc_patch(begp:endp) = spval
           call hist_addfld1d (fname='C13_GRAINC', units='gC/m^2', &

--- a/components/clm/src/biogeochem/CNCarbonStateType.F90
+++ b/components/clm/src/biogeochem/CNCarbonStateType.F90
@@ -1018,10 +1018,10 @@ contains
              avgflag='A', long_name='C13 total wood product C', &
              ptr_col=this%totprodc_col)
 
-       this%seedc_grc(begg:endg) = spval
-       call hist_addfld1d (fname='C13_SEEDC', units='gC13/m^2', &
-            avgflag='A', long_name='C13 pool for seeding new PFTs via dynamic landcover', &
-            ptr_gcell=this%seedc_grc)
+!       this%seedc_grc(begg:endg) = spval
+!       call hist_addfld1d (fname='C13_SEEDC', units='gC13/m^2', &
+!            avgflag='A', long_name='C13 pool for seeding new PFTs via dynamic landcover', &
+!            ptr_gcell=this%seedc_grc)
 
        if (use_crop) then
           this%grainc_patch(begp:endp) = spval


### PR DESCRIPTION
Fixed a few bugs in the history file module - several C14 and C13 variables were added twice there, which caused the model to crash when C13 and C14 are turned on. 

Fixes #2611 
[BFB]