### PR TITLE
Bug fix for optical thickness calculation in COSP-MODIS in maint-1.0

### DIFF
--- a/components/cam/src/physics/cosp/cosp_modis_simulator.F90
+++ b/components/cam/src/physics/cosp/cosp_modis_simulator.F90
@@ -222,7 +222,7 @@ contains
 		        subCols%prec_frac(sunlit(i), j, k) == 3) .and. &
                snowSize(i, j, k) > 0.                    .and. &
                gridBox%dtau_s_snow(sunlit(i),   k) > 0. ) then
-                 opticalThickness(i, j, k) = opticalThickness(i,j,k) + gridBox%dtau_c(sunlit(i), k)
+                 opticalThickness(i, j, k) = opticalThickness(i,j,k) + gridBox%dtau_s_snow(sunlit(i), k)
 		       cloudSnow(i, j, k) = subcolHydro%mr_hydro(sunlit(i), j, k, I_LSSNOW)
 	        else
                cloudSnow       (i, j, k) = 0.


### PR DESCRIPTION
Addition of optical thickness due to stratiform snow incorrectly used the values from convective cloud.

[BFB] except for cosp modis diagnostics output