### PR TITLE
Updates definition of 20TR I-compsets

### DIFF
--- a/components/clm/cime_config/config_compsets.xml
+++ b/components/clm/cime_config/config_compsets.xml
@@ -443,12 +443,12 @@
 
    <compset>
      <alias>I20TRCRUCNRDCTCBC</alias>
-     <lname>1850_DATM%CRU_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>20TR_DATM%CRU_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
    <compset>
     <alias>I20TRCRUCNPRDCTCBC</alias>
-    <lname>1850_DATM%CRU_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>20TR_DATM%CRU_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
    
    <!---I GSWP3 compsets-->
@@ -604,12 +604,12 @@
 
    <compset>
      <alias>I20TRGSWCNRDCTCBC</alias>
-     <lname>1850_DATM%GSWP3v1_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <lname>20TR_DATM%GSWP3v1_CLM45%CNRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
    <compset>
     <alias>I20TRGSWCNPRDCTCBC</alias>
-    <lname>1850_DATM%GSWP3v1_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>20TR_DATM%GSWP3v1_CLM45%CNPRDCTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
   <!---I compset system tests -->


### PR DESCRIPTION
Corrects the following I-compsets to use 20TR forcings instead of
using values for 1850:
 - I20TRCRUCNRDCTCBC
 - I20TRCRUCNPRDCTCBC
 - I20TRGSWCNRDCTCBC
 - I20TRGSWCNPRDCTCBC

[BFB] except for the above-mentioned four I-compsets
Fixes #2920