### PR TITLE
Flow of Agricultural Nitrogen (FAN) 

### DIFF
--- a/cime/scripts/Tools/jenkins_generic_job
+++ b/cime/scripts/Tools/jenkins_generic_job
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-Jenkins runs this script to perform a test of an e3sm 
+Jenkins runs this script to perform a test of an e3sm
 test suite. Essentially, a wrapper around create_test and
 wait_for_tests that handles cleanup of old test results and
 ensures that the batch system is left in a clean state.
@@ -41,6 +41,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
+    default_baseline = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
+    default_baseline = default_baseline.replace(".", "_") # Can't have dots
+
     parser.add_argument("-g", "--generate-baselines", action="store_true",
                         help="Generate baselines")
 
@@ -59,7 +62,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-p", "--cdash-project", default=CIME.wait_for_tests.E3SM_MAIN_CDASH,
                         help="The name of the CDash project where results should be uploaded")
 
-    parser.add_argument("-b", "--baseline-name", default=CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root()),
+    parser.add_argument("-b", "--baseline-name", default=default_baseline,
                         help="Baseline name for baselines to use. Also impacts dashboard job name. Useful for testing a branch other than next or master")
 
     parser.add_argument("-O", "--override-baseline-name",

--- a/cime/scripts/Tools/jenkins_generic_job
+++ b/cime/scripts/Tools/jenkins_generic_job
@@ -42,7 +42,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     CIME.utils.setup_standard_logging_options(parser)
 
     default_baseline = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
-    default_baseline = default_baseline.replace(".", "_") # Can't have dots
+    default_baseline = default_baseline.replace(".", "_").replace("/", "_") # Dots or slashes will mess things up
 
     parser.add_argument("-g", "--generate-baselines", action="store_true",
                         help="Generate baselines")

--- a/components/clm/bld/CLMBuildNamelist.pm
+++ b/components/clm/bld/CLMBuildNamelist.pm
@@ -562,12 +562,8 @@ sub read_namelist_defaults {
   # values for variables contained in the input defaults file.  The
   # configuration object provides attribute values that are relevent
   # for the CLM executable for which the namelist is being produced.
-  print"here!!\n";
   my $defaults = Build::NamelistDefaults->new( shift( @nl_defaults_files ), $cfg);
-  print "done\n";
   foreach my $nl_defaults_file ( @nl_defaults_files ) {
-      print "add $nl_defaults_file\n";
-
     $defaults->add( "$nl_defaults_file" );
   }
   return $defaults;
@@ -1826,9 +1822,7 @@ sub process_namelist_commandline_clm_usr_name {
     # The one difference is that variables are expanded.
     # Create a new NamelistDefaults object.
     my $nl_defaults_file = "$nl_flags->{'cfgdir'}/namelist_files/namelist_defaults_usr_files.xml";
-    print "here4\n";  
     my $uf_defaults = Build::NamelistDefaults->new("$nl_defaults_file", $cfg );
-    print "done4\n";  
     # Loop over the variables specified in the user files
     # Add each one to the namelist.
     my @vars = $uf_defaults->get_variable_names();
@@ -1878,9 +1872,7 @@ sub process_namelist_commandline_use_case {
 
     # The use case definition is contained in an xml file with the same format as the defaults file.
       # Create a new NamelistDefaults object.
-    print "here2\n";
     my $uc_defaults = Build::NamelistDefaults->new("$opts->{'use_case_dir'}/$opts->{'use_case'}.xml", $cfg);
-    print "done2\n";
     my %settings;
     $settings{'res'}            = $nl_flags->{'res'};
     $settings{'rcp'}            = $nl_flags->{'rcp'};
@@ -3031,7 +3023,7 @@ sub setup_logic_nitrogen_deposition {
   my ($test_files, $nl_flags, $definition, $defaults, $nl, $physv, $deptype) = @_;
   my $ndep;  
   if ($deptype eq 'fan') {
-      if (!value_is_true( $nl_flags->{'use_fan'})) { print "no fan!!\n"; return; }
+      if (!value_is_true( $nl_flags->{'use_fan'})) { fatal_error("FAN not on but deptype == fan\n"); }
       $ndep = 'fan';
   } elsif ($deptype eq 'ndep') {
       $ndep = 'ndep';
@@ -3044,7 +3036,6 @@ sub setup_logic_nitrogen_deposition {
   #
 
   if ( $physv->as_long() == $physv->as_long("clm4_0") && $nl_flags->{'bgc_mode'} ne "none" ) {
-      print "here444\n";
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, "${ndep}mapalgo", 'phys'=>$nl_flags->{'phys'}, 
                 'bgc'=>$nl_flags->{'bgc_mode'}, 'hgrid'=>$nl_flags->{'res'} );
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, "stream_year_first_${ndep}", 'phys'=>$nl_flags->{'phys'},
@@ -3065,7 +3056,6 @@ sub setup_logic_nitrogen_deposition {
                 'hgrid'=>"1.9x2.5" );
 
   } elsif ( $physv->as_long() >= $physv->as_long("clm4_5") && $nl_flags->{'bgc_mode'} =~/cn|bgc/ ) {
-      print "here555 $ndep\n";
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, "${ndep}mapalgo", 'phys'=>$nl_flags->{'phys'},
                 'use_cn'=>$nl_flags->{'use_cn'}, 'hgrid'=>$nl_flags->{'res'} );
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, "stream_year_first_${ndep}", 'phys'=>$nl_flags->{'phys'},
@@ -3083,7 +3073,6 @@ sub setup_logic_nitrogen_deposition {
                 'use_cn'=>$nl_flags->{'use_cn'}, 'rcp'=>$nl_flags->{'rcp'},
                 'hgrid'=>"1.9x2.5" );
   } else {
-      print "no cn/cndv $physv->as_long() $nl_flags->{'bgc_mode'} \n";
     # If bgc is NOT CN/CNDV then make sure none of the ndep settings are set!
     if ( defined($nl->get_value('stream_year_first_${ndep}')) ||
          defined($nl->get_value('stream_year_last_${ndep}'))  ||
@@ -3165,7 +3154,6 @@ sub setup_logic_fan {
   # Flags to control FAN (Flow of Agricultural Nitrogen) nitrogen deposition (manure and fertilizer)
   #
    my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
-   #print "FAN MODE: $opts->{'fan'}\n";
    if ( $physv->as_long() >= $physv->as_long("clm4_5") ) {
        if ( $opts->{'fan'} ) {
 	   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fan',
@@ -3799,9 +3787,7 @@ sub validate_options {
               } else {
                  fatal_error("Bad name for use case file = $file");
               }
-	      print "here3\n";
               my $uc_defaults = Build::NamelistDefaults->new("$file", $cfg);
-	      print "done3\n";
 
               printf "%15s = %s\n", $use_case, $uc_defaults->get_value("use_case_desc");
               push @ucases, $use_case;
@@ -4086,7 +4072,6 @@ sub main {
   $nl_flags{'cfgdir'} = dirname(abs_path($0));
 
   my %opts = process_commandline(\%nl_flags);
-  print "FAN: $opts{'fan'}\n";
   my $cfgdir = $nl_flags{'cfgdir'};
   version($nl_flags{'cfgdir'}) if $opts{'version'};
   set_print_level(\%opts);

--- a/components/clm/bld/CLMBuildNamelist.pm
+++ b/components/clm/bld/CLMBuildNamelist.pm
@@ -3178,6 +3178,11 @@ sub setup_logic_fan {
      if ( value_is_true( $nl_flags->{'use_ed'} ) && value_is_true( $nl_flags->{'use_fan'} ) ) {
         fatal_error("Cannot turn use_fan on when use_ed is on\n" );
      }
+     if ($nl_flags->{'use_crop'} ne ".true.") {
+       fatal_error('Cannot use_fan if use_crop is false');
+     }
+	 
+	     
    }
 }
 

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -519,6 +519,45 @@ this mask will have smb calculated over the entire global land surface
 <pdepmapalgo use_cn=".true."   hgrid="1x1_tropicAtl"       >nn</pdepmapalgo>
 <pdepmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</pdepmapalgo>
 
+<!-- FAN Nitrogen (manure) deposition streams namelist defaults -->
+<stream_year_first_fan use_cn=".true."   sim_year="2000" >2000</stream_year_first_fan>
+<stream_year_last_fan  use_cn=".true."   sim_year="2000" >2000</stream_year_last_fan>
+
+<stream_year_first_fan use_cn=".true."   sim_year="1850" >2000</stream_year_first_fan>
+<stream_year_last_fan  use_cn=".true."   sim_year="1850" >2000</stream_year_last_fan>
+
+<stream_year_first_fan use_cn=".true."   sim_year="1000" >2000</stream_year_first_fan>
+<stream_year_last_fan  use_cn=".true."   sim_year="1000" >2000</stream_year_last_fan>
+
+<stream_year_first_fan use_cn=".true."   sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_first_fan>
+<stream_year_last_fan  use_cn=".true."   sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_last_fan>
+
+<stream_year_first_fan use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_fan>
+<stream_year_last_fan  use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_fan>
+
+<stream_year_first_fan use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >2000</stream_year_first_fan>
+<stream_year_last_fan  use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >2000</stream_year_last_fan>
+
+<stream_year_first_fan use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >2000</stream_year_first_fan>
+<stream_year_last_fan  use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >2000</stream_year_last_fan>
+
+<stream_year_first_fan use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2000</stream_year_first_fan>
+<stream_year_last_fan  use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2000</stream_year_last_fan>
+
+<stream_fldfilename_fan>/glade/p/cgd/tss/people/oleson/nitrogen/Nmanure.nc</stream_fldfilename_fan>
+
+<fanmapalgo use_cn=".true."                               >bilinear</fanmapalgo>
+
+<fanmapalgo use_cn=".true."   hgrid="1x1_brazil"          >nn</fanmapalgo>
+<fanmapalgo use_cn=".true."   hgrid="1x1_mexicocityMEX"   >nn</fanmapalgo>
+<fanmapalgo use_cn=".true."   hgrid="1x1_vancouverCAN"    >nn</fanmapalgo>
+<fanmapalgo use_cn=".true."   hgrid="1x1_urbanc_alpha"    >nn</fanmapalgo>
+<fanmapalgo use_cn=".true."   hgrid="1x1_camdenNJ"        >nn</fanmapalgo>
+<fanmapalgo use_cn=".true."   hgrid="1x1_asphaltjungleNJ" >nn</fanmapalgo>
+<fanmapalgo use_cn=".true."   hgrid="1x1_tropicAtl"       >nn</fanmapalgo>
+<fanmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</fanmapalgo>
+
+
 <!-- LAI streams namelist defaults -->
 <use_lai_streams        >.false.</use_lai_streams>
 <stream_year_first_lai  >2001</stream_year_first_lai>
@@ -1724,5 +1763,12 @@ this mask will have smb calculated over the entire global land surface
 <use_lch4            bgc_mode="ed"  >.false.</use_lch4>
 <use_nitrif_denitrif bgc_mode="ed"  >.false.</use_nitrif_denitrif>
 
+<!-- flow of agricultural nitrogen (fan) model -->
+<use_fan phys="clm4_5" use_cn=".true.">.false.</use_fan>
+<use_fan phys="clm4_5" use_cn=".false.">.false.</use_fan>
+<use_fan phys="clm5_0" use_cn=".true.">.false.</use_fan>
+<use_fan phys="clm5_0" use_cn=".false.">.false.</use_fan>
+<use_fan phys="clm5_0" use_ed=".true." >.false.</use_fan>
+<use_fan fan_mode='disable'>.false.</use_fan>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/namelist_defaults_fan.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_fan.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<?xml-stylesheet type="text/xsl" href="namelist_defaults.xsl"?>
+
+<namelist_defaults>
+
+<!--
+Values to use by default for creation of CLM model driver namelists.
+The element names are the same as the corresponding namelist
+variables.  Values that depend on the model configuration use
+attributes to express the dependency.  The recognized attributes
+are: RESOLUTION, defaults, mask, ic_ymd, ic_tod, sim_year and all configuration
+attributes from the config_cache.xml file (with keys converted to upper-case).
+-->
+
+<fan_nh3_to_atm use_fan=".false.">.false.</fan_nh3_to_atm>
+<fan_nh3_to_atm use_fan=".true." fan_mode="atm">.true.</fan_nh3_to_atm>
+
+</namelist_defaults>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -579,6 +579,11 @@ Max number of plant functional types in naturally vegetated landunit.
 Toggle to turn on the dynamic root model.
 </entry>
 
+<entry id="use_fan" type="logical" category="physics"
+        group="clm_inparm" valid_values="" value=".false.">
+Toggle to turn on the Flow of Agricultural Nitrogen (FAN) model
+</entry>
+
 <!--                                                   -->
 <!-- mkmapdata  namelist                               -->
 <!--                                                   -->
@@ -946,6 +951,7 @@ Mapping method from Nitrogen deposition input file to the model resolution
     copy     = copy using the same indices
 </entry>
 
+
 <!-- ========================================================================================  -->
 <!-- pdepdyn streams Namelist (only used when bgc=cn/cndv)                                     -->
 <!-- ========================================================================================  -->
@@ -980,6 +986,42 @@ Mapping method from Phosphorus deposition input file to the model resolution
     spval    = set to special value
     copy     = copy using the same indices
 </entry>
+
+<!-- ========================================================================================  -->
+<!-- fan streams Namelist (only used when bgc=cn/cndv and use_fan=.true.)                 -->
+<!-- ========================================================================================  -->
+
+<entry id="stream_year_first_fan" type="integer" category="datasets"
+       group="fan_nml" valid_values="" >
+First year to loop over for FAN Nitrogen (manure) Deposition data
+</entry>
+
+<entry id="stream_year_last_fan" type="integer" category="datasets"
+       group="fan_nml" valid_values="" >
+Last year to loop over for FAN Nitrogen (manure) Deposition data
+</entry>
+
+<entry id="model_year_align_fan" type="integer" category="datasets"
+       group="fan_nml" valid_values="" >
+Simulation year that aligns with stream_year_first_ndep2 value
+</entry>
+
+<entry id="stream_fldfilename_fan" type="char*256" category="datasets"
+       input_pathname="abs" group="fan_nml" valid_values="" >
+Filename of input stream data for FAN Nitrogen (manure) Deposition
+</entry>
+
+<entry id="fanmapalgo" type="char*256" category="datasets"
+       group="fan_nml" valid_values="bilinear,nn,nnoni,nnonj,spval,copy" >
+Mapping method from FAN Nitrogen (manure) deposition input file to the model resolution
+    bilinear = bilinear interpolation
+    nn       = nearest neighbor
+    nnoni    = nearest neighbor on the "i" (longitude) axis
+    nnonj    = nearest neighbor on the "j" (latitude) axis
+    spval    = set to special value
+    copy     = copy using the same indices
+</entry>
+
 
 
 <!-- ========================================================================================  -->

--- a/components/clm/bld/namelist_files/namelist_definition_drv_flds.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_drv_flds.xml
@@ -128,4 +128,12 @@
     List of fluxes needed by the CARMA model, from CLM to CAM.
   </entry>
 
+  <!-- ========================================================================================  -->
+  <!-- FAN fields                                                                              -->
+  <!-- ========================================================================================  -->
+  <entry id="fan_nh3_to_atm" type="logical" category="FAN"
+	 group="fan_inparm" valid_values="" >
+    Switch on/off the coupling of NH3 emissions from FAN/CLM to CAM
+  </entry>
+
 </namelist_definition>

--- a/components/clm/src/biogeochem/CNEcosystemDynBetrMod.F90
+++ b/components/clm/src/biogeochem/CNEcosystemDynBetrMod.F90
@@ -60,7 +60,7 @@ module CNEcosystemDynBetrMod
          canopystate_vars, soilstate_vars, temperature_vars, crop_vars,  &
          dgvs_vars, photosyns_vars, soilhydrology_vars, energyflux_vars, &
          PlantMicKinetics_vars,                                          &
-         phosphorusflux_vars, phosphorusstate_vars)
+         phosphorusflux_vars, phosphorusstate_vars,frictionvel_vars)
 
     ! Description:
     ! Update vegetation related state variables and
@@ -133,6 +133,7 @@ module CNEcosystemDynBetrMod
     type(PlantMicKinetics_type)      , intent(inout) :: PlantMicKinetics_vars
     type(phosphorusflux_type)        , intent(inout) :: phosphorusflux_vars
     type(phosphorusstate_type)       , intent(inout) :: phosphorusstate_vars
+    type(frictionvel_type)           , intent(in)    :: frictionvel_vars
 
     if(.not. use_ed)then
        ! --------------------------------------------------
@@ -171,8 +172,14 @@ module CNEcosystemDynBetrMod
        ! --------------------------------------------------
 
        call t_startf('CNDeposition')
+       !call CNNDeposition(bounds, &
+       !     atm2lnd_vars, nitrogenflux_vars)
+
        call CNNDeposition(bounds, &
-            atm2lnd_vars, nitrogenflux_vars)
+            atm2lnd_vars, nitrogenflux_vars, nitrogenstate_vars, &
+            frictionvel_vars, waterstate_vars, waterflux_vars, &
+            temperature_vars, soilstate_vars, filter_soilc, num_soilc)
+
        call t_stopf('CNDeposition')
 
        call t_startf('CNMResp')

--- a/components/clm/src/biogeochem/CNEcosystemDynMod.F90
+++ b/components/clm/src/biogeochem/CNEcosystemDynMod.F90
@@ -243,7 +243,7 @@ contains
        atm2lnd_vars, waterstate_vars, waterflux_vars,                   &
        canopystate_vars, soilstate_vars, temperature_vars, crop_vars,   &
        ch4_vars, photosyns_vars,                                        &
-       phosphorusflux_vars,phosphorusstate_vars)
+       phosphorusflux_vars,phosphorusstate_vars,frictionvel_vars)
     !-------------------------------------------------------------------
     ! bgc interface
     ! Phase-1 of CNEcosystemDynNoLeaching
@@ -323,6 +323,7 @@ contains
 !
     type(phosphorusflux_type)  , intent(inout) :: phosphorusflux_vars
     type(phosphorusstate_type) , intent(inout) :: phosphorusstate_vars
+    type(frictionvel_type)   , intent(in)    :: frictionvel_vars
 
     !-----------------------------------------------------------------------
 
@@ -367,8 +368,14 @@ contains
        ! --------------------------------------------------
 
        call t_startf('CNDeposition')
+       !call CNNDeposition(bounds, &
+       !     atm2lnd_vars, nitrogenflux_vars)
+
        call CNNDeposition(bounds, &
-            atm2lnd_vars, nitrogenflux_vars)
+            atm2lnd_vars, nitrogenflux_vars, nitrogenstate_vars, &
+            frictionvel_vars, waterstate_vars, waterflux_vars, &
+            temperature_vars, soilstate_vars, filter_soilc, num_soilc)
+       
        call t_stopf('CNDeposition')
 
        if (.not. nu_com_nfix) then 

--- a/components/clm/src/biogeochem/CNNDynamicsMod.F90
+++ b/components/clm/src/biogeochem/CNNDynamicsMod.F90
@@ -369,7 +369,7 @@ contains
        theta = min(theta, 0.98_r8*thetasat)
        infiltr_m_s = max(waterflux_vars%qflx_infl_col(c), 0.0) * 1e-3 
        evap_m_s = waterflux_vars%qflx_evap_grnd_col(c) * 1e-3
-       runoff_m_s = max(waterflux_vars%qflx_runoff_col(c), 0.0) * 1e-3
+       runoff_m_s = max(waterflux_vars%qflx_surf_col(c), 0.0) * 1e-3
 
        !
        ! grazing

--- a/components/clm/src/biogeochem/CNNDynamicsMod.F90
+++ b/components/clm/src/biogeochem/CNNDynamicsMod.F90
@@ -11,7 +11,7 @@ module CNNDynamicsMod
   use shr_kind_mod        , only : r8 => shr_kind_r8
   use decompMod           , only : bounds_type
   use clm_varcon          , only : dzsoi_decomp, zisoi
-  use clm_varctl          , only : use_nitrif_denitrif, use_vertsoilc
+  use clm_varctl          , only : use_nitrif_denitrif, use_vertsoilc, use_fan
   use subgridAveMod       , only : p2c
   use atm2lndType         , only : atm2lnd_type
   use CNCarbonFluxType    , only : carbonflux_type, nfix_timeconst
@@ -27,7 +27,8 @@ module CNNDynamicsMod
   use CNCarbonStateType   , only : carbonstate_type
   use TemperatureType     , only : temperature_type
   use PhosphorusStateType , only : phosphorusstate_type
-  
+  use FrictionVelocityType, only : frictionvel_type
+  use SoilStateType, only        : soilstate_type
   !
   implicit none
   save
@@ -51,6 +52,9 @@ module CNNDynamicsMod
   end type CNNDynamicsParamsType
   
   type(CNNDynamicsParamsType),private ::  CNNDynamicsParamsInst
+
+  logical, private, parameter :: debug_fan = .false.
+
   !-----------------------------------------------------------------------
 
 contains
@@ -114,7 +118,20 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine CNNDeposition( bounds, &
-       atm2lnd_vars, nitrogenflux_vars )
+       atm2lnd_vars, nitrogenflux_vars, nitrogenstate_vars, frictionvel_vars, waterstate_vars, waterflux_vars, temperature_vars, &
+       soilstate_vars, filter_soilc, num_soilc)
+    use GridcellType         , only: grc => grc_pp
+    use LandunitType         , only: lun => lun_pp
+    use ColumnType           , only : col => col_pp      
+    use VegetationType       , only : patch => veg_pp
+    use clm_varctl     , only : iulog
+    use FanMod
+    use abortutils     , only : endrun
+    use pftvarcon, only : nc4_grass, nc3_nonarctic_grass
+    use landunit_varcon,      only:  istsoil, istcrop
+    use clm_varcon, only : spval, ispval
+    use clm_time_manager     , only: get_step_size, get_curr_date, get_curr_calday, get_nstep
+
     !
     ! !DESCRIPTION:
     ! On the radiation time step, update the nitrogen deposition rate
@@ -127,25 +144,743 @@ contains
     type(bounds_type)        , intent(in)    :: bounds  
     type(atm2lnd_type)       , intent(in)    :: atm2lnd_vars
     type(nitrogenflux_type) , intent(inout) :: nitrogenflux_vars
+    type(nitrogenstate_type) , intent(inout) :: nitrogenstate_vars
+    type(frictionvel_type), intent(in) :: frictionvel_vars
+    type(waterstate_type)    , intent(in)    :: waterstate_vars
+    type(waterflux_type)     , intent(in)    :: waterflux_vars
+    type(temperature_type)  , intent(in) :: temperature_vars
+    type(soilstate_type), intent(in) :: soilstate_vars
+    integer                 , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    integer                  , intent(in)    :: num_soilc       ! number of soil columns in filter
+
     !
     ! !LOCAL VARIABLES:
     integer :: g,c                    ! indices
+    real(r8) :: dt
     !-----------------------------------------------------------------------
-    
+
     associate(& 
          forc_ndep     =>  atm2lnd_vars%forc_ndep_grc           , & ! Input:  [real(r8) (:)]  nitrogen deposition rate (gN/m2/s)                
          ndep_to_sminn =>  nitrogenflux_vars%ndep_to_sminn_col   & ! Output: [real(r8) (:)]                                                    
          )
-      
+
       ! Loop through columns
-      do c = bounds%begc, bounds%endc
-         g = col_pp%gridcell(c)
-         ndep_to_sminn(c) = forc_ndep(g)
-      end do
+    do c = bounds%begc, bounds%endc
+       g = col_pp%gridcell(c)
+       ndep_to_sminn(c) = forc_ndep(g)
+    end do
 
-    end associate
 
-  end subroutine CNNDeposition
+  end associate
+
+  if (use_fan) then
+     dt = real( get_step_size(), r8 )
+     call fan()
+  end if
+
+contains
+
+  subroutine fan()
+    integer, parameter :: num_substeps = 4, balance_check_freq = 1000
+    integer :: c, g, patchcounter, p, status, c1, c2, l, fc, ind_substep
+    real(r8) :: ndep_org(3), orgpools(3), tanprod(3), watertend, fluxes(6,3), tanpools3(3), ratm, tandep, &
+         fluxes2(6,2), fluxes3(6,3), fluxes4(6,4), tanpools2(2), tanpools4(4), fluxes_tmp(6), garbage_total
+    real(r8), parameter :: water_init_grz = 0.005_r8, cnc_nh3_air = 0.0_r8, depth_slurry = 0.005_r8
+    real(r8), parameter :: fract_resist=0.225_r8, fract_unavail=0.025_r8, fract_avail=0.25_r8, fract_tan=0.6_r8
+    real(r8), parameter :: dz_layer_fert = 0.02_r8, dz_layer_grz = 0.02_r8
+    !real(r8), parameter :: fract_resist=0._r8, fract_unavail=0._r8, fract_avail=0._r8, fract_tan=1.0_r8
+
+    real(r8), parameter :: slurry_infiltr_time = 12*3600.0_r8, water_init_fert = 1e-6
+    real(r8), parameter :: &
+         poolranges_grz(3) = (/24*3600.0_r8, 10*24*3600.0_r8, 360*24*3600.0_r8/), &
+         poolranges_fert(3) = (/2*24*3600.0_r8, 24*3600.0_r8, 360*24*3600.0_r8/), &
+         poolranges_slr(4) = (/slurry_infiltr_time, 24*3600.0_r8, 10*24*3600.0_r8, 360*24*3600.0_r8/), &
+                                !Hconc_grz(3) = (/10**(-8.5_r8), 10**(-8.0_r8), 10**(-7.0_r8)/), &
+         Hconc_fert(3) = (/10**(-7.0_r8), 10**(-8.5_r8), 10**(-8.0_r8)/)
+
+    real(r8) :: Hconc_grz(3), Hconc_slr(4), pH_soil, pH_crop
+
+    !logical, parameter :: do_balance_checks = .false.
+    logical :: do_balance_checks
+    real(r8) :: tg, garbage, theta, thetasat, infiltr_m_s, evap_m_s, runoff_m_s, org_n_tot, &
+         nstored_old, nsoilman_old, nsoilfert_old, fert_to_air, fert_to_soil, fert_total, fert_urea, fert_tan, &
+         soilflux_org, urea_resid
+    real(r8) :: tanprod_from_urea(3), ureapools(2), fert_no3, fert_generic
+    !real(r8), parameter :: fract_urea=0.545, fract_no3=0.048
+    real(r8) :: fract_urea, fract_no3, soilph_min, soilph_max
+    integer, parameter :: ind_region = 1
+    integer :: def_ph_count
+
+    Hconc_grz(1:2) = (/10**(-8.5_r8), 10**(-8.0_r8)/)
+    Hconc_slr(1:3) = (/10.0_r8**(-8.0_r8), 10.0_r8**(-8.0_r8), 10.0_r8**(-8.0_r8)/)
+    soilph_min = 999
+    soilph_max = -999
+    def_ph_count = 0
+    do_balance_checks = mod(get_nstep(), balance_check_freq) == 0
+
+    associate(&
+         ngrz => nitrogenflux_vars%man_n_grz_col, &
+         man_u_grz => nitrogenstate_vars%man_u_grz_col, &
+         man_a_grz => nitrogenstate_vars%man_a_grz_col, &
+         man_r_grz => nitrogenstate_vars%man_r_grz_col, &
+         man_u_app => nitrogenstate_vars%man_u_app_col, &
+         man_a_app => nitrogenstate_vars%man_a_app_col, &
+         man_r_app => nitrogenstate_vars%man_r_app_col, &
+         ns => nitrogenstate_vars, &
+         nf => nitrogenflux_vars, &
+         cnv_nf => nitrogenflux_vars, &
+         ram1 => frictionvel_vars%ram1_patch, &
+         rb1 => frictionvel_vars%rb1_patch)
+
+    nf%fert_n_appl_col(bounds%begc:bounds%endc) = 0.0
+    nf%man_n_appl_col(bounds%begc:bounds%endc) = 0.0
+    nf%man_tan_appl_col(bounds%begc:bounds%endc) = 0.0
+
+    call p2c(bounds, num_soilc, filter_soilc, &
+         cnv_nf%fert_patch(bounds%begp:bounds%endp), &
+         nf%fert_n_appl_col(bounds%begc:bounds%endc))
+    !call p2c(bounds, num_soilc, filter_soilc, &
+    !     cnv_nf%manu_patch(bounds%begp:bounds%endp), &
+    !     nf%man_n_appl_col(bounds%begc:bounds%endc))
+
+    nf%man_n_appl_col = 0.0
+
+    if (any(nf%man_n_appl_col > 100)) then
+       write(iulog, *) maxval(nf%man_n_appl_col)
+       call endrun('bad man_n_appl_col')
+    end if
+    if (do_balance_checks) then
+       nstored_old = get_total_n(ns, nf, 'pools_storage')
+       nsoilman_old = get_total_n(ns, nf, 'pools_manure')
+       nsoilfert_old = get_total_n(ns, nf, 'pools_fertilizer')
+    end if
+
+    ! Assign the "pastoral" manure entire to the natural vegetation column
+    do fc = 1, num_soilc
+       c = filter_soilc(fc)
+       l = col%landunit(c)
+       if (.not. (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop)) cycle
+       if (.not. col%active(c) .or. col%wtgcell(c) < 1e-6) cycle
+       g = col%gridcell(c)
+       if (lun%itype(l) == istsoil) then
+          ngrz(c) = atm2lnd_vars%forc_ndep3_grc(g) / col%wtgcell(c) * 1e3 ! kg to g 
+          if (debug_fan) then
+             if (ngrz(c) > 1e12 .or. (isnan(ngrz(c)))) then
+                write(iulog, *) 'bad ngrz', atm2lnd_vars%forc_ndep3_grc(g), col%wtgcell(c)
+                call endrun('bad ngrz 1')
+             end if
+          end if
+          if (nf%man_n_appl_col(c) > 0) then
+             write(iulog, *) nf%man_n_appl_col(c)
+             call endrun(msg='Found fertilizer in soil column')
+          end if
+       else
+          ngrz(c) = 0.0
+       end if
+
+    end do
+
+    if(debug_fan) then
+       write(iulog, *) 'nan count of storage 1', count(isnan(ns%man_n_stored_col))
+       if (any(isnan(nf%man_n_appl_col))) then
+          call endrun('nan nh3 appl b')
+       end if
+    end if
+
+    call handle_storage_v2(bounds, temperature_vars, frictionvel_vars, dt, &
+         atm2lnd_vars%forc_ndep2_grc, &
+         ns%man_n_stored_col, ns%man_tan_stored_col, &
+         nf%man_n_appl_col, nf%man_tan_appl_col, &
+         nf%man_n_grz_col, nf%man_n_mix_col, &
+         nf%nh3_stores_col, nf%nh3_barns_col, &
+         nf%man_n_transf_col, ns%fan_grz_fract_col, &
+         fract_tan, &
+         filter_soilc, num_soilc)
+
+    if (debug_fan) then
+       if (any(isnan(nf%nh3_stores_col))) then
+          call endrun('nan nh3 stores')
+       end if
+       if (any(isnan(nf%nh3_barns_col))) then
+          call endrun('nan nh3 barns')
+       end if
+       if (any(isnan(nf%man_n_appl_col))) then
+          call endrun('nan nh3 appl')
+       end if
+       if (any(isnan(nf%man_n_mix_col))) then
+          call endrun('nan nh3 appl')
+       end if
+    end if
+
+    do fc = 1, num_soilc
+       c = filter_soilc(fc)
+       l = col%landunit(c)
+       g = col%gridcell(c)
+       if (.not. (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop)) cycle
+       if (.not. col%active(c) .or. col%wtgcell(c) < 1e-15) cycle
+
+       if (nf%man_n_appl_col(c) > 1e12 .or. ngrz(c) > 1e12) then
+          write(iulog, *) c, nf%man_n_appl_col(c), ngrz(c), cnv_nf%fert_patch(col%pfti(c):col%pftf(c))
+          call endrun('nf%man_n_appl_col(c) is spval')
+       end if
+
+       ! Find and average the atmospheric resistances Rb and Ra.
+       ! 
+       if (lun%itype(col%landunit(c)) == istcrop) then
+          ! for column, only one patch
+          p = col%pfti(c)
+          if (p /= col%pftf(c)) call endrun(msg='Strange patch for crop')
+          ratm = ram1(p) + rb1(p)
+       else
+          ! if natural, find average over grasses
+          ratm = 0.0
+          patchcounter = 0
+          do p = col%pfti(c), col%pftf(c)
+             if (patch%itype(p) == nc4_grass .or. patch%itype(p) == nc3_nonarctic_grass) then
+                if (.not. patch%active(p) .or. ram1(p) == spval .or. rb1(p) == spval) cycle
+                ratm = ratm + ram1(p) + rb1(p)
+                patchcounter = patchcounter + 1
+             end if
+          end do
+          if (patchcounter > 0) then
+             ratm = ratm / patchcounter
+          else
+             ! grass not found, take something.
+             do p = col%pfti(c), col%pftf(c)
+                if (.not. patch%active(p) .or. ram1(p) == spval .or. rb1(p) == spval) cycle
+                ratm = ram1(p) + rb1(p)
+                exit
+             end do
+             if (p == col%pftf(c) + 1) then
+                ratm = 150.0_r8
+             end if
+          end if
+          ns%fan_grz_fract_col(c) = 1.0_r8 ! for crops handled by handle_storage
+       end if
+
+       ! Calculation of the water fluxes should include the background soil moisture
+       ! tendency. However, it is unclear how to do this in a numerically consistent
+       ! way. Following a naive finite differencing approach led to worse agreement in
+       ! stand-alone simulations so the term is currenltly neglected here.
+       watertend = 0.0_r8 
+       tg = temperature_vars%t_grnd_col(c)
+       theta = waterstate_vars%h2osoi_vol_col(c,1)
+       thetasat = soilstate_vars%watsat_col(c,1)
+       theta = min(theta, 0.98_r8*thetasat)
+       infiltr_m_s = max(waterflux_vars%qflx_infl_col(c), 0.0) * 1e-3 
+       evap_m_s = waterflux_vars%qflx_evap_grnd_col(c) * 1e-3
+       runoff_m_s = max(waterflux_vars%qflx_runoff_col(c), 0.0) * 1e-3
+
+       !
+       ! grazing
+       !
+
+       ndep_org(ind_avail) = ngrz(c) * fract_avail
+       ndep_org(ind_resist) = ngrz(c) * fract_resist
+       ndep_org(ind_unavail) = ngrz(c) * fract_unavail
+       tandep = ngrz(c) * fract_tan
+
+       orgpools(ind_avail) = man_a_grz(c)
+       orgpools(ind_resist) = man_r_grz(c)
+       orgpools(ind_unavail) = man_u_grz(c)
+       call update_org_n(ndep_org, tg, orgpools, dt, tanprod, soilflux_org)
+       man_a_grz(c) = orgpools(ind_avail)
+       man_r_grz(c) = orgpools(ind_resist) 
+       man_u_grz(c) = orgpools(ind_unavail)
+
+       tanpools3(1) = ns%tan_g1_col(c)
+       tanpools3(2) = ns%tan_g2_col(c)
+       tanpools3(3) = ns%tan_g3_col(c)
+       if (any(isnan(tanpools3))) then
+          call endrun('nan1')
+       end if
+
+       ph_soil = atm2lnd_vars%forc_soilph_grc(g)
+       if (ph_soil < 3.0) then
+          ph_soil = 6.5_r8
+          def_ph_count = def_ph_count + 1
+       end if
+       Hconc_grz(3) = 10**-(ph_soil)
+       soilph_max = max(soilph_max, ph_soil)
+       soilph_min = min(soilph_min, ph_soil)
+
+       fluxes_tmp = 0.0
+       garbage_total = 0.0
+       fluxes3 = 0.0
+       garbage = 0
+       do ind_substep = 1, num_substeps
+          call update_npool(tg, ratm, &
+               theta, thetasat, infiltr_m_s, evap_m_s, &
+               atm2lnd_vars%forc_q_downscaled_col(c), watertend, &
+               runoff_m_s, tandep, (/0.0_r8, 0.0_r8, sum(tanprod)/), water_init_grz, &
+               cnc_nh3_air, poolranges_grz, Hconc_grz, dz_layer_grz, tanpools3, &
+               fluxes3(1:5,:), garbage, dt/num_substeps, status, 3)
+          if (status /= 0) then
+             write(iulog, *) 'status = ', status, tanpools2, ratm, theta, thetasat, tandep, tanprod
+             call endrun(msg='update_npool status /= 0')
+          end if
+          if (debug_fan .and. any(isnan(tanpools2))) then
+             call endrun('nan2')
+          end if
+          fluxes_tmp = fluxes_tmp + sum(fluxes3, dim=2)
+          garbage_total = garbage_total + garbage
+       end do
+       fluxes_tmp = fluxes_tmp / num_substeps
+
+       ns%tan_g1_col(c) = tanpools3(1)
+       ns%tan_g2_col(c) = tanpools3(2)
+       ns%tan_g3_col(c) = tanpools3(3)
+       if (debug_fan .and. any(isnan(fluxes3))) then
+          write(iulog, *) fluxes3
+          call endrun('nan3')
+       end if
+
+       nf%nh3_grz_col(c) = fluxes_tmp(iflx_air)
+       nf%manure_runoff_col(c) = fluxes_tmp(iflx_roff)
+       nf%manure_no3_prod_col(c) = fluxes_tmp(iflx_no3)
+       nf%manure_nh4_to_soil_col(c) &
+            = fluxes_tmp(iflx_soild) + fluxes_tmp(iflx_soilq) + garbage_total / dt + soilflux_org
+
+       !
+       ! Manure application
+       !
+
+       org_n_tot = nf%man_n_appl_col(c) - nf%man_tan_appl_col(c)
+       ! Use the the same fractionation of organic N as for grazing, after removing the
+       ! "explicitly" calculated TAN.
+       if (1-fract_tan > 1e-6) then
+          ndep_org(ind_avail) = org_n_tot * fract_avail / (1-fract_tan)
+          ndep_org(ind_resist) = org_n_tot * fract_resist / (1-fract_tan)
+          ndep_org(ind_unavail) = org_n_tot * fract_unavail / (1-fract_tan)
+       else
+          ndep_org = 0.0
+       end if
+       tandep = nf%man_tan_appl_col(c)
+
+       orgpools(ind_avail) = man_a_app(c)
+       orgpools(ind_resist) = man_r_app(c)
+       orgpools(ind_unavail) = man_u_app(c)
+       call update_org_n(ndep_org, tg, orgpools, dt, tanprod, soilflux_org)
+       man_a_app(c) = orgpools(ind_avail)
+       man_r_app(c) = orgpools(ind_resist)
+       man_u_app(c) = orgpools(ind_unavail)
+       tanpools4(1) = ns%tan_s0_col(c)
+       tanpools4(2) = ns%tan_s1_col(c)
+       tanpools4(3) = ns%tan_s2_col(c)
+       tanpools4(4) = ns%tan_s3_col(c)
+
+       ph_crop = min(max(ph_soil, 5.5_r8), 7.5_r8)
+       Hconc_slr(4) = 10**-(ph_crop)
+
+       if (debug_fan .and. any(isnan(tanpools4))) then
+          call endrun('nan31')
+       end if
+
+       fluxes_tmp = 0.0
+       garbage_total = 0.0
+       fluxes4 = 0.0
+       do ind_substep = 1, num_substeps
+          if (debug_fan .and. any(abs(tanpools4) > 1e12)) then
+             write(iulog, *) ind_substep, tanpools4, tandep, nf%fert_n_appl_col(c), &
+                  nf%man_n_appl_col(c), ns%man_n_stored_col(c), ns%man_tan_stored_col(c)
+             call endrun('bad tanpools (manure app)')
+          end if
+
+          call update_4pool(tg, ratm, theta, thetasat, infiltr_m_s, evap_m_s, &
+               atm2lnd_vars%forc_q_downscaled_col(c), watertend, &
+               runoff_m_s, tandep, sum(tanprod), cnc_nh3_air, depth_slurry, &
+               poolranges_slr, tanpools4, Hconc_slr, fluxes4(1:5,:), garbage, dt / num_substeps, status)
+          if (status /= 0) then
+             write(iulog, *) 'status = ', status, tanpools4, tg, ratm, 'th', theta, &
+                  thetasat, tandep, 'tp', tanprod, 'fx', fluxes4
+             call endrun(msg='update_3pool status /= 0')
+          end if
+          fluxes_tmp = fluxes_tmp + sum(fluxes4, dim=2)
+          garbage_total = garbage_total + garbage
+       end do
+       fluxes_tmp = fluxes_tmp / num_substeps
+
+       ns%tan_s0_col(c) = tanpools4(1)
+       ns%tan_s1_col(c) = tanpools4(2)
+       ns%tan_s2_col(c) = tanpools4(3)
+       ns%tan_s3_col(c) = tanpools4(4)
+
+       if (debug_fan .and. any(isnan(fluxes4))) then
+          write(iulog, *) fluxes3, tanpools4,ratm, theta, thetasat, infiltr_m_s, tandep, tanprod
+          call endrun('nan4')
+       end if
+
+       nf%nh3_man_app_col(c) = fluxes_tmp(iflx_air)
+       nf%manure_runoff_col(c) = nf%manure_runoff_col(c) + fluxes_tmp(iflx_roff)
+       nf%manure_no3_prod_col(c) = nf%manure_no3_prod_col(c) + fluxes_tmp(iflx_no3)
+       nf%manure_nh4_to_soil_col(c) &
+            = nf%manure_nh4_to_soil_col(c) + fluxes_tmp(iflx_soild) + fluxes_tmp(iflx_soilq) &
+            + garbage_total / dt + soilflux_org
+
+       !
+       ! Fertilizer
+       !
+
+       fert_total = nf%fert_n_appl_col(c)
+       fract_urea = atm2lnd_vars%forc_ndep_urea_grc(g)
+       fract_no3 = atm2lnd_vars%forc_ndep_nitr_grc(g)
+
+       if (fract_urea < 0 .or. fract_no3 < 0 .or. fract_urea + fract_no3 > 1) then
+          call endrun('bad fertilizer fractions')
+       end if
+
+       fert_urea = fert_total * fract_urea
+       fert_no3 = fert_total * fract_no3
+       fert_generic = fert_total - fert_urea - fert_no3
+       nf%otherfert_n_appl_col(c) = fert_no3 + fert_generic
+
+       ! Urea decomposition 
+       ! 
+       ureapools(1) = ns%fert_u0_col(c)
+       ureapools(2) = ns%fert_u1_col(c)
+       fluxes2 = 0.0
+       call update_urea(tg, theta, thetasat, infiltr_m_s, evap_m_s, watertend, &
+            runoff_m_s, fert_urea, ureapools,  fluxes2, urea_resid, poolranges_fert(1:2), &
+            dt, status, numpools=2)
+       if (status /= 0) then
+          call endrun(msg='Bad status after update_urea for fertilizer')
+       end if
+       ! Nitrogen fluxes from urea pool. Be sure to not zero below!
+       fluxes_tmp = sum(fluxes2, dim=2)
+
+       ns%fert_u0_col(c) = ureapools(1)
+       ns%fert_u1_col(c) = ureapools(2)
+       ! Collect the formed ammonia for updating the TAN pools
+       tanprod_from_urea(1:2) = fluxes2(iflx_to_tan, 1:2)
+       tanprod_from_urea(2) = tanprod_from_urea(2)
+       ! There is no urea pool corresponding to tan_f2, because most of the urea will
+       ! have decomposed. Here whatever remains gets sent to tan_f2. 
+       tanprod_from_urea(3) = urea_resid / dt 
+
+       tanpools3(1) = ns%tan_f0_col(c)
+       tanpools3(2) = ns%tan_f1_col(c)
+       tanpools3(3) = ns%tan_f2_col(c)         
+       garbage_total = 0.0
+       fluxes3 = 0.0
+       nf%nh3_otherfert_col(c) = 0.0
+       do ind_substep = 1, num_substeps
+          ! Fertilizer pools f0...f2
+          call update_npool(tg, ratm, theta, thetasat, infiltr_m_s, evap_m_s, &
+               atm2lnd_vars%forc_q_downscaled_col(c), watertend, &
+               runoff_m_s, 0.0_r8, tanprod_from_urea, water_init_fert, cnc_nh3_air, &
+               poolranges_fert, Hconc_fert, dz_layer_fert, tanpools3, fluxes3(1:5,:), &
+               garbage, dt/num_substeps, status, numpools=3)
+          if (status /= 0) then
+             write(iulog, *) 'status:', status, tanpools3, nf%fert_n_appl_col(c)
+             call endrun(msg='Bad status after npool for fertilizer')
+          end if
+          fluxes_tmp = fluxes_tmp + sum(fluxes3, dim=2) / num_substeps
+          garbage_total = garbage_total + garbage
+
+          ! Fertilizer pool f3
+          call update_npool(tg, ratm, theta, thetasat, infiltr_m_s, evap_m_s, &
+               atm2lnd_vars%forc_q_downscaled_col(c), watertend, &
+               runoff_m_s, fert_generic, (/0.0_r8/), water_init_fert, cnc_nh3_air, &
+                                !(/360*24*3600.0_r8/), (/10**(-6.0_r8)/), dz_layer_fert, ns%tan_f3_col(c:c), fluxes3(1:5,1:1), &
+               (/360*24*3600.0_r8/), (/10**(-ph_crop)/), dz_layer_fert, ns%tan_f3_col(c:c), fluxes3(1:5,1:1), &
+               garbage, dt/num_substeps, status, numpools=1)
+          if (status /= 0) then
+             write(iulog, *) 'status:', status, tanpools3, nf%fert_n_appl_col(c)
+             call endrun(msg='Bad status after npool for generic')
+          end if
+          fluxes_tmp = fluxes_tmp + fluxes3(:, 1) / num_substeps
+          garbage_total = garbage_total + garbage
+          nf%nh3_otherfert_col(c) = nf%nh3_otherfert_col(c) + fluxes3(iflx_air, 1) / num_substeps
+       end do
+
+       ns%tan_f0_col(c) = tanpools3(1)
+       ns%tan_f1_col(c) = tanpools3(2)
+       ns%tan_f2_col(c) = tanpools3(3)
+       ! !!tan_f3_col already updated above by update_npool!!
+
+       nf%nh3_fert_col(c) = fluxes_tmp(iflx_air)
+       nf%fert_runoff_col(c) = fluxes_tmp(iflx_roff)
+       nf%fert_no3_prod_col(c) = fluxes_tmp(iflx_no3) + fert_no3
+       nf%fert_nh4_to_soil_col(c) = fluxes_tmp(iflx_soild) + fluxes_tmp(iflx_soilq) + garbage_total/dt 
+
+       ! Total flux
+       ! 
+       nf%nh3_total_col(c) = nf%nh3_fert_col(c) + nf%nh3_man_app_col(c) &
+            + nf%nh3_grz_col(c) + nf%nh3_stores_col(c) +  nf%nh3_barns_col(c)
+       if (nf%nh3_total_col(c) < -1e15) then
+          call endrun(msg='ERROR: FAN, negative total emission')
+       end if
+    end do
+
+    if (do_balance_checks) then
+       call balance_check('Storage', nstored_old, &
+            get_total_n(ns, nf, 'pools_storage'), get_total_n(ns, nf, 'fluxes_storage'))
+       call balance_check('Manure', nsoilman_old, &
+            get_total_n(ns, nf, 'pools_manure'), get_total_n(ns, nf, 'fluxes_manure'))
+       call balance_check('Fertilizer', nsoilfert_old, &
+            get_total_n(ns, nf, 'pools_fertilizer'), get_total_n(ns, nf, 'fluxes_fertilizer'))
+       write(iulog, *) 'SoilPH check:', soilph_min, soilph_max, def_ph_count
+    end if
+
+  end associate
+
+end subroutine fan
+
+real(r8) function get_total_n(ns, nf, which) result(total)
+  type(nitrogenstate_type), intent(in) :: ns
+  type(nitrogenflux_type), intent(in) :: nf
+  character(len=*), intent(in) :: which
+
+  total = 0
+
+  associate(soilc => filter_soilc(1:num_soilc))
+
+  select case(which)
+  case('pools_storage')
+     total = sum(ns%man_n_stored_col(soilc))
+
+  case('fluxes_storage')
+     total = sum(nf%man_n_mix_col(soilc))
+     total = total - sum(nf%nh3_stores_col(soilc))
+     total = total - sum(nf%nh3_barns_col(soilc)) - sum(nf%man_n_transf_col(soilc))
+
+  case('pools_manure')
+     total = total + sum(ns%tan_g1_col(soilc)) + sum(ns%tan_g2_col(soilc)) 
+     total = total + sum(ns%man_u_grz_col(soilc)) &
+          + sum(ns%man_a_grz_col(soilc)) + sum(ns%man_r_grz_col(soilc))
+     total = total + sum(ns%tan_s0_col(soilc)) &
+          + sum(ns%tan_s1_col(soilc)) + sum(ns%tan_s2_col(soilc))
+     total = total + sum(ns%man_u_app_col(soilc)) &
+          + sum(ns%man_a_app_col(soilc)) + sum(ns%man_r_app_col(soilc))
+
+  case('fluxes_manure')
+     total = sum(nf%man_n_grz_col(soilc)) + sum(nf%man_n_appl_col(soilc)) 
+     total = total - sum(nf%nh3_man_app_col(soilc)) &
+          - sum(nf%nh3_grz_col(soilc)) - sum(nf%manure_runoff_col(soilc))
+     total = total - sum(nf%manure_no3_prod_col(soilc)) - sum(nf%manure_nh4_to_soil_col(soilc))
+
+  case('pools_fertilizer')
+     total = sum(ns%tan_f0_col((soilc))) + sum(ns%tan_f1_col((soilc))) + sum(ns%tan_f2_col(soilc)) &
+          + sum(ns%tan_f3_col(soilc))
+     total = total + sum(ns%fert_u0_col(soilc)) + sum(ns%fert_u1_col(soilc))
+
+  case('fluxes_fertilizer')
+     total = sum(nf%fert_n_appl_col(soilc))
+     total = total - sum(nf%nh3_fert_col(soilc)) - sum(nf%fert_runoff_col(soilc))
+     total = total - sum(nf%fert_no3_prod_col(soilc)) - sum(nf%fert_nh4_to_soil_col(soilc))
+
+  case default
+     call endrun(msg='Bad argument to get_total_n')
+
+  end select
+
+end associate
+
+end function get_total_n
+
+subroutine balance_check(label, total_old, total_new, flux)
+  ! Check and report that the net flux equals the accumulated mass in pools. The
+  ! total pools and fluxes can be evaluated by the function get_total_n.
+character(len=*), intent(in) :: label
+real(r8), intent(in) :: total_old, total_new, flux
+
+real(r8) :: diff, accflux
+real(r8) :: tol = 1e-6_r8
+
+diff = total_new - total_old
+accflux = flux*dt
+write(iulog, *) 'Balance check:', label, diff, accflux
+
+end subroutine balance_check
+
+
+end subroutine CNNDeposition
+
+  subroutine handle_storage_v2(bounds, temperature_inst, frictionvel_inst, dt,  &
+       ndep_mixed_grc, n_stored_col, tan_stored_col, &
+       n_manure_spread_col, tan_manure_spread_col, &
+       n_manure_graze_col, n_manure_mixed_col, &
+       nh3_flux_stores, nh3_flux_barns, man_n_transf, &
+       grz_fract, tan_fract_excr, &
+       filter_soilc, num_soilc)
+    use landunit_varcon, only : max_lunit
+    use pftvarcon, only : nc4_grass, nc3_nonarctic_grass
+    use clm_varcon, only : ispval
+    use landunit_varcon,      only:  istsoil, istcrop
+    use abortutils     , only : endrun
+    use LandunitType   , only: lun => lun_pp
+    use GridcellType   , only: grc => grc_pp
+    use clm_varctl     , only : iulog
+    use ColumnType     , only : col => col_pp
+    use VegetationType       , only : patch => veg_pp
+    use FanMod
+    
+    implicit none
+    type(bounds_type), intent(in)    :: bounds
+    type(temperature_type) , intent(in) :: temperature_inst
+    type(frictionvel_type) , intent(in) :: frictionvel_inst
+    real(r8), intent(in) :: dt
+    
+    ! N excreted in manure, mixed/pastoral systems, gN/m2:
+    real(r8), intent(in) :: ndep_mixed_grc(bounds%begg:bounds%endg)
+    real(r8), intent(inout) :: n_stored_col(bounds%begc:bounds%endc), tan_stored_col(bounds%begc:bounds%endc) ! N, TAN currently stored, gN/m2
+    ! N, TAN spread on grasslands, gN/m2/s:
+    real(r8), intent(inout) :: n_manure_spread_col(bounds%begc:bounds%endc) ! for crops, input, determined by crop model, otherwise output
+    real(r8), intent(out) :: tan_manure_spread_col(bounds%begc:bounds%endc) ! output, calculated from the above and stored manure
+    ! N excreted by animals allocated to mixed production systems temporarily grazing on grasslands:
+    real(r8), intent(inout) :: n_manure_graze_col(bounds%begc:bounds%endc)
+    ! N excreted by animals in mixed systems, total
+    real(r8), intent(out) :: n_manure_mixed_col(bounds%begc:bounds%endc)
+    ! NH3 emission fluxes from manure storage and housings, gN/m2/s
+    real(r8), intent(out) :: nh3_flux_stores(bounds%begc:bounds%endc), nh3_flux_barns(bounds%begc:bounds%endc)
+    ! total nitrogen flux transferred out of a crop column
+    real(r8), intent(out) :: man_n_transf(bounds%begc:bounds%endc)
+    ! fraction of manure excreted when grazing
+    real(r8), intent(out) :: grz_fract(bounds%begc:bounds%endc)
+    ! TAN fraction in excreted N
+    real(r8), intent(in) :: tan_fract_excr
+    integer                  , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                  , intent(in)    :: filter_soilc(:) ! filter for soil columns
+
+    integer :: begg, endg, g, l, c, il, counter, col_grass, status, p
+    real(r8) :: flux_avail, flux_grazing
+    real(r8) :: tempr_ave, windspeed_ave ! windspeed and temperature averaged over agricultural patches
+    real(r8) :: tempr_barns, tempr_stores, vent_barns, flux_grass_crop, tempr_min_10day, &
+         flux_grass_graze, flux_grass_spread, flux_grass_spread_tan, flux_grass_crop_tan
+    real(r8) :: cumflux, totalinput
+    real(r8) :: fluxes_nitr(4), fluxes_tan(4)
+    ! The fraction of manure applied continuously on grasslands (if present in the gridcell)
+    real(r8), parameter :: fract_continuous = 0.1_r8, kg_to_g = 1e3_r8, max_grazing_fract = 0.3_r8, &
+         volat_coef_barns = 0.02_r8, volat_coef_stores = 0.02_r8, &
+         tempr_min_grazing = 283.0_r8!!!!
+
+    begg = bounds%begg; endg = bounds%endg
+    nh3_flux_stores(bounds%begc:bounds%endc) = 0_r8
+    nh3_flux_barns(bounds%begc:bounds%endc) = 0_r8
+
+    totalinput = 0.0
+    cumflux = 0.0
+    
+    do g = begg, endg
+       !totalinput = totalinput + ndep_mixed_grc(g)
+       
+       ! First find out if there are grasslands in this cell. If yes, a fraction of
+       ! manure can be diverted to them before storage.
+       col_grass = ispval
+       do il = 1, max_lunit
+          l = grc%landunit_indices(il, g)
+          if (lun%itype(l) == istsoil) then
+             do p = lun%pfti(l), lun%pftf(l)
+                if (patch%itype(p) == nc4_grass .or. patch%itype(p) == nc3_nonarctic_grass) then
+                   col_grass = patch%column(p)
+                   exit
+                end if
+             end do
+          end if
+          if (col_grass /= ispval) exit
+       end do
+       if (col%wtgcell(col_grass) < 1e-6) col_grass = ispval
+       ! Transfer of manure from all crop columns to the natural vegetation column:
+       flux_grass_graze = 0_r8
+       flux_grass_spread = 0_r8
+       flux_grass_spread_tan = 0_r8
+
+       do il = 1, max_lunit
+          l = grc%landunit_indices(il, g)
+          if (l == ispval) cycle
+          if (lun%itype(l) == istcrop) then
+             ! flux_avail = manure excreted per m2 of crops (ndep_mixed_grc = per m2 / all land units)
+             do c = lun%coli(l), lun%colf(l)
+                if (.not. col%active(c)) cycle
+                if (col%wtgcell(c) < 1e-6) cycle
+
+                if (col%landunit(c) /= l) then
+                   write(iulog, *) g, il, c, col%landunit(c)
+                   call endrun('something wrong')
+                end if
+                if (.not. any(c==filter_soilc(1:num_soilc))) then
+                   write(iulog, *) c, n_manure_spread_col(c)
+                   call endrun('column not in soilfilter')
+                end if
+
+                flux_avail = ndep_mixed_grc(g) * kg_to_g / lun%wtgcell(l)
+                if (flux_avail > 1e12 .or. isnan(flux_avail)) then
+                   write(iulog, *) 'bad flux_avail', ndep_mixed_grc(g), lun%wtgcell(l)
+                   call endrun('bad flux_avail')
+                end if
+                n_manure_mixed_col(c) = flux_avail
+                totalinput = totalinput + flux_avail
+
+                counter = 0
+                if (col_grass == c) call endrun('Something wrong with the indices')
+                if (col%pfti(c) /= col%pftf(c)) then
+                   call endrun(msg="ERROR crop column has multiple patches")
+                end if
+
+                tempr_ave = temperature_inst%t_ref2m_patch(col%pfti(c))
+                windspeed_ave = frictionvel_inst%u10_patch(col%pfti(c))
+
+                tempr_min_10day = temperature_inst%t_a10min_patch(col%pfti(c))
+                if (tempr_min_10day > tempr_min_grazing) then
+                   ! fraction of animals grazing -> allocate some manure to grasslands before barns
+                   flux_grazing = max_grazing_fract * flux_avail
+                   flux_avail = flux_avail - flux_grazing
+                   grz_fract(c) = max_grazing_fract
+                else
+                   flux_grazing = 0
+                   grz_fract(c) = 0
+                end if
+                flux_grass_graze = flux_grass_graze + flux_grazing*col%wtgcell(c)
+
+                call eval_fluxes_storage(flux_avail, tempr_ave, windspeed_ave, 0.0_r8, &
+                     volat_coef_barns, volat_coef_stores, tan_fract_excr, fluxes_nitr, fluxes_tan, status)
+                if (any(fluxes_nitr > 1e12)) then
+                   write(iulog, *) 'bad fluxes', fluxes_nitr
+                end if
+                if (status /=0) then 
+                   write(iulog, *) 'status = ', status
+                   call endrun(msg='eval_fluxes_storage failed')
+                end if
+                cumflux = cumflux + sum(fluxes_nitr)
+                
+                if (fluxes_tan(iflx_to_store) < 0) then
+                   call endrun(msg="ERROR too much manure lost")
+                end if
+
+                flux_grass_spread = flux_grass_spread + fluxes_nitr(iflx_to_store)*col%wtgcell(c)
+                flux_grass_spread_tan = flux_grass_spread_tan + fluxes_tan(iflx_to_store)*col%wtgcell(c)
+
+                man_n_transf(c) = flux_grazing + fluxes_nitr(iflx_to_store)
+                
+                nh3_flux_stores(c) = fluxes_nitr(iflx_air_stores)
+                nh3_flux_barns(c) = fluxes_nitr(iflx_air_barns)
+                
+             end do ! column
+          end if ! crop land unit
+       end do ! landunit
+
+       if (col_grass /= ispval) then
+          if (tan_manure_spread_col(col_grass) > 1) then
+             write(iulog, *) 'bad tan_manure col_grass before adding', n_manure_spread_col(col_grass), &
+                  tan_manure_spread_col(col_grass)
+          end if
+          n_manure_spread_col(col_grass) = n_manure_spread_col(col_grass) &
+               + flux_grass_spread / col%wtgcell(col_grass)
+          tan_manure_spread_col(col_grass) = tan_manure_spread_col(col_grass) &
+               + flux_grass_spread_tan / col%wtgcell(col_grass)
+          n_manure_graze_col(col_grass) = n_manure_graze_col(col_grass) + flux_grass_graze / col%wtgcell(col_grass)
+          !write(iulog, *) 'to grass:', n_manure_spread(col_grass), col_grass
+          if (tan_manure_spread_col(col_grass) > 1) then
+             write(iulog, *) 'bad tan_manure col_grass', flux_grass_spread_tan, col%wtgcell(col_grass)
+          end if
+       else if (flux_grass_spread > 0) then
+          call endrun('Cannot spread manure')
+       end if
+
+    end do ! grid
+
+  end subroutine handle_storage_v2
+
 
   !-----------------------------------------------------------------------
   subroutine CNNFixation(num_soilc, filter_soilc, waterflux_vars, &

--- a/components/clm/src/biogeochem/CNNitrogenFluxType.F90
+++ b/components/clm/src/biogeochem/CNNitrogenFluxType.F90
@@ -7,7 +7,7 @@ module CNNitrogenFluxType
   use clm_varpar             , only : nlevdecomp_full, nlevdecomp, crop_prog
   use clm_varcon             , only : spval, ispval, dzsoi_decomp
   use decompMod              , only : bounds_type
-  use clm_varctl             , only : use_nitrif_denitrif, use_vertsoilc
+  use clm_varctl             , only : use_nitrif_denitrif, use_vertsoilc, use_fan
   use CNDecompCascadeConType , only : decomp_cascade_con
   use abortutils             , only : endrun
   use LandunitType           , only : lun_pp                
@@ -391,6 +391,32 @@ module CNNitrogenFluxType
      real(r8), pointer :: plant_to_cwd_nflux                        (:)     ! for the purpose of mass balance check
      real(r8), pointer :: supplement_to_plantn                      (:)     ! supplementary N flux for plant
 
+     !JV FAN fluxes
+
+     real(r8), pointer :: man_tan_appl_col                           (:)   ! Manure TAN applied on soil (gN/m2/s)
+     real(r8), pointer :: man_n_appl_col                             (:)   ! Manure N (TAN+organic) applied on soil (gN/m2/s)
+     real(r8), pointer :: man_n_grz_col                              (:)   ! Manure N from grazing animals (gN/m2/s)
+     real(r8), pointer :: man_n_mix_col                              (:)   ! Manure N from produced in mixed systems (gN/m2/s)
+     real(r8), pointer :: fert_n_appl_col                            (:)   ! Fertilizer N  applied on soil (gN/m2/s)
+     real(r8), pointer :: otherfert_n_appl_col                       (:)   ! Non-urea fertilizer N  applied on soil (gN/m2/s)
+     real(r8), pointer :: man_n_transf_col                           (:)   ! Manure N removed from the crop column (into the natural veg. column in the gcell) 
+     
+     real(r8), pointer :: nh3_barns_col                              (:)   ! NH3 emission from animal housings (gN/m2/s
+     real(r8), pointer :: nh3_stores_col                             (:)   ! NH3 emission from manure storage, (gN/m2/s
+     real(r8), pointer :: nh3_grz_col                                (:)   ! NH3 emission from manure on pastures, (gN/m2/s
+     real(r8), pointer :: nh3_man_app_col                            (:)   ! NH3 emission from manure applied on crops and grasslands, (gN/m2/s
+     real(r8), pointer :: nh3_fert_col                               (:)   ! NH3 emission from fertilizers applied on crops and grasslands, (gN/m2/s
+     real(r8), pointer :: nh3_otherfert_col                          (:)   ! NH3 emission from non-urea fertilizers applied on crops and grasslands, (gN/m2/s
+     real(r8), pointer :: manure_no3_prod_col                        (:)   ! Nitrification flux from manure (gN/m2/s)  
+     real(r8), pointer :: fert_no3_prod_col                          (:)   ! Nitrification flux from fertilizer (gN/m2/s)
+     real(r8), pointer :: manure_nh4_to_soil_col                     (:)   ! NH4 flux to soil mineral N pools from manure (gN/m2/s)
+     real(r8), pointer :: fert_nh4_to_soil_col                       (:)   ! NH4 flux to soil mineral N pools from fertilizer (gN/m2/s)
+     real(r8), pointer :: manure_runoff_col                          (:)   ! NH4 runoff flux from manure, gN/m2/s
+     real(r8), pointer :: fert_runoff_col                            (:)   ! NH4 runoff flux from fertilizer, gN/m2/s
+
+     real(r8), pointer :: nh3_total_col                              (:)   ! Total NH3 emission from agriculture
+
+     
    contains
 
      procedure , public  :: Init   
@@ -801,7 +827,32 @@ contains
     allocate(this%plant_to_litter_nflux       (begc:endc)) ;             this%plant_to_litter_nflux (:)   = nan
     allocate(this%plant_to_cwd_nflux          (begc:endc)) ;             this%plant_to_cwd_nflux    (:)   = nan
     allocate(this%supplement_to_plantn        (begp:endp)) ;             this%supplement_to_plantn  (:)   = 0.d0
-    
+
+    if (use_fan) then
+       allocate(this%man_tan_appl_col               (begc:endc))                   ; this%man_tan_appl_col           (:)   = spval
+       allocate(this%man_n_appl_col                 (begc:endc))                   ; this%man_n_appl_col             (:)   = spval
+       allocate(this%man_n_grz_col                  (begc:endc))                   ; this%man_n_grz_col              (:)   = spval
+       allocate(this%man_n_mix_col                  (begc:endc))                   ; this%man_n_mix_col              (:)   = spval
+       allocate(this%fert_n_appl_col                (begc:endc))                   ; this%fert_n_appl_col            (:)   = spval
+       allocate(this%otherfert_n_appl_col           (begc:endc))                   ; this%otherfert_n_appl_col       (:)   = spval
+       allocate(this%man_n_transf_col               (begc:endc))                   ; this%man_n_transf_col           (:)   = spval
+
+       allocate(this%nh3_barns_col                  (begc:endc))                   ; this%nh3_barns_col              (:)   = spval
+       allocate(this%nh3_stores_col                 (begc:endc))                   ; this%nh3_stores_col             (:)   = spval
+       allocate(this%nh3_grz_col                    (begc:endc))                   ; this%nh3_grz_col                (:)   = spval
+       allocate(this%nh3_man_app_col                (begc:endc))                   ; this%nh3_man_app_col            (:)   = spval
+       allocate(this%nh3_fert_col                   (begc:endc))                   ; this%nh3_fert_col               (:)   = spval
+       allocate(this%nh3_otherfert_col              (begc:endc))                   ; this%nh3_otherfert_col          (:)   = spval
+       allocate(this%nh3_total_col                  (begc:endc))                   ; this%nh3_total_col              (:)   = spval
+
+       allocate(this%manure_no3_prod_col            (begc:endc))                   ; this%manure_no3_prod_col        (:)   = spval
+       allocate(this%fert_no3_prod_col              (begc:endc))                   ; this%fert_no3_prod_col          (:)   = spval
+       allocate(this%manure_nh4_to_soil_col         (begc:endc))                   ; this%manure_nh4_to_soil_col     (:)   = spval
+       allocate(this%fert_nh4_to_soil_col           (begc:endc))                   ; this%fert_nh4_to_soil_col       (:)   = spval
+       allocate(this%manure_runoff_col              (begc:endc))                   ; this%manure_runoff_col          (:)   = spval
+       allocate(this%fert_runoff_col                (begc:endc))                   ; this%fert_runoff_col            (:)   = spval
+    end if
+
   end subroutine InitAllocate
 
   !------------------------------------------------------------------------
@@ -2022,6 +2073,110 @@ contains
                ptr_col=this%plant_ndemand_vr_col, default='inactive')
     end if ! if (use_pflotran.and.pf_cmode)
     !-----------------------------------------------------------
+    if (use_fan) then
+       this%man_tan_appl_col(begc:endc) = spval
+       call hist_addfld1d( fname='MAN_TAN_APP', units='gN/m^2/s', &
+            avgflag='A', long_name='Manure TAN applied on soil', &
+            ptr_col=this%man_tan_appl_col)
+
+       this%man_n_appl_col(begc:endc) = spval
+       call hist_addfld1d( fname='MAN_N_APP', units='gN/m^2/s', &
+            avgflag='A', long_name='Manure N applied on soil', &
+            ptr_col=this%man_n_appl_col)
+
+       this%man_n_grz_col(begc:endc) = spval
+       call hist_addfld1d( fname='MAN_N_GRZ', units='gN/m^2/s', &
+            avgflag='A', long_name='Manure N from grazing animals', &
+            ptr_col=this%man_n_grz_col)
+
+       this%man_n_mix_col(begc:endc) = spval
+       call hist_addfld1d( fname='MAN_N_MIX', units='gN/m^2/s', &
+            avgflag='A', long_name='Manure N in produced mixed systems', &
+            ptr_col=this%man_n_mix_col)
+
+       this%fert_n_appl_col(begc:endc) = spval
+       call hist_addfld1d( fname='FERT_N_APP', units='gN/m^2/s', &
+            avgflag='A', long_name='Fertilizer N applied on soil', &
+            ptr_col=this%fert_n_appl_col)
+
+       this%otherfert_n_appl_col(begc:endc) = spval
+       call hist_addfld1d( fname='OTHERFERT_N_APP', units='gN/m^2/s', &
+            avgflag='A', long_name='Non-urea fertilizer N applied on soil', &
+            ptr_col=this%otherfert_n_appl_col)
+
+       this%man_n_transf_col(begc:endc) = spval
+       call hist_addfld1d( fname='MAN_N_TRANSF', units='gN/m^2/s', &
+            avgflag='A', long_name='Manure N moved from crop to natural column', &
+            ptr_col=this%man_n_transf_col)
+
+       this%nh3_barns_col(begc:endc) = spval
+       call hist_addfld1d( fname='NH3_BARNS', units='gN/m^2/s', &
+            avgflag='A', long_name='NH3 emitted from animal housings', &
+            ptr_col=this%nh3_barns_col)
+
+       this%nh3_stores_col(begc:endc) = spval
+       call hist_addfld1d( fname='NH3_STORES', units='gN/m^2/s', &
+            avgflag='A', long_name='NH3 emitted from stored manure', &
+            ptr_col=this%nh3_stores_col)
+
+       this%nh3_grz_col(begc:endc) = spval
+       call hist_addfld1d( fname='NH3_GRZ', units='gN/m^2/s', &
+            avgflag='A', long_name='NH3 emitted from manure on pastures', &
+            ptr_col=this%nh3_grz_col)
+
+       this%nh3_man_app_col(begc:endc) = spval
+       call hist_addfld1d( fname='NH3_MAN_APP', units='gN/m^2/s', &
+            avgflag='A', long_name='NH3 emitted from manure applied on crops and grasslands', &
+            ptr_col=this%nh3_man_app_col)
+
+       this%nh3_fert_col(begc:endc) = spval
+       call hist_addfld1d( fname='NH3_FERT', units='gN/m^2/s', &
+            avgflag='A', long_name='NH3 emitted from fertilizer applied on crops', &
+            ptr_col=this%nh3_fert_col)
+
+       this%nh3_otherfert_col(begc:endc) = spval
+       call hist_addfld1d( fname='NH3_OTHERFERT', units='gN/m^2/s', &
+            avgflag='A', long_name='NH3 emitted from fertilizers other than urea', &
+            ptr_col=this%nh3_otherfert_col)
+
+
+       this%nh3_total_col(begc:endc) = spval
+       call hist_addfld1d( fname='NH3_TOTAL', units='gN/m^2/s', &
+            avgflag='A', long_name='Total NH3 emitted from fertilizers and manure', &
+            ptr_col=this%nh3_total_col)
+
+
+       this%manure_no3_prod_col(begc:endc) = spval
+       call hist_addfld1d( fname='MANURE_NO3_PROD', units='gN/m^2/s', &
+            avgflag='A', long_name='Manure nitrification flux', &
+            ptr_col=this%manure_no3_prod_col)
+
+       this%fert_no3_prod_col(begc:endc) = spval
+       call hist_addfld1d( fname='FERT_NO3_PROD', units='gN/m^2/s', &
+            avgflag='A', long_name='Fertilizer nitrification flux', &
+            ptr_col=this%fert_no3_prod_col)
+
+       this%fert_nh4_to_soil_col(begc:endc) = spval
+       call hist_addfld1d( fname='FERT_NH4_TO_SOIL', units='gN/m^2/s', &
+            avgflag='A', long_name='Flux of NH4 to soil mineral pools, fertilizer', &
+            ptr_col=this%fert_nh4_to_soil_col)
+
+       this%manure_nh4_to_soil_col(begc:endc) = spval
+       call hist_addfld1d( fname='MANURE_NH3_TO_SOIL', units='gN/m^2/s', &
+            avgflag='A', long_name='Flux of NH4 to soil mineral pools, manure', &
+            ptr_col=this%manure_nh4_to_soil_col)
+
+
+       this%manure_runoff_col(begc:endc) = spval
+       call hist_addfld1d( fname='MANURE_RUNOFF', units='gN/m^2/s', &
+            avgflag='A', long_name='NH4 in surface runoff, manure', &
+            ptr_col=this%manure_runoff_col)
+
+       this%fert_runoff_col(begc:endc) = spval
+       call hist_addfld1d( fname='FERT_RUNOFF', units='gN/m^2/s', &
+            avgflag='A', long_name='NH4 in surface runoff, fertilizer', &
+            ptr_col=this%fert_runoff_col)
+    end if
   end subroutine InitHistory
 
   !-----------------------------------------------------------------------
@@ -2471,6 +2626,32 @@ contains
        end do
     end if
 
+    if ( use_fan ) then
+       do fi = 1,num_column
+          i = filter_column(fi)
+          this%man_tan_appl_col(i)       = value_column
+          this%man_n_appl_col(i)         = value_column
+          this%man_n_grz_col(i)          = value_column
+          this%man_n_mix_col(i)          = value_column
+          this%fert_n_appl_col(i)        = value_column
+          this%otherfert_n_appl_col(i)   = value_column
+          this%man_n_transf_col(i)       = value_column
+          this%nh3_barns_col(i)          = value_column
+          this%nh3_stores_col(i)         = value_column
+          this%nh3_grz_col(i)            = value_column
+          this%nh3_man_app_col(i)        = value_column
+          this%nh3_fert_col(i)           = value_column
+          this%nh3_otherfert_col(i)      = value_column
+          this%nh3_total_col(i)          = value_column
+          this%manure_no3_prod_col(i)    = value_column
+          this%fert_no3_prod_col(i)      = value_column
+          this%manure_nh4_to_soil_col(i) = value_column
+          this%fert_nh4_to_soil_col(i)   = value_column
+          this%manure_runoff_col(i)      = value_column
+          this%fert_runoff_col(i)        = value_column
+       end do
+    end if
+    
     do j = 1, nlevdecomp_full
        do fi = 1,num_column
           i = filter_column(fi)

--- a/components/clm/src/biogeochem/CNNitrogenStateType.F90
+++ b/components/clm/src/biogeochem/CNNitrogenStateType.F90
@@ -9,7 +9,7 @@ module CNNitrogenStateType
   use clm_varpar             , only : nlevdecomp_full, nlevdecomp, crop_prog
   use clm_varcon             , only : spval, ispval, dzsoi_decomp, zisoi
   use landunit_varcon        , only : istcrop, istsoil 
-  use clm_varctl             , only : use_nitrif_denitrif, use_vertsoilc, use_century_decomp
+  use clm_varctl             , only : use_nitrif_denitrif, use_vertsoilc, use_century_decomp, use_fan
   use clm_varctl             , only : iulog, override_bgc_restart_mismatch_dump, spinup_state
   use decompMod              , only : bounds_type
   use pftvarcon              , only : npcropmin, nstor
@@ -182,6 +182,36 @@ module CNNitrogenStateType
      real(r8), pointer :: plmr_ptlai_z                              (:,:)
      real(r8), pointer :: plmr_pleafn_z                             (:,:)
 
+     !JV, FAN
+     real(r8), pointer :: tan_g1_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool G1
+     real(r8), pointer :: tan_g2_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool G2
+     real(r8), pointer :: tan_g3_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool G2
+     
+     real(r8), pointer :: tan_s0_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool S0
+     real(r8), pointer :: tan_s1_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool S1
+     real(r8), pointer :: tan_s2_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool S2
+     real(r8), pointer :: tan_s3_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool S2
+
+     real(r8), pointer :: tan_f0_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool F0
+     real(r8), pointer :: tan_f1_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool F1
+     real(r8), pointer :: tan_f2_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool F2
+     real(r8), pointer :: tan_f3_col(:)                        ! col (gN/m2) total ammoniacal N in FAN pool F3
+     
+     real(r8), pointer :: fert_u0_col(:)                      ! col (gN/m2) total urea N in FAN pool U0
+     real(r8), pointer :: fert_u1_col(:)                      ! col (gN/m2) total urea N in FAN pool U1
+     
+     real(r8), pointer :: man_u_grz_col(:)                     ! col (gN/m2) unavailable organic N, grazing
+     real(r8), pointer :: man_a_grz_col(:)                     ! col (gN/m2) available organic N, grazing
+     real(r8), pointer :: man_r_grz_col(:)                     ! col (gN/m2) resistant organic N, grazing
+
+     real(r8), pointer :: man_u_app_col(:)                     ! col (gN/m2) unavailable organic N, application
+     real(r8), pointer :: man_a_app_col(:)                     ! col (gN/m2) available organic N, application
+     real(r8), pointer :: man_r_app_col(:)                     ! col (gN/m2) resistant organic N, application
+
+     real(r8), pointer :: man_n_stored_col(:)                  ! col (gN/m2) manure N in storage
+     real(r8), pointer :: man_tan_stored_col(:)                ! col (gN/m2) manure TAN in storage
+     real(r8), pointer :: fan_grz_fract_col(:)                 ! col unitless fraction of animals grazing
+     
    contains
 
      procedure , public  :: Init   
@@ -370,6 +400,36 @@ contains
 
     allocate(this%plant_nbuffer_col(begc:endc));this%plant_nbuffer_col(:) = nan
 
+    if (use_fan) then
+       allocate(this%tan_g1_col(begc:endc)) ; this%tan_g1_col(:) = nan
+       allocate(this%tan_g2_col(begc:endc)) ; this%tan_g2_col(:) = nan
+       allocate(this%tan_g3_col(begc:endc)) ; this%tan_g3_col(:) = nan
+       allocate(this%tan_s0_col(begc:endc)) ; this%tan_s0_col(:) = nan
+       allocate(this%tan_s1_col(begc:endc)) ; this%tan_s1_col(:) = nan
+       allocate(this%tan_s2_col(begc:endc)) ; this%tan_s2_col(:) = nan
+       allocate(this%tan_s3_col(begc:endc)) ; this%tan_s3_col(:) = nan
+       allocate(this%tan_f0_col(begc:endc)) ; this%tan_f0_col(:) = nan
+       allocate(this%tan_f1_col(begc:endc)) ; this%tan_f1_col(:) = nan
+       allocate(this%tan_f2_col(begc:endc)) ; this%tan_f2_col(:) = nan
+       allocate(this%tan_f3_col(begc:endc)) ; this%tan_f3_col(:) = nan
+       allocate(this%fert_u0_col(begc:endc)) ; this%fert_u0_col(:) = nan
+       allocate(this%fert_u1_col(begc:endc)) ; this%fert_u1_col(:) = nan
+
+       allocate(this%man_u_grz_col(begc:endc)) ; this%man_u_grz_col(:) = nan
+       allocate(this%man_a_grz_col(begc:endc)) ; this%man_a_grz_col(:) = nan
+       allocate(this%man_r_grz_col(begc:endc)) ; this%man_r_grz_col(:) = nan
+
+       allocate(this%man_u_app_col(begc:endc)) ; this%man_u_app_col(:) = nan
+       allocate(this%man_a_app_col(begc:endc)) ; this%man_a_app_col(:) = nan
+       allocate(this%man_r_app_col(begc:endc)) ; this%man_r_app_col(:) = nan
+
+       allocate(this%man_n_stored_col(begc:endc)) ; this%man_n_stored_col(:) = nan
+       allocate(this%man_tan_stored_col(begc:endc)) ; this%man_tan_stored_col(:) = nan
+       allocate(this%fan_grz_fract_col(begc:endc)) ; this%fan_grz_fract_col(:) = nan
+
+    end if
+
+    
   end subroutine InitAllocate
 
   !------------------------------------------------------------------------
@@ -713,6 +773,122 @@ contains
          avgflag='A', long_name='total wood product N', &
          ptr_col=this%totprodn_col, default='inactive')
 
+    !JV
+    if (use_fan) then
+       this%tan_g1_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_G1', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool G1', &
+            ptr_col=this%tan_g1_col)
+
+       this%tan_g2_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_G2', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool G2', &
+            ptr_col=this%tan_g2_col)
+
+       this%tan_g3_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_G3', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool G3', &
+            ptr_col=this%tan_g3_col)
+       
+       this%tan_f0_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_F0', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool F0', &
+            ptr_col=this%tan_f0_col)
+
+       this%tan_f1_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_F1', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool F1', &
+            ptr_col=this%tan_f1_col)
+
+       this%tan_f2_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_F2', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool F2', &
+            ptr_col=this%tan_f2_col)
+
+       this%tan_f3_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_F3', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool F3', &
+            ptr_col=this%tan_f3_col)
+
+       this%tan_f0_col(begc:endc) = spval
+       call hist_addfld1d (fname='FERT_U0', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool F0', &
+            ptr_col=this%fert_u0_col)
+
+       this%tan_f1_col(begc:endc) = spval
+       call hist_addfld1d (fname='FERT_U1', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool F1', &
+            ptr_col=this%fert_u1_col)
+
+       
+       this%tan_s0_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_S0', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool S0', &
+            ptr_col=this%tan_s0_col)
+
+       this%tan_s1_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_S1', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool S1', &
+            ptr_col=this%tan_s1_col)
+
+       this%tan_s2_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_S2', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool S2', &
+            ptr_col=this%tan_s2_col)
+
+       this%tan_s3_col(begc:endc) = spval
+       call hist_addfld1d (fname='TAN_S3', units='gN/m^2', &
+            avgflag='A', long_name='Total ammoniacal nitrogen in FAN pool S3', &
+            ptr_col=this%tan_s3_col)
+
+
+       this%man_u_grz_col(begc:endc) = spval
+       call hist_addfld1d (fname='MAN_U_GRZ', units='gN/m^2', &
+            avgflag='A', long_name='Unavailable manure nitrogen, grazing', &
+            ptr_col=this%man_u_grz_col)
+
+       this%man_a_grz_col(begc:endc) = spval
+       call hist_addfld1d (fname='MAN_A_GRZ', units='gN/m^2', &
+            avgflag='A', long_name='Available manure nitrogen, grazing', &
+            ptr_col=this%man_a_grz_col)
+       
+       this%man_r_grz_col(begc:endc) = spval
+       call hist_addfld1d (fname='MAN_R_GRZ', units='gN/m^2', &
+            avgflag='A', long_name='Resistant manure nitrogen, grazing', &
+            ptr_col=this%man_r_grz_col)
+
+       this%man_u_grz_col(begc:endc) = spval
+       call hist_addfld1d (fname='MAN_U_APP', units='gN/m^2', &
+            avgflag='A', long_name='Unavailable manure nitrogen, application', &
+            ptr_col=this%man_u_app_col)
+
+       this%man_a_app_col(begc:endc) = spval
+       call hist_addfld1d (fname='MAN_A_APP', units='gN/m^2', &
+            avgflag='A', long_name='Available manure nitrogen, application', &
+            ptr_col=this%man_a_app_col)
+       
+       this%man_r_app_col(begc:endc) = spval
+       call hist_addfld1d (fname='MAN_R_APP', units='gN/m^2', &
+            avgflag='A', long_name='Resistant manure nitrogen, application', &
+            ptr_col=this%man_r_app_col)
+
+       this%man_n_stored_col(begc:endc) = spval
+       call hist_addfld1d (fname='MAN_N_STORED', units='gN/m^2', &
+            avgflag='A', long_name='Manure nitrogen in storage', &
+            ptr_col=this%man_n_stored_col)
+       
+       this%man_tan_stored_col(begc:endc) = spval
+       call hist_addfld1d (fname='MAN_TAN_STORED', units='gN/m^2', &
+            avgflag='A', long_name='Manure ammoniacal nitrogen in storage', &
+            ptr_col=this%man_tan_stored_col)
+
+       this%fan_grz_fract_col(begc:endc) = spval
+       call hist_addfld1d (fname='FAN_GRZ_FRACT', units='', &
+            avgflag='A', long_name='Fraction of animals grazing', &
+            ptr_col=this%fan_grz_fract_col)
+    end if
+    
+    
   end subroutine InitHistory
 
   !-----------------------------------------------------------------------
