### PR TITLE
Two way irrigation coupling between ELM and MOSART

### DIFF
--- a/cime/src/components/data_comps/dlnd/mct/dlnd_comp_mod.F90
+++ b/cime/src/components/data_comps/dlnd/mct/dlnd_comp_mod.F90
@@ -53,21 +53,23 @@ module dlnd_comp_mod
   !--------------------------------------------------------------------------
   !--- names of fields ---
   integer(IN),parameter :: fld_len = 12       ! max character length of fields in avofld & avifld
-  integer(IN),parameter :: nflds_nosnow = 22
+  integer(IN),parameter :: nflds_nosnow = 28
 
   ! fields other than snow fields:
   character(fld_len),parameter  :: avofld_nosnow(1:nflds_nosnow) = &
        (/ "Sl_t        ","Sl_tref     ","Sl_qref     ","Sl_avsdr    ","Sl_anidr    ", &
        "Sl_avsdf    ","Sl_anidf    ","Sl_snowh    ","Fall_taux   ","Fall_tauy   ", &
        "Fall_lat    ","Fall_sen    ","Fall_lwup   ","Fall_evap   ","Fall_swnet  ", &
-       "Sl_landfrac ","Sl_fv       ","Sl_ram1     ",                               &
+       "Sl_landfrac ","Sl_fv       ","Sl_ram1     ","Flrl_demand ",                &
+        "Flrl_rofsur ","Flrl_rofgwl ","Flrl_rofsub ","Flrl_rofdto ","Flrl_rofi", &
        "Fall_flxdst1","Fall_flxdst2","Fall_flxdst3","Fall_flxdst4"                 /)
 
   character(fld_len),parameter  :: avifld_nosnow(1:nflds_nosnow) = &
        (/ "t           ","tref        ","qref        ","avsdr       ","anidr       ", &
        "avsdf       ","anidf       ","snowh       ","taux        ","tauy        ", &
        "lat         ","sen         ","lwup        ","evap        ","swnet       ", &
-       "lfrac       ","fv          ","ram1        ",                               &
+       "lfrac       ","fv          ","ram1        ","demand      ",                &
+        "rofsur      ","rofgwl      ","rofsub      ","rofdto      ","rofi        ", &
        "flddst1     ","flxdst2     ","flxdst3     ","flxdst4     "                 /)
 
   integer(IN), parameter :: nflds_snow  = 3   ! number of snow fields in each elevation class

--- a/cime/src/drivers/mct/main/prep_rof_mod.F90
+++ b/cime/src/drivers/mct/main/prep_rof_mod.F90
@@ -37,7 +37,7 @@ module prep_rof_mod
   public :: prep_rof_accum_avg
 
   public :: prep_rof_calc_l2r_rx
-
+  
   public :: prep_rof_get_l2racc_lx
   public :: prep_rof_get_l2racc_lx_cnt
   public :: prep_rof_get_mapper_Fl2r
@@ -287,12 +287,14 @@ contains
     integer, save :: index_l2x_Flrl_rofsub
     integer, save :: index_l2x_Flrl_rofdto
     integer, save :: index_l2x_Flrl_rofi
+    integer, save :: index_l2x_Flrl_demand
     integer, save :: index_l2x_Flrl_irrig
     integer, save :: index_x2r_Flrl_rofsur
     integer, save :: index_x2r_Flrl_rofgwl
     integer, save :: index_x2r_Flrl_rofsub
     integer, save :: index_x2r_Flrl_rofdto
     integer, save :: index_x2r_Flrl_rofi
+    integer, save :: index_x2r_Flrl_demand
     integer, save :: index_x2r_Flrl_irrig
     integer, save :: index_l2x_Flrl_rofl_16O
     integer, save :: index_l2x_Flrl_rofi_16O
@@ -338,11 +340,13 @@ contains
           index_l2x_Flrl_irrig  = mct_aVect_indexRA(l2x_r,'Flrl_irrig' )
        end if
        index_l2x_Flrl_rofi   = mct_aVect_indexRA(l2x_r,'Flrl_rofi' )
+       index_l2x_Flrl_demand = mct_aVect_indexRA(l2x_r,'Flrl_demand' )
        index_x2r_Flrl_rofsur = mct_aVect_indexRA(x2r_r,'Flrl_rofsur' )
        index_x2r_Flrl_rofgwl = mct_aVect_indexRA(x2r_r,'Flrl_rofgwl' )
        index_x2r_Flrl_rofsub = mct_aVect_indexRA(x2r_r,'Flrl_rofsub' )
        index_x2r_Flrl_rofdto = mct_aVect_indexRA(x2r_r,'Flrl_rofdto' )
        index_x2r_Flrl_rofi   = mct_aVect_indexRA(x2r_r,'Flrl_rofi' )
+       index_x2r_Flrl_demand = mct_aVect_indexRA(x2r_r,'Flrl_demand' )
        if (have_irrig_field) then
           index_x2r_Flrl_irrig  = mct_aVect_indexRA(x2r_r,'Flrl_irrig' )
        end if
@@ -378,6 +382,8 @@ contains
             'lfrac*l2x%Flrl_rofdto'
        mrgstr(index_x2r_Flrl_rofi) = trim(mrgstr(index_x2r_Flrl_rofi))//' = '// &
             'lfrac*l2x%Flrl_rofi'
+       mrgstr(index_x2r_Flrl_demand) = trim(mrgstr(index_x2r_Flrl_demand))//' = '// &
+             'lfrac*l2x%Flrl_demand'
        if (have_irrig_field) then
           mrgstr(index_x2r_Flrl_irrig) = trim(mrgstr(index_x2r_Flrl_irrig))//' = '// &
                'lfrac*l2x%Flrl_irrig'
@@ -405,6 +411,7 @@ contains
        x2r_r%rAttr(index_x2r_Flrl_rofsub,i) = l2x_r%rAttr(index_l2x_Flrl_rofsub,i) * lfrac
        x2r_r%rAttr(index_x2r_Flrl_rofdto,i) = l2x_r%rAttr(index_l2x_Flrl_rofdto,i) * lfrac
        x2r_r%rAttr(index_x2r_Flrl_rofi,i) = l2x_r%rAttr(index_l2x_Flrl_rofi,i) * lfrac
+       x2r_r%rAttr(index_x2r_Flrl_demand,i) = l2x_r%rAttr(index_l2x_Flrl_demand,i) * lfrac
        if (have_irrig_field) then
           x2r_r%rAttr(index_x2r_Flrl_irrig,i) = l2x_r%rAttr(index_l2x_Flrl_irrig,i) * lfrac
        end if

--- a/cime/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/cime/src/drivers/mct/shr/seq_flds_mod.F90
@@ -1994,6 +1994,13 @@ contains
     attname  = 'Flrl_rofi'
     call metadata_set(attname, longname, stdname, units)
 
+    call seq_flds_add(l2x_fluxes,'Flrl_demand')
+    call seq_flds_add(x2r_fluxes,'Flrl_demand')
+    longname = 'Water flux total demand in land from rof'
+    stdname  = 'water_flux_total_demand_from_runoff'
+    units    = 'kg m-2 s-1'
+    attname  = 'Flrl_demand'
+    call metadata_set(attname, longname, stdname, units)
     ! Currently only the CESM land and runoff models treat irrigation as a separate
     ! field: in E3SM, this field is folded in to the other runoff fields. Eventually,
     ! E3SM may want to update its land and runoff models to map irrigation specially, as
@@ -2074,6 +2081,13 @@ contains
     attname  = 'Flrr_volrmch'
     call metadata_set(attname, longname, stdname, units)
 
+    call seq_flds_add(r2x_fluxes,'Flrr_supply')
+    call seq_flds_add(x2l_fluxes,'Flrr_supply')
+    longname = 'River model supply for land use'
+    stdname  = 'rtm_supply'
+    units    = 'kg m-2 s-1'
+    attname  = 'Flrr_supply'
+    call metadata_set(attname, longname, stdname, units)
     !-----------------------------
     ! wav->ocn and ocn->wav
     !-----------------------------

--- a/cime/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/cime/src/drivers/mct/shr/seq_flds_mod.F90
@@ -1994,13 +1994,15 @@ contains
     attname  = 'Flrl_rofi'
     call metadata_set(attname, longname, stdname, units)
 
-    call seq_flds_add(l2x_fluxes,'Flrl_demand')
-    call seq_flds_add(x2r_fluxes,'Flrl_demand')
-    longname = 'Water flux total demand in land from rof'
-    stdname  = 'water_flux_total_demand_from_runoff'
-    units    = 'kg m-2 s-1'
-    attname  = 'Flrl_demand'
-    call metadata_set(attname, longname, stdname, units)
+    if (trim(cime_model) == 'e3sm') then
+       call seq_flds_add(l2x_fluxes,'Flrl_demand')
+       call seq_flds_add(x2r_fluxes,'Flrl_demand')
+       longname = 'Water flux total demand in land from rof'
+       stdname  = 'water_flux_total_demand_from_runoff'
+       units    = 'kg m-2 s-1'
+       attname  = 'Flrl_demand'
+       call metadata_set(attname, longname, stdname, units)
+    endif
     ! Currently only the CESM land and runoff models treat irrigation as a separate
     ! field: in E3SM, this field is folded in to the other runoff fields. Eventually,
     ! E3SM may want to update its land and runoff models to map irrigation specially, as
@@ -2081,13 +2083,15 @@ contains
     attname  = 'Flrr_volrmch'
     call metadata_set(attname, longname, stdname, units)
 
-    call seq_flds_add(r2x_fluxes,'Flrr_supply')
-    call seq_flds_add(x2l_fluxes,'Flrr_supply')
-    longname = 'River model supply for land use'
-    stdname  = 'rtm_supply'
-    units    = 'kg m-2 s-1'
-    attname  = 'Flrr_supply'
-    call metadata_set(attname, longname, stdname, units)
+    if (trim(cime_model) == 'e3sm') then
+       call seq_flds_add(r2x_fluxes,'Flrr_supply')
+       call seq_flds_add(x2l_fluxes,'Flrr_supply')
+       longname = 'River model supply for land use'
+       stdname  = 'rtm_supply'
+       units    = 'kg m-2 s-1'
+       attname  = 'Flrr_supply'
+       call metadata_set(attname, longname, stdname, units)
+    endif
     !-----------------------------
     ! wav->ocn and ocn->wav
     !-----------------------------

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -42,7 +42,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <irrig>.false.</irrig>
 
 <!-- twowayirrigation default -->
-<twowayirrigation>.false.</twowayirrigation>
+<tw_irr>.false.</tw_irr>
 
 <!-- Supplmental Nitrogen mode -->
 <suplnitro use_cn=".true." >NONE</suplnitro>

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -41,6 +41,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Irrigation default -->
 <irrig>.false.</irrig>
 
+<!-- twowayirrigation default -->
+<twowayirrigation>.false.</twowayirrigation>
+
 <!-- Supplmental Nitrogen mode -->
 <suplnitro use_cn=".true." >NONE</suplnitro>
 <suplnitro use_fates=".true." >NONE</suplnitro>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -165,6 +165,12 @@ Interpolate the soil layers on the surface dataset to the soil layers specified 
 If TRUE, irrigation will be active.
 </entry> 
 
+<entry id="twowayirrigation" type="logical" category="clm_physics"
+       group="clm_inparm"  >
+If TRUE, irrigation will be two-way coupled with MOSART.
+irrigation supply will be constrained by surface water availability from MOSART
+</entry>
+
 <entry id="maxpatch_glcmec" type="integer"  category="clm_physics"
        group="clm_inparm" valid_values="0,1,3,5,10,36" >
 Number of  multiple elevation classes over glacier points.

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -165,7 +165,7 @@ Interpolate the soil layers on the surface dataset to the soil layers specified 
 If TRUE, irrigation will be active.
 </entry> 
 
-<entry id="twowayirrigation" type="logical" category="clm_physics"
+<entry id="tw_irr" type="logical" category="clm_physics"
        group="clm_inparm"  >
 If TRUE, irrigation will be two-way coupled with MOSART.
 irrigation supply will be constrained by surface water availability from MOSART

--- a/components/clm/bld/test_build_namelist/t/input/namelist_defaults_clm4_5_test.xml
+++ b/components/clm/bld/test_build_namelist/t/input/namelist_defaults_clm4_5_test.xml
@@ -29,6 +29,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <spinup_state bgc_spinup="on" >1</spinup_state>
 <spinup_state bgc_spinup="off">0</spinup_state>
 
+<!-- twowayirrigation default -->
+<twowayirrigation>.false.</twowayirrigation>
+
 <!-- Supplmental Nitrogen mode -->
 <suplnitro use_cn=".true." >NONE</suplnitro>
 

--- a/components/clm/bld/test_build_namelist/t/input/namelist_defaults_clm4_5_test.xml
+++ b/components/clm/bld/test_build_namelist/t/input/namelist_defaults_clm4_5_test.xml
@@ -30,7 +30,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <spinup_state bgc_spinup="off">0</spinup_state>
 
 <!-- twowayirrigation default -->
-<twowayirrigation>.false.</twowayirrigation>
+<tw_irr>.false.</tw_irr>
 
 <!-- Supplmental Nitrogen mode -->
 <suplnitro use_cn=".true." >NONE</suplnitro>

--- a/components/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
+++ b/components/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
@@ -91,6 +91,12 @@ Interpolate the soil layers on the surface dataset to the soil layers specified 
 If TRUE, irrigation will be active.
 </entry> 
 
+<entry id="twowayirrigation" type="logical" category="clm_physics"
+       group="clm_inparm"  >
+If TRUE, irrigation will be two-way coupled with MOSART.
+irrigation supply will be constrained by surface water availability from MOSART
+</entry>
+
 <entry id="maxpatch_glcmec" type="integer"  category="clm_physics"
        group="clm_inparm" valid_values="0,1,3,5,10,36" >
 Number of  multiple elevation classes over glacier points.

--- a/components/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
+++ b/components/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
@@ -91,7 +91,7 @@ Interpolate the soil layers on the surface dataset to the soil layers specified 
 If TRUE, irrigation will be active.
 </entry> 
 
-<entry id="twowayirrigation" type="logical" category="clm_physics"
+<entry id="tw_irr" type="logical" category="clm_physics"
        group="clm_inparm"  >
 If TRUE, irrigation will be two-way coupled with MOSART.
 irrigation supply will be constrained by surface water availability from MOSART

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -9,7 +9,7 @@ module BalanceCheckMod
   use shr_log_mod        , only : errMsg => shr_log_errMsg
   use decompMod          , only : bounds_type
   use abortutils         , only : endrun
-  use clm_varctl         , only : iulog, use_var_soil_thick, twowayirrigation
+  use clm_varctl         , only : iulog, use_var_soil_thick, tw_irr
   use clm_varcon         , only : namep, namec
   use GetGlobalValuesMod , only : GetGlobalIndex
   use atm2lndType        , only : atm2lnd_type
@@ -171,7 +171,7 @@ contains
      use clm_varctl        , only : create_glacier_mec_landunit
      use clm_time_manager  , only : get_step_size, get_nstep
      use clm_initializeMod , only : surfalb_vars
-	 use domainMod         , only : ldomain
+     use domainMod         , only : ldomain
      use CanopyStateType   , only : canopystate_type
      use subgridAveMod
      use clm_time_manager  , only : get_curr_date, get_nstep
@@ -222,7 +222,7 @@ contains
           qflx_snow_grnd_col         =>    col_wf%qflx_snow_grnd          , & ! Input:  [real(r8) (:)   ]  snow on ground after interception (mm H2O/s) [+]
           qflx_evap_soi              =>    col_wf%qflx_evap_soi           , & ! Input:  [real(r8) (:)   ]  soil evaporation (mm H2O/s) (+ = to atm)
           qflx_irrig                 =>    col_wf%qflx_irrig              , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)
