### PR TITLE
Update compset definition to match changed DICE options

### DIFF
--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -17,7 +17,7 @@
 
   <compset>
     <alias>CMPASO-IAF</alias>
-    <lname>2000_DATM%IAF_SLND_DICE%SIAF_MPASO%DATMFORCED_DROF%IAF_SGLC_SWAV</lname>
+    <lname>2000_DATM%IAF_SLND_DICE%IAF_MPASO%DATMFORCED_DROF%IAF_SGLC_SWAV</lname>
     <support_level>Experimental, under development</support_level>
   </compset>
 


### PR DESCRIPTION
This PR fixes the definition of the CMPASO-IAF compset, which is active-ocean only, to fit the new DICE options.

Fixes #3191 
[BFB]