### PR TITLE
Fixes hommexx remap bug

### DIFF
--- a/components/homme/src/share/cxx/PpmRemap.hpp
+++ b/components/homme/src/share/cxx/PpmRemap.hpp
@@ -80,8 +80,11 @@ struct PpmMirrored : public PpmBoundaryConditions {
 
   KOKKOS_INLINE_FUNCTION
   static void apply_ppm_boundary(
-      ExecViewUnmanaged<const Real[_ppm_consts::AO_PHYSICAL_LEV]> cell_means,
-      ExecViewUnmanaged<Real[3][NUM_PHYSICAL_LEV]> parabola_coeffs) {}
+      ExecViewUnmanaged<const Real[_ppm_consts::AO_PHYSICAL_LEV]> /* cell_means */,
+      ExecViewUnmanaged<Real[3][NUM_PHYSICAL_LEV]> /* parabola_coeffs */)
+  {
+    // Nothing to do here
+  }
 
   KOKKOS_INLINE_FUNCTION
   static void fill_cell_means_gs(
@@ -148,8 +151,11 @@ struct PpmFixedMeans : public PpmBoundaryConditions {
 
   KOKKOS_INLINE_FUNCTION
   static void apply_ppm_boundary(
-      ExecViewUnmanaged<const Real[_ppm_consts::AO_PHYSICAL_LEV]> cell_means,
-      ExecViewUnmanaged<Real[3][NUM_PHYSICAL_LEV]> parabola_coeffs) {}
+      ExecViewUnmanaged<const Real[_ppm_consts::AO_PHYSICAL_LEV]> /* cell_means */,
+      ExecViewUnmanaged<Real[3][NUM_PHYSICAL_LEV]> /* parabola_coeffs */)
+  {
+    // Nothing to do here
+  }
 
   KOKKOS_INLINE_FUNCTION
   static void fill_cell_means_gs(
@@ -178,16 +184,21 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
   const int gs = _ppm_consts::gs;
 
   explicit PpmVertRemap(const int num_elems, const int num_remap)
-      : dpo("dpo", num_elems), pio("pio", num_elems), pin("pin", num_elems),
-        ppmdx("ppmdx", num_elems), z2("z2", num_elems), kid("kid", num_elems),
-        ao("a0", get_num_concurrent_teams<ExecSpace>(num_elems * num_remap)),
-        mass_o("mass_o",
-               get_num_concurrent_teams<ExecSpace>(num_elems * num_remap)),
-        dma("dma", get_num_concurrent_teams<ExecSpace>(num_elems * num_remap)),
-        ai("ai", get_num_concurrent_teams<ExecSpace>(num_elems * num_remap)),
-        parabola_coeffs(
-            "Coefficients for the interpolating parabola",
-            get_num_concurrent_teams<ExecSpace>(num_elems * num_remap)) {}
+      : m_dpo("dpo", num_elems)
+      , m_pio("pio", num_elems)
+      , m_pin("pin", num_elems)
+      , m_ppmdx("ppmdx", num_elems)
+      , m_z2("z2", num_elems)
+      , m_kid("kid", num_elems)
+      , m_ao("a0", get_num_concurrent_teams<ExecSpace>(num_elems * num_remap))
+      , m_mass_o("mass_o",get_num_concurrent_teams<ExecSpace>(num_elems * num_remap))
+      , m_dma("dma", get_num_concurrent_teams<ExecSpace>(num_elems * num_remap))
+      , m_ai("ai", get_num_concurrent_teams<ExecSpace>(num_elems * num_remap))
+      , m_parabola_coeffs("Coefficients for the interpolating parabola",
+            get_num_concurrent_teams<ExecSpace>(num_elems * num_remap))
+  {
+    // Nothing to do here
+  }
 
   KOKKOS_INLINE_FUNCTION
   void compute_grids_phase(
@@ -215,13 +226,12 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
                            [&](const int k) {
         const int ilevel = k / VECTOR_SIZE;
         const int ivector = k % VECTOR_SIZE;
-        ao(kv.team_idx, igp, jgp, k + _ppm_consts::INITIAL_PADDING) =
+        m_ao(kv.team_idx, igp, jgp, k + _ppm_consts::INITIAL_PADDING) =
             remap_var(igp, jgp, ilevel)[ivector] /
-            dpo(kv.ie, igp, jgp, k + _ppm_consts::INITIAL_PADDING);
+            m_dpo(kv.ie, igp, jgp, k + _ppm_consts::INITIAL_PADDING);
       });
 
-      boundaries::fill_cell_means_gs(kv,
-                                     Homme::subview(ao, kv.team_idx, igp, jgp));
+      boundaries::fill_cell_means_gs(kv,Homme::subview(m_ao, kv.team_idx, igp, jgp));
 
       Dispatch<ExecSpace>::parallel_scan(
           kv.team, NUM_PHYSICAL_LEV,
@@ -231,18 +241,18 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
             // grid spacing so we're working with actual tracer values and can
             // conserve mass.
             if (last) {
-              mass_o(kv.team_idx, igp, jgp, k + 1) = accumulator;
+              m_mass_o(kv.team_idx, igp, jgp, k + 1) = accumulator;
             }
             const int ilevel = k / VECTOR_SIZE;
             const int ivector = k % VECTOR_SIZE;
             accumulator += remap_var(igp, jgp, ilevel)[ivector];
-          });
+      });
 
       Kokkos::single(Kokkos::PerThread(kv.team), [&]() {
         const int ilast = (NUM_PHYSICAL_LEV - 1) / VECTOR_SIZE;
         const int vlast = (NUM_PHYSICAL_LEV - 1) % VECTOR_SIZE;
-        mass_o(kv.team_idx, igp, jgp, NUM_PHYSICAL_LEV + 1) =
-            mass_o(kv.team_idx, igp, jgp, NUM_PHYSICAL_LEV) +
+        m_mass_o(kv.team_idx, igp, jgp, NUM_PHYSICAL_LEV + 1) =
+            m_mass_o(kv.team_idx, igp, jgp, NUM_PHYSICAL_LEV) +
             remap_var(igp, jgp, ilast)[vlast];
       });
 
