### PR TITLE
Update CIME to ESMCI cime5.8.7-2

### DIFF
--- a/cime/config/cesm/config_grids.xml
+++ b/cime/config/cesm/config_grids.xml
@@ -926,11 +926,11 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16pg3_ne16pg3_mg37" not_compset="_POP|_CLM">
+    <model_grid alias="ne16pg3_ne16pg3_mg17" not_compset="_POP|_CLM">
       <grid name="atm">ne16np4.pg3</grid>
       <grid name="lnd">ne16np4.pg3</grid>
       <grid name="ocnice">ne16np4.pg3</grid>
-      <mask>gx3v7</mask>
+      <mask>gx1v7</mask>
     </model_grid>
 
     <model_grid alias="ne30pg3_ne30pg3_mg17" not_compset="_POP">

--- a/cime/scripts/lib/CIME/XML/compilers.py
+++ b/cime/scripts/lib/CIME/XML/compilers.py
@@ -24,16 +24,16 @@ class Compilers(GenericXML):
             if files is None:
                 files = Files()
             infile = files.get_value("COMPILERS_SPEC_FILE")
-            schema = files.get_schema("COMPILERS_SPEC_FILE")
+        schema = files.get_schema("COMPILERS_SPEC_FILE")
 
         GenericXML.__init__(self, infile, schema)
-        self._machobj = machobj
         if version is not None:
             # this is used in scripts_regression_tests to force version 2, it should not be used otherwise
             self._version = version
         else:
             self._version = self.get_version()
 
+        self._machobj = machobj
         self.machine  = machobj.get_machine_name()
         self.os = machobj.get_value("OS")
         if compiler is None:
@@ -52,7 +52,7 @@ class Compilers(GenericXML):
         #This could cause problems if node matchs are repeated when only one is expected
         infile = os.path.join(os.environ.get("HOME"),".cime","config_compilers.xml")
         if os.path.exists(infile):
-            GenericXML.read(self, infile)
+            GenericXML.read(self, infile, schema=schema)
 
         if self.compiler is not None:
             self.set_compiler(compiler)

--- a/cime/scripts/lib/CIME/case/case.py
+++ b/cime/scripts/lib/CIME/case/case.py
@@ -1021,6 +1021,7 @@ class Case(object):
         # we don't want to resolve variables until we need them
         if output_root is None:
             output_root = self.get_value("CIME_OUTPUT_ROOT")
+        output_root = os.path.abspath(output_root)
         self.set_value("CIME_OUTPUT_ROOT", output_root)
         if non_local:
             self.set_value("EXEROOT", os.path.join(output_root, self.get_value("CASE"), "bld"))

--- a/cime/scripts/lib/CIME/get_timing.py
+++ b/cime/scripts/lib/CIME/get_timing.py
@@ -484,7 +484,7 @@ class _TimingParser:
             for k in self.case.get_values("COMP_CLASSES"):
                 m = self.models[k]
                 self.write("    {} Run Time:  {:10.3f} seconds   {:10.3f} seconds/mday   {:10.2f} myears/wday \n".format(k, m.tmax, m.tmax/adays, m.tmaxr))
-                self.write("    CPL COMM Time: {:10.3f} seconds   {:10.3f} seconds/mday   {:10.2f} myears/wday \n".format(xmax, xmax/adays, xmaxr))
+            self.write("    CPL COMM Time: {:10.3f} seconds   {:10.3f} seconds/mday   {:10.2f} myears/wday \n".format(xmax, xmax/adays, xmaxr))
 
             pstrlen = 25
             hoffset = 1

--- a/cime/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -226,10 +226,13 @@
       <value compset="_DATM%COPYALL_NPS">72</value>
       <value compset="_DATM.*_CLM">48</value>
       <value compset="_DATM.*_DICE.*_POP2">4</value>
+      <value compset="_DATM.*_DICE.*_MOM6">24</value>
       <value compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
+      <value compset="_DATM.*_SLND.*_CICE.*_MOM6">24</value>
       <value compset="_DATM.*_CICE.*_DOCN">24</value>
       <value compset="_DATM.*_DOCN%US20">24</value>
       <value compset="_DATM%CPLHIST.+POP\d">48</value>
+      <value compset="_DATM%CPLHIST.+MOM\d">48</value>
       <value compset="_MPAS">1</value>
       <value compset=".+" grid="a%0.23x0.31">96</value>
       <value compset=".+" grid="a%ne60np4">96</value>
@@ -252,7 +255,9 @@
       <value compset=".+" grid="1x1_vancou">24</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DATM.*_DICE.*_POP2.*_WW3">4</value>
+      <value compset="_DATM.*_DICE.*_MOM6.*_WW3">4</value>
       <value compset="_DATM.*_DICE.*_POP2.*_DWAV">4</value>
+      <value compset="_DATM.*_DICE.*_MOM6.*_DWAV">4</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -292,6 +297,7 @@
     <default_value>$ATM_NCPL</default_value>
     <values match="last">
       <value compset="_POP2">1</value>
+      <value compset="_MOM6">24</value>
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
       <value compset="_POP2" grid="oi%gx1v6">24</value>
       <value compset="_POP2" grid="oi%gx1v7">24</value>
@@ -316,6 +322,7 @@
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_SGLC">$ATM_NCPL</value>
       <value compset="_XGLC">$ATM_NCPL</value>
+      <value compset="_MOM6">1</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -348,9 +355,11 @@
     <default_value>8</default_value>
     <values match="last">
       <value compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
+      <value compset="_DATM.*_MOM6.*_DROF">$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
       <value compset="_DATM.*_SLND.*_DICE.*_DOCN">$ATM_NCPL</value>
       <value compset="_DATM%CPLHIST.+POP\d">8</value>
+      <value compset="_DATM%CPLHIST.+MOM\d">8</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_SROF">$ATM_NCPL</value>
@@ -433,6 +442,7 @@
     <values match="last">
       <value compset="_DATM.*_DOCN%SOM"			>CESM1_MOD</value>
       <value compset="_POP2"				>CESM1_MOD</value>
+      <value compset="_MOM6"				>RASM_OPTION1</value>
       <value compset="_POP2" grid="oi%gx1v6"		>RASM_OPTION1</value>
       <value compset="_POP2" grid="oi%gx1v7"		>RASM_OPTION1</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN"	>CESM1_MOD</value>

--- a/cime/src/externals/pio2/.travis.yml
+++ b/cime/src/externals/pio2/.travis.yml
@@ -40,15 +40,14 @@ env:
     - LDFLAGS='-L/usr/lib'
   
 script:
-  - ls -l /usr/include
   - autoreconf -i
-  - export CFLAGS='-std=c99  -fsanitize=address -fno-omit-frame-pointer'
+  - export CFLAGS='-std=c99  -fsanitize=address -fno-omit-frame-pointer -Werror'
   - export FFLAGS='-fsanitize=address -fno-omit-frame-pointer'
-  - export FCFLAGS='-fsanitize=address -fno-omit-frame-pointer'
+  - export FCFLAGS='-fsanitize=address -fno-omit-frame-pointer -Werror'
   - export DISTCHECK_CONFIGURE_FLAGS='--enable-fortran'
   - ./configure --enable-fortran --enable-developer-docs
-  - make
   - make -j distcheck
+  - make -j distclean
   - rm -rf build
   - mkdir build
   - cd build

--- a/cime/src/externals/pio2/configure.ac
+++ b/cime/src/externals/pio2/configure.ac
@@ -21,6 +21,7 @@ AC_SUBST([VERSION_PATCH], [4])
 AC_CONFIG_MACRO_DIR([m4])
 
 # Libtool initialisation.
+LD=ld # Required for MPE to work.
 LT_INIT
 
 # Find and learn about the C compiler.
@@ -50,22 +51,6 @@ test "x$enable_logging" = xyes || enable_logging=no
 AC_MSG_RESULT([$enable_logging])
 if test "x$enable_logging" = xyes; then
    AC_DEFINE([PIO_ENABLE_LOGGING], 1, [If true, turn on logging.])
-fi
-
-# Does the user want to use MPE library?
-AC_MSG_CHECKING([whether use of MPE library is enabled])
-AC_ARG_ENABLE([mpe],
-              [AS_HELP_STRING([--enable-mpe],
-                              [enable use of MPE library for timing and diagnostic info (may negatively impact performance).])])
-test "x$enable_mpe" = xyes || enable_mpe=no
-AC_MSG_RESULT([$enable_mpe])
-if test "x$enable_mpe" = xyes; then
-   AC_SEARCH_LIBS([MPE_Log_get_event_number], [mpe], [HAVE_LIBMPE=yes], [HAVE_LIBMPE=no], [-lpthread -lm])
-   AC_CHECK_HEADERS([mpe.h], [HAVE_MPE=yes], [HAVE_MPE=no])
-   if test "x$HAVE_LIBMPE" = xno -o "x$HAVE_MPE" = xno; then
-      AC_MSG_ERROR([MPE not found but --enable-mpe used.])
-   fi
-   AC_DEFINE([USE_MPE], 1, [If true, use MPE timing library.])
 fi
 
 # Does the user want to enable timing?
@@ -103,6 +88,32 @@ AC_ARG_ENABLE([fortran],
 test "x$enable_fortran" = xyes || enable_fortran=no
 AC_MSG_RESULT([$enable_fortran])
 AM_CONDITIONAL(BUILD_FORTRAN, [test "x$enable_fortran" = xyes])
+
+# Does the user want to use MPE library?
+AC_MSG_CHECKING([whether use of MPE library is enabled])
+AC_ARG_ENABLE([mpe],
+              [AS_HELP_STRING([--enable-mpe],
+                              [enable use of MPE library for timing and diagnostic info (may negatively impact performance).])])
+test "x$enable_mpe" = xyes || enable_mpe=no
+AC_MSG_RESULT([$enable_mpe])
+if test "x$enable_mpe" = xyes; then
+
+   AC_SEARCH_LIBS([pthread_setspecific], [pthread], [], [], [])
+   dnl AC_SEARCH_LIBS([MPE_Log_get_event_number], [mpe], [HAVE_LIBMPE=yes], [HAVE_LIBMPE=no], [])
+   dnl AC_SEARCH_LIBS([MPE_Init_mpi_core], [lmpe], [HAVE_LIBLMPE=yes], [HAVE_LIBLMPE=no], [])
+   AC_CHECK_HEADERS([mpe.h], [HAVE_MPE=yes], [HAVE_MPE=no])
+   dnl if test "x$HAVE_LIBMPE" != xyes; then
+   dnl    AC_MSG_ERROR([-lmpe not found but --enable-mpe used.])
+   dnl fi
+   dnl if test "x$HAVE_LIBLMPE" != xyes; then
+   dnl    AC_MSG_ERROR([-llmpe not found but --enable-mpe used.])
+   dnl fi
+   if test $enable_fortran = yes; then
+      AC_MSG_ERROR([MPE not implemented in Fortran tests and examples. Build without --enable-fortran])
+   fi
+   AC_DEFINE([USE_MPE], 1, [If true, use MPE timing library.])
+
+fi
 
 # Does the user want to disable pnetcdf?
 AC_MSG_CHECKING([whether pnetcdf is to be used])
@@ -150,9 +161,9 @@ if test "x$enable_docs" = xyes; then
    fi
    AC_SUBST([FORTRAN_SRC_FILES], ["../src/flib/piodarray.f90  ../src/flib/pio.F90  ../src/flib/pio_kinds.F90  ../src/flib/piolib_mod.f90  ../src/flib/pionfatt_mod_2.f90  ../src/flib/pio_nf.F90  ../src/flib/pionfget_mod_2.f90  ../src/flib/pionfput_mod.f90  ../src/flib/pio_support.F90  ../src/flib/pio_types.F90"])
    if test "x$enable_developer_docs" = xyes; then
-      AC_SUBST([C_SRC_FILES], ["../src/clib"])
+      AC_SUBST([C_SRC_FILES], ["../src/clib ../src/ncint"])
    else
-      AC_SUBST([C_SRC_FILES], ["../src/clib/pio_nc.c ../src/clib/pio_nc4.c ../src/clib/pio_darray.c ../src/clib/pio_get_nc.c ../src/clib/pio_put_nc.c ../src/clib/pioc_support.c ../src/clib/pioc.c ../src/clib/pio_file.c ../src/clib/pio.h ../src/clib/pio_get_vard.c ../src/clib/pio_put_vard.c"])
+      AC_SUBST([C_SRC_FILES], ["../src/clib/pio_nc.c ../src/clib/pio_nc4.c ../src/clib/pio_darray.c ../src/clib/pio_get_nc.c ../src/clib/pio_put_nc.c ../src/clib/pioc_support.c ../src/clib/pioc.c ../src/clib/pio_file.c ../src/clib/pio.h ../src/clib/pio_get_vard.c ../src/clib/pio_put_vard.c ../src/ncint/ncint_pio.c ../src/ncint/nc_put_vard.c ../src/ncint/nc_get_vard.c"])
    fi
    AC_CONFIG_FILES([doc/Doxyfile])
 fi
@@ -251,6 +262,30 @@ if test "x$enable_timing" = xyes; then
 fi
 AM_CONDITIONAL([HAVE_PAPI], [test "x$have_papi" = xyes])
 
+# Does the user want to build netcdf-c integration layer?
+AC_MSG_CHECKING([whether netcdf-c integration layer should be build])
+AC_ARG_ENABLE([netcdf-integration],
+              [AS_HELP_STRING([--enable-netcdf-integration],
+                              [enable building of netCDF C API integration.])])
+test "x$enable_netcdf_integration" = xyes || enable_netcdf_integration=no
+AC_MSG_RESULT([$enable_netcdf_integration])
+if test "x$enable_netcdf_integration" = xyes -a "x$enable_timing" = xyes; then
+   AC_MSG_ERROR([Cannot use GPTL timing library with netCDF interation.])
+fi
+if test "x$enable_netcdf_integration" = xyes -a "x$have_netcdf_par" = xno; then
+   AC_MSG_ERROR([Cannot use netCDF integration unless netCDF library was built for parallel I/O.])
+fi
+# These are needed by ncdispatch.h. Only build with HDF5 parallel
+# versions of netCDF. */
+if test "x$enable_netcdf_integration" = xyes; then
+  AC_DEFINE([HDF5_PARALLEL],[1],[Does HDF5 library provide parallel access])
+  AC_DEFINE([USE_NETCDF4],[1],[Does HDF5 library provide parallel access])
+  AC_DEFINE([NETCDF_INTEGRATION],[1],[Are we building with netCDF integration])
+fi
+
+AM_CONDITIONAL(BUILD_NCINT, [test "x$enable_netcdf_integration" = xyes])
+AM_CONDITIONAL(NETCDF_INTEGRATION, [test "x$enable_netcdf_integration" = xyes])
+
 AC_CONFIG_FILES([tests/general/pio_tutil.F90:tests/general/util/pio_tutil.F90])
 
 AC_CONFIG_LINKS([tests/unit/input.nl:tests/unit/input.nl])
@@ -262,10 +297,13 @@ AC_CONFIG_HEADERS([config.h])
 AC_OUTPUT(Makefile
           src/Makefile
           src/clib/Makefile
+          src/ncint/Makefile
           src/flib/Makefile
           src/gptl/Makefile
           tests/Makefile
           tests/cunit/Makefile
+          tests/ncint/Makefile
+          tests/fncint/Makefile
           tests/unit/Makefile
           tests/general/Makefile
           tests/general/util/Makefile
@@ -275,4 +313,5 @@ AC_OUTPUT(Makefile
           doc/images/Makefile
           examples/Makefile
           examples/c/Makefile
+          examples/f03/Makefile
           scripts/Makefile)

--- a/cime/src/externals/pio2/doc/source/netcdf_integration.txt
+++ b/cime/src/externals/pio2/doc/source/netcdf_integration.txt
@@ -1,0 +1,22 @@
+/** @page netcdf_integration NetCDF API Integration
+
+The netCDF integration feature allows existing netCDF codes, in C or
+Fortran, to be easily converted to use PIO.
+
+# Building and Using PIO with NetCDF Integration
+
+In order to use netCDF integration:
+
+* The PIO configure must use the option --enable-netcdf-integration.
+
+* The latest master of the netcdf-c library must be built and used,
+and the PIO build must include the netcdf-c/include directory in its
+CPPFLAGS, in order to find internal netCDF header files needed for
+netCDF integration. (The netcdf-c library is being modified to export
+publically everything needed, so future releases of netcdf-c will no
+longer require this.)
+
+Once PIO is build for netCDF integration, it provides the nc_* and
+nf_* functions required to fully integrate PIO and netCDF.
+
+*/

--- a/cime/src/externals/pio2/doc/source/users_guide.txt
+++ b/cime/src/externals/pio2/doc/source/users_guide.txt
@@ -12,6 +12,7 @@ releases.
  - @ref decomp
  - @ref error
  - @ref examp
+ - @ref netcdf_integration
  - @ref faq
  - @ref api
  - @ref c_api

--- a/cime/src/externals/pio2/examples/Makefile.am
+++ b/cime/src/externals/pio2/examples/Makefile.am
@@ -2,5 +2,8 @@
 
 # Ed Hartnett
 
-SUBDIRS = c
+if BUILD_FORTRAN
+F03 = f03
+endif # BUILD_FORTRAN
 
+SUBDIRS = c ${F03}

--- a/cime/src/externals/pio2/examples/c/Makefile.am
+++ b/cime/src/externals/pio2/examples/c/Makefile.am
@@ -4,7 +4,7 @@
 # Ed Hartnett 5/7/18
 
 # Link to our assembled library.
-AM_LDFLAGS = ${top_builddir}/src/clib/libpio.la
+LDADD = ${top_builddir}/src/clib/libpioc.la
 AM_CPPFLAGS = -I$(top_srcdir)/src/clib
 
 # Build the tests for make check.
@@ -19,4 +19,4 @@ endif # RUN_TESTS
 EXTRA_DIST = run_tests.sh
 
 # Clean up files produced during testing.
-CLEANFILES = *.nc *.log
+CLEANFILES = *.nc *.log *.clog2 *.slog2

--- a/cime/src/externals/pio2/examples/c/darray_async.c
+++ b/cime/src/externals/pio2/examples/c/darray_async.c
@@ -71,31 +71,6 @@ int dim_len[NDIM3] = {NC_UNLIMITED, DIM_LEN_X, DIM_LEN_Y};
 /* Names of dimensions. */
 char dim_name[NDIM3][PIO_MAX_NAME + 1] = {"unlimted", "x", "y"};
 
-/* Handle MPI errors. This should only be used with MPI library
- * function calls. */
-#define MPIERR(e) do {                                                  \
-	MPI_Error_string(e, err_buffer, &resultlen);			\
-	printf("MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
-	MPI_Finalize();							\
-	return 2;							\
-    } while (0)
-
-/* Handle non-MPI errors by finalizing the MPI library and exiting
- * with an exit code. */
-#define ERR(e) do {				\
-	MPI_Finalize();				\
-	return e;				\
-    } while (0)
-
-/* Global err buffer for MPI. When there is an MPI error, this buffer
- * is used to store the error message that is associated with the MPI
- * error. */
-char err_buffer[MPI_MAX_ERROR_STRING];
-
-/* This is the length of the most recent MPI error message, stored
- * int the global error string. */
-int resultlen;
-
 /* @brief Check the output file.
  *
  *  Use netCDF to check that the output is as expected.

--- a/cime/src/externals/pio2/examples/c/example1.c
+++ b/cime/src/externals/pio2/examples/c/example1.c
@@ -20,6 +20,12 @@
 #ifdef TIMING
 #include <gptl.h>
 #endif
+#ifdef USE_MPE
+#include <mpe.h>
+#endif /* USE_MPE */
+
+/** The name of this program. */
+#define TEST_NAME "example1"
 
 /** The number of possible output netCDF output flavors available to
  * the ParallelIO library. */
@@ -303,7 +309,13 @@ int check_file(int ntasks, char *filename) {
 	    printf("%d: ParallelIO Library example1 running on %d processors.\n",
 		   my_rank, ntasks);
 
-	/* keep things simple - 1 iotask per MPI process */    
+#ifdef USE_MPE
+        /* If MPE logging is being used, then initialize it. */
+        if ((ret = MPE_Init_log()))
+            return ret;
+#endif /* USE_MPE */
+
+        /* keep things simple - 1 iotask per MPI process */
 	niotasks = ntasks;
 
         /* Turn on logging if available. */
@@ -424,7 +436,7 @@ int check_file(int ntasks, char *filename) {
 	    return ret;
 #endif    
 
-	if (verbose)
+        if (verbose)
 	    printf("rank: %d SUCCESS!\n", my_rank);
 	return 0;
     }

--- a/cime/src/externals/pio2/examples/c/examplePio.c
+++ b/cime/src/externals/pio2/examples/c/examplePio.c
@@ -20,6 +20,12 @@
 #ifdef TIMING
 #include <gptl.h>
 #endif
+#ifdef USE_MPE
+#include <mpe.h>
+#endif /* USE_MPE */
+
+/** The name of this program. */
+#define TEST_NAME "examplePio"
 
 /** The length of our 1-d data array. */
 static const int LEN = 16;
@@ -179,7 +185,16 @@ struct examplePioClass* epc_init( struct examplePioClass* this )
 	  this->ntasks == 8 || this->ntasks == 16))
 	this->errorHandler(this, "Number of processors must be 1, 2, 4, 8, or 16!",
 			   ERR_CODE);
-    
+
+/* #ifdef USE_MPE */
+/*     /\* If MPE logging is being used, then initialize it. *\/ */
+/*     { */
+/*         int ret; */
+/*         if ((ret = MPE_Init_log())) */
+/*             return NULL; */
+/*     } */
+/* #endif /\* USE_MPE *\/ */
+
     /*
     ** set up PIO for rest of example
     */
@@ -458,6 +473,7 @@ struct examplePioClass* epc_cleanUp( struct examplePioClass* this )
     
     PIOc_freedecomp(this->pioIoSystem, this->iodescNCells);
     PIOc_free_iosystem(this->pioIoSystem);
+
     MPI_Finalize();
     
     return this;
@@ -587,7 +603,7 @@ int main(int argc, char* argv[])
     if ((ret = GPTLinitialize ()))
       return ret;
 #endif    
-    
+
     pioExInst->init(pioExInst);
     pioExInst->createDecomp(pioExInst);
     pioExInst->createFile(pioExInst);
@@ -595,6 +611,12 @@ int main(int argc, char* argv[])
     pioExInst->writeVar(pioExInst);
     pioExInst->readVar(pioExInst);
     pioExInst->closeFile(pioExInst);
+
+/* #ifdef USE_MPE */
+/*     if ((ret = MPE_Finish_log("examplePio"))) */
+/*         return ret; */
+/* #endif /\* USE_MPE *\/ */
+
     pioExInst->cleanUp(pioExInst);
     
 #ifdef TIMING    

--- a/cime/src/externals/pio2/examples/f03/Makefile.am
+++ b/cime/src/externals/pio2/examples/f03/Makefile.am
@@ -1,0 +1,28 @@
+## This is the automake file for building the Fortran examples
+## for the PIO library.
+
+# Ed Hartnett 7/17/19
+
+# Put together AM_CPPFLAGS and AM_LDFLAGS.
+include $(top_srcdir)/set_flags.am
+
+AM_FCFLAGS = -I$(top_srcdir)/src/flib
+
+LDADD = ${top_builddir}/src/flib/libpiof.la	\
+${top_builddir}/src/clib/libpioc.la
+
+# Build the test for make check.
+check_PROGRAMS = examplePio
+
+examplePio_SOURCES = examplePio.f90
+
+if RUN_TESTS
+# Tests will run from a bash script.
+TESTS = run_tests.sh
+endif # RUN_TESTS
+
+# Distribute the test script.
+EXTRA_DIST = CMakeLists.txt run_tests.sh
+
+# Clean up files produced during testing.
+CLEANFILES = *.nc *.log *.mod

--- a/cime/src/externals/pio2/examples/f03/run_tests.sh
+++ b/cime/src/externals/pio2/examples/f03/run_tests.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# This is a test script for PIO for tests/general directory.
+# Ed Hartnett 7/22/19
+
+# Stop execution of script if error is returned.
+set -e
+
+# Stop loop if ctrl-c is pressed.
+trap exit INT TERM
+
+printf 'running PIO Fortran examples...\n'
+
+PIO_TESTS='examplePio '
+# pio_rearr_opts pio_rearr_opts2
+
+success1=true
+for TEST in $PIO_TESTS
+do
+    success1=false
+    echo "running ${TEST}"
+    mpiexec -n 4 ./${TEST} && success1=true
+    if test $success1 = false; then
+        break
+    fi
+done
+
+# Did we succeed?
+if test x$success1 = xtrue; then
+    exit 0
+fi
+exit 1

--- a/cime/src/externals/pio2/src/Makefile.am
+++ b/cime/src/externals/pio2/src/Makefile.am
@@ -5,12 +5,19 @@
 # Does the user want to build fortran?
 if BUILD_FORTRAN
 FLIB = flib
-endif
+endif # BUILD_FORTRAN
 
+# Are we building with the GPTL timing library?
 if USE_GPTL
 GPTL = gptl
 endif
 
-SUBDIRS = clib ${GPTL} $(FLIB)
+# Are we building with netCDF integration?
+if BUILD_NCINT
+NCINT = ncint
+endif # BUILD_NCINT
+
+# Build these subdirectories.
+SUBDIRS = ${NCINT} clib ${GPTL} $(FLIB)
 
 EXTRA_DIST = CMakeLists.txt

--- a/cime/src/externals/pio2/src/clib/Makefile.am
+++ b/cime/src/externals/pio2/src/clib/Makefile.am
@@ -2,21 +2,27 @@
 # Ed Hartnett 8/19/17
 
 # The library we are building.
-lib_LTLIBRARIES = libpio.la
+lib_LTLIBRARIES = libpioc.la
+
+# Are we building with netCDF integration?
+if BUILD_NCINT
+libpioc_la_LIBADD = ../ncint/libncint.la
+libpioc_la_CPPFLAGS = -I${top_srcdir}/src/ncint
+endif # BUILD_NCINT
 
 # These linker flags specify libtool version info.
 # See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
 # for information regarding incrementing `-version-info`.
-libpio_la_LDFLAGS = -version-info 2:0:1
+libpioc_la_LDFLAGS = -version-info 2:0:1
 
-# The header file.
-include_HEADERS = pio.h
+# The library header file will be installed in include dir.
+include_HEADERS = pio.h uthash.h
 
 # The library soure files.
-libpio_la_SOURCES = bget.c pioc_sc.c pio_darray.c pio_file.c		\
+libpioc_la_SOURCES = bget.c pioc_sc.c pio_darray.c pio_file.c		\
 pio_getput_int.c pio_msg.c pio_nc.c pio_rearrange.c pioc.c		\
 pioc_support.c pio_darray_int.c pio_get_nc.c pio_lists.c pio_nc4.c	\
 pio_put_nc.c pio_spmd.c pio_get_vard.c pio_put_vard.c pio_internal.h	\
-bget.h uthash.h
+bget.h uthash.h pio_error.h
 
 EXTRA_DIST = CMakeLists.txt

--- a/cime/src/externals/pio2/src/clib/bget.c
+++ b/cime/src/externals/pio2/src/clib/bget.c
@@ -564,12 +564,12 @@ static bufsize pool_len = 0;          /* 0: no bpool calls have been made
 /* added for PIO so that a bpool can be freed and another allocated */
 void bpoolrelease()
 {
-    LOG((2, "bpoolrelease"));
+    PLOG((2, "bpoolrelease"));
     freelist.bh.prevfree=0;
     freelist.bh.bsize=0;
     freelist.ql.flink=&freelist;
     freelist.ql.blink=&freelist;
-    LOG((2, "bpoolrelease"));
+    PLOG((2, "bpoolrelease"));
 
 #ifdef BufStats
     totalloc = 0;             /* Total space currently allocated */
@@ -583,7 +583,7 @@ void bpoolrelease()
     numdrel = 0; /* Number of direct gets and rels */
 #endif /* BECtl */
 #endif /* BufStats */
-    LOG((2, "bpoolrelease"));
+    PLOG((2, "bpoolrelease"));
 
 #ifdef BECtl
 /* Automatic expansion block management functions */
@@ -593,7 +593,7 @@ void bpoolrelease()
     exp_incr = 0;
     pool_len = 0;
 #endif
-    LOG((2, "bpoolrelease"));
+    PLOG((2, "bpoolrelease"));
 
 }
 

--- a/cime/src/externals/pio2/src/clib/pio.h
+++ b/cime/src/externals/pio2/src/clib/pio.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * Public headers for the PIO C interface.
- * @author Jim Edwards
+ * @author Jim Edwards, Ed Hartnett
  * @date  2014
  *
  * @see https://github.com/NCAR/ParallelIO
@@ -1245,6 +1245,80 @@ extern "C" {
                                const long long *op);
     int PIOc_put_vard_ulonglong(int ncid, int varid, int decompid, const PIO_Offset recnum,
                                 const unsigned long long *op);
+
+    /* These functions are for the netCDF integration layer. */
+    int nc_def_iosystemm(MPI_Comm comp_comm, int num_iotasks, int stride, int base, int rearr,
+                         int *iosysidp);
+
+    /* Set the default IOsystem ID. */
+    int nc_set_iosystem(int iosysid);
+
+    /* Get the default IOsystem ID. */
+    int nc_get_iosystem(int *iosysid);
+
+    /* Release the resources associated with an iosystem. */
+    int nc_free_iosystem(int iosysid);
+
+    /* Define a decomposition for distributed arrays. */
+    int nc_def_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen,
+                      int maplen, const size_t *compmap, int *ioidp,
+                      int rearranger, const size_t *iostart,
+                      const size_t *iocount);
+
+    /* Release resources associated with a decomposition. */
+    int nc_free_decomp(int ioid);
+
+    /* Data reads - read a distributed array. */
+    int nc_get_vard(int ncid, int varid, int decompid, const size_t recnum, void *buf);
+    int nc_get_vard_text(int ncid, int varid, int decompid, const size_t recnum,
+                         char *buf);
+    int nc_get_vard_schar(int ncid, int varid, int decompid, const size_t recnum,
+                          signed char *buf);
+    int nc_get_vard_short(int ncid, int varid, int decompid, const size_t recnum,
+                          short *buf);
+    int nc_get_vard_int(int ncid, int varid, int decompid, const size_t recnum,
+                        int *buf);
+    int nc_get_vard_float(int ncid, int varid, int decompid, const size_t recnum,
+                          float *buf);
+    int nc_get_vard_double(int ncid, int varid, int decompid, const size_t recnum,
+                           double *buf);
+    int nc_get_vard_uchar(int ncid, int varid, int decompid, const size_t recnum,
+                          unsigned char *buf);
+    int nc_get_vard_ushort(int ncid, int varid, int decompid, const size_t recnum,
+                           unsigned short *buf);
+    int nc_get_vard_uint(int ncid, int varid, int decompid, const size_t recnum,
+                         unsigned int *buf);
+    int nc_get_vard_longlong(int ncid, int varid, int decompid, const size_t recnum,
+                             long long *buf);
+    int nc_get_vard_ulonglong(int ncid, int varid, int decompid, const size_t recnum,
+                              unsigned long long *buf);
+
+    /* Data writes - Write a distributed array. */
+    int nc_put_vard(int ncid, int varid, int decompid, const size_t recnum,
+                    const void *buf);
+    int nc_put_vard_text(int ncid, int varid, int decompid, const size_t recnum,
+                         const char *op);
+    int nc_put_vard_schar(int ncid, int varid, int decompid, const size_t recnum,
+                          const signed char *op);
+    int nc_put_vard_short(int ncid, int varid, int decompid, const size_t recnum,
+                          const short *op);
+    int nc_put_vard_int(int ncid, int varid, int decompid, const size_t recnum,
+                        const int *op);
+    int nc_put_vard_float(int ncid, int varid, int decompid, const size_t recnum,
+                          const float *op);
+    int nc_put_vard_double(int ncid, int varid, int decompid, const size_t recnum,
+                           const double *op);
+    int nc_put_vard_uchar(int ncid, int varid, int decompid, const size_t recnum,
+                          const unsigned char *op);
+    int nc_put_vard_ushort(int ncid, int varid, int decompid, const size_t recnum,
+                           const unsigned short *op);
+    int nc_put_vard_uint(int ncid, int varid, int decompid, const size_t recnum,
+                         const unsigned int *op);
+    int nc_put_vard_longlong(int ncid, int varid, int decompid, const size_t recnum,
+                             const long long *op);
+    int nc_put_vard_ulonglong(int ncid, int varid, int decompid, const size_t recnum,
+                              const unsigned long long *op);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/cime/src/externals/pio2/src/clib/pio_darray_int.c
+++ b/cime/src/externals/pio2/src/clib/pio_darray_int.c
@@ -75,7 +75,7 @@ compute_buffer_init(iosystem_desc_t *ios)
         bectl(NULL, malloc, bpool_free, pio_cnbuffer_limit);
     }
 #endif
-    LOG((2, "compute_buffer_init complete"));
+    PLOG((2, "compute_buffer_init complete"));
 
     return PIO_NOERR;
 }
@@ -106,10 +106,10 @@ get_gdim0(file_desc_t *file,io_desc_t *iodesc, int varid, int fndims,
         /* We need to confirm the file has an unlimited dimension and
            if it doesn't we need to find the extent of the first
            variable dimension. */
-        LOG((3,"look for numunlimdims"));
+        PLOG((3,"look for numunlimdims"));
         if ((ierr = PIOc_inq_unlimdims(file->pio_ncid, &numunlimdims, NULL)))
             return check_netcdf(file, ierr, __FILE__, __LINE__);
-        LOG((3,"numunlimdims = %d", numunlimdims));
+        PLOG((3,"numunlimdims = %d", numunlimdims));
         if (numunlimdims <= 0)
         {
             int dimids[fndims];
@@ -119,7 +119,7 @@ get_gdim0(file_desc_t *file,io_desc_t *iodesc, int varid, int fndims,
                 return check_netcdf(file, ierr, __FILE__, __LINE__);
         }
     }
-    LOG((3,"gdim0 = %d",*gdim0));
+    PLOG((3,"gdim0 = %d",*gdim0));
     return ierr;
 }
 
@@ -250,8 +250,8 @@ int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdi
 
 #if PIO_ENABLE_LOGGING
         for (int i=0; i< sa_ndims; i++)
-            LOG((3, "vard: sastart[%d]=%d sacount[%d]=%d gdims[%d]=%d %ld %ld displacement = %ld un %d",
-                 i,sastart[i], i,sacount[i], i, gdims[i], startlist[rc][i], countlist[rc][i], displacements[rc], unlimdimoffset));
+            PLOG((3, "vard: sastart[%d]=%d sacount[%d]=%d gdims[%d]=%d %ld %ld displacement = %ld un %d",
+                  i,sastart[i], i,sacount[i], i, gdims[i], startlist[rc][i], countlist[rc][i], displacements[rc], unlimdimoffset));
 #endif
         if (isContig) { /* this request rc is contiguous, no need to create a new MPI datatype */
             if (prev_end == disp) {
@@ -282,7 +282,7 @@ int get_vard_mpidatatype(io_desc_t *iodesc, MPI_Offset gdim0, PIO_Offset unlimdi
         }
 
 #if PIO_ENABLE_LOGGING
-        LOG((3,"vard: blocklengths[%d]=%d displacement[%d]=%ld unlimdimoffset=%ld",rc,blocklengths[rc], rc, displacements[rc], unlimdimoffset));
+        PLOG((3,"vard: blocklengths[%d]=%d displacement[%d]=%ld unlimdimoffset=%ld",rc,blocklengths[rc], rc, displacements[rc], unlimdimoffset));
 #endif
 
     }
@@ -373,7 +373,7 @@ find_start_count(int ndims, int fndims, var_desc_t *vdesc,
 #if PIO_ENABLE_LOGGING
         /* Log arrays for debug purposes. */
         for (int i = 0; i < ndims; i++)
-            LOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
+            PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
 #endif /* PIO_ENABLE_LOGGING */
     }
 
@@ -416,9 +416,9 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
     pioassert(file && file->iosystem && varids && varids[0] >= 0 && varids[0] <= PIO_MAX_VARS &&
               iodesc, "invalid input", __FILE__, __LINE__);
 
-    LOG((1, "write_darray_multi_par nvars = %d iodesc->ndims = %d iodesc->mpitype = %d "
-         "iodesc->maxregions = %d iodesc->llen = %d", nvars, iodesc->ndims,
-         iodesc->mpitype, iodesc->maxregions, iodesc->llen));
+    PLOG((1, "write_darray_multi_par nvars = %d iodesc->ndims = %d iodesc->mpitype = %d "
+          "iodesc->maxregions = %d iodesc->llen = %d", nvars, iodesc->ndims,
+          iodesc->mpitype, iodesc->maxregions, iodesc->llen));
 
 #ifdef TIMING
     /* Start timer if desired. */
@@ -502,7 +502,7 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
                 dsize = 1;
                 for (int i = 0; i < fndims; i++)
                     dsize *= count[i];
-                LOG((3, "dsize = %d", dsize));
+                PLOG((3, "dsize = %d", dsize));
 
                 /* For pnetcdf's ncmpi_iput_varn() function, we need
                  * to provide arrays of arrays for start/count. */
@@ -520,8 +520,8 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
                     {
                         startlist[rrcnt][i] = start[i];
                         countlist[rrcnt][i] = count[i];
-                        LOG((3, "startlist[%d][%d] = %d countlist[%d][%d] = %d", rrcnt, i,
-                             startlist[rrcnt][i], rrcnt, i, countlist[rrcnt][i]));
+                        PLOG((3, "startlist[%d][%d] = %d countlist[%d][%d] = %d", rrcnt, i,
+                              startlist[rrcnt][i], rrcnt, i, countlist[rrcnt][i]));
                     }
                     rrcnt++;
                 }
@@ -591,7 +591,7 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
                             {
                                 if((ierr = ncmpi_inq_recsize(file->fh, &unlimdimoffset)))
                                     return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-                                LOG((3, "num_regions = %d unlimdimoffset %ld", num_regions, unlimdimoffset));
+                                PLOG((3, "num_regions = %d unlimdimoffset %ld", num_regions, unlimdimoffset));
                             }else
                                 unlimdimoffset = gdim0;
                             if (frame)
@@ -660,9 +660,9 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
                             else /* there is only one variable to flush */
                                 filetype = vartypes[0];
 
-                            LOG((3, "vard: call ncmpi_put_vard llen = %d %d", llen, iodesc->mpitype_size ));
+                            PLOG((3, "vard: call ncmpi_put_vard llen = %d %d", llen, iodesc->mpitype_size ));
                             ierr = ncmpi_put_vard_all(file->fh, var0_id, filetype, vard_bufptr, vard_llen, iodesc->mpitype);
-                            LOG((3, "vard: return ncmpi_put_vard ierr = %d", ierr));
+                            PLOG((3, "vard: return ncmpi_put_vard ierr = %d", ierr));
                             if(filetype != MPI_DATATYPE_NULL)
                             {
                                 if((mpierr = MPI_Type_free(&filetype)))
@@ -685,8 +685,8 @@ write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *vari
                         }
 
                         /* Write, in non-blocking fashion, a list of subarrays. */
-                        LOG((3, "about to call ncmpi_iput_varn() varids[%d] = %d rrcnt = %d, llen = %d",
-                             nv, varids[nv], rrcnt, llen));
+                        PLOG((3, "about to call ncmpi_iput_varn() varids[%d] = %d rrcnt = %d, llen = %d",
+                              nv, varids[nv], rrcnt, llen));
                         ierr = ncmpi_iput_varn(file->fh, varids[nv], rrcnt, startlist, countlist,
                                                bufptr, llen, iodesc->mpitype, &vdesc->request[vdesc->nreqs]);
 
@@ -781,9 +781,9 @@ find_all_start_count(io_region *region, int maxregions, int fndims,
                 {
                     tmp_start[i + r * fndims] = region->start[i - (fndims - iodesc_ndims)];
                     tmp_count[i + r * fndims] = region->count[i - (fndims - iodesc_ndims)];
-                    LOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
-                         tmp_start[i + r * fndims], i + r * fndims,
-                         tmp_count[i + r * fndims]));
+                    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
+                          tmp_start[i + r * fndims], i + r * fndims,
+                          tmp_count[i + r * fndims]));
                 }
             }
             else
@@ -793,9 +793,9 @@ find_all_start_count(io_region *region, int maxregions, int fndims,
                 {
                     tmp_start[i + r * fndims] = region->start[i];
                     tmp_count[i + r * fndims] = region->count[i];
-                    LOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
-                         tmp_start[i + r * fndims], i + r * fndims,
-                         tmp_count[i + r * fndims]));
+                    PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + r * fndims,
+                          tmp_start[i + r * fndims], i + r * fndims,
+                          tmp_count[i + r * fndims]));
                 }
             }
 
@@ -840,7 +840,7 @@ send_all_start_count(iosystem_desc_t *ios, io_desc_t *iodesc, PIO_Offset llen,
      * fields are the same length). */
     if ((mpierr = MPI_Send((void *)&llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((3, "sent llen = %d", llen));
+    PLOG((3, "sent llen = %d", llen));
 
     /* Send the number of data regions, the start/count for
      * all regions, and the data buffer with all the data. */
@@ -858,7 +858,7 @@ send_all_start_count(iosystem_desc_t *ios, io_desc_t *iodesc, PIO_Offset llen,
         if ((mpierr = MPI_Send(iobuf, nvars * llen, iodesc->mpitype, 0,
                                ios->io_rank + 4 * ios->num_iotasks, ios->io_comm)))
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-        LOG((3, "sent data for maxregions = %d", maxregions));
+        PLOG((3, "sent data for maxregions = %d", maxregions));
     }
 
     return PIO_NOERR;
@@ -919,8 +919,8 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
     pioassert(file && varids && iodesc && tmp_start && tmp_count, "invalid input",
               __FILE__, __LINE__);
 
-    LOG((2, "recv_and_write_data llen = %d maxregions = %d nvars = %d fndims = %d",
-         llen, maxregions, nvars, fndims));
+    PLOG((2, "recv_and_write_data llen = %d maxregions = %d nvars = %d fndims = %d",
+          llen, maxregions, nvars, fndims));
 
     /* Get pointer to IO system. */
     ios = file->iosystem;
@@ -942,7 +942,7 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
             if ((mpierr = MPI_Recv(&rlen, 1, MPI_OFFSET, rtask, rtask, ios->io_comm,
                                    &status)))
                 return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-            LOG((3, "received rlen = %d", rlen));
+            PLOG((3, "received rlen = %d", rlen));
 
             /* Get the number of regions, the start/count
              * values for all regions, and the data buffer. */
@@ -960,7 +960,7 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
                 if ((mpierr = MPI_Recv(iobuf, nvars * rlen, iodesc->mpitype, rtask,
                                        rtask + 4 * ios->num_iotasks, ios->io_comm, &status)))
                     return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-                LOG((3, "received data rregions = %d fndims = %d", rregions, fndims));
+                PLOG((3, "received data rregions = %d fndims = %d", rregions, fndims));
             }
         }
         else /* task 0 */
@@ -968,7 +968,7 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
             rlen = llen;
             rregions = maxregions;
         }
-        LOG((3, "rtask = %d rlen = %d rregions = %d", rtask, rlen, rregions));
+        PLOG((3, "rtask = %d rlen = %d rregions = %d", rtask, rlen, rregions));
 
         /* If there is data from this task, write it. */
         if (rlen > 0)
@@ -976,20 +976,20 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
             loffset = 0;
             for (int regioncnt = 0; regioncnt < rregions; regioncnt++)
             {
-                LOG((3, "writing data for region with regioncnt = %d", regioncnt));
+                PLOG((3, "writing data for region with regioncnt = %d", regioncnt));
 
                 /* Get the start/count arrays for this region. */
                 for (int i = 0; i < fndims; i++)
                 {
                     start[i] = tmp_start[i + regioncnt * fndims];
                     count[i] = tmp_count[i + regioncnt * fndims];
-                    LOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
+                    PLOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
                 }
 
                 /* Process each variable in the buffer. */
                 for (int nv = 0; nv < nvars; nv++)
                 {
-                    LOG((3, "writing buffer var %d", nv));
+                    PLOG((3, "writing buffer var %d", nv));
                     if ((ierr = get_var_desc(varids[0], &file->varlist, &vdesc)))
                         return pio_err(NULL, file, ierr, __FILE__, __LINE__);
 
@@ -1014,7 +1014,7 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
 
 #ifdef LOGGING
                     for (int i = 1; i < fndims; i++)
-                        LOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
+                        PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
 #endif /* LOGGING */
 
                     /* Call the netCDF functions to write the data. */
@@ -1031,8 +1031,8 @@ recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
                 /* Keep track of where we are in the buffer. */
                 loffset += tsize;
 
-                LOG((3, " at bottom of loop regioncnt = %d tsize = %d loffset = %d", regioncnt,
-                     tsize, loffset));
+                PLOG((3, " at bottom of loop regioncnt = %d tsize = %d loffset = %d", regioncnt,
+                      tsize, loffset));
             } /* next regioncnt */
         } /* endif (rlen > 0) */
     } /* next rtask */
@@ -1072,8 +1072,8 @@ write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const int *v
     pioassert(file && file->iosystem && varids && varids[0] >= 0 &&
               varids[0] <= PIO_MAX_VARS && iodesc, "invalid input", __FILE__, __LINE__);
 
-    LOG((1, "write_darray_multi_serial nvars = %d fndims = %d iodesc->ndims = %d "
-         "iodesc->mpitype = %d", nvars, fndims, iodesc->ndims, iodesc->mpitype));
+    PLOG((1, "write_darray_multi_serial nvars = %d fndims = %d iodesc->ndims = %d "
+          "iodesc->mpitype = %d", nvars, fndims, iodesc->ndims, iodesc->mpitype));
 
     /* Get the iosystem info. */
     ios = file->iosystem;
@@ -1101,7 +1101,7 @@ write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const int *v
         size_t tmp_start[fndims * num_regions]; /* A start array for each region. */
         size_t tmp_count[fndims * num_regions]; /* A count array for each region. */
 
-        LOG((3, "num_regions = %d", num_regions));
+        PLOG((3, "num_regions = %d", num_regions));
 
         /* Fill the tmp_start and tmp_count arrays, which contain the
          * start and count arrays for all regions. */
@@ -1173,7 +1173,7 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
 
     /* Get the IO system info. */
     ios = file->iosystem;
-    LOG((3, "pio_read_darray_nc ios->ioproc %d", ios->ioproc));
+    PLOG((3, "pio_read_darray_nc ios->ioproc %d", ios->ioproc));
 
 #ifdef TIMING
     /* Start timer if desired. */
@@ -1195,7 +1195,7 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
     if(!ios->async || !ios->ioproc)
         ierr = get_gdim0(file, iodesc, vid, fndims, &gdim0);
 #endif
-    /* LOG((4, "fndims %d ndims %d", fndims, ndims)); */
+    /* PLOG((4, "fndims %d ndims %d", fndims, ndims)); */
 
     /* IO procs will read the data. */
     if (ios->ioproc)
@@ -1246,8 +1246,8 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
                 else
                     bufptr=(void *)((char *)iobuf + iodesc->mpitype_size * region->loffset);
 
-                LOG((2, "iodesc->llen - region->loffset %d, iodesc->llen %d, region->loffset  %d vdesc->record %d",
-                     iodesc->llen - region->loffset, iodesc->llen, region->loffset, vdesc->record));
+                PLOG((2, "iodesc->llen - region->loffset %d, iodesc->llen %d, region->loffset  %d vdesc->record %d",
+                      iodesc->llen - region->loffset, iodesc->llen, region->loffset, vdesc->record));
 
                 /* Get the start/count arrays. */
                 if (vdesc->record >= 0 && fndims > 1)
@@ -1278,7 +1278,7 @@ pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobuf)
 
 #ifdef PIO_ENABLE_LOGGING
             for (int i = 1; i < ndims; i++)
-                LOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
+                PLOG((3, "start[%d] %d count[%d] %d", i, start[i], i, count[i]));
 #endif /* LOGGING */
             /* Do the read. */
             switch (file->iotype)
@@ -1444,7 +1444,7 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
     pioassert(file && file->iosystem && iodesc && vid >= 0 && vid <= PIO_MAX_VARS,
               "invalid input", __FILE__, __LINE__);
 
-    LOG((2, "pio_read_darray_nc_serial vid = %d", vid));
+    PLOG((2, "pio_read_darray_nc_serial vid = %d", vid));
     ios = file->iosystem;
 
 #ifdef TIMING
@@ -1468,6 +1468,8 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
      * required for backward compatibility. */
     if (fndims == ndims + 1 && vdesc->record < 0)
         vdesc->record = 0;
+    PLOG((3, "fndims %d ndims %d vdesc->record %d", fndims, ndims,
+          vdesc->record));
 
     /* Confirm that we are being called with the correct ndims. */
     pioassert((fndims == ndims && vdesc->record < 0) ||
@@ -1539,10 +1541,10 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
 
 #if PIO_ENABLE_LOGGING
             /* Log arrays for debug purposes. */
-            LOG((3, "region = %d", region));
+            PLOG((3, "region = %d", region));
             for (int i = 0; i < fndims; i++)
-                LOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + regioncnt * fndims, tmp_start[i + regioncnt * fndims],
-                     i + regioncnt * fndims, tmp_count[i + regioncnt * fndims]));
+                PLOG((3, "tmp_start[%d] = %d tmp_count[%d] = %d", i + regioncnt * fndims, tmp_start[i + regioncnt * fndims],
+                      i + regioncnt * fndims, tmp_count[i + regioncnt * fndims]));
 #endif /* PIO_ENABLE_LOGGING */
 
             /* Move to next region. */
@@ -1556,7 +1558,7 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
         {
             if ((mpierr = MPI_Send(&iodesc->llen, 1, MPI_OFFSET, 0, ios->io_rank, ios->io_comm)))
                 return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-            LOG((3, "sent iodesc->llen = %d", iodesc->llen));
+            PLOG((3, "sent iodesc->llen = %d", iodesc->llen));
 
             if (iodesc->llen > 0)
             {
@@ -1569,12 +1571,12 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
                 if ((mpierr = MPI_Send(tmp_start, iodesc->maxregions * fndims, MPI_OFFSET, 0,
                                        3 * ios->num_iotasks + ios->io_rank, ios->io_comm)))
                     return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                LOG((3, "sent iodesc->maxregions = %d tmp_count and tmp_start arrays", iodesc->maxregions));
+                PLOG((3, "sent iodesc->maxregions = %d tmp_count and tmp_start arrays", iodesc->maxregions));
 
                 if ((mpierr = MPI_Recv(iobuf, iodesc->llen, iodesc->mpitype, 0,
                                        4 * ios->num_iotasks + ios->io_rank, ios->io_comm, &status)))
                     return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                LOG((3, "received %d elements of data", iodesc->llen));
+                PLOG((3, "received %d elements of data", iodesc->llen));
             }
         }
         else if (ios->io_rank == 0)
@@ -1592,7 +1594,7 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
                 {
                     if ((mpierr = MPI_Recv(&tmp_bufsize, 1, MPI_OFFSET, rtask, rtask, ios->io_comm, &status)))
                         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                    LOG((3, "received tmp_bufsize = %d", tmp_bufsize));
+                    PLOG((3, "received tmp_bufsize = %d", tmp_bufsize));
 
                     if (tmp_bufsize > 0)
                     {
@@ -1605,7 +1607,7 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
                         if ((mpierr = MPI_Recv(this_start, maxregions * fndims, MPI_OFFSET, rtask,
                                                3 * ios->num_iotasks + rtask, ios->io_comm, &status)))
                             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-                        LOG((3, "received maxregions = %d this_count, this_start arrays ", maxregions));
+                        PLOG((3, "received maxregions = %d this_count, this_start arrays ", maxregions));
                     }
                 }
                 else
@@ -1613,7 +1615,7 @@ pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
                     maxregions = iodesc->maxregions;
                     tmp_bufsize = iodesc->llen;
                 }
-                LOG((3, "maxregions = %d tmp_bufsize = %d", maxregions, tmp_bufsize));
+                PLOG((3, "maxregions = %d tmp_bufsize = %d", maxregions, tmp_bufsize));
 
                 /* Now get each region of data. */
                 loffset = 0;
@@ -1739,7 +1741,7 @@ flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
 
     /* Check inputs. */
     pioassert(file, "invalid input", __FILE__, __LINE__);
-    LOG((1, "flush_output_buffer"));
+    PLOG((1, "flush_output_buffer"));
     /* Find out the buffer usage. */
     if ((ierr = ncmpi_inq_buffer_usage(file->fh, &usage)))
         /* allow the buffer to be undefined */
@@ -1760,7 +1762,7 @@ flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
     if (usage > maxusage)
         maxusage = usage;
 
-    LOG((2, "flush_output_buffer usage=%ld force=%d",usage, force));
+    PLOG((2, "flush_output_buffer usage=%ld force=%d",usage, force));
     /* If the user forces it, or the buffer has exceeded the size
      * limit, then flush to disk. */
     if (force || (usage >= pio_buffer_size_limit))
@@ -1783,33 +1785,36 @@ flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
         int request[reqcnt];
         int status[reqcnt];
 
-        for (int i = 0; i <= maxreq; i++)
+        if (file->varlist)
         {
-            if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
-                return pio_err(NULL, file, ierr, __FILE__, __LINE__);
-#ifdef MPIO_ONESIDED
-            /*onesided optimization requires that all of the requests in a wait_all call represent
-              a contiguous block of data in the file */
-            if (rcnt > 0 && (prev_record != vdesc->record || vdesc->nreqs == 0))
+            for (int i = 0; i <= maxreq; i++)
             {
-                ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
-                rcnt = 0;
-            }
-            prev_record = vdesc->record;
+                if ((ierr = get_var_desc(i, &file->varlist, &vdesc)))
+                    return pio_err(NULL, file, ierr, __FILE__, __LINE__);
+#ifdef MPIO_ONESIDED
+                /*onesided optimization requires that all of the requests in a wait_all call represent
+                  a contiguous block of data in the file */
+                if (rcnt > 0 && (prev_record != vdesc->record || vdesc->nreqs == 0))
+                {
+                    ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+                    rcnt = 0;
+                }
+                prev_record = vdesc->record;
 #endif
-            for (reqcnt = 0; reqcnt < vdesc->nreqs; reqcnt++)
-                request[rcnt++] = max(vdesc->request[reqcnt], NC_REQ_NULL);
-            LOG((3,"flush_output_buffer rcnt=%d",rcnt));
+                for (reqcnt = 0; reqcnt < vdesc->nreqs; reqcnt++)
+                    request[rcnt++] = max(vdesc->request[reqcnt], NC_REQ_NULL);
+                PLOG((3,"flush_output_buffer rcnt=%d",rcnt));
 
-            if (vdesc->request != NULL)
-                free(vdesc->request);
-            vdesc->request = NULL;
-            vdesc->nreqs = 0;
+                if (vdesc->request != NULL)
+                    free(vdesc->request);
+                vdesc->request = NULL;
+                vdesc->nreqs = 0;
 
 #ifdef FLUSH_EVERY_VAR
-            ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
-            rcnt = 0;
+                ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+                rcnt = 0;
 #endif
+            }
         }
 
         if (rcnt > 0)
@@ -1818,7 +1823,7 @@ flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
         /* Release resources. */
         if (file->iobuf)
         {
-            LOG((3,"freeing variable buffer in flush_output_buffer"));
+            PLOG((3,"freeing variable buffer in flush_output_buffer"));
             brel(file->iobuf);
             file->iobuf = NULL;
         }
@@ -1853,8 +1858,8 @@ cn_buffer_report(iosystem_desc_t *ios, bool collective)
 {
     int mpierr;  /* Return code from MPI functions. */
 
-    LOG((2, "cn_buffer_report ios->iossysid = %d collective = %d CN_bpool = %d",
-         ios->iosysid, collective, CN_bpool));
+    PLOG((2, "cn_buffer_report ios->iossysid = %d collective = %d CN_bpool = %d",
+          ios->iosysid, collective, CN_bpool));
     if (CN_bpool)
     {
         long bget_stats[5];
@@ -1864,28 +1869,28 @@ cn_buffer_report(iosystem_desc_t *ios, bool collective)
         bstats(bget_stats, bget_stats+1,bget_stats+2,bget_stats+3,bget_stats+4);
         if (collective)
         {
-            LOG((3, "cn_buffer_report calling MPI_Reduce ios->comp_comm = %d", ios->comp_comm));
+            PLOG((3, "cn_buffer_report calling MPI_Reduce ios->comp_comm = %d", ios->comp_comm));
             if ((mpierr = MPI_Reduce(bget_stats, bget_maxs, 5, MPI_LONG, MPI_MAX, 0, ios->comp_comm)))
                 check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            LOG((3, "cn_buffer_report calling MPI_Reduce"));
+            PLOG((3, "cn_buffer_report calling MPI_Reduce"));
             if ((mpierr = MPI_Reduce(bget_stats, bget_mins, 5, MPI_LONG, MPI_MIN, 0, ios->comp_comm)))
                 check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
             if (ios->compmaster == MPI_ROOT)
             {
-                LOG((1, "Currently allocated buffer space %ld %ld", bget_mins[0], bget_maxs[0]));
-                LOG((1, "Currently available buffer space %ld %ld", bget_mins[1], bget_maxs[1]));
-                LOG((1, "Current largest free block %ld %ld", bget_mins[2], bget_maxs[2]));
-                LOG((1, "Number of successful bget calls %ld %ld", bget_mins[3], bget_maxs[3]));
-                LOG((1, "Number of successful brel calls  %ld %ld", bget_mins[4], bget_maxs[4]));
+                PLOG((1, "Currently allocated buffer space %ld %ld", bget_mins[0], bget_maxs[0]));
+                PLOG((1, "Currently available buffer space %ld %ld", bget_mins[1], bget_maxs[1]));
+                PLOG((1, "Current largest free block %ld %ld", bget_mins[2], bget_maxs[2]));
+                PLOG((1, "Number of successful bget calls %ld %ld", bget_mins[3], bget_maxs[3]));
+                PLOG((1, "Number of successful brel calls  %ld %ld", bget_mins[4], bget_maxs[4]));
             }
         }
         else
         {
-            LOG((1, "Currently allocated buffer space %ld", bget_stats[0]));
-            LOG((1, "Currently available buffer space %ld", bget_stats[1]));
-            LOG((1, "Current largest free block %ld", bget_stats[2]));
-            LOG((1, "Number of successful bget calls %ld", bget_stats[3]));
-            LOG((1, "Number of successful brel calls  %ld", bget_stats[4]));
+            PLOG((1, "Currently allocated buffer space %ld", bget_stats[0]));
+            PLOG((1, "Currently available buffer space %ld", bget_stats[1]));
+            PLOG((1, "Current largest free block %ld", bget_stats[2]));
+            PLOG((1, "Number of successful bget calls %ld", bget_stats[3]));
+            PLOG((1, "Number of successful brel calls  %ld", bget_stats[4]));
         }
     }
 }
@@ -1902,13 +1907,13 @@ void
 free_cn_buffer_pool(iosystem_desc_t *ios)
 {
 #if !PIO_USE_MALLOC
-    LOG((2, "free_cn_buffer_pool CN_bpool = %d", CN_bpool));
+    PLOG((2, "free_cn_buffer_pool CN_bpool = %d", CN_bpool));
     /* Note: it is possible that CN_bpool has been freed and set to NULL by bpool_free() */
     if (CN_bpool)
     {
         cn_buffer_report(ios, false);
         bpoolrelease(CN_bpool);
-        LOG((2, "free_cn_buffer_pool done!"));
+        PLOG((2, "free_cn_buffer_pool done!"));
         free(CN_bpool);
         CN_bpool = NULL;
     }
@@ -1938,7 +1943,7 @@ flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
     if ((ret = pio_get_file(ncid, &file)))
         return pio_err(NULL, NULL, ret, __FILE__, __LINE__);
 
-    LOG((1, "flush_buffer ncid = %d flushtodisk = %d", ncid, flushtodisk));
+    PLOG((1, "flush_buffer ncid = %d flushtodisk = %d", ncid, flushtodisk));
 
     /* If there are any variables in this buffer... */
     if (wmb->num_arrays > 0)
@@ -1947,7 +1952,7 @@ flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
         ret = PIOc_write_darray_multi(ncid, wmb->vid,  wmb->ioid, wmb->num_arrays,
                                       wmb->arraylen, wmb->data, wmb->frame,
                                       wmb->fillvalue, flushtodisk);
-        LOG((2, "return from PIOc_write_darray_multi ret = %d", ret));
+        PLOG((2, "return from PIOc_write_darray_multi ret = %d", ret));
 
         wmb->num_arrays = 0;
 
@@ -2250,8 +2255,8 @@ compute_maxaggregate_bytes(iosystem_desc_t *ios, io_desc_t *iodesc)
     /* Check inputs. */
     pioassert(iodesc, "invalid input", __FILE__, __LINE__);
 
-    LOG((2, "compute_maxaggregate_bytes iodesc->maxiobuflen = %d iodesc->ndof = %d",
-         iodesc->maxiobuflen, iodesc->ndof));
+    PLOG((2, "compute_maxaggregate_bytes iodesc->maxiobuflen = %d iodesc->ndof = %d",
+          iodesc->maxiobuflen, iodesc->ndof));
 
     /* Determine the max bytes that can be held on IO task. */
     if (ios->ioproc && iodesc->maxiobuflen > 0)
@@ -2263,15 +2268,15 @@ compute_maxaggregate_bytes(iosystem_desc_t *ios, io_desc_t *iodesc)
 
     /* Take the min of the max IO and max comp bytes. */
     maxbytes = min(maxbytesoniotask, maxbytesoncomputetask);
-    LOG((2, "compute_maxaggregate_bytes maxbytesoniotask = %d maxbytesoncomputetask = %d",
-         maxbytesoniotask, maxbytesoncomputetask));
+    PLOG((2, "compute_maxaggregate_bytes maxbytesoniotask = %d maxbytesoncomputetask = %d",
+          maxbytesoniotask, maxbytesoncomputetask));
 
     /* Get the min value of this on all tasks. */
-    LOG((3, "before allreaduce maxbytes = %d", maxbytes));
+    PLOG((3, "before allreaduce maxbytes = %d", maxbytes));
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &maxbytes, 1, MPI_INT, MPI_MIN,
                                 ios->union_comm)))
         return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-    LOG((3, "after allreaduce maxbytes = %d", maxbytes));
+    PLOG((3, "after allreaduce maxbytes = %d", maxbytes));
 
     /* Remember the result. */
     iodesc->maxbytes = maxbytes;

--- a/cime/src/externals/pio2/src/clib/pio_error.h
+++ b/cime/src/externals/pio2/src/clib/pio_error.h
@@ -1,0 +1,85 @@
+/**
+ * @file
+ * Macros to handle errors in tests or libray code.
+ * @author Ed Hartnett
+ * @date 2019
+ *
+ * @see https://github.com/NCAR/ParallelIO
+ */
+
+#ifndef __PIO_ERROR__
+#define __PIO_ERROR__
+
+#include <config.h>
+#include <pio.h>
+
+/**
+ * Handle non-MPI errors by printing error message and goto exit. This
+ * is used in test code.
+ */
+#define PBAIL(e) do {                                                    \
+        fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
+        goto exit;                                                      \
+    } while (0)
+
+/**
+ * Handle non-MPI errors by calling pio_err(), setting return code,
+ * and goto exit. This is used in library code.
+ */
+#define EXIT(ios, e) do {                                               \
+        ret = pio_err(NULL, NULL, e, __FILE__, __LINE__);        \
+        goto exit;                                                      \
+    } while (0)
+
+/**
+ * Same as the EXIT macro, but uses NULL for iosystem.
+ */
+#define EXIT1(e) EXIT(NULL, e)
+
+/**
+ * Handle non-MPI errors by finalizing the MPI library and exiting
+ * with an exit code.
+ */
+#define ERR(e) do {                                                     \
+        fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
+        MPI_Finalize();                                                 \
+        return e;                                                       \
+    } while (0)
+
+/**
+ * Handle MPI errors. This should only be used with MPI library
+ * function calls. Print error message, finalize MPI and return error
+ * code.
+ */
+#define MPIERR(e) do {                                                  \
+        MPI_Error_string(e, err_buffer, &resultlen);                    \
+        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
+        MPI_Finalize();                                                 \
+        return PIO_EIO;                                                 \
+    } while (0)
+
+/**
+ * Handle MPI errors. This should only be used with MPI library
+ * function calls. Print error message, finalize MPI and goto exit.
+ */
+#define MPIBAIL(e) do {                                                 \
+        MPI_Error_string(e, err_buffer, &resultlen);                    \
+        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
+        ret = NC_EIO;                                                   \
+        goto exit;                                                      \
+    } while (0)
+
+/**
+ * Global err buffer for MPI. When there is an MPI error, this buffer
+ * is used to store the error message that is associated with the MPI
+ * error.
+ */
+char err_buffer[MPI_MAX_ERROR_STRING];
+
+/**
+ * This is the length of the most recent MPI error message, stored
+ * int the global error string.
+ */
+int resultlen;
+
+#endif /* __PIO_ERROR__ */

--- a/cime/src/externals/pio2/src/clib/pio_file.c
+++ b/cime/src/externals/pio2/src/clib/pio_file.c
@@ -28,6 +28,11 @@
    netCDF-4/HDF5 (starts at 65xxx). */
 int pio_next_ncid = 16;
 
+#ifdef USE_MPE
+/* The event numbers for MPE logging. */
+extern int event_num[2][NUM_EVENTS];
+#endif /* USE_MPE */
+
 /**
  * Open an existing file using PIO library.
  *
@@ -46,12 +51,13 @@ int pio_next_ncid = 16;
  * @ingroup PIO_open_file_c
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
+int
+PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
                   int mode)
 {
-    LOG((1, "PIOc_openfile iosysid %d *iotype %d filename %s mode %d", iosysid,
-         iotype ? *iotype: 0, filename, mode));
-    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1);
+    PLOG((1, "PIOc_openfile iosysid %d *iotype %d filename %s mode %d", iosysid,
+          iotype ? *iotype: 0, filename, mode));
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 1, 0);
 }
 
 /**
@@ -73,12 +79,13 @@ int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *filename,
  * @ingroup PIO_open_file_c
  * @author Ed Hartnett
  */
-int PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *filename,
+int
+PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *filename,
                    int mode)
 {
-    LOG((1, "PIOc_openfile2 iosysid %d *iotype %d filename %s mode %d", iosysid,
-         iotype ? *iotype : 0, filename, mode));
-    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 0);
+    PLOG((1, "PIOc_openfile2 iosysid %d *iotype %d filename %s mode %d", iosysid,
+          iotype ? *iotype : 0, filename, mode));
+    return PIOc_openfile_retry(iosysid, ncidp, iotype, filename, mode, 0, 0);
 }
 
 /**
@@ -94,31 +101,26 @@ int PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *filename,
  * @ingroup PIO_open_file_c
  * @author Ed Hartnett
  */
-int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
+int
+PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
 {
     int iotype;
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
+    int ret;
 
-    LOG((1, "PIOc_open iosysid = %d path = %s mode = %x", iosysid, path, mode));
+    PLOG((1, "PIOc_open iosysid = %d path = %s mode = %x", iosysid, path, mode));
 
-    /* Figure out the iotype. */
-    if (mode & NC_NETCDF4)
-    {
-        if (mode & NC_MPIIO || mode & NC_MPIPOSIX)
-            iotype = PIO_IOTYPE_NETCDF4P;
-        else
-            iotype = PIO_IOTYPE_NETCDF4C;
-    }
-    else
-    {
-        if (mode & NC_PNETCDF || mode & NC_MPIIO)
-            iotype = PIO_IOTYPE_PNETCDF;
-        else
-            iotype = PIO_IOTYPE_NETCDF;
-    }
+    /* Get the IO system info from the id. */
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
+    /* Find the IOTYPE from the mode flag. */
+    if ((ret = find_iotype_from_omode(mode, &iotype)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Open the file. If the open fails, do not retry as serial
      * netCDF. Just return the error code. */
-    return PIOc_openfile_retry(iosysid, ncidp, &iotype, path, mode, 0);
+    return PIOc_openfile_retry(iosysid, ncidp, &iotype, path, mode, 0, 0);
 }
 
 /**
@@ -139,7 +141,8 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
  * @ingroup PIO_create_file_c
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
+int
+PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
                     int mode)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
@@ -149,11 +152,11 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_createfile iosysid = %d iotype = %d filename = %s mode = %d",
-         iosysid, *iotype, filename, mode));
+    PLOG((1, "PIOc_createfile iosysid = %d iotype = %d filename = %s mode = %d",
+          iosysid, *iotype, filename, mode));
 
     /* Create the file. */
-    if ((ret = PIOc_createfile_int(iosysid, ncidp, iotype, filename, mode)))
+    if ((ret = PIOc_createfile_int(iosysid, ncidp, iotype, filename, mode, 0)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     /* Run this on all tasks if async is not in use, but only on
@@ -176,34 +179,33 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
  * parameters are read on comp task 0 and ignored elsewhere.
  *
  * @param iosysid : A defined pio system descriptor (input)
+ * @param path : The filename to create.
  * @param cmode : The netcdf mode for the create operation.
- * @param filename : The filename to open
  * @param ncidp : A pio file descriptor (output)
+ *
  * @return 0 for success, error code otherwise.
  * @ingroup PIO_create_file_c
  * @author Ed Hartnett
  */
-int PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
+int
+PIOc_create(int iosysid, const char *path, int cmode, int *ncidp)
 {
     int iotype;            /* The PIO IO type. */
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
+    int ret;
 
-    /* Figure out the iotype. */
-    if (cmode & NC_NETCDF4)
-    {
-        if (cmode & NC_MPIIO || cmode & NC_MPIPOSIX)
-            iotype = PIO_IOTYPE_NETCDF4P;
-        else
-            iotype = PIO_IOTYPE_NETCDF4C;
-    }
-    else
-    {
-        if (cmode & NC_PNETCDF || cmode & NC_MPIIO)
-            iotype = PIO_IOTYPE_PNETCDF;
-        else
-            iotype = PIO_IOTYPE_NETCDF;
-    }
+    PLOG((1, "PIOc_create iosysid = %d path = %s cmode = %x", iosysid, path,
+          cmode));
 
-    return PIOc_createfile_int(iosysid, ncidp, &iotype, filename, cmode);
+    /* Get the IO system info from the id. */
+    if (!(ios = pio_get_iosystem_from_id(iosysid)))
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
+    /* Find the IOTYPE from the mode flag. */
+    if ((ret = find_iotype_from_cmode(cmode, &iotype)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+
+    return PIOc_createfile_int(iosysid, ncidp, &iotype, path, cmode, 0);
 }
 
 /**
@@ -214,14 +216,19 @@ int PIOc_create(int iosysid, const char *filename, int cmode, int *ncidp)
  * @ingroup PIO_close_file_c
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_closefile(int ncid)
+int
+PIOc_closefile(int ncid)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
     int ierr = PIO_NOERR;  /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_closefile ncid = %d", ncid));
+#ifdef USE_MPE
+    pio_start_mpe_log(CLOSE);
+#endif /* USE_MPE */
+
+    PLOG((1, "PIOc_closefile ncid = %d", ncid));
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
@@ -294,6 +301,10 @@ int PIOc_closefile(int ncid)
     if ((ierr = pio_delete_file_from_list(ncid)))
         return pio_err(ios, file, ierr, __FILE__, __LINE__);
 
+#ifdef USE_MPE
+    pio_stop_mpe_log(CLOSE, __func__);
+#endif /* USE_MPE */
+
     return ierr;
 }
 
@@ -305,7 +316,8 @@ int PIOc_closefile(int ncid)
  * @returns PIO_NOERR for success, error code otherwise.
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_deletefile(int iosysid, const char *filename)
+int
+PIOc_deletefile(int iosysid, const char *filename)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     int ierr = PIO_NOERR;  /* Return code from function calls. */
@@ -313,7 +325,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
     int msg = PIO_MSG_DELETE_FILE;
     size_t len;
 
-    LOG((1, "PIOc_deletefile iosysid = %d filename = %s", iosysid, filename));
+    PLOG((1, "PIOc_deletefile iosysid = %d filename = %s", iosysid, filename));
 
     /* Get the IO system info from the id. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
@@ -333,7 +345,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
             if (!mpierr)
                 mpierr = MPI_Bcast((void *)filename, len + 1, MPI_CHAR, ios->compmaster,
                                    ios->intercomm);
-            LOG((2, "Bcast len = %d filename = %s", len, filename));
+            PLOG((2, "Bcast len = %d filename = %s", len, filename));
         }
 
         /* Handle MPI errors. */
@@ -341,7 +353,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
             return check_mpi(ios, NULL, mpierr2, __FILE__, __LINE__);
         if (mpierr)
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-        LOG((3, "done hanlding errors mpierr = %d", mpierr));
+        PLOG((3, "done hanlding errors mpierr = %d", mpierr));
     }
 
     /* If this is an IO task, then call the netCDF function. The
@@ -358,7 +370,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
         if (!mpierr)
             mpierr = MPI_Barrier(ios->io_comm);
     }
-    LOG((2, "PIOc_deletefile ierr = %d", ierr));
+    PLOG((2, "PIOc_deletefile ierr = %d", ierr));
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
@@ -382,14 +394,15 @@ int PIOc_deletefile(int iosysid, const char *filename)
  * @ingroup PIO_sync_file_c
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_sync(int ncid)
+int
+PIOc_sync(int ncid)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;  /* Return code from function calls. */
 
-    LOG((1, "PIOc_sync ncid = %d", ncid));
+    PLOG((1, "PIOc_sync ncid = %d", ncid));
 
     /* Get the file info from the ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -403,18 +416,18 @@ int PIOc_sync(int ncid)
         {
             wmulti_buffer *wmb, *twmb;
 
-            LOG((3, "PIOc_sync checking buffers"));
-	    HASH_ITER(hh, file->buffer, wmb, twmb)
-	      {  
+            PLOG((3, "PIOc_sync checking buffers"));
+            HASH_ITER(hh, file->buffer, wmb, twmb)
+            {
                 /* If there are any data arrays waiting in the
                  * multibuffer, flush it. */
                 if (wmb->num_arrays > 0)
                     flush_buffer(ncid, wmb, true);
-		HASH_DEL(file->buffer, wmb);
-		brel(wmb);
-                
-	      }
-	    file->buffer = NULL;
+                HASH_DEL(file->buffer, wmb);
+                brel(wmb);
+
+            }
+            file->buffer = NULL;
         }
     }
 
@@ -465,7 +478,7 @@ int PIOc_sync(int ncid)
                 return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__);
             }
         }
-        LOG((2, "PIOc_sync ierr = %d", ierr));
+        PLOG((2, "PIOc_sync ierr = %d", ierr));
     }
 
     /* Broadcast and check the return code. */

--- a/cime/src/externals/pio2/src/clib/pio_get_nc.c
+++ b/cime/src/externals/pio2/src/clib/pio_get_nc.c
@@ -1039,7 +1039,7 @@ int PIOc_get_var1_ushort(int ncid, int varid, const PIO_Offset *index, unsigned 
 int PIOc_get_var1_short(int ncid, int varid, const PIO_Offset *index, short *buf)
 {
     int ret = PIOc_get_var1_tc(ncid, varid, index, NC_SHORT, buf);
-    LOG((1, "PIOc_get_var1_short returned %d", ret));
+    PLOG((1, "PIOc_get_var1_short returned %d", ret));
     return ret;
 }
 

--- a/cime/src/externals/pio2/src/clib/pio_get_vard.c
+++ b/cime/src/externals/pio2/src/clib/pio_get_vard.c
@@ -1,12 +1,12 @@
 /**
- * @file
- * PIO functions to get data with distributed arrays.
- *
- * @author Ed Hartnett
- * @date  2019
- *
- * @see https://github.com/NCAR/ParallelIO
- */
+  * @file
+  * PIO functions to get data with distributed arrays.
+  *
+  * @author Ed Hartnett
+  * @date  2019
+  *
+  * @see https://github.com/NCAR/ParallelIO
+  */
 #include <config.h>
 #include <pio.h>
 #include <pio_internal.h>

--- a/cime/src/externals/pio2/src/clib/pio_getput_int.c
+++ b/cime/src/externals/pio2/src/clib/pio_getput_int.c
@@ -48,8 +48,8 @@ PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     if (!name || !op || strlen(name) > NC_MAX_NAME || len < 0)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_put_att_tc ncid = %d varid = %d name = %s atttype = %d len = %d memtype = %d",
-         ncid, varid, name, atttype, len, memtype));
+    PLOG((1, "PIOc_put_att_tc ncid = %d varid = %d name = %s atttype = %d len = %d memtype = %d",
+          ncid, varid, name, atttype, len, memtype));
 
     /* Run these on all tasks if async is not in use, but only on
      * non-IO tasks if async is in use. */
@@ -67,7 +67,7 @@ PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             if ((ierr = PIOc_inq_type(ncid, memtype, NULL, &memtype_len)))
                 return check_netcdf(file, ierr, __FILE__, __LINE__);
         }
-        LOG((2, "PIOc_put_att atttype_len = %d memtype_len = %d", ncid, atttype_len, memtype_len));
+        PLOG((2, "PIOc_put_att atttype_len = %d memtype_len = %d", ncid, atttype_len, memtype_len));
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -102,9 +102,9 @@ PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             if (!mpierr)
                 mpierr = MPI_Bcast((void *)op, len * memtype_len, MPI_BYTE, ios->compmaster,
                                    ios->intercomm);
-            LOG((2, "PIOc_put_att finished bcast ncid = %d varid = %d namelen = %d name = %s "
-                 "len = %d atttype_len = %d memtype = %d memtype_len = %d", ncid, varid, namelen,
-                 name, len, atttype_len, memtype, memtype_len));
+            PLOG((2, "PIOc_put_att finished bcast ncid = %d varid = %d namelen = %d name = %s "
+                  "len = %d atttype_len = %d memtype = %d memtype_len = %d", ncid, varid, namelen,
+                  name, len, atttype_len, memtype, memtype_len));
         }
 
         /* Handle MPI errors. */
@@ -118,8 +118,8 @@ PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         if ((mpierr = MPI_Bcast(&memtype_len, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
             check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        LOG((2, "PIOc_put_att bcast from comproot = %d atttype_len = %d", ios->comproot,
-             atttype_len, memtype_len));
+        PLOG((2, "PIOc_put_att bcast from comproot = %d atttype_len = %d", ios->comproot,
+              atttype_len, memtype_len));
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -193,7 +193,7 @@ PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                 ierr = nc_put_att_uint(file->fh, varid, name, atttype, len, op);
                 break;
             case NC_INT64:
-                LOG((3, "about to call nc_put_att_longlong"));
+                PLOG((3, "about to call nc_put_att_longlong"));
                 ierr = nc_put_att_longlong(file->fh, varid, name, atttype, len, op);
                 break;
             case NC_UINT64:
@@ -257,8 +257,8 @@ PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void *ip
     if (!name || !ip || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_get_att_tc ncid %d varid %d name %s memtype %d",
-         ncid, varid, name, memtype));
+    PLOG((1, "PIOc_get_att_tc ncid %d varid %d name %s memtype %d",
+          ncid, varid, name, memtype));
 
     /* Run these on all tasks if async is not in use, but only on
      * non-IO tasks if async is in use. */
@@ -267,7 +267,7 @@ PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void *ip
         /* Get the type and length of the attribute. */
         if ((ierr = PIOc_inq_att(ncid, varid, name, &atttype, &attlen)))
             return check_netcdf(file, ierr, __FILE__, __LINE__);
-        LOG((2, "atttype = %d attlen = %d", atttype, attlen));
+        PLOG((2, "atttype = %d attlen = %d", atttype, attlen));
 
         /* Get the length (in bytes) of the type of the attribute. */
         if ((ierr = PIOc_inq_type(ncid, atttype, NULL, &atttype_len)))
@@ -283,7 +283,7 @@ PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void *ip
                 return check_netcdf(file, ierr, __FILE__, __LINE__);
         }
     }
-    LOG((2, "atttype_len = %d memtype_len = %d", atttype_len, memtype_len));
+    PLOG((2, "atttype_len = %d memtype_len = %d", atttype_len, memtype_len));
 
     /* If async is in use, and this is not an IO task, bcast the
      * parameters and the attribute and type information we fetched. */
@@ -292,7 +292,7 @@ PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void *ip
         if (!ios->ioproc)
         {
             int msg = PIO_MSG_GET_ATT;
-            LOG((2, "sending parameters"));
+            PLOG((2, "sending parameters"));
 
             /* Send the message to IO master. */
             if (ios->compmaster == MPI_ROOT)
@@ -320,9 +320,9 @@ PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void *ip
                 mpierr = MPI_Bcast(&memtype, 1, MPI_INT, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&memtype_len, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
-            LOG((2, "Bcast complete ncid = %d varid = %d namelen = %d name = %s iotype = %d "
-                 "atttype = %d attlen = %d atttype_len = %d", ncid, varid, namelen, name, file->iotype,
-                 atttype, attlen, atttype_len));
+            PLOG((2, "Bcast complete ncid = %d varid = %d namelen = %d name = %s iotype = %d "
+                  "atttype = %d attlen = %d atttype_len = %d", ncid, varid, namelen, name, file->iotype,
+                  atttype, attlen, atttype_len));
         }
 
         /* Handle MPI errors. */
@@ -330,24 +330,24 @@ PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void *ip
             check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        LOG((2, "mpi errors handled"));
+        PLOG((2, "mpi errors handled"));
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
-        LOG((2, "PIOc_get_att_tc bcast from comproot = %d attlen = %d atttype_len = %d", ios->comproot, attlen, atttype_len));
+        PLOG((2, "PIOc_get_att_tc bcast from comproot = %d attlen = %d atttype_len = %d", ios->comproot, attlen, atttype_len));
         if ((mpierr = MPI_Bcast(&attlen, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         if ((mpierr = MPI_Bcast(&atttype_len, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         if ((mpierr = MPI_Bcast(&memtype_len, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        LOG((2, "PIOc_get_att_tc bcast complete attlen = %d atttype_len = %d memtype_len = %d", attlen, atttype_len,
-             memtype_len));
+        PLOG((2, "PIOc_get_att_tc bcast complete attlen = %d atttype_len = %d memtype_len = %d", attlen, atttype_len,
+              memtype_len));
     }
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
-        LOG((2, "calling pnetcdf/netcdf"));
+        PLOG((2, "calling pnetcdf/netcdf"));
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
@@ -416,7 +416,7 @@ PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void *ip
                 ierr = nc_get_att_uint(file->fh, varid, name, ip);
                 break;
             case NC_INT64:
-                LOG((3, "about to call nc_get_att_longlong"));
+                PLOG((3, "about to call nc_get_att_longlong"));
                 ierr = nc_get_att_longlong(file->fh, varid, name, ip);
                 break;
             case NC_UINT64:
@@ -433,19 +433,19 @@ PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void *ip
     }
 
     /* Broadcast and check the return code. */
-    LOG((2, "ierr = %d", ierr));
+    PLOG((2, "ierr = %d", ierr));
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     if (ierr)
         return check_netcdf(file, ierr, __FILE__, __LINE__);
 
     /* Broadcast results to all tasks. */
-    LOG((2, "bcasting att values attlen = %d memtype_len = %d", attlen, memtype_len));
+    PLOG((2, "bcasting att values attlen = %d memtype_len = %d", attlen, memtype_len));
     if ((mpierr = MPI_Bcast(ip, (int)attlen * memtype_len, MPI_BYTE, ios->ioroot,
                             ios->my_comm)))
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
-    LOG((2, "get_att_tc data bcast complete"));
+    PLOG((2, "get_att_tc data bcast complete"));
     return PIO_NOERR;
 }
 
@@ -502,9 +502,9 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr;                           /* Return code. */
 
-    LOG((1, "PIOc_get_vars_tc ncid = %d varid = %d xtype = %d start_present = %d "
-         "count_present = %d stride_present = %d", ncid, varid, xtype, start_present,
-         count_present, stride_present));
+    PLOG((1, "PIOc_get_vars_tc ncid = %d varid = %d xtype = %d start_present = %d "
+          "count_present = %d stride_present = %d", ncid, varid, xtype, start_present,
+          count_present, stride_present));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -539,7 +539,7 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
         /* Get the number of dims for this var. */
         if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
             return check_netcdf(file, ierr, __FILE__, __LINE__);
-        LOG((3, "ndims = %d", ndims));
+        PLOG((3, "ndims = %d", ndims));
 
         /* Only scalar vars can pass NULL for start/count. */
         pioassert(ndims == 0 || (start && count), "need start/count", __FILE__, __LINE__);
@@ -548,7 +548,7 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
          * num_elem will remain 1). */
         for (int vd = 0; vd < ndims; vd++)
             num_elem *= count[vd];
-        LOG((2, "PIOc_get_vars_tc num_elem = %d", num_elem));
+        PLOG((2, "PIOc_get_vars_tc num_elem = %d", num_elem));
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -587,9 +587,9 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
                 mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_get_vars_tc ncid = %d varid = %d ndims = %d start_present = %d "
-                 "count_present = %d stride_present = %d xtype = %d num_elem = %d", ncid, varid,
-                 ndims, start_present, count_present, stride_present, xtype, num_elem));
+            PLOG((2, "PIOc_get_vars_tc ncid = %d varid = %d ndims = %d start_present = %d "
+                  "count_present = %d stride_present = %d xtype = %d num_elem = %d", ncid, varid,
+                  ndims, start_present, count_present, stride_present, xtype, num_elem));
         }
 
         /* Handle MPI errors. */
@@ -613,7 +613,7 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
     {
         if (!stride_present)
         {
-            LOG((2, "stride not present "));
+            PLOG((2, "stride not present "));
             if (!(fake_stride = malloc(ndims * sizeof(PIO_Offset))))
                 return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
             for (int d = 0; d < ndims; d++)
@@ -627,11 +627,11 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
     if (ios->ioproc)
     {
 
-        LOG((2, "file->iotype = %d xtype = %d file->do_io = %d", file->iotype, xtype, file->do_io));
+        PLOG((2, "file->iotype = %d xtype = %d file->do_io = %d", file->iotype, xtype, file->do_io));
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
-            LOG((2, "pnetcdf calling ncmpi_get_vars_*() file->fh = %d varid = %d", file->fh, varid));
+            PLOG((2, "pnetcdf calling ncmpi_get_vars_*() file->fh = %d varid = %d", file->fh, varid));
             /* Turn on independent access for pnetcdf file. */
             if ((ierr = ncmpi_begin_indep_data(file->fh)))
                 return pio_err(ios, file, ierr, __FILE__, __LINE__);
@@ -674,12 +674,12 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
         }
 #endif /* _PNETCDF */
 
-        LOG((2, "duck ndims %d", ndims));
+        PLOG((2, "duck ndims %d", ndims));
         for (int d = 0; d < ndims; d++)
         {
-            LOG((2, "start[%d]  %d", d, start[d]));
-            LOG((2, "count[%d]  %d", d, count[d]));
-            LOG((2, "fake_stride[%d]  %d", d, fake_stride[d]));
+            PLOG((2, "start[%d]  %d", d, start[d]));
+            PLOG((2, "count[%d]  %d", d, count[d]));
+            PLOG((2, "fake_stride[%d]  %d", d, fake_stride[d]));
         }
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
@@ -728,7 +728,7 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
                                         (ptrdiff_t *)fake_stride, buf);
                 break;
             case NC_INT64:
-                LOG((3, "about to call nc_get_vars_longlong"));
+                PLOG((3, "about to call nc_get_vars_longlong"));
                 ierr = nc_get_vars_longlong(file->fh, varid, (size_t *)start, (size_t *)count,
                                             (ptrdiff_t *)fake_stride, buf);
                 break;
@@ -748,10 +748,10 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
 
     }
 
-    LOG((2, "howdy ndims %d", ndims));
+    PLOG((2, "howdy ndims %d", ndims));
     for (int d = 0; d < ndims; d++)
     {
-        LOG((2, "fake_stride[%d]  %d", d, fake_stride[d]));
+        PLOG((2, "fake_stride[%d]  %d", d, fake_stride[d]));
     }
 
     /* Free malloced resources. */
@@ -765,11 +765,11 @@ PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
         return check_netcdf(file, ierr, __FILE__, __LINE__);
 
     /* Send the data. */
-    LOG((2, "PIOc_get_vars_tc bcasting data num_elem = %d typelen = %d ios->ioroot = %d", num_elem,
-         typelen, ios->ioroot));
+    PLOG((2, "PIOc_get_vars_tc bcasting data num_elem = %d typelen = %d ios->ioroot = %d", num_elem,
+          typelen, ios->ioroot));
     if ((mpierr = MPI_Bcast(buf, num_elem * typelen, MPI_BYTE, ios->ioroot, ios->my_comm)))
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-    LOG((2, "PIOc_get_vars_tc bcasting data complete"));
+    PLOG((2, "PIOc_get_vars_tc bcasting data complete"));
 
     return PIO_NOERR;
 }
@@ -840,8 +840,8 @@ PIOc_get_var_tc(int ncid, int varid, nc_type xtype, void *buf)
     int ndims;   /* The number of dimensions in the variable. */
     int ierr;    /* Return code from function calls. */
 
-    LOG((1, "PIOc_get_var_tc ncid = %d varid = %d xtype = %d", ncid, varid,
-         xtype));
+    PLOG((1, "PIOc_get_var_tc ncid = %d varid = %d xtype = %d", ncid, varid,
+          xtype));
 
     /* Find the info about this file. We need this for error handling. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -883,8 +883,8 @@ PIOc_get_var_tc(int ncid, int varid, nc_type xtype, void *buf)
         for (int d = 0; d < ndims; d++)
         {
             startp[d] = 0;
-            LOG((3, "startp[%d] = %d countp[%d] = %d", d, startp[d], d,
-                 countp[d]));
+            PLOG((3, "startp[%d] = %d countp[%d] = %d", d, startp[d], d,
+                  countp[d]));
         }
 
     }
@@ -951,9 +951,9 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr;          /* Return code from function calls. */
 
-    LOG((1, "PIOc_put_vars_tc ncid = %d varid = %d start_present = %d "
-         "count_present = %d stride_present = %d xtype = %d", ncid, varid,
-         start_present, count_present, stride_present, xtype));
+    PLOG((1, "PIOc_put_vars_tc ncid = %d varid = %d start_present = %d "
+          "count_present = %d stride_present = %d xtype = %d", ncid, varid,
+          start_present, count_present, stride_present, xtype));
 
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -989,7 +989,7 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
                 return check_netcdf(file, ierr, __FILE__, __LINE__);
         }
 
-        LOG((2, "ndims = %d typelen = %d", ndims, typelen));
+        PLOG((2, "ndims = %d typelen = %d", ndims, typelen));
 
         /* How many elements of data? If no count array was passed,
          * this is a scalar. */
@@ -1034,9 +1034,9 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
                 mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_put_vars_tc ncid = %d varid = %d ndims = %d start_present = %d "
-                 "count_present = %d stride_present = %d xtype = %d num_elem = %d", ncid, varid,
-                 ndims, start_present, count_present, stride_present, xtype, num_elem));
+            PLOG((2, "PIOc_put_vars_tc ncid = %d varid = %d ndims = %d start_present = %d "
+                  "count_present = %d stride_present = %d xtype = %d num_elem = %d", ncid, varid,
+                  ndims, start_present, count_present, stride_present, xtype, num_elem));
 
             /* Send the data. */
             if (!mpierr)
@@ -1049,15 +1049,15 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
             return check_mpi(NULL, file, mpierr2, __FILE__, __LINE__);
         if (mpierr)
             check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        LOG((2, "PIOc_put_vars_tc checked mpierr = %d", mpierr));
+        PLOG((2, "PIOc_put_vars_tc checked mpierr = %d", mpierr));
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
-        LOG((2, "PIOc_put_vars_tc bcast from comproot"));
+        PLOG((2, "PIOc_put_vars_tc bcast from comproot"));
         if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->comproot, ios->my_comm)))
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->comproot, ios->my_comm)))
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        LOG((2, "PIOc_put_vars_tc complete bcast from comproot ndims = %d", ndims));
+        PLOG((2, "PIOc_put_vars_tc complete bcast from comproot ndims = %d", ndims));
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -1067,7 +1067,7 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
         {
             if (!stride_present)
             {
-                LOG((2, "stride not present"));
+                PLOG((2, "stride not present"));
                 if (!(fake_stride = malloc(ndims * sizeof(PIO_Offset))))
                     return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
                 for (int d = 0; d < ndims; d++)
@@ -1084,8 +1084,8 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
             if (ndims == 0)
             {
                 /* This is a scalar var. */
-                LOG((2, "pnetcdf writing scalar with ncmpi_put_vars_*() file->fh = %d varid = %d",
-                     file->fh, varid));
+                PLOG((2, "pnetcdf writing scalar with ncmpi_put_vars_*() file->fh = %d varid = %d",
+                      file->fh, varid));
                 pioassert(!start && !count && !stride, "expected NULLs", __FILE__, __LINE__);
 
                 /* Turn on independent access for pnetcdf file. */
@@ -1134,7 +1134,7 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
                 var_desc_t *vdesc;
                 int *request;
 
-                LOG((2, "PIOc_put_vars_tc calling pnetcdf function"));
+                PLOG((2, "PIOc_put_vars_tc calling pnetcdf function"));
                 /*vdesc = &file->varlist[varid];*/
                 if ((ierr = get_var_desc(varid, &file->varlist, &vdesc)))
                     return pio_err(ios, file, ierr, __FILE__, __LINE__);
@@ -1143,7 +1143,7 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
                                                    sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                         return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
                 request = vdesc->request + vdesc->nreqs;
-                LOG((2, "PIOc_put_vars_tc request = %d", vdesc->request));
+                PLOG((2, "PIOc_put_vars_tc request = %d", vdesc->request));
 
                 /* Only the IO master actually does the call. */
                 if (ios->iomaster == MPI_ROOT)
@@ -1174,14 +1174,14 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
                     default:
                         return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
                     }
-                    LOG((2, "PIOc_put_vars_tc io_rank 0 done with pnetcdf call, ierr=%d", ierr));
+                    PLOG((2, "PIOc_put_vars_tc io_rank 0 done with pnetcdf call, ierr=%d", ierr));
                 }
                 else
                     *request = PIO_REQ_NULL;
 
                 vdesc->nreqs++;
                 flush_output_buffer(file, false, 0);
-                LOG((2, "PIOc_put_vars_tc flushed output buffer"));
+                PLOG((2, "PIOc_put_vars_tc flushed output buffer"));
 
             } /* endif ndims == 0 */
         }
@@ -1189,8 +1189,8 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
-            LOG((2, "PIOc_put_vars_tc calling netcdf function file->iotype = %d",
-                 file->iotype));
+            PLOG((2, "PIOc_put_vars_tc calling netcdf function file->iotype = %d",
+                  file->iotype));
             switch(xtype)
             {
             case NC_BYTE:
@@ -1250,7 +1250,7 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
             default:
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
             }
-            LOG((2, "PIOc_put_vars_tc io_rank 0 done with netcdf call, ierr=%d", ierr));
+            PLOG((2, "PIOc_put_vars_tc io_rank 0 done with netcdf call, ierr=%d", ierr));
         }
 
         /* Free malloced resources. */
@@ -1266,7 +1266,7 @@ PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Offset 
     /*     return check_mpi(NULL, file, mpierr, __FILE__, __LINE__); */
     /* if (ierr) */
     /*     return check_netcdf(file, ierr, __FILE__, __LINE__); */
-    LOG((2, "PIOc_put_vars_tc bcast netcdf return code %d complete", ierr));
+    PLOG((2, "PIOc_put_vars_tc bcast netcdf return code %d complete", ierr));
 
     return PIO_NOERR;
 }
@@ -1362,8 +1362,8 @@ PIOc_put_var_tc(int ncid, int varid, nc_type xtype, const void *op)
     int ndims;   /* The number of dimensions in the variable. */
     int ierr;    /* Return code from function calls. */
 
-    LOG((1, "PIOc_put_var_tc ncid = %d varid = %d xtype = %d", ncid,
-         varid, xtype));
+    PLOG((1, "PIOc_put_var_tc ncid = %d varid = %d xtype = %d", ncid,
+          varid, xtype));
 
     /* Find the info about this file. We need this for error handling. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -1454,8 +1454,8 @@ PIOc_get_vard_tc(int ncid, int varid, int decompid, const PIO_Offset recnum,
     var_desc_t *vdesc;     /* Pointer to var information. */
     int ret;
 
-    LOG((1, "PIOc_get_vard_tc ncid %d varid %d decompid %d recnum %d "
-         "xtype %d", ncid, varid, decompid, recnum, xtype));
+    PLOG((1, "PIOc_get_vard_tc ncid %d varid %d decompid %d recnum %d "
+          "xtype %d", ncid, varid, decompid, recnum, xtype));
 
     /* Get file info. */
     if ((ret = pio_get_file(ncid, &file)))
@@ -1469,7 +1469,7 @@ PIOc_get_vard_tc(int ncid, int varid, int decompid, const PIO_Offset recnum,
     /* Get var info. */
     if ((ret = get_var_desc(varid, &file->varlist, &vdesc)))
         return pio_err(ios, file, ret, __FILE__, __LINE__);
-    LOG((2, "vdesc->pio_type %d", vdesc->pio_type));
+    PLOG((2, "vdesc->pio_type %d", vdesc->pio_type));
 
     /* Disallow type conversion for now. */
     if (xtype != NC_NAT && xtype != vdesc->pio_type)

--- a/cime/src/externals/pio2/src/clib/pio_lists.c
+++ b/cime/src/externals/pio2/src/clib/pio_lists.c
@@ -49,7 +49,7 @@ pio_get_file(int ncid, file_desc_t **cfile1)
 {
     file_desc_t *cfile = NULL;
 
-    LOG((2, "pio_get_file ncid = %d", ncid));
+    PLOG((2, "pio_get_file ncid = %d", ncid));
 
     /* Caller must provide this. */
     if (!cfile1)
@@ -133,11 +133,11 @@ pio_delete_iosystem_from_list(int piosysid)
 {
     iosystem_desc_t *ciosystem, *piosystem = NULL;
 
-    LOG((1, "pio_delete_iosystem_from_list piosysid = %d", piosysid));
+    PLOG((1, "pio_delete_iosystem_from_list piosysid = %d", piosysid));
 
     for (ciosystem = pio_iosystem_list; ciosystem; ciosystem = ciosystem->next)
     {
-        LOG((3, "ciosystem->iosysid = %d", ciosystem->iosysid));
+        PLOG((3, "ciosystem->iosysid = %d", ciosystem->iosysid));
         if (ciosystem->iosysid == piosysid)
         {
             if (piosystem == NULL)
@@ -199,7 +199,7 @@ pio_get_iosystem_from_id(int iosysid)
 {
     iosystem_desc_t *ciosystem;
 
-    LOG((2, "pio_get_iosystem_from_id iosysid = %d", iosysid));
+    PLOG((2, "pio_get_iosystem_from_id iosysid = %d", iosysid));
 
     for (ciosystem = pio_iosystem_list; ciosystem; ciosystem = ciosystem->next)
         if (ciosystem->iosysid == iosysid)
@@ -223,7 +223,7 @@ pio_num_iosystem(int *niosysid)
     /* Count the elements in the list. */
     for (iosystem_desc_t *c = pio_iosystem_list; c; c = c->next)
     {
-        LOG((3, "pio_num_iosystem c->iosysid %d", c->iosysid));
+        PLOG((3, "pio_num_iosystem c->iosysid %d", c->iosysid));
         count++;
     }
 

--- a/cime/src/externals/pio2/src/clib/pio_msg.c
+++ b/cime/src/externals/pio2/src/clib/pio_msg.c
@@ -1,4 +1,5 @@
-/** @file
+/**
+ * @file
  *
  * PIO async message handling. This file contains the code which
  * runs on the IO nodes when async is in use. This code waits for
@@ -22,6 +23,11 @@ extern int my_rank;
 extern int pio_log_level;
 #endif /* PIO_ENABLE_LOGGING */
 
+#ifdef USE_MPE
+/* The event numbers for MPE logging. */
+extern int event_num[2][NUM_EVENTS];
+#endif /* USE_MPE */
+
 /**
  * This function is run on the IO tasks to handle nc_inq_type*()
  * functions.
@@ -41,7 +47,7 @@ int inq_type_handler(iosystem_desc_t *ios)
     PIO_Offset *sizep = NULL, size;
     int mpierr;
 
-    LOG((1, "inq_type_handler"));
+    PLOG((1, "inq_type_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -64,7 +70,7 @@ int inq_type_handler(iosystem_desc_t *ios)
     /* Call the function. */
     PIOc_inq_type(ncid, xtype, namep, sizep);
 
-    LOG((1, "inq_type_handler succeeded!"));
+    PLOG((1, "inq_type_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -85,7 +91,7 @@ int inq_format_handler(iosystem_desc_t *ios)
     char format_present;
     int mpierr;
 
-    LOG((1, "inq_format_handler"));
+    PLOG((1, "inq_format_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -94,8 +100,8 @@ int inq_format_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&format_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "inq_format_handler got parameters ncid = %d format_present = %d",
-         ncid, format_present));
+    PLOG((2, "inq_format_handler got parameters ncid = %d format_present = %d",
+          ncid, format_present));
 
     /* Manage NULL pointers. */
     if (format_present)
@@ -104,7 +110,7 @@ int inq_format_handler(iosystem_desc_t *ios)
     /* Call the function. */
     PIOc_inq_format(ncid, formatp);
 
-    LOG((1, "inq_format_handler succeeded!"));
+    PLOG((1, "inq_format_handler succeeded!"));
 
     return PIO_NOERR;
 }
@@ -125,7 +131,7 @@ int set_fill_handler(iosystem_desc_t *ios)
     int old_mode, *old_modep = NULL;
     int mpierr;
 
-    LOG((1, "set_fill_handler"));
+    PLOG((1, "set_fill_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -136,8 +142,8 @@ int set_fill_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&old_modep_present, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "set_fill_handler got parameters ncid = %d fillmode = %d old_modep_present = %d",
-         ncid, fillmode, old_modep_present));
+    PLOG((2, "set_fill_handler got parameters ncid = %d fillmode = %d old_modep_present = %d",
+          ncid, fillmode, old_modep_present));
 
     /* Manage NULL pointers. */
     if (old_modep_present)
@@ -146,7 +152,7 @@ int set_fill_handler(iosystem_desc_t *ios)
     /* Call the function. */
     PIOc_set_fill(ncid, fillmode, old_modep);
 
-    LOG((1, "set_fill_handler succeeded!"));
+    PLOG((1, "set_fill_handler succeeded!"));
 
     return PIO_NOERR;
 }
@@ -168,7 +174,7 @@ int create_file_handler(iosystem_desc_t *ios)
     int mode;
     int mpierr;
 
-    LOG((1, "create_file_handler comproot = %d", ios->comproot));
+    PLOG((1, "create_file_handler comproot = %d", ios->comproot));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
@@ -185,14 +191,14 @@ int create_file_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&mode, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "create_file_handler got parameters len = %d filename = %s iotype = %d mode = %d",
-         len, filename, iotype, mode));
+    PLOG((1, "create_file_handler got parameters len = %d filename = %s iotype = %d mode = %d",
+          len, filename, iotype, mode));
 
     /* Call the create file function. */
     PIOc_createfile(ios->iosysid, &ncid, &iotype, filename, mode);
 
 
-    LOG((1, "create_file_handler succeeded!"));
+    PLOG((1, "create_file_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -211,19 +217,19 @@ int close_file_handler(iosystem_desc_t *ios)
     int ncid;
     int mpierr;
 
-    LOG((1, "close_file_handler"));
+    PLOG((1, "close_file_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "close_file_handler got parameter ncid = %d", ncid));
+    PLOG((1, "close_file_handler got parameter ncid = %d", ncid));
 
     /* Call the close file function. */
     PIOc_closefile(ncid);
 
-    LOG((1, "close_file_handler succeeded!"));
+    PLOG((1, "close_file_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -245,7 +251,7 @@ int inq_handler(iosystem_desc_t *ios)
     char ndims_present, nvars_present, ngatts_present, unlimdimid_present;
     int mpierr;
 
-    LOG((1, "inq_handler"));
+    PLOG((1, "inq_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -260,8 +266,8 @@ int inq_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&unlimdimid_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "inq_handler ndims_present = %d nvars_present = %d ngatts_present = %d unlimdimid_present = %d",
-         ndims_present, nvars_present, ngatts_present, unlimdimid_present));
+    PLOG((1, "inq_handler ndims_present = %d nvars_present = %d ngatts_present = %d unlimdimid_present = %d",
+          ndims_present, nvars_present, ngatts_present, unlimdimid_present));
 
     /* NULLs passed in to any of the pointers in the original call
      * need to be matched with NULLs here. Assign pointers where
@@ -300,7 +306,7 @@ int inq_unlimdims_handler(iosystem_desc_t *ios)
     char nunlimdimsp_present, unlimdimidsp_present;
     int mpierr;
 
-    LOG((1, "inq_unlimdims_handler"));
+    PLOG((1, "inq_unlimdims_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -311,8 +317,8 @@ int inq_unlimdims_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&unlimdimidsp_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "inq_unlimdims_handler nunlimdimsp_present = %d unlimdimidsp_present = %d",
-         nunlimdimsp_present, unlimdimidsp_present));
+    PLOG((1, "inq_unlimdims_handler nunlimdimsp_present = %d unlimdimidsp_present = %d",
+          nunlimdimsp_present, unlimdimidsp_present));
 
     /* NULLs passed in to any of the pointers in the original call
      * need to be matched with NULLs here. Assign pointers where
@@ -349,7 +355,7 @@ int inq_dim_handler(iosystem_desc_t *ios, int msg)
     PIO_Offset dimlen;
     int mpierr;
 
-    LOG((1, "inq_dim_handler"));
+    PLOG((1, "inq_dim_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -362,8 +368,8 @@ int inq_dim_handler(iosystem_desc_t *ios, int msg)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&len_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "inq_handler name_present = %d len_present = %d", name_present,
-         len_present));
+    PLOG((2, "inq_handler name_present = %d len_present = %d", name_present,
+          len_present));
 
     /* Set the non-null pointers. */
     if (name_present)
@@ -395,7 +401,7 @@ int inq_dimid_handler(iosystem_desc_t *ios)
     char name[PIO_MAX_NAME + 1];
     int mpierr;
 
-    LOG((1, "inq_dimid_handler"));
+    PLOG((1, "inq_dimid_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -408,8 +414,8 @@ int inq_dimid_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&id_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "inq_dimid_handler ncid = %d namelen = %d name = %s id_present = %d",
-         ncid, namelen, name, id_present));
+    PLOG((1, "inq_dimid_handler ncid = %d namelen = %d name = %s id_present = %d",
+          ncid, namelen, name, id_present));
 
     /* Set non-null pointer. */
     if (id_present)
@@ -441,7 +447,7 @@ int inq_att_handler(iosystem_desc_t *ios)
     char xtype_present, len_present;
     int mpierr;
 
-    LOG((1, "inq_att_handler"));
+    PLOG((1, "inq_att_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -490,7 +496,7 @@ int inq_attname_handler(iosystem_desc_t *ios)
     char name_present;
     int mpierr;
 
-    LOG((1, "inq_att_name_handler"));
+    PLOG((1, "inq_att_name_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -503,8 +509,8 @@ int inq_attname_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&name_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "inq_attname_handler got ncid = %d varid = %d attnum = %d name_present = %d",
-         ncid, varid, attnum, name_present));
+    PLOG((2, "inq_attname_handler got ncid = %d varid = %d attnum = %d name_present = %d",
+          ncid, varid, attnum, name_present));
 
     /* Match NULLs in collective function call. */
     if (name_present)
@@ -535,7 +541,7 @@ int inq_attid_handler(iosystem_desc_t *ios)
     char id_present;
     int mpierr;
 
-    LOG((1, "inq_attid_handler"));
+    PLOG((1, "inq_attid_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -550,8 +556,8 @@ int inq_attid_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&id_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "inq_attid_handler got ncid = %d varid = %d id_present = %d",
-         ncid, varid, id_present));
+    PLOG((2, "inq_attid_handler got ncid = %d varid = %d id_present = %d",
+          ncid, varid, id_present));
 
     /* Match NULLs in collective function call. */
     if (id_present)
@@ -585,7 +591,7 @@ int att_put_handler(iosystem_desc_t *ios)
     void *op;
     int mpierr;
 
-    LOG((1, "att_put_handler"));
+    PLOG((1, "att_put_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -617,9 +623,9 @@ int att_put_handler(iosystem_desc_t *ios)
         free(op);
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     }
-    LOG((1, "att_put_handler ncid = %d varid = %d namelen = %d name = %s"
-         "atttype = %d attlen = %d atttype_len = %d memtype = %d memtype_len = 5d",
-         ncid, varid, namelen, name, atttype, attlen, atttype_len, memtype, memtype_len));
+    PLOG((1, "att_put_handler ncid = %d varid = %d namelen = %d name = %s"
+          "atttype = %d attlen = %d atttype_len = %d memtype = %d memtype_len = 5d",
+          ncid, varid, namelen, name, atttype, attlen, atttype_len, memtype, memtype_len));
 
     /* Call the function to write the attribute. */
     PIOc_put_att_tc(ncid, varid, name, atttype, attlen, memtype, op);
@@ -627,7 +633,7 @@ int att_put_handler(iosystem_desc_t *ios)
     /* Free resources. */
     free(op);
 
-    LOG((2, "att_put_handler complete!"));
+    PLOG((2, "att_put_handler complete!"));
     return PIO_NOERR;
 }
 
@@ -654,7 +660,7 @@ int att_get_handler(iosystem_desc_t *ios)
     int *ip;
     int iotype;
 
-    LOG((1, "att_get_handler"));
+    PLOG((1, "att_get_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -679,9 +685,9 @@ int att_get_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&memtype_len, 1, MPI_OFFSET, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "att_get_handler ncid = %d varid = %d namelen = %d name = %s iotype = %d"
-         " atttype = %d attlen = %d atttype_len = %d memtype = %d memtype_len = %d",
-         ncid, varid, namelen, name, iotype, atttype, attlen, atttype_len, memtype, memtype_len));
+    PLOG((1, "att_get_handler ncid = %d varid = %d namelen = %d name = %s iotype = %d"
+          " atttype = %d attlen = %d atttype_len = %d memtype = %d memtype_len = %d",
+          ncid, varid, namelen, name, iotype, atttype, attlen, atttype_len, memtype, memtype_len));
 
     /* Allocate space for the attribute data. */
     if (!(ip = malloc(attlen * memtype_len)))
@@ -721,7 +727,7 @@ int put_vars_handler(iosystem_desc_t *ios)
     PIO_Offset num_elem; /* Number of data elements in the buffer. */
     int mpierr;          /* Error code from MPI function calls. */
 
-    LOG((1, "put_vars_handler"));
+    PLOG((1, "put_vars_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -741,7 +747,7 @@ int put_vars_handler(iosystem_desc_t *ios)
     if (start_present)
         if ((mpierr = MPI_Bcast(start, ndims, MPI_OFFSET, 0, ios->intercomm)))
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "put_vars_handler getting start[0] = %d ndims = %d", start[0], ndims));
+    PLOG((1, "put_vars_handler getting start[0] = %d ndims = %d", start[0], ndims));
     if ((mpierr = MPI_Bcast(&count_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if (count_present)
@@ -758,10 +764,10 @@ int put_vars_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "put_vars_handler ncid = %d varid = %d ndims = %d "
-         "start_present = %d count_present = %d stride_present = %d xtype = %d "
-         "num_elem = %d typelen = %d", ncid, varid, ndims, start_present, count_present,
-         stride_present, xtype, num_elem, typelen));
+    PLOG((1, "put_vars_handler ncid = %d varid = %d ndims = %d "
+          "start_present = %d count_present = %d stride_present = %d xtype = %d "
+          "num_elem = %d typelen = %d", ncid, varid, ndims, start_present, count_present,
+          stride_present, xtype, num_elem, typelen));
 
     /* Allocate room for our data. */
     if (!(buf = malloc(num_elem * typelen)))
@@ -862,7 +868,7 @@ int get_vars_handler(iosystem_desc_t *ios)
     void *buf; /** Buffer for data storage. */
     PIO_Offset num_elem; /** Number of data elements in the buffer. */
 
-    LOG((1, "get_vars_handler"));
+    PLOG((1, "get_vars_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -906,9 +912,9 @@ int get_vars_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "get_vars_handler ncid = %d varid = %d ndims = %d "
-         "stride_present = %d xtype = %d num_elem = %d typelen = %d",
-         ncid, varid, ndims, stride_present, xtype, num_elem, typelen));
+    PLOG((1, "get_vars_handler ncid = %d varid = %d ndims = %d "
+          "stride_present = %d xtype = %d num_elem = %d typelen = %d",
+          ncid, varid, ndims, stride_present, xtype, num_elem, typelen));
 
     /* Allocate room for our data. */
     if (!(buf = malloc(num_elem * typelen)))
@@ -983,7 +989,7 @@ int get_vars_handler(iosystem_desc_t *ios)
     if (stride_present)
         free(stride);
 
-    LOG((1, "get_vars_handler succeeded!"));
+    PLOG((1, "get_vars_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1007,7 +1013,7 @@ int inq_var_handler(iosystem_desc_t *ios)
     int ndims, natts;
     int mpierr;
 
-    LOG((1, "inq_var_handler"));
+    PLOG((1, "inq_var_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -1026,9 +1032,9 @@ int inq_var_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&natts_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2,"inq_var_handler ncid = %d varid = %d name_present = %d xtype_present = %d ndims_present = %d "
-         "dimids_present = %d natts_present = %d",
-         ncid, varid, name_present, xtype_present, ndims_present, dimids_present, natts_present));
+    PLOG((2,"inq_var_handler ncid = %d varid = %d name_present = %d xtype_present = %d ndims_present = %d "
+          "dimids_present = %d natts_present = %d",
+          ncid, varid, name_present, xtype_present, ndims_present, dimids_present, natts_present));
 
     /* Set the non-NULL pointers. */
     if (name_present)
@@ -1038,7 +1044,7 @@ int inq_var_handler(iosystem_desc_t *ios)
     if (ndims_present)
         ndimsp = &ndims;
     if (dimids_present)
-	dimidsp = dimids;
+        dimidsp = dimids;
     if (natts_present)
         nattsp = &natts;
 
@@ -1046,7 +1052,7 @@ int inq_var_handler(iosystem_desc_t *ios)
     PIOc_inq_var(ncid, varid, namep, xtypep, ndimsp, dimidsp, nattsp);
 
     if (ndims_present)
-        LOG((2, "inq_var_handler ndims = %d", ndims));
+        PLOG((2, "inq_var_handler ndims = %d", ndims));
 
     return PIO_NOERR;
 }
@@ -1069,7 +1075,7 @@ int inq_var_chunking_handler(iosystem_desc_t *ios)
     int mpierr;
 
     assert(ios);
-    LOG((1, "inq_var_chunking_handler"));
+    PLOG((1, "inq_var_chunking_handler"));
 
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
@@ -1083,8 +1089,8 @@ int inq_var_chunking_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&chunksizes_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2,"inq_var_handler ncid = %d varid = %d storage_present = %d chunksizes_present = %d",
-         ncid, varid, storage_present, chunksizes_present));
+    PLOG((2,"inq_var_handler ncid = %d varid = %d storage_present = %d chunksizes_present = %d",
+          ncid, varid, storage_present, chunksizes_present));
 
     /* Set the non-NULL pointers. */
     if (storage_present)
@@ -1097,7 +1103,7 @@ int inq_var_chunking_handler(iosystem_desc_t *ios)
     PIOc_inq_var_chunking(ncid, varid, storagep, chunksizesp);
 
     if(chunksizes_present)
-	free(chunksizesp);
+        free(chunksizesp);
 
     return PIO_NOERR;
 }
@@ -1120,7 +1126,7 @@ int inq_var_fill_handler(iosystem_desc_t *ios)
     int mpierr;
 
     assert(ios);
-    LOG((1, "inq_var_fill_handler"));
+    PLOG((1, "inq_var_fill_handler"));
 
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
@@ -1134,8 +1140,8 @@ int inq_var_fill_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&fill_value_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2,"inq_var_fill_handler ncid = %d varid = %d type_size = %lld, fill_mode_present = %d fill_value_present = %d",
-         ncid, varid, type_size, fill_mode_present, fill_value_present));
+    PLOG((2,"inq_var_fill_handler ncid = %d varid = %d type_size = %lld, fill_mode_present = %d fill_value_present = %d",
+          ncid, varid, type_size, fill_mode_present, fill_value_present));
 
     /* If we need to, alocate storage for fill value. */
     if (fill_value_present)
@@ -1149,21 +1155,21 @@ int inq_var_fill_handler(iosystem_desc_t *ios)
         fill_valuep = fill_value;
 
     /* Call the inq function to get the values. */
-    LOG((3, "inq_var_fill_handlder about to call inq_var_fill"));
+    PLOG((3, "inq_var_fill_handlder about to call inq_var_fill"));
     PIOc_inq_var_fill(ncid, varid, fill_modep, fill_valuep);
     if (fill_modep)
-        LOG((3, "after inq_var_fill fill_modep %d", *fill_modep));
+        PLOG((3, "after inq_var_fill fill_modep %d", *fill_modep));
 
     /* Free fill value storage if we allocated some. */
     if (fill_value_present)
     {
-        LOG((3, "about to free fill_value"));
+        PLOG((3, "about to free fill_value"));
         free(fill_value);
-        LOG((3, "freed fill_value"));
+        PLOG((3, "freed fill_value"));
     }
 
     if (fill_modep)
-        LOG((3, "done with inq_var_fill_handler", *fill_modep));
+        PLOG((3, "done with inq_var_fill_handler", *fill_modep));
     return PIO_NOERR;
 }
 
@@ -1183,7 +1189,7 @@ int inq_var_endian_handler(iosystem_desc_t *ios)
     int mpierr;
 
     assert(ios);
-    LOG((1, "inq_var_endian_handler"));
+    PLOG((1, "inq_var_endian_handler"));
 
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
@@ -1193,8 +1199,8 @@ int inq_var_endian_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&endian_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2,"inq_var_endian_handler ncid = %d varid = %d endian_present = %d", ncid, varid,
-         endian_present));
+    PLOG((2,"inq_var_endian_handler ncid = %d varid = %d endian_present = %d", ncid, varid,
+          endian_present));
 
     /* Set the non-NULL pointers. */
     if (endian_present)
@@ -1226,7 +1232,7 @@ int inq_var_deflate_handler(iosystem_desc_t *ios)
     int mpierr;
 
     assert(ios);
-    LOG((1, "inq_var_deflate_handler"));
+    PLOG((1, "inq_var_deflate_handler"));
 
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
@@ -1249,9 +1255,9 @@ int inq_var_deflate_handler(iosystem_desc_t *ios)
     if (deflate_level_present && !mpierr)
         if ((mpierr = MPI_Bcast(&deflate_level, 1, MPI_INT, 0, ios->intercomm)))
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "inq_var_handler ncid = %d varid = %d shuffle_present = %d deflate_present = %d "
-         "deflate_level_present = %d", ncid, varid, shuffle_present, deflate_present,
-         deflate_level_present));
+    PLOG((2, "inq_var_handler ncid = %d varid = %d shuffle_present = %d deflate_present = %d "
+          "deflate_level_present = %d", ncid, varid, shuffle_present, deflate_present,
+          deflate_level_present));
 
     /* Set the non-NULL pointers. */
     if (shuffle_present)
@@ -1315,19 +1321,19 @@ int sync_file_handler(iosystem_desc_t *ios)
     int ncid;
     int mpierr;
 
-    LOG((1, "sync_file_handler"));
+    PLOG((1, "sync_file_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&ncid, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "sync_file_handler got parameter ncid = %d", ncid));
+    PLOG((1, "sync_file_handler got parameter ncid = %d", ncid));
 
     /* Call the sync file function. */
     PIOc_sync(ncid);
 
-    LOG((2, "sync_file_handler succeeded!"));
+    PLOG((2, "sync_file_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1348,7 +1354,7 @@ int setframe_handler(iosystem_desc_t *ios)
     int frame;
     int mpierr;
 
-    LOG((1, "setframe_handler"));
+    PLOG((1, "setframe_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the comp master
@@ -1359,13 +1365,13 @@ int setframe_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&frame, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "setframe_handler got parameter ncid = %d varid = %d frame = %d",
-         ncid, varid, frame));
+    PLOG((1, "setframe_handler got parameter ncid = %d varid = %d frame = %d",
+          ncid, varid, frame));
 
     /* Call the function. */
     PIOc_setframe(ncid, varid, frame);
 
-    LOG((2, "setframe_handler succeeded!"));
+    PLOG((2, "setframe_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1385,7 +1391,7 @@ int advanceframe_handler(iosystem_desc_t *ios)
     int varid;
     int mpierr;
 
-    LOG((1, "advanceframe_handler"));
+    PLOG((1, "advanceframe_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the comp master
@@ -1394,13 +1400,13 @@ int advanceframe_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&varid, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "advanceframe_handler got parameter ncid = %d varid = %d",
-         ncid, varid));
+    PLOG((1, "advanceframe_handler got parameter ncid = %d varid = %d",
+          ncid, varid));
 
     /* Call the function. */
     PIOc_advanceframe(ncid, varid);
 
-    LOG((2, "advanceframe_handler succeeded!"));
+    PLOG((2, "advanceframe_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1419,7 +1425,7 @@ int change_def_file_handler(iosystem_desc_t *ios, int msg)
     int ncid;
     int mpierr;
 
-    LOG((1, "change_def_file_handler"));
+    PLOG((1, "change_def_file_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the comp master
@@ -1433,7 +1439,7 @@ int change_def_file_handler(iosystem_desc_t *ios, int msg)
     else
         PIOc_redef(ncid);
 
-    LOG((1, "change_def_file_handler succeeded!"));
+    PLOG((1, "change_def_file_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1458,7 +1464,7 @@ int def_var_handler(iosystem_desc_t *ios)
     int *dimids;
     int mpierr;
 
-    LOG((1, "def_var_handler comproot = %d", ios->comproot));
+    PLOG((1, "def_var_handler comproot = %d", ios->comproot));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
@@ -1480,8 +1486,8 @@ int def_var_handler(iosystem_desc_t *ios)
         free(dimids);
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     }
-    LOG((1, "def_var_handler got parameters namelen = %d "
-         "name = %s ncid = %d", namelen, name, ncid));
+    PLOG((1, "def_var_handler got parameters namelen = %d "
+          "name = %s ncid = %d", namelen, name, ncid));
 
     /* Call the function. */
     PIOc_def_var(ncid, name, xtype, ndims, dimids, &varid);
@@ -1489,7 +1495,7 @@ int def_var_handler(iosystem_desc_t *ios)
     /* Free resources. */
     free(dimids);
 
-    LOG((1, "def_var_handler succeeded!"));
+    PLOG((1, "def_var_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1511,7 +1517,7 @@ int def_var_chunking_handler(iosystem_desc_t *ios)
     int mpierr;
 
     assert(ios);
-    LOG((1, "def_var_chunking_handler comproot = %d", ios->comproot));
+    PLOG((1, "def_var_chunking_handler comproot = %d", ios->comproot));
 
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
@@ -1531,16 +1537,16 @@ int def_var_chunking_handler(iosystem_desc_t *ios)
         if ((mpierr = MPI_Bcast(chunksizesp, ndims, MPI_OFFSET, 0, ios->intercomm)))
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     }
-    LOG((1, "def_var_chunking_handler got parameters ncid = %d varid = %d storage = %d "
-         "ndims = %d chunksizes_present = %d", ncid, varid, storage, ndims, chunksizes_present));
+    PLOG((1, "def_var_chunking_handler got parameters ncid = %d varid = %d storage = %d "
+          "ndims = %d chunksizes_present = %d", ncid, varid, storage, ndims, chunksizes_present));
 
     /* Call the function. */
     PIOc_def_var_chunking(ncid, varid, storage, chunksizesp);
 
     if(chunksizes_present)
-	free(chunksizesp);
+        free(chunksizesp);
 
-    LOG((1, "def_var_chunking_handler succeeded!"));
+    PLOG((1, "def_var_chunking_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1562,7 +1568,7 @@ int def_var_fill_handler(iosystem_desc_t *ios)
     int mpierr;
 
     assert(ios);
-    LOG((1, "def_var_fill_handler comproot = %d", ios->comproot));
+    PLOG((1, "def_var_fill_handler comproot = %d", ios->comproot));
 
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
@@ -1586,8 +1592,8 @@ int def_var_fill_handler(iosystem_desc_t *ios)
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
         }
     }
-    LOG((1, "def_var_fill_handler got parameters ncid = %d varid = %d fill_mode = %d "
-         "type_size = %lld fill_value_present = %d", ncid, varid, fill_mode, type_size, fill_value_present));
+    PLOG((1, "def_var_fill_handler got parameters ncid = %d varid = %d fill_mode = %d "
+          "type_size = %lld fill_value_present = %d", ncid, varid, fill_mode, type_size, fill_value_present));
 
     /* Call the function. */
     PIOc_def_var_fill(ncid, varid, fill_mode, fill_valuep);
@@ -1596,7 +1602,7 @@ int def_var_fill_handler(iosystem_desc_t *ios)
     if (fill_valuep)
         free(fill_valuep);
 
-    LOG((1, "def_var_fill_handler succeeded!"));
+    PLOG((1, "def_var_fill_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1615,7 +1621,7 @@ int def_var_endian_handler(iosystem_desc_t *ios)
     int mpierr;
 
     assert(ios);
-    LOG((1, "def_var_endian_handler comproot = %d", ios->comproot));
+    PLOG((1, "def_var_endian_handler comproot = %d", ios->comproot));
 
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
@@ -1625,13 +1631,13 @@ int def_var_endian_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&endian, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "def_var_endian_handler got parameters ncid = %d varid = %d endain = %d ",
-         ncid, varid, endian));
+    PLOG((1, "def_var_endian_handler got parameters ncid = %d varid = %d endain = %d ",
+          ncid, varid, endian));
 
     /* Call the function. */
     PIOc_def_var_endian(ncid, varid, endian);
 
-    LOG((1, "def_var_chunking_handler succeeded!"));
+    PLOG((1, "def_var_chunking_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1652,7 +1658,7 @@ int def_var_deflate_handler(iosystem_desc_t *ios)
     int mpierr;
 
     assert(ios);
-    LOG((1, "def_var_deflate_handler comproot = %d", ios->comproot));
+    PLOG((1, "def_var_deflate_handler comproot = %d", ios->comproot));
 
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
@@ -1666,13 +1672,13 @@ int def_var_deflate_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&deflate_level, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "def_var_deflate_handler got parameters ncid = %d varid = %d shuffle = %d ",
-         "deflate = %d deflate_level = %d", ncid, varid, shuffle, deflate, deflate_level));
+    PLOG((1, "def_var_deflate_handler got parameters ncid = %d varid = %d shuffle = %d ",
+          "deflate = %d deflate_level = %d", ncid, varid, shuffle, deflate, deflate_level));
 
     /* Call the function. */
     PIOc_def_var_deflate(ncid, varid, shuffle, deflate, deflate_level);
 
-    LOG((1, "def_var_deflate_handler succeeded!"));
+    PLOG((1, "def_var_deflate_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1693,7 +1699,7 @@ int set_var_chunk_cache_handler(iosystem_desc_t *ios)
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
 
     assert(ios);
-    LOG((1, "set_var_chunk_cache_handler comproot = %d", ios->comproot));
+    PLOG((1, "set_var_chunk_cache_handler comproot = %d", ios->comproot));
 
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
@@ -1707,13 +1713,13 @@ int set_var_chunk_cache_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&preemption, 1, MPI_FLOAT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "set_var_chunk_cache_handler got params ncid = %d varid = %d size = %d "
-         "nelems = %d preemption = %g", ncid, varid, size, nelems, preemption));
+    PLOG((1, "set_var_chunk_cache_handler got params ncid = %d varid = %d size = %d "
+          "nelems = %d preemption = %g", ncid, varid, size, nelems, preemption));
 
     /* Call the function. */
     PIOc_set_var_chunk_cache(ncid, varid, size, nelems, preemption);
 
-    LOG((1, "def_var_chunk_cache_handler succeeded!"));
+    PLOG((1, "def_var_chunk_cache_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1735,7 +1741,7 @@ int def_dim_handler(iosystem_desc_t *ios)
     int dimid;
     int mpierr;
 
-    LOG((1, "def_dim_handler comproot = %d", ios->comproot));
+    PLOG((1, "def_dim_handler comproot = %d", ios->comproot));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
@@ -1748,13 +1754,13 @@ int def_dim_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&len, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "def_dim_handler got parameters namelen = %d "
-         "name = %s len = %d ncid = %d", namelen, name, len, ncid));
+    PLOG((2, "def_dim_handler got parameters namelen = %d "
+          "name = %s len = %d ncid = %d", namelen, name, len, ncid));
 
     /* Call the function. */
     PIOc_def_dim(ncid, name, len, &dimid);
 
-    LOG((1, "def_dim_handler succeeded!"));
+    PLOG((1, "def_dim_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1776,7 +1782,7 @@ int rename_dim_handler(iosystem_desc_t *ios)
     int dimid;
     int mpierr;
 
-    LOG((1, "rename_dim_handler"));
+    PLOG((1, "rename_dim_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
@@ -1789,13 +1795,13 @@ int rename_dim_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(name, namelen + 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "rename_dim_handler got parameters namelen = %d "
-         "name = %s ncid = %d dimid = %d", namelen, name, ncid, dimid));
+    PLOG((2, "rename_dim_handler got parameters namelen = %d "
+          "name = %s ncid = %d dimid = %d", namelen, name, ncid, dimid));
 
     /* Call the function. */
     PIOc_rename_dim(ncid, dimid, name);
 
-    LOG((1, "rename_dim_handler succeeded!"));
+    PLOG((1, "rename_dim_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1817,7 +1823,7 @@ int rename_var_handler(iosystem_desc_t *ios)
     int varid;
     int mpierr;
 
-    LOG((1, "rename_var_handler"));
+    PLOG((1, "rename_var_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
@@ -1830,13 +1836,13 @@ int rename_var_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(name, namelen + 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "rename_var_handler got parameters namelen = %d "
-         "name = %s ncid = %d varid = %d", namelen, name, ncid, varid));
+    PLOG((2, "rename_var_handler got parameters namelen = %d "
+          "name = %s ncid = %d varid = %d", namelen, name, ncid, varid));
 
     /* Call the function. */
     PIOc_rename_var(ncid, varid, name);
 
-    LOG((1, "rename_var_handler succeeded!"));
+    PLOG((1, "rename_var_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1858,7 +1864,7 @@ int rename_att_handler(iosystem_desc_t *ios)
     char name[PIO_MAX_NAME + 1], newname[PIO_MAX_NAME + 1];
     int mpierr;
 
-    LOG((1, "rename_att_handler"));
+    PLOG((1, "rename_att_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
@@ -1875,13 +1881,13 @@ int rename_att_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(newname, newnamelen + 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "rename_att_handler got parameters namelen = %d name = %s ncid = %d varid = %d "
-         "newnamelen = %d newname = %s", namelen, name, ncid, varid, newnamelen, newname));
+    PLOG((2, "rename_att_handler got parameters namelen = %d name = %s ncid = %d varid = %d "
+          "newnamelen = %d newname = %s", namelen, name, ncid, varid, newnamelen, newname));
 
     /* Call the function. */
     PIOc_rename_att(ncid, varid, name, newname);
 
-    LOG((1, "rename_att_handler succeeded!"));
+    PLOG((1, "rename_att_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1903,7 +1909,7 @@ int delete_att_handler(iosystem_desc_t *ios)
     char name[PIO_MAX_NAME + 1];
     int mpierr;
 
-    LOG((1, "delete_att_handler"));
+    PLOG((1, "delete_att_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
@@ -1916,13 +1922,13 @@ int delete_att_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(name, namelen + 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "delete_att_handler namelen = %d name = %s ncid = %d varid = %d ",
-         namelen, name, ncid, varid));
+    PLOG((2, "delete_att_handler namelen = %d name = %s ncid = %d varid = %d ",
+          namelen, name, ncid, varid));
 
     /* Call the function. */
     PIOc_del_att(ncid, varid, name);
 
-    LOG((1, "delete_att_handler succeeded!"));
+    PLOG((1, "delete_att_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -1944,14 +1950,14 @@ int open_file_handler(iosystem_desc_t *ios)
     int mode;
     int mpierr;
 
-    LOG((1, "open_file_handler comproot = %d", ios->comproot));
+    PLOG((1, "open_file_handler comproot = %d", ios->comproot));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&len, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "open_file_handler got parameter len = %d", len));
+    PLOG((2, "open_file_handler got parameter len = %d", len));
 
     /* Get space for the filename. */
     char filename[len + 1];
@@ -1963,12 +1969,12 @@ int open_file_handler(iosystem_desc_t *ios)
     if ((mpierr = MPI_Bcast(&mode, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
-    LOG((2, "open_file_handler got parameters len = %d filename = %s iotype = %d mode = %d",
-         len, filename, iotype, mode));
+    PLOG((2, "open_file_handler got parameters len = %d filename = %s iotype = %d mode = %d",
+          len, filename, iotype, mode));
 
-    /* Call the open file function. Errors are handling within
+    /* Call the open file function. Errors are handled within
      * function, so return code can be ignored. */
-    PIOc_openfile_retry(ios->iosysid, &ncid, &iotype, filename, mode, 0);
+    PIOc_openfile_retry(ios->iosysid, &ncid, &iotype, filename, mode, 0, 0);
 
     return PIO_NOERR;
 }
@@ -1988,7 +1994,7 @@ int delete_file_handler(iosystem_desc_t *ios)
     int len;
     int mpierr;
 
-    LOG((1, "delete_file_handler comproot = %d", ios->comproot));
+    PLOG((1, "delete_file_handler comproot = %d", ios->comproot));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
@@ -2001,13 +2007,13 @@ int delete_file_handler(iosystem_desc_t *ios)
 
     if ((mpierr = MPI_Bcast(filename, len + 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "delete_file_handler got parameters len = %d filename = %s",
-         len, filename));
+    PLOG((1, "delete_file_handler got parameters len = %d filename = %s",
+          len, filename));
 
     /* Call the delete file function. */
     PIOc_deletefile(ios->iosysid, filename);
 
-    LOG((1, "delete_file_handler succeeded!"));
+    PLOG((1, "delete_file_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -2034,7 +2040,7 @@ int initdecomp_dof_handler(iosystem_desc_t *ios)
     PIO_Offset *iocountp = NULL;
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
 
-    LOG((1, "initdecomp_dof_handler called"));
+    PLOG((1, "initdecomp_dof_handler called"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -2084,9 +2090,9 @@ int initdecomp_dof_handler(iosystem_desc_t *ios)
         if ((mpierr = MPI_Bcast(iocount, ndims, MPI_OFFSET, 0, ios->intercomm)))
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
-    LOG((2, "initdecomp_dof_handler iosysid = %d pio_type = %d ndims = %d maplen = %d "
-         "rearranger_present = %d iostart_present = %d iocount_present = %d ",
-         iosysid, pio_type, ndims, maplen, rearranger_present, iostart_present, iocount_present));
+    PLOG((2, "initdecomp_dof_handler iosysid = %d pio_type = %d ndims = %d maplen = %d "
+          "rearranger_present = %d iostart_present = %d iocount_present = %d ",
+          iosysid, pio_type, ndims, maplen, rearranger_present, iostart_present, iocount_present));
 
     if (rearranger_present)
         rearrangerp = &rearranger;
@@ -2099,7 +2105,7 @@ int initdecomp_dof_handler(iosystem_desc_t *ios)
     PIOc_InitDecomp(iosysid, pio_type, ndims, dims, maplen, compmap, &ioid, rearrangerp,
                     iostartp, iocountp);
 
-    LOG((1, "PIOc_InitDecomp returned"));
+    PLOG((1, "PIOc_InitDecomp returned"));
 
     free(compmap);
     return PIO_NOERR;
@@ -2134,7 +2140,7 @@ int write_darray_multi_handler(iosystem_desc_t *ios)
     int mpierr;
     int ret;
 
-    LOG((1, "write_darray_multi_handler"));
+    PLOG((1, "write_darray_multi_handler"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -2180,9 +2186,9 @@ int write_darray_multi_handler(iosystem_desc_t *ios)
     }
     if ((mpierr = MPI_Bcast(&flushtodisk, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "write_darray_multi_handler ncid = %d nvars = %d ioid = %d arraylen = %d "
-         "frame_present = %d fillvalue_present flushtodisk = %d", ncid, nvars,
-         ioid, arraylen, frame_present, fillvalue_present, flushtodisk));
+    PLOG((1, "write_darray_multi_handler ncid = %d nvars = %d ioid = %d arraylen = %d "
+          "frame_present = %d fillvalue_present flushtodisk = %d", ncid, nvars,
+          ioid, arraylen, frame_present, fillvalue_present, flushtodisk));
 
     /* Get file info based on ncid. */
     if ((ret = pio_get_file(ncid, &file)))
@@ -2212,7 +2218,7 @@ int write_darray_multi_handler(iosystem_desc_t *ios)
         free(fillvalue);
     free(array);
 
-    LOG((1, "write_darray_multi_handler succeeded!"));
+    PLOG((1, "write_darray_multi_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -2251,7 +2257,7 @@ int seterrorhandling_handler(iosystem_desc_t *ios)
     int *old_methodp = NULL;
     int mpierr;
 
-    LOG((1, "seterrorhandling_handler comproot = %d", ios->comproot));
+    PLOG((1, "seterrorhandling_handler comproot = %d", ios->comproot));
     assert(ios);
 
     /* Get the parameters for this function that the he comp master
@@ -2261,8 +2267,8 @@ int seterrorhandling_handler(iosystem_desc_t *ios)
     if ((mpierr = MPI_Bcast(&old_method_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
 
-    LOG((1, "seterrorhandling_handler got parameters method = %d old_method_present = %d",
-         method, old_method_present));
+    PLOG((1, "seterrorhandling_handler got parameters method = %d old_method_present = %d",
+          method, old_method_present));
 
     if (old_method_present)
         old_methodp = &old_method;
@@ -2270,7 +2276,7 @@ int seterrorhandling_handler(iosystem_desc_t *ios)
     /* Call the function. */
     PIOc_set_iosystem_error_handling(ios->iosysid, method, old_methodp);
 
-    LOG((1, "seterrorhandling_handler succeeded!"));
+    PLOG((1, "seterrorhandling_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -2292,7 +2298,7 @@ int set_chunk_cache_handler(iosystem_desc_t *ios)
     float preemption;
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
 
-    LOG((1, "set_chunk_cache_handler called"));
+    PLOG((1, "set_chunk_cache_handler called"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -2307,13 +2313,13 @@ int set_chunk_cache_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&preemption, 1, MPI_FLOAT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "set_chunk_cache_handler got params iosysid = %d iotype = %d size = %d "
-         "nelems = %d preemption = %g", iosysid, iotype, size, nelems, preemption));
+    PLOG((1, "set_chunk_cache_handler got params iosysid = %d iotype = %d size = %d "
+          "nelems = %d preemption = %g", iosysid, iotype, size, nelems, preemption));
 
     /* Call the function. */
     PIOc_set_chunk_cache(iosysid, iotype, size, nelems, preemption);
 
-    LOG((1, "set_chunk_cache_handler succeeded!"));
+    PLOG((1, "set_chunk_cache_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -2336,7 +2342,7 @@ int get_chunk_cache_handler(iosystem_desc_t *ios)
     float preemption, *preemptionp = NULL;
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
 
-    LOG((1, "get_chunk_cache_handler called"));
+    PLOG((1, "get_chunk_cache_handler called"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -2351,9 +2357,9 @@ int get_chunk_cache_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&preemption_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "get_chunk_cache_handler got params iosysid = %d iotype = %d size_present = %d "
-         "nelems_present = %d preemption_present = %g", iosysid, iotype, size_present,
-         nelems_present, preemption_present));
+    PLOG((1, "get_chunk_cache_handler got params iosysid = %d iotype = %d size_present = %d "
+          "nelems_present = %d preemption_present = %g", iosysid, iotype, size_present,
+          nelems_present, preemption_present));
 
     /* Set the non-NULL pointers. */
     if (size_present)
@@ -2366,7 +2372,7 @@ int get_chunk_cache_handler(iosystem_desc_t *ios)
     /* Call the function. */
     PIOc_get_chunk_cache(iosysid, iotype, sizep, nelemsp, preemptionp);
 
-    LOG((1, "get_chunk_cache_handler succeeded!"));
+    PLOG((1, "get_chunk_cache_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -2389,7 +2395,7 @@ int get_var_chunk_cache_handler(iosystem_desc_t *ios)
     float preemption, *preemptionp = NULL;
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
 
-    LOG((1, "get_var_chunk_cache_handler called"));
+    PLOG((1, "get_var_chunk_cache_handler called"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -2404,9 +2410,9 @@ int get_var_chunk_cache_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&preemption_present, 1, MPI_CHAR, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "get_var_chunk_cache_handler got params ncid = %d varid = %d size_present = %d "
-         "nelems_present = %d preemption_present = %g", ncid, varid, size_present,
-         nelems_present, preemption_present));
+    PLOG((1, "get_var_chunk_cache_handler got params ncid = %d varid = %d size_present = %d "
+          "nelems_present = %d preemption_present = %g", ncid, varid, size_present,
+          nelems_present, preemption_present));
 
     /* Set the non-NULL pointers. */
     if (size_present)
@@ -2419,7 +2425,7 @@ int get_var_chunk_cache_handler(iosystem_desc_t *ios)
     /* Call the function. */
     PIOc_get_var_chunk_cache(ncid, varid, sizep, nelemsp, preemptionp);
 
-    LOG((1, "get_var_chunk_cache_handler succeeded!"));
+    PLOG((1, "get_var_chunk_cache_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -2437,7 +2443,7 @@ int freedecomp_handler(iosystem_desc_t *ios)
     int ioid;
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
 
-    LOG((1, "freedecomp_handler called"));
+    PLOG((1, "freedecomp_handler called"));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
@@ -2446,12 +2452,12 @@ int freedecomp_handler(iosystem_desc_t *ios)
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast(&ioid, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "freedecomp_handler iosysid = %d ioid = %d", iosysid, ioid));
+    PLOG((2, "freedecomp_handler iosysid = %d ioid = %d", iosysid, ioid));
 
     /* Call the function. */
     PIOc_freedecomp(iosysid, ioid);
 
-    LOG((1, "PIOc_freedecomp returned"));
+    PLOG((1, "PIOc_freedecomp returned"));
     return PIO_NOERR;
 }
 
@@ -2470,19 +2476,19 @@ int finalize_handler(iosystem_desc_t *ios, int index)
     int iosysid;
     int mpierr;
 
-    LOG((1, "finalize_handler called index = %d", index));
+    PLOG((1, "finalize_handler called index = %d", index));
     assert(ios);
 
     /* Get the parameters for this function that the the comp master
      * task is broadcasting. */
     if ((mpierr = MPI_Bcast(&iosysid, 1, MPI_INT, 0, ios->intercomm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((1, "finalize_handler got parameter iosysid = %d", iosysid));
+    PLOG((1, "finalize_handler got parameter iosysid = %d", iosysid));
 
     /* Call the function. */
     PIOc_finalize(iosysid);
 
-    LOG((1, "finalize_handler succeeded!"));
+    PLOG((1, "finalize_handler succeeded!"));
     return PIO_NOERR;
 }
 
@@ -2510,7 +2516,7 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
     int mpierr;
     int ret = PIO_NOERR;
 
-    LOG((1, "pio_msg_handler2 called"));
+    PLOG((1, "pio_msg_handler2 called"));
     assert(iosys);
 
     /* Have IO comm rank 0 (the ioroot) register to receive
@@ -2520,51 +2526,51 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
         for (int cmp = 0; cmp < component_count; cmp++)
         {
             my_iosys = iosys[cmp];
-            LOG((1, "about to call MPI_Irecv union_comm = %d", my_iosys->union_comm));
+            PLOG((1, "about to call MPI_Irecv union_comm = %d", my_iosys->union_comm));
             if ((mpierr = MPI_Irecv(&(messages[cmp]), 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG,
                                     my_iosys->union_comm, &req[cmp])))
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            LOG((1, "MPI_Irecv req[%d] = %d", cmp, req[cmp]));
+            PLOG((1, "MPI_Irecv req[%d] = %d", cmp, req[cmp]));
         }
     }
 
     /* Keep processing messages until loop is broken. */
     while (1)
     {
-        LOG((3, "pio_msg_handler2 at top of loop"));
+        PLOG((3, "pio_msg_handler2 at top of loop"));
 
         /* Wait until any one of the requests are complete. Once it
          * returns, the Waitany function automatically sets the
          * appropriate member of the req array to MPI_REQUEST_NULL. */
         if (!io_rank)
         {
-            LOG((1, "about to call MPI_Waitany req[0] = %d MPI_REQUEST_NULL = %d",
-                 req[0], MPI_REQUEST_NULL));
+            PLOG((1, "about to call MPI_Waitany req[0] = %d MPI_REQUEST_NULL = %d",
+                  req[0], MPI_REQUEST_NULL));
             for (int c = 0; c < component_count; c++)
-                LOG((3, "req[%d] = %d", c, req[c]));
+                PLOG((3, "req[%d] = %d", c, req[c]));
             if ((mpierr = MPI_Waitany(component_count, req, &index, &status)))
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            LOG((3, "Waitany returned index = %d req[%d] = %d", index, index, req[index]));
-	    msg = messages[index];
+            PLOG((3, "Waitany returned index = %d req[%d] = %d", index, index, req[index]));
+            msg = messages[index];
             for (int c = 0; c < component_count; c++)
-                LOG((3, "req[%d] = %d", c, req[c]));
+                PLOG((3, "req[%d] = %d", c, req[c]));
         }
 
         /* Broadcast the index of the computational component that
          * originated the request to the rest of the IO tasks. */
-        LOG((3, "About to do Bcast of index = %d io_comm = %d", index, io_comm));
+        PLOG((3, "About to do Bcast of index = %d io_comm = %d", index, io_comm));
         if ((mpierr = MPI_Bcast(&index, 1, MPI_INT, 0, io_comm)))
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        LOG((3, "index MPI_Bcast complete index = %d", index));
+        PLOG((3, "index MPI_Bcast complete index = %d", index));
 
         /* Set the correct iosys depending on the index. */
         my_iosys = iosys[index];
 
         /* Broadcast the msg value to the rest of the IO tasks. */
-        LOG((3, "about to call msg MPI_Bcast io_comm = %d", io_comm));
+        PLOG((3, "about to call msg MPI_Bcast io_comm = %d", io_comm));
         if ((mpierr = MPI_Bcast(&msg, 1, MPI_INT, 0, io_comm)))
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-        LOG((1, "pio_msg_handler2 msg MPI_Bcast complete msg = %d", msg));
+        PLOG((1, "pio_msg_handler2 msg MPI_Bcast complete msg = %d", msg));
 
         /* Handle the message. This code is run on all IO tasks. */
         switch (msg)
@@ -2716,12 +2722,12 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
             ret = finalize_handler(my_iosys, index);
             break;
         default:
-            LOG((0, "unknown message received %d", msg));
+            PLOG((0, "unknown message received %d", msg));
             return PIO_EINVAL;
         }
 
         /* If an error was returned by the handler, exit. */
-        LOG((3, "pio_msg_handler2 ret %d msg %d index %d io_rank %d", ret, msg, index, io_rank));
+        PLOG((3, "pio_msg_handler2 ret %d msg %d index %d io_rank %d", ret, msg, index, io_rank));
         if (ret)
             return pio_err(my_iosys, NULL, ret, __FILE__, __LINE__);
 
@@ -2730,17 +2736,17 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
         if (!io_rank && !finalize)
         {
             my_iosys = iosys[index];
-            LOG((3, "pio_msg_handler2 about to Irecv index = %d comproot = %d union_comm = %d",
-                 index, my_iosys->comproot, my_iosys->union_comm));
+            PLOG((3, "pio_msg_handler2 about to Irecv index = %d comproot = %d union_comm = %d",
+                  index, my_iosys->comproot, my_iosys->union_comm));
             if ((mpierr = MPI_Irecv(&(messages[index]), 1, MPI_INT, my_iosys->comproot, MPI_ANY_TAG, my_iosys->union_comm,
                                     &req[index])))
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-            LOG((3, "pio_msg_handler2 called MPI_Irecv req[%d] = %d", index, req[index]));
+            PLOG((3, "pio_msg_handler2 called MPI_Irecv req[%d] = %d", index, req[index]));
         }
 
-        LOG((3, "pio_msg_handler2 done msg = %d open_components = %d",
-             msg, open_components));
-	msg = PIO_MSG_NULL;
+        PLOG((3, "pio_msg_handler2 done msg = %d open_components = %d",
+              msg, open_components));
+        msg = PIO_MSG_NULL;
         /* If there are no more open components, exit. */
         if (finalize)
         {
@@ -2751,6 +2757,6 @@ int pio_msg_handler2(int io_rank, int component_count, iosystem_desc_t **iosys,
         }
     }
 
-    LOG((3, "returning from pio_msg_handler2"));
+    PLOG((3, "returning from pio_msg_handler2"));
     return PIO_NOERR;
 }

--- a/cime/src/externals/pio2/src/clib/pio_nc.c
+++ b/cime/src/externals/pio2/src/clib/pio_nc.c
@@ -100,7 +100,7 @@ PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function calls. */
 
-    LOG((1, "PIOc_inq ncid = %d", ncid));
+    PLOG((1, "PIOc_inq ncid = %d", ncid));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -131,8 +131,8 @@ PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
                 mpierr = MPI_Bcast(&ngatts_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&unlimdimid_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_inq ncid = %d ndims_present = %d nvars_present = %d ngatts_present = %d unlimdimid_present = %d",
-                 ncid, ndims_present, nvars_present, ngatts_present, unlimdimid_present));
+            PLOG((2, "PIOc_inq ncid = %d ndims_present = %d nvars_present = %d ngatts_present = %d unlimdimid_present = %d",
+                  ncid, ndims_present, nvars_present, ngatts_present, unlimdimid_present));
         }
 
         /* Handle MPI errors. */
@@ -150,21 +150,21 @@ PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
         {
             ierr = ncmpi_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);
             if (unlimdimidp)
-                LOG((2, "PIOc_inq returned from ncmpi_inq unlimdimid = %d", *unlimdimidp));
+                PLOG((2, "PIOc_inq returned from ncmpi_inq unlimdimid = %d", *unlimdimidp));
         }
 #endif /* _PNETCDF */
         if (file->iotype == PIO_IOTYPE_NETCDF && file->do_io)
         {
-            LOG((2, "PIOc_inq calling classic nc_inq"));
+            PLOG((2, "PIOc_inq calling classic nc_inq"));
             /* Should not be necessary to do this - nc_inq should
              * handle null pointers. This has been reported as a bug
              * to netCDF developers. */
             int tmp_ndims, tmp_nvars, tmp_ngatts, tmp_unlimdimid;
-            LOG((2, "PIOc_inq calling classic nc_inq"));
+            PLOG((2, "PIOc_inq calling classic nc_inq"));
             ierr = nc_inq(file->fh, &tmp_ndims, &tmp_nvars, &tmp_ngatts, &tmp_unlimdimid);
-            LOG((2, "PIOc_inq calling classic nc_inq"));
+            PLOG((2, "PIOc_inq calling classic nc_inq"));
             if (unlimdimidp)
-                LOG((2, "classic tmp_unlimdimid = %d", tmp_unlimdimid));
+                PLOG((2, "classic tmp_unlimdimid = %d", tmp_unlimdimid));
             if (ndimsp)
                 *ndimsp = tmp_ndims;
             if (nvarsp)
@@ -174,15 +174,15 @@ PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
             if (unlimdimidp)
                 *unlimdimidp = tmp_unlimdimid;
             if (unlimdimidp)
-                LOG((2, "classic unlimdimid = %d", *unlimdimidp));
+                PLOG((2, "classic unlimdimid = %d", *unlimdimidp));
         }
         else if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
-            LOG((2, "PIOc_inq calling netcdf-4 nc_inq"));
+            PLOG((2, "PIOc_inq calling netcdf-4 nc_inq"));
             ierr = nc_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);
         }
 
-        LOG((2, "PIOc_inq netcdf call returned %d", ierr));
+        PLOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -224,7 +224,7 @@ PIOc_inq(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdimidp)
 int
 PIOc_inq_ndims(int ncid, int *ndimsp)
 {
-    LOG((1, "PIOc_inq_ndims"));
+    PLOG((1, "PIOc_inq_ndims"));
     return PIOc_inq(ncid, ndimsp, NULL, NULL, NULL);
 }
 
@@ -271,7 +271,7 @@ PIOc_inq_natts(int ncid, int *ngattsp)
 int
 PIOc_inq_unlimdim(int ncid, int *unlimdimidp)
 {
-    LOG((1, "PIOc_inq_unlimdim ncid = %d", ncid));
+    PLOG((1, "PIOc_inq_unlimdim ncid = %d", ncid));
     return PIOc_inq(ncid, NULL, NULL, NULL, unlimdimidp);
 }
 
@@ -297,7 +297,7 @@ PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function calls. */
 
-    LOG((1, "PIOc_inq_unlimdims ncid = %d", ncid));
+    PLOG((1, "PIOc_inq_unlimdims ncid = %d", ncid));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -322,8 +322,8 @@ PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
                 mpierr = MPI_Bcast(&nunlimdimsp_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&unlimdimidsp_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_inq_unlimdims ncid = %d nunlimdimsp_present = %d unlimdimidsp_present = %d",
-                 ncid, nunlimdimsp_present, unlimdimidsp_present));
+            PLOG((2, "PIOc_inq_unlimdims ncid = %d nunlimdimsp_present = %d unlimdimidsp_present = %d",
+                  ncid, nunlimdimsp_present, unlimdimidsp_present));
         }
 
         /* Handle MPI errors. */
@@ -333,16 +333,16 @@ PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
-    LOG((2, "file->iotype = %d", file->iotype));
+    PLOG((2, "file->iotype = %d", file->iotype));
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
         if (file->iotype == PIO_IOTYPE_NETCDF && file->do_io)
         {
-            LOG((2, "netcdf"));
+            PLOG((2, "netcdf"));
             int tmp_unlimdimid;
             ierr = nc_inq_unlimdim(file->fh, &tmp_unlimdimid);
-            LOG((2, "classic tmp_unlimdimid = %d", tmp_unlimdimid));
+            PLOG((2, "classic tmp_unlimdimid = %d", tmp_unlimdimid));
             tmp_nunlimdims = tmp_unlimdimid >= 0 ? 1 : 0;
             if (nunlimdimsp)
                 *nunlimdimsp = tmp_unlimdimid >= 0 ? 1 : 0;
@@ -352,10 +352,10 @@ PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
 #ifdef _PNETCDF
         else if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
-            LOG((2, "pnetcdf"));
+            PLOG((2, "pnetcdf"));
             int tmp_unlimdimid;
             ierr = ncmpi_inq_unlimdim(file->fh, &tmp_unlimdimid);
-            LOG((2, "pnetcdf tmp_unlimdimid = %d", tmp_unlimdimid));
+            PLOG((2, "pnetcdf tmp_unlimdimid = %d", tmp_unlimdimid));
             tmp_nunlimdims = tmp_unlimdimid >= 0 ? 1 : 0;
             if (nunlimdimsp)
                 *nunlimdimsp = tmp_nunlimdims;
@@ -367,14 +367,14 @@ PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
         else if ((file->iotype == PIO_IOTYPE_NETCDF4C || file->iotype == PIO_IOTYPE_NETCDF4P) &&
                  file->do_io)
         {
-            LOG((2, "PIOc_inq calling netcdf-4 nc_inq_unlimdims"));
+            PLOG((2, "PIOc_inq calling netcdf-4 nc_inq_unlimdims"));
             int *tmp_unlimdimids;
             ierr = nc_inq_unlimdims(file->fh, &tmp_nunlimdims, NULL);
             if (!ierr)
             {
                 if (nunlimdimsp)
                     *nunlimdimsp = tmp_nunlimdims;
-                LOG((3, "tmp_nunlimdims = %d", tmp_nunlimdims));
+                PLOG((3, "tmp_nunlimdims = %d", tmp_nunlimdims));
                 if (!(tmp_unlimdimids = malloc(tmp_nunlimdims * sizeof(int))))
                     ierr = PIO_ENOMEM;
                 if (!ierr)
@@ -382,7 +382,7 @@ PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
                 if (unlimdimidsp)
                     for (int d = 0; d < tmp_nunlimdims; d++)
                     {
-                        LOG((3, "tmp_unlimdimids[%d] = %d", d, tmp_unlimdimids[d]));
+                        PLOG((3, "tmp_unlimdimids[%d] = %d", d, tmp_unlimdimids[d]));
                         unlimdimidsp[d] = tmp_unlimdimids[d];
                     }
                 free(tmp_unlimdimids);
@@ -390,7 +390,7 @@ PIOc_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
         }
 #endif /* _NETCDF4 */
 
-        LOG((2, "PIOc_inq_unlimdims netcdf call returned %d", ierr));
+        PLOG((2, "PIOc_inq_unlimdims netcdf call returned %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -433,7 +433,7 @@ PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_inq_type ncid = %d xtype = %d", ncid, xtype));
+    PLOG((1, "PIOc_inq_type ncid = %d xtype = %d", ncid, xtype));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -479,7 +479,7 @@ PIOc_inq_type(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_type(file->fh, xtype, name, (size_t *)sizep);
-        LOG((2, "PIOc_inq_type netcdf call returned %d", ierr));
+        PLOG((2, "PIOc_inq_type netcdf call returned %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -524,7 +524,7 @@ PIOc_inq_format(int ncid, int *formatp)
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_inq ncid = %d", ncid));
+    PLOG((1, "PIOc_inq ncid = %d", ncid));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -565,7 +565,7 @@ PIOc_inq_format(int ncid, int *formatp)
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_format(file->fh, formatp);
-        LOG((2, "PIOc_inq netcdf call returned %d", ierr));
+        PLOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -609,7 +609,7 @@ PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_inq_dim ncid = %d dimid = %d", ncid, dimid));
+    PLOG((1, "PIOc_inq_dim ncid = %d dimid = %d", ncid, dimid));
 
     /* Get the file info, based on the ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -634,10 +634,10 @@ PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
                 mpierr = MPI_Bcast(&dimid, 1, MPI_INT, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&name_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_inq netcdf Bcast name_present = %d", name_present));
+            PLOG((2, "PIOc_inq netcdf Bcast name_present = %d", name_present));
             if (!mpierr)
                 mpierr = MPI_Bcast(&len_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_inq netcdf Bcast len_present = %d", len_present));
+            PLOG((2, "PIOc_inq netcdf Bcast len_present = %d", len_present));
         }
 
         /* Handle MPI errors. */
@@ -653,17 +653,17 @@ PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
-            LOG((2, "calling ncmpi_inq_dim"));
+            PLOG((2, "calling ncmpi_inq_dim"));
             ierr = ncmpi_inq_dim(file->fh, dimid, name, lenp);;
         }
 #endif /* _PNETCDF */
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
-            LOG((2, "calling nc_inq_dim"));
+            PLOG((2, "calling nc_inq_dim"));
             ierr = nc_inq_dim(file->fh, dimid, name, (size_t *)lenp);;
         }
-        LOG((2, "ierr = %d", ierr));
+        PLOG((2, "ierr = %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -676,7 +676,7 @@ PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
     if (name)
     {
         int slen;
-        LOG((2, "bcasting results my_comm = %d", ios->my_comm));
+        PLOG((2, "bcasting results my_comm = %d", ios->my_comm));
         if (ios->iomaster == MPI_ROOT)
             slen = strlen(name);
         if ((mpierr = MPI_Bcast(&slen, 1, MPI_INT, ios->ioroot, ios->my_comm)))
@@ -689,7 +689,7 @@ PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
         if ((mpierr = MPI_Bcast(lenp , 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
-    LOG((2, "done with PIOc_inq_dim"));
+    PLOG((2, "done with PIOc_inq_dim"));
     return PIO_NOERR;
 }
 
@@ -707,7 +707,7 @@ PIOc_inq_dim(int ncid, int dimid, char *name, PIO_Offset *lenp)
 int
 PIOc_inq_dimname(int ncid, int dimid, char *name)
 {
-    LOG((1, "PIOc_inq_dimname ncid = %d dimid = %d", ncid, dimid));
+    PLOG((1, "PIOc_inq_dimname ncid = %d dimid = %d", ncid, dimid));
     return PIOc_inq_dim(ncid, dimid, name, NULL);
 }
 
@@ -756,13 +756,13 @@ PIOc_inq_dimid(int ncid, const char *name, int *idp)
     if ((ierr = pio_get_file(ncid, &file)))
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
-    LOG((2, "iosysid = %d", ios->iosysid));
+    PLOG((2, "iosysid = %d", ios->iosysid));
 
     /* User must provide name shorter than NC_MAX_NAME +1. */
     if (!name || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_inq_dimid ncid = %d name = %s", ncid, name));
+    PLOG((1, "PIOc_inq_dimid ncid = %d name = %s", ncid, name));
 
     /* If using async, and not an IO task, then send parameters. */
     if (ios->async)
@@ -804,7 +804,7 @@ PIOc_inq_dimid(int ncid, const char *name, int *idp)
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_dimid(file->fh, name, idp);
     }
-    LOG((3, "nc_inq_dimid call complete ierr = %d", ierr));
+    PLOG((3, "nc_inq_dimid call complete ierr = %d", ierr));
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
@@ -855,7 +855,7 @@ PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
     int ierr;
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_inq_var ncid = %d varid = %d", ncid, varid));
+    PLOG((1, "PIOc_inq_var ncid = %d varid = %d", ncid, varid));
 
     /* Get the file info, based on the ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -891,9 +891,9 @@ PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
                 mpierr = MPI_Bcast(&dimids_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&natts_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_inq_var name_present = %d xtype_present = %d ndims_present = %d "
-                 "dimids_present = %d, natts_present = %d nattsp = %d",
-                 name_present, xtype_present, ndims_present, dimids_present, natts_present, nattsp));
+            PLOG((2, "PIOc_inq_var name_present = %d xtype_present = %d ndims_present = %d "
+                  "dimids_present = %d, natts_present = %d nattsp = %d",
+                  name_present, xtype_present, ndims_present, dimids_present, natts_present, nattsp));
         }
 
         /* Handle MPI errors. */
@@ -906,12 +906,12 @@ PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
     /* Call the netCDF layer. */
     if (ios->ioproc)
     {
-        LOG((2, "Calling the netCDF layer"));
+        PLOG((2, "Calling the netCDF layer"));
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
             ierr = ncmpi_inq_varndims(file->fh, varid, &ndims);
-            LOG((2, "from pnetcdf ndims = %d", ndims));
+            PLOG((2, "from pnetcdf ndims = %d", ndims));
             if (!ierr)
                 ierr = ncmpi_inq_var(file->fh, varid, name, xtypep, ndimsp, dimidsp, nattsp);
         }
@@ -920,14 +920,14 @@ PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
         {
             ierr = nc_inq_varndims(file->fh, varid, &ndims);
-            LOG((3, "nc_inq_varndims called ndims = %d", ndims));
+            PLOG((3, "nc_inq_varndims called ndims = %d", ndims));
             if (!ierr)
             {
                 char my_name[NC_MAX_NAME + 1];
                 nc_type my_xtype;
                 int my_ndims = 0, my_dimids[ndims], my_natts = 0;
                 ierr = nc_inq_var(file->fh, varid, my_name, &my_xtype, &my_ndims, my_dimids, &my_natts);
-                LOG((3, "my_name = %s my_xtype = %d my_ndims = %d my_natts = %d",  my_name, my_xtype, my_ndims, my_natts));
+                PLOG((3, "my_name = %s my_xtype = %d my_ndims = %d my_natts = %d",  my_name, my_xtype, my_ndims, my_natts));
                 if (!ierr)
                 {
                     if (name)
@@ -947,7 +947,7 @@ PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
             }
         }
         if (ndimsp)
-            LOG((2, "PIOc_inq_var ndims = %d ierr = %d", *ndimsp, ierr));
+            PLOG((2, "PIOc_inq_var ndims = %d ierr = %d", *ndimsp, ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -973,11 +973,11 @@ PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
 
     if (ndimsp)
     {
-        LOG((2, "PIOc_inq_var about to Bcast ndims = %d ios->ioroot = %d ios->my_comm = %d",
-             *ndimsp, ios->ioroot, ios->my_comm));
+        PLOG((2, "PIOc_inq_var about to Bcast ndims = %d ios->ioroot = %d ios->my_comm = %d",
+              *ndimsp, ios->ioroot, ios->my_comm));
         if ((mpierr = MPI_Bcast(ndimsp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
-        LOG((2, "PIOc_inq_var Bcast ndims = %d", *ndimsp));
+        PLOG((2, "PIOc_inq_var Bcast ndims = %d", *ndimsp));
     }
     if (dimidsp)
     {
@@ -1110,7 +1110,7 @@ PIOc_inq_varid(int ncid, const char *name, int *varidp)
     if (!name || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_inq_varid ncid = %d name = %s", ncid, name));
+    PLOG((1, "PIOc_inq_varid ncid = %d name = %s", ncid, name));
 
     if (ios->async)
     {
@@ -1203,7 +1203,7 @@ PIOc_inq_att_eh(int ncid, int varid, const char *name, int eh,
     if (!name || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_inq_att ncid = %d varid = %d", ncid, varid));
+    PLOG((1, "PIOc_inq_att ncid = %d varid = %d", ncid, varid));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
@@ -1248,7 +1248,7 @@ PIOc_inq_att_eh(int ncid, int varid, const char *name, int eh,
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);
-        LOG((2, "PIOc_inq netcdf call returned %d", ierr));
+        PLOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -1358,8 +1358,8 @@ PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_inq_attname ncid = %d varid = %d attnum = %d", ncid, varid,
-         attnum));
+    PLOG((1, "PIOc_inq_attname ncid = %d varid = %d attnum = %d", ncid, varid,
+          attnum));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -1404,7 +1404,7 @@ PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_attname(file->fh, varid, attnum, name);
-        LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
+        PLOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -1463,7 +1463,7 @@ PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
     if (!name || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_inq_attid ncid = %d varid = %d name = %s", ncid, varid, name));
+    PLOG((1, "PIOc_inq_attid ncid = %d varid = %d name = %s", ncid, varid, name));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
@@ -1506,7 +1506,7 @@ PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_inq_attid(file->fh, varid, name, idp);
-        LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
+        PLOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -1557,7 +1557,7 @@ PIOc_rename_dim(int ncid, int dimid, const char *name)
     if (!name || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_rename_dim ncid = %d dimid = %d name = %s", ncid, dimid, name));
+    PLOG((1, "PIOc_rename_dim ncid = %d dimid = %d name = %s", ncid, dimid, name));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
@@ -1578,8 +1578,8 @@ PIOc_rename_dim(int ncid, int dimid, const char *name)
                 mpierr = MPI_Bcast(&namelen, 1, MPI_INT,  ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_rename_dim Bcast file->fh = %d dimid = %d namelen = %d name = %s",
-                 file->fh, dimid, namelen, name));
+            PLOG((2, "PIOc_rename_dim Bcast file->fh = %d dimid = %d namelen = %d name = %s",
+                  file->fh, dimid, namelen, name));
         }
 
         /* Handle MPI errors. */
@@ -1600,7 +1600,7 @@ PIOc_rename_dim(int ncid, int dimid, const char *name)
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_rename_dim(file->fh, dimid, name);
-        LOG((2, "PIOc_inq netcdf call returned %d", ierr));
+        PLOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -1646,7 +1646,7 @@ PIOc_rename_var(int ncid, int varid, const char *name)
     if (!name || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_rename_var ncid = %d varid = %d name = %s", ncid, varid, name));
+    PLOG((1, "PIOc_rename_var ncid = %d varid = %d name = %s", ncid, varid, name));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
@@ -1667,8 +1667,8 @@ PIOc_rename_var(int ncid, int varid, const char *name)
                 mpierr = MPI_Bcast(&namelen, 1, MPI_INT,  ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_rename_var Bcast file->fh = %d varid = %d namelen = %d name = %s",
-                 file->fh, varid, namelen, name));
+            PLOG((2, "PIOc_rename_var Bcast file->fh = %d varid = %d namelen = %d name = %s",
+                  file->fh, varid, namelen, name));
         }
 
         /* Handle MPI errors. */
@@ -1689,7 +1689,7 @@ PIOc_rename_var(int ncid, int varid, const char *name)
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_rename_var(file->fh, varid, name);
-        LOG((2, "PIOc_inq netcdf call returned %d", ierr));
+        PLOG((2, "PIOc_inq netcdf call returned %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -1738,8 +1738,8 @@ PIOc_rename_att(int ncid, int varid, const char *name,
         !newname || strlen(newname) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_rename_att ncid = %d varid = %d name = %s newname = %s",
-         ncid, varid, name, newname));
+    PLOG((1, "PIOc_rename_att ncid = %d varid = %d name = %s newname = %s",
+          ncid, varid, name, newname));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
@@ -1792,7 +1792,7 @@ PIOc_rename_att(int ncid, int varid, const char *name,
     if (ierr)
         return check_netcdf(file, ierr, __FILE__, __LINE__);
 
-    LOG((2, "PIOc_rename_att succeeded"));
+    PLOG((2, "PIOc_rename_att succeeded"));
     return PIO_NOERR;
 }
 
@@ -1829,7 +1829,7 @@ PIOc_del_att(int ncid, int varid, const char *name)
     if (!name || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_del_att ncid = %d varid = %d name = %s", ncid, varid, name));
+    PLOG((1, "PIOc_del_att ncid = %d varid = %d name = %s", ncid, varid, name));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
@@ -1904,7 +1904,7 @@ PIOc_set_fill(int ncid, int fillmode, int *old_modep)
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI functions. */
 
-    LOG((1, "PIOc_set_fill ncid = %d fillmode = %d", ncid, fillmode));
+    PLOG((1, "PIOc_set_fill ncid = %d fillmode = %d", ncid, fillmode));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -1919,7 +1919,7 @@ PIOc_set_fill(int ncid, int fillmode, int *old_modep)
             int msg = PIO_MSG_SET_FILL;
             int old_modep_present = old_modep ? 1 : 0;
 
-            LOG((3, "PIOc_set_fill about to send msg %d", msg));
+            PLOG((3, "PIOc_set_fill about to send msg %d", msg));
             if (ios->compmaster == MPI_ROOT)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
@@ -1929,8 +1929,8 @@ PIOc_set_fill(int ncid, int fillmode, int *old_modep)
                 mpierr = MPI_Bcast(&fillmode, 1, MPI_INT, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&old_modep_present, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_set_fill sent ncid = %d fillmode = %d old_modep_present = %d", ncid, fillmode,
-                 old_modep_present));
+            PLOG((2, "PIOc_set_fill sent ncid = %d fillmode = %d old_modep_present = %d", ncid, fillmode,
+                  old_modep_present));
         }
 
         /* Handle MPI errors. */
@@ -1946,7 +1946,7 @@ PIOc_set_fill(int ncid, int fillmode, int *old_modep)
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
-            LOG((3, "about to call ncmpi_set_fill() fillmode = %d", fillmode));
+            PLOG((3, "about to call ncmpi_set_fill() fillmode = %d", fillmode));
             ierr = ncmpi_set_fill(file->fh, fillmode, old_modep);
         }
 #endif /* _PNETCDF */
@@ -1964,12 +1964,12 @@ PIOc_set_fill(int ncid, int fillmode, int *old_modep)
     /* Broadcast results. */
     if (old_modep)
     {
-        LOG((2, "old_mode = %d", *old_modep));
+        PLOG((2, "old_mode = %d", *old_modep));
         if ((mpierr = MPI_Bcast(old_modep, 1, MPI_INT, ios->ioroot, ios->my_comm)))
             check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
-    LOG((2, "PIOc_set_fill succeeded"));
+    PLOG((2, "PIOc_set_fill succeeded"));
     return PIO_NOERR;
 }
 
@@ -2047,7 +2047,7 @@ PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
     if (!name || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_def_dim ncid = %d name = %s len = %d", ncid, name, len));
+    PLOG((1, "PIOc_def_dim ncid = %d name = %s len = %d", ncid, name, len));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
@@ -2102,7 +2102,7 @@ PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
         if ((mpierr = MPI_Bcast(idp , 1, MPI_INT, ios->ioroot, ios->my_comm)))
             check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
-    LOG((2, "def_dim ierr = %d", ierr));
+    PLOG((2, "def_dim ierr = %d", ierr));
     return PIO_NOERR;
 }
 
@@ -2149,8 +2149,8 @@ PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     if (!name || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_def_var ncid = %d name = %s xtype = %d ndims = %d", ncid, name,
-         xtype, ndims));
+    PLOG((1, "PIOc_def_var ncid = %d name = %s xtype = %d ndims = %d", ncid, name,
+          xtype, ndims));
 
     /* Run this on all tasks if async is not in use, but only on
      * non-IO tasks if async is in use. Learn whether each dimension
@@ -2273,7 +2273,7 @@ PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->do_io)
             ierr = nc_def_var(file->fh, name, xtype, ndims, dimidsp, &varid);
-        LOG((3, "defined var ierr %d file->iotype %d", ierr, file->iotype));
+        PLOG((3, "defined var ierr %d file->iotype %d", ierr, file->iotype));
 
 #ifdef _NETCDF4
         /* For netCDF-4 serial files, turn on compression for this variable. */
@@ -2344,8 +2344,8 @@ PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_valuep)
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_def_var_fill ncid = %d varid = %d fill_mode = %d\n", ncid, varid,
-         fill_mode));
+    PLOG((1, "PIOc_def_var_fill ncid = %d varid = %d fill_mode = %d\n", ncid, varid,
+          fill_mode));
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -2366,7 +2366,7 @@ PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_valuep)
             return check_netcdf(file, ierr, __FILE__, __LINE__);
         if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &type_size)))
             return check_netcdf(file, ierr, __FILE__, __LINE__);
-        LOG((2, "PIOc_def_var_fill type_size = %d", type_size));
+        PLOG((2, "PIOc_def_var_fill type_size = %d", type_size));
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -2393,8 +2393,8 @@ PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_valuep)
             if (!mpierr && fill_value_present)
                 mpierr = MPI_Bcast((PIO_Offset *)fill_valuep, type_size, MPI_CHAR, ios->compmaster,
                                    ios->intercomm);
-            LOG((2, "PIOc_def_var_fill ncid = %d varid = %d fill_mode = %d type_size = %d fill_value_present = %d",
-                 ncid, varid, fill_mode, type_size, fill_value_present));
+            PLOG((2, "PIOc_def_var_fill ncid = %d varid = %d fill_mode = %d type_size = %d fill_value_present = %d",
+                  ncid, varid, fill_mode, type_size, fill_value_present));
         }
 
         /* Handle MPI errors. */
@@ -2420,7 +2420,7 @@ PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_valuep)
         }
         else if (file->iotype == PIO_IOTYPE_NETCDF)
         {
-            LOG((2, "defining fill value attribute for netCDF classic file"));
+            PLOG((2, "defining fill value attribute for netCDF classic file"));
             if (file->do_io)
             {
                 ierr = nc_set_fill(file->fh, NC_FILL, NULL);
@@ -2435,7 +2435,7 @@ PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_valuep)
                 ierr = nc_def_var_fill(file->fh, varid, fill_mode, fill_valuep);
 #endif
         }
-        LOG((2, "after def_var_fill ierr = %d", ierr));
+        PLOG((2, "after def_var_fill ierr = %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -2477,13 +2477,13 @@ PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;  /* Return code from function calls. */
 
-    LOG((1, "PIOc_inq_var_fill ncid = %d varid = %d", ncid, varid));
+    PLOG((1, "PIOc_inq_var_fill ncid = %d varid = %d", ncid, varid));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
     ios = file->iosystem;
-    LOG((2, "found file"));
+    PLOG((2, "found file"));
 
     /* Run this on all tasks if async is not in use, but only on
      * non-IO tasks if async is in use. Get the size of this vars
@@ -2494,7 +2494,7 @@ PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
             return check_netcdf(file, ierr, __FILE__, __LINE__);
         if ((ierr = PIOc_inq_type(ncid, xtype, NULL, &type_size)))
             return check_netcdf(file, ierr, __FILE__, __LINE__);
-        LOG((2, "PIOc_inq_var_fill type_size = %d", type_size));
+        PLOG((2, "PIOc_inq_var_fill type_size = %d", type_size));
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -2506,7 +2506,7 @@ PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
             char no_fill_present = no_fill ? true : false;
             char fill_value_present = fill_valuep ? true : false;
 
-            LOG((2, "sending msg type_size = %d", type_size));
+            PLOG((2, "sending msg type_size = %d", type_size));
             if (ios->compmaster == MPI_ROOT)
                 mpierr = MPI_Send(&msg, 1,MPI_INT, ios->ioroot, 1, ios->union_comm);
 
@@ -2520,8 +2520,8 @@ PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
                 mpierr = MPI_Bcast(&no_fill_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&fill_value_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_inq_var_fill ncid = %d varid = %d type_size = %lld no_fill_present = %d fill_value_present = %d",
-                 ncid, varid, type_size, no_fill_present, fill_value_present));
+            PLOG((2, "PIOc_inq_var_fill ncid = %d varid = %d type_size = %lld no_fill_present = %d fill_value_present = %d",
+                  ncid, varid, type_size, no_fill_present, fill_value_present));
         }
 
         /* Handle MPI errors. */
@@ -2540,8 +2540,8 @@ PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
     {
-        LOG((2, "calling inq_var_fill file->iotype = %d file->fh = %d varid = %d",
-             file->iotype, file->fh, varid));
+        PLOG((2, "calling inq_var_fill file->iotype = %d file->fh = %d varid = %d",
+              file->iotype, file->fh, varid));
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
 #ifdef _PNETCDF
@@ -2613,7 +2613,7 @@ PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
                 ierr = nc_inq_var_fill(file->fh, varid, no_fill, fill_valuep);
 #endif /* _NETCDF */
         }
-        LOG((2, "after call to inq_var_fill, ierr = %d", ierr));
+        PLOG((2, "after call to inq_var_fill, ierr = %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -2670,12 +2670,12 @@ PIOc_get_att(int ncid, int varid, const char *name, void *ip)
     if (!name || !ip || strlen(name) > NC_MAX_NAME)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
 
-    LOG((1, "PIOc_get_att ncid %d varid %d name %s", ncid, varid, name));
+    PLOG((1, "PIOc_get_att ncid %d varid %d name %s", ncid, varid, name));
 
     /* Get the type of the attribute. */
     if ((ierr = PIOc_inq_att(ncid, varid, name, &atttype, NULL)))
         return ierr;
-    LOG((2, "atttype = %d", atttype));
+    PLOG((2, "atttype = %d", atttype));
 
     return PIOc_get_att_tc(ncid, varid, name, atttype, ip);
 }

--- a/cime/src/externals/pio2/src/clib/pio_nc4.c
+++ b/cime/src/externals/pio2/src/clib/pio_nc4.c
@@ -169,9 +169,9 @@ PIOc_inq_var_deflate(int ncid, int varid, int *shufflep, int *deflatep,
                 mpierr = MPI_Bcast(&deflate_level_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (deflate_level_present && !mpierr)
                 mpierr = MPI_Bcast(deflate_levelp, 1, MPI_INT, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_inq_var_deflate ncid = %d varid = %d shuffle_present = %d deflate_present = %d "
-                 "deflate_level_present = %d", ncid, varid, shuffle_present, deflate_present,
-                 deflate_level_present));
+            PLOG((2, "PIOc_inq_var_deflate ncid = %d varid = %d shuffle_present = %d deflate_present = %d "
+                  "deflate_level_present = %d", ncid, varid, shuffle_present, deflate_present,
+                  deflate_level_present));
         }
 
         /* Handle MPI errors. */
@@ -242,8 +242,8 @@ PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *chunks
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_def_var_chunking ncid = %d varid = %d storage = %d", ncid,
-         varid, storage));
+    PLOG((1, "PIOc_def_var_chunking ncid = %d varid = %d storage = %d", ncid,
+          varid, storage));
 
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -260,7 +260,7 @@ PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *chunks
     if (!ios->async || !ios->ioproc)
         if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
             return check_netcdf(file, ierr, __FILE__, __LINE__);
-    LOG((2, "PIOc_def_var_chunking first ndims = %d", ndims));
+    PLOG((2, "PIOc_def_var_chunking first ndims = %d", ndims));
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
     if (ios->async)
@@ -286,8 +286,8 @@ PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *chunks
             if (!mpierr && chunksizes_present)
                 mpierr = MPI_Bcast((PIO_Offset *)chunksizesp, ndims, MPI_OFFSET, ios->compmaster,
                                    ios->intercomm);
-            LOG((2, "PIOc_def_var_chunking ncid = %d varid = %d storage = %d ndims = %d chunksizes_present = %d",
-                 ncid, varid, storage, ndims, chunksizes_present));
+            PLOG((2, "PIOc_def_var_chunking ncid = %d varid = %d storage = %d ndims = %d chunksizes_present = %d",
+                  ncid, varid, storage, ndims, chunksizes_present));
         }
 
         /* Handle MPI errors. */
@@ -301,7 +301,7 @@ PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *chunks
             check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
-    LOG((2, "PIOc_def_var_chunking ndims = %d", ndims));
+    PLOG((2, "PIOc_def_var_chunking ndims = %d", ndims));
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
@@ -365,7 +365,7 @@ PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunksizes
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ndims; /* The number of dimensions in the variable. */
 
-    LOG((1, "PIOc_inq_var_chunking ncid = %d varid = %d"));
+    PLOG((1, "PIOc_inq_var_chunking ncid = %d varid = %d"));
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -383,7 +383,7 @@ PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunksizes
         /* Find the number of dimensions of this variable. */
         if ((ierr = PIOc_inq_varndims(ncid, varid, &ndims)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
-        LOG((2, "ndims = %d", ndims));
+        PLOG((2, "ndims = %d", ndims));
     }
 
     /* If async is in use, and this is not an IO task, bcast the parameters. */
@@ -408,8 +408,8 @@ PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunksizes
                 mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->compmaster, ios->intercomm);
             if (!mpierr)
                 mpierr = MPI_Bcast(&chunksizes_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
-            LOG((2, "PIOc_inq_var_chunking ncid = %d varid = %d storage_present = %d chunksizes_present = %d",
-                 ncid, varid, storage_present, chunksizes_present));
+            PLOG((2, "PIOc_inq_var_chunking ncid = %d varid = %d storage_present = %d chunksizes_present = %d",
+                  ncid, varid, storage_present, chunksizes_present));
         }
 
         /* Handle MPI errors. */
@@ -443,7 +443,7 @@ PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunksizes
                 }
         }
 #endif
-        LOG((2, "ierr = %d", ierr));
+        PLOG((2, "ierr = %d", ierr));
     }
 
     /* Broadcast and check the return code. */
@@ -572,7 +572,7 @@ PIOc_inq_var_endian(int ncid, int varid, int *endianp)
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_inq_var_endian ncid = %d varid = %d"));
+    PLOG((1, "PIOc_inq_var_endian ncid = %d varid = %d"));
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -666,8 +666,8 @@ PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_set_chunk_cache iosysid = %d iotype = %d size = %d nelems = %d preemption = %g",
-         iosysid, iotype, size, nelems, preemption));
+    PLOG((1, "PIOc_set_chunk_cache iosysid = %d iotype = %d size = %d nelems = %d preemption = %g",
+          iosysid, iotype, size, nelems, preemption));
 
     /* Get the IO system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
@@ -710,7 +710,7 @@ PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems
     if (ios->ioproc)
     {
 #ifdef _NETCDF4
-        LOG((2, "calling nc_chunk_cache"));
+        PLOG((2, "calling nc_chunk_cache"));
         if (iotype == PIO_IOTYPE_NETCDF4P)
             ierr = nc_set_chunk_cache(size, nelems, preemption);
         else
@@ -725,7 +725,7 @@ PIOc_set_chunk_cache(int iosysid, int iotype, PIO_Offset size, PIO_Offset nelems
     if (ierr)
         check_netcdf2(ios, NULL, ierr, __FILE__, __LINE__);
 
-    LOG((2, "PIOc_set_chunk_cache complete!"));
+    PLOG((2, "PIOc_set_chunk_cache complete!"));
     return PIO_NOERR;
 }
 
@@ -768,7 +768,7 @@ PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep, PIO_Offset *nel
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_get_chunk_cache iosysid = %d iotype = %d", iosysid, iotype));
+    PLOG((1, "PIOc_get_chunk_cache iosysid = %d iotype = %d", iosysid, iotype));
 
     /* Get the io system info. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
@@ -802,8 +802,8 @@ PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep, PIO_Offset *nel
             if (!mpierr)
                 mpierr = MPI_Bcast(&preemption_present, 1, MPI_CHAR, ios->compmaster,
                                    ios->intercomm);
-            LOG((2, "PIOc_get_chunk_cache size_present = %d nelems_present = %d "
-                 "preemption_present = %d ", size_present, nelems_present, preemption_present));
+            PLOG((2, "PIOc_get_chunk_cache size_present = %d nelems_present = %d "
+                  "preemption_present = %d ", size_present, nelems_present, preemption_present));
         }
 
         /* Handle MPI errors. */
@@ -823,34 +823,34 @@ PIOc_get_chunk_cache(int iosysid, int iotype, PIO_Offset *sizep, PIO_Offset *nel
             if (!ios->io_rank)
                 ierr = nc_get_chunk_cache((size_t *)sizep, (size_t *)nelemsp, preemptionp);
 #endif
-        LOG((2, "nc_get_chunk_cache called ierr = %d", ierr));
+        PLOG((2, "nc_get_chunk_cache called ierr = %d", ierr));
     }
 
     /* Broadcast and check the return code. */
     if ((mpierr = MPI_Bcast(&ierr, 1, MPI_INT, ios->ioroot, ios->my_comm)))
         return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "bcast complete ierr = %d sizep = %d", ierr, sizep));
+    PLOG((2, "bcast complete ierr = %d sizep = %d", ierr, sizep));
     if (ierr)
         return check_netcdf(NULL, ierr, __FILE__, __LINE__);
 
     if (sizep)
     {
-        LOG((2, "bcasting size = %d ios->ioroot = %d", *sizep, ios->ioroot));
+        PLOG((2, "bcasting size = %d ios->ioroot = %d", *sizep, ios->ioroot));
         if ((mpierr = MPI_Bcast(sizep, 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-        LOG((2, "bcast size = %d", *sizep));
+        PLOG((2, "bcast size = %d", *sizep));
     }
     if (nelemsp)
     {
         if ((mpierr = MPI_Bcast(nelemsp, 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-        LOG((2, "bcast complete nelems = %d", *nelemsp));
+        PLOG((2, "bcast complete nelems = %d", *nelemsp));
     }
     if (preemptionp)
     {
         if ((mpierr = MPI_Bcast(preemptionp, 1, MPI_FLOAT, ios->ioroot, ios->my_comm)))
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
-        LOG((2, "bcast complete preemption = %d", *preemptionp));
+        PLOG((2, "bcast complete preemption = %d", *preemptionp));
     }
 
     return PIO_NOERR;
@@ -976,7 +976,7 @@ PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nel
     int ierr;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
 
-    LOG((1, "PIOc_get_var_chunk_cache ncid = %d varid = %d"));
+    PLOG((1, "PIOc_get_var_chunk_cache ncid = %d varid = %d"));
 
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
@@ -1011,8 +1011,8 @@ PIOc_get_var_chunk_cache(int ncid, int varid, PIO_Offset *sizep, PIO_Offset *nel
             if (!mpierr)
                 mpierr = MPI_Bcast(&preemption_present, 1, MPI_CHAR, ios->compmaster,
                                    ios->intercomm);
-            LOG((2, "PIOc_get_var_chunk_cache size_present = %d nelems_present = %d "
-                 "preemption_present = %d ", size_present, nelems_present, preemption_present));
+            PLOG((2, "PIOc_get_var_chunk_cache size_present = %d nelems_present = %d "
+                  "preemption_present = %d ", size_present, nelems_present, preemption_present));
         }
 
         /* Handle MPI errors. */

--- a/cime/src/externals/pio2/src/clib/pio_put_nc.c
+++ b/cime/src/externals/pio2/src/clib/pio_put_nc.c
@@ -1,11 +1,11 @@
 /**
- * @file
- * PIO functions to write data.
- *
- * @author Ed Hartnett
- * @date  2016
- * @see http://code.google.com/p/parallelio/
- */
+  * @file
+  * PIO functions to write data.
+  *
+  * @author Ed Hartnett
+  * @date  2016
+  * @see http://code.google.com/p/parallelio/
+  */
 #include <config.h>
 #include <pio.h>
 #include <pio_internal.h>

--- a/cime/src/externals/pio2/src/clib/pio_put_vard.c
+++ b/cime/src/externals/pio2/src/clib/pio_put_vard.c
@@ -1,11 +1,11 @@
 /**
- * @file
- * PIO functions to write data with distributed arrays.
- *
- * @author Ed Hartnett
- * @date 2019
- * @see https://github.com/NCAR/ParallelIO
- */
+  * @file
+  * PIO functions to write data with distributed arrays.
+  *
+  * @author Ed Hartnett
+  * @date 2019
+  * @see https://github.com/NCAR/ParallelIO
+  */
 #include <config.h>
 #include <pio.h>
 #include <pio_internal.h>

--- a/cime/src/externals/pio2/src/clib/pio_rearrange.c
+++ b/cime/src/externals/pio2/src/clib/pio_rearrange.c
@@ -1,9 +1,9 @@
 /**
- * @file
- * Code to map IO to model decomposition.
- *
- * @author Jim Edwards
- */
+  * @file
+  * Code to map IO to model decomposition.
+  *
+  * @author Jim Edwards
+  */
 #include <config.h>
 #include <pio_internal.h>
 #include <pio.h>
@@ -28,13 +28,14 @@
  * corresponding to this index.
  * @author Jim Edwards
  */
-inline void idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
-                            PIO_Offset *dim_list)
+inline void
+idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
+                PIO_Offset *dim_list)
 {
     /* Check inputs. */
     pioassert(ndims >= 0 && gdimlen && idx >= -1 && dim_list, "invalid input",
               __FILE__, __LINE__);
-    LOG((2, "idx_to_dim_list ndims = %d idx = %d", ndims, idx));
+    PLOG((2, "idx_to_dim_list ndims = %d idx = %d", ndims, idx));
 
     /* Easiest to start from the right and move left. */
     for (int i = ndims - 1; i >= 0; --i)
@@ -45,8 +46,8 @@ inline void idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
          * and "%". */
         next_idx = idx / gdimlen[i];
         dim_list[i] = idx - (next_idx * gdimlen[i]);
-        LOG((3, "next_idx = %d idx = %d gdimlen[%d] = %d dim_list[%d] = %d",
-             next_idx, idx, i, gdimlen[i], i, dim_list[i]));
+        PLOG((3, "next_idx = %d idx = %d gdimlen[%d] = %d dim_list[%d] = %d",
+              next_idx, idx, i, gdimlen[i], i, dim_list[i]));
         idx = next_idx;
     }
 }
@@ -74,9 +75,10 @@ inline void idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
  * @param count array of size dim + 1 that gets the new counts.
  * @author Jim Edwards
  */
-void expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *map,
-                   int region_size, int region_stride, const int *max_size,
-                   PIO_Offset *count)
+void
+expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *map,
+              int region_size, int region_stride, const int *max_size,
+              PIO_Offset *count)
 {
     /* Flag used to signal that we can no longer expand the region
        along dimension dim. */
@@ -148,18 +150,20 @@ void expand_region(int dim, const int *gdimlen, int maplen, const PIO_Offset *ma
  * found region.
  * @param count array (length ndims) that will get counts of found
  * region.
- * @returns length of the region found.
+ * @param regionlen pointer that gets the length of the region found.
+ * @returns 0 for success, error code otherwise.
  * @author Jim Edwards
  */
-PIO_Offset find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
-                       PIO_Offset *start, PIO_Offset *count)
+int
+find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
+            PIO_Offset *start, PIO_Offset *count, PIO_Offset *regionlen)
 {
-    PIO_Offset regionlen = 1;
-
     /* Check inputs. */
-    pioassert(ndims > 0 && gdimlen && maplen > 0 && map && start && count,
-              "invalid input", __FILE__, __LINE__);
-    LOG((2, "find_region ndims = %d maplen = %d", ndims, maplen));
+    pioassert(ndims > 0 && gdimlen && maplen > 0 && map && start && count &&
+              regionlen, "invalid input", __FILE__, __LINE__);
+    PLOG((2, "find_region ndims = %d maplen = %d", ndims, maplen));
+
+    *regionlen = 1;
 
     int max_size[ndims];
 
@@ -172,7 +176,7 @@ PIO_Offset find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offs
     for (int dim = 0; dim < ndims; ++dim)
     {
         max_size[dim] = gdimlen[dim] - start[dim];
-        LOG((3, "max_size[%d] = %d", max_size[dim]));
+        PLOG((3, "max_size[%d] = %d", max_size[dim]));
     }
 
     /* For each dimension, figure out how far we can expand in that dimension
@@ -184,9 +188,9 @@ PIO_Offset find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offs
 
     /* Calculate the number of data elements in this region. */
     for (int dim = 0; dim < ndims; dim++)
-        regionlen *= count[dim];
+        *regionlen *= count[dim];
 
-    return regionlen;
+    return PIO_NOERR;
 }
 
 /**
@@ -198,7 +202,8 @@ PIO_Offset find_region(int ndims, const int *gdimlen, int maplen, const PIO_Offs
  * @returns the local array index.
  * @author Jim Edwards
  */
-inline PIO_Offset coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO_Offset *count)
+inline PIO_Offset
+coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO_Offset *count)
 {
     PIO_Offset lindex = 0;
     PIO_Offset stride = 1;
@@ -225,7 +230,8 @@ inline PIO_Offset coord_to_lindex(int ndims, const PIO_Offset *lcoord, const PIO
  * @returns 0 for success, error code otherwise.
  * @author Jim Edwards
  */
-int compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
+int
+compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
 {
     PIO_Offset totiosize = 0;
     int mpierr; /* Return code from MPI calls. */
@@ -244,13 +250,13 @@ int compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
             totiosize += iosize;
         }
     }
-    LOG((2, "compute_maxIObuffersize got totiosize = %lld", totiosize));
+    PLOG((2, "compute_maxIObuffersize got totiosize = %lld", totiosize));
 
     /* Share the max io buffer size with all io tasks. */
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &totiosize, 1, MPI_OFFSET, MPI_MAX, io_comm)))
         return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     pioassert(totiosize > 0, "totiosize <= 0", __FILE__, __LINE__);
-    LOG((2, "after allreduce compute_maxIObuffersize got totiosize = %lld", totiosize));
+    PLOG((2, "after allreduce compute_maxIObuffersize got totiosize = %lld", totiosize));
 
     /* Remember the result. */
     iodesc->maxiobuflen = totiosize;
@@ -275,35 +281,39 @@ int compute_maxIObuffersize(MPI_Comm io_comm, io_desc_t *iodesc)
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
-                         const PIO_Offset *mindex, const int *mcount, int *mfrom,
-                         MPI_Datatype *mtype)
+int
+create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
+                     const PIO_Offset *mindex, const int *mcount, int *mfrom,
+                     MPI_Datatype *mtype)
 {
     int blocksize;
     int numinds = 0;
     PIO_Offset *lindex = NULL;
     int mpierr; /* Return code from MPI functions. */
+    int ret = PIO_NOERR;
 
     /* Check inputs. */
     pioassert(msgcnt > 0 && mcount, "invalid input", __FILE__, __LINE__);
 
     PIO_Offset bsizeT[msgcnt];
 
-    LOG((1, "create_mpi_datatypes mpitype = %d msgcnt = %d", mpitype, msgcnt));
-    LOG((2, "MPI_BYTE = %d MPI_CHAR = %d MPI_SHORT = %d MPI_INT = %d MPI_FLOAT = %d MPI_DOUBLE = %d",
-         MPI_BYTE, MPI_CHAR, MPI_SHORT, MPI_INT, MPI_FLOAT, MPI_DOUBLE));
+    PLOG((1, "create_mpi_datatypes mpitype = %d msgcnt = %d", mpitype,
+          msgcnt));
+    PLOG((2, "MPI_BYTE = %d MPI_CHAR = %d MPI_SHORT = %d MPI_INT = %d "
+          "MPI_FLOAT = %d MPI_DOUBLE = %d", MPI_BYTE, MPI_CHAR, MPI_SHORT,
+          MPI_INT, MPI_FLOAT, MPI_DOUBLE));
 
     /* How many indicies in the array? */
     for (int j = 0; j < msgcnt; j++)
         numinds += mcount[j];
-    LOG((2, "numinds = %d", numinds));
+    PLOG((2, "numinds = %d", numinds));
 
     if (mindex)
     {
         if (!(lindex = malloc(numinds * sizeof(PIO_Offset))))
             return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
         memcpy(lindex, mindex, (size_t)(numinds * sizeof(PIO_Offset)));
-        LOG((3, "allocated lindex, copied mindex"));
+        PLOG((3, "allocated lindex, copied mindex"));
     }
 
     bsizeT[0] = 0;
@@ -315,7 +325,7 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
      * rearrangers. (If mfrom is NULL, this is the box rearranger.) */
     if (mfrom == NULL)
     {
-        LOG((3, "mfrom is NULL"));
+        PLOG((3, "mfrom is NULL"));
         for (int i = 0; i < msgcnt; i++)
         {
             if (mcount[i] > 0)
@@ -334,7 +344,7 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
     {
         blocksize = 1;
     }
-    LOG((3, "blocksize = %d", blocksize));
+    PLOG((3, "blocksize = %d", blocksize));
 
     /* pos is an index to the start of each message block. */
     pos = 0;
@@ -346,10 +356,10 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
             int *displace;
 
             if (!(displace = malloc(sizeof(int) * len)))
-                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+                EXIT1(PIO_ENOMEM);
 
-            LOG((3, "blocksize = %d i = %d mcount[%d] = %d len = %d", blocksize, i, i,
-                 mcount[i], len));
+            PLOG((3, "blocksize = %d i = %d mcount[%d] = %d len = %d", blocksize, i, i,
+                  mcount[i], len));
             if (blocksize == 1)
             {
                 if (!mfrom)
@@ -379,11 +389,11 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
 
 #if PIO_ENABLE_LOGGING
             for (int j = 0; j < len; j++)
-                LOG((3, "displace[%d] = %d", j, displace[j]));
+                PLOG((3, "displace[%d] = %d", j, displace[j]));
 #endif /* PIO_ENABLE_LOGGING */
 
-            LOG((3, "calling MPI_Type_create_indexed_block len = %d blocksize = %d "
-                 "mpitype = %d", len, blocksize, mpitype));
+            PLOG((3, "calling MPI_Type_create_indexed_block len = %d blocksize = %d "
+                  "mpitype = %d", len, blocksize, mpitype));
             /* Create an indexed datatype with constant-sized blocks. */
             mpierr = MPI_Type_create_indexed_block(len, blocksize, displace,
                                                    mpitype, &mtype[i]);
@@ -396,19 +406,21 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
                 return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
             /* Commit the MPI data type. */
-            LOG((3, "about to commit type"));
+            PLOG((3, "about to commit type"));
             if ((mpierr = MPI_Type_commit(&mtype[i])))
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
             pos += mcount[i];
         }
     }
 
+    PLOG((3, "done with create_mpi_datatypes()"));
+
+exit:
     /* Free resources. */
     if (lindex)
         free(lindex);
 
-    LOG((3, "done with create_mpi_datatypes()"));
-    return PIO_NOERR;
+    return ret;
 }
 
 /**
@@ -432,13 +444,14 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
+int
+define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
 {
     int ret; /* Return value. */
 
     pioassert(ios && iodesc, "invalid input", __FILE__, __LINE__);
-    LOG((1, "define_iodesc_datatypes ios->ioproc = %d iodesc->rtype is %sNULL, iodesc->nrecvs",
-         ios->ioproc, iodesc->rtype ? "not " : "", iodesc->nrecvs));
+    PLOG((1, "define_iodesc_datatypes ios->ioproc = %d iodesc->rtype is %sNULL, iodesc->nrecvs",
+          ios->ioproc, iodesc->rtype ? "not " : "", iodesc->nrecvs));
 
     /* Set up the to transfer data to and from the IO tasks. */
     if (ios->ioproc)
@@ -452,8 +465,8 @@ int define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
                 /* Allocate memory for array of MPI types for the IO tasks. */
                 if (!(iodesc->rtype = malloc(iodesc->nrecvs * sizeof(MPI_Datatype))))
                     return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-                LOG((2, "allocated memory for IO task MPI types iodesc->nrecvs = %d "
-                     "iodesc->rearranger = %d", iodesc->nrecvs, iodesc->rearranger));
+                PLOG((2, "allocated memory for IO task MPI types iodesc->nrecvs = %d "
+                      "iodesc->rearranger = %d", iodesc->nrecvs, iodesc->rearranger));
 
                 /* Initialize data types to NULL. */
                 for (int i = 0; i < iodesc->nrecvs; i++)
@@ -486,7 +499,7 @@ int define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
             /* Allocate memory for array of MPI types for the computation tasks. */
             if (!(iodesc->stype = malloc(ntypes * sizeof(MPI_Datatype))))
                 return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-            LOG((3, "allocated memory for computation MPI types ntypes = %d", ntypes));
+            PLOG((3, "allocated memory for computation MPI types ntypes = %d", ntypes));
 
             /* Initialize send types to NULL. */
             for (int i = 0; i < ntypes; i++)
@@ -496,14 +509,14 @@ int define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
             iodesc->num_stypes = ntypes;
 
             /* Create the MPI data types. */
-            LOG((3, "about to call create_mpi_datatypes for computation MPI types"));
+            PLOG((3, "about to call create_mpi_datatypes for computation MPI types"));
             if ((ret = create_mpi_datatypes(iodesc->mpitype, ntypes, iodesc->sindex,
                                             iodesc->scount, NULL, iodesc->stype)))
                 return pio_err(ios, NULL, ret, __FILE__, __LINE__);
         }
     }
 
-    LOG((3, "done with define_iodesc_datatypes()"));
+    PLOG((3, "done with define_iodesc_datatypes()"));
     return PIO_NOERR;
 }
 
@@ -539,8 +552,9 @@ int define_iodesc_datatypes(iosystem_desc_t *ios, io_desc_t *iodesc)
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
-                   const int *dest_ioproc, const PIO_Offset *dest_ioindex)
+int
+compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
+               const int *dest_ioproc, const PIO_Offset *dest_ioindex)
 {
     int *recv_buf = NULL;
     int nrecvs = 0;
@@ -551,8 +565,8 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
                                 (iodesc->ndof > 0 && dest_ioproc && dest_ioindex)) &&
               iodesc->rearranger == PIO_REARR_BOX && ios->num_uniontasks > 0,
               "invalid input", __FILE__, __LINE__);
-    LOG((1, "compute_counts ios->num_uniontasks = %d ios->compproc %d ios->ioproc %d",
-         ios->num_uniontasks, ios->compproc, ios->ioproc));
+    PLOG((1, "compute_counts ios->num_uniontasks = %d ios->compproc %d ios->ioproc %d",
+          ios->num_uniontasks, ios->compproc, ios->ioproc));
 
     /* Arrays for swapm all to all gather calls. */
     MPI_Datatype sr_types[ios->num_uniontasks];
@@ -604,8 +618,8 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
         {
             send_counts[ios->ioranks[i]] = 1;
             send_displs[ios->ioranks[i]] = i * sizeof(int);
-            LOG((3, "send_counts[%d] = %d send_displs[%d] = %d", ios->ioranks[i],
-                 send_counts[ios->ioranks[i]], ios->ioranks[i], send_displs[ios->ioranks[i]]));
+            PLOG((3, "send_counts[%d] = %d send_displs[%d] = %d", ios->ioranks[i],
+                  send_counts[ios->ioranks[i]], ios->ioranks[i], send_displs[ios->ioranks[i]]));
         }
     }
 
@@ -625,13 +639,13 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
         {
             recv_counts[ios->compranks[i]] = 1;
             recv_displs[ios->compranks[i]] = i * sizeof(int);
-            LOG((3, "recv_counts[%d] = %d recv_displs[%d] = %d", ios->compranks[i],
-                 recv_counts[ios->compranks[i]], ios->compranks[i],
-                 recv_displs[ios->compranks[i]]));
+            PLOG((3, "recv_counts[%d] = %d recv_displs[%d] = %d", ios->compranks[i],
+                  recv_counts[ios->compranks[i]], ios->compranks[i],
+                  recv_displs[ios->compranks[i]]));
         }
     }
 
-    LOG((2, "about to share scount from each compute task to all IO tasks."));
+    PLOG((2, "about to share scount from each compute task to all IO tasks."));
     /* Share the iodesc->scount from each compute task to all IO
      * tasks. The scounts will end up in array recv_buf. */
     if ((ierr = pio_swapm(iodesc->scount, send_counts, send_displs, sr_types,
@@ -648,7 +662,7 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
         {
             if (recv_buf[i] != 0)
                 nrecvs++;
-            LOG((3, "recv_buf[%d] = %d", i, recv_buf[i]));
+            PLOG((3, "recv_buf[%d] = %d", i, recv_buf[i]));
         }
 
         /* Get memory to hold the count of data receives. */
@@ -658,7 +672,7 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
         /* Get memory to hold the list of task data was from. */
         if (!(iodesc->rfrom = calloc(max(1, nrecvs), sizeof(int))))
             return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        LOG((3, "allocared rfrom max(1, nrecvs) = %d", max(1, nrecvs)));
+        PLOG((3, "allocared rfrom max(1, nrecvs) = %d", max(1, nrecvs)));
 
         nrecvs = 0;
         for (int i = 0; i < ios->num_comptasks; i++)
@@ -675,14 +689,14 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
 
     /* ??? */
     iodesc->nrecvs = nrecvs;
-    LOG((3, "iodesc->nrecvs = %d", iodesc->nrecvs));
+    PLOG((3, "iodesc->nrecvs = %d", iodesc->nrecvs));
 
     /* Allocate an array for indicies on the computation tasks (the
      * send side when writing). */
     if (iodesc->sindex == NULL && iodesc->ndof > 0)
         if (!(iodesc->sindex = malloc(iodesc->ndof * sizeof(PIO_Offset))))
             return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-    LOG((2, "iodesc->ndof = %d ios->num_iotasks = %d", iodesc->ndof, ios->num_iotasks));
+    PLOG((2, "iodesc->ndof = %d ios->num_iotasks = %d", iodesc->ndof, ios->num_iotasks));
 
     int tempcount[ios->num_iotasks];
     int spos[ios->num_iotasks];
@@ -694,7 +708,7 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     {
         spos[i] = spos[i - 1] + iodesc->scount[i - 1];
         tempcount[i] = 0;
-        LOG((3, "spos[%d] = %d tempcount[%d] = %d", i, spos[i], i, tempcount[i]));
+        PLOG((3, "spos[%d] = %d tempcount[%d] = %d", i, spos[i], i, tempcount[i]));
     }
 
     /* ??? */
@@ -703,8 +717,8 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
         int iorank;
         int ioindex;
 
-        LOG((3, "dest_ioproc[%d] = %d dest_ioindex[%d] = %d", i, dest_ioproc[i], i,
-             dest_ioindex[i]));
+        PLOG((3, "dest_ioproc[%d] = %d dest_ioindex[%d] = %d", i, dest_ioproc[i], i,
+              dest_ioindex[i]));
         iorank = dest_ioproc[i];
         ioindex = dest_ioindex[i];
         if (iorank > -1)
@@ -714,8 +728,8 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
 
             s2rindex[spos[iorank] + tempcount[iorank]] = ioindex;
             (tempcount[iorank])++;
-            LOG((3, "iorank = %d ioindex = %d tempcount[iorank] = %d", iorank, ioindex,
-                 tempcount[iorank]));
+            PLOG((3, "iorank = %d ioindex = %d tempcount[iorank] = %d", iorank, ioindex,
+                  tempcount[iorank]));
         }
     }
 
@@ -736,8 +750,8 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
         send_counts[ios->ioranks[i]] = iodesc->scount[i];
         if (send_counts[ios->ioranks[i]] > 0)
             send_displs[ios->ioranks[i]] = spos[i] * SIZEOF_MPI_OFFSET;
-        LOG((3, "ios->ioranks[i] = %d iodesc->scount[%d] = %d spos[%d] = %d",
-             ios->ioranks[i], i, iodesc->scount[i], i, spos[i]));
+        PLOG((3, "ios->ioranks[i] = %d iodesc->scount[%d] = %d spos[%d] = %d",
+              ios->ioranks[i], i, iodesc->scount[i], i, spos[i]));
     }
 
     /* Only do this on IO tasks. */
@@ -755,19 +769,19 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
         {
             recv_displs[iodesc->rfrom[i]] = recv_displs[iodesc->rfrom[i - 1]] +
                 iodesc->rcount[i - 1] * SIZEOF_MPI_OFFSET;
-            LOG((3, "iodesc->rfrom[%d] = %d recv_displs[iodesc->rfrom[i]] = %d", i,
-                 iodesc->rfrom[i], recv_displs[iodesc->rfrom[i]]));
+            PLOG((3, "iodesc->rfrom[%d] = %d recv_displs[iodesc->rfrom[i]] = %d", i,
+                  iodesc->rfrom[i], recv_displs[iodesc->rfrom[i]]));
         }
 
         /* rindex is an array of the indices of the data to be sent from
            this io task to each compute task. */
-        LOG((3, "totalrecv = %d", totalrecv));
+        PLOG((3, "totalrecv = %d", totalrecv));
         if (totalrecv > 0)
         {
             totalrecv = iodesc->llen;  /* can reduce memory usage here */
             if (!(iodesc->rindex = calloc(totalrecv, sizeof(PIO_Offset))))
                 return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-            LOG((3, "allocated totalrecv elements in rindex array"));
+            PLOG((3, "allocated totalrecv elements in rindex array"));
         }
     }
 
@@ -778,7 +792,7 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     /* Here we are sending the mapping from the index on the compute
      * task to the index on the io task. */
     /* s2rindex is the list of indeces on each compute task */
-    LOG((3, "sending mapping"));
+    PLOG((3, "sending mapping"));
     if ((ierr = pio_swapm(s2rindex, send_counts, send_displs, sr_types, iodesc->rindex,
                           recv_counts, recv_displs, sr_types, ios->union_comm,
                           &iodesc->rearr_opts.comp2io)))
@@ -801,8 +815,9 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
-                      void *rbuf, int nvars)
+int
+rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
+                  void *rbuf, int nvars)
 {
     int ntasks;       /* Number of tasks in communicator. */
     int niotasks;     /* Number of IO tasks. */
@@ -819,8 +834,8 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     /* Caller must provide these. */
     pioassert(ios && iodesc && nvars > 0, "invalid input", __FILE__, __LINE__);
 
-    LOG((1, "rearrange_comp2io nvars = %d iodesc->rearranger = %d", nvars,
-         iodesc->rearranger));
+    PLOG((1, "rearrange_comp2io nvars = %d iodesc->rearranger = %d", nvars,
+          iodesc->rearranger));
 
     /* Different rearraangers use different communicators. */
     if (iodesc->rearranger == PIO_REARR_BOX)
@@ -857,8 +872,8 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
         recvtypes[i] = PIO_DATATYPE_NULL;
         sendtypes[i] =  PIO_DATATYPE_NULL;
     }
-    LOG((3, "ntasks = %d iodesc->mpitype_size = %d niotasks = %d", ntasks,
-         iodesc->mpitype_size, niotasks));
+    PLOG((3, "ntasks = %d iodesc->mpitype_size = %d niotasks = %d", ntasks,
+          iodesc->mpitype_size, niotasks));
 
     /* If it has not already been done, define the MPI data types that
      * will be used for this io_desc_t. */
@@ -867,18 +882,18 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
 
     /* If this io proc, we need to exchange data with compute
      * tasks. Create a MPI DataType for that exchange. */
-    LOG((2, "ios->ioproc %d iodesc->nrecvs = %d", ios->ioproc, iodesc->nrecvs));
+    PLOG((2, "ios->ioproc %d iodesc->nrecvs = %d", ios->ioproc, iodesc->nrecvs));
     if (ios->ioproc && iodesc->nrecvs > 0)
     {
         for (int i = 0; i < iodesc->nrecvs; i++)
         {
             if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
             {
-                LOG((3, "iodesc->rtype[%d] = %d iodesc->rearranger = %d", i, iodesc->rtype[i],
-                     iodesc->rearranger));
+                PLOG((3, "iodesc->rtype[%d] = %d iodesc->rearranger = %d", i, iodesc->rtype[i],
+                      iodesc->rearranger));
                 if (iodesc->rearranger == PIO_REARR_SUBSET)
                 {
-                    LOG((3, "exchanging data for subset rearranger"));
+                    PLOG((3, "exchanging data for subset rearranger"));
                     recvcounts[i] = 1;
 
                     /*  Create an MPI derived data type from equally
@@ -897,9 +912,9 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
                 else
                 {
                     recvcounts[iodesc->rfrom[i]] = 1;
-                    LOG((3, "exchanging data for box rearranger i = %d iodesc->rfrom[i] = %d "
-                         "recvcounts[iodesc->rfrom[i]] = %d", i, iodesc->rfrom[i],
-                         recvcounts[iodesc->rfrom[i]]));
+                    PLOG((3, "exchanging data for box rearranger i = %d iodesc->rfrom[i] = %d "
+                          "recvcounts[iodesc->rfrom[i]] = %d", i, iodesc->rfrom[i],
+                          recvcounts[iodesc->rfrom[i]]));
 
                     if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->llen * iodesc->mpitype_size,
                                                           iodesc->rtype[i], &recvtypes[iodesc->rfrom[i]])))
@@ -924,14 +939,14 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
         for (int i = 0; i < niotasks; i++)
         {
             int io_comprank = ios->ioranks[i];
-            LOG((3, "ios->ioranks[%d] = %d", i, ios->ioranks[i]));
+            PLOG((3, "ios->ioranks[%d] = %d", i, ios->ioranks[i]));
             if (iodesc->rearranger == PIO_REARR_SUBSET)
                 io_comprank = 0;
 
-            LOG((3, "i = %d iodesc->scount[i] = %d", i, iodesc->scount[i]));
+            PLOG((3, "i = %d iodesc->scount[i] = %d", i, iodesc->scount[i]));
             if (iodesc->scount[i] > 0 && sbuf)
             {
-                LOG((3, "io task %d creating sendtypes[%d]", i, io_comprank));
+                PLOG((3, "io task %d creating sendtypes[%d]", i, io_comprank));
                 sendcounts[io_comprank] = 1;
                 if ((mpierr = MPI_Type_create_hvector(nvars, 1, (MPI_Aint)iodesc->ndof * iodesc->mpitype_size,
                                                       iodesc->stype[i], &sendtypes[io_comprank])))
@@ -949,7 +964,7 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     }
 
     /* Data in sbuf on the compute nodes is sent to rbuf on the ionodes */
-    LOG((2, "about to call pio_swapm for sbuf"));
+    PLOG((2, "about to call pio_swapm for sbuf"));
     if ((ret = pio_swapm(sbuf, sendcounts, sdispls, sendtypes,
                          rbuf, recvcounts, rdispls, recvtypes, mycomm,
                          &iodesc->rearr_opts.comp2io)))
@@ -958,7 +973,7 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     /* Free the MPI types. */
     for (int i = 0; i < ntasks; i++)
     {
-        LOG((3, "freeing MPI types for task %d", i));
+        PLOG((3, "freeing MPI types for task %d", i));
         if (sendtypes[i] != PIO_DATATYPE_NULL)
             if ((mpierr = MPI_Type_free(&sendtypes[i])))
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
@@ -987,15 +1002,15 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
-                      void *rbuf)
+int
+rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
+                  void *rbuf)
 {
     MPI_Comm mycomm;
     int ntasks;
     int niotasks;
     int mpierr; /* Return code from MPI calls. */
     int ret;
-    void *tmparray;
 
     /* Check inputs. */
     pioassert(ios && iodesc, "invalid input", __FILE__, __LINE__);
@@ -1018,7 +1033,7 @@ int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
         mycomm = iodesc->subset_comm;
         niotasks = 1;
     }
-    LOG((3, "niotasks = %d", niotasks));
+    PLOG((3, "niotasks = %d", niotasks));
 
     /* Get the size of this communicator. */
     if ((mpierr = MPI_Comm_size(mycomm, &ntasks)))
@@ -1119,8 +1134,9 @@ int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
-                   const PIO_Offset *compmap)
+int
+determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
+               const PIO_Offset *compmap)
 {
     PIO_Offset totalllen = 0;
     PIO_Offset totalgridsize = 1;
@@ -1143,12 +1159,12 @@ int determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
                 totalllen++;
 
     /* Add results accross communicator. */
-    LOG((2, "determine_fill before allreduce totalllen = %d totalgridsize = %d",
-         totalllen, totalgridsize));
+    PLOG((2, "determine_fill before allreduce totalllen = %d totalgridsize = %d",
+          totalllen, totalgridsize));
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &totalllen, 1, PIO_OFFSET, MPI_SUM,
                                 ios->union_comm)))
         check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-    LOG((2, "after allreduce totalllen = %d", totalllen));
+    PLOG((2, "after allreduce totalllen = %d", totalllen));
 
     /* If the total size of the data provided to be written is < the
      * total data size then we need fill values. */
@@ -1200,16 +1216,17 @@ int determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap,
-                         const int *gdimlen, int ndims, io_desc_t *iodesc)
+int
+box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *compmap,
+                     const int *gdimlen, int ndims, io_desc_t *iodesc)
 {
     int ret;
 
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims > 0 && iodesc,
               "invalid input", __FILE__, __LINE__);
-    LOG((1, "box_rearrange_create maplen = %d ndims = %d ios->num_comptasks = %d "
-         "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
+    PLOG((1, "box_rearrange_create maplen = %d ndims = %d ios->num_comptasks = %d "
+          "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
 
     /* Allocate arrays needed for this function. */
     int *dest_ioproc = NULL; /* Destination IO task for each data element on compute task. */
@@ -1295,8 +1312,8 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
      * the IO task. For computation tasks, llen will remain at 0. Also
      * set up arrays for the allgather which will give every IO task a
      * complete list of llens for each IO task. */
-    LOG((3, "ios->ioproc = %d ios->num_uniontasks = %d", ios->ioproc,
-         ios->num_uniontasks));
+    PLOG((3, "ios->ioproc = %d ios->num_uniontasks = %d", ios->ioproc,
+          ios->num_uniontasks));
     pioassert(iodesc->llen == 0, "error", __FILE__, __LINE__);
     if (ios->ioproc)
     {
@@ -1307,17 +1324,17 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
         for (int i = 0; i < ndims; i++)
         {
             iodesc->llen *= iodesc->firstregion->count[i];
-            LOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
-                 i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
+            PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
+                  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
         }
-        LOG((2, "iodesc->llen = %d", iodesc->llen));
+        PLOG((2, "iodesc->llen = %d", iodesc->llen));
     }
 
     /* Determine whether fill values will be needed. */
     if ((ret = determine_fill(ios, iodesc, gdimlen, compmap)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-    LOG((2, "iodesc->needsfill = %d ios->num_iotasks = %d", iodesc->needsfill,
-         ios->num_iotasks));
+    PLOG((2, "iodesc->needsfill = %d ios->num_iotasks = %d", iodesc->needsfill,
+          ios->num_iotasks));
 
     /* Set the iomaplen in the sc_info msg */
     sc_info_msg_send[0] = iodesc->llen;
@@ -1366,8 +1383,8 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
     }
 
     /* Send sc_info msg from iotasks (all iotasks) to all procs(compute and I/O procs)*/
-    LOG((3, "about to call pio_swapm with start/count from iotask ndims = %d",
-         ndims));
+    PLOG((3, "about to call pio_swapm with start/count from iotask ndims = %d",
+          ndims));
     if ((ret = pio_swapm(sc_info_msg_send, sendcounts, sdispls, dtypes, sc_info_msg_recv,
                          recvcounts, rdispls, dtypes, ios->union_comm,
                          &iodesc->rearr_opts.io2comp)))
@@ -1376,18 +1393,18 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
 #if PIO_ENABLE_LOGGING
     /* First entry in the sc_info msg for each iorank is the iomaplen */
     for (int i = 0; i < ios->num_iotasks; i++)
-        LOG((3, "iomaplen[%d] = %d", i, sc_info_msg_recv[i * sc_info_msg_sz]));
+        PLOG((3, "iomaplen[%d] = %d", i, sc_info_msg_recv[i * sc_info_msg_sz]));
 #endif /* PIO_ENABLE_LOGGING */
 
     /* Convert a 1-D index into a global coordinate value for each data element */
     for (int k = 0; k < maplen; k++)
     {
         /* The compmap array is 1 based but calculations are 0 based */
-        LOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
+        PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
         idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
 #if PIO_ENABLE_LOGGING
         for (int d = 0; d < ndims; d++)
-            LOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
+            PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
 #endif /* PIO_ENABLE_LOGGING */
     }
 
@@ -1405,7 +1422,7 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
 
 #if PIO_ENABLE_LOGGING
             for (int d = 0; d < ndims; d++)
-                LOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
+                PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
 #endif /* PIO_ENABLE_LOGGING */
 
             /* For each element of the data array on the compute task,
@@ -1442,8 +1459,8 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
                 {
                     dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
                     dest_ioproc[k] = i;
-                    LOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
-                         k, dest_ioproc[k]));
+                    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
+                          k, dest_ioproc[k]));
                 }
             }
         }
@@ -1458,12 +1475,12 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
     for (int k = 0; k < maplen; k++)
         if (dest_ioproc[k] < 0 && compmap[k] > 0)
         {
-            LOG((1, "Error: Found dest_ioproc[%d] = %d and compmap[%d] = %lld", k, dest_ioproc[k], k, compmap[k]));
+            PLOG((1, "Error: Found dest_ioproc[%d] = %d and compmap[%d] = %lld", k, dest_ioproc[k], k, compmap[k]));
             return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
         }
 
     /* Completes the mapping for the box rearranger. */
-    LOG((2, "calling compute_counts maplen = %d", maplen));
+    PLOG((2, "calling compute_counts maplen = %d", maplen));
     if ((ret = compute_counts(ios, iodesc, dest_ioproc, dest_ioindex)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
@@ -1477,14 +1494,14 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
     {
         if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
             return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-        LOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
+        PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
     }
 
     /* Using maxiobuflen compute the maximum number of bytes that the
      * io task buffer can handle. */
     if ((ret = compute_maxaggregate_bytes(ios, iodesc)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-    LOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
+    PLOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:box_rearrange_create")))
@@ -1493,7 +1510,6 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
 
     return PIO_NOERR;
 }
-
 
 /**
  * The box_rearrange_create algorithm optimized for the case where many
@@ -1511,10 +1527,11 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
-                                    const PIO_Offset *compmap,
-                                    const int *gdimlen, int ndims,
-                                    io_desc_t *iodesc)
+int
+box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
+                                const PIO_Offset *compmap,
+                                const int *gdimlen, int ndims,
+                                io_desc_t *iodesc)
 {
     int ret;
 
@@ -1527,8 +1544,8 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims > 0 && iodesc,
               "invalid input", __FILE__, __LINE__);
-    LOG((1, "box_rearrange_create maplen = %d ndims = %d ios->num_comptasks = %d "
-         "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
+    PLOG((1, "box_rearrange_create maplen = %d ndims = %d ios->num_comptasks = %d "
+          "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
 
     /* Allocate arrays needed for this function. */
     int *dest_ioproc = NULL; /* Destination IO task for each data element on compute task. */
@@ -1586,8 +1603,8 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
      * the IO task. For computation tasks, llen will remain at 0. Also
      * set up arrays for the allgather which will give every IO task a
      * complete list of llens for each IO task. */
-    LOG((3, "ios->ioproc = %d ios->num_uniontasks = %d", ios->ioproc,
-         ios->num_uniontasks));
+    PLOG((3, "ios->ioproc = %d ios->num_uniontasks = %d", ios->ioproc,
+          ios->num_uniontasks));
     pioassert(iodesc->llen == 0, "error", __FILE__, __LINE__);
     if (ios->ioproc)
     {
@@ -1605,17 +1622,17 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
         for (int i = 0; i < ndims; i++)
         {
             iodesc->llen *= iodesc->firstregion->count[i];
-            LOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
-                 i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
+            PLOG((3, "iodesc->firstregion->start[%d] = %d iodesc->firstregion->count[%d] = %d",
+                  i, iodesc->firstregion->start[i], i, iodesc->firstregion->count[i]));
         }
-        LOG((2, "iodesc->llen = %d", iodesc->llen));
+        PLOG((2, "iodesc->llen = %d", iodesc->llen));
     }
 
     /* Determine whether fill values will be needed. */
     if ((ret = determine_fill(ios, iodesc, gdimlen, compmap)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-    LOG((2, "iodesc->needsfill = %d ios->num_iotasks = %d", iodesc->needsfill,
-         ios->num_iotasks));
+    PLOG((2, "iodesc->needsfill = %d ios->num_iotasks = %d", iodesc->needsfill,
+          ios->num_iotasks));
 
     /* Set up receive counts and displacements to for an AllToAll
      * gather of llen. */
@@ -1623,32 +1640,32 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
     {
         recvcounts[ios->ioranks[i]] = 1;
         rdispls[ios->ioranks[i]] = i * SIZEOF_MPI_OFFSET;
-        LOG((3, "i = %d ios->ioranks[%d] = %d recvcounts[%d] = %d rdispls[%d] = %d",
-             i, i, ios->ioranks[i], ios->ioranks[i], recvcounts[ios->ioranks[i]],
-             ios->ioranks[i], rdispls[ios->ioranks[i]]));
+        PLOG((3, "i = %d ios->ioranks[%d] = %d recvcounts[%d] = %d rdispls[%d] = %d",
+              i, i, ios->ioranks[i], ios->ioranks[i], recvcounts[ios->ioranks[i]],
+              ios->ioranks[i], rdispls[ios->ioranks[i]]));
     }
 
     /* All-gather the llen to all tasks into array iomaplen. */
-    LOG((3, "calling pio_swapm to allgather llen into array iomaplen, ndims = %d dtypes[0] = %d",
-         ndims, dtypes));
+    PLOG((3, "calling pio_swapm to allgather llen into array iomaplen, ndims = %d dtypes[0] = %d",
+          ndims, dtypes));
     if ((ret = pio_swapm(&iodesc->llen, sendcounts, sdispls, dtypes, iomaplen, recvcounts,
                          rdispls, dtypes, ios->union_comm, &iodesc->rearr_opts.io2comp)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-    LOG((3, "iodesc->llen = %d", iodesc->llen));
+    PLOG((3, "iodesc->llen = %d", iodesc->llen));
 #if PIO_ENABLE_LOGGING
     for (int i = 0; i < ios->num_iotasks; i++)
-        LOG((3, "iomaplen[%d] = %d", i, iomaplen[i]));
+        PLOG((3, "iomaplen[%d] = %d", i, iomaplen[i]));
 #endif /* PIO_ENABLE_LOGGING */
 
     /* Convert a 1-D index into a global coordinate value for each data element */
     for (int k = 0; k < maplen; k++)
     {
         /* The compmap array is 1 based but calculations are 0 based */
-        LOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
+        PLOG((3, "about to call idx_to_dim_list ndims = %d ", ndims));
         idx_to_dim_list(ndims, gdimlen, compmap[k] - 1, gcoord_map[k]);
 #if PIO_ENABLE_LOGGING
         for (int d = 0; d < ndims; d++)
-            LOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
+            PLOG((3, "gcoord_map[%d][%d] = %lld", k, d, gcoord_map[k][d]));
 #endif /* PIO_ENABLE_LOGGING */
     }
 
@@ -1657,7 +1674,7 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
     {
         /* The ipmaplen contains the llen (number of data elements)
          * for this IO task. */
-        LOG((2, "iomaplen[%d] = %d", i, iomaplen[i]));
+        PLOG((2, "iomaplen[%d] = %d", i, iomaplen[i]));
 
         /* If there is data for this IO task, send start/count to all
          * compute tasks. */
@@ -1687,8 +1704,8 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
             recvcounts[ios->ioranks[i]] = ndims * 2;
 
             /* The start/count array from iotask i is sent to all compute tasks. */
-            LOG((3, "about to call pio_swapm with start/count from iotask %d ndims = %d",
-                 i, ndims));
+            PLOG((3, "about to call pio_swapm with start/count from iotask %d ndims = %d",
+                  i, ndims));
             if ((ret = pio_swapm(start_count_send, sendcounts, sdispls, dtypes, start_count_recv,
                                  recvcounts, rdispls, dtypes, ios->union_comm,
                                  &iodesc->rearr_opts.io2comp)))
@@ -1700,7 +1717,7 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
 
 #if PIO_ENABLE_LOGGING
             for (int d = 0; d < ndims; d++)
-                LOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
+                PLOG((3, "start[%d] = %lld count[%d] = %lld", d, start[d], d, count[d]));
 #endif /* PIO_ENABLE_LOGGING */
 
             /* For each element of the data array on the compute task,
@@ -1737,8 +1754,8 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
                 {
                     dest_ioindex[k] = coord_to_lindex(ndims, lcoord, count);
                     dest_ioproc[k] = i;
-                    LOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
-                         k, dest_ioproc[k]));
+                    PLOG((3, "found dest_ioindex[%d] = %d dest_ioproc[%d] = %d", k, dest_ioindex[k],
+                          k, dest_ioproc[k]));
                 }
             }
         }
@@ -1755,7 +1772,7 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
             return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
 
     /* Completes the mapping for the box rearranger. */
-    LOG((2, "calling compute_counts maplen = %d", maplen));
+    PLOG((2, "calling compute_counts maplen = %d", maplen));
     if ((ret = compute_counts(ios, iodesc, dest_ioproc, dest_ioindex)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
@@ -1769,14 +1786,14 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
     {
         if ((ret = compute_maxIObuffersize(ios->io_comm, iodesc)))
             return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-        LOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
+        PLOG((3, "iodesc->maxiobuflen = %d", iodesc->maxiobuflen));
     }
 
     /* Using maxiobuflen compute the maximum number of bytes that the
      * io task buffer can handle. */
     if ((ret = compute_maxaggregate_bytes(ios, iodesc)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
-    LOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
+    PLOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
 
 #ifdef TIMING
     if ((ret = pio_stop_timer("PIO:box_rearrange_create_with_holes")))
@@ -1795,7 +1812,8 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen,
  * @returns 0 if offsets are the same or either pointer is NULL.
  * @author Jim Edwards
  */
-int compare_offsets(const void *a, const void *b)
+int
+compare_offsets(const void *a, const void *b)
 {
     mapsort *x = (mapsort *)a;
     mapsort *y = (mapsort *)b;
@@ -1823,31 +1841,32 @@ int compare_offsets(const void *a, const void *b)
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
-                int *maxregions, io_region *firstregion)
+int
+get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map,
+            int *maxregions, io_region *firstregion)
 {
     int nmaplen = 0;
-    int regionlen;
+    PIO_Offset regionlen;
     io_region *region;
     int ret;
 
     /* Check inputs. */
     pioassert(ndims >= 0 && gdimlen && maplen >= 0 && maxregions && firstregion,
               "invalid input", __FILE__, __LINE__);
-    LOG((1, "get_regions ndims = %d maplen = %d", ndims, maplen));
+    PLOG((1, "get_regions ndims = %d maplen = %d", ndims, maplen));
 
     region = firstregion;
     if (map)
     {
         while (map[nmaplen++] <= 0)
         {
-            LOG((3, "map[%d] = %d", nmaplen, map[nmaplen]));
+            PLOG((3, "map[%d] = %d", nmaplen, map[nmaplen]));
             ;
         }
         nmaplen--;
     }
     region->loffset = nmaplen;
-    LOG((2, "region->loffset = %d", region->loffset));
+    PLOG((2, "region->loffset = %d", region->loffset));
 
     *maxregions = 1;
 
@@ -1861,17 +1880,18 @@ int get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map
             region->count[i] = 1;
 
         /* Set start/count to describe first region in map. */
-        regionlen = find_region(ndims, gdimlen, maplen-nmaplen,
-                                &map[nmaplen], region->start, region->count);
+        if ((ret = find_region(ndims, gdimlen, maplen-nmaplen,
+                               &map[nmaplen], region->start, region->count, &regionlen)))
+            return ret;
         pioassert(region->start[0] >= 0, "failed to find region", __FILE__, __LINE__);
 
         nmaplen = nmaplen + regionlen;
-        LOG((2, "regionlen = %d nmaplen = %d", regionlen, nmaplen));
+        PLOG((2, "regionlen = %d nmaplen = %d", regionlen, nmaplen));
 
         /* If we need to, allocate the next region. */
         if (region->next == NULL && nmaplen < maplen)
         {
-            LOG((2, "allocating next region"));
+            PLOG((2, "allocating next region"));
             if ((ret = alloc_region2(NULL, ndims, &region->next)))
                 return ret;
 
@@ -1885,7 +1905,7 @@ int get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map
                maxregions will be the total number of regions on this
                task. */
             (*maxregions)++;
-            LOG((2, "*maxregions = %d", *maxregions));
+            PLOG((2, "*maxregions = %d", *maxregions));
         }
     }
 
@@ -1910,15 +1930,16 @@ int get_regions(int ndims, const int *gdimlen, int maplen, const PIO_Offset *map
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
+int
+default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
 {
     int color;
     int key;
     int mpierr; /* Return value from MPI functions. */
 
     pioassert(ios && iodesc, "invalid input", __FILE__, __LINE__);
-    LOG((1, "default_subset_partition ios->ioproc = %d ios->io_rank = %d "
-         "ios->comp_rank = %d", ios->ioproc, ios->io_rank, ios->comp_rank));
+    PLOG((1, "default_subset_partition ios->ioproc = %d ios->io_rank = %d "
+          "ios->comp_rank = %d", ios->ioproc, ios->io_rank, ios->comp_rank));
 
     /* Create a new comm for each subset group with the io task in
        rank 0 and only 1 io task per group */
@@ -1933,7 +1954,7 @@ int default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
         key = max(1, ios->comp_rank % taskratio + 1);
         color = min(ios->num_iotasks - 1, ios->comp_rank / taskratio);
     }
-    LOG((3, "key = %d color = %d", key, color));
+    PLOG((3, "key = %d color = %d", key, color));
 
     /* Create new communicators. */
     if ((mpierr = MPI_Comm_split(ios->comp_comm, color, key, &iodesc->subset_comm)))
@@ -1991,8 +2012,9 @@ int default_subset_partition(iosystem_desc_t *ios, io_desc_t *iodesc)
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
-                            const int *gdimlen, int ndims, io_desc_t *iodesc)
+int
+subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compmap,
+                        const int *gdimlen, int ndims, io_desc_t *iodesc)
 {
     int i, j;
     PIO_Offset *iomap = NULL;
@@ -2010,7 +2032,7 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims >= 0 && iodesc,
               "invalid input", __FILE__, __LINE__);
 
-    LOG((2, "subset_rearrange_create maplen = %d ndims = %d", maplen, ndims));
+    PLOG((2, "subset_rearrange_create maplen = %d ndims = %d", maplen, ndims));
 
     /* subset partitions each have exactly 1 io task which is task 0
      * of that subset_comm */
@@ -2213,7 +2235,7 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
     }
 
     /* Handle fill values if needed. */
-    LOG((4, "ios->ioproc %d iodesc->needsfill %d", ios->ioproc, iodesc->needsfill));
+    PLOG((4, "ios->ioproc %d iodesc->needsfill %d", ios->ioproc, iodesc->needsfill));
     if (ios->ioproc && iodesc->needsfill)
     {
         /* we need the list of offsets which are not in the union of iomap */
@@ -2228,7 +2250,7 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
         thisgridsize[0] =  totalgridsize / ios->num_iotasks;
         thisgridmax[0] = thisgridsize[0];
         int xtra = totalgridsize - thisgridsize[0] * ios->num_iotasks;
-        LOG((4, "xtra %d", xtra));
+        PLOG((4, "xtra %d", xtra));
 
         for (nio = 0; nio < ios->num_iotasks; nio++)
         {
@@ -2241,8 +2263,8 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
                     thisgridsize[nio]++;
                 thisgridmin[nio] = thisgridmax[nio - 1] + 1;
                 thisgridmax[nio] = thisgridmin[nio] + thisgridsize[nio] - 1;
-                LOG((4, "nio %d thisgridsize[nio] %d thisgridmin[nio] %d thisgridmax[nio] %d",
-                     nio, thisgridsize[nio], thisgridmin[nio], thisgridmax[nio]));
+                PLOG((4, "nio %d thisgridsize[nio] %d thisgridmin[nio] %d thisgridmax[nio] %d",
+                      nio, thisgridsize[nio], thisgridmin[nio], thisgridmax[nio]));
             }
             for (int i = 0; i < iodesc->llen; i++)
             {
@@ -2253,7 +2275,7 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
                         imin = i;
                 }
             }
-            LOG((4, "cnt %d", cnt));
+            PLOG((4, "cnt %d", cnt));
 
             /* Gather cnt from all tasks in the IO communicator into array gcnt. */
             if ((mpierr = MPI_Gather(&cnt, 1, MPI_INT, gcnt, 1, MPI_INT, nio, ios->io_comm)))
@@ -2281,7 +2303,7 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
 
         /* Allocate and initialize a grid to fill in missing values. ??? */
         PIO_Offset grid[thisgridsize[ios->io_rank]];
-        LOG((4, "thisgridsize[ios->io_rank] %d", thisgridsize[ios->io_rank]));
+        PLOG((4, "thisgridsize[ios->io_rank] %d", thisgridsize[ios->io_rank]));
         for (i = 0; i < thisgridsize[ios->io_rank]; i++)
             grid[i] = 0;
 
@@ -2291,7 +2313,7 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
             int j = myusegrid[i] - thisgridmin[ios->io_rank];
             pioassert(j < thisgridsize[ios->io_rank], "out of bounds array index",
                       __FILE__, __LINE__);
-            LOG((4, "i %d myusegrid[i] %d j %d", i, myusegrid[i], j));
+            PLOG((4, "i %d myusegrid[i] %d j %d", i, myusegrid[i], j));
             if (j >= 0)
             {
                 grid[j] = 1;
@@ -2302,8 +2324,8 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
             free(myusegrid);
 
         iodesc->holegridsize = thisgridsize[ios->io_rank] - cnt;
-        LOG((3, "iodesc->holegridsize %d thisgridsize[%d] %d cnt %d", iodesc->holegridsize,
-             ios->io_rank, thisgridsize[ios->io_rank], cnt));
+        PLOG((3, "iodesc->holegridsize %d thisgridsize[%d] %d cnt %d", iodesc->holegridsize,
+              ios->io_rank, thisgridsize[ios->io_rank], cnt));
         if (iodesc->holegridsize > 0)
         {
             /* Allocate space for the fillgrid. */
@@ -2403,7 +2425,8 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-void performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
+void
+performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
 {
 #ifdef TIMING
 #ifdef PERFTUNE
@@ -2507,8 +2530,8 @@ void performance_tune_rearranger(iosystem_desc_t *ios, io_desc_t *iodesc)
     iodesc->isend = isend;
     iodesc->max_requests = maxreqs;
 
-    LOG((1, "spmd optimization: maxreqs: %d handshake:%d isend:%d mintime=%f\n",
-         maxreqs,handshake,isend,mintime));
+    PLOG((1, "spmd optimization: maxreqs: %d handshake:%d isend:%d mintime=%f\n",
+          maxreqs,handshake,isend,mintime));
 
     /* Free memory. */
     brel(wall);

--- a/cime/src/externals/pio2/src/clib/pioc_sc.c
+++ b/cime/src/externals/pio2/src/clib/pioc_sc.c
@@ -165,7 +165,7 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
 
             bsize = lgcd(bsize, blk_len);
             if (bsize == 1)
-              return 1;
+                return 1;
 
             /* Continue to find next block. */
             blk_len = 1;
@@ -216,8 +216,8 @@ int CalcStartandCount(int pio_type, int ndims, const int *gdims, int num_io_proc
     /* Check inputs. */
     pioassert(pio_type > 0 && ndims > 0 && gdims && num_io_procs > 0 && start && count,
               "invalid input", __FILE__, __LINE__);
-    LOG((1, "CalcStartandCount pio_type = %d ndims = %d num_io_procs = %d myiorank = %d",
-         pio_type, ndims, num_io_procs, myiorank));
+    PLOG((1, "CalcStartandCount pio_type = %d ndims = %d num_io_procs = %d myiorank = %d",
+          pio_type, ndims, num_io_procs, myiorank));
 
     /* We are trying to find start and count indices for each iotask
      * such that each task has approximately blocksize data to write

--- a/cime/src/externals/pio2/src/flib/CMakeLists.txt
+++ b/cime/src/externals/pio2/src/flib/CMakeLists.txt
@@ -38,6 +38,7 @@ endif ()
 
 # Include flib source and binary directories (for Fortran modules)
 target_include_directories (piof
+  PUBLIC ${CMAKE_BINARY_DIR}
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/cime/src/externals/pio2/src/flib/Makefile.am
+++ b/cime/src/externals/pio2/src/flib/Makefile.am
@@ -17,7 +17,12 @@ libpiof_la_LDFLAGS = -version-info 2:0:1
 # The library soure files.
 libpiof_la_LIBADD = libpio_nf.la libpio_kinds.la libpio_support.la	\
 libpiodarray.la libpionfatt.la libpionfget.la libpionfput.la		\
-libpiolib_mod.la libpio.la
+libpiolib_mod.la
+
+if NETCDF_INTEGRATION
+libpiof_la_LIBADD += libncint_mod.la
+endif
+libpiof_la_LIBADD +=  libpio.la
 
 libpiof_la_SOURCES = pio_types.F90
 
@@ -25,6 +30,9 @@ libpiof_la_SOURCES = pio_types.F90
 noinst_LTLIBRARIES = libpio_kinds.la libpio_types.la		\
 libpio_support.la libpio_nf.la libpiodarray.la libpionfatt.la	\
 libpionfget.la libpionfput.la libpiolib_mod.la libpio.la
+if NETCDF_INTEGRATION
+noinst_LTLIBRARIES += libncint_mod.la
+endif
 
 # The convenience libraries depends on their source.
 libpio_kinds_la_SOURCES = pio_kinds.F90
@@ -36,6 +44,7 @@ libpionfatt_la_SOURCES = pionfatt_mod.F90
 libpionfget_la_SOURCES = pionfget_mod.F90
 libpionfput_la_SOURCES = pionfput_mod.F90
 libpiolib_mod_la_SOURCES = piolib_mod.F90
+libncint_mod_la_SOURCES = ncint_mod.F90
 libpio_la_SOURCES = pio.F90
 
 # These F90 files are generated from .F90.in files, using the script
@@ -59,16 +68,24 @@ pionfatt_mod.mod: pionfatt_mod.F90 pionfatt_mod.$(OBJEXT)
 pionfget_mod.mod: pionfget_mod.F90 pionfget_mod.$(OBJEXT)
 pionfput_mod.mod: pionfput_mod.F90 pionfput_mod.$(OBJEXT)
 piolib_mod.mod: piolib_mod.$(OBJEXT)
+ncint_mod.mod: ncint_mod.$(OBJEXT)
 pio.mod: pio.$(OBJEXT)
 
 # Some mod files depend on other mod files.
-pio.$(OBJEXT): pio_kinds.mod piolib_mod.mod pio_types.mod piodarray.mod \
+DEPEND_FILES = pio_kinds.mod piolib_mod.mod pio_types.mod piodarray.mod \
 pio_nf.mod pionfatt_mod.mod pionfget_mod.mod pionfput_mod.mod pio_support.mod
+if NETCDF_INTEGRATION
+DEPEND_FILES += ncint_mod.mod
+endif
+pio.$(OBJEXT): $(DEPEND_FILES)
 
 # Mod files are built and then installed as headers.
 MODFILES = pio_kinds.mod pio_types.mod pio_support.mod pio_nf.mod	\
 piodarray.mod pionfatt_mod.mod pionfget_mod.mod pionfput_mod.mod	\
 piolib_mod.mod pio.mod
+if NETCDF_INTEGRATION
+MODFILES += ncint_mod.mod
+endif
 BUILT_SOURCES = $(MODFILES)
 include_HEADERS = $(MODFILES)
 
@@ -77,11 +94,12 @@ include_HEADERS = $(MODFILES)
 # pre-processor. These will only be used by doxygen when --enable-docs
 # is used at configure.
 if BUILD_DOCS
-BUILT_SOURCES += piodarray.f90 piolib_mod.f90 pionfatt_mod.f90 pionfget_mod.f90 pionfput_mod.f90 pionfatt_mod_2.f90 pionfget_mod_2.f90
+BUILT_SOURCES += piodarray.f90 piolib_mod.f90 pionfatt_mod.f90 pionfget_mod.f90 \
+pionfput_mod.f90 pionfatt_mod_2.f90 pionfget_mod_2.f90
 piodarray.f90: piodarray.F90
 	$(CC) -E $< > $@
 piolib_mod.f90: piolib_mod.F90
-	$(CC) -E $< > $@
+	$(CC) -I../.. $(AM_CPPFLAGS) -E $< > $@
 pionfatt_mod.f90: pionfatt_mod.F90
 	$(CC) -E $< > $@
 pionfget_mod.f90: pionfget_mod.F90

--- a/cime/src/externals/pio2/src/flib/ncint_mod.F90
+++ b/cime/src/externals/pio2/src/flib/ncint_mod.F90
@@ -1,0 +1,237 @@
+#include "config.h"
+!>
+!! @file
+!! These are the extra functions added to support netCDF
+!! integration. In most cases these functions are wrappers for
+!! existing PIO_ functions, but with names that start with nf_.
+!!
+!! @author Ed Hartnett
+!<
+
+!>
+!! @defgroup ncint NetCDF Integration
+!! Integrate netCDF and PIO code.
+!!
+module ncint_mod
+  use iso_c_binding
+  use pio_kinds
+  use pio_types
+  use pio_support, only : piodie, debug, debugio, debugasync, checkmpireturn
+  use pio_nf, only : pio_set_log_level
+  use piolib_mod, only : pio_init, pio_finalize, pio_initdecomp
+
+#ifndef NO_MPIMOD
+  use mpi    ! _EXTERNAL
+#endif
+  implicit none
+  private
+#ifdef NO_MPIMOD
+  include 'mpif.h'    ! _EXTERNAL
+#endif
+
+  public :: nf_def_iosystem, nf_free_iosystem, nf_def_decomp, nf_free_decomp, &
+       nf_put_vard_int
+
+contains
+
+  !>
+  !! @public
+  !! @ingroup ncint
+  !! Initialize the pio subsystem. This is a collective call. Input
+  !! parameters are read on comp_rank=0 values on other tasks are
+  !! ignored. This variation of PIO_init locates the IO tasks on a
+  !! subset of the compute tasks.
+  !!
+  !! @param comp_rank mpi rank of each participating task,
+  !! @param comp_comm the mpi communicator which defines the
+  !! collective.
+  !! @param num_iotasks the number of iotasks to define.
+  !! @param num_aggregator the mpi aggregator count
+  !! @param stride the stride in the mpi rank between io tasks.
+  !! @param rearr @copydoc PIO_rearr_method
+  !! @param iosysid the ID of the IOSystem.
+  !! @param base @em optional argument can be used to offset the first
+  !! io task - default base is task 1.
+  !! @param rearr_opts the rearranger options.
+  !! @author Ed Hartnett
+  !<
+  function nf_def_iosystem(comp_rank, comp_comm, num_iotasks, &
+       num_aggregator, stride,  rearr, iosysid, base, rearr_opts) result(ierr)
+    use pio_types, only : pio_internal_error, pio_rearr_opt_t
+    use iso_c_binding
+
+    integer(i4), intent(in) :: comp_rank
+    integer(i4), intent(in) :: comp_comm
+    integer(i4), intent(in) :: num_iotasks
+    integer(i4), intent(in) :: num_aggregator
+    integer(i4), intent(in) :: stride
+    integer(i4), intent(in) :: rearr
+    integer(i4), intent(out) :: iosysid
+    integer(i4), intent(in),optional :: base
+    type (pio_rearr_opt_t), intent(in), optional :: rearr_opts
+    type (iosystem_desc_t) :: iosystem
+    integer :: ierr
+
+    interface
+       integer(C_INT) function nc_set_iosystem(iosystemid) &
+            bind(C, name="nc_set_iosystem")
+         use iso_c_binding
+         integer(C_INT), intent(in), value :: iosystemid
+       end function nc_set_iosystem
+    end interface
+
+    call PIO_init(comp_rank, comp_comm, num_iotasks, num_aggregator, &
+         stride, rearr, iosystem, base, rearr_opts)
+
+    iosysid = iosystem%iosysid
+    ierr = nc_set_iosystem(iosysid)
+
+  end function nf_def_iosystem
+
+  !>
+  !! @public
+  !! @ingroup ncint
+  !! Finalizes an IO System. This is a collective call.
+  !!
+  !! @param iosystem @copydoc io_desc_t
+  !! @retval ierr @copydoc error_return
+  !! @author Ed Hartnett
+  !<
+  function nf_free_iosystem() result(status)
+    integer(i4) :: ierr
+    integer(i4) :: iosysid;
+    integer :: status
+
+    interface
+       integer(C_INT) function nc_get_iosystem(iosysid) &
+            bind(C, name="nc_get_iosystem")
+         use iso_c_binding
+         integer(C_INT), intent(out) :: iosysid
+       end function nc_get_iosystem
+    end interface
+
+    interface
+       integer(C_INT) function PIOc_finalize(iosysid) &
+            bind(C, name="PIOc_finalize")
+         use iso_c_binding
+         integer(C_INT), intent(in), value :: iosysid
+       end function PIOc_finalize
+    end interface
+
+    ierr = nc_get_iosystem(iosysid)
+    ierr = PIOc_finalize(iosysid)
+    status = ierr
+  end function nf_free_iosystem
+
+  !>
+  !! @public
+  !! @ingroup ncint
+  !! Free a decomposition.
+  !!
+  !! @param decompid the decompostion ID.
+  !! @author Ed Hartnett
+  !<
+  function nf_free_decomp(decompid) result(status)
+    integer, intent(in) :: decompid
+    integer(C_INT) :: cdecompid
+    integer(i4) :: ierr
+    integer :: status
+
+    interface
+       integer(C_INT) function nc_free_decomp(decompid) &
+            bind(C, name="nc_free_decomp")
+         use iso_c_binding
+         integer(C_INT), intent(in), value :: decompid
+       end function nc_free_decomp
+    end interface
+
+    cdecompid = decompid
+    ierr = nc_free_decomp(cdecompid)
+    status = ierr
+  end function nf_free_decomp
+
+  !>
+  !! @public
+  !! @ingroup ncint
+  !! Implements the block-cyclic decomposition for PIO_initdecomp.
+  !! This provides the ability to describe a computational
+  !! decomposition in PIO that has a block-cyclic form. That is
+  !! something that can be described using start and count arrays.
+  !! Optional parameters for this subroutine allows for the
+  !! specification of io decomposition using iostart and iocount
+  !! arrays. If iostart and iocount arrays are not specified by the
+  !! user, and rearrangement is turned on then PIO will calculate a
+  !! suitable IO decomposition
+  !!
+  !! @param iosystem @copydoc iosystem_desc_t
+  !! @param basepiotype @copydoc use_PIO_kinds
+  !! @param dims An array of the global length of each dimesion of the
+  !! variable(s)
+  !! @param compstart The start index into the block-cyclic
+  !! computational decomposition
+  !! @param compcount The count for the block-cyclic computational
+  !! decomposition
+  !! @param iodesc @copydoc iodesc_generate
+  !! @author Ed Hartnett
+  !<
+  function nf_def_decomp(iosysid, basepiotype, dims, compdof, &
+       decompid, rearr, iostart, iocount) result(status)
+    integer(i4), intent(in) :: iosysid
+    integer(i4), intent(in) :: basepiotype
+    integer(i4), intent(in) :: dims(:)
+    integer (PIO_OFFSET_KIND), intent(in) :: compdof(:)
+    integer(i4), intent(out) :: decompid
+    integer, optional, target :: rearr
+    integer (PIO_OFFSET_KIND), optional :: iostart(:), iocount(:)
+    type (io_desc_t) :: iodesc
+    type (iosystem_desc_t) :: iosystem
+    integer :: status
+
+    iosystem%iosysid = iosysid
+    call PIO_initdecomp(iosystem, basepiotype, dims, compdof, &
+         iodesc, rearr, iostart, iocount)
+    decompid = iodesc%ioid
+
+    status = 0
+  end function nf_def_decomp
+
+  !>
+  !! @public
+  !! @ingroup ncint
+  !! Put distributed array subset of an integer variable.
+  !!
+  !! This routine is called collectively by all tasks in the
+  !! communicator ios.union_comm.
+  !!
+  !! @param ncid identifies the netCDF file
+  !! @param varid the variable ID number
+  !! @param decompid the decomposition ID.
+  !! @param recnum the record number.
+  !! @param op pointer to the data to be written.
+  !! @return PIO_NOERR on success, error code otherwise.
+  !! @author Ed Hartnett
+  !<
+  function nf_put_vard_int(ncid, varid, decompid, recnum, ivals) result(status)
+    use iso_c_binding
+    integer, intent(in):: ncid, varid, decompid, recnum
+    integer, intent(in):: ivals(*)
+    integer(c_int64_t):: lrecnum
+    integer(c_int):: ierr
+    integer:: status
+
+    interface
+       function nc_put_vard_int(ncid, varid, decompid, lrecnum, op) bind(c)
+         use iso_c_binding
+         integer(c_int), value, intent(in) :: ncid, varid, decompid
+         integer(c_int64_t), value, intent(in) :: lrecnum
+         integer(c_int), intent(in) :: op(*)
+         integer(c_int) :: nc_put_vard_int
+       end function nc_put_vard_int
+    end interface
+
+    lrecnum = recnum - 1 ! c functions are 0-based
+    ierr = nc_put_vard_int(ncid, varid - 1, decompid, lrecnum, ivals)
+    status = ierr
+  end function nf_put_vard_int
+
+  end module ncint_mod

--- a/cime/src/externals/pio2/src/flib/pio.F90
+++ b/cime/src/externals/pio2/src/flib/pio.F90
@@ -7,6 +7,7 @@
 !>
 !! @defgroup PIO_set_blocksize Box Rearranger Settings
 !! Set the box rearranger blocksize in Fortran.
+#include "config.h"
 
 module pio
 ! Package all exposed variables and functions under one roof
@@ -22,6 +23,11 @@ module pio
        pio_finalize, pio_set_hint, pio_getnumiotasks, pio_file_is_open, &
        PIO_deletefile, PIO_get_numiotasks, PIO_iotype_available, &
        pio_set_rearr_opts
+
+#ifdef NETCDF_INTEGRATION
+  use ncint_mod, only: nf_def_iosystem, nf_free_iosystem, &
+       nf_def_decomp, nf_free_decomp, nf_put_vard_int
+#endif
 
   use pio_types, only : io_desc_t, file_desc_t, var_desc_t, iosystem_desc_t, &
        pio_rearr_opt_t, pio_rearr_comm_fc_opt_t, pio_rearr_comm_fc_2d_enable,&

--- a/cime/src/externals/pio2/src/flib/pio_nf.F90
+++ b/cime/src/externals/pio2/src/flib/pio_nf.F90
@@ -184,8 +184,8 @@ module pio_nf
   end interface pio_inq_dimlen
   interface pio_inq_ndims
      module procedure &
-          inq_ndims_desc                                    , &
           inq_ndims_id
+!          inq_ndims_desc                                    , &
   end interface pio_inq_ndims
   interface pio_inq_dimid
      module procedure &
@@ -200,13 +200,13 @@ module pio_nf
 
   interface pio_inq_nvars
      module procedure &
-          inq_nvars_desc                                    , &
           inq_nvars_id
+!          inq_nvars_desc
   end interface pio_inq_nvars
   interface pio_inq_natts
      module procedure &
-          inq_natts_desc                                    , &
           inq_natts_id
+!          inq_natts_desc
   end interface pio_inq_natts
   interface pio_inq_unlimdim
      module procedure &
@@ -474,7 +474,6 @@ contains
 
   end function inq_dimname_id
 
-  !>
   !! @public
   !! @ingroup PIO_inquire
   !! Get information about the number of dimensions of a file or
@@ -485,11 +484,11 @@ contains
   !! @retval ierr @copydoc error_return
   !! @author Jim Edwards
   !<
-  integer function inq_ndims_desc(File                      , ndims) result(ierr)
-    type (File_desc_t)                                      , intent(inout) :: File
-    integer                                                 , intent(out) :: ndims
-    ierr = inq_ndims_id(file%fh                             , ndims)
-  end function inq_ndims_desc
+  ! integer function inq_ndims_desc(File, ndims) result(ierr)
+  !   type (File_desc_t), intent(inout) :: File
+  !   integer, intent(out) :: ndims
+  !   ierr = inq_ndims_id(file%fh, ndims)
+  ! end function inq_ndims_desc
 
   !>
   !! @public
@@ -512,7 +511,6 @@ contains
     ierr = PIOc_inq_ndims(ncid                              ,ndims)
   end function inq_ndims_id
 
-  !>
   !! @public
   !! @ingroup PIO_inquire
   !! Get information about the number of variables in a file or group.
@@ -522,11 +520,11 @@ contains
   !! @retval ierr @copydoc error_return
   !! @author Jim Edwards
   !<
-  integer function inq_nvars_desc(File                      , nvars) result(ierr)
-    type (File_desc_t)                                      , intent(inout) :: File
-    integer                                                 , intent(out) :: nvars
-    ierr = inq_nvars_id(file%fh                             , nvars)
-  end function inq_nvars_desc
+  ! integer function inq_nvars_desc(File, nvars) result(ierr)
+  !   type (File_desc_t), intent(inout) :: File
+  !   integer, intent(out) :: nvars
+  !   ierr = inq_nvars_id(file%fh, nvars)
+  ! end function inq_nvars_desc
 
   !>
   !! @public
@@ -548,7 +546,6 @@ contains
     ierr = PIOc_inq_nvars(ncid                              ,nvars)
   end function inq_nvars_id
 
-  !>
   !! @public
   !! @ingroup PIO_inquire
   !! Get information about the number of global attributes in a file
@@ -559,11 +556,11 @@ contains
   !! @retval ierr @copydoc error_return
   !! @author Jim Edwards
   !<
-  integer function inq_natts_desc(File                      , natts) result(ierr)
-    type (File_desc_t)                                      , intent(inout) :: File
-    integer                                                 , intent(out) :: natts
-    ierr = inq_natts_id(file%fh                             , natts)
-  end function inq_natts_desc
+  ! integer function inq_natts_desc(File, natts) result(ierr)
+  !   type (File_desc_t), intent(inout) :: File
+  !   integer, intent(out) :: natts
+  !   ierr = inq_natts_id(file%fh, natts)
+  ! end function inq_natts_desc
 
   !>
   !! @public

--- a/cime/src/externals/pio2/src/flib/pio_support.F90
+++ b/cime/src/externals/pio2/src/flib/pio_support.F90
@@ -35,7 +35,7 @@ contains
     integer(kind=pio_offset_kind), optional, intent(in) :: ilen
     integer :: i, slen
     if(present(ilen)) then
-       slen = ilen
+       slen = int(ilen)
     else
        slen = len(istr)
     endif
@@ -166,6 +166,7 @@ contains
          integer(C_INT), value, intent(in) :: f90_comm
        end function PIOc_writemap_from_f90
     end interface
+    if (present(punit)) continue ! to suppress warning
     ndims = size(gdims)
     err = PIOc_writemap_from_f90(trim(file)//C_NULL_CHAR, ndims, gdims, int(size(dof),C_SIZE_T), dof, comm)
 
@@ -207,7 +208,7 @@ contains
          integer(C_INT), value, intent(in) :: f90_comm
        end function PIOc_readmap_from_f90
     end interface
-
+    if (present(punit)) continue ! to suppress warning
     ierr = PIOc_readmap_from_f90(trim(file)//C_NULL_CHAR, ndims, tgdims, maplen, tmap, comm);
 
     call c_f_pointer(tgdims, gdims, (/ndims/))

--- a/cime/src/externals/pio2/src/flib/piodarray.F90.in
+++ b/cime/src/externals/pio2/src/flib/piodarray.F90.in
@@ -59,9 +59,9 @@ interface
         bind(C,name="PIOc_write_darray_multi")
      use iso_c_binding
      integer(C_INT), value :: ncid
+     integer(C_INT), value :: nvars
      integer(C_INT) :: vid(nvars)
      integer(C_INT), value :: ioid
-     integer(C_INT), value :: nvars
      integer(C_SIZE_T), value :: arraylen
      type(c_ptr), value :: array
      type(C_PTR), value :: fillvalue

--- a/cime/src/externals/pio2/src/flib/piolib_mod.F90
+++ b/cime/src/externals/pio2/src/flib/piolib_mod.F90
@@ -1,4 +1,5 @@
 #define __PIO_FILE__ "piolib_mod.f90"
+#include "config.h"
 !>
 !! @file
 !! Initialization Routines for PIO.
@@ -161,7 +162,7 @@ module piolib_mod
   !<
   interface PIO_init
      module procedure init_intracom
-     module procedure init_intercom
+!     module procedure init_intercom
 
   end interface PIO_init
 
@@ -187,10 +188,7 @@ module piolib_mod
      module procedure initdecomp_1dof_bin_i8
      module procedure initdecomp_2dof_nf_i4
      module procedure initdecomp_2dof_nf_i8
-     module procedure initdecomp_2dof_bin_i4
-     module procedure initdecomp_2dof_bin_i8
      module procedure PIO_initdecomp_bc
-     !     module procedure PIO_initdecomp_dof_dof
   end interface PIO_initdecomp
 
   !>
@@ -345,7 +343,7 @@ contains
          integer(C_INT), value :: frame
        end function PIOc_setframe
     end interface
-    iframe = frame-1
+    iframe = int(frame-1)
     ierr = PIOc_setframe(file%fh, vardesc%varid-1, iframe)
   end subroutine setframe
 
@@ -527,75 +525,9 @@ contains
     ierr = PIOc_InitDecomp_bc(iosystem%iosysid, basepiotype, ndims, cdims, &
          cstart, ccount, iodesc%ioid)
 
-
     deallocate(cstart, ccount, cdims)
 
-
   end subroutine PIO_initdecomp_bc
-
-  !>
-  !! @public
-  !! @ingroup PIO_initdecomp
-  !! A deprecated interface to the PIO_initdecomp method.
-  !!
-  !! @param iosystem a defined pio system descriptor, see PIO_types
-  !! @param basepiotype the type of variable(s) associated with this iodesc.
-  !! @copydoc PIO_kinds
-  !! @param dims an array of the global length of each dimesion of the variable(s)
-  !! @param lenblocks
-  !! @param compdof mapping of the storage order of the variable to its memory order
-  !! @param iodofr
-  !! @param iodofw
-  !! @param iodesc @copydoc iodesc_generate
-  !! @deprecated
-  !! @author Jim Edwards
-  !<
-  subroutine initdecomp_2dof_bin_i4(iosystem,basepiotype,dims,lenblocks,compdof,iodofr,iodofw,iodesc)
-    type (iosystem_desc_t), intent(in) :: iosystem
-    integer(i4), intent(in)           :: basepiotype
-    integer(i4)                       :: basetype
-    integer(i4), intent(in)           :: dims(:)
-    integer (i4), intent(in)          :: lenblocks
-    integer (i4), intent(in)          :: compdof(:)   !> global degrees of freedom for computational decomposition
-    integer (i4), intent(in)          :: iodofr(:)     !> global degrees of freedom for io decomposition
-    integer (i4), intent(in)          :: iodofw(:)     !> global degrees of freedom for io decomposition
-    type (io_desc_t), intent(inout)     :: iodesc
-
-
-    call initdecomp_2dof_bin_i8(iosystem,basepiotype,dims,lenblocks,int(compdof,PIO_OFFSET_KIND),int(iodofr,PIO_OFFSET_KIND), &
-         int(iodofw,PIO_OFFSET_KIND),iodesc)
-
-  end subroutine initdecomp_2dof_bin_i4
-
-  !>
-  !! @public
-  !! @ingroup PIO_initdecomp
-  !! A deprecated interface to the PIO_initdecomp method.
-  !!
-  !! @param iosystem a defined pio system descriptor, see PIO_types
-  !! @param basepiotype the type of variable(s) associated with this iodesc.
-  !! @copydoc PIO_kinds
-  !! @param dims an array of the global length of each dimesion of the variable(s)
-  !! @param lenblocks
-  !! @param compdof mapping of the storage order of the variable to its memory order
-  !! @param iodofr
-  !! @param iodofw
-  !! @param iodesc @copydoc iodesc_generate
-  !! @deprecated
-  !! @author Jim Edwards
-  !<
-  subroutine initdecomp_2dof_bin_i8(iosystem,basepiotype,dims,lenblocks,compdof,iodofr,iodofw,iodesc)
-    !    use calcdisplace_mod, only : calcdisplace
-    type (iosystem_desc_t), intent(in) :: iosystem
-    integer(i4), intent(in)           :: basepiotype
-    integer(i4), intent(in)           :: dims(:)
-    integer (i4), intent(in)          :: lenblocks
-    integer (PIO_OFFSET_KIND), intent(in)          :: compdof(:)   !> global degrees of freedom for computational decomposition
-    integer (PIO_OFFSET_KIND), intent(in)          :: iodofr(:)     !> global degrees of freedom for io decomposition
-    integer (PIO_OFFSET_KIND), intent(in)          :: iodofw(:)     !> global degrees of freedom for io decomposition
-    type (io_desc_t), intent(inout)     :: iodesc
-
-  end subroutine initdecomp_2dof_bin_i8
 
   !>
   !! @public
@@ -702,8 +634,6 @@ contains
     type (io_desc_t), intent(inout)     :: iodesc
 
     integer(PIO_OFFSET_KIND), intent(in) :: start(:), count(:)
-    type (io_desc_t) :: tmp
-
 
     call pio_initdecomp(iosystem, basepiotype,dims,lenblocks,int(compdof,PIO_OFFSET_KIND),int(iodofr,PIO_OFFSET_KIND), &
          int(iodofw,PIO_OFFSET_KIND),start,count,iodesc)
@@ -780,7 +710,6 @@ contains
     integer (i4), intent(in)          :: compdof(:)   ! global degrees of freedom for computational decomposition
     integer (i4), intent(in)          :: iodof(:)     ! global degrees of freedom for io decomposition
     type (io_desc_t), intent(inout)     :: iodesc
-    integer :: piotype
     integer(PIO_OFFSET_KIND), intent(in) :: start(:), count(:)
 
     call initdecomp_1dof_nf_i8(iosystem, basepiotype,dims,lenblocks,int(compdof,PIO_OFFSET_KIND),int(iodof,PIO_OFFSET_KIND),&
@@ -814,9 +743,9 @@ contains
     integer (PIO_OFFSET_KIND), intent(in)          :: compdof(:)   ! global degrees of freedom for computational decomposition
     integer (PIO_OFFSET_KIND), intent(in)          :: iodof(:)     ! global degrees of freedom for io decomposition
     type (io_desc_t), intent(inout)     :: iodesc
-    integer :: piotype
     integer(PIO_OFFSET_KIND), intent(in) :: start(:), count(:)
 
+    if (lenblocks /= 0) continue ! to suppress warning
     if(any(iodof/=compdof)) then
        call piodie( __PIO_FILE__,__LINE__, &
             'Not sure what to do here')
@@ -950,7 +879,8 @@ contains
   !! @ingroup PIO_initdecomp
   !! I8 version of PIO_initdecomp_dof_i4.
   !! @author Jim Edwards
-  subroutine PIO_initdecomp_dof_i8(iosystem,basepiotype,dims,compdof, iodesc, rearr, iostart, iocount)
+  subroutine PIO_initdecomp_dof_i8(iosystem, basepiotype, dims, compdof, &
+       iodesc, rearr, iostart, iocount)
     type (iosystem_desc_t), intent(in) :: iosystem
     integer(i4), intent(in)           :: basepiotype
     integer(i4), intent(in)           :: dims(:)
@@ -966,7 +896,8 @@ contains
 
     maplen = size(compdof)
 
-    call PIO_initdecomp_internal(iosystem, basepiotype, dims, maplen, compdof, iodesc, rearr, iostart,iocount)
+    call PIO_initdecomp_internal(iosystem, basepiotype, dims, maplen, &
+         compdof, iodesc, rearr, iostart, iocount)
 
 #ifdef TIMING
     call t_stopf("PIO:initdecomp_dof")
@@ -1027,6 +958,9 @@ contains
        end function PIOc_Init_Intracomm_from_F90
     end interface
 
+    if (comp_rank /= 0) continue ! to suppress warning
+    if (num_aggregator /= 0) continue ! to suppress warning
+
 #ifdef TIMING
     call t_startf("PIO:init")
 #endif
@@ -1040,7 +974,6 @@ contains
 #endif
   end subroutine init_intracom
 
-  !>
   !! @public
   !! @ingroup PIO_init
   !! Initialize the pio subsystem. This is a collective call. Input
@@ -1061,220 +994,220 @@ contains
   !! pio operations (defined in PIO_types).
   !! @author Jim Edwards
   !<
-  subroutine init_intercom(component_count, peer_comm, comp_comms, io_comm, iosystem)
-    use pio_types, only : pio_internal_error, pio_rearr_box
-    integer, intent(in) :: component_count
-    integer, intent(in) :: peer_comm
-    integer, intent(in) :: comp_comms(component_count)   !  The compute communicator
-    integer, intent(in) :: io_comm     !  The io communicator
+!   subroutine init_intercom(component_count, peer_comm, comp_comms, io_comm, iosystem)
+!     use pio_types, only : pio_internal_error, pio_rearr_box
+!     integer, intent(in) :: component_count
+!     integer, intent(in) :: peer_comm
+!     integer, intent(in) :: comp_comms(component_count)   !  The compute communicator
+!     integer, intent(in) :: io_comm     !  The io communicator
 
-    type (iosystem_desc_t), intent(out)  :: iosystem(component_count)  ! io descriptor to initalize
-#ifdef DOTHIS
-    integer :: ierr
-    logical :: is_inter
-    logical, parameter :: check=.true.
+!     type (iosystem_desc_t), intent(out)  :: iosystem(component_count)  ! io descriptor to initalize
+! #ifdef DOTHIS
+!     integer :: ierr
+!     logical :: is_inter
+!     logical, parameter :: check=.true.
 
-    integer :: i, j, iam, io_leader, comp_leader
-    integer(i4), pointer :: iotmp(:)
-    character(len=5) :: cb_nodes
-    integer :: itmp
+!     integer :: i, j, iam, io_leader, comp_leader
+!     integer(i4), pointer :: iotmp(:)
+!     character(len=5) :: cb_nodes
+!     integer :: itmp
 
-#ifdef TIMING
-    call t_startf("PIO:init")
-#endif
-#if defined(NO_MPI2) || defined(_MPISERIAL)
-    call piodie( __PIO_FILE__,__LINE__, &
-         'The PIO async interface requires an MPI2 complient MPI library')
-#else
-    do i=1,component_count
-       iosystem(i)%error_handling = PIO_internal_error
-       iosystem(i)%comp_comm = comp_comms(i)
-       iosystem(i)%io_comm = io_comm
-       iosystem(i)%info = mpi_info_null
-       iosystem(i)%comp_rank= -1
-       iosystem(i)%io_rank  = -1
-       iosystem(i)%async_interface = .true.
-       iosystem(i)%comproot = MPI_PROC_NULL
-       iosystem(i)%ioroot = MPI_PROC_NULL
-       iosystem(i)%compmaster= MPI_PROC_NULL
-       iosystem(i)%iomaster = MPI_PROC_NULL
-       iosystem(i)%numOST = PIO_num_OST
-
-
-       if(io_comm/=MPI_COMM_NULL) then
-          ! Find the rank of the io leader in peer_comm
-          call mpi_comm_rank(io_comm,iosystem(i)%io_rank, ierr)
-          if(iosystem(i)%io_rank==0) then
-             call mpi_comm_rank(peer_comm, iam, ierr)
-          else
-             iam = -1
-          end if
-          call mpi_allreduce(iam, io_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
-          ! Find the rank of the comp leader in peer_comm
-          iam = -1
-          call mpi_allreduce(iam, comp_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
-          ! create the intercomm
-          call mpi_intercomm_create(io_comm, 0, peer_comm, comp_leader, i, iosystem(i)%intercomm, ierr)
-          ! create the union_comm
-          call mpi_intercomm_merge(iosystem(i)%intercomm, .true., iosystem(i)%union_comm, ierr)
-       else
-          ! Find the rank of the io leader in peer_comm
-          iam = -1
-          call mpi_allreduce(iam, io_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
-
-          ! Find the rank of the comp leader in peer_comm
-          iosystem(i)%comp_rank = -1
-          if(comp_comms(i)/=MPI_COMM_NULL) then
-             call mpi_comm_rank(comp_comms(i),iosystem(i)%comp_rank, ierr)
-             if(iosystem(i)%comp_rank==0) then
-                call mpi_comm_rank(peer_comm, iam, ierr)
-             else
-                iam=-1
-             end if
-          end if
-          call mpi_allreduce(iam, comp_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
-
-          ! create the intercomm
-          call mpi_intercomm_create(comp_comms(i), 0, peer_comm, io_leader, i, iosystem(i)%intercomm, ierr)
-          ! create the union comm
-          call mpi_intercomm_merge(iosystem(i)%intercomm, .false., iosystem(i)%union_comm, ierr)
-       end if
-       if(Debugasync) print *,__PIO_FILE__,__LINE__,i, iosystem(i)%intercomm, iosystem(i)%union_comm
-
-       if(iosystem(i)%union_comm /= MPI_COMM_NULL) then
-          call mpi_comm_rank(iosystem(i)%union_comm, iosystem(i)%union_rank, ierr)
-          if(check) call checkmpireturn('init: after call to comm_rank: ',ierr)
-          call mpi_comm_size(iosystem(i)%union_comm, iosystem(i)%num_tasks, ierr)
-          if(check) call checkmpireturn('init: after call to comm_size: ',ierr)
+! #ifdef TIMING
+!     call t_startf("PIO:init")
+! #endif
+! #if defined(NO_MPI2) || defined(_MPISERIAL)
+!     call piodie( __PIO_FILE__,__LINE__, &
+!          'The PIO async interface requires an MPI2 complient MPI library')
+! #else
+!     do i=1,component_count
+!        iosystem(i)%error_handling = PIO_internal_error
+!        iosystem(i)%comp_comm = comp_comms(i)
+!        iosystem(i)%io_comm = io_comm
+!        iosystem(i)%info = mpi_info_null
+!        iosystem(i)%comp_rank= -1
+!        iosystem(i)%io_rank  = -1
+!        iosystem(i)%async_interface = .true.
+!        iosystem(i)%comproot = MPI_PROC_NULL
+!        iosystem(i)%ioroot = MPI_PROC_NULL
+!        iosystem(i)%compmaster= MPI_PROC_NULL
+!        iosystem(i)%iomaster = MPI_PROC_NULL
+!        iosystem(i)%numOST = PIO_num_OST
 
 
-          if(io_comm /= MPI_COMM_NULL) then
-             call mpi_comm_size(io_comm, iosystem(i)%num_iotasks, ierr)
-             if(check) call checkmpireturn('init: after call to comm_size: ',ierr)
+!        if(io_comm/=MPI_COMM_NULL) then
+!           ! Find the rank of the io leader in peer_comm
+!           call mpi_comm_rank(io_comm,iosystem(i)%io_rank, ierr)
+!           if(iosystem(i)%io_rank==0) then
+!              call mpi_comm_rank(peer_comm, iam, ierr)
+!           else
+!              iam = -1
+!           end if
+!           call mpi_allreduce(iam, io_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
+!           call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+!           ! Find the rank of the comp leader in peer_comm
+!           iam = -1
+!           call mpi_allreduce(iam, comp_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
+!           call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+!           ! create the intercomm
+!           call mpi_intercomm_create(io_comm, 0, peer_comm, comp_leader, i, iosystem(i)%intercomm, ierr)
+!           ! create the union_comm
+!           call mpi_intercomm_merge(iosystem(i)%intercomm, .true., iosystem(i)%union_comm, ierr)
+!        else
+!           ! Find the rank of the io leader in peer_comm
+!           iam = -1
+!           call mpi_allreduce(iam, io_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
+!           call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
 
-             if(iosystem(i)%io_rank==0) then
-                iosystem(i)%iomaster = MPI_ROOT
-                iosystem(i)%ioroot = iosystem(i)%union_rank
-             end if
-             iosystem(i)%ioproc = .true.
-             iosystem(i)%compmaster = 0
+!           ! Find the rank of the comp leader in peer_comm
+!           iosystem(i)%comp_rank = -1
+!           if(comp_comms(i)/=MPI_COMM_NULL) then
+!              call mpi_comm_rank(comp_comms(i),iosystem(i)%comp_rank, ierr)
+!              if(iosystem(i)%comp_rank==0) then
+!                 call mpi_comm_rank(peer_comm, iam, ierr)
+!              else
+!                 iam=-1
+!              end if
+!           end if
+!           call mpi_allreduce(iam, comp_leader, 1, mpi_integer, MPI_MAX, peer_comm, ierr)
+!           call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
 
-             call pio_msg_handler_init(io_comm, iosystem(i)%io_rank)
-          end if
+!           ! create the intercomm
+!           call mpi_intercomm_create(comp_comms(i), 0, peer_comm, io_leader, i, iosystem(i)%intercomm, ierr)
+!           ! create the union comm
+!           call mpi_intercomm_merge(iosystem(i)%intercomm, .false., iosystem(i)%union_comm, ierr)
+!        end if
+!        if(Debugasync) print *,__PIO_FILE__,__LINE__,i, iosystem(i)%intercomm, iosystem(i)%union_comm
 
-
-          if(comp_comms(i) /= MPI_COMM_NULL) then
-             call mpi_comm_size(comp_comms(i), iosystem(i)%num_comptasks, ierr)
-             if(check) call checkmpireturn('init: after call to comm_size: ',ierr)
-
-             iosystem(i)%iomaster = 0
-             iosystem(i)%ioproc = .false.
-             if(iosystem(i)%comp_rank==0) then
-                iosystem(i)%compmaster = MPI_ROOT
-                iosystem(i)%comproot = iosystem(i)%union_rank
-             end if
-
-          end if
-
-          iosystem(i)%userearranger = .true.
-          iosystem(i)%rearr = PIO_rearr_box
-
-          if(Debugasync) print *,__PIO_FILE__,__LINE__
-
-          call MPI_allreduce(iosystem(i)%comproot, j, 1, MPI_INTEGER, MPI_MAX,iosystem(i)%union_comm,ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
-
-          iosystem%comproot=j
-          call MPI_allreduce(iosystem(i)%ioroot, j, 1, MPI_INTEGER, MPI_MAX,iosystem(i)%union_comm,ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
-
-          iosystem%ioroot=j
-
-          if(Debugasync) print *,__PIO_FILE__,__LINE__, i, iosystem(i)%comproot, iosystem(i)%ioroot
-
-          if(io_comm/=MPI_COMM_NULL) then
-             call mpi_bcast(iosystem(i)%num_comptasks, 1, mpi_integer, iosystem(i)%compmaster,iosystem(i)%intercomm, ierr)
-
-             call mpi_bcast(iosystem(i)%num_iotasks, 1, mpi_integer, iosystem(i)%iomaster, iosystem(i)%intercomm, ierr)
-
-             call alloc_check(iotmp,iosystem(i)%num_iotasks,'init:iotmp')
-             iotmp(:) = 0
-             iotmp( iosystem(i)%io_rank+1)=iosystem(i)%union_rank
-
-          end if
-          if(comp_comms(i)/=MPI_COMM_NULL) then
-             call mpi_bcast(iosystem(i)%num_comptasks, 1, mpi_integer, iosystem(i)%compmaster, iosystem(i)%intercomm, ierr)
-
-             call mpi_bcast(iosystem(i)%num_iotasks, 1, mpi_integer, iosystem(i)%iomaster, iosystem(i)%intercomm, ierr)
-
-             call alloc_check(iotmp,iosystem(i)%num_iotasks,'init:iotmp')
-             iotmp(:)=0
-
-          end if
-
-          iosystem(i)%my_comm = iosystem(i)%intercomm
-
-          call alloc_check(iosystem(i)%ioranks, iosystem(i)%num_iotasks,'init:n_ioranks')
-          if(Debugasync) print *,__PIO_FILE__,__LINE__,iotmp
-          call MPI_allreduce(iotmp,iosystem(i)%ioranks,iosystem(i)%num_iotasks,MPI_INTEGER,MPI_MAX,iosystem(i)%union_comm,ierr)
-          call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
-
-          if(Debugasync) print *,__PIO_FILE__,__LINE__,iosystem(i)%ioranks
-          call dealloc_check(iotmp)
-
-          !---------------------------------
-          ! initialize the rearranger system
-          !---------------------------------
-          if (iosystem(i)%userearranger) then
-             call rearrange_init(iosystem(i))
-          endif
-       end if
-
-#if defined(USEMPIIO) || defined(_PNETCDF) || defined(_NETCDF4)
-       call mpi_info_create(iosystem(i)%info,ierr)
-       ! turn on mpi-io aggregation
-       !DBG    print *,'PIO_init: before call to setnumagg'
-       !       itmp = num_aggregator
-       !       call mpi_bcast(itmp, 1, mpi_integer, 0, iosystem%union_comm, ierr)
-       !       if(itmp .gt. 0) then
-       !          write(cb_nodes,('(i5)')) itmp
-       !#ifdef BGQ
-       !          call PIO_set_hint(iosystem(i),"bgl_nodes_pset",trim(adjustl(cb_nodes)))
-       !#else
-       !          call PIO_set_hint(iosystem(i),"cb_nodes",trim(adjustl(cb_nodes)))
-       !#endif
-       !       endif
-
-#ifdef PIO_GPFS_HINTS
-       call PIO_set_hint(iosystem(i),"ibm_largeblock_io","true")
-#endif
-#ifdef PIO_LUSTRE_HINTS
-       call PIO_set_hint(iosystem(i), 'romio_ds_read','disable')
-       call PIO_set_hint(iosystem(i),'romio_ds_write','disable')
-#endif
-#endif
-    end do
-
-    if(DebugAsync) print*,__PIO_FILE__,__LINE__, iosystem(1)%ioranks
+!        if(iosystem(i)%union_comm /= MPI_COMM_NULL) then
+!           call mpi_comm_rank(iosystem(i)%union_comm, iosystem(i)%union_rank, ierr)
+!           if(check) call checkmpireturn('init: after call to comm_rank: ',ierr)
+!           call mpi_comm_size(iosystem(i)%union_comm, iosystem(i)%num_tasks, ierr)
+!           if(check) call checkmpireturn('init: after call to comm_size: ',ierr)
 
 
-    iosystem%num_aiotasks = iosystem%num_iotasks
-    iosystem%numost = PIO_NUM_OST
+!           if(io_comm /= MPI_COMM_NULL) then
+!              call mpi_comm_size(io_comm, iosystem(i)%num_iotasks, ierr)
+!              if(check) call checkmpireturn('init: after call to comm_size: ',ierr)
 
-    ! This routine does not return
-    if(io_comm /= MPI_COMM_NULL) call pio_msg_handler(component_count,iosystem)
+!              if(iosystem(i)%io_rank==0) then
+!                 iosystem(i)%iomaster = MPI_ROOT
+!                 iosystem(i)%ioroot = iosystem(i)%union_rank
+!              end if
+!              iosystem(i)%ioproc = .true.
+!              iosystem(i)%compmaster = 0
 
-    if(DebugAsync) print*,__PIO_FILE__,__LINE__, iosystem(1)%ioranks
-#ifdef TIMING
-    call t_stopf("PIO:init")
-#endif
-#endif
-#endif
-  end subroutine init_intercom
+!              call pio_msg_handler_init(io_comm, iosystem(i)%io_rank)
+!           end if
+
+
+!           if(comp_comms(i) /= MPI_COMM_NULL) then
+!              call mpi_comm_size(comp_comms(i), iosystem(i)%num_comptasks, ierr)
+!              if(check) call checkmpireturn('init: after call to comm_size: ',ierr)
+
+!              iosystem(i)%iomaster = 0
+!              iosystem(i)%ioproc = .false.
+!              if(iosystem(i)%comp_rank==0) then
+!                 iosystem(i)%compmaster = MPI_ROOT
+!                 iosystem(i)%comproot = iosystem(i)%union_rank
+!              end if
+
+!           end if
+
+!           iosystem(i)%userearranger = .true.
+!           iosystem(i)%rearr = PIO_rearr_box
+
+!           if(Debugasync) print *,__PIO_FILE__,__LINE__
+
+!           call MPI_allreduce(iosystem(i)%comproot, j, 1, MPI_INTEGER, MPI_MAX,iosystem(i)%union_comm,ierr)
+!           call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+
+!           iosystem%comproot=j
+!           call MPI_allreduce(iosystem(i)%ioroot, j, 1, MPI_INTEGER, MPI_MAX,iosystem(i)%union_comm,ierr)
+!           call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+
+!           iosystem%ioroot=j
+
+!           if(Debugasync) print *,__PIO_FILE__,__LINE__, i, iosystem(i)%comproot, iosystem(i)%ioroot
+
+!           if(io_comm/=MPI_COMM_NULL) then
+!              call mpi_bcast(iosystem(i)%num_comptasks, 1, mpi_integer, iosystem(i)%compmaster,iosystem(i)%intercomm, ierr)
+
+!              call mpi_bcast(iosystem(i)%num_iotasks, 1, mpi_integer, iosystem(i)%iomaster, iosystem(i)%intercomm, ierr)
+
+!              call alloc_check(iotmp,iosystem(i)%num_iotasks,'init:iotmp')
+!              iotmp(:) = 0
+!              iotmp( iosystem(i)%io_rank+1)=iosystem(i)%union_rank
+
+!           end if
+!           if(comp_comms(i)/=MPI_COMM_NULL) then
+!              call mpi_bcast(iosystem(i)%num_comptasks, 1, mpi_integer, iosystem(i)%compmaster, iosystem(i)%intercomm, ierr)
+
+!              call mpi_bcast(iosystem(i)%num_iotasks, 1, mpi_integer, iosystem(i)%iomaster, iosystem(i)%intercomm, ierr)
+
+!              call alloc_check(iotmp,iosystem(i)%num_iotasks,'init:iotmp')
+!              iotmp(:)=0
+
+!           end if
+
+!           iosystem(i)%my_comm = iosystem(i)%intercomm
+
+!           call alloc_check(iosystem(i)%ioranks, iosystem(i)%num_iotasks,'init:n_ioranks')
+!           if(Debugasync) print *,__PIO_FILE__,__LINE__,iotmp
+!           call MPI_allreduce(iotmp,iosystem(i)%ioranks,iosystem(i)%num_iotasks,MPI_INTEGER,MPI_MAX,iosystem(i)%union_comm,ierr)
+!           call CheckMPIReturn('Call to MPI_ALLREDUCE()',ierr,__FILE__,__LINE__)
+
+!           if(Debugasync) print *,__PIO_FILE__,__LINE__,iosystem(i)%ioranks
+!           call dealloc_check(iotmp)
+
+!           !---------------------------------
+!           ! initialize the rearranger system
+!           !---------------------------------
+!           if (iosystem(i)%userearranger) then
+!              call rearrange_init(iosystem(i))
+!           endif
+!        end if
+
+! #if defined(USEMPIIO) || defined(_PNETCDF) || defined(_NETCDF4)
+!        call mpi_info_create(iosystem(i)%info,ierr)
+!        ! turn on mpi-io aggregation
+!        !DBG    print *,'PIO_init: before call to setnumagg'
+!        !       itmp = num_aggregator
+!        !       call mpi_bcast(itmp, 1, mpi_integer, 0, iosystem%union_comm, ierr)
+!        !       if(itmp .gt. 0) then
+!        !          write(cb_nodes,('(i5)')) itmp
+!        !#ifdef BGQ
+!        !          call PIO_set_hint(iosystem(i),"bgl_nodes_pset",trim(adjustl(cb_nodes)))
+!        !#else
+!        !          call PIO_set_hint(iosystem(i),"cb_nodes",trim(adjustl(cb_nodes)))
+!        !#endif
+!        !       endif
+
+! #ifdef PIO_GPFS_HINTS
+!        call PIO_set_hint(iosystem(i),"ibm_largeblock_io","true")
+! #endif
+! #ifdef PIO_LUSTRE_HINTS
+!        call PIO_set_hint(iosystem(i), 'romio_ds_read','disable')
+!        call PIO_set_hint(iosystem(i),'romio_ds_write','disable')
+! #endif
+! #endif
+!     end do
+
+!     if(DebugAsync) print*,__PIO_FILE__,__LINE__, iosystem(1)%ioranks
+
+
+!     iosystem%num_aiotasks = iosystem%num_iotasks
+!     iosystem%numost = PIO_NUM_OST
+
+!     ! This routine does not return
+!     if(io_comm /= MPI_COMM_NULL) call pio_msg_handler(component_count,iosystem)
+
+!     if(DebugAsync) print*,__PIO_FILE__,__LINE__, iosystem(1)%ioranks
+! #ifdef TIMING
+!     call t_stopf("PIO:init")
+! #endif
+! #endif
+! #endif
+!   end subroutine init_intercom
 
   !>
   !! @public
@@ -1448,7 +1381,6 @@ contains
     integer, intent(in) :: iotype
     character(len=*), intent(in)  :: fname
     integer, optional, intent(in) :: mode
-    integer :: iorank
     interface
        integer(C_INT) function PIOc_openfile(iosysid, fh, iotype, fname,mode) &
             bind(C,NAME='PIOc_openfile')

--- a/cime/src/externals/pio2/src/flib/pionfatt_mod.F90.in
+++ b/cime/src/externals/pio2/src/flib/pionfatt_mod.F90.in
@@ -199,7 +199,7 @@ contains
     clen = len_trim(values)
     allocate(cvar(clen+1))
     cvar = C_NULL_CHAR
-    do i=1,clen
+    do i=1,int(clen)
        cvar(i) = values(i:i)
     end do
     ierr = PIOc_put_att_text (ncid,varid-1,trim(name)//C_NULL_CHAR, clen, cvar(1))
@@ -240,7 +240,6 @@ contains
     character(len=*), intent(in) :: name
     integer, intent(in) :: arrlen
     character(len=*), intent(in) :: values(arrlen)
-    integer :: vallen
 
 
     ierr = PIOc_put_att_text (ncid,varid-1,trim(name)//C_NULL_CHAR, int(arrlen,C_SIZE_T),values(1))

--- a/cime/src/externals/pio2/src/flib/pionfput_mod.F90.in
+++ b/cime/src/externals/pio2/src/flib/pionfput_mod.F90.in
@@ -344,6 +344,7 @@ contains
   end function put_var_0d_{TYPE}
 
 
+! TYPE int,real,double
   integer function put_vara_internal_{TYPE} (ncid,varid,start,count, ival) result(ierr)
     integer, intent(in) :: ncid
     integer, intent(in) :: varid
@@ -451,7 +452,19 @@ contains
     character(C_CHAR), intent(out) :: cstr(:)
     integer :: clen, sd({DIMS})
     integer :: cinc
-    integer :: i, j, k, m, n, q
+    integer :: i, j
+#if {DIMS} >= 2
+    integer :: k
+#endif
+#if {DIMS} >= 3
+    integer :: m
+#endif
+#if {DIMS} >= 4
+    integer :: n
+#endif
+#if {DIMS} == 5
+    integer :: q
+#endif
 
     cstr = C_NULL_CHAR
     do i=1,{DIMS}

--- a/cime/src/externals/pio2/src/ncint/Makefile.am
+++ b/cime/src/externals/pio2/src/ncint/Makefile.am
@@ -1,0 +1,13 @@
+## This is the automake file to build the PIO netCDF integration
+## layer.
+# Ed Hartnett 7/3/19
+
+# Find pio.h.
+AM_CPPFLAGS = -I$(top_srcdir)/src/clib
+
+# This is our output. The ncint convenience library.
+noinst_LTLIBRARIES = libncint.la
+
+# The source files.
+libncint_la_SOURCES = ncintdispatch.c ncintdispatch.h ncint_pio.c	\
+nc_put_vard.c nc_get_vard.c

--- a/cime/src/externals/pio2/src/ncint/nc_get_vard.c
+++ b/cime/src/externals/pio2/src/ncint/nc_get_vard.c
@@ -1,0 +1,269 @@
+/**
+  * @file
+  * PIO functions to get data with distributed arrays.
+  *
+  * @author Ed Hartnett
+  * @date  2019
+  *
+  * @see https://github.com/NCAR/ParallelIO
+  */
+#include <config.h>
+#include <pio.h>
+#include <pio_internal.h>
+
+/**
+ * @addtogroup PIO_read_darray_c
+ * Read distributed arrays from a variable in C.
+ * @{
+ */
+
+/**
+ * Get a muti-dimensional subset of a text variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_text(int ncid, int varid, int decompid,
+                       const size_t recnum, char *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_CHAR, buf);
+}
+
+/**
+ * Get a muti-dimensional subset of an unsigned char variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_uchar(int ncid, int varid, int decompid,
+                        const size_t recnum, unsigned char *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_UBYTE, buf);
+}
+
+/**
+ * Get a muti-dimensional subset of a signed char variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_schar(int ncid, int varid, int decompid,
+                        const size_t recnum, signed char *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_BYTE, buf);
+}
+
+/**
+ * Get a muti-dimensional subset of an unsigned 16-bit integer
+ * variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_ushort(int ncid, int varid, int decompid,
+                         const size_t recnum, unsigned short *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_USHORT,
+                            buf);
+}
+
+/**
+ * Get a muti-dimensional subset of a 16-bit integer variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_short(int ncid, int varid, int decompid,
+                        const size_t recnum, short *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_SHORT, buf);
+}
+
+/**
+ * Get a muti-dimensional subset of an unsigned integer variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_uint(int ncid, int varid, int decompid,
+                       const size_t recnum, unsigned int *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_UINT, buf);
+}
+
+/**
+ * Get a muti-dimensional subset of an integer variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_int(int ncid, int varid, int decompid,
+                      const size_t recnum, int *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_INT, buf);
+}
+
+/**
+ * Get a muti-dimensional subset of a floating point variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_float(int ncid, int varid, int decompid,
+                        const size_t recnum, float *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_FLOAT, buf);
+}
+
+/**
+ * Get a muti-dimensional subset of a 64-bit floating point variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_double(int ncid, int varid, int decompid,
+                         const size_t recnum, double *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_DOUBLE,
+                            buf);
+}
+
+/**
+ * Get a muti-dimensional subset of an unsigned 64-bit integer
+ * variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_ulonglong(int ncid, int varid, int decompid,
+                            const size_t recnum, unsigned long long *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_UINT64,
+                            buf);
+}
+
+/**
+ * Get a muti-dimensional subset of a 64-bit integer variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard_longlong(int ncid, int varid, int decompid,
+                           const size_t recnum, long long *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_INT64, buf);
+}
+
+/**
+ * Get a muti-dimensional subset of a variable the same type
+ * as the variable in the file.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param buf pointer that will get the data.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int nc_get_vard(int ncid, int varid, int decompid, const size_t recnum,
+                  void *buf)
+{
+    return PIOc_get_vard_tc(ncid, varid, decompid, recnum, NC_NAT, buf);
+}
+
+
+/**
+ * @}
+ */

--- a/cime/src/externals/pio2/src/ncint/nc_put_vard.c
+++ b/cime/src/externals/pio2/src/ncint/nc_put_vard.c
@@ -1,0 +1,299 @@
+/**
+ * @file
+ * PIO functions to write data with distributed arrays.
+ *
+ * @author Ed Hartnett
+ * @date 2019
+ * @see https://github.com/NCAR/ParallelIO
+ */
+#include <config.h>
+#include <pio.h>
+#include <pio_internal.h>
+
+/**
+ * @addtogroup PIO_write_darray_c
+ * Write distributed arrays to a Variable in C.
+ * @{
+ */
+
+/**
+ * Put distributed array subset of a text variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_text(int ncid, int varid, int decompid, const size_t recnum,
+                 const char *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_CHAR, op);
+}
+
+/**
+ * Put distributed array subset of an unsigned char variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_uchar(int ncid, int varid, int decompid, const size_t recnum,
+                  const unsigned char *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_UBYTE, op);
+}
+
+/**
+ * Put distributed array subset of a signed char variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_schar(int ncid, int varid, int decompid, const size_t recnum,
+                  const signed char *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_BYTE, op);
+}
+
+/**
+ * Put distributed array subset of an unsigned 16-bit integer
+ * variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_ushort(int ncid, int varid, int decompid, const size_t recnum,
+                   const unsigned short *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_USHORT, op);
+}
+
+/**
+ * Put distributed array subset of a 16-bit integer variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_short(int ncid, int varid, int decompid, const size_t recnum,
+                  const short *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_SHORT, op);
+}
+
+/**
+ * Put distributed array subset of an unsigned integer
+ * variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_uint(int ncid, int varid, int decompid, const size_t recnum,
+                 const unsigned int *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_UINT, op);
+}
+
+/**
+ * Put distributed array subset of an integer variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_int(int ncid, int varid, int decompid, const size_t recnum,
+                const int *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_INT, op);
+}
+
+/* /\** */
+/*  * Put distributed array subset of a 64-bit integer variable. */
+/*  * */
+/*  * This routine is called collectively by all tasks in the */
+/*  * communicator ios.union_comm. */
+/*  * */
+/*  * @param ncid identifies the netCDF file */
+/*  * @param varid the variable ID number */
+/*  * @param decompid the decomposition ID. */
+/*  * @param recnum the record number. */
+/*  * @param op pointer to the data to be written. */
+/*  * @return PIO_NOERR on success, error code otherwise. */
+/*  * @author Ed Hartnett */
+/*  *\/ */
+/* int */
+/* nc_put_vard_long(int ncid, int varid, int decompid, const size_t recnum, */
+/*                    const long *op) */
+/* { */
+/*     return PIOc_put_vard_tc(ncid, varid, decompid, recnum, PIO_LONG_INTERNAL, op); */
+/* } */
+
+/**
+ * Put distributed array subset of a floating point variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_float(int ncid, int varid, int decompid, const size_t recnum,
+                  const float *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_FLOAT, op);
+}
+
+/**
+ * Put distributed array subset of a 64-bit unsigned integer
+ * variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_longlong(int ncid, int varid, int decompid, const size_t recnum,
+                     const long long *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_INT64, op);
+}
+
+/**
+ * Put distributed array subset of a 64-bit floating point
+ * variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_double(int ncid, int varid, int decompid, const size_t recnum,
+                   const double *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_DOUBLE, op);
+}
+
+/**
+ * Put distributed array subset of an unsigned 64-bit integer
+ * variable.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard_ulonglong(int ncid, int varid, int decompid, const size_t recnum,
+                      const unsigned long long *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_UINT64, op);
+}
+
+/**
+ * Write distributed array subset of a variable of any type.
+ *
+ * This routine is called collectively by all tasks in the
+ * communicator ios.union_comm.
+ *
+ * @param ncid identifies the netCDF file
+ * @param varid the variable ID number
+ * @param decompid the decomposition ID.
+ * @param recnum the record number.
+ * @param op pointer to the data to be written.
+ * @return PIO_NOERR on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+nc_put_vard(int ncid, int varid, int decompid, const size_t recnum,
+            const void *op)
+{
+    return PIOc_put_vard_tc(ncid, varid, decompid, recnum, NC_NAT, op);
+}
+
+/**
+ * @}
+ */

--- a/cime/src/externals/pio2/src/ncint/ncint_pio.c
+++ b/cime/src/externals/pio2/src/ncint/ncint_pio.c
@@ -1,0 +1,117 @@
+/**
+ * @file
+ * @internal Additional nc_* functions to support netCDF integration.
+ *
+ * @author Ed Hartnett
+ */
+
+#include "config.h"
+#include <stdlib.h>
+#include <pio_internal.h>
+#include "ncintdispatch.h"
+
+/** This is te default io system id. */
+extern int diosysid;
+
+/** Have we initialized the netCDF integration layer? This is where we
+ * register our dispatch layer with netcdf-c. */
+extern int ncint_initialized;
+
+/**
+ * Same as PIOc_Init_Intracomm().
+ *
+ * @author Ed Hartnett
+ */
+int
+nc_def_iosystemm(MPI_Comm comp_comm, int num_iotasks, int stride, int base,
+                 int rearr, int *iosysidp)
+{
+    int ret;
+
+    /* Call the PIOc_ function to initialize the intracomm. */
+    if ((ret = PIOc_Init_Intracomm(comp_comm, num_iotasks, stride, base, rearr,
+                                   iosysidp)))
+        return ret;
+
+    /* Remember the io system id. */
+    diosysid = *iosysidp;
+
+    return PIO_NOERR;
+}
+
+/**
+ * Set the default iosystemID.
+ *
+ * @param iosysid The IO system ID to set.
+ *
+ * @return PIO_NOERR for success.
+ * @author Ed Hartnett
+ */
+int
+nc_set_iosystem(int iosysid)
+{
+    /* Remember the io system id. */
+    diosysid = iosysid;
+
+    return PIO_NOERR;
+}
+
+/**
+ * Get the default iosystemID.
+ *
+ * @param iosysid Pointer that gets The IO system ID.
+ *
+ * @return PIO_NOERR for success.
+ * @author Ed Hartnett
+ */
+int
+nc_get_iosystem(int *iosysid)
+{
+    pioassert(iosysid, "pointer to iosysid must be provided", __FILE__,
+              __LINE__);
+
+    /* Remember the io system id. */
+    *iosysid = diosysid;
+
+    return PIO_NOERR;
+}
+
+/**
+ * Same as PIOc_free_iosystem().
+ *
+ * @author Ed Hartnett
+ */
+int
+nc_free_iosystem(int iosysid)
+{
+    return PIOc_free_iosystem(iosysid);
+}
+
+/**
+ * Same as PIOc_init_decomp().
+ *
+ * @author Ed Hartnett
+ */
+int
+nc_def_decomp(int iosysid, int pio_type, int ndims, const int *gdimlen,
+               int maplen, const size_t *compmap, int *ioidp,
+              int rearranger, const size_t *iostart,
+              const size_t *iocount)
+{
+    return PIOc_init_decomp(iosysid, pio_type, ndims, gdimlen, maplen,
+                            (const PIO_Offset *)compmap, ioidp, rearranger,
+                            (const PIO_Offset *)iostart,
+                            (const PIO_Offset *)iocount);
+}
+
+/**
+ * Same as PIOc_freedecomp().
+ *
+ * @author Ed Hartnett
+ */
+int
+nc_free_decomp(int ioid)
+{
+    PLOG((1, "nc_free_decomp ioid %d", ioid));
+    return PIOc_freedecomp(diosysid, ioid);
+}

--- a/cime/src/externals/pio2/src/ncint/ncintdispatch.c
+++ b/cime/src/externals/pio2/src/ncint/ncintdispatch.c
@@ -1,0 +1,947 @@
+/**
+ * @file
+ * @internal Dispatch layer for netcdf PIO integration.
+ *
+ * @author Ed Hartnett
+ */
+
+#include "config.h"
+#include <stdlib.h>
+#include "ncintdispatch.h"
+#include "pio.h"
+#include "pio_internal.h"
+
+/* Prototypes from nc4internal.h. */
+int nc4_file_list_add(int ncid, const char *path, int mode,
+                      void **dispatchdata);
+int nc4_file_list_del(int ncid);
+int nc4_file_list_get(int ncid, char **path, int *mode,
+                      void **dispatchdata);
+
+/** Default iosysid. */
+int diosysid;
+
+/** Did we initialize user-defined format? */
+int ncint_initialized = 0;
+
+/* This is the dispatch object that holds pointers to all the
+ * functions that make up the NCINT dispatch interface. */
+NC_Dispatch NCINT_dispatcher = {
+
+    NC_FORMATX_UDF0,
+
+    PIO_NCINT_create,
+    PIO_NCINT_open,
+
+    PIO_NCINT_redef,
+    PIO_NCINT__enddef,
+    PIO_NCINT_sync,
+    PIO_NCINT_abort,
+    PIO_NCINT_close,
+    PIO_NCINT_set_fill,
+    NC_NOTNC3_inq_base_pe,
+    NC_NOTNC3_set_base_pe,
+    PIO_NCINT_inq_format,
+    PIO_NCINT_inq_format_extended,
+
+    PIO_NCINT_inq,
+    PIO_NCINT_inq_type,
+
+    PIO_NCINT_def_dim,
+    PIO_NCINT_inq_dimid,
+    PIO_NCINT_inq_dim,
+    PIO_NCINT_inq_unlimdim,
+    PIO_NCINT_rename_dim,
+
+    PIO_NCINT_inq_att,
+    PIO_NCINT_inq_attid,
+    PIO_NCINT_inq_attname,
+    PIO_NCINT_rename_att,
+    PIO_NCINT_del_att,
+    PIO_NCINT_get_att,
+    PIO_NCINT_put_att,
+
+    PIO_NCINT_def_var,
+    PIO_NCINT_inq_varid,
+    PIO_NCINT_rename_var,
+    PIO_NCINT_get_vara,
+    PIO_NCINT_put_vara,
+    PIO_NCINT_get_vars,
+    PIO_NCINT_put_vars,
+    NC_NOTNC3_get_varm,
+    NC_NOTNC3_put_varm,
+
+    PIO_NCINT_inq_var_all,
+
+    NC_NOTNC4_var_par_access,
+    PIO_NCINT_def_var_fill,
+
+    PIO_NCINT_show_metadata,
+    PIO_NCINT_inq_unlimdims,
+
+    NC_NOTNC4_inq_ncid,
+    NC_NOTNC4_inq_grps,
+    NC_NOTNC4_inq_grpname,
+    NC_NOTNC4_inq_grpname_full,
+    NC_NOTNC4_inq_grp_parent,
+    NC_NOTNC4_inq_grp_full_ncid,
+    NC_NOTNC4_inq_varids,
+    NC_NOTNC4_inq_dimids,
+    NC_NOTNC4_inq_typeids,
+    PIO_NCINT_inq_type_equal,
+    NC_NOTNC4_def_grp,
+    NC_NOTNC4_rename_grp,
+    NC_NOTNC4_inq_user_type,
+    NC_NOTNC4_inq_typeid,
+
+    NC_NOTNC4_def_compound,
+    NC_NOTNC4_insert_compound,
+    NC_NOTNC4_insert_array_compound,
+    NC_NOTNC4_inq_compound_field,
+    NC_NOTNC4_inq_compound_fieldindex,
+    NC_NOTNC4_def_vlen,
+    NC_NOTNC4_put_vlen_element,
+    NC_NOTNC4_get_vlen_element,
+    NC_NOTNC4_def_enum,
+    NC_NOTNC4_insert_enum,
+    NC_NOTNC4_inq_enum_member,
+    NC_NOTNC4_inq_enum_ident,
+    NC_NOTNC4_def_opaque,
+    NC_NOTNC4_def_var_deflate,
+    NC_NOTNC4_def_var_fletcher32,
+    NC_NOTNC4_def_var_chunking,
+    NC_NOTNC4_def_var_endian,
+    NC_NOTNC4_def_var_filter,
+    NC_NOTNC4_set_var_chunk_cache,
+    NC_NOTNC4_get_var_chunk_cache
+};
+
+/**
+ * Pointer to the dispatch table used for netCDF/PIO
+ * integration. Files opened or created with mode flag NC_UDF0 will be
+ * opened using the functions in this dispatch table. */
+const NC_Dispatch* NCINT_dispatch_table = NULL;
+
+/**
+ * @internal Initialize NCINT dispatch layer.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_initialize(void)
+{
+    int ret;
+
+    NCINT_dispatch_table = &NCINT_dispatcher;
+
+    PLOG((1, "Adding user-defined format for netCDF PIO integration"));
+
+    /* Add our user defined format. */
+    if ((ret = nc_def_user_format(NC_UDF0, &NCINT_dispatcher, NULL)))
+        return ret;
+    ncint_initialized++;
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Finalize NCINT dispatch layer.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_finalize(void)
+{
+    return NC_NOERR;
+}
+
+/**
+ * Create a file using PIO via netCDF's nc_create().
+ *
+ * @param path The file name of the new file.
+ * @param cmode The creation mode flag.
+ * @param initialsz Ignored by this function.
+ * @param basepe Ignored by this function.
+ * @param chunksizehintp Ignored by this function.
+ * @param parameters pointer to struct holding extra data (e.g. for
+ * parallel I/O) layer. Ignored if NULL.
+ * @param dispatch Pointer to the dispatch table for this file.
+ * @param ncid The ncid assigned to this file by netCDF (aka
+ * ext_ncid).
+ *
+ * @return ::NC_NOERR No error, or error code.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_create(const char *path, int cmode, size_t initialsz, int basepe,
+                 size_t *chunksizehintp, void *parameters,
+                 const NC_Dispatch *dispatch, int ncid)
+{
+    int iotype;
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
+    int ret;
+
+    PLOG((1, "PIO_NCINT_create path = %s mode = %x", path, cmode));
+
+    /* Get the IO system info from the id. */
+    if (!(ios = pio_get_iosystem_from_id(diosysid)))
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
+    /* Turn of NC_UDF0 in the mode flag. */
+    cmode = cmode & ~NC_UDF0;
+
+    /* Find the IOTYPE from the mode flag. */
+    if ((ret = find_iotype_from_omode(cmode, &iotype)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+
+    /* Add necessary structs to hold netcdf-4 file data. */
+    if ((ret = nc4_file_list_add(ncid, path, cmode, NULL)))
+        return ret;
+
+    /* Create the file with PIO. The final parameter tests
+     * createfile_int to accept the externally assigned ncid. */
+    if ((ret = PIOc_createfile_int(diosysid, &ncid, &iotype, path, cmode, 1)))
+        return ret;
+
+    return PIO_NOERR;
+}
+
+/**
+ * @internal Open a netCDF file with PIO.
+ *
+ * @param path The file name of the file.
+ * @param mode The open mode flag.
+ * @param basepe Ignored by this function.
+ * @param chunksizehintp Ignored by this function.
+ * @param parameters pointer to struct holding extra data (e.g. for
+ * parallel I/O) layer. Ignored if NULL. Ignored by this function.
+ * @param dispatch Pointer to the dispatch table for this file.
+ * @param ncid
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EINVAL Invalid input.
+ * @return ::NC_EHDFERR Error from HDF4 layer.
+ * @return ::NC_ENOMEM Out of memory.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
+               void *parameters, const NC_Dispatch *dispatch, int ncid)
+{
+    int iotype;
+    iosystem_desc_t *ios;  /* Pointer to io system information. */
+    int ret;
+
+    PLOG((1, "PIO_NCINT_open path = %s mode = %x", path, mode));
+
+    /* Get the IO system info from the id. */
+    if (!(ios = pio_get_iosystem_from_id(diosysid)))
+        return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__);
+
+    /* Turn of NC_UDF0 in the mode flag. */
+    mode = mode & ~NC_UDF0;
+
+    /* Find the IOTYPE from the mode flag. */
+    if ((ret = find_iotype_from_omode(mode, &iotype)))
+        return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+
+    /* Add necessary structs to hold netcdf-4 file data. */
+    if ((ret = nc4_file_list_add(ncid, path, mode, NULL)))
+        return ret;
+
+    /* Open the file with PIO. Tell openfile_retry to accept the
+     * externally assigned ncid. */
+    if ((ret = PIOc_openfile_retry(diosysid, &ncid, &iotype, path, mode, 0, 1)))
+        return ret;
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal This just calls nc_enddef, ignoring the extra parameters.
+ *
+ * @param ncid File and group ID.
+ * @param h_minfree Ignored.
+ * @param v_align Ignored.
+ * @param v_minfree Ignored.
+ * @param r_align Ignored.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT__enddef(int ncid, size_t h_minfree, size_t v_align,
+                  size_t v_minfree, size_t r_align)
+{
+    return PIOc_enddef(ncid);
+}
+
+/**
+ * @internal Put the file back in redef mode. This is done
+ * automatically for netcdf-4 files, if the user forgets.
+ *
+ * @param ncid File and group ID.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_redef(int ncid)
+{
+    return PIOc_redef(ncid);
+}
+
+/**
+ * @internal Flushes all buffers associated with the file, after
+ * writing all changed metadata. This may only be called in data mode.
+ *
+ * @param ncid File and group ID.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @return ::NC_EINDEFINE Classic model file is in define mode.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_sync(int ncid)
+{
+    return PIOc_sync(ncid);
+}
+
+int
+PIO_NCINT_abort(int ncid)
+{
+    return PIO_NCINT_close(ncid, NULL);
+}
+
+/**
+ * Close a file opened with PIO.
+ *
+ * @param ncid the ncid for the PIO file.
+ * @param v ignored, use NULL.
+ *
+ * @return PIO_NOERR for success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_close(int ncid, void *v)
+{
+    int retval;
+
+    /* Tell PIO to close the file. */
+    if ((retval = PIOc_closefile(ncid)))
+        return retval;
+
+    /* Delete the group name. */
+    if ((retval = nc4_file_list_del(ncid)))
+        return retval;
+
+    return retval;
+}
+
+/**
+ * @internal Set fill mode.
+ *
+ * @param ncid File ID.
+ * @param fillmode File mode.
+ * @param old_modep Pointer that gets old mode. Ignored if NULL.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_set_fill(int ncid, int fillmode, int *old_modep)
+{
+    return PIOc_set_fill(ncid, fillmode, old_modep);
+}
+
+/**
+ * @internal Get the format (i.e. NC_FORMAT_UDF0) of a file opened
+ * with PIO.
+ *
+ * @param ncid File ID (ignored).
+ * @param formatp Pointer that gets the constant indicating format.
+
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_format(int ncid, int *formatp)
+{
+    /* HDF4 is the format. */
+    if (formatp)
+        *formatp = NC_FORMATX_UDF0;
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Return the extended format (i.e. the dispatch model),
+ * plus the mode associated with an open file.
+ *
+ * @param ncid File ID.
+ * @param formatp a pointer that gets the extended format. PIO files
+ * will always get NC_FORMATX_UDF0.
+ * @param modep a pointer that gets the open/create mode associated with
+ * this file. Ignored if NULL.
+
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_format_extended(int ncid, int *formatp, int *modep)
+{
+    int my_mode;
+    int retval;
+
+    PLOG((2, "%s: ncid 0x%x", __func__, ncid));
+
+    if ((retval = nc4_file_list_get(ncid, NULL, &my_mode, NULL)))
+        return NC_EBADID;
+
+    if (modep)
+        *modep = my_mode|NC_UDF0;
+
+    if (formatp)
+        *formatp = NC_FORMATX_UDF0;
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Learn number of dimensions, variables, global attributes,
+ * and the ID of the first unlimited dimension (if any).
+ *
+ * @note It's possible for any of these pointers to be NULL, in which
+ * case don't try to figure out that value.
+ *
+ * @param ncid File and group ID.
+ * @param ndimsp Pointer that gets number of dimensions.
+ * @param nvarsp Pointer that gets number of variables.
+ * @param nattsp Pointer that gets number of global attributes.
+ * @param unlimdimidp Pointer that gets first unlimited dimension ID,
+ * or -1 if there are no unlimied dimensions.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq(int ncid, int *ndimsp, int *nvarsp, int *nattsp, int *unlimdimidp)
+{
+    return PIOc_inq(ncid, ndimsp, nvarsp, nattsp, unlimdimidp);
+}
+
+/**
+ * @internal Get the name and size of a type. For strings, 1 is
+ * returned. For VLEN the base type len is returned.
+ *
+ * @param ncid File and group ID.
+ * @param typeid1 Type ID.
+ * @param name Gets the name of the type.
+ * @param size Gets the size of one element of the type in bytes.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @return ::NC_EBADTYPE Type not found.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_type(int ncid, nc_type typeid1, char *name, size_t *size)
+{
+    return PIOc_inq_type(ncid, typeid1, name, (PIO_Offset *)size);
+}
+
+int
+PIO_NCINT_def_dim(int ncid, const char *name, size_t len, int *idp)
+{
+    return PIOc_def_dim(ncid, name, len, idp);
+}
+
+/**
+ * @internal Given dim name, find its id.
+ *
+ * @param ncid File and group ID.
+ * @param name Name of the dimension to find.
+ * @param idp Pointer that gets dimension ID.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @return ::NC_EBADDIM Dimension not found.
+ * @return ::NC_EINVAL Invalid input. Name must be provided.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_dimid(int ncid, const char *name, int *idp)
+{
+    return PIOc_inq_dimid(ncid, name, idp);
+}
+
+/**
+ * @internal Find out name and len of a dim. For an unlimited
+ * dimension, the length is the largest length so far written. If the
+ * name of lenp pointers are NULL, they will be ignored.
+ *
+ * @param ncid File and group ID.
+ * @param dimid Dimension ID.
+ * @param name Pointer that gets name of the dimension.
+ * @param lenp Pointer that gets length of dimension.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @return ::NC_EDIMSIZE Dimension length too large.
+ * @return ::NC_EBADDIM Dimension not found.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_dim(int ncid, int dimid, char *name, size_t *lenp)
+{
+    return PIOc_inq_dim(ncid, dimid, name, (PIO_Offset *)lenp);
+}
+
+/**
+ * @internal Netcdf-4 files might have more than one unlimited
+ * dimension, but return the first one anyway.
+ *
+ * @note that this code is inconsistent with nc_inq
+ *
+ * @param ncid File and group ID.
+ * @param unlimdimidp Pointer that gets ID of first unlimited
+ * dimension, or -1.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_unlimdim(int ncid, int *unlimdimidp)
+{
+    return PIOc_inq_unlimdim(ncid, unlimdimidp);
+}
+
+/**
+ * @internal Rename a dimension, for those who like to prevaricate.
+ *
+ * @note If we're not in define mode, new name must be of equal or
+ * less size, if strict nc3 rules are in effect for this file. But we
+ * don't check this because reproducing the exact classic behavior
+ * would be too difficult. See github issue #1340.
+ *
+ * @param ncid File and group ID.
+ * @param dimid Dimension ID.
+ * @param name New dimension name.
+ *
+ * @return 0 on success, error code otherwise.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_rename_dim(int ncid, int dimid, const char *name)
+{
+    return PIOc_rename_dim(ncid, dimid, name);
+}
+
+/**
+ * @internal Learn about an att. All the nc4 nc_inq_ functions just
+ * call nc4_get_att to get the metadata on an attribute.
+ *
+ * @param ncid File and group ID.
+ * @param varid Variable ID.
+ * @param name Name of attribute.
+ * @param xtypep Pointer that gets type of attribute.
+ * @param lenp Pointer that gets length of attribute data array.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
+                  size_t *lenp)
+{
+    return PIOc_inq_att(ncid, varid, name, xtypep, (PIO_Offset *)lenp);
+}
+
+/**
+ * @internal Learn an attnum, given a name.
+ *
+ * @param ncid File and group ID.
+ * @param varid Variable ID.
+ * @param name Name of attribute.
+ * @param attnump Pointer that gets the attribute index number.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_attid(int ncid, int varid, const char *name, int *attnump)
+{
+    return PIOc_inq_attid(ncid, varid, name, attnump);
+}
+
+/**
+ * @internal Given an attnum, find the att's name.
+ *
+ * @param ncid File and group ID.
+ * @param varid Variable ID.
+ * @param attnum The index number of the attribute.
+ * @param name Pointer that gets name of attrribute.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_attname(int ncid, int varid, int attnum, char *name)
+{
+    return PIOc_inq_attname(ncid, varid, attnum, name);
+}
+
+/**
+ * @internal I think all atts should be named the exact same thing, to
+ * avoid confusion!
+ *
+ * @param ncid File and group ID.
+ * @param varid Variable ID.
+ * @param name Name of attribute.
+ * @param newname New name for attribute.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_rename_att(int ncid, int varid, const char *name, const char *newname)
+{
+    return PIOc_rename_att(ncid, varid, name, newname);
+}
+
+/**
+ * @internal Delete an att. Rub it out. Push the button on
+ * it. Liquidate it. Bump it off. Take it for a one-way
+ * ride. Terminate it.
+ *
+ * @param ncid File and group ID.
+ * @param varid Variable ID.
+ * @param name Name of attribute to delete.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_del_att(int ncid, int varid, const char *name)
+{
+    return PIOc_del_att(ncid, varid, name);
+}
+
+/**
+ * @internal Get an attribute.
+ *
+ * @param ncid File and group ID.
+ * @param varid Variable ID.
+ * @param name Name of attribute.
+ * @param value Pointer that gets attribute data.
+ * @param memtype The type the data should be converted to as it is
+ * read.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_get_att(int ncid, int varid, const char *name, void *value,
+                  nc_type memtype)
+{
+    return PIOc_get_att_tc(ncid, varid, name, memtype, value);
+}
+
+/**
+ * @internal Write an attribute.
+ *
+ * @return ::NC_EPERM Not allowed.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_put_att(int ncid, int varid, const char *name, nc_type file_type,
+                  size_t len, const void *data, nc_type mem_type)
+{
+    return PIOc_put_att_tc(ncid, varid, name, file_type, (PIO_Offset)len,
+                           mem_type,  data);
+}
+
+int
+PIO_NCINT_def_var(int ncid, const char *name, nc_type xtype, int ndims,
+                  const int *dimidsp, int *varidp)
+{
+    return PIOc_def_var(ncid, name, xtype, ndims, dimidsp, varidp);
+}
+
+/**
+ * @internal Find the ID of a variable, from the name. This function
+ * is called by nc_inq_varid().
+ *
+ * @param ncid File ID.
+ * @param name Name of the variable.
+ * @param varidp Gets variable ID.
+
+ * @returns ::NC_NOERR No error.
+ * @returns ::NC_EBADID Bad ncid.
+ * @returns ::NC_ENOTVAR Bad variable ID.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_varid(int ncid, const char *name, int *varidp)
+{
+    return PIOc_inq_varid(ncid, name, varidp);
+}
+
+/**
+ * @internal Rename a var to "bubba," for example. This is called by
+ * nc_rename_var() for netCDF-4 files. This results in complexities
+ * when coordinate variables are involved.
+
+ * Whenever a var has the same name as a dim, and also uses that dim
+ * as its first dimension, then that var is aid to be a coordinate
+ * variable for that dimensions. Coordinate variables are represented
+ * in the HDF5 by making them dimscales. Dimensions without coordinate
+ * vars are represented by datasets which are dimscales, but have a
+ * special attribute marking them as dimscales without associated
+ * coordinate variables.
+ *
+ * When a var is renamed, we must detect whether it has become a
+ * coordinate var (by being renamed to the same name as a dim that is
+ * also its first dimension), or whether it is no longer a coordinate
+ * var. These cause flags to be set in NC_VAR_INFO_T which are used at
+ * enddef time to make changes in the HDF5 file.
+ *
+ * @param ncid File ID.
+ * @param varid Variable ID
+ * @param name New name of the variable.
+ *
+ * @returns ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_rename_var(int ncid, int varid, const char *name)
+{
+    return PIOc_rename_var(ncid, varid, name);
+}
+
+/**
+ * @internal Read an array of data to a variable.
+ *
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param startp Array of start indices.
+ * @param countp Array of counts.
+ * @param op pointer that gets the data.
+ * @param memtype The type of these data in memory.
+ *
+ * @returns ::NC_NOERR for success
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_get_vara(int ncid, int varid, const size_t *start,
+                   const size_t *count, void *value, nc_type t)
+{
+    return PIOc_get_vars_tc(ncid, varid, (PIO_Offset *)start,
+                            (PIO_Offset *)count, NULL, t, value);
+}
+
+/**
+ * @internal Write an array of data to a variable. This is called by
+ * nc_put_vara() and other nc_put_vara_* functions, for netCDF-4
+ * files.
+ *
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param startp Array of start indices.
+ * @param countp Array of counts.
+ * @param op pointer that gets the data.
+ * @param memtype The type of these data in memory.
+ *
+ * @returns ::NC_NOERR for success
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_put_vara(int ncid, int varid, const size_t *startp,
+                   const size_t *countp, const void *op, int memtype)
+{
+    return PIOc_put_vars_tc(ncid, varid, (PIO_Offset *)startp,
+                            (PIO_Offset *)countp, NULL, memtype, op);
+}
+
+/**
+ * @internal Read a strided array of data from a variable. This is
+ * called by nc_get_vars() for netCDF-4 files, as well as all the
+ * other nc_get_vars_* functions.
+ *
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param startp Array of start indices. Must be provided for
+ * non-scalar vars.
+ * @param countp Array of counts. Will default to counts of extent of
+ * dimension if NULL.
+ * @param stridep Array of strides. Will default to strides of 1 if
+ * NULL.
+ * @param data The data to be written.
+ * @param mem_nc_type The type of the data in memory. (Convert to this
+ * type from file type.)
+ *
+ * @returns ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
+                   const ptrdiff_t *stridep, void *data, nc_type mem_nc_type)
+{
+    return PIOc_get_vars_tc(ncid, varid, (PIO_Offset *)startp,
+                            (PIO_Offset *)countp, (PIO_Offset *)stridep,
+                            mem_nc_type, data);
+}
+
+/**
+ * @internal Write a strided array of data to a variable. This is
+ * called by nc_put_vars() and other nc_put_vars_* functions, for
+ * netCDF-4 files. Also the nc_put_vara() calls end up calling this
+ * with a NULL stride parameter.
+ *
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param startp Array of start indices. Must always be provided by
+ * caller for non-scalar vars.
+ * @param countp Array of counts. Will default to counts of full
+ * dimension size if NULL.
+ * @param stridep Array of strides. Will default to strides of 1 if
+ * NULL.
+ * @param data The data to be written.
+ * @param mem_nc_type The type of the data in memory.
+ *
+ * @returns ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
+                   const ptrdiff_t *stridep, const void *data, nc_type mem_nc_type)
+{
+    return PIOc_put_vars_tc(ncid, varid, (PIO_Offset *)startp,
+                            (PIO_Offset *)countp, (PIO_Offset *)stridep,
+                            mem_nc_type, data);
+}
+/**
+ * @internal Get all the information about a variable. Pass NULL for
+ * whatever you don't care about.
+ *
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param name Gets name.
+ * @param xtypep Gets type.
+ * @param ndimsp Gets number of dims.
+ * @param dimidsp Gets array of dim IDs.
+ * @param nattsp Gets number of attributes.
+ * @param shufflep Gets shuffle setting.
+ * @param deflatep Gets deflate setting.
+ * @param deflate_levelp Gets deflate level.
+ * @param fletcher32p Gets fletcher32 setting.
+ * @param contiguousp Gets contiguous setting.
+ * @param chunksizesp Gets chunksizes.
+ * @param no_fill Gets fill mode.
+ * @param fill_valuep Gets fill value.
+ * @param endiannessp Gets one of ::NC_ENDIAN_BIG ::NC_ENDIAN_LITTLE
+ * ::NC_ENDIAN_NATIVE
+ * @param idp Pointer to memory to store filter id.
+ * @param nparamsp Pointer to memory to store filter parameter count.
+ * @param params Pointer to vector of unsigned integers into which
+ * to store filter parameters.
+ *
+ * @returns ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
+                      int *ndimsp, int *dimidsp, int *nattsp,
+                      int *shufflep, int *deflatep, int *deflate_levelp,
+                      int *fletcher32p, int *contiguousp, size_t *chunksizesp,
+                      int *no_fill, void *fill_valuep, int *endiannessp,
+                      unsigned int *idp, size_t *nparamsp, unsigned int *params)
+{
+    return PIOc_inq_var(ncid, varid, name, xtypep, ndimsp, dimidsp, nattsp);
+}
+
+/**
+ * @internal This functions sets fill value and no_fill mode for a
+ * netCDF-4 variable. It is called by nc_def_var_fill().
+ *
+ * @note All pointer parameters may be NULL, in which case they are ignored.
+ * @param ncid File ID.
+ * @param varid Variable ID.
+ * @param no_fill No_fill setting.
+ * @param fill_value Pointer to fill value.
+ *
+ * @returns ::NC_NOERR for success
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value)
+{
+    return PIOc_def_var_fill(ncid, varid, no_fill, fill_value);
+}
+
+/**
+ * @internal Returns an array of unlimited dimension ids.The user can
+ * get the number of unlimited dimensions by first calling this with
+ * NULL for the second pointer.
+ *
+ * @param ncid File and group ID.
+ * @param nunlimdimsp Pointer that gets the number of unlimited
+ * dimensions. Ignored if NULL.
+ * @param unlimdimidsp Pointer that gets arrray of unlimited dimension
+ * ID. Ignored if NULL.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp)
+{
+    return PIOc_inq_unlimdims(ncid, nunlimdimsp, unlimdimidsp);
+}
+
+/**
+ * @internal Does nothing.
+ *
+ * @param i Ignored
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_show_metadata(int i)
+{
+    return NC_NOERR;
+}
+
+/**
+ * @internal Determine if two types are equal.
+ *
+ * @param ncid1 First file/group ID.
+ * @param typeid1 First type ID.
+ * @param ncid2 Second file/group ID.
+ * @param typeid2 Second type ID.
+ * @param equalp Pointer that will get 1 if the two types are equal.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @return ::NC_EBADTYPE Type not found.
+ * @return ::NC_EINVAL Invalid type.
+ * @author Ed Hartnett
+ */
+int
+PIO_NCINT_inq_type_equal(int ncid1, nc_type typeid1, int ncid2,
+                         nc_type typeid2, int *equalp)
+{
+    if (equalp)
+        *equalp = typeid1 == typeid2 ? 1 : 0;
+    return NC_NOERR;
+}

--- a/cime/src/externals/pio2/src/ncint/ncintdispatch.h
+++ b/cime/src/externals/pio2/src/ncint/ncintdispatch.h
@@ -1,0 +1,154 @@
+/**
+ * @file
+ * This header file contains the prototypes for the PIO netCDF
+ * integration layer.
+ *
+ * Ed Hartnett
+ */
+#ifndef _NCINTDISPATCH_H
+#define _NCINTDISPATCH_H
+
+#include "config.h"
+#include <netcdf_dispatch.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+    extern int
+    PIO_NCINT_initialize(void);
+
+    extern int
+    PIO_NCINT_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
+                  void *parameters, const NC_Dispatch *, int);
+
+    extern int
+    PIO_NCINT_create(const char* path, int cmode, size_t initialsz, int basepe,
+                    size_t *chunksizehintp, void *parameters,
+                    const NC_Dispatch *dispatch, int);
+
+    extern int
+    PIO_NCINT_def_var(int ncid, const char *name, nc_type xtype, int ndims,
+                     const int *dimidsp, int *varidp);
+
+    extern int
+    PIO_NCINT_def_dim(int ncid, const char *name, size_t len, int *idp);
+
+    extern int
+    PIO_NCINT_sync(int ncid);
+
+    extern int
+    PIO_NCINT_redef(int ncid);
+
+    extern int
+    PIO_NCINT__enddef(int ncid, size_t h_minfree, size_t v_align,
+                      size_t v_minfree, size_t r_align);
+
+    extern int
+    PIO_NCINT_set_fill(int ncid, int fillmode, int *old_modep);
+
+    extern int
+    PIO_NCINT_abort(int ncid);
+
+    extern int
+    PIO_NCINT_close(int ncid, void *ignore);
+
+    extern int
+    PIO_NCINT_inq_format(int ncid, int *formatp);
+
+    extern int
+    PIO_NCINT_inq_format_extended(int ncid, int *formatp, int *modep);
+
+    extern int
+    PIO_NCINT_inq(int ncid, int *ndimsp, int *nvarsp, int *nattsp, int *unlimdimidp);
+
+    extern int
+    PIO_NCINT_inq_type(int ncid, nc_type typeid1, char *name, size_t *size);
+
+    extern int
+    PIO_NCINT_inq_dimid(int ncid, const char *name, int *idp);
+
+    extern int
+    PIO_NCINT_inq_dim(int ncid, int dimid, char *name, size_t *lenp);
+
+    extern int
+    PIO_NCINT_inq_unlimdim(int ncid, int *unlimdimidp);
+
+    extern int
+    PIO_NCINT_rename_dim(int ncid, int dimid, const char *name);
+
+    extern int
+    PIO_NCINT_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
+                      size_t *lenp);
+
+    extern int
+    PIO_NCINT_inq_attid(int ncid, int varid, const char *name, int *attnump);
+
+    extern int
+    PIO_NCINT_inq_attname(int ncid, int varid, int attnum, char *name);
+
+    extern int
+    PIO_NCINT_rename_att(int ncid, int varid, const char *name, const char *newname);
+
+    extern int
+    PIO_NCINT_del_att(int ncid, int varid, const char *name);
+
+    extern int
+    PIO_NCINT_get_att(int ncid, int varid, const char *name, void *value,
+                      nc_type memtype);
+
+    extern int
+    PIO_NCINT_put_att(int ncid, int varid, const char *name, nc_type file_type,
+                      size_t len, const void *data, nc_type mem_type);
+
+    extern int
+    PIO_NCINT_inq_varid(int ncid, const char *name, int *varidp);
+
+    extern int
+    PIO_NCINT_rename_var(int ncid, int varid, const char *name);
+
+    extern int
+    PIO_NCINT_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
+                       void *value, nc_type t);
+
+    extern int
+    PIO_NCINT_put_vara(int ncid, int varid, const size_t *startp,
+                       const size_t *countp, const void *op, int memtype);
+
+    extern int
+    PIO_NCINT_get_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
+                       const ptrdiff_t *stridep, void *data, nc_type mem_nc_type);
+
+    extern int
+    PIO_NCINT_put_vars(int ncid, int varid, const size_t *startp, const size_t *countp,
+                       const ptrdiff_t *stridep, const void *data, nc_type mem_nc_type);
+
+
+    extern int
+    PIO_NCINT_inq_var_all(int ncid, int varid, char *name, nc_type *xtypep,
+                          int *ndimsp, int *dimidsp, int *nattsp,
+                          int *shufflep, int *deflatep, int *deflate_levelp,
+                          int *fletcher32p, int *contiguousp, size_t *chunksizesp,
+                          int *no_fill, void *fill_valuep, int *endiannessp,
+                          unsigned int *idp, size_t *nparamsp, unsigned int *params);
+
+    extern int
+    PIO_NCINT_def_var_fill(int ncid, int varid, int no_fill, const void *fill_value);
+
+    extern int
+    PIO_NCINT_inq_unlimdims(int ncid, int *nunlimdimsp, int *unlimdimidsp);
+
+    extern int
+    PIO_NCINT_show_metadata(int i);
+
+    extern int
+    PIO_NCINT_inq_type_equal(int ncid1, nc_type typeid1, int ncid2,
+                             nc_type typeid2, int *equalp);
+
+
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /*_NCINTDISPATCH_H */

--- a/cime/src/externals/pio2/tests/Makefile.am
+++ b/cime/src/externals/pio2/tests/Makefile.am
@@ -8,11 +8,21 @@
 if BUILD_FORTRAN
 UNIT = unit
 GENERAL = general
+# If GPTL us used, also add the performance directory.
 if USE_GPTL
 PERFORMANCE = performance
-endif
-endif
+endif # USE_GPTL
+endif # BUILD_FORTRAN
 
-SUBDIRS = cunit ${UNIT} ${GENERAL} ${PERFORMANCE}
+# Are we building with netCDF integration?
+if BUILD_NCINT
+NCINT = ncint
+if BUILD_FORTRAN
+FNCINT = fncint
+endif # BUILD_FORTRAN
+endif # BUILD_NCINT
+
+# Build in these subdirs.
+SUBDIRS = cunit ${UNIT} ${NCINT} ${GENERAL} ${PERFORMANCE} ${FNCINT}
 
 EXTRA_DIST = CMakeLists.txt

--- a/cime/src/externals/pio2/tests/cunit/Makefile.am
+++ b/cime/src/externals/pio2/tests/cunit/Makefile.am
@@ -4,9 +4,8 @@
 # Ed Hartnett 8/17/17
 
 # Link to our assembled library.
-AM_LDFLAGS = ${top_builddir}/src/clib/libpio.la
 AM_CPPFLAGS = -I$(top_srcdir)/src/clib
-LDADD = ${top_builddir}/src/clib/libpio.la
+LDADD = ${top_builddir}/src/clib/libpioc.la
 
 # Build the tests for make check.
 check_PROGRAMS = test_intercomm2 test_async_mpi test_spmd		\
@@ -70,4 +69,4 @@ test_darray_vard_SOURCES = test_darray_vard.c test_common.c pio_tests.h
 EXTRA_DIST = run_tests.sh
 
 # Clean up files produced during testing.
-CLEANFILES = *.nc *.log decomp*.txt
+CLEANFILES = *.nc *.log decomp*.txt *.clog2 *.slog2

--- a/cime/src/externals/pio2/tests/cunit/pio_tests.h
+++ b/cime/src/externals/pio2/tests/cunit/pio_tests.h
@@ -7,7 +7,7 @@
 
 #ifndef _PIO_TESTS_H
 #define _PIO_TESTS_H
-
+#include <pio_error.h>
 #include <unistd.h> /* Include this for the sleep function. */
 #include <assert.h>
 
@@ -15,6 +15,27 @@
 #ifdef TIMING
 #include <gptl.h>
 #endif
+
+#ifdef USE_MPE
+#include <mpe.h>
+#endif /* USE_MPE */
+
+#ifdef USE_MPE
+/* These are for the event numbers array used to log various events in
+ * the program with the MPE library, which produces output for the
+ * Jumpshot program. */
+#define TEST_NUM_EVENTS 6
+#define TEST_INIT 0
+#define TEST_DECOMP 1
+#define TEST_CREATE 2
+#define TEST_DARRAY_WRITE 3
+#define TEST_CLOSE 4
+#define TEST_CALCULATE 5
+
+int init_mpe_test_logging(int my_rank, int test_event[][TEST_NUM_EVENTS]);
+void test_start_mpe_log(int state);
+void test_stop_mpe_log(int state, const char *msg);
+#endif /* USE_MPE */
 
 /** The number of possible output netCDF output flavors available to
  * the ParallelIO library. */
@@ -60,50 +81,6 @@
 #define NUM_PIO_TYPES_TO_TEST 6
 #endif /* _NETCDF4 */
 
-/** Handle MPI errors. This should only be used with MPI library
- * function calls. Finalize and return. */
-#define MPIERR(e) do {                                                  \
-        MPI_Error_string(e, err_buffer, &resultlen);                    \
-        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
-        MPI_Finalize();                                                 \
-        return ERR_AWFUL;                                               \
-    } while (0)
-
-/** Handle MPI errors. This should only be used with MPI library
- * function calls. Finalize and goto exit. */
-#define MPIBAIL(e) do {                                                  \
-        MPI_Error_string(e, err_buffer, &resultlen);                    \
-        fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
-        MPI_Finalize();                                                 \
-        ret = NC_EIO;                                                  \
-        goto exit;                                                      \
-    } while (0)
-
-/** Handle non-MPI errors by finalizing the MPI library and exiting
- * with an exit code. Finalize and return. */
-#define ERR(e) do {                                                     \
-        fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
-        MPI_Finalize();                                                 \
-        return e;                                                       \
-    } while (0)
-
-/** Handle non-MPI errors by finalizing the MPI library and goto
- * exit. Finalize and goto exit. */
-#define BAIL(e) do {                                                     \
-        fprintf(stderr, "%d Error %d in %s, line %d\n", my_rank, e, __FILE__, __LINE__); \
-        MPI_Finalize();                                                 \
-        goto exit;                                                      \
-    } while (0)
-
-/** Global err buffer for MPI. When there is an MPI error, this buffer
- * is used to store the error message that is associated with the MPI
- * error. */
-char err_buffer[MPI_MAX_ERROR_STRING];
-
-/** This is the length of the most recent MPI error message, stored
- * int the global error string. */
-int resultlen;
-
 /* Function prototypes. */
 int pio_test_init2(int argc, char **argv, int *my_rank, int *ntasks, int min_ntasks,
                    int max_ntasks, int log_level, MPI_Comm *test_comm);
@@ -127,6 +104,7 @@ int check_nc_sample_4(int iosysid, int iotype, int my_rank, int my_comp_idx,
 int get_iotypes(int *num_flavors, int *flavors);
 int get_iotype_name(int iotype, char *name);
 int pio_test_finalize(MPI_Comm *test_comm);
+int pio_test_finalize2(MPI_Comm *test_comm, const char *test_name);
 int test_async2(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm,
                 int component_count, int num_io_procs, int target_ntasks, char *test_name);
 int test_no_async2(int my_rank, int num_flavors, int *flavor, MPI_Comm test_comm, int target_ntasks,

--- a/cime/src/externals/pio2/tests/cunit/test_async_mpi.c
+++ b/cime/src/externals/pio2/tests/cunit/test_async_mpi.c
@@ -430,8 +430,8 @@ int main(int argc, char **argv)
 		    int ioroot = 0;
 		    int msg = MSG_EXIT;
 		    
-                    if (verbose)
-                        printf("my_rank %d sending exit message on union_comm %d\n", my_rank, union_comm[cmp]);
+                    /* if (verbose) */
+                    /*     printf("my_rank %d sending exit message on union_comm %d\n", my_rank, union_comm[cmp]); */
                     if ((mpierr = MPI_Send(&msg, 1, MPI_INT, ioroot, 1, union_comm[cmp])))
                         MPIERR(mpierr);
                 }

--- a/cime/src/externals/pio2/tests/cunit/test_async_multicomp.c
+++ b/cime/src/externals/pio2/tests/cunit/test_async_multicomp.c
@@ -83,7 +83,6 @@ int main(int argc, char **argv)
         {
             for (int i = 0; i < num_iotypes; i++)
             {
-                char filename[NC_MAX_NAME + 1]; /* Test filename. */
                 int my_comp_idx = my_rank - 1; /* Index in iosysid array. */
                 int dim_len_2d[NDIM2] = {DIM_LEN2, DIM_LEN3};
                 int ioid = 0;
@@ -92,9 +91,11 @@ int main(int argc, char **argv)
                                                    &ioid, PIO_SHORT)))
                     ERR(ret);
 
+#ifndef USE_MPE /* For some reason MPE logging breaks this test! */
                 /* Test with and without darrays. */
                 for (int use_darray = 0; use_darray < 2; use_darray++)
                 {
+                    char filename[NC_MAX_NAME + 1]; /* Test filename. */
 
                     /* Create sample file. */
                     if ((ret = create_nc_sample_3(iosysid[my_comp_idx], iotype[i], my_rank, my_comp_idx,
@@ -106,6 +107,7 @@ int main(int argc, char **argv)
                                                  filename, 0, 0, ioid)))
                         ERR(ret);
                 } /* next use_darray */
+#endif /* USE_MPE */
 
                 /* Free the decomposition. */
                 if ((ret = PIOc_freedecomp(iosysid[my_comp_idx], ioid)))

--- a/cime/src/externals/pio2/tests/cunit/test_darray.c
+++ b/cime/src/externals/pio2/tests/cunit/test_darray.c
@@ -423,6 +423,8 @@ int main(int argc, char **argv)
     /* Finalize the MPI library. */
     if ((ret = pio_test_finalize(&test_comm)))
         return ret;
+    /* if ((ret = pio_test_finalize2(&test_comm, TEST_NAME))) */
+    /*     return ret; */
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
     return 0;

--- a/cime/src/externals/pio2/tests/cunit/test_darray_async.c
+++ b/cime/src/externals/pio2/tests/cunit/test_darray_async.c
@@ -68,17 +68,17 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
 
     /* Reopen the file. */
     if ((ret = PIOc_openfile(iosysid, &ncid, &iotype, data_filename, NC_NOWRITE)))
-        BAIL(ret);
+        PBAIL(ret);
 
     /* Get the size of the type. */
     if ((ret = PIOc_inq_type(ncid, piotype, NULL, &type_size)))
-        BAIL(ret);
+        PBAIL(ret);
 
     /* Allocate memory to read data. */
     if (!(data_in = malloc(LAT_LEN * LON_LEN * type_size * NREC)))
-        BAIL(PIO_ENOMEM);
+        PBAIL(PIO_ENOMEM);
     if (!(data_in_norec = malloc(LAT_LEN * LON_LEN * type_size)))
-        BAIL(PIO_ENOMEM);
+        PBAIL(PIO_ENOMEM);
 
     /* We have two sets of variables, those with unlimted, and those
      * without unlimited dimension. */
@@ -90,12 +90,12 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
         /* Read the record data. The values we expect are: 10, 11, 20, 21, 30,
          * 31, in each of three records. */
         if ((ret = PIOc_get_var(ncid, rec_varid, data_in)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Read the non-record data. The values we expect are: 10, 11, 20, 21, 30,
          * 31. */
         if ((ret = PIOc_get_var(ncid, norec_varid, data_in_norec)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Check the results. */
         for (int r = 0; r < LAT_LEN * LON_LEN * NREC; r++)
@@ -105,52 +105,52 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
             {
             case PIO_BYTE:
                 if (((signed char *)data_in)[r] != (tmp_r/2 + 1) * 10 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_CHAR:
                 if (((char *)data_in)[r] != (tmp_r/2 + 1) * 10 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_SHORT:
                 if (((short *)data_in)[r] != (tmp_r/2 + 1) * 10 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_INT:
                 if (((int *)data_in)[r] != (tmp_r/2 + 1) * 10 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_FLOAT:
                 if (((float *)data_in)[r] != (tmp_r/2 + 1) * 10.0 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_DOUBLE:
                 if (((double *)data_in)[r] != (tmp_r/2 + 1) * 10.0 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
 #ifdef _NETCDF4
             case PIO_UBYTE:
                 if (((unsigned char *)data_in)[r] != (tmp_r/2 + 1) * 10 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_USHORT:
                 if (((unsigned short *)data_in)[r] != (tmp_r/2 + 1) * 10 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_UINT:
                 if (((unsigned int *)data_in)[r] != (tmp_r/2 + 1) * 10 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_INT64:
                 if (((long long *)data_in)[r] != (tmp_r/2 + 1) * 10 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_UINT64:
                 if (((unsigned long long *)data_in)[r] != (tmp_r/2 + 1) * 10 + tmp_r % 2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
 #endif /* _NETCDF4 */
             default:
-                BAIL(ERR_WRONG);
+                PBAIL(ERR_WRONG);
             }
         }
 
@@ -161,59 +161,59 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
             {
             case PIO_BYTE:
                 if (((signed char *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_CHAR:
                 if (((char *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_SHORT:
                 if (((short *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_INT:
                 if (((int *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_FLOAT:
                 if (((float *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_DOUBLE:
                 if (((double *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
 #ifdef _NETCDF4
             case PIO_UBYTE:
                 if (((unsigned char *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_USHORT:
                 if (((unsigned short *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_UINT:
                 if (((unsigned int *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_INT64:
                 if (((long long *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
             case PIO_UINT64:
                 if (((unsigned long long *)data_in_norec)[r] != (r/2 + 1) * 20.0 + r%2)
-                    BAIL(ret);
+                    PBAIL(ret);
                 break;
 #endif /* _NETCDF4 */
             default:
-                BAIL(ERR_WRONG);
+                PBAIL(ERR_WRONG);
             }
         }
     } /* next var set */
 
     /* Close the file. */
     if ((ret = PIOc_closefile(ncid)))
-        BAIL(ret);
+        PBAIL(ret);
 
 exit:
     /* Free resources. */
@@ -242,7 +242,7 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm, MPI_Comm
     /* Create the PIO decomposition for this test. */
     if ((ret = PIOc_init_decomp(iosysid, piotype, NDIM2, &dim_len[1], elements_per_pe,
                                 compdof, &ioid, PIO_REARR_BOX, NULL, NULL)))
-        BAIL(ret);
+        PBAIL(ret);
 
     /* Write the decomp file (on appropriate tasks). */
     if ((ret = PIOc_write_nc_decomp(iosysid, decomp_filename, 0, ioid, NULL, NULL, 0)))
@@ -256,7 +256,7 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm, MPI_Comm
 
     /* Free the decomposition. */
     if ((ret = PIOc_freedecomp(iosysid, ioid2)))
-        BAIL(ret);
+        PBAIL(ret);
 
     /* Test each available iotype. */
     for (int fmt = 0; fmt < num_flavors; fmt++)
@@ -353,7 +353,7 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm, MPI_Comm
             break;
 #endif /* _NETCDF4 */
         default:
-            BAIL(ERR_WRONG);
+            PBAIL(ERR_WRONG);
         }
 
         /* Create sample output file. */
@@ -361,104 +361,104 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm, MPI_Comm
                 piotype);
         if ((ret = PIOc_createfile(iosysid, &ncid, &flavor[fmt], data_filename,
                                    NC_CLOBBER)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Find the size of the type. */
         if ((ret = PIOc_inq_type(ncid, piotype, NULL, &type_size)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Create the data for the darray_multi call by making two
          * copies of the data. */
         if (!(my_data_multi = malloc(2 * type_size * elements_per_pe)))
-            BAIL(PIO_ENOMEM);
+            PBAIL(PIO_ENOMEM);
         memcpy(my_data_multi, my_data, type_size * elements_per_pe);
         memcpy((char *)my_data_multi + type_size * elements_per_pe, my_data, type_size * elements_per_pe);
 
         /* Define dimensions. */
         for (int d = 0; d < NDIM3; d++)
             if ((ret = PIOc_def_dim(ncid, dim_name[d], dim_len[d], &dimid[d])))
-                BAIL(ret);
+                PBAIL(ret);
 
         /* Define variables. */
         if ((ret = PIOc_def_var(ncid, REC_VAR_NAME, piotype, NDIM3, dimid, &varid[0])))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_def_var(ncid, REC_VAR_NAME2, piotype, NDIM3, dimid, &varid[1])))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_def_var(ncid, NOREC_VAR_NAME, piotype, NDIM2, &dimid[1],
                                 &varid[2])))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_def_var(ncid, NOREC_VAR_NAME2, piotype, NDIM2, &dimid[1],
                                 &varid[3])))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* End define mode. */
         if ((ret = PIOc_enddef(ncid)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Set the record number for the record vars. */
         if ((ret = PIOc_setframe(ncid, varid[0], 0)))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_setframe(ncid, varid[1], 0)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Write some data to the record vars. */
         if ((ret = PIOc_write_darray(ncid, varid[0], ioid, elements_per_pe, my_data, NULL)))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_write_darray(ncid, varid[1], ioid, elements_per_pe, my_data, NULL)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Write some data to the non-record vars. */
         if ((ret = PIOc_write_darray(ncid, varid[2], ioid, elements_per_pe, my_data_norec, NULL)))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_write_darray(ncid, varid[3], ioid, elements_per_pe, my_data_norec, NULL)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Sync the file. */
         if ((ret = PIOc_sync(ncid)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Increment the record number for the record vars. */
         if ((ret = PIOc_advanceframe(ncid, varid[0])))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_advanceframe(ncid, varid[1])))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Write another record. */
         if ((ret = PIOc_write_darray(ncid, varid[0], ioid, elements_per_pe, my_data, NULL)))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_write_darray(ncid, varid[1], ioid, elements_per_pe, my_data, NULL)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Sync the file. */
         if ((ret = PIOc_sync(ncid)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Increment the record number for the record var. */
         if ((ret = PIOc_advanceframe(ncid, varid[0])))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_advanceframe(ncid, varid[1])))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Write a third record. */
         if ((ret = PIOc_write_darray(ncid, varid[0], ioid, elements_per_pe, my_data, NULL)))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_write_darray(ncid, varid[1], ioid, elements_per_pe, my_data, NULL)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Increment the record number for the record var. */
         if ((ret = PIOc_advanceframe(ncid, varid[0])))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_advanceframe(ncid, varid[1])))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Write a forth record, using darray_multi(). */
         int frame[2] = {3, 3};
         if ((ret = PIOc_write_darray_multi(ncid, varid, ioid, 2, elements_per_pe, my_data_multi, frame, NULL, 0)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Close the file. */
         if ((ret = PIOc_closefile(ncid)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Free resources. */
         free(my_data_multi);
@@ -466,13 +466,13 @@ int run_darray_async_test(int iosysid, int my_rank, MPI_Comm test_comm, MPI_Comm
 
         /* Check the file for correctness. */
         if ((ret = check_darray_file(iosysid, data_filename, PIO_IOTYPE_NETCDF, my_rank, piotype)))
-            BAIL(ret);
+            PBAIL(ret);
 
     } /* next iotype */
 
     /* Free the decomposition. */
     if ((ret = PIOc_freedecomp(iosysid, ioid)))
-        BAIL(ret);
+        PBAIL(ret);
 
 exit:
     if (my_data_multi)

--- a/cime/src/externals/pio2/tests/cunit/test_darray_async_many.c
+++ b/cime/src/externals/pio2/tests/cunit/test_darray_async_many.c
@@ -77,19 +77,19 @@ check_4d_vars(int my_rank, int ncid, int *varid_4d)
 
         /* Get the type of the 4d var. */
         if ((ret = PIOc_inq_vartype(ncid, varid_4d[v], &xtype)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Get the size of this type. */
         if ((ret = PIOc_inq_type(ncid, xtype, NULL, &size)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Allocate memory for data. */
         if (!(data_in2 = malloc(size * VERT_LEN * LAT_LEN * LON_LEN * NREC)))
-            BAIL(PIO_ENOMEM);
+            PBAIL(PIO_ENOMEM);
 
         /* Read the data. */
         if ((ret = PIOc_get_var(ncid, varid_4d[v], data_in2)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Check each element of data. */
         for (int r = 0; r < LAT_LEN * LON_LEN * NREC; r++)
@@ -98,14 +98,14 @@ check_4d_vars(int my_rank, int ncid, int *varid_4d)
             {
             case PIO_INT:
                 if (((int *)data_in2)[r] != expected_int_4d[r % (VERT_LEN * LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_FLOAT:
                 if (((float *)data_in2)[r] != expected_float_4d[r % (VERT_LEN * LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             default:
-                BAIL(ERR_WRONG);
+                PBAIL(ERR_WRONG);
             }
         }
         free(data_in2);
@@ -150,14 +150,14 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
 
     /* Reopen the file. */
     if ((ret = PIOc_openfile(iosysid, &ncid, &iotype, data_filename, NC_NOWRITE)))
-        BAIL(ret);
+        PBAIL(ret);
 
     /* Check metadata. */
     int ndims_in, nvars_in, ngatts_in, unlimdimid_in;
     if ((ret = PIOc_inq(ncid, &ndims_in, &nvars_in, &ngatts_in, &unlimdimid_in)))
-        BAIL(ret);
+        PBAIL(ret);
     if (ndims_in != NDIM4 || nvars_in != num_types * 2 + NUM_4D_VARS || ngatts_in != 0 || unlimdimid_in != 0)
-        BAIL(ERR_WRONG);
+        PBAIL(ERR_WRONG);
 
     /* Check the vars. */
     for (int t = 0; t < num_types; t++)
@@ -166,19 +166,19 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
 
         /* Find size of type. */
         if ((ret = PIOc_inq_type(ncid, my_type[t], NULL, &type_size)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Allocate buffers to hold data. */
         if (!(data_in = malloc(LAT_LEN * LON_LEN * NREC * type_size)))
-            BAIL(PIO_ENOMEM);
+            PBAIL(PIO_ENOMEM);
         if (!(norec_data_in = malloc(LAT_LEN * LON_LEN * type_size)))
-            BAIL(PIO_ENOMEM);
+            PBAIL(PIO_ENOMEM);
 
         /* Read record and non-record vars for this type. */
         if ((ret = PIOc_get_var(ncid, rec_varid[t], data_in)))
-            BAIL(ret);
+            PBAIL(ret);
         if ((ret = PIOc_get_var(ncid, norec_varid[t], norec_data_in)))
-            BAIL(ret);
+            PBAIL(ret);
 
         /* Check each value of non-record data. */
         for (int r = 0; r < LAT_LEN * LON_LEN; r++)
@@ -187,52 +187,52 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
             {
             case PIO_BYTE:
                 if (((signed char *)norec_data_in)[r] != expected_byte[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_CHAR:
                 if (((char *)norec_data_in)[r] != expected_char[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_SHORT:
                 if (((short *)norec_data_in)[r] != expected_short[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_INT:
                 if (((int *)norec_data_in)[r] != expected_int[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_FLOAT:
                 if (((float *)norec_data_in)[r] != expected_float[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_DOUBLE:
                 if (((double *)norec_data_in)[r] != expected_double[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
 #ifdef _NETCDF4
             case PIO_UBYTE:
                 if (((unsigned char *)norec_data_in)[r] != expected_ubyte[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_USHORT:
                 if (((unsigned short *)norec_data_in)[r] != expected_ushort[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_UINT:
                 if (((unsigned int *)norec_data_in)[r] != expected_uint[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_INT64:
                 if (((long long *)norec_data_in)[r] != expected_int64[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_UINT64:
                 if (((unsigned long long *)norec_data_in)[r] != expected_uint64[r])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
 #endif /* _NETCDF4 */
             default:
-                BAIL(ERR_WRONG);
+                PBAIL(ERR_WRONG);
             }
         }
 
@@ -243,52 +243,52 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
             {
             case PIO_BYTE:
                 if (((signed char *)data_in)[r] != expected_byte[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_CHAR:
                 if (((char *)data_in)[r] != expected_char[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_SHORT:
                 if (((short *)data_in)[r] != expected_short[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_INT:
                 if (((int *)data_in)[r] != expected_int[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_FLOAT:
                 if (((float *)data_in)[r] != expected_float[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_DOUBLE:
                 if (((double *)data_in)[r] != expected_double[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
 #ifdef _NETCDF4
             case PIO_UBYTE:
                 if (((unsigned char *)data_in)[r] != expected_ubyte[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_USHORT:
                 if (((unsigned short *)data_in)[r] != expected_ushort[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_UINT:
                 if (((unsigned int *)data_in)[r] != expected_uint[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_INT64:
                 if (((long long *)data_in)[r] != expected_int64[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
             case PIO_UINT64:
                 if (((unsigned long long *)data_in)[r] != expected_uint64[r % (LAT_LEN * LON_LEN)])
-                    BAIL(ERR_WRONG);
+                    PBAIL(ERR_WRONG);
                 break;
 #endif /* _NETCDF4 */
             default:
-                BAIL(ERR_WRONG);
+                PBAIL(ERR_WRONG);
             }
         }
 
@@ -300,7 +300,7 @@ int check_darray_file(int iosysid, char *data_filename, int iotype, int my_rank,
 
         /* Check the 4D vars. */
         if ((ret = check_4d_vars(my_rank, ncid, varid_4d)))
-            BAIL(ret);
+            PBAIL(ret);
     }
 
     /* Close the file. */

--- a/cime/src/externals/pio2/tests/cunit/test_darray_async_simple.c
+++ b/cime/src/externals/pio2/tests/cunit/test_darray_async_simple.c
@@ -210,6 +210,8 @@ int main(int argc, char **argv)
     /* Finalize the MPI library. */
     if ((ret = pio_test_finalize(&test_comm)))
         return ret;
+    /* if ((ret = pio_test_finalize2(&test_comm, TEST_NAME))) */
+    /*     return ret; */
 
     printf("%d %s SUCCESS!!\n", my_rank, TEST_NAME);
 

--- a/cime/src/externals/pio2/tests/cunit/test_perf2.c
+++ b/cime/src/externals/pio2/tests/cunit/test_perf2.c
@@ -9,9 +9,6 @@
 #include <pio_internal.h>
 #include <pio_tests.h>
 #include <sys/time.h>
-#ifdef USE_MPE
-#include <mpe.h>
-#endif /* USE_MPE */
 
 /* The number of tasks this test should run on. */
 #define TARGET_NTASKS 16
@@ -66,61 +63,8 @@ int dim_len[NDIM] = {NC_UNLIMITED, X_DIM_LEN, Y_DIM_LEN, Z_DIM_LEN};
 #define NUM_REARRANGERS_TO_TEST 2
 
 #ifdef USE_MPE
-/* These are for the event numbers array used to log various events in
- * the program with the MPE library, which produces output for the
- * Jumpshot program. */
-#define NUM_EVENTS 7
-#define START 0
-#define END 1
-#define INIT 0
-#define DECOMP 1
-#define CREATE 2
-#define DARRAY_WRITE 3
-#define CLOSE 4
-#define CALCULATE 5
-#define INGEST 6
-
-#define ERR_LOGGING 99
-
 /* This array holds even numbers for MPE. */
-int event_num[2][NUM_EVENTS];
-
-/* This will set up the MPE logging event numbers. */
-int
-init_logging(int my_rank, int event_num[][NUM_EVENTS])
-{
-   /* Get a bunch of event numbers. */
-   event_num[START][INIT] = MPE_Log_get_event_number();
-   event_num[END][INIT] = MPE_Log_get_event_number();
-   event_num[START][DECOMP] = MPE_Log_get_event_number();
-   event_num[END][DECOMP] = MPE_Log_get_event_number();
-   event_num[START][INGEST] = MPE_Log_get_event_number();
-   event_num[END][INGEST] = MPE_Log_get_event_number();
-   event_num[START][CLOSE] = MPE_Log_get_event_number();
-   event_num[END][CLOSE] = MPE_Log_get_event_number();
-   event_num[START][CALCULATE] = MPE_Log_get_event_number();
-   event_num[END][CALCULATE] = MPE_Log_get_event_number();
-   event_num[START][CREATE] = MPE_Log_get_event_number();
-   event_num[END][CREATE] = MPE_Log_get_event_number();
-   event_num[START][DARRAY_WRITE] = MPE_Log_get_event_number();
-   event_num[END][DARRAY_WRITE] = MPE_Log_get_event_number();
-
-   /* You should track at least initialization and partitioning, data
-    * ingest, update computation, all communications, any memory
-    * copies (if you do that), any output rendering, and any global
-    * communications. */
-   if (!my_rank)
-   {
-      MPE_Describe_state(event_num[START][INIT], event_num[END][INIT], "init", "yellow");
-      MPE_Describe_state(event_num[START][INGEST], event_num[END][INGEST], "ingest", "red");
-      MPE_Describe_state(event_num[START][DECOMP], event_num[END][DECOMP], "decomposition", "green");
-      MPE_Describe_state(event_num[START][CALCULATE], event_num[END][CALCULATE], "calculate", "orange");
-      MPE_Describe_state(event_num[START][CREATE], event_num[END][CREATE], "create", "purple");
-      MPE_Describe_state(event_num[START][CLOSE], event_num[END][CLOSE], "close file", "blue");
-      MPE_Describe_state(event_num[START][DARRAY_WRITE], event_num[END][DARRAY_WRITE], "darray write", "pink");
-   }
-   return 0;
-}
+int test_event[2][TEST_NUM_EVENTS];
 #endif /* USE_MPE */
 
 /* Create the decomposition to divide the 4-dimensional sample data
@@ -185,7 +129,6 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
             int my_rank, int ntasks, int num_io_procs, int provide_fill,
             int rearranger)
 {
-    char filename[PIO_MAX_NAME + 1]; /* Name for the output files. */
     int dimids[NDIM];      /* The dimension IDs. */
     int ncid;      /* The ncid of the netCDF file. */
     int varid;     /* The ID of the netCDF varable. */
@@ -206,6 +149,7 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
      * available ways. */
     for (int fmt = 0; fmt < num_flavors; fmt++)
     {
+        char filename[PIO_MAX_NAME + 1]; /* Name for the output files. */
         struct timeval starttime, endtime;
         long long startt, endt;
         long long delta;
@@ -214,8 +158,7 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
         float mb_per_sec;
 
 #ifdef USE_MPE
-        if ((ret = MPE_Log_event(event_num[START][CREATE], 0, "start init")))
-            return ERR_MPI;
+        test_start_mpe_log(TEST_CREATE);
 #endif /* USE_MPE */
 
         /* Create the filename. Use the same filename for all, so we
@@ -246,8 +189,11 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
             ERR(ret);
 
 #ifdef USE_MPE
-        if ((ret = MPE_Log_event(event_num[END][CREATE], 0, "end init")))
-            MPIERR(ret);
+        {
+            char msg[MPE_MAX_MSG_LEN + 1];
+            sprintf(msg, "iotype %d rearr %d", flavor[fmt], rearranger);
+            test_stop_mpe_log(TEST_CREATE, msg);
+        }
 #endif /* USE_MPE */
 
         /* Start the clock. */
@@ -260,8 +206,7 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                 test_data[f] = (my_rank * 10 + f) + t * 1000;
 
 #ifdef USE_MPE
-            if ((ret = MPE_Log_event(event_num[START][DARRAY_WRITE], 0, "start init")))
-                return ERR_MPI;
+            test_start_mpe_log(TEST_DARRAY_WRITE);
 #endif /* USE_MPE */
 
             /* Set the value of the record dimension. */
@@ -273,16 +218,18 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
                 ERR(ret);
 
 #ifdef USE_MPE
-            if ((ret = MPE_Log_event(event_num[END][DARRAY_WRITE], 0, "end init")))
-                MPIERR(ret);
+            {
+                char msg[MPE_MAX_MSG_LEN + 1];
+                sprintf(msg, "write_darray timestep %d", t);
+                test_stop_mpe_log(TEST_DARRAY_WRITE, msg);
+            }
 #endif /* USE_MPE */
 
             num_megabytes += (X_DIM_LEN * Y_DIM_LEN * Z_DIM_LEN * sizeof(int))/(1024*1024);
         }
 
 #ifdef USE_MPE
-        if ((ret = MPE_Log_event(event_num[START][CLOSE], 0, "start init")))
-            return ERR_MPI;
+        test_start_mpe_log(TEST_CLOSE);
 #endif /* USE_MPE */
 
         /* Close the netCDF file. */
@@ -290,10 +237,12 @@ test_darray(int iosysid, int ioid, int num_flavors, int *flavor,
             ERR(ret);
 
 #ifdef USE_MPE
-        if ((ret = MPE_Log_event(event_num[END][CLOSE], 0, "end init")))
-            MPIERR(ret);
+        {
+            char msg[MPE_MAX_MSG_LEN + 1];
+            sprintf(msg, "closed ncid %d", ncid);
+            test_stop_mpe_log(TEST_CLOSE, msg);
+        }
 #endif /* USE_MPE */
-
 
         /* Stop the clock. */
         gettimeofday(&endtime, NULL);
@@ -334,8 +283,7 @@ test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor,
                        MPI_Comm test_comm)
 {
 
-    /* for (int fmt = 0; fmt < num_flavors; fmt++) */
-    for (int fmt = 0; fmt < 1; fmt++)
+    for (int fmt = 0; fmt < num_flavors; fmt++)
     {
 	int ioid2;             /* ID for decomposition we will create from file. */
 	char filename[PIO_MAX_NAME + 1]; /* Name for the output files. */
@@ -429,26 +377,25 @@ test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
         MPIERR(ret);
 
 #ifdef USE_MPE
-    if ((ret = MPE_Log_event(event_num[START][DECOMP], 0, "start init")))
-        return ERR_MPI;
+    test_start_mpe_log(TEST_DECOMP);
 #endif /* USE_MPE */
 
     /* Decompose the data over the tasks. */
     if ((ret = create_decomposition_3d(ntasks, my_rank, iosysid, &ioid)))
         return ret;
 
-    /* Test decomposition read/write. */
-    if ((ret = test_decomp_read_write(iosysid, ioid, num_flavors, flavor, my_rank,
-                                      ntasks, rearranger, test_comm)))
-        return ret;
+    /* /\* Test decomposition read/write. *\/ */
+    /* if ((ret = test_decomp_read_write(iosysid, ioid, num_flavors, flavor, my_rank, */
+    /*                                   ntasks, rearranger, test_comm))) */
+    /*     return ret; */
 
 #ifdef USE_MPE
-    if ((ret = MPE_Log_event(event_num[END][DECOMP], 0, "end init")))
-        MPIERR(ret);
+    test_stop_mpe_log(TEST_DECOMP, TEST_NAME);
 #endif /* USE_MPE */
 
     /* Test with/without providing a fill value to PIOc_write_darray(). */
-    for (int provide_fill = 0; provide_fill < NUM_TEST_CASES_FILLVALUE; provide_fill++)
+    /* for (int provide_fill = 0; provide_fill < NUM_TEST_CASES_FILLVALUE; provide_fill++) */
+    for (int provide_fill = 0; provide_fill < 1; provide_fill++)
     {
         /* Run a simple darray test. */
         if ((ret = test_darray(iosysid, ioid, num_flavors, flavor, my_rank,
@@ -457,8 +404,7 @@ test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
     }
 
 #ifdef USE_MPE
-    if ((ret = MPE_Log_event(event_num[START][DECOMP], 0, "start init")))
-        return ERR_MPI;
+    test_start_mpe_log(TEST_DECOMP);
 #endif /* USE_MPE */
 
     /* Free the PIO decomposition. */
@@ -466,8 +412,7 @@ test_all_darray(int iosysid, int num_flavors, int *flavor, int my_rank,
         ERR(ret);
 
 #ifdef USE_MPE
-    if ((ret = MPE_Log_event(event_num[END][DECOMP], 0, "end init")))
-        MPIERR(ret);
+    test_stop_mpe_log(TEST_DECOMP, TEST_NAME);
 #endif /* USE_MPE */
 
     return PIO_NOERR;
@@ -497,13 +442,11 @@ main(int argc, char **argv)
         ERR(ERR_INIT);
 
 #ifdef USE_MPE
-
-   if ((ret = MPE_Init_log()))
-       return ret;
-   if (init_logging(my_rank, event_num))
-       return ERR_LOGGING;
+    /* If --enable-mpe was specified at configure, start MPE
+     * logging. */
+    if (init_mpe_test_logging(my_rank, test_event))
+       return ERR_AWFUL;
 #endif /* USE_MPE */
-
 
     if ((ret = PIOc_set_iosystem_error_handling(PIO_DEFAULT, PIO_RETURN_ERROR, NULL)))
         return ret;
@@ -533,8 +476,7 @@ main(int argc, char **argv)
         for (r = 0; r < 1; r++)
         {
 #ifdef USE_MPE
-            if ((ret = MPE_Log_event(event_num[START][INIT], 0, "start init")))
-                return ERR_MPI;
+            test_start_mpe_log(TEST_INIT);
 #endif /* USE_MPE */
 
             /* Initialize the PIO IO system. This specifies how
@@ -544,8 +486,7 @@ main(int argc, char **argv)
                 return ret;
 
 #ifdef USE_MPE
-            if ((ret = MPE_Log_event(event_num[END][INIT], 0, "end init")))
-                MPIERR(ret);
+            test_stop_mpe_log(TEST_INIT, "test_perf2 init");
 #endif /* USE_MPE */
 
             /* Run tests. */
@@ -558,20 +499,6 @@ main(int argc, char **argv)
                 return ret;
         } /* next rearranger */
     } /* next num io procs */
-
-
-#ifdef USE_MPE
-   {
-       /* This causes problems on my MPICH2 library on Linux, but seems to be
-	* required for frost. */
-       char file_name[128];
-       sprintf(file_name, "chart_%d", 1);
-       if ((ret = MPE_Finish_log(file_name)))
-	   MPIERR(ret);
-   }
-
-#endif /* USE_MPE */
-
 
     if (!my_rank)
         printf("finalizing io_test!\n");

--- a/cime/src/externals/pio2/tests/fncint/Makefile.am
+++ b/cime/src/externals/pio2/tests/fncint/Makefile.am
@@ -1,0 +1,35 @@
+## This is the automake file for building the netCDF integration layer
+## tests.
+
+# Ed Hartnett 7/3/19
+
+# Put together AM_CPPFLAGS and AM_LDFLAGS.
+include $(top_srcdir)/set_flags.am
+
+# Link to the PIO Fortran and C libraries.
+LDADD = ${top_builddir}/src/flib/libpiof.la ${top_builddir}/src/clib/libpioc.la
+
+# Link to the netCDF fortran library.
+LDADD += -lnetcdff
+
+# Find the pio.mod file.
+AM_FCFLAGS = -I${top_builddir}/src/flib ${CPPFLAGS}
+
+# Find the pio.h and pio_tests.h file for the C test.
+AM_CPPFLAGS = -I${top_srcdir}/src/clib -I${top_srcdir}/tests/cunit
+
+# Build the test for make check.
+check_PROGRAMS = ftst_pio ftst_pio_orig tst_c_pio
+ftst_pio_SOURCES = ftst_pio.f90
+ftst_pio_orig_SOURCES = ftst_pio_orig.f90
+
+if RUN_TESTS
+# Tests will run from a bash script.
+TESTS = run_tests.sh
+endif # RUN_TESTS
+
+# Distribute the test script.
+EXTRA_DIST = run_tests.sh
+
+# Clean up files produced during testing.
+CLEANFILES = *.nc *.log

--- a/cime/src/externals/pio2/tests/fncint/ftst_pio.f90
+++ b/cime/src/externals/pio2/tests/fncint/ftst_pio.f90
@@ -1,0 +1,111 @@
+!> This is a test program for the Fortran API use of the netCDF
+!! integration layer.
+!!
+!! @author Ed Hartnett, 7/19/19
+
+program ftst_pio
+  use pio
+  implicit none
+  include 'mpif.h'
+  include 'netcdf.inc'
+
+  character*(*) FILE_NAME
+  parameter (FILE_NAME = 'ftst_pio.nc')
+  integer :: NDIM3 = 3, NRECS = 2, NLAT = 4, NLON = 4
+  character*(*) LAT_NAME, LON_NAME, REC_NAME, VAR_NAME
+  parameter (LAT_NAME = 'latitude', LON_NAME = 'longitude', &
+       REC_NAME = 'time', VAR_NAME = 'some_data_var')
+  integer :: my_rank, ntasks
+  integer :: niotasks = 1, numAggregator = 0, stride = 1, base = 0
+  integer :: ncid
+  integer(kind = PIO_OFFSET_KIND), dimension(:), allocatable :: compdof
+  integer, dimension(:), allocatable :: data_buffer
+  integer, dimension(2) :: dims
+  integer, dimension(3) :: var_dim
+  integer :: maplen
+  integer :: decompid, iosysid
+  integer :: varid, i
+  integer :: ierr
+
+  ! Set up MPI.
+  call MPI_Init(ierr)
+  call MPI_Comm_rank(MPI_COMM_WORLD, my_rank, ierr)
+  call MPI_Comm_size(MPI_COMM_WORLD, ntasks, ierr)
+
+  ! These control logging in the PIO and netCDF libraries.
+  !ierr = pio_set_log_level(3)
+  !ierr = nf_set_log_level(2)
+
+  ! Define an IOSystem.
+  ierr = nf_def_iosystem(my_rank, MPI_COMM_WORLD, niotasks, numAggregator, &
+       stride, PIO_rearr_box, iosysid, base)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Define a 2D decomposition.
+  dims(1) = 4
+  dims(2) = 4
+  maplen = 4
+  print *, 'dims: ', dims
+  print *, 'maplen: ', maplen
+  print *, 'my_rank: ', my_rank
+  allocate(compdof(maplen))
+  allocate(data_buffer(maplen))
+  ! Row decomposition. Recall that my_rank is 0-based, even
+  ! in fortran. Also recall that compdof is 1-based for fortran.
+  do i = 1, maplen
+     compdof(i) = i + my_rank * maplen
+     data_buffer(i) = my_rank * 10 + i
+  end do
+  print *, 'compdof', my_rank, compdof
+  ierr = nf_def_decomp(iosysid, PIO_int, dims, compdof, decompid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Create a file.
+  ierr = nf_create(FILE_NAME, 64, ncid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Define dimensions.
+  ierr = nf_def_dim(ncid, LAT_NAME, NLAT, var_dim(1))
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+  ierr = nf_def_dim(ncid, LON_NAME, NLON, var_dim(2))
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+  ierr = nf_def_dim(ncid, REC_NAME, NF_UNLIMITED, var_dim(3))
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Define a data variable.
+  ierr = nf_def_var(ncid, VAR_NAME, NF_INT, NDIM3, var_dim, varid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+  ierr = nf_enddef(ncid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Write 1st record with distributed arrays.
+  ierr = nf_put_vard_int(ncid, varid, decompid, 1, data_buffer)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Close the file.
+  ierr = nf_close(ncid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Free resources.
+  ierr = nf_free_decomp(decompid)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+  ierr = nf_free_iosystem()
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+  deallocate(compdof)
+  deallocate(data_buffer)
+
+  ! We're done!
+  call MPI_Finalize(ierr)
+  if (my_rank .eq. 0) then
+     print *, '*** SUCCESS running ftst_pio!'
+  endif
+end program ftst_pio
+
+subroutine handle_err(errcode)
+  implicit none
+  include 'netcdf.inc'
+  integer errcode
+
+  print *, 'Error: ', nf_strerror(errcode)
+  stop 2
+end subroutine handle_err

--- a/cime/src/externals/pio2/tests/fncint/ftst_pio_orig.f90
+++ b/cime/src/externals/pio2/tests/fncint/ftst_pio_orig.f90
@@ -1,0 +1,114 @@
+!> This is a test program for the Fortran API use of the netCDF
+!! integration layer.
+!!
+!! @author Ed Hartnett, 7/19/19
+
+program ftst_pio
+  use pio
+  implicit none
+  include 'mpif.h'
+  include 'netcdf.inc'
+
+  character*(*) FILE_NAME
+  parameter (FILE_NAME = 'ftst_pio_orig.nc')
+  integer :: NDIM3 = 3, NRECS = 2, NLAT = 4, NLON = 4
+  character*(*) LAT_NAME, LON_NAME, REC_NAME, VAR_NAME
+  parameter (LAT_NAME = 'latitude', LON_NAME = 'longitude', &
+       REC_NAME = 'time', VAR_NAME = 'some_data_var')
+  integer :: my_rank, ntasks
+  integer :: niotasks = 1, numAggregator = 0, stride = 1, base = 0
+  integer :: ncid
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(:), allocatable :: data_buffer
+  integer, dimension(2) :: dims
+  integer, dimension(3) :: var_dim
+  type(iosystem_desc_t) :: ioSystem
+  type(file_desc_t) :: pioFileDesc
+  type(io_desc_t) :: iodesc
+  type(var_desc_t) :: var
+  integer(kind=pio_offset_kind) :: recnum = 1
+  integer :: maplen
+  integer :: decompid, iosysid
+  integer :: varid, i
+  integer :: ierr
+
+  ! Set up MPI.
+  call MPI_Init(ierr)
+  call MPI_Comm_rank(MPI_COMM_WORLD, my_rank, ierr)
+  call MPI_Comm_size(MPI_COMM_WORLD, ntasks, ierr)
+
+  ! These control logging in the PIO and netCDF libraries.
+!  ierr = pio_set_log_level(3)
+!  ierr = nf_set_log_level(2)
+
+  ! Define an IOSystem.
+  call PIO_init(my_rank, MPI_COMM_WORLD, niotasks, numAggregator, stride, &
+       PIO_rearr_subset, ioSystem, base=base)
+
+  ! Define a 2D decomposition.
+  dims(1) = 4
+  dims(2) = 4
+  maplen = 4
+  print *, 'dims: ', dims
+  print *, 'maplen: ', maplen
+  print *, 'my_rank: ', my_rank
+  allocate(compdof(maplen))
+  allocate(data_buffer(maplen))
+  ! Row decomposition. Recall that my_rank is 0-based, even
+  ! in fortran. Also recall that compdof is 1-based for fortran.
+  do i = 1, maplen
+     compdof(i) = i + my_rank * maplen
+     data_buffer(i) = my_rank * 10 + i
+  end do
+  print *, 'compdof', my_rank, compdof
+
+  call PIO_initdecomp(ioSystem, PIO_int, dims, compdof, iodesc)
+
+  ! Create a file.
+  ierr = PIO_createfile(ioSystem, pioFileDesc, PIO_IOTYPE_PNETCDF, FILE_NAME, PIO_clobber)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Define dimensions.
+  ierr = PIO_def_dim(pioFileDesc%fh, LAT_NAME, NLAT, var_dim(1))
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+  ierr = PIO_def_dim(pioFileDesc%fh, LON_NAME, NLON, var_dim(2))
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+  ierr = PIO_def_dim(pioFileDesc%fh, REC_NAME, NF_UNLIMITED, var_dim(3))
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Define a data variable.
+  ierr = PIO_def_var(pioFileDesc, VAR_NAME, NF_INT, var_dim, var)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+  ierr = PIO_enddef(pioFileDesc%fh)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Write 1st record with distributed arrays.
+  call PIO_setframe(pioFileDesc, var, recnum)
+  call PIO_write_darray(pioFileDesc, var, iodesc, data_buffer, ierr)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Close the file.
+  call PIO_closefile(pioFileDesc)
+  if (ierr .ne. nf_noerr) call handle_err(ierr)
+
+  ! Free resources.
+  deallocate(compdof)
+  deallocate(data_buffer)
+  call PIO_freedecomp(ioSystem, iodesc)
+  call pio_finalize(ioSystem, ierr)
+
+  ! We're done!
+  call MPI_Finalize(ierr)
+  if (my_rank .eq. 0) then
+     print *, '*** SUCCESS running ftst_pio!'
+  endif
+end program ftst_pio
+
+subroutine handle_err(errcode)
+  implicit none
+  include 'netcdf.inc'
+  integer errcode
+
+  print *, 'Error: ', nf_strerror(errcode)
+  stop 2
+end subroutine handle_err

--- a/cime/src/externals/pio2/tests/fncint/run_tests.sh
+++ b/cime/src/externals/pio2/tests/fncint/run_tests.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# This is a test script for PIO.
+# Ed Hartnett
+
+# Stop execution of script if error is returned.
+set -e
+
+# Stop loop if ctrl-c is pressed.
+trap exit INT TERM
+
+printf 'running Fortran tests for PIO netCDF integration...\n'
+PIO_TESTS='tst_c_pio ftst_pio_orig ftst_pio'
+
+success1=true
+for TEST in $PIO_TESTS
+do
+    success1=false
+    echo "running ${TEST}"
+    mpiexec -n 4 ./${TEST} && success1=true
+    if test $success1 = false; then
+        break
+    fi
+done
+
+# Did we succeed?
+if test x$success1 = xtrue; then
+    exit 0
+fi
+exit 1

--- a/cime/src/externals/pio2/tests/fncint/tst_c_pio.c
+++ b/cime/src/externals/pio2/tests/fncint/tst_c_pio.c
@@ -1,0 +1,118 @@
+/* This program does a very simple I/O system and decomposition, and
+ * writes a simple file.
+
+   Ed Hartnett, 7/27/19
+*/
+
+#include "config.h"
+#include <pio.h>
+#include <mpi.h>
+#include <pio_tests.h>
+#include <pio_internal.h>
+
+#define FILE_NAME "tst_c_pio.nc"
+#define VAR_NAME "data_var"
+#define DIM_NAME_UNLIMITED "dim_unlimited"
+#define DIM_NAME_X "dim_x"
+#define DIM_NAME_Y "dim_y"
+#define DIM_LEN_X 4
+#define DIM_LEN_Y 4
+#define NDIM2 2
+#define NDIM3 3
+#define LLEN 4
+#define MPI_ERR 999
+#define NTASKS4 4
+
+int
+main(int argc, char **argv)
+{
+    int my_rank;
+    int ntasks;
+
+    /* Initialize MPI. */
+    if (MPI_Init(&argc, &argv))
+        return MPI_ERR;
+
+    /* Learn my rank and the total number of processors. */
+    if (MPI_Comm_rank(MPI_COMM_WORLD, &my_rank))
+        return MPI_ERR;
+    if (MPI_Comm_size(MPI_COMM_WORLD, &ntasks))
+        return MPI_ERR;
+    /* Must run on 4 tasks only. */
+    if (ntasks != NTASKS4)
+        return MPI_ERR;
+
+    if (!my_rank)
+    {
+        printf("\n*** Testing simple use of PIO.\n");
+        printf("*** testing creating of simple file...");
+    }
+    {
+        int iosysid;
+        int ncid;
+        int dimid[NDIM3];
+        int varid;
+        int ioid;
+        int dimlen[NDIM3] = {NC_UNLIMITED, DIM_LEN_X, DIM_LEN_Y};
+        char dimname[NDIM3][NC_MAX_NAME + 1] = {DIM_NAME_UNLIMITED, DIM_NAME_X, DIM_NAME_Y};
+        int iotype = PIO_IOTYPE_NETCDF;
+        int my_data[LLEN];
+        PIO_Offset compmap[LLEN];
+        int i;
+        int ret;
+
+        /* PIOc_set_log_level(3); */
+
+        /* Initialize local data. */
+        for (i = 0; i < LLEN; i++)
+            my_data[i] = my_rank * 10 + i;
+
+        /* Initialize the IOSystem. */
+        if ((ret = PIOc_Init_Intracomm(MPI_COMM_WORLD, 1, 1, 0, 0, &iosysid)))
+            return ret;
+
+        /* Create a file. */
+        if ((ret = PIOc_createfile(iosysid, &ncid, &iotype, FILE_NAME, 0)))
+            return ret;
+
+        /* Define metadata. */
+        for (i = 0; i < NDIM3; i++)
+            if ((ret = PIOc_def_dim(ncid, dimname[i], dimlen[i], &dimid[i])))
+                return ret;
+        if ((ret = PIOc_def_var(ncid, VAR_NAME, PIO_INT, NDIM3, dimid, &varid)))
+            return ret;
+        if ((ret = PIOc_enddef(ncid)))
+            return ret;
+
+        /* Create the decomposition. */
+        for (i = 0; i < LLEN; i++)
+            compmap[i] = i + my_rank * LLEN;
+        if ((ret = PIOc_init_decomp(iosysid, PIO_INT, NDIM2, &dimlen[1], LLEN, compmap,
+                                    &ioid, PIO_REARR_BOX, NULL, NULL)))
+            return ret;
+
+        /* Write data. */
+        if ((ret = PIOc_setframe(ncid, varid, 0)))
+            return ret;
+        if ((ret = PIOc_write_darray(ncid, varid, ioid, LLEN, my_data, NULL)))
+            return ret;
+
+        /* Close the file. */
+        if ((ret = PIOc_closefile(ncid)))
+            return ret;
+
+        /* Free the decomposition. */
+        if ((ret = PIOc_freedecomp(iosysid, ioid)))
+            return ret;
+
+        /* Free the IOSystem. */
+        if ((ret = PIOc_free_iosystem(iosysid)))
+            return ret;
+    }
+
+    if (!my_rank)
+        printf("\nSUCCESS!\n");
+    /* Finalize MPI. */
+    MPI_Finalize();
+    return 0;
+}

--- a/cime/src/externals/pio2/tests/general/Makefile.am
+++ b/cime/src/externals/pio2/tests/general/Makefile.am
@@ -11,7 +11,7 @@ include $(top_srcdir)/set_flags.am
 
 LDADD = libpio_tutil.la	\
 ${top_builddir}/src/flib/libpiof.la		\
-${top_builddir}/src/clib/libpio.la
+${top_builddir}/src/clib/libpioc.la
 
 # There is a test utility mod file in this subdir which must be built.
 SUBDIRS = util

--- a/cime/src/externals/pio2/tests/general/ncdf_get_put.F90.in
+++ b/cime/src/externals/pio2/tests/general/ncdf_get_put.F90.in
@@ -251,7 +251,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_slice
   Implicit none
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
-  type(var_desc_t)  :: pio_var, pio_cvar
+  type(var_desc_t)  :: pio_var
   integer :: pio_dim
   integer, parameter :: MAX_ROW_DIM_LEN = 100
   PIO_TF_FC_DATA_TYPE, dimension(MAX_ROW_DIM_LEN) :: gval, exp_val
@@ -315,7 +315,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_4parts
   Implicit none
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
-  type(var_desc_t)  :: pio_var, pio_cvar
+  type(var_desc_t)  :: pio_var
   integer :: pio_dim
   integer, parameter :: DIM_LEN = 16
   integer, parameter :: PART_LEN = DIM_LEN / 4
@@ -420,7 +420,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_md2mdplus1_var
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: num_iotypes
-  integer :: i, k, l, m, n, tstep, ret
+  integer :: i, k, l, m, tstep, ret
   
   num_iotypes = 0
   call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)

--- a/cime/src/externals/pio2/tests/general/ncdf_inq.F90.in
+++ b/cime/src/externals/pio2/tests/general/ncdf_inq.F90.in
@@ -75,7 +75,6 @@ SUBROUTINE test_inq_var(pio_file, ret)
   type(file_desc_t), intent(in) :: pio_file
   integer, intent(inout) :: ret
 
-  type(var_desc_t)  :: pio_var
   integer :: var_id, var_type, var_ndims, var_natts
   integer, dimension(:), allocatable :: var_dims
   character(len=pio_max_name) :: var_name

--- a/cime/src/externals/pio2/tests/general/pio_decomp_fillval.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_decomp_fillval.F90.in
@@ -16,7 +16,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_explicit_fval
   PIO_TF_FC_DATA_TYPE, PARAMETER :: BUF_FILLVAL = -2
   integer, dimension(1) :: dims
   integer :: pio_dim
-  integer :: i, ierr, lsz
+  integer :: i, ierr
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -105,7 +105,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_implicit_fval
   PIO_TF_FC_DATA_TYPE, PARAMETER :: BUF_FILLVAL = -2
   integer, dimension(1) :: dims
   integer :: pio_dim
-  integer :: i, ierr, lsz
+  integer :: i, ierr
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -208,7 +208,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_read_1d_explicit_fval
   PIO_TF_FC_DATA_TYPE, PARAMETER :: BUF_FILLVAL = -2
   integer, dimension(1) :: dims
   integer :: pio_dim
-  integer :: i, ierr, lsz
+  integer :: i, ierr
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -295,7 +295,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_read_1d_implicit_fval
   integer, parameter :: BUF_FILLVAL = -2
   integer, dimension(1) :: dims
   integer :: pio_dim
-  integer :: i, ierr, lsz
+  integer :: i, ierr
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs

--- a/cime/src/externals/pio2/tests/general/pio_decomp_frame_tests.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_decomp_frame_tests.F90.in
@@ -92,8 +92,10 @@ END SUBROUTINE
 
 ! Write with one decomp (to force rearrangement) and read with another (no
 ! rearrangement)
-PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
-PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_4d_col_decomp
+
+SUBROUTINE nc_write_read_4d_col_decomp_PIO_int_integer__
+USE pio_tutil
+
   implicit none
   integer, parameter :: NDIMS = 4
   integer, parameter :: NFRAMES = 6
@@ -103,22 +105,506 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_4d_col_decomp
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(NDIMS) :: start, count
-  PIO_TF_FC_DATA_TYPE, dimension(:,:,:,:), allocatable :: rbuf, wbuf, exp_val
+  integer, dimension(:,:,:,:), allocatable :: rbuf, wbuf, exp_val
   integer, dimension(NDIMS-1) :: dims
   integer, dimension(NDIMS) :: pio_dims
-  integer :: i, j, k, tmp_idx, ierr, lsz, nrows, ncols, nhgts
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
   integer(kind=pio_offset_kind) :: f
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: num_iotypes
-
+   ! pio_decomp_frame_tests.F90.in:115
   ! Set the decomposition for writing data - forcing rearrangement
   call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
   nrows = count(1)
   ncols = count(2)
   nhgts = count(3)
-  
+
+  allocate(wbuf(nrows, ncols, nhgts, NFRAMES))
+  allocate(compdof(nrows * ncols * nhgts))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          wbuf(i,j,k,f) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                        (start(2) - 1 + j - 1) * dims(1) + i
+          wbuf(i,j,k,f) = wbuf(i,j,k,f) + int(f - 1) * (dims(1) * dims(2) * dims(3))
+          tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+          compdof(tmp_idx) = int(wbuf(i,j,k,1))
+        end do
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:137
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_int, dims, compdof, wr_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:140
+  ! Set the decomposition for reading data - different from the write decomp
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
+  allocate(rbuf(nrows, ncols, nhgts, NFRAMES))
+  allocate(compdof(nrows * ncols * nhgts))
+  allocate(exp_val(nrows, ncols, nhgts, NFRAMES))
+   ! pio_decomp_frame_tests.F90.in:150
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+          compdof(tmp_idx) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                              (start(2) - 1 + j - 1) * dims(1) + i
+          exp_val(i,j,k,f) = compdof(tmp_idx) + int(f - 1) * (dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:163
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_int, dims, compdof, rd_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:166
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+
+    IF (pio_tf_world_rank_ == 0) THEN
+      IF (pio_tf_log_level_ >= 0) THEN
+        WRITE(*,"(A)",ADVANCE="NO") "PIO_TF: "
+        WRITE(*,*)  "Testing : PIO_int : ", iotype_descs(i)
+      END IF
+    END IF
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Could not create file " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:173)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:174
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:176)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:177
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:179)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:180
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:182)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:183
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(4))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:185)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:186
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_int, pio_dims, pio_var)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:188)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:189
+    ierr = PIO_enddef(pio_file)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to end redef mode : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:191)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:192
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var, f)
+      ! Write the current frame
+      call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to write darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:197)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:199
+    call PIO_syncfile(pio_file)
+   ! pio_decomp_frame_tests.F90.in:201
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var, f)
+      call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to read darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:205)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:207
+    do f=1,NFRAMES
+
+      IF (.NOT. PIO_TF_Check_val_(rbuf(:,:,:,f), exp_val(:,:,:,f))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Check failed:",&
+             "Got wrong val, frame=", f,&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:209)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:211
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+   ! pio_decomp_frame_tests.F90.in:216
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+   ! pio_decomp_frame_tests.F90.in:221
+  call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+  deallocate(exp_val)
+  deallocate(rbuf)
+  deallocate(wbuf)
+END SUBROUTINE nc_write_read_4d_col_decomp_PIO_int_integer__
+
+
+SUBROUTINE nc_write_read_4d_col_decomp_PIO_real_real_kind_fc_real___
+USE pio_tutil
+
+  implicit none
+  integer, parameter :: NDIMS = 4
+  integer, parameter :: NFRAMES = 6
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wr_iodesc, rd_iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(NDIMS) :: start, count
+  real(kind=fc_real), dimension(:,:,:,:), allocatable :: rbuf, wbuf, exp_val
+  integer, dimension(NDIMS-1) :: dims
+  integer, dimension(NDIMS) :: pio_dims
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
+  integer(kind=pio_offset_kind) :: f
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+   ! pio_decomp_frame_tests.F90.in:115
+  ! Set the decomposition for writing data - forcing rearrangement
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
+  allocate(wbuf(nrows, ncols, nhgts, NFRAMES))
+  allocate(compdof(nrows * ncols * nhgts))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          wbuf(i,j,k,f) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                        (start(2) - 1 + j - 1) * dims(1) + i
+          wbuf(i,j,k,f) = wbuf(i,j,k,f) + real(f - 1) * real(dims(1) * dims(2) * dims(3))
+          tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+          compdof(tmp_idx) = int(wbuf(i,j,k,1))
+        end do
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:137
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_real, dims, compdof, wr_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:140
+  ! Set the decomposition for reading data - different from the write decomp
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
+  allocate(rbuf(nrows, ncols, nhgts, NFRAMES))
+  allocate(compdof(nrows * ncols * nhgts))
+  allocate(exp_val(nrows, ncols, nhgts, NFRAMES))
+   ! pio_decomp_frame_tests.F90.in:150
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+          compdof(tmp_idx) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                              (start(2) - 1 + j - 1) * dims(1) + i
+          exp_val(i,j,k,f) = compdof(tmp_idx) + real(f - 1) * real(dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:163
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_real, dims, compdof, rd_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:166
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+
+    IF (pio_tf_world_rank_ == 0) THEN
+      IF (pio_tf_log_level_ >= 0) THEN
+        WRITE(*,"(A)",ADVANCE="NO") "PIO_TF: "
+        WRITE(*,*)  "Testing : PIO_real : ", iotype_descs(i)
+      END IF
+    END IF
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Could not create file " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:173)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:174
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:176)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:177
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:179)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:180
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:182)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:183
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(4))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:185)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:186
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_real, pio_dims, pio_var)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:188)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:189
+    ierr = PIO_enddef(pio_file)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to end redef mode : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:191)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:192
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var, f)
+      ! Write the current frame
+      call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to write darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:197)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:199
+    call PIO_syncfile(pio_file)
+   ! pio_decomp_frame_tests.F90.in:201
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var, f)
+      call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to read darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:205)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:207
+    do f=1,NFRAMES
+
+      IF (.NOT. PIO_TF_Check_val_(rbuf(:,:,:,f), exp_val(:,:,:,f))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Check failed:",&
+             "Got wrong val, frame=", f,&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:209)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:211
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+   ! pio_decomp_frame_tests.F90.in:216
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+   ! pio_decomp_frame_tests.F90.in:221
+  call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+  deallocate(exp_val)
+  deallocate(rbuf)
+  deallocate(wbuf)
+END SUBROUTINE nc_write_read_4d_col_decomp_PIO_real_real_kind_fc_real___
+
+
+SUBROUTINE nc_write_read_4d_col_decomp_PIO_double_real_kind_fc_double___
+USE pio_tutil
+
+  implicit none
+  integer, parameter :: NDIMS = 4
+  integer, parameter :: NFRAMES = 6
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wr_iodesc, rd_iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(NDIMS) :: start, count
+  real(kind=fc_double), dimension(:,:,:,:), allocatable :: rbuf, wbuf, exp_val
+  integer, dimension(NDIMS-1) :: dims
+  integer, dimension(NDIMS) :: pio_dims
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
+  integer(kind=pio_offset_kind) :: f
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+   ! pio_decomp_frame_tests.F90.in:115
+  ! Set the decomposition for writing data - forcing rearrangement
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
   allocate(wbuf(nrows, ncols, nhgts, NFRAMES))
   allocate(compdof(nrows * ncols * nhgts))
   do f=1,NFRAMES
@@ -129,25 +615,25 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_4d_col_decomp
                         (start(2) - 1 + j - 1) * dims(1) + i
           wbuf(i,j,k,f) = wbuf(i,j,k,f) + (f - 1) * (dims(1) * dims(2) * dims(3))
           tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
-          compdof(tmp_idx) = wbuf(i,j,k,1)
+          compdof(tmp_idx) = int(wbuf(i,j,k,1))
         end do
       end do
     end do
   end do
-
-  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, wr_iodesc)
+   ! pio_decomp_frame_tests.F90.in:137
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_double, dims, compdof, wr_iodesc)
   deallocate(compdof)
-
+   ! pio_decomp_frame_tests.F90.in:140
   ! Set the decomposition for reading data - different from the write decomp
   call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
   nrows = count(1)
   ncols = count(2)
   nhgts = count(3)
-  
+
   allocate(rbuf(nrows, ncols, nhgts, NFRAMES))
   allocate(compdof(nrows * ncols * nhgts))
   allocate(exp_val(nrows, ncols, nhgts, NFRAMES))
-
+   ! pio_decomp_frame_tests.F90.in:150
   do f=1,NFRAMES
     do k=1,nhgts
       do j=1,ncols
@@ -160,77 +646,186 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_4d_col_decomp
       end do
     end do
   end do
-
-  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, rd_iodesc)
+   ! pio_decomp_frame_tests.F90.in:163
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_double, dims, compdof, rd_iodesc)
   deallocate(compdof)
-
+   ! pio_decomp_frame_tests.F90.in:166
   num_iotypes = 0
   call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
   filename = "test_pio_decomp_simple_tests.testfile"
   do i=1,num_iotypes
-    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
-    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
-    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
 
+    IF (pio_tf_world_rank_ == 0) THEN
+      IF (pio_tf_log_level_ >= 0) THEN
+        WRITE(*,"(A)",ADVANCE="NO") "PIO_TF: "
+        WRITE(*,*)  "Testing : PIO_double : ", iotype_descs(i)
+      END IF
+    END IF
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Could not create file " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:173)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:174
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:176)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:177
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:179)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:180
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:182)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:183
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(4))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, pio_dims, pio_var)
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:185)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:186
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_double, pio_dims, pio_var)
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:188)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:189
     ierr = PIO_enddef(pio_file)
-    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to end redef mode : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:191)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:192
     do f=1,NFRAMES
       call PIO_setframe(pio_file, pio_var, f)
       ! Write the current frame
       call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf(:,:,:,f), ierr)
-      PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to write darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:197)"
+        END IF
+        RETURN
+      END IF
     end do
-
+   ! pio_decomp_frame_tests.F90.in:199
     call PIO_syncfile(pio_file)
-
+   ! pio_decomp_frame_tests.F90.in:201
     do f=1,NFRAMES
       call PIO_setframe(pio_file, pio_var, f)
       call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf(:,:,:,f), ierr)
-      PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
-    end do
 
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to read darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:205)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:207
     do f=1,NFRAMES
-      PIO_TF_CHECK_VAL((rbuf(:,:,:,f), exp_val(:,:,:,f)), "Got wrong val, frame=", f)
-    end do
 
+      IF (.NOT. PIO_TF_Check_val_(rbuf(:,:,:,f), exp_val(:,:,:,f))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Check failed:",&
+             "Got wrong val, frame=", f,&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:209)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:211
     call PIO_closefile(pio_file)
-    
+
     call PIO_deletefile(pio_tf_iosystem_, filename);
   end do
-
+   ! pio_decomp_frame_tests.F90.in:216
   if(allocated(iotypes)) then
     deallocate(iotypes)
     deallocate(iotype_descs)
   end if
-
+   ! pio_decomp_frame_tests.F90.in:221
   call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
   call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
   deallocate(exp_val)
   deallocate(rbuf)
   deallocate(wbuf)
-PIO_TF_AUTO_TEST_SUB_END nc_write_read_4d_col_decomp
+END SUBROUTINE nc_write_read_4d_col_decomp_PIO_double_real_kind_fc_double___
+   ! pio_decomp_frame_tests.F90.in:227
 
 ! Using a 3d decomp for writing out a 3d and a 4d var
 ! Write with one decomp (to force rearrangement) and read with another (no
 ! rearrangement)
-PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
-PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
+
+SUBROUTINE nc_reuse_3d_decomp_PIO_int_integer__
+USE pio_tutil
+
   implicit none
   integer, parameter :: NDIMS = 4
   integer, parameter :: NFRAMES = 3
@@ -240,23 +835,699 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(NDIMS) :: start, count
-  PIO_TF_FC_DATA_TYPE, dimension(:,:,:,:), allocatable :: rbuf4d, wbuf4d, exp_val4d
-  PIO_TF_FC_DATA_TYPE, dimension(:,:,:), allocatable :: rbuf3d, wbuf3d, exp_val3d
+  integer, dimension(:,:,:,:), allocatable :: rbuf4d, wbuf4d, exp_val4d
+  integer, dimension(:,:,:), allocatable :: rbuf3d, wbuf3d, exp_val3d
   integer, dimension(NDIMS-1) :: dims
   integer, dimension(NDIMS) :: pio_dims
-  integer :: i, j, k, tmp_idx, ierr, lsz, nrows, ncols, nhgts
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
   integer(kind=pio_offset_kind) :: f
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: num_iotypes
-
+   ! pio_decomp_frame_tests.F90.in:846
   ! Set the decomposition for writing data - forcing rearrangement
   call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
   nrows = count(1)
   ncols = count(2)
   nhgts = count(3)
-  
+
+  ! Initialize the 4d var
+  allocate(wbuf4d(nrows, ncols, nhgts, NFRAMES))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          wbuf4d(i,j,k,f) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                        (start(2) - 1 + j - 1) * dims(1) + i
+          wbuf4d(i,j,k,f) = wbuf4d(i,j,k,f) + int(f - 1) * (dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+  allocate(compdof(nrows * ncols * nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+        compdof(tmp_idx) = int(wbuf4d(i,j,k,1))
+      end do
+    end do
+  end do
+  ! Initialize the 3d var
+  allocate(wbuf3d(nrows, ncols, nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        wbuf3d(i,j,k) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                      (start(2) - 1 + j - 1) * dims(1) + i
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:885
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_int, dims, compdof, wr_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:888
+  ! Set the decomposition for reading data - different from the write decomp
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
+  allocate(rbuf4d(nrows, ncols, nhgts, NFRAMES))
+  rbuf4d = 0
+  ! Expected val for 4d var
+  allocate(exp_val4d(nrows, ncols, nhgts, NFRAMES))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          exp_val4d(i,j,k,f) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                              (start(2) - 1 + j - 1) * dims(1) + i
+          exp_val4d(i,j,k,f) = exp_val4d(i,j,k,f) + int(f - 1) * (dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+  allocate(compdof(nrows * ncols * nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+        compdof(tmp_idx) = int(exp_val4d(i,j,k,1))
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:919
+  allocate(rbuf3d(nrows, ncols, nhgts))
+  rbuf3d = 0
+  ! Expected val for 3d var
+  allocate(exp_val3d(nrows, ncols, nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        exp_val3d(i,j,k) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                            (start(2) - 1 + j - 1) * dims(1) + i
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:932
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_int, dims, compdof, rd_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:935
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+
+    IF (pio_tf_world_rank_ == 0) THEN
+      IF (pio_tf_log_level_ >= 0) THEN
+        WRITE(*,"(A)",ADVANCE="NO") "PIO_TF: "
+        WRITE(*,*)  "Testing : PIO_int : ", iotype_descs(i)
+      END IF
+    END IF
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Could not create file " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:942)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:943
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:945)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:946
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:948)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:949
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:951)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:952
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(4))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:954)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:955
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_3d_var', PIO_int, pio_dims(1:3), pio_var3d)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a 3d var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:957)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:958
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_4d_var', PIO_int, pio_dims, pio_var4d)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a 4d var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:960)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:961
+    ierr = PIO_enddef(pio_file)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to end redef mode : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:963)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:964
+    call PIO_write_darray(pio_file, pio_var3d, wr_iodesc, wbuf3d, ierr)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to write 3d darray : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:966)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:967
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var4d, f)
+      ! Write the current frame
+      call PIO_write_darray(pio_file, pio_var4d, wr_iodesc, wbuf4d(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to write 4d darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:972)"
+        END IF
+        RETURN
+      END IF
+    end do
+    call PIO_syncfile(pio_file)
+   ! pio_decomp_frame_tests.F90.in:975
+    rbuf4d = 0
+    rbuf3d = 0
+   ! pio_decomp_frame_tests.F90.in:978
+    call PIO_read_darray(pio_file, pio_var3d, rd_iodesc, rbuf3d, ierr)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to read 3d darray : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:980)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:981
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var4d, f)
+      call PIO_read_darray(pio_file, pio_var4d, rd_iodesc, rbuf4d(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to read 4d darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:985)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:987
+    do f=1,NFRAMES
+
+      IF (.NOT. PIO_TF_Check_val_(rbuf4d(:,:,:,f), exp_val4d(:,:,:,f))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Check failed:",&
+             "Got wrong 4d val, frame=", f,&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:989)"
+        END IF
+        RETURN
+      END IF
+    end do
+
+    IF (.NOT. PIO_TF_Check_val_(rbuf3d, exp_val3d)) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Check failed:",&
+           "Got wrong 3dd val",&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:991)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:992
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+   ! pio_decomp_frame_tests.F90.in:997
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+   ! pio_decomp_frame_tests.F90.in:1002
+  call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+   ! pio_decomp_frame_tests.F90.in:1005
+  deallocate(exp_val3d)
+  deallocate(rbuf3d)
+  deallocate(wbuf3d)
+   ! pio_decomp_frame_tests.F90.in:1009
+  deallocate(exp_val4d)
+  deallocate(rbuf4d)
+  deallocate(wbuf4d)
+END SUBROUTINE nc_reuse_3d_decomp_PIO_int_integer__
+
+
+SUBROUTINE nc_reuse_3d_decomp_PIO_real_real_kind_fc_real___
+USE pio_tutil
+
+  implicit none
+  integer, parameter :: NDIMS = 4
+  integer, parameter :: NFRAMES = 3
+  type(var_desc_t)  :: pio_var3d, pio_var4d
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wr_iodesc, rd_iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(NDIMS) :: start, count
+  real(kind=fc_real), dimension(:,:,:,:), allocatable :: rbuf4d, wbuf4d, exp_val4d
+  real(kind=fc_real), dimension(:,:,:), allocatable :: rbuf3d, wbuf3d, exp_val3d
+  integer, dimension(NDIMS-1) :: dims
+  integer, dimension(NDIMS) :: pio_dims
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
+  integer(kind=pio_offset_kind) :: f
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+   ! pio_decomp_frame_tests.F90.in:846
+  ! Set the decomposition for writing data - forcing rearrangement
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
+  ! Initialize the 4d var
+  allocate(wbuf4d(nrows, ncols, nhgts, NFRAMES))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          wbuf4d(i,j,k,f) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                        (start(2) - 1 + j - 1) * dims(1) + i
+          wbuf4d(i,j,k,f) = wbuf4d(i,j,k,f) + real(f - 1) * real(dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+  allocate(compdof(nrows * ncols * nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+        compdof(tmp_idx) = int(wbuf4d(i,j,k,1))
+      end do
+    end do
+  end do
+  ! Initialize the 3d var
+  allocate(wbuf3d(nrows, ncols, nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        wbuf3d(i,j,k) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                      (start(2) - 1 + j - 1) * dims(1) + i
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:885
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_real, dims, compdof, wr_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:888
+  ! Set the decomposition for reading data - different from the write decomp
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
+  allocate(rbuf4d(nrows, ncols, nhgts, NFRAMES))
+  rbuf4d = 0
+  ! Expected val for 4d var
+  allocate(exp_val4d(nrows, ncols, nhgts, NFRAMES))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          exp_val4d(i,j,k,f) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                              (start(2) - 1 + j - 1) * dims(1) + i
+          exp_val4d(i,j,k,f) = exp_val4d(i,j,k,f) + real(f - 1) * real(dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+  allocate(compdof(nrows * ncols * nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+        compdof(tmp_idx) = int(exp_val4d(i,j,k,1))
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:919
+  allocate(rbuf3d(nrows, ncols, nhgts))
+  rbuf3d = 0
+  ! Expected val for 3d var
+  allocate(exp_val3d(nrows, ncols, nhgts))
+  do k=1,nhgts
+    do j=1,ncols
+      do i=1,nrows
+        exp_val3d(i,j,k) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                            (start(2) - 1 + j - 1) * dims(1) + i
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:932
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_real, dims, compdof, rd_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:935
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+
+    IF (pio_tf_world_rank_ == 0) THEN
+      IF (pio_tf_log_level_ >= 0) THEN
+        WRITE(*,"(A)",ADVANCE="NO") "PIO_TF: "
+        WRITE(*,*)  "Testing : PIO_real : ", iotype_descs(i)
+      END IF
+    END IF
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Could not create file " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:942)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:943
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:945)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:946
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:948)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:949
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:951)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:952
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(4))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:954)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:955
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_3d_var', PIO_real, pio_dims(1:3), pio_var3d)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a 3d var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:957)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:958
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_4d_var', PIO_real, pio_dims, pio_var4d)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a 4d var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:960)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:961
+    ierr = PIO_enddef(pio_file)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to end redef mode : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:963)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:964
+    call PIO_write_darray(pio_file, pio_var3d, wr_iodesc, wbuf3d, ierr)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to write 3d darray : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:966)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:967
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var4d, f)
+      ! Write the current frame
+      call PIO_write_darray(pio_file, pio_var4d, wr_iodesc, wbuf4d(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to write 4d darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:972)"
+        END IF
+        RETURN
+      END IF
+    end do
+    call PIO_syncfile(pio_file)
+   ! pio_decomp_frame_tests.F90.in:975
+    rbuf4d = 0
+    rbuf3d = 0
+   ! pio_decomp_frame_tests.F90.in:978
+    call PIO_read_darray(pio_file, pio_var3d, rd_iodesc, rbuf3d, ierr)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to read 3d darray : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:980)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:981
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var4d, f)
+      call PIO_read_darray(pio_file, pio_var4d, rd_iodesc, rbuf4d(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to read 4d darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:985)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:987
+    do f=1,NFRAMES
+
+      IF (.NOT. PIO_TF_Check_val_(rbuf4d(:,:,:,f), exp_val4d(:,:,:,f))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Check failed:",&
+             "Got wrong 4d val, frame=", f,&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:989)"
+        END IF
+        RETURN
+      END IF
+    end do
+
+    IF (.NOT. PIO_TF_Check_val_(rbuf3d, exp_val3d)) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Check failed:",&
+           "Got wrong 3dd val",&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:991)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:992
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+   ! pio_decomp_frame_tests.F90.in:997
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+   ! pio_decomp_frame_tests.F90.in:1002
+  call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+   ! pio_decomp_frame_tests.F90.in:1005
+  deallocate(exp_val3d)
+  deallocate(rbuf3d)
+  deallocate(wbuf3d)
+   ! pio_decomp_frame_tests.F90.in:1009
+  deallocate(exp_val4d)
+  deallocate(rbuf4d)
+  deallocate(wbuf4d)
+END SUBROUTINE nc_reuse_3d_decomp_PIO_real_real_kind_fc_real___
+
+
+SUBROUTINE nc_reuse_3d_decomp_PIO_double_real_kind_fc_double___
+USE pio_tutil
+
+  implicit none
+  integer, parameter :: NDIMS = 4
+  integer, parameter :: NFRAMES = 3
+  type(var_desc_t)  :: pio_var3d, pio_var4d
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wr_iodesc, rd_iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(NDIMS) :: start, count
+  real(kind=fc_double), dimension(:,:,:,:), allocatable :: rbuf4d, wbuf4d, exp_val4d
+  real(kind=fc_double), dimension(:,:,:), allocatable :: rbuf3d, wbuf3d, exp_val3d
+  integer, dimension(NDIMS-1) :: dims
+  integer, dimension(NDIMS) :: pio_dims
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
+  integer(kind=pio_offset_kind) :: f
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+   ! pio_decomp_frame_tests.F90.in:846
+  ! Set the decomposition for writing data - forcing rearrangement
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
   ! Initialize the 4d var
   allocate(wbuf4d(nrows, ncols, nhgts, NFRAMES))
   do f=1,NFRAMES
@@ -275,12 +1546,12 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
     do j=1,ncols
       do i=1,nrows
         tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
-        compdof(tmp_idx) = wbuf4d(i,j,k,1)
+        compdof(tmp_idx) = int(wbuf4d(i,j,k,1))
       end do
     end do
   end do
   ! Initialize the 3d var
-  allocate(wbuf3d(nrows, ncols, nhgts)) 
+  allocate(wbuf3d(nrows, ncols, nhgts))
   do k=1,nhgts
     do j=1,ncols
       do i=1,nrows
@@ -289,16 +1560,16 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
       end do
     end do
   end do
-
-  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, wr_iodesc)
+   ! pio_decomp_frame_tests.F90.in:885
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_double, dims, compdof, wr_iodesc)
   deallocate(compdof)
-
+   ! pio_decomp_frame_tests.F90.in:888
   ! Set the decomposition for reading data - different from the write decomp
   call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
   nrows = count(1)
   ncols = count(2)
   nhgts = count(3)
-  
+
   allocate(rbuf4d(nrows, ncols, nhgts, NFRAMES))
   rbuf4d = 0
   ! Expected val for 4d var
@@ -319,11 +1590,11 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
     do j=1,ncols
       do i=1,nrows
         tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
-        compdof(tmp_idx) = exp_val4d(i,j,k,1)
+        compdof(tmp_idx) = int(exp_val4d(i,j,k,1))
       end do
     end do
   end do
-
+   ! pio_decomp_frame_tests.F90.in:919
   allocate(rbuf3d(nrows, ncols, nhgts))
   rbuf3d = 0
   ! Expected val for 3d var
@@ -336,92 +1607,242 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
       end do
     end do
   end do
-
-  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, rd_iodesc)
+   ! pio_decomp_frame_tests.F90.in:932
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_double, dims, compdof, rd_iodesc)
   deallocate(compdof)
-
+   ! pio_decomp_frame_tests.F90.in:935
   num_iotypes = 0
   call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
   filename = "test_pio_decomp_simple_tests.testfile"
   do i=1,num_iotypes
-    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
-    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
-    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
 
+    IF (pio_tf_world_rank_ == 0) THEN
+      IF (pio_tf_log_level_ >= 0) THEN
+        WRITE(*,"(A)",ADVANCE="NO") "PIO_TF: "
+        WRITE(*,*)  "Testing : PIO_double : ", iotype_descs(i)
+      END IF
+    END IF
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Could not create file " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:942)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:943
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:945)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:946
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:948)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:949
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:951)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:952
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(4))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_3d_var', PIO_TF_DATA_TYPE, pio_dims(1:3), pio_var3d)
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a 3d var : " // trim(filename))
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:954)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:955
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_3d_var', PIO_double, pio_dims(1:3), pio_var3d)
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_4d_var', PIO_TF_DATA_TYPE, pio_dims, pio_var4d)
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a 4d var : " // trim(filename))
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a 3d var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:957)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:958
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_4d_var', PIO_double, pio_dims, pio_var4d)
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a 4d var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:960)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:961
     ierr = PIO_enddef(pio_file)
-    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to end redef mode : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:963)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:964
     call PIO_write_darray(pio_file, pio_var3d, wr_iodesc, wbuf3d, ierr)
-    PIO_TF_CHECK_ERR(ierr, "Failed to write 3d darray : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to write 3d darray : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:966)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:967
     do f=1,NFRAMES
       call PIO_setframe(pio_file, pio_var4d, f)
       ! Write the current frame
       call PIO_write_darray(pio_file, pio_var4d, wr_iodesc, wbuf4d(:,:,:,f), ierr)
-      PIO_TF_CHECK_ERR(ierr, "Failed to write 4d darray : " // trim(filename))
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to write 4d darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:972)"
+        END IF
+        RETURN
+      END IF
     end do
     call PIO_syncfile(pio_file)
-
+   ! pio_decomp_frame_tests.F90.in:975
     rbuf4d = 0
     rbuf3d = 0
-
+   ! pio_decomp_frame_tests.F90.in:978
     call PIO_read_darray(pio_file, pio_var3d, rd_iodesc, rbuf3d, ierr)
-    PIO_TF_CHECK_ERR(ierr, "Failed to read 3d darray : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to read 3d darray : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:980)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:981
     do f=1,NFRAMES
       call PIO_setframe(pio_file, pio_var4d, f)
       call PIO_read_darray(pio_file, pio_var4d, rd_iodesc, rbuf4d(:,:,:,f), ierr)
-      PIO_TF_CHECK_ERR(ierr, "Failed to read 4d darray : " // trim(filename))
-    end do
 
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to read 4d darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:985)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:987
     do f=1,NFRAMES
-      PIO_TF_CHECK_VAL((rbuf4d(:,:,:,f), exp_val4d(:,:,:,f)), "Got wrong 4d val, frame=", f)
-    end do
-    PIO_TF_CHECK_VAL((rbuf3d, exp_val3d), "Got wrong 3dd val")
 
+      IF (.NOT. PIO_TF_Check_val_(rbuf4d(:,:,:,f), exp_val4d(:,:,:,f))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Check failed:",&
+             "Got wrong 4d val, frame=", f,&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:989)"
+        END IF
+        RETURN
+      END IF
+    end do
+
+    IF (.NOT. PIO_TF_Check_val_(rbuf3d, exp_val3d)) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Check failed:",&
+           "Got wrong 3dd val",&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:991)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:992
     call PIO_closefile(pio_file)
-    
+
     call PIO_deletefile(pio_tf_iosystem_, filename);
   end do
-
+   ! pio_decomp_frame_tests.F90.in:997
   if(allocated(iotypes)) then
     deallocate(iotypes)
     deallocate(iotype_descs)
   end if
-
+   ! pio_decomp_frame_tests.F90.in:1002
   call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
   call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
-
+   ! pio_decomp_frame_tests.F90.in:1005
   deallocate(exp_val3d)
   deallocate(rbuf3d)
   deallocate(wbuf3d)
-
+   ! pio_decomp_frame_tests.F90.in:1009
   deallocate(exp_val4d)
   deallocate(rbuf4d)
   deallocate(wbuf4d)
-PIO_TF_AUTO_TEST_SUB_END nc_reuse_3d_decomp
+END SUBROUTINE nc_reuse_3d_decomp_PIO_double_real_kind_fc_double___
+   ! pio_decomp_frame_tests.F90.in:1013
+
 
 ! Same as nc_write_read_4d_col_decomp, but use a limited time dimension instead
-PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
-PIO_TF_AUTO_TEST_SUB_BEGIN nc_test_limited_time_dim
+
+SUBROUTINE nc_test_limited_time_dim_PIO_int_integer__
+USE pio_tutil
+
   implicit none
   integer, parameter :: NDIMS = 4
   integer, parameter :: NFRAMES = 6
@@ -431,22 +1852,506 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_test_limited_time_dim
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(NDIMS) :: start, count
-  PIO_TF_FC_DATA_TYPE, dimension(:,:,:,:), allocatable :: rbuf, wbuf, exp_val
+  integer, dimension(:,:,:,:), allocatable :: rbuf, wbuf, exp_val
   integer, dimension(NDIMS-1) :: dims
   integer, dimension(NDIMS) :: pio_dims
-  integer :: i, j, k, tmp_idx, ierr, lsz, nrows, ncols, nhgts
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
   integer(kind=pio_offset_kind) :: f
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: num_iotypes
-
+   ! pio_decomp_frame_tests.F90.in:1862
   ! Set the decomposition for writing data - forcing rearrangement
   call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
   nrows = count(1)
   ncols = count(2)
   nhgts = count(3)
-  
+
+  allocate(wbuf(nrows, ncols, nhgts, NFRAMES))
+  allocate(compdof(nrows * ncols * nhgts))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          wbuf(i,j,k,f) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                        (start(2) - 1 + j - 1) * dims(1) + i
+          wbuf(i,j,k,f) = wbuf(i,j,k,f) + int(f - 1) * (dims(1) * dims(2) * dims(3))
+          tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+          compdof(tmp_idx) = int(wbuf(i,j,k,1))
+        end do
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:1884
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_int, dims, compdof, wr_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:1887
+  ! Set the decomposition for reading data - different from the write decomp
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
+  allocate(rbuf(nrows, ncols, nhgts, NFRAMES))
+  allocate(compdof(nrows * ncols * nhgts))
+  allocate(exp_val(nrows, ncols, nhgts, NFRAMES))
+   ! pio_decomp_frame_tests.F90.in:1897
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+          compdof(tmp_idx) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                              (start(2) - 1 + j - 1) * dims(1) + i
+          exp_val(i,j,k,f) = compdof(tmp_idx) + int(f - 1) * (dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:1910
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_int, dims, compdof, rd_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:1913
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+
+    IF (pio_tf_world_rank_ == 0) THEN
+      IF (pio_tf_log_level_ >= 0) THEN
+        WRITE(*,"(A)",ADVANCE="NO") "PIO_TF: "
+        WRITE(*,*)  "Testing : PIO_int : ", iotype_descs(i)
+      END IF
+    END IF
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Could not create file " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1920)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1921
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1923)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1924
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1926)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1927
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1929)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1930
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time_limited', NFRAMES, pio_dims(4))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1932)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1933
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_int, pio_dims, pio_var)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1935)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1936
+    ierr = PIO_enddef(pio_file)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to end redef mode : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1938)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1939
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var, f)
+      ! Write the current frame
+      call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to write darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:1944)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:1946
+    call PIO_syncfile(pio_file)
+   ! pio_decomp_frame_tests.F90.in:1948
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var, f)
+      call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to read darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:1952)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:1954
+    do f=1,NFRAMES
+
+      IF (.NOT. PIO_TF_Check_val_(rbuf(:,:,:,f), exp_val(:,:,:,f))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Check failed:",&
+             "Got wrong val, frame=", f,&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:1956)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:1958
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+   ! pio_decomp_frame_tests.F90.in:1963
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+   ! pio_decomp_frame_tests.F90.in:1968
+  call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+  deallocate(exp_val)
+  deallocate(rbuf)
+  deallocate(wbuf)
+END SUBROUTINE nc_test_limited_time_dim_PIO_int_integer__
+
+
+SUBROUTINE nc_test_limited_time_dim_PIO_real_real_kind_fc_real___
+USE pio_tutil
+
+  implicit none
+  integer, parameter :: NDIMS = 4
+  integer, parameter :: NFRAMES = 6
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wr_iodesc, rd_iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(NDIMS) :: start, count
+  real(kind=fc_real), dimension(:,:,:,:), allocatable :: rbuf, wbuf, exp_val
+  integer, dimension(NDIMS-1) :: dims
+  integer, dimension(NDIMS) :: pio_dims
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
+  integer(kind=pio_offset_kind) :: f
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+   ! pio_decomp_frame_tests.F90.in:1862
+  ! Set the decomposition for writing data - forcing rearrangement
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
+  allocate(wbuf(nrows, ncols, nhgts, NFRAMES))
+  allocate(compdof(nrows * ncols * nhgts))
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          wbuf(i,j,k,f) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                        (start(2) - 1 + j - 1) * dims(1) + i
+          wbuf(i,j,k,f) = wbuf(i,j,k,f) + real(f - 1) * real(dims(1) * dims(2) * dims(3))
+          tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+          compdof(tmp_idx) = int(wbuf(i,j,k,1))
+        end do
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:1884
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_real, dims, compdof, wr_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:1887
+  ! Set the decomposition for reading data - different from the write decomp
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
+  allocate(rbuf(nrows, ncols, nhgts, NFRAMES))
+  allocate(compdof(nrows * ncols * nhgts))
+  allocate(exp_val(nrows, ncols, nhgts, NFRAMES))
+   ! pio_decomp_frame_tests.F90.in:1897
+  do f=1,NFRAMES
+    do k=1,nhgts
+      do j=1,ncols
+        do i=1,nrows
+          tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
+          compdof(tmp_idx) =  (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
+                              (start(2) - 1 + j - 1) * dims(1) + i
+          exp_val(i,j,k,f) = compdof(tmp_idx) + real(f - 1) * real(dims(1) * dims(2) * dims(3))
+        end do
+      end do
+    end do
+  end do
+   ! pio_decomp_frame_tests.F90.in:1910
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_real, dims, compdof, rd_iodesc)
+  deallocate(compdof)
+   ! pio_decomp_frame_tests.F90.in:1913
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+
+    IF (pio_tf_world_rank_ == 0) THEN
+      IF (pio_tf_log_level_ >= 0) THEN
+        WRITE(*,"(A)",ADVANCE="NO") "PIO_TF: "
+        WRITE(*,*)  "Testing : PIO_real : ", iotype_descs(i)
+      END IF
+    END IF
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Could not create file " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1920)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1921
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1923)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1924
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1926)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1927
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1929)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1930
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time_limited', NFRAMES, pio_dims(4))
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1932)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1933
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_real, pio_dims, pio_var)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1935)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1936
+    ierr = PIO_enddef(pio_file)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to end redef mode : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1938)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1939
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var, f)
+      ! Write the current frame
+      call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to write darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:1944)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:1946
+    call PIO_syncfile(pio_file)
+   ! pio_decomp_frame_tests.F90.in:1948
+    do f=1,NFRAMES
+      call PIO_setframe(pio_file, pio_var, f)
+      call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf(:,:,:,f), ierr)
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to read darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:1952)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:1954
+    do f=1,NFRAMES
+
+      IF (.NOT. PIO_TF_Check_val_(rbuf(:,:,:,f), exp_val(:,:,:,f))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Check failed:",&
+             "Got wrong val, frame=", f,&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:1956)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:1958
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+   ! pio_decomp_frame_tests.F90.in:1963
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+   ! pio_decomp_frame_tests.F90.in:1968
+  call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+  deallocate(exp_val)
+  deallocate(rbuf)
+  deallocate(wbuf)
+END SUBROUTINE nc_test_limited_time_dim_PIO_real_real_kind_fc_real___
+
+
+SUBROUTINE nc_test_limited_time_dim_PIO_double_real_kind_fc_double___
+USE pio_tutil
+
+  implicit none
+  integer, parameter :: NDIMS = 4
+  integer, parameter :: NFRAMES = 6
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wr_iodesc, rd_iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(NDIMS) :: start, count
+  real(kind=fc_double), dimension(:,:,:,:), allocatable :: rbuf, wbuf, exp_val
+  integer, dimension(NDIMS-1) :: dims
+  integer, dimension(NDIMS) :: pio_dims
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
+  integer(kind=pio_offset_kind) :: f
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+   ! pio_decomp_frame_tests.F90.in:1862
+  ! Set the decomposition for writing data - forcing rearrangement
+  call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .true.)
+  nrows = count(1)
+  ncols = count(2)
+  nhgts = count(3)
+
   allocate(wbuf(nrows, ncols, nhgts, NFRAMES))
   allocate(compdof(nrows * ncols * nhgts))
   do f=1,NFRAMES
@@ -457,25 +2362,25 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_test_limited_time_dim
                         (start(2) - 1 + j - 1) * dims(1) + i
           wbuf(i,j,k,f) = wbuf(i,j,k,f) + (f - 1) * (dims(1) * dims(2) * dims(3))
           tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
-          compdof(tmp_idx) = wbuf(i,j,k,1)
+          compdof(tmp_idx) = int(wbuf(i,j,k,1))
         end do
       end do
     end do
   end do
-
-  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, wr_iodesc)
+   ! pio_decomp_frame_tests.F90.in:1884
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_double, dims, compdof, wr_iodesc)
   deallocate(compdof)
-
+   ! pio_decomp_frame_tests.F90.in:1887
   ! Set the decomposition for reading data - different from the write decomp
   call get_3d_col_decomp_info(pio_tf_world_rank_, pio_tf_world_sz_, dims, start, count, .false.)
   nrows = count(1)
   ncols = count(2)
   nhgts = count(3)
-  
+
   allocate(rbuf(nrows, ncols, nhgts, NFRAMES))
   allocate(compdof(nrows * ncols * nhgts))
   allocate(exp_val(nrows, ncols, nhgts, NFRAMES))
-
+   ! pio_decomp_frame_tests.F90.in:1897
   do f=1,NFRAMES
     do k=1,nhgts
       do j=1,ncols
@@ -488,68 +2393,174 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_test_limited_time_dim
       end do
     end do
   end do
-
-  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, rd_iodesc)
+   ! pio_decomp_frame_tests.F90.in:1910
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_double, dims, compdof, rd_iodesc)
   deallocate(compdof)
-
+   ! pio_decomp_frame_tests.F90.in:1913
   num_iotypes = 0
   call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
   filename = "test_pio_decomp_simple_tests.testfile"
   do i=1,num_iotypes
-    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
-    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
-    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
 
+    IF (pio_tf_world_rank_ == 0) THEN
+      IF (pio_tf_log_level_ >= 0) THEN
+        WRITE(*,"(A)",ADVANCE="NO") "PIO_TF: "
+        WRITE(*,*)  "Testing : PIO_double : ", iotype_descs(i)
+      END IF
+    END IF
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Could not create file " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1920)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1921
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_row', dims(1), pio_dims(1))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1923)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1924
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1926)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1927
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1929)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1930
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time_limited', NFRAMES, pio_dims(4))
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, pio_dims, pio_var)
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a dim : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1932)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1933
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_double, pio_dims, pio_var)
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to define a var : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1935)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1936
     ierr = PIO_enddef(pio_file)
-    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
 
+    IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+      pio_tf_retval_utest_ = -1
+      IF (pio_tf_world_rank_ == 0) THEN
+        PRINT *, "PIO_TF: PIO Function failed:",&
+           "Failed to end redef mode : " // trim(filename),&
+          ":", __FILE__, ":", __LINE__,&
+          "(pio_decomp_frame_tests.F90.in:1938)"
+      END IF
+      RETURN
+    END IF
+   ! pio_decomp_frame_tests.F90.in:1939
     do f=1,NFRAMES
       call PIO_setframe(pio_file, pio_var, f)
       ! Write the current frame
       call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf(:,:,:,f), ierr)
-      PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to write darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:1944)"
+        END IF
+        RETURN
+      END IF
     end do
-
+   ! pio_decomp_frame_tests.F90.in:1946
     call PIO_syncfile(pio_file)
-
+   ! pio_decomp_frame_tests.F90.in:1948
     do f=1,NFRAMES
       call PIO_setframe(pio_file, pio_var, f)
       call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf(:,:,:,f), ierr)
-      PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
-    end do
 
+      IF (.NOT. (PIO_TF_Passert_((ierr) == PIO_NOERR, pio_tf_comm_))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Function failed:",&
+             "Failed to read darray : " // trim(filename),&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:1952)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:1954
     do f=1,NFRAMES
-      PIO_TF_CHECK_VAL((rbuf(:,:,:,f), exp_val(:,:,:,f)), "Got wrong val, frame=", f)
-    end do
 
+      IF (.NOT. PIO_TF_Check_val_(rbuf(:,:,:,f), exp_val(:,:,:,f))) THEN
+        pio_tf_retval_utest_ = -1
+        IF (pio_tf_world_rank_ == 0) THEN
+          PRINT *, "PIO_TF: PIO Check failed:",&
+             "Got wrong val, frame=", f,&
+            ":", __FILE__, ":", __LINE__,&
+            "(pio_decomp_frame_tests.F90.in:1956)"
+        END IF
+        RETURN
+      END IF
+    end do
+   ! pio_decomp_frame_tests.F90.in:1958
     call PIO_closefile(pio_file)
-    
+
     call PIO_deletefile(pio_tf_iosystem_, filename);
   end do
-
+   ! pio_decomp_frame_tests.F90.in:1963
   if(allocated(iotypes)) then
     deallocate(iotypes)
     deallocate(iotype_descs)
   end if
-
+   ! pio_decomp_frame_tests.F90.in:1968
   call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
   call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
   deallocate(exp_val)
   deallocate(rbuf)
   deallocate(wbuf)
-PIO_TF_AUTO_TEST_SUB_END nc_test_limited_time_dim
+END SUBROUTINE nc_test_limited_time_dim_PIO_double_real_kind_fc_double___

--- a/cime/src/externals/pio2/tests/general/pio_decomp_tests.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_decomp_tests.F90.in
@@ -41,7 +41,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_darray
   PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: buf
   integer, dimension(1) :: dims
   integer :: pio_dim
-  integer :: i, ierr, lsz
+  integer :: i, ierr
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -117,7 +117,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_const_buf_sz
   PIO_TF_FC_DATA_TYPE, dimension(MAX_VEC_SZ) :: wbuf, rbuf
   integer, dimension(1) :: dims
   integer :: pio_dim
-  integer :: i, ierr, lsz
+  integer :: i, ierr
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -207,7 +207,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_reuse_decomp
   PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: buf, rbuf
   integer, dimension(1) :: dims
   integer :: pio_dim_file1, pio_dim_file2
-  integer :: i, ierr, lsz
+  integer :: i, ierr
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs

--- a/cime/src/externals/pio2/tests/general/pio_decomp_tests_1d.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_decomp_tests_1d.F90.in
@@ -139,7 +139,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_1d_bc
   PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf, wbuf, exp_val
   integer, dimension(1) :: dims
   integer :: pio_dim
-  integer :: i, ierr, lsz
+  integer :: i, ierr
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -249,7 +249,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_with_holes
   PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf, wbuf, exp_val
   integer, dimension(1) :: dims
   integer :: pio_dim
-  integer :: i, ierr, lsz
+  integer :: i, ierr
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -263,7 +263,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_with_holes
   allocate(exp_val(count(1)))
   do i=1,count(1)
     wbuf(i) = start(1) + i - 1
-    compdof(i) = wbuf(i)
+    compdof(i) = int(wbuf(i))
     exp_val(i) = wbuf(i)
   end do
 
@@ -327,7 +327,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_random
   PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf, wbuf
   integer, dimension(1) :: dims
   integer :: pio_dim
-  integer :: i, j, ierr, lsz
+  integer :: i, j, ierr
   integer :: tmp
   real :: u
   ! iotypes = valid io types

--- a/cime/src/externals/pio2/tests/general/pio_decomp_tests_2d.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_decomp_tests_2d.F90.in
@@ -167,7 +167,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_col_decomp
   PIO_TF_FC_DATA_TYPE, dimension(:,:), allocatable :: rbuf, wbuf, exp_val
   integer, dimension(NDIMS) :: dims
   integer, dimension(NDIMS) :: pio_dims
-  integer :: i, j, tmp_idx, ierr, lsz, nrows, ncols
+  integer :: i, j, tmp_idx, ierr, nrows, ncols
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -184,7 +184,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_col_decomp
     do i=1,nrows
       wbuf(i,j) = (start(2) - 1 + j - 1) * nrows + i
       tmp_idx = (j - 1) * nrows + i
-      compdof(tmp_idx) = wbuf(i,j)
+      compdof(tmp_idx) = int(wbuf(i,j))
     end do
   end do
 
@@ -274,7 +274,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_row_decomp
   PIO_TF_FC_DATA_TYPE, dimension(:,:), allocatable :: rbuf, wbuf, exp_val
   integer, dimension(NDIMS) :: dims
   integer, dimension(NDIMS) :: pio_dims
-  integer :: i, j, tmp_idx, ierr, lsz, nrows, ncols
+  integer :: i, j, tmp_idx, ierr, nrows, ncols
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -291,7 +291,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_row_decomp
     do i=1,nrows
       wbuf(i,j) = (start(2) - 1 + j - 1) * dims(1) + start(1) + i - 1
       tmp_idx = (j - 1) * nrows + i
-      compdof(tmp_idx) = wbuf(i,j)
+      compdof(tmp_idx) = int(wbuf(i,j))
     end do
   end do
 

--- a/cime/src/externals/pio2/tests/general/pio_decomp_tests_3d.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_decomp_tests_3d.F90.in
@@ -105,7 +105,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_3d_col_decomp
   PIO_TF_FC_DATA_TYPE, dimension(:,:,:), allocatable :: rbuf, wbuf, exp_val
   integer, dimension(NDIMS) :: dims
   integer, dimension(NDIMS) :: pio_dims
-  integer :: i, j, k, tmp_idx, ierr, lsz, nrows, ncols, nhgts
+  integer :: i, j, k, tmp_idx, ierr, nrows, ncols, nhgts
   ! iotypes = valid io types
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
@@ -125,7 +125,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_3d_col_decomp
         wbuf(i,j,k) = (start(3) - 1 + k - 1) * (dims(1) * dims(2)) +&
                       (start(2) - 1 + j - 1) * dims(1) + i
         tmp_idx = (k - 1) * (ncols * nrows) + (j - 1) * nrows + i
-        compdof(tmp_idx) = wbuf(i,j,k)
+        compdof(tmp_idx) = int(wbuf(i,j,k))
       end do
     end do
   end do

--- a/cime/src/externals/pio2/tests/general/pio_iosystem_tests.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_iosystem_tests.F90.in
@@ -97,13 +97,11 @@ END SUBROUTINE create_file
 ! Check the contents of file : Check the
 ! global attribute 'filename' (should be equal to the
 ! name of the file, fname)
-SUBROUTINE check_file(comm, iosys, iotype, pio_file, fname, attname, dimname, ret)
+SUBROUTINE check_file(comm, pio_file, fname, attname, dimname, ret)
     use pio_tutil
     implicit none
 
     integer, intent(in) :: comm
-    type(iosystem_desc_t), intent(inout) :: iosys
-    integer, intent(in) :: iotype
     type(file_desc_t), intent(inout) :: pio_file
     character(len=*), intent(in) :: fname
     character(len=*), intent(in) :: attname
@@ -148,7 +146,7 @@ SUBROUTINE open_and_check_file(comm, iosys, iotype, pio_file, fname, &
     ret = PIO_openfile(iosys, pio_file, iotype, fname, PIO_write)
     PIO_TF_CHECK_ERR(ret, comm, "Failed to open:" // fname)
 
-    call check_file(comm, iosys, iotype, pio_file, fname, attname, dimname, ret)
+    call check_file(comm, pio_file, fname, attname, dimname, ret)
     PIO_TF_CHECK_ERR(ret, comm, "Checking contents of file failed:" // fname)
 
     if(.not. disable_fclose) then
@@ -227,7 +225,6 @@ PIO_TF_AUTO_TEST_SUB_BEGIN two_iosystems_even_all
   character(len=PIO_TF_MAX_STR_LEN), target :: fname2 = "pio_iosys_test_file2.nc"
   character(len=PIO_TF_MAX_STR_LEN), parameter :: attname = "filename"
   character(len=PIO_TF_MAX_STR_LEN), parameter :: dimname = "filename_dim"
-  character(len=PIO_TF_MAX_STR_LEN), pointer :: fname
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: i, num_iotypes = 0
@@ -280,13 +277,13 @@ PIO_TF_AUTO_TEST_SUB_BEGIN two_iosystems_even_all
     ! Check contents of the files again
     ! - PIO called from odd and even processes separately with odd_even_iosys
     if(is_even) then
-      call check_file(odd_even_comm, odd_even_iosys, iotypes(i), pio_file1, &
+      call check_file(odd_even_comm, pio_file1, &
                       fname1, attname, dimname, ret)
       !call PIO_closefile(pio_file1)
     end if
     PIO_TF_CHECK_ERR(ret, "Checking contents of file failed :" // fname1)
 
-    call check_file(pio_tf_comm_, pio_tf_iosystem_, iotypes(i), pio_file2, &
+    call check_file(pio_tf_comm_, pio_file2, &
                     fname2, attname, dimname, ret)
     PIO_TF_CHECK_ERR(ret, "Checking contents of file failed :" // fname2)
 

--- a/cime/src/externals/pio2/tests/general/pio_iosystem_tests2.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_iosystem_tests2.F90.in
@@ -97,13 +97,11 @@ END SUBROUTINE create_file
 ! Check the contents of file : Check the
 ! global attribute 'filename' (should be equal to the
 ! name of the file, fname)
-SUBROUTINE check_file(comm, iosys, iotype, pio_file, fname, attname, dimname, ret)
+SUBROUTINE check_file(comm, pio_file, fname, attname, dimname, ret)
     use pio_tutil
     implicit none
 
     integer, intent(in) :: comm
-    type(iosystem_desc_t), intent(inout) :: iosys
-    integer, intent(in) :: iotype
     type(file_desc_t), intent(inout) :: pio_file
     character(len=*), intent(in) :: fname
     character(len=*), intent(in) :: attname
@@ -148,7 +146,7 @@ SUBROUTINE open_and_check_file(comm, iosys, iotype, pio_file, fname, &
     ret = PIO_openfile(iosys, pio_file, iotype, fname, PIO_write)
     PIO_TF_CHECK_ERR(ret, comm, "Failed to open:" // fname)
 
-    call check_file(comm, iosys, iotype, pio_file, fname, attname, dimname, ret)
+    call check_file(comm, pio_file, fname, attname, dimname, ret)
     PIO_TF_CHECK_ERR(ret, comm, "Checking contents of file failed:" // fname)
 
     if(.not. disable_fclose) then
@@ -221,7 +219,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN three_files_two_iosystems_odd_even
     PIO_TF_CHECK_ERR(ret, "Checking contents of file failed :" // fname)
 
     ! Make sure that we can still check the contents of the file
-    call check_file(odd_even_comm, odd_even_iosys, iotypes(i), pio_file, &
+    call check_file(odd_even_comm, pio_file, &
                     fname, attname, dimname, ret)
     PIO_TF_CHECK_ERR(ret, "Checking (second) contents of file failed :" // fname)
 

--- a/cime/src/externals/pio2/tests/general/pio_iosystem_tests3.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_iosystem_tests3.F90.in
@@ -113,13 +113,11 @@ END SUBROUTINE create_file
 ! Check the contents of file : Check the
 ! global attribute 'filename' (should be equal to the
 ! name of the file, fname)
-SUBROUTINE check_file(comm, iosys, iotype, pio_file, fname, attname, dimname, ret)
+SUBROUTINE check_file(comm, pio_file, fname, attname, dimname, ret)
     use pio_tutil
     implicit none
 
     integer, intent(in) :: comm
-    type(iosystem_desc_t), intent(inout) :: iosys
-    integer, intent(in) :: iotype
     type(file_desc_t), intent(inout) :: pio_file
     character(len=*), intent(in) :: fname
     character(len=*), intent(in) :: attname
@@ -164,7 +162,7 @@ SUBROUTINE open_and_check_file(comm, iosys, iotype, pio_file, fname, &
     ret = PIO_openfile(iosys, pio_file, iotype, fname, PIO_write)
     PIO_TF_CHECK_ERR(ret, comm, "Failed to open:" // fname)
 
-    call check_file(comm, iosys, iotype, pio_file, fname, attname, dimname, ret)
+    call check_file(comm, pio_file, fname, attname, dimname, ret)
     PIO_TF_CHECK_ERR(ret, comm, "Checking contents of file failed:" // fname)
 
     if(.not. disable_fclose) then
@@ -257,8 +255,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN three_files_two_iosystems_with_overlap
         PIO_TF_CHECK_ERR(ret, overlapped_comms(j), "Checking contents of file failed :" // fname)
 
         ! Make sure that we can still check the contents of the file
-        call check_file(overlapped_comms(j), overlapped_iosys(j), iotypes(i), &
-                        pio_files(j), fname, attname, dimname, ret)
+        call check_file(overlapped_comms(j), pio_files(j), fname, &
+             attname, dimname, ret)
         PIO_TF_CHECK_ERR(ret, overlapped_comms(j), "Checking (second) contents of file failed :" // fname)
       end if
     end do

--- a/cime/src/externals/pio2/tests/general/pio_rearr.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_rearr.F90.in
@@ -189,7 +189,6 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_rearrs_combs
   character(len=PIO_TF_MAX_STR_LEN), parameter :: attname = "filename"
   character(len=PIO_TF_MAX_STR_LEN), parameter :: dimname = "filename_dim"
   integer, parameter :: NUM_REARRANGERS = 2
-  integer :: rearrs(NUM_REARRANGERS) = (/pio_rearr_subset,pio_rearr_box/)
   integer, parameter :: MAX_PERMS = 4
   integer :: rearrs_perms(NUM_REARRANGERS,MAX_PERMS) = reshape(&
                 (/pio_rearr_subset, pio_rearr_box,&
@@ -206,7 +205,6 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_rearrs_combs
               "PIO_REARR_BOX   ", "PIO_REARR_BOX   "/),&
               (/NUM_REARRANGERS,MAX_PERMS/)&
             )
-  character(len=PIO_TF_MAX_STR_LEN) :: rearrs_info(NUM_REARRANGERS) = (/"PIO_REARR_SUBSET","PIO_REARR_BOX   "/)
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: i, j, k, num_iotypes = 0

--- a/cime/src/externals/pio2/tests/general/pio_rearr_opts.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_rearr_opts.F90.in
@@ -11,7 +11,6 @@ PIO_TF_AUTO_TEST_SUB_BEGIN init_fin_with_rearr_opts
 
   integer, parameter :: NUM_REARRANGERS = 2
   integer :: rearrs(NUM_REARRANGERS) = (/pio_rearr_subset,pio_rearr_box/)
-  character(len=PIO_TF_MAX_STR_LEN) :: rearrs_info(NUM_REARRANGERS) = (/"PIO_REARR_SUBSET","PIO_REARR_BOX   "/)
   type(pio_rearr_opt_t) :: pio_rearr_opts
   ! Dummy val for max pend req
   integer, parameter :: MAX_PEND_REQ = 10
@@ -187,7 +186,6 @@ SUBROUTINE create_decomp_and_init_buf(iosys, iocomm, iodesc, wbuf, dims, ret)
   integer, dimension(1), intent(out) :: dims
   integer, intent(out) :: ret
 
-  integer :: pio_dim
   integer, dimension(:), allocatable :: compdof
   integer, dimension(1) :: start, count
   integer :: i
@@ -203,7 +201,7 @@ SUBROUTINE create_decomp_and_init_buf(iosys, iocomm, iodesc, wbuf, dims, ret)
   allocate(compdof(count(1)))
   do i=1,count(1)
     wbuf(i) = start(1) + i - 1
-    compdof(i) = wbuf(i)
+    compdof(i) = int(wbuf(i))
   end do
 
   call PIO_initdecomp(iosys, PIO_real, dims, compdof, iodesc)
@@ -248,7 +246,7 @@ END SUBROUTINE
 ! Open file and inq var
 ! All details are picked from pio_rearr_opts_tgv module
 ! Note: The file is kept open so the called needs to close it
-SUBROUTINE open_file_and_get_var(iosys, pio_file, iotype, pio_var, dims, ret)
+SUBROUTINE open_file_and_get_var(iosys, pio_file, iotype, pio_var, ret)
   use pio_tutil
   use pio_rearr_opts_tgv
   implicit none
@@ -257,10 +255,7 @@ SUBROUTINE open_file_and_get_var(iosys, pio_file, iotype, pio_var, dims, ret)
   type(file_desc_t), intent(out) :: pio_file
   integer, intent(in) :: iotype
   type(var_desc_t), intent(out) :: pio_var
-  integer, dimension(1), intent(in) :: dims
   integer, intent(out) :: ret
-
-  integer :: pio_dim
 
   ret = PIO_openfile(iosys, pio_file, iotype, tgv_fname, pio_write)
   PIO_TF_CHECK_ERR(ret, "Could not create file " // trim(tgv_fname))
@@ -331,7 +326,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN write_with_rearr_opts
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: num_iotypes
-  integer :: ret, ierr, i
+  integer :: ret, i
 
   num_iotypes = 0
   call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
@@ -436,7 +431,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN write_with_rearr_opts
                       rbuf = 0
 
                       call open_file_and_get_var(dup_iosys, pio_file, iotypes(i),&
-                              pio_var, dims, ret)
+                              pio_var, ret)
                       PIO_TF_CHECK_ERR(ret, dup_comm, "Creating file/decomp/var reqd for test failed :" // trim(tgv_fname))
 
                       call PIO_write_darray(pio_file, pio_var, iodesc, wbuf, ret)

--- a/cime/src/externals/pio2/tests/general/pio_rearr_opts2.F90.in
+++ b/cime/src/externals/pio2/tests/general/pio_rearr_opts2.F90.in
@@ -141,7 +141,6 @@ SUBROUTINE create_decomp_and_init_buf(iodesc, wbuf, dims, ret)
   integer, dimension(1), intent(out) :: dims
   integer, intent(out) :: ret
 
-  integer :: pio_dim
   integer, dimension(:), allocatable :: compdof
   integer, dimension(1) :: start, count
   integer :: i
@@ -153,7 +152,7 @@ SUBROUTINE create_decomp_and_init_buf(iodesc, wbuf, dims, ret)
   allocate(compdof(count(1)))
   do i=1,count(1)
     wbuf(i) = start(1) + i - 1
-    compdof(i) = wbuf(i)
+    compdof(i) = int(wbuf(i))
   end do
 
   call PIO_initdecomp(pio_tf_iosystem_, PIO_real, dims, compdof, iodesc)
@@ -207,8 +206,6 @@ SUBROUTINE open_file_and_get_var(pio_file, iotype, pio_var, ret)
   integer, intent(in) :: iotype
   type(var_desc_t), intent(out) :: pio_var
   integer, intent(out) :: ret
-
-  integer :: pio_dim
 
   ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotype, tgv_fname, pio_write)
   PIO_TF_CHECK_ERR(ret, "Could not create file " // trim(tgv_fname))
@@ -273,7 +270,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN set_rearr_opts_and_write
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: num_iotypes
-  integer :: ret, ierr, i
+  integer :: ret, i
 
   num_iotypes = 0
   call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)

--- a/cime/src/externals/pio2/tests/general/util/pio_tutil.F90
+++ b/cime/src/externals/pio2/tests/general/util/pio_tutil.F90
@@ -592,7 +592,6 @@ CONTAINS
     INTEGER :: nequal_idx
     ! Local and global equal bools
     LOGICAL :: lequal, gequal
-    LOGICAL :: failed
     TYPE failed_info
       SEQUENCE
       INTEGER :: idx
@@ -654,6 +653,7 @@ CONTAINS
     INTEGER, DIMENSION(:), INTENT(IN) :: arr
     INTEGER, DIMENSION(:), INTENT(IN) :: exp_arr
     REAL, INTENT(IN) :: tol
+    if (tol /= 0) continue ! to suppress warning
 
     PIO_TF_Check_int_arr_arr_tol = PIO_TF_Check_int_arr_arr(arr, exp_arr)
   END FUNCTION
@@ -724,7 +724,6 @@ CONTAINS
     REAL(KIND=fc_real) :: nequal_idx
     ! Local and global equal bools
     LOGICAL :: lequal, gequal
-    LOGICAL :: failed
     TYPE failed_info
       SEQUENCE
       REAL(KIND=fc_real) :: idx
@@ -734,6 +733,7 @@ CONTAINS
     TYPE (failed_info) :: lfail_info
     TYPE (failed_info), DIMENSION(:), ALLOCATABLE :: gfail_info
 
+    if (tol /= 0) continue ! to suppress warning
     arr_sz = SIZE(arr)
     lequal = .TRUE.;
     gequal = .TRUE.;
@@ -778,7 +778,7 @@ CONTAINS
     REAL, INTENT(IN) :: tol
 
     PIO_TF_Check_real_arr_arr_tol = PIO_TF_Check_real_arr_arr_tol_(arr, exp_arr,&
-                                SHAPE(arr), 0.0)
+                                SHAPE(arr), tol)
   END FUNCTION
 
   LOGICAL FUNCTION PIO_TF_Check_real_arr_arr(arr, exp_arr)
@@ -857,7 +857,6 @@ CONTAINS
     REAL(KIND=fc_double) :: nequal_idx
     ! Local and global equal bools
     LOGICAL :: lequal, gequal
-    LOGICAL :: failed
     TYPE failed_info
       SEQUENCE
       REAL(KIND=fc_double) :: idx
@@ -867,6 +866,7 @@ CONTAINS
     TYPE (failed_info) :: lfail_info
     TYPE (failed_info), DIMENSION(:), ALLOCATABLE :: gfail_info
 
+    if (tol /= 0) continue ! to suppress warning
     arr_sz = SIZE(arr)
     lequal = .TRUE.;
     gequal = .TRUE.;
@@ -914,7 +914,7 @@ CONTAINS
     REAL, INTENT(IN) :: tol
 
     PIO_TF_Check_double_arr_arr_tol = PIO_TF_Check_double_arr_arr_tol_(arr, exp_arr,&
-                                    SHAPE(arr), 0.0)
+                                    SHAPE(arr), tol)
   END FUNCTION
 
   LOGICAL FUNCTION PIO_TF_Check_double_arr_arr(arr, exp_arr)

--- a/cime/src/externals/pio2/tests/ncint/Makefile.am
+++ b/cime/src/externals/pio2/tests/ncint/Makefile.am
@@ -1,0 +1,27 @@
+## This is the automake file for building the netCDF integration layer
+## tests.
+
+# Ed Hartnett 7/3/19
+
+# Put together AM_CPPFLAGS and AM_LDFLAGS.
+AM_CPPFLAGS = -I$(top_srcdir)/src/clib
+LDADD = ${top_builddir}/src/clib/libpioc.la
+
+# Build the test for make check.
+check_PROGRAMS = tst_pio_udf
+
+if RUN_TESTS
+# Tests will run from a bash script.
+TESTS = run_tests.sh
+endif # RUN_TESTS
+
+# if RUN_TESTS
+# # Tests will run from a bash script.
+# TESTS = run_tests.sh
+# endif # RUN_TESTS
+
+# Distribute the test script.
+EXTRA_DIST = run_tests.sh
+
+# Clean up files produced during testing.
+CLEANFILES = *.nc *.log

--- a/cime/src/externals/pio2/tests/ncint/run_tests.sh
+++ b/cime/src/externals/pio2/tests/ncint/run_tests.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# This is a test script for PIO.
+# Ed Hartnett
+
+# Stop execution of script if error is returned.
+set -e
+
+# Stop loop if ctrl-c is pressed.
+trap exit INT TERM
+
+printf 'running PIO tests...\n'
+
+PIO_TESTS='tst_pio_udf'
+
+success1=true
+success2=true
+for TEST in $PIO_TESTS
+do
+    success1=false
+    echo "running ${TEST}"
+    mpiexec -n 4 ./${TEST} && success1=true
+    if test $success1 = false; then
+        break
+    fi
+done
+
+# PIO_TESTS_8='test_async_multi2  test_async_manyproc'
+
+# for TEST in $PIO_TESTS_8
+# do
+#     success2=false
+#     echo "running ${TEST}"
+#     mpiexec -n 8 ./${TEST} && success2=true
+#     if test $success2 = false; then
+#         break
+#     fi
+# done
+
+# Did we succeed?
+if test x$success1 = xtrue -a x$success2 = xtrue; then
+    exit 0
+fi
+exit 1

--- a/cime/src/externals/pio2/tests/ncint/tst_pio_udf.c
+++ b/cime/src/externals/pio2/tests/ncint/tst_pio_udf.c
@@ -1,0 +1,126 @@
+/* Test netcdf integration layer.
+
+   Ed Hartnett
+*/
+
+#include "config.h"
+#include <nc_tests.h>
+#include "err_macros.h"
+#include "netcdf.h"
+#include "nc4dispatch.h"
+#include <pio.h>
+#include <mpi.h>
+
+#define FILE_NAME "tst_pio_udf.nc"
+#define VAR_NAME "data_var"
+#define DIM_NAME_UNLIMITED "dim_unlimited"
+#define DIM_NAME_X "dim_x"
+#define DIM_NAME_Y "dim_y"
+#define DIM_LEN_X 4
+#define DIM_LEN_Y 4
+#define NDIM2 2
+#define NDIM3 3
+
+extern NC_Dispatch NCINT_dispatcher;
+
+int
+main(int argc, char **argv)
+{
+    int my_rank;
+    int ntasks;
+
+    /* Initialize MPI. */
+    if (MPI_Init(&argc, &argv)) ERR;
+
+    /* Learn my rank and the total number of processors. */
+    if (MPI_Comm_rank(MPI_COMM_WORLD, &my_rank)) ERR;
+    if (MPI_Comm_size(MPI_COMM_WORLD, &ntasks)) ERR;
+
+    printf("\n*** Testing netCDF integration layer.\n");
+    printf("*** testing getting/setting of default iosystemid...");
+    {
+        int iosysid;
+
+        if (nc_set_iosystem(TEST_VAL_42)) ERR;
+        if (nc_get_iosystem(&iosysid)) ERR;
+        if (iosysid != TEST_VAL_42) ERR;
+    }
+    SUMMARIZE_ERR;
+
+    printf("*** testing simple use of netCDF integration layer format...");
+    {
+        int ncid, ioid;
+        int dimid[NDIM3], varid;
+        int dimlen[NDIM3] = {NC_UNLIMITED, DIM_LEN_X, DIM_LEN_Y};
+        int iosysid;
+        NC_Dispatch *disp_in;
+        size_t elements_per_pe;
+        size_t *compdof; /* The decomposition mapping. */
+        int *my_data;
+        int *data_in;
+        int i;
+
+        /* Turn on logging for PIO library. */
+        /* PIOc_set_log_level(3); */
+
+        /* Initialize the intracomm. */
+        if (nc_def_iosystemm(MPI_COMM_WORLD, 1, 1, 0, 0, &iosysid)) ERR;
+
+        /* Create a file with a 3D record var. */
+        if (nc_create(FILE_NAME, NC_UDF0, &ncid)) ERR;
+        if (nc_def_dim(ncid, DIM_NAME_UNLIMITED, dimlen[0], &dimid[0])) ERR;
+        if (nc_def_dim(ncid, DIM_NAME_X, dimlen[1], &dimid[1])) ERR;
+        if (nc_def_dim(ncid, DIM_NAME_Y, dimlen[2], &dimid[2])) ERR;
+        if (nc_def_var(ncid, VAR_NAME, NC_INT, NDIM3, dimid, &varid)) ERR;
+
+        /* Calculate a decomposition for distributed arrays. */
+        elements_per_pe = DIM_LEN_X * DIM_LEN_Y / ntasks;
+        if (!(compdof = malloc(elements_per_pe * sizeof(size_t))))
+            ERR;
+        for (i = 0; i < elements_per_pe; i++)
+            compdof[i] = my_rank * elements_per_pe + i;
+
+        /* Create the PIO decomposition for this test. */
+        if (nc_def_decomp(iosysid, PIO_INT, NDIM2, &dimlen[1], elements_per_pe,
+                          compdof, &ioid, 1, NULL, NULL)) ERR;
+        free(compdof);
+
+        /* Create some data on this processor. */
+        if (!(my_data = malloc(elements_per_pe * sizeof(int)))) ERR;
+        for (i = 0; i < elements_per_pe; i++)
+            my_data[i] = my_rank * 10 + i;
+
+        /* Write some data with distributed arrays. */
+        if (nc_put_vard_int(ncid, varid, ioid, 0, my_data)) ERR;
+        if (nc_close(ncid)) ERR;
+
+        /* Check that our user-defined format has been added. */
+        if (nc_inq_user_format(NC_UDF0, &disp_in, NULL)) ERR;
+        if (disp_in != &NCINT_dispatcher) ERR;
+
+        /* Open the file. */
+        if (nc_open(FILE_NAME, NC_UDF0, &ncid)) ERR;
+
+        /* Read distributed arrays. */
+        if (!(data_in = malloc(elements_per_pe * sizeof(int)))) ERR;
+        if (nc_get_vard_int(ncid, varid, ioid, 0, data_in)) ERR;
+
+        /* Check results. */
+        for (i = 0; i < elements_per_pe; i++)
+            if (data_in[i] != my_data[i]) ERR;
+
+        /* Close file. */
+        if (nc_close(ncid)) ERR;
+
+        /* Free resources. */
+        free(data_in);
+        free(my_data);
+        if (nc_free_decomp(ioid)) ERR;
+        if (nc_free_iosystem(iosysid)) ERR;
+    }
+    SUMMARIZE_ERR;
+
+    /* Finalize MPI. */
+    MPI_Finalize();
+    FINAL_RESULTS;
+}

--- a/cime/src/externals/pio2/tests/performance/Makefile.am
+++ b/cime/src/externals/pio2/tests/performance/Makefile.am
@@ -14,7 +14,7 @@ LDADD = $(top_builddir)/src/gptl/libperf_mod.la	\
 $(top_builddir)/src/gptl/libperf_utils.la	\
 ${top_builddir}/tests/general/libpio_tutil.la	\
 ${top_builddir}/src/flib/libpiof.la		\
-${top_builddir}/src/clib/libpio.la
+${top_builddir}/src/clib/libpioc.la
 
 # Find perf_mod and perf_util.
 AM_CPPFLAGS += -I$(top_builddir)/src/gptl

--- a/cime/src/externals/pio2/tests/unit/Makefile.am
+++ b/cime/src/externals/pio2/tests/unit/Makefile.am
@@ -13,7 +13,7 @@ include $(top_srcdir)/set_flags.am
 check_PROGRAMS = pio_unit_test_driver
 pio_unit_test_driver_SOURCES = driver.F90
 pio_unit_test_driver_LDADD = libglobal_vars.la libncdf_tests.la	\
-libbasic_tests.la ${top_builddir}/src/flib/libpiof.la ${top_builddir}/src/clib/libpio.la
+libbasic_tests.la ${top_builddir}/src/flib/libpiof.la ${top_builddir}/src/clib/libpioc.la
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = libglobal_vars.la libncdf_tests.la	\

--- a/cime/src/externals/pio2/tests/unit/basic_tests.F90
+++ b/cime/src/externals/pio2/tests/unit/basic_tests.F90
@@ -33,7 +33,7 @@ module basic_tests
 
       ! Local Vars
       character(len=str_len) :: filename
-      integer                :: iotype, ret_val, ret_val2, pio_dim
+      integer                :: iotype, ret_val, ret_val2
 
       err_msg = "no_error"
 
@@ -146,12 +146,6 @@ module basic_tests
       integer                        :: pio_dim
       integer :: unlimdimid
       type(var_desc_t)               :: pio_var
-
-      ! These will be used to set chunk cache sizes in netCDF-4/HDF5
-      ! files.
-      integer(kind=PIO_OFFSET_KIND) :: chunk_cache_size
-      integer(kind=PIO_OFFSET_KIND) :: chunk_cache_nelems
-      real :: chunk_cache_preemption
 
       err_msg = "no_error"
       dims(1) = 3*ntasks

--- a/cime/src/externals/pio2/tests/unit/driver.F90
+++ b/cime/src/externals/pio2/tests/unit/driver.F90
@@ -15,7 +15,7 @@ Program pio_unit_test_driver
 
   ! local variables
   character(len=str_len) :: err_msg
-  integer :: fail_cnt, test_cnt, ios, test_id, ierr, test_val
+  integer :: fail_cnt, test_cnt, ios, test_id, ierr
   logical :: ltest_netcdf, ltest_pnetcdf
   logical :: ltest_netcdf4p, ltest_netcdf4c
   namelist/piotest_nml/  ltest_netcdf,     &

--- a/cime/src/externals/pio2/tests/unit/ncdf_tests.F90
+++ b/cime/src/externals/pio2/tests/unit/ncdf_tests.F90
@@ -268,7 +268,6 @@ Contains
     ! Local Vars
     character(len=str_len) :: filename
     integer                :: iotype, ret_val
-    integer                :: ret_val1
 
     ! Data used to test writing
     integer,          dimension(2) :: data_to_write, compdof
@@ -282,10 +281,6 @@ Contains
     integer :: shuffle
     integer :: deflate
     integer :: my_deflate_level, deflate_level, deflate_level_2
-
-    ! These will be used to test the chunksizes for netCDF-4 files.
-    integer :: storage
-    integer, dimension(1) :: chunksizes
 
     ! These will be used to set chunk cache sizes in netCDF-4/HDF5
     ! files.

--- a/cime/src/share/util/shr_pio_mod.F90
+++ b/cime/src/share/util/shr_pio_mod.F90
@@ -189,19 +189,20 @@ contains
     allocate(iosystems(total_comps))
 
     if(pio_async_interface) then
-       call pio_init(total_comps,mpi_comm_world, comp_comm, io_comm, iosystems)
-       do i=1,total_comps
-         ret =  pio_set_rearr_opts(iosystems(i), pio_rearr_opt_comm_type,&
-                  pio_rearr_opt_fcd,&
-                  pio_rearr_opt_c2i_enable_hs, pio_rearr_opt_c2i_enable_isend,&
-                  pio_rearr_opt_c2i_max_pend_req,&
-                  pio_rearr_opt_i2c_enable_hs, pio_rearr_opt_i2c_enable_isend,&
-                  pio_rearr_opt_i2c_max_pend_req)
-         if(ret /= PIO_NOERR) then
-            write(shr_log_unit,*) "ERROR: Setting rearranger options failed"
-         end if
-       end do
-       i=1
+       call shr_sys_abort('pio_async_interface is not currently supported')
+!       call pio_init(total_comps,mpi_comm_world, comp_comm, io_comm, iosystems)
+!       do i=1,total_comps
+!         ret =  pio_set_rearr_opts(iosystems(i), pio_rearr_opt_comm_type,&
+!                  pio_rearr_opt_fcd,&
+!                  pio_rearr_opt_c2i_enable_hs, pio_rearr_opt_c2i_enable_isend,&
+!                  pio_rearr_opt_c2i_max_pend_req,&
+!                  pio_rearr_opt_i2c_enable_hs, pio_rearr_opt_i2c_enable_isend,&
+!                  pio_rearr_opt_i2c_max_pend_req)
+!         if(ret /= PIO_NOERR) then
+!            write(shr_log_unit,*) "ERROR: Setting rearranger options failed"
+!         end if
+!       end do
+!       i=1
     else
        do i=1,total_comps
           if(comp_iamin(i)) then


### PR DESCRIPTION
Update CIME to ESMCI cime5.8.7-2

Squash merge of jgfouca/branch-for-to-acme-2019-08-14

Features:
* Update to latest NCAR PIO2 version
* improve the config_compilers.xml schema to catch case errors

Bug fixes:
* make sure output_root path is abspath
* make sure  ~/.cime/config_compilers.xml file is also checked against schema
* fix indentation bug in get_timing

[BFB]