### PR TITLE
DSS omega in SL transport; fix a unit test; fix Intel 18 build.

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -5891,7 +5891,7 @@ Default in homme: 0 (does not use time split wrt HV).
 </entry>
 
 <entry id="hypervis_subcycle_q" type="integer" category="se"
-       group="ctl_nl" valid_values="1" >
+       group="ctl_nl" valid_values="" >
 Number of hyperviscosity subcycles done in tracer advection code.
 The only supported value in CAM is 1.
 Default: Set by build-namelist.

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -6035,6 +6035,13 @@ nearest point in the halo to the departure point, when necessary.
 Default: 0
 </entry>
 
+<entry id="semi_lagrange_hv_q" type="integer" category="se"
+       group="ctl_nl" valid_values="">
+Number of tracers, starting from 1, to which to apply hyperviscosity. For
+example, to apply hyperviscosity to moisture, the first tracer, set the value to
+1. Hyperviscosity is applied using nu_q as the coefficient.
+</entry>
+
 <!-- CAM I/O  -->
 
 <entry id="pio_stride" type="integer" category="pio"

--- a/components/homme/src/share/compose/compose_slmm.cpp
+++ b/components/homme/src/share/compose/compose_slmm.cpp
@@ -3635,7 +3635,9 @@ void calc_q (const CslMpi& cm, const Int& src_lid, const Int& lev,
   if (use_q) {
     // We can use q from calc_q_extrema.
     const Real* const qs0 = ed.q + levos;
-#   pragma ivdep
+    // It was found that Intel 18 produced code that was not BFB between runs
+    // due to this pragma.
+    //#pragma ivdep
     for (Int iq = 0; iq < cm.qsize; ++iq) {
       const Real* const qs = qs0 + iq*np2nlev;
       q_tgt[iq] =
@@ -3648,7 +3650,8 @@ void calc_q (const CslMpi& cm, const Int& src_lid, const Int& lev,
     // q from calc_q_extrema is being overwritten, so have to use qdp/dp.
     const Real* const dp = ed.dp + levos;
     const Real* const qdp0 = ed.qdp + levos;
-#   pragma ivdep
+    // I'm commented out this pragma, too, to be safe.
+    //#pragma ivdep
     for (Int iq = 0; iq < cm.qsize; ++iq) {
       const Real* const qdp = qdp0 + iq*np2nlev;
       q_tgt[iq] = (ry[0]*(rx[0]*(qdp[ 0]/dp[ 0]) + rx[1]*(qdp[ 1]/dp[ 1])  +

--- a/components/homme/src/share/compose/compose_slmm.cpp
+++ b/components/homme/src/share/compose/compose_slmm.cpp
@@ -1835,9 +1835,9 @@ int get_nearest_point (const nearest_point::Mesh& m, const MeshNearestPointData&
 }
 
 Int unittest (const nearest_point::Mesh& m, const Int tgt_elem) {
-  Int nerr = 0, ne;
+  Int nerr = 0, ne = 0;
   const Int nc = len(m.e);
-  for (Int ic = 0, ne = 0; ic < nc; ++ic) {
+  for (Int ic = 0; ic < nc; ++ic) {
     const auto cell = slice(m.e, ic);
     static const Real alphas[] = { 0.01, 0.99, 0, 1 };
     static const int nalphas = sizeof(alphas)/sizeof(*alphas);
@@ -2022,6 +2022,8 @@ struct Advecter {
       local_mesh_nearest_point_data_.resize(nelem);
   }
 
+  void fill_nearest_points_if_needed();
+
   Int np  () const { return np_ ; }
   Int np2 () const { return np2_; }
   Int np4 () const { return np4_; }
@@ -2127,9 +2129,13 @@ void Advecter::init_local_mesh_if_needed (const Int ie, const Array3D& corners,
   m.tgt_elem = slmm::get_src_cell(m, p_inside);
   slmm_assert(m.tgt_elem >= 0 &&
               m.tgt_elem < ncell);
+}
+
+void Advecter::fill_nearest_points_if_needed () {
   if (nearest_point_permitted_lev_bdy_ >= 0)
-    init_nearest_point_data(local_mesh_[ie],
-                            local_mesh_nearest_point_data_[ie]);
+    for (Int ie = 0; ie < static_cast<Int>(local_mesh_.size()); ++ie)
+      init_nearest_point_data(local_mesh_[ie],
+                              local_mesh_nearest_point_data_[ie]);
 }
 
 void Advecter::check_ref2sphere (const Int ie, const Real* p_homme) {
@@ -3297,6 +3303,7 @@ CslMpi::Ptr init (const slmm::Advecter::ConstPtr& advecter,
 // already has a ref to the const'ed one.
 void finalize_local_meshes (CslMpi& cm, slmm::Advecter& advecter) {
   if (cm.halo == 2) extend_halo::extend_local_meshes(*cm.p, cm.ed, advecter);
+  advecter.fill_nearest_points_if_needed();
 }
 
 // Set pointers to HOMME data arrays.


### PR DESCRIPTION
1. Omega is needed for diagnostics. DSS it in SL transport, just like it is DSSed in Eulerian transport.
2. An SL unit test had an uninitialized variable. Fix it.
3. An unused feature in SL transport had a bug. Fix it and the test.
4. Intel 18 with -O3 -fp-model-fast has a problem with a vectorization pragma. Comment it out. Comment out a similar one for safety.

[BFB] except on Anvil with Intel 18, where it solves a BFB problem.