### PR TITLE
Change se_fv_phys_remap_alg default to 1

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1572,7 +1572,7 @@
 <semi_lagrange_cdr_check> .false. </semi_lagrange_cdr_check>
 <semi_lagrange_nearest_point_lev> 0 </semi_lagrange_nearest_point_lev>
 
-<se_fv_phys_remap_alg> 0 </se_fv_phys_remap_alg>
+<se_fv_phys_remap_alg> 1 </se_fv_phys_remap_alg>
 
 <!-- ================================================================== -->
 <!-- Defaults for driver namelist seq_infodata_inparm                   -->


### PR DESCRIPTION
This changes the default physgrid mapping algorithm to the higher order version, which has proven to produce more realistic results.

[BFB] except for pg2 tests that do not use theta dycor option