### PR TITLE
Fixes the land initial conditions for CMIP6 compset

### DIFF
--- a/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
@@ -33,6 +33,6 @@
       
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
-<finidat>lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
+<finidat mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
@@ -33,7 +33,7 @@
       
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
-<finidat>lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
+<finidat mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
 <check_finidat_year_consistency>.false.</check_finidat_year_consistency>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -47,7 +47,7 @@
 
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_2015_c20171018.nc</flanduse_timeseries>
-<finidat>lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc</finidat>
+<finidat mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc</finidat>
 <check_finidat_year_consistency>.false.</check_finidat_year_consistency>
 
 </namelist_defaults>


### PR DESCRIPTION
Adds the land/ocean mask for the existing land initial conditions to
only define a land initial condition file for appropriate resolutions.

[BFB]