-		  qflx_surf_irrig_col        =>    col_wf%qflx_surf_irrig         , & ! Input:  [real(r8) (:)   ]  real surface irrigation flux (mm H2O /s)     
+          qflx_surf_irrig_col        =>    col_wf%qflx_surf_irrig         , & ! Input:  [real(r8) (:)   ]  real surface irrigation flux (mm H2O /s)     
           qflx_over_supply_col       =>    col_wf%qflx_over_supply        , & ! Input:  [real(r8) (:)   ]  over supply irrigation flux (mm H2O /s)
           qflx_snwcp_ice             =>    col_wf%qflx_snwcp_ice          , & ! Input:  [real(r8) (:)   ]  excess snowfall due to snow capping (mm H2O /s) [+]`
           qflx_evap_tot              =>    col_wf%qflx_evap_tot           , & ! Input:  [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg
@@ -319,19 +319,19 @@ contains
 
           ! add qflx_drain_perched and qflx_flood
           if (col_pp%active(c)) then
-		     !if (twowayirrigation) then
+             !if (tw_irr) then
              errh2o(c) = endwb(c) - begwb(c) &
                   - (forc_rain_col(c) + forc_snow_col(c)  + qflx_floodc(c) + qflx_surf_irrig_col(c) + qflx_over_supply_col(c) &
                   - qflx_evap_tot(c) - qflx_surf(c)  - qflx_h2osfc_surf(c) &  
                   - qflx_qrgwl(c) - qflx_drain(c) - qflx_drain_perched(c) - qflx_snwcp_ice(c) &
                   - qflx_lateral(c)) * dtime
-		     !else
+             !else
              !errh2o(c) = endwb(c) - begwb(c) &
              !     - (forc_rain_col(c) + forc_snow_col(c)  + qflx_floodc(c) + qflx_irrig(c) &
              !     - qflx_evap_tot(c) - qflx_surf(c)  - qflx_h2osfc_surf(c) &
              !     - qflx_qrgwl(c) - qflx_drain(c) - qflx_drain_perched(c) - qflx_snwcp_ice(c) &
              !     - qflx_lateral(c) ) * dtime
-			 !endif
+             !endif
              dwb(c) = (endwb(c)-begwb(c))/dtime
 
           else
@@ -391,7 +391,7 @@ contains
              write(iulog,*)'begwb                      = ',begwb(indexc)
              write(iulog,*)'qflx_evap_tot              = ',qflx_evap_tot(indexc)
              write(iulog,*)'qflx_irrig                 = ',qflx_irrig(indexc)
-			 write(iulog,*)'qflx_supply                = ',atm2lnd_vars%supply_grc(g)
+             write(iulog,*)'qflx_supply                = ',atm2lnd_vars%supply_grc(g)
              write(iulog,*)'f_grd                      = ',ldomain%f_grd(g)
              write(iulog,*)'qflx_surf                  = ',qflx_surf(indexc)
              write(iulog,*)'qflx_qrgwl                 = ',qflx_qrgwl(indexc)
@@ -405,6 +405,7 @@ contains
           else if (abs(errh2o(indexc)) > 1.e-4_r8 .and. (nstep > 2) ) then
 
              write(iulog,*)'clm model is stopping - error is greater than 1e-4 (mm)'
+             write(iulog,*)'colum number               = ',col_pp%gridcell(indexc)
              write(iulog,*)'nstep                      = ',nstep
              write(iulog,*)'errh2o                     = ',errh2o(indexc)
              write(iulog,*)'forc_rain                  = ',forc_rain_col(indexc)
@@ -413,10 +414,10 @@ contains
              write(iulog,*)'begwb                      = ',begwb(indexc)
              write(iulog,*)'qflx_evap_tot              = ',qflx_evap_tot(indexc)
              write(iulog,*)'qflx_irrig                 = ',qflx_irrig(indexc)
-			 write(iulog,*)'qflx_surf_irrig_col        = ',qflx_surf_irrig_col(indexc)
+             write(iulog,*)'qflx_surf_irrig_col        = ',qflx_surf_irrig_col(indexc)
              write(iulog,*)'qflx_over_supply_col       = ',qflx_over_supply_col(indexc)
-			 write(iulog,*)'qflx_supply                = ',atm2lnd_vars%supply_grc(g)
-			 write(iulog,*)'f_grd                      = ',ldomain%f_grd(g)
+             write(iulog,*)'qflx_supply                = ',atm2lnd_vars%supply_grc(g)
+             write(iulog,*)'f_grd                      = ',ldomain%f_grd(g)
              write(iulog,*)'qflx_surf                  = ',qflx_surf(indexc)
              write(iulog,*)'qflx_h2osfc_surf           = ',qflx_h2osfc_surf(indexc)
              write(iulog,*)'qflx_qrgwl                 = ',qflx_qrgwl(indexc)
@@ -705,6 +706,7 @@ contains
           write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
           write(iulog,*)'nstep         = ',nstep
           write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)
+          write(iulog,*)'colum number  = ',col_pp%gridcell(indexc)
           if (abs(errsoi_col(indexc)) > 1.e-4_r8 .and. (nstep > 2) ) then
              write(iulog,*)'clm model is stopping'
              call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(__FILE__, __LINE__))

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -9,7 +9,7 @@ module BalanceCheckMod
   use shr_log_mod        , only : errMsg => shr_log_errMsg
   use decompMod          , only : bounds_type
   use abortutils         , only : endrun
-  use clm_varctl         , only : iulog, use_var_soil_thick
+  use clm_varctl         , only : iulog, use_var_soil_thick, twowayirrigation
   use clm_varcon         , only : namep, namec
   use GetGlobalValuesMod , only : GetGlobalIndex
   use atm2lndType        , only : atm2lnd_type
@@ -171,6 +171,7 @@ contains
      use clm_varctl        , only : create_glacier_mec_landunit
      use clm_time_manager  , only : get_step_size, get_nstep
      use clm_initializeMod , only : surfalb_vars
+	 use domainMod         , only : ldomain
      use CanopyStateType   , only : canopystate_type
      use subgridAveMod
      use clm_time_manager  , only : get_curr_date, get_nstep
@@ -220,7 +221,9 @@ contains
           qflx_rain_grnd_col         =>    col_wf%qflx_rain_grnd          , & ! Input:  [real(r8) (:)   ]  rain on ground after interception (mm H2O/s) [+]
           qflx_snow_grnd_col         =>    col_wf%qflx_snow_grnd          , & ! Input:  [real(r8) (:)   ]  snow on ground after interception (mm H2O/s) [+]
           qflx_evap_soi              =>    col_wf%qflx_evap_soi           , & ! Input:  [real(r8) (:)   ]  soil evaporation (mm H2O/s) (+ = to atm)
-          qflx_irrig                 =>    col_wf%qflx_irrig              , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)             
+          qflx_irrig                 =>    col_wf%qflx_irrig              , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)
+		  qflx_surf_irrig_col        =>    col_wf%qflx_surf_irrig         , & ! Input:  [real(r8) (:)   ]  real surface irrigation flux (mm H2O /s)     
+          qflx_over_supply_col       =>    col_wf%qflx_over_supply        , & ! Input:  [real(r8) (:)   ]  over supply irrigation flux (mm H2O /s)
           qflx_snwcp_ice             =>    col_wf%qflx_snwcp_ice          , & ! Input:  [real(r8) (:)   ]  excess snowfall due to snow capping (mm H2O /s) [+]`
           qflx_evap_tot              =>    col_wf%qflx_evap_tot           , & ! Input:  [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg
           qflx_dew_snow              =>    col_wf%qflx_dew_snow           , & ! Input:  [real(r8) (:)   ]  surface dew added to snow pack (mm H2O /s) [+]
@@ -316,12 +319,19 @@ contains
 
           ! add qflx_drain_perched and qflx_flood
           if (col_pp%active(c)) then
-
+		     !if (twowayirrigation) then
              errh2o(c) = endwb(c) - begwb(c) &
-                  - (forc_rain_col(c) + forc_snow_col(c)  + qflx_floodc(c) + qflx_irrig(c) &
-                  - qflx_evap_tot(c) - qflx_surf(c)  - qflx_h2osfc_surf(c) &
+                  - (forc_rain_col(c) + forc_snow_col(c)  + qflx_floodc(c) + qflx_surf_irrig_col(c) + qflx_over_supply_col(c) &
+                  - qflx_evap_tot(c) - qflx_surf(c)  - qflx_h2osfc_surf(c) &  
                   - qflx_qrgwl(c) - qflx_drain(c) - qflx_drain_perched(c) - qflx_snwcp_ice(c) &
-                  - qflx_lateral(c) ) * dtime
+                  - qflx_lateral(c)) * dtime
+		     !else
+             !errh2o(c) = endwb(c) - begwb(c) &
+             !     - (forc_rain_col(c) + forc_snow_col(c)  + qflx_floodc(c) + qflx_irrig(c) &
+             !     - qflx_evap_tot(c) - qflx_surf(c)  - qflx_h2osfc_surf(c) &
+             !     - qflx_qrgwl(c) - qflx_drain(c) - qflx_drain_perched(c) - qflx_snwcp_ice(c) &
+             !     - qflx_lateral(c) ) * dtime
+			 !endif
              dwb(c) = (endwb(c)-begwb(c))/dtime
 
           else
@@ -381,6 +391,8 @@ contains
              write(iulog,*)'begwb                      = ',begwb(indexc)
              write(iulog,*)'qflx_evap_tot              = ',qflx_evap_tot(indexc)
              write(iulog,*)'qflx_irrig                 = ',qflx_irrig(indexc)
+			 write(iulog,*)'qflx_supply                = ',atm2lnd_vars%supply_grc(g)
+             write(iulog,*)'f_grd                      = ',ldomain%f_grd(g)
              write(iulog,*)'qflx_surf                  = ',qflx_surf(indexc)
              write(iulog,*)'qflx_qrgwl                 = ',qflx_qrgwl(indexc)
              write(iulog,*)'qflx_drain                 = ',qflx_drain(indexc)
@@ -401,6 +413,10 @@ contains
              write(iulog,*)'begwb                      = ',begwb(indexc)
              write(iulog,*)'qflx_evap_tot              = ',qflx_evap_tot(indexc)
              write(iulog,*)'qflx_irrig                 = ',qflx_irrig(indexc)
+			 write(iulog,*)'qflx_surf_irrig_col        = ',qflx_surf_irrig_col(indexc)
+             write(iulog,*)'qflx_over_supply_col       = ',qflx_over_supply_col(indexc)
+			 write(iulog,*)'qflx_supply                = ',atm2lnd_vars%supply_grc(g)
+			 write(iulog,*)'f_grd                      = ',ldomain%f_grd(g)
              write(iulog,*)'qflx_surf                  = ',qflx_surf(indexc)
              write(iulog,*)'qflx_h2osfc_surf           = ',qflx_h2osfc_surf(indexc)
              write(iulog,*)'qflx_qrgwl                 = ',qflx_qrgwl(indexc)

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -319,19 +319,11 @@ contains
 
           ! add qflx_drain_perched and qflx_flood
           if (col_pp%active(c)) then
-             !if (tw_irr) then
              errh2o(c) = endwb(c) - begwb(c) &
                   - (forc_rain_col(c) + forc_snow_col(c)  + qflx_floodc(c) + qflx_surf_irrig_col(c) + qflx_over_supply_col(c) &
                   - qflx_evap_tot(c) - qflx_surf(c)  - qflx_h2osfc_surf(c) &  
                   - qflx_qrgwl(c) - qflx_drain(c) - qflx_drain_perched(c) - qflx_snwcp_ice(c) &
                   - qflx_lateral(c)) * dtime
-             !else
-             !errh2o(c) = endwb(c) - begwb(c) &
-             !     - (forc_rain_col(c) + forc_snow_col(c)  + qflx_floodc(c) + qflx_irrig(c) &
-             !     - qflx_evap_tot(c) - qflx_surf(c)  - qflx_h2osfc_surf(c) &
-             !     - qflx_qrgwl(c) - qflx_drain(c) - qflx_drain_perched(c) - qflx_snwcp_ice(c) &
-             !     - qflx_lateral(c) ) * dtime
-             !endif
              dwb(c) = (endwb(c)-begwb(c))/dtime
 
           else

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -647,7 +647,6 @@ contains
                   ! Translate vol_liq_so and eff_porosity into h2osoi_liq_so and h2osoi_liq_sat and calculate deficit
                   h2osoi_liq_so  = vol_liq_so * denh2o * col_pp%dz(c,j)
                   h2osoi_liq_sat = eff_porosity(c,j) * denh2o * col_pp%dz(c,j)
-                  !deficit        = max((h2osoi_liq_so + irrig_factor*(h2osoi_liq_sat - h2osoi_liq_so)) - h2osoi_liq(c,j), 0._r8)
                   deficit        = max((h2osoi_liq_so + ldomain%firrig(g)*(h2osoi_liq_sat - h2osoi_liq_so)) - h2osoi_liq(c,j), 0._r8)
 
                   ! Add deficit to irrig_rate, converting units from mm to mm/sec

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -109,7 +109,7 @@ contains
     use pftvarcon          , only : irrigated
     use clm_varcon         , only : c14ratio
     use perf_mod           , only : t_startf, t_stopf
-	use domainMod          , only : ldomain
+    use domainMod          , only : ldomain
     use QSatMod            , only : QSat
     use FrictionVelocityMod, only : FrictionVelocity, MoninObukIni
     use SoilWaterRetentionCurveMod, only : soil_water_retention_curve_type
@@ -632,7 +632,7 @@ contains
          do f = 1, fn
             p = filterp(f)
             c = veg_pp%column(p)
-			g = veg_pp%gridcell(p)
+            g = veg_pp%gridcell(p)
             if (check_for_irrig(p) .and. .not. frozen_soil(p)) then
                ! if level L was frozen, then we don't look at any levels below L
                if (t_soisno(c,j) <= SHR_CONST_TKFRZ) then

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -109,6 +109,7 @@ contains
     use pftvarcon          , only : irrigated
     use clm_varcon         , only : c14ratio
     use perf_mod           , only : t_startf, t_stopf
+	use domainMod          , only : ldomain
     use QSatMod            , only : QSat
     use FrictionVelocityMod, only : FrictionVelocity, MoninObukIni
     use SoilWaterRetentionCurveMod, only : soil_water_retention_curve_type
@@ -154,7 +155,7 @@ contains
     ! Desired amount of time to irrigate per day (sec). Actual time may 
     ! differ if this is not a multiple of dtime. Irrigation won't work properly 
     ! if dtime > secsperday
-    integer , parameter :: irrig_length = isecspday/6       
+    integer , parameter :: irrig_length = isecspday/6     ! 4 hours irrigation
 
     ! Determines target soil moisture level for irrigation. If h2osoi_liq_so 
     ! is the soil moisture level at which stomata are fully open and 
@@ -631,6 +632,7 @@ contains
          do f = 1, fn
             p = filterp(f)
             c = veg_pp%column(p)
+			g = veg_pp%gridcell(p)
             if (check_for_irrig(p) .and. .not. frozen_soil(p)) then
                ! if level L was frozen, then we don't look at any levels below L
                if (t_soisno(c,j) <= SHR_CONST_TKFRZ) then
@@ -645,7 +647,8 @@ contains
                   ! Translate vol_liq_so and eff_porosity into h2osoi_liq_so and h2osoi_liq_sat and calculate deficit
                   h2osoi_liq_so  = vol_liq_so * denh2o * col_pp%dz(c,j)
                   h2osoi_liq_sat = eff_porosity(c,j) * denh2o * col_pp%dz(c,j)
-                  deficit        = max((h2osoi_liq_so + irrig_factor*(h2osoi_liq_sat - h2osoi_liq_so)) - h2osoi_liq(c,j), 0._r8)
+                  !deficit        = max((h2osoi_liq_so + irrig_factor*(h2osoi_liq_sat - h2osoi_liq_so)) - h2osoi_liq(c,j), 0._r8)
+                  deficit        = max((h2osoi_liq_so + ldomain%firrig(g)*(h2osoi_liq_sat - h2osoi_liq_so)) - h2osoi_liq(c,j), 0._r8)
 
                   ! Add deficit to irrig_rate, converting units from mm to mm/sec
                   irrig_rate(p)  = irrig_rate(p) + deficit/(dtime*irrig_nsteps_per_day)

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -12,7 +12,7 @@ module CanopyHydrologyMod
   ! !USES:
   use shr_kind_mod      , only : r8 => shr_kind_r8
   use shr_log_mod       , only : errMsg => shr_log_errMsg
-  use shr_infnan_mod    , only : isnan => shr_infnan_isnan
+  use shr_infnan_mod    , only : isnan => shr_infnan_isnan                                                        
   use shr_sys_mod       , only : shr_sys_flush
   use decompMod         , only : bounds_type
   use abortutils        , only : endrun
@@ -259,6 +259,7 @@ contains
        
        dtime = get_step_size()
 	   
+       if (tw_irr) then
        !--------------- temp solution for the irrigation mapping issue, if ELM and MOSART share the same grid, no such problem
        gridnum = bounds%endg - bounds%begg + 1 !number of grid on this processer
         do pp = bounds%begp,bounds%endp          
@@ -298,8 +299,8 @@ contains
         currentg = bounds%begg
         do gg = 1, gridnum
           g = currentg + gg - 1
-		  			
-          if (atm2lnd_vars%supply_grc(g)/=atm2lnd_vars%supply_grc(g)) then !change NAN (if any) to zero
+		  			 
+          if (isnan(atm2lnd_vars%supply_grc(g))) then  !change NAN (if any) to zero
             atm2lnd_vars%supply_grc(g)=0._r8
           end if
 		  
@@ -327,7 +328,7 @@ contains
             adjust_f = 1 ! if irrigated area is too small, don't adjust because it would generate huge irrigation rate in a very small area
         end if            
        !----------------- temp solution ends here     
-
+       end if
        ! Start pft loop
 
        do f = 1, num_nolakep
@@ -337,7 +338,7 @@ contains
           l = plandunit(p)
           c = pcolumn(p)
 
-          irrig_rate_grid(g) = irrig_rate(p)/pgwgt(p) ! grid level irrigation rate projected by patch irrigation rate
+          !irrig_rate_grid(g) = irrig_rate(p)/pgwgt(p) ! grid level irrigation rate projected by patch irrigation rate
 
           ! Canopy interception and precipitation onto ground surface
           ! Add precipitation to leaf water
@@ -435,7 +436,7 @@ contains
           ! Determine whether we're irrigating here; set qflx_irrig appropriately
           if (n_irrig_steps_left(p) > 0) then
              qflx_irrig(p)         = irrig_rate(p)
-             qflx_irrig_grid(g) = irrig_rate_grid(g)
+             !qflx_irrig_grid(g) = irrig_rate_grid(g)
              n_irrig_steps_left(p) = n_irrig_steps_left(p) - 1
           else
              qflx_irrig(p) = 0._r8
@@ -459,10 +460,6 @@ contains
                !qflx_surf_irrig(p) = qflx_irrig(p) * supply_frac(g)			
                !qflx_over_supply(p) = 0
                !--    
-               
-                !if (g .eq. 3761) then       ! debug
-                !  write(iulog,*)'ttt1',g,p,qflx_irrig(p),atm2lnd_vars%supply_grc(g), adjust_f, pgwgt(p), qflx_surf_irrig(p),qflx_over_supply(p),qflx_real_irrig(p)
-                !end if
                 
                if (qflx_surf_irrig(p) > qflx_irrig(p)) then  !projected surface water supply is more than total demand, spill the excessive water on the ground
                   qflx_over_supply(p) = qflx_surf_irrig(p) - qflx_irrig(p)

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -169,7 +169,7 @@ contains
      real(r8) :: snowmelt(bounds%begc:bounds%endc)
      integer  :: j
 	 
-	 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Tian
+	 !--------------------------------------------------- ! initializing variables used to adjust irrigation on local processer
      real(r8) :: qflx_irrig_grid(bounds%begg:bounds%endg)      ! irrigation at grid level [mm/s] 
      real(r8) :: irrig_rate_grid(bounds%begg:bounds%endg)
      
@@ -181,7 +181,6 @@ contains
      integer :: currentg
      integer :: gridnum
      real(r8) :: adjust_f
-     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
      !-----------------------------------------------------------------------
 
      associate(                                                     & 
@@ -259,7 +258,7 @@ contains
        
        dtime = get_step_size()
 	   
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! temp solution for the irrigation mapping issue, if ELM and MOSART share the same grid, no such problem
+       !--------------- temp solution for the irrigation mapping issue, if ELM and MOSART share the same grid, no such problem
        gridnum = bounds%endg - bounds%begg + 1 !number of grid on this processer
         do pp = bounds%begp,bounds%endp          
              if (irrig_rate (pp) /= irrig_rate(pp)) then  !change NAN (if any) to zero so that the grid level irrig_rate can be calculated 
@@ -278,7 +277,9 @@ contains
             qflx_irrig_grid(gg) = 0
          end do
         
-        ! loop the pft and assign irrig_rate to qflx_irrig based on n_irrig_steps_left(p), which will be zero if current pft doesn't need irrigation or the current time is out of irrigation schedule
+        ! loop the pft and assign irrig_rate to qflx_irrig based on n_irrig_steps_left(p), 
+        ! which will be zero if current pft doesn't need irrigation or the current time 
+        ! is out of irrigation schedule
          do f = 1, num_nolakep
           p = filter_nolakep(f)
           g = pgridcell(p)
@@ -328,7 +329,7 @@ contains
         if (adjust_f < 1.0e-3_r8) then
             adjust_f = 1 ! if irrigated area is too small, don't adjust because it would generate huge irrigation rate in a very small area
         end if            
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!       
+       !----------------- temp solution ends here     
 
        ! Start pft loop
 
@@ -457,10 +458,10 @@ contains
                    qflx_surf_irrig(p) = atm2lnd_vars%supply_grc(g)/adjust_f
                end if      
                
-               !!!!!!!!!!!!!! use supply_frac to calculate surf_irrg
+               !-- use supply_frac to calculate surf_irrg
                !qflx_surf_irrig(p) = qflx_irrig(p) * supply_frac(g)			
                !qflx_over_supply(p) = 0
-               !!!!!!!!!!!!!!!!!!!!!!!!    
+               !--    
                
                 !if (g .eq. 3761) then       ! debug
                 !  write(iulog,*)'ttt1',g,p,qflx_irrig(p),atm2lnd_vars%supply_grc(g), adjust_f, pgwgt(p), qflx_surf_irrig(p),qflx_over_supply(p),qflx_real_irrig(p)
@@ -479,19 +480,21 @@ contains
                    qflx_real_irrig(p) = qflx_irrig(p)
                end if
                
-                   qflx_grnd_irrig(p) = qflx_real_irrig(p) - qflx_surf_irrig(p) !groundwater irrigation may be less than 'ldomain%f_grd(g)*qflx_irrig(p)' if real irrigation is greater than demand
-                   qflx_prec_grnd_rain(p) = qflx_prec_grnd_rain(p) + qflx_real_irrig(p) + qflx_over_supply(p) !applying irrigation, the over supply is included to balance water
-               
+                   qflx_grnd_irrig(p) = qflx_real_irrig(p) - qflx_surf_irrig(p)
+                   !groundwater irrigation may be less than 'ldomain%f_grd(g)*qflx_irrig(p)' if real irrigation is greater than demand
+                   qflx_prec_grnd_rain(p) = qflx_prec_grnd_rain(p) + qflx_real_irrig(p) + qflx_over_supply(p)
+                   !applying irrigation, the over supply is included to balance water             
                
              else !this pft doesn't need water             
                qflx_prec_grnd_rain(p) = qflx_prec_grnd_rain(p)
-               qflx_real_irrig(p) = 0! this should be zero, just leave it here for testing added by Tian 2/27/2018
+               qflx_real_irrig(p) = 0 ! this should be zero, just leave it here for testing
                qflx_surf_irrig(p) = 0
                qflx_grnd_irrig(p) = 0
                qflx_over_supply(p) = 0
-               !if (qflx_irrig(p) > 0) then
-               !  write(iulog,*)'Tian warning warning irrigp>0 but irrigg is not',qflx_irrig(p),qflx_irrig_grid(g)
-               !end if 
+               
+               if (qflx_irrig(p) > 0) then
+                 write(iulog,*)'warning irrigp>0 but irrigg is not',qflx_irrig(p),qflx_irrig_grid(g)
+               end if 
              end if		
                 
           else  ! one way coupling

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -15,7 +15,7 @@ module CanopyHydrologyMod
   use shr_sys_mod       , only : shr_sys_flush
   use decompMod         , only : bounds_type
   use abortutils        , only : endrun
-  use clm_varctl        , only : iulog
+  use clm_varctl        , only : iulog, twowayirrigation
   use LandunitType      , only : lun_pp                
   use atm2lndType       , only : atm2lnd_type
   use AerosolType       , only : aerosol_type
@@ -117,8 +117,10 @@ contains
      use landunit_varcon    , only : istcrop, istice, istwet, istsoil, istice_mec 
      use clm_varctl         , only : subgridflag
      use clm_varpar         , only : nlevsoi,nlevsno
+	 use atm2lndType        , only : atm2lnd_type
+     use domainMod          , only : ldomain
      use clm_time_manager   , only : get_step_size
-     use subgridAveMod      , only : p2c
+     use subgridAveMod      , only : p2c,p2g
      !
      ! !ARGUMENTS:
      type(bounds_type)      , intent(in)    :: bounds     
@@ -166,6 +168,20 @@ contains
      real(r8) :: newsnow(bounds%begc:bounds%endc)
      real(r8) :: snowmelt(bounds%begc:bounds%endc)
      integer  :: j
+	 
+	 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Tian
+     real(r8) :: qflx_irrig_grid(bounds%begg:bounds%endg)      ! irrigation at grid level [mm/s] 
+     real(r8) :: irrig_rate_grid(bounds%begg:bounds%endg)
+     
+     real(r8) :: total_dem
+     real(r8) :: total_sup
+     real(r8) :: total_sup_irrigrid
+     integer :: gg
+     integer :: pp
+     integer :: currentg
+     integer :: gridnum
+     real(r8) :: adjust_f
+     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
      !-----------------------------------------------------------------------
 
      associate(                                                     & 
@@ -173,7 +189,8 @@ contains
           ptopounit            => veg_pp%topounit                             , & ! Input:  [integer  (:)   ]  pft's topounit
           plandunit            => veg_pp%landunit                             , & ! Input:  [integer  (:)   ]  pft's landunit                           
           pcolumn              => veg_pp%column                               , & ! Input:  [integer  (:)   ]  pft's column                             
-          ltype                => lun_pp%itype                                , & ! Input:  [integer  (:)   ]  landunit type                            
+          pgwgt                => veg_pp%wtgcell                              , & ! Input:  [integer  (:)   ]  pft's weight in gridcell
+		  ltype                => lun_pp%itype                                , & ! Input:  [integer  (:)   ]  landunit type                            
           urbpoi               => lun_pp%urbpoi                               , & ! Input:  [logical  (:)   ]  true => landunit is an urban point       
           cgridcell            => col_pp%gridcell                             , & ! Input:  [integer  (:)   ]  columns's gridcell                       
           clandunit            => col_pp%landunit                             , & ! Input:  [integer  (:)   ]  columns's landunit                       
@@ -227,12 +244,82 @@ contains
           qflx_rain_grnd       => veg_wf%qflx_rain_grnd      , & ! Output: [real(r8) (:)   ]  rain on ground after interception (mm H2O/s) [+]
           qflx_dirct_rain      => veg_wf%qflx_dirct_rain     , & ! Output: [real(r8) (:)   ]  direct rain throughfall on ground (mm H2O/s) 
           qflx_leafdrip        => veg_wf%qflx_leafdrip       , & ! Output: [real(r8) (:)   ]  leap rain drip on ground (mm H2O/s)
-          qflx_irrig           => veg_wf%qflx_irrig            & ! Output: [real(r8) (:)   ]  irrigation amount (mm/s)                
+          qflx_irrig           => veg_wf%qflx_irrig_patch          , & ! Output: [real(r8) (:)   ]  total water demand or irrigation amount if one-way (mm/s)      
+          qflx_real_irrig      => veg_wf%qflx_real_irrig_patch     , & ! Output: [real(r8) (:)   ]  actual irrigation amount (mm/s)      
+          qflx_surf_irrig_col  => col_wf%qflx_surf_irrig       , & ! Output: [real(r8) (:)   ]  col real surface water irrigation flux (mm H2O /s)  
+          qflx_grnd_irrig_col  => col_wf%qflx_grnd_irrig       , & ! Output: [real(r8) (:)   ]  col real groundwater irrigation flux (mm H2O /s)          
+          qflx_over_supply_col => col_wf%qflx_over_supply      , & ! Output: [real(r8) (:)   ]  over supply irrigation flux (mm H2O /s)          
+          qflx_supply          => veg_wf%qflx_supply_patch         , & ! Output: [real(r8) (:)   ]  irrigation supply (mm/s)      
+          qflx_surf_irrig      => veg_wf%qflx_surf_irrig_patch     , & ! Output: [real(r8) (:)   ]  actual surface water irrigation (mm/s)      
+          qflx_grnd_irrig      => veg_wf%qflx_grnd_irrig_patch     , & ! Output: [real(r8) (:)   ]  actual groundwater irrigation (mm/s)     
+          qflx_over_supply     => veg_wf%qflx_over_supply_patch      & ! Output: [real(r8) (:)   ]  the portion of supply that exceed total demand (mm/s)                 
           )
 
        ! Compute time step
        
        dtime = get_step_size()
+	   
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! temp solution for the irrigation mapping issue, if ELM and MOSART share the same grid, no such problem
+       gridnum = bounds%endg - bounds%begg + 1 !number of grid on this processer
+        do pp = bounds%begp,bounds%endp          
+             if (irrig_rate (pp) /= irrig_rate(pp)) then  !change NAN (if any) to zero so that the grid level irrig_rate can be calculated 
+               irrig_rate(pp)=0._r8
+             endif
+        end do
+        
+       ! Find gridcell level irrigation rate based on pft level 
+       call p2g(bounds, &
+         irrig_rate (bounds%begp:bounds%endp), &  
+         irrig_rate_grid (bounds%begg:bounds%endg), &
+         p2c_scale_type='unity', c2l_scale_type= 'unity', l2g_scale_type='unity') 
+		 
+		! initialize the qflx_irrig_grid 
+		 do gg = bounds%begg,bounds%endg
+		   qflx_irrig_grid(gg) = 0
+		 end do
+        
+        ! loop the pft and assign irrig_rate to qflx_irrig based on n_irrig_steps_left(p), which will be zero if current pft doesn't need irrigation or the current time is out of irrigation schedule
+		do f = 1, num_nolakep
+          p = filter_nolakep(f)
+          g = pgridcell(p)
+		  
+		   if (n_irrig_steps_left(p) > 0) then
+             qflx_irrig(p)         = irrig_rate(p)
+             qflx_irrig_grid(g) = irrig_rate_grid(g) ! 
+		   end if
+		 end do
+		 		   
+        !initialize the total supply for all grids over the processer and total supply for grids that need irrigation 
+        total_sup_irrigrid = 0._r8
+        total_sup = 0._r8
+        
+		currentg = bounds%begg
+		do gg = 1, gridnum
+		  g = currentg + gg - 1
+		  if (atm2lnd_vars%supply_grc(g)/=atm2lnd_vars%supply_grc(g)) then !change NAN (if any) to zero
+		     atm2lnd_vars%supply_grc(g)=0._r8
+		  end if
+		  
+		  total_sup = total_sup+atm2lnd_vars%supply_grc(g)*ldomain%area(g) !total supply across all the grids
+		   if (qflx_irrig_grid(g)*ldomain%f_surf(g) > 0._r8 ) then  ! total supply in grids that need water
+		     total_sup_irrigrid = total_sup_irrigrid + atm2lnd_vars%supply_grc(g)*ldomain%area(g)  
+           end if
+		end do
+		  
+        if (total_sup .eq. 0._r8) then ! no surface water supply at all, no need to adjust
+          adjust_f = 1
+        end if
+        
+        if (total_sup .gt. 0._r8 .and. total_sup_irrigrid .eq. 0._r8 ) then !no grid needs water but supply > 0, supply don't know where to go
+          adjust_f = 1
+        end if
+        
+        if (total_sup_irrigrid .gt. 0._r8) then
+		    !This is the ratio between supply over gridcells need water and supply over all gridcells
+			!This value should be ranging from 0 to 1 and will be used to concentrate the water supply into gridcells that need irrigation
+            adjust_f = total_sup_irrigrid/total_sup 
+        end if		
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!       
 
        ! Start pft loop
 
@@ -242,6 +329,8 @@ contains
           t = ptopounit(p)
           l = plandunit(p)
           c = pcolumn(p)
+		  
+		  irrig_rate_grid(g) = irrig_rate(p)/pgwgt(p) ! grid level irrigation rate projected by patch irrigation rate
 
           ! Canopy interception and precipitation onto ground surface
           ! Add precipitation to leaf water
@@ -339,14 +428,71 @@ contains
           ! Determine whether we're irrigating here; set qflx_irrig appropriately
           if (n_irrig_steps_left(p) > 0) then
              qflx_irrig(p)         = irrig_rate(p)
+			 qflx_irrig_grid(g) = irrig_rate_grid(g)
              n_irrig_steps_left(p) = n_irrig_steps_left(p) - 1
           else
              qflx_irrig(p) = 0._r8
+			 qflx_irrig_grid(g) = 0._r8
           end if
 
           ! Add irrigation water directly onto ground (bypassing canopy interception)
           ! Note that it's still possible that (some of) this irrigation water will runoff (as runoff is computed later)
-          qflx_prec_grnd_rain(p) = qflx_prec_grnd_rain(p) + qflx_irrig(p)
+              if (twowayirrigation) then ! else one way  
+                qflx_supply(p) = atm2lnd_vars%supply_grc(g) !!! original supply from WM, need to be updated based on the demand after interpolation              
+		 
+               if (qflx_irrig(p) > 0._r8) then	!this pft needs water	   
+               qflx_surf_irrig(p) = atm2lnd_vars%supply_grc(g)/adjust_f/pgwgt(p)    ! original supply at grid level (mm/s) concentrate
+                                                                                    ! to grid cells that need water  and then project 
+																		            ! to pft level             
+               !!!!!!!!!!!!!! use supply_frac to calculate surf_irrg
+               !qflx_surf_irrig(p) = qflx_irrig(p) * supply_frac(g)			
+               !qflx_over_supply(p) = 0
+               !!!!!!!!!!!!!!!!!!!!!!!!               
+           
+               if (qflx_surf_irrig(p) > qflx_irrig(p)) then  !projected surface water supply is more than total demand, spill the excessive water on the ground
+                  qflx_over_supply(p) = qflx_surf_irrig(p) - qflx_irrig(p)
+                  qflx_surf_irrig(p) = qflx_irrig(p)
+               else
+                  qflx_over_supply(p)=0._r8
+               end if
+               
+               qflx_real_irrig(p) = qflx_surf_irrig(p) + ldomain%f_grd(g)*qflx_irrig(p) ! actual irrigation
+                
+               if (qflx_real_irrig(p) > qflx_irrig(p)) then  !real irrigation is greater than total demand
+                   qflx_real_irrig(p) = qflx_irrig(p)
+               end if
+               
+                   qflx_grnd_irrig(p) = qflx_real_irrig(p) - qflx_surf_irrig(p) !groundwater irrigation may be less than 'ldomain%f_grd(g)*qflx_irrig(p)' if real irrigation is greater than demand
+                   qflx_prec_grnd_rain(p) = qflx_prec_grnd_rain(p) + qflx_real_irrig(p) + qflx_over_supply(p) !applying irrigation, the over supply is included to balance water
+               
+               
+             else !this pft doesn't need water             
+               qflx_prec_grnd_rain(p) = qflx_prec_grnd_rain(p)
+               qflx_real_irrig(p) = 0! this should be zero, just leave it here for testing added by Tian 2/27/2018
+               qflx_surf_irrig(p) = 0
+               qflx_grnd_irrig(p) = 0
+               qflx_over_supply(p) = 0
+               !if (qflx_irrig(p) > 0) then
+               !  write(iulog,*)'Tian warning warning irrigp>0 but irrigg is not',qflx_irrig(p),qflx_irrig_grid(g)
+               !end if 
+             end if		
+             
+                !if (g .eq. 14621) then
+                !  write(iulog,*)'ttt1',g,p,qflx_irrig(p),atm2lnd_vars%supply_grc(g),qflx_surf_irrig(p),qflx_over_supply(p),qflx_real_irrig(p)
+                !end if
+                
+          else  ! one way coupling
+             qflx_prec_grnd_rain(p) = qflx_prec_grnd_rain(p) + ldomain%f_surf(g)*qflx_irrig(p) + ldomain%f_grd(g)*qflx_irrig(p) 
+             qflx_real_irrig(p) = ldomain%f_surf(g)*qflx_irrig(p) + ldomain%f_grd(g)*qflx_irrig(p) ! added by Tian 2/27/2018
+               
+               qflx_surf_irrig(p) = ldomain%f_surf(g)*qflx_irrig(p)
+               qflx_grnd_irrig(p) = ldomain%f_grd(g)*qflx_irrig(p)
+               qflx_over_supply(p) = 0
+			   qflx_supply(p) = 0._r8 !assuming the irrigation demand is always met 
+          end if
+          
+          !no coupling
+          !qflx_prec_grnd_rain(p) = qflx_prec_grnd_rain(p) + qflx_irrig(p)
 
           ! Done irrigation
 
@@ -378,6 +524,19 @@ contains
        call p2c(bounds, num_nolakec, filter_nolakec, &
             qflx_snow_grnd_patch(bounds%begp:bounds%endp), &
             qflx_snow_grnd_col(bounds%begc:bounds%endc))
+			
+		! Update column level irrigation supple for balance check	
+       call p2c(bounds, num_nolakec, filter_nolakec, &      
+            qflx_over_supply(bounds%begp:bounds%endp), &
+            qflx_over_supply_col(bounds%begc:bounds%endc))
+
+       call p2c(bounds, num_nolakec, filter_nolakec, &      
+            qflx_surf_irrig(bounds%begp:bounds%endp), &
+            qflx_surf_irrig_col(bounds%begc:bounds%endc))
+            
+       call p2c(bounds, num_nolakec, filter_nolakec, &      
+            qflx_grnd_irrig(bounds%begp:bounds%endp), &
+            qflx_grnd_irrig_col(bounds%begc:bounds%endc))
 
        ! apply gridcell flood water flux to non-lake columns
        do f = 1, num_nolakec

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -297,11 +297,7 @@ contains
         currentg = bounds%begg
         do gg = 1, gridnum
           g = currentg + gg - 1
-		  
-		  !if (atm2lnd_vars%supply_grc(g)>0) then
-          !       write(iulog,*)'ttt1',atm2lnd_vars%supply_grc(g)
-          !end if
-				
+		  			
           if (atm2lnd_vars%supply_grc(g)/=atm2lnd_vars%supply_grc(g)) then !change NAN (if any) to zero
             atm2lnd_vars%supply_grc(g)=0._r8
           end if

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -12,6 +12,7 @@ module CanopyHydrologyMod
   ! !USES:
   use shr_kind_mod      , only : r8 => shr_kind_r8
   use shr_log_mod       , only : errMsg => shr_log_errMsg
+  use shr_infnan_mod    , only : isnan => shr_infnan_isnan
   use shr_sys_mod       , only : shr_sys_flush
   use decompMod         , only : bounds_type
   use abortutils        , only : endrun
@@ -261,7 +262,7 @@ contains
        !--------------- temp solution for the irrigation mapping issue, if ELM and MOSART share the same grid, no such problem
        gridnum = bounds%endg - bounds%begg + 1 !number of grid on this processer
         do pp = bounds%begp,bounds%endp          
-             if (irrig_rate (pp) /= irrig_rate(pp)) then  !change NAN (if any) to zero so that the grid level irrig_rate can be calculated 
+             if (isnan(irrig_rate (pp))) then  !change NAN (if any) to zero so that the grid level irrig_rate can be calculated 
                irrig_rate(pp)=0._r8
              endif
         end do

--- a/components/clm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/clm/src/biogeophys/HydrologyDrainageMod.F90
@@ -230,6 +230,9 @@ contains
 
       ! Determine wetland and land ice hydrology (must be placed here
       ! since need snow updated from CombineSnowLayers)
+      do c = bounds%begc,bounds%endc
+         qflx_irr_demand(c) = 0._r8
+      end do
 
       do fc = 1,num_nolakec
          c = filter_nolakec(fc)

--- a/components/clm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/clm/src/biogeophys/HydrologyDrainageMod.F90
@@ -16,6 +16,7 @@ module HydrologyDrainageMod
   use TemperatureType   , only : temperature_type
   use WaterfluxType     , only : waterflux_type
   use WaterstateType    , only : waterstate_type
+  use SoilHydrologyMod  , only : WaterTable
   use TopounitDataType  , only : top_af ! atmospheric flux variables
   use LandunitType      , only : lun_pp                
   use ColumnType        , only : col_pp
@@ -49,6 +50,8 @@ contains
     use column_varcon    , only : icol_roof, icol_road_imperv, icol_road_perv, icol_sunwall, icol_shadewall
     use clm_varcon       , only : denh2o, denice, secspday
     use clm_varctl       , only : glc_snow_persistence_max_days, use_vichydro, use_betr
+	use domainMod        , only : ldomain
+    use atm2lndType      , only : atm2lnd_type
     use clm_varpar       , only : nlevgrnd, nlevurb, nlevsoi    
     use clm_time_manager , only : get_step_size, get_nstep
     use SoilHydrologyMod , only : CLMVICMap, Drainage
@@ -104,7 +107,8 @@ contains
          snow_persistence       => col_ws%snow_persistence       , & ! Output: [real(r8) (:)   ]  counter for length of time snow-covered
          total_plant_stored_h2o => col_ws%total_plant_stored_h2o , & ! Input [real(r8) (:) dynamic water stored in plants]
          qflx_evap_tot          => col_wf%qflx_evap_tot           , & ! Input:  [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg     
-         qflx_irrig             => col_wf%qflx_irrig              , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)                       
+         qflx_irrig             => col_wf%qflx_irrig              , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)
+         qflx_irr_demand        => col_wf%qflx_irr_demand         , & ! Input:  [real(r8) (:)   ]  irrigation demand sent to MOSART/WM (mm H2O /s)                       		 
          qflx_glcice_melt       => col_wf%qflx_glcice_melt        , & ! Input:  [real(r8) (:)]  ice melt (positive definite) (mm H2O/s)      
          qflx_h2osfc_surf       => col_wf%qflx_h2osfc_surf        , & ! Output: [real(r8) (:)   ]  surface water runoff (mm/s)                        
          qflx_drain_perched     => col_wf%qflx_drain_perched      , & ! Output: [real(r8) (:)   ]  sub-surface runoff from perched zwt (mm H2O /s)   
@@ -148,6 +152,9 @@ contains
         call ep_betr%DiagDrainWaterFlux(num_hydrologyc, filter_hydrologyc)
         call ep_betr%RetrieveBiogeoFlux(bounds, 1, nlevsoi, waterflux_vars=waterflux_vars)
       endif
+	  
+!      call WaterTable(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc, &
+!           soilhydrology_vars, soilstate_vars, temperature_vars, waterstate_vars, waterflux_vars)
 
       do j = 1, nlevgrnd
          do fc = 1, num_nolakec

--- a/components/clm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/clm/src/biogeophys/HydrologyDrainageMod.F90
@@ -50,7 +50,7 @@ contains
     use column_varcon    , only : icol_roof, icol_road_imperv, icol_road_perv, icol_sunwall, icol_shadewall
     use clm_varcon       , only : denh2o, denice, secspday
     use clm_varctl       , only : glc_snow_persistence_max_days, use_vichydro, use_betr
-	use domainMod        , only : ldomain
+    use domainMod        , only : ldomain
     use atm2lndType      , only : atm2lnd_type
     use clm_varpar       , only : nlevgrnd, nlevurb, nlevsoi    
     use clm_time_manager , only : get_step_size, get_nstep
@@ -282,7 +282,8 @@ contains
          qflx_runoff(c) = qflx_drain(c) + qflx_surf(c)  + qflx_h2osfc_surf(c) + qflx_qrgwl(c) + qflx_drain_perched(c)
 
          if ((lun_pp%itype(l)==istsoil .or. lun_pp%itype(l)==istcrop) .and. col_pp%active(c)) then
-            qflx_runoff(c) = qflx_runoff(c) - qflx_irrig(c)
+            !qflx_runoff(c) = qflx_runoff(c) - qflx_irrig(c)
+            qflx_irr_demand(c) = -1.0_r8 * ldomain%f_surf(g)*qflx_irrig(c) !should keep this, not the above one because this is the max qdem send to MOSART																																		 
          end if
          if (lun_pp%urbpoi(l)) then
             qflx_runoff_u(c) = qflx_runoff(c)
@@ -292,6 +293,8 @@ contains
 
       end do
 
+      !call WaterTable(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc, &
+      !     soilhydrology_vars, soilstate_vars, temperature_vars, waterstate_vars, waterflux_vars)																							  
     end associate
 
   end subroutine HydrologyDrainage

--- a/components/clm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/clm/src/biogeophys/HydrologyDrainageMod.F90
@@ -152,9 +152,6 @@ contains
         call ep_betr%DiagDrainWaterFlux(num_hydrologyc, filter_hydrologyc)
         call ep_betr%RetrieveBiogeoFlux(bounds, 1, nlevsoi, waterflux_vars=waterflux_vars)
       endif
-	  
-!      call WaterTable(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc, &
-!           soilhydrology_vars, soilstate_vars, temperature_vars, waterstate_vars, waterflux_vars)
 
       do j = 1, nlevgrnd
          do fc = 1, num_nolakec
@@ -282,8 +279,7 @@ contains
          qflx_runoff(c) = qflx_drain(c) + qflx_surf(c)  + qflx_h2osfc_surf(c) + qflx_qrgwl(c) + qflx_drain_perched(c)
 
          if ((lun_pp%itype(l)==istsoil .or. lun_pp%itype(l)==istcrop) .and. col_pp%active(c)) then
-            !qflx_runoff(c) = qflx_runoff(c) - qflx_irrig(c)
-            qflx_irr_demand(c) = -1.0_r8 * ldomain%f_surf(g)*qflx_irrig(c) !should keep this, not the above one because this is the max qdem send to MOSART																																		 
+            qflx_irr_demand(c) = -1.0_r8 * ldomain%f_surf(g)*qflx_irrig(c) !surface water demand send to MOSART																																		 
          end if
          if (lun_pp%urbpoi(l)) then
             qflx_runoff_u(c) = qflx_runoff(c)
@@ -292,9 +288,7 @@ contains
          end if
 
       end do
-
-      !call WaterTable(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc, &
-      !     soilhydrology_vars, soilstate_vars, temperature_vars, waterstate_vars, waterflux_vars)																							  
+																					  
     end associate
 
   end subroutine HydrologyDrainage

--- a/components/clm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/clm/src/biogeophys/LakeHydrologyMod.F90
@@ -200,7 +200,7 @@ contains
          qflx_infl            =>  col_wf%qflx_infl          , & ! Output: [real(r8) (:)   ]  infiltration (mm H2O /s)                
          qflx_qrgwl           =>  col_wf%qflx_qrgwl         , & ! Output: [real(r8) (:)   ]  qflx_surf at glaciers, wetlands, lakes  
          qflx_runoff          =>  col_wf%qflx_runoff        , & ! Output: [real(r8) (:)   ]  total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
-         qflx_irrig           =>  veg_wf%qflx_irrig       , & ! Output: [real(r8) (:)   ]  irrigation flux (mm H2O /s)             
+         qflx_irrig           =>  veg_wf%qflx_irrig_patch   , & ! Output: [real(r8) (:)   ]  irrigation flux (mm H2O /s)             
          qflx_irrig_col       =>  col_wf%qflx_irrig         , & ! Output: [real(r8) (:)   ]  irrigation flux (mm H2O /s)             
          qflx_top_soil        =>  col_wf%qflx_top_soil      , & ! Output: [real(r8) (:)   ]  net water input into soil from top (mm/s)
          qflx_sl_top_soil     =>  col_wf%qflx_sl_top_soil   , & ! Output: [real(r8) (:)   ]  liquid water + ice from layer above soil to top soil layer or sent to qflx_qrgwl (mm H2O/s)

--- a/components/clm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SoilHydrologyMod.F90
@@ -699,17 +699,6 @@ contains
           !--  water table is below the soil column  --------------------------------------
 		  g = col_pp%gridcell(c)
           l = col_pp%landunit(c)
-
-       !   local runoff used for irrigation , commented out because it's been taken care of in MOSART-WM 
-       !   qcharge_temp = qcharge(c)
-       !   if ((lun%itype(l)==istsoil .or. lun%itype(l)==istcrop) .and. col%active(c)) then
-       !      qflx_runoff(c) = qflx_runoff(c) - qflx_irrig(c) *ldomain%f_surf(g)
-       !      wa(c) =  max(0.0_r8, wa(c) - qflx_irrig(c) * dtime *
-       !      ldomain%f_grd(g))
-       !      qcharge_temp = qcharge(c)
-       !      qcharge(c) = qcharge(c) - qflx_irrig(c) * ldomain%f_grd(g)
-       !   end if
-
           qcharge_temp = qcharge(c)
 
           wa(c)  = wa(c) - qflx_grnd_irrig_col(c) * dtime

--- a/components/clm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SoilHydrologyMod.F90
@@ -546,7 +546,7 @@ contains
      use clm_varpar       , only : nlevsoi, nlevgrnd
      use column_varcon    , only : icol_roof, icol_road_imperv
      use clm_varctl       , only : use_vsfm, use_var_soil_thick
-	 use domainMod        , only : ldomain
+     use domainMod        , only : ldomain
      use SoilWaterMovementMod, only : zengdecker_2009_with_var_soil_thick
      !
      ! !ARGUMENTS:
@@ -626,9 +626,8 @@ contains
           watsat             =>    soilstate_vars%watsat_col             , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)  
           eff_porosity       =>    soilstate_vars%eff_porosity_col       , & ! Input:  [real(r8) (:,:) ]  effective porosity = porosity - vol_ice   
           
