### PR TITLE
Add configuration and bug fixes to enable running ne1024

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -2270,8 +2270,7 @@
     <domain name="oRRS15to5">
       <nx>5778136</nx>
       <ny>1</ny>
-      <!--file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS15to5.160207.nc</file-->
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS15to5.190514.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS15to5.160207.nc</file>
       <desc>oRRS15to5 is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 15 km gridcells at low and 5 km gridcells at high latitudes:</desc>
     </domain>
 

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1147,6 +1147,16 @@
       <mask>oRRS15to5</mask>
     </model_grid>
 
+    <model_grid alias="ne1024np4_360x720cru_oRRS15to5" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne1024np4</grid>
+      <grid name="lnd">360x720cru</grid>
+      <grid name="ocnice">oRRS15to5</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS15to5</mask>
+    </model_grid>
+
     <!--- mali grids -->
 
     <model_grid alias="ne30_oECv3_aisgis" compset="_MALI">
@@ -2232,7 +2242,8 @@
     <domain name="oRRS15to5">
       <nx>5778136</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS15to5.160207.nc</file>
+      <!--file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS15to5.160207.nc</file-->
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS15to5.190514.nc</file>
       <desc>oRRS15to5 is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 15 km gridcells at low and 5 km gridcells at high latitudes:</desc>
     </domain>
 
@@ -2519,9 +2530,9 @@
     </gridmap>
 
     <gridmap atm_grid="ne1024np4" ocn_grid="oRRS15to5">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190508.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190508.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190508.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190509.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190509.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190509.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map>
     </gridmap>

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1137,7 +1137,7 @@
       <mask>tx0.1v2</mask>
     </model_grid>
 
-    <model_grid alias="ne1024_360x720cru_ne1024" compset="(DOCN|XOCN|SOCN|AQP1)">
+    <model_grid alias="ne1024np4_360x720cru_ne1024np4" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne1024np4</grid>
       <grid name="lnd">360x720cru</grid>
       <grid name="ocnice">ne1024np4</grid>

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1137,6 +1137,26 @@
       <mask>tx0.1v2</mask>
     </model_grid>
 
+    <model_grid alias="ne512np4_360x720cru_ne512np4">
+      <grid name="atm">ne512np4</grid>
+      <grid name="lnd">360x720cru</grid>
+      <grid name="ocnice">ne512np4</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS15to5</mask>
+    </model_grid>
+
+    <model_grid alias="ne512np4_360x720cru_oRRS15to5">
+      <grid name="atm">ne512np4</grid>
+      <grid name="lnd">360x720cru</grid>
+      <grid name="ocnice">oRRS15to5</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS15to5</mask>
+    </model_grid>
+
     <model_grid alias="ne1024np4_360x720cru_ne1024np4" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne1024np4</grid>
       <grid name="lnd">360x720cru</grid>
@@ -1946,6 +1966,14 @@
       <desc>ne240np4 is Spectral Elem 1/8-deg grid:</desc>
     </domain>
 
+    <domain name="ne512np4">
+      <nx>14155778</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.ne512np4_oRRS15to5.190417.nc</file>
+      <file grid="ice|ocn" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.ocn.ne512np4_oRRS15to5.190417.nc</file>
+      <desc>ne512np4 is Spectral Elem 6km grid:</desc>
+    </domain>
+
     <domain name="ne1024np4">
       <nx>56623106</nx>
       <ny>1</ny>
@@ -2527,6 +2555,21 @@
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne240np4/map_ne240np4_to_fv0.23x0.31_aave_110428.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne512np4" ocn_grid="oRRS15to5">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne512np4/map_ne512np4_to_oRRS15to5_mono.190402.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne512np4/map_ne512np4_to_oRRS15to5_mono.190402.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne512np4/map_ne512np4_to_oRRS15to5_mono.190402.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne512np4_mono.190402.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne512np4_mono.190402.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne512np4" lnd_grid="360x720cru">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne512np4/map_ne512np4_to_360x720cru_mono.190409.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne512np4/map_ne512np4_to_360x720cru_mono.190409.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne512np4_mono.190409.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne512np4_mono.190409.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne1024np4" ocn_grid="oRRS15to5">

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1630,6 +1630,7 @@
       <nx>720</nx>
       <ny>360</ny>
       <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.360x720_cruncep.100429.nc</file>
