### PR TITLE
Add (or re-add) support for NLDAS configurations

### DIFF
--- a/cime/config/e3sm/config_files.xml
+++ b/cime/config/e3sm/config_files.xml
@@ -113,6 +113,7 @@
       <value component="mpaso"    >$SRCROOT/components/mpas-ocean/cime_config/config_compsets.xml</value>
       <value component="mali"     >$SRCROOT/components/mpas-albany-landice/cime_config/config_compsets.xml</value>
       <value component="mpassi"   >$SRCROOT/components/mpas-seaice/cime_config/config_compsets.xml</value>
+      <value component="mosart"   >$SRCROOT/components/mosart/cime_config/config_compsets.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -168,7 +168,7 @@
       <mask>360x720cru</mask>
     </model_grid>
 
-    <model_grid alias="NLDAS_NLDAS" compset="(DATM_SATM).+CLM">
+    <model_grid alias="NLDAS_NLDAS" compset="(DATM|SATM).+MOSART">
       <grid name="atm">NLDAS</grid>
       <grid name="lnd">NLDAS</grid>
       <grid name="ocnice">NLDAS</grid>

--- a/cime/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/datm/cime_config/config_component.xml
@@ -10,12 +10,13 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%NLDAS][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
     <desc option="CRUv7"> CLM CRU NCEP v7 data set </desc>
     <desc option="GSWP3v1"> GSWP3v1 data set </desc>
+    <desc option="NLDAS"> NLDAS data set </desc>
     <desc option="NLDAS2"> NLDAS2 regional 0.125 degree data set over the U.S. (25-53N, 235-293E). WARNING: Garbage data will be produced for runs extending beyond this regional domain. </desc>
     <desc option="CPLHIST"> Coupler hist data set (in this mode, it is strongly recommended that the model domain and the coupler history forcing are on the same domain)</desc>
     <desc option="1PT">single point tower site data set </desc>
@@ -35,13 +36,13 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMNLDAS2,CPLHIST,CORE_IAF_JRA</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMNLDAS,CLMNLDAS2,CPLHIST,CORE_IAF_JRA</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
     <desc>Mode for data atmosphere component.
       CORE2_NYF (CORE2 normal year forcing) are modes used in forcing prognostic ocean/sea-ice components.
-      CLM_QIAN, CLMCRUNCEP, CLMCRUNCEPv7, CLMGSWP3v1, CLMNLDAS2 and CLM1PT are modes using observational data for forcing prognostic land components.
+      CLM_QIAN, CLMCRUNCEP, CLMCRUNCEPv7, CLMGSWP3v1, CLMNLDAS, CLMNLDAS2 and CLM1PT are modes using observational data for forcing prognostic land components.
       WARNING for CLMNLDAS2: This is a regional forcing dataset over the U.S. (25-53N, 235-293E). Garbage data will be produced for runs extending beyond this regional domain. </desc>
     <values match="last">
       <value compset="%NYF">CORE2_NYF</value>
@@ -52,6 +53,7 @@
       <value compset="%CRU">CLMCRUNCEP</value>
       <value compset="%CRUv7">CLMCRUNCEPv7</value>
       <value compset="%GSWP3v1">CLMGSWP3v1</value>
+      <value compset="%NLDAS">CLMNLDAS</value>
       <value compset="%NLDAS2">CLMNLDAS2</value>
       <value compset="%1PT">CLM1PT</value>
       <value compset="%CPLHIST">CPLHIST</value>

--- a/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -36,11 +36,12 @@
     CLMCRUNCEP		= Run with the CLM CRU NCEP V4 ( default ) forcing valid from 1900 to 2010 (force CLM)
     CLMCRUNCEPv7 	= Run with the CLM CRU NCEP V7 forcing valid from 1900 to 2010 (force CLM)
     CLMGSWP3v1		= Run with the CLM GSWP3 V1 forcing (force CLM)
+    CLMNLDAS        	= Run with the CLM NLDAS data (force CLM)
     CLMNLDAS2		= Run with the CLM NLDAS2 regional forcing valid from 1980 to 2018 (force CLM)
     CLM1PT		= Run with supplied single point data (force CLM)
     CORE2_NYF		= CORE2 normal year forcing (for forcing POP and CICE)
     CORE2_IAF		= CORE2 intra-annual year forcing (for forcing POP and CICE)
-    CORE_IAF_JRA		= JRA55 intra-annual year forcing (for forcing POP and CICE)
+    CORE_IAF_JRA	= JRA55 intra-annual year forcing (for forcing POP and CICE)
     CPLHIST     	= Streams for lnd or ocn/ice forcing used for spinup
     presaero		= Prescribed aerosol forcing
     topo		= Surface topography
@@ -96,6 +97,8 @@
     CLMGSWP3v1.Solar
     CLMGSWP3v1.Precip
     CLMGSWP3v1.TPQW
+
+    CLMNLDAS
 
     CLMNLDAS2.Solar
     CLMNLDAS2.Precip
@@ -192,6 +195,7 @@
       <value datm_mode="CLMCRUNCEP$">CLMCRUNCEP.Solar,CLMCRUNCEP.Precip,CLMCRUNCEP.TPQW</value>
       <value datm_mode="CLMCRUNCEPv7">CLMCRUNCEPv7.Solar,CLMCRUNCEPv7.Precip,CLMCRUNCEPv7.TPQW</value>
       <value datm_mode="CLMGSWP3v1">CLMGSWP3v1.Solar,CLMGSWP3v1.Precip,CLMGSWP3v1.TPQW</value>
+      <value datm_mode="CLMNLDAS">CLMNLDAS</value>
       <value datm_mode="CLMNLDAS2">CLMNLDAS2.Solar,CLMNLDAS2.Precip,CLMNLDAS2.TPQW</value>
       <value datm_mode="CORE2_NYF" >CORE2_NYF.GISS,CORE2_NYF.GXGXS,CORE2_NYF.NCEP</value>
       <value datm_mode="CORE2_IAF" >CORE2_IAF.GCGCS.PREC,CORE2_IAF.GISS.LWDN,CORE2_IAF.GISS.SWDN,CORE2_IAF.GISS.SWUP,CORE2_IAF.NCEP.DN10,CORE2_IAF.NCEP.Q_10,CORE2_IAF.NCEP.SLP_,CORE2_IAF.NCEP.T_10,CORE2_IAF.NCEP.U_10,CORE2_IAF.NCEP.V_10,CORE2_IAF.CORE2.ArcFactor</value>
@@ -218,6 +222,7 @@
       <value stream="CLMCRUNCEP\.">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CLMCRUNCEP_V5">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.V5.c140715</value>
       <value stream="CLMGSWP3">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516</value>
+      <value stream="CLMNLDAS">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CLMNLDAS2">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CORE2_NYF">$DIN_LOC_ROOT/atm/datm7/NYF</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">$DIN_LOC_ROOT/atm/datm7/CORE2</value>
@@ -285,6 +290,7 @@
       <value stream="CLMCRUNCEP">domain.lnd.360x720.130305.nc</value>
       <value stream="CLMGSWP3v1">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
       <value stream="CLMGSWP3">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
+      <value stream="CLMNLDAS">domain.lnd.nldas2_0224x0464_c110415.nc</value>
       <value stream="CLMNLDAS2">domain.lnd.0.125nldas2_0.125nldas2.190410.nc</value>
       <value stream="CORE2_NYF.GISS">nyf.giss.T62.051007.nc</value>
       <value stream="CORE2_NYF.GXGXS">nyf.gxgxs.T62.051007.nc</value>
@@ -453,6 +459,7 @@
       <value stream="CLMGSWP3.Solar">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/Solar3Hrly</value>
       <value stream="CLMGSWP3.Precip">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/Precip3Hrly</value>
       <value stream="CLMGSWP3.TPQW">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/TPHWL3Hrly</value>
+      <value stream="CLMNLDAS">$DIN_LOC_ROOT/atm/datm7/NLDAS</value>
       <value stream="CLMNLDAS2.Solar">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/Solar</value>
       <value stream="CLMNLDAS2.Precip">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/Precip</value>
       <value stream="CLMNLDAS2.TPQW">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/TPQWL</value>
@@ -530,6 +537,7 @@
       <value  stream="CLMGSWP3v1.Solar">clmforc.GSWP3.c2011.0.5x0.5.Solr.%ym.nc</value>
       <value  stream="CLMGSWP3v1.Precip">clmforc.GSWP3.c2011.0.5x0.5.Prec.%ym.nc</value>
       <value  stream="CLMGSWP3v1.TPQW">clmforc.GSWP3.c2011.0.5x0.5.TPQWL.%ym.nc</value>
+      <value  stream="CLMNLDAS">clmforc.nldas.%ym.nc</value>
       <value  stream="CLMNLDAS2.Solar">ctsmforc.NLDAS2.0.125d.v1.Solr.%ym.nc</value>
       <value  stream="CLMNLDAS2.Precip">ctsmforc.NLDAS2.0.125d.v1.Prec.%ym.nc</value>
       <value  stream="CLMNLDAS2.TPQW">ctsmforc.NLDAS2.0.125d.v1.TPQWL.%ym.nc</value>
@@ -1882,6 +1890,15 @@
         PSRF     pbot
         FLDS     lwdn
       </value>
+      <value  stream="CLMNLDAS">
+        TBOT     tbot
+        WIND     wind
+        QBOT     shum
+        PSRF     pbot
+        FLDS     lwdn
+        PRECTmms precn
+        FSDS     swdn
+      </value>
       <value  stream="CLMNLDAS2.Solar">
         FSDS swdn
       </value>
@@ -2093,6 +2110,7 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_ALIGN</value>
+      <value stream="CLMNLDAS">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMNLDAS2">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1</value>
@@ -2134,6 +2152,7 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_START</value>
+      <value stream="CLMNLDAS">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMNLDAS2">$DATM_CLMNCEP_YR_START</value>
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.NCEP.DENS.SOFS">2010</value>
@@ -2201,6 +2220,7 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_END  </value>
+      <value stream="CLMNLDAS">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMNLDAS2">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.NCEP.DENS.SOFS">2011</value>

--- a/cime/src/components/data_comps/dlnd/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/dlnd/cime_config/config_component.xml
@@ -12,10 +12,11 @@
        This file may have lnd desc entries.
   -->
   <description modifier_mode="1">
-    <desc lnd="DLND[%NULL][%SCPL][%LCPL]">Data land model (DLND) </desc>
+    <desc lnd="DLND[%NULL][%SCPL][%LCPL][%LCLMR]">Data land model (DLND) </desc>
     <desc option="NULL">Null mode </desc>
     <desc option="SCPL">snow coupling mode </desc>
     <desc option="LCPL">non-snow coupling </desc>
+    <desc option="LCLMR">mosart coupling </desc>
   </description>
 
   <entry id="COMP_LND">
@@ -29,11 +30,12 @@
 
   <entry id="DLND_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,GLC_CPLHIST,NULL</valid_values>
+    <valid_values>CPLHIST,CLMNLDAS,GLC_CPLHIST,NULL</valid_values>
     <default_value>NULL</default_value>
     <values match="last">
       <value compset="DLND%NULL">NULL</value>
       <value compset="DLND%LCPL">CPLHIST</value>
+      <value compset="DLND%LCLMR">CLMNLDAS</value>
       <value compset="DLND%SCPL">GLC_CPLHIST</value>
     </values>
     <group>run_component_dlnd</group>
@@ -64,6 +66,7 @@
     <type>char</type>
     <default_value>UNSET</default_value>
     <values match="last">
+      <value compset="2000.*_DLND%LCLMR" grid="l%NLDAS">$DIN_LOC_ROOT/lnd/dlnd7/NLDAS</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">$DIN_LOC_ROOT/lnd/dlnd7/CPLHIST_SNO/i.e20.I1850Clm50Sp.f09_g17.001_c180502</value>
     </values>
     <group>run_component_dlnd</group>
@@ -75,6 +78,7 @@
     <type>char</type>
     <default_value>UNSET</default_value>
     <values match="last">
+      <value compset="2000.*_DLND%LCLMR" grid="l%NLDAS">NLDAS</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">i.e20.I1850Clm50Sp.f09_g17.001</value>
     </values>
     <group>run_component_dlnd</group>
@@ -86,6 +90,7 @@
     <type>integer</type>
     <default_value>-999</default_value>
     <values match="last">
+      <value compset="2000.*_DLND%LCLMR" grid="l%NLDAS">1975</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">1</value>
     </values>
     <group>run_component_dlnd</group>
@@ -109,6 +114,7 @@
     <type>integer</type>
     <default_value>-999</default_value>
     <values match="last">
+      <value compset="2000.*_DLND%LCLMR" grid="l%NLDAS">1975</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">1</value>
     </values>
     <group>run_component_dlnd</group>
@@ -120,6 +126,7 @@
     <type>integer</type>
     <default_value>-999</default_value>
     <values match="last">
+      <value compset="2000.*_DLND%LCLMR" grid="l%NLDAS">1975</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">30</value>
     </values>
     <group>run_component_dlnd</group>

--- a/cime/src/components/data_comps/dlnd/cime_config/namelist_definition_dlnd.xml
+++ b/cime/src/components/data_comps/dlnd/cime_config/namelist_definition_dlnd.xml
@@ -69,6 +69,7 @@
     <values>
       <value dlnd_mode="NULL">NULL</value>
       <value dlnd_mode="^CPLHIST$">lnd.cplhist</value>
+      <value dlnd_mode="CLMNLDAS">clm.nldas</value>
       <value dlnd_mode="GLC_CPLHIST">sno.cplhist</value>
     </values>
   </entry>
@@ -79,7 +80,7 @@
     <group>streams_file</group>
     <desc>Stream domain file directory.</desc>
     <values>
-      <value>null</value>
+      <value stream="clm.nldas">$DLND_CPLHIST_DIR</value>
     </values>
   </entry>
 
@@ -89,7 +90,7 @@
     <group>streams_file</group>
     <desc>Stream domain file path(s).</desc>
     <values>
-      <value>null</value>
+      <value stream="clm.nldas">mosart_nldas_hist_1975.clm2.h1.1975-01-01-00000.nc</value>
     </values>
   </entry>
 
@@ -106,6 +107,13 @@
         doml_aream   area
         doml_mask    mask
       </value>
+      <value stream="clm.nldas">
+        time     time
+        lon      lon
+        lat      lat
+        area     area
+        landfrac mask
+      </value>
     </values>
   </entry>
 
@@ -115,6 +123,7 @@
     <group>streams_file</group>
     <desc>Stream data file directory.</desc>
     <values>
+      <value>$DLND_CPLHIST_DIR</value>
       <value stream="sno.cplhist">$DLND_CPLHIST_DIR</value>
     </values>
   </entry>
@@ -125,7 +134,8 @@
     <group>streams_file</group>
     <desc>Stream data file path(s).</desc>
     <values>
-      <value  stream="sno.cplhist">$DLND_CPLHIST_CASE.cpl.hl2x1yr_glc.%y-01-01.nc</value>
+      <value stream="sno.cplhist">$DLND_CPLHIST_CASE.cpl.hl2x1yr_glc.%y-01-01.nc</value>
+      <value stream="clm.nldas">mosart_nldas_hist_1975.clm2.h1.1975-01-01-00000.nc</value>
     </values>
   </entry>
 
@@ -139,6 +149,10 @@
         l2x1yr_glc_Sl_tsrf%glc     tsrf%glc
         l2x1yr_glc_Sl_topo%glc     topo%glc
         l2x1yr_glc_Flgl_qice%glc   qice%glc
+      </value>
+      <value     stream="clm.nldas">
+        QDRAI     rofsub
+        QOVER     rofsur
       </value>
     </values>
   </entry>
@@ -159,6 +173,7 @@
     <group>streams_file</group>
     <desc>Simulation year to align stream to.</desc>
     <values>
+      <value>$DLND_CPLHIST_YR_ALIGN</value>
       <value stream="sno.cplhist">$DLND_CPLHIST_YR_ALIGN</value>
     </values>
   </entry>
@@ -169,6 +184,7 @@
     <group>streams_file</group>
     <desc>First year of stream.</desc>
     <values>
+      <value>$DLND_CPLHIST_YR_START</value>
       <value stream="sno.cplhist">$DLND_CPLHIST_YR_START</value>
     </values>
   </entry>
@@ -179,7 +195,8 @@
     <group>streams_file</group>
     <desc>Last year of stream.</desc>
     <values>
-      <value   stream="sno.cplhist">$DLND_CPLHIST_YR_END</value>
+      <value>$DLND_CPLHIST_YR_END</value>
+      <value stream="sno.cplhist">$DLND_CPLHIST_YR_END</value>
     </values>
   </entry>
 
@@ -211,6 +228,7 @@
       <value dlnd_mode="NULL">NULL</value>
       <value dlnd_mode="GLC_CPLHIST">COPYALL</value>
       <value dlnd_mode="CPLHIST">COPYALL</value>
+      <value dlnd_mode="CLMNLDAS">COPYALL</value>
     </values>
   </entry>
 
@@ -243,6 +261,7 @@
     </desc>
     <values>
       <value>nn</value>
+      <value dlnd_mode="CLMNLDAS">copy</value>
     </values>
   </entry>
 

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -281,6 +281,8 @@ lnd/clm2/surfdata_map/surfdata_0.9x1.25_simyr1850_c180306.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_1.9x2.5_simyr1850_c180306.nc</fsurdat>
 <fsurdat hgrid="10x15"        sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_10x15_simyr1850_c130927.nc</fsurdat>
+<fsurdat hgrid="NLDAS"        sim_year="1850" irrig=".false." use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_nldas2_simyr2000_c181207.nc</fsurdat>
 
 <fsurdat hgrid="1x1_tropicAtl" sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_1x1_tropicAtl_simyr1850_c130927.nc</fsurdat>

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -213,6 +213,8 @@ lnd/clm2/surfdata_map/surfdata_360x720cru_simyr2000_c180216.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_48x96_simyr2000_c130927.nc</fsurdat>
 <fsurdat hgrid="64x128"    sim_year="2000">
 lnd/clm2/surfdata_map/surfdata_64x128_simyr2000_c170111.nc</fsurdat>
+<fsurdat hgrid="NLDAS"    sim_year="2000" irrig=".false." use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_nldas2_simyr2000_c181207.nc</fsurdat>
 
 <fsurdat hgrid="0.9x1.25"  sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_0.9x1.25_simyr2000_c180404.nc</fsurdat>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1231,7 +1231,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"  
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,0.125x0.125,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,0.125x0.125,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,NLDAS">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry> 
@@ -1245,7 +1245,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*20" category="default_settings"
        group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,tx0.1v2">
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2">
 Land mask description
 </entry> 
 

--- a/components/clm/cime_config/config_compsets.xml
+++ b/components/clm/cime_config/config_compsets.xml
@@ -228,6 +228,11 @@
      <alias>ICNPECACTCBC</alias>
      <lname>2000_DATM%QIA_CLM45%CNPECACTCBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
+
+   <compset>
+     <alias>INLDASCNPECACNTBC</alias>
+     <lname>2000_DATM%NLDAS_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+   </compset>
  
    <compset>
      <alias>I20TRCNECACTCBC</alias>
@@ -247,6 +252,11 @@
    <compset>
      <alias>I20TRCNPECACNTBC</alias>
      <lname>20TR_DATM%QIA_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+   </compset>
+
+   <compset>
+     <alias>IM20TRNLDASCNPECACNTBC</alias>
+     <lname>20TR_DATM%NLDAS_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
    <compset>

--- a/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
+++ b/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
@@ -37,7 +37,7 @@ for the CLM data in the CESM distribution
 
 <frivinp_rtm rof_grid="r0125" >rof/mosart/MOSART_global_8th_20180211c.nc</frivinp_rtm>
 <frivinp_rtm rof_grid="r05" >rof/mosart/MOSART_global_half_20180721a.nc</frivinp_rtm>
-<frivinp_rtm rof_grid="NLDAS" >rof/mosart/MOSART_NLDAS_8th.nc</frivinp_rtm>
+<frivinp_rtm rof_grid="NLDAS" >rof/mosart/MOSART_NLDAS_8th_20160426.nc</frivinp_rtm>
 
 <!-- WRM -->
 

--- a/components/mosart/cime_config/buildnml
+++ b/components/mosart/cime_config/buildnml
@@ -48,8 +48,8 @@ def buildnml(case, caseroot, compname):
     # Verify rof grid is supported
     #--------------------------------------------------------------------
 
-    rof_grid_supported = ("null", "r05", "r0125", "r01")
-    expect(rof_grid in rof_grid_supported, "ROF_GRID '{}' is not supported in mosart. Choose from: null, r05, r0125, r01".format(rof_grid))
+    rof_grid_supported = ("null", "r05", "r0125", "r01", "NLDAS")
+    expect(rof_grid in rof_grid_supported, "ROF_GRID '{}' is not supported in mosart. Choose from: null, r05, r0125, r01, NLDAS".format(rof_grid))
 
     #--------------------------------------------------------------------
     # Invoke mosart build-namelist - output will go in $CASEBUILD/mosartconf

--- a/components/mosart/cime_config/config_compsets.xml
+++ b/components/mosart/cime_config/config_compsets.xml
@@ -10,7 +10,7 @@
   <!---MOSART RM compsets -->
 
   <compset>
-    <alias>RM</alias>
+    <alias>RMOSARTNLDAS</alias>
     <lname>2000_SATM_DLND%LCLMR_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 

--- a/components/mosart/cime_config/config_compsets.xml
+++ b/components/mosart/cime_config/config_compsets.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<compsets>
+
+  <help>
+  Compset format is explained in cime/config/e3sm/allactive/config_compsets.xml
+  or in the CIME documenation
+  </help>
+
+  <!---MOSART RM compsets -->
+
+  <compset>
+    <alias>RM</alias>
+    <lname>2000_SATM_DLND%LCLMR_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+</compsets>


### PR DESCRIPTION
This PR adds support for NLDAS configurations, for use mostly by MOSART developers. There are new compsets, as well as support for an NLDAS_NLDAS grid. The new compsets are:
* INLDASCNPECACNTBC
  (2000_DATM%NLDAS_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV)
* IM20TRNLDASCNPECACNTBC
  (20TR_DATM%NLDAS_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV)
* RM
  (2000_SATM_DLND%LCLMR_SICE_SOCN_MOSART_SGLC_SWAV)
There are new modes added to both datm and dlnd in support of these configurations.

Not clear if this should be added to automated testing suite 

[BFB] for all current tests