### PR TITLE
Implement info_taskmap_comp support in component models

### DIFF
--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -5,6 +5,7 @@ module atm_comp_mct
                                pio_closefile, pio_write_darray, pio_def_var, pio_inq_varid, &
 	                       pio_noerr, pio_bcast_error, pio_internal_error, pio_seterrorhandling 
   use mct_mod
+  use seq_comm_mct     , only: info_taskmap_comp
   use seq_cdata_mod
   use esmf
 
@@ -118,6 +119,8 @@ CONTAINS
     type(mct_gGrid), pointer   :: dom_a
     integer :: ATMID
     integer :: mpicom_atm
+    logical :: no_taskmap_output ! if true, do not write out task-to-node mapping
+    logical :: verbose_taskmap_output ! if true, use verbose task-to-node mapping format
     integer :: lsize
     integer :: iradsw
     logical :: exists           ! true if file exists
@@ -201,21 +204,43 @@ CONTAINS
 
        ! Identify SMP nodes and process/SMP mapping for this instance
        ! (Assume that processor names are SMP node names on SMP clusters.)
-
        write(c_inst_index,'(i8)') inst_index
-       write(c_npes,'(i8)') npes
 
-       if (masterproc) then
-          write(iulog,100) trim(adjustl(c_npes)), trim(adjustl(c_inst_index))
-100       format(/,a,' pes participating in computation of CAM instance #',a)
-          call flush(iulog)
+       if (info_taskmap_comp > 0) then
+
+          no_taskmap_output = .false.
+
+          if (info_taskmap_comp == 1) then
+             verbose_taskmap_output = .false.
+          else
+             verbose_taskmap_output = .true.
+          endif
+
+          write(c_npes,'(i8)') npes
+
+          if (masterproc) then
+             write(iulog,'(/,3A)') &
+                trim(adjustl(c_npes)), &
+                ' pes participating in computation of CAM instance #', &
+                trim(adjustl(c_inst_index))
+             call shr_sys_flush(iulog)
+          endif
+
+       else
+
+         no_taskmap_output = .true.
+         verbose_taskmap_output = .false.
+
        endif
 
        call t_startf("shr_taskmap_write")
        call shr_taskmap_write(iulog, mpicom_atm, &
                               'ATM #'//trim(adjustl(c_inst_index)), &
-                              save_nnodes=nsmps, &
-                              save_task_node_map=proc_smp_map)
+                              verbose=verbose_taskmap_output,       &
+                              no_output=no_taskmap_output,          &
+                              save_nnodes=nsmps,                    &
+                              save_task_node_map=proc_smp_map       )
+       call shr_sys_flush(iulog)
        call t_stopf("shr_taskmap_write")
 
        ! 

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -234,7 +234,7 @@ CONTAINS
        endif
 
        call t_startf("shr_taskmap_write")
