### PR TITLE
Initial scripts changes to add JRA support to mpas-ocean

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -379,6 +379,36 @@
       <mask>oARRM60to6</mask>
     </model_grid>
 
+    <model_grid alias="TL319_oEC60to30v3" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_oARRM60to10" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">oARRM60to10</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oARRM60to10</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_oARRM60to6" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">oARRM60to6</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oARRM60to6</mask>
+    </model_grid>
+
     <!-- finite volume grids -->
 
     <model_grid alias="f02_g16">
@@ -1425,6 +1455,17 @@
       <desc>T31 is Gaussian grid:</desc>
     </domain>
 
+    <domain name="TL319">
+      <nx>640</nx> <ny>320</ny>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oEC60to30v3.181203.nc</file>
+      <file grid="ocnice"  mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oEC60to30v3.181203.nc</file>
+      <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oARRM60to10.180905.nc</file>
+      <file grid="ocnice"  mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to10.180905.nc</file>
+      <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oARRM60to6.180905.nc</file>
+      <file grid="ocnice"  mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to6.180905.nc</file>
+      <desc>TL319 grid for JRA55</desc>
+    </domain>
+
     <domain name="ne4np4">
       <nx>866</nx>
       <ny>1</ny>
@@ -2245,19 +2286,43 @@
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oARRM60to10">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to10_aave.180715.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to10_blin.180715.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to10_patc.180715.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to10/map_oARRM60to10_TO_T62_aave.180715.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to10/map_oARRM60to10_TO_T62_aave.180715.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oARRM60to10_aave.180715.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oARRM60to10_bilin.180715.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oARRM60to10_patch.180715.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to10/map_oARRM60to10_to_T62_aave.180715.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to10/map_oARRM60to10_to_T62_aave.180715.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oARRM60to6">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to6_aave.180803.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to6_blin.180803.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oARRM60to6_patc.180803.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_TO_T62_aave.180803.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_TO_T62_aave.180803.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oARRM60to6_aave.180803.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oARRM60to6_bilin.180803.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oARRM60to6_patch.180803.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_to_T62_aave.180803.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_to_T62_aave.180803.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_aave.181203.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_bilin.181203.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_patch.181203.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_TL319_aave.181203.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_TL319_aave.181203.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="oARRM60to10">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oARRM60to10_aave.180904.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oARRM60to10_bilin.180904.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oARRM60to10_patch.180904.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to10/map_oARRM60to10_to_TL319_aave.180904.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to10/map_oARRM60to10_to_TL319_aave.180904.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="oARRM60to6">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oARRM60to6_aave.180904.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oARRM60to6_blin.180904.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oARRM60to6_patc.180904.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_to_TL319_aave.180904.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_to_TL319_aave.180904.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T31" ocn_grid="gx3v7">
@@ -2580,6 +2645,21 @@
     <gridmap ocn_grid="oARRM60to6" rof_grid="rx1">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oARRM60to6_smoothed.r150e300.180816.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oARRM60to6_smoothed.r150e300.180816.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="oEC60to30v3" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="oARRM60to10" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oARRM60to10_smoothed.r150e300.181219.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oARRM60to10_smoothed.r150e300.181219.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="oARRM60to6" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oARRM60to6_smoothed.r150e300.181220.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oARRM60to6_smoothed.r150e300.181220.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oQU480" rof_grid="r05">

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1456,14 +1456,15 @@
     </domain>
 
     <domain name="TL319">
-      <nx>640</nx> <ny>320</ny>
+      <nx>640</nx>
+      <ny>320</ny>
       <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oEC60to30v3.181203.nc</file>
-      <file grid="ocnice"  mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oEC60to30v3.181203.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oEC60to30v3.181203.nc</file>
       <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oARRM60to10.180905.nc</file>
-      <file grid="ocnice"  mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to10.180905.nc</file>
+      <file grid="ice|ocn" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to10.180905.nc</file>
       <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oARRM60to6.180905.nc</file>
-      <file grid="ocnice"  mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to6.180905.nc</file>
-      <desc>TL319 grid for JRA55</desc>
+      <file grid="ice|ocn" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to6.180905.nc</file>
+      <desc>TL319 is JRA lat/lon grid:</desc>
     </domain>
 
     <domain name="ne4np4">

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1186,7 +1186,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*20" category="default_settings"
        group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,tx0.1v2">
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,tx0.1v2">
 Land mask description
 </entry> 
 

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -47,7 +47,7 @@ OPTIONS
      -ocn_grid             OCN_GRID variable
      -ocn_forcing          variable for defining if the ocn model is forced with an active atm
                            or using CORE forcing.  
-                           Options are: active_atm, core_forced, core_forced_restoring
+                           Options are: active_atm, datm_forced, datm_forced_restoring
      -ocn_iceberg          variable for defining if the ocn model is expecting coupling fields
                            for icebergs from the seaice model
                            Options are: false, true
