### PR TITLE
Refactor e3sm test suite definition format

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -103,7 +103,7 @@ _TESTS = {
             "ERS.f09_g16_g.MALISIA",
             "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
             "SMS.f09_g16_a.IGCLM45_MLI",
-            "SMS_P12x2.ne4_oQU240.A_WCYCL1850.allactive-mach_mods"
+            "SMS_P12x2.ne4_oQU240.A_WCYCL1850.allactive-mach_mods",
             )
         },
 
@@ -124,7 +124,7 @@ _TESTS = {
             "SMS.f09_g16_a.MALI",
             "SMS_D_Ln5.conusx4v1_conusx4v1.FC5AV1C-L",
             "SMS.ne30_oECv3.BGCEXP_BCRC_CNPECACNT_1850.clm-bgcexp",
-            "SMS.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850.clm-bgcexp"
+            "SMS.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850.clm-bgcexp",
             )
         },
 
@@ -133,7 +133,7 @@ _TESTS = {
         "inherit" : "e3sm_atm_extra_coverage",
         "tests"   : (
             "SMS_D_Ln5.enax4v1_enax4v1.FC5AV1C-L",
-            "SMS_D_Ln5.twpx4v1_twpx4v1.FC5AV1C-L"
+            "SMS_D_Ln5.twpx4v1_twpx4v1.FC5AV1C-L",
             )
         },
 
@@ -151,7 +151,7 @@ _TESTS = {
         "tests" : (
             "SMS_D_Ln5.conusx4v1_conusx4v1.FC5AV1C-L",
             "SMS_D_Ln5.enax4v1_enax4v1.FC5AV1C-L",
-            "SMS_D_Ln5.twpx4v1_twpx4v1.FC5AV1C-L"
+            "SMS_D_Ln5.twpx4v1_twpx4v1.FC5AV1C-L",
             )
         },
 

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -5,7 +5,7 @@
 #     "inherit" : (suite1, suite2, ...), # Optional. Suites to inherit tests from. Default is None. Tuple, list, or str.
 #     "time"    : "HH:MM:SS",            # Optional. Recommended upper-limit on test time.
 #     "share"   : True|False,            # Optional. If True, all tests in this suite share a build. Default is False.
