### PR TITLE
Update CIME to ESMCI cime5.8.7

### DIFF
--- a/cime/ChangeLog
+++ b/cime/ChangeLog
@@ -1,6 +1,73 @@
 ======================================================================
 
 Originator: Chris Fischer 
+Date: 7-19-209
+Tag: cime5.8.7
+Answer Changes: Climate changing for CAM ne120, ne120pg3, ne0CONUS grids
+Tests: scripts_regression_tests
+Dependencies:
+
+Brief Summary:
+    - Fix SE to gx1v7 domain and mapping files.
+    - Updates and fixes for MOM6 in cime.
+    - Maint 5.6 merge.
+
+User interface changes: 
+
+PR summary: git log --oneline --first-parent [previous_tag]..master
+6efe21745 Merge pull request #3177 from ESMCI/fischer/SE_gx1v7MaskFix
+764ef08a0 Merge pull request #3156 from ESMCI/nuopc-cmeps-os
+7a5d60356 Merge pull request #3174 from jedwards4b/maint-5.6-merge
+
+Modified files: git diff --name-status [previous_tag]
+M	config/cesm/config_files.xml
+M	config/cesm/config_grids.xml
+M	config/cesm/config_grids_mct.xml
+M	config/cesm/machines/config_batch.xml
+M	config/cesm/machines/config_compilers.xml
+M	config/cesm/machines/config_machines.xml
+A	config/cesm/machines/config_workflow.xml
+A	config/cesm/machines/cylc_suite.rc.template
+M	config/config_headers.xml
+M	config/e3sm/config_files.xml
+M	config/e3sm/machines/config_batch.xml
+A	config/e3sm/machines/config_workflow.xml
+M	config/xml_schemas/config_batch.xsd
+A	config/xml_schemas/config_workflow.xsd
+M	scripts/Tools/Makefile
+M	scripts/Tools/archive_metadata
+A	scripts/Tools/generate_cylc_workflow.py
+M	scripts/Tools/mkDepends
+M	scripts/Tools/preview_run
+M	scripts/create_clone
+M	scripts/create_newcase
+M	scripts/lib/CIME/Servers/wget.py
+M	scripts/lib/CIME/XML/batch.py
+M	scripts/lib/CIME/XML/env_base.py
+M	scripts/lib/CIME/XML/env_batch.py
+M	scripts/lib/CIME/XML/env_mach_specific.py
+A	scripts/lib/CIME/XML/env_workflow.py
+M	scripts/lib/CIME/XML/generic_xml.py
+A	scripts/lib/CIME/XML/workflow.py
+M	scripts/lib/CIME/aprun.py
+M	scripts/lib/CIME/case/case.py
+M	scripts/lib/CIME/case/case_clone.py
+M	scripts/lib/CIME/case/case_run.py
+M	scripts/lib/CIME/case/case_setup.py
+M	scripts/lib/CIME/case/case_st_archive.py
+M	scripts/lib/CIME/case/case_submit.py
+M	scripts/lib/CIME/get_timing.py
+M	scripts/tests/scripts_regression_tests.py
+M	src/build_scripts/buildlib.csm_share
+M	src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+M	src/components/data_comps/dice/nuopc/dice_comp_mod.F90
+M	src/drivers/mct/cime_config/config_component.xml
+M	src/drivers/mct/cime_config/config_component_cesm.xml
+M	src/share/util/shr_file_mod.F90
+
+======================================================================
+
+Originator: Chris Fischer 
 Date: 7-16-2019
 Tag: cime5.8.6
 Answer Changes: None

--- a/cime/config/cesm/config_files.xml
+++ b/cime/config/cesm/config_files.xml
@@ -51,6 +51,15 @@
     <schema>$CIMEROOT/config/xml_schemas/config_batch.xsd</schema>
   </entry>
 