@@ -250,16 +260,18 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
       // the ghost cells
 
       // Computes a monotonic and conservative PPM reconstruction
-      compute_ppm(kv, Homme::subview(ao, kv.team_idx, igp, jgp),
-                  Homme::subview(ppmdx, kv.ie, igp, jgp),
-                  Homme::subview(dma, kv.team_idx, igp, jgp),
-                  Homme::subview(ai, kv.team_idx, igp, jgp),
-                  Homme::subview(parabola_coeffs, kv.team_idx, igp, jgp));
-      compute_remap(kv, Homme::subview(kid, kv.ie, igp, jgp),
-                    Homme::subview(z2, kv.ie, igp, jgp),
-                    Homme::subview(parabola_coeffs, kv.team_idx, igp, jgp),
-                    Homme::subview(mass_o, kv.team_idx, igp, jgp),
-                    Homme::subview(dpo, kv.ie, igp, jgp),
+      compute_ppm(kv,
+                  Homme::subview(m_ao, kv.team_idx, igp, jgp),
+                  Homme::subview(m_ppmdx, kv.ie, igp, jgp),
+                  Homme::subview(m_dma, kv.team_idx, igp, jgp),
+                  Homme::subview(m_ai, kv.team_idx, igp, jgp),
+                  Homme::subview(m_parabola_coeffs, kv.team_idx, igp, jgp));
+      compute_remap(kv,
+                    Homme::subview(m_kid, kv.ie, igp, jgp),
+                    Homme::subview(m_z2, kv.ie, igp, jgp),
+                    Homme::subview(m_parabola_coeffs, kv.team_idx, igp, jgp),
+                    Homme::subview(m_mass_o, kv.team_idx, igp, jgp),
+                    Homme::subview(m_dpo, kv.ie, igp, jgp),
                     Homme::subview(remap_var, igp, jgp));
     }); // End team thread range
     kv.team_barrier();
@@ -281,10 +293,10 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
   }
 
   template <typename ExecSpaceType = ExecSpace>
