### PR TITLE
Implement DCAPE trigger and unrestricted launch level for ZM convection

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1306,6 +1306,7 @@
 <zmconv_ke                       hgrid="512x1024"                     > 1.0E-6 </zmconv_ke>
 
 <zmconv_trigmem                                                       >.false. </zmconv_trigmem>
+<zmconv_trigdcape_ull                                                 >.false. </zmconv_trigdcape_ull>
 <zmconv_tiedke_add                                                    >0.5D0   </zmconv_tiedke_add>
 <zmconv_cape_cin                                                      >5       </zmconv_cape_cin>
 <zmconv_mx_bot_lyr_adj                                                >0       </zmconv_mx_bot_lyr_adj>

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -2525,6 +2525,12 @@ Trigger and memory option in ZM deep convection scheme.
 Default: FALSE
 </entry>
 
+<entry id="zmconv_trigdcape_ull" type="logical" category="conv"
+       group="zmconv_nl" valid_values="" >
+DCAPE trigger along with unrestricted launching level for ZM deep convection scheme.
+Default: FALSE
+</entry>
+
 <entry id="zmconv_tiedke_add" type="real" category="conv"
        group="zmconv_nl" valid_values="" >
 A ZM deep convection parameter

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -30,7 +30,7 @@ module physpkg
 
   use cam_control_mod,  only: ideal_phys, adiabatic
   use phys_control,     only: phys_do_flux_avg, phys_getopts, waccmx_is
-  use zm_conv,          only: trigmem
+  use zm_conv,          only: trigmem, do_zmconv_dcape_ull => trigdcape_ull
   use scamMod,          only: single_column, scm_crm_mode
   use flux_avg,         only: flux_avg_init
 #ifdef SPMD
