### PR TITLE
Disable compiler checks that happen upon cmake launch

### DIFF
--- a/cime/scripts/lib/CIME/build.py
+++ b/cime/scripts/lib/CIME/build.py
@@ -34,6 +34,9 @@ def get_standard_cmake_args(case, shared_lib=False):
     for var in _CMD_ARGS_FOR_BUILD:
         cmake_args += xml_to_make_variable(case, var, cmake=True)
 
+    # Disable compiler checks
+    cmake_args += " -DCMAKE_C_COMPILER_WORKS=1 -DCMAKE_CXX_COMPILER_WORKS=1 -DCMAKE_Fortran_COMPILER_WORKS=1"
+
     return cmake_args
 
 def xml_to_make_variable(case, varname, cmake=False):


### PR DESCRIPTION
Until Macros.cmake is included, we don't even know what compilers will
be used, so it's pointless to check anything before that.

I explored pre-loading the Macros with -C, but we aren't setting cmake variables that cmake recognizes as compilers.

[BFB]