### PR TITLE
Update land use case file for CBGC 20TR compsets

### DIFF
--- a/components/clm/bld/namelist_files/use_cases/20thC_CMIP6bgc_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/20thC_CMIP6bgc_transient.xml
@@ -46,6 +46,5 @@
 <!-- CMIP6 DECK compsets -->
 
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
-<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
-
+<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_2015_c20171018.nc</flanduse_timeseries>
 </namelist_defaults>

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -73,7 +73,7 @@
       <value compset="1850_CAM5%CMIP6_CLM">1850_CMIP6_control</value>
       <value compset="1850_CAM5%CMIP6_CLM45.*_BGC%BCRC">1850_CMIP6bgc_control</value>
       <value compset="20TR_CAM5%CMIP6_CLM">20thC_CMIP6_transient</value>
-      <value compset="20TR_CAM5%CMIP6_CLM45.*_BGC%BCRC">20thC_CMIP6bgc_transient</value> 
+      <value compset="20TR_CAM5%CMIP6_CLM45.*_BGC%B">20thC_CMIP6bgc_transient</value> 
       <value compset="20TR.*_CLM45%[^_]*BGC">20thC_bgc_transient</value>
       <value compset="1950_CAM5%CMIP6-LR*_CLM">1950_CMIP6LR_control</value>
       <value compset="1950_CAM5%CMIP6-HR_CLM">1950_CMIP6HR_control</value>


### PR DESCRIPTION
This PR updates the compset and use case file for CBGC 20TR configurations with the correct land use file.

[BFB] for tested configurations
[NML]