### PR TITLE
Update CIME to ESMCI cime5.8.13

### DIFF
--- a/cime/ChangeLog
+++ b/cime/ChangeLog
@@ -1,6 +1,204 @@
 ======================================================================
 
 Originator: Chris Fischer 
+Date: 10-24-2019
+Tag: cime5.8.13
+Answer Changes: None
+Tests: scripts_regeression_tests
+Dependencies:
+
+Brief Summary:
+    - Add a raw xml option to the query_config interface.
+    - Add --only-job option to case.submit.
+
+User interface changes: 
+    - Add --xml to query_config.
+    - Add option --only-job to case.submit.
+    - Fix an issue with Lockedfile error when case.submit is used with the --no-batch flag.
+    - Change globally uniform SST mode from AQP11 to AQPCONST.
+
+PR summary: git log --oneline --first-parent [previous_tag]..master
+f22ebdafa Merge pull request #3268 from jedwards4b/add_xml_to_query_config
+ab4d53999 Merge pull request #3267 from jedwards4b/no_workflow
+4cd12246f Merge pull request #3265 from jedwards4b/fix_batch_lock_issue
+a45130996 Merge pull request #3257 from ESMCI/whannah/add-AQPCONST-mode
+
+Modified files: git diff --name-status [previous_tag]
+M       scripts/Tools/case.submit
+M       scripts/lib/CIME/XML/env_batch.py
+M       scripts/lib/CIME/case/case.py
+M       scripts/lib/CIME/case/case_submit.py
+M       scripts/lib/CIME/utils.py
+M       scripts/query_config
+M       src/components/data_comps/docn/cime_config/buildnml
+M       src/components/data_comps/docn/cime_config/config_component.xml
+M       src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+M       src/components/data_comps/docn/mct/docn_comp_mod.F90
+M       src/components/data_comps/docn/mct/docn_shr_mod.F90
+M       src/drivers/mct/cime_config/config_component.xml
+M       src/share/util/shr_scam_mod.F90
+
+======================================================================
+
+======================================================================
+
+Originator: Chris Fischer 
+Date: 10-15-2019
+Tag: cime5.8.12
+Answer Changes: None
+Tests: ERS.T5_T5_mg37.QPC4, scripts_regression_tests 
+Dependencies:
+
+Brief Summary:
+    - Add missing domain files for T5_T5_mg37 grid.
+    - Merge maint-5.6 to master 2019-11-10.
+    - Updates for cam testing updates.
+    - Fix nuopc esmf paths.
+
+User interface changes: 
+
+PR summary: git log --oneline --first-parent [previous_tag]..master
+7f1d48fe9 Merge pull request #3263 from ESMCI/fischer/T5_grid_fix
+3468404c1 Merge pull request #3260 from ESMCI/fischer/maint-5.6_merge
+7070d8a5c Merge pull request #3256 from ESMCI/fischer/cam_testing
+4a9b008f2 fix nuopc esmf paths
+
+Modified files: git diff --name-status [previous_tag]
+M       config/cesm/config_files.xml
+M       config/cesm/config_grids.xml
+M       config/cesm/machines/config_machines.xml
+M       config/cesm/machines/config_workflow.xml
+M       config/e3sm/machines/config_workflow.xml
+M       config/xml_schemas/config_workflow.xsd
+M       scripts/create_newcase
+M       scripts/lib/CIME/XML/workflow.py
+M       scripts/lib/CIME/case/case.py
+M       src/drivers/mct/cime_config/namelist_definition_drv.xml
+M       src/drivers/mct/main/seq_flux_mct.F90
+M       src/share/util/shr_flux_mod.F90
+
+======================================================================
+
+======================================================================
+
+Originator: Chris Fischer 
+Date: 10-01-2019
+Tag: cime5.8.11
+Answer Changes: None
+Tests: scripts_regression_tests, Hand tested SMS_D_Vnuopc.f09_g17.X.cheyenne_intel 
+Dependencies:
+
+Brief Summary:
+    - Correct the way esmf is built to avoid library mismatch.
+    - Update gnu compiler on cheyenne, bit for bit.
+
+User interface changes: 
+
+PR summary: git log --oneline --first-parent [previous_tag]..master
+693383167 Merge pull request #3252 from jedwards4b/nuopc_esmf_build_correction
+fcc629127 Merge pull request #3253 from ESMCI/fischer/gnu_fix
+
+Modified files: git diff --name-status [previous_tag]
+M       config/cesm/machines/config_machines.xml
+M       scripts/Tools/Makefile
+
+
+======================================================================
+
+======================================================================
+
+Originator: Chris Fischer 
+Date: 9-26-2019
+Tag: cime5.8.10
+Answer Changes: None
+Tests: scripts_regression_tests, tested with nuopc
+Dependencies:
+
+Brief Summary:
+    - Don't call mpi_bcast on null communicator.
+    - Fix nag compiler flags.
+    - Fix issue with workflow prior to run on master.
+    - Merge maint-5.6.
+    - Update esmf paths on cheyenne for nuopc.
+    - Fix issue in scripts_regression_tests.py.
+    - Fix issue 3232
+    - Update DROF(JRA) to MOM6 mapping file.
+    - acme split 2019-09-05 merge.
+    - Clean up some issues in scripts_regression_tests.py.
+    - Add /cluster/torque/bin to path on izumi.
+
+User interface changes: 
+
+PR summary: git log --oneline --first-parent [previous_tag]..master
+809bcb3b8 Merge pull request #3248 from jedwards4b/mct_null_comm_fix
+2a2b9ecfe Merge pull request #3244 from ESMCI/fischer/cam_nag_fix
+5f4f1c6da Merge pull request #3243 from jedwards4b/workflow_before_run_master
+23409d7e9 Merge pull request #3241 from ESMCI/fischer/maint-5.6_09182019
+47b630012 Merge pull request #3239 from jedwards4b/cheyenne_esmf_update
+00d664666 fix issue in scripts_regression_tests.py
+474dc5fc0 fix issue 3232
+209b1e19b Merge pull request #3233 from alperaltuntas/update_TL319_t061
+35bc87f4f Merge pull request #3230 from ESMCI/jgfouca/branch-for-acme-split-2019-09-05
+d2f7157b8 Merge pull request #3227 from jedwards4b/srt_update
+8bffca6d3 Merge pull request #3221 from billsacks/izumi_add_to_path
+
+
+Modified files: git diff --name-status [previous_tag]
+M	config/cesm/config_archive.xml
+M	config/cesm/config_grids_common.xml
+M	config/cesm/machines/Depends.nag
+M	config/cesm/machines/config_machines.xml
+M	config/e3sm/allactive/config_compsets.xml
+M	config/e3sm/allactive/config_pesall.xml
+M	config/e3sm/machines/config_batch.xml
+M	config/e3sm/machines/config_machines.xml
+M	config/e3sm/machines/config_pio.xml
+M	config/e3sm/tests.py
+M	config/xml_schemas/config_machines.xsd
+M	scripts/Tools/Makefile
+M	scripts/Tools/archive_metadata
+M	scripts/Tools/preview_run
+M	scripts/climate_reproducibility/README.md
+M	scripts/lib/CIME/SystemTests/mvk.py
+M	scripts/lib/CIME/SystemTests/pgn.py
+M	scripts/lib/CIME/SystemTests/tsc.py
+M	scripts/lib/CIME/XML/env_batch.py
+M	scripts/lib/CIME/XML/machines.py
+A	scripts/lib/CIME/XML/stream.py
+M	scripts/lib/CIME/case/case.py
+M	scripts/lib/CIME/case/case_setup.py
+M	scripts/lib/CIME/case/case_submit.py
+M	scripts/lib/CIME/nmlgen.py
+M	scripts/lib/CIME/utils.py
+M	scripts/tests/scripts_regression_tests.py
+M	src/build_scripts/buildlib.pio
+M	src/components/data_comps/datm/cime_config/buildnml
+M	src/components/data_comps/dice/cime_config/buildnml
+M	src/components/data_comps/dlnd/cime_config/buildnml
+M	src/components/data_comps/docn/cime_config/buildnml
+M	src/components/data_comps/docn/cime_config/config_component.xml
+M	src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+M	src/components/data_comps/docn/mct/docn_comp_mod.F90
+M	src/components/data_comps/docn/mct/docn_shr_mod.F90
+M	src/components/data_comps/drof/cime_config/buildnml
+M	src/components/data_comps/dwav/cime_config/buildnml
+M	src/drivers/mct/cime_config/buildnml
+M	src/drivers/mct/cime_config/config_component_cesm.xml
+M	src/drivers/mct/cime_config/config_component_e3sm.xml
+M	src/drivers/mct/cime_config/namelist_definition_drv.xml
+M	src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+M	src/drivers/mct/main/cime_comp_mod.F90
+M	src/drivers/mct/main/seq_flux_mct.F90
+M	src/drivers/mct/shr/seq_infodata_mod.F90
+M	src/share/streams/shr_tInterp_mod.F90
+M	src/share/util/shr_orb_mod.F90
+M	src/share/util/shr_scam_mod.F90
+
+======================================================================
+
+======================================================================
+
+Originator: Chris Fischer 
 Date: 8-29-2019
 Tag: cime5.8.9
 Answer Changes: None

