### PR TITLE
Update CIME to ESMCI cime5.8.8

### DIFF
--- a/cime/config/cesm/config_grids.xml
+++ b/cime/config/cesm/config_grids.xml
@@ -954,6 +954,13 @@
       <mask>gx1v7</mask>
     </model_grid>
 
+    <model_grid alias="ne120pg3_ne120pg3_mt13" not_compset="_POP">
+      <grid name="atm">ne120np4.pg3</grid>
+      <grid name="lnd">ne120np4.pg3</grid>
+      <grid name="ocnice">ne120np4.pg3</grid>
+      <mask>tx0.1v3</mask>
+    </model_grid>
+
     <model_grid alias="ne240pg3_ne240pg3_mg17" not_compset="_POP|_CLM">
       <grid name="atm">ne240np4.pg3</grid>
       <grid name="lnd">ne240np4.pg3</grid>
@@ -966,6 +973,13 @@
       <grid name="lnd">ne120np4.pg3</grid>
       <grid name="ocnice">gx1v7</grid>
       <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne120pg3_t13">
+      <grid name="atm">ne120np4.pg3</grid>
+      <grid name="lnd">ne120np4.pg3</grid>
+      <grid name="ocnice">gx1v7</grid>
+      <mask>tx0.1v3</mask>
     </model_grid>
 
     <!--  spectral element grids with 4x4 FVM physics grid -->
@@ -1455,6 +1469,8 @@
       <nx>777600</nx> <ny>1</ny>
       <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg3_gx1v7.190718.nc</file>
       <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg3_gx1v7.190718.nc</file>
+      <file grid="atm|lnd" mask="tx0.1v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg3_tx0.1v3.190820.nc</file>
+      <file grid="ocnice"  mask="tx0.1v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg3_tx0.1v3.190820.nc</file>
       <desc>ne120np4.pg3 is a Spectral Elem 0.25-deg grid with a 3x3 FVM physics grid:</desc>
       <support>EXPERIMENTAL FVM physics grid</support>
     </domain>

--- a/cime/config/cesm/config_grids_mct.xml
+++ b/cime/config/cesm/config_grids_mct.xml
@@ -191,6 +191,13 @@
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne120np4.pg3_aave.190718.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne120np4.pg3_aave.190718.nc</map>
     </gridmap>
+    <gridmap atm_grid="ne120np4.pg3" ocn_grid="tx0.1v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_tx0.1v3_aave.190820.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_tx0.1v3_blin.190820.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_tx0.1v3_blin.190820.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/tx0.1v3/map_tx0.1v3_TO_ne120np4.pg3_aave.190820.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/tx0.1v3/map_tx0.1v3_TO_ne120np4.pg3_aave.190820.nc</map>
+    </gridmap>
     <gridmap atm_grid="ne120np4.pg3" wav_grid="ww3a">
       <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_ww3a_blin.190503.nc</map>
     </gridmap>

--- a/cime/config/cesm/machines/config_compilers.xml
+++ b/cime/config/cesm/machines/config_compilers.xml
@@ -721,7 +721,7 @@ using a fortran linker.
     <append> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </append>
   </SLIBS>
     <CPPDEFS>
-    <append MODEL="gptl"> -DHAVE_PAPI -DHAVE_SLASHPROC </append>
+    <append MODEL="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
   <LDFLAGS>
     <append>-mkl </append>

--- a/cime/config/cesm/machines/config_machines.xml
+++ b/cime/config/cesm/machines/config_machines.xml
@@ -355,7 +355,7 @@ This allows using a different mpirun command to launch unit tests
 
   <machine MACH="cheyenne">
     <DESC>NCAR SGI platform, os is Linux, 36 pes/node, batch system is PBS</DESC>
