### PR TITLE
Update Anvil soft-env modules

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -278,7 +278,7 @@
 
     <batch_system MACH="anvil" type="slurm" >
       <queues>
-	<queue walltimemax="01:00:00" nodemax="2" default="true">acme</queue>
+	<queue walltimemax="01:00:00" default="true">acme</queue>
       </queues>
     </batch_system>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -277,14 +277,14 @@
       </queues>
     </batch_system>
 
-    <!-- anvil is PBS -->
-    <batch_system MACH="anvil" type="pbs" >
-      <directives>
+    <!-- anvil is slurm -->
+    <batch_system MACH="anvil" type="slurm" >
+      <!-- <directives>
         <directive>-A {{ PROJECT }}</directive>
         <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
-      </directives>
+      </directives> -->
       <queues>
-	<queue walltimemax="01:00:00" default="true">acme</queue>
+	<queue walltimemax="01:00:00" nodemax="2" default="true">acme</queue>
       </queues>
     </batch_system>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -265,7 +265,6 @@
     </directives>
   </batch_system>
 
-    <!-- blues is PBS -->
     <batch_system MACH="blues" type="pbs" >
       <directives>
         <directive>-A {{ PROJECT }}</directive>
@@ -277,12 +276,7 @@
       </queues>
     </batch_system>
 
-    <!-- anvil is slurm -->
     <batch_system MACH="anvil" type="slurm" >
-      <!-- <directives>
-        <directive>-A {{ PROJECT }}</directive>
-        <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
-      </directives> -->
       <queues>
 	<queue walltimemax="01:00:00" nodemax="2" default="true">acme</queue>
       </queues>
@@ -296,7 +290,6 @@
       </queues>
     </batch_system>
 
-    <!-- eos is PBS -->
     <batch_system MACH="eos" type="pbs" >
     <directives>
       <directive>-A {{ project }}</directive>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -725,25 +725,25 @@ for mct, etc.
 </compiler>
 
 <compiler MACH="anvil" COMPILER="intel">
-  <!-- <CFLAGS>
+  <CFLAGS>
     <append compile_threaded="true"> -static-intel</append>
     <append compile_threaded="true" DEBUG="TRUE">-heap-arrays</append>
-  </CFLAGS> -->
+  </CFLAGS>
   <CPPDEFS>
     <append MODEL="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align</append>
-    <!-- <append compile_threaded="true"> -static-intel</append>
-    <append compile_threaded="true" DEBUG="TRUE">-heap-arrays</append> -->
+    <append compile_threaded="true"> -static-intel</append>
+    <append compile_threaded="true" DEBUG="TRUE">-heap-arrays</append>
   </FFLAGS>
-  <!-- <FFLAGS_NOOPT>
+  <FFLAGS_NOOPT>
     <append compile_threaded="true"> -static-intel</append>
   </FFLAGS_NOOPT>
   <LDFLAGS>
     <append compile_threaded="true"> -static-intel</append>
   </LDFLAGS>
-  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS> -->
+  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
   <SLIBS>
     <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} -Wl,-rpath -Wl,$ENV{NETCDF_FORTRAN_PATH}/lib</append>
     <append>-mkl</append>
@@ -751,7 +751,6 @@ for mct, etc.
   <MPICC MPILIB="impi"> mpiicc  </MPICC>
   <MPICXX MPILIB="impi"> mpiicpc </MPICXX>
   <MPIFC MPILIB="impi"> mpiifort </MPIFC>
-
 </compiler>
 
 <compiler MACH="anvil" COMPILER="pgi">

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -716,38 +716,42 @@ for mct, etc.
 
 <compiler MACH="anvil" COMPILER="gnu">
   <CPPDEFS>
-    <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY</append>
+    <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY  </append>
   </CPPDEFS>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
   <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
