### PR TITLE
Update CIME to ESMCI cime5.8.9

### DIFF
--- a/cime/ChangeLog
+++ b/cime/ChangeLog
@@ -1,6 +1,218 @@
 ======================================================================
 
 Originator: Chris Fischer 
+Date: 8-29-2019
+Tag: cime5.8.9
+Answer Changes: None
+Tests:  scripts_regression_tests --compiler nag, SMS_D_Ln9.f19_f19_mg17.QPC6.izumi_nag
+Dependencies:
+
+Brief Summary:
+    - Fix nag compiler for CAM.
+
+User interface changes: 
+
+PR summary: git log --oneline --first-parent [previous_tag]..master
+    - 6026ca341 Merge pull request #3219 from ESMCI/fischer/nag
+
+Modified files: git diff --name-status [previous_tag]
+M       config/cesm/machines/Depends.nag
+
+
+======================================================================
+
+======================================================================
+
+Originator: Chris Fischer 
+Date: 8-26-2019
+Tag: cime5.8.8
+Answer Changes: None
+Tests: scripts_regression_tests, aux_mom 
+Dependencies:
+
+Brief Summary:
+    - Merge maint-5.6 branch.
+    - Add support for ne120pg3 using tx01.v3 mask.
+    - ACME merge 2019-08-20.
+    - Fix bad compset.
+    - Update ncpl and cpl_seq_option for mom6.
+    - Improve the config_compilers.xml schema.
+    - Overindented line fixed.
+    - ACME merge 2019-08-07.
+    - PIO2 update.
+    - Make sure output_root path is abspath.
+    - Use correct mask for ne16pg3 resolution.
+    - Changes to have TG compset with NUOPC cap work correctly.
+    - Point to new mapping files for r05 <-> f10 mapping.
+    - Fix some test fails.
+    - ACME merge 2019-07-22
+    - Remove test SMS.T42_T42.S when testing with nuopc driver.
+
+User interface changes: 
+
+PR summary: git log --oneline --first-parent [previous_tag]..master
+a9c9289f1 Merge branch 'maint-5.6'
+44fd46a43 Merge pull request #3208 from ESMCI/fischer/ne120pg3_tx13
+34e3dbe77 Merge pull request #3206 from ESMCI/jgfouca/branch-for-acme-split-2019-08-20
+0b1c5aab9 Merge pull request #3203 from gold2718/fix_bad_compset
+1c663d0e3 Merge pull request #3198 from alperaltuntas/update_mom6_ncpl
+74b5913c4 Merge pull request #3196 from jedwards4b/config_compiler_schema_improvement
+b0d5c1537 Merge pull request #3197 from jedwards4b/fix_indentation
+c2433ef3f Merge pull request #3195 from ESMCI/jgfouca/branch-for-acme-split-2019-08-07
+74afc1fc1 Merge pull request #3194 from jedwards4b/pio2_update
+97725f090 Merge pull request #3193 from jedwards4b/fix_output_root
+d1efcdc44 Merge pull request #3190 from gold2718/fix_ne16pg3_mask
+f1a4a59cd Merge pull request #3187 from ESMCI/mvertens/nuopc-cism-changes
+f2744838b Merge pull request #3186 from billsacks/fix_r05_f10_maps
+86f60dfd7 Merge pull request #3183 from ESMCI/jgfouca/fix_test_fails
+b6d24eab7 Merge pull request #3181 from ESMCI/jgfouca/branch-for-acme-split-2019-07-22
+d7f56ac8b Merge pull request #3178 from jedwards4b/nuopc_interface_fix
+
+
+Modified files: git diff --name-status [previous_tag]
+M	config/cesm/config_grids.xml
+M	config/cesm/config_grids_common.xml
+M	config/cesm/config_grids_mct.xml
+M	config/cesm/machines/config_compilers.xml
+M	config/cesm/machines/config_machines.xml
+M	config/e3sm/allactive/config_pesall.xml
+M	config/e3sm/config_grids.xml
+M	config/e3sm/machines/config_compilers.xml
+M	config/e3sm/machines/config_machines.xml
+M	config/e3sm/tests.py
+M	scripts/Tools/Makefile
+M	scripts/Tools/mkDepends
+M	scripts/Tools/preview_run
+M	scripts/climate_reproducibility/README.md
+D	scripts/climate_reproducibility/requirements.txt
+M	scripts/lib/CIME/Servers/ftp.py
+M	scripts/lib/CIME/SystemTests/homme.py
+M	scripts/lib/CIME/SystemTests/mvk.py
+M	scripts/lib/CIME/SystemTests/pgn.py
+M	scripts/lib/CIME/SystemTests/tsc.py
+M	scripts/lib/CIME/XML/compilers.py
+M	scripts/lib/CIME/XML/env_batch.py
+M	scripts/lib/CIME/XML/env_workflow.py
+M	scripts/lib/CIME/build.py
+M	scripts/lib/CIME/case/case.py
+M	scripts/lib/CIME/case/case_run.py
+M	scripts/lib/CIME/case/case_submit.py
+M	scripts/lib/CIME/case/check_input_data.py
+M	scripts/lib/CIME/case/check_lockedfiles.py
+M	scripts/lib/CIME/case/preview_namelists.py
+M	scripts/lib/CIME/get_timing.py
+M	scripts/lib/CIME/hist_utils.py
+M	scripts/lib/CIME/nmlgen.py
+M	scripts/lib/CIME/test_scheduler.py
+M	scripts/lib/jenkins_generic_job.py
+M	scripts/tests/scripts_regression_tests.py
+M	src/components/data_comps/dlnd/nuopc/dlnd_comp_mod.F90
+M	src/drivers/mct/cime_config/config_component.xml
+M	src/drivers/mct/cime_config/config_component_cesm.xml
+M	src/drivers/mct/cime_config/config_component_e3sm.xml
+M	src/drivers/mct/main/cime_comp_mod.F90
+M	src/drivers/mct/main/seq_domain_mct.F90
+M	src/drivers/moab/main/cime_comp_mod.F90
+M	src/externals/pio2/.travis.yml
+M	src/externals/pio2/configure.ac
+A	src/externals/pio2/doc/source/netcdf_integration.txt
+M	src/externals/pio2/doc/source/users_guide.txt
+M	src/externals/pio2/examples/Makefile.am
+M	src/externals/pio2/examples/c/Makefile.am
+M	src/externals/pio2/examples/c/darray_async.c
+M	src/externals/pio2/examples/c/darray_no_async.c
+M	src/externals/pio2/examples/c/example1.c
+M	src/externals/pio2/examples/c/examplePio.c
+A	src/externals/pio2/examples/f03/Makefile.am
+A	src/externals/pio2/examples/f03/run_tests.sh
+M	src/externals/pio2/src/Makefile.am
+M	src/externals/pio2/src/clib/Makefile.am
+M	src/externals/pio2/src/clib/bget.c
+M	src/externals/pio2/src/clib/pio.h
+M	src/externals/pio2/src/clib/pio_darray.c
+M	src/externals/pio2/src/clib/pio_darray_int.c
+A	src/externals/pio2/src/clib/pio_error.h
+M	src/externals/pio2/src/clib/pio_file.c
+M	src/externals/pio2/src/clib/pio_get_nc.c
+M	src/externals/pio2/src/clib/pio_get_vard.c
+M	src/externals/pio2/src/clib/pio_getput_int.c
+M	src/externals/pio2/src/clib/pio_internal.h
+M	src/externals/pio2/src/clib/pio_lists.c
+M	src/externals/pio2/src/clib/pio_msg.c
+M	src/externals/pio2/src/clib/pio_nc.c
+M	src/externals/pio2/src/clib/pio_nc4.c
+M	src/externals/pio2/src/clib/pio_put_nc.c
+M	src/externals/pio2/src/clib/pio_put_vard.c
+M	src/externals/pio2/src/clib/pio_rearrange.c
+M	src/externals/pio2/src/clib/pio_spmd.c
+M	src/externals/pio2/src/clib/pioc.c
+M	src/externals/pio2/src/clib/pioc_sc.c
+M	src/externals/pio2/src/clib/pioc_support.c
+M	src/externals/pio2/src/flib/CMakeLists.txt
+M	src/externals/pio2/src/flib/Makefile.am
+A	src/externals/pio2/src/flib/ncint_mod.F90
+M	src/externals/pio2/src/flib/pio.F90
+M	src/externals/pio2/src/flib/pio_nf.F90
+M	src/externals/pio2/src/flib/pio_support.F90
+M	src/externals/pio2/src/flib/piodarray.F90.in
+M	src/externals/pio2/src/flib/piolib_mod.F90
+M	src/externals/pio2/src/flib/pionfatt_mod.F90.in
+M	src/externals/pio2/src/flib/pionfput_mod.F90.in
+A	src/externals/pio2/src/ncint/Makefile.am
+A	src/externals/pio2/src/ncint/nc_get_vard.c
+A	src/externals/pio2/src/ncint/nc_put_vard.c
+A	src/externals/pio2/src/ncint/ncint_pio.c
+A	src/externals/pio2/src/ncint/ncintdispatch.c
+A	src/externals/pio2/src/ncint/ncintdispatch.h
+M	src/externals/pio2/tests/Makefile.am
+M	src/externals/pio2/tests/cunit/Makefile.am
+M	src/externals/pio2/tests/cunit/pio_tests.h
+M	src/externals/pio2/tests/cunit/test_async_mpi.c
+M	src/externals/pio2/tests/cunit/test_async_multicomp.c
+M	src/externals/pio2/tests/cunit/test_async_perf.c
+M	src/externals/pio2/tests/cunit/test_common.c
+M	src/externals/pio2/tests/cunit/test_darray.c
+M	src/externals/pio2/tests/cunit/test_darray_async.c
+M	src/externals/pio2/tests/cunit/test_darray_async_many.c
+M	src/externals/pio2/tests/cunit/test_darray_async_simple.c
+M	src/externals/pio2/tests/cunit/test_perf2.c
+M	src/externals/pio2/tests/cunit/test_rearr.c
+A	src/externals/pio2/tests/fncint/Makefile.am
+A	src/externals/pio2/tests/fncint/ftst_pio.f90
+A	src/externals/pio2/tests/fncint/ftst_pio_orig.f90
+A	src/externals/pio2/tests/fncint/run_tests.sh
+A	src/externals/pio2/tests/fncint/tst_c_pio.c
+M	src/externals/pio2/tests/general/Makefile.am
+M	src/externals/pio2/tests/general/ncdf_get_put.F90.in
+M	src/externals/pio2/tests/general/ncdf_inq.F90.in
+M	src/externals/pio2/tests/general/pio_decomp_fillval.F90.in
+M	src/externals/pio2/tests/general/pio_decomp_frame_tests.F90.in
+M	src/externals/pio2/tests/general/pio_decomp_tests.F90.in
+M	src/externals/pio2/tests/general/pio_decomp_tests_1d.F90.in
+M	src/externals/pio2/tests/general/pio_decomp_tests_2d.F90.in
+M	src/externals/pio2/tests/general/pio_decomp_tests_3d.F90.in
+M	src/externals/pio2/tests/general/pio_iosystem_tests.F90.in
+M	src/externals/pio2/tests/general/pio_iosystem_tests2.F90.in
+M	src/externals/pio2/tests/general/pio_iosystem_tests3.F90.in
+M	src/externals/pio2/tests/general/pio_rearr.F90.in
+M	src/externals/pio2/tests/general/pio_rearr_opts.F90.in
+M	src/externals/pio2/tests/general/pio_rearr_opts2.F90.in
+M	src/externals/pio2/tests/general/util/pio_tutil.F90
+A	src/externals/pio2/tests/ncint/Makefile.am
+A	src/externals/pio2/tests/ncint/run_tests.sh
+A	src/externals/pio2/tests/ncint/tst_pio_udf.c
+M	src/externals/pio2/tests/performance/Makefile.am
+M	src/externals/pio2/tests/unit/Makefile.am
+M	src/externals/pio2/tests/unit/basic_tests.F90
+M	src/externals/pio2/tests/unit/driver.F90
+M	src/externals/pio2/tests/unit/ncdf_tests.F90
+M	src/share/util/shr_pio_mod.F90
+
+======================================================================
+
+======================================================================
+
+Originator: Chris Fischer 
 Date: 7-19-209
 Tag: cime5.8.7
 Answer Changes: Climate changing for CAM ne120, ne120pg3, ne0CONUS grids

