### PR TITLE
Fix transpiration flux boundary condition to FATES

### DIFF
--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -1197,7 +1197,7 @@ contains
 
       if ( use_fates ) then
          call alm_fates%wrap_accumulatefluxes(bounds,fn,filterp(1:fn))
-         call alm_fates%wrap_hydraulics_drive(bounds,soilstate_vars, &
+         call alm_fates%wrap_hydraulics_drive(bounds,fn,filterp(1:fn),soilstate_vars, &
                waterstate_vars,waterflux_vars,solarabs_vars,energyflux_vars)
 
       else

--- a/components/clm/src/main/clmfates_interfaceMod.F90
+++ b/components/clm/src/main/clmfates_interfaceMod.F90
@@ -1448,6 +1448,11 @@ contains
      do s = 1, this%fates(nc)%nsites
         ! filter flag == 1 means that this patch has not been called for photosynthesis
         this%fates(nc)%bc_in(s)%filter_photo_pa(:) = 1
+
+        ! set transpiration input boundary condition to zero. The exposed
+        ! vegetation filter may not even call every patch.
+        this%fates(nc)%bc_in(s)%qflx_transp_pa(:) = 0._r8
+        
      end do
   end subroutine prep_canopyfluxes
 
@@ -2379,6 +2384,7 @@ contains
  ! ======================================================================================
 
  subroutine wrap_hydraulics_drive(this, bounds_clump, &
+                                 fn, filterp, &
                                  soilstate_inst, waterstate_inst, waterflux_inst, &
                                  solarabs_inst, energyflux_inst)
 
@@ -2386,6 +2392,8 @@ contains
    implicit none
    class(hlm_fates_interface_type), intent(inout) :: this
    type(bounds_type),intent(in)                   :: bounds_clump
+   integer, intent(in)                            :: fn
+   integer, intent(in)                            :: filterp(fn)
    type(soilstate_type)    , intent(inout)        :: soilstate_inst
    type(waterstate_type)   , intent(inout)        :: waterstate_inst
    type(waterflux_type)    , intent(inout)        :: waterflux_inst
@@ -2396,6 +2404,7 @@ contains
    integer :: s
    integer :: c 
    integer :: j
+   integer :: f    ! filter loop index
    integer :: ifp
    integer :: p
    integer :: nc
@@ -2434,9 +2443,21 @@ contains
          p = ifp+col_pp%pfti(c)
          this%fates(nc)%bc_in(s)%swrad_net_pa(ifp) = solarabs_inst%fsa_patch(p)
          this%fates(nc)%bc_in(s)%lwrad_net_pa(ifp) = energyflux_inst%eflx_lwrad_net_patch(p)
-         this%fates(nc)%bc_in(s)%qflx_transp_pa(ifp) = veg_wf%qflx_tran_veg(p)
       end do
    end do
+
+   ! The exposed vegetation filter "filterp" dictates which patches
+   ! had their transpiration updated during canopy_fluxes(). Patches
+   ! not in the filter had been zero'd during prep_canopyfluxes().
+   
+   do f = 1,fn
+      p = filterp(f)
+      c = veg_pp%column(p)
+      s = this%f2hmap(nc)%hsites(c)
+      ifp = p - col_pp%pfti(c)
+      this%fates(nc)%bc_in(s)%qflx_transp_pa(ifp) = waterflux_inst%qflx_tran_veg_patch(p)
+   end do
+
 
    ! Call Fates Hydraulics
    ! ------------------------------------------------------------------------------------


### PR DESCRIPTION
Uninitialized transpiration rates were being passed to FATES because some patches 
were not in the exposed vegetation loop. This has caused some problems within FATES, 
even if those patches had no vegetation.

[BFB]