+    <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs}  -L$ENV{MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -liomp5 -lpthread -lm -ldl </append>
   </SLIBS>
 </compiler>
 
 <compiler MACH="anvil" COMPILER="intel">
-  <CFLAGS>
+  <!-- <CFLAGS>
     <append compile_threaded="true"> -static-intel</append>
     <append compile_threaded="true" DEBUG="TRUE">-heap-arrays</append>
-  </CFLAGS>
+  </CFLAGS> -->
   <CPPDEFS>
     <append MODEL="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align</append>
-    <append compile_threaded="true"> -static-intel</append>
-    <append compile_threaded="true" DEBUG="TRUE">-heap-arrays</append>
+    <!-- <append compile_threaded="true"> -static-intel</append>
+    <append compile_threaded="true" DEBUG="TRUE">-heap-arrays</append> -->
   </FFLAGS>
-  <FFLAGS_NOOPT>
+  <!-- <FFLAGS_NOOPT>
     <append compile_threaded="true"> -static-intel</append>
   </FFLAGS_NOOPT>
   <LDFLAGS>
     <append compile_threaded="true"> -static-intel</append>
   </LDFLAGS>
-  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
+  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS> -->
   <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -Wl,-rpath -Wl,$ENV{NETCDF_PATH}/lib</append>
+    <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} -Wl,-rpath -Wl,$ENV{NETCDF_FORTRAN_PATH}/lib</append>
     <append>-mkl</append>
   </SLIBS>
+  <MPICC MPILIB="impi"> mpiicc  </MPICC>
+  <MPICXX MPILIB="impi"> mpiicpc </MPICXX>
+  <MPIFC MPILIB="impi"> mpiifort </MPIFC>
+
 </compiler>
 
 <compiler MACH="anvil" COMPILER="pgi">

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -721,6 +721,7 @@ for mct, etc.
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
   <SLIBS>
     <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs}  -L$ENV{MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -liomp5 -lpthread -lm -ldl </append>
+    <append> $SHELL{$ENV{NETCDF_C_PATH}/bin/nc-config --libs} </append>
   </SLIBS>
 </compiler>
 
@@ -745,12 +746,10 @@ for mct, etc.
   </LDFLAGS>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
   <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} -Wl,-rpath -Wl,$ENV{NETCDF_FORTRAN_PATH}/lib</append>
+    <append> $SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} </append>
+    <append> $SHELL{$ENV{NETCDF_C_PATH}/bin/nc-config --libs} </append>
     <append>-mkl</append>
   </SLIBS>
-  <MPICC MPILIB="impi"> mpiicc  </MPICC>
-  <MPICXX MPILIB="impi"> mpiicpc </MPICXX>
-  <MPIFC MPILIB="impi"> mpiifort </MPIFC>
 </compiler>
 
 <compiler MACH="anvil" COMPILER="pgi">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1175,8 +1175,8 @@
         <command name="load">intel/18.0.4-443hhug</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich">
-	<command name="load">mvapich2/2.3-verbs-jxfqudp</command>
-	<command name="load">parallel-netcdf/1.8.1-zhkvsbx</command>
+	<command name="load">mvapich2/2.3.1-verbs-dtbb6xk</command>
+	<!--command name="load">parallel-netcdf/1.8.1-zhkvsbx</command-->
       </modules>
       <modules compiler="intel" mpilib="openmpi">
 	<command name="load">openmpi/3.1.3-verbs-kqojjbw</command>
@@ -1186,7 +1186,7 @@
         <command name="load">intel-mkl/2018.4.274-jwaeshj</command>
 	<command name="load">hdf5/1.8.16-n5thgua</command>
 	<command name="load">netcdf/4.4.1-qs32hcj</command>
-	<command name="load">netcdf-cxx/4.2-fevpvbh</command>
+	<!--command name="load">netcdf-cxx/4.2-fevpvbh</command-->
 	<command name="load">netcdf-fortran/4.4.4-jy3v3rz</command>
       </modules>
       
@@ -1194,7 +1194,7 @@
         <command name="load">gcc/8.2.0-g7hppkz</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich">
