### PR TITLE
Implement SSP5_8.5 future watercycle compset into BGC (maint-v1.1)

### DIFF
--- a/cime/config/e3sm/allactive/config_compsets.xml
+++ b/cime/config/e3sm/allactive/config_compsets.xml
@@ -50,6 +50,11 @@
 </compset>
 
 <compset>
+  <alias>A_WCYCLSSP585_CMIP6</alias>
+  <lname>SSP585_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
   <alias>A_WCYCL1950S_CMIP6_LR</alias>
   <lname>1950_CAM5%CMIP6-LR_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</lname>
 </compset>
@@ -333,6 +338,7 @@
   <entry id="RUN_STARTDATE">
     <values>
       <value  compset="20TR_CAM">1850-01-01</value>
+      <value  compset="SSP585_CAM">2015-01-01</value>
     </values>
   </entry>
 

--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -617,6 +617,8 @@
       <value compset="^2000.+AV1C-H01C"				>368.865</value>
       <value compset="^1850.+CMIP6"                             >284.317</value>
       <value compset="^1950.+CMIP6"                             >312.821</value>
+      <value compset="^2010.+CMIP6"                             >388.717</value>
+      <value compset="^SSP585.+CMIP6"				>0.000001</value>
       <value compset="^20TR.*BGC%BCRC"                                >284.317</value>
       <value compset="^20TR.*BGC%BCRD"                                >284.317</value>
       <value compset="^20TR.*BGC%BDRC"                                >284.317</value>
@@ -785,6 +787,7 @@
     <desc compset="HIST_">Historical 1850 to 2000 transient:</desc>
     <desc compset="20TR_">Historical 1850 to 2000 transient:</desc>
     <desc compset="AMIP_">AMIP for stand-alone cam:</desc>
+    <desc compset="SSP585_">Future transient using CMIP6 SSP5_8.5 scenario:</desc>
     <desc compset="C2R[68]_">CCMI REFC2 1950 to 2100 transient:</desc>
     <desc compset="C2R4_">CCMI REFC2 2004 to 2100 transient:</desc>
     <desc compset="4804_">1948 to 2004 transient:</desc>

--- a/components/cam/bld/namelist_files/use_cases/SSP585_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/SSP585_cam5_CMIP6.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20171207.nc</solar_data_file>
+<solar_data_type>SERIAL</solar_data_type>
+
+<!-- GHG values from CMIP6 input4MIPS -->
+<bndtvghg>atm/cam/ggas/GHG_CMIP_SSP585-1-2-1_Annual_Global_2015-2500_c20190310.nc</bndtvghg>
+<scenario_ghg>RAMPED</scenario_ghg>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
+<prescribed_volcaero_file    >CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file    >
+<prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
+<prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
+<prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
+
+<!-- Sea Surface Temperatures (SST) are specified using SSTICE in config_compsets.xml -->
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc>.true.</use_hetfrz_classnuc>
+<use_preexisting_ice>.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc>.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep>.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning>.true.</sscav_tuning>
+<convproc_do_aer>.true.</convproc_do_aer>
+<convproc_do_gas>.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc>.true.</demott_ice_nuc>
+<liqcf_fix>.true.</liqcf_fix>
+<regen_fix>.true.</regen_fix>
+<resus_fix>.true.</resus_fix>
+<mam_amicphys_optaa>1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning>.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai>500.0</ice_sed_ai>
+<cldfrc_dp1>0.045D0</cldfrc_dp1>
+<clubb_ice_deep>16.e-6</clubb_ice_deep>
+<clubb_ice_sh>50.e-6</clubb_ice_sh>
+<clubb_liq_deep>8.e-6</clubb_liq_deep>  
+<clubb_liq_sh>10.e-6</clubb_liq_sh>
+<clubb_C2rt>1.75D0</clubb_C2rt>
+<zmconv_c0_lnd>0.007</zmconv_c0_lnd>
+<zmconv_c0_ocn>0.007</zmconv_c0_ocn>
+<zmconv_dmpdz>-0.7e-3</zmconv_dmpdz>
+<zmconv_ke>5.e-6</zmconv_ke>
+<effgw_oro>0.25</effgw_oro>
+<seasalt_emis_scale>0.85</seasalt_emis_scale>
+<dust_emis_fact>2.05D0</dust_emis_fact>
+<clubb_gamma_coef>0.32</clubb_gamma_coef>
+<clubb_C8>4.3</clubb_C8>
+<cldfrc2m_rhmaxi>1.05D0</cldfrc2m_rhmaxi>
+<clubb_c_K10>0.3</clubb_c_K10>
+<effgw_beres>0.4</effgw_beres>
+<do_tms>.false.</do_tms>
+<so4_sz_thresh_icenuc>0.05e-6</so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0</n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add>0.8D0</zmconv_tiedke_add>
+<zmconv_cape_cin>1</zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj>2</zmconv_mx_bot_lyr_adj>
+<taubgnd>2.5D-3</taubgnd>
+<clubb_C1>1.335</clubb_C1>
+<raytau0>5.0D0</raytau0>
+<prc_coef1>30500.0D0</prc_coef1>
+<prc_exp>3.19D0</prc_exp>
+<prc_exp1>-1.2D0</prc_exp1>
+<se_ftype>2</se_ftype>
+<clubb_C14>1.06D0</clubb_C14>
+<relvar_fix>.true.</relvar_fix>
+<mg_prc_coeff_fix>.true.</mg_prc_coeff_fix>
+<rrtmg_temp_fix>.true.</rrtmg_temp_fix>
+
+<!-- Energy fixer options -->
+<ieflx_opt  > 2     </ieflx_opt>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so2_elev_2015-2100_c181228.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_soag_elev_2015-2100_c181228.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_bc_a4_elev_2015-2100_c181228.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a1_elev_2015-2100_c181228.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a2_elev_2015-2100_c181228.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a4_elev_2015-2100_c181228.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_pom_a4_elev_2015-2100_c181228.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a1_elev_2015-2100_c181228.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a2_elev_2015-2100_c181228.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so2_surf_2015-2100_c181228.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_bc_a4_surf_2015-2100_c181228.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a1_surf_2015-2100_c181228.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a2_surf_2015-2100_c181228.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a4_surf_2015-2100_c181228.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_pom_a4_surf_2015-2100_c181228.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a1_surf_2015-2100_c181228.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a2_surf_2015-2100_c181228.nc </so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>
+<tracer_cnst_datapath>atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
+<tracer_cnst_file    >oxid_1.9x2.5_L70_2015-2100_c20190421.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_Hist_SSP585_0003-2503_c20190414.nc</chlorine_loading_file>
+<chlorine_loading_type      >SERIAL</chlorine_loading_type>
+<linoz_data_file            >linoz_1850-2500_CMIP6_Hist_SSP585_10deg_58km_c20190414.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>2015-2100</sim_year>
+
+</namelist_defaults>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -200,6 +200,7 @@
       <value compset="20TR_CAM5.*AV1C-H01C">20TR_cam5_av1c-h01c</value>
       <value compset="20TR_CAM5.*CMIP6"  >20TR_cam5_CMIP6</value>
       <value compset="20TR_CAM5.*CMIP6.*_BGC%B"  >20TR_cam5_CMIP6_bgc</value>