--- a/cime/config/cesm/config_archive.xml
+++ b/cime/config/cesm/config_archive.xml
@@ -1,27 +1,4 @@
 <components version="2.0">
-  <comp_archive_spec compname="clm" compclass="lnd">
-    <rest_file_extension>r</rest_file_extension>
-    <rest_file_extension>rh\d?</rest_file_extension>
-    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
-    <hist_file_extension>e</hist_file_extension>
-    <rest_history_varname>locfnh</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>
-      <rpointer_content>./$CASE.clm2$NINST_STRING.r.$DATENAME.nc</rpointer_content>
-    </rpointer>
-    <test_file_names>
-      <tfile disposition="copy">rpointer.lnd</tfile>
-      <tfile disposition="copy">rpointer.lnd_9999</tfile>
-      <tfile disposition="copy">casename.clm2.r.1976-01-01-00000.nc</tfile>
-      <tfile disposition="copy">casename.clm2.rh4.1976-01-01-00000.nc</tfile>
-      <tfile disposition="move">casename.clm2.h0.1976-01-01-00000.nc</tfile>
-      <tfile disposition="ignore">casename.clm2.h0.1976-01-01-00000.nc.base</tfile>
-      <tfile disposition="move">casename.clm2_0002.e.postassim.1976-01-01-00000.nc</tfile>
-      <tfile disposition="move">casename.clm2_0002.e.preassim.1976-01-01-00000.nc</tfile>
-      <tfile disposition="ignore">anothercasename.clm2.i.1976-01-01-00000.nc</tfile>
-    </test_file_names>
-  </comp_archive_spec>
-
   <comp_archive_spec compname="cice" compclass="ice">
     <rest_file_extension>[ri]</rest_file_extension>
     <hist_file_extension>h\d*.*\.nc$</hist_file_extension>

--- a/cime/config/cesm/config_grids_common.xml
+++ b/cime/config/cesm/config_grids_common.xml
@@ -214,8 +214,8 @@
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx0.66v1_e1000r300_190314.nc</map>
     </gridmap>
     <gridmap rof_grid="JRA025" ocn_grid="tx0.66v1" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190326.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190326.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190910.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190910.nc</map>
     </gridmap>
 
     <!-- ======================================================== -->

--- a/cime/config/cesm/machines/Depends.nag
+++ b/cime/config/cesm/machines/Depends.nag
@@ -1,4 +1,4 @@
 wrap_mpi.o: wrap_mpi.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FFLAGS_NOOPT) $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -mismatch_all $(FFLAGS_NOOPT) $(FREEFLAGS) $<
 fft99.o: fft99.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FFLAGS_NOOPT) $(FREEFLAGS) $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) -mismatch_all $(FFLAGS_NOOPT) $(FREEFLAGS) $<

--- a/cime/config/cesm/machines/config_machines.xml
+++ b/cime/config/cesm/machines/config_machines.xml
@@ -446,37 +446,37 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules mpilib="mpt" compiler="gnu">
 	<command name="load">mpt/2.16</command>
-	<command name="load">netcdf-mpi/4.6.1</command>
+	<command name="load">netcdf-mpi/4.7.1</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
 	<command name="load">mpt/2.19</command>
-	<command name="load">netcdf-mpi/4.6.1</command>
+	<command name="load">netcdf-mpi/4.7.1</command>
 	<command name="load">pnetcdf/1.11.0</command>
       </modules>
       <modules mpilib="mpt" compiler="pgi">
 	<command name="load">mpt/2.19</command>
