### PR TITLE
EAM: enable output of vorticity and divergence 

### DIFF
--- a/components/cam/src/dynamics/se/dp_coupling.F90
+++ b/components/cam/src/dynamics/se/dp_coupling.F90
@@ -35,7 +35,6 @@ CONTAINS
     use physics_buffer,          only: physics_buffer_desc, pbuf_get_chunk, pbuf_get_field
     use shr_vmath_mod,           only: shr_vmath_exp
     use time_manager,            only: is_first_step
-    use viscosity_mod,           only: compute_zeta_C0
     use cam_abortutils,          only: endrun
     use gravity_waves_sources,   only: gws_src_fnct
     use dyn_comp,                only: frontgf_idx, frontga_idx, hvcoord

--- a/components/cam/src/dynamics/se/fv_physics_coupling_mod.F90
+++ b/components/cam/src/dynamics/se/fv_physics_coupling_mod.F90
@@ -140,7 +140,7 @@ contains
     ! Purpose: topo is initially defined on phys grid, 
     !          so this routine copys it to the dynamics grid
     use parallel_mod,   only: par
-    use edge_mod,       only: edgeVpack_nlyr, edgeVunpack_nlry,edge_g
+    use edge_mod,       only: edgeVpack_nlyr, edgeVunpack_nlyr,edge_g
     use bndry_mod,      only: bndry_exchangeV
     implicit none
     !---------------------------------------------------------------------------

--- a/components/cam/src/dynamics/se/fv_physics_coupling_mod.F90
+++ b/components/cam/src/dynamics/se/fv_physics_coupling_mod.F90
@@ -140,8 +140,7 @@ contains
     ! Purpose: topo is initially defined on phys grid, 
     !          so this routine copys it to the dynamics grid
     use parallel_mod,   only: par
-    use edgetype_mod,   only: EdgeBuffer_t
-    use edge_mod,       only: initEdgeBuffer, FreeEdgeBuffer, edgeVpack, edgeVunpack
+    use edge_mod,       only: edgeVpack_nlyr, edgeVunpack_nlry,edge_g
     use bndry_mod,      only: bndry_exchangeV
     implicit none
     !---------------------------------------------------------------------------
@@ -151,7 +150,6 @@ contains
     ! local variables
     integer(kind=int_kind)   :: ie, i, j, icol            ! loop iterators
     integer(kind=int_kind)   :: ii, jj, gi, gj            ! GLL loop iterator and indices for pg2
-    type(EdgeBuffer_t)       :: edgebuf
     !---------------------------------------------------------------------------
     ! Copy topography on the physics grid over to the dynamics grid (GLL)
     !---------------------------------------------------------------------------
@@ -189,14 +187,13 @@ contains
     ! Boundary exchange to make field continuous
     !---------------------------------------------------------------------------
     if (par%dynproc) then
-      call initEdgeBuffer(par, edgebuf, elem, (3+pcnst)*nlev)
       do ie = 1,nelemd
         elem(ie)%state%phis(:,:) = elem(ie)%state%phis(:,:) * elem(ie)%spheremp(:,:)
-        call edgeVpack(edgebuf,elem(ie)%state%phis(:,:),0,0,ie)
+        call edgeVpack_nlyr(edge_g,elem(ie)%desc,elem(ie)%state%phis(:,:),0,0,1)
       end do ! ie
-      call bndry_exchangeV(par, edgebuf)
+      call bndry_exchangeV(par, edge_g)
       do ie = 1,nelemd
-        call edgeVunpack(edgebuf,elem(ie)%state%phis(:,:),0,0,ie)
+        call edgeVunpack_nlyr(edge_g,elem(ie)%desc,elem(ie)%state%phis(:,:),0,0,1)
         elem(ie)%state%phis(:,:) = elem(ie)%state%phis(:,:) * elem(ie)%rspheremp(:,:)
       end do ! ie
     end if ! par%dynproc

--- a/components/cam/src/dynamics/se/gravity_waves_sources.F90
+++ b/components/cam/src/dynamics/se/gravity_waves_sources.F90
@@ -106,7 +106,6 @@ CONTAINS
   !   with dynamics when dyn_npes<npes
   ! 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-<<<<<<< dabe086f6094a68fcc704387aa64b03658adb75e
     use physical_constants, only: kappa
     use derivative_mod,     only: gradient_sphere, ugradv_sphere
     use edge_mod,           only : edge_g, edgevpack_nlyr, edgevunpack_nlyr
