### PR TITLE
Creat F2010C5-CMIP5-HR compset

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -69,7 +69,7 @@
   <OS>CNL</OS>
   <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
   <SUPPORTED_BY>e3sm</SUPPORTED_BY>
-  <GMAKE_J>8</GMAKE_J>
+  <GMAKE_J>3</GMAKE_J>
   <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
   <MAX_MPITASKS_PER_NODE>24</MAX_MPITASKS_PER_NODE>
   <PROJECT>acme</PROJECT>
@@ -130,7 +130,7 @@
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.12</command>
       <command name="rm">cray-mpich</command>
-      <command name="load">pe_archive</command>
+      <command name="load">pe_archive/append-path</command>
       <command name="load">cray-mpich/7.6.0</command>
     </modules>
 
@@ -287,6 +287,7 @@
       <command name="load">pmi/5.0.13</command>
 
       <command name="rm">cray-mpich</command>
+      <command name="load">pe_archive/append-path</command>
       <command name="load">cray-mpich/7.6.2</command>
     </modules>
 
@@ -299,7 +300,7 @@
     <modules compiler="gnu">
       <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
-      <command name="load">pe_archive</command>
+      <command name="load">pe_archive/append-path</command>
       <command name="load">gcc/6.3.0</command>
       <command name="rm">cray-libsci</command>
       <command name="load">cray-libsci/17.09.1</command>
@@ -428,6 +429,7 @@
     </modules>
 
     <modules mpilib="mpt">
+      <command name="load">pe_archive/append-path</command>
       <command name="swap">cray-mpich cray-mpich/7.6.2</command>
     </modules>
 
@@ -444,7 +446,7 @@
     <modules compiler="gnu">
       <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
-      <command name="load">pe_archive</command>
+      <command name="load">pe_archive/append-path</command>
       <command name="load">gcc/6.3.0</command>
       <command name="rm">cray-libsci</command>
       <command name="load">cray-libsci/17.09.1</command>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -69,7 +69,7 @@
   <OS>CNL</OS>
   <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
   <SUPPORTED_BY>e3sm</SUPPORTED_BY>
-  <GMAKE_J>3</GMAKE_J>
+  <GMAKE_J>8</GMAKE_J>
   <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
   <MAX_MPITASKS_PER_NODE>24</MAX_MPITASKS_PER_NODE>
   <PROJECT>acme</PROJECT>
@@ -130,7 +130,7 @@
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.12</command>
       <command name="rm">cray-mpich</command>
-      <command name="load">pe_archive/append-path</command>
+      <command name="load">pe_archive</command>
       <command name="load">cray-mpich/7.6.0</command>
     </modules>
 
@@ -287,7 +287,6 @@
       <command name="load">pmi/5.0.13</command>
 
       <command name="rm">cray-mpich</command>
-      <command name="load">pe_archive/append-path</command>
       <command name="load">cray-mpich/7.6.2</command>
     </modules>
 
@@ -300,7 +299,7 @@
     <modules compiler="gnu">
       <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
-      <command name="load">pe_archive/append-path</command>
+      <command name="load">pe_archive</command>
       <command name="load">gcc/6.3.0</command>
       <command name="rm">cray-libsci</command>
       <command name="load">cray-libsci/17.09.1</command>
@@ -429,7 +428,6 @@
     </modules>
 
     <modules mpilib="mpt">
-      <command name="load">pe_archive/append-path</command>
       <command name="swap">cray-mpich cray-mpich/7.6.2</command>
     </modules>
 
@@ -446,7 +444,7 @@
     <modules compiler="gnu">
       <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
-      <command name="load">pe_archive/append-path</command>
+      <command name="load">pe_archive</command>
       <command name="load">gcc/6.3.0</command>
       <command name="rm">cray-libsci</command>
       <command name="load">cray-libsci/17.09.1</command>

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -167,7 +167,7 @@
       <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
-      <value compset="2010_" grid="a%ne120np4.*_oi%oRRS18to6v3"	>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_HighResMIP_E3SM_0.25x0.25_2010_clim_c20190125.nc</value>
+      <value compset="2010_" grid="a%ne120np4.*_oi%oRRS18to6v3"	>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_HighResMIP_E3SM_0.25x0.25_2010_clim_c20190125_intoisst.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -167,7 +167,7 @@
       <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
