### PR TITLE
Updates for Lawrencium-LBNL

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -542,23 +542,13 @@
      </queues>
    </batch_system>
 
-   <batch_system MACH="lawrencium-lr2" type="slurm" >
+   <batch_system MACH="lawrencium-lr6" type="slurm" >
      <directives>
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
        <directive>--qos=condo_esd2 </directive>
      </directives>
     <queues>
-      <queue walltimemax="01:00:00" default="true">lr3</queue>
-    </queues>
-   </batch_system>
-
-   <batch_system MACH="lawrencium-lr3" type="slurm" >
-     <directives>
-       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
-       <directive>--qos=condo_esd2 </directive>
-     </directives>
-    <queues>
-      <queue walltimemax="01:00:00" default="true">lr3</queue>
+      <queue walltimemax="01:00:00" default="true">lr6</queue>
     </queues>
    </batch_system>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -549,7 +549,7 @@
        <directive>--account={{ project }}</directive>
      </directives>
     <queues>
-      <queue walltimemax="01:00:00" default="true">lr6</queue>
+      <queue walltimemax="01:00:00" default="true">lr2</queue>
     </queues>
    </batch_system>
 
@@ -560,7 +560,7 @@
        <directive>--account={{ project }}</directive>
      </directives>
     <queues>
-      <queue walltimemax="01:00:00" default="true">lr6</queue>
+      <queue walltimemax="01:00:00" default="true">lr3</queue>
     </queues>
    </batch_system>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -542,6 +542,28 @@
      </queues>
    </batch_system>
 
+   <batch_system MACH="lawrencium-lr2" type="slurm" >
+     <directives>
+       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
+       <directive>--qos=lr_normal </directive>
+       <directive>--account={{ project }}</directive>
+     </directives>
+    <queues>
+      <queue walltimemax="01:00:00" default="true">lr6</queue>
+    </queues>
+   </batch_system>
+
+   <batch_system MACH="lawrencium-lr3" type="slurm" >
+     <directives>
+       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
+       <directive>--qos=lr_normal</directive>
+       <directive>--account={{ project }}</directive>
+     </directives>
+    <queues>
+      <queue walltimemax="01:00:00" default="true">lr6</queue>
+    </queues>
+   </batch_system>
+
    <batch_system MACH="lawrencium-lr6" type="slurm" >
      <directives>
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1325,18 +1325,7 @@ for mct, etc.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
-<compiler MACH="lawrencium-lr2" COMPILER="intel">
-  <CPPDEFS>
-    <append MODEL="gptl"> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY </append>
-  </CPPDEFS>
-  <LAPACK_LIBDIR>/global/software/sl-6.x86_64/modules/intel/2016.1.150/lapack/3.6.0-intel/lib</LAPACK_LIBDIR>
-  <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
-  <SLIBS>
-    <append> -lnetcdff -lnetcdf -mkl</append>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="lawrencium-lr3" COMPILER="intel">
+<compiler MACH="lawrencium-lr6" COMPILER="intel">
   <CPPDEFS>
     <append MODEL="gptl"> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY </append>
   </CPPDEFS>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1325,6 +1325,28 @@ for mct, etc.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
+<compiler MACH="lawrencium-lr2" COMPILER="intel">
+  <CPPDEFS>
+    <append MODEL="gptl"> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY </append>
+  </CPPDEFS>
+  <LAPACK_LIBDIR>/global/software/sl-6.x86_64/modules/intel/2016.1.150/lapack/3.6.0-intel/lib</LAPACK_LIBDIR>
+  <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
+  <SLIBS>
+    <append> -lnetcdff -lnetcdf -mkl</append>
+  </SLIBS>
+</compiler>
+
+<compiler MACH="lawrencium-lr3" COMPILER="intel">
+  <CPPDEFS>
+    <append MODEL="gptl"> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY </append>
+  </CPPDEFS>
+  <LAPACK_LIBDIR>/global/software/sl-6.x86_64/modules/intel/2016.1.150/lapack/3.6.0-intel/lib</LAPACK_LIBDIR>
+  <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
+  <SLIBS>
+    <append> -lnetcdff -lnetcdf -mkl</append>
+  </SLIBS>
+</compiler>
+
 <compiler MACH="lawrencium-lr6" COMPILER="intel">
   <CPPDEFS>
     <append MODEL="gptl"> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY </append>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1336,6 +1336,28 @@ for mct, etc.
   </SLIBS>
 </compiler>
 
