### PR TITLE
Fix the calculation to give the best cflag value for cori-knl

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -366,7 +366,7 @@
       <arguments>
         <arg name="label"> --label</arg>
         <arg name="num_tasks"> -n {{ total_tasks }}</arg>
-        <arg name="thread_count">-c $SHELL{echo 272/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
+        <arg name="thread_count">-c $SHELL{mpn=`./xmlquery --value MAX_MPITASKS_PER_NODE`; if [ 68 -ge $mpn ]; then c0=`expr 272 / $mpn`; c1=`expr $c0 / 4`; cflag=`expr $c1 \* 4`; echo $cflag|bc ; else echo 272/$mpn|bc;fi;} </arg>
         <arg name="binding"> $SHELL{if [ 68 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
         <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
     </arguments>


### PR DESCRIPTION
Fix the calculation to give the best cflag value (integer value passed to srun via -c) for KNL.

Otherwise, for certain MAX_MPITASKS_PER_NODE, the calculation could give non-optimal cflag values.  For example, with 16 MPI's per node, this fix should yield -c 16.

The formula I used was 
```
if mpn<=68:
  cflag=((272/mpn)/4)*4 
else:
  cflag=272/mpn
```
Where mpn is MPI's per node and we want "integer math" (eg ignore round-off like floor()) and that seems to compute the right integer. We should now be computing the values that are given in the NERSC job script generator web page. Just to be complete, before this change, we were only using "cflag=272/mpn".

Fixes #2869 

[bfb]