### PR TITLE
Cleanup of SSP5_8.5 watercycle compset

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/SSP585_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/SSP585_cam5_CMIP6.xml
@@ -94,7 +94,6 @@
 <rrtmg_temp_fix>.true.</rrtmg_temp_fix>
 
 <!-- Energy fixer options -->
-<l_ieflx_fix> .true.</l_ieflx_fix>
 <ieflx_opt  > 2     </ieflx_opt>
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->

--- a/components/clm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -15,21 +15,10 @@
 
 <clm_demand >flanduse_timeseries</clm_demand>
 
-<stream_year_first_ndep phys="clm4_0" bgc="cn"   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_0" bgc="cn"   >2005</stream_year_last_ndep>
-<model_year_align_ndep  phys="clm4_0" bgc="cn"   >1850</model_year_align_ndep>
-
-<stream_year_first_ndep phys="clm4_0" bgc="cndv" >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_0" bgc="cndv" >2005</stream_year_last_ndep>
-<model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
-
+<!-- *** NOT USED FOR SATELLITE PHENOLOGY ***
 <stream_year_first_ndep phys="clm4_5" use_cn=".true."   >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm4_5" use_cn=".true."   >2005</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true."   >1850</model_year_align_ndep>
-
-<stream_year_first_ndep phys="clm5_0" use_cn=".true."   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm5_0" use_cn=".true."   >2005</stream_year_last_ndep>
-<model_year_align_ndep  phys="clm5_0" use_cn=".true."   >1850</model_year_align_ndep>
 
 <stream_year_first_pdep phys="clm4_5" use_cn=".true."   >2000</stream_year_first_pdep>
 <stream_year_last_pdep  phys="clm4_5" use_cn=".true."   >2000</stream_year_last_pdep>
@@ -38,10 +27,8 @@
 <stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>
+-->
 
-<stream_year_first_popdens phys="clm5_0" use_cn=".true."   >1850</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm5_0" use_cn=".true."   >2010</stream_year_last_popdens>
-<model_year_align_popdens  phys="clm5_0" use_cn=".true."   >1850</model_year_align_popdens>
 
 <!-- CMIP6 DECK compsets -->
 


### PR DESCRIPTION
Removed options from the SSP5_8.5 definitions that are not used by
E3SMv1.  There is no change to the output from any compset.  These
changes are just to avoid confusion in the future when people want to
examine or modify the SSP5_8.5 compset.

components/cam/bld/namelist_files/use_cases/SSP585_cam5_CMIP6.xml : 

   l_ieflx_fix removed.  This option is now controlled by ieflx_opt.

components/clm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml : 

   clm4.0 & 5.0 options removed because E3SM doesn't support those versions.
   clm4.5 options commented out, because they are not used for the watercycle
   configuration.  However, they need to be activated and set correctly for
   the BGC configuration.

[BFB]