### PR TITLE
Use consistent casing (all-caps) for build_threaded value

### DIFF
--- a/cime/config/e3sm/machines/Depends.cetus
+++ b/cime/config/e3sm/machines/Depends.cetus
@@ -5,7 +5,7 @@ $(SSOBJS): %.o: %.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -qsmallstack $<
 
 QSMPFLAGS:=
-ifeq ($(compile_threaded), true)
+ifeq ($(compile_threaded), TRUE)
   QSMPFLAGS += -qsmp=noauto:noomp
 endif
 shr_reprosum_mod.o: shr_reprosum_mod.F90

--- a/cime/config/e3sm/machines/Depends.mira
+++ b/cime/config/e3sm/machines/Depends.mira
@@ -5,7 +5,7 @@ $(SSOBJS): %.o: %.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -qsmallstack $<
 
 QSMPFLAGS:=
-ifeq ($(compile_threaded), true)
+ifeq ($(compile_threaded), TRUE)
   QSMPFLAGS += -qsmp=noauto:noomp
 endif
 shr_reprosum_mod.o: shr_reprosum_mod.F90

--- a/cime/config/e3sm/machines/Depends.summit.ibm
+++ b/cime/config/e3sm/machines/Depends.summit.ibm
@@ -7,7 +7,7 @@ $(SSOBJS): %.o: %.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -qsmallstack $<
 
 QSMPFLAGS:=
-ifeq ($(compile_threaded), true)
+ifeq ($(compile_threaded), TRUE)
   QSMPFLAGS += -qsmp=noauto:noomp
 endif
 shr_reprosum_mod.o: shr_reprosum_mod.F90

--- a/cime/config/e3sm/machines/Depends.summitdev.ibm
+++ b/cime/config/e3sm/machines/Depends.summitdev.ibm
@@ -7,7 +7,7 @@ $(SSOBJS): %.o: %.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -qsmallstack $<
 
 QSMPFLAGS:=
-ifeq ($(compile_threaded), true)
+ifeq ($(compile_threaded), TRUE)
   QSMPFLAGS += -qsmp=noauto:noomp
 endif
 shr_reprosum_mod.o: shr_reprosum_mod.F90

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -82,7 +82,7 @@ for mct, etc.
 
 <compiler COMPILER="cray">
   <CFLAGS>
-    <append compile_threaded="false"> -h noomp </append>
+    <append compile_threaded="FALSE"> -h noomp </append>
   </CFLAGS>
   <CPPDEFS>
     <!--http://docs.cray.com/cgi-bin/craydoc.cgi?mode=View;id=S-3901-83;idx=books_search;this_sort=;q=;type=books;title=Cray%20Fortran%20Reference%20Manual -->
@@ -94,24 +94,24 @@ for mct, etc.
   </FC_AUTO_R8>
   <FFLAGS>
     <base> -O2  -f free -N 255  -h byteswapio -em </base>
-    <append compile_threaded="false"> -h noomp </append>
+    <append compile_threaded="FALSE"> -h noomp </append>
     <append DEBUG="TRUE"> -g -trapuv  -Wuninitialized </append>
   </FFLAGS>
   <FFLAGS_NOOPT>
     <base> -O0 </base>
-    <append compile_threaded="false"> -h noomp </append>
+    <append compile_threaded="FALSE"> -h noomp </append>
   </FFLAGS_NOOPT>
   <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
     <base> -Wl,--allow-multiple-definition -h byteswapio </base>
-    <append compile_threaded="false"> -h noomp </append>
+    <append compile_threaded="FALSE"> -h noomp </append>
   </LDFLAGS>
 </compiler>
 
 <compiler COMPILER="gnu">
   <CFLAGS>
     <base> -mcmodel=medium </base>
-    <append compile_threaded="true"> -fopenmp </append>
+    <append compile_threaded="TRUE"> -fopenmp </append>
     <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -fcheck=bounds -ffpe-trap=invalid,zero,overflow</append>
     <append DEBUG="FALSE"> -O </append>
     <append MODEL="csm_share"> -std=c99 </append>
@@ -131,7 +131,7 @@ for mct, etc.
     <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS
        so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
     <base> -mcmodel=medium -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </base>
-    <append compile_threaded="true"> -fopenmp </append>
+    <append compile_threaded="TRUE"> -fopenmp </append>
     <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -fcheck=bounds -ffpe-trap=invalid,zero,overflow</append>
     <append DEBUG="FALSE"> -O </append>
   </FFLAGS>
@@ -146,7 +146,7 @@ for mct, etc.
   </FREEFLAGS>
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
-    <append compile_threaded="true"> -fopenmp </append>
+    <append compile_threaded="TRUE"> -fopenmp </append>
   </LDFLAGS>
   <MPICC> mpicc  </MPICC>
   <MPICXX> mpicxx </MPICXX>
@@ -160,7 +160,7 @@ for mct, etc.
 <compiler COMPILER="gnu7">
   <CFLAGS>
     <base> -mcmodel=medium </base>
