### PR TITLE
Jinyuntang/lnd/fix mlitf

### DIFF
--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -8,52 +8,52 @@
 <!-- CLM Namelist -->
 <!-- ========================================================================================  -->
 
-<entry id="finidat_interp_source" 
-       type="char*256" 
+<entry id="finidat_interp_source"
+       type="char*256"
        category="datasets"
-       input_pathname="abs" 
-       group="clm_inparm" 
+       input_pathname="abs"
+       group="clm_inparm"
        valid_values="" >
-If non-blank, then interpinic will be called to interpolate finidat_interp_source and 
+If non-blank, then interpinic will be called to interpolate finidat_interp_source and
 create output file specified by finidat_interp_dest.
 For this to be used finidat MUST BE blank.
 </entry>
 
-<entry id="finidat_interp_dest" 
-       type="char*256" 
+<entry id="finidat_interp_dest"
+       type="char*256"
        category="datasets"
-       input_pathname="abs" 
-       group="clm_inparm" 
+       input_pathname="abs"
+       group="clm_inparm"
        valid_values="" >
-If finidat_interp_source is set to non-blank, then interpinic will be called 
+If finidat_interp_source is set to non-blank, then interpinic will be called
 to interpolate finidat_interp_source and create output file finidat_interp_dest.
 </entry>
 
-<entry id="finidat" 
-       type="char*256" 
+<entry id="finidat"
+       type="char*256"
        category="datasets"
-       input_pathname="abs" 
-       group="clm_inparm" 
+       input_pathname="abs"
+       group="clm_inparm"
        valid_values="" >
 Full pathname of initial conditions file. If blank CLM will startup from
 arbitrary initial conditions.
 </entry>
 
-<entry id="nrevsn" 
-       type="char*256" 
+<entry id="nrevsn"
+       type="char*256"
        category="clm_restart"
-       input_pathname="abs" 
-       group="clm_inparm" 
+       input_pathname="abs"
+       group="clm_inparm"
        valid_values="" >
 Full pathname of master restart file for a branch run. (only used if RUN_TYPE=branch)
 (Set with RUN_REFCASE and RUN_REFDATE)
 </entry>
 
-<entry id="fatmlndfrc" 
-       type="char*256" 
+<entry id="fatmlndfrc"
+       type="char*256"
        category="datasets"
-       input_pathname="abs" 
-       group="clm_inparm" 
+       input_pathname="abs"
+       group="clm_inparm"
        valid_values="" >
 Full pathname of land fraction data file.
 </entry>
@@ -80,8 +80,8 @@ Type of CO2 feedback.
 
 <entry id="suplnitro" type="char*15" category="clm_physics"
        group="clm_inparm" valid_values="NONE,ALL" >
-Supplemental Nitrogen mode and for what type of vegetation it's turned on for. 
-In this mode Nitrogen is unlimited rather than prognosed and in general vegetation is 
+Supplemental Nitrogen mode and for what type of vegetation it's turned on for.
+In this mode Nitrogen is unlimited rather than prognosed and in general vegetation is
 over-productive.
     NONE           = No vegetation types get supplemental Nitrogen
     ALL            = Supplemental Nitrogen is active for all vegetation types
@@ -89,8 +89,8 @@ over-productive.
 
 <entry id="suplphos" type="char*15" category="clm_physics"
        group="clm_inparm" valid_values="NONE,ALL" >
-Supplemental Phosphorus mode and for what type of vegetation it's turned on for. 
-In this mode Phosphorus is unlimited rather than prognosed and in general vegetation is 
+Supplemental Phosphorus mode and for what type of vegetation it's turned on for.
+In this mode Phosphorus is unlimited rather than prognosed and in general vegetation is
 over-productive.
     NONE           = No vegetation types get supplemental Phosphorus
     ALL            = Supplemental Phosphorus is active for all vegetation types
@@ -123,14 +123,20 @@ If TRUE, run forest N/P fertilization experiment
 
 <entry id="ECA_Pconst_RGspin" type="logical" category="clm_physics"
        group="clm_inparm" valid_values="" >
-If TRUE, do not allow soil labile, secondary, occcluded, and 
+If TRUE, do not allow soil labile, secondary, occcluded, and
 parent material phosphorus to change, during Regular Spinup,
 for ECA model
 </entry>
 
+<entry id="use_phenolmter" type="logical" category="clm_physics"
+       group="clm_inparm" valid_values="" >
+If TRUE, apply flux limiter to phenology fluxes to avoid overextraction
+of plant carbon and nutrient fluxes
+</entry>
+
 <entry id="NFIX_PTASE_plant" type="logical" category="clm_physics"
        group="clm_inparm" valid_values="" >
-If TRUE consider priority of plant to get a fraction of 
+If TRUE consider priority of plant to get a fraction of
 symbiotic N fixation and P phosphatase
 </entry>
 
@@ -157,7 +163,7 @@ Interpolate the soil layers on the surface dataset to the soil layers specified 
 <entry id="irrigate" type="logical" category="clm_physics"
        group="clm_inparm"  >
 If TRUE, irrigation will be active.
-</entry> 
+</entry>
 
 <entry id="maxpatch_glcmec" type="integer"  category="clm_physics"
        group="clm_inparm" valid_values="0,1,3,5,10,36" >
@@ -200,12 +206,12 @@ Default: 7300 (20 years)
 Visible and Near-infrared albedo's for glacier ice
 </entry>
 
-<entry id="dtime" type="real"  category="clm_physics" 
+<entry id="dtime" type="real"  category="clm_physics"
        group="clm_inparm" valid_values="">
 Time step (seconds)
 </entry>
 
-<entry id="override_nsrest" type="integer"  category="clm_restart" 
+<entry id="override_nsrest" type="integer"  category="clm_restart"
        group="clm_inparm" valid_values="3">
 Override the start type from the driver: it can only be
 set to 3 meaning branch.
@@ -218,7 +224,7 @@ Full pathname of land-ice mask data file (on lnd grid).
 
 <entry id="flndtopo" type="char*256" category="datasets"
        input_pathname="abs" group="clm_inparm" valid_values="" >
-Full pathname of topography data file. Only required when 
+Full pathname of topography data file. Only required when
 land-ice model is active.
 </entry>
 
@@ -305,7 +311,7 @@ Full pathname datafile with fates parameters
        input_pathname="abs" group="clm_inparm" valid_values="" >
        Full pathname datafile with soil order dependent constants
 </entry>
-       
+
 <entry id="flanduse_timeseries" type="char*256" category="datasets"
        input_pathname="abs" group="dynamic_subgrid" valid_values="" >
 Full pathname of time varying PFT data file. This causes the land-use types of
@@ -317,12 +323,12 @@ the initial surface dataset to vary over time.
 Full pathname of surface data file.
 </entry>
 
-<entry id="fsnowoptics" type="char*256" category="datasets" 
+<entry id="fsnowoptics" type="char*256" category="datasets"
        input_pathname="abs" group="clm_inparm" valid_values="" >
 SNICAR (SNow, ICe, and Aerosol Radiative model) optical data file name
 </entry>
 
-<entry id="fsnowaging" type="char*256"  category="datasets" 
+<entry id="fsnowaging" type="char*256"  category="datasets"
        input_pathname="abs" group="clm_inparm" valid_values="" >
 SNICAR (SNow, ICe, and Aerosol Radiative model) snow aging data file name
 </entry>
@@ -424,7 +430,7 @@ Per tape series  maximum number of time samples.
 
 <entry id="hist_ndens" type="integer(6)" category="history"
        group="clm_inparm" valid_values="1,2" >
-Per tape series  history file density (i.e. output precision) 
+Per tape series  history file density (i.e. output precision)
     1=double precision
     2=single precision
 <default>Default: 2,2,2,2,2,2</default>
@@ -432,7 +438,7 @@ Per tape series  history file density (i.e. output precision)
 
 <entry id="hist_nhtfrq" type="integer(6)" category="history"
        group="clm_inparm" valid_values="" >
-Per tape series history write frequency. 
+Per tape series history write frequency.
     positive means in time steps
     0=monthly
     negative means hours
@@ -514,7 +520,7 @@ Turn on methane model. Standard part of CLM45BGC model.
 
 <entry id="use_cn" type="logical" category="bgc"
        group="clm_inparm" valid_values="" value=".false.">
-CLM Biogeochemistry mode : Carbon Nitrogen model (CN) 
+CLM Biogeochemistry mode : Carbon Nitrogen model (CN)
 (or CLM45BGC if phys=clm4_5, vsoilc_centbgc='on', and clm4me='on')
 </entry>
 
@@ -526,7 +532,7 @@ CLM Biogeochemistry mode : Carbon Nitrogen with Dynamic Global Vegetation Model 
 
 <entry id="use_nitrif_denitrif" type="logical" category="bgc"
        group="clm_inparm" valid_values="" value=".false.">
-Nitrification/denitrification splits the prognostic mineral N pool into two 
+Nitrification/denitrification splits the prognostic mineral N pool into two
    mineral N pools: NO3 and NH4, and includes the transformations between them.
 Requires the CN model to work (either CN or CNDV).
 </entry>
@@ -603,7 +609,7 @@ SCRIP format grid data file
        group="clmexp" valid_values="none,64bit_offset,netcdf4" >
 Flag to pass to the ESMF mapping utility, telling it what kind of large
 file support is needed for an output file generated with this grid as
-either the source or destination ('none', '64bit_offset' or 'netcdf4'). 
+either the source or destination ('none', '64bit_offset' or 'netcdf4').
 </entry>
 
 <entry id="scripgriddata_type" type="char*256" category="mkmapdata"
@@ -623,7 +629,7 @@ in its attributes. (Only used if scripgriddata_src_type = UGRID.)
 <!-- mksurfdata namelist                               -->
 <!--                                                   -->
 <entry id="mksrf_filename" type="char*256" category="mksurfdata"
-       group="default_settings" 
+       group="default_settings"
        valid_values="mksrf_fsoitex,mksrf_forganic,mksrf_flakwat,mksrf_fwetlnd,mksrf_fmax,mksrf_fmax,mksrf_fglacier,mksrf_fvocef,mksrf_furbtopo,mksrf_flndtopo,firrig,mksrf_furban,mksrf_fvegtyp,mksrf_fsoicol,mksrf_fsoiord,mksrf_flai,mksrf_fgdp,mksrf_fpeat,mksrf_fabm,mksrf_ftopostats,mksrf_fvic,mksrf_fch4" >
 Filename for mksurfdata_map to remap raw data into the output surface dataset
 </entry>
@@ -898,7 +904,7 @@ by getco2_historical.ncl
 <!--                                                   -->
 <!-- files needed for tools/ncl_scripts                -->
 <!--                                                   -->
-<entry id="faerdep" type="char*256"  category="tools" 
+<entry id="faerdep" type="char*256"  category="tools"
        input_pathname="abs" group="clmexp" valid_values="" >
 Aerosol deposition file name (only used for aerdepregrid.ncl)
 </entry>
@@ -1132,16 +1138,16 @@ Mapping file to go from one resolution/land-mask to another resolution/land-mask
 </entry>
 
 <entry id="lmask" type="char*10" category="mksurfdata"
-       group="default_settings"  
+       group="default_settings"
        valid_values="nomask,navy,AVHRR,MODIS,USGS,IGBPmergeICESatGIS,IGBP-GSDP,ISRIC-WISE,LandScan2004,GLOBE-Gardner,GLOBE-Gardner-mergeGIS,GRDC,HYDRO1K-merge-nomask">
 Land mask description for mksurfdata input files
-</entry> 
+</entry>
 
 <entry id="hgrid" type="char*10" category="mksurfdata"
-       group="default_settings"  
+       group="default_settings"
        valid_values="0.1x0.1,0.5x0.5,10x10min,5x5min,360x720cru,0.9x1.25,19basin,1km-merge-10min">
 Horizontal grid resolutions for mksurfdata input files
-</entry> 
+</entry>
 
 
 <!-- ========================================================================================  -->
@@ -1160,40 +1166,40 @@ Add a note to the output namelist about the options given to build-namelist
 
 <entry id="clm_start_type" type="char*8"  category="default_settings"
        group="default_settings" valid_values="default,cold,arb_ic,startup,continue,branch" >
-CLM run type.  
+CLM run type.
     'default' use the default type of clm_start type for this configuration
     'cold' is a run from arbitrary initial conditions
     'arb_ic' is a run using initial conditions if provided, OR arbitrary initial conditions if no files can be found
-    'startup' is an initial run with initial conditions provided.  
+    'startup' is an initial run with initial conditions provided.
     'continue' is a restart run.
     'branch' is a restart run in which properties of the output history files may be changed.
 </entry>
 
 <entry id="res" type="char*30" category="default_settings"
-       group="default_settings"  
+       group="default_settings"
        valid_values=
 "512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,0.125x0.125,ne4np4,ne11np4,ne16np4,ne30np4,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
-</entry> 
+</entry>
 
 <entry id="rcp" type="real" category="default_settings"
-       group="default_settings"  
+       group="default_settings"
        valid_values="-999.9,2.6,4.5,6,8.5">
 Representative concentration pathway for future scenarios [radiative forcing at peak or 2100 in W/m^2]
 -999.9 means do NOT use a future scenario, just use historical data.
-</entry> 
+</entry>
 
 <entry id="mask" type="char*20" category="default_settings"
-       group="default_settings"  
+       group="default_settings"
        valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,tx0.1v2">
 Land mask description
-</entry> 
+</entry>
 
 <entry id="irrig" type="logical" category="default_settings"
        group="default_settings"  >
 If TRUE, irrigation will be active (find surface datasets with active irrigation).
-</entry> 
+</entry>
 
 <entry id="sim_year" type="integer" category="default_settings"
        group="default_settings" valid_values=
@@ -1203,7 +1209,7 @@ A sim_year of 1000 corresponds to data used for testing only, NOT corresponding 
 A sim_year greater than 2005 corresponds to rcp scenario data
 Most years are only used for clm_tools and there aren't CLM datasets that correspond to them.
 CLM datasets exist for years: 1000 (for testing), 1850, and 2000
-</entry> 
+</entry>
 
 <entry id="sim_year_range" type="char*9" category="default_settings"
        group="default_settings" valid_values=
@@ -1212,7 +1218,7 @@ Range of years to simulate transitory datasets for (such as dynamic: land-use da
 Constant means simulation will be held at a constant year given in sim_year.
 A sim_year_range of 1000-1002 or 1000-1004 corresponds to data used for testing only, NOT corresponding to any real datasets.
 A sim_year_range that goes beyond 2005 corresponds to historical data until 2005 and then scenario data beyond that point.
-</entry> 
+</entry>
 
 <entry id="clm_demand" type="char*256" category="default_settings"
        group="default_settings" valid_values="">
@@ -1234,8 +1240,8 @@ Command line arguement for turning on CN spinup mode.
 Command line arguement for biogeochemistry mode for CLM4.5
    sp  = Satellitte Phenology
    cn  = Carbon Nitrogen model
-   bgc = CLM4.5 BGC model with: 
-        CENTURY model pools 
+   bgc = CLM4.5 BGC model with:
+        CENTURY model pools
         Nitrification/De-nitrification
         Methane model
         Vertically resolved Carbon
@@ -1247,20 +1253,20 @@ Command line arguement for biogeochemistry mode for CLM4.5
 <!-- ========================================================================================  -->
 
 <entry id="drydep_method" type="char*16" category="dry-deposition"
-       group="drydep_inparm" 
+       group="drydep_inparm"
        valid_values="xactive_lnd,xactive_atm,table">
 Where dry deposition is calculated (from land, atmosphere, or from a table)
 </entry>
 
-<!-- List of all of the potential Chemical species that can be use for Dry-Deposition 
+<!-- List of all of the potential Chemical species that can be use for Dry-Deposition
      Anything NOT in this list - can NOT be used. As species are added in
        seq_drydep_mod.F90 this list needs to be updated.
-     Note: Species from H2 and thereafter are species that "map" 
+     Note: Species from H2 and thereafter are species that "map"
            to other previous species in the list. The mapping is laid
            out in seq_drydep_mod.F90.
 -->
 <entry id="drydep_list" type="char*32(100)" category="dry-deposition"
-       group="drydep_inparm" 
+       group="drydep_inparm"
        valid_values=
 "OX,H2O2,OH,HO2,CO,CH4,CH3O2,CH3OOH,CH2O,CHOOH,NO,NO2,HNO3,CO2,NH3,N2O5,NO3,CH3OH,HO2NO2,O1D,C2H6,C2H5O2,PO2,MACRO2,ISOPO2,C4H10,CH3CHO,C2H5OOH,C3H6,POOH,C2H4,PAN,CH3COOOH,C10H16,CHOCHO,CH3COCHO,GLYALD,CH3CO3,C3H8,C3H7O2,CH3COCH3,C3H7OOH,RO2,ROOH,Rn,ISOP,MVK,MACR,C2H5OH,ONITR,ONIT,ISOPNO3,HYDRALD,HCN,CH3CN,H2,'HYAC','CH3COOH','O3S','O3INERT','MPAN','ISOPOOH','MACROOH','Pb','XOOH','H2SO4','ALKOOH','MEKOOH','TOLOOH','BENOOH','XYLOOH','TERPOOH','SOGM','SOGI','SOGT','SOGB','SOGX','SOA','SO2','SO4','CB1','CB2','OC1','OC2','NH3','NH4','SA1','SA2','SA3','SA4','HCN','CH3CN','HCOOH','SOAM','SOAI','SOAT','SOAB','SOAX','O3A','XMPAN','XPAN','XNO','XNO2','XHNO3','XONIT','XONITR',XHO2NO2','XNH4NO3','COhc','COme','CO01','CO02','CO03','CO04','CO05','CO06','CO07','CO08','CO09','CO10','CO11','CO12','CO13','CO14','CO15','CO16','CO17','CO18','CO19','CO20','CO21','CO22','CO23','CO24','CO25','CO26','CO27','CO28','CO29','CO30','CO31','CO32','CO33','CO34','CO35','CO36','CO37','CO38','CO39','CO40','CO41','CO42','CO43','CO44','CO45','CO46','CO47','CO48','CO49','CO50','NH4NO3'"
 >
@@ -1278,9 +1284,9 @@ Flag for overriding the crash that should occur if user tries to start the model
 
 <entry id="spinup_state" type="integer" category="clm_vertcn"
        group="clm_inparm" valid_values="0,1" >
-Flag for setting the state of the Accelerated decomposition spinup state for the model.  
-   0 = normal model behavior; 
-   1 = AD spinup.  
+Flag for setting the state of the Accelerated decomposition spinup state for the model.
+   0 = normal model behavior;
+   1 = AD spinup.
 Entering and exiting spinup mode occurs automatically by comparing the namelist and restart file values for this variable.
 </entry>
 
@@ -1386,7 +1392,7 @@ Flag to use the atmospheric time series of C14 concentrations from bomb fallout,
 
 <entry id="atm_c14_filename" type="char*256" category="clm_isotope"
        group="clm_inparm" valid_values="" >
-Filename with time series of atmospheric Delta C14 data.  variables in file are "time" and "atm_delta_c14".  time variable is in format 1950.0, and time values must be monotonically increasing for interpolation, however spacing can be unequal. atm_delta_c14 variable has units of permil.  
+Filename with time series of atmospheric Delta C14 data.  variables in file are "time" and "atm_delta_c14".  time variable is in format 1950.0, and time values must be monotonically increasing for interpolation, however spacing can be unequal. atm_delta_c14 variable has units of permil.
 (EXPERIMENTAL and NOT tested)
 </entry>
 
@@ -1420,7 +1426,7 @@ Minimum lake depth to increase non-molecular thermal diffusivities by the factor
        group="clm_inparm" valid_values="" >
 Factor to increase non-molecular thermal diffusivities for lakes deeper than deepmixing_depthcrit
 to account for unresolved 3D processes.
-Set to 1 to 
+Set to 1 to
 </entry>
 
 <entry id="lake_melt_icealb" type="real(2)" category="clm_lake"
@@ -1435,7 +1441,7 @@ Set to alblak values (0.6, 0.4) to keep albedo constant for ice-covered lakes wi
 <!-- ========================================================================================  -->
 <entry id="reaction_method" type="char*256" category="clm_betr"
        group="betr_inparm" valid_values="" >
-Specify what reaction module will be used within the betr framework. 
+Specify what reaction module will be used within the betr framework.
 </entry>
 
 <entry id="AppParNLFile" type="char*256" category="clm_betr"
@@ -1490,7 +1496,7 @@ Use original CLM4 soil hydraulic properties
 
 <entry id="use_aereoxid_prog" type="logical" category="clm_methane"
        group="ch4par_in" valid_values="" >
-Allows user to tune the value of aereoxid.  If set to FALSE, then use the value of aereoxid from 
+Allows user to tune the value of aereoxid.  If set to FALSE, then use the value of aereoxid from
 the parameter file (set to 0.0, but may be tuned with values in the range {0.0,1.0}.  If set to TRUE,
 then don't fix aere (see ch4Mod.F90).
 <default>Default: .true.</default>
@@ -1559,7 +1565,7 @@ used in the Comp_Name variable on the file.
 MEGAN specifier. This is in the form of: Chem-compound = megan_compound(s)
 where megan_compound(s) can be the sum of megan compounds with a "+" between them.
 In each equation, the item to the left of the equal sign is a CAM chemistry compound, the
-items to the right are compounds known to the MEGAN model (single or combinations). 
+items to the right are compounds known to the MEGAN model (single or combinations).
 For example,
 megan_specifier = 'ISOP = isoprene',
                   'C10H16 = pinene_a + carene_3 + thujene_a'
@@ -1572,13 +1578,13 @@ If TRUE then use mapped MEGAN emissions factors for isoprene.
 </entry>
 
 <entry id="megan_cmpds" type="char*32(150)" category="drv_physics"
-       group="drv_physics" 
+       group="drv_physics"
        valid_values=
 "isoprene,myrcene,sabinene,limonene,carene_3,ocimene_t_b,pinene_b,pinene_a,2met_styrene,cymene_p,cymene_o,phellandrene_a,thujene_a,terpinene_a,terpinene_g,terpinolene,phellandrene_b,camphene,bornene,fenchene_a,ocimene_al,ocimene_c_b,tricyclene,estragole,camphor,fenchone,piperitone,thujone_a,thujone_b,cineole_1_8,borneol,linalool,terpineol_4,terpineol_a,linalool_OXD_c,linalool_OXD_t,ionone_b,bornyl_ACT,farnescene_a,caryophyllene_b,acoradiene,aromadendrene,bergamotene_a,bergamotene_b,bisabolene_a,bisabolene_b,bourbonene_b,cadinene_d,cadinene_g,cedrene_a,copaene_a,cubebene_a,cubebene_b,elemene_b,farnescene_b,germacrene_B,germacrene_D,gurjunene_b,humulene_a,humulene_g,isolongifolene,longifolene,longipinene,muurolene_a,muurolene_g,selinene_b,selinene_d,nerolidol_c,nerolidol_t,cedrol,MBO_2m3e2ol,methanol,acetone,methane,ammonia,nitrous_OXD,nitric_OXD,acetaldehyde,ethanol,formic_acid,formaldehyde,acetic_acid,MBO_3m2e1ol,MBO_3m3e1ol,benzaldehyde,butanone_2,decanal,dodecene_1,geranyl_acetone,heptanal,heptane,hexane,met_benzoate,met_heptenone,neryl_acetone,nonanal,nonenal,octanal,octanol,octenol_1e3ol,oxopentanal,pentane,phenyl_CCO,pyruvic_acid,terpinyl_ACT_a,tetradecene_1,toluene,carbon_monoxide,butene,ethane,ethene,hydrogen_cyanide,propane,propene,carbon_2s,carbonyl_s,diallyl_2s,2met_2s,2met_s,met_chloride,met_bromide,met_iodide,hydrogen_s,met_mercaptan,met_propenyl_2s,PPPP_2s,2met_nonatriene,met_salicylate,indole,jasmone,met_jasmonate,3met_3DCTT,hexanal,hexanol_1,hexenal_c3,hexenal_t2,hexenol_c3,hexenyl_ACT_c3,homosalate,Ehsalate,pentanal,heptanone,anisole,verbenene,benzyl-acetate,myrtenal,benzyl-alcohol,meta-cymenene,ipsenol,Napthalene"
 >
 List of possible MEGAN compounds to use
   (the list used by the simulation is on the megan_factors_file as the Comp_Name)
-</entry> 
+</entry>
 
 <!-- ========================================================================================  -->
 <!-- Namelist options controlling prescribed subgrid dynamics                                  -->

--- a/components/clm/src/biogeochem/EcosystemDynMod.F90
+++ b/components/clm/src/biogeochem/EcosystemDynMod.F90
@@ -680,7 +680,7 @@ contains
            veg_cf, veg_cs, &
            c13_veg_cf, c13_veg_cs, &
            c14_veg_cf, c14_veg_cs, &
-           veg_ns, veg_ns, veg_pf, veg_ps)
+           veg_nf, veg_ns, veg_pf, veg_ps)
          call t_stopf('phenology_flux_limiter')
        endif
        call t_startf('CNLitterToColumn')

--- a/components/clm/src/biogeochem/EcosystemDynMod.F90
+++ b/components/clm/src/biogeochem/EcosystemDynMod.F90
@@ -25,7 +25,7 @@ module EcosystemDynMod
   use atm2lndType         , only : atm2lnd_type
   use SoilStateType       , only : soilstate_type
   use CanopyStateType     , only : canopystate_type
-  use TemperatureType     , only : temperature_type 
+  use TemperatureType     , only : temperature_type
   use PhotosynthesisType  , only : photosyns_type
   use CH4Mod              , only : ch4_type
   use EnergyFluxType      , only : energyflux_type
@@ -41,12 +41,13 @@ module EcosystemDynMod
   use VegetationDataType  , only : veg_cf, c13_veg_cf, c14_veg_cf
   use VegetationDataType  , only : veg_ns, veg_nf
   use VegetationDataType  , only : veg_ps, veg_pf
-  
+
   ! bgc interface & pflotran
   use clm_varctl          , only : use_clm_interface, use_clm_bgc, use_pflotran, pf_cmode, pf_hmode
   use VerticalProfileMod   , only : decomp_vertprofiles
   use AllocationMod     , only : nu_com_nfix, nu_com_phosphatase
-  use clm_varctl          , only : nu_com
+  use clm_varctl          , only : nu_com, use_phenolmter
+  use PhenologyFLuxLimitMod , only : phenology_flux_limiter, InitPhenoFluxLimiter
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -78,17 +79,19 @@ contains
     !
     ! !ARGUMENTS:
     implicit none
-    type(bounds_type), intent(in) :: bounds      
+    type(bounds_type), intent(in) :: bounds
     !-----------------------------------------------------------------------
 
     call AllocationInit (bounds)
     call PhenologyInit  (bounds)
     call FireInit       (bounds)
-    
+
     if ( use_c14 ) then
        call C14_init_BombSpike()
     end if
-
+    if(use_phenolmter)then
+      call InitPhenoFluxLimiter()
+    endif
   end subroutine EcosystemDynInit
 
 
@@ -120,10 +123,10 @@ contains
     use perf_mod             , only: t_startf, t_stopf
     use shr_sys_mod          , only: shr_sys_flush
     use PhosphorusDynamicsMod         , only: PhosphorusBiochemMin_balance
-    
+
     !
     ! !ARGUMENTS:
-    type(bounds_type)        , intent(in)    :: bounds  
+    type(bounds_type)        , intent(in)    :: bounds
     integer                  , intent(in)    :: num_soilc         ! number of soil columns in filter
     integer                  , intent(in)    :: filter_soilc(:)   ! filter for soil columns
     integer                  , intent(in)    :: num_soilp         ! number of soil patches in filter
@@ -149,7 +152,7 @@ contains
     type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
 
     !-----------------------------------------------------------------------
-  
+
     ! only do if ed is off
     if( .not. use_fates) then
        !if(.not.(use_pflotran.and.pf_cmode)) then
@@ -186,7 +189,7 @@ contains
                 !call t_stopf('PhosphorusBiochemMin')
              end if
        !end if
-       
+
        !-----------------------------------------------------------------------
        ! pflotran: when both 'pf-bgc' and 'pf-h' on, no need to call CLM-CN's N leaching module
        if (.not. (pf_cmode .and. pf_hmode)) then
@@ -248,7 +251,7 @@ contains
 
        call veg_pf%Summary(bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, col_pf)
        call col_pf%Summary(bounds, num_soilc, filter_soilc)
-       
+
        call veg_ps%Summary(bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, col_ps)
        call col_ps%Summary(bounds, num_soilc, filter_soilc)
 
@@ -285,7 +288,7 @@ contains
     !
     ! !USES:
     use NitrogenDynamicsMod         , only: NitrogenDeposition,NitrogenFixation, NitrogenFert, CNSoyfix
-    use PhosphorusDynamicsMod           , only: PhosphorusDeposition   
+    use PhosphorusDynamicsMod           , only: PhosphorusDeposition
     use MaintenanceRespMod             , only: MaintenanceResp
 !    use SoilLittDecompMod            , only: SoilLittDecompAlloc
 !    use PhenologyMod         , only: Phenology
@@ -315,7 +318,7 @@ contains
     use NitrogenDynamicsMod         , only: NitrogenFixation_balance
     use PhosphorusDynamicsMod           , only: PhosphorusWeathering,PhosphorusAdsportion,PhosphorusDesoprtion,PhosphorusOcclusion
     use PhosphorusDynamicsMod           , only: PhosphorusBiochemMin,PhosphorusBiochemMin_balance
-  
+
     !
     ! !ARGUMENTS:
     type(bounds_type)        , intent(in)    :: bounds
@@ -392,7 +395,7 @@ contains
             atm2lnd_vars, nitrogenflux_vars)
        call t_stopf('CNDeposition')
 
-       if (.not. nu_com_nfix) then 
+       if (.not. nu_com_nfix) then
           call t_startf('CNFixation')
           call NitrogenFixation( num_soilc, filter_soilc, &
                waterflux_vars, carbonflux_vars, nitrogenflux_vars)
@@ -512,7 +515,7 @@ contains
 !    use NitrogenDynamicsMod         , only: NitrogenDeposition,NitrogenFixation, NitrogenFert, CNSoyfix
 !    use MaintenanceRespMod             , only: MaintenanceResp
 !    use SoilLittDecompMod            , only: SoilLittDecompAlloc
-    use PhenologyMod         , only: Phenology
+    use PhenologyMod         , only: Phenology, CNLitterToColumn
     use GrowthRespMod             , only: GrowthResp
     use CarbonStateUpdate1Mod     , only: CarbonStateUpdate1,CarbonStateUpdate0
     use NitrogenStateUpdate1Mod     , only: NitrogenStateUpdate1
@@ -668,6 +671,24 @@ contains
        end if
        call t_stopf('CNUpdate0')
 
+
+       !--------------------------------------------
+       if(use_phenolmter)then
+         call t_startf('phenology_flux_limiter')
+         call phenology_flux_limiter(bounds, num_soilc, filter_soilc,&
+           num_soilp, filter_soilp, crop_vars, cnstate_vars,  &
+           carbonflux_vars, carbonstate_vars, &
+           c13_carbonflux_vars, c13_carbonstate_vars, &
+           c14_carbonflux_vars, c14_carbonstate_vars, &
+           nitrogenflux_vars, nitrogenstate_vars, &
+           phosphorusflux_vars, phosphorusstate_vars)
+         call t_stopf('phenology_flux_limiter')
+       endif
+       call t_startf('CNLitterToColumn')
+       call CNLitterToColumn(num_soilc, filter_soilc, &
+         cnstate_vars, carbonflux_vars, nitrogenflux_vars,phosphorusflux_vars)
+
+       call t_stopf('CNLitterToColumn')
        !--------------------------------------------
        ! Update1
        !--------------------------------------------
@@ -865,10 +886,10 @@ contains
        if( use_c14 ) then
           call c14_col_cf%SummaryCH4(bounds, num_soilc, filter_soilc)
           call c14_veg_cf%SummaryCH4(bounds, num_soilp, filter_soilp)
-       endif    
+       endif
     end if !end of if not use_fates block
 
   end subroutine EcosystemDynNoLeaching2
 
-  
+
 end  module EcosystemDynMod

--- a/components/clm/src/biogeochem/EcosystemDynMod.F90
+++ b/components/clm/src/biogeochem/EcosystemDynMod.F90
@@ -677,11 +677,10 @@ contains
          call t_startf('phenology_flux_limiter')
          call phenology_flux_limiter(bounds, num_soilc, filter_soilc,&
            num_soilp, filter_soilp, crop_vars, cnstate_vars,  &
-           carbonflux_vars, carbonstate_vars, &
-           c13_carbonflux_vars, c13_carbonstate_vars, &
-           c14_carbonflux_vars, c14_carbonstate_vars, &
-           nitrogenflux_vars, nitrogenstate_vars, &
-           phosphorusflux_vars, phosphorusstate_vars)
+           veg_cf, veg_cs, &
+           c13_veg_cf, c13_veg_cs, &
+           c14_veg_cf, c14_veg_cs, &
+           veg_ns, veg_ns, veg_pf, veg_ps)
          call t_stopf('phenology_flux_limiter')
        endif
        call t_startf('CNLitterToColumn')

