### PR TITLE
Fix some build errors for IBM compiler

### DIFF
--- a/components/cam/src/control/scamMod.F90
+++ b/components/cam/src/control/scamMod.F90
@@ -580,8 +580,8 @@ subroutine setiopupdate
           write(iulog,*) 'iopTimeIdx (IOP index) =', iopTimeIdx
           write(iulog,*) 'nstep = ',get_nstep()
           write(iulog,*) 'ncdate (E3SM date) =',ncdate,' ncsec=',ncsec
-          write(iulog,*) 'next_date (IOP file date) =',next_date_print,' &
-	                  next_sec=',next_sec_print
+          write(iulog,*) 'next_date (IOP file date) =',next_date_print,&
+                         'next_sec=',next_sec_print
           write(iulog,*)'******* do iop update'
       endif
 

--- a/components/cam/src/physics/clubb/advance_clubb_core_module.F90
+++ b/components/cam/src/physics/clubb/advance_clubb_core_module.F90
@@ -1158,7 +1158,7 @@ module advance_clubb_core_module
             rtm_pert_neg_rt = pdf_params_frz%rt_2 &
                        - Lscale_pert_coef * sqrt( max( pdf_params_frz%varnce_rt_2, rt_tol**2 ) )
             !Lscale_weight = pdf_params%mixt_frac
