### PR TITLE
Fix build for mksurfdata_map tool

### DIFF
--- a/components/clm/tools/clm4_5/mksurfdata_map/src/Makefile.common
+++ b/components/clm/tools/clm4_5/mksurfdata_map/src/Makefile.common
@@ -248,7 +248,7 @@ ifeq ($(UNAMES),Linux)
   endif
   CPPDEF += -DLINUX -DFORTRANUNDERSCORE
   CFLAGS := $(CPPDEF)
-  LDFLAGS := $(shell $(LIB_NETCDF)/../bin/nf-config --flibs)
+  LDFLAGS := $(shell nf-config --flibs)
   FFLAGS =
 
   ifeq ($(FCTYP),pgf90)


### PR DESCRIPTION
Fix build environment for the `mksurfdata_map` tool, which is used to build new land surface datasets. This only requires a simple change to the Makefile to not assume a path for `nf-config` relative to `LIB_NETCDF`. This was causing a problem because different machines would have a different location for `nf-config` relative to `LIB_NETCDF`. So calling `nf-config` without specifying a path (and assuming that `nf-config` exists in the `PATH` environment variable) seems to make
the build more portable and not require hand editing the Makefile.

[BFB]