+      <file grid="atm|lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.360x720cru_oRRS15to5.190417.nc</file>
       <desc>Exact half-degree CRUNCEP datm forcing grid with CRUNCEP land-mask -- only valid for DATM/CLM compset</desc>
     </domain>
 

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -2575,8 +2575,6 @@
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190509.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190509.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190509.nc</map>
-      <!--map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map-->
-      <!--map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map-->
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_mono.190509.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_mono.190509.nc</map>
     </gridmap>
@@ -2584,8 +2582,6 @@
     <gridmap atm_grid="ne1024np4" lnd_grid="360x720cru">
       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_360x720cru_mono.190508.nc</map>
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_360x720cru_mono.190508.nc</map>
-      <!--map name="LND2ATM_FMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_monotr.190508.nc</map-->
-      <!--map name="LND2ATM_SMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_monotr.190508.nc</map-->
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_mono.190508.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_mono.190508.nc</map>
     </gridmap>

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -2533,15 +2533,19 @@
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190509.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190509.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190509.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map>
+      <!--map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map-->
+      <!--map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map-->
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_mono.190509.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_mono.190509.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne1024np4" lnd_grid="360x720cru">
       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_360x720cru_mono.190508.nc</map>
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_360x720cru_mono.190508.nc</map>
-      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_monotr.190508.nc</map>
-      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_monotr.190508.nc</map>
+      <!--map name="LND2ATM_FMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_monotr.190508.nc</map-->
+      <!--map name="LND2ATM_SMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_monotr.190508.nc</map-->
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_mono.190508.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_mono.190508.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4_enax4v1" lnd_grid="ne30np4">

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1137,6 +1137,16 @@
       <mask>tx0.1v2</mask>
     </model_grid>
 
+    <model_grid alias="ne1024_360x720cru_ne1024" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne1024np4</grid>
+      <grid name="lnd">360x720cru</grid>
+      <grid name="ocnice">ne1024np4</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS15to5</mask>
+    </model_grid>
+
     <!--- mali grids -->
 
     <model_grid alias="ne30_oECv3_aisgis" compset="_MALI">
@@ -1925,6 +1935,14 @@
       <desc>ne240np4 is Spectral Elem 1/8-deg grid:</desc>
     </domain>
 
+    <domain name="ne1024np4">
+      <nx>56623106</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.ne1024np4_oRRS15to5.190514.nc</file>
+      <file grid="ice|ocn" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.ocn.ne1024np4_oRRS15to5.190514.nc</file>
+      <desc>ne1024np4 is Spectral Elem 3km grid:</desc>
+    </domain>
+
     <!--=====================================================================-->
     <!--=====================================================================-->
 
@@ -2497,6 +2515,21 @@
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne240np4/map_ne240np4_to_fv0.23x0.31_aave_110428.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne1024np4" ocn_grid="oRRS15to5">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190508.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190508.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_oRRS15to5_mono.190508.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne1024np4_monotr.190509.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne1024np4" lnd_grid="360x720cru">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_360x720cru_mono.190508.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne1024np4/map_ne1024np4_to_360x720cru_mono.190508.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_monotr.190508.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/360x720cru/map_360x720cru_to_ne1024np4_monotr.190508.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4_enax4v1" lnd_grid="ne30np4">

--- a/components/cam/bld/config_files/horiz_grid.xml
+++ b/components/cam/bld/config_files/horiz_grid.xml
@@ -59,6 +59,7 @@
 <horiz_grid dyn="se"    hgrid="ne120np4"     ncol="777602"  csne="120" csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne120np4.pg2" ncol="345600"  csne="120" csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne240np4"     ncol="3110402" csne="240" csnp="4" npg="0" />
+<horiz_grid dyn="se"    hgrid="ne1024np4"    ncol="56623106" csne="1024" csnp="4" npg="0" />
 
 <!-- Spectral Element w/ Regional Refinement -->
 <horiz_grid dyn="se" hgrid="ne0np4_arm_x8v3_lowcon"           ncol="92558"  csne="0" csnp="4" npg="0" />

--- a/components/cam/bld/config_files/horiz_grid.xml
+++ b/components/cam/bld/config_files/horiz_grid.xml
@@ -59,6 +59,7 @@
 <horiz_grid dyn="se"    hgrid="ne120np4"     ncol="777602"  csne="120" csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne120np4.pg2" ncol="345600"  csne="120" csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne240np4"     ncol="3110402" csne="240" csnp="4" npg="0" />
