### PR TITLE
Add optional stream for co2 timeseries with latitude bands to datm.

### DIFF
--- a/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -295,7 +295,7 @@
       <value stream="CORE_IAF_JRA.NCEP.V_10">domain.atm.TL319.151007.nc</value>
       <value stream="CORE_IAF_JRA.CORE2.ArcFactor">CORE2.t_10.ArcFactor.T62.1997-2004.nc</value>
       <value stream="co2tseries.20tr" cime_model="e3sm">fco2_datm_1765-2007_c100614.nc</value>
-      <value stream="co2tseries.20tr.latbnd" cime_model="cesm">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
+      <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr" cime_model="cesm">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.rcp2.6">fco2_datm_rcp2.6_1765-2500_c130312.nc</value>
       <value stream="co2tseries.rcp4.5">fco2_datm_rcp4.5_1765-2500_c130312.nc</value>
@@ -1630,7 +1630,7 @@
         JRA.v1.3.v_10.TL319.2016.171019.nc
       </value>
       <value stream="CORE_IAF_JRA.CORE2.ArcFactor">CORE2.t_10.ArcFactor.T62.1997-2004.nc</value>
-      <value stream="co2tseries.20tr.latbnd" cime_model="cesm">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
+      <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr" cime_model="cesm">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr" cime_model="e3sm">fco2_datm_1765-2007_c100614.nc</value>
       <value stream="co2tseries.rcp2.6">fco2_datm_rcp2.6_1765-2500_c130312.nc</value>


### PR DESCRIPTION
Add optional stream for co2 timeseries with latitude bands to datm.  This file is not yet used by E3SM but now available as a datm option.

[BFB]