### PR TITLE
Add diagnostic output for hub height winds

### DIFF
--- a/components/cam/src/control/interpolate_data.F90
+++ b/components/cam/src/control/interpolate_data.F90
@@ -1030,7 +1030,7 @@ contains
     !
 
     k = nlev-1
-    do while ( (any(found(:) == .false.) == .true.) .and. k>=1 )
+    do while ( (any(found(:) .eqv. .false.) .eqv. .true.) .and. k>=1 )
        do i=1,ncol
           if ((.not. found(i)) .and. zmid(i,k)>zout .and. zout>=zmid(i,k+1)) then
              found(i) = .true.

--- a/components/cam/src/control/interpolate_data.F90
+++ b/components/cam/src/control/interpolate_data.F90
@@ -1029,14 +1029,27 @@ contains
     ! If all indices for this level have been found,
     ! do the interpolation
     !
-    do k=1,nlev-1
+    !do k=1,nlev-1
+    !   do i=1,ncol
+    !      if ((.not. found(i)) .and. zmid(i,k)>zout .and. zout>=zmid(i,k+1)) then
+    !         found(i) = .true.
+    !         kupper(i) = k
+    !      end if
+    !   end do
+    !end do
+
+    k = nlev-1
+    do while ( (any(found(:) == .false.) == .true.) .and. k>=1 )
        do i=1,ncol
           if ((.not. found(i)) .and. zmid(i,k)>zout .and. zout>=zmid(i,k+1)) then
              found(i) = .true.
              kupper(i) = k
           end if
        end do
+       k = k-1
     end do
+    
+    
     !
     ! If we've fallen through the k=1,nlev-1 loop, we cannot interpolate and
     ! must extrapolate from the bottom or top data level for at least some

--- a/components/cam/src/control/interpolate_data.F90
+++ b/components/cam/src/control/interpolate_data.F90
@@ -1026,17 +1026,8 @@ contains
     error = .false.
     !
     ! Store level indices for interpolation.
-    ! If all indices for this level have been found,
-    ! do the interpolation
+    ! Once all indices have been found, do the interpolation
     !
-    !do k=1,nlev-1
-    !   do i=1,ncol
-    !      if ((.not. found(i)) .and. zmid(i,k)>zout .and. zout>=zmid(i,k+1)) then
-    !         found(i) = .true.
-    !         kupper(i) = k
-    !      end if
-    !   end do
-    !end do
 
     k = nlev-1
     do while ( (any(found(:) == .false.) == .true.) .and. k>=1 )
@@ -1051,9 +1042,9 @@ contains
     
     
     !
-    ! If we've fallen through the k=1,nlev-1 loop, we cannot interpolate and
+    ! If we've fallen through the k-loop, we cannot interpolate and
     ! must extrapolate from the bottom or top data level for at least some
-    ! of the longitude points.
+    ! of the columns.
     !
     do i=1,ncol
        if (zout >= zmid(i,1)) then

--- a/components/cam/src/control/interpolate_data.F90
+++ b/components/cam/src/control/interpolate_data.F90
@@ -992,7 +992,8 @@ contains
     !          to vertinterp to get rid of the need for two separate 
     !          subroutines.
     !          Simple tests were done for linear and logarithmic 
-    !          interpolation, and the results suggested linear is better.
+    !          interpolation, and the results suggested linear is better
+    !          for interpolation of low-level winds.
     !-----------------------------------------------------------------------
 
     implicit none

--- a/components/cam/src/control/interpolate_data.F90
+++ b/components/cam/src/control/interpolate_data.F90
@@ -15,7 +15,7 @@ module interpolate_data
 ! Public Methods:
 !
 
-  public :: interp_type, lininterp, vertinterp, bilin, get_timeinterp_factors
+  public :: interp_type, lininterp, vertinterp, vertinterpz, bilin, get_timeinterp_factors
   public :: lininterp_init, lininterp_finish
   type interp_type
      real(r8), pointer :: wgts(:)
@@ -976,6 +976,96 @@ contains
 
     return
   end subroutine vertinterp
