### PR TITLE
Update mpas-seaice to bring in improvements to the snow model

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -485,16 +485,22 @@ if ($CONTINUE_RUN eq 'TRUE') {
         add_default($nl, 'config_do_restart_hbrine', 'val'=>".true.");
         add_default($nl, 'config_do_restart_zsalinity', 'val'=>".true.");
         add_default($nl, 'config_do_restart_bgc', 'val'=>".true.");
+        add_default($nl, 'config_do_restart_snow_density', 'val'=>".true.");
+        add_default($nl, 'config_do_restart_snow_grain_radius', 'val'=>".true.");
 } else {
         add_default($nl, 'config_do_restart', 'val'=>".false.");
         add_default($nl, 'config_do_restart_hbrine', 'val'=>".false.");
         add_default($nl, 'config_do_restart_zsalinity', 'val'=>".false.");
         add_default($nl, 'config_do_restart_bgc', 'val'=>".false.");
+        add_default($nl, 'config_do_restart_snow_density', 'val'=>".false.");
+        add_default($nl, 'config_do_restart_snow_grain_radius', 'val'=>".false.");
 }
 add_default($nl, 'config_restart_timestamp_name');
 add_default($nl, 'config_do_restart_hbrine');
 add_default($nl, 'config_do_restart_zsalinity');
 add_default($nl, 'config_do_restart_bgc');
+add_default($nl, 'config_do_restart_snow_density');
+add_default($nl, 'config_do_restart_snow_grain_radius');
 
 ##############################
 # Namelist group: dimensions #
@@ -595,6 +601,7 @@ if ($ice_bgc eq 'ice_bgc') {
 }
 add_default($nl, 'config_use_column_itd_thermodynamics');
 add_default($nl, 'config_use_column_ridging');
+add_default($nl, 'config_use_column_snow_tracers');
 
 ##################################
 # Namelist group: column_tracers #
@@ -607,6 +614,8 @@ add_default($nl, 'config_use_cesm_meltponds');
 add_default($nl, 'config_use_level_meltponds');
 add_default($nl, 'config_use_topo_meltponds');
 add_default($nl, 'config_use_aerosols');
+add_default($nl, 'config_use_effective_snow_density');
+add_default($nl, 'config_use_snow_grain_radius');
 
 ###################################
 # Namelist group: biogeochemistry #
@@ -788,6 +797,19 @@ add_default($nl, 'config_snow_shortwave_tuning_parameter');
 add_default($nl, 'config_temp_change_snow_grain_radius_change');
 add_default($nl, 'config_max_melting_snow_grain_radius');
 add_default($nl, 'config_algae_absorption_coefficient');
+
+########################
+# Namelist group: snow #
+########################
+
+add_default($nl, 'config_snow_redistribution_scheme');
+add_default($nl, 'config_fallen_snow_radius');
+add_default($nl, 'config_use_snow_liquid_ponds');
+add_default($nl, 'config_new_snow_density');
+add_default($nl, 'config_max_snow_density');
+add_default($nl, 'config_minimum_wind_compaction');
+add_default($nl, 'config_wind_compaction_factor');
+add_default($nl, 'config_max_dry_snow_radius');
 
 #############################
 # Namelist group: meltponds #