--- a/cime/config/cesm/config_files.xml
+++ b/cime/config/cesm/config_files.xml
@@ -92,6 +92,7 @@
       <value>$CIMEROOT/config/config_tests.xml</value>
       <!-- component specific config_tests files -->
       <value component="clm">$COMP_ROOT_DIR_LND/cime_config/config_tests.xml</value>
+      <value component="cam">$COMP_ROOT_DIR_ATM/cime_config/config_tests.xml</value>
     </values>
     <group>test</group>
     <file>env_test.xml</file>

--- a/cime/config/cesm/config_grids.xml
+++ b/cime/config/cesm/config_grids.xml
@@ -197,6 +197,13 @@
       <mask>gx1v7</mask>
     </model_grid>
 
+    <model_grid alias="T5_T5_mg37" not_compset="_POP">
+      <grid name="atm">T5</grid>
+      <grid name="lnd">T5</grid>
+      <grid name="ocnice">T5</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+
     <model_grid alias="T85_T85_mg16" not_compset="_POP">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>
@@ -1300,6 +1307,13 @@
       <file grid="atm|lnd" mask="gx1v6">domain.lnd.T341_gx1v6.111226.nc</file>
       <desc>T341 is Gaussian grid:</desc>
       <support>Backward compatible for very high resolution Spectral-dycore experiments</support>
+    </domain>
+
+    <domain name="T5">
+      <nx>16</nx> <ny>8</ny>
+      <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T5_gx3v7.181009.nc</file>
+      <file grid="ocnice"  mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.T5_gx3v7.181009.nc</file>
+      <desc>T5 is Gaussian grid:</desc>
     </domain>
 
     <domain name="T85">

--- a/cime/config/cesm/machines/config_machines.xml
+++ b/cime/config/cesm/machines/config_machines.xml
@@ -441,11 +441,11 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">pgi/19.3</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gnu/7.3.0</command>
-        <command name="load">openblas/0.2.20</command>
+        <command name="load">gnu/8.3.0</command>
+        <command name="load">openblas/0.3.6</command>
       </modules>
       <modules mpilib="mpt" compiler="gnu">
-	<command name="load">mpt/2.16</command>
+	<command name="load">mpt/2.19</command>
 	<command name="load">netcdf-mpi/4.7.1</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
@@ -463,7 +463,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules mpilib="openmpi" compiler="gnu">
-        <command name="load">openmpi/3.0.1</command>
+        <command name="load">openmpi/3.1.4</command>
         <command name="load">netcdf/4.7.1</command>
       </modules>
       <modules>
@@ -487,16 +487,16 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_USE_ARRAY"/>
     </environment_variables>
     <environment_variables comp_interface="nuopc" mpilib="mpi-serial" DEBUG="FALSE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/turuncu/ESMF/8.0.0b50/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" mpilib="mpi-serial" DEBUG="TRUE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/turuncu/ESMF/8.0.0b50/lib/libg/Linux.intel.64.mpiuni.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="FALSE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/turuncu/ESMF/8.0.0b50/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="TRUE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/turuncu/ESMF/8.0.0b50/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>

--- a/cime/config/cesm/machines/config_workflow.xml
+++ b/cime/config/cesm/machines/config_workflow.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config_workflow version="2.0">
+<config_workflow version="2.1">
   <!--
   File: config_workflow.xml
   Purpose: Define the jobs to be run, the order to run them, the job size and
@@ -27,7 +27,7 @@
 	  The runtime_parameters block may have an optional MACH attribute.
 
   -->
-  <workflow_jobs case="default">
+  <workflow_jobs id="default">
     <!-- order matters, with no-batch jobs will be run in the order listed here -->
     <job name="case.run">
       <template>template.case.run</template>
@@ -50,7 +50,7 @@
     </job>
   </workflow_jobs>
 
-  <workflow_jobs case="timeseries" prepend="default">
+  <workflow_jobs id="timeseries" prepend="default">
     <job name="timeseries">
       <template>$ENV{POSTPROCESS_PATH}/timeseries/template.timeseries</template>
       <dependency>case.st_archive</dependency>
@@ -67,7 +67,7 @@
       </runtime_parameters>
     </job>
   </workflow_jobs>
-  <workflow_jobs case="timeseries_transfer" prepend="timeseries">
+  <workflow_jobs id="timeseries_transfer" prepend="timeseries">
     <job name="timeseries_transfer">
       <template>$ENV{POSTPROCESS_PATH}/timeseries/template.timeseries_transfer</template>
       <dependency>timeseries</dependency>
@@ -79,7 +79,7 @@
       </runtime_parameters>
     </job>
   </workflow_jobs>
-  <workflow_jobs case="diagnostics" prepend="timeseries">
+  <workflow_jobs id="diagnostics" prepend="timeseries">
     <job name="xconform">
       <template>$CASEROOT/postprocess/xconform</template>
       <dependency>timeseriesL</dependency>

--- a/cime/config/e3sm/machines/config_workflow.xml
+++ b/cime/config/e3sm/machines/config_workflow.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config_workflow version="2.0">
+<config_workflow version="2.1">
   <!--
   File: config_workflow.xml
   Purpose: Define the jobs to be run, the order to run them, the job size and
@@ -27,7 +27,7 @@
 	  The runtime_parameters block may have an optional MACH attribute.
 
   -->
-  <workflow_jobs case="default">
+  <workflow_jobs id="default">
     <!-- order matters, with no-batch jobs will be run in the order listed here -->
     <job name="case.run">
       <template>template.case.run</template>

--- a/cime/config/xml_schemas/config_workflow.xsd
+++ b/cime/config/xml_schemas/config_workflow.xsd
@@ -6,7 +6,7 @@
   <!-- attributes -->
   <xs:attribute name="version" type="xs:decimal"/>
   <xs:attribute name="MACH" type="xs:NCName"/>
-  <xs:attribute name="case" type="xs:NCName"/>
+  <xs:attribute name="id" type="xs:NCName"/>
   <xs:attribute name="prepend" type="xs:NCName"/>
   <xs:attribute name="append" type="xs:NCName"/>
   <xs:attribute name="name" type="xs:NCName"/>
@@ -35,7 +35,7 @@
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="job"/>
       </xs:sequence>
-      <xs:attribute ref="case" use="required"/>
+      <xs:attribute ref="id" use="required"/>
       <xs:attribute ref="prepend"/>
       <xs:attribute ref="append"/>
     </xs:complexType>

--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -320,14 +320,14 @@ endif
 # For compiling and linking with external ESMF.
 # If linking to external ESMF library then include esmf.mk
 # ESMF_F90COMPILEPATHS