@@ -912,6 +1088,36 @@ contains
           this%prod100n_col(c)      = 0._r8
           this%totprodn_col(c)      = 0._r8
        end if
+
+       if ( use_fan ) then
+          !JV
+          this%tan_g1_col(c) = 0.0_r8
+          this%tan_g2_col(c) = 0.0_r8
+          this%tan_g3_col(c) = 0.0_r8
+          this%tan_s0_col(c) = 0.0_r8
+          this%tan_s1_col(c) = 0.0_r8
+          this%tan_s2_col(c) = 0.0_r8
+          this%tan_s3_col(c) = 0.0_r8
+          this%tan_f0_col(c) = 0.0_r8
+          this%tan_f1_col(c) = 0.0_r8
+          this%tan_f2_col(c) = 0.0_r8
+          this%tan_f3_col(c) = 0.0_r8
+          this%fert_u1_col(c) = 0.0_r8
+          this%fert_u0_col(c) = 0.0_r8
+          
+          this%man_u_grz_col(c) = 0.0_r8
+          this%man_a_grz_col(c) = 0.0_r8
+          this%man_r_grz_col(c) = 0.0_r8
+          
+          this%man_u_app_col(c) = 0.0_r8
+          this%man_a_app_col(c) = 0.0_r8
+          this%man_r_app_col(c) = 0.0_r8
+          
+          this%man_tan_stored_col(c) = 0.0_r8
+          this%fan_grz_fract_col(c) = 0.0_r8
+          this%man_n_stored_col(c) = 0.0_r8
+          
+       end if
     end do
 
     ! now loop through special filters and explicitly set the variables that
