### PR TITLE
Update ELM routines to speed up restart write

### DIFF
--- a/components/clm/src/main/subgridRestMod.F90
+++ b/components/clm/src/main/subgridRestMod.F90
@@ -19,6 +19,7 @@ module subgridRestMod
   use LandunitType       , only : lun_pp
   use ColumnType         , only : col_pp
   use VegetationType     , only : veg_pp
+  use perf_mod           , only : t_startf, t_stopf
   use restUtilMod
 
   !
@@ -61,13 +62,19 @@ contains
 
     if (flag /= 'read') then
        if (flag == 'define') then
+          call t_startf('subgridRest_define')
           call subgridRest_define_only(bounds, ncid, flag)
+          call t_stopf('subgridRest_define')
        else
+          call t_startf('subgridRest_write')
           call subgridRest_write_only(bounds, ncid, flag)
+          call t_stopf('subgridRest_write')
        end if
     end if
 
+    call t_startf('subgridRest_write-read')
     call subgridRest_write_and_read(bounds, ncid, flag)
+    call t_stopf('subgridRest_write-read')
 
   end subroutine subgridRest
 

--- a/components/clm/src/main/subgridRestMod.F90
+++ b/components/clm/src/main/subgridRestMod.F90
@@ -60,15 +60,9 @@ contains
     !------------------------------------------------------------------------
 
     if (flag /= 'read') then
-       if (flag == 'define') then
-          call t_startf('subgridRest_define')
-          call subgridRest_write_only(bounds, ncid, flag)
-          call t_stopf('subgridRest_define')
-       else if (flag == 'write') then
-          call t_startf('subgridRest_write')
-          call subgridRest_write_only(bounds, ncid, flag)
-          call t_stopf('subgridRest_write')
-       end if
+       call t_startf('subgridRest_write')
+       call subgridRest_write_only(bounds, ncid, flag)
+       call t_stopf('subgridRest_write')
     end if
 
     call t_startf('subgridRest_write-read')
@@ -127,21 +121,17 @@ contains
          long_name='gridcell latitude', units='degrees_north',         &
          interpinic_flag='skip', readvar=readvar, data=grc_pp%latdeg)
 
-    if (flag == 'write') then
-       do g=bounds%begg,bounds%endg
-          igarr(g)= mod(ldecomp%gdc2glo(g)-1,ldomain%ni) + 1
-       enddo
-    endif
+    do g=bounds%begg,bounds%endg
+       igarr(g)= mod(ldecomp%gdc2glo(g)-1,ldomain%ni) + 1
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='grid1d_ixy', xtype=ncd_int,    &
          dim1name='gridcell',                                          &
          long_name='2d longitude index of corresponding gridcell',     &
          interpinic_flag='skip', readvar=readvar, data=igarr)
 
-    if (flag == 'write') then
-       do g=bounds%begg,bounds%endg
-          igarr(g)= (ldecomp%gdc2glo(g) - 1)/ldomain%ni + 1
-       enddo
-    endif
+    do g=bounds%begg,bounds%endg
+       igarr(g)= (ldecomp%gdc2glo(g) - 1)/ldomain%ni + 1
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='grid1d_jxy', xtype=ncd_int,    &
          dim1name='gridcell',                                          &
          long_name='2d latitude index of corresponding gridcell',      &
@@ -155,49 +145,39 @@ contains
 
     allocate(rlarr(bounds%begl:bounds%endl), ilarr(bounds%begl:bounds%endl))
 
-    if (flag == 'write') then
-       do l=bounds%begl,bounds%endl
-          rlarr(l) = grc_pp%londeg(lun_pp%gridcell(l))
-       enddo
-    endif
+    do l=bounds%begl,bounds%endl
+       rlarr(l) = grc_pp%londeg(lun_pp%gridcell(l))
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='land1d_lon', xtype=ncd_double,  &
          dim1name='landunit',                                                      &
          long_name='landunit longitude', units='degrees_east',                     &
          interpinic_flag='skip', readvar=readvar, data=rlarr)
  
-    if (flag == 'write') then
-       do l=bounds%begl,bounds%endl
-          rlarr(l) = grc_pp%latdeg(lun_pp%gridcell(l))
-       enddo
-    endif
+    do l=bounds%begl,bounds%endl
+       rlarr(l) = grc_pp%latdeg(lun_pp%gridcell(l))
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='land1d_lat', xtype=ncd_double,  &
          dim1name='landunit',                                                      &
          long_name='landunit latitude', units='degrees_north',                     &
          interpinic_flag='skip', readvar=readvar, data=rlarr)
 
-    if (flag == 'write') then
-       do l=bounds%begl,bounds%endl
-          ilarr(l) = mod(ldecomp%gdc2glo(lun_pp%gridcell(l))-1,ldomain%ni) + 1
-       enddo
-    endif
+    do l=bounds%begl,bounds%endl
+       ilarr(l) = mod(ldecomp%gdc2glo(lun_pp%gridcell(l))-1,ldomain%ni) + 1
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='land1d_ixy', xtype=ncd_int,     &
          dim1name='landunit',                                                      &
          long_name='2d longitude index of corresponding landunit',                 &
          interpinic_flag='skip', readvar=readvar, data=ilarr)
 