-    <NODENAME_REGEX>.*.cheyenne.ucar.edu</NODENAME_REGEX>
+    <NODENAME_REGEX>.*.?cheyenne\d?.ucar.edu</NODENAME_REGEX>
     <!-- MPT sometimes timesout at model start time, the next two lines cause
     case_run.py to detect the timeout and retry FORCE_SPARE_NODES times -->
     <MPIRUN_RETRY_REGEX>MPT: Launcher network accept (MPI_LAUNCH_TIMEOUT) timed out</MPIRUN_RETRY_REGEX>
@@ -363,7 +363,7 @@ This allows using a different mpirun command to launch unit tests
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu,pgi</COMPILERS>
     <MPILIBS compiler="intel" >mpt,openmpi</MPILIBS>
-    <MPILIBS compiler="pgi" >mpt</MPILIBS>
+    <MPILIBS compiler="pgi" >openmpi,mpt</MPILIBS>
     <MPILIBS compiler="gnu" >openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/glade/scratch/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
@@ -438,7 +438,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">esmf-7.1.0r-ncdfio-uni-O</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/17.9</command>
+	<command name="load">pgi/19.3</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">gnu/7.3.0</command>
@@ -455,15 +455,19 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules mpilib="mpt" compiler="pgi">
 	<command name="load">mpt/2.19</command>
-	<command name="load">netcdf-mpi/4.6.1</command>
-	<command name="load">pnetcdf/1.11.0</command>
+	<command name="load">netcdf-mpi/4.6.3</command>
+	<command name="load">pnetcdf/1.11.1</command>
       </modules>
-      <modules mpilib="openmpi">
-	<command name="load">openmpi/3.0.1</command>
-	<command name="load">netcdf/4.6.1</command>
+      <modules mpilib="openmpi" compiler="pgi">
+	<command name="load">openmpi/3.1.4</command>
+	<command name="load">netcdf/4.6.3</command>
+      </modules>
+      <modules mpilib="openmpi" compiler="gnu">
+        <command name="load">openmpi/3.0.1</command>
+        <command name="load">netcdf/4.6.1</command>
       </modules>
       <modules>
-	<command name="load">ncarcompilers/0.4.1</command>
+	<command name="load">ncarcompilers/0.5.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial">
 	<command name="load">netcdf/4.6.1</command>
@@ -472,7 +476,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">netcdf/4.6.1</command>
       </modules>
       <modules compiler="pgi" mpilib="mpi-serial">
-	<command name="load">netcdf/4.4.1.1</command>
+	<command name="load">netcdf/4.6.3</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -736,26 +740,25 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
-	<command name="load">papi/5.6.0.3</command>
-	<command name="swap">craype craype/2.5.15</command>
+	<command name="swap">craype craype/2.5.18</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/18.03.1</command>
+	<command name="switch">cray-libsci/19.02.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.6</command>
+	<command name="load">cray-mpich/7.7.8</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.2.0</command>
-	<command name="load">cray-netcdf/4.6.1.3</command>
+	<command name="load">cray-hdf5/1.10.5.0</command>
+	<command name="load">cray-netcdf/4.6.3.0</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-	<command name="load">cray-hdf5-parallel/1.10.2.0</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.4</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.0</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.0</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.0</command>
       </modules>
       <modules>
-	<command name="load">cmake/3.8.2</command>
+	<command name="load">cmake/3.14.4</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -842,23 +845,23 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
-	<command name="swap">craype craype/2.5.15</command>
+	<command name="swap">craype craype/2.5.18</command>
 	<command name="load">craype-mic-knl</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/18.03.1</command>
+	<command name="switch">cray-libsci/19.02.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.6</command>
+	<command name="load">cray-mpich/7.7.8</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.2.0</command>
-	<command name="load">cray-netcdf/4.6.1.3</command>
+	<command name="load">cray-hdf5/1.10.5.0</command>
+	<command name="load">cray-netcdf/4.6.3.0</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-	<command name="load">cray-hdf5-parallel/1.10.2.0</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.4</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.0</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.0</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.0</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -486,6 +486,29 @@ endif
 
 ifeq ($(MODEL),driver)
   INCLDIR += -I$(EXEROOT)/atm/obj -I$(EXEROOT)/ice/obj -I$(EXEROOT)/ocn/obj -I$(EXEROOT)/glc/obj -I$(EXEROOT)/rof/obj -I$(EXEROOT)/wav/obj -I$(EXEROOT)/esp/obj -I$(EXEROOT)/iac/obj