-	<command name="load">mvapich2/2.3.1-verbs</command>
+	<command name="load">mvapich2/2.3.1-verbs-wcfqbl5</command>
 	<!--command name="load">parallel-netcdf/1.8.1-m4l6rud</command-->
       </modules>
       <modules compiler="gnu" mpilib="openmpi">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1125,11 +1125,11 @@
 
   <machine MACH="anvil">
     <DESC>ANL/LCRC Linux Cluster</DESC>
-    <NODENAME_REGEX>blogin.*.lcrc.anl.gov</NODENAME_REGEX>
+    <NODENAME_REGEX>blueslogin.*.lcrc.anl.gov</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>intel,gnu,pgi</COMPILERS>
-    <MPILIBS>mvapich,openmpi</MPILIBS>
-    <PROJECT>ACME</PROJECT>
+    <COMPILERS>intel,gnu</COMPILERS>
+    <MPILIBS>mvapich,impi,openmpi</MPILIBS>
+    <PROJECT>condo</PROJECT>
     <SAVE_TIMING_DIR>/lcrc/group/acme</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>/lcrc/group/acme/$USER/acme_scratch/anvil</CIME_OUTPUT_ROOT>
@@ -1140,106 +1140,117 @@
     <CCSM_CPRNC>/home/ccsm-data/tools/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_integration</TESTS>
-    <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>E3SM</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-    <mpirun mpilib="openmpi">
-      <executable>mpiexec</executable>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
-        <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to core</arg>
-        <!--arg name="label" DEBUG="TRUE">-tag-output</arg>
-        <arg name="bindings" DEBUG="TRUE">-report-bindings</arg-->
-      </arguments>
-    </mpirun>
-    <mpirun mpilib="mvapich">
-      <executable>mpiexec</executable>
-      <arguments>
-        <arg name="label"> -l</arg>
         <arg name="num_tasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpi-serial">
       <executable/>
     </mpirun>
-    <module_system type="soft">
-      <init_path lang="csh">/etc/profile.d/a_softenv.csh</init_path>
-      <init_path lang="sh">/etc/profile.d/a_softenv.sh</init_path>
-      <cmd_path lang="csh">soft</cmd_path>
-      <cmd_path lang="sh">soft</cmd_path>
+    <module_system type="module">
+ <init_path lang="sh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/csh</init_path>
+      <init_path lang="perl">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/perl</init_path>
+      <init_path lang="python">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="perl">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/libexec/lmod perl</cmd_path>
+      <cmd_path lang="python">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="add">+cmake-2.8.12</command>
-        <command name="add">+python-2.7</command>
+        <command name="purge"/>
       </modules>
       <modules compiler="intel">
-        <command name="add">+intel-17.0.0</command>
-        <command name="add">+netcdf-c-4.4.1-f77-4.4.4-intel-17.0.0-serial</command>
+        <command name="load">intel/18.0.4-443hhug</command>
+        <command name="load">intel-mkl/2018.4.274-jwaeshj</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpich">
+	<command name="load">mpich/3.3-verbs-at6arvo</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich">
-        <command name="add">+mvapich2-2.2-intel-17.0.0-acme</command>
-        <command name="add">+pnetcdf-1.7.0-intel-17.0.0-mvapich2-2.2-acme</command>
+	<command name="load">mvapich2/2.3-verbs-jxfqudp</command>
+	<command name="load">hdf5/1.10.4-b2aw6ri</command>
+	<command name="load">netcdf-cxx/4.2-fevpvbh</command>
+	<command name="load">netcdf-fortran/4.4.4-25yzbsw</command>
+	<command name="load">netcdf/4.6.2-xf4e6n6</command>
+	<command name="load">parallel-netcdf/1.11.0-7kvr6ax</command>
       </modules>
       <modules compiler="intel" mpilib="openmpi">
