### PR TITLE
Updates multiple land initial conditions

### DIFF
--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -127,7 +127,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <finidat hgrid="ne11np4"   maxpft="17"  mask="oQU240" use_cn=".false." ic_ymd="20000101" more_vertlayers=".false."
- ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICRUCLM45.ne11_oQU240.1155ba0.clm2.r.nc
+ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICLM45BC.ne11_ne11.71f4e1927.clm2.r.nc
 </finidat>
 
 <!-- HOMME grid ne16 resolution -->
@@ -147,7 +147,7 @@ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 </finidat>
 
 <finidat hgrid="ne120np4"   maxpft="17"  mask="gx1v6" use_cn=".false." ic_ymd="20000101" more_vertlayers=".false."
-ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICRUCLM45.ne120_g16.1155ba0.clm2.r.nc
+ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICLM45BC.ne120_g16.71f4e1927.clm2.r.nc
 </finidat>
 
 <finidat hgrid="ne120np4"   maxpft="17"  mask="oRRS15to5" use_cn=".false." ic_ymd="18500101" more_vertlayers=".false."
@@ -163,7 +163,7 @@ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 </finidat>
 
 <finidat hgrid="ne120np4"   maxpft="17"  mask="oRRS18to6v3" use_cn=".false." ic_ymd="20000101" more_vertlayers=".false."
-ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICRUCLM45.ne120_oRRS18v3.be55494.clm2.r.nc
+ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.A_WCYCL2000_H01AS.ne120_oRRS18v3_ICG.71f4e1927.clm2.r.nc
 </finidat>
 
 <!-- HOMME grid ne240 resolution -->

--- a/components/clm/bld/namelist_files/use_cases/1950_CMIP6LR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1950_CMIP6LR_control.xml
@@ -18,6 +18,6 @@
 <!-- CMIP6 DECK compsets -->
       
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1950_c180314.nc</fsurdat>
-<finidat>lnd/clm2/initdata/clmi.A_WCYCL1950S_CMIP6_LRtunedHR.ne30_oECv3_ICG_simyr1950_c20180316.nc </finidat>
+<finidat>lnd/clm2/initdata_map/clmi.A_WCYCL1950S_CMIP6_LRtunedHR.ne30_oECv3_ICG_simyr1950_71f4e1927.nc </finidat>
 
 </namelist_defaults>


### PR DESCRIPTION
Land IC files are updated at following resolution/compset:
 - ne11_oQU240/ICLM45BC
 - ne120_g16/ICLM45BC
 - ne30_oECv3_ICG/A_WCYCL1950S_CMIP6_LRtunedHR
 - ne120_oRRS18v3_ICG/A_WCYCL2000_H01AS

Fixes #2692
[non-BFB]