-		  qflx_irrig         =>    col_wf%qflx_irrig         , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)
-          qflx_grnd_irrig_col=>    col_wf%qflx_grnd_irrig    , & ! Output: [real(r8) (:)   ]  col real groundwater irrigation flux (mm H2O /s)                                                                                                                                                             
-		  
+          qflx_irrig         =>    col_wf%qflx_irrig         , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)
+          qflx_grnd_irrig_col=>    col_wf%qflx_grnd_irrig    , & ! Output: [real(r8) (:)   ]  col real groundwater irrigation flux (mm H2O /s)                                                                                                                                                               
 
           zwt                =>    soilhydrology_vars%zwt_col            , & ! Output: [real(r8) (:)   ]  water table depth (m)                             
           zwt_perched        =>    soilhydrology_vars%zwt_perched_col    , & ! Output: [real(r8) (:)   ]  perched water table depth (m)                     
@@ -775,7 +774,7 @@ contains
                 end if
              enddo
           endif
-		  qcharge(c) = qcharge_temp
+          qcharge(c) = qcharge_temp
        enddo
 
 

--- a/components/clm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SoilHydrologyMod.F90
@@ -18,7 +18,8 @@ module SoilHydrologyMod
   use LandunitType      , only : lun_pp                
   use ColumnType        , only : col_pp
   use ColumnDataType    , only : col_es, col_ws, col_wf  
-  use VegetationType    , only : veg_pp     
+  use VegetationType    , only : veg_pp
+  use VegetationDataType, only : veg_wf  
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -103,6 +104,8 @@ contains
          qflx_evap_grnd   =>    col_wf%qflx_evap_grnd   , & ! Input:  [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]    
          qflx_top_soil    =>    col_wf%qflx_top_soil    , & ! Output: [real(r8) (:)   ]  net water input into soil from top (mm/s)         
          qflx_surf        =>    col_wf%qflx_surf        , & ! Output: [real(r8) (:)   ]  surface runoff (mm H2O /s)                        
+         qflx_irrig       =>    col_wf%qflx_irrig       , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)
+         irrig_rate       =>    veg_wf%irrig_rate       , & ! Input:  [real(r8) (:)   ]  current irrigation rate (applied if !n_irrig_steps_left > 0) [mm/s]
 
          zwt              =>    soilhydrology_vars%zwt_col          , & ! Input:  [real(r8) (:)   ]  water table depth (m)                             
          max_moist        =>    soilhydrology_vars%max_moist_col    , & ! Input:  [real(r8) (:,:) ]  maximum soil moisture (ice + liq, mm)            
@@ -543,6 +546,7 @@ contains
      use clm_varpar       , only : nlevsoi, nlevgrnd
      use column_varcon    , only : icol_roof, icol_road_imperv
      use clm_varctl       , only : use_vsfm, use_var_soil_thick
+	 use domainMod        , only : ldomain
      use SoilWaterMovementMod, only : zengdecker_2009_with_var_soil_thick
      !
      ! !ARGUMENTS:
@@ -558,7 +562,7 @@ contains
      type(waterflux_type)     , intent(inout) :: waterflux_vars
      !
      ! !LOCAL VARIABLES:
-     integer  :: c,j,fc,i                                ! indices
+     integer  :: c,j,fc,i,l,g                            ! indices
      integer  :: nlevbed                                 ! # layers to bedrock
      real(r8) :: dtime                                   ! land model time step (sec)
      real(r8) :: xs(bounds%begc:bounds%endc)             ! water needed to bring soil moisture to watmin (mm)
@@ -595,6 +599,7 @@ contains
      real(r8) :: q_perch
      real(r8) :: q_perch_max
      real(r8) :: dflag=0._r8
+	 real(r8) :: qcharge_temp
      !-----------------------------------------------------------------------
 
      associate(                                                            & 
@@ -619,7 +624,11 @@ contains
           hksat              =>    soilstate_vars%hksat_col              , & ! Input:  [real(r8) (:,:) ]  hydraulic conductivity at saturation (mm H2O /s)
           sucsat             =>    soilstate_vars%sucsat_col             , & ! Input:  [real(r8) (:,:) ]  minimum soil suction (mm)                       
           watsat             =>    soilstate_vars%watsat_col             , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)  
-          eff_porosity       =>    soilstate_vars%eff_porosity_col       , & ! Input:  [real(r8) (:,:) ]  effective porosity = porosity - vol_ice         
+          eff_porosity       =>    soilstate_vars%eff_porosity_col       , & ! Input:  [real(r8) (:,:) ]  effective porosity = porosity - vol_ice   
+          
+		  qflx_irrig         =>    col_wf%qflx_irrig         , & ! Input:  [real(r8) (:)   ]  irrigation flux (mm H2O /s)
+          qflx_grnd_irrig_col=>    col_wf%qflx_grnd_irrig    , & ! Output: [real(r8) (:)   ]  col real groundwater irrigation flux (mm H2O /s)                                                                                                                                                             
+		  
 
           zwt                =>    soilhydrology_vars%zwt_col            , & ! Output: [real(r8) (:)   ]  water table depth (m)                             
           zwt_perched        =>    soilhydrology_vars%zwt_perched_col    , & ! Output: [real(r8) (:)   ]  perched water table depth (m)                     
@@ -689,6 +698,24 @@ contains
           rous=max(rous,0.02_r8)
 
           !--  water table is below the soil column  --------------------------------------
+		  g = col_pp%gridcell(c)
+          l = col_pp%landunit(c)
+
+       !   local runoff used for irrigation , commented out because it's been taken care of in MOSART-WM 
+       !   qcharge_temp = qcharge(c)
+       !   if ((lun%itype(l)==istsoil .or. lun%itype(l)==istcrop) .and. col%active(c)) then
+       !      qflx_runoff(c) = qflx_runoff(c) - qflx_irrig(c) *ldomain%f_surf(g)
+       !      wa(c) =  max(0.0_r8, wa(c) - qflx_irrig(c) * dtime *
+       !      ldomain%f_grd(g))
+       !      qcharge_temp = qcharge(c)
+       !      qcharge(c) = qcharge(c) - qflx_irrig(c) * ldomain%f_grd(g)
+       !   end if
+
+          qcharge_temp = qcharge(c)
+
+          wa(c)  = wa(c) - qflx_grnd_irrig_col(c) * dtime
+          zwt(c) = zwt(c) + (qflx_grnd_irrig_col(c) * dtime)/1000._r8/rous
+		  
           if(jwt(c) == nlevbed) then             
 	     if (.not. (zengdecker_2009_with_var_soil_thick)) then
                 wa(c)  = wa(c) + qcharge(c)  * dtime
@@ -748,6 +775,7 @@ contains
                 end if
              enddo
           endif
+		  qcharge(c) = qcharge_temp
        enddo
 
 

--- a/components/clm/src/biogeophys/WaterfluxType.F90
+++ b/components/clm/src/biogeophys/WaterfluxType.F90
@@ -108,15 +108,14 @@ module WaterfluxType
      real(r8), pointer :: qflx_real_irrig_patch    (:)   ! patch real irrigation flux (mm H2O/s) 
      real(r8), pointer :: qflx_surf_irrig_col      (:)   ! col real surface irrigation flux (mm H2O/s) 
      real(r8), pointer :: qflx_grnd_irrig_col      (:)   ! col real groundwater irrigation flux (mm H2O/s) 
-	 real(r8), pointer :: qflx_grnd_irrig_patch    (:)   ! groundwater irrigation (mm H2O/s) 
+     real(r8), pointer :: qflx_grnd_irrig_patch    (:)   ! groundwater irrigation (mm H2O/s) 
      real(r8), pointer :: qflx_surf_irrig_patch    (:)   ! surface water irrigation(mm H2O/s) 
      real(r8), pointer :: qflx_supply_patch        (:)   ! patch supply flux (mm H2O/s) 
      real(r8), pointer :: qflx_irrig_col           (:)   ! col irrigation flux (mm H2O/s)
      real(r8), pointer :: qflx_irr_demand_col      (:)   ! col surface irrigation demand (mm H2O /s)
      real(r8), pointer :: irrig_rate_patch         (:)   ! current irrigation rate [mm/s]
-	 real(r8), pointer :: qflx_over_supply_patch   (:)   ! over supplied irrigation !added by Tian July 2018
-     real(r8), pointer :: qflx_over_supply_col     (:)   ! col over supplied irrigation !added by Tian July 2018
-
+     real(r8), pointer :: qflx_over_supply_patch   (:)   ! over supplied irrigation 
+     real(r8), pointer :: qflx_over_supply_col     (:)   ! col over supplied irrigation 
      integer , pointer :: n_irrig_steps_left_patch (:)   ! number of time steps for which we still need to irrigate today (if 0, ignore)
 
      ! For VSFM
@@ -380,7 +379,7 @@ contains
        if (lun_pp%itype(l)==istsoil) then
           this%n_irrig_steps_left_patch(p) = 0
           this%irrig_rate_patch(p)         = 0.0_r8
-		  this%qflx_irr_demand_col(c)  = 0._r8
+          this%qflx_irr_demand_col(c)  = 0._r8
        end if
     end do
 

--- a/components/clm/src/biogeophys/WaterfluxType.F90
+++ b/components/clm/src/biogeophys/WaterfluxType.F90
@@ -370,6 +370,7 @@ contains
        if (lun_pp%itype(l) == istsoil .or. lun_pp%itype(l) == istcrop) then
           this%qflx_drain_col(c) = 0._r8
           this%qflx_surf_col(c)  = 0._r8
+          this%qflx_irr_demand_col(c)  = 0._r8
        end if
     end do
 
@@ -379,7 +380,6 @@ contains
        if (lun_pp%itype(l)==istsoil) then
           this%n_irrig_steps_left_patch(p) = 0
           this%irrig_rate_patch(p)         = 0.0_r8
-          this%qflx_irr_demand_col(c)  = 0._r8
        end if
     end do
 

--- a/components/clm/src/biogeophys/WaterfluxType.F90
+++ b/components/clm/src/biogeophys/WaterfluxType.F90
@@ -268,13 +268,13 @@ contains
 
     allocate(this%qflx_irrig_patch         (begp:endp))              ; this%qflx_irrig_patch         (:)   = nan 
     allocate(this%qflx_real_irrig_patch    (begp:endp))              ; this%qflx_real_irrig_patch    (:)   = nan 
-    allocate(this%qflx_surf_irrig_col      (begc:endc))              ; this%qflx_surf_irrig_col      (:)   = 0._r8
-    allocate(this%qflx_grnd_irrig_col      (begc:endc))              ; this%qflx_grnd_irrig_col      (:)   = 0._r8
+    allocate(this%qflx_surf_irrig_col      (begc:endc))              ; this%qflx_surf_irrig_col      (:)   = nan
+    allocate(this%qflx_grnd_irrig_col      (begc:endc))              ; this%qflx_grnd_irrig_col      (:)   = nan
     allocate(this%qflx_grnd_irrig_patch    (begp:endp))              ; this%qflx_grnd_irrig_patch    (:)   = nan
     allocate(this%qflx_surf_irrig_patch    (begp:endp))              ; this%qflx_surf_irrig_patch    (:)   = nan
     allocate(this%qflx_supply_patch        (begp:endp))              ; this%qflx_supply_patch        (:)   = nan 
     allocate(this%qflx_over_supply_patch   (begp:endp))              ; this%qflx_over_supply_patch   (:)   = nan 
-    allocate(this%qflx_over_supply_col     (begc:endc))              ; this%qflx_over_supply_col     (:)   = 0._r8
+    allocate(this%qflx_over_supply_col     (begc:endc))              ; this%qflx_over_supply_col     (:)   = nan
     allocate(this%qflx_irrig_col           (begc:endc))              ; this%qflx_irrig_col           (:)   = nan
     allocate(this%qflx_irr_demand_col      (begc:endc))              ; this%qflx_irr_demand_col      (:)   = nan
     allocate(this%irrig_rate_patch         (begp:endp))              ; this%irrig_rate_patch         (:)   = nan

--- a/components/clm/src/biogeophys/WaterfluxType.F90
+++ b/components/clm/src/biogeophys/WaterfluxType.F90
@@ -105,8 +105,18 @@ module WaterfluxType
 
      ! Irrigation
      real(r8), pointer :: qflx_irrig_patch         (:)   ! patch irrigation flux (mm H2O/s)
+     real(r8), pointer :: qflx_real_irrig_patch    (:)   ! patch real irrigation flux (mm H2O/s) 
+     real(r8), pointer :: qflx_surf_irrig_col      (:)   ! col real surface irrigation flux (mm H2O/s) 
+     real(r8), pointer :: qflx_grnd_irrig_col      (:)   ! col real groundwater irrigation flux (mm H2O/s) 
+	 real(r8), pointer :: qflx_grnd_irrig_patch    (:)   ! groundwater irrigation (mm H2O/s) 
+     real(r8), pointer :: qflx_surf_irrig_patch    (:)   ! surface water irrigation(mm H2O/s) 
+     real(r8), pointer :: qflx_supply_patch        (:)   ! patch supply flux (mm H2O/s) 
      real(r8), pointer :: qflx_irrig_col           (:)   ! col irrigation flux (mm H2O/s)
+     real(r8), pointer :: qflx_irr_demand_col      (:)   ! col surface irrigation demand (mm H2O /s)
      real(r8), pointer :: irrig_rate_patch         (:)   ! current irrigation rate [mm/s]
+	 real(r8), pointer :: qflx_over_supply_patch   (:)   ! over supplied irrigation !added by Tian July 2018
+     real(r8), pointer :: qflx_over_supply_col     (:)   ! col over supplied irrigation !added by Tian July 2018
+
      integer , pointer :: n_irrig_steps_left_patch (:)   ! number of time steps for which we still need to irrigate today (if 0, ignore)
 
      ! For VSFM
@@ -257,8 +267,17 @@ contains
     allocate(this%qflx_liq_dynbal_grc      (begg:endg))              ; this%qflx_liq_dynbal_grc      (:)   = nan
     allocate(this%qflx_ice_dynbal_grc      (begg:endg))              ; this%qflx_ice_dynbal_grc      (:)   = nan
 
-    allocate(this%qflx_irrig_patch         (begp:endp))              ; this%qflx_irrig_patch         (:)   = nan
+    allocate(this%qflx_irrig_patch         (begp:endp))              ; this%qflx_irrig_patch         (:)   = nan 
+    allocate(this%qflx_real_irrig_patch    (begp:endp))              ; this%qflx_real_irrig_patch    (:)   = nan 
+    allocate(this%qflx_surf_irrig_col      (begc:endc))              ; this%qflx_surf_irrig_col      (:)   = 0._r8
+    allocate(this%qflx_grnd_irrig_col      (begc:endc))              ; this%qflx_grnd_irrig_col      (:)   = 0._r8
+    allocate(this%qflx_grnd_irrig_patch    (begp:endp))              ; this%qflx_grnd_irrig_patch    (:)   = nan
+    allocate(this%qflx_surf_irrig_patch    (begp:endp))              ; this%qflx_surf_irrig_patch    (:)   = nan
+    allocate(this%qflx_supply_patch        (begp:endp))              ; this%qflx_supply_patch        (:)   = nan 
+    allocate(this%qflx_over_supply_patch   (begp:endp))              ; this%qflx_over_supply_patch   (:)   = nan 
+    allocate(this%qflx_over_supply_col     (begc:endc))              ; this%qflx_over_supply_col     (:)   = 0._r8
     allocate(this%qflx_irrig_col           (begc:endc))              ; this%qflx_irrig_col           (:)   = nan
+    allocate(this%qflx_irr_demand_col      (begc:endc))              ; this%qflx_irr_demand_col      (:)   = nan
     allocate(this%irrig_rate_patch         (begp:endp))              ; this%irrig_rate_patch         (:)   = nan
     allocate(this%n_irrig_steps_left_patch (begp:endp))              ; this%n_irrig_steps_left_patch (:)   = 0
 
@@ -361,6 +380,7 @@ contains
        if (lun_pp%itype(l)==istsoil) then
           this%n_irrig_steps_left_patch(p) = 0
           this%irrig_rate_patch(p)         = 0.0_r8
+		  this%qflx_irr_demand_col(c)  = 0._r8
        end if
     end do
 

--- a/components/clm/src/cpl/clm_cpl_indices.F90
+++ b/components/clm/src/cpl/clm_cpl_indices.F90
@@ -28,6 +28,7 @@ module clm_cpl_indices
   integer, public ::index_l2x_Flrl_rofgwl     ! lnd->rtm input liquid gwl fluxes
   integer, public ::index_l2x_Flrl_rofsub     ! lnd->rtm input liquid subsurface fluxes
   integer, public ::index_l2x_Flrl_rofi       ! lnd->rtm input frozen fluxes
+  integer, public ::index_l2x_Flrl_demand     ! lnd->rtm input total fluxes (<= 0)
 
   integer, public ::index_l2x_Sl_t            ! temperature
   integer, public ::index_l2x_Sl_tref         ! 2m reference temperature
@@ -104,6 +105,7 @@ module clm_cpl_indices
   integer, public ::index_x2l_Flrr_flood      ! rtm->lnd rof (flood) flux
   integer, public ::index_x2l_Flrr_volr       ! rtm->lnd rof volr total volume
   integer, public ::index_x2l_Flrr_volrmch    ! rtm->lnd rof volr main channel volume
+  integer, public ::index_x2l_Flrr_supply     ! rtm->lnd rof supply for land use
 
   ! In the following, index 0 is bare land, other indices are glc elevation classes
   integer, public ::index_x2l_Sg_frac(0:glc_nec_max)   = 0   ! Fraction of glacier from glc model
@@ -167,6 +169,7 @@ contains
     index_l2x_Flrl_rofgwl   = mct_avect_indexra(l2x,'Flrl_rofgwl')
     index_l2x_Flrl_rofsub   = mct_avect_indexra(l2x,'Flrl_rofsub')
     index_l2x_Flrl_rofi     = mct_avect_indexra(l2x,'Flrl_rofi')
+	index_l2x_Flrl_demand   = mct_avect_indexra(l2x,'Flrl_demand')
 
     index_l2x_Sl_t          = mct_avect_indexra(l2x,'Sl_t')
     index_l2x_Sl_snowh      = mct_avect_indexra(l2x,'Sl_snowh')
@@ -229,7 +232,8 @@ contains
 
     index_x2l_Flrr_volr     = mct_avect_indexra(x2l,'Flrr_volr')
     index_x2l_Flrr_volrmch  = mct_avect_indexra(x2l,'Flrr_volrmch')
-
+    index_x2l_Flrr_supply   = mct_avect_indexra(x2l,'Flrr_supply')
+	
     index_x2l_Faxa_lwdn     = mct_avect_indexra(x2l,'Faxa_lwdn')
     index_x2l_Faxa_rainc    = mct_avect_indexra(x2l,'Faxa_rainc')
     index_x2l_Faxa_rainl    = mct_avect_indexra(x2l,'Faxa_rainl')

--- a/components/clm/src/cpl/clm_cpl_indices.F90
+++ b/components/clm/src/cpl/clm_cpl_indices.F90
@@ -169,7 +169,7 @@ contains
     index_l2x_Flrl_rofgwl   = mct_avect_indexra(l2x,'Flrl_rofgwl')
     index_l2x_Flrl_rofsub   = mct_avect_indexra(l2x,'Flrl_rofsub')
     index_l2x_Flrl_rofi     = mct_avect_indexra(l2x,'Flrl_rofi')
