### PR TITLE
replace flush with shr_sys_flush

### DIFF
--- a/cime/src/drivers/mct/main/cime_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cime_comp_mod.F90
@@ -821,7 +821,7 @@ contains
              write(logunit,'(3A)') trim(adjustl(c_cpl_npes)), &
                                    ' pes participating in computation of CPL instance #', &
                                    trim(adjustl(c_cpl_inst))
-             call flush(logunit)
+             call shr_sys_flush(logunit)
           endif
 
           call t_startf("shr_taskmap_write")


### PR DESCRIPTION
In a recent PR, a call to flush was introduced into CIME,
but the CIME style is to use shr_sys_flush. This PR corrects
this discrepancy.

[BFB]