### PR TITLE
tweak so HOMME test case only builds needed executables

### DIFF
--- a/cime/scripts/lib/CIME/SystemTests/homme.py
+++ b/cime/scripts/lib/CIME/SystemTests/homme.py
@@ -45,7 +45,7 @@ class HOMME(SystemTestsCommon):
             cmake_cmd = "cmake -C {0}/components/homme/cmake/machineFiles/{1}.cmake -DUSE_NUM_PROCS={2} {0}/components/homme -DHOMME_BASELINE_DIR={3}/{4} -DCPRNC_DIR={5}/..".format(srcroot, mach, procs, baselinedir, basename, cprnc)
 
             run_cmd_no_fail(cmake_cmd, arg_stdout="homme.bldlog", combine_output=True, from_dir=exeroot)
-            run_cmd_no_fail("{} -j{} VERBOSE=1".format(gmake, gmake_j), arg_stdout="homme.bldlog", combine_output=True, from_dir=exeroot)
+            run_cmd_no_fail("{} -j{} VERBOSE=1 test-execs".format(gmake, gmake_j), arg_stdout="homme.bldlog", combine_output=True, from_dir=exeroot)
 
             post_build(self._case, [os.path.join(exeroot, "homme.bldlog")], build_complete=True)
 

--- a/components/homme/cmake/HommeMacros.cmake
+++ b/components/homme/cmake/HommeMacros.cmake
@@ -570,6 +570,9 @@ macro(createTest testFile)
 
     ADD_DEPENDENCIES(${THIS_TEST_INDIV} ${EXEC_NAME})
 
+    # test execs
+    ADD_DEPENDENCIES(test-execs ${EXEC_NAME})
+
     # Check target
     ADD_DEPENDENCIES(check ${EXEC_NAME})
 

--- a/components/homme/test_execs/CMakeLists.txt
+++ b/components/homme/test_execs/CMakeLists.txt
@@ -127,6 +127,9 @@ CONFIGURE_FILE(${HOMME_SOURCE_DIR}/test/reg_test/run_tests/testing-utils.sh
 CONFIGURE_FILE(${HOMME_SOURCE_DIR}/test/reg_test/run_tests/diffTol.py
                ${CMAKE_BINARY_DIR}/tests/diffTol.py COPYONLY)
 
+# create list of all executables needed by tests
+ADD_CUSTOM_TARGET(test-execs)
+
 ADD_CUSTOM_TARGET(check 
                   COMMAND ${CMAKE_CTEST_COMMAND} "--output-on-failure")
 


### PR DESCRIPTION
fix CIME interface to HOMME tests so that they only compile executables necessary for the tests

should reduce compilation time and fix a recent failure on sandiatoss3 where CIME doesn't run the tests due to a compiler error when compiling an obsolete target.  

this PR only impacts the CIME/HOMME test driver - recommend skipping integration and merge straight to next and master

[BFB]