@@ -145,7 +144,6 @@ CONTAINS
         ! pressure at mid points
         p(:,:) = hvcoord%hyam(k)*hvcoord%ps0 + hvcoord%hybm(k)*elem(ie)%state%ps_v(:,:,tl)
         ! potential temperature: theta = T (p/p0)^kappa
-<<<<<<< dabe086f6094a68fcc704387aa64b03658adb75e
         call get_temperature(elem(ie),temperature,hvcoord,tl)
         theta(:,:) = temperature(:,:,k)*(psurf_ref / p(:,:))**kappa
         gradth_gll(:,:,:,k,ie) = gradient_sphere(theta,ederiv,elem(ie)%Dinv)

--- a/components/cam/src/dynamics/se/gravity_waves_sources.F90
+++ b/components/cam/src/dynamics/se/gravity_waves_sources.F90
@@ -146,9 +146,9 @@ CONTAINS
         ! potential temperature: theta = T (p/p0)^kappa
         call get_temperature(elem(ie),temperature,hvcoord,tl)
         theta(:,:) = temperature(:,:,k)*(psurf_ref / p(:,:))**kappa
-        gradth_gll(:,:,:,k,ie) = gradient_sphere(theta,ederiv,elem(ie)%Dinv)
+        gradth_gll(:,:,:,k,ie) = gradient_sphere(theta,deriv1,elem(ie)%Dinv)
         ! compute C = (grad(theta) dot grad ) u
-        C(:,:,:) = ugradv_sphere(gradth_gll(:,:,:,k,ie), elem(ie)%state%v(:,:,:,k,tl),ederiv,elem(ie))
+        C(:,:,:) = ugradv_sphere(gradth_gll(:,:,:,k,ie), elem(ie)%state%v(:,:,:,k,tl),deriv1,elem(ie))
         ! gradth_gll dot C
         frontgf_gll(:,:,k,ie) = -( C(:,:,1)*gradth_gll(:,:,1,k,ie) + C(:,:,2)*gradth_gll(:,:,2,k,ie)  )
         ! apply mass matrix
@@ -163,7 +163,7 @@ CONTAINS
     end do ! ie
 
     ! Boundary exchange
-    if (par%dynproc) call bndry_exchangeV(hybrid,edge3)
+    if (par%dynproc) call bndry_exchangeV(hybrid,edge_g)
 
     do ie = nets,nete
       ! Prepare weights for area averaging

--- a/components/cam/src/dynamics/se/inidat.F90
+++ b/components/cam/src/dynamics/se/inidat.F90
@@ -28,14 +28,14 @@ module inidat
 contains
 
   subroutine read_inidat( ncid_ini, ncid_topo, dyn_in)
+<<<<<<< dabe086f6094a68fcc704387aa64b03658adb75e
     use dyn_comp,                only: dyn_import_t, hvcoord
     use parallel_mod,            only: par
     use bndry_mod,               only: bndry_exchangev
     use constituents,            only: cnst_name, cnst_read_iv, qmin
     use dimensions_mod,          only: nelemd, nlev, np, npsq
     use dof_mod,                 only: putUniquePoints
-    use edge_mod,                only: edgevpack, edgevunpack, InitEdgeBuffer, FreeEdgeBuffer
-    use edgetype_mod,            only: EdgeBuffer_t
+    use edge_mod,                only : edgevpack_nlyr, edgevunpack_nlyr, edge_g
     use ncdio_atm,               only: infld
     use shr_vmath_mod,           only: shr_vmath_log
     use hycoef,                  only: ps0, hyam, hybm
@@ -77,7 +77,6 @@ contains
     character(len=max_fieldname_len) :: fieldname
     logical :: found
     integer :: kptr, m_cnst
-    type(EdgeBuffer_t) :: edge
     integer :: lsize
 
     integer,parameter :: pcnst = PCNST
@@ -97,6 +96,7 @@ contains
     real(r8), parameter :: D2_0 = 2.0_r8
     real(r8) :: scmposlon, minpoint, testlat, testlon, testval 
     character*16 :: subname='READ_INIDAT'
+    integer :: nlev_tot
 
     logical :: iop_update_surface
 
@@ -493,67 +493,63 @@ contains
 
       ! once we've read all the fields we do a boundary exchange to 
       ! update the redundent columns in the dynamics
