### PR TITLE
ARKode-HOMME Interface

### DIFF
--- a/components/homme/CMakeLists.txt
+++ b/components/homme/CMakeLists.txt
@@ -110,6 +110,13 @@ IF (${HOMME_USE_CXX})
   ENABLE_LANGUAGE(CXX)
 ENDIF ()
 
+# Option to use ARKode package from SUNDIALS
+OPTION(HOMME_USE_ARKODE "Use ARKode package from SUNDIALS" FALSE)
+IF (${HOMME_USE_ARKODE})
+  MESSAGE(STATUS "Using ARKode, adding -DARKODE")
+  ADD_DEFINITIONS(-DARKODE)
+ENDIF ()
+
 IF (${HOMME_USE_KOKKOS})
   ############################################
   # Selection of Kokkos execution space
@@ -220,6 +227,12 @@ IF (DEFINED EXTRAE_DIR)
   MESSAGE(STATUS "Building with Extrae")
   FIND_PACKAGE(Extrae REQUIRED)
   SET(HAVE_EXTRAE TRUE)
+ENDIF ()
+
+# this section is for linking to SUNDIALS/ARKODE as an external library
+IF (DEFINED SUNDIALS_DIR)
+  LINK_DIRECTORIES(${SUNDIALS_DIR}/lib)
+  INCLUDE_DIRECTORIES(${SUNDIALS_DIR}/include)
 ENDIF ()
 
 ###########################################

--- a/components/homme/cmake/HommeMacros.cmake
+++ b/components/homme/cmake/HommeMacros.cmake
@@ -150,6 +150,14 @@ macro(createTestExec execName execType macroNP macroNC
     TARGET_LINK_LIBRARIES(${execName} ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES})
   ENDIF()
 
+
+  IF (HOMME_USE_ARKODE AND "${execType}" STREQUAL "theta-l")
+    TARGET_LINK_LIBRARIES(${execName} sundials_farkode)
+    TARGET_LINK_LIBRARIES(${execName} sundials_arkode)
+    TARGET_LINK_LIBRARIES(${execName} sundials_nvecserial)
+    TARGET_LINK_LIBRARIES(${execName} sundials_fnvecserial)
+  ENDIF ()
+
   INSTALL(TARGETS ${execName} RUNTIME DESTINATION tests)
 
 endmacro(createTestExec)

--- a/components/homme/src/arkode/column_linsol.c
+++ b/components/homme/src/arkode/column_linsol.c
@@ -1,0 +1,87 @@
+/*******************************************************************
+ * Daniel R. Reynolds
+ * SMU Mathematics
+ * Copyright 2017; all rights reserved
+ * -----------------------------------------------------------------
+ * This is the implementation file for a Fortran columnwise linear 
+ * solver package for HOMME+ARKode.  This is specifically created
+ * to pair with the NVECTOR_EXTERNAL vector implementation.  It is 
+ * assumed that the linear solver 'setup' is empty, and that the 
+ * 'solve' routine internally sets up the linear system matrix 
+ * on-the-fly and uses it in the solve process.
+ *******************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "column_linsol.h"
+#include "nvector_external.h"
+
+
+/********************* Fortran Interface Functions ***************/
+
+/* define global matrix and linear solver variables for Fortran interface */
+extern void *ARK_arkodemem;
+
+
+/* FCOLUMNSOL_INIT is the Fortran interface routine to initialize the 
+   Fortran linear solver object. */
+void FCOLUMNSOL_INIT(int *ier)
+{
+  ARKodeMem ark_mem;
+
+  /* initialize return value to success */
+  *ier = 0;
+
+  /* verify that ARKode FCMIX interface has been initialized */
+  if (ARK_arkodemem == NULL) {
+    *ier = -1;
+    return;
+  }
+  ark_mem = (ARKodeMem) ARK_arkodemem;
+
+  /* free any existing system solver attached to ARKode */
+  if (ark_mem->ark_lfree)  ark_mem->ark_lfree(ark_mem);
+
+  /* Set system linear solver components of the ARKode memory structure -- 
+     only lsolve is required (and that is all that is used here).
+     Also specify that this is a 'custom' linear solver */
+  ark_mem->ark_lsolve = ColumnSolSolve;
+  ark_mem->ark_linit  = NULL;
+  ark_mem->ark_lsetup = NULL;
+  ark_mem->ark_lfree  = NULL;
+  ark_mem->ark_lsolve_type = 2;
+  ark_mem->ark_lmem = NULL;
+}
+
+
+/* ColumnSolSolve is the C interface routine to call the Fortran-supplied 
+   FCOLUMNSOL_SOLVE routine.
+ */
+int ColumnSolSolve(struct ARKodeMemRec *ark_mem, N_Vector b,
+                   N_Vector ycur, N_Vector fcur) {
+
+  /* declare local data */
+  void *bd, *yd;
+  double tcur, gamma;
+  int ier;
+
+  /* initialize return flag to success */
+  ier = 0;
+
+  /* access current time */
+  tcur = ark_mem->ark_tn;
+
+  /* extract N_Vector data pointers */
+  bd = yd = NULL;
+  bd  = NV_DATA_EXT(b);
+  yd  = NV_DATA_EXT(ycur);
+  gamma = ark_mem->ark_gamma;
+
+  /* call Fortran routine to do operation */
+  FCOLUMNSOL_SOLVE(bd, &tcur, yd, &gamma, &ier);
+  return(ier);
+}
+
+
+/*********************** END OF FILE ***********************/

--- a/components/homme/src/arkode/column_linsol.h
+++ b/components/homme/src/arkode/column_linsol.h
@@ -1,0 +1,69 @@
+/*******************************************************************
+ * Daniel R. Reynolds
+ * SMU Mathematics
+ * Copyright 2017; all rights reserved
+ * -----------------------------------------------------------------
+ * This is the header file for a Fortran columnwise linear solver 
+ * package for HOMME+ARKode.  This is specifically created
+ * to pair with the NVECTOR_EXTERNAL vector implementation.  It is 
+ * assumed that the linear solver 'setup' is empty, and that the 
+ * 'solve' routine internally sets up the linear system matrix 
+ * on-the-fly and uses it in the solve process.  
+ *******************************************************************/
+
+#ifndef _COLUMNSOL_H
+#define _COLUMNSOL_H
+
+#include <sundials/sundials_nvector.h>
+#include <arkode/arkode_impl.h>
+
+#ifdef __cplusplus  /* wrapper to enable C++ usage */
+extern "C" {
+#endif
+
+/*-----------------------------------------------------------------
+  Part I: Fortran callable wrappers for the interface routines, as
+  well as prototypes of the supplied Fortran vector operations
+  to be called by C routines.
+  -----------------------------------------------------------------*/
+
+/* Define Fortran/C interface wrappers */
+#if defined(SUNDIALS_F77_FUNC)
+
+#define FCOLUMNSOL_INIT   SUNDIALS_F77_FUNC(fcolumnsolinit,  FCOLUMNSOLINIT)
+#define FCOLUMNSOL_SOLVE  SUNDIALS_F77_FUNC(fcolumnsolsolve, FCOLUMNSOLSOLVE)
+
+#else
+
+#define FCOLUMNSOL_INIT   fcolumnsolinit_
+#define FCOLUMNSOL_SOLVE  fcolumnsolsolve_
+
+#endif
+
+  /* Prototype of initialization function -- called from Fortran to initialize 
+     this linear solver interface, and attach it to the ARKode memory structure */
+  void FCOLUMNSOL_INIT(int *ier);
+
+  /* Prototype of the Fortran-supplied 'solve' routine: given a RHS vector B, the 
+     current time T, the current solution, Y, and the current time step scale factor, 
+     GAMMA, this solves the linear systems (defined internally), storing the 
+     solution back in the vector B.  
+
+     The return value should be 0 on success, a positive value on a recoverable 
+     failure (e.g. an illegal value that might be fixed with a smaller time step 
+     size), and a negative value on a non-recoverable failure.
+  */
+  void FCOLUMNSOL_SOLVE(void* B, double* T, void* Y, double *GAMMA, int* IER);
+
+  /* Prototype of the C interface to FCOLUMNSOL_SOLVE -- this is the 'lsolve' 
+     routine attached to ARKode's memory structure */
+  int ColumnSolSolve(struct ARKodeMemRec *ark_mem, N_Vector b,
+                     N_Vector ycur, N_Vector fcur);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/components/homme/src/arkode/nvector_external.c
+++ b/components/homme/src/arkode/nvector_external.c
@@ -1,0 +1,705 @@
+/*******************************************************************
+ * Daniel R. Reynolds
+ * SMU Mathematics
+ * Copyright 2010; all rights reserved
+ *-----------------------------------------------------------------
+ * This is the implementation file for an implementation
+ * of the NVECTOR package, specifically suited to interface with
+ * a external [Fortran] data structure and vector implementation.
+ *
+ * It contains the N_Vector kernels listed in nvector_external.h,
+ * as well as implementations of the interfaces to the
+ * create and destroy routines N_VNew_EXT and N_VDestroy_EXT.
+ *
+ *******************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "nvector_external.h"
+#include <sundials/sundials_math.h>
+
+#define ZERO   RCONST(0.0)
+
+
+/********************* Fortran Interface Functions ***************/
+
+/* define global N_Vector variables for Fortran interface */
+N_Vector F2C_CVODE_vec;
+N_Vector F2C_IDA_vec;
+N_Vector F2C_KINSOL_vec;
+N_Vector F2C_ARKODE_vec;
+
+
+/* FNVEXT_INIT is the Fortran interface routine to initialize the
+   template NVector */
+void FNVEXT_INIT(int *code, int *ier)
+{
+  /* initialize return value to success */
+  *ier = 0;
+
+  /* Create solver-specific global NVector */
+  /*   code = FCMIX_CVODE  (1) -> use with CVODE */
+  /*   code = FCMIX_IDA    (2) -> use with IDA */
+  /*   code = FCMIX_KINSOL (3) -> use with KINSOL */
+  /*   code = FCMIX_ARKODE (4) -> use with ARKODE */
+  /*   [others not implemented] */
+  switch(*code) {
+  case FCMIX_CVODE:
+    F2C_CVODE_vec = NULL;
+    F2C_CVODE_vec = N_VNewEmpty_EXT();
+    if (F2C_CVODE_vec == NULL) *ier = -1;
+    break;
+  case FCMIX_IDA:
+    F2C_IDA_vec = NULL;
+    F2C_IDA_vec = N_VNewEmpty_EXT();
+    if (F2C_IDA_vec == NULL) *ier = -1;
+    break;
+  case FCMIX_KINSOL:
+    F2C_KINSOL_vec = NULL;
+    F2C_KINSOL_vec = N_VNewEmpty_EXT();
+    if (F2C_KINSOL_vec == NULL) *ier = -1;
+    break;
+  case FCMIX_ARKODE:
+    F2C_ARKODE_vec = NULL;
+    F2C_ARKODE_vec = N_VNewEmpty_EXT();
+    if (F2C_ARKODE_vec == NULL) *ier = -1;
+    break;
+  default:
+    *ier = -1;
+  }
+}
+
+
+/********************* Exported Functions ************************/
+
+
+/* Returns vector type ID.interface */
+N_Vector_ID N_VGetVectorID_EXT(N_Vector v)
+{
+  return SUNDIALS_NVEC_CUSTOM;
+}
+
+
+/* Function to create a new, empty EXT vector */
+N_Vector N_VNewEmpty_EXT()
+{
+  N_Vector v;
+  N_Vector_Ops ops;
+  N_VectorContent_EXT content;
+
+  /* Initialize vector pointers to NULL */
+  v = NULL;
+  ops = NULL;
+  content = NULL;
+
+  /* Create vector */
+  v = (N_Vector) malloc(sizeof *v);
+  if (v == NULL) return(NULL);
+
+  /* Create vector operation structure */
+  ops = (N_Vector_Ops) malloc(sizeof(struct _generic_N_Vector_Ops));
+  if (ops == NULL) {free(v); return(NULL); }
+
+  /* Attach custom vector routines to N_Vector_Ops structure */
+  ops->nvgetvectorid     = N_VGetVectorID_EXT;
+  ops->nvclone           = N_VClone_EXT;
+  ops->nvcloneempty      = N_VCloneEmpty_EXT;
+  ops->nvdestroy         = N_VDestroy_EXT;
+  ops->nvspace           = N_VSpace_EXT;
+  ops->nvgetarraypointer = N_VGetArrayPointer_EXT;
+  ops->nvsetarraypointer = N_VSetArrayPointer_EXT;
+  ops->nvlinearsum       = N_VLinearSum_EXT;
+  ops->nvconst           = N_VConst_EXT;
+  ops->nvprod            = N_VProd_EXT;
+  ops->nvdiv             = N_VDiv_EXT;
+  ops->nvscale           = N_VScale_EXT;
+  ops->nvabs             = N_VAbs_EXT;
+  ops->nvinv             = N_VInv_EXT;
+  ops->nvaddconst        = N_VAddConst_EXT;
+  ops->nvdotprod         = N_VDotProd_EXT;
+  ops->nvmaxnorm         = N_VMaxNorm_EXT;
+  ops->nvwrmsnorm        = N_VWrmsNorm_EXT;
+  ops->nvwrmsnormmask    = N_VWrmsNormMask_EXT;
+  ops->nvmin             = N_VMin_EXT;
+  ops->nvwl2norm         = N_VWL2Norm_EXT;
+  ops->nvl1norm          = N_VL1Norm_EXT;
+  ops->nvcompare         = N_VCompare_EXT;
+  ops->nvinvtest         = N_VInvTest_EXT;
+  ops->nvconstrmask      = N_VConstrMask_EXT;
+  ops->nvminquotient     = N_VMinQuotient_EXT;
+
+  /* Create content */
+  content =
+    (N_VectorContent_EXT) malloc(sizeof(struct _N_VectorContent_EXT));
+  if (content == NULL) {free(ops); free(v); return(NULL);}
+
+  /* Initialize content structure members */
+  content->data     = NULL;
+  content->own_data = SUNFALSE;
+
+  /* Attach content and ops to generic N_Vector */
+  v->content = content;
+  v->ops     = ops;
+
+  return(v);
+}
+
+
+
+/* N_VMake_EXT (or nvmake) creates a EXT N_Vector with 'content'
+   pointing to user-provided structure */
+N_Vector N_VMake_EXT(void* v_data)
+{
+  /* initialize v to NULL */
+  N_Vector v = NULL;
+
+  /* Create vector */
+  v = N_VNewEmpty_EXT();
+  if (v == NULL) return(NULL);
+
+  /* Attach data if it is non-NULL */
+  if ( v_data != NULL ) {
+    NV_OWN_DATA_EXT(v) = SUNFALSE;
+    NV_DATA_EXT(v)     = v_data;
+  }
+
+  return(v);
+}
+
+
+
+/* N_VPrint_EXT prints the N_Vector v to stdout.  This routine is
+   provided to aid in debugging code using this vector package. */
+void N_VPrint_EXT(N_Vector v)
+{
+  /* initialize vd to NULL */
+  void *vd = NULL;
+
+  /* access content field from vector; return if NULL */
+  vd = NV_DATA_EXT(v);
+  if (vd == NULL) return;
+
+  /* call Fortran subroutine */
+  FNVEXT_PRINT(vd);
+}
+
+
+
+/***************************************************************************/
+/* BEGIN implementation of vector operations */
+
+/* N_VCloneEmpty_EXT returns a new N_Vector of the same form as the
+   input N_Vector, but with empty data container */
+N_Vector N_VCloneEmpty_EXT(N_Vector w)
+{
+  N_Vector v;
+  N_Vector_Ops ops;
+  N_VectorContent_EXT content;
+
+  /* initialize pointers to NULL */
+  v = NULL;
+  ops = NULL;
+  content = NULL;
+
+  /* Check that w has been created */
+  if (w == NULL) return(NULL);
+
+  /* Create vector */
+  v = (N_Vector) malloc(sizeof *v);
+  if (v == NULL) return(NULL);
+
+  /* Create vector operation structure */
+  ops = (N_Vector_Ops) malloc(sizeof(struct _generic_N_Vector_Ops));
+  if (ops == NULL) { free(v); return(NULL); }
+
+  /* Attach operations */
+  ops->nvgetvectorid     = w->ops->nvgetvectorid;
+  ops->nvclone           = w->ops->nvclone;
+  ops->nvcloneempty      = w->ops->nvcloneempty;
+  ops->nvdestroy         = w->ops->nvdestroy;
+  ops->nvspace           = w->ops->nvspace;
+  ops->nvgetarraypointer = w->ops->nvgetarraypointer;
+  ops->nvsetarraypointer = w->ops->nvsetarraypointer;
+  ops->nvlinearsum       = w->ops->nvlinearsum;
+  ops->nvconst           = w->ops->nvconst;
+  ops->nvprod            = w->ops->nvprod;
+  ops->nvdiv             = w->ops->nvdiv;
+  ops->nvscale           = w->ops->nvscale;
+  ops->nvabs             = w->ops->nvabs;
+  ops->nvinv             = w->ops->nvinv;
+  ops->nvaddconst        = w->ops->nvaddconst;
+  ops->nvdotprod         = w->ops->nvdotprod;
+  ops->nvmaxnorm         = w->ops->nvmaxnorm;
+  ops->nvwrmsnorm        = w->ops->nvwrmsnorm;
+  ops->nvwrmsnormmask    = w->ops->nvwrmsnormmask;
+  ops->nvmin             = w->ops->nvmin;
+  ops->nvwl2norm         = w->ops->nvwl2norm;
+  ops->nvl1norm          = w->ops->nvl1norm;
+  ops->nvcompare         = w->ops->nvcompare;
+  ops->nvinvtest         = w->ops->nvinvtest;
+  ops->nvconstrmask      = w->ops->nvconstrmask;
+  ops->nvminquotient     = w->ops->nvminquotient;
+
+  /* Create content */
+  content =
+    (N_VectorContent_EXT) malloc(sizeof(struct _N_VectorContent_EXT));
+  if (content == NULL) { free(ops); free(v); return(NULL); }
+
+  /* Initialize content structure members */
+  content->own_data = SUNFALSE;
+  content->data     = NULL;
+
+  /* Attach content and ops */
+  v->content = content;
+  v->ops     = ops;
+
+  return(v);
+}
+
+
+
+/* N_VClone_EXT returns a new N_Vector of the same form as the
+   input N_Vector. */
+N_Vector N_VClone_EXT(N_Vector w)
+{
+  N_Vector v;
+  void *wdata, *vdata;
+  int ierr;
+
+  /* initialize pointers to NULL */
+  v = NULL;
+  wdata = NULL;
+  vdata = (void **) malloc(sizeof(void *));
+
+  /* Create vector */
+  v = N_VCloneEmpty_EXT(w);
+  if (v == NULL) return(NULL);
+
+  /* Access data pointer for w */
+  wdata = NV_DATA_EXT(w);
+
+  /* Call Fortran routine to allocate data */
+  FNVEXT_CLONE(wdata, vdata, &ierr);
+
+  /* Fail gracefully if data is still NULL */
+  if(ierr != 0) { N_VDestroy_EXT(v); return(NULL); }
+
+  /* Attach data */
+  NV_OWN_DATA_EXT(v) = SUNTRUE;
+  NV_DATA_EXT(v)     = vdata;
+
+  return(v);
+}
+
+
+
+/* N_VDestroy_EXT frees the data storage for a N_Vector */
+void N_VDestroy_EXT(N_Vector v)
+{
+  void *vdata = NULL;
+  if ( (NV_OWN_DATA_EXT(v) == SUNTRUE) && (NV_DATA_EXT(v) != NULL) ) {
+    vdata = NV_DATA_EXT(v);
+    FNVEXT_DESTROY(vdata);
+    NV_DATA_EXT(v) = NULL;
+  }
+  free(v->content); v->content = NULL;
+  free(v->ops); v->ops = NULL;
+  free(v); v = NULL;
+
+  return;
+}
+
+
+
+/* N_VSpace_EXT should return the space requirements for one N_Vector;
+   however this routine is not utilized by SUNDIALS unless the user asks a
+   particular integrator about its storage requirements.  As such, this is
+   essentially a dummy routine, and so we return zero for both arguments. */
+void N_VSpace_EXT(N_Vector v, long int* lrw, long int* liw)
+{
+  *lrw = ZERO;
+  *liw = 0;
+  return;
+}
+
+
+
+/* N_VGetArrayPointer_EXT (or nvgetarraypointer) extracts the
+   data component array from the N_Vector v.  While the resulting pointer
+   is cast to have 'realtype' type, this will just be re-cast to the
+   appropriate pointer type by the user routines.
+
+   **Warning: do not attempt to use SUNDIALS' direct linear solvers
+     from this interface, since they will attempt to access specific
+     entries of the data 'array', which will in actuality point to
+     random memory locations in the Fortran vector data structure. */
+realtype *N_VGetArrayPointer_EXT(N_Vector v)
+{
+  return((realtype *) NV_DATA_EXT(v));
+}
+
+
+
+/* N_VSetArrayPointer_EXT or (nvsetarraypointer) attaches the
+   data component array v_data to the N_Vector v.  While the input
+   pointer is assumed to have 'realtype' type, this will just be
+   re-cast from the actual Fortran pointer type. */
+void N_VSetArrayPointer_EXT(realtype* v_data, N_Vector v)
+{
+  /* if (v_data != NULL)  NV_DATA_EXT(v) = v_data; */
+  if (v_data != NULL)  NV_DATA_EXT(v) = (void *) v_data;
+}
+
+
+
+/* N_VLinearSum_EXT (or nvlinearsum) calculates z = a*x + b*y */
+void N_VLinearSum_EXT(realtype a, N_Vector x, realtype b,
+		      N_Vector y, N_Vector z)
+{
+  /* extract data array handles from vectors */
+  void *xd, *yd, *zd;
+  xd = yd = zd = NULL;
+  xd = NV_DATA_EXT(x);
+  yd = NV_DATA_EXT(y);
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to do operation */
+  FNVEXT_LINSUM(&a, xd, &b, yd, zd);
+
+  return;
+}
+
+
+
+/* N_VConst_EXT (or nvconst) calculates z[i] = c for all i */
+void N_VConst_EXT(realtype c, N_Vector z)
+{
+  /* extract data array handles from N_Vectors */
+  void *zd = NULL;
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to set z to c */
+  FNVEXT_CONST(&c, zd);
+
+  return;
+}
+
+
+
+/* N_VProd_EXT (or nvprod) calculates z[i] = x[i]*y[i] */
+void N_VProd_EXT(N_Vector x, N_Vector y, N_Vector z)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *yd, *zd;
+  xd = yd = zd = NULL;
+  xd = NV_DATA_EXT(x);
+  yd = NV_DATA_EXT(y);
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to do product */
+  FNVEXT_PROD(xd, yd, zd);
+
+  return;
+}
+
+
+
+/* N_VDiv_EXT (or nvdiv) calculates z[i] = x[i]/y[i] */
+void N_VDiv_EXT(N_Vector x, N_Vector y, N_Vector z)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *yd, *zd;
+  xd = yd = zd = NULL;
+  xd = NV_DATA_EXT(x);
+  yd = NV_DATA_EXT(y);
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to do division */
+  FNVEXT_DIV(xd, yd, zd);
+
+  return;
+}
+
+
+
+/* N_VScale_EXT (or nvscale) calculates z = c*x */
+void N_VScale_EXT(realtype c, N_Vector x, N_Vector z)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *zd;
+  xd = zd = NULL;
+  xd = NV_DATA_EXT(x);
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to do operation */
+  FNVEXT_SCALE(&c, xd, zd);
+
+  return;
+}
+
+
+
+/* N_VAbs_EXT or (nvabs) calculates z[i] = |x[i]| */
+void N_VAbs_EXT(N_Vector x, N_Vector z)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *zd;
+  xd = zd = NULL;
+  xd = NV_DATA_EXT(x);
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to do operation */
+  FNVEXT_ABS(xd, zd);
+
+  return;
+}
+
+
+
+/* N_VInv_EXT (or nvinv) calculates z[i] = 1/x[i].
+   Note: it does not check for division by 0.  It should be called only
+   with an N_Vector x which is guaranteed to have all non-zero components. */
+void N_VInv_EXT(N_Vector x, N_Vector z)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *zd;
+  xd = zd = NULL;
+  xd = NV_DATA_EXT(x);
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to do operation */
+  FNVEXT_INV(xd, zd);
+
+  return;
+}
+
+
+
+/* N_VAddConst_EXT (or nvaddconst) calculates z[i] = x[i] + b */
+void N_VAddConst_EXT(N_Vector x, realtype b, N_Vector z)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *zd;
+  xd = zd = NULL;
+  xd = NV_DATA_EXT(x);
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to do operation */
+  FNVEXT_ADDCONST(&b, xd, zd);
+
+  return;
+}
+
+
+
+/* N_VDotProd_EXT (or nvdotprod) returns the value of the
+   ordinary dot product of x and y, i.e. sum (i=0 to N-1) {x[i] * y[i]} */
+realtype N_VDotProd_EXT(N_Vector x, N_Vector y)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *yd;
+  realtype sum = ZERO;
+  xd = yd = NULL;
+  xd = NV_DATA_EXT(x);
+  yd = NV_DATA_EXT(y);
+
+  /* call fortran routine to do operation */
+  FNVEXT_DOTPROD(xd, yd, &sum);
+  return(sum);
+}
+
+
+
+/* N_VMaxNorm_EXT (or nvmaxnorm) returns the maximum norm of x,
+   i.e. max(i=1 to N-1) |x[i]|  */
+realtype N_VMaxNorm_EXT(N_Vector x)
+{
+  /* extract data array handles from N_Vectors */
+  realtype maxval = ZERO;
+  void *xd  = NULL;
+  xd = NV_DATA_EXT(x);
+
+  /* call fortran routine to do operation */
+  FNVEXT_MAXNORM(xd, &maxval);
+  return(maxval);
+}
+
+
+
+/* N_VWrmsNorm_EXT (or nvwrmsnorm) returns the weighted root
+   mean square norm of x with weight factor w,
+   i.e. sqrt [(sum (i=0 to N-1) {(x[i] * w[i])^2}) / N] */
+realtype N_VWrmsNorm_EXT(N_Vector x, N_Vector w)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *wd;
+  realtype wrmsval = ZERO;
+  xd = wd = NULL;
+  xd = NV_DATA_EXT(x);
+  wd = NV_DATA_EXT(w);
+
+  /* call fortran routine to do operation */
+  FNVEXT_WRMSNORM(xd, wd, &wrmsval);
+  return(wrmsval);
+}
+
+
+
+/* N_VWrmsNormMask_EXT or (nvwrmsnormmask) returns wrms norm over
+   indices indicated by id */
+realtype N_VWrmsNormMask_EXT(N_Vector x, N_Vector w, N_Vector id)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *wd, *idd;
+  realtype wrmsval = ZERO;
+  xd = wd = idd = NULL;
+  xd  = NV_DATA_EXT(x);
+  wd  = NV_DATA_EXT(w);
+  idd = NV_DATA_EXT(id);
+
+  /* call fortran routine to do operation */
+  FNVEXT_WRMSNORMMASK(xd, wd, idd, &wrmsval);
+  return(wrmsval);
+}
+
+
+
+/* N_VMin_EXT (or nvmin) returns the smallest element of x */
+realtype N_VMin_EXT(N_Vector x)
+{
+  /* extract data array handles from N_Vectors */
+  realtype minval = ZERO;
+  void *xd = NULL;
+  xd = NV_DATA_EXT(x);
+
+  /* call fortran routine to do operation */
+  FNVEXT_MIN(xd, &minval);
+  return(minval);
+}
+
+
+
+/* N_VWL2Norm_EXT (or nvwl2norm) returns the weighted
+   Euclidean L2 norm of x with weight factor w,
+   i.e. sqrt [(sum (i=0 to N-1) {(x[i]*w[i])^2}) ] */
+realtype N_VWL2Norm_EXT(N_Vector x, N_Vector w)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *wd;
+  realtype wl2val = ZERO;
+  xd = wd = NULL;
+  xd = NV_DATA_EXT(x);
+  wd = NV_DATA_EXT(w);
+
+  /* call fortran routine to do operation */
+  FNVEXT_WL2NORM(xd, wd, &wl2val);
+  return(wl2val);
+}
+
+
+
+/* N_VL1Norm_EXT (or nvl1norm) returns the L1 norm of x,
+   i.e. sum (i=0 to N-1) {|x[i]|} */
+realtype N_VL1Norm_EXT(N_Vector x)
+{
+  /* extract data array handles from N_Vectors */
+  realtype l1norm = ZERO;
+  void *xd = NULL;
+  xd = NV_DATA_EXT(x);
+
+  /* call fortran routine to do operation */
+  FNVEXT_L1NORM(xd, &l1norm);
+  return(l1norm);
+}
+
+
+
+/* N_VCompare_EXT (or nvcompare) calculates
+   z[i] = 1 if |x[i]| > c, z[i] = 0 otherwise */
+void N_VCompare_EXT(realtype c, N_Vector x, N_Vector z)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *zd;
+  xd = zd = NULL;
+  xd = NV_DATA_EXT(x);
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to do operation */
+  FNVEXT_COMPARE(&c, xd, zd);
+
+  return;
+}
+
+
+
+/* N_VInvTest_EXT (or nvinvtest) computes z[i] = 1/x[i]
+   with a test for x[i] == 0 before inverting x[i].  This routine
+   returns SUNTRUE if all components of x are nonzero (successful
+   inversion) and returns SUNFALSE otherwise. */
+booleantype N_VInvTest_EXT(N_Vector x, N_Vector z)
+{
+  /* extract data array handles from N_Vectors */
+  void *xd, *zd;
+  int testval = 0;
+  xd = zd = NULL;
+  xd = NV_DATA_EXT(x);
+  zd = NV_DATA_EXT(z);
+
+  /* call fortran routine to do operation */
+  FNVEXT_INVTEST(xd, zd, &testval);
+
+  if (testval == ZERO)  return(SUNTRUE);
+  else  return(SUNFALSE);
+}
+
+
+
+/* N_VConstrMask_EXT (or nvconstrmask) returns a boolean SUNFALSE
+   if any element fails the constraint test, and SUNTRUE if all passed.  The
+   constraint test is as follows:
+         if c[i] =  2.0, then x[i] must be >  0.0
+         if c[i] =  1.0, then x[i] must be >= 0.0
+         if c[i] = -1.0, then x[i] must be <= 0.0
+         if c[i] = -2.0, then x[i] must be <  0.0
+   It also sets a mask vector m, with elements equal to 1.0 where the
+   corresponding constraint test failed, and equal to 0.0 where the
+   constraint test passed.  This routine is specialized in that it is
+   used only for constraint checking. */
+booleantype N_VConstrMask_EXT(N_Vector c, N_Vector x, N_Vector m)
+{
+  /* extract data array handles from N_Vectors */
+  int testval = 0;
+  void *cd, *xd, *md;
+  cd = xd = md = NULL;
+  cd = NV_DATA_EXT(c);
+  xd = NV_DATA_EXT(x);
+  md = NV_DATA_EXT(m);
+
+  /* call fortran routine to do operation */
+  FNVEXT_CONSTRMASK(cd, xd, md, &testval);
+
+  if (testval == ZERO)  return(SUNTRUE);
+  else  return(SUNFALSE);
+}
+
+
+
+/* N_VMinQuotient_EXT (or nvminquotient) returns
+   min(num[i]/denom[i]) over all i such that denom[i] != 0. */
+realtype N_VMinQuotient_EXT(N_Vector num, N_Vector denom)
+{
+  /* extract data array handles from N_Vectors */
+  void *nd, *dd;
+  realtype minquot = ZERO;
+  nd = dd = NULL;
+  nd = NV_DATA_EXT(num);
+  dd = NV_DATA_EXT(denom);
+
+  /* call fortran routine to do operation */
+  FNVEXT_MINQUOTIENT(nd, dd, &minquot);
+  return(minquot);
+}
+
+
+/*********************** END OF FILE ***********************/