+<horiz_grid dyn="se"    hgrid="ne512np4"     ncol="14155778" csne="512"  csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne1024np4"    ncol="56623106" csne="1024" csnp="4" npg="0" />
 
 <!-- Spectral Element w/ Regional Refinement -->

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -223,6 +223,7 @@
 <bnd_topo hgrid="ne60np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne60np4_16xconsistentSGH.c20140517.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="0">atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
 <bnd_topo hgrid="ne240np4" npg="0">atm/cam/topo/USGS-gtopo30_ne240np4_16xconsistentSGH.c20130724.nc</bnd_topo>
+<bnd_topo hgrid="ne512np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne512np4_16xconsistentSGH.20190212.nc</bnd_topo>
 <bnd_topo hgrid="ne1024np4" npg="0">atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH_20190528.nc</bnd_topo>
 
 <bnd_topo hgrid="ne0np4_arm_x8v3_lowcon"  >atm/cam/inic/homme/USGS-gtopo30_arm_x8v3_lowcon_tensor12xconsistentSGH.nc</bnd_topo>
@@ -807,6 +808,7 @@
 <drydep_srf_file hgrid="ne60np4" >atm/cam/chem/trop_mam/atmsrf_ne60np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne120np4">atm/cam/chem/trop_mam/atmsrf_ne120np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne240np4">atm/cam/chem/trop_mam/atmsrf_ne240np4_110920.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne512np4">atm/cam/chem/trop_mam/atmsrf_ne512np4_interp_20190409.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne1024np4">atm/cam/chem/trop_mam/atmsrf_ne1024np4_20190621.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_arm_x8v3_lowcon">atm/cam/chem/trop_mam/atmsrf_armx8v3.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon">atm/cam/chem/trop_mam/atmsrf_conusx4v1.nc</drydep_srf_file>
@@ -1414,6 +1416,7 @@
 <nu hgrid="ne60np4" >  1.0e14 </nu>
 <nu hgrid="ne120np4">  1.0e13 </nu>
 <nu hgrid="ne240np4">  1.1e12 </nu>
+<nu hgrid="ne512np4">  2.0e11 </nu>
 <nu hgrid="ne1024np4"> 2.5e10 </nu>
 <nu hgrid="ne0np4_arm_x8v3_lowcon"  > 8.0e-8</nu>
 <nu hgrid="ne0np4_conus_x4v1_lowcon"  > 8.0e-8</nu>
@@ -1439,6 +1442,7 @@
 <nu_p hgrid="ne60np4" >  1.0e14 </nu_p>
 <nu_p hgrid="ne120np4">  1.0e13 </nu_p>
 <nu_p hgrid="ne240np4">  1.1e12 </nu_p>
+<nu_p hgrid="ne512np4">  2.0e11 </nu_p>
 <nu_p hgrid="ne1024np4"> 2.5e10 </nu_p>
 <nu_p hgrid="ne0np4_arm_x8v3_lowcon"  > 8.0e-8</nu_p>
 <nu_p hgrid="ne0np4_conus_x4v1_lowcon"  > 8.0e-8</nu_p>
@@ -1456,6 +1460,7 @@
 <nu_div hgrid="ne60np4" >  2.5e14 </nu_div>
 <nu_div hgrid="ne120np4">  2.5e13 </nu_div>
 <nu_div hgrid="ne240np4">  2.5e12 </nu_div>
+<nu_div hgrid="ne512np4">  5.0e11 </nu_div>
 <nu_div hgrid="ne1024np4"> 6.25e10 </nu_div>
 <nu_div hgrid="ne0np4_arm_x8v3_lowcon"  > 20.0e-8</nu_div>
 <nu_div hgrid="ne0np4_conus_x4v1_lowcon"  > 20.0e-8</nu_div>
@@ -1474,6 +1479,7 @@
 <hypervis_subcycle hgrid="ne60np4" >  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne120np4">  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne240np4">  4 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne512np4">  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne1024np4"> 20 </hypervis_subcycle>
 <hypervis_subcycle dyn="se" waccm_phys="1">  1 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_arm_x8v3_lowcon"  > 8 </hypervis_subcycle>
@@ -1497,6 +1503,7 @@
 <rsplit hgrid="ne60np4" >  3 </rsplit>
 <rsplit hgrid="ne120np4">  3 </rsplit>
 <rsplit hgrid="ne240np4">  3 </rsplit>
+<rsplit hgrid="ne512np4">  3 </rsplit>
 <rsplit hgrid="ne1024np4"> 3 </rsplit>
 
 <se_nsplit>                   2 </se_nsplit>
