### PR TITLE
Fix batch submission command for summit

### DIFF
--- a/cime/scripts/lib/CIME/XML/env_batch.py
+++ b/cime/scripts/lib/CIME/XML/env_batch.py
@@ -677,7 +677,7 @@ class EnvBatch(EnvBase):
         batch_env_flag = self.get_value("batch_env", subgroup=None)
         run_args = self._build_run_args_str(job, False, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
                                             submit_resubmits=not resubmit_immediate)
-        if batch_system == 'lsf':
+        if batch_system == 'lsf' and not batch_env_flag:
             sequence = (run_args, batchsubmit, submitargs, batchredirect, get_batch_script_for_job(job))
         elif batch_env_flag:
             sequence = (batchsubmit, submitargs, run_args, batchredirect, get_batch_script_for_job(job))


### PR DESCRIPTION
A recent CIME update broke the case where an lsf batch
system was configured to pass arguments via batch_env.

This PR fixes the issue by changing the command formation logic
to not prepend lfs args if batch_env is set.

Fixes #3124 

[BFB]