@@ -1455,6 +1455,11 @@ subroutine tphysac (ztodt,   cam_in,  &
 
     logical :: do_clubb_sgs 
 
+    !DCAPE-ULL: physics buffer fields to compute tendencies for dcape
+    real(r8), pointer, dimension(:,:) :: t_star   ! temperature
+    real(r8), pointer, dimension(:,:) :: q_star   ! moisture
+    logical :: do_zmconv_trigdcape_ull            ! switch if using dcape-ull as trigger for ZM convection
+                                                  ! default to false, to bbe made controllable by nml
     ! Debug physics_state.
     logical :: state_debug_checks
 
@@ -1794,6 +1799,19 @@ end if ! l_ac_energy_chk
 
     call diag_phys_tend_writeout (state, pbuf,  tend, ztodt, tmp_q, tmp_cldliq, tmp_cldice, &
          tmp_t, qini, cldliqini, cldiceini)
+
+    ! DCAPE-ULL: record current state of T and q for computing dynamical tendencies
+    !            the calculation follows the same format as in diag_phys_tend_writeout
+    if (do_zmconv_dcape_ull) then
+      ifld = pbuf_get_index('T_STAR')
+      call pbuf_get_field(pbuf, ifld, t_star, (/1,1/),(/pcols,pver/))
+      ifld = pbuf_get_index('Q_STAR')
+      call pbuf_get_field(pbuf, ifld, q_star, (/1,1/),(/pcols,pver/))
+      do k=1,pver
+         q_star(:ncol,k) = state%q(:ncol,k,1)
+         t_star(:ncol,k) = state%t(:ncol,k)
+      enddo
+    endif
 
     call clybry_fam_set( ncol, lchnk, map2chm, state%q, pbuf )
 

--- a/components/cam/src/physics/cam/zm_conv.F90
+++ b/components/cam/src/physics/cam/zm_conv.F90
@@ -3401,7 +3401,7 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 
          !DCAPE-ULL
          if (trigdcape_ull) then
-           if (k >= nint(pblt00(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
+           if (k >= nint(pblt600(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
               hmax(i) = hmn(i)
               mx(i) = k
            end if

--- a/components/cam/src/physics/cam/zm_conv.F90
+++ b/components/cam/src/physics/cam/zm_conv.F90
@@ -36,6 +36,7 @@ module zm_conv
   public convtran                 ! convective transport
   public momtran                  ! convective momentum transport
   public trigmem                  ! true if convective memory
+  public trigdcape_ull            ! true if to use dcape-ULL trigger
 
 !
 ! Private data
@@ -50,6 +51,7 @@ module zm_conv
    real(r8) :: zmconv_alfa           = unset_r8   
    real(r8) :: zmconv_tiedke_add     = unset_r8   
    logical  :: zmconv_trigmem        = .false.    
+   logical  :: zmconv_trigdcape_ull  = .false.    
    integer  :: zmconv_cape_cin       = unset_int
    integer  :: zmconv_mx_bot_lyr_adj = unset_int
    real(r8) :: zmconv_tp_fac         = unset_r8
@@ -60,6 +62,14 @@ module zm_conv
 !<songxl 2014-05-20------------------
     real(r8), parameter :: dcapelmt = 1.81e-2_r8  ! threshold value of dcape for deep convection. 65J/kg/hr
 !>songxl 2014-05-20------------------
+
+!DCAPE-ULL
+   real(r8), parameter :: trigdcapelmt = 0._r8  ! threshold value of dcape for deep convection
+   logical :: trigdcape_ull    = .false. !true to use DCAPE trigger and -ULL 
+   integer :: dcapemx(pcols) ! save maxi from 1st call for CAPE calculation and used in 2nd call when DCAPE-ULL active
+!  May need to change to use local variable !  as passed via dummy argument. For now, making it threadprivate as follows,
+!$omp threadprivate (dcapemx)
+
    real(r8) :: ke           ! Tunable evaporation efficiency set from namelist input zmconv_ke
    real(r8) :: c0_lnd       ! set from namelist input zmconv_c0_lnd
    real(r8) :: c0_ocn       ! set from namelist input zmconv_c0_ocn
@@ -107,7 +117,7 @@ subroutine zmconv_readnl(nlfile)
 
    namelist /zmconv_nl/ zmconv_c0_lnd, zmconv_c0_ocn, zmconv_ke, zmconv_tau, & 
            zmconv_dmpdz, zmconv_alfa, zmconv_trigmem, zmconv_tiedke_add,     &
-           zmconv_cape_cin, zmconv_mx_bot_lyr_adj, zmconv_tp_fac
+           zmconv_cape_cin, zmconv_mx_bot_lyr_adj, zmconv_tp_fac, zmconv_trigdcape_ull
    !-----------------------------------------------------------------------------
 
    zmconv_tau = 3600._r8
@@ -130,6 +140,7 @@ subroutine zmconv_readnl(nlfile)
       ke             = zmconv_ke
       tau            = zmconv_tau
       trigmem        = zmconv_trigmem
+      trigdcape_ull  = zmconv_trigdcape_ull
       tiedke_add     = zmconv_tiedke_add
       num_cin        = zmconv_cape_cin
       mx_bot_lyr_adj = zmconv_mx_bot_lyr_adj
@@ -142,6 +153,10 @@ subroutine zmconv_readnl(nlfile)
            alfa_scalar = 0.1_r8
       end if
 
+      if (trigdcape_ull) then 
+         write(iulog,*)'**** ZMCONV-DCAPE trigger with unrestricted launch level:', trigdcape_ull
+      endif
+
    end if
 
 #ifdef SPMD
@@ -153,6 +168,7 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(dmpdz,             1, mpir8,  0, mpicom)
    call mpibcast(alfa_scalar,       1, mpir8,  0, mpicom)
    call mpibcast(trigmem,           1, mpilog, 0, mpicom)
+   call mpibcast(trigdcape_ull,     1, mpilog, 0, mpicom)
    call mpibcast(tiedke_add,        1, mpir8,  0, mpicom)
    call mpibcast(num_cin,           1, mpiint, 0, mpicom)
    call mpibcast(mx_bot_lyr_adj,    1, mpiint, 0, mpicom)
@@ -219,7 +235,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
                     mu      ,md      ,du      ,eu      ,ed      , &
                     dp      ,dsubcld ,jt      ,maxg    ,ideep   , &
                     lengath ,ql      ,rliq    ,landfrac,hu_nm1  , &
-                    cnv_nm1 ,tm1     ,qm1     )  !songxl 2014-05-20
+                    cnv_nm1 ,tm1     ,qm1     ,t_star  ,q_star, dcape)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -355,6 +371,14 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8), intent(in) :: tm1(pcols,pver)       ! grid slice of temperature at mid-layer.
    real(r8), intent(in) :: qm1(pcols,pver)       ! grid slice of specific humidity.
 !>songxl 2014-05-20------------------
+
+!DCAPE-ULL
+!  real(r8), intent(in) :: t_star(pcols,pver)     ! grid slice of temperature at mid-layer.
+!  real(r8), intent(in) :: q_star(pcols,pver)     ! grid slice of specific humidity
+   real(r8), intent(in), pointer, dimension(:,:) :: t_star ! intermediate T between n and n-1 time step
+   real(r8), intent(in), pointer, dimension(:,:) :: q_star ! intermediate q between n and n-1 time step
+
+
 !
 ! output arguments
 !
@@ -380,6 +404,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8), intent(out) :: jcbot(pcols)  ! o row of base of cloud indices passed out.
    real(r8), intent(out) :: prec(pcols)
    real(r8), intent(out) :: rliq(pcols) ! reserved liquid (not yet in cldliq) for energy integrals
+   real(r8), intent(out) :: dcape(pcols)           ! output dynamical CAPE
 
 !<songxl 2014-05-20------------------
    real(r8), intent(inout) :: hu_nm1 (pcols,pver)
@@ -424,12 +449,14 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8) qstpm1(pcols,pver)         ! w parcel temp. saturation mixing ratio at n-1 time step
    real(r8) tlm1(pcols)                ! w LCL parcel Temperature at n-1 time step
    real(r8) capem1(pcols)              ! w CAPE at n-1 time step 
-   real(r8) dcape(pcols)               ! w CAPE change rate due to adv between n and n-1 step
    integer lclm1(pcols)                ! w base level index of deep cumulus convection.
    integer lelm1(pcols)                ! w index of highest theoretical convective plume.
    integer lonm1(pcols)                ! w index of onset level for deep convection.
    integer maxim1(pcols)               ! w index of level with largest moist static energy.
 !>songxl 2014-05-20-----------------
+
+   logical iclosure                    ! switch on sequence of call to buoyan_dilute to derive DCAPE
+   real(r8) capelmt_wk                 ! work capelmt to allow diff values passed to closure with trigdcape
 
    integer lcl(pcols)                  ! w  base level index of deep cumulus convection.
    integer lel(pcols)                  ! w  index of highest theoretical convective plume.
@@ -619,13 +646,21 @@ subroutine zm_convr(lchnk   ,ncol    , &
 
       !  Evaluate Tparcel, qs(Tparcel), buoyancy and CAPE, 
       !     lcl, lel, parcel launch level at index maxi()=hmax
-!<songxl 2014-05-20-----------------
+      !
+
+      ! 1. First call, iclosure = .true., standard calculation, scanning for launching level up to 600 hPa
+      ! 2. Second call, iclosure = .faklse. pass the launch level from 1st call to determine CAPE at previous step
+      !    The differewnce of CAPE values from the two calls is DCAPE, based on the same launch level
+
+         iclosure = .true.
          call buoyan_dilute(lchnk   ,ncol    , &
                   q       ,t       ,p       ,z       ,pf       , &
                   tp      ,qstp    ,tl      ,rl      ,cape     , &
                   pblt    ,lcl     ,lel     ,lon     ,maxi     , &
                   rgas    ,grav    ,cpres   ,msg     , &
-                  tpert   )
+                  tpert   ,iclosure)
+         
+      if (trigdcape_ull) dcapemx(:) = maxi(:)
         
       if(trigmem)then
          call buoyan_dilute(lchnk   ,ncol    , &
@@ -633,13 +668,25 @@ subroutine zm_convr(lchnk   ,ncol    , &
                   tpm1    ,qstpm1  ,tlm1    ,rl      ,capem1   , &
                   pblt    ,lclm1   ,lelm1   ,lonm1   ,maxim1   , &
                   rgas    ,grav    ,cpres   ,msg     , &
-                  tpert   )
+                  tpert   ,iclosure)
 
           do i=1,ncol
              dcape(i) = (cape(i)-capem1(i))/(delt*2._r8)
           end do
-       endif
-!>songxl 2014-05-20------------------
+      endif
+
+      !DCAPE-ULL
+      if (.not. is_first_step() .and. (.not. is_first_restart_step()) .and. trigdcape_ull) then
+         iclosure = .false.
+         call buoyan_dilute(lchnk   ,ncol    , &
+                 q_star  ,t_star     ,p       ,z       ,pf       , &
+                 tpm1    ,qstpm1  ,tlm1    ,rl      ,capem1   , &
+                 pblt    ,lclm1   ,lelm1   ,lonm1   ,maxim1   , &
+                 rgas    ,grav    ,cpres   ,msg     , &
+                 tpert   ,iclosure)
+
+          dcape(:ncol) = (cape(:ncol)-capem1(:ncol))/(delt*2._r8)
+      endif
    end if
 
 !
@@ -647,6 +694,11 @@ subroutine zm_convr(lchnk   ,ncol    , &
 ! (ideep=1) or not (ideep=0), based on values of cape,lcl,lel
 ! (require cape.gt. 0 and lel<lcl as minimum conditions).
 !
+   capelmt_wk = capelmt   ! capelmt_wk default to capelmt for default trigger
+
+   if (trigdcape_ull .and. (.not. is_first_step()) .and. (.not. is_first_restart_step()))  &
+      capelmt_wk = 0.0_r8
+
    lengath = 0
    do i=1,ncol
 !<songxl 2014-05-20----------------
@@ -662,6 +714,19 @@ subroutine zm_convr(lchnk   ,ncol    , &
             index(lengath) = i
          end if
       end if
+     else if (trigdcape_ull) then
+     ! DCAPE-ULL
+      if (is_first_step() .or. is_first_restart_step()) then
+         !Will this cause restart to be non-BFB
+           if (cape(i) > capelmt) then
+              lengath = lengath + 1
+              index(lengath) = i
+           end if
+       else if (cape(i) > 0.0_r8 .and. dcape(i) > trigdcapelmt) then
+           ! use constant 0 or a separate threshold for capt because capelmt is for default trigger
+           lengath = lengath + 1
+           index(lengath) = i
+       endif
      else
       if (cape(i) > capelmt) then
          lengath = lengath + 1
@@ -783,7 +848,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
                 qlg     ,dsubcld ,mb      ,capeg   ,tlg     , &
                 lclg    ,lelg    ,jt      ,maxg    ,1       , &
                 lengath ,rgas    ,grav    ,cpres   ,rl      , &
-                msg     ,capelmt    )
+                msg     ,capelmt_wk )
 !
 ! limit cloud base mass flux to theoretical upper bound.
 !
@@ -3188,7 +3253,7 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
                   tp      ,qstp    ,tl      ,rl      ,cape    , &
                   pblt    ,lcl     ,lel     ,lon     ,mx      , &
                   rd      ,grav    ,cp      ,msg     , &
-                  tpert   )
+                  tpert   ,iclosure)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -3229,6 +3294,7 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
    real(r8), intent(in) :: pf(pcols,pver+1)     ! pressure at interfaces
    real(r8), intent(in) :: pblt(pcols)          ! index of pbl depth
    real(r8), intent(in) :: tpert(pcols)         ! perturbation temperature by pbl processes
