### PR TITLE
Chemistry preprocessor compiler fixes for Cori

### DIFF
--- a/components/cam/chem_proc/inputs/pp_linoz_mam4_resus_mom_soag.inp
+++ b/components/cam/chem_proc/inputs/pp_linoz_mam4_resus_mom_soag.inp
@@ -1,0 +1,109 @@
+BEGSIM
+output_unit_number = 7
+output_file        = linoz_mam4_resus_mom_soag.doc
+procout_path       = ../output/
+src_path           = ../bkend/
+procfiles_path     = ../procfiles/cam/
+sim_dat_path       = ../output/
+sim_dat_filename   = linoz_mam4_resus_mom_soag.dat
+
+Comments
+     E3SMv1 DECK chemistry.
+End Comments
+
+   SPECIES
+
+      Solution
+ O3
+ H2O2, H2SO4, SO2, DMS -> CH3SCH3, SOAG -> C
+ so4_a1 -> NH4HSO4
+ pom_a1 -> C, soa_a1 -> C, bc_a1 -> C
+ dst_a1 -> AlSiO5, ncl_a1 -> NaCl
+ mom_a1 -> C8520H11360O8520
+ num_a1 -> H
+ so4_a2 -> NH4HSO4
+ soa_a2 -> C, ncl_a2 -> NaCl
+ mom_a2 -> C8520H11360O8520
+ num_a2 -> H
+ dst_a3 -> AlSiO5, ncl_a3 -> NaCl
+ so4_a3 -> NH4HSO4
+ bc_a3 -> C, pom_a3 -> C
+ soa_a3 -> C
+ mom_a3 -> C8520H11360O8520
+ num_a3 -> H
+ pom_a4 -> C, bc_a4 -> C
+ mom_a4 -> C8520H11360O8520
+ num_a4 -> H
+      End Solution
+
+      Fixed
+ M, N2, O2, H2O, OH, NO3, HO2, cnst_O3 -> O3
+      End Fixed
+
+      Col-int
+ O3 = 0.
+ O2 = 0.
+      End Col-int
+
+   End SPECIES
+
+   Solution Classes
+      Explicit
+        O3
+      End Explicit
+      Implicit
+        H2O2, H2SO4, SO2, DMS, SOAG
+        so4_a1, pom_a1
+        soa_a1, bc_a1, dst_a1, ncl_a1
+	mom_a1
+        num_a1
+        so4_a2, soa_a2, ncl_a2, mom_a2, num_a2
+        dst_a3, ncl_a3, so4_a3
+        bc_a3, pom_a3, soa_a3, mom_a3, num_a3
+        pom_a4, bc_a4, mom_a4, num_a4
+      End Implicit
+   End Solution Classes
+
+ CHEMISTRY
+      Photolysis
+ [jh2o2]    H2O2 + hv ->
+      End Photolysis
+
+      Reactions
+ [usr_HO2_HO2] HO2 + HO2 -> H2O2
+               H2O2 + OH -> H2O + HO2                                           ; 2.9e-12, -160
+ [usr_SO2_OH]  SO2 + OH -> H2SO4
+               DMS + OH -> SO2                                                  ; 9.6e-12, -234.
+ [usr_DMS_OH]  DMS + OH -> .5 * SO2 + .5 * HO2
+               DMS + NO3 -> SO2 + HNO3                                          ; 1.9e-13,  520.
+      End Reactions
+
+      Ext Forcing
+          SO2 <- dataset
+          so4_a1 <- dataset
+          so4_a2 <- dataset
+          pom_a4 <- dataset
+          bc_a4 <- dataset
+          num_a1 <- dataset
+          num_a2 <- dataset
+          num_a4 <- dataset
+          SOAG <- dataset
+      End Ext Forcing
+
+   END CHEMISTRY
+
+   SIMULATION PARAMETERS
+
+     Version Options
+        model   = cam
+        machine = intel
+        architecture = hybrid
+        vec_ftns  = on
+        multitask = on
+        namemod = on
+        modules = on
+     End Version Options
+
+   END SIMULATION PARAMETERS
+
+ENDSIM

--- a/components/cam/chem_proc/src/Makefile
+++ b/components/cam/chem_proc/src/Makefile
@@ -140,7 +140,6 @@ ifeq ($(COMPILER),xlf95)
   FFLAGS      := -g -c -qarch=auto -qnosave -qfree=f90 -qmoddir=$(OBJ_DIR) -I $(OBJ_DIR) -qstrict -O3
 endif
 ifeq ($(COMPILER),gfortran)
-# FFLAGS      := -g -c -ffree-form
   FFLAGS      := -g -c -ffree-form -J $(OBJ_DIR)
 endif
 ifeq ($(COMPILER),g95)

