### PR TITLE
Control ouput of MPI task to compute node mapping data

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -45,6 +45,26 @@
     Used to set the driver namelist variable "drv_threading".</desc>
   </entry>
 
+  <entry id="INFO_TASKMAP_MODEL">
+    <type>integer</type>
+    <valid_values>0,1,2</valid_values>
+    <default_value>0</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>Sets level of task-to-node mapping output for the whole model 
+    (0: no output; 1: compact; 2: verbose).</desc>
+  </entry>
+
+  <entry id="INFO_TASKMAP_COMP">
+    <type>integer</type>
+    <valid_values>0,1,2</valid_values>
+    <default_value>0</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>Sets level of task-to-node mapping output for supported component models
+    (0: no output; 1: compact; 2: verbose).</desc>
+  </entry>
+
   <entry id="SAVE_TIMING">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -20,6 +20,26 @@
     Used to set the driver namelist variable "drv_threading".</desc>
   </entry>
 
+  <entry id="INFO_TASKMAP_MODEL">
+    <type>integer</type>
+    <valid_values>0,1,2</valid_values>
+    <default_value>2</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>Sets level of task-to-node mapping output for the whole model 
+    (0: no output; 1: compact; 2: verbose).</desc>
+  </entry>
+
+  <entry id="INFO_TASKMAP_COMP">
+    <type>integer</type>
+    <valid_values>0,1,2</valid_values>
+    <default_value>0</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>Sets level of task-to-node mapping output for supported component models
+    (0: no output; 1: compact; 2: verbose).</desc>
+  </entry>
+
   <entry id="SAVE_TIMING">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -2883,6 +2883,34 @@
     </values>
   </entry>
 
+  <entry id="info_taskmap_model">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>
+      level of task-to-node mapping output for the whole model 
+      (0: no output; 1: compact; 2: verbose)
+      default: 2
+    </desc>
+    <values>
+      <value>2</value>
+    </values>
+  </entry>
+
+  <entry id="info_taskmap_comp">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>
+      level of task-to-node mapping output for individual components
+      (0: no output; 1: compact; 2: verbose)
+      default: 0
+    </desc>
+    <values>
+      <value>0</value>
+    </values>
+  </entry>
+
   <!-- =========================== -->
   <!-- group prof_inparm           -->
   <!--  in perf_mod.F90            -->

--- a/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -2890,10 +2890,9 @@
     <desc>
       level of task-to-node mapping output for the whole model 
       (0: no output; 1: compact; 2: verbose)
-      default: 2
     </desc>
     <values>
-      <value>2</value>
+      <value>$INFO_TASKMAP_MODEL</value>
     </values>
   </entry>
 
@@ -2902,12 +2901,11 @@
     <category>cime_pes</category>
     <group>cime_pes</group>
     <desc>
-      level of task-to-node mapping output for individual components
+      level of task-to-node mapping output for individual component models
       (0: no output; 1: compact; 2: verbose)
-      default: 0
     </desc>
     <values>
-      <value>0</value>
+      <value>$INFO_TASKMAP_COMP</value>
     </values>
   </entry>
 

--- a/cime/src/drivers/mct/main/cime_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cime_comp_mod.F90
@@ -818,9 +818,9 @@ contains
 
           if (iamroot_CPLID) then
              write(c_cpl_npes,'(i8)') npes_CPLID
-             write(logunit,100) trim(adjustl(c_cpl_npes)), &
-                                trim(adjustl(c_cpl_inst))
-100          format(a,' pes participating in computation of CPL instance #',a)
+             write(logunit,'(3A)') trim(adjustl(c_cpl_npes)), &
+                                   ' pes participating in computation of CPL instance #', &
+                                   trim(adjustl(c_cpl_inst))
              call flush(logunit)
           endif
 

