### PR TITLE
discontinue support for Eulerian dycore for the SCM (cime)

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -40,7 +40,6 @@ _TESTS = {
             "ERP_Ln9.ne4_ne4.FC5AV1C-L",
             "SMS_Ln9.ne4_ne4.FC5AV1C-L.cam-outfrq9s",
             "SMS.ne4_ne4.FC5AV1C-L.cam-cosplite",
-            "SMS_R_Ld5.T42_T42.FSCM5A97",
             "SMS_R_Ld5.ne4_ne4.FSCM5A97",
             "SMS_D_Ln5.ne4_ne4.FC5AV1C-L",
             )


### PR DESCRIPTION
This PR removes the SMS_R_Ld5.T42_T42.FSCM5A97 developer test, which is the Eulerian dycore test for the SCM.  The SCM will now only work (and be supported) with the Spectral Element (SE) dycore, which has now been well tested/validated, and is consistent with EAM global simulations. 

A companion atm PR will produce errors/abort messages if the user tries to configure the SCM with any dycore other than SE.  