--- a/components/cam/chem_proc/src/Makefile
+++ b/components/cam/chem_proc/src/Makefile
@@ -140,10 +140,14 @@ ifeq ($(COMPILER),xlf95)
   FFLAGS      := -g -c -qarch=auto -qnosave -qfree=f90 -qmoddir=$(OBJ_DIR) -I $(OBJ_DIR) -qstrict -O3
 endif
 ifeq ($(COMPILER),gfortran)
-  FFLAGS      := -g -c -ffree-form
+# FFLAGS      := -g -c -ffree-form
+  FFLAGS      := -g -c -ffree-form -J $(OBJ_DIR)
 endif
 ifeq ($(COMPILER),g95)
   FFLAGS      := -g -c -ffree-form
+endif
+ifeq ($(COMPILER),ftn)
+  FFLAGS      := -f free
 endif
 
 #------------------------------------------------------------------------

--- a/components/cam/chem_proc/src/cam_chempp/mozpp.main.f
+++ b/components/cam/chem_proc/src/cam_chempp/mozpp.main.f
@@ -173,7 +173,8 @@
       sim_dat_filename = 'sim.dat'
       sim_dat_filespec = trim(sim_dat_path) // 'sim.dat'
       cpp_dir  = ' '
-      cpp_opts = '-P -C -I.'
+!     cpp_opts = '-P -C -I.'  ! -C causes problems on Cori
+      cpp_opts = '-P -I.'
 
 !-----------------------------------------------------------------------
 !        ... Assign default input, output units

--- a/components/cam/chem_proc/src/cam_chempp/mozpp.main.f
+++ b/components/cam/chem_proc/src/cam_chempp/mozpp.main.f
@@ -174,7 +174,7 @@
       sim_dat_filespec = trim(sim_dat_path) // 'sim.dat'
       cpp_dir  = ' '
 !     cpp_opts = '-P -C -I.'  ! -C causes problems on Cori
-      cpp_opts = '-P -I.'
+      cpp_opts = '-P -I. -traditional-cpp'  ! Works on Cori (2019-07-15)
 
 !-----------------------------------------------------------------------
 !        ... Assign default input, output units

--- a/components/cam/chem_proc/src/make_chempp.cori
+++ b/components/cam/chem_proc/src/make_chempp.cori
@@ -1,0 +1,44 @@
+#!/bin/csh
+
+### This version Cori 2017-07-206. 
+
+set exenam=cam_chempp
+set objdir=OBJ
+
+rm -f ../bin/$exenam
+rm -f $objdir/*
+
+mkdir -p $objdir
+mkdir -p ../bin
+
+# When running the eventual binary it wants to write into a various
+# directories, but it dies if those directories don't exist. The easy
+# solution is to create the default directories here.  This will fail
+# if a non-standard directory is used, but this seems pretty safe.
+mkdir -p ../tmp
+mkdir -p ../output
+
+#gmake COMPILER=lf95 DEBUG=TRUE EXENAME=cam_chempp
+
+###For Cori:
+module unload PrgEnv-pgi
+module unload PrgEnv-cray
+module unload PrgEnv-gnu
+module unload PrgEnv-intel
+
+#module load PrgEnv-pgi
+#gmake COMPILER=pgf95 DEBUG=TRUE EXENAME=cam_chempp
+
+#module load PrgEnv-pgi
+#gmake COMPILER=gfortran DEBUG=TRUE EXENAME=cam_chempp
+
+#module load PrgEnv-intel
+#gmake COMPILER=ifort DEBUG=TRUE EXENAME=cam_chempp
+
+#module load PrgEnv-cray
+#gmake COMPILER=ftn DEBUG=TRUE EXENAME=cam_chempp
+
+module load PrgEnv-gnu
+gmake COMPILER=gfortran DEBUG=TRUE EXENAME=cam_chempp
+
+# --- end of file ---


### PR DESCRIPTION
The chemistry pre-processor would not compile and run correctly on Cori.  It was previously configured to work on Titan.

This PR fixes the compiler and CPP options so that it will work on Cori.

cpp is used by the chemistry pre-processor to manipulate the fortran output. It seems that modern versions of cpp behave differently than older versions, so the chemistry pre-processor has problems and produces different fortran output. There are two main issues:

1) cpp adds its copyright information to the top of the output using
   C-type comments, which confuses the chemistry pre-processor (and
   probably the E3SM Fortran compiler).

2) cpp deletes parts of the fortran output because it misidentifies it
   as a comment.

Issue 1 occurs with the -C option to cpp, and issue 2 occurs without
the -C option to cpp.  This commit solves the problem by replacing the
-C option with -traditional-cpp.

For future convenience, I copied pp_linoz_mam4_resus_mom_soag.inp from the pre-processed directory in E3SM to the chemistry pre-processor input directory (and added the header so that it will work with the standalone pre-processor).  Note: linoz_mam4_resus_mom_soag is the standard chemistry configuration for E3SMv1.

[E3SM is BFB.  Output of chemistry pre-processor on Cori is now the same as it was on Titan.]