### PR TITLE
Updates the ECA compset definition for CBGC runs

### DIFF
--- a/components/clm/bld/CLMBuildNamelist.pm
+++ b/components/clm/bld/CLMBuildNamelist.pm
@@ -1309,6 +1309,10 @@ sub setup_cmdl_nutrient_comp {
 
           $nl_flags->{$var} = 'ECA';
 
+          $var = "nfix_ptase_plant";
+          $val = '.true.';
+          $nl->set_variable_value($group, $var, $val);
+
         } else {
           fatal_error("-nutrient_comp_pathway has a value ($val) that is not valid. Valid values are: [rd, eca] \n");
         }

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -96,7 +96,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Plant function types (relative to {csmdata}) -->
 <paramfile                 >lnd/clm2/paramdata/clm_params_c180301.nc</paramfile>
 <paramfile use_crop=".true." >lnd/clm2/paramdata/clm_params_c180301.nc</paramfile>
-<paramfile nu_com="ECA"    >lnd/clm2/paramdata/clm_params.c180713.nc</paramfile>
+<paramfile nu_com="ECA"    >lnd/clm2/paramdata/clm_params.cbgc.c07292018.nc</paramfile>
 <paramfile nu_com="RD" use_crop=".false." >lnd/clm2/paramdata/clm_params_c180524.nc</paramfile>
 
 
@@ -108,7 +108,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <!-- soil order related parameters (relative to {csmdata}) -->
 <fsoilordercon             >lnd/clm2/paramdata/CNP_parameters_c131108.nc</fsoilordercon> 
-<fsoilordercon nu_com="RD" >lnd/clm2/paramdata/CNP_parameters_c180529.nc</fsoilordercon> 
+<fsoilordercon nu_com="RD" >lnd/clm2/paramdata/CNP_parameters_c180529.nc</fsoilordercon>
+<fsoilordercon nu_com="ECA">lnd/clm2/paramdata/CNP_parameters_c180312.nc'</fsoilordercon>
 
 <!-- HOMME grid ne4 resolution -->
 


### PR DESCRIPTION
Following changes are made for all ECA compsets:
  - fsoilordercon    = '$DIN_LOC_ROOT/lnd/clm2/paramdata/CNP_parameters_c180312.nc'
  - paramfile        = '$DIN_LOC_ROOT/lnd/clm2/paramdata/clm_params.cbgc.c07292018.nc'
  - nfix_ptase_plant = .true.

[non-BFB]