-# ESMF_F90LINKPATHS
+# ESMF_F90ESMFLINKPATHS
 # ESMF_F90LINKRPATHS
 # ESMF_F90ESMFLINKLIBS
 ifeq ($(USE_ESMF_LIB), TRUE)
   -include $(CIME_ESMFMKFILE)
   CPPDEFS += -DESMF_VERSION_MAJOR=$(ESMF_VERSION_MAJOR) -DESMF_VERSION_MINOR=$(ESMF_VERSION_MINOR)
   FFLAGS += $(ESMF_F90COMPILEPATHS)
-  SLIBS  += $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
+  SLIBS  += $(ESMF_F90ESMFLINKPATHS) $(ESMF_F90ESMFLINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
 endif
 
 # Stub libraries do not need to be built for nuopc driver
@@ -613,18 +613,6 @@ ifdef LIB_MPI
    else
       SLIBS += -L$(LIB_MPI) -l$(MPI_LIB_NAME)
    endif
-endif
-
-# For compiling and linking with external ESMF.
-# If linking to external ESMF library then include esmf.mk
-# ESMF_F90COMPILEPATHS
-# ESMF_F90LINKPATHS
-# ESMF_F90LINKRPATHS
-# ESMF_F90ESMFLINKLIBS
-ifeq ($(USE_ESMF_LIB), TRUE)
-  -include $(CCSM_ESMFMKFILE)
-  FFLAGS += $(ESMF_F90COMPILEPATHS)
-  SLIBS  += $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
 endif
 
 # Add PETSc libraries

--- a/cime/scripts/Tools/case.submit
+++ b/cime/scripts/Tools/case.submit
@@ -17,6 +17,7 @@ Other examples:
 
 from standard_script_setup import *
 from CIME.case        import Case
+from CIME.utils        import expect
 from six.moves import configparser
 
 ###############################################################################
@@ -35,6 +36,13 @@ def parse_command_line(args, description):
     parser.add_argument("--job", "-j",
                         help="Name of the job to be submitted;\n"
                         "can be any of the jobs listed in env_batch.xml.\n"
+                        "This will be the first job of any defined workflow.  "
+                        "Default is case.run.")
+
+    parser.add_argument("--only-job",
+                        help="Name of the job to be submitted;\n"
+                        "can be any of the jobs listed in env_batch.xml.\n"
+                        "Only this job will be run, workflow and RESUBMIT are ignored.  "
                         "Default is case.run.")
 
     parser.add_argument("--no-batch", action="store_true",
@@ -70,15 +78,25 @@ def parse_command_line(args, description):
 
     CIME.utils.resolve_mail_type_args(args)
 
-    return (args.caseroot, args.job, args.no_batch, args.prereq, args.prereq_allow_failure,
+    expect(args.job is None or args.only_job is None, "Cannot specify both --job and --only-job")
+    job = None
+    workflow = True
+    if args.job:
+        job = args.job
+    elif args.only_job:
+        job = args.only_job
+        workflow = False
+
+
+    return (args.caseroot, job, args.no_batch, args.prereq, args.prereq_allow_failure,
             args.resubmit, args.resubmit_immediate, args.skip_preview_namelist, args.mail_user,
-            args.mail_type, args.batch_args)
+            args.mail_type, args.batch_args, workflow)
 
 ###############################################################################
 def _main_func(description, test_args=False):
 ###############################################################################
     caseroot, job, no_batch, prereq, allow_fail, resubmit, resubmit_immediate, skip_pnl, \
-        mail_user, mail_type, batch_args = parse_command_line(sys.argv, description)
+        mail_user, mail_type, batch_args, workflow = parse_command_line(sys.argv, description)
 
     # save these options to a hidden file for use during resubmit
     config_file = os.path.join(caseroot,".submit_options")
@@ -102,7 +120,7 @@ def _main_func(description, test_args=False):
         with Case(caseroot, read_only=False) as case:
             case.submit(job=job, no_batch=no_batch, prereq=prereq, allow_fail=allow_fail,
                         resubmit=resubmit, resubmit_immediate=resubmit_immediate, skip_pnl=skip_pnl,
-                        mail_user=mail_user, mail_type=mail_type, batch_args=batch_args)
+                        mail_user=mail_user, mail_type=mail_type, batch_args=batch_args, workflow=workflow)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/cime/scripts/create_newcase
+++ b/cime/scripts/create_newcase
@@ -94,7 +94,7 @@ def parse_command_line(args, cimeroot, description):
     else:
         workflow_default = "default"
 
-    parser.add_argument("--workflow-case",default=workflow_default,
+    parser.add_argument("--workflow",default=workflow_default,
                         help="A workflow from config_workflow.xml to apply to this case. ")
 
 
@@ -180,7 +180,7 @@ def parse_command_line(args, cimeroot, description):
         args.user_mods_dir, args.pesfile, \
         args.gridfile, args.srcroot, args.test, args.multi_driver, \
         args.ninst, args.walltime, args.queue, args.output_root, args.script_root, \
-        run_unsupported, args.answer, args.input_dir, args.driver, args.workflow_case, args.non_local
+        run_unsupported, args.answer, args.input_dir, args.driver, args.workflow, args.non_local
 
 ###############################################################################
 def _main_func(description):
@@ -219,7 +219,7 @@ def _main_func(description):
                     multi_driver=multi_driver, ninst=ninst, test=test,
                     walltime=walltime, queue=queue, output_root=output_root,
                     run_unsupported=run_unsupported, answer=answer,
-                    input_dir=input_dir, driver=driver, workflow_case=workflow, non_local=non_local)
+                    input_dir=input_dir, driver=driver, workflowid=workflow, non_local=non_local)
 
 ###############################################################################
 

--- a/cime/scripts/lib/CIME/Servers/wget.py
+++ b/cime/scripts/lib/CIME/Servers/wget.py
@@ -17,13 +17,13 @@ class WGET(GenericServer):
 
         cmd = "wget {} --no-check-certificate --spider {}".format(self._args, address)
         err, output, _ = run_cmd(cmd, combine_output=True)
-        expect(err == 0,"Could not connect to repo via '{}'\nThis is most likely either a proxy, or network issue.\nOutput:\n{}".format(cmd, output.encode('utf-8')))
+        expect(err == 0,"Could not connect to repo via '{}'\nThis is most likely either a proxy, or network issue.\nOutput:\n{}".format(cmd, output))
 
     def fileexists(self, rel_path):
         full_url = os.path.join(self._server_loc, rel_path)
         stat, out, err = run_cmd("wget {} --no-check-certificate --spider {}".format(self._args, full_url))
         if (stat != 0):
-            logging.warning("FAIL: Repo '{}' does not have file '{}'\nReason:{}\n{}\n".format(self._server_loc, full_url, out.encode('utf-8'), err.encode('utf-8')))
+            logging.warning("FAIL: Repo '{}' does not have file '{}'\nReason:{}\n{}\n".format(self._server_loc, full_url, out, err))
             return False
         return True
 
@@ -32,7 +32,7 @@ class WGET(GenericServer):
         stat, output, errput = \
                 run_cmd("wget {} {} -nc --no-check-certificate --output-document {}".format(self._args, full_url, full_path))
         if (stat != 0):
-            logging.warning("wget failed with output: {} and errput {}\n".format(output.encode('utf-8'), errput.encode('utf-8')))
+            logging.warning("wget failed with output: {} and errput {}\n".format(output, errput))
             # wget puts an empty file if it fails.
             try:
                 os.remove(full_path)
@@ -50,7 +50,7 @@ class WGET(GenericServer):
         logger.debug(output)
         logger.debug(errput)
         if (stat != 0):
-            logging.warning("wget failed with output: {} and errput {}\n".format(output.encode('utf-8'), errput.encode('utf-8')))
+            logging.warning("wget failed with output: {} and errput {}\n".format(output, errput))
             # wget puts an empty file if it fails.
             try:
                 os.remove(full_path)