-    if (flag == 'write') then
-        do l=bounds%begl,bounds%endl
-           ilarr(l) = (ldecomp%gdc2glo(lun_pp%gridcell(l))-1)/ldomain%ni + 1
-        enddo
-    endif
+     do l=bounds%begl,bounds%endl
+        ilarr(l) = (ldecomp%gdc2glo(lun_pp%gridcell(l))-1)/ldomain%ni + 1
+     enddo
     call restartvar(ncid=ncid, flag=flag, varname='land1d_jxy', xtype=ncd_int,     &
          dim1name='landunit',                                                      &
          long_name='2d latitude index of corresponding landunit',                  &
          interpinic_flag='skip', readvar=readvar, data=ilarr)
 
-    if (flag == 'write') then
-       ilarr = GetGlobalIndexArray(lun_pp%gridcell(bounds%begl:bounds%endl), bounds%begl, bounds%endl, clmlevel=nameg)
-    endif
+    ilarr = GetGlobalIndexArray(lun_pp%gridcell(bounds%begl:bounds%endl), bounds%begl, bounds%endl, clmlevel=nameg)
     call restartvar(ncid=ncid, flag=flag, varname='land1d_gridcell_index', xtype=ncd_int, &
          dim1name='landunit',                                                             &
          long_name='gridcell index of corresponding landunit',                            &
@@ -208,15 +188,13 @@ contains
          long_name='landunit type (see global attributes)', units=' ',             &
          interpinic_flag='skip', readvar=readvar, data=lun_pp%itype)
 
-    if (flag == 'write') then
-       do l=bounds%begl,bounds%endl
-          if (lun_pp%active(l)) then
-             ilarr(l) = 1
-          else
-             ilarr(l) = 0
-          end if
-       enddo
-    endif
+    do l=bounds%begl,bounds%endl
+       if (lun_pp%active(l)) then
+          ilarr(l) = 1
+       else
+          ilarr(l) = 0
+       end if
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='land1d_active', xtype=ncd_int,  &
          dim1name='landunit',                                                      &
          long_name='landunit active flag (1=active, 0=inactive)',                  &
@@ -230,67 +208,53 @@ contains
 
     allocate(rcarr(bounds%begc:bounds%endc), icarr(bounds%begc:bounds%endc))
 
-    if (flag == 'write') then
-       do c= bounds%begc, bounds%endc
-          rcarr(c) = grc_pp%londeg(col_pp%gridcell(c))
-       enddo
-    endif
+    do c= bounds%begc, bounds%endc
+       rcarr(c) = grc_pp%londeg(col_pp%gridcell(c))
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_lon', xtype=ncd_double,   &
          dim1name='column',                                                         &
          long_name='column longitude', units='degrees_east',                        &
          interpinic_flag='skip', readvar=readvar, data=rcarr)
 
-    if (flag == 'write') then
-       do c= bounds%begc, bounds%endc
-          rcarr(c) = grc_pp%latdeg(col_pp%gridcell(c))
-       enddo
-    endif
+    do c= bounds%begc, bounds%endc
+       rcarr(c) = grc_pp%latdeg(col_pp%gridcell(c))
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_lat', xtype=ncd_double,   &
          dim1name='column',                                                         &
          long_name='column latitude', units='degrees_north',                        &
          interpinic_flag='skip', readvar=readvar, data=rcarr)
 
-    if (flag == 'write') then
-       do c= bounds%begc, bounds%endc
-          icarr(c) = mod(ldecomp%gdc2glo(col_pp%gridcell(c))-1,ldomain%ni) + 1
-       enddo
-    endif
+    do c= bounds%begc, bounds%endc
+       icarr(c) = mod(ldecomp%gdc2glo(col_pp%gridcell(c))-1,ldomain%ni) + 1
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_ixy', xtype=ncd_int,      &
          dim1name='column',                                                         &
          long_name='2d longitude index of corresponding column', units=' ',         &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    if (flag == 'write') then
-       do c= bounds%begc, bounds%endc
-          icarr(c) = (ldecomp%gdc2glo(col_pp%gridcell(c))-1)/ldomain%ni + 1
-       enddo
-    endif
+    do c= bounds%begc, bounds%endc
+       icarr(c) = (ldecomp%gdc2glo(col_pp%gridcell(c))-1)/ldomain%ni + 1
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_jxy', xtype=ncd_int,      &
          dim1name='column',                                                         &
          long_name='2d latitude index of corresponding column', units=' ',          &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    if (flag == 'write') then
