### PR TITLE
Fixes issue #3183

### DIFF
--- a/components/homme/src/share/parallel_mod.F90
+++ b/components/homme/src/share/parallel_mod.F90
@@ -121,8 +121,6 @@ contains
     type(parallel_t), intent(out) ::  par
 
 #ifdef _MPI
-#include <mpif.h>
-
     integer(kind=int_kind)                              :: ierr
     logical :: running   ! state of MPI at beginning of initmp call
 #ifdef CAM
@@ -182,6 +180,7 @@ contains
 
   subroutine initmp_from_par(par)
     type (parallel_t),intent(in):: par
+#ifdef _MPI
     character(len=MPI_MAX_PROCESSOR_NAME)               :: my_name
     character(len=MPI_MAX_PROCESSOR_NAME), allocatable  :: the_names(:)
     integer(kind=int_kind),allocatable                  :: tarray(:)
@@ -189,8 +188,6 @@ contains
     integer(kind=int_kind)                              :: ierr,tmp_min,tmp_max
     integer :: node_color
            
-#ifdef _MPI
-#include <mpif.h>
     if (MPI_DOUBLE_PRECISION==20 .and. MPI_REAL8==18) then
        ! LAM MPI defined MPI_REAL8 differently from MPI_DOUBLE_PRECISION
        ! and LAM MPI's allreduce does not accept on MPI_REAL8
@@ -354,7 +351,6 @@ end subroutine haltmp
     type (parallel_t) par
 
 #ifdef _MPI
-#include <mpif.h>
     integer                         :: errorcode,errorlen,ierr
     character(len=MPI_MAX_ERROR_STRING)               :: errorstring
 
@@ -379,7 +375,6 @@ end subroutine haltmp
     integer :: comm
 
 #ifdef _MPI
-#include <mpif.h>
     integer                         :: errorcode,errorlen,ierr
     character(len=MPI_MAX_ERROR_STRING)               :: errorstring
 


### PR DESCRIPTION
The constant MPI_MAX_PROCESSOR_NAME is only defined if mpi headers are
included, so it *must* be used only inside blocks guarded by `#ifdef _MPI`

Also, removing redundant inclusion of mpif.h.

Fixes #3183