@@ -926,7 +926,7 @@ add_default($nl, 'config_rx1_min_layer_thickness');
 
 add_default($nl, 'config_use_activeTracers');
 add_default($nl, 'config_use_activeTracers_surface_bulk_forcing');
-if ($OCN_FORCING eq 'core_forced_restoring') {
+if ($OCN_FORCING eq 'datm_forced_restoring') {
 	add_default($nl, 'config_use_activeTracers_surface_restoring', 'val'=>".true.");
 	add_default($nl, 'config_use_surface_salinity_monthly_restoring', 'val'=>".true.");
 	add_default($nl, 'config_salinity_restoring_constant_piston_velocity', 'val'=>"1.585e-6");

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -171,7 +171,7 @@
 <config_Redi_bottom_layer_tapering_depth>0.0</config_Redi_bottom_layer_tapering_depth>
 <config_GM_Bolus_kappa_function>'constant'</config_GM_Bolus_kappa_function>
 <config_standardGM_tracer_kappa>1800.0</config_standardGM_tracer_kappa>
-<config_standardGM_tracer_kappa ocn_grid="oEC60to30v3wLI" ocn_forcing="core_forced_restoring" >600.0</config_standardGM_tracer_kappa>
+<config_standardGM_tracer_kappa ocn_grid="oEC60to30v3wLI" ocn_forcing="datm_forced_restoring" >600.0</config_standardGM_tracer_kappa>
 <config_GM_Bolus_kappa_min>0.0</config_GM_Bolus_kappa_min>
 <config_GM_Bolus_kappa_max>600.0</config_GM_Bolus_kappa_max>
 <config_GM_Bolus_cell_size_min>20e3</config_GM_Bolus_cell_size_min>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -197,11 +197,11 @@ def buildnml(case, caseroot, compname):
         decomp_prefix += 'mpas-o.graph.info.'
 
     #--------------------------------------------------------------------
-    # Set OCN_FORCING = core_forced_restoring if restoring file is available
+    # Set OCN_FORCING = datm_forced_restoring if restoring file is available
     #--------------------------------------------------------------------
-    if ocn_forcing == 'core_forced':
+    if ocn_forcing == 'datm_forced':
         if restoring_file != '':
-            ocn_forcing = 'core_forced_restoring'
+            ocn_forcing = 'datm_forced_restoring'
         else:
             logger.warning("WARNING: Should be running with salinity restoring on!")
             logger.warning("         But no file available for this grid.")
@@ -227,7 +227,7 @@ def buildnml(case, caseroot, compname):
         if analysis_mask_file != '':
             input_list.write("moc = {}/ocn/mpas-o/{}/{}\n".format(din_loc_root, ocn_mask, analysis_mask_file))
 
-        if ocn_forcing == 'core_forced_restoring':
+        if ocn_forcing == 'datm_forced_restoring':
             input_list.write("sss = {}/ocn/mpas-o/{}/{}\n".format(din_loc_root, ocn_mask, restoring_file))
 
         if eco_forcing_file != '':
@@ -453,7 +453,7 @@ def buildnml(case, caseroot, compname):
         lines.append('the analysis data.')
         lines.append('-->')
         lines.append('')
-        if ocn_forcing == 'core_forced_restoring':
+        if ocn_forcing == 'datm_forced_restoring':
             lines.append('<stream name="surface_salinity_monthly_data"')
             lines.append('       type="input"')
             lines.append('       filename_template="{}/ocn/mpas-o/{}/{}"'.format(din_loc_root, ocn_mask, restoring_file))

--- a/components/mpas-ocean/cime_config/config_component.xml
+++ b/components/mpas-ocean/cime_config/config_component.xml
@@ -15,11 +15,11 @@
 
   <entry id="MPASO_FORCING">
         <type>char</type>
-        <valid_values>active_atm,core_forced</valid_values>
+        <valid_values>active_atm,datm_forced</valid_values>
         <default_value>active_atm</default_value>
         <values>
            <value compset="MPASO_">active_atm</value>
-           <value compset="_MPASO%.*COREFORCED">core_forced</value>
+           <value compset="_MPASO%.*DATMFORCED">datm_forced</value>
         </values>
         <group>case_comp</group>
         <file>env_case.xml</file>

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -11,59 +11,59 @@
 
   <compset>
     <alias>CMPASO-NYF</alias>
-    <lname>2000_DATM%NYF_SLND_DICE%SSMI_MPASO%COREFORCED_DROF%NYF_SGLC_SWAV</lname>
+    <lname>2000_DATM%NYF_SLND_DICE%SSMI_MPASO%DATMFORCED_DROF%NYF_SGLC_SWAV</lname>
     <support_level>"Experimental, under development"</support_level>
   </compset>
 
   <compset>
     <alias>CMPASO-IAF</alias>
-    <lname>2000_DATM%IAF_SLND_DICE%SIAF_MPASO%COREFORCED_DROF%IAF_SGLC_SWAV</lname>
+    <lname>2000_DATM%IAF_SLND_DICE%SIAF_MPASO%DATMFORCED_DROF%IAF_SGLC_SWAV</lname>
     <support_level>Experimental, under development</support_level>
   </compset>
 
   <compset>
     <alias>GMPAS-NYF</alias>
-    <lname>2000_DATM%NYF_SLND_MPASCICE_MPASO%COREFORCED_DROF%NYF_SGLC_SWAV</lname>
+    <lname>2000_DATM%NYF_SLND_MPASCICE_MPASO%DATMFORCED_DROF%NYF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>GMPAS-NYF-ISMF</alias>
-    <lname>2000_DATM%NYF_SLND_MPASCICE_MPASO%ISMFCOREFORCED_DROF%NYFAIS45_SGLC_SWAV</lname>
+    <lname>2000_DATM%NYF_SLND_MPASCICE_MPASO%ISMFDATMFORCED_DROF%NYFAIS45_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>GMPAS-IAF</alias>
-    <lname>2000_DATM%IAF_SLND_MPASCICE_MPASO%COREFORCED_DROF%IAF_SGLC_SWAV</lname>
+    <lname>2000_DATM%IAF_SLND_MPASCICE_MPASO%DATMFORCED_DROF%IAF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>GMPAS-JRA</alias>
-    <lname>2000_DATM%JRA_SLND_MPASCICE_MPASO%JRAFORCED_DROF%JRA_SGLC_SWAV</lname>
+    <lname>2000_DATM%JRA_SLND_MPASCICE_MPASO%DATMFORCED_DROF%JRA_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>GMPAS-IAF-ISMF</alias>
-    <lname>2000_DATM%IAF_SLND_MPASCICE_MPASO%ISMFCOREFORCED_DROF%IAFAIS45_SGLC_SWAV</lname>
+    <lname>2000_DATM%IAF_SLND_MPASCICE_MPASO%ISMFDATMFORCED_DROF%IAFAIS45_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>GMPAS-DIB-NYF</alias>
-    <lname>2000_DATM%NYF_SLND_MPASCICE%DIB_MPASO%IBCOREFORCED_DROF%NYFAIS55_SGLC_SWAV</lname>
+    <lname>2000_DATM%NYF_SLND_MPASCICE%DIB_MPASO%IBDATMFORCED_DROF%NYFAIS55_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>GMPAS-DIB-NYF-ISMF</alias>
-    <lname>2000_DATM%NYF_SLND_MPASCICE%DIB_MPASO%IBISMFCOREFORCED_DROF%NYFAIS00_SGLC_SWAV</lname>
+    <lname>2000_DATM%NYF_SLND_MPASCICE%DIB_MPASO%IBISMFDATMFORCED_DROF%NYFAIS00_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>GMPAS-DIB-IAF</alias>
-    <lname>2000_DATM%IAF_SLND_MPASCICE%DIB_MPASO%IBCOREFORCED_DROF%IAFAIS55_SGLC_SWAV</lname>
+    <lname>2000_DATM%IAF_SLND_MPASCICE%DIB_MPASO%IBDATMFORCED_DROF%IAFAIS55_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>GMPAS-DIB-IAF-ISMF</alias>
-    <lname>2000_DATM%IAF_SLND_MPASCICE%DIB_MPASO%IBISMFCOREFORCED_DROF%IAFAIS00_SGLC_SWAV</lname>
+    <lname>2000_DATM%IAF_SLND_MPASCICE%DIB_MPASO%IBISMFDATMFORCED_DROF%IAFAIS00_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -37,6 +37,11 @@
   </compset>
 
   <compset>
+    <alias>GMPAS-JRA</alias>
+    <lname>2000_DATM%JRA_SLND_MPASCICE_MPASO%COREFORCED_DROF%JRA_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>GMPAS-IAF-ISMF</alias>
     <lname>2000_DATM%IAF_SLND_MPASCICE_MPASO%ISMFCOREFORCED_DROF%IAFAIS45_SGLC_SWAV</lname>
   </compset>

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -38,7 +38,7 @@
 
   <compset>
     <alias>GMPAS-JRA</alias>
-    <lname>2000_DATM%JRA_SLND_MPASCICE_MPASO%COREFORCED_DROF%JRA_SGLC_SWAV</lname>
+    <lname>2000_DATM%JRA_SLND_MPASCICE_MPASO%JRAFORCED_DROF%JRA_SGLC_SWAV</lname>
   </compset>
 
   <compset>


### PR DESCRIPTION
This PR brings in the scripts changes to support JRA forcing in mpas-ocean, including new compsets and grids. These new configurations will need to be tested and validated before they can be considered scientifically supported. The JRA data itself is staged on anvil in the /home/ccsm-data/inputdata/ directory but will need to be moved to the public_htlm/inputdata directory for testing on other platforms. **This should be done prior to merging**

Tested with:
* SMS.TL319_oEC60to30v3.GMPAS-JRA.anvil_intel
* SMS.T62_oEC60to30v3.GMPAS-IAF.anvil_intel

[BFB] for all tested configurations