--- a/cime/scripts/lib/CIME/XML/env_batch.py
+++ b/cime/scripts/lib/CIME/XML/env_batch.py
@@ -5,7 +5,7 @@ Interface to the env_batch.xml file.  This class inherits from EnvBase
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_base import EnvBase
 from CIME.utils import transform_vars, get_cime_root, convert_to_seconds, get_cime_config, get_batch_script_for_job, get_logging_options
-
+from CIME.locked_files import lock_file, unlock_file
 from collections import OrderedDict
 import stat, re, math
 
@@ -161,7 +161,11 @@ class EnvBatch(EnvBase):
             self.add_child(self.copy(batchobj.batch_system_node))
         if batchobj.machine_node is not None:
             self.add_child(self.copy(batchobj.machine_node))
+        if os.path.exists(os.path.join(self._caseroot, "LockedFiles", "env_batch.xml")):
+            unlock_file(os.path.basename(batchobj.filename), caseroot=self._caseroot)
         self.set_value("BATCH_SYSTEM", batch_system_type)
+        if os.path.exists(os.path.join(self._caseroot, "LockedFiles")):
+            lock_file(os.path.basename(batchobj.filename), caseroot=self._caseroot)
 
     def get_job_overrides(self, job, case):
         env_workflow = case.get_env('workflow')
@@ -428,7 +432,17 @@ class EnvBatch(EnvBase):
 
     def submit_jobs(self, case, no_batch=False, job=None, user_prereq=None, skip_pnl=False,
                     allow_fail=False, resubmit_immediate=False, mail_user=None, mail_type=None,
-                    batch_args=None, dry_run=False):
+                    batch_args=None, dry_run=False, workflow=True):
+        """
+          no_batch indicates that the jobs should be run directly rather that submitted to a queueing system
+          job is the first job in the workflow sequence to start
+          user_prereq is a batch system prerequisite as requested by the user
+          skip_pnl indicates that the preview_namelist should not be run by this job
+          allow_fail indicates that the prereq job need only complete not nessasarily successfully to start the next job
+          resubmit_immediate indicates that all jobs indicated by the RESUBMIT option should be submitted at the same time instead of
+                waiting to resubmit at the end of the first sequence
+          workflow is a logical indicating whether only "job" is submitted or the workflow sequence starting with "job" is submitted
+        """
         env_workflow = case.get_env('workflow')
         external_workflow = case.get_value("EXTERNAL_WORKFLOW")
         alljobs = env_workflow.get_jobs()
@@ -463,7 +477,7 @@ class EnvBatch(EnvBase):
         depid = OrderedDict()
         jobcmds = []
 
-        if resubmit_immediate:
+        if workflow and resubmit_immediate:
             num_submit = case.get_value("RESUBMIT") + 1
             case.set_value("RESUBMIT", 0)
             if num_submit <= 0:
@@ -498,12 +512,13 @@ class EnvBatch(EnvBase):
                                                  mail_user=mail_user,
                                                  mail_type=mail_type,
                                                  batch_args=batch_args,
-                                                 dry_run=dry_run)
+                                                 dry_run=dry_run,
+                                                 workflow=workflow)
                 batch_job_id = str(alljobs.index(job)) if dry_run else result
                 depid[job] = batch_job_id
                 jobcmds.append( (job, result) )
 
-                if self._batchtype == "cobalt" or external_workflow:
+                if self._batchtype == "cobalt" or external_workflow or not workflow:
                     break
 
             if not external_workflow and not no_batch:
@@ -584,7 +599,7 @@ class EnvBatch(EnvBase):
 
     def _submit_single_job(self, case, job, dep_jobs=None, allow_fail=False,
                            no_batch=False, skip_pnl=False, mail_user=None, mail_type=None,
-                           batch_args=None, dry_run=False, resubmit_immediate=False):
+                           batch_args=None, dry_run=False, resubmit_immediate=False, workflow=True):
 
         if not dry_run:
             logger.warning("Submit job {}".format(job))
@@ -595,7 +610,7 @@ class EnvBatch(EnvBase):
             job_name = "."+job
             if not dry_run:
                 args = self._build_run_args(job, True, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
-                                            submit_resubmits=not resubmit_immediate)
+                                            submit_resubmits=workflow and not resubmit_immediate)
                 try:
                     if hasattr(case, function_name):
                         getattr(case, function_name)(**{k: v for k, (v, _) in args.items()})
@@ -678,7 +693,7 @@ class EnvBatch(EnvBase):
         batchredirect = self.get_value("batch_redirect", subgroup=None)
         batch_env_flag = self.get_value("batch_env", subgroup=None)
         run_args = self._build_run_args_str(job, False, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
-                                            submit_resubmits=not resubmit_immediate)
+                                            submit_resubmits=workflow and not resubmit_immediate)
         if batch_system == 'lsf' and not batch_env_flag:
             sequence = (run_args, batchsubmit, submitargs, batchredirect, get_batch_script_for_job(job))
         elif batch_env_flag:

--- a/cime/scripts/lib/CIME/XML/workflow.py
+++ b/cime/scripts/lib/CIME/XML/workflow.py
@@ -31,9 +31,9 @@ class Workflow(GenericXML):
         if os.path.exists(infile):
             GenericXML.read(self, infile)
 
-    def get_workflow_jobs(self, machine, workflow_case="default"):
+    def get_workflow_jobs(self, machine, workflowid="default"):
         """
-        Return a list of jobs with the first element the name of the case script
+        Return a list of jobs with the first element the name of the script
         and the second a dict of qualifiers for the job
         """
         jobs = []
@@ -41,8 +41,8 @@ class Workflow(GenericXML):
         findmore = True
         prepend = False
         while findmore:
-            bnode = self.get_optional_child("workflow_jobs", attributes={"case":workflow_case})
-            expect(bnode,"No workflow_case {} found in file {}".format(workflow_case, self.filename))
+            bnode = self.get_optional_child("workflow_jobs", attributes={"id":workflowid})
+            expect(bnode,"No workflow {} found in file {}".format(workflowid, self.filename))
             if prepend:
                 bnodes = [bnode] + bnodes
             else:
@@ -50,10 +50,10 @@ class Workflow(GenericXML):
             prepend = False
             workflow_attribs = self.attrib(bnode)
             if "prepend" in workflow_attribs:
-                workflow_case = workflow_attribs["prepend"]
+                workflowid = workflow_attribs["prepend"]
                 prepend = True
             elif "append" in workflow_attribs:
-                workflow_case = workflow_attribs["append"]
+                workflowid = workflow_attribs["append"]
             else:
                 findmore = False
         for bnode in bnodes:

--- a/cime/scripts/lib/CIME/buildlib.py
+++ b/cime/scripts/lib/CIME/buildlib.py
@@ -86,4 +86,4 @@ def run_gmake(case, compclass, libroot, bldroot, libname="", user_cppdefs=""):
         cmd = cmd + "USER_CPPDEFS='{}'".format(user_cppdefs )
 
     _, out, _ = run_cmd(cmd, combine_output=True)
-    print(out.encode('utf-8'))
+    print(out)

--- a/cime/scripts/lib/CIME/case/case.py
+++ b/cime/scripts/lib/CIME/case/case.py
@@ -893,7 +893,7 @@ class Case(object):
                   multi_driver=False, ninst=1, test=False,
                   walltime=None, queue=None, output_root=None,
                   run_unsupported=False, answer=None,
-                  input_dir=None, driver=None, workflow_case="default",
+                  input_dir=None, driver=None, workflowid="default",
                   non_local=False):
 
         expect(check_name(compset_name, additional_chars='.'), "Invalid compset name {}".format(compset_name))
@@ -1082,7 +1082,7 @@ class Case(object):
         logger.info("Batch_system_type is {}".format(batch_system_type))
         batch = Batch(batch_system=batch_system_type, machine=machine_name, files=files)
         workflow = Workflow(files=files)