--- a/components/clm/src/biogeochem/LSparseMatMod.F90
+++ b/components/clm/src/biogeochem/LSparseMatMod.F90
@@ -1,0 +1,420 @@
+module LSparseMatMod
+
+
+  ! !USES:
+  ! sparse matrix capability
+  use bshr_kind_mod , only : r8 => shr_kind_r8
+  use bshr_log_mod  , only : errMsg => shr_log_errMsg
+implicit none
+  private
+  type, public :: spm_list_type
+    real(r8) :: val
+    integer  :: icol
+    integer  :: irow
+    type(spm_list_type), pointer :: next => null()
+  end type spm_list_type
+
+  type :: lom_type
+  contains
+    procedure :: calc_state_pscal
+    procedure :: calc_reaction_rscal
+    procedure :: apply_reaction_rscal
+  end type lom_type
+  type, public :: sparseMat_type
+    real(r8), pointer :: val(:)      !nonzero val
+    integer , pointer :: icol(:)     !col id for each val
+    integer , pointer :: pB(:)       !first nonzero column id (as in val) in each row
+    integer , pointer :: ncol(:)     !number of nonzero columns in eacho row
+    integer :: szcol                 ! number of columns of the matrix
+    integer :: szrow
+  contains
+    procedure, public :: init
+  end type sparseMat_type
+  real(r8), parameter :: tiny_val=1.e-14_r8
+  public :: spm_list_init, spm_list_insert, spm_list_to_mat
+  public :: flux_correction
+contains
+
+!---------------------------------------------------------------
+  function create_spm_type()
+    !
+    ! ! DESCRIPTION:
+    !
+    ! create an object of type sparseMat_type.
+    ! Right now it is purposely empty
+   class(sparseMat_type), pointer :: spm
+   class(sparseMat_type), pointer ::  create_spm_type
+   allocate(spm)
+   create_spm_type => spm
+  end function create_spm_type
+
+!---------------------------------------------------------------
+  subroutine init(this,nelms,nrows,szcol)
+  !
+  !DESCRIPTION
+  ! initialize the sparse matrix
+  implicit none
+  class(sparseMat_type), intent(inout) :: this
+  integer, intent(in) :: nelms
+  integer, intent(in) :: nrows
+  integer, intent(in) :: szcol
+
+  allocate(this%val(nelms)) ;  this%val(:)  = 0._r8
+  allocate(this%icol(nelms));  this%icol(:) = 0
+  allocate(this%pB(nrows));    this%pB(:) = 0
+  allocate(this%ncol(nrows));  this%ncol(:) = 0
+  this%szcol = szcol
+  this%szrow= nrows
+  end subroutine init
+
+!---------------------------------------------------------------
+  subroutine spm_pack(Amat, nelms)
+
+  implicit none
+  real(r8), dimension(:,:),intent(in) :: Amat
+  integer, intent(in) :: nelms
+
+  class(sparseMat_type), pointer :: spm
+  integer :: nrows, szcol
+  integer :: ii,jj,kk
+  logical :: first
+  nrows=size(Amat,1)
+  szcol=size(Amat,2)
+  allocate(spm, source=create_spm_type())
+
+  call spm%init(nelms, nrows, szcol)
+
+  kk = 0
+  do ii = 1, nrows
+    first =.true.
+    do jj = 1, szcol
+      if(abs(amat(ii,jj))>tiny_val)then
+        kk = kk + 1
+        spm%val(kk) = amat(ii,jj)
+        spm%icol(kk)= jj
+        if(first)then
+          spm%pB(ii) = jj
+        endif
+        spm%ncol(ii)=spm%ncol(ii)+1
+        first=.false.
+      endif
+    enddo
+  enddo
+
+  end subroutine spm_pack
+
+!---------------------------------------------------------------
+
+  subroutine spm_unpack(spm, bmat)
+
+  implicit none
+  class(sparseMat_type), intent(in) :: spm
+  real(r8), pointer :: bmat(:,:)
+
+  integer :: nrs, ncs
+  integer :: i, j, id
+
+  nrs = size(spm%ncol)
+  ncs = spm%szcol
+  allocate(bmat(nrs,ncs))
+
+  do i = 1, nrs
+    do j = 1, spm%ncol(i)
+      id=j+spm%pB(i)
+      bmat(i,spm%icol(id))=spm%val(id)
+    enddo
+  enddo
+
+  end subroutine spm_unpack
+
+!---------------------------------------------------------------
+
+  subroutine spm_axpy(nx, ny, a, x, spm, y, errinfo)
+  implicit none
+  real(r8), intent(in) :: a
+  integer , intent(in) :: nx
+  integer , intent(in) :: ny
+  real(r8), intent(in) :: x(ny)
+  type(sparseMat_type), intent(in) :: spm
+  real(r8), intent(inout) :: y(nx)
+  integer, intent(out) :: errinfo
+
+  integer :: ii, jj, id
+  real(r8) :: dy
+  errinfo=0
+  if(nx /=spm%szrow .or. ny /= spm%szcol)then
+    errinfo=-1
+    return
+  endif
+
+  do ii = 1, spm%szrow
+    dy = 0._r8
+    do jj = 1, spm%ncol(ii)
+      id = spm%pB(ii)+jj-1
+      dy=dy+spm%val(id)*x(spm%icol(id))
+    enddo
+    y(ii) = y(ii) + a*dy
+  enddo
+  end subroutine spm_axpy
+!---------------------------------------------------------------
+
+
+  subroutine spm_list_init(self, val, icol, irow, nelms)
+  implicit none
+  type(spm_list_type), pointer :: self
+  real(r8), intent(in) :: val
+  integer, intent(in) :: icol
+  integer, intent(in) :: irow
+  integer, intent(out):: nelms
+  allocate(self)
+  nullify(self%next)
+
+  self%val=val
+  self%icol=icol
+  self%irow=irow
+  nelms=1
+  end subroutine spm_list_init
+!---------------------------------------------------------------
+
+  subroutine spm_list_insert(self, val, icol, irow, nelms)
+  implicit none
+  type(spm_list_type), pointer :: self
+  real(r8), intent(in) :: val
+  integer, intent(in) :: icol
+  integer, intent(in) :: irow
+  integer, intent(inout):: nelms
+  type(spm_list_type), pointer :: next
+
+  allocate(next)
+
+  next%val=val
+  next%icol=icol
+  next%irow=irow
+  next%next=> self
+  self => next
+  nelms=nelms+1
+  end subroutine spm_list_insert
+!---------------------------------------------------------------
+
+  function spm_list_next(self)result(next)
+
+  implicit none
+  type(spm_list_type), pointer :: self
+  type(spm_list_type), pointer :: next
+
+  next => self%next
+  end function spm_list_next
+!---------------------------------------------------------------
+
+  subroutine spm_list_free(self)
+  implicit none
+  type(spm_list_type), pointer :: self
+  type(spm_list_type), pointer :: current
+  type(spm_list_type), pointer :: elem
+
+  elem => self
+  do while(associated(elem))
+    current => elem
+    elem => current%next
+    deallocate(current)
+  enddo
+  end subroutine spm_list_free
+!---------------------------------------------------------------
+
+  subroutine spm_list_to_mat(spm_list, spm, nelms, szcol)
+  !
+  !copy the list to sparse matrix, and free the list
+  implicit none
+  type(spm_list_type), pointer :: spm_list
+  class(sparseMat_type), pointer :: spm
+  integer, intent(in) :: nelms    !total number of nonzero elements
+  integer, intent(in) :: szcol    !total columns of the matrix
+
+  type(spm_list_type), pointer :: next
+  integer :: nrows
+  integer :: irow, jj
+
+  nrows=spm_list%irow
+
+  allocate(spm, source=create_spm_type())
+
+  call spm%init(nelms, nrows, szcol)
+
+  jj = nelms
+  irow=nrows
+  next => spm_list
+  do while(associated(next))
+    if (irow /= next%irow)then
+       spm%pB(irow)=jj+1
+       irow=next%irow
+    endif
+    spm%val(jj) = next%val
+    spm%icol(jj)= next%icol
+    spm%ncol(irow)=spm%ncol(irow)+1
+    next=>spm_list_next(next)
+    jj=jj-1
+  enddo
+  !fill the last row
+  spm%pB(irow)=jj+1
+  call spm_list_free(spm_list)
+  end subroutine spm_list_to_mat
+
+
+
+  !-------------------------------------------------------------------------------
+  subroutine calc_state_pscal(this, nprimvars, dtime, ystate, p_dt,  d_dt, pscal, lneg, errinfo)
+    !
+    ! !DESCRIPTION:
+    ! calcualte limiting factor from each primary state variable
+    !
+    use BetrstatusType     , only : betr_status_type
+    use betr_constants     , only : betr_errmsg_len
+    use clm_varctl         , only : iulog
+    implicit none
+    ! !ARGUMENTS:
+    class(lom_type), intent(in) :: this
+    integer,  intent(in)  :: nprimvars
+    real(r8), intent(in)  :: dtime
+    real(r8), intent(in)  :: ystate(1:nprimvars)
+    real(r8), intent(in)  :: p_dt(1:nprimvars)
+    real(r8), intent(in)  :: d_dt(1:nprimvars)
+    real(r8), intent(out) :: pscal(1:nprimvars)
+    logical,  intent(out) :: lneg
+    integer,  intent(out) :: errinfo
+    character(len=betr_errmsg_len) :: msg
+
+    ! !LOCAL VARIABLES:
+    real(r8) :: yt
+    integer  :: j
+    real(r8),parameter :: p_par=0.999_r8
+    real(r8), parameter :: tiny_val=-1.e-14_r8
+    real(r8) :: tmp
+
+    lneg =.false.
+    errinfo=0
+    do j = 1, nprimvars
+       yt = ystate(j) + (p_dt(j)+d_dt(j))*dtime
+       if(yt<tiny_val)then
+          tmp = dtime*d_dt(j)
+          pscal(j) = -(p_dt(j)*dtime+max(ystate(j),0._r8))/tmp*p_par
+          if(abs(pscal(j))<1.e-14)pscal(j)=0._r8
+          lneg=.true.
+          if(pscal(j)<0._r8)then
+             write(iulog,*)'pscal',pscal(j),p_dt(j),ystate(j),d_dt(j)
+             errinfo=-1
+             return
+          endif
+       else
+          pscal(j) = 1._r8
+       endif
+    enddo
+  end subroutine calc_state_pscal
+
+  !-------------------------------------------------------------------------------
+  subroutine calc_reaction_rscal(this, nprimvars, nr, pscal, spm_d, rscal)
+    !
+    ! !DESCRIPTION:
+    ! calcualte limiting factor for each reaction
+    ! !USES:
+    use BetrstatusType     , only : betr_status_type
+    implicit none
+    ! !ARGUMENTS:
+    class(lom_type), intent(in) :: this
+    integer , intent(in) :: nprimvars
+    integer , intent(in) :: nr
+    real(r8), intent(in) :: pscal(1:nprimvars)
+    type(sparseMat_type), intent(in) :: spm_d
+    real(r8), intent(out):: rscal(1:nr)
+    ! !LOCAL VARIABLES:
+    integer :: jj, ii, id
+
+    rscal(:)=1._r8
+    do ii=1, spm_d%szrow
+      do jj = 1, spm_d%ncol(ii)
+        id = spm_d%pB(ii)+jj-1
+        rscal(spm_d%icol(id)) = min(pscal(ii),rscal(spm_d%icol(id)))
+      enddo
+    enddo
+
+  end subroutine calc_reaction_rscal
+
+  !-------------------------------------------------------------------------------
+  subroutine apply_reaction_rscal(this, nr, rscal, reaction_rates)
+    !
+    ! !DESCRIPTION:
+    ! reduce reaction rates using input scalar
+    !
+    implicit none
+    ! !ARGUMENTS:
+    class(lom_type), intent(in) :: this
+    integer , intent(in)    :: nr
+    real(r8), intent(in)    :: rscal(1:nr)
+    real(r8), intent(inout) :: reaction_rates(1:nr)
+    ! !LOCAL VARIABLES:
+    integer :: j
+
+    do j = 1, nr
+       reaction_rates(j) = reaction_rates(j)*rscal(j)
+    enddo
+  end subroutine  apply_reaction_rscal
+
+  !-------------------------------------------------------------------------------
+  subroutine flux_correction(nvars, nreactions, spm_p, spm_d, dtime, ystates, rfluxes)
+  !
+  ! DESCRIPTION
+  ! correcting the fluxes to avoid negative state variables
+  use abortutils             , only : endrun
+  implicit none
+  integer, intent(in) :: nvars
+  integer, intent(in) :: nreactions
+  class(sparseMat_type), intent(in) :: spm_p
+  class(sparseMat_type), intent(in) :: spm_d
+  real(r8), intent(in) :: dtime
+  real(r8), intent(in) :: ystates(nvars)
+  real(r8), intent(inout):: rfluxes(nreactions)
+
+  integer :: it
+  real(r8) :: rscal(nreactions)
+  real(r8) :: pscal(nvars)
+  real(r8) :: d_dt(nvars)
+  real(r8) :: p_dt(nvars)
+  integer :: errinfo
+  type(lom_type) :: lom
+  logical :: lneg
+  integer, parameter :: itmax=40
+  it=0
+  rscal=0._r8
+  do
+    !obtain the destruction fluxes
+    d_dt(:)=0._r8
+    call spm_axpy(spm_d%szrow, spm_d%szcol, 1._r8, rfluxes, spm_d, d_dt, errinfo)
+
+    if(errinfo<0)then
+      call endrun(msg='ERROR:: in spm_axpy'//errMsg(__FILE__, __LINE__))
+    endif
+    !obtain the production fluxes
+    p_dt(:)=0._r8
+    call spm_axpy(spm_p%szrow, spm_d%szcol, 1._r8, rfluxes, spm_p, p_dt, errinfo)
+
+    if(errinfo<0)then
+      call endrun(msg='ERROR:: in spm_axpy '//errMsg(__FILE__, __LINE__))
+    endif
+    call lom%calc_state_pscal(spm_d%szrow, dtime, ystates, p_dt,  d_dt, &
+      pscal, lneg, errinfo)
+    if(errinfo<0)then
+      call endrun(msg='ERROR:: in calc_state_pscal '//errMsg(__FILE__, __LINE__))
+    endif
+    if(lneg .and. it<=itmax)then
+      call lom%calc_reaction_rscal(spm_d%szrow, spm_d%szcol,  pscal, &
+        spm_d,rscal)
+
+      call lom%apply_reaction_rscal(spm_d%szcol, rscal, rfluxes)
+    else
+      exit
+    endif
+    it = it + 1
+  enddo
+  end subroutine flux_correction
+
+
+end module LSparseMatMod

--- a/components/clm/src/biogeochem/LSparseMatMod.F90
+++ b/components/clm/src/biogeochem/LSparseMatMod.F90
@@ -294,9 +294,9 @@ contains
     errinfo=0
     do j = 1, nprimvars
        yt = ystate(j) + (p_dt(j)+d_dt(j))*dtime
-       if(yt<tiny_val)then
+       if(yt<tiny_val .and. d_dt(j)<0._r8)then
           tmp = dtime*d_dt(j)
-          pscal(j) = -(p_dt(j)*dtime+max(ystate(j),0._r8))/tmp*p_par
+          pscal(j) = -(max(p_dt(j),0._r8)*dtime+max(ystate(j),0._r8))/tmp*p_par
           if(abs(pscal(j))<1.e-14)pscal(j)=0._r8
           lneg=.true.
           if(pscal(j)<0._r8)then

--- a/components/clm/src/biogeochem/PhenologyFluxLimitMod.F90
+++ b/components/clm/src/biogeochem/PhenologyFluxLimitMod.F90
@@ -1,0 +1,1143 @@
+module PhenologyFLuxLimitMod
+
+!DESCRIPTION
+! limit the allocation fluxes resulting from pheonology
+! calculation to avoid negative state varaibles for
+! carbon, nitrogen and phosphours.
+! The current implementation does not use sparse
+! matrix, future version should consider this possibility.
+
+  use LSparseMatMod               , only : sparseMat_type, flux_correction,spm_list_type
+  use shr_kind_mod                , only : r8 => shr_kind_r8
+  use VegetationType              , only : veg_pp
+  use VegetationPropertiesType    , only : veg_vp
+  use clm_time_manager            , only : get_step_size
+  use pftvarcon                   , only : npcropmin
+  use clm_varctl                  , only : iulog
+  use abortutils                  , only : endrun
+implicit none
+  private
+#define mov(a,b) a=b
+#define imov(a,b) b=max(a,0._r8)
+#define ascal(a,b) a=a*b
+  integer :: s_cpool
+  integer :: s_leafc
+  integer :: s_leafc_xfer
+  integer :: s_leafc_storage
+  integer :: s_frootc
+  integer :: s_frootc_xfer
+  integer :: s_frootc_sotrage
+  integer :: s_livestemc
+  integer :: s_livestemc_xfer
+  integer :: s_livestemc_storage
+  integer :: s_livecrootc
+  integer :: s_livecrootc_xfer
+  integer :: s_livecrootc_storage
+  integer :: s_deadstemc
+  integer :: s_deadstemc_xfer
+  integer :: s_deadstemc_storage
+  integer :: s_deadcrootc
+  integer :: s_deadcrootc_xfer
+  integer :: s_deadcrootc_storage
+  integer :: s_grainc
+  integer :: s_grainc_xfer
+  integer :: s_grainc_storage
+  integer :: s_gresp_xfer
+  integer :: s_gresp_storage
+
+  integer :: f_cpool_to_leafc
+  integer :: f_cpool_to_leafc_storage
+  integer :: f_cpool_to_frootc
+  integer :: f_cpool_to_frootc_storage
+  integer :: f_cpool_to_xsmrpool
+  integer :: f_cpool_to_gresp_storage
+  integer :: f_cpool_to_ar
+  integer :: f_cpool_to_livestemc
+  integer :: f_cpool_to_livestemc_storage
+  integer :: f_cpool_to_deadstemc
+  integer :: f_cpool_to_deadstemc_storage
+  integer :: f_cpool_to_livecrootc
+  integer :: f_cpool_to_livecrootc_storage
+  integer :: f_cpool_to_deadcrootc
+  integer :: f_cpool_to_deadcrootc_storage
+  integer :: f_cpool_to_grainc
+  integer :: f_cpool_to_grainc_storage
+  integer :: f_leafc_to_litter
+  integer :: f_leafc_xfer_to_leafc
+  integer :: f_leafc_storage_to_xfer
+  integer :: f_frootc_to_litter
+  integer :: f_frootc_xfer_to_frootc
+  integer :: f_frootc_storage_to_xfer
+  integer :: f_livestemc_to_deadstemc
+  integer :: f_livestemc_xfer_to_livestemc
+  integer :: f_livestemc_storage_to_xfer
+  integer :: f_livestemc_to_litter
+  integer :: f_deadstemc_xfer_to_deadstemc
+  integer :: f_deadstemc_storage_to_xfer
+  integer :: f_livecrootc_xfer_to_livecrootc
+  integer :: f_livecrootc_storage_to_xfer
+  integer :: f_livecrootc_to_deadcrootc
+  integer :: f_deadcrootc_xfer_to_deadcrootc
+  integer :: f_deadcrootc_storage_to_xfer
+  integer :: f_grainc_to_food
+  integer :: f_grainc_xfer_to_grainc
+  integer :: f_grainc_storage_to_xfer
+  integer :: f_gresp_storage_to_xfer
+
+
+  integer :: s_npool
+  integer :: s_leafn
+  integer :: s_leafn_xfer
+  integer :: s_leafn_storage
+  integer :: s_frootn
+  integer :: s_frootn_xfer
+  integer :: s_frootn_sotrage
+  integer :: s_livestemn
+  integer :: s_livestemn_xfer
+  integer :: s_livestemn_storage
+  integer :: s_deadstemn
+  integer :: s_deadstemn_xfer
+  integer :: s_deadstemn_storage
+  integer :: s_livecrootn
+  integer :: s_livecrootn_xfer
+  integer :: s_livecrootn_storage
+  integer :: s_deadcrootn
+  integer :: s_deadcrootn_xfer
+  integer :: s_deadcrootn_storage
+  integer :: s_retransn
+  integer :: s_grainn
+  integer :: s_grainn_xfer
+  integer :: s_grainn_storage
+
+  integer :: f_npool_to_leafn
+  integer :: f_npool_to_leafn_storage
+  integer :: f_npool_to_frootn
+  integer :: f_npool_to_frootn_storage
+  integer :: f_npool_to_livestemn_storage
+  integer :: f_npool_to_liverootn_storage
+  integer :: f_npool_to_livestemn
+  integer :: f_npool_to_livecrootn
+  integer :: f_npool_to_livecrootn_storage
+  integer :: f_npool_to_deadstemn
+  integer :: f_npool_to_deadcrootn
+  integer :: f_npool_to_deadstemn_storage
+  integer :: f_npool_to_deadcrootn_storage
+  integer :: f_npool_to_grainn
+  integer :: f_npool_to_grainn_storage
+  integer :: f_leafn_to_retransn
+  integer :: f_leafn_to_litter
+  integer :: f_leafn_xfer_to_leafn
+  integer :: f_leafn_storage_to_xfer
+  integer :: f_frootn_xfer_to_frootn
+  integer :: f_frootn_storage_to_xfer
+  integer :: f_frootn_to_retransn
+  integer :: f_frootn_to_litter
+  integer :: f_livestemn_to_litter
+  integer :: f_livestemn_storage_to_xfer
+  integer :: f_livestemn_xfer_to_livestemn
+  integer :: f_livestemn_to_retransn
+  integer :: f_livestemn_to_deadstemn
+  integer :: f_livecrootn_storage_to_xfer
+  integer :: f_livecrootn_xfer_to_livecrootn
+  integer :: f_livecrootn_to_deadcrootn
+  integer :: f_livecrootn_to_retransn
+  integer :: f_deadstemn_storage_to_xfer
+  integer :: f_deadstemn_xfer_to_deadstem
+  integer :: f_deadcrootn_storage_to_xfer
+  integer :: f_deadcrootn_xfer_to_deadcrootn
+  integer :: f_grainn_xfer_to_grainn
+  integer :: f_grainn_to_food
+  integer :: f_retransn_to_npool
+  integer :: f_supplement_to_plantn
+  integer :: n_carbon_fluxes
+  integer :: n_nutrient_fluxes
+  integer :: n_carbon_states
+  integer :: n_nutrient_states
+
+  class(sparseMat_type), pointer :: spm_carbon_p,spm_carbon_d
+  class(sparseMat_type), pointer :: spm_nutrient_p,spm_nutrient_d
+  type(spm_list_type), pointer :: spm_list
+  public :: InitPhenoFluxLimiter
+  public :: phenology_flux_limiter
+contains
+
+
+  function ic_next(id)result(ans)
+
+  implicit none
+  integer, intent(inout) :: id
+  integer :: ans
+  id=id+1
+  ans=id
+  end function ic_next
+  !-------------------------------------------------------------------------------
+  subroutine init_phenofluxl_counters()
+
+  implicit none
+  integer :: id
+
+  id = 0
+  s_cpool              = ic_next(id)
+  s_leafc              = ic_next(id)
+  s_leafc_xfer         = ic_next(id)
+  s_leafc_storage      = ic_next(id)
+  s_frootc             = ic_next(id)
+  s_frootc_xfer        = ic_next(id)
+  s_frootc_sotrage     = ic_next(id)
+  s_livestemc          = ic_next(id)
+  s_livestemc_xfer     = ic_next(id)
+  s_livestemc_storage  = ic_next(id)
+  s_livecrootc         = ic_next(id)
+  s_livecrootc_xfer    = ic_next(id)
+  s_livecrootc_storage = ic_next(id)
+  s_deadstemc          = ic_next(id)
+  s_deadstemc_xfer     = ic_next(id)
+  s_deadstemc_storage  = ic_next(id)
+  s_deadcrootc         = ic_next(id)
+  s_deadcrootc_xfer    = ic_next(id)
+  s_deadcrootc_storage = ic_next(id)
+  s_grainc             = ic_next(id)
+  s_grainc_xfer        = ic_next(id)
+  s_grainc_storage     = ic_next(id)
+  s_gresp_xfer         = ic_next(id)
+  s_gresp_storage      = ic_next(id)
+  n_carbon_states = id
+  id=0
+  f_cpool_to_leafc               = ic_next(id)
+  f_cpool_to_leafc_storage       = ic_next(id)
+  f_cpool_to_frootc              = ic_next(id)
+  f_cpool_to_frootc_storage      = ic_next(id)
+  f_cpool_to_xsmrpool            = ic_next(id)
+  f_cpool_to_gresp_storage       = ic_next(id)
+  f_cpool_to_ar                  = ic_next(id)
+  f_cpool_to_livestemc           = ic_next(id)
+  f_cpool_to_livestemc_storage   = ic_next(id)
+  f_cpool_to_deadstemc           = ic_next(id)
+  f_cpool_to_deadstemc_storage   = ic_next(id)
+  f_cpool_to_livecrootc          = ic_next(id)
+  f_cpool_to_livecrootc_storage  = ic_next(id)
+  f_cpool_to_deadcrootc          = ic_next(id)
+  f_cpool_to_deadcrootc_storage  = ic_next(id)
+  f_cpool_to_grainc              = ic_next(id)
+  f_cpool_to_grainc_storage      = ic_next(id)
+  f_leafc_to_litter              = ic_next(id)
+  f_leafc_xfer_to_leafc          = ic_next(id)
+  f_leafc_storage_to_xfer        = ic_next(id)
+  f_frootc_to_litter             = ic_next(id)
+  f_frootc_xfer_to_frootc        = ic_next(id)
+  f_frootc_storage_to_xfer       = ic_next(id)
+  f_livestemc_to_deadstemc       = ic_next(id)
+  f_livestemc_xfer_to_livestemc  = ic_next(id)
+  f_livestemc_storage_to_xfer    = ic_next(id)
+  f_livestemc_to_litter          = ic_next(id)
+  f_deadstemc_xfer_to_deadstemc  = ic_next(id)
+  f_deadstemc_storage_to_xfer    = ic_next(id)
+  f_livecrootc_xfer_to_livecrootc= ic_next(id)
+  f_livecrootc_storage_to_xfer   = ic_next(id)
+  f_livecrootc_to_deadcrootc     = ic_next(id)
+  f_deadcrootc_xfer_to_deadcrootc= ic_next(id)
+  f_deadcrootc_storage_to_xfer   = ic_next(id)
+  f_grainc_to_food               = ic_next(id)
+  f_grainc_xfer_to_grainc        = ic_next(id)
+  f_grainc_storage_to_xfer       = ic_next(id)
+  f_gresp_storage_to_xfer        = ic_next(id)
+  n_carbon_fluxes = id
+  id=0
+  s_npool               = ic_next(id)
+  s_leafn               = ic_next(id)
+  s_leafn_xfer          = ic_next(id)
+  s_leafn_storage       = ic_next(id)
+  s_frootn              = ic_next(id)
+  s_frootn_xfer         = ic_next(id)
+  s_frootn_sotrage      = ic_next(id)
+  s_livestemn           = ic_next(id)
+  s_livestemn_xfer      = ic_next(id)
+  s_livestemn_storage   = ic_next(id)
+  s_deadstemn           = ic_next(id)
+  s_deadstemn_xfer      = ic_next(id)
+  s_deadstemn_storage   = ic_next(id)
+  s_livecrootn          = ic_next(id)
+  s_livecrootn_xfer     = ic_next(id)
+  s_livecrootn_storage  = ic_next(id)
+  s_deadcrootn          = ic_next(id)
+  s_deadcrootn_xfer     = ic_next(id)
+  s_deadcrootn_storage  = ic_next(id)
+  s_grainn              = ic_next(id)
+  s_grainn_xfer         = ic_next(id)
+  s_grainn_storage      = ic_next(id)
+  s_retransn            = ic_next(id)
+  n_nutrient_states = id
+  id = 0
+  f_npool_to_leafn                = ic_next(id)
+  f_npool_to_leafn_storage        = ic_next(id)
+  f_npool_to_frootn               = ic_next(id)
+  f_npool_to_frootn_storage       = ic_next(id)
+  f_npool_to_livestemn            = ic_next(id)
+  f_npool_to_livestemn_storage    = ic_next(id)
+  f_npool_to_livecrootn           = ic_next(id)
+  f_npool_to_livecrootn_storage   = ic_next(id)
+  f_npool_to_deadstemn            = ic_next(id)
+  f_npool_to_deadcrootn           = ic_next(id)
+  f_npool_to_deadstemn_storage    = ic_next(id)
+  f_npool_to_deadcrootn_storage   = ic_next(id)
+  f_npool_to_grainn               = ic_next(id)
+  f_npool_to_grainn_storage       = ic_next(id)
+  f_leafn_to_retransn             = ic_next(id)
+  f_leafn_to_litter               = ic_next(id)
+  f_leafn_xfer_to_leafn           = ic_next(id)
+  f_leafn_storage_to_xfer         = ic_next(id)
+  f_frootn_xfer_to_frootn         = ic_next(id)
+  f_frootn_storage_to_xfer        = ic_next(id)
+  f_frootn_to_retransn            = ic_next(id)
+  f_frootn_to_litter              = ic_next(id)
+  f_livestemn_to_litter           = ic_next(id)
+  f_livestemn_storage_to_xfer     = ic_next(id)
+  f_livestemn_xfer_to_livestemn   = ic_next(id)
+  f_livestemn_to_retransn         = ic_next(id)
+  f_livestemn_to_deadstemn        = ic_next(id)
+  f_livecrootn_to_deadcrootn      = ic_next(id)
+  f_livecrootn_to_retransn        = ic_next(id)
+  f_livecrootn_storage_to_xfer    = ic_next(id)
+  f_livecrootn_xfer_to_livecrootn = ic_next(id)
+  f_deadstemn_storage_to_xfer     = ic_next(id)
+  f_deadstemn_xfer_to_deadstem    = ic_next(id)
+  f_deadcrootn_storage_to_xfer    = ic_next(id)
+  f_deadcrootn_xfer_to_deadcrootn = ic_next(id)
+  f_grainn_xfer_to_grainn         = ic_next(id)
+  f_grainn_to_food                = ic_next(id)
+  f_retransn_to_npool             = ic_next(id)
+  f_supplement_to_plantn          = ic_next(id)
+  n_nutrient_fluxes = id
+  end subroutine init_phenofluxl_counters
+  !-------------------------------------------------------------------------------
+  subroutine InitPhenoFluxLimiter()
+
+  use LSparseMatMod, only : spm_list_type,  spm_list_to_mat
+  use LSparseMatMod, only : spm_list_init, spm_list_insert
+  implicit none
+  integer :: nelms
+  type(spm_list_type), pointer :: spm_list
+
+  call init_phenofluxl_counters
+
+  call spm_list_init(spm_list, -1._r8, f_cpool_to_leafc                , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_leafc_storage      , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_frootc              , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_frootc_storage      , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_xsmrpool            , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_gresp_storage       , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_ar                  , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_livestemc           , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_livestemc_storage   , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_deadstemc           , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_deadstemc_storage   , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_livecrootc          , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_livecrootc_storage  , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_deadcrootc          , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_deadcrootc_storage  , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_grainc              , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_cpool_to_grainc_storage      , s_cpool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_leafc_to_litter              , s_leafc, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_leafc_xfer_to_leafc          , s_leafc_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_leafc_storage_to_xfer        , s_leafc_storage, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_frootc_to_litter             , s_frootc, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_frootc_xfer_to_frootc        , s_frootc_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_frootc_storage_to_xfer       , s_frootc_sotrage, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livestemc_to_deadstemc       , s_livestemc,nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livestemc_xfer_to_livestemc  , s_livestemc_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livestemc_storage_to_xfer    , s_livestemc_storage, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livestemc_to_litter          , s_livestemc, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_deadstemc_xfer_to_deadstemc  , s_deadstemc_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_deadstemc_storage_to_xfer    , s_deadstemc_storage, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livecrootc_to_deadcrootc     , s_livecrootc, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livecrootc_xfer_to_livecrootc, s_livecrootc_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livecrootc_storage_to_xfer   , s_livecrootc_storage, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_deadcrootc_xfer_to_deadcrootc, s_deadcrootc_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_deadcrootc_storage_to_xfer   , s_deadcrootc_storage,nelms)
+  call spm_list_insert(spm_list, -1._r8, f_grainc_to_food               , s_grainc, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_grainc_xfer_to_grainc        , s_grainc_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_grainc_storage_to_xfer       , s_grainc_storage, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_gresp_storage_to_xfer        , s_gresp_storage,nelms)
+
+  call spm_list_to_mat(spm_list, spm_carbon_d, nelms, f_gresp_storage_to_xfer)
+
+  call spm_list_init(spm_list, 0._r8, f_cpool_to_leafc               , s_cpool, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_leafc             , s_leafc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_leafc_xfer_to_leafc        , s_leafc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_leafc_storage_to_xfer      , s_leafc_xfer, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_leafc_storage     , s_leafc_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_frootc            , s_frootc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_frootc_xfer_to_frootc      , s_frootc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_frootc_storage_to_xfer     , s_frootc_xfer, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_frootc_storage    , s_frootc_sotrage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_livestemc         , s_livestemc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livestemc_xfer_to_livestemc, s_livestemc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livestemc_storage_to_xfer  , s_livestemc_xfer, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_livestemc_storage , s_livestemc_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_deadstemc_xfer_to_deadstemc, s_deadstemc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_deadstemc         , s_deadstemc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livestemc_to_deadstemc     , s_deadstemc,nelms)
+  call spm_list_insert(spm_list, 1._r8, f_deadstemc_storage_to_xfer  , s_deadstemc_xfer, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_deadstemc_storage , s_deadstemc_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_livecrootc        , s_livecrootc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livecrootc_xfer_to_livecrootc, s_livecrootc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livecrootc_storage_to_xfer , s_livecrootc_xfer, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_livecrootc_storage, s_livecrootc_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_deadcrootc        , s_deadcrootc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livecrootc_to_deadcrootc   , s_deadcrootc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_deadcrootc_xfer_to_deadcrootc, s_deadcrootc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_deadcrootc_storage_to_xfer , s_deadcrootc_xfer,nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_deadcrootc_storage, s_deadcrootc_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_grainc_xfer_to_grainc      , s_grainc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_grainc            , s_grainc, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_grainc_storage_to_xfer     , s_grainc_xfer, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_grainc_storage    , s_grainc_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_gresp_storage_to_xfer      , s_gresp_xfer,nelms)
+  call spm_list_insert(spm_list, 1._r8, f_cpool_to_gresp_storage     , s_gresp_storage, nelms)
+
+  call spm_list_to_mat(spm_list, spm_carbon_p, nelms, f_gresp_storage_to_xfer)
+
+  call spm_list_init(spm_list, -1._r8, f_npool_to_leafn                 , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_leafn_storage       , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_frootn              , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_frootn_storage      , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_livestemn           , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_livestemn_storage   , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_deadstemn           , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_deadstemn_storage   , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_livecrootn          , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_livecrootn_storage  , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_deadcrootn          , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_deadcrootn_storage  , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_grainn              , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_npool_to_grainn_storage      , s_npool, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_leafn_to_litter              , s_leafn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_leafn_to_retransn            , s_leafn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_leafn_xfer_to_leafn          , s_leafn_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_leafn_storage_to_xfer        , s_leafn_storage, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_frootn_to_litter             , s_frootn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_frootn_to_retransn           , s_frootn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_frootn_xfer_to_frootn        , s_frootn_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_frootn_storage_to_xfer       , s_frootn_sotrage, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livestemn_to_litter          , s_livestemn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livestemn_to_retransn        , s_livestemn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livestemn_to_deadstemn       , s_livestemn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livestemn_xfer_to_livestemn  , s_livestemn_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livestemn_storage_to_xfer    , s_livestemn_storage,nelms)
+  call spm_list_insert(spm_list, -1._r8, f_deadstemn_xfer_to_deadstem   , s_deadstemn_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_deadstemn_storage_to_xfer    , s_deadstemn_storage, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livecrootn_to_deadcrootn     , s_livecrootn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livecrootn_to_retransn       , s_livecrootn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livecrootn_xfer_to_livecrootn, s_livecrootn_xfer, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_livecrootn_storage_to_xfer   , s_livecrootn_storage,nelms)
+  call spm_list_insert(spm_list, -1._r8, f_deadcrootn_xfer_to_deadcrootn, s_deadcrootn_xfer,nelms)
+  call spm_list_insert(spm_list, -1._r8, f_deadcrootn_storage_to_xfer   , s_deadcrootn_storage,nelms)
+  call spm_list_insert(spm_list, -1._r8, f_grainn_to_food               , s_grainn, nelms)
+  call spm_list_insert(spm_list, -1._r8, f_grainn_xfer_to_grainn        , s_grainn_xfer,nelms)
+  call spm_list_insert(spm_list, -1._r8, f_retransn_to_npool            , s_retransn, nelms)
+
+  call spm_list_to_mat(spm_list, spm_nutrient_d, nelms, f_supplement_to_plantn)
+
+  call spm_list_init(spm_list, 1._r8, f_retransn_to_npool                , s_npool, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_supplement_to_plantn           , s_npool, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_leafn                 , s_leafn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_leafn_xfer_to_leafn            , s_leafn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_leafn_storage_to_xfer          , s_leafn_xfer, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_leafn_storage         , s_leafn_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_frootn                , s_frootn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_frootn_xfer_to_frootn          , s_frootn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_frootn_storage_to_xfer         , s_frootn_xfer, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_frootn_storage        , s_frootn_sotrage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_livestemn             , s_livestemn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livestemn_xfer_to_livestemn    , s_livestemn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livestemn_storage_to_xfer      , s_livestemn_xfer,nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_livestemn_storage     , s_livestemn_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_deadstemn             , s_deadstemn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livestemn_to_deadstemn         , s_deadstemn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_deadstemn_xfer_to_deadstem     , s_deadstemn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_deadstemn_storage_to_xfer      , s_deadstemn_xfer, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_deadstemn_storage     , s_deadstemn_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_livecrootn            , s_livecrootn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livecrootn_xfer_to_livecrootn  , s_livecrootn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livecrootn_storage_to_xfer     , s_livecrootn_xfer,nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_livecrootn_storage    , s_livecrootn_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_deadcrootn            , s_deadcrootn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livecrootn_to_deadcrootn       , s_deadcrootn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_deadcrootn_xfer_to_deadcrootn  , s_deadcrootn,nelms)
+  call spm_list_insert(spm_list, 1._r8, f_deadcrootn_storage_to_xfer     , s_deadcrootn_xfer,nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_deadcrootn_storage    , s_deadcrootn_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_grainn_xfer_to_grainn          , s_grainn,nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_grainn                , s_grainn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_npool_to_grainn_storage        , s_grainn_storage, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_leafn_to_retransn              , s_retransn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_frootn_to_retransn             , s_retransn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livestemn_to_retransn          , s_retransn, nelms)
+  call spm_list_insert(spm_list, 1._r8, f_livecrootn_to_retransn         , s_retransn, nelms)
+
+  call spm_list_to_mat(spm_list, spm_nutrient_p, nelms, f_supplement_to_plantn)
+  end subroutine InitPhenoFluxLimiter
+!---------------------------------------------------------------------------
+  subroutine phenology_flux_limiter(bounds, num_soilc, filter_soilc,&
+      num_soilp, filter_soilp, crop_vars, cnstate_vars,  &
+      carbonflux_vars, carbonstate_vars, &
+      c13_carbonflux_vars, c13_carbonstate_vars, &
+      c14_carbonflux_vars, c14_carbonstate_vars, &
+      nitrogenflux_vars, nitrogenstate_vars, &
+      phosphorusflux_vars, phosphorusstate_vars)
+
+    use decompMod           , only : bounds_type
+    use CropType                  , only : crop_type
+    use CNStateType               , only : cnstate_type
+    use CNCarbonFluxType          , only : carbonflux_type
+    use CNCarbonStateType         , only : carbonstate_type
+    use CNNitrogenFluxType        , only : nitrogenflux_type
+    use CNNitrogenStateType       , only : nitrogenstate_type
+    use PhosphorusFluxType        , only : phosphorusflux_type
+    use PhosphorusStateType       , only : phosphorusstate_type
+    use clm_varctl          , only : use_c13, use_c14
+    implicit none
+    ! !ARGUMENTS:
+    type(bounds_type)      , intent(in)    :: bounds
+    integer                , intent(in)    :: num_soilc       ! number of soil columns filter
+    integer                , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    integer                , intent(in)    :: num_soilp       ! number of soil patches in filter
+    integer                , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    type(crop_type)        , intent(inout) :: crop_vars
+    type(cnstate_type)       , intent(in)    :: cnstate_vars
+    type(carbonflux_type)  , intent(inout) :: carbonflux_vars
+    type(carbonstate_type) , intent(inout) :: carbonstate_vars
+    type(carbonflux_type)  , intent(inout) :: c13_carbonflux_vars
+    type(carbonstate_type) , intent(inout) :: c13_carbonstate_vars
+    type(carbonflux_type)  , intent(inout) :: c14_carbonflux_vars
+    type(carbonstate_type) , intent(inout) :: c14_carbonstate_vars
+    type(nitrogenflux_type)  , intent(inout) :: nitrogenflux_vars
+    type(nitrogenstate_type) , intent(inout) :: nitrogenstate_vars
+    type(phosphorusflux_type)  , intent(inout) :: phosphorusflux_vars
+    type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+
+  call carbon_flux_limiter(bounds, num_soilc, filter_soilc,&
+      num_soilp, filter_soilp, crop_vars,  &
+      carbonflux_vars, carbonstate_vars)
+
+  if (use_c13)then
+    call carbon_flux_limiter(bounds, num_soilc, filter_soilc,&
+      num_soilp, filter_soilp, crop_vars,  &
+      c13_carbonflux_vars, c13_carbonstate_vars)
+  endif
+
+  if (use_c14)then
+    call carbon_flux_limiter(bounds, num_soilc, filter_soilc,&
+      num_soilp, filter_soilp, crop_vars,  &
+      c14_carbonflux_vars, c14_carbonstate_vars)
+  endif
+
+  call nitrogen_flux_limiter(bounds, num_soilc, filter_soilc,&
+      num_soilp, filter_soilp, cnstate_vars,  &
+      nitrogenflux_vars, nitrogenstate_vars)
+
+  call phosphorus_flux_limiter(bounds, num_soilc, filter_soilc,&
+      num_soilp, filter_soilp, cnstate_vars,  &
+      phosphorusflux_vars, phosphorusstate_vars)
+
+
+  end subroutine phenology_flux_limiter
+  !-------------------------------------------------------------------------------
+
+  subroutine carbon_flux_limiter(bounds, num_soilc, filter_soilc,&
+      num_soilp, filter_soilp, crop_vars,  &
+      carbonflux_vars, carbonstate_vars)
+
+    use decompMod           , only : bounds_type
+    use CropType                  , only : crop_type
+    use CNCarbonFluxType          , only : carbonflux_type
+    use CNCarbonStateType         , only : carbonstate_type
+    ! !ARGUMENTS:
+    type(bounds_type)      , intent(in)    :: bounds
+    integer                , intent(in)    :: num_soilc       ! number of soil columns filter
+    integer                , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    integer                , intent(in)    :: num_soilp       ! number of soil patches in filter
+    integer                , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    type(crop_type)        , intent(inout) :: crop_vars
+    type(carbonflux_type)  , intent(inout) :: carbonflux_vars
+    type(carbonstate_type) , intent(inout) :: carbonstate_vars
+
+  integer :: fp, p
+  real(r8) :: ystates(n_carbon_states)
+  real(r8) :: rfluxes(n_carbon_fluxes)
+  real(r8) :: rscal
+  real(r8) :: dt
+  real(r8) :: ar_p
+  associate(                                                    &
+         ivt                   =>    veg_pp%itype             , & ! Input:  [integer  (:)     ]  pft vegetation type
+         woody                 =>    veg_vp%woody             , & ! Input:  [real(r8) (:)     ]  binary flag for woody lifeform (1=woody, 0=not woody)
+         harvdate              =>    crop_vars%harvdate_patch , & ! Input:  [integer  (:)     ]  harvest date
+         cf                    => carbonflux_vars             , &
+         cs                    => carbonstate_vars              &
+         )
+  ! set time steps
+  dt = real( get_step_size(), r8 )
+
+  do fp = 1,num_soilp
+    p = filter_soilp(fp)
+    !assemble state variables
+    ystates(:)=0._r8
+    mov(ystates(s_cpool)              , cs%cpool_patch(p))
+    mov(ystates(s_leafc)              , cs%leafc_patch(p))
+    mov(ystates(s_leafc_xfer)         , cs%leafc_xfer_patch(p))
+    mov(ystates(s_leafc_storage)      , cs%leafc_storage_patch(p))
+    mov(ystates(s_frootc)             , cs%frootc_patch(p))
+    mov(ystates(s_frootc_xfer)        , cs%frootc_xfer_patch(p))
+    mov(ystates(s_frootc_sotrage)     , cs%frootc_storage_patch(p))
+    if (woody(ivt(p)) == 1._r8) then
+      mov(ystates(s_livestemc)          , cs%livestemc_patch(p))
+      mov(ystates(s_livestemc_xfer)     , cs%livestemc_xfer_patch(p))
+      mov(ystates(s_livestemc_storage)  , cs%livestemc_storage_patch(p))
+      mov(ystates(s_livecrootc)         , cs%livecrootc_patch(p))
+      mov(ystates(s_livecrootc_xfer)    , cs%livecrootc_xfer_patch(p))
+      mov(ystates(s_livecrootc_storage) , cs%livecrootc_storage_patch(p))
+      mov(ystates(s_deadstemc)          , cs%deadstemc_patch(p))
+      mov(ystates(s_deadstemc_xfer)     , cs%deadstemc_xfer_patch(p))
+      mov(ystates(s_deadstemc_storage)  , cs%deadstemc_storage_patch(p))
+      mov(ystates(s_deadcrootc)         , cs%deadcrootc_patch(p))
+      mov(ystates(s_deadcrootc_xfer)    , cs%deadcrootc_xfer_patch(p))
+      mov(ystates(s_deadcrootc_storage) , cs%deadcrootc_storage_patch(p))
+    endif
+    if (ivt(p) >= npcropmin) then
+      mov(ystates(s_livestemc)          , cs%livestemc_patch(p))
+      mov(ystates(s_livestemc_xfer)     , cs%livestemc_xfer_patch(p))
+      mov(ystates(s_livestemc_storage)  , cs%livestemc_storage_patch(p))
+      mov(ystates(s_grainc)             , cs%grainc_patch(p))
+      mov(ystates(s_grainc_xfer)        , cs%grainc_xfer_patch(p))
+      mov(ystates(s_grainc_storage)     , cs%grainc_storage_patch(p))
+    endif
+    mov(ystates(s_gresp_xfer)         , cs%gresp_xfer_patch(p))
+    mov(ystates(s_gresp_storage)      , cs%gresp_storage_patch(p))
+
+    rfluxes(:) = 0._r8
+    ar_p = cf%leaf_curmr_patch(p)             &
+         + cf%froot_curmr_patch(p)            &
+         + cf%cpool_leaf_gr_patch(p)          &
+         + cf%cpool_froot_gr_patch(p)         &
+         + cf%cpool_leaf_storage_gr_patch(p)  &
+         + cf%cpool_froot_storage_gr_patch(p)
+    if (woody(ivt(p)) == 1._r8) then
+      ar_p = ar_p                                 &
+         + cf%livestem_curmr_patch(p)             &
+         + cf%livecroot_curmr_patch(p)            &
+         + cf%cpool_livestem_gr_patch(p)          &
+         + cf%cpool_deadstem_gr_patch(p)          &
+         + cf%cpool_livecroot_gr_patch(p)         &
+         + cf%cpool_deadcroot_gr_patch(p)         &
+         + cf%cpool_livestem_storage_gr_patch(p)  &
+         + cf%cpool_deadstem_storage_gr_patch(p)  &
+         + cf%cpool_livecroot_storage_gr_patch(p) &
+         + cf%cpool_deadcroot_storage_gr_patch(p)
+    endif
+    if (ivt(p) >= npcropmin) then
+      ar_p= ar_p                                 &
+        + cf%livestem_curmr_patch(p)             &
+        + cf%grain_curmr_patch(p)                &
+        + cf%cpool_livestem_gr_patch(p)          &
+        + cf%cpool_grain_gr_patch(p)             &
+        + cf%cpool_livestem_storage_gr_patch(p)  &
+        + cf%cpool_grain_storage_gr_patch(p)
+    endif
+    !assemble reactive fluxes
+    mov(rfluxes(f_cpool_to_leafc)               , cf%cpool_to_leafc_patch(p))
+    mov(rfluxes(f_cpool_to_leafc_storage)       , cf%cpool_to_leafc_storage_patch(p))
+    mov(rfluxes(f_cpool_to_frootc)              , cf%cpool_to_frootc_patch(p))
+    mov(rfluxes(f_cpool_to_frootc_storage)      , cf%cpool_to_frootc_storage_patch(p))
+    mov(rfluxes(f_cpool_to_xsmrpool)            , cf%cpool_to_xsmrpool_patch(p))
+    mov(rfluxes(f_cpool_to_gresp_storage)       , cf%cpool_to_gresp_storage_patch(p))
+    mov(rfluxes(f_cpool_to_ar)                  , ar_p)
+    if (woody(ivt(p)) == 1._r8) then
+      mov(rfluxes(f_cpool_to_livestemc)           , cf%cpool_to_livestemc_patch(p))
+      mov(rfluxes(f_cpool_to_livestemc_storage)   , cf%cpool_to_livestemc_storage_patch(p))
+      mov(rfluxes(f_cpool_to_deadstemc)           , cf%cpool_to_deadstemc_patch(p))
+      mov(rfluxes(f_cpool_to_deadstemc_storage)   , cf%cpool_to_deadstemc_storage_patch(p))
+      mov(rfluxes(f_cpool_to_livecrootc)          , cf%cpool_to_livecrootc_patch(p))
+      mov(rfluxes(f_cpool_to_livecrootc_storage)  , cf%cpool_to_livecrootc_storage_patch(p))
+      mov(rfluxes(f_cpool_to_deadcrootc)          , cf%cpool_to_deadcrootc_patch(p))
+      mov(rfluxes(f_cpool_to_deadcrootc_storage)  , cf%cpool_to_deadcrootc_storage_patch(p))
+      mov(rfluxes(f_livestemc_to_deadstemc)       , cf%livestemc_to_deadstemc_patch(p))
+      mov(rfluxes(f_livestemc_xfer_to_livestemc)  , cf%livestemc_xfer_to_livestemc_patch(p))
+      mov(rfluxes(f_livestemc_storage_to_xfer)    , cf%livestemc_storage_to_xfer_patch(p))
+      mov(rfluxes(f_deadstemc_xfer_to_deadstemc)  , cf%deadstemc_xfer_to_deadstemc_patch(p))
+      mov(rfluxes(f_deadstemc_storage_to_xfer)    , cf%deadstemc_storage_to_xfer_patch(p))
+      mov(rfluxes(f_livecrootc_xfer_to_livecrootc), cf%livecrootc_xfer_to_livecrootc_patch(p))
+      mov(rfluxes(f_livecrootc_storage_to_xfer)   , cf%livecrootc_storage_to_xfer_patch(p))
+      mov(rfluxes(f_livecrootc_to_deadcrootc)     , cf%livecrootc_to_deadcrootc_patch(p))
+      mov(rfluxes(f_deadcrootc_xfer_to_deadcrootc), cf%deadcrootc_xfer_to_deadcrootc_patch(p))
+      mov(rfluxes(f_deadcrootc_storage_to_xfer)   , cf%deadcrootc_storage_to_xfer_patch(p))
+      mov(rfluxes(f_gresp_storage_to_xfer)        , cf%gresp_storage_to_xfer_patch(p))
+    endif
+    if (ivt(p) >= npcropmin) then
+      mov(rfluxes(f_cpool_to_livestemc)           , cf%cpool_to_livestemc_patch(p))
+      mov(rfluxes(f_cpool_to_livestemc_storage)   , cf%cpool_to_livestemc_storage_patch(p))
+      mov(rfluxes(f_cpool_to_grainc)              , cf%cpool_to_grainc_patch(p))
+      mov(rfluxes(f_cpool_to_grainc_storage)      , cf%cpool_to_grainc_storage_patch(p))
+      mov(rfluxes(f_livestemc_xfer_to_livestemc)  , cf%livestemc_xfer_to_livestemc_patch(p))
+      mov(rfluxes(f_livestemc_storage_to_xfer)    , cf%livestemc_storage_to_xfer_patch(p))
+      mov(rfluxes(f_livestemc_to_litter)          , cf%livestemc_to_litter_patch(p))
+      mov(rfluxes(f_grainc_to_food)               , cf%grainc_to_food_patch(p))
+      mov(rfluxes(f_grainc_xfer_to_grainc)        , cf%grainc_xfer_to_grainc_patch(p))
+      mov(rfluxes(f_grainc_storage_to_xfer)       , cf%grainc_storage_to_xfer_patch(p))
+    endif
+    mov(rfluxes(f_leafc_to_litter)              , cf%leafc_to_litter_patch(p))
+    mov(rfluxes(f_leafc_xfer_to_leafc)          , cf%leafc_xfer_to_leafc_patch(p))
+    mov(rfluxes(f_leafc_storage_to_xfer)        , cf%leafc_storage_to_xfer_patch(p))
+    mov(rfluxes(f_frootc_to_litter)             , cf%frootc_to_litter_patch(p))
+    mov(rfluxes(f_frootc_xfer_to_frootc)        , cf%frootc_xfer_to_frootc_patch(p))
+    mov(rfluxes(f_frootc_storage_to_xfer)       , cf%frootc_storage_to_xfer_patch(p))
+
+    !obtain the limiting factor
+
+    call flux_correction(spm_carbon_d%szrow, spm_carbon_d%szcol, spm_carbon_p, &
+       spm_carbon_d, dt, ystates, rfluxes)
+
+    !correct the fluxes
+
+    imov(rfluxes(f_cpool_to_leafc)               , cf%cpool_to_leafc_patch(p))
+    imov(rfluxes(f_cpool_to_leafc_storage)       , cf%cpool_to_leafc_storage_patch(p))
+    imov(rfluxes(f_cpool_to_frootc)              , cf%cpool_to_frootc_patch(p))
+    imov(rfluxes(f_cpool_to_frootc_storage)      , cf%cpool_to_frootc_storage_patch(p))
+    imov(rfluxes(f_cpool_to_xsmrpool)            , cf%cpool_to_xsmrpool_patch(p))
+    imov(rfluxes(f_cpool_to_gresp_storage)       , cf%cpool_to_gresp_storage_patch(p))
+
+    if (woody(ivt(p)) == 1._r8) then
+      imov(rfluxes(f_cpool_to_livestemc)           , cf%cpool_to_livestemc_patch(p))
+      imov(rfluxes(f_cpool_to_livestemc_storage)   , cf%cpool_to_livestemc_storage_patch(p))
+      imov(rfluxes(f_cpool_to_deadstemc)           , cf%cpool_to_deadstemc_patch(p))
+      imov(rfluxes(f_cpool_to_deadstemc_storage)   , cf%cpool_to_deadstemc_storage_patch(p))
+      imov(rfluxes(f_cpool_to_livecrootc)          , cf%cpool_to_livecrootc_patch(p))
+      imov(rfluxes(f_cpool_to_livecrootc_storage)  , cf%cpool_to_livecrootc_storage_patch(p))
+      imov(rfluxes(f_cpool_to_deadcrootc)          , cf%cpool_to_deadcrootc_patch(p))
+      imov(rfluxes(f_cpool_to_deadcrootc_storage)  , cf%cpool_to_deadcrootc_storage_patch(p))
+      imov(rfluxes(f_livestemc_to_deadstemc)       , cf%livestemc_to_deadstemc_patch(p))
+      imov(rfluxes(f_livestemc_xfer_to_livestemc)  , cf%livestemc_xfer_to_livestemc_patch(p))
+      imov(rfluxes(f_livestemc_storage_to_xfer)    , cf%livestemc_storage_to_xfer_patch(p))
+      imov(rfluxes(f_deadstemc_xfer_to_deadstemc)  , cf%deadstemc_xfer_to_deadstemc_patch(p))
+      imov(rfluxes(f_deadstemc_storage_to_xfer)    , cf%deadstemc_storage_to_xfer_patch(p))
+      imov(rfluxes(f_livecrootc_xfer_to_livecrootc), cf%livecrootc_xfer_to_livecrootc_patch(p))
+      imov(rfluxes(f_livecrootc_storage_to_xfer)   , cf%livecrootc_storage_to_xfer_patch(p))
+      imov(rfluxes(f_livecrootc_to_deadcrootc)     , cf%livecrootc_to_deadcrootc_patch(p))
+      imov(rfluxes(f_deadcrootc_xfer_to_deadcrootc), cf%deadcrootc_xfer_to_deadcrootc_patch(p))
+      imov(rfluxes(f_deadcrootc_storage_to_xfer)   , cf%deadcrootc_storage_to_xfer_patch(p))
+      imov(rfluxes(f_gresp_storage_to_xfer)        , cf%gresp_storage_to_xfer_patch(p))
+    endif
+    if (ivt(p) >= npcropmin) then
+      imov(rfluxes(f_cpool_to_livestemc)           , cf%cpool_to_livestemc_patch(p))
+      imov(rfluxes(f_cpool_to_livestemc_storage)   , cf%cpool_to_livestemc_storage_patch(p))
+      imov(rfluxes(f_cpool_to_grainc)              , cf%cpool_to_grainc_patch(p))
+      imov(rfluxes(f_cpool_to_grainc_storage)      , cf%cpool_to_grainc_storage_patch(p))
+      imov(rfluxes(f_livestemc_xfer_to_livestemc)  , cf%livestemc_xfer_to_livestemc_patch(p))
+      imov(rfluxes(f_livestemc_storage_to_xfer)    , cf%livestemc_storage_to_xfer_patch(p))
+      imov(rfluxes(f_livestemc_to_litter)          , cf%livestemc_to_litter_patch(p))
+      imov(rfluxes(f_grainc_to_food)               , cf%grainc_to_food_patch(p))
+      imov(rfluxes(f_grainc_xfer_to_grainc)        , cf%grainc_xfer_to_grainc_patch(p))
+      imov(rfluxes(f_grainc_storage_to_xfer)       , cf%grainc_storage_to_xfer_patch(p))
+    endif
+    imov(rfluxes(f_leafc_to_litter)              , cf%leafc_to_litter_patch(p))
+    imov(rfluxes(f_leafc_xfer_to_leafc)          , cf%leafc_xfer_to_leafc_patch(p))
+    imov(rfluxes(f_leafc_storage_to_xfer)        , cf%leafc_storage_to_xfer_patch(p))
+    imov(rfluxes(f_frootc_to_litter)             , cf%frootc_to_litter_patch(p))
+    imov(rfluxes(f_frootc_xfer_to_frootc)        , cf%frootc_xfer_to_frootc_patch(p))
+    imov(rfluxes(f_frootc_storage_to_xfer)       , cf%frootc_storage_to_xfer_patch(p))
+
+    if(rfluxes(f_cpool_to_ar)  <  ar_p)then
+      rscal= rfluxes(f_cpool_to_ar)/ar_p
+      ascal(cf%leaf_curmr_patch(p)                , rscal)
+      ascal(cf%froot_curmr_patch(p)               , rscal)
+      ascal(cf%cpool_leaf_gr_patch(p)             , rscal)
+      ascal(cf%cpool_froot_gr_patch(p)            , rscal)
+      ascal(cf%cpool_leaf_storage_gr_patch(p)     , rscal)
+      ascal(cf%cpool_froot_storage_gr_patch(p)    , rscal)
+      if (woody(ivt(p)) == 1._r8) then
+        ascal(cf%livestem_curmr_patch(p)            , rscal)
+        ascal(cf%livecroot_curmr_patch(p)           , rscal)
+        ascal(cf%cpool_livestem_gr_patch(p)         , rscal)
+        ascal(cf%cpool_deadstem_gr_patch(p)         , rscal)
+        ascal(cf%cpool_livecroot_gr_patch(p)        , rscal)
+        ascal(cf%cpool_deadcroot_gr_patch(p)        , rscal)
+        ascal(cf%cpool_livestem_storage_gr_patch(p) , rscal)
+        ascal(cf%cpool_deadstem_storage_gr_patch(p) , rscal)
+        ascal(cf%cpool_livecroot_storage_gr_patch(p), rscal)
+        ascal(cf%cpool_deadcroot_storage_gr_patch(p), rscal)
+      endif
+      if (ivt(p) >= npcropmin) then
+        ascal(cf%livestem_curmr_patch(p)            , rscal)
+        ascal(cf%grain_curmr_patch(p)               , rscal)
+        ascal(cf%cpool_livestem_gr_patch(p)         , rscal)
+        ascal(cf%cpool_grain_gr_patch(p)            , rscal)
+        ascal(cf%cpool_livestem_storage_gr_patch(p) , rscal)
+        ascal(cf%cpool_grain_storage_gr_patch(p)    , rscal)
+      endif
+    endif
+  enddo
+  end associate
+  end subroutine carbon_flux_limiter
+!---------------------------------------------------------------------------
+  subroutine nitrogen_flux_limiter(bounds, num_soilc, filter_soilc,&
+      num_soilp, filter_soilp, cnstate_vars,  &
+      nitrogenflux_vars, nitrogenstate_vars)
+
+    use decompMod           , only : bounds_type
+    use CNStateType               , only : cnstate_type
+    use CNNitrogenFluxType        , only : nitrogenflux_type
+    use CNNitrogenStateType       , only : nitrogenstate_type
+    implicit none
+    ! !ARGUMENTS:
+    type(bounds_type)      , intent(in)    :: bounds
+    integer                , intent(in)    :: num_soilc       ! number of soil columns filter
+    integer                , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    integer                , intent(in)    :: num_soilp       ! number of soil patches in filter
+    integer                , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    type(cnstate_type)       , intent(in)    :: cnstate_vars
+    type(nitrogenflux_type)  , intent(inout) :: nitrogenflux_vars
+    type(nitrogenstate_type) , intent(inout) :: nitrogenstate_vars
+
+  integer :: fp, p
+  real(r8) :: ystates(n_nutrient_states)
+  real(r8) :: rfluxes(n_nutrient_fluxes)
+  real(r8) :: dt
+  associate(                                                       &
+         ivt                   => veg_pp%itype                   , & ! Input:  [integer  (:)     ]  pft vegetation type
+         woody                 => veg_vp%woody                   , & ! Input:  [real(r8) (:)     ]  binary flag for woody lifeform (1=woody, 0=not woody)
+         nf                    => nitrogenflux_vars              , &
+         ns                    => nitrogenstate_vars               &
+  )
+  ! set time steps
+  dt = real( get_step_size(), r8 )
+  do fp = 1,num_soilp
+    p = filter_soilp(fp)
+    ystates(:) = 0._r8
+    !assemble state variables
+    mov(ystates(s_npool)               , ns%npool_patch(p))
+    mov(ystates(s_leafn)               , ns%leafn_patch(p))
+    mov(ystates(s_leafn_xfer)          , ns%leafn_xfer_patch(p))
+    mov(ystates(s_leafn_storage)       , nf%npool_to_leafn_storage_patch(p))
+    mov(ystates(s_frootn)              , ns%frootn_patch(p))
+    mov(ystates(s_frootn_xfer)         , ns%frootn_xfer_patch(p))
+    mov(ystates(s_frootn_sotrage)      , ns%frootn_storage_patch(p))
+    if (woody(ivt(p)) == 1.0_r8) then
+      mov(ystates(s_livestemn)           , ns%livestemn_patch(p))
+      mov(ystates(s_livestemn_xfer)      , ns%livestemn_xfer_patch(p))
+      mov(ystates(s_livestemn_storage)   , ns%livestemn_storage_patch(p))
+      mov(ystates(s_deadstemn)           , ns%deadstemn_patch(p))
+      mov(ystates(s_deadstemn_xfer)      , ns%deadstemn_xfer_patch(p))
+      mov(ystates(s_deadstemn_storage)   , ns%deadstemn_storage_patch(p))
+      mov(ystates(s_livecrootn)          , ns%livecrootn_patch(p))
+      mov(ystates(s_livecrootn_xfer)     , ns%livecrootn_xfer_patch(p))
+      mov(ystates(s_livecrootn_storage)  , ns%livecrootn_storage_patch(p))
+      mov(ystates(s_deadcrootn)          , ns%deadcrootn_patch(p))
+      mov(ystates(s_deadcrootn_xfer)     , ns%deadcrootn_xfer_patch(p))
+      mov(ystates(s_deadcrootn_storage)  , ns%deadcrootn_storage_patch(p))
+    endif
+    if (ivt(p) >= npcropmin) then
+      mov(ystates(s_grainn)              , ns%grainn_patch(p))
+      mov(ystates(s_grainn_xfer)         , ns%grainn_xfer_patch(p))
+      mov(ystates(s_grainn_storage)      , ns%grainn_storage_patch(p))
+      mov(ystates(s_livestemn)           , ns%livestemn_patch(p))
+      mov(ystates(s_livestemn_xfer)      , ns%livestemn_xfer_patch(p))
+      mov(ystates(s_livestemn_storage)   , ns%livestemn_storage_patch(p))
+    endif
+    mov(ystates(s_retransn)            , ns%retransn_patch(p))
+
+    rfluxes(:) = 0._r8
+    !assemble reactive fluxes
+    mov(rfluxes(f_npool_to_leafn)                , nf%npool_to_leafn_patch(p))
+    mov(rfluxes(f_npool_to_leafn_storage)        , nf%npool_to_leafn_storage_patch(p))
+    mov(rfluxes(f_npool_to_frootn)               , nf%npool_to_frootn_patch(p))
+    mov(rfluxes(f_npool_to_frootn_storage)       , nf%npool_to_frootn_storage_patch(p))
+    if (woody(ivt(p)) == 1.0_r8) then
+      mov(rfluxes(f_npool_to_livestemn)            , nf%npool_to_livestemn_patch(p))
+      mov(rfluxes(f_npool_to_livestemn_storage)    , nf%npool_to_livestemn_storage_patch(p))
+      mov(rfluxes(f_npool_to_livecrootn)           , nf%npool_to_livecrootn_patch(p))
+      mov(rfluxes(f_npool_to_livecrootn_storage)   , nf%npool_to_livecrootn_storage_patch(p))
+      mov(rfluxes(f_npool_to_deadstemn)            , nf%npool_to_deadstemn_patch(p))
+      mov(rfluxes(f_npool_to_deadcrootn)           , nf%npool_to_deadcrootn_patch(p))
+      mov(rfluxes(f_npool_to_deadstemn_storage)    , nf%npool_to_deadstemn_storage_patch(p))
+      mov(rfluxes(f_npool_to_deadcrootn_storage)   , nf%npool_to_deadcrootn_storage_patch(p))
+      mov(rfluxes(f_livestemn_storage_to_xfer)     , nf%livestemn_storage_to_xfer_patch(p))
+      mov(rfluxes(f_livestemn_xfer_to_livestemn)   , nf%livestemn_xfer_to_livestemn_patch(p))
+      mov(rfluxes(f_livestemn_to_retransn)         , nf%livestemn_to_retransn_patch(p))
+      mov(rfluxes(f_livestemn_to_deadstemn)        , nf%livestemn_to_deadstemn_patch(p))
+      mov(rfluxes(f_livecrootn_to_deadcrootn)      , nf%livecrootn_to_deadcrootn_patch(p))
+      mov(rfluxes(f_livecrootn_to_retransn)        , nf%livecrootn_to_retransn_patch(p))
+      mov(rfluxes(f_livecrootn_storage_to_xfer)    , nf%livecrootn_storage_to_xfer_patch(p))
+      mov(rfluxes(f_livecrootn_xfer_to_livecrootn) , nf%livecrootn_xfer_to_livecrootn_patch(p))
+      mov(rfluxes(f_deadstemn_storage_to_xfer)     , nf%deadstemn_storage_to_xfer_patch(p))
+      mov(rfluxes(f_deadstemn_xfer_to_deadstem)    , nf%deadstemn_xfer_to_deadstemn_patch(p))
+      mov(rfluxes(f_deadcrootn_storage_to_xfer)    , nf%deadcrootn_storage_to_xfer_patch(p))
+      mov(rfluxes(f_deadcrootn_xfer_to_deadcrootn) , nf%deadcrootn_xfer_to_deadcrootn_patch(p))
+    endif
+
+    if (ivt(p) >= npcropmin) then
+      mov(rfluxes(f_npool_to_livestemn)            , nf%npool_to_livestemn_patch(p))
+      mov(rfluxes(f_npool_to_livestemn_storage)    , nf%npool_to_livestemn_storage_patch(p))
+      mov(rfluxes(f_npool_to_grainn)               , nf%npool_to_grainn_patch(p))
+      mov(rfluxes(f_npool_to_grainn_storage)       , nf%npool_to_grainn_storage_patch(p))
+      mov(rfluxes(f_frootn_to_retransn)            , nf%frootn_to_retransn_patch(p))
+      mov(rfluxes(f_livestemn_to_litter)           , nf%livestemn_to_litter_patch(p))
+      mov(rfluxes(f_livestemn_storage_to_xfer)     , nf%livestemn_storage_to_xfer_patch(p))
+      mov(rfluxes(f_livestemn_xfer_to_livestemn)   ,  nf%livestemn_xfer_to_livestemn_patch(p))
+      mov(rfluxes(f_livestemn_to_retransn)         , nf%livestemn_to_retransn_patch(p))
+      mov(rfluxes(f_grainn_xfer_to_grainn)         , nf%grainn_xfer_to_grainn_patch(p))
+      mov(rfluxes(f_grainn_to_food)                , nf%grainn_to_food_patch(p))
+    endif
+
+    mov(rfluxes(f_leafn_to_litter)               , nf%leafn_to_litter_patch(p))
+    mov(rfluxes(f_leafn_xfer_to_leafn)           , nf%leafn_xfer_to_leafn_patch(p))
+    mov(rfluxes(f_leafn_storage_to_xfer)         , nf%leafn_storage_to_xfer_patch(p))
+    mov(rfluxes(f_frootn_xfer_to_frootn)         , nf%frootn_xfer_to_frootn_patch(p))
+    mov(rfluxes(f_frootn_storage_to_xfer)        , nf%frootn_storage_to_xfer_patch(p))
+    mov(rfluxes(f_leafn_to_retransn)             , nf%leafn_to_retransn_patch(p))
+    mov(rfluxes(f_frootn_to_litter)              , nf%frootn_to_litter_patch(p))
+
+    mov(rfluxes(f_retransn_to_npool)             , nf%retransn_to_npool_patch(p))
+    mov(rfluxes(f_supplement_to_plantn)          , nf%supplement_to_plantn(p))
+
+    call flux_correction(spm_nutrient_d%szrow, spm_nutrient_d%szcol, spm_nutrient_p, &
+      spm_nutrient_d, dt, ystates, rfluxes)
+
+    !correct the fluxes
+    imov(rfluxes(f_npool_to_leafn)                , nf%npool_to_leafn_patch(p))
+    imov(rfluxes(f_npool_to_leafn_storage)        , nf%npool_to_leafn_storage_patch(p))
+    imov(rfluxes(f_npool_to_frootn)               , nf%npool_to_frootn_patch(p))
+    imov(rfluxes(f_npool_to_frootn_storage)       , nf%npool_to_frootn_storage_patch(p))
+    if (woody(ivt(p)) == 1.0_r8) then
+      imov(rfluxes(f_npool_to_livestemn)            , nf%npool_to_livestemn_patch(p))
+      imov(rfluxes(f_npool_to_livestemn_storage)    , nf%npool_to_livestemn_storage_patch(p))
+      imov(rfluxes(f_npool_to_livecrootn)           , nf%npool_to_livecrootn_patch(p))
+      imov(rfluxes(f_npool_to_livecrootn_storage)   , nf%npool_to_livecrootn_storage_patch(p))
+      imov(rfluxes(f_npool_to_deadstemn)            , nf%npool_to_deadstemn_patch(p))
+      imov(rfluxes(f_npool_to_deadcrootn)           , nf%npool_to_deadcrootn_patch(p))
+      imov(rfluxes(f_npool_to_deadstemn_storage)    , nf%npool_to_deadstemn_storage_patch(p))
+      imov(rfluxes(f_npool_to_deadcrootn_storage)   , nf%npool_to_deadcrootn_storage_patch(p))
+      imov(rfluxes(f_livestemn_storage_to_xfer)     , nf%livestemn_storage_to_xfer_patch(p))
+      imov(rfluxes(f_livestemn_xfer_to_livestemn)   , nf%livestemn_xfer_to_livestemn_patch(p))
+      imov(rfluxes(f_livestemn_to_retransn)         , nf%livestemn_to_retransn_patch(p))
+      imov(rfluxes(f_livestemn_to_deadstemn)        , nf%livestemn_to_deadstemn_patch(p))
+      imov(rfluxes(f_livecrootn_to_deadcrootn)      , nf%livecrootn_to_deadcrootn_patch(p))
+      imov(rfluxes(f_livecrootn_to_retransn)        , nf%livecrootn_to_retransn_patch(p))
+      imov(rfluxes(f_livecrootn_storage_to_xfer)    , nf%livecrootn_storage_to_xfer_patch(p))
+      imov(rfluxes(f_livecrootn_xfer_to_livecrootn) , nf%livecrootn_xfer_to_livecrootn_patch(p))
+      imov(rfluxes(f_deadstemn_storage_to_xfer)     , nf%deadstemn_storage_to_xfer_patch(p))
+      imov(rfluxes(f_deadstemn_xfer_to_deadstem)    , nf%deadstemn_xfer_to_deadstemn_patch(p))
+      imov(rfluxes(f_deadcrootn_storage_to_xfer)    , nf%deadcrootn_storage_to_xfer_patch(p))
+      imov(rfluxes(f_deadcrootn_xfer_to_deadcrootn) , nf%deadcrootn_xfer_to_deadcrootn_patch(p))
+    endif
+
+    if (ivt(p) >= npcropmin) then
+      imov(rfluxes(f_npool_to_livestemn)            , nf%npool_to_livestemn_patch(p))
+      imov(rfluxes(f_npool_to_livestemn_storage)    , nf%npool_to_livestemn_storage_patch(p))
+      imov(rfluxes(f_npool_to_grainn)               , nf%npool_to_grainn_patch(p))
+      imov(rfluxes(f_npool_to_grainn_storage)       , nf%npool_to_grainn_storage_patch(p))
+      imov(rfluxes(f_frootn_to_retransn)            , nf%frootn_to_retransn_patch(p))
+      imov(rfluxes(f_livestemn_to_litter)           , nf%livestemn_to_litter_patch(p))
+      imov(rfluxes(f_livestemn_storage_to_xfer)     , nf%livestemn_storage_to_xfer_patch(p))
+      imov(rfluxes(f_livestemn_xfer_to_livestemn)   ,  nf%livestemn_xfer_to_livestemn_patch(p))
+      imov(rfluxes(f_livestemn_to_retransn)         , nf%livestemn_to_retransn_patch(p))
+      imov(rfluxes(f_grainn_xfer_to_grainn)         , nf%grainn_xfer_to_grainn_patch(p))
+      imov(rfluxes(f_grainn_to_food)                , nf%grainn_to_food_patch(p))
+    endif
+
+    mov(rfluxes(f_leafn_to_litter)               , nf%leafn_to_litter_patch(p))
+    mov(rfluxes(f_leafn_xfer_to_leafn)           , nf%leafn_xfer_to_leafn_patch(p))
+    mov(rfluxes(f_leafn_storage_to_xfer)         , nf%leafn_storage_to_xfer_patch(p))
+    mov(rfluxes(f_frootn_xfer_to_frootn)         , nf%frootn_xfer_to_frootn_patch(p))
+    mov(rfluxes(f_frootn_storage_to_xfer)        , nf%frootn_storage_to_xfer_patch(p))
+    mov(rfluxes(f_leafn_to_retransn)             , nf%leafn_to_retransn_patch(p))
+    mov(rfluxes(f_frootn_to_litter)              , nf%frootn_to_litter_patch(p))
+
+    mov(rfluxes(f_retransn_to_npool)             , nf%retransn_to_npool_patch(p))
+    mov(rfluxes(f_supplement_to_plantn)          , nf%supplement_to_plantn(p))
+
+  enddo
+  end associate
+  end subroutine nitrogen_flux_limiter
+
+  !-------------------------------------------------------------------------------
+  subroutine phosphorus_flux_limiter(bounds, num_soilc, filter_soilc,&
+      num_soilp, filter_soilp, cnstate_vars,  &
+      phosphorusflux_vars, phosphorusstate_vars)
+
+    use decompMod           , only : bounds_type
+    use CNStateType               , only : cnstate_type
+    use PhosphorusFluxType        , only : phosphorusflux_type
+    use PhosphorusStateType       , only : phosphorusstate_type
+    implicit none
+    ! !ARGUMENTS:
+    type(bounds_type)      , intent(in)    :: bounds
+    integer                , intent(in)    :: num_soilc       ! number of soil columns filter
+    integer                , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    integer                , intent(in)    :: num_soilp       ! number of soil patches in filter
+    integer                , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    type(cnstate_type)       , intent(in)    :: cnstate_vars
+    type(phosphorusflux_type)  , intent(inout) :: phosphorusflux_vars
+    type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+
+  integer :: fp, p
+  real(r8) :: ystates(n_nutrient_states)
+  real(r8) :: rfluxes(n_nutrient_fluxes)
+
+  real(r8) :: dt
+
+  associate(                                                     &
+    ivt                   => veg_pp%itype                      , & ! Input:  [integer  (:)     ]  pft vegetation type
+    woody                 => veg_vp%woody                      , & ! Input:  [real(r8) (:)     ]  binary flag for woody lifeform (1=woody, 0=not woody)
+    pf                    => phosphorusflux_vars               , &
+    ps                    => phosphorusstate_vars                &
+  )
+
+  ! set time steps
+  dt = real( get_step_size(), r8 )
+  do fp = 1,num_soilp
+    p = filter_soilp(fp)
+    ystates(:) = 0._r8
+    !assemble state variables
+    mov(ystates(s_npool)               , ps%ppool_patch(p))
+    mov(ystates(s_leafn)               , ps%leafp_patch(p))
+    mov(ystates(s_leafn_xfer)          , ps%leafp_xfer_patch(p))
+    mov(ystates(s_leafn_storage)       , ps%leafp_storage_patch(p))
+    mov(ystates(s_frootn)              , ps%frootp_patch(p))
+    mov(ystates(s_frootn_xfer)         , ps%frootp_xfer_patch(p))
+    mov(ystates(s_frootn_sotrage)      , pf%ppool_to_frootp_storage_patch(p))
+    if (woody(ivt(p)) == 1.0_r8) then
+      mov(ystates(s_livestemn)           , ps%livestemp_patch(p))
+      mov(ystates(s_livestemn_xfer)      , ps%livestemp_xfer_patch(p))
+      mov(ystates(s_livestemn_storage)   , ps%livestemp_storage_patch(p))
+      mov(ystates(s_deadstemn)           , ps%deadstemp_patch(p))
+      mov(ystates(s_deadstemn_xfer)      , ps%deadstemp_xfer_patch(p))
+      mov(ystates(s_deadstemn_storage)   , ps%deadstemp_storage_patch(p))
+      mov(ystates(s_livecrootn)          , ps%livecrootp_patch(p))
+      mov(ystates(s_livecrootn_xfer)     , ps%livecrootp_xfer_patch(p))
+      mov(ystates(s_livecrootn_storage)  , ps%livecrootp_storage_patch(p))
+      mov(ystates(s_deadcrootn)          , ps%deadcrootp_patch(p))
+      mov(ystates(s_deadcrootn_xfer)     , ps%deadcrootp_xfer_patch(p))
+      mov(ystates(s_deadcrootn_storage)  , ps%deadcrootp_storage_patch(p))
+    endif
+    if (ivt(p) >= npcropmin) then
+      mov(ystates(s_grainn)              , ps%grainp_patch(p))
+      mov(ystates(s_grainn_xfer)         , ps%grainp_xfer_patch(p))
+      mov(ystates(s_grainn_storage)      , ps%grainp_storage_patch(p))
+      mov(ystates(s_livestemn)           , ps%livestemp_patch(p))
+      mov(ystates(s_livestemn_xfer)      , ps%livestemp_xfer_patch(p))
+      mov(ystates(s_livestemn_storage)   , ps%livestemp_storage_patch(p))
+    endif
+    mov(ystates(s_retransn)              , ps%retransp_patch(p))
+
+    rfluxes(:) = 0._r8
+    !assemble reactive fluxes
+    mov(rfluxes(f_npool_to_leafn)                , pf%ppool_to_leafp_patch(p))
+    mov(rfluxes(f_npool_to_leafn_storage)        , pf%ppool_to_leafp_storage_patch(p))
+    mov(rfluxes(f_npool_to_frootn)               , pf%ppool_to_frootp_patch(p))
+    mov(rfluxes(f_npool_to_frootn_storage)       , pf%ppool_to_frootp_storage_patch(p))
+    if (woody(ivt(p)) == 1._r8) then
+      mov(rfluxes(f_npool_to_livestemn)            , pf%ppool_to_livestemp_patch(p))
+      mov(rfluxes(f_npool_to_livestemn_storage)    , pf%ppool_to_livestemp_storage_patch(p))
+      mov(rfluxes(f_npool_to_livecrootn)           , pf%ppool_to_livecrootp_patch(p))
+      mov(rfluxes(f_npool_to_livecrootn_storage)   , pf%ppool_to_livecrootp_storage_patch(p))
+      mov(rfluxes(f_npool_to_deadstemn)            , pf%ppool_to_deadstemp_patch(p))
+      mov(rfluxes(f_npool_to_deadcrootn)           , pf%ppool_to_deadcrootp_patch(p))
+      mov(rfluxes(f_npool_to_deadstemn_storage)    , pf%ppool_to_deadstemp_storage_patch(p))
+      mov(rfluxes(f_npool_to_deadcrootn_storage)   , pf%ppool_to_deadcrootp_storage_patch(p))
+      mov(rfluxes(f_livestemn_storage_to_xfer)     , pf%livestemp_storage_to_xfer_patch(p))
+      mov(rfluxes(f_livestemn_xfer_to_livestemn)   , pf%livestemp_xfer_to_livestemp_patch(p))
+      mov(rfluxes(f_livestemn_to_retransn)         , pf%livestemp_to_retransp_patch(p))
+      mov(rfluxes(f_livestemn_to_deadstemn)        , pf%livestemp_to_deadstemp_patch(p))
+      mov(rfluxes(f_livecrootn_to_deadcrootn)      , pf%livecrootp_to_deadcrootp_patch(p))
+      mov(rfluxes(f_livecrootn_to_retransn)        , pf%livecrootp_to_retransp_patch(p))
+      mov(rfluxes(f_livecrootn_storage_to_xfer)    , pf%livecrootp_storage_to_xfer_patch(p))
+      mov(rfluxes(f_livecrootn_xfer_to_livecrootn) , pf%livecrootp_xfer_to_livecrootp_patch(p))
+      mov(rfluxes(f_deadstemn_storage_to_xfer)     , pf%deadstemp_storage_to_xfer_patch(p))
+      mov(rfluxes(f_deadstemn_xfer_to_deadstem)    , pf%deadstemp_xfer_to_deadstemp_patch(p))
+      mov(rfluxes(f_deadcrootn_storage_to_xfer)    , pf%deadcrootp_storage_to_xfer_patch(p))
+      mov(rfluxes(f_deadcrootn_xfer_to_deadcrootn) , pf%deadcrootp_xfer_to_deadcrootp_patch(p))
+    endif
+
+    if (ivt(p) >= npcropmin) then
+      mov(rfluxes(f_npool_to_livestemn)            , pf%ppool_to_livestemp_patch(p))
+      mov(rfluxes(f_npool_to_livestemn_storage)    , pf%ppool_to_livestemp_storage_patch(p))
+      mov(rfluxes(f_npool_to_grainn)               , pf%ppool_to_grainp_patch(p))
+      mov(rfluxes(f_npool_to_grainn_storage)       , pf%ppool_to_grainp_storage_patch(p))
+      mov(rfluxes(f_frootn_to_retransn)            , pf%frootp_to_retransp_patch(p))
+      mov(rfluxes(f_livestemn_to_litter)           , pf%livestemp_to_litter_patch(p))
+      mov(rfluxes(f_livestemn_storage_to_xfer)     , pf%livestemp_storage_to_xfer_patch(p))
+      mov(rfluxes(f_livestemn_xfer_to_livestemn)   , pf%livestemp_xfer_to_livestemp_patch(p))
+      mov(rfluxes(f_livestemn_to_retransn)         , pf%livestemp_to_retransp_patch(p))
+      mov(rfluxes(f_grainn_xfer_to_grainn)         , pf%grainp_xfer_to_grainp_patch(p))
+      mov(rfluxes(f_grainn_to_food)                , pf%grainp_to_food_patch(p))
+    endif
+
+    mov(rfluxes(f_leafn_to_litter)               , pf%leafp_to_litter_patch(p))
+    mov(rfluxes(f_leafn_xfer_to_leafn)           , pf%leafp_xfer_to_leafp_patch(p))
+    mov(rfluxes(f_leafn_storage_to_xfer)         , pf%ppool_to_leafp_storage_patch(p))
+    mov(rfluxes(f_frootn_xfer_to_frootn)         , pf%frootp_xfer_to_frootp_patch(p))
+    mov(rfluxes(f_frootn_storage_to_xfer)        , pf%frootp_storage_to_xfer_patch(p))
+    mov(rfluxes(f_leafn_to_retransn)             , pf%leafp_to_retransp_patch(p))
+    mov(rfluxes(f_frootn_to_litter)              , pf%frootp_to_litter_patch(p))
+    mov(rfluxes(f_retransn_to_npool)             , pf%retransp_to_ppool_patch(p))
+    mov(rfluxes(f_supplement_to_plantn)          , pf%supplement_to_plantp(p))
+    !assemble stoichiometry matrix
+
+    !obtain the limiting factor
+    call flux_correction(spm_nutrient_d%szrow, spm_nutrient_d%szcol, spm_nutrient_p, &
+      spm_nutrient_d, dt, ystates, rfluxes)
+    !correct the fluxes
+    imov(rfluxes(f_npool_to_leafn)                , pf%ppool_to_leafp_patch(p))
+    imov(rfluxes(f_npool_to_leafn_storage)        , pf%ppool_to_leafp_storage_patch(p))
+    imov(rfluxes(f_npool_to_frootn)               , pf%ppool_to_frootp_patch(p))
+    imov(rfluxes(f_npool_to_frootn_storage)       , pf%ppool_to_frootp_storage_patch(p))
+    if (woody(ivt(p)) == 1._r8) then
+      imov(rfluxes(f_npool_to_livestemn)            , pf%ppool_to_livestemp_patch(p))
+      imov(rfluxes(f_npool_to_livestemn_storage)    , pf%ppool_to_livestemp_storage_patch(p))
+      imov(rfluxes(f_npool_to_livecrootn)           , pf%ppool_to_livecrootp_patch(p))
+      imov(rfluxes(f_npool_to_livecrootn_storage)   , pf%ppool_to_livecrootp_storage_patch(p))
+      imov(rfluxes(f_npool_to_deadstemn)            , pf%ppool_to_deadstemp_patch(p))
+      imov(rfluxes(f_npool_to_deadcrootn)           , pf%ppool_to_deadcrootp_patch(p))
+      imov(rfluxes(f_npool_to_deadstemn_storage)    , pf%ppool_to_deadstemp_storage_patch(p))
+      imov(rfluxes(f_npool_to_deadcrootn_storage)   , pf%ppool_to_deadcrootp_storage_patch(p))
+      imov(rfluxes(f_livestemn_storage_to_xfer)     , pf%livestemp_storage_to_xfer_patch(p))
+      imov(rfluxes(f_livestemn_xfer_to_livestemn)   , pf%livestemp_xfer_to_livestemp_patch(p))
+      imov(rfluxes(f_livestemn_to_retransn)         , pf%livestemp_to_retransp_patch(p))
+      imov(rfluxes(f_livestemn_to_deadstemn)        , pf%livestemp_to_deadstemp_patch(p))
+      imov(rfluxes(f_livecrootn_to_deadcrootn)      , pf%livecrootp_to_deadcrootp_patch(p))
+      imov(rfluxes(f_livecrootn_to_retransn)        , pf%livecrootp_to_retransp_patch(p))
+      imov(rfluxes(f_livecrootn_storage_to_xfer)    , pf%livecrootp_storage_to_xfer_patch(p))
+      imov(rfluxes(f_livecrootn_xfer_to_livecrootn) , pf%livecrootp_xfer_to_livecrootp_patch(p))
+      imov(rfluxes(f_deadstemn_storage_to_xfer)     , pf%deadstemp_storage_to_xfer_patch(p))
+      imov(rfluxes(f_deadstemn_xfer_to_deadstem)    , pf%deadstemp_xfer_to_deadstemp_patch(p))
+      imov(rfluxes(f_deadcrootn_storage_to_xfer)    , pf%deadcrootp_storage_to_xfer_patch(p))
+      imov(rfluxes(f_deadcrootn_xfer_to_deadcrootn) , pf%deadcrootp_xfer_to_deadcrootp_patch(p))
+    endif
+
+    if (ivt(p) >= npcropmin) then
+      imov(rfluxes(f_npool_to_livestemn)            , pf%ppool_to_livestemp_patch(p))
+      imov(rfluxes(f_npool_to_livestemn_storage)    , pf%ppool_to_livestemp_storage_patch(p))
+      imov(rfluxes(f_npool_to_grainn)               , pf%ppool_to_grainp_patch(p))
+      imov(rfluxes(f_npool_to_grainn_storage)       , pf%ppool_to_grainp_storage_patch(p))
+      imov(rfluxes(f_frootn_to_retransn)            , pf%frootp_to_retransp_patch(p))
+      imov(rfluxes(f_livestemn_to_litter)           , pf%livestemp_to_litter_patch(p))
+      imov(rfluxes(f_livestemn_storage_to_xfer)     , pf%livestemp_storage_to_xfer_patch(p))
+      imov(rfluxes(f_livestemn_xfer_to_livestemn)   , pf%livestemp_xfer_to_livestemp_patch(p))
+      imov(rfluxes(f_livestemn_to_retransn)         , pf%livestemp_to_retransp_patch(p))
+      imov(rfluxes(f_grainn_xfer_to_grainn)         , pf%grainp_xfer_to_grainp_patch(p))
+      imov(rfluxes(f_grainn_to_food)                , pf%grainp_to_food_patch(p))
+    endif
+
+    imov(rfluxes(f_leafn_to_litter)               , pf%leafp_to_litter_patch(p))
+    imov(rfluxes(f_leafn_xfer_to_leafn)           , pf%leafp_xfer_to_leafp_patch(p))
+    imov(rfluxes(f_leafn_storage_to_xfer)         , pf%ppool_to_leafp_storage_patch(p))
+    imov(rfluxes(f_frootn_xfer_to_frootn)         , pf%frootp_xfer_to_frootp_patch(p))
+    imov(rfluxes(f_frootn_storage_to_xfer)        , pf%frootp_storage_to_xfer_patch(p))
+    imov(rfluxes(f_leafn_to_retransn)             , pf%leafp_to_retransp_patch(p))
+    imov(rfluxes(f_frootn_to_litter)              , pf%frootp_to_litter_patch(p))
+    imov(rfluxes(f_retransn_to_npool)             , pf%retransp_to_ppool_patch(p))
+    imov(rfluxes(f_supplement_to_plantn)          , pf%supplement_to_plantp(p))
+
+  enddo
+  end associate
+  end subroutine phosphorus_flux_limiter
+
+end module PhenologyFLuxLimitMod

--- a/components/clm/src/biogeochem/PhenologyMod.F90
+++ b/components/clm/src/biogeochem/PhenologyMod.F90
@@ -6,7 +6,7 @@ module PhenologyMod
   ! Module holding routines used in phenology model for coupled carbon
   ! nitrogen code.
 
-  !!Adding phosphorus -X.YANG   
+  !!Adding phosphorus -X.YANG
   !
   ! !USES:
   use shr_kind_mod        , only : r8 => shr_kind_r8
@@ -31,15 +31,15 @@ module PhenologyMod
   use WaterstateType      , only : waterstate_type
   use PhosphorusFluxType  , only : phosphorusflux_type
   use PhosphorusStateType , only : phosphorusstate_type
-  use clm_varctl          , only : nu_com 
+  use clm_varctl          , only : nu_com
   use ColumnType          , only : col_pp
-  use ColumnDataType      , only : col_es, col_ws, col_cf, col_nf, col_pf 
-  use TopounitDataType    , only : top_af  
-  use GridcellType        , only : grc_pp                
-  use VegetationType      , only : veg_pp                
+  use ColumnDataType      , only : col_es, col_ws, col_cf, col_nf, col_pf
+  use TopounitDataType    , only : top_af
+  use GridcellType        , only : grc_pp
+  use VegetationType      , only : veg_pp
   use VegetationDataType  , only : veg_es, veg_cs, veg_cf, veg_ns, veg_nf
   use VegetationDataType  , only : veg_ps, veg_pf
-  
+
   !
   implicit none
   save
@@ -48,7 +48,8 @@ module PhenologyMod
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: PhenologyInit      ! Initialization
   public :: Phenology          ! Update
-  public :: readPhenolParams   ! 
+  public :: readPhenolParams   !
+  public :: CNLitterToColumn
   !
   ! !PRIVATE DATA MEMBERS:
   type, private :: PnenolParamsType
@@ -67,7 +68,7 @@ module PhenologyMod
      real(r8) :: lwtop           ! live wood turnover proportion (annual fraction)
   end type PnenolParamsType
 
-  ! PhenolParamsInst is populated in readPhenolParams 
+  ! PhenolParamsInst is populated in readPhenolParams
   type(PnenolParamsType) ::  PhenolParamsInst
 
   real(r8) :: dt                            ! radiation time step delta t (seconds)
@@ -95,7 +96,7 @@ module PhenologyMod
   integer, parameter :: NOT_Harvested = 999 ! If not harvested yet in year
   integer, parameter :: inNH       = 1      ! Northern Hemisphere
   integer, parameter :: inSH       = 2      ! Southern Hemisphere
-  integer, pointer   :: inhemi(:)           ! Hemisphere that pft is in 
+  integer, pointer   :: inhemi(:)           ! Hemisphere that pft is in
 
   integer, allocatable :: minplantjday(:,:) ! minimum planting julian day
   integer, allocatable :: maxplantjday(:,:) ! maximum planting julian day
@@ -127,7 +128,7 @@ contains
 
     !
     ! read in parameters
-    !   
+    !
     tString='crit_dayl'
     call ncd_io(varname=trim(tString),data=tempr, flag='read', ncid=ncid, readvar=readv)
     if ( .not. readv ) call endrun( msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
@@ -135,7 +136,7 @@ contains
 
     tString='crit_dayl_stress'
     call ncd_io(varname=trim(tString),data=tempr, flag='read', ncid=ncid, readvar=readv)
-    if ( .not. readv ) then 
+    if ( .not. readv ) then
         crit_dayl_stress = secspday / 4 !call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
     else
         PhenolParamsInst%crit_dayl_stress=tempr
@@ -197,7 +198,7 @@ contains
     tString='lwtop_ann'
     call ncd_io(varname=trim(tString),data=tempr, flag='read', ncid=ncid, readvar=readv)
     if ( .not. readv ) call endrun( msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
-    PhenolParamsInst%lwtop=tempr   
+    PhenolParamsInst%lwtop=tempr
 
   end subroutine readPhenolParams
 
@@ -243,7 +244,7 @@ contains
          temperature_vars, cnstate_vars)
 
     call CNEvergreenPhenology(num_soilp, filter_soilp, &
-         cnstate_vars) 
+         cnstate_vars)
 
     call CNSeasonDecidPhenology(num_soilp, filter_soilp, &
          temperature_vars, cnstate_vars, &
@@ -291,8 +292,8 @@ contains
 
     ! gather all patch-level litterfall fluxes to the column for litter C and N inputs
 
-    call CNLitterToColumn(num_soilc, filter_soilc, &
-         cnstate_vars, carbonflux_vars, nitrogenflux_vars,phosphorusflux_vars)
+    !call CNLitterToColumn(num_soilc, filter_soilc, &
+    !     cnstate_vars, carbonflux_vars, nitrogenflux_vars,phosphorusflux_vars)
 
   end subroutine Phenology
 
@@ -310,7 +311,7 @@ contains
     !
     ! !ARGUMENTS:
     implicit none
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     !------------------------------------------------------------------------
 
     !
@@ -319,7 +320,7 @@ contains
     dt      = real( get_step_size(), r8 )
     fracday = dt/secspday
 
-    ! set constants for CNSeasonDecidPhenology 
+    ! set constants for CNSeasonDecidPhenology
     ! (critical daylength from Biome-BGC, v4.1.2)
     crit_dayl=PhenolParamsInst%crit_dayl
 
@@ -348,7 +349,7 @@ contains
     ! offset parameters
     crit_offset_fdd=PhenolParamsInst%crit_offset_fdd
     crit_offset_swi=PhenolParamsInst%crit_offset_swi
-    soilpsi_off=PhenolParamsInst%soilpsi_off    
+    soilpsi_off=PhenolParamsInst%soilpsi_off
 
     ! -----------------------------------------
     ! Constants for CNLivewoodTurnover
@@ -398,20 +399,20 @@ contains
     real(r8), parameter :: yravgm1 = yravg-1.0_r8 ! minus 1 of above
     !-----------------------------------------------------------------------
 
-    associate(                                                  & 
-         t_ref2m        => veg_es%t_ref2m     , & ! Input:  [real(r8) (:) ]  2m air temperature (K)                            
-         gdd0           => veg_es%gdd0        , & ! Output: [real(r8) (:) ]  growing deg. days base 0 deg C (ddays)            
-         gdd8           => veg_es%gdd8        , & ! Output: [real(r8) (:) ]     "     "    "    "   8  "  "    "               
-         gdd10          => veg_es%gdd10       , & ! Output: [real(r8) (:) ]     "     "    "    "  10  "  "    "               
-         gdd020         => veg_es%gdd020      , & ! Output: [real(r8) (:) ]  20-yr mean of gdd0 (ddays)                        
-         gdd820         => veg_es%gdd820      , & ! Output: [real(r8) (:) ]  20-yr mean of gdd8 (ddays)                        
-         gdd1020        => veg_es%gdd1020     , & ! Output: [real(r8) (:) ]  20-yr mean of gdd10 (ddays)                       
-         
-         tempavg_t2m    => cnstate_vars%tempavg_t2m_patch       & ! Output: [real(r8) (:) ]  temp. avg 2m air temperature (K)                  
+    associate(                                                  &
+         t_ref2m        => veg_es%t_ref2m     , & ! Input:  [real(r8) (:) ]  2m air temperature (K)
+         gdd0           => veg_es%gdd0        , & ! Output: [real(r8) (:) ]  growing deg. days base 0 deg C (ddays)
+         gdd8           => veg_es%gdd8        , & ! Output: [real(r8) (:) ]     "     "    "    "   8  "  "    "
+         gdd10          => veg_es%gdd10       , & ! Output: [real(r8) (:) ]     "     "    "    "  10  "  "    "
+         gdd020         => veg_es%gdd020      , & ! Output: [real(r8) (:) ]  20-yr mean of gdd0 (ddays)
+         gdd820         => veg_es%gdd820      , & ! Output: [real(r8) (:) ]  20-yr mean of gdd8 (ddays)
+         gdd1020        => veg_es%gdd1020     , & ! Output: [real(r8) (:) ]  20-yr mean of gdd10 (ddays)
+
+         tempavg_t2m    => cnstate_vars%tempavg_t2m_patch       & ! Output: [real(r8) (:) ]  temp. avg 2m air temperature (K)
          )
 
       ! set time steps
-      
+
       dayspyr = get_days_per_year()
 
       do fp = 1,num_soilp
@@ -447,7 +448,7 @@ contains
             end if                                                 ! <-- END of YR 1
             gdd020(p)  = (yravgm1* gdd020(p)  + gdd0(p))  / yravg  ! gdd..20 must be long term avgs
             gdd820(p)  = (yravgm1* gdd820(p)  + gdd8(p))  / yravg  ! so ignore results for yrs 1 & 2
-            gdd1020(p) = (yravgm1* gdd1020(p) + gdd10(p)) / yravg 
+            gdd1020(p) = (yravgm1* gdd1020(p) + gdd10(p)) / yravg
          end if
       end do
 
@@ -457,7 +458,7 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine CNEvergreenPhenology (num_soilp, filter_soilp , &
-       cnstate_vars) 
+       cnstate_vars)
     !
     ! !DESCRIPTION:
     ! For coupled carbon-nitrogen code (CN).
@@ -477,16 +478,16 @@ contains
     integer :: fp                     ! lake filter pft index
     !-----------------------------------------------------------------------
 
-    associate(                                    & 
-         ivt         => veg_pp%itype                , & ! Input:  [integer  (:) ]  pft vegetation type                                
+    associate(                                    &
+         ivt         => veg_pp%itype                , & ! Input:  [integer  (:) ]  pft vegetation type
 
-         evergreen   => veg_vp%evergreen     , & ! Input:  [real(r8) (:) ]  binary flag for evergreen leaf habit (0 or 1)     
-         leaf_long   => veg_vp%leaf_long     , & ! Input:  [real(r8) (:) ]  leaf longevity (yrs)                              
+         evergreen   => veg_vp%evergreen     , & ! Input:  [real(r8) (:) ]  binary flag for evergreen leaf habit (0 or 1)
+         leaf_long   => veg_vp%leaf_long     , & ! Input:  [real(r8) (:) ]  leaf longevity (yrs)
          froot_long  => veg_vp%froot_long    , & ! Input:  [real(r8) (:) ]  fine root longevity (yrs)
-         bglfr_leaf  => cnstate_vars%bglfr_leaf_patch , & ! Output: [real(r8) (:) ]  background leaf litterfall rate (1/s)                  
+         bglfr_leaf  => cnstate_vars%bglfr_leaf_patch , & ! Output: [real(r8) (:) ]  background leaf litterfall rate (1/s)
          bglfr_froot => cnstate_vars%bglfr_froot_patch, & ! Output: [real(r8) (:) ]  background fine root litterfall (1/s)
-         bgtr        => cnstate_vars%bgtr_patch  , & ! Output: [real(r8) (:) ]  background transfer growth rate (1/s)             
-         lgsf        => cnstate_vars%lgsf_patch    & ! Output: [real(r8) (:) ]  long growing season factor [0-1]                  
+         bgtr        => cnstate_vars%bgtr_patch  , & ! Output: [real(r8) (:) ]  background transfer growth rate (1/s)
+         lgsf        => cnstate_vars%lgsf_patch    & ! Output: [real(r8) (:) ]  long growing season factor [0-1]
          )
 
       dayspyr   = get_days_per_year()
@@ -540,112 +541,112 @@ contains
     real(r8):: soilt
     !-----------------------------------------------------------------------
 
-    associate(                                                                                             & 
-         ivt                                 =>    veg_pp%itype                                             , & ! Input:  [integer   (:)   ]  pft vegetation type                                
+    associate(                                                                                             &
+         ivt                                 =>    veg_pp%itype                                             , & ! Input:  [integer   (:)   ]  pft vegetation type
          dayl                                =>    grc_pp%dayl                                              , & ! Input:  [real(r8)  (:)   ]  daylength (s)
          prev_dayl                           =>    grc_pp%prev_dayl                                         , & ! Input:  [real(r8)  (:)   ]  daylength from previous time step (s)
-         
+
          season_decid                        =>    veg_vp%season_decid                               , & ! Input:  [real(r8)  (:)   ]  binary flag for seasonal-deciduous leaf habit (0 or 1)
          woody                               =>    veg_vp%woody                                      , & ! Input:  [real(r8)  (:)   ]  binary flag for woody lifeform (1=woody, 0=not woody)
-         
+
          t_soisno                            =>    col_es%t_soisno                         , & ! Input:  [real(r8)  (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevgrnd)
-         
-         annavg_t2m                          =>    cnstate_vars%annavg_t2m_patch                         , & ! Input:  [real(r8)  (:)   ]  annual average 2m air temperature (K)             
-         dormant_flag                        =>    cnstate_vars%dormant_flag_patch                       , & ! Output: [real(r8)  (:)   ]  dormancy flag                                     
-         days_active                         =>    cnstate_vars%days_active_patch                        , & ! Output: [real(r8)  (:)   ]  number of days since last dormancy                
-         onset_flag                          =>    cnstate_vars%onset_flag_patch                         , & ! Output: [real(r8)  (:)   ]  onset flag                                        
-         onset_counter                       =>    cnstate_vars%onset_counter_patch                      , & ! Output: [real(r8)  (:)   ]  onset counter (seconds)                           
-         onset_gddflag                       =>    cnstate_vars%onset_gddflag_patch                      , & ! Output: [real(r8)  (:)   ]  onset freeze flag                                 
-         onset_gdd                           =>    cnstate_vars%onset_gdd_patch                          , & ! Output: [real(r8)  (:)   ]  onset growing degree days                         
-         offset_flag                         =>    cnstate_vars%offset_flag_patch                        , & ! Output: [real(r8)  (:)   ]  offset flag                                       
-         offset_counter                      =>    cnstate_vars%offset_counter_patch                     , & ! Output: [real(r8)  (:)   ]  offset counter (seconds)                          
-         bglfr_leaf                          =>    cnstate_vars%bglfr_leaf_patch                         , & ! Output: [real(r8)  (:)   ]  background leaf litterfall rate (1/s)                  
-         bglfr_froot                         =>    cnstate_vars%bglfr_froot_patch                        , & ! Output: [real(r8)  (:)   ]  background fine root litterfall rate (1/s)     
-         bgtr                                =>    cnstate_vars%bgtr_patch                               , & ! Output: [real(r8)  (:)   ]  background transfer growth rate (1/s)             
-         lgsf                                =>    cnstate_vars%lgsf_patch                               , & ! Output: [real(r8)  (:)   ]  long growing season factor [0-1]                  
-         
-         leafc_storage                       =>    veg_cs%leafc_storage                  , & ! Input:  [real(r8)  (:)   ]  (gC/m2) leaf C storage                            
-         frootc_storage                      =>    veg_cs%frootc_storage                 , & ! Input:  [real(r8)  (:)   ]  (gC/m2) fine root C storage                       
-         livestemc_storage                   =>    veg_cs%livestemc_storage              , & ! Input:  [real(r8)  (:)   ]  (gC/m2) live stem C storage                       
-         deadstemc_storage                   =>    veg_cs%deadstemc_storage              , & ! Input:  [real(r8)  (:)   ]  (gC/m2) dead stem C storage                       
-         livecrootc_storage                  =>    veg_cs%livecrootc_storage             , & ! Input:  [real(r8)  (:)   ]  (gC/m2) live coarse root C storage                
-         deadcrootc_storage                  =>    veg_cs%deadcrootc_storage             , & ! Input:  [real(r8)  (:)   ]  (gC/m2) dead coarse root C storage                
-         gresp_storage                       =>    veg_cs%gresp_storage                  , & ! Input:  [real(r8)  (:)   ]  (gC/m2) growth respiration storage                
-         leafc_xfer                          =>    veg_cs%leafc_xfer                     , & ! Output:  [real(r8) (:)   ]  (gC/m2) leaf C transfer                           
-         frootc_xfer                         =>    veg_cs%frootc_xfer                    , & ! Output:  [real(r8) (:)   ]  (gC/m2) fine root C transfer                      
-         livestemc_xfer                      =>    veg_cs%livestemc_xfer                 , & ! Output:  [real(r8) (:)   ]  (gC/m2) live stem C transfer                      
-         deadstemc_xfer                      =>    veg_cs%deadstemc_xfer                 , & ! Output:  [real(r8) (:)   ]  (gC/m2) dead stem C transfer                      
-         livecrootc_xfer                     =>    veg_cs%livecrootc_xfer                , & ! Output:  [real(r8) (:)   ]  (gC/m2) live coarse root C transfer               
-         deadcrootc_xfer                     =>    veg_cs%deadcrootc_xfer                , & ! Output:  [real(r8) (:)   ]  (gC/m2) dead coarse root C transfer               
-         
-         leafn_storage                       =>    veg_ns%leafn_storage                , & ! Input:  [real(r8)  (:)   ]  (gN/m2) leaf N storage                            
-         frootn_storage                      =>    veg_ns%frootn_storage               , & ! Input:  [real(r8)  (:)   ]  (gN/m2) fine root N storage                       
-         livestemn_storage                   =>    veg_ns%livestemn_storage            , & ! Input:  [real(r8)  (:)   ]  (gN/m2) live stem N storage                       
-         deadstemn_storage                   =>    veg_ns%deadstemn_storage            , & ! Input:  [real(r8)  (:)   ]  (gN/m2) dead stem N storage                       
-         livecrootn_storage                  =>    veg_ns%livecrootn_storage           , & ! Input:  [real(r8)  (:)   ]  (gN/m2) live coarse root N storage                
-         deadcrootn_storage                  =>    veg_ns%deadcrootn_storage           , & ! Input:  [real(r8)  (:)   ]  (gN/m2) dead coarse root N storage                
+
+         annavg_t2m                          =>    cnstate_vars%annavg_t2m_patch                         , & ! Input:  [real(r8)  (:)   ]  annual average 2m air temperature (K)
+         dormant_flag                        =>    cnstate_vars%dormant_flag_patch                       , & ! Output: [real(r8)  (:)   ]  dormancy flag
+         days_active                         =>    cnstate_vars%days_active_patch                        , & ! Output: [real(r8)  (:)   ]  number of days since last dormancy
+         onset_flag                          =>    cnstate_vars%onset_flag_patch                         , & ! Output: [real(r8)  (:)   ]  onset flag
+         onset_counter                       =>    cnstate_vars%onset_counter_patch                      , & ! Output: [real(r8)  (:)   ]  onset counter (seconds)
+         onset_gddflag                       =>    cnstate_vars%onset_gddflag_patch                      , & ! Output: [real(r8)  (:)   ]  onset freeze flag
+         onset_gdd                           =>    cnstate_vars%onset_gdd_patch                          , & ! Output: [real(r8)  (:)   ]  onset growing degree days
+         offset_flag                         =>    cnstate_vars%offset_flag_patch                        , & ! Output: [real(r8)  (:)   ]  offset flag
+         offset_counter                      =>    cnstate_vars%offset_counter_patch                     , & ! Output: [real(r8)  (:)   ]  offset counter (seconds)
+         bglfr_leaf                          =>    cnstate_vars%bglfr_leaf_patch                         , & ! Output: [real(r8)  (:)   ]  background leaf litterfall rate (1/s)
+         bglfr_froot                         =>    cnstate_vars%bglfr_froot_patch                        , & ! Output: [real(r8)  (:)   ]  background fine root litterfall rate (1/s)
+         bgtr                                =>    cnstate_vars%bgtr_patch                               , & ! Output: [real(r8)  (:)   ]  background transfer growth rate (1/s)
+         lgsf                                =>    cnstate_vars%lgsf_patch                               , & ! Output: [real(r8)  (:)   ]  long growing season factor [0-1]
+
+         leafc_storage                       =>    veg_cs%leafc_storage                  , & ! Input:  [real(r8)  (:)   ]  (gC/m2) leaf C storage
+         frootc_storage                      =>    veg_cs%frootc_storage                 , & ! Input:  [real(r8)  (:)   ]  (gC/m2) fine root C storage
+         livestemc_storage                   =>    veg_cs%livestemc_storage              , & ! Input:  [real(r8)  (:)   ]  (gC/m2) live stem C storage
+         deadstemc_storage                   =>    veg_cs%deadstemc_storage              , & ! Input:  [real(r8)  (:)   ]  (gC/m2) dead stem C storage
+         livecrootc_storage                  =>    veg_cs%livecrootc_storage             , & ! Input:  [real(r8)  (:)   ]  (gC/m2) live coarse root C storage
+         deadcrootc_storage                  =>    veg_cs%deadcrootc_storage             , & ! Input:  [real(r8)  (:)   ]  (gC/m2) dead coarse root C storage
+         gresp_storage                       =>    veg_cs%gresp_storage                  , & ! Input:  [real(r8)  (:)   ]  (gC/m2) growth respiration storage
+         leafc_xfer                          =>    veg_cs%leafc_xfer                     , & ! Output:  [real(r8) (:)   ]  (gC/m2) leaf C transfer
+         frootc_xfer                         =>    veg_cs%frootc_xfer                    , & ! Output:  [real(r8) (:)   ]  (gC/m2) fine root C transfer
+         livestemc_xfer                      =>    veg_cs%livestemc_xfer                 , & ! Output:  [real(r8) (:)   ]  (gC/m2) live stem C transfer
+         deadstemc_xfer                      =>    veg_cs%deadstemc_xfer                 , & ! Output:  [real(r8) (:)   ]  (gC/m2) dead stem C transfer
+         livecrootc_xfer                     =>    veg_cs%livecrootc_xfer                , & ! Output:  [real(r8) (:)   ]  (gC/m2) live coarse root C transfer
+         deadcrootc_xfer                     =>    veg_cs%deadcrootc_xfer                , & ! Output:  [real(r8) (:)   ]  (gC/m2) dead coarse root C transfer
+
+         leafn_storage                       =>    veg_ns%leafn_storage                , & ! Input:  [real(r8)  (:)   ]  (gN/m2) leaf N storage
+         frootn_storage                      =>    veg_ns%frootn_storage               , & ! Input:  [real(r8)  (:)   ]  (gN/m2) fine root N storage
+         livestemn_storage                   =>    veg_ns%livestemn_storage            , & ! Input:  [real(r8)  (:)   ]  (gN/m2) live stem N storage
+         deadstemn_storage                   =>    veg_ns%deadstemn_storage            , & ! Input:  [real(r8)  (:)   ]  (gN/m2) dead stem N storage
+         livecrootn_storage                  =>    veg_ns%livecrootn_storage           , & ! Input:  [real(r8)  (:)   ]  (gN/m2) live coarse root N storage
+         deadcrootn_storage                  =>    veg_ns%deadcrootn_storage           , & ! Input:  [real(r8)  (:)   ]  (gN/m2) dead coarse root N storage
 
          !! phosphorus
-         leafp_storage                       =>    veg_ps%leafp_storage                , & ! Input:  [real(r8)  (:)   ]  (gP/m2) leaf P storage                            
-         frootp_storage                      =>    veg_ps%frootp_storage               , & ! Input:  [real(r8)  (:)   ]  (gP/m2) fine root P storage                       
-         livestemp_storage                   =>    veg_ps%livestemp_storage            , & ! Input:  [real(r8)  (:)   ]  (gP/m2) live stem P storage                       
-         deadstemp_storage                   =>    veg_ps%deadstemp_storage            , & ! Input:  [real(r8)  (:)   ]  (gP/m2) dead stem P storage                       
-         livecrootp_storage                  =>    veg_ps%livecrootp_storage           , & ! Input:  [real(r8)  (:)   ]  (gP/m2) live coarse root P storage                
-         deadcrootp_storage                  =>    veg_ps%deadcrootp_storage           , & ! Input:  [real(r8)  (:)   ]  (gP/m2) dead coarse root P storage                
+         leafp_storage                       =>    veg_ps%leafp_storage                , & ! Input:  [real(r8)  (:)   ]  (gP/m2) leaf P storage
+         frootp_storage                      =>    veg_ps%frootp_storage               , & ! Input:  [real(r8)  (:)   ]  (gP/m2) fine root P storage
+         livestemp_storage                   =>    veg_ps%livestemp_storage            , & ! Input:  [real(r8)  (:)   ]  (gP/m2) live stem P storage
+         deadstemp_storage                   =>    veg_ps%deadstemp_storage            , & ! Input:  [real(r8)  (:)   ]  (gP/m2) dead stem P storage
+         livecrootp_storage                  =>    veg_ps%livecrootp_storage           , & ! Input:  [real(r8)  (:)   ]  (gP/m2) live coarse root P storage
+         deadcrootp_storage                  =>    veg_ps%deadcrootp_storage           , & ! Input:  [real(r8)  (:)   ]  (gP/m2) dead coarse root P storage
 
          prev_leafc_to_litter                =>    veg_cf%prev_leafc_to_litter            , & ! Output: [real(r8)  (:)   ]  previous timestep leaf C litterfall flux (gC/m2/s)
          prev_frootc_to_litter               =>    veg_cf%prev_frootc_to_litter           , & ! Output: [real(r8)  (:)   ]  previous timestep froot C litterfall flux (gC/m2/s)
-         leafc_xfer_to_leafc                 =>    veg_cf%leafc_xfer_to_leafc             , & ! Output:  [real(r8) (:)   ]                                                    
-         frootc_xfer_to_frootc               =>    veg_cf%frootc_xfer_to_frootc           , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemc_xfer_to_livestemc         =>    veg_cf%livestemc_xfer_to_livestemc     , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemc_xfer_to_deadstemc         =>    veg_cf%deadstemc_xfer_to_deadstemc     , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootc_xfer_to_livecrootc       =>    veg_cf%livecrootc_xfer_to_livecrootc   , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootc_xfer_to_deadcrootc       =>    veg_cf%deadcrootc_xfer_to_deadcrootc   , & ! Output:  [real(r8) (:)   ]                                                    
-         leafc_storage_to_xfer               =>    veg_cf%leafc_storage_to_xfer           , & ! Output:  [real(r8) (:)   ]                                                    
-         frootc_storage_to_xfer              =>    veg_cf%frootc_storage_to_xfer          , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemc_storage_to_xfer           =>    veg_cf%livestemc_storage_to_xfer       , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemc_storage_to_xfer           =>    veg_cf%deadstemc_storage_to_xfer       , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootc_storage_to_xfer          =>    veg_cf%livecrootc_storage_to_xfer      , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootc_storage_to_xfer          =>    veg_cf%deadcrootc_storage_to_xfer      , & ! Output:  [real(r8) (:)   ]                                                    
-         gresp_storage_to_xfer               =>    veg_cf%gresp_storage_to_xfer           , & ! Output:  [real(r8) (:)   ]                                                    
-         
-         leafn_xfer_to_leafn                 =>    veg_nf%leafn_xfer_to_leafn           , & ! Output:  [real(r8) (:)   ]                                                    
-         frootn_xfer_to_frootn               =>    veg_nf%frootn_xfer_to_frootn         , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemn_xfer_to_livestemn         =>    veg_nf%livestemn_xfer_to_livestemn   , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemn_xfer_to_deadstemn         =>    veg_nf%deadstemn_xfer_to_deadstemn   , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootn_xfer_to_livecrootn       =>    veg_nf%livecrootn_xfer_to_livecrootn , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootn_xfer_to_deadcrootn       =>    veg_nf%deadcrootn_xfer_to_deadcrootn , & ! Output:  [real(r8) (:)   ]                                                    
-         leafn_xfer                          =>    veg_ns%leafn_xfer                   , & ! Output:  [real(r8) (:)   ]  (gN/m2) leaf N transfer                           
-         frootn_xfer                         =>    veg_ns%frootn_xfer                  , & ! Output:  [real(r8) (:)   ]  (gN/m2) fine root N transfer                      
-         livestemn_xfer                      =>    veg_ns%livestemn_xfer               , & ! Output:  [real(r8) (:)   ]  (gN/m2) live stem N transfer                      
-         deadstemn_xfer                      =>    veg_ns%deadstemn_xfer               , & ! Output:  [real(r8) (:)   ]  (gN/m2) dead stem N transfer                      
-         livecrootn_xfer                     =>    veg_ns%livecrootn_xfer              , & ! Output:  [real(r8) (:)   ]  (gN/m2) live coarse root N transfer               
-         deadcrootn_xfer                     =>    veg_ns%deadcrootn_xfer              , & ! Output:  [real(r8) (:)   ]  (gN/m2) dead coarse root N transfer               
-         leafn_storage_to_xfer               =>    veg_nf%leafn_storage_to_xfer         , & ! Output:  [real(r8) (:)   ]                                                    
-         frootn_storage_to_xfer              =>    veg_nf%frootn_storage_to_xfer        , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemn_storage_to_xfer           =>    veg_nf%livestemn_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemn_storage_to_xfer           =>    veg_nf%deadstemn_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootn_storage_to_xfer          =>    veg_nf%livecrootn_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootn_storage_to_xfer          =>    veg_nf%deadcrootn_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]                                                    
+         leafc_xfer_to_leafc                 =>    veg_cf%leafc_xfer_to_leafc             , & ! Output:  [real(r8) (:)   ]
+         frootc_xfer_to_frootc               =>    veg_cf%frootc_xfer_to_frootc           , & ! Output:  [real(r8) (:)   ]
+         livestemc_xfer_to_livestemc         =>    veg_cf%livestemc_xfer_to_livestemc     , & ! Output:  [real(r8) (:)   ]
+         deadstemc_xfer_to_deadstemc         =>    veg_cf%deadstemc_xfer_to_deadstemc     , & ! Output:  [real(r8) (:)   ]
+         livecrootc_xfer_to_livecrootc       =>    veg_cf%livecrootc_xfer_to_livecrootc   , & ! Output:  [real(r8) (:)   ]
+         deadcrootc_xfer_to_deadcrootc       =>    veg_cf%deadcrootc_xfer_to_deadcrootc   , & ! Output:  [real(r8) (:)   ]
+         leafc_storage_to_xfer               =>    veg_cf%leafc_storage_to_xfer           , & ! Output:  [real(r8) (:)   ]
+         frootc_storage_to_xfer              =>    veg_cf%frootc_storage_to_xfer          , & ! Output:  [real(r8) (:)   ]
+         livestemc_storage_to_xfer           =>    veg_cf%livestemc_storage_to_xfer       , & ! Output:  [real(r8) (:)   ]
+         deadstemc_storage_to_xfer           =>    veg_cf%deadstemc_storage_to_xfer       , & ! Output:  [real(r8) (:)   ]
+         livecrootc_storage_to_xfer          =>    veg_cf%livecrootc_storage_to_xfer      , & ! Output:  [real(r8) (:)   ]
+         deadcrootc_storage_to_xfer          =>    veg_cf%deadcrootc_storage_to_xfer      , & ! Output:  [real(r8) (:)   ]
+         gresp_storage_to_xfer               =>    veg_cf%gresp_storage_to_xfer           , & ! Output:  [real(r8) (:)   ]
 
-         leafp_xfer_to_leafp                 =>    veg_pf%leafp_xfer_to_leafp           , & ! Output:  [real(r8) (:)   ]                                                    
-         frootp_xfer_to_frootp               =>    veg_pf%frootp_xfer_to_frootp         , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemp_xfer_to_livestemp         =>    veg_pf%livestemp_xfer_to_livestemp   , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemp_xfer_to_deadstemp         =>    veg_pf%deadstemp_xfer_to_deadstemp   , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootp_xfer_to_livecrootp       =>    veg_pf%livecrootp_xfer_to_livecrootp , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootp_xfer_to_deadcrootp       =>    veg_pf%deadcrootp_xfer_to_deadcrootp , & ! Output:  [real(r8) (:)   ]                                                    
-         leafp_xfer                          =>    veg_ps%leafp_xfer                   , & ! Output:  [real(r8) (:)   ]  (gP/m2) leaf P transfer                           
-         frootp_xfer                         =>    veg_ps%frootp_xfer                  , & ! Output:  [real(r8) (:)   ]  (gP/m2) fine root P transfer                      
-         livestemp_xfer                      =>    veg_ps%livestemp_xfer               , & ! Output:  [real(r8) (:)   ]  (gP/m2) live stem P transfer                      
-         deadstemp_xfer                      =>    veg_ps%deadstemp_xfer               , & ! Output:  [real(r8) (:)   ]  (gP/m2) dead stem P transfer                      
-         livecrootp_xfer                     =>    veg_ps%livecrootp_xfer              , & ! Output:  [real(r8) (:)   ]  (gP/m2) live coarse root P transfer               
-         deadcrootp_xfer                     =>    veg_ps%deadcrootp_xfer              , & ! Output:  [real(r8) (:)   ]  (gP/m2) dead coarse root P transfer               
-         leafp_storage_to_xfer               =>    veg_pf%leafp_storage_to_xfer         , & ! Output:  [real(r8) (:)   ]                                                    
-         frootp_storage_to_xfer              =>    veg_pf%frootp_storage_to_xfer        , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemp_storage_to_xfer           =>    veg_pf%livestemp_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemp_storage_to_xfer           =>    veg_pf%deadstemp_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootp_storage_to_xfer          =>    veg_pf%livecrootp_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootp_storage_to_xfer          =>    veg_pf%deadcrootp_storage_to_xfer      & ! Output:  [real(r8) (:)   ]                                                    
+         leafn_xfer_to_leafn                 =>    veg_nf%leafn_xfer_to_leafn           , & ! Output:  [real(r8) (:)   ]
+         frootn_xfer_to_frootn               =>    veg_nf%frootn_xfer_to_frootn         , & ! Output:  [real(r8) (:)   ]
+         livestemn_xfer_to_livestemn         =>    veg_nf%livestemn_xfer_to_livestemn   , & ! Output:  [real(r8) (:)   ]
+         deadstemn_xfer_to_deadstemn         =>    veg_nf%deadstemn_xfer_to_deadstemn   , & ! Output:  [real(r8) (:)   ]
+         livecrootn_xfer_to_livecrootn       =>    veg_nf%livecrootn_xfer_to_livecrootn , & ! Output:  [real(r8) (:)   ]
+         deadcrootn_xfer_to_deadcrootn       =>    veg_nf%deadcrootn_xfer_to_deadcrootn , & ! Output:  [real(r8) (:)   ]
+         leafn_xfer                          =>    veg_ns%leafn_xfer                   , & ! Output:  [real(r8) (:)   ]  (gN/m2) leaf N transfer
+         frootn_xfer                         =>    veg_ns%frootn_xfer                  , & ! Output:  [real(r8) (:)   ]  (gN/m2) fine root N transfer
+         livestemn_xfer                      =>    veg_ns%livestemn_xfer               , & ! Output:  [real(r8) (:)   ]  (gN/m2) live stem N transfer
+         deadstemn_xfer                      =>    veg_ns%deadstemn_xfer               , & ! Output:  [real(r8) (:)   ]  (gN/m2) dead stem N transfer
+         livecrootn_xfer                     =>    veg_ns%livecrootn_xfer              , & ! Output:  [real(r8) (:)   ]  (gN/m2) live coarse root N transfer
+         deadcrootn_xfer                     =>    veg_ns%deadcrootn_xfer              , & ! Output:  [real(r8) (:)   ]  (gN/m2) dead coarse root N transfer
+         leafn_storage_to_xfer               =>    veg_nf%leafn_storage_to_xfer         , & ! Output:  [real(r8) (:)   ]
+         frootn_storage_to_xfer              =>    veg_nf%frootn_storage_to_xfer        , & ! Output:  [real(r8) (:)   ]
+         livestemn_storage_to_xfer           =>    veg_nf%livestemn_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]
+         deadstemn_storage_to_xfer           =>    veg_nf%deadstemn_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]
+         livecrootn_storage_to_xfer          =>    veg_nf%livecrootn_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]
+         deadcrootn_storage_to_xfer          =>    veg_nf%deadcrootn_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]
+
+         leafp_xfer_to_leafp                 =>    veg_pf%leafp_xfer_to_leafp           , & ! Output:  [real(r8) (:)   ]
+         frootp_xfer_to_frootp               =>    veg_pf%frootp_xfer_to_frootp         , & ! Output:  [real(r8) (:)   ]
+         livestemp_xfer_to_livestemp         =>    veg_pf%livestemp_xfer_to_livestemp   , & ! Output:  [real(r8) (:)   ]
+         deadstemp_xfer_to_deadstemp         =>    veg_pf%deadstemp_xfer_to_deadstemp   , & ! Output:  [real(r8) (:)   ]
+         livecrootp_xfer_to_livecrootp       =>    veg_pf%livecrootp_xfer_to_livecrootp , & ! Output:  [real(r8) (:)   ]
+         deadcrootp_xfer_to_deadcrootp       =>    veg_pf%deadcrootp_xfer_to_deadcrootp , & ! Output:  [real(r8) (:)   ]
+         leafp_xfer                          =>    veg_ps%leafp_xfer                   , & ! Output:  [real(r8) (:)   ]  (gP/m2) leaf P transfer
+         frootp_xfer                         =>    veg_ps%frootp_xfer                  , & ! Output:  [real(r8) (:)   ]  (gP/m2) fine root P transfer
+         livestemp_xfer                      =>    veg_ps%livestemp_xfer               , & ! Output:  [real(r8) (:)   ]  (gP/m2) live stem P transfer
+         deadstemp_xfer                      =>    veg_ps%deadstemp_xfer               , & ! Output:  [real(r8) (:)   ]  (gP/m2) dead stem P transfer
+         livecrootp_xfer                     =>    veg_ps%livecrootp_xfer              , & ! Output:  [real(r8) (:)   ]  (gP/m2) live coarse root P transfer
+         deadcrootp_xfer                     =>    veg_ps%deadcrootp_xfer              , & ! Output:  [real(r8) (:)   ]  (gP/m2) dead coarse root P transfer
+         leafp_storage_to_xfer               =>    veg_pf%leafp_storage_to_xfer         , & ! Output:  [real(r8) (:)   ]
+         frootp_storage_to_xfer              =>    veg_pf%frootp_storage_to_xfer        , & ! Output:  [real(r8) (:)   ]
+         livestemp_storage_to_xfer           =>    veg_pf%livestemp_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]
+         deadstemp_storage_to_xfer           =>    veg_pf%deadstemp_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]
+         livecrootp_storage_to_xfer          =>    veg_pf%livecrootp_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]
+         deadcrootp_storage_to_xfer          =>    veg_pf%deadcrootp_storage_to_xfer      & ! Output:  [real(r8) (:)   ]
 
          )
 