@@ -1507,6 +1514,7 @@
 <se_nsplit hgrid="ne60np4" >  4 </se_nsplit>
 <se_nsplit hgrid="ne120np4">  4 </se_nsplit>
 <se_nsplit hgrid="ne240np4">  5 </se_nsplit>
+<se_nsplit hgrid="ne512np4">  5 </se_nsplit>
 <se_nsplit hgrid="ne1024np4"> 10 </se_nsplit>
 <se_nsplit hgrid="ne0np4_arm_x8v3_lowcon"  > 5 </se_nsplit>
 <se_nsplit hgrid="ne0np4_conus_x4v1_lowcon"  > 4 </se_nsplit>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -223,7 +223,7 @@
 <bnd_topo hgrid="ne60np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne60np4_16xconsistentSGH.c20140517.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="0">atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
 <bnd_topo hgrid="ne240np4" npg="0">atm/cam/topo/USGS-gtopo30_ne240np4_16xconsistentSGH.c20130724.nc</bnd_topo>
-<bnd_topo hgrid="ne1024np4" npg="0">atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH.20190528.nc</bnd_topo>
+<bnd_topo hgrid="ne1024np4" npg="0">atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH_20190528.nc</bnd_topo>
 
 <bnd_topo hgrid="ne0np4_arm_x8v3_lowcon"  >atm/cam/inic/homme/USGS-gtopo30_arm_x8v3_lowcon_tensor12xconsistentSGH.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_conus_x4v1_lowcon"  >atm/cam/topo/USGS_conusx4v1-tensor12x_consistentSGH_c150924.nc</bnd_topo>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -223,6 +223,7 @@
 <bnd_topo hgrid="ne60np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne60np4_16xconsistentSGH.c20140517.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="0">atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
 <bnd_topo hgrid="ne240np4" npg="0">atm/cam/topo/USGS-gtopo30_ne240np4_16xconsistentSGH.c20130724.nc</bnd_topo>
+<bnd_topo hgrid="ne1024np4" npg="0">atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH.20190528.nc</bnd_topo>
 
 <bnd_topo hgrid="ne0np4_arm_x8v3_lowcon"  >atm/cam/inic/homme/USGS-gtopo30_arm_x8v3_lowcon_tensor12xconsistentSGH.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_conus_x4v1_lowcon"  >atm/cam/topo/USGS_conusx4v1-tensor12x_consistentSGH_c150924.nc</bnd_topo>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -159,6 +159,9 @@
 <ncdata dyn="se" hgrid="ne120np4" nlev="72"             ic_ymd="101" >atm/cam/inic/homme/cami_mam3_Linoz_0000-01-ne120np4_L72_c160318.nc</ncdata>
 <ncdata dyn="se" hgrid="ne240np4" nlev="26"             ic_ymd="101" >atm/cam/inic/homme/cami_1850-01-01_ne240np4_L26_c110314.nc</ncdata>
 <ncdata dyn="se" hgrid="ne240np4" nlev="26"             ic_ymd="901" >atm/cam/inic/homme/cami_0000-09-01_ne240np4_L26_c061106.nc</ncdata>
+<ncdata dyn="se" hgrid="ne512np4" nlev="72"        ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne512np4_topoadj_L72.nc</ncdata>
+<ncdata dyn="se" hgrid="ne1024np4" nlev="72"       ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne1024np4_topoadj_L72.nc</ncdata>
+<ncdata dyn="se" hgrid="ne1024np4" nlev="120"      ic_ymd="20160801">atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_ne1024np4_topoadj_L120.nc</ncdata>
 
 <!-- E3SM Aquaplanet -->
 <ncdata dyn="se" hgrid="ne4np4"   nlev="72"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/homme/cami_aquaplanet_ne4np4_L72_c190218.nc</ncdata>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1479,7 +1479,7 @@
 <hypervis_subcycle hgrid="ne60np4" >  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne120np4">  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne240np4">  4 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne512np4">  4 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne512np4">  10 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne1024np4"> 20 </hypervis_subcycle>
 <hypervis_subcycle dyn="se" waccm_phys="1">  1 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_arm_x8v3_lowcon"  > 8 </hypervis_subcycle>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -807,6 +807,7 @@
 <drydep_srf_file hgrid="ne60np4" >atm/cam/chem/trop_mam/atmsrf_ne60np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne120np4">atm/cam/chem/trop_mam/atmsrf_ne120np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne240np4">atm/cam/chem/trop_mam/atmsrf_ne240np4_110920.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne1024np4">atm/cam/chem/trop_mam/atmsrf_ne1024np4_20190621.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_arm_x8v3_lowcon">atm/cam/chem/trop_mam/atmsrf_armx8v3.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon">atm/cam/chem/trop_mam/atmsrf_conusx4v1.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_svalbard_x8v1_lowcon">atm/cam/chem/trop_mam/atmsrf_svalbardx8v1.nc</drydep_srf_file>
