### PR TITLE
Updates finidat for tsc and pgn test

### DIFF
--- a/cime/scripts/lib/CIME/SystemTests/pgn.py
+++ b/cime/scripts/lib/CIME/SystemTests/pgn.py
@@ -186,7 +186,7 @@ class PGN(SystemTestsCommon):
 
         csmdata_root = self._case.get_value("DIN_LOC_ROOT")
         csmdata_atm  = csmdata_root+"/atm/cam/inic/homme/ne4_v1_init/"
-        csmdata_lnd  = csmdata_root+"/lnd/clm2/initdata/ne4_v1_init/"
+        csmdata_lnd  = csmdata_root+"/lnd/clm2/initdata/ne4_v1_init/b58d55680/"
 
         iinst = 1
         for icond in range(ninit_cond):

--- a/cime/scripts/lib/CIME/SystemTests/tsc.py
+++ b/cime/scripts/lib/CIME/SystemTests/tsc.py
@@ -88,7 +88,7 @@ class TSC(SystemTestsCommon):
         # generate paths/file names for initial conditons
         csmdata_root = self._case.get_value("DIN_LOC_ROOT")
         csmdata_atm  = csmdata_root+"/atm/cam/inic/homme/ne4_v1_init/"
-        csmdata_lnd  = csmdata_root+"/lnd/clm2/initdata/ne4_v1_init/"
+        csmdata_lnd  = csmdata_root+"/lnd/clm2/initdata/ne4_v1_init/b58d55680/"
         file_pref_atm = "SMS_Ly5.ne4_ne4.FC5AV1C-04P2.eos_intel.ne45y.cam.i.0002-"
         file_pref_lnd = "SMS_Ly5.ne4_ne4.FC5AV1C-04P2.eos_intel.ne45y.clm2.r.0002-"
 


### PR DESCRIPTION
This PR updates finidat files path for tsc and pgn tests. These tests
are currently using these files for generating ensemble members. The
old files are not working as finidat file now has a new format. See
PR #2564 for more details

[BFB] - Bit-For-Bit