### PR TITLE
Merge maint-1.0 to maint-1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,11 @@
 [submodule "components/mpas-source"]
 	path = components/mpas-source
 	url = git@github.com:MPAS-Dev/MPAS-Model.git
+[submodule "externals/scorpio"]
+	path = externals/scorpio
+  url = https://github.com/E3SM-Project/scorpio
+	branch = master
+[submodule "externals/scorpio_classic"]
+	path = externals/scorpio_classic
+  url = https://github.com/E3SM-Project/scorpio
+	branch = scorpio_classic

--- a/cime/config/config_tests.xml
+++ b/cime/config/config_tests.xml
@@ -613,4 +613,22 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_N>$STOP_N</HIST_N>
   </test>
 
+  <test NAME="TSC">
+    <DESC>solution reproducibility test based on time-step convergence</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>none</REST_OPTION>
+  </test>
+
+  <test NAME="NPG">
+    <DESC>solution reproducibility test</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>none</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+  </test>
+
 </config_test>

--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -5,14 +5,14 @@
       <pes compset="any" pesize="any">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>16</ntasks_atm>
-          <ntasks_lnd>16</ntasks_lnd>
-          <ntasks_rof>16</ntasks_rof>
-          <ntasks_ice>16</ntasks_ice>
-          <ntasks_ocn>16</ntasks_ocn>
-          <ntasks_glc>16</ntasks_glc>
-          <ntasks_wav>16</ntasks_wav>
-          <ntasks_cpl>16</ntasks_cpl>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-1</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -85,43 +85,6 @@
           <ntasks_glc>16</ntasks_glc>
           <ntasks_wav>16</ntasks_wav>
           <ntasks_cpl>16</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="any">
-    <mach name="any">
-      <pes compset="XATM|DATM.+CLM" pesize="any">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-1</ntasks_lnd>
-          <ntasks_rof>-1</ntasks_rof>
-          <ntasks_ice>-1</ntasks_ice>
-          <ntasks_ocn>-1</ntasks_ocn>
-          <ntasks_glc>-1</ntasks_glc>
-          <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-1</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -4689,6 +4652,90 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="compy">
+      <pes compset="any" pesize="any">
+        <comment>ne30_ne30 grid on 23 nodes 40 ppn pure-MPI</comment>
+        <ntasks>
+          <ntasks_atm>900</ntasks_atm>
+          <ntasks_lnd>900</ntasks_lnd>
+          <ntasks_rof>900</ntasks_rof>
+          <ntasks_ice>900</ntasks_ice>
+          <ntasks_ocn>900</ntasks_ocn>
+          <ntasks_cpl>900</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+      <pes compset="any" pesize="L">
+        <comment>ne30_ne30 grid on 68 nodes 40 ppn pure-MPI</comment>
+        <ntasks>
+          <ntasks_atm>2700</ntasks_atm>
+          <ntasks_lnd>2700</ntasks_lnd>
+          <ntasks_rof>2700</ntasks_rof>
+          <ntasks_ice>2700</ntasks_ice>
+          <ntasks_ocn>2700</ntasks_ocn>
+          <ntasks_cpl>2700</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+      <pes compset="any" pesize="XL">
+        <comment>ne30_ne30 grid on 135 nodes 40 ppn pure-MPI</comment>
+        <ntasks>
+          <ntasks_atm>5400</ntasks_atm>
+          <ntasks_lnd>5400</ntasks_lnd>
+          <ntasks_rof>5400</ntasks_rof>
+          <ntasks_ice>5400</ntasks_ice>
+          <ntasks_ocn>5400</ntasks_ocn>
+          <ntasks_cpl>5400</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+
   </grid>
   <grid name="any">
     <mach name="anvil">
@@ -4703,6 +4750,41 @@
           <ntasks_glc>720</ntasks_glc>
           <ntasks_wav>720</ntasks_wav>
           <ntasks_cpl>720</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+    <mach name="compy">
+      <pes compset="any" pesize="any">
+        <comment>default,4nodes*40tasks*1thread</comment>
+        <ntasks>
+          <ntasks_atm>160</ntasks_atm>
+          <ntasks_lnd>160</ntasks_lnd>
+          <ntasks_rof>160</ntasks_rof>
+          <ntasks_ice>160</ntasks_ice>
+          <ntasks_ocn>160</ntasks_ocn>
+          <ntasks_glc>160</ntasks_glc>
+          <ntasks_wav>160</ntasks_wav>
+          <ntasks_cpl>160</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -7540,6 +7622,41 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="compy">
+      <pes compset="any" pesize="any">
+        <comment>ne4 default,2nodes*40tasks*1thread</comment>
+        <ntasks>
+          <ntasks_atm>80</ntasks_atm>
+          <ntasks_lnd>80</ntasks_lnd>
+          <ntasks_rof>80</ntasks_rof>
+          <ntasks_ice>80</ntasks_ice>
+          <ntasks_ocn>80</ntasks_ocn>
+          <ntasks_glc>80</ntasks_glc>
+          <ntasks_wav>80</ntasks_wav>
+          <ntasks_cpl>80</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
   </grid>
   <grid name="a%ne30np4_l%ne30np4_oi%oEC60to30">
     <mach name="anvil|bebop">
@@ -7712,6 +7829,116 @@
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
+        </rootpe>
+      </pes>
+    </mach>
+    <mach name="compy">
+      <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="S">
+        <comment> -compset A_WCYCL* -res ne30_oEC* on 27 nodes pure-MPI </comment>
+        <ntasks>
+          <ntasks_atm>900</ntasks_atm>
+          <ntasks_lnd>900</ntasks_lnd>
+          <ntasks_rof>900</ntasks_rof>
+          <ntasks_ice>900</ntasks_ice>
+          <ntasks_ocn>160</ntasks_ocn>
+          <ntasks_cpl>900</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>920</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+      <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="any">
+        <comment> -compset A_WCYCL* -res ne30_oEC* on 40 nodes pure-MPI </comment>
+        <ntasks>
+          <ntasks_atm>1350</ntasks_atm>
+          <ntasks_lnd>1350</ntasks_lnd>
+          <ntasks_rof>1350</ntasks_rof>
+          <ntasks_ice>1350</ntasks_ice>
+          <ntasks_ocn>240</ntasks_ocn>
+          <ntasks_cpl>1350</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>1360</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+      <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="L">
+        <comment> -compset A_WCYCL* -res ne30_oEC* on 92 nodes pure-MPI </comment>
+        <ntasks>
+          <ntasks_atm>2700</ntasks_atm>
+          <ntasks_lnd>2700</ntasks_lnd>
+          <ntasks_rof>2700</ntasks_rof>
+          <ntasks_ice>2700</ntasks_ice>
+          <ntasks_ocn>960</ntasks_ocn>
+          <ntasks_cpl>2700</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>2720</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+      <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="XL">
+        <comment> -compset A_WCYCL* -res ne30_oEC* on 185 nodes pure-MPI </comment>
+        <ntasks>
+          <ntasks_atm>5400</ntasks_atm>
+          <ntasks_lnd>5400</ntasks_lnd>
+          <ntasks_rof>5400</ntasks_rof>
+          <ntasks_ice>5400</ntasks_ice>
+          <ntasks_ocn>2000</ntasks_ocn>
+          <ntasks_cpl>5400</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>5400</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>

--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -5,14 +5,14 @@
       <pes compset="any" pesize="any">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-1</ntasks_lnd>
-          <ntasks_rof>-1</ntasks_rof>
-          <ntasks_ice>-1</ntasks_ice>
-          <ntasks_ocn>-1</ntasks_ocn>
-          <ntasks_glc>-1</ntasks_glc>
-          <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_atm>16</ntasks_atm>
+          <ntasks_lnd>16</ntasks_lnd>
+          <ntasks_rof>16</ntasks_rof>
+          <ntasks_ice>16</ntasks_ice>
+          <ntasks_ocn>16</ntasks_ocn>
+          <ntasks_glc>16</ntasks_glc>
+          <ntasks_wav>16</ntasks_wav>
+          <ntasks_cpl>16</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -85,6 +85,43 @@
           <ntasks_glc>16</ntasks_glc>
           <ntasks_wav>16</ntasks_wav>
           <ntasks_cpl>16</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="any">
+    <mach name="any">
+      <pes compset="XATM|DATM.+CLM" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-1</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -4652,90 +4689,6 @@
         </rootpe>
       </pes>
     </mach>
-    <mach name="compy">
-      <pes compset="any" pesize="any">
-        <comment>ne30_ne30 grid on 23 nodes 40 ppn pure-MPI</comment>
-        <ntasks>
-          <ntasks_atm>900</ntasks_atm>
-          <ntasks_lnd>900</ntasks_lnd>
-          <ntasks_rof>900</ntasks_rof>
-          <ntasks_ice>900</ntasks_ice>
-          <ntasks_ocn>900</ntasks_ocn>
-          <ntasks_cpl>900</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset="any" pesize="L">
-        <comment>ne30_ne30 grid on 68 nodes 40 ppn pure-MPI</comment>
-        <ntasks>
-          <ntasks_atm>2700</ntasks_atm>
-          <ntasks_lnd>2700</ntasks_lnd>
-          <ntasks_rof>2700</ntasks_rof>
-          <ntasks_ice>2700</ntasks_ice>
-          <ntasks_ocn>2700</ntasks_ocn>
-          <ntasks_cpl>2700</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset="any" pesize="XL">
-        <comment>ne30_ne30 grid on 135 nodes 40 ppn pure-MPI</comment>
-        <ntasks>
-          <ntasks_atm>5400</ntasks_atm>
-          <ntasks_lnd>5400</ntasks_lnd>
-          <ntasks_rof>5400</ntasks_rof>
-          <ntasks_ice>5400</ntasks_ice>
-          <ntasks_ocn>5400</ntasks_ocn>
-          <ntasks_cpl>5400</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-
   </grid>
   <grid name="any">
     <mach name="anvil">
@@ -4750,41 +4703,6 @@
           <ntasks_glc>720</ntasks_glc>
           <ntasks_wav>720</ntasks_wav>
           <ntasks_cpl>720</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-    <mach name="compy">
-      <pes compset="any" pesize="any">
-        <comment>default,4nodes*40tasks*1thread</comment>
-        <ntasks>
-          <ntasks_atm>160</ntasks_atm>
-          <ntasks_lnd>160</ntasks_lnd>
-          <ntasks_rof>160</ntasks_rof>
-          <ntasks_ice>160</ntasks_ice>
-          <ntasks_ocn>160</ntasks_ocn>
-          <ntasks_glc>160</ntasks_glc>
-          <ntasks_wav>160</ntasks_wav>
-          <ntasks_cpl>160</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -7622,41 +7540,6 @@
         </rootpe>
       </pes>
     </mach>
-    <mach name="compy">
-      <pes compset="any" pesize="any">
-        <comment>ne4 default,2nodes*40tasks*1thread</comment>
-        <ntasks>
-          <ntasks_atm>80</ntasks_atm>
-          <ntasks_lnd>80</ntasks_lnd>
-          <ntasks_rof>80</ntasks_rof>
-          <ntasks_ice>80</ntasks_ice>
-          <ntasks_ocn>80</ntasks_ocn>
-          <ntasks_glc>80</ntasks_glc>
-          <ntasks_wav>80</ntasks_wav>
-          <ntasks_cpl>80</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
   </grid>
   <grid name="a%ne30np4_l%ne30np4_oi%oEC60to30">
     <mach name="anvil|bebop">
@@ -7829,116 +7712,6 @@
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
-        </rootpe>
-      </pes>
-    </mach>
-    <mach name="compy">
-      <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="S">
-        <comment> -compset A_WCYCL* -res ne30_oEC* on 27 nodes pure-MPI </comment>
-        <ntasks>
-          <ntasks_atm>900</ntasks_atm>
-          <ntasks_lnd>900</ntasks_lnd>
-          <ntasks_rof>900</ntasks_rof>
-          <ntasks_ice>900</ntasks_ice>
-          <ntasks_ocn>160</ntasks_ocn>
-          <ntasks_cpl>900</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>920</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="any">
-        <comment> -compset A_WCYCL* -res ne30_oEC* on 40 nodes pure-MPI </comment>
-        <ntasks>
-          <ntasks_atm>1350</ntasks_atm>
-          <ntasks_lnd>1350</ntasks_lnd>
-          <ntasks_rof>1350</ntasks_rof>
-          <ntasks_ice>1350</ntasks_ice>
-          <ntasks_ocn>240</ntasks_ocn>
-          <ntasks_cpl>1350</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>1360</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="L">
-        <comment> -compset A_WCYCL* -res ne30_oEC* on 92 nodes pure-MPI </comment>
-        <ntasks>
-          <ntasks_atm>2700</ntasks_atm>
-          <ntasks_lnd>2700</ntasks_lnd>
-          <ntasks_rof>2700</ntasks_rof>
-          <ntasks_ice>2700</ntasks_ice>
-          <ntasks_ocn>960</ntasks_ocn>
-          <ntasks_cpl>2700</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>2720</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+" pesize="XL">
-        <comment> -compset A_WCYCL* -res ne30_oEC* on 185 nodes pure-MPI </comment>
-        <ntasks>
-          <ntasks_atm>5400</ntasks_atm>
-          <ntasks_lnd>5400</ntasks_lnd>
-          <ntasks_rof>5400</ntasks_rof>
-          <ntasks_ice>5400</ntasks_ice>
-          <ntasks_ocn>2000</ntasks_ocn>
-          <ntasks_cpl>5400</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>5400</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>

--- a/cime/config/e3sm/config_inputdata.xml
+++ b/cime/config/e3sm/config_inputdata.xml
@@ -7,11 +7,7 @@
     <address>https://web.lcrc.anl.gov/public/e3sm/inputdata/</address>
   </server>
   <server>
-    <protocol>svn</protocol>
-    <address>https://acme-svn2.ornl.gov/acme-repo/acme/inputdata</address>
-  </server>
-  <server>
-    <protocol>svn</protocol>
+    <protocal>svn</protocal>
     <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
   </server>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -389,12 +389,6 @@
     </queues>
    </batch_system>
 
-   <batch_system MACH="compy" type="slurm">
-    <queues>
-      <queue walltimemax="00:59:00" default="true">slurm</queue>
-    </queues>
-   </batch_system>
-
    <batch_system MACH="sooty" type="slurm" >
      <directives>
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -274,14 +274,10 @@
       </queues>
     </batch_system>
 
-    <!-- anvil is PBS -->
-    <batch_system MACH="anvil" type="pbs" >
-      <directives>
-        <directive>-A {{ PROJECT }}</directive>
-        <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
-      </directives>
+    <!-- anvil is slurm -->
+    <batch_system MACH="anvil" type="slurm" >
       <queues>
-	<queue walltimemax="01:00:00" default="true">acme</queue>
+	<queue walltimemax="01:00:00" default="true">acme-centos6</queue>
       </queues>
     </batch_system>
 
@@ -356,12 +352,12 @@
 
     <batch_system MACH="theta" type="cobalt_theta">
       <queues>
-        <queue walltimemax="01:00:00" nodemax="8" strict="true">debug-cache-quad</queue>
-        <queue walltimemin="00:30:00" walltimemax="02:00:00" nodemin="8" nodemax="15" strict="true">default</queue>
-        <queue walltimemin="00:30:00" walltimemax="04:00:00" nodemin="16" nodemax="127" strict="true">default</queue>
-        <queue walltimemin="00:30:00" walltimemax="06:00:00" nodemin="128" nodemax="383" strict="true">default</queue>
-        <queue walltimemin="00:30:00" walltimemax="12:00:00" nodemin="384" nodemax="647" strict="true">default</queue>
-        <queue walltimemin="00:30:00" walltimemax="24:00:00" nodemin="648" strict="true" default="true">default</queue>
+        <queue walltimemax="01:00:00" nodemin="1" nodemax="8" strict="true">debug-cache-quad</queue>
+        <queue walltimemin="00:30:00" walltimemax="03:00:00" nodemin="128" nodemax="255"  strict="true">default</queue>
+        <queue walltimemin="00:30:00" walltimemax="06:00:00" nodemin="256" nodemax="383"  strict="true">default</queue>
+        <queue walltimemin="00:30:00" walltimemax="09:00:00" nodemin="384" nodemax="639"  strict="true">default</queue>
+        <queue walltimemin="00:30:00" walltimemax="12:00:00" nodemin="640" nodemax="801"  strict="true">default</queue>
+        <queue walltimemin="00:30:00" walltimemax="24:00:00" nodemin="802" strict="true" default="true">default</queue>
       </queues>
     </batch_system>
 
@@ -382,6 +378,12 @@
       <directive>--output=slurm.out</directive>
       <directive>--error=slurm.err</directive>
     </directives>
+    <queues>
+      <queue walltimemax="00:59:00" default="true">slurm</queue>
+    </queues>
+   </batch_system>
+
+   <batch_system MACH="compy" type="slurm">
     <queues>
       <queue walltimemax="00:59:00" default="true">slurm</queue>
     </queues>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -78,6 +78,12 @@ for mct, etc.
      compilers -->
 <compiler>
   <SUPPORTS_CXX>FALSE</SUPPORTS_CXX>
+  <CPPDEFS>
+    <!-- MPAS Components rely on this flag to use the newer PIO/Scorpio interfaces. These newer interfaces are available on both Scorpio and Scorpio classic -->
+    <append MODEL="ice"> -DUSE_PIO2 </append>
+    <append MODEL="ocn"> -DUSE_PIO2 </append>
+    <append MODEL="glc"> -DUSE_PIO2 </append>
+  </CPPDEFS>
 </compiler>
 
 <compiler COMPILER="cray">
@@ -855,46 +861,6 @@ for mct, etc.
   </SLIBS>
 </compiler>
 
-<compiler MACH="cab" COMPILER="intel">
-  <CFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <CPPDEFS>
-    <append> -DNO_SHR_VMATH -DCNL </append>
-  </CPPDEFS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-    <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </append>
-  </FFLAGS>
-  <LDFLAGS>
-    <append> -llapack -lblas</append>
-  </LDFLAGS>
-  <MPI_LIB_NAME> mpich</MPI_LIB_NAME>
-  <MPI_PATH>/usr/local/tools/mvapich2-intel-2.1/</MPI_PATH>
-  <NETCDF_PATH>/usr/local/tools/netcdf-intel-4.1.3</NETCDF_PATH>
-  <SLIBS>
-    <append>$SHELL{/usr/local/tools/netcdf-intel-4.1.3/bin/nc-config --flibs}</append>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="cab" COMPILER="pgi">
-  <CPPDEFS>
-    <append> -DNO_SHR_VMATH -DCNL </append>
-  </CPPDEFS>
-  <LDFLAGS>
-    <append> -Wl,-rpath /usr/local/tools/netcdf-pgi-4.1.3/lib -llapack -lblas</append>
-  </LDFLAGS>
-  <MPI_LIB_NAME> mpich</MPI_LIB_NAME>
-  <MPI_PATH>/usr/local/tools/mvapich2-pgi-1.7/</MPI_PATH>
-  <NETCDF_PATH>/usr/local/tools/netcdf-pgi-4.1.3</NETCDF_PATH>
-  <SLIBS>
-    <append>$SHELL{/usr/local/tools/netcdf-pgi-4.1.3/bin/nc-config --flibs}</append>
-  </SLIBS>
-</compiler>
-
 <compiler MACH="cades" COMPILER="gnu">
   <CFLAGS>
     <append compile_threaded="true"> -fopenmp </append>
@@ -1618,6 +1584,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
 <compiler MACH="compy" COMPILER="intel">
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
+    <append MODEL="gptl"> -DHAVE_SLASHPROC </append>
   </CFLAGS>
   <CONFIG_ARGS>
     <base> --host=Linux </base>
@@ -1639,6 +1606,33 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <MPICC  MPILIB="impi">mpiicc</MPICC>
   <MPICXX MPILIB="impi">mpiicpc</MPICXX>
   <MPIFC  MPILIB="impi">mpiifort</MPIFC>
