### PR TITLE
Fix nonbfb behavior in homme with map2 wrt number of ranks

### DIFF
--- a/components/homme/src/share/interpolate_mod.F90
+++ b/components/homme/src/share/interpolate_mod.F90
@@ -1052,13 +1052,14 @@ contains
     type (cartesian2D_t), intent(out)     :: cart
     integer             , intent(out)     :: number
 
-    integer               :: ii
+    integer               :: ii, globalid, maxglobalid
     Logical               :: found
     type (cartesian3D_t)       :: sphere_xyz
     type (cartesian2D_t)  :: cube
     sphere_xyz=spherical_to_cart(sphere)
 
     number=-1
+    maxglobalid = number
 !    print *,'WARNING: using GC map'
     do ii = 1,nelemd
        ! for equiangular gnomonic map:
@@ -1071,10 +1072,15 @@ contains
        endif
 
        if (found) then
-          number = ii
-          cart = parametric_coordinates(sphere, elem(ii)%corners3D,&
-               cubed_sphere_map,elem(ii)%corners,elem(ii)%cartp,elem(ii)%facenum)
-          exit
+          !get current global id
+          globalid = elem(ii)%vertex%number
+          !if current global id > the previous one, re-assign
+          if ( globalid > maxglobalid ) then
+             maxglobalid = globalid
+             number = ii
+             cart = parametric_coordinates(sphere, elem(ii)%corners3D,&
+                  cubed_sphere_map,elem(ii)%corners,elem(ii)%cartp,elem(ii)%facenum)
+          endif
        end if
     end do
   end subroutine cube_facepoint_unstructured


### PR DESCRIPTION
Fixes nonbfb behavior in homme with map2 wrt number of ranks. Note that the problem is only with interpolated output (not mentioned in the issue). There is no problem with reproducibility in the dycore. One can compare std outputs from different # of ranks and the output is identical. In addition we ran native output with the same scripts and movies are identical.

In case of interpolated output and map2 there is a code in interpolation_mod (in routine cube_facepoint_unstructured) that exits after the first matching element for an interpotalion point is found. In scenario when 2 elements share the same point, run with both elements on the same rank can possibly return element with lower global id as the match for this point. However, in case when both elements belong to different ranks, only element with bigger global id will 'owe' this point. The fix addresses exactly this scenario.

I re-used the same scripts as in issue #2535 to test this pr with map2 for runs with meshes on 24 ranks and for runs with ne2 on 24 ranks. I did not run ne2 vs mesh comparisons.

Though there is an 'exit' statement in defining local_gid for map0, I don't believe map0 has the same issue. There, global id is computed from cube face value for a particular interpolation point. Then a rank tries to find an element with such id within its element set. This logic does not seem to depend on a rank.

Fixes issue #2535 .