-        bjobs = workflow.get_workflow_jobs(machine=machine_name, workflow_case=workflow_case)
+        bjobs = workflow.get_workflow_jobs(machine=machine_name, workflowid=workflowid)
         env_workflow = self.get_env("workflow")
 
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
@@ -1339,13 +1339,13 @@ directory, NOT in this subdirectory."""
 
     def submit_jobs(self, no_batch=False, job=None, skip_pnl=None, prereq=None, allow_fail=False,
                     resubmit_immediate=False, mail_user=None, mail_type=None, batch_args=None,
-                    dry_run=False):
+                    dry_run=False, workflow=True):
         env_batch = self.get_env('batch')
         result =  env_batch.submit_jobs(self, no_batch=no_batch, skip_pnl=skip_pnl,
                                         job=job, user_prereq=prereq, allow_fail=allow_fail,
                                         resubmit_immediate=resubmit_immediate,
                                         mail_user=mail_user, mail_type=mail_type,
-                                        batch_args=batch_args, dry_run=dry_run)
+                                        batch_args=batch_args, dry_run=dry_run, workflow=workflow)
         return result
 
     def get_job_info(self):
@@ -1583,7 +1583,7 @@ directory, NOT in this subdirectory."""
                multi_driver=False, ninst=1, test=False,
                walltime=None, queue=None, output_root=None,
                run_unsupported=False, answer=None,
-               input_dir=None, driver=None, workflow_case="default", non_local=False):
+               input_dir=None, driver=None, workflowid="default", non_local=False):
         try:
             # Set values for env_case.xml
             self.set_lookup_value("CASE", os.path.basename(casename))
@@ -1600,7 +1600,7 @@ directory, NOT in this subdirectory."""
                            output_root=output_root,
                            run_unsupported=run_unsupported, answer=answer,
                            input_dir=input_dir, driver=driver,
-                           workflow_case=workflow_case, non_local=non_local)
+                           workflowid=workflowid, non_local=non_local)
 
             self.create_caseroot()
 

--- a/cime/scripts/lib/CIME/case/case_submit.py
+++ b/cime/scripts/lib/CIME/case/case_submit.py
@@ -25,7 +25,7 @@ def _build_prereq_str(case, prev_job_ids):
 
 def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resubmit=False,
             resubmit_immediate=False, skip_pnl=False, mail_user=None, mail_type=None,
-            batch_args=None):
+            batch_args=None, workflow=True):
     if job is None:
         job = case.get_first_job()
 
@@ -63,7 +63,7 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
         batch_system = "none"
     else:
         batch_system = env_batch.get_batch_system_type()
-
+    unlock_file(os.path.basename(env_batch.filename))
     case.set_value("BATCH_SYSTEM", batch_system)
 
     env_batch_has_changed = False
@@ -81,8 +81,7 @@ env_batch.xml appears to have changed, regenerating batch scripts
 manual edits to these file will be lost!
 """)
         env_batch.make_all_batch_files(case)
-
-    unlock_file(os.path.basename(env_batch.filename))
+    case.flush()
     lock_file(os.path.basename(env_batch.filename))
 
     if resubmit:
@@ -141,7 +140,7 @@ manual edits to these file will be lost!
     job_ids = case.submit_jobs(no_batch=no_batch, job=job, prereq=prereq,
                                skip_pnl=skip_pnl, resubmit_immediate=resubmit_immediate,
                                allow_fail=allow_fail, mail_user=mail_user,
-                               mail_type=mail_type, batch_args=batch_args)
+                               mail_type=mail_type, batch_args=batch_args, workflow=workflow)
 
     xml_jobids = []
     for jobname, jobid in job_ids.items():
@@ -157,7 +156,7 @@ manual edits to these file will be lost!
 
 def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubmit=False,
            resubmit_immediate=False, skip_pnl=False, mail_user=None, mail_type=None,
-           batch_args=None):
+           batch_args=None, workflow=True):
     if resubmit_immediate and self.get_value("MACH") in ['mira', 'cetus']:
         logger.warning("resubmit_immediate does not work on Mira/Cetus, submitting normally")
         resubmit_immediate = False
@@ -195,7 +194,7 @@ def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubm
                                   allow_fail=allow_fail, resubmit=resubmit,
                                   resubmit_immediate=resubmit_immediate, skip_pnl=skip_pnl,
                                   mail_user=mail_user, mail_type=mail_type,
-                                  batch_args=batch_args)
+                                  batch_args=batch_args, workflow=workflow)
         run_and_log_case_status(functor, "case.submit", caseroot=caseroot,
                                 custom_success_msg_functor=verbatim_success_msg)
     except BaseException: # Want to catch KeyboardInterrupt too

--- a/cime/scripts/lib/CIME/test_scheduler.py
+++ b/cime/scripts/lib/CIME/test_scheduler.py
@@ -416,7 +416,7 @@ class TestScheduler(object):
                 self._log_output(test,
                                  "{} FAILED for test '{}'.\nCommand: {}\nOutput: {}\n".
                                  format(phase, test, cmd,
-                                        output.encode('utf-8') + b"\n" + errput.encode('utf-8')))
+                                        output + "\n" + errput))
                 # Temporary hack to get around odd file descriptor use by
                 # buildnml scripts.
                 if "bad interpreter" in output:
@@ -431,7 +431,7 @@ class TestScheduler(object):
                 self._log_output(test,
                                  "{} PASSED for test '{}'.\nCommand: {}\nOutput: {}\n".
                                  format(phase, test, cmd,
-                                        output.encode('utf-8') + b"\n" + errput.encode('utf-8')))
+                                        output + "\n" + errput))
                 return True, errput
 
     ###########################################################################
@@ -861,7 +861,7 @@ class TestScheduler(object):
 
         if not success:
             status_str += "\n    Case dir: {}\n".format(self._get_test_dir(test))
-            status_str += "    Errors were:\n        {}\n".format("\n        ".join(str(errors.encode('utf-8')).splitlines()))
+            status_str += "    Errors were:\n        {}\n".format("\n        ".join(errors.splitlines()))
 
         logger.info(status_str)
 

--- a/cime/scripts/lib/CIME/utils.py
+++ b/cime/scripts/lib/CIME/utils.py
@@ -132,10 +132,8 @@ def expect(condition, error_msg, exc_type=CIMEError, error_prefix="ERROR:"):
         if logger.isEnabledFor(logging.DEBUG):
             import pdb
             pdb.set_trace()
-        try:
-            msg = str(error_prefix + " " + error_msg)
-        except UnicodeEncodeError:
-            msg = (error_prefix + " " + error_msg).encode('utf-8')
+
+        msg = error_prefix + " " + error_msg
         raise exc_type(msg)
 
 def id_generator(size=6, chars=string.ascii_lowercase + string.digits):
@@ -463,16 +461,28 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
                             env=env)
 
     output, errput = proc.communicate(input_str)
-    if output is not None:
-        try:
-            output = output.decode('utf-8', errors='ignore').strip()
-        except AttributeError:
-            pass
-    if errput is not None:
-        try:
-            errput = errput.decode('utf-8', errors='ignore').strip()
-        except AttributeError:
-            pass
+
+    # In Python3, subprocess.communicate returns bytes. We want to work with strings
+    # as much as possible, so we convert bytes to string (which is unicode in py3) via
+    # decode. For python2, we do NOT want to do this since decode will yield unicode
+    # strings which are not necessarily compatible with the system's default base str type.
+    if not six.PY2:
+        if output is not None:
+            try:
+                output = output.decode('utf-8', errors='ignore')
+            except AttributeError:
+                pass
+        if errput is not None:
+            try:
+                errput = errput.decode('utf-8', errors='ignore')
+            except AttributeError:
+                pass
+
+    # Always strip outputs
+    if output:
+        output = output.strip()
+    if errput:
+        errput = errput.strip()
 
     stat = proc.wait()
     if six.PY2:
