### PR TITLE
Bug fix so that compsets with data icebergs (DIB) pass E3SM ERS tests.

### DIFF
--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -898,6 +898,7 @@ contains
       if (seq_timemgr_RestartAlarmIsOn(EClock)) then
          ! Write a restart file, because the coupler asked for it.
          if (debugOn) call mpas_log_write('Writing restart streams', masterOnly=.true.)
+         call seaice_forcing_write_restart_times(domain)
          call mpas_stream_mgr_begin_iteration(domain % streamManager)
          do while ( mpas_stream_mgr_get_next_stream(domain % streamManager, streamID=streamName, &
                     directionProperty=streamDirection, activeProperty=streamActive) )


### PR DESCRIPTION
This PR fixes a bug where data icebergs were not being properly read in on restarts in E3SM. This PR only impacts cryosphere science campaign compsets with data icebergs (DIB).

Successfully tested with ERS.ne30_oECv3wLI.A_WCYCL1850-DIB_CMIP6.edison_intel.