-  KOKKOS_INLINE_FUNCTION typename std::enable_if<
-      !Homme::OnGpu<ExecSpaceType>::value, void>::type
-  compute_remap(
-      KernelVariables &kv, ExecViewUnmanaged<const int[NUM_PHYSICAL_LEV]> k_id,
+  KOKKOS_INLINE_FUNCTION
+  typename std::enable_if<!Homme::OnGpu<ExecSpaceType>::value, void>::type
+  compute_remap(KernelVariables &kv,
+      ExecViewUnmanaged<const int[NUM_PHYSICAL_LEV]> k_id,
       ExecViewUnmanaged<const Real[NUM_PHYSICAL_LEV]> integral_bounds,
       ExecViewUnmanaged<const Real[3][NUM_PHYSICAL_LEV]> parabola_coeffs,
       ExecViewUnmanaged<Real[_ppm_consts::MASS_O_PHYSICAL_LEV]> mass,
@@ -296,38 +308,33 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
     // Then take the difference between accumulation at successive interfaces
     // gives the mass inside each cell. Since Qdp is supposed to hold the full
     // mass this needs no normalization.
+    Real mass1 = 0;
+    Real mass2;
+    ExecViewUnmanaged<Real[NUM_PHYSICAL_LEV]> rvar(reinterpret_cast<Real*>(remap_var.data()));
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
                          [&](const int k) {
       const int kk_cur_lev = k_id(k);
-      assert(kk_cur_lev + 1 >= k);
       assert(kk_cur_lev < parabola_coeffs.extent_int(1));
 
       const Real x2_cur_lev = integral_bounds(k);
       // Repurpose the mass buffer to store the new mass.
       // WARNING: This may not be thread safe in future architectures which
       //          use this level of parallelism!!!
-      mass(k) = compute_mass(
+      mass2 = compute_mass(
           parabola_coeffs(2, kk_cur_lev), parabola_coeffs(1, kk_cur_lev),
           parabola_coeffs(0, kk_cur_lev), mass(kk_cur_lev + 1),
           prev_dp(kk_cur_lev + _ppm_consts::INITIAL_PADDING), x2_cur_lev);
+
+      rvar(k) = mass2 - mass1;
+      mass1 = mass2;
     });
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
-                         [&](const int k) {
-      const int ilevel = k / VECTOR_SIZE;
-      const int ivector = k % VECTOR_SIZE;
-      if (k > 0) {
-        remap_var(ilevel)[ivector] = mass(k) - mass(k - 1);
-      } else {
-        remap_var(ilevel)[ivector] = mass(k);
-      }
-    }); // k loop
   }
 
   template <typename ExecSpaceType = ExecSpace>