@@ -531,7 +541,7 @@ def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
             else:
                 errput = ""
 
-        expect(False, "Command: '{}' failed with error '{}' from dir '{}'".format(cmd, errput.encode('utf-8'), os.getcwd() if from_dir is None else from_dir))
+        expect(False, "Command: '{}' failed with error '{}' from dir '{}'".format(cmd, errput, os.getcwd() if from_dir is None else from_dir))
 
     return output
 
@@ -1579,6 +1589,9 @@ def _get_most_recent_lid_impl(files):
     >>> files = ['/foo/bar/e3sm.log.20160905_111212', '/foo/bar/e3sm.log.20160906_111212.gz']
     >>> _get_most_recent_lid_impl(files)
     ['20160905_111212', '20160906_111212']
+    >>> files = ['/foo/bar/e3sm.log.20160905_111212', '/foo/bar/e3sm.log.20160905_111212.gz']
+    >>> _get_most_recent_lid_impl(files)
+    ['20160905_111212']
     """
     results = []
     for item in files:
@@ -1589,7 +1602,7 @@ def _get_most_recent_lid_impl(files):
         else:
             logger.warning("Apparent model log file '{}' did not conform to expected name format".format(item))
 
-    return sorted(results)
+    return sorted(list(set(results)))
 
 def ls_sorted_by_mtime(path):
     ''' return list of path sorted by timestamp oldest first'''

--- a/cime/scripts/query_config
+++ b/cime/scripts/query_config
@@ -20,7 +20,7 @@ from argparse           import RawTextHelpFormatter
 logger = logging.getLogger(__name__)
 supported_comp_interfaces = ["mct", "nuopc", "moab"]
 
-def query_grids(files, long_output):
+def query_grids(files, long_output, xml=False):
     """
     query all grids.
     """
@@ -29,12 +29,14 @@ def query_grids(files, long_output):
            "Cannot find config_file {} on disk".format(config_file))
 
     grids = Grids(config_file)
-    if long_output:
+    if xml:
+        print("{}".format(grids.get_raw_record()))
+    elif long_output:
         grids.print_values(long_output=long_output)
     else:
         grids.print_values()
 
-def query_machines(files, machine_name='all'):
+def query_machines(files, machine_name='all', xml=False):
     """
     query machines. Defaule: all
     """
@@ -43,9 +45,16 @@ def query_machines(files, machine_name='all'):
            "Cannot find config_file {} on disk".format(config_file))
     # Provide a special machine name indicating no need for a machine name
     machines = Machines(config_file, machine="Query")
-    machines.print_values(machine_name=machine_name)
+    if xml:
+        if machine_name == 'all':
+            print("{}".format(machines.get_raw_record()))
+        else:
+            machines.set_machine(machine_name)
+            print("{}".format(machines.get_raw_record(root=machines.machine_node)))
+    else:
+        machines.print_values(machine_name=machine_name)
 
-def query_compsets(files, name):
+def query_compsets(files, name, xml=False):
     """
     query compset definition give a compset name
     """
@@ -69,11 +78,11 @@ def query_compsets(files, name):
     if all_components:  # print all compsets
         for component in components:
             # the all_components flag will only print available components
-            print_compset(component, files, all_components=all_components)
+            print_compset(component, files, all_components=all_components, xml=xml)
     else:
-        print_compset(name, files)
+        print_compset(name, files, xml=xml)
 
-def print_compset(name, files, all_components=False):
+def print_compset(name, files, all_components=False, xml=False):
     """
     print compsets associated with the component name, but if all_components is true only
     print the details if the associated component is available
@@ -97,9 +106,12 @@ def print_compset(name, files, all_components=False):
     # determine component xml content
     compsets = Compsets(config_file)
     # print compsets associated with component without help text
-    compsets.print_values(arg_help=False)
+    if xml:
+        print("{}".format(compsets.get_raw_record()))
+    else:
+        compsets.print_values(arg_help=False)
 
-def query_all_components(files):
+def query_all_components(files, xml=False):
     """
     query all components
     """
@@ -111,9 +123,9 @@ def query_all_components(files):
         # determine all components in string
         components = files.get_components(string)
         for item in components:
-            query_component(item, files, all_components=True)
+            query_component(item, files, all_components=True, xml=xml)
 
-def query_component(name, files, all_components=False):
+def query_component(name, files, all_components=False, xml=False):
     """
     query a component by name
     """
@@ -164,7 +176,10 @@ def query_component(name, files, all_components=False):
 
     # determine component xml content
     component = Component(config_file, "CPL")
-    component.print_values()
+    if xml:
+        print("{}".format(component.get_raw_record()))
+    else:
+        component.print_values()
 
 def parse_command_line(args, description):
     """
@@ -178,6 +193,10 @@ def parse_command_line(args, description):
     CIME.utils.setup_standard_logging_options(parser)
 
     valid_components = ['all']
+
+    parser.add_argument("--xml", action="store_true",
+                        help="Output in xml format.")
+
     files = {}
     for comp_interface in supported_comp_interfaces:
         files[comp_interface] = Files(comp_interface=comp_interface)
@@ -243,7 +262,7 @@ def parse_command_line(args, description):
         parser.print_help(sys.stderr)
 
     return args.grids, args.compsets, args.components, args.machines, \
-        args.long, files[args.comp_interface]
+        args.long, args.xml, files[args.comp_interface]
 
 def get_compsets(files):
     """
@@ -347,23 +366,23 @@ def _main_func(description):
     """
     main function
     """
-    grids, compsets, components, machines, long_output, files = parse_command_line(sys.argv, description)
+    grids, compsets, components, machines, long_output, xml, files = parse_command_line(sys.argv, description)
 
 
     if grids:
-        query_grids(files, long_output)
+        query_grids(files, long_output, xml=xml)
 
     if compsets is not None:
-        query_compsets(files, name=compsets)
+        query_compsets(files, name=compsets, xml=xml)
 
     if components is not None:
         if re.search("^all$", components):  # print all compsets
-            query_all_components(files)
+            query_all_components(files, xml=xml)
         else:
-            query_component(components, files)
+            query_component(components, files, xml=xml)
 
     if machines is not None:
-        query_machines(files, machine_name=machines)
+        query_machines(files, machine_name=machines, xml=xml)
 
 # main entry point
 if __name__ == "__main__":

--- a/cime/src/components/data_comps/docn/cime_config/buildnml
+++ b/cime/src/components/data_comps/docn/cime_config/buildnml
@@ -98,6 +98,12 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
             value = ['null']
             nmlgen.set_value("streams",value)
 
+    # globally uniform SST mode
+    if docn_mode=='sst_aquap_constant':
+        value = ['null']
+        nmlgen.set_value("streams",value)
+        value = [case.get_value('DOCN_AQPCONST_VALUE')]
+        nmlgen.set_value("sst_constant_value",value)
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.
     #----------------------------------------------------

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -13,7 +13,7 @@
        This file may have ocn desc entries.
   -->
   <description modifier_mode="1">
-    <desc ocn="DOCN[%NULL][%DOM][%SOM][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQP11][%AQPFILE]">DOCN </desc>
+    <desc ocn="DOCN[%NULL][%DOM][%SOM][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQPFILE][%AQPCONST]">DOCN </desc>
     <desc option="NULL">  null mode</desc>
     <desc option="DOM">  prescribed ocean mode</desc>
     <desc option="SOM">  slab ocean mode</desc>
@@ -30,8 +30,8 @@
     <desc option="AQP8">  analytic aquaplanet sst - option 8</desc>
     <desc option="AQP9">  analytic aquaplanet sst - option 9</desc>
     <desc option="AQP10">  analytic aquaplanet sst - option 10</desc>
-    <desc option="AQP11">  CONSTANT, UNIFORM aquaplanet sst - option 11</desc>
     <desc option="AQPFILE">  file input aquaplanet sst </desc>
