### PR TITLE
Update MPAS-O: 3d varying GM bolus and 2d varying phase speed

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -616,6 +616,10 @@ add_default($nl, 'config_GM_Bolus_cell_size_max');
 add_default($nl, 'config_Redi_kappa');
 add_default($nl, 'config_gravWaveSpeed_trunc');
 add_default($nl, 'config_max_relative_slope');
+add_default($nl, 'config_gm_lat_variable_c2');
+add_default($nl, 'config_gm_kappa_lat_depth_variable');
+add_default($nl, 'config_gm_min_stratification_ratio');
+add_default($nl, 'config_gm_min_phase_speed');
 
 ####################################
 # Namelist group: hmix_del2_tensor #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -603,6 +603,10 @@ add_default($nl, 'config_Leith_visc2_max');
 ###################################################
 
 add_default($nl, 'config_use_standardGM');
+add_default($nl, 'config_gm_lat_variable_c2');
+add_default($nl, 'config_gm_kappa_lat_depth_variable');
+add_default($nl, 'config_gm_min_stratification_ratio');
+add_default($nl, 'config_gm_min_phase_speed');
 add_default($nl, 'config_use_Redi_surface_layer_tapering');
 add_default($nl, 'config_Redi_surface_layer_tapering_extent');
 add_default($nl, 'config_use_Redi_bottom_layer_tapering');
@@ -616,10 +620,6 @@ add_default($nl, 'config_GM_Bolus_cell_size_max');
 add_default($nl, 'config_Redi_kappa');
 add_default($nl, 'config_gravWaveSpeed_trunc');
 add_default($nl, 'config_max_relative_slope');
-add_default($nl, 'config_gm_lat_variable_c2');
-add_default($nl, 'config_gm_kappa_lat_depth_variable');
-add_default($nl, 'config_gm_min_stratification_ratio');
-add_default($nl, 'config_gm_min_phase_speed');
 
 ####################################
 # Namelist group: hmix_del2_tensor #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -144,6 +144,10 @@ add_default($nl, 'config_Leith_visc2_max');
 ###################################################
 
 add_default($nl, 'config_use_standardGM');
+add_default($nl, 'config_gm_lat_variable_c2');
+add_default($nl, 'config_gm_kappa_lat_depth_variable');
+add_default($nl, 'config_gm_min_stratification_ratio');
+add_default($nl, 'config_gm_min_phase_speed');
 add_default($nl, 'config_use_Redi_surface_layer_tapering');
 add_default($nl, 'config_Redi_surface_layer_tapering_extent');
 add_default($nl, 'config_use_Redi_bottom_layer_tapering');
@@ -157,10 +161,6 @@ add_default($nl, 'config_GM_Bolus_cell_size_max');
 add_default($nl, 'config_Redi_kappa');
 add_default($nl, 'config_gravWaveSpeed_trunc');
 add_default($nl, 'config_max_relative_slope');
-add_default($nl, 'config_gm_lat_variable_c2');
-add_default($nl, 'config_gm_kappa_lat_depth_variable');
-add_default($nl, 'config_gm_min_stratification_ratio');
-add_default($nl, 'config_gm_min_phase_speed');
 
 ####################################
 # Namelist group: hmix_del2_tensor #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -157,6 +157,10 @@ add_default($nl, 'config_GM_Bolus_cell_size_max');
 add_default($nl, 'config_Redi_kappa');
 add_default($nl, 'config_gravWaveSpeed_trunc');
 add_default($nl, 'config_max_relative_slope');
+add_default($nl, 'config_gm_lat_variable_c2');
+add_default($nl, 'config_gm_kappa_lat_depth_variable');
+add_default($nl, 'config_gm_min_stratification_ratio');
+add_default($nl, 'config_gm_min_phase_speed');
 
 ####################################
 # Namelist group: hmix_del2_tensor #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -168,6 +168,10 @@
 <config_use_standardGM ocn_grid="oRRS15to5">.false.</config_use_standardGM>
 <config_use_standardGM ocn_grid="oARRM60to10">.false.</config_use_standardGM>
 <config_use_standardGM ocn_grid="oARRM60to6">.false.</config_use_standardGM>
