### PR TITLE
Host climate reproducibility tests at machine specific locations

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -65,6 +65,8 @@
     <SAVE_TIMING_DIR>/project/projectdirs/acme</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>acme,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/cori-haswell</CIME_OUTPUT_ROOT>
+    <CIME_HTML_ROOT>/global/project/projectdirs/acme/www/$ENV{USER}</CIME_HTML_ROOT>
+    <CIME_URL_ROOT>http://portal.nersc.gov/project/acme/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
@@ -212,6 +214,8 @@
     <SAVE_TIMING_DIR>/project/projectdirs/acme</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>acme,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/cori-knl</CIME_OUTPUT_ROOT>
+    <CIME_HTML_ROOT>/global/project/projectdirs/acme/www/$ENV{USER}</CIME_HTML_ROOT>
+    <CIME_URL_ROOT>http://portal.nersc.gov/project/acme/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>

--- a/cime/config/xml_schemas/config_machines.xsd
+++ b/cime/config/xml_schemas/config_machines.xsd
@@ -37,6 +37,8 @@
   <xs:element name="SAVE_TIMING_DIR" type="xs:string"/>
   <xs:element name="SAVE_TIMING_DIR_PROJECTS" type="xs:string"/>
   <xs:element name="CIME_OUTPUT_ROOT" type="xs:string"/>
+  <xs:element name="CIME_HTML_ROOT" type="xs:string"/>
+  <xs:element name="CIME_URL_ROOT" type="xs:string"/>
   <xs:element name="DIN_LOC_ROOT" type="xs:string"/>
   <xs:element name="DIN_LOC_ROOT_CLMFORC" type="xs:string"/>
   <xs:element name="DOUT_S_ROOT" type="xs:string"/>
@@ -123,6 +125,10 @@
         <!-- CIME_OUTPUT_ROOT: Base directory for case output,
              the bld and run directories are written below here -->
         <xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
+        <xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
+        <xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
         <!-- DIN_LOC_ROOT: location of the inputdata directory -->
         <xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
         <!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->

--- a/cime/scripts/lib/CIME/SystemTests/mvk.py
+++ b/cime/scripts/lib/CIME/SystemTests/mvk.py
@@ -10,11 +10,15 @@ import os
 import json
 import logging
 
+from distutils import dir_util
+
 import CIME.test_status
+import CIME.utils
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case.case_setup import case_setup
 from CIME.hist_utils import _get_all_hist_files
-from CIME.utils import safe_copy, SharedArea, append_testlog
+from CIME.XML.machines import Machines
+
 
 import evv4esm  # pylint: disable=import-error
 from evv4esm.__main__ import main as evv  # pylint: disable=import-error