-  KOKKOS_INLINE_FUNCTION typename std::enable_if<
-      Homme::OnGpu<ExecSpaceType>::value, void>::type
-  compute_remap(
-      KernelVariables &kv, ExecViewUnmanaged<const int[NUM_PHYSICAL_LEV]> k_id,
+  KOKKOS_INLINE_FUNCTION
+  typename std::enable_if<Homme::OnGpu<ExecSpaceType>::value, void>::type
+  compute_remapa(KernelVariables &kv,
+      ExecViewUnmanaged<const int[NUM_PHYSICAL_LEV]> k_id,
       ExecViewUnmanaged<const Real[NUM_PHYSICAL_LEV]> integral_bounds,
       ExecViewUnmanaged<const Real[3][NUM_PHYSICAL_LEV]> parabola_coeffs,
       ExecViewUnmanaged<Real[_ppm_consts::MASS_O_PHYSICAL_LEV]> prev_mass,
@@ -341,7 +348,7 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
               ? compute_mass(
                     parabola_coeffs(2, k_id(k - 1)),
                     parabola_coeffs(1, k_id(k - 1)),
-                    parabola_coeffs(0, k_id(k - 1)), prev_mass(k_id(k - 1) + 1),
+                    parabola_coeffs(0, k_id(k - 1)), prev_mass(k_id(k - 1)),
                     prev_dp(k_id(k - 1) + _ppm_consts::INITIAL_PADDING),
                     integral_bounds(k - 1))
               : 0.0;
@@ -364,11 +371,10 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void compute_grids(
-      KernelVariables &kv,
+  void compute_grids(KernelVariables &kv,
       const ExecViewUnmanaged<const Real[_ppm_consts::DPO_PHYSICAL_LEV]> dx,
-      const ExecViewUnmanaged<Real[10][_ppm_consts::PPMDX_PHYSICAL_LEV]> grids)
-      const {
+      const ExecViewUnmanaged<Real[10][_ppm_consts::PPMDX_PHYSICAL_LEV]> grids) const
+  {
     constexpr int dpo_offset = _ppm_consts::INITIAL_PADDING - _ppm_consts::gs;
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,
                                                    NUM_PHYSICAL_LEV + 2),
@@ -413,8 +419,7 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void compute_ppm(
-      KernelVariables &kv,
+  void compute_ppm(KernelVariables &kv,
       // input  views
       ExecViewUnmanaged<const Real[_ppm_consts::AO_PHYSICAL_LEV]> cell_means,
       ExecViewUnmanaged<const Real[10][_ppm_consts::PPMDX_PHYSICAL_LEV]> dx,
@@ -422,9 +427,9 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
       ExecViewUnmanaged<Real[_ppm_consts::DMA_PHYSICAL_LEV]> dma,
       ExecViewUnmanaged<Real[_ppm_consts::AI_PHYSICAL_LEV]> ai,
       // result view
-      ExecViewUnmanaged<Real[3][NUM_PHYSICAL_LEV]> parabola_coeffs) const {
+      ExecViewUnmanaged<Real[3][NUM_PHYSICAL_LEV]> parabola_coeffs) const
+  {
     const auto INITIAL_PADDING = _ppm_consts::INITIAL_PADDING;
-    const auto gs = _ppm_consts::gs;
 
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,
                                                    NUM_PHYSICAL_LEV + 2),
@@ -513,9 +518,9 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
       const int igp = loop_idx / NP;
       const int jgp = loop_idx % NP;
       ExecViewUnmanaged<Real[_ppm_consts::PIO_PHYSICAL_LEV]> pt_pio =
-          Homme::subview(pio, kv.ie, igp, jgp);
+          Homme::subview(m_pio, kv.ie, igp, jgp);
       ExecViewUnmanaged<Real[_ppm_consts::PIN_PHYSICAL_LEV]> pt_pin =
-          Homme::subview(pin, kv.ie, igp, jgp);
+          Homme::subview(m_pin, kv.ie, igp, jgp);
       ExecViewUnmanaged<const Scalar[NUM_LEV]> pt_src_thickness =
           Homme::subview(src_layer_thickness, igp, jgp);
       ExecViewUnmanaged<const Scalar[NUM_LEV]> pt_tgt_thickness =
@@ -553,8 +558,8 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
         // threads to run in the remapping phase. It makes
         // sure there's an old interface value below the
         // domain that is larger.
-        assert(fabs(pio(kv.ie, igp, jgp, NUM_PHYSICAL_LEV) -
-                    pin(kv.ie, igp, jgp, NUM_PHYSICAL_LEV)) < 1.0);
+        assert(fabs(m_pio(kv.ie, igp, jgp, NUM_PHYSICAL_LEV) -
+                    m_pin(kv.ie, igp, jgp, NUM_PHYSICAL_LEV)) < 1.0);
 
         pt_pio(_ppm_consts::PIO_PHYSICAL_LEV - 1) =
             pt_pio(_ppm_consts::PIO_PHYSICAL_LEV - 2) + 1.0;
@@ -569,7 +574,7 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
                            [&](const int &k) {
         int ilevel = k / VECTOR_SIZE;
         int ivector = k % VECTOR_SIZE;
-        dpo(kv.ie, igp, jgp, k + _ppm_consts::INITIAL_PADDING) =
+        m_dpo(kv.ie, igp, jgp, k + _ppm_consts::INITIAL_PADDING) =
             src_layer_thickness(igp, jgp, ilevel)[ivector];
       });
     });
@@ -585,11 +590,11 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
       const int jgp = loop_idx % NP;
       Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team, gs),
                            [&](const int &k) {
-        dpo(kv.ie, igp, jgp, _ppm_consts::INITIAL_PADDING - 1 - k) =
-            dpo(kv.ie, igp, jgp, k + _ppm_consts::INITIAL_PADDING);
-        dpo(kv.ie, igp, jgp,
+        m_dpo(kv.ie, igp, jgp, _ppm_consts::INITIAL_PADDING - 1 - k) =
+            m_dpo(kv.ie, igp, jgp, k + _ppm_consts::INITIAL_PADDING);
+        m_dpo(kv.ie, igp, jgp,
             NUM_PHYSICAL_LEV + _ppm_consts::INITIAL_PADDING + k) =
-            dpo(kv.ie, igp, jgp,
+            m_dpo(kv.ie, igp, jgp,
                 NUM_PHYSICAL_LEV + _ppm_consts::INITIAL_PADDING - 1 - k);
       });
     });
@@ -616,7 +621,7 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
         // deformation. Numerous tests confirmed that the
         // bottom and top of the grids match to machine
         // precision, so set them equal to each other.
-        int kk = k + 1;
+        int kk = k;// + 1;
         // This reduces the work required to find the index where this
         // fails at, and is typically less than NUM_PHYSICAL_LEV^2 Since
         // the top bounds match anyway, the value of the coefficients
@@ -630,37 +635,37 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
         // NUM_PHYSICAL_LEV + 2 Furthermore, since we set pio(:, :, :,
         // 0) = 0.0 and pin(:, :, :, 0) = 0.0 kk must be incremented at
         // least once
