### PR TITLE
for add-inundation soil erosion model

### DIFF
--- a/cime/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/datm/cime_config/config_component.xml
@@ -10,13 +10,14 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSW][%GSWP3v1][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSW][%GSWP3v1][%NLDAS][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
     <desc option="CRUv7"> CLM CRU NCEP v7 data set </desc>
     <desc option="GSW"> GSWP3 data set </desc>
     <desc option="GSWP3v1"> GSWP3v1 data set </desc>
+    <desc option="NLDAS"> NLDAS data set </desc>
     <desc option="CPLHIST"> Coupler hist data set (in this mode, it is strongly recommended that the model domain and the coupler history forcing are on the same domain)</desc>
     <desc option="1PT">single point tower site data set </desc>
     <desc option="NYF">COREv2 normal year forcing</desc>
@@ -35,13 +36,13 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CPLHIST,CORE_IAF_JRA</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMNLDAS,CPLHIST,CORE_IAF_JRA</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
     <desc>Mode for data atmosphere component.
       CORE2_NYF (CORE2 normal year forcing) are modes used in forcing prognostic ocean/sea-ice components.
-      CLM_QIAN, CLMCRUNCEP, CLMCRUNCEPv7, CLMGSWP3v1 and CLM1PT are modes using observational data for forcing prognostic land components.</desc>
+      CLM_QIAN, CLMCRUNCEP, CLMCRUNCEPv7, CLMGSWP3v1, CLMNLDAS and CLM1PT are modes using observational data for forcing prognostic land components.</desc>
     <values match="last">
       <value compset="%NYF">CORE2_NYF</value>
       <value compset="%IAF">CORE2_IAF</value>
@@ -51,6 +52,7 @@
       <value compset="%CRU">CLMCRUNCEP</value>
       <value compset="%CRUv7">CLMCRUNCEPv7</value>
       <value compset="%GSWP3v1">CLMGSWP3v1</value>
+      <value compset="%NLDAS">CLMNLDAS</value>
       <value compset="%1PT">CLM1PT</value>
       <value compset="%CPLHIST">CPLHIST</value>
     </values>

--- a/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -36,6 +36,7 @@
     CLMCRUNCEP		= Run with the CLM CRU NCEP V4 ( default ) forcing valid from 1900 to 2010 (force CLM)
     CLMCRUNCEPv7 	= Run with the CLM CRU NCEP V7 forcing valid from 1900 to 2010 (force CLM)
     CLMGSWP3v1		= Run with the CLM GSWP3 V1 forcing (force CLM)
+    CLMNLDAS        = Run with the CLM NLDAS data (force CLM)
     CLM1PT		= Run with supplied single point data (force CLM)
     CORE2_NYF		= CORE2 normal year forcing (for forcing POP and CICE)
     CORE2_IAF		= CORE2 intra-annual year forcing (for forcing POP and CICE)
@@ -95,6 +96,8 @@
     CLMGSWP3v1.Solar
     CLMGSWP3v1.Precip
     CLMGSWP3v1.TPQW
+
+    CLMNLDAS
 
     co2tseries.20tr
     co2tseries.rcp2.6
@@ -169,6 +172,7 @@
       <value datm_mode="CLMCRUNCEP$">CLMCRUNCEP.Solar,CLMCRUNCEP.Precip,CLMCRUNCEP.TPQW</value>
       <value datm_mode="CLMCRUNCEPv7">CLMCRUNCEPv7.Solar,CLMCRUNCEPv7.Precip,CLMCRUNCEPv7.TPQW</value>
       <value datm_mode="CLMGSWP3v1">CLMGSWP3v1.Solar,CLMGSWP3v1.Precip,CLMGSWP3v1.TPQW</value>
+      <value datm_mode="CLMNLDAS">CLMNLDAS</value>
       <value datm_mode="CORE2_NYF" >CORE2_NYF.GISS,CORE2_NYF.GXGXS,CORE2_NYF.NCEP</value>
       <value datm_mode="CORE2_IAF" >CORE2_IAF.GCGCS.PREC,CORE2_IAF.GISS.LWDN,CORE2_IAF.GISS.SWDN,CORE2_IAF.GISS.SWUP,CORE2_IAF.NCEP.DN10,CORE2_IAF.NCEP.Q_10,CORE2_IAF.NCEP.SLP_,CORE2_IAF.NCEP.T_10,CORE2_IAF.NCEP.U_10,CORE2_IAF.NCEP.V_10,CORE2_IAF.CORE2.ArcFactor</value>
       <value datm_mode="CORE_IAF_JRA" >CORE_IAF_JRA.GCGCS.PREC,CORE_IAF_JRA.GISS.LWDN,CORE_IAF_JRA.GISS.SWDN,CORE_IAF_JRA.NCEP.Q_10,CORE_IAF_JRA.NCEP.SLP_,CORE_IAF_JRA.NCEP.T_10,CORE_IAF_JRA.NCEP.U_10,CORE_IAF_JRA.NCEP.V_10,CORE_IAF_JRA.CORE2.ArcFactor</value>
@@ -194,6 +198,7 @@
       <value stream="CLMCRUNCEP\.">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CLMCRUNCEP_V5">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.V5.c140715</value>
       <value stream="CLMGSWP3">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516</value>
+      <value stream="CLMNLDAS">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CORE2_NYF">$DIN_LOC_ROOT/atm/datm7/NYF</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">$DIN_LOC_ROOT/atm/datm7/CORE2</value>
       <value stream="CORE2_IAF.NCEP.DENS.SOFS">$DIN_LOC_ROOT/share/domains</value>
@@ -258,6 +263,7 @@
       <value stream="CLMCRUNCEP">domain.lnd.360x720.130305.nc</value>
       <value stream="CLMGSWP3v1">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
       <value stream="CLMGSWP3">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
+      <value stream="CLMNLDAS">domain.lnd.nldas2_0224x0464_c110415.nc</value>
       <value stream="CORE2_NYF.GISS">nyf.giss.T62.051007.nc</value>
       <value stream="CORE2_NYF.GXGXS">nyf.gxgxs.T62.051007.nc</value>
       <value stream="CORE2_NYF.NCEP">nyf.ncep.T62.050923.nc</value>
@@ -402,6 +408,7 @@
       <value stream="CLMGSWP3.Solar">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/Solar3Hrly</value>
       <value stream="CLMGSWP3.Precip">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/Precip3Hrly</value>
       <value stream="CLMGSWP3.TPQW">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/TPHWL3Hrly</value>
+      <value stream="CLMNLDAS">$DIN_LOC_ROOT/atm/datm7/NLDAS</value>
       <value stream="CORE2_NYF">$DIN_LOC_ROOT/atm/datm7/NYF</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">$DIN_LOC_ROOT/atm/datm7/CORE2</value>
       <value stream="CORE2_IAF">$DIN_LOC_ROOT/ocn/iaf</value>
@@ -475,6 +482,7 @@
       <value  stream="CLMGSWP3v1.Solar">clmforc.GSWP3.c2011.0.5x0.5.Solr.%ym.nc</value>
       <value  stream="CLMGSWP3v1.Precip">clmforc.GSWP3.c2011.0.5x0.5.Prec.%ym.nc</value>
       <value  stream="CLMGSWP3v1.TPQW">clmforc.GSWP3.c2011.0.5x0.5.TPQWL.%ym.nc</value>
+      <value  stream="CLMNLDAS">clmforc.nldas.%ym.nc</value>
       <value  stream="CORE2_NYF.GISS">nyf.giss.T62.051007.nc</value>
       <value  stream="CORE2_NYF.GXGXS">nyf.gxgxs.T62.051007.nc</value>
       <value  stream="CORE2_NYF.NCEP">nyf.ncep.T62.050923.nc</value>
@@ -1793,6 +1801,15 @@
         PSRF     pbot
         FLDS     lwdn
       </value>
+      <value  stream="CLMNLDAS">
+        TBOT     tbot
+        WIND     wind
+        QBOT     shum
+        PSRF     pbot
+        FLDS     lwdn
+        PRECTmms precn
+        FSDS     swdn
+      </value>
       <value stream="CORE2_NYF.GISS">
         lwdn  lwdn
         swdn  swdn
@@ -2000,6 +2017,7 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_ALIGN</value>
+      <value stream="CLMNLDAS">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1</value>
       <value stream="CORE2_IAF">1</value>
@@ -2035,6 +2053,7 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_START</value>
+      <value stream="CLMNLDAS">$DATM_CLMNCEP_YR_START</value>
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.NCEP.DENS.SOFS">2010</value>
       <value stream="CORE2_IAF.NCEP.PSLV.SOFS">2010</value>
@@ -2096,6 +2115,7 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_END  </value>
+      <value stream="CLMNLDAS">$DATM_CLMNCEP_YR_END</value>
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.NCEP.DENS.SOFS">2011</value>
       <value stream="CORE2_IAF.NCEP.PSLV.SOFS">2011</value>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1714,4 +1714,23 @@ Runtime flag to turn on/off PETSc based thermal model.
 Runtime flag to turn on/off variable soil thickness.
 </entry>
 
+<!-- ========================================================================================  -->
+<!-- Namelist options for soil erosion model                                                   -->
+<!-- ========================================================================================  -->
+
+<entry id="use_erosion" type="logical" category="physics"
+       group="clm_inparm" valid_values="" value=".false.">
+Toggle to turn on the soil erosion model.
+</entry>
+
+<entry id="ero_lndsld" type="logical" category="physics"
+       group="clm_inparm" valid_values="" value=".false.">
+Toggle to turn on the soil erosion landslide model.
+</entry>
+
+<entry id="ero_ccycle" type="logical" category="physics"
+       group="clm_inparm" valid_values="" value=".false.">
+Toggle to turn on the soil erosion and OM pools feedback.
+</entry>
+
 </namelist_definition>

--- a/components/clm/cime_config/config_compsets.xml
+++ b/components/clm/cime_config/config_compsets.xml
@@ -542,6 +542,11 @@
      <lname>20TR_DATM%QIA_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
+   <compset>
+     <alias>IM20TRNLDASCNPECACNTBC</alias>
+     <lname>20TR_DATM%NLDAS_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+   </compset>
+
    <!---I CRUNCEP compsets -->
 
   <compset>

--- a/components/clm/src/biogeochem/CNCStateUpdate3Mod.F90
+++ b/components/clm/src/biogeochem/CNCStateUpdate3Mod.F90
@@ -10,8 +10,10 @@ module CNCStateUpdate3Mod
   use abortutils       , only : endrun
   use clm_time_manager , only : get_step_size
   use clm_varpar       , only : nlevdecomp, ndecomp_pools, i_cwd, i_met_lit, i_cel_lit, i_lig_lit
+  use clm_varctl       , only : use_erosion, ero_ccycle
   use CNCarbonStateType, only : carbonstate_type
   use CNCarbonFluxType , only : carbonflux_type
+  use CNDecompCascadeConType , only : decomp_cascade_con
   ! bgc interface & pflotran:
   use clm_varctl       , only : use_pflotran, pf_cmode
   !
@@ -31,7 +33,7 @@ contains
     !
     ! !DESCRIPTION:
     ! On the radiation time step, update all the prognostic carbon state
-    ! variables affected by fire fluxes
+    ! variables affected by fire fluxes and also erosion fluxes
     !
     use tracer_varcon       , only : is_active_betr_bgc
     use subgridAveMod       , only : p2c        
@@ -85,6 +87,19 @@ contains
          end do
       endif !
 
+      ! SOM C losses due to erosion
+      if ( use_erosion .and. ero_ccycle ) then 
+         do l = 1, ndecomp_pools
+            if ( decomp_cascade_con%is_soil(l) ) then
+               do j = 1, nlevdecomp
+                  do fc = 1, num_soilc
+                     c = filter_soilc(fc)
+                     cs%decomp_cpools_vr_col(c,j,l) = cs%decomp_cpools_vr_col(c,j,l) - cf%decomp_cpools_yield_vr_col(c,j,l) * dt
+                  end do
+               end do
+            end if
+         end do
+      end if
 
       ! patch loop
       do fp = 1,num_soilp

--- a/components/clm/src/biogeochem/CNCarbonFluxType.F90
+++ b/components/clm/src/biogeochem/CNCarbonFluxType.F90
@@ -16,6 +16,7 @@ module CNCarbonFluxType
   use ColumnType             , only : col_pp                
   use LandunitType           , only : lun_pp
   use clm_varctl             , only : nu_com
+  use clm_varctl             , only : use_erosion
   ! bgc interface & pflotran
   use clm_varctl             , only : use_clm_interface, use_pflotran, pf_cmode, use_vertsoilc
   ! 
@@ -331,6 +332,15 @@ module CNCarbonFluxType
      real(r8), pointer :: som_c_leached_col                         (:)     ! total SOM C loss from vertical transport (gC/m^2/s)
      real(r8), pointer :: decomp_cpools_leached_col                 (:,:)   ! C loss from vertical transport from each decomposing C pool (gC/m^2/s)
      real(r8), pointer :: decomp_cpools_transport_tendency_col      (:,:,:) ! C tendency due to vertical transport in decomposing C pools (gC/m^3/s)
+
+     ! column-level soil erosion fluxes
+     real(r8), pointer :: somc_erode_col                            (:)     ! total SOM C detachment (gC/m^2/s)
+     real(r8), pointer :: somc_deposit_col                          (:)     ! total SOM C hillslope redeposition (gC/m^2/s)
+     real(r8), pointer :: somc_yield_col                            (:)     ! total SOM C loss (gC/m^2/s)
+     real(r8), pointer :: decomp_cpools_erode_col                   (:,:)   ! vertically-integrated decomposing C detachment (gC/m^2/s)
+     real(r8), pointer :: decomp_cpools_deposit_col                 (:,:)   ! vertically-integrated decomposing C hillslope redeposition (gC/m^2/s)
+     real(r8), pointer :: decomp_cpools_yield_col                   (:,:)   ! vertically-integrated decomposing C loss (gC/m^2/s)
+     real(r8), pointer :: decomp_cpools_yield_vr_col                (:,:,:) ! vertically-resolved decomposing C loss (gC/m^3/s)
 
      ! nitrif_denitrif
      real(r8), pointer :: phr_vr_col                                (:,:)   ! potential hr (not N-limited) (gC/m3/s)
@@ -716,6 +726,9 @@ contains
      allocate(this%dwt_prod100c_gain_col             (begc:endc))                  ; this%dwt_prod100c_gain_col     (:)  =nan
      allocate(this%som_c_leached_col                 (begc:endc))                  ; this%som_c_leached_col         (:)  =nan
      allocate(this%somc_fire_col                     (begc:endc))                  ; this%somc_fire_col             (:)  =nan
+     allocate(this%somc_erode_col                    (begc:endc))                  ; this%somc_erode_col            (:)  =nan
+     allocate(this%somc_deposit_col                  (begc:endc))                  ; this%somc_deposit_col          (:)  =nan
+     allocate(this%somc_yield_col                    (begc:endc))                  ; this%somc_yield_col            (:)  =nan
      allocate(this%landuseflux_col                   (begc:endc))                  ; this%landuseflux_col           (:)  =nan
      allocate(this%landuptake_col                    (begc:endc))                  ; this%landuptake_col            (:)  =nan
      allocate(this%prod1c_loss_col                   (begc:endc))                  ; this%prod1c_loss_col           (:)  =nan
@@ -792,6 +805,18 @@ contains
 
      allocate(this%decomp_cpools_transport_tendency_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))          
      this%decomp_cpools_transport_tendency_col(:,:,:)= nan