-      if(par%dynproc) then
-!for nonhydro change size of buf
-!other issues: not inited w_i, phi?
-        call initEdgeBuffer(par, edge, elem, (3+pcnst)*nlev+2)
-      end if
+      nlev_tot=(3+pcnst)*nlev+2
 
 #ifdef MODEL_THETA_L
       do ie=1,nelemd
         kptr=0
-        call edgeVpack(edge, elem(ie)%state%ps_v(:,:,tl),1,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%ps_v(:,:,tl),1,kptr,nlev_tot)
         kptr=kptr+1
-        call edgeVpack(edge, elem(ie)%state%phis,1,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%phis,1,kptr,nlev_tot)
         kptr=kptr+1
-        call edgeVpack(edge, elem(ie)%state%v(:,:,:,:,tl),2*nlev,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%v(:,:,:,:,tl),2*nlev,kptr,nlev_tot)
         kptr=kptr+2*nlev
-        call edgeVpack(edge, elem(ie)%derived%FT(:,:,:),nlev,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%derived%FT(:,:,:),nlev,kptr,nlev_tot)
         kptr=kptr+nlev
-        call edgeVpack(edge, elem(ie)%state%Q(:,:,:,:),nlev*pcnst,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%Q(:,:,:,:),nlev*pcnst,kptr,nlev_tot)
       end do
 #else
       do ie=1,nelemd
         kptr=0
-        call edgeVpack(edge, elem(ie)%state%ps_v(:,:,tl),1,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%ps_v(:,:,tl),1,kptr,nlev_tot)
         kptr=kptr+1
-        call edgeVpack(edge, elem(ie)%state%phis,1,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%phis,1,kptr,nlev_tot)
         kptr=kptr+1
-        call edgeVpack(edge, elem(ie)%state%v(:,:,:,:,tl),2*nlev,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%v(:,:,:,:,tl),2*nlev,kptr,nlev_tot)
         kptr=kptr+2*nlev
-        call edgeVpack(edge, elem(ie)%state%T(:,:,:,tl),nlev,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%T(:,:,:,tl),nlev,kptr,nlev_tot)
         kptr=kptr+nlev
-        call edgeVpack(edge, elem(ie)%state%Q(:,:,:,:),nlev*pcnst,kptr,ie)
+        call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%Q(:,:,:,:),nlev*pcnst,kptr,nlev_tot)
       end do
 #endif
       if(par%dynproc) then
-        call bndry_exchangeV(par,edge)
+        call bndry_exchangeV(par,edge_g)
       end if
 #ifdef MODEL_THETA_L
       do ie=1,nelemd
         kptr=0
-        call edgeVunpack(edge, elem(ie)%state%ps_v(:,:,tl),1,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%ps_v(:,:,tl),1,kptr,nlev_tot)
         kptr=kptr+1
-        call edgeVunpack(edge, elem(ie)%state%phis,1,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%phis,1,kptr,nlev_tot)
         kptr=kptr+1
-        call edgeVunpack(edge, elem(ie)%state%v(:,:,:,:,tl),2*nlev,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%v(:,:,:,:,tl),2*nlev,kptr,nlev_tot)
         kptr=kptr+2*nlev
-        call edgeVunpack(edge, elem(ie)%derived%FT(:,:,:),nlev,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%derived%FT(:,:,:),nlev,kptr,nlev_tot)
         kptr=kptr+nlev
-        call edgeVunpack(edge, elem(ie)%state%Q(:,:,:,:),nlev*pcnst,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%Q(:,:,:,:),nlev*pcnst,kptr,nlev_tot)
       end do
 #else
       do ie=1,nelemd
         kptr=0
-        call edgeVunpack(edge, elem(ie)%state%ps_v(:,:,tl),1,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%ps_v(:,:,tl),1,kptr,nlev_tot)
         kptr=kptr+1
-        call edgeVunpack(edge, elem(ie)%state%phis,1,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%phis,1,kptr,nlev_tot)
         kptr=kptr+1
-        call edgeVunpack(edge, elem(ie)%state%v(:,:,:,:,tl),2*nlev,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%v(:,:,:,:,tl),2*nlev,kptr,nlev_tot)
         kptr=kptr+2*nlev
-        call edgeVunpack(edge, elem(ie)%state%T(:,:,:,tl),nlev,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%T(:,:,:,tl),nlev,kptr,nlev_tot)
         kptr=kptr+nlev