-       icarr = GetGlobalIndexArray(col_pp%gridcell(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=nameg)
-    endif
+    icarr = GetGlobalIndexArray(col_pp%gridcell(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=nameg)
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_gridcell_index', xtype=ncd_int, &
          dim1name='column',                                                               &
          long_name='gridcell index of corresponding column',                              &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    if (flag == 'write') then
-       icarr = GetGlobalIndexArray(col_pp%landunit(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=namel)
-    endif
+    icarr = GetGlobalIndexArray(col_pp%landunit(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=namel)
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_landunit_index', xtype=ncd_int, &
          dim1name='column',                                                               &
          long_name='landunit index of corresponding column',                              &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    if (flag == 'write') then
-       do c= bounds%begc, bounds%endc
-          icarr(c) = lun_pp%itype(col_pp%landunit(c))
-       enddo
-    endif
+    do c= bounds%begc, bounds%endc
+       icarr(c) = lun_pp%itype(col_pp%landunit(c))
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_ityplun', xtype=ncd_int,  &
          dim1name='column',                                                         &
          long_name='column landunit type (see global attributes)', units=' ',       &
@@ -301,15 +265,13 @@ contains
          long_name='column type (see global attributes)', units=' ',                &
          interpinic_flag='skip', readvar=readvar, data=col_pp%itype)
 
-    if (flag == 'write') then
-       do c=bounds%begc,bounds%endc
-          if (col_pp%active(c)) then 
-             icarr(c) = 1
-          else
-             icarr(c) = 0
-          end if
-       enddo
-    endif
+    do c=bounds%begc,bounds%endc
+       if (col_pp%active(c)) then 
+          icarr(c) = 1
+       else
+          icarr(c) = 0
+       end if
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_active', xtype=ncd_int,   &
          dim1name='column',                                                         &
          long_name='column active flag (1=active, 0=inactive)', units=' ',          &
@@ -323,65 +285,51 @@ contains
 
     allocate(rparr(bounds%begp:bounds%endp), iparr(bounds%begp:bounds%endp))
 
-    if (flag == 'write') then
-       do p=bounds%begp,bounds%endp
-          rparr(p) = grc_pp%londeg(veg_pp%gridcell(p))
-       enddo
-    endif
+    do p=bounds%begp,bounds%endp
+       rparr(p) = grc_pp%londeg(veg_pp%gridcell(p))
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_lon', xtype=ncd_double, &
          dim1name='pft',                                                          &
          long_name='pft longitude', units='degrees_east',                         &
          interpinic_flag='skip', readvar=readvar, data=rparr)
 
-    if (flag == 'write') then
-       do p=bounds%begp,bounds%endp
-          rparr(p) = grc_pp%latdeg(veg_pp%gridcell(p))
-       enddo
-    endif
+    do p=bounds%begp,bounds%endp
+       rparr(p) = grc_pp%latdeg(veg_pp%gridcell(p))
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_lat', xtype=ncd_double, &
          dim1name='pft',                                                          &
          long_name='pft latitude', units='degrees_north',                         &
          interpinic_flag='skip', readvar=readvar, data=rparr)
 
-    if (flag == 'write') then
-       do p=bounds%begp,bounds%endp
-          iparr(p) = mod(ldecomp%gdc2glo(veg_pp%gridcell(p))-1,ldomain%ni) + 1
-       enddo
-    endif
+    do p=bounds%begp,bounds%endp
+       iparr(p) = mod(ldecomp%gdc2glo(veg_pp%gridcell(p))-1,ldomain%ni) + 1
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_ixy', xtype=ncd_int, &
          dim1name='pft',                                                       &
          long_name='2d longitude index of corresponding pft', units='',        &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'write') then
-       do p=bounds%begp,bounds%endp
-          iparr(p) = (ldecomp%gdc2glo(veg_pp%gridcell(p))-1)/ldomain%ni + 1
-       enddo
-    endif
+    do p=bounds%begp,bounds%endp
+       iparr(p) = (ldecomp%gdc2glo(veg_pp%gridcell(p))-1)/ldomain%ni + 1
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_jxy', xtype=ncd_int, &
          dim1name='pft',                                                       &
          long_name='2d latitude index of corresponding pft', units='',         &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'write') then
-       iparr = GetGlobalIndexArray(veg_pp%gridcell(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=nameg)
-    endif
+    iparr = GetGlobalIndexArray(veg_pp%gridcell(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=nameg)
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_gridcell_index', xtype=ncd_int, &
          dim1name='pft',                                                                  &
          long_name='gridcell index of corresponding pft',                                 &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'write') then
-       iparr = GetGlobalIndexArray(veg_pp%landunit(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namel)
-    endif
+    iparr = GetGlobalIndexArray(veg_pp%landunit(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namel)
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_landunit_index', xtype=ncd_int, &
          dim1name='pft',                                                                  &
          long_name='landunit index of corresponding pft',                                 &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'write') then
-       iparr = GetGlobalIndexArray(veg_pp%column(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namec)
-    endif
+    iparr = GetGlobalIndexArray(veg_pp%column(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namec)
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_column_index', xtype=ncd_int,   &
          dim1name='pft',                                                                  &
          long_name='column index of corresponding pft',                                   &
@@ -392,46 +340,38 @@ contains
          long_name='pft vegetation type', units='',                                 &
          interpinic_flag='skip', readvar=readvar, data=veg_pp%itype)
 
-    if (flag == 'write') then
-       do p=bounds%begp,bounds%endp
-          iparr(p) = col_pp%itype(veg_pp%column(p))
-       enddo
-    endif
+    do p=bounds%begp,bounds%endp
+       iparr(p) = col_pp%itype(veg_pp%column(p))
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_itypcol', xtype=ncd_int, &
          dim1name='pft',                                                           &
          long_name='pft column type (see global attributes)', units='',          &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'write') then
-       do p=bounds%begp,bounds%endp
-          iparr(p) = lun_pp%itype(veg_pp%landunit(p))
-       enddo
-    endif
+    do p=bounds%begp,bounds%endp
+       iparr(p) = lun_pp%itype(veg_pp%landunit(p))
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_ityplun', xtype=ncd_int, &
          dim1name='pft',                                                           &
          long_name='pft landunit type (see global attributes)', units='',          &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'write') then
-       do p=bounds%begp,bounds%endp
-          if (veg_pp%active(p)) then
-             iparr(p) = 1
-          else
-             iparr(p) = 0
-          end if
-       enddo
-    endif
+    do p=bounds%begp,bounds%endp
+       if (veg_pp%active(p)) then
+          iparr(p) = 1
+       else
+          iparr(p) = 0
+       end if
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_active', xtype=ncd_int, &
          dim1name='pft',                                                          &
          long_name='pft active flag (1=active, 0=inactive)', units='',            &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'write') then
