### PR TITLE
Improve throughput on Compy

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1058,6 +1058,7 @@ for mct, etc.
 <compiler MACH="compy" COMPILER="intel">
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
+    <append MODEL="gptl"> -DHAVE_SLASHPROC </append>
   </CFLAGS>
   <CONFIG_ARGS>
     <base> --host=Linux </base>
@@ -1083,6 +1084,7 @@ for mct, etc.
 <compiler MACH="compy" COMPILER="pgi">
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
+    <append MODEL="gptl"> -DHAVE_SLASHPROC </append>
   </CFLAGS>
   <CONFIG_ARGS>
     <base> --host=Linux </base>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1944,6 +1944,8 @@
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.05</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
       <env name="NETCDF_HOME">$ENV{NETCDF_ROOT}/</env>
       <env name="MKL_PATH">$ENV{MKLROOT}</env>

--- a/cime/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/cime/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -474,7 +474,7 @@ class SystemTestsCommon(object):
                         diff = (baseline - current)/baseline
                         tolerance = self._case.get_value("TEST_TPUT_TOLERANCE")
                         if tolerance is None:
-                            tolerance = 0.25
+                            tolerance = 0.1
                         expect(tolerance > 0.0, "Bad value for throughput tolerance in test")
                         if diff < tolerance and self._test_status.get_status(THROUGHPUT_PHASE) is None:
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -688,7 +688,7 @@ contains
        found = .false.
        do c = bounds%begc,bounds%endc
           if (col_pp%active(c)) then
-             if (abs(errsoi_col(c)) > 1.0e-6_r8 ) then
+             if (abs(errsoi_col(c)) > 1.0e-5_r8 ) then
                 found = .true.
                 indexc = c
              end if

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -2219,7 +2219,9 @@ contains
        else
           call t_startf('mosartr_euler')
           ! debug 
+#ifdef DEBUG
           write(iulog,*) 'clm-mosart subT: (call Euler) ns=', ns
+#endif
           call Euler()
           call t_stopf('mosartr_euler')
        endif

--- a/components/mosart/src/riverroute/RtmTimeManager.F90
+++ b/components/mosart/src/riverroute/RtmTimeManager.F90
@@ -731,7 +731,9 @@ subroutine advance_timestep(nsub)
            if (dd1 /= dd0) new_day = .true.
         endif
      endif
+#ifdef DEBUG
      write(iulog,'(2a,4i6,3l4)') sub," yy,mm,dd = ",yy1,mm1,dd1,tod1,new_year,new_month,new_day
+#endif
   endif
 
 end subroutine advance_timestep


### PR DESCRIPTION
Improve throughput on Compy by reducing stdout writes:  Turn off MOSART debug writes and increase tolerance in an ELM BalanceCheck.  Also add a throughput tolerance check to compy.

Fixes E3SM-Project/E3SM#3150

[BFB]