### PR TITLE
Fix the constant CO2 concentration value for BGC%BC compsets

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/cime/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -623,6 +623,7 @@
       <value compset="^20TR.*BGC%BCRD"                                >284.317</value>
       <value compset="^20TR.*BGC%BDRC"                                >284.317</value>
       <value compset="^20TR.*BGC%BDRD"                                >284.317</value>
+      <value compset="^SSP585.*BGC%B"                                 >284.317</value>  
       <!-- Override values based on CAM (WACCM) chemistry -->
       <value compset="CAM[45]%W"				>0.000001</value>
       <value compset="CAM[45]%SSOA"				>0.000001</value>


### PR DESCRIPTION
This PR adds a default setting for CCSM_CO2_PPMV for BGC%BC compsets, required for BGC runs. Changes to the maint-1.1 branch.

[BFB] for all tested configurations