-	<command name="load">netcdf-mpi/4.6.3</command>
+	<command name="load">netcdf-mpi/4.7.1</command>
 	<command name="load">pnetcdf/1.11.1</command>
       </modules>
       <modules mpilib="openmpi" compiler="pgi">
 	<command name="load">openmpi/3.1.4</command>
-	<command name="load">netcdf/4.6.3</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules mpilib="openmpi" compiler="gnu">
         <command name="load">openmpi/3.0.1</command>
-        <command name="load">netcdf/4.6.1</command>
+        <command name="load">netcdf/4.7.1</command>
       </modules>
       <modules>
 	<command name="load">ncarcompilers/0.5.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial">
-	<command name="load">netcdf/4.6.1</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
-	<command name="load">netcdf/4.6.1</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules compiler="pgi" mpilib="mpi-serial">
-	<command name="load">netcdf/4.6.3</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -486,11 +486,17 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_IB_CONGESTED">1</env>
       <env name="MPI_USE_ARRAY"/>
     </environment_variables>
+    <environment_variables comp_interface="nuopc" mpilib="mpi-serial" DEBUG="FALSE">
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
+    </environment_variables>
+    <environment_variables comp_interface="nuopc" mpilib="mpi-serial" DEBUG="TRUE">
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
+    </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="FALSE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="TRUE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>
@@ -1516,6 +1522,8 @@ This allows using a different mpirun command to launch unit tests
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
+      <!-- The following is needed in order to run qsub from the compute nodes -->
+      <env name="PATH">$ENV{PATH}:/cluster/torque/bin</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>

--- a/cime/scripts/Tools/archive_metadata
+++ b/cime/scripts/Tools/archive_metadata
@@ -30,7 +30,7 @@ from six.moves      import configparser, urllib
 # define global constants
 logger = logging.getLogger(__name__)
 _svn_expdb_url = 'https://svn-cesm2-expdb.cgd.ucar.edu'
-_exp_types = ['CMIP6', 'production', 'tuning']
+_exp_types = ['CMIP6', 'production', 'tuning','lens']
 _xml_vars = ['CASE', 'COMPILER', 'COMPSET', 'CONTINUE_RUN', 'DOUT_S', 'DOUT_S_ROOT',
              'GRID', 'MACH', 'MPILIB', 'MODEL', 'MODEL_VERSION', 'REST_N', 'REST_OPTION',
              'RUNDIR', 'RUN_REFCASE', 'RUN_REFDATE', 'RUN_STARTDATE', 'RUN_TYPE',
@@ -546,8 +546,9 @@ def get_case_status(case_dict):
     cstatus = case_dict['CASEROOT']+'/CaseStatus'
     if os.path.exists(cstatus):
         # get the run status
-        run_status = is_last_process_complete(cstatus, "case.run success", "case.run starting")
-        if run_status is True:
+        run_status_1 = is_last_process_complete(cstatus, "case.run success", "case.run starting")
+        run_status_2 = is_last_process_complete(cstatus, "model execution success", "model execution starting")
+        if run_status_1 is True or run_status_2 is True:
             case_dict['run_status'] = 'Succeeded'
         case_dict['run_size'] = get_disk_usage(case_dict['run_path'])
         case_dict['run_last_date'] = get_run_last_date(case_dict['CASE'], case_dict['run_path'])

--- a/cime/scripts/Tools/preview_run
+++ b/cime/scripts/Tools/preview_run
@@ -59,9 +59,8 @@ def _main_func(description):
         print("")
 
         print("BATCH INFO:")
-        if job is None:
-            job = case.get_primary_job()
-
+        if not job:
+            job = case.get_first_job()
         set_logger_indent("      ")
         job_id_to_cmd = case.submit_jobs(dry_run=True, job=job)
         env_batch = case.get_env('batch')
@@ -76,13 +75,14 @@ def _main_func(description):
             print("    SUBMIT CMD:")
             print("      {}".format(case.get_resolved_value(cmd)))
             print("")
+            if job_id in ("case.run", "case.test"):
+                # get_job_overrides must come after the case.load_env since the cmd may use
+                # env vars.
+                overrides = env_batch.get_job_overrides(job_id, case)
+                print("    MPIRUN (job={}):".format(job_id))
+                print ("      {}".format(case.get_resolved_value(overrides["mpirun"])))
+                print("")
 
-            # get_job_overrides must come after the case.load_env since the cmd may use
-            # env vars.
-            overrides = env_batch.get_job_overrides(job_id, case)
-            print("    MPIRUN (job={}):".format(job_id))
-            print ("      {}".format(case.get_resolved_value(overrides["mpirun"])))
-            print("")
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/cime/scripts/lib/CIME/XML/env_batch.py
+++ b/cime/scripts/lib/CIME/XML/env_batch.py
@@ -434,6 +434,7 @@ class EnvBatch(EnvBase):
         alljobs = env_workflow.get_jobs()
         alljobs = [j for j in alljobs
                    if os.path.isfile(os.path.join(self._caseroot,get_batch_script_for_job(j)))]
+
         startindex = 0
         jobs = []
         firstjob = job
@@ -458,6 +459,7 @@ class EnvBatch(EnvBase):
 
             if self._batchtype == "cobalt":
                 break
+
         depid = OrderedDict()
         jobcmds = []
 

--- a/cime/scripts/lib/CIME/XML/machines.py
+++ b/cime/scripts/lib/CIME/XML/machines.py
@@ -246,7 +246,7 @@ class Machines(GenericXML):
         """
         Check the compiler is valid for the current machine
 
-        >>> machobj = Machines(machine="edison")
+        >>> machobj = Machines(machine="cori-knl")
         >>> machobj.get_default_compiler()
         'intel'
         >>> machobj.is_valid_compiler("gnu")
@@ -260,7 +260,7 @@ class Machines(GenericXML):
         """
         Check the MPILIB is valid for the current machine
 
-        >>> machobj = Machines(machine="edison")
+        >>> machobj = Machines(machine="cori-knl")
         >>> machobj.is_valid_MPIlib("mpi-serial")
         True
         >>> machobj.is_valid_MPIlib("fake-mpi")
@@ -273,7 +273,7 @@ class Machines(GenericXML):
         """
         Return if this machine has a batch system
 
-        >>> machobj = Machines(machine="edison")
+        >>> machobj = Machines(machine="cori-knl")
         >>> machobj.has_batch_system()
         True
         >>> machobj.set_machine("melvin")

--- a/cime/scripts/lib/CIME/XML/stream.py
+++ b/cime/scripts/lib/CIME/XML/stream.py
@@ -1,0 +1,49 @@
+"""
+Interface to the streams.xml style files.  This class inherits from GenericXML.py
+
+stream files predate cime and so do not conform to entry id format
+"""
+from CIME.XML.standard_module_setup import *
+from CIME.XML.generic_xml import GenericXML
+from CIME.XML.files import Files
+from CIME.utils import expect
+
+logger = logging.getLogger(__name__)
+
+class Stream(GenericXML):
+
+    def __init__(self, infile=None, files=None):
+        """
+        initialize an object
+        """
+        if files is None:
+            files = Files()
+        schema = None
+        GenericXML.__init__(self, infile, schema=schema)
+
+    def get_value(self, item, attribute=None, resolved=True, subgroup=None):
+        """
+        Get Value of fields in a stream.xml file
+        """
+        expect(subgroup is None, "This class does not support subgroups")
+        value = None
+        node = None
+        names = item.split('/')
+        node = None
+        for name in names:
+            node = self.scan_child(name, root=node)
+        if node is not None:
+            value = self.text(node).strip()
+
+        if value is None:
+            # if all else fails
+            #pylint: disable=assignment-from-none
+            value = GenericXML.get_value(self, item, attribute, resolved, subgroup)
+
+        if resolved:
+            if value is not None:
+                value = self.get_resolved_value(value)
+            elif item in os.environ:
+                value = os.environ[item]
+
+        return value

--- a/cime/scripts/lib/CIME/case/case.py
+++ b/cime/scripts/lib/CIME/case/case.py
@@ -1639,3 +1639,8 @@ directory, NOT in this subdirectory."""
 
     def get_primary_job(self):
         return "case.test" if self.get_value("TEST") else "case.run"
+
+    def get_first_job(self):
+        env_workflow = self.get_env("workflow")
+        jobs = env_workflow.get_jobs()
+        return jobs[0]

--- a/cime/scripts/lib/CIME/case/case_setup.py
+++ b/cime/scripts/lib/CIME/case/case_setup.py
@@ -78,7 +78,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         din_loc_root = case.get_value("DIN_LOC_ROOT")
         testcase     = case.get_value("TESTCASE")
         expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
-               "inputdata root is not a directory: {}".format(din_loc_root))
+               "inputdata root is not a directory or is not readable: {}".format(din_loc_root))
 
     # Remove batch scripts
     if reset or clean:

