### PR TITLE
Add new scheme SNICAR_AD for snow shortwave radiative properties

### DIFF
--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -566,6 +566,13 @@ Toggle to turn on calculation of SNow and Ice Aerosol Radiation model (SNICAR) r
 (snicar_frc=".true." is EXPERIMENTAL NOT SUPPORTED!)
 </entry>
 
+<entry id="use_snicar_ad" type="logical" category="physics"
+       group="clm_inparm" valid_values="" value=".false.">
+Toggle to turn on SNICAR_AD snow shortwave algorithms
+The same snow shortwave algorithm can be turned on for sea-ice simulation
+with config_use_snicar_ad in mpas-seaic namelist
+</entry>
+
 <entry id="use_noio" type="logical" category="default_settings"
        group="clm_inparm" valid_values="" value=".false." >
 Toggle to turn all history output completely OFF (possibly used for testing)

--- a/components/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
+++ b/components/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
@@ -408,6 +408,13 @@ Toggle to turn on calculation of SNow and Ice Aerosol Radiation model (SNICAR) r
 (snicar_frc=".true." is EXPERIMENTAL NOT SUPPORTED!)
 </entry>
 
+<entry id="use_snicar_ad" type="logical" category="physics"
+       group="clm_inparm" valid_values="" value=".false.">
+Toggle to turn on SNICAR_AD snow shortwave algorithms
+The same snow shortwave algorithm can be turned on for sea-ice simulation
+with config_use_snicar_ad in mpas-seaic namelist
+</entry>
+
 <entry id="use_noio" type="logical" category="default_settings"
        group="clm_inparm" valid_values="" value=".false." >
 Toggle to turn all history output completely OFF (possibly used for testing)

--- a/components/clm/src/biogeophys/SnowSnicarMod.F90
+++ b/components/clm/src/biogeophys/SnowSnicarMod.F90
@@ -1623,4 +1623,1066 @@ contains
 
    end subroutine SnowAge_init
    
