### PR TITLE
Make RRTMGP thread-safe

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 [submodule "components/cam/src/physics/rrtmgp/external"]
 	path = components/cam/src/physics/rrtmgp/external
 	url = git@github.com:RobertPincus/rte-rrtmgp.git
-	branch = master
+	branch = develop

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1157,6 +1157,11 @@ contains
       ! modified in this routine.
       call pbuf_get_field(pbuf, pbuf_get_index('QRS'), qrs)
       call pbuf_get_field(pbuf, pbuf_get_index('QRL'), qrl)
+
+      ! Initialize clearsky-heating rates to make sure we do not get garbage
+      ! for columns beyond ncol or nday
+      qrsc(:,:) = 0
+      qrlc(:,:) = 0
      
       ! Do shortwave stuff...
       if (radiation_do('sw')) then

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1126,8 +1126,8 @@ contains
       ! ---------------------------------------------------------------------------
 
       ! Pointers to heating rates on physics buffer
-      real(r8), pointer :: qrs(:,:) => null()  ! shortwave radiative heating rate 
-      real(r8), pointer :: qrl(:,:) => null()  ! longwave  radiative heating rate 
+      real(r8), pointer :: qrs(:,:)  ! shortwave radiative heating rate 
+      real(r8), pointer :: qrl(:,:)  ! longwave  radiative heating rate 
 
       ! Clear-sky heating rates are not on the physics buffer, and we have no
       ! reason to put them there, so declare these are regular arrays here

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1131,8 +1131,8 @@ contains
 
       ! Clear-sky heating rates are not on the physics buffer, and we have no
       ! reason to put them there, so declare these are regular arrays here
-      real(r8) :: qrsc(pcols,pver) = 0._r8
-      real(r8) :: qrlc(pcols,pver) = 0._r8
+      real(r8) :: qrsc(pcols,pver)
+      real(r8) :: qrlc(pcols,pver)
 
       ! Flag to carry (QRS,QRL)*dp across time steps. 
       ! TODO: what does this mean?


### PR DESCRIPTION
Make RRTMGP radiation code thread-safe. This fixes a long-standing bug in RRTMGP that prevented us from running the code in threaded configurations. The fix involves a very small change in the RRTMGP interface (in `radiation.F90`), and similarly small changes in the external RRTMGP repo. In order to pull in the external changes, .gitmodules is updated to point to the "develop" branch of the external RRTMGP repo, and the submodule is updated to point to the latest commit. Changes are BFB for RRTMGP configurations (and should be for non-RRTMGP configurations as well since no code is touched outside of the RRTMGP except .gitmodules).