-        <command name="add">+openmpi-2.0.1-intel-17.0.0-acme</command>
-        <command name="add">+pnetcdf-1.7.0-intel-17.0.0-openmpi-2.0.1-acme</command>
+	<command name="load">openmpi/3.1.3-verbs-kqojjbw</command>
+	<command name="load">hdf5/1.10.4-uitg4of</command>
+	<command name="load">netcdf-cxx/4.2-crwzy3r</command>
+	<command name="load">netcdf-fortran/4.4.4-fve36ga</command>
+	<command name="load">netcdf/4.6.2-3jynwg5</command>
+	<!-- <command name="load">no-parallel-netcdf!</command> -->
       </modules>
+      <modules compiler="intel" mpilib="impi">
+	<command name="load">intel-mpi/2018.4.274-4hmwfl6</command>
+	<command name="load">hdf5/1.10.4-zlri7fo</command>
+	<command name="load">netcdf/4.6.2-64hby3x</command>
+	<command name="load">netcdf-fortran/4.4.4-hr5agu5</command>
+	<command name="load">netcdf-cxx/4.2-efl7ntf</command>
+	<command name="load">parallel-netcdf/1.11.0-acswzws</command>
+      </modules>
+      
       <modules compiler="gnu">
-        <command name="add">+gcc-5.3.0</command>
-        <command name="add">+netcdf-c-4.4.0-f77-4.4.3-gcc-5.3.0-serial</command>
+        <command name="load">gcc/8.2.0-g7hppkz</command>
+	<command name="load">intel-mkl/2018.4.274-2amycpi</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich">
-        <command name="add">+mvapich2-2.2b-gcc-5.3.0-acme</command>
-        <command name="add">+pnetcdf-1.6.1-gcc-5.3.0-mvapich2-2.2b-acme</command>
+	<command name="load">mvapich2/2.3-verbs-yyaahvp</command>
+	<command name="load">hdf5/1.10.5-va2annc</command>
+	<command name="load">netcdf/4.6.3-pj7p2s7</command>
+	<command name="load">netcdf-cxx/4.2-gxtq6xt</command>
+	<command name="load">netcdf-fortran/4.4.4-togj5w5</command>
+	<command name="load">parallel-netcdf/1.11.0-e5iciuq</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-        <command name="add">+openmpi-1.10.2-gcc-5.3.0-acme</command>
-        <command name="add">+pnetcdf-1.6.1-gcc-5.3.0-openmpi-1.10.2-acme</command>
+        <command name="load">openmpi/3.1.3-verbs-q4swt25</command>
+	<command name="load">hdf5/1.10.5-kuyb5xe</command>
+	<command name="load">netcdf/4.6.3-xcyxt2i</command>
+	<command name="load">netcdf-fortran/4.4.4-tad5qcj</command>
+	<command name="load">netcdf-cxx/4.2-2dftcw4</command>
+	<command name="load">parallel-netcdf/1.11.0-g7mipbc</command>
       </modules>
-      <modules compiler="pgi">
-        <command name="add">+pgi-16.3</command>
-        <command name="add">+netcdf-c-4.4.0-f77-4.4.3-pgi-16.3-serial</command>
+      <modules compiler="gnu" mpilib="impi">
+	<command name="load">intel-mpi/2018.4.274-ozfo327</command>
+	<command name="load">hdf5/1.10.5-vozfsah</command>
+	<command name="load">netcdf/4.6.3-c2b5ohk</command>
+	<command name="load">netcdf-fortran/4.4.4-x323ez3</command>
+	<command name="load">netcdf-cxx/4.2-skdn4fw</command>
+	<command name="load">parallel-netcdf/1.11.0-filvnis</command>
       </modules>
-      <modules compiler="pgi" mpilib="mvapich">
-        <command name="add">+mvapich2-2.2b-pgi-16.3-acme</command>
-        <command name="add">+pnetcdf-1.6.1-pgi-16.3-mvapich2-2.2b-acme</command>
+      <modules>
+        <command name="load">cmake</command>
       </modules>