+# nagfor and gcc have incompatible LDFLAGS.
+# nagfor requires the weird "-Wl,-Wl,," syntax.
+# If done in config_compilers.xml, we break MCT.
+  ifeq ($(strip $(COMPILER)),nag)
+     ifeq ($(NETCDF_SEPARATE), false)
+       SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF)
+     else ifeq ($(NETCDF_SEPARATE), true)
+       SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF_C)
+       SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF_FORTRAN)
+     endif
+  endif
+else
+  ifeq ($(strip $(COMPILER)),nag)
+    ifeq ($(DEBUG), TRUE)
+      ifneq (,$(filter $(strip $(MACH)),hobart izumi))
+       # GCC needs to be able to link to
+       # nagfor runtime to get autoconf
+       # tests to work.
+         CFLAGS += -Wl,--as-needed,--allow-shlib-undefined
+         SLIBS += -L$(COMPILER_PATH)/lib/NAG_Fortran -lf62rts
+       endif
+    endif
+  endif
 endif
 
 ifndef MCT_LIBDIR
@@ -590,6 +613,18 @@ ifdef LIB_MPI
    else
       SLIBS += -L$(LIB_MPI) -l$(MPI_LIB_NAME)
    endif
+endif
+
+# For compiling and linking with external ESMF.
+# If linking to external ESMF library then include esmf.mk
+# ESMF_F90COMPILEPATHS
+# ESMF_F90LINKPATHS
+# ESMF_F90LINKRPATHS
+# ESMF_F90ESMFLINKLIBS
+ifeq ($(USE_ESMF_LIB), TRUE)
+  -include $(CCSM_ESMFMKFILE)
+  FFLAGS += $(ESMF_F90COMPILEPATHS)
+  SLIBS  += $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
 endif
 
 # Add PETSc libraries

--- a/cime/scripts/lib/CIME/Servers/ftp.py
+++ b/cime/scripts/lib/CIME/Servers/ftp.py
@@ -7,6 +7,7 @@ from CIME.Servers.generic_server import GenericServer
 from ftplib import FTP as FTPpy
 from ftplib import all_errors as all_ftp_errors
 
+
 logger = logging.getLogger(__name__)
 # I think that multiple inheritence would be useful here, but I couldnt make it work
 # in a py2/3 compatible way.
@@ -50,6 +51,8 @@ class FTP(GenericServer):
         try:
             stat = self.ftp.retrbinary('RETR {}'.format(rel_path), open(full_path, "wb").write)
         except all_ftp_errors:
+            if os.path.isfile(full_path):
+                os.remove(full_path)
             logger.warning("ERROR from ftp server, trying next server")
             return False
 

--- a/cime/scripts/lib/CIME/case/case.py
+++ b/cime/scripts/lib/CIME/case/case.py
@@ -483,7 +483,7 @@ class Case(object):
             self._compsetname = compset_name
 
         # Fill in compset name
-        self._compsetname, self._components = self.valid_compset(self._compsetname, files)
+        self._compsetname, self._components = self.valid_compset(self._compsetname, compset_alias, files)
         # if this is a valiid compset longname there will be at least 7 components.
         components = self.get_compset_components()
         expect(len(components) > 6, "No compset alias {} found and this does not appear to be a compset longname.".format(compset_name))
@@ -544,30 +544,37 @@ class Case(object):
 
         return primary_component
 
