### PR TITLE
Update mpas-source for Langmuir ocean vertical mixing parameterization

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -644,12 +644,58 @@ add_default($nl, 'config_Rayleigh_damping_coeff');
 add_default($nl, 'config_Rayleigh_bottom_friction');
 add_default($nl, 'config_Rayleigh_bottom_damping_coeff');
 
-########################
-# Namelist group: vmix #
-########################
+#########################
+# Namelist group: cvmix #
+#########################
 
-add_default($nl, 'config_convective_visc');
-add_default($nl, 'config_convective_diff');
+add_default($nl, 'config_use_cvmix');
+add_default($nl, 'config_cvmix_prandtl_number');
+add_default($nl, 'config_use_cvmix_background');
+add_default($nl, 'config_cvmix_background_diffusion');
+add_default($nl, 'config_cvmix_background_viscosity');
+add_default($nl, 'config_use_cvmix_convection');
+add_default($nl, 'config_cvmix_convective_diffusion');
+add_default($nl, 'config_cvmix_convective_viscosity');
+add_default($nl, 'config_cvmix_convective_basedOnBVF');
+add_default($nl, 'config_cvmix_convective_triggerBVF');
+add_default($nl, 'config_use_cvmix_shear');
+add_default($nl, 'config_cvmix_num_ri_smooth_loops');
+add_default($nl, 'config_cvmix_use_BLD_smoothing');
+add_default($nl, 'config_cvmix_shear_mixing_scheme');
+add_default($nl, 'config_cvmix_shear_PP_nu_zero');
+add_default($nl, 'config_cvmix_shear_PP_alpha');
+add_default($nl, 'config_cvmix_shear_PP_exp');
+add_default($nl, 'config_cvmix_shear_KPP_nu_zero');
+add_default($nl, 'config_cvmix_shear_KPP_Ri_zero');
+add_default($nl, 'config_cvmix_shear_KPP_exp');
+add_default($nl, 'config_use_cvmix_tidal_mixing');
+add_default($nl, 'config_use_cvmix_double_diffusion');
+add_default($nl, 'config_use_cvmix_kpp');
+add_default($nl, 'config_use_cvmix_fixed_boundary_layer');
+add_default($nl, 'config_cvmix_kpp_boundary_layer_depth');
+add_default($nl, 'config_cvmix_kpp_criticalBulkRichardsonNumber');
+add_default($nl, 'config_cvmix_kpp_matching');
+add_default($nl, 'config_cvmix_kpp_EkmanOBL');
+add_default($nl, 'config_cvmix_kpp_MonObOBL');
+add_default($nl, 'config_cvmix_kpp_interpolationOMLType');
+add_default($nl, 'config_cvmix_kpp_surface_layer_extent');
+add_default($nl, 'config_cvmix_kpp_surface_layer_averaging');
+add_default($nl, 'configure_cvmix_kpp_minimum_OBL_under_sea_ice');
+add_default($nl, 'config_cvmix_kpp_stop_OBL_search');
+add_default($nl, 'config_cvmix_kpp_use_enhanced_diff');
+add_default($nl, 'config_cvmix_kpp_nonlocal_with_implicit_mix');
+add_default($nl, 'config_cvmix_kpp_use_theory_wave');
+add_default($nl, 'config_cvmix_kpp_langmuir_mixing_opt');
+add_default($nl, 'config_cvmix_kpp_langmuir_entrainment_opt');
+
+##############################
+# Namelist group: vmix_const #
+##############################
+
+add_default($nl, 'config_use_const_visc');
+add_default($nl, 'config_use_const_diff');
+add_default($nl, 'config_vert_visc');
+add_default($nl, 'config_vert_diff');
 
 ##############################
 # Namelist group: vmix_const #
@@ -669,6 +715,13 @@ add_default($nl, 'config_use_rich_diff');
 add_default($nl, 'config_bkrd_vert_visc');
 add_default($nl, 'config_bkrd_vert_diff');
 add_default($nl, 'config_rich_mix');
+
+########################
+# Namelist group: vmix #
+########################
+
+add_default($nl, 'config_convective_visc');
+add_default($nl, 'config_convective_diff');
 
 #############################
 # Namelist group: vmix_tanh #