+    <desc option="AQPCONST">  globally constant SST for idealized experiments, such as RCE </desc>
   </description>
 
   <entry id="COMP_OCN">
@@ -45,7 +45,7 @@
 
   <entry id="DOCN_MODE">
     <type>char</type>
-    <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,sst_aquap11,sst_aquapfile,som,som_aquap,interannual,null</valid_values>
+    <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,sst_aquapfile,som,som_aquap,sst_aquap_constant,interannual,null</valid_values>
     <default_value>prescribed</default_value>
     <values match="last">
       <value compset="_DOCN%NULL_">null</value>
@@ -63,8 +63,8 @@
       <value compset="_DOCN%AQP8_">sst_aquap8</value>
       <value compset="_DOCN%AQP9_">sst_aquap9</value>
       <value compset="_DOCN%AQP10_">sst_aquap10</value>
-      <value compset="_DOCN%AQP11_">sst_aquap11</value>
       <value compset="_DOCN%AQPFILE_">sst_aquapfile</value>
+      <value compset="_DOCN%AQPCONST_">sst_aquap_constant</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>
@@ -134,6 +134,18 @@
     <file>env_run.xml</file>
     <desc>Sets aquaplanet forcing filename instead of using an analytic form.
     This is only used when DOCN_MODE=sst_aquapfile.</desc>
+  </entry>
+
+   <entry id="DOCN_AQPCONST_VALUE">
+    <type>real</type>
+    <valid_values></valid_values>
+    <default_value>-1</default_value>
+    <values match="last">
+      <value compset="_DOCN%AQPCONST">300</value>
+    </values>
+    <group>run_component_docn</group>
+    <file>env_run.xml</file>
+    <desc>Sets globally constant SST value</desc>
   </entry>
 
   <entry id="SSTICE_STREAM">

--- a/cime/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/cime/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -56,8 +56,8 @@
       <value docn_mode="sst_aquap8">''</value>
       <value docn_mode="sst_aquap9">''</value>
       <value docn_mode="sst_aquap10">''</value>
-      <value docn_mode="sst_aquap11">''</value>
       <value docn_mode="sst_aquapfile">aquapfile</value>
+      <value docn_mode="sst_aquap_constant">''</value>
       <value docn_mode="som">som</value>
       <value docn_mode="som_aquap">som</value>
       <value docn_mode="interannual">interannual</value>
@@ -257,7 +257,7 @@
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>SSTDATA,SST_AQUAP1,SST_AQUAP2,SST_AQUAP3,SST_AQUAP4,SST_AQUAP5,SST_AQUAP6,SST_AQUAP7,SST_AQUAP8,SST_AQUAP9,SST_AQUAP10,SST_AQUAP11,SST_AQUAPFILE,SOM,SOM_AQUAP,IAF,NULL,COPYALL</valid_values>
+    <valid_values>SSTDATA,SST_AQUAP1,SST_AQUAP2,SST_AQUAP3,SST_AQUAP4,SST_AQUAP5,SST_AQUAP6,SST_AQUAP7,SST_AQUAP8,SST_AQUAP9,SST_AQUAP10,SST_AQUAPFILE,SST_AQUAP_CONSTANT,SOM,SOM_AQUAP,IAF,NULL,COPYALL</valid_values>
     <desc>
       General method that operates on the data. This is generally
       implemented in the data models but is set in the strdata method for
@@ -323,8 +323,8 @@
       <value docn_mode="sst_aquap8$">SST_AQUAP8</value>
       <value docn_mode="sst_aquap9$">SST_AQUAP9</value>
       <value docn_mode="sst_aquap10$">SST_AQUAP10</value>
-      <value docn_mode="sst_aquap11$">SST_AQUAP11</value>
       <value docn_mode="sst_aquapfile$">SST_AQUAPFILE</value>
+      <value docn_mode="sst_aquap_constant$">SST_AQUAP_CONSTANT</value>
       <value docn_mode="som$">SOM</value>
       <value docn_mode="som_aquap">SOM_AQUAP</value>
       <value docn_mode="interannual">IAF</value>
@@ -644,15 +644,16 @@
     </values>
   </entry>
 
-  <entry id="fixed_sst">
-    <type>real</type>
+  <entry id="sst_constant_value" per_stream_entry="true">
+    <type>real(30)</type>
     <category>docn</category>
     <group>docn_nml</group>
     <desc>
-      Sea Surface Temperature for RCE runs
+      Value of globally uniform SST (K) for idealized experiments 
+      when data ocean mode is sst_aquap_constant
     </desc>
     <values>
-      <value>26.85</value>
+      <value>-1.0</value>
     </values>
   </entry>
 

--- a/cime/src/drivers/mct/cime_config/config_component.xml
+++ b/cime/src/drivers/mct/cime_config/config_component.xml
@@ -2886,7 +2886,11 @@
    <default_value></default_value>
    <group>job_submission</group>
    <file>env_workflow.xml</file>
-   <desc>The machine wallclock setting.  Default determined in config_machines.xml can be overwritten by testing</desc>
+   <desc>The machine wallclock setting.  Default determined in
+   config_machines.xml can be overwritten by testing.  Format is
+   DD:HH:MM with DD assumed 0 if not present, this is translated to
+   the format specified by walltime format defined in
+   config_batch.xml</desc>
  </entry>
 
   <entry id="BATCH_COMMAND_FLAGS">

--- a/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -4749,4 +4749,17 @@
     </values>
   </entry>
 
+  <entry id="seq_flux_atmocn_minwind">
+    <type>real</type>
+    <category>seq_flux_mct</category>
+    <group>seq_flux_mct_inparm</group>
+    <desc>
+       minimum wind speed for atmOcn flux calculations
+    </desc>
+    <values>
+      <value>0.5</value>
+      <value aqua_planet_sst_type="sst_aquap11">1.0</value>
+    </values>
+  </entry>
+
 </entry_id>

--- a/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -4758,7 +4758,8 @@
     </desc>
     <values>
       <value>0.5</value>
-      <value aqua_planet_sst_type="sst_aquap11">1.0</value>
+      <value cime_model='cesm' aqua_planet_sst_type="sst_aquap11">1.0</value>
+      <value cime_model='e3sm' aqua_planet_sst_type="sst_aquap_constant">1.0</value>
     </values>
   </entry>
 

--- a/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -4758,8 +4758,7 @@
     </desc>
     <values>
       <value>0.5</value>
-      <value cime_model='cesm' aqua_planet_sst_type="sst_aquap11">1.0</value>
-      <value cime_model='e3sm' aqua_planet_sst_type="sst_aquap_constant">1.0</value>
+      <value aqua_planet_sst_type="sst_aquap_constant">1.0</value>
     </values>
   </entry>
 

--- a/cime/src/drivers/mct/main/seq_flux_mct.F90
+++ b/cime/src/drivers/mct/main/seq_flux_mct.F90
@@ -111,6 +111,7 @@ module seq_flux_mct
   ! albedo reference variables - set via namelist
   real(r8)  :: seq_flux_mct_albdif  ! albedo, diffuse
   real(r8)  :: seq_flux_mct_albdir  ! albedo, direct
+  real(r8)  :: seq_flux_atmocn_minwind ! minimum wind temperature for atmocn flux routines
 
   ! Coupler field indices
 
@@ -477,7 +478,7 @@ contains
 
     character(len=256) :: cime_model
 
-    namelist /seq_flux_mct_inparm/ seq_flux_mct_albdif, seq_flux_mct_albdir
+    namelist /seq_flux_mct_inparm/ seq_flux_mct_albdif, seq_flux_mct_albdir, seq_flux_atmocn_minwind
 
     character(len=*),parameter :: subname = '(seq_flux_readnl_mct) '
 
@@ -507,10 +508,13 @@ contains
         call shr_file_freeUnit( unitn )
 
      end if
+
      if (seq_comm_iamin(ID)) then
         call shr_mpi_bcast(seq_flux_mct_albdif, mpicom)
         call shr_mpi_bcast(seq_flux_mct_albdir, mpicom)
