### PR TITLE
Manually reverts gustiness changes from PRs #1035 and #1624

### DIFF
--- a/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -726,18 +726,6 @@
     </values>
   </entry>
 
-  <entry id="gust_fac">
-    <type>real</type>
-    <category>control</category>
-    <group>seq_infodata_inparm</group>
-    <desc>
-      wind gustiness factor
-    </desc>
-    <values>
-      <value>0.0D0</value>
-    </values>
-  </entry>
-
   <entry id="atm_gnam" modify_via_xml="ATM_GRID">
     <type>char</type>
     <category>mapping</category>

--- a/cime/src/drivers/mct/main/seq_flux_mct.F90
+++ b/cime/src/drivers/mct/main/seq_flux_mct.F90
@@ -74,7 +74,6 @@ module seq_flux_mct
   real(r8), allocatable :: swdn   (:) ! short wave, downward
   real(r8), allocatable :: swup   (:) ! short wave, upward
   real(r8), allocatable :: prec   (:) ! precip
-  real(r8), allocatable :: prec_gust (:) ! atm precip for convective gustiness (kg/m^3)
 
   ! Diurnal cycle variables wrt flux
 
@@ -331,9 +330,6 @@ contains
     allocate(prec(nloc),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate prec',ier)
     prec = 0.0_r8
-    allocate(prec_gust(nloc),stat=ier)
-    if(ier/=0) call mct_die(subName,'allocate prec_gust',ier)
-    prec_gust = 0.0_r8
     allocate(fswpen(nloc),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate fswpen',ier)
     fswpen = 0.0_r8
@@ -905,7 +901,6 @@ contains
     integer(in) :: index_sumwt
     integer(in) :: atm_nx,atm_ny,ocn_nx,ocn_ny
     real(r8)    :: wt
-    real(r8)    :: gust_fac = huge(1.0_r8) !wind gust factor
     integer(in) :: tod, dt
     logical,save:: first_call = .true.
     logical     :: read_restart    ! .true. => model starting from restart
@@ -936,8 +931,7 @@ contains
          atm_nx=atm_nx, atm_ny=atm_ny,  &
          ocn_nx=ocn_nx, ocn_ny=ocn_ny,  &
          ocn_prognostic=ocn_prognostic, &
-         flux_diurnal=flux_diurnal,     &
-         gust_fac = gust_fac            )
+         flux_diurnal=flux_diurnal)
 
     cold_start = .false.   ! use restart data or data from last timestep
 
@@ -1023,7 +1017,7 @@ contains
             duu10n,ustar, re  , ssq , missval = 0.0_r8, &
             cold_start=cold_start)
     else
-       call shr_flux_atmocn (nloc_a2o , zbot , ubot, vbot, thbot, prec_gust, gust_fac, &
+       call shr_flux_atmocn (nloc_a2o , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
             tocn , emask, sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
@@ -1187,7 +1181,6 @@ contains
     logical     :: flux_albav   ! flux avg option
     logical     :: dead_comps   ! .true.  => dead components are used
     integer(in) :: n            ! indices
-    real(r8)    :: gust_fac = huge(1.0_r8) !wind gust factor
     integer(in) :: nloc, nloca, nloco    ! number of gridcells
     logical,save:: first_call = .true.
     logical     :: cold_start      ! .true. to initialize internal fields in shr_flux diurnal
@@ -1209,8 +1202,7 @@ contains
          flux_albav=flux_albav, &
          dead_comps=dead_comps, &
          ocn_prognostic=ocn_prognostic, &
-         flux_diurnal=flux_diurnal,     &
-         gust_fac = gust_fac            )
+         flux_diurnal=flux_diurnal)
 
     cold_start = .false.   ! use restart data or data from last timestep
 
@@ -1329,7 +1321,6 @@ contains
           uGust(n)=   0.0_r8
           lwdn(n) =   0.0_r8
           prec(n) =   0.0_r8
-          prec_gust(n) =  0.0_r8
           fswpen(n)=  0.0_r8
           ocnsal(n)=  0.0_r8
 
@@ -1387,7 +1378,6 @@ contains
                   & + a2x%rAttr(index_a2x_Faxa_rainl,n) &
                   & + a2x%rAttr(index_a2x_Faxa_snowc,n) &
                   & + a2x%rAttr(index_a2x_Faxa_snowl,n)
-             prec_gust (n) = a2x%rAttr(index_a2x_Faxa_rainc,n)
              fswpen(n)= o2x%rAttr(index_o2x_So_fswpen ,n)
              ocnsal(n)= o2x%rAttr(index_o2x_So_s      ,n)
 
@@ -1436,7 +1426,7 @@ contains
                                 !duu10n,ustar, re  , ssq, missval = 0.0_r8 )
             cold_start=cold_start)
     else
