### PR TITLE
Support multiqueueing for sandiatoss3

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -406,14 +406,14 @@
 
   <batch_system MACH="sandiatoss3" type="slurm" >
     <queues>
-      <queue nodemax="12" walltimemax="04:00:00" strict="true" default="true">short</queue>
+      <queue nodemax="12" walltimemax="04:00:00" strict="true" default="true">short,batch</queue>
       <queue walltimemax="24:00:00">batch</queue>
     </queues>
   </batch_system>
 
   <batch_system MACH="ghost" type="slurm" >
     <queues>
-      <queue nodemax="12" walltimemax="04:00:00" strict="true" default="true">short</queue>
+      <queue nodemax="12" walltimemax="04:00:00" strict="true" default="true">short,batch</queue>
       <queue walltimemax="24:00:00">batch</queue>
     </queues>
   </batch_system>

--- a/cime/config/xml_schemas/config_batch.xsd
+++ b/cime/config/xml_schemas/config_batch.xsd
@@ -162,7 +162,7 @@
   <xs:element name="queue">
     <xs:complexType>
       <xs:simpleContent>
-        <xs:extension base="xs:NCName">
+        <xs:extension base="xs:string">
           <xs:attribute name="default" type="xs:boolean"/>
           <xs:attribute name="strict" type="xs:boolean"/>
           <xs:attribute name="nodemax" type="xs:integer"/>


### PR DESCRIPTION
Any job that could run on our 'short' queue could also
run on our 'batch' queue. If the short queue is full and
the batch one isn't, it would make sense to run the job in
the batch queue.

[BFB]