-    <append compile_threaded="true"> -fopenmp </append>
+    <append compile_threaded="TRUE"> -fopenmp </append>
     <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -fcheck=bounds -ffpe-trap=invalid,zero,overflow</append>
     <append DEBUG="FALSE"> -O </append>
   </CFLAGS>
@@ -179,7 +179,7 @@ for mct, etc.
     <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS
        so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
     <base> -mcmodel=medium -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </base>
-    <append compile_threaded="true"> -fopenmp </append>
+    <append compile_threaded="TRUE"> -fopenmp </append>
     <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -fcheck=bounds -ffpe-trap=invalid,zero,overflow</append>
     <append DEBUG="FALSE"> -O </append>
   </FFLAGS>
@@ -194,7 +194,7 @@ for mct, etc.
   </FREEFLAGS>
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
-    <append compile_threaded="true"> -fopenmp </append>
+    <append compile_threaded="TRUE"> -fopenmp </append>
   </LDFLAGS>
   <MPICC> mpicc  </MPICC>
   <MPICXX> mpicxx </MPICXX>
@@ -209,8 +209,8 @@ for mct, etc.
   <CFLAGS>
     <base> -g -qfullpath -qmaxmem=-1 -qphsinfo </base>
     <append DEBUG="FALSE"> -O3  </append>
-    <append DEBUG="FALSE" compile_threaded="true"> -qsmp=omp -qsuppress=1520-045 </append>
-    <append DEBUG="TRUE" compile_threaded="true"> -qsmp=omp:noopt -qsuppress=1520-045 </append>
+    <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp -qsuppress=1520-045 </append>
+    <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt -qsuppress=1520-045 </append>
   </CFLAGS>
   <CPPDEFS>
     <!-- http://publib.boulder.ibm.com/infocenter/comphelp/v7v91/index.jsp
@@ -239,8 +239,8 @@ for mct, etc.
   <FFLAGS>
     <base> -g -qfullpath -qmaxmem=-1 -qphsinfo </base>
     <append DEBUG="FALSE"> -O2 -qstrict -Q </append>
-    <append DEBUG="FALSE" compile_threaded="true"> -qsmp=omp -qsuppress=1520-045 </append>
-    <append DEBUG="TRUE" compile_threaded="true"> -qsmp=omp:noopt -qsuppress=1520-045 </append>
+    <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp -qsuppress=1520-045 </append>
+    <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt -qsuppress=1520-045 </append>
     <append DEBUG="TRUE"> -qinitauto=7FF7FFFF -qflttrap=ov:zero:inv:en </append>
   </FFLAGS>
   <FIXEDFLAGS>
@@ -255,7 +255,7 @@ for mct, etc.
 <compiler COMPILER="intel">
   <CFLAGS>
     <base> -O2 -fp-model precise -std=gnu99 </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="FALSE"> -O2 -debug minimal </append>
     <append DEBUG="TRUE"> -O0 -g </append>
   </CFLAGS>
@@ -277,7 +277,7 @@ for mct, etc.
   </FC_AUTO_R8>
   <FFLAGS>
     <base>  -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
     <!-- WJS (8-11-14): For some reason, yellowstone-intel has starting giving lots of
        messages about array temporaries, leading to a ton of standard output, and
        sometimes causing runs to die. Adding '-check noarg_temp_created' to suppress these
@@ -289,7 +289,7 @@ for mct, etc.
   </FFLAGS>
   <FFLAGS_NOOPT>
     <base> -O0 </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
   </FFLAGS_NOOPT>
   <FIXEDFLAGS>
     <base> -fixed -132 </base>
@@ -299,7 +299,7 @@ for mct, etc.
   </FREEFLAGS>
   <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
   </LDFLAGS>
   <MPICC> mpicc  </MPICC>
   <MPICXX> mpicxx </MPICXX>
@@ -334,8 +334,8 @@ for mct, etc.
     <!-- The "-gline" option is nice, but it doesn't work with OpenMP.         -->
     <!-- Runtime checks with OpenMP (in fact, all OpenMP cases) are WIP.       -->
     <append DEBUG="TRUE"> -C=all -g -time -f2003 -ieee=stop </append>
-    <append DEBUG="TRUE" compile_threaded="false"> -gline </append>
-    <append compile_threaded="true"> -openmp </append>
+    <append DEBUG="TRUE" compile_threaded="FALSE"> -gline </append>
+    <append compile_threaded="TRUE"> -openmp </append>
   </FFLAGS>
   <FFLAGS_NOOPT>
     <base> $FFLAGS </base>
@@ -344,8 +344,8 @@ for mct, etc.
     <!-- FFLAGS_NOOPT, allowing strict checks to be removed from files by      -->
     <!-- having them use FFLAGS_NOOPT in Depends.nag                           -->
     <append DEBUG="TRUE"> -g -time -f2003 -ieee=stop </append>
-    <append DEBUG="TRUE" compile_threaded="false"> -gline        </append>
-    <append compile_threaded="true"> -openmp </append>
+    <append DEBUG="TRUE" compile_threaded="FALSE"> -gline        </append>
+    <append compile_threaded="TRUE"> -openmp </append>
   </FFLAGS_NOOPT>
   <FIXEDFLAGS>
     <base> -fixed </base>
