### PR TITLE
Specify recursive doubling for MPI_Allreduce on Compy

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2077,6 +2077,9 @@
       <env name="MV2_ENABLE_AFFINITY">0</env>
       <env name="MV2_SHOW_CPU_BINDING">1</env>
     </environment_variables>
+    <environment_variables mpilib="impi">
+      <env name="I_MPI_ADJUST_ALLREDUCE">1</env>
+    </environment_variables>
     <environment_variables mpilib="impi" DEBUG="TRUE">
       <env name="I_MPI_DEBUG">10</env>
     </environment_variables>


### PR DESCRIPTION
The default algorithm used for MPI_Allreduce with available
versions of the Intel MPI library is failing for some process
counts and problem sizes. This default appears to be a hybrid
algorithm that uses Rabenseifners's algorithm when the number
of processes becomes large, and standalone experiments indicate
that the implementation of Rabenseifner's algorithm is at fault
here. A workaround while Intel addresses this error is to
specify a different algorithm using an environment variable
set in env_mach_specific.xml for Compy when using the Intel
MPI library.

This addresses issue #3082 , but only for master, and the issue
references maint-1.0, so should not be closed yet.

Master may not be seeing problems from this issue, because
the corruption of the input vector is in a stack array, and does
no permanant damage. The bad algorithm implementation
(Rabenseifner's) also is used only for a combination of long vectors
and large process counts, and the dof_mod.F90 routine may be
the only case where MPI_Allreduce is called in this situation.

Changing the MPI_Allreduce algorithm is often a cause for 
non-BFB, but MPI_Allreduce is not guaranteed to be BFB
for floating point summation with respect to changes in
process count in general. As such, we use shr_reprosum_mod.F90 where
non-BFB behavior would otherwise occur. So, I am assuming
that this is

BFB

i.e., that MPI_Allreduce with MPI_SUM is used only for integer
vectors, in which case changing the algorithm does not change
the numerics.