-	index_l2x_Flrl_demand   = mct_avect_indexra(l2x,'Flrl_demand')
+    index_l2x_Flrl_demand   = mct_avect_indexra(l2x,'Flrl_demand')
 
     index_l2x_Sl_t          = mct_avect_indexra(l2x,'Sl_t')
     index_l2x_Sl_snowh      = mct_avect_indexra(l2x,'Sl_snowh')

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -179,7 +179,7 @@ contains
 
        atm2lnd_vars%volr_grc(g)   = x2l(index_x2l_Flrr_volr,i) * (ldomain%area(g) * 1.e6_r8)
        atm2lnd_vars%volrmch_grc(g)= x2l(index_x2l_Flrr_volrmch,i) * (ldomain%area(g) * 1.e6_r8)
-	   atm2lnd_vars%supply_grc(g) = x2l(index_x2l_Flrr_supply,i)
+       atm2lnd_vars%supply_grc(g) = x2l(index_x2l_Flrr_supply,i)
 
        ! Determine required receive fields
 
@@ -1169,7 +1169,7 @@ contains
     use shr_kind_mod       , only : r8 => shr_kind_r8
     use clm_varctl         , only : iulog, create_glacier_mec_landunit
     use clm_time_manager   , only : get_nstep, get_step_size  
-	use domainMod          , only : ldomain
+    use domainMod          , only : ldomain
     use seq_drydep_mod     , only : n_drydep
     use shr_megan_mod      , only : shr_megan_mechcomps_n
     !
@@ -1186,7 +1186,7 @@ contains
     integer  :: nstep ! time step index
     integer  :: dtime ! time step   
     integer  :: num   ! counter
-	character(len=*), parameter :: sub = 'lnd_export_mct'
+    character(len=*), parameter :: sub = 'lnd_export_mct'
     !---------------------------------------------------------------------------
 
     ! cesm sign convention is that fluxes are positive downward
@@ -1251,8 +1251,8 @@ contains
        l2x(index_l2x_Flrl_rofsub,i) = lnd2atm_vars%qflx_rofliq_qsub_grc(g) &
                                     + lnd2atm_vars%qflx_rofliq_qsubp_grc(g)   !  perched drainiage
        l2x(index_l2x_Flrl_rofgwl,i) = lnd2atm_vars%qflx_rofliq_qgwl_grc(g)
-	   
-	   l2x(index_l2x_Flrl_demand,i) =  lnd2atm_vars%qflx_irr_demand_grc(g)   ! needs to be filled in
+  
+       l2x(index_l2x_Flrl_demand,i) =  lnd2atm_vars%qflx_irr_demand_grc(g)   ! needs to be filled in
        if (l2x(index_l2x_Flrl_demand,i) > 0.0_r8) then
            write(iulog,*)'lnd2atm_vars%qflx_irr_demand_grc is',lnd2atm_vars%qflx_irr_demand_grc(g)
            write(iulog,*)'l2x(index_l2x_Flrl_demand,i) is',l2x(index_l2x_Flrl_demand,i)

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -90,7 +90,7 @@ contains
     integer*2 :: temp(1,500000)
     integer :: xtoget, ytoget, thisx, thisy, calday_start
     character(len=200) metsource_str, thisline
-    character(len=32), parameter :: sub = 'lnd_import_mct'
+    character(len=*), parameter :: sub = 'lnd_import_mct'
     integer :: av, v, n, nummetdims, g3, gtoget, ztoget, line, mystart, tod_start, thistimelen  
     character(len=20) aerovars(14), metvars(14)
     character(len=3) zst
@@ -179,6 +179,7 @@ contains
 
        atm2lnd_vars%volr_grc(g)   = x2l(index_x2l_Flrr_volr,i) * (ldomain%area(g) * 1.e6_r8)
        atm2lnd_vars%volrmch_grc(g)= x2l(index_x2l_Flrr_volrmch,i) * (ldomain%area(g) * 1.e6_r8)
+	   atm2lnd_vars%supply_grc(g) = x2l(index_x2l_Flrr_supply,i)
 
        ! Determine required receive fields
 
@@ -1168,6 +1169,7 @@ contains
     use shr_kind_mod       , only : r8 => shr_kind_r8
     use clm_varctl         , only : iulog, create_glacier_mec_landunit
     use clm_time_manager   , only : get_nstep, get_step_size  
+	use domainMod          , only : ldomain
     use seq_drydep_mod     , only : n_drydep
     use shr_megan_mod      , only : shr_megan_mechcomps_n
     !
@@ -1184,6 +1186,7 @@ contains
     integer  :: nstep ! time step index
     integer  :: dtime ! time step   
     integer  :: num   ! counter
+	character(len=*), parameter :: sub = 'lnd_export_mct'
     !---------------------------------------------------------------------------
 
     ! cesm sign convention is that fluxes are positive downward
@@ -1248,6 +1251,13 @@ contains
        l2x(index_l2x_Flrl_rofsub,i) = lnd2atm_vars%qflx_rofliq_qsub_grc(g) &
                                     + lnd2atm_vars%qflx_rofliq_qsubp_grc(g)   !  perched drainiage
        l2x(index_l2x_Flrl_rofgwl,i) = lnd2atm_vars%qflx_rofliq_qgwl_grc(g)