@@ -73,7 +77,7 @@ class MVK(SystemTestsCommon):
         """
         super(MVK, self)._generate_baseline()
 
-        with SharedArea():
+        with CIME.utils.SharedArea():
             basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"),
                                        self._case.get_value("BASEGEN_CASE"))
 
@@ -89,7 +93,7 @@ class MVK(SystemTestsCommon):
                 if os.path.exists(baseline):
                     os.remove(baseline)
 
-                safe_copy(hist, baseline, preserve_meta=False)
+                CIME.utils.safe_copy(hist, baseline, preserve_meta=False)
 
     def _compare_baseline(self):
         with self._test_status:
@@ -145,12 +149,26 @@ class MVK(SystemTestsCommon):
                     break
 
                 status = self._test_status.get_status(CIME.test_status.BASELINE_PHASE)
+                mach_name = self._case.get_value("MACH")
+                mach_obj = Machines(machine=mach_name)
+                htmlroot = CIME.utils.get_htmlroot(mach_obj)
+                urlroot = CIME.utils.get_urlroot(mach_obj)
+                if htmlroot is not None:
+                    with CIME.utils.SharedArea():
+                        dir_util.copy_tree(evv_out_dir, os.path.join(htmlroot, 'evv', case_name), preserve_mode=False)
+                    if urlroot is None:
+                        urlroot = "[{}_URL]".format(mach_name.capitalize())
+                    viewing = "{}/evv/{}/index.html".format(urlroot, case_name)
+                else:
+                    viewing = "{}\n" \
+                              "    EVV viewing instructions can be found at: " \
+                              "        https://github.com/E3SM-Project/E3SM/blob/master/cime/scripts/" \
+                              "climate_reproducibility/README.md#test-passfail-and-extended-output" \
+                              "".format(evv_out_dir)
+
                 comments = "{} {} for test '{}'.\n" \
                            "    {}\n" \
-                           "    EVV results can be viewed at: {}\n" \
-                           "    EVV viewing instructions can be found at: " \
-                           "        https://github.com/E3SM-Project/E3SM/blob/master/cime/scripts/" \
-                           "climate_reproducibility/README.md#test-passfail-and-extended-output" \
-                           "".format(CIME.test_status.BASELINE_PHASE, status, test_name, comments, evv_out_dir)
+                           "    EVV results can be viewed at:\n" \
+                           "        {}".format(CIME.test_status.BASELINE_PHASE, status, test_name, comments, viewing)
 
-                append_testlog(comments, self._orig_caseroot)
+                CIME.utils.append_testlog(comments, self._orig_caseroot)

--- a/cime/scripts/lib/CIME/SystemTests/pgn.py
+++ b/cime/scripts/lib/CIME/SystemTests/pgn.py
@@ -15,14 +15,18 @@ import json
 import shutil
 import logging
 
+from collections import OrderedDict
+from distutils import dir_util
+
 import pandas as pd
 import numpy as np
-from collections import OrderedDict
+
 
 import CIME.test_status
+import CIME.utils
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case.case_setup import case_setup
-from CIME.utils import expect, append_testlog
+from CIME.XML.machines import Machines
 
 import evv4esm  # pylint: disable=import-error
 from evv4esm.extensions import pg  # pylint: disable=import-error
@@ -118,8 +122,8 @@ class PGN(SystemTestsCommon):
         rundir = self._case.get_value("RUNDIR")
         prg_fname = 'pergro_ptend_names.txt'
         var_file = os.path.join(rundir, prg_fname)
-        expect(os.path.isfile(var_file),
-               "File {} does not exist in: {}".format(prg_fname, rundir))
+        CIME.utils.expect(os.path.isfile(var_file),
+                          "File {} does not exist in: {}".format(prg_fname, rundir))
 
         with open(var_file, 'r') as fvar:
             var_list = fvar.readlines()
@@ -185,15 +189,29 @@ class PGN(SystemTestsCommon):
                     break
 
             status = self._test_status.get_status(CIME.test_status.BASELINE_PHASE)
+            mach_name = self._case.get_value("MACH")
+            mach_obj = Machines(machine=mach_name)
+            htmlroot = CIME.utils.get_htmlroot(mach_obj)
+            urlroot = CIME.utils.get_urlroot(mach_obj)
+            if htmlroot is not None:
+                with CIME.utils.SharedArea():
+                    dir_util.copy_tree(evv_out_dir, os.path.join(htmlroot, 'evv', case_name), preserve_mode=False)
+                if urlroot is None:
+                    urlroot = "[{}_URL]".format(mach_name.capitalize())
+                viewing = "{}/evv/{}/index.html".format(urlroot, case_name)
+            else:
+                viewing = "{}\n" \
+                          "    EVV viewing instructions can be found at: " \
+                          "        https://github.com/E3SM-Project/E3SM/blob/master/cime/scripts/" \
+                          "climate_reproducibility/README.md#test-passfail-and-extended-output" \
+                          "".format(evv_out_dir)
+
             comments = "{} {} for test '{}'.\n" \
                        "    {}\n" \
-                       "    EVV results can be viewed at: {}\n" \
-                       "    EVV viewing instructions can be found at: " \
-                       "        https://github.com/E3SM-Project/E3SM/blob/master/cime/scripts/" \
-                       "climate_reproducibility/README.md#test-passfail-and-extended-output" \
-                       "".format(CIME.test_status.BASELINE_PHASE, status, test_name, comments, evv_out_dir)
+                       "    EVV results can be viewed at:\n" \
+                       "        {}".format(CIME.test_status.BASELINE_PHASE, status, test_name, comments, viewing)
 
-            append_testlog(comments, self._orig_caseroot)
+            CIME.utils.append_testlog(comments, self._orig_caseroot)
 
     def run_phase(self):
         logger.debug("PGN_INFO: RUN PHASE")
@@ -217,8 +235,8 @@ class PGN(SystemTestsCommon):
                 try:
                     shutil.move(fname, renamed_fname)
                 except IOError:
-                    expect(os.path.isfile(renamed_fname),
-                           "ERROR: File {} does not exist".format(renamed_fname))
+                    CIME.utils.expect(os.path.isfile(renamed_fname),
+                                      "ERROR: File {} does not exist".format(renamed_fname))
                     logger.debug("PGN_INFO: Renamed file already exists:"
                                  "{}".format(renamed_fname))
 

--- a/cime/scripts/lib/CIME/SystemTests/tsc.py
+++ b/cime/scripts/lib/CIME/SystemTests/tsc.py
@@ -11,11 +11,14 @@ import os
 import json
 import logging
 
+from distutils import dir_util
+
 import CIME.test_status
+import CIME.utils
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case.case_setup import case_setup
 from CIME.hist_utils import rename_all_hist_files, _get_all_hist_files
-from CIME.utils import safe_copy, SharedArea, append_testlog
+from CIME.XML.machines import Machines
 
 import evv4esm  # pylint: disable=import-error
 from evv4esm.__main__ import main as evv  # pylint: disable=import-error
@@ -163,20 +166,34 @@ class TSC(SystemTestsCommon):
                     break
 
             status = self._test_status.get_status(CIME.test_status.BASELINE_PHASE)
+            mach_name = self._case.get_value("MACH")
+            mach_obj = Machines(machine=mach_name)
+            htmlroot = CIME.utils.get_htmlroot(mach_obj)
+            urlroot = CIME.utils.get_urlroot(mach_obj)
+            if htmlroot is not None:
+                with CIME.utils.SharedArea():
+                    dir_util.copy_tree(evv_out_dir, os.path.join(htmlroot, 'evv', case_name), preserve_mode=False)
+                if urlroot is None:
+                    urlroot = "[{}_URL]".format(mach_name.capitalize())
+                viewing = "{}/evv/{}/index.html".format(urlroot, case_name)
+            else:
+                viewing = "{}\n" \
+                          "    EVV viewing instructions can be found at: " \
+                          "        https://github.com/E3SM-Project/E3SM/blob/master/cime/scripts/" \
+                          "climate_reproducibility/README.md#test-passfail-and-extended-output" \
+                          "".format(evv_out_dir)
+
             comments = "{} {} for test '{}'.\n" \
                        "    {}\n" \
-                       "    EVV results can be viewed at: {}\n" \
-                       "    EVV viewing instructions can be found at: " \
-                       "        https://github.com/E3SM-Project/E3SM/blob/master/cime/scripts/" \
-                       "climate_reproducibility/README.md#test-passfail-and-extended-output" \
-                       "".format(CIME.test_status.BASELINE_PHASE, status, test_name, comments, evv_out_dir)
+                       "    EVV results can be viewed at:\n" \
+                       "        {}".format(CIME.test_status.BASELINE_PHASE, status, test_name, comments, viewing)
 
-            append_testlog(comments, self._orig_caseroot)
+            CIME.utils.append_testlog(comments, self._orig_caseroot)
 
     def _generate_baseline(self):
         super(TSC, self)._generate_baseline()
 
-        with SharedArea():
+        with CIME.utils.SharedArea():
             basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"),
                                        self._case.get_value("BASEGEN_CASE"))
 
@@ -192,4 +209,4 @@ class TSC(SystemTestsCommon):
                 if os.path.exists(baseline):
                     os.remove(baseline)
 
-                safe_copy(hist, baseline, preserve_meta=False)
+                CIME.utils.safe_copy(hist, baseline, preserve_meta=False)

--- a/cime/scripts/lib/CIME/utils.py
+++ b/cime/scripts/lib/CIME/utils.py
@@ -1816,3 +1816,61 @@ def model_log(model, arg_logger, msg, debug_others=True):
         arg_logger.info(msg)
     elif debug_others:
         arg_logger.debug(msg)
+
+def get_htmlroot(machobj=None):
+    """Get location for test HTML output
+
+    Hierarchy for choosing CIME_HTML_ROOT:
+    0. Environment variable CIME_HTML_ROOT
+    1. File $HOME/.cime/config
+    2. config_machines.xml (if machobj provided)
+    """
+    htmlroot = os.environ.get("CIME_HTML_ROOT")
+    if htmlroot is not None:
+        logger.info("Using htmlroot from env CIME_HTML_ROOT: {}".format(htmlroot))
+        return htmlroot
+
+    cime_config = get_cime_config()
+    if cime_config.has_option("main", "CIME_HTML_ROOT"):
+        htmlroot = cime_config.get("main", "CIME_HTML_ROOT")
+        if htmlroot is not None:
+            logger.info("Using htmlroot from .cime/config: {}".format(htmlroot))
+            return htmlroot
+
+    if machobj is not None:
+        htmlroot = machobj.get_value("CIME_HTML_ROOT")
+        if htmlroot is not None:
+            logger.info("Using htmlroot from config_machines.xml: {}".format(htmlroot))
+            return htmlroot
+
+    logger.info("No htmlroot info available")
+    return None
+
+def get_urlroot(machobj=None):
+    """Get URL to htmlroot
+
+    Hierarchy for choosing CIME_URL_ROOT:
+    0. Environment variable CIME_URL_ROOT
+    1. File $HOME/.cime/config
+    2. config_machines.xml (if machobj provided)
+    """
+    urlroot = os.environ.get("CIME_URL_ROOT")
+    if urlroot is not None:
+        logger.info("Using urlroot from env CIME_URL_ROOT: {}".format(urlroot))
+        return urlroot
+
+    cime_config = get_cime_config()
+    if cime_config.has_option("main", "CIME_URL_ROOT"):
+        urlroot = cime_config.get("main", "CIME_URL_ROOT")
+        if urlroot is not None:
+            logger.info("Using urlroot from .cime/config: {}".format(urlroot))
+            return urlroot
+
+    if machobj is not None:
+        urlroot = machobj.get_value("CIME_URL_ROOT")
+        if urlroot is not None:
+            logger.info("Using urlroot from config_machines.xml: {}".format(urlroot))
+            return urlroot
+
+    logger.info("No urlroot info available")
+    return None


### PR DESCRIPTION
This adds the ability to specify an `CIME_HTML_ROOT` and `CIME_URL_ROOT` in `config_machines.xml` so that output websites produced by the climate reproducibility tests (MVK, PGN, TSC) can be copied into a location that is hosted, and the URL reported in `TestStatus.log` so it appears on CDASH

Both `CIME_HTML_ROOT` and `CIME_URL_ROOT` can be following this hierarchy:

1. Environment variable
2. File `$HOME/.cime/config`
3. `config_machines.xml`

`CIME_HTML_ROOT` and `CIME_URL_ROOT` are currently only specified for `cori-knl` and `cori-haswell`

[B4B]