### PR TITLE
Allow EAM to respect PIO_NETCDF_FORMAT

### DIFF
--- a/components/cam/src/control/cam_history.F90
+++ b/components/cam/src/control/cam_history.F90
@@ -3662,7 +3662,6 @@ end subroutine print_active_fldlst
     integer                          :: mdimsize
     integer                          :: ierr
     integer,          allocatable    :: mdimids(:)
-    integer                          :: amode
     logical                          :: interpolate
     logical                          :: patch_output
 
@@ -3674,12 +3673,10 @@ end subroutine print_active_fldlst
       if(masterproc) write(iulog,*)'Opening netcdf history file ', trim(nhfil(t))
     end if
 
-    amode = PIO_CLOBBER
-
     if(restart) then
-      call cam_pio_createfile (tape(t)%File, hrestpath(t), amode)
+      call cam_pio_createfile (tape(t)%File, hrestpath(t))
     else
-      call cam_pio_createfile (tape(t)%File, nhfil(t), amode)
+      call cam_pio_createfile (tape(t)%File, nhfil(t))
     end if
     if(is_satfile(t)) then
       interpolate = .false. ! !!XXgoldyXX: Do we ever want to support this?

--- a/components/cam/src/control/cam_restart.F90
+++ b/components/cam/src/control/cam_restart.F90
@@ -214,7 +214,7 @@ end subroutine restart_printopts
          fname = interpret_filename_spec( rfilename_spec )
       end if
 
-      call cam_pio_createfile(File, trim(fname), 0)
+      call cam_pio_createfile(File, trim(fname))
       call timemgr_init_restart(File)
 
       call init_restart_dynamics(File, dyn_out)

--- a/components/cam/src/cpl/atm_comp_esmf.F90
+++ b/components/cam/src/cpl/atm_comp_esmf.F90
@@ -1104,7 +1104,7 @@ CONTAINS
     fname_srf_cam = interpret_filename_spec( rsfilename_spec_cam, &
          yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
 
-    call cam_pio_createfile(File, fname_srf_cam, 0)
+    call cam_pio_createfile(File, fname_srf_cam)
     call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), dof, iodesc)
     
     call esmfshr_util_ArrayGetSize(x2a,lsize1=nf_x2a)

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -913,7 +913,7 @@ CONTAINS
     fname_srf_cam = interpret_filename_spec( rsfilename_spec_cam, &
          yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
 
-    call cam_pio_createfile(File, fname_srf_cam, 0)
+    call cam_pio_createfile(File, fname_srf_cam)
     call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), dof, iodesc)
 
     nf_x2a = mct_aVect_nRattr(x2a_a)

--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -418,7 +418,7 @@ CONTAINS
     ! Create a CS grid mapping file for postprocessing tools
 
        ! write meta data for physics on GLL nodes
-       call cam_pio_createfile(nc, 'SEMapping.nc', 0)
+       call cam_pio_createfile(nc, 'SEMapping.nc')
    
        ierr = pio_def_dim(nc, 'ncenters', npm12*nelem, dim1)
        ierr = pio_def_dim(nc, 'ncorners', 4, dim2)

--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -417,40 +417,40 @@ CONTAINS
 
     ! Create a CS grid mapping file for postprocessing tools
 
-       ! write meta data for physics on GLL nodes
-       call cam_pio_createfile(nc, 'SEMapping.nc')
-   
-       ierr = pio_def_dim(nc, 'ncenters', npm12*nelem, dim1)
-       ierr = pio_def_dim(nc, 'ncorners', 4, dim2)
-       ierr = pio_def_var(nc, 'element_corners', PIO_INT, (/dim1,dim2/),vid)
-    
-       ierr = pio_enddef(nc)
-       if (par%dynproc) then
-          call createmetadata(par, elem, subelement_corners)
-       end if
+    ! write meta data for physics on GLL nodes
+    call cam_pio_createfile(nc, 'SEMapping.nc')
 
-       jj=0
-       do cc=0,3
-          do ie=1,nelemd
-             base = ((elem(ie)%globalid-1)+cc*nelem)*npm12
-             ii=0
-             do j=1,np-1
-                do i=1,np-1
-                   ii=ii+1
-                   jj=jj+1
-                   dof(jj) = base+ii
-                end do
+    ierr = pio_def_dim(nc, 'ncenters', npm12*nelem, dim1)
+    ierr = pio_def_dim(nc, 'ncorners', 4, dim2)
+    ierr = pio_def_var(nc, 'element_corners', PIO_INT, (/dim1,dim2/),vid)
+
+    ierr = pio_enddef(nc)
+    if (par%dynproc) then
+       call createmetadata(par, elem, subelement_corners)
+    end if
+
+    jj=0
+    do cc=0,3
+       do ie=1,nelemd
+          base = ((elem(ie)%globalid-1)+cc*nelem)*npm12
+          ii=0
+          do j=1,np-1
+             do i=1,np-1
+                ii=ii+1
+                jj=jj+1
+                dof(jj) = base+ii
              end do
           end do
        end do