+	   
+	   l2x(index_l2x_Flrl_demand,i) =  lnd2atm_vars%qflx_irr_demand_grc(g)   ! needs to be filled in
+       if (l2x(index_l2x_Flrl_demand,i) > 0.0_r8) then
+           write(iulog,*)'lnd2atm_vars%qflx_irr_demand_grc is',lnd2atm_vars%qflx_irr_demand_grc(g)
+           write(iulog,*)'l2x(index_l2x_Flrl_demand,i) is',l2x(index_l2x_Flrl_demand,i)
+           call endrun( sub//' ERROR: demand must be <= 0.')
+       endif
 
        ! glc coupling
 

--- a/components/clm/src/data_types/ColumnDataType.F90
+++ b/components/clm/src/data_types/ColumnDataType.F90
@@ -464,7 +464,13 @@ module ColumnDataType
     real(r8), pointer :: qflx_lateral         (:)   => null() ! lateral subsurface flux (mm H2O /s)
     real(r8), pointer :: snow_sources         (:)   => null() ! snow sources (mm H2O/s)
     real(r8), pointer :: snow_sinks           (:)   => null() ! snow sinks (mm H2O/s)
-    real(r8), pointer :: qflx_irrig           (:)   => null() ! irrigation flux (mm H2O/s)
+
+	real(r8), pointer :: qflx_surf_irrig      (:)   => null() ! col real surface irrigation flux (mm H2O/s) 
+    real(r8), pointer :: qflx_grnd_irrig      (:)   => null() ! col real groundwater irrigation flux (mm H2O/s) 
+    real(r8), pointer :: qflx_irrig           (:)   => null() ! col irrigation flux (mm H2O/s)
+    real(r8), pointer :: qflx_irr_demand      (:)   => null() ! col surface irrigation demand (mm H2O /s)
+    real(r8), pointer :: qflx_over_supply     (:)   => null() ! col over supplied irrigation 
+
     real(r8), pointer :: mflx_infl_1d         (:)   => null() ! infiltration source in top soil control volume (kg H2O /s)
     real(r8), pointer :: mflx_dew_1d          (:)   => null() ! liquid+snow dew source in top soil control volume (kg H2O /s)
     real(r8), pointer :: mflx_et_1d           (:)   => null() ! evapotranspiration sink from all soil coontrol volumes (kg H2O /s)
@@ -5144,6 +5150,10 @@ contains
     allocate(this%snow_sources           (begc:endc))             ; this%snow_sources         (:)   = nan
     allocate(this%snow_sinks             (begc:endc))             ; this%snow_sinks           (:)   = nan
     allocate(this%qflx_irrig             (begc:endc))             ; this%qflx_irrig           (:)   = nan
+	allocate(this%qflx_surf_irrig        (begc:endc))             ; this%qflx_surf_irrig      (:)   = 0._r8
+    allocate(this%qflx_grnd_irrig        (begc:endc))             ; this%qflx_grnd_irrig      (:)   = 0._r8
+    allocate(this%qflx_over_supply       (begc:endc))             ; this%qflx_over_supply     (:)   = 0._r8
+    allocate(this%qflx_irr_demand        (begc:endc))             ; this%qflx_irr_demand      (:)   = nan
     
     !VSFM variables
     ncells = endc - begc + 1
@@ -5193,6 +5203,11 @@ contains
     call hist_addfld1d (fname='QDRAI',  units='mm/s',  &
          avgflag='A', long_name='sub-surface drainage', &
          ptr_col=this%qflx_drain, c2l_scale_type='urbanf')
+		 
+    this%qflx_irr_demand(begc:endc) = 0._r8
+    call hist_addfld1d (fname='QIRRIG_WM',  units='mm/s',  &
+         avgflag='A', long_name='Surface water irrigation demand sent to MOSART/WM', &
+         ptr_col=this%qflx_irr_demand, c2l_scale_type='urbanf')
 
     this%qflx_top_soil(begc:endc) = spval
     call hist_addfld1d (fname='QTOPSOIL',  units='mm/s',  &

--- a/components/clm/src/data_types/ColumnDataType.F90
+++ b/components/clm/src/data_types/ColumnDataType.F90
@@ -5150,9 +5150,9 @@ contains
     allocate(this%snow_sources           (begc:endc))             ; this%snow_sources         (:)   = nan
     allocate(this%snow_sinks             (begc:endc))             ; this%snow_sinks           (:)   = nan
     allocate(this%qflx_irrig             (begc:endc))             ; this%qflx_irrig           (:)   = nan
-	allocate(this%qflx_surf_irrig        (begc:endc))             ; this%qflx_surf_irrig      (:)   = 0._r8
-    allocate(this%qflx_grnd_irrig        (begc:endc))             ; this%qflx_grnd_irrig      (:)   = 0._r8
-    allocate(this%qflx_over_supply       (begc:endc))             ; this%qflx_over_supply     (:)   = 0._r8
+    allocate(this%qflx_surf_irrig        (begc:endc))             ; this%qflx_surf_irrig      (:)   = nan
+    allocate(this%qflx_grnd_irrig        (begc:endc))             ; this%qflx_grnd_irrig      (:)   = nan
+    allocate(this%qflx_over_supply       (begc:endc))             ; this%qflx_over_supply     (:)   = nan
     allocate(this%qflx_irr_demand        (begc:endc))             ; this%qflx_irr_demand      (:)   = nan
     
     !VSFM variables
@@ -5204,7 +5204,7 @@ contains
          avgflag='A', long_name='sub-surface drainage', &
          ptr_col=this%qflx_drain, c2l_scale_type='urbanf')
 		 
-    this%qflx_irr_demand(begc:endc) = 0._r8
+    this%qflx_irr_demand(begc:endc) = spval
     call hist_addfld1d (fname='QIRRIG_WM',  units='mm/s',  &
          avgflag='A', long_name='Surface water irrigation demand sent to MOSART/WM', &
          ptr_col=this%qflx_irr_demand, c2l_scale_type='urbanf')
@@ -5307,6 +5307,10 @@ contains
     this%qflx_snow_melt  (begc:endc)   = 0._r8
 
     this%dwb(begc:endc) = 0._r8
+
+    this%qflx_surf_irrig(begc:endc) = 0._r8
+    this%qflx_grnd_irrig(begc:endc) = 0._r8
+    this%qflx_over_supply(begc:endc) = 0._r8
     ! needed for CNNLeaching 
     do c = begc, endc
        l = col_pp%landunit(c)

--- a/components/clm/src/data_types/ColumnDataType.F90
+++ b/components/clm/src/data_types/ColumnDataType.F90
@@ -465,7 +465,7 @@ module ColumnDataType
     real(r8), pointer :: snow_sources         (:)   => null() ! snow sources (mm H2O/s)
     real(r8), pointer :: snow_sinks           (:)   => null() ! snow sinks (mm H2O/s)
 
-	real(r8), pointer :: qflx_surf_irrig      (:)   => null() ! col real surface irrigation flux (mm H2O/s) 
+    real(r8), pointer :: qflx_surf_irrig      (:)   => null() ! col real surface irrigation flux (mm H2O/s) 
     real(r8), pointer :: qflx_grnd_irrig      (:)   => null() ! col real groundwater irrigation flux (mm H2O/s) 
     real(r8), pointer :: qflx_irrig           (:)   => null() ! col irrigation flux (mm H2O/s)
     real(r8), pointer :: qflx_irr_demand      (:)   => null() ! col surface irrigation demand (mm H2O /s)

--- a/components/clm/src/data_types/VegetationDataType.F90
+++ b/components/clm/src/data_types/VegetationDataType.F90
@@ -5374,11 +5374,6 @@ module VegetationDataType
     !-----------------------------------------------------------------------
     ! initialize history fields for select members of veg_wf
     !-----------------------------------------------------------------------
-    !this%qflx_irrig(begp:endp) = spval
-    !call hist_addfld1d (fname='QIRRIG', units='mm/s', &
-    !     avgflag='A', long_name='water added through irrigation', &
-    !     ptr_patch=this%qflx_irrig)
-		 
     this%qflx_irrig_patch(begp:endp) = spval
     call hist_addfld1d (fname='QIRRIG_ORIG', units='mm/s', &
          avgflag='A', long_name='Original total irrigation water demand (surface + ground)', &

--- a/components/clm/src/data_types/VegetationDataType.F90
+++ b/components/clm/src/data_types/VegetationDataType.F90
@@ -372,8 +372,8 @@ module VegetationDataType
     real(r8), pointer :: qflx_ev_soil       (:)   => null() ! evaporation heat flux from soil       (W/m**2) [+ to atm] ! NOTE: unit shall be mm H2O/s for water NOT heat
     real(r8), pointer :: qflx_ev_h2osfc     (:)   => null() ! evaporation heat flux from soil       (W/m**2) [+ to atm] ! NOTE: unit shall be mm H2O/s for water NOT heat
     real(r8), pointer :: qflx_rootsoi_frac  (:,:) => null() !  
-   ! real(r8), pointer :: qflx_irrig         (:)   => null() ! irrigation flux (mm H2O/s)
-    real(r8), pointer :: irrig_rate         (:)   => null() ! current irrigation rate [mm/s]
+   
+    real(r8), pointer :: irrig_rate               (:)   => null() ! current irrigation rate [mm/s]
     real(r8), pointer :: qflx_irrig_patch         (:)   => null()   ! patch irrigation flux (mm H2O/s)
     real(r8), pointer :: qflx_real_irrig_patch    (:)   => null()   ! patch real irrigation flux (mm H2O/s) 
     real(r8), pointer :: qflx_grnd_irrig_patch    (:)   => null()   ! groundwater irrigation (mm H2O/s) 
@@ -5359,17 +5359,15 @@ module VegetationDataType
     allocate(this%qflx_ev_soil           (begp:endp))             ; this%qflx_ev_soil         (:)   = nan
     allocate(this%qflx_ev_h2osfc         (begp:endp))             ; this%qflx_ev_h2osfc       (:)   = nan
     allocate(this%qflx_rootsoi_frac      (begp:endp,1:nlevgrnd))  ; this%qflx_rootsoi_frac    (:,:) = nan
-    !allocate(this%qflx_irrig             (begp:endp))             ; this%qflx_irrig           (:)   = nan
-    allocate(this%irrig_rate             (begp:endp))             ; this%irrig_rate           (:)   = nan
-	
+    
+    allocate(this%irrig_rate               (begp:endp))              ; this%irrig_rate               (:)   = nan
     allocate(this%qflx_irrig_patch         (begp:endp))              ; this%qflx_irrig_patch         (:)   = nan
     allocate(this%qflx_real_irrig_patch    (begp:endp))              ; this%qflx_real_irrig_patch    (:)   = nan
     allocate(this%qflx_grnd_irrig_patch    (begp:endp))              ; this%qflx_grnd_irrig_patch    (:)   = nan
     allocate(this%qflx_surf_irrig_patch    (begp:endp))              ; this%qflx_surf_irrig_patch    (:)   = nan
     allocate(this%qflx_supply_patch        (begp:endp))              ; this%qflx_supply_patch        (:)   = nan
     allocate(this%qflx_over_supply_patch   (begp:endp))              ; this%qflx_over_supply_patch   (:)   = nan 
-	
-    allocate(this%n_irrig_steps_left     (begp:endp))             ; this%n_irrig_steps_left   (:)   = 0
+    allocate(this%n_irrig_steps_left       (begp:endp))              ; this%n_irrig_steps_left       (:)   = 0
     
     !-----------------------------------------------------------------------
     ! initialize history fields for select members of veg_wf

--- a/components/clm/src/data_types/VegetationDataType.F90
+++ b/components/clm/src/data_types/VegetationDataType.F90
@@ -374,8 +374,8 @@ module VegetationDataType
     real(r8), pointer :: qflx_rootsoi_frac  (:,:) => null() !  
    ! real(r8), pointer :: qflx_irrig         (:)   => null() ! irrigation flux (mm H2O/s)
     real(r8), pointer :: irrig_rate         (:)   => null() ! current irrigation rate [mm/s]
-	real(r8), pointer :: qflx_irrig_patch         (:)   => null()   ! patch irrigation flux (mm H2O/s)
-	real(r8), pointer :: qflx_real_irrig_patch    (:)   => null()   ! patch real irrigation flux (mm H2O/s) 
+    real(r8), pointer :: qflx_irrig_patch         (:)   => null()   ! patch irrigation flux (mm H2O/s)
+    real(r8), pointer :: qflx_real_irrig_patch    (:)   => null()   ! patch real irrigation flux (mm H2O/s) 
     real(r8), pointer :: qflx_grnd_irrig_patch    (:)   => null()   ! groundwater irrigation (mm H2O/s) 
     real(r8), pointer :: qflx_surf_irrig_patch    (:)   => null()   ! surface water irrigation(mm H2O/s) 
     real(r8), pointer :: qflx_supply_patch        (:)   => null()   ! patch supply flux (mm H2O/s) 
@@ -5362,7 +5362,7 @@ module VegetationDataType
     !allocate(this%qflx_irrig             (begp:endp))             ; this%qflx_irrig           (:)   = nan
     allocate(this%irrig_rate             (begp:endp))             ; this%irrig_rate           (:)   = nan
 	
-	allocate(this%qflx_irrig_patch         (begp:endp))              ; this%qflx_irrig_patch         (:)   = nan
+    allocate(this%qflx_irrig_patch         (begp:endp))              ; this%qflx_irrig_patch         (:)   = nan
     allocate(this%qflx_real_irrig_patch    (begp:endp))              ; this%qflx_real_irrig_patch    (:)   = nan
     allocate(this%qflx_grnd_irrig_patch    (begp:endp))              ; this%qflx_grnd_irrig_patch    (:)   = nan
     allocate(this%qflx_surf_irrig_patch    (begp:endp))              ; this%qflx_surf_irrig_patch    (:)   = nan

--- a/components/clm/src/data_types/VegetationDataType.F90
+++ b/components/clm/src/data_types/VegetationDataType.F90
@@ -372,8 +372,15 @@ module VegetationDataType
     real(r8), pointer :: qflx_ev_soil       (:)   => null() ! evaporation heat flux from soil       (W/m**2) [+ to atm] ! NOTE: unit shall be mm H2O/s for water NOT heat
     real(r8), pointer :: qflx_ev_h2osfc     (:)   => null() ! evaporation heat flux from soil       (W/m**2) [+ to atm] ! NOTE: unit shall be mm H2O/s for water NOT heat
     real(r8), pointer :: qflx_rootsoi_frac  (:,:) => null() !  
-    real(r8), pointer :: qflx_irrig         (:)   => null() ! irrigation flux (mm H2O/s)
+   ! real(r8), pointer :: qflx_irrig         (:)   => null() ! irrigation flux (mm H2O/s)
     real(r8), pointer :: irrig_rate         (:)   => null() ! current irrigation rate [mm/s]
+	real(r8), pointer :: qflx_irrig_patch         (:)   => null()   ! patch irrigation flux (mm H2O/s)
+	real(r8), pointer :: qflx_real_irrig_patch    (:)   => null()   ! patch real irrigation flux (mm H2O/s) 
+    real(r8), pointer :: qflx_grnd_irrig_patch    (:)   => null()   ! groundwater irrigation (mm H2O/s) 
+    real(r8), pointer :: qflx_surf_irrig_patch    (:)   => null()   ! surface water irrigation(mm H2O/s) 
+    real(r8), pointer :: qflx_supply_patch        (:)   => null()   ! patch supply flux (mm H2O/s) 
+
+    real(r8), pointer :: qflx_over_supply_patch   (:)   => null()   ! over supplied irrigation
     integer , pointer :: n_irrig_steps_left (:)   => null() ! number of time steps for which we still need to irrigate today (if 0, ignore)
 
   contains
@@ -5352,17 +5359,55 @@ module VegetationDataType
     allocate(this%qflx_ev_soil           (begp:endp))             ; this%qflx_ev_soil         (:)   = nan
     allocate(this%qflx_ev_h2osfc         (begp:endp))             ; this%qflx_ev_h2osfc       (:)   = nan
     allocate(this%qflx_rootsoi_frac      (begp:endp,1:nlevgrnd))  ; this%qflx_rootsoi_frac    (:,:) = nan
-    allocate(this%qflx_irrig             (begp:endp))             ; this%qflx_irrig           (:)   = nan
+    !allocate(this%qflx_irrig             (begp:endp))             ; this%qflx_irrig           (:)   = nan
     allocate(this%irrig_rate             (begp:endp))             ; this%irrig_rate           (:)   = nan
+	
+	allocate(this%qflx_irrig_patch         (begp:endp))              ; this%qflx_irrig_patch         (:)   = nan
+    allocate(this%qflx_real_irrig_patch    (begp:endp))              ; this%qflx_real_irrig_patch    (:)   = nan
+    allocate(this%qflx_grnd_irrig_patch    (begp:endp))              ; this%qflx_grnd_irrig_patch    (:)   = nan
+    allocate(this%qflx_surf_irrig_patch    (begp:endp))              ; this%qflx_surf_irrig_patch    (:)   = nan
+    allocate(this%qflx_supply_patch        (begp:endp))              ; this%qflx_supply_patch        (:)   = nan
+    allocate(this%qflx_over_supply_patch   (begp:endp))              ; this%qflx_over_supply_patch   (:)   = nan 
+	
     allocate(this%n_irrig_steps_left     (begp:endp))             ; this%n_irrig_steps_left   (:)   = 0
     
     !-----------------------------------------------------------------------
     ! initialize history fields for select members of veg_wf
     !-----------------------------------------------------------------------
-    this%qflx_irrig(begp:endp) = spval
-    call hist_addfld1d (fname='QIRRIG', units='mm/s', &
-         avgflag='A', long_name='water added through irrigation', &
-         ptr_patch=this%qflx_irrig)
+    !this%qflx_irrig(begp:endp) = spval
+    !call hist_addfld1d (fname='QIRRIG', units='mm/s', &
+    !     avgflag='A', long_name='water added through irrigation', &
+    !     ptr_patch=this%qflx_irrig)
+		 
+    this%qflx_irrig_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QIRRIG_ORIG', units='mm/s', &
+         avgflag='A', long_name='Original total irrigation water demand (surface + ground)', &
+         ptr_patch=this%qflx_irrig_patch)
+		 
+    this%qflx_real_irrig_patch(begp:endp) = spval     ! real irrig
+    call hist_addfld1d (fname='QIRRIG_REAL', units='mm/s', &
+         avgflag='A', long_name='actual water added through irrigation (surface + ground)', &
+         ptr_patch=this%qflx_real_irrig_patch)
+    
+    this%qflx_supply_patch(begp:endp) = spval     
+    call hist_addfld1d (fname='QSUPPLY', units='mm/s', &
+         avgflag='A', long_name='irrigation supply from MOSART', &
+         ptr_patch=this%qflx_supply_patch)
+         
+    this%qflx_surf_irrig_patch(begp:endp) = spval    
+    call hist_addfld1d (fname='QSURF_IRRIG', units='mm/s', &
+         avgflag='A', long_name='Surface water irrigation', &
+         ptr_patch=this%qflx_surf_irrig_patch)
+    
+    this%qflx_grnd_irrig_patch(begp:endp) = spval   
+    call hist_addfld1d (fname='QGRND_IRRIG', units='mm/s', &
+         avgflag='A', long_name='Groundwater irrigation', &
+         ptr_patch=this%qflx_grnd_irrig_patch)
+		 
+    this%qflx_over_supply_patch(begp:endp) = spval   
+    call hist_addfld1d (fname='QOVER_SUPPLY', units='mm/s', &
+         avgflag='A', long_name='Over supplied irrigation due to remapping, added to irrigation to conserve mass', &
+         ptr_patch=this%qflx_over_supply_patch)
 
     this%qflx_prec_intr(begp:endp) = spval
     call hist_addfld1d (fname='QINTR', units='mm/s',  &

--- a/components/clm/src/main/atm2lndType.F90
+++ b/components/clm/src/main/atm2lndType.F90
@@ -104,7 +104,8 @@ module atm2lndType
      real(r8), pointer :: forc_flood_grc                (:)   => null() ! rof flood (mm/s)
      real(r8), pointer :: volr_grc                      (:)   => null() ! rof volr total volume (m3)
      real(r8), pointer :: volrmch_grc                   (:)   => null() ! rof volr main channel (m3)
-
+     real(r8), pointer :: supply_grc                    (:)   => null() ! rof volr supply (mm/s)
+	 
      ! anomaly forcing
      real(r8), pointer :: af_precip_grc                 (:)   => null() ! anomaly forcing 
      real(r8), pointer :: af_uwind_grc                  (:)   => null() ! anomaly forcing 
@@ -251,6 +252,7 @@ contains
     allocate(this%forc_flood_grc                (begg:endg))        ; this%forc_flood_grc                (:)   = ival
     allocate(this%volr_grc                      (begg:endg))        ; this%volr_grc                      (:)   = ival
     allocate(this%volrmch_grc                   (begg:endg))        ; this%volrmch_grc                   (:)   = ival
+    allocate(this%supply_grc                    (begg:endg))        ; this%supply_grc                    (:)   = ival
 
     ! anomaly forcing
     allocate(this%bc_precip_grc                 (begg:endg))        ; this%bc_precip_grc                 (:)   = ival
@@ -312,6 +314,11 @@ contains
     call hist_addfld1d (fname='VOLRMCH',  units='m3',  &
          avgflag='A', long_name='river channel main channel water storage', &
          ptr_lnd=this%volrmch_grc)
+		 
+    this%supply_grc(begg:endg) = spval
+    call hist_addfld1d (fname='SUPPLY',  units='mm/s',  &
+         avgflag='A', long_name='runoff supply for land use', &
+         ptr_lnd=this%supply_grc)
 
 !    this%forc_wind_grc(begg:endg) = spval
 !    call hist_addfld1d (fname='WIND', units='m/s',  &

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -1735,7 +1735,7 @@ contains
          col_wf%qflx_dew_snow(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_nolakec, filter_nolakec, &
-         veg_wf%qflx_irrig(bounds%begp:bounds%endp), &
+         veg_wf%qflx_irrig_patch(bounds%begp:bounds%endp), &
          col_wf%qflx_irrig(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_nolakec, filter_nolakec, &

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -122,7 +122,14 @@ module clm_varctl
   !----------------------------------------------------------
 
   ! do not irrigate by default
-  logical, public :: irrigate = .false.            
+  logical, public :: irrigate = .false.
+
+  !----------------------------------------------------------
+  ! Two-way coupled irrigation with MOSART
+  !----------------------------------------------------------
+
+  ! True is 2way, false is 1way
+  logical, public :: twowayirrigation = .false.  
 
   !----------------------------------------------------------
   ! Landunit logic

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -129,7 +129,7 @@ module clm_varctl
   !----------------------------------------------------------
 
   ! True is 2way, false is 1way
-  logical, public :: twowayirrigation = .false.  
+  logical, public :: tw_irr = .false.  
 
   !----------------------------------------------------------
   ! Landunit logic

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -209,7 +209,7 @@ contains
     namelist /clm_inparm/  &
          clump_pproc, wrtdia, &
          create_crop_landunit, nsegspc, co2_ppmv, override_nsrest, &
-         albice, more_vertlayers, subgridflag, irrigate, all_active
+         albice, more_vertlayers, subgridflag, irrigate, tw_irr, all_active
     ! Urban options
 
     namelist /clm_inparm/  &
@@ -619,6 +619,7 @@ contains
 
     ! Irrigation
     call mpi_bcast(irrigate, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast(tw_irr, 1, MPI_LOGICAL, 0, mpicom, ier)
 
     ! Landunit generation
     call mpi_bcast(create_crop_landunit, 1, MPI_LOGICAL, 0, mpicom, ier)

--- a/components/clm/src/main/lnd2atmMod.F90
+++ b/components/clm/src/main/lnd2atmMod.F90
@@ -293,6 +293,11 @@ contains
          col_wf%qflx_h2osfc_surf (bounds%begc:bounds%endc), &
          lnd2atm_vars%qflx_rofliq_qsurp_grc  (bounds%begg:bounds%endg), &
          c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+		 
+    call c2g( bounds, &
+         col_wf%qflx_irr_demand (bounds%begc:bounds%endc), &
+         lnd2atm_vars%qflx_irr_demand_grc   (bounds%begg:bounds%endg), &
+         c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
 
     call c2g( bounds, &
          col_wf%qflx_drain (bounds%begc:bounds%endc), &

--- a/components/clm/src/main/lnd2atmType.F90
+++ b/components/clm/src/main/lnd2atmType.F90
@@ -56,7 +56,7 @@ module lnd2atmType
      real(r8), pointer :: qflx_rofliq_qsub_grc (:) => null() ! rof liq -- subsurface runoff component
      real(r8), pointer :: qflx_rofliq_qsubp_grc(:) => null() ! rof liq -- perched subsurface runoff component
      real(r8), pointer :: qflx_rofliq_qgwl_grc (:) => null() ! rof liq -- glacier, wetland and lakes water balance residual component
-	 real(r8), pointer :: qflx_irr_demand_grc  (:) => null() ! rof liq -- demand term
+     real(r8), pointer :: qflx_irr_demand_grc  (:) => null() ! rof liq -- demand term
      real(r8), pointer :: qflx_rofice_grc      (:) => null() ! rof ice forcing
 
      real(r8), pointer :: qflx_rofliq_qsur_doc_grc(:) => null()

--- a/components/clm/src/main/lnd2atmType.F90
+++ b/components/clm/src/main/lnd2atmType.F90
@@ -56,6 +56,7 @@ module lnd2atmType
      real(r8), pointer :: qflx_rofliq_qsub_grc (:) => null() ! rof liq -- subsurface runoff component
      real(r8), pointer :: qflx_rofliq_qsubp_grc(:) => null() ! rof liq -- perched subsurface runoff component
      real(r8), pointer :: qflx_rofliq_qgwl_grc (:) => null() ! rof liq -- glacier, wetland and lakes water balance residual component
+	 real(r8), pointer :: qflx_irr_demand_grc  (:) => null() ! rof liq -- demand term
      real(r8), pointer :: qflx_rofice_grc      (:) => null() ! rof ice forcing
 
      real(r8), pointer :: qflx_rofliq_qsur_doc_grc(:) => null()
@@ -128,6 +129,7 @@ contains
     allocate(this%qflx_rofliq_qsub_grc (begg:endg))            ; this%qflx_rofliq_qsub_grc (:) =ival
     allocate(this%qflx_rofliq_qsubp_grc(begg:endg))            ; this%qflx_rofliq_qsubp_grc(:) =ival
     allocate(this%qflx_rofliq_qgwl_grc (begg:endg))            ; this%qflx_rofliq_qgwl_grc (:) =ival
+    allocate(this%qflx_irr_demand_grc  (begg:endg))            ; this%qflx_irr_demand_grc  (:) =ival
     allocate(this%qflx_rofice_grc      (begg:endg))            ; this%qflx_rofice_grc      (:) =ival
 
     allocate(this%qflx_rofliq_qsur_doc_grc(begg:endg))          ; this%qflx_rofliq_qsur_doc_grc(:) = ival

--- a/components/clm/src/main/surfrdMod.F90
+++ b/components/clm/src/main/surfrdMod.F90
@@ -12,7 +12,7 @@ module surfrdMod
   use clm_varpar      , only : nlevsoifl, numpft, numcft
   use landunit_varcon , only : numurbl
   use clm_varcon      , only : grlnd
-  use clm_varctl      , only : iulog, scmlat, scmlon, single_column, twowayirrigation
+  use clm_varctl      , only : iulog, scmlat, scmlon, single_column, tw_irr
   use clm_varctl      , only : create_glacier_mec_landunit
   use surfrdUtilsMod  , only : check_sums_equal_1
   use ncdio_pio       , only : file_desc_t, var_desc_t, ncd_pio_openfile, ncd_pio_closefile
@@ -548,10 +548,11 @@ contains
     !    o real % abundance PFTs (as a percent of vegetated area)
     !
     ! !USES:
-    use clm_varctl  , only : create_crop_landunit
+    use clm_varctl  , only : create_crop_landunit, tw_irr
     use fileutils   , only : getfil
     use domainMod   , only : domain_type, domain_init, domain_clean
     use clm_varsur  , only : wt_lunit, topo_glc_mec
+
     !
     ! !ARGUMENTS:
     integer,          intent(in) :: begg, endg      
@@ -654,7 +655,7 @@ contains
     call surfrd_special(begg, endg, ncid, ldomain%ns)
 	
 	! Obtain firrig and surface/grnd irrigation fraction
-    if (twowayirrigation) then
+    if (tw_irr) then
      call ncd_io(ncid=ncid, varname='FIRRIG', flag='read', data=ldomain%firrig, &
           dim1name=grlnd, readvar=readvar)
      if (.not. readvar) call endrun( trim(subname)//' ERROR: FIRRIG NOT on surfdata file' )!

--- a/components/clm/src/main/surfrdMod.F90
+++ b/components/clm/src/main/surfrdMod.F90
@@ -12,7 +12,7 @@ module surfrdMod
   use clm_varpar      , only : nlevsoifl, numpft, numcft
   use landunit_varcon , only : numurbl
   use clm_varcon      , only : grlnd
-  use clm_varctl      , only : iulog, scmlat, scmlon, single_column
+  use clm_varctl      , only : iulog, scmlat, scmlon, single_column, twowayirrigation
   use clm_varctl      , only : create_glacier_mec_landunit
   use surfrdUtilsMod  , only : check_sums_equal_1
   use ncdio_pio       , only : file_desc_t, var_desc_t, ncd_pio_openfile, ncd_pio_closefile
@@ -652,7 +652,21 @@ contains
     ! Obtain special landunit info
 
     call surfrd_special(begg, endg, ncid, ldomain%ns)
+	
+	! Obtain firrig and surface/grnd irrigation fraction
+    if (twowayirrigation) then
+     call ncd_io(ncid=ncid, varname='FIRRIG', flag='read', data=ldomain%firrig, &
+          dim1name=grlnd, readvar=readvar)
+     if (.not. readvar) call endrun( trim(subname)//' ERROR: FIRRIG NOT on surfdata file' )!
 
+     call ncd_io(ncid=ncid, varname='FSURF', flag='read', data=ldomain%f_surf, &
+          dim1name=grlnd, readvar=readvar)
+     if (.not. readvar) call endrun( trim(subname)//' ERROR: FSURF NOT on surfdata file' )!
+
+     call ncd_io(ncid=ncid, varname='FGRD', flag='read', data=ldomain%f_grd, &
+          dim1name=grlnd, readvar=readvar)
+     if (.not. readvar) call endrun( trim(subname)//' ERROR: FGRD NOT on surfdata file' )
+    end if
     ! Obtain vegetated landunit info
 
     call surfrd_veg_all(begg, endg, ncid, ldomain%ns)

--- a/components/clm/src/utils/domainMod.F90
+++ b/components/clm/src/utils/domainMod.F90
@@ -31,6 +31,9 @@ module domainMod
      real(r8),pointer :: topo(:)    ! topography
      real(r8),pointer :: latc(:)    ! latitude of grid cell (deg)
      real(r8),pointer :: lonc(:)    ! longitude of grid cell (deg)
+	 real(r8),pointer :: firrig(:)
+     real(r8),pointer :: f_surf(:)  ! fraction of water withdraws from surfacewater
+     real(r8),pointer :: f_grd(:)   ! fraction of water withdraws from groundwater
      real(r8),pointer :: xCell(:)   ! x-position of grid cell (m)
      real(r8),pointer :: yCell(:)   ! y-position of grid cell (m)
      real(r8),pointer :: area(:)    ! grid cell area (km**2)
@@ -117,8 +120,8 @@ contains
        call domain_clean(domain)
     endif
     allocate(domain%mask(nb:ne),domain%frac(nb:ne),domain%latc(nb:ne), &
-             domain%pftm(nb:ne),domain%area(nb:ne),domain%lonc(nb:ne), &
-             domain%topo(nb:ne),domain%glcmask(nb:ne), &
+             domain%pftm(nb:ne),domain%area(nb:ne),domain%firrig(nb:ne),domain%lonc(nb:ne), &
+             domain%topo(nb:ne),domain%f_surf(nb:ne),domain%f_grd(nb:ne),domain%glcmask(nb:ne), &
              domain%xCell(nb:ne),domain%yCell(nb:ne),stat=ier)
     if (ier /= 0) then
        call shr_sys_abort('domain_init ERROR: allocate mask, frac, lat, lon, area ')
@@ -160,6 +163,9 @@ contains
     domain%xCell    = nan
     domain%yCell    = nan
     domain%area     = nan
+	domain%firrig   = 0.7_r8    
+    domain%f_surf   = 1.0_r8
+    domain%f_grd    = 0.0_r8
 
     domain%set      = set
     if (domain%nbeg == 1 .and. domain%nend == domain%ns) then
@@ -201,8 +207,8 @@ end subroutine domain_init
           write(iulog,*) 'domain_clean: cleaning ',domain%ni,domain%nj
        endif
        deallocate(domain%mask,domain%frac,domain%latc, &
-                  domain%lonc,domain%area,domain%pftm, &
-                  domain%topo,domain%glcmask,stat=ier)
+                  domain%lonc,domain%area,domain%firrig,domain%pftm, &
+                  domain%topo,domain%f_surf,domain%f_grd,domain%glcmask,stat=ier)
        if (ier /= 0) then
           call shr_sys_abort('domain_clean ERROR: deallocate mask, frac, lat, lon, area ')
        endif
@@ -280,6 +286,9 @@ end subroutine domain_clean
     write(iulog,*) '  domain_check mask      = ',minval(domain%mask),maxval(domain%mask)
     write(iulog,*) '  domain_check frac      = ',minval(domain%frac),maxval(domain%frac)
     write(iulog,*) '  domain_check topo      = ',minval(domain%topo),maxval(domain%topo)
+	write(iulog,*) '  domain_check firrig    = ',minval(domain%firrig),maxval(domain%firrig)
+    write(iulog,*) '  domain_check f_surf    = ',minval(domain%f_surf),maxval(domain%f_surf)
+    write(iulog,*) '  domain_check f_grd     = ',minval(domain%f_grd),maxval(domain%f_grd)
     write(iulog,*) '  domain_check area      = ',minval(domain%area),maxval(domain%area)
     write(iulog,*) '  domain_check pftm      = ',minval(domain%pftm),maxval(domain%pftm)
     write(iulog,*) '  domain_check glcmask   = ',minval(domain%glcmask),maxval(domain%glcmask)

--- a/components/clm/src/utils/domainMod.F90
+++ b/components/clm/src/utils/domainMod.F90
@@ -31,7 +31,7 @@ module domainMod
      real(r8),pointer :: topo(:)    ! topography
      real(r8),pointer :: latc(:)    ! latitude of grid cell (deg)
      real(r8),pointer :: lonc(:)    ! longitude of grid cell (deg)
-	 real(r8),pointer :: firrig(:)
+     real(r8),pointer :: firrig(:)
      real(r8),pointer :: f_surf(:)  ! fraction of water withdraws from surfacewater
      real(r8),pointer :: f_grd(:)   ! fraction of water withdraws from groundwater
      real(r8),pointer :: xCell(:)   ! x-position of grid cell (m)
@@ -163,7 +163,7 @@ contains
     domain%xCell    = nan
     domain%yCell    = nan
     domain%area     = nan
-	domain%firrig   = 0.7_r8    
+    domain%firrig   = 0.7_r8    
     domain%f_surf   = 1.0_r8
     domain%f_grd    = 0.0_r8
 
@@ -286,7 +286,7 @@ end subroutine domain_clean
     write(iulog,*) '  domain_check mask      = ',minval(domain%mask),maxval(domain%mask)
     write(iulog,*) '  domain_check frac      = ',minval(domain%frac),maxval(domain%frac)
     write(iulog,*) '  domain_check topo      = ',minval(domain%topo),maxval(domain%topo)
-	write(iulog,*) '  domain_check firrig    = ',minval(domain%firrig),maxval(domain%firrig)
+    write(iulog,*) '  domain_check firrig    = ',minval(domain%firrig),maxval(domain%firrig)
     write(iulog,*) '  domain_check f_surf    = ',minval(domain%f_surf),maxval(domain%f_surf)
     write(iulog,*) '  domain_check f_grd     = ',minval(domain%f_grd),maxval(domain%f_grd)
     write(iulog,*) '  domain_check area      = ',minval(domain%area),maxval(domain%area)

--- a/components/mosart/src/cpl/rof_comp_esmf.F90
+++ b/components/mosart/src/cpl/rof_comp_esmf.F90
@@ -41,8 +41,8 @@ module rof_comp_esmf
                                 index_x2r_Flrl_rofgwl, index_x2r_Flrl_rofsub, &
                                 index_x2r_Flrl_rofdto, &
                                 index_r2x_Flrr_flood, &
-                                index_r2x_Flrr_volr, index_r2x_Flrr_volrmch
-                                !index_r2x_Flrr_supply , index_r2x_Flrr_supplyfrac, index_x2r_Flrl_demand
+                                index_r2x_Flrr_volr, index_r2x_Flrr_volrmch, &
+                                index_r2x_Flrr_supply, index_x2r_Flrl_demand
   use perf_mod         , only : t_startf, t_stopf, t_barrierf
 !
 ! !PUBLIC MEMBER FUNCTIONS:
@@ -694,11 +694,13 @@ contains
        else
           rtmCTL%qdto(n,nliq) = 0.0_r8
        endif
+       rtmCTL%qdem(n,nliq) = fptr(index_x2r_Flrl_demand,n2) * (rtmCTL%area(n)*0.001_r8)
 
        rtmCTL%qsur(n,nfrz) = fptr(index_x2r_Flrl_rofi,n2) * (rtmCTL%area(n)*0.001_r8)
        rtmCTL%qsub(n,nfrz) = 0.0_r8
        rtmCTL%qgwl(n,nfrz) = 0.0_r8
        rtmCTL%qdto(n,nfrz) = 0.0_r8
+       rtmCTL%qdem(n,nfrz) = 0.0_r8
 
     enddo
 
@@ -800,7 +802,12 @@ contains
        fptr(index_r2x_Flrr_flood,ni) = -rtmCTL%flood(n)/(rtmCTL%area(n)*0.001_r8)
        fptr(index_r2x_Flrr_volr,ni)    = (Trunoff%wr(n,nliq) + Trunoff%wt(n,nliq)) / rtmCTL%area(n)
        fptr(index_r2x_Flrr_volrmch,ni) = Trunoff%wr(n,nliq) / rtmCTL%area(n)
-
+       fptr(index_r2x_Flrr_supply,ni)  = 0._r8  ! tcxcpl
+#ifdef INCLUDE_WRM
+       if (wrmflag) then
+          fptr(index_r2x_Flrr_supply,ni)  = StorWater%Supply(n) / (rtmCTL%area(n)*0.001_r8)    ! convert m3/s to mm/s
+       endif
+#endif
     end do
 
   end subroutine rof_export_esmf

--- a/components/mosart/src/cpl/rof_comp_esmf.F90
+++ b/components/mosart/src/cpl/rof_comp_esmf.F90
@@ -803,11 +803,11 @@ contains
        fptr(index_r2x_Flrr_volr,ni)    = (Trunoff%wr(n,nliq) + Trunoff%wt(n,nliq)) / rtmCTL%area(n)
        fptr(index_r2x_Flrr_volrmch,ni) = Trunoff%wr(n,nliq) / rtmCTL%area(n)
        fptr(index_r2x_Flrr_supply,ni)  = 0._r8  ! tcxcpl
-#ifdef INCLUDE_WRM
+
        if (wrmflag) then
           fptr(index_r2x_Flrr_supply,ni)  = StorWater%Supply(n) / (rtmCTL%area(n)*0.001_r8)    ! convert m3/s to mm/s
        endif
-#endif
+
     end do
 
   end subroutine rof_export_esmf

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -35,10 +35,11 @@ module rof_comp_mct
   use rof_cpl_indices  , only : rof_cpl_indices_set, nt_rtm, rtm_tracers, &
                                 index_x2r_Flrl_rofsur, index_x2r_Flrl_rofi, &
                                 index_x2r_Flrl_rofgwl, index_x2r_Flrl_rofsub, &
-                                index_x2r_Flrl_rofdto, &
+                                index_x2r_Flrl_rofdto, index_x2r_Flrl_demand, &
                                 index_r2x_Forr_rofl, index_r2x_Forr_rofi, &
                                 index_r2x_Flrr_flood, &
-                                index_r2x_Flrr_volr, index_r2x_Flrr_volrmch
+                                index_r2x_Flrr_volr, index_r2x_Flrr_volrmch, &
+                                index_r2x_Flrr_supply
 
   use mct_mod
   use ESMF
@@ -252,11 +253,11 @@ contains
        lsize = mct_gsMap_lsize(gsMap_rof, mpicom_rof)
        call rof_domain_mct( lsize, gsMap_rof, dom_r )
        
-       ! Initialize lnd -> mosart attribute vector		
+       ! Initialize lnd -> mosart attribute vector
        call mct_aVect_init(x2r_r, rList=seq_flds_x2r_fields, lsize=lsize)
        call mct_aVect_zero(x2r_r)
        
-       ! Initialize mosart -> ocn attribute vector		
+       ! Initialize mosart -> ocn attribute vector
        call mct_aVect_init(r2x_r, rList=seq_flds_r2x_fields, lsize=lsize)
        call mct_aVect_zero(r2x_r) 
        
@@ -594,11 +595,12 @@ contains
        else
           rtmCTL%qdto(n,nliq) = 0.0_r8
        endif
-
+      rtmCTL%qdem(n,nliq) = x2r_r%rAttr(index_x2r_Flrl_demand,n2) * (rtmCTL%area(n)*0.001_r8)
        rtmCTL%qsur(n,nfrz) = x2r_r%rAttr(index_x2r_Flrl_rofi,n2) * (rtmCTL%area(n)*0.001_r8)
        rtmCTL%qsub(n,nfrz) = 0.0_r8
        rtmCTL%qgwl(n,nfrz) = 0.0_r8
        rtmCTL%qdto(n,nfrz) = 0.0_r8
+       rtmCTL%qdem(n,nfrz) = 0.0_r8
 
     enddo
 
@@ -695,6 +697,12 @@ contains
        r2x_r%rattr(index_r2x_Flrr_flood,ni)   = -rtmCTL%flood(n) / (rtmCTL%area(n)*0.001_r8)
        r2x_r%rattr(index_r2x_Flrr_volr,ni)    = (Trunoff%wr(n,nliq) + Trunoff%wt(n,nliq)) / rtmCTL%area(n)
        r2x_r%rattr(index_r2x_Flrr_volrmch,ni) = Trunoff%wr(n,nliq) / rtmCTL%area(n)
+       r2x_r%rattr(index_r2x_Flrr_supply,ni)  = 0._r8 
+#ifdef INCLUDE_WRM
+       if (wrmflag) then
+          r2x_r%rattr(index_r2x_Flrr_supply,ni)  = StorWater%Supply(n) / (rtmCTL%area(n)*0.001_r8)   !converted to mm/s (Tian)
+       endif
+#endif
     end do
 
   end subroutine rof_export_mct

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -698,11 +698,9 @@ contains
        r2x_r%rattr(index_r2x_Flrr_volr,ni)    = (Trunoff%wr(n,nliq) + Trunoff%wt(n,nliq)) / rtmCTL%area(n)
        r2x_r%rattr(index_r2x_Flrr_volrmch,ni) = Trunoff%wr(n,nliq) / rtmCTL%area(n)
        r2x_r%rattr(index_r2x_Flrr_supply,ni)  = 0._r8 
-#ifdef INCLUDE_WRM
        if (wrmflag) then
           r2x_r%rattr(index_r2x_Flrr_supply,ni)  = StorWater%Supply(n) / (rtmCTL%area(n)*0.001_r8)   !converted to mm/s (Tian)
        endif
-#endif
     end do
 
   end subroutine rof_export_mct

--- a/components/mosart/src/cpl/rof_cpl_indices.F90
+++ b/components/mosart/src/cpl/rof_cpl_indices.F90
@@ -28,6 +28,7 @@ module rof_cpl_indices
   integer, public :: index_x2r_Flrl_rofsub = 0  ! lnd->rof liquid subsurface runoff from land
   integer, public :: index_x2r_Flrl_rofdto = 0  ! lnd->rof liquid direct to ocean runoff
   integer, public :: index_x2r_Flrl_rofi  = 0   ! lnd->rof ice runoff forcing from land
+  integer, public :: index_x2r_Flrl_demand = 0  ! lnd->rof input total fluxes (<= 0)
   integer, public :: nflds_x2r = 0
 
   !TODO - nt_rtm and rtm_tracers need to be removed and set by access to the index array
@@ -43,6 +44,7 @@ module rof_cpl_indices
   integer, public :: index_r2x_Flrr_flood = 0   ! rof->lnd flood runoff (>fthresh) back to land
   integer, public :: index_r2x_Flrr_volr = 0    ! rof->lnd volr total volume back to land
   integer, public :: index_r2x_Flrr_volrmch = 0 ! rof->lnd volr main channel back to land
+  integer, public :: index_r2x_Flrr_supply = 0  ! rof->lnd supply flux for land use
   integer, public :: nflds_r2x = 0
 
 !=======================================================================
@@ -84,6 +86,7 @@ contains
     index_x2r_Flrl_rofsub = mct_avect_indexra(avtmp,'Flrl_rofsub')
     index_x2r_Flrl_rofdto = mct_avect_indexra(avtmp,'Flrl_rofdto',perrwith='quiet')
     index_x2r_Flrl_rofi   = mct_avect_indexra(avtmp,'Flrl_rofi')
+    index_x2r_Flrl_demand = mct_avect_indexra(avtmp,'Flrl_demand')
     nflds_x2r = mct_avect_nRattr(avtmp)
 
     call mct_aVect_clean(avtmp)
@@ -97,6 +100,7 @@ contains
     index_r2x_Flrr_flood = mct_avect_indexra(avtmp,'Flrr_flood')
     index_r2x_Flrr_volr  = mct_avect_indexra(avtmp,'Flrr_volr')
     index_r2x_Flrr_volrmch = mct_avect_indexra(avtmp,'Flrr_volrmch')
+    index_r2x_Flrr_supply = mct_avect_indexra(avtmp,'Flrr_supply')
     nflds_r2x = mct_avect_nRattr(avtmp)
 
     call mct_aVect_clean(avtmp)

--- a/components/mosart/src/inundation/MOSARTinund_Core_MOD.F90
+++ b/components/mosart/src/inundation/MOSARTinund_Core_MOD.F90
@@ -1,7 +1,6 @@
 
 MODULE MOSARTinund_Core_MOD
 
-!#ifdef INCLUDE_INUND
 !--------------------------------------------------------------------------------------
 ! DESCRIPTION: Core simulation of MOSART-Inundation.
 ! 

--- a/components/mosart/src/inundation/MOSARTinund_PreProcs_MOD.F90
+++ b/components/mosart/src/inundation/MOSARTinund_PreProcs_MOD.F90
@@ -1,7 +1,6 @@
 
 MODULE MOSARTinund_PreProcs_MOD
 
-!#ifdef INCLUDE_INUND
 !-----------------------------------------------------------------------------
 ! DESCRIPTION: Pre-processing for MOSART-Inundation.
 ! 
@@ -366,6 +365,5 @@ MODULE MOSARTinund_PreProcs_MOD
   end function interpolation_linear
 
 !-----------------------------------------------------------------------------
-!#endif
   
 end MODULE MOSARTinund_PreProcs_MOD

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -39,14 +39,10 @@ module RtmMod
   use MOSART_physics_mod, only : Euler
   use MOSART_physics_mod, only : updatestate_hillslope, updatestate_subnetwork, &
                                  updatestate_mainchannel
-!#ifdef INCLUDE_WRM
   use WRM_type_mod    , only : ctlSubwWRM, WRMUnit, StorWater
   use WRM_subw_IO_mod , only : WRM_init, WRM_computeRelease
-!#endif
-!#ifdef INCLUDE_INUND
   use MOSARTinund_PreProcs_MOD, only : calc_chnlMannCoe, preprocess_elevProf
   use MOSARTinund_Core_MOD    , only : MOSARTinund_simulate, ManningEq
-!#endif 
   use RtmIO
   use mct_mod
   use perf_mod
@@ -95,7 +91,6 @@ module RtmMod
   real(r8), save, pointer :: eroutup_avg(:,:)! eroutup average over coupling period (m3/s)
   real(r8), save, pointer :: erlat_avg(:,:)  ! erlateral average over coupling period (m3/s)
 
-!#ifdef INCLUDE_INUND
   real(r8), save :: vol_chnl2fp                 ! Total volume of flows from main channels to floodplains (for all local grid cells and all sub-steps of coupling period) (m^3).
   real(r8), save :: vol_fp2chnl                 ! Total volume of flows from floodplains to main channels (for all local grid cells and all sub-steps of coupling period) (m^3).
 
@@ -105,7 +100,6 @@ module RtmMod
   real(r8), save, pointer :: totalVelo_up(:)    ! Total upward flow velocity (for all local grid cells and all sub-steps of coupling period) (m/s).
   integer, save, pointer :: chnlNum_down(:)     ! Total number of channels with downward flow velocities (for all local grid cells and all sub-steps of coupling period) (dimensionless).
   integer, save, pointer :: chnlNum_up(:)       ! Total number of channels with upward flow velocities (for all local grid cells and all sub-steps of coupling period) (dimensionless).
-!#endif
 
 ! global MOSART grid
   real(r8),pointer :: rlatc(:)    ! latitude of 1d grid cell (deg)
@@ -235,11 +229,9 @@ contains
     type(mct_sMat)    :: sMat                 ! temporary sparse matrix, needed for sMatP
     character(len=*),parameter :: subname = '(Rtmini) '
 
-!#ifdef INCLUDE_INUND
     real(r8) :: wd_chnl                       ! Channel water depth (m).
     real(r8) :: hydrR                         ! Hydraulic radius (= wet A / wet P) (m).
     real(r8) :: v_chnl                        ! Channel flow velocity (m/s).#endif
-!#endif
 !-----------------------------------------------------------------------
 
     !-------------------------------------------------------
@@ -315,21 +307,19 @@ contains
           endif
        end do
        call relavu( unitn )
-!#ifdef INCLUDE_INUND
        if (inundflag) then
-       unitn = getavu()
-       write(iulog,*) 'Read in inund_inparm namelist from: ', trim(nlfilename_rof)
-       open( unitn, file=trim(nlfilename_rof), status='old' )
-       ier = 1
-       do while ( ier /= 0 )
-          read(unitn, inund_inparm, iostat=ier)
-          if (ier < 0) then
-             call shr_sys_abort( subname//' encountered end-of-file on inund_inparm read' )
-          endif
-       end do
-       call relavu( unitn )
-	   end if
-!#endif
+          unitn = getavu()
+          write(iulog,*) 'Read in inund_inparm namelist from: ', trim(nlfilename_rof)
+          open( unitn, file=trim(nlfilename_rof), status='old' )
+          ier = 1
+          do while ( ier /= 0 )
+             read(unitn, inund_inparm, iostat=ier)
+             if (ier < 0) then
+                call shr_sys_abort( subname//' encountered end-of-file on inund_inparm read' )
+             endif
+          end do
+          call relavu( unitn )
+       end if
     end if
 
     call mpi_bcast (coupling_period,   1, MPI_INTEGER, 0, mpicom_rof, ier)
@@ -364,25 +354,23 @@ contains
 
     call mpi_bcast (rtmhist_avgflag_pertape, size(rtmhist_avgflag_pertape), MPI_CHARACTER, 0, mpicom_rof, ier)
 
-!#ifdef INCLUDE_INUND
- if (inundflag) then
-    call mpi_bcast (OPT_inund,          1, MPI_INTEGER, 0, mpicom_rof, ier)
-    call mpi_bcast (OPT_trueDW,         1, MPI_INTEGER, 0, mpicom_rof, ier)
-    call mpi_bcast (OPT_calcNr,         1, MPI_INTEGER, 0, mpicom_rof, ier)
-    call mpi_bcast (nr_max,             1, MPI_REAL8  , 0, mpicom_rof, ier)
-    call mpi_bcast (nr_min,             1, MPI_REAL8  , 0, mpicom_rof, ier)
-    call mpi_bcast (nr_uniform,         1, MPI_REAL8  , 0, mpicom_rof, ier)
-    call mpi_bcast (rdepth_max,         1, MPI_REAL8  , 0, mpicom_rof, ier)
-    call mpi_bcast (rdepth_min,         1, MPI_REAL8  , 0, mpicom_rof, ier)
-    call mpi_bcast (rwidth_max,         1, MPI_REAL8  , 0, mpicom_rof, ier)
-    call mpi_bcast (rwidth_min,         1, MPI_REAL8  , 0, mpicom_rof, ier)
-    call mpi_bcast (rslp_assume,        1, MPI_REAL8  , 0, mpicom_rof, ier)
-    call mpi_bcast (minL_tribRouting,   1, MPI_REAL8  , 0, mpicom_rof, ier)
-    call mpi_bcast (OPT_elevProf,       1, MPI_INTEGER, 0, mpicom_rof, ier)
-    call mpi_bcast (npt_elevProf,       1, MPI_INTEGER, 0, mpicom_rof, ier)
-    call mpi_bcast (threshold_slpRatio, 1, MPI_REAL8  , 0, mpicom_rof, ier)
- end if
-!#endif
+    if (inundflag) then
+       call mpi_bcast (OPT_inund,          1, MPI_INTEGER, 0, mpicom_rof, ier)
+       call mpi_bcast (OPT_trueDW,         1, MPI_INTEGER, 0, mpicom_rof, ier)
+       call mpi_bcast (OPT_calcNr,         1, MPI_INTEGER, 0, mpicom_rof, ier)
+       call mpi_bcast (nr_max,             1, MPI_REAL8  , 0, mpicom_rof, ier)
+       call mpi_bcast (nr_min,             1, MPI_REAL8  , 0, mpicom_rof, ier)
+       call mpi_bcast (nr_uniform,         1, MPI_REAL8  , 0, mpicom_rof, ier)
+       call mpi_bcast (rdepth_max,         1, MPI_REAL8  , 0, mpicom_rof, ier)
+       call mpi_bcast (rdepth_min,         1, MPI_REAL8  , 0, mpicom_rof, ier)
+       call mpi_bcast (rwidth_max,         1, MPI_REAL8  , 0, mpicom_rof, ier)
+       call mpi_bcast (rwidth_min,         1, MPI_REAL8  , 0, mpicom_rof, ier)
+       call mpi_bcast (rslp_assume,        1, MPI_REAL8  , 0, mpicom_rof, ier)
+       call mpi_bcast (minL_tribRouting,   1, MPI_REAL8  , 0, mpicom_rof, ier)
+       call mpi_bcast (OPT_elevProf,       1, MPI_INTEGER, 0, mpicom_rof, ier)
+       call mpi_bcast (npt_elevProf,       1, MPI_INTEGER, 0, mpicom_rof, ier)
+       call mpi_bcast (threshold_slpRatio, 1, MPI_REAL8  , 0, mpicom_rof, ier)
+    end if
 
     runtyp(:)               = 'missing'
     runtyp(nsrStartup  + 1) = 'initial'
@@ -393,25 +381,23 @@ contains
     Tctl%DLevelH2R     = DLevelH2R
     Tctl%DLevelR       = DLevelR
 
-!#ifdef INCLUDE_INUND
     if (inundflag) then
-    Tctl%OPT_inund = OPT_inund     !
-    Tctl%OPT_trueDW = OPT_trueDW   ! diffusion wave method
-    Tctl%OPT_calcNr = OPT_calcNr   ! method to calculate channel Manning
-    Tctl%nr_max = nr_max           ! Max Manning coefficient
-    Tctl%nr_min = nr_min           ! Min Manning coefficient
-    Tctl%nr_uniform = nr_uniform   ! uniform Manning for all channels
-    Tctl%rdepth_max = rdepth_max   ! Max channel depth
-    Tctl%rdepth_min = rdepth_min   ! Min channel depth
-    Tctl%rwidth_max = rwidth_max   ! Max channel width
-    Tctl%rwidth_min = rwidth_min   ! Min channel width
-    Tctl%rslp_assume = rslp_assume ! assumed riverbed slope if input slope<=0
-    Tctl%minL_tribRouting = minL_tribRouting
-    Tctl%OPT_elevProf = OPT_elevProf
-    Tctl%npt_elevProf = npt_elevProf
-    Tctl%threshold_slpRatio = threshold_slpRatio
-	end if
-!#endif
+       Tctl%OPT_inund = OPT_inund     !
+       Tctl%OPT_trueDW = OPT_trueDW   ! diffusion wave method
+       Tctl%OPT_calcNr = OPT_calcNr   ! method to calculate channel Manning
+       Tctl%nr_max = nr_max           ! Max Manning coefficient
+       Tctl%nr_min = nr_min           ! Min Manning coefficient
+       Tctl%nr_uniform = nr_uniform   ! uniform Manning for all channels
+       Tctl%rdepth_max = rdepth_max   ! Max channel depth
+       Tctl%rdepth_min = rdepth_min   ! Min channel depth
+       Tctl%rwidth_max = rwidth_max   ! Max channel width
+       Tctl%rwidth_min = rwidth_min   ! Min channel width
+       Tctl%rslp_assume = rslp_assume ! assumed riverbed slope if input slope<=0
+       Tctl%minL_tribRouting = minL_tribRouting
+       Tctl%OPT_elevProf = OPT_elevProf
+       Tctl%npt_elevProf = npt_elevProf
+       Tctl%threshold_slpRatio = threshold_slpRatio
+    end if
 
     if (masterproc) then
        write(iulog,*) 'define run:'
@@ -432,7 +418,6 @@ contains
        if (nsrest == nsrStartup .and. finidat_rtm /= ' ') then
           write(iulog,*) '   MOSART initial data   = ',trim(finidat_rtm)
        end if
-!#ifdef INCLUDE_INUND
        if (inundflag) then
           write(iulog,*) ' '
           write(iulog,*) 'inundation settings:'
@@ -452,7 +437,6 @@ contains
           write(iulog,*) '  npt_elevProf       = ',Tctl%npt_elevProf
           write(iulog,*) '  threshold_slpRatio = ',Tctl%threshold_slpRatio
        endif
-!#endif
     endif
 
     rtm_active = do_rtm
@@ -1124,33 +1108,31 @@ contains
     eroutup_avg(:,:) = 0._r8
     erlat_avg(:,:)   = 0._r8
 
-!#ifdef INCLUDE_INUND
- if (inundflag) then
-    ! If inundation scheme is turned on :
-    !if ( Tctl%OPT_inund .eq. 1 ) then
-      allocate ( fa_fp_cplPeriod(rtmCTL%begr : rtmCTL%endr), stat=ier )
-      if (ier /= 0) then
-        write(iulog, *) subname,' Allocation ERROR for "fa_fp_cplPeriod".'
-        call shr_sys_abort(subname//' Allocationt ERROR for "fa_fp_cplPeriod".')
-      end if
-      fa_fp_cplPeriod(:) = 0._r8
-    !end if
+    if (inundflag) then
+       ! If inundation scheme is turned on :
+       !if ( Tctl%OPT_inund .eq. 1 ) then
+       allocate ( fa_fp_cplPeriod(rtmCTL%begr : rtmCTL%endr), stat=ier )
+       if (ier /= 0) then
+          write(iulog, *) subname,' Allocation ERROR for "fa_fp_cplPeriod".'
+          call shr_sys_abort(subname//' Allocationt ERROR for "fa_fp_cplPeriod".')
+       end if
+       fa_fp_cplPeriod(:) = 0._r8
+       !end if
 
-    allocate ( totalVelo_down(nt_rtm), &
-               totalVelo_up(nt_rtm), &
-               chnlNum_down(nt_rtm), &
-               chnlNum_up(nt_rtm), &
-               stat=ier )
-    if (ier /= 0) then
-      write(iulog, *) subname,' Allocation ERROR for velocity variables.'
-      call shr_sys_abort(subname//' Allocationt ERROR for velocity variables.')
+       allocate ( totalVelo_down(nt_rtm), &
+            totalVelo_up(nt_rtm), &
+            chnlNum_down(nt_rtm), &
+            chnlNum_up(nt_rtm), &
+            stat=ier )
+       if (ier /= 0) then
+          write(iulog, *) subname,' Allocation ERROR for velocity variables.'
+          call shr_sys_abort(subname//' Allocationt ERROR for velocity variables.')
+       end if
+       totalVelo_down(:) = 0._r8
+       totalVelo_up(:) = 0._r8
+       chnlNum_down(:) = 0
+       chnlNum_up(:) = 0
     end if
-    totalVelo_down(:) = 0._r8
-    totalVelo_up(:) = 0._r8
-    chnlNum_down(:) = 0
-    chnlNum_up(:) = 0
- end if
-!#endif
 
     !-------------------------------------------------------
     ! Allocate runoff datatype 
@@ -1548,15 +1530,13 @@ contains
 
     call t_stopf('mosarti_mosart_init')
 
-!#ifdef INCLUDE_WRM
- if (wrmflag) then
-    call t_startf('mosarti_wrm_init')
     if (wrmflag) then
-       call WRM_init()
-    endif
-    call t_startf('mosarti_wrm_init')
- end if
-!#endif
+       call t_startf('mosarti_wrm_init')
+       if (wrmflag) then
+          call WRM_init()
+       endif
+       call t_startf('mosarti_wrm_init')
+    end if
 
     !-------------------------------------------------------
     ! Read restart/initial info
@@ -1578,22 +1558,20 @@ contains
        TRunoff%wr   = rtmCTL%wr
        TRunoff%erout= rtmCTL%erout
 
-!#ifdef INCLUDE_INUND
- if (inundflag) then
-       ! If inundation scheme is turned on :
-       if ( Tctl%OPT_inund .eq. 1 ) then
-         !TRunoff%wf_ini(:) = rtmCTL%wf(:, 1)
-         ! Innudation floodplain water volume (m3)
-         TRunoff%wf_ini(:) = rtmCTL%inundwf(:)
-         ! Inundation floodplain water depth (m)
-         TRunoff%hf_ini(:) = rtmCTL%inundhf(:)
-         ! Inundation floodplain fraction      ! added by Tian
-         TRunoff%ff_ini(:) = rtmCTL%inundff(:)
-         ! Inundation flooded fraction      
-         TRunoff%ffunit_ini(:) = rtmCTL%inundffunit(:)
+       if (inundflag) then
+          ! If inundation scheme is turned on :
+          if ( Tctl%OPT_inund .eq. 1 ) then
+             !TRunoff%wf_ini(:) = rtmCTL%wf(:, 1)
+             ! Innudation floodplain water volume (m3)
+             TRunoff%wf_ini(:) = rtmCTL%inundwf(:)
+             ! Inundation floodplain water depth (m)
+             TRunoff%hf_ini(:) = rtmCTL%inundhf(:)
+             ! Inundation floodplain fraction      ! added by Tian
+             TRunoff%ff_ini(:) = rtmCTL%inundff(:)
+             ! Inundation flooded fraction      
+             TRunoff%ffunit_ini(:) = rtmCTL%inundffunit(:)
+          end if
        end if
- end if
-!#endif
 
     else
 !       do nt = 1,nt_rtm
@@ -1604,15 +1582,11 @@ contains
 !       enddo
 !       enddo
 
-!#ifdef INCLUDE_WRM
         if (wrmflag) then
            call WRM_computeRelease()
         endif
-!#endif
 
     endif
-
-!#ifdef INCLUDE_INUND
 
     !----------------------------------  
     ! Set inital condition (water volumes and streamflows) :
@@ -1688,8 +1662,6 @@ contains
 !#endif
 
     if (inundflag) then
-!#ifdef INCLUDE_INUND
-!tcraig, this only operates on tracer 1!
        do nr = rtmCTL%begr, rtmCTL%endr
           !if ( TUnit%mask( nr ) .gt. 0 ) then
           if ( rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3 ) then   ! 1--Land; 3--Basin outlet (downstream is ocean).
@@ -1731,7 +1703,6 @@ contains
              end if
           end do
        endif
-!#endif
     else
 
     do nt = 1,nt_rtm
@@ -1804,11 +1775,9 @@ contains
     real(r8) :: budget_terms (budget_terms_total,nt_rtm)    ! local budget sums
     real(r8) :: budget_global(budget_terms_total,nt_rtm)    ! global budget sums
 
-!#ifdef INCLUDE_INUND
     real(r8) :: budget_glb_inund(budget_terms_total, nt_rtm)! Global values.
     real(r8) :: budget_diff                 ! Percentage difference between water volume change and flux difference (%).
     character( len = 9 ) :: tracerID
-!#endif
 
     real(r8),save :: budget_accum(nt_rtm)   ! BUDGET accumulator over run
     integer ,save :: budget_accum_cnt       ! counter for budget_accum
@@ -1843,7 +1812,6 @@ contains
     integer,parameter :: bv_dstor_i= 9  ! initial dam storage
     integer,parameter :: bv_dstor_f= 10 ! final   dam storage
 
-!#ifdef INCLUDE_INUND
     integer,parameter :: bv_fp_i   = 11 ! Initial water volume over floodplains.
     integer,parameter :: bv_fp_f   = 12 ! Final water volume over floodplains.
 
@@ -1862,7 +1830,7 @@ contains
     integer,parameter :: bmask_uOcnrLnd = 37 ! Tunit%mask() is ocean, rtmCTL%mask() is land.
     integer,parameter :: bmask_uOcnrOut = 38 ! Tunit%mask() is ocean, rtmCTL%mask() is outlet.
     integer,parameter :: bmask_uOcnrOcn = 39 ! Tunit%mask() is ocean, rtmCTL%mask() is ocean.
-!#endif
+
     ! Input TERMS (rates, m3/s)
     integer,parameter :: br_qsur   = 20 ! input qsur
     integer,parameter :: br_qsub   = 21 ! input qsub
@@ -1878,7 +1846,6 @@ contains
     integer,parameter :: bv_dsupp_i= 44 ! initial dam supply
     integer,parameter :: bv_dsupp_f= 45 ! final   dam supply
 
-!#ifdef INCLUDE_INUND
     integer,parameter :: bv_chnl2fp       = 46 ! Volume of flows from main channels to floodplains (m^3).
     integer,parameter :: bv_fp2chnl       = 47 ! Volume of flows from floodplains to main channels (m^3).
     integer,parameter :: br_landOutflow   = 48 ! Total streamflow (flow rate) from land to oceans (m^3/s).
@@ -1891,7 +1858,6 @@ contains
     integer,parameter :: bVelo_downChnlNo = 56 ! Total number of main channels with downward flow velocities (dimensionless).
     integer,parameter :: bVelo_upward     = 57 ! Sum of all upward flow velocities (is negative) (m/s).
     integer,parameter :: bVelo_upChnlNo   = 58 ! Total number of channels with upward flow velocities (dimensionless).
-!#endif
 
     ! Other Diagnostic TERMS (rates, m3/s)
     integer,parameter :: br_erolpo = 60 ! erout lag ocn previous
@@ -1964,21 +1930,19 @@ contains
     rtmCTL%dvolrdtlnd = spval      ! dvolrdt masked for land (mm/s)
     rtmCTL%dvolrdtocn = spval     ! dvolrdt masked for ocn  (mm/s)
 
-!#ifdef INCLUDE_INUND
- if (inundflag) then
-    ! If inundation scheme is turned on :
-    if ( Tctl%OPT_inund .eq. 1 ) then
-      vol_chnl2fp = 0._r8
-      vol_fp2chnl = 0._r8
-      fa_fp_cplPeriod(:) = 0._r8
-    end if
+    if (inundflag) then
+       ! If inundation scheme is turned on :
+       if ( Tctl%OPT_inund .eq. 1 ) then
+          vol_chnl2fp = 0._r8
+          vol_fp2chnl = 0._r8
+          fa_fp_cplPeriod(:) = 0._r8
+       end if
 
-    totalVelo_down(:) = 0._r8
-    totalVelo_up(:) = 0._r8
-    chnlNum_down(:) = 0
-    chnlNum_up(:) = 0
- end if
-!#endif
+       totalVelo_down(:) = 0._r8
+       totalVelo_up(:) = 0._r8
+       chnlNum_down(:) = 0
+       chnlNum_up(:) = 0
+    end if
 
     if (budget_check) then
        call t_startf('mosartr_budget')
@@ -1996,7 +1960,6 @@ contains
        enddo
        enddo
 
-!#ifdef INCLUDE_INUND
        ! If inundation scheme is turned on :
        if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
          do nr = rtmCTL%begr, rtmCTL%endr
@@ -2009,9 +1972,7 @@ contains
 
          end do
        end if
-!#endif
 
-!#ifdef INCLUDE_WRM
        if (wrmflag) then
           StorWater%supply = 0._r8             !initial supply at the start of Tian Feb 2018
           nt = 1
@@ -2022,7 +1983,6 @@ contains
              budget_terms(bv_dstor_i,nt) = budget_terms(bv_dstor_i,nt) + StorWater%storage(idam)
           enddo
        endif
-!#endif
        call t_stopf('mosartr_budget')
     endif ! budget_check
 
@@ -2139,44 +2099,41 @@ contains
 
           !---- water outside the basin ---
           !---- *** DO NOT TURN THIS ONE OFF, conservation will fail *** ---
-!#ifdef INCLUDE_INUND
-     if (inundflag) then
-          if ( rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3 ) then   ! 1--Land; 3--Basin outlet (downstream is ocean).
-		  
-		  else
+          if (inundflag) then
+             if ( rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3 ) then   ! 1--Land; 3--Basin outlet (downstream is ocean).
+
+             else
                 avsrc_direct%rAttr(nt,cnt) = avsrc_direct%rAttr(nt,cnt) + &
-                TRunoff%qsub(nr,nt) + &
-                TRunoff%qsur(nr,nt) + &
-                TRunoff%qgwl(nr,nt)
+                     TRunoff%qsub(nr,nt) + &
+                     TRunoff%qsur(nr,nt) + &
+                     TRunoff%qgwl(nr,nt)
                 TRunoff%qsub(nr,nt) = 0._r8
                 TRunoff%qsur(nr,nt) = 0._r8
                 TRunoff%qgwl(nr,nt) = 0._r8
-          end if
+             end if
 
-     else
-!#else
-          if (TUnit%mask(nr) > 0) then
-!#endif
-             ! mosart euler
           else
-             avsrc_direct%rAttr(nt,cnt) = avsrc_direct%rAttr(nt,cnt) + &
-                TRunoff%qsub(nr,nt) + &
-                TRunoff%qsur(nr,nt) + &
-                TRunoff%qgwl(nr,nt)
-             TRunoff%qsub(nr,nt) = 0._r8
-             TRunoff%qsur(nr,nt) = 0._r8
-             TRunoff%qgwl(nr,nt) = 0._r8
+             if (TUnit%mask(nr) > 0) then
+                ! mosart euler
+             else
+                avsrc_direct%rAttr(nt,cnt) = avsrc_direct%rAttr(nt,cnt) + &
+                     TRunoff%qsub(nr,nt) + &
+                     TRunoff%qsur(nr,nt) + &
+                     TRunoff%qgwl(nr,nt)
+                TRunoff%qsub(nr,nt) = 0._r8
+                TRunoff%qsur(nr,nt) = 0._r8
+                TRunoff%qgwl(nr,nt) = 0._r8
+             end if
           end if
-      end if
 
           !---- all nt=2 water ---
           !---- can turn off euler_calc for this tracer ----
           if (nt == 2) then
              TUnit%euler_calc(nt) = .false.
              avsrc_direct%rAttr(nt,cnt) = avsrc_direct%rAttr(nt,cnt) + &
-                TRunoff%qsub(nr,nt) + &
-                TRunoff%qsur(nr,nt) + &
-                TRunoff%qgwl(nr,nt)
+                  TRunoff%qsub(nr,nt) + &
+                  TRunoff%qsur(nr,nt) + &
+                  TRunoff%qgwl(nr,nt)
              TRunoff%qsub(nr,nt) = 0._r8
              TRunoff%qsur(nr,nt) = 0._r8
              TRunoff%qgwl(nr,nt) = 0._r8
@@ -2257,9 +2214,7 @@ contains
      
        if (inundflag) then
           call t_startf('mosartr_inund_sim')
-!#ifdef INCLUDE_INUND
           call MOSARTinund_simulate ( )
-!#endif     
           call t_stopf('mosartr_inund_sim')
        else
           call t_startf('mosartr_euler')
@@ -2323,59 +2278,57 @@ contains
        enddo
 
 
-!#ifdef INCLUDE_INUND
-if (inundflag) then
-       ! If 'budget_check' is true & inundation scheme is turned on :
-       if ( inundflag .and. budget_check .and. Tctl%OPT_inund .eq. 1 ) then
+       if (inundflag) then
+          ! If 'budget_check' is true & inundation scheme is turned on :
+          if ( inundflag .and. budget_check .and. Tctl%OPT_inund .eq. 1 ) then
 
-         do nt = 1, 1
-           do nr = rtmCTL%begr, rtmCTL%endr
+             do nt = 1, 1
+                do nr = rtmCTL%begr, rtmCTL%endr
 
-             !if (Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2) then     ! 1 -- Land; 2 -- Basin outlet.
-             if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then    ! 1 -- Land; 3 -- Basin outlet.
+                   !if (Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2) then     ! 1 -- Land; 2 -- Basin outlet.
+                   if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then    ! 1 -- Land; 3 -- Basin outlet.
 
-               ! Accumulate flow from main channel to floodplain (for all local grid cells and all sub-steps of coupling period):
-               if ( TRunoff%se_rf(nr) .gt. 0._r8 ) then
-                 vol_chnl2fp = vol_chnl2fp + TRunoff%se_rf(nr)
+                      ! Accumulate flow from main channel to floodplain (for all local grid cells and all sub-steps of coupling period):
+                      if ( TRunoff%se_rf(nr) .gt. 0._r8 ) then
+                         vol_chnl2fp = vol_chnl2fp + TRunoff%se_rf(nr)
 
-               ! Accumulate flow from floodplain to main channel (for all local grid cells and all sub-steps of coupling period):
-               elseif ( TRunoff%se_rf(nr) .lt. 0._r8 ) then
-                 vol_fp2chnl = vol_fp2chnl - TRunoff%se_rf(nr)
-               end if
+                         ! Accumulate flow from floodplain to main channel (for all local grid cells and all sub-steps of coupling period):
+                      elseif ( TRunoff%se_rf(nr) .lt. 0._r8 ) then
+                         vol_fp2chnl = vol_fp2chnl - TRunoff%se_rf(nr)
+                      end if
 
-               ! Accumulate inundated floodplain area for all sub-steps of coupling period (for each land grid cell):
-               fa_fp_cplPeriod(nr) = fa_fp_cplPeriod(nr) + TRunoff%fa_fp(nr)
-             end if
+                      ! Accumulate inundated floodplain area for all sub-steps of coupling period (for each land grid cell):
+                      fa_fp_cplPeriod(nr) = fa_fp_cplPeriod(nr) + TRunoff%fa_fp(nr)
+                   end if
 
-           end do
-         end do
+                end do
+             end do
+          end if
+
+          if ( budget_check ) then
+
+             do nt = 1, nt_rtm
+                do nr = rtmCTL%begr, rtmCTL%endr
+
+                   if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then    ! 1 -- Land; 3 -- Basin outlet.
+                      !if (Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2) then     ! 1 -- Land; 2 -- Basin outlet.
+
+                      ! Flow velocity is downward or zero:
+                      if ( TRunoff%vr( nr, nt ) .ge. 0._r8 ) then
+                         totalVelo_down(nt) = totalVelo_down(nt) + TRunoff%vr( nr, nt )
+                         chnlNum_down(nt) = chnlNum_down(nt) + 1
+
+                         ! Flow velocity is upward (is negative):
+                      else
+                         totalVelo_up(nt) = totalVelo_up(nt) + TRunoff%vr( nr, nt )
+                         chnlNum_up(nt) = chnlNum_up(nt) + 1
+                      end if
+
+                   end if
+                end do
+             end do
+          end if
        end if
-
-       if ( budget_check ) then
-
-         do nt = 1, nt_rtm
-           do nr = rtmCTL%begr, rtmCTL%endr
-
-             if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then    ! 1 -- Land; 3 -- Basin outlet.
-             !if (Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2) then     ! 1 -- Land; 2 -- Basin outlet.
-
-               ! Flow velocity is downward or zero:
-               if ( TRunoff%vr( nr, nt ) .ge. 0._r8 ) then
-                 totalVelo_down(nt) = totalVelo_down(nt) + TRunoff%vr( nr, nt )
-                 chnlNum_down(nt) = chnlNum_down(nt) + 1
-
-               ! Flow velocity is upward (is negative):
-               else
-                 totalVelo_up(nt) = totalVelo_up(nt) + TRunoff%vr( nr, nt )
-                 chnlNum_up(nt) = chnlNum_up(nt) + 1
-               end if
-
-             end if
-           end do
-         end do
-       end if
-end if
-!#endif
 
     enddo ! nsub
 
@@ -2391,12 +2344,10 @@ end if
     eroutup_avg = eroutup_avg / float(nsub)
     erlat_avg   = erlat_avg   / float(nsub)
 
-!#ifdef INCLUDE_INUND
-if (inundflag) then
-    ! Mean inundated floodplain area for all sub-steps of coupling period (for each land grid cell):
-    fa_fp_cplPeriod = fa_fp_cplPeriod / float(nsub)
-endif
-!#endif
+    if (inundflag) then
+       ! Mean inundated floodplain area for all sub-steps of coupling period (for each land grid cell):
+       fa_fp_cplPeriod = fa_fp_cplPeriod / float(nsub)
+    endif
 
     !-----------------------------------
     ! update states when subsycling completed
@@ -2407,8 +2358,6 @@ endif
     rtmCTL%wr      = TRunoff%wr
     rtmCTL%erout   = TRunoff%erout
 
-!#ifdef INCLUDE_INUND
-
     ! If inundation scheme is turned on :
     if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
       !rtmCTL%wf(:, 1) = TRunoff%wf_ini(:)
@@ -2418,18 +2367,14 @@ endif
       rtmCTL%inundffunit(:) = TRunoff%ffunit_ini(:)
     end if
 
-!#endif
-
     do nt = 1,nt_rtm
     do nr = rtmCTL%begr,rtmCTL%endr
        volr_init = rtmCTL%volr(nr,nt)
        rtmCTL%volr(nr,nt) = (TRunoff%wt(nr,nt) + TRunoff%wr(nr,nt) + &
                              TRunoff%wh(nr,nt)*rtmCTL%area(nr)) * TUnit%frac(nr)
-!#ifdef INCLUDE_INUND
        if (inundflag .and. Tctl%OPT_inund == 1 .and. nt == 1) then
           rtmCTL%volr(nr,nt) = rtmCTL%volr(nr,nt) + TRunoff%wf_ini(nr)
        endif
-!#endif
        rtmCTL%dvolrdt(nr,nt) = (rtmCTL%volr(nr,nt) - volr_init) / delt_coupling
        rtmCTL%runoff(nr,nt) = flow(nr,nt)
 
@@ -2491,7 +2436,6 @@ endif
        do nr = rtmCTL%begr,rtmCTL%endr
           budget_terms(br_flood,nt) = budget_terms(br_flood,nt) + rtmCTL%flood(nr)*delt_coupling           ! (This flood volume is from former method. It equals zero when the inundation scheme is turned on. --Inund.)
        enddo
-!#ifdef INCLUDE_WRM
        if (wrmflag) then
           nt = 1
           do nr = rtmCTL%begr,rtmCTL%endr
@@ -2505,130 +2449,127 @@ endif
              budget_terms(bv_dstor_f,nt) = budget_terms(bv_dstor_f,nt) + StorWater%storage(idam)
           enddo
        endif
-!#endif
 
-!#ifdef INCLUDE_INUND
-if (inundflag) then
-       do nt = 1, nt_rtm
-         do nr = rtmCTL%begr, rtmCTL%endr
-           if (rtmCTL%mask(nr) .eq. 3) then        ! 3 -- Basin outlet (downstream is ocean).
-           !if ( Tunit%mask(nr) .eq. 2 ) then      ! 2 -- Basin outlet (downstream is ocean).
-             ! Total streamflow (flow rate) from land to oceans (m^3/s):
-             budget_terms(br_landOutflow, nt) = budget_terms(br_landOutflow, nt) + rtmCTL%runoff(nr, nt)
-           end if
-         end do
-       end do
+       if (inundflag) then
+          do nt = 1, nt_rtm
+             do nr = rtmCTL%begr, rtmCTL%endr
+                if (rtmCTL%mask(nr) .eq. 3) then        ! 3 -- Basin outlet (downstream is ocean).
+                   !if ( Tunit%mask(nr) .eq. 2 ) then      ! 2 -- Basin outlet (downstream is ocean).
+                   ! Total streamflow (flow rate) from land to oceans (m^3/s):
+                   budget_terms(br_landOutflow, nt) = budget_terms(br_landOutflow, nt) + rtmCTL%runoff(nr, nt)
+                end if
+             end do
+          end do
 
-       ! If inundation scheme is turned on :
-       if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
+          ! If inundation scheme is turned on :
+          if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
 
-         ! Total volume of flows from main channels to floodplains (for all local grid cells and all sub-steps of coupling period) (m^3):
-         budget_terms(bv_chnl2fp, 1) = vol_chnl2fp
+             ! Total volume of flows from main channels to floodplains (for all local grid cells and all sub-steps of coupling period) (m^3):
+             budget_terms(bv_chnl2fp, 1) = vol_chnl2fp
 
-         ! Total volume of flows from floodplains to main channels (for all local grid cells and all sub-steps of coupling period) (m^3):
-         budget_terms(bv_fp2chnl, 1) = vol_fp2chnl
+             ! Total volume of flows from floodplains to main channels (for all local grid cells and all sub-steps of coupling period) (m^3):
+             budget_terms(bv_fp2chnl, 1) = vol_fp2chnl
 
-         do nr = rtmCTL%begr, rtmCTL%endr
-           if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then      ! 1 -- Land; 3 -- Basin outlet.
-           !if ( Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2 ) then     ! 1--Land; 2--Basin outlet (downstream is ocean).
+             do nr = rtmCTL%begr, rtmCTL%endr
+                if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then      ! 1 -- Land; 3 -- Basin outlet.
+                   !if ( Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2 ) then     ! 1--Land; 2--Basin outlet (downstream is ocean).
 
-             ! Water volume over floodplains at coupling-period end:
-             if ( Tctl%OPT_inund .eq. 1 ) then
-                budget_terms(bv_fp_f, 1) = budget_terms(bv_fp_f, 1) + TRunoff%wf_ini(nr)
-             endif
+                   ! Water volume over floodplains at coupling-period end:
+                   if ( Tctl%OPT_inund .eq. 1 ) then
+                      budget_terms(bv_fp_f, 1) = budget_terms(bv_fp_f, 1) + TRunoff%wf_ini(nr)
+                   endif
 
-             ! Sum up channel surface area:
-             budget_terms(bi_mainChnlArea, 1) = budget_terms(bi_mainChnlArea, 1) + TUnit%area(nr) * TUnit%frac(nr) * TUnit%a_chnl(nr)
+                   ! Sum up channel surface area:
+                   budget_terms(bi_mainChnlArea, 1) = budget_terms(bi_mainChnlArea, 1) + TUnit%area(nr) * TUnit%frac(nr) * TUnit%a_chnl(nr)
 
-             ! Sum up flooded area (including channel area):
-             budget_terms(bi_floodedArea, 1) = budget_terms(bi_floodedArea, 1) + fa_fp_cplPeriod(nr) + TUnit%area(nr) * TUnit%frac(nr) * TUnit%a_chnl(nr)
+                   ! Sum up flooded area (including channel area):
+                   budget_terms(bi_floodedArea, 1) = budget_terms(bi_floodedArea, 1) + fa_fp_cplPeriod(nr) + TUnit%area(nr) * TUnit%frac(nr) * TUnit%a_chnl(nr)
 
-             ! Sum up land area:
-             budget_terms(bi_landArea, 1) = budget_terms(bi_landArea, 1) + TUnit%area(nr) * TUnit%frac(nr)
-           end if
-         end do
-       end if
+                   ! Sum up land area:
+                   budget_terms(bi_landArea, 1) = budget_terms(bi_landArea, 1) + TUnit%area(nr) * TUnit%frac(nr)
+                end if
+             end do
+          end if
 
-       do nt = 1, nt_rtm
-         ! Total downward flow velocity (for all local grid cells and all sub-steps of coupling period) (m/s):
-         budget_terms(bVelo_downward, nt) = totalVelo_down(nt)
+          do nt = 1, nt_rtm
+             ! Total downward flow velocity (for all local grid cells and all sub-steps of coupling period) (m/s):
+             budget_terms(bVelo_downward, nt) = totalVelo_down(nt)
 
-         ! Total upward flow velocity (for all local grid cells and all sub-steps of coupling period) (m/s):
-         budget_terms(bVelo_upward, nt) = totalVelo_up(nt)
+             ! Total upward flow velocity (for all local grid cells and all sub-steps of coupling period) (m/s):
+             budget_terms(bVelo_upward, nt) = totalVelo_up(nt)
 
-         ! Total number of channels with downward flow velocities (for all local grid cells and all sub-steps of coupling period):
-         budget_terms(bVelo_downChnlNo, nt) = chnlNum_down(nt)
+             ! Total number of channels with downward flow velocities (for all local grid cells and all sub-steps of coupling period):
+             budget_terms(bVelo_downChnlNo, nt) = chnlNum_down(nt)
 
-         ! Total number of channels with upward flow velocities (for all local grid cells and all sub-steps of coupling period):
-         budget_terms(bVelo_upChnlNo, nt) = chnlNum_up(nt)
-       end do
+             ! Total number of channels with upward flow velocities (for all local grid cells and all sub-steps of coupling period):
+             budget_terms(bVelo_upChnlNo, nt) = chnlNum_up(nt)
+          end do
 
-       !--- Debug: compare rtmCTL%mask() and Tunit%mask() ---
-       do nr = rtmCTL%begr, rtmCTL%endr
-         ! Tunit%mask() is land, but rtmCTL%mask() is not land :
-         if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .ne. 1 ) then
-           budget_terms(bmask_lndErr, 1) = budget_terms(bmask_lndErr, 1) + 1
-         end if
+          !--- Debug: compare rtmCTL%mask() and Tunit%mask() ---
+          do nr = rtmCTL%begr, rtmCTL%endr
+             ! Tunit%mask() is land, but rtmCTL%mask() is not land :
+             if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .ne. 1 ) then
+                budget_terms(bmask_lndErr, 1) = budget_terms(bmask_lndErr, 1) + 1
+             end if
 
-         ! Tunit%mask() is basin outlet, but rtmCTL%mask() is not basin outlet :
-         if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .ne. 3 ) then
-           budget_terms(bmask_outErr, 1) = budget_terms(bmask_outErr, 1) + 1
-         end if
+             ! Tunit%mask() is basin outlet, but rtmCTL%mask() is not basin outlet :
+             if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .ne. 3 ) then
+                budget_terms(bmask_outErr, 1) = budget_terms(bmask_outErr, 1) + 1
+             end if
 
-         ! Tunit%mask() is ocean, but rtmCTL%mask() is not ocean :
-         if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .ne. 2 ) then
-           budget_terms(bmask_ocnErr, 1) = budget_terms(bmask_ocnErr, 1) + 1
-         end if
+             ! Tunit%mask() is ocean, but rtmCTL%mask() is not ocean :
+             if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .ne. 2 ) then
+                budget_terms(bmask_ocnErr, 1) = budget_terms(bmask_ocnErr, 1) + 1
+             end if
 
-         ! Tunit%mask() is land, rtmCTL%mask() is land :
-         if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 1 ) then
-           budget_terms(bmask_uLndrLnd, 1) = budget_terms(bmask_uLndrLnd, 1) + 1
-         end if
+             ! Tunit%mask() is land, rtmCTL%mask() is land :
+             if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 1 ) then
+                budget_terms(bmask_uLndrLnd, 1) = budget_terms(bmask_uLndrLnd, 1) + 1
+             end if
 
-         ! Tunit%mask() is land, rtmCTL%mask() is outlet :
-         if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 3 ) then
-           budget_terms(bmask_uLndrOut, 1) = budget_terms(bmask_uLndrOut, 1) + 1
-         end if
+             ! Tunit%mask() is land, rtmCTL%mask() is outlet :
+             if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 3 ) then
+                budget_terms(bmask_uLndrOut, 1) = budget_terms(bmask_uLndrOut, 1) + 1
+             end if
 
-         ! Tunit%mask() is land, rtmCTL%mask() is ocean :
-         if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 2 ) then
-           budget_terms(bmask_uLndrOcn, 1) = budget_terms(bmask_uLndrOcn, 1) + 1
-         end if
+             ! Tunit%mask() is land, rtmCTL%mask() is ocean :
+             if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 2 ) then
+                budget_terms(bmask_uLndrOcn, 1) = budget_terms(bmask_uLndrOcn, 1) + 1
+             end if
 
-         ! Tunit%mask() is outlet, rtmCTL%mask() is land :
-         if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 1 ) then
-           budget_terms(bmask_uOutrLnd, 1) = budget_terms(bmask_uOutrLnd, 1) + 1
-         end if
+             ! Tunit%mask() is outlet, rtmCTL%mask() is land :
+             if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 1 ) then
+                budget_terms(bmask_uOutrLnd, 1) = budget_terms(bmask_uOutrLnd, 1) + 1
+             end if
 
-         ! Tunit%mask() is outlet, rtmCTL%mask() is outlet :
-         if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 3 ) then
-           budget_terms(bmask_uOutrOut, 1) = budget_terms(bmask_uOutrOut, 1) + 1
-         end if
+             ! Tunit%mask() is outlet, rtmCTL%mask() is outlet :
+             if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 3 ) then
+                budget_terms(bmask_uOutrOut, 1) = budget_terms(bmask_uOutrOut, 1) + 1
+             end if
 
-         ! Tunit%mask() is outlet, rtmCTL%mask() is ocean :
-         if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 2 ) then
-           budget_terms(bmask_uOutrOcn, 1) = budget_terms(bmask_uOutrOcn, 1) + 1
-         end if
+             ! Tunit%mask() is outlet, rtmCTL%mask() is ocean :
+             if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 2 ) then
+                budget_terms(bmask_uOutrOcn, 1) = budget_terms(bmask_uOutrOcn, 1) + 1
+             end if
 
