### PR TITLE
Fix gen_domain tool to work in the absence of masks

### DIFF
--- a/cime/tools/mapping/gen_domain_files/README
+++ b/cime/tools/mapping/gen_domain_files/README
@@ -31,6 +31,7 @@ $ gen_domain -m <filemap>
              [-c <user comment gen_domain.nml>]
              [--fminval <fminval>]
              [--fmaxval <fmaxval>]
+             [--set-omask]
  
 where:
     filemap = input mapping file name  (character string)
@@ -40,6 +41,12 @@ where:
     set_fv_pole_yc = [0,1,2] ~ optional, default = 0 (see comments below)
     fminval = minimum allowable land fraction (reset to 0 below fminval)
     fmaxval = maximum allowable land fraction (reset to 1 above fmaxval)
+
+Notes:
+    If --set-omask is passed, then an ocean mask is not required and will
+    simply be set to a vector of 1s if mask_a is not present in the input
+    mapping file. If --set-omask is omitted, then mask_a is required and an
+    error will be raised if it does not exist in the input mapping file.
 
 The following output domain files are created:
   domain.lnd.gridlnd_gridocn.nc

--- a/cime/tools/mapping/gen_domain_files/README
+++ b/cime/tools/mapping/gen_domain_files/README
@@ -29,8 +29,8 @@ $ gen_domain -m <filemap>
              -l <gridlnd>
              [-p set_fv_pole_yc]
              [-c <user comment gen_domain.nml>]
-             [--fminval <fminval>]'
-             [--fmaxval <fmaxval>]'
+             [--fminval <fminval>]
+             [--fmaxval <fmaxval>]
  
 where:
     filemap = input mapping file name  (character string)
@@ -38,13 +38,13 @@ where:
     gridlnd = output land grid name    (NOT A FILE NAME!)
     usercomment = optional, netcdf global attribute (character string)
     set_fv_pole_yc = [0,1,2] ~ optional, default = 0 (see comments below)
-    fminval = minimum allowable land fraction (reset to 0 below fminval)'
-    fmaxval = maximum allowable land fraction (reset to 1 above fmaxval)'
+    fminval = minimum allowable land fraction (reset to 0 below fminval)
+    fmaxval = maximum allowable land fraction (reset to 1 above fmaxval)
 
 The following output domain files are created:
   domain.lnd.gridlnd_gridocn.nc
   domain.ocn.gridlnd_gridocn.nc
-  domain.ocn.gridocn.nc'
+  domain.ocn.gridocn.nc
 
 =====
 NOTES

--- a/cime/tools/mapping/gen_domain_files/README
+++ b/cime/tools/mapping/gen_domain_files/README
@@ -29,13 +29,17 @@ $ gen_domain -m <filemap>
              -l <gridlnd>
              [-p set_fv_pole_yc]
              [-c <user comment gen_domain.nml>]
-
+             [--fminval <fminval>]'
+             [--fmaxval <fmaxval>]'
+ 
 where:
     filemap = input mapping file name  (character string)
     gridocn = output ocean grid name   (NOT A FILE NAME!)
     gridlnd = output land grid name    (NOT A FILE NAME!)
     usercomment = optional, netcdf global attribute (character string)
     set_fv_pole_yc = [0,1,2] ~ optional, default = 0 (see comments below)
+    fminval = minimum allowable land fraction (reset to 0 below fminval)'
+    fmaxval = maximum allowable land fraction (reset to 1 above fmaxval)'
 
 The following output domain files are created:
   domain.lnd.gridlnd_gridocn.nc


### PR DESCRIPTION
Remove dependence on "mask" variables in the mapping files that are input to the `gen_domain` 
tool.

The `gen_domain` tool is used to construct "domain files", which indicate the fractional coverage of component grids. This tool previously expected "mask" variables for both the target and source grids, which indicated whether or not component values would be valid at each point in the grid. This concept applied to FV grids, where a global mesh was established but various components may or may not be active at each point in that mesh. For example, the ocean would not be active over land points, so the mask should be zero for those points. This concept does not necessarily apply to newer unstructured grids, which can be designed to simply not include points where the component would not be active. Thus, a mask variable is unnecessary for these grids.

Add options to set the ocean mask to 1 if its not present.  Program will still die if mask is not present and --set-omask is not given.

Also make the fminval and fmaxval optional input paramaters.