@@ -723,6 +776,9 @@ add_default($nl, 'configure_cvmix_kpp_minimum_OBL_under_sea_ice');
 add_default($nl, 'config_cvmix_kpp_stop_OBL_search');
 add_default($nl, 'config_cvmix_kpp_use_enhanced_diff');
 add_default($nl, 'config_cvmix_kpp_nonlocal_with_implicit_mix');
+add_default($nl, 'config_cvmix_kpp_use_theory_wave');
+add_default($nl, 'config_cvmix_kpp_langmuir_mixing_opt');
+add_default($nl, 'config_cvmix_kpp_langmuir_entrainment_opt');
 
 ###########################
 # Namelist group: forcing #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -185,45 +185,6 @@ add_default($nl, 'config_Rayleigh_damping_coeff');
 add_default($nl, 'config_Rayleigh_bottom_friction');
 add_default($nl, 'config_Rayleigh_bottom_damping_coeff');
 
-########################
-# Namelist group: vmix #
-########################
-
-add_default($nl, 'config_convective_visc');
-add_default($nl, 'config_convective_diff');
-
-##############################
-# Namelist group: vmix_const #
-##############################
-
-add_default($nl, 'config_use_const_visc');
-add_default($nl, 'config_use_const_diff');
-add_default($nl, 'config_vert_visc');
-add_default($nl, 'config_vert_diff');
-
-#############################
-# Namelist group: vmix_rich #
-#############################
-
-add_default($nl, 'config_use_rich_visc');
-add_default($nl, 'config_use_rich_diff');
-add_default($nl, 'config_bkrd_vert_visc');
-add_default($nl, 'config_bkrd_vert_diff');
-add_default($nl, 'config_rich_mix');
-
-#############################
-# Namelist group: vmix_tanh #
-#############################
-
-add_default($nl, 'config_use_tanh_visc');
-add_default($nl, 'config_use_tanh_diff');
-add_default($nl, 'config_max_visc_tanh');
-add_default($nl, 'config_min_visc_tanh');
-add_default($nl, 'config_max_diff_tanh');
-add_default($nl, 'config_min_diff_tanh');
-add_default($nl, 'config_zMid_tanh');
-add_default($nl, 'config_zWidth_tanh');
-
 #########################
 # Namelist group: cvmix #
 #########################
@@ -264,6 +225,48 @@ add_default($nl, 'configure_cvmix_kpp_minimum_OBL_under_sea_ice');
 add_default($nl, 'config_cvmix_kpp_stop_OBL_search');
 add_default($nl, 'config_cvmix_kpp_use_enhanced_diff');
 add_default($nl, 'config_cvmix_kpp_nonlocal_with_implicit_mix');
+add_default($nl, 'config_cvmix_kpp_use_theory_wave');
+add_default($nl, 'config_cvmix_kpp_langmuir_mixing_opt');
+add_default($nl, 'config_cvmix_kpp_langmuir_entrainment_opt');
+
+##############################
+# Namelist group: vmix_const #
+##############################
+
+add_default($nl, 'config_use_const_visc');
+add_default($nl, 'config_use_const_diff');
+add_default($nl, 'config_vert_visc');
+add_default($nl, 'config_vert_diff');
+
+#############################
+# Namelist group: vmix_rich #
+#############################
+
+add_default($nl, 'config_use_rich_visc');
+add_default($nl, 'config_use_rich_diff');
+add_default($nl, 'config_bkrd_vert_visc');
+add_default($nl, 'config_bkrd_vert_diff');
+add_default($nl, 'config_rich_mix');
+
+########################
+# Namelist group: vmix #
+########################
+
+add_default($nl, 'config_convective_visc');
+add_default($nl, 'config_convective_diff');
+
+#############################
+# Namelist group: vmix_tanh #
+#############################
+
+add_default($nl, 'config_use_tanh_visc');
+add_default($nl, 'config_use_tanh_diff');
+add_default($nl, 'config_max_visc_tanh');
+add_default($nl, 'config_min_visc_tanh');
+add_default($nl, 'config_max_diff_tanh');
+add_default($nl, 'config_min_diff_tanh');
+add_default($nl, 'config_zMid_tanh');
+add_default($nl, 'config_zWidth_tanh');
 
 ###########################
 # Namelist group: forcing #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -238,6 +238,9 @@
 <config_cvmix_kpp_stop_OBL_search>100.0</config_cvmix_kpp_stop_OBL_search>
 <config_cvmix_kpp_use_enhanced_diff>.true.</config_cvmix_kpp_use_enhanced_diff>
 <config_cvmix_kpp_nonlocal_with_implicit_mix>.false.</config_cvmix_kpp_nonlocal_with_implicit_mix>
