### PR TITLE
Turn budgets on by default for all fully-active compsets

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -561,6 +561,7 @@
     <values match="last">
       <value compset="DATM.*_POP\d"    >TRUE</value>
       <value compset="CAM.*_POP\d"     >TRUE</value>
+      <value compset="CAM.*_MPASO"     >TRUE</value>
       <value compset="CAM.*_DOCN%SOM">TRUE</value>
     </values>
     <group>run_budgets</group>


### PR DESCRIPTION
Requires further testing

This PR changes the default setting for BUDGET output from false to true for fully-coupled compsets (with both CAM and MPASO).

Tested with:
* SMS.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850.anvil_intel

[BFB]
[NML]