--- a/cime/scripts/lib/CIME/case/case_submit.py
+++ b/cime/scripts/lib/CIME/case/case_submit.py
@@ -27,7 +27,7 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
             resubmit_immediate=False, skip_pnl=False, mail_user=None, mail_type=None,
             batch_args=None):
     if job is None:
-        job = case.get_primary_job()
+        job = case.get_first_job()
 
     # Check if CONTINUE_RUN value makes sense
     if job != "case.test" and case.get_value("CONTINUE_RUN"):

--- a/cime/scripts/lib/CIME/nmlgen.py
+++ b/cime/scripts/lib/CIME/nmlgen.py
@@ -15,7 +15,8 @@ from CIME.namelist import Namelist, parse, \
     character_literal_to_string, string_to_character_literal, \
     expand_literal_list, compress_literal_list, merge_literal_lists
 from CIME.XML.namelist_definition import NamelistDefinition
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
+from CIME.XML.stream import Stream
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,8 @@ _var_ref_re = re.compile(r"\$(\{)?(?P<name>\w+)(?(1)\})")
 
 _ymd_re = re.compile(r"%(?P<digits>[1-9][0-9]*)?y(?P<month>m(?P<day>d)?)?")
 
-_stream_file_template = """
+_stream_file_template = """<?xml version="1.0"?>
+<file id="stream" version="1.0">
 <dataSource>
    GENERIC
 </dataSource>
@@ -52,6 +54,7 @@ _stream_file_template = """
       {offset}
    </offset>
 </fieldInfo>
+</file>
 """
 
 class NamelistGenerator(object):
@@ -413,7 +416,7 @@ class NamelistGenerator(object):
                     new_lines.append(new_line)
         return "\n".join(new_lines)
 
