### PR TITLE
Update melvin openmpi

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -708,8 +708,8 @@
         <command name="load">acme-pfunit/3.2.8/base</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">sems-openmpi/1.8.7</command>
-        <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
+        <command name="load">acme-openmpi/2.1.5/acme</command>
+        <command name="load">acme-netcdf/4.4.1/acme</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>


### PR DESCRIPTION
The old version that was being used, 1.8.7, was hanging for unknown
reasons on an all_gather that was recently added for computing MPI task
to node mappings.

[BFB]