### PR TITLE
Modifications to preserve the vertical shape of CO2 tracers

### DIFF
--- a/components/cam/src/physics/cam/co2_cycle.F90
+++ b/components/cam/src/physics/cam/co2_cycle.F90
@@ -37,6 +37,7 @@ public co2_init_cnst                 ! initialize mixing ratios if not read from
 public co2_init                      ! initialize (history) variables
 public co2_time_interp_ocn           ! time interpolate co2 flux
 public co2_time_interp_fuel          ! time interpolate co2 flux
+public co2_cycle_set_cnst_type       ! set co2 tracers mixing type for local versions of cnst_type
 
 ! Public data
  
@@ -316,6 +317,32 @@ subroutine co2_init_cnst(name, q, gcid)
    end select
 
 end subroutine co2_init_cnst
+!===============================================================================
+
+subroutine co2_cycle_set_cnst_type(cnst_type_loc, cnst_type_val)
+
+!----------------------------------------------------------------------- 
+! 
+! Purpose: 
+! Set a local copy of cnst_type to be 'wet' or 'dry'       
+!
+!-----------------------------------------------------------------------
+   use constituents, only: pcnst
+
+! Arguments
+   character(len=3), intent(inout) :: cnst_type_loc(pcnst) ! a local copy of cnst_type
+   character(len=3), intent(in)    :: cnst_type_val        ! set mmr type: 'wet' or 'dry'
+   integer                         :: m                    ! loop index
+!-----------------------------------------------------------------------
+
+   if (.not. co2_flag) return
+
+   ! set cnst_type_loc for each CO2 tracer
+   do m = 1, ncnst
+      cnst_type_loc(c_i(m)) = cnst_type_val
+   end do
+
+end subroutine co2_cycle_set_cnst_type
 !===============================================================================
  
 end module co2_cycle

--- a/components/cam/src/physics/cam/gw_drag.F90
+++ b/components/cam/src/physics/cam/gw_drag.F90
@@ -560,6 +560,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   !-----------------------------------------------------------------------
   use physics_types,  only: physics_state_copy, set_dry_to_wet
   use constituents,   only: cnst_type
+  use co2_cycle,      only: co2_cycle_set_cnst_type
   use physics_buffer, only: physics_buffer_desc, pbuf_get_field
   use camsrfexch, only: cam_in_t
   ! Location-dependent cpair
@@ -661,13 +662,19 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   real(r8) :: rdpm(state%ncol,pver)
   real(r8) :: zm(state%ncol,pver)
 
+  ! local override option for constituents cnst_type
+  character(len=3), dimension(pcnst) :: cnst_type_loc
+
   !------------------------------------------------------------------------
 
   ! Make local copy of input state.
   call physics_state_copy(state, state1)
 
   ! constituents are all treated as wet mmr
-  call set_dry_to_wet(state1)
+  ! don't convert co2 tracers to wet mixing ratios
+  cnst_type_loc(:) = cnst_type(:)
+  call co2_cycle_set_cnst_type(cnst_type_loc, 'wet')
+  call set_dry_to_wet(state1, cnst_type_loc)
 
   lchnk = state1%lchnk
   ncol  = state1%ncol

--- a/components/cam/src/physics/cam/physics_types.F90
+++ b/components/cam/src/physics/cam/physics_types.F90
@@ -1433,41 +1433,61 @@ end subroutine set_state_pdry
 
 !===============================================================================
 
-subroutine set_wet_to_dry (state)
+subroutine set_wet_to_dry (state, cnst_type_in)
 
   use constituents,  only: pcnst, cnst_type
 
   type(physics_state), intent(inout) :: state
+  character(len=3), intent(in), optional :: cnst_type_in(pcnst)  ! use a specified cnst_type instead
+                                                                 ! of that in the module constituents
 
   integer m, ncol
   
   ncol = state%ncol
 