+
+  subroutine vertinterpz(ncol, ncold, nlev, zmid, zout, arrin, arrout)
+
+    !-----------------------------------------------------------------------
+    !
+    ! Purpose: Vertically interpolate input array to output height (above 
+    !          surface) level.  Copy values at boundaries.
+    !
+    ! Method:  Copies vertinterp and shifts its logic so height decreases 
+    !          with increasing level index.
+    !
+    ! Author:  Bryce Harrop
+    ! Note:    A more elegant method would be to introduce controlling logic
+    !          to vertinterp to get rid of the need for two separate 
+    !          subroutines.
+    !          Simple tests were done for linear and logarithmic 
+    !          interpolation, and the results suggested linear is better.
+    !-----------------------------------------------------------------------
+
+    implicit none
+
+    !------------------------------Arguments--------------------------------
+    integer , intent(in)  :: ncol              ! column dimension
+    integer , intent(in)  :: ncold             ! declared column dimension
+    integer , intent(in)  :: nlev              ! vertical dimension
+    real(r8), intent(in)  :: zmid(ncold,nlev)  ! input level height levels
+    real(r8), intent(in)  :: zout              ! output height level
+    real(r8), intent(in)  :: arrin(ncold,nlev) ! input  array
+    real(r8), intent(out) :: arrout(ncold)     ! output array (interpolated)
+    !--------------------------------------------------------------------------
+
+    !---------------------------Local variables-----------------------------
+    integer i,k               ! indices
+    integer kupper(ncold)     ! Level indices for interpolation
+    real(r8) dzu              ! upper level height difference
+    real(r8) dzl              ! lower level height difference
+    logical found(ncold)      ! true if input levels found
+    logical error             ! error flag
+    !-----------------------------------------------------------------
+    !
+    ! Initialize index array and logical flags
+    !
+    do i=1,ncol
+       found(i)  = .false.
+       kupper(i) = 1
+    end do
+    error = .false.
+    !
+    ! Store level indices for interpolation.
+    ! If all indices for this level have been found,
+    ! do the interpolation
+    !
+    do k=1,nlev-1
+       do i=1,ncol
+          if ((.not. found(i)) .and. zmid(i,k)>zout .and. zout>=zmid(i,k+1)) then
+             found(i) = .true.
+             kupper(i) = k
+          end if
+       end do
+    end do
+    !
+    ! If we've fallen through the k=1,nlev-1 loop, we cannot interpolate and
+    ! must extrapolate from the bottom or top data level for at least some
+    ! of the longitude points.
+    !
+    do i=1,ncol
+       if (zout >= zmid(i,1)) then
+          arrout(i) = arrin(i,1)
+       else if (zout <= zmid(i,nlev)) then
+          arrout(i) = arrin(i,nlev)
+       else if (found(i)) then
+          dzu = zout - zmid(i,kupper(i))  !B Don't know the pressure thicknesses
+          dzl = zmid(i,kupper(i)+1) - zout
+          !BEH This is a linear interpolation
+          arrout(i) = (arrin(i,kupper(i)  )*dzl + arrin(i,kupper(i)+1)*dzu)/(dzl + dzu)
+          !BEH this is a logarthmic interpolation
+          !arrout(i) = arrin(i,kupper(i))**(dzl/(dzl + dzu)) * arrin(i,kupper(i)+1)**(dzu/(dzl + dzu))
+       else
+          error = .true.
+       end if
+    end do
+    !
+    ! Error check
+    !
+    if (error) then
+       call endrun ('VERTINTERPZ: ERROR FLAG')
+    end if
+
+    return
+  end subroutine vertinterpz
 
   subroutine get_timeinterp_factors (cycflag, np1, cdayminus, cdayplus, cday, &
        fact1, fact2, str)

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -309,6 +309,9 @@ subroutine diag_init()
    call addfld ('TH9251000',horiz_only,   'A','K','Theta difference 925 mb - 1000 mb')   
    call addfld ('THE9251000',horiz_only,   'A','K','ThetaE difference 925 mb - 1000 mb') 
 
+   call addfld ('U90M',horiz_only,    'A','m/s','Zonal wind at turbine hub height (90m above surface)')
+   call addfld ('V90M',horiz_only,    'A','m/s','Meridional wind at turbine hub height (90m above surface)')
+
    ! This field is added by radiation when full physics is used
    if ( ideal_phys )then
       call addfld('QRS', (/ 'lev' /), 'A', 'K/s', 'Solar heating rate')
@@ -834,7 +837,7 @@ end subroutine diag_conv_tend_ini
 !-----------------------------------------------------------------------
     use physconst,          only: gravit, rga, rair, cpair, latvap, rearth, pi, cappa
     use time_manager,       only: get_nstep
-    use interpolate_data,   only: vertinterp
+    use interpolate_data,   only: vertinterp, vertinterpz
     use constituent_burden, only: constituent_burden_comp
     use cam_control_mod,    only: moist_physics
     use co2_cycle,          only: c_i, co2_transport
@@ -1239,6 +1242,14 @@ end subroutine diag_conv_tend_ini
     if (hist_fld_active('V200')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%v, p_surf)
        call outfld('V200    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U90M')) then
+       call vertinterpz(ncol, pcols, pver, state%zm, 90._r8, state%u, p_surf)
+       call outfld('U90M    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V90M')) then
+       call vertinterpz(ncol, pcols, pver, state%zm, 90._r8, state%u, p_surf)
+       call outfld('V90M    ', p_surf, pcols, lchnk )
     end if
 
     ftem(:ncol,:) = state%t(:ncol,:)*state%t(:ncol,:)

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -1248,7 +1248,7 @@ end subroutine diag_conv_tend_ini
        call outfld('U90M    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('V90M')) then
-       call vertinterpz(ncol, pcols, pver, state%zm, 90._r8, state%u, p_surf)
+       call vertinterpz(ncol, pcols, pver, state%zm, 90._r8, state%v, p_surf)
        call outfld('V90M    ', p_surf, pcols, lchnk )
     end if
 


### PR DESCRIPTION
Added an option for outputting U and V at a fixed height above the
surface (90m for wind turbine hub height). New variables are called
"U90M" and "V90M". Since the vertinterp scheme only works with pressure,
a copy was made (vertinterpz) for interpolating with height coordinates.
Offline tests with a snapshot of wind data suggested linear
interpolation was slightly better than logarithmic interpolation for
interpolating low-level winds, so linear interpolation is used in
"vertinterpz".

[BFB]