### PR TITLE
bugfix in NH heating term

### DIFF
--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -1284,7 +1284,7 @@ contains
              pnh,exner,temp_i,caller='advance_hypervis')
         
         do k=1,nlev
-           k2=max(k,nlev)
+           k2=min(k+1,nlev)
            if (theta_hydrostatic_mode) then
               heating(:,:,k)= (elem(ie)%state%v(:,:,1,k,nt)*vtens(:,:,1,k,ie) + &
                    elem(ie)%state%v(:,:,2,k,nt)*vtens(:,:,2,k,ie) ) / &


### PR DESCRIPTION
Fixes wrong index to average w at the top. Found by Luca Bertagna.

[BFB] except for EAM theta NH tests and HOMME standalone NH tests