### PR TITLE
Fix 20th-century transient BGC use case specification 

### DIFF
--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -199,7 +199,7 @@
       <value compset="20TR_CAM5.*AV1C-H01B">20TR_cam5_av1c-h01b</value>
       <value compset="20TR_CAM5.*AV1C-H01C">20TR_cam5_av1c-h01c</value>
       <value compset="20TR_CAM5.*CMIP6"  >20TR_cam5_CMIP6</value>
-      <value compset="20TR_CAM5.*CMIP6*_BGC%B"  >20TR_cam5_CMIP6_bgc</value>
+      <value compset="20TR_CAM5.*CMIP6.*_BGC%B"  >20TR_cam5_CMIP6_bgc</value>
       <value compset="2000_CAM5%COSP"   >2000_cam5_cosp</value>
       <value compset="2000_CAM4%WCMX"   >waccmx_2000_cam4</value>
       <value compset="1996_CAM4%WCMX"   >waccmx_1996_cam4</value>


### PR DESCRIPTION
This PR fixes a single-character mistake in the regular expression
that matches the 20th-century compset definitions for BGC cases.

This is non-BFB and NML changing only for compsets matching:

`20TR_CAM5.*CMIP6.*_BGC%B`

[BFB]
[NML]