+<config_cvmix_kpp_use_theory_wave>.false.</config_cvmix_kpp_use_theory_wave>
+<config_cvmix_kpp_langmuir_mixing_opt>'NONE'</config_cvmix_kpp_langmuir_mixing_opt>
+<config_cvmix_kpp_langmuir_entrainment_opt>'NONE'</config_cvmix_kpp_langmuir_entrainment_opt>
 
 <!-- vmix_const -->
 <config_use_const_visc>.false.</config_use_const_visc>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -239,8 +239,8 @@
 <config_cvmix_kpp_use_enhanced_diff>.true.</config_cvmix_kpp_use_enhanced_diff>
 <config_cvmix_kpp_nonlocal_with_implicit_mix>.false.</config_cvmix_kpp_nonlocal_with_implicit_mix>
 <config_cvmix_kpp_use_theory_wave>.false.</config_cvmix_kpp_use_theory_wave>
-<config_cvmix_kpp_langmuir_mixing_opt>'none'</config_cvmix_kpp_langmuir_mixing_opt>
-<config_cvmix_kpp_langmuir_entrainment_opt>'none'</config_cvmix_kpp_langmuir_entrainment_opt>
+<config_cvmix_kpp_langmuir_mixing_opt>'NONE'</config_cvmix_kpp_langmuir_mixing_opt>
+<config_cvmix_kpp_langmuir_entrainment_opt>'NONE'</config_cvmix_kpp_langmuir_entrainment_opt>
 
 <!-- vmix_const -->
 <config_use_const_visc>.false.</config_use_const_visc>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -238,9 +238,9 @@
 <config_cvmix_kpp_stop_OBL_search>100.0</config_cvmix_kpp_stop_OBL_search>
 <config_cvmix_kpp_use_enhanced_diff>.true.</config_cvmix_kpp_use_enhanced_diff>
 <config_cvmix_kpp_nonlocal_with_implicit_mix>.false.</config_cvmix_kpp_nonlocal_with_implicit_mix>
-<config_cvmix_kpp_use_theory_wave>.false.</config_cvmix_kpp_use_theory_wave>
-<config_cvmix_kpp_langmuir_mixing_opt>'NONE'</config_cvmix_kpp_langmuir_mixing_opt>
-<config_cvmix_kpp_langmuir_entrainment_opt>'NONE'</config_cvmix_kpp_langmuir_entrainment_opt>
+<config_cvmix_kpp_use_theory_wave>.true.</config_cvmix_kpp_use_theory_wave>
+<config_cvmix_kpp_langmuir_mixing_opt>'LWF16'</config_cvmix_kpp_langmuir_mixing_opt>
+<config_cvmix_kpp_langmuir_entrainment_opt>'LF17'</config_cvmix_kpp_langmuir_entrainment_opt>
 
 <!-- vmix_const -->
 <config_use_const_visc>.false.</config_use_const_visc>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -238,9 +238,9 @@
 <config_cvmix_kpp_stop_OBL_search>100.0</config_cvmix_kpp_stop_OBL_search>
 <config_cvmix_kpp_use_enhanced_diff>.true.</config_cvmix_kpp_use_enhanced_diff>
 <config_cvmix_kpp_nonlocal_with_implicit_mix>.false.</config_cvmix_kpp_nonlocal_with_implicit_mix>
-<config_cvmix_kpp_use_theory_wave>.true.</config_cvmix_kpp_use_theory_wave>
-<config_cvmix_kpp_langmuir_mixing_opt>'LWF16'</config_cvmix_kpp_langmuir_mixing_opt>
-<config_cvmix_kpp_langmuir_entrainment_opt>'LF17'</config_cvmix_kpp_langmuir_entrainment_opt>
+<config_cvmix_kpp_use_theory_wave>.false.</config_cvmix_kpp_use_theory_wave>
+<config_cvmix_kpp_langmuir_mixing_opt>'none'</config_cvmix_kpp_langmuir_mixing_opt>
+<config_cvmix_kpp_langmuir_entrainment_opt>'none'</config_cvmix_kpp_langmuir_entrainment_opt>
 
 <!-- vmix_const -->
 <config_use_const_visc>.false.</config_use_const_visc>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1085,6 +1085,30 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_cvmix_kpp_use_theory_wave" type="logical"
