### PR TITLE
Revert Compy's Intel compiler from 19.0.3(intelmpi) to 18.0.0(mvapich2)

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1869,7 +1869,7 @@
     <NODENAME_REGEX>compy</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,pgi</COMPILERS>
-    <MPILIBS>impi,mvapich2</MPILIBS>
+    <MPILIBS>mvapich2,impi</MPILIBS>
     <SAVE_TIMING_DIR>/compyfs</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>/compyfs/$USER/e3sm_scratch</CIME_OUTPUT_ROOT>
@@ -1922,7 +1922,7 @@
         <command name="load">cmake/3.11.4</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/19.0.3</command>
+        <command name="load">intel/18.0.0</command>
       </modules>
       <modules compiler="pgi">
         <command name="load">pgi/18.10</command>
@@ -1931,12 +1931,12 @@
         <command name="load">mvapich2/2.3.1</command>
       </modules>
       <modules mpilib="impi">
-        <command name="load">intelmpi/2019u3</command>
+        <command name="load">intelmpi/2018</command>
       </modules>
       <modules>
         <command name="load">netcdf/4.6.3</command>
         <command name="load">pnetcdf/1.9.0</command>
-        <command name="load">mkl/2019u3</command>
+        <command name="load">mkl/2018</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>


### PR DESCRIPTION
Intel 19.0.3 produces wrong answers when the model is run with CLUBBv2.
We saw this behavior only on Compy. The same compiler works fine on
Cori. All other compilers, libraries and machines work fine.

Intel 18.0.0 doesn't work with intel mpi due to some bug in the mpi
implementation. Therefore, mvapich2 is used instead with intel
18.0.0

[BFB] - Bit-For-Bit