-    def _valid_compset_impl(self, compset_name, comp_classes, comp_hash):
+    def _valid_compset_impl(self, compset_name, compset_alias, comp_classes, comp_hash):
         """Add stub models missing in <compset_name>, return full compset name.
         <comp_classes> is a list of all supported component classes.
         <comp_hash> is a dictionary where each key is a supported component
         (e.g., datm) and the associated value is the index in <comp_classes> of
         that component's class (e.g., 1 for atm).
-        >>> Case(read_only=False)._valid_compset_impl('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
+        >>> Case(read_only=False)._valid_compset_impl('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
         ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
-        >>> Case(read_only=False)._valid_compset_impl('2000_DATM%NYF_DICE%SSMI_DOCN%DOM_DROF%NYF', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
+        >>> Case(read_only=False)._valid_compset_impl('2000_DATM%NYF_DICE%SSMI_DOCN%DOM_DROF%NYF', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
         ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
-        >>> Case(read_only=False)._valid_compset_impl('2000_DICE%SSMI_DOCN%DOM_DATM%NYF_DROF%NYF', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
+        >>> Case(read_only=False)._valid_compset_impl('2000_DICE%SSMI_DOCN%DOM_DATM%NYF_DROF%NYF', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
         ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
-        >>> Case(read_only=False)._valid_compset_impl('2000_DICE%SSMI_DOCN%DOM_DATM%NYF_DROF%NYF_TEST', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
+        >>> Case(read_only=False)._valid_compset_impl('2000_DICE%SSMI_DOCN%DOM_DATM%NYF_DROF%NYF_TEST', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
         ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP_TEST', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
-        >>> Case(read_only=False)._valid_compset_impl('1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1, 'cam':1,'dlnd':2,'clm':2,'slnd':2,'cice':3,'dice':3,'sice':3,'pop':4,'docn':4,'socn':4,'mosart':5,'drof':5,'srof':5,'cism':6,'sglc':6,'ww':7,'swav':7,'ww3':7,'sesp':8})
+        >>> Case(read_only=False)._valid_compset_impl('1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1, 'cam':1,'dlnd':2,'clm':2,'slnd':2,'cice':3,'dice':3,'sice':3,'pop':4,'docn':4,'socn':4,'mosart':5,'drof':5,'srof':5,'cism':6,'sglc':6,'ww':7,'swav':7,'ww3':7,'sesp':8})
         ('1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_SESP_BGC%BDRD', ['1850', 'CAM60', 'CLM50%BGC-CROP', 'CICE', 'POP2%ECO%ABIO-DIC', 'MOSART', 'CISM2%NOEVOLVE', 'WW3', 'SESP'])
-        >>> Case(read_only=False)._valid_compset_impl('1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD_TEST', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'IAC', 'ESP'], {'datm':1,'satm':1, 'cam':1,'dlnd':2,'clm':2,'slnd':2,'cice':3,'dice':3,'sice':3,'pop':4,'docn':4,'socn':4,'mosart':5,'drof':5,'srof':5,'cism':6,'sglc':6,'ww':7,'swav':7,'ww3':7,'sesp':8})
+        >>> Case(read_only=False)._valid_compset_impl('1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD_TEST', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'IAC', 'ESP'], {'datm':1,'satm':1, 'cam':1,'dlnd':2,'clm':2,'slnd':2,'cice':3,'dice':3,'sice':3,'pop':4,'docn':4,'socn':4,'mosart':5,'drof':5,'srof':5,'cism':6,'sglc':6,'ww':7,'swav':7,'ww3':7,'sesp':8})
         ('1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_SIAC_SESP_BGC%BDRD_TEST', ['1850', 'CAM60', 'CLM50%BGC-CROP', 'CICE', 'POP2%ECO%ABIO-DIC', 'MOSART', 'CISM2%NOEVOLVE', 'WW3', 'SIAC', 'SESP'])
+        >>> Case(read_only=False)._valid_compset_impl('1850_SATM_SLND_SICE_SOCN_SGLC_SWAV', 'S', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'IAC', 'ESP'], {'datm':1,'satm':1, 'cam':1,'dlnd':2,'clm':2,'slnd':2,'cice':3,'dice':3,'sice':3,'pop':4,'docn':4,'socn':4,'mosart':5,'drof':5,'srof':5,'cism':6,'sglc':6,'ww':7,'swav':7,'ww3':7,'sesp':8})
+        ('1850_SATM_SLND_SICE_SOCN_SROF_SGLC_SWAV_SIAC_SESP', ['1850', 'SATM', 'SLND', 'SICE', 'SOCN', 'SROF', 'SGLC', 'SWAV', 'SIAC', 'SESP'])
+
+        >>> Case(read_only=False)._valid_compset_impl('1850_SATM_SLND_SICE_SOCN_SGLC_SWAV', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'IAC', 'ESP'], {'datm':1,'satm':1, 'cam':1,'dlnd':2,'clm':2,'slnd':2,'cice':3,'dice':3,'sice':3,'pop':4,'docn':4,'socn':4,'mosart':5,'drof':5,'srof':5,'cism':6,'sglc':6,'ww':7,'swav':7,'ww3':7,'sesp':8}) #doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        CIMEError: ERROR: Invalid compset name, 1850_SATM_SLND_SICE_SOCN_SGLC_SWAV, all stub components generated
         """
         # Find the models declared in the compset
         model_set = [None]*len(comp_classes)
         components = compset_name.split('_')
         model_set[0] = components[0]
         noncomps = []
