### PR TITLE
Update config files for LC resources

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1440,6 +1440,7 @@
     <EXEROOT>/p/lscratchh/$CCSMUSER/$CASE/bld</EXEROOT>
     <environment_variables compiler="intel">
       <env name="NETCDFROOT">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-18.0.1/</env>
+      <env name="NETCDF_PATH">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-18.0.1/</env>
     </environment_variables>
     <environment_variables compiler="intel" mpilib="!mpi-serial">
       <env name="PNETCDFROOT">/usr/tce/packages/pnetcdf/pnetcdf-1.9.0-intel-18.0.1-mvapich2-2.2/</env>
@@ -1492,6 +1493,7 @@
     <EXEROOT>/p/lscratchh/$CCSMUSER/$CASE/bld</EXEROOT>
     <environment_variables compiler="intel">
       <env name="NETCDFROOT">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-18.0.1/</env>
+      <env name="NETCDF_PATH">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-18.0.1/</env>
     </environment_variables>
     <environment_variables compiler="intel" mpilib="!mpi-serial">
       <env name="PNETCDFROOT">/usr/tce/packages/pnetcdf/pnetcdf-1.9.0-intel-18.0.1-mvapich2-2.2/</env>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1428,8 +1428,10 @@
       <modules compiler="intel">
         <command name="load">python</command>
         <command name="load">git</command>
-        <command name="load">intel</command>
-        <command name="load">mvapich2</command>
+        <command name="load">intel/18.0.1</command>
+        <command name="unload">pnetcdf/1.9.0</command>
+        <command name="unload">mvapich2</command>
+        <command name="load">mvapich2/2.2</command>
         <command name="load">netcdf-fortran/4.4.4</command>
         <command name="load">pnetcdf/1.9.0</command>
       </modules>
@@ -1478,8 +1480,10 @@
       <modules compiler="intel">
         <command name="load">python</command>
         <command name="load">git</command>
-        <command name="load">intel</command>
-        <command name="load">mvapich2</command>
+        <command name="load">intel/18.0.1</command>
+        <command name="unload">pnetcdf/1.9.0</command>
+        <command name="unload">mvapich2</command>
+        <command name="load">mvapich2/2.2</command>
         <command name="load">netcdf-fortran/4.4.4</command>
         <command name="load">pnetcdf/1.9.0</command>
       </modules>

--- a/run_e3sm.template.csh
+++ b/run_e3sm.template.csh
@@ -647,7 +647,7 @@ if ( `lowercase $walltime` == default ) then
   if ( `lowercase $debug_queue` == true ) then
     set walltime = '0:30:00'
   else
-    if ( $machine == 'cab' || $machine == 'syrah' ) then
+    if ( $machine == 'quartz' || $machine == 'syrah' ) then
       set walltime = '1:29:00'
     else
       set walltime = '2:00:00'
@@ -835,7 +835,7 @@ endif
 #===========================
 
 if ( `lowercase $debug_queue` == true ) then
-  if ( $machine == cab || $machine == sierra ) then
+  if ( $machine == quartz || $machine == syrah ) then
     $xmlchange_exe --id JOB_QUEUE --val 'pdebug'
   else if ($machine != sandiatoss3 && $machine != bebop && $machine != blues) then
     $xmlchange_exe --id JOB_QUEUE --val 'debug'
@@ -957,6 +957,7 @@ if ( `lowercase $old_executable` == false ) then
   e3sm_print '-------- Starting Build --------'
   e3sm_newline
 
+  e3sm_print 'WARNING: Make sure there are no double-slashes (//) in the build command below: => Will cause a build error'
   e3sm_print ${case_build_exe}
   ${case_build_exe}
 


### PR DESCRIPTION
Changes the config files in CIME to reflect recent changes in Livermore
Computing resources:

Update syrah and quartz machine config entries to explicitly load
mvapich2/2.2 which is the only mvapich version on LC that grants
access to pnetcdf/1.9.0.

These changes reflect a change in the default module loads on LC
machines.

In addition, there is a change to the run_script to purge all mention
of the machines cab and sierra (which have been taken down) and to
add a warning message to the build section warning of the sensitivity
of CIME to double slashes (//) in the case directory path.

[BFB] - Bit-For-Bit

See confluence for a more detailed description about these tags.