### PR TITLE
Update edison machine setting

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -130,7 +130,7 @@
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.12</command>
       <command name="rm">cray-mpich</command>
-      <command name="load">pe_archive</command>
+      <command name="load">pe_archive/append-path</command>
       <command name="load">cray-mpich/7.6.0</command>
     </modules>
 


### PR DESCRIPTION
Use pe_archive/append-path instead of pe_archive to avoid module version
changes caused by the recent edison machine changes.

The test on edison (/global/cscratch1/sd/tang30/E3SM_simulations/20190327.tstBFB3_DECKv1b_H1.ne30_oEC.edison) shows that it's BFB.

[BFB] - Bit-For-Bit