--- a/components/homme/src/arkode/nvector_external.h
+++ b/components/homme/src/arkode/nvector_external.h
@@ -1,0 +1,274 @@
+/*******************************************************************
+ * Daniel R. Reynolds
+ * SMU Mathematics
+ * Copyright 2010; all rights reserved
+ *------------------------------------------------------------------
+ * This is the header file for an implementation of an NVECTOR
+ * package, specifically suited to interface with an external
+ * [Fortran] implementation of the vector operations. In these 
+ * vectors, local data consists of an arbitrary array of a given 
+ * length.
+ *
+ * Part I of this file contains definitions and prototypes of the
+ * Fortran interface functions for this implementation.
+ *
+ * Part II of this file contains declarations which are specific to 
+ * this particular vector specification.  This includes the typedef 
+ * for the 'content' field of the vector.
+ *
+ * Part III of this file defines accessor macros that allow the
+ * user to efficiently use N_Vector type without making explicit 
+ * references to its underlying representation.
+ *
+ * Part IV of this file contains the prototypes for
+ * initialization and printing routines specific to this
+ * implementation.
+ *
+ * Part V of this file contains prototypes for the vector kernels
+ * which operate on the N_Vector.  These prototypes are unique to
+ * this particular implementation of the vector package, and are
+ * attached to the generic N_Vector structure for use within the
+ * various SUNDIALS solvers.
+ *
+ * NOTES:
+ *
+ * The definitions of the generic N_Vector structure is in the
+ * SUNDIALS header file nvector.h.
+ *
+ * The definition of the type realtype is in the SUNDIALS header
+ * file sundialstypes.h and may be changed according to the user's
+ * needs. The SUNDIALS file sundialstypes.h also contains the
+ * definition for the type booleantype.
+ *
+ *******************************************************************/
+
+
+#ifndef _NVECTOR_EXTERNAL_H
+#define _NVECTOR_EXTERNAL_H
+
+#include <sundials/sundials_nvector.h>
+#include <sundials/sundials_fnvector.h>
+
+#ifdef __cplusplus     /* wrapper to enable C++ usage */
+extern "C" {
+#endif
+
+
+
+/****************************************************************
+ * PART I:
+ * Fortran callable wrappers for the interface routines, as
+ * well as prototypes of the supplied Fortran vector operations
+ * to be called by C routines.
+ ****************************************************************/
+
+/* Define Fortran/C interface wrappers */
+#if defined(SUNDIALS_F77_FUNC)
+
+#define FNVEXT_INIT         SUNDIALS_F77_FUNC(fnvextinit,         FNVEXTINIT)
+#define FNVEXT_PRINT        SUNDIALS_F77_FUNC(fnvextprint,        FNVEXTPRINT)
+#define FNVEXT_CLONE        SUNDIALS_F77_FUNC(fnvextclone,        FNVEXTCLONE)
+#define FNVEXT_DESTROY      SUNDIALS_F77_FUNC(fnvextdestroy,      FNVEXTDESTROY)
+#define FNVEXT_LINSUM       SUNDIALS_F77_FUNC(fnvextlinearsum,    FNVEXTLINEARSUM)
+#define FNVEXT_CONST        SUNDIALS_F77_FUNC(fnvextconst,        FNVEXTCONST)
+#define FNVEXT_PROD         SUNDIALS_F77_FUNC(fnvextprod,         FNVEXTPROD)
+#define FNVEXT_DIV          SUNDIALS_F77_FUNC(fnvextdiv,          FNVEXTDIV)
+#define FNVEXT_SCALE        SUNDIALS_F77_FUNC(fnvextscale,        FNVEXTSCALE)
+#define FNVEXT_ABS          SUNDIALS_F77_FUNC(fnvextabs,          FNVEXTABS)
+#define FNVEXT_INV          SUNDIALS_F77_FUNC(fnvextinv,          FNVEXTINV)
+#define FNVEXT_ADDCONST     SUNDIALS_F77_FUNC(fnvextaddconst,     FNVEXTADDCONST)
+#define FNVEXT_DOTPROD      SUNDIALS_F77_FUNC(fnvextdotprod,      FNVEXTDOTPROD)
+#define FNVEXT_MAXNORM      SUNDIALS_F77_FUNC(fnvextmaxnorm,      FNVEXTMAXNORM)
+#define FNVEXT_WRMSNORM     SUNDIALS_F77_FUNC(fnvextwrmsnorm,     FNVEXTWRMSNORM)
+#define FNVEXT_WRMSNORMMASK SUNDIALS_F77_FUNC(fnvextwrmsnormmask, FNVEXTWRMSNORMMASK)
+#define FNVEXT_MIN          SUNDIALS_F77_FUNC(fnvextmin,          FNVEXTMIN)
+#define FNVEXT_WL2NORM      SUNDIALS_F77_FUNC(fnvextwl2norm,      FNVEXTWL2NORM)
+#define FNVEXT_L1NORM       SUNDIALS_F77_FUNC(fnvextl1norm,       FNVEXTL1NORM)
+#define FNVEXT_COMPARE      SUNDIALS_F77_FUNC(fnvextcompare,      FNVEXTCOMPARE)
+#define FNVEXT_INVTEST      SUNDIALS_F77_FUNC(fnvextinvtest,      FNVEXTINVTEST)
+#define FNVEXT_CONSTRMASK   SUNDIALS_F77_FUNC(fnvextconstrmask,   FNVEXTCONSTRMASK)
+#define FNVEXT_MINQUOTIENT  SUNDIALS_F77_FUNC(fnvextminquotient,  FNVEXTMINQUOTIENT)
+
+#else
+
+#define FNVEXT_INIT         fnvextinit_
+#define FNVEXT_PRINT        fnvextprint_
+#define FNVEXT_CLONE        fnvextclone_
+#define FNVEXT_DESTROY      fnvextdestroy_
+#define FNVEXT_LINSUM       fnvextlinearsum_
+#define FNVEXT_CONST        fnvextconst_
+#define FNVEXT_PROD         fnvextprod_
+#define FNVEXT_DIV          fnvextdiv_
+#define FNVEXT_SCALE        fnvextscale_
+#define FNVEXT_ABS          fnvextabs_
+#define FNVEXT_INV          fnvextinv_
+#define FNVEXT_ADDCONST     fnvextaddconst_
+#define FNVEXT_DOTPROD      fnvextdotprod_
+#define FNVEXT_MAXNORM      fnvextmaxnorm_
+#define FNVEXT_WRMSNORM     fnvextwrmsnorm_
+#define FNVEXT_WRMSNORMMASK fnvextwrmsnormmask_
+#define FNVEXT_MIN          fnvextmin_
+#define FNVEXT_WL2NORM      fnvextwl2norm_
+#define FNVEXT_L1NORM       fnvextl1norm_
+#define FNVEXT_COMPARE      fnvextcompare_
+#define FNVEXT_INVTEST      fnvextinvtest_
+#define FNVEXT_CONSTRMASK   fnvextconstrmask_
+#define FNVEXT_MINQUOTIENT  fnvextminquotient_
+
+#endif
+
+  /* Declarations of global variables */
+  extern N_Vector F2C_CVODE_vec;
+  extern N_Vector F2C_IDA_vec;
+  extern N_Vector F2C_KINSOL_vec;
+  extern N_Vector F2C_ARKODE_vec;
+
+  /* Prototype of initialization function */
+  void FNVEXT_INIT(int *code, int *ier);
+  
+  /* Prototypes of the Fortran routines -- these are provided by 
+     the user, and define the variables in the supplied vector 
+     depending on the physical problem under consideration */
+  void FNVEXT_PRINT(void*);
+  void FNVEXT_CLONE(void*, void*, int*);
+  void FNVEXT_DESTROY(void*);
+  void FNVEXT_LINSUM(realtype*, void*, realtype*, void*, void*);
+  void FNVEXT_CONST(realtype*, void*);
+  void FNVEXT_PROD(void*, void*, void*);
+  void FNVEXT_DIV(void*, void*, void*);
+  void FNVEXT_SCALE(realtype*, void*, void*);
+  void FNVEXT_ABS(void*, void*);
+  void FNVEXT_INV(void*, void*);
+  void FNVEXT_ADDCONST(realtype*, void*, void*);
+  void FNVEXT_DOTPROD(void*, void*, realtype*);
+  void FNVEXT_MAXNORM(void*, realtype*);
+  void FNVEXT_WRMSNORM(void*, void*, realtype*);
+  void FNVEXT_WRMSNORMMASK(void*, void*, void*, realtype*);
+  void FNVEXT_MIN(void*, realtype*);
+  void FNVEXT_WL2NORM(void*, void*, realtype*);
+  void FNVEXT_L1NORM(void*, realtype*);
+  void FNVEXT_COMPARE(realtype*, void*, void*);
+  void FNVEXT_INVTEST(void*, void*, int*);
+  void FNVEXT_CONSTRMASK(void*, void*, void*, int*);
+  void FNVEXT_MINQUOTIENT(void*, void*, realtype*);
+
+
+
+/****************************************************************
+ * PART II: implementation
+ ****************************************************************/
+
+/* The FNVEXT implementation of the N_Vector 'content' structure 
+   contains the a void** pointer to the actual Fortran vector 
+   structure memory location, and a flag indicating whether this 
+   vector was allocated from SUNDIALS calls (versus by the user program) */
+struct _N_VectorContent_EXT {
+  void *data;              /* ptr to Fortran vector structure location */
+  booleantype own_data;    /* flag for ownership of data */
+};
+typedef struct _N_VectorContent_EXT *N_VectorContent_EXT;
+
+
+/****************************************************************
+ * PART III: Macros
+ *    NV_CONTENT_EXT, NV_DATA_EXT, NV_OWN_DATA_EXT
+ *--------------------------------------------------------------
+ * (1) NV_CONTENT_EXT
+ *
+ *     This macro gives access to the 'content' structure of the
+ *     N_Vector.
+ *
+ *     The assignment v_cont = NV_CONTENT_EXT(v) sets
+ *     v_cont to be a pointer to the EXT N_Vector
+ *     content structure.
+ *
+ * (2) NV_DATA_EXT
+ *
+ *     This macro gives access to the actual void** Fortran 
+ *     vector object portion held in the 'content' structure.
+ *
+ *     The assignment v_data = NV_DATA_EXT(v) sets v_data to
+ *     be a pointer to the void** data component from v.
+ *
+ *     The assignment NV_DATA_EXT(v) = v_data sets the 
+ *     void** data component in v by storing the pointer v_data.
+ *
+ * (3) NV_OWN_DATA_EXT
+ *
+ *     This macro gives access to the flag within the N_Vector 
+ *     content structure indicating ownership of the data.
+ *
+ ****************************************************************/ 
+
+#define NV_CONTENT_EXT(v) ( (N_VectorContent_EXT)(v->content) )
+#define NV_DATA_EXT(v) ( NV_CONTENT_EXT(v)->data )
+#define NV_OWN_DATA_EXT(v) ( NV_CONTENT_EXT(v)->own_data )
+
+
+
+/****************************************************************
+ * PART III: Functions exported by nvector_ext
+ *
+ * CONSTRUCTORS:
+ *    N_VNewEmpty_EXT
+ *    N_VMake_EXT
+ * EXTRA OPERATIONS:
+ *    N_VPrint_EXT
+ *--------------------------------------------------------------*/
+
+/* N_VNewEmpty_EXT */ 
+/* This function creates a new EXT vector with an empty (NULL) content pointer */
+N_Vector N_VNewEmpty_EXT();
+
+/* N_VMake_EXT */
+/* This function creates an EXT vector with user-provided content pointer */
+N_Vector N_VMake_EXT(void* FVec);
+
+/* N_VPrint_EXT */
+/* This function prints the content of a EXT vector to stdout */
+void N_VPrint_EXT(N_Vector v);
+
+
+
+/****************************************************************
+ * PART VI: vector operations in nvector_ext
+ *--------------------------------------------------------------*/
+
+SUNDIALS_EXPORT N_Vector_ID N_VGetVectorID_EXT(N_Vector);
+SUNDIALS_EXPORT N_Vector    N_VCloneEmpty_EXT(N_Vector);
+SUNDIALS_EXPORT N_Vector    N_VClone_EXT(N_Vector);
+SUNDIALS_EXPORT void        N_VDestroy_EXT(N_Vector);
+SUNDIALS_EXPORT void        N_VSpace_EXT(N_Vector, long int *, long int *);
+SUNDIALS_EXPORT realtype*   N_VGetArrayPointer_EXT(N_Vector);
+SUNDIALS_EXPORT void        N_VSetArrayPointer_EXT(realtype *, N_Vector);
+SUNDIALS_EXPORT void        N_VLinearSum_EXT(realtype, N_Vector, realtype, 
+                                             N_Vector, N_Vector);
+SUNDIALS_EXPORT void        N_VConst_EXT(realtype, N_Vector);
+SUNDIALS_EXPORT void        N_VProd_EXT(N_Vector, N_Vector, N_Vector);
+SUNDIALS_EXPORT void        N_VDiv_EXT(N_Vector, N_Vector, N_Vector);
+SUNDIALS_EXPORT void        N_VScale_EXT(realtype, N_Vector, N_Vector);
+SUNDIALS_EXPORT void        N_VAbs_EXT(N_Vector, N_Vector);
+SUNDIALS_EXPORT void        N_VInv_EXT(N_Vector, N_Vector);
+SUNDIALS_EXPORT void        N_VAddConst_EXT(N_Vector, realtype, N_Vector);
+SUNDIALS_EXPORT realtype    N_VDotProd_EXT(N_Vector, N_Vector);
+SUNDIALS_EXPORT realtype    N_VMaxNorm_EXT(N_Vector);
+SUNDIALS_EXPORT realtype    N_VWrmsNorm_EXT(N_Vector, N_Vector);
+SUNDIALS_EXPORT realtype    N_VWrmsNormMask_EXT(N_Vector, N_Vector, N_Vector);
+SUNDIALS_EXPORT realtype    N_VMin_EXT(N_Vector);
+SUNDIALS_EXPORT realtype    N_VWL2Norm_EXT(N_Vector, N_Vector);
+SUNDIALS_EXPORT realtype    N_VL1Norm_EXT(N_Vector);
+SUNDIALS_EXPORT void        N_VCompare_EXT(realtype, N_Vector, N_Vector);
+SUNDIALS_EXPORT booleantype N_VInvTest_EXT(N_Vector, N_Vector);
+SUNDIALS_EXPORT booleantype N_VConstrMask_EXT(N_Vector, N_Vector, N_Vector);   
+SUNDIALS_EXPORT realtype    N_VMinQuotient_EXT(N_Vector, N_Vector);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+
+
+/*********************** END OF FILE ***********************/

--- a/components/homme/src/arkode/theta-l/arkode_interface.F90
+++ b/components/homme/src/arkode/theta-l/arkode_interface.F90
@@ -1,0 +1,805 @@
+!-----------------------------------------------------------------
+! Daniel R. Reynolds
+! SMU Mathematics
+!
+! This file contains all required subroutines for interfacing to
+! the ARKode Fortran interface, as well as a small number of
+! auxiliary routines to assist.  This uses a custom NVector
+! interface, implemented in Fortran.
+!
+! The following subroutines are 'users' of the ARKode Fortran
+! interface:
+!    arkode_init -- initializes NVectors and ARKode for subsequent
+!                   solves (only called once)
+!
+! The following user-supplied subroutines are required by the
+! ARKode Fortran interface:
+!    farkifun -- implements all implicit portions of the ODE
+!                right-hand side function
+!    farkefun -- implements all explicit portions of the ODE
+!                right-hand side function
+!
+! The following user-supplied subroutines are optional within
+! the ARKode Fortran interface:
+!    FColumnSolSolve -- routine to perform a Fortran-supplied,
+!                       columnwise linear solver
+!    farkjtsetup -- prepares for Jacobian-vector products, J*v,
+!                   where J(u) is the Jacobian of farkifun
+!                   with respect to u.
+!    farkjtimes -- implements the Jacobian-vector product, J*v,
+!                  where J(u) is the Jacobian of farkifun
+!                  with respect to u.
+!    farkpset -- performs setup for the preconditioner matrix
+!                (called infrequently)
+!    farkpsol -- performs the preconditioner solve (called every
+!                linear iteration)
+!
+! The following are 'helper' subroutines that I often use when
+! interfacing to SUNDIALS solvers from Fortran:
+!    farkdiags -- writes ARKode solver diagnostics to the screen
+!
+! Copyright 2017; all rights reserved
+!
+! Modified by Christopher J. Vogl (LLNL) 2018
+!=================================================================
+
+subroutine farkifun(t, y_C, fy_C, ipar, rpar, ierr)
+  !-----------------------------------------------------------------
+  ! Description: farkifun provides the implicit portion of the right
+  !     hand side function for the ODE:   dy/dt = fi(t,y) + fe(t,y)
+  !
+  ! Arguments:
+  !       t - (dbl, input) current time
+  !     y_C - (ptr) C pointer to NVec_t containing current solution
+  !    fy_C - (ptr) C pointer to NVec_t to hold right-hand side function
+  !    ipar - (long int(*), input) integer user parameter data (unused here)
+  !    rpar - (dbl(*), input) real user parameter data (unused here)
+  !    ierr - (int, output) return flag: 0=>success,
+  !            1=>recoverable error, -1=>non-recoverable error
+  !-----------------------------------------------------------------
+
+  !======= Inclusions ===========
+  use arkode_mod,       only: max_stage_num, get_RHS_vars, get_hvcoord_ptr, &
+                              get_qn0
+  use kinds,            only: real_kind
+  use HommeNVector,     only: NVec_t
+  use hybrid_mod,       only: hybrid_t
+  use derivative_mod,   only: derivative_t
+  use dimensions_mod,   only: nlevp
+  use hybvcoord_mod,    only: hvcoord_t
+  use prim_advance_mod, only: compute_andor_apply_rhs
+  use iso_c_binding
+
+  !======= Declarations =========
+  implicit none
+
+  ! calling variables
+  real*8,            intent(in)         :: t
+  type(c_ptr),       intent(in), target :: y_C
+  type(c_ptr),       intent(in), target :: fy_C
+  integer(C_LONG),   intent(in)         :: ipar(1)
+  real*8,            intent(in)         :: rpar(1)
+  integer(C_INT),    intent(out)        :: ierr
+
+  ! local variables
+  type(derivative_t)    :: deriv
+  type(hybrid_t)        :: hybrid
+  type(hvcoord_t)       :: hvcoord
+  type(NVec_t), pointer :: y => NULL()
+  type(NVec_t), pointer :: fy => NULL()
+  real (real_kind)      :: dt, eta_ave_w, bval, cval, scale1, scale2
+  integer               :: imex, qn0, ie
+
+  !======= Internals ============
+  call get_hvcoord_ptr(hvcoord)
+  call get_qn0(qn0)
+  call get_RHS_vars(imex,dt,eta_ave_w,hybrid,deriv)
+
+  ! set scale factors depending on whether using implicit, explicit, or IMEX
+  if (imex == 0) then
+    scale1 = 1.d0
+    scale2 = 1.d0
+  else if (imex == 1) then
+    scale1 = 0.d0
+    scale2 = 0.d0
+  else if (imex == 2) then
+    scale1 = 0.d0
+    scale2 = 1.d0
+  end if
+
+  ! set return value to success
+  ierr = 0
+
+  ! dereference pointer for NVec_t objects
+  call c_f_pointer(y_C, y)
+  call c_f_pointer(fy_C, fy)
+
+  ! TODO: obtain b value for current 'stage number' (only affect tracers)
+  bval = 1.d0/max_stage_num
+
+  ! The function call to compute_andor_apply_rhs is as follows:
+  !  compute_andor_apply_rhs(np1, nm1, n0, qn0, dt2, elem, hvcoord, hybrid, &
+  !     deriv, nets, nete, compute_diagnostics, eta_ave_w, scale1, scale2, scale3)
+  !
+  !  This call returns the following:
+  !
+  !   u(np1) = scale3*u(nm1) + dt2*DSS[ nonstiffRHS(u(n0))*scale1 + stiffRHS(un0)*scale2 ]
+  !
+  !   nonstiffRHS and the stiffRHS are determined within the function and can be change by
+  !   multiplying different terms by scale1 and scale2
+  !
+  !  Setting scale1=scale2=1.0, scale3=0.0, and dt2=1.0 returns the full rhs
+  !
+  !  DSS is the averaging procedure for the active and inactive nodes
+  !
+
+  call compute_andor_apply_rhs(fy%tl_idx, fy%tl_idx, y%tl_idx, qn0, &
+        1.d0, y%elem, hvcoord, hybrid, deriv, y%nets, y%nete, &
+        .false., bval*eta_ave_w, scale1, scale2, 0.d0)
+
+  ! Zero out RHS vector elements to maintain (d/dt)phinh_i(nlevp) = 0
+  do ie=fy%nets,fy%nete
+    fy%elem(ie)%state%phinh_i(:,:,nlevp,fy%tl_idx) = 0.d0
+  end do
+
+  return
+end subroutine farkifun
+
+!=================================================================
+
+subroutine farkefun(t, y_C, fy_C, ipar, rpar, ierr)
+  !-----------------------------------------------------------------
+  ! Description: farkefun provides the explicit portion of the right
+  !     hand side function for the ODE:   dy/dt = fi(t,y) + fe(t,y)
+  !
+  ! Arguments:
+  !       t - (dbl, input) current time
+  !     y_C - (ptr) C pointer to NVec_t containing current solution
+  !    fy_C - (ptr) C pointer to NVec_t to hold right-hand side function
+  !    ipar - (long int(*), input) integer user parameter data (unused here)
+  !    rpar - (dbl(*), input) real user parameter data (unused here)
+  !    ierr - (int, output) return flag: 0=>success,
+  !            1=>recoverable error, -1=>non-recoverable error
+  !-----------------------------------------------------------------
+
+  !======= Inclusions ===========
+  use arkode_mod,       only: max_stage_num, get_RHS_vars, get_hvcoord_ptr, &
+                              get_qn0
+  use kinds,            only: real_kind
+  use HommeNVector,     only: NVec_t
+  use hybrid_mod,       only: hybrid_t
+  use derivative_mod,   only: derivative_t
+  use dimensions_mod,   only: nlevp
+  use hybvcoord_mod,    only: hvcoord_t
+  use prim_advance_mod, only: compute_andor_apply_rhs
+  use iso_c_binding
+
+  !======= Declarations =========
+  implicit none
+
+  ! calling variables
+  real*8,            intent(in)         :: t
+  type(c_ptr),       intent(in), target :: y_C
+  type(c_ptr),       intent(in), target :: fy_C
+  integer(C_LONG),   intent(in)         :: ipar(1)
+  real*8,            intent(in)         :: rpar(1)
+  integer(C_INT),    intent(out)        :: ierr
+
+  ! local variables
+  type(derivative_t)    :: deriv
+  type(hybrid_t)        :: hybrid
+  type(hvcoord_t)       :: hvcoord
+  type(NVec_t), pointer :: y => NULL()
+  type(NVec_t), pointer :: fy => NULL()
+  real(real_kind)       :: dt, eta_ave_w, bval, cval, scale1, scale2
+  integer               :: imex, qn0, ie
+
+  !======= Internals ============
+  call get_hvcoord_ptr(hvcoord)
+  call get_qn0(qn0)
+  call get_RHS_vars(imex,dt,eta_ave_w,hybrid,deriv)
+
+  ! set scale factors depending on whether using implicit, explicit, or IMEX
+  if (imex == 0) then
+    scale1 = 0.d0
+    scale2 = 0.d0
+  else if (imex == 1) then
+    scale1 = 1.d0
+    scale2 = 1.d0
+  else if (imex == 2) then
+    scale1 = 1.d0
+    scale2 = 0.d0
+  end if
+
+  ! set return value to success
+  ierr = 0
+
+  ! dereference pointer for NVec_t objects
+  call c_f_pointer(y_C, y)
+  call c_f_pointer(fy_C, fy)
+
+  ! TODO: obtain b value for current 'stage number' (only affects tracers)
+  bval = 1.d0/max_stage_num
+
+  ! The function call to compute_andor_apply_rhs is as follows:
+  !  compute_andor_apply_rhs(np1, nm1, n0, qn0, dt2, elem, hvcoord, hybrid, &
+  !     deriv, nets, nete, compute_diagnostics, eta_ave_w, scale1, scale2, scale3)
+  !
+  !  This call returns the following:
+  !
+  !   u(np1) = scale3*u(nm1) + dt2*DSS[ nonstiffRHS(u(n0))*scale1 + stiffRHS(un0)*scale2 ]
+  !
+  !   nonstiffRHS and the stiffRHS are determined within the function and can be change by
+  !   multiplying different terms by scale1 and scale2
+  !
+  !  Setting scale1=scale2=1.0, scale3=0.0, and dt2=1.0 returns the full rhs
+  !
+  !  DSS is the averaging procedure for the active and inactive nodes
+  !
+
+  call compute_andor_apply_rhs(fy%tl_idx, fy%tl_idx, y%tl_idx, qn0, &
+        1.d0, y%elem, hvcoord, hybrid, deriv, y%nets, y%nete, &
+        .false., bval*eta_ave_w, scale1, scale2, 0.d0)
+
+  ! Zero out RHS vector elements to maintain (d/dt)phinh_i(nlevp) = 0
+  do ie=fy%nets,fy%nete
+    fy%elem(ie)%state%phinh_i(:,:,nlevp,fy%tl_idx) = 0.d0
+  end do
+
+  return
+end subroutine farkefun
+
+!=================================================================
+
+subroutine farkdiags(iout, rout, ap)
+  !-----------------------------------------------------------------
+  ! Description: subroutine to output arkode diagnostics
+  !
+  ! Arguments:
+  !        iout - (long int*, input) integer optional outputs
+  !        rout - (dbl*, input) real optional outputs
+  !        ap   - (parameter_list, input) arkode parameters
+  !-----------------------------------------------------------------
+  !======= Inclusions ===========
+  use iso_c_binding
+  use arkode_mod
+
+  !======= Declarations =========
+  implicit none
+
+  integer(C_LONG), intent(in) :: iout(40)
+  real*8,          intent(in) :: rout(40)
+  type(parameter_list), intent(in) :: ap
+
+  !======= Internals ============
+
+  ! general solver statistics
+  print *, '   '
+  print *,  ' ARKode output values:'
+  print '(4x,A,i9)','Total internal steps taken =',iout(3)
+  print '(4x,A,i9)','   stability-limited steps =',iout(4)
+  print '(4x,A,i9)','    accuracy-limited steps =',iout(5)
+  print '(4x,A,i9)','  internal steps attempted =',iout(6)
+  print '(4x,A,i9)','Total explicit rhs calls   =',iout(7)
+  print '(4x,A,i9)','Total implicit rhs calls   =',iout(8)
+
+  print '(4x,A,i9)','Total nonlinear iterations =',iout(11)
+  if (iout(13) > 0)  print '(4x,A,i9)','Total root function calls  =',iout(13)
+
+  ! linear solver statistics
+  print '(4x,A,i9)','Total linear iterations    =',iout(21)
+  if (iout(9) > 0)  print '(4x,A,i9)','Num lin solver setup calls =',iout(9)
+  if (.not.use_column_solver) then
+     if (iout(17) > 0) print '(4x,A,i9)','Num lin solver rhs calls   =',iout(17)
+     if (iout(18) > 0) print '(4x,A,i9)','Num lin solver Jac calls   =',iout(18)
+     if (iout(19) > 0) print '(4x,A,i9)','Num PSet routine calls     =',iout(19)
+     if (iout(20) > 0) print '(4x,A,i9)','Num PSolve routine calls   =',iout(20)
+  endif
+
+  ! error statistics
+  if (iout(10) > 0) print '(4x,A,i9)','Num error test failures    =',iout(10)
+  if (iout(12) > 0) print '(4x,A,i9)','Num nonlin conv failures   =',iout(12)
+  if (.not.use_column_solver) then
+     if (iout(22) > 0) print '(4x,A,i9)','Num linear conv failures   =',iout(22)
+  endif
+
+  ! general time-stepping information
+  print '(4x,A,es12.5)','First internal step size   =',rout(1)
+  print '(4x,A,es12.5)','Last internal step size    =',rout(2)
+  print '(4x,A,es12.5)','Next internal step size    =',rout(3)
+  print '(4x,A,es12.5)','Current internal time      =',rout(4)
+  print '(4x,A,es12.5)','Suggested tol scale factor =',rout(5)
+  print *, '   '
+
+  return
+end subroutine farkdiags
+!=================================================================
+
+
+subroutine FColumnSolSolve(b_C, t, y_C, gamma, ierr)
+  !-----------------------------------------------------------------
+  ! Description: FColumnSolSolve is the routine called by ARKode to
+  !     perform the linear solve at the state defined by (t,y_C),
+  !     where b_C stores the right-hand side vector on input, and
+  !     the solution vector on output.
+  !
+  ! Arguments:
+  !     b_C - (ptr, in/out) C pointer to NVec_t containing linear
+  !            system RHS on input, and solution on output
+  !       t - (dbl, input) current time
+  !     y_C - (ptr) C pointer to NVec_t containing current state
+  !   gamma - (dbl, input) scaling factor for Jacobian in system
+  !            matrix, A = I-gamma*J
+  !    ierr - (int, output) return flag: 0=>success,
+  !            1=>recoverable error, -1=>non-recoverable error
+  !-----------------------------------------------------------------
+
+  !======= Inclusions ===========
+  use arkode_mod,         only: get_hvcoord_ptr, get_qn0
+  use control_mod,        only: theta_hydrostatic_mode
+  use eos,                only: get_pnh_and_exner, get_dirk_jacobian
+  use kinds,              only: real_kind
+  use HommeNVector,       only: NVec_t
+  use hybvcoord_mod,      only: hvcoord_t
+  use physical_constants, only: g
+  use dimensions_mod,     only: np, nlev, nlevp
+  use parallel_mod,       only: abortmp
+  use iso_c_binding
+
+  !======= Declarations =========
+  implicit none
+
+  ! calling variables
+  type(c_ptr),       intent(in), target :: b_C
+  real*8,            intent(in)         :: t
+  type(c_ptr),       intent(in), target :: y_C
+  real*8,            intent(in)         :: gamma
+  integer(C_INT),    intent(out)        :: ierr
+
+  ! local variables
+  type(hvcoord_t)       :: hvcoord
+  type(NVec_t), pointer :: b  => NULL()
+  type(NVec_t), pointer :: y  => NULL()
+  real (kind=real_kind), pointer, dimension(:,:,:) :: phi_np1
+  real (kind=real_kind), pointer, dimension(:,:,:) :: dp3d
+  real (kind=real_kind), pointer, dimension(:,:,:) :: vtheta_dp
+  real (kind=real_kind), pointer, dimension(:,:)   :: phis
+  real (kind=real_kind) :: JacD(nlev,np,np)
+  real (kind=real_kind) :: JacL(nlev-1,np,np)
+  real (kind=real_kind) :: JacU(nlev-1,np,np)
+  real (kind=real_kind) :: JacU2(nlev-2,np,np)
+  real (kind=real_kind) :: pnh(np,np,nlev)
+  real (kind=real_kind) :: pnh_i(np,np,nlevp)
+  real (kind=real_kind) :: dp3d_i(np,np,nlevp)
+  real (kind=real_kind) :: dpnh_dp_i(np,np,nlevp)
+  real (kind=real_kind) :: exner(np,np,nlev)
+  real (kind=real_kind) :: b1(nlev,np,np)
+  integer :: qn0, i, j, k, ie, info(np,np), Ipiv(nlev,np,np)
+
+  !======= Internals ============
+  call get_hvcoord_ptr(hvcoord)
+  call get_qn0(qn0)
+
+  ! set return value to success
+  ierr = 0
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(b_C, b)
+  call c_f_pointer(y_C, y)
+
+  !--------------------------------
+  ! perform solve
+  !
+  ! Notes: prim_advance_mod::compute_stage_value_dirk() performs a full Newton
+  ! iteration on the implicit system
+  !    w = w0 + g*dt2*(1-dpdpi(phi))
+  !    phi = phi0 + g*dt2*w
+  ! where w0 and phi0 contain the explicit portions of each time-dependent equation,
+  ! g is the gravitational constant, dt2 is the scaled time step size (includes the
+  ! diagonal coefficient for the DIRK method: dt*Ai(i,i)), and dpdpi = (dp/dpi).  Due to its
+  ! structure, this is solved via substitution:
+  !
+  !    phi = phi0 + g*dt2*(w0 + g*dt2*(1-dpdpi(phi)))
+  ! <=>
+  !    phi = phi0 + g*dt2*w0 + (g*dt2)^2 - (g*dt2)^2*dpdpi(phi)
+  ! <=>
+  !    phi + (g*dt2)^2*dpdpi(phi) - phi0 - g*dt2*w0 - (g*dt2)^2 = 0
+  !
+  ! This nonlinear equation has tridiagonal Jacobian matrix, M = I + (g*dt2)^2*J,
+  ! where J is the Jacobian matrix of dpdpi(phi).
+  ! The diagonals of M are constructed in the call get_dirk_jacobian().
+  !
+  ! For our problem, we consider a 'state vector'
+  !    U = [v1; v2; w; phi; vtheta_dp; dp3d]
+  ! and we solve an IMEX problem of the form  U' = fE(U) + fI(U), where the implicit
+  ! portion has structure
+  !    fI(U) = [0; 0; fI_w(phi); fI_phi(w); 0; 0], where
+  !    fI_W(phi) = g*(1 - dpdpi(phi))
+  !    fI_phi(w) = g*w
+  ! The resulting Jacobian for our nonlinear implicit solve has structure
+  !    A = I-gamma*[0  0   0    0   0  0]
+  !                [0  0   0    0   0  0]
+  !                [0  0   0  -g*J  0  0]
+  !                [0  0  g*I   0   0  0]
+  !                [0  0   0    0   0  0]
+  !                [0  0   0    0   0  0]
+  !    gamma = dt*Ai(i,i) = dt2
+  ! or equivalently, the linear system A*x = b corresponds to
+  !      x_v1 = b_v1,  x_v2 = b_v2,  x_theta = b_theta,  x_dp3d = b_dp3d,
+  ! and
+  !       [       I     gamma*g*J ] [ x_w   ] = [ b_w   ]
+  !       [ -gamma*g*I       I    ] [ x_phi ] = [ b_phi ]
+  ! This 2x2 block linear system is equivalent to
+  !       x_w + gamma*g*J*x_phi = b_w
+  !       -gamma*g*x_w + x_phi  = b_phi
+  !   <=>
+  !       x_w = b_w - gamma*g*J*x_phi
+  !       x_phi - gamma*g*(b_w - gamma*g*J*x_phi) = b_phi
+  !   <=>
+  !       x_w = b_w - gamma*g*J*x_phi
+  !       (I + (gamma*g)^2*J) x_phi = b_phi + gamma*g*b_w
+  !   <=>
+  !       M*x_phi = (b_phi + gamma*g*b_w)
+  !       x_w =  b_w + [x_phi - M*x_phi]/(gamma*g)
+  ! So to solve our full linear system, we use the following steps:
+  !    (a) construct M = I + (gamma*g)^2*J via a call to get_dirk_jacobian with dt2=gamma
+  !    (b) construct right-hand side vector:  b1 = (b_phi + gamma*g*b_w)
+  !    (c) solve M*x_phi = b1 for x_phi via calls to DGTTRF and DGTTRS
+  !    (d) compute x_w = [x_phi - b_phi]/(gamma*g)
+  !    (e) copy x_v1 = b_v1, x_v2 = b_v2, x_theta = b_theta, x_dp3d = b_dp3d
+
+  ! outer loop
+  do ie=y%nets,y%nete
+
+     !-------------
+     ! step (a) construct M = I + (gamma*g)^2*J via a call to get_dirk_jacobian with dt2=gamma
+     !-------------
+     ! set pointers for this ie
+     dp3d  => y%elem(ie)%state%dp3d(:,:,:,y%tl_idx)
+     vtheta_dp  => y%elem(ie)%state%vtheta_dp(:,:,:,y%tl_idx)
+     phi_np1 => y%elem(ie)%state%phinh_i(:,:,:,y%tl_idx)
+     phis => y%elem(ie)%state%phis(:,:)
+
+     ! compute intermediate variables for Jacobian calculation
+     call get_pnh_and_exner(hvcoord, vtheta_dp, dp3d, phi_np1, &
+             pnh, exner, dpnh_dp_i, pnh_i_out=pnh_i)
+
+     ! compute dp3d_i -- note that compute_stage_value_dirk
+     ! computes this twice (with potential memory reference issues in the second pass)
+     dp3d_i(:,:,1) = dp3d(:,:,1)
+     dp3d_i(:,:,nlevp) = dp3d(:,:,nlev)
+     do k=2,nlev
+        dp3d_i(:,:,k) = 0.5d0*(dp3d(:,:,k) + dp3d(:,:,k-1))
+     end do
+
+     ! get tridigonal matrix M
+     info(:,:) = 0
+     call get_dirk_jacobian(JacL,JacD,JacU,gamma,dp3d,phi_np1,pnh,1)
+
+     ! loop over components of this ie
+#if (defined COLUMN_OPENMP)
+  !$omp parallel do private(i,j,k) collapse(2)
+#endif
+     do i=1,np
+        do j=1,np
+           !-------------
+           ! step (b) construct right-hand side vector:  b1 = (b_phi + gamma*g*b_w)
+           !-------------
+           b1(:,i,j) = b%elem(ie)%state%phinh_i(i,j,1:nlev,b%tl_idx) &
+                    + gamma*g*b%elem(ie)%state%w_i(i,j,1:nlev,b%tl_idx)
+
+           !-------------
+           ! step (c) solve M*x_phi = b1 for x_phi via calls to DGTTRF and DGTTRS
+           !          note solution will be in b1 on output
+           !-------------
+           call DGTTRF( nlev, JacL(:,i,j), JacD(:,i,j), JacU(:,i,j), JacU2(:,i,j), &
+                        Ipiv(:,i,j), info(i,j) )
+           call DGTTRS( 'N', nlev, 1, JacL(:,i,j), JacD(:,i,j), JacU(:,i,j), &
+                        JacU2(:,i,j), Ipiv(:,i,j), b1(:,i,j), nlev, info(i,j) )
+
+           !-------------
+           ! step (d) compute x_w = [x_phi - b_phi]/(gamma*g), then copy x_phi
+           !          into b_phi (for output purposes)
+           !-------------
+           b%elem(ie)%state%w_i(i,j,1:nlev,b%tl_idx) = (b1(:,i,j)  - &
+              b%elem(ie)%state%phinh_i(i,j,1:nlev,b%tl_idx)) / (gamma*g)
+           b%elem(ie)%state%phinh_i(i,j,1:nlev,b%tl_idx) = b1(:,i,j)
+
+           !-------------
+           ! step (e) copy x_v1 = b_v1, x_v2 = b_v2, x_theta = b_theta, x_dp3d = b_dp3d
+           !-------------
+           ! Note: since the vector b stores b_* on input and x_* on output, this is already done
+
+        end do  ! end j loop
+     end do  ! end i loop
+  end do   ! end ie loop
+
+  return
+end subroutine FColumnSolSolve
+
+!=================================================================
+
+
+!-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+!
+! NOTE: All of the remaining subroutines are not required when
+! interfacing with ARKode, and so they are not currently
+! implemented.  These may be provided to improve ARKode
+! performance on this application; if so they should be 'enabled'
+! by calling the relevant ARKode interface routine.
+!
+!-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+
+subroutine farkjtimes(v_C, Jv_C, t, y_C, fy_C, h, ipar, rpar, v1_C, ierr)
+  !-----------------------------------------------------------------
+  ! Description: farkjtimes provides the Jacobian-vector product
+  !    routine for the linearized Newton system.
+  !
+  !  Arguments:
+  !       v_C - (ptr) C pointer to NVec_t vector to multiply
+  !      Jv_C - (ptr) C pointer to NVec_t for result of Jacobian-vector product
+  !         t - (dbl, input) current time
+  !       y_C - (ptr) C pointer to NVec_t containing current solution
+  !      fy_C - (ptr) C pointer to NVec_t containing current implicit ODE rhs
+  !         h - (dbl, input) time step size for last internal step
+  !      ipar - (long int(*), input) integer user parameter data
+  !             (passed back here, unused)
+  !      rpar - (dbl(*), input) real user parameter data (passed here,
+  !             unused)
+  !      v1_C - (ptr) C pointer to NVec_t scratch vector
+  !      ierr - (int, output) return flag: 0=>success,
+  !             1=>recoverable error, -1=>non-recoverable error
+  !-----------------------------------------------------------------
+  !======= Inclusions ===========
+  use iso_c_binding
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev
+
+  !======= Declarations =========
+  implicit none
+
+  ! calling variables
+  type(c_ptr),     intent(in), target :: v_C
+  type(c_ptr),     intent(in), target :: Jv_C
+  real*8,          intent(in)         :: t
+  type(c_ptr),     intent(in), target :: y_C
+  type(c_ptr),     intent(in), target :: fy_C
+  real*8,          intent(in)         :: h
+  integer(C_LONG), intent(in)         :: ipar(1)
+  real*8,          intent(in)         :: rpar(1)
+  type(c_ptr),     intent(in), target :: v1_C
+  integer(C_INT),  intent(out)        :: ierr
+
+  ! local variables
+  type(NVec_t), pointer :: v  => NULL()
+  type(NVec_t), pointer :: Jv => NULL()
+  type(NVec_t), pointer :: y  => NULL()
+  type(NVec_t), pointer :: fy => NULL()
+  type(NVec_t), pointer :: v1 => NULL()
+
+
+  !======= Internals ============
+
+  ! set return value to success
+  ierr = 0
+
+  ! dereference pointer for NVec_t objects
+  call c_f_pointer(v_C, v)
+  call c_f_pointer(Jv_C, Jv)
+  call c_f_pointer(y_C, y)
+  call c_f_pointer(fy_C, fy)
+  call c_f_pointer(v1_C, v1)
+
+  ! perform matrix-vector product, inserting result into Jv
+
+  return
+end subroutine farkjtimes
+!=================================================================
+
+
+
+
+
+
+subroutine farkjtsetup(t, y_C, fy_C, h, ipar, rpar, ierr)
+  !-----------------------------------------------------------------
+  ! Description: farkjtsetup performs any preparations for
+  !    subsequent calls to farkjtimes.
+  !
+  !  Arguments:
+  !         t - (dbl, input) current time
+  !       y_C - (ptr) C pointer to NVec_t containing current solution
+  !      fy_C - (ptr) C pointer to NVec_t containing current implicit ODE rhs
+  !         h - (dbl, input) time step size for last internal step
+  !      ipar - (long int(*), input) integer user parameter data
+  !             (passed back here, unused)
+  !      rpar - (dbl(*), input) real user parameter data (passed here,
+  !             unused)
+  !      ierr - (int, output) return flag: 0=>success,
+  !             1=>recoverable error, -1=>non-recoverable error
+  !-----------------------------------------------------------------
+  !======= Inclusions ===========
+  use iso_c_binding
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev
+
+  !======= Declarations =========
+  implicit none
+
+  ! calling variables
+  real*8,          intent(in)         :: t
+  type(c_ptr),     intent(in), target :: y_C
+  type(c_ptr),     intent(in), target :: fy_C
+  real*8,          intent(in)         :: h
+  integer(C_LONG), intent(in)         :: ipar(1)
+  real*8,          intent(in)         :: rpar(1)
+  integer(C_INT),  intent(out)        :: ierr
+
+  ! local variables
+  type(NVec_t), pointer :: y  => NULL()
+  type(NVec_t), pointer :: fy => NULL()
+
+
+  !======= Internals ============
+
+  ! set return value to success
+  ierr = 0
+
+  ! dereference pointer for NVec_t objects
+  call c_f_pointer(y_C, y)
+  call c_f_pointer(fy_C, fy)
+
+  ! perform setup for matrix-vector products
+
+  return
+end subroutine farkjtsetup
+!=================================================================
+
+
+
+
+subroutine farkpset(t, y_C, fy_C, jok, jcur, gamma, h, ipar, rpar, ierr)
+  !-----------------------------------------------------------------
+  ! Description: farkpset provides the preconditioner setup
+  !    routine for the linearized Newton system.
+  !
+  !  Arguments:
+  !         t - (dbl, input) current time
+  !       y_C - (ptr) C pointer to NVec_t containing current solution
+  !      fy_C - (ptr) C pointer to NVec_t containing current implicit ODE rhs
+  !       jok - (int, input) flag denoting whether to recompute
+  !              Jacobian-related data: 0=>recompute, 1=>unnecessary
+  !      jcur - (int, output) output flag to say if Jacobian data
+  !              was recomputed: 1=>was recomputed, 0=>was not
+  !     gamma - (dbl, input) the scalar appearing in the Newton matrix
+  !              A = M-gamma*J
+  !         h - (dbl, input) time step size for last internal step
+  !      ipar - (long int(*), input) integer user parameter data
+  !             (passed back here, unused)
+  !      rpar - (dbl(*), input) real user parameter data (passed here,
+  !             unused)
+  !      ierr - (int, output) return flag: 0=>success,
+  !             1=>recoverable error, -1=>non-recoverable error
+  !-----------------------------------------------------------------
+  !======= Inclusions ===========
+  use iso_c_binding
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev
+
+  !======= Declarations =========
+  implicit none
+
+  ! calling variables
+  real*8,          intent(in)         :: t
+  type(c_ptr),     intent(in), target :: y_C
+  type(c_ptr),     intent(in), target :: fy_C
+  integer(C_INT),  intent(in)         :: jok
+  integer(C_INT),  intent(out)        :: jcur
+  real*8,          intent(in)         :: gamma
+  real*8,          intent(in)         :: h
+  integer(C_LONG), intent(in)         :: ipar(1)
+  real*8,          intent(in)         :: rpar(1)
+  integer(C_INT),  intent(out)        :: ierr
+
+  ! local variables
+  type(NVec_t), pointer :: y  => NULL()
+  type(NVec_t), pointer :: fy => NULL()
+
+  !======= Internals ============
+
+  ! initialize return value to success, jcur to not-recomputed
+  ierr = 0
+  jcur = 0
+
+  ! dereference pointer for NVec_t objects
+  call c_f_pointer(y_C, y)
+  call c_f_pointer(fy_C, fy)
+
+  ! return if no preconditioner update is required
+  if (jok == 1)  return
+
+  ! update the preconditioner
+
+  ! set Jacobian recomputation flag
+  jcur = 1
+
+  return
+end subroutine farkpset
+!=================================================================
+
+
+
+
+subroutine farkpsol(t, y_C, fy_C, r_C, z_C, gamma, delta, lr, ipar, &
+                    rpar, ierr)
+  !-----------------------------------------------------------------
+  ! Description: farkpsol provides the preconditioner solve routine
+  !    for the preconditioning of the linearized Newton system.
+  !         i.e. solves P*z = r
+  !
+  ! Arguments:
+  !         t - (dbl, input) current time
+  !       y_C - (ptr) C pointer to NVec_t containing current solution
+  !      fy_C - (ptr) C pointer to NVec_t containing current implicit ODE rhs
+  !       r_C - (ptr) C pointer to NVec_t rhs vector of prec. system
+  !       z_C - (ptr) C pointer to NVec_t solution vector of prec. system
+  !     gamma - (dbl, input) scalar appearing in the Newton Matrix
+  !             A = M-gamma*J
+  !     delta - (dbl, input) desired tolerance if using an iterative
+  !             method.  In that case, solve until
+  !                  Sqrt[Sum((r-Pz).*ewt)^2] < delta
+  !             where the ewt vector is obtainable by calling
+  !             FARKGETERRWEIGHTS()
+  !        lr - (int, input) flag indicating preconditioning type to
+  !             apply: 1 => left,  2 => right
+  !      ipar - (long int(*), input) integer user parameter data
+  !             (passed back here, unused)
+  !      rpar - (dbl(*), input) real user parameter data (passed here,
+  !             unused)
+  !      ierr - (int, output) return flag: 0=>success,
+  !             1=>recoverable error, -1=>non-recoverable error
+  !-----------------------------------------------------------------
+  !======= Inclusions ===========
+  use iso_c_binding
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev
+
+  !======= Declarations =========
+  implicit none
+
+  ! calling variables
+  real*8,          intent(in)         :: t
+  type(c_ptr),     intent(in), target :: y_C
+  type(c_ptr),     intent(in), target :: fy_C
+  type(c_ptr),     intent(in), target :: r_C
+  type(c_ptr),     intent(in), target :: z_C
+  real*8,          intent(in)         :: gamma
+  real*8,          intent(in)         :: delta
+  integer(C_INT),  intent(in)         :: lr
+  integer(C_LONG), intent(in)         :: ipar(1)
+  real*8,          intent(in)         :: rpar(1)
+  integer(C_INT),  intent(out)        :: ierr
+
+  ! local variables
+  type(NVec_t), pointer :: y  => NULL()
+  type(NVec_t), pointer :: fy => NULL()
+  type(NVec_t), pointer :: r  => NULL()
+  type(NVec_t), pointer :: z  => NULL()
+
+  !======= Internals ============
+
+  ! set return value to success
+  ierr = 0
+
+  ! dereference pointer for NVec_t objects
+  call c_f_pointer(y_C, y)
+  call c_f_pointer(fy_C, fy)
+  call c_f_pointer(r_C, r)
+  call c_f_pointer(z_C, z)
+
+  ! perform preconditioner solve to fill z
+
+  return
+end subroutine farkpsol
+!=================================================================

--- a/components/homme/src/arkode/theta-l/arkode_mod.F90
+++ b/components/homme/src/arkode/theta-l/arkode_mod.F90
@@ -1,0 +1,1354 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#define ARK324_ARK 1
+#define ARK436_ARK 2
+#define ARK453_ARK 3
+#define ARS222_ARK 4
+#define ARS232_ARK 5
+#define ARS233_ARK 6
+#define ARS343_ARK 7
+#define ARS443_ARK 8
+#define SSP3333B_ARK 9
+#define SSP3333C_ARK 10
+#define RK2_ARK 11
+#define KGU35_ARK 12
+#define IMKG232a_ARK 13
+#define IMKG232b_ARK 14
+#define IMKG242a_ARK 15
+#define IMKG242b_ARK 16
+#define IMKG243a_ARK 17
+#define IMKG243b_ARK 18
+#define IMKG252a_ARK 19
+#define IMKG252b_ARK 20
+#define IMKG253a_ARK 21
+#define IMKG253b_ARK 22
+#define IMKG254a_ARK 23
+#define IMKG254b_ARK 24
+#define IMKG254c_ARK 25
+#define IMKG343a_ARK 26
+#define IMKG343b_ARK 27
+
+
+
+
+module arkode_mod
+
+  use element_state,  only: timelevels
+  use derivative_mod, only: derivative_t
+  use HommeNVector,   only: NVec_t
+  use hybrid_mod,     only: hybrid_t
+  use hybvcoord_mod,  only: hvcoord_t
+  use kinds,          only: real_kind
+  use iso_c_binding
+
+  implicit none
+
+  private
+
+  integer, parameter :: max_stage_num = 10
+  integer, parameter :: freelevels = timelevels-35
+  ! Note that 35 is an estimate, but needs to be at least > 30
+  ! If a larger Krylov subspace is desired, timelevels should be
+  ! increased.
+  integer, parameter :: max_niters = 10
+
+  ! ARKode namelist variables
+  real(real_kind), public :: rel_tol = 1.d-8
+  real(real_kind), public :: abs_tol = 1.d-8  ! val < 0 indicates array atol
+  logical, public         :: calc_nonlinear_stats = .true.
+  logical, public         :: use_column_solver = .true.
+
+  ! data type for passing ARKode Butcher table names
+  type :: table_list
+    integer :: ARK324     = ARK324_ARK
+    integer :: ARK436     = ARK436_ARK
+    integer :: ARK453     = ARK453_ARK
+    integer :: ARS222     = ARS222_ARK
+    integer :: ARS232     = ARS232_ARK
+    integer :: ARS233     = ARS233_ARK
+    integer :: ARS343     = ARS343_ARK
+    integer :: ARS443     = ARS443_ARK
+    integer :: SSP3333B   = SSP3333B_ARK
+    integer :: SSP3333C   = SSP3333C_ARK
+    integer :: RK2        = RK2_ARK
+    integer :: KGU35      = KGU35_ARK
+    integer :: IMKG232a = IMKG232a_ARK
+    integer :: IMKG232b = IMKG232b_ARK
+    integer :: IMKG242a = IMKG242a_ARK
+    integer :: IMKG242b = IMKG242b_ARK
+    integer :: IMKG243a = IMKG243a_ARK
+    integer :: IMKG243b = IMKG243b_ARK
+    integer :: IMKG252a = IMKG252a_ARK
+    integer :: IMKG252b = IMKG252b_ARK
+    integer :: IMKG253a = IMKG253a_ARK
+    integer :: IMKG253b = IMKG253b_ARK
+    integer :: IMKG254a = IMKG254a_ARK
+    integer :: IMKG254b = IMKG254b_ARK
+    integer :: IMKG254c = IMKG254c_ARK
+    integer :: IMKG343a = IMKG343a_ARK
+    integer :: IMKG343b = IMKG343b_ARK
+  end type table_list
+
+  ! data type for passing ARKode parameters
+  type :: parameter_list
+    ! *RK Method Information
+    integer         :: imex ! 0=implicit, 1=explicit, 2=imex
+    integer         :: s ! number of stages
+    integer         :: q ! method order
+    integer         :: p ! embedded method order
+    ! Explicit Butcher Table
+    real(real_kind) :: Ae(max_stage_num,max_stage_num)
+    real(real_kind) :: be(max_stage_num)
+    real(real_kind) :: be2(max_stage_num)
+    real(real_kind) :: ce(max_stage_num)
+    ! Implicit Butcher Table
+    real(real_kind) :: Ai(max_stage_num,max_stage_num)
+    real(real_kind) :: bi(max_stage_num)
+    real(real_kind) :: bi2(max_stage_num)
+    real(real_kind) :: ci(max_stage_num)
+    ! Linear Solver Info (flag for columnwise/GMRES, GMRES parameters)
+    integer         :: precLR ! preconditioning: 0=none, 1=left, 2=right, 3=left+right
+    integer         :: gstype ! Gram-Schmidt orthogonalization: 1=modified, 2=classical
+    integer         :: maxl = freelevels ! max size of Krylov subspace (# of iterations/vectors)
+    real(real_kind) :: lintol ! linear convergence tolerance factor (0 indicates default)
+    ! General Iteration Info
+    real(real_kind) :: rtol ! relative tolerance for iteration convergence
+    real(real_kind) :: atol(6) ! absolute tolerances (u,v,w,phinh,vtheta_dp,dp3d)
+  end type parameter_list
+
+  public :: parameter_list, update_arkode, get_solution_ptr, get_hvcoord_ptr
+  public :: get_qn0, get_RHS_vars
+  public :: max_stage_num, table_list, set_Butcher_tables
+  public :: update_nonlinear_stats, finalize_nonlinear_stats
+
+  save
+
+  type(hvcoord_t), pointer      :: hvcoord_ptr
+  type(hybrid_t), pointer       :: hybrid_ptr
+  type(derivative_t), pointer   :: deriv_ptr
+  type(parameter_list), pointer :: param_ptr
+  type(NVec_t), target          :: y_F(3), atol_F
+  type(c_ptr)                   :: y_C(3), atol_C
+  real(real_kind)               :: dt_save, eta_ave_w_save, rout(40)
+  integer                       :: imex_save, qn0_save
+  logical                       :: initialized = .false.
+  integer(C_LONG)               :: iout(40)
+  ! variables used for nonlinear solver stats, not necessary for use of ARKode
+  integer :: total_nonlinear_iterations = 0
+  integer :: max_nonlinear_iterations = 0
+  integer :: num_timesteps = 0
+
+contains
+
+  subroutine update_nonlinear_stats(timesteps, nonlinear_iters)
+    !-----------------------------------------------------------------
+    ! Description: update ARKode performance statistics
+    !   Arguments:
+    !          timesteps - (int, input, optional) specify # of timesteps
+    !    nonlinear_iters - (int, input, optional) specify # of nonlinear iters
+    !-----------------------------------------------------------------
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    integer, intent(in), optional :: timesteps
+    integer, intent(in), optional :: nonlinear_iters
+
+    !======= Internals ============
+    if (present(timesteps)) then
+      num_timesteps = num_timesteps + timesteps
+    else
+      num_timesteps = num_timesteps + 1
+    end if
+    if (present(nonlinear_iters)) then
+      max_nonlinear_iterations = max(max_nonlinear_iterations, nonlinear_iters)
+      total_nonlinear_iterations = total_nonlinear_iterations + nonlinear_iters
+    else
+      max_nonlinear_iterations = max(max_nonlinear_iterations, iout(11))
+      total_nonlinear_iterations = total_nonlinear_iterations + iout(11)
+    end if
+    return
+  end subroutine update_nonlinear_stats
+
+  !=================================================================
+
+  subroutine finalize_nonlinear_stats(comm, my_rank, master_rank, comm_size)
+    !-----------------------------------------------------------------
+    ! Description: print ARKode performance statistics
+    !-----------------------------------------------------------------
+
+    !======= Inclusions ===========
+    use mpi
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    integer, intent(in) :: comm
+    integer, intent(in) :: my_rank
+    integer, intent(in) :: master_rank
+    integer, intent(in) :: comm_size
+
+    ! local variables
+    integer :: max_result, sum_result, ierr
+
+    !======= Internals ============
+    call MPI_Reduce(max_nonlinear_iterations, max_result, 1, MPI_INTEGER, &
+                    MPI_MAX, master_rank, comm, ierr)
+    call MPI_Reduce(total_nonlinear_iterations, sum_result, 1, MPI_INTEGER, &
+                    MPI_SUM, master_rank, comm, ierr)
+    if (my_rank == master_rank) then
+      print *, 'ARKode Nonlinear Solver Statistics:'
+      print '(2x,A,i9)','Max num nonlin iters   =', max_result
+      print '(2x,A,i9)','Total num nonlin iters =', sum_result
+      print '(2x,A,i9)','Total num timesteps    =', num_timesteps
+      print '(2x,A,f9.2)','Avg num nonlin iters   =', sum_result/float(comm_size*num_timesteps)
+    end if
+
+    return
+  end subroutine finalize_nonlinear_stats
+
+  !=================================================================
+
+  subroutine get_solution_ptr(np1, ynp1)
+    !-----------------------------------------------------------------
+    ! Description: sets pointer to NVector for specified timelevel
+    !   Arguments:
+    !     np1 - (int, input) timelevel
+    !    ynp1 - (cptr, output) NVector pointer
+    !-----------------------------------------------------------------
+
+    !======= Inclusions ===========
+    use iso_c_binding
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    integer,      intent(in) :: np1
+    type(c_ptr), intent(out) :: ynp1
+
+    !======= Internals ============
+    ynp1 = y_C(np1)
+
+    return
+  end subroutine get_solution_ptr
+
+  !=================================================================
+
+  subroutine get_hvcoord_ptr(hvcoord)
+    !-----------------------------------------------------------------
+    ! Description: sets pointer to current hvcoord object
+    !   Arguments:
+    !     hvcoord - (obj*, output) hvcoord object pointer
+    !-----------------------------------------------------------------
+
+    !======= Inclusions ===========
+    use hybvcoord_mod,  only: hvcoord_t
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    type(hvcoord_t),    intent(out) :: hvcoord
+
+    !======= Internals ============
+    hvcoord = hvcoord_ptr
+
+    return
+  end subroutine get_hvcoord_ptr
+
+  !=================================================================
+
+  subroutine get_qn0(qn0)
+    !-----------------------------------------------------------------
+    ! Description: obtains current qn0 value
+    !   Arguments:
+    !     qn0 - (int, output) qn0 value
+    !-----------------------------------------------------------------
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    integer, intent(out) :: qn0
+
+    !======= Internals ============
+    qn0 = qn0_save
+
+    return
+  end subroutine get_qn0
+
+  !=================================================================
+
+  subroutine get_RHS_vars(imex, dt, eta_ave_w, hybrid, deriv)
+    !-----------------------------------------------------------------
+    ! Description: sets variables and objects needed to compute RHS
+    !   Arguments:
+    !        imex - (int, output) variable for imex specification
+    !          dt - (real, output) variable for timestep size
+    !   eta_ave_w - (real, output) variable for eta_ave_w value
+    !      hybrid - (obj*, output) hybrid object pointer
+    !       deriv - (obj*, output) deriv object pointer
+    !-----------------------------------------------------------------
+
+    !======= Inclusions ===========
+    use derivative_mod, only: derivative_t
+    use hybrid_mod,     only: hybrid_t
+    use kinds,          only: real_kind
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    type(hybrid_t),     intent(out) :: hybrid
+    type(derivative_t), intent(out) :: deriv
+    integer,            intent(out) :: imex
+    real(real_kind),    intent(out) :: dt, eta_ave_w
+
+    !======= Internals ============
+    imex = imex_save
+    dt = dt_save
+    eta_ave_w = eta_ave_w_save
+    hybrid = hybrid_ptr
+    deriv = deriv_ptr
+
+    return
+  end subroutine get_RHS_vars
+
+  !=================================================================
+
+  subroutine update_arkode(elem, nets, nete, deriv, hvcoord, hybrid, &
+                           dt, eta_ave_w, n0, qn0, arkode_parameters)
+    !-----------------------------------------------------------------
+    ! Description: resets internal ARKode solution without memory allocation
+    !   Arguments:
+    !                 elem - (obj*, input) element objects
+    !                 nets - (int, input) starting index for elem array
+    !                 nete - (int, input) ending index for elem array
+    !                   tl - (obj*, input) timelevel object
+    !                deriv - (obj*, input) deriv object
+    !              hvcoord - (obj*, input) hvcoord object
+    !               hybrid - (obj*, input) hybrid object
+    !                   dt - (real, input) current timestep
+    !            eta_ave_w - (real, input) average flux value
+    !                   n0 - (int, input) timelevel holding current solution
+    !                  qn0 - (int, input) timelevel for tracer mass
+    !    arkode_parameters - (parameter, input) object for arkode parameters
+    !-----------------------------------------------------------------
+
+    !======= Inclusions ===========
+    use derivative_mod,   only: derivative_t
+    use element_mod,      only: element_t
+    use HommeNVector,     only: NVec_t, MakeHommeNVector, SetHommeNVectorPar
+    use hybrid_mod,       only: hybrid_t
+    use hybvcoord_mod,    only: hvcoord_t
+    use kinds,            only: real_kind
+    use parallel_mod,     only: abortmp
+    use iso_c_binding
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    type(derivative_t), target, intent(in) :: deriv
+    type(hvcoord_t), target,    intent(in) :: hvcoord
+    type(hybrid_t), target,     intent(in) :: hybrid
+    type(parameter_list),       intent(in) :: arkode_parameters
+    real(real_kind),            intent(in) :: dt, eta_ave_w
+    integer,                    intent(in) :: nets, nete, n0, qn0
+    type(element_t),            intent(inout) :: elem(:)
+
+    ! local variables
+    real(real_kind) :: tstart
+    integer(C_INT)  :: iflag, ierr
+    integer         :: i
+
+    !======= Internals ============
+    ! Set NVector communicator
+    call SetHommeNVectorPar(hybrid%par)
+
+    ! specify start time to be 0.0 so stage time available in farkefun & farkifun
+    tstart = 0.d0
+
+    ! store variables for farkefun and farkifun
+    dt_save = dt
+    eta_ave_w_save = eta_ave_w
+    imex_save = arkode_parameters%imex
+    qn0_save = qn0
+    hybrid_ptr => hybrid
+    deriv_ptr => deriv
+    hvcoord_ptr => hvcoord
+
+    ! Initialize or reinitialize ARKode
+    if (.not.initialized) then
+      call initialize(elem, nets, nete, hybrid%par, n0, qn0, tstart, &
+                      arkode_parameters)
+      initialized = .true.
+    else
+      call reinitialize(n0, tstart, arkode_parameters)
+    end if
+
+    ! Set ARKode time step
+    call farksetrin('FIXED_STEP', dt, ierr)
+    if (ierr /= 0) then
+      call abortmp('farksetrin failed')
+    endif
+
+    return
+  end subroutine update_arkode
+
+  !=================================================================
+
+  subroutine reinitialize(n0, tstart, arkode_parameters)
+    !-----------------------------------------------------------------
+    ! Description: resets internal ARKode solution without memory allocation
+    !   Arguments:
+    !                   n0 - (int, input) timelevel holding current solution
+    !               tstart - (real, input) time to start ARKode solve at
+    !    arkode_parameters - (parameter, input) arkode parameter object
+    !-----------------------------------------------------------------
+
+    !======= Inclusions ===========
+    use kinds,            only: real_kind
+    use parallel_mod,     only: abortmp
+    use iso_c_binding
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    type(parameter_list), target, intent(in)  :: arkode_parameters
+    integer,                      intent(in)  :: n0
+    real(real_kind),              intent(in)  :: tstart
+
+    ! local variables
+    type(parameter_list), pointer :: ap
+    integer(C_INT)                :: iatol, ierr
+    integer(C_LONG)               :: ival
+    integer                       :: ie
+
+    !======= Internals ============
+    ap => arkode_parameters
+
+    ! update rtol and atol
+    do ie=atol_F%nets,atol_F%nete
+      atol_F%elem(ie)%state%v(:,:,1,:,atol_F%tl_idx) = ap%atol(1)
+      atol_F%elem(ie)%state%v(:,:,2,:,atol_F%tl_idx) = ap%atol(2)
+      atol_F%elem(ie)%state%w_i(:,:,:,atol_F%tl_idx) = ap%atol(3)
+      atol_F%elem(ie)%state%phinh_i(:,:,:,atol_F%tl_idx) = ap%atol(4)
+      atol_F%elem(ie)%state%vtheta_dp(:,:,:,atol_F%tl_idx) = ap%atol(5)
+      atol_F%elem(ie)%state%dp3d(:,:,:,atol_F%tl_idx) = ap%atol(6)
+    end do
+
+    ! reinitialize ARKode with current solution and tolerances
+    iatol = 2
+    call farkreinit(tstart, y_C(n0), ap%imex, iatol, ap%rtol, atol_C, ierr)
+    if (ierr /= 0) then
+      call abortmp('arkode_reinit: farkreinit failed')
+    endif
+
+    ! reset max number of nonlinear iterations per stage
+    ival = max_niters
+    call farksetiin('MAX_NITERS', ival, ierr)
+    if (ierr /= 0) then
+      call abortmp('arkode_reinit: farksetinn(MAX_NITERS) failed')
+    endif
+
+    return
+  end subroutine reinitialize
+
+  !=================================================================
+
+  subroutine initialize(elem, nets, nete, par, n0, qn0, tstart, arkode_parameters)
+    !-----------------------------------------------------------------
+    ! Description: allocates memory for and initializes ARKode
+    !   Arguments:
+    !                 elem - (obj*, input) element objects
+    !                 nets - (int, input) starting index for elem array
+    !                 nete - (int, input) ending index for elem array
+    !                  par - (obj*, input) parallel object
+    !                   n0 - (int, input) timelevel holding current solution
+    !                  qn0 - (int, input) timelevel for tracer mass
+    !               tstart - (real, input) time to start ARKode solve at
+    !    arkode_parameters - (parameter, input) object for arkode parameters
+    !-----------------------------------------------------------------
+
+    !======= Inclusions ===========
+    use element_mod,      only: element_t
+    use HommeNVector,     only: NVec_t, MakeHommeNVector, SetHommeNVectorPar
+    use kinds,            only: real_kind
+    use parallel_mod,     only: parallel_t, abortmp
+    use iso_c_binding
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    type(parallel_t),             intent(in) :: par
+    type(parameter_list), target, intent(in) :: arkode_parameters
+    real(real_kind),              intent(in) :: tstart
+    integer,                      intent(in) :: nets, nete, n0, qn0
+    type(element_t),              intent(inout) :: elem(:)
+
+    ! local variables
+    type(parameter_list), pointer :: ap
+    real(real_kind)               :: rpar(1)
+    real(real_kind)               :: A_C1(arkode_parameters%s*arkode_parameters%s)
+    real(real_kind)               :: A_C2(arkode_parameters%s*arkode_parameters%s)
+    integer(C_INT)                :: idef, iatol, ierr
+    integer(C_LONG)               :: ipar(1), ival
+    integer                       :: i, j
+
+    !======= Internals ============
+    ap => arkode_parameters
+
+    ! initialize error flag and placeholders for optional farmalloc outputs
+    ierr = 0
+    iout = 0
+    rout = 0.d0
+
+    if (par%masterproc) print *,"Initializing ARKode"
+    ! 'create' NVec_t objects that will correspond to the original 3 HOMME
+    ! timelevels, assuming that tl%nm1, tl%n0, and tl%np1 are taken from the
+    ! set {1,2,3}
+    do i=1,3
+      call MakeHommeNVector(elem, nets, nete, i, y_F(i), ierr)
+      if (ierr /= 0) then
+        call abortmp('Error in MakeHommeNVector')
+      end if
+      ! get C pointer
+      y_C(i) = c_loc(y_F(i))
+    end do
+
+    ! save rtol, set data in 4th timelevel to atol values,
+    ! and 'create' NVec_t object
+    do i=nets,nete
+      elem(i)%state%v(:,:,1,:,4) = ap%atol(1)
+      elem(i)%state%v(:,:,2,:,4) = ap%atol(2)
+      elem(i)%state%w_i(:,:,:,4) = ap%atol(3)
+      elem(i)%state%phinh_i(:,:,:,4) = ap%atol(4)
+      elem(i)%state%vtheta_dp(:,:,:,4) = ap%atol(5)
+      elem(i)%state%dp3d(:,:,:,4) = ap%atol(6)
+    end do
+    call MakeHommeNVector(elem, nets, nete, 4, atol_F, ierr)
+    if (ierr /= 0) then
+      call abortmp('Error in MakeHommeNVector')
+    end if
+    ! get C pointer
+    atol_C = c_loc(atol_F)
+
+    ! initialize ARKode data & operators
+    idef = 4  ! flag specifying which SUNDIALS solver will be used (4=ARKode)
+    call fnvextinit(idef, ierr)
+    if (ierr /= 0) then
+       call abortmp('arkode_init: fnvextinit failed')
+    end if
+
+    ! ARKode dataspace
+    iatol = 2
+    call farkmalloc(tstart, y_C(n0), ap%imex, iatol, ap%rtol, atol_C, &
+                    iout, rout, ipar, rpar, ierr)
+    if (ierr /= 0) then
+       call abortmp('arkode_init: farkmalloc failed')
+    end if
+
+    ! Set IRK Butcher table for implicit problems
+    if (ap%imex == 0) then
+      ! flatten Ai to C array (row-major)
+      do i=1,ap%s
+        do j = 1,ap%s
+          A_C1(ap%s*(i-1)+j) = ap%Ai(i,j)
+        end do
+      end do
+      ! set table
+      call farksetirktable(ap%s, ap%q, ap%p, ap%ci, A_C1, ap%bi, ap%bi2, ierr)
+      if (ierr /= 0) then
+        call abortmp('arkode_init: farksetirktable failed')
+      end if
+
+    ! Set ERK Butcher table for explicit problems
+    else if (ap%imex == 1) then
+      ! flatten Ae to C array (row-major)
+      do i=1,ap%s
+        do j = 1,ap%s
+          A_C1(ap%s*(i-1)+j) = ap%Ae(i,j)
+        end do
+      end do
+      ! set table
+      call farkseterktable(ap%s, ap%q, ap%p, ap%ce, A_C1, ap%be, ap%be2, ierr)
+      if (ierr /= 0) then
+        call abortmp('arkode_init: farkseterktable failed')
+      end if
+
+    ! Set ARK Butcher table for IMEX problems
+    else if (ap%imex == 2) then
+      ! flatten Ae and Ai to C arrays (row-major)
+      do i=1,ap%s
+        do j = 1,ap%s
+          A_C1(ap%s*(i-1)+j) = ap%Ai(i,j)
+          A_C2(ap%s*(i-1)+j) = ap%Ae(i,j)
+        end do
+      end do
+      ! set tables
+      call farksetarktables(ap%s, ap%q, ap%p, ap%ci, ap%ce, A_C1, A_C2, &
+                          ap%bi, ap%be, ap%bi2, ap%be2, ierr)
+      if (ierr /= 0) then
+        call abortmp('arkode_init: farksetarktable failed')
+      end if
+    else
+      call abortmp('arkode_init: invalid imex parameter value')
+    end if
+
+    ! Set linear solve if implicit or imex problem
+    if (ap%imex == 0 .or. ap%imex == 2) then
+    !      To indicate that the implicit problem is linear, make the following
+    !      call.  The argument specifies whether the linearly implicit problem
+    !      changes as the problem evolves (1) or not (0)
+    !  lidef = 0
+  !  call farksetiin('LINEAR', lidef, ierr)
+  !  if (ierr /= 0) then
+  !     write(0,*) ' arkode_init: farksetiin failed'
+  !  endif
+
+
+      if (use_column_solver) then
+      ! use the HOMME columnwise direct solver
+        call FColumnSolInit(ierr)
+        if (ierr /= 0) then
+          call abortmp('arkode_init: FColumnSolInit failed')
+        end if
+
+      else
+      ! use the GMRES linear solver (and set options)
+        idef = 4 ! flag specifying which SUNDIALS solver will be used (4=ARKode)
+        call FSunSPGMRInit(idef, ap%precLR, ap%maxl, ierr)
+        if (ierr /= 0) then
+          call abortmp('arkode_init: FSunSPGMRInit failed')
+        end if
+        call FSunSPGMRSetGSType(idef, ap%gstype, ierr)
+        if (ierr /= 0) then
+          call abortmp('arkode_init: FSunSPGMRSetGSType failed')
+        end if
+        call FARKSpilsInit(ierr)
+        if (ierr /= 0) then
+          call abortmp('arkode_init: FARKSpilsInit failed')
+        end if
+        call FARKSpilsSetEpsLin(ap%lintol, ierr)
+        if (ierr /= 0) then
+          call abortmp('arkode_init: FARKSpilsSetEpsLin failed')
+        end if
+
+        !      Indicate to use our own preconditioner setup/solve routines (otherwise
+        !      preconditioning is disabled)
+        if (ap%precLR /= 0) then
+          idef = 1
+          call farkspilssetprec(idef, ierr)
+          if (ierr /= 0) then
+            write(0,*) ' arkode_init: farkspilssetprec failed'
+          endif
+        endif
+
+        !      Indicate to use our own Jacobian-vector product routine (otherwise it
+        !      uses a finite-difference approximation)
+        !idef = 1
+        !call farkspilssetjac(idef, ierr)
+        !if (ierr /= 0) then
+        !   write(0,*) ' arkode_init: farkspilssetjac failed'
+        !endif
+
+      endif
+    endif
+
+    ! reset max number of nonlinear iterations per stage
+    ival = max_niters
+    call farksetiin('MAX_NITERS', ival, ierr)
+    if (ierr /= 0) then
+      call abortmp('arkode_reinit: farksetinn(MAX_NITERS) failed')
+    endif
+
+    if (par%masterproc) call farkwriteparameters(ierr)
+
+
+
+    return
+  end subroutine initialize
+
+  !=================================================================
+
+  subroutine set_Butcher_tables(arkode_parameters, table_name)
+    !-----------------------------------------------------------------
+    ! Description: sets Butcher tables for ARKode solver
+    !   Arguments:
+    !    arkode_parameters - (parameter, in/output) object for arkode parameters
+    !           table_name - (integer, input) constant identifying table name
+    !-----------------------------------------------------------------
+
+    !======= Inclusions ===========
+    use kinds,            only: real_kind
+    use parallel_mod,     only: abortmp
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    type(parameter_list), target, intent(inout) :: arkode_parameters
+    integer,                      intent(in)    :: table_name
+
+    ! local variables
+    type(parameter_list), pointer :: ap
+    real(real_kind) :: beta, gamma, delta, b1, b2
+    real(real_kind) :: a(max_stage_num), ahat(max_stage_num)
+    real(real_kind) :: b(max_stage_num), dhat(max_stage_num)
+
+    !======= Internals ============
+    ap => arkode_parameters
+
+    select case (table_name)
+
+    case (RK2_ARK)
+        ap%imex = 1 ! explicit
+        ap%s = 2 ! 2 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:2,1:2) = 0.d0
+        ap%Ae(2,1) = 0.5d0
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:2) = (/ 0.d0, 0.5d0 /)
+        ap%be(1:2) = (/ 0.d0, 1.d0 /)
+
+      case (KGU35_ARK)
+        ap%imex = 1 ! explicit
+        ap%s = 5 ! 5 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:5,1:5) = 0.d0
+        ap%Ae(2,1) = 0.2d0
+        ap%Ae(3,1:2) = (/  0.d0, 0.2d0 /)
+        ap%Ae(4,1:3) = (/  0.d0,  0.d0, 1.d0/3.d0 /)
+        ap%Ae(5,1:4) = (/  0.d0,  0.d0,      0.d0, 2.d0/3.d0 /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:5) = (/   0.d0, 0.2d0, 0.2d0, 1.d0/3.d0, 2.d0/3.d0 /)
+        ap%be(1:5) = (/ 0.25d0,  0.d0,  0.d0,      0.d0,    0.75d0 /)
+
+      case (ARS232_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 3 ! 3 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        delta = -2.d0*sqrt(2.d0)/3.d0
+        gamma = 1.d0 - 1.d0/sqrt(2.d0)
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:3,1:3) = 0.d0
+        ap%Ai(2,1:2) = (/ 0.d0,      gamma /)
+        ap%Ai(3,1:3) = (/ 0.d0, 1.d0-gamma, gamma /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:3) = (/ 0.d0, gamma, 1.d0 /)
+        ap%bi(1:3) = (/ 0.d0, 1.d0-gamma, gamma /)
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:3,1:3) = 0.d0
+        ap%Ae(2,1) =  gamma
+        ap%Ae(3,1:2) = (/ delta, 1.d0-delta /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:3) = ap%ci(1:3)
+        ap%be(1:3) = ap%bi(1:3)
+
+      case (ARK453_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 5 ! 5 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:5,1:5) = 0.d0
+        ap%Ai(2,1:2) = (/ -0.22284985318525410d0, 0.32591194130117247d0 /)
+        ap%Ai(3,1:3) = (/ -0.46801347074080545d0, 0.86349284225716961d0, &
+                            0.32591194130117247d0 /)
+        ap%Ai(4,1:4) = (/ -0.46509906651927421d0, 0.81063103116959553d0, &
+                            0.61036726756832357d0, 0.32591194130117247d0 /)
+        ap%Ai(5,1:5) = (/ 0.87795339639076675d0, -0.72692641526151547d0, &
+                            0.75204137157372720d0, -0.22898029400415088d0, &
+                            0.32591194130117247d0 /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:5) = (/ 0.d0, 0.1030620881159184d0, &
+                          0.72139131281753662d0, 1.28181117351981733d0, &
+                          1.d0 /)
+        ap%bi(1:5) = (/ 0.87795339639076672d0, -0.72692641526151549d0, &
+                          0.7520413715737272d0, -0.22898029400415090d0, &
+                          0.32591194130117246d0 /)
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:5,1:5) = 0.d0
+        ap%Ae(2,1) = 0.10306208811591838d0
+        ap%Ae(3,1:2) = (/ -0.94124866143519894d0, 1.6626399742527356d0 /)
+        ap%Ae(4,1:3) = (/ -1.3670975201437765d0, 1.3815852911016873d0, &
+                            1.2673234025619065d0 /)
+        ap%Ae(5,1:4) = (/ -0.81287582068772448d0, 0.81223739060505738d0, &
+                            0.90644429603699305d0, 0.094194134045674111d0 /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:5) = ap%ci(1:5)
+        ap%be(1:5) = ap%bi(1:5)
+
+      case (ARS233_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 3 ! 3 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        gamma = 1.d0/6.d0*(3.d0 + sqrt(3.d0))
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:3,1:3) = 0.d0
+        ap%Ai(2,1:2) = (/ 0.d0,          gamma /)
+        ap%Ai(3,1:3) = (/ 0.d0, 1.d0-2.d0*gamma, gamma /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:3) = (/ 0.d0, gamma, 1.d0-gamma /)
+        ap%bi(1:3) = (/ 0.d0, 0.5d0,      0.5d0 /)
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:3,1:3) = 0.d0
+        ap%Ae(2,1) = gamma
+        ap%Ae(3,1:2) = (/ gamma-1.d0, 2.d0*(1.d0-gamma) /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:3) = ap%ci(1:3)
+        ap%be(1:3) = ap%bi(1:3)
+
+      case (ARS222_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 3 ! 3 stage
+        ap%q = 2 ! 2rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        gamma = 1.d0 - 1.d0/sqrt(2.d0)
+        delta = 1.d0 - 1.d0/(2.d0*gamma)
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:3,1:3) = 0.d0
+        ap%Ai(2,1:2) = (/ 0.d0,      gamma /)
+        ap%Ai(3,1:3) = (/ 0.d0, 1.d0-gamma, gamma /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:3) = (/ 0.d0,      gamma,  1.d0 /)
+        ap%bi(1:3) = (/ 0.d0, 1.d0-gamma, gamma /)
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:3,1:3) = 0.d0
+        ap%Ae(2,1) = gamma
+        ap%Ae(3,1:2) = (/ delta, 1.d0-delta /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:3) = ap%ci(1:3)
+        ap%be(1:3) = ap%bi(1:3)
+
+      case (ARS343_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 4 ! 4 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        gamma = 0.4358665215084590d0
+        b1 = -3.d0*gamma*gamma/2.d0 + 4.d0*gamma - 1.d0/4.d0
+        b2 = 3.d0*gamma*gamma/2.d0 - 5.d0*gamma + 5.d0/4.d0
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:4,1:4) = 0.d0
+        ap%Ai(2,1:2) = (/ 0.d0, gamma /)
+        ap%Ai(3,1:3) = (/ 0.d0, (1.d0-gamma)/2.d0, gamma /)
+        ap%Ai(4,1:4) = (/ 0.d0,                b1,    b2, gamma /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:4) = (/ 0.d0, gamma, (1.d0+gamma)/2.d0,  1.d0 /)
+        ap%bi(1:4) = (/ 0.d0,    b1,                b2, gamma /)
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:4,1:4) = 0.d0
+        ap%Ae(2,1) = gamma
+        ap%Ae(4,2) = 0.5529291480359398d0
+        ap%Ae(4,3) = 0.5529291480359398d0
+        ap%Ae(4,1) = 1.d0 - ap%Ae(4,2) - ap%Ae(4,3)
+        ap%Ae(3,1) = ap%Ae(4,2)*(2.d0 - 9.d0*gamma + 3.d0*gamma*gamma)/2.d0 &
+                    +ap%Ae(4,3)*(11.d0 - 42.d0*gamma + 15.d0*gamma*gamma)/4.d0 &
+                    -7.d0/2.d0 + 13.d0*gamma - 9.d0*gamma*gamma/2.d0
+        ap%Ae(3,2) = ap%Ae(4,2)*(-2.d0 + 9.d0*gamma - 3.d0*gamma*gamma)/2.d0 &
+                    +ap%Ae(4,3)*(-11.d0 + 42.d0*gamma - 15.d0*gamma*gamma)/4.d0 &
+                    +4.d0 - 25.d0*gamma/2.d0 + 9.d0*gamma*gamma/2.d0
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:4) = ap%ci(1:4)
+        ap%be(1:4) = ap%bi(1:4)
+
+      case (ARS443_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 5 ! 5 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:5,1:5) = 0.d0
+        ap%Ai(2,1:2) = (/ 0.d0,  1.d0/2.d0 /)
+        ap%Ai(3,1:3) = (/ 0.d0,  1.d0/6.d0,  1.d0/2.d0 /)
+        ap%Ai(4,1:4) = (/ 0.d0, -1.d0/2.d0,  1.d0/2.d0, 1.d0/2.d0 /)
+        ap%Ai(5,1:5) = (/ 0.d0,  3.d0/2.d0, -3.d0/2.d0, 1.d0/2.d0, 1.d0/2.d0 /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:5) = (/ 0.d0, 1.d0/2.d0,  2.d0/3.d0, 1.d0/2.d0,      1.d0 /)
+        ap%bi(1:5) = (/ 0.d0, 3.d0/2.d0, -3.d0/2.d0, 1.d0/2.d0, 1.d0/2.d0 /)
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:5,1:5) = 0.d0
+        ap%Ae(2,1) = 1.d0/2.d0
+        ap%Ae(3,1:2) = (/ 11.d0/18.d0, 1.d0/18.d0 /)
+        ap%Ae(4,1:3) = (/   5.d0/6.d0, -5.d0/6.d0, 1.d0/2.d0 /)
+        ap%Ae(5,1:4) = (/   1.d0/4.d0,  7.d0/4.d0, 3.d0/4.d0, -7.d0/4.d0 /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:5) = ap%ci(1:5)
+        ap%be(1:5) = (/ 1.d0/4.d0, 7.d0/4.d0, 3.d0/4.d0, -7.d0/4.d0, 0.d0 /)
+
+      case (ARK324_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 4 ! 4 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 2 ! 2nd order embedding
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:4,1:4) = 0.d0
+        ap%Ai(2,1:2) = (/ 1767732205903.d0/4055673282236.d0, &
+                          1767732205903.d0/4055673282236.d0 /)
+        ap%Ai(3,1:3) = (/ 2746238789719.d0/10658868560708.d0, &
+                         -640167445237.d0/6845629431997.d0, &
+                          1767732205903.d0/4055673282236.d0 /)
+        ap%Ai(4,1:4) = (/ 1471266399579.d0/7840856788654.d0, &
+                         -4482444167858.d0/7529755066697.d0, &
+                          11266239266428.d0/11593286722821.d0, &
+                          1767732205903.d0/4055673282236.d0 /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:4) = (/ 0.d0, 1767732205903.d0/2027836641118.d0, 3.d0/5.d0, 1.d0 /)
+        ap%bi(1) = 1471266399579.d0/7840856788654.d0
+        ap%bi(2) = -4482444167858.d0/7529755066697.d0
+        ap%bi(3) =  11266239266428.d0/11593286722821.d0
+        ap%bi(4) = 1767732205903.d0/4055673282236.d0
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:4,1:4) = 0.d0
+        ap%Ae(2,1) = 1767732205903.d0/2027836641118.d0
+        ap%Ae(3,1:2) = (/ 5535828885825.d0/10492691773637.d0, &
+                          788022342437.d0/10882634858940.d0 /)
+        ap%Ae(4,1:3) = (/ 6485989280629.d0/16251701735622.d0, &
+                         -4246266847089.d0/9704473918619.d0, &
+                          10755448449292.d0/10357097424841.d0 /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:4) = ap%ci(1:4)
+        ap%be(1:4) = ap%bi(1:4)
+        ! Embedding
+        ap%be2(1) = 2756255671327.d0/12835298489170.d0
+        ap%be2(2) = -10771552573575.d0/22201958757719.d0
+        ap%be2(3) = 9247589265047.d0/10645013368117.d0
+        ap%be2(4) = 2193209047091.d0/5459859503100.d0
+
+      case (ARK436_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 6 ! 6 stage
+        ap%q = 4 ! 4th order
+        ap%p = 3 ! 3rd order embedding
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:6,1:6) = 0.d0
+        ap%Ai(2,1:2) = (/ 1.d0/4.d0, 1.d0/4.d0 /)
+        ap%Ai(3,1:3) = (/ 8611.d0/62500.d0, -1743.d0/31250.d0, 1.d0/4.d0 /)
+        ap%Ai(4,1:4) = (/ 5012029.d0/34652500.d0, -654441.d0/2922500.d0, &
+                          174375.d0/388108.d0, 1.d0/4.d0 /)
+        ap%Ai(5,1:5) = (/ 15267082809.d0/155376265600.d0, &
+                          -71443401.d0/120774400.d0, 730878875.d0/902184768.d0, &
+                          2285395.d0/8070912.d0, 1.d0/4.d0 /)
+        ap%Ai(6,1:6) = (/ 82889.d0/524892.d0, 0.d0, 15625.d0/83664.d0, &
+                          69875.d0/102672.d0, -2260.d0/8211.d0, 1.d0/4.d0 /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:6) = (/ 0.d0, 1.d0/2.d0, 83.d0/250.d0, 31.d0/50.d0, &
+                      17.d0/20.d0, 1.d0 /)
+        ap%bi(1:6) = (/ 82889.d0/524892.d0, 0.d0, 15625.d0/83664.d0, &
+                      69875.d0/102672.d0, -2260.d0/8211.d0, 1.d0/4.d0 /)
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:6,1:6) = 0.d0
+        ap%Ae(2,1) = 1.d0/2.d0
+        ap%Ae(3,1:2) = (/ 13861.d0/62500.d0, 6889.d0/62500.d0 /)
+        ap%Ae(4,1:3) = (/ -116923316275.d0/2393684061468.d0, &
+                          -2731218467317.d0/15368042101831.d0, &
+                          9408046702089.d0/11113171139209.d0 /)
+        ap%Ae(5,1:4) = (/ -451086348788.d0/2902428689909.d0, &
+                          -2682348792572.d0/7519795681897.d0, &
+                          12662868775082.d0/11960479115383.d0, &
+                          3355817975965.d0/11060851509271.d0 /)
+        ap%Ae(6,1:5) = (/ 647845179188.d0/3216320057751.d0, &
+                          73281519250.d0/8382639484533.d0, &
+                          552539513391.d0/3454668386233.d0, &
+                          3354512671639.d0/8306763924573.d0, 4040.d0/17871.d0 /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:6) = ap%ci(1:6)
+        ap%be(1:6) = ap%bi(1:6)
+        ! Embedding
+        ap%be2(1:6) = (/ 4586570599.d0/29645900160.d0, 0.d0, 178811875.d0/945068544.d0, &
+                        814220225.d0/1159782912.d0, -3700637.d0/11593932.d0, &
+                        61727.d0/225920.d0 /)
+
+      case (SSP3333B_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 3 ! 3 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:3,1:3) = 0.d0
+        ap%Ai(2,1:2) = (/      0.d0,       1.d0 /)
+        ap%Ai(3,1:3) = (/ 1.d0/6.d0, -1.d0/3.d0, 2.d0/3.d0 /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:3) = (/ 0.d0, 1.d0, 0.5d0 /)
+        ap%bi(1:3) = (/ 1.d0/6.d0, 1.d0/6.d0, 2.d0/3.d0 /)
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:3,1:3) = 0.d0
+        ap%Ae(2,1) = 1.d0
+        ap%Ae(3,1:2) = (/ 0.25d0, 0.25d0 /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:3) = ap%ci(1:3)
+        ap%be(1:3) = ap%bi(1:3)
+
+      case (SSP3333C_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 3 ! 3 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        beta = sqrt(3.d0)/5.d0 + 0.5d0
+        gamma = -1.d0/8.d0*(sqrt(3.d0) + 1.d0)
+        ! Implicit Butcher Table (matrix)
+        ap%Ai(1:3,1:3) = 0.d0
+        ap%Ai(2,1:2) = (/ 4.d0*gamma + 2.d0*beta, 1.d0 - 4.d0*gamma - 2.d0*beta /)
+        ap%Ai(3,1:3) = (/   0.5d0 - beta - gamma,                         gamma, beta /)
+        ! Implicit Butcher Table (vectors)
+        ap%ci(1:3) = (/ 0.d0, 1.d0, 0.5d0 /)
+        ap%bi(1:3) = (/ 1.d0/6.d0, 1.d0/6.d0, 2.d0/3.d0 /)
+        ! Explicit Butcher Table (matrix)
+        ap%Ae(1:3,1:3) = 0.d0
+        ap%Ae(2,1) = 1.d0
+        ap%Ae(3,1:2) = (/ 0.25d0, 0.25d0 /)
+        ! Explicit Butcher Table (vectors)
+        ap%ce(1:3) = ap%ci(1:3)
+        ap%be(1:3) = ap%bi(1:3)
+
+      case (IMKG232a_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 4 ! 4 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0*(2.d0-sqrt(2.d0))
+        a(1:3) = (/ 0.5d0, 0.5d0, 1.d0 /)
+        ahat(1:3) = (/ 0.d0, 0.5d0*(sqrt(2.d0)-1.d0), 1.d0 /)
+        dhat(1:2) = (/ delta, delta /)
+        b(1:2) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG232b_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 4 ! 4 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0*(2.d0+sqrt(2.d0))
+        a(1:3) = (/ 0.5d0, 0.5d0, 1.d0 /)
+        ahat(1:3) = (/ 0.d0, -0.5d0*(sqrt(2.d0)+1.d0), 1.d0 /)
+        dhat(1:2) = (/ delta, delta /)
+        b(1:2) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG242a_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 5 ! 5 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0*(2.d0-sqrt(2.d0))
+        a(1:4) = (/ 0.25d0, 1.d0/3.d0, 0.5d0, 1.d0 /)
+        ahat(1:4) = (/ 0.d0, 0.d0, 0.5d0*(sqrt(2.d0)-1.d0), 1.d0 /)
+        dhat(1:3) = (/ 0.d0, delta, delta /)
+        b(1:3) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG242b_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 5 ! 5 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0*(2.d0+sqrt(2.d0))
+        a(1:4) = (/ 0.25d0, 1.d0/3.d0, 0.5d0, 1.d0 /)
+        ahat(1:4) = (/ 0.d0, 0.d0, -0.5d0*(sqrt(2.d0)+1.d0), 1.d0 /)
+        dhat(1:3) = (/ 0.d0, delta, delta /)
+        b(1:3) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG243a_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 5 ! 5 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0-sqrt(3.d0)/6.d0
+        a(1:4) = (/ 0.25d0, 1.d0/3.d0, 0.5d0, 1.d0 /)
+        ahat(1:4) = (/ 0.d0, 1.d0/6.d0, sqrt(3.d0)/6.d0, 1.d0 /)
+        dhat(1:3) = (/ delta, delta, delta /)
+        b(1:3) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG243b_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 5 ! 5 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0+sqrt(3.d0)/6.d0
+        a(1:4) = (/ 0.25d0, 1.d0/3.d0, 0.5d0, 1.d0 /)
+        ahat(1:4) = (/ 0.d0, 1.d0/6.d0, -sqrt(3.d0)/6.d0, 1.d0 /)
+        dhat(1:3) = (/ delta, delta, delta /)
+        b(1:3) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG252a_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 6 ! 6 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0*(2.d0-sqrt(2.0))
+        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
+        ahat(1:5) = (/ 0.d0, 0.d0, 0.d0, 0.5d0*(sqrt(2.d0)-1.d0), 1.d0 /)
+        dhat(1:4) = (/ 0.d0, 0.d0, delta, delta /)
+        b(1:4) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG252b_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 6 ! 6 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0*(2.d0+sqrt(2.0))
+        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
+        ahat(1:5) = (/ 0.d0, 0.d0, 0.d0, -0.5d0*(sqrt(2.d0)+1.d0), 1.d0 /)
+        dhat(1:4) = (/ 0.d0, 0.d0, delta, delta /)
+        b(1:4) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG253a_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 6 ! 6 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0-sqrt(3.d0)/6.d0
+        gamma = 0.25d0*sqrt(3.d0)*(1.d0-sqrt(3.d0)/3.d0)*((sqrt(3.d0)/3.d0+1.d0)**2-2.d0)
+        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
+        ahat(1:5) = (/ 0.d0, 0.d0, gamma, sqrt(3.d0)/6.d0, 1.d0 /)
+        dhat(1:4) = (/ 0.d0, delta, delta, delta /)
+        b(1:4) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG253b_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 6 ! 6 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 0.5d0+sqrt(3.d0)/6.d0
+        gamma = 0.25d0*sqrt(3.d0)*(1.d0+sqrt(3.d0)/3.d0)*((sqrt(3.d0)/3.d0-1.d0)**2-2.d0)
+        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
+        ahat(1:5) = (/ 0.d0, 0.d0, gamma, -sqrt(3.d0)/6.d0, 1.d0 /)
+        dhat(1:4) = (/ 0.d0, delta, delta, delta /)
+        b(1:4) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG254a_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 6 ! 6 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
+        ahat(1:5) = (/ 0.d0, 1.d0/60.d0, 5.d0/12.d0, -1.d0, 1.d0 /)
+        dhat(1:4) = (/ 1.d0/6.d0, 0.5d0, 0.5d0, 1.5d0 /)
+        b(1:4) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG254b_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 6 ! 6 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
+        ahat(1:5) = (/ 0.d0, -1.d0/20.d0, 1.25d0, -0.5d0, 1.d0 /)
+        dhat(1:4) = (/ -0.5d0, 1.d0, 1.d0, 1.d0 /)
+        b(1:4) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG254c_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 6 ! 6 stage
+        ap%q = 2 ! 2nd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        delta = 1.d0/6.d0
+        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
+        ahat(1:5) = (/ 0.d0, 1.d0/20.d0, 5.d0/36.d0, -1.d0/3.d0, 1.d0 /)
+        dhat(1:4) = (/ delta, delta, delta, delta /)
+        b(1:4) = 0.d0
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG343a_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 5 ! 5 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        a(1:4) = (/ 0.25d0, 2.d0/3.d0, 1.d0/3.d0, 0.75d0 /)
+        ahat(1:4) = (/ 0.d0, -1.d0/3.d0, -2.d0/3.d0, 0.75d0 /)
+        dhat(1:3) = (/ -1.d0/3.d0, 1.d0, 1.d0 /)
+        b(1:3) = (/ 0.d0, 1.d0/3.d0, 0.25d0 /)
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case (IMKG343b_ARK)
+        ap%imex = 2 ! imex
+        ap%s = 5 ! 5 stage
+        ap%q = 3 ! 3rd order
+        ap%p = 0 ! no embedded order
+        ap%be2 = 0.d0 ! no embedded explicit method
+        ! IMEX-KG vectors
+        a(1:4) = (/ 0.25d0, 2.d0/3.d0, 1.d0/3.d0, 0.75d0 /)
+        ahat(1:4) = (/ 0.4358665215084589d0, &
+                     0.23080014515820763d0, &
+                    -0.10253318817512572d0, &
+                    0.75d0 /)
+        dhat(1:3) = 0.4358665215084589d0
+        b(1:3) = (/ 0.d0, 1.d0/3.d0, 0.25d0 /)
+        ! set IMEX-KG Butcher table
+        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
+      case default
+        call abortmp('Unknown ARKode Butcher table name')
+    end select
+
+  end subroutine set_Butcher_tables
+  !=================================================================
+
+  subroutine set_IMKG_Butcher_tables(arkode_parameters, s, a, ahat, dhat, b)
+    !-----------------------------------------------------------------
+    ! Description: sets Butcher tables in IMEX-KG format:
+    !   Ae:   0 |    0             Ai:     0 |       0
+    !        c1 |   a1    0            chat1 |   ahat1 dhat1
+    !        c2 |   b2   a2  0         chat2 |   bhat1 ahat2 dhat2
+    !        c3 |   b3    0 a3 0       chat3 |   bhat2     0 ahat3 dhat3
+    !           |                            |
+    !        cq | bq-1 0 ... 0 aq 0    chatq | bhatq-1     0    ...    0 ahatq 0
+    !        ----------------------    -----------------------------------------
+    !           | bq-1 0 ... 0 aq 0          | bhatq-1     0    ...    0 ahatq 0
+    !
+    !        ci = sum_j Ae(i,j)        chati = sum_j Ai(i,j)
+    !
+    !   Arguments:
+    !    arkode_parameters - (parameter, in/output) object for arkode parameters
+    !                    s - (integer, input) number of stages
+    !                    a - (real(max_stage_num), input) alpha vector
+    !                 ahat - (real(max_stage_num), input) alpha_hat vector
+    !                 dhat - (real(max_stage_num), in/output) delta_hat vector
+    !                    b - (real(max_stage_num), input) beta vector
+    !-----------------------------------------------------------------
+
+    !======= Inclusions ===========
+    use kinds,            only: real_kind
+    use parallel_mod,     only: abortmp
+
+    !======= Declarations =========
+    implicit none
+
+    ! calling variables
+    type(parameter_list), target, intent(inout) :: arkode_parameters
+    integer,                      intent(in)    :: s
+    real(real_kind),              intent(in)    :: a(max_stage_num)
+    real(real_kind),              intent(in)    :: ahat(max_stage_num)
+    real(real_kind),              intent(inout) :: dhat(max_stage_num)
+    real(real_kind),              intent(in)    :: b(max_stage_num)
+
+    ! local variables
+    type(parameter_list), pointer :: ap
+
+    !======= Internals ============
+    ap => arkode_parameters
+
+    ! for easier implementation, extend dhat vector by setting s-1 index to zero
+    dhat(s-1) = 0.d0
+
+    ! set matrices and c vectors according to IMEX-KG format
+    ap%Ai(1:s,1:s) = 0.d0
+    ap%Ae(1:s,1:s) = 0.d0
+    ap%ci(1) = 0.d0
+    ap%ce(1) = 0.d0
+    if (s > 1) then
+      ap%Ai(2,1:2) = (/ ahat(1), dhat(1) /)
+      ap%Ae(2,1) = a(1)
+      ap%ci(2) = ahat(1)+dhat(1)
+      ap%ce(2) = a(1)
+    end if
+    if (s > 2) then
+      ap%Ai(3,1:3) = (/ b(1), ahat(2), dhat(2) /)
+      ap%Ae(3,1:2) = (/ b(1), a(2) /)
+      ap%ci(3) = b(1)+ahat(2)+dhat(2)
+      ap%ce(3) = b(1)+a(2)
+    end if
+    if (s > 3) then
+      ap%Ai(4,1:4) = (/ b(2), 0.d0, ahat(3), dhat(3) /)
+      ap%Ae(4,1:3) = (/ b(2), 0.d0, a(3) /)
+      ap%ci(4) = b(2)+ahat(3)+dhat(3)
+      ap%ce(4) = b(2)+a(3)
+    end if
+    if (s > 4) then
+      ap%Ai(5,1:5) = (/ b(3), 0.d0, 0.d0, ahat(4), dhat(4) /)
+      ap%Ae(5,1:4) = (/ b(3), 0.d0, 0.d0, a(4) /)
+      ap%ci(5) = b(3)+ahat(4)+dhat(4)
+      ap%ce(5) = b(3)+a(4)
+    end if
+    if (s > 5) then
+      ap%Ai(6,1:6) = (/ b(4), 0.d0, 0.d0, 0.d0, ahat(5), dhat(5) /)
+      ap%Ae(6,1:5) = (/ b(4), 0.d0, 0.d0, 0.d0, a(5) /)
+      ap%ci(6) = b(4)+ahat(5)+dhat(5)
+      ap%ce(6) = b(4)+a(5)
+    end if
+    if (s > 6) then
+      call abortmp('ARKode IMEX-KG only implemented for 6 stages or less')
+    end if
+
+    ! set b vectors
+    ap%bi(1:s) = ap%Ai(s,1:s)
+    ap%be(1:s) = ap%Ae(s,1:s)
+
+  end subroutine set_IMKG_Butcher_tables
+
+end module arkode_mod

--- a/components/homme/src/arkode/theta-l/arkode_mod.F90
+++ b/components/homme/src/arkode/theta-l/arkode_mod.F90
@@ -14,21 +14,16 @@
 #define SSP3333C_ARK 10
 #define RK2_ARK 11
 #define KGU35_ARK 12
-#define IMKG232a_ARK 13
-#define IMKG232b_ARK 14
-#define IMKG242a_ARK 15
-#define IMKG242b_ARK 16
-#define IMKG243a_ARK 17
-#define IMKG243b_ARK 18
-#define IMKG252a_ARK 19
-#define IMKG252b_ARK 20
-#define IMKG253a_ARK 21
-#define IMKG253b_ARK 22
-#define IMKG254a_ARK 23
-#define IMKG254b_ARK 24
-#define IMKG254c_ARK 25
-#define IMKG343a_ARK 26
-#define IMKG343b_ARK 27
+#define IMKG232_ARK 13
+#define IMKG242_ARK 14
+#define IMKG243_ARK 15
+#define IMKG252_ARK 16
+#define IMKG253_ARK 17
+#define IMKG254_ARK 18
+#define IMKG342_ARK 19
+#define IMKG343_ARK 20
+#define IMKG353_ARK 21
+#define IMKG354_ARK 22
 
 
 
@@ -62,33 +57,28 @@ module arkode_mod
 
   ! data type for passing ARKode Butcher table names
   type :: table_list
-    integer :: ARK324     = ARK324_ARK
-    integer :: ARK436     = ARK436_ARK
-    integer :: ARK453     = ARK453_ARK
-    integer :: ARS222     = ARS222_ARK
-    integer :: ARS232     = ARS232_ARK
-    integer :: ARS233     = ARS233_ARK
-    integer :: ARS343     = ARS343_ARK
-    integer :: ARS443     = ARS443_ARK
-    integer :: SSP3333B   = SSP3333B_ARK
-    integer :: SSP3333C   = SSP3333C_ARK
-    integer :: RK2        = RK2_ARK
-    integer :: KGU35      = KGU35_ARK
-    integer :: IMKG232a = IMKG232a_ARK
-    integer :: IMKG232b = IMKG232b_ARK
-    integer :: IMKG242a = IMKG242a_ARK
-    integer :: IMKG242b = IMKG242b_ARK
-    integer :: IMKG243a = IMKG243a_ARK
-    integer :: IMKG243b = IMKG243b_ARK
-    integer :: IMKG252a = IMKG252a_ARK
-    integer :: IMKG252b = IMKG252b_ARK
-    integer :: IMKG253a = IMKG253a_ARK
-    integer :: IMKG253b = IMKG253b_ARK
-    integer :: IMKG254a = IMKG254a_ARK
-    integer :: IMKG254b = IMKG254b_ARK
-    integer :: IMKG254c = IMKG254c_ARK
-    integer :: IMKG343a = IMKG343a_ARK
-    integer :: IMKG343b = IMKG343b_ARK
+    integer :: ARK324   = ARK324_ARK
+    integer :: ARK436   = ARK436_ARK
+    integer :: ARK453   = ARK453_ARK
+    integer :: ARS222   = ARS222_ARK
+    integer :: ARS232   = ARS232_ARK
+    integer :: ARS233   = ARS233_ARK
+    integer :: ARS343   = ARS343_ARK
+    integer :: ARS443   = ARS443_ARK
+    integer :: SSP3333B = SSP3333B_ARK
+    integer :: SSP3333C = SSP3333C_ARK
+    integer :: RK2      = RK2_ARK
+    integer :: KGU35    = KGU35_ARK
+    integer :: IMKG232  = IMKG232_ARK
+    integer :: IMKG242  = IMKG242_ARK
+    integer :: IMKG243  = IMKG243_ARK
+    integer :: IMKG252  = IMKG252_ARK
+    integer :: IMKG253  = IMKG253_ARK
+    integer :: IMKG254  = IMKG254_ARK
+    integer :: IMKG342  = IMKG342_ARK
+    integer :: IMKG343  = IMKG343_ARK
+    integer :: IMKG353  = IMKG353_ARK
+    integer :: IMKG354  = IMKG353_ARK
   end type table_list
 
   ! data type for passing ARKode parameters
@@ -1026,22 +1016,7 @@ contains
         ap%ce(1:3) = ap%ci(1:3)
         ap%be(1:3) = ap%bi(1:3)
 
-      case (IMKG232a_ARK)
-        ap%imex = 2 ! imex
-        ap%s = 4 ! 4 stage
-        ap%q = 2 ! 2nd order
-        ap%p = 0 ! no embedded order
-        ap%be2 = 0.d0 ! no embedded explicit method
-        ! IMEX-KG vectors
-        delta = 0.5d0*(2.d0-sqrt(2.d0))
-        a(1:3) = (/ 0.5d0, 0.5d0, 1.d0 /)
-        ahat(1:3) = (/ 0.d0, 0.5d0*(sqrt(2.d0)-1.d0), 1.d0 /)
-        dhat(1:2) = (/ delta, delta /)
-        b(1:2) = 0.d0
-        ! set IMEX-KG Butcher table
-        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
-
-      case (IMKG232b_ARK)
+      case (IMKG232_ARK)
         ap%imex = 2 ! imex
         ap%s = 4 ! 4 stage
         ap%q = 2 ! 2nd order
@@ -1056,22 +1031,7 @@ contains
         ! set IMEX-KG Butcher table
         call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
 
-      case (IMKG242a_ARK)
-        ap%imex = 2 ! imex
-        ap%s = 5 ! 5 stage
-        ap%q = 2 ! 2nd order
-        ap%p = 0 ! no embedded order
-        ap%be2 = 0.d0 ! no embedded explicit method
-        ! IMEX-KG vectors
-        delta = 0.5d0*(2.d0-sqrt(2.d0))
-        a(1:4) = (/ 0.25d0, 1.d0/3.d0, 0.5d0, 1.d0 /)
-        ahat(1:4) = (/ 0.d0, 0.d0, 0.5d0*(sqrt(2.d0)-1.d0), 1.d0 /)
-        dhat(1:3) = (/ 0.d0, delta, delta /)
-        b(1:3) = 0.d0
-        ! set IMEX-KG Butcher table
-        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
-
-      case (IMKG242b_ARK)
+      case (IMKG242_ARK)
         ap%imex = 2 ! imex
         ap%s = 5 ! 5 stage
         ap%q = 2 ! 2nd order
@@ -1086,22 +1046,7 @@ contains
         ! set IMEX-KG Butcher table
         call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
 
-      case (IMKG243a_ARK)
-        ap%imex = 2 ! imex
-        ap%s = 5 ! 5 stage
-        ap%q = 2 ! 2nd order
-        ap%p = 0 ! no embedded order
-        ap%be2 = 0.d0 ! no embedded explicit method
-        ! IMEX-KG vectors
-        delta = 0.5d0-sqrt(3.d0)/6.d0
-        a(1:4) = (/ 0.25d0, 1.d0/3.d0, 0.5d0, 1.d0 /)
-        ahat(1:4) = (/ 0.d0, 1.d0/6.d0, sqrt(3.d0)/6.d0, 1.d0 /)
-        dhat(1:3) = (/ delta, delta, delta /)
-        b(1:3) = 0.d0
-        ! set IMEX-KG Butcher table
-        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
-
-      case (IMKG243b_ARK)
+      case (IMKG243_ARK)
         ap%imex = 2 ! imex
         ap%s = 5 ! 5 stage
         ap%q = 2 ! 2nd order
@@ -1116,22 +1061,7 @@ contains
         ! set IMEX-KG Butcher table
         call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
 
-      case (IMKG252a_ARK)
-        ap%imex = 2 ! imex
-        ap%s = 6 ! 6 stage
-        ap%q = 2 ! 2nd order
-        ap%p = 0 ! no embedded order
-        ap%be2 = 0.d0 ! no embedded explicit method
-        ! IMEX-KG vectors
-        delta = 0.5d0*(2.d0-sqrt(2.0))
-        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
-        ahat(1:5) = (/ 0.d0, 0.d0, 0.d0, 0.5d0*(sqrt(2.d0)-1.d0), 1.d0 /)
-        dhat(1:4) = (/ 0.d0, 0.d0, delta, delta /)
-        b(1:4) = 0.d0
-        ! set IMEX-KG Butcher table
-        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
-
-      case (IMKG252b_ARK)
+      case (IMKG252_ARK)
         ap%imex = 2 ! imex
         ap%s = 6 ! 6 stage
         ap%q = 2 ! 2nd order
@@ -1146,23 +1076,7 @@ contains
         ! set IMEX-KG Butcher table
         call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
 
-      case (IMKG253a_ARK)
-        ap%imex = 2 ! imex
-        ap%s = 6 ! 6 stage
-        ap%q = 2 ! 2nd order
-        ap%p = 0 ! no embedded order
-        ap%be2 = 0.d0 ! no embedded explicit method
-        ! IMEX-KG vectors
-        delta = 0.5d0-sqrt(3.d0)/6.d0
-        gamma = 0.25d0*sqrt(3.d0)*(1.d0-sqrt(3.d0)/3.d0)*((sqrt(3.d0)/3.d0+1.d0)**2-2.d0)
-        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
-        ahat(1:5) = (/ 0.d0, 0.d0, gamma, sqrt(3.d0)/6.d0, 1.d0 /)
-        dhat(1:4) = (/ 0.d0, delta, delta, delta /)
-        b(1:4) = 0.d0
-        ! set IMEX-KG Butcher table
-        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
-
-      case (IMKG253b_ARK)
+      case (IMKG253_ARK)
         ap%imex = 2 ! imex
         ap%s = 6 ! 6 stage
         ap%q = 2 ! 2nd order
@@ -1178,21 +1092,7 @@ contains
         ! set IMEX-KG Butcher table
         call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
 
-      case (IMKG254a_ARK)
-        ap%imex = 2 ! imex
-        ap%s = 6 ! 6 stage
-        ap%q = 2 ! 2nd order
-        ap%p = 0 ! no embedded order
-        ap%be2 = 0.d0 ! no embedded explicit method
-        ! IMEX-KG vectors
-        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
-        ahat(1:5) = (/ 0.d0, 1.d0/60.d0, 5.d0/12.d0, -1.d0, 1.d0 /)
-        dhat(1:4) = (/ 1.d0/6.d0, 0.5d0, 0.5d0, 1.5d0 /)
-        b(1:4) = 0.d0
-        ! set IMEX-KG Butcher table
-        call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
-
-      case (IMKG254b_ARK)
+      case (IMKG254_ARK)
         ap%imex = 2 ! imex
         ap%s = 6 ! 6 stage
         ap%q = 2 ! 2nd order
@@ -1206,22 +1106,23 @@ contains
         ! set IMEX-KG Butcher table
         call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
 
-      case (IMKG254c_ARK)
+      case (IMKG342_ARK)
         ap%imex = 2 ! imex
-        ap%s = 6 ! 6 stage
-        ap%q = 2 ! 2nd order
+        ap%s = 5 ! 5 stage
+        ap%q = 3 ! 3rd order
         ap%p = 0 ! no embedded order
         ap%be2 = 0.d0 ! no embedded explicit method
         ! IMEX-KG vectors
-        delta = 1.d0/6.d0
-        a(1:5) = (/ 0.25d0, 1.d0/6.d0, 3.d0/8.d0, 0.5d0, 1.d0 /)
-        ahat(1:5) = (/ 0.d0, 1.d0/20.d0, 5.d0/36.d0, -1.d0/3.d0, 1.d0 /)
-        dhat(1:4) = (/ delta, delta, delta, delta /)
-        b(1:4) = 0.d0
+        delta = 0.5d0*(1.d0+sqrt(3.d0)/3.d0)
+        a(1:4) = (/ 0.25d0, 2.d0/3.d0, 1.d0/3.d0, 0.75d0 /)
+        ahat(1:4) = (/ 0.d0, (1.d0-sqrt(3.d0))/6.d0, -(1.d0+sqrt(3.d0))/6.d0, 0.75d0 /)
+        dhat(1:3) = (/ 0.d0, delta, delta /)
+        b(1:3) = (/ 0.d0, 1.d0/3.d0, 0.25d0 /)
         ! set IMEX-KG Butcher table
         call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
 
-      case (IMKG343a_ARK)
+
+      case (IMKG343_ARK)
         ap%imex = 2 ! imex
         ap%s = 5 ! 5 stage
         ap%q = 3 ! 3rd order
@@ -1235,22 +1136,21 @@ contains
         ! set IMEX-KG Butcher table
         call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
 
-      case (IMKG343b_ARK)
+      case (IMKG353_ARK)
         ap%imex = 2 ! imex
-        ap%s = 5 ! 5 stage
+        ap%s = 6 ! 6 stage
         ap%q = 3 ! 3rd order
         ap%p = 0 ! no embedded order
         ap%be2 = 0.d0 ! no embedded explicit method
         ! IMEX-KG vectors
-        a(1:4) = (/ 0.25d0, 2.d0/3.d0, 1.d0/3.d0, 0.75d0 /)
-        ahat(1:4) = (/ 0.4358665215084589d0, &
-                     0.23080014515820763d0, &
-                    -0.10253318817512572d0, &
-                    0.75d0 /)
-        dhat(1:3) = 0.4358665215084589d0
-        b(1:3) = (/ 0.d0, 1.d0/3.d0, 0.25d0 /)
+        a(1:5) = (/ -0.017391304347826087d0, -.92d0, 5.d0/3.d0, 1.d0/3.d0, 3.d0/4.d0 /)
+        ahat(1:2) = (/ 0.3075640504095504d0, -1.2990164859879263d0 /)
+        ahat(3:5) = (/ 1.2516666666666665d0, -0.8166666666666668d0, 3d0/4d0/)
+        dhat(1:4) = (/ -0.2981612530370581d0, .415d0, .415d0, 1.15d0 /)
+        b(1:4) = (/ 1.d0, -1.d0, 1.d0/3.d0, 0.25d0 /)
         ! set IMEX-KG Butcher table
         call set_IMKG_Butcher_tables(arkode_parameters, ap%s, a, ahat, dhat, b)
+
 
       case default
         call abortmp('Unknown ARKode Butcher table name')
@@ -1264,8 +1164,8 @@ contains
     ! Description: sets Butcher tables in IMEX-KG format:
     !   Ae:   0 |    0             Ai:     0 |       0
     !        c1 |   a1    0            chat1 |   ahat1 dhat1
-    !        c2 |   b2   a2  0         chat2 |   bhat1 ahat2 dhat2
-    !        c3 |   b3    0 a3 0       chat3 |   bhat2     0 ahat3 dhat3
+    !        c2 |   b1   a2  0         chat2 |   bhat1 ahat2 dhat2
+    !        c3 |   b2    0 a3 0       chat3 |   bhat2     0 ahat3 dhat3
     !           |                            |
     !        cq | bq-1 0 ... 0 aq 0    chatq | bhatq-1     0    ...    0 ahatq 0
     !        ----------------------    -----------------------------------------

--- a/components/homme/src/arkode/theta-l/homme_nvector.F90
+++ b/components/homme/src/arkode/theta-l/homme_nvector.F90
@@ -1,0 +1,1212 @@
+!-----------------------------------------------------------------------
+! Daniel R. Reynolds
+! SMU Mathematics
+!
+! Copyright 2017; all rights reserved
+!
+! Modified by Christopher J. Vogl (LLNL) 2018
+!=======================================================================
+
+module HommeNVector
+  !-----------------------------------------------------------------------
+  ! Description: simple Fortran user-defined type for example interface
+  !-----------------------------------------------------------------------
+  use element_mod,    only: element_t
+  use element_state,  only: timelevels
+  use parallel_mod,   only: parallel_t
+  use, intrinsic :: iso_c_binding
+  public
+
+  type :: NVec_t
+     type(element_t), pointer :: elem(:)
+     integer                  :: nets
+     integer                  :: nete
+     integer                  :: tl_idx
+  end type NVec_t
+
+  save
+
+  integer, parameter :: RegistryLength=timelevels
+  logical :: HommeNVectorRegistry(RegistryLength)=.false.
+  type(parallel_t), pointer :: par_ptr
+
+  !-------------------------------------
+
+contains
+
+  subroutine SetHommeNVectorPar(par)
+    ! sets current par object pointer for MPI_Allreduce and wrap_repro_sum calls
+    implicit none
+    type(parallel_t), target, intent(in) :: par
+    par_ptr => par
+  end subroutine
+
+  integer function ReserveHommeNVectorRegistryIdx()
+    ! Marks first available vector from registry as used (if any are available)
+    integer :: i
+    do i=1,RegistryLength
+       if (.not. HommeNVectorRegistry(i)) then
+          HommeNVectorRegistry(i) = .true.
+          ReserveHommeNVectorRegistryIdx = i
+          return
+       end if
+    end do
+    ReserveHommeNVectorRegistryIdx = 0
+    return
+  end function ReserveHommeNVectorRegistryIdx
+
+  subroutine MakeHommeNVector(elem, nets, nete, tl_idx, vec, ierr)
+    ! Function to create an NVec_t wrapper (vec) to the Homme solution
+    !   structure, and reserve its index in the vector registry.
+    ! The return value is 0 if succssful, 1 if failure (if the registry
+    !   index is already taken)
+    use element_mod,    only: element_t
+    type (element_t),    target    :: elem(:)
+    integer, intent(in)            :: nets
+    integer, intent(in)            :: nete
+    integer, intent(in)            :: tl_idx
+    type(NVec_t), intent(out)      :: vec
+    integer(C_INT), intent(out)    :: ierr
+
+    ! if registry index is already taken, return failure
+    ierr = 0
+    if (HommeNVectorRegistry(tl_idx)) then
+       ierr = 1
+       return
+    end if
+
+    ! otherwise, set up wrapper and reserve registry entry
+    vec%elem => elem
+    vec%nets = nets
+    vec%nete = nete
+    vec%tl_idx = tl_idx
+    HommeNVectorRegistry(tl_idx) = .true.
+
+    return
+  end subroutine MakeHommeNVector
+
+  !=======================================================================
+end module HommeNVector
+
+
+
+subroutine FNVExtPrint(x_C)
+  !-----------------------------------------------------------------------
+  ! Print routine for EXT vector
+  !
+  ! Note: this function is not required by ARKode (or any of SUNDIALS) --
+  !       it is merely here for convenience when debugging
+  !-----------------------------------------------------------------------
+  use HommeNVector,     only: NVec_t, par_ptr
+  use dimensions_mod,   only: np, nlev, nlevp
+  use MPI,              only: MPI_comm_rank
+
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr) :: x_C
+  type(NVec_t), pointer :: x => NULL()
+
+  integer :: ie, inpx, inpy, inlev, rank, ierr
+
+  !=======Internals ============
+
+  ! dereference x_C pointer for NVec_t object
+  call c_f_pointer(x_C, x)
+
+  ! get rank
+  call MPI_comm_rank(par_ptr%comm,rank,ierr)
+
+  ! print vector data
+  do inlev=1,nlev
+    do ie=x%nets,x%nete
+      do inpx=1,np
+        do inpy=1,np
+          print '(/,"proc ",i2,",", " elem ",i4,",", " u(",i1,",",i1,",",i2,") = ",f15.5)', &
+            rank, ie, inpx, inpy, inlev, x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx)
+          print '("proc ",i2,",", " elem ",i4,",", " v(",i1,",",i1,",",i2,") = ",f15.5)', &
+            rank, ie, inpx, inpy, inlev, x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx)
+          print '("proc ",i2,",", " elem ",i4,",", " vtheta_dp(",i1,",",i1,",",i2,") = ",f15.5)', &
+            rank, ie, inpx, inpy, inlev, x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx)
+          print '("proc ",i2,",", " elem ",i4,",", " dp3d(",i1,",",i1,",",i2,") = ",f15.5,/)', &
+            rank, ie, inpx, inpy, inlev, x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx)
+        end do
+      end do
+    end do
+  end do
+  do inlev=1,nlevp
+    do ie=x%nets,x%nete
+      do inpx=1,np
+        do inpy=1,np
+          print '("proc ",i2,",", " elem ",i4,",", " w(",i1,",",i1,",",i2,") = ",f15.5)', &
+            rank, ie, inpx, inpy, inlev, x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx)
+          print '("proc ",i2,",", " elem ",i4,",", " phinh(",i1,",",i1,",",i2,") = ",f15.5)', &
+            rank, ie, inpx, inpy, inlev, x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx)
+        end do
+      end do
+    end do
+  end do
+
+  return
+end subroutine FNVExtPrint
+!=======================================================================
+
+
+
+subroutine FNVExtClone(x_C, y_C, ierr)
+  !-----------------------------------------------------------------------
+  ! Clone routine for EXT vector -- allocates memory for a new NVec_t y that
+  ! that matches structure for x.
+  !-----------------------------------------------------------------------
+  use HommeNVector, only: NVec_t, ReserveHommeNVectorRegistryIdx
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr), intent(in) :: x_C
+  type(c_ptr), intent(out) :: y_C
+  integer(c_int), intent(out) :: ierr
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: y => NULL()
+  integer :: tl_idx
+
+  !=======Internals ============
+
+  ! grab next available registry index;
+  ! if none are available, set error flag and return
+  ierr = 0
+  tl_idx = ReserveHommeNVectorRegistryIdx()
+  if (tl_idx == 0) then
+     ierr = 1
+     return
+  end if
+
+  ! dereference x_C pointer for NVec_t object
+  call c_f_pointer(x_C, x)
+
+  ! allocate new vector
+  allocate(y)
+
+  ! setup y to replicate x, but with unique registry index
+  y%elem => x%elem
+  y%nets = x%nets
+  y%nete = x%nete
+  y%tl_idx = tl_idx
+
+  ! associate y_C pointer with y
+  y_C = c_loc(y)
+
+  return
+end subroutine FNVExtClone
+!=======================================================================
+
+
+
+subroutine FNVExtDestroy(x_C)
+  !-----------------------------------------------------------------------
+  ! Destroy routine for EXT vector -- nullifies data for a given NVec_t
+  ! and returns its vector index to the registry
+  !-----------------------------------------------------------------------
+  use HommeNVector, only: NVec_t, HommeNVectorRegistry
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr) :: x_C
+  type(NVec_t), pointer :: x => NULL()
+
+  !=======Internals ============
+
+  ! dereference x_C pointer for NVec_t object
+  call c_f_pointer(x_C, x)
+
+  ! return index to registry
+  HommeNVectorRegistry(x%tl_idx) = .false.
+
+  ! detach pointers, deallocate vector and nullify x_C
+  if (associated(x%elem))     nullify(x%elem)
+  deallocate(x)
+  x_C = C_NULL_PTR
+
+  return
+end subroutine FNVExtDestroy
+!=======================================================================
+
+
+
+subroutine FNVExtLinearSum(aval, x_C, bval, y_C, z_C)
+  !-----------------------------------------------------------------------
+  ! z = a*x + b*y
+  !-----------------------------------------------------------------------
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev, nlevp
+  use, intrinsic :: iso_c_binding
+  implicit none
+  real(c_double), intent(in) :: aval
+  type(c_ptr),    intent(in) :: x_C
+  real(c_double), intent(in) :: bval
+  type(c_ptr),    intent(in) :: y_C
+  type(c_ptr),    intent(in) :: z_C
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: y => NULL()
+  type(NVec_t), pointer :: z => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+
+  !=======Internals ============
+
+  ! dereference pointer for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(y_C, y)
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+  do ie=z%nets,z%nete
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%v(inpx,inpy,1,inlev,z%tl_idx) = &
+            aval * x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx) + &
+            bval * y%elem(ie)%state%v(inpx,inpy,1,inlev,y%tl_idx)
+          z%elem(ie)%state%v(inpx,inpy,2,inlev,z%tl_idx) = &
+            aval * x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx) + &
+            bval * y%elem(ie)%state%v(inpx,inpy,2,inlev,y%tl_idx)
+          z%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,z%tl_idx) = &
+            aval * x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx) + &
+            bval * y%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,y%tl_idx)
+          z%elem(ie)%state%dp3d(inpx,inpy,inlev,z%tl_idx) = &
+            aval * x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx) + &
+            bval * y%elem(ie)%state%dp3d(inpx,inpy,inlev,y%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%w_i(inpx,inpy,inlev,z%tl_idx) = &
+            aval * x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx) + &
+            bval * y%elem(ie)%state%w_i(inpx,inpy,inlev,y%tl_idx)
+          z%elem(ie)%state%phinh_i(inpx,inpy,inlev,z%tl_idx) = &
+            aval * x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx) + &
+            bval * y%elem(ie)%state%phinh_i(inpx,inpy,inlev,y%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  return
+end subroutine FNVExtLinearSum
+!=======================================================================
+
+
+
+subroutine FNVExtConst(cval, z_C)
+  !-----------------------------------------------------------------------
+  ! z = c
+  !-----------------------------------------------------------------------
+  use HommeNVector,   only: NVec_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  real(c_double), intent(in) :: cval
+  type(c_ptr),    intent(in) :: z_C
+
+  type(NVec_t), pointer :: z => NULL()
+
+  integer :: ie
+
+  !=======Internals ============
+
+  ! dereference z_C pointer for NVec_t object
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+  do ie=z%nets,z%nete
+     z%elem(ie)%state%v(:,:,:,:,z%tl_idx) = cval
+     z%elem(ie)%state%w_i(:,:,:,z%tl_idx) = cval
+     z%elem(ie)%state%phinh_i(:,:,:,z%tl_idx) = cval
+     z%elem(ie)%state%vtheta_dp(:,:,:,z%tl_idx) = cval
+     z%elem(ie)%state%dp3d(:,:,:,z%tl_idx) = cval
+  end do
+
+  return
+end subroutine FNVExtConst
+!=======================================================================
+
+
+
+subroutine FNVExtProd(x_C, y_C, z_C)
+  !-----------------------------------------------------------------------
+  ! z = x.*y (Matlab notation)
+  !-----------------------------------------------------------------------
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev, nlevp
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr), intent(in) :: x_C
+  type(c_ptr), intent(in) :: y_C
+  type(c_ptr), intent(in) :: z_C
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: y => NULL()
+  type(NVec_t), pointer :: z => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(y_C, y)
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+  do ie=z%nets,z%nete
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%v(inpx,inpy,1,inlev,z%tl_idx) = &
+            x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx)* &
+            y%elem(ie)%state%v(inpx,inpy,1,inlev,y%tl_idx)
+          z%elem(ie)%state%v(inpx,inpy,2,inlev,z%tl_idx) = &
+            x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx)* &
+            y%elem(ie)%state%v(inpx,inpy,2,inlev,y%tl_idx)
+          z%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx)* &
+            y%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,y%tl_idx)
+          z%elem(ie)%state%dp3d(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx)* &
+            y%elem(ie)%state%dp3d(inpx,inpy,inlev,y%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%w_i(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx)* &
+            y%elem(ie)%state%w_i(inpx,inpy,inlev,y%tl_idx)
+          z%elem(ie)%state%phinh_i(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx)* &
+            y%elem(ie)%state%phinh_i(inpx,inpy,inlev,y%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  return
+end subroutine FNVExtProd
+!=======================================================================
+
+
+
+subroutine FNVExtDiv(x_C, y_C, z_C)
+  !-----------------------------------------------------------------------
+  ! z = x./y (Matlab notation; doesn't check for legal denominator)
+  !-----------------------------------------------------------------------
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev, nlevp
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr), intent(in) :: x_C
+  type(c_ptr), intent(in) :: y_C
+  type(c_ptr), intent(in) :: z_C
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: y => NULL()
+  type(NVec_t), pointer :: z => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(y_C, y)
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+  do ie=z%nets,z%nete
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%v(inpx,inpy,1,inlev,z%tl_idx) = &
+            x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx)/ &
+            y%elem(ie)%state%v(inpx,inpy,1,inlev,y%tl_idx)
+          z%elem(ie)%state%v(inpx,inpy,2,inlev,z%tl_idx) = &
+            x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx)/ &
+            y%elem(ie)%state%v(inpx,inpy,2,inlev,y%tl_idx)
+          z%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx)/ &
+            y%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,y%tl_idx)
+          z%elem(ie)%state%dp3d(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx)/ &
+            y%elem(ie)%state%dp3d(inpx,inpy,inlev,y%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%w_i(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx)/ &
+            y%elem(ie)%state%w_i(inpx,inpy,inlev,y%tl_idx)
+          z%elem(ie)%state%phinh_i(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx)/ &
+            y%elem(ie)%state%phinh_i(inpx,inpy,inlev,y%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  return
+end subroutine FNVExtDiv
+!=======================================================================
+
+
+
+subroutine FNVExtScale(cval, x_C, z_C)
+  !-----------------------------------------------------------------------
+  ! z = c*x
+  !-----------------------------------------------------------------------
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev, nlevp
+  use, intrinsic :: iso_c_binding
+  implicit none
+  real(c_double), intent(in) :: cval
+  type(c_ptr),    intent(in) :: x_C
+  type(c_ptr),    intent(in) :: z_C
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: z => NULL()
+
+  integer :: ie, inlev, inpy, inpx
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+  do ie=z%nets,z%nete
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%v(inpx,inpy,1,inlev,z%tl_idx) = &
+            cval * x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx)
+          z%elem(ie)%state%v(inpx,inpy,2,inlev,z%tl_idx) = &
+            cval * x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx)
+          z%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,z%tl_idx) = &
+            cval * x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx)
+          z%elem(ie)%state%dp3d(inpx,inpy,inlev,z%tl_idx) = &
+            cval * x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%w_i(inpx,inpy,inlev,z%tl_idx) = &
+            cval * x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx)
+          z%elem(ie)%state%phinh_i(inpx,inpy,inlev,z%tl_idx) = &
+            cval * x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  return
+end subroutine FNVExtScale
+!=======================================================================
+
+
+
+subroutine FNVExtAbs(x_C, z_C)
+  !-----------------------------------------------------------------------
+  ! z = |x|  (componentwise)
+  !-----------------------------------------------------------------------
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev, nlevp
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr), intent(in) :: x_C
+  type(c_ptr), intent(in) :: z_C
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: z => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+  do ie=z%nets,z%nete
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%v(inpx,inpy,1,inlev,z%tl_idx) = &
+            abs(x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx))
+          z%elem(ie)%state%v(inpx,inpy,2,inlev,z%tl_idx) = &
+            abs(x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx))
+          z%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,z%tl_idx) = &
+            abs(x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx))
+          z%elem(ie)%state%dp3d(inpx,inpy,inlev,z%tl_idx) = &
+            abs(x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx))
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%w_i(inpx,inpy,inlev,z%tl_idx) = &
+            abs(x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx))
+          z%elem(ie)%state%phinh_i(inpx,inpy,inlev,z%tl_idx) = &
+            abs(x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx))
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  return
+end subroutine FNVExtAbs
+!=======================================================================
+
+
+
+subroutine FNVExtInv(x_C, z_C)
+  !-----------------------------------------------------------------------
+  ! z = 1./x (Matlab notation: doesn't check for division by zero)
+  !-----------------------------------------------------------------------
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev, nlevp
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr), intent(in) :: x_C
+  type(c_ptr), intent(in) :: z_C
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: z => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+  do ie=z%nets,z%nete
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%v(inpx,inpy,1,inlev,z%tl_idx) = &
+            1.d0 / x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx)
+          z%elem(ie)%state%v(inpx,inpy,2,inlev,z%tl_idx) = &
+            1.d0 / x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx)
+          z%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,z%tl_idx) = &
+            1.d0 / x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx)
+          z%elem(ie)%state%dp3d(inpx,inpy,inlev,z%tl_idx) = &
+            1.d0 / x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%w_i(inpx,inpy,inlev,z%tl_idx) = &
+            1.d0 / x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx)
+          z%elem(ie)%state%phinh_i(inpx,inpy,inlev,z%tl_idx) = &
+            1.d0 / x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  return
+end subroutine FNVExtInv
+!=======================================================================
+
+
+subroutine FNVExtAddConst(cval, x_C, z_C)
+  !-----------------------------------------------------------------------
+  ! z = x+c (add c to each component of the vector x)
+  !-----------------------------------------------------------------------
+  use HommeNVector,   only: NVec_t
+  use dimensions_mod, only: np, nlev, nlevp
+  use, intrinsic :: iso_c_binding
+  implicit none
+  real(c_double), intent(in) :: cval
+  type(c_ptr), intent(in) :: x_C
+  type(c_ptr), intent(in) :: z_C
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: z => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+  do ie=z%nets,z%nete
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%v(inpx,inpy,1,inlev,z%tl_idx) = &
+            x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx) + cval
+          z%elem(ie)%state%v(inpx,inpy,2,inlev,z%tl_idx) = &
+            x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx) + cval
+          z%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx) + cval
+          z%elem(ie)%state%dp3d(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx) + cval
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          z%elem(ie)%state%w_i(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx) + cval
+          z%elem(ie)%state%phinh_i(inpx,inpy,inlev,z%tl_idx) = &
+            x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx) + cval
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  return
+end subroutine FNVExtAddConst
+!=======================================================================
+
+
+
+subroutine FNVExtDotProd(x_C, y_C, cval)
+  !-----------------------------------------------------------------------
+  ! c = <x,y>  (only include 'active' data; no ghost cells, etc.)
+  !-----------------------------------------------------------------------
+  use HommeNVector,     only: NVec_t, par_ptr
+  use dimensions_mod,   only: np, nlev, nlevp
+  use parallel_mod,     only: global_shared_buf, global_shared_sum
+  use global_norms_mod, only: wrap_repro_sum
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: x_C
+  type(c_ptr),    intent(in)  :: y_C
+  real(c_double), intent(out) :: cval
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: y => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(y_C, y)
+
+  ! NOTE: this use of spheremp acknowledges the fact that unknowns are
+  ! duplicated, in that the sum including spheremp performs the
+  ! integral over the domain
+  do ie=x%nets,x%nete
+    global_shared_buf(ie,1) = 0.d0
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          global_shared_buf(ie,1) = global_shared_buf(ie,1) + &
+            (x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx)* &
+              y%elem(ie)%state%v(inpx,inpy,1,inlev,y%tl_idx) + &
+            x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx)* &
+              y%elem(ie)%state%v(inpx,inpy,2,inlev,y%tl_idx) + &
+            x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx)* &
+              y%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,y%tl_idx) + &
+            x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx)* &
+              y%elem(ie)%state%dp3d(inpx,inpy,inlev,y%tl_idx)) &
+            * x%elem(ie)%spheremp(inpx,inpy)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          global_shared_buf(ie,1) = global_shared_buf(ie,1) + &
+            (x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx)* &
+              y%elem(ie)%state%w_i(inpx,inpy,inlev,y%tl_idx) + &
+            x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx)* &
+              y%elem(ie)%state%phinh_i(inpx,inpy,inlev,y%tl_idx)) &
+            * x%elem(ie)%spheremp(inpx,inpy)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  ! accumulate sum using wrap_repro_sum and then copy to cval
+  ! Q: should we divide by 4*pi to account for the integral?
+  call wrap_repro_sum(nvars=1, comm=par_ptr%comm)
+  cval = global_shared_sum(1)
+
+  return
+end subroutine FNVExtDotProd
+!=======================================================================
+
+
+
+subroutine FNVExtMaxNorm(x_C, cval)
+  !-----------------------------------------------------------------------
+  ! c = max(|x|)
+  !-----------------------------------------------------------------------
+  use HommeNVector,     only: NVec_t, par_ptr
+  use dimensions_mod,   only: np, nlev, nlevp
+  use MPI,              only: MPI_MAX
+  use parallel_mod,     only: MPIreal_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: x_C
+  real(c_double), intent(out) :: cval
+
+  type(NVec_t), pointer :: x => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+  double precision :: cval_loc, cval_max
+
+  !=======Internals ============
+
+  ! dereference x_C pointer for NVec_t object
+  call c_f_pointer(x_C, x)
+
+  ! NOTE: we do not use spheremp here since we want the 'max'
+  ! and all 'inactive' data are just duplicates of 'active' data
+  cval_loc = 0.d0
+  do ie=x%nets,x%nete
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          cval_loc = max(cval_loc, &
+            abs(x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx)), &
+            abs(x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx)), &
+            abs(x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx)), &
+            abs(x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx)))
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          cval_loc = max(cval_loc, &
+            abs(x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx)), &
+            abs(x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx)))
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  ! accumulate in a local "double precision" variable
+  ! just to be safe, and then copy to cval
+  call MPI_Allreduce(cval_loc, cval_max, 1, MPIreal_t, &
+       MPI_MAX, par_ptr%comm, ie)
+  cval = cval_max
+
+  return
+end subroutine FNVExtMaxNorm
+!=======================================================================
+
+
+
+subroutine FNVExtWrmsNorm(x_C, w_C, cval)
+  !-----------------------------------------------------------------------
+  ! cval = sqrt( sum_i smp(i)*[x(i)*w(i)]^2 / [4*pi*6*nlev] )
+  !-----------------------------------------------------------------------
+  use HommeNVector,       only: NVec_t, par_ptr
+  use dimensions_mod,     only: np, nlev, nlevp
+  use physical_constants, only: dd_pi
+  use parallel_mod,       only: abortmp, global_shared_buf, global_shared_sum
+  use global_norms_mod,   only: wrap_repro_sum
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: x_C
+  type(c_ptr),    intent(in)  :: w_C
+  real(c_double), intent(out) :: cval
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: w => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(w_C, w)
+
+  ! NOTE: this use of spheremp acknowledges the fact that unknowns are
+  ! duplicated, in that the sum including spheremp performs the
+  ! integral over the domain.  We also use the fact that the overall
+  ! spherical domain has area 4*pi
+  do ie=x%nets,x%nete
+    global_shared_buf(ie,1) = 0.d0
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          global_shared_buf(ie,1) = global_shared_buf(ie,1) + &
+            ( &
+              (x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx)* &
+                w%elem(ie)%state%v(inpx,inpy,1,inlev,w%tl_idx))**2 + &
+              (x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx)* &
+                w%elem(ie)%state%v(inpx,inpy,2,inlev,w%tl_idx))**2 + &
+              (x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx)* &
+                w%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,w%tl_idx))**2 + &
+              (x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx)* &
+                w%elem(ie)%state%dp3d(inpx,inpy,inlev,w%tl_idx))**2 &
+            ) * x%elem(ie)%spheremp(inpx,inpy)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          global_shared_buf(ie,1) = global_shared_buf(ie,1) + &
+            ( &
+              (x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx)* &
+                w%elem(ie)%state%w_i(inpx,inpy,inlev,w%tl_idx))**2 + &
+              (x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx)* &
+                w%elem(ie)%state%phinh_i(inpx,inpy,inlev,w%tl_idx))**2 &
+            ) * x%elem(ie)%spheremp(inpx,inpy)
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  ! accumulate sum using wrap_repro_sum and then copy to cval and divide
+  ! note that if all x_C entries are alpha and all w_C entries are 1/beta,
+  ! then ||x_C||_wrms < 1 implies that alpha < beta, because
+  ! sum_i smp(i)*[x(i)*w(i)]^2 = 4*pi*(nlev*6+2)*alpha^2/beta^2)
+  call wrap_repro_sum(nvars=1, comm=par_ptr%comm)
+  cval = sqrt(global_shared_sum(1)/(4.d0*dd_pi*(6.d0*nlev+2.d0)))
+
+  return
+end subroutine FNVExtWrmsNorm
+!=======================================================================
+
+
+
+subroutine FNVExtMin(x_C, cval)
+  !-----------------------------------------------------------------------
+  ! cval = min(|xvec|)
+  !-----------------------------------------------------------------------
+  use HommeNVector,     only: NVec_t, par_ptr
+  use dimensions_mod,   only: np, nlev, nlevp
+  use MPI,              only: MPI_MIN
+  use parallel_mod,     only: MPIreal_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: x_C
+  real(c_double), intent(out) :: cval
+
+  type(NVec_t), pointer :: x => NULL()
+
+  integer :: ie, inlev, inpx, inpy
+  double precision :: cval_loc, cval_min
+
+  !=======Internals ============
+
+  ! dereference x_C pointer for NVec_t object
+  call c_f_pointer(x_C, x)
+
+  ! NOTE: we do not use spheremp here since we want the 'min'
+  ! and all 'inactive' data are just duplicates of 'active' data
+  cval_loc = abs(x%elem(x%nets)%state%v(1,1,1,1,x%tl_idx))
+  do ie=x%nets,x%nete
+    do inlev=1,nlev
+      do inpy=1,np
+        do inpx=1,np
+          cval_loc = min(cval_loc, &
+            abs(x%elem(ie)%state%v(inpx,inpy,1,inlev,x%tl_idx)), &
+            abs(x%elem(ie)%state%v(inpx,inpy,2,inlev,x%tl_idx)), &
+            abs(x%elem(ie)%state%vtheta_dp(inpx,inpy,inlev,x%tl_idx)), &
+            abs(x%elem(ie)%state%dp3d(inpx,inpy,inlev,x%tl_idx)))
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+    do inlev=1,nlevp
+      do inpy=1,np
+        do inpx=1,np
+          cval_loc = min(cval_loc, &
+            abs(x%elem(ie)%state%w_i(inpx,inpy,inlev,x%tl_idx)), &
+            abs(x%elem(ie)%state%phinh_i(inpx,inpy,inlev,x%tl_idx)))
+        end do ! inpx
+      end do ! inpy
+    end do ! inlev
+  end do ! ie
+
+  ! accumulate in a local "double precision" variable
+  ! just to be safe, and then copy to cval
+  call MPI_Allreduce(cval_loc, cval_min, 1, MPIreal_t, &
+       MPI_MIN, par_ptr%comm, ie)
+  cval = cval_min
+
+  return
+end subroutine FNVExtMin
+!=======================================================================
+
+
+
+
+
+!-----------------------------------------------------------------------
+! NOTE: the remaining subroutines are not required when interfacing
+! with ARKode, and are hence not currently implemented.  If this will
+! utilize alternate SUNDIALS solvers in the future, some additional
+! subset of these may need to be implemented as well.
+!-----------------------------------------------------------------------
+
+
+
+
+subroutine FNVExtWrmsNormMask(x_C, w_C, l_C, cval)
+  !-----------------------------------------------------------------------
+  ! cval = ||x.*w||_2 / Ntotal (but only where l > 0)
+  !
+  ! Note: this function is not required by ARKode (it is used for other
+  !       SUNDIALS solvers).  As such it need not be implemented, and
+  !       it may be removed from the associated nvector_external files
+  !       (set the corresponding function pointer in the 'ops' to 'NULL()')
+  !-----------------------------------------------------------------------
+  use HommeNVector, only: NVec_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: x_C
+  type(c_ptr),    intent(in)  :: w_C
+  type(c_ptr),    intent(in)  :: l_C
+  real(c_double), intent(out) :: cval
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: w => NULL()
+  type(NVec_t), pointer :: l => NULL()
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(w_C, w)
+  call c_f_pointer(l_C, l)
+
+  ! perform vector operation
+  cval = 0.d0
+
+  return
+end subroutine FNVExtWrmsNormMask
+!=======================================================================
+
+
+
+subroutine FNVExtWl2Norm(x_C, w_C, cval)
+  !-----------------------------------------------------------------------
+  ! c = ||x.*w||_2
+  !
+  ! Note: this function is not required by ARKode (it is used for other
+  !       SUNDIALS solvers).  As such it need not be implemented, and
+  !       it may be removed from the associated nvector_external files
+  !       (set the corresponding function pointer in the 'ops' to 'NULL()')
+  !-----------------------------------------------------------------------
+  use HommeNVector, only: NVec_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: x_C
+  type(c_ptr),    intent(in)  :: w_C
+  real(c_double), intent(out) :: cval
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: w => NULL()
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(w_C, w)
+
+  ! perform vector operation
+  cval = 0.d0
+
+  return
+end subroutine FNVExtWl2Norm
+!=======================================================================
+
+
+
+subroutine FNVExtl1Norm(x_C, cval)
+  !-----------------------------------------------------------------------
+  ! c = ||x||_1
+  !
+  ! Note: this function is not required by ARKode (it is used for other
+  !       SUNDIALS solvers).  As such it need not be implemented, and
+  !       it may be removed from the associated nvector_external files
+  !       (set the corresponding function pointer in the 'ops' to 'NULL()')
+  !-----------------------------------------------------------------------
+  use HommeNVector, only: NVec_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: x_C
+  real(c_double), intent(out) :: cval
+
+  type(NVec_t), pointer :: x => NULL()
+
+  !=======Internals ============
+
+  ! dereference x_C pointer for NVec_t object
+  call c_f_pointer(x_C, x)
+
+  ! perform vector operation
+  cval = 0.d0
+
+  return
+end subroutine FNVExtl1Norm
+!=======================================================================
+
+
+
+subroutine FNVExtCompare(cval, x_C, z_C)
+  !-----------------------------------------------------------------------
+  ! z(i) = 1 if x(i) > c, otherwise z(i) = 0
+  !
+  ! Note: this function is not required by ARKode (it is used for other
+  !       SUNDIALS solvers).  As such it need not be implemented, and
+  !       it may be removed from the associated nvector_external files
+  !       (set the corresponding function pointer in the 'ops' to 'NULL()')
+  !-----------------------------------------------------------------------
+  use HommeNVector, only: NVec_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  real(c_double), intent(in) :: cval
+  type(c_ptr),    intent(in) :: x_C
+  type(c_ptr),    intent(in) :: z_C
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: z => NULL()
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+
+  return
+end subroutine FNVExtCompare
+!=======================================================================
+
+
+
+subroutine FNVExtInvTest(x_C, z_C, cval)
+  !-----------------------------------------------------------------------
+  ! z = 1./x, if all x nonzero, cval = 0, else cval = 1
+  !
+  ! Note: this function is not required by ARKode (it is used for other
+  !       SUNDIALS solvers).  As such it need not be implemented, and
+  !       it may be removed from the associated nvector_external files
+  !       (set the corresponding function pointer in the 'ops' to 'NULL()')
+  !-----------------------------------------------------------------------
+  use HommeNVector, only: NVec_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: x_C
+  type(c_ptr),    intent(in)  :: z_C
+  integer(c_int), intent(out) :: cval
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: z => NULL()
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(z_C, z)
+
+  ! perform vector operation
+  cval = -1
+
+  return
+end subroutine FNVExtInvTest
+!=======================================================================
+
+
+
+subroutine FNVExtConstrMask(c_C, x_C, m_C, testval)
+  !-----------------------------------------------------------------------
+  ! Returns testval = 1 if any element fails constraint test,
+  ! otherwise testval = 0.  Test is as follows:
+  ! if c(i) =  2, then x(i) >  0
+  ! if c(i) =  1, then x(i) >= 0
+  ! if c(i) = -1, then x(i) <= 0
+  ! if c(i) = -2, then x(i) <  0
+  ! fills m(i) = 1 where test fails, m(i) = 0 elsewhere.
+  !
+  ! Note: this function is not required by ARKode (it is used for other
+  !       SUNDIALS solvers).  As such it need not be implemented, and
+  !       it may be removed from the associated nvector_external files
+  !       (set the corresponding function pointer in the 'ops' to 'NULL()')
+  !-----------------------------------------------------------------------
+  use HommeNVector, only: NVec_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: c_C
+  type(c_ptr),    intent(in)  :: x_C
+  type(c_ptr),    intent(in)  :: m_C
+  integer(c_int), intent(out) :: testval
+
+  type(NVec_t), pointer :: c => NULL()
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: m => NULL()
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(c_C, c)
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(m_C, m)
+
+  ! perform vector operation
+  testval = -1
+
+  return
+end subroutine FNVExtConstrMask
+!=======================================================================
+
+
+
+subroutine FNVExtMinQuotient(x_C, y_C, cval)
+  !-----------------------------------------------------------------------
+  ! c = min(x./y), over all y /= 0
+  !
+  ! Note: this function is not required by ARKode (it is used for other
+  !       SUNDIALS solvers).  As such it need not be implemented, and
+  !       it may be removed from the associated nvector_external files
+  !       (set the corresponding function pointer in the 'ops' to 'NULL()')
+  !-----------------------------------------------------------------------
+  use HommeNVector, only: NVec_t
+  use, intrinsic :: iso_c_binding
+  implicit none
+  type(c_ptr),    intent(in)  :: x_C
+  type(c_ptr),    intent(in)  :: y_C
+  real(c_double), intent(out) :: cval
+
+  type(NVec_t), pointer :: x => NULL()
+  type(NVec_t), pointer :: y => NULL()
+
+  !=======Internals ============
+
+  ! dereference pointers for NVec_t objects
+  call c_f_pointer(x_C, x)
+  call c_f_pointer(y_C, y)
+
+  ! perform vector operation
+  cval = 0.d0
+
+  return
+end subroutine FNVExtMinQuotient
+!=======================================================================