+
+     allocate(this%decomp_cpools_erode_col(begc:endc,1:ndecomp_pools))
+     this%decomp_cpools_erode_col(:,:)= nan
+
+     allocate(this%decomp_cpools_deposit_col(begc:endc,1:ndecomp_pools))
+     this%decomp_cpools_deposit_col(:,:)= nan
+
+     allocate(this%decomp_cpools_yield_col(begc:endc,1:ndecomp_pools))
+     this%decomp_cpools_yield_col(:,:)= nan
+
+     allocate(this%decomp_cpools_yield_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools))
+     this%decomp_cpools_yield_vr_col(:,:,:) = nan
 
 
      allocate(this%tempsum_npp_patch     (begp:endp)) ; this%tempsum_npp_patch     (:) = nan
@@ -2851,6 +2876,49 @@ contains
             avgflag='A', long_name='C loss due to peat burning', &
             ptr_col=this%somc_fire_col, default='inactive')
 
+       ! Z. Tan
+       this%somc_erode_col(begc:endc) = spval
+       call hist_addfld1d (fname='SOMC_ERO', units='gC/m^2/s', &
+            avgflag='A', long_name='SOC detachment due to erosion', &
+            ptr_col=this%somc_erode_col, default='inactive')       
+
+       this%somc_deposit_col(begc:endc) = spval
+       call hist_addfld1d (fname='SOMC_DEP', units='gC/m^2/s', &
+            avgflag='A', long_name='SOC hillslope redeposition', &
+            ptr_col=this%somc_deposit_col, default='inactive')
+
+       this%somc_yield_col(begc:endc) = spval
+       call hist_addfld1d (fname='SOMC_YLD', units='gC/m^2/s', &
+            avgflag='A', long_name='SOC loss to inland waters', &
+            ptr_col=this%somc_yield_col, default='inactive')
+
+       this%decomp_cpools_erode_col(begc:endc,:) = spval
+       this%decomp_cpools_deposit_col(begc:endc,:) = spval
+       this%decomp_cpools_yield_col(begc:endc,:) = spval
+       do k = 1, ndecomp_pools
+          if ( decomp_cascade_con%is_soil(k) ) then
+             data1dptr => this%decomp_cpools_erode_col(:,k)
+             fieldname = trim(decomp_cascade_con%decomp_pool_name_history(k))//'C_ERO'
+             longname =  trim(decomp_cascade_con%decomp_pool_name_long(k))//' C detachment'
+             call hist_addfld1d (fname=fieldname, units='gC/m^2/s',  &
+                  avgflag='A', long_name=longname, &
+                  ptr_col=data1dptr, default='inactive')
+
+             data1dptr => this%decomp_cpools_deposit_col(:,k)
+             fieldname = trim(decomp_cascade_con%decomp_pool_name_history(k))//'C_DEP'
+             longname =  trim(decomp_cascade_con%decomp_pool_name_long(k))//' C hillslope redeposition'
+             call hist_addfld1d (fname=fieldname, units='gC/m^2/s',  &
+                  avgflag='A', long_name=longname, &
+                  ptr_col=data1dptr, default='inactive')
+
+             data1dptr => this%decomp_cpools_yield_col(:,k)
+             fieldname = trim(decomp_cascade_con%decomp_pool_name_history(k))//'C_YLD'
+             longname =  trim(decomp_cascade_con%decomp_pool_name_long(k))//' C loss to inland waters'
+             call hist_addfld1d (fname=fieldname, units='gC/m^2/s',  &
+                  avgflag='A', long_name=longname, &
+                  ptr_col=data1dptr, default='inactive')
+          endif
+       end do
 
        this%m_decomp_cpools_to_fire_col(begc:endc,:)      = spval
        this%m_decomp_cpools_to_fire_vr_col(begc:endc,:,:) = spval
@@ -4267,6 +4335,7 @@ contains
              i = filter_column(fi)
              this%m_decomp_cpools_to_fire_vr_col(i,j,k) = value_column
              this%decomp_cpools_transport_tendency_col(i,j,k) = value_column
+             this%decomp_cpools_yield_vr_col(i,j,k) = value_column
           end do
        end do
     end do
@@ -4294,6 +4363,9 @@ contains
        do fi = 1,num_column
           i = filter_column(fi)
           this%decomp_cpools_leached_col(i,k) = value_column
+          this%decomp_cpools_erode_col(i,k) = value_column
+          this%decomp_cpools_deposit_col(i,k) = value_column
+          this%decomp_cpools_yield_col(i,k) = value_column
           this%m_decomp_cpools_to_fire_col(i,k) = value_column
           this%bgc_cpool_ext_inputs_vr_col(i,:, k) = value_column
           this%bgc_cpool_ext_loss_vr_col(i,:, k) = value_column
@@ -4327,6 +4399,9 @@ contains
        this%cwdc_loss_col(i)                 = value_column
        this%litterc_loss_col(i)              = value_column
        this%som_c_leached_col(i)             = value_column
+       this%somc_erode_col(i)                = value_column
+       this%somc_deposit_col(i)              = value_column
+       this%somc_yield_col(i)                = value_column
 
        ! Zero p2c column fluxes
        this%rr_col(i)                    = value_column  
@@ -4932,6 +5007,18 @@ contains
        end do
     end do
 
+    ! vertically integrate column-level carbon erosion flux
+    do l = 1, ndecomp_pools
+       do j = 1, nlev
+          do fc = 1, num_soilc
+             c = filter_soilc(fc)
+             this%decomp_cpools_yield_col(c,l) = &
+                  this%decomp_cpools_yield_col(c,l) + &
+                  this%decomp_cpools_yield_vr_col(c,j,l) * dzsoi_decomp(j)
+          end do
+       end do
+    end do
+
     ! column-level carbon losses to fire, including pft losses
     do fc = 1,num_soilc
        c = filter_soilc(fc)
@@ -4978,6 +5065,23 @@ contains
             this%nee_col(c) - &
             this%landuseflux_col(c)
     end do
+
+    ! column-level carbon losses due to soil erosion
+    if ( use_erosion ) then 
+       do l = 1, ndecomp_pools
+          if ( is_soil(l) ) then
+             do fc = 1, num_soilc
+                c = filter_soilc(fc)
+                this%somc_erode_col(c) = this%somc_erode_col(c) + &
+                     this%decomp_cpools_erode_col(c,l)
+                this%somc_deposit_col(c) = this%somc_deposit_col(c) + &
+                     this%decomp_cpools_deposit_col(c,l)
+                this%somc_yield_col(c) = this%somc_yield_col(c) + &
+                     this%decomp_cpools_yield_col(c,l)
+             end do
+          end if
+       end do
+    end if
 
     if  (.not. is_active_betr_bgc) then
 

--- a/components/clm/src/biogeochem/CNEcosystemDynMod.F90
+++ b/components/clm/src/biogeochem/CNEcosystemDynMod.F90
@@ -33,6 +33,7 @@ module CNEcosystemDynMod
   use FrictionVelocityType, only : frictionvel_type
   use PhosphorusFluxType  , only : phosphorusflux_type
   use PhosphorusStateType , only : phosphorusstate_type
+  use SedFluxType         , only : sedflux_type 
   ! bgc interface & pflotran
   use clm_varctl          , only : use_clm_interface, use_clm_bgc, use_pflotran, pf_cmode, pf_hmode
   use CNVerticalProfileMod   , only : decomp_vertprofiles
@@ -472,7 +473,7 @@ contains
        atm2lnd_vars, waterstate_vars, waterflux_vars,                           &
        canopystate_vars, soilstate_vars, temperature_vars, crop_vars, ch4_vars, &
        dgvs_vars, photosyns_vars, soilhydrology_vars, energyflux_vars,          &
-       phosphorusflux_vars,phosphorusstate_vars)
+       phosphorusflux_vars, phosphorusstate_vars, sedflux_vars)
     !-------------------------------------------------------------------
     ! bgc interface
     ! Phase-2 of CNEcosystemDynNoLeaching
@@ -499,6 +500,7 @@ contains
     use CNNStateUpdate2Mod     , only: NStateUpdate2, NStateUpdate2h
     use PStateUpdate2Mod       , only: PStateUpdate2, PStateUpdate2h
     use CNFireMod              , only: CNFireArea, CNFireFluxes
+    use CNErosionMod           , only: CNErosionFluxes
     use CNCStateUpdate3Mod     , only: CStateUpdate3
     use CNCIsoFluxMod          , only: CIsoFlux1, CIsoFlux2, CIsoFlux2h, CIsoFlux3
     use CNC14DecayMod          , only: C14Decay, C14BombSpike
@@ -549,6 +551,7 @@ contains
 !
     type(phosphorusflux_type)  , intent(inout) :: phosphorusflux_vars
     type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+    type(sedflux_type)       , intent(in)    :: sedflux_vars
 
     !-----------------------------------------------------------------------
 
@@ -801,6 +804,10 @@ contains
        call CNFireFluxes(num_soilc, filter_soilc, num_soilp, filter_soilp, &
             dgvs_vars, cnstate_vars, carbonstate_vars, nitrogenstate_vars, &
             carbonflux_vars,nitrogenflux_vars,phosphorusstate_vars,phosphorusflux_vars)
+
+       call CNErosionFluxes(bounds, num_soilc, filter_soilc, soilstate_vars, sedflux_vars, &
+            carbonstate_vars, nitrogenstate_vars, phosphorusstate_vars, carbonflux_vars, &
+            nitrogenflux_vars, phosphorusflux_vars)
 
        call t_stopf('CNUpdate2')
 