-       do p=bounds%begp,bounds%endp
-          c = veg_pp%column(p)
-          rparr(p) = col_pp%glc_topo(c)
-       enddo
-    endif
+    do p=bounds%begp,bounds%endp
+       c = veg_pp%column(p)
+       rparr(p) = col_pp%glc_topo(c)
+    enddo
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_topoglc', xtype=ncd_double,   &
          dim1name='column',                                                             &
          long_name='mean elevation on glacier elevation classes', units='m',            &

--- a/components/clm/src/main/subgridRestMod.F90
+++ b/components/clm/src/main/subgridRestMod.F90
@@ -60,9 +60,15 @@ contains
     !------------------------------------------------------------------------
 
     if (flag /= 'read') then
-       call t_startf('subgridRest_write')
-       call subgridRest_write_only(bounds, ncid, flag)
-       call t_stopf('subgridRest_write')
+       if (flag == 'define') then
+          call t_startf('subgridRest_define')
+          call subgridRest_write_only(bounds, ncid, flag)
+          call t_stopf('subgridRest_define')
+       else if (flag == 'write') then
+          call t_startf('subgridRest_write')
+          call subgridRest_write_only(bounds, ncid, flag)
+          call t_stopf('subgridRest_write')
+       end if
     end if
 
     call t_startf('subgridRest_write-read')
@@ -121,7 +127,7 @@ contains
          long_name='gridcell latitude', units='degrees_north',         &
          interpinic_flag='skip', readvar=readvar, data=grc_pp%latdeg)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do g=bounds%begg,bounds%endg
           igarr(g)= mod(ldecomp%gdc2glo(g)-1,ldomain%ni) + 1
        enddo
@@ -131,7 +137,7 @@ contains
          long_name='2d longitude index of corresponding gridcell',     &
          interpinic_flag='skip', readvar=readvar, data=igarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do g=bounds%begg,bounds%endg
           igarr(g)= (ldecomp%gdc2glo(g) - 1)/ldomain%ni + 1
        enddo
@@ -149,7 +155,7 @@ contains
 
     allocate(rlarr(bounds%begl:bounds%endl), ilarr(bounds%begl:bounds%endl))
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do l=bounds%begl,bounds%endl
           rlarr(l) = grc_pp%londeg(lun_pp%gridcell(l))
        enddo
@@ -159,7 +165,7 @@ contains
          long_name='landunit longitude', units='degrees_east',                     &
          interpinic_flag='skip', readvar=readvar, data=rlarr)
  
-    if (flag == 'read') then
+    if (flag == 'write') then
        do l=bounds%begl,bounds%endl
           rlarr(l) = grc_pp%latdeg(lun_pp%gridcell(l))
        enddo
@@ -169,7 +175,7 @@ contains
          long_name='landunit latitude', units='degrees_north',                     &
          interpinic_flag='skip', readvar=readvar, data=rlarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do l=bounds%begl,bounds%endl
           ilarr(l) = mod(ldecomp%gdc2glo(lun_pp%gridcell(l))-1,ldomain%ni) + 1
        enddo
@@ -179,7 +185,7 @@ contains
          long_name='2d longitude index of corresponding landunit',                 &
          interpinic_flag='skip', readvar=readvar, data=ilarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
         do l=bounds%begl,bounds%endl
            ilarr(l) = (ldecomp%gdc2glo(lun_pp%gridcell(l))-1)/ldomain%ni + 1
         enddo
@@ -189,7 +195,7 @@ contains
          long_name='2d latitude index of corresponding landunit',                  &
          interpinic_flag='skip', readvar=readvar, data=ilarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        ilarr = GetGlobalIndexArray(lun_pp%gridcell(bounds%begl:bounds%endl), bounds%begl, bounds%endl, clmlevel=nameg)
     endif
     call restartvar(ncid=ncid, flag=flag, varname='land1d_gridcell_index', xtype=ncd_int, &
@@ -202,7 +208,7 @@ contains
          long_name='landunit type (see global attributes)', units=' ',             &
          interpinic_flag='skip', readvar=readvar, data=lun_pp%itype)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do l=bounds%begl,bounds%endl
           if (lun_pp%active(l)) then
              ilarr(l) = 1
@@ -224,7 +230,7 @@ contains
 
     allocate(rcarr(bounds%begc:bounds%endc), icarr(bounds%begc:bounds%endc))
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do c= bounds%begc, bounds%endc
           rcarr(c) = grc_pp%londeg(col_pp%gridcell(c))
        enddo