--- a/components/homme/src/preqx/share/element_ops.F90
+++ b/components/homme/src/preqx/share/element_ops.F90
@@ -262,12 +262,12 @@ contains
   end subroutine
 
 
-  subroutine set_state_i(u,v,w,T,ps,phis,p,dp,zm,g,i,j,k,elem,n0,n1)
+  subroutine set_state_i(u,v,w,T,ps,phis,p,zm,g,i,j,k,elem,n0,n1)
   !
   ! set state variables at node(i,j,k) at layer interfaces
   ! preqx model has no such variables, so do nothing
   !
-  real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,dp,zm,g
+  real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,zm,g
   integer,          intent(in)    :: i,j,k,n0,n1
   type(element_t),  intent(inout) :: elem
 

--- a/components/homme/src/preqx_kokkos/element_ops.F90
+++ b/components/homme/src/preqx_kokkos/element_ops.F90
@@ -214,12 +214,12 @@ contains
   end subroutine
 
 
-  subroutine set_state_i(u,v,w,T,ps,phis,p,dp,zm,g,i,j,k,elem,n0,n1)
+  subroutine set_state_i(u,v,w,T,ps,phis,p,zm,g,i,j,k,elem,n0,n1)
   !
   ! set state variables at node(i,j,k) at layer interfaces
   ! preqx model has no such variables, so do nothing
   !
