### PR TITLE
update compatibility with FATES API 6.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "components/clm/src/external_models/fates"]
 	path = components/clm/src/external_models/fates
-	url = git@github.com:NGEET/fates-release.git
+	url = git@github.com:NGEET/fates.git
 [submodule "alm-mpp"]
 	path = components/clm/src/external_models/mpp
 	url = git@github.com:MPP-LSM/MPP.git

--- a/components/clm/bld/CLMBuildNamelist.pm
+++ b/components/clm/bld/CLMBuildNamelist.pm
@@ -790,7 +790,8 @@ sub setup_cmdl_fates_mode {
       # no need to set defaults, covered in a different routine
       my @list  = (  "use_fates_spitfire", "use_vertsoilc", "use_century_decomp",
                      "use_fates_planthydro", "use_fates_ed_st3", "use_fates_ed_prescribed_phys", 
-		     "use_fates_inventory_init", "fates_inventory_ctrl_filename","use_fates_logging" );
+		     "use_fates_inventory_init", "fates_inventory_ctrl_filename","use_fates_logging",
+		     "use_fates_parteh_mode");
       foreach my $var ( @list ) {
 	  if ( defined($nl->get_value($var))  ) {
 	      $nl_flags->{$var} = $nl->get_value($var);
@@ -814,6 +815,10 @@ sub setup_cmdl_fates_mode {
            fatal_error("$var is being set, but can ONLY be set when -bgc ed option is used.\n");
        }
        $var = "use_fates_logging";
+       if ( defined($nl->get_value($var)) ) {
+	   fatal_error("$var is being set, but can ONLY be set when -bgc ed option is used.\n");
+       }
+       $var = "fates_parteh_mode";
        if ( defined($nl->get_value($var)) ) {
 	   fatal_error("$var is being set, but can ONLY be set when -bgc ed option is used.\n");
        }
@@ -3336,8 +3341,9 @@ sub setup_logic_fates {
 
     if ($physv->as_long() >= $physv->as_long("clm4_5") && value_is_true( $nl_flags->{'use_fates'})  ) {
  	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_spitfire', 'use_fates'=>$nl_flags->{'use_fates'} );
-	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_logging',            'use_fates'=>$nl_flags->{'use_fates'} );
+	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_logging',            'use_fates'=>$nl_flags->{'use_fates'});
 	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_planthydro',         'use_fates'=>$nl_flags->{'use_fates'});
+	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fates_parteh_mode',            'use_fates'=>$nl_flags->{'use_fates'});
 	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_ed_st3',             'use_fates'=>$nl_flags->{'use_fates'});
 	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_ed_prescribed_phys', 'use_fates'=>$nl_flags->{'use_fates'});
 	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_inventory_init',     'use_fates'=>$nl_flags->{'use_fates'});

--- a/components/clm/bld/configure
+++ b/components/clm/bld/configure
@@ -653,6 +653,7 @@ sub write_filepath_cesmbld
 		     "external_models/fates/biogeophys",
 		     "external_models/fates/biogeochem",
 		     "external_models/fates/fire",
+		     "external_models/fates/parteh",
 		     "external_models/mpp/src/mpp/dtypes",
 		     "external_models/mpp/src/mpp/thermal",
 		     "external_models/mpp/src/mpp/util",

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -103,7 +103,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
-<fates_paramfile >lnd/clm2/paramdata/fates_params_default_2trop.c180518.nc</fates_paramfile>
+<fates_paramfile >lnd/clm2/paramdata/fates_params_default_2trop.c181022.nc</fates_paramfile>
 
 
 <!-- soil order related parameters (relative to {csmdata}) -->
@@ -1717,6 +1717,7 @@ this mask will have smb calculated over the entire global land surface
 <use_fates_ed_st3              use_fates=".true.">.false.</use_fates_ed_st3>
 <use_fates_ed_prescribed_phys  use_fates=".true.">.false.</use_fates_ed_prescribed_phys>
 <use_fates_logging             use_fates=".true.">.false.</use_fates_logging>
+<fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>
 <use_fates_inventory_init      use_fates=".true.">.false.</use_fates_inventory_init>
 <fates_inventory_ctrl_filename use_fates=".true."> " " </fates_inventory_ctrl_filename>
 <use_vertsoilc                 bgc_mode="fates"  >.true.</use_vertsoilc>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -253,6 +253,12 @@ Toggle to turn on the FATES
 Toggle to turn on spitfire (only relevant if FATES is being used).
 </entry>
 
+<entry id="fates_parteh_mode" type="integer" category="physics"
+       group="clm_inparm" valid_values="">
+Switch deciding which nutrient model to use in FATES.
+</entry>
+
+
 <entry id="use_fates_logging" type="logical" category="physics"
         group="clm_inparm" valid_values="" value=".false.">
 Toggle to turn on the logging module (only relevant if FATES is being used).

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -195,6 +195,10 @@ module clm_varctl
   logical, public            :: use_fates_ed_prescribed_phys = .false. ! true => prescribed physiology
   logical, public            :: use_fates_inventory_init = .false.     ! true => initialize fates from inventory
   character(len=256), public :: fates_inventory_ctrl_filename = ''     ! filename for inventory control
+  integer, public            :: fates_parteh_mode = -9                 ! 1 => carbon only
+                                                                       ! 2 => C+N+P (not enabled yet)
+                                                                       ! no others enabled
+
 
   !----------------------------------------------------------
   !  BeTR switches

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -228,7 +228,8 @@ contains
           use_fates_planthydro, use_fates_ed_st3,       &
           use_fates_ed_prescribed_phys,                 &
           use_fates_inventory_init,                     &
-          fates_inventory_ctrl_filename
+          fates_inventory_ctrl_filename,                &
+          fates_parteh_mode
 
     namelist /clm_inparm / use_betr
         
@@ -646,6 +647,7 @@ contains
     call mpi_bcast (use_fates_inventory_init, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (fates_inventory_ctrl_filename, len(fates_inventory_ctrl_filename), &
           MPI_CHARACTER, 0, mpicom, ier)
+    call mpi_bcast (fates_parteh_mode, 1, MPI_INTEGER, 0, mpicom, ier)
 
 
     call mpi_bcast (use_betr, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -987,6 +989,7 @@ contains
        write(iulog, *) '    use_fates_logging = ', use_fates_logging
        write(iulog, *) '    fates_paramfile = ', fates_paramfile
        write(iulog, *) '    use_fates_planthydro = ', use_fates_planthydro
+       write(iulog, *) '    fates_parteh_mode = ', fates_parteh_mode
        write(iulog, *) '    use_fates_ed_st3 = ',use_fates_ed_st3
        write(iulog, *) '    use_fates_ed_prescribed_phys = ',use_fates_ed_prescribed_phys
        write(iulog, *) '    use_fates_inventory_init = ',use_fates_inventory_init


### PR DESCRIPTION
This changeset bring E3SM compatibility up to the most recent FATES API 6.0.0.  
This change enables the switching of different plant allocation modules "fates_parteh_mode"
in the namelist file.  This change also added a call in the interface to accomodate preprocessing
some extra information needed to correctly restart the radiation environment.

[non-BFB]