+        allstubs = True
         for model in components[1:]:
             match = Case.__mod_match_re__.match(model.lower())
             expect(match is not None, "No model match for {}".format(model))
@@ -588,7 +595,11 @@ class Case(object):
                 stub = 'S' + comp_class
                 logger.info("Automatically adding {} to compset".format(stub))
                 model_set[comp_ind] = stub
+            elif model_set[comp_ind][0] != 'S':
+                allstubs = False
 
+        expect((compset_alias is not None) or (not allstubs),
+               'Invalid compset name, {}, all stub components generated'.format(compset_name))
         # Return the completed compset
         compsetname = '_'.join(model_set)
         for noncomp in noncomps:
@@ -602,7 +613,7 @@ class Case(object):
     # is handled consistenly, this should not affect functionality.
     # Note: interstitial digits are included (e.g., in FV3GFS).
     __mod_match_re__ = re.compile(r"([^%]*[^0-9%]+)")
-    def valid_compset(self, compset_name, files):
+    def valid_compset(self, compset_name, compset_alias, files):
         """Add stub models missing in <compset_name>, return full compset name.
         <files> is used to collect set of all supported components.
         """
@@ -633,7 +644,8 @@ class Case(object):
                 mod_match = Case.__mod_match_re__.match(model.lower()).group(1)
                 comp_hash[mod_match] = comp_ind
 
-        return self._valid_compset_impl(compset_name, comp_classes, comp_hash)
+        return self._valid_compset_impl(compset_name, compset_alias,
+                                        comp_classes, comp_hash)
 
 
     def _set_info_from_primary_component(self, files, pesfile=None):

--- a/cime/scripts/lib/CIME/case/check_input_data.py
+++ b/cime/scripts/lib/CIME/case/check_input_data.py
@@ -6,7 +6,7 @@ from CIME.utils import SharedArea, find_files, safe_copy, expect
 from CIME.XML.inputdata import Inputdata
 import CIME.Servers
 
-import glob, hashlib
+import glob, hashlib, shutil
 
 logger = logging.getLogger(__name__)
 # The inputdata_checksum.dat file will be read into this hash if it's available
@@ -134,7 +134,10 @@ def _download_if_in_repo(server, input_data_root, rel_path, isdirectory=False):
             # this is intended to prevent a race condition in which
             # one case attempts to use a refdir before another one has
             # completed the download