-  real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,dp,zm,g
+  real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,zm,g
   integer,          intent(in)    :: i,j,k,n0,n1
   type(element_t),  intent(inout) :: elem
 

--- a/components/homme/src/prim_main.F90
+++ b/components/homme/src/prim_main.F90
@@ -23,6 +23,9 @@ program prim_main
   use perf_mod,         only: t_initf, t_prf, t_finalizef, t_startf, t_stopf ! _EXTERNAL
   use restart_io_mod ,  only: restartheader_t, writerestart
   use hybrid_mod,       only: hybrid_create
+#if (defined MODEL_THETA_L && defined ARKODE)
+  use arkode_mod,       only: calc_nonlinear_stats, finalize_nonlinear_stats
+#endif
 
 #ifdef VERTICAL_INTERPOLATION
   use netcdf_interp_mod, only: netcdf_interp_init, netcdf_interp_write, netcdf_interp_finish
@@ -256,6 +259,11 @@ program prim_main
   call prim_movie_finish
 #endif
 
+#if (defined MODEL_THETA_L && defined ARKODE)
+  if (calc_nonlinear_stats) then
+    call finalize_nonlinear_stats(par%comm, par%rank, par%root, par%nprocs)
+  endif
+#endif
 
   call t_stopf('Total')
   if(par%masterproc) print *,"writing timing data"