-        assert(pio(kv.ie, igp, jgp, _ppm_consts::PIO_PHYSICAL_LEV - 1) >
-               pin(kv.ie, igp, jgp, k + 1));
-        while (pio(kv.ie, igp, jgp, kk - 1) <= pin(kv.ie, igp, jgp, k + 1)) {
-          kk++;
-          assert(kk - 1 < pio.extent_int(3));
+        assert(m_pio(kv.ie, igp, jgp, _ppm_consts::PIO_PHYSICAL_LEV - 1) >
+               m_pin(kv.ie, igp, jgp, k + 1));
+        if (m_pio(kv.ie,igp,jgp,kk) <= m_pin(kv.ie,igp,jgp,k+1)) {
+          while (m_pio(kv.ie, igp, jgp, kk) <= m_pin(kv.ie, igp, jgp, k + 1)) {
+            kk++;
+            assert(kk < m_pio.extent_int(3));
+          }
+          --kk;
+        } else {
+          binary_search(Homme::subview(m_pio,kv.ie,igp,jgp),m_pin(kv.ie,igp,jgp,k+1),kk);
         }
 
-        kk--;
         // This is to keep the indices in bounds.
-        if (kk == _ppm_consts::PIN_PHYSICAL_LEV) {
-          kk = _ppm_consts::PIN_PHYSICAL_LEV - 1;
+        if (kk == NUM_PHYSICAL_LEV) {
+          --kk;
         }
         // kk is now the cell index we're integrating over.
 
         // Save kk for reuse
-        kid(kv.ie, igp, jgp, k) = kk - 1;
+        m_kid(kv.ie, igp, jgp, k) = kk;
         // PPM interpolants are normalized to an independent coordinate
         // domain
         // [-0.5, 0.5].
-        assert(kk >= k);
-        assert(kk < pio.extent_int(3));
-        z2(kv.ie, igp, jgp, k) =
-            (pin(kv.ie, igp, jgp, k + 1) -
-             (pio(kv.ie, igp, jgp, kk - 1) + pio(kv.ie, igp, jgp, kk)) * 0.5) /
-            dpo(kv.ie, igp, jgp, kk + 1 + _ppm_consts::INITIAL_PADDING - gs);
+        m_z2(kv.ie, igp, jgp, k) =
+            (m_pin(kv.ie, igp, jgp, k + 1) -
+             (m_pio(kv.ie, igp, jgp, kk) + m_pio(kv.ie, igp, jgp, kk+1)) * 0.5) /
+            m_dpo(kv.ie, igp, jgp, kk + _ppm_consts::INITIAL_PADDING);
       });
 
-      ExecViewUnmanaged<Real[_ppm_consts::DPO_PHYSICAL_LEV]> point_dpo =
-          Homme::subview(dpo, kv.ie, igp, jgp);
-      ExecViewUnmanaged<Real[10][_ppm_consts::PPMDX_PHYSICAL_LEV]> point_ppmdx =
-          Homme::subview(ppmdx, kv.ie, igp, jgp);
+      auto point_dpo   = Homme::subview(m_dpo, kv.ie, igp, jgp);
+      auto point_ppmdx = Homme::subview(m_ppmdx, kv.ie, igp, jgp);
       compute_grids(kv, point_dpo, point_ppmdx);
     });
   }
@@ -672,20 +677,46 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
            sq_coeff * (x2 * x2 * x2 - x1 * x1 * x1) / 3.0;
   }
 