-      <value compset="2010_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_1950_clim_c20180910.nc</value>
+      <value compset="2010_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_HighResMIP_E3SM_0.25x0.25_2010_clim_c20190125.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -167,6 +167,7 @@
       <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
+      <value compset="2010_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_1950_clim_c20180910.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -167,7 +167,7 @@
       <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
-      <value compset="2010_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_HighResMIP_E3SM_0.25x0.25_2010_clim_c20190125.nc</value>
+      <value compset="2010_" grid="a%ne120np4.*_oi%oRRS18to6v3"	>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_HighResMIP_E3SM_0.25x0.25_2010_clim_c20190125.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>
@@ -205,6 +205,7 @@
       <value compset="1850" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"				>$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
       <value compset="1850" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
       <value compset="1850" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
+      <value compset="2010_" grid="a%ne120np4.*_oi%oRRS18to6v3"	>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.0.25x0.25.c20190221.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"                                         >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF"                                         >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7"                  >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.4x5_gx3v7_100120.nc</value>

--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -600,6 +600,7 @@
       <value compset="^2000.+AV1C-H01C"				>368.865</value>
       <value compset="^1850.+CMIP6"                             >284.317</value>
       <value compset="^1950.+CMIP6"                             >312.821</value>
+      <value compset="^2010.+CMIP6"                             >388.717</value>
       <!-- Override values based on CAM (WACCM) chemistry -->
       <value compset="CAM[45]%W"				>0.000001</value>
       <value compset="CAM[45]%SSOA"				>0.000001</value>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -5,7 +5,7 @@
 <cosp_lite>.true.</cosp_lite>
 
 <!-- Atmosphere initial condition -->
-<ncdata>atm/cam/inic/homme/cori-knl.20190214_maint-1.0.F2010C5-CMIP6-HR.ARE.nudgeUV.ne120_oRRS18v3.cam.i.2011-01-01-00000.nc</ncdata>
+<ncdata>atm/cam/inic/homme/cori-knl.20190214_maint-1.0.F2010-CMIP6-HR.noCNT.ARE.nudgeUV.ne120_oRRS18v3.cam.i.2011-01-01-00000.nc</ncdata>
 
 <!-- Solar constant from CMIP6 input4MIPS -->
 <solar_data_file>atm/cam/solar/Solar_2010control_input4MIPS_c20181017.nc</solar_data_file>
@@ -112,28 +112,28 @@
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type         >CYCLICAL</ext_frc_type>
 <ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_elev_2010-2014_c181121.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_soag_elev_2010-2014_c181121.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_elev_2010-2014_c181121.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_elev_2010-2014_c181121.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_elev_2010-2014_c181121.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_elev_2010-2014_c181121.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_elev_2010-2014_c181121.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_elev_2010-2014_c181121.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_elev_2010-2014_c181121.nc </so4_a2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_elev_2010-2014_c190326.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_soag_elev_2010-2014_c190326.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_elev_2010-2014_c190326.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_elev_2010-2014_c190326.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_elev_2010-2014_c190326.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_elev_2010-2014_c190326.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_elev_2010-2014_c190326.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_elev_2010-2014_c190326.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_elev_2010-2014_c190326.nc </so4_a2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type        >CYCLICAL</srf_emis_type>
 <srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
 <dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_surf_2010-2014_c181121.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_surf_2010-2014_c181121.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_surf_2010-2014_c181121.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_surf_2010-2014_c181121.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_surf_2010-2014_c181121.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_surf_2010-2014_c181121.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_surf_2010-2014_c181121.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_surf_2010-2014_c181121.nc </so4_a2_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_surf_2010-2014_c190326.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_surf_2010-2014_c190326.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_surf_2010-2014_c190326.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_surf_2010-2014_c190326.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_surf_2010-2014_c190326.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_surf_2010-2014_c190326.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_surf_2010-2014_c190326.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_surf_2010-2014_c190326.nc </so4_a2_emis_file>
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -137,7 +137,7 @@
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
-<tracer_cnst_cycle_yr>1955</tracer_cnst_cycle_yr>
+<tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr>
 <tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
@@ -162,7 +162,7 @@
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
 <!-- sim_year used for CLM datasets and SSTs forcings -->