-       call shr_taskmap_write(iulog, mpicom_atm, &
+       call shr_taskmap_write(iulog, mpicom_atm,                    &
                               'ATM #'//trim(adjustl(c_inst_index)), &
                               verbose=verbose_taskmap_output,       &
                               no_output=no_taskmap_output,          &

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -228,8 +228,8 @@ CONTAINS
 
        else
 
-         no_taskmap_output = .true.
-         verbose_taskmap_output = .false.
+          no_taskmap_output = .true.
+          verbose_taskmap_output = .false.
 
        endif
 

--- a/components/cam/src/utils/spmd_utils.F90
+++ b/components/cam/src/utils/spmd_utils.F90
@@ -35,6 +35,7 @@ module spmd_utils
    use shr_kind_mod,     only: r8 => shr_kind_r8
    use cam_abortutils,   only: endrun
    use shr_taskmap_mod,  only: shr_taskmap_write
+   use shr_sys_mod,      only: shr_sys_flush
    use perf_mod,         only: t_startf, t_stopf
 
 #if ( defined SPMD )
@@ -262,9 +263,10 @@ contains
        write(c_npes,'(i8)') npes
 
        if (masterproc) then
-          write(iulog,100) trim(adjustl(c_npes))
-100       format(/,a,' pes participating in computation of CAM instance')
-          call flush(iulog)
+          write(iulog,'(/,2A)') &
+             trim(adjustl(c_npes)), &
+             ' pes participating in computation of CAM instance'
+          call shr_sys_flush(iulog)
        endif
 
        call t_startf("shr_taskmap_write")

--- a/components/clm/src/cpl/lnd_comp_mct.F90
+++ b/components/clm/src/cpl/lnd_comp_mct.F90
@@ -190,7 +190,7 @@ contains
     endif
 
     call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(iulog, mpicom_lnd, &
+    call shr_taskmap_write(iulog, mpicom_lnd,                    &
                            'LND #'//trim(adjustl(c_inst_index)), &
                            verbose=verbose_taskmap_output,       &
                            no_output=no_taskmap_output           )

--- a/components/clm/src/cpl/lnd_comp_mct.F90
+++ b/components/clm/src/cpl/lnd_comp_mct.F90
@@ -54,6 +54,7 @@ contains
     use shr_file_mod     , only : shr_file_getUnit, shr_file_setIO
     use shr_taskmap_mod  , only : shr_taskmap_write
     use seq_cdata_mod    , only : seq_cdata, seq_cdata_setptrs
+    use seq_comm_mct     , only : info_taskmap_comp
     use seq_timemgr_mod  , only : seq_timemgr_EClockGetData
     use seq_infodata_mod , only : seq_infodata_type, seq_infodata_GetData, seq_infodata_PutData, &
                                   seq_infodata_start_type_start, seq_infodata_start_type_cont,   &
@@ -84,6 +85,8 @@ contains
     integer  :: dtime_sync                           ! coupling time-step from the input synchronization clock
     integer  :: dtime_clm                            ! clm time-step
     logical  :: exists                               ! true if file exists
+    logical  :: no_taskmap_output                    ! true then do not write out task-to-node mapping
+    logical  :: verbose_taskmap_output               ! true then use verbose task-to-node mapping format
     logical  :: atm_aero                             ! Flag if aerosol data sent from atm model
     logical  :: atm_present                          ! Flag if atmosphere model present
     real(r8) :: scmlat                               ! single-column latitude
@@ -157,18 +160,40 @@ contains
     
     ! Identify SMP nodes and process/SMP mapping for this instance
     ! (Assume that processor names are SMP node names on SMP clusters.)
-
     write(c_inst_index,'(i8)') inst_index
-    write(c_npes,'(i8)') npes
 
-    if (masterproc) then
-       write(iulog,100) trim(adjustl(c_npes)), trim(adjustl(c_inst_index))
-100    format(/,a,' pes participating in computation of CLM instance #',a)
-       call flush(iulog)
+    if (info_taskmap_comp > 0) then
+
+       no_taskmap_output = .false.
+
+       if (info_taskmap_comp == 1) then
+          verbose_taskmap_output = .false.
+       else
+          verbose_taskmap_output = .true.
+       endif
+
+       write(c_npes,'(i8)') npes
+
+       if (masterproc) then
+          write(iulog,'(/,3A)') &
+             trim(adjustl(c_npes)), &
+             ' pes participating in computation of CLM instance #', &
+             trim(adjustl(c_inst_index))
+          call shr_sys_flush(iulog)
+       endif
+
+    else
+
+       no_taskmap_output = .true.
+       verbose_taskmap_output = .false.
+
     endif
 
     call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(iulog, mpicom_lnd, 'LND #'//trim(adjustl(c_inst_index)))
+    call shr_taskmap_write(iulog, mpicom_lnd, &
+                           'LND #'//trim(adjustl(c_inst_index)), &
+                           verbose=verbose_taskmap_output,       &
+                           no_output=no_taskmap_output           )
     call t_stopf("shr_taskmap_write")
 
     ! Use infodata to set orbital values

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -14,6 +14,7 @@ module rof_comp_mct
   use shr_const_mod    , only : SHR_CONST_REARTH
   use shr_taskmap_mod  , only : shr_taskmap_write
   use seq_cdata_mod    , only : seq_cdata, seq_cdata_setptrs
+  use seq_comm_mct     , only : info_taskmap_comp
   use seq_timemgr_mod  , only : seq_timemgr_EClockGetData, seq_timemgr_StopAlarmIsOn, &
                                 seq_timemgr_RestartAlarmIsOn, seq_timemgr_EClockDateInSync
   use seq_infodata_mod , only : seq_infodata_type, seq_infodata_GetData, seq_infodata_PutData, &
@@ -90,6 +91,8 @@ contains
     integer :: lsize                                 ! size of attribute vector
     integer :: g,i,j,n                               ! indices
     logical :: exists                                ! true if file exists
+    logical :: no_taskmap_output                     ! true then do not write out task-to-node mapping
+    logical :: verbose_taskmap_output                ! true then use verbose task-to-node mapping format
     integer :: nsrest                                ! restart type
     integer :: ref_ymd                               ! reference date (YYYYMMDD)
     integer :: ref_tod                               ! reference time of day (sec)
@@ -160,18 +163,40 @@ contains
 
     ! Identify SMP nodes and process/SMP mapping for this instance.
     ! (Assume that processor names are SMP node names on SMP clusters.)
-
     write(c_inst_index,'(i8)') inst_index
+
+    if (info_taskmap_comp > 0) then
+
+       no_taskmap_output = .false.
+
+       if (info_taskmap_comp == 1) then
+          verbose_taskmap_output = .false.
+       else
+          verbose_taskmap_output = .true.
+       endif
+
        write(c_npes,'(i8)') npes
 
-    if (masterproc) then
-       write(iulog,100) trim(adjustl(c_npes)), trim(adjustl(c_inst_index))
-100    format(/,a,' pes participating in computation of MOSART instance #',a)
-       call flush(iulog)
+       if (masterproc) then
+          write(iulog,'(/,3A)') &
+             trim(adjustl(c_npes)), &
+             ' pes participating in computation of MOSART instance #', &
+             trim(adjustl(c_inst_index))
+          call shr_sys_flush(iulog)
+       endif
+
+    else
+
+       no_taskmap_output = .true.
+       verbose_taskmap_output = .false.
+
     endif
 
     call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(iulog, mpicom_rof, 'ROF #'//trim(adjustl(c_inst_index)))
+    call shr_taskmap_write(iulog, mpicom_rof, &
+                           'ROF #'//trim(adjustl(c_inst_index)), &
+                           verbose=verbose_taskmap_output,       &
+                           no_output=no_taskmap_output           )
     call t_stopf("shr_taskmap_write")
 
     ! Initialize mosart

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -193,7 +193,7 @@ contains
     endif
 
     call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(iulog, mpicom_rof, &
+    call shr_taskmap_write(iulog, mpicom_rof,                    &
                            'ROF #'//trim(adjustl(c_inst_index)), &
                            verbose=verbose_taskmap_output,       &
                            no_output=no_taskmap_output           )

--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -20,7 +20,7 @@ module glc_comp_mct
   use seq_cdata_mod
   use seq_infodata_mod
   use seq_timemgr_mod
-  use seq_comm_mct,      only : seq_comm_suffix, seq_comm_inst, seq_comm_name
+  use seq_comm_mct,      only : seq_comm_suffix, seq_comm_inst, seq_comm_name, info_taskmap_comp
   use shr_file_mod
   use shr_cal_mod,       only : shr_cal_date2ymd
   use shr_sys_mod
@@ -153,6 +153,8 @@ contains
                                       averagePool
 
     logical :: exists
+    logical :: no_taskmap_output                     ! true then do not write out task-to-node mapping
+    logical :: verbose_taskmap_output                ! true then use verbose task-to-node mapping format
 
     character(kind=c_char), dimension(StrKIND+1) :: c_filename       ! StrKIND+1 for C null-termination character
     integer(kind=c_int) :: c_comm
@@ -289,20 +291,42 @@ contains
 
     ! Identify SMP nodes and process/SMP mapping for this instance
     ! (Assume that processor names are SMP node names on SMP clusters.)
-    call MPI_comm_size(mpicom_g,npes,ierr)
-    write(c_npes,'(i8)') npes
-
     inst_index = seq_comm_inst(glcID)
     write(c_inst_index,'(i8)') inst_index
 
-    if (iam==0) then
-       write(glcLogUnit,100) trim(adjustl(c_npes)), trim(adjustl(c_inst_index))
-100    format(/,a,' pes participating in computation of MPAS-ALBANY-LANDICE instance #',a)
-       call flush(glcLogUnit)
+    if (info_taskmap_comp > 0) then
+
+       no_taskmap_output = .false.
+
+       if (info_taskmap_comp == 1) then
+          verbose_taskmap_output = .false.
+       else
+          verbose_taskmap_output = .true.
+       endif
+
+       call MPI_comm_size(mpicom_g,npes,ierr)
+       write(c_npes,'(i8)') npes
+
+       if (iam==0) then
+          write(glcLogUnit,'(/,3A)') &
+             trim(adjustl(c_npes)), &
+             ' pes participating in computation of MPAS-ALBANY-LANDICE instance #', &
+             trim(adjustl(c_inst_index))
+          call shr_sys_flush(glcLogUnit)
+       endif
+
+    else
+
+       no_taskmap_output = .true.
+       verbose_taskmap_output = .false.
+
     endif
 
     call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(glcLogUnit, mpicom_g, 'GLC #'//trim(adjustl(c_inst_index)))
+    call shr_taskmap_write(glcLogUnit, mpicom_g,                 &
+                           'GLC #'//trim(adjustl(c_inst_index)), &
+                           verbose=verbose_taskmap_output,       &
+                           no_output=no_taskmap_output           )
     call t_stopf("shr_taskmap_write")
 
     ! Setup function pointers for MALI core and domain types

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -15,7 +15,7 @@ module ocn_comp_mct
    use seq_cdata_mod
    use seq_infodata_mod
    use seq_timemgr_mod
-   use seq_comm_mct,      only : seq_comm_suffix, seq_comm_inst, seq_comm_name
+   use seq_comm_mct,      only : seq_comm_suffix, seq_comm_inst, seq_comm_name, info_taskmap_comp
    use shr_file_mod 
    use shr_cal_mod,       only : shr_cal_date2ymd
    use shr_sys_mod
@@ -164,6 +164,8 @@ contains
                                       averagePool, scratchPool
 
     logical :: exists
+    logical :: no_taskmap_output                     ! true then do not write out task-to-node mapping
+    logical :: verbose_taskmap_output                ! true then use verbose task-to-node mapping format
 
     character(kind=c_char), dimension(StrKIND+1) :: c_filename       ! StrKIND+1 for C null-termination character
     integer(kind=c_int) :: c_comm
@@ -321,20 +323,42 @@ contains
 
     ! Identify SMP nodes and process/SMP mapping for this instance
     ! (Assume that processor names are SMP node names on SMP clusters.)
-    call MPI_comm_size(mpicom_o,npes,ierr)
-    write(c_npes,'(i8)') npes
-
     inst_index = seq_comm_inst(ocnID)
     write(c_inst_index,'(i8)') inst_index
 
-    if (iam==0) then
-       write(ocnLogUnit,100) trim(adjustl(c_npes)), trim(adjustl(c_inst_index))
-100    format(/,a,' pes participating in computation of MPAS-OCEAN instance #',a)
-       call flush(ocnLogUnit)
+    if (info_taskmap_comp > 0) then
+
+       no_taskmap_output = .false.
+
+       if (info_taskmap_comp == 1) then
+          verbose_taskmap_output = .false.
+       else
+          verbose_taskmap_output = .true.
+       endif
+
+       call MPI_comm_size(mpicom_o,npes,ierr)
+       write(c_npes,'(i8)') npes
+
+       if (iam==0) then
+          write(ocnLogUnit,'(/,3A)') &
+             trim(adjustl(c_npes)), &
+             ' pes participating in computation of MPAS-OCEAN instance #', &
+             trim(adjustl(c_inst_index))
+          call shr_sys_flush(ocnLogUnit)
+       endif
+
+    else
+
+       no_taskmap_output = .true.
+       verbose_taskmap_output = .false.
+
     endif
 
     call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(ocnLogUnit, mpicom_o, 'OCN #'//trim(adjustl(c_inst_index)))
+    call shr_taskmap_write(ocnLogUnit, mpicom_o,                 &
+                           'OCN #'//trim(adjustl(c_inst_index)), &
+                           verbose=verbose_taskmap_output,       &
+                           no_output=no_taskmap_output           )
     call t_stopf("shr_taskmap_write")
 
     ! Setup function pointers for MPASO core and domain types

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -16,7 +16,7 @@ module ice_comp_mct
    use seq_cdata_mod
    use seq_infodata_mod
    use seq_timemgr_mod
-   use seq_comm_mct,      only : seq_comm_suffix, seq_comm_inst, seq_comm_name
+   use seq_comm_mct,      only : seq_comm_suffix, seq_comm_inst, seq_comm_name, info_taskmap_comp
    use shr_file_mod 
    use shr_cal_mod,       only : shr_cal_date2ymd
    use shr_sys_mod
@@ -163,6 +163,8 @@ contains
     type (MPAS_Pool_Type), pointer :: shortwave
 
     logical :: exists
+    logical :: no_taskmap_output                     ! true then do not write out task-to-node mapping
+    logical :: verbose_taskmap_output                ! true then use verbose task-to-node mapping format
 
     character(kind=c_char), dimension(StrKIND+1) :: c_filename       ! StrKIND+1 for C null-termination character
     integer(kind=c_int) :: c_comm
@@ -303,20 +305,42 @@ contains
 
     ! Identify SMP nodes and process/SMP mapping for this instance
     ! (Assume that processor names are SMP node names on SMP clusters.)
-    call MPI_comm_size(mpicom_i,npes,ierr)
-    write(c_npes,'(i8)') npes
-
     inst_index = seq_comm_inst(iceID)
     write(c_inst_index,'(i8)') inst_index
 
-    if (iam==0) then
-       write(iceLogUnit,100) trim(adjustl(c_npes)), trim(adjustl(c_inst_index))
-100    format(/,a,' pes participating in computation of MPAS-SEAICE instance #',a)
-       call flush(iceLogUnit)
+    if (info_taskmap_comp > 0) then
+
+       no_taskmap_output = .false.
+
+       if (info_taskmap_comp == 1) then
+          verbose_taskmap_output = .false.
+       else
+          verbose_taskmap_output = .true.
+       endif
+
+       call MPI_comm_size(mpicom_i,npes,ierr)
+       write(c_npes,'(i8)') npes
+
+       if (iam==0) then
+          write(iceLogUnit,'(/,3A)') &
+             trim(adjustl(c_npes)), &
+             ' pes participating in computation of MPAS-SEAICE instance #', &
+             trim(adjustl(c_inst_index))
+          call shr_sys_flush(iceLogUnit)
+       endif
+
+    else
+
+       no_taskmap_output = .true.
+       verbose_taskmap_output = .false.
+
     endif
 
     call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(iceLogUnit, mpicom_i, 'ICE #'//trim(adjustl(c_inst_index)))
+    call shr_taskmap_write(iceLogUnit, mpicom_i,                 &
+                           'ICE #'//trim(adjustl(c_inst_index)), &
+                           verbose=verbose_taskmap_output,       &
+                           no_output=no_taskmap_output           )
     call t_stopf("shr_taskmap_write")
 
     ! Setup function pointers for MPASSI core and domain types


### PR DESCRIPTION
A recent commit added the env_run.xml parameter INFO_TASKMAP_COMP
and the associated cime_pes namelist parameter info_taskmap_comp
to enable (> 0) or disable (<= 0) the output of the
task-to-node mapping for the component models. If enabled,
it further specifies whether to use a compact (== 1) or
a more verbose (> 1) output format. Here the necessary control
logic is added to CAM, CLM, Mosart, mpas-albany-landice,
mpas-ocean, and mpas-seaice.

At the moment, the default for INFO_TASKMAP_COMP is 0, so this removes all component-specific task-to-node mapping information from the log files but allows us to experiment
with this and supports writing out all task-to-node mapping information in the new more compact representation simply by changing the default for INFO_TASKMAP_COMP to 1 (or 2).

BFB