@@ -355,7 +355,7 @@ for mct, etc.
   </FREEFLAGS>
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
-    <append compile_threaded="true"> -openmp </append>
+    <append compile_threaded="TRUE"> -openmp </append>
   </LDFLAGS>
   <MPICC> mpicc </MPICC>
   <MPIFC> mpif90 </MPIFC>
@@ -365,7 +365,7 @@ for mct, etc.
 
 <compiler COMPILER="pathscale">
   <CFLAGS>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="TRUE"> -mp </append>
   </CFLAGS>
   <CPPDEFS>
     <!-- http://www.pathscale.com/node/70 -->
@@ -376,7 +376,7 @@ for mct, etc.
   </FC_AUTO_R8>
   <FFLAGS>
     <base> -O -extend_source -ftpp -fno-second-underscore -funderscoring -byteswapio  </base>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="TRUE"> -mp </append>
     <append DEBUG="TRUE"> -g -trapuv -Wuninitialized </append>
   </FFLAGS>
   <FFLAGS_NOOPT>
@@ -384,7 +384,7 @@ for mct, etc.
   </FFLAGS_NOOPT>
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="TRUE"> -mp </append>
   </LDFLAGS>
   <MPICC> mpicc  </MPICC>
   <MPIFC> mpif90 </MPIFC>
@@ -393,8 +393,8 @@ for mct, etc.
 <compiler COMPILER="pgi">
   <CFLAGS>
     <base> -gopt -time </base>
-    <append compile_threaded="false"> </append>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="FALSE"> </append>
+    <append compile_threaded="TRUE"> -mp </append>
   </CFLAGS>
   <CPPDEFS>
     <!-- http://www.pgroup.com/resources/docs.htm                                              -->
@@ -429,8 +429,8 @@ for mct, etc.
   </FC_AUTO_R8>
   <FFLAGS>
     <base>  -i4 -gopt  -time -Mstack_arrays  -Mextend -byteswapio -Mflushz -Kieee -Mallocatable=03 </base>
-    <append compile_threaded="false"> </append>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="FALSE"> </append>
+    <append compile_threaded="TRUE"> -mp </append>
     <append DEBUG="TRUE"> -O0 -g -Ktrap=fp -Mbounds -Kieee </append>
     <append MODEL="datm"> -Mnovect </append>
     <append MODEL="dlnd"> -Mnovect </append>
@@ -441,8 +441,8 @@ for mct, etc.
   </FFLAGS>
   <FFLAGS_NOOPT>
     <base> -O0 -g -Ktrap=fp -Mbounds -Kieee  </base>
-    <append compile_threaded="false"> </append>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="FALSE"> </append>
+    <append compile_threaded="TRUE"> -mp </append>
   </FFLAGS_NOOPT>
   <FIXEDFLAGS>
     <base> -Mfixed </base>
@@ -458,8 +458,8 @@ for mct, etc.
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
     <base> -time -Wl,--allow-multiple-definition </base>
-    <append compile_threaded="false"> </append>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="FALSE"> </append>
+    <append compile_threaded="TRUE"> -mp </append>
   </LDFLAGS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpicxx </MPICXX>
@@ -472,8 +472,8 @@ for mct, etc.
 <compiler COMPILER="pgiacc">
   <CFLAGS>
     <base> -time </base>
-    <append compile_threaded="false"> </append>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="FALSE"> </append>
+    <append compile_threaded="TRUE"> -mp </append>
   </CFLAGS>
   <CPPDEFS>
     <!-- http://www.pgroup.com/resources/docs.htm                                              -->
@@ -508,8 +508,8 @@ for mct, etc.
   </FC_AUTO_R8>
   <FFLAGS>
     <base>  -i4 -time -Mstack_arrays -Mextend -byteswapio -Mflushz -Kieee  </base>
-    <append compile_threaded="false"> </append>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="FALSE"> </append>
+    <append compile_threaded="TRUE"> -mp </append>
     <append MODEL="cam"> </append>
     <append DEBUG="TRUE"> -O0 -g -Ktrap=fp -Mbounds -Kieee </append>
     <append MODEL="datm"> -Mnovect </append>
@@ -521,8 +521,8 @@ for mct, etc.
   </FFLAGS>
   <FFLAGS_NOOPT>
     <base> -O0 -g -Ktrap=fp -Mbounds -Kieee  </base>
-    <append compile_threaded="false"> </append>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="FALSE"> </append>
+    <append compile_threaded="TRUE"> -mp </append>
   </FFLAGS_NOOPT>
   <FIXEDFLAGS>
     <base> -Mfixed </base>
@@ -538,8 +538,8 @@ for mct, etc.
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
     <base> -time -Wl,--allow-multiple-definition -acc</base>
-    <append compile_threaded="false"> </append>
-    <append compile_threaded="true"> -mp </append>
+    <append compile_threaded="FALSE"> </append>
+    <append compile_threaded="TRUE"> -mp </append>
   </LDFLAGS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpicxx </MPICXX>
