### PR TITLE
Add ocean active tracer fluxes to analysis terms

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -866,6 +866,8 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var name="velocityMeridionalSquared"/>')
         lines.append('    <var name="velocityZonalTimesTemperature"/>')
         lines.append('    <var name="velocityMeridionalTimesTemperature"/>')
+        lines.append('    <var_array name="activeTracerVerticalAdvectionTopFlux"/>')
+        lines.append('    <var_array name="activeTracerHorizontalAdvectionEdgeFlux"/>')
         if ocn_iceberg == 'true':
             lines.append('    <var name="icebergHeatFlux"/>')
             lines.append('    <var name="icebergFreshWaterFlux"/>')


### PR DESCRIPTION
This PR adds variables within tracer_advection_mono to capture the edge based fluxes of temperature and salinity to fully close the heat and salinity budgets regionally.

bfb