### PR TITLE
Update mpas-seaice and supporting scripts

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -776,6 +776,7 @@ add_default($nl, 'config_ratio_C_to_N_proteins');
 
 add_default($nl, 'config_shortwave_type');
 add_default($nl, 'config_albedo_type');
+add_default($nl, 'config_use_snicar');
 add_default($nl, 'config_visible_ice_albedo');
 add_default($nl, 'config_infrared_ice_albedo');
 add_default($nl, 'config_visible_snow_albedo');

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -315,6 +315,7 @@ add_default($nl, 'config_ratio_C_to_N_proteins');
 
 add_default($nl, 'config_shortwave_type');
 add_default($nl, 'config_albedo_type');
+add_default($nl, 'config_use_snicar');
 add_default($nl, 'config_visible_ice_albedo');
 add_default($nl, 'config_infrared_ice_albedo');
 add_default($nl, 'config_visible_snow_albedo');

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -299,6 +299,7 @@
 <!-- shortwave -->
 <config_shortwave_type>'dEdd'</config_shortwave_type>
 <config_albedo_type>'ccsm3'</config_albedo_type>
+<config_use_snicar>false</config_use_snicar>
 <config_visible_ice_albedo>0.78</config_visible_ice_albedo>
 <config_infrared_ice_albedo>0.36</config_infrared_ice_albedo>
 <config_visible_snow_albedo>0.98</config_visible_snow_albedo>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -1926,6 +1926,14 @@ Valid values: 'ccsm3' or 'constant'
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_use_snicar" type="logical"
+	category="shortwave" group="shortwave">
+If true turn on snicar 5-band snow system
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_visible_ice_albedo" type="real"
 	category="shortwave" group="shortwave">
 Visible ice albedo for ice thickness greater than config_variable_albedo_thickness_limit.


### PR DESCRIPTION
This PR brings in a new mpas-source submodule that updates the mpas-seaice codebase, as well as supporting scripts. The seaice codebase brings in several small updates as well as introducing a snicar feature, which is turned off by default. It also makes a small modification to a convergence criteria to prevent thermo energy conservation errors that has been tested in the BGC v1 runs (see PR #2638) that can cause small answer changes in certain situations.

[NML]
[non-BFB]