### PR TITLE
Improve accuracy of the SCM "Replay" mode

### DIFF
--- a/cime/src/drivers/mct/main/cime_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cime_comp_mod.F90
@@ -1887,7 +1887,7 @@ contains
     !----------------------------------------------------------
 
     areafact_samegrid = .false.
-#if (defined BFB_E3SM_SCM_IOP )
+#if (defined E3SM_SCM_REPLAY )
     if (.not.samegrid_alo) then
        call shr_sys_abort(subname//' ERROR: samegrid_alo is false - Must run with same atm/ocn/lnd grids when configured for scam iop')
     else

--- a/cime/src/drivers/mct/main/cime_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cime_comp_mod.F90
@@ -1887,7 +1887,7 @@ contains
     !----------------------------------------------------------
 
     areafact_samegrid = .false.
-#if (defined BFB_CAM_SCAM_IOP )
+#if (defined BFB_E3SM_SCM_IOP )
     if (.not.samegrid_alo) then
        call shr_sys_abort(subname//' ERROR: samegrid_alo is false - Must run with same atm/ocn/lnd grids when configured for scam iop')
     else

--- a/cime/src/drivers/moab/main/cime_comp_mod.F90
+++ b/cime/src/drivers/moab/main/cime_comp_mod.F90
@@ -1697,7 +1697,7 @@ contains
     !----------------------------------------------------------
 
     areafact_samegrid = .false.
-#if (defined BFB_E3SM_SCM_IOP )
+#if (defined E3SM_SCM_REPLAY )
     if (.not.samegrid_alo) then
        call shr_sys_abort(subname//' ERROR: samegrid_alo is false - Must run with same atm/ocn/lnd grids when configured for scam iop')
     else

--- a/cime/src/drivers/moab/main/cime_comp_mod.F90
+++ b/cime/src/drivers/moab/main/cime_comp_mod.F90
@@ -1697,7 +1697,7 @@ contains
     !----------------------------------------------------------
 
     areafact_samegrid = .false.
-#if (defined BFB_CAM_SCAM_IOP )
+#if (defined BFB_E3SM_SCM_IOP )
     if (.not.samegrid_alo) then
        call shr_sys_abort(subname//' ERROR: samegrid_alo is false - Must run with same atm/ocn/lnd grids when configured for scam iop')
     else

--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -3979,7 +3979,7 @@ if ($cfg->get('scam')) {
 }
 
 # CAM generates IOP file for SCAM
-if ($cfg->get('e3smreplay')) {
+if ($cfg->get('e3smreplay') or $cfg->get('e3smreplay_b4b')) {
     add_default($nl, 'inithist', 'val'=>'CAMIOP');
     add_default($nl, 'ndens', 'val'=>'1,1');
     add_default($nl, 'mfilt', 'val'=>'1,10');

--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -3979,7 +3979,7 @@ if ($cfg->get('scam')) {
 }
 
 # CAM generates IOP file for SCAM
-if ($cfg->get('camiop')) {
+if ($cfg->get('e3smreplay')) {
     add_default($nl, 'inithist', 'val'=>'CAMIOP');
     add_default($nl, 'ndens', 'val'=>'1,1');
     add_default($nl, 'mfilt', 'val'=>'1,10');

--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -3979,7 +3979,7 @@ if ($cfg->get('scam')) {
 }
 
 # CAM generates IOP file for SCAM
-if ($cfg->get('e3smreplay') or $cfg->get('e3smreplay_b4b')) {
+if ($cfg->get('e3smreplay')) {
     add_default($nl, 'inithist', 'val'=>'CAMIOP');
     add_default($nl, 'ndens', 'val'=>'1,1');
     add_default($nl, 'mfilt', 'val'=>'1,10');

--- a/components/cam/bld/config_files/definition.xml
+++ b/components/cam/bld/config_files/definition.xml
@@ -142,9 +142,9 @@ Modifications that allow perturbation growth testing: 0=off, 1=on.
 Configure CAM for single column mode: 0=off, 1=on.  This option only
 supported for the Eulerian dycore.
 </entry>
-<entry id="camiop" valid_values="0,1" value="0">
-Configure CAM to generate an IOP file that can be used to drive SCAM: 0=no, 1=yes.
-This option only supported for the Eulerian dycore.
+<entry id="e3smreplay" valid_values="0,1" value="0">
+Configure E3SM to generate an IOP file that can be used to drive the SCM: 0=no, 1=yes.
+This option only supported for the Spectral Element dycore.
 </entry>
 <entry id="hgrid" value="">
 Horizontal grid specifier.  The recognized values depend on

--- a/components/cam/bld/config_files/definition.xml
+++ b/components/cam/bld/config_files/definition.xml
@@ -146,10 +146,6 @@ supported for the Eulerian dycore.
 Configure E3SM to generate an IOP file that can be used to drive the SCM: 0=no, 1=yes.
 This option only supported for the Spectral Element dycore.
 </entry>
-<entry id="e3smreplay_b4b" valid_values="0,1" value="0">
-Configure E3SM to generate an IOP file that can be used to drive the SCM with b4b results: 0=no, 1=yes.
-This option only supported for the Spectral Element dycore.
-</entry>
 <entry id="hgrid" value="">
 Horizontal grid specifier.  The recognized values depend on
 the dynamics type and are contained in the config_horiz_grid.xml file.

--- a/components/cam/bld/config_files/definition.xml
+++ b/components/cam/bld/config_files/definition.xml
@@ -146,6 +146,10 @@ supported for the Eulerian dycore.
 Configure E3SM to generate an IOP file that can be used to drive the SCM: 0=no, 1=yes.
 This option only supported for the Spectral Element dycore.
 </entry>
+<entry id="e3smreplay_b4b" valid_values="0,1" value="0">
+Configure E3SM to generate an IOP file that can be used to drive the SCM with b4b results: 0=no, 1=yes.
+This option only supported for the Spectral Element dycore.
+</entry>
 <entry id="hgrid" value="">
 Horizontal grid specifier.  The recognized values depend on
 the dynamics type and are contained in the config_horiz_grid.xml file.

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -169,6 +169,10 @@ OPTIONS
 
      -e3smreplay        Configure E3SM to generate an IOP file that can be used to drive the SCM.
                         This switch only works with the Spectral Element dycore.
+     -e3smreplay_b4b    Configure E3SM to generate an IOP file that can be used to drive the SCM.
+                        This switch only works with the Spectral Element dycore.	
+			This result will produce output that is capable of providing a bit-4-bit
+			solution in the E3SM single column model.  		
      -scam              Compiles model in single column mode.  Only works with SE dycore.
 
   CAM parallelization:
@@ -310,6 +314,7 @@ GetOptions(
     "cam_exe=s"                 => \$opts{'cam_exe'},
     "cam_exedir=s"              => \$opts{'cam_exedir'},
     "e3smreplay"                => \$opts{'e3smreplay'},
+    "e3smreplay_b4b"            => \$opts{'e3smreplay_b4b'},
     "cc=s"                      => \$opts{'cc'},
     "ccsm_seq"                  => \$opts{'ccsm_seq'},
     "cflags=s"                  => \$opts{'cflags'},
@@ -1226,10 +1231,17 @@ if ($print>=2) { print "CAM single column mode (SCAM): $scam$eol"; }
 if (defined $opts{'e3smreplay'}) {
     $cfg_ref->set('e3smreplay', 1);
 }
+
 my $e3smreplay = $cfg_ref->get('e3smreplay') ? "ON" : "OFF";
 
+if (defined $opts{'e3smreplay_b4b'}) {
+    $cfg_ref->set('e3smreplay_b4b', 1);
+}
+
+my $e3smreplay_b4b = $cfg_ref->get('e3smreplay_b4b') ? "ON" : "OFF";
+
 # The only dycore supported in REPLAY mode is Spectral Element
-if ($e3smreplay eq 'ON' and $dyn_pkg ne 'se') {
+if (($e3smreplay eq 'ON' | $e3smreplay_b4b eq 'ON')  and $dyn_pkg ne 'se') {
     die <<"EOF";
 **  ERROR: REPLAY mode only works with Spectral Element dycore.
 **         Requested dycore is: $dyn_pkg
@@ -1237,6 +1249,8 @@ EOF
 }
 
 if ($print>=2) { print "Produce IOP file for SCAM: $e3smreplay$eol"; }
+
+if ($print>=2) { print "Produce B4B capable IOP file for SCAM: $e3smreplay_b4b$eol"; }
 
 #-----------------------------------------------------------------------------------------------
 # Horizontal grid parameters
@@ -1950,6 +1964,11 @@ if ($pergro eq "ON") { $cfg_cppdefs .= " -DPERGRO"; }
 
 # Configure CAM to produce IOP files for SCAM
 if ($e3smreplay eq 'ON') { $cfg_cppdefs .= " -DE3SM_SCM_REPLAY"; }
+
+if ($e3smreplay_b4b eq 'ON'){
+    $cfg_cppdefs .= " -DE3SM_SCM_REPLAY";
+    $cfg_cppdefs .= " -DE3SM_SCM_REPLAY_B4B";
+}
 
 # Resolution parameters for rectangular lat/lon grids
 my $nlon = $cfg_ref->get('nlon');

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -1949,7 +1949,7 @@ $cfg_cppdefs .= " -DMAXPATCH_PFT=numpft+1 -DLSMLAT=1 -DLSMLON=1";
 if ($pergro eq "ON") { $cfg_cppdefs .= " -DPERGRO"; }
 
 # Configure CAM to produce IOP files for SCAM
-if ($e3smreplay eq 'ON') { $cfg_cppdefs .= " -DBFB_E3SM_SCM_IOP"; }
+if ($e3smreplay eq 'ON') { $cfg_cppdefs .= " -DE3SM_SCM_REPLAY"; }
 
 # Resolution parameters for rectangular lat/lon grids
 my $nlon = $cfg_ref->get('nlon');

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -168,11 +168,7 @@ OPTIONS
   Options relevent to SCAM mode:
 
      -e3smreplay        Configure E3SM to generate an IOP file that can be used to drive the SCM.
-                        This switch only works with the Spectral Element dycore.
-     -e3smreplay_b4b    Configure E3SM to generate an IOP file that can be used to drive the SCM.
-                        This switch only works with the Spectral Element dycore.	
-			This result will produce output that is capable of providing a bit-4-bit
-			solution in the E3SM single column model.  		
+                        This switch only works with the Spectral Element dycore.		
      -scam              Compiles model in single column mode.  Only works with SE dycore.
 
   CAM parallelization:
@@ -314,7 +310,6 @@ GetOptions(
     "cam_exe=s"                 => \$opts{'cam_exe'},
     "cam_exedir=s"              => \$opts{'cam_exedir'},
     "e3smreplay"                => \$opts{'e3smreplay'},
-    "e3smreplay_b4b"            => \$opts{'e3smreplay_b4b'},
     "cc=s"                      => \$opts{'cc'},
     "ccsm_seq"                  => \$opts{'ccsm_seq'},
     "cflags=s"                  => \$opts{'cflags'},
@@ -1234,14 +1229,8 @@ if (defined $opts{'e3smreplay'}) {
 
 my $e3smreplay = $cfg_ref->get('e3smreplay') ? "ON" : "OFF";
 
-if (defined $opts{'e3smreplay_b4b'}) {
-    $cfg_ref->set('e3smreplay_b4b', 1);
-}
-
-my $e3smreplay_b4b = $cfg_ref->get('e3smreplay_b4b') ? "ON" : "OFF";
-
 # The only dycore supported in REPLAY mode is Spectral Element
-if (($e3smreplay eq 'ON' | $e3smreplay_b4b eq 'ON')  and $dyn_pkg ne 'se') {
+if ($e3smreplay eq 'ON'  and $dyn_pkg ne 'se') {
     die <<"EOF";
 **  ERROR: REPLAY mode only works with Spectral Element dycore.
 **         Requested dycore is: $dyn_pkg
@@ -1249,8 +1238,6 @@ EOF
 }
 
 if ($print>=2) { print "Produce IOP file for SCAM: $e3smreplay$eol"; }
-
-if ($print>=2) { print "Produce B4B capable IOP file for SCAM: $e3smreplay_b4b$eol"; }
 
 #-----------------------------------------------------------------------------------------------
 # Horizontal grid parameters
@@ -1964,11 +1951,6 @@ if ($pergro eq "ON") { $cfg_cppdefs .= " -DPERGRO"; }
 
 # Configure CAM to produce IOP files for SCAM
 if ($e3smreplay eq 'ON') { $cfg_cppdefs .= " -DE3SM_SCM_REPLAY"; }
-
-if ($e3smreplay_b4b eq 'ON'){
-    $cfg_cppdefs .= " -DE3SM_SCM_REPLAY";
-    $cfg_cppdefs .= " -DE3SM_SCM_REPLAY_B4B";
-}
 
 # Resolution parameters for rectangular lat/lon grids
 my $nlon = $cfg_ref->get('nlon');

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -167,9 +167,9 @@ OPTIONS
 
   Options relevent to SCAM mode:
 
-     -camiop            Configure CAM to generate an IOP file that can be used to drive SCAM.
-                        This switch only works with the Eulerian dycore.
-     -scam              Compiles model in single column mode.  Only works with Eulerian dycore.
+     -e3smreplay        Configure E3SM to generate an IOP file that can be used to drive the SCM.
+                        This switch only works with the Spectral Element dycore.
+     -scam              Compiles model in single column mode.  Only works with SE dycore.
 
   CAM parallelization:
 
@@ -309,7 +309,7 @@ GetOptions(
     "cam_bld=s"                 => \$opts{'cam_bld'},
     "cam_exe=s"                 => \$opts{'cam_exe'},
     "cam_exedir=s"              => \$opts{'cam_exedir'},
-    "camiop"                    => \$opts{'camiop'},
+    "e3smreplay"                => \$opts{'e3smreplay'},
     "cc=s"                      => \$opts{'cc'},
     "ccsm_seq"                  => \$opts{'ccsm_seq'},
     "cflags=s"                  => \$opts{'cflags'},
@@ -1223,20 +1223,20 @@ if ($print>=2) { print "CAM single column mode (SCAM): $scam$eol"; }
 
 #-----------------------------------------------------------------------------------------------
 # Generate IOP
-if (defined $opts{'camiop'}) {
-    $cfg_ref->set('camiop', 1);
+if (defined $opts{'e3smreplay'}) {
+    $cfg_ref->set('e3smreplay', 1);
 }
-my $camiop = $cfg_ref->get('camiop') ? "ON" : "OFF";
+my $e3smreplay = $cfg_ref->get('e3smreplay') ? "ON" : "OFF";
 
-# The only dycore supported in CAMIOP mode is Spectral Element
-if ($camiop eq 'ON' and $dyn_pkg ne 'se') {
+# The only dycore supported in REPLAY mode is Spectral Element
+if ($e3smreplay eq 'ON' and $dyn_pkg ne 'se') {
     die <<"EOF";
-**  ERROR: CAMIOP mode only works with Spectral Element dycore.
+**  ERROR: REPLAY mode only works with Spectral Element dycore.
 **         Requested dycore is: $dyn_pkg
 EOF
 }
 
-if ($print>=2) { print "Produce IOP file for SCAM: $camiop$eol"; }
+if ($print>=2) { print "Produce IOP file for SCAM: $e3smreplay$eol"; }
 
 #-----------------------------------------------------------------------------------------------
 # Horizontal grid parameters
@@ -1949,7 +1949,7 @@ $cfg_cppdefs .= " -DMAXPATCH_PFT=numpft+1 -DLSMLAT=1 -DLSMLON=1";
 if ($pergro eq "ON") { $cfg_cppdefs .= " -DPERGRO"; }
 
 # Configure CAM to produce IOP files for SCAM
-if ($camiop eq 'ON') { $cfg_cppdefs .= " -DBFB_CAM_SCAM_IOP"; }
+if ($e3smreplay eq 'ON') { $cfg_cppdefs .= " -DBFB_E3SM_SCM_IOP"; }
 
 # Resolution parameters for rectangular lat/lon grids
 my $nlon = $cfg_ref->get('nlon');

--- a/components/cam/src/chemistry/mozart/mo_drydep.F90
+++ b/components/cam/src/chemistry/mozart/mo_drydep.F90
@@ -2036,7 +2036,7 @@ contains
                          wetland, vegetation_map, soilw_map, do_soilw )
 
     use mo_constants, only : r2d
-    use scamMod, only : latiop,loniop,scmlat,scmlon,use_camiop
+    use scamMod, only : latiop,loniop,scmlat,scmlon,use_replay
     use shr_scam_mod  , only: shr_scam_getCloseLatLon  ! Standardized system subroutines
     use filenames, only: ncdata
     use dycore, only : dycore_is
@@ -2101,7 +2101,7 @@ contains
     ju = plon
 
     if (single_column) then
-       if (use_camiop) then
+       if (use_replay) then
           call getfil (ncdata, ncdata_loc)
           call cam_pio_openfile (piofile, trim(ncdata_loc), PIO_NOWRITE)
           call shr_scam_getCloseLatLon(piofile,scmlat,scmlon,closelat,closelon,latidx,lonidx)

--- a/components/cam/src/chemistry/utils/tracer_data.F90
+++ b/components/cam/src/chemistry/utils/tracer_data.F90
@@ -1188,7 +1188,7 @@ contains
 
     ! If single column do not interpolate aerosol data, just use the step function. 
     !   The exception is if we are trying to "replay" a column from the full model
-    if(single_column .and. .not. use_camiop) then
+    if(single_column .and. .not. use_replay) then
       file%stepTime = .true.
     endif
 

--- a/components/cam/src/control/cam_comp.F90
+++ b/components/cam/src/control/cam_comp.F90
@@ -87,7 +87,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    use physpkg,          only: phys_init, phys_register
    
    use dycore,           only: dycore_is
-#if (defined BFB_E3SM_SCM_IOP)
+#if (defined E3SM_SCM_REPLAY)
    use history_defaults, only: initialize_iop_history
 #endif
 !   use shr_orb_mod,      only: shr_orb_params
@@ -169,7 +169,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
      ! Commented out the hub2atm_alloc call as it overwrite cam_in, which is undesirable. The fields in cam_in are necessary for getting BFB restarts
 	 ! There are no side effects of commenting out this call as this call allocates cam_in and cam_in allocation has already been done in cam_init
      !call hub2atm_alloc( cam_in )
-#if (defined BFB_E3SM_SCM_IOP)
+#if (defined E3SM_SCM_REPLAY)
       call initialize_iop_history()
 #endif
    end if

--- a/components/cam/src/control/cam_comp.F90
+++ b/components/cam/src/control/cam_comp.F90
@@ -87,7 +87,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    use physpkg,          only: phys_init, phys_register
    
    use dycore,           only: dycore_is
-#if (defined BFB_CAM_SCAM_IOP)
+#if (defined BFB_E3SM_SCM_IOP)
    use history_defaults, only: initialize_iop_history
 #endif
 !   use shr_orb_mod,      only: shr_orb_params
@@ -169,7 +169,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
      ! Commented out the hub2atm_alloc call as it overwrite cam_in, which is undesirable. The fields in cam_in are necessary for getting BFB restarts
 	 ! There are no side effects of commenting out this call as this call allocates cam_in and cam_in allocation has already been done in cam_init
      !call hub2atm_alloc( cam_in )
-#if (defined BFB_CAM_SCAM_IOP)
+#if (defined BFB_E3SM_SCM_IOP)
       call initialize_iop_history()
 #endif
    end if

--- a/components/cam/src/control/cam_history.F90
+++ b/components/cam/src/control/cam_history.F90
@@ -3408,7 +3408,7 @@ end subroutine print_active_fldlst
       ierr=pio_inq_varid (tape(t)%File,'time_bnds',   tape(t)%tbndid)
       ierr=pio_inq_varid (tape(t)%File,'date_written',tape(t)%date_writtenid)
       ierr=pio_inq_varid (tape(t)%File,'time_written',tape(t)%time_writtenid)
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
       ierr=pio_inq_varid (tape(t)%File,'tsec    ',tape(t)%tsecid)
       ierr=pio_inq_varid (tape(t)%File,'bdate   ',tape(t)%bdateid)
 #endif
@@ -3764,8 +3764,8 @@ end subroutine print_active_fldlst
     str = 'CF-1.0'
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'Conventions', trim(str))
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'source', 'CAM')
-#if ( defined BFB_CAM_SCAM_IOP )
-    ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'CAM_GENERATED_FORCING','create SCAM IOP dataset')
+#if ( defined BFB_E3SM_SCM_IOP )
+    ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'E3SM_GENERATED_FORCING','create SCM IOP dataset')
 #endif
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'case',caseid)
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'title',ctitle)
@@ -3825,7 +3825,7 @@ end subroutine print_active_fldlst
       str = 'base date (YYYYMMDD)'
       ierr=pio_put_att (tape(t)%File, tape(t)%nbdateid, 'long_name', trim(str))
 
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
       ierr=pio_def_var (tape(t)%File,'bdate',PIO_INT,tape(t)%bdateid)
       str = 'base date (YYYYMMDD)'
       ierr=pio_put_att (tape(t)%File, tape(t)%bdateid, 'long_name', trim(str))
@@ -3902,7 +3902,7 @@ end subroutine print_active_fldlst
       end if
 
 
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
       ierr=pio_def_var (tape(t)%File,'tsec ',pio_int,(/timdim/), tape(t)%tsecid)
       str = 'current seconds of current date needed for scam'
       ierr=pio_put_att (tape(t)%File, tape(t)%tsecid, 'long_name', trim(str))
@@ -4145,7 +4145,7 @@ end subroutine print_active_fldlst
 
       ierr = pio_put_var(tape(t)%File, tape(t)%nbdateid, (/nbdate/))
       call cam_pio_handle_error(ierr, 'h_define: cannot put nbdate')
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
       ierr = pio_put_var(tape(t)%File, tape(t)%bdateid, (/nbdate/))
       call cam_pio_handle_error(ierr, 'h_define: cannot put bdate')
 #endif
@@ -4526,7 +4526,7 @@ end subroutine print_active_fldlst
     character(len=max_string_len) :: fname ! Filename
     logical :: prev              ! Label file with previous date rather than current
     integer :: ierr
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
     integer :: tsec             ! day component of current time
     integer :: dtime            ! seconds component of current time
 #endif
@@ -4670,7 +4670,7 @@ end subroutine print_active_fldlst
           end if
 
           ierr = pio_put_var (tape(t)%File, tape(t)%datesecid,(/start/),(/count1/),(/ncsec/))
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
           dtime = get_step_size()
           tsec=dtime*nstep
           ierr = pio_put_var (tape(t)%File, tape(t)%tsecid,(/start/),(/count1/),(/tsec/))

--- a/components/cam/src/control/cam_history.F90
+++ b/components/cam/src/control/cam_history.F90
@@ -3408,7 +3408,7 @@ end subroutine print_active_fldlst
       ierr=pio_inq_varid (tape(t)%File,'time_bnds',   tape(t)%tbndid)
       ierr=pio_inq_varid (tape(t)%File,'date_written',tape(t)%date_writtenid)
       ierr=pio_inq_varid (tape(t)%File,'time_written',tape(t)%time_writtenid)
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
       ierr=pio_inq_varid (tape(t)%File,'tsec    ',tape(t)%tsecid)
       ierr=pio_inq_varid (tape(t)%File,'bdate   ',tape(t)%bdateid)
 #endif
@@ -3764,7 +3764,7 @@ end subroutine print_active_fldlst
     str = 'CF-1.0'
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'Conventions', trim(str))
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'source', 'CAM')
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'E3SM_GENERATED_FORCING','create SCM IOP dataset')
 #endif
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'case',caseid)
@@ -3825,7 +3825,7 @@ end subroutine print_active_fldlst
       str = 'base date (YYYYMMDD)'
       ierr=pio_put_att (tape(t)%File, tape(t)%nbdateid, 'long_name', trim(str))
 
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
       ierr=pio_def_var (tape(t)%File,'bdate',PIO_INT,tape(t)%bdateid)
       str = 'base date (YYYYMMDD)'
       ierr=pio_put_att (tape(t)%File, tape(t)%bdateid, 'long_name', trim(str))
@@ -3902,7 +3902,7 @@ end subroutine print_active_fldlst
       end if
 
 
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
       ierr=pio_def_var (tape(t)%File,'tsec ',pio_int,(/timdim/), tape(t)%tsecid)
       str = 'current seconds of current date needed for scam'
       ierr=pio_put_att (tape(t)%File, tape(t)%tsecid, 'long_name', trim(str))
@@ -4145,7 +4145,7 @@ end subroutine print_active_fldlst
 
       ierr = pio_put_var(tape(t)%File, tape(t)%nbdateid, (/nbdate/))
       call cam_pio_handle_error(ierr, 'h_define: cannot put nbdate')
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
       ierr = pio_put_var(tape(t)%File, tape(t)%bdateid, (/nbdate/))
       call cam_pio_handle_error(ierr, 'h_define: cannot put bdate')
 #endif
@@ -4526,7 +4526,7 @@ end subroutine print_active_fldlst
     character(len=max_string_len) :: fname ! Filename
     logical :: prev              ! Label file with previous date rather than current
     integer :: ierr
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
     integer :: tsec             ! day component of current time
     integer :: dtime            ! seconds component of current time
 #endif
@@ -4670,7 +4670,7 @@ end subroutine print_active_fldlst
           end if
 
           ierr = pio_put_var (tape(t)%File, tape(t)%datesecid,(/start/),(/count1/),(/ncsec/))
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
           dtime = get_step_size()
           tsec=dtime*nstep
           ierr = pio_put_var (tape(t)%File, tape(t)%tsecid,(/start/),(/count1/),(/tsec/))

--- a/components/cam/src/control/cam_history.F90
+++ b/components/cam/src/control/cam_history.F90
@@ -3764,11 +3764,8 @@ end subroutine print_active_fldlst
     str = 'CF-1.0'
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'Conventions', trim(str))
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'source', 'CAM')
-#if defined (E3SM_SCM_REPLAY) && !defined(E3SM_SCM_REPLAY_B4B)
+#if defined (E3SM_SCM_REPLAY)
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'E3SM_GENERATED_FORCING','create SCM IOP dataset')
-#endif
-#if defined (E3SM_SCM_REPLAY_B4B)
-    ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'E3SM_B4B_GENERATED_FORCING','create SCM IOP dataset')
 #endif
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'case',caseid)
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'title',ctitle)

--- a/components/cam/src/control/cam_history.F90
+++ b/components/cam/src/control/cam_history.F90
@@ -3764,8 +3764,11 @@ end subroutine print_active_fldlst
     str = 'CF-1.0'
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'Conventions', trim(str))
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'source', 'CAM')
-#if ( defined E3SM_SCM_REPLAY )
+#if defined (E3SM_SCM_REPLAY) && !defined(E3SM_SCM_REPLAY_B4B)
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'E3SM_GENERATED_FORCING','create SCM IOP dataset')
+#endif
+#if defined (E3SM_SCM_REPLAY_B4B)
+    ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'E3SM_B4B_GENERATED_FORCING','create SCM IOP dataset')
 #endif
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'case',caseid)
     ierr=pio_put_att (tape(t)%File, PIO_GLOBAL, 'title',ctitle)

