### PR TITLE
This commit fixes C14 related bugs

### DIFF
--- a/components/clm/src/data_types/GridcellDataType.F90
+++ b/components/clm/src/data_types/GridcellDataType.F90
@@ -507,11 +507,13 @@ contains
   !------------------------------------------------------------------------
   ! Subroutines to initialize and clean gridcell carbon state data structure
   !------------------------------------------------------------------------
-  subroutine grc_cs_init(this, begg, endg)
+  subroutine grc_cs_init(this, begg, endg,carbon_type)
     !
     ! !ARGUMENTS:
     class(gridcell_carbon_state) :: this
     integer, intent(in) :: begg,endg
+    character(len=3) , intent(in) :: carbon_type ! one of ['c12', c13','c14']    
+
     !
     ! !LOCAL VARIABLES:
     integer :: g
@@ -529,10 +531,24 @@ contains
     ! initialize history fields for select members of grc_cs
     !-----------------------------------------------------------------------
     if (.not. use_fates) then
-       this%seedc(begg:endg) = spval
-       call hist_addfld1d (fname='SEEDC_GRC', units='gC/m^2', &
-            avgflag='A', long_name='pool for seeding new PFTs via dynamic landcover', &
-            ptr_gcell=this%seedc)
+       if (carbon_type == 'c12') then
+          this%seedc(begg:endg) = spval
+          call hist_addfld1d (fname='SEEDC_GRC', units='gC/m^2', &
+               avgflag='A', long_name='pool for seeding new PFTs via dynamic landcover', &
+               ptr_gcell=this%seedc)
+       end if 
+       if (carbon_type == 'c13') then
+          this%seedc(begg:endg) = spval
+          call hist_addfld1d (fname='C13_SEEDC_GRC', units='gC/m^2', &
+               avgflag='A', long_name='pool for seeding new PFTs via dynamic landcover', &
+               ptr_gcell=this%seedc)
+       end if 
+       if (carbon_type == 'c14') then
+          this%seedc(begg:endg) = spval
+          call hist_addfld1d (fname='C14_SEEDC_GRC', units='gC/m^2', &
+               avgflag='A', long_name='pool for seeding new PFTs via dynamic landcover', &
+               ptr_gcell=this%seedc)
+       end if 
     end if
     
     !-----------------------------------------------------------------------

--- a/components/clm/src/main/clm_instMod.F90
+++ b/components/clm/src/main/clm_instMod.F90
@@ -168,20 +168,20 @@ contains
        ! c14_cs data structure so that they can be used in
        ! associate statements (nag compiler complains otherwise)
 
-       call grc_cs%Init(begg, endg)
+       call grc_cs%Init(begg, endg, carbon_type='c12')
        call col_cs%Init(begc, endc, carbon_type='c12', ratio=1._r8)
        call veg_cs%Init(begp, endp, carbon_type='c12', ratio=1._r8)
        if (use_c13) then
-          call c13_grc_cs%Init(begg, endg)
+          call c13_grc_cs%Init(begg, endg,carbon_type='c13')
           call c13_col_cs%Init(begc, endc, carbon_type='c13', ratio=c13ratio, &
                c12_carbonstate_vars=col_cs)
-          call c13_veg_cs%Init(begc, endc, carbon_type='c13', ratio=c13ratio)
+          call c13_veg_cs%Init(begp, endp, carbon_type='c13', ratio=c13ratio)
        end if
        if (use_c14) then
-          call c14_grc_cs%Init(begg, endg)
+          call c14_grc_cs%Init(begg, endg,carbon_type='c14')
           call c14_col_cs%Init(begc, endc, carbon_type='c14', ratio=c14ratio, &
                c12_carbonstate_vars=col_cs)
-          call c14_veg_cs%Init(begc, endc, carbon_type='c14', ratio=c14ratio)
+          call c14_veg_cs%Init(begp, endp, carbon_type='c14', ratio=c14ratio)
        end if
 
        ! Note - always initialize the memory for the c13_carbonflux_vars and


### PR DESCRIPTION
When C14 is turned on, ELM simulations using current master failed due to 
(1) same output variable names were used for C12 and C14
(2) incorrect initialization of C14 related data types
These have been fixed in this commit

fixes #3250 

[BFB]