### PR TITLE
MPAS Makefile and framework update

### DIFF
--- a/components/mpas-albany-landice/cime_config/buildlib
+++ b/components/mpas-albany-landice/cime_config/buildlib
@@ -6,7 +6,7 @@ my $component = "mpas-albany-landice";
 my $component_dir = "glc";
 my $component_driver = "glc_cesm_driver";
 my $core = "landice";
-my $esm = "ACME";
+my $esm = "E3SM";
 
 if ($#ARGV == -1) {
     die " ERROR $component buildlib: must specify a caseroot input argument";
@@ -70,7 +70,7 @@ if (defined $ENV{MPAS_TOOL_DIR}) {
 if ( $MALI_USE_ALBANY eq "TRUE" ) {
         print "Building MALI with Albany support.\n";
         $bldcmd .= ' ALBANY=true';
-        # Note MPAS_EXTERNAL_LIBS is not needed since ACME is doing the linking!
+        # Note MPAS_EXTERNAL_LIBS is not needed since E3SM is doing the linking!
 }
 
 print "Compiling MALI with this command: $bldcmd \n";

--- a/components/mpas-albany-landice/cime_config/config_component.xml
+++ b/components/mpas-albany-landice/cime_config/config_component.xml
@@ -35,7 +35,7 @@
       library The first-order velocity solver in MALI uses the
       Albany library.  In order to use that velocity solver, MALI
       must be built with Albany support and linking to Albany must
-      occur when building the ACME executable.  This occurs if this
+      occur when building the E3SM executable.  This occurs if this
       variable is set to TRUE.  Note that is only available on a
       limited set of machines/compilers.  This must remain FALSE to
       run MALI on a machine that does not have Albany, or for which

--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -72,7 +72,7 @@ module glc_comp_mct
 
   integer  :: nsend, nrecv
 
-  character(len=StrKIND) :: runtype  !< ACME run type: initial, continue, branch
+  character(len=StrKIND) :: runtype  !< E3SM run type: initial, continue, branch
   character(len=StrKIND) :: coupleTimeStamp
 
   type(seq_infodata_type), pointer :: infodata  ! coupler infodata
@@ -342,7 +342,7 @@ contains
     end if
 
     ! Set core specific options here
-    ! Disable output from all but the master task for ACME!
+    ! Disable output from all but the master task for E3SM!
     ! (This overrides the default set by mpas_log_init based on MPAS_DEBUG setting.)
     if (iam /= 0) then
        domain % logInfo % outputLog % isActive = .false.
@@ -798,7 +798,7 @@ contains
 !!  local variables
 !!
 !!-----------------------------------------------------------------------
-! Variables related to ACME coupler
+! Variables related to E3SM coupler
       integer :: shrloglev, shrlogunit
 
 ! Variable related to MALI
@@ -1526,7 +1526,7 @@ contains
        call mpas_log_write('MPAS ymd=$i  MPAS tod=$i', MPAS_LOG_ERR, intArgs=(/ymd, tod/))
        call mpas_log_write('sync ymd=$i  sync tod=$i', MPAS_LOG_ERR, intArgs=(/curr_ymd, curr_tod/))
        call mpas_log_write('Internal mpas clock not in sync with sync clock', MPAS_LOG_ERR)
-       call mpas_log_write("Internal MPAS clock not in sync with ACME sync clock. Aborting...", MPAS_LOG_CRIT)
+       call mpas_log_write("Internal MPAS clock not in sync with E3SM sync clock. Aborting...", MPAS_LOG_CRIT)
     end if
 
    end subroutine check_clocks_sync

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -228,7 +228,7 @@ Default: Defined in namelist_defaults.xml
 	category="init_setup" group="init_setup">
 Name of vertical grid to use in configuration generation
 
-Valid values: 'uniform', '60layerPHC', '42layerWOCE', '100layerACMEv1', '1dCVTgenerator', ...
+Valid values: 'uniform', '60layerPHC', '42layerWOCE', '100layerE3SMv1', '1dCVTgenerator', ...
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1309,7 +1309,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_frazil_heat_of_fusion" type="real"
 	category="frazil_ice" group="frazil_ice">
-Energy per kilogram released when sea water freezes. NOTE: test and make consistent with ACME.
+Energy per kilogram released when sea water freezes. NOTE: test and make consistent with E3SM.
 
 Valid values: Any positive real number.
 Default: Defined in namelist_defaults.xml
@@ -1317,7 +1317,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_frazil_ice_density" type="real"
 	category="frazil_ice" group="frazil_ice">
-Assumed density of frazil. NOTE: test and make consistent with ACME.
+Assumed density of frazil. NOTE: test and make consistent with E3SM.
 
 Valid values: Any positive real number.
 Default: Defined in namelist_defaults.xml
@@ -1333,7 +1333,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_specific_heat_sea_water" type="real"
 	category="frazil_ice" group="frazil_ice">
-Energy per kilogram per C needed to raise ocean temperature 1 C. NOTE: test and make consistent with ACME.
+Energy per kilogram per C needed to raise ocean temperature 1 C. NOTE: test and make consistent with E3SM.
 
 Valid values: Any positive real number.
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/cime_config/buildlib
+++ b/components/mpas-ocean/cime_config/buildlib
@@ -6,7 +6,7 @@ my $component = "mpas-ocean";
 my $component_dir = "ocn";
 my $component_driver = "ocean_cesm_driver";
 my $core = "ocean";
-my $esm = "ACME";
+my $esm = "E3SM";
 
 if ($#ARGV == -1) {
     die " ERROR $component buildlib: must specify a caseroot input argument";

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -7,7 +7,7 @@
   or in the CIME documenation
   </help>
 
-  <!-- ACME C/G compsets -->
+  <!-- E3SM C/G compsets -->
 
   <compset>
     <alias>CMPASO-NYF</alias>

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -374,7 +374,7 @@ contains
     end if
 
     ! Set core specific options here
-    ! Disable output from all but the master task for ACME!
+    ! Disable output from all but the master task for E3SM!
     ! (This overrides the default set by mpas_log_init based on MPAS_DEBUG setting.)
     if (iam /= 0) then
        domain % logInfo % outputLog % isActive = .false.
@@ -2416,7 +2416,7 @@ contains
        call mpas_log_write('MPAS ymd=$i  MPAS tod=$i', MPAS_LOG_ERR, intArgs=(/ymd, tod/))
        call mpas_log_write('sync ymd=$i  sync tod=$i', MPAS_LOG_ERR, intArgs=(/curr_ymd, curr_tod/))
        call mpas_log_write('Internal mpas clock not in sync with sync clock', MPAS_LOG_ERR)
-       call mpas_log_write("Internal MPAS clock not in sync with ACME sync clock. Aborting...", MPAS_LOG_CRIT)
+       call mpas_log_write("Internal MPAS clock not in sync with E3SM sync clock. Aborting...", MPAS_LOG_CRIT)
     end if
 
  end subroutine check_clocks_sync

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -3,7 +3,7 @@
 #
 # build-namelist
 #
-# This script builds the namelists for the MPASSI configuration of ACME.
+# This script builds the namelists for the MPASSI configuration of E3SM.
 #
 # build-namelist uses a config_cache.xml file that current contains the seaice grid information.
 # build-namelist reads this file to obtain information it needs to provide

--- a/components/mpas-seaice/cime_config/buildlib
+++ b/components/mpas-seaice/cime_config/buildlib
@@ -6,7 +6,7 @@ my $component = "mpas-seaice";
 my $component_dir = "ice";
 my $component_driver = "seaice_acme_driver";
 my $core = "seaice";
-my $esm = "ACME";
+my $esm = "E3SM";
 
 if ($#ARGV == -1) {
     die " ERROR $component buildlib: must specify a caseroot input argument";

--- a/components/mpas-seaice/cime_config/config_compsets.xml
+++ b/components/mpas-seaice/cime_config/config_compsets.xml
@@ -7,7 +7,7 @@
    or in the CIME documenation
    </help>
 
-  <!-- ACME D compsets -->
+  <!-- E3SM D compsets -->
 
   <compset>
     <alias>DTESTM</alias>

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -356,7 +356,7 @@ contains
     end if
 
     ! Set core specific options here
-    ! Disable output from all but the master task for ACME!
+    ! Disable output from all but the master task for E3SM!
     ! (This overrides the default set by mpas_log_init based on MPAS_DEBUG setting.)
     if (iam /= 0) then
        domain % logInfo % outputLog % isActive = .false.
@@ -774,7 +774,7 @@ contains
 !!  local variables
 !!
 !!-----------------------------------------------------------------------
-! Variables related to ACME coupler
+! Variables related to E3SM coupler
       integer :: ymd, tod, ihour, iminute, isecond
       integer :: iyear, imonth, iday, curr_ymd, curr_tod
       integer :: shrloglev, shrlogunit


### PR DESCRIPTION
Updating MPAS framework. This includes:
- Rename Makefile.in.ACME to Makefile.in.E3SM: https://github.com/MPAS-Dev/MPAS-Model/pull/195
- Change Makefile.in.E3SM to standard CESM formatting (TRUE in caps): https://github.com/MPAS-Dev/MPAS-Model/pull/191
- Add -Uvector to Makefile.in.E3SM to ignore the word 'vector' in comments when using GEN_F90=TRUE: https://github.com/MPAS-Dev/MPAS-Model/pull/200, fixes #2725
- Fix memory leak due to double allocate, only used by RK4 time stepping, does not change E3SM runs: https://github.com/MPAS-Dev/MPAS-Model/pull/185
- Changes to atmosphere directories are not used by E3SM.
- COMPASS testing updates, not used by E3SM, including python 3 updates.
- Fix typos that cause warnings on some compilers: https://github.com/MPAS-Dev/MPAS-Model/pull/196, https://github.com/MPAS-Dev/MPAS-Model/pull/197, https://github.com/MPAS-Dev/MPAS-Model/pull/198, https://github.com/MPAS-Dev/MPAS-Model/pull/199

E3SM updates that coincide:
- Change calls from Makefile.in.ACME to Makefile.in.E3SM
- Change ACME to E3SM in comments, xml descriptions, and warning strings

bfb
Fixes #2725
Fixes #2879