--- a/components/clm/src/biogeochem/CNErosionMod.F90
+++ b/components/clm/src/biogeochem/CNErosionMod.F90
@@ -1,0 +1,327 @@
+module CNErosionMod 
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Calculate the fluxes of SOMC, SOMN and SOMP induced by sediment flux 
+  !
+  use shr_kind_mod      , only : r8 => shr_kind_r8
+  use shr_log_mod       , only : errMsg => shr_log_errMsg
+  use decompMod         , only : bounds_type
+  use clm_time_manager  , only : get_step_size
+  use clm_varcon        , only : dzsoi_decomp
+  use clm_varpar        , only : ndecomp_pools, nlevdecomp
+  use CNCarbonFluxType  , only : carbonflux_type
+  use CNCarbonStateType , only : carbonstate_type
+  use CNDecompCascadeConType , only : decomp_cascade_con
+  use CNNitrogenFluxType  , only : nitrogenflux_type
+  use CNNitrogenStateType , only : nitrogenstate_type
+  use PhosphorusFluxType  , only : phosphorusflux_type
+  use PhosphorusStateType , only : phosphorusstate_type
+  use SedFluxType       , only : sedflux_type
+  use SoilStateType     , only : soilstate_type
+  !
+  ! !PUBLIC TYPES:
+  implicit none
+  save
+  private
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public :: CNErosionFluxes         ! Calculate erosion introduced CN fluxes 
+  ! !MODULE CONSTANTS
+  !-----------------------------------------------------------------------
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine CNErosionFluxes (bounds, num_soilc, filter_soilc, &
+    soilstate_vars, sedflux_vars, carbonstate_vars, nitrogenstate_vars, & 
+    phosphorusstate_vars, carbonflux_vars, nitrogenflux_vars, &
+    phosphorusflux_vars)
+    !
+    ! !DESCRIPTION:
+    ! Calculate soil erosion introduced soil CN fluxes 
+    !
+    ! !USES:
+    use clm_varctl      , only : iulog
+    use spmdMod         , only : masterproc
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)        , intent(in)    :: bounds
+    integer                  , intent(in)    :: num_soilc       ! number of column soil points in column filter
+    integer                  , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    type(soilstate_type)     , intent(in)    :: soilstate_vars
+    type(sedflux_type)       , intent(in)    :: sedflux_vars
+    type(carbonstate_type)   , intent(in)    :: carbonstate_vars
+    type(nitrogenstate_type) , intent(in)    :: nitrogenstate_vars
+    type(phosphorusstate_type), intent(in)   :: phosphorusstate_vars
+    type(carbonflux_type)    , intent(inout) :: carbonflux_vars
+    type(nitrogenflux_type)  , intent(inout) :: nitrogenflux_vars
+    type(phosphorusflux_type), intent(inout) :: phosphorusflux_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c, fc, l, j                              ! indices
+    integer  :: k, kn, kp                                ! new layer indices
+    integer  :: k1, k2                                   ! new layer indices     
+    real(r8) :: dh, dhn, dhp                             ! erosion height (m)
+    real(r8) :: dm_ero, dm_yld, dm                       ! erosion mass (kg/m2)
+    real(r8) :: soc_yld                                  ! SOC erosion (gC/m2)
+    real(r8) :: erode_tmp, deposit_tmp                   ! temporal variable
+    real(r8) :: zsoi_tot, zsoi_top                       ! soil layer height (m)
+    real(r8) :: soc, son                                 ! soil OC and ON content (%)
+    real(r8) :: decomp_ctot                              ! total C density (gC/m3)
+    real(r8) :: decomp_ntot                              ! total N density (gN/m3)
+    real(r8) :: decomp_ptot                              ! total P density (gP/m3)
+    real(r8) :: som_n2c, som_p2c                         ! eroded SOM N/C and N/P weight ratios
+    real(r8) :: decomp_cpool_vr_new                      ! new SOM C pool (gC/m3)
+    real(r8) :: decomp_npool_vr_new                      ! new SOM N pool (gN/m3)
+    real(r8) :: decomp_ppool_vr_new                      ! new SOM P pool (gP/m3)
+    real(r8) :: dt                                       ! radiation time step (seconds)
+    character(len=32) :: subname = 'CNErosionFluxes'     ! subroutine name
+    !-----------------------------------------------------------------------
+
+    associate(                                                        &
+         decomp_cpools_vr =>    carbonstate_vars%decomp_cpools_vr_col       , & ! Input: [real(r8) (:) ] SOM C pools [gC/m3]
+         decomp_npools_vr =>    nitrogenstate_vars%decomp_npools_vr_col     , & ! Input: [real(r8) (:) ] SOM N pools [gN/m3]
+         decomp_ppools_vr =>    phosphorusstate_vars%decomp_ppools_vr_col   , & ! Input: [real(r8) (:) ] SOM P pools [gP/m3]
+
+         flx_sed_ero      =>    sedflux_vars%flx_sed_ero_col        , & ! Input: [real(r8) (:) ] sed total detachment (kg/m2/s)
+         flx_sed_yld      =>    sedflux_vars%flx_sed_yld_col        , & ! Input: [real(r8) (:) ] sed total yield (kg/m2/s)
+         
+         bd               =>    soilstate_vars%bd_col               , & ! Input: [real(r8) (:,:) ] soil bulk density (kg/m3)
+
+         cpools_erode     =>    carbonflux_vars%decomp_cpools_erode_col         , & ! Output: [real(r8) (:,:) ] vertically-integrated decomposing C detachment (gC/m2/s)
+         cpools_deposit   =>    carbonflux_vars%decomp_cpools_deposit_col       , & ! Output: [real(r8) (:,:) ] vertically-integrated decomposing C redeposition (gC/m2/s)
+         cpools_yield_vr  =>    carbonflux_vars%decomp_cpools_yield_vr_col      , & ! Output: [real(r8) (:,:,:) ] vertically-resolved decomposing C loss (gC/m3/s)
+                  
+         npools_erode     =>    nitrogenflux_vars%decomp_npools_erode_col       , & ! Output: [real(r8) (:,:) ] vertically-integrated decomposing N detachment (gN/m2/s)
+         npools_deposit   =>    nitrogenflux_vars%decomp_npools_deposit_col     , & ! Output: [real(r8) (:,:) ] vertically-integrated decomposing N redeposition (gN/m2/s)
+         npools_yield_vr  =>    nitrogenflux_vars%decomp_npools_yield_vr_col    , & ! Output: [real(r8) (:,:,:) ] vertically-resolved decomposing N loss (gN/m3/s)
+         
+         ppools_erode     =>    phosphorusflux_vars%decomp_ppools_erode_col     , & ! Output: [real(r8) (:,:) ] vertically-integrated decomposing P detachment (gP/m2/s)
+         ppools_deposit   =>    phosphorusflux_vars%decomp_ppools_deposit_col   , & ! Output: [real(r8) (:,:) ] vertically-integrated decomposing P redeposition (gP/m2/s)
+         ppools_yield_vr  =>    phosphorusflux_vars%decomp_ppools_yield_vr_col    & ! Output: [real(r8) (:,:,:) ] vertically-resolved decomposing P loss (gP/m3/s)
+         )
+
+         dt = real( get_step_size(), r8 )
+
+         ! soil col filters
+         do fc = 1, num_soilc
+            c = filter_soilc(fc)
+
+            ! initialization
+            cpools_erode(c,:)       = 0._r8
+            cpools_deposit(c,:)     = 0._r8
+            cpools_yield_vr(c,:,:)  = 0._r8
+            
+            npools_erode(c,:)       = 0._r8
+            npools_deposit(c,:)     = 0._r8
+            npools_yield_vr(c,:,:)  = 0._r8
+            
+            ppools_erode(c,:)       = 0._r8
+            ppools_deposit(c,:)     = 0._r8
+            ppools_yield_vr(c,:,:)  = 0._r8    
+
+            dm_ero = max(0._r8, flx_sed_ero(c)) * dt
+            dm_yld = max(0._r8, flx_sed_yld(c)) * dt
+            ! calculate erosion heights 
+            dh = 0._r8
+            dm = dm_yld
+            soc_yld = 0._r8
+            k = 1
+            do j = 1, nlevdecomp
+               decomp_ctot = 0._r8
+               do l = 1, ndecomp_pools
+                  if ( decomp_cascade_con%is_soil(l) ) then
+                     decomp_ctot = decomp_ctot + decomp_cpools_vr(c,j,l)
+                  end if
+               end do
+               if (dm<=bd(c,j)*dzsoi_decomp(j)) then
+                  dh = dh + dm/bd(c,j) 
+                  soc_yld = soc_yld + decomp_ctot*dm/bd(c,j)
+                  exit
+               end if
+               dh = dh + dzsoi_decomp(j) 
+               dm = dm - bd(c,j)*dzsoi_decomp(j)
+               soc_yld = soc_yld + decomp_ctot*dzsoi_decomp(j)
+               k = k + 1
+            end do
+
+            ! SOC content in eroded soil (only mud in surface)
+            if (dh>0._r8 .and. dh<=dzsoi_decomp(1)) then
+               soc = 0.1 * soc_yld / 1460._r8 / dh
+            else if (dh>dzsoi_decomp(1)) then
+               soc = 0.1 * soc_yld / dm_yld
+            else
+               soc = 0._r8
+            end if
+            son = 0.116 * soc - 0.019           ! Beusen et al. (2005)
+            if (soc>0._r8 .and. son>0._r8) then
+               som_n2c = son / soc 
+            else
+               som_n2c = 1._r8 / 10.2           ! Beusen et al. (2005)
+            end if
+            som_p2c = 1._r8 / 22                ! Meybeck (1982)
+
+            ! equivalent erosion heights for N and P
+            dm = som_n2c * soc_yld
+            dhn = 0._r8
+            kn = 1
+            do j = 1, nlevdecomp
+               decomp_ntot = 0._r8
+               do l = 1, ndecomp_pools
+                  if ( decomp_cascade_con%is_soil(l) ) then
+                     decomp_ntot = decomp_ntot + decomp_npools_vr(c,j,l)   
+                  end if
+               end do
+               if (dm<=decomp_ntot*dzsoi_decomp(j)) then
+                  dhn = dhn + dm/decomp_ntot
+                  exit
+               end if
+               dhn = dhn + dzsoi_decomp(j)
+               dm = dm - decomp_ntot*dzsoi_decomp(j)
+               kn = kn + 1
+            end do
+
+            dm = som_p2c * soc_yld
+            dhp = 0._r8
+            kp = 1
+            do j = 1, nlevdecomp
+               decomp_ptot = 0._r8
+               do l = 1, ndecomp_pools
+                  if ( decomp_cascade_con%is_soil(l) ) then
+                     decomp_ptot = decomp_ptot + decomp_ppools_vr(c,j,l)
+                  end if
+               end do
+               if (dm<=decomp_ptot*dzsoi_decomp(j)) then
+                  dhp = dhp + dm/decomp_ptot
+                  exit
+               end if
+               dhp = dhp + dzsoi_decomp(j)
+               dm = dm - decomp_ptot*dzsoi_decomp(j)
+               kp = kp + 1
+            end do
+
+            do l = 1, ndecomp_pools
+               if ( decomp_cascade_con%is_soil(l) ) then
+                  ! C, N, P loss from soil column
+                  if ( soc_yld > 0._r8 .and. k <= nlevdecomp ) then
+                     cpools_erode(c,l) = 0._r8 
+                     cpools_deposit(c,l) = 0._r8 
+                     k1 = k
+                     do j = 1, nlevdecomp
+                        ! update bottom index
+                        if (k1<=nlevdecomp) then
+                           zsoi_tot = sum(dzsoi_decomp(1:k1))
+                           zsoi_top = sum(dzsoi_decomp(1:j-1)) + dh
+                           if (zsoi_top+dzsoi_decomp(j)<zsoi_tot) then
+                              k2 = k1
+                           else
+                              k2 = k1 + 1
+                           end if
+                        end if
+                        if (k1==k2) then
+                           if (k1<=nlevdecomp) then
+                              decomp_cpool_vr_new = decomp_cpools_vr(c,k1,l)
+                           else
+                              decomp_cpool_vr_new = 0._r8
+                           end if
+                        else
+                           if (k2<=nlevdecomp) then
+                              decomp_cpool_vr_new = decomp_cpools_vr(c,k1,l)*(zsoi_tot-zsoi_top)/dzsoi_decomp(j) + &
+                                 decomp_cpools_vr(c,k2,l)*(1._r8-(zsoi_tot-zsoi_top)/dzsoi_decomp(j))
+                           else
+                              decomp_cpool_vr_new = decomp_cpools_vr(c,k1,l)*(zsoi_tot-zsoi_top)/dzsoi_decomp(j)
+                           end if
+                        end if
+                        cpools_yield_vr(c,j,l) = (decomp_cpools_vr(c,j,l) - decomp_cpool_vr_new) / dt
+                        erode_tmp = cpools_yield_vr(c,j,l)*dzsoi_decomp(j)*dm_ero/dm_yld
+                        deposit_tmp = cpools_yield_vr(c,j,l)*dzsoi_decomp(j)*(dm_ero-dm_yld)/dm_yld
+                        cpools_erode(c,l) = cpools_erode(c,l) + erode_tmp 
+                        cpools_deposit(c,l) = cpools_deposit(c,l) + deposit_tmp
+                        k1 = k2     ! update top index
+                     end do
+                  end if
+                  if ( soc_yld > 0._r8 .and. kn <= nlevdecomp ) then
+                     npools_erode(c,l) = 0._r8 
+                     npools_deposit(c,l) = 0._r8 
+                     k1 = kn
+                     do j = 1, nlevdecomp
+                        ! update bottom index
+                        if (k1<=nlevdecomp) then
+                           zsoi_tot = sum(dzsoi_decomp(1:k1))
+                           zsoi_top = sum(dzsoi_decomp(1:j-1)) + dhn
+                           if (zsoi_top+dzsoi_decomp(j)<zsoi_tot) then
+                              k2 = k1
+                           else
+                              k2 = k1 + 1
+                           end if
+                        end if
+                        if (k1==k2) then
+                           if (k1<=nlevdecomp) then
+                              decomp_npool_vr_new = decomp_npools_vr(c,k1,l)
+                           else
+                              decomp_npool_vr_new = 0._r8
+                           end if
+                        else
+                           if (k2<=nlevdecomp) then
+                              decomp_npool_vr_new = decomp_npools_vr(c,k1,l)*(zsoi_tot-zsoi_top)/dzsoi_decomp(j) + &
+                                 decomp_npools_vr(c,k2,l)*(1._r8-(zsoi_tot-zsoi_top)/dzsoi_decomp(j))
+                           else
+                              decomp_npool_vr_new = decomp_npools_vr(c,k1,l)*(zsoi_tot-zsoi_top)/dzsoi_decomp(j)
+                           end if
+                        end if
+                        npools_yield_vr(c,j,l) = (decomp_npools_vr(c,j,l) - decomp_npool_vr_new) / dt
+                        erode_tmp = npools_yield_vr(c,j,l)*dzsoi_decomp(j)*dm_ero/dm_yld
+                        deposit_tmp = npools_yield_vr(c,j,l)*dzsoi_decomp(j)*(dm_ero-dm_yld)/dm_yld
+                        npools_erode(c,l) = npools_erode(c,l) + erode_tmp
+                        npools_deposit(c,l) = npools_deposit(c,l) + deposit_tmp
+                        k1 = k2     ! update top index
+                     end do
+                  end if 
+                  if ( soc_yld > 0._r8 .and. kp <= nlevdecomp ) then
+                     ppools_erode(c,l) = 0._r8 
+                     ppools_deposit(c,l) = 0._r8 
+                     k1 = kp
+                     do j = 1, nlevdecomp
+                        ! update bottom index
+                        if (k1<=nlevdecomp) then
+                           zsoi_tot = sum(dzsoi_decomp(1:k1))
+                           zsoi_top = sum(dzsoi_decomp(1:j-1)) + dhp
+                           if (zsoi_top+dzsoi_decomp(j)<zsoi_tot) then
+                              k2 = k1
+                           else
+                              k2 = k1 + 1
+                           end if
+                        end if
+                        if (k1==k2) then
+                           if (k1<=nlevdecomp) then
+                              decomp_ppool_vr_new = decomp_ppools_vr(c,k1,l)
+                           else
+                              decomp_ppool_vr_new = 0._r8
+                           end if
+                        else
+                           if (k2<=nlevdecomp) then
+                              decomp_ppool_vr_new = decomp_ppools_vr(c,k1,l)*(zsoi_tot-zsoi_top)/dzsoi_decomp(j) + &
+                                 decomp_ppools_vr(c,k2,l)*(1._r8-(zsoi_tot-zsoi_top)/dzsoi_decomp(j))
+                           else
+                              decomp_ppool_vr_new = decomp_ppools_vr(c,k1,l)*(zsoi_tot-zsoi_top)/dzsoi_decomp(j)
+                           end if
+                        end if
+                        ppools_yield_vr(c,j,l) = (decomp_ppools_vr(c,j,l) - decomp_ppool_vr_new) / dt
+                        erode_tmp = ppools_yield_vr(c,j,l)*dzsoi_decomp(j)*dm_ero/dm_yld
+                        deposit_tmp = ppools_yield_vr(c,j,l)*dzsoi_decomp(j)*(dm_ero-dm_yld)/dm_yld
+                        ppools_erode(c,l) = ppools_erode(c,l) + erode_tmp
+                        ppools_deposit(c,l) = ppools_deposit(c,l) + deposit_tmp
+                        k1 = k2     ! update top index
+                     end do
+                  end if
+               end if
+            end do
+
+         end do
+    
+    end associate
+
+  end subroutine CNErosionFluxes
+
+end module CNErosionMod 

--- a/components/clm/src/biogeochem/CNNStateUpdate3Mod.F90
+++ b/components/clm/src/biogeochem/CNNStateUpdate3Mod.F90
@@ -11,6 +11,8 @@ module CNNStateUpdate3Mod
   use clm_time_manager    , only : get_step_size
   use clm_varctl          , only : iulog, use_nitrif_denitrif
   use clm_varpar          , only : i_cwd, i_met_lit, i_cel_lit, i_lig_lit
+  use clm_varctl          , only : use_erosion, ero_ccycle
+  use CNDecompCascadeConType , only : decomp_cascade_con
   use CNNitrogenStateType , only : nitrogenstate_type
   use CNNitrogenFLuxType  , only : nitrogenflux_type
   ! bgc interface & pflotran:
@@ -33,6 +35,7 @@ contains
     ! !DESCRIPTION:
     ! On the radiation time step, update all the prognostic nitrogen state
     ! variables affected by gap-phase mortality fluxes. Also the Sminn leaching flux.
+    ! Also include the erosion flux.
     ! NOTE - associate statements have been removed where there are
     ! no science equations. This increases readability and maintainability.
     !
@@ -104,6 +107,21 @@ contains
          end do
 
       endif
+
+      ! SOM N losses due to erosion
+      if ( use_erosion .and. ero_ccycle ) then
+         do l = 1, ndecomp_pools
+            if ( decomp_cascade_con%is_soil(l) ) then
+               do j = 1, nlevdecomp
+                  do fc = 1, num_soilc
+                     c = filter_soilc(fc)
+                     ns%decomp_npools_vr_col(c,j,l) = ns%decomp_npools_vr_col(c,j,l) - nf%decomp_npools_yield_vr_col(c,j,l) * dt
+                  end do
+               end do
+            end if
+         end do
+      end if
+
       ! patch-level nitrogen fluxes 
       
       do fp = 1,num_soilp

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -219,6 +219,8 @@ contains
           qflx_prec_intr       => waterflux_vars%qflx_prec_intr_patch      , & ! Output: [real(r8) (:)   ]  interception of precipitation [mm/s]    
           qflx_prec_grnd       => waterflux_vars%qflx_prec_grnd_patch      , & ! Output: [real(r8) (:)   ]  water onto ground including canopy runoff [kg/(m2 s)]
           qflx_rain_grnd       => waterflux_vars%qflx_rain_grnd_patch      , & ! Output: [real(r8) (:)   ]  rain on ground after interception (mm H2O/s) [+]
