### PR TITLE
Remove the module craype-hugepages2M for Cori.

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -273,6 +273,7 @@
       <command name="rm">cray-petsc</command>
       <command name="rm">esmf</command>
       <command name="rm">zlib</command>
+      <command name="rm">craype-hugepages2M</command>
 
       <!-- first load basic defaults, then remove/swap/load as necessary -->
       <command name="load">craype</command>
@@ -419,6 +420,7 @@
       <command name="rm">cray-petsc</command>
       <command name="rm">esmf</command>
       <command name="rm">zlib</command>
+      <command name="rm">craype-hugepages2M</command>
 
       <!-- first load basic defaults, then remove/swap/load as necessary -->
       <command name="load">craype</command>


### PR DESCRIPTION
Remove the module craype-hugepages2M for Cori.
This module was added as a default module after the Cori SW upgrade.
It was not expected to have an impact, and perhaps does not.
However, it's best to keep environment as close as possible to what it was before upgrade.
This module *might* be causing some non-reproducable runtime errors.

[BFB]