### PR TITLE
Add a new kokkos build-only test to e3sm_developer.

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1418,7 +1418,6 @@ for mct, etc.
 
 <compiler MACH="melvin" COMPILER="gnu">
   <ALBANY_PATH>/projects/install/rhel6-x86_64/ACME/AlbanyTrilinos/Albany/build/install</ALBANY_PATH>
-  <KOKKOS_OPTIONS> --with-openmp --with-options=aggressive_vectorization </KOKKOS_OPTIONS>
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -112,6 +112,7 @@ _TESTS = {
             "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
             "SMS.f09_g16_a.IGCLM45_MLI",
             "SMS_P12x2.ne4_oQU240.A_WCYCL1850.allactive-mach_mods",
+            "SMS_B.ne4_ne4.FC5AV1C-L-AQUAP.cam-hommexx",
             )
         },
 

--- a/cime/src/build_scripts/buildlib.kokkos
+++ b/cime/src/build_scripts/buildlib.kokkos
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from standard_script_setup import *
-from CIME.utils import expect, run_bld_cmd_ensure_logging, run_cmd_no_fail
+from CIME.utils import expect, run_bld_cmd_ensure_logging, run_cmd_no_fail, run_cmd
 from CIME.case import Case
 from CIME.build import get_standard_makefile_args
 
@@ -52,8 +52,14 @@ def buildlib(bldroot, installpath, case):
     # (generated from config_compilers.xml), but we want to otherwise
     # let kokkos control flags
     make_args = get_standard_makefile_args(case)
-    kokkos_options = run_cmd_no_fail("make -f Macros.make {} -p | grep KOKKOS_OPTIONS".format(make_args)).split(":=")[-1].strip()
-    cxx            = run_cmd_no_fail("make -f Macros.make {} -p | grep SCXX".format(make_args)).split(":=")[-1].strip()
+    stat, output, _ = run_cmd("make -f Macros.make {} -p | grep KOKKOS_OPTIONS".format(make_args))
+    if stat == 0:
+        kokkos_options = output.split(":=")[-1].strip()
+    else:
+        kokkos_options = "--with-openmp --with-serial" # This is the default
+        logger.warning("Failed to find custom kokkos options, using default.")
+
+    cxx = run_cmd_no_fail("make -f Macros.make {} -p | grep SCXX".format(make_args)).split(":=")[-1].strip()
 
     gmake_cmd = case.get_value("GMAKE")
     gmake_j = case.get_value("GMAKE_J")


### PR DESCRIPTION
Change list:
1) Add a new 'B' test option to indicate a build-only test
2) Have '--with-openmp --with-serial' be the default kokkos configuration
3) Add SMS_B.ne4_ne4.FC5AV1C-L-AQUAP.cam-hommexx to e3sm_developer

[BFB]