### PR TITLE
Large scale vertical velocity bug fix in Eulerian SCM

### DIFF
--- a/components/cam/src/dynamics/eul/eul_single_column_mod.F90
+++ b/components/cam/src/dynamics/eul/eul_single_column_mod.F90
@@ -118,6 +118,11 @@ subroutine eul_post_forecast(lat, psm1, qfcst, cwava, &
    integer nlon
    integer i,k,m
 
+!
+! Assign prescribed wfld to the Eulerian omega field
+
+   if (have_omega) omga(1,:,lat) = wfld(:)
+
    call pdelb0 (psm1, pdelb, nlon)
 !
 ! Accumulate mass integrals

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -22,7 +22,6 @@ use phys_control,  only: phys_getopts
 use wv_saturation, only: qsat, qsat_water, svp_ice
 use time_manager,  only: is_first_step
 
-use scamMod,       only: single_column, wfld
 use cam_abortutils,    only: endrun
 
 implicit none
@@ -1063,14 +1062,7 @@ end subroutine diag_conv_tend_ini
 
 ! Vertical velocity and advection
 
-! EUL-SCM does not properly assign prescribed wfld to state%omega, while SE-SCM does.
-! Keep the original form of outfld for OMEGA until it is fixed for EUL-SCM
- 
-    if (single_column) then
-       call outfld('OMEGA   ',wfld,    pcols,   lchnk     )
-    else
-       call outfld('OMEGA   ',state%omega,    pcols,   lchnk     )
-    endif
+    call outfld('OMEGA   ',state%omega,    pcols,   lchnk     )
 
 #if (defined BFB_CAM_SCAM_IOP )
     call outfld('omega   ',state%omega,    pcols,   lchnk     )


### PR DESCRIPTION
Bug fix to allow prescribed omega to propagate to state variable.  The prescribed omega (wfld) is used directly by the dynamics and this implementation has always been correct.  However, CLUBB (physics parameterization) uses the large scale vertical velocity as well.  Thus, since wlfd was not being passed to state correctly CLUBB was never seeing the updated wfld, only the wfld at the first time step.  CLUBB is not very sensitive to changes in wfld, so the SCM solutions are not very sensitive, but not bit for bit.

In addition, after this fix, the outfld conditional call for OMEGA in cam_diagnostics.F90 is not necessary and has been removed.

[BFB] except for SCM mode