### PR TITLE
Add regression test for gen_domain tool (WIP)

### DIFF
--- a/cime/scripts/tests/scripts_regression_tests.py
+++ b/cime/scripts/tests/scripts_regression_tests.py
@@ -3246,17 +3246,18 @@ class M_TestGenDomain(unittest.TestCase): #TestCreateTestCommon):
         inputdata_root = MACHINE.get_value("DIN_LOC_ROOT")
         mapping_files = ("%s/cpl/gridmaps/oRRS30to10/map_oRRS30to10_to_ne30np4_aave.160419.nc"%inputdata_root,
                          "%s/cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_360x720cru_aave.190409.nc"%inputdata_root)
+        ocn_grids = ("oRRS30to10", "oRRS15to5")
+        lnd_grids = ("ne30np4", "360x720cru")
         baseline_root = "%s/share/domains"%inputdata_root
-        ocn_grid = "oRRS30to10"
-        lnd_grid = "ne30np4"
         temp_dir = tempfile.mkdtemp()
 
-        for mapping_file in mapping_files:
+        for (mapping_file, ocn_grid, lnd_grid) in zip(mapping_files, ocn_grids, lnd_grids):
 
             # Run the domain tool to get new outputs
             domain_files = self._run(mapping_file, ocn_grid, lnd_grid, from_dir=temp_dir)
 
             # Build cprnc
+            print('temp_dir = ', temp_dir)
             cprnc_root = "%s/tools/cprnc"%get_cime_root()
             cmd = "cd %s; gmake clean; gmake"%cprnc_root
             cmd = ". ./.env_mach_specific.sh; %s"%cmd
@@ -3270,6 +3271,7 @@ class M_TestGenDomain(unittest.TestCase): #TestCreateTestCommon):
                         baseline_root,
                         os.path.basename(testfile).rsplit(".", 2)[0]
                         )))[-1]
+                print('%s <-> %s'%(baseline, testfile))
 
                 # Run cprnc to compare
                 cmd = "%s/cprnc -m %s %s"%(cprnc_root, testfile, baseline) 

--- a/cime/scripts/tests/scripts_regression_tests.py
+++ b/cime/scripts/tests/scripts_regression_tests.py
@@ -3257,7 +3257,6 @@ class M_TestGenDomain(unittest.TestCase): #TestCreateTestCommon):
             domain_files = self._run(mapping_file, ocn_grid, lnd_grid, from_dir=temp_dir)
 
             # Build cprnc
-            print('temp_dir = ', temp_dir)
             cprnc_root = "%s/tools/cprnc"%get_cime_root()
             cmd = "cd %s; gmake clean; gmake"%cprnc_root
             cmd = ". ./.env_mach_specific.sh; %s"%cmd
@@ -3271,7 +3270,6 @@ class M_TestGenDomain(unittest.TestCase): #TestCreateTestCommon):
                         baseline_root,
                         os.path.basename(testfile).rsplit(".", 2)[0]
                         )))[-1]
-                print('%s <-> %s'%(baseline, testfile))
 
                 # Run cprnc to compare
                 cmd = "%s/cprnc -m %s %s"%(cprnc_root, testfile, baseline) 

--- a/cime/tools/mapping/gen_domain_files/src/gen_domain.F90
+++ b/cime/tools/mapping/gen_domain_files/src/gen_domain.F90
@@ -57,7 +57,7 @@ program fmain
   nargs = iargc()
   if (nargs == 0) then
      write(6,*)'invoke gen_domain -h for usage'
-     stop
+     call exit(1)
   end if
 
   ! Parse command line arguments
@@ -245,7 +245,7 @@ contains
          pole_fix = .false.
       else
          write(6,*) ' ERROR: nf loop error '
-         stop
+         call exit(1)
       endif
 
       pole_fix = .false.
@@ -369,7 +369,7 @@ contains
                omask(:) = 1
             else
                write(6,*) 'ERROR: mask'//trim(suffix)//' does not exist in inputfile.'
-               stop
+               call exit(1)
             end if
          end if
          ofrac(:) = c0
@@ -405,7 +405,7 @@ contains
                mask_a(:) = 1
             else
                write(6,*) 'ERROR: mask_a not present in inputfile.'
-               stop
+               call exit(1)
             end if
          end if
 
@@ -456,7 +456,7 @@ contains
          if (ni > 1 .and. nj == 1) then
             if (dst_grid_rank /= 2) then
                write(6,*)'pole_fix not appropriate for unstructured grid'
-               stop
+               call exit(1)
             end if
          end if
          do i = 1,dst_grid_dims(1)
@@ -587,7 +587,7 @@ contains
     write(6,*) '    domain.ocn.gridocn.nc'
     write(6,*) '      ocean domain on the ocean grid '
     write(6,*) ' '
-    stop
+    call exit(1)
   end subroutine usage_exit
 
 !===========================================================================
@@ -676,7 +676,7 @@ contains
     call sys_getenv('LOGNAME',user,rcode)
     if (rcode /= 0) then
        write(6,*) ' ERROR: getting LOGNAME'
-       stop
+       call exit(1)
     end if
     str = 'created by '//trim(user)//', '//cdate(1:4)//'-'//cdate(5:6)//'-'//cdate(7:8) &
          &                //' '//ctime(1:2)//':'//ctime(3:4)//':'//ctime(5:6)
@@ -858,7 +858,8 @@ SUBROUTINE sys_getenv(name, val, rcode)
 #else
 
    write(*,F00) 'ERROR: no implementation of getenv for this architecture'
-   stop subname//'no implementation of getenv for this machine'
+   write(*,*)   subname//'no implementation of getenv for this machine'
+   call exit(1)
 
 #endif
 


### PR DESCRIPTION
Add a regression test for the `gen_domain` tool in `cime/tools/mapping/gen_domain_files`. This adds a class to `scripts_regression_tests.py` to implement and run the test. The test compares against an existing domain file in the inputdata repository, using an existing mapping file in the repository. The `cprnc` tool is used to do the comparison. Test is successful if `cprnc` indicates that a new set of domain files generated by the `gen_domain` code are bit-for-bit with the existing domain files in the repository. 