### PR TITLE
Change the module commands that load pe_archive to be pe_archive/append

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -130,7 +130,7 @@
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.12</command>
       <command name="rm">cray-mpich</command>
-      <command name="load">pe_archive</command>
+      <command name="load">pe_archive/append-path</command>
       <command name="load">cray-mpich/7.6.0</command>
     </modules>
 
@@ -299,7 +299,7 @@
     <modules compiler="gnu">
       <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
-      <command name="load">pe_archive</command>
+      <command name="load">pe_archive/append-path</command>
       <command name="load">gcc/6.3.0</command>
       <command name="rm">cray-libsci</command>
       <command name="load">cray-libsci/17.09.1</command>
@@ -444,7 +444,7 @@
     <modules compiler="gnu">
       <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
       <command name="rm">gcc</command>
-      <command name="load">pe_archive</command>
+      <command name="load">pe_archive/append-path</command>
       <command name="load">gcc/6.3.0</command>
       <command name="rm">cray-libsci</command>
       <command name="load">cray-libsci/17.09.1</command>


### PR DESCRIPTION
Change the module commands that load pe_archive to be pe_archive/append-path

NERSC made a change that broke our environment and a fix was suggested to use "pe_archive/append-path" instead of "pe_archive".
This allows for the use of older versions of modules.

This is primarily for edison so that we can continue using cray-mpich/7.6.0.
Also changed the instances for cori so that we can use gcc/6.3.0 -- obviously only affects cori builds using the GNU compiler.

Fixes https://github.com/E3SM-Project/E3SM/issues/2829

[bfb]