+   logical, intent(in) :: iclosure              ! true for normal procedure, otherwise use dcapemx from 1st call
 !
 ! output arguments
 !
@@ -3260,6 +3326,9 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
    logical plge600(pcols)
    integer knt(pcols)
    integer lelten(pcols,num_cin)
+
+! DCAPE-ULL
+   real(r8) pblt600(pcols)
 
    real(r8) cp
    real(r8) e
@@ -3298,6 +3367,15 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
    tp(:ncol,:) = t(:ncol,:)
    qstp(:ncol,:) = q(:ncol,:)
 
+!DCAPE-ULL
+   if (trigdcape_ull) then
+      do k = pver - 1,msg + 1,-1
+      do i = 1,ncol
+         if ((p(i,k).le.600._r8) .and. (p(i,k+1).gt.600._r8)) pblt600(i) = dble(k)
+      end do
+      end do
+   endif
+
 !!! RBN - Initialize tv and buoy for output.
 !!! tv=tv : tpv=tpv : qstp=q : buoy=0.
    tv(:ncol,:) = t(:ncol,:) *(1._r8+1.608_r8*q(:ncol,:))/ (1._r8+q(:ncol,:))
@@ -3309,6 +3387,11 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 ! search for this level stops at planetary boundary layer top.
 !
    bot_layer = pver - mx_bot_lyr_adj
