### PR TITLE
Fix seaice initial conditions for oRRS30to10v3wLI grid

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -66,10 +66,10 @@
 <config_initial_snow_volume>0.0</config_initial_snow_volume>
 <config_initial_latitude_north>70.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oEC60to30v3wLI">75.0</config_initial_latitude_north>
-<config_initial_latitude_north ice_grid="oRRS30to10v3wLI">75.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="oRRS30to10v3wLI">85.0</config_initial_latitude_north>
 <config_initial_latitude_south>-60.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oEC60to30v3wLI">-75.0</config_initial_latitude_south>
-<config_initial_latitude_south ice_grid="oRRS30to10v3wLI">-75.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="oRRS30to10v3wLI">-85.0</config_initial_latitude_south>
 <config_initial_velocity_type>'uniform'</config_initial_velocity_type>
 <config_initial_uvelocity>0.0</config_initial_uvelocity>
 <config_initial_vvelocity>0.0</config_initial_vvelocity>


### PR DESCRIPTION
This PR changes the latitudes north and south that define the initial seaice disks as default initial conditions for the oRRS30to10v3wLI grid. The current initial conditions result in failures in the ocean model when the ice sheet melt fluxes are off, due to a negative layer thickness. Initializing with reduced seaice initial disks seems to allow the models to spinup together without issue.

Tested with several one year runs on theta, with ice shelf melt fluxes on and off

Fixes #2606
Fixes #2654 

[non-BFB] only for G-compsets using this medium-res grid
[NML] only for configurations using this medium-res grid