@@ -1413,6 +1414,7 @@
 <nu hgrid="ne60np4" >  1.0e14 </nu>
 <nu hgrid="ne120np4">  1.0e13 </nu>
 <nu hgrid="ne240np4">  1.1e12 </nu>
+<nu hgrid="ne1024np4"> 2.5e10 </nu>
 <nu hgrid="ne0np4_arm_x8v3_lowcon"  > 8.0e-8</nu>
 <nu hgrid="ne0np4_conus_x4v1_lowcon"  > 8.0e-8</nu>
 <nu hgrid="ne0np4_svalbard_x8v1_lowcon"  > 8.0e-8</nu>
@@ -1437,6 +1439,7 @@
 <nu_p hgrid="ne60np4" >  1.0e14 </nu_p>
 <nu_p hgrid="ne120np4">  1.0e13 </nu_p>
 <nu_p hgrid="ne240np4">  1.1e12 </nu_p>
+<nu_p hgrid="ne1024np4"> 2.5e10 </nu_p>
 <nu_p hgrid="ne0np4_arm_x8v3_lowcon"  > 8.0e-8</nu_p>
 <nu_p hgrid="ne0np4_conus_x4v1_lowcon"  > 8.0e-8</nu_p>
 <nu_p hgrid="ne0np4_svalbard_x8v1_lowcon"  > 8.0e-8</nu_p>
@@ -1453,6 +1456,7 @@
 <nu_div hgrid="ne60np4" >  2.5e14 </nu_div>
 <nu_div hgrid="ne120np4">  2.5e13 </nu_div>
 <nu_div hgrid="ne240np4">  2.5e12 </nu_div>
+<nu_div hgrid="ne1024np4"> 6.25e10 </nu_div>
 <nu_div hgrid="ne0np4_arm_x8v3_lowcon"  > 20.0e-8</nu_div>
 <nu_div hgrid="ne0np4_conus_x4v1_lowcon"  > 20.0e-8</nu_div>
 <nu_div hgrid="ne0np4_svalbard_x8v1_lowcon"  > 20.0e-8</nu_div>
@@ -1470,6 +1474,7 @@
 <hypervis_subcycle hgrid="ne60np4" >  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne120np4">  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne240np4">  4 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne1024np4"> 20 </hypervis_subcycle>
 <hypervis_subcycle dyn="se" waccm_phys="1">  1 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_arm_x8v3_lowcon"  > 8 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_conus_x4v1_lowcon"  > 7 </hypervis_subcycle>
@@ -1492,6 +1497,7 @@
 <rsplit hgrid="ne60np4" >  3 </rsplit>
 <rsplit hgrid="ne120np4">  3 </rsplit>
 <rsplit hgrid="ne240np4">  3 </rsplit>
+<rsplit hgrid="ne1024np4"> 3 </rsplit>
 
 <se_nsplit>                   2 </se_nsplit>
 <se_nsplit hgrid="ne4np4" >   2 </se_nsplit>
@@ -1501,6 +1507,7 @@
 <se_nsplit hgrid="ne60np4" >  4 </se_nsplit>
 <se_nsplit hgrid="ne120np4">  4 </se_nsplit>
 <se_nsplit hgrid="ne240np4">  5 </se_nsplit>
+<se_nsplit hgrid="ne1024np4"> 10 </se_nsplit>
 <se_nsplit hgrid="ne0np4_arm_x8v3_lowcon"  > 5 </se_nsplit>
 <se_nsplit hgrid="ne0np4_conus_x4v1_lowcon"  > 4 </se_nsplit>
 <se_nsplit hgrid="ne0np4_svalbard_x8v1_lowcon"  > 5 </se_nsplit>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -223,7 +223,7 @@
 <bnd_topo hgrid="ne60np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne60np4_16xconsistentSGH.c20140517.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="0">atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
 <bnd_topo hgrid="ne240np4" npg="0">atm/cam/topo/USGS-gtopo30_ne240np4_16xconsistentSGH.c20130724.nc</bnd_topo>
