### PR TITLE
Adds MOSART-heat

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1863,6 +1863,8 @@
     <required_gridmap grid1="atm_grid" grid2="lnd_grid">ATM2LND_SMAPNAME</required_gridmap>
     <required_gridmap grid1="atm_grid" grid2="lnd_grid">LND2ATM_FMAPNAME</required_gridmap>
     <required_gridmap grid1="atm_grid" grid2="lnd_grid">LND2ATM_SMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="rof_grid">ATM2ROF_FMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="rof_grid">ATM2ROF_SMAPNAME</required_gridmap>
     <required_gridmap grid1="atm_grid" grid2="wav_grid">ATM2WAV_SMAPNAME</required_gridmap>
     <required_gridmap grid1="ocn_grid" grid2="wav_grid">OCN2WAV_SMAPNAME</required_gridmap>
     <required_gridmap grid1="ocn_grid" grid2="wav_grid">ICE2WAV_SMAPNAME</required_gridmap> <!-- ??? -->
@@ -2379,6 +2381,11 @@
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/T341/map_T341_to_fv0.23x0.31_aave_110413.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_T341_aave_110413.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_T341_aave_110413.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne30np4/map_ne30np4_to_0.5x0.5rtm_aave_da_110320.nc</map>
+      <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/ne30np4/map_ne30np4_to_0.5x0.5rtm_aave_da_110320.nc</map>
     </gridmap>
 
     <!--  QL, 150525, wav to ocn, atm, ice mapping files  -->

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1863,8 +1863,8 @@
     <required_gridmap grid1="atm_grid" grid2="lnd_grid">ATM2LND_SMAPNAME</required_gridmap>
     <required_gridmap grid1="atm_grid" grid2="lnd_grid">LND2ATM_FMAPNAME</required_gridmap>
     <required_gridmap grid1="atm_grid" grid2="lnd_grid">LND2ATM_SMAPNAME</required_gridmap>
-    <required_gridmap grid1="atm_grid" grid2="rof_grid">ATM2ROF_FMAPNAME</required_gridmap>
-    <required_gridmap grid1="atm_grid" grid2="rof_grid">ATM2ROF_SMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="rof_grid" compset="_MOSART">ATM2ROF_FMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="rof_grid" compset="_MOSART">ATM2ROF_SMAPNAME</required_gridmap>
     <required_gridmap grid1="atm_grid" grid2="wav_grid">ATM2WAV_SMAPNAME</required_gridmap>
     <required_gridmap grid1="ocn_grid" grid2="wav_grid">OCN2WAV_SMAPNAME</required_gridmap>
     <required_gridmap grid1="ocn_grid" grid2="wav_grid">ICE2WAV_SMAPNAME</required_gridmap> <!-- ??? -->
@@ -2383,9 +2383,39 @@
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_T341_aave_110413.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne4np4" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne4np4/map_ne4np4_TO_r05_aave.160621.nc</map>
+      <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/ne4np4/map_ne4np4_TO_r05_aave.160621.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne11np4" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne11np4/map_ne11np4_TO_r05_aave.160621.nc</map>
+      <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/ne11np4/map_ne11np4_TO_r05_aave.160621.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="ne30np4" rof_grid="r05">
       <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne30np4/map_ne30np4_to_0.5x0.5rtm_aave_da_110320.nc</map>
       <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/ne30np4/map_ne30np4_to_0.5x0.5rtm_aave_da_110320.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="0.9x1.25" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.9x1.25/map_0.9x1.25_nomask_to_0.5x0.5_nomask_aave_da_c120522.nc</map>
+      <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/0.9x1.25/map_0.9x1.25_nomask_to_0.5x0.5_nomask_aave_da_c120522.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="1.9x2.5" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/1.9x2.5/map_1.9x2.5_nomask_to_0.5x0.5_nomask_aave_da_c120522.nc</map>
+      <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/1.9x2.5/map_1.9x2.5_nomask_to_0.5x0.5_nomask_aave_da_c120522.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="4x5" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/4x5/map_4x5_nomask_to_0.5x0.5_nomask_aave_da_c110822.nc</map>
+      <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/4x5/map_4x5_nomask_to_0.5x0.5_nomask_aave_da_c110822.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="360x720cru" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/360x720/map_360x720_nomask_to_0.5x0.5_nomask_aave_da_c130103.nc</map>
+      <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/360x720/map_360x720_nomask_to_0.5x0.5_nomask_aave_da_c130103.nc</map>
     </gridmap>
 
     <!--  QL, 150525, wav to ocn, atm, ice mapping files  -->

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1943,7 +1943,7 @@
       </modules>
       <modules>
         <command name="load">perl/5.20.0</command>
-        <command name="load">cmake/3.9.2</command>
+        <command name="load">cmake/3.12.3</command>
         <command name="load">python/2.7.8</command>
       </modules>
       <modules compiler="intel">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1943,7 +1943,7 @@
       </modules>
       <modules>
         <command name="load">perl/5.20.0</command>
-        <command name="load">cmake/3.12.3</command>
+        <command name="load">cmake/3.9.2</command>
         <command name="load">python/2.7.8</command>
       </modules>
       <modules compiler="intel">

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1943,7 +1943,7 @@
       </modules>
       <modules>
         <command name="load">perl/5.20.0</command>
-        <command name="load">cmake/3.3.0</command>
+        <command name="load">cmake/3.12.3</command>
         <command name="load">python/2.7.8</command>
       </modules>
       <modules compiler="intel">

--- a/cime/config/xml_schemas/config_grids_v2.1.xsd
+++ b/cime/config/xml_schemas/config_grids_v2.1.xsd
@@ -125,6 +125,7 @@
         <xs:extension base="xs:NCName">
           <xs:attribute ref="grid1" use="required" />
           <xs:attribute ref="grid2" use="required" />
+          <xs:attribute ref="compset" />
           <xs:attribute ref="not_compset" />
         </xs:extension>
       </xs:simpleContent>

--- a/cime/config/xml_schemas/config_grids_v2.xsd
+++ b/cime/config/xml_schemas/config_grids_v2.xsd
@@ -125,6 +125,7 @@
         <xs:extension base="xs:NCName">
           <xs:attribute ref="grid1" use="required" />
           <xs:attribute ref="grid2" use="required" />
+          <xs:attribute ref="compset" />
           <xs:attribute ref="not_compset" />
         </xs:extension>
       </xs:simpleContent>

--- a/cime/scripts/lib/CIME/XML/grids.py
+++ b/cime/scripts/lib/CIME/XML/grids.py
@@ -70,7 +70,7 @@ class Grids(GenericXML):
         gridinfo.update(domains)
 
         # determine gridmaps given component_grids
-        gridmaps = self._get_gridmaps(component_grids, driver)
+        gridmaps = self._get_gridmaps(component_grids, driver, compset)
         gridinfo.update(gridmaps)
 
         return gridinfo
@@ -276,7 +276,7 @@ class Grids(GenericXML):
 
         return domains
 
-    def _get_gridmaps(self, component_grids, driver):
+    def _get_gridmaps(self, component_grids, driver, compset):
         """
         set all mapping files for config_grids.xml v2 schema
         """
@@ -287,8 +287,18 @@ class Grids(GenericXML):
         # (1) set all possibly required gridmaps to idmap
         required_gridmaps_node = self.get_child("required_gridmaps")
         required_gridmap_nodes = self.get_children("required_gridmap", root=required_gridmaps_node)
-        for node in required_gridmap_nodes:
+
+        tmp_gridmap_nodes = self.get_children("required_gridmap", root=required_gridmaps_node)
+        required_gridmap_nodes = []
+        for node in tmp_gridmap_nodes:
+            compset_att = self.get(node,"compset")
+            not_compset_att = self.get(node,"not_compset")
+            if compset_att and not compset_att in compset or \
+               not_compset_att and not_compset_att in compset:
+                continue
+            required_gridmap_nodes.append(node)
             gridmaps[self.text(node)] = "idmap"
+
 
         # (2) determine values gridmaps for target grid
         for idx, grid in enumerate(grids):

--- a/cime/src/drivers/mct/cime_config/config_component.xml
+++ b/cime/src/drivers/mct/cime_config/config_component.xml
@@ -1387,6 +1387,40 @@
     <desc>atm2lnd state mapping file decomp type</desc>
   </entry>
 
+  <entry id="ATM2ROF_FMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>atm2rof flux mapping file</desc>
+  </entry>
+
+  <entry id="ATM2ROF_FMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>X</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>atm2rof flux mapping file decomp type</desc>
+  </entry>
+
+  <entry id="ATM2ROF_SMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>atm2rof state mapping file</desc>
+  </entry>
+
+  <entry id="ATM2ROF_SMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>X</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>atm2rof state mapping file decomp type</desc>
+  </entry>
+
   <entry id="ATM2WAV_SMAPNAME">
     <type>char</type>
     <default_value>idmap</default_value>

--- a/cime/src/drivers/mct/cime_config/config_component.xml
+++ b/cime/src/drivers/mct/cime_config/config_component.xml
@@ -1389,7 +1389,7 @@
 
   <entry id="ATM2ROF_FMAPNAME">
     <type>char</type>
-    <default_value>idmap</default_value>
+    <default_value>idmap_ignore</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
     <desc>atm2rof flux mapping file</desc>
@@ -1406,7 +1406,7 @@
 
   <entry id="ATM2ROF_SMAPNAME">
     <type>char</type>
-    <default_value>idmap</default_value>
+    <default_value>idmap_ignore</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
     <desc>atm2rof state mapping file</desc>

--- a/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -3865,6 +3865,66 @@
     </values>
   </entry>
 
+  <entry id="atm2rof_fmapname"    modify_via_xml="ATM2ROF_FMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      atm to runoff flux mapping file
+    </desc>
+    <values>
+      <value>$ATM2ROF_FMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="atm2rof_fmaptype"    modify_via_xml="ATM2ROF_FMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$ATM2ROF_FMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="atm2rof_smapname"    modify_via_xml="ATM2ROF_SMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      atm to runoff state mapping file
+    </desc>
+    <values>
+      <value>$ATM2ROF_SMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="atm2rof_smaptype"    modify_via_xml="ATM2ROF_SMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$ATM2ROF_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
   <entry id="rof2ocn_fmapname"    modify_via_xml="ROF2OCN_FMAPNAME">
     <type>char</type>
     <category>mapping</category>

--- a/cime/src/drivers/mct/main/cime_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cime_comp_mod.F90
@@ -407,6 +407,7 @@ module cime_comp_mod
   logical  :: iac_prognostic         ! .true.  => iac comp expects input
 
   logical  :: atm_c2_lnd             ! .true.  => atm to lnd coupling on
+  logical  :: atm_c2_rof             ! .true.  => atm to rof coupling on
   logical  :: atm_c2_ocn             ! .true.  => atm to ocn coupling on
   logical  :: atm_c2_ice             ! .true.  => atm to ice coupling on
   logical  :: atm_c2_wav             ! .true.  => atm to wav coupling on
@@ -1554,6 +1555,7 @@ contains
     ! derive coupling connection flags
 
     atm_c2_lnd = .false.
+    atm_c2_rof = .false.
     atm_c2_ocn = .false.
     atm_c2_ice = .false.
     atm_c2_wav = .false.
@@ -1581,6 +1583,7 @@ contains
 
     if (atm_present) then
        if (lnd_prognostic) atm_c2_lnd = .true.
+       if (rof_prognostic) atm_c2_rof = .true.
        if (ocn_prognostic) atm_c2_ocn = .true.
        if (ocn_present   ) atm_c2_ocn = .true. ! needed for aoflux calc if aoflux=ocn
        if (ice_prognostic) atm_c2_ice = .true.
@@ -1685,6 +1688,7 @@ contains
        write(logunit,F0L)'esp model prognostic  = ',esp_prognostic
 
        write(logunit,F0L)'atm_c2_lnd            = ',atm_c2_lnd
+       write(logunit,F0L)'atm_c2_rof            = ',atm_c2_rof
        write(logunit,F0L)'atm_c2_ocn            = ',atm_c2_ocn
        write(logunit,F0L)'atm_c2_ice            = ',atm_c2_ice
        write(logunit,F0L)'atm_c2_wav            = ',atm_c2_wav
@@ -1838,7 +1842,7 @@ contains
 
        call prep_ice_init(infodata, ocn_c2_ice, glc_c2_ice, glcshelf_c2_ice, rof_c2_ice )
 
-       call prep_rof_init(infodata, lnd_c2_rof)
+       call prep_rof_init(infodata, lnd_c2_rof, atm_c2_rof)
 
        call prep_glc_init(infodata, lnd_c2_glc, ocn_c2_glcshelf)
 
@@ -3657,6 +3661,10 @@ contains
        call t_drvstartf ('CPL:ATMPOST',cplrun=.true.,barrier=mpicom_CPLID)
        if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
 
+       if (atm_c2_rof) then
+          call prep_rof_accum_atm(timer='CPL:atmpost_acca2r')
+       endif
+
        call component_diag(infodata, atm, flow='c2x', comment= 'recv atm', &
             info_debug=info_debug, timer_diag='CPL:atmpost_diagav')
 
@@ -4012,7 +4020,7 @@ contains
             info_debug=info_debug, timer_diag='CPL:lndpost_diagav')
 
        ! Accumulate rof and glc inputs (module variables in prep_rof_mod and prep_glc_mod)
-       if (lnd_c2_rof) call prep_rof_accum(timer='CPL:lndpost_accl2r')
+       if (lnd_c2_rof) call prep_rof_accum_lnd(timer='CPL:lndpost_accl2r')
        if (lnd_c2_glc) call prep_glc_accum_lnd(timer='CPL:lndpost_accl2g' )
        if (lnd_c2_iac) call prep_iac_accum(timer='CPL:lndpost_accl2z')
 
@@ -4137,6 +4145,8 @@ contains
        call prep_rof_accum_avg(timer='CPL:rofprep_l2xavg')
 
        if (lnd_c2_rof) call prep_rof_calc_l2r_rx(fractions_lx, timer='CPL:rofprep_lnd2rof')
+
+       if (atm_c2_rof) call prep_rof_calc_a2r_rx(timer='CPL:rofprep_atm2rof')
 
        call prep_rof_mrg(infodata, fractions_rx, timer_mrg='CPL:rofprep_mrgx2r')
 

--- a/cime/src/drivers/mct/main/prep_rof_mod.F90
+++ b/cime/src/drivers/mct/main/prep_rof_mod.F90
@@ -197,6 +197,7 @@ contains
                list2 = irrig_flux_field, &
                listout = lnd2rof_normal_fluxes)
        endif
+    end if
 
     if (rof_present .and. atm_present) then
 

--- a/cime/src/drivers/mct/main/prep_rof_mod.F90
+++ b/cime/src/drivers/mct/main/prep_rof_mod.F90
@@ -288,7 +288,7 @@ contains
 
     !---------------------------------------------------------------
     ! Description
-    ! Accumulate land input to river component
+    ! Accumulate atmosphere input to river component
     !
     ! Arguments
     character(len=*), intent(in) :: timer

--- a/cime/src/drivers/mct/main/prep_rof_mod.F90
+++ b/cime/src/drivers/mct/main/prep_rof_mod.F90
@@ -6,7 +6,7 @@ module prep_rof_mod
   use shr_kind_mod,     only: cl => SHR_KIND_CL
   use shr_kind_mod,     only: cxx => SHR_KIND_CXX
   use shr_sys_mod,      only: shr_sys_abort, shr_sys_flush
-  use seq_comm_mct,     only: num_inst_lnd, num_inst_rof, num_inst_frc
+  use seq_comm_mct,     only: num_inst_lnd, num_inst_rof, num_inst_frc, num_inst_atm
   use seq_comm_mct,     only: CPLID, ROFID, logunit
   use seq_comm_mct,     only: seq_comm_getData=>seq_comm_setptrs
   use seq_infodata_mod, only: seq_infodata_type, seq_infodata_getdata
@@ -18,7 +18,7 @@ module prep_rof_mod
   use mct_mod
   use perf_mod
   use component_type_mod, only: component_get_x2c_cx, component_get_c2x_cx
-  use component_type_mod, only: rof, lnd
+  use component_type_mod, only: rof, lnd, atm
   use prep_lnd_mod, only: prep_lnd_get_mapper_Fr2l
   use map_lnd2rof_irrig_mod, only: map_lnd2rof_irrig
 
@@ -33,14 +33,20 @@ module prep_rof_mod
   public :: prep_rof_init
   public :: prep_rof_mrg
 
-  public :: prep_rof_accum
+  public :: prep_rof_accum_lnd
+  public :: prep_rof_accum_atm
   public :: prep_rof_accum_avg
 
   public :: prep_rof_calc_l2r_rx
+  public :: prep_rof_calc_a2r_rx
 
   public :: prep_rof_get_l2racc_lx
   public :: prep_rof_get_l2racc_lx_cnt
   public :: prep_rof_get_mapper_Fl2r
+  public :: prep_rof_get_a2racc_ax
+  public :: prep_rof_get_a2racc_ax_cnt
+  public :: prep_rof_get_mapper_Sa2r
+  public :: prep_rof_get_mapper_Fa2r
 
   !--------------------------------------------------------------------------
   ! Private interfaces
@@ -53,17 +59,25 @@ module prep_rof_mod
   !--------------------------------------------------------------------------
 
   ! mappers
+  type(seq_map), pointer :: mapper_Sa2r
+  type(seq_map), pointer :: mapper_Fa2r
   type(seq_map), pointer :: mapper_Fl2r
 
   ! attribute vectors
   type(mct_aVect), pointer :: l2r_rx(:)
+  type(mct_aVect), pointer :: a2r_rx(:)
 
   ! accumulation variables
   type(mct_aVect), pointer :: l2racc_lx(:)   ! lnd export, lnd grid, cpl pes
   integer        , target  :: l2racc_lx_cnt  ! l2racc_lx: number of time samples accumulated
+  type(mct_aVect), pointer :: a2racc_ax(:)   ! atm export, atm grid, cpl pes
+  integer        , target  :: a2racc_ax_cnt  ! a2racc_ax: number of time samples accumulated
 
   ! other module variables
-  integer :: mpicom_CPLID                            ! MPI cpl communicator
+  integer :: mpicom_CPLID  ! MPI cpl communicator
+  logical :: rof_present   ! .true.  => rof is present
+  logical :: lnd_present   ! .true.  => lnd is present
+  logical :: atm_present   ! .true.  => atm is present
 
   ! field names and lists, for fields that need to be treated specially
   character(len=*), parameter :: irrig_flux_field = 'Flrl_irrig'
@@ -77,7 +91,7 @@ contains
 
   !================================================================================================
 
-  subroutine prep_rof_init(infodata, lnd_c2_rof)
+  subroutine prep_rof_init(infodata, lnd_c2_rof, atm_c2_rof)
 
     !---------------------------------------------------------------
     ! Description
@@ -87,19 +101,24 @@ contains
     ! Arguments
     type(seq_infodata_type) , intent(in)    :: infodata
     logical                 , intent(in)    :: lnd_c2_rof ! .true.  => lnd to rof coupling on
+    logical                 , intent(in)    :: atm_c2_rof ! .true.  => atm to rof coupling on
     !
     ! Local Variables
     integer                     :: lsize_r
     integer                     :: lsize_l
-    integer                     :: eli, eri
-    logical                     :: samegrid_lr   ! samegrid land and rof
+    integer                     :: lsize_a
+    integer                     :: eli, eri, eai
+    logical                     :: samegrid_lr   ! samegrid lnd and rof
+    logical                     :: samegrid_ar   ! samegrid atm and rof
     logical                     :: esmf_map_flag ! .true. => use esmf for mapping
     logical                     :: rof_present   ! .true.  => rof is present
     logical                     :: lnd_present   ! .true.  => lnd is present
     logical                     :: iamroot_CPLID ! .true. => CPLID masterproc
+    character(CL)               :: atm_gnam      ! atm grid
     character(CL)               :: lnd_gnam      ! lnd grid
     character(CL)               :: rof_gnam      ! rof grid
     type(mct_aVect) , pointer   :: l2x_lx
+    type(mct_aVect) , pointer   :: a2x_ax
     type(mct_aVect) , pointer   :: x2r_rx
     integer                     :: index_irrig
     character(*)    , parameter :: subname = '(prep_rof_init)'
@@ -110,9 +129,13 @@ contains
          esmf_map_flag=esmf_map_flag   , &
          rof_present=rof_present       , &
          lnd_present=lnd_present       , &
+         atm_present=atm_present       , &
          lnd_gnam=lnd_gnam             , &
+         atm_gnam=atm_gnam             , &
          rof_gnam=rof_gnam             )
 
+    allocate(mapper_Sa2r)
+    allocate(mapper_Fa2r)
     allocate(mapper_Fl2r)
 
     if (rof_present) then
@@ -174,6 +197,51 @@ contains
                list2 = irrig_flux_field, &
                listout = lnd2rof_normal_fluxes)
        endif
+
+    if (rof_present .and. atm_present) then
+
+       call seq_comm_getData(CPLID, &
+            mpicom=mpicom_CPLID, iamroot=iamroot_CPLID)
+
+       lsize_r = mct_aVect_lsize(x2r_rx)
+
+       a2x_ax => component_get_c2x_cx(atm(1))
+       lsize_a = mct_aVect_lsize(a2x_ax)
+
+       allocate(a2racc_ax(num_inst_atm))
+       do eai = 1,num_inst_atm
+          call mct_aVect_initSharedFields(a2x_ax, x2r_rx, a2racc_ax(eai), lsize=lsize_a)
+          call mct_aVect_zero(a2racc_ax(eai))
+       end do
+       a2racc_ax_cnt = 0
+
+       allocate(a2r_rx(num_inst_rof))
+       do eri = 1,num_inst_rof
+          call mct_avect_init(a2r_rx(eri), rList=seq_flds_x2r_fields, lsize=lsize_r)
+          call mct_avect_zero(a2r_rx(eri))
+       end do
+
+       samegrid_ar = .true.
+       if (trim(atm_gnam) /= trim(rof_gnam)) samegrid_ar = .false.
+
+       if (atm_c2_rof) then
+          if (iamroot_CPLID) then
+             write(logunit,*) ' '
+             write(logunit,F00) 'Initializing mapper_Fa2r'
+          end if
+          call seq_map_init_rcfile(mapper_Fa2r, atm(1), rof(1), &
+               'seq_maps.rc','atm2rof_fmapname:','atm2rof_fmaptype:',samegrid_ar, &
+               string='mapper_Fa2r initialization', esmf_map=esmf_map_flag)
+
+          if (iamroot_CPLID) then
+             write(logunit,*) ' '
+             write(logunit,F00) 'Initializing mapper_Sa2r'
+          end if
+          call seq_map_init_rcfile(mapper_Sa2r, atm(1), rof(1), &
+               'seq_maps.rc','atm2rof_smapname:','atm2rof_smaptype:',samegrid_ar, &
+               string='mapper_Sa2r initialization', esmf_map=esmf_map_flag)
+       endif
+	   
        call shr_sys_flush(logunit)
 
     end if
@@ -182,7 +250,7 @@ contains
 
   !================================================================================================
 
-  subroutine prep_rof_accum(timer)
+  subroutine prep_rof_accum_lnd(timer)
 
     !---------------------------------------------------------------
     ! Description
@@ -194,7 +262,7 @@ contains
     ! Local Variables
     integer :: eli
     type(mct_aVect), pointer :: l2x_lx
-    character(*), parameter  :: subname = '(prep_rof_accum)'
+    character(*), parameter  :: subname = '(prep_rof_accum_lnd)'
     !---------------------------------------------------------------
 
     call t_drvstartf (trim(timer),barrier=mpicom_CPLID)
@@ -209,7 +277,40 @@ contains
     l2racc_lx_cnt = l2racc_lx_cnt + 1
     call t_drvstopf (trim(timer))
 
-  end subroutine prep_rof_accum
+  end subroutine prep_rof_accum_lnd
+
+  !================================================================================================
+
+  subroutine prep_rof_accum_atm(timer)
+
+    !---------------------------------------------------------------
+    ! Description
+    ! Accumulate land input to river component
+    !
+    ! Arguments
+    character(len=*), intent(in) :: timer
+    !
+    ! Local Variables
+    integer :: eai
+    type(mct_aVect), pointer :: a2x_ax
+    character(*), parameter  :: subname = '(prep_rof_accum_atm)'
+    !---------------------------------------------------------------
+
+    call t_drvstartf (trim(timer),barrier=mpicom_CPLID)
+
+    do eai = 1,num_inst_atm
+       a2x_ax => component_get_c2x_cx(atm(eai))
+       if (a2racc_ax_cnt == 0) then
+          call mct_avect_copy(a2x_ax, a2racc_ax(eai))
+       else
+          call mct_avect_accum(a2x_ax, a2racc_ax(eai))
+       endif
+    end do
+    a2racc_ax_cnt = a2racc_ax_cnt + 1
+
+    call t_drvstopf (trim(timer))
+
+  end subroutine prep_rof_accum_atm
 
   !================================================================================================
 
@@ -223,7 +324,7 @@ contains
     character(len=*), intent(in) :: timer
     !
     ! Local Variables
-    integer :: eri, eli
+    integer :: eri, eli, eai
     character(*), parameter :: subname = '(prep_rof_accum_avg)'
     !---------------------------------------------------------------
 
@@ -231,8 +332,11 @@ contains
     do eri = 1,num_inst_rof
        eli = mod((eri-1),num_inst_lnd) + 1
        call mct_avect_avg(l2racc_lx(eli),l2racc_lx_cnt)
+       eai = mod((eri-1),num_inst_atm) + 1
+       call mct_avect_avg(a2racc_ax(eai),a2racc_ax_cnt)
     end do
     l2racc_lx_cnt = 0
+    a2racc_ax_cnt = 0
     call t_drvstopf (trim(timer))
 
   end subroutine prep_rof_accum_avg
@@ -261,7 +365,7 @@ contains
        efi = mod((eri-1),num_inst_frc) + 1
 
        x2r_rx => component_get_x2c_cx(rof(eri))  ! This is actually modifying x2r_rx
-       call prep_rof_merge(l2r_rx(eri), fractions_rx(efi), x2r_rx)
+       call prep_rof_merge(l2r_rx(eri), a2r_rx(eri), fractions_rx(efi), x2r_rx)
     end do
     call t_drvstopf (trim(timer_mrg))
 
@@ -269,7 +373,7 @@ contains
 
   !================================================================================================
 
-  subroutine prep_rof_merge(l2x_r, fractions_r, x2r_r)
+  subroutine prep_rof_merge(l2x_r, a2x_r, fractions_r, x2r_r)
 
     !-----------------------------------------------------------------------
     ! Description
@@ -277,6 +381,7 @@ contains
     !
     ! Arguments
     type(mct_aVect),intent(in)    :: l2x_r
+    type(mct_aVect),intent(in)    :: a2x_r
     type(mct_aVect),intent(in)    :: fractions_r
     type(mct_aVect),intent(inout) :: x2r_r
     !
@@ -306,6 +411,32 @@ contains
     integer, save :: index_l2x_Flrl_rofi_HDO
     integer, save :: index_x2r_Flrl_rofl_HDO
     integer, save :: index_x2r_Flrl_rofi_HDO
