### PR TITLE
Adds machine files for Compy

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -386,6 +386,16 @@
     </queues>
    </batch_system>
 
+   <batch_system MACH="compy" type="slurm">
+    <directives>
+      <directive>--output=slurm.out</directive>
+      <directive>--error=slurm.err</directive>
+    </directives>
+    <queues>
+      <queue walltimemax="00:59:00" default="true">slurm</queue>
+    </queues>
+   </batch_system>
+
    <batch_system MACH="sooty" type="slurm" >
      <directives>
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1070,7 +1070,7 @@ for mct, etc.
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
-    <base> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH} -lmkl_rt</base>
+    <base> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt</base>
   </SLIBS>
 </compiler>
 
@@ -1086,15 +1086,14 @@ for mct, etc.
   </CPPDEFS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
-    <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </append>
     <append DEBUG="TRUE">-C -Mbounds -traceback -Mchkfpstk -Mchkstk -Mdalign  -Mdepchk  -Mextend -Miomutex -Mrecursive  -Ktrap=fp -O0 -g -byteswapio -Meh_frame</append>
   </FFLAGS>
   <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
-  <SLIBS>
-    <base> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH} -lmkl_rt  -L$ENV{MPI_LIB} -lmpich </base>
-  </SLIBS>
+  <LDFLAGS>
+    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt </append>
+  </LDFLAGS>
 </compiler>
 
 <compiler MACH="compy" COMPILER="gnu">
@@ -1110,8 +1109,7 @@ for mct, etc.
   <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <LDFLAGS>
-    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH} -lmkl_rt -L$ENV{MPI_LIB}  -lmpich </append>
-    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_HOME}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 </append>
+    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt</append>
   </LDFLAGS>
 </compiler>
 

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1066,7 +1066,7 @@ for mct, etc.
     <append DEBUG="FALSE"> -O2 </append>
     <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv -init=snan</append>
   </FFLAGS>
-  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDF_HOME}</NETCDF_PATH>
   <PNETCDF_PATH>$ENV{PNETCDF_HOME}</PNETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
@@ -1093,24 +1093,6 @@ for mct, etc.
   <PNETCDF_PATH>$ENV{PNETCDF_HOME}</PNETCDF_PATH>
   <LDFLAGS>
     <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt $ENV{PNETCDF_LIBRARIES} </append>
-  </LDFLAGS>
-</compiler>
-
-<compiler MACH="compy" COMPILER="gnu">
-  <CFLAGS>
-    <append DEBUG="FALSE"> -O2  </append>
-  </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2  </append>
-  </FFLAGS>
-  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
-  <PNETCDF_PATH>$ENV{PNETCDF_HOME}</PNETCDF_PATH>
-  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <LDFLAGS>
-    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt $ENV{PNETCDF_LIBRARIES}</append>
   </LDFLAGS>
 </compiler>
 

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1067,10 +1067,10 @@ for mct, etc.
     <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv -init=snan</append>
   </FFLAGS>
   <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF_HOME}</PNETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
-    <base> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt</base>
+    <base> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt $ENV{PNETCDF_LIBRARIES}</base>
   </SLIBS>
 </compiler>
 
@@ -1090,9 +1090,9 @@ for mct, etc.
   </FFLAGS>
   <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF_HOME}</PNETCDF_PATH>
   <LDFLAGS>
-    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt </append>
+    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt $ENV{PNETCDF_LIBRARIES} </append>
   </LDFLAGS>
 </compiler>
 
@@ -1107,9 +1107,10 @@ for mct, etc.
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
   <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF_HOME}</PNETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <LDFLAGS>
-    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt</append>
+    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt $ENV{PNETCDF_LIBRARIES}</append>
   </LDFLAGS>
 </compiler>
 

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1052,6 +1052,69 @@ for mct, etc.
   </SLIBS>
 </compiler>
 
