### PR TITLE
Add new history variables at selected levels

### DIFF
--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -198,7 +198,8 @@ subroutine diag_init()
    call constituent_burden_init
 
    call addfld ('Z3',(/ 'lev' /), 'A','m','Geopotential Height (above sea level)')
-   call addfld ('Z1000',horiz_only,    'A','m','Geopotential Z at 700 mbar pressure surface')
+   call addfld ('Z1000',horiz_only,    'A','m','Geopotential Z at 1000 mbar pressure surface')
+   call addfld ('Z925',horiz_only,    'A','m','Geopotential Z at 925 mbar pressure surface')
    call addfld ('Z700',horiz_only,    'A','m','Geopotential Z at 700 mbar pressure surface')
    call addfld ('Z500',horiz_only,    'A','m','Geopotential Z at 500 mbar pressure surface')
    call addfld ('Z300',horiz_only,    'A','m','Geopotential Z at 300 mbar pressure surface')
@@ -274,12 +275,17 @@ subroutine diag_init()
    call addfld ('T300',horiz_only,    'A','K','Temperature at 300 mbar pressure surface')
    call addfld ('T200',horiz_only,    'A','K','Temperature at 200 mbar pressure surface')
    call addfld ('Q850',horiz_only,    'A','kg/kg','Specific Humidity at 850 mbar pressure surface')
-   call addfld ('Q200',horiz_only,    'A','kg/kg','Specific Humidity at 700 mbar pressure surface')
+   call addfld ('Q500',horiz_only,    'A','kg/kg','Specific Humidity at 500 mbar pressure surface')
+   call addfld ('Q200',horiz_only,    'A','kg/kg','Specific Humidity at 200 mbar pressure surface')
+   call addfld ('U925',horiz_only,    'A','m/s','Zonal wind at 925 mbar pressure surface')
    call addfld ('U850',horiz_only,    'A','m/s','Zonal wind at 850 mbar pressure surface')
+   call addfld ('U500',horiz_only,    'A','m/s','Zonal wind at 500 mbar pressure surface')
    call addfld ('U250',horiz_only,    'A','m/s','Zonal wind at 250 mbar pressure surface')
    call addfld ('U200',horiz_only,    'A','m/s','Zonal wind at 200 mbar pressure surface')
    call addfld ('U010',horiz_only,    'A','m/s','Zonal wind at  10 mbar pressure surface')
+   call addfld ('V925',horiz_only,    'A','m/s','Meridional wind at 925 mbar pressure surface')
    call addfld ('V850',horiz_only,    'A','m/s','Meridional wind at 850 mbar pressure surface')
+   call addfld ('V500',horiz_only,    'A','m/s','Meridional wind at 500 mbar pressure surface')
    call addfld ('V200',horiz_only,    'A','m/s','Meridional wind at 200 mbar pressure surface')
    call addfld ('V250',horiz_only,    'A','m/s','Meridional wind at 250 mbar pressure surface')
 
@@ -925,6 +931,10 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, z3, p_surf)
        call outfld('Z1000    ', p_surf, pcols, lchnk)
     end if
+    if (hist_fld_active('Z925')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, z3, p_surf)
+       call outfld('Z925    ', p_surf, pcols, lchnk)
+    end if
     if (hist_fld_active('Z700')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, z3, p_surf)
        call outfld('Z700    ', p_surf, pcols, lchnk)
@@ -1213,13 +1223,25 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%q(1,1,1), p_surf)
        call outfld('Q850    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('Q500')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q500    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('Q200')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%q(1,1,1), p_surf)
        call outfld('Q200    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('U925')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, state%u, p_surf)
+       call outfld('U925    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('U850')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%u, p_surf)
        call outfld('U850    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U500')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%u, p_surf)
+       call outfld('U500    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('U250')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 25000._r8, state%u, p_surf)
@@ -1233,9 +1255,17 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid,  1000._r8, state%u, p_surf)
        call outfld('U010    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('V925')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, state%v, p_surf)
+       call outfld('V925    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('V850')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%v, p_surf)
        call outfld('V850    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V500')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%v, p_surf)
+       call outfld('V500    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('V250')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 25000._r8, state%v, p_surf)


### PR DESCRIPTION
Enable several fields at selected levels as standalone history
variables. The new fields include geopotential height at 925 hPa,
specific humidity at 500 hPa, and u- and v-wind components at 925 and 500 hPa.

Typo errors for several longname description of existing history
variables (Z1000, Q200) are also corrected.

[BFB]