### PR TITLE
Fixing restart for theta-l, round 2

### DIFF
--- a/components/cam/src/dynamics/se/restart_dynamics.F90
+++ b/components/cam/src/dynamics/se/restart_dynamics.F90
@@ -327,8 +327,8 @@ CONTAINS
 #ifdef MODEL_THETA_L
     if( .not. theta_hydrostatic_mode ) then
        deallocate(var3dp)
+       call pio_freedecomp(File, iodesc3dp)
     endif
-    call pio_freedecomp(File, iodesc3dp)
 #endif
 
 

--- a/components/cam/src/dynamics/se/restart_dynamics.F90
+++ b/components/cam/src/dynamics/se/restart_dynamics.F90
@@ -135,7 +135,6 @@ CONTAINS
 
 #ifdef MODEL_THETA_L
     if( .not. theta_hydrostatic_mode ) then
-!what does pio decomp do? do i need ifdef, if here?
        ldof => get_restart_decomp(elem, nlevp)
        call PIO_InitDecomp(pio_subsystem, pio_double, (/nelem*np*np,nlevp/),ldof , iodesc3dp)
        deallocate(ldof)

--- a/components/homme/src/theta-l/eos.F90
+++ b/components/homme/src/theta-l/eos.F90
@@ -68,9 +68,15 @@ implicit none
 
 
   ! check for bad state that will crash exponential function below
-  ierr= any(vtheta_dp(:,:,:) < 0 )  .or. &
-        any(dp3d(:,:,:) < 0 ) .or. &
-        any(phi_i(:,:,1:nlev) <= phi_i(:,:,2:nlevp))
+  if (theta_hydrostatic_mode) then
+    ierr= any(vtheta_dp(:,:,:) < 0 )  .or. &
+          any(dp3d(:,:,:) < 0 )
+  else
+    ierr= any(vtheta_dp(:,:,:) < 0 )  .or. &
+          any(dp3d(:,:,:) < 0 ) .or. &
+          any(phi_i(:,:,1:nlev) <= phi_i(:,:,2:nlevp))
+  endif
+
   if (ierr) then
      if (present(caller)) then
         print *,'bad state in EOS, called from: ',caller


### PR DESCRIPTION
Fixes 1 memory bug and 1 unnecessary EOS check up that were preventing restart runs for theta H and NH. Should be BFB because we don't have restart tests yet.