+<config_gm_lat_variable_c2>.true.</config_gm_lat_variable_c2>
+<config_gm_kappa_lat_depth_variable>.true.</config_gm_kappa_lat_depth_variable>
+<config_gm_min_stratification_ratio>0.1</config_gm_min_stratification_ratio>
+<config_gm_min_phase_speed>0.1</config_gm_min_phase_speed>
 <config_use_Redi_surface_layer_tapering>.false.</config_use_Redi_surface_layer_tapering>
 <config_Redi_surface_layer_tapering_extent>0.0</config_Redi_surface_layer_tapering_extent>
 <config_use_Redi_bottom_layer_tapering>.false.</config_use_Redi_bottom_layer_tapering>
@@ -182,10 +186,6 @@
 <config_Redi_kappa>0.0</config_Redi_kappa>
 <config_gravWaveSpeed_trunc>0.3</config_gravWaveSpeed_trunc>
 <config_max_relative_slope>0.01</config_max_relative_slope>
-<config_gm_min_phase_speed>0.1</config_gm_min_phase_speed>
-<config_gm_min_stratification_ratio>0.1</config_gm_min_stratification_ratio>
-<config_gm_kappa_lat_depth_variable>.true.</config_gm_kappa_lat_depth_variable>
-<config_gm_lat_variable_c2>.true.</config_gm_lat_variable_c2>
 
 <!-- hmix_del2_tensor -->
 <config_use_mom_del2_tensor>.false.</config_use_mom_del2_tensor>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -182,6 +182,10 @@
 <config_Redi_kappa>0.0</config_Redi_kappa>
 <config_gravWaveSpeed_trunc>0.3</config_gravWaveSpeed_trunc>
 <config_max_relative_slope>0.01</config_max_relative_slope>
+<config_gm_min_phase_speed>0.1</config_gm_min_phase_speed>
+<config_gm_min_stratification_ratio>0.1</config_gm_min_stratification_ratio>
+<config_gm_kappa_lat_depth_variable>.true.</config_gm_kappa_lat_depth_variable>
+<config_gm_lat_variable_c2>.true.</config_gm_lat_variable_c2>
 
 <!-- hmix_del2_tensor -->
 <config_use_mom_del2_tensor>.false.</config_use_mom_del2_tensor>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -585,6 +585,38 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_gm_lat_variable_c2" type="logical"
+	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+If true, spatially variable phase speed is used Following Ferrari et al (2010)
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gm_kappa_lat_depth_variable" type="logical"
+	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+If true, spatitally and deph varying Bolus Kappa is used, following Danabasoglu et al (2007)
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gm_min_stratification_ratio" type="real"
+	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+minimum value for N2/Nmax2 ratio
+
+Valid values: small positive reals
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gm_min_phase_speed" type="real"
+	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+minimum allowed phase speed for spatially variable computation
+
+Valid values: small positive reals
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_use_Redi_surface_layer_tapering" type="logical"
 	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
 If true, the Redi K33 vertical mixing is limited in and just below the ocean boundary layer.