+	
+    integer, save :: index_l2x_Flrl_Tqsur
+    integer, save :: index_l2x_Flrl_Tqsub
+    integer, save :: index_a2x_Sa_tbot
+    integer, save :: index_a2x_Sa_pbot
+    integer, save :: index_a2x_Sa_u
+    integer, save :: index_a2x_Sa_v
+    integer, save :: index_a2x_Sa_shum
+    integer, save :: index_a2x_Faxa_swndr
+    integer, save :: index_a2x_Faxa_swndf
+    integer, save :: index_a2x_Faxa_swvdr
+    integer, save :: index_a2x_Faxa_swvdf
+    integer, save :: index_a2x_Faxa_lwdn
+    integer, save :: index_x2r_Flrl_Tqsur
+    integer, save :: index_x2r_Flrl_Tqsub
+    integer, save :: index_x2r_Sa_tbot
+    integer, save :: index_x2r_Sa_pbot
+    integer, save :: index_x2r_Sa_u
+    integer, save :: index_x2r_Sa_v
+    integer, save :: index_x2r_Sa_shum
+    integer, save :: index_x2r_Faxa_swndr
+    integer, save :: index_x2r_Faxa_swndf
+    integer, save :: index_x2r_Faxa_swvdr
+    integer, save :: index_x2r_Faxa_swvdf
+    integer, save :: index_x2r_Faxa_lwdn
+
     integer, save :: index_lfrac
     logical, save :: first_time = .true.
     logical, save :: flds_wiso_rof = .false.
@@ -346,8 +477,12 @@ contains
        if (have_irrig_field) then
           index_x2r_Flrl_irrig  = mct_aVect_indexRA(x2r_r,'Flrl_irrig' )
        end if
+       index_l2x_Flrl_Tqsur = mct_aVect_indexRA(l2x_r,'Flrl_Tqsur' )
+       index_l2x_Flrl_Tqsub = mct_aVect_indexRA(l2x_r,'Flrl_Tqsub' )
+       index_x2r_Flrl_Tqsur = mct_aVect_indexRA(x2r_r,'Flrl_Tqsur' )
+       index_x2r_Flrl_Tqsub = mct_aVect_indexRA(x2r_r,'Flrl_Tqsub' )	   
+	   
        index_l2x_Flrl_rofl_16O = mct_aVect_indexRA(l2x_r,'Flrl_rofl_16O', perrWith='quiet' )
-
        if ( index_l2x_Flrl_rofl_16O /= 0 ) flds_wiso_rof = .true.
        if ( flds_wiso_rof ) then
           index_l2x_Flrl_rofi_16O = mct_aVect_indexRA(l2x_r,'Flrl_rofi_16O' )
@@ -382,6 +517,8 @@ contains
           mrgstr(index_x2r_Flrl_irrig) = trim(mrgstr(index_x2r_Flrl_irrig))//' = '// &
                'lfrac*l2x%Flrl_irrig'
        end if
+       mrgstr(index_x2r_Flrl_Tqsur) = trim(mrgstr(index_x2r_Flrl_Tqsur))//' = '//'l2x%Flrl_Tqsur'
+       mrgstr(index_x2r_Flrl_Tqsur) = trim(mrgstr(index_x2r_Flrl_Tqsub))//' = '//'l2x%Flrl_Tqsub'
        if ( flds_wiso_rof ) then
           mrgstr(index_x2r_Flrl_rofl_16O) = trim(mrgstr(index_x2r_Flrl_rofl_16O))//' = '// &
                'lfrac*l2x%Flrl_rofl_16O'
@@ -396,6 +533,39 @@ contains
           mrgstr(index_x2r_Flrl_rofi_HDO) = trim(mrgstr(index_x2r_Flrl_rofi_HDO))//' = '// &
                'lfrac*l2x%Flrl_rofi_HDO'
        end if
+	   
+       index_a2x_Sa_tbot    = mct_aVect_indexRA(a2x_r,'Sa_tbot')
+       index_a2x_Sa_pbot    = mct_aVect_indexRA(a2x_r,'Sa_pbot')
+       index_a2x_Sa_u       = mct_aVect_indexRA(a2x_r,'Sa_u')
+       index_a2x_Sa_v       = mct_aVect_indexRA(a2x_r,'Sa_v')
+       index_a2x_Sa_shum    = mct_aVect_indexRA(a2x_r,'Sa_shum')
+       index_a2x_Faxa_swndr = mct_aVect_indexRA(a2x_r,'Faxa_swndr')
+       index_a2x_Faxa_swndf = mct_aVect_indexRA(a2x_r,'Faxa_swndf')
+       index_a2x_Faxa_swvdr = mct_aVect_indexRA(a2x_r,'Faxa_swvdr')
+       index_a2x_Faxa_swvdf = mct_aVect_indexRA(a2x_r,'Faxa_swvdf')
+       index_a2x_Faxa_lwdn  = mct_aVect_indexRA(a2x_r,'Faxa_lwdn')
+     
+       index_x2r_Sa_tbot    = mct_aVect_indexRA(x2r_r,'Sa_tbot')
+       index_x2r_Sa_pbot    = mct_aVect_indexRA(x2r_r,'Sa_pbot')
+       index_x2r_Sa_u       = mct_aVect_indexRA(x2r_r,'Sa_u')
+       index_x2r_Sa_v       = mct_aVect_indexRA(x2r_r,'Sa_v')
+       index_x2r_Sa_shum    = mct_aVect_indexRA(x2r_r,'Sa_shum')
+       index_x2r_Faxa_swndr = mct_aVect_indexRA(x2r_r,'Faxa_swndr')
+       index_x2r_Faxa_swndf = mct_aVect_indexRA(x2r_r,'Faxa_swndf')
+       index_x2r_Faxa_swvdr = mct_aVect_indexRA(x2r_r,'Faxa_swvdr')
+       index_x2r_Faxa_swvdf = mct_aVect_indexRA(x2r_r,'Faxa_swvdf')
+       index_x2r_Faxa_lwdn  = mct_aVect_indexRA(x2r_r,'Faxa_lwdn')
+     
+       mrgstr(index_x2r_Sa_tbot)    = trim(mrgstr(index_x2r_Sa_tbot))//' = '//'a2x%Sa_tbot'
+       mrgstr(index_x2r_Sa_pbot)    = trim(mrgstr(index_x2r_Sa_pbot))//' = '//'a2x%Sa_pbot'
+       mrgstr(index_x2r_Sa_u)       = trim(mrgstr(index_x2r_Sa_u))//' = '//'a2x%Sa_u'
+       mrgstr(index_x2r_Sa_v)       = trim(mrgstr(index_x2r_Sa_v))//' = '//'a2x%Sa_v'
+       mrgstr(index_x2r_Sa_shum)    = trim(mrgstr(index_x2r_Sa_shum))//' = '//'a2x%Sa_shum'
+       mrgstr(index_x2r_Faxa_swndr) = trim(mrgstr(index_x2r_Faxa_swndr))//' = '//'a2x%Faxa_swndr'
+       mrgstr(index_x2r_Faxa_swndf) = trim(mrgstr(index_x2r_Faxa_swndf))//' = '//'a2x%Faxa_swndf'
+       mrgstr(index_x2r_Faxa_swvdr) = trim(mrgstr(index_x2r_Faxa_swvdr))//' = '//'a2x%Faxa_swvdr'
+       mrgstr(index_x2r_Faxa_swvdf) = trim(mrgstr(index_x2r_Faxa_swvdf))//' = '//'a2x%Faxa_swvdf'
+       mrgstr(index_x2r_Faxa_lwdn)  = trim(mrgstr(index_x2r_Faxa_lwdn))//' = '//'a2x%Faxa_lwdn'
     end if
 
     do i = 1,lsize
@@ -408,6 +578,8 @@ contains
        if (have_irrig_field) then
           x2r_r%rAttr(index_x2r_Flrl_irrig,i) = l2x_r%rAttr(index_l2x_Flrl_irrig,i) * lfrac
        end if
+       x2r_r%rAttr(index_x2r_Flrl_Tqsur,i) = l2x_r%rAttr(index_l2x_Flrl_Tqsur,i)
+       x2r_r%rAttr(index_x2r_Flrl_Tqsub,i) = l2x_r%rAttr(index_l2x_Flrl_Tqsub,i)
        if ( flds_wiso_rof ) then
           x2r_r%rAttr(index_x2r_Flrl_rofl_16O,i) = l2x_r%rAttr(index_l2x_Flrl_rofl_16O,i) * lfrac
           x2r_r%rAttr(index_x2r_Flrl_rofi_16O,i) = l2x_r%rAttr(index_l2x_Flrl_rofi_16O,i) * lfrac
@@ -416,6 +588,18 @@ contains
           x2r_r%rAttr(index_x2r_Flrl_rofl_HDO,i) = l2x_r%rAttr(index_l2x_Flrl_rofl_HDO,i) * lfrac
           x2r_r%rAttr(index_x2r_Flrl_rofi_HDO,i) = l2x_r%rAttr(index_l2x_Flrl_rofi_HDO,i) * lfrac
        end if
+
+       x2r_r%rAttr(index_x2r_Sa_tbot,i)    = a2x_r%rAttr(index_a2x_Sa_tbot,i)
+       x2r_r%rAttr(index_x2r_Sa_pbot,i)    = a2x_r%rAttr(index_a2x_Sa_pbot,i)
+       x2r_r%rAttr(index_x2r_Sa_u,i)       = a2x_r%rAttr(index_a2x_Sa_u,i)
+       x2r_r%rAttr(index_x2r_Sa_v,i)       = a2x_r%rAttr(index_a2x_Sa_v,i)
+       x2r_r%rAttr(index_x2r_Sa_shum,i)    = a2x_r%rAttr(index_a2x_Sa_shum,i)
+       x2r_r%rAttr(index_x2r_Faxa_swndr,i) = a2x_r%rAttr(index_a2x_Faxa_swndr,i)
+       x2r_r%rAttr(index_x2r_Faxa_swndf,i) = a2x_r%rAttr(index_a2x_Faxa_swndf,i)
+       x2r_r%rAttr(index_x2r_Faxa_swvdr,i) = a2x_r%rAttr(index_a2x_Faxa_swvdr,i)
+       x2r_r%rAttr(index_x2r_Faxa_swvdf,i) = a2x_r%rAttr(index_a2x_Faxa_swvdf,i)
+       x2r_r%rAttr(index_x2r_Faxa_lwdn,i)  = a2x_r%rAttr(index_a2x_Faxa_lwdn,i)
+
     end do
 
     if (first_time) then
@@ -481,6 +665,33 @@ contains
 
   !================================================================================================
 
+  subroutine prep_rof_calc_a2r_rx(timer)
+    !---------------------------------------------------------------
+    ! Description
+    ! Create a2r_rx (note that a2r_rx is a local module variable)
+    !
+    ! Arguments
+    character(len=*), intent(in) :: timer
+    !
+    ! Local Variables
+    integer :: eri, eai
+    type(mct_avect), pointer :: r2x_rx
+    character(*), parameter :: subname = '(prep_rof_calc_a2r_rx)'
+    !---------------------------------------------------------------
+
+    call t_drvstartf (trim(timer),barrier=mpicom_CPLID)
+    do eri = 1,num_inst_rof
+       eai = mod((eri-1),num_inst_atm) + 1
+       r2x_rx => component_get_c2x_cx(rof(eri))
+       call seq_map_map(mapper_Sa2r, a2racc_ax(eai), a2r_rx(eri), fldlist=seq_flds_a2x_states, norm=.true.)
+       call seq_map_map(mapper_Fa2r, a2racc_ax(eai), a2r_rx(eri), fldlist=seq_flds_a2x_fluxes, norm=.true.)
+    end do
+    call t_drvstopf  (trim(timer))
+
+  end subroutine prep_rof_calc_a2r_rx
+
+  !================================================================================================
+
   function prep_rof_get_l2racc_lx()
     type(mct_aVect), pointer :: prep_rof_get_l2racc_lx(:)
     prep_rof_get_l2racc_lx => l2racc_lx(:)
@@ -495,5 +706,25 @@ contains
     type(seq_map), pointer :: prep_rof_get_mapper_Fl2r
     prep_rof_get_mapper_Fl2r => mapper_Fl2r
   end function prep_rof_get_mapper_Fl2r
+
+  function prep_rof_get_a2racc_ax()
+    type(mct_aVect), pointer :: prep_rof_get_a2racc_ax(:)
+    prep_rof_get_a2racc_ax => a2racc_ax(:)
+  end function prep_rof_get_a2racc_ax
+
+  function prep_rof_get_a2racc_ax_cnt()
+    integer, pointer :: prep_rof_get_a2racc_ax_cnt
+    prep_rof_get_a2racc_ax_cnt => a2racc_ax_cnt
+  end function prep_rof_get_a2racc_ax_cnt
+
+  function prep_rof_get_mapper_Fa2r()
+    type(seq_map), pointer :: prep_rof_get_mapper_Fa2r
+    prep_rof_get_mapper_Fa2r => mapper_Fa2r
+  end function prep_rof_get_mapper_Fa2r
+
+  function prep_rof_get_mapper_Sa2r()
+    type(seq_map), pointer :: prep_rof_get_mapper_Sa2r
+    prep_rof_get_mapper_Sa2r => mapper_Sa2r
+  end function prep_rof_get_mapper_Sa2r
 
 end module prep_rof_mod

--- a/cime/src/drivers/mct/main/prep_rof_mod.F90
+++ b/cime/src/drivers/mct/main/prep_rof_mod.F90
@@ -197,6 +197,8 @@ contains
                list2 = irrig_flux_field, &
                listout = lnd2rof_normal_fluxes)
        endif
+       call shr_sys_flush(logunit)
+
     end if
 
     if (rof_present .and. atm_present) then

--- a/cime/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/cime/src/drivers/mct/shr/seq_flds_mod.F90
@@ -600,6 +600,7 @@ contains
     call seq_flds_add(a2x_states,"Sa_u")
     call seq_flds_add(x2l_states,"Sa_u")
     call seq_flds_add(x2i_states,"Sa_u")
+    call seq_flds_add(x2r_states,"Sa_u")
     call seq_flds_add(x2w_states,"Sa_u")
     longname = 'Zonal wind at the lowest model level'
     stdname  = 'eastward_wind'
@@ -611,6 +612,7 @@ contains
     call seq_flds_add(a2x_states,"Sa_v")
     call seq_flds_add(x2l_states,"Sa_v")
     call seq_flds_add(x2i_states,"Sa_v")
+    call seq_flds_add(x2r_states,"Sa_v")
     call seq_flds_add(x2w_states,"Sa_v")
     longname = 'Meridional wind at the lowest model level'
     stdname  = 'northward_wind'
@@ -622,6 +624,7 @@ contains
     call seq_flds_add(a2x_states,"Sa_tbot")
     call seq_flds_add(x2l_states,"Sa_tbot")
     call seq_flds_add(x2i_states,"Sa_tbot")
+    call seq_flds_add(x2r_states,"Sa_tbot")
     call seq_flds_add(x2w_states,"Sa_tbot")
     longname = 'Temperature at the lowest model level'
     stdname  = 'air_temperature'
@@ -643,6 +646,7 @@ contains
     call seq_flds_add(a2x_states,"Sa_shum")
     call seq_flds_add(x2l_states,"Sa_shum")
     call seq_flds_add(x2i_states,"Sa_shum")
+    call seq_flds_add(x2r_states,"Sa_shum")
     longname = 'Specific humidity at the lowest model level'
     stdname  = 'specific_humidity'
     units    = 'kg kg-1'
@@ -653,6 +657,7 @@ contains
     call seq_flds_add(a2x_states,"Sa_pbot")
     call seq_flds_add(x2l_states,"Sa_pbot")
     call seq_flds_add(x2i_states,"Sa_pbot")
+    call seq_flds_add(x2r_states,"Sa_pbot")
     if (trim(cime_model) == 'e3sm') then
        call seq_flds_add(x2o_states,"Sa_pbot")
     end if
@@ -727,6 +732,7 @@ contains
     call seq_flds_add(a2x_fluxes,"Faxa_lwdn")
     call seq_flds_add(x2l_fluxes,"Faxa_lwdn")
     call seq_flds_add(x2i_fluxes,"Faxa_lwdn")
+    call seq_flds_add(x2r_fluxes,"Faxa_lwdn")
     call seq_flds_add(x2o_fluxes,"Faxa_lwdn")
     longname = 'Downward longwave heat flux'
     stdname  = 'downwelling_longwave_flux'
@@ -737,6 +743,7 @@ contains
     ! direct near-infrared incident solar radiation
     call seq_flds_add(a2x_fluxes,"Faxa_swndr")
     call seq_flds_add(x2i_fluxes,"Faxa_swndr")
+    call seq_flds_add(x2r_fluxes,"Faxa_swndr")
     call seq_flds_add(x2l_fluxes,"Faxa_swndr")
     longname = 'Direct near-infrared incident solar radiation'
     stdname  = 'surface_downward_direct_shortwave_flux_due_to_near_infrared_radiation'
@@ -747,6 +754,7 @@ contains
     ! direct visible incident solar radiation
     call seq_flds_add(a2x_fluxes,"Faxa_swvdr")
     call seq_flds_add(x2i_fluxes,"Faxa_swvdr")
+    call seq_flds_add(x2r_fluxes,"Faxa_swvdr")
     call seq_flds_add(x2l_fluxes,"Faxa_swvdr")
     longname = 'Direct visible incident solar radiation'
     stdname  = 'surface_downward_direct_shortwave_flux_due_to_visible_radiation'
@@ -757,6 +765,7 @@ contains
     ! diffuse near-infrared incident solar radiation
     call seq_flds_add(a2x_fluxes,"Faxa_swndf")
     call seq_flds_add(x2i_fluxes,"Faxa_swndf")
+    call seq_flds_add(x2r_fluxes,"Faxa_swndf")
     call seq_flds_add(x2l_fluxes,"Faxa_swndf")
     longname = 'Diffuse near-infrared incident solar radiation'
     stdname  = 'surface_downward_diffuse_shortwave_flux_due_to_near_infrared_radiation'
@@ -767,6 +776,7 @@ contains
     ! diffuse visible incident solar radiation
     call seq_flds_add(a2x_fluxes,"Faxa_swvdf")
     call seq_flds_add(x2i_fluxes,"Faxa_swvdf")
+    call seq_flds_add(x2r_fluxes,"Faxa_swvdf")
     call seq_flds_add(x2l_fluxes,"Faxa_swvdf")
     longname = 'Diffuse visible incident solar radiation'
     stdname  = 'surface_downward_diffuse_shortwave_flux_due_to_visible_radiation'
@@ -1992,6 +2002,22 @@ contains
     stdname  = 'frozen_water_flux_into_runoff'
     units    = 'kg m-2 s-1'
     attname  = 'Flrl_rofi'
+    call metadata_set(attname, longname, stdname, units)
+
+    call seq_flds_add(l2x_fluxes,'Flrl_Tqsur')
+    call seq_flds_add(x2r_fluxes,'Flrl_Tqsur')
+    longname = 'Temperature of surface runoff'
+    stdname  = 'Temperature_of_surface_runoff'
+    units    = 'Kelvin'
+    attname  = 'Flrl_Tqsur'
+    call metadata_set(attname, longname, stdname, units)
+
+    call seq_flds_add(l2x_fluxes,'Flrl_Tqsub')
+    call seq_flds_add(x2r_fluxes,'Flrl_Tqsub')
+    longname = 'Temperature of subsurface runoff'
+    stdname  = 'Temperature_of_subsurface_runoff'
+    units    = 'Kelvin'
+    attname  = 'Flrl_Tqsub'
     call metadata_set(attname, longname, stdname, units)
 
     ! Currently only the CESM land and runoff models treat irrigation as a separate

--- a/components/clm/src/cpl/clm_cpl_indices.F90
+++ b/components/clm/src/cpl/clm_cpl_indices.F90
@@ -28,6 +28,8 @@ module clm_cpl_indices
   integer, public ::index_l2x_Flrl_rofgwl     ! lnd->rtm input liquid gwl fluxes
   integer, public ::index_l2x_Flrl_rofsub     ! lnd->rtm input liquid subsurface fluxes
   integer, public ::index_l2x_Flrl_rofi       ! lnd->rtm input frozen fluxes
+  integer, public ::index_l2x_Flrl_Tqsur      ! lnd->rtm input surface runoff temperature
+  integer, public ::index_l2x_Flrl_Tqsub      ! lnd->rtm input subsurface runoff temperature
 
   integer, public ::index_l2x_Sl_t            ! temperature
   integer, public ::index_l2x_Sl_tref         ! 2m reference temperature
@@ -167,6 +169,8 @@ contains
     index_l2x_Flrl_rofgwl   = mct_avect_indexra(l2x,'Flrl_rofgwl')
     index_l2x_Flrl_rofsub   = mct_avect_indexra(l2x,'Flrl_rofsub')
     index_l2x_Flrl_rofi     = mct_avect_indexra(l2x,'Flrl_rofi')
+    index_l2x_Flrl_Tqsur    = mct_avect_indexra(l2x,'Flrl_Tqsur')
+    index_l2x_Flrl_Tqsub    = mct_avect_indexra(l2x,'Flrl_Tqsub')
 
     index_l2x_Sl_t          = mct_avect_indexra(l2x,'Sl_t')
     index_l2x_Sl_snowh      = mct_avect_indexra(l2x,'Sl_snowh')

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -105,7 +105,7 @@ contains
     character(len=CL)  :: stream_fldFileName_popdens ! poplulation density stream filename
     character(len=CL)  :: stream_fldFileName_ndep    ! nitrogen deposition stream filename
     logical :: use_sitedata, has_zonefile, use_daymet, use_livneh
-    data caldaym / 1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 /	
+    data caldaym / 1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 /    
 
     ! Constants to compute vapor pressure
     parameter (a0=6.107799961_r8    , a1=4.436518521e-01_r8, &
@@ -141,7 +141,7 @@ contains
 
     namelist /ndepdyn_nml/        &
         stream_year_first_ndep,  &
-	stream_year_last_ndep,   &
+    stream_year_last_ndep,   &
         model_year_align_ndep,   &
         ndepmapalgo,             &
         stream_fldFileName_ndep
@@ -401,7 +401,7 @@ contains
             !get the conversion factors
             ierr = nf90_get_att(met_ncids(v), varid, 'scale_factor', atm2lnd_vars%scale_factors(v))
             ierr = nf90_get_att(met_ncids(v), varid, 'add_offset', atm2lnd_vars%add_offsets(v))
-            !get the met data	     
+            !get the met data         
             starti(1) = 1
             starti(2) = gtoget
             counti(1) = atm2lnd_vars%timelen_spinup(v)
@@ -506,7 +506,7 @@ contains
         !get weights for linear interpolation 
         do v=1,met_nvars
           if (atm2lnd_vars%npf(v) - 1._r8 .gt. 1e-3) then
-               wt1(v) = 1._r8 - (mod(nstep-1-atm2lnd_vars%npf(v)/2._r8,atm2lnd_vars%npf(v))*1._r8)/atm2lnd_vars%npf(v)	
+               wt1(v) = 1._r8 - (mod(nstep-1-atm2lnd_vars%npf(v)/2._r8,atm2lnd_vars%npf(v))*1._r8)/atm2lnd_vars%npf(v)    
                wt2(v) = 1._r8 - wt1(v)
           else
              wt1(v) = 0._r8    
@@ -538,7 +538,7 @@ contains
                                                      *atm2lnd_vars%scale_factors(3)+atm2lnd_vars%add_offsets(3))*wt2(3)) * &
                                                      atm2lnd_vars%var_mult(3,g,mon) + atm2lnd_vars%var_offset(3,g,mon), 1e-9_r8)
 
-        if (atm2lnd_vars%metsource == 2) then  !convert RH to qbot						     
+        if (atm2lnd_vars%metsource == 2) then  !convert RH to qbot                             
           if (tbot > SHR_CONST_TKFRZ) then
             e = esatw(tdc(tbot))
           else
@@ -567,7 +567,7 @@ contains
         avgcosz = 0d0
         if (atm2lnd_vars%npf(4) - 1._r8 .gt. 1e-3) then 
           do tm=1,nint(atm2lnd_vars%npf(4))  
-            !Get the average cosine zenith angle over the time resolution of the input data 	 
+            !Get the average cosine zenith angle over the time resolution of the input data      
             if (tod-2*get_step_size() >= 0) then 
               tod_start =  int(((tod-2*get_step_size())/nint(3600*atm2lnd_vars%timeres(4)))*atm2lnd_vars%timeres(4))
               calday_start = int(thiscalday)

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -1248,6 +1248,8 @@ contains
        l2x(index_l2x_Flrl_rofsub,i) = lnd2atm_vars%qflx_rofliq_qsub_grc(g) &
                                     + lnd2atm_vars%qflx_rofliq_qsubp_grc(g)   !  perched drainiage
        l2x(index_l2x_Flrl_rofgwl,i) = lnd2atm_vars%qflx_rofliq_qgwl_grc(g)
+       l2x(index_l2x_Flrl_Tqsur,i)  = lnd2atm_vars%Tqsur_grc(g)
+       l2x(index_l2x_Flrl_Tqsub,i)  = lnd2atm_vars%Tqsub_grc(g)
 
        ! glc coupling
 

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -112,6 +112,7 @@ module clm_driver
   use clm_instMod            , only : surfalb_vars
   use clm_instMod            , only : surfrad_vars
   use clm_instMod            , only : temperature_vars
+  use clm_instMod            , only : col_es
   use clm_instMod            , only : waterflux_vars
   use clm_instMod            , only : waterstate_vars
   use clm_instMod            , only : atm2lnd_vars
@@ -1323,7 +1324,7 @@ contains
 
     call t_startf('lnd2atm')
     call lnd2atm(bounds_proc,                                            &
-         atm2lnd_vars, surfalb_vars, temperature_vars, frictionvel_vars, &
+         atm2lnd_vars, surfalb_vars, frictionvel_vars, &
          waterstate_vars, waterflux_vars, energyflux_vars,               &
          solarabs_vars, carbonflux_vars, drydepvel_vars,                 &
          vocemis_vars, dust_vars, ch4_vars, soilhydrology_vars, lnd2atm_vars) 

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -1326,7 +1326,7 @@ contains
          atm2lnd_vars, surfalb_vars, temperature_vars, frictionvel_vars, &
          waterstate_vars, waterflux_vars, energyflux_vars,               &
          solarabs_vars, carbonflux_vars, drydepvel_vars,                 &
-         vocemis_vars, dust_vars, ch4_vars, lnd2atm_vars) 
+         vocemis_vars, dust_vars, ch4_vars, soilhydrology_vars, lnd2atm_vars) 
     call t_stopf('lnd2atm')
 
     ! ============================================================================

--- a/components/clm/src/main/lnd2atmMod.F90
+++ b/components/clm/src/main/lnd2atmMod.F90
@@ -353,7 +353,7 @@ contains
        ! TODO temperary treatment in case weird values after c2g
        if(lnd2atm_vars%t_soisno_grc(g, 1) > 400._r8) then
            write(iulog,*)'lnd2atm_vars%t_soisno_grc(g, 1) is',lnd2atm_vars%t_soisno_grc(g, 1)
