### PR TITLE
Updates to the land model to use DECKv1 restart files with maint-1.1

### DIFF
--- a/components/clm/src/biogeophys/EnergyFluxType.F90
+++ b/components/clm/src/biogeophys/EnergyFluxType.F90
@@ -713,7 +713,7 @@ contains
          long_name='', units='', &
          interpinic_flag='interp', readvar=readvar, data=this%btran2_patch) 
 
-    call this%eflx_dynbal_dribbler%Restart(bounds, ncid, flag)
+    !call this%eflx_dynbal_dribbler%Restart(bounds, ncid, flag)
 
   end subroutine Restart
 

--- a/components/clm/src/biogeophys/TemperatureType.F90
+++ b/components/clm/src/biogeophys/TemperatureType.F90
@@ -425,10 +425,10 @@ contains
          avgflag='A', long_name='post land cover change total heat content', &
          ptr_lnd=this%heat2_grc, default='inactive')  
 
-    this%liquid_water_temp1_grc(begg:endg) = spval
-    call hist_addfld1d (fname='LIQUID_WATER_TEMP1', units='K', &
-         avgflag='A', long_name='initial gridcell weighted average liquid water temperature', &
-         ptr_lnd=this%liquid_water_temp1_grc, default='inactive')
+    !this%liquid_water_temp1_grc(begg:endg) = spval
+    !call hist_addfld1d (fname='LIQUID_WATER_TEMP1', units='K', &
+    !     avgflag='A', long_name='initial gridcell weighted average liquid water temperature', &
+    !     ptr_lnd=this%liquid_water_temp1_grc, default='inactive')
 
     this%snot_top_col(begc:endc) = spval 
     call hist_addfld1d (fname='SNOTTOPL', units='K/m', &

--- a/components/clm/src/biogeophys/WaterfluxType.F90
+++ b/components/clm/src/biogeophys/WaterfluxType.F90
@@ -675,8 +675,8 @@ contains
          long_name='mass flux due to disapperance of last snow layer', units='kg/s', &
          interpinic_flag='interp', readvar=readvar, data=this%mflx_snowlyr_col)
 
-    call this%qflx_liq_dynbal_dribbler%Restart(bounds, ncid, flag)
-    call this%qflx_ice_dynbal_dribbler%Restart(bounds, ncid, flag)
+    !call this%qflx_liq_dynbal_dribbler%Restart(bounds, ncid, flag)
+    !call this%qflx_ice_dynbal_dribbler%Restart(bounds, ncid, flag)
 
   end subroutine Restart
 


### PR DESCRIPTION
Following fixes allows one to use DECKv1 restart files with maint-1.1 branch:

* Disable the reading of data from restart file related to energy and water
  dribblers. The dribblers are currently not used in the code.
* Code to add a new optional land variable for history tapes is commented out.
  This avoids memory corruption during the update of land history variables.

[BFB]