@@ -1115,6 +1137,7 @@ my @groups = qw(seaice_model
                 column_tracers
                 biogeochemistry
                 shortwave
+                snow
                 meltponds
                 thermodynamics
                 itd

--- a/components/mpas-seaice/bld/build-namelist-group-list
+++ b/components/mpas-seaice/bld/build-namelist-group-list
@@ -13,6 +13,7 @@ my @groups = qw(seaice_model
                 column_tracers
                 biogeochemistry
                 shortwave
+                snow
                 meltponds
                 thermodynamics
                 itd

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -46,16 +46,22 @@ if ($CONTINUE_RUN eq 'TRUE') {
         add_default($nl, 'config_do_restart_hbrine', 'val'=>".true.");
         add_default($nl, 'config_do_restart_zsalinity', 'val'=>".true.");
         add_default($nl, 'config_do_restart_bgc', 'val'=>".true.");
+        add_default($nl, 'config_do_restart_snow_density', 'val'=>".true.");
+        add_default($nl, 'config_do_restart_snow_grain_radius', 'val'=>".true.");
 } else {
         add_default($nl, 'config_do_restart', 'val'=>".false.");
         add_default($nl, 'config_do_restart_hbrine', 'val'=>".false.");
         add_default($nl, 'config_do_restart_zsalinity', 'val'=>".false.");
         add_default($nl, 'config_do_restart_bgc', 'val'=>".false.");
+        add_default($nl, 'config_do_restart_snow_density', 'val'=>".false.");
+        add_default($nl, 'config_do_restart_snow_grain_radius', 'val'=>".false.");
 }
 add_default($nl, 'config_restart_timestamp_name');
 add_default($nl, 'config_do_restart_hbrine');
 add_default($nl, 'config_do_restart_zsalinity');
 add_default($nl, 'config_do_restart_bgc');
+add_default($nl, 'config_do_restart_snow_density');
+add_default($nl, 'config_do_restart_snow_grain_radius');
 
 ##############################
 # Namelist group: dimensions #
@@ -149,6 +155,7 @@ add_default($nl, 'config_use_column_vertical_thermodynamics');
 add_default($nl, 'config_use_column_biogeochemistry');
 add_default($nl, 'config_use_column_itd_thermodynamics');
 add_default($nl, 'config_use_column_ridging');
+add_default($nl, 'config_use_column_snow_tracers');
 
 ##################################
 # Namelist group: column_tracers #
@@ -161,6 +168,8 @@ add_default($nl, 'config_use_cesm_meltponds');
 add_default($nl, 'config_use_level_meltponds');
 add_default($nl, 'config_use_topo_meltponds');
 add_default($nl, 'config_use_aerosols');
+add_default($nl, 'config_use_effective_snow_density');
+add_default($nl, 'config_use_snow_grain_radius');
 
 ###################################
 # Namelist group: biogeochemistry #
@@ -327,6 +336,19 @@ add_default($nl, 'config_snow_shortwave_tuning_parameter');
 add_default($nl, 'config_temp_change_snow_grain_radius_change');
 add_default($nl, 'config_max_melting_snow_grain_radius');
 add_default($nl, 'config_algae_absorption_coefficient');
+
+########################
+# Namelist group: snow #
+########################
+
+add_default($nl, 'config_snow_redistribution_scheme');
+add_default($nl, 'config_fallen_snow_radius');
+add_default($nl, 'config_use_snow_liquid_ponds');
+add_default($nl, 'config_new_snow_density');
+add_default($nl, 'config_max_snow_density');
+add_default($nl, 'config_minimum_wind_compaction');
+add_default($nl, 'config_wind_compaction_factor');
+add_default($nl, 'config_max_dry_snow_radius');
 
 #############################
 # Namelist group: meltponds #

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -53,6 +53,8 @@
 <config_do_restart_hbrine>false</config_do_restart_hbrine>
 <config_do_restart_zsalinity>false</config_do_restart_zsalinity>
 <config_do_restart_bgc>false</config_do_restart_bgc>
+<config_do_restart_snow_density>false</config_do_restart_snow_density>
+<config_do_restart_snow_grain_radius>false</config_do_restart_snow_grain_radius>
 
 <!-- dimensions -->
 <config_nCategories>5</config_nCategories>
@@ -142,6 +144,7 @@
 <config_use_column_biogeochemistry>false</config_use_column_biogeochemistry>
 <config_use_column_itd_thermodynamics>true</config_use_column_itd_thermodynamics>
 <config_use_column_ridging>true</config_use_column_ridging>
+<config_use_column_snow_tracers>false</config_use_column_snow_tracers>
 
 <!-- column_tracers -->
 <config_use_ice_age>true</config_use_ice_age>
@@ -151,6 +154,8 @@
 <config_use_level_meltponds>true</config_use_level_meltponds>
 <config_use_topo_meltponds>false</config_use_topo_meltponds>
 <config_use_aerosols>false</config_use_aerosols>
+<config_use_effective_snow_density>false</config_use_effective_snow_density>
+<config_use_snow_grain_radius>false</config_use_snow_grain_radius>
 
 <!-- biogeochemistry -->
 <config_use_brine>false</config_use_brine>
@@ -311,6 +316,16 @@
 <config_temp_change_snow_grain_radius_change>1.5</config_temp_change_snow_grain_radius_change>
 <config_max_melting_snow_grain_radius>1500.0</config_max_melting_snow_grain_radius>
 <config_algae_absorption_coefficient>0.6</config_algae_absorption_coefficient>
+
+<!-- snow -->
+<config_snow_redistribution_scheme>'none'</config_snow_redistribution_scheme>
+<config_fallen_snow_radius>54.4</config_fallen_snow_radius>
+<config_use_snow_liquid_ponds>false</config_use_snow_liquid_ponds>
+<config_new_snow_density>100.0</config_new_snow_density>
+<config_max_snow_density>450.0</config_max_snow_density>
+<config_minimum_wind_compaction>10.0</config_minimum_wind_compaction>
+<config_wind_compaction_factor>27.3</config_wind_compaction_factor>
+<config_max_dry_snow_radius>2800.0</config_max_dry_snow_radius>
 
 <!-- meltponds -->
 <config_snow_to_ice_transition_depth>0.0</config_snow_to_ice_transition_depth>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -261,6 +261,22 @@ Valid values: true or false
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_do_restart_snow_density" type="logical"
+	category="restart" group="restart">
+Restart the snow density tracers
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_do_restart_snow_grain_radius" type="logical"
+	category="restart" group="restart">
+Restart the snow grain radius tracer
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- dimensions -->
 
@@ -709,6 +725,14 @@ Valid values: true or false
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_use_column_snow_tracers" type="logical"
+	category="column_package" group="column_package">
+Allow snow modifications plus additional snow tracers
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- column_tracers -->
 
@@ -763,6 +787,22 @@ Default: Defined in namelist_defaults.xml
 <entry id="config_use_aerosols" type="logical"
 	category="column_tracers" group="column_tracers">
 Carry aerosols in the ice (NCAR scheme)
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_effective_snow_density" type="logical"
+	category="column_tracers" group="column_tracers">
+Use effective snow density
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_snow_grain_radius" type="logical"
+	category="column_tracers" group="column_tracers">
+Use prognosed snow grain radius aging
 
 Valid values: true or false
 Default: Defined in namelist_defaults.xml
@@ -2019,6 +2059,73 @@ Default: Defined in namelist_defaults.xml
 Algae absorption coefficient for 0.5 m thick layer.
 
 Valid values: 
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
+<!-- snow -->
+
+<entry id="config_snow_redistribution_scheme" type="char*1024"
+	category="snow" group="snow">
+Use a snow redistribution scheme
+
+Valid values: '30percent (30% rule, precip only)','30percentsw (30% rulewith shortwave)','ITDsd (Lecomte PhD, 2014)','ITDrdg (like ITDsd but use level/ridged ice)','default or none (none)'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_fallen_snow_radius" type="real"
+	category="snow" group="snow">
+fallen snow grain radius
+
+Valid values: positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_snow_liquid_ponds" type="logical"
+	category="snow" group="snow">
+use snow liquid tracer for ponds
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_new_snow_density" type="real"
+	category="snow" group="snow">
+new snow density
+
+Valid values: positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_max_snow_density" type="real"
+	category="snow" group="snow">
+maximum snow density
+
+Valid values: positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_minimum_wind_compaction" type="real"
+	category="snow" group="snow">
+minimum wind speed to compact snow
+
+Valid values: positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_wind_compaction_factor" type="real"
+	category="snow" group="snow">
+wind compaction factor
+
+Valid values: positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_max_dry_snow_radius" type="real"
+	category="snow" group="snow">
+maximum dry metamorphism snow grain radius
+
+Valid values: positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 


### PR DESCRIPTION
This PR brings in a new mpas-source submodule with updates only to the seaice core. These changes add improvements to the seaice snow model, though they are turned off by default and therefore should be bfb. The snow model does add some new variables to the seaice Registry and corresponding namelists.

[BFB]
[NML]