-      <modules compiler="pgi" mpilib="openmpi">
-        <command name="add">+openmpi-1.10.2-pgi-16.3-acme</command>
-        <command name="add">+pnetcdf-1.6.1-pgi-16.3-openmpi-1.10.2-acme</command>
-      </modules>
+      <!-- <modules mpilib="!mpi-serial">
+        <command name="load">parallel-netcdf/1.6.1</command>
+      </modules> -->
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
     <environment_variables>
-      <env name="NETCDF_PATH">$SHELL{which nf-config | xargs dirname | xargs dirname}</env>
+      <env name="NETCDF_C_PATH">$SHELL{which nc-config | xargs dirname | xargs dirname}</env>
+      <env name="NETCDF_FORTRAN_PATH">$SHELL{which nf-config | xargs dirname | xargs dirname}</env>
+      <env name="PATH">/lcrc/group/acme/soft/perl/5.26.0/bin:$ENV{PATH}</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
       <env name="PNETCDF_PATH">$SHELL{which pnetcdf_version | xargs dirname | xargs dirname}</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
-      <env name="OMP_STACKSIZE">64M</env>
-      <env name="KMP_HOT_TEAMS_MODE">1</env>
+      <env name="OMP_STACKSIZE">128M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" DEBUG="FALSE">
-      <env name="KMP_AFFINITY">scatter</env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" DEBUG="TRUE">
-      <env name="KMP_AFFINITY">verbose,scatter</env>
-      <env name="OMP_DISPLAY_ENV">verbose</env>
-    </environment_variables>
-    <environment_variables mpilib="mvapich">
-      <env name="MV2_ENABLE_AFFINITY">1</env>
-      <env name="MV2_USE_SHARED_MEM">1</env>
-      <env name="MV2_SMP_USE_CMA">1</env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" mpilib="mvapich">
-      <!--e.g. 6 threads: MV2_CPU_MAPPING=0-5:6-11:12-17:18-23:24-29:30-35: -->
-      <env name="MV2_CPU_MAPPING">$SHELL{t=$ENV{OMP_NUM_THREADS};b=0;r=$[36/$t];while [ $r -gt 0 ];do printf "$b-$[$b+$t-1]:";((r--));((b=b+t));done;}</env>
-    </environment_variables>
-    <environment_variables DEBUG="TRUE" mpilib="mvapich">
-      <env name="MV2_SHOW_CPU_BINDING">1</env>
+    <environment_variables mpilib="impi">
+      <env name="I_MPI_FABRICS">shm:tmi</env>
     </environment_variables>
   </machine>
 

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1176,7 +1176,6 @@
       </modules>
       <modules compiler="intel" mpilib="mvapich">
 	<command name="load">mvapich2/2.3.1-verbs-dtbb6xk</command>
-	<!--command name="load">parallel-netcdf/1.8.1-zhkvsbx</command-->
       </modules>
       <modules compiler="intel" mpilib="openmpi">
 	<command name="load">openmpi/3.1.3-verbs-kqojjbw</command>
@@ -1221,9 +1220,9 @@
       <env name="NETCDF_FORTRAN_PATH">$SHELL{which nf-config | xargs dirname | xargs dirname}</env>
       <env name="PATH">/lcrc/group/acme/soft/perl/5.26.0/bin:$ENV{PATH}</env>
     </environment_variables>
-    <!--environment_variables mpilib="!mpi-serial">
-      <env name="PNETCDF_PATH">$SHELL{which pnetcdf_version | xargs dirname | xargs dirname}</env>
-    </environment_variables-->
+    <environment_variables mpilib="mvapich" compiler="intel">
+      <env name="PNETCDF_PATH">/blues/gpfs/home/software/climate/pnetcdf/1.8.1/intel-18.0.4/mvapich2-2.3.1-verbs</env>
+    </environment_variables>
     <environment_variables mpilib="mvapich">
       <env name="MV2_ENABLE_AFFINITY">1</env>
       <env name="MV2_USE_THREAD_WARNING">0</env>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1128,7 +1128,7 @@
     <NODENAME_REGEX>blueslogin.*.lcrc.anl.gov</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>mvapich,impi,openmpi</MPILIBS>
