### PR TITLE
Change kokkos submodule to an e3sm fork of kokkos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,8 +13,8 @@
 	url = git@github.com:MPAS-Dev/MPAS-Model.git
 [submodule "externals/kokkos"]
 	path = externals/kokkos
-	url = git@github.com:kokkos/kokkos.git
-	branch = develop
+	url = git@github.com:E3SM-Project/kokkos.git
+	branch = e3sm/kokkos
 [submodule "components/cam/src/physics/rrtmgp/external"]
 	path = components/cam/src/physics/rrtmgp/external
 	url = git@github.com:RobertPincus/rte-rrtmgp.git


### PR DESCRIPTION
This will give us (E3SM) more control over the submodule, allowing
us to use commits that aren't in the main kokkos repo.

This also adds a commit to kokkos that allows for --fmad support
for nvcc.

Fixes #3203 

[BFB]