### PR TITLE
Update name of finidat file for cryosphere compsets

### DIFF
--- a/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
@@ -34,6 +34,6 @@
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
 <fsurdat mask="oEC60to30v3" >lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <fsurdat mask="oEC60to30v3wLI" >lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_c180306.nc </fsurdat>
-<finidat mask="oEC60to30v3wLI" >lnd/clm2/initdata_map/clmi.I1850CLM45.ne30_oECv3wLI.clm2.r.0331-01-01-00000.nc </finidat>
+<finidat mask="oEC60to30v3wLI" >lnd/clm2/initdata_map/clmi.I1850CLM45.ne30_oECv3wLI.b58d55680.clm2.r.0331-01-01-00000.nc </finidat>
 
 </namelist_defaults>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -66,8 +66,10 @@
 <config_initial_snow_volume>0.0</config_initial_snow_volume>
 <config_initial_latitude_north>70.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oEC60to30v3wLI">75.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="oRRS30to10v3wLI">75.0</config_initial_latitude_north>
 <config_initial_latitude_south>-60.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oEC60to30v3wLI">-75.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="oRRS30to10v3wLI">-75.0</config_initial_latitude_south>
 <config_initial_velocity_type>'uniform'</config_initial_velocity_type>
 <config_initial_uvelocity>0.0</config_initial_uvelocity>
 <config_initial_vvelocity>0.0</config_initial_vvelocity>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -65,7 +65,9 @@
 <config_initial_ice_volume>1.0</config_initial_ice_volume>
 <config_initial_snow_volume>0.0</config_initial_snow_volume>
 <config_initial_latitude_north>70.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="oEC60to30v3wLI">75.0</config_initial_latitude_north>
 <config_initial_latitude_south>-60.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="oEC60to30v3wLI">-75.0</config_initial_latitude_south>
 <config_initial_velocity_type>'uniform'</config_initial_velocity_type>
 <config_initial_uvelocity>0.0</config_initial_uvelocity>
 <config_initial_vvelocity>0.0</config_initial_vvelocity>


### PR DESCRIPTION
This PR updates the name of the finidat file used for cryosphere 1850 CMIP6 compsets, which is needed after #2564. This PR also changes (reduces) the default extent of the sea ice initial condition for ice grids oEC60to30v3wLI / oRRS30to10v3wLI.

This will change namelists and answers only for tests with the oEC60to30v3wLI and oRRS30to10v3wLI grids.
[NML] - only for tests with oEC60to30v3wLI / oRRS30to10v3wLI
[non-BFB] - only for tests with oEC60to30v3wLI / oRRS30to10v3wLI