+        call shr_mpi_bcast(seq_flux_atmocn_minwind, mpicom)
      endif
+
   end subroutine seq_flux_readnl_mct
 
   !===============================================================================
@@ -1077,7 +1081,8 @@ contains
        endif
        call shr_flux_atmocn_diurnal (nloc_a2o , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
-            tocn , emask, sen , lat , lwup , &
+            tocn , emask, seq_flux_atmocn_minwind, &
+            sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             uGust, lwdn , swdn , swup, prec, &
@@ -1101,7 +1106,8 @@ contains
 
        call shr_flux_atmocn (nloc_a2o , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
-            tocn , emask, sen , lat , lwup , &
+            tocn , emask, seq_flux_atmocn_minwind, &
+            sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
             ocn_surface_flux_scheme, &
@@ -1500,7 +1506,8 @@ contains
 
        call shr_flux_atmocn_diurnal (nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
-            tocn , emask, sen , lat , lwup , &
+            tocn , emask, seq_flux_atmocn_minwind, &
+            sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             uGust, lwdn , swdn , swup, prec, &
@@ -1526,7 +1533,8 @@ contains
     else
        call shr_flux_atmocn (nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
-            tocn , emask, sen , lat , lwup , &
+            tocn , emask, seq_flux_atmocn_minwind, &
+            sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             ocn_surface_flux_scheme, &

--- a/cime/src/share/util/shr_flux_mod.F90
+++ b/cime/src/share/util/shr_flux_mod.F90
@@ -141,7 +141,8 @@ end subroutine shr_flux_adjust_constants
 SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   & 
            &               qbot  ,s16O  ,sHDO  ,s18O  ,rbot  ,   &
            &               tbot  ,us    ,vs    ,   &
-           &               ts    ,mask  ,sen   ,lat   ,lwup  ,   &
+           &               ts    ,mask  , seq_flux_atmocn_minwind, &
+           &               sen   ,lat   ,lwup  ,   &
            &               r16O, rhdo, r18O, &
            &               evap  ,evap_16O, evap_HDO, evap_18O, &
            &               taux  ,tauy  ,tref  ,qref  ,   &
@@ -160,6 +161,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
    !--- input arguments --------------------------------
    integer(IN),intent(in) ::       nMax  ! data vector length
    integer(IN),intent(in) :: mask (nMax) ! ocn domain mask       0 <=> out of domain
+   integer(IN),intent(in) :: ocn_surface_flux_scheme
    real(R8)   ,intent(in) :: zbot (nMax) ! atm level height      (m)
    real(R8)   ,intent(in) :: ubot (nMax) ! atm u wind            (m/s)
    real(R8)   ,intent(in) :: vbot (nMax) ! atm v wind            (m/s)
@@ -176,7 +178,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
    real(R8)   ,intent(in) :: us   (nMax) ! ocn u-velocity        (m/s)
    real(R8)   ,intent(in) :: vs   (nMax) ! ocn v-velocity        (m/s)
    real(R8)   ,intent(in) :: ts   (nMax) ! ocn temperature       (K)
-   integer(IN),intent(in) :: ocn_surface_flux_scheme
+   real(R8)   ,intent(in) :: seq_flux_atmocn_minwind        ! minimum wind speed for atmocn      (m/s)
 
    !--- output arguments -------------------------------
    real(R8),intent(out)  ::  sen  (nMax) ! heat flux: sensible    (W/m^2)
@@ -201,7 +203,6 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
 ! !EOP
 
    !--- local constants --------------------------------
-   real(R8),parameter :: umin  =  0.5_R8 ! minimum wind speed       (m/s)
    real(R8),parameter :: zref  = 10.0_R8 ! reference height           (m)
    real(R8),parameter :: ztref =  2.0_R8 ! reference height for air T (m)
 !!++ Large only
@@ -323,7 +324,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
      if (mask(n) /= 0) then
 
         !--- compute some needed quantities ---
-        vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
+        vmag   = max(seq_flux_atmocn_minwind, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
         if (use_coldair_outbreak_mod) then
             ! Cold Air Outbreak Modification:
             ! Increase windspeed for negative tbot-ts
@@ -475,7 +476,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
      if (mask(n) /= 0) then
     
         !--- compute some needed quantities ---
-        vmag    = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
+        vmag    = max(seq_flux_atmocn_minwind, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
 
          if (use_coldair_outbreak_mod) then
             ! Cold Air Outbreak Modification:
@@ -1152,7 +1153,8 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                           (nMax  ,zbot  ,ubot  ,vbot  ,thbot ,             &
                            qbot  ,s16O  ,sHDO  ,s18O  ,rbot  ,             &
                            tbot  ,us    ,vs    ,                           &
-                           ts    ,mask  ,sen   ,lat   ,lwup  ,             &
+                           ts    ,mask  , seq_flux_atmocn_minwind,         &
+                           sen   ,lat   ,lwup  ,                           &
                            r16O  ,rhdo  ,r18O  ,evap  ,evap_16O,           &
                            evap_HDO     ,evap_18O,                         &
                            taux  ,tauy  ,tref  ,qref  ,                    &
@@ -1231,6 +1233,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    integer(IN),intent(in) :: secs               ! NEW  elsapsed seconds in day (GMT)
    integer(IN),intent(in) :: dt                 ! NEW
    logical ,intent(in)    :: cold_start         ! cold start flag
+   real(R8),intent(in)    :: seq_flux_atmocn_minwind   ! minimum wind speed for atmocn      (m/s)
 
    real(R8),intent(in) ,optional :: missval     ! masked value
 
@@ -1256,7 +1259,6 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
 
 
    !--- local constants --------------------------------
-   real(R8),parameter :: umin  =  0.5_R8 ! minimum wind speed       (m/s)
    real(R8),parameter :: zref  = 10.0_R8 ! reference height           (m)
    real(R8),parameter :: ztref =  2.0_R8 ! reference height for air T (m)
 
@@ -1460,7 +1462,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
 
          !--- compute some initial and useful flux quantities ---
 
-         vmag     = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
+         vmag     = max(seq_flux_atmocn_minwind, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
          if (use_coldair_outbreak_mod) then
             ! Cold Air Outbreak Modification:
             ! Increase windspeed for negative tbot-ts

--- a/cime/src/share/util/shr_scam_mod.F90
+++ b/cime/src/share/util/shr_scam_mod.F90
@@ -641,13 +641,13 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, ocn_compid, ocn_mpicom, &
    character(*),parameter :: subname = "(shr_scam_checkSurface) "
    character(*),parameter :: F00   = "('(shr_scam_checkSurface) ',8a)"
    character(len=CL)      :: decomp = '1d' ! restart pointer file
-   real(r8)               :: fixed_sst 
+   real(r8)               :: sst_constant_value 
    character(len=CL)      :: restfilm = 'unset'
    character(len=CL)      :: restfils = 'unset'
    integer(IN)   :: nfrac
    logical :: force_prognostic_true = .false.
    namelist /dom_inparm/ sstcyc, nrevsn, rest_pfile, bndtvs, focndomain
-   namelist / docn_nml / decomp, fixed_sst, force_prognostic_true, &
+   namelist / docn_nml / decomp, sst_constant_value, force_prognostic_true, &
         restfilm, restfils
 
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
Update CIME to ESMCI cime5.8.13

Squash merge of jgfouca/branch-for-to-acme-2019-10-28

Features:
* Updates to workflow support in CIME.
* Add namelist for minimum wind speed for atmOcn fluxes.
* Change globally uniform SST mode from AQP11 to AQPCONST
* Add --only-job option to case.submit: run only jobname and ignore any defined workflow
* Adds a raw xml option to the query_config interface.
* Refactor how run_cmd handles strings

Bug fixes:
* Fix an issue with Lockedfile error when case.submit is used with the --no-batch flag

[NML]
[BFB]