+    <MPILIBS>mvapich,openmpi</MPILIBS>
     <PROJECT>condo</PROJECT>
     <SAVE_TIMING_DIR>/lcrc/group/acme</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
@@ -1174,60 +1174,40 @@
       </modules>
       <modules compiler="intel">
         <command name="load">intel/18.0.4-443hhug</command>
-        <command name="load">intel-mkl/2018.4.274-jwaeshj</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich">
 	<command name="load">mvapich2/2.3-verbs-jxfqudp</command>
-	<command name="load">hdf5/1.10.4-b2aw6ri</command>
-	<command name="load">netcdf-cxx/4.2-fevpvbh</command>
-	<command name="load">netcdf-fortran/4.4.4-25yzbsw</command>
-	<command name="load">netcdf/4.6.2-xf4e6n6</command>
-	<command name="load">parallel-netcdf/1.11.0-7kvr6ax</command>
+	<command name="load">parallel-netcdf/1.8.1-zhkvsbx</command>
       </modules>
       <modules compiler="intel" mpilib="openmpi">
 	<command name="load">openmpi/3.1.3-verbs-kqojjbw</command>
-	<command name="load">hdf5/1.10.4-uitg4of</command>
-	<command name="load">netcdf-cxx/4.2-crwzy3r</command>
-	<command name="load">netcdf-fortran/4.4.4-fve36ga</command>
-	<command name="load">netcdf/4.6.2-3jynwg5</command>
-	<command name="load">parallel-netcdf/1.11.0-e7zc5da</command>
+	<command name="load">parallel-netcdf/1.8.1-5ldccd7</command>
       </modules>
-      <modules compiler="intel" mpilib="impi">
-	<command name="load">intel-mpi/2018.4.274-4hmwfl6</command>
-	<command name="load">hdf5/1.10.4-zlri7fo</command>
-	<command name="load">netcdf/4.6.2-64hby3x</command>
-	<command name="load">netcdf-fortran/4.4.4-hr5agu5</command>
-	<command name="load">netcdf-cxx/4.2-efl7ntf</command>
-	<command name="load">parallel-netcdf/1.11.0-acswzws</command>
+      <modules>
+        <command name="load">intel-mkl/2018.4.274-jwaeshj</command>
+	<command name="load">hdf5/1.8.16-n5thgua</command>
+	<command name="load">netcdf/4.4.1-qs32hcj</command>
+	<command name="load">netcdf-cxx/4.2-fevpvbh</command>
+	<command name="load">netcdf-fortran/4.4.4-jy3v3rz</command>
       </modules>
       
       <modules compiler="gnu">
         <command name="load">gcc/8.2.0-g7hppkz</command>
-	<command name="load">intel-mkl/2018.4.274-2amycpi</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich">
 	<command name="load">mvapich2/2.3-verbs-yyaahvp</command>
-	<command name="load">hdf5/1.10.5-va2annc</command>
-	<command name="load">netcdf/4.6.3-pj7p2s7</command>
-	<command name="load">netcdf-cxx/4.2-gxtq6xt</command>
-	<command name="load">netcdf-fortran/4.4.4-togj5w5</command>
-	<command name="load">parallel-netcdf/1.11.0-e5iciuq</command>
+	<command name="load">parallel-netcdf/1.8.1-m4l6rud</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
         <command name="load">openmpi/3.1.3-verbs-q4swt25</command>
-	<command name="load">hdf5/1.10.5-kuyb5xe</command>
-	<command name="load">netcdf/4.6.3-xcyxt2i</command>
-	<command name="load">netcdf-fortran/4.4.4-tad5qcj</command>
-	<command name="load">netcdf-cxx/4.2-2dftcw4</command>
-	<command name="load">parallel-netcdf/1.11.0-g7mipbc</command>
+	<command name="load">parallel-netcdf/1.8.1-re3um7k</command>
       </modules>
