### PR TITLE
bug fix for SCM time index

### DIFF
--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -446,6 +446,7 @@ subroutine setiopupdate
    integer bdate, bdate_varID
    integer STATUS
    integer next_date, next_sec, last_date, last_sec
+   integer next_date_print, next_sec_print
    integer :: ncsec,ncdate                      ! current time of day,date
    integer :: yr, mon, day                      ! year, month, and day component
    integer :: start_ymd,start_tod
@@ -553,16 +554,16 @@ subroutine setiopupdate
 
       doiopupdate = .false.
       iopTimeIdx = iopTimeIdx
-      i=0
       doiter=.true.
       do while(doiter)
-        call timemgr_time_inc(bdate, 0, next_date, next_sec,inc_s=tsec(iopTimeIdx+i+1))
+        call timemgr_time_inc(bdate, 0, next_date, next_sec,inc_s=tsec(iopTimeIdx+1))
         if (ncdate .gt. next_date .or. (ncdate .eq. next_date &
           .and. ncsec .ge. next_sec)) then
 
           doiopupdate=.true.
-          i=i+1
           iopTimeIdx=iopTimeIdx+1
+	  next_date_print = next_date
+	  next_sec_print = next_sec
         else
           doiter=.false.
         endif
@@ -576,10 +577,11 @@ subroutine setiopupdate
 
       if (doiopupdate) then
 
-          write(iulog,*) 'iopTimeIdx =', iopTimeIdx
+          write(iulog,*) 'iopTimeIdx (IOP index) =', iopTimeIdx
           write(iulog,*) 'nstep = ',get_nstep()
-          write(iulog,*) 'ncdate=',ncdate,' ncsec=',ncsec
-          write(iulog,*) 'next_date=',next_date,' next_sec=',next_sec
+          write(iulog,*) 'ncdate (E3SM date) =',ncdate,' ncsec=',ncsec
+          write(iulog,*) 'next_date (IOP file date) =',next_date_print,' &
+	                  next_sec=',next_sec_print
           write(iulog,*)'******* do iop update'
       endif
 


### PR DESCRIPTION
This bug fix effects single column model (SCM) cases when the temporal resolution of the forcing is different than that of E3SM.  Here the index "i" in the iteration loop to find the next available forcing is redundant and can result in forcing being read in with a time step lag.  

Also cleaned up the print statements to the E3SM logs to make them more verbose and to print out the correct values.

All E3SM developer tests pass, except SMS_R_Ld5.ne4_ne4.FSCM5A97, which is an expected fail