### PR TITLE
Extends support inline interpolation in ELM

### DIFF
--- a/components/clm/src/data_types/TopounitDataType.F90
+++ b/components/clm/src/data_types/TopounitDataType.F90
@@ -430,21 +430,21 @@ module TopounitDataType
             subgrid_type='topounit', numlev=1, init_value=0._r8)
     end if
     ! Accumulator variables for radiation fluxes
-    call init_accum_field (name='FSD24H', units='W/m2',                                             &
-         desc='24hr average of direct solar radiation',  accum_type='runmean', accum_period=-1,    &
-         subgrid_type='topounit', numlev=1, init_value=0._r8)
+    !call init_accum_field (name='FSD24H', units='W/m2',                                             &
+    !     desc='24hr average of direct solar radiation',  accum_type='runmean', accum_period=-1,    &
+    !     subgrid_type='topounit', numlev=1, init_value=0._r8)
 
-    call init_accum_field (name='FSD240H', units='W/m2',                                            &
-         desc='240hr average of direct solar radiation',  accum_type='runmean', accum_period=-10,  &
-         subgrid_type='topounit', numlev=1, init_value=0._r8)
+    !call init_accum_field (name='FSD240H', units='W/m2',                                            &
+    !     desc='240hr average of direct solar radiation',  accum_type='runmean', accum_period=-10,  &
+    !     subgrid_type='topounit', numlev=1, init_value=0._r8)
 
-    call init_accum_field (name='FSI24H', units='W/m2',                                             &
-         desc='24hr average of diffuse solar radiation',  accum_type='runmean', accum_period=-1,   &
-         subgrid_type='topounit', numlev=1, init_value=0._r8)
+    !call init_accum_field (name='FSI24H', units='W/m2',                                             &
+    !     desc='24hr average of diffuse solar radiation',  accum_type='runmean', accum_period=-1,   &
+    !     subgrid_type='topounit', numlev=1, init_value=0._r8)
 
-    call init_accum_field (name='FSI240H', units='W/m2',                                            &
-         desc='240hr average of diffuse solar radiation',  accum_type='runmean', accum_period=-10, &
-         subgrid_type='topounit', numlev=1, init_value=0._r8)
+    !call init_accum_field (name='FSI240H', units='W/m2',                                            &
+    !     desc='240hr average of diffuse solar radiation',  accum_type='runmean', accum_period=-10, &
+    !     subgrid_type='topounit', numlev=1, init_value=0._r8)
   end subroutine init_acc_buffer_top_af
   
   !-----------------------------------------------------------------------
@@ -483,17 +483,17 @@ module TopounitDataType
     ! Determine time step
     nstep = get_nstep()
 
-    call extract_accum_field ('FSD24H', rbufslt, nstep)
-    this%fsd24h(begt:endt) = rbufslt(begt:endt)
+    !call extract_accum_field ('FSD24H', rbufslt, nstep)
+    !this%fsd24h(begt:endt) = rbufslt(begt:endt)
 
-    call extract_accum_field ('FSD240H', rbufslt, nstep)
-    this%fsd240h(begt:endt) = rbufslt(begt:endt)
+    !call extract_accum_field ('FSD240H', rbufslt, nstep)
+    !this%fsd240h(begt:endt) = rbufslt(begt:endt)
 
-    call extract_accum_field ('FSI24H', rbufslt, nstep)
-    this%fsi24h(begt:endt) = rbufslt(begt:endt)
+    !call extract_accum_field ('FSI24H', rbufslt, nstep)
+    !this%fsi24h(begt:endt) = rbufslt(begt:endt)
 
-    call extract_accum_field ('FSI240H', rbufslt, nstep)
-    this%fsi240h(begt:endt) = rbufslt(begt:endt)
+    !call extract_accum_field ('FSI240H', rbufslt, nstep)
+    !this%fsi240h(begt:endt) = rbufslt(begt:endt)
 
     if (use_cn) then
        call extract_accum_field ('PREC10D', rbufslt, nstep)
@@ -547,19 +547,19 @@ module TopounitDataType
     do t = begt,endt
        rbufslt(t) = this%solad(t,1)
     end do
-    call update_accum_field  ('FSD240H', rbufslt              , nstep)
-    call extract_accum_field ('FSD240H', this%fsd240h         , nstep)
-    call update_accum_field  ('FSD24H' , rbufslt              , nstep)
-    call extract_accum_field ('FSD24H' , this%fsd24h          , nstep)
+    !call update_accum_field  ('FSD240H', rbufslt              , nstep)
+    !call extract_accum_field ('FSD240H', this%fsd240h         , nstep)
+    !call update_accum_field  ('FSD24H' , rbufslt              , nstep)
+    !call extract_accum_field ('FSD24H' , this%fsd24h          , nstep)
 
     ! Accumulate and extract forc_solai24 & forc_solai240 
     do t = begt,endt
        rbufslt(t) = this%solai(t,1)
     end do