@@ -1077,6 +1283,82 @@ contains
             interpinic_flag='interp', readvar=readvar, data=this%grainn_xfer_patch)
     end if
     
+    !JV
+    if (use_fan) then
+       call restartvar(ncid=ncid, flag=flag, varname='tan_g1', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_g1_col)
+       call restartvar(ncid=ncid, flag=flag, varname='tan_g2', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_g2_col)
+       call restartvar(ncid=ncid, flag=flag, varname='tan_g3', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_g3_col)
+
+       call restartvar(ncid=ncid, flag=flag, varname='tan_s0', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_s0_col)
+       call restartvar(ncid=ncid, flag=flag, varname='tan_s1', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_s1_col)
+       call restartvar(ncid=ncid, flag=flag, varname='tan_s2', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_s2_col)
+       call restartvar(ncid=ncid, flag=flag, varname='tan_s3', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_s3_col)
+
+       call restartvar(ncid=ncid, flag=flag, varname='tan_f0', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_f0_col)
+       call restartvar(ncid=ncid, flag=flag, varname='tan_f1', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_f1_col)
+       call restartvar(ncid=ncid, flag=flag, varname='tan_f2', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_f2_col)
+       call restartvar(ncid=ncid, flag=flag, varname='tan_f3', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%tan_f3_col)
+
+       call restartvar(ncid=ncid, flag=flag, varname='fert_u0', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%fert_u0_col)
+       call restartvar(ncid=ncid, flag=flag, varname='fert_u1', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%fert_u1_col)
+
+       call restartvar(ncid=ncid, flag=flag, varname='man_u_grz', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%man_u_grz_col)
+       call restartvar(ncid=ncid, flag=flag, varname='man_a_grz', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%man_a_grz_col)
+       call restartvar(ncid=ncid, flag=flag, varname='man_r_grz', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%man_r_grz_col)
+
+       call restartvar(ncid=ncid, flag=flag, varname='man_u_app', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%man_u_app_col)
+       call restartvar(ncid=ncid, flag=flag, varname='man_a_app', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%man_a_app_col)
+       call restartvar(ncid=ncid, flag=flag, varname='man_r_app', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%man_r_app_col)
+
+       call restartvar(ncid=ncid, flag=flag, varname='man_tan_stored', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%man_tan_stored_col)
+       call restartvar(ncid=ncid, flag=flag, varname='man_n_stored', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%man_n_stored_col)
+       call restartvar(ncid=ncid, flag=flag, varname='fan_grz_fract', xtype=ncd_double, &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%fan_grz_fract_col)
+    end if
+
     call restartvar(ncid=ncid, flag=flag,  varname='npimbalance_patch', xtype=ncd_double,  &
         dim1name='pft',    long_name='npimbalance_patch', units='-', &
         interpinic_flag='interp', readvar=readvar, data=this%npimbalance_patch)