-  ExecViewManaged<Real * [NP][NP][_ppm_consts::DPO_PHYSICAL_LEV]> dpo;
-  // pio corresponds to the points in each layer of the source layer thickness
-  ExecViewManaged<Real * [NP][NP][_ppm_consts::PIO_PHYSICAL_LEV]> pio;
-  // pin corresponds to the points in each layer of the target layer thickness
-  ExecViewManaged<Real * [NP][NP][_ppm_consts::PIN_PHYSICAL_LEV]> pin;
-  ExecViewManaged<Real * [NP][NP][10][_ppm_consts::PPMDX_PHYSICAL_LEV]> ppmdx;
-  ExecViewManaged<Real * [NP][NP][NUM_PHYSICAL_LEV]> z2;
-  ExecViewManaged<int * [NP][NP][NUM_PHYSICAL_LEV]> kid;
+  KOKKOS_INLINE_FUNCTION
+  void binary_search (ExecViewUnmanaged<const Real[_ppm_consts::PIO_PHYSICAL_LEV]> pt_pio,
+                      const Real pivot, int& k) const {
+    int lo,hi;
 
-  ExecViewManaged<Real * [NP][NP][_ppm_consts::AO_PHYSICAL_LEV]> ao;
-  ExecViewManaged<Real * [NP][NP][_ppm_consts::MASS_O_PHYSICAL_LEV]> mass_o;
-  ExecViewManaged<Real * [NP][NP][_ppm_consts::DMA_PHYSICAL_LEV]> dma;
-  ExecViewManaged<Real * [NP][NP][_ppm_consts::AI_PHYSICAL_LEV]> ai;
-  ExecViewManaged<Real * [NP][NP][3][NUM_PHYSICAL_LEV]> parabola_coeffs;
+    // Initialize lower and upper bounds
+    if (pt_pio(k)>pivot) {
+      lo = 0;
+      hi = k;
+    } else {
+      lo = k;
+      hi = _ppm_consts::PIO_PHYSICAL_LEV-1;
+    }
+
+    // Binary search until hi=lo
+    while (hi>lo+1) {
+      k = (lo+hi)/2;
+      if (pt_pio(k)>pivot) {
+        hi = k;
+      } else {
+        lo = k;
+      }
+    }
+    k = lo;
+  }
+
+  ExecViewManaged<Real * [NP][NP][_ppm_consts::DPO_PHYSICAL_LEV]> m_dpo;
+  // pio corresponds to the points in each layer of the source layer thickness
+  ExecViewManaged<Real * [NP][NP][_ppm_consts::PIO_PHYSICAL_LEV]> m_pio;
+  // pin corresponds to the points in each layer of the target layer thickness
+  ExecViewManaged<Real * [NP][NP][_ppm_consts::PIN_PHYSICAL_LEV]> m_pin;
+  ExecViewManaged<Real * [NP][NP][10][_ppm_consts::PPMDX_PHYSICAL_LEV]> m_ppmdx;
+  ExecViewManaged<Real * [NP][NP][NUM_PHYSICAL_LEV]>  m_z2;
+  ExecViewManaged<int * [NP][NP][NUM_PHYSICAL_LEV]>   m_kid;
+
+  ExecViewManaged<Real * [NP][NP][_ppm_consts::AO_PHYSICAL_LEV]> m_ao;
+  ExecViewManaged<Real * [NP][NP][_ppm_consts::MASS_O_PHYSICAL_LEV]> m_mass_o;
+  ExecViewManaged<Real * [NP][NP][_ppm_consts::DMA_PHYSICAL_LEV]> m_dma;
+  ExecViewManaged<Real * [NP][NP][_ppm_consts::AI_PHYSICAL_LEV]> m_ai;
+  ExecViewManaged<Real * [NP][NP][3][NUM_PHYSICAL_LEV]> m_parabola_coeffs;
 };
 
 } // namespace Ppm

--- a/components/homme/src/share/cxx/PpmRemap.hpp
+++ b/components/homme/src/share/cxx/PpmRemap.hpp
@@ -333,7 +333,7 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
   template <typename ExecSpaceType = ExecSpace>
   KOKKOS_INLINE_FUNCTION
   typename std::enable_if<Homme::OnGpu<ExecSpaceType>::value, void>::type