-<sim_year>1955</sim_year>
+<sim_year>2015</sim_year>
 
 <!-- land datasets -->
 <!-- Set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -8,8 +8,8 @@
 <ncdata>atm/cam/inic/homme/20180716.DECKv1b_A3.ne30_oEC.edison.cam.i.2010-01-01-00000_c20190219.nc</ncdata>
 
 <!-- Solar constant from CMIP6 input4MIPS -->
-<solar_data_file>atm/cam/solar/Solar_1950control_input4MIPS_c20171208.nc</solar_data_file>
-<solar_data_ymd>19500101</solar_data_ymd>
+<solar_data_file>atm/cam/solar/Solar_2010control_input4MIPS_c20181017.nc</solar_data_file>
+<solar_data_ymd>20100101</solar_data_ymd>
 <solar_data_type>FIXED</solar_data_type>
 
 <!-- 1850 GHG values from CMIP6 input4MIPS -->

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -5,7 +5,7 @@
 <cosp_lite>.true.</cosp_lite>
 
 <!-- Atmosphere initial condition -->
-<ncdata>atm/cam/inic/homme/20180716.DECKv1b_A3.ne30_oEC.edison.cam.i.2010-01-01-00000_c20190219.nc</ncdata>
+<ncdata>atm/cam/inic/homme/20180716.DECKv1b_A3.ne30_oEC_to_ne120_oRRS18v3.edison.cam.i.2010-01-01-00000_c20190219.nc</ncdata>
 
 <!-- Solar constant from CMIP6 input4MIPS -->
 <solar_data_file>atm/cam/solar/Solar_2010control_input4MIPS_c20181017.nc</solar_data_file>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -12,12 +12,12 @@
 <solar_data_ymd>20100101</solar_data_ymd>
 <solar_data_type>FIXED</solar_data_type>
 
-<!-- 1850 GHG values from CMIP6 input4MIPS -->
+<!-- 2010 GHG values from CMIP6 input4MIPS -->
 <!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in cime/src/drivers/mct/cime_config/config_component_acme.xml -->
-<ch4vmr>1163.821e-9</ch4vmr>
-<n2ovmr>289.739e-9</n2ovmr>
-<f11vmr>62.83147e-12</f11vmr>
-<f12vmr>6.382257e-12</f12vmr>
+<ch4vmr>1807.851e-9</ch4vmr>
+<n2ovmr>323.141e-9</n2ovmr>
+<f11vmr>768.7644e-12</f11vmr>
+<f12vmr>531.2820e-12</f12vmr>
 
 <!-- Stratospheric aerosols from CMIP6 input4MIPS -->
 <prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -104,8 +104,7 @@
 <cld_macmic_num_steps>3</cld_macmic_num_steps>
 
 <!-- Energy fixer options -->