-		   call endrun( msg=' lnd2atm ERROR: lnd2atm_vars%t_soisno_grc >  400 Kelvin degree.'//errMsg(__FILE__, __LINE__))
+           call endrun( msg=' lnd2atm ERROR: lnd2atm_vars%t_soisno_grc >  400 Kelvin degree.'//errMsg(__FILE__, __LINE__))
        end if
        lnd2atm_vars%Tqsur_grc(g) = avg_tsoil_surf(lnd2atm_vars%t_soisno_grc(g,-nlevsno+1:nlevgrnd))
        lnd2atm_vars%Tqsub_grc(g) = avg_tsoil(lnd2atm_vars%zwt_grc(g),lnd2atm_vars%t_soisno_grc(g,-nlevsno+1:nlevgrnd))

--- a/components/clm/src/main/lnd2atmMod.F90
+++ b/components/clm/src/main/lnd2atmMod.F90
@@ -138,10 +138,11 @@ contains
     type(vocemis_type)     , intent(in)     :: vocemis_vars
     type(dust_type)        , intent(in)     :: dust_vars
     type(ch4_type)         , intent(in)     :: ch4_vars
+    type(soilhydrology_type), intent(in)    :: soilhydrology_vars
     type(lnd2atm_type)     , intent(inout)  :: lnd2atm_vars 
     !
     ! !LOCAL VARIABLES:
-    integer :: g             ! index
+    integer :: g, lvl             ! index
     real(r8), parameter :: amC   = 12.0_r8 ! Atomic mass number for Carbon
     real(r8), parameter :: amO   = 16.0_r8 ! Atomic mass number for Oxygen
     real(r8), parameter :: amCO2 = amC + 2.0_r8*amO ! Atomic mass number for CO2

--- a/components/clm/src/main/lnd2atmType.F90
+++ b/components/clm/src/main/lnd2atmType.F90
@@ -61,14 +61,14 @@ module lnd2atmType
      real(r8), pointer :: qflx_rofliq_qsur_doc_grc(:) => null()
      real(r8), pointer :: qflx_rofliq_qsur_dic_grc(:) => null()
      real(r8), pointer :: qflx_rofliq_qsub_doc_grc(:) => null()
-     real(r8), pointer :: qflx_rofliq_qsub_dic_grc(:) => null()	 
-	 
+     real(r8), pointer :: qflx_rofliq_qsub_dic_grc(:) => null()     
+     
      real(r8), pointer :: t_grnd_grc(:) => null()            ! grc ground temperature (Kelvin)
      real(r8), pointer :: zwt_grc(:) => null()               ! grc water table depth
      real(r8), pointer :: t_soisno_grc(:,:) => null()        ! grc soil temperature (Kelvin)  (-nlevsno+1:nlevgrnd) 
      real(r8), pointer :: Tqsur_grc(:) => null()             ! grc Temperature of surface runoff
      real(r8), pointer :: Tqsub_grc(:) => null()             ! grc Temperature of subsurface runoff
-	 
+     
    contains
 
      procedure, public  :: Init
@@ -147,7 +147,7 @@ contains
     allocate(this%t_soisno_grc (begg:endg,-nlevsno+1:nlevgrnd)) ; this%t_soisno_grc        (:,:) =ival
     allocate(this%Tqsur_grc            (begg:endg))            ; this%Tqsur_grc            (:) =ival
     allocate(this%Tqsub_grc            (begg:endg))            ; this%Tqsub_grc            (:) =ival
-	
+    
     if (shr_megan_mechcomps_n>0) then
        allocate(this%flxvoc_grc(begg:endg,1:shr_megan_mechcomps_n));  this%flxvoc_grc(:,:)=ival
     endif

--- a/components/clm/src/main/lnd2atmType.F90
+++ b/components/clm/src/main/lnd2atmType.F90
@@ -9,7 +9,7 @@ module lnd2atmType
   use shr_infnan_mod, only : nan => shr_infnan_nan, assignment(=)
   use shr_log_mod   , only : errMsg => shr_log_errMsg
   use shr_megan_mod , only : shr_megan_mechcomps_n
-  use clm_varpar    , only : numrad, ndst, nlevgrnd !ndst = number of dust bins.
+  use clm_varpar    , only : numrad, ndst, nlevsno, nlevgrnd !ndst = number of dust bins.
   use clm_varcon    , only : rair, grav, cpair, hfus, tfrz, spval
   use clm_varctl    , only : iulog, use_c13, use_cn, use_lch4
   use seq_drydep_mod, only : n_drydep, drydep_method, DD_XLND
@@ -61,7 +61,14 @@ module lnd2atmType
      real(r8), pointer :: qflx_rofliq_qsur_doc_grc(:) => null()
      real(r8), pointer :: qflx_rofliq_qsur_dic_grc(:) => null()
      real(r8), pointer :: qflx_rofliq_qsub_doc_grc(:) => null()
-     real(r8), pointer :: qflx_rofliq_qsub_dic_grc(:) => null()
+     real(r8), pointer :: qflx_rofliq_qsub_dic_grc(:) => null()	 
+	 
+     real(r8), pointer :: t_grnd_grc(:) => null()            ! grc ground temperature (Kelvin)
+     real(r8), pointer :: zwt_grc(:) => null()               ! grc water table depth
+     real(r8), pointer :: t_soisno_grc(:,:) => null()        ! grc soil temperature (Kelvin)  (-nlevsno+1:nlevgrnd) 
+     real(r8), pointer :: Tqsur_grc(:) => null()             ! grc Temperature of surface runoff
+     real(r8), pointer :: Tqsub_grc(:) => null()             ! grc Temperature of subsurface runoff
+	 
    contains
 
      procedure, public  :: Init
@@ -135,6 +142,12 @@ contains
     allocate(this%qflx_rofliq_qsub_doc_grc(begg:endg))          ; this%qflx_rofliq_qsub_doc_grc(:) = ival
     allocate(this%qflx_rofliq_qsub_dic_grc(begg:endg))          ; this%qflx_rofliq_qsub_dic_grc(:) = ival 
 
+    allocate(this%zwt_grc              (begg:endg))            ; this%zwt_grc              (:) =ival
+    allocate(this%t_grnd_grc           (begg:endg))            ; this%t_grnd_grc           (:) =ival
+    allocate(this%t_soisno_grc (begg:endg,-nlevsno+1:nlevgrnd)) ; this%t_soisno_grc        (:,:) =ival
+    allocate(this%Tqsur_grc            (begg:endg))            ; this%Tqsur_grc            (:) =ival
+    allocate(this%Tqsub_grc            (begg:endg))            ; this%Tqsub_grc            (:) =ival
+	
     if (shr_megan_mechcomps_n>0) then
        allocate(this%flxvoc_grc(begg:endg,1:shr_megan_mechcomps_n));  this%flxvoc_grc(:,:)=ival
     endif

--- a/components/mosart/bld/build-namelist
+++ b/components/mosart/bld/build-namelist
@@ -301,6 +301,7 @@ if ($ROF_GRID eq "null") {
 
 if ($MOSART_MODE eq "NULL") {
     add_default($nl, 'rtm_mode', 'val'=>"$MOSART_MODE");
+    add_default($nl, 'do_rtm', 'val'=>".false.");
 }
 else {
     # Set Initial conditions if there is a file for this grid and sim-yr

--- a/components/mosart/src/cpl/rof_comp_esmf.F90
+++ b/components/mosart/src/cpl/rof_comp_esmf.F90
@@ -25,7 +25,7 @@ module rof_comp_esmf
   use seq_flds_mod
   use esmf
   use esmfshr_mod
-  use RunoffMod        , only : rtmCTL, TRunoff
+  use RunoffMod        , only : rtmCTL, TRunoff, THeat
   use RtmVar           , only : rtmlon, rtmlat, ice_runoff, iulog, &
                                 nsrStartup, nsrContinue, nsrBranch, & 
                                 inst_index, inst_suffix, inst_name, RtmVarSet
@@ -41,6 +41,7 @@ module rof_comp_esmf
                                 index_x2r_Flrl_rofgwl, index_x2r_Flrl_rofsub, &
                                 index_x2r_Flrl_rofdto, &
                                 index_r2x_Flrr_flood, &
+								index_x2r_Flrl_Tqsur, index_x2r_Flrl_Tqsub, &
                                 index_r2x_Flrr_volr, index_r2x_Flrr_volrmch
                                 !index_r2x_Flrr_supply , index_r2x_Flrr_supplyfrac, index_x2r_Flrl_demand
   use perf_mod         , only : t_startf, t_stopf, t_barrierf
@@ -659,6 +660,7 @@ contains
     ! LOCAL VARIABLES
     real(R8), pointer :: fptr(:, :)
     integer :: n2, n, nt, begr, endr, nliq, nfrz
+	real(R8) :: tmp1, tmp2
     character(len=32), parameter :: sub = 'rof_import_mct'
     !---------------------------------------------------------------------------
     
@@ -713,6 +715,19 @@ contains
        !?? = x2r_r%rAttr(index_x2r_Faxa_swvdf,n2)
        !?? = x2r_r%rAttr(index_x2r_Faxa_swndr,n2)
        !?? = x2r_r%rAttr(index_x2r_Faxa_swndf,n2)
+	   rtmCTL%Tqsur(n) = fptr(index_x2r_Flrl_Tqsur,n2) !x2r_r%rAttr(index_x2r_Flrl_Tqsur,n2)
+	   rtmCTL%Tqsub(n) = fptr(index_x2r_Flrl_Tqsub,n2) !x2r_r%rAttr(index_x2r_Flrl_Tqsub,n2)
+	   THeat%Tqsur(n) = rtmCTL%Tqsur(n)
+	   THeat%Tqsub(n) = rtmCTL%Tqsub(n)
+	   
+	   THeat%forc_t(n) = fptr(index_x2r_Sa_tbot,n2)
+	   THeat%forc_pbot(n) = fptr(index_x2r_Sa_pbot,n2)
+	   tmp1 = fptr(index_x2r_Sa_u   ,n2)
+	   tmp2 = fptr(index_x2r_Sa_v   ,n2)
+	   THeat%forc_wind(n) = sqrt(tmp1*tmp1 + tmp2*tmp2)
+	   THeat%forc_lwrad(n)= fptr(index_x2r_Faxa_lwdn ,n2)
+	   THeat%forc_solar(n)= fptr(index_x2r_Faxa_swvdr,n2) + fptr(index_x2r_Faxa_swvdf,n2) + &
+	                        fptr(index_x2r_Faxa_swndr,n2) + fptr(index_x2r_Faxa_swndf,n2)
 
     enddo
 

--- a/components/mosart/src/cpl/rof_comp_esmf.F90
+++ b/components/mosart/src/cpl/rof_comp_esmf.F90
@@ -28,7 +28,7 @@ module rof_comp_esmf
   use RunoffMod        , only : rtmCTL, TRunoff, THeat
   use RtmVar           , only : rtmlon, rtmlat, ice_runoff, iulog, &
                                 nsrStartup, nsrContinue, nsrBranch, & 
-                                inst_index, inst_suffix, inst_name, RtmVarSet
+                                inst_index, inst_suffix, inst_name, RtmVarSet, heatflag
   use RtmSpmd          , only : masterproc, iam, npes, RtmSpmdInit, ROFID
   use RtmMod           , only : Rtmini, Rtmrun
   use RtmTimeManager   , only : timemgr_setup, get_curr_date, get_step_size!, advance_timestep 
@@ -39,7 +39,7 @@ module rof_comp_esmf
                                 index_x2r_Flrl_rofsur, index_x2r_Flrl_rofi, &
                                 index_x2r_Flrl_rofgwl, index_x2r_Flrl_rofsub, &
                                 index_x2r_Flrl_rofdto, &
-								index_x2r_Flrl_Tqsur, index_x2r_Flrl_Tqsub, &
+                                index_x2r_Flrl_Tqsur, index_x2r_Flrl_Tqsub, &
                                 index_x2r_Sa_tbot, index_x2r_Sa_pbot, &
                                 index_x2r_Sa_u   , index_x2r_Sa_v   , &
                                 index_x2r_Sa_shum, &
@@ -666,7 +666,7 @@ contains
     ! LOCAL VARIABLES
     real(R8), pointer :: fptr(:, :)
     integer :: n2, n, nt, begr, endr, nliq, nfrz
-	real(R8) :: tmp1, tmp2
+    real(R8) :: tmp1, tmp2
     character(len=32), parameter :: sub = 'rof_import_mct'
     !---------------------------------------------------------------------------
     
@@ -721,19 +721,22 @@ contains
        !?? = x2r_r%rAttr(index_x2r_Faxa_swvdf,n2)
        !?? = x2r_r%rAttr(index_x2r_Faxa_swndr,n2)
        !?? = x2r_r%rAttr(index_x2r_Faxa_swndf,n2)
-	   rtmCTL%Tqsur(n) = fptr(index_x2r_Flrl_Tqsur,n2) !x2r_r%rAttr(index_x2r_Flrl_Tqsur,n2)
-	   rtmCTL%Tqsub(n) = fptr(index_x2r_Flrl_Tqsub,n2) !x2r_r%rAttr(index_x2r_Flrl_Tqsub,n2)
-	   THeat%Tqsur(n) = rtmCTL%Tqsur(n)
-	   THeat%Tqsub(n) = rtmCTL%Tqsub(n)
-	   
-	   THeat%forc_t(n) = fptr(index_x2r_Sa_tbot,n2)
-	   THeat%forc_pbot(n) = fptr(index_x2r_Sa_pbot,n2)
-	   tmp1 = fptr(index_x2r_Sa_u   ,n2)
-	   tmp2 = fptr(index_x2r_Sa_v   ,n2)
-	   THeat%forc_wind(n) = sqrt(tmp1*tmp1 + tmp2*tmp2)
-	   THeat%forc_lwrad(n)= fptr(index_x2r_Faxa_lwdn ,n2)
-	   THeat%forc_solar(n)= fptr(index_x2r_Faxa_swvdr,n2) + fptr(index_x2r_Faxa_swvdf,n2) + &
-	                        fptr(index_x2r_Faxa_swndr,n2) + fptr(index_x2r_Faxa_swndf,n2)
+       
+       if(heatflag) then
+          rtmCTL%Tqsur(n) = fptr(index_x2r_Flrl_Tqsur,n2) !x2r_r%rAttr(index_x2r_Flrl_Tqsur,n2)
+          rtmCTL%Tqsub(n) = fptr(index_x2r_Flrl_Tqsub,n2) !x2r_r%rAttr(index_x2r_Flrl_Tqsub,n2)
+          THeat%Tqsur(n) = rtmCTL%Tqsur(n)
+          THeat%Tqsub(n) = rtmCTL%Tqsub(n)
+          
+          THeat%forc_t(n) = fptr(index_x2r_Sa_tbot,n2)
+          THeat%forc_pbot(n) = fptr(index_x2r_Sa_pbot,n2)
+          tmp1 = fptr(index_x2r_Sa_u   ,n2)
+          tmp2 = fptr(index_x2r_Sa_v   ,n2)
+          THeat%forc_wind(n) = sqrt(tmp1*tmp1 + tmp2*tmp2)
+          THeat%forc_lwrad(n)= fptr(index_x2r_Faxa_lwdn ,n2)
+          THeat%forc_solar(n)= fptr(index_x2r_Faxa_swvdr,n2) + fptr(index_x2r_Faxa_swvdf,n2) + &
+                               fptr(index_x2r_Faxa_swndr,n2) + fptr(index_x2r_Faxa_swndf,n2)
+       end if                 
 
     enddo
 

--- a/components/mosart/src/cpl/rof_comp_esmf.F90
+++ b/components/mosart/src/cpl/rof_comp_esmf.F90
@@ -36,14 +36,20 @@ module rof_comp_esmf
   use WRM_type_mod     , only : StorWater
 !#endif
   use rof_cpl_indices  , only : rof_cpl_indices_set, nt_rtm, rtm_tracers, &
-                                index_r2x_Forr_rofl, index_r2x_Forr_rofi, &
-                                index_x2r_Flrl_rofi, index_x2r_Flrl_rofsur, &
+                                index_x2r_Flrl_rofsur, index_x2r_Flrl_rofi, &
                                 index_x2r_Flrl_rofgwl, index_x2r_Flrl_rofsub, &
                                 index_x2r_Flrl_rofdto, &
-                                index_r2x_Flrr_flood, &
 								index_x2r_Flrl_Tqsur, index_x2r_Flrl_Tqsub, &
+                                index_x2r_Sa_tbot, index_x2r_Sa_pbot, &
+                                index_x2r_Sa_u   , index_x2r_Sa_v   , &
+                                index_x2r_Sa_shum, &
+                                index_x2r_Faxa_lwdn , &
+                                index_x2r_Faxa_swvdr, index_x2r_Faxa_swvdf, &
+                                index_x2r_Faxa_swndr, index_x2r_Faxa_swndf, &
+                                index_r2x_Forr_rofl, index_r2x_Forr_rofi, &
+                                index_r2x_Flrr_flood, &
                                 index_r2x_Flrr_volr, index_r2x_Flrr_volrmch
-                                !index_r2x_Flrr_supply , index_r2x_Flrr_supplyfrac, index_x2r_Flrl_demand
+                                !index_r2x_Flrr_supply , index_r2x_Flrr_supplyfrac, index_x2r_Flrl_demand, 
   use perf_mod         , only : t_startf, t_stopf, t_barrierf
 !
 ! !PUBLIC MEMBER FUNCTIONS:

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -21,7 +21,7 @@ module rof_comp_mct
                                 seq_infodata_start_type_start, seq_infodata_start_type_cont,   &
                                 seq_infodata_start_type_brnch
   use seq_comm_mct     , only : seq_comm_suffix, seq_comm_inst, seq_comm_name
-  use RunoffMod        , only : rtmCTL, TRunoff
+  use RunoffMod        , only : rtmCTL, TRunoff, THeat
   use RtmVar           , only : rtmlon, rtmlat, ice_runoff, iulog, &
                                 nsrStartup, nsrContinue, nsrBranch, & 
                                 inst_index, inst_suffix, inst_name, RtmVarSet, wrmflag
@@ -38,6 +38,7 @@ module rof_comp_mct
                                 index_x2r_Flrl_rofdto, &
                                 index_r2x_Forr_rofl, index_r2x_Forr_rofi, &
                                 index_r2x_Flrr_flood, &
+								index_x2r_Flrl_Tqsur, index_x2r_Flrl_Tqsub, &
                                 index_r2x_Flrr_volr, index_r2x_Flrr_volrmch
                                 !index_r2x_Flrr_supply , index_r2x_Flrr_supplyfrac, index_x2r_Flrl_demand, 
   use mct_mod
@@ -562,6 +563,7 @@ contains
     !
     ! LOCAL VARIABLES
     integer :: n2, n, nt, begr, endr, nliq, nfrz
+	real(R8) :: tmp1, tmp2
     character(len=32), parameter :: sub = 'rof_import_mct'
     !---------------------------------------------------------------------------
     
@@ -614,6 +616,19 @@ contains
        !?? = x2r_r%rAttr(index_x2r_Faxa_swvdf,n2)
        !?? = x2r_r%rAttr(index_x2r_Faxa_swndr,n2)
        !?? = x2r_r%rAttr(index_x2r_Faxa_swndf,n2)
+	   rtmCTL%Tqsur(n) = x2r_r%rAttr(index_x2r_Flrl_Tqsur,n2)
+	   rtmCTL%Tqsub(n) = x2r_r%rAttr(index_x2r_Flrl_Tqsub,n2)
+	   THeat%Tqsur(n) = rtmCTL%Tqsur(n)
+	   THeat%Tqsub(n) = rtmCTL%Tqsub(n)
+
+	   THeat%forc_t(n) = x2r_r%rAttr(index_x2r_Sa_tbot,n2)
+	   THeat%forc_pbot(n) = x2r_r%rAttr(index_x2r_Sa_pbot,n2)
+	   tmp1 = x2r_r%rAttr(index_x2r_Sa_u   ,n2)
+	   tmp2 = x2r_r%rAttr(index_x2r_Sa_v   ,n2)
+	   THeat%forc_wind(n) = sqrt(tmp1*tmp1 + tmp2*tmp2)
+	   THeat%forc_lwrad(n)= x2r_r%rAttr(index_x2r_Faxa_lwdn ,n2)
+	   THeat%forc_solar(n)= x2r_r%rAttr(index_x2r_Faxa_swvdr,n2) + x2r_r%rAttr(index_x2r_Faxa_swvdf,n2) + &
+	                        x2r_r%rAttr(index_x2r_Faxa_swndr,n2) + x2r_r%rAttr(index_x2r_Faxa_swndf,n2)
 
     enddo
 

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -36,9 +36,15 @@ module rof_comp_mct
                                 index_x2r_Flrl_rofsur, index_x2r_Flrl_rofi, &
                                 index_x2r_Flrl_rofgwl, index_x2r_Flrl_rofsub, &
                                 index_x2r_Flrl_rofdto, &
+								index_x2r_Flrl_Tqsur, index_x2r_Flrl_Tqsub, &
+                                index_x2r_Sa_tbot, index_x2r_Sa_pbot, &
+                                index_x2r_Sa_u   , index_x2r_Sa_v   , &
+                                index_x2r_Sa_shum, &
+                                index_x2r_Faxa_lwdn , &
+                                index_x2r_Faxa_swvdr, index_x2r_Faxa_swvdf, &
+                                index_x2r_Faxa_swndr, index_x2r_Faxa_swndf, &
                                 index_r2x_Forr_rofl, index_r2x_Forr_rofi, &
                                 index_r2x_Flrr_flood, &
-								index_x2r_Flrl_Tqsur, index_x2r_Flrl_Tqsub, &
                                 index_r2x_Flrr_volr, index_r2x_Flrr_volrmch
                                 !index_r2x_Flrr_supply , index_r2x_Flrr_supplyfrac, index_x2r_Flrl_demand, 
   use mct_mod

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -355,6 +355,9 @@ contains
     nlend = seq_timemgr_StopAlarmIsOn( EClock )
     rstwr = seq_timemgr_RestartAlarmIsOn( EClock )
     !call advance_timestep()
+	write(iulog,*) 'wokao1, ', rstwr
+	write(iulog,*) 'wokao2, ', nlend
+	write(iulog,*) 'wokao3, ', rdate
     call Rtmrun(rstwr,nlend,rdate)
 
     ! Map roff data to MCT datatype (input is rtmCTL%runoff, output is r2x_r)

--- a/components/mosart/src/cpl/rof_cpl_indices.F90
+++ b/components/mosart/src/cpl/rof_cpl_indices.F90
@@ -31,16 +31,16 @@ module rof_cpl_indices
   integer, public :: index_x2r_Flrl_Tqsur  = 0  ! lnd->rof Temperature of surface runoff
   integer, public :: index_x2r_Flrl_Tqsub  = 0  ! lnd->rof Temperature of subsurface runoff
 !  integer, public :: index_x2r_Flrl_demand = 0  ! lnd->rof input total fluxes (<= 0)
-!  integer, public :: index_x2r_Sa_tbot = 0      ! atm->rof air temperature
-!  integer, public :: index_x2r_Sa_pbot = 0      ! atm->rof surface pressure
-!  integer, public :: index_x2r_Sa_u    = 0      ! atm->rof zonal velocity
-!  integer, public :: index_x2r_Sa_v    = 0      ! atm->rof merid velocity
-!  integer, public :: index_x2r_Sa_shum = 0      ! atm->rof specific humidity
-!  integer, public :: index_x2r_Faxa_lwdn  = 0   ! atm->rof longwave down flux
-!  integer, public :: index_x2r_Faxa_swvdr = 0   ! atm->rof shorwave visible direct flux
-!  integer, public :: index_x2r_Faxa_swvdf = 0   ! atm->rof shorwave visible diffus flux
-!  integer, public :: index_x2r_Faxa_swndr = 0   ! atm->rof shorwave near-ir direct flux
-!  integer, public :: index_x2r_Faxa_swndf = 0   ! atm->rof shorwave near-ir diffus flux
+  integer, public :: index_x2r_Sa_tbot = 0      ! atm->rof air temperature
+  integer, public :: index_x2r_Sa_pbot = 0      ! atm->rof surface pressure
+  integer, public :: index_x2r_Sa_u    = 0      ! atm->rof zonal velocity
+  integer, public :: index_x2r_Sa_v    = 0      ! atm->rof merid velocity
+  integer, public :: index_x2r_Sa_shum = 0      ! atm->rof specific humidity
+  integer, public :: index_x2r_Faxa_lwdn  = 0   ! atm->rof longwave down flux
+  integer, public :: index_x2r_Faxa_swvdr = 0   ! atm->rof shorwave visible direct flux
+  integer, public :: index_x2r_Faxa_swvdf = 0   ! atm->rof shorwave visible diffus flux
+  integer, public :: index_x2r_Faxa_swndr = 0   ! atm->rof shorwave near-ir direct flux
+  integer, public :: index_x2r_Faxa_swndf = 0   ! atm->rof shorwave near-ir diffus flux
 
   integer, public :: nflds_x2r = 0
 
@@ -103,16 +103,16 @@ contains
     index_x2r_Flrl_Tqsur  = mct_avect_indexra(avtmp,'Flrl_Tqsur')
     index_x2r_Flrl_Tqsub  = mct_avect_indexra(avtmp,'Flrl_Tqsub')
 !    index_x2r_Flrl_demand = mct_avect_indexra(avtmp,'Flrl_demand')
-!    index_x2r_Sa_tbot     = mct_avect_indexra(avtmp,'Sa_tbot')
-!    index_x2r_Sa_pbot     = mct_avect_indexra(avtmp,'Sa_pbot')
-!    index_x2r_Sa_u        = mct_avect_indexra(avtmp,'Sa_u')
-!    index_x2r_Sa_v        = mct_avect_indexra(avtmp,'Sa_v')
-!    index_x2r_Sa_shum     = mct_avect_indexra(avtmp,'Sa_shum')
-!    index_x2r_Faxa_lwdn   = mct_avect_indexra(avtmp,'Faxa_lwdn')
-!    index_x2r_Faxa_swvdr  = mct_avect_indexra(avtmp,'Faxa_swvdr')
-!    index_x2r_Faxa_swvdf  = mct_avect_indexra(avtmp,'Faxa_swvdf')
-!    index_x2r_Faxa_swndr  = mct_avect_indexra(avtmp,'Faxa_swndr')
-!    index_x2r_Faxa_swndf  = mct_avect_indexra(avtmp,'Faxa_swndf')
+    index_x2r_Sa_tbot     = mct_avect_indexra(avtmp,'Sa_tbot')
+    index_x2r_Sa_pbot     = mct_avect_indexra(avtmp,'Sa_pbot')
+    index_x2r_Sa_u        = mct_avect_indexra(avtmp,'Sa_u')
+    index_x2r_Sa_v        = mct_avect_indexra(avtmp,'Sa_v')
+    index_x2r_Sa_shum     = mct_avect_indexra(avtmp,'Sa_shum')
+    index_x2r_Faxa_lwdn   = mct_avect_indexra(avtmp,'Faxa_lwdn')
+    index_x2r_Faxa_swvdr  = mct_avect_indexra(avtmp,'Faxa_swvdr')
+    index_x2r_Faxa_swvdf  = mct_avect_indexra(avtmp,'Faxa_swvdf')
+    index_x2r_Faxa_swndr  = mct_avect_indexra(avtmp,'Faxa_swndr')
+    index_x2r_Faxa_swndf  = mct_avect_indexra(avtmp,'Faxa_swndf')
 
     nflds_x2r = mct_avect_nRattr(avtmp)
 

--- a/components/mosart/src/cpl/rof_cpl_indices.F90
+++ b/components/mosart/src/cpl/rof_cpl_indices.F90
@@ -28,6 +28,8 @@ module rof_cpl_indices
   integer, public :: index_x2r_Flrl_rofsub = 0  ! lnd->rof liquid subsurface runoff from land
   integer, public :: index_x2r_Flrl_rofdto = 0  ! lnd->rof liquid direct to ocean runoff
   integer, public :: index_x2r_Flrl_rofi  = 0   ! lnd->rof ice runoff forcing from land
+  integer, public :: index_x2r_Flrl_Tqsur  = 0  ! lnd->rof Temperature of surface runoff
+  integer, public :: index_x2r_Flrl_Tqsub  = 0  ! lnd->rof Temperature of subsurface runoff
 !  integer, public :: index_x2r_Flrl_demand = 0  ! lnd->rof input total fluxes (<= 0)
 !  integer, public :: index_x2r_Sa_tbot = 0      ! atm->rof air temperature
 !  integer, public :: index_x2r_Sa_pbot = 0      ! atm->rof surface pressure
@@ -98,6 +100,8 @@ contains
     index_x2r_Flrl_rofsub = mct_avect_indexra(avtmp,'Flrl_rofsub')
     index_x2r_Flrl_rofdto = mct_avect_indexra(avtmp,'Flrl_rofdto',perrwith='quiet')
     index_x2r_Flrl_rofi   = mct_avect_indexra(avtmp,'Flrl_rofi')
+    index_x2r_Flrl_Tqsur  = mct_avect_indexra(avtmp,'Flrl_Tqsur')
+    index_x2r_Flrl_Tqsub  = mct_avect_indexra(avtmp,'Flrl_Tqsub')
 !    index_x2r_Flrl_demand = mct_avect_indexra(avtmp,'Flrl_demand')
 !    index_x2r_Sa_tbot     = mct_avect_indexra(avtmp,'Sa_tbot')
 !    index_x2r_Sa_pbot     = mct_avect_indexra(avtmp,'Sa_pbot')

--- a/components/mosart/src/riverroute/MOSART_heat_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_heat_mod.F90
@@ -34,10 +34,10 @@ MODULE MOSART_heat_mod
             ! adjust surface runoff temperature estimated based on the top-layer soil temperature, i.e., no less than freezing point
             if(THeat%Tqsur(iunit) < 273.15_r8-TINYVALUE1) then
                 !write(unit=1821,fmt=*)  'Tqsub error at hillslopeHeat, ', iunit, THeat%Tqsur(iunit), THeat%Tqsub(iunit)
-				THeat%Tqsur(iunit) = 273.15_r8
+                THeat%Tqsur(iunit) = 273.15_r8
             !else
                 !write(unit=1822,fmt=*)  'Tqsur good at hillslopeHeat, ', iunit, THeat%Tqsur(iunit), THeat%Tqsub(iunit)
-			end if
+            end if
             
             THeat%Tqsub(iunit) = THeat%Tqsub(iunit)
             if(THeat%Tqsub(iunit) < 273.15_r8-TINYVALUE1) then
@@ -239,7 +239,7 @@ MODULE MOSART_heat_mod
             !  write(unit=1111,fmt="(i10, 6(f10.4), 2(e20.11))") iunit, THeat%Tr(iunit), THeat%forc_t(iunit), THeat%Tqsur(iunit), THeat%Tqsub(iunit), THeat%forc_lwrad(iunit), THeat%forc_solar(iunit), TRunoff%qsur(iunit,nt_nliq), TRunoff%qsub(iunit,nt_nliq)
             !  write(unit=1112,fmt="(i10, 4(f10.4), 2(e20.11))") iunit, THeat%Tr(iunit), THeat%forc_t(iunit), THeat%forc_lwrad(iunit), THeat%forc_solar(iunit), THeat%deltaH_r(iunit), THeat%deltaM_r(iunit)
             !end if
-			!if(THeat%Tr(iunit) < 200._r8) then
+            !if(THeat%Tr(iunit) < 200._r8) then
             !if(iunit == 98784) then
             !  write(unit=1113,fmt="(i10, 3(f10.4))") iunit, THeat%Tr(iunit), THeat%forc_lwrad(iunit), THeat%forc_solar(iunit)
             !  write(unit=1112,fmt="(i10, 3(e20.11))") iunit, Mr, THeat%deltaH_r(iunit), THeat%deltaM_r(iunit)
@@ -259,30 +259,30 @@ MODULE MOSART_heat_mod
         THeat%Tr(iunit) = THeat%Tt(iunit)
     end subroutine mainchannelTemp_simple
 
-	subroutine reservoirHeat(iunit, theDeltaT)
-	! !DESCRIPTION: calculate the net heat balance of reservoir. invoked after the regulation subroutine
-	! simplified version as of 09/2014, now assuming the flow regulation won't modify the release water temperature directly
-	! to be extended later, e.g., incorporating the stratification processes
-		implicit none
-		integer, intent(in) :: iunit
+    subroutine reservoirHeat(iunit, theDeltaT)
+    ! !DESCRIPTION: calculate the net heat balance of reservoir. invoked after the regulation subroutine
+    ! simplified version as of 09/2014, now assuming the flow regulation won't modify the release water temperature directly
+    ! to be extended later, e.g., incorporating the stratification processes
+        implicit none
+        integer, intent(in) :: iunit
         real(r8), intent(in) :: theDeltaT
-		!if(TUnit%indexDown(iunit) > 0) then
-			THeat%Ha_rout(iunit) = -cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
-			!THeat%Ha_rout(iunit) = THeat%Ha_rout(iunit) - cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
-		!else
-		!	THeat%Ha_rout(iunit) = 0._r8
-		!end if
-    end subroutine reservoirHeat	
+        !if(TUnit%indexDown(iunit) > 0) then
+            THeat%Ha_rout(iunit) = -cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
+            !THeat%Ha_rout(iunit) = THeat%Ha_rout(iunit) - cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
+        !else
+        !    THeat%Ha_rout(iunit) = 0._r8
+        !end if
+    end subroutine reservoirHeat    
 
-	subroutine reservoirTemp(iunit)
-	! !DESCRIPTION: calculate the water temperature of reservoir.
-	! simplified version as of 09/2014, to be extended later
-		implicit none
-		integer, intent(in) :: iunit
+    subroutine reservoirTemp(iunit)
+    ! !DESCRIPTION: calculate the water temperature of reservoir.
+    ! simplified version as of 09/2014, to be extended later
+        implicit none
+        integer, intent(in) :: iunit
         
-        		
-    end subroutine reservoirTemp		
-	
+                
+    end subroutine reservoirTemp        
+    
     function cr_swrad(Hswin_, Aw_) result(Hsw_)
     ! closure relationship for net short-wave solar radiation
         implicit none

--- a/components/mosart/src/riverroute/MOSART_heat_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_heat_mod.F90
@@ -29,19 +29,14 @@ MODULE MOSART_heat_mod
         
         integer, intent(in) :: iunit
         real(r8), intent(in) :: theDeltaT        
-        !if(TUnit%fdir(iunit) >= 0 .and. TUnit%areaTotal(iunit) > TINYVALUE1) then
             THeat%Tqsur(iunit) = THeat%Tqsur(iunit)
             ! adjust surface runoff temperature estimated based on the top-layer soil temperature, i.e., no less than freezing point
             if(THeat%Tqsur(iunit) < 273.15_r8-TINYVALUE1) then
-                !write(unit=1821,fmt=*)  'Tqsub error at hillslopeHeat, ', iunit, THeat%Tqsur(iunit), THeat%Tqsub(iunit)
                 THeat%Tqsur(iunit) = 273.15_r8
-            !else
-                !write(unit=1822,fmt=*)  'Tqsur good at hillslopeHeat, ', iunit, THeat%Tqsur(iunit), THeat%Tqsub(iunit)
             end if
             
             THeat%Tqsub(iunit) = THeat%Tqsub(iunit)
             if(THeat%Tqsub(iunit) < 273.15_r8-TINYVALUE1) then
-                !write(unit=1822,fmt=*)  'Tqsub error at hillslopeHeat, ', iunit, THeat%Tqsur(iunit), THeat%Tqsub(iunit)
                 THeat%Tqsub(iunit) = 273.15_r8
             end if
         !end if
@@ -71,7 +66,6 @@ MODULE MOSART_heat_mod
             THeat%deltaH_t(iunit) = theDeltaT * (THeat%Hs_t(iunit) + THeat%Hl_t(iunit) + THeat%He_t(iunit) + THeat%Hc_t(iunit) + THeat%Hh_t(iunit))
             ! change of energy due to advective heat flux
             THeat%deltaM_t(iunit) = theDeltaT * (THeat%Ha_h2t(iunit)-cr_advectheat(Qsur + Qsub, THeat%Tt(iunit)))
-        !end if
     end subroutine subnetworkHeat
 
     subroutine subnetworkHeat_simple(iunit, theDeltaT)

--- a/components/mosart/src/riverroute/MOSART_heat_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_heat_mod.F90
@@ -1,0 +1,570 @@
+!
+MODULE MOSART_heat_mod
+! Description: core code of MOSART-heat. 
+! 
+! Developed by Hongyi Li, 12/29/2015. 
+! REVISION HISTORY:
+! April 2019, migrated to E3SM
+!-----------------------------------------------------------------------
+    
+! !USES:
+    use shr_kind_mod  , only : r8 => shr_kind_r8, SHR_KIND_CL
+    use shr_const_mod , only : SHR_CONST_REARTH, SHR_CONST_PI
+    use shr_const_mod , only : cpliq => SHR_CONST_CPFW, denh2o => SHR_CONST_RHOFW, denice => SHR_CONST_RHOICE, sb => SHR_CONST_STEBOL
+    use RunoffMod , only : Tctl, TUnit, TRunoff, THeat, TPara
+    use RunoffMod , only : rtmCTL
+    use rof_cpl_indices, only : nt_rtm, rtm_tracers, nt_nliq, nt_nice
+    implicit none
+    real(r8), parameter :: TINYVALUE1 = 1.0e-14_r8  ! double precision variable has a significance of about 16 decimal digits
+    real(r8), parameter :: Hthreshold = 0.05_r8  ! threshold value of channel water depth, if lower than this, headwater temp is calculated using the simplified formula, instead of heat balance equation
+    real(r8), parameter :: WaterAreaRatio = 0.125_r8  ! t
+  
+
+! !PUBLIC MEMBER FUNCTIONS:
+    contains
+    
+    subroutine hillslopeHeat(iunit, theDeltaT)
+    ! !DESCRIPTION: calculate the temperature of surface and subsurface runoff.
+        implicit none
+        
+        integer, intent(in) :: iunit
+        real(r8), intent(in) :: theDeltaT        
+        !if(TUnit%fdir(iunit) >= 0 .and. TUnit%areaTotal(iunit) > TINYVALUE1) then
+            THeat%Tqsur(iunit) = THeat%Tqsur(iunit)
+            ! adjust surface runoff temperature estimated based on the top-layer soil temperature, i.e., no less than freezing point
+            if(THeat%Tqsur(iunit) < 273.15_r8-TINYVALUE1) then
+                !write(unit=1821,fmt=*)  'Tqsub error at hillslopeHeat, ', iunit, THeat%Tqsur(iunit), THeat%Tqsub(iunit)
+				THeat%Tqsur(iunit) = 273.15_r8
+            !else
+                !write(unit=1822,fmt=*)  'Tqsur good at hillslopeHeat, ', iunit, THeat%Tqsur(iunit), THeat%Tqsub(iunit)
+			end if
+            
+            THeat%Tqsub(iunit) = THeat%Tqsub(iunit)
+            if(THeat%Tqsub(iunit) < 273.15_r8-TINYVALUE1) then
+                !write(unit=1822,fmt=*)  'Tqsub error at hillslopeHeat, ', iunit, THeat%Tqsur(iunit), THeat%Tqsub(iunit)
+                THeat%Tqsub(iunit) = 273.15_r8
+            end if
+        !end if
+    end subroutine hillslopeHeat
+    
+    subroutine subnetworkHeat(iunit, theDeltaT)
+    ! !DESCRIPTION: calculate the net heat balance of subnetwork channel.
+    use shr_sys_mod , only : shr_sys_flush
+        implicit none
+        integer, intent(in) :: iunit
+        real(r8), intent(in) :: theDeltaT    
+        
+        real(r8) :: Qsur, Qsub ! flow rate of surface and subsurface runoff separately
+        !if(TUnit%fdir(iunit) >= 0 .and. TUnit%areaTotal(iunit) > TINYVALUE1 .and. TUnit%tlen(iunit) >= TINYVALUE1) then
+                TRunoff%tarea(iunit,nt_nliq) = WaterAreaRatio*TUnit%twidth(iunit) * TUnit%tlen(iunit)
+                THeat%Hs_t(iunit) = cr_swrad(THeat%forc_solar(iunit), TRunoff%tarea(iunit,nt_nliq))
+                THeat%Hl_t(iunit) = cr_lwrad(THeat%forc_lwrad(iunit), THeat%Tt(iunit), TRunoff%tarea(iunit,nt_nliq))
+                THeat%He_t(iunit) = cr_latentheat(THeat%forc_t(iunit), THeat%forc_pbot(iunit), THeat%forc_vp(iunit), THeat%forc_wind(iunit), 1._r8, THeat%Tt(iunit), TRunoff%tarea(iunit,nt_nliq))
+                THeat%Hh_t(iunit) = cr_sensibleheat(THeat%forc_t(iunit), THeat%forc_pbot(iunit), THeat%forc_wind(iunit), 1._r8, THeat%Tt(iunit), TRunoff%tarea(iunit,nt_nliq))
+                THeat%Hc_t(iunit) = cr_condheat(THeat%Hs_t(iunit),THeat%Hl_t(iunit),TRunoff%tarea(iunit,nt_nliq))
+
+                Qsur = (-TRunoff%ehout(iunit,nt_nliq)-TRunoff%ehout(iunit,nt_nice)) * TUnit%area(iunit) * TUnit%frac(iunit)
+                Qsub = TRunoff%qsub(iunit,nt_nliq) * TUnit%area(iunit) * TUnit%frac(iunit)
+                THeat%Ha_h2t(iunit) = cr_advectheat(Qsur, THeat%Tqsur(iunit)) + cr_advectheat(Qsub, THeat%Tqsub(iunit))
+                THeat%Ha_t2r(iunit) = -cr_advectheat(abs(TRunoff%etout(iunit,nt_nliq)+TRunoff%etout(iunit,nt_nice)), THeat%Tt(iunit))
+            ! change of energy due to heat exchange with the environment
+            THeat%deltaH_t(iunit) = theDeltaT * (THeat%Hs_t(iunit) + THeat%Hl_t(iunit) + THeat%He_t(iunit) + THeat%Hc_t(iunit) + THeat%Hh_t(iunit))
+            ! change of energy due to advective heat flux
+            THeat%deltaM_t(iunit) = theDeltaT * (THeat%Ha_h2t(iunit)-cr_advectheat(Qsur + Qsub, THeat%Tt(iunit)))
+        !end if
+    end subroutine subnetworkHeat
+
+    subroutine subnetworkHeat_simple(iunit, theDeltaT)
+    ! !DESCRIPTION: calculate the net heat balance of subnetwork channel.
+    use shr_sys_mod , only : shr_sys_flush
+        implicit none
+        integer, intent(in) :: iunit
+        real(r8), intent(in) :: theDeltaT    
+        
+        real(r8) :: Qsur, Qsub ! flow rate of surface and subsurface runoff separately
+        !if(TUnit%fdir(iunit) >= 0 .and. TUnit%areaTotal(iunit) > TINYVALUE1) then
+                THeat%Hs_t(iunit) = 0._r8
+                THeat%Hl_t(iunit) = 0._r8
+                THeat%He_t(iunit) = 0._r8
+                THeat%Hh_t(iunit) = 0._r8
+                THeat%Hc_t(iunit) = 0._r8
+
+                THeat%Ha_h2t(iunit) = 0._r8
+                THeat%Ha_t2r(iunit) = -cr_advectheat(abs(TRunoff%etout(iunit,nt_nliq)+TRunoff%etout(iunit,nt_nice)), THeat%Tt(iunit))
+            ! change of energy due to heat exchange with the environment
+            THeat%deltaH_t(iunit) = theDeltaT * (THeat%Hs_t(iunit) + THeat%Hl_t(iunit) + THeat%He_t(iunit) + THeat%Hc_t(iunit) + THeat%Hh_t(iunit))
+            ! change of energy due to advective heat flux
+            THeat%deltaM_t(iunit) = theDeltaT * (THeat%Ha_h2t(iunit)-cr_advectheat(Qsur + Qsub, THeat%Tt(iunit)))
+        !end if
+    end subroutine subnetworkHeat_simple
+
+    
+    subroutine mainchannelHeat(iunit, theDeltaT)
+    ! !DESCRIPTION: calculate the net heat balance of main channel.
+        use shr_sys_mod , only : shr_sys_flush
+        implicit none
+        integer, intent(in) :: iunit
+        real(r8), intent(in) :: theDeltaT    
+        integer    :: k
+        real(r8) :: Ha_temp, Ha_temp1, Ha_temp2
+        THeat%Ha_rin(iunit) = 0._r8
+        !if(TUnit%fdir(iunit) >= 0 .and. TUnit%areaTotal(iunit) > TINYVALUE1 .and. TUnit%rlen(iunit) >= TINYVALUE1) then
+                if(TRunoff%yr(iunit,nt_nliq) > TUnit%rdepth(iunit)) then ! TODO: the cases w/o flooding should be treated differently, here treated the same for now
+                    !TRunoff%rarea(iunit,nt_nliq) = WaterAreaRatio*TUnit%rwidth0(iunit) * TUnit%rlen(iunit)
+                    TRunoff%rarea(iunit,nt_nliq) = WaterAreaRatio*TUnit%rwidth(iunit) * TUnit%rlen(iunit)
+                else
+                    TRunoff%rarea(iunit,nt_nliq) = WaterAreaRatio*TUnit%rwidth(iunit) * TUnit%rlen(iunit)
+                end if
+                THeat%Hs_r(iunit) = cr_swrad(THeat%forc_solar(iunit), TRunoff%rarea(iunit,nt_nliq))
+                THeat%Hl_r(iunit) = cr_lwrad(THeat%forc_lwrad(iunit), THeat%Tr(iunit), TRunoff%rarea(iunit,nt_nliq))
+                THeat%He_r(iunit) = cr_latentheat(THeat%forc_t(iunit), THeat%forc_pbot(iunit), THeat%forc_vp(iunit), THeat%forc_wind(iunit), 1._r8, THeat%Tr(iunit), TRunoff%rarea(iunit,nt_nliq))
+                THeat%Hh_r(iunit) = cr_sensibleheat(THeat%forc_t(iunit), THeat%forc_pbot(iunit), THeat%forc_wind(iunit), 1._r8, THeat%Tr(iunit), TRunoff%rarea(iunit,nt_nliq))
+                THeat%Hc_r(iunit) = cr_condheat(THeat%Hs_r(iunit),THeat%Hl_r(iunit),TRunoff%rarea(iunit,nt_nliq))
+                
+                !do k=1,TUnit%nUp(iunit)
+                !    THeat%Ha_rin(iunit) = THeat%Ha_rin(iunit) - THeat%Ha_rout(TUnit%iUp(iunit,k))
+                !end do
+                
+                THeat%Ha_rin(iunit) = THeat%Ha_rin(iunit) - THeat%Ha_eroutUp(iunit) 
+                !if(TUnit%indexDown(iunit) > 0) then
+                    THeat%Ha_rout(iunit) = -cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
+                !else
+                !    THeat%Ha_rout(iunit) = 0._r8
+                !end if
+ 
+            ! change of energy due to heat exchange with the environment
+            THeat%deltaH_r(iunit) = theDeltaT * (THeat%Hs_r(iunit) + THeat%Hl_r(iunit) + THeat%He_r(iunit) + THeat%Hc_r(iunit) + THeat%Hh_r(iunit))
+            ! change of energy due to advective heat fluxes. Note here the advective heat flux is calculated differently from that by Huan Wu or van Vliet et al.
+            ! Their routing model is based on source-to-sink, while our model is explicitly tracing inflow from each upstream channel.
+            Ha_temp = cr_advectheat(TRunoff%erin(iunit,nt_nliq)+TRunoff%erin(iunit,nt_nice)+TRunoff%erlateral(iunit,nt_nliq)+TRunoff%erlateral(iunit,nt_nice),THeat%Tr(iunit))
+            THeat%deltaM_r(iunit) = theDeltaT * (THeat%Ha_lateral(iunit) + THeat%Ha_rin(iunit) - Ha_temp)
+            
+            !if(iunit == 85088) then
+            !  write(unit=2111,fmt="(i10, 6(e16.4))") iunit, THeat%Hs_r(iunit), THeat%Hl_r(iunit), THeat%He_r(iunit), THeat%Hc_r(iunit), THeat%Hh_r(iunit), TRunoff%rarea(iunit,nt_nliq)
+            !  write(unit=2112,fmt="(i10, f10.4, 6(e14.4))") iunit, THeat%Tr(iunit), THeat%ha_lateral(iunit), THeat%Ha_rin(iunit), Ha_temp, TRunoff%erin(iunit,nt_nliq), THeat%Ha_rout(iunit), TRunoff%erout(iunit,nt_nliq)
+            !end if
+        !end if
+    end subroutine mainchannelHeat
+
+    subroutine mainchannelHeat_simple(iunit, theDeltaT)
+    ! !DESCRIPTION: calculate the net heat balance of main channel.
+        use shr_sys_mod , only : shr_sys_flush
+        implicit none
+        integer, intent(in) :: iunit
+        real(r8), intent(in) :: theDeltaT    
+        integer    :: k
+        real(r8) :: Ha_temp, Ha_temp1, Ha_temp2
+        THeat%Ha_rin(iunit) = 0._r8
+        !if(TUnit%fdir(iunit) >= 0 .and. TUnit%areaTotal(iunit) > TINYVALUE1) then
+                THeat%Hs_r(iunit) = 0._r8
+                THeat%Hl_r(iunit) = 0._r8
+                THeat%He_r(iunit) = 0._r8
+                THeat%Hh_r(iunit) = 0._r8
+                THeat%Hc_r(iunit) = 0._r8
+                THeat%Ha_rin(iunit) = 0._r8
+                !if(TUnit%indexDown(iunit) > 0) then
+                    THeat%Ha_rout(iunit) = -cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
+                !else
+                    !THeat%Ha_rout(iunit) = 0._r8
+                !end if                
+
+            ! change of energy due to heat exchange with the environment
+            THeat%deltaH_r(iunit) = theDeltaT * (THeat%Hs_r(iunit) + THeat%Hl_r(iunit) + THeat%He_r(iunit) + THeat%Hc_r(iunit) + THeat%Hh_r(iunit))
+            ! change of energy due to advective heat fluxes. Note here the advective heat flux is calculated differently from that by Huan Wu or van Vliet et al.
+            ! Their routing model is based on source-to-sink, while our model is explicitly tracing inflow from each upstream channel.
+            Ha_temp = cr_advectheat(TRunoff%erin(iunit,nt_nliq)+TRunoff%erin(iunit,nt_nice)+TRunoff%erlateral(iunit,nt_nliq)+TRunoff%erlateral(iunit,nt_nice),THeat%Tr(iunit))
+            THeat%deltaM_r(iunit) = theDeltaT * (THeat%ha_lateral(iunit) + THeat%Ha_rin(iunit) - Ha_temp)
+        !end if
+    end subroutine mainchannelHeat_simple
+    
+    subroutine subnetworkTemp(iunit)
+    ! !DESCRIPTION: calculate the water temperature of subnetwork channel.
+        implicit none
+        integer, intent(in) :: iunit
+        
+        real(r8) :: Mt  !mass of water (Kg)
+        real(r8) :: Ttmp1, Ttmp2  !
+        
+            if((TRunoff%wt(iunit,nt_nliq)+TRunoff%wt(iunit,nt_nice)) > TINYVALUE1  .and. THeat%forc_t(iunit) > 200._r8) then
+                Mt = TRunoff%wt(iunit,nt_nliq) * denh2o + TRunoff%wt(iunit,nt_nice) * denice
+                THeat%Tt(iunit) = THeat%Tt(iunit) + (THeat%deltaH_t(iunit)+THeat%deltaM_t(iunit)) / (Mt * cpliq)
+            else
+                if(TRunoff%qsur(iunit,nt_nliq)+TRunoff%qsur(iunit,nt_nice) > TINYVALUE1) then
+                    THeat%Tt(iunit) = THeat%Tqsur(iunit) * (TRunoff%qsur(iunit,nt_nliq)+TRunoff%qsur(iunit,nt_nice)) + THeat%Tqsub(iunit) * (TRunoff%qsub(iunit,nt_nliq)+TRunoff%qsub(iunit,nt_nice))
+                    THeat%Tt(iunit) = THeat%Tt(iunit)/(TRunoff%qsur(iunit,nt_nliq)+TRunoff%qsur(iunit,nt_nice)+TRunoff%qsub(iunit,nt_nliq)+TRunoff%qsub(iunit,nt_nice))
+                else
+                    THeat%Tt(iunit) = THeat%Tqsur(iunit)
+                end if
+            end if
+
+        
+    end subroutine subnetworkTemp
+
+    subroutine subnetworkTemp_simple(iunit)
+    ! !DESCRIPTION: calculate the water temperature of subnetwork channel.
+        implicit none
+        integer, intent(in) :: iunit
+        
+        real(r8) :: Mt  !mass of water (Kg)
+        real(r8) :: Ttmp1, Ttmp2  !
+        
+        if(TRunoff%qsur(iunit,nt_nliq)+TRunoff%qsub(iunit,nt_nliq) > TINYVALUE1) then
+            THeat%Tt(iunit) = THeat%Tqsur(iunit) * (TRunoff%qsur(iunit,nt_nliq)+TRunoff%qsur(iunit,nt_nice)) + THeat%Tqsub(iunit) * (TRunoff%qsub(iunit,nt_nliq)+TRunoff%qsub(iunit,nt_nice))
+            THeat%Tt(iunit) = THeat%Tt(iunit)/(TRunoff%qsur(iunit,nt_nliq)+TRunoff%qsur(iunit,nt_nice)+TRunoff%qsub(iunit,nt_nliq)+TRunoff%qsub(iunit,nt_nice))
+        else
+            THeat%Tt(iunit) = THeat%Tqsur(iunit)
+        end if
+    end subroutine subnetworkTemp_simple
+    
+    
+    subroutine mainchannelTemp(iunit)
+    ! !DESCRIPTION: calculate the water temperature of subnetwork channel.
+    use shr_sys_mod , only : shr_sys_flush
+        implicit none
+        integer, intent(in) :: iunit
+        
+        real(r8) :: Mr  !mass of water (Kg)
+        real(r8) :: Ttmp1, Ttmp2  !
+        
+            if((TRunoff%wr(iunit,nt_nliq)+TRunoff%wr(iunit,nt_nice)) > TINYVALUE1 .and. THeat%forc_t(iunit) > 200._r8) then
+                Mr = TRunoff%wr(iunit,nt_nliq) * denh2o + TRunoff%wr(iunit,nt_nice) * denice
+                THeat%Tr(iunit) = THeat%Tr(iunit) + (THeat%deltaH_r(iunit)+THeat%deltaM_r(iunit)) / (Mr * cpliq)
+            else
+                THeat%Tr(iunit) = THeat%Tt(iunit)
+            end if
+            
+            !if(THeat%Tr(iunit) < 200._r8) then
+            ! if(iunit == 85088) then
+                
+            !  write(unit=1111,fmt="(i10, 6(f10.4), 2(e20.11))") iunit, THeat%Tr(iunit), THeat%forc_t(iunit), THeat%Tqsur(iunit), THeat%Tqsub(iunit), THeat%forc_lwrad(iunit), THeat%forc_solar(iunit), TRunoff%qsur(iunit,nt_nliq), TRunoff%qsub(iunit,nt_nliq)
+            !  write(unit=1112,fmt="(i10, 4(f10.4), 2(e20.11))") iunit, THeat%Tr(iunit), THeat%forc_t(iunit), THeat%forc_lwrad(iunit), THeat%forc_solar(iunit), THeat%deltaH_r(iunit), THeat%deltaM_r(iunit)
+            !end if
+			!if(THeat%Tr(iunit) < 200._r8) then
+            !if(iunit == 98784) then
+            !  write(unit=1113,fmt="(i10, 3(f10.4))") iunit, THeat%Tr(iunit), THeat%forc_lwrad(iunit), THeat%forc_solar(iunit)
+            !  write(unit=1112,fmt="(i10, 3(e20.11))") iunit, Mr, THeat%deltaH_r(iunit), THeat%deltaM_r(iunit)
+            !end if
+        
+    end subroutine mainchannelTemp
+
+    subroutine mainchannelTemp_simple(iunit)
+    ! !DESCRIPTION: calculate the water temperature of subnetwork channel.
+    use shr_sys_mod , only : shr_sys_flush
+        implicit none
+        integer, intent(in) :: iunit
+        
+        real(r8) :: Mr  !mass of water (Kg)
+        real(r8) :: Ttmp1, Ttmp2  !
+        
+        THeat%Tr(iunit) = THeat%Tt(iunit)
+    end subroutine mainchannelTemp_simple
+
+	subroutine reservoirHeat(iunit, theDeltaT)
+	! !DESCRIPTION: calculate the net heat balance of reservoir. invoked after the regulation subroutine
+	! simplified version as of 09/2014, now assuming the flow regulation won't modify the release water temperature directly
+	! to be extended later, e.g., incorporating the stratification processes
+		implicit none
+		integer, intent(in) :: iunit
+        real(r8), intent(in) :: theDeltaT
+		!if(TUnit%indexDown(iunit) > 0) then
+			THeat%Ha_rout(iunit) = -cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
+			!THeat%Ha_rout(iunit) = THeat%Ha_rout(iunit) - cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
+		!else
+		!	THeat%Ha_rout(iunit) = 0._r8
+		!end if
+    end subroutine reservoirHeat	
+
+	subroutine reservoirTemp(iunit)
+	! !DESCRIPTION: calculate the water temperature of reservoir.
+	! simplified version as of 09/2014, to be extended later
+		implicit none
+		integer, intent(in) :: iunit
+        
+        		
+    end subroutine reservoirTemp		
+	
+    function cr_swrad(Hswin_, Aw_) result(Hsw_)
+    ! closure relationship for net short-wave solar radiation
+        implicit none
+        real(r8), intent(in) :: Hswin_, Aw_  ! incoming short-wave radiation, surface area
+        real(r8) :: Hsw_ ! [J/s]
+        
+        real(r8) :: Hswout_  ! short-wave radiation reflected by the water
+        Hswout_ = 0.03_r8 * Hswin_  ! 3% of the incoming short-wave radiation [Wu et al., 2012; Herbert et al., 2011]
+        Hsw_ = Hswin_ - Hswout_
+        Hsw_ = Hsw_ * Aw_
+        
+        return
+    end function cr_swrad 
+
+    function cr_lwrad(Hlwin_, Tw_, Aw_) result(Hlw_)
+    ! closure relationship for net long-wave radiation
+        implicit none
+        real(r8), intent(in) :: Hlwin_, Tw_, Aw_  ! incoming atmos. long-wave radiation, water temperature (kelvin), surface area (m2)
+        real(r8) :: Hlw_ ! [J/s]
+        
+        real(r8) :: Hlwout_  ! long-wave radiation emitted by the water
+        Hlwout_ = 0.97_r8 * sb * Tw_**4
+        Hlw_ = Hlwin_ - Hlwout_
+        Hlw_ = Hlw_ * Aw_
+        
+        return
+    end function cr_lwrad 
+
+    function cr_latentheat(Ta_, Pbot_, e_, U_, F_, Tw_, Aw_) result(He_)
+    ! closure relationship for latent heat flux, [Wu et al., 2012]
+        implicit none
+        real(r8), intent(in) :: Ta_, Pbot_  ! air temperature (k), surface atmospheric pressure (pa)
+        real(r8), intent(in) :: e_, U_, Tw_ ! atmos. vapor pressure (pa), wind speed (m/s), 
+        real(r8), intent(in) :: F_, Aw_ ! dimensionless coefficient for the wind shltering by riparian vegetation, , surface area (m2)
+        real(r8) :: He_ ! [J/s]
+        
+        real(r8) :: esat_  ! atmospheric saturated vapor pressure at certain temperature
+        real(r8) :: esdT, qs, qsdT  ! d(es)/d(T), humidity (kg/kg), d(qs)/d(T) 
+        real(r8) :: Kl_    ! empirical coefficient for the turbulent exchange of water vapor (mm/d/hpa)
+        real(r8) :: Le_    ! latent heat of vaporization (J/Kg)
+        real(r8) :: Evap_     ! evaporation rate (mm/d)
+        
+        call QSat(Ta_, Pbot_, esat_, esdT, qs, qsdT)        
+        
+        Kl_ = 0.211_r8 + 0.103_r8 * U_ * F_
+        Le_ = 2499.64_r8 - 2.51_r8 * (Tw_-273.15_r8)
+        Evap_  = Kl_ * (esat_ - e_)/100._r8  ! 100 here is for conversion from Pa to hPa
+        He_ = -denh2o * Evap_ * Le_ / (86.4e6)
+        He_ = He_ * Aw_
+        
+        return
+    end function cr_latentheat
+    
+    function cr_sensibleheat(Ta_, Pbot_, U_, F_, Tw_, Aw_) result(Hh_)
+    ! closure relationship for sensible heat flux, [Wu et al., 2012]
+        implicit none
+        real(r8), intent(in) :: Ta_, Pbot_  ! air temperature (k), surface atmospheric pressure (pa)
+        real(r8), intent(in) :: U_, Tw_ ! wind speed (m/s), water temperature (K)
+        real(r8), intent(in) :: F_ , Aw_ ! dimensionless coefficient for the wind shltering by riparian vegetation, surface area (m2)
+        real(r8) :: Hh_ ! [J/s]
+        
+        real(r8) :: Kl_    ! empirical coefficient for the turbulent exchange of water vapor (mm/d/hpa)
+        real(r8) :: Le_    ! latent heat of vaporization (J/Kg)
+        real(r8) :: gamma = 0.655_r8  ! psychrometric constant at normal pressure, 0.655 hPa/Celcus
+        real(r8) :: Pbot0 = 1013.25_r8 ! normal atmosphere pressure (hpa)
+        
+        Kl_ = 0.211_r8 + 0.103_r8 * U_ * F_
+        Le_ = 2499.64_r8 - 2.51_r8 * (Tw_-273.15_r8)
+        Hh_ = -gamma * (Pbot_/100._r8/Pbot0) * Kl_ * Le_ * (Tw_ - Ta_) * denh2o/(86.4e6)
+        Hh_ = Hh_ * Aw_
+        
+        return
+    end function cr_sensibleheat
+    
+    function cr_condheat(Hsw_, Hlw_, Aw_) result(Hc_)
+    ! closure relationship for conductive heat flux
+        implicit none
+        real(r8), intent(in) :: Hsw_,Hlw_, Aw_  ! net short-wave radiation, surface area (m2)
+        real(r8) :: Hc_ ! [J/s]
+        
+        Hc_ = 0.05_r8 * (Hsw_ + Hlw_)  !  [Wu et al., 2012]
+        
+        return
+    end function cr_condheat 
+    
+    function cr_advectheat(Qin_, Twin_) result(Ha_)
+    ! closure relationship for advective heat flux, assuming reference temperature (to define internal energy) is zero
+        implicit none
+        real(r8), intent(in) :: Qin_, Twin_ ! rate of water inflow (m3/s), temperature of water  inflow (K),
+        real(r8) :: Ha_        ! conductive heat flux (J/s)
+        
+        Ha_ = denh2o * cpliq * Qin_ * Twin_
+        
+        return
+    end function cr_advectheat 
+    
+    function cr_S_curve(iunit_,Ta_) result(Tw_)
+    ! closure relationship to calculate water temperature based on the linear relationship proposed by Stefan and Preudhomme (1993)
+        implicit none
+        integer, intent(in) :: iunit_ ! 
+        real(r8), intent(in) :: Ta_ ! temperature of air (Kelvin),
+        real(r8) :: Tw_        ! temperature of water (Kelvin)
+
+        Tw_ = 5.0_r8 + 0.75_r8 * (Ta_ - 273.15_r8) + 273.15_r8
+    
+        return
+    end function cr_S_curve
+
+    function cr_S_curve_bkp(iunit_,Ta_) result(Tw_)
+    ! closure relationship to calculate water temperature based on the S-curve 
+        implicit none
+        integer, intent(in) :: iunit_ ! 
+        real(r8), intent(in) :: Ta_ ! temperature of air (Kelvin),
+        real(r8) :: Tw_        ! temperature of water (Kelvin)
+
+        real(r8) :: Ttmp1, Ttmp2  !
+        Ttmp1 = TPara%t_alpha(iunit_) - TPara%t_mu(iunit_)
+        Ttmp2 = 1._r8 + exp(TPara%t_gamma(iunit_)*(TPara%t_beta(iunit_) - (Ta_-273.15_r8)))
+        Tw_ = TPara%t_mu(iunit_) + Ttmp1/Ttmp2 + 273.15_r8
+        if(Tw_ < 273.15_r8) then
+               Tw_ = 273.15_r8
+        end if
+    
+        return
+    end function cr_S_curve_bkp
+
+!-----------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE: QSat
+!
+! !INTERFACE:
+  subroutine QSat (T, p, es, esdT, qs, qsdT)
+!
+! !DESCRIPTION:
+! Computes saturation mixing ratio and the change in saturation
+! mixing ratio with respect to temperature.
+! Reference:  Polynomial approximations from:
+!             Piotr J. Flatau, et al.,1992:  Polynomial fits to saturation
+!             vapor pressure.  Journal of Applied Meteorology, 31, 1507-1513.
+!
+! !USES:
+    use shr_kind_mod , only: r8 => shr_kind_r8
+    use shr_const_mod, only: SHR_CONST_TKFRZ
+!
+! !ARGUMENTS:
+    implicit none
+    real(r8), intent(in)  :: T        ! temperature (K)
+    real(r8), intent(in)  :: p        ! surface atmospheric pressure (pa)
+    real(r8), intent(out) :: es       ! vapor pressure (pa)
+    real(r8), intent(out) :: esdT     ! d(es)/d(T)
+    real(r8), intent(out) :: qs       ! humidity (kg/kg)
+    real(r8), intent(out) :: qsdT     ! d(qs)/d(T)
+!
+! !CALLED FROM:
+! subroutine Biogeophysics1 in module Biogeophysics1Mod
+! subroutine BiogeophysicsLake in module BiogeophysicsLakeMod
+! subroutine CanopyFluxesMod CanopyFluxesMod
+!
+! !REVISION HISTORY:
+! 15 September 1999: Yongjiu Dai; Initial code
+! 15 December 1999:  Paul Houser and Jon Radakovich; F90 Revision
+!
+!
+! !LOCAL VARIABLES:
+!EOP
+!
+    real(r8) :: T_limit
+    real(r8) :: td,vp,vp1,vp2
+!
+! For water vapor (temperature range 0C-100C)
+!
+    real(r8), parameter :: a0 =  6.11213476_r8
+    real(r8), parameter :: a1 =  0.444007856_r8
+    real(r8), parameter :: a2 =  0.143064234e-01_r8
+    real(r8), parameter :: a3 =  0.264461437e-03_r8
+    real(r8), parameter :: a4 =  0.305903558e-05_r8
+    real(r8), parameter :: a5 =  0.196237241e-07_r8
+    real(r8), parameter :: a6 =  0.892344772e-10_r8
+    real(r8), parameter :: a7 = -0.373208410e-12_r8
+    real(r8), parameter :: a8 =  0.209339997e-15_r8
+!
+! For derivative:water vapor
+!
+    real(r8), parameter :: b0 =  0.444017302_r8
+    real(r8), parameter :: b1 =  0.286064092e-01_r8
+    real(r8), parameter :: b2 =  0.794683137e-03_r8
+    real(r8), parameter :: b3 =  0.121211669e-04_r8
+    real(r8), parameter :: b4 =  0.103354611e-06_r8
+    real(r8), parameter :: b5 =  0.404125005e-09_r8
+    real(r8), parameter :: b6 = -0.788037859e-12_r8
+    real(r8), parameter :: b7 = -0.114596802e-13_r8
+    real(r8), parameter :: b8 =  0.381294516e-16_r8
+!
+! For ice (temperature range -75C-0C)
+!
+    real(r8), parameter :: c0 =  6.11123516_r8
+    real(r8), parameter :: c1 =  0.503109514_r8
+    real(r8), parameter :: c2 =  0.188369801e-01_r8
+    real(r8), parameter :: c3 =  0.420547422e-03_r8
+    real(r8), parameter :: c4 =  0.614396778e-05_r8
+    real(r8), parameter :: c5 =  0.602780717e-07_r8
+    real(r8), parameter :: c6 =  0.387940929e-09_r8
+    real(r8), parameter :: c7 =  0.149436277e-11_r8
+    real(r8), parameter :: c8 =  0.262655803e-14_r8
+!
+! For derivative:ice
+!
+    real(r8), parameter :: d0 =  0.503277922_r8
+    real(r8), parameter :: d1 =  0.377289173e-01_r8
+    real(r8), parameter :: d2 =  0.126801703e-02_r8
+    real(r8), parameter :: d3 =  0.249468427e-04_r8
+    real(r8), parameter :: d4 =  0.313703411e-06_r8
+    real(r8), parameter :: d5 =  0.257180651e-08_r8
+    real(r8), parameter :: d6 =  0.133268878e-10_r8
+    real(r8), parameter :: d7 =  0.394116744e-13_r8
+    real(r8), parameter :: d8 =  0.498070196e-16_r8
+!-----------------------------------------------------------------------
+
+    T_limit = T - SHR_CONST_TKFRZ
+    if (T_limit > 100.0_r8) T_limit=100.0_r8
+    if (T_limit < -75.0_r8) T_limit=-75.0_r8
+
+    td       = T_limit
+    if (td >= 0.0_r8) then
+       es   = a0 + td*(a1 + td*(a2 + td*(a3 + td*(a4 &
+            + td*(a5 + td*(a6 + td*(a7 + td*a8)))))))
+       esdT = b0 + td*(b1 + td*(b2 + td*(b3 + td*(b4 &
+            + td*(b5 + td*(b6 + td*(b7 + td*b8)))))))
+    else
+       es   = c0 + td*(c1 + td*(c2 + td*(c3 + td*(c4 &
+            + td*(c5 + td*(c6 + td*(c7 + td*c8)))))))
+       esdT = d0 + td*(d1 + td*(d2 + td*(d3 + td*(d4 &
+            + td*(d5 + td*(d6 + td*(d7 + td*d8)))))))
+    endif
+
+    es    = es    * 100._r8            ! pa
+    esdT  = esdT  * 100._r8            ! pa/K
+
+    vp    = 1.0_r8   / (p - 0.378_r8*es)
+    vp1   = 0.622_r8 * vp
+    vp2   = vp1   * vp
+
+    qs    = es    * vp1             ! kg/kg
+    qsdT  = esdT  * vp2 * p         ! 1 / K
+
+  end subroutine QSat
+    
+    
+  subroutine printTest1(nio)
+      ! !DESCRIPTION: output the simulation results into external files
+      implicit none
+      integer, intent(in) :: nio        ! unit of the file to print
+      
+      !integer :: IDlist(1:5) = (/9958,7232,7241,6850,6852/)
+      integer :: IDlist(1:4) = (/1233,1244,1138,1583/)
+      integer :: ios,ii                    ! flag of io status
+            
+
+      write(unit=nio,fmt="(12(e20.11))") rtmCTL%runofflnd_nt1(IDlist(1)), rtmCTL%templand_Tchanr_nt1(IDlist(1)), rtmCTL%templand_Ttrib_nt1(IDlist(1)), &
+                                         rtmCTL%runofflnd_nt1(IDlist(2)), rtmCTL%templand_Tchanr_nt1(IDlist(2)), rtmCTL%templand_Ttrib_nt1(IDlist(2)), &
+                                         rtmCTL%runofflnd_nt1(IDlist(3)), rtmCTL%templand_Tchanr_nt1(IDlist(3)), rtmCTL%templand_Ttrib_nt1(IDlist(3)), &
+                                         rtmCTL%runofflnd_nt1(IDlist(4)), rtmCTL%templand_Tchanr_nt1(IDlist(4)), rtmCTL%templand_Ttrib_nt1(IDlist(4))
+      
+      !write(unit=nio,fmt="(16(e20.11))") TRunoff%erout(IDlist(1),1), TRunoff%wr(IDlist(1),1), THeat%Tt(IDlist(1)), THeat%Tr(IDlist(1)), &
+      !                                   TRunoff%erout(IDlist(2),1), TRunoff%wr(IDlist(2),1), THeat%Tt(IDlist(2)), THeat%Tr(IDlist(2)), &
+      !                                     TRunoff%erout(IDlist(3),1), TRunoff%wr(IDlist(3),1), THeat%Tt(IDlist(3)), THeat%Tr(IDlist(3)), &
+      !                                     TRunoff%erout(IDlist(4),1), TRunoff%wr(IDlist(4),1), THeat%Tt(IDlist(4)), THeat%Tr(IDlist(4))
+      !write(unit=nio,fmt="(32(e20.11))") THeat%Hs_r(IDlist(1)), THeat%Hl_r(IDlist(1)), THeat%He_r(IDlist(1)), THeat%Hh_r(IDlist(1)), THeat%Hc_r(IDlist(1)), THeat%Ha_lateral(IDlist(1)), THeat%deltaH_r(IDlist(1)), THeat%deltaM_r(IDlist(1)), &
+      !                                   THeat%Hs_r(IDlist(2)), THeat%Hl_r(IDlist(2)), THeat%He_r(IDlist(2)), THeat%Hh_r(IDlist(2)), THeat%Hc_r(IDlist(2)), THeat%Ha_lateral(IDlist(2)), THeat%deltaH_r(IDlist(2)), THeat%deltaM_r(IDlist(2)), &
+      !                                     THeat%Hs_r(IDlist(3)), THeat%Hl_r(IDlist(3)), THeat%He_r(IDlist(3)), THeat%Hh_r(IDlist(3)), THeat%Hc_r(IDlist(3)), THeat%Ha_lateral(IDlist(3)), THeat%deltaH_r(IDlist(3)), THeat%deltaM_r(IDlist(3)), &
+      !                                     THeat%Hs_r(IDlist(4)), THeat%Hl_r(IDlist(4)), THeat%He_r(IDlist(4)), THeat%Hh_r(IDlist(4)), THeat%Hc_r(IDlist(4)), THeat%Ha_lateral(IDlist(4)), THeat%deltaH_r(IDlist(4)), THeat%deltaM_r(IDlist(4))
+      !write(unit=nio,fmt="((a10),(e20.11))") theTime, liqWater%flow(ii)
+      !write(unit=nio,fmt="((a10),6(e20.11))") theTime, liqWater%qsur(ii), liqWater%qsub(ii), liqWater%etin(ii)/(TUnit%area(ii)*TUnit%frac(ii)), liqWater%erlateral(ii)/(TUnit%area(ii)*TUnit%frac(ii)), liqWater%erin(ii), liqWater%flow(ii)
+      !if(liqWater%yr(ii) > 0._r8) then
+      !    write(unit=nio,fmt="((a10),6(e20.11))") theTime, liqWater%mr(ii)/liqWater%yr(ii),liqWater%yr(ii), liqWater%vr(ii), liqWater%erin(ii), liqWater%erout(ii)/(TUnit%area(ii)*TUnit%frac(ii)), liqWater%flow(ii)
+      !else
+      !    write(unit=nio,fmt="((a10),6(e20.11))") theTime, liqWater%mr(ii)-liqWater%mr(ii),liqWater%yr(ii), liqWater%vr(ii), liqWater%erin(ii), liqWater%erout(ii)/(TUnit%area(ii)*TUnit%frac(ii)), liqWater%flow(ii)
+      !end if
+      !write(unit=nio,fmt="((a10),7(e20.11))") theTime, liqWater%erlateral(ii)/(TUnit%area(ii)*TUnit%frac(ii)), liqWater%wr(ii),liqWater%mr(ii), liqWater%yr(ii), liqWater%pr(ii), liqWater%rr(ii), liqWater%flow(ii)
+      !write(unit=nio,fmt="((a10),7(e20.11))") theTime, liqWater%yh(ii), liqWater%dwh(ii),liqWater%etin(ii), liqWater%vr(ii), liqWater%erin(ii), liqWater%erout(ii)/(TUnit%area(ii)*TUnit%frac(ii)), liqWater%flow(ii)
+  
+  end subroutine printTest1
+    
+end MODULE MOSART_heat_mod

--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -14,8 +14,9 @@ MODULE MOSART_physics_mod
   use shr_const_mod , only : SHR_CONST_REARTH, SHR_CONST_PI
   use shr_sys_mod   , only : shr_sys_abort
   use RtmVar        , only : iulog, barrier_timers, wrmflag, inundflag, sediflag, heatflag
-  use RunoffMod     , only : Tctl, TUnit, TRunoff, TPara, rtmCTL, &
+  use RunoffMod     , only : Tctl, TUnit, TRunoff, Theat, TPara, rtmCTL, &
                              SMatP_upstrm, avsrc_upstrm, avdst_upstrm
+  use MOSART_heat_mod
   use RtmSpmd       , only : masterproc, mpicom_rof, iam
   use RtmTimeManager, only : get_curr_date, is_new_month
 !#ifdef INCLUDE_WRM
@@ -28,7 +29,7 @@ MODULE MOSART_physics_mod
                              estimate_returnflow_deficit
   use WRM_subw_io_mod, only : WRM_readDemand, WRM_computeRelease
 !#endif
-  use rof_cpl_indices, only : nt_rtm, rtm_tracers, nt_nliq
+  use rof_cpl_indices, only : nt_rtm, rtm_tracers, nt_nliq, nt_nice
   use perf_mod, only: t_startf, t_stopf
   use mct_mod
 
@@ -36,7 +37,7 @@ MODULE MOSART_physics_mod
   private
 
   real(r8), parameter :: TINYVALUE = 1.0e-14_r8  ! double precision variable has a significance of about 16 decimal digits
-    integer  :: nt               ! loop indices
+  integer  :: nt               ! loop indices
   real(r8), parameter :: SLOPE1def = 0.1_r8        ! here give it a small value in order to avoid the abrupt change of hydraulic radidus etc.
   real(r8) :: sinatanSLOPE1defr   ! 1.0/sin(atan(slope1))
   public Euler
@@ -54,12 +55,15 @@ MODULE MOSART_physics_mod
   ! !DESCRIPTION: solve the ODEs with Euler algorithm
     implicit none    
     
-    integer :: iunit, idam, m, k, unitUp, cnt, ier   !local index
-    real(r8) :: temp_erout, localDeltaT
+    integer :: iunit, idam, m, k, unitUp, cnt, ier, dd, nSubStep   !local index
+    real(r8) :: temp_erout, localDeltaT, temp_haout, temp_Tt, temp_Tr, temp_T, temp_ha
     real(r8) :: negchan
     integer  :: yr,mon,day,tod
+    real(r8) :: myTINYVALUE
     character(len=*),parameter :: subname = '(Euler)'
     !------------------
+
+    myTINYVALUE = 1.e-6
 
     call get_curr_date(yr, mon, day, tod)
 	
@@ -93,9 +97,9 @@ MODULE MOSART_physics_mod
            endif
             do nt=1,nt_rtm  
               if (TUnit%mask(iunit) > 0) then
-      if (ctlSubwWRM%ExternalDemandFlag == 0) then  ! if demand is from ELM
-                 StorWater%demand0(iunit) = StorWater%demand0(iunit) - TRunoff%qdem(iunit,nt) * TUnit%area(iunit) * TUnit%frac(iunit)
-      endif
+                  if (ctlSubwWRM%ExternalDemandFlag == 0) then  ! if demand is from ELM
+                      StorWater%demand0(iunit) = StorWater%demand0(iunit) - TRunoff%qdem(iunit,nt) * TUnit%area(iunit) * TUnit%frac(iunit)
+                  endif
               endif
             enddo  
           enddo
@@ -119,9 +123,10 @@ MODULE MOSART_physics_mod
           call hillslopeRouting(iunit,nt,Tctl%DeltaT)
           TRunoff%wh(iunit,nt) = TRunoff%wh(iunit,nt) + TRunoff%dwh(iunit,nt) * Tctl%DeltaT
           call UpdateState_hillslope(iunit,nt)
-! NV WARNNG WARNING JUST FOR TESTING
-!          TRunoff%qsub(iunit,nt) = TRunoff%qsub(iunit,nt) / 1.6_r8
           TRunoff%etin(iunit,nt) = (-TRunoff%ehout(iunit,nt) + TRunoff%qsub(iunit,nt)) * TUnit%area(iunit) * TUnit%frac(iunit)
+		  if (heatflag) then
+              call hillslopeHeat(iunit, Tctl%DeltaT)
+		  end if
        endif
     end do
     endif
@@ -149,6 +154,10 @@ MODULE MOSART_physics_mod
     TRunoff%eroup_lagf = 0._r8
     TRunoff%eroutup_avg = 0._r8
     TRunoff%erlat_avg = 0._r8
+    THeat%Ha_eroutup_avg = 0._r8
+    THeat%Ha_erlat_avg = 0._r8
+    THeat%Tt_avg = 0._r8
+    THeat%Tr_avg = 0._r8
     negchan = 9999.0_r8
     do m=1,Tctl%DLevelH2R
 
@@ -158,15 +167,17 @@ MODULE MOSART_physics_mod
 
        call t_startf('mosartr_subnetwork')    
        TRunoff%erlateral(:,:) = 0._r8
+       THeat%ha_lateral(:) = 0._r8
        do nt=1,nt_rtm
        if (TUnit%euler_calc(nt)) then
        do iunit=rtmCTL%begr,rtmCTL%endr
+          temp_Tt = 0._r8
           if(TUnit%mask(iunit) > 0) then
 !extraction from subnetwork here from wt
 !#ifdef INCLUDE_WRM
              if (wrmflag) then
                 if (nt == nt_nliq) then
-                   if  (ctlSubwWRM%ExtractionFlag > 0 ) then
+                   if  (ctlSubwWRM%ExtractionFlag > 0 .and. TRunoff%yt(iunit,nt_nliq) >= 0.1_r8) then
                       localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R
                       call irrigationExtractionSubNetwork(iunit, localDeltaT )
                       call UpdateState_subnetwork(iunit,nt)
@@ -180,8 +191,43 @@ MODULE MOSART_physics_mod
                 TRunoff%wt(iunit,nt) = TRunoff%wt(iunit,nt) + TRunoff%dwt(iunit,nt) * localDeltaT
                 call UpdateState_subnetwork(iunit,nt)
                 TRunoff%erlateral(iunit,nt) = TRunoff%erlateral(iunit,nt)-TRunoff%etout(iunit,nt)
+				if (heatflag) then
+                    if(TUnit%tlen(iunit) > myTINYVALUE) then
+                          if(TRunoff%yt(iunit,nt_nliq) >= 0.5_r8) then 
+                              call subnetworkHeat(iunit,localDeltaT)
+                              call subnetworkTemp(iunit)
+                          elseif(TRunoff%yt(iunit,nt_nliq) <= 0.1_r8) then
+                              call subnetworkHeat_simple(iunit,localDeltaT)
+                              THeat%Tt(iunit) = cr_S_curve(iunit,THeat%forc_t(iunit))
+                          else
+                              temp_T = 0._r8
+                              temp_ha = 0._r8
+                              nSubStep = 10
+                              do dd=1,nSubStep
+                                  call subnetworkHeat(iunit,localDeltaT/nSubStep)
+                                  call subnetworkTemp(iunit)
+                                  temp_T = temp_T + THeat%Tt(iunit)
+                                  temp_ha = temp_ha + THeat%Ha_t2r(iunit)
+                              end do
+                              THeat%Tt(iunit) = temp_T/nSubStep
+                              THeat%Ha_t2r(iunit) = temp_ha/nSubStep
+                          end if
+                          THeat%ha_lateral(iunit) = THeat%ha_lateral(iunit) - THeat%Ha_t2r(iunit)
+                          temp_Tt = temp_Tt + THeat%Tt(iunit)
+                      else
+                          call subnetworkHeat_simple(iunit,localDeltaT)
+                          call subnetworkTemp_simple(iunit)
+                          THeat%ha_lateral(iunit) = THeat%ha_lateral(iunit) - THeat%Ha_t2r(iunit)
+                          temp_Tt = temp_Tt + THeat%Tt(iunit)
+                    end if
+				end if
              end do ! numDT_t
              TRunoff%erlateral(iunit,nt) = TRunoff%erlateral(iunit,nt) / TUnit%numDT_t(iunit)
+			 if (heatflag) then
+                 THeat%ha_lateral(iunit) = THeat%ha_lateral(iunit) / TUnit%numDT_t(iunit)
+                 temp_Tt = temp_Tt / TUnit%numDT_t(iunit)
+                 THeat%Tt_avg(iunit) = THeat%Tt_avg(iunit) + temp_Tt
+			 end if
           endif
        end do ! iunit
        endif  ! euler_calc
@@ -203,6 +249,7 @@ MODULE MOSART_physics_mod
 
        call t_startf('mosartr_SMeroutUp')    
        TRunoff%eroutUp = 0._r8
+       THeat%Ha_eroutUp = 0._r8
 #ifdef NO_MCT
        do iunit=rtmCTL%begr,rtmCTL%endr
        do k=1,TUnit%nUp(iunit)
@@ -210,6 +257,9 @@ MODULE MOSART_physics_mod
           do nt=1,nt_rtm
              TRunoff%eroutUp(iunit,nt) = TRunoff%eroutUp(iunit,nt) + TRunoff%erout(unitUp,nt)
           end do
+		  if (heatflag) then
+              THeat%Ha_eroutUp(iunit) = THeat%Ha_eroutUp(iunit) + THeat%Ha_rout(unitUp)
+		  end if
        end do
        end do
 #else
@@ -221,6 +271,9 @@ MODULE MOSART_physics_mod
           do nt = 1,nt_rtm
              avsrc_upstrm%rAttr(nt,cnt) = TRunoff%erout(iunit,nt)
           enddo
+		  if (heatflag) then
+              avsrc_upstrm%rAttr(nt_rtm+1,cnt) = THeat%Ha_rout(iunit)
+		  end if
        enddo
        call mct_avect_zero(avdst_upstrm)
 
@@ -233,12 +286,19 @@ MODULE MOSART_physics_mod
           do nt = 1,nt_rtm
              TRunoff%eroutUp(iunit,nt) = avdst_upstrm%rAttr(nt,cnt)
           enddo
+		  if (heatflag) then
+              THeat%Ha_eroutUp(iunit) = avdst_upstrm%rAttr(nt_rtm+1,cnt)
+		  end if
        enddo
 #endif
        call t_stopf('mosartr_SMeroutUp')    
 
        TRunoff%eroutup_avg = TRunoff%eroutup_avg + TRunoff%eroutUp
        TRunoff%erlat_avg   = TRunoff%erlat_avg   + TRunoff%erlateral
+	   if (heatflag) then
+           THeat%Ha_eroutup_avg = THeat%Ha_eroutup_avg + THeat%Ha_eroutUp
+           THeat%Ha_erlat_avg   = THeat%Ha_erlat_avg   + THeat%Ha_lateral
+	   end if
 
        !------------------
        ! channel routing
@@ -251,6 +311,8 @@ MODULE MOSART_physics_mod
           if(TUnit%mask(iunit) > 0) then
              localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R/TUnit%numDT_r(iunit)
              temp_erout = 0._r8
+             temp_haout = 0._r8
+             temp_Tr = 0._r8
              do k=1,TUnit%numDT_r(iunit)
                 call mainchannelRouting(iunit,nt,localDeltaT)    
                 TRunoff%wr(iunit,nt) = TRunoff%wr(iunit,nt) + TRunoff%dwr(iunit,nt) * localDeltaT
@@ -260,15 +322,51 @@ MODULE MOSART_physics_mod
 !                   call shr_sys_abort('mosart: negative channel storage')
 !                end if
                 call UpdateState_mainchannel(iunit,nt)
-                temp_erout = temp_erout + TRunoff%erout(iunit,nt) ! erout here might be inflow to some downstream subbasin, so treat it differently than erlateral
+                temp_erout = temp_erout + TRunoff%erout(iunit,nt) ! erout here might be inflow to some downstream subbasin, so treat it differently than erlateral                
              end do
              temp_erout = temp_erout / TUnit%numDT_r(iunit)
              TRunoff%erout(iunit,nt) = temp_erout
+			 if (heatflag) then
+                 do k=1,TUnit%numDT_r(iunit)                
+                    if(TUnit%rlen(iunit) > myTINYVALUE) then
+                        if(TRunoff%yr(iunit,nt_nliq) >= 0.5_r8) then
+                            call mainchannelHeat(iunit, localDeltaT)
+                            call mainchannelTemp(iunit)
+                        elseif(TRunoff%yr(iunit,nt_nliq) <= 0.1_r8) then
+                            call mainchannelHeat_simple(iunit, localDeltaT)
+                            THeat%Tr(iunit) = cr_S_curve(iunit,THeat%forc_t(iunit))
+                        else
+                            temp_T = 0._r8
+                            temp_ha = 0._r8
+                            nSubStep = 10
+                            do dd=1,nSubStep
+                                call mainchannelHeat(iunit, localDeltaT/nSubStep)
+                                call mainchannelTemp(iunit)
+                                temp_T = temp_T + THeat%Tr(iunit)
+                                temp_ha = temp_ha + THeat%ha_rout(iunit)
+                            end do
+                            THeat%Tr(iunit) = temp_T/nSubStep
+                            THeat%ha_rout(iunit) = temp_ha/nSubStep
+                        end if
+                        temp_haout = temp_haout + THeat%ha_rout(iunit)
+                        temp_Tr = temp_Tr + THeat%Tr(iunit)
+                    else
+                        call mainchannelHeat_simple(iunit, localDeltaT)
+                        call mainchannelTemp_simple(iunit)
+                        temp_haout = temp_haout + THeat%ha_rout(iunit)
+                        temp_Tr = temp_Tr + THeat%Tr(iunit)
+                    end if                
+                 end do
+                 temp_haout = temp_haout / TUnit%numDT_r(iunit)
+                 THeat%ha_rout(iunit) = temp_haout
+                 temp_Tr = temp_Tr / TUnit%numDT_r(iunit)
+                 THeat%Tr_avg(iunit) = THeat%Tr_avg(iunit) + temp_Tr
+             end if
 !#ifdef INCLUDE_WRM
              if (wrmflag) then
                 if (nt == nt_nliq) then
                    localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R
-                   if (ctlSubwWRM%ExtractionMainChannelFlag > 0 .AND. ctlSubwWRM%ExtractionFlag > 0 ) then
+                   if (ctlSubwWRM%ExtractionMainChannelFlag > 0 .AND. ctlSubwWRM%ExtractionFlag > 0  .and. TRunoff%yr(iunit,nt_nliq) >= 0.1_r8) then
                       call IrrigationExtractionMainChannel(iunit, localDeltaT )
                       if (ctlSubwWRM%TotalDemandFlag > 0 .AND. ctlSubwWRM%ReturnFlowFlag > 0 ) then
                          call insert_returnflow_channel(iunit, localDeltaT )
@@ -289,7 +387,9 @@ MODULE MOSART_physics_mod
 !                      if ( ctlSubwWRM%ExtractionFlag > 0 ) then
 !                         call ExtractionRegulatedFlow(iunit, localDeltaT)
 !                      endif
- 
+                      if (heatflag) then
+                          call reservoirHeat(iunit, localDeltaT)
+					  end if
                    endif
                 endif
 !                ! do not update wr after regulation or extraction from reservoir release. Because of the regulation, 
@@ -304,7 +404,7 @@ MODULE MOSART_physics_mod
        end do ! nt
        negchan = min(negchan, minval(TRunoff%wr(:,:)))
 
-       call t_stopf('mosartr_chanroute')    
+       call t_stopf('mosartr_chanroute') 
     end do  ! DLevelH2R
 
 ! check for negative channel storage
@@ -317,6 +417,12 @@ MODULE MOSART_physics_mod
     TRunoff%eroup_lagf = TRunoff%eroup_lagf / Tctl%DLevelH2R
     TRunoff%eroutup_avg = TRunoff%eroutup_avg / Tctl%DLevelH2R
     TRunoff%erlat_avg = TRunoff%erlat_avg / Tctl%DLevelH2R
+	if (heatflag) then
+       THeat%Ha_eroutup_avg = THeat%Ha_eroutup_avg / Tctl%DLevelH2R
+       THeat%Ha_erlat_avg = THeat%Ha_erlat_avg / Tctl%DLevelH2R
+       THeat%Tt_avg = THeat%Tt_avg / Tctl%DLevelH2R
+       THeat%Tr_avg = THeat%Tr_avg / Tctl%DLevelH2R
+	end if
 
     !------------------
     ! WRM Regulation
@@ -333,6 +439,11 @@ MODULE MOSART_physics_mod
           do iunit=rtmCTL%begr,rtmCTL%endr
              TRunoff%erowm_regi(iunit,nt_nliq) = -TRunoff%erout(iunit,nt_nliq)
              TRunoff%flow(iunit,nt_nliq) = TRunoff%flow(iunit,nt_nliq) + TRunoff%erout(iunit,nt_nliq)
+			 ! a simple treatment after extracting water from the regulated streamflow. Assuming the extraction won't change the water temperature in the release
+			 ! but the heat flux will be changed due to chaning streamflow
+			 if (heatflag) then
+			     THeat%Ha_rout(iunit) = -cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
+			 end if
           enddo
           localDeltaT = Tctl%DeltaT
 !          call t_startf('mosartr_wrm_Reg')

--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -66,7 +66,7 @@ MODULE MOSART_physics_mod
     myTINYVALUE = 1.e-6
 
     call get_curr_date(yr, mon, day, tod)
-	
+    
 !#if (1 == 0)
 !  if (masterproc) write(iulog,*) trim(subname), 'Tian testing hashtag comment working'
 !#endif
@@ -124,9 +124,9 @@ MODULE MOSART_physics_mod
           TRunoff%wh(iunit,nt) = TRunoff%wh(iunit,nt) + TRunoff%dwh(iunit,nt) * Tctl%DeltaT
           call UpdateState_hillslope(iunit,nt)
           TRunoff%etin(iunit,nt) = (-TRunoff%ehout(iunit,nt) + TRunoff%qsub(iunit,nt)) * TUnit%area(iunit) * TUnit%frac(iunit)
-		  if (heatflag) then
+          if (heatflag) then
               call hillslopeHeat(iunit, Tctl%DeltaT)
-		  end if
+          end if
        endif
     end do
     endif
@@ -191,7 +191,7 @@ MODULE MOSART_physics_mod
                 TRunoff%wt(iunit,nt) = TRunoff%wt(iunit,nt) + TRunoff%dwt(iunit,nt) * localDeltaT
                 call UpdateState_subnetwork(iunit,nt)
                 TRunoff%erlateral(iunit,nt) = TRunoff%erlateral(iunit,nt)-TRunoff%etout(iunit,nt)
-				if (heatflag) then
+                if (heatflag) then
                     if(TUnit%tlen(iunit) > myTINYVALUE) then
                           if(TRunoff%yt(iunit,nt_nliq) >= 0.5_r8) then 
                               call subnetworkHeat(iunit,localDeltaT)
@@ -220,14 +220,14 @@ MODULE MOSART_physics_mod
                           THeat%ha_lateral(iunit) = THeat%ha_lateral(iunit) - THeat%Ha_t2r(iunit)
                           temp_Tt = temp_Tt + THeat%Tt(iunit)
                     end if
-				end if
+                end if
              end do ! numDT_t
              TRunoff%erlateral(iunit,nt) = TRunoff%erlateral(iunit,nt) / TUnit%numDT_t(iunit)
-			 if (heatflag) then
+             if (heatflag) then
                  THeat%ha_lateral(iunit) = THeat%ha_lateral(iunit) / TUnit%numDT_t(iunit)
                  temp_Tt = temp_Tt / TUnit%numDT_t(iunit)
                  THeat%Tt_avg(iunit) = THeat%Tt_avg(iunit) + temp_Tt
-			 end if
+             end if
           endif
        end do ! iunit
        endif  ! euler_calc
@@ -257,9 +257,9 @@ MODULE MOSART_physics_mod
           do nt=1,nt_rtm
              TRunoff%eroutUp(iunit,nt) = TRunoff%eroutUp(iunit,nt) + TRunoff%erout(unitUp,nt)
           end do
-		  if (heatflag) then
+          if (heatflag) then
               THeat%Ha_eroutUp(iunit) = THeat%Ha_eroutUp(iunit) + THeat%Ha_rout(unitUp)
-		  end if
+          end if
        end do
        end do
 #else
@@ -271,9 +271,9 @@ MODULE MOSART_physics_mod
           do nt = 1,nt_rtm
              avsrc_upstrm%rAttr(nt,cnt) = TRunoff%erout(iunit,nt)
           enddo
-		  if (heatflag) then
+          if (heatflag) then
               avsrc_upstrm%rAttr(nt_rtm+1,cnt) = THeat%Ha_rout(iunit)
-		  end if
+          end if
        enddo
        call mct_avect_zero(avdst_upstrm)
 
@@ -286,19 +286,19 @@ MODULE MOSART_physics_mod
           do nt = 1,nt_rtm
              TRunoff%eroutUp(iunit,nt) = avdst_upstrm%rAttr(nt,cnt)
           enddo
-		  if (heatflag) then
+          if (heatflag) then
               THeat%Ha_eroutUp(iunit) = avdst_upstrm%rAttr(nt_rtm+1,cnt)
-		  end if
+          end if
        enddo
 #endif
        call t_stopf('mosartr_SMeroutUp')    
 
        TRunoff%eroutup_avg = TRunoff%eroutup_avg + TRunoff%eroutUp
        TRunoff%erlat_avg   = TRunoff%erlat_avg   + TRunoff%erlateral
-	   if (heatflag) then
+       if (heatflag) then
            THeat%Ha_eroutup_avg = THeat%Ha_eroutup_avg + THeat%Ha_eroutUp
            THeat%Ha_erlat_avg   = THeat%Ha_erlat_avg   + THeat%Ha_lateral
-	   end if
+       end if
 
        !------------------
        ! channel routing
@@ -326,7 +326,7 @@ MODULE MOSART_physics_mod
              end do
              temp_erout = temp_erout / TUnit%numDT_r(iunit)
              TRunoff%erout(iunit,nt) = temp_erout
-			 if (heatflag) then
+             if (heatflag) then
                  do k=1,TUnit%numDT_r(iunit)                
                     if(TUnit%rlen(iunit) > myTINYVALUE) then
                         if(TRunoff%yr(iunit,nt_nliq) >= 0.5_r8) then
@@ -389,7 +389,7 @@ MODULE MOSART_physics_mod
 !                      endif
                       if (heatflag) then
                           call reservoirHeat(iunit, localDeltaT)
-					  end if
+                      end if
                    endif
                 endif
 !                ! do not update wr after regulation or extraction from reservoir release. Because of the regulation, 
@@ -417,12 +417,12 @@ MODULE MOSART_physics_mod
     TRunoff%eroup_lagf = TRunoff%eroup_lagf / Tctl%DLevelH2R
     TRunoff%eroutup_avg = TRunoff%eroutup_avg / Tctl%DLevelH2R
     TRunoff%erlat_avg = TRunoff%erlat_avg / Tctl%DLevelH2R
-	if (heatflag) then
+    if (heatflag) then
        THeat%Ha_eroutup_avg = THeat%Ha_eroutup_avg / Tctl%DLevelH2R
        THeat%Ha_erlat_avg = THeat%Ha_erlat_avg / Tctl%DLevelH2R
        THeat%Tt_avg = THeat%Tt_avg / Tctl%DLevelH2R
        THeat%Tr_avg = THeat%Tr_avg / Tctl%DLevelH2R
-	end if
+    end if
 
     !------------------
     ! WRM Regulation
@@ -439,11 +439,11 @@ MODULE MOSART_physics_mod
           do iunit=rtmCTL%begr,rtmCTL%endr
              TRunoff%erowm_regi(iunit,nt_nliq) = -TRunoff%erout(iunit,nt_nliq)
              TRunoff%flow(iunit,nt_nliq) = TRunoff%flow(iunit,nt_nliq) + TRunoff%erout(iunit,nt_nliq)
-			 ! a simple treatment after extracting water from the regulated streamflow. Assuming the extraction won't change the water temperature in the release
-			 ! but the heat flux will be changed due to chaning streamflow
-			 if (heatflag) then
-			     THeat%Ha_rout(iunit) = -cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
-			 end if
+             ! a simple treatment after extracting water from the regulated streamflow. Assuming the extraction won't change the water temperature in the release
+             ! but the heat flux will be changed due to chaning streamflow
+             if (heatflag) then
+                 THeat%Ha_rout(iunit) = -cr_advectheat(abs(TRunoff%erout(iunit,nt_nliq)+TRunoff%erout(iunit,nt_nice)), THeat%Tr(iunit))
+             end if
           enddo
           localDeltaT = Tctl%DeltaT
 !          call t_startf('mosartr_wrm_Reg')

--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -154,10 +154,12 @@ MODULE MOSART_physics_mod
     TRunoff%eroup_lagf = 0._r8
     TRunoff%eroutup_avg = 0._r8
     TRunoff%erlat_avg = 0._r8
-    THeat%Ha_eroutup_avg = 0._r8
-    THeat%Ha_erlat_avg = 0._r8
-    THeat%Tt_avg = 0._r8
-    THeat%Tr_avg = 0._r8
+    if (heatflag) then
+       THeat%Ha_eroutup_avg = 0._r8
+       THeat%Ha_erlat_avg = 0._r8
+       THeat%Tt_avg = 0._r8
+       THeat%Tr_avg = 0._r8
+    endif
     negchan = 9999.0_r8
     do m=1,Tctl%DLevelH2R
 
@@ -167,7 +169,7 @@ MODULE MOSART_physics_mod
 
        call t_startf('mosartr_subnetwork')    
        TRunoff%erlateral(:,:) = 0._r8
-       THeat%ha_lateral(:) = 0._r8
+       if (heatflag) THeat%ha_lateral(:) = 0._r8
        do nt=1,nt_rtm
        if (TUnit%euler_calc(nt)) then
        do iunit=rtmCTL%begr,rtmCTL%endr
@@ -249,7 +251,7 @@ MODULE MOSART_physics_mod
 
        call t_startf('mosartr_SMeroutUp')    
        TRunoff%eroutUp = 0._r8
-       THeat%Ha_eroutUp = 0._r8
+       if (heatflag) THeat%Ha_eroutUp = 0._r8
 #ifdef NO_MCT
        do iunit=rtmCTL%begr,rtmCTL%endr
        do k=1,TUnit%nUp(iunit)

--- a/components/mosart/src/riverroute/RtmHistFlds.F90
+++ b/components/mosart/src/riverroute/RtmHistFlds.F90
@@ -90,6 +90,10 @@ contains
          avgflag='A', long_name='MOSART direct discharge into ocean: '//trim(rtm_tracers(2)), &
          ptr_rof=rtmCTL%runoffdir_nt2, default='active')
 
+    call RtmHistAddfld (fname='Main_Channel_STORAGE'//'_'//trim(rtm_tracers(1)), units='m3',  &
+         avgflag='A', long_name='MOSART main channel storage: '//trim(rtm_tracers(1)), &
+         ptr_rof=rtmCTL%wr_nt1, default='active')
+
     call RtmHistAddfld (fname='STORAGE'//'_'//trim(rtm_tracers(1)), units='m3',  &
          avgflag='A', long_name='MOSART storage: '//trim(rtm_tracers(1)), &
          ptr_rof=rtmCTL%volr_nt1, default='active')
@@ -201,6 +205,22 @@ contains
     endif
 !#endif
 
+    call RtmHistAddfld (fname='TEMP_QSUR', units='Kelvin',  &
+         avgflag='A', long_name='Temperature of surface runoff', &
+         ptr_rof=rtmCTL%templand_Tqsur_nt1)
+
+    call RtmHistAddfld (fname='TEMP_QSUB', units='Kelvin',  &
+         avgflag='A', long_name='Temperature of subsurface runoff', &
+         ptr_rof=rtmCTL%templand_Tqsub_nt1)
+
+    call RtmHistAddfld (fname='TEMP_TRIB', units='Kelvin',  &
+         avgflag='A', long_name='Water temperature of tributary channels', &
+         ptr_rof=rtmCTL%templand_Ttrib_nt1)
+
+    call RtmHistAddfld (fname='TEMP_CHANR', units='Kelvin',  &
+         avgflag='A', long_name='Water temperature of main channels', &
+         ptr_rof=rtmCTL%templand_Tchanr_nt1)		 
+		 
     ! Print masterlist of history fields
 
     call RtmHistPrintflds()
@@ -244,6 +264,8 @@ contains
     rtmCTL%dvolrdtocn_nt1(:) = rtmCTL%dvolrdtocn(:,1)
     rtmCTL%dvolrdtocn_nt2(:) = rtmCTL%dvolrdtocn(:,2)
 
+    rtmCTL%wr_nt1(:)         = rtmCTL%wr(:,1)
+
     rtmCTL%volr_nt1(:)       = rtmCTL%volr(:,1)
     rtmCTL%volr_nt2(:)       = rtmCTL%volr(:,2)
 
@@ -272,6 +294,15 @@ contains
     endif
 !#endif
 
+	rtmCTL%templand_Tqsur_nt1(:) = rtmCTL%templand_Tqsur(:)
+	rtmCTL%templand_Tqsur_nt2(:) = rtmCTL%templand_Tqsur(:)
+	rtmCTL%templand_Tqsub_nt1(:) = rtmCTL%templand_Tqsub(:)
+	rtmCTL%templand_Tqsub_nt2(:) = rtmCTL%templand_Tqsub(:)
+	rtmCTL%templand_Ttrib_nt1(:) = rtmCTL%templand_Ttrib(:)
+	rtmCTL%templand_Ttrib_nt2(:) = rtmCTL%templand_Ttrib(:)
+	rtmCTL%templand_Tchanr_nt1(:) = rtmCTL%templand_Tchanr(:)
+	rtmCTL%templand_Tchanr_nt2(:) = rtmCTL%templand_Tchanr(:)
+	
   end subroutine RtmHistFldsSet
 
 

--- a/components/mosart/src/riverroute/RtmHistFlds.F90
+++ b/components/mosart/src/riverroute/RtmHistFlds.F90
@@ -201,26 +201,27 @@ contains
       call RtmHistAddfld (fname='FLOODED_FRACTION', units='none',  &
          avgflag='A', long_name='MOSART flooded water area fraction', &
          ptr_rof=rtmCTL%inundffunit, default='active')
-		!!!!!!!!!!!!!!!!!!!!!!!!
+        !!!!!!!!!!!!!!!!!!!!!!!!
     endif
 !#endif
 
-    call RtmHistAddfld (fname='TEMP_QSUR', units='Kelvin',  &
-         avgflag='A', long_name='Temperature of surface runoff', &
-         ptr_rof=rtmCTL%templand_Tqsur_nt1)
-
-    call RtmHistAddfld (fname='TEMP_QSUB', units='Kelvin',  &
-         avgflag='A', long_name='Temperature of subsurface runoff', &
-         ptr_rof=rtmCTL%templand_Tqsub_nt1)
-
-    call RtmHistAddfld (fname='TEMP_TRIB', units='Kelvin',  &
-         avgflag='A', long_name='Water temperature of tributary channels', &
-         ptr_rof=rtmCTL%templand_Ttrib_nt1)
-
-    call RtmHistAddfld (fname='TEMP_CHANR', units='Kelvin',  &
-         avgflag='A', long_name='Water temperature of main channels', &
-         ptr_rof=rtmCTL%templand_Tchanr_nt1)		 
-		 
+    if(heatflag) then
+      call RtmHistAddfld (fname='TEMP_QSUR', units='Kelvin',  &
+           avgflag='A', long_name='Temperature of surface runoff', &
+           ptr_rof=rtmCTL%templand_Tqsur_nt1)
+    
+      call RtmHistAddfld (fname='TEMP_QSUB', units='Kelvin',  &
+           avgflag='A', long_name='Temperature of subsurface runoff', &
+           ptr_rof=rtmCTL%templand_Tqsub_nt1)
+    
+      call RtmHistAddfld (fname='TEMP_TRIB', units='Kelvin',  &
+           avgflag='A', long_name='Water temperature of tributary channels', &
+           ptr_rof=rtmCTL%templand_Ttrib_nt1)
+    
+      call RtmHistAddfld (fname='TEMP_CHANR', units='Kelvin',  &
+           avgflag='A', long_name='Water temperature of main channels', &
+           ptr_rof=rtmCTL%templand_Tchanr_nt1)         
+    end if     
     ! Print masterlist of history fields
 
     call RtmHistPrintflds()
@@ -294,15 +295,17 @@ contains
     endif
 !#endif
 
-	rtmCTL%templand_Tqsur_nt1(:) = rtmCTL%templand_Tqsur(:)
-	rtmCTL%templand_Tqsur_nt2(:) = rtmCTL%templand_Tqsur(:)
-	rtmCTL%templand_Tqsub_nt1(:) = rtmCTL%templand_Tqsub(:)
-	rtmCTL%templand_Tqsub_nt2(:) = rtmCTL%templand_Tqsub(:)
-	rtmCTL%templand_Ttrib_nt1(:) = rtmCTL%templand_Ttrib(:)
-	rtmCTL%templand_Ttrib_nt2(:) = rtmCTL%templand_Ttrib(:)
-	rtmCTL%templand_Tchanr_nt1(:) = rtmCTL%templand_Tchanr(:)
-	rtmCTL%templand_Tchanr_nt2(:) = rtmCTL%templand_Tchanr(:)
-	
+    if(heatflag) then
+      rtmCTL%templand_Tqsur_nt1(:) = rtmCTL%templand_Tqsur(:)
+      rtmCTL%templand_Tqsur_nt2(:) = rtmCTL%templand_Tqsur(:)
+      rtmCTL%templand_Tqsub_nt1(:) = rtmCTL%templand_Tqsub(:)
+      rtmCTL%templand_Tqsub_nt2(:) = rtmCTL%templand_Tqsub(:)
+      rtmCTL%templand_Ttrib_nt1(:) = rtmCTL%templand_Ttrib(:)
+      rtmCTL%templand_Ttrib_nt2(:) = rtmCTL%templand_Ttrib(:)
+      rtmCTL%templand_Tchanr_nt1(:) = rtmCTL%templand_Tchanr(:)
+      rtmCTL%templand_Tchanr_nt2(:) = rtmCTL%templand_Tchanr(:)
+    end if
+    
   end subroutine RtmHistFldsSet
 
 

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -1998,18 +1998,18 @@ endif
 !#endif
 
     if(heatflag) then
-    rtmCTL%templand_Tqsur = spval
-    rtmCTL%templand_Tqsub = spval
-    rtmCTL%templand_Ttrib = spval
-    rtmCTL%templand_Tchanr = spval
-    do n = rtmCTL%begr,rtmCTL%endr
-        if (rtmCTL%mask(n) .eq. 1 .or. rtmCTL%mask(n) .eq. 3) then
-            rtmCTL%templand_Tqsur(n) = 0._r8
-            rtmCTL%templand_Tqsub(n) = 0._r8
-            rtmCTL%templand_Ttrib(n) = 0._r8
-            rtmCTL%templand_Tchanr(n) = 0._r8
-        end if
-    end do
+      rtmCTL%templand_Tqsur = spval
+      rtmCTL%templand_Tqsub = spval
+      rtmCTL%templand_Ttrib = spval
+      rtmCTL%templand_Tchanr = spval
+      do n = rtmCTL%begr,rtmCTL%endr
+          if (rtmCTL%mask(n) .eq. 1 .or. rtmCTL%mask(n) .eq. 3) then
+              rtmCTL%templand_Tqsur(n) = 0._r8
+              rtmCTL%templand_Tqsub(n) = 0._r8
+              rtmCTL%templand_Ttrib(n) = 0._r8
+              rtmCTL%templand_Tchanr(n) = 0._r8
+          end if
+      end do
     end if
 	
     if (budget_check) then
@@ -2408,15 +2408,16 @@ if (inundflag) then
        end if
 end if
 !#endif
-
-       do n = rtmCTL%begr,rtmCTL%endr
-           if (rtmCTL%mask(n) .eq. 1 .or. rtmCTL%mask(n) .eq. 3) then
-               rtmCTL%templand_Tqsur(n) = rtmCTL%templand_Tqsur(n) + THeat%Tqsur(n)
-               rtmCTL%templand_Tqsub(n) = rtmCTL%templand_Tqsub(n) + THeat%Tqsub(n)
-               rtmCTL%templand_Ttrib(n) = rtmCTL%templand_Ttrib(n) + THeat%Tt_avg(n)
-               rtmCTL%templand_Tchanr(n) = rtmCTL%templand_Tchanr(n) + THeat%Tr_avg(n)
-           end if
-       enddo
+       if(heatflag) then
+         do n = rtmCTL%begr,rtmCTL%endr
+             if (rtmCTL%mask(n) .eq. 1 .or. rtmCTL%mask(n) .eq. 3) then
+                 rtmCTL%templand_Tqsur(n) = rtmCTL%templand_Tqsur(n) + THeat%Tqsur(n)
+                 rtmCTL%templand_Tqsub(n) = rtmCTL%templand_Tqsub(n) + THeat%Tqsub(n)
+                 rtmCTL%templand_Ttrib(n) = rtmCTL%templand_Ttrib(n) + THeat%Tt_avg(n)
+                 rtmCTL%templand_Tchanr(n) = rtmCTL%templand_Tchanr(n) + THeat%Tr_avg(n)
+             end if
+         enddo
+	   end if
        
     enddo ! nsub
 
@@ -2461,25 +2462,27 @@ endif
 
 !#endif
 
-    rtmCTL%Tqsur   = THeat%Tqsur
-    rtmCTL%Tqsub   = THeat%Tqsub
-    rtmCTL%Tt      = THeat%Tt
-    rtmCTL%Tr      = THeat%Tr
-    rtmCTL%Ha_rout   = THeat%Ha_rout
-
-    do n = rtmCTL%begr,rtmCTL%endr
-       if(rtmCTL%mask(n) .eq. 1 .or. rtmCTL%mask(n) .eq. 3) then
-          rtmCTL%templand_Tqsur(n) = rtmCTL%templand_Tqsur(n) / float(nsub)
-          rtmCTL%templand_Tqsub(n) = rtmCTL%templand_Tqsub(n) / float(nsub)
-          rtmCTL%templand_Ttrib(n) = rtmCTL%templand_Ttrib(n) / float(nsub)
-          rtmCTL%templand_Tchanr(n) = rtmCTL%templand_Tchanr(n) / float(nsub)
-       else
-          rtmCTL%templand_Tqsur(n) = spval
-          rtmCTL%templand_Tqsub(n) = spval
-          rtmCTL%templand_Ttrib(n) = spval
-          rtmCTL%templand_Tchanr(n) = spval
-       end if
-    end do
+    if (heatflag) then
+      rtmCTL%Tqsur   = THeat%Tqsur
+      rtmCTL%Tqsub   = THeat%Tqsub
+      rtmCTL%Tt      = THeat%Tt
+      rtmCTL%Tr      = THeat%Tr
+      rtmCTL%Ha_rout   = THeat%Ha_rout
+    
+      do n = rtmCTL%begr,rtmCTL%endr
+         if(rtmCTL%mask(n) .eq. 1 .or. rtmCTL%mask(n) .eq. 3) then
+            rtmCTL%templand_Tqsur(n) = rtmCTL%templand_Tqsur(n) / float(nsub)
+            rtmCTL%templand_Tqsub(n) = rtmCTL%templand_Tqsub(n) / float(nsub)
+            rtmCTL%templand_Ttrib(n) = rtmCTL%templand_Ttrib(n) / float(nsub)
+            rtmCTL%templand_Tchanr(n) = rtmCTL%templand_Tchanr(n) / float(nsub)
+         else
+            rtmCTL%templand_Tqsur(n) = spval
+            rtmCTL%templand_Tqsub(n) = spval
+            rtmCTL%templand_Ttrib(n) = spval
+            rtmCTL%templand_Tchanr(n) = spval
+         end if
+      end do
+	end if
 
     do nt = 1,nt_rtm
     do nr = rtmCTL%begr,rtmCTL%endr

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -271,8 +271,8 @@ endif
     ice_runoff  = .true.
     wrmflag     = .false.
     inundflag   = .false.
-	sediflag    = .false.
-	heatflag    = .false.
+    sediflag    = .false.
+    heatflag    = .false.
     barrier_timers = .false.
     finidat_rtm = ' '
     nrevsn_rtm  = ' '
@@ -332,7 +332,7 @@ endif
           endif
        end do
        call relavu( unitn )
-	   end if
+       end if
 !#endif
     end if
 
@@ -416,7 +416,7 @@ endif
     Tctl%OPT_elevProf = OPT_elevProf
     Tctl%npt_elevProf = npt_elevProf
     Tctl%threshold_slpRatio = threshold_slpRatio
-	end if
+    end if
 !#endif
 
     if (masterproc) then
@@ -2011,7 +2011,7 @@ endif
           end if
       end do
     end if
-	
+    
     if (budget_check) then
        call t_startf('mosartr_budget')
        do nt = 1,nt_rtm
@@ -2174,8 +2174,8 @@ endif
 !#ifdef INCLUDE_INUND
      if (inundflag) then
           if ( rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3 ) then   ! 1--Land; 3--Basin outlet (downstream is ocean).
-		  
-		  else
+          
+          else
                 avsrc_direct%rAttr(nt,cnt) = avsrc_direct%rAttr(nt,cnt) + &
                 TRunoff%qsub(nr,nt) + &
                 TRunoff%qsur(nr,nt) + &
@@ -2356,57 +2356,57 @@ endif
 
 
 !#ifdef INCLUDE_INUND
-if (inundflag) then
-       ! If 'budget_check' is true & inundation scheme is turned on :
-       if ( inundflag .and. budget_check .and. Tctl%OPT_inund .eq. 1 ) then
-
-         do nt = 1, 1
-           do nr = rtmCTL%begr, rtmCTL%endr
-
-             !if (Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2) then     ! 1 -- Land; 2 -- Basin outlet.
-             if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then    ! 1 -- Land; 3 -- Basin outlet.
-
-               ! Accumulate flow from main channel to floodplain (for all local grid cells and all sub-steps of coupling period):
-               if ( TRunoff%se_rf(nr) .gt. 0._r8 ) then
-                 vol_chnl2fp = vol_chnl2fp + TRunoff%se_rf(nr)
-
-               ! Accumulate flow from floodplain to main channel (for all local grid cells and all sub-steps of coupling period):
-               elseif ( TRunoff%se_rf(nr) .lt. 0._r8 ) then
-                 vol_fp2chnl = vol_fp2chnl - TRunoff%se_rf(nr)
-               end if
-
-               ! Accumulate inundated floodplain area for all sub-steps of coupling period (for each land grid cell):
-               fa_fp_cplPeriod(nr) = fa_fp_cplPeriod(nr) + TRunoff%fa_fp(nr)
-             end if
-
-           end do
-         end do
+       if (inundflag) then
+           ! If 'budget_check' is true & inundation scheme is turned on :
+           if ( inundflag .and. budget_check .and. Tctl%OPT_inund .eq. 1 ) then
+    
+             do nt = 1, 1
+               do nr = rtmCTL%begr, rtmCTL%endr
+    
+                 !if (Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2) then     ! 1 -- Land; 2 -- Basin outlet.
+                 if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then    ! 1 -- Land; 3 -- Basin outlet.
+    
+                   ! Accumulate flow from main channel to floodplain (for all local grid cells and all sub-steps of coupling period):
+                   if ( TRunoff%se_rf(nr) .gt. 0._r8 ) then
+                     vol_chnl2fp = vol_chnl2fp + TRunoff%se_rf(nr)
+    
+                   ! Accumulate flow from floodplain to main channel (for all local grid cells and all sub-steps of coupling period):
+                   elseif ( TRunoff%se_rf(nr) .lt. 0._r8 ) then
+                     vol_fp2chnl = vol_fp2chnl - TRunoff%se_rf(nr)
+                   end if
+    
+                   ! Accumulate inundated floodplain area for all sub-steps of coupling period (for each land grid cell):
+                   fa_fp_cplPeriod(nr) = fa_fp_cplPeriod(nr) + TRunoff%fa_fp(nr)
+                 end if
+    
+               end do
+             end do
+           end if
+    
+           if ( budget_check ) then
+    
+             do nt = 1, nt_rtm
+               do nr = rtmCTL%begr, rtmCTL%endr
+    
+                 if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then    ! 1 -- Land; 3 -- Basin outlet.
+                 !if (Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2) then     ! 1 -- Land; 2 -- Basin outlet.
+    
+                   ! Flow velocity is downward or zero:
+                   if ( TRunoff%vr( nr, nt ) .ge. 0._r8 ) then
+                     totalVelo_down(nt) = totalVelo_down(nt) + TRunoff%vr( nr, nt )
+                     chnlNum_down(nt) = chnlNum_down(nt) + 1
+    
+                   ! Flow velocity is upward (is negative):
+                   else
+                     totalVelo_up(nt) = totalVelo_up(nt) + TRunoff%vr( nr, nt )
+                     chnlNum_up(nt) = chnlNum_up(nt) + 1
+                   end if
+    
+                 end if
+               end do
+             end do
+           end if
        end if
-
-       if ( budget_check ) then
-
-         do nt = 1, nt_rtm
-           do nr = rtmCTL%begr, rtmCTL%endr
-
-             if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then    ! 1 -- Land; 3 -- Basin outlet.
-             !if (Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2) then     ! 1 -- Land; 2 -- Basin outlet.
-
-               ! Flow velocity is downward or zero:
-               if ( TRunoff%vr( nr, nt ) .ge. 0._r8 ) then
-                 totalVelo_down(nt) = totalVelo_down(nt) + TRunoff%vr( nr, nt )
-                 chnlNum_down(nt) = chnlNum_down(nt) + 1
-
-               ! Flow velocity is upward (is negative):
-               else
-                 totalVelo_up(nt) = totalVelo_up(nt) + TRunoff%vr( nr, nt )
-                 chnlNum_up(nt) = chnlNum_up(nt) + 1
-               end if
-
-             end if
-           end do
-         end do
-       end if
-end if
 !#endif
        if(heatflag) then
          do n = rtmCTL%begr,rtmCTL%endr
@@ -2417,7 +2417,7 @@ end if
                  rtmCTL%templand_Tchanr(n) = rtmCTL%templand_Tchanr(n) + THeat%Tr_avg(n)
              end if
          enddo
-	   end if
+       end if
        
     enddo ! nsub
 
@@ -2434,10 +2434,10 @@ end if
     erlat_avg   = erlat_avg   / float(nsub)
 
 !#ifdef INCLUDE_INUND
-if (inundflag) then
-    ! Mean inundated floodplain area for all sub-steps of coupling period (for each land grid cell):
-    fa_fp_cplPeriod = fa_fp_cplPeriod / float(nsub)
-endif
+    if (inundflag) then
+        ! Mean inundated floodplain area for all sub-steps of coupling period (for each land grid cell):
+        fa_fp_cplPeriod = fa_fp_cplPeriod / float(nsub)
+    endif
 !#endif
 
     !-----------------------------------
@@ -2482,7 +2482,7 @@ endif
             rtmCTL%templand_Tchanr(n) = spval
          end if
       end do
-	end if
+    end if
 
     do nt = 1,nt_rtm
     do nr = rtmCTL%begr,rtmCTL%endr
@@ -2564,14 +2564,14 @@ endif
              if (StorWater%supply(nr) > 0) then            
                StorWater%supply(nr) = StorWater%supply(nr)/delt_coupling               
              endif
-			 
-			  !!!!!!!!!!!!!!!!!!
+             
+              !!!!!!!!!!!!!!!!!!
             ! do iunit=rtmCTL%begr,rtmCTL%endr
-			!if (StorWater%demand0(nr) >0) then
+            !if (StorWater%demand0(nr) >0) then
              ! StorWater%SupplyFrac(nr) = StorWater%Supply(nr) / StorWater%demand0(nr)   ! calculate the supply percentage relative to demand0, Tian June 2018
-			  !StorWater%SupplyFrac(nr) = StorWater%Supply(nr) / (StorWater%demand(nr) + StorWater%Supply(nr))  ! calculate the supply percentage relative to demand0, Tian June 2018
+              !StorWater%SupplyFrac(nr) = StorWater%Supply(nr) / (StorWater%demand(nr) + StorWater%Supply(nr))  ! calculate the supply percentage relative to demand0, Tian June 2018
 
-			  !write(iulog,*)'Tian get supply frac'
+              !write(iulog,*)'Tian get supply frac'
               !write(iulog,*)'supply is ',StorWater%Supply(nr)
               !write(iulog,*)'demand0 is ',StorWater%demand0(nr)
               !write(iulog,*)'frac is ',StorWater%SupplyFrac(nr)
@@ -2588,126 +2588,126 @@ endif
 !#endif
 
 !#ifdef INCLUDE_INUND
-if (inundflag) then
-       do nt = 1, nt_rtm
-         do nr = rtmCTL%begr, rtmCTL%endr
-           if (rtmCTL%mask(nr) .eq. 3) then        ! 3 -- Basin outlet (downstream is ocean).
-           !if ( Tunit%mask(nr) .eq. 2 ) then      ! 2 -- Basin outlet (downstream is ocean).
-             ! Total streamflow (flow rate) from land to oceans (m^3/s):
-             budget_terms(br_landOutflow, nt) = budget_terms(br_landOutflow, nt) + rtmCTL%runoff(nr, nt)
+       if (inundflag) then
+           do nt = 1, nt_rtm
+             do nr = rtmCTL%begr, rtmCTL%endr
+               if (rtmCTL%mask(nr) .eq. 3) then        ! 3 -- Basin outlet (downstream is ocean).
+               !if ( Tunit%mask(nr) .eq. 2 ) then      ! 2 -- Basin outlet (downstream is ocean).
+                 ! Total streamflow (flow rate) from land to oceans (m^3/s):
+                 budget_terms(br_landOutflow, nt) = budget_terms(br_landOutflow, nt) + rtmCTL%runoff(nr, nt)
+               end if
+             end do
+           end do
+    
+           ! If inundation scheme is turned on :
+           if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
+    
+             ! Total volume of flows from main channels to floodplains (for all local grid cells and all sub-steps of coupling period) (m^3):
+             budget_terms(bv_chnl2fp, 1) = vol_chnl2fp
+    
+             ! Total volume of flows from floodplains to main channels (for all local grid cells and all sub-steps of coupling period) (m^3):
+             budget_terms(bv_fp2chnl, 1) = vol_fp2chnl
+    
+             do nr = rtmCTL%begr, rtmCTL%endr
+               if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then      ! 1 -- Land; 3 -- Basin outlet.
+               !if ( Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2 ) then     ! 1--Land; 2--Basin outlet (downstream is ocean).
+    
+                 ! Water volume over floodplains at coupling-period end:
+                 if ( Tctl%OPT_inund .eq. 1 ) then
+                    budget_terms(bv_fp_f, 1) = budget_terms(bv_fp_f, 1) + TRunoff%wf_ini(nr)
+                 endif
+    
+                 ! Sum up channel surface area:
+                 budget_terms(bi_mainChnlArea, 1) = budget_terms(bi_mainChnlArea, 1) + TUnit%area(nr) * TUnit%frac(nr) * TUnit%a_chnl(nr)
+    
+                 ! Sum up flooded area (including channel area):
+                 budget_terms(bi_floodedArea, 1) = budget_terms(bi_floodedArea, 1) + fa_fp_cplPeriod(nr) + TUnit%area(nr) * TUnit%frac(nr) * TUnit%a_chnl(nr)
+    
+                 ! Sum up land area:
+                 budget_terms(bi_landArea, 1) = budget_terms(bi_landArea, 1) + TUnit%area(nr) * TUnit%frac(nr)
+               end if
+             end do
            end if
-         end do
-       end do
-
-       ! If inundation scheme is turned on :
-       if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
-
-         ! Total volume of flows from main channels to floodplains (for all local grid cells and all sub-steps of coupling period) (m^3):
-         budget_terms(bv_chnl2fp, 1) = vol_chnl2fp
-
-         ! Total volume of flows from floodplains to main channels (for all local grid cells and all sub-steps of coupling period) (m^3):
-         budget_terms(bv_fp2chnl, 1) = vol_fp2chnl
-
-         do nr = rtmCTL%begr, rtmCTL%endr
-           if (rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3) then      ! 1 -- Land; 3 -- Basin outlet.
-           !if ( Tunit%mask(nr) .eq. 1 .or. Tunit%mask(nr) .eq. 2 ) then     ! 1--Land; 2--Basin outlet (downstream is ocean).
-
-             ! Water volume over floodplains at coupling-period end:
-             if ( Tctl%OPT_inund .eq. 1 ) then
-                budget_terms(bv_fp_f, 1) = budget_terms(bv_fp_f, 1) + TRunoff%wf_ini(nr)
-             endif
-
-             ! Sum up channel surface area:
-             budget_terms(bi_mainChnlArea, 1) = budget_terms(bi_mainChnlArea, 1) + TUnit%area(nr) * TUnit%frac(nr) * TUnit%a_chnl(nr)
-
-             ! Sum up flooded area (including channel area):
-             budget_terms(bi_floodedArea, 1) = budget_terms(bi_floodedArea, 1) + fa_fp_cplPeriod(nr) + TUnit%area(nr) * TUnit%frac(nr) * TUnit%a_chnl(nr)
-
-             ! Sum up land area:
-             budget_terms(bi_landArea, 1) = budget_terms(bi_landArea, 1) + TUnit%area(nr) * TUnit%frac(nr)
-           end if
-         end do
-       end if
-
-       do nt = 1, nt_rtm
-         ! Total downward flow velocity (for all local grid cells and all sub-steps of coupling period) (m/s):
-         budget_terms(bVelo_downward, nt) = totalVelo_down(nt)
-
-         ! Total upward flow velocity (for all local grid cells and all sub-steps of coupling period) (m/s):
-         budget_terms(bVelo_upward, nt) = totalVelo_up(nt)
-
-         ! Total number of channels with downward flow velocities (for all local grid cells and all sub-steps of coupling period):
-         budget_terms(bVelo_downChnlNo, nt) = chnlNum_down(nt)
-
-         ! Total number of channels with upward flow velocities (for all local grid cells and all sub-steps of coupling period):
-         budget_terms(bVelo_upChnlNo, nt) = chnlNum_up(nt)
-       end do
-
-       !--- Debug: compare rtmCTL%mask() and Tunit%mask() ---
-       do nr = rtmCTL%begr, rtmCTL%endr
-         ! Tunit%mask() is land, but rtmCTL%mask() is not land :
-         if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .ne. 1 ) then
-           budget_terms(bmask_lndErr, 1) = budget_terms(bmask_lndErr, 1) + 1
-         end if
-
-         ! Tunit%mask() is basin outlet, but rtmCTL%mask() is not basin outlet :
-         if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .ne. 3 ) then
-           budget_terms(bmask_outErr, 1) = budget_terms(bmask_outErr, 1) + 1
-         end if
-
-         ! Tunit%mask() is ocean, but rtmCTL%mask() is not ocean :
-         if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .ne. 2 ) then
-           budget_terms(bmask_ocnErr, 1) = budget_terms(bmask_ocnErr, 1) + 1
-         end if
-
-         ! Tunit%mask() is land, rtmCTL%mask() is land :
-         if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 1 ) then
-           budget_terms(bmask_uLndrLnd, 1) = budget_terms(bmask_uLndrLnd, 1) + 1
-         end if
-
-         ! Tunit%mask() is land, rtmCTL%mask() is outlet :
-         if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 3 ) then
-           budget_terms(bmask_uLndrOut, 1) = budget_terms(bmask_uLndrOut, 1) + 1
-         end if
-
-         ! Tunit%mask() is land, rtmCTL%mask() is ocean :
-         if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 2 ) then
-           budget_terms(bmask_uLndrOcn, 1) = budget_terms(bmask_uLndrOcn, 1) + 1
-         end if
-
-         ! Tunit%mask() is outlet, rtmCTL%mask() is land :
-         if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 1 ) then
-           budget_terms(bmask_uOutrLnd, 1) = budget_terms(bmask_uOutrLnd, 1) + 1
-         end if
-
-         ! Tunit%mask() is outlet, rtmCTL%mask() is outlet :
-         if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 3 ) then
-           budget_terms(bmask_uOutrOut, 1) = budget_terms(bmask_uOutrOut, 1) + 1
-         end if
-
-         ! Tunit%mask() is outlet, rtmCTL%mask() is ocean :
-         if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 2 ) then
-           budget_terms(bmask_uOutrOcn, 1) = budget_terms(bmask_uOutrOcn, 1) + 1
-         end if
-
-         ! Tunit%mask() is ocean, rtmCTL%mask() is land :
-         if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 1 ) then
-           budget_terms(bmask_uOcnrLnd, 1) = budget_terms(bmask_uOcnrLnd, 1) + 1
-         end if
-
-         ! Tunit%mask() is ocean, rtmCTL%mask() is outlet :
-         if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 3 ) then
-           budget_terms(bmask_uOcnrOut, 1) = budget_terms(bmask_uOcnrOut, 1) + 1
-         end if
-
-         ! Tunit%mask() is ocean, rtmCTL%mask() is ocean :
-         if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 2 ) then
-           budget_terms(bmask_uOcnrOcn, 1) = budget_terms(bmask_uOcnrOcn, 1) + 1
-         end if
-
-       end do
-       !--- Debug ---
-endif
+    
+           do nt = 1, nt_rtm
+             ! Total downward flow velocity (for all local grid cells and all sub-steps of coupling period) (m/s):
+             budget_terms(bVelo_downward, nt) = totalVelo_down(nt)
+    
+             ! Total upward flow velocity (for all local grid cells and all sub-steps of coupling period) (m/s):
+             budget_terms(bVelo_upward, nt) = totalVelo_up(nt)
+    
+             ! Total number of channels with downward flow velocities (for all local grid cells and all sub-steps of coupling period):
+             budget_terms(bVelo_downChnlNo, nt) = chnlNum_down(nt)
+    
+             ! Total number of channels with upward flow velocities (for all local grid cells and all sub-steps of coupling period):
+             budget_terms(bVelo_upChnlNo, nt) = chnlNum_up(nt)
+           end do
+    
+           !--- Debug: compare rtmCTL%mask() and Tunit%mask() ---
+           do nr = rtmCTL%begr, rtmCTL%endr
+             ! Tunit%mask() is land, but rtmCTL%mask() is not land :
+             if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .ne. 1 ) then
+               budget_terms(bmask_lndErr, 1) = budget_terms(bmask_lndErr, 1) + 1
+             end if
+    
+             ! Tunit%mask() is basin outlet, but rtmCTL%mask() is not basin outlet :
+             if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .ne. 3 ) then
+               budget_terms(bmask_outErr, 1) = budget_terms(bmask_outErr, 1) + 1
+             end if
+    
+             ! Tunit%mask() is ocean, but rtmCTL%mask() is not ocean :
+             if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .ne. 2 ) then
+               budget_terms(bmask_ocnErr, 1) = budget_terms(bmask_ocnErr, 1) + 1
+             end if
+    
+             ! Tunit%mask() is land, rtmCTL%mask() is land :
+             if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 1 ) then
+               budget_terms(bmask_uLndrLnd, 1) = budget_terms(bmask_uLndrLnd, 1) + 1
+             end if
+    
+             ! Tunit%mask() is land, rtmCTL%mask() is outlet :
+             if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 3 ) then
+               budget_terms(bmask_uLndrOut, 1) = budget_terms(bmask_uLndrOut, 1) + 1
+             end if
+    
+             ! Tunit%mask() is land, rtmCTL%mask() is ocean :
+             if ( Tunit%mask(nr) .eq. 1 .and. rtmCTL%mask(nr) .eq. 2 ) then
+               budget_terms(bmask_uLndrOcn, 1) = budget_terms(bmask_uLndrOcn, 1) + 1
+             end if
+    
+             ! Tunit%mask() is outlet, rtmCTL%mask() is land :
+             if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 1 ) then
+               budget_terms(bmask_uOutrLnd, 1) = budget_terms(bmask_uOutrLnd, 1) + 1
+             end if
+    
+             ! Tunit%mask() is outlet, rtmCTL%mask() is outlet :
+             if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 3 ) then
+               budget_terms(bmask_uOutrOut, 1) = budget_terms(bmask_uOutrOut, 1) + 1
+             end if
+    
+             ! Tunit%mask() is outlet, rtmCTL%mask() is ocean :
+             if ( Tunit%mask(nr) .eq. 2 .and. rtmCTL%mask(nr) .eq. 2 ) then
+               budget_terms(bmask_uOutrOcn, 1) = budget_terms(bmask_uOutrOcn, 1) + 1
+             end if
+    
+             ! Tunit%mask() is ocean, rtmCTL%mask() is land :
+             if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 1 ) then
+               budget_terms(bmask_uOcnrLnd, 1) = budget_terms(bmask_uOcnrLnd, 1) + 1
+             end if
+    
+             ! Tunit%mask() is ocean, rtmCTL%mask() is outlet :
+             if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 3 ) then
+               budget_terms(bmask_uOcnrOut, 1) = budget_terms(bmask_uOcnrOut, 1) + 1
+             end if
+    
+             ! Tunit%mask() is ocean, rtmCTL%mask() is ocean :
+             if ( Tunit%mask(nr) .eq. 0 .and. rtmCTL%mask(nr) .eq. 2 ) then
+               budget_terms(bmask_uOcnrOcn, 1) = budget_terms(bmask_uOcnrOcn, 1) + 1
+             end if
+    
+           end do
+           !--- Debug ---
+       endif
 !#endif
 
        ! accumulate the budget total over the run to make sure it's decreasing on avg
