### PR TITLE
Summit machine file: Update MPI module

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -3016,13 +3016,13 @@
       <!-- mpi lib settings -->
       <!-- Sometimes,same versions of libraries are not available for different compilers, hence the split below -->
       <modules compiler="ibm" mpilib="!mpi-serial">
-	    <command name="load">spectrum-mpi/10.3.0.0-20190419</command>
+	    <command name="load">spectrum-mpi/10.3.0.1-20190611</command>
       </modules>
       <modules compiler="pgi.*" mpilib="!mpi-serial">
-	    <command name="load">spectrum-mpi/10.3.0.0-20190419</command>
+	    <command name="load">spectrum-mpi/10.3.0.1-20190611</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial">
-	    <command name="load">spectrum-mpi/10.3.0.0-20190419</command>
+	    <command name="load">spectrum-mpi/10.3.0.1-20190611</command>
       </modules>
 
       <modules>


### PR DESCRIPTION
Default MPI module has been updated on Summit. Old module is still
available but hidden in listing.

A SIGSEGV error was encountered using older module with F-case. This
module update fixes that issue.

Fixes #3114

[BFB]