+
+! DCAPE-ULL
+  if (trigdcape_ull .and. (.not. iclosure)) then
+     mx(:ncol) = dcapemx(:ncol)
+  else
 #ifdef PERGRO
    do k = bot_layer,msg + 1,-1
       do i = 1,ncol
@@ -3317,9 +3400,18 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 ! Reset max moist static energy level when relative difference exceeds 1.e-4
 !
          rhd = (hmn(i) - hmax(i))/(hmn(i) + hmax(i))
-         if (k >= nint(pblt(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
-            hmax(i) = hmn(i)
-            mx(i) = k
+
+         !DCAPE-ULL
+         if (trigdcape_ull) then
+           if (k >= nint(pblt00(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
+              hmax(i) = hmn(i)
+              mx(i) = k
+           end if
+         else
+           if (k >= nint(pblt(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
+              hmax(i) = hmn(i)
+              mx(i) = k
+           end if
          end if
       end do
    end do
@@ -3327,13 +3419,24 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
    do k = bot_layer,msg + 1,-1
       do i = 1,ncol
          hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
-         if (k >= nint(pblt(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
-            hmax(i) = hmn(i)
-            mx(i) = k
+
+         !DCAPE-ULL
+         if (trigdcape_ull) then
+            if (k >= nint(pblt600(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
+               hmax(i) = hmn(i)
+               mx(i) = k
+            end if
+         else
+           if (k >= nint(pblt(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
+              hmax(i) = hmn(i)
+              mx(i) = k
+           end if
          end if
       end do
    end do
 #endif
+
+  end if
 
 ! LCL dilute calculation - initialize to mx(i)
 ! Determine lcl in parcel_dilute and get pl,tl after parcel_dilute

--- a/components/cam/src/physics/cam/zm_conv.F90
+++ b/components/cam/src/physics/cam/zm_conv.F90
@@ -373,8 +373,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
 !>songxl 2014-05-20------------------
 
 !DCAPE-ULL
-!  real(r8), intent(in) :: t_star(pcols,pver)     ! grid slice of temperature at mid-layer.
-!  real(r8), intent(in) :: q_star(pcols,pver)     ! grid slice of specific humidity
    real(r8), intent(in), pointer, dimension(:,:) :: t_star ! intermediate T between n and n-1 time step
    real(r8), intent(in), pointer, dimension(:,:) :: q_star ! intermediate q between n and n-1 time step
 
@@ -676,7 +674,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
       endif
 
       !DCAPE-ULL
-      if (.not. is_first_step() .and. (.not. is_first_restart_step()) .and. trigdcape_ull) then
+      if (.not. is_first_step() .and. trigdcape_ull) then
          iclosure = .false.
          call buoyan_dilute(lchnk   ,ncol    , &
                  q_star  ,t_star     ,p       ,z       ,pf       , &
@@ -696,7 +694,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
 !
    capelmt_wk = capelmt   ! capelmt_wk default to capelmt for default trigger
 
-   if (trigdcape_ull .and. (.not. is_first_step()) .and. (.not. is_first_restart_step()))  &
+   if (trigdcape_ull .and. (.not. is_first_step()) )  &
       capelmt_wk = 0.0_r8
 
    lengath = 0
@@ -716,7 +714,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
       end if
      else if (trigdcape_ull) then
      ! DCAPE-ULL
-      if (is_first_step() .or. is_first_restart_step()) then
+      if (is_first_step()) then
          !Will this cause restart to be non-BFB
            if (cape(i) > capelmt) then
               lengath = lengath + 1

--- a/components/cam/src/physics/cam/zm_conv_intr.F90
+++ b/components/cam/src/physics/cam/zm_conv_intr.F90
@@ -15,7 +15,7 @@ module zm_conv_intr
    use physconst,    only: cpair                              
    use physconst,    only: latvap, gravit   !songxl 2014-05-20
    use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
-   use zm_conv,      only: zm_conv_evap, zm_convr, convtran, momtran, trigmem
+   use zm_conv,      only: zm_conv_evap, zm_convr, convtran, momtran, trigmem, trigdcape_ull
    use cam_history,  only: outfld, addfld, horiz_only, add_default
    use perf_mod
    use cam_logfile,  only: iulog
@@ -47,6 +47,10 @@ module zm_conv_intr
    integer :: tm1_idx,     &!tm1 index in physics buffer
               qm1_idx       !qm1 index in physics buffer
 !>songxl 2014-05-20------------------
+
+! DCAPE-ULL
+   integer :: t_star_idx       !t_star index in physics buffer
+   integer :: q_star_idx       !q_star index in physics buffer
 
 !  indices for fields in the physics buffer
    integer  ::    cld_idx          = 0    
@@ -98,6 +102,15 @@ subroutine zm_conv_register
     call pbuf_add_field('QM1', 'global', dtype_r8,(/pcols,pver/), qm1_idx) 
 !  endif
 !>songxl 2014-05-20-------------
+
+! DCAPE-UPL
+
+   if (trigdcape_ull) then
+    ! temperature from physics in n-1 time step
+    call pbuf_add_field('T_STAR','global',dtype_r8,(/pcols,pver/), t_star_idx)
+    ! moisturetendency from physics in n-1 time step 
+    call pbuf_add_field('Q_STAR','global',dtype_r8,(/pcols,pver/), q_star_idx)
+   endif
 
 end subroutine zm_conv_register
 
@@ -159,6 +172,8 @@ subroutine zm_conv_init(pref_edge)
 
     call addfld ('PCONVB',horiz_only , 'A','Pa'    ,'convection base pressure')
     call addfld ('PCONVT',horiz_only , 'A','Pa'    ,'convection top  pressure')
+
+    call addfld ('MAXI',horiz_only , 'A','level'    ,'model level of launching parcel')
 
     call addfld ('CAPE',       horiz_only, 'A',   'J/kg', 'Convectively available potential energy')
     call addfld ('FREQZM',horiz_only  ,'A','fraction', 'Fractional occurance of ZM convection') 
@@ -342,6 +357,13 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    real(r8), pointer, dimension(:,:) :: qm1   ! intermediate q between n and n-1 time step
 !>songxl 2014-05-20---------
 
+   ! DCAPE-ULL
+   real(r8), pointer, dimension(:,:) :: t_star ! intermediate T between n and n-1 time step
+   real(r8), pointer, dimension(:,:) :: q_star ! intermediate q between n and n-1 time step
+   real(r8) :: dcape(pcols)                    ! dynamical cape
+   real(r8) :: maxgsav(pcols)                  ! tmp array for recording and outfld to MAXI
+
+
    real(r8) :: jctop(pcols)  ! o row of top-of-deep-convection indices passed out.
    real(r8) :: jcbot(pcols)  ! o row of base of cloud indices passed out.
 
@@ -414,6 +436,16 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    end if
 !<songxl 2014-05-20-----------------
 
+! DCAPE-ULL
+   if(trigdcape_ull)then
+     call pbuf_get_field(pbuf, t_star_idx,     t_star)
+     call pbuf_get_field(pbuf, q_star_idx,     q_star)
+     if ( is_first_step() .or. is_first_restart_step() ) then
+       q_star(:ncol,:pver) = state%q(:ncol,:pver,1)
+       t_star(:ncol,:pver) = state%t(:ncol,:pver)
+     end if
+   end if
+
 !
 ! Begin with Zhang-McFarlane (1996) convection parameterization
 !
@@ -426,7 +458,8 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
                     tpert   ,dlf     ,pflx    ,zdu     ,rprd    , &
                     mu,md,du,eu,ed      , &
                     dp ,dsubcld ,jt,maxg,ideep   , &
-                    lengath ,ql      ,rliq  ,landfrac, hu_nm1, cnv_nm1, tm1, qm1 )  !songxl 2014-05-20   
+                    lengath ,ql      ,rliq  ,landfrac, hu_nm1, cnv_nm1, tm1, qm1, &
+                    t_star, q_star, dcape)  
    call t_stopf ('zm_convr')
 
    call outfld('CAPE', cape, pcols, lchnk)        ! RBN - CAPE output
@@ -466,19 +499,20 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call outfld('ZMDT    ',ftem           ,pcols   ,lchnk   )
    call outfld('ZMDQ    ',ptend_loc%q(1,1,1) ,pcols   ,lchnk   )
 
-!    do i = 1,pcols
-!    do i = 1,nco
+   maxgsav(:) = 0._r8 ! zero if no convection. true mean to be MAXI/FREQZM
    pcont(:ncol) = state%ps(:ncol)
    pconb(:ncol) = state%ps(:ncol)
    do i = 1,lengath
        if (maxg(i).gt.jt(i)) then
           pcont(ideep(i)) = state%pmid(ideep(i),jt(i))  ! gathered array (or jctop ungathered)
           pconb(ideep(i)) = state%pmid(ideep(i),maxg(i))! gathered array
+          maxgsav(ideep(i)) = dble(maxg(i))             ! gathered array for launching level
        endif
        !     write(iulog,*) ' pcont, pconb ', pcont(i), pconb(i), cnt(i), cnb(i)
-    end do
-    call outfld('PCONVT  ',pcont          ,pcols   ,lchnk   )
-    call outfld('PCONVB  ',pconb          ,pcols   ,lchnk   )
+   end do
+   call outfld('PCONVT  ',pcont          ,pcols   ,lchnk   )
+   call outfld('PCONVB  ',pconb          ,pcols   ,lchnk   )
+   call outfld('MAXI  ',maxgsav          ,pcols   ,lchnk   )
 
   call physics_ptend_init(ptend_all, state%psetcols, 'zm_conv_tend')
 

--- a/components/cam/src/physics/cam/zm_conv_intr.F90
+++ b/components/cam/src/physics/cam/zm_conv_intr.F90
@@ -440,7 +440,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    if(trigdcape_ull)then
      call pbuf_get_field(pbuf, t_star_idx,     t_star)
      call pbuf_get_field(pbuf, q_star_idx,     q_star)
-     if ( is_first_step() .or. is_first_restart_step() ) then
+     if ( is_first_step()) then
        q_star(:ncol,:pver) = state%q(:ncol,:pver,1)
        t_star(:ncol,:pver) = state%t(:ncol,:pver)
      end if


### PR DESCRIPTION
A new trigger for ZM convective scheme is implemented, along with the use of unrestricted laucnhing level (ULL). The DCAPE trigger and ULL can be enable via EAM namelist variable zmconv_trigdcape_ull.

The following files are modified:

   components/cam/bld/namelist_files/namelist_defaults_cam.xml
   components/cam/bld/namelist_files/namelist_definition.xml
   components/cam/src/physics/cam/physpkg.F90
   components/cam/src/physics/cam/zm_conv.F90
   components/cam/src/physics/cam/zm_conv_intr.F90

[BFB]