@@ -624,8 +624,8 @@ for mct, etc.
 
 <compiler OS="BGQ" COMPILER="ibm">
   <CFLAGS>
-    <append DEBUG="FALSE" compile_threaded="true"> -qsmp=omp:nested_par -qsuppress=1520-045 </append>
-    <append DEBUG="TRUE" compile_threaded="true"> -qsmp=omp:nested_par:noopt -qsuppress=1520-045 </append>
+    <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp:nested_par -qsuppress=1520-045 </append>
+    <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:nested_par:noopt -qsuppress=1520-045 </append>
   </CFLAGS>
   <CONFIG_ARGS>
     <base> --build=powerpc-bgp-linux --host=powerpc64-suse-linux </base>
@@ -636,8 +636,8 @@ for mct, etc.
   <FFLAGS>
     <base> -g -qfullpath -qmaxmem=-1 -qspillsize=2500 -qextname=flush -qphsinfo </base>
     <append DEBUG="FALSE"> -O3 -qstrict -Q </append>
-    <append DEBUG="FALSE" compile_threaded="true"> -qsmp=omp:nested_par -qsuppress=1520-045 </append>
-    <append DEBUG="TRUE" compile_threaded="true"> -qsmp=omp:nested_par:noopt -qsuppress=1520-045 </append>
+    <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp:nested_par -qsuppress=1520-045 </append>
+    <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:nested_par:noopt -qsuppress=1520-045 </append>
   </FFLAGS>
   <LDFLAGS>
     <base>  -Wl,--relax -Wl,--allow-multiple-definition </base>
@@ -676,7 +676,7 @@ for mct, etc.
 
 <compiler OS="Darwin" COMPILER="intel">
   <FFLAGS>
-    <append compile_threaded="false"> -heap-arrays </append>
+    <append compile_threaded="FALSE"> -heap-arrays </append>
   </FFLAGS>
   <SLIBS>
     <append MPILIB="mpich"> -mkl=cluster </append>
@@ -726,22 +726,22 @@ for mct, etc.
 
 <compiler MACH="anvil" COMPILER="intel">
   <CFLAGS>
-    <append compile_threaded="true"> -static-intel</append>
-    <append compile_threaded="true" DEBUG="TRUE">-heap-arrays</append>
+    <append compile_threaded="TRUE"> -static-intel</append>
+    <append compile_threaded="TRUE" DEBUG="TRUE">-heap-arrays</append>
   </CFLAGS>
   <CPPDEFS>
     <append MODEL="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align</append>
-    <append compile_threaded="true"> -static-intel</append>
-    <append compile_threaded="true" DEBUG="TRUE">-heap-arrays</append>
+    <append compile_threaded="TRUE"> -static-intel</append>
+    <append compile_threaded="TRUE" DEBUG="TRUE">-heap-arrays</append>
   </FFLAGS>
   <FFLAGS_NOOPT>
-    <append compile_threaded="true"> -static-intel</append>
+    <append compile_threaded="TRUE"> -static-intel</append>
   </FFLAGS_NOOPT>
   <LDFLAGS>
-    <append compile_threaded="true"> -static-intel</append>
+    <append compile_threaded="TRUE"> -static-intel</append>
   </LDFLAGS>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
   <SLIBS>
@@ -862,7 +862,7 @@ for mct, etc.
 
 <compiler MACH="cades" COMPILER="gnu">
   <CFLAGS>
-    <append compile_threaded="true"> -fopenmp </append>
+    <append compile_threaded="TRUE"> -fopenmp </append>
   </CFLAGS>
   <CMAKE_OPTS>
     <append MODEL="cism"> -D CISM_GNU=ON </append>
@@ -880,7 +880,7 @@ for mct, etc.
     <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS
                                  so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
     <base> -O -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none -fno-range-check</base>
-    <append compile_threaded="true"> -fopenmp </append>
+    <append compile_threaded="TRUE"> -fopenmp </append>
     <append DEBUG="TRUE"> -g -Wall </append>
     <!-- <append MODEL="clm"> -I/lustre/or-hydra/cades-ccsi/$USER/models/pflotran-interface/src/clm-pflotran</append> -->
   </FFLAGS>
@@ -898,7 +898,7 @@ for mct, etc.
   <PNETCDF_PATH>/software/dev_tools/swtree/cs400_centos7.2_pe2016-08/pnetcdf/1.9.0/centos7.2_gnu5.3.0</PNETCDF_PATH>
   <LAPACK_LIBDIR>/software/tools/compilers/intel_2017/mkl/lib/intel64</LAPACK_LIBDIR>
   <LDFLAGS>
-    <append compile_threaded="true"> -fopenmp </append>
+    <append compile_threaded="TRUE"> -fopenmp </append>
     <append MODEL="driver"> -L$NETCDF_PATH/lib -Wl,-rpath=$NETCDF_PATH/lib -lnetcdff -lnetcdf </append>
     <!-- <append MODEL="driver"> -L$ENV{CLM_PFLOTRAN_SOURCE_DIR} -lpflotran $ENV{PETSC_LIB} </append> -->
   </LDFLAGS>
