### PR TITLE
Restore how omega is output to history file for EUL-SCM

### DIFF
--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -1063,7 +1063,14 @@ end subroutine diag_conv_tend_ini
 
 ! Vertical velocity and advection
 
-    call outfld('OMEGA   ',state%omega,    pcols,   lchnk     )
+! EUL-SCM does not properly assign prescribed wfld to state%omega, while SE-SCM does.
+! Keep the original form of outfld for OMEGA until it is fixed for EUL-SCM
+ 
+    if (single_column) then
+       call outfld('OMEGA   ',wfld,    pcols,   lchnk     )
+    else
+       call outfld('OMEGA   ',state%omega,    pcols,   lchnk     )
+    endif
 
 #if (defined BFB_CAM_SCAM_IOP )
     call outfld('omega   ',state%omega,    pcols,   lchnk     )


### PR DESCRIPTION
PR # 2667 introduced a change to have a more consistent treatment of calling outfld to save OMEGA field that works for SE dycore. But after the change, the prescribed vertical velocity field would not be saved as is because of a currently unidentified issue in EUL-SCM concerning state%omega. This causes integration test SMS_R_Ld5.T42_T42.FSCM5A9 to have DIFF failure, though the simulation results are not affected. The original format of outfld call is restored until a fix for EUL-SCM on state%omega is found.

[BFB]