--- a/cime/src/drivers/mct/main/cime_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cime_comp_mod.F90
@@ -37,6 +37,7 @@ module cime_comp_mod
   use shr_orb_mod,       only: shr_orb_params
   use shr_frz_mod,       only: shr_frz_freezetemp_init
   use shr_reprosum_mod,  only: shr_reprosum_setopts
+  use shr_taskmap_mod,   only: shr_taskmap_write
   use mct_mod            ! mct_ wrappers for mct lib
   use perf_mod
   use ESMF
@@ -59,7 +60,7 @@ module cime_comp_mod
   !----------------------------------------------------------------------------
 
   ! mpi comm data & routines, plus logunit and loglevel
-  use seq_comm_mct, only: CPLID, GLOID, logunit, loglevel
+  use seq_comm_mct, only: CPLID, GLOID, logunit, loglevel, info_taskmap_comp
   use seq_comm_mct, only: ATMID, LNDID, OCNID, ICEID, GLCID, ROFID, WAVID, ESPID
   use seq_comm_mct, only: ALLATMID,ALLLNDID,ALLOCNID,ALLICEID,ALLGLCID,ALLROFID,ALLWAVID,ALLESPID
   use seq_comm_mct, only: CPLALLATMID,CPLALLLNDID,CPLALLOCNID,CPLALLICEID
@@ -634,6 +635,10 @@ contains
     character(len=seq_comm_namelen) :: comp_name(num_inst_total)
     integer :: it
     integer :: driver_comm
+    integer :: npes_CPLID
+    logical :: verbose_taskmap_output
+    character(len=8) :: c_cpl_inst    ! coupler instance number
+    character(len=8) :: c_cpl_npes    ! number of pes in coupler
 
     call mpi_init(ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_init')
@@ -672,8 +677,8 @@ contains
     if (iamroot_GLOID) output_perf = .true.
 
     call seq_comm_getinfo(CPLID,mpicom=mpicom_CPLID,&
-         iamroot=iamroot_CPLID,nthreads=nthreads_CPLID,&
-         iam=comp_comm_iam(it))
+         iamroot=iamroot_CPLID,npes=npes_CPLID, &
+         nthreads=nthreads_CPLID,iam=comp_comm_iam(it))
     if (iamroot_CPLID) output_perf = .true.
 
     comp_id(it)    = CPLID
@@ -791,6 +796,42 @@ contains
     else
        loglevel = 0
        call shr_file_setLogLevel(loglevel)
+    endif
+
+    !----------------------------------------------------------
+    !| Output task-to-node mapping data for coupler
+    !----------------------------------------------------------
+
+    if (info_taskmap_comp > 0) then
+       ! Identify SMP nodes and process/SMP mapping for the coupler.
+       ! (Assume that processor names are SMP node names on SMP clusters.)
+
+       if (iamin_CPLID) then
+
+          if (info_taskmap_comp == 1) then
+            verbose_taskmap_output = .false.
+          else
+            verbose_taskmap_output = .true.
+          endif
+
+          write(c_cpl_inst,'(i8)') num_inst_driver
+
+          if (iamroot_CPLID) then
+             write(c_cpl_npes,'(i8)') npes_CPLID
+             write(logunit,100) trim(adjustl(c_cpl_npes)), &
+                                trim(adjustl(c_cpl_inst))
+100          format(a,' pes participating in computation of CPL instance #',a)
+             call flush(logunit)
+          endif
+
+          call t_startf("shr_taskmap_write")
+          call shr_taskmap_write(logunit, mpicom_CPLID,                &
+                                 'CPL #'//trim(adjustl(c_cpl_inst)),   &
+                                 verbose=verbose_taskmap_output        )
+          call t_stopf("shr_taskmap_write")
+
+       endif
+
     endif
 
     !----------------------------------------------------------

--- a/cime/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/cime/src/drivers/mct/shr/seq_comm_mct.F90
@@ -151,6 +151,10 @@ module seq_comm_mct
 
   integer, parameter, public :: seq_comm_namelen=16
 