@@ -689,37 +721,6 @@ Valid values: Positive real numbers
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_gm_lat_variable_c2" type="logical"
-  category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-If true, will include a spattially variable wave speed in the computation, following Ferrarri et al 2010
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_gm_kappa_lat_depth_variable" type="logical"
-  category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-If true, will have a full space and time varying bolus kappa for the GM computation -- follows danabasoglu et al 2007
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_gm_min_stratification_ratio" type="real"
-  category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Minimum stratification ratio in the danabasoglu et al 2007 calculation
-
-Valid values: small positive real numbers
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_gm_min_phase_speed" type="real"
-  category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Minimum value of wave speed for the ferrari et al 2010 calculation
-
-Valid values: small positive real numbers
-Default: Defined in namelist_defaults.xml
-</entry>
 
 <!-- hmix_del2_tensor -->
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -689,6 +689,37 @@ Valid values: Positive real numbers
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_gm_lat_variable_c2" type="logical"
+  category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+If true, will include a spattially variable wave speed in the computation, following Ferrarri et al 2010
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gm_kappa_lat_depth_variable" type="logical"
+  category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+If true, will have a full space and time varying bolus kappa for the GM computation -- follows danabasoglu et al 2007
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gm_min_stratification_ratio" type="real"
+  category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+Minimum stratification ratio in the danabasoglu et al 2007 calculation
+
+Valid values: small positive real numbers
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gm_min_phase_speed" type="real"
+  category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+Minimum value of wave speed for the ferrari et al 2010 calculation
+
+Valid values: small positive real numbers
+Default: Defined in namelist_defaults.xml
+</entry>
 
 <!-- hmix_del2_tensor -->
 

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -821,9 +821,9 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var name="vertGMBolusVelocityTop"/>')
             lines.append('    <var name="GMBolusVelocityZonal"/>')
             lines.append('    <var name="GMBolusVelocityMeridional"/>')
-	    lines.append('    <var name="kappaGM3D"/>')
+            lines.append('    <var name="kappaGM3D"/>')
             lines.append('    <var name="cGMphaseSpeed"/>')
-	    lines.append('    <var name="velocityZonalTimesTemperature_GM"/>')
+            lines.append('    <var name="velocityZonalTimesTemperature_GM"/>')
             lines.append('    <var name="velocityMeridionalTimesTemperature_GM"/>')
 
         lines.append('    <var_struct name="tracersSurfaceFlux"/>')

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -821,6 +821,8 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var name="vertGMBolusVelocityTop"/>')
 	    lines.append('    <var name="kappaGM3D"/>')
             lines.append('    <var name="cGMphaseSpeed"/>')
+	    lines.append('    <var name="velocityZonalTimesTemperature_GM"/>')
+            lines.append('    <var name="velocityMeridionalTimesTemperature_GM"/>')
 
         lines.append('    <var_struct name="tracersSurfaceFlux"/>')
         lines.append('    <var name="penetrativeTemperatureFlux"/>')

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -819,6 +819,8 @@ def buildnml(case, caseroot, compname):
         if not ocn_grid.startswith("oRRS1"):
             lines.append('    <var name="normalGMBolusVelocity"/>')
             lines.append('    <var name="vertGMBolusVelocityTop"/>')
+	    lines.append('    <var name="kappaGM3D"/>')
+            lines.append('    <var name="cGMphaseSpeed"/>')
 
         lines.append('    <var_struct name="tracersSurfaceFlux"/>')
         lines.append('    <var name="penetrativeTemperatureFlux"/>')

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -819,6 +819,8 @@ def buildnml(case, caseroot, compname):
         if not ocn_grid.startswith("oRRS1"):
             lines.append('    <var name="normalGMBolusVelocity"/>')
             lines.append('    <var name="vertGMBolusVelocityTop"/>')
+            lines.append('    <var name="GMBolusVelocityZonal"/>')
+            lines.append('    <var name="GMBolusVelocityMeridional"/>')
 	    lines.append('    <var name="kappaGM3D"/>')
             lines.append('    <var name="cGMphaseSpeed"/>')
 	    lines.append('    <var name="velocityZonalTimesTemperature_GM"/>')


### PR DESCRIPTION
In the GM bolus calculation, there is a specified diffusivity and phase
speed (see Ferrari et al. 2010). Currently MPAS-O assumes these values
are fixed in time and space. This PR allows separate flags to enable
2D varying (+time) phase speed (based on the first baroclinic mode phase
speed) and a separate flag for 3D (+time) varying diffusivity.

See https://github.com/MPAS-Dev/MPAS-Model/pull/288

[NML]
[non-BFB]