-<bnd_topo hgrid="ne512np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne512np4_16xconsistentSGH.20190212.nc</bnd_topo>
+<bnd_topo hgrid="ne512np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne512np4_16xconsistentSGH_20190212.nc</bnd_topo>
 <bnd_topo hgrid="ne1024np4" npg="0">atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH_20190528.nc</bnd_topo>
 
 <bnd_topo hgrid="ne0np4_arm_x8v3_lowcon"  >atm/cam/inic/homme/USGS-gtopo30_arm_x8v3_lowcon_tensor12xconsistentSGH.nc</bnd_topo>

--- a/components/cam/src/dynamics/se/restart_dynamics.F90
+++ b/components/cam/src/dynamics/se/restart_dynamics.F90
@@ -115,7 +115,7 @@ CONTAINS
     type(element_t), pointer :: elem(:)
     real(kind=r8) :: time
     integer :: ndcur, nscur
-    integer, pointer :: ldof(:)
+    integer(kind=pio_offset_kind), pointer :: ldof(:)
 
     call write_restart_hycoef(File)
 
@@ -347,8 +347,9 @@ CONTAINS
   function get_restart_decomp(elem, lev) result(ldof)
     use element_mod, only : element_t
     use dimensions_mod, only : np, nelemd, nelem
+    use pio, only: pio_offset_kind
     type(element_t), intent(in) :: elem(:)
-    integer, pointer :: ldof(:)
+    integer(kind=pio_offset_kind), pointer :: ldof(:)
     integer, intent(in) :: lev
 
     integer ::  i, j, k, ie
@@ -359,12 +360,12 @@ CONTAINS
     do k=1,lev
        do ie=1,nelemd
           do i=1,np*np
-             ldof(j) = (elem(ie)%GlobalID-1)*np*np+(k-1)*nelem*np*np+i
+             ldof(j) = int(elem(ie)%GlobalID-1, pio_offset_kind)*np*np &
+                     + int(k-1, pio_offset_kind)*nelem*np*np + i
              j=j+1
           end do
        end do
     end do
-
 
   end function get_restart_decomp
 
@@ -400,7 +401,7 @@ CONTAINS
     real(r8), allocatable :: var3d(:), var3dp(:), var2d(:)
     integer :: ie, ierr, fne, fnp, fnlev
     integer :: ncols
-    integer, pointer :: ldof(:)
+    integer(kind=pio_offset_kind), pointer :: ldof(:)
     type(element_t), pointer :: elem(:)               ! pointer to dyn_in element array
     integer(kind=pio_offset_kind), parameter :: t = 1
     integer :: i, k, cnt, st, en, tl, tlQdp, ii, jj, s2d, q, j

--- a/components/cam/src/utils/cam_grid_support.F90
+++ b/components/cam/src/utils/cam_grid_support.F90
@@ -2559,7 +2559,8 @@ contains
     ! Local variables
     integer                                :: dims(2)
     integer                                :: dstrt, dend
-    integer                                :: gridlen, gridloc, ierr
+    integer(iMap)                          :: gridlen, gridloc
+    integer                                :: ierr
 
     ! Check to make sure the map meets our needs
     call this%coord_lengths(dims)
@@ -2582,7 +2583,7 @@ contains
       gridloc = count((map(dstrt,:) /= 0) .and. (map(dend,:) /= 0))
     end if
     call MPI_Allreduce(gridloc, gridlen, 1, MPI_INTEGER, MPI_SUM, mpicom, ierr)
-    if (gridlen /= product(dims)) then
+    if (gridlen /= product(int(dims,iMap))) then
       call endrun('cam_grid_set_map: Bad map size for '//trim(this%name))
     else
       if (.not. associated(this%map)) then

--- a/components/cam/src/utils/cam_map_utils.F90
+++ b/components/cam/src/utils/cam_map_utils.F90
@@ -683,7 +683,7 @@ contains
     end if
 
     !
-    fileSize = product(filelens)
+    fileSize = product(int(filelens,iMap))
     srccnt = size(fieldlens)
     srclens(1:srccnt) = fieldlens(1:srccnt)
     if (srccnt < 7) then
@@ -691,7 +691,7 @@ contains
     end if
 
     ! Allocate output filemap (dof)
-    allocate(filemap(product(fieldlens)))
+    allocate(filemap(product(int(fieldlens,iMap))))
     filemap = 0
 
     ! Find map source dimensions in input array


### PR DESCRIPTION
Add configuration for new ne1024 and ne512 grids, as well as a few bug fixes to prevent integer overflows when using grids of this size. This allows using create_newcase to configure a case with resolution `ne1024np4_360x720cru_oRRS15to5` or `ne512np4_360x720cru_oRRS15to5`.

[bfb]