### PR TITLE
Fix for failing SCM developer test on Anvil

### DIFF
--- a/cime/scripts/lib/CIME/test_scheduler.py
+++ b/cime/scripts/lib/CIME/test_scheduler.py
@@ -637,6 +637,7 @@ class TestScheduler(object):
                     for comp in comps:
                         envtest.set_test_parameter("NTASKS_"+comp, "1")
                         envtest.set_test_parameter("NTHRDS_"+comp, "1")
+			envtest.set_test_parameter("ROOTPE_"+comp, "0")
 
                 elif (opt.startswith('I') or # Marker to distinguish tests with same name - ignored
                       opt.startswith('M') or # handled in create_newcase

--- a/cime/scripts/lib/CIME/test_scheduler.py
+++ b/cime/scripts/lib/CIME/test_scheduler.py
@@ -637,7 +637,7 @@ class TestScheduler(object):
                     for comp in comps:
                         envtest.set_test_parameter("NTASKS_"+comp, "1")
                         envtest.set_test_parameter("NTHRDS_"+comp, "1")
-			envtest.set_test_parameter("ROOTPE_"+comp, "0")
+                        envtest.set_test_parameter("ROOTPE_"+comp, "0")
 
                 elif (opt.startswith('I') or # Marker to distinguish tests with same name - ignored
                       opt.startswith('M') or # handled in create_newcase


### PR DESCRIPTION
The SMS_R_Ld5.ne4_ne4.FSCM5A97 test was failing on Anvil.  The reason is that ROOTPE needs to be explicitly set to zero for all component models for PTS_MODE (single column model mode).  All developer tests pass with this change. 

Addresses #2963 