@@ -845,11 +846,11 @@ contains
       end do ! end of pft loop
 
     end associate
- 
+
   end subroutine CNSeasonDecidPhenology
 
   !-----------------------------------------------------------------------
-  subroutine CNStressDecidPhenology (num_soilp, filter_soilp , &                                            
+  subroutine CNStressDecidPhenology (num_soilp, filter_soilp , &
        soilstate_vars, atm2lnd_vars, temperature_vars, cnstate_vars        , &
        carbonstate_vars, nitrogenstate_vars, carbonflux_vars,nitrogenflux_vars,&
        phosphorusstate_vars,phosphorusflux_vars)
@@ -894,120 +895,120 @@ contains
     real(r8):: psi             ! water stress of top soil layer
     !-----------------------------------------------------------------------
 
-    associate(                                                                                             & 
-         ivt                                 =>    veg_pp%itype                                             , & ! Input:  [integer   (:)   ]  pft vegetation type                                
+    associate(                                                                                             &
+         ivt                                 =>    veg_pp%itype                                             , & ! Input:  [integer   (:)   ]  pft vegetation type
          dayl                                =>    grc_pp%dayl                                              , & ! Input:  [real(r8)  (:)   ]  daylength (s)
-         
-         leaf_long                           =>    veg_vp%leaf_long                                  , & ! Input:  [real(r8)  (:)   ]  leaf longevity (yrs)                              
-         froot_long                          =>    veg_vp%froot_long                                 , & ! Input:  [real(r8)  (:)   ]  fine root longevity (yrs)                  
+
+         leaf_long                           =>    veg_vp%leaf_long                                  , & ! Input:  [real(r8)  (:)   ]  leaf longevity (yrs)
+         froot_long                          =>    veg_vp%froot_long                                 , & ! Input:  [real(r8)  (:)   ]  fine root longevity (yrs)
          woody                               =>    veg_vp%woody                                      , & ! Input:  [real(r8)  (:)   ]  binary flag for woody lifeform (1=woody, 0=not woody)
          stress_decid                        =>    veg_vp%stress_decid                               , & ! Input:  [real(r8)  (:)   ]  binary flag for stress-deciduous leaf habit (0 or 1)
-         
-         soilpsi                             =>    soilstate_vars%soilpsi_col                            , & ! Input:  [real(r8)  (:,:) ]  soil water potential in each soil layer (MPa)   
-         
+
+         soilpsi                             =>    soilstate_vars%soilpsi_col                            , & ! Input:  [real(r8)  (:,:) ]  soil water potential in each soil layer (MPa)
+
          t_soisno                            =>    col_es%t_soisno                         , & ! Input:  [real(r8)  (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevgrnd)
-         
+
          prec10                              =>    top_af%prec10d                                        , & ! Input:  [real(r8) (:)    ]  10-day running mean precipitation, mm H2O/s
-         dormant_flag                        =>    cnstate_vars%dormant_flag_patch                       , & ! Output:  [real(r8) (:)   ]  dormancy flag                                     
-         days_active                         =>    cnstate_vars%days_active_patch                        , & ! Output:  [real(r8) (:)   ]  number of days since last dormancy                
-         onset_flag                          =>    cnstate_vars%onset_flag_patch                         , & ! Output:  [real(r8) (:)   ]  onset flag                                        
-         onset_counter                       =>    cnstate_vars%onset_counter_patch                      , & ! Output:  [real(r8) (:)   ]  onset counter (seconds)                           
-         onset_gddflag                       =>    cnstate_vars%onset_gddflag_patch                      , & ! Output:  [real(r8) (:)   ]  onset freeze flag                                 
-         onset_fdd                           =>    cnstate_vars%onset_fdd_patch                          , & ! Output:  [real(r8) (:)   ]  onset freezing degree days counter                
-         onset_gdd                           =>    cnstate_vars%onset_gdd_patch                          , & ! Output:  [real(r8) (:)   ]  onset growing degree days                         
-         onset_swi                           =>    cnstate_vars%onset_swi_patch                          , & ! Output:  [real(r8) (:)   ]  onset soil water index                            
-         offset_flag                         =>    cnstate_vars%offset_flag_patch                        , & ! Output:  [real(r8) (:)   ]  offset flag                                       
-         offset_counter                      =>    cnstate_vars%offset_counter_patch                     , & ! Output:  [real(r8) (:)   ]  offset counter (seconds)                          
-         offset_fdd                          =>    cnstate_vars%offset_fdd_patch                         , & ! Output:  [real(r8) (:)   ]  offset freezing degree days counter               
-         offset_swi                          =>    cnstate_vars%offset_swi_patch                         , & ! Output:  [real(r8) (:)   ]  offset soil water index                           
-         lgsf                                =>    cnstate_vars%lgsf_patch                               , & ! Output:  [real(r8) (:)   ]  long growing season factor [0-1]                  
-         bglfr_leaf                          =>    cnstate_vars%bglfr_leaf_patch                         , & ! Output:  [real(r8) (:)   ]  background leaf litterfall rate (1/s)                  
-         bglfr_froot                         =>    cnstate_vars%bglfr_froot_patch                        , & ! Output:  [real(r8) (:)   ]  background fine root litterfall rate (1/s)  
-         bgtr                                =>    cnstate_vars%bgtr_patch                               , & ! Output:  [real(r8) (:)   ]  background transfer growth rate (1/s)             
-         annavg_t2m                          =>    cnstate_vars%annavg_t2m_patch                         , & ! Output:  [real(r8) (:)   ]  annual average 2m air temperature (K)             
-     
-         leafc_storage                       =>    veg_cs%leafc_storage                  , & ! Input:  [real(r8)  (:)   ]  (gC/m2) leaf C storage                            
-         frootc_storage                      =>    veg_cs%frootc_storage                 , & ! Input:  [real(r8)  (:)   ]  (gC/m2) fine root C storage                       
-         livestemc_storage                   =>    veg_cs%livestemc_storage              , & ! Input:  [real(r8)  (:)   ]  (gC/m2) live stem C storage                       
-         deadstemc_storage                   =>    veg_cs%deadstemc_storage              , & ! Input:  [real(r8)  (:)   ]  (gC/m2) dead stem C storage                       
-         livecrootc_storage                  =>    veg_cs%livecrootc_storage             , & ! Input:  [real(r8)  (:)   ]  (gC/m2) live coarse root C storage                
-         deadcrootc_storage                  =>    veg_cs%deadcrootc_storage             , & ! Input:  [real(r8)  (:)   ]  (gC/m2) dead coarse root C storage                
-         gresp_storage                       =>    veg_cs%gresp_storage                  , & ! Input:  [real(r8)  (:)   ]  (gC/m2) growth respiration storage                
-         leafc_xfer                          =>    veg_cs%leafc_xfer                     , & ! Output:  [real(r8) (:)   ]  (gC/m2) leaf C transfer                           
-         frootc_xfer                         =>    veg_cs%frootc_xfer                    , & ! Output:  [real(r8) (:)   ]  (gC/m2) fine root C transfer                      
-         livestemc_xfer                      =>    veg_cs%livestemc_xfer                 , & ! Output:  [real(r8) (:)   ]  (gC/m2) live stem C transfer                      
-         deadstemc_xfer                      =>    veg_cs%deadstemc_xfer                 , & ! Output:  [real(r8) (:)   ]  (gC/m2) dead stem C transfer                      
-         livecrootc_xfer                     =>    veg_cs%livecrootc_xfer                , & ! Output:  [real(r8) (:)   ]  (gC/m2) live coarse root C transfer               
-         deadcrootc_xfer                     =>    veg_cs%deadcrootc_xfer                , & ! Output:  [real(r8) (:)   ]  (gC/m2) dead coarse root C transfer               
-         
-         leafn_storage                       =>    veg_ns%leafn_storage                , & ! Input:  [real(r8)  (:)   ]  (gN/m2) leaf N storage                            
-         frootn_storage                      =>    veg_ns%frootn_storage               , & ! Input:  [real(r8)  (:)   ]  (gN/m2) fine root N storage                       
-         livestemn_storage                   =>    veg_ns%livestemn_storage            , & ! Input:  [real(r8)  (:)   ]  (gN/m2) live stem N storage                       
-         deadstemn_storage                   =>    veg_ns%deadstemn_storage            , & ! Input:  [real(r8)  (:)   ]  (gN/m2) dead stem N storage                       
-         livecrootn_storage                  =>    veg_ns%livecrootn_storage           , & ! Input:  [real(r8)  (:)   ]  (gN/m2) live coarse root N storage                
-         deadcrootn_storage                  =>    veg_ns%deadcrootn_storage           , & ! Input:  [real(r8)  (:)   ]  (gN/m2) dead coarse root N storage                
-         leafn_xfer                          =>    veg_ns%leafn_xfer                   , & ! Output:  [real(r8) (:)   ]  (gN/m2) leaf N transfer                           
-         frootn_xfer                         =>    veg_ns%frootn_xfer                  , & ! Output:  [real(r8) (:)   ]  (gN/m2) fine root N transfer                      
-         livestemn_xfer                      =>    veg_ns%livestemn_xfer               , & ! Output:  [real(r8) (:)   ]  (gN/m2) live stem N transfer                      
-         deadstemn_xfer                      =>    veg_ns%deadstemn_xfer               , & ! Output:  [real(r8) (:)   ]  (gN/m2) dead stem N transfer                      
-         livecrootn_xfer                     =>    veg_ns%livecrootn_xfer              , & ! Output:  [real(r8) (:)   ]  (gN/m2) live coarse root N transfer               
-         deadcrootn_xfer                     =>    veg_ns%deadcrootn_xfer              , & ! Output:  [real(r8) (:)   ]  (gN/m2) dead coarse root N transfer               
+         dormant_flag                        =>    cnstate_vars%dormant_flag_patch                       , & ! Output:  [real(r8) (:)   ]  dormancy flag
+         days_active                         =>    cnstate_vars%days_active_patch                        , & ! Output:  [real(r8) (:)   ]  number of days since last dormancy
+         onset_flag                          =>    cnstate_vars%onset_flag_patch                         , & ! Output:  [real(r8) (:)   ]  onset flag
+         onset_counter                       =>    cnstate_vars%onset_counter_patch                      , & ! Output:  [real(r8) (:)   ]  onset counter (seconds)
+         onset_gddflag                       =>    cnstate_vars%onset_gddflag_patch                      , & ! Output:  [real(r8) (:)   ]  onset freeze flag
+         onset_fdd                           =>    cnstate_vars%onset_fdd_patch                          , & ! Output:  [real(r8) (:)   ]  onset freezing degree days counter
+         onset_gdd                           =>    cnstate_vars%onset_gdd_patch                          , & ! Output:  [real(r8) (:)   ]  onset growing degree days
+         onset_swi                           =>    cnstate_vars%onset_swi_patch                          , & ! Output:  [real(r8) (:)   ]  onset soil water index
+         offset_flag                         =>    cnstate_vars%offset_flag_patch                        , & ! Output:  [real(r8) (:)   ]  offset flag
+         offset_counter                      =>    cnstate_vars%offset_counter_patch                     , & ! Output:  [real(r8) (:)   ]  offset counter (seconds)
+         offset_fdd                          =>    cnstate_vars%offset_fdd_patch                         , & ! Output:  [real(r8) (:)   ]  offset freezing degree days counter
+         offset_swi                          =>    cnstate_vars%offset_swi_patch                         , & ! Output:  [real(r8) (:)   ]  offset soil water index
+         lgsf                                =>    cnstate_vars%lgsf_patch                               , & ! Output:  [real(r8) (:)   ]  long growing season factor [0-1]
+         bglfr_leaf                          =>    cnstate_vars%bglfr_leaf_patch                         , & ! Output:  [real(r8) (:)   ]  background leaf litterfall rate (1/s)
+         bglfr_froot                         =>    cnstate_vars%bglfr_froot_patch                        , & ! Output:  [real(r8) (:)   ]  background fine root litterfall rate (1/s)
+         bgtr                                =>    cnstate_vars%bgtr_patch                               , & ! Output:  [real(r8) (:)   ]  background transfer growth rate (1/s)
+         annavg_t2m                          =>    cnstate_vars%annavg_t2m_patch                         , & ! Output:  [real(r8) (:)   ]  annual average 2m air temperature (K)
+
+         leafc_storage                       =>    veg_cs%leafc_storage                  , & ! Input:  [real(r8)  (:)   ]  (gC/m2) leaf C storage
+         frootc_storage                      =>    veg_cs%frootc_storage                 , & ! Input:  [real(r8)  (:)   ]  (gC/m2) fine root C storage
+         livestemc_storage                   =>    veg_cs%livestemc_storage              , & ! Input:  [real(r8)  (:)   ]  (gC/m2) live stem C storage
+         deadstemc_storage                   =>    veg_cs%deadstemc_storage              , & ! Input:  [real(r8)  (:)   ]  (gC/m2) dead stem C storage
+         livecrootc_storage                  =>    veg_cs%livecrootc_storage             , & ! Input:  [real(r8)  (:)   ]  (gC/m2) live coarse root C storage
+         deadcrootc_storage                  =>    veg_cs%deadcrootc_storage             , & ! Input:  [real(r8)  (:)   ]  (gC/m2) dead coarse root C storage
+         gresp_storage                       =>    veg_cs%gresp_storage                  , & ! Input:  [real(r8)  (:)   ]  (gC/m2) growth respiration storage
+         leafc_xfer                          =>    veg_cs%leafc_xfer                     , & ! Output:  [real(r8) (:)   ]  (gC/m2) leaf C transfer
+         frootc_xfer                         =>    veg_cs%frootc_xfer                    , & ! Output:  [real(r8) (:)   ]  (gC/m2) fine root C transfer
+         livestemc_xfer                      =>    veg_cs%livestemc_xfer                 , & ! Output:  [real(r8) (:)   ]  (gC/m2) live stem C transfer
+         deadstemc_xfer                      =>    veg_cs%deadstemc_xfer                 , & ! Output:  [real(r8) (:)   ]  (gC/m2) dead stem C transfer
+         livecrootc_xfer                     =>    veg_cs%livecrootc_xfer                , & ! Output:  [real(r8) (:)   ]  (gC/m2) live coarse root C transfer
+         deadcrootc_xfer                     =>    veg_cs%deadcrootc_xfer                , & ! Output:  [real(r8) (:)   ]  (gC/m2) dead coarse root C transfer
+
+         leafn_storage                       =>    veg_ns%leafn_storage                , & ! Input:  [real(r8)  (:)   ]  (gN/m2) leaf N storage
+         frootn_storage                      =>    veg_ns%frootn_storage               , & ! Input:  [real(r8)  (:)   ]  (gN/m2) fine root N storage
+         livestemn_storage                   =>    veg_ns%livestemn_storage            , & ! Input:  [real(r8)  (:)   ]  (gN/m2) live stem N storage
+         deadstemn_storage                   =>    veg_ns%deadstemn_storage            , & ! Input:  [real(r8)  (:)   ]  (gN/m2) dead stem N storage
+         livecrootn_storage                  =>    veg_ns%livecrootn_storage           , & ! Input:  [real(r8)  (:)   ]  (gN/m2) live coarse root N storage
+         deadcrootn_storage                  =>    veg_ns%deadcrootn_storage           , & ! Input:  [real(r8)  (:)   ]  (gN/m2) dead coarse root N storage
+         leafn_xfer                          =>    veg_ns%leafn_xfer                   , & ! Output:  [real(r8) (:)   ]  (gN/m2) leaf N transfer
+         frootn_xfer                         =>    veg_ns%frootn_xfer                  , & ! Output:  [real(r8) (:)   ]  (gN/m2) fine root N transfer
+         livestemn_xfer                      =>    veg_ns%livestemn_xfer               , & ! Output:  [real(r8) (:)   ]  (gN/m2) live stem N transfer
+         deadstemn_xfer                      =>    veg_ns%deadstemn_xfer               , & ! Output:  [real(r8) (:)   ]  (gN/m2) dead stem N transfer
+         livecrootn_xfer                     =>    veg_ns%livecrootn_xfer              , & ! Output:  [real(r8) (:)   ]  (gN/m2) live coarse root N transfer
+         deadcrootn_xfer                     =>    veg_ns%deadcrootn_xfer              , & ! Output:  [real(r8) (:)   ]  (gN/m2) dead coarse root N transfer
 
 
-         leafp_storage                       =>    veg_ps%leafp_storage                , & ! Input:  [real(r8)  (:)   ]  (gP/m2) leaf P storage                            
-         frootp_storage                      =>    veg_ps%frootp_storage               , & ! Input:  [real(r8)  (:)   ]  (gP/m2) fine root P storage                       
-         livestemp_storage                   =>    veg_ps%livestemp_storage            , & ! Input:  [real(r8)  (:)   ]  (gP/m2) live stem P storage                       
-         deadstemp_storage                   =>    veg_ps%deadstemp_storage            , & ! Input:  [real(r8)  (:)   ]  (gP/m2) dead stem P storage                       
-         livecrootp_storage                  =>    veg_ps%livecrootp_storage           , & ! Input:  [real(r8)  (:)   ]  (gP/m2) live coarse root P storage                
-         deadcrootp_storage                  =>    veg_ps%deadcrootp_storage           , & ! Input:  [real(r8)  (:)   ]  (gP/m2) dead coarse root P storage                
-         leafp_xfer                          =>    veg_ps%leafp_xfer                   , & ! Output:  [real(r8) (:)   ]  (gP/m2) leaf P transfer                           
-         frootp_xfer                         =>    veg_ps%frootp_xfer                  , & ! Output:  [real(r8) (:)   ]  (gP/m2) fine root P transfer                      
-         livestemp_xfer                      =>    veg_ps%livestemp_xfer               , & ! Output:  [real(r8) (:)   ]  (gP/m2) live stem P transfer                      
-         deadstemp_xfer                      =>    veg_ps%deadstemp_xfer               , & ! Output:  [real(r8) (:)   ]  (gP/m2) dead stem P transfer                      
-         livecrootp_xfer                     =>    veg_ps%livecrootp_xfer              , & ! Output:  [real(r8) (:)   ]  (gP/m2) live coarse root P transfer               
-         deadcrootp_xfer                     =>    veg_ps%deadcrootp_xfer              , & ! Output:  [real(r8) (:)   ]  (gP/m2) dead coarse root P transfer               
-         
+         leafp_storage                       =>    veg_ps%leafp_storage                , & ! Input:  [real(r8)  (:)   ]  (gP/m2) leaf P storage
+         frootp_storage                      =>    veg_ps%frootp_storage               , & ! Input:  [real(r8)  (:)   ]  (gP/m2) fine root P storage
+         livestemp_storage                   =>    veg_ps%livestemp_storage            , & ! Input:  [real(r8)  (:)   ]  (gP/m2) live stem P storage
+         deadstemp_storage                   =>    veg_ps%deadstemp_storage            , & ! Input:  [real(r8)  (:)   ]  (gP/m2) dead stem P storage
+         livecrootp_storage                  =>    veg_ps%livecrootp_storage           , & ! Input:  [real(r8)  (:)   ]  (gP/m2) live coarse root P storage
+         deadcrootp_storage                  =>    veg_ps%deadcrootp_storage           , & ! Input:  [real(r8)  (:)   ]  (gP/m2) dead coarse root P storage
+         leafp_xfer                          =>    veg_ps%leafp_xfer                   , & ! Output:  [real(r8) (:)   ]  (gP/m2) leaf P transfer
+         frootp_xfer                         =>    veg_ps%frootp_xfer                  , & ! Output:  [real(r8) (:)   ]  (gP/m2) fine root P transfer
+         livestemp_xfer                      =>    veg_ps%livestemp_xfer               , & ! Output:  [real(r8) (:)   ]  (gP/m2) live stem P transfer
+         deadstemp_xfer                      =>    veg_ps%deadstemp_xfer               , & ! Output:  [real(r8) (:)   ]  (gP/m2) dead stem P transfer
+         livecrootp_xfer                     =>    veg_ps%livecrootp_xfer              , & ! Output:  [real(r8) (:)   ]  (gP/m2) live coarse root P transfer
+         deadcrootp_xfer                     =>    veg_ps%deadcrootp_xfer              , & ! Output:  [real(r8) (:)   ]  (gP/m2) dead coarse root P transfer
+
          prev_leafc_to_litter                =>    veg_cf%prev_leafc_to_litter            , & ! Output:  [real(r8) (:)   ]  previous timestep leaf C litterfall flux (gC/m2/s)
          prev_frootc_to_litter               =>    veg_cf%prev_frootc_to_litter           , & ! Output:  [real(r8) (:)   ]  previous timestep froot C litterfall flux (gC/m2/s)
-         leafc_xfer_to_leafc                 =>    veg_cf%leafc_xfer_to_leafc             , & ! Output:  [real(r8) (:)   ]                                                    
-         frootc_xfer_to_frootc               =>    veg_cf%frootc_xfer_to_frootc           , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemc_xfer_to_livestemc         =>    veg_cf%livestemc_xfer_to_livestemc     , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemc_xfer_to_deadstemc         =>    veg_cf%deadstemc_xfer_to_deadstemc     , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootc_xfer_to_livecrootc       =>    veg_cf%livecrootc_xfer_to_livecrootc   , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootc_xfer_to_deadcrootc       =>    veg_cf%deadcrootc_xfer_to_deadcrootc   , & ! Output:  [real(r8) (:)   ]                                                    
-         leafc_storage_to_xfer               =>    veg_cf%leafc_storage_to_xfer           , & ! Output:  [real(r8) (:)   ]                                                    
-         frootc_storage_to_xfer              =>    veg_cf%frootc_storage_to_xfer          , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemc_storage_to_xfer           =>    veg_cf%livestemc_storage_to_xfer       , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemc_storage_to_xfer           =>    veg_cf%deadstemc_storage_to_xfer       , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootc_storage_to_xfer          =>    veg_cf%livecrootc_storage_to_xfer      , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootc_storage_to_xfer          =>    veg_cf%deadcrootc_storage_to_xfer      , & ! Output:  [real(r8) (:)   ]                                                    
-         gresp_storage_to_xfer               =>    veg_cf%gresp_storage_to_xfer           , & ! Output:  [real(r8) (:)   ]                                                    
-         
-         leafn_xfer_to_leafn                 =>    veg_nf%leafn_xfer_to_leafn           , & ! Output:  [real(r8) (:)   ]                                                    
-         frootn_xfer_to_frootn               =>    veg_nf%frootn_xfer_to_frootn         , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemn_xfer_to_livestemn         =>    veg_nf%livestemn_xfer_to_livestemn   , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemn_xfer_to_deadstemn         =>    veg_nf%deadstemn_xfer_to_deadstemn   , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootn_xfer_to_livecrootn       =>    veg_nf%livecrootn_xfer_to_livecrootn , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootn_xfer_to_deadcrootn       =>    veg_nf%deadcrootn_xfer_to_deadcrootn , & ! Output:  [real(r8) (:)   ]                                                    
-         leafn_storage_to_xfer               =>    veg_nf%leafn_storage_to_xfer         , & ! Output:  [real(r8) (:)   ]                                                    
-         frootn_storage_to_xfer              =>    veg_nf%frootn_storage_to_xfer        , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemn_storage_to_xfer           =>    veg_nf%livestemn_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemn_storage_to_xfer           =>    veg_nf%deadstemn_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootn_storage_to_xfer          =>    veg_nf%livecrootn_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootn_storage_to_xfer          =>    veg_nf%deadcrootn_storage_to_xfer    ,  & ! Output:  [real(r8) (:)   ]                                                    
+         leafc_xfer_to_leafc                 =>    veg_cf%leafc_xfer_to_leafc             , & ! Output:  [real(r8) (:)   ]
+         frootc_xfer_to_frootc               =>    veg_cf%frootc_xfer_to_frootc           , & ! Output:  [real(r8) (:)   ]
+         livestemc_xfer_to_livestemc         =>    veg_cf%livestemc_xfer_to_livestemc     , & ! Output:  [real(r8) (:)   ]
+         deadstemc_xfer_to_deadstemc         =>    veg_cf%deadstemc_xfer_to_deadstemc     , & ! Output:  [real(r8) (:)   ]
+         livecrootc_xfer_to_livecrootc       =>    veg_cf%livecrootc_xfer_to_livecrootc   , & ! Output:  [real(r8) (:)   ]
+         deadcrootc_xfer_to_deadcrootc       =>    veg_cf%deadcrootc_xfer_to_deadcrootc   , & ! Output:  [real(r8) (:)   ]
+         leafc_storage_to_xfer               =>    veg_cf%leafc_storage_to_xfer           , & ! Output:  [real(r8) (:)   ]
+         frootc_storage_to_xfer              =>    veg_cf%frootc_storage_to_xfer          , & ! Output:  [real(r8) (:)   ]
+         livestemc_storage_to_xfer           =>    veg_cf%livestemc_storage_to_xfer       , & ! Output:  [real(r8) (:)   ]
+         deadstemc_storage_to_xfer           =>    veg_cf%deadstemc_storage_to_xfer       , & ! Output:  [real(r8) (:)   ]
+         livecrootc_storage_to_xfer          =>    veg_cf%livecrootc_storage_to_xfer      , & ! Output:  [real(r8) (:)   ]
+         deadcrootc_storage_to_xfer          =>    veg_cf%deadcrootc_storage_to_xfer      , & ! Output:  [real(r8) (:)   ]
+         gresp_storage_to_xfer               =>    veg_cf%gresp_storage_to_xfer           , & ! Output:  [real(r8) (:)   ]
 
-         leafp_xfer_to_leafp                 =>    veg_pf%leafp_xfer_to_leafp           , & ! Output:  [real(r8) (:)   ]                                                    
-         frootp_xfer_to_frootp               =>    veg_pf%frootp_xfer_to_frootp         , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemp_xfer_to_livestemp         =>    veg_pf%livestemp_xfer_to_livestemp   , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemp_xfer_to_deadstemp         =>    veg_pf%deadstemp_xfer_to_deadstemp   , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootp_xfer_to_livecrootp       =>    veg_pf%livecrootp_xfer_to_livecrootp , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootp_xfer_to_deadcrootp       =>    veg_pf%deadcrootp_xfer_to_deadcrootp , & ! Output:  [real(r8) (:)   ]                                                    
-         leafp_storage_to_xfer               =>    veg_pf%leafp_storage_to_xfer         , & ! Output:  [real(r8) (:)   ]                                                    
-         frootp_storage_to_xfer              =>    veg_pf%frootp_storage_to_xfer        , & ! Output:  [real(r8) (:)   ]                                                    
-         livestemp_storage_to_xfer           =>    veg_pf%livestemp_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]                                                    
-         deadstemp_storage_to_xfer           =>    veg_pf%deadstemp_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]                                                    
-         livecrootp_storage_to_xfer          =>    veg_pf%livecrootp_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]                                                    
-         deadcrootp_storage_to_xfer          =>    veg_pf%deadcrootp_storage_to_xfer      & ! Output:  [real(r8) (:)   ]                                                    
+         leafn_xfer_to_leafn                 =>    veg_nf%leafn_xfer_to_leafn           , & ! Output:  [real(r8) (:)   ]
+         frootn_xfer_to_frootn               =>    veg_nf%frootn_xfer_to_frootn         , & ! Output:  [real(r8) (:)   ]
+         livestemn_xfer_to_livestemn         =>    veg_nf%livestemn_xfer_to_livestemn   , & ! Output:  [real(r8) (:)   ]
+         deadstemn_xfer_to_deadstemn         =>    veg_nf%deadstemn_xfer_to_deadstemn   , & ! Output:  [real(r8) (:)   ]
+         livecrootn_xfer_to_livecrootn       =>    veg_nf%livecrootn_xfer_to_livecrootn , & ! Output:  [real(r8) (:)   ]
+         deadcrootn_xfer_to_deadcrootn       =>    veg_nf%deadcrootn_xfer_to_deadcrootn , & ! Output:  [real(r8) (:)   ]
+         leafn_storage_to_xfer               =>    veg_nf%leafn_storage_to_xfer         , & ! Output:  [real(r8) (:)   ]
+         frootn_storage_to_xfer              =>    veg_nf%frootn_storage_to_xfer        , & ! Output:  [real(r8) (:)   ]
+         livestemn_storage_to_xfer           =>    veg_nf%livestemn_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]
+         deadstemn_storage_to_xfer           =>    veg_nf%deadstemn_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]
+         livecrootn_storage_to_xfer          =>    veg_nf%livecrootn_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]
+         deadcrootn_storage_to_xfer          =>    veg_nf%deadcrootn_storage_to_xfer    ,  & ! Output:  [real(r8) (:)   ]
+
+         leafp_xfer_to_leafp                 =>    veg_pf%leafp_xfer_to_leafp           , & ! Output:  [real(r8) (:)   ]
+         frootp_xfer_to_frootp               =>    veg_pf%frootp_xfer_to_frootp         , & ! Output:  [real(r8) (:)   ]
+         livestemp_xfer_to_livestemp         =>    veg_pf%livestemp_xfer_to_livestemp   , & ! Output:  [real(r8) (:)   ]
+         deadstemp_xfer_to_deadstemp         =>    veg_pf%deadstemp_xfer_to_deadstemp   , & ! Output:  [real(r8) (:)   ]
+         livecrootp_xfer_to_livecrootp       =>    veg_pf%livecrootp_xfer_to_livecrootp , & ! Output:  [real(r8) (:)   ]
+         deadcrootp_xfer_to_deadcrootp       =>    veg_pf%deadcrootp_xfer_to_deadcrootp , & ! Output:  [real(r8) (:)   ]
+         leafp_storage_to_xfer               =>    veg_pf%leafp_storage_to_xfer         , & ! Output:  [real(r8) (:)   ]
+         frootp_storage_to_xfer              =>    veg_pf%frootp_storage_to_xfer        , & ! Output:  [real(r8) (:)   ]
+         livestemp_storage_to_xfer           =>    veg_pf%livestemp_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]
+         deadstemp_storage_to_xfer           =>    veg_pf%deadstemp_storage_to_xfer     , & ! Output:  [real(r8) (:)   ]
+         livecrootp_storage_to_xfer          =>    veg_pf%livecrootp_storage_to_xfer    , & ! Output:  [real(r8) (:)   ]
+         deadcrootp_storage_to_xfer          =>    veg_pf%deadcrootp_storage_to_xfer      & ! Output:  [real(r8) (:)   ]
 
          )
 