+	category="cvmix" group="cvmix">
+Flag for use of theory-wave in Li et al. (2017) to approximate the Langmuir number and enhancement factor
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_cvmix_kpp_langmuir_mixing_opt" type="char*1024"
+	category="cvmix" group="cvmix">
+Option of Langmuir enhanced mixing parameterization
+
+Valid values: NONE, LWF16, RWHGK16
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_cvmix_kpp_langmuir_entrainment_opt" type="char*1024"
+	category="cvmix" group="cvmix">
+Option of Langmuir enhanced entrainment parameterization
+
+Valid values: NONE, LWF16, LF17, RWHGK16
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- vmix_const -->
 

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -157,10 +157,10 @@ contains
     index_o2x_Faoo_fco2_ocn = mct_avect_indexra(o2x,'Faoo_fco2_ocn',perrWith='quiet')
     index_o2x_Faoo_fdms_ocn = mct_avect_indexra(o2x,'Faoo_fdms_ocn',perrWith='quiet')
 
-    index_o2x_So_blt	   = mct_avect_indexra(o2x,'So_blt')
-    index_o2x_So_bls	   = mct_avect_indexra(o2x,'So_bls')
-    index_o2x_So_htv	   = mct_avect_indexra(o2x,'So_htv')
-    index_o2x_So_stv	   = mct_avect_indexra(o2x,'So_stv')
+    index_o2x_So_blt        = mct_avect_indexra(o2x,'So_blt')
+    index_o2x_So_bls        = mct_avect_indexra(o2x,'So_bls')
+    index_o2x_So_htv        = mct_avect_indexra(o2x,'So_htv')
+    index_o2x_So_stv        = mct_avect_indexra(o2x,'So_stv')
     index_o2x_So_rhoeff     = mct_avect_indexra(o2x,'So_rhoeff')
 
     index_o2x_So_algae1     = mct_avect_indexra(o2x,'So_algae1',perrWith='quiet')
@@ -250,8 +250,8 @@ contains
 
     index_x2o_Fogx_qicelo = mct_avect_indexra(x2o,'Fogx_qicelo')
     index_x2o_Fogx_qiceho = mct_avect_indexra(x2o,'Fogx_qiceho')
-    index_x2o_Sg_blit	 = mct_avect_indexra(x2o,'Sg_blit')
-    index_x2o_Sg_blis	 = mct_avect_indexra(x2o,'Sg_blis')
+    index_x2o_Sg_blit    = mct_avect_indexra(x2o,'Sg_blit')
+    index_x2o_Sg_blis    = mct_avect_indexra(x2o,'Sg_blis')
     index_x2o_Sg_lithop  = mct_avect_indexra(x2o,'Sg_lithop')
     index_x2o_Sg_icemask = mct_avect_indexra(x2o,'Sg_icemask')
     index_x2o_Sg_icemask = mct_avect_indexra(x2o,'Sg_icemask_grounded')

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2067,6 +2067,9 @@ contains
    call mpas_pool_get_field(forcingPool, 'landIceHeatFlux', landIceHeatFluxField)
    call mpas_pool_get_field(forcingPool, 'landIceFraction', landIceFractionField)
    call mpas_pool_get_field(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracersField)
+
+   call mpas_pool_get_field(forcingPool, 'windSpeed10m', windSpeed10mField)
+
    call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceTemperature', indexIT)
    call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceSalinity', indexIS)
    !call mpas_pool_get_field(forcingPool, 'landIcePressure', landIcePressureField)
@@ -2178,6 +2181,10 @@ contains
 !   if ( landIcePressureField % isActive ) then
 !      call mpas_dmpar_exch_halo_field(landIcePressureField)
 !   end if
+
+   if ( windSpeed10mField % isActive ) then
+      call mpas_dmpar_exch_halo_field(windSpeed10mField)
+   end if
 
    ! BGC fields
    if (config_use_ecosysTracers) then

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1567,7 +1567,8 @@ contains
                        config_use_DMSTracers_sea_ice_coupling,  &
                        config_use_MacroMoleculesTracers,  &
                        config_use_MacroMoleculesTracers_sea_ice_coupling, &