+  <entry id="WORKFLOW_SPEC_FILE">
+    <type>char</type>
+    <default_value>$CIMEROOT/config/$MODEL/machines/config_workflow.xml</default_value>
+    <group>case_last</group>
+    <file>env_case.xml</file>
+    <desc>file containing workflow (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_workflow.xsd</schema>
+  </entry>
+
   <entry id="INPUTDATA_SPEC_FILE">
     <type>char</type>
     <default_value>$CIMEROOT/config/$MODEL/config_inputdata.xml</default_value>
@@ -126,6 +135,7 @@
     <values>
       <value component="pop"       >$SRCROOT/components/pop/</value>
       <value component="mom"       >$SRCROOT/components/mom/</value>
+      <value component="nemo"      >$SRCROOT/components/nemo/</value>
       <value component="docn"      >$CIMEROOT/src/components/data_comps/docn</value>
       <value component="socn"      >$CIMEROOT/src/components/stub_comps/socn</value>
       <value component="xocn"      >$CIMEROOT/src/components/xcpl_comps/xocn</value>
@@ -251,6 +261,7 @@
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
+      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -271,6 +282,7 @@
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
+      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -297,6 +309,7 @@
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
+      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
       <value component="rtm"      >$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
     </values>
@@ -314,6 +327,7 @@
       <value component="cam">$COMP_ROOT_DIR_ATM/cime_config/SystemTests</value>
       <value component="pop">$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
       <value component="mom">$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
+      <value component="nemo">$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
       <value component="cice">$COMP_ROOT_DIR_ICE/cime_config/SystemTests</value>
       <value component="cism">$COMP_ROOT_DIR_GLC/cime_config/SystemTests</value>
       <value component="rtm">$COMP_ROOT_DIR_ROF/cime_config/SystemTests</value>
@@ -336,6 +350,7 @@
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testlist_cice.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_pop.xml</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_mom.xml</value>
+      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_nemo.xml</value>
       <value component="rtm"      >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_rtm.xml</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_mosart.xml</value>
     </values>
@@ -359,6 +374,7 @@
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
+      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -379,6 +395,7 @@
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/usermods_dirs</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/usermods_dirs</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/usermods_dirs</value>
+      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/usermods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -406,6 +423,7 @@
       <value component="clm"      >$COMP_ROOT_DIR_LND/bld/namelist_files/namelist_definition_ctsm.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_pop.xml</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_mom.xml</value>
+      <value component="nemo"   >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_nemo.xml</value>
       -->
     </values>
     <group>case_last</group>

--- a/cime/config/cesm/config_grids.xml
+++ b/cime/config/cesm/config_grids.xml
@@ -246,6 +246,20 @@
       <mask>tx1v1</mask>
     </model_grid>
 
+    <model_grid alias="T62_n13" not_compset="_CAM">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">tn1v3</grid>
+      <mask>tn1v3</mask>
+    </model_grid>
+
+    <model_grid alias="T62_n0253" not_compset="_CAM">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">tn0.25v3</grid>
+      <mask>tn0.25v3</mask>
+    </model_grid>
+
     <model_grid alias="T62_t12" not_compset="_CAM">
       <grid name="atm">T62</grid>
       <grid name="lnd">T62</grid>
@@ -343,6 +357,20 @@
       <mask>gx1v7</mask>
     </model_grid>
 
+    <model_grid alias="f02_n13">
+      <grid name="atm">0.23x0.31</grid>
+      <grid name="lnd">0.23x0.31</grid>
+      <grid name="ocnice">tn1v3</grid>
+      <mask>tn1v3</mask>
+    </model_grid>
+
+    <model_grid alias="f02_n0253">
+      <grid name="atm">0.23x0.31</grid>
+      <grid name="lnd">0.23x0.31</grid>
+      <grid name="ocnice">tn0.25v3</grid>
+      <mask>tn0.25v3</mask>
+    </model_grid>
+
     <model_grid alias="f02_t12">
       <grid name="atm">0.23x0.31</grid>
       <grid name="lnd">0.23x0.31</grid>
@@ -383,6 +411,20 @@
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v7</grid>
       <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="f09_n13">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">tn1v3</grid>
+      <mask>tn1v3</mask>
+    </model_grid>
+
+    <model_grid alias="f09_n0253">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">tn0.25v3</grid>
+      <mask>tn0.25v3</mask>
     </model_grid>
 
     <model_grid alias="f09_g16_gl4" compset="_CISM">
@@ -1163,6 +1205,10 @@
       <nx>1152</nx> <ny>768</ny>
       <file grid="atm|lnd" mask="gx1v6">domain.lnd.fv0.23x0.31_gx1v6.100517.nc</file>
       <file grid="ocnice"  mask="gx1v6">domain.ocn.0.23x0.31_gx1v6_101108.nc</file>
+      <file grid="atm|lnd" mask="tn1v3">domain.lnd.fv0.23x0.31_tn1v3.160414.nc</file>
+      <file grid="ocnice"  mask="tn1v3">domain.ocn.fv0.23x0.31_tn1v3.160414.nc</file>
+      <file grid="atm|lnd" mask="tn0.25v3">domain.lnd.fv0.23x0.31_tn0.25v3.160721.nc</file>
+      <file grid="ocnice"  mask="tn0.25v3">domain.ocn.fv0.23x0.31_tn0.25v3.160721.nc</file>
       <desc>0.23x0.31 is FV 1/4-deg grid:</desc>
     </domain>
 
@@ -1184,6 +1230,12 @@
       <file grid="ocnice"  mask="gx1v7">domain.ocn.fv0.9x1.25_gx1v7.151020.nc</file>
       <file grid="atm|lnd" mask="tx0.66v1">domain.lnd.fv0.9x1.25_tx0.66v1.190314.nc</file>
       <file grid="ocnice"  mask="tx0.66v1">domain.ocn.fv0.9x1.25_tx0.66v1.190314.nc</file>
+      <file grid="atm|lnd" mask="tn1v3">domain.lnd.fv0.9x1.25_tn1v3.160414.nc</file>
+      <file grid="ocnice"  mask="tn1v3">domain.ocn.fv0.9x1.25_tn1v3.160414.nc</file>
+      <file grid="atm|lnd" mask="tn0.25v3">domain.lnd.fv0.9x1.25_tn0.25v3.160721.nc</file>
+      <file grid="ocnice"  mask="tn0.25v3">domain.ocn.fv0.9x1.25_tn0.25v3.160721.nc</file>
+      <file grid="atm|lnd" mask="null">/glade/u/home/benedict/ys/datain/domain.aqua.fv0.9x1.25.nc</file>
+      <file grid="ocnice"  mask="null">/glade/u/home/benedict/ys/datain/domain.aqua.fv0.9x1.25.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</mesh>
       <desc>0.9x1.25 is FV 1-deg grid:</desc>
     </domain>
@@ -1259,6 +1311,8 @@
       <file grid="ocnice"  mask="gx1v7"   >$DIN_LOC_ROOT/share/domains/domain.ocn.T62_gx1v7.151008.nc</file>
       <file grid="ocnice"  mask="gx3v7"   >$DIN_LOC_ROOT/share/domains/domain.ocn.T62_gx3v7.130409.nc</file>
       <file grid="ocnice"  mask="tx0.66v1">$DIN_LOC_ROOT/share/domains/domain.ocn.T62_tx0.66v1.190425.nc</file>
+      <file grid="atm|lnd" mask="tn1v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tn1v3.160414.nc</file>
+      <file grid="atm|lnd" mask="tn0.25v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tn0.25v3.160721.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/T62_040121_ESMFmesh.nc</mesh>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
@@ -1383,8 +1437,8 @@
       <nx>777602</nx> <ny>1</ny>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4_gx1v6.110502.nc</file>
       <file grid="ocnice"  mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4_gx1v6.121113.nc</file>
-      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4_gx1v7.190502.nc</file>
-      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4_gx1v7.190502.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4_gx1v7.190718.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4_gx1v7.190718.nc</file>
       <desc>ne120np4 is Spectral Elem 1/4-deg grid:</desc>
     </domain>
 
@@ -1399,8 +1453,8 @@
 
     <domain name="ne120np4.pg3">
       <nx>777600</nx> <ny>1</ny>
-      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg3_gx1v7.190503.nc</file>
-      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg3_gx1v7.190503.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg3_gx1v7.190718.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg3_gx1v7.190718.nc</file>
       <desc>ne120np4.pg3 is a Spectral Elem 0.25-deg grid with a 3x3 FVM physics grid:</desc>
       <support>EXPERIMENTAL FVM physics grid</support>
     </domain>
@@ -1541,6 +1595,20 @@
     <!-- ======================================================== -->
     <!-- ROF domains -->
     <!-- ======================================================== -->
+
+    <domain name="tn1v3">
+      <nx>360</nx> <ny>291</ny>
+      <file grid="ocnice">$DIN_LOC_ROOT/share/domains/domain.ocn.tn1v3.160414.nc</file>
+      <desc>tn1v3 is NEMO ORCA1 tripole grid at 1 deg (reduced eORCA):</desc>
+      <support>NEMO ORCA1 tripole ocean grid</support>
+    </domain>
+
+    <domain name="tn0.25v3">
+      <nx>1440</nx> <ny>1050</ny>
+      <file grid="ocnice">$DIN_LOC_ROOT/share/domains/domain.ocn.tn0.25v3.160721.nc</file>
+      <desc>tn0.25v3 is NEMO ORCA1 tripole grid at 1/4 deg (reduced eORCA):</desc>
+      <support>NEMO ORCA1 tripole ocean grid</support>
+    </domain>
 
     <domain name="rx1">
       <nx>360</nx> <ny>180</ny>

--- a/cime/config/cesm/config_grids_common.xml
+++ b/cime/config/cesm/config_grids_common.xml
@@ -97,8 +97,8 @@
     </gridmap>
 
     <gridmap lnd_grid="10x15" rof_grid="r05">
-      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_10x15_to_0.5x0.5rtm_aave_da_110307.nc</map>
-      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_0.5x0.5_nomask_to_10x15_nomask_aave_da_c121019.nc</map>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_10x15_to_0.5x0.5rtm_aave_da_c20190725.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_0.5x0.5_nomask_to_10x15_nomask_aave_da_c20190725.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="4x5" rof_grid="r05">

--- a/cime/config/cesm/config_grids_mct.xml
+++ b/cime/config/cesm/config_grids_mct.xml
@@ -175,21 +175,21 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_to_ne120np4_aave_110428.nc</map>
     </gridmap>
     <gridmap atm_grid="ne120np4" ocn_grid="gx1v7">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v7_aave_190502.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v7_bilin_190502.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v7_bilin_190502.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v7_to_ne120np4_aave_190502.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v7_to_ne120np4_aave_190502.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v7_aave_190718.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v7_bilin_190718.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v7_bilin_190718.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_to_ne120np4_aave_190718.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_to_ne120np4_aave_190718.nc</map>
     </gridmap>
     <gridmap atm_grid="ne120np4" wav_grid="ww3a">
       <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_ww3a_blin.190502.nc</map>
     </gridmap>
     <gridmap atm_grid="ne120np4.pg3" ocn_grid="gx1v7">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_gx1v7_aave.190503.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_gx1v7_blin.190503.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_gx1v7_blin.190503.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne120np4.pg3_aave.190503.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne120np4.pg3_aave.190503.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_gx1v7_aave.190718.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_gx1v7_blin.190718.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_gx1v7_blin.190718.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne120np4.pg3_aave.190718.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne120np4.pg3_aave.190718.nc</map>
     </gridmap>
     <gridmap atm_grid="ne120np4.pg3" wav_grid="ww3a">
       <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_ww3a_blin.190503.nc</map>
@@ -236,11 +236,11 @@
     </gridmap>
 
     <gridmap atm_grid="ne0np4CONUS.ne30x8" ocn_grid="gx1v7">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_aave.190322.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_blin.190322.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_patc.190322.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190322.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190322.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_aave.190718.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_blin.190718.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_patc.190718.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190718.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190718.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4CONUS.ne30x8" wav_grid="ww3a">

--- a/cime/config/cesm/machines/config_batch.xml
+++ b/cime/config/cesm/machines/config_batch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config_batch version="2.0">
+<config_batch version="2.1">
   <!--
      File:    config_batch.xml
      Purpose: abstract out the parts of run scripts that are different, and use this configuration to
@@ -101,6 +101,7 @@
     <batch_submit>bsub</batch_submit>
     <batch_cancel>bkill</batch_cancel>
     <batch_redirect>&lt;</batch_redirect>
+    <batch_env> </batch_env>
     <batch_directive>#BSUB</batch_directive>
     <jobid_pattern>&lt;(\d+)&gt;</jobid_pattern>
     <depend_string> -w 'done(jobid)'</depend_string>
@@ -139,7 +140,7 @@
       <arg flag="-A" name="$PROJECT"/>
     </submit_args>
     <directives>
-      <directive> -N {{ job_id }}</directive>
+      <directive>-N {{ job_id }}</directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
       <!-- <directive> -j oe {{ job_id }} </directive> -->
       <directive> -j oe </directive>
@@ -166,6 +167,16 @@
       <directive> --output={{ job_id }}   </directive>
       <directive> --exclusive                        </directive>
     </directives>
+  </batch_system>
+
+  <batch_system MACH="aleph" type="pbs" >
+    <directives>
+      <directive>-l nodes={{ num_nodes }}</directive>
+      <directive>-q {{ queue }}</directive>
+    </directives>
+    <queues>
+      <queue default="true" >iccp</queue>
+    </queues>
   </batch_system>
 
   <!-- athena is lsf -->
@@ -225,10 +236,10 @@
     <unknown_queue_directives>regular</unknown_queue_directives>
 
     <queues>
-      <queue walltimemax="12:00" nodemin="1" nodemax="4032">regular</queue>
-      <queue walltimemax="12:00" nodemin="1" nodemax="4032">premium</queue>
-      <queue default="true" walltimemax="06:00" jobmin="1" jobmax="18">share</queue>
-      <queue walltimemax="12:00" nodemin="1" nodemax="4032">economy</queue>
+      <queue walltimemax="12:00:00" nodemin="1" nodemax="4032">regular</queue>
+      <queue walltimemax="12:00:00" nodemin="1" nodemax="4032">premium</queue>
+      <queue default="true" walltimemax="06:00:00" jobmin="1" jobmax="18">share</queue>
+      <queue walltimemax="12:00:00" nodemin="1" nodemax="4032">economy</queue>
     </queues>
   </batch_system>
 
@@ -591,25 +602,4 @@
       <queue walltimemax="00:60:00" nodemin="1" nodemax="50" default="true">default</queue>
     </queues>
   </batch_system>
-
-  <batch_jobs>
-    <!-- order matters, with no-batch jobs will be run in the order listed here -->
-    <job name="case.run">
-      <template>template.case.run</template>
-      <prereq>$BUILD_COMPLETE and not $TEST</prereq>
-    </job>
-    <job name="case.test">
-      <template>template.case.test</template>
-      <prereq>$BUILD_COMPLETE and $TEST</prereq>
-    </job>
-    <job name="case.st_archive">
-      <template>template.st_archive</template>
-      <task_count>1</task_count>
-      <walltime>0:20:00</walltime>
-      <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
-      <dependency>case.run or case.test</dependency>
-      <prereq>$DOUT_S</prereq>
-    </job>
-  </batch_jobs>
-
 </config_batch>

--- a/cime/config/cesm/machines/config_compilers.xml
+++ b/cime/config/cesm/machines/config_compilers.xml
@@ -80,7 +80,7 @@ using a fortran linker.
   </INCLDIR>
   <FFLAGS>
     <append MODEL="fv3gfs"> $(FC_AUTO_R8) </append>
-    <append MODEL="mom"> $(FC_AUTO_R8) </append>
+    <append MODEL="mom"> $(FC_AUTO_R8) -Duse_LARGEFILE</append>
   </FFLAGS>
   <SUPPORTS_CXX>FALSE</SUPPORTS_CXX>
 </compiler>
@@ -495,6 +495,65 @@ using a fortran linker.
   <FFLAGS>
     <append>  -xHost </append>
   </FFLAGS>
+  <MPICXX MPILIB="mpich2">mpiicpc</MPICXX>
+  <MPICC MPILIB="mpich2">mpiicc</MPICC>
+  <MPIFC MPILIB="mpich2">mpiifort</MPIFC>
+  <SCC>icc</SCC>
+  <SFC>ifort</SFC>
+  <TRILINOS_PATH MPILIB="mpich2">$ENV{TRILINOS_PATH}</TRILINOS_PATH>
+</compiler>
+
+<compiler MACH="aleph" COMPILER="intel">
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CFLAGS>
+    <append> -xCORE-AVX2 </append>
+  </CFLAGS>
+  <FFLAGS>
+    <append> -xCORE-AVX2 </append>
+  </FFLAGS>
+  <SLIBS>
+    <append> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </append>
+  </SLIBS>
+  <CPPDEFS>
+    <append MODEL="gptl"> -DHAVE_PAPI -DHAVE_SLASHPROC </append>
+  </CPPDEFS>
+  <LDFLAGS>
+    <append>-mkl </append>
+  </LDFLAGS>
+</compiler>
+
+<compiler MACH="athena">
+  <CPPDEFS>
+    <!-- these flags enable nano timers -->
+    <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
+  </CPPDEFS>
+  <NETCDF_PATH>$ENV{NETCDF}</NETCDF_PATH>
+  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  <PNETCDF_PATH>$ENV{PNETCDF}</PNETCDF_PATH>
+  <AR>xiar</AR>
+  <ARFLAGS>
+    <base>cru</base>
+  </ARFLAGS>
+</compiler>
+
+<compiler MACH="athena" COMPILER="intel">
+  <CFLAGS>
+    <append>  -xHost </append>
+  </CFLAGS>
+  <CPPDEFS>
+    <append> -DINTEL_MKL -DHAVE_SSE2 </append>
+  </CPPDEFS>
+  <FFLAGS>
+    <append>  -xHost </append>
+  </FFLAGS>
+  <FFLAGS>
+    <append MODEL="nemo"> $(FC_AUTO_R8) -O3 -assume norealloc_lhs </append>
+  </FFLAGS>
+  <SLIBS>
+    <append> $SHELL{${NETCDF_PATH}/bin/nc-config --flibs}</append>
+  </SLIBS>
   <MPICXX MPILIB="mpich2">mpiicpc</MPICXX>
   <MPICC MPILIB="mpich2">mpiicc</MPICC>
   <MPIFC MPILIB="mpich2">mpiifort</MPIFC>

--- a/cime/config/cesm/machines/config_machines.xml
+++ b/cime/config/cesm/machines/config_machines.xml
@@ -49,6 +49,72 @@ This allows using a different mpirun command to launch unit tests
 -->
 
 <config_machines version="2.0">
+  <machine MACH="aleph">
+    <DESC>XC50 SkyLake, os is CNL, 40 pes/node, batch system is PBSPro</DESC>
+    <NODENAME_REGEX>.*eth\d</NODENAME_REGEX>
+    <OS>CNL</OS>
+    <COMPILERS>intel,gnu,cray</COMPILERS>
+    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <CIME_OUTPUT_ROOT>$ENV{BASEDIR}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>$ENV{DIN_LOC_ROOT}</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$DIN_LOC_ROOT</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>${CIME_OUTPUT_ROOT}/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>${CIME_OUTPUT_ROOT}/cesm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>/home/jedwards/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
+    <SUPPORTED_BY> @ pusan.ac.kr</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>40</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>40</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+      <executable>aprun</executable>
+      <arguments>
+        <arg name="hyperthreading" default="1"> -j {{ hyperthreading }}</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
+        <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
+        <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
+        <arg name="env_thread_count">--mpmd-env OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/opt/modules/default/init/perl.pm</init_path>
+      <init_path lang="python">/opt/modules/default/init/python.py</init_path>
+      <init_path lang="sh">/opt/modules/default/init/sh</init_path>
+      <init_path lang="csh">/opt/modules/default/init/csh</init_path>
+      <cmd_path lang="perl">/opt/modules/default/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/opt/modules/default/bin/modulecmd python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="rm">craype-x86-skylake</command>
+        <command name="rm">PrgEnv-pgi</command>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">papi</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">PrgEnv-intel</command>
+        <command name="load">craype-x86-skylake</command>
+        <command name="load">craype-hugepages2M</command>
+        <command name="rm">perftools-base/7.0.4</command>
+        <command name="load">cray-netcdf/4.6.1.3</command>
+        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-parallel-netcdf/1.8.1.3</command>
+        <command name="load">papi/5.6.0.4</command>
+        <command name="load">gridftp/6.0</command>
+        <command name="load">cray-python/3.6.5.1</command>
+      </modules>
+    </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">256M</env>
+      <env name="POSTPROCESS_PATH">/home/jedwards/workflow/CESM_postprocessing</env>
+    </environment_variables>
+  </machine>
 
   <machine MACH="athena">
     <DESC> CMCC IBM iDataPlex, os is Linux, 16 pes/node, batch system is LSFd mpich</DESC>
@@ -131,6 +197,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="I_MPI_LSF_USE_COLLECTIVE_LAUNCH">1</env>
       <env name="I_MPI_DAPL_UD">on</env>
       <env name="I_MPI_DAPL_SCALABLE_PROGRESS">on</env>
+      <env name="XIOS_PATH">/users/home/models/nemo/xios-cmip6/intel_xe_2013</env>
     </environment_variables>
   </machine>
 
@@ -260,7 +327,7 @@ This allows using a different mpirun command to launch unit tests
 	<arg name="ntasks"> -np {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
-    <module_system type="module">
+    <module_system type="module" allow_error="true">
       <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
       <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
       <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
@@ -274,6 +341,8 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules compiler="gnu">
 	<command name="load">compiler/gnu/8.2.0</command>
+	<command name="load">mpi/3.3/gcc-8.2.0</command>
+	<command name="load">tool/netcdf/4.6.1/gcc-8.1.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -647,7 +716,7 @@ This allows using a different mpirun command to launch unit tests
 
       <modules compiler="intel">
 	<command name="load">PrgEnv-intel</command>
-	<command name="switch">intel intel/18.0.2.199</command>
+	<command name="switch">intel intel/19.0.3.199</command>
 	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
@@ -674,16 +743,16 @@ This allows using a different mpirun command to launch unit tests
 	<command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.0</command>
+	<command name="load">cray-mpich/7.7.6</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.1.1</command>
-	<command name="load">cray-netcdf/4.4.1.1.6</command>
+	<command name="load">cray-hdf5/1.10.2.0</command>
+	<command name="load">cray-netcdf/4.6.1.3</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
+	<command name="load">cray-hdf5-parallel/1.10.2.0</command>
+	<command name="load">cray-parallel-netcdf/1.8.1.4</command>
       </modules>
       <modules>
 	<command name="load">cmake/3.8.2</command>
@@ -750,13 +819,17 @@ This allows using a different mpirun command to launch unit tests
 	<command name="rm">cray-hdf5</command>
 	<command name="rm">cray-netcdf-hdf5parallel</command>
       </modules>
+
       <modules compiler="intel">
 	<command name="load">PrgEnv-intel</command>
-	<command name="switch">intel intel/18.0.1.163</command>
+	<command name="switch">intel intel/19.0.3.199</command>
 	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-knl</command>
+	<command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-knl</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial" >
+	<command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-knl</command>
       </modules>
 
       <modules compiler="cray">
@@ -769,26 +842,23 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
-	<command name="load">craype-mic-knl</command>
 	<command name="swap">craype craype/2.5.15</command>
+	<command name="load">craype-mic-knl</command>
       </modules>
       <modules>
 	<command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.0</command>
+	<command name="load">cray-mpich/7.7.6</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.1.1</command>
-	<command name="load">cray-netcdf/4.4.1.1.6</command>
+	<command name="load">cray-hdf5/1.10.2.0</command>
+	<command name="load">cray-netcdf/4.6.1.3</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
-      </modules>
-      <modules>
-	<command name="load">cmake/3.8.2</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
+	<command name="load">cray-hdf5-parallel/1.10.2.0</command>
+	<command name="load">cray-parallel-netcdf/1.8.1.4</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/cime/config/cesm/machines/config_workflow.xml
+++ b/cime/config/cesm/machines/config_workflow.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0"?>
+<config_workflow version="2.0">
+  <!--
+  File: config_workflow.xml
+  Purpose: Define the jobs to be run, the order to run them, the job size and
+  any dependancies they may have.
+
+  job name: The name of the script as it appears in the case.
+  template: The template from which the job script will be derived.
+            If a template does not include a full path it is assumed to be
+	    in the config/$CIME_MODEL/machines directory.
+	    In the template {{ }} denotes a keyword that will be expanded to create the job script.
+            This is done in the case.setup stage.
+	    recognized keywords are:
+	      total_tasks, num_nodes, max_tasks_per_node, job_id, batchdirectives, mpirun
+	      most xml variables in the case and any case attribute.
+            If the template is not found the corresponding step will not be included in the
+	    workflow.
+
+  prereq: A logical value derived from case xml variables used to determine if this step should
+          be included in the workflow
+  dependency: one or more job names in the workflow that must complete successfully before this step
+              is started.
+  runtime_parameters:
+          case.run or case.test determine their pelayout from the config_pes.xml file but other jobs
+          in the workflow may have other requirements variables in this block determine those requirements.
+	  The runtime_parameters block may have an optional MACH attribute.
+
+  -->
+  <workflow_jobs case="default">
+    <!-- order matters, with no-batch jobs will be run in the order listed here -->
+    <job name="case.run">
+      <template>template.case.run</template>
+      <prereq>$BUILD_COMPLETE and not $TEST</prereq>
+    </job>
+    <job name="case.test">
+      <template>template.case.test</template>
+      <prereq>$BUILD_COMPLETE and $TEST</prereq>
+    </job>
+    <job name="case.st_archive">
+      <template>template.st_archive</template>
+      <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
+      <dependency>case.run or case.test</dependency>
+      <prereq>$DOUT_S</prereq>
+      <runtime_parameters>
+	<task_count>1</task_count>
+	<tasks_per_node>1</tasks_per_node>
+	<walltime>0:20:00</walltime>
+      </runtime_parameters>
+    </job>
+  </workflow_jobs>
+
+  <workflow_jobs case="timeseries" prepend="default">
+    <job name="timeseries">
+      <template>$ENV{POSTPROCESS_PATH}/timeseries/template.timeseries</template>
+      <dependency>case.st_archive</dependency>
+      <prereq>$TIMESERIES</prereq>
+      <runtime_parameters MACH="aleph">
+	<task_count>72</task_count>
+	<tasks_per_node>9</tasks_per_node>
+	<walltime>0:20:00</walltime>
+      </runtime_parameters>
+      <runtime_parameters MACH="cheyenne">
+	<task_count>72</task_count>
+	<tasks_per_node>9</tasks_per_node>
+	<walltime>0:20:00</walltime>
+      </runtime_parameters>
+    </job>
+  </workflow_jobs>
+  <workflow_jobs case="timeseries_transfer" prepend="timeseries">
+    <job name="timeseries_transfer">
+      <template>$ENV{POSTPROCESS_PATH}/timeseries/template.timeseries_transfer</template>
+      <dependency>timeseries</dependency>
+      <prereq>1</prereq>
+      <runtime_parameters>
+	<task_count>1</task_count>
+	<tasks_per_node>1</tasks_per_node>
+	<walltime>1:00:00</walltime>
+      </runtime_parameters>
+    </job>
+  </workflow_jobs>
+  <workflow_jobs case="diagnostics" prepend="timeseries">
+    <job name="xconform">
+      <template>$CASEROOT/postprocess/xconform</template>
+      <dependency>timeseriesL</dependency>
+      <prereq>$CASEROOT/postprocess/pp_config -value --get STANDARDIZE_TIMESERIES</prereq>
+    </job>
+
+    <job name="atm_averages">
+      <template>$CASEROOT/postprocess/atm_averages</template>
+      <dependency>timeseries or case.st_archive</dependency>
+      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_AVGS_ATM</prereq>
+    </job>
+
+    <job name="lnd_averages">
+      <template>$CASEROOT/postprocess/lnd_averages</template>
+      <dependency>:lnd_avg(args)
+timeseries or case.st_archive</dependency>
+      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_AVGS_ATM</prereq>
+    </job>
+
+    <job name="ice_averages">
+      <template>$CASEROOT/postprocess/ice_averages</template>
+      <dependency>timeseries or case.st_archive</dependency>
+      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_AVGS_ATM</prereq>
+    </job>
+
+
+    <job name="ocn_averages">
+      <template>$CASEROOT/postprocess/ocn_averages</template>
+      <dependency>timeseries or case.st_archive</dependency>
+      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_AVGS_ATM</prereq>
+    </job>
+
+    <job name="atm_diagnostics">
+      <template>$CASEROOT/postprocess/atm_diagnostics</template>
+      <dependency>atm_averages</dependency>
+      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_AVGS_ATM</prereq>
+    </job>
+
+    <job name="lnd_diagnostics">
+      <template>$CASEROOT/postprocess/lnd_diagnostics</template>
+      <dependency>lnd_averages</dependency>
+      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_AVGS_ATM</prereq>
+    </job>
+    <job name="ice_diagnostics">
+      <template>$CASEROOT/postprocess/ice_diagnostics</template>
+      <dependency>ice_averages</dependency>
+      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_AVGS_ATM</prereq>
+    </job>
+    <job name="ocn_diagnostics">
+      <template>$CASEROOT/postprocess/ocn_diagnostics</template>
+      <dependency>ocn_averages</dependency>
+      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_AVGS_ATM</prereq>
+    </job>
+
+  </workflow_jobs>
+</config_workflow>

--- a/cime/config/cesm/machines/cylc_suite.rc.template
+++ b/cime/config/cesm/machines/cylc_suite.rc.template
@@ -1,0 +1,24 @@
+[meta]
+  title = CESM CYLC workflow for {{ workflow_description }}
+[cylc]
+  [[parameters]]
+    member = {{ members }}
+
+[scheduling]
+  cycling mode = integer
+  initial cycle point = 1
+  final cycle point = {{ cycles }}
+
+  [[dependencies]]
+    [[[R1]]]
+      graph = "set_external_workflow<member> => run<member> => st_archive<member> "
+    [[[R/P1]]] # Integer Cycling
+      graph = """
+	     st_archive<member>[-P1] => run<member>
+             run<member> => st_archive<member>
+	     """
+[runtime]
+  [[set_external_workflow<member>]]
+    script = cd {{ case_path_string }} ./xmlchange EXTERNAL_WORKFLOW=TRUE
+  [[st_archive<member>]]
+    script = cd {{ case_path_string }} ./case.submit --job case.st_archive; ./xmlchange CONTINUE_RUN=TRUE

--- a/cime/config/config_headers.xml
+++ b/cime/config/config_headers.xml
@@ -10,6 +10,13 @@
     </header>
   </file>
 
+  <file name="env_workflow.xml">
+    <header>
+      These variables may be changed anytime during a run, they
+      control jobs that will be submitted and their dependancies.
+    </header>
+  </file>
+
   <file name="env_case.xml">
     <header>
     These variables CANNOT BE CHANGED once a case has been created.

--- a/cime/config/e3sm/config_files.xml
+++ b/cime/config/e3sm/config_files.xml
@@ -33,6 +33,15 @@
     <schema>$CIMEROOT/config/xml_schemas/config_batch.xsd</schema>
   </entry>
 
+  <entry id="WORKFLOW_SPEC_FILE">
+    <type>char</type>
+    <default_value>$CIMEROOT/config/$MODEL/machines/config_workflow.xml</default_value>
+    <group>case_last</group>
+    <file>env_case.xml</file>
+    <desc>file containing workflow (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_workflow.xsd</schema>
+  </entry>
+
   <entry id="INPUTDATA_SPEC_FILE">
     <type>char</type>
     <default_value>$CIMEROOT/config/$MODEL/config_inputdata.xml</default_value>

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -569,29 +569,4 @@
     </queues>
    </batch_system>
 
-  <batch_jobs>
-    <!-- order matters, with no-batch jobs will be run in the order listed here -->
-    <job name="case.run">
-      <template>template.case.run</template>
-      <prereq>$BUILD_COMPLETE and not $TEST</prereq>
-    </job>
-    <job name="case.run.sh">
-      <template>template.case.run.sh</template>
-      <prereq>False</prereq>
-    </job>
-   <job name="case.test">
-      <template>template.case.test</template>
-      <prereq>$BUILD_COMPLETE and $TEST</prereq>
-    </job>
-    <job name="case.st_archive">
-      <template>template.st_archive</template>
-      <task_count>1</task_count>
-      <walltime>0:20:00</walltime>
-      <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
-      <dependency>case.run case.test</dependency>
-      <prereq>$DOUT_S</prereq>
-    </job>
-  </batch_jobs>
-
 </config_batch>
-

--- a/cime/config/e3sm/machines/config_workflow.xml
+++ b/cime/config/e3sm/machines/config_workflow.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<config_workflow version="2.0">
+  <!--
+  File: config_workflow.xml
+  Purpose: Define the jobs to be run, the order to run them, the job size and
+  any dependancies they may have.
+
+  job name: The name of the script as it appears in the case.
+  template: The template from which the job script will be derived.
+            If a template does not include a full path it is assumed to be
+	    in the config/$CIME_MODEL/machines directory.
+	    In the template {{ }} denotes a keyword that will be expanded to create the job script.
+            This is done in the case.setup stage.
+	    recognized keywords are:
+	      total_tasks, num_nodes, max_tasks_per_node, job_id, batchdirectives, mpirun
+	      most xml variables in the case and any case attribute.
+            If the template is not found the corresponding step will not be included in the
+	    workflow.
+
+  prereq: A logical value derived from case xml variables used to determine if this step should
+          be included in the workflow
+  dependency: one or more job names in the workflow that must complete successfully before this step
+              is started.
+  runtime_parameters:
+          case.run or case.test determine their pelayout from the config_pes.xml file but other jobs
+          in the workflow may have other requirements variables in this block determine those requirements.
+	  The runtime_parameters block may have an optional MACH attribute.
+
+  -->
+  <workflow_jobs case="default">
+    <!-- order matters, with no-batch jobs will be run in the order listed here -->
+    <job name="case.run">
+      <template>template.case.run</template>
+      <prereq>$BUILD_COMPLETE and not $TEST</prereq>
+    </job>
+    <job name="case.test">
+      <template>template.case.test</template>
+      <prereq>$BUILD_COMPLETE and $TEST</prereq>
+    </job>
+    <job name="case.st_archive">
+      <template>template.st_archive</template>
+      <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
+      <dependency>case.run or case.test</dependency>
+      <prereq>$DOUT_S</prereq>
+      <runtime_parameters>
+	<task_count>1</task_count>
+	<walltime>0:20:00</walltime>
+      </runtime_parameters>
+    </job>
+  </workflow_jobs>
+</config_workflow>

--- a/cime/config/xml_schemas/config_batch.xsd
+++ b/cime/config/xml_schemas/config_batch.xsd
@@ -24,7 +24,7 @@
   <xs:element name="batch_mail_type_flag" type="xs:string"/>
   <xs:element name="batch_mail_type" type="xs:string"/>
   <xs:element name="batch_mail_default" type="xs:string"/>
-  <xs:element name="template" type="xs:NCName"/>
+  <xs:element name="template" type="xs:anyURI"/>
   <xs:element name="task_count" type="xs:integer"/>
   <xs:element name="walltime" type="xs:string"/>
   <xs:element name="dependency" type="xs:string"/>
@@ -37,7 +37,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="batch_system" maxOccurs="unbounded" />
-        <xs:element ref="batch_jobs"/>
+        <xs:element ref="batch_jobs" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute ref="version" use="required"/>
     </xs:complexType>

--- a/cime/config/xml_schemas/config_workflow.xsd
+++ b/cime/config/xml_schemas/config_workflow.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   version="2.0">
+  <!-- attributes -->
+  <xs:attribute name="version" type="xs:decimal"/>
+  <xs:attribute name="MACH" type="xs:NCName"/>
+  <xs:attribute name="case" type="xs:NCName"/>
+  <xs:attribute name="prepend" type="xs:NCName"/>
+  <xs:attribute name="append" type="xs:NCName"/>
+  <xs:attribute name="name" type="xs:NCName"/>
+
+  <!-- simple elements -->
+  <xs:element name="template" type="xs:anyURI"/>
+  <xs:element name="task_count" type="xs:integer"/>
+  <xs:element name="tasks_per_node" type="xs:integer"/>
+  <xs:element name="walltime" type="xs:string"/>
+  <xs:element name="dependency" type="xs:string"/>
+  <xs:element name="prereq" type="xs:string"/>
+
+  <!-- complex elements -->
+
+  <xs:element name="config_workflow">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="workflow_jobs" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute ref="version" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="workflow_jobs">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="job"/>
+      </xs:sequence>
+      <xs:attribute ref="case" use="required"/>
+      <xs:attribute ref="prepend"/>
+      <xs:attribute ref="append"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="runtime_parameters">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="task_count"/>
+        <xs:element minOccurs="0" ref="tasks_per_node"/>
+        <xs:element minOccurs="0" ref="walltime"/>
+      </xs:sequence>
+      <xs:attribute ref="MACH" />
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="job">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="template"/>
+        <xs:element minOccurs="0" ref="dependency"/>
+        <xs:element ref="prereq"/>
+	<xs:element ref="runtime_parameters" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute ref="name" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/cime/scripts/Tools/archive_metadata
+++ b/cime/scripts/Tools/archive_metadata
@@ -791,7 +791,7 @@ def get_trunk_tag(case_dict, username, password):
     if result:
         last_tag = [i for i in result.split('\n') if i][-1]
         last_tag = last_tag[:-1].split('_')[-1]
-        tag = int(last_tag.strip('0'))
+        tag = int(last_tag.lstrip('0'))
 
     return tag
 

--- a/cime/scripts/Tools/generate_cylc_workflow.py
+++ b/cime/scripts/Tools/generate_cylc_workflow.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+"""
+Generates a cylc workflow file for the case.  See https://cylc.github.io for details about cylc
+"""
+
+from standard_script_setup import *
+
+from CIME.case              import Case
+from CIME.utils             import expect, transform_vars
+
+import argparse, re
+logger = logging.getLogger(__name__)
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
+                        help="Case directory for which namelists are generated.\n"
+                        "Default is current directory.")
+
+    parser.add_argument('--cycles', default=1,
+                        help="The number of cycles to run, default is RESUBMIT")
+
+    parser.add_argument("--ensemble", default=1,
+                        help="generate suite.rc for an ensemble of cases, the case name argument must end in an integer.\n"
+                        "for example: ./generate_cylc_workflow.py --ensemble 4 \n"
+                        "will generate a workflow file in the current case, if that case is named case.01,"
+                        "the workflow will include case.01, case.02, case.03 and case.04")
+
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    return args.caseroot, args.cycles, int(args.ensemble)
+
+def cylc_get_ensemble_first_and_last(case, ensemble):
+    if ensemble == 1:
+        return 1,None
+    casename = case.get_value("CASE")
+    m = re.search(r"(.*[^\d])(\d+)$", casename)
+    minval = int(m.group(2))
+    maxval = minval+ensemble-1
+    return minval,maxval
+
+def cylc_get_case_path_string(case, ensemble):
+    caseroot = case.get_value("CASEROOT")
+    casename = case.get_value("CASE")
+    if ensemble == 1:
+        return "{};".format(caseroot)
+    basepath = os.path.abspath(caseroot+"/..")
+    m = re.search(r"(.*[^\d])(\d+)$", casename)
+
+    expect(m, "casename {} must end in an integer for ensemble method".format(casename))
+
+    return "{basepath}/{basename}$(printf \"%0{intlen}d\"".format(basepath=basepath, basename=m.group(1), intlen=len(m.group(2))) + " ${CYLC_TASK_PARAM_member});"
+
+
+def cylc_batch_job_template(job, jobname, case, ensemble):
+
+    env_batch = case.get_env("batch")
+    batch_system_type = env_batch.get_batch_system_type()
+    batchsubmit = env_batch.get_value("batch_submit")
+    submit_args = env_batch.get_submit_args(case, job)
+    case_path_string = cylc_get_case_path_string(case, ensemble)
+
+    return """
+    [[{jobname}<member>]]
+    script = cd {case_path_string} ./case.submit --job {job}
+    [[[job]]]
+      batch system = {batch_system_type}
+      batch submit command template = {batchsubmit} {submit_args}  '%(job)s'
+    [[[directives]]]
+""".format(jobname=jobname, job=job, case_path_string=case_path_string, batch_system_type=batch_system_type,
+           batchsubmit=batchsubmit, submit_args=submit_args) + "{{ batchdirectives }}\n"
+
+
+def cylc_script_job_template(job, case, ensemble):
+    case_path_string = cylc_get_case_path_string(case, ensemble)
+    return """
+    [[{job}<member>]]
+    script = cd {case_path_string} ./case.submit --job {job}
+""".format(job=job, case_path_string=case_path_string)
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    caseroot, cycles, ensemble = parse_command_line(sys.argv, description)
+
+    expect(os.path.isfile(os.path.join(caseroot, "CaseStatus")),
+           "case.setup must be run prior to running {}".format(__file__))
+    with Case(caseroot, read_only=True) as case:
+        if cycles == 1:
+            cycles = max(1, case.get_value('RESUBMIT'))
+        env_batch = case.get_env('batch')
+        env_workflow = case.get_env('workflow')
+        jobs = env_workflow.get_jobs()
+        casename = case.get_value('CASE')
+        input_template = os.path.join(case.get_value("MACHDIR"),"cylc_suite.rc.template")
+
+        overrides = {"cycles":cycles,
+                     'casename':casename}
+        input_text = open(input_template).read()
+
+        first,last = cylc_get_ensemble_first_and_last(case, ensemble)
+        if ensemble == 1:
+            overrides.update({'members':"{}".format(first)})
+            overrides.update({"workflow_description":"case {}".format(case.get_value("CASE"))})
+        else:
+            overrides.update({'members':"{}..{}".format(first,last)})
+            firstcase = case.get_value("CASE")
+            intlen = len(str(last))
+            lastcase = firstcase[:-intlen]+str(last)
+            overrides.update({"workflow_description":"ensemble from {} to {}".format(firstcase,lastcase)})
+        overrides.update({"case_path_string":cylc_get_case_path_string(case, ensemble)})
+
+        for job in jobs:
+            jobname = job
+            if job == 'case.st_archive':
+                continue
+            if job == 'case.run':
+                jobname = 'run'
+                overrides.update(env_batch.get_job_overrides(job, case))
+                overrides.update({'job_id':'run.'+casename})
+                input_text = input_text + cylc_batch_job_template(job, jobname, case, ensemble)
+            else:
+                depends_on = env_workflow.get_value('dependency', subgroup=job)
+                if depends_on.startswith('case.'):
+                    depends_on = depends_on[5:]
+                input_text = input_text.replace(' => '+depends_on,' => '+depends_on+'<member> => '+job)
+
+
+                overrides.update(env_batch.get_job_overrides(job, case))
+                overrides.update({'job_id':job+'.'+casename})
+                if 'total_tasks' in overrides and overrides['total_tasks'] > 1:
+                    input_text = input_text + cylc_batch_job_template(job, jobname, case, ensemble)
+                else:
+                    input_text = input_text + cylc_script_job_template(jobname, case, ensemble)
+
+
+            overrides.update({'batchdirectives':env_batch.get_batch_directives(case,job, overrides=overrides,
+                                                                           output_format='cylc')})
+            # we need to re-transform for each job to get job size correctly
+            input_text = transform_vars(input_text, case=case, subgroup=job, overrides=overrides)
+
+        with open("suite.rc", "w") as f:
+            f.write(case.get_resolved_value(input_text))
+
+
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/cime/scripts/Tools/mkDepends
+++ b/cime/scripts/Tools/mkDepends
@@ -71,29 +71,86 @@
 #   CESM Software Engineering Group, NCAR
 #   Mar 2013
 # -----------------------------------------------------------------------------
+# Modifications to Santos' version needed by the NEMO ocean model:
+#
+#  - Handling of module use statements activated by CPP macros, i.e.:
+#
+#     #ifdef KEY
+#       USE mod1
+#     #else
+#       USE mod2
+#     #endif
+#
+#  - Handling of Fortran code inclusion through CPP "#include"
+#    (NEMO's *.h90 files)
+#
+# When preprocessing is required (-p option) fortran files *.F and *.F90 are
+# preprocessed before serching for module dependencies. Preprocessed files are
+# saved in a temp subdir of the current dir which is removed at the end of execution.
+# The default preprocessor command is 'cpp'.
+# User can override it setting the env variable CPP before execution.
+# CPP macros can be defined (-D option) or undefined (-U option).
+# CPP search path can be defined (-I option).
+# Defined/undefined macros and search path can be passed in the env variable
+# CPPFLAGS too.
+#
+#   Pier Giuseppe Fogli
+#   ANS, CMCC
+#   Jun 2013
+# -----------------------------------------------------------------------------
 
-
-use Getopt::Std;
+use Getopt::Long qw(:config bundling);
 use File::Basename;
+use File::Temp qw/ :POSIX /;
 
 # Check for usage request.
 @ARGV >= 2                          or usage();
 
 # Process command line.
-my %opt = ();
-getopts( "t:wd:m:", \%opt )        or usage();
+my $opt_w = 0;
+my $obj_dir;
+my $additional_file;
+my $do_cpp = 0;
+my $mangle_scheme = "lower";
+my @cpp_def_key;
+my @cpp_undef_key;
+my @cpp_inc_path;
+GetOptions('p' => \$do_cpp,
+	'w' => \$opt_w,
+	'D=s' => \@cpp_def_key,
+	'U=s' => \@cpp_undef_key,
+	'I=s' => \@cpp_inc_path,
+	't=s' => \$obj_dir,
+	'd=s' => \$additional_file,
+	'm=s' => \$mangle_scheme,
+) or usage();
+@ARGV == 2                        or usage();  # Check that only 2 files remain
 my $filepath_arg = shift()        or usage();
 my $srcfile_arg = shift()         or usage();
 @ARGV == 0                        or usage();  # Check that all args were processed.
 
-my $obj_dir = "";
-if ( defined $opt{'t'} ) { $obj_dir = $opt{'t'}."/"; }
-
-my $additional_file = "";
-if ( defined $opt{'d'} ) { $additional_file = $opt{'d'}; }
-
-my $mangle_scheme = "lower";
-if ( defined $opt{'m'} ) { $mangle_scheme = $opt{'m'}; }
+# Setup CPP stuff if needed
+my $cpp = "cpp";
+my $red = " ";
+if ($do_cpp){
+    my @cpp_keys = ();
+    my @cpp_path = ();
+    #
+    # Override default cpp from env
+    $ENV{"CPP"} and $cpp = $ENV{"CPP"} ;
+    $ENV{"CPPFLAGS"} and @$cpp_keys = $ENV{"CPPFLAGS"} ;
+    #
+    foreach $k (@cpp_def_key){
+	push @$cpp_keys, "-D".$k ;
+    }
+    foreach $k (@cpp_undef_key){
+	push @$cpp_keys, "-U".$k ;
+    }
+    foreach $k (@cpp_inc_path){
+	push @$cpp_path, "-I".$k ;
+    }
+    if ($cpp =~ /gcc/){ $red = ">"; }
+}
 
 open(FILEPATH, $filepath_arg) or die "Can't open $filepath_arg: $!\n";
 open(SRCFILES, $srcfile_arg) or die "Can't open $srcfile_arg: $!\n";
@@ -106,7 +163,7 @@ close(FILEPATH);
 chomp @file_paths;
 unshift(@file_paths,'.');
 foreach $dir (@file_paths) {  # (could check that directories exist here)
-    $dir =~ s!/?\s*$!!;  # remove / and any whitespace at end of directory name
+    $dir =~ s!/?\s*$!!;  #!# remove / and any whitespace at end of directory name
     ($dir) = glob $dir;  # Expand tildes in path names.
 }
 
@@ -120,7 +177,8 @@ my %module_files = ();
 # Attempt to parse each file for /^\s*module/ and extract module names
 # for each file.
 my ($f, $name, $path, $suffix, $mod);
-my @suffixes = ('\.[fF]90', '\.[fF]','\.F90\.in' );
+# include NEMO's *.h90 files
+my @suffixes = ('\.[fFh]90', '\.[fF]','\.F90\.in' );
 foreach $f (@src) {
     ($name, $path, $suffix) = fileparse($f, @suffixes);
     # find the file in the list of directorys (in @file_paths)
@@ -169,12 +227,32 @@ my %file_modules = ();
 my %file_includes = ();
 my @check_includes = ();
 my %modules_used = ();
+
+# Create a temp dir for preprocessed files if needed
+my $tmp_dir;
+my $tmp_file;
+if ($do_cpp){
+    my $tmp_nam = tmpnam();
+    $tmp_dir = basename($tmp_nam);
+    my $cmd = "mkdir " . $tmp_dir;
+    system($cmd) == 0 or die "Failed to run command $cmd !\n";
+}
+
 foreach $f ( @src ) {
 
     # Find the file in the seach path (@file_paths).
     unless ($file_path = find_file($f)) {
-	if (defined $opt{'w'}) {print STDERR "$f not found\n";}
+	if ($opt_w) {print STDERR "$f not found\n";}
 	next;
+    }
+
+    # Preprocess if required
+    ($name, $path, $suffix) = fileparse($f, @suffixes);
+    if ($do_cpp && $suffix =~ /\.F/){
+        $tmp_file = catfile($tmp_dir, $name . lc($suffix));
+	my $cmd = $cpp . " " . "@$cpp_path" . " " . "@$cpp_keys" . " " . $file_path . $red . $tmp_file ;
+	system($cmd) == 0 or die "Failed to run command $cmd !\n";
+	$file_path = $tmp_file;
     }
 
     # Find the module and include dependencies.
@@ -189,16 +267,22 @@ foreach $f ( @src ) {
     push @check_includes, @{$file_includes{$f}};
 }
 
-print STDERR "\%file_modules\n";
-while ( ($k,$v) = each %file_modules ) {
-    print STDERR "$k => @$v\n";
+# Remove temp preprocessed file
+if ($do_cpp){
+  my $cmd = "rm -rf " . $tmp_dir;
+  system($cmd) == 0 or die "Failed to run command: $cmd !\n";
 }
-print STDERR "\%file_includes\n";
-while ( ($k,$v) = each %file_includes ) {
-    print STDERR "$k => @$v\n";
-}
-print STDERR "\@check_includes\n";
-print STDERR "@check_includes\n";
+
+#print STDERR "\%file_modules\n";
+#while ( ($k,$v) = each %file_modules ) {
+#    print STDERR "$k => @$v\n";
+#}
+#print STDERR "\%file_includes\n";
+#while ( ($k,$v) = each %file_includes ) {
+#    print STDERR "$k => @$v\n";
+#}
+#print STDERR "\@check_includes\n";
+#print STDERR "@check_includes\n";
 
 # Find include file dependencies.
 my %include_depends = ();
@@ -281,10 +365,10 @@ print "# Declare all module files used to build each object.\n";
 foreach $f (sort keys %file_modules) {
     my $file;
     if($f =~ /\.F90\.in$/){
-	$f =~ /(.+)\.F90\.in/;
+    	$f =~ /(.+)\.F90\.in/;
 	$file = $1;
     }else{
-	$f =~ /(.+)\./;
+        $f =~ /(.+)\./;
 	$file = $1;
     }
     $target = $obj_dir."$file.o";
@@ -326,12 +410,12 @@ sub find_dependencies {
     my @suffixes = ('\.[fF]90', '\.[fF]','\.F90\.in' );
     ($name, $path, $suffix) = fileparse($file, @suffixes);
     $target = "$name.o";
-    my $include;
+
     while ( <FH> ) {
-	# Search for "#include" and strip filename when found.
-	if ( /^#include\s+[<"](.*)[>"]/ ) {
+	# Search for CPP include and strip filename when found.
+	if ( /^#\s*include\s+[<"](.*)[>"]/ ) {
 	    $include = $1;
-	}
+	 }
 	# Search for Fortran include dependencies.
 	elsif ( /^\s*include\s+['"](.*)['"]/ ) {                   #" for emacs fontlock
 	    $include = $1;
@@ -429,8 +513,22 @@ sub usage {
     ($ProgName = $0) =~ s!.*/!!;            # name of program
     die <<EOF
 SYNOPSIS
-     $ProgName [-d depfile] [-m mangle_scheme] [-t dir] [-w] Filepath Srcfiles
+     $ProgName [-p [-Dmacro[=val]] [-Umacro] [-Idir]] [-d depfile]
+               [-m mangle_scheme] [-t dir] [-w] Filepath Srcfiles
 OPTIONS
+     -p
+          Preprocess files (suffix .F and .F90) before  searching
+	  for module dependencies. Default CPP preprocessor: cpp.
+	  Set env variables CPP and/or CPPFLAGS to override.
+     -D macro[=val]
+          Define the CPP macro with val as its value.
+	  Ignored when -p option is not active.
+     -U macro
+          Undefine the CPP macro.
+	  Ignored when -p option is not active.
+     -I dir
+          Add dir to the include path for CPP.
+	  Ignored when -p option is not active.
      -d depfile
           Additional file to be added to every .o dependence.
      -m mangle_scheme

--- a/cime/scripts/Tools/preview_run
+++ b/cime/scripts/Tools/preview_run
@@ -64,19 +64,24 @@ def _main_func(description):
 
         set_logger_indent("      ")
         job_id_to_cmd = case.submit_jobs(dry_run=True, job=job)
+        env_batch = case.get_env('batch')
         for job_id, cmd in job_id_to_cmd:
+            overrides = env_batch.get_job_overrides(job_id, case)
             print("  FOR JOB: {}".format(job_id))
             print("    ENV:")
             case.load_env(job=job_id, reset=True, verbose=True)
             if "OMP_NUM_THREADS" in os.environ:
                 print("      Setting Environment OMP_NUM_THREADS={}".format(os.environ["OMP_NUM_THREADS"]))
+            print("")
             print("    SUBMIT CMD:")
             print("      {}".format(case.get_resolved_value(cmd)))
             print("")
 
-        if job == case.get_primary_job():
-            print("MPIRUN:")
-            print ("  {}".format(case.get_mpirun_cmd()))
+            print("    MPIRUN (job={}):".format(job_id))
+            print ("      {}".format(overrides["mpirun"]))
+            print("")
+            
+
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/cime/scripts/create_clone
+++ b/cime/scripts/create_clone
@@ -5,7 +5,7 @@ from Tools.standard_script_setup import *
 from CIME.utils import expect
 from CIME.case  import Case
 from argparse   import RawTextHelpFormatter
-
+import re
 logger = logging.getLogger(__name__)
 
 ###############################################################################
@@ -22,6 +22,11 @@ def parse_command_line(args):
     parser.add_argument("--clone", "-clone", required=True,
                         help="(required) Specify a case to be cloned. If not a full pathname, "
                         "\nthe case to be cloned is assumed to be under then current working directory.")
+
+    parser.add_argument("--ensemble", default=1,
+                        help="clone an ensemble of cases, the case name argument must end in an integer.\n"
+                        "for example: ./create_clone --clone case.template --case case.001 --ensemble 4 \n"
+                        "will create case.001, case.002, case.003, case.004 from existing case.template"  )
 
     parser.add_argument("--user-mods-dir",
                         help="Full pathname to a directory containing any combination of user_nl_* files "
@@ -61,14 +66,21 @@ def parse_command_line(args):
         expect(False,
                "Must specify -clone as an input argument")
 
+    startval = '1'
+    if int(args.ensemble) > 1:
+        m = re.search(r'(\d+)$', args.case)
+        expect(m, " case name must end in an integer to use this feature")
+        startval = m.group(1)
+
     return args.case, args.clone, args.keepexe, args.mach_dir, args.project, \
-        args.cime_output_root, args.user_mods_dir
+        args.cime_output_root, args.user_mods_dir, int(args.ensemble), startval
 
 ##############################################################################
 def _main_func():
 ###############################################################################
 
-    case, clone, keepexe, mach_dir, project, cime_output_root, user_mods_dir = parse_command_line(sys.argv)
+    case, clone, keepexe, mach_dir, project, cime_output_root, user_mods_dir, \
+        ensemble, startval = parse_command_line(sys.argv)
 
     cloneroot = os.path.abspath(clone)
     expect(os.path.isdir(cloneroot),
@@ -77,12 +89,16 @@ def _main_func():
     if user_mods_dir is not None:
         if os.path.isdir(user_mods_dir):
             user_mods_dir = os.path.abspath(user_mods_dir)
+    nint = len(startval)
 
-    with Case(cloneroot, read_only=False) as clone:
-        clone.create_clone(case, keepexe=keepexe, mach_dir=mach_dir,
-                           project=project,
-                           cime_output_root=cime_output_root,
-                           user_mods_dir=user_mods_dir)
+    for i in range(int(startval), int(startval)+ensemble):
+        if ensemble > 1:
+            case = case[:-nint] + '{{0:0{0:d}d}}'.format(nint).format(i)
+        with Case(cloneroot, read_only=False) as clone:
+            clone.create_clone(case, keepexe=keepexe, mach_dir=mach_dir,
+                               project=project,
+                               cime_output_root=cime_output_root,
+                               user_mods_dir=user_mods_dir)
 
 ###############################################################################
 

--- a/cime/scripts/create_newcase
+++ b/cime/scripts/create_newcase
@@ -89,6 +89,14 @@ def parse_command_line(args, cimeroot, description):
                         help="Full pathname of config grid file to use. "
                         "\nThis should be a copy of config/config_grids.xml with the new user grid changes added to it. \n")
 
+    if cime_config and cime_config.has_option('main','workflow'):
+        workflow_default = cime_config.get('main', 'workflow')
+    else:
+        workflow_default = "default"
+
+    parser.add_argument("--workflow-case",default=workflow_default,
+                        help="A workflow from config_workflow.xml to apply to this case. ")
+
 
     if cime_config and cime_config.has_option('main','SRCROOT'):
         srcroot_default = cime_config.get('main', 'srcroot')
@@ -172,7 +180,7 @@ def parse_command_line(args, cimeroot, description):
         args.user_mods_dir, args.pesfile, \
         args.gridfile, args.srcroot, args.test, args.multi_driver, \
         args.ninst, args.walltime, args.queue, args.output_root, args.script_root, \
-        run_unsupported, args.answer, args.input_dir, args.driver, args.non_local
+        run_unsupported, args.answer, args.input_dir, args.driver, args.workflow_case, args.non_local
 
 ###############################################################################
 def _main_func(description):
@@ -184,7 +192,9 @@ def _main_func(description):
         user_mods_dir, pesfile, \
         gridfile, srcroot, test, multi_driver, ninst, walltime, \
         queue, output_root, script_root, run_unsupported, \
-        answer, input_dir, driver, non_local = parse_command_line(sys.argv, cimeroot, description)
+        answer, input_dir, driver, \
+        workflow, non_local = parse_command_line(sys.argv, cimeroot, description)
+
 
     if script_root is None:
         caseroot = os.path.abspath(casename)
@@ -209,7 +219,7 @@ def _main_func(description):
                     multi_driver=multi_driver, ninst=ninst, test=test,
                     walltime=walltime, queue=queue, output_root=output_root,
                     run_unsupported=run_unsupported, answer=answer,
-                    input_dir=input_dir, driver=driver, non_local=non_local)
+                    input_dir=input_dir, driver=driver, workflow_case=workflow, non_local=non_local)
 
 ###############################################################################
 

--- a/cime/scripts/lib/CIME/Servers/wget.py
+++ b/cime/scripts/lib/CIME/Servers/wget.py
@@ -50,7 +50,7 @@ class WGET(GenericServer):
         logger.debug(output)
         logger.debug(errput)
         if (stat != 0):
-            logging.warning("wget failed with output: {} and errput {}\n".format(output, errput))
+            logging.warning("wget failed with output: {} and errput {}\n".format(output.encode('utf-8'), errput.encode('utf-8')))
             # wget puts an empty file if it fails.
             try:
                 os.remove(full_path)

--- a/cime/scripts/lib/CIME/XML/batch.py
+++ b/cime/scripts/lib/CIME/XML/batch.py
@@ -107,14 +107,15 @@ class Batch(GenericXML):
         and the second a dict of qualifiers for the job
         """
         jobs = []
-        bnode = self.get_child("batch_jobs")
-        for jnode in self.get_children(root=bnode):
-            if self.name(jnode) == "job":
-                name = self.get(jnode, "name")
-                jdict = {}
-                for child in self.get_children(root=jnode):
-                    jdict[self.name(child)] = self.text(child)
+        bnode = self.get_optional_child("batch_jobs")
+        if bnode:
+            for jnode in self.get_children(root=bnode):
+                if self.name(jnode) == "job":
+                    name = self.get(jnode, "name")
+                    jdict = {}
+                    for child in self.get_children(root=jnode):
+                        jdict[self.name(child)] = self.text(child)
 
-            jobs.append((name, jdict))
+                    jobs.append((name, jdict))
 
         return jobs

--- a/cime/scripts/lib/CIME/XML/env_base.py
+++ b/cime/scripts/lib/CIME/XML/env_base.py
@@ -12,7 +12,7 @@ class EnvBase(EntryID):
     def __init__(self, case_root, infile, schema=None, read_only=False):
         if case_root is None:
             case_root = os.getcwd()
-
+        self._caseroot = case_root
         if os.path.isabs(infile):
             fullpath = infile
         else:

--- a/cime/scripts/lib/CIME/XML/env_batch.py
+++ b/cime/scripts/lib/CIME/XML/env_batch.py
@@ -4,7 +4,7 @@ Interface to the env_batch.xml file.  This class inherits from EnvBase
 
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_base import EnvBase
-from CIME.utils import transform_vars, get_cime_root, convert_to_seconds, format_time, get_cime_config, get_batch_script_for_job, get_logging_options
+from CIME.utils import transform_vars, get_cime_root, convert_to_seconds, get_cime_config, get_batch_script_for_job, get_logging_options
 
 from collections import OrderedDict
 import stat, re, math
@@ -32,21 +32,6 @@ class EnvBatch(EnvBase):
         """
         val = None
 
-        if item == "JOB_WALLCLOCK_TIME":
-            #Most systems use %H:%M:%S format for wallclock but LSF
-            #uses %H:%M this code corrects the value passed in to be
-            #the correct format - if we find we have more exceptions
-            #than this we may need to generalize this further
-            walltime_format = self.get_value("walltime_format", subgroup=None)
-            if walltime_format is not None and walltime_format.count(":") != value.count(":"): # pylint: disable=maybe-no-member
-                if value.count(":") == 1:
-                    t_spec = "%H:%M"
-                elif value.count(":") == 2:
-                    t_spec = "%H:%M:%S"
-                else:
-                    expect(False, "could not interpret format for wallclock time {}".format(value))
-                value = format_time(walltime_format, t_spec, value)
-
         if item == "JOB_QUEUE":
             expect(value in self._get_all_queue_names() or ignore_type,
                    "Unknown Job Queue specified use --force to set")
@@ -69,34 +54,26 @@ class EnvBatch(EnvBase):
         return val
 
     # pylint: disable=arguments-differ
-    def get_value(self, item, attribute=None, resolved=True, subgroup="PRIMARY"):
+    def get_value(self, item, attribute=None, resolved=True, subgroup=None):
         """
         Must default subgroup to something in order to provide single return value
         """
 
         value = None
-        if subgroup is None:
-            node = self.get_optional_child(item, attribute)
-            if node is None:
-                # this will take the last instance of item listed in all batch_system elements
-                bs_nodes = self.get_children("batch_system")
-                for bsnode in bs_nodes:
-                    cnode = self.get_optional_child(item, attribute, root=bsnode)
-                    if cnode is not None:
-                        node = cnode
-
-            if node is not None:
-                value = self.text(node)
-                if resolved:
-                    value = self.get_resolved_value(value)
-            else:
-                value = super(EnvBatch, self).get_value(item,attribute,resolved)
-
+        node = self.get_optional_child(item, attribute)
+        if node is None:
+            # this will take the last instance of item listed in all batch_system elements
+            bs_nodes = self.get_children("batch_system")
+            for bsnode in bs_nodes:
+                cnode = self.get_optional_child(item, attribute, root=bsnode)
+                if cnode is not None:
+                    node = cnode
+        if node is None or item in ("BATCH_SYSTEM", "PROJECT_REQUIRED"):
+            value = super(EnvBatch, self).get_value(item,attribute,resolved)
         else:
-            if subgroup == "PRIMARY":
-                subgroup = "case.test" if "case.test" in self.get_jobs() else "case.run"
-            #pylint: disable=assignment-from-none
-            value = super(EnvBatch, self).get_value(item, attribute=attribute, resolved=resolved, subgroup=subgroup)
+            value = self.text(node)
+            if resolved:
+                value = self.get_resolved_value(value)
 
         return value
 
@@ -186,25 +163,39 @@ class EnvBatch(EnvBase):
             self.add_child(self.copy(batchobj.machine_node))
         self.set_value("BATCH_SYSTEM", batch_system_type)
 
+    def get_job_overrides(self, job, case):
+        env_workflow = case.get_env('workflow')
+        total_tasks, num_nodes, tasks_per_node, thread_count = env_workflow.get_job_specs(job)
+        overrides = {}
+
+        if total_tasks:
+            overrides["total_tasks"] = total_tasks
+            overrides["num_nodes"]   = num_nodes
+            overrides["tasks_per_node"] =  tasks_per_node
+            if thread_count:
+                overrides["thread_count"] = thread_count
+        else:
+            total_tasks = case.get_value("TOTALPES")*int(case.thread_count)
+            thread_count = case.thread_count
+        if int(total_tasks)*int(thread_count) < case.get_value("MAX_TASKS_PER_NODE"):
+            overrides["max_tasks_per_node"] = int(total_tasks)
+
+        overrides["mpirun"] = case.get_mpirun_cmd(job=job, overrides=overrides)
+        return overrides
+
     def make_batch_script(self, input_template, job, case, outfile=None):
         expect(os.path.exists(input_template), "input file '{}' does not exist".format(input_template))
-        task_count = self.get_value("task_count", subgroup=job)
-        overrides = {}
-        if task_count is not None:
-            overrides["total_tasks"] = int(task_count)
-            overrides["num_nodes"]   = int(math.ceil(float(task_count)/float(case.tasks_per_node)))
-        else:
-            task_count = case.get_value("TOTALPES")*int(case.thread_count)
-        if int(task_count) < case.get_value("MAX_TASKS_PER_NODE"):
-            overrides["max_tasks_per_node"] = int(task_count)
-
-        overrides["job_id"] = case.get_value("CASE") + os.path.splitext(job)[1]
+        overrides = self.get_job_overrides(job, case)
+        ext = os.path.splitext(job)[-1]
+        if len(ext) == 0:
+            ext = job
+        if ext.startswith('.'):
+            ext = ext[1:]
+        overrides["job_id"] = ext + '.' + case.get_value("CASE")
         if "pleiades" in case.get_value("MACH"):
             # pleiades jobname needs to be limited to 15 chars
             overrides["job_id"] = overrides["job_id"][:15]
-
         overrides["batchdirectives"] = self.get_batch_directives(case, job, overrides=overrides)
-        overrides["mpirun"] = case.get_mpirun_cmd(job=job)
         output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)
         output_name = get_batch_script_for_job(job) if outfile is None else outfile
         logger.info("Creating file {}".format(output_name))
@@ -220,8 +211,8 @@ class EnvBatch(EnvBase):
 
         if self._batchtype == "none":
             return
-
-        known_jobs = self.get_jobs()
+        env_workflow = case.get_env('workflow')
+        known_jobs = env_workflow.get_jobs()
 
         for job, jsect in batch_jobs:
             if job not in known_jobs:
@@ -281,9 +272,8 @@ class EnvBatch(EnvBase):
                     walltime = specs[3]
 
                 walltime = self._default_walltime if walltime is None else walltime # last-chance fallback
-
-            self.set_value("JOB_QUEUE", queue, subgroup=job, ignore_type=specs is None)
-            self.set_value("JOB_WALLCLOCK_TIME", walltime, subgroup=job)
+            env_workflow.set_value("JOB_QUEUE", queue, subgroup=job, ignore_type=specs is None)
+            env_workflow.set_value("JOB_WALLCLOCK_TIME", walltime, subgroup=job)
             logger.debug("Job {} queue {} walltime {}".format(job, queue, walltime))
 
     def _match_attribs(self, attribs, case, queue):
@@ -317,7 +307,7 @@ class EnvBatch(EnvBase):
         logger.debug("(env_mach_specific) _match {} {} {}".format(my_value, xml_value, result))
         return result
 
-    def get_batch_directives(self, case, job, overrides=None):
+    def get_batch_directives(self, case, job, overrides=None, output_format='default'):
         """
         """
         result = []
@@ -335,8 +325,10 @@ class EnvBatch(EnvBase):
         for root in roots:
             if root is not None:
                 if directive_prefix is None:
-                    directive_prefix = self.get_element_text("batch_directive", root=root)
-
+                    if output_format == 'default':
+                        directive_prefix = self.get_element_text("batch_directive", root=root)
+                    elif output_format == 'cylc':
+                        directive_prefix = "     "
                 if unknown_queue:
                     unknown_queue_directives = self.get_element_text("unknown_queue_directives",
                                                                      root=root)
@@ -351,6 +343,16 @@ class EnvBatch(EnvBase):
                     if self._match_attribs(self.attrib(dnode), case, queue):
                         for node in nodes:
                             directive = self.get_resolved_value("" if self.text(node) is None else self.text(node))
+                            if output_format == 'cylc':
+                                if self._batchtype == 'pbs':
+                                    # cylc includes the -N itself, no need to add
+                                    if directive.startswith("-N"):
+                                        directive=''
+                                        continue
+                                    m = re.match(r'\s*(-[\w])', directive)
+                                    if m:
+                                        directive = re.sub(r'(-[\w]) ','{} = '.format(m.group(1)), directive)
+
                             default = self.get(node, "default")
                             if default is None:
                                 directive = transform_vars(directive, case=case, subgroup=job, default=default, overrides=overrides)
@@ -427,34 +429,35 @@ class EnvBatch(EnvBase):
     def submit_jobs(self, case, no_batch=False, job=None, user_prereq=None, skip_pnl=False,
                     allow_fail=False, resubmit_immediate=False, mail_user=None, mail_type=None,
                     batch_args=None, dry_run=False):
-        alljobs = self.get_jobs()
+        env_workflow = case.get_env('workflow')
+        external_workflow = case.get_value("EXTERNAL_WORKFLOW")
+        alljobs = env_workflow.get_jobs()
+        alljobs = [j for j in alljobs
+                   if os.path.isfile(os.path.join(self._caseroot,get_batch_script_for_job(j)))]
         startindex = 0
         jobs = []
         firstjob = job
         if job is not None:
             expect(job in alljobs, "Do not know about batch job {}".format(job))
             startindex = alljobs.index(job)
-
         for index, job in enumerate(alljobs):
             logger.debug( "Index {:d} job {} startindex {:d}".format(index, job, startindex))
             if index < startindex:
                 continue
             try:
-                prereq = self.get_value('prereq', subgroup=job, resolved=False)
-                if prereq is None or job == firstjob or (dry_run and prereq == "$BUILD_COMPLETE"):
+                prereq = env_workflow.get_value('prereq', subgroup=job, resolved=False)
+                if external_workflow or prereq is None or job == firstjob or (dry_run and prereq == "$BUILD_COMPLETE"):
                     prereq = True
                 else:
                     prereq = case.get_resolved_value(prereq)
                     prereq = eval(prereq)
             except Exception:
                 expect(False,"Unable to evaluate prereq expression '{}' for job '{}'".format(self.get_value('prereq',subgroup=job), job))
-
             if prereq:
-                jobs.append((job, self.get_value('dependency', subgroup=job)))
+                jobs.append((job, env_workflow.get_value('dependency', subgroup=job)))
 
             if self._batchtype == "cobalt":
                 break
-
         depid = OrderedDict()
         jobcmds = []
 
@@ -467,7 +470,7 @@ class EnvBatch(EnvBase):
             num_submit = 1
 
         prev_job = None
-
+        batch_job_id = None
         for _ in range(num_submit):
             for job, dependency in jobs:
                 if dependency is not None:
@@ -497,10 +500,13 @@ class EnvBatch(EnvBase):
                 batch_job_id = str(alljobs.index(job)) if dry_run else result
                 depid[job] = batch_job_id
                 jobcmds.append( (job, result) )
-                if self._batchtype == "cobalt":
-                    break
-            prev_job = batch_job_id
 
+                if self._batchtype == "cobalt" or external_workflow:
+                    break
+
+            if not external_workflow and not no_batch:
+                expect(batch_job_id, "No result from jobs {}".format(jobs))
+                prev_job = batch_job_id
 
         if dry_run:
             return jobcmds
@@ -577,17 +583,23 @@ class EnvBatch(EnvBase):
     def _submit_single_job(self, case, job, dep_jobs=None, allow_fail=False,
                            no_batch=False, skip_pnl=False, mail_user=None, mail_type=None,
                            batch_args=None, dry_run=False, resubmit_immediate=False):
+
         if not dry_run:
             logger.warning("Submit job {}".format(job))
         batch_system = self.get_value("BATCH_SYSTEM", subgroup=None)
         if batch_system is None or batch_system == "none" or no_batch:
             logger.info("Starting job script {}".format(job))
             function_name = job.replace(".", "_")
+            job_name = "."+job
             if not dry_run:
                 args = self._build_run_args(job, True, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
                                             submit_resubmits=not resubmit_immediate)
                 try:
-                    getattr(case, function_name)(**{k: v for k, (v, _) in args.items()})
+                    if hasattr(case, function_name):
+                        getattr(case, function_name)(**{k: v for k, (v, _) in args.items()})
+                    else:
+                        expect(os.path.isfile(job_name),"Could not find file {}".format(job_name))
+                        run_cmd_no_fail(os.path.join(self._caseroot,job_name), combine_output=True, verbose=True, from_dir=self._caseroot)
                 except Exception as e:
                     # We don't want exception from the run phases getting into submit phase
                     logger.warning("Exception from {}: {}".format(function_name, str(e)))
@@ -665,13 +677,14 @@ class EnvBatch(EnvBase):
         batch_env_flag = self.get_value("batch_env", subgroup=None)
         run_args = self._build_run_args_str(job, False, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
                                             submit_resubmits=not resubmit_immediate)
-        if batch_env_flag:
+        if batch_system == 'lsf':
+            sequence = (run_args, batchsubmit, submitargs, batchredirect, get_batch_script_for_job(job))
+        elif batch_env_flag:
             sequence = (batchsubmit, submitargs, run_args, batchredirect, get_batch_script_for_job(job))
         else:
             sequence = (batchsubmit, submitargs, batchredirect, get_batch_script_for_job(job), run_args)
 
         submitcmd = " ".join(s.strip() for s in sequence if s is not None)
-
         if dry_run:
             return submitcmd
         else:
@@ -807,8 +820,7 @@ class EnvBatch(EnvBase):
         return nodes
 
     def get_children(self, name=None, attributes=None, root=None):
-        if name in ("JOB_WALLCLOCK_TIME", "PROJECT", "CHARGE_ACCOUNT",
-                        "PROJECT_REQUIRED", "JOB_QUEUE", "BATCH_COMMAND_FLAGS"):
+        if name == "PROJECT_REQUIRED":
             nodes = super(EnvBatch, self).get_children("entry", attributes={"id":name}, root=root)
         else:
             nodes = super(EnvBatch, self).get_children(name, attributes=attributes, root=root)
@@ -883,8 +895,18 @@ class EnvBatch(EnvBase):
 
     def make_all_batch_files(self, case):
         machdir  = case.get_value("MACHDIR")
+        env_workflow = case.get_env("workflow")
         logger.info("Creating batch scripts")
-        for job in self.get_jobs():
-            input_batch_script = os.path.join(machdir,self.get_value('template', subgroup=job))
-            logger.info("Writing {} script from input template {}".format(job, input_batch_script))
-            self.make_batch_script(input_batch_script, job, case)
+        jobs = env_workflow.get_jobs()
+        for job in jobs:
+            template = case.get_resolved_value(env_workflow.get_value('template', subgroup=job))
+
+            if os.path.isabs(template):
+                input_batch_script = template
+            else:
+                input_batch_script = os.path.join(machdir,template)
+            if os.path.isfile(input_batch_script):
+                logger.info("Writing {} script from input template {}".format(job, input_batch_script))
+                self.make_batch_script(input_batch_script, job, case)
+            else:
+                logger.warning("Input template file {} for job {} does not exist or cannot be read.".format(input_batch_script, job))

--- a/cime/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/cime/scripts/lib/CIME/XML/env_mach_specific.py
@@ -406,7 +406,7 @@ class EnvMachSpecific(EnvBase):
         cmd_nodes = self.get_optional_child("cmd_path", attributes={"lang":lang}, root=self.get_child("module_system"))
         return self.text(cmd_nodes) if cmd_nodes is not None else None
 
-    def get_mpirun(self, case, attribs, job, exe_only=False):
+    def get_mpirun(self, case, attribs, job, exe_only=False, overrides=None):
         """
         Find best match, return (executable, {arg_name : text})
         """
@@ -462,12 +462,12 @@ class EnvMachSpecific(EnvBase):
         # Now that we know the best match, compute the arguments
         if not exe_only:
             arg_node = self.get_optional_child("arguments", root=the_match)
-            if arg_node is not None:
+            if arg_node:
                 arg_nodes = self.get_children("arg", root=arg_node)
                 for arg_node in arg_nodes:
                     arg_value = transform_vars(self.text(arg_node),
                                                case=case,
-                                               subgroup=job,
+                                               subgroup=job,overrides=overrides,
                                                default=self.get(arg_node, "default"))
                     args.append(arg_value)
 

--- a/cime/scripts/lib/CIME/XML/env_workflow.py
+++ b/cime/scripts/lib/CIME/XML/env_workflow.py
@@ -1,0 +1,141 @@
+"""
+Interface to the env_workflow.xml file.  This class inherits from EnvBase
+"""
+
+from CIME.XML.standard_module_setup import *
+from CIME.XML.env_base import EnvBase
+from CIME.utils import get_cime_root
+import re, math
+
+logger = logging.getLogger(__name__)
+
+# pragma pylint: disable=attribute-defined-outside-init
+
+class EnvWorkflow(EnvBase):
+
+    def __init__(self, case_root=None, infile="env_workflow.xml", read_only=False):
+        """
+        initialize an object interface to file env_workflow.xml in the case directory
+        """
+        # This arbitrary setting should always be overwritten
+        #        schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_workflow.xsd")
+        # TODO: define schema for this file
+        schema = None
+        super(EnvWorkflow,self).__init__(case_root, infile, schema=schema, read_only=read_only)
+
+    def create_job_groups(self, batch_jobs, is_test):
+        # Subtle: in order to support dynamic batch jobs, we need to remove the
+        # job_submission group and replace with job-based groups
+
+        orig_group = self.get_child("group", {"id":"job_submission"},
+                                    err_msg="Looks like job groups have already been created")
+        orig_group_children = super(EnvWorkflow, self).get_children(root=orig_group)
+
+        childnodes = []
+        for child in reversed(orig_group_children):
+            childnodes.append(child)
+
+        self.remove_child(orig_group)
+
+        for name, jdict in batch_jobs:
+            if name == "case.run" and is_test:
+                pass # skip
+            elif name == "case.test" and not is_test:
+                pass # skip
+            elif name == "case.run.sh":
+                pass # skip
+            else:
+                new_job_group = self.make_child("group", {"id":name})
+                for field in jdict.keys():
+                    if field == "runtime_parameters":
+                        continue
+                    val = jdict[field]
+                    node = self.make_child("entry", {"id":field,"value":val}, root=new_job_group)
+                    self.make_child("type", root=node, text="char")
+
+                for child in childnodes:
+                    self.add_child(self.copy(child), root=new_job_group)
+
+    def get_jobs(self):
+        groups = self.get_children("group")
+        results = []
+        for group in groups:
+            results.append(self.get(group, "id"))
+        return results
+
+    def get_type_info(self, vid):
+        gnodes = self.get_children("group")
+        type_info = None
+        for gnode in gnodes:
+            nodes = self.get_children("entry",{"id":vid}, root=gnode)
+            type_info = None
+            for node in nodes:
+                new_type_info = self._get_type_info(node)
+                if type_info is None:
+                    type_info = new_type_info
+                else:
+                    expect( type_info == new_type_info,
+                            "Inconsistent type_info for entry id={} {} {}".format(vid, new_type_info, type_info))
+        return type_info
+
+    def get_job_specs(self, job):
+        task_count = self.get_value("task_count", subgroup=job)
+        tasks_per_node = self.get_value("tasks_per_node", subgroup=job)
+        thread_count = self.get_value("thread_count", subgroup=job)
+        num_nodes = None
+        if task_count is not None and tasks_per_node is not None:
+            task_count = int(task_count)
+            num_nodes   = int(math.ceil(float(task_count)/float(tasks_per_node)))
+            tasks_per_node =  task_count//num_nodes
+        if not thread_count:
+            thread_count = 1
+
+        return task_count, num_nodes, tasks_per_node, thread_count
+
+    # pylint: disable=arguments-differ
+    def get_value(self, item, attribute=None, resolved=True, subgroup="PRIMARY"):
+        """
+        Must default subgroup to something in order to provide single return value
+        """
+        value = None
+        if subgroup == "PRIMARY":
+            subgroup = "case.test" if "case.test" in self.get_jobs() else "case.run"
+
+        #pylint: disable=assignment-from-none
+        if value is None:
+            value = super(EnvWorkflow, self).get_value(item, attribute=attribute, resolved=resolved, subgroup=subgroup)
+
+        return value
+
+    # pylint: disable=arguments-differ
+    def set_value(self, item, value, subgroup=None, ignore_type=False):
+        """
+        Override the entry_id set_value function with some special cases for this class
+        """
+        val = None
+
+        # allow the user to set item for all jobs if subgroup is not provided
+        if subgroup is None:
+            gnodes = self.get_children("group")
+            for gnode in gnodes:
+                node = self.get_optional_child("entry", {"id":item}, root=gnode)
+                if node is not None:
+                    self._set_value(node, value, vid=item, ignore_type=ignore_type)
+                    val = value
+        else:
+            group = self.get_optional_child("group", {"id":subgroup})
+            if group is not None:
+                node = self.get_optional_child("entry", {"id":item}, root=group)
+                if node is not None:
+                    val = self._set_value(node, value, vid=item, ignore_type=ignore_type)
+
+        return val
+
+    def get_children(self, name=None, attributes=None, root=None):
+        if name in ("JOB_WALLCLOCK_TIME", "PROJECT", "CHARGE_ACCOUNT",
+                    "JOB_QUEUE", "BATCH_COMMAND_FLAGS"):
+            nodes = super(EnvWorkflow, self).get_children("entry", attributes={"id":name}, root=root)
+        else:
+            nodes = super(EnvWorkflow, self).get_children(name, attributes=attributes, root=root)
+
+        return nodes

--- a/cime/scripts/lib/CIME/XML/generic_xml.py
+++ b/cime/scripts/lib/CIME/XML/generic_xml.py
@@ -370,7 +370,7 @@ class GenericXML(object):
         """
         nodes = self.scan_children(nodename, attributes=attributes, root=root)
 
-        expect(len(nodes) <= 1, "Multiple matches for nodename '{}' and attrs '{}' in file '{}'".format(nodename, attributes, self.filename))
+        expect(len(nodes) <= 1, "Multiple matches for nodename '{}' and attrs '{}' in file '{}', found {} matches".format(nodename, attributes, self.filename, len(nodes)))
         return nodes[0] if nodes else None
 
     def scan_children(self, nodename, attributes=None, root=None):

--- a/cime/scripts/lib/CIME/XML/workflow.py
+++ b/cime/scripts/lib/CIME/XML/workflow.py
@@ -1,0 +1,80 @@
+"""
+Interface to the config_workflow.xml file.  This class inherits from GenericXML.py
+"""
+
+from CIME.XML.standard_module_setup import *
+from CIME.XML.generic_xml import GenericXML
+from CIME.XML.files import Files
+from CIME.utils import expect
+
+logger = logging.getLogger(__name__)
+
+class Workflow(GenericXML):
+
+    def __init__(self, infile=None, files=None):
+        """
+        initialize an object
+        """
+        if files is None:
+            files = Files()
+        if infile is None:
+            infile = files.get_value("WORKFLOW_SPEC_FILE")
+        expect(infile, "No workflow file defined in {}".format(files.filename))
+
+        schema = files.get_schema("WORKFLOW_SPEC_FILE")
+
+        GenericXML.__init__(self, infile, schema=schema)
+
+        #Append the contents of $HOME/.cime/config_workflow.xml if it exists
+        #This could cause problems if node matchs are repeated when only one is expected
+        infile = os.path.join(os.environ.get("HOME"),".cime","config_workflow.xml")
+        if os.path.exists(infile):
+            GenericXML.read(self, infile)
+
+    def get_workflow_jobs(self, machine, workflow_case="default"):
+        """
+        Return a list of jobs with the first element the name of the case script
+        and the second a dict of qualifiers for the job
+        """
+        jobs = []
+        bnodes = []
+        findmore = True
+        prepend = False
+        while findmore:
+            bnode = self.get_optional_child("workflow_jobs", attributes={"case":workflow_case})
+            expect(bnode,"No workflow_case {} found in file {}".format(workflow_case, self.filename))
+            if prepend:
+                bnodes = [bnode] + bnodes
+            else:
+                bnodes.append(bnode)
+            prepend = False
+            workflow_attribs = self.attrib(bnode)
+            if "prepend" in workflow_attribs:
+                workflow_case = workflow_attribs["prepend"]
+                prepend = True
+            elif "append" in workflow_attribs:
+                workflow_case = workflow_attribs["append"]
+            else:
+                findmore = False
+        for bnode in bnodes:
+            for jnode in self.get_children(root=bnode):
+                if self.name(jnode) == "job":
+                    name = self.get(jnode, "name")
+                    jdict = {}
+                    for child in self.get_children(root=jnode):
+                        if self.name(child) == "runtime_parameters":
+                            attrib = self.attrib(child)
+                            if attrib and attrib == {'MACH' : machine}:
+                                for rtchild in self.get_children(root=child):
+                                    jdict[self.name(rtchild)] = self.text(rtchild)
+                            elif not attrib:
+                                for rtchild in self.get_children(root=child):
+                                    if self.name(rtchild) not in jdict:
+                                        jdict[self.name(rtchild)] = self.text(rtchild)
+
+                        else:
+                            jdict[self.name(child)] = self.text(child)
+
+                jobs.append((name, jdict))
+
+        return jobs

--- a/cime/scripts/lib/CIME/aprun.py
+++ b/cime/scripts/lib/CIME/aprun.py
@@ -108,7 +108,7 @@ def _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids,
     return aprun_args, total_node_count, total_task_count, min_tasks_per_node, max_thread_count
 
 ###############################################################################
-def get_aprun_cmd_for_case(case, run_exe):
+def get_aprun_cmd_for_case(case, run_exe, overrides=None):
 ###############################################################################
     """
     Given a case, construct and return the aprun command and optimized node count
@@ -120,9 +120,19 @@ def get_aprun_cmd_for_case(case, run_exe):
         for the_list, item_name in zip([ntasks, nthreads, rootpes, pstrids],
                                        ["NTASKS", "NTHRDS", "ROOTPE", "PSTRID"]):
             the_list.append(case.get_value("_".join([item_name, model])))
+    max_tasks_per_node = case.get_value("MAX_TASKS_PER_NODE")
+    if overrides:
+        if 'max_tasks_per_node' in overrides:
+            max_tasks_per_node = overrides['max_tasks_per_node'] 
+        if 'total_tasks' in overrides:
+            ntasks = [overrides['total_tasks'] if x > 1 else x for x in ntasks]
+        if 'thread_count' in overrides:
+            nthreads = [overrides['thread_count'] if x > 1 else x for x in nthreads]
+    
+
 
     return _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids,
-                                        case.get_value("MAX_TASKS_PER_NODE"),
+                                        max_tasks_per_node,
                                         case.get_value("MAX_MPITASKS_PER_NODE"),
                                         case.get_value("PIO_NUMTASKS"),
                                         case.get_value("PIO_ASYNC_INTERFACE"),

--- a/cime/scripts/lib/CIME/case/case.py
+++ b/cime/scripts/lib/CIME/case/case.py
@@ -22,6 +22,7 @@ from CIME.XML.component             import Component
 from CIME.XML.compsets              import Compsets
 from CIME.XML.grids                 import Grids
 from CIME.XML.batch                 import Batch
+from CIME.XML.workflow              import Workflow
 from CIME.XML.pio                   import PIO
 from CIME.XML.archive               import Archive
 from CIME.XML.env_test              import EnvTest
@@ -32,6 +33,7 @@ from CIME.XML.env_build             import EnvBuild
 from CIME.XML.env_run               import EnvRun
 from CIME.XML.env_archive           import EnvArchive
 from CIME.XML.env_batch             import EnvBatch
+from CIME.XML.env_workflow          import EnvWorkflow
 from CIME.XML.generic_xml           import GenericXML
 from CIME.user_mod_support          import apply_user_mods
 from CIME.aprun import get_aprun_cmd_for_case
@@ -204,6 +206,8 @@ class Case(object):
         self._env_entryid_files.append(EnvBuild(self._caseroot, components=components, read_only=self._force_read_only))
         self._env_entryid_files.append(EnvMachPes(self._caseroot, components=components, read_only=self._force_read_only))
         self._env_entryid_files.append(EnvBatch(self._caseroot, read_only=self._force_read_only))
+        self._env_entryid_files.append(EnvWorkflow(self._caseroot, read_only=self._force_read_only))
+
         if os.path.isfile(os.path.join(self._caseroot,"env_test.xml")):
             self._env_entryid_files.append(EnvTest(self._caseroot, components=components, read_only=self._force_read_only))
         self._env_generic_files = []
@@ -877,7 +881,8 @@ class Case(object):
                   multi_driver=False, ninst=1, test=False,
                   walltime=None, queue=None, output_root=None,
                   run_unsupported=False, answer=None,
-                  input_dir=None, driver=None, non_local=False):
+                  input_dir=None, driver=None, workflow_case="default",
+                  non_local=False):
 
         expect(check_name(compset_name, additional_chars='.'), "Invalid compset name {}".format(compset_name))
 
@@ -1062,11 +1067,13 @@ class Case(object):
 
         batch_system_type = machobj.get_value("BATCH_SYSTEM")
         logger.info("Batch_system_type is {}".format(batch_system_type))
-        batch = Batch(batch_system=batch_system_type, machine=machine_name)
-        bjobs = batch.get_batch_jobs()
+        batch = Batch(batch_system=batch_system_type, machine=machine_name, files=files)
+        workflow = Workflow(files=files)
+        bjobs = workflow.get_workflow_jobs(machine=machine_name, workflow_case=workflow_case)
+        env_workflow = self.get_env("workflow")
 
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
-        env_batch.create_job_groups(bjobs, test)
+        env_workflow.create_job_groups(bjobs, test)
 
         if walltime:
             self.set_value("USER_REQUESTED_WALLTIME", walltime, subgroup=self.get_primary_job())
@@ -1141,7 +1148,6 @@ class Case(object):
         except Exception as e:
             logger.warning("FAILED to set up exefiles: {}".format(str(e)))
 
-        # set up utility files in caseroot/Tools/
         toolfiles = [os.path.join(toolsdir, "check_lockedfiles"),
                      os.path.join(toolsdir, "get_standard_makefile_args"),
                      os.path.join(toolsdir, "getTiming"),
@@ -1364,7 +1370,7 @@ directory, NOT in this subdirectory."""
             if not success:
                 logger.warning("Failed to kill {}".format(jobid))
 
-    def get_mpirun_cmd(self, job=None, allow_unresolved_envvars=True):
+    def get_mpirun_cmd(self, job=None, allow_unresolved_envvars=True, overrides=None):
         if job is None:
             job = self.get_primary_job()
 
@@ -1394,11 +1400,11 @@ directory, NOT in this subdirectory."""
             logger.info('Using a custom run_misc_suffix {}'.format(custom_run_misc_suffix))
             run_misc_suffix = custom_run_misc_suffix
 
-
         # special case for aprun
         if executable is not None and "aprun" in executable and not "theta" in self.get_value("MACH"):
-            aprun_args, num_nodes = get_aprun_cmd_for_case(self, run_exe)[0:2]
-            expect( (num_nodes + self.spare_nodes) == self.num_nodes, "Not using optimized num nodes")
+            aprun_args, num_nodes = get_aprun_cmd_for_case(self, run_exe, overrides=overrides)[0:2]
+            if job in ("case.run","case.test"):
+                expect( (num_nodes + self.spare_nodes) == self.num_nodes, "Not using optimized num nodes")
             return self.get_resolved_value(executable + aprun_args + " " + run_misc_suffix, allow_unresolved_envvars=allow_unresolved_envvars)
 
         else:
@@ -1459,10 +1465,9 @@ directory, NOT in this subdirectory."""
             #   called if run_unsupported is False.
             tests = Testlist(tests_spec_file, files)
             testlist = tests.get_tests(compset=compset_alias, grid=grid_name, supported_only=True)
+            test_categories = ["prealpha", "prebeta", "test_release", "aux_"]
             for test in testlist:
-                if test["category"] == "prealpha" \
-                   or test["category"] == "prebeta" \
-                   or "aux_" in test["category"] \
+                if test["category"] in test_categories \
                    or get_cime_default_driver() in test["category"]:
                     testcnt += 1
         if testcnt > 0:
@@ -1501,6 +1506,8 @@ directory, NOT in this subdirectory."""
                     new_env_file = EnvMachPes(infile=xmlfile, components=components)
                 elif ftype == "env_batch.xml":
                     new_env_file = EnvBatch(infile=xmlfile)
+                elif ftype == "env_workflow.xml":
+                    new_env_file = EnvWorkflow(infile=xmlfile)
                 elif ftype == "env_test.xml":
                     new_env_file = EnvTest(infile=xmlfile)
                 elif ftype == "env_archive.xml":
@@ -1563,7 +1570,7 @@ directory, NOT in this subdirectory."""
                multi_driver=False, ninst=1, test=False,
                walltime=None, queue=None, output_root=None,
                run_unsupported=False, answer=None,
-               input_dir=None, driver=None, non_local=False):
+               input_dir=None, driver=None, workflow_case="default", non_local=False):
         try:
             # Set values for env_case.xml
             self.set_lookup_value("CASE", os.path.basename(casename))
@@ -1579,7 +1586,8 @@ directory, NOT in this subdirectory."""
                            walltime=walltime, queue=queue,
                            output_root=output_root,
                            run_unsupported=run_unsupported, answer=answer,
-                           input_dir=input_dir, driver=driver, non_local=non_local)
+                           input_dir=input_dir, driver=driver,
+                           workflow_case=workflow_case, non_local=non_local)
 
             self.create_caseroot()
 

--- a/cime/scripts/lib/CIME/case/case_clone.py
+++ b/cime/scripts/lib/CIME/case/case_clone.py
@@ -4,9 +4,9 @@ create_clone is a member of the Case class from file case.py
 import os, glob, shutil
 from CIME.XML.standard_module_setup import *
 from CIME.utils import expect, check_name, safe_copy
-from CIME.user_mod_support import apply_user_mods
-from CIME.locked_files         import lock_file
 from CIME.simple_compare            import compare_files
+from CIME.locked_files         import lock_file
+from CIME.user_mod_support import apply_user_mods
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +122,14 @@ def create_clone(self, newcaseroot, keepexe=False, mach_dir=None, project=None,
             shutil.copytree(os.path.join(cloneroot, casesub),
                             os.path.join(newcaseroot, casesub),
                             symlinks=True)
+
+        # copy the postprocessing directory if it exists
+        if os.path.isdir(os.path.join(cloneroot, "postprocess")):
+            shutil.copytree(os.path.join(cloneroot, "postprocess"),
+                            os.path.join(newcaseroot, "postprocess"),
+                            symlinks=True)
+
+
 
         # lock env_case.xml in new case
         lock_file("env_case.xml", newcaseroot)

--- a/cime/scripts/lib/CIME/case/case_setup.py
+++ b/cime/scripts/lib/CIME/case/case_setup.py
@@ -116,9 +116,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 
         # Set tasks to 1 if mpi-serial library
         if mpilib == "mpi-serial":
-            for vid, value in case:
-                if vid.startswith("NTASKS") and value != 1:
-                    case.set_value(vid, 1)
+            case.set_value("NTASKS", 1)
 
         # Check ninst.
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.

--- a/cime/scripts/lib/CIME/case/case_st_archive.py
+++ b/cime/scripts/lib/CIME/case/case_st_archive.py
@@ -223,6 +223,36 @@ def _archive_history_files(archive, archive_entry,
     if compname == 'clm':
         compname = r'clm2?'
 
+    if compname == 'nemo':
+        archive_rblddir = os.path.join(dout_s_root, compclass, 'rebuild')
+        if not os.path.exists(archive_rblddir):
+            os.makedirs(archive_rblddir)
+            logger.debug("created directory {}".format(archive_rblddir))
+
+        sfxrbld = r'mesh_mask_' + r'[0-9]*'
+        pfile = re.compile(sfxrbld)
+        rbldfiles = [f for f in os.listdir(rundir) if pfile.search(f)]
+        logger.debug("rbldfiles = {} ".format(rbldfiles))
+
+        if rbldfiles:
+            for rbldfile in rbldfiles:
+                srcfile = join(rundir, rbldfile)
+                destfile = join(archive_rblddir, rbldfile)
+                logger.info("moving {} to {} ".format(srcfile, destfile))
+                archive_file_fn(srcfile, destfile)
+
+        sfxhst = casename + r'_[0-9][mdy]_' + r'[0-9]*'
+        pfile = re.compile(sfxhst)
+        hstfiles = [f for f in os.listdir(rundir) if pfile.search(f)]
+        logger.debug("hstfiles = {} ".format(hstfiles))
+
+        if hstfiles:
+            for hstfile in hstfiles:
+                srcfile = join(rundir, hstfile)
+                destfile = join(archive_histdir, hstfile)
+                logger.info("moving {} to {} ".format(srcfile, destfile))
+                archive_file_fn(srcfile, destfile)
+
     # determine ninst and ninst_string
 
     # archive history files - the only history files that kept in the
@@ -314,6 +344,9 @@ def _archive_restarts_date(case, casename, rundir, archive,
     """
     logger.info('-------------------------------------------')
     logger.info('Archiving restarts for date {}'.format(datename))
+    logger.debug('last date {}'.format(last_date))
+    logger.debug('date is last? {}'.format(datename_is_last))
+    logger.debug('components are {}'.format(components))
     logger.info('-------------------------------------------')
     logger.debug("last date: {}".format(last_date))
 
@@ -391,6 +424,10 @@ def _archive_restarts_date_comp(case, casename, rundir, archive, archive_entry,
             pattern = compname + r'\.' + suffix + r'\.' + '_'.join(datename_str.rsplit('-', 1))
             pfile = re.compile(pattern)
             restfiles = [f for f in os.listdir(rundir) if pfile.search(f)]
+        elif compname == 'nemo':
+            pattern = r'_*_' + suffix + r'[0-9]*'
+            pfile = re.compile(pattern)
+            restfiles = [f for f in os.listdir(rundir) if pfile.search(f)]
         else:
             pattern = r"^{}\.{}[\d_]*\.".format(casename, compname)
             pfile = re.compile(pattern)
@@ -399,10 +436,10 @@ def _archive_restarts_date_comp(case, casename, rundir, archive, archive_entry,
             pfile = re.compile(pattern)
             restfiles = [f for f in files if pfile.search(f)]
             logger.debug("pattern is {} restfiles {}".format(pattern, restfiles))
-        for restfile in restfiles:
-            restfile = os.path.basename(restfile)
+        for rfile in restfiles:
+            rfile = os.path.basename(rfile)
 
-            file_date = get_file_date(restfile)
+            file_date = get_file_date(rfile)
             if last_date is not None and file_date > last_date:
                 # Skip this file
                 continue
@@ -413,7 +450,7 @@ def _archive_restarts_date_comp(case, casename, rundir, archive, archive_entry,
             # obtain array of history files for restarts
             # need to do this before archiving restart files
             histfiles_for_restart = get_histfiles_for_restarts(rundir, archive,
-                                                               archive_entry, restfile,
+                                                               archive_entry, rfile,
                                                                testonly=testonly)
 
             if datename_is_last and histfiles_for_restart:
@@ -424,8 +461,8 @@ def _archive_restarts_date_comp(case, casename, rundir, archive, archive_entry,
             # archive restart files and all history files that are needed for restart
             # Note that the latest file should be copied and not moved
             if datename_is_last:
-                srcfile = os.path.join(rundir, restfile)
-                destfile = os.path.join(archive_restdir, restfile)
+                srcfile = os.path.join(rundir, rfile)
+                destfile = os.path.join(archive_restdir, rfile)
                 last_restart_file_fn(srcfile, destfile)
                 logger.info("{} file {} to {}".format(last_restart_file_fn_msg, srcfile, destfile))
                 for histfile in histfiles_for_restart:
@@ -439,8 +476,8 @@ def _archive_restarts_date_comp(case, casename, rundir, archive, archive_entry,
             else:
                 # Only archive intermediate restarts if requested - otherwise remove them
                 if case.get_value('DOUT_S_SAVE_INTERIM_RESTART_FILES'):
-                    srcfile = os.path.join(rundir, restfile)
-                    destfile = os.path.join(archive_restdir, restfile)
+                    srcfile = os.path.join(rundir, rfile)
+                    destfile = os.path.join(archive_restdir, rfile)
                     expect(os.path.isfile(srcfile),
                            "restart file {} does not exist ".format(srcfile))
                     archive_file_fn(srcfile, destfile)
@@ -456,15 +493,93 @@ def _archive_restarts_date_comp(case, casename, rundir, archive, archive_entry,
                         logger.info("copying {} to {}".format(srcfile, destfile))
                         safe_copy(srcfile, destfile)
                 else:
-                    srcfile = os.path.join(rundir, restfile)
-                    logger.info("removing interim restart file {}".format(srcfile))
-                    if (os.path.isfile(srcfile)):
-                        try:
-                            os.remove(srcfile)
-                        except OSError:
-                            logger.warning("unable to remove interim restart file {}".format(srcfile))
+                    if compname == 'nemo':
+                        flist = glob.glob(rundir + "/" + casename + "_*_restart*.nc")
+                        logger.debug("nemo restart file {}".format(flist))
+                        if len(flist) > 2:
+                            flist0 = glob.glob(rundir + "/" + casename + "_*_restart_0000.nc")
+                            if len(flist0) > 1:
+                                rstfl01 = flist0[0]
+                                rstfl01spl = rstfl01.split("/")
+                                logger.debug("splitted name {}".format(rstfl01spl))
+                                rstfl01nm = rstfl01spl[-1]
+                                rstfl01nmspl = rstfl01nm.split("_")
+                                logger.debug("splitted name step2 {}".format(rstfl01nmspl))
+                                rsttm01 = rstfl01nmspl[-3]
+
+                                rstfl02 = flist0[1]
+                                rstfl02spl = rstfl02.split("/")
+                                logger.debug("splitted name {}".format(rstfl02spl))
+                                rstfl02nm = rstfl02spl[-1]
+                                rstfl02nmspl = rstfl02nm.split("_")
+                                logger.debug("splitted name step2 {}".format(rstfl02nmspl))
+                                rsttm02 = rstfl02nmspl[-3]
+
+                                if int(rsttm01) > int(rsttm02):
+                                    restlist = glob.glob(rundir + "/" + casename + "_" + rsttm02  + "_restart_*.nc")
+                                else:
+                                    restlist = glob.glob(rundir + "/" + casename + "_" + rsttm01  + "_restart_*.nc")
+                                logger.debug("nemo restart list {}".format(restlist))
+                                if restlist:
+                                    for _restfile in restlist:
+                                        srcfile = os.path.join(rundir, _restfile)
+                                        logger.info("removing interim restart file {}".format(srcfile))
+                                        if (os.path.isfile(srcfile)):
+                                            try:
+                                                os.remove(srcfile)
+                                            except OSError:
+                                                logger.warning("unable to remove interim restart file {}".format(srcfile))
+                                        else:
+                                            logger.warning("interim restart file {} does not exist".format(srcfile))
+                        elif len(flist) == 2:
+                            flist0 = glob.glob(rundir + "/" + casename + "_*_restart.nc")
+                            if len(flist0) > 1:
+                                rstfl01 = flist0[0]
+                                rstfl01spl = rstfl01.split("/")
+                                logger.debug("splitted name {}".format(rstfl01spl))
+                                rstfl01nm = rstfl01spl[-1]
+                                rstfl01nmspl = rstfl01nm.split("_")
+                                logger.debug("splitted name step2 {}".format(rstfl01nmspl))
+                                rsttm01 = rstfl01nmspl[-2]
+
+                                rstfl02 = flist0[1]
+                                rstfl02spl = rstfl02.split("/")
+                                logger.debug("splitted name {}".format(rstfl02spl))
+                                rstfl02nm = rstfl02spl[-1]
+                                rstfl02nmspl = rstfl02nm.split("_")
+                                logger.debug("splitted name step2 {}".format(rstfl02nmspl))
+                                rsttm02 = rstfl02nmspl[-2]
+
+                                if int(rsttm01) > int(rsttm02):
+                                    restlist = glob.glob(rundir + "/" + casename + "_" + rsttm02  + "_restart_*.nc")
+                                else:
+                                    restlist = glob.glob(rundir + "/" + casename + "_" + rsttm01  + "_restart_*.nc")
+                                logger.debug("nemo restart list {}".format(restlist))
+                                if restlist:
+                                    for _rfile in restlist:
+                                        srcfile = os.path.join(rundir, _rfile)
+                                        logger.info("removing interim restart file {}".format(srcfile))
+                                        if (os.path.isfile(srcfile)):
+                                            try:
+                                                os.remove(srcfile)
+                                            except OSError:
+                                                logger.warning("unable to remove interim restart file {}".format(srcfile))
+                                        else:
+                                            logger.warning("interim restart file {} does not exist".format(srcfile))
+                        else:
+                            logger.warning("unable to find NEMO restart file in {}".format(rundir))
+
+
                     else:
-                        logger.warning("interim restart file {} does not exist".format(srcfile))
+                        srcfile = os.path.join(rundir, rfile)
+                        logger.info("removing interim restart file {}".format(srcfile))
+                        if (os.path.isfile(srcfile)):
+                            try:
+                                os.remove(srcfile)
+                            except OSError:
+                                logger.warning("unable to remove interim restart file {}".format(srcfile))
+                        else:
+                            logger.warning("interim restart file {} does not exist".format(srcfile))
 
     return histfiles_savein_rundir
 
@@ -597,6 +712,7 @@ def case_st_archive(self, last_date_str=None, archive_incomplete_logs=True, copy
     """
     Create archive object and perform short term archiving
     """
+    logger.debug("resubmit {}".format(resubmit))
     caseroot = self.get_value("CASEROOT")
     self.load_env(job="case.st_archive")
     if last_date_str is not None:
@@ -631,18 +747,19 @@ def case_st_archive(self, last_date_str=None, archive_incomplete_logs=True, copy
     logger.info("st_archive completed")
 
     # resubmit case if appropriate
-    resubmit_cnt = self.get_value("RESUBMIT")
-    logger.debug("resubmit_cnt {} resubmit {}".format(resubmit_cnt, resubmit))
-    if resubmit_cnt > 0 and resubmit:
-        logger.info("resubmitting from st_archive, resubmit={:d}".format(resubmit_cnt))
-        if self.get_value("MACH") == "mira":
-            expect(os.path.isfile(".original_host"), "ERROR alcf host file not found")
-            with open(".original_host", "r") as fd:
-                sshhost = fd.read()
-            run_cmd("ssh cooleylogin1 ssh {} '{case}/case.submit {case} --resubmit' "\
+    if not self.get_value("EXTERNAL_WORKFLOW"):
+        resubmit_cnt = self.get_value("RESUBMIT")
+        logger.debug("resubmit_cnt {} resubmit {}".format(resubmit_cnt, resubmit))
+        if resubmit_cnt > 0 and resubmit:
+            logger.info("resubmitting from st_archive, resubmit={:d}".format(resubmit_cnt))
+            if self.get_value("MACH") == "mira":
+                expect(os.path.isfile(".original_host"), "ERROR alcf host file not found")
+                with open(".original_host", "r") as fd:
+                    sshhost = fd.read()
+                run_cmd("ssh cooleylogin1 ssh {} '{case}/case.submit {case} --resubmit' "\
                         .format(sshhost, case=caseroot), verbose=True)
-        else:
-            self.submit(resubmit=True)
+            else:
+                self.submit(resubmit=True)
 
     return True
 

--- a/cime/scripts/lib/CIME/case/case_submit.py
+++ b/cime/scripts/lib/CIME/case/case_submit.py
@@ -55,8 +55,8 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
     # if case.submit is called with the no_batch flag then we assume that this
     # flag will stay in effect for the duration of the RESUBMITs
     env_batch = case.get_env("batch")
-
-    if resubmit and env_batch.get_batch_system_type() == "none":
+    external_workflow = case.get_value("EXTERNAL_WORKFLOW")
+    if resubmit and env_batch.get_batch_system_type() == "none" or external_workflow:
         no_batch = True
     if no_batch:
         batch_system = "none"
@@ -66,12 +66,13 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
     case.set_value("BATCH_SYSTEM", batch_system)
 
     env_batch_has_changed = False
-    try:
-        case.check_lockedfile(os.path.basename(env_batch.filename))
-    except:
-        env_batch_has_changed = True
+    if not external_workflow:
+        try:
+            case.check_lockedfile(os.path.basename(env_batch.filename))
+        except:
+            env_batch_has_changed = True
 
-    if batch_system != "none" and env_batch_has_changed:
+    if batch_system != "none" and env_batch_has_changed and not external_workflow:
         # May need to regen batch files if user made batch setting changes (e.g. walltime, queue, etc)
         logger.warning(\
 """
@@ -214,7 +215,6 @@ def check_case(self):
     if self.get_value('COMP_WAV') == 'ww':
         # the ww3 buildnml has dependancies on inputdata so we must run it again
         self.create_namelists(component='WAV')
-
 
     expect(self.get_value("BUILD_COMPLETE"), "Build complete is "
            "not True please rebuild the model by calling case.build")

--- a/cime/scripts/lib/CIME/get_timing.py
+++ b/cime/scripts/lib/CIME/get_timing.py
@@ -450,15 +450,16 @@ class _TimingParser:
         self.write("\n")
 
         self.write("  Overall Metrics: \n")
-        self.write("    Model Cost:         {:10.2f}   pe-hrs/simulated_year ".format((tmax*365.0*pecost)/(3600.0*adays)))
-        if inst_label:
-            self.write("      (Model Cost is for entire ensemble)")
-        self.write("\n")
-        self.write("    Model Throughput:   {:10.2f}   simulated_years/day \n".format((86400.0*adays)/(tmax*365.0)) )
+        if adays > 0:
+            self.write("    Model Cost:         {:10.2f}   pe-hrs/simulated_year \n".format((tmax*365.0*pecost)/(3600.0*adays)))
+        if tmax > 0:
+            self.write("    Model Throughput:   {:10.2f}   simulated_years/day \n".format((86400.0*adays)/(tmax*365.0)) )
+
         self.write("\n")
 
         self.write("    Init Time   :  {:10.3f} seconds \n".format(nmax))
-        self.write("    Run Time    :  {:10.3f} seconds   {:10.3f} seconds/day \n".format(tmax, tmax/adays))
+        if adays > 0:
+            self.write("    Run Time    :  {:10.3f} seconds   {:10.3f} seconds/day \n".format(tmax, tmax/adays))
         self.write("    Final Time  :  {:10.3f} seconds \n".format(fmax))
 
         self.write("\n")
@@ -477,14 +478,13 @@ class _TimingParser:
                    "with other components \n")
         self.write("\n")
 
-        self.write("    TOT Run Time:  {:10.3f} seconds   {:10.3f} seconds/mday   {:10.2f} myears/wday \n".format(tmax, tmax/adays, tmaxr))
-        for k in self.case.get_values("COMP_CLASSES"):
-            m = self.models[k]
-            self.write("    {} Run Time:  {:10.3f} seconds   {:10.3f} seconds/mday   {:10.2f} myears/wday \n".format(k, m.tmax, m.tmax/adays, m.tmaxr))
-        self.write("    CPL COMM Time: {:10.3f} seconds   {:10.3f} seconds/mday   {:10.2f} myears/wday \n".format(xmax, xmax/adays, xmaxr))
-        if self._driver == "mct":
-            self.write("\n\n---------------- DRIVER TIMING FLOWCHART "
-                       "--------------------- \n\n")
+
+        if adays > 0:
+            self.write("    TOT Run Time:  {:10.3f} seconds   {:10.3f} seconds/mday   {:10.2f} myears/wday \n".format(tmax, tmax/adays, tmaxr))
+            for k in self.case.get_values("COMP_CLASSES"):
+                m = self.models[k]
+                self.write("    {} Run Time:  {:10.3f} seconds   {:10.3f} seconds/mday   {:10.2f} myears/wday \n".format(k, m.tmax, m.tmax/adays, m.tmaxr))
+                self.write("    CPL COMM Time: {:10.3f} seconds   {:10.3f} seconds/mday   {:10.2f} myears/wday \n".format(xmax, xmax/adays, xmaxr))
 
             pstrlen = 25
             hoffset = 1

--- a/cime/scripts/tests/scripts_regression_tests.py
+++ b/cime/scripts/tests/scripts_regression_tests.py
@@ -1097,6 +1097,11 @@ class TestCreateTestCommon(unittest.TestCase):
     ###########################################################################
     def _create_test(self, extra_args, test_id=None, pre_run_errors=False, run_errors=False, env_changes=""):
     ###########################################################################
+        # All stub model not supported in nuopc driver
+        driver = CIME.utils.get_cime_default_driver()
+        if driver == 'nuopc':
+            extra_args.append(" ^SMS.T42_T42.S")
+
         test_id = CIME.utils.get_timestamp() if test_id is None else test_id
         extra_args.append("-t {}".format(test_id))
         extra_args.append("--baseline-root {}".format(self._baseline_area))
@@ -1837,6 +1842,8 @@ class K_TestCimeCase(TestCreateTestCommon):
 
         run_cmd_assert_result(self, "{}/create_newcase {}".format(SCRIPT_DIR, args),
                               from_dir=SCRIPT_DIR)
+        run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
+
         return testdir
 
     ###########################################################################

--- a/cime/src/build_scripts/buildlib.csm_share
+++ b/cime/src/build_scripts/buildlib.csm_share
@@ -71,6 +71,8 @@ def buildlib(bldroot, installpath, case):
     else:
         use_esmf = "noesmf"
         filepath.append(os.path.join(cimeroot, "src", "share", "esmf_wrf_timemgr"))
+
+    comp_interface = case.get_value("COMP_INTERFACE")
     ninst_value = case.get_value("NINST_VALUE")
     libdir = os.path.join(bldroot,comp_interface,use_esmf, ninst_value,"csm_share")
     if not os.path.isdir(libdir):
@@ -98,6 +100,9 @@ def buildlib(bldroot, installpath, case):
         else:
             ninst_comp = case.get_value("NINST_{}".format(comp))
         multiinst_cppdefs += " -DNUM_COMP_INST_{}={}".format(comp, ninst_comp)
+
+    if case.get_value("COMP_OCN") == "nemo":
+        multiinst_cppdefs += " -DNEMO_IN_CCSM "
 
     installdir = os.path.join(installpath, comp_interface,
                               use_esmf, ninst_value)

--- a/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -352,7 +352,6 @@
       <value stream="presaero.SSP4-6.0" atm_grid="CLM_USRDAT">aerosoldep_SSP4-6.0_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
       <value stream="presaero.SSP5-3.4" atm_grid="CLM_USRDAT">aerosoldep_SSP5-3.4_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
       <value stream="presaero.SSP5-8.5" atm_grid="CLM_USRDAT">aerosoldep_SSP5-8.5_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
-
       <value stream="presaero.clim_1850" cime_model="e3sm">aerosoldep_monthly_1850_mean_1.9x2.5_c090421.nc</value>
       <value stream="presaero.clim_2000" cime_model="e3sm">aerosoldep_monthly_2000_mean_1.9x2.5_c090421.nc</value>
       <value stream="presaero.trans_1850-2000" cime_model="e3sm">aerosoldep_monthly_1849-2006_1.9x2.5_c090803.nc</value>
@@ -1732,6 +1731,7 @@
       <value stream="presaero.SSP5-3.4" atm_grid="CLM_USRDAT">aerosoldep_SSP5-3.4_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
       <value stream="presaero.SSP5-8.5" atm_grid="CLM_USRDAT">aerosoldep_SSP5-8.5_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
 
+      <value stream="presaero.SSP1-2.6">aerodep_clm_SSP126_b.e21.BSSP126cmip6.f09_g17.CMIP6-SSP1-2.6.001_2014-2101_monthly_0.9x1.25_c190523.nc</value>
       <value stream="presaero.SSP2-4.5">aerodep_clm_SSP245_b.e21.BWSSP245cmip6.f09_g17.CMIP6-SSP2-4.5-WACCM.001_2014-2101_monthly_0.9x1.25_c190401.nc</value>
       <value stream="presaero.SSP3-7.0">aerodep_clm_SSP370_b.e21.BWSSP370cmip6.f09_g17.CMIP6-SSP3-7.0-WACCM.001_2014-2101_monthly_0.9x1.25_c190402.nc</value>
       <value stream="presaero.SSP5-3.4">null</value>

--- a/cime/src/components/data_comps/dice/nuopc/dice_comp_mod.F90
+++ b/cime/src/components/data_comps/dice/nuopc/dice_comp_mod.F90
@@ -465,7 +465,7 @@ contains
     ! error check that mesh lats and lons correspond to those on the input domain file
     index_lon = mct_aVect_indexRA(SDICE%grid%data,'lon')
     do n = 1, lsize
-       if (abs( SDICE%grid%data%rattr(index_lon,n) - xc(n)) > 1.e-4) then
+       if (abs(mod(SDICE%grid%data%rattr(index_lon,n) - xc(n),360.0_R8)) > 1.e-4) then
           write(6,*)'ERROR: lon diff = ',abs(SDICE%grid%data%rattr(index_lon,n) -  xc(n)),' too large'
           call shr_sys_abort()
        end if

--- a/cime/src/components/data_comps/dlnd/nuopc/dlnd_comp_mod.F90
+++ b/cime/src/components/data_comps/dlnd/nuopc/dlnd_comp_mod.F90
@@ -134,15 +134,16 @@ contains
        end do
 
        ! The following puts all of the elevation class fields as an
-       ! undidstributed dimension in the export state field
+       ! undidstributed dimension in the export state field - index1 is bare land - and the total number of 
+       ! elevation classes not equal to bare land go from index2 -> glc_nec+1 
 
        call dshr_fld_add(med_fld="Sl_lfrin", fldlist_num=fldsFrLnd_num, fldlist=fldsFrLnd)
        call dshr_fld_add(med_fld='Sl_tsrf_elev', fldlist_num=fldsFrLnd_num, fldlist=fldsFrLnd, &
-            ungridded_lbound=1, ungridded_ubound=glc_nec)
+            ungridded_lbound=1, ungridded_ubound=glc_nec+1)
        call dshr_fld_add(med_fld='Sl_topo_elev', fldlist_num=fldsFrLnd_num, fldlist=fldsFrLnd, &
-            ungridded_lbound=1, ungridded_ubound=glc_nec)
+            ungridded_lbound=1, ungridded_ubound=glc_nec+1)
        call dshr_fld_add(med_fld='Flgl_qice_elev', fldlist_num=fldsFrLnd_num, fldlist=fldsFrLnd, &
-            ungridded_lbound=1, ungridded_ubound=glc_nec)
+            ungridded_lbound=1, ungridded_ubound=glc_nec+1)
 
     end if
 
@@ -534,19 +535,19 @@ contains
     call dshr_export(l2x%rattr(k,:), exportState, "Sl_lfrin", rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    do n = 1,glc_nec
+    do n = 0,glc_nec
        nec_str = glc_elevclass_as_string(n)
 
        k = mct_aVect_indexRA(l2x, "Sl_tsrf" // nec_str)
-       call dshr_export(l2x%rattr(k,:), exportState, "Sl_tsrf_elev", ungridded_index=n, rc=rc)
+       call dshr_export(l2x%rattr(k,:), exportState, "Sl_tsrf_elev", ungridded_index=n+1, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        k = mct_aVect_indexRA(l2x, "Sl_topo" // nec_str)
-       call dshr_export(l2x%rattr(k,:), exportState, "Sl_topo_elev", ungridded_index=n, rc=rc)
+       call dshr_export(l2x%rattr(k,:), exportState, "Sl_topo_elev", ungridded_index=n+1, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        k = mct_aVect_indexRA(l2x, "Flgl_qice" // nec_str)
-       call dshr_export(l2x%rattr(k,:), exportState, "Flgl_qice_elev", ungridded_index=n, rc=rc)
+       call dshr_export(l2x%rattr(k,:), exportState, "Flgl_qice_elev", ungridded_index=n+1, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end do
 

--- a/cime/src/drivers/mct/cime_config/config_component.xml
+++ b/cime/src/drivers/mct/cime_config/config_component.xml
@@ -1966,7 +1966,7 @@
 
   <entry id="EPS_OGRID">
     <type>real</type>
-    <default_value>1.0e-02</default_value>
+    <default_value>1.0e-01</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
     <desc>Error tolerance for differences in ocean/ice lon/lat in domain checking</desc>
@@ -2847,18 +2847,27 @@
     <desc>External script to be run after model completion</desc>
   </entry>
 
+ <entry id="EXTERNAL_WORKFLOW">
+   <type>logical</type>
+   <valid_values>TRUE,FALSE</valid_values>
+   <default_value>FALSE</default_value>
+   <group>external_tools</group>
+   <file>env_run.xml</file>
+   <desc>whether the case uses an external workflow driver </desc>
+ </entry>
+
  <!-- Job Submission stuff -->
  <entry id="USER_REQUESTED_QUEUE">
    <type>char</type>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>Store user override for queue</desc>
  </entry>
 
  <entry id="USER_REQUESTED_WALLTIME">
    <type>char</type>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>Store user override for walltime</desc>
  </entry>
 
@@ -2867,7 +2876,7 @@
    <valid_values></valid_values>
    <default_value></default_value>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>The machine queue in which to submit the job.  Default determined in config_machines.xml can be overwritten by testing</desc>
  </entry>
 
@@ -2876,7 +2885,7 @@
    <valid_values></valid_values>
    <default_value></default_value>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>The machine wallclock setting.  Default determined in config_machines.xml can be overwritten by testing</desc>
  </entry>
 
@@ -2885,7 +2894,7 @@
     <valid_values></valid_values>
     <default_value></default_value>
     <group>job_submission</group>
-    <file>env_batch.xml</file>
+    <file>env_workflow.xml</file>
     <desc>Override the batch submit command this job. Do not include executable or dependencies</desc>
   </entry>
 
@@ -2893,7 +2902,7 @@
    <type>char</type>
    <default_value></default_value>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>project for project-sensitive build and run paths, and job scripts</desc>
  </entry>
 
@@ -2901,7 +2910,7 @@
    <type>char</type>
    <default_value></default_value>
    <group>job_submission</group>
-   <file>env_batch.xml</file>
+   <file>env_workflow.xml</file>
    <desc>project to charge in scripts if different from PROJECT</desc>
  </entry>
 
@@ -2930,7 +2939,6 @@
    <file>env_build.xml</file>
    <desc>TRUE=>turn on CPP variable COMPARE_TO_NUOPC</desc>
  </entry>
-
 
  <help>
     =========================================

--- a/cime/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -300,6 +300,7 @@
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_XOCN">$ATM_NCPL</value>
       <value compset="_SOCN">$ATM_NCPL</value>
+      <value compset="_NEMO">24</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -381,8 +382,10 @@
     <default_value>FALSE</default_value>
     <values match="last">
       <value compset="DATM.+POP\d">TRUE</value>
+      <value compset="DATM.+MOM\d">TRUE</value>
       <value compset="DATM.+DOCN%IAF">TRUE</value>
       <value compset="DATM%CPLHIST.+POP\d">FALSE</value>
+      <value compset="DATM%CPLHIST.+MOM\d">FALSE</value>
     </values>
     <group>run_component_cpl</group>
     <file>env_run.xml</file>

--- a/cime/src/share/util/shr_file_mod.F90
+++ b/cime/src/share/util/shr_file_mod.F90
@@ -61,6 +61,9 @@ MODULE shr_file_mod
   public :: shr_file_setLogLevel  ! Reset the logging debug level
   public :: shr_file_getLogUnit   ! Get the log unit number
   public :: shr_file_getLogLevel  ! Get the logging debug level
+#if defined NEMO_IN_CCSM
+   public :: shr_file_maxUnit      ! Max unit number to give
+#endif
 
   ! !PUBLIC DATA MEMBERS:
 


### PR DESCRIPTION
Update CIME to ESMCI cime5.8.7

Squash merge of jgfouca/branch-for-to-acme-2019-07-29

Features:

* A new tool generate_cylc_workflow.py is added. This tool will create a cylc 7.8.3 compatible suite.rc file in the case directory. The user sets the parameters in the case for the span of a submitted run and the number of resubmits, sets up and builds the case and then generates the workflow file. The user can either set the RESUBMIT variable using xmlchange or use --cycles argument to generate_cylc_workflow.py to set the number of times the workflow is repeated.

* New workflow XML files, replaces some of the stuff that was in env_batch
* Several updates and fixes for MOM6 in cime xml files, drivers, and dice.
* Adds a --ensemble option to create_clone allowing the user to generate an ensemble of cases cloned from --clone

Bug Fixes:
* ftp protocol won't make 0-size files anymore

Other:
Driver namelist change:   from eps_ogrid = 0.01 to eps_ogrid = 0.1

[BFB]
[NML]