@@ -1159,7 +1160,7 @@ contains
                if (onset_flag(p) == 1._r8 .and. dayl(g) <= crit_dayl_stress) then
                   onset_flag(p) = 0._r8
                end if
-               ! Require cumulative precipitation threshold for onset 
+               ! Require cumulative precipitation threshold for onset
                ! Dahlin et al., Biogeosciences 2015.
                if (prec10(t) * 86400._r8 * 10._r8 < cumprec_onset .and. nu_com .eq. 'RD') then
                   onset_flag(p) = 0._r8
@@ -1355,7 +1356,7 @@ contains
     ! !DESCRIPTION:
     ! Code from AgroIBIS to determine crop phenology and code from CN to
     ! handle CN fluxes during the phenological onset                       & offset periods.
-    
+
     ! !USES:
     use clm_time_manager , only : get_curr_date, get_curr_calday, get_days_per_year
     use pftvarcon        , only : ncorn, nscereal, nwcereal, nsoybean, gddmin, hybgdd
@@ -1395,59 +1396,59 @@ contains
     real(r8) ndays_on ! number of days to fertilize
     !------------------------------------------------------------------------
 
-    associate(                                                                   & 
-         ivt                =>    veg_pp%itype                                 , & ! Input:  [integer  (:) ]  pft vegetation type                                
-         
-         leaf_long          =>    veg_vp%leaf_long                             , & ! Input:  [real(r8) (:) ]  leaf longevity (yrs)                              
-         froot_long         =>    veg_vp%froot_long                            , & ! Input:  [real(r8) (:) ]  fine root longevity (yrs)                              
+    associate(                                                                   &
+         ivt                =>    veg_pp%itype                                 , & ! Input:  [integer  (:) ]  pft vegetation type
 
-         leafcn             =>    veg_vp%leafcn                                , & ! Input:  [real(r8) (:) ]  leaf C:N (gC/gN)                                  
-         fertnitro          =>    veg_vp%fertnitro                             , & ! Input:  [real(r8) (:) ]  max fertilizer to be applied in total (kgN/m2)    
-         
+         leaf_long          =>    veg_vp%leaf_long                             , & ! Input:  [real(r8) (:) ]  leaf longevity (yrs)
+         froot_long         =>    veg_vp%froot_long                            , & ! Input:  [real(r8) (:) ]  fine root longevity (yrs)
+
+         leafcn             =>    veg_vp%leafcn                                , & ! Input:  [real(r8) (:) ]  leaf C:N (gC/gN)
+         fertnitro          =>    veg_vp%fertnitro                             , & ! Input:  [real(r8) (:) ]  max fertilizer to be applied in total (kgN/m2)
+
          t_ref2m_min        =>    veg_es%t_ref2m_min           , & ! Input:  [real(r8) (:) ]  daily minimum of average 2 m height surface air temperature (K)
-         t10                =>    veg_es%t_a10                 , & ! Input:  [real(r8) (:) ]  10-day running mean of the 2 m temperature (K)    
-         a5tmin             =>    veg_es%t_a5min               , & ! Input:  [real(r8) (:) ]  5-day running mean of min 2-m temperature         
-         a10tmin            =>    veg_es%t_a10min              , & ! Input:  [real(r8) (:) ]  10-day running mean of min 2-m temperature        
-         gdd020             =>    veg_es%gdd020                , & ! Input:  [real(r8) (:) ]  20 yr mean of gdd0                                
-         gdd820             =>    veg_es%gdd820                , & ! Input:  [real(r8) (:) ]  20 yr mean of gdd8                                
-         gdd1020            =>    veg_es%gdd1020               , & ! Input:  [real(r8) (:) ]  20 yr mean of gdd10                               
-         hui                =>    crop_vars%gddplant_patch                     , & ! Input:  [real(r8) (:) ]  gdd since planting (gddplant)                    
-         leafout            =>    crop_vars%gddtsoi_patch                      , & ! Input:  [real(r8) (:) ]  gdd from top soil layer temperature              
-         
-         tlai               =>    canopystate_vars%tlai_patch                  , & ! Input:  [real(r8) (:) ]  one-sided leaf area index, no burying by snow     
-         
-         idop               =>    cnstate_vars%idop_patch                      , & ! Output: [integer  (:) ]  date of planting                                   
-         harvdate           =>    crop_vars%harvdate_patch                     , & ! Output: [integer  (:) ]  harvest date                                       
-         croplive           =>    crop_vars%croplive_patch                     , & ! Output: [logical  (:) ]  Flag, true if planted, not harvested               
-         cropplant          =>    crop_vars%cropplant_patch                    , & ! Output: [logical  (:) ]  Flag, true if crop may be planted                  
-         gddmaturity        =>    cnstate_vars%gddmaturity_patch               , & ! Output: [real(r8) (:) ]  gdd needed to harvest                             
+         t10                =>    veg_es%t_a10                 , & ! Input:  [real(r8) (:) ]  10-day running mean of the 2 m temperature (K)
+         a5tmin             =>    veg_es%t_a5min               , & ! Input:  [real(r8) (:) ]  5-day running mean of min 2-m temperature
+         a10tmin            =>    veg_es%t_a10min              , & ! Input:  [real(r8) (:) ]  10-day running mean of min 2-m temperature
+         gdd020             =>    veg_es%gdd020                , & ! Input:  [real(r8) (:) ]  20 yr mean of gdd0
+         gdd820             =>    veg_es%gdd820                , & ! Input:  [real(r8) (:) ]  20 yr mean of gdd8
+         gdd1020            =>    veg_es%gdd1020               , & ! Input:  [real(r8) (:) ]  20 yr mean of gdd10
+         hui                =>    crop_vars%gddplant_patch                     , & ! Input:  [real(r8) (:) ]  gdd since planting (gddplant)
+         leafout            =>    crop_vars%gddtsoi_patch                      , & ! Input:  [real(r8) (:) ]  gdd from top soil layer temperature
+
+         tlai               =>    canopystate_vars%tlai_patch                  , & ! Input:  [real(r8) (:) ]  one-sided leaf area index, no burying by snow
+
+         idop               =>    cnstate_vars%idop_patch                      , & ! Output: [integer  (:) ]  date of planting
+         harvdate           =>    crop_vars%harvdate_patch                     , & ! Output: [integer  (:) ]  harvest date
+         croplive           =>    crop_vars%croplive_patch                     , & ! Output: [logical  (:) ]  Flag, true if planted, not harvested
+         cropplant          =>    crop_vars%cropplant_patch                    , & ! Output: [logical  (:) ]  Flag, true if crop may be planted
+         gddmaturity        =>    cnstate_vars%gddmaturity_patch               , & ! Output: [real(r8) (:) ]  gdd needed to harvest
          huileaf            =>    cnstate_vars%huileaf_patch                   , & ! Output: [real(r8) (:) ]  heat unit index needed from planting to leaf emergence
-         huigrain           =>    cnstate_vars%huigrain_patch                  , & ! Output: [real(r8) (:) ]  same to reach vegetative maturity                 
-         cumvd              =>    cnstate_vars%cumvd_patch                     , & ! Output: [real(r8) (:) ]  cumulative vernalization d?ependence?             
-         hdidx              =>    cnstate_vars%hdidx_patch                     , & ! Output: [real(r8) (:) ]  cold hardening index?                             
-         vf                 =>    crop_vars%vf_patch                           , & ! Output: [real(r8) (:) ]  vernalization factor                              
-         bglfr_leaf         =>    cnstate_vars%bglfr_leaf_patch                , & ! Output: [real(r8) (:) ]  background leaf litterfall rate (1/s)                  
-         bglfr_froot        =>    cnstate_vars%bglfr_froot_patch               , & ! Output: [real(r8) (:) ]  background fine root litterfall rate (1/s)    
-         bgtr               =>    cnstate_vars%bgtr_patch                      , & ! Output: [real(r8) (:) ]  background transfer growth rate (1/s)             
-         lgsf               =>    cnstate_vars%lgsf_patch                      , & ! Output: [real(r8) (:) ]  long growing season factor [0-1]                  
-         onset_flag         =>    cnstate_vars%onset_flag_patch                , & ! Output: [real(r8) (:) ]  onset flag                                        
-         offset_flag        =>    cnstate_vars%offset_flag_patch               , & ! Output: [real(r8) (:) ]  offset flag                                       
-         onset_counter      =>    cnstate_vars%onset_counter_patch             , & ! Output: [real(r8) (:) ]  onset counter                                     
-         offset_counter     =>    cnstate_vars%offset_counter_patch            , & ! Output: [real(r8) (:) ]  offset counter                                    
-         
-         leafc_xfer         =>    veg_cs%leafc_xfer            , & ! Output: [real(r8) (:) ]  (gC/m2)   leaf C transfer                           
+         huigrain           =>    cnstate_vars%huigrain_patch                  , & ! Output: [real(r8) (:) ]  same to reach vegetative maturity
+         cumvd              =>    cnstate_vars%cumvd_patch                     , & ! Output: [real(r8) (:) ]  cumulative vernalization d?ependence?
+         hdidx              =>    cnstate_vars%hdidx_patch                     , & ! Output: [real(r8) (:) ]  cold hardening index?
+         vf                 =>    crop_vars%vf_patch                           , & ! Output: [real(r8) (:) ]  vernalization factor
+         bglfr_leaf         =>    cnstate_vars%bglfr_leaf_patch                , & ! Output: [real(r8) (:) ]  background leaf litterfall rate (1/s)
+         bglfr_froot        =>    cnstate_vars%bglfr_froot_patch               , & ! Output: [real(r8) (:) ]  background fine root litterfall rate (1/s)
+         bgtr               =>    cnstate_vars%bgtr_patch                      , & ! Output: [real(r8) (:) ]  background transfer growth rate (1/s)
+         lgsf               =>    cnstate_vars%lgsf_patch                      , & ! Output: [real(r8) (:) ]  long growing season factor [0-1]
+         onset_flag         =>    cnstate_vars%onset_flag_patch                , & ! Output: [real(r8) (:) ]  onset flag
+         offset_flag        =>    cnstate_vars%offset_flag_patch               , & ! Output: [real(r8) (:) ]  offset flag
+         onset_counter      =>    cnstate_vars%onset_counter_patch             , & ! Output: [real(r8) (:) ]  onset counter
+         offset_counter     =>    cnstate_vars%offset_counter_patch            , & ! Output: [real(r8) (:) ]  offset counter
 
-         crop_seedc_to_leaf =>    veg_cf%crop_seedc_to_leaf     , & ! Output: [real(r8) (:) ]  (gC/m2/s) seed source to PFT-level                
+         leafc_xfer         =>    veg_cs%leafc_xfer            , & ! Output: [real(r8) (:) ]  (gC/m2)   leaf C transfer
 
-         fert_counter       =>    veg_nf%fert_counter         , & ! Output: [real(r8) (:) ]  >0 fertilize; <=0 not (seconds)                   
-         leafn_xfer         =>    veg_ns%leafn_xfer          , & ! Output: [real(r8) (:) ]  (gN/m2)   leaf N transfer                           
-         crop_seedn_to_leaf =>    veg_nf%crop_seedn_to_leaf   , & ! Output: [real(r8) (:) ]  (gN/m2/s) seed source to PFT-level                
+         crop_seedc_to_leaf =>    veg_cf%crop_seedc_to_leaf     , & ! Output: [real(r8) (:) ]  (gC/m2/s) seed source to PFT-level
+
+         fert_counter       =>    veg_nf%fert_counter         , & ! Output: [real(r8) (:) ]  >0 fertilize; <=0 not (seconds)
+         leafn_xfer         =>    veg_ns%leafn_xfer          , & ! Output: [real(r8) (:) ]  (gN/m2)   leaf N transfer
+         crop_seedn_to_leaf =>    veg_nf%crop_seedn_to_leaf   , & ! Output: [real(r8) (:) ]  (gN/m2/s) seed source to PFT-level
          crpyld             =>    crop_vars%crpyld_patch                       , & ! Output: [real(r8) ):)]  harvested crop (bu/acre)
          dmyield            =>    crop_vars%dmyield_patch                      , & ! Output: [real(r8) ):)]  dry matter harvested crop (t/ha)
