### PR TITLE
Implement O3v2 in Linoz

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -5454,6 +5454,24 @@ if <varname>linoz_data_type</varname> is 'FIXED'.
 Default: 0 seconds
 </entry>
 
+<entry id="linoz_lbl" type="integer" category="linoz"
+       group="linoz_nl" valid_values="" >
+Tunable number of layers with ozone decay from the surface in Linoz
+Default: set by build-namelist
+</entry>
+
+<entry id="linoz_sfc" type="real" category="linoz"
+       group="linoz_nl" valid_values="" >
+Tunable boundary layer concentration (ppb) to which Linoz ozone e-fold
+Default: set by build-namelist
+</entry>
+
+<entry id="linoz_tau" type="real" category="linoz"
+       group="linoz_nl" valid_values="" >
+Tunable Linoz e-fold time scale (in seconds) in the boundary layer
+Default: set by build-namelist
+</entry>
+
 <entry id="tracer_cnst_datapath" type="char*256" input_pathname="abs" category="cam_chem"
        group="chem_inparm" valid_values="" >
 Full pathname of the directory that contains the files specified in

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -5457,19 +5457,19 @@ Default: 0 seconds
 <entry id="linoz_lbl" type="integer" category="linoz"
        group="linoz_nl" valid_values="" >
 Tunable number of layers with ozone decay from the surface in Linoz
-Default: set by build-namelist
+Default: 4
 </entry>
 
 <entry id="linoz_sfc" type="real" category="linoz"
        group="linoz_nl" valid_values="" >
 Tunable boundary layer concentration (ppb) to which Linoz ozone e-fold
-Default: set by build-namelist
+Default: 30.0e-9
 </entry>
 
 <entry id="linoz_tau" type="real" category="linoz"
        group="linoz_nl" valid_values="" >
 Tunable Linoz e-fold time scale (in seconds) in the boundary layer
-Default: set by build-namelist
+Default: 172800.0
 </entry>
 
 <entry id="tracer_cnst_datapath" type="char*256" input_pathname="abs" category="cam_chem"

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
@@ -162,6 +162,9 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>1850</sim_year>
 

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6_bgc.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6_bgc.xml
@@ -162,6 +162,9 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>1850</sim_year>
 

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-HR.xml
@@ -160,6 +160,9 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>1955</sim_year>
 

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LR.xml
@@ -152,6 +152,9 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>1955</sim_year>
 

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
@@ -156,6 +156,9 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>1955</sim_year>
 

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2.xml
@@ -114,6 +114,9 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>2000</sim_year>
 

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
@@ -144,6 +144,9 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
 
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>1850-2000</sim_year>
 

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6_bgc.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6_bgc.xml
@@ -145,6 +145,9 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
 
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>1850-2000</sim_year>
 

--- a/components/cam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/cam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -240,7 +240,7 @@ contains
 !
 ! LINOZ
 !
-    use lin_strat_chem,    only : do_lin_strat_chem, lin_strat_chem_solve
+    use lin_strat_chem,    only : do_lin_strat_chem, lin_strat_chem_solve, lin_strat_sfcsink
     use linoz_data,        only : has_linoz_data
 !
 ! for aqueous chemistry and aerosol growth
@@ -376,6 +376,7 @@ contains
     real(r8) :: mmr_tend(pcols,pver,gas_pcnst) ! chemistry species tendencies (kg/kg/s)
     real(r8) :: qh2o(pcols,pver)               ! specific humidity (kg/kg)
     real(r8) :: delta
+    real(r8) :: o3lsfcsink(ncol)               ! linoz o3l surface sink from call lin_strat_sfcsink 
 
   ! for aerosol formation....  
     real(r8) :: del_h2so4_gasprod(ncol,pver)
@@ -485,17 +486,17 @@ contains
     !-----------------------------------------------------------------------      
     !        ... set tropospheric ozone for Linoz_MAM  (pjc, 2015)
     !-----------------------------------------------------------------------
-    if ( chem_name == 'linoz_mam3'.or.chem_name == 'linoz_mam4_resus'.or.chem_name == 'linoz_mam4_resus_mom' &
-       .or.chem_name == 'linoz_mam4_resus_soag'.or.chem_name == 'linoz_mam4_resus_mom_soag' ) then
+!    if ( chem_name == 'linoz_mam3'.or.chem_name == 'linoz_mam4_resus'.or.chem_name == 'linoz_mam4_resus_mom' &
+!       .or.chem_name == 'linoz_mam4_resus_soag'.or.chem_name == 'linoz_mam4_resus_mom_soag' ) then
 !     write(iulog,*) 'Set tropospheric ozone for linoz_mam: inv_ndx_cnst_o3 =',inv_ndx_cnst_o3
-      do k = 1, pver                !Following loop logic from below.  However, reordering loops can get rid of IF statement.
-         do i = 1, ncol
-            if( k > troplev(i) ) then
-              vmr(i,k,o3_ndx) = invariants(i,k,inv_ndx_cnst_o3) / invariants(i,k,inv_ndx_m)   ! O3 and cnst_o3
-            endif
-         end do
-      end do
-    end if
+!      do k = 1, pver                !Following loop logic from below.  However, reordering loops can get rid of IF statement.
+!         do i = 1, ncol
+!            if( k > troplev(i) ) then
+!              vmr(i,k,o3_ndx) = invariants(i,k,inv_ndx_cnst_o3) / invariants(i,k,inv_ndx_m)   ! O3 and cnst_o3
+!            endif
+!         end do
+!      end do
+!    end if
 
 
     if (carma_do_hetchem) then 
@@ -853,6 +854,7 @@ contains
 !
     if ( do_lin_strat_chem ) then
        call lin_strat_chem_solve( ncol, lchnk, vmr(:,:,o3_ndx), col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev )
+       call   lin_strat_sfcsink (ncol, lchnk,  vmr(:,:,o3_ndx), delt, pdel(:ncol,:))
     end if
 
     !-----------------------------------------------------------------------      

--- a/components/cam/src/control/runtime_opts.F90
+++ b/components/cam/src/control/runtime_opts.F90
@@ -238,6 +238,7 @@ contains
    use modal_aer_opt,       only: modal_aer_opt_readnl
    use clubb_intr,          only: clubb_readnl
    use chemistry,           only: chem_readnl
+   use lin_strat_chem,      only: linoz_readnl
    use prescribed_volcaero, only: prescribed_volcaero_readnl
    use aerodep_flx,         only: aerodep_flx_readnl
    use solar_data,          only: solar_data_readnl
@@ -478,6 +479,7 @@ contains
    call rad_data_readnl(nlfilename)
    call modal_aer_opt_readnl(nlfilename)
    call chem_readnl(nlfilename)
+   call linoz_readnl(nlfilename)
    call prescribed_volcaero_readnl(nlfilename)
    call solar_data_readnl(nlfilename)
    call carma_readnl(nlfilename)


### PR DESCRIPTION
Previous PR #3042 has some issues that I couldn't push new commits to the remote branch. The issue was fixed by deleting and recreating the remote branch.

Implement the newly designed Linoz O3v2
* Add ozone sink in the boundary layer with a fix e-folding
decay to a typical ozone concentration in the boundary layer
* Disable the tropospheric ozone rewrite to mozart climatology
* The parameters controlling this new ozone sink are name list variables.
* Turn off ozone dry deposition (Currently turned off in the
test runs via user_nl_cam, need to do it by changing compset settings
in future commit)


[Non-BFB] - Non Bit-For-Bit