### PR TITLE
Change dust emission size distribution and shortwave absorption props

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -335,7 +335,7 @@
 <mam_pom  rad="rrtmg">atm/cam/physprops/ocpho_rrtmg_c130709.nc</mam_pom>
 <mam_soa  rad="rrtmg">atm/cam/physprops/ocphi_rrtmg_c100508.nc</mam_soa>
 <mam_bc   rad="rrtmg">atm/cam/physprops/bcpho_rrtmg_c100508.nc</mam_bc>
-<mam_dst  rad="rrtmg">atm/cam/physprops/dust4_rrtmg_c090521.nc</mam_dst>
+<mam_dst  rad="rrtmg">atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc</mam_dst>
 <mam_ncl  rad="rrtmg">atm/cam/physprops/ssam_rrtmg_c100508.nc</mam_ncl>
 <mam_nh4  rad="rrtmg">atm/cam/physprops/sulfate_rrtmg_c080918.nc</mam_nh4>
 
@@ -389,9 +389,9 @@
 <mam3_mode2_file rad="rrtmg">atm/cam/physprops/mam3_mode2_rrtmg_c110318.nc</mam3_mode2_file>
 <mam3_mode3_file rad="rrtmg">atm/cam/physprops/mam3_mode3_rrtmg_c110318.nc</mam3_mode3_file>
 
-<mam4_mode1_file rad="rrtmg">atm/cam/physprops/mam4_mode1_rrtmg_c130628.nc</mam4_mode1_file>
+<mam4_mode1_file rad="rrtmg">atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc</mam4_mode1_file>
 <mam4_mode2_file rad="rrtmg">atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc</mam4_mode2_file>
-<mam4_mode3_file rad="rrtmg">atm/cam/physprops/mam4_mode3_rrtmg_c130628.nc</mam4_mode3_file>
+<mam4_mode3_file rad="rrtmg">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam4_mode3_file>
 <mam4_mode4_file rad="rrtmg">atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc</mam4_mode4_file>
 
 <mam7_mode1_file rad="rrtmg">atm/cam/physprops/mam7_mode1_rrtmg_c120904.nc</mam7_mode1_file>
@@ -1033,6 +1033,9 @@
 
 <!-- dust emission tuning factor -->
 <dust_emis_fact                                                         >2.76D0</dust_emis_fact>
+<dust_emis_fact          hgrid="ne30np4"   phys="cam5"                  >0.95D0</dust_emis_fact>
+<dust_emis_fact          hgrid="ne120np4"  phys="cam5"                  >1.2D0</dust_emis_fact>
+
 <dust_emis_fact                                         chem="trop_bam"	>4.2D0 </dust_emis_fact>
 <dust_emis_fact                            phys="cam5"                  >0.35D0</dust_emis_fact>
 <dust_emis_fact          hgrid="0.47x0.63" phys="cam5"                  >0.45D0</dust_emis_fact>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
@@ -70,7 +70,7 @@
 <zmconv_ke               > 5E-6      </zmconv_ke>
 <effgw_oro               > 0.25      </effgw_oro>
 <seasalt_emis_scale      > 0.85      </seasalt_emis_scale>
-<dust_emis_fact          > 2.05D0    </dust_emis_fact>
+<dust_emis_fact          > 0.95D0    </dust_emis_fact>
 <clubb_gamma_coef        > 0.32      </clubb_gamma_coef>
 <clubb_gamma_coefb> 0.32      </clubb_gamma_coefb>
 <clubb_C8                > 4.3       </clubb_C8>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6_bgc.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6_bgc.xml
@@ -70,7 +70,7 @@
 <zmconv_ke               > 5E-6      </zmconv_ke>
 <effgw_oro               > 0.25      </effgw_oro>
 <seasalt_emis_scale      > 0.85      </seasalt_emis_scale>
-<dust_emis_fact          > 2.05D0    </dust_emis_fact>
+<dust_emis_fact          > 0.95D0    </dust_emis_fact>
 <clubb_gamma_coef        > 0.32      </clubb_gamma_coef>
 <clubb_gamma_coefb> 0.32      </clubb_gamma_coefb>
 <clubb_C8                > 4.3       </clubb_C8>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-04p2.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-04p2.xml
@@ -60,7 +60,7 @@
 <zmconv_ke>          1.5E-6 </zmconv_ke>
 <effgw_oro>          0.25    </effgw_oro>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
-<dust_emis_fact>     2.05D0 </dust_emis_fact>
+<dust_emis_fact>     0.95D0 </dust_emis_fact>
 <clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <clubb_gamma_coefb>   0.32   </clubb_gamma_coefb>
 <clubb_C8>           4.3    </clubb_C8>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01a.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01a.xml