-<l_ieflx_fix> .true.</l_ieflx_fix>
-<ieflx_opt  > 2     </ieflx_opt>
+<ieflx_opt  > 0     </ieflx_opt>
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type         >CYCLICAL</ext_frc_type>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_1950control_input4MIPS_c20171208.nc</solar_data_file>
+<solar_data_ymd>19500101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 1850 GHG values from CMIP6 input4MIPS -->
+<!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in cime/src/drivers/mct/cime_config/config_component_acme.xml -->
+<ch4vmr>1163.821e-9</ch4vmr>
+<n2ovmr>289.739e-9</n2ovmr>
+<f11vmr>62.83147e-12</f11vmr>
+<f12vmr>6.382257e-12</f12vmr>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
+<prescribed_volcaero_file    >CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file    >
+<prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
+<prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
+<prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc    >.true.</use_hetfrz_classnuc>
+<use_preexisting_ice    >.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep      >.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning            >.true.</sscav_tuning>
+<convproc_do_aer         >.true.</convproc_do_aer>
+<convproc_do_gas         >.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc          >.true.</demott_ice_nuc>
+<liqcf_fix               >.true.</liqcf_fix>
+<regen_fix               >.true.</regen_fix>
+<resus_fix               >.true.</resus_fix>
+<mam_amicphys_optaa      >1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning    >.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg       >.true.</history_amwg>
+<history_aerosol    >.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<clubb_ice_deep>     12.e-6 </clubb_ice_deep>
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
+<clubb_liq_sh>       10.e-6 </clubb_liq_sh>
+<clubb_C2rt>         1.75D0 </clubb_C2rt>
+<effgw_oro>          0.25    </effgw_oro>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<dust_emis_fact>     2.5D0 </dust_emis_fact>
+<clubb_gamma_coef>   0.32   </clubb_gamma_coef>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<clubb_c_K10>        0.3    </clubb_c_K10>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<so4_sz_thresh_icenuc>0.05e-6</so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add       >0.8D0</zmconv_tiedke_add>
+<zmconv_cape_cin         >1</zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   >2</zmconv_mx_bot_lyr_adj>
+<taubgnd                 >2.5D-3 </taubgnd>
+<clubb_C1                >1.5</clubb_C1>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<se_ftype                >2</se_ftype>
+<relvar_fix              >.true.</relvar_fix>
+<mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+
+<!-- Parameters further tuned for ne120 L72 configuration based on AV1C-04P2 -->
+
+<zmconv_alfa         >0.2D0</zmconv_alfa>
+<zmconv_c0_lnd       >0.0035D0</zmconv_c0_lnd>
+<zmconv_c0_ocn       >0.0043D0</zmconv_c0_ocn>
+<zmconv_dmpdz        >-0.2e-3</zmconv_dmpdz>
+<zmconv_ke           >6.0E-6</zmconv_ke>
+<cldfrc_dp1          >0.039D0</cldfrc_dp1>
+<clubb_C8            >4.73D0</clubb_C8>
+<clubb_C14           >1.75D0</clubb_C14>
+<se_nsplit           >6</se_nsplit>
+<rsplit              >2</rsplit>
+<qsplit              >1</qsplit>
+<cld_macmic_num_steps>3</cld_macmic_num_steps>
+
+<!-- Energy fixer options -->
+<l_ieflx_fix> .true.</l_ieflx_fix>
+<ieflx_opt  > 2     </ieflx_opt>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<ext_frc_type         >CYCLICAL</ext_frc_type>
+<ext_frc_cycle_yr     >1950</ext_frc_cycle_yr>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_elev_1950-1960_c180203.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_soag_elev_1950-1960_c171020.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_elev_1950-1960_c180203.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_elev_1950-1960_c180203.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_elev_1950-1960_c180203.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_elev_1950-1960_c180203.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_elev_1950-1960_c180203.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_elev_1950-1960_c180203.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_elev_1950-1960_c180203.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type        >CYCLICAL</srf_emis_type>
+<srf_emis_cycle_yr    >1950</srf_emis_cycle_yr>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1950.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20171210.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_surf_1950-1960_c180203.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_surf_1950-1960_c180203.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_surf_1950-1960_c180203.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_surf_1950-1960_c180203.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_surf_1950-1960_c180203.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_surf_1950-1960_c180203.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_surf_1950-1960_c180203.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_surf_1950-1960_c180203.nc </so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr>1955</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >19500101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >1950</linoz_data_cycle_yr>
+<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1955</sim_year>
+
+<!-- land datasets -->
+<!-- Set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+
+
+</namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -4,6 +4,9 @@
 <!-- Set default output options for CMIP6 simulations -->
 <cosp_lite>.true.</cosp_lite>
 
+<!-- Atmosphere initial condition -->
+<ncdata>atm/cam/inic/homme/20180716.DECKv1b_A3.ne30_oEC.edison.cam.i.2010-01-01-00000_c20190219.nc</ncdata>
+
 <!-- Solar constant from CMIP6 input4MIPS -->
 <solar_data_file>atm/cam/solar/Solar_1950control_input4MIPS_c20171208.nc</solar_data_file>
 <solar_data_ymd>19500101</solar_data_ymd>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -5,7 +5,7 @@
 <cosp_lite>.true.</cosp_lite>
 
 <!-- Atmosphere initial condition -->
-<ncdata>atm/cam/inic/homme/20180716.DECKv1b_A3.ne30_oEC_to_ne120_oRRS18v3.edison.cam.i.2010-01-01-00000_c20190219.nc</ncdata>
+<ncdata>atm/cam/inic/homme/cori-knl.20190214_maint-1.0.F2010C5-CMIP6-HR.ARE.nudgeUV.ne120_oRRS18v3.cam.i.2011-01-01-00000.nc</ncdata>
 
 <!-- Solar constant from CMIP6 input4MIPS -->
 <solar_data_file>atm/cam/solar/Solar_2010control_input4MIPS_c20181017.nc</solar_data_file>
