### PR TITLE
add gnu-5.3.0 to anvil-intel environment

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1174,6 +1174,7 @@
         <command name="add">+python-2.7</command>
       </modules>
       <modules compiler="intel">
+	<command name="add">+gcc-5.3.0</command>
         <command name="add">+intel-17.0.0</command>
         <command name="add">+netcdf-c-4.4.1-f77-4.4.4-intel-17.0.0-serial</command>
       </modules>


### PR DESCRIPTION
Allows homme to link with compatible glibc/libstdc++ libraries on anvil