-         ! Tunit%mask() is ocean, rtmCTL%mask() is land :
-         if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 1 ) then
-           budget_terms(bmask_uOcnrLnd, 1) = budget_terms(bmask_uOcnrLnd, 1) + 1
-         end if
+             ! Tunit%mask() is ocean, rtmCTL%mask() is land :
+             if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 1 ) then
+                budget_terms(bmask_uOcnrLnd, 1) = budget_terms(bmask_uOcnrLnd, 1) + 1
+             end if
 
-         ! Tunit%mask() is ocean, rtmCTL%mask() is outlet :
-         if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 3 ) then
-           budget_terms(bmask_uOcnrOut, 1) = budget_terms(bmask_uOcnrOut, 1) + 1
-         end if
+             ! Tunit%mask() is ocean, rtmCTL%mask() is outlet :
+             if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 3 ) then
+                budget_terms(bmask_uOcnrOut, 1) = budget_terms(bmask_uOcnrOut, 1) + 1
+             end if
 
-         ! Tunit%mask() is ocean, rtmCTL%mask() is ocean :
-         if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 2 ) then
-           budget_terms(bmask_uOcnrOcn, 1) = budget_terms(bmask_uOcnrOcn, 1) + 1
-         end if
+             ! Tunit%mask() is ocean, rtmCTL%mask() is ocean :
+             if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 2 ) then
+                budget_terms(bmask_uOcnrOcn, 1) = budget_terms(bmask_uOcnrOcn, 1) + 1
+             end if
 