-        call edgeVunpack(edge, elem(ie)%state%Q(:,:,:,:),nlev*pcnst,kptr,ie)
+        call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%Q(:,:,:,:),nlev*pcnst,kptr,nlev_tot)
       end do
 #endif    
     endif
@@ -564,18 +560,12 @@ contains
        elem(ie)%state%w_i = 0.0
        !sets Theta and phi, not w
        call set_thermostate(elem(ie),elem(ie)%derived%FT,hvcoord)
-       !reset FT?
+       !FT used as tmp array - reset
        elem(ie)%derived%FT = 0.0
 #else
        call set_thermostate(elem(ie),elem(ie)%state%T(:,:,:,tl),hvcoord)
 #endif
     end do
-
-    if (.not. single_column) then
-      if(par%dynproc) then
-        call FreeEdgeBuffer(edge)
-      end if
-    endif
 
     deallocate(tmp)
 

--- a/components/cam/src/dynamics/se/inidat.F90
+++ b/components/cam/src/dynamics/se/inidat.F90
@@ -28,7 +28,6 @@ module inidat
 contains
 
   subroutine read_inidat( ncid_ini, ncid_topo, dyn_in)
-<<<<<<< dabe086f6094a68fcc704387aa64b03658adb75e
     use dyn_comp,                only: dyn_import_t, hvcoord
     use parallel_mod,            only: par
     use bndry_mod,               only: bndry_exchangev

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -50,6 +50,7 @@ module stepon
 ! !REVISION HISTORY:
 !
 ! 2006.05.31  JPE    Created
+! 2019.06.28  MT     Updated to output vorticity/divergence, new DSS interface
 !
 !EOP
 !----------------------------------------------------------------------
@@ -432,7 +433,9 @@ subroutine stepon_run2(phys_state, phys_tend, dyn_in, dyn_out )
    ! at timelevel "tl_f".  
    ! we will output dycore variables here to ensure they are always at the same
    ! time as what the physics is writing.  
-   if (.not. single_column) then ! MT: ask pete why we need this???
+   ! in single_column mode, dycore is not fully initialized so dont use
+   ! outfld() on dycore decompositions
+   if (.not. single_column) then 
    if (hist_fld_active('VOR')) then
       call compute_zeta_C0(tmp_dyn,dyn_in%elem,par,tl_f)
       do ie=1,nelemd

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -270,7 +270,6 @@ subroutine stepon_run2(phys_state, phys_tend, dyn_in, dyn_out )
    call t_startf('stepon_bndry_exch')
    ! do boundary exchange
    if (.not. single_column) then 
-<<<<<<< dabe086f6094a68fcc704387aa64b03658adb75e
       do ie=1,nelemd
 
          if (fv_nphys>0) then
@@ -310,7 +309,6 @@ subroutine stepon_run2(phys_state, phys_tend, dyn_in, dyn_out )
    rec2dt = 1._r8/dtime
 
    do ie=1,nelemd
-<<<<<<< dabe086f6094a68fcc704387aa64b03658adb75e
       if (.not. single_column) then
 
          kptr=0

--- a/components/homme/src/preqx_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/preqx_kokkos/prim_driver_mod.F90
@@ -16,6 +16,7 @@ module prim_driver_mod
   public :: prim_init2
   public :: prim_run_subcycle
   public :: prim_finalize
+  public :: deriv1
 
   private :: generate_global_to_local
   private :: init_cxx_connectivity_internal

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -644,10 +644,10 @@ contains
     type (parallel_t),  intent(in)  :: par
 
     ! single global edge buffer for all models:
-    ! hydrostatic 4*nlev      NH:  6*nlev+1
-    ! SL tracers: (qsize+1)*nlev
+    ! hydrostatic 4*nlev      NH:  6*nlev+1  
+    ! SL tracers: (qsize+1)*nlev   e3sm:  (qsize+3)*nlev+2
     ! if this is too small, code will abort with an error message
-    call initEdgeBuffer(par,edge_g,elem,max((qsize+1)*nlev,6*nlev+1))
+    call initEdgeBuffer(par,edge_g,elem,max((qsize+3)*nlev+2,6*nlev+1))
 
     call prim_advance_init1(par,elem,integration)
 #ifdef TRILINOS