-            os.rename(full_path+".tmp",full_path)
+            if success:
+                os.rename(full_path+".tmp",full_path)
+            else:
+                shutil.rmtree(full_path+".tmp")
         else:
             success = server.getfile(rel_path, full_path)
     return success
@@ -356,8 +359,8 @@ def verify_chksum(input_data_root, rundir, filename, isdirectory):
     For file in filename perform a chksum and compare the result to that stored in
     the local checksumfile, if isdirectory chksum all files in the directory of form *.*
     """
+    hashfile = os.path.join(rundir, local_chksum_file)
     if not chksum_hash:
-        hashfile = os.path.join(rundir, local_chksum_file)
         if not os.path.isfile(hashfile):
             logger.warning("Failed to find or download file {}".format(hashfile))
             return

--- a/cime/scripts/lib/CIME/nmlgen.py
+++ b/cime/scripts/lib/CIME/nmlgen.py
@@ -475,7 +475,9 @@ class NamelistGenerator(object):
             for i, filename in enumerate(domain_filenames.split("\n")):
                 if filename.strip() == '':
                     continue
-                filepath = os.path.join(domain_filepath, filename.strip())
+                filepath, filename = os.path.split(filename)
+                if not filepath:
+                    filepath = os.path.join(domain_filepath, os.path.dirname(filename.strip()))
                 string = "domain{:d} = {}\n".format(i+1, filepath)
                 hashValue = hashlib.md5(string.rstrip().encode('utf-8')).hexdigest()
                 if hashValue not in lines_hash:

--- a/cime/scripts/tests/scripts_regression_tests.py
+++ b/cime/scripts/tests/scripts_regression_tests.py
@@ -306,7 +306,7 @@ class J_TestCreateNewcase(unittest.TestCase):
         testdir = os.path.join(cls._testroot, 'testcreatenewcase')
         if os.path.exists(testdir):
             shutil.rmtree(testdir)
-        args =  " --case %s --compset X --output-root %s --handle-preexisting-dirs=r --debug " % (testdir, cls._testroot)
+        args =  " --case %s --compset X --output-root %s --handle-preexisting-dirs=r " % (testdir, cls._testroot)
         if TEST_COMPILER is not None:
             args = args +  " --compiler %s"%TEST_COMPILER
         if TEST_MPILIB is not None:
@@ -760,6 +760,29 @@ class J_TestCreateNewcase(unittest.TestCase):
 
             cls._do_teardown.append(testdir)
 
+    def test_n_createnewcase_bad_compset(self):
+        cls = self.__class__
+        model = CIME.utils.get_model()
+
+        testdir = os.path.join(cls._testroot, 'testcreatenewcase_bad_compset')
+        if os.path.exists(testdir):
+            shutil.rmtree(testdir)
+        args =  " --case %s --compset InvalidCompsetName --output-root %s --handle-preexisting-dirs=r " % (testdir, cls._testroot)
+        if model == "cesm":
+            args += " --run-unsupported"
+        if TEST_COMPILER is not None:
+            args = args +  " --compiler %s"%TEST_COMPILER
+        if TEST_MPILIB is not None:
+            args = args +  " --mpilib %s"%TEST_MPILIB
+        if CIME.utils.get_cime_default_driver() == "nuopc":
+            args += " --res f19_g17 "
+        else:
+            args += " --res f19_g16 "
+
+        cls._testdirs.append(testdir)
+        run_cmd_assert_result(self, "./create_newcase %s"%(args),
+                              from_dir=SCRIPT_DIR, expected_stat=1)
+        self.assertFalse(os.path.exists(testdir))
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Update CIME to ESMCI cime5.8.8

Squash merge of jgfouca/branch-for-to-acme-2019-08-26

Features:
* Fix bad compset: Added a check for an invalid compset name. (Fixes #3152)

Bug fixes:
* nml fix: If a stream filename (such as DOCN_AQP_FILENAME) is an absolute path then use it to set the filepath argument, otherwise use domain_filepath.
* avoid undefined variable error when checking input files

[BFB]