### PR TITLE
Update maint-1.0 module versions for Cori after July/19 maint upgrade 

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -236,6 +236,7 @@
       <arg name="num_tasks" > -n $TOTALPES</arg>
       <arg name="thread_count">-c $SHELL{echo 64/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
       <arg name="binding"> $SHELL{if [ 32 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
+      <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
     </arguments>
   </mpirun>
   <module_system type="module">
@@ -256,7 +257,7 @@
       <command name="rm">cce</command>
       <command name="rm">gcc</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="rm">cray-parallel-hdf5</command>
+      <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">pmi</command>
       <command name="rm">cray-libsci</command>
       <command name="rm">cray-mpich2</command>
@@ -281,32 +282,28 @@
       <command name="load">craype-haswell</command>
     </modules>
 
-    <modules>
-      <command name="rm">craype</command>
-      <command name="load">craype/2.5.14</command>
-      <command name="load">pmi/5.0.13</command>
-
-      <command name="rm">cray-mpich</command>
-      <command name="load">pe_archive/append-path</command>
-      <command name="load">cray-mpich/7.6.2</command>
+    <modules mpilib="mpt">
+      <command name="swap">cray-mpich cray-mpich/7.7.6</command>
     </modules>
 
     <modules compiler="intel">
-      <command name="load">PrgEnv-intel/6.0.4</command>
+      <command name="load">PrgEnv-intel/6.0.5</command>
       <command name="rm">intel</command>
-      <command name="load">intel/18.0.1.163</command>
+      <command name="load">intel/19.0.3.199</command>
     </modules>
 
     <modules compiler="gnu">
-      <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
+      <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
       <command name="rm">gcc</command>
-      <command name="load">pe_archive/append-path</command>
-      <command name="load">gcc/6.3.0</command>
+      <command name="load">gcc/8.2.0</command>
       <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/17.09.1</command>
+      <command name="load">cray-libsci/19.02.1</command>
     </modules>
 
     <modules>
+      <command name="swap">craype craype/2.5.18</command>
+      <command name="rm">pmi</command>
+      <command name="load">pmi/5.0.14</command>
       <command name="rm">craype-mic-knl</command>
       <command name="load">craype-haswell</command>
     </modules>
@@ -315,21 +312,21 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-netcdf/4.4.1.1.6</command>
-      <command name="load">cray-hdf5/1.10.1.1</command>
+      <command name="load">cray-netcdf/4.6.1.3</command>
+      <command name="load">cray-hdf5/1.10.2.0</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-      <command name="load">cray-hdf5-parallel/1.10.1.1</command>
-      <command name="load">cray-parallel-netcdf/1.8.1.3</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
+      <command name="load">cray-hdf5-parallel/1.10.2.0</command>
+      <command name="load">cray-parallel-netcdf/1.8.1.4</command>
     </modules>
 
     <modules>
       <command name="rm">git</command>
       <command name="load">git</command>
       <command name="rm">cmake</command>
-      <command name="load">cmake/3.3.2</command>
+      <command name="load">cmake/3.14.4</command>
     </modules>
   </module_system>
 
@@ -343,6 +340,8 @@
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
     <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+
+    <env name="PERL5LIB">/project/projectdirs/acme/perl5/lib/perl5/x86_64-linux-thread-multi</env>
   </environment_variables>
   <environment_variables compiler="intel">
     <env name="FORT_BUFFERED">yes</env>
@@ -354,7 +353,7 @@
   <DESC>Cori. XC40 Cray system at NERSC. KNL partition. os is CNL, 68 pes/node (for now only use 64), batch system is SLURM</DESC>
   <NODENAME_REGEX>cori</NODENAME_REGEX>
   <TESTS>e3sm_developer</TESTS>
-  <COMPILERS>intel,gnu,gnu7</COMPILERS>
+  <COMPILERS>intel,gnu</COMPILERS>
   <MPILIBS>mpt,impi</MPILIBS>
   <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/cori-knl</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -382,8 +381,9 @@
     <arguments>
       <arg name="label"> --label</arg>
       <arg name="num_tasks" > -n $TOTALPES</arg>
-      <arg name="thread_count">-c $SHELL{echo 272/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
+      <arg name="thread_count">-c $SHELL{mpn=`./xmlquery --value MAX_MPITASKS_PER_NODE`; if [ 68 -ge $mpn ]; then c0=`expr 272 / $mpn`; c1=`expr $c0 / 4`; cflag=`expr $c1 \* 4`; echo $cflag|bc ; else echo 272/$mpn|bc;fi;} </arg>
       <arg name="binding"> $SHELL{if [ 68 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
+      <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
     </arguments>
   </mpirun>
   <module_system type="module">
@@ -406,7 +406,7 @@
       <command name="rm">cce</command>
       <command name="rm">gcc</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="rm">cray-parallel-hdf5</command>
+      <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">pmi</command>
       <command name="rm">cray-mpich2</command>
       <command name="rm">cray-mpich</command>
@@ -429,42 +429,31 @@
     </modules>
 
     <modules mpilib="mpt">
-      <command name="load">pe_archive/append-path</command>
-      <command name="swap">cray-mpich cray-mpich/7.6.2</command>
+      <command name="swap">cray-mpich cray-mpich/7.7.6</command>
     </modules>
 
     <modules mpilib="impi">
-      <command name="swap">cray-mpich impi/2018.up1</command>
+      <command name="swap">cray-mpich impi/2019.up3</command>
     </modules>
 
     <modules compiler="intel">
-      <command name="load">PrgEnv-intel/6.0.4</command>
+      <command name="load">PrgEnv-intel/6.0.5</command>
       <command name="rm">intel</command>
       <command name="load">intel/18.0.1.163</command>
     </modules>
 
     <modules compiler="gnu">
-      <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.4</command>
+      <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
       <command name="rm">gcc</command>
-      <command name="load">pe_archive/append-path</command>
-      <command name="load">gcc/6.3.0</command>
+      <command name="load">gcc/8.2.0</command>
       <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/17.09.1</command>
-    </modules>
-
-    <modules compiler="gnu7">
-      <command name="rm">PrgEnv-intel</command>
-      <command name="load">PrgEnv-gnu/6.0.4</command>
-      <command name="rm">gcc</command>
-      <command name="load">gcc/7.2.0</command>
-      <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/17.12.1</command>
+      <command name="load">cray-libsci/19.02.1</command>
     </modules>
 
     <modules>
-      <command name="swap">craype craype/2.5.14</command>
+      <command name="swap">craype craype/2.5.18</command>
       <command name="rm">pmi</command>
-      <command name="load">pmi/5.0.13</command>
+      <command name="load">pmi/5.0.14</command>
       <command name="rm">craype-haswell</command>
       <command name="load">craype-mic-knl</command>
     </modules>
@@ -473,20 +462,20 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-netcdf/4.4.1.1.6</command>
-      <command name="load">cray-hdf5/1.10.1.1</command>
+      <command name="load">cray-netcdf/4.6.1.3</command>
+      <command name="load">cray-hdf5/1.10.2.0</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-      <command name="load">cray-hdf5-parallel/1.10.1.1</command>
-      <command name="load">cray-parallel-netcdf/1.8.1.3</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
+      <command name="load">cray-hdf5-parallel/1.10.2.0</command>
+      <command name="load">cray-parallel-netcdf/1.8.1.4</command>
     </modules>
     <modules>
       <command name="rm">git</command>
       <command name="load">git</command>
       <command name="rm">cmake</command>
-      <command name="load">cmake/3.3.2</command>
+      <command name="load">cmake/3.14.4</command>
     </modules>
 
     <!--command name="list">&gt;&amp; ml.txt</command-->
@@ -502,17 +491,12 @@
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
     <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+
+    <env name="PERL5LIB">/project/projectdirs/acme/perl5/lib/perl5/x86_64-linux-thread-multi</env>
   </environment_variables>
 
   <environment_variables mpilib="mpt">
     <env name="MPICH_GNI_DYNAMIC_CONN">disabled</env>
-  </environment_variables>
-  <environment_variables mpilib="impi">
-    <env name="I_MPI_FABRICS">ofi</env>
-    <env name="I_MPI_OFI_PROVIDER">gni</env>
-    <env name="I_MPI_PRINT_VERSION">yes</env>
-    <env name="I_MPI_OFI_LIBRARY">/global/common/cori/software/libfabric/1.6.1/gnu/lib/libfabric.so</env>
-    <env name="I_MPI_PMI_LIBRARY">/usr/lib64/slurmpmi/libpmi.so</env>
   </environment_variables>
   <environment_variables compiler="intel">
     <env name="FORT_BUFFERED">yes</env>


### PR DESCRIPTION
Compiler version is the same, but several others are now different.

cray-mpich/7.7.0 --> cray-mpich/7.7.6
PrgEnv-intel/6.0.4 --> PrgEnv-intel/6.0.5
craype/2.5.14 --> craype/2.5.18
pmi/5.0.13 --> pmi/5.0.14
cray-netcdf-hdf5parallel/4.4.1.1.6 --> cray-netcdf-hdf5parallel/4.6.1.3
cray-hdf5-parallel/1.10.1.1 --> cray-hdf5-parallel/1.10.2.0
cray-parallel-netcdf/1.8.1.3 --> cray-parallel-netcdf/1.8.1.4
cmake/3.11.4 --> cmake/3.14.4

PrgEnv-gnu/6.0.4 --> PrgEnv-gnu/6.0.5
gcc/7.3.0 --> gcc/8.2.0
cray-libsci/18.03.1 --> cray-libsci/19.02.1