### PR TITLE
Update the constant CO2 override value to be CMIP6-compliant

### DIFF
--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -256,9 +256,9 @@
     <values>
       <value compset="_CAM.*%RCO2"> scenario_ghg=&apos;RAMP_CO2_ONLY&apos;ramp_co2_annual_rate=1 </value> 
       <value compset="_BGC%BDRD"> co2_cycle_rad_passive=.true. </value>
-      <value compset="_BGC%BCRC"> co2_cycle_rad_passive=.true. co2vmr_rad=284.7e-6  </value>
+      <value compset="_BGC%BCRC"> co2_cycle_rad_passive=.true. co2vmr_rad=284.317e-6  </value>
       <value compset="_BGC%BCRD"> co2_cycle_rad_passive=.true. </value>
-      <value compset="_BGC%BDRC"> co2_cycle_rad_passive=.true. co2vmr_rad=284.7e-6 </value>
+      <value compset="_BGC%BDRC"> co2_cycle_rad_passive=.true. co2vmr_rad=284.317e-6 </value>
     </values>
     <group>run_component_cam</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
In BCRC and BDRC compsets, the constant value of CO2 seen by the
atmosphere radiation code is specified using the user namelist
override variable, co2vmr_rad.  This variable was still set to the
CMIP5 value for PI CO2 concentrations.  This PR updates the value to
the CMIP6 number, which is consistent with the default constant CO2
values specified elsewhere in the code, and provided to land and ocean
BGC components in the BGC experiment compsets.

[Non-BFB]
[NML]