### PR TITLE
Bugfix for naming mismatch in HOMME-ARKode interface

### DIFF
--- a/components/homme/src/arkode/theta-l/arkode_mod.F90
+++ b/components/homme/src/arkode/theta-l/arkode_mod.F90
@@ -1164,12 +1164,12 @@ contains
     ! Description: sets Butcher tables in IMEX-KG format:
     !   Ae:   0 |    0             Ai:     0 |       0
     !        c1 |   a1    0            chat1 |   ahat1 dhat1
-    !        c2 |   b1   a2  0         chat2 |   bhat1 ahat2 dhat2
-    !        c3 |   b2    0 a3 0       chat3 |   bhat2     0 ahat3 dhat3
+    !        c2 |   b1   a2  0         chat2 |    b1 ahat2 dhat2
+    !        c3 |   b2    0 a3 0       chat3 |    b2     0 ahat3 dhat3
     !           |                            |
-    !        cq | bq-1 0 ... 0 aq 0    chatq | bhatq-1     0    ...    0 ahatq 0
+    !        cq | bq-1 0 ... 0 aq 0    chatq |  bq-1     0    ...    0 ahatq 0
     !        ----------------------    -----------------------------------------
-    !           | bq-1 0 ... 0 aq 0          | bhatq-1     0    ...    0 ahatq 0
+    !           | bq-1 0 ... 0 aq 0          |  bq-1     0    ...    0 ahatq 0
     !
     !        ci = sum_j Ae(i,j)        chati = sum_j Ai(i,j)
     !

--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -760,50 +760,35 @@ contains
     else if (tstep_type==31) then ! ARKode Conde et al ssp3(3,3,3)b (renamed here)
       call set_Butcher_tables(arkode_parameters, arkode_tables%SSP3333C)
 
-    else if (tstep_type==32) then ! ARKode IMKG 2nd-order, 4 stage, variant a
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG232a)
+    else if (tstep_type==32) then ! ARKode IMKG 2nd-order, 4 stage (2 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG232)
 
-    else if (tstep_type==33) then ! ARKode IMKG 2nd-order, 4 stage, variant b
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG232b)
+    else if (tstep_type==33) then ! ARKode IMKG 2nd-order, 5 stage (2 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG242)
 
-    else if (tstep_type==34) then ! ARKode IMKG 2nd-order, 5 stage, variant a
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG242a)
+    else if (tstep_type==34) then ! ARKode IMKG 2nd-order, 5 stage (3 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG243)
 
-    else if (tstep_type==35) then ! ARKode IMKG 2nd-order, 5 stage, variant b
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG242b)
+    else if (tstep_type==35) then ! ARKode IMKG 2nd-order, 6 stage (2 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG252)
 
-    else if (tstep_type==36) then ! ARKode IMKG 2nd-order, 5 stage, variant a
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG243a)
+    else if (tstep_type==36) then ! ARKode IMKG 2nd-order, 6 stage (3 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG253)
 
-    else if (tstep_type==37) then ! ARKode IMKG 2nd-order, 5 stage, variant b
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG243b)
+    else if (tstep_type==37) then ! ARKode IMKG 2nd-order, 6 stage (4 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG254)
 
-    else if (tstep_type==38) then ! ARKode IMKG 2nd-order, 6 stage, variant a
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG252a)
+    else if (tstep_type==38) then ! ARKode IMKG 3rd-order, 5 stage (2 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG342)
 
-    else if (tstep_type==39) then ! ARKode IMKG 2nd-order, 6 stage, variant b
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG252b)
+    else if (tstep_type==39) then ! ARKode IMKG 3rd-order, 5 stage (3 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG343)
 
-    else if (tstep_type==40) then ! ARKode IMKG 2nd-order, 6 stage, variant a
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG253a)
+    else if (tstep_type==40) then ! ARKode IMKG 3rd-order, 6 stage (3 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG353)
 
-    else if (tstep_type==41) then ! ARKode IMKG 2nd-order, 6 stage, variant b
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG253b)
-
-    else if (tstep_type==42) then ! ARKode IMKG 2nd-order, 6 stage, variant a
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG254a)
-
-    else if (tstep_type==43) then ! ARKode IMKG 2nd-order, 6 stage, variant b
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG254b)
-
-    else if (tstep_type==44) then ! ARKode IMKG 2nd-order, 6 stage, variant c
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG254c)
-
-    else if (tstep_type==45) then ! ARKode IMKG 3rd-order, 5 stage, variant a
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG343a)
-
-    else if (tstep_type==46) then ! ARKode IMKG 3rd-order, 5 stage, variant b
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG343b)
+    else if (tstep_type==41) then ! ARKode IMKG 3rd-order, 6 stage (4 implicit)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG354)
 
     else 
        call abortmp('ERROR: bad choice of tstep_type')


### PR DESCRIPTION
merge of the HOMME-ARKode interface. This should be BFB in that it
only modifies code within an ifdef block that is disabled by default.