### PR TITLE
Update mpas-source: Add ALE options, default off.

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -535,6 +535,9 @@ add_default($nl, 'config_time_integrator');
 #####################################
 
 add_default($nl, 'config_vert_coord_movement');
+add_default($nl, 'config_ALE_thickness_proportionality');
+add_default($nl, 'config_vert_taper_weight_depth_1');
+add_default($nl, 'config_vert_taper_weight_depth_2');
 add_default($nl, 'config_use_min_max_thickness');
 add_default($nl, 'config_min_thickness');
 add_default($nl, 'config_max_thickness_factor');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -76,6 +76,9 @@ add_default($nl, 'config_time_integrator');
 #####################################
 
 add_default($nl, 'config_vert_coord_movement');
+add_default($nl, 'config_ALE_thickness_proportionality');
+add_default($nl, 'config_vert_taper_weight_depth_1');
+add_default($nl, 'config_vert_taper_weight_depth_2');
 add_default($nl, 'config_use_min_max_thickness');
 add_default($nl, 'config_min_thickness');
 add_default($nl, 'config_max_thickness_factor');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -65,6 +65,9 @@
 
 <!-- ALE_vertical_grid -->
 <config_vert_coord_movement>'uniform_stretching'</config_vert_coord_movement>
+<config_ALE_thickness_proportionality>'restingThickness_times_weights'</config_ALE_thickness_proportionality>
+<config_vert_taper_weight_depth_1>250.0</config_vert_taper_weight_depth_1>
+<config_vert_taper_weight_depth_2>500.0</config_vert_taper_weight_depth_2>
 <config_use_min_max_thickness>.false.</config_use_min_max_thickness>
 <config_min_thickness>1.0</config_min_thickness>
 <config_max_thickness_factor>6.0</config_max_thickness_factor>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -296,7 +296,31 @@ Default: Defined in namelist_defaults.xml
 	category="ALE_vertical_grid" group="ALE_vertical_grid">
 Determines the vertical coordinate movement type. 'uniform_stretching' distributes SSH perturbations through all vertical levels (z-star vertical coordinate); 'fixed' places them all in the top level (z-level vertical coordinate); 'user_specified' allows the input file to determine the distribution using the variable vertCoordMovementWeights (weighted z-star vertical coordinate); and 'impermeable_interfaces' makes the vertical transport between layers zero, i.e. $w^t=0$ (idealized isopycnal).
 
-Valid values: 'uniform_stretching', 'fixed', 'user_specified', 'impermeable_interfaces'
+Valid values: 'uniform_stretching', 'fixed', 'user_specified', 'impermeable_interfaces', 'tapered'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_ALE_thickness_proportionality" type="char*1024"
+	category="ALE_vertical_grid" group="ALE_vertical_grid">
+When config_vert_coord_movement='uniform_stretching' (z-star type coordinate), determines whether ALE layer thickness is proportional to the resting thickness times weights, or just the weights. The first is standard for global runs and is what is specified in Petersen et al 2015 eqns 4 and 6. The second is useful for wetting/drying test cases where resting thickness may be zero at the coastlines.
+
+Valid values: 'restingThickness_times_weights' or 'weights_only'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_vert_taper_weight_depth_1" type="real"
+	category="ALE_vertical_grid" group="ALE_vertical_grid">
+Vertical coordinate taper weight is one above this depth, linearly decreases to zero below.
+
+Valid values: any positive real value, but typically 100 to 1000 m.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_vert_taper_weight_depth_2" type="real"
+	category="ALE_vertical_grid" group="ALE_vertical_grid">
+Vertical coordinate taper weight is zero below this depth, linearly increases to one above.
+
+Valid values: any positive real value, but typically 100 to 1000 m and greater than config_vert_taper_weight_depth_1.
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1989,7 +2013,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_disable_vel_coriolis" type="logical"
 	category="debug" group="debug">
-Diables tendencies on the velocity field from the Coriolis force.
+Diables tendencies on the velocity field from the Coriolis force and momentum advection.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml


### PR DESCRIPTION
Some small updates for MPAS-Ocean:
- Add flag for two different types of ALE thickness weighting
- Fix optional weighting in ALE SSH thickness distribution
- Change internal RK4 weight name for clarity
- COMPASS changes

[NML]
[BFB]