### PR TITLE
Update Livermore Computing machine file entries.

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1419,12 +1419,9 @@
       <modules compiler="intel">
         <command name="load">python</command>
         <command name="load">git</command>
-        <command name="load">intel/18.0.1</command>
-        <command name="unload">pnetcdf/1.9.0</command>
-        <command name="unload">mvapich2</command>
-        <command name="unload">cmake</command>
-        <command name="load">cmake/3.12.1</command>
-        <command name="load">mvapich2/2.2</command>
+        <command name="load">intel/19.0.4</command>
+        <command name="load">mvapich2/2.3</command>
+        <command name="load">cmake/3.14.5</command>
         <command name="load">netcdf-fortran/4.4.4</command>
         <command name="load">pnetcdf/1.9.0</command>
       </modules>
@@ -1474,12 +1471,9 @@
       <modules compiler="intel">
         <command name="load">python</command>
         <command name="load">git</command>
-        <command name="load">intel/18.0.1</command>
-        <command name="unload">pnetcdf/1.9.0</command>
-        <command name="unload">mvapich2</command>
-        <command name="unload">cmake</command>
-        <command name="load">cmake/3.12.1</command>
-        <command name="load">mvapich2/2.2</command>
+        <command name="load">intel/19.0.4</command>
+        <command name="load">mvapich2/2.3</command>
+        <command name="load">cmake/3.14.5</command>
         <command name="load">netcdf-fortran/4.4.4</command>
         <command name="load">pnetcdf/1.9.0</command>
       </modules>


### PR DESCRIPTION
This commit updates the machines file entries for the LC
machines syrah and quartz, to reflect recent updates to
those machines modules.

[BFB] - Bit-For-Bit

See confluence for a more detailed description about these tags.