-         leafcp             =>    veg_vp%leafcp                                , & ! Input:  [real(r8) (:) ]  leaf C:P (gC/gP)                                  
-         leafp_xfer         =>    veg_ps%leafp_xfer        , & ! Output: [real(r8) (:) ]  (gP/m2)   leaf P transfer                           
-         crop_seedp_to_leaf =>    veg_pf%crop_seedp_to_leaf , & ! Output: [real(r8) (:) ]  (gP/m2/s) seed source to PFT-level                
-         fert               =>    veg_nf%fert                   & ! Output: [real(r8) (:) ]  (gN/m2/s) fertilizer applied each timestep 
+         leafcp             =>    veg_vp%leafcp                                , & ! Input:  [real(r8) (:) ]  leaf C:P (gC/gP)
+         leafp_xfer         =>    veg_ps%leafp_xfer        , & ! Output: [real(r8) (:) ]  (gP/m2)   leaf P transfer
+         crop_seedp_to_leaf =>    veg_pf%crop_seedp_to_leaf , & ! Output: [real(r8) (:) ]  (gP/m2/s) seed source to PFT-level
+         fert               =>    veg_nf%fert                   & ! Output: [real(r8) (:) ]  (gN/m2/s) fertilizer applied each timestep
          )
 
       ! get time info