-  do m = 1,pcnst
-     if (cnst_type(m).eq.'dry') then
-        state%q(:ncol,:,m) = state%q(:ncol,:,m)*state%pdel(:ncol,:)/state%pdeldry(:ncol,:)
-     endif
-  end do
+  if ( present(cnst_type_in) ) then
+     do m = 1,pcnst
+        if (cnst_type_in(m).eq.'dry') then
+           state%q(:ncol,:,m) = state%q(:ncol,:,m)*state%pdel(:ncol,:)/state%pdeldry(:ncol,:)
+        endif
+     end do
+  else
+     do m = 1,pcnst
+        if (cnst_type(m).eq.'dry') then
+           state%q(:ncol,:,m) = state%q(:ncol,:,m)*state%pdel(:ncol,:)/state%pdeldry(:ncol,:)
+        endif
+     end do
+  endif
 
 end subroutine set_wet_to_dry 
 
 !===============================================================================
 
-subroutine set_dry_to_wet (state)
+subroutine set_dry_to_wet (state, cnst_type_in)
 
   use constituents,  only: pcnst, cnst_type
 
   type(physics_state), intent(inout) :: state
+  character(len=3), intent(in), optional :: cnst_type_in(pcnst)  ! use a specified cnst_type instead
+                                                                 ! of that in the module constituents
 
   integer m, ncol
   
   ncol = state%ncol
 
-  do m = 1,pcnst
-     if (cnst_type(m).eq.'dry') then
-        state%q(:ncol,:,m) = state%q(:ncol,:,m)*state%pdeldry(:ncol,:)/state%pdel(:ncol,:)
-     endif
-  end do
+  if ( present(cnst_type_in) ) then
+     do m = 1,pcnst
+        if (cnst_type_in(m).eq.'dry') then
+           state%q(:ncol,:,m) = state%q(:ncol,:,m)*state%pdeldry(:ncol,:)/state%pdel(:ncol,:)
+        endif
+     end do
+  else
+     do m = 1,pcnst
+        if (cnst_type(m).eq.'dry') then
+           state%q(:ncol,:,m) = state%q(:ncol,:,m)*state%pdeldry(:ncol,:)/state%pdel(:ncol,:)
+        endif
+     end do
+  endif
 
 end subroutine set_dry_to_wet
 

--- a/components/cam/src/physics/cam/vertical_diffusion.F90
+++ b/components/cam/src/physics/cam/vertical_diffusion.F90
@@ -656,6 +656,7 @@ contains
     use wv_saturation,      only : qsat
     use molec_diff,         only : compute_molec_diff, vd_lu_qdecomp
     use constituents,       only : qmincg, qmin, cnst_type
+    use co2_cycle,          only : co2_cycle_set_cnst_type
     use diffusion_solver,   only : compute_vdiff, any, operator(.not.)
     use physconst,          only : cpairv, rairv !Needed for calculation of upward H flux
     use time_manager,       only : get_nstep
@@ -815,12 +816,17 @@ contains
 
     logical  :: lq(pcnst)
 
+    character(len=3), dimension(pcnst) :: cnst_type_loc             ! local override option for constituents cnst_type
+
     ! ----------------------- !
     ! Main Computation Begins !
     ! ----------------------- !
 
     ! Assume 'wet' mixing ratios in diffusion code.
-    call set_dry_to_wet(state)
+    ! don't convert co2 tracers to wet mixing ratios
+    cnst_type_loc(:) = cnst_type(:)
+    call co2_cycle_set_cnst_type(cnst_type_loc, 'wet')
+    call set_dry_to_wet(state, cnst_type_loc)
 
     rztodt = 1._r8 / ztodt
     lchnk  = state%lchnk
@@ -1226,7 +1232,10 @@ contains
        endif
     end do
     ! convert wet mmr back to dry before conservation check
-    call set_wet_to_dry(state)
+    ! avoid converting co2 tracers again
+    cnst_type_loc(:) = cnst_type(:)
+    call co2_cycle_set_cnst_type(cnst_type_loc, 'wet')
+    call set_wet_to_dry(state, cnst_type_loc)
 
     slten(:ncol,:)         = ( sl(:ncol,:) - sl_prePBL(:ncol,:) ) * rztodt
     qtten(:ncol,:)         = ( qt(:ncol,:) - qt_prePBL(:ncol,:) ) * rztodt


### PR DESCRIPTION
Follows suggestions by Keith Lindsay for modifying the fix
to conserve non-water tracer species (#2883 ) so that the 
nearly constant profile of CO2 is preserved.

Non-BFB when CO2 tracers are active.

[BFB] 