@@ -945,7 +945,7 @@ for mct, etc.
     <append DEBUG="TRUE" MODEL="cam">  -C=all  -g  -nan -O0 -v  </append>
   </FFLAGS>
   <LDFLAGS>
-    <append compile_threaded="true">  </append>
+    <append compile_threaded="TRUE">  </append>
   </LDFLAGS>
   <MPI_PATH MPILIB="mvapich2"> $ENV{MPI_LIB}</MPI_PATH>
   <NETCDF_PATH>$ENV{NETCDF_ROOT}</NETCDF_PATH>
@@ -978,7 +978,7 @@ for mct, etc.
   <SFC> mpixlf2003_r </SFC>
   <SLIBS>
     <append>-L$NETCDF_PATH/lib -lnetcdff -lnetcdf -L$HDF5_PATH/lib -lhdf5_hl -lhdf5 -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
-    <append compile_threaded="true"> -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
+    <append compile_threaded="TRUE"> -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
   </SLIBS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
@@ -1101,7 +1101,7 @@ for mct, etc.
 <compiler MACH="cori-knl" COMPILER="intel19">
   <CFLAGS>
     <base> -O2 -fp-model precise -std=gnu99 </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="FALSE"> -O2 -debug minimal </append>
     <append DEBUG="TRUE"> -O0 -g </append>
   </CFLAGS>
@@ -1120,13 +1120,13 @@ for mct, etc.
   </FC_AUTO_R8>
   <FFLAGS>
     <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml -fimf-use-svml=false:asin </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
   </FFLAGS>
   <FFLAGS_NOOPT>
     <base> -O0 </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
   </FFLAGS_NOOPT>
   <FIXEDFLAGS>
     <base> -fixed -132 </base>
@@ -1136,7 +1136,7 @@ for mct, etc.
   </FREEFLAGS>
   <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
   </LDFLAGS>
   <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
   <SCC> icc </SCC>
@@ -1201,7 +1201,7 @@ for mct, etc.
 <compiler MACH="edison" COMPILER="intel18">
   <CFLAGS>
     <base> -O2 -fp-model precise -std=gnu99 </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="FALSE"> -O2 -debug minimal </append>
     <append DEBUG="TRUE"> -O0 -g </append>
   </CFLAGS>
@@ -1220,13 +1220,13 @@ for mct, etc.
   </FC_AUTO_R8>
   <FFLAGS>
     <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
   </FFLAGS>
   <FFLAGS_NOOPT>
     <base> -O0 </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
   </FFLAGS_NOOPT>
   <FIXEDFLAGS>
     <base> -fixed -132 </base>
@@ -1236,7 +1236,7 @@ for mct, etc.
   </FREEFLAGS>
   <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
   </LDFLAGS>
   <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
   <SCC> icc </SCC>
@@ -1286,7 +1286,7 @@ for mct, etc.
   </FFLAGS>
   <MPI_PATH MPILIB="openmpi">/opt/openmpi-1.8-intel</MPI_PATH>
   <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
-  <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="false">/projects/ccsm/pfunit/3.2.9/mpi-serial</PFUNIT_PATH>
+  <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="FALSE">/projects/ccsm/pfunit/3.2.9/mpi-serial</PFUNIT_PATH>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
@@ -1299,7 +1299,7 @@ for mct, etc.
 <compiler MACH="itasca" COMPILER="intel">
   <CFLAGS>
     <base> -O2 -fp-model precise -I/soft/intel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
-    <append compile_threaded="true"> -openmp </append>
+    <append compile_threaded="TRUE"> -openmp </append>
   </CFLAGS>
   <CPPDEFS>
     <append> -DFORTRANUNDERSCORE -DNO_R16</append>
@@ -1314,7 +1314,7 @@ for mct, etc.
   </FC_AUTO_R8>
   <FFLAGS>
     <base> -fp-model source -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -I/soft/intel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
-    <append compile_threaded="true"> -openmp </append>
+    <append compile_threaded="TRUE"> -openmp </append>
     <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 </append>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
@@ -1328,7 +1328,7 @@ for mct, etc.
     <base> -free </base>
   </FREEFLAGS>
   <LDFLAGS>
-    <append compile_threaded="true"> -openmp </append>
+    <append compile_threaded="TRUE"> -openmp </append>
     <append> -lnetcdff </append>
   </LDFLAGS>
   <MPICC> mpiicc  </MPICC>
@@ -1432,7 +1432,7 @@ for mct, etc.
     <append > -I$ENV{NETCDFROOT}/include  </append>
   </FFLAGS>
   <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
-  <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="false">$ENV{SEMS_PFUNIT_ROOT}</PFUNIT_PATH>
+  <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="FALSE">$ENV{SEMS_PFUNIT_ROOT}</PFUNIT_PATH>
   <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append>$SHELL{$NETCDF_PATH/bin/nf-config --flibs} -lblas -llapack</append>