-       end do
-       !--- Debug ---
-endif
-!#endif
+          end do
+          !--- Debug ---
+       endif
 
        ! accumulate the budget total over the run to make sure it's decreasing on avg
        budget_accum_cnt = budget_accum_cnt + 1
@@ -2682,14 +2623,12 @@ endif
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wt    = ',nt,budget_global(bv_wt_f,nt)-budget_global(bv_wt_i,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wr    = ',nt,budget_global(bv_wr_f,nt)-budget_global(bv_wr_i,nt)
 
-!#ifdef INCLUDE_INUND
             ! If inundation scheme is turned on :
             if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
               if ( nt .eq. 1 ) then
                 write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wf    = ',nt,budget_global(bv_fp_f,nt)-budget_global(bv_fp_i,nt)
               end if
             end if
-!#endif
 
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume dstor = ',nt,budget_global(bv_dstor_f,nt)-budget_global(bv_dstor_i,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' * dvolume total = ',nt,budget_volume   !(Global volume change during a coupling period. --Inund.)
@@ -2789,216 +2728,214 @@ endif
           enddo   ! (do nt = 1,nt_rtm   --Inund.)
           write(iulog,'(a)') '----------------------------------- '
 
-!#ifdef INCLUDE_INUND
-if (inundflag) then
-          write(iulog,'(a)') ' '
-          write(iulog,'(a)') '=================================================== '
-          write(iulog,'(a)') ' '
+          if (inundflag) then
+             write(iulog,'(a)') ' '
+             write(iulog,'(a)') '=================================================== '
+             write(iulog,'(a)') ' '
 
-          write(iulog,'(a)') 'MOSART-Inundation simulation information (global total or average values):'
+             write(iulog,'(a)') 'MOSART-Inundation simulation information (global total or average values):'
 
-          ! Unit conversion (from million m^3 to km^3 (cubic kilometer) ):
-          !budget_glb_km3 = budget_global / 1000._r8
+             ! Unit conversion (from million m^3 to km^3 (cubic kilometer) ):
+             !budget_glb_km3 = budget_global / 1000._r8
 
-          ! Unit conversion:
+             ! Unit conversion:
 
-          ! From million m^3 to km^3 :
-          budget_glb_inund(bv_volt_i, 1) = budget_global(bv_volt_i, 1) / 1000._r8   ! Initial total surface-water volume.
-          budget_glb_inund(bv_volt_f, 1) = budget_global(bv_volt_f, 1) / 1000._r8   ! Final total surface-water volume.
-          budget_glb_inund(bv_wt_i, 1) = budget_global(bv_wt_i, 1) / 1000._r8       ! Initial water volume in subnetworks.
-          budget_glb_inund(bv_wt_f, 1) = budget_global(bv_wt_f, 1) / 1000._r8       ! Final water volume in subnetworks.
-          budget_glb_inund(bv_wr_i, 1) = budget_global(bv_wr_i, 1) / 1000._r8       ! Initial water volume in main channels.
-          budget_glb_inund(bv_wr_f, 1) = budget_global(bv_wr_f, 1) / 1000._r8       ! Final water volume in main channels.
-          budget_glb_inund(bv_wh_i, 1) = budget_global(bv_wh_i, 1) / 1000._r8       ! Inital water volume over hillslopes.
-          budget_glb_inund(bv_wh_f, 1) = budget_global(bv_wh_f, 1) / 1000._r8       ! Final water volume over hillslopes.
-          budget_glb_inund(br_qsur, 1) = budget_global(br_qsur, 1) / 1000._r8       ! Input surface runoff.
-          budget_glb_inund(br_qsub, 1) = budget_global(br_qsub, 1) / 1000._r8       ! Input sub-surface runoff.
-          budget_glb_inund(br_qgwl, 1) = budget_global(br_qgwl, 1) / 1000._r8       ! Input from glacier, wetland or lake.
-          budget_glb_inund(br_qdto, 1) = budget_global(br_qdto, 1) / 1000._r8       ! Input direct-to-ocean runoff.
-          budget_glb_inund(br_ocnout, 1) = budget_global(br_ocnout, 1) / 1000._r8   ! Output flows to oceans.
-          budget_glb_inund(br_direct, 1) = budget_global(br_direct, 1) / 1000._r8   ! Output direct to oceans.
+             ! From million m^3 to km^3 :
+             budget_glb_inund(bv_volt_i, 1) = budget_global(bv_volt_i, 1) / 1000._r8   ! Initial total surface-water volume.
+             budget_glb_inund(bv_volt_f, 1) = budget_global(bv_volt_f, 1) / 1000._r8   ! Final total surface-water volume.
+             budget_glb_inund(bv_wt_i, 1) = budget_global(bv_wt_i, 1) / 1000._r8       ! Initial water volume in subnetworks.
+             budget_glb_inund(bv_wt_f, 1) = budget_global(bv_wt_f, 1) / 1000._r8       ! Final water volume in subnetworks.
+             budget_glb_inund(bv_wr_i, 1) = budget_global(bv_wr_i, 1) / 1000._r8       ! Initial water volume in main channels.
+             budget_glb_inund(bv_wr_f, 1) = budget_global(bv_wr_f, 1) / 1000._r8       ! Final water volume in main channels.
+             budget_glb_inund(bv_wh_i, 1) = budget_global(bv_wh_i, 1) / 1000._r8       ! Inital water volume over hillslopes.
+             budget_glb_inund(bv_wh_f, 1) = budget_global(bv_wh_f, 1) / 1000._r8       ! Final water volume over hillslopes.
+             budget_glb_inund(br_qsur, 1) = budget_global(br_qsur, 1) / 1000._r8       ! Input surface runoff.
+             budget_glb_inund(br_qsub, 1) = budget_global(br_qsub, 1) / 1000._r8       ! Input sub-surface runoff.
+             budget_glb_inund(br_qgwl, 1) = budget_global(br_qgwl, 1) / 1000._r8       ! Input from glacier, wetland or lake.
+             budget_glb_inund(br_qdto, 1) = budget_global(br_qdto, 1) / 1000._r8       ! Input direct-to-ocean runoff.
+             budget_glb_inund(br_ocnout, 1) = budget_global(br_ocnout, 1) / 1000._r8   ! Output flows to oceans.
+             budget_glb_inund(br_direct, 1) = budget_global(br_direct, 1) / 1000._r8   ! Output direct to oceans.
 
-          if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
-            budget_glb_inund(bv_fp_i, 1) = budget_global(bv_fp_i, 1) / 1000._r8         ! From million m^3 to km^3 (initial water volume over floodplains).
-            budget_glb_inund(bv_fp_f, 1) = budget_global(bv_fp_f, 1) / 1000._r8         ! From million m^3 to km^3 (final water volume over floodplains).
-            budget_glb_inund(bv_chnl2fp, 1) = budget_global(bv_chnl2fp, 1) / 1000._r8   ! From million m^3 to km^3 (volume of flows from main channels to floodplains).
-            budget_glb_inund(bv_fp2chnl, 1) = budget_global(bv_fp2chnl, 1) / 1000._r8   ! From million m^3 to km^3 (volume of flows from floodplains to main channels).
-            budget_glb_inund(bi_landArea, 1) = budget_global(bi_landArea, 1) * 1.0e6_r8 / 1.0e9_r8         ! First recovered to m^2, then converted to thousand km^2 (total land area).
-            budget_glb_inund(bi_floodedArea, 1) = budget_global(bi_floodedArea, 1) * 1.0e6_r8 / 1.0e9_r8   ! First recovered to m^2, then converted to thousand km^2 (total flooded area [including channel area] ).
-            budget_glb_inund(bi_mainChnlArea, 1) = budget_global(bi_mainChnlArea, 1) * 1.0e6_r8 / 1.0e9_r8 ! First recovered to m^2, then converted to thousand km^2 (total channel surface area).
-          end if
+             if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
+                budget_glb_inund(bv_fp_i, 1) = budget_global(bv_fp_i, 1) / 1000._r8         ! From million m^3 to km^3 (initial water volume over floodplains).
+                budget_glb_inund(bv_fp_f, 1) = budget_global(bv_fp_f, 1) / 1000._r8         ! From million m^3 to km^3 (final water volume over floodplains).
+                budget_glb_inund(bv_chnl2fp, 1) = budget_global(bv_chnl2fp, 1) / 1000._r8   ! From million m^3 to km^3 (volume of flows from main channels to floodplains).
+                budget_glb_inund(bv_fp2chnl, 1) = budget_global(bv_fp2chnl, 1) / 1000._r8   ! From million m^3 to km^3 (volume of flows from floodplains to main channels).
+                budget_glb_inund(bi_landArea, 1) = budget_global(bi_landArea, 1) * 1.0e6_r8 / 1.0e9_r8         ! First recovered to m^2, then converted to thousand km^2 (total land area).
+                budget_glb_inund(bi_floodedArea, 1) = budget_global(bi_floodedArea, 1) * 1.0e6_r8 / 1.0e9_r8   ! First recovered to m^2, then converted to thousand km^2 (total flooded area [including channel area] ).
+                budget_glb_inund(bi_mainChnlArea, 1) = budget_global(bi_mainChnlArea, 1) * 1.0e6_r8 / 1.0e9_r8 ! First recovered to m^2, then converted to thousand km^2 (total channel surface area).
+             end if
 
-          budget_glb_inund(br_landOutflow, :) = budget_global(br_landOutflow, :) * 1.0e6_r8 / 1000._r8 ! First recovered to m^3/s, then converted to thousand m^3/s (total streamflow [flow rate] from land to oceans).
+             budget_glb_inund(br_landOutflow, :) = budget_global(br_landOutflow, :) * 1.0e6_r8 / 1000._r8 ! First recovered to m^3/s, then converted to thousand m^3/s (total streamflow [flow rate] from land to oceans).
 
-          budget_glb_inund(bVelo_downward, :) = budget_global(bVelo_downward, :) * 1.0e6_r8 ! Recovered to m/s (sum of all downward flow velocities).
-          budget_glb_inund(bVelo_downChnlNo, :) = budget_global(bVelo_downChnlNo, :) * 1.0e6_r8 ! Recovered to number (total number of main channels with downward flow velocities).
-          budget_glb_inund(bVelo_upward, :) = budget_global(bVelo_upward, :) * 1.0e6_r8     ! Recovered to m/s (sum of all upward flow velocities).
-          budget_glb_inund(bVelo_upChnlNo, :) = budget_global(bVelo_upChnlNo, :) * 1.0e6_r8 ! Recovered to number (total number of main channels with upward flow velocities).
+             budget_glb_inund(bVelo_downward, :) = budget_global(bVelo_downward, :) * 1.0e6_r8 ! Recovered to m/s (sum of all downward flow velocities).
+             budget_glb_inund(bVelo_downChnlNo, :) = budget_global(bVelo_downChnlNo, :) * 1.0e6_r8 ! Recovered to number (total number of main channels with downward flow velocities).
+             budget_glb_inund(bVelo_upward, :) = budget_global(bVelo_upward, :) * 1.0e6_r8     ! Recovered to m/s (sum of all upward flow velocities).
+             budget_glb_inund(bVelo_upChnlNo, :) = budget_global(bVelo_upChnlNo, :) * 1.0e6_r8 ! Recovered to number (total number of main channels with upward flow velocities).
 
-          budget_glb_inund(bmask_lndErr, :) = budget_global(bmask_lndErr, :) * 1.0e6_r8     ! Recovered to number (number of land cells not matched).
-          budget_glb_inund(bmask_outErr, :) = budget_global(bmask_outErr, :) * 1.0e6_r8     ! Recovered to number (number of outlet cells not matched).
-          budget_glb_inund(bmask_ocnErr, :) = budget_global(bmask_ocnErr, :) * 1.0e6_r8     ! Recovered to number (number of ocean cells not matched).
+             budget_glb_inund(bmask_lndErr, :) = budget_global(bmask_lndErr, :) * 1.0e6_r8     ! Recovered to number (number of land cells not matched).
+             budget_glb_inund(bmask_outErr, :) = budget_global(bmask_outErr, :) * 1.0e6_r8     ! Recovered to number (number of outlet cells not matched).
+             budget_glb_inund(bmask_ocnErr, :) = budget_global(bmask_ocnErr, :) * 1.0e6_r8     ! Recovered to number (number of ocean cells not matched).
 
-          budget_glb_inund(bmask_uLndrLnd, :) = budget_global(bmask_uLndrLnd, :) * 1.0e6_r8 ! Recovered to number (Tunit is land, rtmCTL is land).
-          budget_glb_inund(bmask_uLndrOut, :) = budget_global(bmask_uLndrOut, :) * 1.0e6_r8 ! Recovered to number (Tunit is land, rtmCTL is outlet).
-          budget_glb_inund(bmask_uLndrOcn, :) = budget_global(bmask_uLndrOcn, :) * 1.0e6_r8 ! Recovered to number (Tunit is land, rtmCTL is ocean).
+             budget_glb_inund(bmask_uLndrLnd, :) = budget_global(bmask_uLndrLnd, :) * 1.0e6_r8 ! Recovered to number (Tunit is land, rtmCTL is land).
+             budget_glb_inund(bmask_uLndrOut, :) = budget_global(bmask_uLndrOut, :) * 1.0e6_r8 ! Recovered to number (Tunit is land, rtmCTL is outlet).
+             budget_glb_inund(bmask_uLndrOcn, :) = budget_global(bmask_uLndrOcn, :) * 1.0e6_r8 ! Recovered to number (Tunit is land, rtmCTL is ocean).
 
-          budget_glb_inund(bmask_uOutrLnd, :) = budget_global(bmask_uOutrLnd, :) * 1.0e6_r8 ! Recovered to number (Tunit is outlet, rtmCTL is land).
-          budget_glb_inund(bmask_uOutrOut, :) = budget_global(bmask_uOutrOut, :) * 1.0e6_r8 ! Recovered to number (Tunit is outlet, rtmCTL is outlet).
-          budget_glb_inund(bmask_uOutrOcn, :) = budget_global(bmask_uOutrOcn, :) * 1.0e6_r8 ! Recovered to number (Tunit is outlet, rtmCTL is ocean).
+             budget_glb_inund(bmask_uOutrLnd, :) = budget_global(bmask_uOutrLnd, :) * 1.0e6_r8 ! Recovered to number (Tunit is outlet, rtmCTL is land).
+             budget_glb_inund(bmask_uOutrOut, :) = budget_global(bmask_uOutrOut, :) * 1.0e6_r8 ! Recovered to number (Tunit is outlet, rtmCTL is outlet).
+             budget_glb_inund(bmask_uOutrOcn, :) = budget_global(bmask_uOutrOcn, :) * 1.0e6_r8 ! Recovered to number (Tunit is outlet, rtmCTL is ocean).
 
-          budget_glb_inund(bmask_uOcnrLnd, :) = budget_global(bmask_uOcnrLnd, :) * 1.0e6_r8 ! Recovered to number (Tunit is ocean, rtmCTL is land).
-          budget_glb_inund(bmask_uOcnrOut, :) = budget_global(bmask_uOcnrOut, :) * 1.0e6_r8 ! Recovered to number (Tunit is ocean, rtmCTL is outlet).
-          budget_glb_inund(bmask_uOcnrOcn, :) = budget_global(bmask_uOcnrOcn, :) * 1.0e6_r8 ! Recovered to number (Tunit is ocean, rtmCTL is ocean).
+             budget_glb_inund(bmask_uOcnrLnd, :) = budget_global(bmask_uOcnrLnd, :) * 1.0e6_r8 ! Recovered to number (Tunit is ocean, rtmCTL is land).
+             budget_glb_inund(bmask_uOcnrOut, :) = budget_global(bmask_uOcnrOut, :) * 1.0e6_r8 ! Recovered to number (Tunit is ocean, rtmCTL is outlet).
+             budget_glb_inund(bmask_uOcnrOcn, :) = budget_global(bmask_uOcnrOcn, :) * 1.0e6_r8 ! Recovered to number (Tunit is ocean, rtmCTL is ocean).
 