+  ! taskmap output level specifications for components
+  ! (0:no output, 1:compact, 2:verbose)
+  integer, public :: info_taskmap_comp
+
   ! suffix for log and timing files if multi coupler driver
   character(len=seq_comm_namelen), public  :: cpl_inst_tag
 
@@ -225,7 +229,10 @@ contains
     integer, pointer :: comps(:) ! array with component ids
     integer, pointer :: comms(:) ! array with mpicoms
     integer :: nu
-    character(len=8) :: c_global_numpes ! global number of pes
+    logical :: verbose_taskmap_output
+    integer :: drv_inst
+    character(len=8) :: c_drv_inst      ! driver instance number
+    character(len=8) :: c_driver_numpes ! number of pes in driver
     character(len=seq_comm_namelen) :: valid_comps(ncomps)
 
     integer :: &
@@ -237,7 +244,8 @@ contains
          rof_ntasks, rof_rootpe, rof_pestride, rof_nthreads, &
          ocn_ntasks, ocn_rootpe, ocn_pestride, ocn_nthreads, &
          esp_ntasks, esp_rootpe, esp_pestride, esp_nthreads, &
-         cpl_ntasks, cpl_rootpe, cpl_pestride, cpl_nthreads
+         cpl_ntasks, cpl_rootpe, cpl_pestride, cpl_nthreads, &
+         info_taskmap_model
 
     namelist /cime_pes/  &
          atm_ntasks, atm_rootpe, atm_pestride, atm_nthreads, atm_layout, &
@@ -248,7 +256,8 @@ contains
          rof_ntasks, rof_rootpe, rof_pestride, rof_nthreads, rof_layout, &
          ocn_ntasks, ocn_rootpe, ocn_pestride, ocn_nthreads, ocn_layout, &
          esp_ntasks, esp_rootpe, esp_pestride, esp_nthreads, esp_layout, &
-         cpl_ntasks, cpl_rootpe, cpl_pestride, cpl_nthreads
+         cpl_ntasks, cpl_rootpe, cpl_pestride, cpl_nthreads,             &
+         info_taskmap_model, info_taskmap_comp
     !----------------------------------------------------------
 
     ! make sure this is first pass and set comms unset