@@ -55,7 +55,7 @@
 <clubb_C2rt>         1.75D0 </clubb_C2rt>
 <effgw_oro>          0.25    </effgw_oro>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
-<dust_emis_fact>     2.05D0 </dust_emis_fact>
+<dust_emis_fact>     1.2D0 </dust_emis_fact>
 <clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <clubb_gamma_coefb>   0.32   </clubb_gamma_coefb>
 <cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-HR.xml
@@ -65,7 +65,7 @@
 <clubb_C2rt>         1.75D0 </clubb_C2rt>
 <effgw_oro>          0.25    </effgw_oro>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
-<dust_emis_fact>     2.5D0 </dust_emis_fact>
+<dust_emis_fact>     1.2D0 </dust_emis_fact>
 <clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <clubb_gamma_coefb>   0.32   </clubb_gamma_coefb>
 <cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LR.xml
@@ -70,7 +70,7 @@
 <zmconv_ke               > 5E-6      </zmconv_ke>
 <effgw_oro               > 0.25      </effgw_oro>
 <seasalt_emis_scale      > 0.85      </seasalt_emis_scale>
-<dust_emis_fact          > 2.05D0    </dust_emis_fact>
+<dust_emis_fact          > 0.95D0    </dust_emis_fact>
 <clubb_gamma_coef        > 0.32      </clubb_gamma_coef>
 <clubb_gamma_coefb> 0.32      </clubb_gamma_coefb>
 <clubb_C8                > 4.3       </clubb_C8>

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
@@ -65,7 +65,7 @@
 <clubb_C2rt>         1.75D0 </clubb_C2rt>
 <effgw_oro>          0.25    </effgw_oro>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
-<dust_emis_fact>     2.5D0 </dust_emis_fact>
+<dust_emis_fact>     1.2D0 </dust_emis_fact>
 <clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <clubb_gamma_coefb>   0.32   </clubb_gamma_coefb>
 <cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2.xml
@@ -60,7 +60,7 @@
 <zmconv_ke>          1.5E-6 </zmconv_ke>
 <effgw_oro>          0.25    </effgw_oro>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
-<dust_emis_fact>     2.05D0 </dust_emis_fact>
+<dust_emis_fact>     0.95D0 </dust_emis_fact>
 <clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <clubb_gamma_coefb>   0.32   </clubb_gamma_coefb>
 <clubb_C8>           4.3    </clubb_C8>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2_bgc.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2_bgc.xml
@@ -63,7 +63,7 @@
 <zmconv_ke>          1.5E-6 </zmconv_ke>
 <effgw_oro>          0.25    </effgw_oro>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
-<dust_emis_fact>     2.05D0 </dust_emis_fact>
+<dust_emis_fact>     0.95D0 </dust_emis_fact>
 <clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <clubb_gamma_coefb>   0.32   </clubb_gamma_coefb>
 <clubb_C8>           4.3    </clubb_C8>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01a.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01a.xml
@@ -55,7 +55,7 @@
 <clubb_C2rt>         1.75D0 </clubb_C2rt>
 <effgw_oro>          0.25    </effgw_oro>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
-<dust_emis_fact>     2.05D0 </dust_emis_fact>
+<dust_emis_fact>     1.2D0 </dust_emis_fact>
 <clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <clubb_gamma_coefb>   0.32   </clubb_gamma_coefb>
 <cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
@@ -67,7 +67,7 @@
 <zmconv_ke>5.e-6</zmconv_ke>
 <effgw_oro>0.25</effgw_oro>
 <seasalt_emis_scale>0.85</seasalt_emis_scale>
-<dust_emis_fact>2.05D0</dust_emis_fact>
+<dust_emis_fact>0.95D0</dust_emis_fact>
 <clubb_gamma_coef>0.32</clubb_gamma_coef>
 <clubb_gamma_coefb>0.32</clubb_gamma_coefb>
 <clubb_C8>4.3</clubb_C8>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6_bgc.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6_bgc.xml
@@ -67,7 +67,7 @@
 <zmconv_ke               > 5E-6      </zmconv_ke>
 <effgw_oro               > 0.25      </effgw_oro>
 <seasalt_emis_scale      > 0.85      </seasalt_emis_scale>
-<dust_emis_fact          > 2.05D0    </dust_emis_fact>
+<dust_emis_fact          > 0.95D0    </dust_emis_fact>
 <clubb_gamma_coef        > 0.32      </clubb_gamma_coef>
 <clubb_gamma_coefb> 0.32      </clubb_gamma_coefb>
 <clubb_C8                > 4.3       </clubb_C8>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-04p2.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-04p2.xml
@@ -65,7 +65,7 @@
 <zmconv_ke>          1.5E-6 </zmconv_ke>
 <effgw_oro>          0.25    </effgw_oro>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