+<compiler MACH="lawrencium-lr6" COMPILER="gnu">
+  <LAPACK_LIBDIR>$ENV{LAPACK_DIR}/lib</LAPACK_LIBDIR>
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2  </append>
+  </CFLAGS>
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CXX_LIBS>
+    <base>-lstdc++ -lmpi_cxx</base>
+  </CXX_LIBS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2  </append>
+    <append > -I$ENV{NETCDF_DIR}/include  </append>
+  </FFLAGS>
+  <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF_DIR}</PNETCDF_PATH>
+  <SLIBS>
+    <append> -L/global/software/sl-7.x86_64/modules/gcc/6.3.0/netcdf/4.4.1.1-gcc-p/lib -lnetcdff -lnetcdf -lnetcdf -lblas -llapack </append>
+  </SLIBS>
+</compiler>
+
 <compiler MACH="linux-generic" COMPILER="gnu">
   <NETCDF_PATH> $ENV{NETCDF_PATH}</NETCDF_PATH>
   <PNETCDF_PATH> $ENV{PNETCDF_PATH}</PNETCDF_PATH>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2588,7 +2588,7 @@
     <DESC>Lawrencium LR6 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
     <NODENAME_REGEX>n000*</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>intel</COMPILERS>
+    <COMPILERS>intel,gnu</COMPILERS>
     <MPILIBS>openmpi</MPILIBS>
     <CHARGE_ACCOUNT>ac_acme</CHARGE_ACCOUNT>
     <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
@@ -2640,8 +2640,22 @@
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial">
         <command name="load">openmpi</command>
-        <command name="load">netcdf/4.4.1.1-intel-s</command>
+        <command name="load">netcdf/4.4.1.1-intel-p</command>
       </modules>
+      <modules compiler="gnu">
+        <command name="load">gcc/6.3.0</command>
+        <command name="load">lapack/3.8.0-gcc</command>
+      </modules>
+      <modules compiler="gnu" mpilib="mpi-serial">
+        <command name="load">netcdf/5.4.1.1-gcc-s</command>
+        <command name="unload">openmpi/2.0.2-gcc</command>
+      </modules>
+      <modules compiler="gnu" mpilib="!mpi-serial">
+        <command name="load">openmpi/3.0.1-gcc</command>
+        <command name="load">netcdf/4.4.1.1-gcc-p</command>
+        <command name="unload">openmpi/2.0.2-gcc</command>
+      </modules>
+
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2584,6 +2584,160 @@
     <!-- path to the cprnc tool used to compare netcdf history files in testing -->
   </machine>
 
