### PR TITLE
Enable newer PIO2 interfaces for MPAS

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -78,6 +78,12 @@ for mct, etc.
      compilers -->
 <compiler>
   <SUPPORTS_CXX>FALSE</SUPPORTS_CXX>
+  <CPPDEFS>
+    <!-- MPAS Components rely on this flag to use the newer PIO/Scorpio interfaces. These newer interfaces are available on both Scorpio and Scorpio classic -->
+    <append MODEL="ice"> -DUSE_PIO2 </append>
+    <append MODEL="ocn"> -DUSE_PIO2 </append>
+    <append MODEL="glc"> -DUSE_PIO2 </append>
+  </CPPDEFS>
 </compiler>
 
 <compiler COMPILER="cray">


### PR DESCRIPTION
Turning on newer PIO2 interfaces in MPAS for both
scorpio and scorpio classic

[BFB]