### PR TITLE
Updates land initial condition for 20th Century CMIP6 compset

### DIFF
--- a/components/clm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -47,7 +47,7 @@
 
 <fsurdat res="ne30np4">lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries res="ne30np4">lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_2015_c20171018.nc</flanduse_timeseries>
-<finidat res="ne30np4" mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc</finidat>
+<finidat res="ne30np4" mask="oEC60to30v3">lnd/clm2/initdata_map/20180316.DECKv1b_A1.ne30_oEC.edison.clm2.r.1980-01-01-00000.8575c3f_c20190904.nc</finidat>
 
 <fsurdat res="r0125">lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr1850_c190730.nc</fsurdat>
 


### PR DESCRIPTION
The new restart file is generated by remapping the following file:
20180316.DECKv1b_A1.ne30_oEC.edison.1980-01-01/20180316.DECKv1b_A1.ne30_oEC.edison.clm2.r.1980-01-01-00000.nc

[BFB]