### PR TITLE
Update gravity wave drag mods to ingest improved tuning for QBO via nml

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -1168,6 +1168,12 @@ In the low-top model, this helps to conserve momentum and produce a QBO.
 Default: set by build-namelist.
 </entry>
 
+<entry id="gw_convect_hcf" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Heating rate conversion factor associated with convective gravity waves
+Default: 20.0
+</entry>
+
 <entry id="effgw_beres" type="real" category="gw_drag"
        group="gw_drag_nl" valid_values="" >
 Efficiency associated with convective gravity waves from the Beres

--- a/components/cam/src/physics/cam/gw_convect.F90
+++ b/components/cam/src/physics/cam/gw_convect.F90
@@ -60,7 +60,7 @@ end subroutine gw_convect_init
 
 subroutine gw_beres_src(ncol, ngwv, lat, u, v, netdt, &
      zm, src_level, tend_level, tau, ubm, ubi, xv, yv, c, &
-     hdepth, maxq0)
+     hdepth, maxq0, CF)
 !-----------------------------------------------------------------------
 ! Driver for multiple gravity wave drag parameterization.
 !
@@ -88,6 +88,9 @@ subroutine gw_beres_src(ncol, ngwv, lat, u, v, netdt, &
   real(r8), intent(in) :: netdt(:,:)
   ! Midpoint altitudes.
   real(r8), intent(in) :: zm(ncol,pver)
+
+  ! Heating conversion factor
+  real(r8), intent(in) :: CF
 
   ! Indices of top gravity wave source level and lowest level where wind
   ! tendencies are allowed.
@@ -133,8 +136,8 @@ subroutine gw_beres_src(ncol, ngwv, lat, u, v, netdt, &
   ! Index to shift spectra relative to ground.
   integer :: shift
 
-  ! Heating rate conversion factor.
-  real(r8), parameter :: CF = 20._r8
+  ! Heating rate conversion factor. Change to take the value from caller and controllable by namelist (to tune QBO)
+  ! real(r8), parameter :: CF = 20._r8
   ! Averaging length.
   real(r8), parameter :: AL = 1.0e5_r8
 

--- a/components/cam/src/physics/cam/gw_drag.F90
+++ b/components/cam/src/physics/cam/gw_drag.F90
@@ -80,6 +80,9 @@ module gw_drag
   ! Background stress source strength.
   real(r8) :: taubgnd = unset_r8
 
+  ! Convective heating rate conversion factor, default is 20.0_r8
+  real(r8) :: gw_convect_hcf = 20.0_r8
+
   ! Whether or not to enforce an upper boundary condition of tau = 0.
   ! (Like many variables, this is only here to hold the value between
   ! the readnl phase and the init phase of the CAM physics; only gw_common
@@ -129,7 +132,7 @@ subroutine gw_drag_readnl(nlfile)
   real(r8) :: gw_dc = unset_r8
 
   namelist /gw_drag_nl/ pgwv, gw_dc, tau_0_ubc, effgw_beres, effgw_cm, &
-       effgw_oro, fcrit2, frontgfc, gw_drag_file, taubgnd
+      effgw_oro, fcrit2, frontgfc, gw_drag_file, taubgnd, gw_convect_hcf
   !----------------------------------------------------------------------
 
   if (masterproc) then
@@ -158,6 +161,7 @@ subroutine gw_drag_readnl(nlfile)
   call mpibcast(frontgfc,    1, mpir8,  0, mpicom)
   call mpibcast(taubgnd,     1, mpir8,  0, mpicom)
   call mpibcast(gw_drag_file, len(gw_drag_file), mpichar, 0, mpicom)
+  call mpibcast(gw_convect_hcf, 1, mpir8,  0, mpicom)
 #endif
 
   dc = gw_dc
@@ -735,7 +739,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
         ! Determine wave sources for Beres04 scheme
         call gw_beres_src(ncol, pgwv, state1%lat(:ncol), u, v, ttend_dp, &
              zm, src_level, tend_level, tau, ubm, ubi, xv, yv, c, &
-             hdepth, maxq0)
+             hdepth, maxq0, gw_convect_hcf)
 
         ! Solve for the drag profile with Beres source spectrum.
         call gw_drag_prof(ncol, pgwv, src_level, tend_level, .false., dt, &


### PR DESCRIPTION
Convective heating rate conversion factor (CF) and gravity wave tendency efficiency
for Beres scheme (effgw_beres) are retuned to improve QBO for adoption in EAMv2.

In the new tuning with much improved QBO, the conversion factor is
changed to 12.5 from 20.0, and the tendency efficiency is reduced to 0.35 from 0.4.

This implementation adds namelist control for the conversion factor to incorporate the
new tuning for V2 while preserving reproducibility of all existing compsets.
The new values for CF and effgw_beres will be ingested via new compsets and corresponding use case files.

[BFB] 