-          !--- Debug ---
-          write(iulog,'(a)') ' '
-          write(iulog,'(a)') '---------------------------------'
-          write(iulog,'(a)') '   Compare Tunit%mask() and rtmCTL%mask() :'
-          write(iulog,'(a)') '---------------------------------'
+             !--- Debug ---
+             write(iulog,'(a)') ' '
+             write(iulog,'(a)') '---------------------------------'
+             write(iulog,'(a)') '   Compare Tunit%mask() and rtmCTL%mask() :'
+             write(iulog,'(a)') '---------------------------------'
 
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is land, but rtmCTL%mask() is not land, number     =', budget_glb_inund(bmask_lndErr, 1)
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is outlet, but rtmCTL%mask() is not outlet, number =', budget_glb_inund(bmask_outErr, 1)
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is ocean, but rtmCTL%mask() is not ocean, number   =', budget_glb_inund(bmask_ocnErr, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is land, but rtmCTL%mask() is not land, number     =', budget_glb_inund(bmask_lndErr, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is outlet, but rtmCTL%mask() is not outlet, number =', budget_glb_inund(bmask_outErr, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is ocean, but rtmCTL%mask() is not ocean, number   =', budget_glb_inund(bmask_ocnErr, 1)
 
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is land, rtmCTL%mask() is land, number     =', budget_glb_inund(bmask_uLndrLnd, 1)
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is land, rtmCTL%mask() is outlet, number   =', budget_glb_inund(bmask_uLndrOut, 1)
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is land, rtmCTL%mask() is ocean, number    =', budget_glb_inund(bmask_uLndrOcn, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is land, rtmCTL%mask() is land, number     =', budget_glb_inund(bmask_uLndrLnd, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is land, rtmCTL%mask() is outlet, number   =', budget_glb_inund(bmask_uLndrOut, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is land, rtmCTL%mask() is ocean, number    =', budget_glb_inund(bmask_uLndrOcn, 1)
 
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is outlet, rtmCTL%mask() is land, number   =', budget_glb_inund(bmask_uOutrLnd, 1)
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is outlet, rtmCTL%mask() is outlet, number =', budget_glb_inund(bmask_uOutrOut, 1)
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is outlet, rtmCTL%mask() is ocean, number  =', budget_glb_inund(bmask_uOutrOcn, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is outlet, rtmCTL%mask() is land, number   =', budget_glb_inund(bmask_uOutrLnd, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is outlet, rtmCTL%mask() is outlet, number =', budget_glb_inund(bmask_uOutrOut, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is outlet, rtmCTL%mask() is ocean, number  =', budget_glb_inund(bmask_uOutrOcn, 1)
 
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is ocean, rtmCTL%mask() is land, number    =', budget_glb_inund(bmask_uOcnrLnd, 1)
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is ocean, rtmCTL%mask() is outlet, number  =', budget_glb_inund(bmask_uOcnrOut, 1)
-          write(iulog,'(a, f22.6)') '   Tunit%mask() is ocean, rtmCTL%mask() is ocean, number   =', budget_glb_inund(bmask_uOcnrOcn, 1)
-          !--- Debug ---
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is ocean, rtmCTL%mask() is land, number    =', budget_glb_inund(bmask_uOcnrLnd, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is ocean, rtmCTL%mask() is outlet, number  =', budget_glb_inund(bmask_uOcnrOut, 1)
+             write(iulog,'(a, f22.6)') '   Tunit%mask() is ocean, rtmCTL%mask() is ocean, number   =', budget_glb_inund(bmask_uOcnrOcn, 1)
+             !--- Debug ---
 
-          do nt = 1, nt_rtm
+             do nt = 1, nt_rtm
 
-            write(iulog,'(a)') ' '
-            write(iulog,'(a, i2)') 'tracer =', nt
+                write(iulog,'(a)') ' '
+                write(iulog,'(a, i2)') 'tracer =', nt
 
-            write (tracerID, '(a7, i1, a1)') '(tracer', nt, ')'
+                write (tracerID, '(a7, i1, a1)') '(tracer', nt, ')'
 
-            write(iulog,'(a)') ' '
-            write(iulog,'(a)') trim(tracerID)//'---------------------------------'
-            write(iulog,'(a)') trim(tracerID)//'   Surface-water balance check:'
-            write(iulog,'(a)') trim(tracerID)//'---------------------------------'
-          
-            budget_input = budget_glb_inund(br_qsur, nt) + budget_glb_inund(br_qsub, nt) + budget_glb_inund(br_qgwl, nt) + budget_glb_inund(br_qdto, nt)
-            budget_output = budget_glb_inund(br_ocnout, nt) + budget_glb_inund(br_direct, nt)
+                write(iulog,'(a)') ' '
+                write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                write(iulog,'(a)') trim(tracerID)//'   Surface-water balance check:'
+                write(iulog,'(a)') trim(tracerID)//'---------------------------------'
 
-            if ( abs( budget_input - budget_output ) .lt. 1e-9_r8 ) then      ! 1e-9 km^3 = 1 m^3
-              write(iulog,'(a)') trim(tracerID)//'   Total input equals total output to oceans.'
-            else
-              budget_diff = (budget_glb_inund(bv_volt_f, nt) - budget_glb_inund(bv_volt_i, nt) - budget_input + budget_output)/abs(budget_input - budget_output) * 100._r8
-              write(iulog,'(a, f22.6)') trim(tracerID)//' * Surface-water balance error(%)             =', budget_diff
-            end if
+                budget_input = budget_glb_inund(br_qsur, nt) + budget_glb_inund(br_qsub, nt) + budget_glb_inund(br_qgwl, nt) + budget_glb_inund(br_qdto, nt)
+                budget_output = budget_glb_inund(br_ocnout, nt) + budget_glb_inund(br_direct, nt)
 
-            write(iulog,'(a, f22.6)') trim(tracerID)//' * Total volume change (km^3)                 =', budget_glb_inund(bv_volt_f, nt) - budget_glb_inund(bv_volt_i, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//' * Total input minus output to oceans (km^3)  =', budget_input - budget_output
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Input surface runoff (km^3)                =', budget_glb_inund(br_qsur, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Input sub-surface runoff (km^3)            =', budget_glb_inund(br_qsub, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Input from glacier, wetland or lake (km^3) =', budget_glb_inund(br_qgwl, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Input direct-to-ocean runoff (km^3)        =', budget_glb_inund(br_qdto, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Output flows to oceans (km^3)              =', budget_glb_inund(br_ocnout, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Output direct to oceans (km^3)             =', budget_glb_inund(br_direct, nt)
+                if ( abs( budget_input - budget_output ) .lt. 1e-9_r8 ) then      ! 1e-9 km^3 = 1 m^3
+                   write(iulog,'(a)') trim(tracerID)//'   Total input equals total output to oceans.'
+                else
+                   budget_diff = (budget_glb_inund(bv_volt_f, nt) - budget_glb_inund(bv_volt_i, nt) - budget_input + budget_output)/abs(budget_input - budget_output) * 100._r8
+                   write(iulog,'(a, f22.6)') trim(tracerID)//' * Surface-water balance error(%)             =', budget_diff
+                end if
 
-            write(iulog,'(a)') ' '
-            write(iulog,'(a)') trim(tracerID)//'---------------------------------'
-            write(iulog,'(a)') trim(tracerID)//'   Initial surface water volumes (before coupling period):'
-            write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                write(iulog,'(a, f22.6)') trim(tracerID)//' * Total volume change (km^3)                 =', budget_glb_inund(bv_volt_f, nt) - budget_glb_inund(bv_volt_i, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//' * Total input minus output to oceans (km^3)  =', budget_input - budget_output
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Input surface runoff (km^3)                =', budget_glb_inund(br_qsur, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Input sub-surface runoff (km^3)            =', budget_glb_inund(br_qsub, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Input from glacier, wetland or lake (km^3) =', budget_glb_inund(br_qgwl, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Input direct-to-ocean runoff (km^3)        =', budget_glb_inund(br_qdto, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Output flows to oceans (km^3)              =', budget_glb_inund(br_ocnout, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Output direct to oceans (km^3)             =', budget_glb_inund(br_direct, nt)
 
-            write(iulog,'(a, f22.6)') trim(tracerID)//' * Total surface water volume (km^3)          =', budget_glb_inund(bv_volt_i, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over hillslopes (km^3)              =', budget_glb_inund(bv_wh_i, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in subnetworks (km^3)               =', budget_glb_inund(bv_wt_i, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in main channels (km^3)             =', budget_glb_inund(bv_wr_i, nt)
+                write(iulog,'(a)') ' '
+                write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                write(iulog,'(a)') trim(tracerID)//'   Initial surface water volumes (before coupling period):'
+                write(iulog,'(a)') trim(tracerID)//'---------------------------------'
 
-            ! If inundation scheme is on & the 1st tracer (liquid water) :
-            if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over fps before cpl period (km^3)   =', budget_glb_inund(bv_fp_i, nt)
-            end if
+                write(iulog,'(a, f22.6)') trim(tracerID)//' * Total surface water volume (km^3)          =', budget_glb_inund(bv_volt_i, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over hillslopes (km^3)              =', budget_glb_inund(bv_wh_i, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in subnetworks (km^3)               =', budget_glb_inund(bv_wt_i, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in main channels (km^3)             =', budget_glb_inund(bv_wr_i, nt)
 
-            write(iulog,'(a)') ' '
-            write(iulog,'(a)') trim(tracerID)//'---------------------------------'
-            write(iulog,'(a)') trim(tracerID)//'   Final surface water volumes (after coupling period):'
-            write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                ! If inundation scheme is on & the 1st tracer (liquid water) :
+                if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over fps before cpl period (km^3)   =', budget_glb_inund(bv_fp_i, nt)
+                end if
 
-            write(iulog,'(a, f22.6)') trim(tracerID)//' * Total surface water volume (km^3)          =', budget_glb_inund(bv_volt_f, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over hillslopes (km^3)              =', budget_glb_inund(bv_wh_f, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in subnetworks (km^3)               =', budget_glb_inund(bv_wt_f, nt)
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in main channels (km^3)             =', budget_glb_inund(bv_wr_f, nt)
+                write(iulog,'(a)') ' '
+                write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                write(iulog,'(a)') trim(tracerID)//'   Final surface water volumes (after coupling period):'
+                write(iulog,'(a)') trim(tracerID)//'---------------------------------'
 
-            ! If inundation scheme is on & the 1st tracer (liquid water) :
-            if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over floodplains (km^3)             =', budget_glb_inund(bv_fp_f, nt)
-            end if
+                write(iulog,'(a, f22.6)') trim(tracerID)//' * Total surface water volume (km^3)          =', budget_glb_inund(bv_volt_f, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over hillslopes (km^3)              =', budget_glb_inund(bv_wh_f, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in subnetworks (km^3)               =', budget_glb_inund(bv_wt_f, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in main channels (km^3)             =', budget_glb_inund(bv_wr_f, nt)
 
-            ! If inundation scheme is on & the 1st tracer (liquid water) :
-            if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
+                ! If inundation scheme is on & the 1st tracer (liquid water) :
+                if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over floodplains (km^3)             =', budget_glb_inund(bv_fp_f, nt)
+                end if
 
-              write(iulog,'(a)') ' '
-              write(iulog,'(a)') trim(tracerID)//'---------------------------------'
-              write(iulog,'(a)') trim(tracerID)//'   Floodplain water balance check:'
-              write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                ! If inundation scheme is on & the 1st tracer (liquid water) :
+                if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
 
-              if ( abs( budget_glb_inund(bv_chnl2fp, nt) - budget_glb_inund(bv_fp2chnl, nt) ) .lt. 1e-9_r8 ) then      ! 1e-9 km^3 = 1 m^3
-                write(iulog,'(a)') trim(tracerID)//'   Total channel-to-floodplain flow equals total floodplain-to-channel flow.'
-              else
-                budget_diff = (budget_glb_inund(bv_fp_f, nt) - budget_glb_inund(bv_fp_i, nt) - budget_glb_inund(bv_chnl2fp, nt) + budget_glb_inund(bv_fp2chnl, nt))&
-                    /abs(budget_glb_inund(bv_chnl2fp, nt) - budget_glb_inund(bv_fp2chnl, nt)) * 100._r8
-                write(iulog,'(a, f22.6)') trim(tracerID)//' * Floodplain water balance error(%)          =', budget_diff
-              end if
+                   write(iulog,'(a)') ' '
+                   write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                   write(iulog,'(a)') trim(tracerID)//'   Floodplain water balance check:'
+                   write(iulog,'(a)') trim(tracerID)//'---------------------------------'
 
-              write(iulog,'(a, f22.6)') trim(tracerID)//' * Total change of floodplain volume (km^3)   =', budget_glb_inund(bv_fp_f, nt) - budget_glb_inund(bv_fp_i, nt)
-              write(iulog,'(a, f22.6)') trim(tracerID)//' * Total input minus output (km^3)            =', budget_glb_inund(bv_chnl2fp, nt) - budget_glb_inund(bv_fp2chnl, nt)
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Channel-to-floodplain flow (km^3)          =', budget_glb_inund(bv_chnl2fp, nt)
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Floodplain-to-channel flow (km^3)          =', budget_glb_inund(bv_fp2chnl, nt)
+                   if ( abs( budget_glb_inund(bv_chnl2fp, nt) - budget_glb_inund(bv_fp2chnl, nt) ) .lt. 1e-9_r8 ) then      ! 1e-9 km^3 = 1 m^3
+                      write(iulog,'(a)') trim(tracerID)//'   Total channel-to-floodplain flow equals total floodplain-to-channel flow.'
+                   else
+                      budget_diff = (budget_glb_inund(bv_fp_f, nt) - budget_glb_inund(bv_fp_i, nt) - budget_glb_inund(bv_chnl2fp, nt) + budget_glb_inund(bv_fp2chnl, nt))&
+                           /abs(budget_glb_inund(bv_chnl2fp, nt) - budget_glb_inund(bv_fp2chnl, nt)) * 100._r8
+                      write(iulog,'(a, f22.6)') trim(tracerID)//' * Floodplain water balance error(%)          =', budget_diff
+                   end if
 
-              write(iulog,'(a)') ' '
-              write(iulog,'(a)') trim(tracerID)//'---------------------------------'
-              write(iulog,'(a)') trim(tracerID)//'   Inundation statistics:'
-              write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                   write(iulog,'(a, f22.6)') trim(tracerID)//' * Total change of floodplain volume (km^3)   =', budget_glb_inund(bv_fp_f, nt) - budget_glb_inund(bv_fp_i, nt)
+                   write(iulog,'(a, f22.6)') trim(tracerID)//' * Total input minus output (km^3)            =', budget_glb_inund(bv_chnl2fp, nt) - budget_glb_inund(bv_fp2chnl, nt)
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Channel-to-floodplain flow (km^3)          =', budget_glb_inund(bv_chnl2fp, nt)
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Floodplain-to-channel flow (km^3)          =', budget_glb_inund(bv_fp2chnl, nt)
 
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Percentage of area flooded (incl. channel) =', budget_glb_inund(bi_floodedArea, nt)/budget_glb_inund(bi_landArea, nt)*100._r8
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Percentage of main channel surface area    =', budget_glb_inund(bi_mainChnlArea, nt)/budget_glb_inund(bi_landArea, nt)*100._r8
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Total land area (k*km^2)                   =', budget_glb_inund(bi_landArea, nt)
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Total flooded area (incl. channel; k*km^2) =', budget_glb_inund(bi_floodedArea, nt)
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Total main channel surface area (k*km^2)   =', budget_glb_inund(bi_mainChnlArea, nt)
+                   write(iulog,'(a)') ' '
+                   write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                   write(iulog,'(a)') trim(tracerID)//'   Inundation statistics:'
+                   write(iulog,'(a)') trim(tracerID)//'---------------------------------'
 
-            end if
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Percentage of area flooded (incl. channel) =', budget_glb_inund(bi_floodedArea, nt)/budget_glb_inund(bi_landArea, nt)*100._r8
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Percentage of main channel surface area    =', budget_glb_inund(bi_mainChnlArea, nt)/budget_glb_inund(bi_landArea, nt)*100._r8
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Total land area (k*km^2)                   =', budget_glb_inund(bi_landArea, nt)
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Total flooded area (incl. channel; k*km^2) =', budget_glb_inund(bi_floodedArea, nt)
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Total main channel surface area (k*km^2)   =', budget_glb_inund(bi_mainChnlArea, nt)
 
-            write(iulog,'(a)') ' '
-            write(iulog,'(a)') trim(tracerID)//'---------------------------------'
-            write(iulog,'(a)') trim(tracerID)//'   Main channel flow statistics:'
-            write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                end if
 
-            ! Number of channels with downward velocities (this is mean value for sub-steps in a coupling period):
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Number of channels with downward velocities=', budget_glb_inund(bVelo_downChnlNo, nt)/float(nsub)
-            if ( budget_glb_inund(bVelo_downChnlNo, nt) .gt. 0 ) then
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Average downward flow velocity (m/s)       =', budget_glb_inund(bVelo_downward, nt)/budget_glb_inund(bVelo_downChnlNo, nt)
-            else
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Average downward flow velocity (m/s)       =', 0._r8
-            end if
+                write(iulog,'(a)') ' '
+                write(iulog,'(a)') trim(tracerID)//'---------------------------------'
+                write(iulog,'(a)') trim(tracerID)//'   Main channel flow statistics:'
+                write(iulog,'(a)') trim(tracerID)//'---------------------------------'
 
-            ! Number of channels with upward velocities (this is mean value for sub-steps in a coupling period):
-            write(iulog,'(a, f22.6)') trim(tracerID)//'   Number of channels with upward velocities  =', budget_glb_inund(bVelo_upChnlNo, nt)/float(nsub)
-            if ( budget_glb_inund(bVelo_upChnlNo, nt) .gt. 0 ) then
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Average upward flow velocity (m/s)         =', budget_glb_inund(bVelo_upward, nt)/budget_glb_inund(bVelo_upChnlNo, nt)
-            else
-              write(iulog,'(a, f22.6)') trim(tracerID)//'   Average upward flow velocity (m/s)         =', 0._r8
-            end if
+                ! Number of channels with downward velocities (this is mean value for sub-steps in a coupling period):
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Number of channels with downward velocities=', budget_glb_inund(bVelo_downChnlNo, nt)/float(nsub)
+                if ( budget_glb_inund(bVelo_downChnlNo, nt) .gt. 0 ) then
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Average downward flow velocity (m/s)       =', budget_glb_inund(bVelo_downward, nt)/budget_glb_inund(bVelo_downChnlNo, nt)
+                else
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Average downward flow velocity (m/s)       =', 0._r8
+                end if
 
-            write(iulog,'(a, f22.6)') trim(tracerID)//' * Total land-to-ocean streamflow (k*m^3/s)   =', budget_glb_inund(br_landOutflow, nt)
+                ! Number of channels with upward velocities (this is mean value for sub-steps in a coupling period):
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Number of channels with upward velocities  =', budget_glb_inund(bVelo_upChnlNo, nt)/float(nsub)
+                if ( budget_glb_inund(bVelo_upChnlNo, nt) .gt. 0 ) then
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Average upward flow velocity (m/s)         =', budget_glb_inund(bVelo_upward, nt)/budget_glb_inund(bVelo_upChnlNo, nt)
+                else
+                   write(iulog,'(a, f22.6)') trim(tracerID)//'   Average upward flow velocity (m/s)         =', 0._r8
+                end if
 
-          end do   ! end of 'do nt = 1, nt_rtm'
+                write(iulog,'(a, f22.6)') trim(tracerID)//' * Total land-to-ocean streamflow (k*m^3/s)   =', budget_glb_inund(br_landOutflow, nt)
 
-          write(iulog,'(a)') ' '
-          write(iulog,'(a)') '=================================================== '
-          write(iulog,'(a)') ' '
-endif
-!#endif
+             end do   ! end of 'do nt = 1, nt_rtm'
+
+             write(iulog,'(a)') ' '
+             write(iulog,'(a)') '=================================================== '
+             write(iulog,'(a)') ' '
+          endif
        endif   ! (End of if (masterproc). --Inund.)
 
        call t_stopf('mosartr_budget')
@@ -3353,20 +3290,16 @@ endif
      call shr_sys_flush(iulog)
 
      if (inundflag) then
-!#ifdef INCLUDE_INUND
+        do n = rtmCtl%begr, rtmCTL%endr
+           if ( rtmCTL%mask(n) .eq. 1 .or. rtmCTL%mask(n) .eq. 3 ) then   ! 1--Land; 3--Basin outlet (downstream is ocean).
 
-       do n = rtmCtl%begr, rtmCTL%endr
-         if ( rtmCTL%mask(n) .eq. 1 .or. rtmCTL%mask(n) .eq. 3 ) then   ! 1--Land; 3--Basin outlet (downstream is ocean).
+              ! If Channel area >= unit area * 0.7 (note: 0.7 may be changed) :
+              if ( TUnit%rwidth(n) * TUnit%rlen(n) .ge. TUnit%area(n) * 0.7_r8 ) then
+                 TUnit%rwidth(n) = TUnit%area(n) * 0.7_r8 / TUnit%rlen(n)
+              endif
 
-           ! If Channel area >= unit area * 0.7 (note: 0.7 may be changed) :
-           if ( TUnit%rwidth(n) * TUnit%rlen(n) .ge. TUnit%area(n) * 0.7_r8 ) then
-             TUnit%rwidth(n) = TUnit%area(n) * 0.7_r8 / TUnit%rlen(n)
-           endif
-
-         end if
-       end do
-
-!#endif
+           end if
+        end do
      end if
 
      allocate(TUnit%rwidth0(begr:endr))  
@@ -3384,10 +3317,8 @@ endif
      allocate(TUnit%nr(begr:endr))
   
      if (inundflag) then
-!#ifdef INCLUDE_INUND
         ! Calculate channel Manning roughness coefficients :
         call calc_chnlMannCoe ( )
-!#endif
      else
         !!allocate(TUnit%nr(begr:endr))   !(Repetitive, removed on 6-1-17. --Inund.)
         ier = pio_inq_varid(ncid, name='nr', vardesc=vardesc)
@@ -3396,7 +3327,6 @@ endif
         call shr_sys_flush(iulog)
      endif
 
-!#ifdef INCLUDE_INUND
      if (inundflag) then
 
         !----------------------------------   
@@ -3480,7 +3410,6 @@ endif
         end do
 
      end if
-!#endif
 
      allocate(TUnit%nUp(begr:endr))
      TUnit%nUp = 0
@@ -3491,7 +3420,6 @@ endif
      allocate(TUnit%indexDown(begr:endr))
      TUnit%indexDown = 0
    
-!#ifdef INCLUDE_INUND
      if (inundflag) then
        if ( Tctl%RoutingMethod == 4 ) then       ! Use diffusion wave method in channel routing computation.
           allocate (TUnit%rlen_dstrm(begr:endr))
@@ -3636,7 +3564,6 @@ endif
        endif
 
      end if  ! inundflag
-!#endif
   
      ! initialize water states and fluxes
      allocate (TRunoff%wh(begr:endr,nt_rtm))
@@ -3765,7 +3692,6 @@ endif
      allocate (TPara%c_twid(begr:endr))
      TPara%c_twid = 1.0_r8
    
-!#ifdef INCLUDE_INUND
      if (inundflag) then
         !allocate (TRunoff%wr_ini(begr:endr))
         !TRunoff%wr_ini = 0.0
@@ -3828,7 +3754,6 @@ endif
            TRunoff%ff_unit = 0.0_r8
         endif
      end if
-!#endif
 
      call pio_freedecomp(ncid, iodesc_dbl)
      call pio_freedecomp(ncid, iodesc_int)
@@ -3837,7 +3762,6 @@ endif
    ! control parameters and some other derived parameters
    ! estimate derived input variables
 
-!#ifdef INCLUDE_INUND
      if (inundflag .and. Tctl%OPT_inund == 1) then
         do iunit = rtmCTL%begr, rtmCTL%endr
           if ( rtmCTL%mask(iunit) .eq. 1 .or. rtmCTL%mask(iunit) .eq. 3 ) then   ! 1--Land; 3--Basin outlet (downstream is ocean).
@@ -3848,7 +3772,6 @@ endif
           end if 
         end do
      end if
-!#endif
 
      do iunit=rtmCTL%begr,rtmCTL%endr
         if(TUnit%Gxr(iunit) > 0._r8) then
@@ -3896,11 +3819,9 @@ endif
         if(TUnit%rslp(iunit) <= 0._r8) then
 
         if (inundflag) then
-!#ifdef INCLUDE_INUND
-if (inundflag) then
-           TUnit%rslp(iunit) = Tctl%rslp_assume
-endif
-!#endif
+           if (inundflag) then
+              TUnit%rslp(iunit) = Tctl%rslp_assume
+           endif
         else
            TUnit%rslp(iunit) = 0.0001_r8
         endif

--- a/components/mosart/src/riverroute/RtmRestFile.F90
+++ b/components/mosart/src/riverroute/RtmRestFile.F90
@@ -23,12 +23,11 @@ module RtmRestFile
   use RunoffMod     , only : rtmCTL
   use RtmIO       
   use RtmDateTime
-!#ifdef INCLUDE_WRM
   use WRM_type_mod  , only : ctlSubwWRM, WRMUnit, StorWater
   use WRM_subw_io_mod, only : WRM_computeRelease
-!#endif
+
   use rof_cpl_indices , only : nt_rtm, rtm_tracers 
-!
+
 ! !PUBLIC TYPES:
   implicit none
   save

--- a/components/mosart/src/riverroute/RunoffMod.F90
+++ b/components/mosart/src/riverroute/RunoffMod.F90
@@ -151,7 +151,6 @@ module RunoffMod
      character(len=80), pointer :: out_name(:)  ! the name of the outlets  
      character(len=80) :: curOutlet    ! the name of the current outlet
    
-!#ifdef INCLUDE_INUND   
      integer :: OPT_inund            ! Options for inundation, 0=inundation off, 1=inundation on
      integer :: OPT_trueDW           ! Options for diffusion wave channel routing method:
                                      !     1 -- True diffusion wave method for channel routing;
@@ -188,7 +187,6 @@ module RunoffMod
      ! (2) Steep slope:
      !real(r8) :: e_eprof_std(12) = (/ 0.0_r8, 15.0_r8, 35.0_r8, 60.0_r8, 90.0_r8, 125.0_r8, 165.0_r8, 205.0_r8, 245.0_r8, 285.0_r8, 325.0_r8, 10000.0_r8 /)
 
-!#endif   
   end type Tcontrol
   
   ! --- Topographic and geometric properties, applicable for both grid- and subbasin-based representations
@@ -239,7 +237,6 @@ module RunoffMod
      real(r8), pointer :: phi_r(:)     ! the indicator used to define numDT_r
      real(r8), pointer :: phi_t(:)     ! the indicator used to define numDT_t
    
-!#ifdef INCLUDE_INUND   
      real(r8), pointer :: rlen_dstrm(:)  ! Length of downstream channel (m).
      real(r8), pointer :: rslp_dstrm(:)  ! Bed slope of downstream channel (dimensionless).
      real(r8), pointer :: wr_bf(:)       ! Water volume in the bankfull channel (i.e., channel storage capacity) (m^3).
@@ -272,7 +269,6 @@ module RunoffMod
      real(r8), pointer :: alfa3(:,:)     ! Coefficient (1/m).
      real(r8), pointer :: p3(:,:)        ! Coefficient (m).
      real(r8), pointer :: q3(:,:)        ! Coefficient (m^2).
-!#endif
 
   end type Tspatialunit
 
@@ -351,7 +347,6 @@ module RunoffMod
      real(r8), pointer :: k3(:,:)
      real(r8), pointer :: k4(:,:)
    
-!#ifdef INCLUDE_INUND
     !real(r8), pointer :: wr_ini(:)     ! Channel water volume at beginning of step (m^3).
     !real(r8), pointer :: yr_ini(:)     ! Channel water depth at beginning of step (m).
     real(r8), pointer :: wf_ini(:)      ! Floodplain water volume at beginning of step (m^3).
@@ -374,7 +369,6 @@ module RunoffMod
     !real(r8), pointer :: delta_wr(:)   ! Change of channel water volume during channel routing (m^3).
     real(r8), pointer :: wr_rtg(:)      ! Channel water volume after channel routing (m^3).
     real(r8), pointer :: yr_rtg(:)      ! Channel water depth after channel routing (m).
-!#endif
    
   end type TstatusFlux
   !== Hongyi


### PR DESCRIPTION
Add two-way coupled irrigation scheme to land and river models. 
This function can be turn on/off by a flag in user_nl_clm.

ELM computes the surface water irrigation demand and sends to MOSART and
then MOSART determines the irrigation supply based on the demand and the
water availability and sends back to ELM to constrain the surface water irrigation.

[BFB]
[NML]
