### PR TITLE
Replaces CLUBB with new version of CLUBB (V2): For re-merging

### DIFF
--- a/components/cam/src/physics/cam/clubb_intr.F90
+++ b/components/cam/src/physics/cam/clubb_intr.F90
@@ -577,7 +577,9 @@ end subroutine clubb_init_cnst
 
 
     !----- Begin Code -----
+    !$OMP PARALLEL
     l_do_expldiff_rtm_thlm = do_expldiff
+    !$OMP END PARALLEL
     
     allocate( &
        pdf_params_chnk(pcols,begchunk:endchunk),   &


### PR DESCRIPTION
NOTE: This PR is created to re-merge changes in PR #2897

The v1 version of CLUBB left pockets of supersaturation for the microphysics. To mitigate this, the
v2 version of CLUBB does CLUBB's saturation adjustment immediately before microphysics when
ipdf_call_placement = ipdf_pre_advance_fields.

CLUBB_v2 includes performance optimizations that may lead to speedups, but also may be vitiated
by a performance degradation in the CLUBB interface that was introduced in order to change the
position of the saturation adjustment.

CLUBB_v2 also adds new options that may be interest when tuning E3SMv2:

CLUBB's gustiness can be enhanced if C_wp2_splat is set to non-zero values. This may enhance the benefits found with Po-Lun Ma connection of CLUBB's gustiness and surface processes.

CLUBB_v2 can now prognose momentum fluxes if l_predict_upwp_vpwp = .true. This is designed to reduce ocean surface stress in cumulus regions.

[NBFB]