@@ -234,7 +240,7 @@ contains
          long_name='column longitude', units='degrees_east',                        &
          interpinic_flag='skip', readvar=readvar, data=rcarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do c= bounds%begc, bounds%endc
           rcarr(c) = grc_pp%latdeg(col_pp%gridcell(c))
        enddo
@@ -244,7 +250,7 @@ contains
          long_name='column latitude', units='degrees_north',                        &
          interpinic_flag='skip', readvar=readvar, data=rcarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do c= bounds%begc, bounds%endc
           icarr(c) = mod(ldecomp%gdc2glo(col_pp%gridcell(c))-1,ldomain%ni) + 1
        enddo
@@ -254,7 +260,7 @@ contains
          long_name='2d longitude index of corresponding column', units=' ',         &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do c= bounds%begc, bounds%endc
           icarr(c) = (ldecomp%gdc2glo(col_pp%gridcell(c))-1)/ldomain%ni + 1
        enddo
@@ -264,7 +270,7 @@ contains
          long_name='2d latitude index of corresponding column', units=' ',          &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        icarr = GetGlobalIndexArray(col_pp%gridcell(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=nameg)
     endif
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_gridcell_index', xtype=ncd_int, &
@@ -272,7 +278,7 @@ contains
          long_name='gridcell index of corresponding column',                              &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        icarr = GetGlobalIndexArray(col_pp%landunit(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=namel)
     endif
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_landunit_index', xtype=ncd_int, &
@@ -280,7 +286,7 @@ contains
          long_name='landunit index of corresponding column',                              &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do c= bounds%begc, bounds%endc
           icarr(c) = lun_pp%itype(col_pp%landunit(c))
        enddo
@@ -295,7 +301,7 @@ contains
          long_name='column type (see global attributes)', units=' ',                &
          interpinic_flag='skip', readvar=readvar, data=col_pp%itype)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do c=bounds%begc,bounds%endc
           if (col_pp%active(c)) then 
              icarr(c) = 1
@@ -317,7 +323,7 @@ contains
 
     allocate(rparr(bounds%begp:bounds%endp), iparr(bounds%begp:bounds%endp))
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do p=bounds%begp,bounds%endp
           rparr(p) = grc_pp%londeg(veg_pp%gridcell(p))
        enddo
@@ -327,7 +333,7 @@ contains
          long_name='pft longitude', units='degrees_east',                         &
          interpinic_flag='skip', readvar=readvar, data=rparr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do p=bounds%begp,bounds%endp
           rparr(p) = grc_pp%latdeg(veg_pp%gridcell(p))
        enddo
@@ -337,7 +343,7 @@ contains
          long_name='pft latitude', units='degrees_north',                         &
          interpinic_flag='skip', readvar=readvar, data=rparr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do p=bounds%begp,bounds%endp
           iparr(p) = mod(ldecomp%gdc2glo(veg_pp%gridcell(p))-1,ldomain%ni) + 1
        enddo
@@ -347,7 +353,7 @@ contains
          long_name='2d longitude index of corresponding pft', units='',        &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do p=bounds%begp,bounds%endp
           iparr(p) = (ldecomp%gdc2glo(veg_pp%gridcell(p))-1)/ldomain%ni + 1
        enddo
@@ -357,7 +363,7 @@ contains
          long_name='2d latitude index of corresponding pft', units='',         &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        iparr = GetGlobalIndexArray(veg_pp%gridcell(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=nameg)
     endif
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_gridcell_index', xtype=ncd_int, &
@@ -365,7 +371,7 @@ contains
          long_name='gridcell index of corresponding pft',                                 &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        iparr = GetGlobalIndexArray(veg_pp%landunit(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namel)
     endif
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_landunit_index', xtype=ncd_int, &
@@ -373,7 +379,7 @@ contains
          long_name='landunit index of corresponding pft',                                 &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        iparr = GetGlobalIndexArray(veg_pp%column(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namec)
     endif
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_column_index', xtype=ncd_int,   &
@@ -386,7 +392,7 @@ contains
          long_name='pft vegetation type', units='',                                 &
          interpinic_flag='skip', readvar=readvar, data=veg_pp%itype)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do p=bounds%begp,bounds%endp
           iparr(p) = col_pp%itype(veg_pp%column(p))
        enddo
@@ -396,7 +402,7 @@ contains
          long_name='pft column type (see global attributes)', units='',          &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do p=bounds%begp,bounds%endp
           iparr(p) = lun_pp%itype(veg_pp%landunit(p))
        enddo
@@ -406,7 +412,7 @@ contains
          long_name='pft landunit type (see global attributes)', units='',          &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do p=bounds%begp,bounds%endp
           if (veg_pp%active(p)) then
              iparr(p) = 1
@@ -420,7 +426,7 @@ contains
          long_name='pft active flag (1=active, 0=inactive)', units='',            &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    if (flag == 'read') then
+    if (flag == 'write') then
        do p=bounds%begp,bounds%endp
           c = veg_pp%column(p)
           rparr(p) = col_pp%glc_topo(c)

--- a/components/clm/src/main/subgridRestMod.F90
+++ b/components/clm/src/main/subgridRestMod.F90
@@ -14,12 +14,13 @@ module subgridRestMod
   use clm_varpar         , only : nlevsno
   use pio                , only : file_desc_t
   use ncdio_pio          , only : ncd_int, ncd_double
-  use GetGlobalValuesMod , only : GetGlobalIndex
-  use GridcellType       , only : grc_pp                
-  use LandunitType       , only : lun_pp                
-  use ColumnType         , only : col_pp                
-  use VegetationType          , only : veg_pp                
+  use GetGlobalValuesMod , only : GetGlobalIndexArray
+  use GridcellType       , only : grc_pp
+  use LandunitType       , only : lun_pp
+  use ColumnType         , only : col_pp
+  use VegetationType     , only : veg_pp
   use restUtilMod
+
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -33,6 +34,7 @@ module subgridRestMod
 
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: subgridRest_write_only     ! handle restart of subgrid variables that only need to be written, not read
+  private :: subgridRest_define_only    ! handle restart of subgrid variables that only need to be defined
   private :: subgridRest_write_and_read ! handle restart of subgrid variables that need to be read as well as written
   private :: save_old_weights
 
@@ -58,12 +60,244 @@ contains
     !------------------------------------------------------------------------
 
     if (flag /= 'read') then
-       call subgridRest_write_only(bounds, ncid, flag)
+       if (flag == 'define') then
+          call subgridRest_define_only(bounds, ncid, flag)
+       else
+          call subgridRest_write_only(bounds, ncid, flag)
+       end if
     end if
 
     call subgridRest_write_and_read(bounds, ncid, flag)
 
   end subroutine subgridRest
+
+  !-----------------------------------------------------------------------
+  subroutine subgridRest_define_only(bounds, ncid, flag)
+    !
+    ! !DESCRIPTION:
+    ! Handle restart for variables that only need to be written, not read. This applies
+    ! to variables that are time-constant and are only put on the restart file for the
+    ! sake of having some additional metadata there.
+    !
+    ! Note that 'active' flags appear in this routine: they don't need to be read because
+    ! they can be computed using other info on the restart file (particularly subgrid
+    ! weights).
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    type(bounds_type), intent(in)    :: bounds ! bounds
+    type(file_desc_t), intent(inout) :: ncid   ! netCDF dataset id
+    character(len=*) , intent(in)    :: flag   ! flag to determine if define, write or read data
+    !
+    ! !LOCAL VARIABLES:
+    integer :: g,l,c,p,i             ! indices
+    logical :: readvar               ! temporary
+    real(r8), pointer :: rgarr(:)    ! temporary
+    real(r8), pointer :: rlarr(:)    ! temporary
+    real(r8), pointer :: rcarr(:)    ! temporary
+    real(r8), pointer :: rparr(:)    ! temporary
+    integer , pointer :: igarr(:)    ! temporary
+    integer , pointer :: ilarr(:)    ! temporary
+    integer , pointer :: icarr(:)    ! temporary
+    integer , pointer :: iparr(:)    ! temporary
+    
+    character(len=*), parameter :: subname = 'subgridRest_define_only'
+    !-----------------------------------------------------------------------
+    
+    !------------------------------------------------------------------
+    ! Write gridcell info
+    !------------------------------------------------------------------
+
+    allocate(rgarr(bounds%begg:bounds%endg), igarr(bounds%begg:bounds%endg))
+
+    call restartvar(ncid=ncid, flag=flag, varname='grid1d_lon', xtype=ncd_double, &
+         dim1name='gridcell',                                          &
+         long_name='gridcell longitude', units='degrees_east',         &
+         interpinic_flag='skip', readvar=readvar, data=grc_pp%londeg)
+
+    call restartvar(ncid=ncid, flag=flag, varname='grid1d_lat', xtype=ncd_double, &
+         dim1name='gridcell',                                          &
+         long_name='gridcell latitude', units='degrees_north',         &
+         interpinic_flag='skip', readvar=readvar, data=grc_pp%latdeg)
+
+    call restartvar(ncid=ncid, flag=flag, varname='grid1d_ixy', xtype=ncd_int,    &
+         dim1name='gridcell',                                          &
+         long_name='2d longitude index of corresponding gridcell',     &
+         interpinic_flag='skip', readvar=readvar, data=igarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='grid1d_jxy', xtype=ncd_int,    &
+         dim1name='gridcell',                                          &
+         long_name='2d latitude index of corresponding gridcell',      &
+         interpinic_flag='skip', readvar=readvar, data=igarr)
+
+    deallocate(rgarr,igarr)
+
+    !------------------------------------------------------------------
+    ! Write landunit info
+    !------------------------------------------------------------------
+
+    allocate(rlarr(bounds%begl:bounds%endl), ilarr(bounds%begl:bounds%endl))
+
+    call restartvar(ncid=ncid, flag=flag, varname='land1d_lon', xtype=ncd_double,  &
+         dim1name='landunit',                                                      &
+         long_name='landunit longitude', units='degrees_east',                     &
+         interpinic_flag='skip', readvar=readvar, data=rlarr)
+    
+    call restartvar(ncid=ncid, flag=flag, varname='land1d_lat', xtype=ncd_double,  &
+         dim1name='landunit',                                                      &
+         long_name='landunit latitude', units='degrees_north',                     &
+         interpinic_flag='skip', readvar=readvar, data=rlarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='land1d_ixy', xtype=ncd_int,     &
+         dim1name='landunit',                                                      &
+         long_name='2d longitude index of corresponding landunit',                 &
+         interpinic_flag='skip', readvar=readvar, data=ilarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='land1d_jxy', xtype=ncd_int,     &
+         dim1name='landunit',                                                      &
+         long_name='2d latitude index of corresponding landunit',                  &
+         interpinic_flag='skip', readvar=readvar, data=ilarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='land1d_gridcell_index', xtype=ncd_int, &
+         dim1name='landunit',                                                             &
+         long_name='gridcell index of corresponding landunit',                            &
+         interpinic_flag='skip', readvar=readvar, data=ilarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='land1d_ityplun', xtype=ncd_int, &
+         dim1name='landunit',                                                      &
+         long_name='landunit type (see global attributes)', units=' ',             &
+         interpinic_flag='skip', readvar=readvar, data=lun_pp%itype)
+
+    call restartvar(ncid=ncid, flag=flag, varname='land1d_active', xtype=ncd_int,  &
+         dim1name='landunit',                                                      &
+         long_name='landunit active flag (1=active, 0=inactive)',                  &
+         interpinic_flag='skip', readvar=readvar, data=ilarr)
+
+    deallocate(rlarr, ilarr)
+
+    !------------------------------------------------------------------
+    ! Write column info
+    !------------------------------------------------------------------
+
+    allocate(rcarr(bounds%begc:bounds%endc), icarr(bounds%begc:bounds%endc))
+
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_lon', xtype=ncd_double,   &
+         dim1name='column',                                                         &
+         long_name='column longitude', units='degrees_east',                        &
+         interpinic_flag='skip', readvar=readvar, data=rcarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_lat', xtype=ncd_double,   &
+         dim1name='column',                                                         &
+         long_name='column latitude', units='degrees_north',                        &
+         interpinic_flag='skip', readvar=readvar, data=rcarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_ixy', xtype=ncd_int,      &
+         dim1name='column',                                                         &
+         long_name='2d longitude index of corresponding column', units=' ',         &
+         interpinic_flag='skip', readvar=readvar, data=icarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_jxy', xtype=ncd_int,      &
+         dim1name='column',                                                         &
+         long_name='2d latitude index of corresponding column', units=' ',          &
+         interpinic_flag='skip', readvar=readvar, data=icarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_gridcell_index', xtype=ncd_int, &
+         dim1name='column',                                                               &
+         long_name='gridcell index of corresponding column',                              &
+         interpinic_flag='skip', readvar=readvar, data=icarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_landunit_index', xtype=ncd_int, &
+         dim1name='column',                                                               &
+         long_name='landunit index of corresponding column',                              &
+         interpinic_flag='skip', readvar=readvar, data=icarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_ityplun', xtype=ncd_int,  &
+         dim1name='column',                                                         &
+         long_name='column landunit type (see global attributes)', units=' ',       &
+         interpinic_flag='skip', readvar=readvar, data=icarr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_ityp', xtype=ncd_int,     &
+         dim1name='column',                                                         &
+         long_name='column type (see global attributes)', units=' ',                &
+         interpinic_flag='skip', readvar=readvar, data=col_pp%itype)
+
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_active', xtype=ncd_int,   &
+         dim1name='column',                                                         &
+         long_name='column active flag (1=active, 0=inactive)', units=' ',          &
+         interpinic_flag='skip', readvar=readvar, data=icarr)
+
+    deallocate(rcarr, icarr)
+
+    !------------------------------------------------------------------
+    ! Write pft info
+    !------------------------------------------------------------------
+
+    allocate(rparr(bounds%begp:bounds%endp), iparr(bounds%begp:bounds%endp))
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_lon', xtype=ncd_double, &
+         dim1name='pft',                                                          &
+         long_name='pft longitude', units='degrees_east',                         &
+         interpinic_flag='skip', readvar=readvar, data=rparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_lat', xtype=ncd_double, &
+         dim1name='pft',                                                          &
+         long_name='pft latitude', units='degrees_north',                         &
+         interpinic_flag='skip', readvar=readvar, data=rparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_ixy', xtype=ncd_int, &
+         dim1name='pft',                                                       &
+         long_name='2d longitude index of corresponding pft', units='',        &
+         interpinic_flag='skip', readvar=readvar, data=iparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_jxy', xtype=ncd_int, &
+         dim1name='pft',                                                       &
+         long_name='2d latitude index of corresponding pft', units='',         &
+         interpinic_flag='skip', readvar=readvar, data=iparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_gridcell_index', xtype=ncd_int, &
+         dim1name='pft',                                                                  &
+         long_name='gridcell index of corresponding pft',                                 &
+         interpinic_flag='skip', readvar=readvar, data=iparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_landunit_index', xtype=ncd_int, &
+         dim1name='pft',                                                                  &
+         long_name='landunit index of corresponding pft',                                 &
+         interpinic_flag='skip', readvar=readvar, data=iparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_column_index', xtype=ncd_int,   &
+         dim1name='pft',                                                                  &
+         long_name='column index of corresponding pft',                                   &
+         interpinic_flag='skip', readvar=readvar, data=iparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_itypveg', xtype=ncd_int,  &
+         dim1name='pft',                                                            &
+         long_name='pft vegetation type', units='',                                 &
+         interpinic_flag='skip', readvar=readvar, data=veg_pp%itype)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_itypcol', xtype=ncd_int, &
+         dim1name='pft',                                                           &
+         long_name='pft column type (see global attributes)', units='',          &
+         interpinic_flag='skip', readvar=readvar, data=iparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_ityplun', xtype=ncd_int, &
+         dim1name='pft',                                                           &
+         long_name='pft landunit type (see global attributes)', units='',          &
+         interpinic_flag='skip', readvar=readvar, data=iparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_active', xtype=ncd_int, &
+         dim1name='pft',                                                          &
+         long_name='pft active flag (1=active, 0=inactive)', units='',            &
+         interpinic_flag='skip', readvar=readvar, data=iparr)
+
+    call restartvar(ncid=ncid, flag=flag, varname='pfts1d_topoglc', xtype=ncd_double,   &
+         dim1name='column',                                                             &
+         long_name='mean elevation on glacier elevation classes', units='m',            &
+         interpinic_flag='skip', readvar=readvar, data=rparr)
+
+    deallocate(rparr, iparr)
+
+  end subroutine subgridRest_define_only
 
   !-----------------------------------------------------------------------
   subroutine subgridRest_write_only(bounds, ncid, flag)