@@ -27,7 +27,7 @@
 <prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
 
 <!-- Ice nucleation mods-->
-<use_hetfrz_classnuc    >.true.</use_hetfrz_classnuc>
+<use_hetfrz_classnuc    >.false.</use_hetfrz_classnuc>
 <use_preexisting_ice    >.false.</use_preexisting_ice>
 <hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
 <micro_mg_dcs_tdep      >.true.</micro_mg_dcs_tdep>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -111,29 +111,29 @@
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type         >CYCLICAL</ext_frc_type>
-<ext_frc_cycle_yr     >1950</ext_frc_cycle_yr>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_elev_1950-1960_c180203.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_soag_elev_1950-1960_c171020.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_elev_1950-1960_c180203.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_elev_1950-1960_c180203.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_elev_1950-1960_c180203.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_elev_1950-1960_c180203.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_elev_1950-1960_c180203.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_elev_1950-1960_c180203.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_elev_1950-1960_c180203.nc </so4_a2_ext_file>
+<ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_elev_2010-2014_c181121.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_soag_elev_2010-2014_c181121.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_elev_2010-2014_c181121.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_elev_2010-2014_c181121.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_elev_2010-2014_c181121.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_elev_2010-2014_c181121.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_elev_2010-2014_c181121.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_elev_2010-2014_c181121.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_elev_2010-2014_c181121.nc </so4_a2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type        >CYCLICAL</srf_emis_type>
-<srf_emis_cycle_yr    >1950</srf_emis_cycle_yr>
+<srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
 <dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1950.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20171210.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_surf_1950-1960_c180203.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_surf_1950-1960_c180203.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_surf_1950-1960_c180203.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_surf_1950-1960_c180203.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_surf_1950-1960_c180203.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_surf_1950-1960_c180203.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_surf_1950-1960_c180203.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_surf_1950-1960_c180203.nc </so4_a2_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_surf_2010-2014_c181121.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_surf_2010-2014_c181121.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_surf_2010-2014_c181121.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_surf_2010-2014_c181121.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_surf_2010-2014_c181121.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_surf_2010-2014_c181121.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_surf_2010-2014_c181121.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_surf_2010-2014_c181121.nc </so4_a2_emis_file>
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -154,9 +154,9 @@
 
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
-<chlorine_loading_fixed_ymd >19500101</chlorine_loading_fixed_ymd>
+<chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
-<linoz_data_cycle_yr        >1950</linoz_data_cycle_yr>
+<linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
 <linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -125,7 +125,7 @@
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type        >CYCLICAL</srf_emis_type>
 <srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
-<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1950.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20171210.nc</dms_emis_file>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
 <so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_surf_2010-2014_c181121.nc </so2_emis_file>
 <bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_surf_2010-2014_c181121.nc </bc_a4_emis_file>
 <mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_surf_2010-2014_c181121.nc </mam7_num_a1_emis_file> 

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -61,6 +61,7 @@
       <value compset="_CAM5%CMIP6-LR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6-LRtunedHR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="1950_CAM5%CMIP6-[LH]R"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -cppdefs -DAPPLY_POST_DECK_BUGFIXES -nlev 72</value>
+      <value compset="2010_CAM5%CMIP6-[LH]R"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -cppdefs -DAPPLY_POST_DECK_BUGFIXES -nlev 72</value>
       <value compset="_CAM5%AV1F"     >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1F-00"  >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1F-01"  >-clubb_sgs -microphys mg2 -chem trop_mam4_resus_soag -rain_evap_to_coarse_aero -nlev 72</value>
@@ -200,6 +201,7 @@
       <value compset="20TR_CAM5.*AV1C-H01B">20TR_cam5_av1c-h01b</value>
       <value compset="20TR_CAM5.*AV1C-H01C">20TR_cam5_av1c-h01c</value>
       <value compset="20TR_CAM5.*CMIP6"  >20TR_cam5_CMIP6</value>