+<compiler MACH="compy" COMPILER="intel">
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2 </append>
+  </CFLAGS>
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CPPDEFS>
+    <append> -DLINUX </append>
+  </CPPDEFS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2 </append>
+    <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv -init=snan</append>
+  </FFLAGS>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
+  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
+  <SLIBS>
+    <base> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH} -lmkl_rt</base>
+  </SLIBS>
+</compiler>
+
+<compiler MACH="compy" COMPILER="pgi">
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2 </append>
+  </CFLAGS>
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CPPDEFS>
+    <append> -DLINUX </append>
+  </CPPDEFS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2 </append>
+    <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </append>
+    <append DEBUG="TRUE">-C -Mbounds -traceback -Mchkfpstk -Mchkstk -Mdalign  -Mdepchk  -Mextend -Miomutex -Mrecursive  -Ktrap=fp -O0 -g -byteswapio -Meh_frame</append>
+  </FFLAGS>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
+  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
+  <SLIBS>
+    <base> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH} -lmkl_rt  -L$ENV{MPI_LIB} -lmpich </base>
+  </SLIBS>
+</compiler>
+
+<compiler MACH="compy" COMPILER="gnu">
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2  </append>
+  </CFLAGS>
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2  </append>
+  </FFLAGS>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
+  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+  <LDFLAGS>
+    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH} -lmkl_rt -L$ENV{MPI_LIB}  -lmpich </append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_HOME}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 </append>
+  </LDFLAGS>
+</compiler>
+
 <compiler MACH="cori-haswell" COMPILER="intel">
   <CONFIG_ARGS>
     <base> --host=Linux </base>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2044,6 +2044,7 @@
       </modules>
       <modules>
         <command name="load">netcdf/4.6.3</command>
+	<command name="load">pnetcdf/1.9.0</command>
 	<command name="load">mkl/2019u3</command>
       </modules>
     </module_system>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1977,8 +1977,8 @@
     <DESC>PNL E3SM Intel Xeon Gold 6148(Skylake) nodes, OS is Linux, SLURM</DESC>
     <NODENAME_REGEX>compy</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>intel,pgi,gnu</COMPILERS>
-    <MPILIBS>mvapich2,openmpi</MPILIBS>
+    <COMPILERS>intel,pgi</COMPILERS>
+    <MPILIBS>mvapich2</MPILIBS>
     <CIME_OUTPUT_ROOT>/compyfs/$USER/e3sm_scratch</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/compyfs/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/compyfs/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -2003,18 +2003,6 @@
         <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
-    <mpirun mpilib="intelmpi">
-      <executable>mpirun</executable>
-      <arguments>
-        <arg name="num_tasks">-n {{ total_tasks }}</arg>
-      </arguments>
-    </mpirun>
-    <mpirun mpilib="openmpi">
-      <executable>mpirun</executable>
-      <arguments>
-        <arg name="num_tasks">-n {{ total_tasks }}</arg>
-      </arguments>
-    </mpirun>
     <module_system type="module">
       <init_path lang="perl">/share/apps/modules/init/perl.pm</init_path>
       <init_path lang="python">/share/apps/modules/init/python.py</init_path>
@@ -2033,14 +2021,8 @@
       <modules compiler="pgi">
         <command name="load">pgi/18.10</command>
       </modules>
-      <modules compiler="gnu">
-        <command name="load">gcc/8.1.0</command>
-      </modules>
       <modules mpilib="mvapich2">
         <command name="load">mvapich2/2.3.1</command>
-      </modules>
-      <modules mpilib="openmpi">
-        <command name="load">openmpi/3.1.3</command>
       </modules>
       <modules>
         <command name="load">netcdf/4.6.3</command>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1973,6 +1973,104 @@
     </environment_variables>
   </machine>
 
