### PR TITLE
CAM fix for scorpio

### DIFF
--- a/components/cam/src/control/ncdio_atm.F90
+++ b/components/cam/src/control/ncdio_atm.F90
@@ -202,7 +202,7 @@ contains
         ! Specifically, this condition is for when the single column model 
         !  is run in the Spectral Element dycore
         cnt(1) = 1 
-        call shr_scam_getCloseLatLon(ncid%fh,scmlat,scmlon,closelat,closelon,latidx,lonidx)
+        call shr_scam_getCloseLatLon(ncid,scmlat,scmlon,closelat,closelon,latidx,lonidx)
         strt(1) = lonidx
         ierr = pio_get_var(ncid, varid, strt, cnt, field)
 


### PR DESCRIPTION
This PR includes a fix related to scorpio file id usage in CAM.

PR #2771 has fixed similar issues for other
shr_scam_getCloseLatLon calls.

Fixes #2963

[BFB]