### PR TITLE
improve stability and correctness of dissipation

### DIFF
--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -557,12 +557,15 @@ contains
           endif
        endif
        if(nu_top>0) then
-          nu_top_actual=4*nu_top
 #ifdef MODEL_THETA_L
-          ! oops - nu_scale_top not yet computed. assume 4
-#endif
+          nu_top_actual=8*nu_top
+          write(iulog,'(a,f10.2,a)') '8*nu_top viscosity CFL: dt < S*', &
+               1.0d0/(nu_top_actual*((rrearth*max_normDinv)**2)*lambda_vis),'s'
+#else
+          nu_top_actual=4*nu_top
           write(iulog,'(a,f10.2,a)') '4*nu_top viscosity CFL: dt < S*', &
                1.0d0/(nu_top_actual*((rrearth*max_normDinv)**2)*lambda_vis),'s'
+#endif
        end if
 
       if(dcmip16_mu>0)  write(iulog,'(a,f10.2,a)') 'dcmip16_mu   viscosity CFL: dt < S*', &

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -272,7 +272,7 @@ contains
     real (kind=real_kind) :: normDinv_hypervis
     real (kind=real_kind) :: x, y, noreast, nw, se, sw
     real (kind=real_kind), dimension(np,np,nets:nete) :: zeta
-    real (kind=real_kind) :: lambda_max, lambda_vis, min_gw, lambda, nu_div_actual
+    real (kind=real_kind) :: lambda_max, lambda_vis, min_gw, lambda, nu_div_actual, nu_top_actual
     integer :: ie,corner, i, j, rowind, colind
     type (quadrature_t)    :: gp
 
@@ -535,32 +535,40 @@ contains
                                    1/(342.0d0*max_normDinv*lambda_max*rrearth),'s'
        if (nu>0) then
           if (hypervis_order==1) then
-              write(iulog,'(a,f10.2,a)') 'Stability: viscosity dt < S *',1/(((rrearth*max_normDinv)**2)*lambda_vis),'s'
+              write(iulog,'(a,f10.2,a)') 'Stability: viscosity dt < S *',&
+                   1/(nu*((rrearth*max_normDinv)**2)*lambda_vis),'s'
           endif
           if (hypervis_order==2) then
              ! counrant number = dtnu*normDinv_hypervis  < S
              !  dt < S  1/nu*normDinv
              write(iulog,'(a,f10.2,a)') "Stability: nu_q   hyperviscosity dt < S *", 1/(nu_q*normDinv_hypervis),'s'
              write(iulog,'(a,f10.2,a)') "Stability: nu_vor hyperviscosity dt < S *", 1/(nu*normDinv_hypervis),'s'
-             
-             ! bug in nu_div implimentation:
+#ifdef MODEL_THETA_L
+             nu_div_actual = nu_div
+#else             
+             ! bug in preqx nu_div implimentation:
              ! we apply nu_ration=(nu_div/nu) in laplace, so it is applied 2x
              ! making the effective nu_div = nu * (nu_div/nu)**2 
              ! should be fixed - but need all CAM defaults adjusted, 
-             ! so we have to coordiante with CAM
              nu_div_actual = nu_div**2/nu
-             write(iulog,'(a,f10.2,a)') "Stability: nu_div hyperviscosity dt < S *", 1/(nu_div_actual*normDinv_hypervis),'s'
+#endif
+             write(iulog,'(a,f10.2,a)') "Stability: nu_div hyperviscosity dt < S *",&
+                  1/(nu_div_actual*normDinv_hypervis),'s'
           endif
        endif
        if(nu_top>0) then
-          write(iulog,'(a,f10.2,a)') 'TOP3 viscosity CFL: dt < S*', &
-                                  1.0d0/(4*nu_top*((rrearth*max_normDinv)**2)*lambda_vis),'s'
+          nu_top_actual=4*nu_top
+#ifdef MODEL_THETA_L
+          ! oops - nu_scale_top not yet computed. assume 4
+#endif
+          write(iulog,'(a,f10.2,a)') '4*nu_top viscosity CFL: dt < S*', &
+               1.0d0/(nu_top_actual*((rrearth*max_normDinv)**2)*lambda_vis),'s'
        end if
 
       if(dcmip16_mu>0)  write(iulog,'(a,f10.2,a)') 'dcmip16_mu   viscosity CFL: dt < S*', &
-           1.0d0/(4*dcmip16_mu*  ((rrearth*max_normDinv)**2)*lambda_vis),'s'
+           1.0d0/(dcmip16_mu*  ((rrearth*max_normDinv)**2)*lambda_vis),'s'
       if(dcmip16_mu_s>0)write(iulog,'(a,f10.2,a)') 'dcmip16_mu_s viscosity CFL: dt < S*', &
-           1.0d0/(4*dcmip16_mu_s*((rrearth*max_normDinv)**2)*lambda_vis),'s'
+           1.0d0/(dcmip16_mu_s*((rrearth*max_normDinv)**2)*lambda_vis),'s'
 
       if (hypervis_power /= 0) then
         write(iulog,'(a,3e11.4)')'Hyperviscosity (dynamics): ave,min,max = ', &

--- a/components/homme/src/theta-l/model_init_mod.F90
+++ b/components/homme/src/theta-l/model_init_mod.F90
@@ -81,31 +81,33 @@ contains
        ! sponge layer starts at p=4*ptop 
        ! 
        ! some test cases have ptop=200mb