-          else where
+          elsewhere
             rtm_pert_pos_rt = pdf_params_frz%rt_2 &
                        + Lscale_pert_coef * sqrt( max( pdf_params_frz%varnce_rt_2, rt_tol**2 ) )
             thlm_pert_pos_rt = pdf_params_frz%thl_2 + ( sign_rtpthlp * Lscale_pert_coef &
@@ -1180,7 +1180,7 @@ module advance_clubb_core_module
             rtm_pert_neg_rt = pdf_params%rt_2 &
                        - Lscale_pert_coef * sqrt( max( pdf_params%varnce_rt_2, rt_tol**2 ) )
             !Lscale_weight = pdf_params%mixt_frac
-          else where
+          elsewhere
             rtm_pert_pos_rt = pdf_params%rt_2 &
                        + Lscale_pert_coef * sqrt( max( pdf_params%varnce_rt_2, rt_tol**2 ) )
             thlm_pert_pos_rt = pdf_params%thl_2 + ( sign_rtpthlp * Lscale_pert_coef &

--- a/components/cam/src/physics/clubb/advance_xp2_xpyp_module.F90
+++ b/components/cam/src/physics/clubb/advance_xp2_xpyp_module.F90
@@ -3635,7 +3635,7 @@ module advance_xp2_xpyp_module
     !thlp2_mc will both be zero.  This also avoids a divide by zero error
     where ( precip_frac_double_delta > cloud_frac_min )
       pf_const = ( 1.0_core_rknd - precip_frac_double_delta ) / precip_frac_double_delta
-    else where
+    elsewhere
       pf_const = 0.0_core_rknd
     end where
 

--- a/components/cam/src/physics/clubb/stats_clubb_utilities.F90
+++ b/components/cam/src/physics/clubb/stats_clubb_utilities.F90
@@ -2304,7 +2304,7 @@ module stats_clubb_utilities
       if ( ircm_in_cloud > 0 ) then
         where ( cloud_frac(:) > cloud_frac_min )
             rcm_in_cloud(:) = rcm / cloud_frac
-        else where
+        elsewhere
             rcm_in_cloud(:) = rcm
         end where
 

--- a/components/cam/src/physics/cosp/actsim/lidar_simulator.F90
+++ b/components/cam/src/physics/cosp/actsim/lidar_simulator.F90
@@ -552,7 +552,7 @@ pnorm_perp_tot(:,:)=0
             ELSEWHERE
                beta_perp_ice(:,k)=pnorm_perp_ice(:,k)/EXP(-2.0*tautot_ice(:,k+1))
             END WHERE
-         else where
+         elsewhere
             ! If attenuation to TOA is too large, exp(-2.0*tautot_ice(:,k+1))
             ! goes to zero and the above code has a divide by zero error. A
             ! simple fix is to set the beta values of such layers to zero.
@@ -578,7 +578,7 @@ pnorm_perp_tot(:,:)=0
               ELSEWHERE
                  beta_perp_liq(:,k)=pnorm_perp_liq(:,k)/EXP(-2.0*tautot_liq(:,k+1))
               END WHERE
-           else where
+           elsewhere
               ! If attenuation to TOA is too large, exp(-2.0*tautot_liq(:,k+1))
               ! goes to zero and the above code has a divide by zero error. A
               ! simple fix is to set the beta values of such layers to zero.

--- a/components/homme/src/share/gllfvremap_mod.F90
+++ b/components/homme/src/share/gllfvremap_mod.F90
@@ -184,10 +184,10 @@ contains
           ! Document state of pg1. dcmip2016_test1 shows it is too coarse. For
           ! boost_pg1 = true, stepon's DSS loop needs to be separated from its
           ! tendency application loop.
-          write(iulog,*), 'gfr> Warning: pg1 is too coarse; see comments at top of gllfvremap_mod.F90'
+          write(iulog,*) 'gfr> Warning: pg1 is too coarse; see comments at top of gllfvremap_mod.F90'
           if (.not. gfr%boost_pg1) then
-             write(iulog,*), 'gfr> Warning: If you want to try pg1, use the boosted-accuracy &
-                  boost_pg1 option and call gfr_pg1_reconstruct(_topo).'
+             write(iulog,*) 'gfr> Warning: If you want to try pg1, use the boosted-accuracy &
+                  &boost_pg1 option and call gfr_pg1_reconstruct(_topo).'
           end if
        end if
     end if
@@ -1956,7 +1956,7 @@ contains
        qmax_f = maxval(q_f(:nf,:nf,k))
        qmin_g = minval(elem(ie)%state%Q(:,:,k,qi))
        qmax_g = maxval(elem(ie)%state%Q(:,:,k,qi))
-       den = gfr%tolfac*max(1e-10, maxval(abs(elem(ie)%state%Q(:,:,k,qi))))
+       den = gfr%tolfac*max(1e-10_real_kind, maxval(abs(elem(ie)%state%Q(:,:,k,qi))))
        mass_f = sum(reshape(gfr%w_ff(:nf2)*gfr%fv_metdet(:nf2,ie), (/nf,nf/))* &
             dp_fv(:nf,:nf,k)*q_f(:nf,:nf,k))
        mass_g = sum(elem(ie)%spheremp*dp(:,:,k)*q_g(:,:,k))
@@ -1992,7 +1992,7 @@ contains
        qmax_f = qmax(k)
        qmin_g = minval(q1_g(:,:,k))
        qmax_g = maxval(q1_g(:,:,k))
-       den = gfr%tolfac*max(1e-10, maxval(abs(q0_g(:,:,k))))
+       den = gfr%tolfac*max(1e-10_real_kind, maxval(abs(q0_g(:,:,k))))
        if (qmin_g < qmin_f - 50*eps*den .or. qmax_g > qmax_f + 50*eps*den) then
           write(iulog,*) 'gfr> f2g mixing ratio limits:', hybrid%par%rank, hybrid%ithr, ie, qi, k, &
                qmin_f, qmin_g-qmin_f, qmax_g-qmax_f, qmax_f, mass0, mass1, 'ERROR'
@@ -2075,7 +2075,7 @@ contains
     call gfr_hybrid_create(par, dom_mt, hybrid, nets, nete)
 
     if (hybrid%masterthread) then
-       write(iulog,  '(a,i3,a,i3)'), 'gfr> npi', gfr%npi, ' nphys', nf
+       write(iulog,  '(a,i3,a,i3)') 'gfr> npi', gfr%npi, ' nphys', nf
        if (verbose) then
           write(iulog,*) 'gfr> w_ff', nf, gfr%w_ff(:nf2)
           write(iulog,*) 'gfr> w_gg', np, gfr%w_gg(:np, :np)


### PR DESCRIPTION
With PR #3153 and #3184 locally merged for testing, there are still build errors reported by IBM XL compiler on Summit.

This PR fixes the following build errors for IBM compiler:
1511-077 (E) ELSEWHERE statement is in error.
1513-041 (S) Arguments of the wrong type were specified for the INTRINSIC procedure "max".
1515-019 (S) Syntax is incorrect.
1515-021 (E) Syntax error: Token " & " is expected.
1515-022 (S) Syntax Error: Extra token " , " was found.

[BFB]