### PR TITLE
Single Column Model "Replay" Option

### DIFF
--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -1223,10 +1223,10 @@ if (defined $opts{'camiop'}) {
 }
 my $camiop = $cfg_ref->get('camiop') ? "ON" : "OFF";
 
-# The only dycore supported in CAMIOP mode is Eulerian
-if ($camiop eq 'ON' and $dyn_pkg ne 'eul' and $dyn_pkg ne 'se') {
+# The only dycore supported in CAMIOP mode is Spectral Element
+if ($camiop eq 'ON' and $dyn_pkg ne 'se') {
     die <<"EOF";
-**  ERROR: CAMIOP mode only works with Eulerian dycore.
+**  ERROR: CAMIOP mode only works with Spectral Element dycore.
 **         Requested dycore is: $dyn_pkg
 EOF
 }

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -1224,7 +1224,7 @@ if (defined $opts{'camiop'}) {
 my $camiop = $cfg_ref->get('camiop') ? "ON" : "OFF";
 
 # The only dycore supported in CAMIOP mode is Eulerian
-if ($camiop eq 'ON' and $dyn_pkg ne 'eul') {
+if ($camiop eq 'ON' and $dyn_pkg ne 'eul' and $dyn_pkg ne 'se') {
     die <<"EOF";
 **  ERROR: CAMIOP mode only works with Eulerian dycore.
 **         Requested dycore is: $dyn_pkg

--- a/components/cam/src/chemistry/utils/tracer_data.F90
+++ b/components/cam/src/chemistry/utils/tracer_data.F90
@@ -1186,8 +1186,9 @@ contains
       endif
     enddo
 
-    ! If single column do not interpolate aerosol data, just use the step function
-    if(single_column) then
+    ! If single column do not interpolate aerosol data, just use the step function. 
+    !   The exception is if we are trying to "replay" a column from the full model
+    if(single_column .and. .not. use_camiop) then
       file%stepTime = .true.
     endif
 

--- a/components/cam/src/control/getinterpnetcdfdata.F90
+++ b/components/cam/src/control/getinterpnetcdfdata.F90
@@ -132,7 +132,7 @@ subroutine getinterpncdata( NCID, camlat, camlon, TimeIdx, &
          usable_var = .true.
       endif
 
-      if ( dim_name .EQ. 'lon' ) then
+      if ( dim_name .EQ. 'lon' .or. dim_name .EQ. 'ncol') then
          start( i ) = lonIdx
          count( i ) = 1           ! Extract a single value
          dims_set = dims_set + 1

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -145,7 +145,6 @@ CONTAINS
          call add_default (trim(cnst_name(m))//'_dqfx',2,' ')
        endif
     end do
-
     call addfld ('shflx',horiz_only,    'A','W/m2','Surface sensible heat flux for scam')
     call add_default ('shflx ',2,' ')
     call addfld ('lhflx',horiz_only,    'A','W/m2','Surface latent heat flux for scam')

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -62,14 +62,16 @@ CONTAINS
 !jt
 
 #if ( defined BFB_CAM_SCAM_IOP )
-    call addfld ('CLAT1&IC',horiz_only,    'I','none','cos lat for bfb testing', gridname=gauss_grid)
-    call add_default ('CLAT1&IC       ',0, 'I')
-    call addfld ('CLON1&IC',horiz_only,    'I','none','cos lon for bfb testing', gridname=gauss_grid)
-    call add_default ('CLON1&IC       ',0, 'I')
-    call addfld ('PHI&IC',horiz_only,    'I','none','lat for bfb testing', gridname=gauss_grid)
-    call add_default ('PHI&IC       ',0, 'I')
-    call addfld ('LAM&IC',horiz_only,    'I','none','lon for bfb testing', gridname=gauss_grid)
-    call add_default ('LAM&IC       ',0, 'I')
+    if (dycore_is('EUL')) then
+      call addfld ('CLAT1&IC',horiz_only,    'I','none','cos lat for bfb testing', gridname='gauss_grid')
+      call add_default ('CLAT1&IC       ',0, 'I')
+      call addfld ('CLON1&IC',horiz_only,    'I','none','cos lon for bfb testing', gridname='gauss_grid')
+      call add_default ('CLON1&IC       ',0, 'I')
+      call addfld ('PHI&IC',horiz_only,    'I','none','lat for bfb testing', gridname='gauss_grid')
+      call add_default ('PHI&IC       ',0, 'I')
+      call addfld ('LAM&IC',horiz_only,    'I','none','lon for bfb testing', gridname='gauss_grid')
+      call add_default ('LAM&IC       ',0, 'I')
+    endif
 #endif
 
     call addfld ('DQP',(/ 'lev' /), 'A','kg/kg/s','Specific humidity tendency due to precipitation')
@@ -82,7 +84,6 @@ CONTAINS
 !
 ! !DESCRIPTION: 
 ! !USES:
-    use iop
     use ppgrid, only: pver, pverp
     use phys_control,     only: phys_getopts
 ! !ARGUMENTS:
@@ -96,36 +97,55 @@ CONTAINS
 !
 ! !LOCAL VARIABLES:
     integer m
+    character(len=100) dyngrid
+    
+    if (dycore_is('EUL')) then
+      dyngrid = 'gauss_grid'
+    else
+      dyngrid = 'GLL'
+    endif
 !-----------------------------------------------------------------------
-    call addfld ('CLAT',horiz_only,    'A','none','cos lat for bfb testing', gridname=gauss_grid)
+    call addfld ('CLAT',horiz_only,    'A','none','cos lat for bfb testing', gridname=trim(dyngrid))
     call add_default ('CLAT',2,' ')
-    call addfld ('q',(/ 'lev' /), 'A','kg/kg','Q for scam',gridname=gauss_grid)
+    call addfld ('q',(/ 'lev' /), 'A','kg/kg','Q for scam',gridname=trim(dyngrid))
     call add_default ('q',2, ' ')
-    call addfld ('u',(/ 'lev' /), 'A','m/s','U for scam',gridname=gauss_grid)
+    call addfld ('u',(/ 'lev' /), 'A','m/s','U for scam',gridname=trim(dyngrid))
     call add_default ('u',2,' ')
-    call addfld ('v',(/ 'lev' /), 'A','m/s','V for scam',gridname=gauss_grid)
+    call addfld ('v',(/ 'lev' /), 'A','m/s','V for scam',gridname=trim(dyngrid))
     call add_default ('v',2,' ')
-    call addfld ('t',(/ 'lev' /), 'A','K','Temperature for scam',gridname=gauss_grid)
+    call addfld ('t',(/ 'lev' /), 'A','K','Temperature for scam',gridname=trim(dyngrid))
     call add_default ('t',2,' ')
     call addfld ('Tg',horiz_only,    'A','K','Surface temperature (radiative) for scam')
     call add_default ('Tg',2,' ')
-    call addfld ('Ps',horiz_only, 'A','Pa','Ps for scam',gridname=gauss_grid)
+    call addfld ('Ps',horiz_only, 'A','Pa','Ps for scam',gridname=trim(dyngrid))
     call add_default ('Ps',2,' ')
-    call addfld ('divT3d',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=gauss_grid)
+    call addfld ('divT3d',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
     call add_default ('divT3d',2,' ')
-    call addfld ('fixmas',horiz_only, 'A','percent','Mass fixer',gridname=gauss_grid)
-    call add_default ('fixmas',2,' ')
-    call addfld ('beta',horiz_only, 'A','percent','Mass fixer',gridname=gauss_grid)
-    call add_default ('beta',2,' ')
+
+    if (dycore_is('SE')) then
+      call addfld ('heat_glob',horiz_only, 'A', 'K/s', 'Global mean total energy difference')
+      call add_default ('heat_glob',2,' ')
+    endif
+
+    if (dycore_is('EUL')) then
+      call addfld ('fixmas',horiz_only, 'A','percent','Mass fixer',gridname=trim(dyngrid))
+      call add_default ('fixmas',2,' ')
+      call addfld ('beta',horiz_only, 'A','percent','Mass fixer',gridname=trim(dyngrid))
+      call add_default ('beta',2,' ')
+    endif
+      
     do m=1,pcnst
        call addfld (trim(cnst_name(m))//'_dten',(/ 'lev' /), 'A','kg/kg', &
-            trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=gauss_grid)
+            trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
        call add_default (trim(cnst_name(m))//'_dten',2,' ')
-       call addfld (trim(cnst_name(m))//'_alph',horiz_only, 'A','kg/kg',trim(cnst_name(m))//' alpha constituent fixer',gridname=gauss_grid)
-       call add_default (trim(cnst_name(m))//'_alph',2,' ')
-       call addfld (trim(cnst_name(m))//'_dqfx',(/ 'lev' /), 'A','kg/kg',trim(cnst_name(m))//' dqfx3 fixer',gridname=gauss_grid)
-       call add_default (trim(cnst_name(m))//'_dqfx',2,' ')
+       if (dycore_is('EUL')) then
+         call addfld (trim(cnst_name(m))//'_alph',horiz_only, 'A','kg/kg',trim(cnst_name(m))//' alpha constituent fixer',gridname=trim(dyngrid))
+         call add_default (trim(cnst_name(m))//'_alph',2,' ')
+         call addfld (trim(cnst_name(m))//'_dqfx',(/ 'lev' /), 'A','kg/kg',trim(cnst_name(m))//' dqfx3 fixer',gridname=trim(dyngrid))
+         call add_default (trim(cnst_name(m))//'_dqfx',2,' ')
+       endif
     end do
+
     call addfld ('shflx',horiz_only,    'A','W/m2','Surface sensible heat flux for scam')
     call add_default ('shflx ',2,' ')
     call addfld ('lhflx',horiz_only,    'A','W/m2','Surface latent heat flux for scam')

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -79,12 +79,10 @@ CONTAINS
 ! !LOCAL VARIABLES:
     integer m
     character(len=100) dyngrid
-    
-    if (dycore_is('EUL')) then
-      dyngrid = 'gauss_grid'
-    else
-      dyngrid = 'GLL'
-    endif
+
+    ! Currently SE is the only supported dycore for REPLAY    
+    dyngrid = 'GLL'
+
 !-----------------------------------------------------------------------
     call addfld ('CLAT',horiz_only,    'A','none','cos lat for bfb testing', gridname=trim(dyngrid))
     call add_default ('CLAT',2,' ')

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -55,25 +55,6 @@ CONTAINS
 !
     call addfld ('SGH',horiz_only,    'I','m','Standard deviation of orography')
     call addfld ('SGH30',horiz_only,    'I','m','Standard deviation of 30s orography')
-
-
-!jt
-!jt Maybe add this to scam specific initialization
-!jt
-
-#if ( defined BFB_CAM_SCAM_IOP )
-    if (dycore_is('EUL')) then
-      call addfld ('CLAT1&IC',horiz_only,    'I','none','cos lat for bfb testing', gridname='gauss_grid')
-      call add_default ('CLAT1&IC       ',0, 'I')
-      call addfld ('CLON1&IC',horiz_only,    'I','none','cos lon for bfb testing', gridname='gauss_grid')
-      call add_default ('CLON1&IC       ',0, 'I')
-      call addfld ('PHI&IC',horiz_only,    'I','none','lat for bfb testing', gridname='gauss_grid')
-      call add_default ('PHI&IC       ',0, 'I')
-      call addfld ('LAM&IC',horiz_only,    'I','none','lon for bfb testing', gridname='gauss_grid')
-      call add_default ('LAM&IC       ',0, 'I')
-    endif
-#endif
-
     call addfld ('DQP',(/ 'lev' /), 'A','kg/kg/s','Specific humidity tendency due to precipitation')
 
   end subroutine bldfld
@@ -122,28 +103,13 @@ CONTAINS
     call addfld ('divT3d',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
     call add_default ('divT3d',2,' ')
 
-    if (dycore_is('SE')) then
-      call addfld ('heat_glob',horiz_only, 'A', 'K/s', 'Global mean total energy difference')
-      call add_default ('heat_glob',2,' ')
-    endif
-
-    if (dycore_is('EUL')) then
-      call addfld ('fixmas',horiz_only, 'A','percent','Mass fixer',gridname=trim(dyngrid))
-      call add_default ('fixmas',2,' ')
-      call addfld ('beta',horiz_only, 'A','percent','Mass fixer',gridname=trim(dyngrid))
-      call add_default ('beta',2,' ')
-    endif
+    call addfld ('heat_glob',horiz_only, 'A', 'K/s', 'Global mean total energy difference')
+    call add_default ('heat_glob',2,' ')
       
     do m=1,pcnst
        call addfld (trim(cnst_name(m))//'_dten',(/ 'lev' /), 'A','kg/kg', &
             trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
        call add_default (trim(cnst_name(m))//'_dten',2,' ')
-       if (dycore_is('EUL')) then
-         call addfld (trim(cnst_name(m))//'_alph',horiz_only, 'A','kg/kg',trim(cnst_name(m))//' alpha constituent fixer',gridname=trim(dyngrid))
-         call add_default (trim(cnst_name(m))//'_alph',2,' ')
-         call addfld (trim(cnst_name(m))//'_dqfx',(/ 'lev' /), 'A','kg/kg',trim(cnst_name(m))//' dqfx3 fixer',gridname=trim(dyngrid))
-         call add_default (trim(cnst_name(m))//'_dqfx',2,' ')
-       endif
     end do
     call addfld ('shflx',horiz_only,    'A','W/m2','Surface sensible heat flux for scam')
     call add_default ('shflx ',2,' ')

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -567,6 +567,12 @@ subroutine setiopupdate
           doiter=.false.
         endif
       enddo
+      
+      ! Check to make sure we didn't overshoot at the last 
+      !  IOP timestep.  
+      if (iopTimeIdx .gt. ntime) then
+        iopTimeIdx = ntime
+      endif      
 
       if (doiopupdate) then
 

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -993,26 +993,6 @@ endif !scm_observed_aero
        have_t = .true.
      endif
 
-     ! If using CAMIOP need to be sure that surface temperature is read in 
-     !  for first radiation call, to ensure b4b (or close) reproducibility. 
-     !  Else, for other SCM cases, it is fine initialize as a cold start.   
-     if (is_first_step() .and. use_camiop) then      
-       status = nf90_inq_varid( ncid, 'Tg', varid   )
-       if (status .ne. nf90_noerr) then
-         write(iulog,*)'Could not find variable Tg'
-         if ( have_tsair ) then
-           write(iulog,*) 'UsingTsair'
-           tground = tsair     ! use surface value from T field
-         else
-           write(iulog,*) 'UsingTat lowest level'
-           tground = tobs(plev) 
-         endif
-       else
-         call wrap_get_vara_realx (ncid,varid,strt4,cnt4,tground)
-         have_tg = .true.
-       endif    
-     endif 
-
      status = nf90_inq_varid( ncid, 'qsrf', varid   )
      if ( status .ne. nf90_noerr ) then
        have_srf = .false.
@@ -1298,6 +1278,22 @@ endif !scm_observed_aero
        ptend= srf(1)
      endif
 
+     call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, &
+       'omega', .true., ptend, fill_ends, scm_crm_mode, &
+       dplevs, nlev,psobs, hyam, hybm, wfld, status )
+     if ( status .ne. nf90_noerr ) then
+       have_omega = .false.
+       write(iulog,*)'Could not find variable omega'
+       if ( .not. use_userdata ) then
+         status = nf90_close( ncid )
+         return
+       else
+         write(iulog,*) 'Using value from Analysis Dataset'
+       endif
+     else
+       have_omega = .true.
+     endif
+
      call plevs0(1    ,plon   ,plev    ,psobs   ,pint,pmid ,pdel)
      call shr_sys_flush( iulog )
 !
@@ -1432,60 +1428,23 @@ endif !scm_observed_aero
        status = nf90_get_var(ncid, varid, srf(1), strt4)
        fixmascam=srf(1)
      endif
-     
-     if (.not. use_camiop) then 
-     call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, &
-       'omega', .true., ptend, fill_ends, scm_crm_mode, &
-       dplevs, nlev,psobs, hyam, hybm, wfld, status )
-     if ( status .ne. nf90_noerr ) then
-       have_omega = .false.
-       write(iulog,*)'Could not find variable omega'
-       if ( .not. use_userdata ) then
-         status = nf90_close( ncid )
-         return
-       else
-         write(iulog,*) 'Using value from Analysis Dataset'
-       endif
-     else
-       have_omega = .true.
-     endif 
-     endif
    
    else ! if read in surface information
    
-        status = nf90_inq_varid( ncid, 'Tg', varid   )
-!     status = nf90_inq_varid( ncid, 'trefht', varid )
+     status = nf90_inq_varid( ncid, 'Tg', varid   )
      if (status .ne. nf90_noerr) then
        write(iulog,*)'Could not find variable Tg'
        if ( have_tsair ) then
-         write(iulog,*) 'UsingTsair'
+         write(iulog,*) 'Using Tsair'
          tground = tsair     ! use surface value from T field
        else
-         write(iulog,*) 'UsingTat lowest level'
+         write(iulog,*) 'Using T at lowest level'
          tground = tobs(plev) 
        endif
      else
        call wrap_get_vara_realx (ncid,varid,strt4,cnt4,tground)
        have_tg = .true.
-     endif  
-
-     if (use_camiop) then 
-     call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, &
-       'omega', .true., ptend, fill_ends, scm_crm_mode, &
-       dplevs, nlev,psobs, hyam, hybm, wfld, status )
-     if ( status .ne. nf90_noerr ) then
-       have_omega = .false.
-       write(iulog,*)'Could not find variable omega'
-       if ( .not. use_userdata ) then
-         status = nf90_close( ncid )
-         return
-       else
-         write(iulog,*) 'Using value from Analysis Dataset'
-       endif
-     else
-       have_omega = .true.
-     endif 
-     endif 
+     endif
      
      ! If camiop is used, then need to read in the global
      !   energy fixer

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -338,6 +338,9 @@ CONTAINS
        call seq_timemgr_EClockGetData(EClock,curr_ymd=CurrentYMD, StepNo=StepNo, dtime=DTime_Sync )
        if (StepNo == 0) then
           call atm_import( x2a_a%rattr, cam_in )
+	  if (single_column) then
+	    call scam_use_iop_srf( cam_in )
+	  endif
           call cam_run1 ( cam_in, cam_out ) 
           call atm_export( cam_out, a2x_a%rattr )
        else

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -47,7 +47,7 @@ module atm_comp_mct
   use cam_logfile      , only: iulog
   use co2_cycle        , only: co2_readFlux_ocn, co2_readFlux_fuel
   use runtime_opts     , only: read_namelist
-  use scamMod          , only: single_column,scmlat,scmlon
+  use scamMod          , only: use_camiop,single_column,scmlat,scmlon
 
 !
 ! !PUBLIC TYPES:
@@ -338,7 +338,7 @@ CONTAINS
        call seq_timemgr_EClockGetData(EClock,curr_ymd=CurrentYMD, StepNo=StepNo, dtime=DTime_Sync )
        if (StepNo == 0) then
           call atm_import( x2a_a%rattr, cam_in )
-	  if (single_column) then
+	  if (single_column .and. use_camiop) then
 	    call scam_use_iop_srf( cam_in )
 	  endif
           call cam_run1 ( cam_in, cam_out ) 

--- a/components/cam/src/dynamics/se/se_single_column_mod.F90
+++ b/components/cam/src/dynamics/se/se_single_column_mod.F90
@@ -73,7 +73,7 @@ subroutine scm_setinitial(elem)
               if (have_cldliq) elem(ie)%state%Q(i,j,k,icldliq) = cldliqobs(k)
               if (have_numice) elem(ie)%state%Q(i,j,k,inumice) = numiceobs(k)
               if (have_cldice) elem(ie)%state%Q(i,j,k,icldice) = cldiceobs(k)
-              if (have_omega) elem(ie)%derived%omega_p(i,j,k) = wfldh(k)
+              if (have_omega) elem(ie)%derived%omega_p(i,j,k) = wfld(k)
             enddo
 
           endif
@@ -85,18 +85,19 @@ subroutine scm_setinitial(elem)
 
 end subroutine scm_setinitial
 
-subroutine scm_setfield(elem)
+subroutine scm_setfield(elem,iop_update_surface)
 
   implicit none
 
+  logical :: iop_update_surface
   type(element_t), intent(inout) :: elem(:)
 
   integer i, j, k, ie
 
   do ie=1,nelemd
-    if (have_ps) elem(ie)%state%ps_v(:,:,:) = psobs 
+    if (have_ps .and. .not. iop_update_surface) elem(ie)%state%ps_v(:,:,:) = psobs 
     do i=1, PLEV
-      if (have_omega) elem(ie)%derived%omega_p(:,:,i)=wfldh(i)  !     set t to tobs at first
+      if (have_omega .and. iop_update_surface) elem(ie)%derived%omega_p(:,:,i)=wfld(i)  !     set t to tobs at first
     end do
   end do
 

--- a/components/cam/src/dynamics/se/se_single_column_mod.F90
+++ b/components/cam/src/dynamics/se/se_single_column_mod.F90
@@ -8,6 +8,7 @@ use scamMod
 use constituents, only: cnst_get_ind
 use dimensions_mod, only: nelemd, np
 use time_manager, only: get_nstep, dtime
+use ppgrid, only: begchunk
 
 implicit none
 
@@ -122,7 +123,7 @@ subroutine apply_SC_forcing(elem,hvcoord,tl,n,t_before_advance,nets,nete)
     type (hvcoord_t)                  :: hvcoord
     type (TimeLevel_t), intent(in)       :: tl
     logical :: t_before_advance, do_column_scm
-    real(kind=real_kind), parameter :: rad2deg = 180.0 / SHR_CONST_PI
+    real(kind=real_kind), parameter :: rad2deg = 180.0_real_kind / SHR_CONST_PI
 
     integer :: ie,k,i,j,t,nm_f
     real (kind=real_kind), dimension(np,np,nlev)  :: dpt1,dpt2   ! delta pressure
@@ -173,14 +174,14 @@ subroutine apply_SC_forcing(elem,hvcoord,tl,n,t_before_advance,nets,nete)
     stateQin2(:,:) = stateQin_qfcst(:,:)        
 
     if (.not. use_3dfrc) then
-      dummy1(:) = 0.0
+      dummy1(:) = 0.0_real_kind
     else
       dummy1(:) = elem(ie)%derived%fT(i,j,:)
     endif
-    dummy2(:) = 0.0
+    dummy2(:) = 0.0_real_kind
     forecast_ps = elem(ie)%state%ps_v(i,j,t1)
 
-    call forecast(97,elem(ie)%state%ps_v(i,j,t1),&
+    call forecast(begchunk,elem(ie)%state%ps_v(i,j,t1),&
            elem(ie)%state%ps_v(i,j,t1),forecast_ps,forecast_u,&
            elem(ie)%state%v(i,j,1,:,t1),elem(ie)%state%v(i,j,1,:,t1),&
            forecast_v,elem(ie)%state%v(i,j,2,:,t1),&

--- a/components/cam/src/dynamics/se/se_single_column_mod.F90
+++ b/components/cam/src/dynamics/se/se_single_column_mod.F90
@@ -86,19 +86,18 @@ subroutine scm_setinitial(elem)
 
 end subroutine scm_setinitial
 
-subroutine scm_setfield(elem,iop_update_surface)
+subroutine scm_setfield(elem)
 
   implicit none
 
-  logical :: iop_update_surface
   type(element_t), intent(inout) :: elem(:)
 
   integer i, j, k, ie
 
   do ie=1,nelemd
-    if (have_ps .and. .not. iop_update_surface) elem(ie)%state%ps_v(:,:,:) = psobs 
+    if (have_ps) elem(ie)%state%ps_v(:,:,:) = psobs 
     do i=1, PLEV
-      if (have_omega .and. iop_update_surface) elem(ie)%derived%omega_p(:,:,i)=wfld(i)  !     set t to tobs at first
+      if (have_omega) elem(ie)%derived%omega_p(:,:,i)=wfld(i)  !     set t to tobs at first
     end do
   end do
 

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -209,7 +209,7 @@ subroutine stepon_run1( dtime_out, phys_state, phys_tend,               &
   if (single_column) then
     iop_update_surface = .true. 
     if (doiopupdate) call readiopdata( iop_update_surface,hyam,hybm )
-    call scm_setfield(elem,iop_update_surface)       
+    call scm_setfield(elem)       
   endif 
   
    call t_barrierf('sync_d_p_coupling', mpicom)
@@ -574,7 +574,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
      if (doiopupdate) then
        call scm_setinitial(elem)
        call readiopdata(iop_update_surface,hyam,hybm)
-       call scm_setfield(elem, iop_update_surface)
+       call scm_setfield(elem)
      endif   
 
    endif   

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -167,6 +167,7 @@ subroutine stepon_run1( dtime_out, phys_state, phys_tend,               &
   use control_mod, only: ftype
   use physics_buffer, only : physics_buffer_desc
   use hycoef,      only: hyam, hybm
+  use se_single_column_mod, only: scm_setfield
   implicit none
 !
 ! !OUTPUT PARAMETERS:
@@ -178,8 +179,11 @@ subroutine stepon_run1( dtime_out, phys_state, phys_tend,               &
    type (dyn_import_t), intent(inout) :: dyn_in  ! Dynamics import container
    type (dyn_export_t), intent(inout) :: dyn_out ! Dynamics export container
    type (physics_buffer_desc), pointer :: pbuf2d(:,:)
+   type (element_t), pointer :: elem(:)
 
 !-----------------------------------------------------------------------
+
+   elem => dyn_out%elem
 
    ! NOTE: dtime_out computed here must match formula below
    dtime_out = get_step_size()
@@ -195,11 +199,6 @@ subroutine stepon_run1( dtime_out, phys_state, phys_tend,               &
    ! Move data into phys_state structure.
    !----------------------------------------------------------
    
-   call t_barrierf('sync_d_p_coupling', mpicom)
-   call t_startf('d_p_coupling')
-   call d_p_coupling (phys_state, phys_tend,  pbuf2d, dyn_out )
-   call t_stopf('d_p_coupling')
-   
   ! Determine whether it is time for an IOP update;
   ! doiopupdate set to true if model time step > next available IOP 
   if (use_iop .and. .not. is_last_step()) then
@@ -209,7 +208,13 @@ subroutine stepon_run1( dtime_out, phys_state, phys_tend,               &
   if (single_column) then
     iop_update_surface = .true. 
     if (doiopupdate) call readiopdata( iop_update_surface,hyam,hybm )
-  endif   
+    call scm_setfield(elem,iop_update_surface)
+  endif  
+  
+   call t_barrierf('sync_d_p_coupling', mpicom)
+   call t_startf('d_p_coupling')
+   call d_p_coupling (phys_state, phys_tend,  pbuf2d, dyn_out )
+   call t_stopf('d_p_coupling') 
    
 end subroutine stepon_run1
 
@@ -526,16 +531,35 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    use dyn_comp,    only: dyn_run
    use time_mod,    only: tstep
    use hycoef,      only: hyam, hybm
+   use dimensions_mod, only: nlev, nelemd, np, npsq
    use se_single_column_mod, only: scm_setfield, scm_setinitial
+   use dyn_comp, only: TimeLevel
+   use cam_history,     only: outfld   
    real(r8), intent(in) :: dtime   ! Time-step
+   real(r8) :: ftmp_temp(np,np,nlev,nelemd), ftmp_q(np,np,nlev,pcnst,nelemd)
+   real(r8) :: forcing_temp(npsq,nlev), forcing_q(npsq,nlev,pcnst)
+   real(r8) :: out_temp(npsq,nlev), out_q(npsq,nlev), out_u(npsq,nlev), &
+               out_v(npsq,nlev), out_psv(npsq)   
    type(cam_out_t),     intent(inout) :: cam_out(:) ! Output from CAM to surface
    type(physics_state), intent(inout) :: phys_state(begchunk:endchunk)
    type (dyn_import_t), intent(inout) :: dyn_in  ! Dynamics import container
    type (dyn_export_t), intent(inout) :: dyn_out ! Dynamics export container
    type (element_t), pointer :: elem(:)
-   integer :: rc
+   integer :: rc, i, j, k, p, ie, tl_f
    
    elem => dyn_out%elem
+   
+#if (defined BFB_CAM_SCAM_IOP)   
+
+   tl_f = TimeLevel%n0   ! timelevel which was adjusted by physics
+   
+   ! Save ftmp stuff to get state before dynamics is called
+   do ie=1,nelemd
+     ftmp_temp(:,:,:,ie) = dyn_in%elem(ie)%state%T(:,:,:,tl_f)
+     ftmp_q(:,:,:,:,ie) = dyn_in%elem(ie)%state%Q(:,:,:,:)
+   enddo
+
+#endif   
    
    if (single_column) then
      
@@ -545,7 +569,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
      if (doiopupdate) then
        call scm_setinitial(elem)
        call readiopdata(iop_update_surface,hyam,hybm)
-       call scm_setfield(elem)
+       call scm_setfield(elem, iop_update_surface)
      endif   
 
    endif   
@@ -554,6 +578,48 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    call t_startf ('dyn_run')
    call dyn_run(dyn_out,rc)	
    call t_stopf  ('dyn_run')
+   
+   ! Update to get tendency 
+#if (defined BFB_CAM_SCAM_IOP) 
+
+   tl_f = TimeLevel%n0
+   
+   do ie=1,nelemd
+     do k=1,nlev
+       do j=1,np
+         do i=1,np
+	 
+	   forcing_temp(i+(j-1)*np,k) = (dyn_in%elem(ie)%state%T(i,j,k,tl_f) - &
+	        ftmp_temp(i,j,k,ie))/dtime - dyn_in%elem(ie)%derived%FT(i,j,k)
+           out_temp(i+(j-1)*np,k) = dyn_in%elem(ie)%state%T(i,j,k,tl_f)
+	   out_u(i+(j-1)*np,k) = dyn_in%elem(ie)%state%v(i,j,1,k,tl_f)
+	   out_v(i+(j-1)*np,k) = dyn_in%elem(ie)%state%v(i,j,2,k,tl_f)
+	   out_q(i+(j-1)*np,k) = dyn_in%elem(ie)%state%Q(i,j,k,1)
+	   out_psv(i+(j-1)*np) = dyn_in%elem(ie)%state%ps_v(i,j,tl_f)
+
+	   do p=1,pcnst		
+	     forcing_q(i+(j-1)*np,k,p) = (dyn_in%elem(ie)%state%Q(i,j,k,p) - &
+	        ftmp_q(i,j,k,p,ie))/dtime
+	   enddo
+	  
+	   
+	 enddo
+       enddo
+     enddo
+     
+     call outfld('divT3d',forcing_temp,npsq,ie)
+     call outfld('Ps',out_psv,npsq,ie)
+     call outfld('t',out_temp,npsq,ie)
+     call outfld('q',out_q,npsq,ie)
+     call outfld('u',out_u,npsq,ie)
+     call outfld('v',out_v,npsq,ie)
+     do p=1,pcnst
+       call outfld(trim(cnst_name(p))//'_dten',forcing_q(:,:,p),npsq,ie)   
+     enddo
+     
+   enddo
+
+#endif   
 
 end subroutine stepon_run3
 

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -1063,11 +1063,7 @@ end subroutine diag_conv_tend_ini
 
 ! Vertical velocity and advection
 
-    if (single_column) then
-       call outfld('OMEGA   ',wfld,    pcols,   lchnk     )
-    else
-       call outfld('OMEGA   ',state%omega,    pcols,   lchnk     )
-    endif
+    call outfld('OMEGA   ',state%omega,    pcols,   lchnk     )
 
 #if (defined BFB_CAM_SCAM_IOP )
     call outfld('omega   ',state%omega,    pcols,   lchnk     )

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -1579,6 +1579,7 @@ subroutine diag_surf (cam_in, cam_out, ps, trefmxav, trefmnav )
     call outfld('shflx   ',cam_in%shf,   pcols,   lchnk)
     call outfld('lhflx   ',cam_in%lhf,   pcols,   lchnk)
     call outfld('trefht  ',cam_in%tref,  pcols,   lchnk)
+    call outfld('Tg', cam_in%ts, pcols, lchnk)
 #endif
 !
 ! Ouput ocn and ice fractions

--- a/components/cam/src/physics/cam/check_energy.F90
+++ b/components/cam/src/physics/cam/check_energy.F90
@@ -813,6 +813,9 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
 !-----------------------------------------------------------------------
 !------------------------------Arguments--------------------------------
 
+    use cam_history, only: outfld
+    use scamMod, only: heat_glob_scm, single_column
+
     type(physics_state), intent(in   ) :: state
     type(physics_ptend), intent(out)   :: ptend
 
@@ -822,8 +825,10 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
 !---------------------------Local storage-------------------------------
     integer  :: i                        ! column
     integer  :: ncol                     ! number of atmospheric columns in chunk
+    integer  :: lchnk
 !-----------------------------------------------------------------------
     ncol = state%ncol
+    lchnk = state%lchnk
 
     call physics_ptend_init(ptend, state%psetcols, 'chkenergyfix', ls=.true.)
 
@@ -832,6 +837,9 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
     heat_glob = 0._r8
 #endif
 ! add (-) global mean total energy difference as heating
+    if (single_column) then
+      heat_glob = heat_glob_scm(1)
+    endif
     ptend%s(:ncol,:pver) = heat_glob
 !!$    write(iulog,*) "chk_fix: heat", state%lchnk, ncol, heat_glob
 

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1010,12 +1010,6 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
        !-----------------------------------------------------------------------
        !
 
-#if (defined BFB_CAM_SCAM_IOP )
-       do c=begchunk, endchunk
-          call outfld('Tg',cam_in(c)%ts,pcols   ,c     )
-       end do
-#endif
-
        call t_barrierf('sync_bc_physics', mpicom)
        call t_startf ('bc_physics')
        !call t_adj_detailf(+1)


### PR DESCRIPTION
Modifications to allow for the Single Column Model (SCM) "Replay" option.  This will allow the user to run the full E3SM model and extract forcing for a desired location that can then be used to drive the E3SM SCM (with spectral element dynamical core only).  Note that code modifications provided in this PR will only reproduce the behavior of a column.  This PR will not yet produce bit-4-bit reproduction of a column with the SCM.  A future PR will address this.  

This branch passes all e3sm_developer tests