--- a/components/cam/src/control/cam_history_support.F90
+++ b/components/cam/src/control/cam_history_support.F90
@@ -195,7 +195,7 @@ module cam_history_support
     type(var_desc_t) :: f12vmrid         ! var id for f12 volume mixing ratio
     type(var_desc_t) :: sol_tsiid        ! var id for total solar irradiance (W/m2)
     type(var_desc_t) :: datesecid        ! var id for curent seconds of current date
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
     type(var_desc_t) :: bdateid         ! var id for base date
     type(var_desc_t) :: tsecid        ! var id for curent seconds of current date
 #endif

--- a/components/cam/src/control/cam_history_support.F90
+++ b/components/cam/src/control/cam_history_support.F90
@@ -195,7 +195,7 @@ module cam_history_support
     type(var_desc_t) :: f12vmrid         ! var id for f12 volume mixing ratio
     type(var_desc_t) :: sol_tsiid        ! var id for total solar irradiance (W/m2)
     type(var_desc_t) :: datesecid        ! var id for curent seconds of current date
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
     type(var_desc_t) :: bdateid         ! var id for base date
     type(var_desc_t) :: tsecid        ! var id for curent seconds of current date
 #endif

--- a/components/cam/src/control/forecast.F90
+++ b/components/cam/src/control/forecast.F90
@@ -196,7 +196,7 @@ subroutine forecast(lat, psm1, psm2,ps, &
 
       go to 1000
 
-   end if 
+   end if
 
 !
 !  provide an eulerian forecast.  First check to ensure that 2d forcing

--- a/components/cam/src/control/forecast.F90
+++ b/components/cam/src/control/forecast.F90
@@ -117,7 +117,9 @@ subroutine forecast(lat, psm1, psm2,ps, &
    real(r8) dotprodb           ! dot product
    integer i,k,m           ! longitude, level, constituent indices
    real(r16) divt3d_full, divq3d_full, term1, term2, term3, term4
-   real(r16) term5, term6
+   real(r16) reconst1, reconst2, mult_reconst
+   real(r16) term5, term6, mult
+   real(r8) e_count
 !
 !     Below are Variables Used in the Advection Diagnostics
 !
@@ -208,7 +210,12 @@ subroutine forecast(lat, psm1, psm2,ps, &
 !  advection calculation.  Skip to diagnostic estimates of vertical term.
       i=1
       do k=1,plev
-         divt3d_full = divt3d(k) + divt3d_2(k)
+         e_count=divt3d_3(k)
+	 mult_reconst=1.0_r16*10._r16**(e_count)
+	 reconst2=divt3d_2(k)
+	 reconst1=divt3d(k)
+	 divt3d_full = reconst2 + reconst1/mult_reconst
+
 	 term1 = t3m2(k)
 	 term2 = ztodt
 	 term3 = t2(k)
@@ -219,7 +226,13 @@ subroutine forecast(lat, psm1, psm2,ps, &
       end do
       do m=1,pcnst
          do k=1,plev
-	    divq3d_full = divq3d(k,m) + divq3d_2(k,m)
+            e_count=divq3d_3(k,m)
+	    mult_reconst=1.0_r16*10._r16**(e_count)
+	    reconst2=divq3d_2(k,m)
+	    reconst1=divq3d(k,m)	 
+	 
+	    divq3d_full = reconst2 + reconst1/mult_reconst	 
+
 	    term1 = qminus(1,k,m)
 	    term2 = ztodt
 	    term3 = term1 + divq3d_full*term2

--- a/components/cam/src/control/forecast.F90
+++ b/components/cam/src/control/forecast.F90
@@ -178,18 +178,12 @@ subroutine forecast(lat, psm1, psm2,ps, &
    end do
 
    wfldint(plevp) = 0.0_r8
- 
-   if (use_3dfrc .and. use_iop) then
 
-!  If using the E3SM REPLAY option, then this method will not 
-!    give exact b4b results with the GCM column, though this 
-!    should faithful represent the behavior and regime of
-!    the column with small error.  
+   if (use_3dfrc .and. use_iop) then
 
 !  Complete a very simple forecast using supplied 3-dimensional forcing
 !  by the large scale.  Obviates the need for any kind of vertical 
 !  advection calculation.  Skip to diagnostic estimates of vertical term.
-
       i=1
       do k=1,plev
          tfcst(k) = t3m2(k) + ztodt*t2(k) + ztodt*divt3d(k)
@@ -202,7 +196,7 @@ subroutine forecast(lat, psm1, psm2,ps, &
 
       go to 1000
 
-   end if  
+   end if 
 
 !
 !  provide an eulerian forecast.  First check to ensure that 2d forcing

--- a/components/cam/src/control/forecast.F90
+++ b/components/cam/src/control/forecast.F90
@@ -184,7 +184,7 @@ subroutine forecast(lat, psm1, psm2,ps, &
 
    wfldint(plevp) = 0.0_r8
 
-   if (use_3dfrc .and. use_iop .and. .not. use_replay) then
+   if (use_3dfrc .and. use_iop .and. .not. use_replay_b4b) then
 
 !  Complete a very simple forecast using supplied 3-dimensional forcing
 !  by the large scale.  Obviates the need for any kind of vertical 
@@ -203,7 +203,7 @@ subroutine forecast(lat, psm1, psm2,ps, &
 
    end if
    
-   if (use_3dfrc .and. use_iop .and. use_replay) then
+   if (use_3dfrc .and. use_iop .and. use_replay_b4b) then
 
 !  Complete a very simple forecast using supplied 3-dimensional forcing
 !  by the large scale.  Obviates the need for any kind of vertical 

--- a/components/cam/src/control/forecast.F90
+++ b/components/cam/src/control/forecast.F90
@@ -239,13 +239,15 @@ subroutine forecast(lat, psm1, psm2,ps, &
 	 ! Read in part one of the dynamics tendency
 	 reconst1_r16=divt3d(k)
 	 
+!	 write(*,*) 'PARTTWOandTHREE ', exp_count, reconst2_r16
+	 
 	 ! Now we have all terms to reconstruct the r16 
 	 !  dynamics tendency needed for our forecast.  This 
 	 !  needs to be computed EXACTLY the same way as it was 
 	 !  done in routine "replay_b4b_output".  In this routine
 	 !  we computed reconst2 as:
 	 !     reconst2 = (divt3d_full - reconst1)/mult_reconst
-	 !  Thus, we will rearrange to solve for divt2d_full as:
+	 !  Thus, we will rearrange to solve for divt3d_full as:
 
 	 divt3d_r16 = reconst2_r16 + reconst1_r16/mult_reconst_r16
 
@@ -258,7 +260,7 @@ subroutine forecast(lat, psm1, psm2,ps, &
 
          ! compute the forecast in r16	 
 	 var_afterdyn_r16 = var_beforedyn_r16 + timestep_r16*phystend_r16 &
-	     + phystend_r16*divt3d_r16
+	     + timestep_r16*divt3d_r16
 	     
 	 ! Now convert the r16 forecast to r8
          tfcst(k) = var_afterdyn_r16

--- a/components/cam/src/control/forecast.F90
+++ b/components/cam/src/control/forecast.F90
@@ -184,7 +184,7 @@ subroutine forecast(lat, psm1, psm2,ps, &
 
    wfldint(plevp) = 0.0_r8
 
-   if (use_3dfrc .and. use_iop .and. .not. use_camiop) then
+   if (use_3dfrc .and. use_iop .and. .not. use_replay) then
 
 !  Complete a very simple forecast using supplied 3-dimensional forcing
 !  by the large scale.  Obviates the need for any kind of vertical 
@@ -203,7 +203,7 @@ subroutine forecast(lat, psm1, psm2,ps, &
 
    end if
    
-   if (use_3dfrc .and. use_iop .and. use_camiop) then
+   if (use_3dfrc .and. use_iop .and. use_replay) then
 
 !  Complete a very simple forecast using supplied 3-dimensional forcing
 !  by the large scale.  Obviates the need for any kind of vertical 

--- a/components/cam/src/control/forecast.F90
+++ b/components/cam/src/control/forecast.F90
@@ -32,7 +32,6 @@ subroutine forecast(lat, psm1, psm2,ps, &
 !
 ! Input arguments
 !
-   integer, parameter :: r16 = selected_real_kind(24)
    real(r8), intent(inout) :: t2(plev)         ! temp tendency
    real(r8), intent(inout) :: fu(plev)         ! u wind tendency
    real(r8), intent(inout) :: fv(plev)         ! v wind tendency
@@ -116,11 +115,6 @@ subroutine forecast(lat, psm1, psm2,ps, &
    real(r8) dotproda           ! dot product
    real(r8) dotprodb           ! dot product
    integer i,k,m           ! longitude, level, constituent indices
-   real(r16) divt3d_r16, divq3d_r16
-   real(r16) reconst1_r16, reconst2_r16, mult_reconst_r16
-   real(r16) timestep_r16, phystend_r16
-   real(r16) var_beforedyn_r16, var_afterdyn_r16
-   real(r8) exp_count
 !
 !     Below are Variables Used in the Advection Diagnostics
 !

--- a/components/cam/src/control/forecast.F90
+++ b/components/cam/src/control/forecast.F90
@@ -116,7 +116,8 @@ subroutine forecast(lat, psm1, psm2,ps, &
    real(r8) dotproda           ! dot product
    real(r8) dotprodb           ! dot product
    integer i,k,m           ! longitude, level, constituent indices
-   real(r16) divt3d_full, divq3d_full
+   real(r16) divt3d_full, divq3d_full, term1, term2, term3, term4
+   real(r16) term5, term6
 !
 !     Below are Variables Used in the Advection Diagnostics
 !
@@ -208,12 +209,22 @@ subroutine forecast(lat, psm1, psm2,ps, &
       i=1
       do k=1,plev
          divt3d_full = divt3d(k) + divt3d_2(k)
-         tfcst(k) = t3m2(k) + ztodt*t2(k) + ztodt*divt3d_full!divt3d(k)
+	 term1 = t3m2(k)
+	 term2 = ztodt
+	 term3 = t2(k)
+	 
+	 term4 = term1 + term2*term3 + term2*divt3d_full
+         tfcst(k) = term4
+!         tfcst(k) = t3m2(k) + ztodt*t2(k) + ztodt*divt3d_full!divt3d(k)
       end do
       do m=1,pcnst
          do k=1,plev
 	    divq3d_full = divq3d(k,m) + divq3d_2(k,m)
-            qfcst(1,k,m) = qminus(1,k,m) +  divq3d_full*ztodt
+	    term1 = qminus(1,k,m)
+	    term2 = ztodt
+	    term3 = term1 + divq3d_full*term2
+	    qfcst(1,k,m) = term3
+!            qfcst(1,k,m) = qminus(1,k,m) +  divq3d_full*ztodt
          end do
       enddo
 

--- a/components/cam/src/control/getinterpnetcdfdata.F90
+++ b/components/cam/src/control/getinterpnetcdfdata.F90
@@ -189,7 +189,7 @@ subroutine getinterpncdata( NCID, camlat, camlon, TimeIdx, &
       outdata(1) = tmp(1)
       return                 ! no need to do interpolation 
    endif
-!   if ( use_camiop .and. nlev.eq.plev) then
+!   if ( use_replay .and. nlev.eq.plev) then
    if ( nlev.eq.plev .or. nlev.eq.plev+1) then
       outData(:nlev)= tmp(:nlev)! no need to do interpolation 
    else

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -100,10 +100,13 @@ CONTAINS
     call add_default ('Ps',2,' ')
     call addfld ('divT3d',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
     call add_default ('divT3d',2,' ')
+    
+#if (defined E3SM_SCM_REPLAY_B4B)
     call addfld ('divT3d_2',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
     call add_default ('divT3d_2',2,' ')  
     call addfld ('divT3d_3',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
-    call add_default ('divT3d_3',2,' ')      
+    call add_default ('divT3d_3',2,' ')  
+#endif    
 
     call addfld ('heat_glob',horiz_only, 'A', 'K/s', 'Global mean total energy difference')
     call add_default ('heat_glob',2,' ')
@@ -112,14 +115,16 @@ CONTAINS
        call addfld (trim(cnst_name(m))//'_dten',(/ 'lev' /), 'A','kg/kg', &
             trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
        call add_default (trim(cnst_name(m))//'_dten',2,' ')
-       
+
+#if (defined E3SM_SCM_REPLAY_B4B)       
        call addfld (trim(cnst_name(m))//'_dten_2',(/ 'lev' /), 'A','kg/kg', &
             trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
        call add_default (trim(cnst_name(m))//'_dten_2',2,' ') 
        
        call addfld (trim(cnst_name(m))//'_dten_3',(/ 'lev' /), 'A','kg/kg', &
             trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
-       call add_default (trim(cnst_name(m))//'_dten_3',2,' ')             
+       call add_default (trim(cnst_name(m))//'_dten_3',2,' ')
+#endif             
       
     end do
     call addfld ('shflx',horiz_only,    'A','W/m2','Surface sensible heat flux for scam')

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -22,7 +22,7 @@ module history_defaults
 
   public :: bldfld
 
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
   public :: initialize_iop_history
 #endif
 
@@ -60,7 +60,7 @@ CONTAINS
   end subroutine bldfld
 
 !#######################################################################
-#if ( defined BFB_E3SM_SCM_IOP  )
+#if ( defined E3SM_SCM_REPLAY  )
   subroutine initialize_iop_history()
 !
 ! !DESCRIPTION: 

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -101,7 +101,9 @@ CONTAINS
     call addfld ('divT3d',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
     call add_default ('divT3d',2,' ')
     call addfld ('divT3d_2',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
-    call add_default ('divT3d_2',2,' ')    
+    call add_default ('divT3d_2',2,' ')  
+    call addfld ('divT3d_3',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
+    call add_default ('divT3d_3',2,' ')      
 
     call addfld ('heat_glob',horiz_only, 'A', 'K/s', 'Global mean total energy difference')
     call add_default ('heat_glob',2,' ')
@@ -113,7 +115,11 @@ CONTAINS
        
        call addfld (trim(cnst_name(m))//'_dten_2',(/ 'lev' /), 'A','kg/kg', &
             trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
-       call add_default (trim(cnst_name(m))//'_dten_2',2,' ')       
+       call add_default (trim(cnst_name(m))//'_dten_2',2,' ') 
+       
+       call addfld (trim(cnst_name(m))//'_dten_3',(/ 'lev' /), 'A','kg/kg', &
+            trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
+       call add_default (trim(cnst_name(m))//'_dten_3',2,' ')             
       
     end do
     call addfld ('shflx',horiz_only,    'A','W/m2','Surface sensible heat flux for scam')

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -102,9 +102,9 @@ CONTAINS
     call add_default ('divT3d',2,' ')
     
 #if (defined E3SM_SCM_REPLAY_B4B)
-    call addfld ('divT3d_2',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
+    call addfld ('divT3d_2',(/ 'lev' /), 'A','K','Part two dynamics Residual for T',gridname=trim(dyngrid))
     call add_default ('divT3d_2',2,' ')  
-    call addfld ('divT3d_3',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
+    call addfld ('divT3d_3',(/ 'lev' /), 'A','-','Exponent for dynamics Residual for T',gridname=trim(dyngrid))
     call add_default ('divT3d_3',2,' ')  
 #endif    
 
@@ -118,11 +118,11 @@ CONTAINS
 
 #if (defined E3SM_SCM_REPLAY_B4B)       
        call addfld (trim(cnst_name(m))//'_dten_2',(/ 'lev' /), 'A','kg/kg', &
-            trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
+            trim(cnst_name(m))//' Part two IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
        call add_default (trim(cnst_name(m))//'_dten_2',2,' ') 
        
-       call addfld (trim(cnst_name(m))//'_dten_3',(/ 'lev' /), 'A','kg/kg', &
-            trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
+       call addfld (trim(cnst_name(m))//'_dten_3',(/ 'lev' /), 'A','-', &
+            trim(cnst_name(m))//' Exponent for IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
        call add_default (trim(cnst_name(m))//'_dten_3',2,' ')
 #endif             
       

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -99,7 +99,7 @@ CONTAINS
     call addfld ('Ps',horiz_only, 'A','Pa','Ps for scam',gridname=trim(dyngrid))
     call add_default ('Ps',2,' ')
     call addfld ('divT3d',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
-    call add_default ('divT3d',2,' ')   
+    call add_default ('divT3d',2,' ')
 
     call addfld ('heat_glob',horiz_only, 'A', 'K/s', 'Global mean total energy difference')
     call add_default ('heat_glob',2,' ')
@@ -107,8 +107,7 @@ CONTAINS
     do m=1,pcnst
        call addfld (trim(cnst_name(m))//'_dten',(/ 'lev' /), 'A','kg/kg', &
             trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
-       call add_default (trim(cnst_name(m))//'_dten',2,' ')             
-      
+       call add_default (trim(cnst_name(m))//'_dten',2,' ')
     end do
     call addfld ('shflx',horiz_only,    'A','W/m2','Surface sensible heat flux for scam')
     call add_default ('shflx ',2,' ')

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -22,7 +22,7 @@ module history_defaults
 
   public :: bldfld
 
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
   public :: initialize_iop_history
 #endif
 
@@ -60,7 +60,7 @@ CONTAINS
   end subroutine bldfld
 
 !#######################################################################
-#if ( defined BFB_CAM_SCAM_IOP  )
+#if ( defined BFB_E3SM_SCM_IOP  )
   subroutine initialize_iop_history()
 !
 ! !DESCRIPTION: 

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -99,14 +99,7 @@ CONTAINS
     call addfld ('Ps',horiz_only, 'A','Pa','Ps for scam',gridname=trim(dyngrid))
     call add_default ('Ps',2,' ')
     call addfld ('divT3d',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
-    call add_default ('divT3d',2,' ')
-    
-#if (defined E3SM_SCM_REPLAY_B4B)
-    call addfld ('divT3d_2',(/ 'lev' /), 'A','K','Part two dynamics Residual for T',gridname=trim(dyngrid))
-    call add_default ('divT3d_2',2,' ')  
-    call addfld ('divT3d_3',(/ 'lev' /), 'A','-','Exponent for dynamics Residual for T',gridname=trim(dyngrid))
-    call add_default ('divT3d_3',2,' ')  
-#endif    
+    call add_default ('divT3d',2,' ')   
 
     call addfld ('heat_glob',horiz_only, 'A', 'K/s', 'Global mean total energy difference')
     call add_default ('heat_glob',2,' ')
@@ -114,17 +107,7 @@ CONTAINS
     do m=1,pcnst
        call addfld (trim(cnst_name(m))//'_dten',(/ 'lev' /), 'A','kg/kg', &
             trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
-       call add_default (trim(cnst_name(m))//'_dten',2,' ')
-
-#if (defined E3SM_SCM_REPLAY_B4B)       
-       call addfld (trim(cnst_name(m))//'_dten_2',(/ 'lev' /), 'A','kg/kg', &
-            trim(cnst_name(m))//' Part two IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
-       call add_default (trim(cnst_name(m))//'_dten_2',2,' ') 
-       
-       call addfld (trim(cnst_name(m))//'_dten_3',(/ 'lev' /), 'A','-', &
-            trim(cnst_name(m))//' Exponent for IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
-       call add_default (trim(cnst_name(m))//'_dten_3',2,' ')
-#endif             
+       call add_default (trim(cnst_name(m))//'_dten',2,' ')             
       
     end do
     call addfld ('shflx',horiz_only,    'A','W/m2','Surface sensible heat flux for scam')

--- a/components/cam/src/control/history_defaults.F90
+++ b/components/cam/src/control/history_defaults.F90
@@ -100,6 +100,8 @@ CONTAINS
     call add_default ('Ps',2,' ')
     call addfld ('divT3d',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
     call add_default ('divT3d',2,' ')
+    call addfld ('divT3d_2',(/ 'lev' /), 'A','K','Dynamics Residual for T',gridname=trim(dyngrid))
+    call add_default ('divT3d_2',2,' ')    
 
     call addfld ('heat_glob',horiz_only, 'A', 'K/s', 'Global mean total energy difference')
     call add_default ('heat_glob',2,' ')
@@ -108,6 +110,11 @@ CONTAINS
        call addfld (trim(cnst_name(m))//'_dten',(/ 'lev' /), 'A','kg/kg', &
             trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
        call add_default (trim(cnst_name(m))//'_dten',2,' ')
+       
+       call addfld (trim(cnst_name(m))//'_dten_2',(/ 'lev' /), 'A','kg/kg', &
+            trim(cnst_name(m))//' IOP Dynamics Residual for '//trim(cnst_name(m)),gridname=trim(dyngrid))
+       call add_default (trim(cnst_name(m))//'_dten_2',2,' ')       
+      
     end do
     call addfld ('shflx',horiz_only,    'A','W/m2','Surface sensible heat flux for scam')
     call add_default ('shflx ',2,' ')

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -96,8 +96,10 @@ module scamMod
 
   real(r8), public ::      divq3d(plev,pcnst)  ! 3D q advection
   real(r8), public ::      divq3d_2(plev,pcnst)  ! 3D q advection
+  real(r8), public ::      divq3d_3(plev,pcnst)  ! 3D q advection
   real(r8), public ::      divt3d(plev)        ! 3D T advection
   real(r8), public ::      divt3d_2(plev)        ! 3D T advection
+  real(r8), public ::      divt3d_3(plev)        ! 3D T advection
   real(r8), public ::      vertdivq(plev,pcnst)! vertical q advection
   real(r8), public ::      vertdivt(plev)      ! vertical T advection
   real(r8), public ::      ptend               ! surface pressure tendency
@@ -156,6 +158,7 @@ module scamMod
   logical*4, public ::  have_vertdivq ! dataset contains vertdivq 
   logical*4, public ::  have_divt3d   ! dataset contains divt3d
   logical*4, public ::  have_divt3d_2 ! dataset contains divt3d_2 
+  logical*4, public ::  have_divt3d_3 ! dataset contains divt3d_2
   logical*4, public ::  have_divu     ! dataset contains divu
   logical*4, public ::  have_divv     ! dataset contains divv 
   logical*4, public ::  have_omega    ! dataset contains omega
@@ -1136,7 +1139,18 @@ endif !scm_observed_aero
            divq3d_2(1:,m)=0._r8
          else
            have_cnst(m) = .true.
-         endif             
+         endif 
+	 
+         call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, trim(cnst_name(m))//'_dten_3', &
+           have_srf, srf(1), fill_ends, scm_crm_mode, &
+           dplevs, nlev,psobs, hyam, hybm, divq3d_3(:,m), status )
+         if ( status .ne. nf90_noerr ) then
+           have_cnst(m) = .false.
+           divq3d_3(1:,m)=0._r8
+         else
+           have_cnst(m) = .true.
+         endif 	 
+	             
        endif
 
        call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, trim(cnst_name(m))//'_dqfx', &
@@ -1320,6 +1334,15 @@ endif !scm_observed_aero
        else
          have_divt3d_2 = .true.
        endif
+       
+       call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, 'divT3d_3', &
+         have_srf, srf(1), fill_ends, scm_crm_mode, &
+         dplevs, nlev,psobs, hyam, hybm, divt3d_3, status )
+       if ( status .ne. nf90_noerr ) then
+         have_divt3d_3 = .false.
+       else
+         have_divt3d_3 = .true.
+       endif       
      
      endif     
 

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -193,6 +193,7 @@ module scamMod
   logical*4, public ::  lwrad_off     ! turn off LW radiation
   logical*4, public ::  precip_off    ! turn off precipitation processes
   logical*4, public ::  use_replay    ! use e3sm generated forcing 
+  logical*4, public ::  use_replay_b4b ! use e3sm generated forcing to get b4b results
   logical*4, public ::  use_3dfrc     ! use 3d forcing
   logical*4, public ::  have_heat_glob ! dataset contains global energy fixer
 

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -34,7 +34,10 @@ module scamMod
   public scam_default_opts        ! SCAM default run-time options 
   public scam_setopts             ! SCAM run-time options 
   public setiopupdate
-  public readiopdata         
+  public readiopdata
+  public replay_b4b_output         
+
+  integer, parameter :: r16 = selected_real_kind(24)
 
 !
 ! !PUBLIC MODULE DATA:
@@ -1602,5 +1605,46 @@ endif !scm_observed_aero
    return
 end subroutine readiopdata
 
+subroutine replay_b4b_output(tendency,part_one,part_two,part_three)
+   
+   real(r16), intent(in) :: tendency
+   real(r8), intent(out) :: part_one
+   real(r8), intent(out) :: part_two
+   real(r8), intent(out) :: part_three
+   
+   real(r16) :: mult_test, tendency_16_test, tendency_lrg_16
+   real(r16) :: mult, part_one_16, part_two_16
+   real(r16) :: tendency_int2float_16
+   real(r8) :: e_count   
+   real(r16), parameter :: threshold = 1.E10_r16
+   
+   integer(i8) :: tendency_int
+   
+   ! Start code
+   mult_test = 1.0_r16
+   e_count = 1.0_r8
+   tendency_16_test = tendency
+   do while((abs(tendency_16_test) < threshold) .and. (tendency .ne. 0._r16))
+     tendency_16_test = tendency*mult_test
+     if (abs(tendency_16_test) < threshold) then
+       mult_test = mult_test*10._r16
+       e_count = e_count + 1.0_r8
+     endif
+   enddo
+   
+   mult = mult_test
+   tendency_lrg_16 = tendency*mult
+   tendency_int = int8(tendency_lrg_16)
+   tendency_int2float_16 = tendency_int
+   
+   part_one = tendency_int2float_16
+   
+   part_two_16 = (tendency_lrg_16 - tendency_int2float_16)/mult
+   part_two = part_two_16 
+   
+   part_three = e_count
+   
+   return
+end subroutine replay_b4b_output
 
 end module scamMod

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -36,8 +36,6 @@ module scamMod
   public setiopupdate
   public readiopdata        
 
-  integer, parameter :: r16 = selected_real_kind(24)
-
 !
 ! !PUBLIC MODULE DATA:
 !
@@ -97,11 +95,7 @@ module scamMod
   real(r8), public ::  dqfxcam(plon,plev,pcnst)
 
   real(r8), public ::      divq3d(plev,pcnst)  ! 3D q advection
-  real(r8), public ::      divq3d_2(plev,pcnst)  ! 3D q advection
-  real(r8), public ::      divq3d_3(plev,pcnst)  ! 3D q advection
   real(r8), public ::      divt3d(plev)        ! 3D T advection
-  real(r8), public ::      divt3d_2(plev)        ! 3D T advection
-  real(r8), public ::      divt3d_3(plev)        ! 3D T advection
   real(r8), public ::      vertdivq(plev,pcnst)! vertical q advection
   real(r8), public ::      vertdivt(plev)      ! vertical T advection
   real(r8), public ::      ptend               ! surface pressure tendency
@@ -142,7 +136,7 @@ module scamMod
                                                ! mo_drydep algorithm
 					       
   real(r8), public ::  scm_relaxation_low      ! lowest level to apply relaxation
-  real(r8), public ::  scm_relaxation_high     ! highest level to apply relaxation					       
+  real(r8), public ::  scm_relaxation_high     ! highest level to apply relaxation			       
 					       
   real(r8), public, pointer :: loniop(:)
   real(r8), public, pointer :: latiop(:)
@@ -159,8 +153,6 @@ module scamMod
   logical*4, public ::  have_vertdivt ! dataset contains vertdivt
   logical*4, public ::  have_vertdivq ! dataset contains vertdivq 
   logical*4, public ::  have_divt3d   ! dataset contains divt3d
-  logical*4, public ::  have_divt3d_2 ! dataset contains divt3d_2 
-  logical*4, public ::  have_divt3d_3 ! dataset contains divt3d_2
   logical*4, public ::  have_divu     ! dataset contains divu
   logical*4, public ::  have_divv     ! dataset contains divv 
   logical*4, public ::  have_omega    ! dataset contains omega

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -347,6 +347,13 @@ subroutine scam_setopts( scmlat_in, scmlon_in,iopfile_in,single_column_in, &
            use_replay = .false.
         endif
 	
+	if ( nf90_inquire_attribute( ncid, NF90_GLOBAL, 'E3SM_B4B_GENERATED_FORCING', attnum=i ).EQ. NF90_NOERR ) then
+           use_replay_b4b = .true.
+	   use_replay = .true. 
+        else
+           use_replay_b4b = .false.
+        endif	
+	
 	if (dycore_is('SE') .and. use_replay) then
 	  call wrap_inq_dimid( ncid, 'ncol', londimid   )
 	  call wrap_inq_dimlen( ncid, londimid, lonsiz   )
@@ -696,6 +703,13 @@ end subroutine setiopupdate
    else
       use_replay = .false.
    endif
+   
+   if ( nf90_inquire_attribute( ncid, NF90_GLOBAL, 'E3SM_B4B_GENERATED_FORCING',attnum=i ).EQ. NF90_NOERR ) then
+      use_replay_b4b = .true.
+      use_replay = .true. 
+   else
+      use_replay_b4b = .false.
+   endif   
 
 !=====================================================================
 !     
@@ -1134,7 +1148,7 @@ endif !scm_observed_aero
          have_cnst(m) = .true.
        endif
        
-       if (use_replay) then
+       if (use_replay_b4b) then
          call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, trim(cnst_name(m))//'_dten_2', &
            have_srf, srf(1), fill_ends, scm_crm_mode, &
            dplevs, nlev,psobs, hyam, hybm, divq3d_2(:,m), status )
@@ -1328,7 +1342,7 @@ endif !scm_observed_aero
        have_divt3d = .true.
      endif
      
-     if (use_replay) then
+     if (use_replay_b4b) then
      
        call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, 'divT3d_2', &
          have_srf, srf(1), fill_ends, scm_crm_mode, &

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -606,7 +606,7 @@ subroutine setiopupdate
 
 end subroutine setiopupdate
 
-  subroutine readiopdata(iop_update_surface,hyam,hybm)
+  subroutine readiopdata(iop_update_phase1,hyam,hybm)
 
 !-----------------------------------------------------------------------
 !     
@@ -631,7 +631,7 @@ end subroutine setiopupdate
 #endif
 !------------------------------Locals-----------------------------------
 !     
-   logical, intent(in) :: iop_update_surface
+   logical, intent(in) :: iop_update_phase1
    integer NCID, status
    integer time_dimID, lev_dimID,lev_varID,mod_dimID,&
            mod_varID,sps_varID,sps_dimID
@@ -752,7 +752,7 @@ end subroutine setiopupdate
 ! =====================================================
 !     read observed aersol data
 
- if(scm_observed_aero .and. .not. iop_update_surface) then
+ if(scm_observed_aero .and. .not. iop_update_phase1) then
    status = NF90_INQ_DIMID( ncid, 'mod', mod_dimID )
    if ( status .ne. nf90_noerr ) then
       write(iulog,* )'ERROR - readiopdata.F:Could not find variable dim ID  for lev'
@@ -908,7 +908,7 @@ endif !scm_observed_aero
    cnt4(3)  = 1
    cnt4(4)  = 1
 
-   if (.not. iop_update_surface) then
+   if (.not. iop_update_phase1) then
 
      status = nf90_inq_varid( ncid, 'Ps', varid   )
      if ( status .ne. nf90_noerr ) then

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -34,7 +34,7 @@ module scamMod
   public scam_default_opts        ! SCAM default run-time options 
   public scam_setopts             ! SCAM run-time options 
   public setiopupdate
-  public readiopdata        
+  public readiopdata      
 
 !
 ! !PUBLIC MODULE DATA:
@@ -136,7 +136,7 @@ module scamMod
                                                ! mo_drydep algorithm
 					       
   real(r8), public ::  scm_relaxation_low      ! lowest level to apply relaxation
-  real(r8), public ::  scm_relaxation_high     ! highest level to apply relaxation			       
+  real(r8), public ::  scm_relaxation_high     ! highest level to apply relaxation
 					       
   real(r8), public, pointer :: loniop(:)
   real(r8), public, pointer :: latiop(:)
@@ -335,7 +335,7 @@ subroutine scam_setopts( scmlat_in, scmlon_in,iopfile_in,single_column_in, &
            use_replay = .true.
         else
            use_replay = .false.
-        endif	
+        endif
 	
 	if (dycore_is('SE') .and. use_replay) then
 	  call wrap_inq_dimid( ncid, 'ncol', londimid   )
@@ -685,7 +685,7 @@ end subroutine setiopupdate
       use_replay = .true.
    else
       use_replay = .false.
-   endif 
+   endif
 
 !=====================================================================
 !     
@@ -1293,7 +1293,7 @@ endif !scm_observed_aero
        have_divt3d = .false.
      else
        have_divt3d = .true.
-     endif    
+     endif
 
      status = nf90_inq_varid( ncid, 'Ptend', varid   )
      if ( status .ne. nf90_noerr ) then
@@ -1549,5 +1549,6 @@ endif !scm_observed_aero
 
    return
 end subroutine readiopdata
+
 
 end module scamMod

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -34,7 +34,7 @@ module scamMod
   public scam_default_opts        ! SCAM default run-time options 
   public scam_setopts             ! SCAM run-time options 
   public setiopupdate
-  public readiopdata      
+  public readiopdata         
 
 !
 ! !PUBLIC MODULE DATA:
@@ -1306,24 +1306,6 @@ endif !scm_observed_aero
        ptend= srf(1)
      endif
 
-     if (.not. use_replay) then
-       call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, &
-         'omega', .true., ptend, fill_ends, scm_crm_mode, &
-         dplevs, nlev,psobs, hyam, hybm, wfld, status )
-       if ( status .ne. nf90_noerr ) then
-         have_omega = .false.
-         write(iulog,*)'Could not find variable omega'
-         if ( .not. use_userdata ) then
-           status = nf90_close( ncid )
-           return
-         else
-           write(iulog,*) 'Using value from Analysis Dataset'
-         endif
-       else
-         have_omega = .true.
-       endif
-     endif
-
      call plevs0(1    ,plon   ,plev    ,psobs   ,pint,pmid ,pdel)
      call shr_sys_flush( iulog )
 !
@@ -1478,23 +1460,21 @@ endif !scm_observed_aero
        have_tg = .true.
      endif
      
-     if (use_replay) then
-       call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, &
-         'omega', .true., ptend, fill_ends, scm_crm_mode, &
-         dplevs, nlev,psobs, hyam, hybm, wfld, status )
-       if ( status .ne. nf90_noerr ) then
-         have_omega = .false.
-         write(iulog,*)'Could not find variable omega'
-         if ( .not. use_userdata ) then
-           status = nf90_close( ncid )
-           return
-         else
-           write(iulog,*) 'Using value from Analysis Dataset'
-         endif
-       else
-         have_omega = .true.
-       endif
-     endif      
+     call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, &
+       'omega', .true., ptend, fill_ends, scm_crm_mode, &
+        dplevs, nlev,psobs, hyam, hybm, wfld, status )
+     if ( status .ne. nf90_noerr ) then
+        have_omega = .false.
+        write(iulog,*)'Could not find variable omega'
+        if ( .not. use_userdata ) then
+          status = nf90_close( ncid )
+          return
+        else
+          write(iulog,*) 'Using value from Analysis Dataset'
+        endif
+     else
+        have_omega = .true.
+     endif     
      
      ! If REPLAY is used, then need to read in the global
      !   energy fixer

--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -95,7 +95,9 @@ module scamMod
   real(r8), public ::  dqfxcam(plon,plev,pcnst)
 
   real(r8), public ::      divq3d(plev,pcnst)  ! 3D q advection
+  real(r8), public ::      divq3d_2(plev,pcnst)  ! 3D q advection
   real(r8), public ::      divt3d(plev)        ! 3D T advection
+  real(r8), public ::      divt3d_2(plev)        ! 3D T advection
   real(r8), public ::      vertdivq(plev,pcnst)! vertical q advection
   real(r8), public ::      vertdivt(plev)      ! vertical T advection
   real(r8), public ::      ptend               ! surface pressure tendency
@@ -153,6 +155,7 @@ module scamMod
   logical*4, public ::  have_vertdivt ! dataset contains vertdivt
   logical*4, public ::  have_vertdivq ! dataset contains vertdivq 
   logical*4, public ::  have_divt3d   ! dataset contains divt3d
+  logical*4, public ::  have_divt3d_2 ! dataset contains divt3d_2 
   logical*4, public ::  have_divu     ! dataset contains divu
   logical*4, public ::  have_divv     ! dataset contains divv 
   logical*4, public ::  have_omega    ! dataset contains omega
@@ -1123,6 +1126,18 @@ endif !scm_observed_aero
        else
          have_cnst(m) = .true.
        endif
+       
+       if (use_camiop) then
+         call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, trim(cnst_name(m))//'_dten_2', &
+           have_srf, srf(1), fill_ends, scm_crm_mode, &
+           dplevs, nlev,psobs, hyam, hybm, divq3d_2(:,m), status )
+         if ( status .ne. nf90_noerr ) then
+           have_cnst(m) = .false.
+           divq3d_2(1:,m)=0._r8
+         else
+           have_cnst(m) = .true.
+         endif             
+       endif
 
        call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, trim(cnst_name(m))//'_dqfx', &
          have_srf, srf(1), fill_ends, scm_crm_mode, &
@@ -1294,6 +1309,19 @@ endif !scm_observed_aero
      else
        have_divt3d = .true.
      endif
+     
+     if (use_camiop) then
+     
+       call getinterpncdata( ncid, scmlat, scmlon, ioptimeidx, 'divT3d_2', &
+         have_srf, srf(1), fill_ends, scm_crm_mode, &
+         dplevs, nlev,psobs, hyam, hybm, divt3d_2, status )
+       if ( status .ne. nf90_noerr ) then
+         have_divt3d_2 = .false.
+       else
+         have_divt3d_2 = .true.
+       endif
+     
+     endif     
 
      status = nf90_inq_varid( ncid, 'Ptend', varid   )
      if ( status .ne. nf90_noerr ) then

--- a/components/cam/src/control/startup_initialconds.F90
+++ b/components/cam/src/control/startup_initialconds.F90
@@ -23,7 +23,7 @@ subroutine initial_conds(dyn_in)
 
    use comsrf,        only: initialize_comsrf
    use radae,         only: initialize_radbuffer
-#if (defined BFB_CAM_SCAM_IOP )
+#if (defined BFB_E3SM_SCM_IOP )
    use history_defaults, only: initialize_iop_history
 #endif
    
@@ -44,7 +44,7 @@ subroutine initial_conds(dyn_in)
    call initialize_comsrf
    call initialize_radbuffer
 
-#if (defined BFB_CAM_SCAM_IOP )
+#if (defined BFB_E3SM_SCM_IOP )
    call initialize_iop_history
 #endif
 

--- a/components/cam/src/control/startup_initialconds.F90
+++ b/components/cam/src/control/startup_initialconds.F90
@@ -23,7 +23,7 @@ subroutine initial_conds(dyn_in)
 
    use comsrf,        only: initialize_comsrf
    use radae,         only: initialize_radbuffer
-#if (defined BFB_E3SM_SCM_IOP )
+#if (defined E3SM_SCM_REPLAY )
    use history_defaults, only: initialize_iop_history
 #endif
    
@@ -44,7 +44,7 @@ subroutine initial_conds(dyn_in)
    call initialize_comsrf
    call initialize_radbuffer
 
-#if (defined BFB_E3SM_SCM_IOP )
+#if (defined E3SM_SCM_REPLAY )
    call initialize_iop_history
 #endif
 

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -51,7 +51,7 @@ module atm_comp_mct
   use cam_logfile      , only: iulog
   use co2_cycle        , only: co2_readFlux_ocn, co2_readFlux_fuel
   use runtime_opts     , only: read_namelist
-  use scamMod          , only: use_replay,single_column,scmlat,scmlon
+  use scamMod          , only: single_column,scmlat,scmlon
 
 !
 ! !PUBLIC TYPES:

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -51,7 +51,7 @@ module atm_comp_mct
   use cam_logfile      , only: iulog
   use co2_cycle        , only: co2_readFlux_ocn, co2_readFlux_fuel
   use runtime_opts     , only: read_namelist
-  use scamMod          , only: use_camiop,single_column,scmlat,scmlon
+  use scamMod          , only: use_replay,single_column,scmlat,scmlon
 
 !
 ! !PUBLIC TYPES:

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -390,9 +390,6 @@ CONTAINS
        call seq_timemgr_EClockGetData(EClock,curr_ymd=CurrentYMD, StepNo=StepNo, dtime=DTime_Sync )
        if (StepNo == 0) then
           call atm_import( x2a_a%rattr, cam_in )
-	  if (single_column .and. use_camiop) then
-	    call scam_use_iop_srf( cam_in )
-	  endif
           call cam_run1 ( cam_in, cam_out ) 
           call atm_export( cam_out, a2x_a%rattr )
        else

--- a/components/cam/src/dynamics/eul/eul_single_column_mod.F90
+++ b/components/cam/src/dynamics/eul/eul_single_column_mod.F90
@@ -25,7 +25,7 @@ subroutine scm_setinitial
   integer i, j, k, thelev
   integer inumliq, inumice, icldliq, icldice
 
-  if (.not. use_camiop) then
+  if (.not. use_replay) then
     call cnst_get_ind('NUMLIQ', inumliq, abort=.false.)
     call cnst_get_ind('NUMICE', inumice, abort=.false.)
     call cnst_get_ind('CLDLIQ', icldliq)

--- a/components/cam/src/dynamics/eul/inidat.F90
+++ b/components/cam/src/dynamics/eul/inidat.F90
@@ -21,7 +21,7 @@ module inidat
    use spmd_utils,          only: masterproc, mpicom, mpir8
    use cam_control_mod,     only: ideal_phys, aqua_planet, moist_physics, adiabatic
    use cam_initfiles,       only: initial_file_get_id, topo_file_get_id
-   use scamMod,             only: single_column, use_camiop, have_u, have_v, &
+   use scamMod,             only: single_column, use_replay, have_u, have_v, &
                                   have_cldliq, have_cldice,loniop,latiop,scmlat,scmlon
    use cam_logfile,         only: iulog
    use pio,                 only: file_desc_t, pio_noerr, pio_inq_varid, pio_get_att, &
@@ -233,7 +233,7 @@ contains
     deallocate ( phis_tmp )
 
     if (single_column) then
-       if ( use_camiop ) then
+       if ( use_replay ) then
           fieldname = 'CLAT1'
           call infld(fieldname, fh_ini, 'lon', 'lat', 1, pcols, begchunk, endchunk, &
                clat2d, readvar, gridname='physgrid')

--- a/components/cam/src/dynamics/se/se_single_column_mod.F90
+++ b/components/cam/src/dynamics/se/se_single_column_mod.F90
@@ -90,11 +90,11 @@ subroutine scm_setinitial(elem)
 
 end subroutine scm_setinitial
 
-subroutine scm_setfield(elem,iop_update_surface)
+subroutine scm_setfield(elem,iop_update_phase1)
 
   implicit none
 
-  logical, intent(in) :: iop_update_surface
+  logical, intent(in) :: iop_update_phase1
   type(element_t), intent(inout) :: elem(:)
 
 #ifndef MODEL_THETA_L
@@ -102,9 +102,9 @@ subroutine scm_setfield(elem,iop_update_surface)
   integer i, j, k, ie
 
   do ie=1,nelemd
-    if (have_ps .and. .not. iop_update_surface) elem(ie)%state%ps_v(:,:,:) = psobs 
+    if (have_ps .and. .not. iop_update_phase1) elem(ie)%state%ps_v(:,:,:) = psobs 
     do i=1, PLEV
-      if (have_omega .and. iop_update_surface) elem(ie)%derived%omega_p(:,:,i)=wfld(i)  !     set t to tobs at first
+      if (have_omega .and. iop_update_phase1) elem(ie)%derived%omega_p(:,:,i)=wfld(i)  !     set t to tobs at first
     end do
   end do
 

--- a/components/cam/src/dynamics/se/se_single_column_mod.F90
+++ b/components/cam/src/dynamics/se/se_single_column_mod.F90
@@ -31,7 +31,7 @@ subroutine scm_setinitial(elem)
   integer i, j, k, ie, thelev
   integer inumliq, inumice, icldliq, icldice
 
-  if (.not. use_camiop .and. get_nstep() .eq. 0) then
+  if (.not. use_replay .and. get_nstep() .eq. 0) then
     call cnst_get_ind('NUMLIQ', inumliq, abort=.false.)
     call cnst_get_ind('NUMICE', inumice, abort=.false.)
     call cnst_get_ind('CLDLIQ', icldliq)

--- a/components/cam/src/dynamics/se/se_single_column_mod.F90
+++ b/components/cam/src/dynamics/se/se_single_column_mod.F90
@@ -90,10 +90,11 @@ subroutine scm_setinitial(elem)
 
 end subroutine scm_setinitial
 
-subroutine scm_setfield(elem)
+subroutine scm_setfield(elem,iop_update_surface)
 
   implicit none
 
+  logical, intent(in) :: iop_update_surface
   type(element_t), intent(inout) :: elem(:)
 
 #ifndef MODEL_THETA_L
@@ -101,9 +102,9 @@ subroutine scm_setfield(elem)
   integer i, j, k, ie
 
   do ie=1,nelemd
-    if (have_ps) elem(ie)%state%ps_v(:,:,:) = psobs 
+    if (have_ps .and. .not. iop_update_surface) elem(ie)%state%ps_v(:,:,:) = psobs 
     do i=1, PLEV
-      if (have_omega) elem(ie)%derived%omega_p(:,:,i)=wfld(i)  !     set t to tobs at first
+      if (have_omega .and. iop_update_surface) elem(ie)%derived%omega_p(:,:,i)=wfld(i)  !     set t to tobs at first
     end do
   end do
 

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -448,7 +448,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    type (dyn_export_t), intent(inout) :: dyn_out ! Dynamics export container
    type (element_t), pointer :: elem(:)
    integer :: rc, i, j, k, p, ie, tl_f
-#if (defined BFB_CAM_SCAM_IOP)
+#if (defined BFB_E3SM_SCM_IOP)
    real(r16) :: forcing_temp, forcing_temp_lrg, forcing_temp_lrg_test, threshold
    real(r8) :: forcing_temp_part1(npsq,nlev), forcing_temp_part2(npsq,nlev), forcing_temp_part3(npsq,nlev)
    real(r8) :: forcing_q_part1(npsq,nlev,pcnst), forcing_q_part2(npsq,nlev,pcnst), forcing_q_part3(npsq,nlev,pcnst)
@@ -461,7 +461,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    
    elem => dyn_out%elem
    
-#if (defined BFB_CAM_SCAM_IOP)   
+#if (defined BFB_E3SM_SCM_IOP)   
 
    tl_f = TimeLevel%n0   ! timelevel which was adjusted by physics
    
@@ -492,7 +492,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    call t_stopf  ('dyn_run')
    
    ! Update to get tendency 
-#if (defined BFB_CAM_SCAM_IOP) 
+#if (defined BFB_E3SM_SCM_IOP) 
 
    tl_f = TimeLevel%n0
    
@@ -510,7 +510,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
 	   forcing_temp = (term1 - term2)/term3 - term4
 			
 	   mult_test = 1.0_r16
-	   e_count = 0.0_r8
+	   e_count = 1.0_r8
 	   forcing_temp_lrg_test = forcing_temp
 	   do while((abs(forcing_temp_lrg_test) < threshold) .and. (forcing_temp .ne. 0._r16))
 	     forcing_temp_lrg_test = forcing_temp*mult_test

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -31,7 +31,6 @@ module stepon
    use shr_const_mod,       only: SHR_CONST_PI
 
    implicit none
-   
    private
    save
 
@@ -483,7 +482,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
 #if (defined E3SM_SCM_REPLAY) 
 
    tl_f = TimeLevel%n0
-
+   
    do ie=1,nelemd
      do k=1,nlev
        do j=1,np
@@ -521,7 +520,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
      call outfld('divT3d',forcing_temp,npsq,ie)
      do p=1,pcnst
        call outfld(trim(cnst_name(p))//'_dten',forcing_q(:,:,p),npsq,ie)   
-     enddo    
+     enddo 
      
    enddo
 

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -504,7 +504,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
              ! If B4B results are not desired in the SCM, then we simply need
 	     !  to compute the tendency in r8		
 	     forcing_q(i+(j-1)*np,k,p) = (dyn_in%elem(ie)%state%Q(i,j,k,p) - &
-	       ftmp_q(i,j,k,p,ie))/dtime		
+	        ftmp_q(i,j,k,p,ie))/dtime	
 	   enddo
 	   
 	 enddo
@@ -520,7 +520,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
      call outfld('divT3d',forcing_temp,npsq,ie)
      do p=1,pcnst
        call outfld(trim(cnst_name(p))//'_dten',forcing_q(:,:,p),npsq,ie)   
-     enddo 
+     enddo
      
    enddo
 

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -440,6 +440,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
                out_v(npsq,nlev), out_psv(npsq)  
    real(r8), parameter :: rad2deg = 180.0 / SHR_CONST_PI
    real(r8), parameter :: fac = 1000._r8	
+   integer, parameter :: i8 = selected_int_kind(12)
 !   real(r8) :: term1, term2        
    type(cam_out_t),     intent(inout) :: cam_out(:) ! Output from CAM to surface
    type(physics_state), intent(inout) :: phys_state(begchunk:endchunk)
@@ -448,11 +449,13 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    type (element_t), pointer :: elem(:)
    integer :: rc, i, j, k, p, ie, tl_f
 #if (defined BFB_CAM_SCAM_IOP)
-   real(r16) :: forcing_temp, forcing_temp_lrg, threshold
-   real(r8) :: forcing_temp_part1(npsq,nlev), forcing_temp_part2(npsq,nlev)
-   real(r8) :: forcing_q_part1(npsq,nlev,pcnst), forcing_q_part2(npsq,nlev,pcnst)
-   real(r16) :: mult, term1, term2, term3, term4 
-   integer :: forcing_temp_int
+   real(r16) :: forcing_temp, forcing_temp_lrg, forcing_temp_lrg_test, threshold
+   real(r8) :: forcing_temp_part1(npsq,nlev), forcing_temp_part2(npsq,nlev), forcing_temp_part3(npsq,nlev)
+   real(r8) :: forcing_q_part1(npsq,nlev,pcnst), forcing_q_part2(npsq,nlev,pcnst), forcing_q_part3(npsq,nlev,pcnst)
+   real(r16) :: mult, mult_test, term1, term2, term3, term4 
+   integer(i8) :: forcing_temp_int
+   real(r8) :: forcing_temp_float, mult_float, second_part, e_count
+   real(r16) :: forcing_temp_float_16, second_part_16
    
 #endif
    
@@ -493,7 +496,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
 
    tl_f = TimeLevel%n0
    
-   threshold = 1000._r16
+   threshold = 1.E10_r16
    mult = 1.0_r16
    do ie=1,nelemd
      do k=1,nlev
@@ -506,16 +509,29 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
 	   term4=dyn_in%elem(ie)%derived%FT(i,j,k)
 	   forcing_temp = (term1 - term2)/term3 - term4
 			
-	   mult = 1.0_r16
-	   forcing_temp_lrg = forcing_temp
-	   do while((abs(forcing_temp_lrg) < threshold) .and. (forcing_temp .ne. 0._r16))
-	     forcing_temp_lrg = forcing_temp*mult
-	     if (abs(forcing_temp_lrg) < threshold) mult = mult*10._r16
+	   mult_test = 1.0_r16
+	   e_count = 0.0_r8
+	   forcing_temp_lrg_test = forcing_temp
+	   do while((abs(forcing_temp_lrg_test) < threshold) .and. (forcing_temp .ne. 0._r16))
+	     forcing_temp_lrg_test = forcing_temp*mult_test
+	     if (abs(forcing_temp_lrg_test) < threshold) then
+	       mult_test = mult_test*10._r16
+	       e_count = e_count + 1.0_r8
+	     endif
 	   end do	
 	   
-	   forcing_temp_int = int(forcing_temp_lrg)
-	   forcing_temp_part1(i+(j-1)*np,k)=forcing_temp_int/mult	   
-	   forcing_temp_part2(i+(j-1)*np,k)=(forcing_temp_lrg-forcing_temp_int)/mult
+	   mult=mult_test
+	   forcing_temp_lrg=forcing_temp*mult
+	   forcing_temp_int = int8(forcing_temp_lrg)
+	   forcing_temp_float_16 = forcing_temp_int
+	 
+	   second_part_16 = (forcing_temp_lrg - forcing_temp_float_16)/mult
+	   second_part = second_part_16
+
+	   forcing_temp_float=forcing_temp_float_16
+	   forcing_temp_part1(i+(j-1)*np,k)=forcing_temp_float	   
+	   forcing_temp_part2(i+(j-1)*np,k)=second_part
+	   forcing_temp_part3(i+(j-1)*np,k)=e_count
 		
            out_temp(i+(j-1)*np,k) = dyn_in%elem(ie)%state%T(i,j,k,tl_f)
 	   out_u(i+(j-1)*np,k) = dyn_in%elem(ie)%state%v(i,j,1,k,tl_f)
@@ -528,17 +544,29 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
 	     term2=ftmp_q(i,j,k,p,ie)
 	     term3=dtime	
 	     forcing_temp = (term1 - term2)/term3
-		
-	     mult = 1.0_r16
-	     forcing_temp_lrg = forcing_temp
-	     do while((abs(forcing_temp_lrg) < threshold) .and. (forcing_temp .ne. 0._r16))
-	       forcing_temp_lrg = forcing_temp*mult
-	       if (abs(forcing_temp_lrg) < threshold) mult=mult*10._r16
-	     enddo
 	     
-	     forcing_temp_int = int(forcing_temp_lrg)
-	     forcing_q_part1(i+(j-1)*np,k,p)=forcing_temp_int/mult
-	     forcing_q_part2(i+(j-1)*np,k,p)=(forcing_temp_lrg-forcing_temp_int)/mult
+	     mult_test = 1.0_r16
+	     e_count = 0.0_r8
+	     forcing_temp_lrg_test = forcing_temp
+	     do while((abs(forcing_temp_lrg_test) < threshold) .and. (forcing_temp .ne. 0._r16))
+	       forcing_temp_lrg_test = forcing_temp*mult_test
+	       if (abs(forcing_temp_lrg_test) < threshold) then
+	         mult_test = mult_test*10._r16
+		 e_count = e_count + 1.0_r8
+	       endif
+	     end do	     
+		
+	     mult=mult_test
+	     forcing_temp_lrg=forcing_temp*mult
+	     forcing_temp_int = int8(forcing_temp_lrg)
+	     forcing_temp_float_16 = forcing_temp_int
+	 
+	     second_part_16 = (forcing_temp_lrg - forcing_temp_float_16)/mult
+	     second_part = second_part_16
+	     forcing_temp_float=forcing_temp_float_16
+	     forcing_q_part1(i+(j-1)*np,k,p)=forcing_temp_float	   
+	     forcing_q_part2(i+(j-1)*np,k,p)=second_part
+	     forcing_q_part3(i+(j-1)*np,k,p)=e_count	 
 		
 	   enddo
 	   
@@ -548,6 +576,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
      
      call outfld('divT3d',forcing_temp_part1,npsq,ie)
      call outfld('divT3d_2',forcing_temp_part2,npsq,ie)
+     call outfld('divT3d_3',forcing_temp_part3,npsq,ie)
      call outfld('Ps',out_psv,npsq,ie)
      call outfld('t',out_temp,npsq,ie)
      call outfld('q',out_q,npsq,ie)
@@ -555,7 +584,8 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
      call outfld('v',out_v,npsq,ie)
      do p=1,pcnst
        call outfld(trim(cnst_name(p))//'_dten',forcing_q_part1(:,:,p),npsq,ie) 
-       call outfld(trim(cnst_name(p))//'_dten_2',forcing_q_part2(:,:,p),npsq,ie)  
+       call outfld(trim(cnst_name(p))//'_dten_2',forcing_q_part2(:,:,p),npsq,ie)
+       call outfld(trim(cnst_name(p))//'_dten_3',forcing_q_part3(:,:,p),npsq,ie)  
      enddo
      
    enddo

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -490,21 +490,18 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
 	 
            ! Note that this calculation will not provide b4b results with 
 	   !  an E3SM because the dynamics tendency is not computed in the exact
-	   !  same way as an E3SM run.
+	   !  same way as an E3SM run, introducing error with roundoff 
 	   forcing_temp(i+(j-1)*np,k) = (dyn_in%elem(ie)%state%T(i,j,k,tl_f) - &
-	        ftmp_temp(i,j,k,ie))/dtime - dyn_in%elem(ie)%derived%FT(i,j,k)
-		
+	        ftmp_temp(i,j,k,ie))/dtime - dyn_in%elem(ie)%derived%FT(i,j,k)	
            out_temp(i+(j-1)*np,k) = dyn_in%elem(ie)%state%T(i,j,k,tl_f)
 	   out_u(i+(j-1)*np,k) = dyn_in%elem(ie)%state%v(i,j,1,k,tl_f)
 	   out_v(i+(j-1)*np,k) = dyn_in%elem(ie)%state%v(i,j,2,k,tl_f)
 	   out_q(i+(j-1)*np,k) = dyn_in%elem(ie)%state%Q(i,j,k,1)
 	   out_psv(i+(j-1)*np) = dyn_in%elem(ie)%state%ps_v(i,j,tl_f)
 
-	   do p=1,pcnst	 
-             ! If B4B results are not desired in the SCM, then we simply need
-	     !  to compute the tendency in r8		
+	   do p=1,pcnst	 	
 	     forcing_q(i+(j-1)*np,k,p) = (dyn_in%elem(ie)%state%Q(i,j,k,p) - &
-	        ftmp_q(i,j,k,p,ie))/dtime	
+	        ftmp_q(i,j,k,p,ie))/dtime
 	   enddo
 	   
 	 enddo
@@ -516,7 +513,6 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
      call outfld('q',out_q,npsq,ie)
      call outfld('u',out_u,npsq,ie)
      call outfld('v',out_v,npsq,ie)
-
      call outfld('divT3d',forcing_temp,npsq,ie)
      do p=1,pcnst
        call outfld(trim(cnst_name(p))//'_dten',forcing_q(:,:,p),npsq,ie)   

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -59,7 +59,7 @@ module stepon
 ! !PRIVATE DATA MEMBERS:
 !
 
-  logical :: iop_update_surface
+  logical :: iop_update_phase1
 
   type (derivative_t)   :: deriv           ! derivative struct
   type (quadrature_t)   :: gv,gp           ! quadratures on velocity and pressure grids
@@ -203,9 +203,9 @@ subroutine stepon_run1( dtime_out, phys_state, phys_tend,               &
   end if
   
   if (single_column) then
-    iop_update_surface = .true. 
-    if (doiopupdate) call readiopdata( iop_update_surface,hyam,hybm )
-    call scm_setfield(elem,iop_update_surface)       
+    iop_update_phase1 = .true. 
+    if (doiopupdate) call readiopdata( iop_update_phase1,hyam,hybm )
+    call scm_setfield(elem,iop_update_phase1)       
   endif 
   
    call t_barrierf('sync_d_p_coupling', mpicom)
@@ -465,11 +465,11 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
      
      ! Update IOP properties e.g. omega, divT, divQ
      
-     iop_update_surface = .false. 
+     iop_update_phase1 = .false. 
      if (doiopupdate) then
        call scm_setinitial(elem)
-       call readiopdata(iop_update_surface,hyam,hybm)
-       call scm_setfield(elem,iop_update_surface)
+       call readiopdata(iop_update_phase1,hyam,hybm)
+       call scm_setfield(elem,iop_update_phase1)
      endif   
 
    endif   

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -448,7 +448,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    type (dyn_export_t), intent(inout) :: dyn_out ! Dynamics export container
    type (element_t), pointer :: elem(:)
    integer :: rc, i, j, k, p, ie, tl_f
-#if (defined BFB_E3SM_SCM_IOP)
+#if (defined E3SM_SCM_REPLAY)
    real(r16) :: forcing_temp, forcing_temp_lrg, forcing_temp_lrg_test, threshold
    real(r8) :: forcing_temp_part1(npsq,nlev), forcing_temp_part2(npsq,nlev), forcing_temp_part3(npsq,nlev)
    real(r8) :: forcing_q_part1(npsq,nlev,pcnst), forcing_q_part2(npsq,nlev,pcnst), forcing_q_part3(npsq,nlev,pcnst)
@@ -461,7 +461,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    
    elem => dyn_out%elem
    
-#if (defined BFB_E3SM_SCM_IOP)   
+#if (defined E3SM_SCM_REPLAY)   
 
    tl_f = TimeLevel%n0   ! timelevel which was adjusted by physics
    
@@ -492,7 +492,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    call t_stopf  ('dyn_run')
    
    ! Update to get tendency 
-#if (defined BFB_E3SM_SCM_IOP) 
+#if (defined E3SM_SCM_REPLAY) 
 
    tl_f = TimeLevel%n0
    

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -440,7 +440,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
                out_v(npsq,nlev), out_psv(npsq)  
    real(r8), parameter :: rad2deg = 180.0 / SHR_CONST_PI
    real(r8), parameter :: fac = 1000._r8	
-   real(r8) :: term1, term2        
+!   real(r8) :: term1, term2        
    type(cam_out_t),     intent(inout) :: cam_out(:) ! Output from CAM to surface
    type(physics_state), intent(inout) :: phys_state(begchunk:endchunk)
    type (dyn_import_t), intent(inout) :: dyn_in  ! Dynamics import container
@@ -451,7 +451,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
    real(r16) :: forcing_temp, forcing_temp_lrg, threshold
    real(r8) :: forcing_temp_part1(npsq,nlev), forcing_temp_part2(npsq,nlev)
    real(r8) :: forcing_q_part1(npsq,nlev,pcnst), forcing_q_part2(npsq,nlev,pcnst)
-   real(r16) :: mult 
+   real(r16) :: mult, term1, term2, term3, term4 
    integer :: forcing_temp_int
    
 #endif
@@ -500,8 +500,11 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
        do j=1,np
          do i=1,np
 	 
-	   forcing_temp = (dyn_in%elem(ie)%state%T(i,j,k,tl_f) - &
-	        ftmp_temp(i,j,k,ie))/dtime - dyn_in%elem(ie)%derived%FT(i,j,k)
+	   term1=dyn_in%elem(ie)%state%T(i,j,k,tl_f)
+	   term2=ftmp_temp(i,j,k,ie)
+	   term3=dtime
+	   term4=dyn_in%elem(ie)%derived%FT(i,j,k)
+	   forcing_temp = (term1 - term2)/term3 - term4
 			
 	   mult = 1.0_r16
 	   forcing_temp_lrg = forcing_temp
@@ -520,9 +523,11 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
 	   out_q(i+(j-1)*np,k) = dyn_in%elem(ie)%state%Q(i,j,k,1)
 	   out_psv(i+(j-1)*np) = dyn_in%elem(ie)%state%ps_v(i,j,tl_f)
 
-	   do p=1,pcnst		
-	     forcing_temp = (dyn_in%elem(ie)%state%Q(i,j,k,p) - &
-	        ftmp_q(i,j,k,p,ie))/dtime
+	   do p=1,pcnst	
+	     term1=dyn_in%elem(ie)%state%Q(i,j,k,p)
+	     term2=ftmp_q(i,j,k,p,ie)
+	     term3=dtime	
+	     forcing_temp = (term1 - term2)/term3
 		
 	     mult = 1.0_r16
 	     forcing_temp_lrg = forcing_temp

--- a/components/cam/src/dynamics/se/stepon.F90
+++ b/components/cam/src/dynamics/se/stepon.F90
@@ -204,7 +204,7 @@ subroutine stepon_run1( dtime_out, phys_state, phys_tend,               &
   if (single_column) then
     iop_update_surface = .true. 
     if (doiopupdate) call readiopdata( iop_update_surface,hyam,hybm )
-    call scm_setfield(elem)       
+    call scm_setfield(elem,iop_update_surface)       
   endif 
   
    call t_barrierf('sync_d_p_coupling', mpicom)
@@ -467,7 +467,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
      if (doiopupdate) then
        call scm_setinitial(elem)
        call readiopdata(iop_update_surface,hyam,hybm)
-       call scm_setfield(elem)
+       call scm_setfield(elem,iop_update_surface)
      endif   
 
    endif   

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -906,7 +906,7 @@ end subroutine diag_conv_tend_ini
 
 
 
-#if (defined BFB_CAM_SCAM_IOP )
+#if (defined BFB_E3SM_SCM_IOP )
     call outfld('phis    ',state%phis,    pcols,   lchnk     )
 #endif
 
@@ -1064,7 +1064,7 @@ end subroutine diag_conv_tend_ini
 
     call outfld('OMEGA   ',state%omega,    pcols,   lchnk     )
 
-#if (defined BFB_CAM_SCAM_IOP )
+#if (defined BFB_E3SM_SCM_IOP )
     call outfld('omega   ',state%omega,    pcols,   lchnk     )
 #endif
 
@@ -1481,7 +1481,7 @@ subroutine diag_conv(state, ztodt, pbuf)
    call outfld('PRECLav ', precl, pcols, lchnk )
    call outfld('PRECCav ', precc, pcols, lchnk )
 
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
    call outfld('Prec   ' , prect, pcols, lchnk )
 #endif
 
@@ -1574,7 +1574,7 @@ subroutine diag_surf (cam_in, cam_out, ps, trefmxav, trefmnav )
     call outfld('RHREFHT',   ftem,      pcols, lchnk)
 
 
-#if (defined BFB_CAM_SCAM_IOP )
+#if (defined BFB_E3SM_SCM_IOP )
     call outfld('shflx   ',cam_in%shf,   pcols,   lchnk)
     call outfld('lhflx   ',cam_in%lhf,   pcols,   lchnk)
     call outfld('trefht  ',cam_in%tref,  pcols,   lchnk)

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -1579,6 +1579,7 @@ subroutine diag_surf (cam_in, cam_out, ps, trefmxav, trefmnav )
     call outfld('lhflx   ',cam_in%lhf,   pcols,   lchnk)
     call outfld('trefht  ',cam_in%tref,  pcols,   lchnk)
     call outfld('Tg', cam_in%ts, pcols, lchnk)
+    call outfld('Tsair',cam_in%ts, pcols, lchnk)
 #endif
 !
 ! Ouput ocn and ice fractions

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -906,7 +906,7 @@ end subroutine diag_conv_tend_ini
 
 
 
-#if (defined BFB_E3SM_SCM_IOP )
+#if (defined E3SM_SCM_REPLAY )
     call outfld('phis    ',state%phis,    pcols,   lchnk     )
 #endif
 
@@ -1064,7 +1064,7 @@ end subroutine diag_conv_tend_ini
 
     call outfld('OMEGA   ',state%omega,    pcols,   lchnk     )
 
-#if (defined BFB_E3SM_SCM_IOP )
+#if (defined E3SM_SCM_REPLAY )
     call outfld('omega   ',state%omega,    pcols,   lchnk     )
 #endif
 
@@ -1481,7 +1481,7 @@ subroutine diag_conv(state, ztodt, pbuf)
    call outfld('PRECLav ', precl, pcols, lchnk )
    call outfld('PRECCav ', precc, pcols, lchnk )
 
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
    call outfld('Prec   ' , prect, pcols, lchnk )
 #endif
 
@@ -1574,7 +1574,7 @@ subroutine diag_surf (cam_in, cam_out, ps, trefmxav, trefmnav )
     call outfld('RHREFHT',   ftem,      pcols, lchnk)
 
 
-#if (defined BFB_E3SM_SCM_IOP )
+#if (defined E3SM_SCM_REPLAY )
     call outfld('shflx   ',cam_in%shf,   pcols,   lchnk)
     call outfld('lhflx   ',cam_in%lhf,   pcols,   lchnk)
     call outfld('trefht  ',cam_in%tref,  pcols,   lchnk)

--- a/components/cam/src/physics/cam/check_energy.F90
+++ b/components/cam/src/physics/cam/check_energy.F90
@@ -814,7 +814,7 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
 !------------------------------Arguments--------------------------------
 
     use cam_history, only: outfld
-    use scamMod, only: heat_glob_scm, single_column, use_camiop
+    use scamMod, only: heat_glob_scm, single_column, use_replay
 
     type(physics_state), intent(in   ) :: state
     type(physics_ptend), intent(out)   :: ptend
@@ -838,13 +838,13 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
     heat_glob = 0._r8
 #endif
 ! add (-) global mean total energy difference as heating
-    if (single_column .and. use_camiop) then
+    if (single_column .and. use_replay) then
       heat_glob = heat_glob_scm(1)
     endif
     ptend%s(:ncol,:pver) = heat_glob
 !!$    write(iulog,*) "chk_fix: heat", state%lchnk, ncol, heat_glob
 
-#if ( defined BFB_CAM_SCAM_IOP )
+#if ( defined BFB_E3SM_SCM_IOP )
     if (nstep > 0) then
       heat_out(:ncol) = heat_glob
       call outfld('heat_glob',  heat_out(:ncol), pcols, lchnk)

--- a/components/cam/src/physics/cam/check_energy.F90
+++ b/components/cam/src/physics/cam/check_energy.F90
@@ -844,7 +844,7 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
     ptend%s(:ncol,:pver) = heat_glob
 !!$    write(iulog,*) "chk_fix: heat", state%lchnk, ncol, heat_glob
 
-#if ( defined BFB_E3SM_SCM_IOP )
+#if ( defined E3SM_SCM_REPLAY )
     if (nstep > 0) then
       heat_out(:ncol) = heat_glob
       call outfld('heat_glob',  heat_out(:ncol), pcols, lchnk)

--- a/components/cam/src/physics/cam/iop_surf.F90
+++ b/components/cam/src/physics/cam/iop_surf.F90
@@ -30,7 +30,7 @@ subroutine scam_use_iop_srf( cam_in )
      !       preserve the cold-start that is used in the full model
      !       Else, temperature should be initialized as specified 
      !       in the IOP forcing file 
-             if (use_camiop .and. is_first_step()) then
+             if (use_replay .and. is_first_step()) then
                cam_in(c)%ts(:ncol) = cam_in(c)%ts(:ncol)
                cam_in(c)%lwup(:ncol) = cam_in(c)%lwup(:ncol) 
              else 

--- a/components/cam/src/physics/cam/iop_surf.F90
+++ b/components/cam/src/physics/cam/iop_surf.F90
@@ -4,7 +4,6 @@ subroutine scam_use_iop_srf( cam_in )
     use camsrfexch,       only: cam_in_t    
     use physconst,   only: stebol, latvap
     use scamMod
-    use time_manager, only : is_first_step
 
     implicit none
     save
@@ -25,7 +24,7 @@ subroutine scam_use_iop_srf( cam_in )
              cam_in(c)%cflx(:ncol,1) = lhflxobs(1)/latvap
           endif
           if(have_shflx) cam_in(c)%shf(:ncol) = shflxobs(1)
-          if(have_tg) then 
+          if(have_tg) then
              cam_in(c)%ts(:ncol) = tground(1)
              cam_in(c)%lwup(:ncol) = stebol * tground(1)**4
           endif

--- a/components/cam/src/physics/cam/iop_surf.F90
+++ b/components/cam/src/physics/cam/iop_surf.F90
@@ -25,18 +25,9 @@ subroutine scam_use_iop_srf( cam_in )
              cam_in(c)%cflx(:ncol,1) = lhflxobs(1)/latvap
           endif
           if(have_shflx) cam_in(c)%shf(:ncol) = shflxobs(1)
-          if(have_tg) then
-     !       For bit-4-bit reproducibility in Replay mode, 
-     !       preserve the cold-start that is used in the full model
-     !       Else, temperature should be initialized as specified 
-     !       in the IOP forcing file 
-             if (use_replay .and. is_first_step()) then
-               cam_in(c)%ts(:ncol) = cam_in(c)%ts(:ncol)
-               cam_in(c)%lwup(:ncol) = cam_in(c)%lwup(:ncol) 
-             else 
-               cam_in(c)%ts(:ncol) = tground(1)
-               cam_in(c)%lwup(:ncol) = stebol * tground(1)**4
-             endif
+          if(have_tg) then 
+             cam_in(c)%ts(:ncol) = tground(1)
+             cam_in(c)%lwup(:ncol) = stebol * tground(1)**4
           endif
        end do
     endif

--- a/components/cam/src/physics/cam/iop_surf.F90
+++ b/components/cam/src/physics/cam/iop_surf.F90
@@ -4,6 +4,7 @@ subroutine scam_use_iop_srf( cam_in )
     use camsrfexch,       only: cam_in_t    
     use physconst,   only: stebol, latvap
     use scamMod
+    use time_manager, only : is_first_step
 
     implicit none
     save
@@ -25,8 +26,17 @@ subroutine scam_use_iop_srf( cam_in )
           endif
           if(have_shflx) cam_in(c)%shf(:ncol) = shflxobs(1)
           if(have_tg) then
-             cam_in(c)%ts(:ncol) = tground(1)
-             cam_in(c)%lwup(:ncol) = stebol * tground(1)**4
+     !       For bit-4-bit reproducibility in Replay mode, 
+     !       preserve the cold-start that is used in the full model
+     !       Else, temperature should be initialized as specified 
+     !       in the IOP forcing file 
+             if (use_camiop .and. is_first_step()) then
+               cam_in(c)%ts(:ncol) = cam_in(c)%ts(:ncol)
+               cam_in(c)%lwup(:ncol) = cam_in(c)%lwup(:ncol) 
+             else 
+               cam_in(c)%ts(:ncol) = tground(1)
+               cam_in(c)%lwup(:ncol) = stebol * tground(1)**4
+             endif
           endif
        end do
     endif

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -938,7 +938,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
     use check_energy,   only: check_energy_gmean
 
     use physics_buffer,         only: physics_buffer_desc, pbuf_get_chunk, pbuf_allocate
-#if (defined BFB_CAM_SCAM_IOP )
+#if (defined BFB_E3SM_SCM_IOP )
     use cam_history,    only: outfld
 #endif
     use comsrf,         only: fsns, fsnt, flns, sgh, sgh30, flnt, landm, fsds

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -938,7 +938,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
     use check_energy,   only: check_energy_gmean
 
     use physics_buffer,         only: physics_buffer_desc, pbuf_get_chunk, pbuf_allocate
-#if (defined BFB_E3SM_SCM_IOP )
+#if (defined E3SM_SCM_REPLAY )
     use cam_history,    only: outfld
 #endif
     use comsrf,         only: fsns, fsnt, flns, sgh, sgh30, flnt, landm, fsds

--- a/components/cice/src/source/ice_grid.F90
+++ b/components/cice/src/source/ice_grid.F90
@@ -1191,7 +1191,7 @@
             tinyarea(i,j,iblk) = puny*tarea(i,j,iblk)
 
             if (single_column) then
-               ULAT  (i,j,iblk) = TLAT(i,j,iblk)+(pi/nj)  
+               ULAT  (i,j,iblk) = TLAT(i,j,iblk)+(pi/ni)  
             else
                if (ny_global == 1) then
                   ULAT  (i,j,iblk) = TLAT(i,j,iblk)

--- a/components/clm/src/main/ncdio_pio.F90.in
+++ b/components/clm/src/main/ncdio_pio.F90.in
@@ -500,6 +500,12 @@ contains
        ier = pio_inq_dimlen(ncid, dimid, ni)
        if (ier == PIO_NOERR) nj = 1
     end if
+    
+    ier = pio_inq_dimid (ncid, 'topounit', dimid)
+    if (ier == PIO_NOERR) then
+       ier = pio_inq_dimlen(ncid, dimid, ni)
+       if (ier == PIO_NOERR) nj = 1
+    end if       
 
     call pio_seterrorhandling(ncid, PIO_INTERNAL_ERROR)
 
@@ -2026,7 +2032,7 @@ end subroutine ncd_io_{DIMS}d_{TYPE}_glob
        if ( trim(dimname)=='nj'.or. trim(dimname)=='lat'.or. trim(dimname)=='lsmlat') then
           start(i)=latidx
           count(i)=1
-       else if ( trim(dimname)=='ni'.or. trim(dimname)=='lon'.or. trim(dimname)=='lsmlon' .or. trim(dimname)=='gridcell') then
+       else if ( trim(dimname)=='ni'.or. trim(dimname)=='lon'.or. trim(dimname)=='lsmlon' .or. trim(dimname)=='gridcell' .or. trim(dimname)=='topounit') then
           start(i)=lonidx
           count(i)=1
        else if ( trim(dimname)=='column') then


### PR DESCRIPTION
This PR improves the accuracy of the SCM Replay mode.  Previous implementation allowed the user to “replicate the behavior” of an E3SM run in SCM, but with temperature errors on the order of ~0.1 K after a day.  This PR will provide the user with capability to produce “quasi-bit-for-bit” results with Replay mode, with temperature errors on the order of ~1.e-5 K.  

The reason why Replay mode is unable to provide fully B4B results is because the dynamics tendency computed for Replay is not identical to the way that the full model computes its dynamics tendencies (which involves sub-cycling in the SE dynamical core).  Thus, there is issue with roundoff.  Note that in the past, CAM Replay mode with Eulerian dy-core could produce “B4B” results but only because if the flag to generate Replay mode output was turned on, they updated their T and Q based on the tendency computed for Replay purposes.  Thus the run to generate Replay forcing was NOT b4b with a normal production run.  We are working on a truly B4B Replay mode for E3SM and a future PR will support this which will involve higher precision computation of the dynamical tendencies.    

This PR also renames the old “-camiop” flag to “-e3smreplay” flag to be more current and consistent with E3SM.  Other flags are renamed accordingly throughout the code.

Note that in this PR the e3sm_developer test “SMS_R_Ld5.ne4_ne4.FSCM5A97” is an expected fail when comparing results to baseline.  This is because where the large-scale vertical velocity is read in and updated had to be moved so that CLUBB could see it at the consistent timestep.  It was validated that results for selected tested cases (ARM97, GOAMAZON, DYCOMS-RF01, BOMEX) have very minimal impacts with this fix included.  

All other e3sm_developer tests pass. 