### PR TITLE
modify behavior of t_startstop_valsf

### DIFF
--- a/cime/src/share/timing/private.h
+++ b/cime/src/share/timing/private.h
@@ -60,6 +60,8 @@ typedef struct {
   double accum;             /* accumulated time */
   float max;                /* longest time for start/stop pair */
   float min;                /* shortest time for start/stop pair */
+  float prev_min;           /* previous shortest time for start/stop pair */
+  int latest_is_min;        /* whether min is current latest (1) or not (0) */
 } Wallstats;
 
 typedef struct {


### PR DESCRIPTION
The perf_mod command t_startstop_valsf (GPTL command
GPTLstartstop_vals) is used to create a timer or add time to an
existing timer when t_startf/t_stopf cannot be used to time the
corresponding event. The motivating example is measuring the time
spent in MPI_Init (before the timing library has been
initialized). When the "call count" parameter callcount is set to 1,
the max and min for the event are updated as expected. However, when
callcount is 0 (adding time without incrementing the call count) or
greater than 1 (adding time associated with multiple calls that are
not recorded individually), max and min cannot be updated in the usual
way. The current implementation is insufficient even given this basic
ambiguity, and this PR modifies the min/max update logic to improve
upon this.

[BFB]