@@ -1489,22 +1489,22 @@ for mct, etc.
     <base> -xCORE_AVX512 -mkl -std=c++11 </base>
     <append DEBUG="FALSE"> -O3 -g -debug minimal </append>
     <append DEBUG="TRUE"> -O0 -g </append>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
   </CXXFLAGS>
   <FFLAGS>
     <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -xCORE_AVX512 -mkl </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="FALSE"> -O3 -g -debug minimal </append>
     <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
   </FFLAGS>
   <LDFLAGS>
     <base> -mkl -lstdc++ </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
     <append MODEL="driver">-L$(NETCDF_FORTRAN_PATH)/lib64</append>
   </LDFLAGS>
   <FFLAGS_NOOPT>
     <base> -O0 </base>
-    <append compile_threaded="true"> -qopenmp </append>
+    <append compile_threaded="TRUE"> -qopenmp </append>
   </FFLAGS_NOOPT>
   <FIXEDFLAGS>
     <base> -fixed -132 </base>
@@ -1530,7 +1530,7 @@ for mct, etc.
   <CFLAGS>
     <base> -O2 -fp-model precise -I/soft/intel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/inc
 lude </base>
-    <append compile_threaded="true"> -openmp </append>
+    <append compile_threaded="TRUE"> -openmp </append>
   </CFLAGS>
   <CPPDEFS>
     <append> -DFORTRANUNDERSCORE -DNO_R16</append>
@@ -1546,7 +1546,7 @@ lude </base>
   <FFLAGS>
     <base> -fp-model source -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -I/soft/i
 ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
-    <append compile_threaded="true"> -openmp </append>
+    <append compile_threaded="TRUE"> -openmp </append>
     <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 </append>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
@@ -1560,7 +1560,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <base> -free </base>
   </FREEFLAGS>
   <LDFLAGS>
-    <append compile_threaded="true"> -openmp </append>
+    <append compile_threaded="TRUE"> -openmp </append>
     <append> -lnetcdff </append>
   </LDFLAGS>
   <MPICC> mpiicc  </MPICC>
@@ -1599,7 +1599,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <SFC> mpixlf2003_r </SFC>
   <SLIBS>
     <append>-L$NETCDF_PATH/lib -lnetcdff -lnetcdf -L$HDF5_PATH/lib -lhdf5_hl -lhdf5 -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
-    <append compile_threaded="true"> -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
+    <append compile_threaded="TRUE"> -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
   </SLIBS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
@@ -1674,7 +1674,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   </FFLAGS>
   <MPI_PATH MPILIB="openmpi">$ENV{MPIHOME}</MPI_PATH>
   <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
-  <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="false">/projects/ccsm/pfunit/3.2.9/mpi-serial</PFUNIT_PATH>
+  <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="FALSE">/projects/ccsm/pfunit/3.2.9/mpi-serial</PFUNIT_PATH>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
@@ -2181,16 +2181,16 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <base>-lstdc++ -lmpi_cxx</base>
   </CXX_LIBS>
   <CFLAGS>
-    <base>compile_threaded="true"> -qopenmp</base>
+    <base>compile_threaded="TRUE"> -qopenmp</base>
   </CFLAGS>
   <FFLAGS>
-    <base>compile_threaded="true"> -qopenmp</base>
+    <base>compile_threaded="TRUE"> -qopenmp</base>
   </FFLAGS>
   <LDFLAGS>
-    <base>compile_threaded="true"> -qopenmp</base>
+    <base>compile_threaded="TRUE"> -qopenmp</base>
   </LDFLAGS>
   <FFLAGS_NOOPT>
-    <base>compile_threaded="true"> -qopenmp</base>
+    <base>compile_threaded="TRUE"> -qopenmp</base>
   </FFLAGS_NOOPT>
 </compiler>
 

--- a/cime/config/e3sm/machines/userdefined_laptop_template/config_compilers.xml
+++ b/cime/config/e3sm/machines/userdefined_laptop_template/config_compilers.xml
@@ -6,9 +6,9 @@
    <compiler COMPILER="gnu" MACH="example-osx-homebrew">
       <!-- homebrew -->
       <ADD_CPPDEFS> -DFORTRANUNDERSCORE -DNO_R16</ADD_CPPDEFS>
-      <ADD_CFLAGS compile_threaded="true"> -fopenmp </ADD_CFLAGS>
-      <ADD_FFLAGS compile_threaded="true"> -fopenmp </ADD_FFLAGS>
-      <ADD_LDFLAGS compile_threaded="true"> -L /usr/local/Cellar/gcc/4.9.2/lib/gcc/x86_64-apple-darwin14.0.0/4.9.2 -fopenmp </ADD_LDFLAGS>
+      <ADD_CFLAGS compile_threaded="TRUE"> -fopenmp </ADD_CFLAGS>
+      <ADD_FFLAGS compile_threaded="TRUE"> -fopenmp </ADD_FFLAGS>
+      <ADD_LDFLAGS compile_threaded="TRUE"> -L /usr/local/Cellar/gcc/4.9.2/lib/gcc/x86_64-apple-darwin14.0.0/4.9.2 -fopenmp </ADD_LDFLAGS>
       <ADD_CMAKE_OPTS MODEL="cism"> -D CISM_GNU=ON </ADD_CMAKE_OPTS>
       <FIXEDFLAGS>  -ffixed-form </FIXEDFLAGS>
       <FREEFLAGS> -ffree-form </FREEFLAGS>
