### PR TITLE
Minor build fixes

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -260,7 +260,8 @@ for mct, etc.
     <append DEBUG="TRUE"> -O0 -g </append>
   </CFLAGS>
   <CXXFLAGS>
-    <base> -std=c++11 -fp-model source -qopenmp </base>
+    <base> -std=c++11 -fp-model source </base>
+    <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="TRUE"> -O0 -g </append>
     <append DEBUG="FALSE"> -O2 </append>
   </CXXFLAGS>

--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -128,7 +128,7 @@ endif
 ifeq ($(strip $(PIO_VERSION)),1)
   CPPDEFS += -DPIO1
 else
-  USE_CXX = true
+  USE_CXX = TRUE
 endif
 
 ifeq (,$(SHAREDPATH))


### PR DESCRIPTION
Need consistent case for USE_CXX in Makefile (Restores cxxlib flag for PIO2). Intel should
not add qopenmp unless compile_threaded is TRUE.

Fixes #2858 

[BFB]