-    def create_stream_file_and_update_shr_strdata_nml(self, config, #pylint:disable=too-many-locals
+    def create_stream_file_and_update_shr_strdata_nml(self, config, caseroot, #pylint:disable=too-many-locals
                            stream, stream_path, data_list_path):
         """Write the pseudo-XML file corresponding to a given stream.
 
@@ -427,48 +430,62 @@ class NamelistGenerator(object):
         `data_list_path` - Path of file to append input data information to.
         """
 
-        # Stream-specific configuration.
+        if os.path.exists(stream_path):
+            os.unlink(stream_path)
+        user_stream_path = os.path.join(caseroot, "user_"+os.path.basename(stream_path))
+
+        # Use the user's stream file, or create one if necessary.
         config = config.copy()
         config["stream"] = stream
 
-        # Figure out the details of this stream.
-        if stream in ("prescribed", "copyall"):
-            # Assume only one file for prescribed mode!
-            grid_file = self.get_default("strm_grid_file", config)
-            domain_filepath, domain_filenames = os.path.split(grid_file)
-            data_file = self.get_default("strm_data_file", config)
-            data_filepath, data_filenames = os.path.split(data_file)
+
+        # Stream-specific configuration.
+        if os.path.exists(user_stream_path):
+            safe_copy(user_stream_path, stream_path)
+            strmobj = Stream(infile=stream_path)
+            domain_filepath = strmobj.get_value("domainInfo/filePath")
+            data_filepath = strmobj.get_value("fieldInfo/filePath")
+            domain_filenames = strmobj.get_value("domainInfo/fileNames")
+            data_filenames = strmobj.get_value("fieldInfo/fileNames")
         else:
-            domain_filepath = self.get_default("strm_domdir", config)
-            domain_filenames = self.get_default("strm_domfil", config)
-            data_filepath = self.get_default("strm_datdir", config)
-            data_filenames = self.get_default("strm_datfil", config)
+            # Figure out the details of this stream.
+            if stream in ("prescribed", "copyall"):
+                # Assume only one file for prescribed mode!
+                grid_file = self.get_default("strm_grid_file", config)
+                domain_filepath, domain_filenames = os.path.split(grid_file)
+                data_file = self.get_default("strm_data_file", config)
+                data_filepath, data_filenames = os.path.split(data_file)
+            else:
+                domain_filepath = self.get_default("strm_domdir", config)
+                domain_filenames = self.get_default("strm_domfil", config)
+                data_filepath = self.get_default("strm_datdir", config)
+                data_filenames = self.get_default("strm_datfil", config)
 
-        domain_varnames = self._sub_fields(self.get_default("strm_domvar", config))
-        data_varnames = self._sub_fields(self.get_default("strm_datvar", config))
-        offset = self.get_default("strm_offset", config)
-        year_start = int(self.get_default("strm_year_start", config))
-        year_end = int(self.get_default("strm_year_end", config))
-        data_filenames = self._sub_paths(data_filenames, year_start, year_end)
-        domain_filenames = self._sub_paths(domain_filenames, year_start, year_end)
+            domain_varnames = self._sub_fields(self.get_default("strm_domvar", config))
+            data_varnames = self._sub_fields(self.get_default("strm_datvar", config))
+            offset = self.get_default("strm_offset", config)
+            year_start = int(self.get_default("strm_year_start", config))
+            year_end = int(self.get_default("strm_year_end", config))
+            data_filenames = self._sub_paths(data_filenames, year_start, year_end)
+            domain_filenames = self._sub_paths(domain_filenames, year_start, year_end)
 
-        # Overwrite domain_file if should be set from stream data
-        if domain_filenames == 'null':
-            domain_filepath = data_filepath
-            domain_filenames = data_filenames.splitlines()[0]
+            # Overwrite domain_file if should be set from stream data
+            if domain_filenames == 'null':
+                domain_filepath = data_filepath
+                domain_filenames = data_filenames.splitlines()[0]
 
-        stream_file_text = _stream_file_template.format(
-            domain_varnames=domain_varnames,
-            domain_filepath=domain_filepath,
-            domain_filenames=domain_filenames,
-            data_varnames=data_varnames,
-            data_filepath=data_filepath,
-            data_filenames=data_filenames,
-            offset=offset,
-        )
+            stream_file_text = _stream_file_template.format(
+                domain_varnames=domain_varnames,
+                domain_filepath=domain_filepath,
+                domain_filenames=domain_filenames,
+                data_varnames=data_varnames,
+                data_filepath=data_filepath,
+                data_filenames=data_filenames,
+                offset=offset,
+            )
 
-        with open(stream_path, 'w') as stream_file:
-            stream_file.write(stream_file_text)
+            with open(stream_path, 'w') as stream_file:
+                stream_file.write(stream_file_text)
 
         lines_hash = self._get_input_file_hash(data_list_path)
         with open(data_list_path, 'a') as input_data_list:

--- a/cime/scripts/lib/CIME/utils.py
+++ b/cime/scripts/lib/CIME/utils.py
@@ -1024,8 +1024,7 @@ def find_files(rootdir, pattern):
 
 
 def setup_standard_logging_options(parser):
-    helpfile = "{}.log".format(sys.argv[0])
-    helpfile = os.path.join(os.getcwd(),os.path.basename(helpfile))
+    helpfile = os.path.join(os.getcwd(),os.path.basename("{}.log".format(sys.argv[0])))
     parser.add_argument("-d", "--debug", action="store_true",
                         help="Print debug information (very verbose) to file {}".format(helpfile))
     parser.add_argument("-v", "--verbose", action="store_true",

--- a/cime/scripts/tests/scripts_regression_tests.py
+++ b/cime/scripts/tests/scripts_regression_tests.py
@@ -7,7 +7,7 @@ to confirm overall CIME correctness.
 
 import glob, os, re, shutil, signal, sys, tempfile, \
     threading, time, logging, unittest, getpass, \
-    filecmp, time
+    filecmp, time, atexit
 
 from xml.etree.ElementTree import ParseError
 
@@ -427,6 +427,7 @@ class J_TestCreateNewcase(unittest.TestCase):
         cmd = "%s/create_clone --clone %s --case %s --keepexe --user-mods-dir %s" \
               % (SCRIPT_DIR, prevtestdir, testdir, user_mods_dir)
         run_cmd_assert_result(self, cmd, from_dir=SCRIPT_DIR, expected_stat=1)
+        cls._do_teardown.append(testdir)
 
     def test_d_create_clone_new_user(self):
         cls = self.__class__
@@ -469,6 +470,7 @@ class J_TestCreateNewcase(unittest.TestCase):
             case2 = case1.create_clone(testdir)
             with self.assertRaises(CIMEError):
                 case2.set_value("CHARGE_ACCOUNT", "fouc")
+        cls._do_teardown.append(testdir)
 
     def test_e_xmlquery(self):
         # Set script and script path
@@ -779,7 +781,6 @@ class J_TestCreateNewcase(unittest.TestCase):
         else:
             args += " --res f19_g16 "
 
-        cls._testdirs.append(testdir)
         run_cmd_assert_result(self, "./create_newcase %s"%(args),
                               from_dir=SCRIPT_DIR, expected_stat=1)
         self.assertFalse(os.path.exists(testdir))
@@ -787,17 +788,22 @@ class J_TestCreateNewcase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         do_teardown = len(cls._do_teardown) > 0 and sys.exc_info() == (None, None, None) and not NO_TEARDOWN
-
+        rmtestroot = True
         for tfile in cls._testdirs:
             if tfile not in cls._do_teardown:
                 print("Detected failed test or user request no teardown")
                 print("Leaving case directory : %s"%tfile)
+                rmtestroot = False
             elif do_teardown:
                 try:
                     print ("Attempt to remove directory {}".format(tfile))
                     shutil.rmtree(tfile)
                 except BaseException:
                     print("Could not remove directory {}".format(tfile))
+        if rmtestroot:
+            shutil.rmtree(cls._testroot)
+
+
 
 ###############################################################################
 class M_TestWaitForTests(unittest.TestCase):
@@ -1100,7 +1106,7 @@ class TestCreateTestCommon(unittest.TestCase):
                 files_to_clean.append(leftover)
 
         do_teardown = self._do_teardown and sys.exc_info() == (None, None, None)
-        if (not do_teardown):
+        if (not do_teardown and files_to_clean):
             print("Detected failed test or user request no teardown")
             print("Leaving files:")
             for file_to_clean in files_to_clean:
@@ -2284,6 +2290,8 @@ class K_TestCimeCase(TestCreateTestCommon):
         except ImportError:
             print("imp not found, skipping case.submit interface test")
             return
+        # the current directory may not exist, so make sure we are in a real directory
+        os.chdir(os.getenv("HOME"))
         sys.path.append(TOOLS_DIR)
         case_submit_path = os.path.join(TOOLS_DIR, "case.submit")
         submit_interface = imp.load_source("case_submit_interface", case_submit_path)
@@ -3267,6 +3275,12 @@ def write_provenance_info():
     logging.info("Test root: %s" % TEST_ROOT)
     logging.info("Test driver: %s\n" % CIME.utils.get_cime_default_driver())
 
+def cleanup():
+    # if the TEST_ROOT directory exists and is empty, remove it
+    if os.path.exists(TEST_ROOT) and not os.listdir(TEST_ROOT):
+        print("All pass, removing directory:", TEST_ROOT)
+        os.rmdir(TEST_ROOT)
+
 def _main_func(description):
     global MACHINE
     global NO_CMAKE
@@ -3386,6 +3400,7 @@ OR
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, None)
 
     write_provenance_info()
+    atexit.register(cleanup)
 
     # Find all python files in repo and create a pylint test for each
     if check_for_pylint():
@@ -3402,12 +3417,8 @@ OR
     except CIMEError as e:
         if e.__str__() != "False":
             print("Detected failures, leaving directory:", TEST_ROOT)
-        else:
-            print("All pass, removing directory:", TEST_ROOT)
-            if os.path.exists(TEST_ROOT) and not NO_TEARDOWN:
-                shutil.rmtree(TEST_ROOT)
+            raise
 
-        raise
 
 if (__name__ == "__main__"):
     _main_func(__doc__)

--- a/cime/src/build_scripts/buildlib.pio
+++ b/cime/src/build_scripts/buildlib.pio
@@ -48,6 +48,7 @@ def buildlib(bldroot, installpath, case):
     cime_model = case.get_value("MODEL")
     caseroot = case.get_value("CASEROOT")
     pio_version = case.get_value("PIO_VERSION")
+    scorpio_src_root_dir = None
     if cime_model == "e3sm":
         srcroot = case.get_value("SRCROOT")
         scorpio_src_root_dir = os.path.join(srcroot, "externals")

--- a/cime/src/components/data_comps/datm/cime_config/buildnml
+++ b/cime/src/components/data_comps/datm/cime_config/buildnml
@@ -120,15 +120,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DATM stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "datm.streams.txt." + inst_stream)
-        user_stream_path = os.path.join(case.get_case_root(), "user_datm.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"),stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/cime/src/components/data_comps/dice/cime_config/buildnml
+++ b/cime/src/components/data_comps/dice/cime_config/buildnml
@@ -89,16 +89,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DICE stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "dice.streams.txt." + inst_stream)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_dice.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"),stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/cime/src/components/data_comps/dlnd/cime_config/buildnml
+++ b/cime/src/components/data_comps/dlnd/cime_config/buildnml
@@ -86,16 +86,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DLND stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "dlnd.streams.txt." + inst_stream)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_dlnd.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"), stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/cime/src/components/data_comps/docn/cime_config/buildnml
+++ b/cime/src/components/data_comps/docn/cime_config/buildnml
@@ -89,16 +89,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DOCN stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "docn.streams.txt." + inst_stream)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_docn.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"), stream, stream_path, data_list_path)
 
     # For aquaplanet prescribed have no streams
     match = re.match(r'^sst_aquap\d+',docn_mode)

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -13,7 +13,7 @@
        This file may have ocn desc entries.
   -->
   <description modifier_mode="1">
-    <desc ocn="DOCN[%NULL][%DOM][%SOM][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQPFILE]">DOCN </desc>
+    <desc ocn="DOCN[%NULL][%DOM][%SOM][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQP11][%AQPFILE]">DOCN </desc>
     <desc option="NULL">  null mode</desc>
     <desc option="DOM">  prescribed ocean mode</desc>
     <desc option="SOM">  slab ocean mode</desc>
@@ -30,6 +30,7 @@
     <desc option="AQP8">  analytic aquaplanet sst - option 8</desc>
     <desc option="AQP9">  analytic aquaplanet sst - option 9</desc>
     <desc option="AQP10">  analytic aquaplanet sst - option 10</desc>
+    <desc option="AQP11">  CONSTANT, UNIFORM aquaplanet sst - option 11</desc>
     <desc option="AQPFILE">  file input aquaplanet sst </desc>
   </description>
 
@@ -44,7 +45,7 @@
 
   <entry id="DOCN_MODE">
     <type>char</type>
