### PR TITLE
C++/Kokkos: Refine a few build pieces.

### DIFF
--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -285,7 +285,7 @@ endif
 ifeq ($(strip $(USE_KOKKOS)), TRUE)
   include $(INSTALL_SHAREDPATH)/Makefile.kokkos
   SLIBS += $(KOKKOS_LIBS)
-  CFLAGS += $(KOKKOS_CXXFLAGS)
+  CXXFLAGS += $(KOKKOS_CXXFLAGS)
   CXX_LDFLAGS += $(KOKKOS_LDFLAGS)
 endif
 
@@ -509,7 +509,7 @@ INCLDIR +=	-I$(INSTALL_SHAREDPATH)/include
 # Use the MCT dir for the cache for all configure calls because it is the first one
 #
 CFLAGS+=$(CPPDEFS)
-CXXFLAGS+=$(CFLAGS)
+CXXFLAGS+=$(CPPDEFS)
 CONFIG_ARGS +=  CC="$(CC)" FC="$(FC)" MPICC="$(MPICC)" \
                 MPIFC="$(MPIFC)" FCFLAGS="$(FFLAGS) $(FREEFLAGS) $(INCLDIR)" \
                 CPPDEFS="$(CPPDEFS)" CFLAGS="$(CFLAGS) -I.. $(INCLDIR)" \

--- a/cime/src/build_scripts/buildlib.kokkos
+++ b/cime/src/build_scripts/buildlib.kokkos
@@ -56,8 +56,13 @@ def buildlib(bldroot, installpath, case):
     if stat == 0:
         kokkos_options = output.split(":=")[-1].strip()
     else:
-        kokkos_options = "--with-openmp --with-serial" # This is the default
-        logger.warning("Failed to find custom kokkos options, using default.")
+        # This is the default setup.
+        kokkos_options = "--with-serial"
+        build_threaded = case.get_build_threaded()
+        if build_threaded:
+            kokkos_options += " --with-openmp"
+        logger.warning("Failed to find custom kokkos options, using default: {:s}.".
+                       format(kokkos_options))
 
     cxx = run_cmd_no_fail("make -f Macros.make {} -p | grep SCXX".format(make_args)).split(":=")[-1].strip()
 


### PR DESCRIPTION
1. Add KOKOS_CXXFLAGS to CXXFLAGS.
2. Add CPPDEFS to CXXFLAGS.
3. Do not add CFLAGS to CXXFLAGS.
4. For default build (i.e., no KOKKOS_OPTIONS provided), build
   Kokkos --with-openmp only if case.get_build_threaded().

[BFB]