@@ -172,9 +406,7 @@ contains
          long_name='2d latitude index of corresponding landunit',                  &
          interpinic_flag='skip', readvar=readvar, data=ilarr)
 
-    do l=bounds%begl,bounds%endl
-       ilarr(l) = GetGlobalIndex(decomp_index=lun_pp%gridcell(l), clmlevel=nameg)
-    end do
+    ilarr = GetGlobalIndexArray(lun_pp%gridcell(bounds%begl:bounds%endl), bounds%begl, bounds%endl, clmlevel=nameg)
     call restartvar(ncid=ncid, flag=flag, varname='land1d_gridcell_index', xtype=ncd_int, &
          dim1name='landunit',                                                             &
          long_name='gridcell index of corresponding landunit',                            &
@@ -237,17 +469,13 @@ contains
          long_name='2d latitude index of corresponding column', units=' ',          &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    do c= bounds%begc, bounds%endc
-       icarr(c) = GetGlobalIndex(decomp_index=col_pp%gridcell(c), clmlevel=nameg)
-    end do
+    icarr = GetGlobalIndexArray(col_pp%gridcell(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=nameg)
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_gridcell_index', xtype=ncd_int, &
          dim1name='column',                                                               &
          long_name='gridcell index of corresponding column',                              &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    do c= bounds%begc, bounds%endc
-       icarr(c) = GetGlobalIndex(decomp_index=col_pp%landunit(c), clmlevel=namel)
-    end do
+    icarr = GetGlobalIndexArray(col_pp%landunit(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=namel)
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_landunit_index', xtype=ncd_int, &
          dim1name='column',                                                               &
          long_name='landunit index of corresponding column',                              &
@@ -318,25 +546,19 @@ contains
          long_name='2d latitude index of corresponding pft', units='',         &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    do p=bounds%begp,bounds%endp
-       iparr(p) = GetGlobalIndex(decomp_index=veg_pp%gridcell(p), clmlevel=nameg)
-    enddo
+    iparr = GetGlobalIndexArray(veg_pp%gridcell(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=nameg)
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_gridcell_index', xtype=ncd_int, &
          dim1name='pft',                                                                  &
          long_name='gridcell index of corresponding pft',                                 &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    do p=bounds%begp,bounds%endp
-       iparr(p) = GetGlobalIndex(decomp_index=veg_pp%landunit(p), clmlevel=namel)
-    enddo
+    iparr = GetGlobalIndexArray(veg_pp%landunit(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namel)
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_landunit_index', xtype=ncd_int, &
          dim1name='pft',                                                                  &
          long_name='landunit index of corresponding pft',                                 &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    do p=bounds%begp,bounds%endp
-       iparr(p) = GetGlobalIndex(decomp_index=veg_pp%column(p), clmlevel=namec)
-    enddo
+    iparr = GetGlobalIndexArray(veg_pp%column(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namec)
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_column_index', xtype=ncd_int,   &
          dim1name='pft',                                                                  &
          long_name='column index of corresponding pft',                                   &


### PR DESCRIPTION
This PR adds a couple of new routines to help speed up the restart write process. It brings in:
* a function GetGlobalIndexArray that adds capability to get global indices on an array
   instead of a single point;
* a new routine for only defining the subGrid restart, subgridRest_define_only, which is
  identical to subgridRest_write_only but does not gather data. 
Previously the restart write process called the same subroutine twice, once to define the variables and once to output them, but was unnecessarily gathering all the data for both steps. This PR also replaces calls to GetGlobalIndex on single points inside loops with calls to GetGlobalIndexArray.

The time for high-res (r0125) restart file output dropped from ~2000s to ~55s using these changes.


[BFB]