@@ -1563,7 +1564,7 @@ contains
                   leafp_xfer(p)  = leafc_xfer(p) / leafcp(ivt(p)) ! with onset
                   crop_seedp_to_leaf(p) = leafp_xfer(p)/dt
 
-                  ! latest possible date to plant winter cereal and after all other 
+                  ! latest possible date to plant winter cereal and after all other
                   ! crops were harvested for that year
 
                else if (jday       >=  maxplantjday(ivt(p),h) .and. &
@@ -1803,7 +1804,7 @@ contains
 
             else if (hui(p) >= huigrain(p)) then
                bglfr_leaf(p)  = 1._r8/(leaf_long(ivt(p))*dayspyr*secspday)
-               bglfr_froot(p) = 1._r8/(froot_long(ivt(p))*dayspyr*secspday) 
+               bglfr_froot(p) = 1._r8/(froot_long(ivt(p))*dayspyr*secspday)
             end if
 
             ! continue fertilizer application while in phase 2;
@@ -1847,7 +1848,7 @@ contains
     !
     ! !ARGUMENTS:
     implicit none
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     !
     ! LOCAL VARAIBLES:
     integer           :: p,g,n,i                     ! indices
@@ -1930,19 +1931,19 @@ contains
     integer  c,g                        ! indices
     !------------------------------------------------------------------------
 
-    associate(                                               & 
-         tlai        => canopystate_vars%tlai_patch        , & ! Input:  [real(r8) (:) ]  one-sided leaf area index, no burying by snow     
+    associate(                                               &
+         tlai        => canopystate_vars%tlai_patch        , & ! Input:  [real(r8) (:) ]  one-sided leaf area index, no burying by snow
 
-         t_ref2m     => veg_es%t_ref2m     , & ! Input:  [real(r8) (:) ]  2 m height surface air temperature (K)            
+         t_ref2m     => veg_es%t_ref2m     , & ! Input:  [real(r8) (:) ]  2 m height surface air temperature (K)
          t_ref2m_min => veg_es%t_ref2m_min , & ! Input:  [real(r8) (:) ] daily minimum of average 2 m height surface air temperature (K)
          t_ref2m_max => veg_es%t_ref2m_max , & ! Input:  [real(r8) (:) ] daily maximum of average 2 m height surface air temperature (K)
 
-         snow_depth  => col_ws%snow_depth     , & ! Input:  [real(r8) (:) ]  snow height (m)                                   
+         snow_depth  => col_ws%snow_depth     , & ! Input:  [real(r8) (:) ]  snow height (m)
 
-         hdidx       => cnstate_vars%hdidx_patch           , & ! Output: [real(r8) (:) ]  cold hardening index?                             
-         cumvd       => cnstate_vars%cumvd_patch           , & ! Output: [real(r8) (:) ]  cumulative vernalization d?ependence?             
-         vf          => crop_vars%vf_patch              , & ! Output: [real(r8) (:) ]  vernalization factor for cereal                   
-         gddmaturity => cnstate_vars%gddmaturity_patch     , & ! Output: [real(r8) (:) ]  gdd needed to harvest                             
+         hdidx       => cnstate_vars%hdidx_patch           , & ! Output: [real(r8) (:) ]  cold hardening index?
+         cumvd       => cnstate_vars%cumvd_patch           , & ! Output: [real(r8) (:) ]  cumulative vernalization d?ependence?
+         vf          => crop_vars%vf_patch              , & ! Output: [real(r8) (:) ]  vernalization factor for cereal
+         gddmaturity => cnstate_vars%gddmaturity_patch     , & ! Output: [real(r8) (:) ]  gdd needed to harvest
          huigrain    => cnstate_vars%huigrain_patch          & ! Output: [real(r8) (:) ]  heat unit index needed to reach vegetative maturity
          )
 
@@ -1951,7 +1952,7 @@ contains
       ! for all equations - temperatures must be in degrees (C)
       ! calculate temperature of crown of crop (e.g., 3 cm soil temperature)
       ! snow depth in centimeters
-      
+
       if (t_ref2m(p) < tfrz) then !slevis: t_ref2m inst of td=daily avg (K)
          tcrown = 2._r8 + (t_ref2m(p) - tfrz) * (0.4_r8 + 0.0018_r8 * &
               (min(snow_depth(c)*100._r8, 15._r8) - 15._r8)**2)
@@ -2039,7 +2040,7 @@ contains
          end if
       end if
 
-    end associate 
+    end associate
 
   end subroutine vernalization
 
@@ -2071,58 +2072,58 @@ contains
     real(r8):: t1           ! temporary variable
     !-----------------------------------------------------------------------
 
-    associate(                                                                                             & 
-         ivt                                 =>    veg_pp%itype                                             , & ! Input:  [integer   (:) ]  pft vegetation type                                
+    associate(                                                                                             &
+         ivt                                 =>    veg_pp%itype                                             , & ! Input:  [integer   (:) ]  pft vegetation type
 
          woody                               =>    veg_vp%woody                                      , & ! Input:  [real(r8)  (:) ]  binary flag for woody lifeform (1=woody, 0=not woody)
-         
-         onset_flag                          =>    cnstate_vars%onset_flag_patch                           , & ! Input:  [real(r8)  (:) ]  onset flag                                        
-         onset_counter                       =>    cnstate_vars%onset_counter_patch                        , & ! Input:  [real(r8)  (:) ]  onset days counter                                
-         bgtr                                =>    cnstate_vars%bgtr_patch                                 , & ! Input:  [real(r8)  (:) ]  background transfer growth rate (1/s)             
-         
-         leafc_xfer                          =>    veg_cs%leafc_xfer                     , & ! Input:  [real(r8)  (:) ]  (gC/m2) leaf C transfer                           
-         frootc_xfer                         =>    veg_cs%frootc_xfer                    , & ! Input:  [real(r8)  (:) ]  (gC/m2) fine root C transfer                      
-         livestemc_xfer                      =>    veg_cs%livestemc_xfer                 , & ! Input:  [real(r8)  (:) ]  (gC/m2) live stem C transfer                      
-         deadstemc_xfer                      =>    veg_cs%deadstemc_xfer                 , & ! Input:  [real(r8)  (:) ]  (gC/m2) dead stem C transfer                      
-         livecrootc_xfer                     =>    veg_cs%livecrootc_xfer                , & ! Input:  [real(r8)  (:) ]  (gC/m2) live coarse root C transfer               
-         deadcrootc_xfer                     =>    veg_cs%deadcrootc_xfer                , & ! Input:  [real(r8)  (:) ]  (gC/m2) dead coarse root C transfer               
-         
-         leafn_xfer                          =>    veg_ns%leafn_xfer                   , & ! Input:  [real(r8)  (:) ]  (gN/m2) leaf N transfer                           
-         frootn_xfer                         =>    veg_ns%frootn_xfer                  , & ! Input:  [real(r8)  (:) ]  (gN/m2) fine root N transfer                      
-         livestemn_xfer                      =>    veg_ns%livestemn_xfer               , & ! Input:  [real(r8)  (:) ]  (gN/m2) live stem N transfer                      
-         deadstemn_xfer                      =>    veg_ns%deadstemn_xfer               , & ! Input:  [real(r8)  (:) ]  (gN/m2) dead stem N transfer                      
-         livecrootn_xfer                     =>    veg_ns%livecrootn_xfer              , & ! Input:  [real(r8)  (:) ]  (gN/m2) live coarse root N transfer               
-         deadcrootn_xfer                     =>    veg_ns%deadcrootn_xfer              , & ! Input:  [real(r8)  (:) ]  (gN/m2) dead coarse root N transfer               
+
+         onset_flag                          =>    cnstate_vars%onset_flag_patch                           , & ! Input:  [real(r8)  (:) ]  onset flag
+         onset_counter                       =>    cnstate_vars%onset_counter_patch                        , & ! Input:  [real(r8)  (:) ]  onset days counter
+         bgtr                                =>    cnstate_vars%bgtr_patch                                 , & ! Input:  [real(r8)  (:) ]  background transfer growth rate (1/s)
+
+         leafc_xfer                          =>    veg_cs%leafc_xfer                     , & ! Input:  [real(r8)  (:) ]  (gC/m2) leaf C transfer
+         frootc_xfer                         =>    veg_cs%frootc_xfer                    , & ! Input:  [real(r8)  (:) ]  (gC/m2) fine root C transfer
+         livestemc_xfer                      =>    veg_cs%livestemc_xfer                 , & ! Input:  [real(r8)  (:) ]  (gC/m2) live stem C transfer
+         deadstemc_xfer                      =>    veg_cs%deadstemc_xfer                 , & ! Input:  [real(r8)  (:) ]  (gC/m2) dead stem C transfer
+         livecrootc_xfer                     =>    veg_cs%livecrootc_xfer                , & ! Input:  [real(r8)  (:) ]  (gC/m2) live coarse root C transfer
+         deadcrootc_xfer                     =>    veg_cs%deadcrootc_xfer                , & ! Input:  [real(r8)  (:) ]  (gC/m2) dead coarse root C transfer
+
+         leafn_xfer                          =>    veg_ns%leafn_xfer                   , & ! Input:  [real(r8)  (:) ]  (gN/m2) leaf N transfer
+         frootn_xfer                         =>    veg_ns%frootn_xfer                  , & ! Input:  [real(r8)  (:) ]  (gN/m2) fine root N transfer
+         livestemn_xfer                      =>    veg_ns%livestemn_xfer               , & ! Input:  [real(r8)  (:) ]  (gN/m2) live stem N transfer
+         deadstemn_xfer                      =>    veg_ns%deadstemn_xfer               , & ! Input:  [real(r8)  (:) ]  (gN/m2) dead stem N transfer
+         livecrootn_xfer                     =>    veg_ns%livecrootn_xfer              , & ! Input:  [real(r8)  (:) ]  (gN/m2) live coarse root N transfer
+         deadcrootn_xfer                     =>    veg_ns%deadcrootn_xfer              , & ! Input:  [real(r8)  (:) ]  (gN/m2) dead coarse root N transfer
 
 
-         leafp_xfer                          =>    veg_ps%leafp_xfer                   , & ! Input:  [real(r8)(:)   ]  (gP/m2) leaf P transfer                           
-         frootp_xfer                         =>    veg_ps%frootp_xfer                  , & ! Input:  [real(r8)(:)   ]  (gP/m2) fine root P transfer                      
-         livestemp_xfer                      =>    veg_ps%livestemp_xfer               , & ! Input:  [real(r8)(:)   ]  (gP/m2) live stem P transfer                      
-         deadstemp_xfer                      =>    veg_ps%deadstemp_xfer               , & ! Input:  [real(r8)(:)   ]  (gP/m2) dead stem P transfer                      
-         livecrootp_xfer                     =>    veg_ps%livecrootp_xfer              , & ! Input:  [real(r8)(:)   ]  (gP/m2) live coarse root P transfer               
-         deadcrootp_xfer                     =>    veg_ps%deadcrootp_xfer              , & ! Input:  [real(r8)(:)   ]  (gP/m2) dead coarse root P transfer               
+         leafp_xfer                          =>    veg_ps%leafp_xfer                   , & ! Input:  [real(r8)(:)   ]  (gP/m2) leaf P transfer
+         frootp_xfer                         =>    veg_ps%frootp_xfer                  , & ! Input:  [real(r8)(:)   ]  (gP/m2) fine root P transfer
+         livestemp_xfer                      =>    veg_ps%livestemp_xfer               , & ! Input:  [real(r8)(:)   ]  (gP/m2) live stem P transfer
+         deadstemp_xfer                      =>    veg_ps%deadstemp_xfer               , & ! Input:  [real(r8)(:)   ]  (gP/m2) dead stem P transfer
+         livecrootp_xfer                     =>    veg_ps%livecrootp_xfer              , & ! Input:  [real(r8)(:)   ]  (gP/m2) live coarse root P transfer
+         deadcrootp_xfer                     =>    veg_ps%deadcrootp_xfer              , & ! Input:  [real(r8)(:)   ]  (gP/m2) dead coarse root P transfer
 
 
-         leafc_xfer_to_leafc                 =>    veg_cf%leafc_xfer_to_leafc             , & ! Output:  [real(r8) (:) ]                                                    
-         frootc_xfer_to_frootc               =>    veg_cf%frootc_xfer_to_frootc           , & ! Output:  [real(r8) (:) ]                                                    
-         livestemc_xfer_to_livestemc         =>    veg_cf%livestemc_xfer_to_livestemc     , & ! Output:  [real(r8) (:) ]                                                    
-         deadstemc_xfer_to_deadstemc         =>    veg_cf%deadstemc_xfer_to_deadstemc     , & ! Output:  [real(r8) (:) ]                                                    
-         livecrootc_xfer_to_livecrootc       =>    veg_cf%livecrootc_xfer_to_livecrootc   , & ! Output:  [real(r8) (:) ]                                                    
-         deadcrootc_xfer_to_deadcrootc       =>    veg_cf%deadcrootc_xfer_to_deadcrootc   , & ! Output:  [real(r8) (:) ]                                                    
-         
-         leafn_xfer_to_leafn                 =>    veg_nf%leafn_xfer_to_leafn           , & ! Output:  [real(r8) (:) ]                                                    
-         frootn_xfer_to_frootn               =>    veg_nf%frootn_xfer_to_frootn         , & ! Output:  [real(r8) (:) ]                                                    
-         livestemn_xfer_to_livestemn         =>    veg_nf%livestemn_xfer_to_livestemn   , & ! Output:  [real(r8) (:) ]                                                    
-         deadstemn_xfer_to_deadstemn         =>    veg_nf%deadstemn_xfer_to_deadstemn   , & ! Output:  [real(r8) (:) ]                                                    
-         livecrootn_xfer_to_livecrootn       =>    veg_nf%livecrootn_xfer_to_livecrootn , & ! Output:  [real(r8) (:) ]                                                    
-         deadcrootn_xfer_to_deadcrootn       =>    veg_nf%deadcrootn_xfer_to_deadcrootn , & ! Output:  [real(r8) (:) ]                                                    
+         leafc_xfer_to_leafc                 =>    veg_cf%leafc_xfer_to_leafc             , & ! Output:  [real(r8) (:) ]
+         frootc_xfer_to_frootc               =>    veg_cf%frootc_xfer_to_frootc           , & ! Output:  [real(r8) (:) ]
+         livestemc_xfer_to_livestemc         =>    veg_cf%livestemc_xfer_to_livestemc     , & ! Output:  [real(r8) (:) ]
+         deadstemc_xfer_to_deadstemc         =>    veg_cf%deadstemc_xfer_to_deadstemc     , & ! Output:  [real(r8) (:) ]
+         livecrootc_xfer_to_livecrootc       =>    veg_cf%livecrootc_xfer_to_livecrootc   , & ! Output:  [real(r8) (:) ]
+         deadcrootc_xfer_to_deadcrootc       =>    veg_cf%deadcrootc_xfer_to_deadcrootc   , & ! Output:  [real(r8) (:) ]
 
-         leafp_xfer_to_leafp                 =>    veg_pf%leafp_xfer_to_leafp           , & ! Output:  [real(r8) (:) ]                                                    
-         frootp_xfer_to_frootp               =>    veg_pf%frootp_xfer_to_frootp         , & ! Output:  [real(r8) (:) ]                                                    
-         livestemp_xfer_to_livestemp         =>    veg_pf%livestemp_xfer_to_livestemp   , & ! Output:  [real(r8) (:) ]                                                    
-         deadstemp_xfer_to_deadstemp         =>    veg_pf%deadstemp_xfer_to_deadstemp   , & ! Output:  [real(r8) (:) ]                                                    
-         livecrootp_xfer_to_livecrootp       =>    veg_pf%livecrootp_xfer_to_livecrootp , & ! Output:  [real(r8) (:) ]                                                    
-         deadcrootp_xfer_to_deadcrootp       =>    veg_pf%deadcrootp_xfer_to_deadcrootp   & ! Output:  [real(r8) (:) ]                                                    
+         leafn_xfer_to_leafn                 =>    veg_nf%leafn_xfer_to_leafn           , & ! Output:  [real(r8) (:) ]
+         frootn_xfer_to_frootn               =>    veg_nf%frootn_xfer_to_frootn         , & ! Output:  [real(r8) (:) ]
+         livestemn_xfer_to_livestemn         =>    veg_nf%livestemn_xfer_to_livestemn   , & ! Output:  [real(r8) (:) ]
+         deadstemn_xfer_to_deadstemn         =>    veg_nf%deadstemn_xfer_to_deadstemn   , & ! Output:  [real(r8) (:) ]
+         livecrootn_xfer_to_livecrootn       =>    veg_nf%livecrootn_xfer_to_livecrootn , & ! Output:  [real(r8) (:) ]
+         deadcrootn_xfer_to_deadcrootn       =>    veg_nf%deadcrootn_xfer_to_deadcrootn , & ! Output:  [real(r8) (:) ]
+
+         leafp_xfer_to_leafp                 =>    veg_pf%leafp_xfer_to_leafp           , & ! Output:  [real(r8) (:) ]
+         frootp_xfer_to_frootp               =>    veg_pf%frootp_xfer_to_frootp         , & ! Output:  [real(r8) (:) ]
+         livestemp_xfer_to_livestemp         =>    veg_pf%livestemp_xfer_to_livestemp   , & ! Output:  [real(r8) (:) ]
+         deadstemp_xfer_to_deadstemp         =>    veg_pf%deadstemp_xfer_to_deadstemp   , & ! Output:  [real(r8) (:) ]
+         livecrootp_xfer_to_livecrootp       =>    veg_pf%livecrootp_xfer_to_livecrootp , & ! Output:  [real(r8) (:) ]
+         deadcrootp_xfer_to_deadcrootp       =>    veg_pf%deadcrootp_xfer_to_deadcrootp   & ! Output:  [real(r8) (:) ]
          )
 
       ! patch loop
@@ -2232,15 +2233,15 @@ contains
    !-------------------------------------------------------------------------
    associate(&
    ivt                   =>    veg_pp%itype                                   , & ! Input:  [integer (:)]  pft vegetation type
-   offset_flag           =>    cnstate_vars%offset_flag_patch              , & ! Input:  [real(r8) (:) ]  offset flag      
+   offset_flag           =>    cnstate_vars%offset_flag_patch              , & ! Input:  [real(r8) (:) ]  offset flag
    offset_counter        =>    cnstate_vars%offset_counter_patch           , & ! Input:  [real(r8) (:) ]  offset days counter
 
-   presharv              =>    veg_vp%presharv                         , & ! Input:  [real(r8) (:) ]  porportion of residue harvested 
+   presharv              =>    veg_vp%presharv                         , & ! Input:  [real(r8) (:) ]  porportion of residue harvested
    fyield                =>    veg_vp%fyield                           , & ! Input:  [real(r8) (:) ]  fraction of grain actually harvested
    convfact              =>    veg_vp%convfact                         , & ! Input:  [real(r8) (:) ]  converstion factor for bu/acre
 
-   leafc                 =>    veg_cs%leafc                , & ! Input:  [real(r8) (:) ]  (gC/m2) leaf C   
-   grainc                =>    veg_cs%grainc               , & ! Input:  [real(r8) (:) ]  (gC/m2) grain C  
+   leafc                 =>    veg_cs%leafc                , & ! Input:  [real(r8) (:) ]  (gC/m2) leaf C
+   grainc                =>    veg_cs%grainc               , & ! Input:  [real(r8) (:) ]  (gC/m2) grain C
    livestemc             =>    veg_cs%livestemc            , & ! Input:  [real(r8) (:) ]  (gC/m2) livestem C
    leafn                 =>    veg_ns%leafn              , & ! Input:  [real(r8) (:) ]  (gN/m2) leaf N
    grainn                =>    veg_ns%grainn             , & ! Input:  [real(r8) (:) ]  (gN/m2) grain N
@@ -2341,63 +2342,63 @@ contains
     real(r8):: t1           ! temporary variable
     !-----------------------------------------------------------------------
 
-    associate(                                                                     & 
-         ivt                   =>    veg_pp%itype                                   , & ! Input:  [integer  (:) ]  pft vegetation type                                
+    associate(                                                                     &
+         ivt                   =>    veg_pp%itype                                   , & ! Input:  [integer  (:) ]  pft vegetation type
 
-         leafcn                =>    veg_vp%leafcn                           , & ! Input:  [real(r8) (:) ]  leaf C:N (gC/gN)                                  
-         lflitcn               =>    veg_vp%lflitcn                          , & ! Input:  [real(r8) (:) ]  leaf litter C:N (gC/gN)                           
-         frootcn               =>    veg_vp%frootcn                          , & ! Input:  [real(r8) (:) ]  fine root C:N (gC/gN)                             
-         livewdcn              =>    veg_vp%livewdcn                         , & ! Input:  [real(r8) (:) ]  live wood C:N (gC/gN)                             
-         graincn               =>    veg_vp%graincn                          , & ! Input:  [real(r8) (:) ]  grain C:N (gC/gN)                                 
+         leafcn                =>    veg_vp%leafcn                           , & ! Input:  [real(r8) (:) ]  leaf C:N (gC/gN)
+         lflitcn               =>    veg_vp%lflitcn                          , & ! Input:  [real(r8) (:) ]  leaf litter C:N (gC/gN)
+         frootcn               =>    veg_vp%frootcn                          , & ! Input:  [real(r8) (:) ]  fine root C:N (gC/gN)
+         livewdcn              =>    veg_vp%livewdcn                         , & ! Input:  [real(r8) (:) ]  live wood C:N (gC/gN)
+         graincn               =>    veg_vp%graincn                          , & ! Input:  [real(r8) (:) ]  grain C:N (gC/gN)
          presharv              =>    veg_vp%presharv                         , & ! Input:  [real(r8) (:) ]  porportion of residue harvested
 
-         leafcp                =>    veg_vp%leafcp                           , & ! Input:  [real(r8) (:) ]  leaf C:P (gC/gP)                                  
-         lflitcp               =>    veg_vp%lflitcp                          , & ! Input:  [real(r8) (:) ]  leaf litter C:P (gC/gP)                           
-         frootcp               =>    veg_vp%frootcp                          , & ! Input:  [real(r8) (:) ]  fine root C:P (gC/gP)                             
-         livewdcp              =>    veg_vp%livewdcp                         , & ! Input:  [real(r8) (:) ]  live wood C:P (gC/gP)                             
-         graincp               =>    veg_vp%graincp                          , & ! Input:  [real(r8) (:) ]  grain C:P (gC/gP)                                 
+         leafcp                =>    veg_vp%leafcp                           , & ! Input:  [real(r8) (:) ]  leaf C:P (gC/gP)
+         lflitcp               =>    veg_vp%lflitcp                          , & ! Input:  [real(r8) (:) ]  leaf litter C:P (gC/gP)
+         frootcp               =>    veg_vp%frootcp                          , & ! Input:  [real(r8) (:) ]  fine root C:P (gC/gP)
+         livewdcp              =>    veg_vp%livewdcp                         , & ! Input:  [real(r8) (:) ]  live wood C:P (gC/gP)
+         graincp               =>    veg_vp%graincp                          , & ! Input:  [real(r8) (:) ]  grain C:P (gC/gP)
 
-         offset_flag           =>    cnstate_vars%offset_flag_patch              , & ! Input:  [real(r8) (:) ]  offset flag                                       
-         offset_counter        =>    cnstate_vars%offset_counter_patch           , & ! Input:  [real(r8) (:) ]  offset days counter                               
+         offset_flag           =>    cnstate_vars%offset_flag_patch              , & ! Input:  [real(r8) (:) ]  offset flag
+         offset_counter        =>    cnstate_vars%offset_counter_patch           , & ! Input:  [real(r8) (:) ]  offset days counter
 
-         leafc                 =>    veg_cs%leafc                , & ! Input:  [real(r8) (:) ]  (gC/m2) leaf C                                    
-         frootc                =>    veg_cs%frootc               , & ! Input:  [real(r8) (:) ]  (gC/m2) fine root C                               
-         grainc                =>    veg_cs%grainc               , & ! Input:  [real(r8) (:) ]  (gC/m2) grain C                                   
-         livestemc             =>    veg_cs%livestemc            , & ! Input:  [real(r8) (:) ]  (gC/m2) livestem C                                
+         leafc                 =>    veg_cs%leafc                , & ! Input:  [real(r8) (:) ]  (gC/m2) leaf C
+         frootc                =>    veg_cs%frootc               , & ! Input:  [real(r8) (:) ]  (gC/m2) fine root C
+         grainc                =>    veg_cs%grainc               , & ! Input:  [real(r8) (:) ]  (gC/m2) grain C
+         livestemc             =>    veg_cs%livestemc            , & ! Input:  [real(r8) (:) ]  (gC/m2) livestem C
 
-         cpool_to_grainc       =>    veg_cf%cpool_to_grainc       , & ! Input:  [real(r8) (:) ]  allocation to grain C (gC/m2/s)                   
-         cpool_to_livestemc    =>    veg_cf%cpool_to_livestemc    , & ! Input:  [real(r8) (:) ]  allocation to live stem C (gC/m2/s)               
-         cpool_to_leafc        =>    veg_cf%cpool_to_leafc        , & ! Input:  [real(r8) (:) ]  allocation to leaf C (gC/m2/s)                    
-         cpool_to_frootc       =>    veg_cf%cpool_to_frootc       , & ! Input:  [real(r8) (:) ]  allocation to fine root C (gC/m2/s)               
+         cpool_to_grainc       =>    veg_cf%cpool_to_grainc       , & ! Input:  [real(r8) (:) ]  allocation to grain C (gC/m2/s)
+         cpool_to_livestemc    =>    veg_cf%cpool_to_livestemc    , & ! Input:  [real(r8) (:) ]  allocation to live stem C (gC/m2/s)
+         cpool_to_leafc        =>    veg_cf%cpool_to_leafc        , & ! Input:  [real(r8) (:) ]  allocation to leaf C (gC/m2/s)
+         cpool_to_frootc       =>    veg_cf%cpool_to_frootc       , & ! Input:  [real(r8) (:) ]  allocation to fine root C (gC/m2/s)
          prev_leafc_to_litter  =>    veg_cf%prev_leafc_to_litter  , & ! Output: [real(r8) (:) ]  previous timestep leaf C litterfall flux (gC/m2/s)
          prev_frootc_to_litter =>    veg_cf%prev_frootc_to_litter , & ! Output: [real(r8) (:) ]  previous timestep froot C litterfall flux (gC/m2/s)
-         leafc_to_litter       =>    veg_cf%leafc_to_litter       , & ! Output: [real(r8) (:) ]  leaf C litterfall (gC/m2/s)                       
-         frootc_to_litter      =>    veg_cf%frootc_to_litter      , & ! Output: [real(r8) (:) ]  fine root C litterfall (gC/m2/s)                  
-         livestemc_to_litter   =>    veg_cf%livestemc_to_litter   , & ! Output: [real(r8) (:) ]  live stem C litterfall (gC/m2/s)                  
-         grainc_to_food        =>    veg_cf%grainc_to_food        , & ! Output: [real(r8) (:) ]  grain C to food (gC/m2/s)                         
+         leafc_to_litter       =>    veg_cf%leafc_to_litter       , & ! Output: [real(r8) (:) ]  leaf C litterfall (gC/m2/s)
+         frootc_to_litter      =>    veg_cf%frootc_to_litter      , & ! Output: [real(r8) (:) ]  fine root C litterfall (gC/m2/s)
+         livestemc_to_litter   =>    veg_cf%livestemc_to_litter   , & ! Output: [real(r8) (:) ]  live stem C litterfall (gC/m2/s)
+         grainc_to_food        =>    veg_cf%grainc_to_food        , & ! Output: [real(r8) (:) ]  grain C to food (gC/m2/s)
 
-         livestemn_to_litter   =>    veg_nf%livestemn_to_litter , & ! Output: [real(r8) (:) ]  livestem N to litter (gN/m2/s)                    
-         grainn_to_food        =>    veg_nf%grainn_to_food      , & ! Output: [real(r8) (:) ]  grain N to food (gN/m2/s)                         
-         leafn_to_litter       =>    veg_nf%leafn_to_litter     , & ! Output: [real(r8) (:) ]  leaf N litterfall (gN/m2/s)                       
-         leafn_to_retransn     =>    veg_nf%leafn_to_retransn   , & ! Output: [real(r8) (:) ]  leaf N to retranslocated N pool (gN/m2/s)         
-         frootn_to_litter      =>    veg_nf%frootn_to_litter    , & ! Output: [real(r8) (:) ]  fine root N litterfall (gN/m2/s)                  
+         livestemn_to_litter   =>    veg_nf%livestemn_to_litter , & ! Output: [real(r8) (:) ]  livestem N to litter (gN/m2/s)
+         grainn_to_food        =>    veg_nf%grainn_to_food      , & ! Output: [real(r8) (:) ]  grain N to food (gN/m2/s)
+         leafn_to_litter       =>    veg_nf%leafn_to_litter     , & ! Output: [real(r8) (:) ]  leaf N litterfall (gN/m2/s)
+         leafn_to_retransn     =>    veg_nf%leafn_to_retransn   , & ! Output: [real(r8) (:) ]  leaf N to retranslocated N pool (gN/m2/s)
+         frootn_to_litter      =>    veg_nf%frootn_to_litter    , & ! Output: [real(r8) (:) ]  fine root N litterfall (gN/m2/s)
 
-         livestemp_to_litter   =>    veg_pf%livestemp_to_litter , & ! Output: [real(r8) (:) ]  livestem P to litter (gP/m2/s)                    
-         grainp_to_food        =>    veg_pf%grainp_to_food      , & ! Output: [real(r8) (:) ]  grain P to food (gP/m2/s)                         
-         leafp_to_litter       =>    veg_pf%leafp_to_litter     , & ! Output: [real(r8) (:) ]  leaf P litterfall (gP/m2/s)                       
-         leafp_to_retransp     =>    veg_pf%leafp_to_retransp   , & ! Output: [real(r8) (:) ]  leaf P to retranslocated P pool (gP/m2/s)         
-         frootp_to_litter      =>    veg_pf%frootp_to_litter    , & ! Output: [real(r8) (:) ]  fine root P litterfall (gP/m2/s) 
-         
+         livestemp_to_litter   =>    veg_pf%livestemp_to_litter , & ! Output: [real(r8) (:) ]  livestem P to litter (gP/m2/s)
+         grainp_to_food        =>    veg_pf%grainp_to_food      , & ! Output: [real(r8) (:) ]  grain P to food (gP/m2/s)
+         leafp_to_litter       =>    veg_pf%leafp_to_litter     , & ! Output: [real(r8) (:) ]  leaf P litterfall (gP/m2/s)
+         leafp_to_retransp     =>    veg_pf%leafp_to_retransp   , & ! Output: [real(r8) (:) ]  leaf P to retranslocated P pool (gP/m2/s)
+         frootp_to_litter      =>    veg_pf%frootp_to_litter    , & ! Output: [real(r8) (:) ]  fine root P litterfall (gP/m2/s)
+
          prev_leafn_to_litter  =>    veg_nf%prev_leafn_to_litter    , & ! Output: [real(r8) (:) ]  previous timestep leaf N litterfall flux (gN/m2/s)
          prev_frootn_to_litter =>    veg_nf%prev_frootn_to_litter   , & ! Output: [real(r8) (:) ]  previous timestep froot N litterfall flux (gN/m2/s)
          prev_leafp_to_litter  =>    veg_pf%prev_leafp_to_litter  , & ! Output: [real(r8) (:) ]  previous timestep leaf P litterfall flux (gP/m2/s)
          prev_frootp_to_litter =>    veg_pf%prev_frootp_to_litter , & ! Output: [real(r8) (:) ]  previous timestep froot P litterfall flux (gP/m2/s)
-         leafn                 =>    veg_ns%leafn                  , & ! Input:  [real(r8) (:) ]  (gN/m2) leaf N                                  
-         frootn                =>    veg_ns%frootn                 , & ! Input:  [real(r8) (:) ]  (gN/m2) fine root N                               
-         livestemn             =>    veg_ns%livestemn              , & ! Input:  [real(r8) (:) ]  (gN/m2) livestem N                               
-         leafp                 =>    veg_ps%leafp                , & ! Input:  [real(r8) (:) ]  (gP/m2) leaf P                                 
-         frootp                =>    veg_ps%frootp               , & ! Input:  [real(r8) (:) ]  (gP/m2) fine root P                               
-         livestemp             =>    veg_ps%livestemp            , & ! Input:  [real(r8) (:) ]  (gP/m2) livestem P                              
+         leafn                 =>    veg_ns%leafn                  , & ! Input:  [real(r8) (:) ]  (gN/m2) leaf N
+         frootn                =>    veg_ns%frootn                 , & ! Input:  [real(r8) (:) ]  (gN/m2) fine root N
+         livestemn             =>    veg_ns%livestemn              , & ! Input:  [real(r8) (:) ]  (gN/m2) livestem N
+         leafp                 =>    veg_ps%leafp                , & ! Input:  [real(r8) (:) ]  (gP/m2) leaf P
+         frootp                =>    veg_ps%frootp               , & ! Input:  [real(r8) (:) ]  (gP/m2) fine root P
+         livestemp             =>    veg_ps%livestemp            , & ! Input:  [real(r8) (:) ]  (gP/m2) livestem P
          npool_to_leafn        =>    veg_nf%npool_to_leafn          , &
          npool_to_frootn       =>    veg_nf%npool_to_frootn         , &
          npool_to_livestemn    =>    veg_nf%npool_to_livestemn      , &
@@ -2414,7 +2415,7 @@ contains
 
       ! The litterfall transfer rate starts at 0.0 and increases linearly
       ! over time, with displayed growth going to 0.0 on the last day of litterfall
-      
+
       do fp = 1,num_soilp
          p = filter_soilp(fp)
 
@@ -2470,7 +2471,7 @@ contains
 
                   ! calculate fine root P litterfall (no retranslocation of fine root N)
                   frootp_to_litter(p) = frootc_to_litter(p) / frootcp(ivt(p))
-               end if 
+               end if
             else
                if (offset_counter(p) == dt) then
                   t1 = 1.0_r8 / dt
@@ -2485,12 +2486,12 @@ contains
 
                      livestemn_to_litter(p) = (1.0_r8 - presharv(ivt(p))) * ((t1 * livestemn(p)) + npool_to_livestemn(p))
                      livestemp_to_litter(p) = (1.0_r8 - presharv(ivt(p))) * ((t1 * livestemp(p)) + ppool_to_livestemp(p))
-                        
+
                   else
                      leafn_to_litter(p)   = (max(t1 * leafn(p),0._r8) + npool_to_leafn(p))*0.38_r8
                      leafn_to_retransn(p) = (max(t1 * leafn(p),0._r8) + npool_to_leafn(p))*0.62_r8
                      frootn_to_litter(p)  = max(t1 * frootn(p),0._r8) + npool_to_frootn(p)
-                     
+
                      leafp_to_litter(p)   = (max(t1 * leafp(p),0._r8) + ppool_to_leafp(p))*0.35_r8
                      leafp_to_retransp(p) = (max(t1 * leafp(p),0._r8) + ppool_to_leafp(p))*0.65_r8
                      frootp_to_litter(p)  = max(t1 * frootp(p),0._r8) + ppool_to_frootp(p)
@@ -2499,13 +2500,13 @@ contains
                   leafn_to_litter(p)   = max(min(leafc_to_litter(p) / max(leafc(p), 1.e-20_r8) * leafn(p), t1 * leafn(p)),0._r8)* 0.38_r8
                   leafn_to_retransn(p) = max(min(leafc_to_litter(p) / max(leafc(p), 1.e-20_r8) * leafn(p), t1 * leafn(p)),0._r8) * 0.62_r8
                   frootn_to_litter(p)  = max(min(frootc_to_litter(p)/max(frootc(p), 1.e-20_r8) * frootn(p),t1 * frootn(p)),0._r8)
-                    
+
                   leafp_to_litter(p)   = max(min(leafc_to_litter(p) / max(leafc(p), 1.e-20_r8) * leafp(p), t1 * leafp(p)),0._r8) * 0.35_r8
                   leafp_to_retransp(p) = max(min(leafc_to_litter(p) / max(leafc(p), 1.e-20_r8) * leafp(p), t1 * leafp(p)),0._r8) * 0.65_r8
                   frootp_to_litter(p)  = max(min(frootc_to_litter(p)/max(frootc(p), 1.e-20_r8) * frootp(p), t1 * frootp(p)),0._r8)
                end if
             end if
- 
+
             ! save the current litterfall fluxes
             prev_leafc_to_litter(p)  = leafc_to_litter(p)
             prev_frootc_to_litter(p) = frootc_to_litter(p)
@@ -2514,13 +2515,13 @@ contains
 
       end do ! end pft loop
 
-    end associate 
+    end associate
 
   end subroutine CNOffsetLitterfall
 
   !-----------------------------------------------------------------------
   subroutine CNBackgroundLitterfall (num_soilp, filter_soilp, &
-       cnstate_vars, carbonstate_vars, carbonflux_vars, nitrogenflux_vars,& 
+       cnstate_vars, carbonstate_vars, carbonflux_vars, nitrogenflux_vars,&
        phosphorusflux_vars, nitrogenstate_vars, phosphorusstate_vars)
     !
     ! !DESCRIPTION:
@@ -2543,34 +2544,34 @@ contains
     integer :: fp           ! lake filter pft index
     !-----------------------------------------------------------------------
 
-    associate(                                                               & 
-         ivt               =>    veg_pp%itype                                 , & ! Input:  [integer  (:) ]  pft vegetation type                                
+    associate(                                                               &
+         ivt               =>    veg_pp%itype                                 , & ! Input:  [integer  (:) ]  pft vegetation type
 
-         leafcn            =>    veg_vp%leafcn                         , & ! Input:  [real(r8) (:) ]  leaf C:N (gC/gN)                                  
-         lflitcn           =>    veg_vp%lflitcn                        , & ! Input:  [real(r8) (:) ]  leaf litter C:N (gC/gN)                           
-         frootcn           =>    veg_vp%frootcn                        , & ! Input:  [real(r8) (:) ]  fine root C:N (gC/gN)                             
+         leafcn            =>    veg_vp%leafcn                         , & ! Input:  [real(r8) (:) ]  leaf C:N (gC/gN)
+         lflitcn           =>    veg_vp%lflitcn                        , & ! Input:  [real(r8) (:) ]  leaf litter C:N (gC/gN)
+         frootcn           =>    veg_vp%frootcn                        , & ! Input:  [real(r8) (:) ]  fine root C:N (gC/gN)
 
-         leafcp            =>    veg_vp%leafcp                         , & ! Input:  [real(r8) (:) ]  leaf C:P (gC/gP)                                  
-         lflitcp           =>    veg_vp%lflitcp                        , & ! Input:  [real(r8) (:) ]  leaf litter C:P (gC/gP)                           
-         frootcp           =>    veg_vp%frootcp                        , & ! Input:  [real(r8) (:) ]  fine root C:P (gC/gP)                             
+         leafcp            =>    veg_vp%leafcp                         , & ! Input:  [real(r8) (:) ]  leaf C:P (gC/gP)
+         lflitcp           =>    veg_vp%lflitcp                        , & ! Input:  [real(r8) (:) ]  leaf litter C:P (gC/gP)
+         frootcp           =>    veg_vp%frootcp                        , & ! Input:  [real(r8) (:) ]  fine root C:P (gC/gP)
 
-         bglfr_leaf        =>    cnstate_vars%bglfr_leaf_patch            , & ! Input:  [real(r8) (:) ]  background leaf litterfall rate (1/s)                  
-         bglfr_froot       =>    cnstate_vars%bglfr_froot_patch           , & ! Input:  [real(r8) (:) ]  background fine root litterfall rate (1/s)    
+         bglfr_leaf        =>    cnstate_vars%bglfr_leaf_patch            , & ! Input:  [real(r8) (:) ]  background leaf litterfall rate (1/s)
+         bglfr_froot       =>    cnstate_vars%bglfr_froot_patch           , & ! Input:  [real(r8) (:) ]  background fine root litterfall rate (1/s)
 
-         leafc             =>    veg_cs%leafc              , & ! Input:  [real(r8) (:) ]  (gC/m2) leaf C                                    
-         frootc            =>    veg_cs%frootc             , & ! Input:  [real(r8) (:) ]  (gC/m2) fine root C                               
-         
-         leafc_to_litter   =>    veg_cf%leafc_to_litter     , & ! Output: [real(r8) (:) ]                                                    
-         frootc_to_litter  =>    veg_cf%frootc_to_litter    , & ! Output: [real(r8) (:) ]                                                    
+         leafc             =>    veg_cs%leafc              , & ! Input:  [real(r8) (:) ]  (gC/m2) leaf C
+         frootc            =>    veg_cs%frootc             , & ! Input:  [real(r8) (:) ]  (gC/m2) fine root C
 
-         leafn_to_litter   =>    veg_nf%leafn_to_litter   , & ! Output: [real(r8) (:) ]                                                    
-         leafn_to_retransn =>    veg_nf%leafn_to_retransn , & ! Output: [real(r8) (:) ]                                                    
-         frootn_to_litter  =>    veg_nf%frootn_to_litter  , & ! Output: [real(r8) (:) ]                                                    
+         leafc_to_litter   =>    veg_cf%leafc_to_litter     , & ! Output: [real(r8) (:) ]
+         frootc_to_litter  =>    veg_cf%frootc_to_litter    , & ! Output: [real(r8) (:) ]
 
-         leafp_to_litter   =>    veg_pf%leafp_to_litter   , & ! Output: [real(r8) (:) ]                                                    
-         leafp_to_retransp =>    veg_pf%leafp_to_retransp , & ! Output: [real(r8) (:) ]                                                    
-         frootp_to_litter  =>    veg_pf%frootp_to_litter  , & ! Output: [real(r8) (:) ]   
-         
+         leafn_to_litter   =>    veg_nf%leafn_to_litter   , & ! Output: [real(r8) (:) ]
+         leafn_to_retransn =>    veg_nf%leafn_to_retransn , & ! Output: [real(r8) (:) ]
+         frootn_to_litter  =>    veg_nf%frootn_to_litter  , & ! Output: [real(r8) (:) ]
+
+         leafp_to_litter   =>    veg_pf%leafp_to_litter   , & ! Output: [real(r8) (:) ]
+         leafp_to_retransp =>    veg_pf%leafp_to_retransp , & ! Output: [real(r8) (:) ]
+         frootp_to_litter  =>    veg_pf%frootp_to_litter  , & ! Output: [real(r8) (:) ]
+
          leafn             =>    veg_ns%leafn              , &
          frootn            =>    veg_ns%frootn             , &
          leafp             =>    veg_ps%leafp            , &
@@ -2619,7 +2620,7 @@ contains
          end if
       end do
 
-    end associate 
+    end associate
 
   end subroutine CNBackgroundLitterfall
 
@@ -2651,36 +2652,36 @@ contains
     real(r8):: ptovr        ! temporary variable for phosphorus turnover
     !-----------------------------------------------------------------------
 
-    associate(                                                                             & 
-         ivt                      =>    veg_pp%itype                                        , & ! Input:  [integer  (:) ]  pft vegetation type                                
+    associate(                                                                             &
+         ivt                      =>    veg_pp%itype                                        , & ! Input:  [integer  (:) ]  pft vegetation type
 
          woody                    =>    veg_vp%woody                                 , & ! Input:  [real(r8) (:) ]  binary flag for woody lifeform (1=woody, 0=not woody)
-         livewdcn                 =>    veg_vp%livewdcn                              , & ! Input:  [real(r8) (:) ]  live wood (phloem and ray parenchyma) C:N (gC/gN) 
-         deadwdcn                 =>    veg_vp%deadwdcn                              , & ! Input:  [real(r8) (:) ]  dead wood (xylem and heartwood) C:N (gC/gN)       
+         livewdcn                 =>    veg_vp%livewdcn                              , & ! Input:  [real(r8) (:) ]  live wood (phloem and ray parenchyma) C:N (gC/gN)
+         deadwdcn                 =>    veg_vp%deadwdcn                              , & ! Input:  [real(r8) (:) ]  dead wood (xylem and heartwood) C:N (gC/gN)
 
-         livestemc                =>    veg_cs%livestemc                 , & ! Input:  [real(r8) (:) ]  (gC/m2) live stem C                               
-         livecrootc               =>    veg_cs%livecrootc                , & ! Input:  [real(r8) (:) ]  (gC/m2) live coarse root C                        
+         livestemc                =>    veg_cs%livestemc                 , & ! Input:  [real(r8) (:) ]  (gC/m2) live stem C
+         livecrootc               =>    veg_cs%livecrootc                , & ! Input:  [real(r8) (:) ]  (gC/m2) live coarse root C
 
-         livestemn                =>    veg_ns%livestemn               , & ! Input:  [real(r8) (:) ]  (gN/m2) live stem N                               
-         livecrootn               =>    veg_ns%livecrootn              , & ! Input:  [real(r8) (:) ]  (gN/m2) live coarse root N                        
+         livestemn                =>    veg_ns%livestemn               , & ! Input:  [real(r8) (:) ]  (gN/m2) live stem N
+         livecrootn               =>    veg_ns%livecrootn              , & ! Input:  [real(r8) (:) ]  (gN/m2) live coarse root N
 
-         livestemp                =>    veg_ps%livestemp               , & ! Input:  [real(r8) (:) ]  (gN/m2) live stem N                               
-         livecrootp               =>    veg_ps%livecrootp              , & ! Input:  [real(r8) (:) ]  (gN/m2) live coarse root N                        
-         
-         livestemc_to_deadstemc   =>    veg_cf%livestemc_to_deadstemc     , & ! Output: [real(r8) (:) ]                                                    
-         livecrootc_to_deadcrootc =>    veg_cf%livecrootc_to_deadcrootc   , & ! Output: [real(r8) (:) ]                                                    
+         livestemp                =>    veg_ps%livestemp               , & ! Input:  [real(r8) (:) ]  (gN/m2) live stem N
+         livecrootp               =>    veg_ps%livecrootp              , & ! Input:  [real(r8) (:) ]  (gN/m2) live coarse root N
 
-         livestemn_to_deadstemn   =>    veg_nf%livestemn_to_deadstemn   , & ! Output: [real(r8) (:) ]                                                    
-         livestemn_to_retransn    =>    veg_nf%livestemn_to_retransn    , & ! Output: [real(r8) (:) ]                                                    
-         livecrootn_to_deadcrootn =>    veg_nf%livecrootn_to_deadcrootn , & ! Output: [real(r8) (:) ]                                                    
-         livecrootn_to_retransn   =>    veg_nf%livecrootn_to_retransn   , & ! Output: [real(r8) (:) ]                                                    
- 
-         livewdcp                 =>    veg_vp%livewdcp                              , & ! Input:  [real(r8) (:) ]  live wood (phloem and ray parenchyma) C:P (gC/gP) 
-         deadwdcp                 =>    veg_vp%deadwdcp                              , & ! Input:  [real(r8) (:) ]  dead wood (xylem and heartwood) C:P (gC/gP)       
-         livestemp_to_deadstemp   =>    veg_pf%livestemp_to_deadstemp   , & ! Output: [real(r8) (:) ]                                                    
-         livestemp_to_retransp    =>    veg_pf%livestemp_to_retransp    , & ! Output: [real(r8) (:) ]                                                    
-         livecrootp_to_deadcrootp =>    veg_pf%livecrootp_to_deadcrootp , & ! Output: [real(r8) (:) ]                                                    
-         livecrootp_to_retransp   =>    veg_pf%livecrootp_to_retransp     & ! Output: [real(r8) (:) ]                                              
+         livestemc_to_deadstemc   =>    veg_cf%livestemc_to_deadstemc     , & ! Output: [real(r8) (:) ]
+         livecrootc_to_deadcrootc =>    veg_cf%livecrootc_to_deadcrootc   , & ! Output: [real(r8) (:) ]
+
+         livestemn_to_deadstemn   =>    veg_nf%livestemn_to_deadstemn   , & ! Output: [real(r8) (:) ]
+         livestemn_to_retransn    =>    veg_nf%livestemn_to_retransn    , & ! Output: [real(r8) (:) ]
+         livecrootn_to_deadcrootn =>    veg_nf%livecrootn_to_deadcrootn , & ! Output: [real(r8) (:) ]
+         livecrootn_to_retransn   =>    veg_nf%livecrootn_to_retransn   , & ! Output: [real(r8) (:) ]
+
+         livewdcp                 =>    veg_vp%livewdcp                              , & ! Input:  [real(r8) (:) ]  live wood (phloem and ray parenchyma) C:P (gC/gP)
+         deadwdcp                 =>    veg_vp%deadwdcp                              , & ! Input:  [real(r8) (:) ]  dead wood (xylem and heartwood) C:P (gC/gP)
+         livestemp_to_deadstemp   =>    veg_pf%livestemp_to_deadstemp   , & ! Output: [real(r8) (:) ]
+         livestemp_to_retransp    =>    veg_pf%livestemp_to_retransp    , & ! Output: [real(r8) (:) ]
+         livecrootp_to_deadcrootp =>    veg_pf%livecrootp_to_deadcrootp , & ! Output: [real(r8) (:) ]
+         livecrootp_to_retransp   =>    veg_pf%livecrootp_to_retransp     & ! Output: [real(r8) (:) ]
          )
 
       ! patch loop
@@ -2699,7 +2700,7 @@ contains
                livestemc_to_deadstemc(p) = ctovr
                livestemn_to_deadstemn(p) = ctovr / deadwdcn(ivt(p))
                livestemn_to_retransn(p)  = ntovr - livestemn_to_deadstemn(p)
-               
+
                livestemp_to_deadstemp(p) = ctovr / deadwdcp(ivt(p))
                livestemp_to_retransp(p)  = ptovr - livestemp_to_deadstemp(p)
                ! live coarse root to dead coarse root turnover
@@ -2745,7 +2746,7 @@ contains
 
       end do
 
-    end associate 
+    end associate
 
   end subroutine CNLivewoodTurnover
 
@@ -2773,45 +2774,45 @@ contains
     integer :: fc,c,pi,p,j       ! indices
     !-----------------------------------------------------------------------
 
-    associate(                                                                                       & 
-         ivt                                 =>    veg_pp%itype                                       , & ! Input:  [integer  (:)   ]  pft vegetation type                                
-         wtcol                               =>    veg_pp%wtcol                                       , & ! Input:  [real(r8) (:)   ]  weight (relative to column) for this pft (0-1)    
+    associate(                                                                                       &
+         ivt                                 =>    veg_pp%itype                                       , & ! Input:  [integer  (:)   ]  pft vegetation type
+         wtcol                               =>    veg_pp%wtcol                                       , & ! Input:  [real(r8) (:)   ]  weight (relative to column) for this pft (0-1)
 
-         lf_flab                             =>    veg_vp%lf_flab                              , & ! Input:  [real(r8) (:)   ]  leaf litter labile fraction                       
-         lf_fcel                             =>    veg_vp%lf_fcel                              , & ! Input:  [real(r8) (:)   ]  leaf litter cellulose fraction                    
-         lf_flig                             =>    veg_vp%lf_flig                              , & ! Input:  [real(r8) (:)   ]  leaf litter lignin fraction                       
-         fr_flab                             =>    veg_vp%fr_flab                              , & ! Input:  [real(r8) (:)   ]  fine root litter labile fraction                  
-         fr_fcel                             =>    veg_vp%fr_fcel                              , & ! Input:  [real(r8) (:)   ]  fine root litter cellulose fraction               
-         fr_flig                             =>    veg_vp%fr_flig                              , & ! Input:  [real(r8) (:)   ]  fine root litter lignin fraction                  
+         lf_flab                             =>    veg_vp%lf_flab                              , & ! Input:  [real(r8) (:)   ]  leaf litter labile fraction
+         lf_fcel                             =>    veg_vp%lf_fcel                              , & ! Input:  [real(r8) (:)   ]  leaf litter cellulose fraction
+         lf_flig                             =>    veg_vp%lf_flig                              , & ! Input:  [real(r8) (:)   ]  leaf litter lignin fraction
+         fr_flab                             =>    veg_vp%fr_flab                              , & ! Input:  [real(r8) (:)   ]  fine root litter labile fraction
+         fr_fcel                             =>    veg_vp%fr_fcel                              , & ! Input:  [real(r8) (:)   ]  fine root litter cellulose fraction
+         fr_flig                             =>    veg_vp%fr_flig                              , & ! Input:  [real(r8) (:)   ]  fine root litter lignin fraction
 
-         leaf_prof                           =>    cnstate_vars%leaf_prof_patch                    , & ! Input:  [real(r8) (:,:) ]  (1/m) profile of leaves                         
-         froot_prof                          =>    cnstate_vars%froot_prof_patch                   , & ! Input:  [real(r8) (:,:) ]  (1/m) profile of fine roots                     
+         leaf_prof                           =>    cnstate_vars%leaf_prof_patch                    , & ! Input:  [real(r8) (:,:) ]  (1/m) profile of leaves
+         froot_prof                          =>    cnstate_vars%froot_prof_patch                   , & ! Input:  [real(r8) (:,:) ]  (1/m) profile of fine roots
 
-         leafc_to_litter                     =>    veg_cf%leafc_to_litter           , & ! Input:  [real(r8) (:)   ]  leaf C litterfall (gC/m2/s)                       
-         frootc_to_litter                    =>    veg_cf%frootc_to_litter          , & ! Input:  [real(r8) (:)   ]  fine root N litterfall (gN/m2/s)                  
-         livestemc_to_litter                 =>    veg_cf%livestemc_to_litter       , & ! Input:  [real(r8) (:)   ]  live stem C litterfall (gC/m2/s)                  
-!         grainc_to_food                      =>    veg_cf%grainc_to_food            , & ! Input:  [real(r8) (:)   ]  grain C to food (gC/m2/s)                         
+         leafc_to_litter                     =>    veg_cf%leafc_to_litter           , & ! Input:  [real(r8) (:)   ]  leaf C litterfall (gC/m2/s)
+         frootc_to_litter                    =>    veg_cf%frootc_to_litter          , & ! Input:  [real(r8) (:)   ]  fine root N litterfall (gN/m2/s)
+         livestemc_to_litter                 =>    veg_cf%livestemc_to_litter       , & ! Input:  [real(r8) (:)   ]  live stem C litterfall (gC/m2/s)
+!         grainc_to_food                      =>    veg_cf%grainc_to_food            , & ! Input:  [real(r8) (:)   ]  grain C to food (gC/m2/s)
          phenology_c_to_litr_met_c           =>    col_cf%phenology_c_to_litr_met_c   , & ! Output: [real(r8) (:,:) ]  C fluxes associated with phenology (litterfall and crop) to litter metabolic pool (gC/m3/s)
          phenology_c_to_litr_cel_c           =>    col_cf%phenology_c_to_litr_cel_c   , & ! Output: [real(r8) (:,:) ]  C fluxes associated with phenology (litterfall and crop) to litter cellulose pool (gC/m3/s)
          phenology_c_to_litr_lig_c           =>    col_cf%phenology_c_to_litr_lig_c   , & ! Output: [real(r8) (:,:) ]  C fluxes associated with phenology (litterfall and crop) to litter lignin pool (gC/m3/s)
 
-         livestemn_to_litter                 =>    veg_nf%livestemn_to_litter     , & ! Input:  [real(r8) (:)   ]  livestem N to litter (gN/m2/s)                    
-!         grainn_to_food                      =>    veg_nf%grainn_to_food          , & ! Input:  [real(r8) (:)   ]  grain N to food (gN/m2/s)                         
-         leafn_to_litter                     =>    veg_nf%leafn_to_litter         , & ! Input:  [real(r8) (:)   ]  leaf N litterfall (gN/m2/s)                       
-         frootn_to_litter                    =>    veg_nf%frootn_to_litter        , & ! Input:  [real(r8) (:)   ]  fine root N litterfall (gN/m2/s)                  
+         livestemn_to_litter                 =>    veg_nf%livestemn_to_litter     , & ! Input:  [real(r8) (:)   ]  livestem N to litter (gN/m2/s)
+!         grainn_to_food                      =>    veg_nf%grainn_to_food          , & ! Input:  [real(r8) (:)   ]  grain N to food (gN/m2/s)
+         leafn_to_litter                     =>    veg_nf%leafn_to_litter         , & ! Input:  [real(r8) (:)   ]  leaf N litterfall (gN/m2/s)
+         frootn_to_litter                    =>    veg_nf%frootn_to_litter        , & ! Input:  [real(r8) (:)   ]  fine root N litterfall (gN/m2/s)
          phenology_n_to_litr_met_n           =>    col_nf%phenology_n_to_litr_met_n , & ! Output: [real(r8) (:,:) ]  N fluxes associated with phenology (litterfall and crop) to litter metabolic pool (gN/m3/s)
          phenology_n_to_litr_cel_n           =>    col_nf%phenology_n_to_litr_cel_n , & ! Output: [real(r8) (:,:) ]  N fluxes associated with phenology (litterfall and crop) to litter cellulose pool (gN/m3/s)
          phenology_n_to_litr_lig_n           =>    col_nf%phenology_n_to_litr_lig_n , & ! Output: [real(r8) (:,:) ]  N fluxes associated with phenology (litterfall and crop) to litter lignin pool (gN/m3/s)
 
-         livestemp_to_litter                 =>    veg_pf%livestemp_to_litter     , & ! Input:  [real(r8) (:)   ]  livestem P to litter (gP/m2/s)                    
-!         grainp_to_food                      =>    veg_pf%grainp_to_food          , & ! Input:  [real(r8) (:)   ]  grain P to food (gP/m2/s)                         
-         leafp_to_litter                     =>    veg_pf%leafp_to_litter         , & ! Input:  [real(r8) (:)   ]  leaf P litterfall (gP/m2/s)                       
-         frootp_to_litter                    =>    veg_pf%frootp_to_litter        , & ! Input:  [real(r8) (:)   ]  fine root P litterfall (gP/m2/s)                  
+         livestemp_to_litter                 =>    veg_pf%livestemp_to_litter     , & ! Input:  [real(r8) (:)   ]  livestem P to litter (gP/m2/s)
+!         grainp_to_food                      =>    veg_pf%grainp_to_food          , & ! Input:  [real(r8) (:)   ]  grain P to food (gP/m2/s)
+         leafp_to_litter                     =>    veg_pf%leafp_to_litter         , & ! Input:  [real(r8) (:)   ]  leaf P litterfall (gP/m2/s)
+         frootp_to_litter                    =>    veg_pf%frootp_to_litter        , & ! Input:  [real(r8) (:)   ]  fine root P litterfall (gP/m2/s)
          phenology_p_to_litr_met_p           =>    col_pf%phenology_p_to_litr_met_p , & ! Output: [real(r8) (:,:) ]  P fluxes associated with phenology (litterfall and crop) to litter metabolic pool (gP/m3/s)
          phenology_p_to_litr_cel_p           =>    col_pf%phenology_p_to_litr_cel_p , & ! Output: [real(r8) (:,:) ]  P fluxes associated with phenology (litterfall and crop) to litter cellulose pool (gP/m3/s)
          phenology_p_to_litr_lig_p           =>    col_pf%phenology_p_to_litr_lig_p   & ! Output: [real(r8) (:,:) ]  P fluxes associated with phenology (litterfall and crop) to litter lignin pool (gP/m3/s)
          )
-    
+
       do j = 1, nlevdecomp
          do pi = 1,max_patch_per_col
             do fc = 1,num_soilc
@@ -2909,7 +2910,7 @@ contains
          end do
       end do
 
-    end associate 
+    end associate
 
   end subroutine CNLitterToColumn
 

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -17,7 +17,7 @@ module clm_varctl
   public :: cnallocate_carbonnitrogen_only
   public :: cnallocate_carbonphosphorus_only_set
   public :: cnallocate_carbonphosphorus_only
-  public :: get_carbontag ! get the tag for carbon simulations  
+  public :: get_carbontag ! get the tag for carbon simulations
   !
   private
   save
@@ -32,44 +32,44 @@ module clm_varctl
   ! Run control variables
   !
   ! case id
-  character(len=256), public :: caseid  = ' '                            
+  character(len=256), public :: caseid  = ' '
 
   ! case title
-  character(len=256), public :: ctitle  = ' '                            
+  character(len=256), public :: ctitle  = ' '
 
   ! Type of run
-  integer, public :: nsrest             = iundef                         
+  integer, public :: nsrest             = iundef
 
   ! Startup from initial conditions
-  integer, public, parameter :: nsrStartup  = 0                          
+  integer, public, parameter :: nsrStartup  = 0
 
   ! Continue from restart files
-  integer, public, parameter :: nsrContinue = 1                          
+  integer, public, parameter :: nsrContinue = 1
 
   ! Branch from restart files
-  integer, public, parameter :: nsrBranch   = 2                          
+  integer, public, parameter :: nsrBranch   = 2
 
   ! true => allow case name to remain the same for branch run
   ! by default this is not allowed
-  logical, public :: brnch_retain_casename = .false.                     
+  logical, public :: brnch_retain_casename = .false.
 
   !true => no valid land points -- do NOT run
-  logical, public :: noland = .false.                                    
+  logical, public :: noland = .false.
 
   ! Hostname of machine running on
-  character(len=256), public :: hostname = ' '                           
+  character(len=256), public :: hostname = ' '
 
   ! username of user running program
-  character(len=256), public :: username = ' '                           
+  character(len=256), public :: username = ' '
 
   ! description of this source
-  character(len=256), public :: source   = "Community Land Model CLM4.0" 
+  character(len=256), public :: source   = "Community Land Model CLM4.0"
 
   ! version of program
-  character(len=256), public :: version  = " "                           
+  character(len=256), public :: version  = " "
 
   ! dataset conventions
-  character(len=256), public :: conventions = "CF-1.0"                   
+  character(len=256), public :: conventions = "CF-1.0"
 
   !----------------------------------------------------------
   ! Unit Numbers
@@ -103,75 +103,75 @@ module clm_varctl
   ! Flag to turn on MEGAN VOC's
   !----------------------------------------------------------
 
-  logical, public :: use_voc = .true. 
+  logical, public :: use_voc = .true.
 
   !----------------------------------------------------------
   ! Interpolation of finidat if requested
   !----------------------------------------------------------
 
-  logical, public :: bound_h2osoi = .true. ! for debugging 
+  logical, public :: bound_h2osoi = .true. ! for debugging
 
   ! If finidat_interp_source is non-blank and finidat is blank then interpolation will be done from
   ! finidat_interp_source to finidat_interp_dest
 
   character(len=fname_len), public :: finidat_interp_source = ' '
-  character(len=fname_len), public :: finidat_interp_dest   = 'finidat_interp_dest.nc'     
+  character(len=fname_len), public :: finidat_interp_dest   = 'finidat_interp_dest.nc'
 
   !----------------------------------------------------------
   ! Irrigate logic
   !----------------------------------------------------------
 
   ! do not irrigate by default
-  logical, public :: irrigate = .false.            
+  logical, public :: irrigate = .false.
 
   !----------------------------------------------------------
   ! Landunit logic
   !----------------------------------------------------------
 
   ! true => separate crop landunit is not created by default
-  logical, public :: create_crop_landunit = .false.     
-  
+  logical, public :: create_crop_landunit = .false.
+
   !----------------------------------------------------------
   ! Other subgrid logic
   !----------------------------------------------------------
 
   ! true => make ALL patches, cols & landunits active (even if weight is 0)
-  logical, public :: all_active = .false.          
+  logical, public :: all_active = .false.
 
   !----------------------------------------------------------
   ! BGC logic and datasets
   !----------------------------------------------------------
 
   ! values of 'prognostic','diagnostic','constant'
-  character(len=16), public :: co2_type = 'constant'    
+  character(len=16), public :: co2_type = 'constant'
 
-  ! State of the model for the accelerated decomposition (AD) spinup. 
+  ! State of the model for the accelerated decomposition (AD) spinup.
   ! 0 (default) = normal model; 1 = AD SPINUP
-  integer, public :: spinup_state = 0 
+  integer, public :: spinup_state = 0
   integer, public :: nyears_ad_carbon_only = 0
   real(r8), public :: spinup_mortality_factor = 1._r8
 
   ! true => anoxia is applied to heterotrophic respiration also considered in CH4 model
   ! default value reset in controlMod
-  logical, public :: anoxia  = .true. 
+  logical, public :: anoxia  = .true.
 
   ! used to override an error check on reading in restart files
-  logical, public :: override_bgc_restart_mismatch_dump = .false. 
+  logical, public :: override_bgc_restart_mismatch_dump = .false.
 
   ! Set in AllocationInit (TODO - had to move it here to avoid circular dependency)
-  logical, private:: carbon_only      
-  logical, private:: carbonnitrogen_only      
-  logical, private:: carbonphosphorus_only      
+  logical, private:: carbon_only
+  logical, private:: carbonnitrogen_only
+  logical, private:: carbonphosphorus_only
 
   !----------------------------------------------------------
   ! Physics
   !----------------------------------------------------------
 
   ! use subgrid fluxes
-  integer,  public :: subgridflag = 1                   
+  integer,  public :: subgridflag = 1
 
   ! true => write global average diagnostics to std out
-  logical,  public :: wrtdia       = .false.            
+  logical,  public :: wrtdia       = .false.
 
   ! atmospheric CO2 molar ratio (by volume) (umol/mol)
   real(r8), public :: co2_ppmv     = 355._r8            !
@@ -199,7 +199,6 @@ module clm_varctl
                                                                        ! 2 => C+N+P (not enabled yet)
                                                                        ! no others enabled
 
-
   !----------------------------------------------------------
   !  BeTR switches
   !----------------------------------------------------------
@@ -223,30 +222,30 @@ module clm_varctl
   !----------------------------------------------------------
 
   ! glacier_mec landunit is not created (set in controlMod)
-  logical , public :: create_glacier_mec_landunit = .false. 
+  logical , public :: create_glacier_mec_landunit = .false.
 
   ! if true, pass surface mass balance info to GLC
-  logical , public :: glc_smb = .true.                      
+  logical , public :: glc_smb = .true.
 
   ! if false, pass positive-degree-day info to GLC
 
-  ! true => CLM glacier area & topography changes dynamically 
-  logical , public :: glc_do_dynglacier = .false.           
+  ! true => CLM glacier area & topography changes dynamically
+  logical , public :: glc_do_dynglacier = .false.
 
   ! true => downscale precip division into rain & snow
-  logical , public :: glcmec_downscale_rain_snow_convert = .false.     
+  logical , public :: glcmec_downscale_rain_snow_convert = .false.
 
   ! true => downscale longwave radiation
-  logical , public :: glcmec_downscale_longwave = .true.    
+  logical , public :: glcmec_downscale_longwave = .true.
 
   ! number of days before one considers the perennially snow-covered point 'land ice'
-  integer , public :: glc_snow_persistence_max_days = 7300  
+  integer , public :: glc_snow_persistence_max_days = 7300
 
-  ! glc_grid used to determine fglcmask  
-  character(len=256), public :: glc_grid = ' '              
+  ! glc_grid used to determine fglcmask
+  character(len=256), public :: glc_grid = ' '
 
   ! glacier mask file name (based on glc_grid)
-  character(len=fname_len), public :: fglcmask = ' '        
+  character(len=fname_len), public :: fglcmask = ' '
   !
   !----------------------------------------------------------
   ! single column control variables
@@ -269,22 +268,22 @@ module clm_varctl
   !----------------------------------------------------------
 
   ! number of segments per clump for decomp
-  integer, public :: nsegspc = 20                       
+  integer, public :: nsegspc = 20
 
   !----------------------------------------------------------
   ! Derived variables (run, history and restart file)
   !----------------------------------------------------------
 
   ! directory name for local restart pointer file
-  character(len=256), public :: rpntdir = '.'            
+  character(len=256), public :: rpntdir = '.'
 
   ! file name for local restart pointer file
-  character(len=256), public :: rpntfil = 'rpointer.lnd' 
+  character(len=256), public :: rpntfil = 'rpointer.lnd'
 
   ! moved hist_wrtch4diag from histFileMod.F90 to here - caused compiler error with intel
   ! namelist: write CH4 extra diagnostic output
-  logical, public :: hist_wrtch4diag = .false.         
-  
+  logical, public :: hist_wrtch4diag = .false.
+
   !----------------------------------------------------------
   ! ED/FATES
   !----------------------------------------------------------
@@ -335,17 +334,17 @@ module clm_varctl
   !
   logical, private :: clmvarctl_isset = .false.
   !-----------------------------------------------------------------------
- 
+
   !-----------------------------------------------------------------------
   ! nutrient competition (nu_com), default is relative demand approach (RD)
   character(len=15), public :: nu_com = 'RD'
- 
-  !-----------------------------------------------------------------------
-  ! forest N/P fertilization
-  logical, public :: forest_fert_exp = .false. 
 
   !-----------------------------------------------------------------------
-  ! ECA regular spinup with P on, keep labile, secondary, occluded, parent 
+  ! forest N/P fertilization
+  logical, public :: forest_fert_exp = .false.
+
+  !-----------------------------------------------------------------------
+  ! ECA regular spinup with P on, keep labile, secondary, occluded, parent
   ! material P being constant or not
   logical, public :: ECA_Pconst_RGspin = .false.
 
@@ -358,6 +357,11 @@ module clm_varctl
   !-----------------------------------------------------------------------
   logical, public            :: lateral_connectivity  = .false.
   character(len=256), public :: domain_decomp_type    = 'round_robin'
+
+  !-----------------------------------------------------------------------
+  ! flux limiter for phenology flux calculation
+  public, logical :: use_phenolmter = .false.
+
 
   !-----------------------------------------------------------------------
   ! bgc & pflotran interface
@@ -405,7 +409,7 @@ contains
     ! !ARGUMENTS:
     character(len=256), optional, intent(IN) :: caseid_in                ! case id
     character(len=256), optional, intent(IN) :: ctitle_in                ! case title
-    logical,            optional, intent(IN) :: brnch_retain_casename_in ! true => allow case name to remain the 
+    logical,            optional, intent(IN) :: brnch_retain_casename_in ! true => allow case name to remain the
                                                                          ! same for branch run
     logical,            optional, intent(IN) :: single_column_in         ! true => single column mode
     real(r8),           optional, intent(IN) :: scmlat_in                ! single column lat
@@ -470,9 +474,9 @@ contains
   function get_carbontag(carbon_type)result(ctag)
     implicit none
     character(len=*) :: carbon_type
-     
+
     character(len=3) :: ctag
-  
+
     if(carbon_type=='c12')then
        ctag = 'C'
     elseif(carbon_type=='c13')then
@@ -481,5 +485,5 @@ contains
        ctag = 'C14'
     endif
   end function get_carbontag
-  
+
 end module clm_varctl

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -360,7 +360,7 @@ module clm_varctl
 
   !-----------------------------------------------------------------------
   ! flux limiter for phenology flux calculation
-  public, logical :: use_phenolmter = .false.
+  logical, public :: use_phenolmter = .false.
 
 
   !-----------------------------------------------------------------------

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -10,7 +10,7 @@ module controlMod
   !       Display the file in a browser to see it neatly formatted in html.
   !
   ! !USES:
-  use clm_varctl   
+  use clm_varctl
   use shr_kind_mod            , only: r8 => shr_kind_r8, SHR_KIND_CL
   use shr_nl_mod              , only: shr_nl_find_group_name
   use shr_const_mod           , only: SHR_CONST_CDAY
@@ -19,20 +19,20 @@ module controlMod
   use spmdMod                 , only: masterproc
   use decompMod               , only: clump_pproc
   use clm_varpar              , only: maxpatch_pft, maxpatch_glcmec, more_vertlayers
-  use histFileMod             , only: max_tapes, max_namlen 
-  use histFileMod             , only: hist_empty_htapes, hist_dov2xy, hist_avgflag_pertape, hist_type1d_pertape 
+  use histFileMod             , only: max_tapes, max_namlen
+  use histFileMod             , only: hist_empty_htapes, hist_dov2xy, hist_avgflag_pertape, hist_type1d_pertape
   use histFileMod             , only: hist_nhtfrq, hist_ndens, hist_mfilt, hist_fincl1, hist_fincl2, hist_fincl3
   use histFileMod             , only: hist_fincl4, hist_fincl5, hist_fincl6, hist_fexcl1, hist_fexcl2, hist_fexcl3
   use histFileMod             , only: hist_fexcl4, hist_fexcl5, hist_fexcl6
-  use LakeCon                 , only: deepmixing_depthcrit, deepmixing_mixfact 
+  use LakeCon                 , only: deepmixing_depthcrit, deepmixing_mixfact
   use AllocationMod         , only: suplnitro
   use AllocationMod         , only: suplphos
   use ColumnDataType          , only: nfix_timeconst
   use CNNitrifDenitrifMod     , only: no_frozen_nitrif_denitrif
   use C14DecayMod           , only: use_c14_bombspike, atm_c14_filename
   use SoilLittVertTranspMod , only: som_adv_flux, max_depth_cryoturb
-  use VerticalProfileMod    , only: exponential_rooting_profile, rootprof_exp 
-  use VerticalProfileMod    , only: surfprof_exp, pftspecific_rootingprofile  
+  use VerticalProfileMod    , only: exponential_rooting_profile, rootprof_exp
+  use VerticalProfileMod    , only: surfprof_exp, pftspecific_rootingprofile
   use SharedParamsMod       , only: anoxia_wtsat
   use CanopyfluxesMod         , only: perchroot, perchroot_alt
   use CanopyHydrologyMod      , only: CanopyHydrology_readnl
@@ -40,12 +40,13 @@ module controlMod
   use UrbanParamsType         , only: urban_hac, urban_traffic
   use clm_varcon              , only: h2osno_max
   use clm_varctl              , only: use_dynroot
-  use AllocationMod         , only: nu_com_phosphatase,nu_com_nfix 
+  use AllocationMod         , only: nu_com_phosphatase,nu_com_nfix
   use clm_varctl              , only: nu_com, use_var_soil_thick
   use seq_drydep_mod          , only: drydep_method, DD_XLND, n_drydep
   use clm_varctl              , only: forest_fert_exp
   use clm_varctl              , only: ECA_Pconst_RGspin
   use clm_varctl              , only: NFIX_PTASE_plant
+  use clm_varctl              , only : use_phenolmter
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -172,7 +173,9 @@ contains
          ECA_Pconst_RGspin
     namelist /clm_inparm/ &
          NFIX_PTASE_plant
-         
+    namelist /clm_inparm/ &
+         use_phenolmter
+
     namelist /clm_inparm/  &
          suplnitro,suplphos
     namelist /clm_inparm/ &
@@ -196,9 +199,9 @@ contains
     ! lake_melt_icealb is of dimension numrad
 
     ! Glacier_mec info
-    namelist /clm_inparm/ &    
+    namelist /clm_inparm/ &
          maxpatch_glcmec, glc_smb, glc_do_dynglacier, glcmec_downscale_rain_snow_convert, &
-         glcmec_downscale_longwave, glc_snow_persistence_max_days, glc_grid, fglcmask 
+         glcmec_downscale_longwave, glc_snow_persistence_max_days, glc_grid, fglcmask
 
     ! Other options
 
@@ -216,7 +219,7 @@ contains
          som_adv_flux, max_depth_cryoturb
 
     ! C and N input vertical profiles
-    namelist /clm_inparm/  & 
+    namelist /clm_inparm/  &
           exponential_rooting_profile, rootprof_exp, surfprof_exp, pftspecific_rootingprofile
 
     namelist /clm_inparm / no_frozen_nitrif_denitrif
@@ -232,13 +235,13 @@ contains
           fates_parteh_mode
 
     namelist /clm_inparm / use_betr
-        
+
     namelist /clm_inparm / use_lai_streams
 
     namelist /clm_inparm/  &
          use_c14_bombspike, atm_c14_filename
 
-    ! All old cpp-ifdefs are below and have been converted to namelist variables 
+    ! All old cpp-ifdefs are below and have been converted to namelist variables
 
     ! max number of plant functional types in naturally vegetated landunit
     namelist /clm_inparm/ maxpatch_pft
@@ -299,7 +302,7 @@ contains
     if (masterproc) then
 
        ! ----------------------------------------------------------------------
-       ! Read namelist from standard input. 
+       ! Read namelist from standard input.
        ! ----------------------------------------------------------------------
 
        if ( len_trim(NLFilename) == 0  )then
@@ -316,7 +319,7 @@ contains
              call endrun(msg='ERROR reading clm_inparm namelist'//errMsg(__FILE__, __LINE__))
           end if
        end if
-       
+
        print*,"X.YANG debug SUPL NITROGEN and PHOSPHORUS ",suplnitro,suplphos
        call relavu( unitn )
 
@@ -341,7 +344,7 @@ contains
           endif
        end do
 
-       ! Override start-type (can only override to branch (3)  and only 
+       ! Override start-type (can only override to branch (3)  and only
        ! if the driver is a startup type
        if ( override_nsrest /= nsrest )then
            if ( override_nsrest /= nsrBranch .and. nsrest /= nsrStartup )then
@@ -351,14 +354,14 @@ contains
            end if
            call clm_varctl_set( nsrest_in=override_nsrest )
        end if
-       
+
        if (maxpatch_glcmec > 0) then
           create_glacier_mec_landunit = .true.
        else
           create_glacier_mec_landunit = .false.
        end if
 
-       ! Check compatibility with the FATES model 
+       ! Check compatibility with the FATES model
        if ( use_fates ) then
 
           use_voc = .false.
@@ -367,12 +370,12 @@ contains
              call endrun(msg=' ERROR: use_cn and use_fates cannot both be set to true.'//&
                    errMsg(__FILE__, __LINE__))
           end if
-          
+
           if ( use_crop ) then
              call endrun(msg=' ERROR: use_crop and use_fates cannot both be set to true.'//&
                    errMsg(__FILE__, __LINE__))
           end if
-          
+
           if( use_lch4 ) then
              call endrun(msg=' ERROR: use_lch4 (methane) and use_fates cannot both be set to true.'//&
                    errMsg(__FILE__, __LINE__))
@@ -390,18 +393,18 @@ contains
           call endrun(msg=' ERROR:: CROP and C13/C14 can NOT be on at the same time'//&
             errMsg(__FILE__, __LINE__))
        end if
-       
+
        if (use_crop .and. .not. create_crop_landunit) then
           call endrun(msg=' ERROR: prognostic crop Patches require create_crop_landunit=.true.'//&
             errMsg(__FILE__, __LINE__))
        end if
-       
+
        if (.not. use_crop .and. irrigate) then
           call endrun(msg=' ERROR: irrigate = .true. requires CROP model active.'//&
             errMsg(__FILE__, __LINE__))
        end if
-       
-       if (use_lch4 .and. use_vertsoilc) then 
+
+       if (use_lch4 .and. use_vertsoilc) then
           anoxia = .true.
        else
           anoxia = .false.
@@ -443,7 +446,7 @@ contains
     !For future version, I suggest to  put the following two calls inside their
     !own modules, which are called from their own initializing methods
     call init_hydrology( NLFilename )
-    
+
     call CanopyHydrology_readnl( NLFilename )
 
     ! ----------------------------------------------------------------------
@@ -451,14 +454,14 @@ contains
     ! ----------------------------------------------------------------------
 
     call control_spmd()
-    
+
     if (use_pflotran) then
        call clm_pf_readnl(NLFilename)
     end if
 
     if (use_betr) then
        call betr_readNL( NLFilename, use_c13, use_c14)
-    endif    
+    endif
 
     ! ----------------------------------------------------------------------
     ! consistency checks
@@ -473,7 +476,7 @@ contains
 
     ! Check on run type
     if (nsrest == iundef) then
-       call endrun(msg=' ERROR:: must set nsrest'//& 
+       call endrun(msg=' ERROR:: must set nsrest'//&
             errMsg(__FILE__, __LINE__))
     end if
     if (nsrest == nsrBranch .and. nrevsn == ' ') then
@@ -483,7 +486,7 @@ contains
 
     ! Consistency settings for co2_ppvm
     if ( (co2_ppmv <= 0.0_r8) .or. (co2_ppmv > 3000.0_r8) ) then
-       call endrun(msg=' ERROR: co2_ppmv is out of a reasonable range'//& 
+       call endrun(msg=' ERROR: co2_ppmv is out of a reasonable range'//&
             errMsg(__FILE__, __LINE__))
     end if
 
@@ -551,9 +554,9 @@ contains
   subroutine control_spmd()
     !
     ! !DESCRIPTION:
-    ! Distribute namelist data all processors. All program i/o is 
-    ! funnelled through the master processor. Processor 0 either 
-    ! reads restart/history data from the disk and distributes 
+    ! Distribute namelist data all processors. All program i/o is
+    ! funnelled through the master processor. Processor 0 either
+    ! reads restart/history data from the disk and distributes
     ! it to all processors, or collects data from
     ! all processors and writes it to disk.
     !
@@ -635,7 +638,7 @@ contains
     call mpi_bcast (forest_fert_exp, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (ECA_Pconst_RGspin, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (NFIX_PTASE_plant, 1, MPI_LOGICAL, 0, mpicom, ier)
-
+    call mpi_bcast (use_phenolmter, 1, MPI_LOGICAL, 0, mpicom, ier)
     ! isotopes
     call mpi_bcast (use_c13, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_c14, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -671,7 +674,7 @@ contains
        call mpi_bcast (pftspecific_rootingprofile,        1, MPI_LOGICAL,  0, mpicom, ier)
     end if
 
-    if (use_cn .and. use_nitrif_denitrif) then 
+    if (use_cn .and. use_nitrif_denitrif) then
        call mpi_bcast (no_frozen_nitrif_denitrif,  1, MPI_LOGICAL, 0, mpicom, ier)
     end if
 
@@ -756,7 +759,7 @@ contains
     call mpi_bcast (use_clm_interface, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_clm_bgc, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_pflotran, 1, MPI_LOGICAL, 0, mpicom, ier)
-    
+
     !cpl_bypass
      call mpi_bcast (metdata_type,   len(metdata_type),   MPI_CHARACTER, 0, mpicom, ier)
      call mpi_bcast (metdata_bypass, len(metdata_bypass), MPI_CHARACTER, 0, mpicom, ier)
@@ -858,13 +861,13 @@ contains
           write(iulog,*) '   Supplemental Nitrogen mode is set to run over Patches: ', &
                trim(suplnitro)
        end if
-       
+
        if (nfix_timeconst /= 0._r8) then
           write(iulog,*) '   nfix_timeconst, timescale for smoothing npp in N fixation term: ', nfix_timeconst
        else
           write(iulog,*) '   nfix_timeconst == zero, use standard N fixation scheme. '
        end if
-       
+
        write(iulog,*) '   spinup_state, (0 = normal mode; 1 = AD spinup)         : ', spinup_state
        if ( spinup_state .eq. 0 ) then
           write(iulog,*) '   model is currently NOT in AD spinup mode.'
@@ -876,7 +879,7 @@ contains
           call endrun(msg=' error: spinup_state can only have integer value of 0 or 1'//&
                errMsg(__FILE__, __LINE__))
        end if
-       
+
        write(iulog,*) '   override_bgc_restart_mismatch_dump                     : ', override_bgc_restart_mismatch_dump
     end if
        if (suplphos /= suplpNon)then
@@ -887,14 +890,14 @@ contains
     if (use_cn .and. use_vertsoilc) then
        write(iulog, *) '   som_adv_flux, the advection term in soil mixing (m/s) : ', som_adv_flux
        write(iulog, *) '   max_depth_cryoturb (m)                                : ', max_depth_cryoturb
-       
+
        write(iulog, *) '   exponential_rooting_profile                           : ', exponential_rooting_profile
        write(iulog, *) '   rootprof_exp                                          : ', rootprof_exp
        write(iulog, *) '   surfprof_exp                                          : ', surfprof_exp
        write(iulog, *) '   pftspecific_rootingprofile                            : ', pftspecific_rootingprofile
        write(iulog, *) '   dynamic roots                                         : ', use_dynroot
     end if
-       
+
     if (use_cn .and. .not. use_nitrif_denitrif) then
        write(iulog, *) '   no_frozen_nitrif_denitrif                             : ', no_frozen_nitrif_denitrif
     end if
@@ -921,7 +924,7 @@ contains
        write(iulog,*) '   glc number of elevation classes =', maxpatch_glcmec
        write(iulog,*) '   glc grid for glacier mask file = ',trim(glc_grid)
        write(iulog,*) '   glc glacier mask file = ',trim(fglcmask)
-       
+
        write(iulog,*) '   Max snow depth (mm) =', h2osno_max
        if (glcmec_downscale_rain_snow_convert) then
           write(iulog,*) '   Rain and snow will be converted based on surface temperature'


### PR DESCRIPTION
Introduced a flux limiter to avoid the occurrence of negative litter fluxes after the phenology calculation. The flux limiter is optional, and is off by default, but it can be turned on by setting the logical switch use_phenolmter to true. This feature will be essential when the elm big leaf model is coupled to plug-in reactive transport models, such as BeTR. The code has passed the  e3sm_land_developer test suite on cori, and is BFB when the new feature is off.