-      <modules compiler="gnu" mpilib="impi">
-	<command name="load">intel-mpi/2018.4.274-ozfo327</command>
-	<command name="load">hdf5/1.10.5-vozfsah</command>
-	<command name="load">netcdf/4.6.3-c2b5ohk</command>
-	<command name="load">netcdf-fortran/4.4.4-x323ez3</command>
-	<command name="load">netcdf-cxx/4.2-skdn4fw</command>
-	<command name="load">parallel-netcdf/1.11.0-filvnis</command>
+      <modules compiler="gnu">
+	<command name="load">intel-mkl/2018.4.274-2amycpi</command>
+	<command name="load">hdf5/1.8.16-mz7lmxh</command>
+	<command name="load">netcdf/4.4.1-xkjcghm</command>
+	<command name="load">netcdf-cxx/4.2-kyva3os</command>
+	<command name="load">netcdf-fortran/4.4.4-mpstomu</command>
       </modules>
       <modules>
         <command name="load">cmake</command>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1145,16 +1145,15 @@
     <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-    <mpirun mpilib="openmpi">
+    <!--mpirun mpilib="openmpi">
       <executable>mpiexec</executable>
       <arguments>
         <arg name="num_tasks"> -n {{ total_tasks }} </arg>
-        <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket,PE=$ENV{OMP_NUM_THREADS} --bind-to core</arg>
-        <!--arg name="label" DEBUG="TRUE">-tag-output -report-bindings</arg-->
+        <arg name="tasks_per_node"> - -map-by ppr:{{ tasks_per_numa }}:socket,PE=$ENV{OMP_NUM_THREADS} - -bind-to core -tag-output -report-bindings</arg>
       </arguments>
-    </mpirun>
+    </mpirun-->
     <mpirun mpilib="default">
-      <executable>mpirun</executable>
+      <executable>srun</executable>
       <arguments>
         <arg name="num_tasks"> -l -n {{ total_tasks }} </arg>
       </arguments>
@@ -1195,8 +1194,8 @@
         <command name="load">gcc/8.2.0-g7hppkz</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich">
-	<command name="load">mvapich2/2.3-verbs-yyaahvp</command>
-	<command name="load">parallel-netcdf/1.8.1-m4l6rud</command>
+	<command name="load">mvapich2/2.3.1-verbs</command>
+	<!--command name="load">parallel-netcdf/1.8.1-m4l6rud</command-->
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
         <command name="load">openmpi/3.1.3-verbs-q4swt25</command>
@@ -1222,9 +1221,9 @@
       <env name="NETCDF_FORTRAN_PATH">$SHELL{which nf-config | xargs dirname | xargs dirname}</env>
       <env name="PATH">/lcrc/group/acme/soft/perl/5.26.0/bin:$ENV{PATH}</env>
     </environment_variables>
-    <environment_variables mpilib="!mpi-serial">
+    <!--environment_variables mpilib="!mpi-serial">
       <env name="PNETCDF_PATH">$SHELL{which pnetcdf_version | xargs dirname | xargs dirname}</env>
-    </environment_variables>
+    </environment_variables-->
     <environment_variables mpilib="mvapich">
       <env name="MV2_ENABLE_AFFINITY">1</env>
       <env name="MV2_USE_THREAD_WARNING">0</env>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1187,7 +1187,7 @@
 	<command name="load">netcdf-cxx/4.2-crwzy3r</command>
 	<command name="load">netcdf-fortran/4.4.4-fve36ga</command>
 	<command name="load">netcdf/4.6.2-3jynwg5</command>
-	<!-- <command name="load">no-parallel-netcdf!</command> -->
+	<command name="load">parallel-netcdf/1.11.0-e7zc5da</command>
       </modules>
       <modules compiler="intel" mpilib="impi">
 	<command name="load">intel-mpi/2018.4.274-4hmwfl6</command>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1149,7 +1149,7 @@
       <executable>mpiexec</executable>
       <arguments>
         <arg name="num_tasks"> -n {{ total_tasks }} </arg>