@@ -3617,61 +3617,61 @@ endif
           allocate( TUnit%e_eprof_in2( 11, begr:endr ) )    
           ! --------------------------------- 
           ! (assign elevation values to TUnit%e_eprof_in2( :, : ) ). Tian Apr. 2018
-		   
-     ier = pio_inq_varid(ncid, name='ele0', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(1,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele0 ',minval(TUnit%e_eprof_in2(1,:)),maxval(TUnit%e_eprof_in2(1,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele1', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(2,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele1 ',minval(TUnit%e_eprof_in2(2,:)),maxval(TUnit%e_eprof_in2(2,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele2', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(3,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele2 ',minval(TUnit%e_eprof_in2(3,:)),maxval(TUnit%e_eprof_in2(3,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele3', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(4,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele3 ',minval(TUnit%e_eprof_in2(4,:)),maxval(TUnit%e_eprof_in2(4,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele4', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(5,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele4 ',minval(TUnit%e_eprof_in2(5,:)),maxval(TUnit%e_eprof_in2(5,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele5', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(6,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele5 ',minval(TUnit%e_eprof_in2(6,:)),maxval(TUnit%e_eprof_in2(6,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele6', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(7,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele6 ',minval(TUnit%e_eprof_in2(7,:)),maxval(TUnit%e_eprof_in2(7,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele7', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(8,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele7 ',minval(TUnit%e_eprof_in2(8,:)),maxval(TUnit%e_eprof_in2(8,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele8', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(9,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele8 ',minval(TUnit%e_eprof_in2(9,:)),maxval(TUnit%e_eprof_in2(9,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele9', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(10,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele9 ',minval(TUnit%e_eprof_in2(10,:)),maxval(TUnit%e_eprof_in2(10,:))
-     call shr_sys_flush(iulog)
-     
-     ier = pio_inq_varid(ncid, name='ele10', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(11,:), ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read ele10 ',minval(TUnit%e_eprof_in2(11,:)),maxval(TUnit%e_eprof_in2(11,:))
-     call shr_sys_flush(iulog)
+           
+          ier = pio_inq_varid(ncid, name='ele0', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(1,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele0 ',minval(TUnit%e_eprof_in2(1,:)),maxval(TUnit%e_eprof_in2(1,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele1', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(2,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele1 ',minval(TUnit%e_eprof_in2(2,:)),maxval(TUnit%e_eprof_in2(2,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele2', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(3,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele2 ',minval(TUnit%e_eprof_in2(3,:)),maxval(TUnit%e_eprof_in2(3,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele3', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(4,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele3 ',minval(TUnit%e_eprof_in2(4,:)),maxval(TUnit%e_eprof_in2(4,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele4', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(5,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele4 ',minval(TUnit%e_eprof_in2(5,:)),maxval(TUnit%e_eprof_in2(5,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele5', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(6,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele5 ',minval(TUnit%e_eprof_in2(6,:)),maxval(TUnit%e_eprof_in2(6,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele6', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(7,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele6 ',minval(TUnit%e_eprof_in2(7,:)),maxval(TUnit%e_eprof_in2(7,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele7', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(8,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele7 ',minval(TUnit%e_eprof_in2(8,:)),maxval(TUnit%e_eprof_in2(8,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele8', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(9,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele8 ',minval(TUnit%e_eprof_in2(9,:)),maxval(TUnit%e_eprof_in2(9,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele9', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(10,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele9 ',minval(TUnit%e_eprof_in2(10,:)),maxval(TUnit%e_eprof_in2(10,:))
+          call shr_sys_flush(iulog)
+          
+          ier = pio_inq_varid(ncid, name='ele10', vardesc=vardesc)
+          call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(11,:), ier)
+          if (masterproc) write(iulog,FORMR) trim(subname),' read ele10 ',minval(TUnit%e_eprof_in2(11,:)),maxval(TUnit%e_eprof_in2(11,:))
+          call shr_sys_flush(iulog)
      
           ! --------------------------------- 
 
@@ -3910,7 +3910,7 @@ endif
      end if
 !#endif
      
-	 if(heatflag) then
+     if(heatflag) then
         ! initialize heat states and fluxes
         allocate (THeat%forc_t(begr:endr))
         THeat%forc_t = 273.15_r8
@@ -3932,8 +3932,6 @@ endif
 
         allocate (THeat%Tt(begr:endr))
         THeat%Tt = 273.15_r8
-        !allocate (THeat%Ha_t(begr:endr))
-        !THeat%Ha_t = 0._r8
         allocate (THeat%Ha_h2t(begr:endr))
         THeat%Ha_h2t = 0._r8
         allocate (THeat%Ha_t2r(begr:endr))
@@ -3957,8 +3955,6 @@ endif
 
         allocate (THeat%Tr(begr:endr))
         THeat%Tr = 273.15_r8
-        !allocate (THeat%Ha_r(begr:endr))
-        !THeat%Ha_r = 0._r8
         allocate (THeat%Ha_rin(begr:endr))
         THeat%Ha_rin = 0._r8
         allocate (THeat%Ha_rout(begr:endr))
@@ -3988,27 +3984,20 @@ endif
         THeat%Tt_avg = 273.15_r8
         allocate (THeat%Tr_avg(begr:endr))
         THeat%Tr_avg = 273.15_r8
-		
+        
        ! read the parameters for mosart-heat
         if(endr >= begr) then
-            !call check_ret(nf_open(frivinp_rtm, 0, ncid), 'Reading file: ' // frivinp_rtm)
             allocate(TPara%t_alpha(begr:endr))    
            TPara%t_alpha = 27.19_r8
-            !call MOSART_read_dbl(ncid, 'alpha', TPara%t_alpha)
             allocate(TPara%t_beta(begr:endr))
            TPara%t_beta = 13.63_r8
-            !call MOSART_read_dbl(ncid, 'beta', TPara%t_beta)
             allocate(TPara%t_gamma(begr:endr))
            TPara%t_gamma = 0.1576_r8
-            !call MOSART_read_dbl(ncid, 'gamma', TPara%t_gamma)
              allocate(TPara%t_mu(begr:endr))
            TPara%t_mu = 0.5278_r8
-            !call MOSART_read_dbl(ncid, 'mu', TPara%t_mu)
-           
-            !call check_ret(nf_close(ncid), subname)
         end if
-    end if
-	
+     end if
+    
      call pio_freedecomp(ncid, iodesc_dbl)
      call pio_freedecomp(ncid, iodesc_int)
      call pio_closefile(ncid)
@@ -4076,9 +4065,9 @@ endif
 
         if (inundflag) then
 !#ifdef INCLUDE_INUND
-if (inundflag) then
+        if (inundflag) then
            TUnit%rslp(iunit) = Tctl%rslp_assume
-endif
+        endif
 !#endif
         else
            TUnit%rslp(iunit) = 0.0001_r8

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -352,6 +352,8 @@ endif
     call mpi_bcast (do_rtmflood,    1, MPI_LOGICAL, 0, mpicom_rof, ier)
     call mpi_bcast (ice_runoff,     1, MPI_LOGICAL, 0, mpicom_rof, ier)
     call mpi_bcast (wrmflag,        1, MPI_LOGICAL, 0, mpicom_rof, ier)
+    call mpi_bcast (sediflag,       1, MPI_LOGICAL, 0, mpicom_rof, ier)
+    call mpi_bcast (heatflag,       1, MPI_LOGICAL, 0, mpicom_rof, ier)
     call mpi_bcast (inundflag,      1, MPI_LOGICAL, 0, mpicom_rof, ier)
     call mpi_bcast (barrier_timers, 1, MPI_LOGICAL, 0, mpicom_rof, ier)
 
@@ -429,6 +431,8 @@ endif
        write(iulog,*) '   smat_option           = ',trim(smat_option)
        write(iulog,*) '   wrmflag               = ',wrmflag
        write(iulog,*) '   inundflag             = ',inundflag
+       write(iulog,*) '   sediflag              = ',inundflag
+       write(iulog,*) '   heatflag              = ',inundflag
        write(iulog,*) '   barrier_timers        = ',barrier_timers
        write(iulog,*) '   RoutingMethod         = ',Tctl%RoutingMethod
        write(iulog,*) '   DLevelH2R             = ',Tctl%DLevelH2R
@@ -1993,6 +1997,7 @@ endif
  end if
 !#endif
 
+    if(heatflag) then
     rtmCTL%templand_Tqsur = spval
     rtmCTL%templand_Tqsub = spval
     rtmCTL%templand_Ttrib = spval
@@ -2005,7 +2010,8 @@ endif
             rtmCTL%templand_Tchanr(n) = 0._r8
         end if
     end do
-    
+    end if
+	
     if (budget_check) then
        call t_startf('mosartr_budget')
        do nt = 1,nt_rtm
@@ -3900,7 +3906,8 @@ endif
         endif
      end if
 !#endif
-
+     
+	 if(heatflag) then
         ! initialize heat states and fluxes
         allocate (THeat%forc_t(begr:endr))
         THeat%forc_t = 273.15_r8
@@ -3978,26 +3985,27 @@ endif
         THeat%Tt_avg = 273.15_r8
         allocate (THeat%Tr_avg(begr:endr))
         THeat%Tr_avg = 273.15_r8
-     
-    ! read the parameters for mosart-heat
-     if(endr >= begr) then
-         !call check_ret(nf_open(frivinp_rtm, 0, ncid), 'Reading file: ' // frivinp_rtm)
-         allocate(TPara%t_alpha(begr:endr))    
-        TPara%t_alpha = 27.19_r8
-         !call MOSART_read_dbl(ncid, 'alpha', TPara%t_alpha)
-         allocate(TPara%t_beta(begr:endr))
-        TPara%t_beta = 13.63_r8
-         !call MOSART_read_dbl(ncid, 'beta', TPara%t_beta)
-         allocate(TPara%t_gamma(begr:endr))
-        TPara%t_gamma = 0.1576_r8
-         !call MOSART_read_dbl(ncid, 'gamma', TPara%t_gamma)
-          allocate(TPara%t_mu(begr:endr))
-        TPara%t_mu = 0.5278_r8
-         !call MOSART_read_dbl(ncid, 'mu', TPara%t_mu)
-        
-         !call check_ret(nf_close(ncid), subname)
-     end if
-
+		
+       ! read the parameters for mosart-heat
+        if(endr >= begr) then
+            !call check_ret(nf_open(frivinp_rtm, 0, ncid), 'Reading file: ' // frivinp_rtm)
+            allocate(TPara%t_alpha(begr:endr))    
+           TPara%t_alpha = 27.19_r8
+            !call MOSART_read_dbl(ncid, 'alpha', TPara%t_alpha)
+            allocate(TPara%t_beta(begr:endr))
+           TPara%t_beta = 13.63_r8
+            !call MOSART_read_dbl(ncid, 'beta', TPara%t_beta)
+            allocate(TPara%t_gamma(begr:endr))
+           TPara%t_gamma = 0.1576_r8
+            !call MOSART_read_dbl(ncid, 'gamma', TPara%t_gamma)
+             allocate(TPara%t_mu(begr:endr))
+           TPara%t_mu = 0.5278_r8
+            !call MOSART_read_dbl(ncid, 'mu', TPara%t_mu)
+           
+            !call check_ret(nf_close(ncid), subname)
+        end if
+    end if
+	
      call pio_freedecomp(ncid, iodesc_dbl)
      call pio_freedecomp(ncid, iodesc_int)
      call pio_closefile(ncid)

--- a/components/mosart/src/riverroute/RunoffMod.F90
+++ b/components/mosart/src/riverroute/RunoffMod.F90
@@ -136,7 +136,7 @@ module RunoffMod
      real(r8), pointer :: templand_Tqsub_nt2(:)
      real(r8), pointer :: templand_Ttrib_nt2(:)
      real(r8), pointer :: templand_Tchanr_nt2(:)
-	 
+     
   end type runoff_flow
 
   

--- a/components/mosart/src/riverroute/RunoffMod.F90
+++ b/components/mosart/src/riverroute/RunoffMod.F90
@@ -79,6 +79,11 @@ module RunoffMod
      real(r8), pointer :: wt(:,:)          ! MOSART sub-network water storage (m3)
      real(r8), pointer :: wr(:,:)          ! MOSART main channel water storage (m3)
      real(r8), pointer :: erout(:,:)       ! MOSART flow out of the main channel, instantaneous (m3/s) (negative is out)
+     real(r8), pointer :: Tqsur(:)         ! MOSART hillslope surface runoff water temperature (K)
+     real(r8), pointer :: Tqsub(:)         ! MOSART hillslope subsurface runoff water temperature (K)
+     real(r8), pointer :: Tt(:)            ! MOSART sub-network water temperature (K)
+     real(r8), pointer :: Tr(:)            ! MOSART main channel water temperature (K)
+     real(r8), pointer :: Ha_rout(:)       ! MOSART heat flux out of the main channel, instantaneous (Watt)
 
      ! inputs
      real(r8), pointer :: qsur(:,:)        ! coupler surface forcing [m3/s]
@@ -105,6 +110,7 @@ module RunoffMod
      real(r8), pointer :: dvolrdtlnd_nt2(:)
      real(r8), pointer :: dvolrdtocn_nt1(:)
      real(r8), pointer :: dvolrdtocn_nt2(:)
+     real(r8), pointer :: wr_nt1(:)
      real(r8), pointer :: volr_nt1(:)
      real(r8), pointer :: volr_nt2(:)
      real(r8), pointer :: qsur_nt1(:)
@@ -118,6 +124,19 @@ module RunoffMod
      real(r8), pointer :: qdem_nt1(:)
      real(r8), pointer :: qdem_nt2(:)
 
+     real(r8), pointer :: templand_Tqsur(:)
+     real(r8), pointer :: templand_Tqsub(:)
+     real(r8), pointer :: templand_Ttrib(:)
+     real(r8), pointer :: templand_Tchanr(:)     
+     real(r8), pointer :: templand_Tqsur_nt1(:)
+     real(r8), pointer :: templand_Tqsub_nt1(:)
+     real(r8), pointer :: templand_Ttrib_nt1(:)
+     real(r8), pointer :: templand_Tchanr_nt1(:)
+     real(r8), pointer :: templand_Tqsur_nt2(:)
+     real(r8), pointer :: templand_Tqsub_nt2(:)
+     real(r8), pointer :: templand_Ttrib_nt2(:)
+     real(r8), pointer :: templand_Tchanr_nt2(:)
+	 
   end type runoff_flow
 
   
@@ -378,6 +397,65 @@ module RunoffMod
    
   end type TstatusFlux
   !== Hongyi
+
+
+  ! heat status and flux variables
+  public :: TstatusFlux_heat
+  type TstatusFlux_heat
+      ! overall
+      real(r8), pointer :: forc_t(:)      ! atmospheric temperature (Kelvin)
+      real(r8), pointer :: forc_pbot(:)   ! atmospheric pressure (Pa)
+      real(r8), pointer :: forc_vp(:)     ! atmospheric vapor pressure (Pa)
+      real(r8), pointer :: forc_wind(:)   ! atmospheric wind speed (m/s)
+      real(r8), pointer :: forc_lwrad(:)  ! downward infrared (longwave) radiation (W/m**2)
+      real(r8), pointer :: forc_solar(:)  ! atmospheric incident solar (shortwave) radiation (W/m**2)
+      
+      ! hillsloope
+      !! states
+      real(r8), pointer :: Tqsur(:)       ! temperature of surface runoff, [K]
+      real(r8), pointer :: Tqsub(:)       ! temperature of subsurface runoff, [K]
+      real(r8), pointer :: Tqice(:)       ! temperature of ice flow, [K]
+      !! fluxes
+      
+      ! subnetwork channel
+      !! states
+      real(r8), pointer :: Tt(:)            ! temperature of subnetwork water, [K]
+      !! fluxes
+      !real(r8), pointer :: Ha_t(:)       ! advective heat flux through the subnetwork, [Watt]
+      real(r8), pointer :: Ha_h2t(:)      ! advective heat flux from hillslope into the subnetwork, [Watt]
+      real(r8), pointer :: Ha_t2r(:)      ! advective heat flux from subnetwork channel into the main channel, [Watt]
+      real(r8), pointer :: Ha_lateral(:)  ! average advective heat flux from subnetwork channel into the main channel, [Watt], corresponding to TRunoff%erlateral
+      real(r8), pointer :: Hs_t(:)        ! net solar short-wave radiation, [Watt]
+      real(r8), pointer :: Hl_t(:)        ! net solar long-wave radiation, [Watt]
+      real(r8), pointer :: He_t(:)        ! flux of latent heat, [Watt]
+      real(r8), pointer :: Hh_t(:)        ! flux of sensible heat, [Watt]
+      real(r8), pointer :: Hc_t(:)        ! conductive heat flux at the streambed, [Watt]
+      real(r8), pointer :: deltaH_t(:)    ! net heat exchange with surroundings, [J]
+      real(r8), pointer :: deltaM_t(:)    ! net heat change due to inflow, [J]
+
+      ! main channel
+      !! states
+      real(r8), pointer :: Tr(:)            ! temperature of main channel water, [K]
+      !! fluxes
+      !real(r8), pointer :: Ha_r(:)       ! advective heat flux through the main channel, [Watt]
+      real(r8), pointer :: Ha_rin(:)      ! advective heat flux from upstream into the main channel, [Watt]
+      real(r8), pointer :: Ha_rout(:)     ! advective heat flux to downstream channel, [Watt]
+      real(r8), pointer :: Ha_eroutUp(:) ! outflow sum of upstream gridcells, instantaneous (Watt)
+      real(r8), pointer :: Ha_eroutUp_avg(:) ! outflow sum of upstream gridcells, average [Watt]
+      real(r8), pointer :: Ha_erlat_avg(:) ! erlateral average [Watt]
+      real(r8), pointer :: Hs_r(:)        ! net solar short-wave radiation, [Watt]
+      real(r8), pointer :: Hl_r(:)        ! net solar long-wave radiation, [Watt]
+      real(r8), pointer :: He_r(:)        ! flux of latent heat, [Watt]
+      real(r8), pointer :: Hh_r(:)        ! flux of sensible heat, [Watt]
+      real(r8), pointer :: Hc_r(:)        ! conductive heat flux at the streambed, [Watt]
+      real(r8), pointer :: deltaH_r(:)    ! net heat exchange with surroundings, [J]
+      real(r8), pointer :: deltaM_r(:)    ! net heat change due to inflow, [J]
+
+      real(r8), pointer :: Tt_avg(:)      ! average temperature of subnetwork channel water, [K], for output purpose
+      real(r8), pointer :: Tr_avg(:)      ! average temperature of main channel water, [K], for output purpose
+      
+  end type TstatusFlux_heat
+
  
   ! parameters to be calibrated. Ideally, these parameters are supposed to be uniform for one region
   public :: Tparameter
@@ -385,12 +463,17 @@ module RunoffMod
      real(r8), pointer :: c_nr(:)       ! coefficient to adjust the manning's roughness of channels
      real(r8), pointer :: c_nh(:)       ! coefficient to adjust the manning's roughness of overland flow across hillslopes
      real(r8), pointer :: c_twid(:)     ! coefficient to adjust the width of sub-reach channel
+     real(r8), pointer :: t_alpha(:)    ! alpha parameter in air-water temperature relationship (S-curve)
+     real(r8), pointer :: t_beta(:)     ! beta parameter in air-water temperature relationship (S-curve)
+     real(r8), pointer :: t_gamma(:)    ! gamma parameter in air-water temperature relationship (S-curve)
+     real(r8), pointer :: t_mu(:)       ! mu parameter in air-water temperature relationship (S-curve)
   end type Tparameter 
 
   !== Hongyi
   type (Tcontrol)    , public :: Tctl
   type (Tspatialunit), public :: TUnit
   type (TstatusFlux) , public :: TRunoff
+  type (TstatusFlux_heat), public :: THeat
   type (Tparameter)  , public :: TPara
   !== Hongyi
 
@@ -439,6 +522,7 @@ contains
              rtmCTL%dvolrdtlnd_nt2(begr:endr),    &
              rtmCTL%dvolrdtocn_nt1(begr:endr),    &
              rtmCTL%dvolrdtocn_nt2(begr:endr),    &
+             rtmCTL%wr_nt1(begr:endr),          &
              rtmCTL%qsur_nt1(begr:endr),          &
              rtmCTL%qsur_nt2(begr:endr),          &
              rtmCTL%qsub_nt1(begr:endr),          &
@@ -465,6 +549,23 @@ contains
              rtmCTL%qgwl(begr:endr,nt_rtm),       &
              rtmCTL%qdto(begr:endr,nt_rtm),       &
              rtmCTL%qdem(begr:endr,nt_rtm),       & 
+             rtmCTL%Tqsur(begr:endr),                 &
+             rtmCTL%Tqsub(begr:endr),                 &
+             rtmCTL%Tt(begr:endr),                    &
+             rtmCTL%Tr(begr:endr),                    &
+             rtmCTL%Ha_rout(begr:endr),               &
+             rtmCTL%templand_Tqsur(begr:endr),        &
+             rtmCTL%templand_Tqsub(begr:endr),        &
+             rtmCTL%templand_Ttrib(begr:endr),        &
+             rtmCTL%templand_Tchanr(begr:endr),       &
+             rtmCTL%templand_Tqsur_nt1(begr:endr),    &
+             rtmCTL%templand_Tqsub_nt1(begr:endr),    &
+             rtmCTL%templand_Ttrib_nt1(begr:endr),    &
+             rtmCTL%templand_Tchanr_nt1(begr:endr),   &
+             rtmCTL%templand_Tqsur_nt2(begr:endr),    &
+             rtmCTL%templand_Tqsub_nt2(begr:endr),    &
+             rtmCTL%templand_Ttrib_nt2(begr:endr),    &
+             rtmCTL%templand_Tchanr_nt2(begr:endr),   &
              stat=ier)
     if (ier /= 0) then
        write(iulog,*)'Rtmini ERROR allocation of runoff local arrays'
@@ -490,6 +591,11 @@ contains
     rtmCTL%qgwl(:,:)        = 0._r8
     rtmCTL%qdto(:,:)        = 0._r8
     rtmCTL%qdem(:,:)        = 0._r8
+
+    rtmCTL%templand_Tqsur(:)  = spval
+    rtmCTL%templand_Tqsub(:)  = spval
+    rtmCTL%templand_Ttrib(:)  = spval
+    rtmCTL%templand_Tchanr(:) = spval
 
   end subroutine RunoffInit
 

--- a/components/mosart/src/riverroute/RunoffMod.F90
+++ b/components/mosart/src/riverroute/RunoffMod.F90
@@ -11,7 +11,7 @@ module RunoffMod
 ! !USES:
   use shr_kind_mod, only : r8 => shr_kind_r8
   use mct_mod
-  use RtmVar         , only : iulog, spval
+  use RtmVar         , only : iulog, spval, heatflag
   use rof_cpl_indices, only : nt_rtm
 
 ! !PUBLIC TYPES:
@@ -549,23 +549,6 @@ contains
              rtmCTL%qgwl(begr:endr,nt_rtm),       &
              rtmCTL%qdto(begr:endr,nt_rtm),       &
              rtmCTL%qdem(begr:endr,nt_rtm),       & 
-             rtmCTL%Tqsur(begr:endr),                 &
-             rtmCTL%Tqsub(begr:endr),                 &
-             rtmCTL%Tt(begr:endr),                    &
-             rtmCTL%Tr(begr:endr),                    &
-             rtmCTL%Ha_rout(begr:endr),               &
-             rtmCTL%templand_Tqsur(begr:endr),        &
-             rtmCTL%templand_Tqsub(begr:endr),        &
-             rtmCTL%templand_Ttrib(begr:endr),        &
-             rtmCTL%templand_Tchanr(begr:endr),       &
-             rtmCTL%templand_Tqsur_nt1(begr:endr),    &
-             rtmCTL%templand_Tqsub_nt1(begr:endr),    &
-             rtmCTL%templand_Ttrib_nt1(begr:endr),    &
-             rtmCTL%templand_Tchanr_nt1(begr:endr),   &
-             rtmCTL%templand_Tqsur_nt2(begr:endr),    &
-             rtmCTL%templand_Tqsub_nt2(begr:endr),    &
-             rtmCTL%templand_Ttrib_nt2(begr:endr),    &
-             rtmCTL%templand_Tchanr_nt2(begr:endr),   &
              stat=ier)
     if (ier /= 0) then
        write(iulog,*)'Rtmini ERROR allocation of runoff local arrays'
@@ -586,16 +569,44 @@ contains
     rtmCTL%inundhf(:)      = 0._r8
     rtmCTL%inundff(:)      = 0._r8
     rtmCTL%inundffunit(:)  = 0._r8
-    rtmCTL%qsur(:,:)        = 0._r8
-    rtmCTL%qsub(:,:)        = 0._r8
-    rtmCTL%qgwl(:,:)        = 0._r8
-    rtmCTL%qdto(:,:)        = 0._r8
-    rtmCTL%qdem(:,:)        = 0._r8
-
-    rtmCTL%templand_Tqsur(:)  = spval
-    rtmCTL%templand_Tqsub(:)  = spval
-    rtmCTL%templand_Ttrib(:)  = spval
-    rtmCTL%templand_Tchanr(:) = spval
+    rtmCTL%qsur(:,:)       = 0._r8
+    rtmCTL%qsub(:,:)       = 0._r8
+    rtmCTL%qgwl(:,:)       = 0._r8
+    rtmCTL%qdto(:,:)       = 0._r8
+    rtmCTL%qdem(:,:)       = 0._r8
+    
+    if (heatflag) then
+      allocate(rtmCTL%Tqsur(begr:endr),                 &
+               rtmCTL%Tqsub(begr:endr),                 &
+               rtmCTL%Tt(begr:endr),                    &
+               rtmCTL%Tr(begr:endr),                    &
+               rtmCTL%Ha_rout(begr:endr),               &
+               rtmCTL%templand_Tqsur(begr:endr),        &
+               rtmCTL%templand_Tqsub(begr:endr),        &
+               rtmCTL%templand_Ttrib(begr:endr),        &
+               rtmCTL%templand_Tchanr(begr:endr),       &
+               rtmCTL%templand_Tqsur_nt1(begr:endr),    &
+               rtmCTL%templand_Tqsub_nt1(begr:endr),    &
+               rtmCTL%templand_Ttrib_nt1(begr:endr),    &
+               rtmCTL%templand_Tchanr_nt1(begr:endr),   &
+               rtmCTL%templand_Tqsur_nt2(begr:endr),    &
+               rtmCTL%templand_Tqsub_nt2(begr:endr),    &
+               rtmCTL%templand_Ttrib_nt2(begr:endr),    &
+               rtmCTL%templand_Tchanr_nt2(begr:endr),   &
+               stat=ier)
+      if (ier /= 0) then
+         write(iulog,*)'Rtmini ERROR allocation of runoff local arrays'
+         call shr_sys_abort
+      end if
+      
+      rtmCTL%Tqsur(:)        = 273.15_r8
+      rtmCTL%Tqsub(:)        = 273.15_r8
+      rtmCTL%templand_Tqsur(:)  = spval
+      rtmCTL%templand_Tqsub(:)  = spval
+      rtmCTL%templand_Ttrib(:)  = spval
+      rtmCTL%templand_Tchanr(:) = spval
+      
+    end if
 
   end subroutine RunoffInit
 


### PR DESCRIPTION
Added a new submodule to MOSART, MOSART-heat, which simulates water 
temperature in the rivers. MOSART-heat is coupled to both ELM and EAM. 
More specifically, MOSART-heat needs the runoff and soil temperature 
simulated by ELM, and solar radiation, wind speed etc. from EAM. 
To couple MOSART-heat with EAM, we newly added the ATM2ROF 
mapping (including code changes and several new ATM2ROF mapping files) 
which did not exist previously in E3SM. MOSART-heat can be turned on/off
with a heatflag option in user_nl_mosart.  

[BFB]
[NML]