-    <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,sst_aquapfile,som,som_aquap,interannual,null</valid_values>
+    <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,sst_aquap11,sst_aquapfile,som,som_aquap,interannual,null</valid_values>
     <default_value>prescribed</default_value>
     <values match="last">
       <value compset="_DOCN%NULL_">null</value>
@@ -62,6 +63,7 @@
       <value compset="_DOCN%AQP8_">sst_aquap8</value>
       <value compset="_DOCN%AQP9_">sst_aquap9</value>
       <value compset="_DOCN%AQP10_">sst_aquap10</value>
+      <value compset="_DOCN%AQP11_">sst_aquap11</value>
       <value compset="_DOCN%AQPFILE_">sst_aquapfile</value>
     </values>
     <group>run_component_docn</group>

--- a/cime/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/cime/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -56,6 +56,7 @@
       <value docn_mode="sst_aquap8">''</value>
       <value docn_mode="sst_aquap9">''</value>
       <value docn_mode="sst_aquap10">''</value>
+      <value docn_mode="sst_aquap11">''</value>
       <value docn_mode="sst_aquapfile">aquapfile</value>
       <value docn_mode="som">som</value>
       <value docn_mode="som_aquap">som</value>
@@ -256,7 +257,7 @@
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>SSTDATA,SST_AQUAP1,SST_AQUAP2,SST_AQUAP3,SST_AQUAP4,SST_AQUAP5,SST_AQUAP6,SST_AQUAP7,SST_AQUAP8,SST_AQUAP9,SST_AQUAP10,SST_AQUAPFILE,SOM,SOM_AQUAP,IAF,NULL,COPYALL</valid_values>
+    <valid_values>SSTDATA,SST_AQUAP1,SST_AQUAP2,SST_AQUAP3,SST_AQUAP4,SST_AQUAP5,SST_AQUAP6,SST_AQUAP7,SST_AQUAP8,SST_AQUAP9,SST_AQUAP10,SST_AQUAP11,SST_AQUAPFILE,SOM,SOM_AQUAP,IAF,NULL,COPYALL</valid_values>
     <desc>
       General method that operates on the data. This is generally
       implemented in the data models but is set in the strdata method for
@@ -322,6 +323,7 @@
       <value docn_mode="sst_aquap8$">SST_AQUAP8</value>
       <value docn_mode="sst_aquap9$">SST_AQUAP9</value>
       <value docn_mode="sst_aquap10$">SST_AQUAP10</value>
+      <value docn_mode="sst_aquap11$">SST_AQUAP11</value>
       <value docn_mode="sst_aquapfile$">SST_AQUAPFILE</value>
       <value docn_mode="som$">SOM</value>
       <value docn_mode="som_aquap">SOM_AQUAP</value>
@@ -639,6 +641,18 @@
     <desc>If TRUE, prognostic is forced to true. (default=false)</desc>
     <values>
       <value>.false.</value>
+    </values>
+  </entry>
+
+  <entry id="fixed_sst">
+    <type>real</type>
+    <category>docn</category>
+    <group>docn_nml</group>
+    <desc>
+      Sea Surface Temperature for RCE runs
+    </desc>
+    <values>
+      <value>26.85</value>
     </values>
   </entry>
 

--- a/cime/src/components/data_comps/docn/mct/docn_comp_mod.F90
+++ b/cime/src/components/data_comps/docn/mct/docn_comp_mod.F90
@@ -28,6 +28,7 @@ module docn_comp_mod
   use docn_shr_mod   , only: decomp         ! namelist input
   use docn_shr_mod   , only: rest_file      ! namelist input
   use docn_shr_mod   , only: rest_file_strm ! namelist input
+  use docn_shr_mod   , only: fixed_sst      ! namelist input
   use docn_shr_mod   , only: nullstr
 
   ! !PUBLIC TYPES:
@@ -749,7 +750,6 @@ CONTAINS
     real(r8), parameter ::   latrad6    = 15._r8*pio180
     real(r8), parameter ::   latrad8    = 30._r8*pio180
     real(r8), parameter ::   lonrad     = 30._r8*pio180
-    !-------------------------------------------------------------------------------
 
     pi = SHR_CONST_PI
 
@@ -760,7 +760,7 @@ CONTAINS
 
     ! Control
 
-    if (sst_option < 1 .or. sst_option > 10) then
+    if (sst_option < 1 .or. sst_option > 11) then
        call shr_sys_abort ('prescribed_sst: ERROR: sst_option must be between 1 and 10')
     end if
 
@@ -919,6 +919,11 @@ CONTAINS
              sst(i) = tmp*(t0_max - t0_min) + t0_min
           end if
        end do
+    end if
+
+    ! RCE 
+    if (sst_option == 11) then
+       sst = fixed_sst
     end if
 
   end subroutine prescribed_sst

--- a/cime/src/components/data_comps/docn/mct/docn_shr_mod.F90
+++ b/cime/src/components/data_comps/docn/mct/docn_shr_mod.F90
@@ -28,6 +28,7 @@ module docn_shr_mod
   character(CL) , public :: restfilm              ! model restart file namelist
   character(CL) , public :: restfils              ! stream restart file namelist
   logical       , public :: force_prognostic_true ! if true set prognostic true
+  real(r8)      , public :: fixed_sst             ! fixed SST
 
   ! variables obtained from namelist read
   character(CL) , public :: rest_file             ! restart filename
@@ -76,7 +77,7 @@ CONTAINS
 
     !----- define namelist -----
     namelist / docn_nml / &
-         decomp, restfilm, restfils, force_prognostic_true
+         decomp, restfilm, restfils, force_prognostic_true, fixed_sst
 
     !----------------------------------------------------------------------------
     ! Determine input filenamname
@@ -93,6 +94,8 @@ CONTAINS
     restfilm   = trim(nullstr)
     restfils   = trim(nullstr)
     force_prognostic_true = .false.
+    fixed_sst    = 26.85_r8   ! degrees C 300 - 273.15 = 26.85
+
     if (my_task == master_task) then
        nunit = shr_file_getUnit() ! get unused unit number
        open (nunit,file=trim(filename),status="old",action="read")
@@ -107,11 +110,13 @@ CONTAINS
        write(logunit,F00)' restfilm   = ',trim(restfilm)
        write(logunit,F00)' restfils   = ',trim(restfils)
        write(logunit,F0L)' force_prognostic_true = ',force_prognostic_true
+       write(logunit,F02)' fixed_sst = ',fixed_sst
     endif
     call shr_mpi_bcast(decomp  ,mpicom,'decomp')
     call shr_mpi_bcast(restfilm,mpicom,'restfilm')
     call shr_mpi_bcast(restfils,mpicom,'restfils')
     call shr_mpi_bcast(force_prognostic_true,mpicom,'force_prognostic_true')
+    call shr_mpi_bcast(fixed_sst,mpicom,'fixed_sst')
 
     rest_file = trim(restfilm)
     rest_file_strm = trim(restfils)

--- a/cime/src/components/data_comps/drof/cime_config/buildnml
+++ b/cime/src/components/data_comps/drof/cime_config/buildnml
@@ -87,16 +87,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DROF stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "drof.streams.txt." + inst_stream)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_drof.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"), stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/cime/src/components/data_comps/dwav/cime_config/buildnml
+++ b/cime/src/components/data_comps/dwav/cime_config/buildnml
@@ -86,16 +86,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DWAV stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "dwav.streams.txt." + inst_stream)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_dwav.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"), stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create dwav_nml namelists group

--- a/cime/src/drivers/mct/cime_config/buildnml
+++ b/cime/src/drivers/mct/cime_config/buildnml
@@ -53,6 +53,12 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['atm_grid'] = case.get_value('ATM_GRID')
     config['compocn'] = case.get_value('COMP_OCN')
 
