### PR TITLE
For cori-knl, update intel19 version and the version of Intel's MPI lib

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1167,10 +1167,11 @@ for mct, etc.
     <base> -r8 </base>
   </FC_AUTO_R8>
   <FFLAGS>
-    <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml -fimf-use-svml=false:asin </base>
+    <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml </base>
     <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
+    <append MPILIB="impi"> -xMIC-AVX512 </append>
   </FFLAGS>
   <FFLAGS_NOOPT>
     <base> -O0 </base>
@@ -1190,6 +1191,11 @@ for mct, etc.
   <SCC> icc </SCC>
   <SCXX> icpc </SCXX>
   <SFC> ifort </SFC>
+  <MPICC MPILIB="impi"> mpiicc </MPICC>
+  <MPICXX MPILIB="impi"> mpiicpc </MPICXX>
+  <MPIFC MPILIB="impi"> mpiifort </MPIFC>
+  <!-- When using Intel MPI, can't use the Cray compiler wrappers. Must also set environment variables in config_machines.xml -->
+  <MPI_LIB_NAME MPILIB="impi">impi</MPI_LIB_NAME>
   <SLIBS>
     <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
     <append> -mkl -lpthread </append>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -251,7 +251,7 @@
         <command name="rm">cce</command>
         <command name="rm">gcc</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">cray-parallel-hdf5</command>
+        <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">pmi</command>
         <command name="rm">cray-libsci</command>
         <command name="rm">cray-mpich2</command>
@@ -391,7 +391,7 @@
         <command name="rm">cce</command>
         <command name="rm">gcc</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">cray-parallel-hdf5</command>
+        <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">pmi</command>
         <command name="rm">cray-mpich2</command>
         <command name="rm">cray-mpich</command>
@@ -418,7 +418,7 @@
       </modules>
 
       <modules mpilib="impi">
-        <command name="swap">cray-mpich impi/2018.up2</command>
+        <command name="swap">cray-mpich impi/2019.up3</command>
       </modules>
 
       <modules compiler="intel">
@@ -430,7 +430,7 @@
       <modules compiler="intel19">
         <command name="load">PrgEnv-intel/6.0.4</command>
         <command name="rm">intel</command>
-        <command name="load">intel/19.0.0.117</command>
+        <command name="load">intel/19.0.3.199</command>
       </modules>
 
       <modules compiler="gnu">
@@ -490,13 +490,6 @@
 
     <environment_variables mpilib="mpt">
       <env name="MPICH_GNI_DYNAMIC_CONN">disabled</env>
-    </environment_variables>
-    <environment_variables mpilib="impi">
-      <env name="I_MPI_FABRICS">ofi</env>
-      <env name="I_MPI_OFI_PROVIDER">gni</env>
-      <env name="I_MPI_PRINT_VERSION">yes</env>
-      <env name="I_MPI_OFI_LIBRARY">/global/common/cori/software/libfabric/1.6.1/gnu/lib/libfabric.so</env>
-      <env name="I_MPI_PMI_LIBRARY">/usr/lib64/slurmpmi/libpmi.so</env>
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="FORT_BUFFERED">yes</env>


### PR DESCRIPTION
For cori-knl:
* Update the version of intel19 compiler to intel/19.0.3.199 (does not affect default intel compiler)
  Adjust (simplify) compiler flags for this version.
* Update the version of Intel MPI to impi/2019.up3 (does not affect the default which is cray-mpich)
  Adjust (simplify) environmnet variables for impi

For both cori machines:
* Fix a typo in the name of module that we remove before loading others. Should
have no affect

[bfb]