### PR TITLE
Fix bug in setting gases above model top for RRTMGP

### DIFF
--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -2321,7 +2321,10 @@ subroutine set_gas_concentrations(icall, state, pbuf, &
 
       ! Map to radiation grid
       vol_mix_ratio_out(1:ncol,ktop:kbot) = vol_mix_ratio(1:ncol,1:pver)
-      vol_mix_ratio_out(1:ncol,1) = vol_mix_ratio(1:ncol,ktop)
+
+      ! Copy top-most model level to top-most rad level (which could be above
+      ! the top of the model)
+      vol_mix_ratio_out(1:ncol,1) = vol_mix_ratio(1:ncol,1)
 
       ! Populate the RRTMGP gas concentration object with values for this gas.
       ! NOTE: RRTMGP makes some assumptions about gas names internally, so we


### PR DESCRIPTION
Fix bug in setting the gases above model top. An extra level is added above the model top in the radiation code to handle heating between the top of the model and the top of the atmosphere. The code in question here was supposed to copy the gases from the top-most model level into the extra level above the model top, but instead we accidentally copied the *second* model level.

[non-BFB] only for the RRTMGP tests.