--- a/components/clm/src/biogeochem/FanMod.F90
+++ b/components/clm/src/biogeochem/FanMod.F90
@@ -1,0 +1,1526 @@
+module FanMod
+#ifdef _PYMOD_
+  use qsatmod
+#else
+  use shr_const_mod
+  use shr_kind_mod                    , only : r8 => shr_kind_r8
+  use QSatMod                         , only : QSat
+#endif
+  implicit none
+
+#ifdef _REALPR_
+  integer, parameter :: r8 = 8
+#endif
+  
+#ifdef _PYMOD_
+  public
+
+  real(r8), parameter :: SHR_CONST_BOLTZ   = 1.38065e-23
+  real(r8), parameter :: SHR_CONST_AVOGAD  = 6.02214e26
+  real(r8), parameter :: SHR_CONST_RGAS    = SHR_CONST_AVOGAD*SHR_CONST_BOLTZ
+  real(r8), parameter :: SHR_CONST_MWDAIR  = 28.966
+  real(r8), parameter :: SHR_CONST_RDAIR   = SHR_CONST_RGAS/SHR_CONST_MWDAIR
+
+#else
+  private
+  public update_org_n
+  public eval_fluxes_storage
+  public update_npool
+  public update_3pool
+  public update_4pool
+  public update_urea
+#endif
+  
+  ! Indices in flux arrays, soil:
+  integer, parameter, public :: iflx_air = 1, & ! flux to air
+       iflx_soild = 2, & ! diffusion to soil
+       iflx_no3 = 3, &   ! nitrification
+       iflx_soilq = 4, & ! percolation to soil
+       iflx_roff = 5, &  ! surface runoff
+       iflx_to_tan = 6   ! conversion to tan (from urea) 
+  ! Indices in flux arrays, storage:
+  integer, parameter, public :: iflx_air_barns = 1, &
+       iflx_air_stores = 2, &
+       iflx_appl = 3, &
+       iflx_to_store = 4
+  ! Indices in the organic N pools and fluxes
+  integer, parameter, public :: ind_avail = 1, ind_resist = 2, ind_unavail = 3 
+  
+  ! nominal depth where the soil TAN concentration vanishes:
+  real(r8), parameter, public :: soildepth_reservoir = 0.05_r8
+
+  integer, parameter, public :: err_bad_theta = 1, err_negative_tan = 2, err_negative_flux = 3, &
+       err_balance_tan = 4, err_balance_nitr = 5, err_nan = 6, err_bad_subst = 7
+
+  integer, parameter, public :: subst_tan = 1, subst_urea = 2
+  
+  real(r8), parameter, public :: water_relax_t = 24*3600.0_r8
+  
+contains
+
+  ! accessor functions are only needed for the python interface... 
+  !
+  integer function ind_soild() result(ind)
+    ind = iflx_soild
+  end function ind_soild
+
+  integer function ind_soilq() result(ind)
+    ind = iflx_soilq
+  end function ind_soilq
+
+  integer function ind_air() result(ind)
+    ind = iflx_air
+  end function ind_air
+
+  integer function ind_no3() result(ind)
+    ind = iflx_no3
+  end function ind_no3
+
+  integer function ind_roff() result(ind)
+    ind = iflx_roff
+  end function ind_roff
+
+  integer function ind_air_barns() result(ind)
+    ind = iflx_air_barns
+  end function ind_air_barns
+
+  integer function ind_air_stores() result(ind)
+    ind = iflx_air_stores
+  end function ind_air_stores
+
+  integer function ind_appl() result(ind)
+    ind = iflx_appl
+  end function ind_appl
+
+  integer function ind_to_store() result(ind)
+    ind = iflx_to_store
+  end function ind_to_store
+  
+  function eval_diffusivity_liq_mq(theta, thetasat, tg) result(diff)
+    ! Evaluate the aquous phase diffusivity for TAN in soil according to the Millington &
+    ! Quirk model.
+    implicit none
+    real(r8), intent(in) :: theta, thetasat, tg
+    real(r8) :: diff
+    
+    real(r8) :: kaq_base
+    real(r8), parameter :: pw = 10.0_r8 / 3.0_r8
+    
+    kaq_base = 9.8e-10_r8 * 1.03_r8 ** (Tg-273.0_r8)
+    diff = kaq_base * (theta**pw) / (thetasat**2)
+
+  end function eval_diffusivity_liq_mq
+
+  function eval_diffusivity_gas_mq(theta, thetasat, tg) result(diff)
+    ! Evaluate the gas phase diffusivity for NH3 in soil according to the Millington &
+    ! Quirk model.
+    implicit none
+    real(r8), intent(in) :: theta, thetasat, tg
+    real(r8) :: diff
+    
+    real(r8) :: soilair, dair
+    real(r8), parameter :: pw = 10.0_r8 / 3.0_r8
+    real(r8), parameter :: mNH3 = 17., mair = 29, vNH3 = 14.9, vair = 20.1, press = 1.0
+    
+    soilair = thetasat - theta
+    !dair = 1.7e-5_r8 * 1.03_r8**(Tg-293.0_r8)
+    !dair = 18e-6_r8
+    !dair = 1.4e-5
+    
+    ! Base rate from Perry's Chemical Engineer's Handbook, 8th ed.
+    dair = (0.001 * tg**1.75 * sqrt(1/mNH3 + 1/mair)) / (press * (vair**(1./3) * vNH3**(1./3))**2) * 1e-4
+    diff = dair * (soilair**pw) / (thetasat**2)
+
+  end function eval_diffusivity_gas_mq
+
+  function eval_diffusivity_gas_m03(theta, thetasat, tg) result(diff)
+    ! Evaluate the gas phase diffusivity for NH3 in soil according to the method of
+    ! Moldrup (2003).
+    implicit none
+    real(r8), intent(in) :: theta, thetasat, tg
+    real(r8) :: diff
+    
+    real(r8) :: soilair, dair
+    real(r8), parameter :: pw = 10.0_r8 / 3.0_r8
+    real(r8), parameter :: bsw = 5.0_r8, m03_T = 2.0, m03_W = 3.0 / bsw
+    
+    soilair = thetasat - theta
+    dair = 1.7e-5 * 1.03**(Tg-293.0_r8)
+   
+    diff = dair * soilair**m03_T * (soilair/thetasat)**m03_W
+    
+  end function eval_diffusivity_gas_m03
+
+  function eval_diffusivity_liq_m03(theta, thetasat, tg) result(diff)
+    ! Evaluate the aquous phase diffusivity for TAN in soil according to the method of Moldrup (2003).
+    implicit none
+    real(r8), intent(in) :: theta, thetasat, tg
+    real(r8) :: diff
+    
+    real(r8) :: kaq_base
+    real(r8), parameter :: pw = 10.0_r8 / 3.0_r8, bsw = 5.0_r8, m03_T = 2.0_r8, m03_W = 0.3333_r8*bsw - 1.0
+    
+    kaq_base = 9.8e-10 * 1.03 ** (Tg-273.0_r8)
+    
+    diff = kaq_base * theta**m03_T * (theta/thetasat)**m03_W
+
+  end function eval_diffusivity_liq_m03
+  
+
+  ! The following three subroutines are meant for evaluating the net NH3 flux between soil and atmosphere as
+  !
+  ! F = g * (N - beta * cair)
+  !
+  ! where F is the net upwards flux of NH3, g is a conductance (m/s), cair is the
+  ! atmospheric concentration of NH3, and beta is a unitless constant. N denotes the TAN
+  ! concentration in soil in different phases as detailed below.
+  
+  subroutine get_volat_coefs_liq(ratm, tg, theta, thetasat, Hconc, depth, conductance, beta)
+    ! 
+    ! Evaluate the conductance g with N = [NH4+ (aq)] + [NH3 (aq)] in soilwater and
+    ! assuming that [NH3 (g)] < N in soil.
+    ! 
+    ! For cair = 0, this subroutine is actually equivalent to get_volat_soil_leachn.
+    ! 
+    implicit none
+    real(r8), intent(in) :: ratm ! resistance between the soil surface and bulk atmosphere
+    real(r8), intent(in) :: tg   ! ground temperature
+    real(r8), intent(in) :: theta ! volumetric water content 
+    real(r8), intent(in) :: thetasat ! volumetric water content at saturation
+    real(r8), intent(in) :: Hconc ! hydrogen ion concentration, -log10(pH)
+    real(r8), intent(in) :: depth ! thickenss of the soil layer, m
+    real(r8), intent(out) :: conductance ! as defined above  
+    real(r8), intent(out) :: beta ! as defined above
+    
+    real(r8) :: dz, henry_eff, dsl, dsg, rsl, rsg, grad, cond, air
+    
+    dz = 0.5*depth 
+    dsl = eval_diffusivity_liq_mq(theta, thetasat, Tg)
+    dsg = eval_diffusivity_gas_mq(theta, thetasat, Tg)
+    
+    henry_eff = get_henry_eff(Tg, Hconc)
+    beta = 1/henry_eff
+    air = thetasat - theta
+
+    rsg = dz / (dsg*air)
+    rsl = dz / (dsl*theta)
+    
+    conductance = henry_eff*(henry_eff*rsl + rsg)/(henry_eff*ratm*rsl + henry_eff*rsg*rsl + ratm*rsg)
+    
+  end subroutine get_volat_coefs_liq
+
+  subroutine get_volat_coefs_bulk(ratm, tg, theta, thetasat, Hconc, depth, conductance, beta)
+    !
+    ! Evaluate the conductance g with N = [NH4+ (aq)] + [NH3 (aq)] + [NH3 (g)] measured per volume of soil.
+    !
+    ! More accurate than get_volat_coefs_liq but in practice rarely different because when
+    ! measured in mass per volume, most of the TAN is normally in soil water.
+    
+    implicit none
+    real(r8), intent(in) :: ratm, tg, theta, thetasat, Hconc, depth
+    real(r8), intent(out) :: conductance, beta
+    
+    real(r8) :: dz, henry_eff, dsl, dsg, rsl, rsg, cond, air
+    
+    dz = 0.5*depth 
+    dsl = eval_diffusivity_liq_mq(theta, thetasat, Tg)
+    dsg = eval_diffusivity_gas_mq(theta, thetasat, Tg)
+    
+    henry_eff = get_henry_eff(Tg, Hconc)
+    beta = (air*henry_eff + theta)/henry_eff
+    air = thetasat - theta
+
+    rsg = dz / (dsg*air)
+    rsl = dz / (dsl*theta)
+
+    conductance = henry_eff*(henry_eff*rsl + rsg) &
+         /(air*henry_eff**2*ratm*rsl + air*henry_eff**2*rsg*rsl + air*henry_eff*ratm*rsg &
+         + henry_eff*ratm*rsl*theta + henry_eff*rsg*rsl*theta + ratm*rsg*theta)
+    
+  end subroutine get_volat_coefs_bulk
+
+  subroutine get_volat_coefs_3p(ratm, tg, theta, thetasat, Hconc, depth, cond, beta)
+    !
+    ! Evaluate the conductance g including absorbed "solid" NH4+,
+    !
+    ! N = [NH3 (aq)] + [NHH4+ (aq)] + [NH3 (g)] + [NH4+ (s)].
+    !
+    ! The partitioning between absorbed and aquoeous NH4+ is evaluted with a linear isotherm
+    ! such that [NH4+ (s)] / [NH4+ (aq)] = kxc, where kxc is a constant set below.
+    !
+    implicit none
+    real(r8), intent(in) :: ratm, tg, theta, thetasat, Hconc, depth
+    real(r8), intent(out) :: cond, beta
+    
+    real(r8) :: dz, henry_eff, dsl, dsg, rsl, rsg, air, solid
+    real(r8), parameter :: kxc = 0.3_r8
+    
+    dz = 0.5*depth 
+    dsl = eval_diffusivity_liq_mq(theta, thetasat, Tg)
+    dsg = eval_diffusivity_gas_mq(theta, thetasat, Tg)
+    
+    henry_eff = get_henry_eff(Tg, Hconc)
+    solid = 1 - thetasat
+    air = thetasat - theta
+    beta = (air*henry_eff + kxc*solid + theta)/henry_eff
+
+    rsg = dz / (dsg*air)
+    rsl = dz / (dsl*theta)
+
+    cond = henry_eff*(henry_eff*rsl + rsg) &
+         / (air*henry_eff**2*ratm*rsl + air*henry_eff**2*rsg*rsl + air*henry_eff*ratm*rsg &
+         + henry_eff*kxc*solid*ratm*rsl + henry_eff*kxc*solid*rsg*rsl + henry_eff*ratm*rsl*theta &
+         + henry_eff*rsg*rsl*theta + kxc*solid*ratm*rsg + ratm*rsg*theta)
+    
+  end subroutine get_volat_coefs_3p
+
+  function get_volat_soil_leachn(ratm, tg, theta, thetasat, Hconc, depth) result(rate)
+    ! Evaluate the instanteneous volatilization rate from soil as done in the LEACHN
+    ! model. Includes gas and aquoues phase diffusion within soil and gas/liquid
+    ! partitioning.
+    real(r8), intent(in) :: ratm, tg, theta, thetasat, Hconc, depth
+    real(r8) :: rate
+    
+    real(r8) :: dz, henry_eff, dsl, dsg, dstot, gs, gatm_eff
+    
+    dz = 0.5*depth 
+
+    henry_eff = get_henry_eff(Tg, Hconc)
+    gatm_eff = henry_eff / ratm 
+    dsl = eval_diffusivity_liq_mq(theta, thetasat, Tg)
+    dsg = eval_diffusivity_gas_mq(theta, thetasat, Tg)
+    dstot = dsl*theta + dsg*henry_eff*(thetasat-theta)
+    gs = dstot / dz
+    rate = gs*gatm_eff / (gs + gatm_eff)
+        
+  end function get_volat_soil_leachn
+
+  
+  real(r8) function get_henry_eff(tg, Hconc) result(henry)
+    ! Evaluate the "effective Henry constant" for ammonia, i.e the ratio
+    ! H* = [NH3 (g)] / [NH3 (aq) + NH4+ (aq)]
+    ! given a fixed H+ concentration in the solution.
+    real(r8), intent(in) :: tg ! soil temperature, K
+    real(r8), intent(in) :: Hconc ! H+ concentration, mol / l
+
+    real(r8) :: KNH4, KH
+    real(r8), parameter :: Tref = 298.15_r8
+        
+    KNH4 = 5.67_r8 * 1e-10_r8 * exp(-6286.0_r8 * (1.0_r8/Tg - 1.0_r8/Tref))
+    KH = 4.59_r8 * Tg * exp(4092_r8 * (1.0_r8/Tg - 1.0_r8/Tref))
+    henry = 1.0_r8 / (1.0_r8 + KH + KH*Hconc/KNH4)
+    
+  end function get_henry_eff
+
+  real(r8) function eval_no3prod(theta, Tg, Hconc) result(kNO3)
+    ! Evaluate nitrification rate as in the Riddick et al. (2016) paper.
+    real(r8), intent(in) :: theta ! volumetric soil water m/m
+    real(r8), intent(in) :: Tg    ! soil temperature, K
+    real(r8), intent(in) :: Hconc ! hydrogen ion concentration mol/l
+
+    real(r8) :: KNH4, KH, gas, stf, wmr, smrf, mNH4
+
+    real(r8), parameter :: soil_dens = 1050.0_r8 ! Soil density, kg/m3
+    real(r8), parameter :: water_dens = 1000.0_r8
+    real(r8), parameter :: rmax = 1.16e-6_r8   ! Maximum rate of nitrification, s-1
+    real(r8), parameter :: tmax = 313.0       ! Maximm temperature of microbial activity, K
+    real(r8), parameter :: topt = 301.0       ! Optimal temperature of microbial acticity, K
+    real(r8), parameter :: asg  = 2.4_8        ! a_sigma, empirical factor
+    real(r8), parameter :: wmr_crit = 0.12_r8  ! Critical water content, g/g
+    real(r8), parameter :: smrf_b = 2          ! Parameter in soil moisture response function
+    real(r8), parameter :: Tref = 298.15_r8
+    
+    KNH4 = 5.67_r8 * 1e-10_r8 * exp(-6286.0_r8 * (1.0_r8/Tg - 1.0_r8/Tref))
+    KH = 4.59_r8 * Tg * exp(4092_r8 * (1.0_r8/Tg - 1.0_r8/Tref))
+    gas = 1.0_r8 / (1.0_r8 + KH + KH*Hconc/KNH4)
+    mNH4 = gas * KH*Hconc/KNH4
+
+    ! soil temperature function
+    stf = (max(1e-3_r8, tmax-Tg) / (tmax-topt))**asg * exp(asg * (Tg-topt)/(tmax-topt))
+
+    ! gravimetric soil water
+    wmr = theta * water_dens / soil_dens
+
+    ! soil moisture response function
+    
+    smrf = 1.0_r8 - exp(-(wmr/wmr_crit)**smrf_b)
+    !if stf < 1e-9 or smrf < 1e-9:
+    !    print theta
+    !    1/0
+    kNO3 = 2.0_r8 * rmax * mNH4 / (1.0_r8/stf + 1.0_r8/smrf)
+    
+  end function eval_no3prod
+  
+  subroutine eval_fluxes_slurry(water, mtan, Hconc, tg, ratm, theta, thetasat, perc, runoff, cnc_nh3_air, fluxes)
+    ! Evaluate nitrogen fluxes for a partly infiltrated layer of slurry.
+    ! The state of infiltration is detemined from the amounts water on surface and in soil.
+    ! Positive flux means loss of TAN.
+    implicit none
+    real(r8), intent(in) :: water(2) ! water in (surface , subsurface), m
+    real(r8), intent(in) :: mtan   ! TAN, mass units / m2, surface + subsurface
+    real(r8), intent(out) :: fluxes(5) ! TAN fluxes, see top of the module
+    real(r8), intent(in) :: Hconc    ! H+ concentration, -log10(pH)
+    real(r8), intent(in) :: tg       ! soil temperature, K
+    real(r8), intent(in) :: ratm     ! atmospheric resistance, s/m
+    real(r8), intent(in) :: theta    ! volumetric soil water in "clean" soil
+    real(r8), intent(in) :: thetasat ! volumetric soil water at saturation
+    real(r8), intent(in) :: perc     ! percolation water flux thourgh the bottom of volatilization layer, m/s
+    real(r8), intent(in) :: runoff   ! surface runoff, m/s
+    real(r8), intent(in) :: cnc_nh3_air ! atmospheric NH3 concentration, mass units / m3
+    !real(r8), intent(in) :: dt       ! timestep
+
+    real(r8) :: water_tot, cnc, air, depth_soilsat, diffusivity_water, diffusivity_satsoil, halfwater, insoil, r1, dz2
+    real(r8) :: r2, volat_rate, kno3, henry_eff, depth_lower
+
+    water_tot = water(1) + water(2)
+
+    air = thetasat - theta
+    ! depth of the saturated soil layer below the surface pool
+    depth_soilsat = water(2) / air 
+
+    cnc = mtan / water_tot
+
+    fluxes(iflx_roff) = cnc * runoff
+    fluxes(iflx_soilq) = cnc * perc
+
+
+    diffusivity_water = 9.8e-10_r8 * 1.03_r8 ** (tg - 273.0_r8)
+    diffusivity_satsoil = eval_diffusivity_liq_mq(thetasat, thetasat, tg) * thetasat
+
+    halfwater = 0.5_r8 * water_tot
+
+    ! Calculate the internal resistance r1 of the slurry/soil layer by integrating the
+    ! diffusivity for distance that covers half of the slurry water.
+    if (water(1) < halfwater) then
+       ! contribution from both pool and the saturated soil.
+       insoil = (halfwater - water(1)) / thetasat
+       r1 = water(1) / diffusivity_water + insoil / diffusivity_satsoil
+    else
+       ! pool only
+       r1 = halfwater / diffusivity_water
+    end if
+    
+    depth_lower = max(soildepth_reservoir, depth_soilsat*1.5)
+    ! Diffusion to deeper soil over distance dz2
+    dz2 = depth_lower - 0.5*depth_soilsat
+    r2 = 0.5 * depth_soilsat/diffusivity_satsoil + dz2 / eval_diffusivity_liq_mq(theta, thetasat, tg)
+    !print *, 'r2', r2, diffusivity_satsoil, dz2, depth_soilsat
+    fluxes(iflx_soild) = cnc / r2
+
+    henry_eff = get_henry_eff(tg, Hconc)
+    volat_rate = 1.0_r8 / (r1 + ratm / henry_eff) ! conductance from aqueous TAN in slurry to NH3 in atmosphere
+    fluxes(iflx_air) = max(volat_rate*(cnc - cnc_nh3_air), 0.0_r8)
+    
+    ! nitrification
+    kno3 = eval_no3prod(thetasat, tg, Hconc)
+    fluxes(iflx_no3) = kno3 * mtan
+
+    !fluxes(3:) = 0
+    
+  end subroutine eval_fluxes_slurry
+
+  subroutine eval_fluxes_soil(mtan, water_manure, Hconc, tg, ratm, theta, thetasat, perc, &
+       & runoff, cnc_nh3_air, soildepth, fluxes, substance, status)
+    !
+    ! Evaluate nitrogen fluxes from a soil layer. Use for all cases except the partly
+    ! infiltrated slurry (above). Fluxes can be evaluated either for urea or TAN: for
+    ! urea, only the aqueous phase fluxes are evaluated and nitrification is set to zero.
+    ! 
+    implicit none
+    real(r8), intent(in) :: mtan ! TAN, mass units / m2
+    real(r8), intent(in) :: water_manure ! water in the soil pool *in addition to* background soil water
+    real(r8), intent(out) :: fluxes(5)   ! nitrogen fluxes, mass units / m2 / s, see top of module
+    real(r8), intent(in) :: Hconc        ! Hydrogen ion concentration, mol/l
+    real(r8), intent(in) :: tg           ! soil temperature, K
+    real(r8), intent(in) :: ratm         ! atmospheric resistance, s/m
+    real(r8), intent(in) :: theta        ! volumetric soil water in "clean" soil, m/m
+    real(r8), intent(in) :: thetasat     ! volumetric soil water at saturation
+    real(r8), intent(in) :: perc         ! downwards water percolation rate at the bottom of layer, m/s, > 0
+    real(r8), intent(in) :: runoff       ! runoff water flux, m / s
+    real(r8), intent(in) :: cnc_nh3_air  ! NH3 concentration in air, mass units / m3
+    real(r8), intent(in) :: soildepth    ! thickness of the volatlization layer
+    integer, intent(in) :: substance     ! subst_tan or subst_urea.
+    integer, intent(out) :: status      ! error flag
+    
+    
+    real(r8) :: water_tot, cnc, air, henry_eff, dsl, dsg, dstot, dz2, no3_rate, volat_rate, theta_tot, beta
+
+    water_tot = water_manure + theta*soildepth
+    if (water_tot < 1e-9) then
+       fluxes = 0.0
+       return
+    end if
+    
+    theta_tot = water_tot / soildepth
+    if (theta_tot > thetasat) then
+       status = err_bad_theta
+       return
+    end if
+
+    cnc = mtan / water_tot
+
+    air = thetasat - theta_tot
+    beta = 0.0
+    
+    if (substance == subst_tan) then
+
+       volat_rate = get_volat_soil_leachn(ratm, tg, water_tot/soildepth, thetasat, Hconc, soildepth)
+       !fluxes(iflx_air) = max((cnc-cnc_nh3_air) * volat_rate, 0.0_r8)
+
+       !call get_volat_coefs_liq(ratm, tg, water_tot/soildepth, thetasat, Hconc, soildepth, volat_rate, beta)
+       !fluxes(iflx_air) = volat_rate * (cnc - beta*cnc_nh3_air)
+
+       call get_volat_coefs_bulk(ratm, tg, water_tot/soildepth, thetasat, Hconc, soildepth, volat_rate, beta)
+       !call get_volat_coefs_3p(ratm, tg, water_tot/soildepth, thetasat, Hconc, soildepth, volat_rate, beta)
+       fluxes(iflx_air) = volat_rate * (mtan/soildepth - beta*cnc_nh3_air)
+
+       henry_eff = get_henry_eff(tg, Hconc)
+       dsg = eval_diffusivity_gas_mq(theta_tot, thetasat, tg)
+       no3_rate = eval_no3prod(theta_tot, tg, Hconc)
+    else if (substance == subst_urea) then
+       fluxes(iflx_air) = 0.0_r8
+       henry_eff = 0.0_r8
+       dsg = 0.0_r8
+       no3_rate = 0.0_r8
+    else
+       status = err_bad_subst
+       return
+    end if
+    
+    ! Downwards diffusion
+    ! soil diffusivities: liquid, gas, bulk
+    dsl = eval_diffusivity_liq_mq(theta_tot, thetasat, tg)
+    dstot = dsl*theta_tot + dsg*henry_eff*air
+    dz2 = soildepth_reservoir - 0.5 * soildepth
+    !print *, 'dz2:', dz2
+    fluxes(iflx_soild) = cnc * dstot / dz2
+    fluxes(iflx_no3) = mtan * no3_rate
+    fluxes(iflx_soilq) = cnc * perc
+    fluxes(iflx_roff) = cnc * runoff
+
+    status = 0
+    !fluxes(4:) = 0
+    
+  end subroutine eval_fluxes_soil
+
+  subroutine eval_fluxes_soilroff(mtan, water_manure, Hconc, tg, ratm, theta, thetasat, perc, &
+       & runoff, cnc_nh3_air, soildepth, fluxes, substance, status)
+    !
+    ! Evaluate nitrogen fluxes from a soil layer. Use for all cases except the partly
+    ! infiltrated slurry (above). Fluxes can be evaluated either for urea or TAN: for
+    ! urea, only the aqueous phase fluxes are evaluated and nitrification is set to zero.
+    ! 
+    implicit none
+    real(r8), intent(in) :: mtan ! TAN, mass units / m2
+    real(r8), intent(in) :: water_manure ! water in the soil pool *in addition to* background soil water
+    real(r8), intent(out) :: fluxes(5)   ! nitrogen fluxes, mass units / m2 / s, see top of module
+    real(r8), intent(in) :: Hconc        ! Hydrogen ion concentration, mol/l
+    real(r8), intent(in) :: tg           ! soil temperature, K
+    real(r8), intent(in) :: ratm         ! atmospheric resistance, s/m
+    real(r8), intent(in) :: theta        ! volumetric soil water in "clean" soil, m/m
+    real(r8), intent(in) :: thetasat     ! volumetric soil water at saturation
+    real(r8), intent(in) :: perc         ! downwards water percolation rate at the bottom of layer, m/s, > 0
+    real(r8), intent(in) :: runoff       ! runoff water flux, m / s
+    real(r8), intent(in) :: cnc_nh3_air  ! NH3 concentration in air, mass units / m3
+    real(r8), intent(in) :: soildepth    ! thickness of the volatlization layer
+    integer, intent(in) :: substance     ! subst_tan or subst_urea.
+    integer, intent(out) :: status      ! error flag
+    
+    
+    real(r8) :: water_tot, cnc, air, henry_eff, dsl, dsg, dstot, dz2, no3_rate, volat_rate, theta_tot, beta
+    real(r8) :: cnc_srfg, cnc_srfaq, cnc_soilaq, cnc_soilg, dz, rsl, rsg, qrf
+
+    water_tot = water_manure + theta*soildepth
+    if (water_tot < 1e-9) then
+       fluxes = 0.0
+       return
+    end if
+    
+    theta_tot = water_tot / soildepth
+    if (theta_tot > thetasat) then
+       status = err_bad_theta
+       return
+    end if
+
+    cnc = mtan / soildepth
+    qrf = runoff
+    air = thetasat - theta_tot
+    beta = 0.0
+
+    dz = 0.5*soildepth 
+    dsl = eval_diffusivity_liq_mq(theta_tot, thetasat, Tg)
+    dsg = eval_diffusivity_gas_mq(theta_tot, thetasat, Tg)
+    rsg = dz / (dsg*air)
+    rsl = dz / (dsl*theta_tot)
+
+    if (substance == subst_tan) then
+       henry_eff = get_henry_eff(tg, Hconc)
+       no3_rate = eval_no3prod(theta_tot, tg, Hconc)
+       cnc_soilg = cnc / (theta_tot/henry_eff + air)
+    else if (substance == subst_urea) then
+       henry_eff = 0.0
+       no3_rate = 0.0_r8
+       cnc_soilg = 0.0_r8
+    else
+       status = err_bad_subst
+       return
+    end if
+
+    cnc_srfg = (henry_eff * ratm * cnc * (henry_eff*rsl + rsg)) &
+         / (air*henry_eff**2*rsl*(ratm + rsg) + air*henry_eff*ratm*rsg*(qrf*rsl + 1) &
+         + henry_eff*rsl*theta_tot*(ratm + rsg) + ratm*rsg*theta_tot*(qrf*rsl + 1))
+    
+    cnc_srfaq = ratm * cnc * (henry_eff*rsl + rsg)&
+         / (air*henry_eff**2*rsl*(ratm + rsg) + air*henry_eff*ratm*rsg*(qrf*rsl + 1) &
+         + henry_eff*rsl*theta_tot*(ratm + rsg) + ratm*rsg*theta_tot*(qrf*rsl + 1))
+    
+    fluxes(iflx_air) = cnc_srfg / ratm
+    fluxes(iflx_roff) = runoff * cnc_srfaq
+
+    dstot = dsl*theta_tot + dsg*henry_eff*air
+    dz2 = soildepth_reservoir - 0.5 * soildepth
+    
+    cnc_soilaq = cnc / (theta_tot + air*henry_eff)
+    
+    fluxes(iflx_soild) = (cnc_soilaq * dsl) / dz2 + (cnc_soilg * dsg) / dz2
+
+
+    fluxes(iflx_no3) = mtan * no3_rate
+    fluxes(iflx_soilq) = cnc_soilaq * perc
+
+    status = 0
+    !fluxes(4:) = 0
+    
+  end subroutine eval_fluxes_soilroff
+
+
+  subroutine eval_fluxes_soil_3p(mtan, water_manure, Hconc, tg, ratm, theta, thetasat, perc, &
+       & runoff, cnc_nh3_air, soildepth, fluxes, substance, status)
+    !
+    ! Evaluate nitrogen fluxes from a soil layer. Use for all cases except the partly
+    ! infiltrated slurry (above). Fluxes can be evaluated either for urea or TAN: for
+    ! urea, only the aqueous phase fluxes are evaluated and nitrification is set to zero.
+    ! 
+    implicit none
+    real(r8), intent(in) :: mtan ! TAN, mass units / m2
+    real(r8), intent(in) :: water_manure ! water in the soil pool *in addition to* background soil water
+    real(r8), intent(out) :: fluxes(5)   ! nitrogen fluxes, mass units / m2 / s, see top of module
+    real(r8), intent(in) :: Hconc        ! Hydrogen ion concentration, mol/l
+    real(r8), intent(in) :: tg           ! soil temperature, K
+    real(r8), intent(in) :: ratm         ! atmospheric resistance, s/m
+    real(r8), intent(in) :: theta        ! volumetric soil water in "clean" soil, m/m
+    real(r8), intent(in) :: thetasat     ! volumetric soil water at saturation
+    real(r8), intent(in) :: perc         ! downwards water percolation rate at the bottom of layer, m/s, > 0
+    real(r8), intent(in) :: runoff       ! runoff water flux, m / s
+    real(r8), intent(in) :: cnc_nh3_air  ! NH3 concentration in air, mass units / m3
+    real(r8), intent(in) :: soildepth    ! thickness of the volatlization layer
+    integer, intent(in) :: substance     ! subst_tan or subst_urea.
+    integer, intent(out) :: status      ! error flag
+    
+    
+    real(r8) :: water_tot, cnc, air, henry_eff, dsl, dsg, dstot, dz2, no3_rate, volat_rate, theta_tot, beta
+    real(r8) :: part_liq, part_gas, part_nh4, part_solid, part_avail
+    
+    water_tot = water_manure + theta*soildepth
+    if (water_tot < 1e-9) then
+       fluxes = 0.0
+       return
+    end if
+    
+    theta_tot = water_tot / soildepth
+    if (theta_tot > thetasat) then
+       status = err_bad_theta
+       return
+    end if
+
+    cnc = mtan / water_tot
+
+    air = thetasat - theta_tot
+    beta = 0.0
+    dz2 = soildepth_reservoir - 0.5 * soildepth
+    
+    if (substance == subst_tan) then
+       call get_fluxes_3p(mtan/soildepth, ratm, theta_tot, thetasat, tg, 0.5*soildepth, dz2, Hconc, &
+            fluxes(iflx_air), fluxes(iflx_soild), part_liq, part_gas, part_nh4, part_solid)
+       !print *, 'part:', part_liq, part_gas, part_nh4, part_solid
+       !volat_rate = get_volat_soil_leachn(ratm, tg, water_tot/soildepth, thetasat, Hconc, soildepth)
+       !fluxes(iflx_air) = max((cnc-cnc_nh3_air) * volat_rate, 0.0_r8)
+
+       !call get_volat_coefs_liq(ratm, tg, water_tot/soildepth, thetasat, Hconc, soildepth, volat_rate, beta)
+       !fluxes(iflx_air) = volat_rate * (cnc - beta*cnc_nh3_air)
+
+       !call get_volat_coefs_bulk(ratm, tg, water_tot/soildepth, thetasat, Hconc, soildepth, volat_rate, beta)
+       !call get_volat_coefs_3p(ratm, tg, water_tot/soildepth, thetasat, Hconc, soildepth, volat_rate, beta)
+       !fluxes(iflx_air) = volat_rate * (mtan/soildepth - beta*cnc_nh3_air)
+       part_avail = 1 - part_solid
+       no3_rate = thetasat * part_avail * eval_no3prod(theta_tot, tg, Hconc) 
+       no3_rate = eval_no3prod(theta_tot, tg, Hconc) 
+       fluxes(iflx_no3) = no3_rate * mtan! * ( 1 - part_solid * (1-thetasat))
+       cnc = mtan / soildepth * part_liq
+    else if (substance == subst_urea) then
+       fluxes(iflx_air) = 0.0_r8
+       henry_eff = 0.0_r8
+       dsg = 0.0_r8
+       no3_rate = 0.0_r8
+       part_avail = 1.0_r8
+       dsl = eval_diffusivity_liq_mq(theta_tot, thetasat, tg)
+       dstot = dsl*theta_tot + dsg*henry_eff*air
+       fluxes(iflx_soild) = cnc * dstot / dz2
+       fluxes(iflx_no3) = 0.0
+    else
+       status = err_bad_subst
+       return
+    end if
+    
+    ! Downwards diffusion
+    ! soil diffusivities: liquid, gas, bulk
+    
+    !print *, 'dz2:', dz2
+    fluxes(iflx_soilq) = cnc * perc 
+    fluxes(iflx_roff) = cnc * runoff
+
+    status = 0
+    !fluxes(4:) = 0
+
+  contains
+    
+    subroutine get_fluxes_3p(tan_soil, ratm, theta, thetasat, tg, dzup, dzdown, Hconc, &
+         flux_atm, flux_soild, part_soil_liq, part_soil_gas, part_soil_nh4, part_soil_solid)
+      real(r8), intent(in) :: tan_soil, ratm, theta, thetasat, tg, dzup, dzdown, Hconc
+      real(r8), intent(out) :: flux_atm, flux_soild, part_soil_liq, part_soil_gas, part_soil_nh4, part_soil_solid
+      
+      real(r8) :: rsl, rsg, knh4, kh, air, solid, comp
+      real(r8), parameter :: Tref = 298.15_r8
+      real(r8), parameter :: kx = 1.0
+      
+      KNH4 = 5.67_r8 * 1e-10_r8 * exp(-6286.0_r8 * (1.0_r8/Tg - 1.0_r8/Tref))
+      KH = 4.59_r8 * Tg * exp(4092_r8 * (1.0_r8/Tg - 1.0_r8/Tref))
+
+      air = thetasat - theta
+      solid = 1 - thetasat
+      
+      rsl = dzup / (theta * eval_diffusivity_liq_mq(theta, thetasat, tg))
+      rsg = dzup / (air * eval_diffusivity_gas_mq(theta, thetasat, tg))
+
+      comp = knh4*(cnc_nh3_air*rsg*rsl*(Hconc*kh*kx*solid + Hconc*kh*theta + &
+           air*knh4 + kh*knh4*theta) + ratm*tan_soil*(Hconc*kh*rsg + kh*knh4*rsg + &
+           knh4*rsl))/(Hconc**2*kh**2*kx*ratm*rsg*solid + Hconc**2*kh**2*ratm*rsg*theta + &
+           Hconc*air*kh*knh4*ratm*rsg + Hconc*kh**2*knh4*kx*ratm*rsg*solid + &
+           2*Hconc*kh**2*knh4*ratm*rsg*theta + Hconc*kh*knh4*kx*rsl*solid*(ratm + rsg) + &
+           Hconc*kh*knh4*rsl*theta*(ratm + rsg) + air*kh*knh4**2*ratm*rsg + &
+           air*knh4**2*rsl*(ratm + rsg) + kh**2*knh4**2*ratm*rsg*theta + &
+           kh*knh4**2*rsl*theta*(ratm + rsg))
+
+      flux_atm = comp / ratm
+
+      part_soil_liq = kh*(Hconc + knh4)/(Hconc*kh*kx*solid + Hconc*kh*theta + air*knh4 + kh*knh4*theta)
+      part_soil_nh4 = Hconc*kh/(Hconc*kh*kx*solid + Hconc*kh*theta + air*knh4 + kh*knh4*theta)
+      part_soil_gas = knh4/(Hconc*kh*kx*solid + Hconc*kh*theta + air*knh4 + kh*knh4*theta)
+      part_soil_solid = Hconc*kh*kx/(Hconc*kh*kx*solid + Hconc*kh*theta + air*knh4 + kh*knh4*theta)
+      !flux_soild = &
+      !     tan_soil*(kh*rsg*(Hconc + knh4) + knh4*rsl)&
+      !     /(rsg*rsl*(Hconc*kh*kx*solid + H*kh*theta + epsilon*knh4 + kh*knh4*theta))
+
+      rsl = dzdown / (theta * eval_diffusivity_liq_mq(theta, thetasat, tg))
+      rsg = dzdown / (air * eval_diffusivity_gas_mq(theta, thetasat, tg))
+
+      flux_soild = tan_soil * part_soil_liq / rsl + tan_soil * part_soil_gas / rsg
+      
+    end subroutine get_fluxes_3p
+    
+  end subroutine eval_fluxes_soil_3p
+
+  subroutine partition_to_layer(water, theta, thetasat, soildepth, fraction_in, fraction_down, fraction_runoff)
+    ! Evaluate the fraction of water volume that can be accommodated (before saturation)
+    ! by soil layer with current water content theta.
+    implicit none
+    real(r8), intent(in) :: water ! water to be added to the layer, m
+    real(r8), intent(in) :: theta, thetasat ! vol. soil water, current and saturation, m/m
+    real(r8), intent(in) :: soildepth ! thickness of the layer, m
+    real(r8), intent(out) :: fraction_in ! fraction that fits in
+    real(r8), intent(out) :: fraction_down ! fraction excess
+    real(r8), intent(out) :: fraction_runoff ! = 1 if theta is > 99% saturation otherwise 0
+
+    real(r8) :: watvol, watvol_sat, vol_to_layer, vol_to_deeper, vol_avail
+    
+    watvol = theta*soildepth
+    watvol_sat = thetasat*soildepth
+
+    if (watvol < 0.99*watvol_sat) then
+       vol_avail = watvol_sat - watvol
+       vol_to_layer = min(water, vol_avail)
+       vol_to_deeper = water - vol_to_layer
+       fraction_down = vol_to_deeper / water
+       fraction_runoff = 0.0
+       fraction_in = 1.0_r8 - fraction_down
+    else
+       fraction_down = 0.0
+       fraction_in = 0.0
+       fraction_runoff = 1.0_r8
+    end if
+    
+  end subroutine partition_to_layer
+
+  subroutine age_pools_soil(ndep, dt, pools, mtan, garbage)
+    implicit none
+    real(r8), intent(in) :: ndep ! flux of TAN input, gN/m2/s
+    real(r8), intent(inout) :: mtan(:) ! TAN pools for each age range. gN/m2
+    real(r8), intent(in) :: dt ! timestep, s
+    real(r8), intent(in) :: pools(:) ! age spans covered by each bin, seconds. size(mtan) = size(pools)
+    real(r8), intent(out) :: garbage ! TAN removed from the oldest pool. gN/m2
+
+    real(r8) :: flux_out(size(mtan))
+
+    flux_out = mtan / pools
+
+    ! new nitrogen
+    mtan(1) = mtan(1) + ndep * dt
+    ! transfer nitrogen from fresh to old pools
+    mtan = mtan - flux_out * dt
+    if (size(mtan) > 1) mtan(2:) = mtan(2:) + flux_out(:size(mtan)-1) * dt
+    ! provided that the oldest pool has wide enough age range, the amount transferred out
+    ! should be small.
+    garbage = flux_out(size(mtan)) * dt
+    
+  end subroutine age_pools_soil
+
+  subroutine age_pools_slurry(ndep, dt, water_slurry, tan_slurry, tan_soil, pools, garbage)
+    implicit none
+    real(r8), intent(in) :: ndep ! flux of TAN input, gN/m2/s
+    real(r8), intent(in) :: dt ! timestep, s
+    ! water in slurry pool, on surface (1) and below surface (2) not including the background water content (theta)
+    real(r8), intent(in) :: water_slurry(2)
+    real(r8), intent(inout) :: tan_slurry  ! TAN in slurry pool, gN/m2
+    real(r8), intent(inout) :: tan_soil(:) ! TAN in soil pools, gN/m2
+    real(r8), intent(in) :: pools(:) ! age spans covered by each pool, including the S0 surface slurry. seconds.
+    real(r8), intent(out) :: garbage       ! garbage TAN, see above
+
+    real(r8) :: fract_slurry_soil, flux_to_soilpools
+    
+    fract_slurry_soil = water_slurry(2) / sum(water_slurry)
+    flux_to_soilpools = tan_slurry * fract_slurry_soil / pools(1)
+    tan_slurry = tan_slurry + (ndep - flux_to_soilpools) * dt
+
+    call age_pools_soil(flux_to_soilpools, dt, pools(2:), tan_soil, garbage)
+    
+  end subroutine age_pools_slurry
+
+  subroutine update_3pool(tg, ratm, theta, thetasat, precip, evap, qbot, watertend, runoff, tandep, tanprod, cnc_nh3_air, &
+       depth_slurry, poolranges, tanpools, fluxes, garbage, dt, status)
+    !
+    ! Evalute fluxes and update TAN pools for the 3-pool slurry model with a partly
+    ! infiltrated, freshly infiltrated and aged TAN pools.
+    !
+    implicit none
+    real(r8), intent(in) :: tg ! soil temperature, K
+    real(r8), intent(in) :: ratm ! atmospheric resistance, s/m
+    real(r8), intent(in) :: theta ! volumetric soil water in soil column (unaffected by slurry)
+    real(r8), intent(in) :: thetasat ! vol. soil water at saturation
+    real(r8), intent(in) :: precip   ! precipitation, m/s
+    real(r8), intent(in) :: evap   ! ground evaporation, m/s
+    real(r8), intent(in) :: qbot   ! specific humidity (kg/kg) at lowest atmospheric model level
+    real(r8), intent(in) :: watertend ! time derivative of theta
+    real(r8), intent(in) :: runoff    ! surface runoff flux, m/s
+    real(r8), intent(in) :: tandep    ! TAN input flux, gN/m2/s
+    real(r8), intent(in) :: tanprod   ! TAN produced in the column, added to aged TAN pool
+    !real(r8), intent(in) :: infiltr_slurry ! Slurry infiltration rate, m/s
+    real(r8), intent(in) :: depth_slurry ! Initial slurry depth, m
+    real(r8), intent(in) :: cnc_nh3_air ! NH3 concentration in air, gN/m3
+    real(r8), intent(in) :: poolranges(3)  ! age ranges of TAN pools S0, S1, S2, sec. Slurry infiltration time is inferred from S0. 
+    real(r8), intent(inout) :: tanpools(3) ! TAN pools gN/m2
+    real(r8), intent(out) :: fluxes(5,3) ! TAN fluxes, gN/m2/s (type of flux, pool)
+    real(r8), intent(out) :: garbage     ! over-aged TAN occurring during the step, gN/m.
+    real(r8), intent(in) :: dt ! timestep, sec, >0
+    integer, intent(out) :: status ! return status, 0 = good
+    
+    real(r8) :: infiltr_slurry, infiltrated, percolated, evap_slurry, water_slurry(2), perc_slurry_mean, waterloss
+    real(r8) :: percolation, water_soil, age_prev, water_in_layer, tanpools_old(3)
+    integer :: indpl
+    
+    real(r8), parameter :: dz_layer = 0.02 ! thickness of the volatilization layer, m
+    ! H+ concentration in each pool 
+    real(r8), parameter :: Hconc(3) = (/10.0_r8**(-8.0_r8), 10.0_r8**(-8.0_r8), 10.0_r8**(-8.0_r8)/)
+
+    if (theta > thetasat) then
+       status = err_bad_theta
+       return
+    end if
+
+    tanpools_old = tanpools
+
+    ! Pool S0
+    !
+    evap_slurry = get_evap_pool(tg, ratm, qbot)
+    infiltr_slurry = max(depth_slurry / poolranges(1), precip)
+    infiltrated = depth_slurry * infiltr_slurry / (infiltr_slurry + evap_slurry)
+    ! Slurry water (in addition to soil water, theta) on surface and in soil. Represents
+    ! mean over pool S0.
+    water_slurry = (/0.5*depth_slurry, 0.5*infiltrated/) 
+    ! The excess water assumed to have percolated down from the volat. layer.
+    percolated = max(infiltrated - dz_layer*(thetasat-theta), 0.0)
+    ! Percolation rate out of volat layer, average over the pool S0.
+    perc_slurry_mean = percolated / poolranges(1)
+
+    call eval_fluxes_slurry(water_slurry, tanpools(1), Hconc(1), tg, ratm, theta, thetasat, perc_slurry_mean, &
+         runoff, cnc_nh3_air, fluxes(:,1))
+
+    if (any(isnan(fluxes))) then
+       status = err_nan * 10
+    end if
+
+    call update_pools(tanpools(1:1), fluxes(1:5,1:1), dt, 1, 5)
+
+    if (any(tanpools < -1e-15)) then
+       status = err_negative_tan
+       return
+    end if
+    
+    ! Pool aging & input
+    !
+    call age_pools_slurry(tandep, dt, water_slurry, tanpools(1), tanpools(2:3), poolranges, garbage)
+    ! TAN produced (mineralization) goes to directly the old TAN pool. 
+    tanpools(3) = tanpools(3) + tanprod*dt
+
+    ! Soil bins S1 and S2
+    !
+    age_prev = 0 ! for water evaluations, consider beginning of S1 as the starting point
+    water_in_layer = infiltrated - percolated ! water in layer just after slurry has infiltrated
+    do indpl = 2, 3
+       ! water content lost during the aging
+       waterloss = water_in_layer * (waterfunction(age_prev) - waterfunction(age_prev+poolranges(indpl)))
+       percolation = eval_perc(waterloss, evap, precip, watertend, poolranges(indpl))
+       ! water content at the mean age of the pool
+       water_soil = water_in_layer * waterfunction(age_prev + 0.5*poolranges(indpl))
+       call eval_fluxes_soil(tanpools(indpl), water_soil, Hconc(indpl), tg, &
+            & ratm, theta, thetasat, percolation, runoff, cnc_nh3_air, &
+            & dz_layer, fluxes(:,indpl), subst_tan, status)
+       if (status /= 0) return
+       age_prev = age_prev + poolranges(indpl)
+    end do
+    
+    call update_pools(tanpools(2:3), fluxes(1:5,2:3), dt, 2, 5)
+    
+    if (any(tanpools < -1e-15)) then
+       status = err_negative_tan * 10
+       return
+       !end if
+    end if
+
+    if (any(isnan(fluxes))) then
+       status = err_nan * 100
+    end if
+
+    if (abs(sum(tanpools - tanpools_old) - (-sum(fluxes) + tandep + tanprod)*dt + garbage) &
+         > max(sum(tanpools_old)*1e-2, 1e-4)) then
+       status = err_balance_tan
+       return
+    end if
+    
+    status = 0
+    
+  end subroutine update_3pool
+
+  subroutine update_4pool(tg, ratm, theta, thetasat, precip, evap, qbot, watertend, runoff, tandep, tanprod, cnc_nh3_air, &
+       depth_slurry, poolranges, tanpools, Hconc, fluxes, garbage, dt, status)
+    !
+    ! Experimental, as above but with an additional long-lived TAN pool.
+    !
+    implicit none
+    real(r8), intent(in) :: tg ! soil temperature, K
+    real(r8), intent(in) :: ratm ! atmospheric resistance, s/m
+    real(r8), intent(in) :: theta ! volumetric soil water in soil column (unaffected by slurry)
+    real(r8), intent(in) :: thetasat ! vol. soil water at saturation
+    real(r8), intent(in) :: precip   ! precipitation, m/s
+    real(r8), intent(in) :: evap   ! ground evaporation, m/s
+    real(r8), intent(in) :: qbot   ! specific humidity (kg/kg) at lowest atmospheric model level
+    real(r8), intent(in) :: watertend ! time derivative of theta
+    real(r8), intent(in) :: runoff    ! surface runoff flux, m/s
+    real(r8), intent(in) :: tandep    ! TAN input flux, gN/m2/s
+    real(r8), intent(in) :: tanprod   ! TAN produced in the column, added to aged TAN pool
+    !real(r8), intent(in) :: infiltr_slurry ! Slurry infiltration rate, m/s
+    real(r8), intent(in) :: depth_slurry ! Initial slurry depth, m
+    real(r8), intent(in) :: cnc_nh3_air ! NH3 concentration in air, gN/m3
+    real(r8), intent(in) :: poolranges(4)  ! age ranges of TAN pools S0, S1, S2, sec. Slurry infiltration time is inferred from S0. 
+    real(r8), intent(inout) :: tanpools(4) ! TAN pools gN/m2
+    real(r8), intent(out) :: fluxes(5,4) ! TAN fluxes, gN/m2/s (type of flux, pool)
+    real(r8), intent(in) :: Hconc(4) ! H+ concentration
+    real(r8), intent(out) :: garbage     ! over-aged TAN occurring during the step, gN/m.
+    real(r8), intent(in) :: dt ! timestep, sec, >0
+    integer, intent(out) :: status ! return status, 0 = good
+    
+    real(r8) :: infiltr_slurry, infiltrated, percolated, evap_slurry, water_slurry(2), perc_slurry_mean, waterloss
+    real(r8) :: percolation, water_soil, age_prev, water_in_layer, tanpools_old(4)
+    integer :: indpl
+    
+    real(r8), parameter :: dz_layer = 0.02 ! thickness of the volatilization layer, m
+    ! H+ concentration in each pool 
+    !real(r8), parameter :: Hconc(4) = (/10.0_r8**(-8.0_r8), 10.0_r8**(-8.0_r8), 10.0_r8**(-8.0_r8), 10.0_r8**(-7_r8)/)
+
+    if (theta > thetasat) then
+       status = err_bad_theta
+       return
+    end if
+
+    tanpools_old = tanpools
+
+    ! Pool S0
+    !
+    evap_slurry = get_evap_pool(tg, ratm, qbot)
+    infiltr_slurry = max(depth_slurry / poolranges(1), precip)
+    infiltrated = depth_slurry * infiltr_slurry / (infiltr_slurry + evap_slurry)
+    ! Slurry water (in addition to soil water, theta) on surface and in soil. Represents
+    ! mean over pool S0.
+    water_slurry = (/0.5*depth_slurry, 0.5*infiltrated/) 
+    ! The excess water assumed to have percolated down from the volat. layer.
+    percolated = max(infiltrated - dz_layer*(thetasat-theta), 0.0)
+    ! Percolation rate out of volat layer, average over the pool S0.
+    perc_slurry_mean = percolated / poolranges(1)
+
+    call eval_fluxes_slurry(water_slurry, tanpools(1), Hconc(1), tg, ratm, theta, thetasat, perc_slurry_mean, &
+         runoff, cnc_nh3_air, fluxes(:,1))
+
+    if (any(isnan(fluxes))) then
+       status = err_nan * 10
+    end if
+    
+    !tanpools(1) = tanpools(1) - sum(fluxes(:,1)) * dt
+    call update_pools(tanpools(1:1), fluxes(1:5,1:1), dt, 1, 5)
+
+    if (any(tanpools < -1e-15)) then
+       status = err_negative_tan
+       return
+    end if
+    
+    ! Pool aging & input
+    !
+    call age_pools_slurry(tandep, dt, water_slurry, tanpools(1), tanpools(2:), poolranges, garbage)
+    ! TAN produced (mineralization) goes to directly the old TAN pool. 
+    tanpools(4) = tanpools(4) + tanprod*dt
+
+    ! Soil bins S1 and S2
+    !
+    age_prev = 0 ! for water evaluations, consider beginning of S1 as the starting point
+    water_in_layer = infiltrated - percolated ! water in layer just after slurry has infiltrated
+    do indpl = 2, 4
+       ! water content lost during the aging
+       waterloss = water_in_layer * (waterfunction(age_prev) - waterfunction(age_prev+poolranges(indpl)))
+       percolation = eval_perc(waterloss, evap, precip, watertend, poolranges(indpl))
+       !print *, water_in_layer*waterfunction(age_prev), water_in_layer*waterfunction(age_prev+poolranges(indpl))
+       ! water content at the mean age of the pool
+       water_soil = water_in_layer * waterfunction(age_prev + 0.5*poolranges(indpl))
+       !print *, tanpools(indpl), water_soil, Hconc(indpl), tg, &
+       !     & ratm, theta, thetasat, percolation, runoff, cnc_nh3_air, &
+       !     & dz_layer
+       call eval_fluxes_soil(tanpools(indpl), water_soil, Hconc(indpl), tg, &
+            & ratm, theta, thetasat, percolation, runoff, cnc_nh3_air, &
+            & dz_layer, fluxes(:,indpl), subst_tan, status)
+       if (status /= 0) return
+       !print *, fluxes(4,indpl), percolation, waterloss
+       !fluxes(:,indpl) = 0
+       !fluxes(5:,indpl) = 0
+       !tanpools(indpl) = tanpools(indpl) - sum(fluxes(:,indpl)) * dt
+       age_prev = age_prev + poolranges(indpl)
+    end do
+    
+    call update_pools(tanpools(2:), fluxes(1:5,2:), dt, 3, 5)
+    
+    if (any(tanpools < -1e-15)) then
+       !if (any(tanpools < -1e-3)) then
+       status = err_negative_tan * 10
+       return
+       !end if
+    end if
+
+    if (any(isnan(fluxes))) then
+       status = err_nan * 100
+    end if
+
+    if (abs(sum(tanpools - tanpools_old) - (-sum(fluxes) + tandep + tanprod)*dt + garbage) > max(sum(tanpools_old)*1e-2, 1e-4)) then
+       !print *, sum(tanpools_old), sum(tanpools), sum(tanpools - tanpools_old)
+       !print *, sum(fluxes), tandep*dt, tanprod*dt
+       status = err_balance_tan
+       return
+    end if
+    !print *, sum(tanpools), sum(tanpools - tanpools_old) !+ garbage
+    
+    status = 0
+    
+  end subroutine update_4pool
+  
+  subroutine update_npool(tg, ratm, theta, thetasat, precip, evap, qbot, watertend, runoff, tandep, tanprod, &
+       water_init, cnc_nh3_air, poolranges, Hconc, dz_layer, tanpools, fluxes, garbage, dt, status, numpools)
+    !
+    ! Evaluate fluxes and update TAN pools for a model with arbitrary number of pools
+    ! divided by age and pH.
+    ! 
+    implicit none
+    real(r8), intent(in) :: tg ! soil temperature, K
+    real(r8), intent(in) :: ratm ! atmospheric resistance, s/m
+    real(r8), intent(in) :: theta ! volumetric soil water in soil column (unaffected by slurry)
+    real(r8), intent(in) :: thetasat ! vol. soil water at saturation
+    real(r8), intent(in) :: precip   ! precipitation, m/s
+    real(r8), intent(in) :: evap   ! ground evaporation, m/s
+    real(r8), intent(in) :: qbot   ! specific humidity (kg/kg) at lowest atmospheric model level
+    real(r8), intent(in) :: watertend ! time derivative of theta*dz
+    real(r8), intent(in) :: runoff    ! surface runoff flux, m/s
+    real(r8), intent(in) :: tandep    ! TAN input flux, gN/m2/s
+    real(r8), intent(in) :: tanprod(numpools)   ! flux of TAN produced (from urea/organic n) in the column
+    real(r8), intent(in) :: water_init ! Initial water volume in the affected patch, m
+    real(r8), intent(in) :: cnc_nh3_air ! NH3 concentration in air, gN/m3
+    real(r8), intent(in) :: poolranges(numpools)  ! age ranges of TAN pools (npools)
+    real(r8), intent(in) :: Hconc(numpools)       ! H+ concentration, mol/l (npools)
+    real(r8), intent(in) :: dz_layer ! thickness of the volatilization layer, m
+    real(r8), intent(inout) :: tanpools(numpools) ! TAN pools gN/m2 (npools)
+    real(r8), intent(out) :: fluxes(5,numpools) ! TAN fluxes, gN/m2/s (type of flux, pool)
+    real(r8), intent(out) :: garbage     ! "over-aged" TAN produced during the step, gN/m.
+    real(r8), intent(in) :: dt ! timestep, sec, >0
+    integer, intent(out) :: status ! 0 == OK
+    integer, intent(in) :: numpools
+    
+    real(r8) :: fraction_layer, fraction_reservoir, fraction_runoff, waterloss, direct_runoff
+    real(r8) :: percolation, water_soil, age_prev, tandep_remaining, direct_percolation, water_into_layer
+    real(r8) :: tanpools_old(size(tanpools)), imbalance
+    integer :: indpl
+    
+    real(r8), parameter :: water_relax_t = 24*3600.0_r8
+    logical :: fixed
+
+    tanpools_old = tanpools
+    
+    if (theta > thetasat) then
+       !print *, 'bad theta update_npool 1', theta, thetasat
+       status = err_bad_theta
+       return
+    end if
+    
+    ! Initial water excess goes to runoff if the surface is close to saturation, otherwise to the soil.
+    !
+    call partition_to_layer(water_init, theta, thetasat, dz_layer, fraction_layer, fraction_reservoir, fraction_runoff)
+    direct_runoff = fraction_runoff * tandep
+    direct_percolation = fraction_reservoir * tandep
+    tandep_remaining = tandep - direct_runoff - direct_percolation
+    water_into_layer = water_init * (1.0_r8 - fraction_reservoir - fraction_runoff)
+    if (tandep_remaining < -1e-15) then
+       status = err_negative_tan + 10
+       return
+    end if
+    if (water_into_layer/dz_layer + theta > thetasat+1e-5) then
+       status = err_bad_theta
+       return
+    end if
+
+    if(any(isnan(tanpools))) then
+       status = err_nan 
+       return
+    end if
+    
+    ! Pool aging & TAN input
+    !
+    call age_pools_soil(tandep_remaining, dt, poolranges, tanpools, garbage)
+    ! TAN produced (mineralization) goes to directly the old TAN pool. 
+    
+    if (any(tanpools < 0)) then
+       if (any(tanpools < -1e-15)) then
+          print *, '<0 2', tanpools_old, 'new', tanpools, 'fx', &
+               sum(fluxes(:,1)) * dt, sum(fluxes(:,2)) * dt, sum(fluxes(:,3)) * dt
+          status = err_negative_tan + 10000
+          return
+       else
+          where(tanpools<0) tanpools = 0.0
+       end if
+    end if
+
+    imbalance = abs((sum(tanpools) - sum(tanpools_old)) - ((tandep_remaining)*dt+garbage))
+    if (imbalance > max(1e-14, 0.001*sum(tanpools_old))) then
+       print *, imbalance, 'old', tanpools_old, 'new', tanpools, 'g', garbage, tandep_remaining, &
+            'diff', sum(tanpools_old-tanpools), &
+            'depprod', tandep+sum(tanprod), garbage
+       status = err_balance_tan*10
+       return
+    end if
+    
+    age_prev = 0 ! for water evaluations, consider beginning of S1 as the starting point
+    do indpl = 1, size(tanpools)
+       ! water content lost during the aging
+       waterloss = water_into_layer * (waterfunction(age_prev) - waterfunction(age_prev+poolranges(indpl)))
+       percolation = eval_perc(waterloss, evap, precip, watertend, poolranges(indpl))
+       ! water content at the middle of the age range
+       water_soil = water_into_layer * waterfunction(age_prev + 0.5*poolranges(indpl))
+       !call eval_fluxes_soil(tanpools(indpl), water_soil, Hconc(indpl), tg, &
+       !call eval_fluxes_soil_3p(tanpools(indpl), water_soil, Hconc(indpl), tg, &
+       call eval_fluxes_soilroff(tanpools(indpl), water_soil, Hconc(indpl), tg, &
+            & ratm, theta, thetasat, percolation, runoff, cnc_nh3_air, &
+            & dz_layer, fluxes(:,indpl), subst_tan, status)
+       if (status /= 0) then
+          return
+       end if
+       age_prev = age_prev + poolranges(indpl)
+    end do
+    
+    call update_pools(tanpools, fluxes, dt, numpools, 5, fixed)
+    !print *, 'pools just after', tanpools
+    tanpools = tanpools + tanprod*dt
+    if(any(isnan(tanpools))) then
+       status = err_nan+100
+       return
+    end if
+    
+    if (any(isnan(fluxes))) then
+       status = err_nan + 1000
+    end if
+    
+    if (any(tanpools < -1e-15)) then
+       status = err_negative_tan + 1000
+       print *, '<0 2', tanpools_old, tanpools, sum(fluxes(:,1)) * dt, sum(fluxes(:,2)) * dt
+       
+       return
+    end if
+    
+    
+    if (abs(sum(tanpools - tanpools_old) + (sum(fluxes)-tandep_remaining-sum(tanprod))*dt + garbage) &
+         > max(sum(tanpools_old)*1e-2, 1d-2)) then
+       print *, tanpools, tanpools_old, 'fx', fluxes*dt, 'dp', tandep_remaining*dt, tanprod*dt, 'g', garbage, &
+            'ib', sum(tanpools-tanpools_old), (sum(fluxes)-tandep_remaining-sum(tanprod))*dt + garbage, 'fix', fixed
+       status = err_balance_tan
+       return
+    end if
+
+    ! Add the "direct" fluxes to the fluxes of the first pool 
+    fluxes(iflx_roff, 1) = fluxes(iflx_roff, 1) + direct_runoff
+    fluxes(iflx_soilq, 1) = fluxes(iflx_soilq, 1) + direct_percolation
+    
+    if (any(fluxes < -1e-6)) then
+       print *, fluxes
+       status = err_negative_flux
+       return
+    end if
+    
+    status = 0
+    
+  end subroutine update_npool
+
+  subroutine update_pools(tanpools, fluxes, dt, np, nf, fixed)
+    ! Update tan pools using the fluxes and an ad-hoc scheme agains negative TAN masses.
+    implicit none
+    real(r8), intent(inout) :: tanpools(np), fluxes(nf,np)
+    real(r8), intent(in) :: dt
+    integer, intent(in) :: np, nf
+    logical, intent(out), optional :: fixed
+
+    integer :: ip
+    real(r8) :: sumflux, ff
+    logical :: fixed_
+
+    fixed_ = .false.
+    do ip = 1, np
+       sumflux = sum(fluxes(:,ip))*dt
+       if (sumflux > tanpools(ip)) then
+          if (sumflux > 1e-15) then
+             fixed_ = .true.
+             ff = tanpools(ip) / sumflux
+             fluxes(:,ip) = fluxes(:,ip) * ff
+             sumflux = tanpools(ip)
+             sumflux = sum(fluxes(:,ip))*dt
+          else
+             sumflux = 0.0
+          end if
+       end if
+       tanpools(ip) = tanpools(ip) - sumflux
+    end do
+    if (present(fixed)) fixed = fixed_
+    
+  end subroutine update_pools
+  
+  function get_evap_pool(tg, ratm, qbot) result(evap)
+    ! Evaluate evaporation rate for surface water given spcific humidity at the reference
+    ! height.
+    implicit none
+    real(r8), intent(in) :: tg, ratm, qbot
+    real(r8) :: evap ! m/s
+
+    real(r8) :: es, esdt, qs, qsdt, dens, flux
+    real(r8), parameter :: press = 101300.0_r8
+    
+    call qsat(tg, press, es, esdt, qs, qsdt)
+    if (qbot > qs) then
+       evap = 0
+       return
+    end if
+
+    dens = press / (SHR_CONST_RDAIR * tg)
+    flux = dens * (qs - qbot) / ratm ! kg/s/m2 == mm/s
+    evap = flux*1e-3
+    
+  end function get_evap_pool
+
+  function waterfunction(pool_age) result(water)
+    implicit none
+    real(r8), intent(in) :: pool_age ! sec
+    real(r8) :: water
+
+    water = exp(-pool_age / water_relax_t)
+  end function waterfunction
+
+  function eval_perc(waterloss, evap, precip, watertend, dt) result(rate)
+    !
+    ! Evaluate the downwards water flux at the layer bottom given the infiltration and
+    ! evaporation fluxes.
+    implicit none
+    real(r8), intent(in) :: waterloss ! total water loss during dt, m
+    real(r8), intent(in) :: evap ! average evaporation rate, m/s
+    real(r8), intent(in) :: precip ! average infiltration rate, m/s
+    real(r8), intent(in) :: watertend ! background water tendency, m/s
+    real(r8), intent(in) :: dt ! timespan, s
+
+    real(r8) :: rate ! percolation rate, m/s
+    real(r8) :: perc_base, perc_adj
+    
+    perc_base = waterloss / dt
+    perc_adj = perc_base + precip - evap - watertend
+    rate = max(perc_adj, 0.0)
+
+  end function eval_perc
+
+  subroutine eval_fluxes_storage(nitr_input, tempr_outside, windspeed, fract_direct, &
+       volat_coef_barns, volat_coef_stores, &
+       tan_fract_excr, fluxes_nitr, fluxes_tan, status)
+    !
+    ! Evaluate nitrogen fluxes in animal housings and storage. Only volatilization losses
+    ! are assumed. The volatilization fluxes are assumed to depend linearly on the TAN
+    ! fluxes entering the housings or storage. The base coefficients are given as
+    ! arguments and adjusted according the model of Gyldenkaerne et al.
+    ! 
+    implicit none
+    real(r8), intent(in) :: nitr_input ! total nitrogen excreted by animals in housings
+    real(r8), intent(in) :: tempr_outside ! K
+    real(r8), intent(in) :: windspeed ! m/s
+    real(r8), intent(in) :: fract_direct
+    real(r8), intent(in) :: volat_coef_barns, volat_coef_stores
+    real(r8), intent(in) :: tan_fract_excr ! fraction of NH4 nitrogen in excreted N
+    real(r8), intent(out) :: fluxes_nitr(4), fluxes_tan(4)
+    integer, intent(out) :: status
+
+    ! parameters for the Gyldenkaerne et al. parameterization
+    real(r8), parameter :: Tfloor_barns = 4.0_8, Tfloor_stores = 1.0_8
+    real(r8), parameter :: Tmin_barns = 0_8
+    real(r8), parameter :: Tmax_barns = 12.5_8
+    real(r8), parameter :: tempr_D = 3.0
+    real(r8), parameter :: Vmin_barns = 0.2_8
+    real(r8), parameter :: Vmax_barns = 0.228_8
+    real(r8), parameter :: pA = 0.89_8, pB = 0.26_8  
+    
+    real(r8) :: flux_avail, flux_avail_tan, tempr_stores, tempr_barns, vent_barns, flux_direct, flux_direct_tan, &
+         & flux_barn, flux_store, tempr_C
+    
+    fluxes_nitr = 0.0_r8
+    fluxes_tan = 0.0_r8
+    tempr_C = tempr_outside - 273
+    
+    tempr_barns = max(tempr_C+tempr_D, Tfloor_barns)
+    if (tempr_C < Tmin_barns) then
+       vent_barns = Vmin_barns
+    else if (tempr_C > Tmax_barns) then
+       vent_barns = Vmax_barns
+    else
+       vent_barns = Vmin_barns + tempr_C * (Vmax_barns-Vmin_barns) / (Tmax_barns - Tmin_barns)
+    end if
+
+    flux_avail = nitr_input
+    flux_avail_tan = nitr_input * tan_fract_excr
+
+    if (flux_avail < -1e-15 .or. flux_avail_tan < -1e-15) then
+       status = err_negative_flux
+       return
+    end if
+    
+    flux_barn = flux_avail_tan * volat_coef_barns * tempr_barns**pA * vent_barns**pB
+
+    fluxes_tan(iflx_air_barns) = flux_barn
+    fluxes_nitr(iflx_air_barns) = flux_barn
+    
+    flux_avail = flux_avail - flux_barn
+    flux_avail_tan = flux_avail_tan - flux_barn
+
+    if (flux_avail < 0 .or. flux_avail_tan < 0) then
+       status = err_negative_flux
+       return
+    end if
+    
+    flux_direct = fract_direct * flux_avail
+    flux_avail = flux_avail - flux_direct
+    flux_direct_tan = flux_avail_tan * fract_direct
+    flux_avail_tan = flux_avail_tan - flux_direct_tan
+
+    fluxes_tan(iflx_appl) = flux_direct_tan
+    fluxes_nitr(iflx_appl) = flux_direct
+
+    tempr_stores = max(Tfloor_stores, tempr_C)
+    flux_store = flux_avail_tan &
+         & * volat_coef_stores * tempr_stores**pA * windspeed**pB
+    flux_store = min(flux_avail_tan, flux_store)
+
+    fluxes_tan(iflx_air_stores) = flux_store
+    fluxes_nitr(iflx_air_stores) = flux_store
+    
+    flux_avail = flux_avail - flux_store
+    flux_avail_tan = flux_avail_tan - flux_store
+    if (flux_avail < 0) then
+       !print *, 'stores'
+       status = err_negative_flux
+       return
+    end if
+
+    fluxes_nitr(iflx_to_store) = flux_avail
+    fluxes_tan(iflx_to_store) = flux_avail_tan
+    
+    if (abs(sum(fluxes_nitr) - nitr_input) > 1e-5*nitr_input) then
+       !print *, fluxes_nitr, sum(fluxes_nitr), nitr_input
+       status = err_balance_nitr
+       return
+    end if
+
+    if (abs(sum(fluxes_tan) - nitr_input*tan_fract_excr) > 1e-5*nitr_input) then
+       status = err_balance_tan
+       return
+    end if
+
+    if (any(fluxes_nitr < 0) .or. any(fluxes_tan < 0)) then
+       !print *, 'final'
+       status = err_negative_flux
+       return
+    end if
+    
+    status = 0
+    
+  end subroutine eval_fluxes_storage
+
+  subroutine update_org_n(flux_input, tg, pools, dt, tanprod, soilflux)
+    !
+    ! Evaluate the decomposition/mineralization N fluxes from the available, resistant and
+    ! unavailable N fractions, and update the organic N pools. In addition, evaluate the
+    ! flux of organic N into the soil pools according to a fixed time constant set below.
+    implicit none
+    real(r8), intent(in) :: flux_input(3) ! organic N entering the pools. gN/m2/s. For
+                                          ! indices see at top of the module.
+    real(r8), intent(in) :: tg          ! ground temperature, K
+    real(r8), intent(inout) :: pools(3) ! organic N pools
+    real(r8), intent(in) :: dt       ! timestep, sec
+    real(r8), intent(out) :: tanprod(3)      ! Flux of TAN formed, both pools
+    real(r8), intent(out) :: soilflux  ! Flux of organic nitrogen to soil
+
+    real(r8) :: rate_res, rate_avail, TR
+    real(r8), parameter :: ka1 = 8.94e-7_r8, ka2 = 6.38e-8 ! 1/s
+    real(r8), parameter :: tr1 = 0.0106, tr2 = 0.12979 
+    real(r8), parameter :: org_to_soil_time = 365*24*3600.0_r8
+
+    real(r8) :: soilfluxes(3)
+    
+    TR = tr1 * exp(tr2 * (tg-273.15_r8))
+    tanprod(ind_avail) = ka1 * TR * pools(ind_avail)
+    tanprod(ind_resist) = ka2 * TR * pools(ind_resist)
+    tanprod(ind_unavail) = 0.0
+    soilfluxes = pools * 1.0_r8 / org_to_soil_time
+
+    pools = pools + (flux_input - tanprod - soilfluxes) * dt
+    soilflux = sum(soilfluxes)
+    
+  end subroutine update_org_n
+
+  subroutine update_urea(tg, theta, thetasat, precip, evap, watertend, runoff, &
+       ndep, pools, fluxes, garbage, ranges, dt, status, numpools)
+    !
+    ! Evaluate fluxes and update the urea pools. The procedure is similar to updating the
+    ! soil TAN pools, but NO3 and volatilization fluxes do not occur.
+    ! 
+    implicit none
+    real(r8), intent(in) :: tg ! soil temperature, K
+    real(r8), intent(in) :: theta ! volumetric soil water in soil column (background)
+    real(r8), intent(in) :: thetasat ! vol. soil water at saturation
+    real(r8), intent(in) :: precip   ! precipitation, m/s
+    real(r8), intent(in) :: evap   ! ground evaporation, m/s
+    real(r8), intent(in) :: watertend ! time derivative of theta*dz
+    real(r8), intent(in) :: runoff    ! surface runoff flux, m/s
+    real(r8), intent(in) :: ndep
+    real(r8), intent(inout) :: pools(numpools)
+    real(r8), intent(out) :: fluxes(6, numpools) ! one extra for the to_tan flux
+    real(r8), intent(in) :: ranges(numpools)
+    real(r8), intent(out) :: garbage
+    real(r8), intent(in) :: dt
+    integer, intent(out) :: status
+    integer, intent(in) :: numpools
+
+    real(r8), parameter :: rate = 4.83e-6 ! 1/s
+    real(r8), parameter :: missing = 1e36 ! for the parameters not needed for urea fluxes
+    real(r8), parameter :: dz_layer = 0.02 ! thickness of the volatilization layer, m
+    
+    real(r8) :: age_prev, percolation, old_total, balance
+    integer :: indpl
+
+    old_total = sum(pools)
+    
+    call age_pools_soil(ndep, dt, ranges, pools, garbage)
+
+    age_prev = 0 
+    do indpl = 1, numpools
+       percolation = eval_perc(0.0_r8, evap, precip, watertend, ranges(indpl))
+       call eval_fluxes_soilroff(pools(indpl), 0.0_r8, missing, tg, &
+       !call eval_fluxes_soil(pools(indpl), 0.0_r8, missing, tg, &
+            & missing, theta, thetasat, percolation, runoff, missing, &
+            & dz_layer, fluxes(1:5,indpl), subst_urea, status)
+       if (status /= 0) then
+          return
+       end if
+       fluxes(iflx_to_tan, indpl) = rate*pools(indpl)
+       age_prev = age_prev + ranges(indpl)
+    end do
+
+    ! Here goes also flux_tan!
+    call update_pools(pools, fluxes, dt, numpools, 6)
+
+    balance = sum(pools) - old_total
+    if (abs(balance - (ndep-sum(fluxes))*dt + garbage) > 1e-9) then
+       print *, balance, 'f', sum(fluxes)*dt, ndep*dt, (ndep-sum(fluxes))*dt-garbage - balance, &
+            'p', pools, 'g', garbage
+       status = err_balance_nitr
+       return
+    end if
+
+    status = 0
+    
+  end subroutine update_urea
+  
+  subroutine get_storage_fluxes_tan_ar(manure_excr, tempr_outside, windspeed, fract_direct, &
+     & flux_direct, flux_direct_tan, flux_barn, flux_store, flux_resid, flux_resid_tan, &
+     & volat_target_barns, volat_target_stores, volat_coef_barns, volat_coef_stores, tan_fract_excr, nn)
+
+    real(8), intent(in), dimension(nn) :: manure_excr, tempr_outside, windspeed, fract_direct
+    real(8), intent(out), dimension(nn) :: flux_barn, flux_store, flux_direct, flux_resid, &
+         & flux_direct_tan, flux_resid_tan
+    real(8), intent(in) :: volat_target_barns, volat_target_stores, volat_coef_barns, volat_coef_stores, tan_fract_excr
+    integer, intent(in) :: nn
+
+    integer :: ii, status
+    real(r8) :: fluxes_nitr(4), fluxes_tan(4)
+    
+    do ii = 1, nn
+       call eval_fluxes_storage(manure_excr(ii), tempr_outside(ii), windspeed(ii), fract_direct(ii), &
+            & volat_coef_barns, volat_coef_stores, tan_fract_excr, &
+            & fluxes_nitr, fluxes_tan, status)
+
+       if (status /= 0) then
+          print *, 'Status = ', status
+          return
+       end if
+
+       flux_direct(ii) = fluxes_nitr(iflx_appl)
+       flux_direct_tan(ii) = fluxes_tan(iflx_appl)
+       flux_barn(ii) = fluxes_tan(iflx_air_barns)
+       flux_store(ii) = fluxes_tan(iflx_air_stores)
+       flux_resid(ii) = fluxes_nitr(iflx_to_store)
+       flux_resid_tan(ii) = fluxes_tan(iflx_to_store)
+       !print *, '1', fluxes_nitr(iflx_appl), flux_direct(ii)
+       
+    end do
+  end subroutine get_storage_fluxes_tan_ar
+  
+end module FanMod

--- a/components/clm/src/main/atm2lndType.F90
+++ b/components/clm/src/main/atm2lndType.F90
@@ -11,7 +11,7 @@ module atm2lndType
   use shr_megan_mod , only : shr_megan_mechcomps_n
   use clm_varpar    , only : numrad, ndst, nlevgrnd !ndst = number of dust bins.
   use clm_varcon    , only : rair, grav, cpair, hfus, tfrz, spval
-  use clm_varctl    , only : iulog, use_c13, use_cn, use_lch4, use_cndv, use_ed
+  use clm_varctl    , only : iulog, use_c13, use_cn, use_lch4, use_cndv, use_ed, use_fan
   use seq_drydep_mod, only : n_drydep, drydep_method, DD_XLND
   use decompMod     , only : bounds_type
   use abortutils    , only : endrun
@@ -82,6 +82,14 @@ module atm2lndType
      real(r8), pointer :: forc_aer_grc                  (:,:) => null() ! aerosol deposition array
      real(r8), pointer :: forc_pch4_grc                 (:)   => null() ! CH4 partial pressure (Pa)
 
+!JV
+     real(r8), pointer :: forc_ndep2_grc                (:)   => null() ! FAN nitrogen deposition (manure) rate (gN/m2/s)
+     real(r8), pointer :: forc_ndep3_grc                (:)   => null() ! FAN nitrogen deposition (fertilizer) rate (gN/m2/s)
+     real(r8), pointer :: forc_ndep_urea_grc            (:)   => null() ! FAN nitrogen deposition, urea fertilizer fraction
+     real(r8), pointer :: forc_ndep_nitr_grc            (:)   => null() ! FAN nitrogen deposition, nitrate fertilizer fraction
+     real(r8), pointer :: forc_soilph_grc               (:)   => null() ! FAN soil pH
+!JV
+     
      real(r8), pointer :: forc_t_not_downscaled_grc     (:)   => null() ! not downscaled atm temperature (Kelvin)       
      real(r8), pointer :: forc_th_not_downscaled_grc    (:)   => null() ! not downscaled atm potential temperature (Kelvin)    
      real(r8), pointer :: forc_q_not_downscaled_grc     (:)   => null() ! not downscaled atm specific humidity (kg/kg)  
@@ -279,6 +287,14 @@ contains
     end if
     allocate(this%t_mo_patch                    (begp:endp))        ; this%t_mo_patch               (:)   = nan
     allocate(this%t_mo_min_patch                (begp:endp))        ; this%t_mo_min_patch           (:)   = spval ! TODO - initialize this elsewhere
+
+    if ( use_fan ) then
+       allocate(this%forc_ndep2_grc             (begg:endg))        ; this%forc_ndep2_grc                (:)   = ival
+       allocate(this%forc_ndep3_grc             (begg:endg))        ; this%forc_ndep3_grc                (:)   = ival
+       allocate(this%forc_ndep_urea_grc         (begg:endg))        ; this%forc_ndep3_grc                (:)   = ival
+       allocate(this%forc_ndep_nitr_grc         (begg:endg))        ; this%forc_ndep3_grc                (:)   = ival
+       allocate(this%forc_soilph_grc            (begg:endg))        ; this%forc_soilph_grc               (:)   = ival
+    end if
 
   end subroutine InitAllocate
 

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -9,7 +9,7 @@ module clm_driver
   !
   ! !USES:
   use shr_kind_mod           , only : r8 => shr_kind_r8
-  use clm_varctl             , only : wrtdia, iulog, create_glacier_mec_landunit, use_ed
+  use clm_varctl             , only : wrtdia, iulog, create_glacier_mec_landunit, use_ed, use_fan
   use clm_varpar             , only : nlevtrc_soil, nlevsoi
   use clm_varctl             , only : wrtdia, iulog, create_glacier_mec_landunit, use_ed, use_betr  
   use clm_varctl             , only : use_cn, use_cndv, use_lch4, use_voc, use_noio, use_c13, use_c14
@@ -124,6 +124,8 @@ module clm_driver
   use VegetationType         , only : veg_pp
   use shr_sys_mod            , only : shr_sys_flush
   use shr_log_mod            , only : errMsg => shr_log_errMsg
+
+  use FanStreamMod           , only : fanstream_interp
 
   !----------------------------------------------------------------------------
   ! bgc interface & pflotran:
@@ -404,6 +406,10 @@ contains
 
 #endif
 
+    if (use_fan) then
+       call fanstream_interp(bounds_proc, atm2lnd_vars)
+    end if
+    
     ! ============================================================================
     ! Initialize variables from previous time step, downscale atm forcings, and
     ! Determine canopy interception and precipitation onto ground surface.
@@ -757,7 +763,7 @@ contains
                  canopystate_vars, soilstate_vars, temperature_vars, crop_vars, &
                  dgvs_vars, photosyns_vars, soilhydrology_vars, energyflux_vars,&
                  PlantMicKinetics_vars,                                         &
-                 phosphorusflux_vars, phosphorusstate_vars)
+                 phosphorusflux_vars, phosphorusstate_vars,frictionvel_vars)
 
            call CNAnnualUpdate(bounds_clump,            &
                   filter(nc)%num_soilc, filter(nc)%soilc, &
@@ -790,7 +796,7 @@ contains
                        atm2lnd_vars, waterstate_vars, waterflux_vars,                   &
                        canopystate_vars, soilstate_vars, temperature_vars, crop_vars,   &
                        ch4_vars, photosyns_vars,                                        &
-                       phosphorusflux_vars,phosphorusstate_vars)
+                       phosphorusflux_vars,phosphorusstate_vars,frictionvel_vars)
 
              !--------------------------------------------------------------------------------
              if (use_clm_interface) then