@@ -264,11 +272,3 @@ program prim_main
   call t_finalizef()
   call haltmp("exiting program...")
 end program prim_main
-
-
-
-
-
-
-
-

--- a/components/homme/src/test_src/dcmip12_wrapper.F90
+++ b/components/homme/src/test_src/dcmip12_wrapper.F90
@@ -44,7 +44,6 @@ real(rl):: zi(nlevp), zm(nlev)                                          ! z coor
 real(rl):: ddn_hyai(nlevp), ddn_hybi(nlevp)                             ! vertical derivativess of hybrid coefficients
 real(rl):: tau
 real(rl):: ztop
-
 contains
 
 !_____________________________________________________________________
@@ -557,7 +556,7 @@ subroutine dcmip2012_test4_init(elem,hybrid,hvcoord,nets,nete)
   real(rl), parameter :: ps_test = 100000.0d0
 
   integer :: i,j,k,ie                                                   !
-  real(rl):: lon,lat!,hyam,hybm,hyai,hybi
+  real(rl):: lon,lat,hyam,hybm,hyai,hybi
   real(rl):: p,z,phis,u,v,w,T,ps,rho,dp    !pointwise field values
   real(rl):: q,q1,q2,qarray(3),pressure
   integer :: qs
@@ -570,18 +569,14 @@ subroutine dcmip2012_test4_init(elem,hybrid,hvcoord,nets,nete)
     do k=1,nlev
       pressure=hvcoord%hyam(k)*hvcoord%ps0 + hvcoord%hybm(k)*ps_test
       do j=1,np; do i=1,np
