### PR TITLE
Update mpas-seaice for snicar and snow grain model

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -785,7 +785,7 @@ add_default($nl, 'config_ratio_C_to_N_proteins');
 
 add_default($nl, 'config_shortwave_type');
 add_default($nl, 'config_albedo_type');
-add_default($nl, 'config_use_snicar');
+add_default($nl, 'config_use_snicar_ad');
 add_default($nl, 'config_visible_ice_albedo');
 add_default($nl, 'config_infrared_ice_albedo');
 add_default($nl, 'config_visible_snow_albedo');

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -324,7 +324,7 @@ add_default($nl, 'config_ratio_C_to_N_proteins');
 
 add_default($nl, 'config_shortwave_type');
 add_default($nl, 'config_albedo_type');
-add_default($nl, 'config_use_snicar');
+add_default($nl, 'config_use_snicar_ad');
 add_default($nl, 'config_visible_ice_albedo');
 add_default($nl, 'config_infrared_ice_albedo');
 add_default($nl, 'config_visible_snow_albedo');

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -304,7 +304,7 @@
 <!-- shortwave -->
 <config_shortwave_type>'dEdd'</config_shortwave_type>
 <config_albedo_type>'ccsm3'</config_albedo_type>
-<config_use_snicar>false</config_use_snicar>
+<config_use_snicar_ad>false</config_use_snicar_ad>
 <config_visible_ice_albedo>0.78</config_visible_ice_albedo>
 <config_infrared_ice_albedo>0.36</config_infrared_ice_albedo>
 <config_visible_snow_albedo>0.98</config_visible_snow_albedo>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -1966,9 +1966,9 @@ Valid values: 'ccsm3' or 'constant'
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_use_snicar" type="logical"
+<entry id="config_use_snicar_ad" type="logical"
 	category="shortwave" group="shortwave">
-If true turn on snicar 5-band snow system
+If true turn on snicar_ad 5-band snow system
 
 Valid values: true or false
 Default: Defined in namelist_defaults.xml
@@ -2413,7 +2413,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_ocean_surface_type" type="char*1024"
 	category="ocean" group="ocean">
-Type of coupled ocean surface: (MPASO:'free'), (SOM:'non-free')
+Type of coupled ocean surface: (MPAS-O:'free'), (SOM:'non-free')
 
 Valid values: 'free' or 'non-free'
 Default: Defined in namelist_defaults.xml


### PR DESCRIPTION
This PR brings in a new mpas-source submodule that only updates the mpas-seaice code, as well as the supporting scripts to match. The seaice has changes to:
* the snicar coding (MPAS-Dev/MPAS-Model PR #278);
* snow grain model  (bug fixes)

Because these features are off by default, this PR is BFB but does have a namelist change.

[NML]
[BFB]