### PR TITLE
Update threading for coupled BGC cases

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -51,13 +51,6 @@ def buildnml(case, caseroot, compname):
     if not os.path.isdir(mpasoconf_dir): os.mkdir(mpasoconf_dir)
 
     #--------------------------------------------------------------------
-    # MPAS-O with active BGC fails bfb restart with more than 1 thread
-    # DO NOT run with ocean bgc turned on with more than 1 thread
-    #--------------------------------------------------------------------
-    expect(nthrds_ocn == 1 or ocn_bgc == 'no_bgc',
-           " ERROR mpas-o buildnml: ocn bgc cannot be run with more than 1 thread\n")
-
-    #--------------------------------------------------------------------
     # Determine date stamp, from grid names
     #--------------------------------------------------------------------
 


### PR DESCRIPTION
This lifts the restriction of running multi-threaded BGC cases. Threading is important for better performance on KNL nodes (64 cores, 128 hyper-threads).

This needs the corresponding PR MPAS-Dev/MPAS-Model#152 to be brought into `components/mpas-source` on `maint-1.1` branch.

[BFB]

Fixes E3SM-Project/E3SM#1931