+</compiler>
+
+<compiler MACH="compy" COMPILER="pgi">
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2 </append>
+    <append MODEL="gptl"> -DHAVE_SLASHPROC </append>
+  </CFLAGS>
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CPPDEFS>
+    <append> -DLINUX </append>
+  </CPPDEFS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2 </append>
+    <append DEBUG="TRUE">-C -Mbounds -traceback -Mchkfpstk -Mchkstk -Mdalign  -Mdepchk  -Mextend -Miomutex -Mrecursive  -Ktrap=fp -O0 -g -byteswapio -Meh_frame</append>
+  </FFLAGS>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
+  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+  <PNETCDF_PATH>$ENV{PNETCDF_HOME}</PNETCDF_PATH>
+  <LDFLAGS>
+    <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt $ENV{PNETCDF_LIBRARIES} </append>
+  </LDFLAGS>
+  <MPICC  MPILIB="impi">mpipgcc</MPICC>
+  <MPICXX MPILIB="impi">mpipgcxx</MPICXX>
+  <MPIFC  MPILIB="impi">mpipgf90</MPIFC>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
 <compiler MACH="sooty" COMPILER="intel">
@@ -1941,6 +1935,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <FFLAGS>
     <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent</base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align -fp-speculation=off</append>
+    <append> -DHAVE_ERF_INTRINSICS </append>
   </FFLAGS>
   <SCC> icc </SCC>
   <SCXX> icpc </SCXX>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -494,7 +494,7 @@
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/projects/acme/scratch</CIME_OUTPUT_ROOT>
     <BASELINE_ROOT>$ENV{HOME}/projects/acme/baselines/$COMPILER</BASELINE_ROOT>
-    <!-- cmake -DCMAKE_Fortran_COMPILER=/opt/local/bin/mpif90-mpich-gcc48 -DHDF5_DIR=/opt/local -DNetcdf_INCLUDE_DIR=/opt/local/include .. -->>
+    <!-- cmake -DCMAKE_Fortran_COMPILER=/opt/local/bin/mpif90-mpich-gcc48 -DHDF5_DIR=/opt/local -DNetcdf_INCLUDE_DIR=/opt/local/include .. -->
     <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
     <SUPPORTED_BY>jayesh at mcs dot anl dot gov</SUPPORTED_BY>
 <!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
@@ -1943,10 +1943,10 @@
       <modules mpilib="mvapich2">
         <command name="load">mvapich2/2.3.1</command>
       </modules>
-      <modules mpilib="impi" compiler="intel">>
+      <modules mpilib="impi" compiler="intel">
         <command name="load">intelmpi/2019u4</command>
       </modules>
-      <modules mpilib="impi" compiler="pgi">>
+      <modules mpilib="impi" compiler="pgi">
         <command name="load">intelmpi/2019u3</command>
       </modules>
       <modules>
@@ -1955,8 +1955,6 @@
         <command name="load">mkl/2019u5</command>
       </modules>
     </module_system>
-    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
-    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.05</TEST_TPUT_TOLERANCE>
     <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
     <environment_variables>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1935,7 +1935,7 @@
         <command name="load">cmake/3.11.4</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/19.0.3</command>
+        <command name="load">intel/19.0.5</command>
       </modules>
       <modules compiler="pgi">
         <command name="load">pgi/18.10</command>
@@ -1943,16 +1943,22 @@
       <modules mpilib="mvapich2">
         <command name="load">mvapich2/2.3.1</command>
       </modules>
-      <modules mpilib="impi">
+      <modules mpilib="impi" compiler="intel">>
+        <command name="load">intelmpi/2019u4</command>
+      </modules>
+      <modules mpilib="impi" compiler="pgi">>
         <command name="load">intelmpi/2019u3</command>
       </modules>
       <modules>
         <command name="load">netcdf/4.6.3</command>
         <command name="load">pnetcdf/1.9.0</command>
-        <command name="load">mkl/2019u3</command>
+        <command name="load">mkl/2019u5</command>
       </modules>
     </module_system>
-
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.05</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
       <env name="NETCDF_HOME">$ENV{NETCDF_ROOT}/</env>
       <env name="MKL_PATH">$ENV{MKLROOT}</env>
@@ -1966,8 +1972,7 @@
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
-      <env name="OMP_PROC_BIND">spread</env>
-      <env name="OMP_PLACES">threads</env>
+      <env name="OMP_PLACES">cores</env>
     </environment_variables>
 
 </machine> 

--- a/cime/config/e3sm/machines/config_pio.xml
+++ b/cime/config/e3sm/machines/config_pio.xml
@@ -63,9 +63,10 @@
     </values>
   </entry>
 
+  <!-- Using the BOX rearranger as the default -->
   <entry id="PIO_REARRANGER">
     <values>
-      <value>$PIO_VERSION</value>
+      <value>1</value>
     </values>
   </entry>
 
@@ -122,13 +123,13 @@
     </values>
   </entry>
   -->
-  <entry id="LND_PIO_REARRANGER">
+<!--  <entry id="LND_PIO_REARRANGER">
     <values>
       <value compset="_CLM40" >2</value>
       <value compset="_CLM45" >1</value>
       <value compset="_CLM50" >1</value>
     </values>
-  </entry>
+  </entry> -->
 
   <!--- uncomment and fill in relevant sections
   <entry id="LND_PIO_STRIDE">

--- a/cime/config/e3sm/testmods_dirs/allactive/v1cmip6/shell_commands
+++ b/cime/config/e3sm/testmods_dirs/allactive/v1cmip6/shell_commands
@@ -1,6 +1,5 @@
 #!/bin/bash
 ./xmlchange --append CAM_CONFIG_OPTS='-cosp'
 ./xmlchange --id BUDGETS --val TRUE
-./xmlchange PIO_TYPENAME=netcdf
 if [ `./xmlquery --value MACH` == cetus ]||[ `./xmlquery --value MACH` == mira ]; then sed s/64M/128M/ env_mach_specific.xml >tmp && mv tmp env_mach_specific.xml; fi
 

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -118,6 +118,7 @@ _TESTS = {
     "e3sm_prod" : (("e3sm_atm_prod",),None,
                      (
 		      ("SMS_Ld2.ne30_oECv3_ICG.A_WCYCL1850S_CMIP6","allactive-v1cmip6"),
+                      ("SMS_Ld2.ne30_oECv3_ICG.A_WCYCL20TRS_CMIP6","allactive-v1cmip6")
 		      )),
 
     "fates" : (None, None,

--- a/cime/scripts/Tools/Makefile
+++ b/cime/scripts/Tools/Makefile
@@ -110,6 +110,8 @@ endif
 
 ifeq ($(strip $(PIO_VERSION)),1)
   CPPDEFS += -DPIO1
+else
+  USE_CXX = true
 endif
 
 ifeq (,$(SHAREDPATH))
@@ -601,20 +603,33 @@ $(SHAREDLIBROOT)/$(SHAREDPATH)/mct/mpi-serial/Makefile.conf:
 	@echo "SHAREDLIBROOT |$(SHAREDLIBROOT)| SHAREDPATH |$(SHAREDPATH)|"; \
 	$(CONFIG_SHELL) $(CIMEROOT)/src/externals/mct/mpi-serial/configure $(CONFIG_ARGS) --srcdir $(CIMEROOT)/src/externals/mct/mpi-serial
 
+ifndef IO_LIB_SRCROOT
+  ifndef PIO_SRCROOT
+    PIO_SRCROOT = $(CIMEROOT)/src/externals
+  endif
+
+  ifeq ($(PIO_VERSION),2)
+    PIO_SRC_DIR = $(PIO_SRCROOT)/pio2
+  else
+    ifneq ("$(wildcard $(PIO_SRCROOT)/pio1/pio)", "")
+      PIO_SRC_DIR = $(PIO_SRCROOT)/pio1
+    else
+      PIO_SRC_DIR = $(PIO_SRCROOT)/pio1/pio
+    endif
+  endif
+else
+  PIO_SRC_DIR = $(IO_LIB_SRCROOT)/$(IO_LIB_v$(PIO_VERSION)_SRCDIR)
+endif
+
+
 ifeq ($(PIO_VERSION),2)
 # This is a pio2 library
   PIOLIB = $(PIO_LIBDIR)/libpiof.a $(PIO_LIBDIR)/libpioc.a
   PIOLIBNAME = -lpiof -lpioc
-  PIO_SRC_DIR = $(CIMEROOT)/src/externals/pio2
 else
 # This is a pio1 library
   PIOLIB = $(PIO_LIBDIR)/libpio.a
   PIOLIBNAME = -lpio
-  ifneq ("$(wildcard $(CIMEROOT)/src/externals/pio1/pio)", "")
-    PIO_SRC_DIR = $(CIMEROOT)/src/externals/pio1
-  else
-    PIO_SRC_DIR = $(CIMEROOT)/src/externals/pio1/pio
-  endif
 endif
 #endif
 
@@ -641,6 +656,7 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(EXTRA_PIO_FPPDEFS) $(IN
               -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
               -D GPTL_PATH:STRING=$(INSTALL_SHAREDPATH) \
               -D PIO_ENABLE_TESTS:BOOL=OFF \
+              -D PIO_USE_MALLOC:BOOL=ON \
 	      -D USER_CMAKE_MODULE_PATH:LIST="$(CIMEROOT)/src/CMake;$(CIMEROOT)/src/externals/pio2/cmake" \
 
 # Allow for separate installations of the NetCDF C and Fortran libraries
@@ -653,6 +669,10 @@ else ifeq ($(NETCDF_SEPARATE), true)
                 -D NetCDF_Fortran_PATH:PATH=$(NETCDF_FORTRAN_PATH)
 endif
 
+ifdef HDF5_PATH
+        CMAKE_OPTS += -D HDF5_PATH:STRING="$(HDF5_PATH)"
+endif
+
 ifdef PNETCDF_PATH
 	CMAKE_OPTS += -D PnetCDF_PATH:STRING="$(PNETCDF_PATH)"
 else
@@ -660,6 +680,9 @@ else
 endif
 ifdef PIO_FILESYSTEM_HINTS
 	CMAKE_OPTS += -D PIO_FILESYSTEM_HINTS:STRING="$(PIO_FILESYSTEM_HINTS)"
+endif
+ifeq ($(MPILIB),mpi-serial)
+	CMAKE_OPTS += -D PIO_USE_MPISERIAL=TRUE -D MPISERIAL_PATH=$(INSTALL_SHAREDPATH)
 endif
 
 # This captures the many cism-specific options to cmake

--- a/cime/scripts/Tools/jenkins_generic_job
+++ b/cime/scripts/Tools/jenkins_generic_job
@@ -65,6 +65,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-b", "--baseline-name", default=default_baseline,
                         help="Baseline name for baselines to use. Also impacts dashboard job name. Useful for testing a branch other than next or master")
 
+    parser.add_argument("-B", "--baseline-root",
+                        help="Baseline area for baselines to use. Default will be config_machine value for machine")
+
     parser.add_argument("-O", "--override-baseline-name",
                         help="Force comparison with these baseines without impacting dashboard or test-id.")
 
@@ -120,15 +123,15 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
         args.override_baseline_name = args.baseline_name
 
     return args.generate_baselines, args.submit_to_cdash, args.no_batch, args.baseline_name, args.cdash_build_name, \
-        args.cdash_project, args.test_suite, args.cdash_build_group, args.baseline_compare, args.scratch_root, args.parallel_jobs, args.walltime, args.machine, args.compiler, args.override_baseline_name
+        args.cdash_project, args.test_suite, args.cdash_build_group, args.baseline_compare, args.scratch_root, args.parallel_jobs, args.walltime, args.machine, args.compiler, args.override_baseline_name, args.baseline_root
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler, real_baseline_name = \
+    generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler, real_baseline_name, baseline_root = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler, real_baseline_name)
+    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler, real_baseline_name, baseline_root)
              else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/cime/scripts/lib/CIME/BuildTools/macrowriterbase.py
+++ b/cime/scripts/lib/CIME/BuildTools/macrowriterbase.py
@@ -315,7 +315,7 @@ def _parse_hash(macros, fd, depth, output_format, cmakedebug=""):
                 if key.startswith("ADD_"):
                     fd.write("{} {} += {}\n".format(" " * width, key[4:], value))
                 else:
-                    fd.write("{} {} += {}\n".format(" " * width, key, value))
+                    fd.write("{} {} := {}\n".format(" " * width, key, value))
 
             else:
                 value = value.replace("(", "{").replace(")", "}")

--- a/cime/scripts/lib/CIME/Servers/svn.py
+++ b/cime/scripts/lib/CIME/Servers/svn.py
@@ -15,6 +15,8 @@ class SVN(GenericServer):
         if passwd:
             self._args += "--password {}".format(passwd)
 
