### PR TITLE
Add test of capability to interpolate output online during a simulation

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -49,13 +49,12 @@ _TESTS = {
         "tests" : (
             "ERP_Ln9.ne4_ne4.F-EAMv1-AQP1",
             "SMS_Ld1.ne4_ne4.F-EAMv1-AQP1.cam-clubb_only",
-            "SMS_Ln5.ne4_ne4.FC5AV1C-L.cam-intrp_out_frq5ts",
             "PET_Ln5.ne4_ne4.FC5AV1C-L.allactive-mach-pet",
             "PEM_Ln5.ne4_ne4.FC5AV1C-L",
             "SMS_D_Ln5.ne4_ne4.FC5AV1C-L.cam-cosplite_nhtfrq5",
             "ERS_Ld5.ne4_ne4.FC5AV1C-L.cam-rrtmgp",
             "ERS_Ld5.ne4_ne4.FC5AV1C-L.cam-gust_param",
-            "REP_Ln5.ne4_ne4.FC5AV1C-L",
+            "REP_Ln5.ne4_ne4.FC5AV1C-L.cam-intrp_out_frq5ts",
             )
         },
 

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -49,6 +49,7 @@ _TESTS = {
         "tests" : (
             "ERP_Ln9.ne4_ne4.F-EAMv1-AQP1",
             "SMS_Ld1.ne4_ne4.F-EAMv1-AQP1.cam-clubb_only",
+            "SMS_Ln5.ne4_ne4.FC5AV1C-L.cam-intrp_out_frq5ts",
             "PET_Ln5.ne4_ne4.FC5AV1C-L.allactive-mach-pet",
             "PEM_Ln5.ne4_ne4.FC5AV1C-L",
             "SMS_D_Ln5.ne4_ne4.FC5AV1C-L.cam-cosplite_nhtfrq5",

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/intrp_out_frq5ts/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/intrp_out_frq5ts/user_nl_cam
@@ -1,0 +1,2 @@
+interpolate_output = .true.
+nhtfrq = 5


### PR DESCRIPTION
This PR adds a test to test an interpolation capability in the model. If `interpolate_output = .true.` is set in the atm_in namelist, the model will interpolate the SE grid output to Lat-Lon grid by default and will produce h0/h* files on lat-lon grid. 

[BFB] - Bit-For-Bit