### PR TITLE
preview_run: Fix case where mpirun cmd uses env vars

### DIFF
--- a/cime/scripts/Tools/preview_run
+++ b/cime/scripts/Tools/preview_run
@@ -66,10 +66,10 @@ def _main_func(description):
         job_id_to_cmd = case.submit_jobs(dry_run=True, job=job)
         env_batch = case.get_env('batch')
         for job_id, cmd in job_id_to_cmd:
-            overrides = env_batch.get_job_overrides(job_id, case)
             print("  FOR JOB: {}".format(job_id))
             print("    ENV:")
             case.load_env(job=job_id, reset=True, verbose=True)
+
             if "OMP_NUM_THREADS" in os.environ:
                 print("      Setting Environment OMP_NUM_THREADS={}".format(os.environ["OMP_NUM_THREADS"]))
             print("")
@@ -77,11 +77,12 @@ def _main_func(description):
             print("      {}".format(case.get_resolved_value(cmd)))
             print("")
 
+            # get_job_overrides must come after the case.load_env since the cmd may use
+            # env vars.
+            overrides = env_batch.get_job_overrides(job_id, case)
             print("    MPIRUN (job={}):".format(job_id))
-            print ("      {}".format(overrides["mpirun"]))
+            print ("      {}".format(case.get_resolved_value(overrides["mpirun"])))
             print("")
-            
-
 
 if __name__ == "__main__":
     _main_func(__doc__)


### PR DESCRIPTION
The mpirun cmd was being retrieved before the full environment was
being loaded, leading to unresolved env vars appearing in the command.

[BFB]