### PR TITLE
Modifies simulation length for ERP test from 5 to 7 time steps

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -68,7 +68,7 @@ _TESTS = {
             "ERS_Ld31.ne4_ne4.FC5AV1C-L",
             "ERP_Lm3.ne4_ne4.FC5AV1C-L",
             "SMS_D_Ln5.ne30_ne30.FC5AV1C-L",
-            "ERP_Ln5.ne30_ne30.FC5AV1C-L",
+            "ERP_Ln7.ne30_ne30.FC5AV1C-L",
             "SMS_Ly1.ne4_ne4.FC5AV1C-L",
             )
         },


### PR DESCRIPTION
ERP_Ln5.ne30_ne30.FC5AV1C-L test in "extra coverage" testing suite was
blowing up due to NaNs in SHR_REPROSUM. Changing the run lenth to 7
time steps, fixes that issue.
The reason for this is explained in issue #3229.

Addresses #3229

[BFB] - Bit-For-Bit