+   !-----------------------------------------------------------------------
+   subroutine SNICAR_AD_RT (flg_snw_ice, bounds, num_nourbanc, filter_nourbanc,  &
+                         coszen, flg_slr_in, h2osno_liq, h2osno_ice, snw_rds,   &
+                         mss_cnc_aer_in, albsfc, albout, flx_abs, waterstate_vars)
+     !
+     ! !DESCRIPTION:
+     ! Determine reflectance of, and vertically-resolved solar absorption in,
+     ! snow with impurities, with updated shortwave scheme
+     !
+     ! The multi-layer solution for multiple-scattering used here is from:
+     ! Briegleb, P. and Light, B.: A Delta-Eddington mutiple scattering
+     ! parameterization for solar radiation in the sea ice component of the
+     ! community climate system model, 2007.
+     !
+     ! The implementation of the SNICAR-AD model in ELM is described in:
+     ! Dang et al., Inter-comparison and improvement of 2-stream shortwave
+     ! radiative transfer models for unified treatment of cryospheric surfaces
+     ! in ESMs, in review, 2019
+     !
+     ! To use this subtroutine, set use_snicar_ad = true in ELM
+     ! 
+     ! if config_use_snicar_ad = true in MPAS-seaice
+     ! Snow on land and snow on sea ice will be treated
+     ! with the same model for their solar radiative properties.
+     !
+     ! The inputs and outputs are the same to subroutine SNICAR_RT
+     !
+     ! !USES:
+     use clm_varpar       , only : nlevsno, numrad
+     use clm_time_manager , only : get_nstep
+     use shr_const_mod    , only : SHR_CONST_PI
+     !
+     ! !ARGUMENTS:
+     integer           , intent(in)  :: flg_snw_ice                                        ! flag: =1 when called from CLM, =2 when called from CSIM
+     type (bounds_type), intent(in)  :: bounds
+     integer           , intent(in)  :: num_nourbanc                                       ! number of columns in non-urban filter
+     integer           , intent(in)  :: filter_nourbanc(:)                                 ! column filter for non-urban points
+     real(r8)          , intent(in)  :: coszen         ( bounds%begc: )                    ! cosine of solar zenith angle for next time step (col) [unitless]
+     integer           , intent(in)  :: flg_slr_in                                         ! flag: =1 for direct-beam incident flux,=2 for diffuse incident flux
+     real(r8)          , intent(in)  :: h2osno_liq     ( bounds%begc: , -nlevsno+1: )      ! liquid water content (col,lyr) [kg/m2]
+     real(r8)          , intent(in)  :: h2osno_ice     ( bounds%begc: , -nlevsno+1: )      ! ice content (col,lyr) [kg/m2]
+     integer           , intent(in)  :: snw_rds        ( bounds%begc: , -nlevsno+1: )      ! snow effective radius (col,lyr) [microns, m^-6]
+     real(r8)          , intent(in)  :: mss_cnc_aer_in ( bounds%begc: , -nlevsno+1: , 1: ) ! mass concentration of all aerosol species (col,lyr,aer) [kg/kg]
+     real(r8)          , intent(in)  :: albsfc         ( bounds%begc: , 1: )               ! albedo of surface underlying snow (col,bnd) [frc]
+     real(r8)          , intent(out) :: albout         ( bounds%begc: , 1: )               ! snow albedo, averaged into 2 bands (=0 if no sun or no snow) (col,bnd) [frc]
+     real(r8)          , intent(out) :: flx_abs        ( bounds%begc: , -nlevsno+1: , 1: ) ! absorbed flux in each layer per unit flux incident (col, lyr, bnd)
+     type(waterstate_type) , intent(in)  :: waterstate_vars
+     !
+     ! !LOCAL VARIABLES:
+     !
+     ! variables for snow radiative transfer calculations
+
+     ! Local variables representing single-column values of arrays:
+     integer :: snl_lcl                            ! negative number of snow layers [nbr]
+     integer :: snw_rds_lcl(-nlevsno+1:0)          ! snow effective radius [m^-6]
+     real(r8):: flx_slrd_lcl(1:numrad_snw)         ! direct beam incident irradiance [W/m2] (set to 1)
+     real(r8):: flx_slri_lcl(1:numrad_snw)         ! diffuse incident irradiance [W/m2] (set to 1)
+     real(r8):: mss_cnc_aer_lcl(-nlevsno+1:0,1:sno_nbr_aer) ! aerosol mass concentration (lyr,aer_nbr) [kg/kg]
+     real(r8):: h2osno_lcl                         ! total column snow mass [kg/m2]
+     real(r8):: h2osno_liq_lcl(-nlevsno+1:0)       ! liquid water mass [kg/m2]
+     real(r8):: h2osno_ice_lcl(-nlevsno+1:0)       ! ice mass [kg/m2]
+     real(r8):: albsfc_lcl(1:numrad_snw)           ! albedo of underlying surface [frc]
+     real(r8):: ss_alb_snw_lcl(-nlevsno+1:0)       ! single-scatter albedo of ice grains (lyr) [frc]
+     real(r8):: asm_prm_snw_lcl(-nlevsno+1:0)      ! asymmetry parameter of ice grains (lyr) [frc]
+     real(r8):: ext_cff_mss_snw_lcl(-nlevsno+1:0)  ! mass extinction coefficient of ice grains (lyr) [m2/kg]
+     real(r8):: ss_alb_aer_lcl(sno_nbr_aer)        ! single-scatter albedo of aerosol species (aer_nbr) [frc]
+     real(r8):: asm_prm_aer_lcl(sno_nbr_aer)       ! asymmetry parameter of aerosol species (aer_nbr) [frc]
+     real(r8):: ext_cff_mss_aer_lcl(sno_nbr_aer)   ! mass extinction coefficient of aerosol species (aer_nbr) [m2/kg]
+
+#ifdef MODAL_AER
+     !mgf++
+     real(r8) :: rds_bcint_lcl(-nlevsno+1:0)       ! effective radius of within-ice BC [nm]
+     real(r8) :: rds_bcext_lcl(-nlevsno+1:0)       ! effective radius of external BC [nm]
+     !mgf--
+#endif
+
+
+     ! Other local variables
+     integer :: DELTA                              ! flag to use Delta approximation (Joseph, 1976)
+                                                   ! (1= use, 0= don't use)
+     real(r8):: flx_wgt(1:numrad_snw)              ! weights applied to spectral bands,
+                                                   ! specific to direct and diffuse cases (bnd) [frc]
+     integer :: flg_nosnl                          ! flag: =1 if there is snow, but zero snow layers,
+                                                   ! =0 if at least 1 snow layer [flg]
+     !integer :: trip                               ! flag: =1 to redo RT calculation if result is unrealistic
+     !integer :: flg_dover                          ! defines conditions for RT redo (explained below)
+
+     real(r8):: albedo                             ! temporary snow albedo [frc]
+     real(r8):: flx_sum                            ! temporary summation variable for NIR weighting
+     real(r8):: albout_lcl(numrad_snw)             ! snow albedo by band [frc]
+     real(r8):: flx_abs_lcl(-nlevsno+1:1,numrad_snw)! absorbed flux per unit incident flux at top of snowpack (lyr,bnd) [frc]
+
+     real(r8):: L_snw(-nlevsno+1:0)                ! h2o mass (liquid+solid) in snow layer (lyr) [kg/m2]
+     real(r8):: tau_snw(-nlevsno+1:0)              ! snow optical depth (lyr) [unitless]
+     real(r8):: L_aer(-nlevsno+1:0,sno_nbr_aer)    ! aerosol mass in snow layer (lyr,nbr_aer) [kg/m2]
+     real(r8):: tau_aer(-nlevsno+1:0,sno_nbr_aer)  ! aerosol optical depth (lyr,nbr_aer) [unitless]
+     real(r8):: tau_sum                            ! cumulative (snow+aerosol) optical depth [unitless]
+     real(r8):: tau_clm(-nlevsno+1:0)              ! column optical depth from layer bottom to snowpack top (lyr) [unitless]
+     real(r8):: omega_sum                          ! temporary summation of single-scatter albedo of all aerosols [frc]
+     real(r8):: g_sum                              ! temporary summation of asymmetry parameter of all aerosols [frc]
+
+     real(r8):: tau(-nlevsno+1:0)                  ! weighted optical depth of snow+aerosol layer (lyr) [unitless]
+     real(r8):: omega(-nlevsno+1:0)                ! weighted single-scatter albedo of snow+aerosol layer (lyr) [frc]
+     real(r8):: g(-nlevsno+1:0)                    ! weighted asymmetry parameter of snow+aerosol layer (lyr) [frc]
+     real(r8):: tau_star(-nlevsno+1:0)             ! transformed (i.e. Delta-Eddington) optical depth of snow+aerosol layer
+                                                   ! (lyr) [unitless]
+     real(r8):: omega_star(-nlevsno+1:0)           ! transformed (i.e. Delta-Eddington) SSA of snow+aerosol layer (lyr) [frc]
+     real(r8):: g_star(-nlevsno+1:0)               ! transformed (i.e. Delta-Eddington) asymmetry paramater of snow+aerosol layer
+                                                   ! (lyr) [frc]
+
+     integer :: nstep                              ! current timestep [nbr] (debugging only)
+     integer :: g_idx, c_idx, l_idx                ! gridcell, column, and landunit indices [idx]
+     integer :: bnd_idx                            ! spectral band index (1 <= bnd_idx <= numrad_snw) [idx]
+     integer :: rds_idx                            ! snow effective radius index for retrieving
+                                                   ! Mie parameters from lookup table [idx]
+     integer :: snl_btm                            ! index of bottom snow layer (0) [idx]
+     integer :: snl_top                            ! index of top snow layer (-4 to 0) [idx]
+     integer :: fc                                 ! column filter index
+     integer :: i                                  ! layer index [idx]
+     integer :: j                                  ! aerosol number index [idx]
+     integer :: m                                  ! secondary layer index [idx]
+
+     real(r8):: F_abs(-nlevsno+1:0)                ! net absorbed radiative energy (lyr) [W/m^2]
+     real(r8):: F_abs_sum                          ! total absorbed energy in column [W/m^2]
+     real(r8):: F_sfc_pls                          ! upward radiative flux at snowpack top [W/m^2]
+     real(r8):: F_btm_net                          ! net flux at bottom of snowpack [W/m^2]
+     real(r8):: energy_sum                         ! sum of all energy terms; should be 0.0 [W/m^2]
+     real(r8):: mu_not                             ! cosine of solar zenith angle (used locally) [frc]
+
+     integer :: err_idx                            ! counter for number of times through error loop [nbr]
+     real(r8):: lat_coord                          ! gridcell latitude (debugging only)
+     real(r8):: lon_coord                          ! gridcell longitude (debugging only)
+     integer :: sfctype                            ! underlying surface type (debugging only)
+     real(r8):: pi                                 ! 3.1415...
+
+     ! SNICAR_AD new variables, follow sea-ice shortwave conventions
+     real(r8):: &
+        trndir(-nlevsno+1:1)  , & ! solar beam down transmission from top
+        trntdr(-nlevsno+1:1)  , & ! total transmission to direct beam for layers above
+        trndif(-nlevsno+1:1)  , & ! diffuse transmission to diffuse beam for layers above
+        rupdir(-nlevsno+1:1)  , & ! reflectivity to direct radiation for layers below
+        rupdif(-nlevsno+1:1)  , & ! reflectivity to diffuse radiation for layers below
+        rdndif(-nlevsno+1:1)  , & ! reflectivity to diffuse radiation for layers above
+        dfdir(-nlevsno+1:1)   , & ! down-up flux at interface due to direct beam at top surface
+        dfdif(-nlevsno+1:1)   , & ! down-up flux at interface due to diffuse beam at top surface
+        dftmp(-nlevsno+1:1)       ! temporary variable for down-up flux at interface
+
+     real(r8):: &
+        rdir(-nlevsno+1:0)       , & ! layer reflectivity to direct radiation
+        rdif_a(-nlevsno+1:0)     , & ! layer reflectivity to diffuse radiation from above
+        rdif_b(-nlevsno+1:0)     , & ! layer reflectivity to diffuse radiation from below
+        tdir(-nlevsno+1:0)       , & ! layer transmission to direct radiation (solar beam + diffuse)
+        tdif_a(-nlevsno+1:0)     , & ! layer transmission to diffuse radiation from above
+        tdif_b(-nlevsno+1:0)     , & ! layer transmission to diffuse radiation from below
+        trnlay(-nlevsno+1:0)         ! solar beam transm for layer (direct beam only)
+
+     real(r8):: &
+         ts       , & ! layer delta-scaled extinction optical depth
+         ws       , & ! layer delta-scaled single scattering albedo
+         gs       , & ! layer delta-scaled asymmetry parameter
+         extins   , & ! extinction
+         alp      , & ! temporary for alpha
+         gam      , & ! temporary for agamm
+         amg      , & ! alp - gam
+         apg      , & ! alp + gam
+         ue       , & ! temporary for u
+         refk     , & ! interface multiple scattering
+         refkp1   , & ! interface multiple scattering for k+1
+         refkm1   , & ! interface multiple scattering for k-1
+         tdrrdir  , & ! direct tran times layer direct ref
+         tdndif       ! total down diffuse = tot tran - direct tran
+
+     real(r8) :: &
+         alpha    , & ! term in direct reflectivity and transmissivity
+         agamm    , & ! term in direct reflectivity and transmissivity
+         el       , & ! term in alpha,agamm,n,u
+         taus     , & ! scaled extinction optical depth
+         omgs     , & ! scaled single particle scattering albedo
+         asys     , & ! scaled asymmetry parameter
+         u        , & ! term in diffuse reflectivity and transmissivity
+         n        , & ! term in diffuse reflectivity and transmissivity
+         lm       , & ! temporary for el
+         mu       , & ! cosine solar zenith for either snow or water
+         ne           ! temporary for n
+
+     ! perpendicular and parallel relative to plane of incidence and scattering
+     real(r8) :: &
+         R1       , & ! perpendicular polarization reflection amplitude
+         R2       , & ! parallel polarization reflection amplitude
+         T1       , & ! perpendicular polarization transmission amplitude
+         T2       , & ! parallel polarization transmission amplitude
+         Rf_dir_a , & ! fresnel reflection to direct radiation
+         Tf_dir_a , & ! fresnel transmission to direct radiation
+         Rf_dif_a , & ! fresnel reflection to diff radiation from above
+         Rf_dif_b , & ! fresnel reflection to diff radiation from below
+         Tf_dif_a , & ! fresnel transmission to diff radiation from above
+         Tf_dif_b     ! fresnel transmission to diff radiation from below
+
+     real(r8) :: &
+         gwt      , & ! gaussian weight
+         swt      , & ! sum of weights
+         trn      , & ! layer transmission
+         rdr      , & ! rdir for gaussian integration
+         tdr      , & ! tdir for gaussian integration
+         smr      , & ! accumulator for rdif gaussian integration
+         smt      , & ! accumulator for tdif gaussian integration
+         exp_min      ! minimum exponential value
+
+     integer :: &
+         ng             , & ! gaussian integration index
+         snl_btm_itf    , & ! index of bottom snow layer interfaces (1) [idx]
+         ngmax = 8          ! gaussian integration index
+
+     ! Gaussian integration angle and coefficients
+     real(r8) :: &
+         difgauspt(1:8)  , &
+         difgauswt(1:8)
+     ! real(r8),  dimension (1:8) :: &
+     !     dif_gauspt     & ! gaussian angles (radians)
+     !       = (/ 0.9894009_r8,  0.9445750_r8, &
+     !            0.8656312_r8,  0.7554044_r8, &
+     !            0.6178762_r8,  0.4580168_r8, &
+     !            0.2816036_r8,  0.0950125_r8/) , &
+     !     dif_gauswt     & ! gaussian weights
+     !       = (/ 0.0271525_r8,  0.0622535_r8, &
+     !            0.0951585_r8,  0.1246290_r8, &
+     !            0.1495960_r8,  0.1691565_r8, &
+     !            0.1826034_r8,  0.1894506_r8/)
+
+     ! constants used in algorithm
+     real(r8) :: &
+         c0      = 0.0_r8     , &
+         c1      = 1.0_r8     , &
+         c3      = 3.0_r8     , &
+         c4      = 4.0_r8     , &
+         c6      = 6.0_r8     , &
+         cp01    = 0.01_r8    , &
+         cp5     = 0.5_r8     , &
+         cp75    = 0.75_r8    , &
+         c1p5    = 1.5_r8     , &
+         trmin   = 0.001_r8   , &
+         argmax  = 10.0_r8       ! maximum argument of exponential
+
+     ! cconstant coefficients used for SZA parameterization
+     real(r8) :: &
+         sza_a0 =  0.085730_r8 , &
+         sza_a1 = -0.630883_r8 , &
+         sza_a2 =  1.303723_r8 , &
+         sza_b0 =  1.467291_r8 , &
+         sza_b1 = -3.338043_r8 , &
+         sza_b2 =  6.807489_r8 , &
+         puny   =  1.0e-11_r8  , &
+         mu_75  =  0.2588_r8       ! cosine of 75 degree
+
+     ! coefficients used for SZA parameterization
+     real(r8) :: &
+         sza_c1          , & ! coefficient, SZA parameteirzation
+         sza_c0          , & ! coefficient, SZA parameterization
+         sza_factor      , & ! factor used to adjust NIR direct albedo
+         flx_sza_adjust  , & ! direct NIR flux adjustment from sza_factor
+         mu0                 ! incident solar zenith angle
+
+     ! Delta-Eddington solution expressions
+     ! alpha(w,uu,gg,e) = p75*w*uu*((c1 + gg*(c1-w))/(c1 - e*e*uu*uu))
+     ! agamm(w,uu,gg,e) = p5*w*((c1 + c3*gg*(c1-w)*uu*uu)/(c1-e*e*uu*uu))
+     ! n(uu,et)         = ((uu+c1)*(uu+c1)/et ) - ((uu-c1)*(uu-c1)*et)
+     ! u(w,gg,e)        = c1p5*(c1 - w*gg)/e
+     ! el(w,gg)         = sqrt(c3*(c1-w)*(c1 - w*gg))
+
+     !-----------------------------------------------------------------------
+#ifdef MODAL_AER
+         !mgf++
+         integer :: idx_bcint_icerds                  ! index of ice effective radius for optical properties lookup table
+         integer :: idx_bcint_nclrds                  ! index of within-ice BC effective radius for optical properties lookup table
+         integer :: idx_bcext_nclrds                  ! index of external BC effective radius for optical properties lookup table
+         real(r8):: enh_fct                           ! extinction/absorption enhancement factor for within-ice BC
+         real(r8):: tmp1                              ! temporary variable
+         !mgf--
+#endif
+
+     ! Enforce expected array sizes
+     SHR_ASSERT_ALL((ubound(coszen)         == (/bounds%endc/)),                 errMsg(__FILE__, __LINE__))
+     SHR_ASSERT_ALL((ubound(h2osno_liq)     == (/bounds%endc, 0/)),              errMsg(__FILE__, __LINE__))
+     SHR_ASSERT_ALL((ubound(h2osno_ice)     == (/bounds%endc, 0/)),              errMsg(__FILE__, __LINE__))
+     SHR_ASSERT_ALL((ubound(snw_rds)        == (/bounds%endc, 0/)),              errMsg(__FILE__, __LINE__))
+     SHR_ASSERT_ALL((ubound(mss_cnc_aer_in) == (/bounds%endc, 0, sno_nbr_aer/)), errMsg(__FILE__, __LINE__))
+     SHR_ASSERT_ALL((ubound(albsfc)         == (/bounds%endc, numrad/)),         errMsg(__FILE__, __LINE__))
+     SHR_ASSERT_ALL((ubound(albout)         == (/bounds%endc, numrad/)),         errMsg(__FILE__, __LINE__))
+     SHR_ASSERT_ALL((ubound(flx_abs)        == (/bounds%endc, 1, numrad/)),      errMsg(__FILE__, __LINE__))
+
+     associate(&
+          snl         =>   col_pp%snl                           , & ! Input:  [integer (:)]  negative number of snow layers (col) [nbr]
+
+          h2osno      =>   waterstate_vars%h2osno_col        , & ! Input:  [real(r8) (:)]  snow liquid water equivalent (col) [kg/m2]
+          frac_sno    =>   waterstate_vars%frac_sno_eff_col    & ! Input:  [real(r8) (:)]  fraction of ground covered by snow (0 to 1)
+          )
+
+       ! Define constants
+       pi = SHR_CONST_PI
+
+       ! always use Delta approximation for snow
+       DELTA = 1
+
+       ! Get current timestep
+       nstep = get_nstep()
+
+       !Gaussian integration angle and coefficients for diffuse radiation
+       difgauspt(1:8)     & ! gaussian angles (radians)
+         = (/ 0.9894009_r8,  0.9445750_r8, &
+              0.8656312_r8,  0.7554044_r8, &
+              0.6178762_r8,  0.4580168_r8, &
+              0.2816036_r8,  0.0950125_r8/)
+       difgauswt(1:8)     & ! gaussian weights
+         = (/ 0.0271525_r8,  0.0622535_r8, &
+              0.0951585_r8,  0.1246290_r8, &
+              0.1495960_r8,  0.1691565_r8, &
+              0.1826034_r8,  0.1894506_r8/)
+
+
+      ! Loop over all non-urban columns
+      ! (when called from CSIM, there is only one column)
+       do fc = 1,num_nourbanc
+          c_idx = filter_nourbanc(fc)
+
+          ! Zero absorbed radiative fluxes:
+          do i=-nlevsno+1,1,1
+             flx_abs_lcl(:,:)   = 0._r8
+             flx_abs(c_idx,i,:) = 0._r8
+          enddo
+
+          ! set snow/ice mass to be used for RT:
+          if (flg_snw_ice == 1) then
+             h2osno_lcl = h2osno(c_idx)
+          else
+             h2osno_lcl = h2osno_ice(c_idx,0)
+          endif
+
+
+          ! Qualifier for computing snow RT:
+          !  1) sunlight from atmosphere model
+          !  2) minimum amount of snow on ground.
+          !     Otherwise, set snow albedo to zero
+          if ((coszen(c_idx) > 0._r8) .and. (h2osno_lcl > min_snw)) then
+
+             ! Set variables specific to CLM
+             if (flg_snw_ice == 1) then
+                ! If there is snow, but zero snow layers, we must create a layer locally.
+                ! This layer is presumed to have the fresh snow effective radius.
+                if (snl(c_idx) > -1) then
+                   flg_nosnl         =  1
+                   snl_lcl           =  -1
+                   h2osno_ice_lcl(0) =  h2osno_lcl
+                   h2osno_liq_lcl(0) =  0._r8
+                   snw_rds_lcl(0)    =  nint(snw_rds_min)
+                else
+                   flg_nosnl         =  0
+                   snl_lcl           =  snl(c_idx)
+                   h2osno_liq_lcl(:) =  h2osno_liq(c_idx,:)
+                   h2osno_ice_lcl(:) =  h2osno_ice(c_idx,:)
+                   snw_rds_lcl(:)    =  snw_rds(c_idx,:)
+                endif
+
+                snl_btm   = 0
+                snl_top   = snl_lcl+1
+
+                ! for debugging only
+                l_idx     = col_pp%landunit(c_idx)
+                g_idx     = col_pp%gridcell(c_idx)
+                sfctype   = lun_pp%itype(l_idx)
+                lat_coord = grc_pp%latdeg(g_idx)
+                lon_coord = grc_pp%londeg(g_idx)
+
+
+                ! Set variables specific to CSIM
+             else
+                flg_nosnl         = 0
+                snl_lcl           = -1
+                h2osno_liq_lcl(:) = h2osno_liq(c_idx,:)
+                h2osno_ice_lcl(:) = h2osno_ice(c_idx,:)
+                snw_rds_lcl(:)    = snw_rds(c_idx,:)
+                snl_btm           = 0
+                snl_top           = 0
+                sfctype           = -1
+                lat_coord         = -90
+                lon_coord         = 0
+             endif ! end if flg_snw_ice == 1
+
+#ifdef MODAL_AER
+           !mgf++
+           !
+           ! Assume fixed BC effective radii of 100nm. This is close to
+           ! the effective radius of 95nm (number median radius of
+           ! 40nm) assumed for freshly-emitted BC in MAM.  Future
+           ! implementations may prognose the BC effective radius in
+           ! snow.
+           rds_bcint_lcl(:)  =  100._r8
+           rds_bcext_lcl(:)  =  100._r8
+           !mgf--
+#endif
+
+             ! Set local aerosol array
+             do j=1,sno_nbr_aer
+                mss_cnc_aer_lcl(:,j) = mss_cnc_aer_in(c_idx,:,j)
+             enddo
+
+
+             ! Set spectral underlying surface albedos to their corresponding VIS or NIR albedos
+             albsfc_lcl(1)                       = albsfc(c_idx,1)
+             albsfc_lcl(nir_bnd_bgn:nir_bnd_end) = albsfc(c_idx,2)
+
+
+             ! Error check for snow grain size:
+             do i=snl_top,snl_btm,1
+                if ((snw_rds_lcl(i) < snw_rds_min_tbl) .or. (snw_rds_lcl(i) > snw_rds_max_tbl)) then
+                   write (iulog,*) "SNICAR ERROR: snow grain radius of ", snw_rds_lcl(i), " out of bounds."
+                   write (iulog,*) "NSTEP= ", nstep
+                   write (iulog,*) "flg_snw_ice= ", flg_snw_ice
+                   write (iulog,*) "column: ", c_idx, " level: ", i, " snl(c)= ", snl_lcl
+                   write (iulog,*) "lat= ", lat_coord, " lon= ", lon_coord
+                   write (iulog,*) "h2osno(c)= ", h2osno_lcl
+                   call endrun(decomp_index=c_idx, clmlevel=namec, msg=errmsg(__FILE__, __LINE__))
+                endif
+             enddo
+
+             ! Incident flux weighting parameters
+             !  - sum of all VIS bands must equal 1
+             !  - sum of all NIR bands must equal 1
+             !
+             ! Spectral bands (5-band case)
+             !  Band 1: 0.3-0.7um (VIS)
+             !  Band 2: 0.7-1.0um (NIR)
+             !  Band 3: 1.0-1.2um (NIR)
+             !  Band 4: 1.2-1.5um (NIR)
+             !  Band 5: 1.5-5.0um (NIR)
+             !
+             ! The following weights are appropriate for surface-incident flux in a mid-latitude winter atmosphere
+             !
+             ! 3-band weights
+             if (numrad_snw==3) then
+                ! Direct:
+                if (flg_slr_in == 1) then
+                   flx_wgt(1) = 1._r8
+                   flx_wgt(2) = 0.66628670195247_r8
+                   flx_wgt(3) = 0.33371329804753_r8
+                   ! Diffuse:
+                elseif (flg_slr_in == 2) then
+                   flx_wgt(1) = 1._r8
+                   flx_wgt(2) = 0.77887652162877_r8
+                   flx_wgt(3) = 0.22112347837123_r8
+                endif
+
+                ! 5-band weights
+             elseif(numrad_snw==5) then
+                ! Direct:
+                if (flg_slr_in == 1) then
+                   flx_wgt(1) = 1._r8
+                   flx_wgt(2) = 0.49352158521175_r8
+                   flx_wgt(3) = 0.18099494230665_r8
+                   flx_wgt(4) = 0.12094898498813_r8
+                   flx_wgt(5) = 0.20453448749347_r8
+                   ! Diffuse:
+                elseif (flg_slr_in == 2) then
+                   flx_wgt(1) = 1._r8
+                   flx_wgt(2) = 0.58581507618433_r8
+                   flx_wgt(3) = 0.20156903770812_r8
+                   flx_wgt(4) = 0.10917889346386_r8
+                   flx_wgt(5) = 0.10343699264369_r8
+                endif
+             endif ! end if numrad_snw
+
+             ! Loop over snow spectral bands
+
+             exp_min = exp(-argmax)
+             do bnd_idx = 1,numrad_snw
+
+               ! note that we can remove flg_dover since this algorithm is
+               ! stable for mu_not > 0.01
+
+               ! mu_not is cosine solar zenith angle above the fresnel level; make
+               ! sure mu_not is large enough for stable and meaningful radiation
+               ! solution: .01 is like sun just touching horizon with its lower edge
+               ! equivalent to mu0 in sea-ice shortwave model ice_shortwave.F90
+                mu_not = max(coszen(c_idx), cp01)
+
+
+                   ! Set direct or diffuse incident irradiance to 1
+                   ! (This has to be within the bnd loop because mu_not is adjusted in rare cases)
+                   if (flg_slr_in == 1) then
+                      flx_slrd_lcl(bnd_idx) = 1._r8/(mu_not*pi) ! this corresponds to incident irradiance of 1.0
+                      flx_slri_lcl(bnd_idx) = 0._r8
+                   else
+                      flx_slrd_lcl(bnd_idx) = 0._r8
+                      flx_slri_lcl(bnd_idx) = 1._r8
+                   endif
+
+                   ! Pre-emptive error handling: aerosols can reap havoc on these absorptive bands.
+                   ! Since extremely high soot concentrations have a negligible effect on these bands, zero them.
+                   if ( (numrad_snw == 5).and.((bnd_idx == 5).or.(bnd_idx == 4)) ) then
+                      mss_cnc_aer_lcl(:,:) = 0._r8
+                   endif
+
+                   if ( (numrad_snw == 3).and.(bnd_idx == 3) ) then
+                      mss_cnc_aer_lcl(:,:) = 0._r8
+                   endif
+
+                   ! Define local Mie parameters based on snow grain size and aerosol species,
+                   !  retrieved from a lookup table.
+                   if (flg_slr_in == 1) then
+                      do i=snl_top,snl_btm,1
+                         rds_idx = snw_rds_lcl(i) - snw_rds_min_tbl + 1
+                         ! snow optical properties (direct radiation)
+                         ss_alb_snw_lcl(i)      = ss_alb_snw_drc(rds_idx,bnd_idx)
+                         asm_prm_snw_lcl(i)     = asm_prm_snw_drc(rds_idx,bnd_idx)
+                         ext_cff_mss_snw_lcl(i) = ext_cff_mss_snw_drc(rds_idx,bnd_idx)
+                      enddo
+                   elseif (flg_slr_in == 2) then
+                      do i=snl_top,snl_btm,1
+                         rds_idx = snw_rds_lcl(i) - snw_rds_min_tbl + 1
+                         ! snow optical properties (diffuse radiation)
+                         ss_alb_snw_lcl(i)      = ss_alb_snw_dfs(rds_idx,bnd_idx)
+                         asm_prm_snw_lcl(i)     = asm_prm_snw_dfs(rds_idx,bnd_idx)
+                         ext_cff_mss_snw_lcl(i) = ext_cff_mss_snw_dfs(rds_idx,bnd_idx)
+                      enddo
+                   endif
+
+   !H. Wang
+                   ! aerosol species 1 optical properties
+                  ! ss_alb_aer_lcl(1)        = ss_alb_bc1(bnd_idx)
+                  ! asm_prm_aer_lcl(1)       = asm_prm_bc1(bnd_idx)
+                  ! ext_cff_mss_aer_lcl(1)   = ext_cff_mss_bc1(bnd_idx)
+
+                   ! aerosol species 2 optical properties
+                  ! ss_alb_aer_lcl(2)        = ss_alb_bc2(bnd_idx)
+                  ! asm_prm_aer_lcl(2)       = asm_prm_bc2(bnd_idx)
+                  ! ext_cff_mss_aer_lcl(2)   = ext_cff_mss_bc2(bnd_idx)
+   !H. Wang
+                   ! aerosol species 3 optical properties
+                   ss_alb_aer_lcl(3)        = ss_alb_oc1(bnd_idx)
+                   asm_prm_aer_lcl(3)       = asm_prm_oc1(bnd_idx)
+                   ext_cff_mss_aer_lcl(3)   = ext_cff_mss_oc1(bnd_idx)
+
+                   ! aerosol species 4 optical properties
+                   ss_alb_aer_lcl(4)        = ss_alb_oc2(bnd_idx)
+                   asm_prm_aer_lcl(4)       = asm_prm_oc2(bnd_idx)
+                   ext_cff_mss_aer_lcl(4)   = ext_cff_mss_oc2(bnd_idx)
+
+                   ! aerosol species 5 optical properties
+                   ss_alb_aer_lcl(5)        = ss_alb_dst1(bnd_idx)
+                   asm_prm_aer_lcl(5)       = asm_prm_dst1(bnd_idx)
+                   ext_cff_mss_aer_lcl(5)   = ext_cff_mss_dst1(bnd_idx)
+
+                   ! aerosol species 6 optical properties
+                   ss_alb_aer_lcl(6)        = ss_alb_dst2(bnd_idx)
+                   asm_prm_aer_lcl(6)       = asm_prm_dst2(bnd_idx)
+                   ext_cff_mss_aer_lcl(6)   = ext_cff_mss_dst2(bnd_idx)
+
+                   ! aerosol species 7 optical properties
+                   ss_alb_aer_lcl(7)        = ss_alb_dst3(bnd_idx)
+                   asm_prm_aer_lcl(7)       = asm_prm_dst3(bnd_idx)
+                   ext_cff_mss_aer_lcl(7)   = ext_cff_mss_dst3(bnd_idx)
+
+                   ! aerosol species 8 optical properties
+                   ss_alb_aer_lcl(8)        = ss_alb_dst4(bnd_idx)
+                   asm_prm_aer_lcl(8)       = asm_prm_dst4(bnd_idx)
+                   ext_cff_mss_aer_lcl(8)   = ext_cff_mss_dst4(bnd_idx)
+
+
+                   ! 1. snow and aerosol layer column mass (L_snw, L_aer [kg/m^2])
+                   ! 2. optical Depths (tau_snw, tau_aer)
+                   ! 3. weighted Mie properties (tau, omega, g)
+
+                   ! Weighted Mie parameters of each layer
+                   do i=snl_top,snl_btm,1
+#ifdef MODAL_AER
+                    !mgf++ within-ice and external BC optical properties
+                    !
+                    ! Lookup table indices for BC optical properties,
+                    ! dependent on snow grain size and BC particle
+                    ! size.
+
+                    ! valid for 25 < snw_rds < 1625 um:
+                    if (snw_rds_lcl(i) < 125) then
+                       tmp1 = snw_rds_lcl(i)/50
+                       idx_bcint_icerds = nint(tmp1)
+                    elseif (snw_rds_lcl(i) < 175) then
+                       idx_bcint_icerds = 2
+                    else
+                       tmp1 = (snw_rds_lcl(i)/250)+2
+                       idx_bcint_icerds = nint(tmp1)
+                    endif
+
+                    ! valid for 25 < bc_rds < 525 nm
+                    idx_bcint_nclrds = nint(rds_bcint_lcl(i)/50)
+                    idx_bcext_nclrds = nint(rds_bcext_lcl(i)/50)
+
+                    ! check bounds:
+                    if (idx_bcint_icerds < idx_bcint_icerds_min) idx_bcint_icerds = idx_bcint_icerds_min
+                    if (idx_bcint_icerds > idx_bcint_icerds_max) idx_bcint_icerds = idx_bcint_icerds_max
+                    if (idx_bcint_nclrds < idx_bc_nclrds_min) idx_bcint_nclrds = idx_bc_nclrds_min
+                    if (idx_bcint_nclrds > idx_bc_nclrds_max) idx_bcint_nclrds = idx_bc_nclrds_max
+                    if (idx_bcext_nclrds < idx_bc_nclrds_min) idx_bcext_nclrds = idx_bc_nclrds_min
+                    if (idx_bcext_nclrds > idx_bc_nclrds_max) idx_bcext_nclrds = idx_bc_nclrds_max
+
+                    ! print ice index (debug):
+                    !write(iulog,*) "MGF: ice index= ", idx_bcint_icerds
+
+                    ! retrieve absorption enhancement factor for within-ice BC
+                    enh_fct = bcenh(bnd_idx,idx_bcint_nclrds,idx_bcint_icerds)
+
+                    ! get BC optical properties (moved from above)
+                    ! aerosol species 1 optical properties (within-ice BC)
+                    ss_alb_aer_lcl(1)        = ss_alb_bc1(bnd_idx,idx_bcint_nclrds)
+                    asm_prm_aer_lcl(1)       = asm_prm_bc1(bnd_idx,idx_bcint_nclrds)
+                    ext_cff_mss_aer_lcl(1)   = ext_cff_mss_bc1(bnd_idx,idx_bcint_nclrds)*enh_fct
+
+                    ! aerosol species 2 optical properties (external BC)
+                    ss_alb_aer_lcl(2)        = ss_alb_bc2(bnd_idx,idx_bcext_nclrds)
+                    asm_prm_aer_lcl(2)       = asm_prm_bc2(bnd_idx,idx_bcext_nclrds)
+                    ext_cff_mss_aer_lcl(2)   = ext_cff_mss_bc2(bnd_idx,idx_bcext_nclrds)
+
+#else
+                    ! bulk aerosol treatment (BC optical properties independent
+                    ! of BC and ice grain size)
+                    ! aerosol species 1 optical properties (within-ice BC)
+                    ss_alb_aer_lcl(1)        = ss_alb_bc1(bnd_idx)
+                    asm_prm_aer_lcl(1)       = asm_prm_bc1(bnd_idx)
+                    ext_cff_mss_aer_lcl(1)   = ext_cff_mss_bc1(bnd_idx)
+
+                    ! aerosol species 2 optical properties
+                    ss_alb_aer_lcl(2)        = ss_alb_bc2(bnd_idx)
+                    asm_prm_aer_lcl(2)       = asm_prm_bc2(bnd_idx)
+                    ext_cff_mss_aer_lcl(2)   = ext_cff_mss_bc2(bnd_idx)
+#endif
+                    !mgf--
+
+                      L_snw(i)   = h2osno_ice_lcl(i)+h2osno_liq_lcl(i)
+                      tau_snw(i) = L_snw(i)*ext_cff_mss_snw_lcl(i)
+
+                      do j=1,sno_nbr_aer
+                         L_aer(i,j)   = L_snw(i)*mss_cnc_aer_lcl(i,j)
+                         tau_aer(i,j) = L_aer(i,j)*ext_cff_mss_aer_lcl(j)
+                      enddo
+
+                      tau_sum   = 0._r8
+                      omega_sum = 0._r8
+                      g_sum     = 0._r8
+
+                      do j=1,sno_nbr_aer
+                         tau_sum    = tau_sum + tau_aer(i,j)
+                         omega_sum  = omega_sum + (tau_aer(i,j)*ss_alb_aer_lcl(j))
+                         g_sum      = g_sum + (tau_aer(i,j)*ss_alb_aer_lcl(j)*asm_prm_aer_lcl(j))
+                      enddo
+
+                      tau(i)    = tau_sum + tau_snw(i)
+                      omega(i)  = (1/tau(i))*(omega_sum+(ss_alb_snw_lcl(i)*tau_snw(i)))
+                      g(i)      = (1/(tau(i)*omega(i)))*(g_sum+ (asm_prm_snw_lcl(i)*ss_alb_snw_lcl(i)*tau_snw(i)))
+                   enddo ! endWeighted Mie parameters of each layer
+
+                   ! DELTA transformations, if requested
+                   if (DELTA == 1) then
+                      do i=snl_top,snl_btm,1
+                         g_star(i)     = g(i)/(1+g(i))
+                         omega_star(i) = ((1-(g(i)**2))*omega(i)) / (1-(omega(i)*(g(i)**2)))
+                         tau_star(i)   = (1-(omega(i)*(g(i)**2)))*tau(i)
+                      enddo
+                   else
+                      do i=snl_top,snl_btm,1
+                         g_star(i)     = g(i)
+                         omega_star(i) = omega(i)
+                         tau_star(i)   = tau(i)
+                      enddo
+                   endif
+
+                   ! Begin radiative transfer solver
+                   ! Given input vertical profiles of optical properties, evaluate the
+                   ! monochromatic Delta-Eddington adding-doubling solution
+
+                   ! note that trndir, trntdr, trndif, rupdir, rupdif, rdndif
+                   ! are variables at the layer interface,
+                   ! for snow with layers rangeing from snl_top to snl_btm
+                   ! there are snl_top to snl_btm+1 layer interface
+                   snl_btm_itf = snl_btm + 1
+
+                   do i = snl_top,snl_btm_itf,1
+                      trndir(i) = c0
+                      trntdr(i) = c0
+                      trndif(i) = c0
+                      rupdir(i) = c0
+                      rupdif(i) = c0
+                      rdndif(i) = c0
+                   enddo
+
+                   ! initialize top interface of top layer
+                   trndir(snl_top) = c1
+                   trntdr(snl_top) = c1
+                   trndif(snl_top) = c1
+                   rdndif(snl_top) = c0
+
+                  ! begin main level loop
+                  ! for layer interfaces except for the very bottom
+                  do i = snl_top,snl_btm,1
+
+                     ! initialize all layer apparent optical properties to 0
+                     rdir  (i) = c0
+                     rdif_a(i) = c0
+                     rdif_b(i) = c0
+                     tdir  (i) = c0
+                     tdif_a(i) = c0
+                     tdif_b(i) = c0
+                     trnlay(i) = c0
+
+                     ! compute next layer Delta-eddington solution only if total transmission
+                     ! of radiation to the interface just above the layer exceeds trmin.
+
+                     if (trntdr(i) > trmin ) then
+
+                        ! calculation over layers with penetrating radiation
+
+                        ! delta-transformed single-scattering properties
+                        ! of this layer
+                        ts = tau_star(i)
+                        ws = omega_star(i)
+                        gs = g_star(i)
+
+                       ! Delta-Eddington solution expressions
+                        ! n(uu,et)         = ((uu+c1)*(uu+c1)/et ) - ((uu-c1)*(uu-c1)*et)
+                        ! u(w,gg,e)        = c1p5*(c1 - w*gg)/e
+                        ! el(w,gg)         = sqrt(c3*(c1-w)*(c1 - w*gg))
+                        lm = sqrt(c3*(c1-ws)*(c1 - ws*gs))  !lm = el(ws,gs)
+                        ue = c1p5*(c1 - ws*gs)/lm           !ue = u(ws,gs,lm)
+                        extins = max(exp_min, exp(-lm*ts))
+                        ne = ((ue+c1)*(ue+c1)/extins) - ((ue-c1)*(ue-c1)*extins) !ne = n(ue,extins)
+
+                        ! first calculation of rdif, tdif using Delta-Eddington formulas
+                        ! rdif_a(k) = (ue+c1)*(ue-c1)*(c1/extins - extins)/ne
+                        rdif_a(i) = (ue**2-c1)*(c1/extins - extins)/ne
+                        tdif_a(i) = c4*ue/ne
+
+                        ! evaluate rdir,tdir for direct beam
+                        trnlay(i) = max(exp_min, exp(-ts/mu_not))
+
+                        ! Delta-Eddington solution expressions
+                        ! alpha(w,uu,gg,e) = p75*w*uu*((c1 + gg*(c1-w))/(c1 - e*e*uu*uu))
+                        ! agamm(w,uu,gg,e) = p5*w*((c1 + c3*gg*(c1-w)*uu*uu)/(c1-e*e*uu*uu))
+                        ! alp = alpha(ws,mu_not,gs,lm)
+                        ! gam = agamm(ws,mu_not,gs,lm)
+                        alp = cp75*ws*mu_not*((c1 + gs*(c1-ws))/(c1 - lm*lm*mu_not*mu_not))
+                        gam = cp5*ws*((c1 + c3*gs*(c1-ws)*mu_not*mu_not)/(c1-lm*lm*mu_not*mu_not))
+                        apg = alp + gam
+                        amg = alp - gam
+
+                        rdir(i) = apg*rdif_a(i) +  amg*(tdif_a(i)*trnlay(i) - c1)
+                        tdir(i) = apg*tdif_a(i) + (amg* rdif_a(i)-apg+c1)*trnlay(i)
+
+                        ! recalculate rdif,tdif using direct angular integration over rdir,tdir,
+                        ! since Delta-Eddington rdif formula is not well-behaved (it is usually
+                        ! biased low and can even be negative); use ngmax angles and gaussian
+                        ! integration for most accuracy:
+                        R1 = rdif_a(i) ! use R1 as temporary
+                        T1 = tdif_a(i) ! use T1 as temporary
+                        swt = c0
+                        smr = c0
+                        smt = c0
+                        do ng=1,ngmax
+                           mu  = difgauspt(ng)
+                           gwt = difgauswt(ng)
+                           swt = swt + mu*gwt
+                           trn = max(exp_min, exp(-ts/mu))
+                           ! alp = alpha(ws,mu,gs,lm)
+                           ! gam = agamm(ws,mu,gs,lm)
+                           alp = cp75*ws*mu*((c1 + gs*(c1-ws))/(c1 - lm*lm*mu*mu))
+                           gam = cp5*ws*((c1 + c3*gs*(c1-ws)*mu*mu)/(c1-lm*lm*mu*mu))
+                           apg = alp + gam
+                           amg = alp - gam
+                           rdr = apg*R1 + amg*T1*trn - amg
+                           tdr = apg*T1 + amg*R1*trn - apg*trn + trn
+                           smr = smr + mu*rdr*gwt
+                           smt = smt + mu*tdr*gwt
+                        enddo      ! ng
+                        rdif_a(i) = smr/swt
+                        tdif_a(i) = smt/swt
+
+                        ! homogeneous layer
+                        rdif_b(i) = rdif_a(i)
+                        tdif_b(i) = tdif_a(i)
+
+                      endif ! trntdr(k) > trmin
+
+                      ! Calculate the solar beam transmission, total transmission, and
+                      ! reflectivity for diffuse radiation from below at interface i,
+                      ! the top of the current layer k:
+                      !
+                      !              layers       interface
+                      !
+                      !       ---------------------  i-1
+                      !                i-1
+                      !       ---------------------  i
+                      !                 i
+                      !       ---------------------
+
+                      trndir(i+1) = trndir(i)*trnlay(i)
+                      refkm1      = c1/(c1 - rdndif(i)*rdif_a(i))
+                      tdrrdir     = trndir(i)*rdir(i)
+                      tdndif      = trntdr(i) - trndir(i)
+                      trntdr(i+1) = trndir(i)*tdir(i) + &
+                           (tdndif + tdrrdir*rdndif(i))*refkm1*tdif_a(i)
+                      rdndif(i+1) = rdif_b(i) + &
+                           (tdif_b(i)*rdndif(i)*refkm1*tdif_a(i))
+                      trndif(i+1) = trndif(i)*refkm1*tdif_a(i)
+
+                  enddo       ! i    end main level loop
+
+
+                  ! compute reflectivity to direct and diffuse radiation for layers
+                  ! below by adding succesive layers starting from the underlying
+                  ! ground and working upwards:
+                  !
+                  !              layers       interface
+                  !
+                  !       ---------------------  i
+                  !                 i
+                  !       ---------------------  i+1
+                  !                i+1
+                  !       ---------------------
+
+                  ! set the underlying ground albedo == albedo of near-IR
+                  ! unless bnd_idx == 1, for visible
+                  rupdir(snl_btm_itf) = albsfc(c_idx,2)
+                  rupdif(snl_btm_itf) = albsfc(c_idx,2)
+                  if (bnd_idx == 1) then
+                      rupdir(snl_btm_itf) = albsfc(c_idx,1)
+                      rupdif(snl_btm_itf) = albsfc(c_idx,1)
+                  endif
+
+                  do i=snl_btm,snl_top,-1
+                     ! interface scattering
+                     refkp1        = c1/( c1 - rdif_b(i)*rupdif(i+1))
+                     ! dir from top layer plus exp tran ref from lower layer, interface
+                     ! scattered and tran thru top layer from below, plus diff tran ref
+                     ! from lower layer with interface scattering tran thru top from below
+                     rupdir(i) = rdir(i) &
+                          + (        trnlay(i)  *rupdir(i+1) &
+                          +  (tdir(i)-trnlay(i))*rupdif(i+1))*refkp1*tdif_b(i)
+                     ! dif from top layer from above, plus dif tran upwards reflected and
+                     ! interface scattered which tran top from below
+                     rupdif(i) = rdif_a(i) + tdif_a(i)*rupdif(i+1)*refkp1*tdif_b(i)
+                  enddo       ! i
+
+                  ! net flux (down-up) at each layer interface from the
+                  ! snow top (i = snl_top) to bottom interface above land (i = snl_btm_itf)
+                  ! the interface reflectivities and transmissivities required
+                  ! to evaluate interface fluxes are returned from solution_dEdd;
+                  ! now compute up and down fluxes for each interface, using the
+                  ! combined layer properties at each interface:
+                  !
+                  !              layers       interface
+                  !
+                  !       ---------------------  i
+                  !                 i
+                  !       ---------------------
+
+                  do i = snl_top, snl_btm_itf
+                     ! interface scattering
+                     refk          = c1/(c1 - rdndif(i)*rupdif(i))
+                     ! dir tran ref from below times interface scattering, plus diff
+                     ! tran and ref from below times interface scattering
+                     ! fdirup(i) = (trndir(i)*rupdir(i) + &
+                     !                 (trntdr(i)-trndir(i))  &
+                     !                 *rupdif(i))*refk
+                     ! dir tran plus total diff trans times interface scattering plus
+                     ! dir tran with up dir ref and down dif ref times interface scattering
+                     ! fdirdn(i) = trndir(i) + (trntdr(i) &
+                     !               - trndir(i) + trndir(i)  &
+                     !               *rupdir(i)*rdndif(i))*refk
+                     ! diffuse tran ref from below times interface scattering
+                     ! fdifup(i) = trndif(i)*rupdif(i)*refk
+                     ! diffuse tran times interface scattering
+                     ! fdifdn(i) = trndif(i)*refk
+
+                     ! netflux, down - up
+                     ! dfdir = fdirdn - fdirup
+                     dfdir(i) = trndir(i) &
+                                 + (trntdr(i)-trndir(i)) * (c1 - rupdif(i)) * refk &
+                                 -  trndir(i)*rupdir(i)  * (c1 - rdndif(i)) * refk
+                     if (dfdir(i) < puny) dfdir(i) = c0
+                     ! dfdif = fdifdn - fdifup
+                     dfdif(i) = trndif(i) * (c1 - rupdif(i)) * refk
+                     if (dfdif(i) < puny) dfdif(i) = c0
+                  enddo       ! k
+
+                  ! SNICAR_AD_RT is called twice for direct and diffuse incident fluxes
+                  ! direct incident
+                  if (flg_slr_in == 1) then
+                    albedo = rupdir(snl_top)
+                    dftmp  = dfdir
+                    refk   = c1/(c1 - rdndif(snl_top)*rupdif(snl_top))
+                    F_sfc_pls = (trndir(snl_top)*rupdir(snl_top) + &
+                                (trntdr(snl_top)-trndir(snl_top))  &
+                                 *rupdif(snl_top))*refk
+                  !diffuse incident
+                  else
+                    albedo = rupdif(snl_top)
+                    dftmp  = dfdif
+                    refk   = c1/(c1 - rdndif(snl_top)*rupdif(snl_top))
+                    F_sfc_pls = trndif(snl_top)*rupdif(snl_top)*refk
+                  endif
+
+                  ! Absorbed flux in each layer
+                  do i=snl_top,snl_btm,1
+                    F_abs(i) = dftmp(i)-dftmp(i+1)
+                    flx_abs_lcl(i,bnd_idx) = F_abs(i)
+
+                    ! ERROR check: negative absorption
+                    if (flx_abs_lcl(i,bnd_idx) < -0.00001) then
+                      write (iulog,"(a,e13.6,a,i6,a,i6)") "SNICAR ERROR: negative absoption : ", flx_abs_lcl(i,bnd_idx), &
+                           " at timestep: ", nstep, " at column: ", c_idx
+                      write(iulog,*) "SNICAR_AD STATS: snw_rds(0)= ", snw_rds(c_idx,0)
+                      write(iulog,*) "SNICAR_AD STATS: L_snw(0)= ", L_snw(0)
+                      write(iulog,*) "SNICAR_AD STATS: h2osno= ", h2osno_lcl, " snl= ", snl_lcl
+                      write(iulog,*) "SNICAR_AD STATS: soot1(0)= ", mss_cnc_aer_lcl(0,1)
+                      write(iulog,*) "SNICAR_AD STATS: soot2(0)= ", mss_cnc_aer_lcl(0,2)
+                      write(iulog,*) "SNICAR_AD STATS: dust1(0)= ", mss_cnc_aer_lcl(0,3)
+                      write(iulog,*) "SNICAR_AD STATS: dust2(0)= ", mss_cnc_aer_lcl(0,4)
+                      write(iulog,*) "SNICAR_AD STATS: dust3(0)= ", mss_cnc_aer_lcl(0,5)
+                      write(iulog,*) "SNICAR_AD STATS: dust4(0)= ", mss_cnc_aer_lcl(0,6)
+                      call endrun(decomp_index=c_idx, clmlevel=namec, msg=errmsg(__FILE__, __LINE__))
+                    endif
+                  enddo
+
+                  ! absobed flux by the underlying ground
+                  F_btm_net = dftmp(snl_btm_itf)
+
+                  ! note here, snl_btm_itf = 1 by snow column set up in CLM
+                  flx_abs_lcl(1,bnd_idx) = F_btm_net
+
+                 if (flg_nosnl == 1) then
+                    ! If there are no snow layers (but still snow), all absorbed energy must be in top soil layer
+                    !flx_abs_lcl(:,bnd_idx) = 0._r8
+                    !flx_abs_lcl(1,bnd_idx) = F_abs(0) + F_btm_net
+
+                    ! changed on 20070408:
+                    ! OK to put absorbed energy in the fictitous snow layer because routine SurfaceRadiation
+                    ! handles the case of no snow layers. Then, if a snow layer is addded between now and
+                    ! SurfaceRadiation (called in CanopyHydrology), absorbed energy will be properly distributed.
+                    flx_abs_lcl(0,bnd_idx) = F_abs(0)
+                    flx_abs_lcl(1,bnd_idx) = F_btm_net
+                 endif
+
+                 !Underflow check (we've already tripped the error condition above)
+                 do i=snl_top,1,1
+                    if (flx_abs_lcl(i,bnd_idx) < 0._r8) then
+                       flx_abs_lcl(i,bnd_idx) = 0._r8
+                    endif
+                 enddo
+
+                 F_abs_sum = 0._r8
+                 do i=snl_top,snl_btm,1
+                    F_abs_sum = F_abs_sum + F_abs(i)
+                 enddo
+
+                !enddo !enddo while (flg_dover > 0)
+
+                ! Energy conservation check:
+                ! Incident direct+diffuse radiation equals (absorbed+bulk_transmitted+bulk_reflected)
+                energy_sum = (mu_not*pi*flx_slrd_lcl(bnd_idx)) + flx_slri_lcl(bnd_idx) - (F_abs_sum + F_btm_net + F_sfc_pls)
+                if (abs(energy_sum) > 0.00001_r8) then
+                   write (iulog,"(a,e13.6,a,i6,a,i6)") "SNICAR ERROR: Energy conservation error of : ", energy_sum, &
+                        " at timestep: ", nstep, " at column: ", c_idx
+                   write(iulog,*) "F_abs_sum: ",F_abs_sum
+                   write(iulog,*) "F_btm_net: ",F_btm_net
+                   write(iulog,*) "F_sfc_pls: ",F_sfc_pls
+                   write(iulog,*) "mu_not*pi*flx_slrd_lcl(bnd_idx): ", mu_not*pi*flx_slrd_lcl(bnd_idx)
+                   write(iulog,*) "flx_slri_lcl(bnd_idx)", flx_slri_lcl(bnd_idx)
+                   write(iulog,*) "bnd_idx", bnd_idx
+                   write(iulog,*) "F_abs", F_abs
+                   write(iulog,*) "albedo", albedo
+                   call endrun(decomp_index=c_idx, clmlevel=namec, msg=errmsg(__FILE__, __LINE__))
+                endif
+
+                albout_lcl(bnd_idx) = albedo
+                ! Check that albedo is less than 1
+                if (albout_lcl(bnd_idx) > 1.0) then
+                   write (iulog,*) "SNICAR ERROR: Albedo > 1.0 at c: ", c_idx, " NSTEP= ",nstep
+                   write (iulog,*) "SNICAR STATS: bnd_idx= ",bnd_idx
+                   write (iulog,*) "SNICAR STATS: albout_lcl(bnd)= ",albout_lcl(bnd_idx), &
+                        " albsfc_lcl(bnd_idx)= ",albsfc_lcl(bnd_idx)
+                   write (iulog,*) "SNICAR STATS: landtype= ", sfctype
+                   write (iulog,*) "SNICAR STATS: h2osno= ", h2osno_lcl, " snl= ", snl_lcl
+                   write (iulog,*) "SNICAR STATS: coszen= ", coszen(c_idx), " flg_slr= ", flg_slr_in
+
+                   write (iulog,*) "SNICAR STATS: soot(-4)= ", mss_cnc_aer_lcl(-4,1)
+                   write (iulog,*) "SNICAR STATS: soot(-3)= ", mss_cnc_aer_lcl(-3,1)
+                   write (iulog,*) "SNICAR STATS: soot(-2)= ", mss_cnc_aer_lcl(-2,1)
+                   write (iulog,*) "SNICAR STATS: soot(-1)= ", mss_cnc_aer_lcl(-1,1)
+                   write (iulog,*) "SNICAR STATS: soot(0)= ", mss_cnc_aer_lcl(0,1)
+
+                   write (iulog,*) "SNICAR STATS: L_snw(-4)= ", L_snw(-4)
+                   write (iulog,*) "SNICAR STATS: L_snw(-3)= ", L_snw(-3)
+                   write (iulog,*) "SNICAR STATS: L_snw(-2)= ", L_snw(-2)
+                   write (iulog,*) "SNICAR STATS: L_snw(-1)= ", L_snw(-1)
+                   write (iulog,*) "SNICAR STATS: L_snw(0)= ", L_snw(0)
+
+                   write (iulog,*) "SNICAR STATS: snw_rds(-4)= ", snw_rds(c_idx,-4)
+                   write (iulog,*) "SNICAR STATS: snw_rds(-3)= ", snw_rds(c_idx,-3)
+                   write (iulog,*) "SNICAR STATS: snw_rds(-2)= ", snw_rds(c_idx,-2)
+                   write (iulog,*) "SNICAR STATS: snw_rds(-1)= ", snw_rds(c_idx,-1)
+                   write (iulog,*) "SNICAR STATS: snw_rds(0)= ", snw_rds(c_idx,0)
+
+                   call endrun(decomp_index=c_idx, clmlevel=namec, msg=errmsg(__FILE__, __LINE__))
+                endif
+
+             enddo   ! loop over wvl bands
+
+
+             ! Weight output NIR albedo appropriately
+             albout(c_idx,1) = albout_lcl(1)
+             flx_sum         = 0._r8
+             do bnd_idx= nir_bnd_bgn,nir_bnd_end
+                flx_sum = flx_sum + flx_wgt(bnd_idx)*albout_lcl(bnd_idx)
+             enddo
+             albout(c_idx,2) = flx_sum / sum(flx_wgt(nir_bnd_bgn:nir_bnd_end))
+
+             ! Weight output NIR absorbed layer fluxes (flx_abs) appropriately
+             flx_abs(c_idx,:,1) = flx_abs_lcl(:,1)
+             do i=snl_top,1,1
+                flx_sum = 0._r8
+                do bnd_idx= nir_bnd_bgn,nir_bnd_end
+                   flx_sum = flx_sum + flx_wgt(bnd_idx)*flx_abs_lcl(i,bnd_idx)
+                enddo
+                flx_abs(c_idx,i,2) = flx_sum / sum(flx_wgt(nir_bnd_bgn:nir_bnd_end))
+             enddo
+
+             ! near-IR direct albedo/absorption adjustment for high solar zenith angles
+             ! solar zenith angle parameterization
+             ! calculate the scaling factor for NIR direct albedo if SZA>75 degree
+             if ((mu_not < mu_75) .and. (flg_slr_in == 1)) then
+                sza_c1 = sza_a0 + sza_a1 * mu_not + sza_a2 * mu_not**2
+                sza_c0 = sza_b0 + sza_b1 * mu_not + sza_b2 * mu_not**2
+                sza_factor = sza_c1 * (log10(snw_rds_lcl(snl_top) * c1) - c6) + sza_c0
+                flx_sza_adjust  = albout(c_idx,2) * (sza_factor-c1) * sum(flx_wgt(nir_bnd_bgn:nir_bnd_end))
+                albout(c_idx,2) = albout(c_idx,2) * sza_factor
+                flx_abs(c_idx,snl_top,2) = flx_abs(c_idx,snl_top,2) - flx_sza_adjust
+             endif
+
+             ! If snow < minimum_snow, but > 0, and there is sun, set albedo to underlying surface albedo
+          elseif ( (coszen(c_idx) > 0._r8) .and. (h2osno_lcl < min_snw) .and. (h2osno_lcl > 0._r8) ) then
+             albout(c_idx,1) = albsfc(c_idx,1)
+             albout(c_idx,2) = albsfc(c_idx,2)
+
+             ! There is either zero snow, or no sun
+          else
+             albout(c_idx,1) = 0._r8
+             albout(c_idx,2) = 0._r8
+          endif    ! if column has snow and coszen > 0
+
+       enddo    ! loop over all columns
+
+     end associate
+
+   end subroutine SNICAR_AD_RT
+
+
  end module SnowSnicarMod

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -304,6 +304,7 @@ module clm_varctl
   logical, public :: use_cn              = .false.
   logical, public :: use_crop            = .false.
   logical, public :: use_snicar_frc      = .false.
+  logical, public :: use_snicar_ad       = .false.
   logical, public :: use_vancouver       = .false.
   logical, public :: use_mexicocity      = .false.
   logical, public :: use_noio            = .false.

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -246,7 +246,7 @@ contains
     namelist /clm_inparm/ &
          use_nofire, use_lch4, use_nitrif_denitrif, use_vertsoilc, use_extralakelayers, &
          use_vichydro, use_century_decomp, use_cn, use_crop, use_snicar_frc, &
-         use_vancouver, use_mexicocity, use_noio
+         use_snicar_ad, use_vancouver, use_mexicocity, use_noio
 
     ! cpl_bypass variables
     namelist /clm_inparm/ metdata_type, metdata_bypass, metdata_biases, &
@@ -588,6 +588,7 @@ contains
     call mpi_bcast (use_crop, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_voc, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_snicar_frc, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (use_snicar_ad, 1, MPI_LOGICAL, 0, mpicom, ier)   
     call mpi_bcast (use_vancouver, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_mexicocity, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_noio, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -826,6 +827,7 @@ contains
     write(iulog,*) '    use_cn = ', use_cn
     write(iulog,*) '    use_crop = ', use_crop
     write(iulog,*) '    use_snicar_frc = ', use_snicar_frc
+    write(iulog,*) '    use_snicar_ad = ', use_snicar_ad
     write(iulog,*) '    use_vancouver = ', use_vancouver
     write(iulog,*) '    use_mexicocity = ', use_mexicocity
     write(iulog,*) '    use_noio = ', use_noio


### PR DESCRIPTION
Adds a new snow shortwave radiative algorithm SNICAR_AD to land model.
This new algorithm can be selected by a new namelist variable use_snicar_ad = .true./.false.

[BFB] when use_snicar_ad = false (default)
[non-BFB] when use_snicar_ad = true