-    call update_accum_field  ('FSI24H' , rbufslt              , nstep)
-    call extract_accum_field ('FSI24H' , this%fsi24h          , nstep)
-    call update_accum_field  ('FSI240H', rbufslt              , nstep)
-    call extract_accum_field ('FSI240H', this%fsi240h         , nstep)
+    !call update_accum_field  ('FSI24H' , rbufslt              , nstep)
+    !call extract_accum_field ('FSI24H' , this%fsi24h          , nstep)
+    !call update_accum_field  ('FSI240H', rbufslt              , nstep)
+    !call extract_accum_field ('FSI240H', this%fsi240h         , nstep)
 
     ! Accumulate and extract total precip
     do t = begt,endt

--- a/components/clm/src/main/initInterp.F90
+++ b/components/clm/src/main/initInterp.F90
@@ -124,6 +124,7 @@ contains
     logical , pointer  :: pft_activei(:), pft_activeo(:) 
     logical , pointer  :: col_activei(:), col_activeo(:) 
     logical , pointer  :: lun_activei(:), lun_activeo(:) 
+    logical , pointer  :: grc_activei(:), grc_activeo(:) 
     integer , pointer  :: sgridindex(:)
     logical , pointer  :: activei(:), activeo(:)
     !--------------------------------------------------------------------
@@ -194,22 +195,27 @@ contains
     begp_i = 1 ;  endp_i = npftsi
     begc_i = 1 ;  endc_i = ncolsi
     begl_i = 1 ;  endl_i = nlunsi
+    begg_i = 1 ;  endg_i = ngrcsi
 
     begp_o = bounds%begp ;  endp_o = bounds%endp
     begc_o = bounds%begc ;  endc_o = bounds%endc
     begl_o = bounds%begl ;  endl_o = bounds%endl
+    begg_o = bounds%begg ;  endg_o = bounds%endg
 
     allocate(pft_activei(begp_i:endp_i))
     allocate(col_activei(begc_i:endc_i))
     allocate(lun_activei(begl_i:endl_i))
+    allocate(grc_activei(begg_i:endg_i))
 
     allocate(pft_activeo(begp_o:endp_o))
     allocate(col_activeo(begc_o:endc_o))
     allocate(lun_activeo(begl_o:endl_o))
+    allocate(grc_activeo(begg_o:endg_o))
 
     allocate(pftindx(begp_o:endp_o))
     allocate(colindx(begc_o:endc_o))
     allocate(lunindx(begl_o:endl_o))
+    allocate(grcindx(begg_o:endg_o))
 
     ! For each output pft, find the input pft, pftindx, that is closest
 
@@ -237,6 +243,15 @@ contains
     vec_dimname = 'landunit'
     call findMinDist(vec_dimname, begl_i, endl_i, begl_o, endl_o, ncidi, ncido, &
          lun_activei, lun_activeo, lunindx )
+
+    ! For each output gridcell, find the input gridcell, grcindx, that is closest
+
+    if (masterproc) then
+       write(iulog,*)'finding minimum distance for gridcells'
+    end if
+    vec_dimname = 'gridcell'
+    call findMinDist(vec_dimname, begg_i, endg_i, begg_o, endg_o, ncidi, ncido, &
+         grc_activei, grc_activeo, grcindx )
 
     !------------------------------------------------------------------------          
     ! Read input initial data and write output initial data
@@ -386,6 +401,14 @@ contains
              activei => lun_activei
              activeo => lun_activeo
              sgridindex => lunindx
+          else if ( vec_dimname == 'gridcell' )then
+             begi = begg_i
+             endi = endg_i
+             bego = begg_o
+             endo = endg_o
+             activei => grc_activei
+             activeo => grc_activeo
+             sgridindex => grcindx
           else
              call endrun(msg='ERROR interpinic: 1D variable '//trim(varname)//&
                   'with unknown subgrid dimension: '//trim(vec_dimname)//&
@@ -600,6 +623,10 @@ contains
        call ncd_io(ncid=ncid, varname='land1d_lat'    , flag='read', data=subgrid%lat  , dim1name='landunit') 
        call ncd_io(ncid=ncid, varname='land1d_ityplun', flag='read', data=subgrid%ltype, dim1name='landunit')
        call ncd_io(ncid=ncid, varname='land1d_active' , flag='read', data=itemp        , dim1name='landunit') 
+    else if (dimname == 'gridcell') then
+       call ncd_io(ncid=ncid, varname='grid1d_lon'    , flag='read', data=subgrid%lon  , dim1name='gridunit') 
+       call ncd_io(ncid=ncid, varname='grid1d_lat'    , flag='read', data=subgrid%lat  , dim1name='gridunit') 
+       itemp(:) = 1
     end if
 
     do n = beg,end
@@ -831,6 +858,8 @@ contains
        if (subgridi%ltype(ni) == subgrido%ltype(no)) then
           is_sametype = .true.
        end if
+    else if (trim(subgridi%name) == 'gridcell' .and. trim(subgrido%name) == 'gridcell') then
+       is_sametype = .true.
     else 
        if (masterproc) then
           write(iulog,*)'ERROR interpinic: is_sametype check on input and output type not supported'


### PR DESCRIPTION
Disables the output of few unused topounit-level variables in restart files
and extends inline-interpolation to support interpolation of grid-level 
output variables.

[BFB]