### PR TITLE
Update Anvil performance archiving support for switch to SLURM

### DIFF
--- a/cime/config/e3sm/machines/syslog.anvil
+++ b/cime/config/e3sm/machines/syslog.anvil
@@ -8,28 +8,54 @@ set lid = $3
 set run = $4
 set timing = $5
 set dir = $6
-set ncores = 0
 
 # Wait until job task-to-node mapping information is output before saving output file.
 # Target length was determined empirically (maximum number of lines before job mapping 
 #  information starts + number of nodes), and it may need to be adjusted in the future.
 # (Note that calling script 'touch'es the e3sm log file before spawning this script, so that 'wc' does not fail.)
-set nnodes = `qstat -f $jid | grep -F Resource_List.nodes | sed 's/ *Resource_List.nodes = *\([0-9]*\):ppn=*\([0-9]*\) */\1/' `
-@ target_lines = 25 + $nnodes
+set nnodes = `squeue --noheader -o '%D' --job $jid | sed 's/^0*\([0-9]*\)/\1/' `
+if ("X$nnodes" == "X") set nnodes = 0
+@ target_lines = 150 + $nnodes
 sleep 10
 set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
 while ($outlth < $target_lines)
   sleep 60
   set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
 end
-set remaining = `qstat -f $jid | grep -F Walltime.Remaining | sed 's/ *Walltime.Remaining = *\([0-9]*\) */\1/' `
+
+set TimeLeft     = `squeue --noheader -O 'timeleft' --job $jid `
+set TimeLeftwday = `echo $TimeLeft | grep '-' `
+if ("X$TimeLeftwday" == "X") then
+  set left_days  = 0
+  set TimeLeftwhour = `echo $TimeLeft | grep '.*:.*:.*' `
+  if ("X$TimeLeftwhour" == "X") then
+    set left_hours = 0
+    set left_mins  = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\)/\1/' `
+    set left_secs  = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\)/\2/' `
+  else
+    set left_hours = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
+    set left_mins  = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
+    set left_secs  = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
+  endif
+else
+  set left_days  = `echo $TimeLeft | sed 's/^0*\([0-9]*\)-0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
+  set left_hours = `echo $TimeLeft | sed 's/^0*\([0-9]*\)-0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
+  set left_mins  = `echo $TimeLeft | sed 's/^0*\([0-9]*\)-0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
+  set left_secs  = `echo $TimeLeft | sed 's/^0*\([0-9]*\)-0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\4/' `
+endif
+
+if ("X$left_days"  == "X") set left_days = 0
+if ("X$left_hours" == "X") set left_hours = 0
+if ("X$left_mins"  == "X") set left_mins = 0
+if ("X$left_secs"  == "X") set left_secs = 0
+@ remaining = 86400 * $left_days + 3600 * $left_hours + 60 * $left_mins + $left_secs
 cat > $run/Walltime.Remaining <<EOF1
 $remaining $sample_interval
 EOF1
 /bin/cp --preserve=timestamps $run/e3sm.log.$lid $dir/e3sm.log.$lid.$remaining
 if ($remaining <= 0) then
-  qstat -r acme > $dir/qstatr.$lid.$remaining
-  qstat -1 -n acme > $dir/qstatn.$lid.$remaining
+  squeue -t R -o  "%.10i %.10P %.15u %.20a %.2t %.6D %.8C %.12M %.12l %j" > $dir/squeuef.$lid.$remaining
+  squeue -s | grep -v -F extern > $dir/squeues.$lid.$remaining
 endif
 
 while ($remaining > 0)
@@ -47,8 +73,8 @@ while ($remaining > 0)
   echo "Wallclock time remaining: $remaining" >> $dir/cpl.log.$lid.step
   tail -n 4 $dir/cpl.log.$lid.step-all >> $dir/cpl.log.$lid.step
   /bin/cp --preserve=timestamps -u $timing/* $dir
-  qstat -r acme > $dir/qstatr.$lid.$remaining
-  qstat -1 -n acme > $dir/qstatn.$lid.$remaining
+  squeue -t R -o  "%.10i %.10P %.15u %.20a %.2t %.6D %.8C %.12M %.12l %j" > $dir/squeuef.$lid.$remaining
+  squeue -s | grep -v -F extern > $dir/squeues.$lid.$remaining
   chmod a+r $dir/*
   # sleep $sample_interval
   set sleep_remaining = $sample_interval
@@ -57,11 +83,34 @@ while ($remaining > 0)
    @ sleep_remaining = $sleep_remaining - 120
   end
   sleep $sleep_remaining
-  set remaining = `qstat -f $jid | grep -F Walltime.Remaining | sed 's/ *Walltime.Remaining = *\([0-9]*\) */\1/' `
-  if ("X$remaining" == "X") set remaining = 0
+  # query remaining time
+  set TimeLeft     = `squeue --noheader -O 'timeleft' --job $jid `
+  set TimeLeftwday = `echo $TimeLeft | grep '-' `
+  if ("X$TimeLeftwday" == "X") then
+    set left_days  = 0
+    set TimeLeftwhour = `echo $TimeLeft | grep '.*:.*:.*' `
+    if ("X$TimeLeftwhour" == "X") then
+      set left_hours = 0
+      set left_mins  = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\)/\1/' `
+      set left_secs  = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\)/\2/' `
+    else
+      set left_hours = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
+      set left_mins  = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
+      set left_secs  = `echo $TimeLeft | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
+    endif
+  else
+    set left_days  = `echo $TimeLeft | sed 's/^0*\([0-9]*\)-0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
+    set left_hours = `echo $TimeLeft | sed 's/^0*\([0-9]*\)-0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
+    set left_mins  = `echo $TimeLeft | sed 's/^0*\([0-9]*\)-0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
+    set left_secs  = `echo $TimeLeft | sed 's/^0*\([0-9]*\)-0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\4/' `
+  endif
+  if ("X$left_days"  == "X") set left_days = 0
+  if ("X$left_hours" == "X") set left_hours = 0
+  if ("X$left_mins"  == "X") set left_mins = 0
+  if ("X$left_secs"  == "X") set left_secs = 0
+  @ remaining = 86400 * $left_days + 3600 * $left_hours + 60 * $left_mins + $left_secs
   cat > $run/Walltime.Remaining << EOF2
 $remaining $sample_interval
 EOF2
 
 end
-


### PR DESCRIPTION
Anvil recently moved from PBS to SLURM. This requires changes to
syslog.anvil and provenance.py to replace calls to PBS inquiry
functions with calls to SLURM inquiry functions, to document
job provenance and to capture job progress tracking data.

[BFB]