+        self._svn_loc = address
+
         err = run_cmd("svn --non-interactive --trust-server-cert {} ls {}".format(self._args, address))[0]
         if err != 0:
             logging.warning(
@@ -23,7 +25,6 @@ Could not connect to svn repo '{0}'
 This is most likely either a credential, proxy, or network issue .
 To check connection and store your credential run 'svn ls {0}' and permanently store your password""".format(address))
             return None
-        self._svn_loc = address
 
     def fileexists(self, rel_path):
         full_url = os.path.join(self._svn_loc, rel_path)
@@ -34,9 +35,11 @@ To check connection and store your credential run 'svn ls {0}' and permanently s
         return True
 
     def getfile(self, rel_path, full_path):
+        if not rel_path:
+            return False
         full_url = os.path.join(self._svn_loc, rel_path)
         stat, output, errput = \
-            run_cmd("svn --non-interactive --trust-server-cert {} export {} {}".format(self._args, full_url, full_path))
+                               run_cmd("svn --non-interactive --trust-server-cert {} export {} {}".format(self._args, full_url, full_path))
         if (stat != 0):
             logging.warning("svn export failed with output: {} and errput {}\n".format(output, errput))
             return False

--- a/cime/scripts/lib/CIME/Servers/wget.py
+++ b/cime/scripts/lib/CIME/Servers/wget.py
@@ -4,24 +4,24 @@ WGET Server class.  Interact with a server using WGET protocol
 # pylint: disable=super-init-not-called
 from CIME.XML.standard_module_setup import *
 from CIME.Servers.generic_server import GenericServer
-
 logger = logging.getLogger(__name__)
 
 class WGET(GenericServer):
     def __init__(self, address, user='', passwd=''):
         self._args = ''
         if user:
-            self._args += "--user {}".format(user)
+            self._args += "--user {} ".format(user)
         if passwd:
-            self._args += "--password {}".format(passwd)
-
-        err = run_cmd("wget {} --spider {}".format(self._args, address))[0]
-        expect(err == 0,"Could not connect to repo '{0}'\nThis is most likely either a proxy, or network issue .")
+            self._args += "--password {} ".format(passwd)
         self._server_loc = address
+
+        cmd = "wget {} --no-check-certificate --spider {}".format(self._args, address)
+        err, output, _ = run_cmd(cmd, combine_output=True)
+        expect(err == 0,"Could not connect to repo via '{}'\nThis is most likely either a proxy, or network issue.\nOutput:\n{}".format(cmd, output.encode('utf-8')))
 
     def fileexists(self, rel_path):
         full_url = os.path.join(self._server_loc, rel_path)
-        stat, out, err = run_cmd("wget {} --spider {}".format(self._args, full_url))
+        stat, out, err = run_cmd("wget {} --no-check-certificate --spider {}".format(self._args, full_url))
         if (stat != 0):
             logging.warning("FAIL: Repo '{}' does not have file '{}'\nReason:{}\n{}\n".format(self._server_loc, full_url, out.encode('utf-8'), err.encode('utf-8')))
             return False
@@ -30,7 +30,25 @@ class WGET(GenericServer):
     def getfile(self, rel_path, full_path):
         full_url = os.path.join(self._server_loc, rel_path)
         stat, output, errput = \
-                run_cmd("wget {} {} -nc --output-document {}".format(self._args, full_url, full_path))
+                run_cmd("wget {} {} -nc --no-check-certificate --output-document {}".format(self._args, full_url, full_path))
+        if (stat != 0):
+            logging.warning("wget failed with output: {} and errput {}\n".format(output.encode('utf-8'), errput.encode('utf-8')))
+            # wget puts an empty file if it fails.
+            try:
+                os.remove(full_path)
+            except OSError:
+                pass
+            return False
+        else:
+            logging.info("SUCCESS\n")
+            return True
+
+    def getdirectory(self, rel_path, full_path):
+        full_url = os.path.join(self._server_loc, rel_path)
+        stat, output, errput = \
+            run_cmd("wget  {} {} -r -N --no-check-certificate --no-directories ".format(self._args, full_url+os.sep), from_dir=full_path)
+        logger.debug(output)
+        logger.debug(errput)
         if (stat != 0):
             logging.warning("wget failed with output: {} and errput {}\n".format(output, errput))
             # wget puts an empty file if it fails.

--- a/cime/scripts/lib/CIME/SystemTests/npg.py
+++ b/cime/scripts/lib/CIME/SystemTests/npg.py
@@ -1,0 +1,623 @@
+"""
+Perturbation Growth New (NPG) - The CESM/ACME model's
+multi-instance capability is used to conduct an ensemble
+of simulations starting from different initial conditions.
+
+This class inherits from SystemTestsCommon.
+
+"""
+
+import os
+import glob
+import shutil
+import numpy as np
+import scipy.stats as stats
+
+
+from netCDF4 import Dataset
+from math import sqrt
+from sklearn.metrics import mean_squared_error
+
+from CIME.test_status import *
+from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.case.case_setup import case_setup
+from CIME.build import post_build
+from CIME.hist_utils import rename_all_hist_files
+from CIME.utils import expect
+
+#Logic for NPG ensemble runs:
+# We need two inputs:
+# A. Number of inic cond files
+# B. perturbations (e.g. currently we have: without prt, pos prt and neg prt)
+
+# Based off the above, we compute number of instances to have (A * B)
+# Build phase               : Change the user_nl* files to add perturbations and other flags 
+# Run pahse                 : Rename history files
+# Baselines generation phase: Compute cloud, store in netcdf file, copy netcdf file to baseline folder
+# Baseline Comparison phase : Compare against baseline cloud to know pass/fail, and plot (optional)
+
+
+#TODO: 
+#1. The loop to change user_nl* files is run twice as we call build again after changing ninst, which changes ntasks
+#2. Do we want to remove user_nl_cam, user_nl_clm etc. files as they are not used in the simulation?
+#3. change code so that pergro_ptend_names.txt is not generated if it is already there or only one instance writes this file...
+#4. Plot generation is very basic at this point(no lables, legends etc.), improve it! 
+#5. Decision making about PASS/FAIL should have multiple criteria
+
+logger = logging.getLogger(__name__)
+
+#--------------------------------------------------------
+#Variables which needs global scope for various functions
+#--------------------------------------------------------
+
+#number of inital conditions
+NINIT_COND = 6 #12
+        
+#perturbations for runs
+PRT        = [0.0, 1.0e-14, -1.0e-14]
+PRTSTR     = ['woprt','posprt','negprt']
+
+#file name for file containing PGE cloud
+FCLD_NC  = 'cam.h0.cloud.nc'
+
+#For preparing paths for namelist files for initial condition files
+FILE_PREF_ATM = "SMS_Ly5.ne4_ne4.FC5AV1C-04P2.eos_intel.ne45y.cam.i.0002-"
+FILE_PREF_LND = "SMS_Ly5.ne4_ne4.FC5AV1C-04P2.eos_intel.ne45y.clm2.r.0002-"
+
+FILE_SUF_ATM = "-01-00000.nc"
+FILE_SUF_LND = "-01-00000.nc"
+
+#------------------------------------------------------------
+# Some flags for debugging or invoking extra features
+#------------------------------------------------------------
+
+#DEBUGGING: prints out max rmse diffs if set to True
+INDEX = False 
+
+# generate a plot
+DOPLOT = False  #It impacts performance!
+
+class NPG(SystemTestsCommon):
+
+    def __init__(self, case):
+        """
+        initialize an object interface to the NPG test
+        """
+
+        #perturbation values and number of perturbation strings should be same
+        expect(len(PRT)== len(PRTSTR),"Number of perturbation values ("+str(len(PRT))+") are NOT " 
+               "equal to number of perturbation strings("+ str(len(PRTSTR))+")")
+        SystemTestsCommon.__init__(self, case)
+
+    #=================================================================
+    # Compile model with multiple instances
+    #=================================================================
+    def build_phase(self, sharedlib_only=False, model_only=False):
+
+        #------------------------------------------------------
+        #Compute number of instances:
+        #------------------------------------------------------
+
+        #------------------------------------------------------
+        #Number of instances:
+        #~~~~~~~~~~~~~~~~~~~
+        #Comput it from number of initial conditions to use and 
+        #number of perturbation ensemble members to use
+        #------------------------------------------------------
+        nprt       = len(PRT)
+        ninst      = NINIT_COND * nprt
+
+        logger.debug('NPG_INFO: number of instance: '+str(ninst))
+        
+        #------------------------------------------------------
+        #Fake Build:
+        #~~~~~~~~~~
+        #(for debugging only) Building the model can take 
+        #significant amount of time. Setting fake_bld to True 
+        #can savethat time
+        #------------------------------------------------------
+        fake_bld = False
+
+        #Find number of instance in the default setup
+        default_ninst = self._case.get_value("NINST_ATM")
+        
+        #Sanity check: see if NINST is same for all model components, otherwise exit with error
+        for comp in ['OCN','WAV','GLC','ICE','ROF','LND']:
+            iinst = self._case.get_value("NINST_%s"%comp)
+            expect(default_ninst == iinst, "ERROR: component "+str(comp)+" NINST("+str(iinst)+")"
+                   " is different from component ATM NINST("+str(default_ninst)+")")
+
+        #------------------------------------------------------
+        #Setup multi-instances for model components:
+        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        #Set the model for multi-instance ONLY if NINST == 1 
+        #for all model components. This is because, for 
+        #NINST > 1 (e.g. rebuilding an old case) the following 
+        #loop will increase the ntasks to a multiple of ninst 
+        #(requiring a clean build again). We hit this issue if 
+        #we launch ./case.build in the case directory of NPG 
+        #test
+        #------------------------------------------------------
+
+        if(default_ninst == 1): #if multi-instance is not already set
+            # Only want this to happen once. It will impact the sharedlib build
+            # so it has to happen here.
+            if not model_only:
+                # Lay all of the components out concurrently
+                logger.debug("NPG_INFO: Updating NINST for multi-instance in env_mach_pes.xml")
+                for comp in ['ATM','OCN','WAV','GLC','ICE','ROF','LND']:
+                    ntasks = self._case.get_value("NTASKS_%s"%comp)
+                    self._case.set_value("ROOTPE_%s"%comp, 0)
+                    self._case.set_value("NINST_%s"%comp,  ninst)
+                    self._case.set_value("NTASKS_%s"%comp, ntasks*ninst)
+
+                self._case.set_value("ROOTPE_CPL",0)
+                self._case.set_value("NTASKS_CPL",ntasks*ninst)
+                self._case.flush()
+
+                case_setup(self._case, test_mode=False, reset=True)
+
+        #Faking a bld can save the time code spend in building the model components
+        if fake_bld:
+            logger.debug("NPG_INFO: FAKE Build")
+            if (not sharedlib_only):
+                post_build(self._case, [])
+        else:
+            # Build exectuable with multiple instances
+            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+
+
+        #----------------------------------------------------------------
+        # Namelist settings:
+        #~~~~~~~~~~~~~~~~~~
+        # Do this already in build_phase so that we can check the xml and
+        # namelist files before job starts running.
+        #----------------------------------------------------------------
+        logger.debug("NPG_INFO: Updating user_nl_* files")
+
+        csmdata_root = self._case.get_value("DIN_LOC_ROOT")
+        csmdata_atm  = csmdata_root+"/atm/cam/inic/homme/ne4_v1_init/"
+        csmdata_lnd  = csmdata_root+"/lnd/clm2/initdata/ne4_v1_init/b58d55680/"
+
+        iinst = 1
+        for icond in range(NINIT_COND):
+            icond_label_2digits = str(icond+1).zfill(2)
+            fatm_in = FILE_PREF_ATM + icond_label_2digits + FILE_SUF_ATM
+            flnd_in = FILE_PREF_LND + icond_label_2digits + FILE_SUF_LND
+            for iprt in PRT:
+                with open('user_nl_cam_'+str(iinst).zfill(4), 'w') as atmnlfile, \
+                        open('user_nl_clm_'+str(iinst).zfill(4), 'w') as lndnlfile:
+                    
+                    #atm/lnd intitial conditions                   
+                    
+                    #initial condition files to use for atm and land
+                    #atmnlfile.write("ncdata  = '"+ "/pic/projects/uq_climate/wanh895/acme_input/ne4_v1_init/" + fatm_in+"' \n")
+                    #lndnlfile.write("finidat = '"+ "/pic/projects/uq_climate/wanh895/acme_input/ne4_v1_init/" + flnd_in+"' \n")
+                    
+                    #uncomment the following when there files are on SVN server
+                    atmnlfile.write("ncdata  = '"+ csmdata_atm + "/" + fatm_in+"' \n")
+                    lndnlfile.write("finidat = '"+ csmdata_lnd + "/" + flnd_in+"' \n")
+                    
+                    
+                    #atm model output
+                    atmnlfile.write("avgflag_pertape = 'I' \n")
+                    atmnlfile.write("nhtfrq = 1 \n")
+                    atmnlfile.write("mfilt  = 2  \n")
+                    atmnlfile.write("ndens  = 1  \n")
+                    atmnlfile.write("pergro_mods  = .true. \n")
+                    atmnlfile.write("pergro_test_active = .true. \n")
+
+                    #atmnlfile.write("empty_htapes = .true. \n")
+                    #atmnlfile.write("fincl1 = 'PS','U','V','T','Q','CLDLIQ','CLDICE','NUMLIQ','NUMICE','num_a1','num_a2','num_a3','LANDFRAC' \n")
+                    #atmnlfile.write("phys_debug_lat = 41.3495891345")
+                    #atmnlfile.write("phys_debug_lon = 45.0" )
+                
+                    if(iprt != 0.0):
+                        atmnlfile.write("pertlim = "+str(iprt)+" \n")
+                        
+                    iinst += 1
+
+        #--------------------------------
+        #Settings common to all instances
+        #--------------------------------
+
+        #Coupler settings which are applicable to ALL the instances (as there is only one coupler for all instances)
+        self._case.set_value("STOP_N",     "1")
+        self._case.set_value("STOP_OPTION","nsteps")
+
+
+    #===========================================================
+    # Some user defined functions to avoid repeated calculations
+    #===========================================================
+
+    def get_fname_wo_ext(self,rundir,casename,iinst):
+        """
+        construct file name given the input
+        """
+        #form file name withOUT extension
+        tstmp    = '00000'
+        date_str = '.h0.0001-01-01-'
+        cam_str  = 'cam_'
+        if(casename != "" ):
+            cam_str = '.'+cam_str
+        return os.path.join(rundir,casename+cam_str+str(iinst).zfill(4)+date_str+tstmp)
+
+    def get_var_list(self):
+        """
+        Get variable list for pergro specific output vars
+        """
+        rundir    = self._case.get_value("RUNDIR")
+        casename  = self._case.get_value("CASE")    
+        prg_fname = 'pergro_ptend_names.txt'
+        var_file = os.path.join(rundir,prg_fname)
+        expect(os.path.isfile(var_file),"File "+prg_fname+" does not exist in: "+rundir)
+
+        with open(var_file, 'r') as fvar:
+            var_list = fvar.readlines()
+                    
+        return  map(str.strip,var_list)
+
+    def nc_write_handle(self,fname_nc,rmse_nc_var):
+        """
+        Opens and write netcdf file for PGE curves
+        This function is here purely to avoid duplicate 
+        codes so that it is easy to maintain code longterm        
+        """
+
+        fhndl = Dataset(fname_nc,'w', format='NETCDF4')
+
+        var_list     = self.get_var_list()
+        len_var_list = len(var_list)
+        nprt         = len(PRT)
+
+        #create dims
+        fhndl.createDimension('ninit', NINIT_COND)
+        fhndl.createDimension('nprt', nprt)
+        fhndl.createDimension('nprt_m1', nprt-1)
+        fhndl.createDimension('nvars', len_var_list)
+
+
+        #create variables in the file
+        init_cond_nc = fhndl.createVariable('init_cond_fnames', 'S100', 'ninit')
+        prt_nc       = fhndl.createVariable('perturb_strings', 'S10', 'nprt')
+        variables_nc = fhndl.createVariable('perturb_vnames', 'S20', 'nvars')
+        rmse_nc      = fhndl.createVariable(rmse_nc_var, 'f8', ('ninit', 'nprt_m1', 'nvars'))
+
+
+        #assign variables for writing to the netcdf file
+        for iprt in range(nprt):
+            prt_nc[iprt]       = PRTSTR[iprt]
+
+        for ivar in range(len_var_list):
+            variables_nc[ivar] = var_list[ivar]
+
+        for icond in range(NINIT_COND):
+            icond_label_2digits = str(icond+1).zfill(2)
+            init_cond_nc[icond] =  FILE_PREF_ATM + icond_label_2digits + FILE_SUF_ATM
+
+        return fhndl, rmse_nc
+        
+    def rmse_var(self,ifile_test, ifile_cntl,  var_list, var_suffix ):
+        """
+        Compute RMSE difference between ifile_test and ifile_cntl for
+        variables listed in var_list
+        """
+        
+        #------------------ARGS-------------------------
+        #ifile_test: path of test file
+        #ifile_cntl: path of control file
+        #var_list  : List of all variables
+        #var_suffix: Suffix for var_list (e.g. t_, t_ qv_ etc.)
+        #-----------------------------------------------
+
+        # See if the files exists or not....
+        expect(os.path.isfile(ifile_test), "ERROR: Test file "+ifile_test+" does not exist")
+        expect(os.path.isfile(ifile_cntl), "ERROR: CNTL file "+ifile_cntl+" does not exist")
+        
+        ftest = Dataset(ifile_test,  mode='r')
+        fcntl = Dataset(ifile_cntl, mode='r')
+
+        #if max RMSE/DIFF is to be printed, extract lat lons from a file
+        if(INDEX):
+            lat = ftest.variables['lat']
+            lon = ftest.variables['lon']
+        
+        rmse = np.zeros(shape=(len(var_list)))
+        icntvar = 0
+        
+        is_se = (len(ftest.variables[var_suffix+var_list[icntvar]].dimensions)==3) # see if it is SE grid
+        
+        for ivar in var_list:
+            var = var_suffix+ivar
+            if var in ftest.variables:
+                vtest    = ftest.variables[var.strip()][0,...] # first dimention is time (=0)
+                vcntl    = fcntl.variables[var.strip()][0,...] # first dimention is time (=0)
+
+                #reshape for RMSE
+                if(is_se ):
+                    nx, ny = vtest.shape #shape will be same for both arrays
+                    nz = 1
+                else:
+                    nx, ny, nz = vtest.shape #shape will be same for both arrays
+
+                rmse[icntvar]  = sqrt(mean_squared_error(vtest.reshape((nx,ny*nz)), vcntl.reshape((nx,ny*nz))))
+
+                if(INDEX):
+                    #NEED to work on formatting this....
+                    diff_arr = abs(vtest[...] - vcntl[...])
+                    max_diff = np.amax(diff_arr)
+                    ind_max = np.unravel_index(diff_arr.argmax(),diff_arr.shape)
+                    print(ind_max)
+                    print_str = var+' '+str(max_diff)+' '+str(vtest[ind_max])+' ' +str(vcntl[ind_max])+' '+str(lat[ind_max[1]])+' '+ str(lon[ind_max[1]])+' '+str(ind_max[0])
+                    print("{}".format(print_str))
+                    #print('{0:15}{1:15}{2:15}\n'.format(name, a, b))#TRY THIS!!
+
+
+                #normalize by mean values of the field in the control case
+                rmse[icntvar] = rmse[icntvar]/np.mean(vcntl)
+                icntvar += 1
+                vtest = None
+                vcntl = None
+                var   = None
+        ftest.close()
+        fcntl.close()
+        return rmse
+
+    def _compare_baseline(self):
+        
+        #import time
+        #t0 = time.time()
+        """
+        Compare baselines in the pergro test sense. That is,
+        compare PGE from the test simulation with the baseline 
+        cloud
+        """
+        logger.debug("NPG_INFO:BASELINE COMPARISON STARTS")
+
+        rundir    = self._case.get_value("RUNDIR")
+        casename  = self._case.get_value("CASE") 
+
+        var_list = self.get_var_list()
+        len_var_list = len(var_list)
+        nprt         = len(PRT)
+
+        #baseline directory names
+        base_root = self._case.get_value("BASELINE_ROOT")
+        base_comp = self._case.get_value("BASECMP_CASE")        
+
+        #baseline directory is:base_root/base_comp
+        base_dir = os.path.join(base_root,base_comp)
+
+        #for test cases (new environment etc.)        
+        logger.debug("NPG_INFO: Test case comparison...")
+
+        #---------------------------------------------
+        # Write netcdf file for comparison
+        #---------------------------------------------
+        fcomp_nc = 'comp_cld.nc'
+        fcomp_cld, comp_rmse_nc  = self.nc_write_handle(fcomp_nc,'comp_rmse')
+
+        iinst = 0
+        for icond in range(NINIT_COND):
+            iinst += 1;  iprt = 0
+            ifile_cntl = os.path.join(base_dir,self.get_fname_wo_ext('','',iinst)+'_woprt.nc')
+            expect(os.path.isfile(ifile_cntl), "ERROR: File "+ifile_cntl+" does not exist")
+            logger.debug("NPG_INFO:CNTL_TST:"+ifile_cntl)
+
+            for aprt in PRTSTR[1:]:
+                iinst += 1;                
+                ifile_test = os.path.join(rundir,self.get_fname_wo_ext(rundir,casename,iinst)+'_'+aprt+'.nc')
+                expect(os.path.isfile(ifile_test), "ERROR: File "+ifile_test+" does not exist")
+                comp_rmse_nc[icond,iprt,0:len_var_list] = self.rmse_var(ifile_test, ifile_cntl,  var_list, 't_' )
+                logger.debug("NPG_INFO:Compared to TEST_TST:"+ifile_test)
+
+                iprt += 1
+        
+        #--------------------------------------------
+        #Student's t-test
+        #-------------------------------------------
+
+        #Extract last element of each PGE curve of the cloud
+        path_cld_nc  = os.path.join(base_dir,FCLD_NC)
+        expect(os.path.isfile(path_cld_nc), "ERROR: "+FCLD_NC+"  does not exist at:"+path_cld_nc)
+
+        fcld         = Dataset(path_cld_nc,'r', format='NETCDF4')
+
+        #Get dimentions of cloud PGE curves
+        ninic_cld = fcld.variables['cld_rmse'].shape[0]
+        nprt_cld  = fcld.variables['cld_rmse'].shape[1]
+        nvar_cld  = fcld.variables['cld_rmse'].shape[2]
+
+        expect(ninic_cld == NINIT_COND, "BASELINE COMPARISON: Number of initial conditions should be same:" \
+               "inic cld:"+str(ninic_cld)+"  inic comp:"+str(NINIT_COND))
+
+        expect(nprt_cld == nprt-1, "BASELINE COMPARISON: Number of perturbations should be same:" \
+               "prt cld:"+str(nprt_cld)+"  prt comp:"+str(nprt - 1))
+
+        expect(nvar_cld == len_var_list, "BASELINE COMPARISON: Number of phys update variables should be same:" \
+               "nvar cld:"+str(nvar_cld)+"  nvar comp:"+str(len_var_list))
+
+
+        pgecld =  fcld.variables['cld_rmse']
+
+        if (DOPLOT):
+            import pylab as pl            
+            #generate plot
+            ax = pl.gca()
+            for icond in range(NINIT_COND):
+                for iprt in range(nprt-1):
+                    ax.semilogy(pgecld[icond,iprt,:],color='b')
+                    ax.semilogy(comp_rmse_nc[icond,iprt,:],color='r')
+            pl.savefig('plot_comp.png')
+
+        pge_ends_cld  = fcld.variables['cld_rmse'][:,:,len_var_list-1]
+        pge_ends_comp = comp_rmse_nc[:,0:nprt-1,len_var_list-1]
+
+        #run the t-test
+        pge_ends_cld = pge_ends_cld.flatten()
+        pge_ends_comp = pge_ends_comp.flatten()        
+
+        t_stat, p_val = stats.ttest_ind(pge_ends_cld, pge_ends_comp)
+
+        t_stat = abs(t_stat) #only value of t_stat matters, not the sign
+
+        print("NPG_INFO: T value:"+str(t_stat))
+        print("NPG_INFO: P value:"+str(p_val))
+
+        logger.warn(" T value:"+str(t_stat))
+        logger.warn(" P value:"+str(p_val))
+        
+        
+        #There should be multiple criteria to determin pass/fail
+        #This part of decision making should be more polished
+
+        if (t_stat > 3):
+            with self._test_status:
+                self._test_status.set_status(BASELINE_PHASE, TEST_FAIL_STATUS)
+            print('NPG_INFO:TEST FAIL')
+        else:
+            with self._test_status:
+                self._test_status.set_status(BASELINE_PHASE, TEST_PASS_STATUS)
+            print('NPG_INFO:TEST PASS')
+                    
+        #Close this file after you access "comp_rmse_nc" variable
+        fcomp_cld.close()
+        logger.debug("NPG_INFO: POST PROCESSING PHASE ENDS")
+        
+        #t1 = time.time()
+        #print('time: '+str(t1-t0))
+    #=================================================================
+    # run_phase
+    #=================================================================
+    def run_phase(self):
+        logger.debug("NPG_INFO: RUN PHASE")
+        
+        self.run_indv()
+
+        #cwd = os.getcwd()
+
+        #Here were are in case directory, we need to go to the run directory and rename files
+        rundir   = self._case.get_value("RUNDIR")
+        casename = self._case.get_value("CASE") 
+        logger.debug("NPG_INFO: Case name is:"+casename )
+
+        iinst = 1
+        for icond in range(NINIT_COND):
+            for iprt in range(len(PRT)):
+                
+                #------------------------------------------------------
+                #SANITY CHECK - To confirm that history file extension
+                #~~~~~~~~~~~~
+                # corresponds to the right perturbation
+                #------------------------------------------------------
+                #find corresponding atm_in_*
+                fatm_in = os.path.join(rundir,'atm_in_'+str(iinst).zfill(4))
+                #see if atm_in_* file has pertlim same as PRT[iprt] (sanity check)
+                found  = False
+                prtval = 0.0
+                with open(fatm_in) as atmfile:
+                    for line in atmfile:
+                        if(line.find('pertlim') > 0):
+                            found = True
+                            prtval = float(line.split('=')[1])
+                            expect(prtval == PRT[iprt], "ERROR: prtval doesn't match, prtval:"+str(prtval)+"; prt["+str(iprt)+"]:"+str(PRT[iprt]))
+                            logger.debug("NPG_INFO:prtval:"+str(prtval)+"; prt["+str(iprt)+"]:"+str(PRT[iprt]))
+                
+                if(not found):
+                    expect(prtval == PRT[iprt], "ERROR: default prtval doesn't match, prtval:"+str(prtval)+"; prt["+str(iprt)+"]:"+str(PRT[iprt]))
+                    logger.debug("NPG_INFO:def prtval:"+str(prtval)+"; prt["+str(iprt)+"]:"+str(PRT[iprt]))
+                  
+                #---------------------------------------------------------
+                #Rename file
+                #---------------------------------------------------------
+
+                #form file name
+                fname = self.get_fname_wo_ext(rundir,casename,iinst) #NOTE:without extension
+                logger.debug("NPG_INFO: fname to rename:"+fname )
+                
+                renamed_fname = fname +'_'+PRTSTR[iprt]+'.nc'
+                fname_w_ext   = fname + '.nc' #add extention
+
+                #see if file exists
+                if (os.path.isfile(fname_w_ext)):
+                    #rename file
+                    shutil.move(fname_w_ext,renamed_fname)
+                    logger.debug("NPG_INFO: Renamed file:"+renamed_fname)
+                else:
+                    expect(os.path.isfile(renamed_fname), "ERROR: File "+renamed_fname+" does not exist")
+                    logger.debug("NPG_INFO: Renamed file already exists:"+renamed_fname)
+                
+                iinst += 1
+
+        #cloud generation
+
+        logger.debug("NPG_INFO: cloud generation-gen base")
+            
+        var_list     = self.get_var_list()
+        len_var_list = len(var_list)
+        nprt         = len(PRT)
+        
+        #for trusted cloud sims
+        logger.debug("NPG_INFO: Computing cloud")
+            
+        cld_res = np.empty([len_var_list])
+            
+        #---------------------------------------------
+        # Write netcdf file for cloud in rundir
+        #---------------------------------------------
+        os.chdir(rundir)
+        fcld, cld_rmse_nc = self.nc_write_handle(FCLD_NC,'cld_rmse')
+
+        iinst = 0
+        for icond in range(NINIT_COND):
+            iinst += 1;  iprt = 0
+            ifile_cntl = os.path.join(rundir,self.get_fname_wo_ext('',casename,iinst)+'_'+PRTSTR[iprt]+'.nc')
+            expect(os.path.isfile(ifile_cntl), "ERROR: File "+ifile_cntl+" does not exist")
+            logger.debug("NPG_INFO:CNTL_CLD:"+ifile_cntl)            
+            
+            for aprt in PRTSTR[1:]:
+                iinst += 1;
+                iprt = PRTSTR.index(aprt) - 1 # subtracted 1 as we will only get two curves for each inic (wo-pos and wo-neg)
+                ifile_test = os.path.join(rundir,self.get_fname_wo_ext('',casename,iinst)+'_'+aprt+'.nc')
+                expect(os.path.isfile(ifile_test), "ERROR: File "+ifile_test+" does not exist")
+                cld_rmse_nc[icond,iprt,0:len_var_list] = self.rmse_var(ifile_test, ifile_cntl,  var_list, 't_' )
+                logger.debug("NPG_INFO:Compared to CLD:"+ifile_test)
+
+        fcld.close()
+
+        if(self._case.get_value("GENERATE_BASELINE")):
+            
+            #baseline directory names
+            base_root = self._case.get_value("BASELINE_ROOT")
+            base_gen  = self._case.get_value("BASEGEN_CASE")
+        
+            #baseline directory is:base_root/base_gen
+            base_dir = os.path.join(base_root,base_gen)
+
+            #first copy files to the baseline directory
+            self._generate_baseline()#BALLI-CHECK IF THIS IS OKAY
+
+            #copy cloud.nc file to baseline directory
+            logger.debug("NPG_INFO:copy:"+FCLD_NC+" to "+base_dir)
+            shutil.copy(FCLD_NC,base_dir)
+
+        logger.debug("NPG_INFO: RUN PHASE ENDS" )
+
+
+#=====================================================
+#Debugging:
+#=====================================================
+
+#-----------------------------------------------------
+#DEBUG type 1 (DB1): Ensure that model produces BFB instances
+#-----------------------------------------------------
+##Replace the following lines in the script with the following updated values
+#PRT        = [0.0, 0.0] #DB1
+#PRTSTR     = ['woprt','posprt']
+
+## Comment out all namelist changes so that all instances have same namelist values
+## For testing effect of namelist changes, uncomment namlist changes such that
+## namelists are same for all instances
+
+## Comment out sanity checks as well if needed....

--- a/cime/scripts/lib/CIME/SystemTests/tsc.py
+++ b/cime/scripts/lib/CIME/SystemTests/tsc.py
@@ -1,0 +1,161 @@
+"""
+Solution reproducibility test based on time-step convergence
+The CESM/ACME model's
+multi-instance capability is used to conduct an ensemble
+of simulations starting from different initial conditions.
+
+This class inherits from SystemTestsCommon.
+"""
+
+from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.case.case_setup import case_setup
+from CIME.build import post_build
+from CIME.hist_utils import rename_all_hist_files
+from CIME.test_status import *
+#import CIME.utils
+#from CIME.check_lockedfiles import *
+
+logger = logging.getLogger(__name__)
+
+class TSC(SystemTestsCommon):
+
+    def __init__(self, case):
+        """
+        initialize an object interface to the TSC test
+        """
+        SystemTestsCommon.__init__(self, case)
+
+    #=================================================================
+    # Compile model with multiple instances
+    #=================================================================
+    def build_phase(self, sharedlib_only=False, model_only=False):
+
+        ninst = 12
+
+        #BSINGH: For debugging only - Building the model can take
+        #significant amount of time. Setting fake_bld to True can save
+        #that time
+        fake_bld = False
+
+        # Build exectuable with multiple instances
+        # (in the development phase we use 3)
+        # Lay all of the components out concurrently
+
+        # Only want this to happen once. It will impact the sharedlib build
+        # so it has to happen there.
+        if not model_only:
+            logging.warning("Starting to build multi-instance exe")
+            for comp in ['ATM','OCN','WAV','GLC','ICE','ROF','LND']:
+                ntasks = self._case.get_value("NTASKS_%s"%comp)
+                self._case.set_value("ROOTPE_%s"%comp, 0)
+                self._case.set_value("NINST_%s"%comp,  ninst)
+                self._case.set_value("NTASKS_%s"%comp, ntasks*ninst)
+
+            self._case.set_value("ROOTPE_CPL",0)
+            self._case.set_value("NTASKS_CPL",ntasks*ninst)
+            self._case.flush()
+
+            case_setup(self._case, test_mode=False, reset=True)
+
+        #BSINGH: Faking a bld can save the time code spend in building the model components
+        if fake_bld:
+            if (not sharedlib_only):
+                post_build(self._case, [])
+        else:
+            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+
+    #=================================================================
+    # Conduct one multi-instance run with specified time step size.
+    # The complete run_phase (defined below) will contain two calls
+    # of this function using different dtime.
+    #=================================================================
+    def _run_with_specified_dtime(self,dtime=2):
+
+        # dtime is model time step size in seconds. Default is set to 2.
+
+        # Change the coupling frequency accordingly
+        ncpl  = 86400/dtime
+        self._case.set_value("ATM_NCPL",ncpl)
+
+        # Simulation length = 10 minutes
+        nsteps = 600/dtime
+        self._case.set_value("STOP_N",     nsteps)
+        self._case.set_value("STOP_OPTION","nsteps")
+
+        # Write output every 10 seconds
+        nhtfrq = 10/dtime
+
+        # generate paths/file names for initial conditons
+        csmdata_root = self._case.get_value("DIN_LOC_ROOT")
+        csmdata_atm  = csmdata_root+"/atm/cam/inic/homme/ne4_v1_init/"
+        csmdata_lnd  = csmdata_root+"/lnd/clm2/initdata/ne4_v1_init/b58d55680/"
+        file_pref_atm = "SMS_Ly5.ne4_ne4.FC5AV1C-04P2.eos_intel.ne45y.cam.i.0002-"
+        file_pref_lnd = "SMS_Ly5.ne4_ne4.FC5AV1C-04P2.eos_intel.ne45y.clm2.r.0002-"
+
+        file_suf_atm = "-01-00000.nc"
+        file_suf_lnd = "-01-00000.nc"
+
+        # user_nl_... files are modified for every instance.
+        # The number instances specified here has to be consistent with the
+        # value set in build_phase.
+        ninst = 12
+        for iinst in range(1, ninst+1):
+
+            with open('user_nl_cam_'+str(iinst).zfill(4), 'w') as atmnlfile, \
+                 open('user_nl_clm_'+str(iinst).zfill(4), 'w') as lndnlfile:
+
+                # atm/lnd intitial conditions
+
+                inst_label_2digits = str(iinst).zfill(2)
+
+                atmnlfile.write("ncdata  = '"+ csmdata_atm + "/" + file_pref_atm + inst_label_2digits + file_suf_atm+"' \n")
+                lndnlfile.write("finidat = '"+ csmdata_lnd + "/" + file_pref_lnd + inst_label_2digits + file_suf_lnd+"' \n")
+
+                # for initial testing on constance@pnnl
+                #atmnlfile.write("ncdata  = '"+ "/pic/projects/uq_climate/wanh895/acme_input/ne4_v1_init/" + file_pref_atm + inst_label_2digits + file_suf_atm+"' \n")
+                #lndnlfile.write("finidat = '"+ "/pic/projects/uq_climate/wanh895/acme_input/ne4_v1_init/" + file_pref_lnd + inst_label_2digits + file_suf_lnd+"' \n")
+
+                # time step sizes
+
+                atmnlfile.write("dtime = "+str(dtime)+" \n")
+                atmnlfile.write("iradsw = 2 \n")
+                atmnlfile.write("iradlw = 2 \n")
+
+                lndnlfile.write("dtime = "+str(dtime)+" \n")
+
+                # atm model output
+
+                atmnlfile.write("avgflag_pertape = 'I' \n")
+                atmnlfile.write("nhtfrq = "+str(nhtfrq)+" \n")
+                atmnlfile.write("mfilt  = 1  \n")
+                atmnlfile.write("ndens  = 1  \n")
+                atmnlfile.write("empty_htapes = .true. \n")
+                atmnlfile.write("fincl1 = 'PS','U','V','T','Q','CLDLIQ','CLDICE','NUMLIQ','NUMICE','num_a1','num_a2','num_a3','LANDFRAC' \n")
+
+        # Force rebuild namelists
+        self._skip_pnl = False
+
+        # Namelist settings done. Now run the model.
+        self.run_indv()
+
+        # Append "DT000x" to the history file names
+        rename_all_hist_files( self._case, suffix="DT"+str(dtime).zfill(4) )
+
+
+    #=================================================================
+    # run_phase
+    #=================================================================
+    def run_phase(self):
+
+        # Run simulations with 2-s time step
+        self._run_with_specified_dtime(dtime=2)
+
+        # Run simulations with 1-s time step. This is NOT needed
+        # for testing new code or new computing environment.
+        if self._case.get_value("GENERATE_BASELINE"):
+            self._run_with_specified_dtime(dtime=1)
+    def _compare_baseline(self):
+        #currently faking it as PENDING
+        with self._test_status as ts:
+            ts.set_status(BASELINE_PHASE, TEST_PEND_STATUS)

--- a/cime/scripts/lib/CIME/case/check_input_data.py
+++ b/cime/scripts/lib/CIME/case/check_input_data.py
@@ -2,11 +2,7 @@
 API for checking input for testcase
 """
 from CIME.XML.standard_module_setup import *
-<<<<<<< HEAD
 from CIME.utils import SharedArea, find_files, safe_copy, expect
-=======
-from CIME.utils import SharedArea, find_files, expect
->>>>>>> maint-1.0
 from CIME.XML.inputdata import Inputdata
 import CIME.Servers
 
@@ -113,11 +109,7 @@ def stage_refcase(self, input_data_root=None, data_list_dir=None):
         # copy the refcases' rpointer files to the run directory
         for rpointerfile in glob.iglob(os.path.join("{}","*rpointer*").format(refdir)):
             logger.info("Copy rpointer {}".format(rpointerfile))
-<<<<<<< HEAD
-            safe_copy(rpointerfile, rundir)
-=======
             shutil.copy2(rpointerfile, rundir)
->>>>>>> maint-1.0
 
         # link everything else
 

--- a/cime/scripts/lib/CIME/case/check_input_data.py
+++ b/cime/scripts/lib/CIME/case/check_input_data.py
@@ -2,7 +2,11 @@
 API for checking input for testcase
 """
 from CIME.XML.standard_module_setup import *
+<<<<<<< HEAD
 from CIME.utils import SharedArea, find_files, safe_copy, expect
+=======
+from CIME.utils import SharedArea, find_files, expect
+>>>>>>> maint-1.0
 from CIME.XML.inputdata import Inputdata
 import CIME.Servers
 
@@ -109,7 +113,11 @@ def stage_refcase(self, input_data_root=None, data_list_dir=None):
         # copy the refcases' rpointer files to the run directory
         for rpointerfile in glob.iglob(os.path.join("{}","*rpointer*").format(refdir)):
             logger.info("Copy rpointer {}".format(rpointerfile))
+<<<<<<< HEAD
             safe_copy(rpointerfile, rundir)
+=======
+            shutil.copy2(rpointerfile, rundir)
+>>>>>>> maint-1.0
 
         # link everything else
 

--- a/cime/scripts/lib/CIME/test_status.py
+++ b/cime/scripts/lib/CIME/test_status.py
@@ -147,6 +147,12 @@ class TestStatus(object):
         for phase, data in self._phase_statuses.items():
             yield phase, data[0]
 
+    def __eq__(self, rhs):
+        return self._phase_statuses == rhs._phase_statuses # pylint: disable=protected-access
+
+    def __ne__(self, rhs):
+        return not self.__eq__(rhs)
+
     def get_name(self):
         return self._test_name
 

--- a/cime/scripts/lib/CIME/utils.py
+++ b/cime/scripts/lib/CIME/utils.py
@@ -409,7 +409,7 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
         arg_stderr = _convert_to_fd(arg_stdout, from_dir)
 
     if (verbose != False and (verbose or logger.isEnabledFor(logging.DEBUG))):
-        logger.info("RUN: {}".format(cmd))
+        logger.info("RUN: {}\nFROM: {}".format(cmd, os.getcwd() if from_dir is None else from_dir))
 
     if (input_str is not None):
         stdin = subprocess.PIPE

--- a/cime/scripts/lib/CIME/wait_for_tests.py
+++ b/cime/scripts/lib/CIME/wait_for_tests.py
@@ -51,20 +51,8 @@ def get_test_output(test_path):
         return ""
 
 ###############################################################################
-def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname):
+def create_cdash_xml_boiler(phase, cdash_build_name, cdash_build_group, utc_time, current_time, hostname, git_commit):
 ###############################################################################
-    # We assume all cases were created from the same code repo
-    first_result_case = os.path.dirname(list(results.items())[0][1][0])
-    try:
-        srcroot = run_cmd_no_fail("./xmlquery --value CIMEROOT", from_dir=first_result_case)
-    except:
-        # Use repo containing this script as last resort
-        srcroot = CIME.utils.get_cime_root()
-
-    git_commit = CIME.utils.get_current_commit(repo=srcroot)
-
-    data_rel_path = os.path.join("Testing", utc_time)
-
     site_elem = xmlet.Element("Site")
 
     if ("JENKINS_START_TIME" in os.environ):
@@ -79,40 +67,89 @@ def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time
     site_elem.attrib["Hostname"] = hostname
     site_elem.attrib["OSVersion"] = "Commit: {}{}".format(git_commit, time_info_str)
 
-    testing_elem = xmlet.SubElement(site_elem, "Testing")
+    phase_elem = xmlet.SubElement(site_elem, phase)
 
-    start_date_time_elem = xmlet.SubElement(testing_elem, "StartDateTime")
-    start_date_time_elem.text = time.ctime(current_time)
+    xmlet.SubElement(phase_elem, "StartDateTime").text = time.ctime(current_time)
+    xmlet.SubElement(phase_elem, "Start{}Time".format("Test" if phase == "Testing" else phase)).text = str(int(current_time))
 
-    start_test_time_elem = xmlet.SubElement(testing_elem, "StartTestTime")
-    start_test_time_elem.text = str(int(current_time))
+    return site_elem, phase_elem
+
+###############################################################################
+def create_cdash_config_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname, data_rel_path, git_commit):
+###############################################################################
+    site_elem, config_elem = create_cdash_xml_boiler("Configure", cdash_build_name, cdash_build_group, utc_time, current_time, hostname, git_commit)
+
+    xmlet.SubElement(config_elem, "ConfigureCommand").text = "namelists"
+
+    config_results = []
+    for test_name in sorted(results):
+        test_status = results[test_name][1]
+        config_results.append("{} {} Config {}".format("" if test_status != NAMELIST_FAIL_STATUS else "CMake Warning:\n", test_name, "PASS" if test_status != NAMELIST_FAIL_STATUS else "NML DIFF"))
+
+    xmlet.SubElement(config_elem, "Log").text = "\n".join(config_results)
+
+    xmlet.SubElement(config_elem, "ConfigureStatus").text = "0"
+    xmlet.SubElement(config_elem, "ElapsedMinutes").text = "0" # Skip for now
+
+    etree = xmlet.ElementTree(site_elem)
+    etree.write(os.path.join(data_rel_path, "Configure.xml"))
+
+###############################################################################
+def create_cdash_build_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname, data_rel_path, git_commit):
+###############################################################################
+    site_elem, build_elem = create_cdash_xml_boiler("Build", cdash_build_name, cdash_build_group, utc_time, current_time, hostname, git_commit)
+
+    xmlet.SubElement(build_elem, "ConfigureCommand").text = "case.build"
+
+    build_results = []
+    for test_name in sorted(results):
+        build_results.append(test_name)
+
+    xmlet.SubElement(build_elem, "Log").text = "\n".join(build_results)
+
+    for idx, test_name in enumerate(sorted(results)):
+        test_path = results[test_name][0]
+        test_norm_path = test_path if os.path.isdir(test_path) else os.path.dirname(test_path)
+        if get_test_time(test_norm_path) == 0:
+            error_elem = xmlet.SubElement(build_elem, "Error")
+            xmlet.SubElement(error_elem, "Text").text = test_name
+            xmlet.SubElement(error_elem, "BuildLogLine").text = str(idx)
+            xmlet.SubElement(error_elem, "PreContext").text = test_name
+            xmlet.SubElement(error_elem, "PostContext").text = ""
+            xmlet.SubElement(error_elem, "RepeatCount").text = "0"
+
+    xmlet.SubElement(build_elem, "ElapsedMinutes").text = "0" # Skip for now
+
+    etree = xmlet.ElementTree(site_elem)
+    etree.write(os.path.join(data_rel_path, "Build.xml"))
+
+###############################################################################
+def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname, data_rel_path, git_commit):
+###############################################################################
+    site_elem, testing_elem = create_cdash_xml_boiler("Testing", cdash_build_name, cdash_build_group, utc_time, current_time, hostname, git_commit)
 
     test_list_elem = xmlet.SubElement(testing_elem, "TestList")
     for test_name in sorted(results):
-        test_elem = xmlet.SubElement(test_list_elem, "Test")
-        test_elem.text = test_name
+        xmlet.SubElement(test_list_elem, "Test").text = test_name
 
     for test_name in sorted(results):
         test_path, test_status = results[test_name]
-        test_passed = test_status == TEST_PASS_STATUS
+        test_passed = test_status in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS]
         test_norm_path = test_path if os.path.isdir(test_path) else os.path.dirname(test_path)
 
         full_test_elem = xmlet.SubElement(testing_elem, "Test")
-        if (test_passed):
+        if test_passed:
             full_test_elem.attrib["Status"] = "passed"
-        elif (test_status == NAMELIST_FAIL_STATUS):
+        elif (test_status == TEST_PEND_STATUS):
             full_test_elem.attrib["Status"] = "notrun"
         else:
             full_test_elem.attrib["Status"] = "failed"
 
-        name_elem = xmlet.SubElement(full_test_elem, "Name")
-        name_elem.text = test_name
+        xmlet.SubElement(full_test_elem, "Name").text = test_name
 
-        path_elem = xmlet.SubElement(full_test_elem, "Path")
-        path_elem.text = test_norm_path
+        xmlet.SubElement(full_test_elem, "Path").text = test_norm_path
 
-        full_name_elem = xmlet.SubElement(full_test_elem, "FullName")
-        full_name_elem.text = test_name
+        xmlet.SubElement(full_test_elem, "FullName").text = test_name
 
         xmlet.SubElement(full_test_elem, "FullCommandLine")
         # text ?
@@ -132,23 +169,42 @@ def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time
             named_measurement_elem.attrib["type"] = type_attr
             named_measurement_elem.attrib["name"] = name_attr
 
-            value_elem = xmlet.SubElement(named_measurement_elem, "Value")
-            value_elem.text = value
+            xmlet.SubElement(named_measurement_elem, "Value").text = value
 
         measurement_elem = xmlet.SubElement(results_elem, "Measurement")
 
         value_elem = xmlet.SubElement(measurement_elem, "Value")
         value_elem.text = ''.join([item for item in get_test_output(test_norm_path) if ord(item) < 128])
 
-    elapsed_time_elem = xmlet.SubElement(testing_elem, "ElapsedMinutes")
-    elapsed_time_elem.text = "0" # Skip for now
+    xmlet.SubElement(testing_elem, "ElapsedMinutes").text = "0" # Skip for now
 
     etree = xmlet.ElementTree(site_elem)
 
     etree.write(os.path.join(data_rel_path, "Test.xml"))
 
 ###############################################################################
-def create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_time, hostname, force_log_upload):
+def create_cdash_xml_fakes(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname):
+###############################################################################
+    # We assume all cases were created from the same code repo
+    first_result_case = os.path.dirname(list(results.items())[0][1][0])
+    try:
+        srcroot = run_cmd_no_fail("./xmlquery --value CIMEROOT", from_dir=first_result_case)
+    except:
+        # Use repo containing this script as last resort
+        srcroot = CIME.utils.get_cime_root()
+
+    git_commit = CIME.utils.get_current_commit(repo=srcroot)
+
+    data_rel_path = os.path.join("Testing", utc_time)
+
+    create_cdash_config_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname, data_rel_path, git_commit)
+
+    create_cdash_build_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname, data_rel_path, git_commit)
+
+    create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname, data_rel_path, git_commit)
+
+###############################################################################
+def create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_time, hostname):
 ###############################################################################
 
     data_rel_path = os.path.join("Testing", utc_time)
@@ -276,7 +332,7 @@ NightlyStartTime: {5} UTC
     with open("Testing/TAG", "w") as tag_fd:
         tag_fd.write("{}\n{}\n".format(utc_time, cdash_build_group))
 
-    create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname)
+    create_cdash_xml_fakes(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname)
 
     create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_time, hostname, force_log_upload)
 
@@ -291,32 +347,48 @@ def wait_for_test(test_path, results, wait, check_throughput, check_memory, igno
         test_status_filepath = test_path
 
     logging.debug("Watching file: '{}'".format(test_status_filepath))
+    test_log_path = os.path.join(os.path.dirname(test_status_filepath), ".internal_test_status.log")
 
-    while (True):
-        if (os.path.exists(test_status_filepath)):
-            ts = TestStatus(test_dir=os.path.dirname(test_status_filepath))
-            test_name = ts.get_name()
-            test_status = ts.get_overall_test_status(wait_for_run=not no_run, # Important
-                                                     no_run=no_run,
-                                                     check_throughput=check_throughput,
-                                                     check_memory=check_memory, ignore_namelists=ignore_namelists,
-                                                     ignore_memleak=ignore_memleak)
+    # We don't want to make it a requirement that wait_for_tests has write access
+    # to all case directories
+    try:
+        fd = open(test_log_path, "w")
+        fd.close()
+    except:
+        test_log_path = "/dev/null"
 
-            if (test_status == TEST_PEND_STATUS and (wait and not SIGNAL_RECEIVED)):
-                time.sleep(SLEEP_INTERVAL_SEC)
-                logging.debug("Waiting for test to finish")
+    prior_ts = None
+    with open(test_log_path, "w") as log_fd:
+        while (True):
+            if (os.path.exists(test_status_filepath)):
+                ts = TestStatus(test_dir=os.path.dirname(test_status_filepath))
+                test_name = ts.get_name()
+                test_status = ts.get_overall_test_status(wait_for_run=True, # Important
+                                                         check_throughput=check_throughput,
+                                                         check_memory=check_memory, ignore_namelists=ignore_namelists,
+                                                         ignore_memleak=ignore_memleak)
+
+                if prior_ts is not None and prior_ts != ts:
+                    log_fd.write(ts.phase_statuses_dump())
+                    log_fd.write("OVERALL: {}\n\n".format(test_status))
+
+                prior_ts = ts
+
+                if (test_status == TEST_PEND_STATUS and (wait and not SIGNAL_RECEIVED)):
+                    time.sleep(SLEEP_INTERVAL_SEC)
+                    logging.debug("Waiting for test to finish")
+                else:
+                    results.put( (test_name, test_path, test_status) )
+                    break
+
             else:
-                results.put( (test_name, test_path, test_status) )
-                break
-
-        else:
-            if (wait and not SIGNAL_RECEIVED):
-                logging.debug("File '{}' does not yet exist".format(test_status_filepath))
-                time.sleep(SLEEP_INTERVAL_SEC)
-            else:
-                test_name = os.path.abspath(test_status_filepath).split("/")[-2]
-                results.put( (test_name, test_path, "File '{}' doesn't exist".format(test_status_filepath)) )
-                break
+                if (wait and not SIGNAL_RECEIVED):
+                    logging.debug("File '{}' does not yet exist".format(test_status_filepath))
+                    time.sleep(SLEEP_INTERVAL_SEC)
+                else:
+                    test_name = os.path.abspath(test_status_filepath).split("/")[-2]
+                    results.put( (test_name, test_path, "File '{}' doesn't exist".format(test_status_filepath)) )
+                    break
 
 ###############################################################################
 def wait_for_tests_impl(test_paths, no_wait=False, check_throughput=False, check_memory=False, ignore_namelists=False, ignore_memleak=False, no_run=False):

--- a/cime/scripts/lib/get_tests.py
+++ b/cime/scripts/lib/get_tests.py
@@ -51,6 +51,9 @@ _CIME_TESTS = {
                     "TESTMEMLEAKPASS_P1.f09_g16.X")
                    ),
 
+    "cime_test_all" : ("cime_test_only", "0:10:00",
+                       ("TESTRUNDIFF_P1.f19_g16_rx1.A", )),
+
     "cime_developer" : (None, "0:15:00",
                             ("NCK_Ld3.f45_g37_rx1.A",
                              "ERI.f09_g16.X",

--- a/cime/scripts/lib/jenkins_generic_job.py
+++ b/cime/scripts/lib/jenkins_generic_job.py
@@ -28,7 +28,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
                         arg_test_suite,
                         cdash_build_group, baseline_compare,
                         scratch_root, parallel_jobs, walltime,
-                        machine, compiler, real_baseline_name):
+                        machine, compiler, real_baseline_name, baseline_root):
 ###############################################################################
     """
     Return True if all tests passed
@@ -102,6 +102,9 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
 
     if walltime is not None:
         create_test_args.append(" --walltime " + walltime)
+
+    if baseline_root is not None:
+        create_test_args.append(" --baseline-root " + baseline_root)
 
     create_test_cmd = "./create_test " + " ".join(create_test_args)
 

--- a/cime/src/build_scripts/buildlib.pio
+++ b/cime/src/build_scripts/buildlib.pio
@@ -44,7 +44,22 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def buildlib(bldroot, installpath, caseroot):
 ###############################################################################
     with Case(caseroot, read_only=False) as case:
+        cime_model = case.get_value("MODEL")
         pio_version = case.get_value("PIO_VERSION")
+        if cime_model == "e3sm":
+            srcroot = case.get_value("SRCROOT")
+            scorpio_src_root_dir = os.path.join(srcroot, "externals")
+            # Scorpio classic is derived from PIO1
+            scorpio_classic_dir = "scorpio_classic"
+            # Scorpio is derived from PIO2
+            scorpio_dir = "scorpio"
+            scorpio_classic_src_dir = os.path.join(scorpio_src_root_dir,
+                                        scorpio_classic_dir)
+            scorpio_src_dir = os.path.join(scorpio_src_root_dir, scorpio_dir)
+            if (not os.path.isdir(scorpio_src_root_dir) or
+                not os.path.isdir(scorpio_classic_src_dir) or
+                not os.path.isdir(scorpio_src_dir)):
+                scorpio_src_root_dir = None
         mpilib = case.get_value("MPILIB")
         exeroot = case.get_value("EXEROOT")
         pio_model = "pio{}".format(pio_version)
@@ -55,13 +70,32 @@ def buildlib(bldroot, installpath, caseroot):
             os.makedirs(pio_dir)
         casetools = case.get_value("CASETOOLS")
         cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/genf90 \""
-        gmake_opts = "{}/Makefile -C {} CASEROOT={} MODEL={} USER_CMAKE_OPTS={} "\
-            "PIO_LIBDIR={} CASETOOLS={} PIO_VERSION={} MPILIB={} "\
-            "SHAREDLIBROOT={} EXEROOT={} COMPILER={} BUILD_THREADED={} "\
-            "USER_CPPDEFS=-DTIMING -f {}/Makefile"\
-            .format(pio_dir,pio_dir,caseroot,pio_model, cmake_opts, pio_dir, casetools,
-              pio_version, mpilib, bldroot, exeroot, compiler, build_threaded,
-              casetools)
+        gmake_vars =  "CASEROOT={caseroot} MODEL={pio_model} "\
+                      "USER_CMAKE_OPTS={cmake_opts} "\
+                      "PIO_LIBDIR={pio_dir} CASETOOLS={casetools} "\
+                      "PIO_VERSION={pio_version} MPILIB={mpilib} "\
+                      "SHAREDLIBROOT={sharedlibroot} EXEROOT={exeroot} "\
+                      "COMPILER={compiler} BUILD_THREADED={build_threaded} "\
+                      "USER_CPPDEFS=-DTIMING"\
+                      .format(caseroot=caseroot, pio_model=pio_model,
+                              cmake_opts=cmake_opts, pio_dir=pio_dir,
+                              casetools=casetools,
+                              pio_version=pio_version, mpilib=mpilib,
+                              sharedlibroot=bldroot, exeroot=exeroot,
+                              compiler=compiler, build_threaded=build_threaded)
+
+        if scorpio_src_root_dir is not None:
+            gmake_vars += " IO_LIB_SRCROOT={scorpio_src_root_dir} "\
+                          " IO_LIB_v1_SRCDIR={scorpio_classic_dir} "\
+                          " IO_LIB_v2_SRCDIR={scorpio_dir} "\
+                          .format(scorpio_src_root_dir=scorpio_src_root_dir,
+                                  scorpio_classic_dir=scorpio_classic_dir,
+                                  scorpio_dir=scorpio_dir)
+
+        gmake_opts =  "{pio_dir}/Makefile -C {pio_dir} "\
+                      " {gmake_vars} -f {casetools}/Makefile"\
+                      .format(pio_dir=pio_dir, gmake_vars=gmake_vars,
+                              casetools=casetools)
 
         gmake_cmd = case.get_value("GMAKE")
 

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -162,11 +162,14 @@
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_1850_2012_c130411.nc</value>
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_1850_2012_c130411.nc</value>
       <value compset="1850_" grid=".+"								>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_pi_c101029.nc</value>
+      <value compset="1850S_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_1850_clim_c20190125.nc</value>
       <value compset="1850_" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
       <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
+      <value compset="2010_" grid="a%ne30np4.*_oi%oEC60to30v3"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_2010_clim_c20190415.nc</value>
+      <value compset="2010_" grid="a%ne120np4.*_oi%oRRS18to6v3"	>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_HighResMIP_E3SM_0.25x0.25_2010_clim_c20190125_intoisst.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>
@@ -204,6 +207,7 @@
       <value compset="1850" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"				>$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
       <value compset="1850" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
       <value compset="1850" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
+      <value compset="2010_" grid="a%ne120np4.*_oi%oRRS18to6v3"	>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.0.25x0.25.c20190221.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"                                         >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF"                                         >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7"                  >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.4x5_gx3v7_100120.nc</value>

--- a/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <namelist_defaults>
 
+<!-- Set default atmospheric IC file -->
+<ncdata>atm/cam/inic/homme/20180129.DECKv1b_piControl.ne30_oEC.edison.cam.i.0501-01-01-00000_c20190202.nc</ncdata>
+
 <!-- Set default output options for CMIP6 simulations -->
 <cosp_lite>.true.</cosp_lite>
 
@@ -90,15 +93,13 @@
 <prc_exp                 > 3.19D0    </prc_exp>
 <prc_exp1                > -1.2D0    </prc_exp1>
 <se_ftype                > 2         </se_ftype>
-<clubb_C14               > 1.17D0     </clubb_C14>
+<clubb_C14               > 1.06D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>
 <rrtmg_temp_fix          > .true.    </rrtmg_temp_fix>
 
 <!-- Energy fixer options -->
-<l_ieflx_fix> .true.</l_ieflx_fix>
-<ieflx_opt  > 2     </ieflx_opt>
-
+<ieflx_opt  > 0     </ieflx_opt>
 
 <!-- 1850 ozone data is from Jean-Francois Lamarque -->
 <!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->
@@ -111,33 +112,33 @@
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type         >CYCLICAL</ext_frc_type>
 <ext_frc_cycle_yr     >1850</ext_frc_cycle_yr>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c180205.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c170525.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c170525.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c170525.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c170525.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c170525.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c170525.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c170525.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c170525.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c170525.nc </so4_a2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type        >CYCLICAL</srf_emis_type>
 <srf_emis_cycle_yr    >1850</srf_emis_cycle_yr>
 <dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file>
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc </so4_a2_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c170525.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c170525.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c170525.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c170525.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c170525.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c170525.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c170525.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c170525.nc </so4_a2_emis_file>
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
 <tracer_cnst_cycle_yr>1849</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20171110.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
 
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
@@ -5,7 +5,7 @@
 <cosp_lite>.true.</cosp_lite>
 
 <!-- Solar constant from CMIP6 input4MIPS -->
-<solar_data_file>atm/cam/solar/Solar_1850control_input4MIPS_c20171101.nc</solar_data_file>
+<solar_data_file>atm/cam/solar/Solar_1850control_input4MIPS_c20181106.nc</solar_data_file>
 <solar_data_ymd>18500101</solar_data_ymd>
 <solar_data_type>FIXED</solar_data_type>
 
@@ -111,33 +111,33 @@
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type         >CYCLICAL</ext_frc_type>
 <ext_frc_cycle_yr     >1850</ext_frc_cycle_yr>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c170525.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c170525.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c170525.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c170525.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c170525.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c170525.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c170525.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c170525.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c170525.nc </so4_a2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c180205.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type        >CYCLICAL</srf_emis_type>
 <srf_emis_cycle_yr    >1850</srf_emis_cycle_yr>
 <dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c170525.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c170525.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c170525.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c170525.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c170525.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c170525.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c170525.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c170525.nc </so4_a2_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file>
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc </so4_a2_emis_file>
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
 <tracer_cnst_cycle_yr>1849</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20171110.nc</tracer_cnst_file>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
 
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-HR.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Atmosphere initial condition -->
+<ncdata>atm/cam/inic/homme/cori-knl.20190214_maint-1.0.F2010-CMIP6-HR.noCNT.ARE.nudgeUV.ne120_oRRS18v3.cam.i.2011-01-01-00000.nc</ncdata>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_2010control_input4MIPS_c20181017.nc</solar_data_file>
+<solar_data_ymd>20100101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 2010 GHG values from CMIP6 input4MIPS -->
+<!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in cime/src/drivers/mct/cime_config/config_component_acme.xml -->
+<ch4vmr>1807.851e-9</ch4vmr>
+<n2ovmr>323.141e-9</n2ovmr>
+<f11vmr>768.7644e-12</f11vmr>
+<f12vmr>531.2820e-12</f12vmr>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
+<prescribed_volcaero_file    >CMIP_DOE-ACME_radiation_average_1850-2014_v3_c20171204.nc</prescribed_volcaero_file    >
+<prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
+<prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
+<prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc    >.false.</use_hetfrz_classnuc>
+<use_preexisting_ice    >.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep      >.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning            >.true.</sscav_tuning>
+<convproc_do_aer         >.true.</convproc_do_aer>
+<convproc_do_gas         >.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc          >.true.</demott_ice_nuc>
+<liqcf_fix               >.true.</liqcf_fix>
+<regen_fix               >.true.</regen_fix>
+<resus_fix               >.true.</resus_fix>
+<mam_amicphys_optaa      >1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning    >.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg       >.true.</history_amwg>
+<history_aerosol    >.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<clubb_ice_deep>     12.e-6 </clubb_ice_deep>
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
+<clubb_liq_sh>       10.e-6 </clubb_liq_sh>
+<clubb_C2rt>         1.75D0 </clubb_C2rt>
+<effgw_oro>          0.25    </effgw_oro>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<dust_emis_fact>     2.5D0 </dust_emis_fact>
+<clubb_gamma_coef>   0.32   </clubb_gamma_coef>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<clubb_c_K10>        0.3    </clubb_c_K10>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<so4_sz_thresh_icenuc>0.05e-6</so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add       >0.8D0</zmconv_tiedke_add>
+<zmconv_cape_cin         >1</zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   >2</zmconv_mx_bot_lyr_adj>
+<taubgnd                 >2.5D-3 </taubgnd>
+<clubb_C1                >1.5</clubb_C1>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<se_ftype                >2</se_ftype>
+<relvar_fix              >.true.</relvar_fix>
+<mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+
+<!-- Parameters further tuned for ne120 L72 configuration based on AV1C-04P2 -->
+
+<zmconv_alfa         >0.2D0</zmconv_alfa>
+<zmconv_c0_lnd       >0.0035D0</zmconv_c0_lnd>
+<zmconv_c0_ocn       >0.0043D0</zmconv_c0_ocn>
+<zmconv_dmpdz        >-0.2e-3</zmconv_dmpdz>
+<zmconv_ke           >6.0E-6</zmconv_ke>
+<cldfrc_dp1          >0.039D0</cldfrc_dp1>
+<clubb_C8            >4.73D0</clubb_C8>
+<clubb_C14           >1.75D0</clubb_C14>
+<se_nsplit           >6</se_nsplit>
+<rsplit              >2</rsplit>
+<qsplit              >1</qsplit>
+<cld_macmic_num_steps>3</cld_macmic_num_steps>
+
+<!-- Energy fixer options -->
+<ieflx_opt  > 0     </ieflx_opt>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<ext_frc_type         >CYCLICAL</ext_frc_type>
+<ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_elev_2010-2014_c190326.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_soag_elev_2010-2014_c190326.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_elev_2010-2014_c190326.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_elev_2010-2014_c190326.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_elev_2010-2014_c190326.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_elev_2010-2014_c190326.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_elev_2010-2014_c190326.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_elev_2010-2014_c190326.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_elev_2010-2014_c190326.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type        >CYCLICAL</srf_emis_type>
+<srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_surf_2010-2014_c190326.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_surf_2010-2014_c190326.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_surf_2010-2014_c190326.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_surf_2010-2014_c190326.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_surf_2010-2014_c190326.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_surf_2010-2014_c190326.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_surf_2010-2014_c190326.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_surf_2010-2014_c190326.nc </so4_a2_emis_file>
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
+<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>2015</sim_year>
+
+<!-- land datasets -->
+<!-- Set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->
+
+
+</namelist_defaults>

--- a/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-LR.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010_cam5_CMIP6-LR.xml
@@ -4,17 +4,20 @@
 <!-- Set default output options for CMIP6 simulations -->
 <cosp_lite>.true.</cosp_lite>
 
+<!-- Atmosphere initial condition -->
+<ncdata>atm/cam/inic/homme/20180716.DECKv1b_A3.ne30_oEC.edison.cam.i.2010-01-01-00000.nc</ncdata>
+
 <!-- Solar constant from CMIP6 input4MIPS -->
-<solar_data_file>atm/cam/solar/Solar_1850control_input4MIPS_c20171101.nc</solar_data_file>
-<solar_data_ymd>18500101</solar_data_ymd>
+<solar_data_file>atm/cam/solar/Solar_2010control_input4MIPS_c20181017.nc</solar_data_file>
+<solar_data_ymd>20100101</solar_data_ymd>
 <solar_data_type>FIXED</solar_data_type>
 
-<!-- 1850 GHG values from CMIP6 input4MIPS -->
-<!-- <co2vmr>284.317e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in config_compset.xml -->
-<ch4vmr>808.249e-9</ch4vmr>
-<n2ovmr>273.0211e-9</n2ovmr>
-<f11vmr>32.1102e-12</f11vmr>
-<f12vmr>0.0</f12vmr>
+<!-- 2010 GHG values from CMIP6 input4MIPS -->
+<!-- <co2vmr>312.821e-6</co2vmr> The CMIP6 concentration set by CCSM_CO2_PPMV in cime/src/drivers/mct/cime_config/config_component_acme.xml -->
+<ch4vmr>1807.851e-9</ch4vmr>
+<n2ovmr>323.141e-9</n2ovmr>
+<f11vmr>768.7644e-12</f11vmr>
+<f12vmr>531.2820e-12</f12vmr>
 
 <!-- Stratospheric aerosols from CMIP6 input4MIPS -->
 <prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
@@ -90,56 +93,45 @@
 <prc_exp                 > 3.19D0    </prc_exp>
 <prc_exp1                > -1.2D0    </prc_exp1>
 <se_ftype                > 2         </se_ftype>
-<clubb_C14               > 1.17D0     </clubb_C14>
+<clubb_C14               > 1.06D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>
 <rrtmg_temp_fix          > .true.    </rrtmg_temp_fix>
 
 <!-- Energy fixer options -->
-<l_ieflx_fix> .true.</l_ieflx_fix>
-<ieflx_opt  > 2     </ieflx_opt>
-
-
-<!-- 1850 ozone data is from Jean-Francois Lamarque -->
-<!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->
-<prescribed_ozone_datapath>atm/cam/ozone</prescribed_ozone_datapath>
-<prescribed_ozone_file    >ozone_1.9x2.5_L26_1850clim_c090420.nc</prescribed_ozone_file>
-<prescribed_ozone_name    >O3</prescribed_ozone_name>
-<prescribed_ozone_type    >CYCLICAL</prescribed_ozone_type>
-<prescribed_ozone_cycle_yr>1850</prescribed_ozone_cycle_yr>
+<ieflx_opt  > 0     </ieflx_opt>
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type         >CYCLICAL</ext_frc_type>
-<ext_frc_cycle_yr     >1850</ext_frc_cycle_yr>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c180205.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
+<ext_frc_cycle_yr     >2010</ext_frc_cycle_yr>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c170525.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c170525.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c170525.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c170525.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c170525.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c170525.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c170525.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c170525.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c170525.nc </so4_a2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type        >CYCLICAL</srf_emis_type>
-<srf_emis_cycle_yr    >1850</srf_emis_cycle_yr>
-<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file>
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc </so4_a2_emis_file>
+<srf_emis_cycle_yr    >2010</srf_emis_cycle_yr>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c170525.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c170525.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c170525.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c170525.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c170525.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c170525.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c170525.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c170525.nc </so4_a2_emis_file>
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
-<tracer_cnst_cycle_yr>1849</tracer_cnst_cycle_yr>
+<tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr>
 <tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
-
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
 
 <!-- Marine organic aerosol namelist settings -->
@@ -154,15 +146,15 @@
 
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
-<chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
+<chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
-<linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
+<linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
 <linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
 <!-- sim_year used for CLM datasets and SSTs forcings -->
-<sim_year>1850</sim_year>
+<sim_year>2015</sim_year>
 
 <!-- land datasets -->
 <!-- Set in components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml -->

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
@@ -5,11 +5,11 @@
 <cosp_lite>.true.</cosp_lite>
 
 <!-- Solar constant from CMIP6 input4MIPS -->
-<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20171207.nc</solar_data_file>
+<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20181106.nc</solar_data_file>
 <solar_data_type>SERIAL</solar_data_type>
 
 <!-- GHG values from CMIP6 input4MIPS -->
-<bndtvghg>atm/cam/ggas/GHG_CMIP-1-2-0_Annual_Global_0000-2014_c20180105.nc</bndtvghg>
+<bndtvghg>atm/cam/ggas/GHG_CMIP-1-2-0_Annual_Global_0000-2014_c20181106.nc</bndtvghg>
 <scenario_ghg>RAMPED</scenario_ghg>
 
 <!-- Stratospheric aerosols from CMIP6 input4MIPS -->
@@ -98,31 +98,31 @@
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c170525.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c170525.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c170525.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c170525.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c170525.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c170525.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c170525.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c170525.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c170525.nc </so4_a2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205.nc </so2_ext_file>
+<soag_ext_file        >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c180205.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
 <dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c170525.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c170525.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c170525.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c170525.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c170525.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c170525.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c170525.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c170525.nc </so4_a2_emis_file>
+<so2_emis_file        >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file>
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc </so4_a2_emis_file>
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>
-<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20171110.nc</tracer_cnst_file>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
 
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6_bgc.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6_bgc.xml
@@ -5,11 +5,11 @@
 <cosp_lite>.true.</cosp_lite>
 
 <!-- Solar constant from CMIP6 input4MIPS -->
-<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20171207.nc</solar_data_file>
+<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20181106.nc</solar_data_file>
 <solar_data_type>SERIAL</solar_data_type>
 
 <!-- GHG values from CMIP6 input4MIPS -->
-<bndtvghg>atm/cam/ggas/GHG_CMIP-1-2-0_Annual_Global_0000-2014_c20180105.nc</bndtvghg>
+<bndtvghg>atm/cam/ggas/GHG_CMIP-1-2-0_Annual_Global_0000-2014_c20181106.nc</bndtvghg>
 <scenario_ghg>RAMPED</scenario_ghg>
 
 <!-- Stratospheric aerosols from CMIP6 input4MIPS -->
@@ -98,31 +98,31 @@
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c170525.nc </so2_ext_file>
-<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c170525.nc </soag_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c170525.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c170525.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c170525.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c170525.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c170525.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c170525.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c170525.nc </so4_a2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c180205.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
 <dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c170525.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c170525.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c170525.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c170525.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c170525.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c170525.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c170525.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c170525.nc </so4_a2_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file>
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc </so4_a2_emis_file>
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>
-<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20171110.nc</tracer_cnst_file>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
 
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->

--- a/components/cam/bld/namelist_files/use_cases/SSP585_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/SSP585_cam5_CMIP6.xml
@@ -5,7 +5,7 @@
 <cosp_lite>.true.</cosp_lite>
 
 <!-- Solar constant from CMIP6 input4MIPS -->
-<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20171207.nc</solar_data_file>
+<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20181106.nc</solar_data_file>
 <solar_data_type>SERIAL</solar_data_type>
 
 <!-- GHG values from CMIP6 input4MIPS -->
@@ -98,6 +98,7 @@
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
+<<<<<<< HEAD
 <so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so2_elev_2015-2100_c181228.nc </so2_ext_file>
 <soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_soag_elev_2015-2100_c181228.nc </soag_ext_file>
 <bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_bc_a4_elev_2015-2100_c181228.nc </bc_a4_ext_file>
@@ -107,10 +108,22 @@
 <pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_pom_a4_elev_2015-2100_c181228.nc </pom_a4_ext_file>
 <so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a1_elev_2015-2100_c181228.nc </so4_a1_ext_file>
 <so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a2_elev_2015-2100_c181228.nc </so4_a2_ext_file>
+=======
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so2_elev_2015-2100_c190828.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_soag_elev_2015-2100_c190828.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_bc_a4_elev_2015-2100_c190828.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a1_elev_2015-2100_c190828.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a2_elev_2015-2100_c190828.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a4_elev_2015-2100_c190828.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_pom_a4_elev_2015-2100_c190828.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a1_elev_2015-2100_c190828.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a2_elev_2015-2100_c190828.nc </so4_a2_ext_file>
+>>>>>>> maint-1.0
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
 <dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<<<<<<< HEAD
 <so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so2_surf_2015-2100_c181228.nc </so2_emis_file>
 <bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_bc_a4_surf_2015-2100_c181228.nc </bc_a4_emis_file>
 <mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a1_surf_2015-2100_c181228.nc </mam7_num_a1_emis_file> 
@@ -119,6 +132,16 @@
 <pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_pom_a4_surf_2015-2100_c181228.nc </pom_a4_emis_file>
 <so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a1_surf_2015-2100_c181228.nc </so4_a1_emis_file>
 <so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a2_surf_2015-2100_c181228.nc </so4_a2_emis_file>
+=======
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so2_surf_2015-2100_c190828.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_bc_a4_surf_2015-2100_c190828.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a1_surf_2015-2100_c190828.nc </mam7_num_a1_emis_file>
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a2_surf_2015-2100_c190828.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_num_a4_surf_2015-2100_c190828.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_pom_a4_surf_2015-2100_c190828.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a1_surf_2015-2100_c190828.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP585_ne30/cmip6_ssp585_mam4_so4_a2_surf_2015-2100_c190828.nc </so4_a2_emis_file>
+>>>>>>> maint-1.0
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>

--- a/components/cam/bld/namelist_files/use_cases/scam_arm97.xml
+++ b/components/cam/bld/namelist_files/use_cases/scam_arm97.xml
@@ -3,7 +3,7 @@
 
 <namelist_defaults>
 
-<ncdata             hgrid="64x128"                scam="1"  >atm/cam/inic/gaus/cami_0000-09-01_64x128_L72_c031210.nc</ncdata>
+<ncdata             hgrid="64x128"                scam="1"  >atm/cam/inic/gaus/cami_0000-09-01_64x128_L72_c181106.nc</ncdata>
 <iopfile dyn="eul"                                scam="1"  >atm/cam/scam/iop/ARM97_iopfile_4scam.nc</iopfile>
 <soag_ext_file >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_2000_c160427.nc</soag_ext_file>
 <scmlat                                           scam="1"  >   36.6     </scmlat>

--- a/components/cam/bld/namelist_files/use_cases/scam_generic.xml
+++ b/components/cam/bld/namelist_files/use_cases/scam_generic.xml
@@ -3,7 +3,7 @@
 
 <namelist_defaults>
 
-<ncdata             hgrid="64x128"    nlev="72"   scam="1"  >atm/cam/inic/gaus/cami_0000-09-01_64x128_L72_c031210.nc</ncdata>
+<ncdata             hgrid="64x128"    nlev="72"   scam="1"  >atm/cam/inic/gaus/cami_0000-09-01_64x128_L72_c181106.nc</ncdata>
 <soag_ext_file      >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_2000_c160427.nc</soag_ext_file>
 
 </namelist_defaults>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -60,6 +60,8 @@
       <value compset="_CAM5%CMIP6-HR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6-LR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6-LRtunedHR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
+      <value compset="1950_CAM5%CMIP6-[LH]R"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -cppdefs -DAPPLY_POST_DECK_BUGFIXES -nlev 72</value>
+      <value compset="2010_CAM5%CMIP6-[LH]R"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -cppdefs -DAPPLY_POST_DECK_BUGFIXES -nlev 72</value>
       <value compset="_CAM5%AV1F"     >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1F-00"  >-clubb_sgs -microphys mg2 -chem trop_mam4_resus      -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1F-01"  >-clubb_sgs -microphys mg2 -chem trop_mam4_resus_soag -rain_evap_to_coarse_aero -nlev 72</value>
@@ -171,6 +173,7 @@
       <value compset="1850_CAM5.*AV1C-H01B">1850_cam5_av1c-h01b</value>
       <value compset="1850_CAM5.*AV1C-H01C">1850_cam5_av1c-h01c</value>
       <value compset="1850_CAM5.*CMIP6"  >1850_cam5_CMIP6</value>
+      <value compset="1850S_CAM5.*CMIP6"  >1850S_cam5_CMIP6</value>
       <value compset="1950_CAM5.*CMIP6-LR"  >1950_cam5_CMIP6-LR</value>
       <value compset="1950_CAM5.*CMIP6-HR"  >1950_cam5_CMIP6-HR</value>
       <value compset="1950_CAM5.*CMIP6-LRtunedHR"  >1950_cam5_CMIP6-LRtunedHR</value>
@@ -202,6 +205,8 @@
       <value compset="20TR_CAM5.*CMIP6.*_BGC%B"  >20TR_cam5_CMIP6_bgc</value>
       <value compset="SSP585_CAM5.*CMIP6">SSP585_cam5_CMIP6</value>
       <value compset="SSP585_CAM5.*CMIP6.*_BGC%B">SSP585_cam5_CMIP6_bgc</value>
+      <value compset="2010_CAM5.*CMIP6-LR"  >2010_cam5_CMIP6-LR</value>
+      <value compset="2010_CAM5.*CMIP6-HR"  >2010_cam5_CMIP6-HR</value>
       <value compset="2000_CAM5%COSP"   >2000_cam5_cosp</value>
       <value compset="2000_CAM4%WCMX"   >waccmx_2000_cam4</value>
       <value compset="1996_CAM4%WCMX"   >waccmx_1996_cam4</value>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -82,6 +82,11 @@
   </compset>
 
   <compset>
+    <alias>F1850SC5-CMIP6</alias>
+    <lname>1850S_CAM5%CMIP6_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>FC5AV1C-01</alias>
     <lname>2000_CAM5%AV1C-01_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
@@ -189,6 +194,16 @@
   <compset>
     <alias>F20TRC5-CMIP6</alias>
     <lname>20TR_CAM5%CMIP6_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F2010C5-CMIP6-LR</alias>
+    <lname>2010_CAM5%CMIP6-LR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>F2010C5-CMIP6-HR</alias>
+    <lname>2010_CAM5%CMIP6-HR_CLM45%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/components/cam/src/chemistry/mozart/mo_drydep.F90
+++ b/components/cam/src/chemistry/mozart/mo_drydep.F90
@@ -2098,7 +2098,7 @@ contains
        if (use_camiop) then
           call getfil (ncdata, ncdata_loc)
           call cam_pio_openfile (piofile, trim(ncdata_loc), PIO_NOWRITE)
-          call shr_scam_getCloseLatLon(piofile%fh,scmlat,scmlon,closelat,closelon,latidx,lonidx)
+          call shr_scam_getCloseLatLon(piofile,scmlat,scmlon,closelat,closelon,latidx,lonidx)
           call pio_closefile ( piofile)
           ploniop=size(loniop)
           platiop=size(latiop)

--- a/components/cam/src/control/ncdio_atm.F90
+++ b/components/cam/src/control/ncdio_atm.F90
@@ -393,7 +393,7 @@ contains
           strt(1) = dim1b
           strt(2) = dim2b
           cnt = arraydimsize
-          call shr_scam_getCloseLatLon(ncid%fh,scmlat,scmlon,closelat,closelon,latidx,lonidx)
+          call shr_scam_getCloseLatLon(ncid,scmlat,scmlon,closelat,closelon,latidx,lonidx)
           if (trim(field_dnames(1)) == 'lon') then
             strt(1) = lonidx ! First dim always lon for Eulerian dycore
           else
@@ -807,7 +807,7 @@ contains
           strt(2) = dim2b
           strt(3) = dim3b
           cnt = arraydimsize
-          call shr_scam_getCloseLatLon(ncid%fh,scmlat,scmlon,closelat,closelon,latidx,lonidx)
+          call shr_scam_getCloseLatLon(ncid,scmlat,scmlon,closelat,closelon,latidx,lonidx)
           if (trim(field_dnames(1)) == 'lon') then
             strt(1) = lonidx ! First dim always lon for Eulerian dycore
           else

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -198,9 +198,17 @@ subroutine diag_init()
    call constituent_burden_init
 
    call addfld ('Z3',(/ 'lev' /), 'A','m','Geopotential Height (above sea level)')
-   call addfld ('Z1000',horiz_only,    'A','m','Geopotential Z at 700 mbar pressure surface')
+   call addfld ('Z1000',horiz_only,    'A','m','Geopotential Z at 1000 mbar pressure surface')
+   call addfld ('Z975',horiz_only,    'A','m','Geopotential Z at 975 mbar pressure surface')
+   call addfld ('Z950',horiz_only,    'A','m','Geopotential Z at 950 mbar pressure surface')
+   call addfld ('Z925',horiz_only,    'A','m','Geopotential Z at 925 mbar pressure surface')
+   call addfld ('Z900',horiz_only,    'A','m','Geopotential Z at 900 mbar pressure surface')
+   call addfld ('Z850',horiz_only,    'A','m','Geopotential Z at 850 mbar pressure surface')
+   call addfld ('Z800',horiz_only,    'A','m','Geopotential Z at 800 mbar pressure surface')
    call addfld ('Z700',horiz_only,    'A','m','Geopotential Z at 700 mbar pressure surface')
+   call addfld ('Z600',horiz_only,    'A','m','Geopotential Z at 600 mbar pressure surface')
    call addfld ('Z500',horiz_only,    'A','m','Geopotential Z at 500 mbar pressure surface')
+   call addfld ('Z400',horiz_only,    'A','m','Geopotential Z at 400 mbar pressure surface')
    call addfld ('Z300',horiz_only,    'A','m','Geopotential Z at 300 mbar pressure surface')
    call addfld ('Z200',horiz_only,    'A','m','Geopotential Z at 200 mbar pressure surface')
    call addfld ('Z100',horiz_only,    'A','m','Geopotential Z at 100 mbar pressure surface')
@@ -252,8 +260,37 @@ subroutine diag_init()
    call addfld ('OMEGA',(/ 'lev' /), 'A','Pa/s','Vertical velocity (pressure)')
    call addfld ('OMEGAT',(/ 'lev' /), 'A','K Pa/s  ','Vertical heat flux' )
    call addfld ('OMEGAU',(/ 'lev' /), 'A','m Pa/s2 ','Vertical flux of zonal momentum' )
+   call addfld ('OMEGA1000',horiz_only,    'A','Pa/s','Vertical velocity at 1000 mbar pressure surface')
+   call addfld ('OMEGA975',horiz_only,    'A','Pa/s','Vertical velocity at 975 mbar pressure surface')
+   call addfld ('OMEGA950',horiz_only,    'A','Pa/s','Vertical velocity at 950 mbar pressure surface')
+   call addfld ('OMEGA925',horiz_only,    'A','Pa/s','Vertical velocity at 925 mbar pressure surface')
+   call addfld ('OMEGA900',horiz_only,    'A','Pa/s','Vertical velocity at 900 mbar pressure surface')
    call addfld ('OMEGA850',horiz_only,    'A','Pa/s','Vertical velocity at 850 mbar pressure surface')
+   call addfld ('OMEGA800',horiz_only,    'A','Pa/s','Vertical velocity at 800 mbar pressure surface')
+   call addfld ('OMEGA700',horiz_only,    'A','Pa/s','Vertical velocity at 700 mbar pressure surface')
+   call addfld ('OMEGA600',horiz_only,    'A','Pa/s','Vertical velocity at 600 mbar pressure surface')
    call addfld ('OMEGA500',horiz_only,    'A','Pa/s','Vertical velocity at 500 mbar pressure surface')
+   call addfld ('OMEGA400',horiz_only,    'A','Pa/s','Vertical velocity at 400 mbar pressure surface')
+   call addfld ('OMEGA300',horiz_only,    'A','Pa/s','Vertical velocity at 300 mbar pressure surface')
+   call addfld ('OMEGA200',horiz_only,    'A','Pa/s','Vertical velocity at 200 mbar pressure surface')
+   call addfld ('OMEGA100',horiz_only,    'A','Pa/s','Vertical velocity at 100 mbar pressure surface')
+   call addfld ('OMEGABOT',horiz_only,    'A','Pa/s','Lowest model level vertical velocity')
+
+   call addfld ('RH1000',horiz_only,    'A','%','Relative humidity at 1000 mbar pressure surface')
+   call addfld ('RH975',horiz_only,    'A','%','Relative humidity at 975 mbar pressure surface')
+   call addfld ('RH950',horiz_only,    'A','%','Relative humidity at 950 mbar pressure surface')
+   call addfld ('RH925',horiz_only,    'A','%','Relative humidity at 925 mbar pressure surface')
+   call addfld ('RH900',horiz_only,    'A','%','Relative humidity at 900 mbar pressure surface')
+   call addfld ('RH850',horiz_only,    'A','%','Relative humidity at 850 mbar pressure surface')
+   call addfld ('RH800',horiz_only,    'A','%','Relative humidity at 800 mbar pressure surface')
+   call addfld ('RH700',horiz_only,    'A','%','Relative humidity at 700 mbar pressure surface')
+   call addfld ('RH600',horiz_only,    'A','%','Relative humidity at 600 mbar pressure surface')
+   call addfld ('RH500',horiz_only,    'A','%','Relative humidity at 500 mbar pressure surface')
+   call addfld ('RH400',horiz_only,    'A','%','Relative humidity at 400 mbar pressure surface')
+   call addfld ('RH300',horiz_only,    'A','%','Relative humidity at 300 mbar pressure surface')
+   call addfld ('RH200',horiz_only,    'A','%','Relative humidity at 200 mbar pressure surface')
+   call addfld ('RH100',horiz_only,    'A','%','Relative humidity at 100 mbar pressure surface')
+   call addfld ('RHBOT',horiz_only,    'A','%','Lowest model level relative humidity')
 
    call addfld ('MQ',(/ 'lev' /), 'A','kg/m2','Water vapor mass in layer')
    call addfld ('TMQ',horiz_only,    'A','kg/m2','Total (vertically integrated) precipitable water')
@@ -274,14 +311,39 @@ subroutine diag_init()
    call addfld ('T300',horiz_only,    'A','K','Temperature at 300 mbar pressure surface')
    call addfld ('T200',horiz_only,    'A','K','Temperature at 200 mbar pressure surface')
    call addfld ('Q850',horiz_only,    'A','kg/kg','Specific Humidity at 850 mbar pressure surface')
-   call addfld ('Q200',horiz_only,    'A','kg/kg','Specific Humidity at 700 mbar pressure surface')
+   call addfld ('Q500',horiz_only,    'A','kg/kg','Specific Humidity at 500 mbar pressure surface')
+   call addfld ('Q200',horiz_only,    'A','kg/kg','Specific Humidity at 200 mbar pressure surface')
+   call addfld ('U1000',horiz_only,    'A','m/s','Zonal wind at 1000 mbar pressure surface')
+   call addfld ('U975',horiz_only,    'A','m/s','Zonal wind at 975 mbar pressure surface')
+   call addfld ('U950',horiz_only,    'A','m/s','Zonal wind at 950 mbar pressure surface')
+   call addfld ('U925',horiz_only,    'A','m/s','Zonal wind at 925 mbar pressure surface')
+   call addfld ('U900',horiz_only,    'A','m/s','Zonal wind at 900 mbar pressure surface')
    call addfld ('U850',horiz_only,    'A','m/s','Zonal wind at 850 mbar pressure surface')
+   call addfld ('U800',horiz_only,    'A','m/s','Zonal wind at 800 mbar pressure surface')
+   call addfld ('U700',horiz_only,    'A','m/s','Zonal wind at 700 mbar pressure surface')
+   call addfld ('U600',horiz_only,    'A','m/s','Zonal wind at 600 mbar pressure surface')
+   call addfld ('U500',horiz_only,    'A','m/s','Zonal wind at 500 mbar pressure surface')
+   call addfld ('U400',horiz_only,    'A','m/s','Zonal wind at 400 mbar pressure surface')
+   call addfld ('U300',horiz_only,    'A','m/s','Zonal wind at 300 mbar pressure surface')
    call addfld ('U250',horiz_only,    'A','m/s','Zonal wind at 250 mbar pressure surface')
    call addfld ('U200',horiz_only,    'A','m/s','Zonal wind at 200 mbar pressure surface')
+   call addfld ('U100',horiz_only,    'A','m/s','Zonal wind at 100 mbar pressure surface')
    call addfld ('U010',horiz_only,    'A','m/s','Zonal wind at  10 mbar pressure surface')
+   call addfld ('V1000',horiz_only,    'A','m/s','Meridional wind at 1000 mbar pressure surface')
+   call addfld ('V975',horiz_only,    'A','m/s','Meridional wind at 975 mbar pressure surface')
+   call addfld ('V950',horiz_only,    'A','m/s','Meridional wind at 950 mbar pressure surface')
+   call addfld ('V925',horiz_only,    'A','m/s','Meridional wind at 925 mbar pressure surface')
+   call addfld ('V900',horiz_only,    'A','m/s','Meridional wind at 900 mbar pressure surface')
    call addfld ('V850',horiz_only,    'A','m/s','Meridional wind at 850 mbar pressure surface')
-   call addfld ('V200',horiz_only,    'A','m/s','Meridional wind at 200 mbar pressure surface')
+   call addfld ('V800',horiz_only,    'A','m/s','Meridional wind at 800 mbar pressure surface')
+   call addfld ('V700',horiz_only,    'A','m/s','Meridional wind at 700 mbar pressure surface')
+   call addfld ('V600',horiz_only,    'A','m/s','Meridional wind at 600 mbar pressure surface')
+   call addfld ('V500',horiz_only,    'A','m/s','Meridional wind at 500 mbar pressure surface')
+   call addfld ('V400',horiz_only,    'A','m/s','Meridional wind at 400 mbar pressure surface')
+   call addfld ('V300',horiz_only,    'A','m/s','Meridional wind at 300 mbar pressure surface')
    call addfld ('V250',horiz_only,    'A','m/s','Meridional wind at 250 mbar pressure surface')
+   call addfld ('V200',horiz_only,    'A','m/s','Meridional wind at 200 mbar pressure surface')
+   call addfld ('V100',horiz_only,    'A','m/s','Meridional wind at 100 mbar pressure surface')
 
    call addfld ('TT',(/ 'lev' /), 'A','K2','Eddy temperature variance' )
 
@@ -293,11 +355,27 @@ subroutine diag_init()
    call addfld ('ATMEINT',horiz_only, 'A','J/m2','Vertically integrated total atmospheric energy ')
 
    call addfld ('T1000',horiz_only,   'A','K','Temperature at 1000 mbar pressure surface')
+   call addfld ('T975',horiz_only,   'A','K','Temperature at 975 mbar pressure surface')   
+   call addfld ('T950',horiz_only,   'A','K','Temperature at 950 mbar pressure surface')   
    call addfld ('T925',horiz_only,   'A','K','Temperature at 925 mbar pressure surface')   
+   call addfld ('T900',horiz_only,   'A','K','Temperature at 900 mbar pressure surface')   
+   call addfld ('T800',horiz_only,   'A','K','Temperature at 800 mbar pressure surface')   
    call addfld ('T700',horiz_only,   'A','K','Temperature at 700 mbar pressure surface')
+   call addfld ('T600',horiz_only,   'A','K','Temperature at 600 mbar pressure surface')
+   call addfld ('T400',horiz_only,   'A','K','Temperature at 400 mbar pressure surface')
+   call addfld ('T100',horiz_only,   'A','K','Temperature at 100 mbar pressure surface')
    call addfld ('T010',horiz_only,   'A','K','Temperature at 10 mbar pressure surface')
    call addfld ('Q1000',horiz_only,   'A','kg/kg','Specific Humidity at 1000 mbar pressure surface')   
+   call addfld ('Q975',horiz_only,   'A','kg/kg','Specific Humidity at 975 mbar pressure surface')
+   call addfld ('Q950',horiz_only,   'A','kg/kg','Specific Humidity at 950 mbar pressure surface')
    call addfld ('Q925',horiz_only,   'A','kg/kg','Specific Humidity at 925 mbar pressure surface')
+   call addfld ('Q900',horiz_only,   'A','kg/kg','Specific Humidity at 900 mbar pressure surface')
+   call addfld ('Q800',horiz_only,   'A','kg/kg','Specific Humidity at 800 mbar pressure surface')
+   call addfld ('Q700',horiz_only,   'A','kg/kg','Specific Humidity at 700 mbar pressure surface')
+   call addfld ('Q600',horiz_only,   'A','kg/kg','Specific Humidity at 600 mbar pressure surface')
+   call addfld ('Q400',horiz_only,   'A','kg/kg','Specific Humidity at 400 mbar pressure surface')
+   call addfld ('Q300',horiz_only,   'A','kg/kg','Specific Humidity at 300 mbar pressure surface')
+   call addfld ('Q100',horiz_only,   'A','kg/kg','Specific Humidity at 100 mbar pressure surface')
 
    call addfld ('T7001000',horiz_only,   'A','K','Temperature difference 700 mb - 1000 mb')
    call addfld ('TH7001000',horiz_only,   'A','K','Theta difference 700 mb - 1000 mb')
@@ -925,13 +1003,45 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, z3, p_surf)
        call outfld('Z1000    ', p_surf, pcols, lchnk)
     end if
