### PR TITLE
Add precomputed hypervis reference states in derived

### DIFF
--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/CMakeLists.txt
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB NCL_SCRIPTS    "*.ncl")                                       # get ncl-scripts
+file(GLOB SHELL_SCRIPTS  "*.sh")                                        # get shell-scripts
+file(GLOB NAMELISTS      "*.nl")                                        # get namelists
+file(GLOB PYTHON_SCRIPTS "*.py")                                        # get python scripts
+file(GLOB M_FILES        "*.m")                                         # get matlab scripts
+
+# Copy test files to build
+install(PROGRAMS ${NCL_SCRIPTS} ${SHELL_SCRIPTS} ${NAMELISTS} ${PYTHON_SCRIPTS} ${M_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+add_subdirectory(movies)

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/build.sh
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cwd=`pwd`
+cd ../../..
+  echo "make -j theta-l-nlev60"
+  make -j theta-l-nlev60
+cd $cwd

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/jobscript-snl.sh
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/jobscript-snl.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+#SBATCH --job-name d21-theta
+#SNL:
+#SBATCH --account=FY150001
+#SBATCH -p ec
+#anvil:
+#SBATCH --account=condo
+#SBATCH -p acme-centos6
+#SBATCH -N 12
+#SBATCH --time=0:20:00
+
+
+export OMP_NUM_THREADS=1
+# compute number of MPI tasks                                                                                               
+if [ -n "$SLURM_NNODES" ]; then
+  NNODES=$SLURM_NNODES
+else
+  NNODES=1
+fi
+
+
+EXEC=../../../test_execs/theta-l-nlev60/theta-l-nlev60
+
+# hydrostatic theta
+namelist=namelist-h.nl
+\cp -f $namelist input.nl
+srun -c 1 -N $SLURM_NNODES  $EXEC < input.nl
+ncl plot_lon_vs_z.ncl
+\mv -f movies/dcmip2012_test2_11.nc  movies/hydro_dcmip2012_test2_11.nc
+\mv -f dcmip2012_test2_1_T_t10.pdf   hydro_T_t10.pdf
+
+# nonhydrostatic theta
+namelist=namelist-nh.nl
+\cp -f $namelist input.nl
+srun -c 1 -N $SLURM_NNODES $EXEC < input.nl
+ncl plot_lon_vs_z.ncl
+\mv -f movies/dcmip2012_test2_11.nc  movies/nonhydro_dcmip2012_test2_11.nc
+\mv -f dcmip2012_test2_1_T_t10.pdf   nonhydro_T_t10.pdf
+
+date

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-h-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-h-lowres.nl
@@ -1,0 +1,49 @@
+!
+! namelist for dcmip2012 test2-1: nonhydro mountain waves without shear
+!_______________________________________________________________________
+&ctl_nl
+  nthreads          = 1
+  partmethod        = 4                         ! mesh parition method: 4 = space filling curve
+  topology          = "cube"                    ! mesh type: cubed sphere
+  test_case         = "dcmip2012_test2_1"       ! test identifier
+  theta_hydrostatic_mode = .true.
+  rsplit            = 3
+  ne                = 7                         ! number of elements per cube face
+  qsize             = 0                         ! num tracer fields
+  nmax              = 7200                      ! 7200s / 1s per step = 7200 steps
+  statefreq         = 360                       ! number of steps between screen dumps
+  restartfreq       = -1                        ! don't write restart files if < 0
+  runtype           = 0                         ! 0 => new run
+  tstep             = 1.0                       ! largest timestep in seconds
+  integration       = 'explicit'                ! explicit time integration
+  tstep_type        = 5                         ! 1 => default method
+  nu                = 2.2e9                     ! reduced planet hyperviscosity hv/500^3
+  nu_s              = 2.2e9
+  nu_p              = 2.2e9
+  hypervis_order    = 2                         ! 2 = hyperviscosity
+  hypervis_subcycle = 1                         ! 1 = no hyperviz subcycling
+  rearth            = 12752.0                   ! reduced planet radius rearth = a/500.0
+  omega             = 0.0                       ! earth angular speed = 0.0
+  dcmip2_x_ueq      = 20.0                      ! windspeed at equator  (m/s)
+  dcmip2_x_h0       = 250.0                     ! mountain height       (m)
+  dcmip2_x_d        = 5000.0                    ! mountain half-width   (m)
+  dcmip2_x_xi       = 8000.0                    ! mountain wavelength   (m)
+/
+&vert_nl
+  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
+  vanalytic         = 1                         ! set vcoords in initialization routine
+  vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
+/
+&analysis_nl
+  output_dir        = "./movies/"               ! destination dir for netcdf file
+  output_timeunits  = 3,                        ! 0=timesteps, 1=days, 2=hours, 3=seconds
+  output_frequency  = 720,                      ! 720 seconds (10+1 outputs)
+  output_varnames1  ='T','ps','u','v','omega','geo'   ! variables to write to file
+  interp_type       = 0                         ! 0=native grid, 1=bilinear
+  output_type       ='netcdf'                   ! netcdf or pnetcdf
+  num_io_procs      = 16         
+/
+&prof_inparm
+  profile_outpe_num   = 100
+  profile_single_file	= .true.
+/

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-h.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-h.nl
@@ -1,0 +1,49 @@
+!
+! namelist for dcmip2012 test2-1: nonhydro mountain waves without shear
+!_______________________________________________________________________
+&ctl_nl
+  nthreads          = 1
+  partmethod        = 4                         ! mesh parition method: 4 = space filling curve
+  topology          = "cube"                    ! mesh type: cubed sphere
+  test_case         = "dcmip2012_test2_1"       ! test identifier
+  theta_hydrostatic_mode = .true.
+  rsplit            = 3
+  ne                = 20                        ! number of elements per cube face
+  qsize             = 0                         ! num tracer fields
+  nmax              = 18000                     ! 7200s / 0.4s per step = 18000 steps
+  statefreq         = 360                       ! number of steps between screen dumps
+  restartfreq       = -1                        ! don't write restart files if < 0
+  runtype           = 0                         ! 0 => new run
+  tstep             = 0.4                       ! largest timestep in seconds
+  integration       = 'explicit'                ! explicit time integration
+  tstep_type        = 5                         ! 1 => default method
+  nu                = 3.2e7                     ! reduced planet hyperviscosity hv/500^3
+  nu_s              = 3.2e7
+  nu_p              = 3.2e7
+  hypervis_order    = 2                         ! 2 = hyperviscosity
+  hypervis_subcycle = 1                         ! 1 = no hyperviz subcycling
+  rearth            = 12752.0                   ! reduced planet radius rearth = a/500.0
+  omega             = 0.0                       ! earth angular speed = 0.0
+  dcmip2_x_ueq      = 20.0                      ! windspeed at equator  (m/s)
+  dcmip2_x_h0       = 250.0                     ! mountain height       (m)
+  dcmip2_x_d        = 5000.0                    ! mountain half-width   (m)
+  dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
+/
+&vert_nl
+  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
+  vanalytic         = 1                         ! set vcoords in initialization routine
+  vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
+/
+&analysis_nl
+  output_dir        = "./movies/"               ! destination dir for netcdf file
+  output_timeunits  = 3,                        ! 0=timesteps, 1=days, 2=hours, 3=seconds
+  output_frequency  = 720,                      ! 720 seconds (10+1 outputs)
+  output_varnames1  ='T','ps','u','v','omega','geo'   ! variables to write to file
+  interp_type       = 0                         ! 0=native grid, 1=bilinear
+  output_type       ='netcdf'                   ! netcdf or pnetcdf
+  num_io_procs      = 16         
+/
+&prof_inparm
+  profile_outpe_num   = 100
+  profile_single_file	= .true.
+/

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-nh.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-nh.nl
@@ -1,0 +1,49 @@
+!
+! namelist for dcmip2012 test2-1: nonhydro mountain waves without shear
+!_______________________________________________________________________
+&ctl_nl
+  nthreads          = 1
+  partmethod        = 4                         ! mesh parition method: 4 = space filling curve
+  topology          = "cube"                    ! mesh type: cubed sphere
+  test_case         = "dcmip2012_test2_1"       ! test identifier
+  theta_hydrostatic_mode = .false.
+  rsplit            = 1
+  ne                = 20                        ! number of elements per cube face
+  qsize             = 0                         ! num tracer fields
+  nmax              = 18000                     ! 7200s / 0.4s per step = 18000 steps
+  statefreq         = 360                       ! number of steps between screen dumps
+  restartfreq       = -1                        ! don't write restart files if < 0
+  runtype           = 0                         ! 0 => new run
+  tstep             = 0.4                       ! largest timestep in seconds
+  integration       = 'explicit'                ! explicit time integration
+  tstep_type        = 5                         ! 1 => default method
+  nu                = 3.2e7                     ! reduced planet hyperviscosity hv/500^3
+  nu_s              = 3.2e7
+  nu_p              = 3.2e7
+  hypervis_order    = 2                         ! 2 = hyperviscosity
+  hypervis_subcycle = 1                         ! 1 = no hyperviz subcycling
+  rearth            = 12752.0                   ! reduced planet radius rearth = a/500.0
+  omega             = 0.0                       ! earth angular speed = 0.0
+  dcmip2_x_ueq      = 20.0                      ! windspeed at equator  (m/s)
+  dcmip2_x_h0       = 250.0                     ! mountain height       (m)
+  dcmip2_x_d        = 5000.0                    ! mountain half-width   (m)
+  dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
+/
+&vert_nl
+  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
+  vanalytic         = 1                         ! set vcoords in initialization routine
+  vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
+/
+&analysis_nl
+  output_dir        = "./movies/"               ! destination dir for netcdf file
+  output_timeunits  = 3,                        ! 0=timesteps, 1=days, 2=hours, 3=seconds
+  output_frequency  = 720,                      ! 720 seconds (10+1 outputs)
+  output_varnames1  ='T','ps','u','v','omega','geo'   ! variables to write to file
+  interp_type       = 0                         ! 0=native grid, 1=bilinear
+  output_type       ='netcdf'                   ! netcdf or pnetcdf
+  num_io_procs      = 16         
+/
+&prof_inparm
+  profile_outpe_num   = 100
+  profile_single_file	= .true.
+/

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/plot_lon_vs_z.ncl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/plot_lon_vs_z.ncl
@@ -1,0 +1,217 @@
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"   
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl"
+
+begin
+
+  ;_____________________________________________________________________
+  ; open file and read in data(time,lev,lat,long) from 0 to n-1
+
+  data_dir ="./movies/dcmip2012_test2_11.nc"
+  print ("data_dir="+data_dir)
+  f    = addfile(data_dir,"r")
+
+  lat  = f->lat
+  lon  = f->lon
+  lev  = f->lev
+  time = f->time
+
+  nlat = dimsizes(lat)
+  nlon = dimsizes(lon)
+  nlev = dimsizes(lev)
+  nt   = dimsizes(time)
+
+  ti = nt-1                              ; set t to max time
+  if(isvar("t")) then
+    ti = t                               ; use t from command line if possible
+  end if
+
+  X               = 500   ; small-planet scale factor
+  dt              = 0.1   ; seconds per step for hydrostatic
+  output_interval = 100 ;1000  ; steps per output
+  sec_per_day     = 3600.0*24
+
+
+  t_sec = time(ti)*sec_per_day
+  earth_days = time(ti)*X
+  print ("ti="+ti+" t= "+t_sec+"s earth_days="+earth_days)
+
+  equator = nlat/2                          ; The equator is at nlat/2
+
+  ; Select var_choice
+  ; 1 - Temperature Pert
+  ; 2 - Zonal Velocity Pert
+  ; 3 - Vertical Pressure Velocity
+
+  var_choice = 1
+  if(isvar("n")) then
+    var_choice = n
+  end if
+
+  if (var_choice .eq. 1) then               ; Select T
+    var1 = f->T(ti,:,equator,:) - 300
+  end if
+
+  if (var_choice .eq. 2) then               ; Select u
+    var1 = f->u(ti,:,equator,:) - 20.0
+  end if
+
+  if (var_choice .eq. 3) then               ; Select omega
+    var1 = f->omega(ti,:,equator,:)-0.0
+  end if
+
+  if (var_choice .eq. 4) then               ; Select v
+    var1 = f->v(ti,:,equator,:)-0.0
+  end if
+
+  ;var1@units = ""
+  ;var1@long_name = " "
+
+  ;_____________________________________________________________________
+  ; Get z positions of eta levels
+
+  Teq     = 300.d0      ; Temperature at Equator
+  Rd      = 287.0d0     ; Ideal gas const dry air (J kg^-1 K^1)
+  g       = 9.80616d0   ; Gravity (m s^2)
+  H       = Rd*Teq/g
+  z_eta   = -H * log(lev)
+
+
+  epsilon = 0.001 ;meter
+  do i=1,nlev-1
+    if( z_eta(i) .eq. z_eta(i-1) ) then
+      z_eta(i) = z_eta(i)-epsilon
+    end if
+  end do
+
+;print("z_eta="+z_eta)
+
+  ;_____________________________________________________________________
+  ; Get evenly spaced z levels
+
+  z   = new((/nlev/),double)
+  dz  = 30000.0/nlev
+  do kk=0,nlev-1
+    z(kk) = (30000.0-0.5*dz)-(kk)*dz
+  end do
+  
+  ;_________________________________________________
+  ; Interpolate from z_eta to evenly spaced z
+
+
+  var_z = new( (/nlev,nlon/), double)
+
+	do i = 0, nlon-1
+
+    z_col       = z_eta(::-1)                 ; single column of z field, inverted
+    var_col     = var1 (::-1,i)               ; single column of var field, inverted
+		var_z(:,i)  = ftcurv(z_col, var_col, z) ; interpolate to evenly spaced z using splines
+
+	end do
+
+
+  ;_____________________________________________________________________
+  ;plot  = new (1, graphic)                          ; define plot - need 3 panels
+  res1                          = True
+  res1@gsnDraw                  = False              ; panel plot
+  res1@gsnFrame                 = False             ; don't draw yet
+  res1@gsnMaximize              = True
+  res1@cnFillOn                 = True
+  res1@cnLinesOn                = True
+  res1@gsnContourLineThicknessesScale = 1.5
+  ;res1@gsnSpreadColors          = True
+  res1@lbLabelAutoStride        = True
+  res1@gsnCenterString          = ""
+  res1@tiMainString             = ""
+  res1@vpWidthF                 = 2.0
+  res1@vpHeightF                = 1.0
+  res1@cnInfoLabelOn            = False
+  res1@cnLineLabelsOn           = False
+  res1@lbLabelBarOn             = True
+  res1@lbOrientation            = "horizontal"
+  res1@lbLabelStride            = 1
+  res1@gsnPaperOrientation      = "portrait"
+  res1@sfXArray                 = lon           		; uses lon as plot x-axis
+  res1@sfYArray                 = z/1000.0          ; uses z for y axis
+  res1@trYReverse               = False          		; reverses y-axis, false
+  res1@tiYAxisString            = "height (km)"     ; y-axis title
+  res1@tiXAxisString            = ""                ; x-axis title
+  res1@gsnStringFontHeightF     = 0.04
+  res1@tmXBLabelFontHeightF     = 0.03
+  res1@tmYLLabelFontHeightF     = 0.03
+  res1@tiYAxisFontHeightF       = 0.03
+  res1@cnLevelSelectionMode     = "AutomaticLevels"
+  ;res1@cnFillPalette           ="temp_diff_18lev"; "BlWhRe"; "BlueWhiteOrangeRed";  "BlueRed"; "cmp_b2r";
+  res1@lbOrientation        = "Vertical"
+
+;  res1@gsnContourZeroLineThicknessF = 0.0
+
+
+  print("max = "+max(var1)+" min="+min(var1))
+  prefix = "dcmip2012_test2_1_"
+
+  if (var_choice .eq. 1) then         ; Setup for T'
+
+    pltTitle = sprintf("CAM-SE Test 2-1  T'  t=%.1f s",t_sec)
+    fileName = sprinti(prefix + "T_t%i",ti)
+
+    res1@cnLevelSelectionMode = "ManualLevels"
+    res1@cnMaxLevelValF  = 1.2				; max contour color label
+    res1@cnMinLevelValF  =-1.2				; min contour color label
+    res1@cnLevelSpacingF = 0.2				; contour color spacing
+
+  end if
+
+  if (var_choice .eq. 2) then		; Setup for U'
+
+    pltTitle = sprintf("CAM-SE Test 2-1  U'  t=%.1f s",t_sec)
+    fileName = sprinti(prefix + "u_t%i",ti)
+    res1@cnLevelSelectionMode = "ManualLevels"
+    res1@cnMaxLevelValF  = 2				; max contour color label
+    res1@cnMinLevelValF  =-2				; min contour color label
+    res1@cnLevelSpacingF = 0.4				; contour color spacing
+
+  end if
+
+  if (var_choice .eq. 3) then		; Setup for OMEGA
+
+    pltTitle = sprintf("CAM-SE Test 2-1  Omega  t=%.1f s",t_sec)
+    fileName = sprinti(prefix + "omega_t%i",ti)
+     res1@cnLevelSelectionMode = "ManualLevels"
+     res1@cnMaxLevelValF  = 30.0				; max contour color label
+     res1@cnMinLevelValF  =-30.0				; min contour color label
+     res1@cnLevelSpacingF = 5.0				; contour color spacing
+
+  end if
+
+  if (var_choice .eq. 4) then		; Setup for V
+
+    pltTitle = sprintf("CAM-SE Test 2-1  V  t=%.1f s",t_sec)
+    fileName = sprinti(prefix + "v_t%i",ti)
+     res1@cnLevelSelectionMode = "ManualLevels"
+     res1@cnMaxLevelValF  = 1.8				; max contour color label
+     res1@cnMinLevelValF  =-1.8				; min contour color label
+     res1@cnLevelSpacingF = 0.4				; contour color spacing
+
+  end if
+  print("filename = "+fileName)
+
+  wks_type                  = "pdf"
+  wks_type@wkPaperHeightF   = 8
+  wks_type@wkPaperWidthF    = 11
+  wks_type@wkOrientation    = "portrait"
+  wks = gsn_open_wks(wks_type,fileName)
+  gsn_define_colormap(wks,"gui_default")  		; Colormap
+
+  res1@gsnCenterString = pltTitle
+
+  ;plot = gsn_csm_contour(wks,var1(:,:),res1)		; plot var1
+  plot = gsn_csm_contour(wks,var_z(:,:),res1)		; plot var1
+  plot1 = ColorNegDashZeroPosContour(plot,"transparent","black","transparent")
+
+  draw(plot1)
+  frame(wks)
+
+end
+

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/CMakeLists.txt
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB NCL_SCRIPTS    "*.ncl")                                       # get ncl-scripts
+file(GLOB SHELL_SCRIPTS  "*.sh")                                        # get shell-scripts
+file(GLOB NAMELISTS      "*.nl")                                        # get namelists
+file(GLOB PYTHON_SCRIPTS "*.py")                                        # get python scripts
+file(GLOB M_FILES        "*.m")                                         # get matlab scripts
+
+# Copy test files to build
+install(PROGRAMS ${NCL_SCRIPTS} ${SHELL_SCRIPTS} ${NAMELISTS} ${PYTHON_SCRIPTS} ${M_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+add_subdirectory(movies)

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/build.sh
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cwd=`pwd`
+cd ../../..
+  echo "make -j theta-l-nlev60p"
+  make -j theta-l-nlev60
+cd $cwd

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/jobscript-snl.sh
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/jobscript-snl.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+#SBATCH --job-name d21-theta
+#SNL:
+#SBATCH --account=FY150001
+#SBATCH -p ec
+#anvil:
+#SBATCH --account=condo
+#SBATCH -p acme-centos6
+#SBATCH -N 12
+#SBATCH --time=0:20:00
+
+export OMP_NUM_THREADS=1
+# compute number of MPI tasks                                                                                               
+if [ -n "$SLURM_NNODES" ]; then
+  NNODES=$SLURM_NNODES
+else
+  NNODES=1
+fi
+
+
+EXEC=../../../test_execs/theta-l-nlev60/theta-l-nlev60
+
+# hydrostatic theta
+namelist=namelist-h.nl
+\cp -f $namelist input.nl
+srun -c 1 -N $SLURM_NNODES  $EXEC < input.nl
+ncl plot_lon_vs_z.ncl
+\mv -f movies/dcmip2012_test2_21.nc  movies/hydro_dcmip2012_test2_21.nc
+\mv -f dcmip2012_test2_2_T_t10.pdf   hydro_T_t10.pdf
+
+# nonhydrostatic theta
+namelist=namelist-nh.nl
+\cp -f $namelist input.nl
+srun -c 1 -N $SLURM_NNODES   $EXEC < input.nl
+ncl plot_lon_vs_z.ncl
+\mv -f movies/dcmip2012_test2_21.nc  movies/nonhydro_dcmip2012_test2_21.nc
+\mv -f dcmip2012_test2_2_T_t10.pdf   nonhydro_T_t10.pdf
+
+date

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/jobscript-snl.sh
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/jobscript-snl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#SBATCH --job-name d21-theta
+#SBATCH --job-name d22-theta
 #SNL:
 #SBATCH --account=FY150001
 #SBATCH -p ec

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-h-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-h-lowres.nl
@@ -1,0 +1,50 @@
+!
+! namelist for dcmip2012 test2-2: nonhydro mountain waves without shear
+!_______________________________________________________________________
+&ctl_nl
+  nthreads          = 1
+  partmethod        = 4                         ! mesh parition method: 4 = space filling curve
+  topology          = "cube"                    ! mesh type: cubed sphere
+  test_case         = "dcmip2012_test2_2"       ! test identifier
+  theta_hydrostatic_mode = .true.
+  ne                = 7                         ! number of elements per cube face
+  qsize             = 0                         ! num tracer fields
+  nmax              = 7200                      ! 7200s / 0.1s per step = 72000 steps
+  statefreq         = 75                        ! number of steps between screen dumps
+  restartfreq       = -1                        ! don't write restart files if < 0
+  runtype           = 0                         ! 0 => new run
+  rsplit            = 3                         ! vertical remap
+  tstep             = 1                         ! largest timestep in seconds
+  integration       = 'explicit'                ! explicit time integration
+  tstep_type        = 5                         ! 1 => default method
+  vert_remap_q_alg  = 0
+  nu                = 2.2e9                       ! reduced planet hyperviscosity hv/500^3
+  nu_s              = 2.2e9
+  nu_p              = 2.2e9
+  hypervis_order    = 2                         ! 2 = hyperviscosity
+  hypervis_subcycle = 1                         ! 1 = no hyperviz subcycling
+  rearth            = 12752.0                   ! reduced planet radius rearth = a/500.0
+  omega             = 0.0                       ! earth angular speed = 0.0
+  dcmip2_x_ueq      = 20.0                      ! windspeed at equator  (m/s)
+  dcmip2_x_h0       = 250.0                     ! mountain height       (m)
+  dcmip2_x_d        = 5000.0                    ! mountain half-width   (m)
+  dcmip2_x_xi       = 8000.0                    ! mountain wavelength   (m)
+/
+&vert_nl
+  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
+  vanalytic         = 1                         ! set vcoords in initialization routine
+  vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
+/
+&analysis_nl
+  output_dir        = "./movies/"               ! destination dir for netcdf file
+  output_timeunits  = 3,                        ! 3=seconds
+  output_frequency  = 720,                      ! 720 seconds
+  output_varnames1  ='T','ps','u','v','geo','omega' ! variables to write to file
+  interp_type       = 1                         ! 0=native grid, 1=bilinear
+  output_type       ='netcdf'                   ! netcdf or pnetcdf
+  num_io_procs      = 16         
+/
+&prof_inparm
+  profile_outpe_num   = 100
+  profile_single_file	= .true.
+/

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-h.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-h.nl
@@ -1,0 +1,50 @@
+!
+! namelist for dcmip2012 test2-2: nonhydro mountain waves without shear
+!_______________________________________________________________________
+&ctl_nl
+  nthreads          = 1
+  partmethod        = 4                         ! mesh parition method: 4 = space filling curve
+  topology          = "cube"                    ! mesh type: cubed sphere
+  test_case         = "dcmip2012_test2_2"       ! test identifier
+  theta_hydrostatic_mode = .true.
+  ne                = 20                        ! number of elements per cube face
+  qsize             = 0                         ! num tracer fields
+  nmax              = 18000                     ! 7200s / 0.4s per step = 18000 steps
+  statefreq         = 300                       ! number of steps between screen dumps
+  restartfreq       = -1                        ! don't write restart files if < 0
+  runtype           = 0                         ! 0 => new run
+  rsplit            = 3                         ! vertical remap 
+  tstep             = 0.40                      ! largest timestep in seconds
+  integration       = 'explicit'                ! explicit time integration
+  tstep_type        = 5                         ! 1 => default method
+  vert_remap_q_alg  = 0
+  nu                = 3.2e7                     ! reduced planet hyperviscosity hv/500^3
+  nu_s              = 3.2e7
+  nu_p              = 3.2e7
+  hypervis_order    = 2                         ! 2 = hyperviscosity
+  hypervis_subcycle = 1                         ! 1 = no hyperviz subcycling
+  rearth            = 12752.0                   ! reduced planet radius rearth = a/500.0
+  omega             = 0.0                       ! earth angular speed = 0.0
+  dcmip2_x_ueq      = 20.0                      ! windspeed at equator  (m/s)
+  dcmip2_x_h0       = 250.0                     ! mountain height       (m)
+  dcmip2_x_d        = 5000.0                    ! mountain half-width   (m)
+  dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
+/
+&vert_nl
+  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
+  vanalytic         = 1                         ! set vcoords in initialization routine
+  vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
+/
+&analysis_nl
+  output_dir        = "./movies/"               ! destination dir for netcdf file
+  output_timeunits  = 3,                        ! 3=seconds
+  output_frequency  = 720,                      ! 720 seconds
+  output_varnames1  ='T','ps','u','v','geo','omega' ! variables to write to file
+  interp_type       = 1                         ! 0=native grid, 1=bilinear
+  output_type       ='netcdf'                   ! netcdf or pnetcdf
+  num_io_procs      = 16         
+/
+&prof_inparm
+  profile_outpe_num   = 100
+  profile_single_file	= .true.
+/

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-nh.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-nh.nl
@@ -1,0 +1,50 @@
+!
+! namelist for dcmip2012 test2-2: nonhydro mountain waves without shear
+!_______________________________________________________________________
+&ctl_nl
+  nthreads          = 1
+  partmethod        = 4                         ! mesh parition method: 4 = space filling curve
+  topology          = "cube"                    ! mesh type: cubed sphere
+  test_case         = "dcmip2012_test2_2"       ! test identifier
+  theta_hydrostatic_mode = .false.
+  ne                = 20                        ! number of elements per cube face
+  qsize             = 0                         ! num tracer fields
+  nmax              = 18000                     ! 7200s / 0.4s per step = 18000 steps
+  statefreq         = 300                       ! number of steps between screen dumps
+  restartfreq       = -1                        ! don't write restart files if < 0
+  runtype           = 0                         ! 0 => new run
+  rsplit            = 1                         ! vertical remap 
+  tstep             = 0.40                      ! largest timestep in seconds
+  integration       = 'explicit'                ! explicit time integration
+  tstep_type        = 5                         ! 1 => default method
+  vert_remap_q_alg  = 0
+  nu                = 3.2e7                     ! reduced planet hyperviscosity hv/500^3
+  nu_s              = 3.2e7
+  nu_p              = 3.2e7
+  hypervis_order    = 2                         ! 2 = hyperviscosity
+  hypervis_subcycle = 1                         ! 1 = no hyperviz subcycling
+  rearth            = 12752.0                   ! reduced planet radius rearth = a/500.0
+  omega             = 0.0                       ! earth angular speed = 0.0
+  dcmip2_x_ueq      = 20.0                      ! windspeed at equator  (m/s)
+  dcmip2_x_h0       = 250.0                     ! mountain height       (m)
+  dcmip2_x_d        = 5000.0                    ! mountain half-width   (m)
+  dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
+/
+&vert_nl
+  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
+  vanalytic         = 1                         ! set vcoords in initialization routine
+  vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
+/
+&analysis_nl
+  output_dir        = "./movies/"               ! destination dir for netcdf file
+  output_timeunits  = 3,                        ! 3=seconds
+  output_frequency  = 720,                      ! 720 seconds
+  output_varnames1  ='T','ps','u','v','geo','omega' ! variables to write to file
+  interp_type       = 1                         ! 0=native grid, 1=bilinear
+  output_type       ='netcdf'                   ! netcdf or pnetcdf
+  num_io_procs      = 16         
+/
+&prof_inparm
+  profile_outpe_num   = 100
+  profile_single_file	= .true.
+/

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/plot_lon_vs_z.ncl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/plot_lon_vs_z.ncl
@@ -1,0 +1,216 @@
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"   
+load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl"
+
+begin
+
+  ;_____________________________________________________________________
+  ; open file and read in data(time,lev,lat,long) from 0 to n-1
+
+  data_dir ="./movies/dcmip2012_test2_21.nc"
+  print ("data_dir="+data_dir)
+  f    = addfile(data_dir,"r")
+
+  lat  = f->lat
+  lon  = f->lon
+  lev  = f->lev
+  time = f->time
+
+  nlat = dimsizes(lat)
+  nlon = dimsizes(lon)
+  nlev = dimsizes(lev)
+  nt   = dimsizes(time)
+
+  ti = nt-1                              ; set t to max time
+  if(isvar("t")) then
+    ti = t                               ; use t from command line if possible
+  end if
+
+  X               = 500   ; small-planet scale factor
+  dt              = 0.1   ; seconds per step for hydrostatic
+  output_interval = 100 ;1000  ; steps per output
+  sec_per_day     = 3600.0*24
+
+
+  t = time(ti)*sec_per_day
+  earth_days = time(ti)*X
+  print ("ti="+ti+" t= "+t+"s earth_days="+earth_days)
+
+  equator = nlat/2                          ; The equator is at nlat/2
+
+  ; Select var_choice
+  ; 1 - Temperature Pert
+  ; 2 - Zonal Velocity Pert
+  ; 3 - Vertical Pressure Velocity
+
+  var_choice = 1
+  if(isvar("n")) then
+    var_choice = n
+  end if
+
+  if (var_choice .eq. 1) then               ; Select T
+    var1 = f->T(ti,:,equator,:) - 300
+  end if
+
+  if (var_choice .eq. 2) then               ; Select u
+    var1 = f->u(ti,:,equator,:) - 20.0
+  end if
+
+  if (var_choice .eq. 3) then               ; Select omega
+    var1 = f->omega(ti,:,equator,:)-0.0
+  end if
+
+  if (var_choice .eq. 4) then               ; Select v
+    var1 = f->v(ti,:,equator,:)-0.0
+  end if
+
+  ;var1@units = ""
+  ;var1@long_name = " "
+
+  ;_____________________________________________________________________
+  ; Get z positions of eta levels
+
+  Teq     = 300.d0      ; Temperature at Equator
+  Rd      = 287.0d0     ; Ideal gas const dry air (J kg^-1 K^1)
+  g       = 9.80616d0   ; Gravity (m s^2)
+  H       = Rd*Teq/g
+  z_eta   = -H * log(lev)
+
+
+  epsilon = 0.001 ;meter
+  do i=1,nlev-1
+    if( z_eta(i) .eq. z_eta(i-1) ) then
+      z_eta(i) = z_eta(i)-epsilon
+    end if
+  end do
+
+;print("z_eta="+z_eta)
+
+  ;_____________________________________________________________________
+  ; Get evenly spaced z levels
+
+  z   = new((/nlev/),double)
+  dz  = 30000.0/nlev
+  do kk=0,nlev-1
+    z(kk) = (30000.0-0.5*dz)-(kk)*dz
+  end do
+  
+  ;_________________________________________________
+  ; Interpolate from z_eta to evenly spaced z
+
+
+  var_z = new( (/nlev,nlon/), double)
+
+	do i = 0, nlon-1
+
+    z_col       = z_eta(::-1)                 ; single column of z field, inverted
+    var_col     = var1 (::-1,i)               ; single column of var field, inverted
+		var_z(:,i)  = ftcurv(z_col, var_col, z) ; interpolate to evenly spaced z using splines
+
+	end do
+
+
+  ;_____________________________________________________________________
+  res1                          = True
+  res1@gsnDraw                  = False              ; panel plot
+  res1@gsnFrame                 = False             ; don't draw yet
+  res1@gsnMaximize              = True
+  res1@cnFillOn                 = True
+  res1@cnLinesOn                = True
+  res1@gsnContourLineThicknessesScale = 1.5
+  ;res1@gsnSpreadColors          = True
+  res1@lbLabelAutoStride        = True
+  res1@gsnCenterString          = ""
+  res1@tiMainString             = ""
+  res1@vpWidthF                 = 2.0
+  res1@vpHeightF                = 1.0
+  res1@cnInfoLabelOn            = False
+  res1@cnLineLabelsOn           = False
+  res1@lbLabelBarOn             = True
+  res1@lbOrientation            = "horizontal"
+  res1@lbLabelStride            = 1
+  res1@gsnPaperOrientation      = "portrait"
+  res1@sfXArray                 = lon           		; uses lon as plot x-axis
+  res1@sfYArray                 = z/1000.0          ; uses z for y axis
+  res1@trYReverse               = False          		; reverses y-axis, false
+  res1@tiYAxisString            = "height (km)"     ; y-axis title
+  res1@tiXAxisString            = ""                ; x-axis title
+  res1@gsnStringFontHeightF     = 0.04
+  res1@tmXBLabelFontHeightF     = 0.03
+  res1@tmYLLabelFontHeightF     = 0.03
+  res1@tiYAxisFontHeightF       = 0.03
+  res1@cnLevelSelectionMode     = "AutomaticLevels"
+  res1@lbOrientation        = "Vertical"
+
+  ;res1@gsnContourZeroLineThicknessF = 0.0
+
+  ;res1@cnFillPalette           ="temp_diff_18lev"; "BlWhRe"; "BlueWhiteOrangeRed";  "BlueRed"; "cmp_b2r";
+
+  print("max = "+max(var1)+" min="+min(var1))
+  prefix = "dcmip2012_test2_2_"
+
+  if (var_choice .eq. 1) then         ; Setup for T'
+
+    pltTitle = sprintf("CAM-SE Test 2-2  T'  t=%.1f s",t)
+    fileName = sprinti(prefix + "T_t%i",ti)
+
+    res1@cnLevelSelectionMode = "ManualLevels"
+    res1@cnMaxLevelValF  = 1.2				; max contour color label
+    res1@cnMinLevelValF  =-1.2				; min contour color label
+    res1@cnLevelSpacingF = 0.2				; contour color spacing
+
+  end if
+
+  if (var_choice .eq. 2) then		; Setup for U'
+
+    pltTitle = sprintf("CAM-SE Test 2-2  U'  t=%.1f s",t)
+    fileName = sprinti(prefix + "u_t%i",ti)
+    res1@cnLevelSelectionMode = "ManualLevels"
+    res1@cnMaxLevelValF  = 2				; max contour color label
+    res1@cnMinLevelValF  =-2				; min contour color label
+    res1@cnLevelSpacingF = 0.4				; contour color spacing
+
+  end if
+
+  if (var_choice .eq. 3) then		; Setup for OMEGA
+
+    pltTitle = sprintf("CAM-SE Test 2-2  Omega  t=%.1f s",t)
+    fileName = sprinti(prefix + "omega_t%i",ti)
+     res1@cnLevelSelectionMode = "ManualLevels"
+     res1@cnMaxLevelValF  = 30.0				; max contour color label
+     res1@cnMinLevelValF  =-30.0				; min contour color label
+     res1@cnLevelSpacingF = 5.0				; contour color spacing
+
+  end if
+
+  if (var_choice .eq. 4) then		; Setup for V
+
+    pltTitle = sprintf("CAM-SE Test 2-2  V  t=%.1f s",t)
+    fileName = sprinti(prefix + "v_t%i",ti)
+     res1@cnLevelSelectionMode = "ManualLevels"
+     res1@cnMaxLevelValF  = 1.8				; max contour color label
+     res1@cnMinLevelValF  =-1.8				; min contour color label
+     res1@cnLevelSpacingF = 0.4				; contour color spacing
+
+  end if
+  print("filename = "+fileName)
+
+  wks_type                  = "pdf"
+  wks_type@wkPaperHeightF   = 8
+  wks_type@wkPaperWidthF    = 11
+  wks_type@wkOrientation    = "portrait"
+  wks = gsn_open_wks(wks_type,fileName)
+  gsn_define_colormap(wks,"gui_default")  		; Colormap
+
+  res1@gsnCenterString = pltTitle
+
+;  plot = gsn_csm_contour(wks,var1(:,:),res1)		; plot var1
+  plot = gsn_csm_contour(wks,var_z(:,:),res1)		; plot var1
+  plot1 = ColorNegDashZeroPosContour(plot,"transparent","black","transparent")
+
+  draw(plot1)
+  frame(wks)
+
+end
+

--- a/components/homme/src/theta-l/element_ops.F90
+++ b/components/homme/src/theta-l/element_ops.F90
@@ -369,7 +369,7 @@ contains
   do k=1,nlev
      p(:,:,k) = hvcoord%hyam(k)*hvcoord%ps0 + hvcoord%hybm(k)*ps(:,:)
      dp(:,:,k) = ( hvcoord%hyai(k+1) - hvcoord%hyai(k) )*hvcoord%ps0 + &
-          ( hvcoord%hybi(k+1) - hvcoord%hybi(k) )*elem%state%ps_v(:,:,nt)
+          ( hvcoord%hybi(k+1) - hvcoord%hybi(k) )*ps(:,:)
   enddo
 
 !set vtheta
@@ -483,10 +483,10 @@ contains
     u   = elem%state%v   (:,:,1,:,nt)
     v   = elem%state%v   (:,:,2,:,nt)
     ps  = elem%state%ps_v(:,:,  nt)
+    dp  = elem%state%dp3d(:,:,:,nt)
     phi_i = elem%state%phinh_i(:,:,:,nt)
 
     do k=1,nlev
-       dp(:,:,k)=(hvcoord%hyai(k+1)-hvcoord%hyai(k))*hvcoord%ps0 +(hvcoord%hybi(k+1)-hvcoord%hybi(k))*ps(:,:)
        w(:,:,k) = (elem%state%w_i(:,:,k,nt) + elem%state%w_i(:,:,k+1,nt))/2
     end do
 

--- a/components/homme/src/theta-l/element_state.F90
+++ b/components/homme/src/theta-l/element_state.F90
@@ -82,7 +82,7 @@ module element_state
     real (kind=real_kind) :: gradphis(np,np,2)   ! grad phi at the surface, computed once in model initialization
     real (kind=real_kind) :: dp_ref(np,np,nlev)    ! ref states based on PHIS
     real (kind=real_kind) :: theta_ref(np,np,nlev)
-    real (kind=real_kind) :: phi_ref(np,np,nlev)  
+    real (kind=real_kind) :: phi_ref(np,np,nlevp)  
   end type derived_state_t
   
 

--- a/components/homme/src/theta-l/eos.F90
+++ b/components/homme/src/theta-l/eos.F90
@@ -101,18 +101,16 @@ implicit none
      enddo
   endif
 
-  ! hydrostatic pressure
-  pi_i(:,:,1)=hvcoord%hyai(1)*hvcoord%ps0
-  do k=1,nlev
-     pi_i(:,:,k+1)=pi_i(:,:,k) + dp3d(:,:,k)
-  enddo
-  do k=1,nlev
-     pi(:,:,k)=pi_i(:,:,k) + dp3d(:,:,k)/2
-  enddo
-
-
   if (theta_hydrostatic_mode) then
      ! hydrostatic pressure
+     pi_i(:,:,1)=hvcoord%hyai(1)*hvcoord%ps0
+     do k=1,nlev
+        pi_i(:,:,k+1)=pi_i(:,:,k) + dp3d(:,:,k)
+     enddo
+     do k=1,nlev
+        pi(:,:,k)=pi_i(:,:,k) + dp3d(:,:,k)/2
+     enddo
+     
      exner  = (pi/p0)**kappa
      pnh = pi ! copy hydrostatic pressure into output variable
      dpnh_dp_i = 1
@@ -132,7 +130,7 @@ implicit none
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! boundary terms
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  
-   pnh_i(:,:,1) = pi_i(:,:,1)   ! hydrostatic ptop    
+   pnh_i(:,:,1) = hvcoord%hyai(1)*hvcoord%ps0  ! hydrostatic ptop    
    ! surface boundary condition pnh_i determined by w equation to enforce
    ! w b.c.  This is computed in the RHS calculation.  Here, we use
    ! an approximation (hydrostatic) so that dpnh/dpi = 1

--- a/components/homme/src/theta-l/model_init_mod.F90
+++ b/components/homme/src/theta-l/model_init_mod.F90
@@ -82,30 +82,7 @@ contains
       temp=elem(ie)%derived%theta_ref*elem(ie)%derived%dp_ref
       call phi_from_eos(hvcoord,elem(ie)%state%phis,&
            temp,elem(ie)%derived%dp_ref,elem(ie)%derived%phi_ref)
-#endif
-#ifdef HV_REFSTATES_V2
-      ! use Newton to solve for surface pressure
-      ! so that Cp theta_ref grad(exner_ref) + grad(phis) = 0
-      T1 = .0065*TREF*Cp/g ! = 191                                                            
-      T0 = TREF-T1         ! = 97                                                             
-      exner(:,:) =  exp( -kappa*elem(ie)%state%phis(:,:)/(Rgas*TREF))
-      do i=1,5
-         exner(:,:) = exner(:,:) - &
-              (elem(ie)%state%phis(:,:)/Cp + T0*log(exner(:,:))+T1*exner(:,:)-T1 ) &
-              / (T0/exner(:,:)+T1)
-      enddo
-      ps_ref(:,:) = (exner(:,:)**(1/kappa)) / p0
-
-      do k=1,nlev
-         elem(ie)%derived%dp_ref(:,:,k) = ( hvcoord%hyai(k+1) - hvcoord%hyai(k) )*hvcoord%ps0 + &
-              (hvcoord%hybi(k+1)-hvcoord%hybi(k))*ps_ref(:,:)
-      enddo
-      call set_theta_ref(hvcoord,elem(ie)%derived%dp_ref,temp)
-      temp=temp*elem(ie)%derived%dp_ref
-      call phi_from_eos(hvcoord,elem(ie)%state%phis,&
-           temp,elem(ie)%derived%dp_ref,elem(ie)%derived%phi_ref)
-
-      elem(ie)%derived_theta_ref=0
+      elem(ie)%derived%theta_ref=0
 #endif
     enddo 
 

--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -2046,7 +2046,7 @@ contains
                
                !  Form IEvert1
                elem(ie)%accum%IEvert1(i,j)=elem(ie)%accum%IEvert1(i,j)      &
-                    -exner(i,j,k)*theta_vadv(i,j,k)                        
+                    -Cp*exner(i,j,k)*theta_vadv(i,j,k)                        
                ! Form IEvert2 
                ! here use of dpnh_dp_i on boundry (with incorrect data)
                ! is harmess becuase eta_dot_dpdn=0

--- a/components/homme/src/theta-l/prim_state_mod.F90
+++ b/components/homme/src/theta-l/prim_state_mod.F90
@@ -355,7 +355,7 @@ contains
 #ifdef CAM
        ! CAM neglicts the small, constant p(top) term.  Add this
        ! term in to be consistent
-       tmp(:,:,ie)=temp(:,:,ie) + hvcoord%hyai(1)*hvcoord%ps0 
+       tmp(:,:,ie)=tmp(:,:,ie) + hvcoord%hyai(1)*hvcoord%ps0 
 #endif
     enddo
     Mass2 = global_integral(elem, tmp(:,:,nets:nete),hybrid,npts,nets,nete)

--- a/components/homme/src/theta-l/vertremap_mod.F90
+++ b/components/homme/src/theta-l/vertremap_mod.F90
@@ -12,7 +12,6 @@ module vertremap_mod
   use perf_mod, only               : t_startf, t_stopf  ! _EXTERNAL
   use parallel_mod, only           : abortmp, parallel_t
   use control_mod, only : vert_remap_q_alg
-  use element_ops, only : set_theta_ref
   use eos, only : phi_from_eos
   implicit none
   private
@@ -50,7 +49,6 @@ contains
   integer :: q
 
   real (kind=real_kind), dimension(np,np,nlev)  :: dp,dp_star
-  real (kind=real_kind), dimension(np,np,nlev)  :: theta_ref
   real (kind=real_kind), dimension(np,np,nlevp) :: phi_ref
   real (kind=real_kind), dimension(np,np,nlev,5)  :: ttmp
 
@@ -106,9 +104,6 @@ contains
      endif
 
      if (rsplit>0) then
-        !removing theta_ref does not help much and will not conserve theta*dp
-        !call set_theta_ref(hvcoord,dp_star,theta_ref)
-
         ! remove hydrostatic phi befor remap
         call phi_from_eos(hvcoord,elem(ie)%state%phis,elem(ie)%state%vtheta_dp(:,:,:,np1),dp_star,phi_ref)
         elem(ie)%state%phinh_i(:,:,:,np1)=&
@@ -117,7 +112,7 @@ contains
         !  REMAP u,v,T from levels in dp3d() to REF levels
         ttmp(:,:,:,1)=elem(ie)%state%v(:,:,1,:,np1)*dp_star
         ttmp(:,:,:,2)=elem(ie)%state%v(:,:,2,:,np1)*dp_star
-        ttmp(:,:,:,3)=elem(ie)%state%vtheta_dp(:,:,:,np1)   ! - theta_ref*dp_star*Cp
+        ttmp(:,:,:,3)=elem(ie)%state%vtheta_dp(:,:,:,np1)
         do k=1,nlev
            ttmp(:,:,k,4)=elem(ie)%state%phinh_i(:,:,k+1,np1)-&
                 elem(ie)%state%phinh_i(:,:,k,np1) 
@@ -131,10 +126,9 @@ contains
         call remap1(ttmp,np,5,dp_star,dp)
         call t_stopf('vertical_remap1_1')
 
-        !call set_theta_ref(hvcoord,dp,theta_ref)
         elem(ie)%state%v(:,:,1,:,np1)=ttmp(:,:,:,1)/dp
         elem(ie)%state%v(:,:,2,:,np1)=ttmp(:,:,:,2)/dp
-        elem(ie)%state%vtheta_dp(:,:,:,np1)=ttmp(:,:,:,3) ! + theta_ref*dp*Cp
+        elem(ie)%state%vtheta_dp(:,:,:,np1)=ttmp(:,:,:,3)
       
         
         do k=nlev,1,-1

--- a/components/homme/src/theta-l/vertremap_mod.F90
+++ b/components/homme/src/theta-l/vertremap_mod.F90
@@ -164,9 +164,7 @@ contains
      endif
 
      ! reinitialize dp3d after remap
-     do k=1,nlev    
-        elem(ie)%state%dp3d(:,:,:,np1)=dp(:,:,:)
-     enddo
+     elem(ie)%state%dp3d(:,:,:,np1)=dp(:,:,:)
 
   enddo
   call t_stopf('vertical_remap')


### PR DESCRIPTION
Precompute reference states used for hyperviscosity. 

related code cleanup:
-- adding dcmip2012 tests for theta-l model (used to test new reference profiles)
-- added missing Cp term from IEvert1 diagnostic
-- remove unnecessary use of ps_v 
-- remove unnecessary scan to compute hydrostatic pressure

[non-BFB] for EAM theta-l tests