--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -11,7 +11,7 @@ module clm_initializeMod
   use abortutils       , only : endrun
   use clm_varctl       , only : nsrest, nsrStartup, nsrContinue, nsrBranch
   use clm_varctl       , only : create_glacier_mec_landunit, iulog
-  use clm_varctl       , only : use_lch4, use_cn, use_cndv, use_voc, use_c13, use_c14, use_ed, use_betr  
+  use clm_varctl       , only : use_lch4, use_cn, use_cndv, use_voc, use_c13, use_c14, use_ed, use_betr, use_fan
   use clm_varsur       , only : wt_lunit, urban_valid, wt_nat_patch, wt_cft, wt_glc_mec, topo_glc_mec
   use clm_varsur       , only : fert_cft
   use perf_mod         , only : t_startf, t_stopf
@@ -427,6 +427,8 @@ contains
     use tracer_varcon         , only : is_active_betr_bgc    
     use clm_time_manager      , only : is_restart
     use ALMbetrNLMod          , only : betr_namelist_buffer
+    use FanStreamMod          , only : fanstream_init, fanstream_interp
+
     !
     ! !ARGUMENTS    
     implicit none
@@ -788,6 +790,12 @@ contains
        call ndep_init(bounds_proc)
        call ndep_interp(bounds_proc, atm2lnd_vars)
        call t_stopf('init_ndep')
