### PR TITLE
Adds intel mpi specific options for pgi compiler on Compy

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1094,6 +1094,9 @@ for mct, etc.
   <LDFLAGS>
     <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt $ENV{PNETCDF_LIBRARIES} </append>
   </LDFLAGS>
+  <MPICC  MPILIB="impi">mpipgcc</MPICC>
+  <MPICXX MPILIB="impi">mpipgcxx</MPICXX>
+  <MPIFC  MPILIB="impi">mpipgf90</MPIFC>
 </compiler>
 
 <compiler MACH="cori-haswell" COMPILER="intel">


### PR DESCRIPTION
Intel MPI for PGI compiler on Compy was missing specification of
right mpi wrapper for mpi compilers. This PR adds the missing
specifications in config_compilers.xml.

[BFB] - Bit-For-Bit