### PR TITLE
Create F1850SC5-CMIP6 compset

### DIFF
--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -162,6 +162,7 @@
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_1850_2012_c130411.nc</value>
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_1850_2012_c130411.nc</value>
       <value compset="1850_" grid=".+"								>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_pi_c101029.nc</value>
+      <value compset="1850S_" grid=".+"								>$DIN_LOC_ROOT/atm/cam/sst/sst_ice_CMIP6_DECK_E3SM_1x1_1850_clim_c190125.nc</value>
       <value compset="1850_" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -162,7 +162,7 @@
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_1850_2012_c130411.nc</value>
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_1850_2012_c130411.nc</value>
       <value compset="1850_" grid=".+"								>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_pi_c101029.nc</value>
-      <value compset="1850S_" grid=".+"								>$DIN_LOC_ROOT/atm/cam/sst/sst_ice_CMIP6_DECK_E3SM_1x1_1850_clim_c190125.nc</value>
+      <value compset="1850S_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_1850_clim_c20190125.nc</value>
       <value compset="1850_" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>

--- a/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
@@ -99,8 +99,7 @@
 <rrtmg_temp_fix          > .true.    </rrtmg_temp_fix>
 
 <!-- Energy fixer options -->
-<l_ieflx_fix> .false.</l_ieflx_fix>
-<ieflx_opt  > 2     </ieflx_opt>
+<ieflx_opt  > 0     </ieflx_opt>
 
 
 <!-- 1850 ozone data is from Jean-Francois Lamarque -->

--- a/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default atmospheric IC file -->
+<ncdata>atm/cam/inic/homme/20180129.DECKv1b_piControl.ne30_oEC.edison.cam.i.0501-01-01-00000_c20190202.nc</ncdata>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_1850control_input4MIPS_c20171101.nc</solar_data_file>
+<solar_data_ymd>18500101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 1850 GHG values from CMIP6 input4MIPS -->
+<!-- <co2vmr>284.317e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in config_compset.xml -->
+<ch4vmr>808.249e-9</ch4vmr>
+<n2ovmr>273.0211e-9</n2ovmr>
+<f11vmr>32.1102e-12</f11vmr>
+<f12vmr>0.0</f12vmr>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
+<prescribed_volcaero_file    >CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file    >
+<prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
+<prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
+<prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc    >.true.</use_hetfrz_classnuc>
+<use_preexisting_ice    >.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep      >.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning            >.true.</sscav_tuning>
+<convproc_do_aer         >.true.</convproc_do_aer>
+<convproc_do_gas         >.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc          >.true.</demott_ice_nuc>
+<liqcf_fix               >.true.</liqcf_fix>
+<regen_fix               >.true.</regen_fix>
+<resus_fix               >.true.</resus_fix>
+<mam_amicphys_optaa      >1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning    >.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg       >.true.</history_amwg>
+<history_aerosol    >.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai              > 500.0     </ice_sed_ai>
+<cldfrc_dp1              > 0.045D0   </cldfrc_dp1>
+<clubb_ice_deep          > 16.e-6    </clubb_ice_deep>
+<clubb_ice_sh            > 50.e-6    </clubb_ice_sh>
+<clubb_liq_deep          > 8.e-6     </clubb_liq_deep>  
+<clubb_liq_sh            > 10.e-6    </clubb_liq_sh>
+<clubb_C2rt              > 1.75D0    </clubb_C2rt>
+<zmconv_c0_lnd           > 0.007     </zmconv_c0_lnd>
+<zmconv_c0_ocn           > 0.007     </zmconv_c0_ocn>
+<zmconv_dmpdz            >-0.7e-3    </zmconv_dmpdz>
+<zmconv_ke               > 5E-6      </zmconv_ke>
+<effgw_oro               > 0.25      </effgw_oro>
+<seasalt_emis_scale      > 0.85      </seasalt_emis_scale>
+<dust_emis_fact          > 2.05D0    </dust_emis_fact>
+<clubb_gamma_coef        > 0.32      </clubb_gamma_coef>
+<clubb_C8                > 4.3       </clubb_C8>
+<cldfrc2m_rhmaxi         > 1.05D0    </cldfrc2m_rhmaxi>
+<clubb_c_K10             > 0.3       </clubb_c_K10>
+<effgw_beres             > 0.4       </effgw_beres>
+<do_tms                  > .false.   </do_tms>
+<so4_sz_thresh_icenuc    > 0.05e-6   </so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage  > 8.0D0     </n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac> 1.5D0     </micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add       > 0.8D0     </zmconv_tiedke_add>
+<zmconv_cape_cin         > 1         </zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   > 2         </zmconv_mx_bot_lyr_adj>
+<taubgnd                 > 2.5D-3    </taubgnd>
+<clubb_C1                > 1.335     </clubb_C1>
+<raytau0                 > 5.0D0     </raytau0>
+<prc_coef1               > 30500.0D0 </prc_coef1>
+<prc_exp                 > 3.19D0    </prc_exp>
+<prc_exp1                > -1.2D0    </prc_exp1>
+<se_ftype                > 2         </se_ftype>
+<clubb_C14               > 1.06D0     </clubb_C14>
+<relvar_fix              > .true.    </relvar_fix>
+<mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>
+<rrtmg_temp_fix          > .true.    </rrtmg_temp_fix>
+
+<!-- Energy fixer options -->
+<l_ieflx_fix> .false.</l_ieflx_fix>
+<ieflx_opt  > 2     </ieflx_opt>
+
+
+<!-- 1850 ozone data is from Jean-Francois Lamarque -->
+<!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->
+<prescribed_ozone_datapath>atm/cam/ozone</prescribed_ozone_datapath>
+<prescribed_ozone_file    >ozone_1.9x2.5_L26_1850clim_c090420.nc</prescribed_ozone_file>
+<prescribed_ozone_name    >O3</prescribed_ozone_name>
+<prescribed_ozone_type    >CYCLICAL</prescribed_ozone_type>
+<prescribed_ozone_cycle_yr>1850</prescribed_ozone_cycle_yr>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<ext_frc_type         >CYCLICAL</ext_frc_type>
+<ext_frc_cycle_yr     >1850</ext_frc_cycle_yr>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c170525.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c170525.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c170525.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c170525.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c170525.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c170525.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c170525.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c170525.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c170525.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type        >CYCLICAL</srf_emis_type>
+<srf_emis_cycle_yr    >1850</srf_emis_cycle_yr>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c170525.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c170525.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c170525.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c170525.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c170525.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c170525.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c170525.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c170525.nc </so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr>1849</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20171110.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
+<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- land datasets -->
+<!-- Set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+
+
+</namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
@@ -101,7 +101,6 @@
 <!-- Energy fixer options -->
 <ieflx_opt  > 0     </ieflx_opt>
 
