### PR TITLE
Update mpas-seaice version in mpas-source submodule

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -759,6 +759,7 @@ add_default($nl, 'config_mobility_type_DMSPd');
 add_default($nl, 'config_mobility_type_humics');
 add_default($nl, 'config_mobility_type_saccharids');
 add_default($nl, 'config_mobility_type_lipids');
+add_default($nl, 'config_mobility_type_inorganic_carbon');
 add_default($nl, 'config_mobility_type_proteins');
 add_default($nl, 'config_mobility_type_dissolved_iron');
 add_default($nl, 'config_mobility_type_particulate_iron');

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -298,6 +298,7 @@ add_default($nl, 'config_mobility_type_DMSPd');
 add_default($nl, 'config_mobility_type_humics');
 add_default($nl, 'config_mobility_type_saccharids');
 add_default($nl, 'config_mobility_type_lipids');
+add_default($nl, 'config_mobility_type_inorganic_carbon');
 add_default($nl, 'config_mobility_type_proteins');
 add_default($nl, 'config_mobility_type_dissolved_iron');
 add_default($nl, 'config_mobility_type_particulate_iron');

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -248,9 +248,9 @@
 <config_iron_saturation_phaeocystis>0.1</config_iron_saturation_phaeocystis>
 <config_fraction_spilled_to_DON>0.6</config_fraction_spilled_to_DON>
 <config_degredation_of_DON>0.03</config_degredation_of_DON>
-<config_fraction_DON_ammonium>0.25</config_fraction_DON_ammonium>
-<config_fraction_loss_to_saccharids>0.4</config_fraction_loss_to_saccharids>
-<config_fraction_loss_to_lipids>0.4</config_fraction_loss_to_lipids>
+<config_fraction_DON_ammonium>1.0</config_fraction_DON_ammonium>
+<config_fraction_loss_to_saccharids>0.5</config_fraction_loss_to_saccharids>
+<config_fraction_loss_to_lipids>0.5</config_fraction_loss_to_lipids>
 <config_fraction_exudation_to_saccharids>1.0</config_fraction_exudation_to_saccharids>
 <config_fraction_exudation_to_lipids>1.0</config_fraction_exudation_to_lipids>
 <config_remineralization_saccharids>0.03</config_remineralization_saccharids>
@@ -281,6 +281,7 @@
 <config_mobility_type_humics>0.0</config_mobility_type_humics>
 <config_mobility_type_saccharids>0.0</config_mobility_type_saccharids>
 <config_mobility_type_lipids>0.0</config_mobility_type_lipids>
+<config_mobility_type_inorganic_carbon>-1.0</config_mobility_type_inorganic_carbon>
 <config_mobility_type_proteins>0.0</config_mobility_type_proteins>
 <config_mobility_type_dissolved_iron>0.0</config_mobility_type_dissolved_iron>
 <config_mobility_type_particulate_iron>0.5</config_mobility_type_particulate_iron>
@@ -299,7 +300,7 @@
 <config_scales_absorption_diatoms>2.0</config_scales_absorption_diatoms>
 <config_scales_absorption_small_plankton>4.0</config_scales_absorption_small_plankton>
 <config_scales_absorption_phaeocystis>5.0</config_scales_absorption_phaeocystis>
-<config_ratio_C_to_N_proteins>7.0</config_ratio_C_to_N_proteins>
+<config_ratio_C_to_N_proteins>5.0</config_ratio_C_to_N_proteins>
 
 <!-- shortwave -->
 <config_shortwave_type>'dEdd'</config_shortwave_type>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -1795,6 +1795,14 @@ Valid values: -1 = entirely in the mobile phase; 0 = retention dominated; 1 = re
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_mobility_type_inorganic_carbon" type="real"
+	category="biogeochemistry" group="biogeochemistry">
+Transport type of dissolved inorganic carbon
+
+Valid values: -1 = entirely in the mobile phase; 0 = retention dominated; 1 = release dominated; 0.5 = equal but rapid exchange; 2 = equal but slow exchange
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_mobility_type_proteins" type="real"
 	category="biogeochemistry" group="biogeochemistry">
 Transport type of proteins


### PR DESCRIPTION
This PR brings in a new mpas-source submodule that updates the version of mpas-seaice as well as supporting scripts changes. The mpas-seaice update brings in four separate merges, only one of which impacts E3SM. Those merges are:
* seaice standalone testing forcing README and files (ee79424);
* zbgc modifications that should only impact certain BGC compsets (340e782);
* ifdef'd threading support for GNU-openmp (93bbc4e); and
* strain/stress standalone testing addition (818b069).

The only impact on E3SM should be for BGC compsets, though there will be NML changes.

[NML]
[BFB]