### PR TITLE
SCM SE energy bug fix

### DIFF
--- a/components/cam/src/physics/cam/check_energy.F90
+++ b/components/cam/src/physics/cam/check_energy.F90
@@ -841,6 +841,15 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
     if (single_column .and. use_replay) then
       heat_glob = heat_glob_scm(1)
     endif
+    
+    ! If single column model we do NOT want to take into
+    !   consideration the dynamics energy fixer.  Since only
+    !   only column of dynamics is active, this data will 
+    !   essentially be garbage. 
+    if (single_column .and. .not. use_replay) then
+      heat_glob = 0._r8
+    endif
+    
     ptend%s(:ncol,:pver) = heat_glob
 !!$    write(iulog,*) "chk_fix: heat", state%lchnk, ncol, heat_glob
 


### PR DESCRIPTION
The spectral element (SE) dycore has a global energy fixer associated with it.  In SCM mode, only one dynamics column is active and thus the value of this energy fixer should be set to zero, to avoid corrupt data from being used (in replay mode this value is prescribed from the IOP forcing file to preserve near-b4b status with the global run, which was already being performed).  

Bug fix has small impacts on SCM simulations in free running and hindcast mode, but has larger impacts on runs using nudging (i.e. runs with namelist scm_relaxation = .true.), resulting in larger temperature errors than one would expect when nudging to observations.  

All tests e3sm_developer tests pass except SMS_R_Ld5.ne4_ne4.FSCM5A97, which is an expected fail due to answer changes.  