### PR TITLE
Upgrading Summit modules

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -3010,8 +3010,8 @@
         <command name="load">python/3.5.2</command>
         <command name="load">subversion/1.9.3</command>
         <command name="load">git/2.13.0</command>
-        <command name="load">cmake/3.9.2</command>
-        <command name="load">essl/6.1.0-20180406</command>
+        <command name="load">cmake/3.13.4</command>
+        <command name="load">essl/6.1.0-2</command>
         <command name="load">netlib-lapack/3.8.0</command>
       </modules>
       <!-- List of modules elements, executing commands if compiler and mpilib condition applies -->
@@ -3032,13 +3032,13 @@
       <!-- mpi lib settings -->
       <!-- Sometimes,same versions of libraries are not available for different compilers, hence the split below -->
       <modules compiler="ibm" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.2.0.10-20181214</command>
+        <command name="load">spectrum-mpi/10.2.0.11-20190201</command>
       </modules>
       <modules compiler="pgi.*" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.2.0.10-20181214</command>
+        <command name="load">spectrum-mpi/10.2.0.11-20190201</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.2.0.10-20181214</command>
+        <command name="load">spectrum-mpi/10.2.0.11-20190201</command>
       </modules>
 
       <modules>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -3078,6 +3078,8 @@
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
       <env name="HDF5_PATH">$ENV{OLCF_HDF5_ROOT}</env>
+      <!-- OMPI_MCA_io env is required due to OOM errors -->
+      <env name="OMPI_MCA_io">romio314</env>
       <env name="PNETCDF_PATH">$ENV{OLCF_PARALLEL_NETCDF_ROOT}</env>
     </environment_variables>
   </machine>


### PR DESCRIPTION
Upgrading the summit cmake, essl and MPI modules.

Also updating the ROMIO version to prevent OOM errors.

Fixes #2847

[BFB]