+       if ( use_fan ) then
+          call t_startf('init_ndep2')
+          call fanstream_init(bounds_proc, NLFilename)
+          call fanstream_interp(bounds_proc, atm2lnd_vars)
+          call t_stopf('init_ndep2')
+       end if
     end if
     
     ! ------------------------------------------------------------------------

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -305,7 +305,7 @@ module clm_varctl
   logical, public :: use_mexicocity      = .false.
   logical, public :: use_noio            = .false.
   logical, public :: use_var_soil_thick  = .false.
-
+  logical, public :: use_fan = .false.
   !----------------------------------------------------------
   ! VSFM switches
   !----------------------------------------------------------

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -130,7 +130,7 @@ contains
     ! ----------------------------------------------------------------------
 
     ! Time step
-    namelist / clm_inparm/ &
+    namelist /clm_inparm/ &
          dtime
 
     ! CLM namelist settings
@@ -304,6 +304,7 @@ contains
        call shr_nl_find_group_name(unitn, 'clm_inparm', status=ierr)
        if (ierr == 0) then
           read(unitn, clm_inparm, iostat=ierr)
+          print *, 'ierr:', ierr
           if (ierr /= 0) then
              call endrun(msg='ERROR reading clm_inparm namelist'//errMsg(__FILE__, __LINE__))
           end if

--- a/components/clm/src/main/fanStreamMod.F90
+++ b/components/clm/src/main/fanStreamMod.F90
@@ -1,0 +1,346 @@
+module FanStreamMod
+
+  !----------------------------------------------------------------------- 
+  ! !DESCRIPTION: 
+  ! Contains methods for reading in FAN nitrogen deposition (in the form of
+  ! manure) data file
+  ! Also includes functions for dynamic ndep2 file handling and 
+  ! interpolation.
+  !
+  ! !USES
+  use shr_kind_mod, only: r8 => shr_kind_r8, CL => shr_kind_cl
+  use shr_strdata_mod
+  use shr_stream_mod
+  use shr_string_mod
+  use shr_sys_mod
+  use shr_mct_mod
+  use mct_mod
+  use spmdMod     , only: mpicom, masterproc, comp_id, iam
+  use clm_varctl  , only: iulog
+  use abortutils  , only: endrun
+  use fileutils   , only: getavu, relavu
+  use decompMod   , only: bounds_type, ldecomp, gsmap_lnd_gdc2glo 
+  use domainMod   , only: ldomain
+!KO
+  use ndepStreamMod, only: clm_domain_mct
+!KO
+
+  ! !PUBLIC TYPES:
+  implicit none
+  private
+  save
+
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public :: fanstream_init     ! position datasets for dynamic ndep2
+  public :: fanstream_interp   ! interpolates between two years of ndep2 file data
+!KO  public :: clm_domain_mct ! Sets up MCT domain for this resolution
+
+  ! ! PRIVATE TYPES
+  type(shr_strdata_type)  :: sdat_past, sdat_mix, sdat_urea, sdat_nitr, sdat_soilph         ! input data streams
+  integer :: stream_year_first_fan      ! first year in stream to use
+  integer :: stream_year_last_fan       ! last year in stream to use
+  integer :: model_year_align_fan       ! align stream_year_firstfan with 
+
+  character(len=*), parameter, private :: sourcefile = &
+       __FILE__
+  !==============================================================================
+
+contains
+
+  !==============================================================================
+
+  subroutine fanstream_init(bounds, NLFilename)
+   !    
+   ! Initialize data stream information.  
+   !
+   ! Uses:
+   use clm_varctl       , only : inst_name
+   use clm_time_manager , only : get_calendar
+   use ncdio_pio        , only : pio_subsystem
+   use shr_pio_mod      , only : shr_pio_getiotype
+   use shr_nl_mod       , only : shr_nl_find_group_name
+   use shr_log_mod      , only : errMsg => shr_log_errMsg
+   !
+   ! arguments
+   implicit none
+   type(bounds_type), intent(in) :: bounds  
+   character(len=*),  intent(in) :: NLFilename   ! Namelist filename
+   !
+   ! local variables
+   integer            :: nu_nml    ! unit for namelist file
+   integer            :: nml_error ! namelist i/o error flag
+   type(mct_ggrid)    :: dom_clm   ! domain information 
+   character(len=CL)  :: stream_fldFileName_fan
+   character(len=CL)  :: fanmapalgo = 'bilinear'
+   character(*), parameter :: shr_strdata_unset = 'NOT_SET'
+   character(*), parameter :: subName = "('fandyn_init')"
+   character(*), parameter :: F00 = "('(fandyn_init) ',4a)"
+   !-----------------------------------------------------------------------
+
+   namelist /fan_nml/        &
+        stream_year_first_fan,  &
+	stream_year_last_fan,   &
+        model_year_align_fan,   &
+        fanmapalgo,             &
+        stream_fldFileName_fan
+
+   ! Default values for namelist
+    stream_year_first_fan  = 1                ! first year in stream to use
+    stream_year_last_fan   = 1                ! last  year in stream to use
+    model_year_align_fan   = 1                ! align stream_year_first_fan with this model year
+    stream_fldFileName_fan = ' '
+
+   ! Read fandyn_nml namelist
+   if (masterproc) then
+      nu_nml = getavu()
+      open( nu_nml, file=trim(NLFilename), status='old', iostat=nml_error )
+      call shr_nl_find_group_name(nu_nml, 'fan_nml', status=nml_error)
+      if (nml_error == 0) then
+         read(nu_nml, nml=fan_nml,iostat=nml_error)
+         if (nml_error /= 0) then
+            call endrun(msg=' ERROR reading fan_nml namelist'//errMsg(sourcefile, __LINE__))
+         end if
+      else
+         call endrun(msg=' ERROR finding fan_nml namelist'//errMsg(sourcefile, __LINE__))
+      end if
+      close(nu_nml)
+      call relavu( nu_nml )
+   endif
+
+   call shr_mpi_bcast(stream_year_first_fan, mpicom)
+   call shr_mpi_bcast(stream_year_last_fan, mpicom)
+   call shr_mpi_bcast(model_year_align_fan, mpicom)
+   call shr_mpi_bcast(stream_fldFileName_fan, mpicom)
+
+   if (masterproc) then
+      write(iulog,*) ' '
+      write(iulog,*) 'fan stream settings:'
+      write(iulog,*) '  stream_year_first_fan  = ',stream_year_first_fan
+      write(iulog,*) '  stream_year_last_fan   = ',stream_year_last_fan   
+      write(iulog,*) '  model_year_align_fan   = ',model_year_align_fan   
+      write(iulog,*) '  stream_fldFileName_fan = ',stream_fldFileName_fan
+      write(iulog,*) ' '
+   endif
+
+   call clm_domain_mct (bounds, dom_clm)
+
+   call shr_strdata_create(sdat_past,name="clmfanpast",    &
+        pio_subsystem=pio_subsystem,                & 
+        pio_iotype=shr_pio_getiotype(inst_name),    &
+        mpicom=mpicom, compid=comp_id,              &
+        gsmap=gsmap_lnd_gdc2glo, ggrid=dom_clm,     &
+        nxg=ldomain%ni, nyg=ldomain%nj,             &
+        yearFirst=stream_year_first_fan,          &
+        yearLast=stream_year_last_fan,            &
+        yearAlign=model_year_align_fan,           &
+        offset=0,                                   &
+        domFilePath='',                             &
+        domFileName=trim(stream_fldFileName_fan), &
+        domTvarName='time',                         &
+        domXvarName='x' ,                           &
+        domYvarName='y' ,                           &  
+        domAreaName='area',                         &
+        domMaskName='mask',                         &
+        filePath='',                                &
+        filename=(/trim(stream_fldFileName_fan)/),&
+        fldListFile='Nmanure_pastures',             &
+        fldListModel='Nmanure_pastures',            &
+        fillalgo='none',                            &
+        mapalgo=fanmapalgo,                       &
+        calendar=get_calendar(),                    &
+	taxmode='extend'                            )
+
+   if (masterproc) then
+      call shr_strdata_print(sdat_past,'CLMFAN data')
+   endif
+
+   call shr_strdata_create(sdat_mix,name="clmfanmixed",    &
+        pio_subsystem=pio_subsystem,                & 
+        pio_iotype=shr_pio_getiotype(inst_name),    &
+        mpicom=mpicom, compid=comp_id,              &
+        gsmap=gsmap_lnd_gdc2glo, ggrid=dom_clm,     &
+        nxg=ldomain%ni, nyg=ldomain%nj,             &
+        yearFirst=stream_year_first_fan,          &
+        yearLast=stream_year_last_fan,            &
+        yearAlign=model_year_align_fan,           &
+        offset=0,                                   &
+        domFilePath='',                             &
+        domFileName=trim(stream_fldFileName_fan), &
+        domTvarName='time',                         &
+        domXvarName='x' ,                           &
+        domYvarName='y' ,                           &  
+        domAreaName='area',                         &
+        domMaskName='mask',                         &
+        filePath='',                                &
+        filename=(/trim(stream_fldFileName_fan)/),&
+        fldListFile='Nmanure_mixed',                &
+        fldListModel='Nmanure_mixed',               &
+        fillalgo='none',                            &
+        mapalgo=fanmapalgo,                       &
+        calendar=get_calendar(),                    &
+	taxmode='extend'                            )
+
+   if (masterproc) then
+      call shr_strdata_print(sdat_mix,'CLMFAN data')
+   endif
+
+   call shr_strdata_create(sdat_urea,name="clmfanurea",    &
+        pio_subsystem=pio_subsystem,                & 
+        pio_iotype=shr_pio_getiotype(inst_name),    &
+        mpicom=mpicom, compid=comp_id,              &
+        gsmap=gsmap_lnd_gdc2glo, ggrid=dom_clm,     &
+        nxg=ldomain%ni, nyg=ldomain%nj,             &
+        yearFirst=stream_year_first_fan,          &
+        yearLast=stream_year_last_fan,            &
+        yearAlign=model_year_align_fan,           &
+        offset=0,                                   &
+        domFilePath='',                             &
+        domFileName=trim(stream_fldFileName_fan), &
+        domTvarName='time',                         &
+        domXvarName='x' ,                           &
+        domYvarName='y' ,                           &  
+        domAreaName='area',                         &
+        domMaskName='mask',                         &
+        filePath='',                                &
+        filename=(/trim(stream_fldFileName_fan)/),&
+        fldListFile='fract_urea',                &
+        fldListModel='fract_urea',               &
+        fillalgo='none',                            &
+        mapalgo='nn',                       &
+        calendar=get_calendar(),                    &
+	taxmode='extend'                            )
+
+   if (masterproc) then
+      call shr_strdata_print(sdat_urea,'CLMFAN data')
+   endif
+
+   call shr_strdata_create(sdat_nitr,name="clmfannitr",    &
+        pio_subsystem=pio_subsystem,                & 
+        pio_iotype=shr_pio_getiotype(inst_name),    &
+        mpicom=mpicom, compid=comp_id,              &
+        gsmap=gsmap_lnd_gdc2glo, ggrid=dom_clm,     &
+        nxg=ldomain%ni, nyg=ldomain%nj,             &
+        yearFirst=stream_year_first_fan,          &
+        yearLast=stream_year_last_fan,            &
+        yearAlign=model_year_align_fan,           &
+        offset=0,                                   &
+        domFilePath='',                             &
+        domFileName=trim(stream_fldFileName_fan), &
+        domTvarName='time',                         &
+        domXvarName='x' ,                           &
+        domYvarName='y' ,                           &  
+        domAreaName='area',                         &
+        domMaskName='mask',                         &
+        filePath='',                                &
+        filename=(/trim(stream_fldFileName_fan)/),&
+        fldListFile='fract_nitr',                &
+        fldListModel='fract_nitr',               &
+        fillalgo='none',                            &
+        mapalgo='nn',                       &
+        calendar=get_calendar(),                    &
+	taxmode='extend'                            )
+
+   call shr_strdata_create(sdat_soilph,name="clmfanph",    &
+        pio_subsystem=pio_subsystem,                & 
+        pio_iotype=shr_pio_getiotype(inst_name),    &
+        mpicom=mpicom, compid=comp_id,              &
+        gsmap=gsmap_lnd_gdc2glo, ggrid=dom_clm,     &
+        nxg=ldomain%ni, nyg=ldomain%nj,             &
+        yearFirst=stream_year_first_fan,          &
+        yearLast=stream_year_last_fan,            &
+        yearAlign=model_year_align_fan,           &
+        offset=0,                                   &
+        domFilePath='',                             &
+        domFileName=trim(stream_fldFileName_fan), &
+        domTvarName='time',                         &
+        domXvarName='x' ,                           &
+        domYvarName='y' ,                           &  
+        domAreaName='area',                         &
+        domMaskName='mask',                         &
+        filePath='',                                &
+        filename=(/trim(stream_fldFileName_fan)/),&
+        fldListFile='soilph',                &
+        fldListModel='fansoilph',               &
+        fillalgo='none',                            &
+        mapalgo='nn',                       &
+        calendar=get_calendar(),                    &
+	taxmode='extend'                            )
+
+   if (masterproc) then
+      call shr_strdata_print(sdat_mix,'CLMFAN data')
+   endif
+
+   
+ end subroutine fanstream_init
+  
+ !================================================================
+ subroutine fanstream_interp(bounds, atm2lnd_inst)
+
+   !-----------------------------------------------------------------------
+   use clm_time_manager, only : get_curr_date, get_days_per_year
+   use clm_varcon      , only : secspday
+   use atm2lndType     , only : atm2lnd_type
+   !
+   ! Arguments
+   type(bounds_type) , intent(in)    :: bounds  
+   type(atm2lnd_type), intent(inout) :: atm2lnd_inst
+   !
+   ! Local variables
+   integer :: g, ig 
+   integer :: year    ! year (0, ...) for nstep+1
+   integer :: mon     ! month (1, ..., 12) for nstep+1
+   integer :: day     ! day of month (1, ..., 31) for nstep+1
+   integer :: sec     ! seconds into current date for nstep+1
+   integer :: mcdate  ! Current model date (yyyymmdd)
+   integer :: dayspyr ! days per year
+   !-----------------------------------------------------------------------
+
+   call get_curr_date(year, mon, day, sec)
+   mcdate = year*10000 + mon*100 + day
+   dayspyr = get_days_per_year( )
+
+   call shr_strdata_advance(sdat_past, mcdate, sec, mpicom, 'clmfanpasture')
+
+   ig = 0
+   do g = bounds%begg,bounds%endg
+      ig = ig+1
+      atm2lnd_inst%forc_ndep3_grc(g) = sdat_past%avs(1)%rAttr(1,ig) / (secspday * dayspyr)
+   end do
+
+   call shr_strdata_advance(sdat_mix, mcdate, sec, mpicom, 'clmfanmixed')
+
+   ig = 0
+   do g = bounds%begg,bounds%endg
+      ig = ig+1
+      atm2lnd_inst%forc_ndep2_grc(g) = sdat_mix%avs(1)%rAttr(1,ig) / (secspday * dayspyr)
+   end do
+
+   call shr_strdata_advance(sdat_urea, mcdate, sec, mpicom, 'clmfanurea')
+
+   ig = 0
+   do g = bounds%begg,bounds%endg
+      ig = ig+1
+      atm2lnd_inst%forc_ndep_urea_grc(g) = sdat_urea%avs(1)%rAttr(1,ig)
+   end do
+
+   call shr_strdata_advance(sdat_nitr, mcdate, sec, mpicom, 'clmfannitr')
+
+   ig = 0
+   do g = bounds%begg,bounds%endg
+      ig = ig+1
+      atm2lnd_inst%forc_ndep_nitr_grc(g) = sdat_nitr%avs(1)%rAttr(1,ig)
+   end do
+
+   call shr_strdata_advance(sdat_soilph, mcdate, sec, mpicom, 'clmfanph')
+
+   ig = 0
+   do g = bounds%begg,bounds%endg
+      ig = ig+1
+      atm2lnd_inst%forc_soilph_grc(g) = sdat_soilph%avs(1)%rAttr(1,ig)
+   end do
+
+   
+ end subroutine fanstream_interp
+    
+end module FanStreamMod
+


### PR DESCRIPTION
This PR contains a prototype implementation of the FAN model (https://www.geosci-model-dev-discuss.net/gmd-2019-233/) in the E3SM Land Model. The model evaluates volatilization losses of nitrogen from fertilizers and livestock manure. The N fertilization rate and timing is determined by the crop model; the manure N is read from an additional stream file.

At present, the FAN code is only "one-way" coupled to the ELM N cycle: FAN uses the fertilization applied in crop model, but the losses evaluated by FAN are fed back to ELM. Therefore, enabling FAN should not change answers for any existing variables in ELM. The NH3 losses evaluated by FAN/ELM are generally similar to those in the CLM implementation except where the fertilizer applications differ.