+      <value compset="2010_CAM5.*CMIP6-HR"  >2010_cam5_CMIP6-HR</value>
       <value compset="20TR_CAM5.*CMIP6*_BGC%B"  >20TR_cam5_CMIP6_bgc</value>
       <value compset="2000_CAM5%COSP"   >2000_cam5_cosp</value>
       <value compset="2000_CAM4%WCMX"   >waccmx_2000_cam4</value>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -192,6 +192,11 @@
   </compset>
 
   <compset>
+    <alias>F2010C5-CMIP6-HR</alias>
+    <lname>2010_CAM5%CMIP6-HR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>FC5ATMMODCOSP</alias>
     <lname>2000_CAM5%ATMMODCOSP_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc>Conditions to simulate 1950 land-use</use_case_desc>
+
+<sim_year>1955</sim_year>
+
+<sim_year_range>constant</sim_year_range>
+
+<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_last_ndep>
+
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_last_pdep>
+
+<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_last_popdens>
+
+<!-- CMIP6 HighResMIP compsets -->
+<fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr1950_c20180108.nc </fsurdat>
+<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/clmi.A_WCYCL1950.ne120np4_oRRS18to6v3_ICG_simyr1950_c20180124.nc </finidat>
+
+</namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -20,5 +20,6 @@
 <!-- CMIP6 HighResMIP compsets -->
 <fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc </fsurdat>
 <finidat hgrid="ne120np4" >lnd/clm2/initdata_map/cori-knl.20190214_maint-1.0.F2010-CMIP6-HR.noCNT.ARE.nudgeUV.ne120_oRRS18v3.clm2.r.2011-01-01-00000.nc </finidat>
+<check_finidat_pct_consistency>.false.</check_finidat_pct_consistency>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -19,6 +19,6 @@
 
 <!-- CMIP6 HighResMIP compsets -->
 <fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc </fsurdat>
-<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/cori-knl.20190214_maint-1.0.F2010C5-CMIP6-HR.ARE.nudgeUV.ne120_oRRS18v3.clm2.r.2011-01-01-00000.nc </finidat>
+<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/cori-knl.20190214_maint-1.0.F2010-CMIP6-HR.noCNT.ARE.nudgeUV.ne120_oRRS18v3.clm2.r.2011-01-01-00000.nc </finidat>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -4,21 +4,21 @@
 
 <use_case_desc>Conditions to simulate 2010 land-use</use_case_desc>
 
-<sim_year>2015</sim_year>
+<sim_year>2010</sim_year>
 
 <sim_year_range>constant</sim_year_range>
 
-<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_last_ndep>
 
-<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_pdep>
-<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_pdep>
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_last_pdep>
 
-<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_popdens>
+<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_last_popdens>
 
 <!-- CMIP6 HighResMIP compsets -->
 <fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc </fsurdat>
-<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC.edison.clm2.r.2010-01-01-00000_c20190219.nc </finidat>
+<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC_to_ne120np4_oRRS18v3.edison.clm2.r.2010-01-01-00000_c20190219.nc </finidat>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -19,6 +19,6 @@
 
 <!-- CMIP6 HighResMIP compsets -->
 <fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc </fsurdat>
-<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC_to_ne120_oRRS18v3.edison.clm2.r.2010-01-01-00000_c20190219.nc </finidat>
+<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/cori-knl.20190214_maint-1.0.F2010C5-CMIP6-HR.ARE.nudgeUV.ne120_oRRS18v3.clm2.r.2011-01-01-00000.nc </finidat>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -19,6 +19,6 @@
 
 <!-- CMIP6 HighResMIP compsets -->
 <fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc </fsurdat>
-<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC_to_ne120np4_oRRS18v3.edison.clm2.r.2010-01-01-00000_c20190219.nc </finidat>
+<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC_to_ne120_oRRS18v3.edison.clm2.r.2010-01-01-00000_c20190219.nc </finidat>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -2,23 +2,23 @@
 
 <namelist_defaults>
 
-<use_case_desc>Conditions to simulate 1950 land-use</use_case_desc>
+<use_case_desc>Conditions to simulate 2010 land-use</use_case_desc>
 
-<sim_year>1955</sim_year>
+<sim_year>2015</sim_year>
 
 <sim_year_range>constant</sim_year_range>
 
-<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_ndep>
 