-#     "tests"   : (test1, test2, ...)    # Required. The list of tests for this suite. See above for format. Tuple, list, or str.
+#     "tests"   : (test1, test2, ...)    # Optional. The list of tests for this suite. See above for format. Tuple, list, or str.
 # }
 
 _TESTS = {

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -1,136 +1,172 @@
 # Here are the tests belonging to e3sm suites. Format is
-# <test>.<grid>.<compset>.
-# suite_name -> (inherits_from, timelimit, [test [, mods[, machines]]])
-#   To elaborate, if no mods are needed, a string representing the testname is all that is needed.
-#   If testmods are needed, a 2-ple must be provided  (test, mods)
-#   If you want to restrict the test mods to certain machines, than a 3-ple is needed (test, mods, [machines])
+# <test>.<grid>.<compset>[.<testmod>]
+#
+# suite_name : {
+#     "inherit" : (suite1, suite2, ...), # Optional. Suites to inherit tests from. Default is None. Tuple, list, or str.
+#     "time"    : "HH:MM:SS",            # Optional. Recommended upper-limit on test time.
+#     "share"   : True|False,            # Optional. If True, all tests in this suite share a build. Default is False.
+#     "tests"   : (test1, test2, ...)    # Required. The list of tests for this suite. See above for format. Tuple, list, or str.
+# }
+
 _TESTS = {
 
-    "e3sm_land_developer" : (None, "0:45:00",
-                             ("ERS.f19_f19.ICLM45",
-                              "ERS.f19_f19.I1850CLM45CN",
-                              "ERS.f09_g16.I1850CLM45CN",
-                              "ERS.f19_f19.I20TRCLM45CN",
-                              "SMS_Ld1.hcru_hcru.I1850CRUCLM45CN",
-                             ("ERS.f19_g16.I1850CNECACNTBC" ,"clm-eca"),
-                             ("ERS.f19_g16.I1850CNECACTCBC" ,"clm-eca"),
-                             ("SMS_Ly2_P1x1.1x1_smallvilleIA.ICLM45CNCROP", "clm-force_netcdf_pio"),
-                             ("ERS_Ld3.f45_f45.ICLM45ED","clm-fates"),
-                             ("ERS.f19_g16.I1850CLM45","clm-betr"),
-                             ("ERS.f19_g16.I1850CLM45","clm-vst"),
-                             ("ERS.f09_g16.I1850CLM45CN","clm-bgcinterface"),
-                              "ERS.ne11_oQU240.I20TRCLM45",
-                             ("ERS.f19_g16.I1850CNRDCTCBC","clm-rd"),
-                             ("ERS.f19_g16.I1850GSWCNPECACNTBC","clm-eca_f19_g16_I1850GSWCNPECACNTBC"),
-                             ("ERS.f19_g16.I20TRGSWCNPECACNTBC","clm-eca_f19_g16_I20TRGSWCNPECACNTBC"),
-                             ("ERS.f19_g16.I1850GSWCNPRDCTCBC","clm-ctc_f19_g16_I1850GSWCNPRDCTCBC"),
-                             ("ERS.f19_g16.I20TRGSWCNPRDCTCBC","clm-ctc_f19_g16_I20TRGSWCNPRDCTCBC"),
-                              "ERS.f09_g16.ICLM45BC")
-                             ),
+    "e3sm_land_developer" : {
+        "time"  : "0:45:00",
+        "tests" : (
+            "ERS.f19_f19.ICLM45",
+            "ERS.f19_f19.I1850CLM45CN",
+            "ERS.f09_g16.I1850CLM45CN",
+            "ERS.f19_f19.I20TRCLM45CN",
+            "SMS_Ld1.hcru_hcru.I1850CRUCLM45CN",
+            "ERS.f19_g16.I1850CNECACNTBC.clm-eca",
+            "ERS.f19_g16.I1850CNECACTCBC.clm-eca",
+            "SMS_Ly2_P1x1.1x1_smallvilleIA.ICLM45CNCROP.clm-force_netcdf_pio",
+            "ERS_Ld3.f45_f45.ICLM45ED.clm-fates",
+            "ERS.f19_g16.I1850CLM45.clm-betr",
+            "ERS.f19_g16.I1850CLM45.clm-vst",
+            "ERS.f09_g16.I1850CLM45CN.clm-bgcinterface",
+            "ERS.ne11_oQU240.I20TRCLM45",
+            "ERS.f19_g16.I1850CNRDCTCBC.clm-rd",
+            "ERS.f19_g16.I1850GSWCNPECACNTBC.clm-eca_f19_g16_I1850GSWCNPECACNTBC",
+            "ERS.f19_g16.I20TRGSWCNPECACNTBC.clm-eca_f19_g16_I20TRGSWCNPECACNTBC",
+            "ERS.f19_g16.I1850GSWCNPRDCTCBC.clm-ctc_f19_g16_I1850GSWCNPRDCTCBC",
+            "ERS.f19_g16.I20TRGSWCNPRDCTCBC.clm-ctc_f19_g16_I20TRGSWCNPRDCTCBC",
+            "ERS.f09_g16.ICLM45BC",
+            )
+        },
 
-    "e3sm_atm_developer" : (None, None,
-                            ("ERP_Ln9.ne4_ne4.FC5AV1C-L",
-                             ("SMS_Ln9.ne4_ne4.FC5AV1C-L", "cam-outfrq9s"),
-                             ("SMS.ne4_ne4.FC5AV1C-L", "cam-cosplite"),
-                             "SMS_R_Ld5.T42_T42.FSCM5A97",
-                             "SMS_D_Ln5.ne4_ne4.FC5AV1C-L")
-                            ),
+    "e3sm_atm_developer" : {
+        "tests" : (
+            "ERP_Ln9.ne4_ne4.FC5AV1C-L",
+            "SMS_Ln9.ne4_ne4.FC5AV1C-L.cam-outfrq9s",
+            "SMS.ne4_ne4.FC5AV1C-L.cam-cosplite",
+            "SMS_R_Ld5.T42_T42.FSCM5A97",
+            "SMS_D_Ln5.ne4_ne4.FC5AV1C-L",
+            )
+        },
 
-    "e3sm_atm_integration" : (None, None,
-                              ("ERP_Ln9.ne4_ne4.FC5AV1C-L-AQUAP",
-                              ("SMS_Ld1.ne4_ne4.FC5AV1C-L-AQUAP","cam-clubb_only"),
-                               ("PET_Ln5.ne4_ne4.FC5AV1C-L","allactive-mach-pet"),
-                               "PEM_Ln5.ne4_ne4.FC5AV1C-L",
-                               ("SMS_D_Ln5.ne4_ne4.FC5AV1C-L", "cam-cosplite_nhtfrq5"),
-                               ("ERS_Ld5.ne4_ne4.FC5AV1C-L", "cam-rrtmgp"),
-                               "REP_Ln5.ne4_ne4.FC5AV1C-L")
-                              ),
+    "e3sm_atm_integration" : {
+        "tests" : (
+            "ERP_Ln9.ne4_ne4.FC5AV1C-L-AQUAP",
+            "SMS_Ld1.ne4_ne4.FC5AV1C-L-AQUAP.cam-clubb_only",
+            "PET_Ln5.ne4_ne4.FC5AV1C-L.allactive-mach-pet",
+            "PEM_Ln5.ne4_ne4.FC5AV1C-L",
+            "SMS_D_Ln5.ne4_ne4.FC5AV1C-L.cam-cosplite_nhtfrq5",
+            "ERS_Ld5.ne4_ne4.FC5AV1C-L.cam-rrtmgp",
+            "REP_Ln5.ne4_ne4.FC5AV1C-L",
+            )
+        },
+
     #atmopheric tests for extra coverage
-    "e3sm_atm_extra_coverage" : (None, None,
-                         ("SMS_Lm1.ne4_ne4.FC5AV1C-L",
-                          "ERS_Ld31.ne4_ne4.FC5AV1C-L",
-                          "ERP_Lm3.ne4_ne4.FC5AV1C-L",
-                          "SMS_D_Ln5.ne30_ne30.FC5AV1C-L",
-                          ("ERP_Ln5.ne30_ne30.FC5AV1C-L"),
-                          "SMS_Ly1.ne4_ne4.FC5AV1C-L")
-                         ),
+    "e3sm_atm_extra_coverage" : {
+        "tests" : (
+            "SMS_Lm1.ne4_ne4.FC5AV1C-L",
+            "ERS_Ld31.ne4_ne4.FC5AV1C-L",
+            "ERP_Lm3.ne4_ne4.FC5AV1C-L",
+            "SMS_D_Ln5.ne30_ne30.FC5AV1C-L",
+            "ERP_Ln5.ne30_ne30.FC5AV1C-L",
+            "SMS_Ly1.ne4_ne4.FC5AV1C-L",
+            )
+        },
+
     #atmopheric tests for hi-res
-    "e3sm_atm_hi_res" : (None, "01:30:00",
-                         (
-                          "SMS.ne120_ne120.FC5AV1C-H01A",
-                         )),
+    "e3sm_atm_hi_res" : {
+        "time" : "01:30:00",
+        "tests" : "SMS.ne120_ne120.FC5AV1C-H01A"
+        },
+
     #atmopheric tests to mimic low res production runs
-    "e3sm_atm_prod" : (None, None,
-                       (("SMS_Ln5.ne30_ne30.FC5AV1C-L", "cam-cosplite"),
-                        )
-                       ),
+    "e3sm_atm_prod" : {
+        "tests" : "SMS_Ln5.ne30_ne30.FC5AV1C-L.cam-cosplite"
+        },
 
     #atmopheric nbfb tests
-    "e3sm_atm_nbfb" : (None, None,
-                                 ("PGN_P1x1.ne4_ne4.FC5AV1C-L",
-                                  "TSC.ne4_ne4.FC5AV1C-L")
-                                 ),
+    "e3sm_atm_nbfb" : {
+        "tests" : (
+            "PGN_P1x1.ne4_ne4.FC5AV1C-L",
+            "TSC.ne4_ne4.FC5AV1C-L",
+            )
+        },
 
-    "e3sm_developer" : (("e3sm_land_developer","e3sm_atm_developer"), "0:45:00",
-                        ("ERS.f19_g16_rx1.A",
-                         "ERS.ne30_g16_rx1.A",
-                         "SEQ.f19_g16.X",
-                         "ERIO.ne30_g16_rx1.A",
-                         "HOMME_P24.f19_g16_rx1.A",
-                         "NCK.f19_g16_rx1.A",
-                         "SMS.ne30_f19_g16_rx1.A",
-                         "ERS_Ld5.T62_oQU120.CMPASO-NYF",
-                         "ERS.f09_g16_g.MALISIA",
-                         "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
-                         "SMS.f09_g16_a.IGCLM45_MLI",
-                        ("SMS_P12x2.ne4_oQU240.A_WCYCL1850","allactive-mach_mods")
-                        )),
+    "e3sm_developer" : {
+        "inherit" : ("e3sm_land_developer", "e3sm_atm_developer"),
+        "time"    : "0:45:00",
+        "tests"   : (
+            "ERS.f19_g16_rx1.A",
+            "ERS.ne30_g16_rx1.A",
+            "SEQ.f19_g16.X",
+            "ERIO.ne30_g16_rx1.A",
+            "HOMME_P24.f19_g16_rx1.A",
+            "NCK.f19_g16_rx1.A",
+            "SMS.ne30_f19_g16_rx1.A",
+            "ERS_Ld5.T62_oQU120.CMPASO-NYF",
+            "ERS.f09_g16_g.MALISIA",
+            "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
+            "SMS.f09_g16_a.IGCLM45_MLI",
+            "SMS_P12x2.ne4_oQU240.A_WCYCL1850.allactive-mach_mods"
+            )
+        },
 
-    "e3sm_integration" : (("e3sm_developer", "e3sm_atm_integration"),"03:00:00",
-                          ("ERS.ne11_oQU240.A_WCYCL1850",
-		           ("SMS_D_Ld1.ne30_oECv3_ICG.A_WCYCL1850S_CMIP6","allactive-v1cmip6"),
-                           "ERS_Ln9.ne4_ne4.FC5AV1C-L",
-                          #"ERT_Ld31.ne16_g37.B1850C5",#add this line back in with the new correct compset
-                           "NCK.ne11_oQU240.A_WCYCL1850",
-                           ("PET.f19_g16.X","allactive-mach-pet"),
-                           ("PET.f45_g37_rx1.A","allactive-mach-pet"),
-                           ("PET_Ln9_PS.ne30_oECv3_ICG.A_WCYCL1850S","allactive-mach-pet"),
-                           "PEM_Ln9.ne30_oECv3_ICG.A_WCYCL1850S",
-                           "ERP_Ld3.ne30_oECv3_ICG.A_WCYCL1850S",
-                           "SMS.f09_g16_a.MALI",
-                           "SMS_D_Ln5.conusx4v1_conusx4v1.FC5AV1C-L",
-                           ("SMS.ne30_oECv3.BGCEXP_BCRC_CNPECACNT_1850","clm-bgcexp"),
-                           ("SMS.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850","clm-bgcexp"))
-                          ),
+    "e3sm_integration" : {
+        "inherit" : ("e3sm_developer", "e3sm_atm_integration"),
+        "time"    : "03:00:00",
+        "tests"   : (
+            "ERS.ne11_oQU240.A_WCYCL1850",
+            "SMS_D_Ld1.ne30_oECv3_ICG.A_WCYCL1850S_CMIP6.allactive-v1cmip6",
+            "ERS_Ln9.ne4_ne4.FC5AV1C-L",
+            #"ERT_Ld31.ne16_g37.B1850C5",#add this line back in with the new correct compset
+            "NCK.ne11_oQU240.A_WCYCL1850",
+            "PET.f19_g16.X.allactive-mach-pet",
+            "PET.f45_g37_rx1.A.allactive-mach-pet",
+            "PET_Ln9_PS.ne30_oECv3_ICG.A_WCYCL1850S.allactive-mach-pet",
+            "PEM_Ln9.ne30_oECv3_ICG.A_WCYCL1850S",
+            "ERP_Ld3.ne30_oECv3_ICG.A_WCYCL1850S",
+            "SMS.f09_g16_a.MALI",
+            "SMS_D_Ln5.conusx4v1_conusx4v1.FC5AV1C-L",
+            "SMS.ne30_oECv3.BGCEXP_BCRC_CNPECACNT_1850.clm-bgcexp",
+            "SMS.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850.clm-bgcexp"
+            )
+        },
+
     #e3sm tests for extra coverage
-    "e3sm_extra_coverage" : (("e3sm_atm_extra_coverage",), None,
-                             ("SMS_D_Ln5.enax4v1_enax4v1.FC5AV1C-L",
-                              "SMS_D_Ln5.twpx4v1_twpx4v1.FC5AV1C-L")),
+    "e3sm_extra_coverage" : {
+        "inherit" : "e3sm_atm_extra_coverage",
+        "tests"   : (
+            "SMS_D_Ln5.enax4v1_enax4v1.FC5AV1C-L",
+            "SMS_D_Ln5.twpx4v1_twpx4v1.FC5AV1C-L"
+            )
+        },
 
     #e3sm tests for hi-res
-    "e3sm_hi_res" : (("e3sm_atm_hi_res",),None,
-                     (
-                      ("SMS.ne120_oRRS18v3_ICG.A_WCYCL2000_H01AS", "cam-cosplite"),
-                       "SMS.T62_oRRS30to10v3wLI.GMPAS-IAF",
-                     )),
+    "e3sm_hi_res" : {
+        "inherit" : "e3sm_atm_hi_res",
+        "tests"   : (
+            "SMS.ne120_oRRS18v3_ICG.A_WCYCL2000_H01AS.cam-cosplite",
+            "SMS.T62_oRRS30to10v3wLI.GMPAS-IAF",
+            )
+        },
 
     #e3sm tests for RRM grids
-    "e3sm_rrm" : (None, None,
-                  ("SMS_D_Ln5.conusx4v1_conusx4v1.FC5AV1C-L",
-                   "SMS_D_Ln5.enax4v1_enax4v1.FC5AV1C-L",
-                   "SMS_D_Ln5.twpx4v1_twpx4v1.FC5AV1C-L")
-                 ),
+    "e3sm_rrm" : {
+        "tests" : (
+            "SMS_D_Ln5.conusx4v1_conusx4v1.FC5AV1C-L",
+            "SMS_D_Ln5.enax4v1_enax4v1.FC5AV1C-L",
+            "SMS_D_Ln5.twpx4v1_twpx4v1.FC5AV1C-L"
+            )
+        },
 
     #e3sm tests to mimic production runs
-    "e3sm_prod" : (("e3sm_atm_prod",),None,
-                     (
-		      ("SMS_Ld2.ne30_oECv3_ICG.A_WCYCL1850S_CMIP6","allactive-v1cmip6"),
-		      )),
+    "e3sm_prod" : {
+        "inherit" : "e3sm_atm_prod",
+        "tests"   : "SMS_Ld2.ne30_oECv3_ICG.A_WCYCL1850S_CMIP6.allactive-v1cmip6"
+        },
 
-    "fates" : (None, None,
-                         ("ERS_Ld9.1x1_brazil.ICLM45ED",
-                          "ERS_D_Ld9.1x1_brazil.ICLM45ED",
-                          "SMS_D_Lm6.1x1_brazil.ICLM45ED")
-               ),
+    "fates" : {
+        "tests" : (
+            "ERS_Ld9.1x1_brazil.ICLM45ED",
+            "ERS_D_Ld9.1x1_brazil.ICLM45ED",
+            "SMS_D_Lm6.1x1_brazil.ICLM45ED",
+            )
+        },
 
 }

--- a/cime/scripts/lib/CIME/BuildTools/cmakemacroswriter.py
+++ b/cime/scripts/lib/CIME/BuildTools/cmakemacroswriter.py
@@ -86,8 +86,8 @@ class CMakeMacroWriter(MacroWriterBase):
         >>> import io
         >>> s = io.StringIO()
         >>> CMakeMacroWriter(s).set_variable("foo", "bar")
-        >>> s.getvalue()
-        u'set(foo "bar")\\n'
+        >>> str(s.getvalue())
+        'set(foo "bar")\\n'
         """
         value_transformed = self._transform_value(value)
         self.write_line("set(" + name + ' "' + value_transformed + '")')
@@ -98,8 +98,8 @@ class CMakeMacroWriter(MacroWriterBase):
         >>> import io
         >>> s = io.StringIO()
         >>> CMakeMacroWriter(s).start_ifeq("foo", "bar")
-        >>> s.getvalue()
-        u'if("foo" STREQUAL "bar")\\n'
+        >>> str(s.getvalue())
+        'if("foo" STREQUAL "bar")\\n'
         """
         self.write_line('if("' + left + '" STREQUAL "' + right + '")')
         self.indent_right()
@@ -113,8 +113,8 @@ class CMakeMacroWriter(MacroWriterBase):
         >>> writer.start_ifeq("foo", "bar")
         >>> writer.set_variable("foo2", "bar2")
         >>> writer.end_ifeq()
-        >>> s.getvalue()
-        u'if("foo" STREQUAL "bar")\\n  set(foo2 "bar2")\\nendif()\\n'
+        >>> str(s.getvalue())
+        'if("foo" STREQUAL "bar")\\n  set(foo2 "bar2")\\nendif()\\n'
         """
         self.indent_left()
         self.write_line("endif()")

--- a/cime/scripts/lib/CIME/BuildTools/macrowriterbase.py
+++ b/cime/scripts/lib/CIME/BuildTools/macrowriterbase.py
@@ -132,7 +132,7 @@ class MacroWriterBase(object):
 
         A trailing newline is added, whether or not the input has one.
         """
-        self.output.write(str(self.indent_string() + line + "\n"))
+        self.output.write(u"{}{}\n".format(self.indent_string(), line))
 
     @abstractmethod
     def environment_variable_string(self, name):

--- a/cime/scripts/lib/CIME/case/case_st_archive.py
+++ b/cime/scripts/lib/CIME/case/case_st_archive.py
@@ -52,6 +52,7 @@ def _datetime_str(_date):
     """
     Returns the standard format associated with filenames.
 
+    >>> from CIME.date import date
     >>> _datetime_str(date(5, 8, 22))
     '0005-08-22-00000'
     >>> _datetime_str(get_file_date("0011-12-09-00435"))
@@ -68,6 +69,7 @@ def _datetime_str_mpas(_date):
     """
     Returns the mpas format associated with filenames.
 
+    >>> from CIME.date import date
     >>> _datetime_str_mpas(date(5, 8, 22))
     '0005-08-22_00:00:00'
     >>> _datetime_str_mpas(get_file_date("0011-12-09-00435"))

--- a/cime/scripts/lib/get_tests.py
+++ b/cime/scripts/lib/get_tests.py
@@ -14,78 +14,151 @@ try:
 except ImportError:
     pass
 
-# Here are the tests belonging to e3sm suites. Format is
-# <test>.<grid>.<compset>.
-# suite_name -> (inherits_from, timelimit, [test [, mods[, machines]]])
-#   To elaborate, if no mods are needed, a string representing the testname is all that is needed.
-#   If testmods are needed, a 2-ple must be provided  (test, mods)
-#   If you want to restrict the test mods to certain machines, than a 3-ple is needed (test, mods, [machines])
+# Here are the tests belonging to cime suites. Format for individual tests is
+# <test>.<grid>.<compset>[.<testmod>]
+#
+# suite_name : {
+#     "inherit" : (suite1, suite2, ...), # Optional. Suites to inherit tests from. Default is None. Tuple, list, or str.
+#     "time"    : "HH:MM:SS",            # Optional. Recommended upper-limit on test time.
+#     "share"   : True|False,            # Optional. If True, all tests in this suite share a build. Default is False.
+#     "tests"   : (test1, test2, ...)    # Required. The list of tests for this suite. See above for format. Tuple, list, or str.
+# }
 
 _CIME_TESTS = {
 
-    "cime_tiny" : (None, "0:10:00",
-                   ("ERS.f19_g16_rx1.A",
-                    "NCK.f19_g16_rx1.A")
-                   ),
+    "cime_tiny" : {
+        "time"  : "0:10:00",
+        "tests" : (
+            "ERS.f19_g16_rx1.A",
+            "NCK.f19_g16_rx1.A",
+            )
+        },
 
-    "cime_test_only_pass" : (None, "0:10:00",
-                   ("TESTRUNPASS_P1.f19_g16_rx1.A",
-                    "TESTRUNPASS_P1.ne30_g16_rx1.A",
-                    "TESTRUNPASS_P1.f45_g37_rx1.A")
-                   ),
+    "cime_test_only_pass" : {
+        "time"  : "0:10:00",
+        "tests" : (
+            "TESTRUNPASS_P1.f19_g16_rx1.A",
+            "TESTRUNPASS_P1.ne30_g16_rx1.A",
+            "TESTRUNPASS_P1.f45_g37_rx1.A",
+            )
+        },
 
-    "cime_test_only_slow_pass" : (None, "0:10:00",
-                   ("TESTRUNSLOWPASS_P1.f19_g16_rx1.A",
-                    "TESTRUNSLOWPASS_P1.ne30_g16_rx1.A",
-                    "TESTRUNSLOWPASS_P1.f45_g37_rx1.A")
-                   ),
+    "cime_test_only_slow_pass" : {
+        "time"  : "0:10:00",
+        "tests" : (
+            "TESTRUNSLOWPASS_P1.f19_g16_rx1.A",
+            "TESTRUNSLOWPASS_P1.ne30_g16_rx1.A",
+            "TESTRUNSLOWPASS_P1.f45_g37_rx1.A",
+            )
+        },
 
-    "cime_test_only" : (None, "0:10:00",
-                   ("TESTBUILDFAIL_P1.f19_g16_rx1.A",
-                    "TESTBUILDFAILEXC_P1.f19_g16_rx1.A",
-                    "TESTRUNFAIL_P1.f19_g16_rx1.A",
-                    "TESTRUNSTARCFAIL_P1.f19_g16_rx1.A",
-                    "TESTRUNFAILEXC_P1.f19_g16_rx1.A",
-                    "TESTRUNPASS_P1.f19_g16_rx1.A",
-                    "TESTTESTDIFF_P1.f19_g16_rx1.A",
-                    "TESTMEMLEAKFAIL_P1.f09_g16.X",
-                    "TESTMEMLEAKPASS_P1.f09_g16.X")
-                   ),
+    "cime_test_only" : {
+        "time"  : "0:10:00",
+        "tests" : (
+            "TESTBUILDFAIL_P1.f19_g16_rx1.A",
+            "TESTBUILDFAILEXC_P1.f19_g16_rx1.A",
+            "TESTRUNFAIL_P1.f19_g16_rx1.A",
+            "TESTRUNSTARCFAIL_P1.f19_g16_rx1.A",
+            "TESTRUNFAILEXC_P1.f19_g16_rx1.A",
+            "TESTRUNPASS_P1.f19_g16_rx1.A",
+            "TESTTESTDIFF_P1.f19_g16_rx1.A",
+            "TESTMEMLEAKFAIL_P1.f09_g16.X",
+            "TESTMEMLEAKPASS_P1.f09_g16.X",
+            )
+        },
 
-    "cime_test_all" : ("cime_test_only", "0:10:00",
-                       ("TESTRUNDIFF_P1.f19_g16_rx1.A", )),
+    "cime_test_all" : {
+        "inherit" : "cime_test_only",
+        "time"    : "0:10:00",
+        "tests"   : "TESTRUNDIFF_P1.f19_g16_rx1.A"
+        },
 
-    "cime_developer" : (None, "0:15:00",
-                            ("NCK_Ld3.f45_g37_rx1.A",
-                             "ERI.f09_g16.X",
-                             "ERIO.f09_g16.X",
-                             "SEQ_Ln9.f19_g16_rx1.A",
-                             ("ERS.ne30_g16_rx1.A","drv-y100k"),
-                             "IRT_N2.f19_g16_rx1.A",
-                             "ERR.f45_g37_rx1.A",
-                             "ERP.f45_g37_rx1.A",
-                             "SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A",
-                             "DAE.ww3a.ADWAV",
-                             "PET_P4.f19_f19.A",
-                             "PEM_P4.f19_f19.A",
-                             "SMS.T42_T42.S",
-                             "PRE.f19_f19.ADESP",
-                             "PRE.f19_f19.ADESP_TEST",
-                             "MCC_P1.f19_g16_rx1.A",
-                             "LDSTA.f45_g37_rx1.A")
-                            ),
+    "cime_test_share" : {
+        "time"  : "0:10:00",
+        "share" : True,
+        "tests" : (
+            "SMS_P2.f19_g16_rx1.A",
+            "SMS_P4.f19_g16_rx1.A",
+            "SMS_P8.f19_g16_rx1.A",
+            "SMS_P16.f19_g16_rx1.A",
+            )
+        },
+
+    "cime_developer" : {
+        "time"  : "0:15:00",
+        "tests" : (
+            "NCK_Ld3.f45_g37_rx1.A",
+            "ERI.f09_g16.X",
+            "ERIO.f09_g16.X",
+            "SEQ_Ln9.f19_g16_rx1.A",
+            "ERS.ne30_g16_rx1.A.drv-y100k",
+            "IRT_N2.f19_g16_rx1.A",
+            "ERR.f45_g37_rx1.A",
+            "ERP.f45_g37_rx1.A",
+            "SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A",
+            "DAE.ww3a.ADWAV",
+            "PET_P4.f19_f19.A",
+            "PEM_P4.f19_f19.A",
+            "SMS.T42_T42.S",
+            "PRE.f19_f19.ADESP",
+            "PRE.f19_f19.ADESP_TEST",
+            "MCC_P1.f19_g16_rx1.A",
+            "LDSTA.f45_g37_rx1.A",
+            )
+        },
 
 }
 
 _ALL_TESTS.update(_CIME_TESTS)
 
 ###############################################################################
-def get_test_suite(suite, machine=None, compiler=None):
+def _get_key_data(raw_dict, key, the_type):
+###############################################################################
+    if key not in raw_dict:
+        if the_type is tuple:
+            return ()
+        elif the_type is str:
+            return None
+        elif the_type is bool:
+            return False
+        else:
+            expect(False, "Unsupported type {}".format(the_type))
+    else:
+        val = raw_dict[key]
+        if the_type is tuple and isinstance(val, six.string_types):
+            val = (val, )
+
+        expect(isinstance(val, the_type),
+               "Wrong type for {}, {} is a {} but expected {}".format(key, val, type(val), the_type))
+
+        return val
+
+###############################################################################
+def get_test_data(suite):
+###############################################################################
+    """
+    For a given suite, returns (inherit, time, share, tests)
+    """
+    raw_dict = _ALL_TESTS[suite]
+    for key in raw_dict.keys():
+        expect(key in ["inherit", "time", "share", "tests"], "Unexpected test key '{}'".format(key))
+
+    expect("tests" in raw_dict.keys(), "Missing tests for suite '{}'".format(suite))
+
+    return _get_key_data(raw_dict, "inherits", tuple), _get_key_data(raw_dict, "time", str), _get_key_data(raw_dict, "share", bool), _get_key_data(raw_dict, "tests", tuple)
+
+###############################################################################
+def get_test_suites():
+###############################################################################
+    return list(_ALL_TESTS.keys())
+
+###############################################################################
+def get_test_suite(suite, machine=None, compiler=None, skip_inherit=False):
 ###############################################################################
     """
     Return a list of FULL test names for a suite.
     """
-    expect(suite in _ALL_TESTS, "Unknown test suite: '{}'".format(suite))
+    expect(suite in get_test_suites(), "Unknown test suite: '{}'".format(suite))
     machobj = Machines(machine=machine)
     machine = machobj.get_machine_name()
 
@@ -93,31 +166,24 @@ def get_test_suite(suite, machine=None, compiler=None):
         compiler = machobj.get_default_compiler()
     expect(machobj.is_valid_compiler(compiler),"Compiler {} not valid for machine {}".format(compiler,machine))
 
-    inherits_from, _, tests_raw = _ALL_TESTS[suite]
+    inherits_from, _, _, tests_raw = get_test_data(suite)
     tests = []
     for item in tests_raw:
-        test_mod = None
-        if (isinstance(item, six.string_types)):
-            test_name = item
-        else:
-            expect(isinstance(item, tuple), "Bad item type for item '{}'".format(str(item)))
-            expect(len(item) in [2, 3], "Expected two or three items in item '{}'".format(str(item)))
-            expect(isinstance(item[0], six.string_types), "Expected string in first field of item '{}'".format(str(item)))
-            expect(isinstance(item[1], six.string_types), "Expected string in second field of item '{}'".format(str(item)))
+        expect(isinstance(item, six.string_types), "Bad type of test {}, expected string".format(item))
 
-            test_name = item[0]
-            if (len(item) == 2):
-                test_mod = item[1]
-            else:
-                expect(type(item[2]) in [six.string_types, tuple], "Expected string or tuple for third field of item '{}'".format(str(item)))
-                test_mod_machines = [item[2]] if isinstance(item[2], six.string_types) else item[2]
-                if (machine in test_mod_machines):
-                    test_mod = item[1]
+        test_mod = None
+        test_components = item.split(".")
+        expect(len(test_components) in [3, 4], "Bad test name {}".format(item))
+
+        if (len(test_components) == 4):
+            test_name = ".".join(test_components[:-1])
+            test_mod = test_components[-1]
+        else:
+            test_name = item
 
         tests.append(CIME.utils.get_full_test_name(test_name, machine=machine, compiler=compiler, testmod=test_mod))
 
-    if (inherits_from is not None):
-        inherits_from = [inherits_from] if isinstance(inherits_from, six.string_types) else inherits_from
+    if not skip_inherit:
         for inherits in inherits_from:
             inherited_tests = get_test_suite(inherits, machine, compiler)
 
@@ -126,11 +192,6 @@ def get_test_suite(suite, machine=None, compiler=None):
             tests.extend(inherited_tests)
 
     return tests
-
-###############################################################################
-def get_test_suites():
-###############################################################################
-    return list(_ALL_TESTS.keys())
 
 ###############################################################################
 def infer_machine_name_from_tests(testargs):
@@ -239,26 +300,11 @@ def get_recommended_test_time(test_full_name):
     best_time = None
     suites = get_test_suites()
     for suite in suites:
-        _, rec_time, tests_raw = _ALL_TESTS[suite]
-        for item in tests_raw:
-            test_mod = None
-            if (isinstance(item, six.string_types)):
-                test_name = item
-            else:
-                test_name = item[0]
-                if (len(item) == 2):
-                    test_mod = item[1]
-                else:
-                    test_mod_machines = [item[2]] if isinstance(item[2], six.string_types) else item[2]
-                    if (machine in test_mod_machines):
-                        test_mod = item[1]
-
-            full_test = CIME.utils.get_full_test_name(test_name, machine=machine, compiler=compiler, testmod=test_mod)
-
-            if full_test == test_full_name and rec_time is not None:
-                if best_time is None or \
-                        convert_to_seconds(rec_time) < convert_to_seconds(best_time):
-                    best_time = rec_time
+        tests    = get_test_suite(suite, machine=machine, compiler=compiler, skip_inherit=True)
+        rec_time = get_test_data(suite)[1]
+        if test_full_name in tests and rec_time is not None and \
+           (best_time is None or convert_to_seconds(rec_time) < convert_to_seconds(best_time)):
+            best_time = rec_time
 
     return best_time
 

--- a/cime/scripts/tests/scripts_regression_tests.py
+++ b/cime/scripts/tests/scripts_regression_tests.py
@@ -118,7 +118,7 @@ class A_RunUnitTests(unittest.TestCase):
     def test_lib_doctests(self):
         # Find and run all the doctests in the lib directory tree
         skip_list = ["six.py", "CIME/SystemTests/mvk.py", "CIME/SystemTests/pgn.py"]
-        for root, dirs, files in os.walk(LIB_DIR):
+        for root, _, files in os.walk(LIB_DIR):
             for file_ in files:
                 filepath = os.path.join(root, file_)[len(LIB_DIR)+1:]
                 if filepath.endswith(".py") and filepath not in skip_list:

--- a/cime/scripts/tests/scripts_regression_tests.py
+++ b/cime/scripts/tests/scripts_regression_tests.py
@@ -115,13 +115,20 @@ class A_RunUnitTests(unittest.TestCase):
 
         self.assertTrue(results.wasSuccessful())
 
-    def test_CIME_doctests(self):
-        # Find and run all the doctests in the CIME directory tree
-        run_cmd_assert_result(self, "PYTHONPATH=%s:$PYTHONPATH python -m doctest *.py 2>&1" % LIB_DIR, from_dir=os.path.join(LIB_DIR,"CIME"))
-
-    def test_CIMEXML_doctests(self):
-        # Find and run all the doctests in the XML directory tree
-        run_cmd_assert_result(self, "PYTHONPATH=%s:$PYTHONPATH python -m doctest *.py 2>&1" % LIB_DIR, from_dir=os.path.join(LIB_DIR,"CIME","XML"))
+    def test_lib_doctests(self):
+        # Find and run all the doctests in the lib directory tree
+        skip_list = ["six.py", "CIME/SystemTests/mvk.py", "CIME/SystemTests/pgn.py"]
+        for root, dirs, files in os.walk(LIB_DIR):
+            for file_ in files:
+                filepath = os.path.join(root, file_)[len(LIB_DIR)+1:]
+                if filepath.endswith(".py") and filepath not in skip_list:
+                    with open(os.path.join(root, file_)) as fd:
+                        content = fd.read()
+                    if '>>>' in content:
+                        print("Running doctests for {}".format(filepath))
+                        run_cmd_assert_result(self, 'PYTHONPATH={}:$PYTHONPATH python -m doctest {} 2>&1'.format(LIB_DIR, filepath), from_dir=LIB_DIR)
+                    else:
+                        print("{} has no doctests".format(filepath))
 
 ###############################################################################
 def make_fake_teststatus(path, testname, status, phase):


### PR DESCRIPTION
The use of tuples is not scalable as we increase the
configurability of test suites.

Fixes #2409 

[BFB]