### PR TITLE
update CCSM_CO2_PPMV for new BGC compset names

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -617,6 +617,10 @@
       <value compset="^2000.+AV1C-H01C"				>368.865</value>
       <value compset="^1850.+CMIP6"                             >284.317</value>
       <value compset="^1950.+CMIP6"                             >312.821</value>
+      <value compset="^20TR.*BGC%BCRC"                                >284.317</value>
+      <value compset="^20TR.*BGC%BCRD"                                >284.317</value>
+      <value compset="^20TR.*BGC%BDRC"                                >284.317</value>
+      <value compset="^20TR.*BGC%BDRD"                                >284.317</value>
       <!-- Override values based on CAM (WACCM) chemistry -->
       <value compset="CAM[45]%W"				>0.000001</value>
       <value compset="CAM[45]%SSOA"				>0.000001</value>


### PR DESCRIPTION
This PR adds the new coupled BGC compset names as tests when setting CCSM_CO2_PPMV. when the compset names were changed quite some time ago (for example, from 20TR_CAM5%AV1C-L.... to 20TR_CAM5%CMIP6....) this file was not updated, so none of the 20th century BGC compsets (BCRD, BDRC, BDRD) had CCSM_CO2_PPMV set correctly.

Cherry-picked for maint-1.1 from PR #2620 

[NML]
[BFB]