-       call shr_flux_atmocn (nloc , zbot , ubot, vbot, thbot, prec_gust, gust_fac, &
+       call shr_flux_atmocn (nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
             tocn , emask, sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &

--- a/cime/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/cime/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -108,7 +108,6 @@ MODULE seq_infodata_mod
      logical                 :: coldair_outbreak_mod ! (Mahrt & Sun 1995,MWR)
      real(SHR_KIND_R8)       :: flux_convergence   ! atmocn flux calc convergence value
      integer                 :: flux_max_iteration ! max number of iterations of atmocn flux loop
-     real(SHR_KIND_R8)       :: gust_fac        ! wind gustiness factor
      character(SHR_KIND_CL)  :: glc_renormalize_smb ! Whether to renormalize smb sent from lnd -> glc
      real(SHR_KIND_R8)       :: wall_time_limit ! force stop time limit (hours)
      character(SHR_KIND_CS)  :: force_stop_at   ! when to force a stop (month, day, etc)
@@ -347,7 +346,6 @@ CONTAINS
     logical                 :: coldair_outbreak_mod ! (Mahrt & Sun 1995,MWR)
     real(SHR_KIND_R8)       :: flux_convergence   ! atmocn flux calc convergence value
     integer                 :: flux_max_iteration ! max number of iterations of atmocn flux loop
-    real(SHR_KIND_R8)      :: gust_fac           ! wind gustiness factor
     character(SHR_KIND_CL) :: glc_renormalize_smb ! Whether to renormalize smb sent from lnd -> glc
     real(SHR_KIND_R8)      :: wall_time_limit    ! force stop time limit (hours)
     character(SHR_KIND_CS) :: force_stop_at      ! when to force a stop (month, day, etc)
@@ -417,7 +415,7 @@ CONTAINS
          single_column, scmlat, force_stop_at,             &
          scmlon, logFilePostFix, outPathRoot, flux_diurnal,&
          coldair_outbreak_mod, &
-         flux_convergence, flux_max_iteration, gust_fac   ,&
+         flux_convergence, flux_max_iteration,             &
          perpetual, perpetual_ymd, flux_epbal, flux_albav, &
          orb_iyear_align, orb_mode, wall_time_limit,       &
          orb_iyear, orb_obliq, orb_eccen, orb_mvelp,       &
@@ -498,7 +496,6 @@ CONTAINS
        coldair_outbreak_mod = .false.
        flux_convergence      = 0.0_SHR_KIND_R8
        flux_max_iteration    = 2
-       gust_fac              = huge(1.0_SHR_KIND_R8)
        glc_renormalize_smb   = 'on_if_glc_coupled_fluxes'
        wall_time_limit       = -1.0
        force_stop_at         = 'month'
@@ -624,7 +621,6 @@ CONTAINS
        infodata%flux_convergence      = flux_convergence
        infodata%coldair_outbreak_mod      = coldair_outbreak_mod
        infodata%flux_max_iteration    = flux_max_iteration
-       infodata%gust_fac              = gust_fac
        infodata%glc_renormalize_smb   = glc_renormalize_smb
        infodata%wall_time_limit       = wall_time_limit
        infodata%force_stop_at         = force_stop_at
@@ -945,7 +941,7 @@ CONTAINS
        glc_g2lupdate, atm_aero, run_barriers, esmf_map_flag,              &
        do_budgets, do_histinit, drv_threading, flux_diurnal,              &
        coldair_outbreak_mod, &
-       flux_convergence, flux_max_iteration, gust_fac,                    &
+       flux_convergence, flux_max_iteration,                              &
        budget_inst, budget_daily, budget_month, wall_time_limit,          &
        budget_ann, budget_ltann, budget_ltend , force_stop_at,            &
        histaux_a2x    , histaux_a2x1hri, histaux_a2x1hr,                  &
@@ -1018,7 +1014,6 @@ CONTAINS
     logical, optional, intent(out) :: coldair_outbreak_mod        ! (Mahrt & Sun 1995, MWR)
     integer, optional, intent(OUT)                :: flux_max_iteration ! max number of iterations of atmocn flux loop
 
-    real(SHR_KIND_R8),      optional, intent(OUT) :: gust_fac                ! wind gustiness factor
     character(len=*),       optional, intent(OUT) :: glc_renormalize_smb     ! Whether to renormalize smb sent from lnd -> glc
     real(SHR_KIND_R8),      optional, intent(OUT) :: wall_time_limit         ! force stop wall time (hours)
     character(len=*),       optional, intent(OUT) :: force_stop_at           ! force stop at next (month, day, etc)
@@ -1187,7 +1182,6 @@ CONTAINS
     if ( present(coldair_outbreak_mod)) coldair_outbreak_mod = infodata%coldair_outbreak_mod
     if ( present(flux_convergence)) flux_convergence = infodata%flux_convergence
     if ( present(flux_max_iteration)) flux_max_iteration = infodata%flux_max_iteration
-    if ( present(gust_fac)       ) gust_fac       = infodata%gust_fac
     if ( present(glc_renormalize_smb)) glc_renormalize_smb = infodata%glc_renormalize_smb
     if ( present(wall_time_limit)) wall_time_limit= infodata%wall_time_limit
     if ( present(force_stop_at)  ) force_stop_at  = infodata%force_stop_at
@@ -1453,7 +1447,7 @@ CONTAINS
        glc_g2lupdate, atm_aero, esmf_map_flag, wall_time_limit,           &
        do_budgets, do_histinit, drv_threading, flux_diurnal,              &
        coldair_outbreak_mod,                                                           &
-       flux_convergence, flux_max_iteration, gust_fac,                    &
+       flux_convergence, flux_max_iteration,                              &
        budget_inst, budget_daily, budget_month, force_stop_at,            &
        budget_ann, budget_ltann, budget_ltend ,                           &
        histaux_a2x    , histaux_a2x1hri, histaux_a2x1hr,                  &
@@ -1524,7 +1518,6 @@ CONTAINS
     logical, optional, intent(in) :: coldair_outbreak_mod
     real(SHR_KIND_R8),      optional, intent(IN)    :: flux_convergence   ! atmocn flux calc convergence value
     integer,                optional, intent(IN)    :: flux_max_iteration ! max number of iterations of atmocn flux loop
-    real(SHR_KIND_R8),      optional, intent(IN)    :: gust_fac                ! wind gustiness factor
     character(len=*),       optional, intent(IN)    :: glc_renormalize_smb     ! Whether to renormalize smb sent from lnd -> glc
     real(SHR_KIND_R8),      optional, intent(IN)    :: wall_time_limit         ! force stop wall time (hours)
     character(len=*),       optional, intent(IN)    :: force_stop_at           ! force a stop at next (month, day, etc)
@@ -1691,7 +1684,6 @@ CONTAINS
     if ( present(coldair_outbreak_mod)   ) infodata%coldair_outbreak_mod  = coldair_outbreak_mod
     if ( present(flux_convergence)) infodata%flux_convergence  = flux_convergence
     if ( present(flux_max_iteration)) infodata%flux_max_iteration   = flux_max_iteration
-    if ( present(gust_fac)       ) infodata%gust_fac       = gust_fac
     if ( present(glc_renormalize_smb)) infodata%glc_renormalize_smb = glc_renormalize_smb
     if ( present(wall_time_limit)) infodata%wall_time_limit= wall_time_limit
     if ( present(force_stop_at)  ) infodata%force_stop_at  = force_stop_at
@@ -1978,7 +1970,6 @@ CONTAINS
     call shr_mpi_bcast(infodata%coldair_outbreak_mod,            mpicom)
     call shr_mpi_bcast(infodata%flux_convergence,        mpicom)
     call shr_mpi_bcast(infodata%flux_max_iteration,      mpicom)
-    call shr_mpi_bcast(infodata%gust_fac,                mpicom)
     call shr_mpi_bcast(infodata%glc_renormalize_smb,     mpicom)
     call shr_mpi_bcast(infodata%wall_time_limit,         mpicom)
     call shr_mpi_bcast(infodata%force_stop_at,           mpicom)
@@ -2637,7 +2628,6 @@ CONTAINS
     write(logunit,F0L) subname,'coldair_outbreak_mod            = ', infodata%coldair_outbreak_mod
     write(logunit,F0R) subname,'flux_convergence         = ', infodata%flux_convergence
     write(logunit,F0I) subname,'flux_max_iteration       = ', infodata%flux_max_iteration
-    write(logunit,F0R) subname,'gust_fac                 = ', infodata%gust_fac
     write(logunit,F0A) subname,'glc_renormalize_smb      = ', trim(infodata%glc_renormalize_smb)
     write(logunit,F0R) subname,'wall_time_limit          = ', infodata%wall_time_limit
     write(logunit,F0A) subname,'force_stop_at            = ', trim(infodata%force_stop_at)

--- a/cime/src/share/util/shr_flux_mod.F90
+++ b/cime/src/share/util/shr_flux_mod.F90
@@ -134,7 +134,7 @@ end subroutine shr_flux_adjust_constants
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_fac, &
+SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   & 
            &               qbot  ,s16O  ,sHDO  ,s18O  ,rbot  ,   &
            &               tbot  ,us    ,vs    ,   &
            &               ts    ,mask  ,sen   ,lat   ,lwup  ,   &
@@ -171,8 +171,6 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    real(R8)   ,intent(in) :: us   (nMax) ! ocn u-velocity        (m/s)
    real(R8)   ,intent(in) :: vs   (nMax) ! ocn v-velocity        (m/s)
    real(R8)   ,intent(in) :: ts   (nMax) ! ocn temperature       (K)
-   real(R8)   ,intent(in) :: prec_gust (nMax) ! atm precip for convective gustiness (kg/m^3)
-   real(R8)   ,intent(in) :: gust_fac    ! wind gustiness factor
 
    !--- output arguments -------------------------------
    real(R8),intent(out)  ::  sen  (nMax) ! heat flux: sensible    (W/m^2)
@@ -205,7 +203,6 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    integer(IN) :: n      ! vector loop index
    integer(IN) :: iter
    real(R8)    :: vmag   ! surface wind magnitude   (m/s)
-   real(R8)    :: vmag_old   ! surface wind magnitude without gustiness (m/s)
    real(R8)    :: ssq    ! sea surface humidity     (kg/kg)
    real(R8)    :: delt   ! potential T difference   (K)
    real(R8)    :: delq   ! humidity difference      (kg/kg)
@@ -239,11 +236,9 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    real(R8)    :: cdn    ! function: neutral drag coeff at 10m
    real(R8)    :: psimhu ! function: unstable part of psimh
    real(R8)    :: psixhu ! function: unstable part of psimx
-   real(R8)    :: ugust  ! function: gustiness as a function of convective rainfall
    real(R8)    :: Umps   ! dummy arg ~ wind velocity (m/s)
    real(R8)    :: Tk     ! dummy arg ~ temperature (K)
    real(R8)    :: xd     ! dummy arg ~ ?
-   real(R8)    :: gprec  ! dummy arg ~ ?
    !--- for cold air outbreak calc --------------------------------
    real(R8)    :: tdiff(nMax)               ! tbot - ts
    real(R8)    :: vscl
@@ -253,12 +248,6 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    cdn(Umps)  =   0.0027_R8 / Umps + 0.000142_R8 + 0.0000764_R8 * Umps
    psimhu(xd) = log((1.0_R8+xd*(2.0_R8+xd))*(1.0_R8+xd*xd)/8.0_R8) - 2.0_R8*atan(xd) + 1.571_R8
    psixhu(xd) = 2.0_R8 * log((1.0_R8 + xd*xd)/2.0_R8)
-
-   ! Convective gustiness appropriate for input precipitation.
-   ! Following Redelsperger et al. (2000, J. Clim)
-   ! Ug = log(1.0+6.69R-0.476R^2)
-   ! Coefficients X by 8640 for mm/s (from cam) -> cm/day (for above forumla)
-   ugust(gprec) = gust_fac*log(1._R8+57801.6_R8*gprec-3.55332096e7_R8*(gprec**2.0_R8))
 
    !--- formats ----------------------------------------
    character(*),parameter :: subName = '(shr_flux_atmOcn) '
@@ -303,22 +292,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
      if (mask(n) /= 0) then
 
         !--- compute some needed quantities ---
-
-        ! old version
-        !vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
-
-        !--- vmag+ugust (convective gustiness) Limit to a max precip 6 cm/day = 0.00069444 m/s.
-        !--- reverts to original formula if gust_fac=0
-
-        !PMA saves vmag_old for taux tauy computation
-
-        vmag_old    = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
-
-        if (gust_fac .gt. 1.e-12_R8) then
-         vmag       = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) + ugust(min(prec_gust(n),6.94444e-4_R8)))
-        else
-         vmag       = vmag_old
-        endif
+        vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
          if (use_coldair_outbreak_mod) then
             ! Cold Air Outbreak Modification:
             ! Increase windspeed for negative tbot-ts
@@ -327,7 +301,6 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
             if (tdiff(n).lt.td0) then
                vscl=min((1._R8+alpha*(abs(tdiff(n)-td0)**0.5_R8/abs(vmag))),maxscl)
                vmag=vmag*vscl
-               vmag_old=vmag_old*vscl
             endif
          endif
 
@@ -395,8 +368,8 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
         tau = rbot(n) * ustar * ustar
 
         !--- momentum flux ---
-        taux(n) = tau * (ubot(n)-us(n)) / vmag_old !PMA uses vmag_old for taux
-        tauy(n) = tau * (vbot(n)-vs(n)) / vmag_old !    tauy c20170620
+        taux(n) = tau * (ubot(n)-us(n)) / vmag
+        tauy(n) = tau * (vbot(n)-vs(n)) / vmag
 
         !--- heat flux ---
         sen (n) =          cp * tau * tstar / ustar


### PR DESCRIPTION
The gustiness parameterization is now implemented in eam model via 932f14c. This PR removes gustiness changes added by 9bbfad5 and 2338c63fd
as they are no longer needed.

[BFB] - Bit-For-Bit
[NML]