### PR TITLE
Add the NETCDF_PATH env for Summit

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -3080,6 +3080,7 @@
       <env name="OMP_STACKSIZE">128M</env>
       <env name="NETCDF_C_PATH">$ENV{OLCF_NETCDF_ROOT}</env>
       <env name="NETCDF_FORTRAN_PATH">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
+      <env name="NETCDF_PATH">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
       <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
       <env name="NETLIB_LAPACK_PATH">$ENV{OLCF_NETLIB_LAPACK_ROOT}</env>
     </environment_variables>


### PR DESCRIPTION
The MPAS components use the NETCDF_PATH env to find the NetCDF package
and the env has not been defined in the machine and compiler xml files.

[BFB] - Bit-For-Bit