-
 <!-- 1850 ozone data is from Jean-Francois Lamarque -->
 <!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->
 <prescribed_ozone_datapath>atm/cam/ozone</prescribed_ozone_datapath>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -172,6 +172,7 @@
       <value compset="1850_CAM5.*AV1C-H01B">1850_cam5_av1c-h01b</value>
       <value compset="1850_CAM5.*AV1C-H01C">1850_cam5_av1c-h01c</value>
       <value compset="1850_CAM5.*CMIP6"  >1850_cam5_CMIP6</value>
+      <value compset="1850S_CAM5.*CMIP6"  >1850S_cam5_CMIP6</value>
       <value compset="1950_CAM5.*CMIP6-LR"  >1950_cam5_CMIP6-LR</value>
       <value compset="1950_CAM5.*CMIP6-HR"  >1950_cam5_CMIP6-HR</value>
       <value compset="1950_CAM5.*CMIP6-LRtunedHR"  >1950_cam5_CMIP6-LRtunedHR</value>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -82,6 +82,11 @@
   </compset>
 
   <compset>
+    <alias>F1850SC5-CMIP6</alias>
+    <lname>1850S_CAM5%CMIP6_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>FC5AV1C-01</alias>
     <lname>2000_CAM5%AV1C-01_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>

--- a/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
@@ -34,5 +34,6 @@
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
 <finidat>lnd/clm2/initdata_map/20180129.DECKv1b_piControl.ne30_oEC.edison.clm2.r.0501-01-01-00000_c20190202.nc </finidat>
+<check_finidat_year_consistency>.false.</check_finidat_year_consistency>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc>Conditions to simulate 1850 land-use</use_case_desc>
+
+<sim_year>1850</sim_year>
+
+<sim_year_range>constant</sim_year_range>
+
+<stream_year_first_ndep phys="clm4_0" bgc="cn"   ndepsrc="stream" >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_0" bgc="cn"   ndepsrc="stream" >1850</stream_year_last_ndep>
+
+<stream_year_first_ndep phys="clm4_0" bgc="cndv" ndepsrc="stream" >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_0" bgc="cndv" ndepsrc="stream" >1850</stream_year_last_ndep>
+
+<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_ndep>
+
+<stream_year_first_ndep phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_ndep>
+
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2000</stream_year_last_pdep>
+
+<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_popdens>
+
+<stream_year_first_popdens phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm5_0" use_cn=".true." ndepsrc="stream" >1850</stream_year_last_popdens>
+
+<!-- CMIP6 DECK compsets -->
+      
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
+<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
+<finidat>lnd/clm2/initdata_map/20180129.DECKv1b_piControl.ne30_oEC.edison.clm2.r.0501-01-01-00000_c20190202.nc </finidat>
+
+</namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
@@ -33,7 +33,7 @@
       
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
-<finidat>lnd/clm2/initdata_map/20180129.DECKv1b_piControl.ne30_oEC.edison.clm2.r.0501-01-01-00000_c20190202.nc </finidat>
+<finidat>lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
 <check_finidat_year_consistency>.false.</check_finidat_year_consistency>
 
 </namelist_defaults>

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -72,6 +72,7 @@
       <value compset="PDAY.*_CLM"       >1850-2100_rcp4.5_transient</value> 
       <!-- CMIP6 DECK compsets and related BGC compsets -->
       <value compset="1850_CAM5%CMIP6_CLM">1850_CMIP6_control</value>
+      <value compset="1850S_CAM5%CMIP6_CLM">1850_SCMIP6_control</value>
       <value compset="1850_CAM5%CMIP6_CLM45%[^_]*BGC">1850_CMIP6bgc_control</value>
       <value compset="20TR_CAM5%CMIP6_CLM">20thC_CMIP6_transient</value>
       <value compset="20TR_CAM5%CMIP6_CLM45%[^_]*BGC">20thC_CMIP6bgc_transient</value> 


### PR DESCRIPTION
Create the F1850SC5-CMIP6 compset (letter "S" in the name stands for special), since the following settings will be different from the F1850C5-CMIP6 compset used by the companion coupled compset (piControl, A_WCYCL1850S_CMIP6)

- l_ieflx_fix flag default to .false.
- Atmosphere and land initial condition data use results at the end (0501-01-01) of the DECK piControl simulation. This is particularly useful to have a better spun-up land state.
- SST and sea ice data use the CMIP6 climatology calculated from 1870-1879.

All the new input files were uploaded to the E3SM input data server: https://web.lcrc.anl.gov/public/e3sm/inputdata/