+      <value compset="SSP585_CAM5.*CMIP6">SSP585_cam5_CMIP6</value>
       <value compset="2000_CAM5%COSP"   >2000_cam5_cosp</value>
       <value compset="2000_CAM4%WCMX"   >waccmx_2000_cam4</value>
       <value compset="1996_CAM4%WCMX"   >waccmx_1996_cam4</value>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1201,7 +1201,7 @@ CLM datasets exist for years: 1000 (for testing), 1850, and 2000
 
 <entry id="sim_year_range" type="char*9" category="default_settings"
        group="default_settings" valid_values=
-"constant,1000-1002,1000-1004,850-1100,1100-1350,1350-1600,1600-1850,1850-2000,1850-2100,2000-2100">
+"constant,1000-1002,1000-1004,850-1100,1100-1350,1350-1600,1600-1850,1850-2000,1850-2100,2000-2100,2015-2100">
 Range of years to simulate transitory datasets for (such as dynamic: land-use datasets, aerosol-deposition, Nitrogen deposition rates etc.)
 Constant means simulation will be held at a constant year given in sim_year.
 A sim_year_range of 1000-1002 or 1000-1004 corresponds to data used for testing only, NOT corresponding to any real datasets.

--- a/components/clm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc                 >Simulate transient land-use, and aerosol deposition changes from 2015 to 2100</use_case_desc>
+<use_case_desc bgc="cn"        >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 2015 to 2100</use_case_desc>
+<use_case_desc bgc="cndv"      >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 2015 to 2100</use_case_desc>
+<use_case_desc use_cn=".true." >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 2015 to 2100</use_case_desc>
+
+<!-- <sim_year>1850</sim_year> -->
+
+<sim_year_range>2015-2100</sim_year_range>
+
+<clm_start_type>arb_ic</clm_start_type>
+
+<clm_demand >flanduse_timeseries</clm_demand>
+
+<!-- *** NOT USED FOR SATELLITE PHENOLOGY ***
+<stream_year_first_ndep phys="clm4_5" use_cn=".true."   >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true."   >2005</stream_year_last_ndep>
+<model_year_align_ndep  phys="clm4_5" use_cn=".true."   >1850</model_year_align_ndep>
+
+<stream_year_first_pdep phys="clm4_5" use_cn=".true."   >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true."   >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true."   >2000</model_year_align_pdep>
+
+<stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
+<model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>
+-->
+
+
+<!-- CMIP6 DECK compsets -->
+
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
+<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_ssp5_rcp8.5_simyr2015-2100_c190411.nc</flanduse_timeseries>
+<finidat>lnd/clm2/initdata_map/20180215.DECKv1b_H1.ne30_oEC.edison.clm2.r.2015-01-01-00000.nc</finidat>
+<check_finidat_year_consistency>.true.</check_finidat_year_consistency>
+<check_dynpft_consistency>.false.</check_dynpft_consistency>
+
+</namelist_defaults>

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -77,6 +77,7 @@
       <value compset="20TR.*_CLM45%[^_]*BGC">20thC_bgc_transient</value>
       <value compset="1950_CAM5%CMIP6-LR*_CLM">1950_CMIP6LR_control</value>
       <value compset="1950_CAM5%CMIP6-HR_CLM">1950_CMIP6HR_control</value>
+      <value compset="SSP585_CAM5%CMIP6_CLM">2015-2100_SSP585_transient</value>
     </values>
     <group>run_component_clm</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
This is a porting of the the SSP5_8.5 future watercycle compset from
maint-1.0 to maint-1.1.

[BFB, except for new compset]