-        !call get_coordinates(lat,lon,hyam,hybm, i,j,k,elem(ie),hvcoord)
-        lon  = elem(ie)%spherep(i,j)%lon
-        lat  = elem(ie)%spherep(i,j)%lat
+        call get_coordinates(lat,lon,hyam,hybm, i,j,k,elem(ie),hvcoord)
 
         !test4_baroclinic_wave(moist,X,lon,lat,p,z,zcoords,u,v,w,t,phis,ps,rho,q,q1,q2)
         !moist 0 or 1, X is Earth scale factor, zcoord=0, q is vapor, q1, q2
         call test4_baroclinic_wave(dcmip4_moist,dcmip4_X,lon,lat,&
                                    pressure,z,zcoords,u,v,w,T,phis,ps,rho,q,q1,q2)
         qarray(1)=q; qarray(2)=q1; qarray(3)=q2;
-        !dp = pressure_thickness(ps,k,hvcoord)
-        dp = (hvcoord%hyai(k+1)-hvcoord%hyai(k))*p0 + (hvcoord%hybi(k+1)-hvcoord%hybi(k))*ps
-
+        dp = pressure_thickness(ps,k,hvcoord)
         call set_state(u,v,w,T,ps,phis,pressure,dp,z,g, i,j,k,elem(ie),1,nt)
 
         !init only <=qsize tracers