+    if (hist_fld_active('Z975')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 97500._r8, z3, p_surf)
+       call outfld('Z975    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z950')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 95000._r8, z3, p_surf)
+       call outfld('Z950    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z925')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, z3, p_surf)
+       call outfld('Z925    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z900')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 90000._r8, z3, p_surf)
+       call outfld('Z900    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z850')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, z3, p_surf)
+       call outfld('Z850    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z800')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 80000._r8, z3, p_surf)
+       call outfld('Z800    ', p_surf, pcols, lchnk)
+    end if
     if (hist_fld_active('Z700')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, z3, p_surf)
        call outfld('Z700    ', p_surf, pcols, lchnk)
     end if
+    if (hist_fld_active('Z600')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, z3, p_surf)
+       call outfld('Z600    ', p_surf, pcols, lchnk)
+    end if
     if (hist_fld_active('Z500')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, z3, p_surf)
        call outfld('Z500    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z400')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 40000._r8, z3, p_surf)
+       call outfld('Z400    ', p_surf, pcols, lchnk)
     end if
     if (hist_fld_active('Z300')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, z3, p_surf)
@@ -1086,13 +1196,64 @@ end subroutine diag_conv_tend_ini
 !
 ! Output omega at 850 and 500 mb pressure levels
 !
+    if (hist_fld_active('OMEGA1000')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, state%omega, p_surf)
+       call outfld('OMEGA1000', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA975')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 97500._r8, state%omega, p_surf)
+       call outfld('OMEGA975', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA950')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 95000._r8, state%omega, p_surf)
+       call outfld('OMEGA950', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA925')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, state%omega, p_surf)
+       call outfld('OMEGA925', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA900')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 90000._r8, state%omega, p_surf)
+       call outfld('OMEGA900', p_surf, pcols, lchnk)
+    end if
     if (hist_fld_active('OMEGA850')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%omega, p_surf)
        call outfld('OMEGA850', p_surf, pcols, lchnk)
     end if
+    if (hist_fld_active('OMEGA800')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 80000._r8, state%omega, p_surf)
+       call outfld('OMEGA800', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA700')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, state%omega, p_surf)
+       call outfld('OMEGA700', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA600')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%omega, p_surf)
+       call outfld('OMEGA600', p_surf, pcols, lchnk)
+    end if
     if (hist_fld_active('OMEGA500')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%omega, p_surf)
        call outfld('OMEGA500', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA400')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 40000._r8, state%omega, p_surf)
+       call outfld('OMEGA400', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA300')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, state%omega, p_surf)
+       call outfld('OMEGA300', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA200')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%omega, p_surf)
+       call outfld('OMEGA200', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGA100')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%omega, p_surf)
+       call outfld('OMEGA100', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('OMEGABOT')) then
+       call outfld('OMEGABOT', state%omega(:,pver), pcols, lchnk)
     end if
 !     
 ! Mass of q, by layer and vertically integrated
@@ -1144,6 +1305,67 @@ end subroutine diag_conv_tend_ini
           call outfld ('RELHUM  ',ftem    ,pcols   ,lchnk     )
        end if
 
+       ! ftem defined above assuming RELHUM in one of the history tape
+       if (hist_fld_active('RH1000')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, ftem, p_surf)
+          call outfld('RH1000', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH975')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 97500._r8, ftem, p_surf)
+          call outfld('RH975', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH950')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 95000._r8, ftem, p_surf)
+          call outfld('RH950', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH925')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, ftem, p_surf)
+          call outfld('RH925', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH900')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 90000._r8, ftem, p_surf)
+          call outfld('RH900', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH850')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, ftem, p_surf)
+          call outfld('RH850', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH800')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 80000._r8, ftem, p_surf)
+          call outfld('RH800', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH700')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, ftem, p_surf)
+          call outfld('RH700', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH600')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, ftem, p_surf)
+          call outfld('RH600', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH500')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, ftem, p_surf)
+          call outfld('RH500', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH400')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 40000._r8, ftem, p_surf)
+          call outfld('RH400', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH300')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, ftem, p_surf)
+          call outfld('RH300', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH200')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, ftem, p_surf)
+          call outfld('RH200', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RH100')) then
+          call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, ftem, p_surf)
+          call outfld('RH100', p_surf, pcols, lchnk)
+       end if
+       if (hist_fld_active('RHBOT')) then
+          call outfld('RHBOT', ftem(:,pver), pcols, lchnk)
+       end if
+
        if (hist_fld_active('RHW') .or. hist_fld_active('RHI') .or. hist_fld_active('RHCFMIP') ) then
 	  
           ! RH w.r.t liquid (water)
@@ -1193,13 +1415,37 @@ end subroutine diag_conv_tend_ini
 !
 ! Output T,q,u,v fields on pressure surfaces
 !
+    if (hist_fld_active('T975')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 97500._r8, state%t, p_surf)
+       call outfld('T975    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('T950')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 95000._r8, state%t, p_surf)
+       call outfld('T950    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('T900')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 90000._r8, state%t, p_surf)
+       call outfld('T900    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('T850')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%t, p_surf)
        call outfld('T850    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('T800')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 80000._r8, state%t, p_surf)
+       call outfld('T800    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('T600')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%t, p_surf)
+       call outfld('T600    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('T500')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%t, p_surf)
        call outfld('T500    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('T400')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 40000._r8, state%t, p_surf)
+       call outfld('T400    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('T300')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, state%t, p_surf)
@@ -1209,17 +1455,105 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%t, p_surf)
        call outfld('T200    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('T100')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%t, p_surf)
+       call outfld('T100    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('Q975')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 97500._r8, state%q(1,1,1), p_surf)
+       call outfld('Q975    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('Q950')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 95000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q950    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('Q900')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 90000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q900    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('Q850')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%q(1,1,1), p_surf)
        call outfld('Q850    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('Q800')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 80000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q800    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('Q700')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q700    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('Q600')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q600    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('Q500')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q500    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('Q400')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 40000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q400    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('Q300')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q300    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('Q200')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%q(1,1,1), p_surf)
        call outfld('Q200    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('Q100')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%q(1,1,1), p_surf)
+       call outfld('Q100    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U1000')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, state%u, p_surf)
+       call outfld('U1000   ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U975')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 97500._r8, state%u, p_surf)
+       call outfld('U975    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U950')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 95000._r8, state%u, p_surf)
+       call outfld('U950    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U925')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, state%u, p_surf)
+       call outfld('U925    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U900')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 90000._r8, state%u, p_surf)
+       call outfld('U900    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('U850')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%u, p_surf)
        call outfld('U850    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U800')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 80000._r8, state%u, p_surf)
+       call outfld('U800    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U700')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, state%u, p_surf)
+       call outfld('U700    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U600')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%u, p_surf)
+       call outfld('U600    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U500')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%u, p_surf)
+       call outfld('U500    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U400')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 40000._r8, state%u, p_surf)
+       call outfld('U400    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U300')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, state%u, p_surf)
+       call outfld('U300    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('U250')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 25000._r8, state%u, p_surf)
@@ -1229,13 +1563,61 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%u, p_surf)
        call outfld('U200    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('U100')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%u, p_surf)
+       call outfld('U100    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('U010')) then
        call vertinterp(ncol, pcols, pver, state%pmid,  1000._r8, state%u, p_surf)
        call outfld('U010    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('V1000')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, state%v, p_surf)
+       call outfld('V1000   ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V975')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 97500._r8, state%v, p_surf)
+       call outfld('V975    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V950')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 95000._r8, state%v, p_surf)
+       call outfld('V950    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V925')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, state%v, p_surf)
+       call outfld('V925    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V900')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 90000._r8, state%v, p_surf)
+       call outfld('V900    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('V850')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%v, p_surf)
        call outfld('V850    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V800')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 80000._r8, state%v, p_surf)
+       call outfld('V800    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V700')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, state%v, p_surf)
+       call outfld('V700    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V600')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%v, p_surf)
+       call outfld('V600    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V500')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%v, p_surf)
+       call outfld('V500    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V400')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 40000._r8, state%v, p_surf)
+       call outfld('V400    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V300')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, state%v, p_surf)
+       call outfld('V300    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('V250')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 25000._r8, state%v, p_surf)
@@ -1244,6 +1626,10 @@ end subroutine diag_conv_tend_ini
     if (hist_fld_active('V200')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%v, p_surf)
        call outfld('V200    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V100')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%v, p_surf)
+       call outfld('V100    ', p_surf, pcols, lchnk )
     end if
 
     ftem(:ncol,:) = state%t(:ncol,:)*state%t(:ncol,:)

--- a/components/cam/src/physics/cam/modal_aer_opt.F90
+++ b/components/cam/src/physics/cam/modal_aer_opt.F90
@@ -180,6 +180,7 @@ subroutine modal_aer_opt_init()
    call addfld ('tropopause_m',horiz_only,    'A',' m  ','tropopause level in meters', flag_xyfill=.true.)
    call addfld ('ABSORB',(/ 'lev' /),    'A','/m','Aerosol absorption', flag_xyfill=.true.)
    call addfld ('AODVIS',horiz_only,    'A','  ','Aerosol optical depth 550 nm', flag_xyfill=.true.)
+   call addfld ('AODALL',horiz_only,    'A','  ','AOD 550 nm for all time and species', flag_xyfill=.true.)
    call addfld ('AODUV',horiz_only,    'A','  ','Aerosol optical depth 350 nm', flag_xyfill=.true.)  
    call addfld ('AODNIR',horiz_only,    'A','  ','Aerosol optical depth 850 nm', flag_xyfill=.true.) 
    call addfld ('AODABS',horiz_only,    'A','  ','Aerosol absorption optical depth 550 nm', flag_xyfill=.true.)
@@ -226,10 +227,11 @@ subroutine modal_aer_opt_init()
       call add_default ('AODDUST1'     , 1, ' ')
       call add_default ('AODDUST3'     , 1, ' ')
       call add_default ('AODVIS'       , 1, ' ')
-      if ( history_verbose ) then
+      call add_default ('AODALL'       , 1, ' ')
       call add_default ('BURDEN1'      , 1, ' ')
       call add_default ('BURDEN2'      , 1, ' ')
       call add_default ('BURDEN3'      , 1, ' ')
+      if ( history_verbose ) then
       call add_default ('BURDENDUST'   , 1, ' ')
       call add_default ('BURDENSO4'    , 1, ' ')
       call add_default ('BURDENPOM'    , 1, ' ')
@@ -253,6 +255,7 @@ subroutine modal_aer_opt_init()
       call add_default ('AODMODE2'     , 1, ' ')
       call add_default ('AODMODE3'     , 1, ' ')
       call add_default ('AODVIS'       , 1, ' ')
+      call add_default ('AODALL'       , 1, ' ')
       call add_default ('AODUV'        , 1, ' ')
       call add_default ('AODNIR'       , 1, ' ')
       call add_default ('AODABS'       , 1, ' ')
@@ -263,11 +266,11 @@ subroutine modal_aer_opt_init()
       call add_default ('AODSOA'       , 1, ' ')
       call add_default ('AODBC'        , 1, ' ')
       call add_default ('AODSS'        , 1, ' ')
-      if (history_verbose) then
-      call add_default ('ABSORB'       , 1, ' ')
       call add_default ('BURDEN1'      , 1, ' ')
       call add_default ('BURDEN2'      , 1, ' ')
       call add_default ('BURDEN3'      , 1, ' ')
+      if (history_verbose) then
+      call add_default ('ABSORB'       , 1, ' ')
       call add_default ('BURDENDUST'   , 1, ' ')
       call add_default ('BURDENSO4'    , 1, ' ')
       call add_default ('BURDENPOM'    , 1, ' ')
@@ -300,7 +303,7 @@ subroutine modal_aer_opt_init()
      if (history_aero_optics) then
         call add_default ('AODDUST4', 1, ' ')
         call add_default ('AODMODE4', 1, ' ')
-        if (history_verbose) call add_default ('BURDEN4' , 1, ' ')
+        call add_default ('BURDEN4' , 1, ' ')
      end if
   end if
    if (cam_chempkg_is('trop_mam7').or.cam_chempkg_is('trop_mam9').or.cam_chempkg_is('trop_strat_mam7')) then      
@@ -350,12 +353,15 @@ subroutine modal_aer_opt_init()
               'Aerosol absorption', flag_xyfill=.true.)
          call addfld ('AODVIS'//diag(ilist),       horiz_only, 'A','  ', &
               'Aerosol optical depth 550 nm', flag_xyfill=.true.)
+         call addfld ('AODALL'//diag(ilist),       horiz_only, 'A','  ', &
+              'AOD 550 nm all time', flag_xyfill=.true.)
          call addfld ('AODABS'//diag(ilist),       horiz_only, 'A','  ', &
               'Aerosol absorption optical depth 550 nm', flag_xyfill=.true.)
          
          call add_default ('EXTINCT'//diag(ilist), 1, ' ')
          call add_default ('ABSORB'//diag(ilist),  1, ' ')
          call add_default ('AODVIS'//diag(ilist),  1, ' ')
+         call add_default ('AODALL'//diag(ilist),  1, ' ')
          call add_default ('AODABS'//diag(ilist),  1, ' ')
          
       end if
@@ -443,6 +449,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
    real(r8) :: extinct(pcols,pver), tropopause_m(pcols)
    real(r8) :: absorb(pcols,pver)
    real(r8) :: aodvis(pcols)               ! extinction optical depth
+   real(r8) :: aodall(pcols)               ! extinction optical depth
    real(r8) :: aodabs(pcols)               ! absorption optical depth
 
    real(r8) :: aodabsbc(pcols)             ! absorption optical depth of BC
@@ -538,6 +545,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
    extinct(1:ncol,:)     = 0.0_r8
    absorb(1:ncol,:)      = 0.0_r8
    aodvis(1:ncol)        = 0.0_r8
+   aodall(1:ncol)        = 0.0_r8
    aodabs(1:ncol)        = 0.0_r8
    burdendust(:ncol)     = 0.0_r8
    burdenso4(:ncol)      = 0.0_r8
@@ -858,6 +866,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
                   extinct(i,k) = extinct(i,k) + dopaer(i)*air_density(i,k)/mass(i,k)
                   absorb(i,k)  = absorb(i,k) + pabs(i)*air_density(i,k)
                   aodvis(i)    = aodvis(i) + dopaer(i)
+                  aodall(i)    = aodall(i) + dopaer(i)
                   aodabs(i)    = aodabs(i) + pabs(i)*mass(i,k)
                   aodmode(i)   = aodmode(i) + dopaer(i)
                   ssavis(i)    = ssavis(i) + dopaer(i)*palb(i)
@@ -1029,7 +1038,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
       ! be necessary to provide output for the rad_diag lists.
       if (list_idx == 0) then
          do i = 1, nnite
-            burden(idxnite(i))  = fillvalue
+!            burden(idxnite(i))  = fillvalue
             aodmode(idxnite(i)) = fillvalue
             dustaodmode(idxnite(i)) = fillvalue
          end do
@@ -1089,6 +1098,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
    call outfld('tropopause_m', tropopause_m, pcols, lchnk)
    call outfld('ABSORB'//diag(list_idx),   absorb,  pcols, lchnk)
    call outfld('AODVIS'//diag(list_idx),   aodvis,  pcols, lchnk)
+   call outfld('AODALL'//diag(list_idx),   aodall,  pcols, lchnk)
    call outfld('AODABS'//diag(list_idx),   aodabs,  pcols, lchnk)
 
    ! These diagnostics are output only for climate list
@@ -1106,20 +1116,21 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
 
          aoduv(idxnite(i))      = fillvalue
          aodnir(idxnite(i))     = fillvalue
-
-         burdendust(idxnite(i)) = fillvalue
-         burdenso4(idxnite(i))  = fillvalue
-         burdenpom(idxnite(i))  = fillvalue
-         burdensoa(idxnite(i))  = fillvalue
-         burdenbc(idxnite(i))   = fillvalue
-         burdenseasalt(idxnite(i)) = fillvalue
-#if ( defined MODAL_AERO_4MODE_MOM )
-         burdenmom(idxnite(i)) = fillvalue
-#elif ( defined MODAL_AERO_9MODE )
-         burdenpoly(idxnite(i)) = fillvalue
-         burdenprot(idxnite(i)) = fillvalue
-         burdenlip(idxnite(i)) = fillvalue
-#endif
+!Following burden* variables are commented out so that "nite" indices
+!retain their original value instead of being overwritten by "fillvalue"
+!         burdendust(idxnite(i)) = fillvalue
+!         burdenso4(idxnite(i))  = fillvalue
+!         burdenpom(idxnite(i))  = fillvalue
+!         burdensoa(idxnite(i))  = fillvalue
+!         burdenbc(idxnite(i))   = fillvalue
+!         burdenseasalt(idxnite(i)) = fillvalue
+!#if ( defined MODAL_AERO_4MODE_MOM )
+!         burdenmom(idxnite(i)) = fillvalue
+!#elif ( defined MODAL_AERO_9MODE )
+!         burdenpoly(idxnite(i)) = fillvalue
+!         burdenprot(idxnite(i)) = fillvalue
+!         burdenlip(idxnite(i)) = fillvalue
+!#endif
 
          aodabsbc(idxnite(i))   = fillvalue
 

--- a/components/cam/src/utils/cam_dom/ocn_comp.F90
+++ b/components/cam/src/utils/cam_dom/ocn_comp.F90
@@ -294,7 +294,7 @@ contains
        call getfil(focndomain, locfn)
        call cam_pio_openfile(ncid_dom, locfn, 0)
        if (single_column) then
-          call shr_scam_getCloseLatLon(ncid_dom%fh,scmlat,scmlon,closelat,closelon,closelatidx,closelonidx)
+          call shr_scam_getCloseLatLon(ncid_dom,scmlat,scmlon,closelat,closelon,closelatidx,closelonidx)
           rcode = pio_inq_varid(ncid_dom, 'frac', fracid)
           rcode = pio_get_var(ncid_dom,fracid,(/closelonidx,closelatidx/),(/1,1/),arr2d)
        else

--- a/components/cam/src/utils/cam_dom/sst_data.F90
+++ b/components/cam/src/utils/cam_dom/sst_data.F90
@@ -283,7 +283,7 @@ subroutine sstini(ncid_sst)
 
 
   if (single_column) then
-     call shr_scam_GetCloseLatLon(ncid_sst%fh,scmlat,scmlon,closelat,closelon,closelatidx,closelonidx)
+     call shr_scam_GetCloseLatLon(ncid_sst,scmlat,scmlon,closelat,closelon,closelatidx,closelonidx)
      strt3(1) = closelonidx
      strt3(2) = closelatidx
      strt3(3) = 1
@@ -432,7 +432,7 @@ subroutine sstint(ncid_sst, prev_timestep)
 
   if (masterproc) then
      if (single_column) then
-        call shr_scam_GetCloseLatLon(ncid_sst%fh,scmlat,scmlon,closelat,closelon,closelatidx,closelonidx)
+        call shr_scam_GetCloseLatLon(ncid_sst,scmlat,scmlon,closelat,closelon,closelatidx,closelonidx)
         strt3(1) = closelonidx
         strt3(2) = closelatidx
         strt3(3) = 1

--- a/components/cice/src/drivers/cpl/ice_restart.F90
+++ b/components/cice/src/drivers/cpl/ice_restart.F90
@@ -1446,12 +1446,12 @@
          call pio_seterrorhandling(File, PIO_INTERNAL_ERROR)
       endif
 
-      call pio_closefile(File)
-
       call PIO_freeDecomp(File,iodesc2d)
       call PIO_freeDecomp(File,iodesc3d_ncat)
       call PIO_freeDecomp(File,iodesc3d_ntilyr)
       call PIO_freeDecomp(File,iodesc3d_ntslyr)
+
+      call pio_closefile(File)
 
       call bound_state (aicen, trcrn, &
                         vicen, vsnon, &

--- a/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
@@ -34,5 +34,6 @@
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
 <finidat mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
+<check_finidat_year_consistency>.false.</check_finidat_year_consistency>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc>Conditions to simulate 2010 land-use</use_case_desc>
+
+<sim_year>2015</sim_year>
+
+<sim_year_range>constant</sim_year_range>
+
+<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_ndep>
+
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_pdep>
+
+<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_popdens>
+
+<!-- CMIP6 HighResMIP compsets -->
+<fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc </fsurdat>
+<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/cori-knl.20190214_maint-1.0.F2010-CMIP6-HR.noCNT.ARE.nudgeUV.ne120_oRRS18v3.clm2.r.2011-01-01-00000.nc </finidat>
+<check_finidat_pct_consistency>.false.</check_finidat_pct_consistency>
+
+</namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6LR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6LR_control.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc>Conditions to simulate 2010 land-use</use_case_desc>
+
+<sim_year>2015</sim_year>
+
+<sim_year_range>constant</sim_year_range>
+
+<stream_year_first_ndep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_ndep>
+
+<stream_year_first_pdep phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_pdep>
+
+<stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_popdens>
+
+<!-- CMIP6 DECK compsets -->
+<fsurdat hgrid="ne30np4" >lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2010_c20181025.nc </fsurdat>
+<finidat hgrid="ne30np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC.edison.clm2.r.2010-01-01-00000.nc </finidat>
+
+</namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -47,7 +47,7 @@
 
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_2015_c20171018.nc</flanduse_timeseries>
-<finidat>lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc</finidat>
+<finidat mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc</finidat>
 <check_finidat_year_consistency>.false.</check_finidat_year_consistency>
 
 </namelist_defaults>

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -24,6 +24,8 @@
       <value compset="_CLM45"                >-phys clm4_5</value>
       <value compset="_CLM50"                >-phys clm5_0</value>
       <value compset="_CLM45%[^_]*BC" >-phys clm4_5 -cppdefs -DMODAL_AER</value>
+      <value compset="1950_CAM5%CMIP6-[LH]R[^_]*_CLM45%[^_]*BC"                >-phys clm4_5 -cppdefs '-DMODAL_AER -DAPPLY_POST_DECK_BUGFIXES'</value>
+      <value compset="2010_CAM5%CMIP6-[LH]R[^_]*_CLM45%[^_]*BC"                >-phys clm4_5 -cppdefs '-DMODAL_AER -DAPPLY_POST_DECK_BUGFIXES'</value>
     </values>
     <group>build_component_clm</group>
     <file>env_build.xml</file>
@@ -72,6 +74,7 @@
       <!-- CMIP6 DECK compsets and related BGC compsets -->
       <value compset="1850_CAM5%CMIP6_CLM">1850_CMIP6_control</value>
       <value compset="1850_CAM5%CMIP6_CLM45.*_BGC%BCRC">1850_CMIP6bgc_control</value>
+      <value compset="1850S_CAM5%CMIP6_CLM">1850_SCMIP6_control</value>
       <value compset="20TR_CAM5%CMIP6_CLM">20thC_CMIP6_transient</value>
       <value compset="20TR_CAM5%CMIP6_CLM45.*_BGC%B">20thC_CMIP6bgc_transient</value> 
       <value compset="20TR.*_CLM45%[^_]*BGC">20thC_bgc_transient</value>
@@ -79,6 +82,8 @@
       <value compset="1950_CAM5%CMIP6-HR_CLM">1950_CMIP6HR_control</value>
       <value compset="SSP585_CAM5%CMIP6_CLM">2015-2100_SSP585_transient</value>
       <value compset="SSP585_CAM5%CMIP6_CLM45.*_BGC%B">2015-2100_SSP585_CMIP6bgc_transient</value> 
+      <value compset="2010_CAM5%CMIP6-LR_CLM">2010_CMIP6LR_control</value>
+      <value compset="2010_CAM5%CMIP6-HR_CLM">2010_CMIP6HR_control</value>
     </values>
     <group>run_component_clm</group>
     <file>env_run.xml</file>

--- a/components/clm/src/main/ncdio_pio.F90.in
+++ b/components/clm/src/main/ncdio_pio.F90.in
@@ -1317,37 +1317,34 @@ contains
 
        call ncd_inqvid  (ncid, varname, varid, vardesc)
 
-#if ({DIMS}==0) 
-       start(1) = 1  ; count(1) = 1
-       if (present(nt)) start(1) = nt ; count(1) = 1
-       temp(1) = data
-       status = pio_put_var(ncid, varid, start, count, temp)
-#elif ({DIMS}==1) 
-       start(1) = 1 ; count(1) = size(data) 
-       start(2) = 1 ; count(2) = 1
-       if (present(nt)) start(2) = nt
-       status = pio_put_var(ncid, varid, start, count, data)
-#elif ({DIMS}==2) 
-       start(1) = 1  ; count(1) = size(data, dim=1)
-       start(2) = 1  ; count(2) = size(data, dim=2)
-       start(3) = 1  ; count(3) = 1
-       if (present(nt)) start(3) = nt 
-       status = pio_put_var(ncid, varid, start, count, data)
-#elif ({DIMS}==3) 
        if (present(nt)) then
+#if ({DIMS}==0) 
+          start(1) = nt  ; count(1) = 1
+          temp(1) = data
+          status = pio_put_var(ncid, varid, start, count, temp)
+#elif ({DIMS}==1) 
+          start(1) = 1 ; count(1) = size(data) 
+          start(2) = nt ; count(2) = 1
+          status = pio_put_var(ncid, varid, start, count, data)
+#elif ({DIMS}==2) 
+          start(1) = 1  ; count(1) = size(data, dim=1)
+          start(2) = 1  ; count(2) = size(data, dim=2)
+          start(3) = nt  ; count(3) = 1
+          status = pio_put_var(ncid, varid, start, count, data)
+#elif ({DIMS}==3) 
           start(1) = 1  ; count(1) = size(data,dim=1)
           start(2) = 1  ; count(2) = size(data,dim=2)
           start(3) = 1  ; count(3) = size(data,dim=3)
           start(4) = nt ; count(4) = 1
           status = pio_put_var(ncid, varid, start, count, data)
+#endif
        else
           status = pio_put_var(ncid, varid, data)
        end if
-#endif
 
     endif
 
-  end subroutine ncd_io_{DIMS}d_{TYPE}_glob
+end subroutine ncd_io_{DIMS}d_{TYPE}_glob
 
   !------------------------------------------------------------------------
   !DIMS 0,1,2

--- a/components/homme/cmake/machineFiles/anlworkstation.cmake
+++ b/components/homme/cmake/machineFiles/anlworkstation.cmake
@@ -1,0 +1,25 @@
+# anlworkstation
+
+SET (CMAKE_Fortran_COMPILER mpif90 CACHE FILEPATH "")
+SET (CMAKE_C_COMPILER mpicc CACHE FILEPATH "")
+SET (CMAKE_CXX_COMPILER mpicxx CACHE FILEPATH "")
+
+#SET (CMAKE_Fortran_FLAGS "-WF,-C! -O2 -Ipreqx_modules" CACHE STRING "")
+#SET (FORCE_Fortran_FLAGS "-WF,-C!" CACHE STRING "")
+SET (ENABLE_OPENMP TRUE CACHE BOOL "")
+
+SET (PNETCDF_DIR /soft/apps/packages/climate/pnetcdf/1.8.1/gcc-6.2.0 CACHE FILEPATH "")
+SET (NETCDF_DIR /soft/apps/packages/climate/netcdf/4.3.3.1c-4.2cxx-4.4.2f-parallel/gcc-6.2.0 CACHE FILEPATH "")
+SET (ENV{HDF5} /soft/apps/packages/climate/hdf5/1.8.16-parallel/gcc-6.2.0 CACHE FILEPATH "")
+#SET (ENV{LIBZ} /soft/libraries/alcf/current/xl/ZLIB CACHE FILEPATH "")
+SET (CPRNC_DIR /home/climate1/acme/cprnc/build/cprnc CACHE FILEPATH "")
+
+SET (USE_QUEUING FALSE CACHE BOOL "")
+SET (USE_MPIEXEC mpiexec CACHE FILEPATH "")
+
+SET (HOMME_FIND_BLASLAPACK TRUE CACHE BOOL "")
+#SET (ENV{PATH} "/soft/libraries/alcf/current/xl/BLAS/lib:/soft/libraries/alcf/current/xl/LAPACK/lib:$ENV{PATH}")
+SET (ENV{PATH} "/soft/apps/packages/climate/netcdf/4.3.3.1c-4.2cxx-4.4.2f-parallel:$ENV{PATH}")
+SET (ENV{LD_LIBRARY_PATH} "/soft/apps/packages/climate/hdf5/1.8.16-serial/gcc-6.2.0/lib:$ENV{LD_LIBRARY_PATH}")
+
+SET (BUILD_HOMME_SWEQX FALSE CACHE BOOL "")

--- a/components/mosart/src/riverroute/RtmIO.F90
+++ b/components/mosart/src/riverroute/RtmIO.F90
@@ -1087,6 +1087,8 @@ contains
 
     elseif (flag == 'write') then
 
+       start = 0
+       count = 0
        if (present(nt))      then
           start(1) = 1
           count(1) = size(data)
@@ -1095,8 +1097,6 @@ contains
        else
           start(1) = 1
           count(1) = size(data)
-          start(2) = 1
-          count(2) = 1
        end if
        call ncd_inqvid  (ncid, varname, varid, vardesc)
        status = pio_put_var(ncid, varid, start, count, data)
@@ -1148,6 +1148,8 @@ contains
 
     elseif (flag == 'write') then
 
+       start = 0
+       count = 0
        if (present(nt))      then
           start(1) = 1
           count(1) = size(data)
@@ -1156,8 +1158,6 @@ contains
        else
           start(1) = 1
           count(1) = size(data)
-          start(2) = 1
-          count(2) = 1
        end if
        call ncd_inqvid  (ncid, varname, varid, vardesc)
        allocate( idata(size(data)) ) 
@@ -1209,6 +1209,8 @@ contains
 
     elseif (flag == 'write') then
 
+       start = 0
+       count = 0
        if (present(nt))      then
           start(1) = 1
           start(2) = nt
@@ -1216,9 +1218,7 @@ contains
           count(2) = 1
        else
           start(1) = 1
-          start(2) = 1
           count(1) = size(data)
-          count(2) = 1
        end if
        call ncd_inqvid  (ncid, varname, varid, vardesc)
        status = pio_put_var(ncid, varid, start, count, data)
@@ -1325,6 +1325,8 @@ contains
 
     elseif (flag == 'write') then
 
+       start = 0
+       count = 0
        if (present(nt))      then
           start(1) = 1
           start(2) = 1
@@ -1335,10 +1337,8 @@ contains
        else
           start(1) = 1
           start(2) = 1
-          start(3) = 1
           count(1) = size(data, dim=1)
           count(2) = size(data, dim=2)
-          count(3) = 1
        end if
        call ncd_inqvid(ncid, varname, varid, vardesc)
        status = pio_put_var(ncid, varid, start, count, data)
@@ -1384,6 +1384,8 @@ contains
 
     elseif (flag == 'write') then
 
+       start = 0
+       count = 0
        if (present(nt))      then
           start(1) = 1
           start(2) = 1
@@ -1394,10 +1396,8 @@ contains
        else
           start(1) = 1
           start(2) = 1
-          start(3) = 1
           count(1) = size(data, dim=1)
           count(2) = size(data, dim=2)
-          count(3) = 1
        end if
        call ncd_inqvid  (ncid, varname, varid, vardesc)
        status = pio_put_var(ncid, varid, start, count, data)


### PR DESCRIPTION
Merge of maint-1.0 in to maint-1.1
    
Bring several changes made to maint-1.0 to the maint-1.1 branch

Major changes:
Convert all use cases to use netcdf3 input files.
Add SCORPIO external and use it.
Add some CMPI6 use cases.

Summary:

EAM:
    Add use cases (and compsets):
       2010_cam5_CMIP6-HR.xml
       2010_cam5_CMIP6-LR.xml
       1850S_cam5_CMIP6.xml
    Update CMIP6_bgc use cases and others to use netcdf3
    Modify cam_diagnostics to output at more pressure levels.
    Adds AODALL to compute total aerosol (incl. nighttime) optical depth
    
CICE:
       Fix CICE restart fail - freeing iodesc
ELM:
       Land init fix for missing mask
Driver:
       mpi tag fix needed for ensembles in new tests.
I/O:  (most of the files touched are from adding SCORPIO)
       Add SCORPIO external directories and enable PIO2 as option in all models and
        make box rearranger the default.
    
CIME scripts:  Fix bug in cime macrowriterbase, Fix implementation of SVN server,
   Sync wget from master, Ignore unicode chars from command output, update check_input_data
    to prevent server outage from crashing case.submit
    
testing:   add transient test to production, allow netcdf3 in v1cmip testmod,
    Big update to wait_for_tests/jenkins, Adds tsc and npg tests
    
config_batch:   Update queue policy on theta
config_inputdata:  Remove old ornl svn data server
config_compilers:   remove cab,  update theta:intel, update compy:intel, add compy:pgi add PIO2 flags.
config_machines:   update compy to be same as master
