### PR TITLE
Resolving random compilation failure due to missing cosp module

### DIFF
--- a/components/cam/src/physics/cosp/Makefile.cospinline.in
+++ b/components/cam/src/physics/cosp/Makefile.cospinline.in
@@ -80,7 +80,7 @@ dsd.o          : array_lib.o math_lib.o calc_Re.o
 format_input.o : array_lib.o
 math_lib.o                : array_lib.o mrgrnk.o
 radar_simulator.o         : array_lib.o math_lib.o mrgrnk.o optics_lib.o \
-	                         radar_simulator_types.o
+	                         radar_simulator_types.o scale_LUTs_io.o
 radar_simulator_init.o    : radar_simulator_types.o
 scale_LUTs_io.o           : radar_simulator_types.o
 zeff.o                    : math_lib.o optics_lib.o


### PR DESCRIPTION
Nightly test of cosplite_nhtfrq5 on sandiatoss3 failed from time to time complaining
error in opening a compiled module file during compilation of
quickbeam/radar_simulator.f90. The missing module is scale_LUTs_io.

It turns out there was no rule explicitly setting the object of radar_simulator.o to
be dependent of module scale_LUTs_io, which may cause the compilation of radar_simultor.f90
to be started before scale_LUTs_io.f90 is compiled, hence unable to open the required module.

This update explicitly enforces it in cam/src/physics/cosp/Makefile.cospinline.in

[BFB]