### PR TITLE
Improve bless_test_results robustness

### DIFF
--- a/cime/scripts/lib/CIME/bless_test_results.py
+++ b/cime/scripts/lib/CIME/bless_test_results.py
@@ -9,7 +9,7 @@ import os, glob, time, six
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def bless_namelists(test_name, test_dir, report_only, force, baseline_name, baseline_root):
+def bless_namelists(test_name, report_only, force, baseline_name, baseline_root):
 ###############################################################################
     # Be aware that restart test will overwrite the original namelist files
     # with versions of the files that should not be blessed. This forces us to
@@ -19,16 +19,6 @@ def bless_namelists(test_name, test_dir, report_only, force, baseline_name, base
     logger.info("Test '{}' had namelist diff".format(test_name))
     if (not report_only and
         (force or six.moves.input("Update namelists (y/n)? ").upper() in ["Y", "YES"])):
-
-        if baseline_name is None:
-            stat, baseline_name, _ = run_cmd("./xmlquery --value BASELINE_NAME_CMP", from_dir=test_dir)
-            if stat != 0 or not baseline_name:
-                baseline_name = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
-
-        if baseline_root is None:
-            stat, baseline_root, _ = run_cmd("./xmlquery --value BASELINE_ROOT", from_dir=test_dir)
-            if stat != 0 or not baseline_root:
-                return False, "Could not determine baseline root"
 
         create_test_gen_args = " -g {} ".format(baseline_name if get_model() == "cesm" else " -g -b {} ".format(baseline_name))
         stat, out, _ = run_cmd("{}/create_test {} -n {} --baseline-root {} -o".format(get_scripts_root(), test_name, create_test_gen_args, baseline_root), combine_output=True)
@@ -40,38 +30,30 @@ def bless_namelists(test_name, test_dir, report_only, force, baseline_name, base
         return True, None
 
 ###############################################################################
-def bless_history(test_name, test_dir, baseline_name, baseline_root, report_only, force):
+def bless_history(test_name, case, baseline_name, baseline_root, report_only, force):
 ###############################################################################
-    with Case(test_dir) as case:
-        real_user = case.get_value("REALUSER")
-        with EnvironmentContext(USER=real_user):
-            if baseline_name is None:
-                baseline_name = case.get_value("BASELINE_NAME_CMP")
-                if not baseline_name:
-                    baseline_name = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
+    real_user = case.get_value("REALUSER")
+    with EnvironmentContext(USER=real_user):
 
-            if baseline_root is None:
-                baseline_root = case.get_value("BASELINE_ROOT")
+        baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
 
-            baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
-
-            cmp_result, cmp_comments = compare_baseline(case, baseline_dir=baseline_full_dir, outfile_suffix=None)
-            if cmp_result:
-                logger.info("Diff appears to have been already resolved.")
-                return True, None
-            else:
-                logger.info(cmp_comments)
-                if (not report_only and
-                    (force or six.moves.input("Update this diff (y/n)? ").upper() in ["Y", "YES"])):
-                    gen_result, gen_comments = generate_baseline(case, baseline_dir=baseline_full_dir)
-                    if not gen_result:
-                        logger.warning("Hist file bless FAILED for test {}".format(test_name))
-                        return False, "Generate baseline failed: {}".format(gen_comments)
-                    else:
-                        logger.info(gen_comments)
-                        return True, None
+        cmp_result, cmp_comments = compare_baseline(case, baseline_dir=baseline_full_dir, outfile_suffix=None)
+        if cmp_result:
+            logger.info("Diff appears to have been already resolved.")
+            return True, None
+        else:
+            logger.info(cmp_comments)
+            if (not report_only and
+                (force or six.moves.input("Update this diff (y/n)? ").upper() in ["Y", "YES"])):
+                gen_result, gen_comments = generate_baseline(case, baseline_dir=baseline_full_dir)
+                if not gen_result:
+                    logger.warning("Hist file bless FAILED for test {}".format(test_name))
+                    return False, "Generate baseline failed: {}".format(gen_comments)
                 else:
+                    logger.info(gen_comments)
                     return True, None
+            else:
+                return True, None
 
 ###############################################################################
 def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, namelists_only=False, hist_only=False,
@@ -90,7 +72,8 @@ def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_i
             case_dir = os.path.basename(test_dir)
             test_name = CIME.utils.normalize_case_id(case_dir)
             if (bless_tests in [[], None] or CIME.utils.match_any(test_name, bless_tests)):
-                broken_blesses.append((test_name, "test had invalid TestStatus file: '{}'".format(test_status_file)))
+                broken_blesses.append(("unknown", "test had invalid TestStatus file: '{}'".format(test_status_file)))
+                continue
             else:
                 continue
 
@@ -136,22 +119,44 @@ def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_i
                 if not force:
                     time.sleep(2)
 
-                # Bless namelists
-                if nl_bless:
-                    success, reason = bless_namelists(test_name, test_dir, report_only, force, baseline_name, baseline_root)
-                    if not success:
-                        broken_blesses.append((test_name, reason))
-
-                # Bless hist files
-                if hist_bless:
-                    if "HOMME" in test_name:
-                        success = False
-                        reason = "HOMME tests cannot be blessed with bless_for_tests"
+                with Case(test_dir) as case:
+                    # Resolve baseline_name and baseline_root
+                    if baseline_name is None:
+                        baseline_name_resolved = case.get_value("BASELINE_NAME_CMP")
+                        if not baseline_name_resolved:
+                            baseline_name_resolved = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
                     else:
-                        success, reason = bless_history(test_name, test_dir, baseline_name, baseline_root, report_only, force)
+                        baseline_name_resolved = baseline_name
 
-                    if (not success):
-                        broken_blesses.append((test_name, reason))
+                    if baseline_root is None:
+                        baseline_root_resolved = case.get_value("BASELINE_ROOT")
+                    else:
+                        baseline_root_resolved = baseline_root
+
+                    if baseline_name_resolved is None:
+                        broken_blesses.append((test_name, "Could not determine baseline name"))
+                        continue
+
+                    if baseline_root_resolved is None:
+                        broken_blesses.append((test_name, "Could not determine baseline root"))
+                        continue
+
+                    # Bless namelists
+                    if nl_bless:
+                        success, reason = bless_namelists(test_name, report_only, force, baseline_name_resolved, baseline_root_resolved)
+                        if not success:
+                            broken_blesses.append((test_name, reason))
+
+                    # Bless hist files
+                    if hist_bless:
+                        if "HOMME" in test_name:
+                            success = False
+                            reason = "HOMME tests cannot be blessed with bless_for_tests"
+                        else:
+                            success, reason = bless_history(test_name, case, baseline_name_resolved, baseline_root_resolved, report_only, force)
+
+                        if (not success):
+                            broken_blesses.append((test_name, reason))
 
     # Make sure user knows that some tests were not blessed
     success = True


### PR DESCRIPTION
Using xmlquery to get case values opens the possibility of
permissions errors if the source repo is not visible to the
current user. Instead, open a Case object which was already
needed in some code paths anyway.

[BFB]