### PR TITLE
Update the logic controlling CO2 coupling to be simpler and more flexible

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -177,21 +177,14 @@
     <values match="last">
       <value compset="_CAM\d+"     >CO2A</value>
       <value compset="_DATM"    >none</value>
-      <value compset="_BGC%BPRP">CO2C</value>
       <value compset="HIST.*_DATM%(QIA|CRU|GSW)">CO2A</value>
       <value compset="20TR.*_DATM%(QIA|CRU|GSW)">CO2A</value>
       <value compset="RCP.*_DATM%(QIA|CRU|GSW)" >CO2A</value>
       <value compset="_DATM%IAF.*_MPASO%OECO" >CO2A</value>
       <value compset="_MPASCICE%BGC.*_MPASO%OIECO" >CO2A_OI</value>
       <value compset="_MPASCICE%BGC.*_MPASO%TOIECO_" >CO2A_OI</value>
-      <value compset="_MPASCICE_MPASO_.*_BGC%BCRC" >CO2C</value>
-      <value compset="_MPASCICE_MPASO_.*_BGC%BCRD" >CO2C</value>
-      <value compset="_MPASCICE_MPASO_.*_BGC%BDRC" >CO2C</value>
-      <value compset="_MPASCICE_MPASO_.*_BGC%BDRD" >CO2C</value>
-      <value compset="_MPASCICE%BGC.*_MPASO%OIECO.*_BGC%BCRC" >CO2C_OI</value>
-      <value compset="_MPASCICE%BGC.*_MPASO%OIECO.*_BGC%BCRD" >CO2C_OI</value>
-      <value compset="_MPASCICE%BGC.*_MPASO%OIECO.*_BGC%BDRC" >CO2C_OI</value>
-      <value compset="_MPASCICE%BGC.*_MPASO%OIECO.*_BGC%BDRD" >CO2C_OI</value>
+      <value compset="_BGC%B">CO2C</value>
+      <value compset="_MPASCICE%BGC.*_MPASO%OIECO.*_BGC%B" >CO2C_OI</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
This change simplifies the regular expression matching logic that
controls the CO2 coupling configuration, and makes allows it to more
flexibly match and correctly set the coupling option for additional
compsets.

[BFB]