### PR TITLE
Turn eddyProductVariables AM on by default

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -857,10 +857,6 @@
 
 <!-- AM_eddyProductVariables -->
 <config_AM_eddyProductVariables_enable>.true.</config_AM_eddyProductVariables_enable>
-<config_AM_eddyProductVariables_enable ocn_grid="oQU480">.false.</config_AM_eddyProductVariables_enable>
-<config_AM_eddyProductVariables_enable ocn_grid="oQU240">.false.</config_AM_eddyProductVariables_enable>
-<config_AM_eddyProductVariables_enable ocn_grid="oQU240wLI">.false.</config_AM_eddyProductVariables_enable>
-<config_AM_eddyProductVariables_enable ocn_grid="oQU120">.false.</config_AM_eddyProductVariables_enable>
 <config_AM_eddyProductVariables_compute_interval>'0000-00-00_01:00:00'</config_AM_eddyProductVariables_compute_interval>
 <config_AM_eddyProductVariables_output_stream>'eddyProductVariablesOutput'</config_AM_eddyProductVariables_output_stream>
 <config_AM_eddyProductVariables_compute_on_startup>.true.</config_AM_eddyProductVariables_compute_on_startup>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -856,12 +856,11 @@
 <config_AM_transectTransport_transect_group>'all'</config_AM_transectTransport_transect_group>
 
 <!-- AM_eddyProductVariables -->
-<config_AM_eddyProductVariables_enable>.false.</config_AM_eddyProductVariables_enable>
-<config_AM_eddyProductVariables_enable ocn_grid="oEC60to30v3">.true.</config_AM_eddyProductVariables_enable>
-<config_AM_eddyProductVariables_enable ocn_grid="oEC60to30v3wLI">.true.</config_AM_eddyProductVariables_enable>
-<config_AM_eddyProductVariables_enable ocn_grid="oRRS30to10v3">.true.</config_AM_eddyProductVariables_enable>
-<config_AM_eddyProductVariables_enable ocn_grid="oRRS30to10v3wLI">.true.</config_AM_eddyProductVariables_enable>
-<config_AM_eddyProductVariables_enable ocn_grid="oRRS18to6v3">.true.</config_AM_eddyProductVariables_enable>
+<config_AM_eddyProductVariables_enable>.true.</config_AM_eddyProductVariables_enable>
+<config_AM_eddyProductVariables_enable ocn_grid="oQU480">.false.</config_AM_eddyProductVariables_enable>
+<config_AM_eddyProductVariables_enable ocn_grid="oQU240">.false.</config_AM_eddyProductVariables_enable>
+<config_AM_eddyProductVariables_enable ocn_grid="oQU240wLI">.false.</config_AM_eddyProductVariables_enable>
+<config_AM_eddyProductVariables_enable ocn_grid="oQU120">.false.</config_AM_eddyProductVariables_enable>
 <config_AM_eddyProductVariables_compute_interval>'0000-00-00_01:00:00'</config_AM_eddyProductVariables_compute_interval>
 <config_AM_eddyProductVariables_output_stream>'eddyProductVariablesOutput'</config_AM_eddyProductVariables_output_stream>
 <config_AM_eddyProductVariables_compute_on_startup>.true.</config_AM_eddyProductVariables_compute_on_startup>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -649,7 +649,7 @@ def buildnml(case, caseroot, compname):
         lines.append('        filename_template="mpaso.hist.am.eddyProductVariables.$Y-$M-$D.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')
         lines.append('        reference_time="01-01-01_00:00:00"')
-        lines.append('        output_interval="none"')
+        lines.append('        output_interval="00-01-00_00:00:00"')
         lines.append('        clobber_mode="truncate"')
         lines.append('        packages="eddyProductVariablesAMPKG">')
         lines.append('')


### PR DESCRIPTION
This PR turns the mpas-ocean eddyProductVariables analysis member on by default for all grids. It does not impact any results, just simply adds an output stream. For some ultra-low resolutions, this has previously been turned off, so there may be namelist changes for those tests.

[NML]
[BFB]