+    docn_mode = case.get_value("DOCN_MODE")
+    if docn_mode and 'aqua' in docn_mode:
+        config['aqua_planet_sst_type'] = docn_mode
+    else:
+        config['aqua_planet_sst_type'] = 'none'
+        
     if case.get_value('RUN_TYPE') == 'startup':
         config['run_type'] = 'startup'
     elif case.get_value('RUN_TYPE') == 'hybrid':

--- a/cime/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -394,6 +394,7 @@
       <value compset="DATM.+MOM\d">TRUE</value>
       <value compset="DATM.+DOCN%IAF">TRUE</value>
       <value compset="DATM%CPLHIST.+POP\d">FALSE</value>
+      <value compset="DOCN%AQP11">TRUE</value>
       <value compset="DATM%CPLHIST.+MOM\d">FALSE</value>
     </values>
     <group>run_component_cpl</group>

--- a/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -4724,4 +4724,29 @@
     </values>
   </entry>
 
+  <entry id="seq_flux_mct_albdif">
+    <type>real</type>
+    <category>seq_flux_mct</category>
+    <group>seq_flux_mct_inparm</group>
+    <desc>
+       Surface albedo for direct radiation
+    </desc>
+    <values>
+      <value>0.06</value>
+      <value aqua_planet_sst_type="sst_aquap11">0.07</value>
+    </values>
+  </entry>
+
+  <entry id="seq_flux_mct_albdir">
+    <type>real</type>
+    <category>seq_flux_mct</category>
+    <group>seq_flux_mct_inparm</group>
+    <desc>
+       Surface albedo for diffuse radiation
+    </desc>
+    <values>
+      <value>0.07</value>
+    </values>
+  </entry>
+
 </entry_id>

--- a/cime/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/cime/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -70,22 +70,22 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cime_baselines">
 	<options>
-	  <option name="wallclock">00:10</option>
+	  <option name="wallclock">00:10:00</option>
 	</options>
       </machine>
       <machine name="cheyenne" compiler="intel" category="jim">
 	<options>
-	  <option name="wallclock">00:10</option>
+	  <option name="wallclock">00:10:00</option>
 	</options>
       </machine>
       <machine name="cheyenne" compiler="gnu" category="jim">
 	<options>
-	  <option name="wallclock">00:10</option>
+	  <option name="wallclock">00:10:00</option>
 	</options>
       </machine>
       <machine name="cheyenne" compiler="pgi" category="jim">
 	<options>
-	  <option name="wallclock">00:10</option>
+	  <option name="wallclock">00:10:00</option>
 	</options>
       </machine>
     </machines>

--- a/cime/src/drivers/mct/main/cime_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cime_comp_mod.F90
@@ -128,7 +128,7 @@ module cime_comp_mod
 
   ! flux calc routines
   use seq_flux_mct, only: seq_flux_init_mct, seq_flux_initexch_mct, seq_flux_ocnalb_mct
-  use seq_flux_mct, only: seq_flux_atmocn_mct, seq_flux_atmocnexch_mct
+  use seq_flux_mct, only: seq_flux_atmocn_mct, seq_flux_atmocnexch_mct, seq_flux_readnl_mct
 
   ! domain fraction routines
   use seq_frac_mct, only : seq_frac_init, seq_frac_set
@@ -1004,6 +1004,11 @@ contains
     else
        call seq_infodata_init(infodata,nlfilename, GLOID, pioid)
     end if
+
+    !----------------------------------------------------------
+    ! Read shr_flux  namelist settings
+    !----------------------------------------------------------
+    call seq_flux_readnl_mct(nlfilename, CPLID)
 
     !----------------------------------------------------------
     ! Print Model heading and copyright message

--- a/cime/src/drivers/mct/main/seq_flux_mct.F90
+++ b/cime/src/drivers/mct/main/seq_flux_mct.F90
@@ -22,6 +22,7 @@ module seq_flux_mct
   !--------------------------------------------------------------------------
 
   public seq_flux_init_mct
+  public seq_flux_readnl_mct
   public seq_flux_initexch_mct
 
   public seq_flux_ocnalb_mct
@@ -106,6 +107,10 @@ module seq_flux_mct
 
   real(r8),parameter :: const_pi      = SHR_CONST_PI       ! pi
   real(r8),parameter :: const_deg2rad = const_pi/180.0_r8  ! deg to rads
+
+  ! albedo reference variables - set via namelist
+  real(r8)  :: seq_flux_mct_albdif  ! albedo, diffuse
+  real(r8)  :: seq_flux_mct_albdir  ! albedo, direct
 
   ! Coupler field indices
 
@@ -454,6 +459,62 @@ contains
 
   !===============================================================================
 
+  subroutine seq_flux_readnl_mct (nmlfile, ID)
+
+    use shr_file_mod,   only : shr_file_getUnit, shr_file_freeUnit
+    use shr_mpi_mod,    only : shr_mpi_bcast
+    use seq_infodata_mod, only : seq_infodata_type, seq_infodata_getdata
+    use shr_nl_mod, only: shr_nl_find_group_name
+
+    !INPUT/OUTPUT PARAMETERS
+    character(len=*), intent(in) :: nmlfile   ! Name-list filename
+    integer                , intent(in) :: ID
+
+    !LOCAL VARIABLES
+    integer :: mpicom             ! MPI communicator
+    integer :: ierr               ! I/O error code
+    integer :: unitn              ! Namelist unit number to read
+
+    character(len=256) :: cime_model
+
+    namelist /seq_flux_mct_inparm/ seq_flux_mct_albdif, seq_flux_mct_albdir
+
+    character(len=*),parameter :: subname = '(seq_flux_readnl_mct) '
+
+    !-------------------------------------------------------------------------------
+
+    call seq_comm_setptrs(ID,mpicom=mpicom)
+    if (seq_comm_iamroot(ID)) then
+
+       !---------------------------------------------------------------------------
+       ! Read in namelist
+       !---------------------------------------------------------------------------
+
+        unitn = shr_file_getUnit()
+        write(logunit,"(A)") subname//': read seq_flux_mct_inparm namelist from: '&
+             //trim(nmlfile)
+        open( unitn, file=trim(nmlfile), status='old' )
+        call shr_nl_find_group_name(unitn, 'seq_flux_mct_inparm', ierr)
+        ierr = 1
+        read(unitn,nml=seq_flux_mct_inparm,iostat=ierr)
+
+        if (ierr < 0) then
+           call shr_sys_abort( &
+                subname//"ERROR: namelist read returns an EOF or EOR condition" )
+        end if
+
+        close(unitn)
+        call shr_file_freeUnit( unitn )
+
+     end if
+     if (seq_comm_iamin(ID)) then
+        call shr_mpi_bcast(seq_flux_mct_albdif, mpicom)
+        call shr_mpi_bcast(seq_flux_mct_albdir, mpicom)
+     endif
+  end subroutine seq_flux_readnl_mct
+
+  !===============================================================================
+
   subroutine seq_flux_initexch_mct(atm, ocn, mpicom_cplid, cplid)
 
     !-----------------------------------------------------------------------
@@ -714,8 +775,6 @@ contains
     logical             :: update_alb           ! was albedo updated
     logical,save        :: first_call = .true.
     !
-    real(r8),parameter :: albdif = 0.06_r8 ! 60 deg reference albedo, diffuse
-    real(r8),parameter :: albdir = 0.07_r8 ! 60 deg reference albedo, direct
     character(*),parameter :: subName =   '(seq_flux_ocnalb_mct) '
     !
     !-----------------------------------------------------------------------
@@ -759,10 +818,10 @@ contains
     if (flux_albav) then
 
        do n=1,nloc_o
-          anidr = albdir
-          avsdr = albdir
-          anidf = albdif
-          avsdf = albdif
+          anidr = seq_flux_mct_albdir
+          avsdr = seq_flux_mct_albdir
+          anidf = seq_flux_mct_albdif
+          avsdf = seq_flux_mct_albdif
 
           ! Albedo is now function of latitude (will be new implementation)
           !rlat = const_deg2rad * lats(n)
@@ -822,8 +881,8 @@ contains
                      (cosz         - 0.500_r8 ) *   &
                      (cosz         - 1.000_r8 )  )
                 avsdr = anidr
