### PR TITLE
Adds cmake 3.11.4 module to Compy's machine files

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2039,6 +2039,9 @@
       <modules>
         <command name="purge"/>
       </modules>
+      <modules>
+	<command name="load">cmake/3.11.4</command>
+      </modules>
       <modules compiler="intel">
         <command name="load">intel/19.0.3</command>
       </modules>


### PR DESCRIPTION
Compy default cmake was 2.8.12.2, which doesn't work with the new Cmake build for EAM.   This updates cmake to 3.11.4.

SMS test built fine on Compy with this new cmake version.

[BFB] - Bit-For-Bit