### PR TITLE
For cori-knl only, add intel19 compiler and remove gnu7

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1098,6 +1098,57 @@ for mct, etc.
   </SLIBS>
 </compiler>
 
+<compiler MACH="cori-knl" COMPILER="intel19">
+  <CFLAGS>
+    <base> -O2 -fp-model precise -std=gnu99 </base>
+    <append compile_threaded="true"> -qopenmp </append>
+    <append DEBUG="FALSE"> -O2 -debug minimal </append>
+    <append DEBUG="TRUE"> -O0 -g </append>
+  </CFLAGS>
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CPPDEFS>
+    <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL</append>
+  </CPPDEFS>
+  <CXX_LDFLAGS>
+    <base> -cxxlib </base>
+  </CXX_LDFLAGS>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <FC_AUTO_R8>
+    <base> -r8 </base>
+  </FC_AUTO_R8>
+  <FFLAGS>
+    <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml -fimf-use-svml=false:asin </base>
+    <append compile_threaded="true"> -qopenmp </append>
+    <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
+    <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
+  </FFLAGS>
+  <FFLAGS_NOOPT>
+    <base> -O0 </base>
+    <append compile_threaded="true"> -qopenmp </append>
+  </FFLAGS_NOOPT>
+  <FIXEDFLAGS>
+    <base> -fixed -132 </base>
+  </FIXEDFLAGS>
+  <FREEFLAGS>
+    <base> -free </base>
+  </FREEFLAGS>
+  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
+  <LDFLAGS>
+    <append compile_threaded="true"> -qopenmp </append>
+  </LDFLAGS>
+  <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
+  <SCC> icc </SCC>
+  <SCXX> icpc </SCXX>
+  <SFC> ifort </SFC>
+  <SLIBS>
+    <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
+    <append> -mkl -lpthread </append>
+  </SLIBS>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+</compiler>
+
 <compiler MACH="eastwind" COMPILER="pgi">
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -343,7 +343,7 @@
     <DESC>Cori. XC40 Cray system at NERSC. KNL partition. os is CNL, 68 pes/node (for now only use 64), batch system is SLURM</DESC>
     <NODENAME_REGEX>cori</NODENAME_REGEX>
     <OS>CNL</OS>
-    <COMPILERS>intel,gnu,gnu7</COMPILERS>
+    <COMPILERS>intel,gnu,intel19</COMPILERS>
     <MPILIBS>mpt,impi</MPILIBS>
     <PROJECT>acme</PROJECT>
     <SAVE_TIMING_DIR>/project/projectdirs/acme</SAVE_TIMING_DIR>
@@ -427,15 +427,13 @@
         <command name="load">intel/18.0.1.163</command>
       </modules>
 
-      <modules compiler="gnu">
-        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
-        <command name="rm">gcc</command>
-        <command name="load">gcc/7.3.0</command>
-        <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/18.03.1</command>
+      <modules compiler="intel19">
+        <command name="load">PrgEnv-intel/6.0.4</command>
+        <command name="rm">intel</command>
+        <command name="load">intel/19.0.0.117</command>
       </modules>
 
-      <modules compiler="gnu7">
+      <modules compiler="gnu">
         <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
         <command name="rm">gcc</command>
         <command name="load">gcc/7.3.0</command>
@@ -464,6 +462,7 @@
         <command name="load">cray-hdf5-parallel/1.10.1.1</command>
         <command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
+
       <modules>
         <command name="rm">git</command>
         <command name="load">git</command>
@@ -501,6 +500,9 @@
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="FORT_BUFFERED">yes</env>
+      <env name="MPICH_MEMORY_REPORT">1</env>
+    </environment_variables>
+    <environment_variables compiler="intel19">
       <env name="MPICH_MEMORY_REPORT">1</env>
     </environment_variables>
   </machine>


### PR DESCRIPTION
The intel/19.0.0.117 compiler has been available on Cori and this change adds the option to use it via `--compiler=intel19`.
After initial testing, behavior seems similar to intel v18.
There is a new flag added (for intel19) to avoid a common floating-point issue with asin (`-fimf-use-svml=false:asin` )
Most tests pass, but a few fail.

Removed the gnu7 option as version 7 of GNU is now the default.

[bfb]