+    end do
 
-       call pio_initdecomp(pio_subsystem, pio_int, (/nelem*npm12,4/), dof, iodesc)
+    call pio_initdecomp(pio_subsystem, pio_int, (/nelem*npm12,4/), dof, iodesc)
 
-       call pio_write_darray(nc, vid, iodesc, reshape(subelement_corners,(/nelemd*npm12*4/)), ierr)
-       
-       call pio_freedecomp(nc, iodesc)
-       
-       call pio_closefile(nc)
+    call pio_write_darray(nc, vid, iodesc, reshape(subelement_corners,(/nelemd*npm12*4/)), ierr)
+
+    call pio_freedecomp(nc, iodesc)
+
+    call pio_closefile(nc)
 
   end subroutine write_grid_mapping
 

--- a/components/cam/src/dynamics/se/native_mapping.F90
+++ b/components/cam/src/dynamics/se/native_mapping.F90
@@ -406,7 +406,7 @@ contains
 114    format('map_ne',i3.3,'np',i1,'_to_',a,'_',a,'_',3a2,'.nc')
 115    format('map_ne',i4.4,'np',i1,'_to_',a,'_',a,'_',3a2,'.nc')
 
-       call cam_pio_createfile( ogfile,mappingfile , 0)
+       call cam_pio_createfile(ogfile, mappingfile)
 
        ierr = pio_def_dim( ogfile, 'n_a', ncol, na_dim)
        ierr = pio_def_dim( ogfile, 'n_b', npts, nb_dim) 

--- a/components/cam/src/utils/cam_pio_utils.F90
+++ b/components/cam/src/utils/cam_pio_utils.F90
@@ -1076,8 +1076,8 @@ contains
   end subroutine clean_iodesc_list
 
   subroutine cam_pio_createfile(file, fname, mode_in)
-    use pio,            only: pio_createfile, file_desc_t, &
-                              pio_noerr, pio_iotask_rank
+    use pio,            only: pio_createfile, file_desc_t, pio_iotask_rank, &
+                              PIO_NOERR, PIO_CLOBBER
     use cam_abortutils, only: endrun
     use cam_instance,   only: atm_id
     use shr_pio_mod,    only: shr_pio_getioformat
@@ -1098,6 +1098,9 @@ contains
     else
       mode = shr_pio_getioformat(atm_id)
     end if
+
+    ! Make sure the above set a mode properly, default to PIO_CLOBBER if not
+    mode = ior(mode, PIO_CLOBBER)
 
     ! Create new file
     ierr = pio_createfile(pio_subsystem, file, pio_iotype, fname, mode)

--- a/components/cam/src/utils/cam_pio_utils.F90
+++ b/components/cam/src/utils/cam_pio_utils.F90
@@ -1076,9 +1076,11 @@ contains
   end subroutine clean_iodesc_list
 
   subroutine cam_pio_createfile(file, fname, mode_in)
-    use pio, only : pio_createfile, file_desc_t, pio_noerr, pio_clobber,      &
-         pio_64bit_offset, pio_iotask_rank
-    use cam_abortutils, only : endrun
+    use pio,            only: pio_createfile, file_desc_t, &
+                              pio_noerr, pio_iotask_rank
+    use cam_abortutils, only: endrun
+    use cam_instance,   only: atm_id
+    use shr_pio_mod,    only: shr_pio_getioformat
 
     ! Dummy arguments
     type(file_desc_t),          intent(inout) :: file
@@ -1089,13 +1091,18 @@ contains
     integer                                   :: ierr
     integer                                   :: mode
     
-    mode = ior(PIO_CLOBBER, PIO_64BIT_OFFSET)
+    ! Get mode to open file in. The default is to get this from shr_pio_mod,
+    ! but an optional mode_in argument is allowed to override this.
     if (present(mode_in)) then
-      mode = ior(mode, mode_in)
+      mode = mode_in
+    else
+      mode = shr_pio_getioformat(atm_id)
     end if
 
+    ! Create new file
     ierr = pio_createfile(pio_subsystem, file, pio_iotype, fname, mode)
 
+    ! Check that file was opened successfully
     if(ierr /= PIO_NOERR) then
        call endrun('Failed to open file,'//trim(fname)//', to write')
     else if(pio_iotask_rank(pio_subsystem) == 0) then


### PR DESCRIPTION
Allow EAM to respect the value of the XML variable `PIO_NETCDF_FORMAT` that is set in `env_run.xml`. Previously, setting this variable had no effect on the actual format used to write EAM output files (restart, history, initial conditions), due to calls to `cam_pio_createfile` explicitly passing in a mode argument hard-coded to `PIO_CLOBBER`. Note that there are some whitespace changes in  components/cam/src/dynamics/se/dyn_comp.F90 just because I found some inconsistent indenting when opening that file to remove the hard-coded mode argument in the call to `cam_pio_createfile`. 

Fixes #2903

[BFB]