-                anidf = albdif
-                avsdf = albdif
+                anidf = seq_flux_mct_albdif
+                avsdf = seq_flux_mct_albdif
              else !--- dark side of earth ---
                 anidr = 1.0_r8
                 avsdr = 1.0_r8
@@ -1039,7 +1098,7 @@ contains
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
             duu10n,ustar, re  , ssq , missval = 0.0_r8 )
     else
-       
+
        call shr_flux_atmocn (nloc_a2o , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
             tocn , emask, sen , lat , lwup , &
@@ -1216,8 +1275,6 @@ contains
     integer(in) :: flux_max_iteration ! maximum number of iterations for convergence
     logical :: coldair_outbreak_mod !  cold air outbreak adjustment  (Mahrt & Sun 1995,MWR)
     !
-    real(r8),parameter :: albdif = 0.06_r8 ! 60 deg reference albedo, diffuse
-    real(r8),parameter :: albdir = 0.07_r8 ! 60 deg reference albedo, direct
     character(*),parameter :: subName =   '(seq_flux_atmocn_mct) '
     !
     !-----------------------------------------------------------------------
@@ -1440,7 +1497,7 @@ contains
        if (ocn_surface_flux_scheme.eq.2) then
           call shr_sys_abort(trim(subname)//' ERROR cannot use flux_diurnal with UA flux scheme')
        endif
-       
+
        call shr_flux_atmocn_diurnal (nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
             tocn , emask, sen , lat , lwup , &

--- a/cime/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/cime/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -143,7 +143,7 @@ MODULE seq_infodata_mod
      logical                 :: histaux_a2x24hr ! cpl writes aux hist files: a2x daily all
      logical                 :: histaux_l2x1yrg ! cpl writes aux hist files: l2x annual glc forcings
      logical                 :: histaux_l2x     ! cpl writes aux hist files: l2x every c2l comm
-     logical                 :: histaux_r2x     ! cpl writes aux hist files: r2x daily
+     logical                 :: histaux_r2x     ! cpl writes aux hist files: r2x every c2o comm
      logical                 :: histaux_double_precision ! if true, use double-precision for cpl aux hist files
      logical                 :: histavg_atm     ! cpl writes atm fields in average history file
      logical                 :: histavg_lnd     ! cpl writes lnd fields in average history file
@@ -389,7 +389,7 @@ CONTAINS
     logical                :: histaux_a2x24hr    ! cpl writes aux hist files: a2x daily all
     logical                :: histaux_l2x1yrg    ! cpl writes aux hist files: l2x annual glc forcings
     logical                :: histaux_l2x        ! cpl writes aux hist files: l2x every c2l comm
-    logical                :: histaux_r2x        ! cpl writes aux hist files: r2x daily
+    logical                :: histaux_r2x        ! cpl writes aux hist files: r2x every c2o comm
     logical                :: histaux_double_precision ! if true, use double-precision for cpl aux hist files
     logical                :: histavg_atm        ! cpl writes atm fields in average history file
     logical                :: histavg_lnd        ! cpl writes lnd fields in average history file

--- a/cime/src/share/streams/shr_tInterp_mod.F90
+++ b/cime/src/share/streams/shr_tInterp_mod.F90
@@ -391,7 +391,7 @@ contains
     call shr_cal_date2julian(ymd,tod,calday,calendar)
     call shr_orb_decl( calday, eccen, mvelpp, lambm0, obliqr, declin, eccf)
     do n = 1,lsize
-       cosz(n) = max(solZenMin, shr_orb_cosz( calday, latr(n), lonr(n), declin ))
+       cosz(n) = max(solZenMin, shr_orb_cosz( calday, latr(n), lonr(n), declin))
     end do
 
   end subroutine shr_tInterp_getCosz

--- a/cime/src/share/util/shr_orb_mod.F90
+++ b/cime/src/share/util/shr_orb_mod.F90
@@ -37,7 +37,7 @@ MODULE shr_orb_mod
 CONTAINS
   !===============================================================================
 
-  real(SHR_KIND_R8) pure FUNCTION shr_orb_cosz(jday,lat,lon,declin,dt_avg)
+  real(SHR_KIND_R8) pure FUNCTION shr_orb_cosz(jday,lat,lon,declin,dt_avg,uniform_angle)
 
     !----------------------------------------------------------------------------
     !
@@ -57,24 +57,27 @@ CONTAINS
     real   (SHR_KIND_R8),intent(in) :: lon    ! Centered longitude (radians)
     real   (SHR_KIND_R8),intent(in) :: declin ! Solar declination (radians)
     real   (SHR_KIND_R8),intent(in), optional   :: dt_avg ! if present and set non-zero, then use in the
+    real   (SHR_KIND_R8),intent(in), optional   :: uniform_angle ! if present and true, apply uniform insolation 
     ! average cosz calculation
     logical :: use_dt_avg
 
     !----------------------------------------------------------------------------
-
-    use_dt_avg = .false.
-    if (present(dt_avg)) then
-       if (dt_avg /= 0.0_shr_kind_r8) use_dt_avg = .true.
-    end if
-
-
-    ! If dt for the average cosz is specified, then call the shr_orb_avg_cosz
-    if (use_dt_avg) then
-       shr_orb_cosz =  shr_orb_avg_cosz(jday, lat, lon, declin, dt_avg)
-    else
-       shr_orb_cosz = sin(lat)*sin(declin) - &
-            cos(lat)*cos(declin) * &
-            cos((jday-floor(jday))*2.0_SHR_KIND_R8*pi + lon)
+    
+    if (present(uniform_angle)) then
+       shr_orb_cosz = cos(uniform_angle)
+    else ! perform the calculation of shr_orb_cosz
+       use_dt_avg = .false.
+       if (present(dt_avg)) then
+          if (dt_avg /= 0.0_shr_kind_r8) use_dt_avg = .true.
+       end if
+       ! If dt for the average cosz is specified, then call the shr_orb_avg_cosz
+       if (use_dt_avg) then
+          shr_orb_cosz =  shr_orb_avg_cosz(jday, lat, lon, declin, dt_avg)
+       else
+          shr_orb_cosz = sin(lat)*sin(declin) - &
+               cos(lat)*cos(declin) * &
+               cos((jday-floor(jday))*2.0_SHR_KIND_R8*pi + lon)
+       end if
     end if
 
   END FUNCTION shr_orb_cosz

--- a/cime/src/share/util/shr_scam_mod.F90
+++ b/cime/src/share/util/shr_scam_mod.F90
@@ -641,12 +641,13 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, ocn_compid, ocn_mpicom, &
    character(*),parameter :: subname = "(shr_scam_checkSurface) "
    character(*),parameter :: F00   = "('(shr_scam_checkSurface) ',8a)"
    character(len=CL)      :: decomp = '1d' ! restart pointer file
+   real(r8)               :: fixed_sst 
    character(len=CL)      :: restfilm = 'unset'
    character(len=CL)      :: restfils = 'unset'
    integer(IN)   :: nfrac
    logical :: force_prognostic_true = .false.
    namelist /dom_inparm/ sstcyc, nrevsn, rest_pfile, bndtvs, focndomain
-   namelist / docn_nml / decomp, force_prognostic_true, &
+   namelist / docn_nml / decomp, fixed_sst, force_prognostic_true, &
         restfilm, restfils
 
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
Update CIME to ESMCI cime5.8.9

Squash merge of jgfouca/branch-for-to-acme-2019-09-24

Features:
* Add support for running Radiative Convective Equilibrium including new aquaplanet mode 11.
* Add support to archive metadata for lens experiment type.
* Make the streams file legitimate xml files so that we can parse them.

Bug fixes:
* Fix script_regression_tests directory cleanup
* fix issue with workflow prior to run on master
* dont call bcast on mpi_comm_null in seq_flux_mct

[BFB]