### PR TITLE
Update the MOSART 1/8th degree global parameter file

### DIFF
--- a/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
+++ b/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
@@ -28,7 +28,7 @@ for the CLM data in the CESM distribution
 
 <!-- River Transport Model river routing file (relative to {csmdata}) -->
 
-<frivinp_rtm rof_grid="r0125" >rof/mosart/MOSART_global_8th_20180211b.nc</frivinp_rtm>
+<frivinp_rtm rof_grid="r0125" >rof/mosart/MOSART_global_8th_20180211c.nc</frivinp_rtm>
 <frivinp_rtm rof_grid="r05" >rof/mosart/MOSART_global_half_20180721a.nc</frivinp_rtm>
 <frivinp_rtm rof_grid="NLDAS" >rof/mosart/MOSART_NLDAS_8th.nc</frivinp_rtm>
 


### PR DESCRIPTION
Do not merge until tested

This PR brings in a new MOSART 1/8th-degree global parameter file that corrects the unrealistic values in the uh (Manning's roughness coefficient for overland flow routing) field. The new file is called MOSART_global_8th_20180211c.nc and has been uploaded to the inputdata directory on anvil.

[NML]
[non-BFB] only for high-res configurations with active runoff