-       ptop_over_press = hvcoord%etai(1) / hvcoord%etam(k)  ! pure sigma coordinates has etai(1)=0
+       if (hvcoord%etai(1)==0) then
+          ! pure sigma coordinates could have etai(1)=0
+          ptop_over_press = hvcoord%etam(1) / hvcoord%etam(k)  
+       else
+          ptop_over_press = hvcoord%etai(1) / hvcoord%etam(k)  
+       endif
 
        ! active for p<4*ptop (following cd_core.F90 in CAM-FV)
-       ! CAM 26L and 30L:  top 2 levels
+       ! CAM 26L and 30L:  top 3 levels
        ! E3SM 72L:  top 3 levels
        nu_scale_top(k) = 8*(1+tanh(log(ptop_over_press))) ! active for p<4*ptop
+       if (nu_scale_top(k)<0.3d0) nu_scale_top(k)=0
 
        ! active for p<7*ptop 
-       ! CAM 26L and 30L:  top 3 levels
-       ! E3SM 72L:  top ? levels
        !nu_scale_top(k) = 8*(1+.911*tanh(log(ptop_over_press))) ! active for p<6.5*ptop
+       !if (nu_scale_top(k)<0.3d0) nu_scale_top(k)=0
 
        ! original CAM3/preqx formula
        !if (k==1) nu_scale_top(k)=4
        !if (k==2) nu_scale_top(k)=2
-       !if (k==3) nu_scale_top(k)=1 + 1d-10
+       !if (k==3) nu_scale_top(k)=1
        !if (k>3) nu_scale_top(k)=0
 
-
        if (hybrid%masterthread) then
-          if (nu_scale_top(k)>1) write(iulog,*) "  nu_scale_top ",k,nu_scale_top(k)
+          if (nu_scale_top(k)>0) write(iulog,*) "  nu_scale_top ",k,nu_scale_top(k)
        end if
-
     end do
-    
   end subroutine 
 
 

--- a/components/homme/src/theta-l/model_init_mod.F90
+++ b/components/homme/src/theta-l/model_init_mod.F90
@@ -85,17 +85,25 @@ contains
 
        ! active for p<4*ptop (following cd_core.F90 in CAM-FV)
        ! CAM 26L and 30L:  top 2 levels
-       ! E3SM 72L:  top 4 levels
+       ! E3SM 72L:  top 3 levels
        nu_scale_top(k) = 8*(1+tanh(log(ptop_over_press))) ! active for p<4*ptop
 
        ! active for p<7*ptop 
        ! CAM 26L and 30L:  top 3 levels
-       ! E3SM 72L:  top 5 levels
+       ! E3SM 72L:  top ? levels
        !nu_scale_top(k) = 8*(1+.911*tanh(log(ptop_over_press))) ! active for p<6.5*ptop
+
+       ! original CAM3/preqx formula
+       !if (k==1) nu_scale_top(k)=4
+       !if (k==2) nu_scale_top(k)=2
+       !if (k==3) nu_scale_top(k)=1 + 1d-10
+       !if (k>3) nu_scale_top(k)=0
+
 
        if (hybrid%masterthread) then
           if (nu_scale_top(k)>1) write(iulog,*) "  nu_scale_top ",k,nu_scale_top(k)
        end if
+
     end do
     
   end subroutine 

--- a/components/homme/src/theta-l/viscosity_theta.F90
+++ b/components/homme/src/theta-l/viscosity_theta.F90
@@ -74,22 +74,19 @@ endif
    var_coef1 = .true.
    if(hypervis_scaling > 0)    var_coef1 = .false.
 
-   ! note: there is a scaling bug in the treatment of nu_div
-   ! nu_ratio is applied twice, once in each laplace operator
-   ! so in reality:   nu_div_actual = (nu_div/nu)**2 nu
-   ! We should fix this, but it requires adjusting all CAM defaults
+   ! correct nu_div scaling. do not match buggy scaling used by PREQX model
    nu_ratio1=1
    nu_ratio2=1
    if (nu_div/=nu) then
       if(hypervis_scaling /= 0) then
-         ! we have a problem with the tensor in that we cant seperate
-         ! div and curl components.  So we do, with tensor V:
+         ! with the tensor, we cant seperate div and curl components.  instead:
          ! nu * (del V del ) * ( nu_ratio * grad(div) - curl(curl))
-         nu_ratio1=(nu_div/nu)    ! do not match buggy scaling used by PREQX model
+         nu_ratio1=(nu_div/nu)    
          nu_ratio2=1
       else
-         nu_ratio1=nu_div/nu
-         nu_ratio2=nu_div/nu
+         ! since operator is applied twice, take the sqrt
+         nu_ratio1=sqrt(nu_div/nu)
+         nu_ratio2=sqrt(nu_div/nu)
       endif
    endif
 


### PR DESCRIPTION
three changes related to dissipation:

update TOM scaling of nu_top as a function of k to match CAM-FV
fix bug in weigthing of dpdiss_ave used for Eulerian tracer consistency
TOM dissipation: switch from laplace(theta) to 1/dp0 laplace(theta*dp) for improved CFL stability.

[BFB] except for HOMME tests involving theta-l model