-<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_first_pdep>
-<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_last_pdep>
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_pdep>
 
-<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_last_popdens>
+<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_popdens>
 
 <!-- CMIP6 HighResMIP compsets -->
-<fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr1950_c20180108.nc </fsurdat>
-<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/clmi.A_WCYCL1950.ne120np4_oRRS18to6v3_ICG_simyr1950_c20180124.nc </finidat>
+<fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc </fsurdat>
+<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC.edison.clm2.r.2010-01-01-00000_c20190219.nc </finidat>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -4,18 +4,18 @@
 
 <use_case_desc>Conditions to simulate 2010 land-use</use_case_desc>
 
-<sim_year>2010</sim_year>
+<sim_year>2015</sim_year>
 
 <sim_year_range>constant</sim_year_range>
 
-<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_ndep>
 
-<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_first_pdep>
-<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_last_pdep>
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_pdep>
 
-<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2010</stream_year_last_popdens>
+<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_popdens>
 
 <!-- CMIP6 HighResMIP compsets -->
 <fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc </fsurdat>

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -25,6 +25,7 @@
       <value compset="_CLM50"                >-phys clm5_0</value>
       <value compset="_CLM45%[^_]*BC" >-phys clm4_5 -cppdefs -DMODAL_AER</value>
       <value compset="1950_CAM5%CMIP6-[LH]R[^_]*_CLM45%[^_]*BC"                >-phys clm4_5 -cppdefs '-DMODAL_AER -DAPPLY_POST_DECK_BUGFIXES'</value>
+      <value compset="2010_CAM5%CMIP6-[LH]R[^_]*_CLM45%[^_]*BC"                >-phys clm4_5 -cppdefs '-DMODAL_AER -DAPPLY_POST_DECK_BUGFIXES'</value>
     </values>
     <group>build_component_clm</group>
     <file>env_build.xml</file>
@@ -79,6 +80,7 @@
       <value compset="1950_CAM5%CMIP6.*_CLM">1950_CMIP6_control</value>
       <value compset="1950_CAM5%CMIP6-LR*_CLM">1950_CMIP6LR_control</value>
       <value compset="1950_CAM5%CMIP6-HR_CLM">1950_CMIP6HR_control</value>
+      <value compset="2010_CAM5%CMIP6-HR_CLM">2010_CMIP6HR_control</value>
     </values>
     <group>run_component_clm</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
This PR created the F2010 HR compset with CMIP6 forcings. The compset name is F2010C5-CMIP6-HR.

- It uses daily 0.25 degree sst_seaice data.
- atm and lnd initial conditions from an ne120 nudging simulation
- Classical Nucleation Theory (CNT) for ice deposition growth is turned off
- Include atm and lnd use_case files specifically for this compset

[BFB] for existing compsets.

Following is retained here for record but not included in commit message.

This is the ne120 F2010 compset based on the F1950 compset. The provenance is documented on confluence page: [F2010C5-CMIP6-HR](https://acme-climate.atlassian.net/wiki/spaces/ED/pages/925631509/F2010C5-CMIP6-HR). All the new input files are uploaded to the E3SM input data server (https://web.lcrc.anl.gov/public/e3sm/inputdata/)

I haven't done the test run yet, as there are a few issues that should be discussed. In particular,
- Do we need to create a new ocean domain file for the data ocean? The old domain file is for 1x1 degree grid, which is probably not compatible with the new 0.25x0.25 degree SST & sea ice file.
- I am not sure if the land surface file (surfdata_ne120np4_simyr2010_c20181023.nc) is correct. The procedure of creating this file is documented in Section 7 "Generate land surface data (fsurdat)" of [this page](https://acme-climate.atlassian.net/wiki/spaces/ED/pages/872579110/Adding+support+for+new+atmosphere+resolutions).
- The variables in many 2010 MAM4 emission files are different from the ones used in F1950 compset. For example, The 2010 file cmip6_mam4_soag_elev_2010-2014_c181121.nc has the variable "ALL", which is the sum of many sources, while the 1950 file cmip6_mam4_soag_elev_1950-1960_c171020.nc contains variables (SOAff_src, SOAbb_src, SOAbg_src) for different sources. Will this difference fail the model?

I am still new to this compset creation business and probably missed some settings that should be changed from 1950 to 2010...