### PR TITLE
Modifies test to use new AQUAP compset

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -112,7 +112,7 @@ _TESTS = {
             "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
             "SMS.f09_g16_a.IGCLM45_MLI",
             "SMS_P12x2.ne4_oQU240.A_WCYCL1850.allactive-mach_mods",
-            "SMS_B.ne4_ne4.FC5AV1C-L-AQUAP.cam-hommexx",
+            "SMS_B.ne4_ne4.F-EAMv1-AQP1.cam-hommexx",
             )
         },
 


### PR DESCRIPTION
A test has been modified to use a new AQUAP compset as the old
one doesn't exist anymore

[BFB] - Bit-For-Bit