### PR TITLE
Fix DTESTM compset definition and add to automated testing

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -136,6 +136,7 @@ _TESTS = {
             "SMS_D_Ln5.conusx4v1_conusx4v1.FC5AV1C-L",
             "SMS.ne30_oECv3.BGCEXP_BCRC_CNPECACNT_1850.clm-bgcexp",
             "SMS.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850.clm-bgcexp",
+            "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
             )
         },
 

--- a/components/mpas-seaice/cime_config/config_compsets.xml
+++ b/components/mpas-seaice/cime_config/config_compsets.xml
@@ -11,12 +11,12 @@
 
   <compset>
     <alias>DTESTM</alias>
-    <lname>2000_DATM%NYF_SLND_MPASSI_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST </lname>
+    <lname>2000_DATM%NYF_SLND_MPASSI_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST</lname>
   </compset>
 
   <compset>
     <alias>DTESTM-BGC</alias>
-    <lname>2000_DATM%NYF_SLND_MPASSI%BGC_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST </lname>
+    <lname>2000_DATM%NYF_SLND_MPASSI%BGC_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST</lname>
   </compset>
 
 </compsets>


### PR DESCRIPTION
This PR fixes the DTESTM and DTESTM-BGC compsets, which have active seaice only, by removing an incorrect space in the long names. It also adds a new test for the DTESTM compset to the automated testing suite, SMS_D_Ld1.T62_oEC60to30v3.DTESTM.

Fixes #2953 
[BFB]