### PR TITLE
Add transient test to production for maint1.0

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -112,6 +112,7 @@ _TESTS = {
     "e3sm_prod" : (("e3sm_atm_prod",),None,
                      (
 		      ("SMS_Ld2.ne30_oECv3_ICG.A_WCYCL1850S_CMIP6","allactive-v1cmip6"),
+                      ("SMS_LD2.ne30_oECv3_ICG.A_WCYCL20TRS_CMIP6","allactive-v1cmip6")
 		      )),
 
     "fates" : (None, None,


### PR DESCRIPTION
Add test of transient water cycle fully coupled case to production suite for maint1.0.  This will read in a few different input files compared to the PI case.

[BFB]