### PR TITLE
Update default compy layouts to reflect slower MPAS-O on maint-1.0

### DIFF
--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -7781,13 +7781,13 @@
         </rootpe>
       </pes>
       <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="L">
-        <comment> -compset A_WCYCL* -res ne30_oEC* on 80 nodes pure-MPI </comment>
+        <comment> -compset A_WCYCL* -res ne30_oEC* on 92 nodes pure-MPI </comment>
         <ntasks>
           <ntasks_atm>2700</ntasks_atm>
           <ntasks_lnd>2700</ntasks_lnd>
           <ntasks_rof>2700</ntasks_rof>
           <ntasks_ice>2700</ntasks_ice>
-          <ntasks_ocn>480</ntasks_ocn>
+          <ntasks_ocn>960</ntasks_ocn>
           <ntasks_cpl>2700</ntasks_cpl>
         </ntasks>
         <nthrds>
@@ -7808,13 +7808,13 @@
         </rootpe>
       </pes>
       <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="XL">
-        <comment> -compset A_WCYCL* -res ne30_oEC* on 160 nodes pure-MPI </comment>
+        <comment> -compset A_WCYCL* -res ne30_oEC* on 185 nodes pure-MPI </comment>
         <ntasks>
           <ntasks_atm>5400</ntasks_atm>
           <ntasks_lnd>5400</ntasks_lnd>
           <ntasks_rof>5400</ntasks_rof>
           <ntasks_ice>5400</ntasks_ice>
-          <ntasks_ocn>1000</ntasks_ocn>
+          <ntasks_ocn>2000</ntasks_ocn>
           <ntasks_cpl>5400</ntasks_cpl>
         </ntasks>
         <nthrds>


### PR DESCRIPTION
This PR updates the default "L" and "XL" pecounts for B-cases on compy from those optimized for master. The maint-1.0 branch still has shorter timesteps for mpas-o so the ocean requires more processors than master does for efficient layouts.

[BFB]