+          qflx_dirct_rain      => waterflux_vars%qflx_dirct_rain_patch     , & ! Output: [real(r8) (:)   ]  direct rain throughfall on ground (mm H2O/s) 
+          qflx_leafdrip        => waterflux_vars%qflx_leafdrip_patch       , & ! Output: [real(r8) (:)   ]  leap rain drip on ground (mm H2O/s)
           qflx_irrig           => waterflux_vars%qflx_irrig_patch            & ! Output: [real(r8) (:)   ]  irrigation amount (mm/s)                
           )
 
@@ -311,14 +313,20 @@ contains
              if (frac_veg_nosno(p) == 0) then
                 qflx_prec_grnd_snow(p) = forc_snow(c)
                 qflx_prec_grnd_rain(p) = forc_rain(c)
+                qflx_dirct_rain(p) = forc_rain(c)
+                qflx_leafdrip(p) = 0._r8
              else
                 qflx_prec_grnd_snow(p) = qflx_through_snow(p) + (qflx_candrip(p) * fracsnow(p))
                 qflx_prec_grnd_rain(p) = qflx_through_rain(p) + (qflx_candrip(p) * fracrain(p))
+                qflx_dirct_rain(p) = qflx_through_rain(p)
+                qflx_leafdrip(p) = qflx_candrip(p) * fracrain(p)
              end if
              ! Urban sunwall and shadewall have no intercepted precipitation
           else
              qflx_prec_grnd_snow(p) = 0.
              qflx_prec_grnd_rain(p) = 0.
+             qflx_dirct_rain(p) = 0._r8
+             qflx_leafdrip(p) = 0._r8
           end if
 
           ! Determine whether we're irrigating here; set qflx_irrig appropriately

--- a/components/clm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/clm/src/biogeophys/LakeFluxesMod.F90
@@ -191,6 +191,8 @@ contains
          qflx_snwcp_ice   =>    waterflux_vars%qflx_snwcp_ice_patch    , & ! Output: [real(r8) (:)   ]  excess snowfall due to snow capping (mm H2O /s) [+]
          qflx_snwcp_liq   =>    waterflux_vars%qflx_snwcp_liq_patch    , & ! Output: [real(r8) (:)   ]  excess rainfall due to snow capping (mm H2O /s) [+] 
          qflx_prec_grnd   =>    waterflux_vars%qflx_prec_grnd_patch    , & ! Output: [real(r8) (:)   ]  water onto ground including canopy runoff [kg/(m2 s)]
+         qflx_dirct_rain  =>    waterflux_vars%qflx_dirct_rain_patch   , & ! Output: [real(r8) (:)   ]  direct rain throughfall [mm H2O/s]
+         qflx_leafdrip    =>    waterflux_vars%qflx_leafdrip_patch     , & ! Output: [real(r8) (:)   ]  leaf rain drip [mm H2O/s]
 
          t_veg            =>    temperature_vars%t_veg_patch           , & ! Output: [real(r8) (:)   ]  vegetation temperature (Kelvin)                   
          t_ref2m          =>    temperature_vars%t_ref2m_patch         , & ! Output: [real(r8) (:)   ]  2 m height surface air temperature (Kelvin)       
@@ -615,6 +617,8 @@ contains
          t_veg(p) = forc_t(c)
          eflx_lwrad_net(p)  = eflx_lwrad_out(p) - forc_lwrad(c)
          qflx_prec_grnd(p) = forc_rain(c) + forc_snow(c)
+         qflx_dirct_rain(p) = 0._r8
+         qflx_leafdrip(p) = 0._r8
 
          ! Because they will be used in pft2col initialize here.
          ! This will be overwritten in LakeHydrology

--- a/components/clm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/clm/src/biogeophys/LakeHydrologyMod.F90
@@ -170,6 +170,10 @@ contains
          qflx_dew_grnd        =>  waterflux_vars%qflx_dew_grnd_patch    , & ! Output: [real(r8) (:)   ]  ground surface dew formation (mm H2O /s) [+]
          qflx_snwcp_ice       =>  waterflux_vars%qflx_snwcp_ice_patch   , & ! Output: [real(r8) (:)   ]  excess snowfall due to snow capping (mm H2O /s) [+]
          qflx_snwcp_liq       =>  waterflux_vars%qflx_snwcp_liq_patch   , & ! Output: [real(r8) (:)   ]  excess rainfall due to snow capping (mm H2O /s) [+]
+         qflx_dirct_rain      =>  waterflux_vars%qflx_dirct_rain_patch  , & ! Output: [real(r8) (:)   ]  direct rain throughfall (mm H2O/s)
+         qflx_leafdrip        =>  waterflux_vars%qflx_leafdrip_patch    , & ! Output: [real(r8) (:)   ]  leaf rain drip (mm H2O/s)
+         qflx_dirct_rain_col  =>  waterflux_vars%qflx_dirct_rain_col    , & ! Output: [real(r8) (:)   ]  direct rain throughfall (mm H2O/s)
+         qflx_leafdrip_col    =>  waterflux_vars%qflx_leafdrip_col      , & ! Output: [real(r8) (:)   ]  leaf rain drip (mm H2O/s)
          qflx_snomelt         =>  waterflux_vars%qflx_snomelt_col       , & ! Output: [real(r8) (:)   ]  snow melt (mm H2O /s)                   
          qflx_prec_grnd_col   =>  waterflux_vars%qflx_prec_grnd_col     , & ! Output: [real(r8) (:)   ]  water onto ground including canopy runoff [kg/(m2 s)]
          qflx_evap_grnd_col   =>  waterflux_vars%qflx_evap_grnd_col     , & ! Output: [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]
@@ -229,6 +233,9 @@ contains
          qflx_prec_grnd_snow(p) = forc_snow(c)
          qflx_prec_grnd_rain(p) = forc_rain(c)
          qflx_prec_grnd(p) = qflx_prec_grnd_snow(p) + qflx_prec_grnd_rain(p)
+
+         qflx_dirct_rain(p) = 0._r8
+         qflx_leafdrip(p) = 0._r8
 
          if (do_capsnow(c)) then
             qflx_snwcp_ice(p) = qflx_prec_grnd_snow(p)
@@ -406,6 +413,8 @@ contains
          qflx_dew_grnd_col(c)  = qflx_dew_grnd(p)
          qflx_dew_snow_col(c)  = qflx_dew_snow(p)
          qflx_sub_snow_col(c)  = qflx_sub_snow(p)
