### PR TITLE
fix EAM compiler errors and better abort message

### DIFF
--- a/components/cam/src/dynamics/se/interp_mod.F90
+++ b/components/cam/src/dynamics/se/interp_mod.F90
@@ -1,12 +1,12 @@
 module interp_mod
   use cam_logfile,         only: iulog
   use shr_kind_mod,        only: r8 => shr_kind_r8
-  use dimensions_mod,      only: nelemd, np, ne
+  use dimensions_mod,      only: nelem,nelemd, np, ne
   use interpolate_mod,     only: interpdata_t
   use interpolate_mod,     only: interp_lat => lat, interp_lon => lon
   use interpolate_mod,     only: interp_gweight => gweight
   use dyn_grid,            only: elem
-  use spmd_utils,          only: masterproc, iam
+  use spmd_utils,          only: masterproc, iam, npes
   use cam_history_support, only: fillvalue
   use hybrid_mod,          only: hybrid_t, hybrid_create
   use cam_abortutils,      only: endrun
@@ -70,8 +70,11 @@ CONTAINS
     character(len=max_hcoordname_len)  :: gridname
 
     if(any(interp_output)) then
-       if (.not. par%dynproc) &
-       call endrun('setup_history_interpolation: interpolated output not supported if atm_ntasks>dyn_npes')
+       if (par%nprocs /= npes ) then
+          write(iulog,*) 'Atmopshere MPI tasks:  atm_ntasks=',npes
+          write(iulog,*) 'SE dycore MPI tasks, number of elements:',par%nprocs,nelem
+          call endrun('setup_history_interpolation: interpolated output not supported if atm_ntasks>dyn_npes')
+       endif
     endif
 
     if (associated(cam_interpolate)) then

--- a/components/cam/src/dynamics/se/interp_mod.F90
+++ b/components/cam/src/dynamics/se/interp_mod.F90
@@ -262,7 +262,7 @@ CONTAINS
     if(decomp_type==phys_decomp) then
        fld_dyn = -999_R8
        if(local_dp_map) then
-          !$omp parallel do private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, ioff)
+          !$omp parallel do private (lchnk, ncols, pgcols, icol, k, idmb1, idmb2, idmb3, ie, ioff)
           do lchnk=begchunk,endchunk
              ncols=get_ncols_p(lchnk)
              call get_gcol_all_p(lchnk,pcols,pgcols)
@@ -281,7 +281,7 @@ CONTAINS
           allocate( bbuffer(block_buf_nrecs*numlev) )
           allocate( cbuffer(chunk_buf_nrecs*numlev) )
 
-          !$omp parallel do private (lchnk, ncols, cpter, i, icol)
+          !$omp parallel do private (lchnk, ncols, cpter, i,k, icol)
           do lchnk = begchunk,endchunk
              ncols = get_ncols_p(lchnk)
 
@@ -301,7 +301,7 @@ CONTAINS
 
           call transpose_chunk_to_block(1, cbuffer, bbuffer)
           if(par%dynproc) then
-             !$omp parallel do private (ie, bpter, icol)
+             !$omp parallel do private (ie, bpter, icol, ncols, k)
              do ie=1,nelemd
 
                 call chunk_to_block_recv_pters(elem(ie)%GlobalID,npsq,pverp,1,bpter)
@@ -455,7 +455,7 @@ CONTAINS
     if(decomp_type==phys_decomp) then
        allocate(dest(np,np,2,numlev,nelemd))
        if(local_dp_map) then
-          !$omp parallel do private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, ioff)
+          !$omp parallel do private (lchnk, ncols, pgcols, icol, k, idmb1, idmb2, idmb3, ie, ioff)
           do lchnk=begchunk,endchunk
              ncols=get_ncols_p(lchnk)
              call get_gcol_all_p(lchnk,pcols,pgcols)
@@ -497,7 +497,7 @@ CONTAINS
 
           call transpose_chunk_to_block(2, cbuffer, bbuffer)
           if(par%dynproc) then
-             !$omp parallel do private (ie, bpter, icol)
+             !$omp parallel do private (ie, bpter, icol, ncols, k)
              do ie=1,nelemd
                 
                 call chunk_to_block_recv_pters(elem(ie)%GlobalID,npsq,pverp,2,bpter)

--- a/components/cam/src/dynamics/se/interp_mod.F90
+++ b/components/cam/src/dynamics/se/interp_mod.F90
@@ -69,6 +69,11 @@ CONTAINS
     type(horiz_coord_t), pointer       :: lon_coord
     character(len=max_hcoordname_len)  :: gridname
 
+    if(any(interp_output)) then
+       if (.not. par%dynproc) &
+       call endrun('setup_history_interpolation: interpolated output not supported if atm_ntasks>dyn_npes')
+    endif
+
     if (associated(cam_interpolate)) then
       do i = 1, size(cam_interpolate)
         if (associated(interpdata_set(ithr)%interpdata)) then

--- a/components/homme/src/share/element_mod.F90
+++ b/components/homme/src/share/element_mod.F90
@@ -22,16 +22,16 @@ module element_mod
   public :: setup_element_pointers
 
   type, public :: index_t
-     integer(kind=int_kind) :: ia(npsq),ja(npsq)
-     integer(kind=int_kind) :: is,ie
-     integer(kind=int_kind) :: NumUniquePts
-     integer(kind=int_kind) :: UniquePtOffset
+!    native grid "uniquepoints" output global id given by  UniquePtOffset + 0..NumUniquePts
+     integer(kind=int_kind) :: ia(npsq),ja(npsq)     ! GLL element index for uniquepoints
+     integer(kind=int_kind) :: NumUniquePts          ! number of unique points contributed by this element
+     integer(kind=int_kind) :: UniquePtOffset        ! starting offset of i=1..ncols uniquepts global id
   end type index_t
 
   !___________________________________________________________________
   type, public :: element_t
-     integer(kind=int_kind) :: LocalId
-     integer(kind=int_kind) :: GlobalId
+     integer(kind=int_kind) :: LocalId       ! element numbering on each MPI task
+     integer(kind=int_kind) :: GlobalId      ! global element numbering independent of MPI decomposition
 
      ! Coordinate values of element points
      type (spherical_polar_t) :: spherep(np,np)                       ! Spherical coords of GLL points

--- a/components/homme/src/share/mesh_mod.F90
+++ b/components/homme/src/share/mesh_mod.F90
@@ -1048,7 +1048,7 @@ contains
                             !there can be at most max_corner element of these
              
              a_corner_elems = 0
-             a_corner_elems = elem_neighbor(elem_nbr_start : elem_nbr_start + cnt -1)
+             a_corner_elems(1:cnt) = elem_neighbor(elem_nbr_start : elem_nbr_start + cnt -1)
              !corner-sides(2) is clockwise of corner_side(1)
              corner_array= 0
              orig_pos = 0


### PR DESCRIPTION
avoid compiler error with assumed shape array
abort if ntasks_atm>dyn_pes and interpolated output turned on
remove unused variables from elem struct

Fixes E3SM-Project/E3SM#2983
Fixes E3SM-Project/E3SM#2959

[BFB]
