### PR TITLE
Turn on eddy stats for oEC60to30v3 and oEC60to30v3wLI grids by default

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -817,6 +817,8 @@
 
 <!-- AM_eddyProductVariables -->
 <config_AM_eddyProductVariables_enable>.false.</config_AM_eddyProductVariables_enable>
+<config_AM_eddyProductVariables_enable ocn_grid="oEC60to30v3">.true.</config_AM_eddyProductVariables_enable>
+<config_AM_eddyProductVariables_enable ocn_grid="oEC60to30v3wLI">.true.</config_AM_eddyProductVariables_enable>
 <config_AM_eddyProductVariables_enable ocn_grid="oRRS30to10v3">.true.</config_AM_eddyProductVariables_enable>
 <config_AM_eddyProductVariables_enable ocn_grid="oRRS30to10v3wLI">.true.</config_AM_eddyProductVariables_enable>
 <config_AM_eddyProductVariables_enable ocn_grid="oRRS18to6v3">.true.</config_AM_eddyProductVariables_enable>


### PR DESCRIPTION
This PR turns on the ocean analysis member eddyProductVariables by default for the oEC60to30v3 and oEC60to30v3wLI MPAS-Ocean grids.

[BFB]
[NML] - changes namelist option for compsets using oEC60to30v3, oEC60to30v3wLI grids.

Passes 
```ERS.T62_oEC60to30v3wLI.GMPAS-DIB-IAF-ISMF.edison_intel```