@@ -295,19 +304,6 @@ contains
        call shr_sys_abort(trim(subname)//' ERROR decomposition error ')
     endif
 
-#ifdef TIMING
-    ! output task-to-node mapping
-    if (mype == 0) then
-       write(c_global_numpes,'(i8)') global_numpes
-       write(logunit,100) trim(adjustl(c_global_numpes))
-100    format(/,a,' pes participating in computation of coupled model')
-       call shr_sys_flush(logunit)
-    endif
-    call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(logunit, GLOBAL_COMM_IN, 'GLOBAL', verbose=.true.)
-    call t_stopf("shr_taskmap_write")
-#endif
-
     ! Initialize gloiam on all IDs
 
     global_mype = mype
@@ -329,6 +325,8 @@ contains
        call comp_pelayout_init(numpes, glc_ntasks, glc_rootpe, glc_pestride, glc_nthreads, glc_layout)
        call comp_pelayout_init(numpes, esp_ntasks, esp_rootpe, esp_pestride, esp_nthreads, esp_layout)
        call comp_pelayout_init(numpes, cpl_ntasks, cpl_rootpe, cpl_pestride, cpl_nthreads)
+       info_taskmap_model = 0
+       info_taskmap_comp  = 0
 
        ! Read namelist if it exists
 
@@ -364,6 +362,51 @@ contains
     call shr_mpi_bcast(rof_layout,DRIVER_COMM,'rof_layout')
     call shr_mpi_bcast(esp_layout,DRIVER_COMM,'esp_layout')
 
+    call shr_mpi_bcast(info_taskmap_model,DRIVER_COMM,'info_taskmap_model')
+    call shr_mpi_bcast(info_taskmap_comp, DRIVER_COMM,'info_taskmap_comp' )
+
+#ifdef TIMING
+    if (info_taskmap_model > 0) then
+       ! output task-to-node mapping
+
+       if (info_taskmap_model == 1) then
+         verbose_taskmap_output = .false.
+       else
+         verbose_taskmap_output = .true.
+       endif
+
+       if (present(drv_comm_id)) then
+          drv_inst = drv_comm_id
+          write(c_drv_inst,'(i8)') drv_inst
+       else
+          drv_inst = 0
+       endif
+
+       if (mype == 0) then
+          write(c_driver_numpes,'(i8)') numpes
+          if (drv_inst == 0) then
+             write(logunit,100) trim(adjustl(c_driver_numpes))
+100          format(/,a,' pes participating in computation of coupled model')
+          else
+             write(logunit,101) trim(adjustl(c_driver_numpes)), trim(adjustl(c_drv_inst))
+101          format(/,a,' pes participating in computation of DRIVER instance #',a)
+          endif
+          call shr_sys_flush(logunit)
+       endif
+
+       call t_startf("shr_taskmap_write")
+       if (drv_inst == 0) then
+          call shr_taskmap_write(logunit, DRIVER_COMM, &
+                                 'GLOBAL', &
+                                 verbose=verbose_taskmap_output)
+       else
+          call shr_taskmap_write(logunit, DRIVER_COMM, &
+                                 'DRIVER #'//trim(adjustl(c_drv_inst)), &
+                                 verbose=verbose_taskmap_output)
+       endif
+       call t_stopf("shr_taskmap_write")
+    endif
+#endif
 
     !--- compute some other num_inst values
 

--- a/cime/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/cime/src/drivers/mct/shr/seq_comm_mct.F90
@@ -385,11 +385,12 @@ contains
        if (mype == 0) then
           write(c_driver_numpes,'(i8)') numpes
           if (drv_inst == 0) then
-             write(logunit,100) trim(adjustl(c_driver_numpes))
-100          format(/,a,' pes participating in computation of coupled model')
+             write(logunit,'(2A)') trim(adjustl(c_driver_numpes)), &
+                                   ' pes participating in computation of coupled model'
           else
-             write(logunit,101) trim(adjustl(c_driver_numpes)), trim(adjustl(c_drv_inst))
-101          format(/,a,' pes participating in computation of DRIVER instance #',a)
+             write(logunit,'(3A)') trim(adjustl(c_driver_numpes)), &
+                                   ' pes participating in computation of DRIVER instance #', &
+                                   trim(adjustl(c_drv_inst))
           endif
           call shr_sys_flush(logunit)
        endif


### PR DESCRIPTION
A recent PR fixed the output of component-specific MPI task to compute
node mapping for ATM and LND, and added it for ROF, OCN, ICE, and
GLC. The utility of this output for each component is unclear, and a
namelist variable to enable  or disable it is added here. This
variable also allows setting  the format of the output. All component
model task-to-node mapping output is controlled by this single
cime_pes namelist variable info_taskmap_comp, where setting this to 0
disables output,  setting it to 1 uses the more compact format, and
setting it to 2 uses the more verbose format.

Note that a separate component-only PR will be needed for the
components to be aware of info_taskmap_comp and use this as described
above, but this additional code has been used to test this PR.

For symmetry, a cime_pes namelist variable info_taskmap_model
was also added to control the task-to-node mapping output for
the full coupled model, with the same options (0, 1, and 2). The
default here is 2 (preserving the current behavior).

Also for symmetry, output of task-to-node mapping data was added
for the CPL component (and is controlled by info_taskmap_comp the same
as for the other component models).

Finally, the implementation for the whole-model task-to-node mapping
data output was modified to better reflect the (currently incomplete?)
support for running the model with multiple drivers.

The two new namelist parameters were added to env_run.xml, and should
be set from there.

[BFB]
[NML]