### PR TITLE
Bugfix for naming mismatch in HOMME-ARKode interface

### DIFF
--- a/components/homme/src/arkode/theta-l/arkode_mod.F90
+++ b/components/homme/src/arkode/theta-l/arkode_mod.F90
@@ -1163,13 +1163,13 @@ contains
     !-----------------------------------------------------------------
     ! Description: sets Butcher tables in IMEX-KG format:
     !   Ae:   0 |    0             Ai:     0 |       0
-    !        c1 |   a1    0            chat1 |   ahat1 dhat1
-    !        c2 |   b1   a2  0         chat2 |   bhat1 ahat2 dhat2
-    !        c3 |   b2    0 a3 0       chat3 |   bhat2     0 ahat3 dhat3
+    !        c1 |   a1    0            chat1 | ahat1 dhat1
+    !        c2 |   b1   a2  0         chat2 |    b1 ahat2 dhat2
+    !        c3 |   b2    0 a3 0       chat3 |    b2     0 ahat3 dhat3
     !           |                            |
-    !        cq | bq-1 0 ... 0 aq 0    chatq | bhatq-1     0    ...    0 ahatq 0
+    !        cq | bq-1 0 ... 0 aq 0    chatq |  bq-1     0    ...    0 ahatq 0
     !        ----------------------    -----------------------------------------
-    !           | bq-1 0 ... 0 aq 0          | bhatq-1     0    ...    0 ahatq 0
+    !           | bq-1 0 ... 0 aq 0          |  bq-1     0    ...    0 ahatq 0
     !
     !        ci = sum_j Ae(i,j)        chati = sum_j Ai(i,j)
     !

--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -778,8 +778,17 @@ contains
     else if (tstep_type==37) then ! ARKode IMKG 2nd-order, 6 stage (4 implicit)
       call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG254)
 
-    else if (tstep_type==38) then ! ARKode IMKG 3rd-order, 5 stage (3 implicit)
+    else if (tstep_type==38) then ! ARKode IMKG 3rd-order, 5 stage (2 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG342)
+
+    else if (tstep_type==39) then ! ARKode IMKG 3rd-order, 5 stage (3 implicit)
       call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG343)
+
+    else if (tstep_type==40) then ! ARKode IMKG 3rd-order, 6 stage (3 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG353)
+
+    else if (tstep_type==41) then ! ARKode IMKG 3rd-order, 6 stage (4 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG354)
 
     else
        call abortmp('ERROR: bad choice of tstep_type')


### PR DESCRIPTION
This will fix a naming mismatch that occurred during the original merge of the HOMME-ARKode interface.  This should be BFB in that it only modifies code within an `ifdef` block that is disabled by default.