@@ -592,21 +587,14 @@ subroutine dcmip2012_test4_init(elem,hybrid,hvcoord,nets,nete)
     do k=1,nlevp
       pressure=hvcoord%hyai(k)*hvcoord%ps0 + hvcoord%hybi(k)*ps_test
       do j=1,np; do i=1,np
-        !call get_coordinates(lat,lon,hyai,hybi, i,j,k,elem(ie),hvcoord)
-        lon  = elem(ie)%spherep(i,j)%lon
-        lat  = elem(ie)%spherep(i,j)%lat
+        call get_coordinates(lat,lon,hyai,hybi, i,j,k,elem(ie),hvcoord)
 
         !test4_baroclinic_wave(moist,X,lon,lat,p,z,zcoords,u,v,w,t,phis,ps,rho,q,q1,q2)
         !moist 0 or 1, X is Earth scale factor, zcoord=0, q is vapor, q1, q2
         call test4_baroclinic_wave(dcmip4_moist,dcmip4_X,lon,lat,&
                                    pressure,z,zcoords,u,v,w,T,phis,ps,rho,q,q1,q2)
         qarray(1)=q; qarray(2)=q1; qarray(3)=q2;
-        !dp = pressure_thickness(ps,k,hvcoord)
-        if (k <= nlev) then
-          dp = (hvcoord%hyai(k+1)-hvcoord%hyai(k))*p0 + (hvcoord%hybi(k+1)-hvcoord%hybi(k))*ps
-        else
-          dp = (hvcoord%hyai(k)-hvcoord%hyai(k-1))*p0 + (hvcoord%hybi(k)-hvcoord%hybi(k-1))*ps
-        endif
+        dp = pressure_thickness(ps,k,hvcoord)
         call set_state_i(u,v,w,T,ps,phis,pressure,dp,z,g, i,j,k,elem(ie),1,nt)
 
       enddo; enddo; enddo; 

