### PR TITLE
Update mpas-source to remove unused variables

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1249,7 +1249,6 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var name="snowFlux"/>')
         lines.append('    <var name="iceFraction"/>')
         lines.append('    <var name="nAccumulatedCoupled"/>')
-        lines.append('    <var name="salineContractionCoeff"/>')
         lines.append('</stream>')
         lines.append('')
         lines.append('</streams>')

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1249,7 +1249,6 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var name="snowFlux"/>')
         lines.append('    <var name="iceFraction"/>')
         lines.append('    <var name="nAccumulatedCoupled"/>')
-        lines.append('    <var name="thermalExpansionCoeff"/>')
         lines.append('    <var name="salineContractionCoeff"/>')
         lines.append('</stream>')
         lines.append('')


### PR DESCRIPTION
SurfaceDensityDisplaced is not used but computed. All references and associated computations of this variable are removed.

NO NOT MERGE until this PR passes BFB testing

[BFB]