@@ -29,15 +29,15 @@
       <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
       <NETCDF_PATH>/usr/local</NETCDF_PATH>
       <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -framework Accelerate</ADD_SLIBS>
-      <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="false">$ENV{HOME}/local/pfunit/pfunit-sf.git.ae92605e8e</PFUNIT_PATH>
+      <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="FALSE">$ENV{HOME}/local/pfunit/pfunit-sf.git.ae92605e8e</PFUNIT_PATH>
    </compiler>
 
    <compiler COMPILER="gnu" MACH="example-osx-macports">
       <!-- macports -->
       <ADD_CPPDEFS> -DFORTRANUNDERSCORE -DNO_R16</ADD_CPPDEFS>
-      <ADD_CFLAGS compile_threaded="true"> -fopenmp </ADD_CFLAGS>
-      <ADD_FFLAGS compile_threaded="true"> -fopenmp </ADD_FFLAGS>
-      <ADD_LDFLAGS compile_threaded="true"> -fopenmp </ADD_LDFLAGS>
+      <ADD_CFLAGS compile_threaded="TRUE"> -fopenmp </ADD_CFLAGS>
+      <ADD_FFLAGS compile_threaded="TRUE"> -fopenmp </ADD_FFLAGS>
+      <ADD_LDFLAGS compile_threaded="TRUE"> -fopenmp </ADD_LDFLAGS>
       <ADD_CMAKE_OPTS MODEL="cism"> -D CISM_GNU=ON </ADD_CMAKE_OPTS>
       <FIXEDFLAGS>  -ffixed-form </FIXEDFLAGS>
       <FREEFLAGS> -ffree-form </FREEFLAGS>
@@ -57,6 +57,6 @@
       <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
       <NETCDF_PATH>/opt/local</NETCDF_PATH>
       <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -framework Accelerate</ADD_SLIBS>
-      <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="false">$ENV{HOME}/local/pfunit/pfunit-sf.git.ae92605e8e</PFUNIT_PATH>
+      <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="FALSE">$ENV{HOME}/local/pfunit/pfunit-sf.git.ae92605e8e</PFUNIT_PATH>
    </compiler>
 </config_compilers>

--- a/cime/config/xml_schemas/config_compilers_v2.xsd
+++ b/cime/config/xml_schemas/config_compilers_v2.xsd
@@ -8,7 +8,7 @@
   <xs:attribute name="COMPILER" type="xs:token"/>
   <xs:attribute name="OS" type="xs:token"/>
   <xs:attribute name="MACH" type="xs:token"/>
-  <xs:attribute name="compile_threaded" type="xs:boolean"/>
+  <xs:attribute name="compile_threaded" type="upperBoolean"/>
   <xs:attribute name="DEBUG" type="upperBoolean"/>
   <xs:attribute name="MODEL" type="xs:token"/>
   <xs:attribute name="MPILIB" type="xs:token"/>

--- a/cime/doc/source/users_guide/cime-config.rst
+++ b/cime/doc/source/users_guide/cime-config.rst
@@ -66,8 +66,8 @@ CIME recognizes a user-created custom configuration directory, ``$HOME/.cime``. 
         <compiler COMPILER="ibm" OS="BGQ">
            <FFLAGS> -g -qfullpath -qmaxmem=-1 -qspillsize=2500 -qextname=flush </FFLAGS>
 	   <ADD_FFLAGS DEBUG="FALSE"> -O3 -qstrict -qinline=auto </ADD_FFLAGS>
-	   <ADD_FFLAGS DEBUG="FALSE" compile_threaded="true"> -qsmp=omp </ADD_FFLAGS>
-	   <ADD_FFLAGS DEBUG="TRUE" compile_threaded="true"> -qsmp=omp:noopt </ADD_FFLAGS>
+	   <ADD_FFLAGS DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp </ADD_FFLAGS>
+	   <ADD_FFLAGS DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt </ADD_FFLAGS>
 	   <ADD_CPPDEFS> -DLINUX  </ADD_CPPDEFS>
 	   <CONFIG_ARGS> --build=powerpc-bgp-linux --host=powerpc64-suse-linux </CONFIG_ARGS>
 	   <LDFLAGS>  -Wl,--relax -Wl,--allow-multiple-definition </LDFLAGS>

--- a/cime/doc/source/users_guide/unit_testing.rst
+++ b/cime/doc/source/users_guide/unit_testing.rst
@@ -165,7 +165,7 @@ For a serial build, your setting will look like this example:
 
 .. code-block:: xml
 
-     <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="false">$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.2.8_cheyenne_Intel17.0.1_noMPI_noOpenMP</PFUNIT_PATH>
+     <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="FALSE">$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.2.8_cheyenne_Intel17.0.1_noMPI_noOpenMP</PFUNIT_PATH>
 
 The ``MPILIB`` attribute should be either:
 
