### PR TITLE
Fix the setting of ocn_c2_glcshelf based on value of land_ice_flux_mode

### DIFF
--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -790,9 +790,14 @@ contains
     if ( trim(config_land_ice_flux_mode) .eq. 'pressure_only' ) then
        call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
                                             ocn_c2_glcshelf=.false.)
-    else
+    else if ( trim(config_land_ice_flux_mode) .eq. 'standalone' ) then
+       call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
+                                            ocn_c2_glcshelf=.false.)
+    else if ( trim(config_land_ice_flux_mode) .eq. 'coupled' ) then
        call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
                                             ocn_c2_glcshelf=.true.)
+    else
+       call mpas_log_write('ERROR: unknown land_ice_flux_mode: ' // trim(config_land_ice_flux_mode), MPAS_LOG_CRIT)
     end if
 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the value of ocn_c2_glcshelf that is passed from mpas-o to the coupler and used to determine whether or not the coupler computes ice sheet melt fluxes. It is now based on all possible values of land_ice_flux_mode and fixes issues with ocean ISMF compsets.

Fixes #2947
[BFB]