-<dust_emis_fact>     2.05D0 </dust_emis_fact>
+<dust_emis_fact>     0.95D0 </dust_emis_fact>
 <clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <clubb_gamma_coefb>   0.32   </clubb_gamma_coefb>
 <clubb_C8>           4.3    </clubb_C8>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01a.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01a.xml
@@ -60,7 +60,7 @@
 <clubb_C2rt>         1.75D0 </clubb_C2rt>
 <effgw_oro>          0.25    </effgw_oro>
 <seasalt_emis_scale> 0.85   </seasalt_emis_scale>
-<dust_emis_fact>     2.05D0 </dust_emis_fact>
+<dust_emis_fact>     1.2D0 </dust_emis_fact>
 <clubb_gamma_coef>   0.32   </clubb_gamma_coef>
 <clubb_gamma_coefb>   0.32   </clubb_gamma_coefb>
 <cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>

--- a/components/cam/bld/namelist_files/use_cases/aquaplanet_EAMv1.xml
+++ b/components/cam/bld/namelist_files/use_cases/aquaplanet_EAMv1.xml
@@ -126,7 +126,7 @@
 <zmconv_ke               >1.5E-6    </zmconv_ke>
 <effgw_oro               >0.25      </effgw_oro>
 <seasalt_emis_scale      >0.85      </seasalt_emis_scale>
-<dust_emis_fact          >2.05D0    </dust_emis_fact>
+<dust_emis_fact          >0.95D0    </dust_emis_fact>
 <clubb_gamma_coef        >0.32      </clubb_gamma_coef>
 <clubb_C8                >4.3       </clubb_C8>
 <cldfrc2m_rhmaxi         >1.05D0    </cldfrc2m_rhmaxi>

--- a/components/cam/src/chemistry/modal_aero/dust_model.F90
+++ b/components/cam/src/chemistry/modal_aero/dust_model.F90
@@ -24,7 +24,10 @@ module dust_model
 #if  ( defined MODAL_AERO_3MODE || defined MODAL_AERO_4MODE || defined MODAL_AERO_4MODE_MOM )
   character(len=6), parameter :: dust_names(dust_nbin+dust_nnum) = (/ 'dst_a1', 'dst_a3', 'num_a1', 'num_a3' /)
   real(r8),         parameter :: dust_dmt_grd(dust_nbin+1) = (/ 0.1e-6_r8, 1.0e-6_r8, 10.0e-6_r8/)
-  real(r8),         parameter :: dust_emis_sclfctr(dust_nbin) = (/ 0.032_r8,0.968_r8 /)
+! Zender03: fractions of bin (0.1-1) and bin (1-10) in size 0.1-10
+!  real(r8),         parameter :: dust_emis_sclfctr(dust_nbin) = (/ 0.032_r8,0.968_r8 /)
+! Kok11: fractions of bin (0.1-1) and bin (1-10) in size 0.1-10
+  real(r8),         parameter :: dust_emis_sclfctr(dust_nbin) = (/ 0.011_r8,0.989_r8 /)
 #elif ( defined MODAL_AERO_7MODE || defined MODAL_AERO_9MODE )
   character(len=6), parameter :: dust_names(dust_nbin+dust_nnum) = (/ 'dst_a5', 'dst_a7', 'num_a5', 'num_a7' /)
   real(r8),         parameter :: dust_dmt_grd(dust_nbin+1) = (/ 0.1e-6_r8, 2.0e-6_r8, 10.0e-6_r8/)
@@ -140,7 +143,11 @@ module dust_model
 
           idst = dust_indices(m)
 
-          cflx(i,idst) = sum( -dust_flux_in(i,:) ) &
+       ! Correct the dust input flux calculated by CLM, which uses size distribution in Zender03
+       ! to calculate fraction of bin (0.1-10um) in range (0.1-20um) = 0.87
+       ! based on Kok11, that fraction is 0.73
+!          cflx(i,idst) = sum( -dust_flux_in(i,:) ) &
+          cflx(i,idst) = sum( -dust_flux_in(i,:) ) * 0.73_r8/0.87_r8 &
                * dust_emis_sclfctr(m)*soil_erod(i)/soil_erod_fact*1.15_r8
 
           x_mton = 6._r8 / (pi * dust_density * (dust_dmt_vwr(m)**3._r8))                


### PR DESCRIPTION
Change dust emission size distribution to emit more coarse dust particles. This is consistent
with the recent emission measurement data. Change shortwave absorption properties to
reduce the absorption of dust particles. This results in better agreement with the AERONET
surface measurements of aerosol absorption optical depth.

Change dust_emis_fact for default and all typically used cases including CMIP6 to tune
dust emissions to match the aerosol optical depth constraint with the updated emission
size distribution above.

[CC]
[NML]