--- a/components/homme/src/share/viscosity_base.F90
+++ b/components/homme/src/share/viscosity_base.F90
@@ -21,7 +21,7 @@ use derivative_mod, only : derivative_t, laplace_sphere_wk, vlaplace_sphere_wk, 
 use edgetype_mod, only : EdgeBuffer_t, EdgeDescriptor_t
 use edge_mod, only : edgevpack, edgevunpack, edgevunpackmin, &
     edgevunpackmax, initEdgeBuffer, FreeEdgeBuffer, edgeSunpackmax, edgeSunpackmin,edgeSpack, &
-    edgevpack_nlyr, edgevunpack_nlyr
+    edgevpack_nlyr, edgevunpack_nlyr, edge_g
 
 use bndry_mod, only : bndry_exchangev, bndry_exchangeS, bndry_exchangeS_start,bndry_exchangeS_finish
 use control_mod, only : hypervis_scaling, nu, nu_div
@@ -193,25 +193,22 @@ integer :: nets,nete,klev
 real (kind=real_kind), dimension(np,np,klev,nets:nete) :: zeta
 
 ! local
-integer :: k,i,j,ie,ic,kptr
+integer :: k,i,j,ie,ic
 
-call initEdgeBuffer(hybrid%par,edge1,elem,klev)
 do ie=nets,nete
    do k=1,klev
       zeta(:,:,k,ie)=zeta(:,:,k,ie)*elem(ie)%spheremp(:,:)
    enddo
-   kptr=0
-   call edgeVpack(edge1, zeta(1,1,1,ie),klev,kptr,ie)
+   call edgeVpack_nlyr(edge_g,elem(ie)%desc,zeta(1,1,1,ie),klev,0,klev)
 enddo
-call bndry_exchangeV(hybrid,edge1)
+call bndry_exchangeV(hybrid,edge_g)
 do ie=nets,nete
-   kptr=0
-   call edgeVunpack(edge1, zeta(1,1,1,ie),klev,kptr, ie)
+   call edgeVunpack_nlyr(edge_g,elem(ie)%desc,zeta(1,1,1,ie),klev,0,klev)
+
    do k=1,klev
       zeta(:,:,k,ie)=zeta(:,:,k,ie)*elem(ie)%rspheremp(:,:)
    enddo
 enddo
-call FreeEdgeBuffer(edge1) 
 end subroutine
 
 

--- a/components/homme/src/sweqx/edge_mod.F90
+++ b/components/homme/src/sweqx/edge_mod.F90
@@ -7,6 +7,6 @@ module edge_mod
                            edgeVpack, edgeVunpack, edgeVpack_nlyr, edgeVunpack_nlyr,      &
                            edgeVunpackMIN, edgeVunpackMAX, edgeDGVpack, edgeDGVunpack, edgeVunpackVert, edgeDefaultVal, initGhostBuffer3D, FreeGhostBuffer3D, &
                            ghostVpackfull, ghostVunpackfull, ghostVpack_unoriented, ghostVunpack_unoriented, ghostVpack3d, ghostVunpack3d,  &
-                           edgeSpack, edgeSunpackMin, edgeSunpackMax
+                           edgeSpack, edgeSunpackMin, edgeSunpackMax, edge_g
   implicit none
 end module edge_mod

--- a/components/homme/src/sweqx/init_mod.F90
+++ b/components/homme/src/sweqx/init_mod.F90
@@ -37,7 +37,7 @@ contains
         set_area_correction_map2
 
     ! --------------------------------
-    use edge_mod, only : initedgebuffer
+    use edge_mod, only : initedgebuffer, edge_g
     use edgetype_mod, only : EdgeDescriptor_t, edgebuffer_t
     ! --------------------------------
     use reduction_mod, only : reductionbuffer_ordered_1d_t, red_min, red_flops, red_timer, &
@@ -338,6 +338,7 @@ contains
     ! =================================================================
     ! Initialize shared boundary_exchange and reduction buffers
     ! =================================================================
+    call initEdgeBuffer(par,edge_g,elem,max(2,nlev))
     call initEdgeBuffer(par,edge1,elem,nlev)
     call initEdgeBuffer(par,edge2,elem,2*nlev)
     call initEdgeBuffer(par,edge3,elem,11*nlev)


### PR DESCRIPTION
enable outfld() calls for vorticity and divergence

add code to dp coupling layer to compute vorticity and divergence from u,v, and then DSS the results using the make_c0() routine.  

update all DSS calls in dp coupling layer and make_c0() routine to use
nlyr pack/unpack interface and have all routines use single edge_g buffer.
This reduces memory footprint and removes many edge buffer allocate/deallocate statements

[BFB]