### PR TITLE
Updating modules for Cori (haswell and KNL) on maint-1.0 branch

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -271,11 +271,19 @@
       <command name="rm">cmake</command>
       <command name="rm">cray-petsc</command>
       <command name="rm">esmf</command>
+      <command name="rm">zlib</command>
+
+      <!-- first load basic defaults, then remove/swap/load as necessary -->
+      <command name="load">craype</command>
+      <command name="load">PrgEnv-intel</command>
+      <command name="load">cray-mpich</command>
+      <command name="rm">craype-mic-knl</command>
+      <command name="load">craype-haswell</command>
     </modules>
 
     <modules>
       <command name="rm">craype</command>
-      <command name="load">craype/2.5.13</command>
+      <command name="load">craype/2.5.14</command>
       <command name="load">pmi/5.0.13</command>
 
       <command name="rm">cray-mpich</command>
@@ -291,6 +299,7 @@
     <modules compiler="gnu">
       <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
+      <command name="load">pe_archive</command>
       <command name="load">gcc/6.3.0</command>
       <command name="rm">cray-libsci</command>
       <command name="load">cray-libsci/17.09.1</command>
@@ -320,8 +329,6 @@
       <command name="load">git</command>
       <command name="rm">cmake</command>
       <command name="load">cmake/3.3.2</command>
-      <command name="rm">zlib</command>
-      <command name="load">zlib/1.2.8</command>
     </modules>
   </module_system>
 
@@ -410,6 +417,7 @@
       <command name="rm">cmake</command>
       <command name="rm">cray-petsc</command>
       <command name="rm">esmf</command>
+      <command name="rm">zlib</command>
 
       <!-- first load basic defaults, then remove/swap/load as necessary -->
       <command name="load">craype</command>
@@ -436,6 +444,7 @@
     <modules compiler="gnu">
       <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
+      <command name="load">pe_archive</command>
       <command name="load">gcc/6.3.0</command>
       <command name="rm">cray-libsci</command>
       <command name="load">cray-libsci/17.09.1</command>
@@ -451,7 +460,7 @@
     </modules>
 
     <modules>
-      <command name="swap">craype craype/2.5.13</command>
+      <command name="swap">craype craype/2.5.14</command>
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.13</command>
       <command name="rm">craype-haswell</command>
@@ -476,8 +485,6 @@
       <command name="load">git</command>
       <command name="rm">cmake</command>
       <command name="load">cmake/3.3.2</command>
-      <command name="rm">zlib</command>
-      <command name="load">zlib/1.2.8</command>
     </modules>
 
     <!--command name="list">&gt;&amp; ml.txt</command-->


### PR DESCRIPTION
Use craype version 2.5.14 (instead of the removed 2.5.13)
When using gcc, load pe_archive module to allow access to 6.3.0
Remove loading of the zlib module as no longer needed (and may cause module errors)

[bfb]