+  <machine MACH="compy">
+    <DESC>PNL E3SM Intel Xeon Gold 6148(Skylake) nodes, OS is Linux, SLURM</DESC>
+    <NODENAME_REGEX>compy</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel,pgi,gnu</COMPILERS>
+    <MPILIBS>mvapich2,openmpi</MPILIBS>
+    <CIME_OUTPUT_ROOT>/compyfs/$USER/e3sm_scratch</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/compyfs/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/compyfs/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/compyfs/$USER/e3sm_scratch/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/compyfs/e3sm_baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/compyfs/e3sm_baselines/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>bibi.mathew -at- pnnl.gov</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>40</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>40</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="mpi-serial">
+      <executable/>
+    </mpirun>
+    <mpirun mpilib="mvapich2">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="mpi">--mpi=none</arg>
+        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="intelmpi">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="openmpi">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/share/apps/modules/init/perl.pm</init_path>
+      <init_path lang="python">/share/apps/modules/init/python.py</init_path>
+      <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
+      <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
+      <cmd_path lang="perl"> /share/apps/modules/bin/modulecmd  perl</cmd_path>
+      <cmd_path lang="python">/share/apps/modules/bin/modulecmd python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="purge"/>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">intel/19.0.3</command>
+        <command name="load">mkl/2019u3</command>
+      </modules>
+      <modules compiler="pgi">
+        <command name="load">pgi/19.1</command>
+	<command name="load">mkl/2019u3</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">gcc/4.8.5</command>
+	<command name="load">mkl/2019u3</command>
+      </modules>
+      <modules mpilib="mvapich2" compiler="intel">
+        <command name="load">mvapich2/2.3.1</command>
+      </modules>
+      <modules mpilib="mvapich2" compiler="pgi">
+        <command name="load">mvapich2/2.3.1</command>
+      </modules>
+      <modules mpilib="mvapich2" compiler="gnu">
+        <command name="load">mvapich2/2.3.1</command>
+      </modules>
+      <modules mpilib="openmpi">
+        <command name="load">openmpi/3.1.3</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">netcdf/4.6.3</command>
+      </modules>
+      <modules compiler="pgi">
+        <command name="load">netcdf/4.6.3</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">netcdf/4.6.3</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">64M</env>
+      <env name="NETCDF_HOME">$ENV{NETCDF_ROOT}/</env>
+    </environment_variables>
+    <environment_variables compiler="intel">
+      <env name="MKL_PATH">$ENV{MKLROOT}</env>
+    </environment_variables>
+  </machine>
 
   <machine MACH="oic5">
     <DESC>ORNL XK6, os is Linux, 32 pes/node, batch system is PBS</DESC>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2029,36 +2029,22 @@
       </modules>
       <modules compiler="intel">
         <command name="load">intel/19.0.3</command>
-        <command name="load">mkl/2019u3</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">pgi/19.1</command>
-	<command name="load">mkl/2019u3</command>
+        <command name="load">pgi/18.10</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gcc/4.8.5</command>
-	<command name="load">mkl/2019u3</command>
+        <command name="load">gcc/8.1.0</command>
       </modules>
-      <modules mpilib="mvapich2" compiler="intel">
-        <command name="load">mvapich2/2.3.1</command>
-      </modules>
-      <modules mpilib="mvapich2" compiler="pgi">
-        <command name="load">mvapich2/2.3.1</command>
-      </modules>
-      <modules mpilib="mvapich2" compiler="gnu">
+      <modules mpilib="mvapich2">
         <command name="load">mvapich2/2.3.1</command>
       </modules>
       <modules mpilib="openmpi">
         <command name="load">openmpi/3.1.3</command>
       </modules>
-      <modules compiler="intel">
+      <modules>
         <command name="load">netcdf/4.6.3</command>
-      </modules>
-      <modules compiler="pgi">
-        <command name="load">netcdf/4.6.3</command>
-      </modules>
-      <modules compiler="gnu">
-        <command name="load">netcdf/4.6.3</command>
+	<command name="load">mkl/2019u3</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -2067,7 +2053,7 @@
       <env name="OMP_STACKSIZE">64M</env>
       <env name="NETCDF_HOME">$ENV{NETCDF_ROOT}/</env>
     </environment_variables>
-    <environment_variables compiler="intel">
+    <environment_variables>
       <env name="MKL_PATH">$ENV{MKLROOT}</env>
     </environment_variables>
   </machine>


### PR DESCRIPTION
This PR adds first set of machine files for E3SM machine Compy. Machine
files for compilers Intel, gnu and PGI are added. I have used the
following test to compile and run the model:

SMS.ne4_ne4.FC5AV1C-L

For the above test:
-Intel compiler works fine
-GNU 4.8.5: Land model has a compile time error
-PGI: Netcdf is not built using this compiler yet

[BFB]