### PR TITLE
discontinue support for Eulerian dycore for the SCM (atm)

### DIFF
--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -1211,10 +1211,10 @@ if (defined $opts{'scam'}) {
 }
 my $scam = $cfg_ref->get('scam') ? "ON" : "OFF";
 
-# Currently only Eulerian and Spectral Element dycores support SCM
-if ($scam eq 'ON' and $dyn_pkg ne 'eul' and $dyn_pkg ne 'se') {
+# Currently only Spectral Element dycore supports SCM
+if ($scam eq 'ON' and $dyn_pkg ne 'se') {
     die <<"EOF";
-**  ERROR: SCAM mode only works with Eulerian dycore or Spectral Element dycore.
+**  ERROR: The Single Column Model only works with Spectral Element dycore.
 **         Requested dycore is: $dyn_pkg
 EOF
 }

--- a/components/cam/bld/namelist_files/use_cases/scam_arm97.xml
+++ b/components/cam/bld/namelist_files/use_cases/scam_arm97.xml
@@ -3,8 +3,7 @@
 
 <namelist_defaults>
 
-<ncdata dyn="eul"                                 scam="1"  >atm/cam/inic/gaus/cami_0000-09-01_64x128_L72_c031210.nc</ncdata>
-<ncdata dyn="se"                                  scam="1"  >atm/cam/inic/homme/cami_mam3_Linoz_ne4np4_L72_c160909.nc</ncdata>
+<ncdata                                           scam="1"  >atm/cam/inic/homme/cami_mam3_Linoz_ne4np4_L72_c160909.nc</ncdata>
 <iopfile                                          scam="1"  >atm/cam/scam/iop/ARM97_iopfile_4scam.nc</iopfile>
 <soag_ext_file >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_2000_c160427.nc</soag_ext_file>
 <scmlat                                           scam="1"  >   36.6     </scmlat>
@@ -12,8 +11,7 @@
 <start_ymd                                        scam="1"  >   19970619 </start_ymd>
 <start_tod                                        scam="1"  >   84585    </start_tod>
 <mfilt                                            scam="1"  >   1500     </mfilt>
-<cld_macmic_num_steps     dyn="eul"               scam="1"  >   8        </cld_macmic_num_steps>
-<dtime dyn="se"                                   scam="1"  >   1800     </dtime>
+<dtime                                            scam="1"  >   1800     </dtime>
 <scm_iop_srf_prop                                 scam="1"  >   .true.   </scm_iop_srf_prop>
 <nhtfrq                                           scam="1"  >   1        </nhtfrq>
 <single_column                                    scam="1"  >  .true.    </single_column>

--- a/components/cam/bld/namelist_files/use_cases/scam_generic.xml
+++ b/components/cam/bld/namelist_files/use_cases/scam_generic.xml
@@ -3,7 +3,7 @@
 
 <namelist_defaults>
 
-<ncdata             hgrid="64x128"    nlev="72"   scam="1"  >atm/cam/inic/gaus/cami_0000-09-01_64x128_L72_c031210.nc</ncdata>
+<ncdata             >atm/cam/inic/homme/cami_mam3_Linoz_ne4np4_L72_c160909.nc</ncdata>
 <soag_ext_file      >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_2000_c160427.nc</soag_ext_file>
 
 </namelist_defaults>


### PR DESCRIPTION
This PR will disable the Eulerian dycore for running the single column model (SCM).  The SCM will now only work (and be supported) with the Spectral Element (SE) dycore, which has now been well tested/validated, and is consistent with EAM global simulations.  

With this PR an error and abort message will be provided to the user should they try to configure the SCM with any dycore other than SE.  In addition, hooks for the Eulerian core are removed from the scam_arm97.xml use_case, as this is the compset used for SCM developer tests.  

Note that the SCM developer test for Eulerian SCM is removed in a companion cime PR.  

All developer tests pass, except SMS_R_Ld5.T42_T42.FSCM5A97, which is an expected fail.