-        <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to core</arg>
+        <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket,PE=$ENV{OMP_NUM_THREADS} --bind-to core</arg>
         <!--arg name="label" DEBUG="TRUE">-tag-output -report-bindings</arg-->
       </arguments>
     </mpirun>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1145,21 +1145,27 @@
     <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+    <mpirun mpilib="openmpi">
+      <executable>mpiexec</executable>
+      <arguments>
+        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
+        <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to core</arg>
+        <!--arg name="label" DEBUG="TRUE">-tag-output -report-bindings</arg-->
+      </arguments>
+    </mpirun>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
+        <arg name="num_tasks"> -l -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpi-serial">
       <executable/>
     </mpirun>
     <module_system type="module">
- <init_path lang="sh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/sh</init_path>
+      <init_path lang="sh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/sh</init_path>
       <init_path lang="csh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/csh</init_path>
-      <init_path lang="perl">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/perl</init_path>
       <init_path lang="python">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/env_modules_python.py</init_path>
-      <cmd_path lang="perl">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/libexec/lmod perl</cmd_path>
       <cmd_path lang="python">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
@@ -1169,9 +1175,6 @@
       <modules compiler="intel">
         <command name="load">intel/18.0.4-443hhug</command>
         <command name="load">intel-mkl/2018.4.274-jwaeshj</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpich">
-	<command name="load">mpich/3.3-verbs-at6arvo</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich">
 	<command name="load">mvapich2/2.3-verbs-jxfqudp</command>
@@ -1229,13 +1232,11 @@
       <modules>
         <command name="load">cmake</command>
       </modules>
-      <!-- <modules mpilib="!mpi-serial">
-        <command name="load">parallel-netcdf/1.6.1</command>
-      </modules> -->
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
       <env name="NETCDF_C_PATH">$SHELL{which nc-config | xargs dirname | xargs dirname}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{which nf-config | xargs dirname | xargs dirname}</env>
@@ -1244,13 +1245,29 @@
     <environment_variables mpilib="!mpi-serial">
       <env name="PNETCDF_PATH">$SHELL{which pnetcdf_version | xargs dirname | xargs dirname}</env>
     </environment_variables>
+    <environment_variables mpilib="mvapich">
+      <env name="MV2_ENABLE_AFFINITY">1</env>
+      <env name="MV2_USE_THREAD_WARNING">0</env>
+    </environment_variables>
+    <environment_variables mpilib="mvapich" DEBUG="TRUE">
+      <env name="MV2_DEBUG_SHOW_BACKTRACE">1</env>
+      <env name="MV2_SHOW_CPU_BINDING">1</env>
+      <env name="MV2_SHOW_ENV_INFO">2</env>
+    </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
-      <env name="OMP_STACKSIZE">128M</env>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" mpilib="mvapich">
+      <!--e.g. 6 threads: MV2_CPU_MAPPING=0-5:6-11:12-17:18-23:24-29:30-35: -->
+      <env name="MV2_CPU_MAPPING">$SHELL{t=$ENV{OMP_NUM_THREADS};b=0;r=$[36/$t];while [ $r -gt 0 ];do printf "$b-$[$b+$t-1]:";((r--));((b=b+t));done;}</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="intel">
+      <env name="KMP_AFFINITY">granularity=thread,scatter</env>
+      <env name="KMP_HOT_TEAMS_MODE">1</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="!intel">
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
-    </environment_variables>
-    <environment_variables mpilib="impi">
-      <env name="I_MPI_FABRICS">shm:tmi</env>
     </environment_variables>
   </machine>
 

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1137,7 +1137,7 @@
     <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/lcrc/group/acme/$USER/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/home/ccsm-data/tools/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/lcrc/group/acme/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_integration</TESTS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>


### PR DESCRIPTION
Update Anvil soft-env modules after the upgrade of the OS, module environment and update to SLURM.

[non-BFB] - due to update of software libraries