### PR TITLE
Fix buildnml bug in CICE for Python3

### DIFF
--- a/components/cice/cime_config/buildnml
+++ b/components/cice/cime_config/buildnml
@@ -61,7 +61,7 @@ def buildnml(case, caseroot, compname):
     # update env_build.xml settings to reflect changes in the configuration
     # this will trigger whether an automatic build is set upon the job resubmission
     if cice_auto_decomp:
-        ntasks = ntasks_ice / ninst_ice
+        ntasks = int(ntasks_ice / ninst_ice)
         hgrid  = ice_grid
         if ice_grid == 'ar9v2': hgrid = 'ar9v1'
         if ice_grid == 'ar9v4': hgrid = 'ar9v3'


### PR DESCRIPTION
Explicitly cast `ntasks` in CICE `buildnml` script to integer. This is needed because previously, certain python versions would interpret the calculation of `ntasks = ntasks_ice / ninst_ice` in the CICE `buildnml` script as floating point division and hence cast `ntasks` to float. This caused `generate_cice_decomp.pl` to throw an error, because it expects `ntasks` to be an integer. Explicitly casting ntasks to be an integer solves this problem.   Thanks to @mrnorman and @pochedls for this fi

Fixes #2650