+         qflx_dirct_rain_col(c) = qflx_dirct_rain(p)
+         qflx_leafdrip_col(c) = qflx_leafdrip(p)
       enddo
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/components/clm/src/biogeophys/SedFluxType.F90
+++ b/components/clm/src/biogeophys/SedFluxType.F90
@@ -1,0 +1,242 @@
+module SedFluxType
+
+  !------------------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Hold sediment, POC, PON and POP dynamic fluxes induced by soil erosion 
+  !
+  use shr_kind_mod      , only : r8 => shr_kind_r8
+  use shr_log_mod       , only : errMsg => shr_log_errMsg
+  use clm_varcon        , only : spval
+  use clm_varctl        , only : use_erosion
+  use decompMod         , only : bounds_type
+  use abortutils        , only : endrun
+  use ColumnType        , only : col_pp
+  !
+  implicit none
+  save
+  private
+  !
+  ! !PUBLIC TYPES:
+  type, public :: sedflux_type
+
+     ! Soil erosion model parameters
+     real(r8), pointer :: prnsf_col(:)              ! col rainfall-driven erosion scaling factor
+     real(r8), pointer :: qrnsf_col(:)              ! col runoff-driven erosion scaling factor
+     real(r8), pointer :: tcsf_col(:)               ! col transport capacity scaling factor
+     
+     ! Soil erosion fluxes
+     real(r8), pointer :: flx_p_ero_col(:)          ! col sed detach driven by rainfall (kg/m2/s)
+     real(r8), pointer :: flx_q_ero_col(:)          ! col sed detach driven by runoff (kg/m2/s)
+     real(r8), pointer :: flx_lndsld_ero_col(:)     ! col sed detach driven by landslides (kg/m2/s)
+     real(r8), pointer :: flx_sed_ero_col(:)        ! col total sed detach (kg/m2/s)
+     real(r8), pointer :: flx_lndsld_yld_col(:)     ! col sed yield driven by landslides (kg/m2/s)
+     real(r8), pointer :: flx_sed_yld_col(:)        ! col total sed yield (kg/m2/s) 
+
+  contains
+
+     procedure, public  :: Init
+     procedure, private :: InitAllocate
+     procedure, private :: InitHistory
+     procedure, private :: InitCold
+     procedure, public  :: Restart
+
+  end type sedflux_type
+  !------------------------------------------------------------------------
+
+contains
+
+  !------------------------------------------------------------------------
+  subroutine Init(this, bounds)
+    
+    class(sedflux_type)            :: this
+    type(bounds_type) , intent(in) :: bounds
+
+    call this%InitAllocate ( bounds )
+    if (use_erosion) then
+       call this%InitHistory ( bounds )
+       call this%InitCold ( bounds )
+    end if
+
+  end subroutine Init
+
+  !------------------------------------------------------------------------
+  subroutine InitAllocate(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Initialize module data structure
+    !
+    ! !USES:
+    use shr_infnan_mod , only : nan => shr_infnan_nan, assignment(=)
+    !
+    ! !ARGUMENTS:
+    class(sedflux_type) :: this
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+    integer :: begc, endc
+    !------------------------------------------------------------------------
+
+    begc = bounds%begc; endc= bounds%endc
+
+    allocate( this%flx_p_ero_col       (begc:endc))      ; this%flx_p_ero_col          (:) = nan
+    allocate( this%flx_q_ero_col       (begc:endc))      ; this%flx_q_ero_col          (:) = nan
+    allocate( this%flx_lndsld_ero_col  (begc:endc))      ; this%flx_lndsld_ero_col     (:) = nan
+    allocate( this%flx_sed_ero_col     (begc:endc))      ; this%flx_sed_ero_col        (:) = nan
+    allocate( this%flx_lndsld_yld_col  (begc:endc))      ; this%flx_lndsld_yld_col     (:) = nan
+    allocate( this%flx_sed_yld_col     (begc:endc))      ; this%flx_sed_yld_col        (:) = nan
+
+    allocate( this%prnsf_col           (begc:endc))      ; this%prnsf_col              (:) = nan
+    allocate( this%qrnsf_col           (begc:endc))      ; this%qrnsf_col              (:) = nan
+    allocate( this%tcsf_col            (begc:endc))      ; this%tcsf_col               (:) = nan
+
+  end subroutine InitAllocate
+
+  !------------------------------------------------------------------------
+  subroutine InitHistory(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Initialize module data structure
+    !
+    ! !USES:
+    use histFileMod    , only : hist_addfld1d
+    use shr_infnan_mod , only : nan => shr_infnan_nan, assignment(=)
+    !
+    ! !ARGUMENTS:
+    class(sedflux_type) :: this
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+    integer           :: begc, endc
+    character(24)     :: fieldname
+    character(100)    :: longname
+    real(r8), pointer :: data1dptr(:)   ! temp. pointer for slicing larger arrays
+    !------------------------------------------------------------------------
+
+    begc = bounds%begc; endc= bounds%endc
+
+    this%flx_p_ero_col(begc:endc) = spval
+    call hist_addfld1d (fname='P_ERO',  units='kg/m^2/s',  &
+         avgflag='A', long_name='hillslope rainfall-driven erosion', &
+         ptr_col=this%flx_p_ero_col, l2g_scale_type='veg', &
+         default='inactive')
+
+    this%flx_q_ero_col(begc:endc) = spval
+    call hist_addfld1d (fname='Q_ERO',  units='kg/m^2/s',  &
+         avgflag='A', long_name='hillslope runoff-driven erosion', &
+         ptr_col=this%flx_q_ero_col, l2g_scale_type= 'veg', &
+         default='inactive')
+
+    this%flx_lndsld_ero_col(begc:endc) = spval
+    call hist_addfld1d (fname='LNDSLD_ERO',  units='kg/m^2/s',  &
+         avgflag='A', long_name='hillslope landslide-driven erosion', &
+         ptr_col=this%flx_lndsld_ero_col, l2g_scale_type= 'veg', &
+         default='inactive')
+
+    this%flx_sed_ero_col(begc:endc) = spval
+    call hist_addfld1d (fname='SED_ERO',  units='kg/m^2/s',  &
+         avgflag='A', long_name='hillslope total erosion', &
+         ptr_col=this%flx_sed_ero_col, l2g_scale_type= 'veg', &
+         default='inactive')
+
+    this%flx_lndsld_yld_col(begc:endc) = spval
+    call hist_addfld1d (fname='LNDSLD_YLD',  units='kg/m^2/s',  &
+         avgflag='A', long_name='hillslope landslide sediment yield', &
+         ptr_col=this%flx_lndsld_yld_col, l2g_scale_type= 'veg', &
+         default='inactive')
+
+    this%flx_sed_yld_col(begc:endc) = spval
+    call hist_addfld1d (fname='SED_YLD',  units='kg/m^2/s',  &
+         avgflag='A', long_name='hillslope total sediment yield', &
+         ptr_col=this%flx_sed_yld_col, l2g_scale_type= 'veg', &
+         default='inactive')
+
+  end subroutine InitHistory
+
+  !-----------------------------------------------------------------------
+  subroutine InitCold(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Initialize cold start conditions for module variables
+    !
+    ! !USES:
+    use shr_kind_mod   , only : r8 => shr_kind_r8
+    use clm_varcon     , only : grlnd
+    use clm_varctl     , only : fsurdat
+    use fileutils      , only : getfil
+    use ncdio_pio      , only : file_desc_t, ncd_io, ncd_pio_openfile, ncd_pio_closefile
+    !
+    ! !ARGUMENTS:
+    class(sedflux_type)         :: this
+    type(bounds_type) , intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+    integer            :: c, g
+    logical            :: readvar
+    type(file_desc_t)  :: ncid
+    character(len=256) :: locfn
+    real(r8) ,pointer  :: prnsf2d         (:)      ! read in - prnsf
+    real(r8) ,pointer  :: qrnsf2d         (:)      ! read in - qrnsf
+    real(r8) ,pointer  :: tcsf2d          (:)      ! read in - tcsf
+    !-----------------------------------------------------------------------
+
+    allocate(prnsf2d(bounds%begg:bounds%endg))
+    allocate(qrnsf2d(bounds%begg:bounds%endg))
+    allocate(tcsf2d(bounds%begg:bounds%endg))
+
+    call getfil (fsurdat, locfn, 0)
+    call ncd_pio_openfile (ncid, locfn, 0)
+    call ncd_io(ncid=ncid, varname='parEro_c1', flag='read', data=prnsf2d, dim1name=grlnd, readvar=readvar)
+    if (.not. readvar) then
+       call endrun(msg=' ERROR: parEro_c1 NOT on surfdata file'//errMsg(__FILE__, __LINE__)) 
+    end if
+    call ncd_io(ncid=ncid, varname='parEro_c2', flag='read', data=qrnsf2d, dim1name=grlnd, readvar=readvar)
+    if (.not. readvar) then
+       call endrun(msg=' ERROR: parEro_c2 NOT on surfdata file'//errMsg(__FILE__, __LINE__)) 
+    end if
+    call ncd_io(ncid=ncid, varname='parEro_c3', flag='read', data=tcsf2d, dim1name=grlnd, readvar=readvar)
+    if (.not. readvar) then
+       call endrun(msg=' ERROR: parEro_c3 NOT on surfdata file'//errMsg(__FILE__, __LINE__)) 
+    end if
+    call ncd_pio_closefile(ncid)
+
+    do c = bounds%begc, bounds%endc
+       this%flx_p_ero_col(c)                 = 0._r8
+       this%flx_q_ero_col(c)                 = 0._r8
+       this%flx_lndsld_ero_col(c)            = 0._r8
+       this%flx_sed_ero_col(c)               = 0._r8
+       this%flx_lndsld_yld_col(c)            = 0._r8
+       this%flx_sed_yld_col(c)               = 0._r8
+
+       g = col_pp%gridcell(c)
+       this%prnsf_col(c)                     = prnsf2d(g)
+       this%qrnsf_col(c)                     = qrnsf2d(g)
+       this%tcsf_col(c)                      = tcsf2d(g)
+    end do
+
+    deallocate(prnsf2d, qrnsf2d, tcsf2d)
+
+  end subroutine InitCold
+
+  !------------------------------------------------------------------------
+  subroutine Restart(this, bounds, ncid, flag)
+    ! 
+    ! !DESCRIPTION:
+    ! Read/Write module information to/from restart file.
+    !
+    ! !USES:
+    use ncdio_pio       , only : file_desc_t
+    !
+    ! !ARGUMENTS:
+    class(sedflux_type) :: this
+    type(bounds_type), intent(in)    :: bounds
+    type(file_desc_t), intent(inout) :: ncid
+    character(len=*) , intent(in)    :: flag
+    !
+    ! !LOCAL VARIABLES:
+    !-----------------------------------------------------------------------
+
+    ! do nothing
+
+  end subroutine Restart
+
+end module SedFluxType

--- a/components/clm/src/biogeophys/SedYieldMod.F90
+++ b/components/clm/src/biogeophys/SedYieldMod.F90
@@ -1,0 +1,666 @@
+module SedYieldMod
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Calculate the sediment flux caused by soil erosion based on the 
+  ! improved Morgan model (Tan et al., 2017 & 2018) 
+  !
+  use shr_const_mod     , only : T0 => SHR_CONST_TKFRZ
+  use shr_kind_mod      , only : r8 => shr_kind_r8
+  use shr_log_mod       , only : errMsg => shr_log_errMsg
+  use decompMod         , only : bounds_type
+  use clm_varcon        , only : grav, denh2o, rpi
+  use clm_varpar        , only : mxpft, nlevsno, max_patch_per_col
+  use atm2lndType       , only : atm2lnd_type
+  use CanopyStateType   , only : CanopyState_type
+  use EnergyFluxType    , only : energyflux_type
+  use SoilHydrologyType , only : soilhydrology_type
+  use SoilStateType     , only : soilstate_type
+  use WaterfluxType     , only : waterflux_type
+  use WaterStateType    , only : waterstate_type
+  use TemperatureType   , only : temperature_type
+  use ColumnType        , only : col_pp
+  use LandunitType      , only : lun_pp
+  use VegetationType    , only : veg_pp
+  use SedFluxType       , only : sedflux_type 
+  !
+  ! !PUBLIC TYPES:
+  implicit none
+  save
+  private
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public :: SoilErosion          ! Calculate hillslope sediment flux
+  public :: Landslide            ! Calculate landslide-driven sediment flux 
+  ! !MODULE CONSTANTS
+  ! a free parameter for soil cohesion
+  real(r8), parameter :: lndsld_cs = 0.0196_r8
+  ! a free parameter for root-induced soil shear strength
+  real(r8), parameter :: lndsld_cr = 0.0031_r8
+  ! a free parameter for power law of exponent for landslide
+  real(r8), parameter :: lndsld_xi = 1.3529_r8
+  ! a free parameter for landslide volume upper limit (m^3)
+  real(r8), parameter :: lndsld_Vmax = 1.3344d+03
+  ! landslide cut-off volume (m^3)
+  real(r8), parameter :: lndsld_Vmin = 45._r8
+  !-----------------------------------------------------------------------
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine SoilErosion (bounds, num_hydrologyc, filter_hydrologyc, &
+    atm2lnd_vars, canopystate_vars, soilstate_vars, waterstate_vars, &
+    waterflux_vars, sedflux_vars)
+    !
+    ! !DESCRIPTION:
+    ! Calculate rainfall and runoff driven erosion 
+    !
+    ! !USES:
+    use clm_time_manager, only : get_step_size
+    use clm_varctl      , only : iulog
+    use landunit_varcon , only : istcrop, istsoil
+    use pftvarcon       , only : gcpsi, pftcc
+    use spmdMod         , only : masterproc
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)        , intent(in)    :: bounds
+    integer                  , intent(in)    :: num_hydrologyc       ! number of column soil points in column filter
+    integer                  , intent(in)    :: filter_hydrologyc(:) ! column filter for soil points
+    type(atm2lnd_type)       , intent(in)    :: atm2lnd_vars
+    type(CanopyState_type)   , intent(in)    :: canopystate_vars
+    type(soilstate_type)     , intent(in)    :: soilstate_vars
+    type(waterstate_type)    , intent(in)    :: waterstate_vars
+    type(waterflux_type)     , intent(in)    :: waterflux_vars
+    type(sedflux_type)       , intent(inout) :: sedflux_vars
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: c, fc, p, pi, l, j                         ! indices
+    integer  :: dtime                                      ! timestep size [seconds]
+    integer  :: nslp                                       ! slope level #
+    real(r8) :: sinslp, fslp, factor_slp                   ! topo gradient
+    real(r8) :: gndbare, vegcc, fbare                      ! veg cover factors
+    real(r8) :: fungrvl                                    ! ground uncovered by gravel
+    real(r8) :: K, COH                                     ! soil erodibility
+    real(r8) :: Qs, Ptot, Ie, Dl                           ! water fluxes
+    real(r8) :: Tc, Es_Q, Es_P, KE_DT, KE_LD               ! temporaries 
+    real(r8) :: stxt(4)                                    ! soil texture including gravel
+    character(len=32) :: subname = 'SoilErosion'           ! subroutine name
+    !-----------------------------------------------------------------------
+
+    associate(                                                        &
+         forc_rain        =>    atm2lnd_vars%forc_rain_downscaled_col   , & ! Input: [real(r8) (:) ] rain rate [mm/s]
+         forc_t           =>    atm2lnd_vars%forc_t_downscaled_col      , & ! Input: [real(r8) (:) ] atmospheric temperature (Kelvin) 
+
+         tlai             =>    canopystate_vars%tlai_patch         , & ! Input: [real(r8) (:) ] LAI
+         hbot             =>    canopystate_vars%hbot_patch         , & ! Input: [real(r8) (:) ] canopy bottom (m)
+         htop             =>    canopystate_vars%htop_patch         , & ! Input: [real(r8) (:) ] canopy top (m) 
+
+         hslp             =>    col_pp%hslp                         , & ! Input: [real(r8) (:) ]  hillslope gradient
+         hslp_p10         =>    col_pp%hslp_p10                     , & ! Input: [real(r8) (:,:) ] hillslope gradient percentiles
+    
+         bd               =>    soilstate_vars%bd_col               , & ! Input: [real(r8) (:,:) ] soil bulk density (kg/m3)
+         fsand            =>    soilstate_vars%cellsand_col         , & ! Input: [real(r8) (:,:) ] sand percentage
+         fclay            =>    soilstate_vars%cellclay_col         , & ! Input: [real(r8) (:,:) ] clay percentage
+         fgrvl            =>    soilstate_vars%cellgrvl_col         , & ! Input: [real(r8) (:,:) ] gravel percentage
+
+         hsnow            =>    waterstate_vars%snow_depth_col      , & ! Input: [real(r8) (:) ] snow depth (m)
+
+         prnsf            =>    sedflux_vars%prnsf_col              , & ! Input: [real(r8) (:) ] rainfall-driven erosion scaling factor
+         qrnsf            =>    sedflux_vars%qrnsf_col              , & ! Input: [real(r8) (:) ] runoff-driven erosion scaling factor
+         tcsf             =>    sedflux_vars%tcsf_col               , & ! Input: [real(r8) (:) ] transport capacity scaling factor 
+
+         qflx_surf        =>    waterflux_vars%qflx_surf_col            , & ! Input: [real(r8) (:) ] surface runoff (mm/s)
+         qflx_dirct_rain  =>    waterflux_vars%qflx_dirct_rain_patch    , & ! Input: [real(r8) (:) ] direct throughfall rain (mm/s)
+         qflx_leafdrip    =>    waterflux_vars%qflx_leafdrip_patch      , & ! Input: [real(r8) (:) ] leaf rain drip (mm/s)
+
+         flx_p_ero        =>    sedflux_vars%flx_p_ero_col          , & ! Output: [real(r8) (:) ] sed detached by rainfall (kg/m2/s)
+         flx_q_ero        =>    sedflux_vars%flx_q_ero_col          , & ! Output: [real(r8) (:) ] sed detached by runoff (kg/m2/s)
+         flx_sed_ero      =>    sedflux_vars%flx_sed_ero_col        , & ! Output: [real(r8) (:) ] total detachment (kg/m2/s)
+         flx_sed_yld      =>    sedflux_vars%flx_sed_yld_col          & ! Output: [real(r8) (:) ] sed flux to inland waters (kg/m2/s)
+         )
+
+         ! Get time step
+         dtime = get_step_size()
+
+         ! nolakec or other col filters
+         do fc = 1, num_hydrologyc
+            c = filter_hydrologyc(fc)
+            l = col_pp%landunit(c)
+
+            ! initialization
+            flx_p_ero(c)          = 0._r8
+            flx_q_ero(c)          = 0._r8
+            flx_sed_ero(c)        = 0._r8
+            flx_sed_yld(c)        = 0._r8
+
+            ! check landunit type and ground covered by snow/ice
+            if ( lun_pp%itype(l)/=istsoil .and. lun_pp%itype(l)/=istcrop ) then
+               cycle
+            else if (hsnow(c)>0) then
+               cycle
+            end if
+
+            ! soil detachment by rainfall
+            stxt = (/fclay(c,1), 100.-fclay(c,1)-fsand(c,1), fsand(c,1), &
+                fgrvl(c,1)/)  
+            K = SoilDetachability(stxt)
+            COH = SoilCohesion(stxt)
+            Es_P = 0._r8    ! detachment by throughfall + leap drip
+            if (forc_t(c)>T0 .and. forc_rain(c)>0._r8) then
+               fungrvl = 1. - 0.01 * fgrvl(c,1)
+               do pi = 1, max_patch_per_col
+                  if ( pi<=col_pp%npfts(c) ) then
+                     p = col_pp%pfti(c) + pi - 1
+                     if (veg_pp%active(p) .and. veg_pp%wtcol(p)>0) then
+                        ! throughfall power
+                        Ptot = qflx_dirct_rain(p) * dtime   ! mm
+                        Ie = 3.6d3 * forc_rain(c)           ! mm/hr
+                        KE_DT = Ptot * fungrvl * max(0._r8,8.95+8.44*log10(Ie))
+                        ! leaf drip power
+                        Dl = max(0._r8, qflx_leafdrip(p)*dtime)      ! mm
+                        KE_LD = max(0._r8,15.8*sqrt(0.5*(htop(p)+hbot(p)))-5.87) * &
+                           fungrvl * Dl
+                        Es_P = Es_P + prnsf(c) * veg_pp%wtcol(p) * K * (KE_DT+KE_LD)
+                     end if
+                  end if
+               end do
+            end if
+            Es_P = 1d-7 / 8.64 * Es_P   ! kg/m2/s
+
+            ! soil detachment by runoff
+            gndbare = 0._r8
+            vegcc = 0._r8
+            do pi = 1, max_patch_per_col
+               if ( pi<=col_pp%npfts(c) ) then
+                  p = col_pp%pfti(c) + pi - 1
+                  if (veg_pp%active(p)) then
+                     fbare = exp( -gcpsi(veg_pp%itype(p)) * tlai(p) )
+                     gndbare = gndbare + veg_pp%wtcol(p) * fbare
+                     vegcc = vegcc + veg_pp%wtcol(p) * pftcc(veg_pp%itype(p))
+                  end if
+               end if
+            end do
+            
+            Es_Q = 0._r8
+            Tc = 0._r8
+            if (qflx_surf(c)>0) then
+               Qs = 8.64d4 * qflx_surf(c)  ! mm/d
+               nslp = size(hslp_p10(c,:))
+               factor_slp = 0._r8
+               do j = 1, nslp
+                  if (j==1) then
+                     fslp = 1.5 / DBLE(nslp)
+                  else if (j<nslp-1) then
+                     fslp = 1.0 / DBLE(nslp)
+                  else if (j==nslp-1) then
+                     fslp = 1.3 / DBLE(nslp)
+                  else
+                     fslp = 0.2 / DBLE(nslp)
+                  end if
+                  sinslp = sin(atan(max(hslp_p10(c,j),1d-4)))
+                  factor_slp = factor_slp + fslp * sinslp
+               end do
+               Es_Q = 19.1 * qrnsf(c) * 2.0 / COH * factor_slp * &
+                  gndbare * Qs**1.5
+               Tc = 19.1 * tcsf(c) * factor_slp * vegcc * Qs**2.0
+            end if
+            Es_Q = 1d-7 / 8.64 * Es_Q
+            Tc = 1d-7 / 8.64 * Tc
+
+            ! assign flux values
+            flx_p_ero(c) = flx_p_ero(c) + Es_P
+            flx_q_ero(c) = flx_q_ero(c) + Es_Q
+            flx_sed_ero(c) = flx_sed_ero(c) + Es_P + Es_Q 
+            flx_sed_yld(c) = flx_sed_yld(c) + min(Es_P+Es_Q, Tc)
+         end do
+    
+    end associate
+
+  end subroutine SoilErosion
+
+  !-----------------------------------------------------------------------
+  subroutine Landslide (bounds, num_hydrologyc, filter_hydrologyc, &
+    soilstate_vars, waterstate_vars, sedflux_vars)
+    !
+    ! !DESCRIPTION:
+    ! Calculate landslide-induced sediment detachment 
+    !
+    ! !USES:
+    use clm_varctl      , only : iulog
+    use clm_varpar      , only : nlevsoi, maxpatch_pft
+    use landunit_varcon , only : istcrop, istsoil
+    use spmdMod         , only : masterproc
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)        , intent(in)    :: bounds
+    integer                  , intent(in)    :: num_hydrologyc       ! number of column soil points in column filter
+    integer                  , intent(in)    :: filter_hydrologyc(:) ! column filter for soil points
+    type(soilstate_type)     , intent(in)    :: soilstate_vars
+    type(waterstate_type)    , intent(in)    :: waterstate_vars
+    type(sedflux_type)       , intent(inout) :: sedflux_vars
+    ! !LOCAL VARIABLES:
+    integer  :: c, j, fc, p, pi, l                          ! indices
+    integer  :: nslp                                        ! slope level #
+    real(r8) :: FS                                          ! safety factor
+    real(r8) :: hslp_max, omega, sin_omega, tan_omega       ! topo variables
+    real(r8) :: tan_phi                                     ! soil internal friction
+    real(r8) :: zsum, zn                                    ! soil depth (m)
+    real(r8) :: ssum                                        ! total soil mass (kg/m2)
+    real(r8) :: vwat, vwatsat, vwatmin                      ! cur, saturated and min soil moisture (v/v)
+    real(r8) :: theta                                       ! effective saturation
+    real(r8) :: Cs, Cr                                      ! intrinsic and root-induced soil cohesion (Pa)
+    real(r8) :: ftree                                       ! tree fraction
+    real(r8) :: Rwat, Rsed                                  ! unit weight (N/m3)
+    real(r8) :: alpha                                       ! Van Genuchten parameter
+    real(r8) :: rn                                          ! pore-shape distribution parameter
+    real(r8) :: h                                           ! pressure head (m)
+    real(r8) :: expn, vol                                   ! landslide run-out volume variables
+    real(r8) :: fslp                                        ! slope level areal fraction
+    real(r8) :: Es_L                                        ! landslide erosion (kg/m2/s)
+    real(r8) :: stxt(4)                                     ! soil texture
+    character(len=32) :: subname = 'Landslide'              ! subroutine name
+    !-----------------------------------------------------------------------
+  
+    associate(                                                        &
+         dz               =>    col_pp%dz                           , & ! Input: [real(r8) (:,:) ] layer thickness (m)                                 
+         hslp_p10         =>    col_pp%hslp_p10                     , & ! Input: [real(r8) (:,:) ] hillslope gradient percentiles 
+         znsoil           =>    col_pp%znsoil                       , & ! Input: [real(r8) (:)   ] soil depth (m)
+
+         bd               =>    soilstate_vars%bd_col               , & ! Input: [real(r8) (:,:) ] soil bulk density (kg/m3)
+         fsand            =>    soilstate_vars%cellsand_col         , & ! Input: [real(r8) (:,:) ] sand fraction
+         fclay            =>    soilstate_vars%cellclay_col         , & ! Input: [real(r8) (:,:) ] clay fraction
+         fgrvl            =>    soilstate_vars%cellgrvl_col         , & ! Input: [real(r8) (:,:) ] gravel fraction
+         watmin           =>    soilstate_vars%watmin_col           , & ! Input: [real(r8) (:,:) ] minimum volumetric soil water (v/v)
+         watsat           =>    soilstate_vars%watsat_col           , & ! Input: [real(r8) (:,:) ] soil porosity (v/v) 
+
+         h2osoi_vol       =>    waterstate_vars%h2osoi_vol_col      , & ! Input: [real(r8) (:,:) ] volumetric soil water (v/v)
+
+         flx_lndsld_ero   =>    sedflux_vars%flx_lndsld_ero_col     , & ! Output: [real(r8) (:) ] landslide sed detach (kg/m2/s)
+         flx_lndsld_yld   =>    sedflux_vars%flx_lndsld_yld_col     , & ! Output: [real(r8) (:) ] landslide sed flux to rivers (kg/m2/s)
+         flx_sed_yld      =>    sedflux_vars%flx_sed_yld_col          & ! Output: [real(r8) (:) ] total sed flux to rivers (kg/m2/s)
+         )
+
+         do fc = 1, num_hydrologyc
+            c = filter_hydrologyc(fc)
+            l = col_pp%landunit(c)
+
+            ! initialization
+            flx_lndsld_ero(c) = 0._r8
+            flx_lndsld_yld(c) = 0._r8 
+
+            ! check the landunit type
+            if (lun_pp%itype(l)/=istsoil .and. lun_pp%itype(l)/=istcrop) then
+               cycle
+            end if
+
+            ! no steep hillslopes
+            tan_phi = tan(rpi*25./180.)
+            hslp_max = maxval(hslp_p10(c,:))
+            if (hslp_max<=tan_phi) then
+               cycle
+            end if
+
+            zsum = 0._r8
+            vwat = 0._r8
+            vwatsat = 0._r8 
+            vwatmin = 0._r8
+            Cs = 0._r8
+            Cr = 0._r8
+            Rsed = 0._r8
+            alpha = 0._r8
+            rn = 0._r8
+            ssum = 0._r8
+            do j = 1, nlevsoi
+               zsum = zsum + dz(c,j)
+               vwat = vwat + h2osoi_vol(c,j)*dz(c,j)
+               vwatsat = vwatsat + watsat(c,j)*dz(c,j) 
+               vwatmin = vwatmin + watmin(c,j)*dz(c,j)
+               Rsed = Rsed + (bd(c,j)+h2osoi_vol(c,j)*denh2o)*dz(c,j)
+               stxt = (/fclay(c,j), 100.-fclay(c,j)-fsand(c,j), fsand(c,j), &
+                  fgrvl(c,j)/)
+               Cs = Cs + 1d3*lndsld_cs*SoilCohesion2(stxt)*dz(c,j)
+               Cr = Cr + 5d3*lndsld_cr*dz(c,j)
+               alpha = alpha + SoilVanGenuchten(stxt)*dz(c,j)
+               rn = rn + SoilPoreShape(stxt)*dz(c,j)
+               ssum = ssum + bd(c,j)*dz(c,j)
+            end do
+
+            ftree = 0._r8
+            do pi = 1, max_patch_per_col
+               if ( pi<=col_pp%npfts(c) ) then
+                  p = col_pp%pfti(c) + pi - 1
+                  if (veg_pp%active(p)) then
+                     if (veg_pp%itype(p)>=1 .and. veg_pp%itype(p)<=8) then
+                        ftree = ftree + veg_pp%wtcol(p)
+                     end if
+                  end if
+               end if
+            end do
+
+            vwat = vwat / zsum
+            vwatsat = vwatsat / zsum
+            vwatmin = vwatmin / zsum
+            Rwat = denh2o * grav
+            Rsed = Rsed * grav / zsum
+            Cs = Cs / zsum
+            Cr = ftree * Cr / zsum
+            alpha = alpha / zsum
+            rn = rn / zsum
+            theta = min( (vwat-vwatmin)/(vwatsat-vwatmin), 1.0 )
+            h = -1._r8/alpha*(theta**(-rn/(rn-1.))-1.)**(1./rn)
+
+            Es_L = 0._r8
+            nslp = size(hslp_p10(c,:))
+            do j = 1, nslp
+               if (j==1) then
+                  fslp = 1.5 / DBLE(nslp)
+               else if (j<nslp-1) then
+                  fslp = 1.0 / DBLE(nslp)
+               else if (j==nslp-1) then
+                  fslp = 1.3 / DBLE(nslp)
+               else
+                  fslp = 0.2 / DBLE(nslp)
+               end if
+               if (hslp_p10(c,j)>tan_phi) then
+                  omega = atan(hslp_p10(c,j))
+                  sin_omega = sin(omega)
+                  tan_omega = tan(omega)
+                  zn = znsoil(c) * cos(omega)
+                  FS = (Cs+Cr)/(zn*Rsed*sin_omega) + tan_phi/tan_omega - &
+                     (Rwat*h)/(Rsed*zn)*theta*tan_phi/sin_omega
+                  if (FS<1.0) then
+                     expn = 2. - lndsld_xi
+                     if (expn==0.0) then
+                        vol = log(1d3/lndsld_Vmin)
+                     else
+                        vol = (lndsld_Vmax**expn - lndsld_Vmin**expn) / expn
+                     end if
+                     Es_L = Es_L + 1d-10 / 8.64 * fslp * Rsed * vol
+                  end if
+               end if
+            end do
+
+            flx_lndsld_ero(c) = flx_lndsld_ero(c) + Es_L
+            flx_lndsld_yld(c) = flx_lndsld_yld(c) + Es_L
+            flx_sed_yld(c) = flx_sed_yld(c) + Es_L
+         end do
+
+    end associate
+
+  end subroutine Landslide
+
+  !------------------------------------------------------------------------------
+  character(len=32) function SoilTextureType(stxt)
+    !
+    ! !DESCRIPTION:
+    ! soil texture 
+    !
+    ! !ARGUMENTS:
+    implicit none
+    real(r8), intent(in) :: stxt(4)  ! [clay, silt, sand, gravel] in percentage
+    !
+    ! !LOCAL VARIABLES:
+    real(r8) :: clay, silt, sand, tsum 
+    !------------------------------------------------------------------------------
+
+    tsum = sum(stxt(1:3))
+    clay = stxt(1) / tsum 
+    silt = stxt(2) / tsum
+    sand = stxt(3) / tsum
+    if (silt + 1.5*clay < 15) then
+       SoilTextureType = 'sand'
+    else if (silt + 2*clay < 30) then
+       SoilTextureType = 'loamy sand'
+    else if (((clay>=7 .and. clay<20) .and. sand>52) .or. &
+            (clay<7 .and. silt<50)) then
+       SoilTextureType = 'sandy loam'
+    else if ((clay>=7 .and. clay<27) .and. (silt>=28 .and. silt<50) .and. &
+            sand<=52) then
+       SoilTextureType = 'loam'
+    else if ((silt>=50 .and. (clay>=12 .and. clay<27)) .or. &
+            ((silt>=50 .and. silt<80) .and. clay<12)) then
+       SoilTextureType = 'silt loam'
+    else if (silt>=80 .and. clay<12) then
+       SoilTextureType = 'silt'
+    else if ((clay>=20 .and. clay<35) .and. silt<28 .and. sand>45) then
+       SoilTextureType = 'sandy clay loam'
+    else if ((clay>=27 .and. clay<40) .and. (sand>20 .and. sand<=45)) then
+       SoilTextureType = 'clay loam'
+    else if ((clay>=27 .and. clay<40) .and. sand<=20) then
+       SoilTextureType = 'silty clay loam'
+    else if (clay>=35 .and. sand>45) then
+       SoilTextureType = 'sandy clay'
+    else if (clay>=40 .and. silt>=40) then
+       SoilTextureType = 'silty clay'
+    else if (clay>=40 .and. sand<=45 .and. silt<40) then
+       SoilTextureType = 'clay'     
+    end if
+
+  end function SoilTextureType
+
+  !------------------------------------------------------------------------------
+  real(r8) function SoilDetachability(stxt)
+    !
+    ! !DESCRIPTION:
+    ! soil detachability by rain drops (g J-1)
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    implicit none
+    real(r8), intent(in) :: stxt(4)  ! [clay, silt, sand, gravel] in fraction 
+    !
+    ! !LOCAL VARIABLES:
+    character(len=32) :: txttype
+    !------------------------------------------------------------------------------
+
+    txttype = SoilTextureType(stxt) 
+    if (trim(txttype)=='clay') then
+       SoilDetachability = 0.05
+    else if (trim(txttype)=='silty clay') then
+       SoilDetachability = 0.5
+    else if (trim(txttype)=='sandy clay') then
+       SoilDetachability = 0.3
+    else if (trim(txttype)=='silty clay loam') then
+       SoilDetachability = 0.8
+    else if (trim(txttype)=='clay loam') then
+       SoilDetachability = 0.7
+    else if (trim(txttype)=='sandy clay loam') then
+       SoilDetachability = 0.1
+    else if (trim(txttype)=='silt') then
+       SoilDetachability = 1.0
+    else if (trim(txttype)=='silt loam') then
+       SoilDetachability = 0.9
+    else if (trim(txttype)=='loam') then
+       SoilDetachability = 0.8
+    else if (trim(txttype)=='sandy loam') then
+       SoilDetachability = 0.7
+    else if (trim(txttype)=='loamy sand') then
+       SoilDetachability = 0.3
+    else if (trim(txttype)=='sand') then
+       SoilDetachability = 1.9
+    end if
+
+  end function SoilDetachability
+
+  !------------------------------------------------------------------------------
+  real(r8) function SoilCohesion(stxt)
+    !
+    ! !DESCRIPTION:
+    ! soil cohesion against concentrated flow (kPa)
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    implicit none
+    real(r8), intent(in) :: stxt(4)  ! [clay, silt, sand, gravel] in fraction 
+    !
+    ! !LOCAL VARIABLES:
+    character(len=32) :: txttype
+    !------------------------------------------------------------------------------
+
+    txttype = SoilTextureType(stxt)
+    if (trim(txttype)=='clay') then
+       SoilCohesion = 12.0
+    else if (trim(txttype)=='silty clay') then
+       SoilCohesion = 10.0
+    else if (trim(txttype)=='sandy clay') then
+       SoilCohesion = 10.0
+    else if (trim(txttype)=='silty clay loam') then
+       SoilCohesion = 9.0
+    else if (trim(txttype)=='clay loam') then
+       SoilCohesion = 10.0
+    else if (trim(txttype)=='sandy clay loam') then
+       SoilCohesion = 3.0
+    else if (trim(txttype)=='silt') then
+       SoilCohesion = 3.0
+    else if (trim(txttype)=='silt loam') then
+       SoilCohesion = 3.0
+    else if (trim(txttype)=='loam') then
+       SoilCohesion = 3.0
+    else if (trim(txttype)=='sandy loam') then
+       SoilCohesion = 2.0
+    else if (trim(txttype)=='loamy sand') then
+       SoilCohesion = 2.0
+    else if (trim(txttype)=='sand') then
+       SoilCohesion = 2.0
+    end if
+
+  end function SoilCohesion
+
+  !------------------------------------------------------------------------------
+  real(r8) function SoilCohesion2(stxt)
+    !
+    ! !DESCRIPTION:
+    ! soil cohesion against landslide (kPa)
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    implicit none
+    real(r8), intent(in) :: stxt(4)  ! [clay, silt, sand, gravel] in fraction 
+    !
+    ! !LOCAL VARIABLES:
+    character(len=32) :: txttype
+    !------------------------------------------------------------------------------
+
+    txttype = SoilTextureType(stxt)
+    if (trim(txttype)=='clay') then
+       SoilCohesion2 = 10.0
+    else if (trim(txttype)=='silty clay') then
+       SoilCohesion2 = 6.0
+    else if (trim(txttype)=='sandy clay') then
+       SoilCohesion2 = 6.0
+    else if (trim(txttype)=='silty clay loam') then
+       SoilCohesion2 = 8.0
+    else if (trim(txttype)=='clay loam') then
+       SoilCohesion2 = 8.0
+    else if (trim(txttype)=='sandy clay loam') then
+       SoilCohesion2 = 6.0
+    else if (trim(txttype)=='silt') then
+       SoilCohesion2 = 4.0
+    else if (trim(txttype)=='silt loam') then
+       SoilCohesion2 = 8.0
+    else if (trim(txttype)=='loam') then
+       SoilCohesion2 = 8.0
+    else if (trim(txttype)=='sandy loam') then
+       SoilCohesion2 = 6.0
+    else if (trim(txttype)=='loamy sand') then
+       SoilCohesion2 = 2.0
+    else if (trim(txttype)=='sand') then
+       SoilCohesion2 = 2.0
+    end if
+
+  end function SoilCohesion2
+
+  !------------------------------------------------------------------------------
+  real(r8) function SoilVanGenuchten(stxt)
+    !
+    ! !DESCRIPTION:
+    ! soil van genuchten parameter (Schaap et al., 2001)
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    implicit none
+    real(r8), intent(in) :: stxt(4)  ! [clay, silt, sand, gravel] in fraction 
+    !
+    ! !LOCAL VARIABLES:
+    character(len=32) :: txttype
+    !------------------------------------------------------------------------------
+
+    txttype = SoilTextureType(stxt)
+    if (trim(txttype)=='clay') then
+       SoilVanGenuchten = 1.496
+    else if (trim(txttype)=='silty clay') then
+       SoilVanGenuchten = 1.622
+    else if (trim(txttype)=='sandy clay') then
+       SoilVanGenuchten = 3.342
+    else if (trim(txttype)=='silty clay loam') then
+       SoilVanGenuchten = 0.840
+    else if (trim(txttype)=='clay loam') then
+       SoilVanGenuchten = 1.581
+    else if (trim(txttype)=='sandy clay loam') then
+       SoilVanGenuchten = 2.109
+    else if (trim(txttype)=='silt') then
+       SoilVanGenuchten = 0.658
+    else if (trim(txttype)=='silt loam') then
+       SoilVanGenuchten = 0.506
+    else if (trim(txttype)=='loam') then
+       SoilVanGenuchten = 1.112
+    else if (trim(txttype)=='sandy loam') then
+       SoilVanGenuchten = 2.667
+    else if (trim(txttype)=='loamy sand') then
+       SoilVanGenuchten = 3.475
+    else if (trim(txttype)=='sand') then
+       SoilVanGenuchten = 3.524
+    end if
+
+  end function SoilVanGenuchten
+
+  !------------------------------------------------------------------------------
+  real(r8) function SoilPoreShape(stxt)
+    !
+    ! !DESCRIPTION:
+    ! soil van genuchten parameter (Schaap et al., 2001)
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    implicit none
+    real(r8), intent(in) :: stxt(4)  ! [clay, silt, sand, gravel] in fraction 
+    !
+    ! !LOCAL VARIABLES:
+    character(len=32) :: txttype
+    !------------------------------------------------------------------------------
+
+    txttype = SoilTextureType(stxt)
+    if (trim(txttype)=='clay') then
+       SoilPoreShape = 1.253
+    else if (trim(txttype)=='silty clay') then
+       SoilPoreShape = 1.321
+    else if (trim(txttype)=='sandy clay') then
+       SoilPoreShape = 1.208
+    else if (trim(txttype)=='silty clay loam') then
+       SoilPoreShape = 1.521
+    else if (trim(txttype)=='clay loam') then
+       SoilPoreShape = 1.416
+    else if (trim(txttype)=='sandy clay loam') then
+       SoilPoreShape = 1.331
+    else if (trim(txttype)=='silt') then
+       SoilPoreShape = 1.679
+    else if (trim(txttype)=='silt loam') then
+       SoilPoreShape = 1.663
+    else if (trim(txttype)=='loam') then
+       SoilPoreShape = 1.472
+    else if (trim(txttype)=='sandy loam') then
+       SoilPoreShape = 1.449
+    else if (trim(txttype)=='loamy sand') then
+       SoilPoreShape = 1.746
+    else if (trim(txttype)=='sand') then
+       SoilPoreShape = 3.177
+    end if
+
+  end function SoilPoreShape
+
+end module SedYieldMod

--- a/components/clm/src/biogeophys/SoilStateType.F90
+++ b/components/clm/src/biogeophys/SoilStateType.F90
@@ -18,6 +18,7 @@ module SoilStateType
   use clm_varcon      , only : secspday, pc, mu, denh2o, denice, grlnd
   use clm_varctl      , only : use_cn, use_lch4,use_dynroot, use_ed
   use clm_varctl      , only : use_var_soil_thick
+  use clm_varctl      , only : use_erosion
   use clm_varctl      , only : iulog, fsurdat, hist_wrtch4diag
   use ch4varcon       , only : allowlakeprod
   use LandunitType    , only : lun_pp                
@@ -34,10 +35,12 @@ module SoilStateType
      ! sand/ clay/ organic matter
      real(r8), pointer :: sandfrac_patch       (:)   ! patch sand fraction
      real(r8), pointer :: clayfrac_patch       (:)   ! patch clay fraction
+     real(r8), pointer :: grvlfrac_patch       (:)   ! patch gravel fraction
      real(r8), pointer :: mss_frc_cly_vld_col  (:)   ! col mass fraction clay limited to 0.20
      real(r8), pointer :: cellorg_col          (:,:) ! col organic matter for gridcell containing column (1:nlevsoi)
      real(r8), pointer :: cellsand_col         (:,:) ! sand value for gridcell containing column (1:nlevsoi)
      real(r8), pointer :: cellclay_col         (:,:) ! clay value for gridcell containing column (1:nlevsoi)
+     real(r8), pointer :: cellgrvl_col         (:,:) ! gravel value for gridcell containing column (1:nlevsoi)
      real(r8), pointer :: bd_col               (:,:) ! col bulk density of dry soil material [kg/m^3] (CN)
 
      ! hydraulic properties
@@ -130,9 +133,11 @@ contains
     allocate(this%mss_frc_cly_vld_col  (begc:endc))                     ; this%mss_frc_cly_vld_col  (:)   = nan
     allocate(this%sandfrac_patch       (begp:endp))                     ; this%sandfrac_patch       (:)   = nan
     allocate(this%clayfrac_patch       (begp:endp))                     ; this%clayfrac_patch       (:)   = nan
+    allocate(this%grvlfrac_patch       (begp:endp))                     ; this%grvlfrac_patch       (:)   = nan
     allocate(this%cellorg_col          (begc:endc,nlevgrnd))            ; this%cellorg_col          (:,:) = nan 
     allocate(this%cellsand_col         (begc:endc,nlevgrnd))            ; this%cellsand_col         (:,:) = nan 
     allocate(this%cellclay_col         (begc:endc,nlevgrnd))            ; this%cellclay_col         (:,:) = nan 
+    allocate(this%cellgrvl_col         (begc:endc,nlevgrnd))            ; this%cellgrvl_col         (:,:) = nan
     allocate(this%bd_col               (begc:endc,nlevgrnd))            ; this%bd_col               (:,:) = nan
 
     allocate(this%hksat_col            (begc_all:endc_all,nlevgrnd))    ; this%hksat_col            (:,:) = spval
@@ -340,7 +345,7 @@ contains
     real(r8)           :: bd                            ! bulk density of dry soil material [kg/m^3]
     real(r8)           :: tkm                           ! mineral conductivity
     real(r8)           :: xksat                         ! maximum hydraulic conductivity of soil [mm/s]
-    real(r8)           :: clay,sand                     ! temporaries
+    real(r8)           :: clay,sand,gravel              ! temporaries
     real(r8)           :: organic_max                   ! organic matter (kg/m3) where soil is assumed to act like peat
     integer            :: dimid                         ! dimension id
     logical            :: readvar 
@@ -351,6 +356,7 @@ contains
     real(r8) ,pointer  :: gti (:)                       ! read in - fmax 
     real(r8) ,pointer  :: sand3d (:,:)                  ! read in - soil texture: percent sand (needs to be a pointer for use in ncdio)
     real(r8) ,pointer  :: clay3d (:,:)                  ! read in - soil texture: percent clay (needs to be a pointer for use in ncdio)
+    real(r8) ,pointer  :: grvl3d (:,:)                  ! read in - soil texture: percent gravel (needs to be a pointer for use in ncdio)
     real(r8) ,pointer  :: organic3d (:,:)               ! read in - organic matter: kg/m3 (needs to be a pointer for use in ncdio)
     character(len=256) :: locfn                         ! local filename
     integer            :: nlevbed                       ! # of layers above bedrock
@@ -408,13 +414,14 @@ contains
 
     allocate(sand3d(begg:endg,nlevsoifl))
     allocate(clay3d(begg:endg,nlevsoifl))
+    allocate(grvl3d(begg:endg,nlevsoifl))
 
     ! --------------------------------------------------------------------
     ! Read surface dataset
     ! --------------------------------------------------------------------
 
     if (masterproc) then
-       write(iulog,*) 'Attempting to read soil color, sand and clay boundary data .....'
+       write(iulog,*) 'Attempting to read soil color, sand and clay, gravel boundary data .....'
     end if
 
     call getfil (fsurdat, locfn, 0)
@@ -437,7 +444,7 @@ contains
     allocate(organic3d(bounds%begg:bounds%endg,nlevsoifl))
     call organicrd(organic3d)
 
-    ! Read in sand and clay data
+    ! Read in sand, clay, gravel data
 
     call ncd_io(ncid=ncid, varname='PCT_SAND', flag='read', data=sand3d, dim1name=grlnd, readvar=readvar)
     if (.not. readvar) then
@@ -447,6 +454,15 @@ contains
     call ncd_io(ncid=ncid, varname='PCT_CLAY', flag='read', data=clay3d, dim1name=grlnd, readvar=readvar)
     if (.not. readvar) then
        call endrun(msg=' ERROR: PCT_CLAY NOT on surfdata file'//errMsg(__FILE__, __LINE__)) 
+    end if
+
+    if (use_erosion) then
+       call ncd_io(ncid=ncid, varname='PCT_GRVL', flag='read', data=grvl3d, dim1name=grlnd, readvar=readvar)
+       if (.not. readvar) then
+          call endrun(msg=' ERROR: PCT_GRVL NOT on surfdata file'//errMsg(__FILE__, __LINE__))
+       end if
+    else
+       grvl3d(:,:) = 0._r8
     end if
 
     do p = bounds%begp,bounds%endp
@@ -463,8 +479,20 @@ contains
           call endrun(msg='after setting, found points sum to zero'//errMsg(__FILE__, __LINE__)) 
        end if
 
+       if ( grvl3d(g,1) == 0.0_r8 )then
+          if ( any( grvl3d(g,:) /= 0.0_r8 ) )then
+             call endrun(msg='found depth points that do NOT sum to zero when surface does'//&
+                  errMsg(__FILE__, __LINE__))
+          end if
+          grvl3d(g,:) = 1.0_r8
+       end if
+       if ( any( grvl3d(g,:) == 0.0_r8 ) )then
+          call endrun(msg='after setting, found points sum to zero'//errMsg(__FILE__, __LINE__))
+       end if
+
        this%sandfrac_patch(p) = sand3d(g,1)/100.0_r8
        this%clayfrac_patch(p) = clay3d(g,1)/100.0_r8
+       this%grvlfrac_patch(p) = grvl3d(g,1)/100.0_r8
     end do
 
     ! Read fmax
@@ -536,6 +564,7 @@ contains
              if (lev <= nlevsoi) then
                 this%cellsand_col(c,lev) = spval
                 this%cellclay_col(c,lev) = spval
+                this%cellgrvl_col(c,lev) = spval
                 this%cellorg_col(c,lev)  = spval
              end if
           end do
@@ -568,6 +597,7 @@ contains
              if (lev <= nlevsoi) then
                 this%cellsand_col(c,lev) = spval
                 this%cellclay_col(c,lev) = spval
+                this%cellgrvl_col(c,lev) = spval
                 this%cellorg_col(c,lev)  = spval
              end if
           end do
@@ -589,28 +619,33 @@ contains
                 if (lev .eq. 1) then
                    clay = clay3d(g,1)
                    sand = sand3d(g,1)
+                   gravel = grvl3d(g,1)
                    om_frac = organic3d(g,1)/organic_max 
                 else if (lev <= nlevsoi) then
                    do j = 1,nlevsoifl-1
                       if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
                          clay = clay3d(g,j+1)
                          sand = sand3d(g,j+1)
+                         gravel = grvl3d(g,j+1)
                          om_frac = organic3d(g,j+1)/organic_max    
                       endif
                    end do
                 else
                    clay = clay3d(g,nlevsoifl)
                    sand = sand3d(g,nlevsoifl)
+                   gravel = grvl3d(g,nlevsoifl)
                    om_frac = 0._r8
                 endif
              else
                 if (lev <= nlevsoi) then ! duplicate clay and sand values from 10th soil layer
                    clay = clay3d(g,lev)
                    sand = sand3d(g,lev)
+                   gravel = grvl3d(g,lev)
                    om_frac = (organic3d(g,lev)/organic_max)**2._r8
                 else
                    clay = clay3d(g,nlevsoi)
                    sand = sand3d(g,nlevsoi)
+                   gravel = grvl3d(g,nlevsoi)
                    om_frac = 0._r8
                 endif
              end if
@@ -620,6 +655,7 @@ contains
                 if (lev <= nlevsoi) then
                    this%cellsand_col(c,lev) = sand
                    this%cellclay_col(c,lev) = clay
+                   this%cellgrvl_col(c,lev) = gravel
                    this%cellorg_col(c,lev)  = om_frac*organic_max
                 end if
 
@@ -632,6 +668,7 @@ contains
                 if (lev <= nlevbed) then
                    this%cellsand_col(c,lev) = sand
                    this%cellclay_col(c,lev) = clay
+                   this%cellgrvl_col(c,lev) = gravel
                    this%cellorg_col(c,lev)  = om_frac*organic_max
                 end if
 
@@ -739,10 +776,12 @@ contains
              if ( lev <= nlevsoi )then
                 clay    =  this%cellclay_col(c,lev)
                 sand    =  this%cellsand_col(c,lev)
+                gravel  =  this%cellgrvl_col(c,lev)
                 om_frac = (this%cellorg_col(c,lev)/organic_max)**2._r8
              else
                 clay    = this%cellclay_col(c,nlevsoi)
                 sand    = this%cellsand_col(c,nlevsoi)
+                gravel  = this%cellgrvl_col(c,nlevsoi)
                 om_frac = 0.0_r8
              end if
 
@@ -814,7 +853,7 @@ contains
     ! Deallocate memory
     ! --------------------------------------------------------------------
 
-    deallocate(sand3d, clay3d, organic3d)
+    deallocate(sand3d, clay3d, grvl3d, organic3d)
     deallocate(zisoifl, zsoifl, dzsoifl)
 
   end subroutine InitCold

--- a/components/clm/src/biogeophys/WaterfluxType.F90
+++ b/components/clm/src/biogeophys/WaterfluxType.F90
@@ -51,6 +51,10 @@ module WaterfluxType
      real(r8), pointer :: qflx_dew_grnd_col        (:)   ! col ground surface dew formation (mm H2O /s) [+] (+ = to atm); usually eflx_bot >= 0)
      real(r8), pointer :: qflx_prec_intr_patch     (:)   ! patch interception of precipitation [mm/s]
      real(r8), pointer :: qflx_prec_intr_col       (:)   ! col interception of precipitation [mm/s]
+     real(r8), pointer :: qflx_dirct_rain_patch    (:)   ! patch direct through rainfall [mm/s]
+     real(r8), pointer :: qflx_dirct_rain_col      (:)   ! col direct through rainfall [mm/s] 
+     real(r8), pointer :: qflx_leafdrip_patch      (:)   ! patch leaf rain drip [mm/s]
+     real(r8), pointer :: qflx_leafdrip_col        (:)   ! col leaf rain drip [mm/s]
 
      real(r8), pointer :: qflx_ev_snow_patch       (:)   ! patch evaporation heat flux from snow       (W/m**2) [+ to atm] ! NOTE: unit shall be mm H2O/s for water NOT heat
      real(r8), pointer :: qflx_ev_snow_col         (:)   ! col evaporation heat flux from snow         (W/m**2) [+ to atm] ! NOTE: unit shall be mm H2O/s for water NOT heat
@@ -190,6 +194,11 @@ contains
 
     allocate(this%qflx_dew_grnd_patch      (begp:endp))              ; this%qflx_dew_grnd_patch      (:)   = nan
     allocate(this%qflx_dew_snow_patch      (begp:endp))              ; this%qflx_dew_snow_patch      (:)   = nan
+
+    allocate(this%qflx_dirct_rain_patch    (begp:endp))              ; this%qflx_dirct_rain_patch    (:)   = nan
+    allocate(this%qflx_leafdrip_patch      (begp:endp))              ; this%qflx_leafdrip_patch      (:)   = nan
+    allocate(this%qflx_dirct_rain_col      (begc:endc))              ; this%qflx_dirct_rain_col      (:)   = nan
+    allocate(this%qflx_leafdrip_col        (begc:endc))              ; this%qflx_leafdrip_col        (:)   = nan
 
     allocate(this%qflx_prec_intr_col       (begc:endc))              ; this%qflx_prec_intr_col       (:)   = nan
     allocate(this%qflx_prec_grnd_col       (begc:endc))              ; this%qflx_prec_grnd_col       (:)   = nan
@@ -444,6 +453,16 @@ contains
     call hist_addfld1d (fname='QSNWCPLIQ', units='mm H2O/s', &
          avgflag='A', long_name='excess rainfall due to snow capping', &
          ptr_patch=this%qflx_snwcp_liq_patch, c2l_scale_type='urbanf', default='inactive')
+
+    this%qflx_dirct_rain_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QWTRGH', units='mm/s',  &
+         avgflag='A', long_name='direct rain throughfall', &
+         ptr_patch=this%qflx_dirct_rain_patch, c2l_scale_type='urbanf', default='inactive')
+
+    this%qflx_leafdrip_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QWDRIP', units='mm/s',  &
+         avgflag='A', long_name='leaf rain drip', &
+         ptr_patch=this%qflx_leafdrip_patch, c2l_scale_type='urbanf', default='inactive')
 
     ! Use qflx_snwcp_ice_col rather than qflx_snwcp_ice_patch, because the column version 
     ! is the final version, which includes some  additional corrections beyond the patch-level version

--- a/components/clm/src/data_types/ColumnType.F90
+++ b/components/clm/src/data_types/ColumnType.F90
@@ -50,7 +50,10 @@ module ColumnType
      real(r8), pointer :: n_melt               (:)   ! SCA shape parameter
      real(r8), pointer :: topo_slope           (:)   ! gridcell topographic slope
      real(r8), pointer :: topo_std             (:)   ! gridcell elevation standard deviation
-     integer, pointer  :: nlevbed             (:)   ! number of layers to bedrock
+     real(r8), pointer :: hslp                 (:)   ! hillslope average slope (unitless)
+     real(r8), pointer :: hslp_p10             (:,:) ! hillslope slope percentiles (unitless)
+     real(r8), pointer :: znsoil               (:)   ! soil depth (m)
+     integer, pointer  :: nlevbed              (:)   ! number of layers to bedrock
      real(r8), pointer :: zibed                (:)   ! bedrock depth in model (interface level at nlevbed)
 
      ! vertical levels
@@ -109,6 +112,9 @@ contains
     allocate(this%n_melt      (begc:endc))                     ; this%n_melt      (:)   = nan 
     allocate(this%topo_slope  (begc:endc))                     ; this%topo_slope  (:)   = nan
     allocate(this%topo_std    (begc:endc))                     ; this%topo_std    (:)   = nan
+    allocate(this%hslp        (begc:endc))                     ; this%hslp        (:)   = nan
+    allocate(this%hslp_p10    (begc:endc,10))                  ; this%hslp_p10    (:,:) = nan
+    allocate(this%znsoil      (begc:endc))                     ; this%znsoil      (:)   = nan
     allocate(this%nlevbed     (begc:endc))                     ; this%nlevbed     (:)   = ispval
     allocate(this%zibed       (begc:endc))                     ; this%zibed       (:)   = nan
 
@@ -143,6 +149,9 @@ contains
     deallocate(this%n_melt     )
     deallocate(this%topo_slope )
     deallocate(this%topo_std   )
+    deallocate(this%hslp       )
+    deallocate(this%hslp_p10   )
+    deallocate(this%znsoil     )
     deallocate(this%nlevbed    )
     deallocate(this%zibed      )
 

--- a/components/clm/src/main/ColumnMod.F90
+++ b/components/clm/src/main/ColumnMod.F90
@@ -65,6 +65,8 @@ contains
     idx = idx + 1; if (.not. isnan(col_pp%n_melt      (c)))  values(idx) = col_pp%n_melt      (c)
     idx = idx + 1; if (.not. isnan(col_pp%topo_slope  (c)))  values(idx) = col_pp%topo_slope  (c)
     idx = idx + 1; if (.not. isnan(col_pp%topo_std    (c)))  values(idx) = col_pp%topo_std    (c)
+    idx = idx + 1; if (.not. isnan(col_pp%hslp        (c)))  values(idx) = col_pp%hslp        (c)
+    idx = idx + 1; if (.not. isnan(col_pp%znsoil      (c)))  values(idx) = col_pp%znsoil      (c)
 
     idx = idx + 1;                                         values(idx) = real(col_pp%snl   (c))
     idx = idx + 1; if (.not. isnan(col_pp%lakedepth   (c)))  values(idx) =      col_pp%lakedepth(c)
@@ -87,6 +89,10 @@ contains
 
     do j = 1,nlevlak
        idx = idx + 1; if (.not. isnan(col_pp%z_lake(c,j))) values(idx) = col_pp%z_lake(c,j)
+    enddo
+
+    do j = 1,10
+       idx = idx + 1; if (.not. isnan(col_pp%hslp_p10(c,j))) values(idx) = col_pp%hslp_p10(c,j) 
     enddo
 
   end subroutine GetValuesForColumn
@@ -138,6 +144,8 @@ contains
     idx = idx + 1;                           col_pp%n_melt      (c) = values(idx)
     idx = idx + 1;                           col_pp%topo_slope  (c) = values(idx)
     idx = idx + 1;                           col_pp%topo_std    (c) = values(idx)
+    idx = idx + 1;                           col_pp%hslp        (c) = values(idx)
+    idx = idx + 1;                           col_pp%znsoil      (c) = values(idx)
 
     idx = idx + 1;                           col_pp%snl         (c) = int(values(idx))
     idx = idx + 1;                           col_pp%lakedepth   (c) = values(idx)
@@ -160,6 +168,10 @@ contains
 
     do j = 1,nlevlak
        idx = idx + 1; col_pp%z_lake(c,j) = values(idx)
+    enddo
+
+    do j = 1,10
+       idx = idx + 1; col_pp%hslp_p10(c,j) = values(idx)
     enddo
 
   end subroutine SetValuesForColumn

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -664,7 +664,7 @@ contains
                ch4_vars, dgvs_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
                nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
                soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-               waterflux_vars, waterstate_vars,                                               &
+               waterflux_vars, waterstate_vars, sedflux_vars,                                 &
                phosphorusstate_vars,phosphorusflux_vars,                                      &
                ep_betr,                                                                       &
                alm_fates)
@@ -680,7 +680,7 @@ contains
             ch4_vars, dgvs_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
             nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
             soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-            waterflux_vars, waterstate_vars,                                               &
+            waterflux_vars, waterstate_vars, sedflux_vars,                                 &
             phosphorusstate_vars,phosphorusflux_vars,                                      &
             ep_betr,                                                                       &
             alm_fates)
@@ -724,7 +724,7 @@ contains
             ch4_vars, dgvs_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
             nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
             soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-            waterflux_vars, waterstate_vars,                                               &
+            waterflux_vars, waterstate_vars, sedflux_vars,                                 &
             phosphorusstate_vars,phosphorusflux_vars,                                      &
             ep_betr,                                                                       &
             alm_fates)
@@ -740,7 +740,7 @@ contains
             ch4_vars, dgvs_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
             nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
             soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-            waterflux_vars, waterstate_vars,                                               &
+            waterflux_vars, waterstate_vars, sedflux_vars,                                 &
             phosphorusstate_vars,phosphorusflux_vars,                                      &
             ep_betr,                                                                       &
             alm_fates)

--- a/components/clm/src/main/clm_instMod.F90
+++ b/components/clm/src/main/clm_instMod.F90
@@ -29,6 +29,7 @@ module clm_instMod
   use FrictionVelocityType       , only : frictionvel_type
   use LakeStateType              , only : lakestate_type
   use PhotosynthesisType         , only : photosyns_type
+  use SedFluxType                , only : sedflux_type
   use SoilHydrologyType          , only : soilhydrology_type
   use SoilStateType              , only : soilstate_type
   use SolarAbsorbedType          , only : solarabs_type
@@ -92,6 +93,7 @@ module clm_instMod
   type(frictionvel_type)                              :: frictionvel_vars
   type(lakestate_type)                                :: lakestate_vars
   type(photosyns_type)                                :: photosyns_vars
+  type(sedflux_type)                                  :: sedflux_vars
   type(soilstate_type)                                :: soilstate_vars
   type(soilhydrology_type)                            :: soilhydrology_vars
   type(solarabs_type)                                 :: solarabs_vars
@@ -391,6 +393,8 @@ contains
 
     ! Note - always initialize the memory for cnstate_vars (used in biogeophys/)
     call cnstate_vars%Init(bounds_proc)
+
+    call sedflux_vars%Init(bounds_proc)
     ! --------------------------------------------------------------
     ! Initialise the BeTR
     ! --------------------------------------------------------------

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -346,6 +346,13 @@ module clm_varctl
   character(len=256), public :: domain_decomp_type    = 'round_robin'
 
   !-----------------------------------------------------------------------
+  ! Soil erosion
+  !-----------------------------------------------------------------------
+  logical, public :: use_erosion    = .false.
+  logical, public :: ero_lndsld     = .false.
+  logical, public :: ero_ccycle     = .false.
+
+  !-----------------------------------------------------------------------
   ! bgc & pflotran interface
   !
   logical, public :: use_clm_interface  = .false.

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -262,6 +262,9 @@ contains
     namelist /clm_inparm/ &
          use_petsc_thermal_model
 
+    namelist /clm_inparm/ &
+         use_erosion, ero_lndsld, ero_ccycle
+
     ! ----------------------------------------------------------------------
     ! Default values
     ! ----------------------------------------------------------------------
@@ -392,6 +395,16 @@ contains
        
        if (.not. use_crop .and. irrigate) then
           call endrun(msg=' ERROR: irrigate = .true. requires CROP model active.'//&
+            errMsg(__FILE__, __LINE__))
+       end if
+
+       if (.not. use_erosion .and. ero_lndsld) then
+          call endrun(msg=' ERROR: ero_lndsld = .true. requires erosion model active.'//&
+            errMsg(__FILE__, __LINE__))
+       end if
+
+       if (.not. use_erosion .and. ero_ccycle) then
+          call endrun(msg=' ERROR: ero_ccycle = .true. requires erosion model active.'//&
             errMsg(__FILE__, __LINE__))
        end if
        
@@ -778,6 +791,11 @@ contains
 
     ! PETSc-based thermal model
     call mpi_bcast (use_petsc_thermal_model, 1, MPI_LOGICAL, 0, mpicom, ier)
+
+    ! soil erosion
+    call mpi_bcast (use_erosion, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (ero_lndsld , 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (ero_ccycle , 1, MPI_LOGICAL, 0, mpicom, ier)
 
   end subroutine control_spmd
 

--- a/components/clm/src/main/pftvarcon.F90
+++ b/components/clm/src/main/pftvarcon.F90
@@ -249,6 +249,9 @@ module pftvarcon
   real(r8)              :: laimax
   ! Hydrology
   real(r8)              :: rsub_top_globalmax
+  ! Z. Tan add pft dependent parameters for ground cover
+  real(r8), allocatable :: gcpsi(:)            !bare ground LAI-decay parameter
+  real(r8), allocatable :: pftcc(:)            !plant cover reduction factor for transport capacity
 
   !
   ! !PUBLIC MEMBER FUNCTIONS:
@@ -275,6 +278,7 @@ contains
                             ncd_inqdid, ncd_inqdlen
     use clm_varctl,  only : paramfile, use_ed
     use clm_varctl,  only : use_crop, use_dynroot
+    use clm_varctl,  only : use_erosion
     use clm_varcon,  only : tfrz
     use spmdMod   ,  only : masterproc
 
@@ -497,6 +501,9 @@ contains
     allocate( mbbopt             (0:mxpft) )
     allocate( nstor              (0:mxpft) )
     allocate( br_xr              (0:mxpft) )
+    ! Ground cover for soil erosion
+    allocate( gcpsi              (0:mxpft) )
+    allocate( pftcc              (0:mxpft) )
 
     ! Set specific vegetation type values
 
@@ -883,6 +890,12 @@ contains
     if (.not. readv) br_xr(:) = 0._r8
     call ncd_io('tc_stress', tc_stress, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__))
+    if (use_erosion) then
+        call ncd_io('gcpsi',gcpsi, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+        if ( .not. readv ) call endrun(msg=' ERROR: error in reading in gcpsi data'//errMsg(__FILE__, __LINE__))
+        call ncd_io('pftcc',pftcc, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+        if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pftcc data'//errMsg(__FILE__, __LINE__))
+    end if
        
     call ncd_pio_closefile(ncid)
 


### PR DESCRIPTION
Hi,

Could you help review my soil erosion submission? In the model, soil erosion is calculated as a function of direct throughfall, rain drips and surface runoff. The eroded SOC is calculated based on the amount of soil erosion and the soil carbon content. The eroded SON and SOP are calculated based on the eroded SOC and the estimated C/N and C/P weight ratios in surface soil. When erosion takes place, the surface layer is truncated by the erosion height, and at the same time an amount of organic C, N and P corresponding to this erosion height is removed. As the thickness of soil layers is always conserved in the model, due to erosion, soils in the next soil layer are allocated to the surface layer by the amount of the erosion height and the organic C, N and P in the allocated soils are also moved. In this way, organic C, N and P from all the following soil layers move upward. We also assume that new substrates replacing the materials of the bottom soil layer are organic C, N and P free. Consequently, organic C, N and P in the last layer will decrease towards zero with erosion proceeding.

Zeli