### PR TITLE
Adjust max node number for sandiatoss3 short q

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -409,7 +409,7 @@
 
   <batch_system MACH="sandiatoss3" type="slurm" >
     <queues>
-      <queue nodemax="24" walltimemax="04:00:00" strict="true" default="true">short,batch</queue>
+      <queue nodemax="16" walltimemax="04:00:00" strict="true" default="true">short,batch</queue>
       <queue walltimemax="24:00:00">batch</queue>
     </queues>
   </batch_system>

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -409,7 +409,7 @@
 
   <batch_system MACH="sandiatoss3" type="slurm" >
     <queues>
-      <queue nodemax="12" walltimemax="04:00:00" strict="true" default="true">short,batch</queue>
+      <queue nodemax="24" walltimemax="04:00:00" strict="true" default="true">short,batch</queue>
       <queue walltimemax="24:00:00">batch</queue>
     </queues>
   </batch_system>


### PR DESCRIPTION
Adjust max node number for sandiatoss3 short q.

According to help for short q,
'Walltime limit is 4 hours, node limit is 24 nodes per job.'

[BFB]