### PR TITLE
Fixes a configuration option and the bug it was masking in hommexx

### DIFF
--- a/components/homme/src/share/cxx/EulerStepFunctorImpl.hpp
+++ b/components/homme/src/share/cxx/EulerStepFunctorImpl.hpp
@@ -29,11 +29,10 @@ namespace Kokkos {
 struct Real2 {
   Homme::Real v[2];
   KOKKOS_FORCEINLINE_FUNCTION Real2 () { v[0] = v[1] = 0; }
-  KOKKOS_FORCEINLINE_FUNCTION Real2 operator+= (const Real2& o) const {
-    Real2 r;
-    r.v[0] = v[0] + o.v[0];
-    r.v[1] = v[1] + o.v[1];
-    return r;
+  KOKKOS_FORCEINLINE_FUNCTION Real2 operator+= (const Real2& o) {
+    v[0] += o.v[0];
+    v[1] += o.v[1];
+    return *this;
   }
 };
 

--- a/components/homme/src/share/cxx/ExecSpaceDefs.hpp
+++ b/components/homme/src/share/cxx/ExecSpaceDefs.hpp
@@ -318,7 +318,7 @@ struct Dispatch<Kokkos::Cuda> {
     const LoopBdyType& loop_boundaries,
     const Lambda& lambda, ValueType& result)
   {
-#if defined HOMMEXX_GPU_BFB_WITH_CPU
+#if HOMMEXX_GPU_BFB_WITH_CPU
     // We want to get C++ on GPU to match F90 on CPU. Thus, need to
     // serialize parallel reductions.
 
@@ -365,7 +365,7 @@ struct Dispatch<Kokkos::Cuda> {
     const int num_iters,
     const Lambda& lambda)
   {
-#if defined HOMMEXX_GPU_BFB_WITH_CPU
+#if HOMMEXX_GPU_BFB_WITH_CPU
     // We want to get C++ on GPU to match F90 on CPU. Thus, need to
     // serialize parallel scans.
 


### PR DESCRIPTION
Fixes definition of HOMMEXX_GPU_BFB_WITH_CPU. At some point HOMMEXX_GPU_BFB_WITH_CPU became a cmakedefine01, but we still used it as a cmakedefine. This then forced team reductions to serialize on GPU. This in turn masked a bug in one of the reductions. This commit fixes both issues.

This PR is BFB w.r.t. the usual testing but fixes a GPU issue in the performance build. (It gives a little more performance but now is truly non-BFB w.r.t, say, Fortran on P9.)

[BFB]