@@ -173,7 +173,7 @@ The ``MPILIB`` attribute should be either:
 
 * the name of the MPI library you used for a pFUnit build where ``-DMPI=YES``. (For example, you might use ``mpich``, which should be one of the machine's MPI libraries specified by ``MPILIBS`` in **config_machines.xml**.)
 
-The ``compile_threaded`` attribute should be either ``true`` or ``false`` depending on the value of ``-DOPENMP``.
+The ``compile_threaded`` attribute should be either ``TRUE`` or ``FALSE`` depending on the value of ``-DOPENMP``.
 
 Once you have specified the path for your build(s), you should be able to run the unit tests by following the instructions in :ref:`running_unit_tests`.
 

--- a/cime/scripts/fortran_unit_testing/run_tests.py
+++ b/cime/scripts/fortran_unit_testing/run_tests.py
@@ -237,7 +237,7 @@ def find_pfunit(compilerobj, mpilib, use_openmp):
     - use_openmp: Boolean
     """
     attrs = {"MPILIB": mpilib,
-             "compile_threaded": "true" if use_openmp else "false"
+             "compile_threaded": "TRUE" if use_openmp else "FALSE"
              }
 
     pfunit_path = compilerobj.get_optional_compiler_node("PFUNIT_PATH", attributes=attrs)
@@ -337,9 +337,9 @@ def _main():
     os.environ["DEBUG"] = stringify_bool(debug)
     os.environ["MPILIB"] = mpilib
     if use_openmp:
-        os.environ["compile_threaded"] = "true"
+        os.environ["compile_threaded"] = "TRUE"
     else:
-        os.environ["compile_threaded"] = "false"
+        os.environ["compile_threaded"] = "FALSE"
 
     os.environ["UNIT_TEST_HOST"] = socket.gethostname()
     if "NETCDF_PATH" in os.environ and not "NETCDF" in os.environ:

--- a/cime/scripts/lib/CIME/BuildTools/valuesetting.py
+++ b/cime/scripts/lib/CIME/BuildTools/valuesetting.py
@@ -116,7 +116,7 @@ class ValueSetting(object):
 
         >>> a = ValueSetting('foo', False, {"DEBUG": "TRUE"}, [], [])
         >>> b = ValueSetting('bar', False, {"DEBUG": "TRUE", "MPILIB": "mpich2"}, [], [])
-        >>> c = ValueSetting('bar', False, {"DEBUG": "TRUE", "compile_threaded": "false"}, [], [])
+        >>> c = ValueSetting('bar', False, {"DEBUG": "TRUE", "compile_threaded": "FALSE"}, [], [])
         >>> d = ValueSetting('foo', False, {"DEBUG": "FALSE"}, [], [])
         >>> a.has_special_case(b)
         True

--- a/cime/scripts/lib/CIME/build.py
+++ b/cime/scripts/lib/CIME/build.py
@@ -18,7 +18,7 @@ def get_standard_makefile_args(case):
                  "OCN_SUBMODEL", "CISM_USE_TRILINOS", "USE_ALBANY", "USE_PETSC"]
 
     make_args = "CIME_MODEL={} ".format(case.get_value("MODEL"))
-    make_args += " compile_threaded={} ".format(case.get_build_threaded())
+    make_args += " compile_threaded={} ".format(stringify_bool(case.get_build_threaded()))
     for var in variables:
         make_args+=xml_to_make_variable(case, var)
 

--- a/cime/scripts/tests/scripts_regression_tests.py
+++ b/cime/scripts/tests/scripts_regression_tests.py
@@ -235,7 +235,7 @@ class N_TestUnitTest(unittest.TestCase):
             compiler = Compilers(MACHINE, compiler=default_compiler)
         else:
             compiler = Compilers(MACHINE, compiler=TEST_COMPILER)
-        attrs = {'MPILIB': 'mpi-serial', 'compile_threaded': 'false'}
+        attrs = {'MPILIB': 'mpi-serial', 'compile_threaded': 'FALSE'}
         pfunit_path = compiler.get_optional_compiler_node("PFUNIT_PATH",
                                                           attributes=attrs)
         if pfunit_path is None:

--- a/cime/tools/mapping/gen_mapping_files/runoff_to_ocn/src/Makefile
+++ b/cime/tools/mapping/gen_mapping_files/runoff_to_ocn/src/Makefile
@@ -37,8 +37,8 @@ VPATH    := $(shell pwd)
 SRCFILE  := NONE
 SRCS     := NONE
 DEPGEN   := ./makdep  # an externally provided dependency generator
-#compile_threaded := true
-compile_threaded := false
+#compile_threaded := TRUE
+compile_threaded := FALSE
 
 ifneq ($(VPATH),.)
   # this variable was specified on cmd line or in an env var


### PR DESCRIPTION
Three different casing styles were being used for this value
and Make does case-senstive comparisons, so it was incorrectly
interpretting build_threaded to be false.

Fixes #2826 

[BFB]