-                       config_remove_AIS_coupler_runoff
+                       config_remove_AIS_coupler_runoff, &
+                       config_cvmix_kpp_use_theory_wave
 
    character(len=StrKIND), pointer :: config_ecosys_atm_co2_option, &
                                       config_ecosys_atm_alt_co2_option
@@ -1615,7 +1616,8 @@ contains
                                   iceFluxDustField, &
                                   landIceFreshwaterFluxField, &
                                   landIceHeatFluxField, &
-                                  landIceFractionField
+                                  landIceFractionField, &
+                                  windSpeed10mField
                                   !landIcePressureField
 
    type (field2DReal), pointer :: iceFluxPhytoCField, &
@@ -1649,7 +1651,8 @@ contains
                                                iceFluxDust, &
                                                landIceFreshwaterFlux, &
                                                landIceHeatFlux, &
-                                               landIceFraction
+                                               landIceFraction, &
+                                               windSpeed10m
                                                !landIcePressure
 
    real (kind=RKIND), dimension(:), pointer :: latCell
@@ -1689,6 +1692,7 @@ contains
    call mpas_pool_get_config(domain % configs, 'config_use_MacroMoleculesTracers_sea_ice_coupling',  &
                                                 config_use_MacroMoleculesTracers_sea_ice_coupling)
    call mpas_pool_get_config(domain % configs, 'config_remove_AIS_coupler_runoff', config_remove_AIS_coupler_runoff)
+   call mpas_pool_get_config(domain % configs, 'config_cvmix_kpp_use_theory_wave', config_cvmix_kpp_use_theory_wave)
 
    n = 0
    removedRiverRunoffFluxThisProc = 0.0_RKIND
@@ -1729,6 +1733,9 @@ contains
       call mpas_pool_get_field(forcingPool, 'landIceHeatFlux', landIceHeatFluxField)
       call mpas_pool_get_field(forcingPool, 'landIceFraction', landIceFractionField)
       call mpas_pool_get_field(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracersField)
+
+      call mpas_pool_get_field(forcingPool, 'windSpeed10m', windSpeed10mField)
+
       call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceTemperature', indexIT)
       call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceSalinity', indexIS)
 
@@ -1761,6 +1768,7 @@ contains
       landIceHeatFlux => landIceHeatFluxField % array
       landIceInterfaceTracers => landIceInterfaceTracersField % array
       landIceFraction => landIceFractionField % array
+      windSpeed10m => windSpeed10mField % array
       !landIcePressure => landIcePressureField % array
 
       call mpas_pool_get_array(meshPool, 'latCell', latCell)
@@ -1825,6 +1833,11 @@ contains
          ! Initialize these fields
          removedRiverRunoffFlux(:) = 0.0_RKIND
          removedIceRunoffFlux(:) = 0.0_RKIND
+      endif
+
+      if (config_cvmix_kpp_use_theory_wave) then
+         ! Initialize these fields
+         windSpeed10m(:) = 0.0_RKIND
       endif
 
       do i = 1, nCellsSolve
@@ -1909,6 +1922,12 @@ contains
         if ( iceFractionField % isActive ) then
            iceFraction(i) = x2o_o % rAttr(index_x2o_Si_ifrac, n)
         end if
+
+        if (config_cvmix_kpp_use_theory_wave) then
+           if ( windSpeed10mField% isActive ) then
+              windSpeed10m(i) = sqrt( x2o_o % rAttr(index_x2o_So_duu10n, n))
+           end if
+        endif
 
         if ( landIceFreshwaterFluxField % isActive ) then
            !landIceFreshwaterFlux(i) = x2o_o % rAttr(index_x2o_Fogx_qicelo, n)


### PR DESCRIPTION
This merge adds Langmuir mixing parameterization via CVMix

1. Change the CVMix repository to use the 'theory-wave' approximation of Li et al., 2017 to estimate the Langmuir enhancement factor from 10-meter wind, surface friction velocity and boundary layer depth
2. New entries in mpaso namelist allowing different options of Langmuir mixing parameterization

This PR is climate changing if new flags are used to turn on the new mixing.

[BFB]
[NML]
[FCC]