### PR TITLE
Fix inconsistency in c12 maintenance respiration calculation

### DIFF
--- a/components/clm/src/data_types/VegetationDataType.F90
+++ b/components/clm/src/data_types/VegetationDataType.F90
@@ -8070,12 +8070,10 @@ module VegetationDataType
             this%psnshade_to_cpool(p)
 
        ! maintenance respiration (MR)
-       if ( trim(isotope) == 'c13' .or. trim(isotope) == 'c14') then
-          this%leaf_mr(p)      = this%leaf_curmr(p)      + this%leaf_xsmr(p)
-          this%froot_mr(p)     = this%froot_curmr(p)     + this%froot_xsmr(p)
-          this%livestem_mr(p)  = this%livestem_curmr(p)  + this%livestem_xsmr(p)
-          this%livecroot_mr(p) = this%livecroot_curmr(p) + this%livecroot_xsmr(p)
-       endif
+       this%leaf_mr(p)      = this%leaf_curmr(p)      + this%leaf_xsmr(p)
+       this%froot_mr(p)     = this%froot_curmr(p)     + this%froot_xsmr(p)
+       this%livestem_mr(p)  = this%livestem_curmr(p)  + this%livestem_xsmr(p)
+       this%livecroot_mr(p) = this%livecroot_curmr(p) + this%livecroot_xsmr(p)
 
        this%mr(p)  = &
             this%leaf_mr(p)     + &


### PR DESCRIPTION
For ELM, when use_pheno_flux_limiter=.true., the components
of maintance respiration are updated to avoid negative carbon
state variables. However, the total maintenance respiration
is not updated accordingly, causing an overesimation of total
maintenance respiration mr. Now this bug is fixed by ensuring
maintenance respiration is always recalculated by summing up
its components.

[non-BFB] due to very tiny value changes.

Fixes #3256 