--- a/components/homme/src/test_src/dcmip12_wrapper.F90
+++ b/components/homme/src/test_src/dcmip12_wrapper.F90
@@ -100,7 +100,7 @@ subroutine dcmip2012_test1_1(elem,hybrid,hvcoord,nets,nete,time,n0,n1)
       z = H  * log(1.0d0/hvcoord%etai(k))
       p = p0 * hvcoord%etai(k)
       call test1_advection_deformation(time,lon,lat,p,z,zcoords,u,v,w,T,phis,ps,rho,q(1),q(2),q(3),q(4))
-      call set_state_i(u,v,w,T,ps,phis,p,dp,zi(k),g, i,j,k,elem(ie),n0,n1)
+      call set_state_i(u,v,w,T,ps,phis,p,zi(k),g, i,j,k,elem(ie),n0,n1)
 
       ! get vertical derivative of p at point i,j,k
       dp_dn = ddn_hyai(k)*p0 + ddn_hybi(k)*ps
@@ -168,8 +168,7 @@ subroutine dcmip2012_test1_2(elem,hybrid,hvcoord,nets,nete,time,n0,n1)
       z = H  * log(1.0d0/hvcoord%etai(k))
       p = p0 * hvcoord%etai(k)
       call test1_advection_hadley(time,lon,lat,p,z,zcoords,u,v,w,T,phis,ps,rho,q(1),q(2))
-      dp = pressure_thickness(ps,k,hvcoord)
-      call set_state_i(u,v,w,T,ps,phis,p,dp,zi(k),g, i,j,k,elem(ie),n0,n1)
+      call set_state_i(u,v,w,T,ps,phis,p,zi(k),g, i,j,k,elem(ie),n0,n1)
 
 
       ! get vertical derivative of p at point i,j,k
@@ -241,8 +240,7 @@ subroutine dcmip2012_test1_3(elem,hybrid,hvcoord,nets,nete,time,n0,n1,deriv)
         hyai=hvcoord%hyai(k); hybi=hvcoord%hybi(k)
         lon  = elem(ie)%spherep(i,j)%lon; lat  = elem(ie)%spherep(i,j)%lat
         call test1_advection_orography (lon,lat,p,z,zcoords,cfv,use_eta,hyai,hybi,gc,u,v,w,t,phis,ps,rho,q(1),q(2),q(3),q(4))
-        dp = pressure_thickness(ps,k,hvcoord)
-        call set_state_i(u,v,w,T,ps,phis,p,dp,zi(k),g, i,j,k,elem(ie),n0,n1)
+        call set_state_i(u,v,w,T,ps,phis,p,zi(k),g, i,j,k,elem(ie),n0,n1)
         p_i(i,j) = p
         u_i(i,j) = u
         v_i(i,j) = v
@@ -303,10 +301,9 @@ subroutine dcmip2012_test2_0(elem,hybrid,hvcoord,nets,nete)
      do k=1,nlevp; do j=1,np; do i=1,np
         call get_coordinates(lat,lon,hyai,hybi, i,j,k,elem(ie),hvcoord)
         call test2_steady_state_mountain(lon,lat,p,z,zcoords,use_eta,hyai,hybi,u,v,w,T,phis,ps,rho,q(1))
-        dp = pressure_thickness(ps,k,hvcoord)
         !let's get an analytical \phi
         he = (T0 - T)/gamma
-        call set_state_i(u,v,w,T,ps,phis,p,dp,he,g, i,j,k,elem(ie),1,nt)
+        call set_state_i(u,v,w,T,ps,phis,p,he,g, i,j,k,elem(ie),1,nt)
      enddo; enddo; enddo; 
      call tests_finalize(elem(ie),hvcoord,1,nt)
   enddo
@@ -365,8 +362,7 @@ subroutine dcmip2012_test2_x(elem,hybrid,hvcoord,nets,nete,shear)
      do k=1,nlevp; do j=1,np; do i=1,np
         call get_coordinates(lat,lon,hyai,hybi, i,j,k,elem(ie),hvcoord)
         call test2_schaer_mountain(lon,lat,p,z,zcoords,use_eta,hyai,hybi,shear,u,v,w,T,phis,ps,rho,q(1))
-        dp = pressure_thickness(ps,k,hvcoord)
-        call set_state_i(u,v,w,T,ps,phis,p,dp,z,g, i,j,k,elem(ie),1,nt)
+        call set_state_i(u,v,w,T,ps,phis,p,z,g, i,j,k,elem(ie),1,nt)
      enddo; enddo; enddo; 
      call tests_finalize(elem(ie),hvcoord,1,nt)
   enddo
@@ -431,8 +427,7 @@ subroutine mtest_init(elem,hybrid,hvcoord,nets,nete,testid)
      do k=1,nlevp; do j=1,np; do i=1,np
         call get_coordinates(lat,lon,hyai,hybi, i,j,k,elem(ie),hvcoord)
         call mtest_state(lon,lat,p,z,hyai,hybi,u,v,w,T,phis,ps,rho,testid)
-        dp = pressure_thickness(ps,k,hvcoord)
-        call set_state_i(u,v,w,T,ps,phis,p,dp,z,g, i,j,k,elem(ie),1,nt)
+        call set_state_i(u,v,w,T,ps,phis,p,z,g, i,j,k,elem(ie),1,nt)
         
      enddo; enddo; enddo; 
      call tests_finalize(elem(ie),hvcoord,1,nt)
@@ -535,8 +530,7 @@ subroutine dcmip2012_test3(elem,hybrid,hvcoord,nets,nete)
      do k=1,nlevp; do j=1,np; do i=1,np
         call get_coordinates(lat,lon,hyai,hybi, i,j,k,elem(ie),hvcoord)
         call test3_gravity_wave(lon,lat,p,z,zcoords,use_eta,hyai,hybi,u,v,w,T,T_mean,phis,ps,rho,rho_mean,q(1))
-        dp = pressure_thickness(ps,k,hvcoord)
-        call set_state_i(u,v,w,T,ps,phis,p,dp,zi(k),g, i,j,k,elem(ie),1,nt)
+        call set_state_i(u,v,w,T,ps,phis,p,zi(k),g, i,j,k,elem(ie),1,nt)
      enddo; enddo; enddo; 
      call tests_finalize(elem(ie),hvcoord,1,nt)
   enddo
@@ -594,8 +588,7 @@ subroutine dcmip2012_test4_init(elem,hybrid,hvcoord,nets,nete)
         call test4_baroclinic_wave(dcmip4_moist,dcmip4_X,lon,lat,&
                                    pressure,z,zcoords,u,v,w,T,phis,ps,rho,q,q1,q2)
         qarray(1)=q; qarray(2)=q1; qarray(3)=q2;
-        dp = pressure_thickness(ps,k,hvcoord)
-        call set_state_i(u,v,w,T,ps,phis,pressure,dp,z,g, i,j,k,elem(ie),1,nt)
+        call set_state_i(u,v,w,T,ps,phis,pressure,z,g, i,j,k,elem(ie),1,nt)
 
       enddo; enddo; enddo; 
 

--- a/components/homme/src/test_src/dcmip12_wrapper.F90
+++ b/components/homme/src/test_src/dcmip12_wrapper.F90
@@ -44,6 +44,7 @@ real(rl):: zi(nlevp), zm(nlev)                                          ! z coor
 real(rl):: ddn_hyai(nlevp), ddn_hybi(nlevp)                             ! vertical derivativess of hybrid coefficients
 real(rl):: tau
 real(rl):: ztop
+
 contains
 
 !_____________________________________________________________________
@@ -556,7 +557,7 @@ subroutine dcmip2012_test4_init(elem,hybrid,hvcoord,nets,nete)
   real(rl), parameter :: ps_test = 100000.0d0
 
   integer :: i,j,k,ie                                                   !
-  real(rl):: lon,lat,hyam,hybm,hyai,hybi
+  real(rl):: lon,lat!,hyam,hybm,hyai,hybi
   real(rl):: p,z,phis,u,v,w,T,ps,rho,dp    !pointwise field values
   real(rl):: q,q1,q2,qarray(3),pressure
   integer :: qs
@@ -569,14 +570,18 @@ subroutine dcmip2012_test4_init(elem,hybrid,hvcoord,nets,nete)
     do k=1,nlev
       pressure=hvcoord%hyam(k)*hvcoord%ps0 + hvcoord%hybm(k)*ps_test
       do j=1,np; do i=1,np
-        call get_coordinates(lat,lon,hyam,hybm, i,j,k,elem(ie),hvcoord)
+        !call get_coordinates(lat,lon,hyam,hybm, i,j,k,elem(ie),hvcoord)
+        lon  = elem(ie)%spherep(i,j)%lon
+        lat  = elem(ie)%spherep(i,j)%lat
 
         !test4_baroclinic_wave(moist,X,lon,lat,p,z,zcoords,u,v,w,t,phis,ps,rho,q,q1,q2)
         !moist 0 or 1, X is Earth scale factor, zcoord=0, q is vapor, q1, q2
         call test4_baroclinic_wave(dcmip4_moist,dcmip4_X,lon,lat,&
                                    pressure,z,zcoords,u,v,w,T,phis,ps,rho,q,q1,q2)
         qarray(1)=q; qarray(2)=q1; qarray(3)=q2;
-        dp = pressure_thickness(ps,k,hvcoord)
+        !dp = pressure_thickness(ps,k,hvcoord)
+        dp = (hvcoord%hyai(k+1)-hvcoord%hyai(k))*p0 + (hvcoord%hybi(k+1)-hvcoord%hybi(k))*ps
+
         call set_state(u,v,w,T,ps,phis,pressure,dp,z,g, i,j,k,elem(ie),1,nt)
 
         !init only <=qsize tracers
@@ -587,14 +592,21 @@ subroutine dcmip2012_test4_init(elem,hybrid,hvcoord,nets,nete)
     do k=1,nlevp
       pressure=hvcoord%hyai(k)*hvcoord%ps0 + hvcoord%hybi(k)*ps_test
       do j=1,np; do i=1,np
-        call get_coordinates(lat,lon,hyai,hybi, i,j,k,elem(ie),hvcoord)
+        !call get_coordinates(lat,lon,hyai,hybi, i,j,k,elem(ie),hvcoord)
+        lon  = elem(ie)%spherep(i,j)%lon
+        lat  = elem(ie)%spherep(i,j)%lat
 
         !test4_baroclinic_wave(moist,X,lon,lat,p,z,zcoords,u,v,w,t,phis,ps,rho,q,q1,q2)
         !moist 0 or 1, X is Earth scale factor, zcoord=0, q is vapor, q1, q2
         call test4_baroclinic_wave(dcmip4_moist,dcmip4_X,lon,lat,&
                                    pressure,z,zcoords,u,v,w,T,phis,ps,rho,q,q1,q2)
         qarray(1)=q; qarray(2)=q1; qarray(3)=q2;
-        dp = pressure_thickness(ps,k,hvcoord)
+        !dp = pressure_thickness(ps,k,hvcoord)
+        if (k <= nlev) then
+          dp = (hvcoord%hyai(k+1)-hvcoord%hyai(k))*p0 + (hvcoord%hybi(k+1)-hvcoord%hybi(k))*ps
+        else
+          dp = (hvcoord%hyai(k)-hvcoord%hyai(k-1))*p0 + (hvcoord%hybi(k)-hvcoord%hybi(k-1))*ps
+        endif
         call set_state_i(u,v,w,T,ps,phis,pressure,dp,z,g, i,j,k,elem(ie),1,nt)
 
       enddo; enddo; enddo; 

--- a/components/homme/src/theta-l/CMakeLists.txt
+++ b/components/homme/src/theta-l/CMakeLists.txt
@@ -8,12 +8,22 @@ SET(SRC_DIR           ${HOMME_SOURCE_DIR}/src)
 SET(SRC_SHARE_DIR     ${HOMME_SOURCE_DIR}/src/share)
 SET(TEST_SRC_DIR      ${HOMME_SOURCE_DIR}/src/test_src)
 SET(UTILS_TIMING_DIR  ${CMAKE_BINARY_DIR}/utils/cime/src/share/timing)
+SET(ARKODE_DIR        ${HOMME_SOURCE_DIR}/src/arkode)
 
 # Make INCLUDE_DIRS global so the tests can access it
 SET (EXEC_INCLUDE_DIRS ${PIO_INCLUDE_DIRS} ${UTILS_TIMING_DIR} )
 
-# Find F90 files in target directory
+# Find F90 files in share and test directories
 FILE(GLOB TARGET_F90  ${TARGET_DIR}/*.F90 ${SRC_SHARE_DIR}/*.F90 ${TEST_SRC_DIR}/*.F90)
+
+IF (HOMME_USE_ARKODE)
+  SET(TARGET_F90
+    ${TARGET_F90}
+    ${ARKODE_DIR}/theta-l/arkode_interface.F90
+    ${ARKODE_DIR}/theta-l/arkode_mod.F90
+    ${ARKODE_DIR}/theta-l/homme_nvector.F90
+  )
+ENDIF ()
 
 SET(THETAL_SRCS_F90
   ${TARGET_F90}
@@ -40,13 +50,22 @@ SET(THETAL_SRCS_F90
   ${UTILS_SHARE_DIR}/shr_spfn_mod.F90
 )
 
+IF (HOMME_USE_ARKODE)
+  SET(THETAL_SRCS_C
+    ${ARKODE_DIR}/nvector_external.h
+    ${ARKODE_DIR}/nvector_external.c
+    ${ARKODE_DIR}/column_linsol.h
+    ${ARKODE_DIR}/column_linsol.c
+  )
+ENDIF ()
+
 # If the user specified a file for custom compiler options use those
 IF (DEFINED THETA_CUSTOM_FLAGS_FILE)
   setCustomCompilerFlags(THETA_CUSTOM_FLAGS_FILE THETAL_SRCS_F90)
 ENDIF ()
 
 # Make SRCS global so the tests can access it
-SET(EXEC_SOURCES ${THETAL_SRCS} ${THETAL_SRCS_F90} )
+SET(EXEC_SOURCES ${THETAL_SRCS} ${THETAL_SRCS_C} ${THETAL_SRCS_F90} )
 
 # Set up defaults
 IF (NOT PREQX_NP)
@@ -85,4 +104,4 @@ thetal_setup()
 ############################################################################
 createTestExec(theta-l theta-l ${PREQX_NP} ${PREQX_NC} ${PREQX_PLEV} ${PREQX_USE_PIO}  ${PREQX_USE_ENERGY} ${QSIZE_D})
 
-
+TARGET_LINK_LIBRARIES(theta-l dl)

--- a/components/homme/src/theta-l/element_ops.F90
+++ b/components/homme/src/theta-l/element_ops.F90
@@ -377,13 +377,13 @@ contains
   end subroutine set_state
 
 
-  subroutine set_state_i(u,v,w,T,ps,phis,p,dp,zm,g,i,j,k,elem,n0,n1)
+  subroutine set_state_i(u,v,w,T,ps,phis,p,zm,g,i,j,k,elem,n0,n1)
   !
   ! set state variables at node(i,j,k) at layer interfaces
   ! used by idealized tests for dry initial conditions
   ! so we use constants cp, kappa  
   !
-  real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,dp,zm,g
+  real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,zm,g
   integer,          intent(in)    :: i,j,k,n0,n1
   type(element_t),  intent(inout) :: elem
 

--- a/components/homme/src/theta-l/element_state.F90
+++ b/components/homme/src/theta-l/element_state.F90
@@ -9,7 +9,11 @@ module element_state
 
   implicit none
   private
+#ifdef ARKODE
+  integer, public, parameter :: timelevels = 50
+#else
   integer, public, parameter :: timelevels = 3
+#endif
 
   ! maximum number of Newton iterations taken for an IMEX-RK stage per time-step
   integer, public               :: max_itercnt_perstep

--- a/components/homme/src/theta/element_ops.F90
+++ b/components/homme/src/theta/element_ops.F90
@@ -460,12 +460,12 @@ contains
 
 
 
-  subroutine set_state_i(u,v,w,T,ps,phis,p,dp,zm,g,i,j,k,elem,n0,n1)
+  subroutine set_state_i(u,v,w,T,ps,phis,p,zm,g,i,j,k,elem,n0,n1)
   !
   ! set state variables at node(i,j,k) at layer interfaces
   ! preqx model has no such variables, so do nothing
   !
-  real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,dp,zm,g
+  real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,zm,g
   integer,          intent(in)    :: i,j,k,n0,n1
   type(element_t),  intent(inout) :: elem
 


### PR DESCRIPTION
This PR allows the user to enable an interface to ARKode (https://computation.llnl.gov/projects/sundials/arkode) in HOMME-NH. This allows for rapid implementation and testing of Additive Runge-Kutta methods within the HOMME-NH dycore. The interface code is wrapped in ifdef directives that evaluate to false by default, so these changes should be BFB unless the interface is enabled (via a flag to CMake).