-  compute_remapa(KernelVariables &kv,
+  compute_remap(KernelVariables &kv,
       ExecViewUnmanaged<const int[NUM_PHYSICAL_LEV]> k_id,
       ExecViewUnmanaged<const Real[NUM_PHYSICAL_LEV]> integral_bounds,
       ExecViewUnmanaged<const Real[3][NUM_PHYSICAL_LEV]> parabola_coeffs,

--- a/components/homme/src/share/cxx/PpmRemap.hpp
+++ b/components/homme/src/share/cxx/PpmRemap.hpp
@@ -677,32 +677,6 @@ template <typename boundaries> struct PpmVertRemap : public VertRemapAlg {
            sq_coeff * (x2 * x2 * x2 - x1 * x1 * x1) / 3.0;
   }
 
-  KOKKOS_INLINE_FUNCTION
-  void binary_search (ExecViewUnmanaged<const Real[_ppm_consts::PIO_PHYSICAL_LEV]> pt_pio,
-                      const Real pivot, int& k) const {
-    int lo,hi;
-
-    // Initialize lower and upper bounds
-    if (pt_pio(k)>pivot) {
-      lo = 0;
-      hi = k;
-    } else {
-      lo = k;
-      hi = _ppm_consts::PIO_PHYSICAL_LEV-1;
-    }
-
-    // Binary search until hi=lo
-    while (hi>lo+1) {
-      k = (lo+hi)/2;
-      if (pt_pio(k)>pivot) {
-        hi = k;
-      } else {
-        lo = k;
-      }
-    }
-    k = lo;
-  }
-
   ExecViewManaged<Real * [NP][NP][_ppm_consts::DPO_PHYSICAL_LEV]> m_dpo;
   // pio corresponds to the points in each layer of the source layer thickness
   ExecViewManaged<Real * [NP][NP][_ppm_consts::PIO_PHYSICAL_LEV]> m_pio;

--- a/components/homme/src/share/cxx/utilities/MathUtils.hpp
+++ b/components/homme/src/share/cxx/utilities/MathUtils.hpp
@@ -124,6 +124,33 @@ frobenius_norm(const ViewType view, bool ignore_nans = false) {
   return std::sqrt(norm);
 }
 
+template<typename T, int N, typename... Properties>
+KOKKOS_INLINE_FUNCTION
+void binary_search (ViewType<T[N],Properties...> array,
+                    const T& pivot, int& k) {
+  int lo,hi;
+
+  // Initialize lower and upper bounds
+  if (array(k)>pivot) {
+    lo = 0;
+    hi = k;
+  } else {
+    lo = k;
+    hi = N-1;
+  }
+
+  // Binary search until hi=lo+1
+  while (hi>lo+1) {
+    k = (lo+hi)/2;
+    if (array(k)>pivot) {
+      hi = k;
+    } else {
+      lo = k;
+    }
+  }
+  k = lo;
+}
+
 } // namespace Homme
 
 #endif // HOMMEXX_MATH_UTILS_HPP

--- a/components/homme/test_execs/share_kokkos_ut/remap_ut.cpp
+++ b/components/homme/test_execs/share_kokkos_ut/remap_ut.cpp
@@ -319,8 +319,7 @@ public:
     HostViewManaged<Real[NUM_PHYSICAL_LEV][NP][NP]>
     f90_tgt_layer_thickness_input("fortran target layer thickness");
 
-    HostViewManaged<Scalar * * [NP][NP][NUM_LEV]> kokkos_remapped(
-        "kokkos_remapped", ne, num_remap);
+    auto kokkos_remapped = Kokkos::create_mirror_view(remap_vals);
     Kokkos::deep_copy(kokkos_remapped, remap_vals);
 
     for (int ie = 0; ie < ne; ++ie) {

--- a/components/homme/test_execs/share_kokkos_ut/remap_ut.cpp
+++ b/components/homme/test_execs/share_kokkos_ut/remap_ut.cpp
@@ -73,7 +73,7 @@ public:
   void test_grid() {
     std::random_device rd;
     rngAlg engine(rd());
-    genRandArray(remap.dpo, engine,
+    genRandArray(remap.m_dpo, engine,
                  std::uniform_real_distribution<Real>(0.125, 1000),
                  nan_boundaries);
     Kokkos::parallel_for(
@@ -85,12 +85,12 @@ public:
         "fortran dpo");
     HostViewManaged<Real[_ppm_consts::PPMDX_PHYSICAL_LEV][10]> f90_result(
         "fortra ppmdx");
-    auto kokkos_result = Kokkos::create_mirror_view(remap.ppmdx);
-    Kokkos::deep_copy(kokkos_result, remap.ppmdx);
+    auto kokkos_result = Kokkos::create_mirror_view(remap.m_ppmdx);
+    Kokkos::deep_copy(kokkos_result, remap.m_ppmdx);
     for (int ie = 0; ie < ne; ++ie) {
       for (int igp = 0; igp < NP; ++igp) {
         for (int jgp = 0; jgp < NP; ++jgp) {
-          Kokkos::deep_copy(f90_input, Homme::subview(remap.dpo, ie, igp, jgp));
+          Kokkos::deep_copy(f90_input, Homme::subview(remap.m_dpo, ie, igp, jgp));
           // These arrays must be 0 offset.
           for (int k = 0; k < NUM_PHYSICAL_LEV + 2 * _ppm_consts::gs; ++k) {
             f90_input(k) =
@@ -124,28 +124,28 @@ public:
                          [&](const int &loop_idx) {
       const int igp = loop_idx / NP;
       const int jgp = loop_idx % NP;
-      remap.compute_grids(kv, Homme::subview(remap.dpo, kv.ie, igp, jgp),
-                          Homme::subview(remap.ppmdx, kv.ie, igp, jgp));
+      remap.compute_grids(kv, Homme::subview(remap.m_dpo, kv.ie, igp, jgp),
+                          Homme::subview(remap.m_ppmdx, kv.ie, igp, jgp));
     });
   }
 
   void test_ppm() {
     // Hack to get the right number of outputs
-    remap.ao = ExecViewManaged<Real * [NP][NP][_ppm_consts::AO_PHYSICAL_LEV]>(
+    remap.m_ao = ExecViewManaged<Real * [NP][NP][_ppm_consts::AO_PHYSICAL_LEV]>(
         "ao", num_remap * ne);
-    remap.dma = ExecViewManaged<Real * [NP][NP][_ppm_consts::DMA_PHYSICAL_LEV]>(
+    remap.m_dma = ExecViewManaged<Real * [NP][NP][_ppm_consts::DMA_PHYSICAL_LEV]>(
         "dma", num_remap * ne);
-    remap.ai = ExecViewManaged<Real * [NP][NP][_ppm_consts::AI_PHYSICAL_LEV]>(
+    remap.m_ai = ExecViewManaged<Real * [NP][NP][_ppm_consts::AI_PHYSICAL_LEV]>(
         "ai", num_remap * ne);
-    remap.parabola_coeffs = ExecViewManaged<Real * [NP][NP][3][NUM_PHYSICAL_LEV]>(
+    remap.m_parabola_coeffs = ExecViewManaged<Real * [NP][NP][3][NUM_PHYSICAL_LEV]>(
         "parabola coeffs", num_remap * ne);
 
     std::random_device rd;
     rngAlg engine(rd());
-    genRandArray(remap.ppmdx, engine,
+    genRandArray(remap.m_ppmdx, engine,
                  std::uniform_real_distribution<Real>(0.125, 1000));
     for (int i = 0; i < num_remap; ++i) {
-      genRandArray(remap.ao, engine,
+      genRandArray(remap.m_ao, engine,
                    std::uniform_real_distribution<Real>(0.125, 1000),
                    nan_boundaries);
     }
@@ -160,16 +160,16 @@ public:
     HostViewManaged<Real[_ppm_consts::PPMDX_PHYSICAL_LEV][10]> f90_dx_input(
         "fortran ppmdx");
     HostViewManaged<Real[NUM_PHYSICAL_LEV][3]> f90_result("fortran result");
-    auto kokkos_result = Kokkos::create_mirror_view(remap.parabola_coeffs);
-    Kokkos::deep_copy(kokkos_result, remap.parabola_coeffs);
+    auto kokkos_result = Kokkos::create_mirror_view(remap.m_parabola_coeffs);
+    Kokkos::deep_copy(kokkos_result, remap.m_parabola_coeffs);
     for (int var = 0; var < num_remap; ++var) {
       for (int ie = 0; ie < ne; ++ie) {
         for (int igp = 0; igp < NP; ++igp) {
           for (int jgp = 0; jgp < NP; ++jgp) {
             Kokkos::deep_copy(
                 f90_cellmeans_input,
-                Homme::subview(remap.ao, ie * num_remap + var, igp, jgp));
-            sync_to_host(Homme::subview(remap.ppmdx, ie, igp, jgp),
+                Homme::subview(remap.m_ao, ie * num_remap + var, igp, jgp));
+            sync_to_host(Homme::subview(remap.m_ppmdx, ie, igp, jgp),
                          f90_dx_input);
             // Fix the Fortran input to be 0 offset
             for (int i = 0; i < NUM_PHYSICAL_LEV + 2 * _ppm_consts::gs; ++i) {
@@ -181,8 +181,8 @@ public:
               f90_cellmeans_input(i) = std::numeric_limits<Real>::quiet_NaN();
             }
 
-            auto tmp = Kokkos::create_mirror_view(remap.ppmdx);
-            Kokkos::deep_copy(tmp, remap.ppmdx);
+            auto tmp = Kokkos::create_mirror_view(remap.m_ppmdx);
+            Kokkos::deep_copy(tmp, remap.m_ppmdx);
 
             compute_ppm_c_callable(f90_cellmeans_input.data(),
                                    f90_dx_input.data(), f90_result.data(),
@@ -214,12 +214,12 @@ public:
       const int igp = (loop_idx / NP) % NP;
       const int jgp = loop_idx % NP;
       remap.compute_ppm(
-          kv, Homme::subview(remap.ao, kv.ie * num_remap + var, igp, jgp),
-          Homme::subview(remap.ppmdx, kv.ie, igp, jgp),
-          Homme::subview(remap.dma, kv.ie * num_remap + var, igp, jgp),
-          Homme::subview(remap.ai, kv.ie * num_remap + var, igp, jgp),
-          Homme::subview(remap.parabola_coeffs, kv.ie * num_remap + var, igp,
-                         jgp));
+          kv,
+          Homme::subview(remap.m_ao, kv.ie * num_remap + var, igp, jgp),
+          Homme::subview(remap.m_ppmdx, kv.ie, igp, jgp),
+          Homme::subview(remap.m_dma, kv.ie * num_remap + var, igp, jgp),
+          Homme::subview(remap.m_ai, kv.ie * num_remap + var, igp, jgp),
+          Homme::subview(remap.m_parabola_coeffs, kv.ie * num_remap + var, igp, jgp));
     });
   }
 


### PR DESCRIPTION
Propagates a fix in vertical remap (already present in the Fortran code) to the C++/Kokkos code.

Also: suppressing some compiler warnings (unused/shadowing variables).

Fixes #2711 .

[BFB]