+  <machine MACH="lawrencium-lr2">
+    <DESC>Lawrencium LR6 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
+    <NODENAME_REGEX>n000*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel,gnu</COMPILERS>
+    <MPILIBS>openmpi</MPILIBS>
+    <CHARGE_ACCOUNT>ac_acme</CHARGE_ACCOUNT>
+    <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/global/scratch/$ENV{USER}/cesm_input_datasets/</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/$CIME_OUTPUT_ROOT/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>4</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>gbisht at lbl dot gov</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>12</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="mpi-serial">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks">-np {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks">-np {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
+      <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
+      <init_path lang="perl">/usr/Modules/init/perl.pm</init_path>
+      <init_path lang="python">/usr/Modules/python.py</init_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="load">cmake</command>
+        <command name="load">perl xml-libxml switch python/2.7</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">intel/2016.4.072</command>
+        <command name="load">mkl</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial">
+        <command name="load">netcdf/4.4.1.1-intel-s</command>
+      </modules>
+      <modules compiler="intel" mpilib="!mpi-serial">
+        <command name="load">openmpi</command>
+        <command name="load">netcdf/4.4.1.1-intel-p</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">gcc/6.3.0</command>
+        <command name="load">lapack/3.8.0-gcc</command>
+      </modules>
+      <modules compiler="gnu" mpilib="mpi-serial">
+        <command name="load">netcdf/5.4.1.1-gcc-s</command>
+        <command name="unload">openmpi/2.0.2-gcc</command>
+      </modules>
+      <modules compiler="gnu" mpilib="!mpi-serial">
+        <command name="load">openmpi/3.0.1-gcc</command>
+        <command name="load">netcdf/4.4.1.1-gcc-p</command>
+        <command name="unload">openmpi/2.0.2-gcc</command>
+      </modules>
+
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+  </machine>
+
+  <machine MACH="lawrencium-lr3">
+    <DESC>Lawrencium LR6 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
+    <NODENAME_REGEX>n000*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel,gnu</COMPILERS>
+    <MPILIBS>openmpi</MPILIBS>
+    <CHARGE_ACCOUNT>ac_acme</CHARGE_ACCOUNT>
+    <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/global/scratch/$ENV{USER}/cesm_input_datasets/</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/$CIME_OUTPUT_ROOT/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>4</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>gbisht at lbl dot gov</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>12</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="mpi-serial">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks">-np {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks">-np {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
+      <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
+      <init_path lang="perl">/usr/Modules/init/perl.pm</init_path>
+      <init_path lang="python">/usr/Modules/python.py</init_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="load">cmake</command>
+        <command name="load">perl xml-libxml switch python/2.7</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">intel/2016.4.072</command>
+        <command name="load">mkl</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial">
+        <command name="load">netcdf/4.4.1.1-intel-s</command>
+      </modules>
+      <modules compiler="intel" mpilib="!mpi-serial">
+        <command name="load">openmpi</command>
+        <command name="load">netcdf/4.4.1.1-intel-p</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">gcc/6.3.0</command>
+        <command name="load">lapack/3.8.0-gcc</command>
+      </modules>
+      <modules compiler="gnu" mpilib="mpi-serial">
+        <command name="load">netcdf/5.4.1.1-gcc-s</command>
+        <command name="unload">openmpi/2.0.2-gcc</command>
+      </modules>
+      <modules compiler="gnu" mpilib="!mpi-serial">
+        <command name="load">openmpi/3.0.1-gcc</command>
+        <command name="load">netcdf/4.4.1.1-gcc-p</command>
+        <command name="unload">openmpi/2.0.2-gcc</command>
+      </modules>
+
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+  </machine>
+
   <machine MACH="lawrencium-lr6">
     <DESC>Lawrencium LR6 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
     <NODENAME_REGEX>n000*</NODENAME_REGEX>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2584,71 +2584,8 @@
     <!-- path to the cprnc tool used to compare netcdf history files in testing -->
   </machine>
 
-  <machine MACH="lawrencium-lr3">
-    <DESC>Lawrencium LR3 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
-    <NODENAME_REGEX>n000*</NODENAME_REGEX>
-    <OS>LINUX</OS>
-    <COMPILERS>intel</COMPILERS>
-    <MPILIBS>openmpi</MPILIBS>
-    <CHARGE_ACCOUNT>ac_acme</CHARGE_ACCOUNT>
-    <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/global/scratch/$ENV{USER}/cesm_input_datasets/</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/$CIME_OUTPUT_ROOT/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
-    <GMAKE_J>4</GMAKE_J>
-    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
-    <SUPPORTED_BY>gbisht at lbl dot gov</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable>mpirun</executable>
-      <arguments>
-        <arg name="num_tasks">-np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
-      </arguments>
-    </mpirun>
-    <mpirun mpilib="default">
-      <executable>mpirun</executable>
-      <arguments>
-        <arg name="num_tasks">-np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
-      </arguments>
-    </mpirun>
-    <module_system type="module">
-      <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
-      <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
-      <init_path lang="perl">/usr/Modules/init/perl.pm</init_path>
-      <init_path lang="python">/usr/Modules/python.py</init_path>
-      <cmd_path lang="sh">module</cmd_path>
-      <cmd_path lang="csh">module</cmd_path>
-      <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
-      <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
-      <modules>
-        <command name="purge"/>
-        <command name="load">cmake</command>
-        <command name="load">perl xml-libxml switch python/2.7</command>
-      </modules>
-      <modules compiler="intel">
-        <command name="load">intel/2016.4.072</command>
-        <command name="load">mkl</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpi-serial">
-        <command name="load">netcdf/4.4.1.1-intel-s</command>
-      </modules>
-      <modules compiler="intel" mpilib="!mpi-serial">
-        <command name="load">openmpi</command>
-        <command name="load">netcdf/4.4.1.1-intel-p</command>
-      </modules>
-    </module_system>
-    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
-    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-  </machine>
-
-  <machine MACH="lawrencium-lr2">
-    <DESC>Lawrencium LR2 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
+  <machine MACH="lawrencium-lr6">
+    <DESC>Lawrencium LR6 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
     <NODENAME_REGEX>n000*</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>

--- a/cime/config/e3sm/machines/config_pio.xml
+++ b/cime/config/e3sm/machines/config_pio.xml
@@ -53,6 +53,8 @@
       <value mach="pleiades.*">netcdf</value>
       <value mach="hobart" compiler="pgi">netcdf</value>
       <value mach="oic5">netcdf</value>
+      <value mach="lawrencium-lr2">netcdf</value>
+      <value mach="lawrencium-lr3">netcdf</value>
       <value mach="lawrencium-lr6">netcdf</value>
       <value mach="cades">netcdf</value>
       <value mach="grizzly">netcdf</value>

--- a/cime/config/e3sm/machines/config_pio.xml
+++ b/cime/config/e3sm/machines/config_pio.xml
@@ -53,8 +53,7 @@
       <value mach="pleiades.*">netcdf</value>
       <value mach="hobart" compiler="pgi">netcdf</value>
       <value mach="oic5">netcdf</value>
-      <value mach="lawrencium-lr2">netcdf</value>
-      <value mach="lawrencium-lr3">netcdf</value>
+      <value mach="lawrencium-lr6">netcdf</value>
       <value mach="cades">netcdf</value>
       <value mach="grizzly">netcdf</value>
       <value mach="wolf">netcdf</value>


### PR DESCRIPTION
Updates machine files for lawrencium-lr2 and lawrencium-lr3, while 
new support for lawrencium-lr6 is added.
Additionally, support for GNU compiler for lawrencium-lr6 is added.

[BFB]