### PR TITLE
CIME changes for PIO2

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -867,6 +867,7 @@
       <env name="LD_LIBRARY_PATH">/soft/apps/packages/climate/hdf5/1.8.16-serial/gcc-6.2.0/lib:$ENV{LD_LIBRARY_PATH}</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
+      <env name="HDF5_PATH">$SHELL{dirname $(dirname $(which h5dump))}</env>
       <!-- We currently don't have a soft env for pnetcdf 1.8.1 -->
       <env name="PNETCDF_PATH">/soft/apps/packages/climate/pnetcdf/1.8.1/gcc-6.2.0</env>
     </environment_variables>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -830,8 +830,8 @@
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -854,7 +854,7 @@
       <modules compiler="gnu" mpilib="!mpi-serial">
         <command name="add">+mpich-3.2-gcc-6.2.0</command>
         <command name="add">+hdf5-1.8.16-gcc-6.2.0-mpich-3.2-parallel</command>
-        <command name="add">+netcdf-4.3.3.1c-4.2cxx-4.4.2f-parallel-gcc6.2.0-mpich3.2</command>
+        <command name="add">+netcdf-4.4.1c-4.2cxx-4.4.4f-parallel-gcc6.2.0-mpich-3.2</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -855,7 +855,6 @@
         <command name="add">+mpich-3.2-gcc-6.2.0</command>
         <command name="add">+hdf5-1.8.16-gcc-6.2.0-mpich-3.2-parallel</command>
         <command name="add">+netcdf-4.3.3.1c-4.2cxx-4.4.2f-parallel-gcc6.2.0-mpich3.2</command>
-        <command name="add">+pnetcdf-1.6.1-gcc-6.2.0-mpich-3.2</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -868,7 +867,8 @@
       <env name="LD_LIBRARY_PATH">/soft/apps/packages/climate/hdf5/1.8.16-serial/gcc-6.2.0/lib:$ENV{LD_LIBRARY_PATH}</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
-      <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
+      <!-- We currently don't have a soft env for pnetcdf 1.8.1 -->
+      <env name="PNETCDF_PATH">/soft/apps/packages/climate/pnetcdf/1.8.1/gcc-6.2.0</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">64M</env>

--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -676,6 +676,7 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(EXTRA_PIO_FPPDEFS) $(IN
               -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
               -D GPTL_PATH:STRING=$(INSTALL_SHAREDPATH) \
               -D PIO_ENABLE_TESTS:BOOL=OFF \
+              -D PIO_USE_MALLOC:BOOL=ON \
 	      -D USER_CMAKE_MODULE_PATH:LIST="$(CIMEROOT)/src/CMake;$(CIMEROOT)/src/externals/pio2/cmake" \
 
 # Allow for separate installations of the NetCDF C and Fortran libraries

--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -689,6 +689,10 @@ else ifeq ($(NETCDF_SEPARATE), TRUE)
                 -D NetCDF_Fortran_PATH:PATH=$(NETCDF_FORTRAN_PATH)
 endif
 
+ifdef HDF5_PATH
+        CMAKE_OPTS += -D HDF5_PATH:STRING="$(HDF5_PATH)"
+endif
+
 ifdef PNETCDF_PATH
 	CMAKE_OPTS += -D PnetCDF_PATH:STRING="$(PNETCDF_PATH)"
 else

--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -703,6 +703,9 @@ endif
 ifdef PIO_FILESYSTEM_HINTS
 	CMAKE_OPTS += -D PIO_FILESYSTEM_HINTS:STRING="$(PIO_FILESYSTEM_HINTS)"
 endif
+ifeq ($(MPILIB),mpi-serial)
+	CMAKE_OPTS += -D PIO_USE_MPISERIAL=TRUE -D MPISERIAL_PATH=$(INSTALL_SHAREDPATH)
+endif
 
 # This captures the many cism-specific options to cmake
 CMAKE_OPTS += $(USER_CMAKE_OPTS)

--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -134,6 +134,8 @@ endif
 
 ifeq ($(strip $(PIO_VERSION)),1)
   CPPDEFS += -DPIO1
+else
+  USE_CXX = true
 endif
 
 ifeq (,$(SHAREDPATH))

--- a/components/homme/cmake/machineFiles/anlworkstation.cmake
+++ b/components/homme/cmake/machineFiles/anlworkstation.cmake
@@ -9,7 +9,7 @@ SET (CMAKE_CXX_COMPILER mpicxx CACHE FILEPATH "")
 SET (ENABLE_OPENMP TRUE CACHE BOOL "")
 
 SET (PNETCDF_DIR /soft/apps/packages/climate/pnetcdf/1.8.1/gcc-6.2.0 CACHE FILEPATH "")
-SET (NETCDF_DIR /soft/apps/packages/climate/netcdf/4.3.3.1c-4.2cxx-4.4.2f-parallel/gcc-6.2.0 CACHE FILEPATH "")
+SET (NETCDF_DIR /soft/apps/packages/climate/netcdf/4.4.1c-4.2cxx-4.4.4f-parallel/gcc-6.2.0 CACHE FILEPATH "")
 SET (ENV{HDF5} /soft/apps/packages/climate/hdf5/1.8.16-parallel/gcc-6.2.0 CACHE FILEPATH "")
 #SET (ENV{LIBZ} /soft/libraries/alcf/current/xl/ZLIB CACHE FILEPATH "")
 SET (CPRNC_DIR /home/climate1/acme/cprnc/build/cprnc CACHE FILEPATH "")
@@ -19,7 +19,7 @@ SET (USE_MPIEXEC mpiexec CACHE FILEPATH "")
 
 SET (HOMME_FIND_BLASLAPACK TRUE CACHE BOOL "")
 #SET (ENV{PATH} "/soft/libraries/alcf/current/xl/BLAS/lib:/soft/libraries/alcf/current/xl/LAPACK/lib:$ENV{PATH}")
-SET (ENV{PATH} "/soft/apps/packages/climate/netcdf/4.3.3.1c-4.2cxx-4.4.2f-parallel:$ENV{PATH}")
+SET (ENV{PATH} "/soft/apps/packages/climate/netcdf/4.4.1c-4.2cxx-4.4.4f-parallel:$ENV{PATH}")
 SET (ENV{LD_LIBRARY_PATH} "/soft/apps/packages/climate/hdf5/1.8.16-serial/gcc-6.2.0/lib:$ENV{LD_LIBRARY_PATH}")
 
 SET (BUILD_HOMME_SWEQX FALSE CACHE BOOL "")


### PR DESCRIPTION
This PR includes CIME fixes for PIO2,

* Configure/compile options for PIO2
* Some machine file changes for anlworkstation for PIO2
   (Upgrades NetCDF and PnetCDF lib versions, reduces default number of tasks from 64 to 32)

[BFB]