### PR TITLE
Update F20TRC5-CMIP6 SST and sea ice settings

### DIFF
--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -169,7 +169,8 @@
       <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DOCN%DOM" grid="a%0.47x0.63.*_oi%0.47x0.63"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_c061106.nc</value>
       <value compset="DOCN%DOM" grid="a%0.23x0.31.*_oi%0.23x0.31"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_c110526.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid=".+"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_1850_2012_c130411.nc</value>
+      <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)" grid=".+"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_1850_2012_c130411.nc</value>
+      <value compset="20TR_CAM5%AV" grid=".+"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_1850_2012_c130411.nc</value>
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%T31.*_oi%T31"		>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_1850_2012_c130411.nc</value>
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%1.9x2.5.*_oi%1.9x2.5"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_1850_2012_c130411.nc</value>
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_1850_2012_c130411.nc</value>
@@ -184,6 +185,7 @@
       <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
       <value compset="1950_" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_1950_clim_c20180910.nc</value>
       <value compset="2010S_" grid="a%ne30np4.*_oi%oEC60to30v3"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_2010_clim_c20190821.nc</value>
+      <value compset="20TR_CAM5%CMIP6" grid=".+"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_c20180213.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>
@@ -238,7 +240,9 @@
     <valid_values></valid_values>
     <default_value>1</default_value>
     <values match="last">
-      <value compset="(AMIP_|20TR_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
+      <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
+      <value compset="20TR_CAM5%AV">1850</value>
+      <value compset="20TR_CAM5%CMIP6">1849</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -260,7 +264,9 @@
     <valid_values></valid_values>
     <default_value>0</default_value>
     <values match="last">
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)">1850</value>
+      <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
+      <value compset="20TR_CAM5%AV">1850</value>
+      <value compset="20TR_CAM5%CMIP6">1849</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -276,7 +282,9 @@
     <valid_values></valid_values>
     <default_value>0</default_value>
     <values match="last">
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)">2012</value>
+      <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">2012</value>
+      <value compset="20TR_CAM5%AV">2012</value>
+      <value compset="20TR_CAM5%CMIP6">2016</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -242,7 +242,7 @@
     <values match="last">
       <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
       <value compset="20TR_CAM5%AV">1850</value>
-      <value compset="20TR_CAM5%CMIP6">1870</value>
+      <value compset="20TR_CAM5%CMIP6">1869</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -266,7 +266,7 @@
     <values match="last">
       <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
       <value compset="20TR_CAM5%AV">1850</value>
-      <value compset="20TR_CAM5%CMIP6">1870</value>
+      <value compset="20TR_CAM5%CMIP6">1869</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>

--- a/cime/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/docn/cime_config/config_component.xml
@@ -242,7 +242,7 @@
     <values match="last">
       <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
       <value compset="20TR_CAM5%AV">1850</value>
-      <value compset="20TR_CAM5%CMIP6">1849</value>
+      <value compset="20TR_CAM5%CMIP6">1870</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -266,7 +266,7 @@
     <values match="last">
       <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
       <value compset="20TR_CAM5%AV">1850</value>
-      <value compset="20TR_CAM5%CMIP6">1849</value>
+      <value compset="20TR_CAM5%CMIP6">1870</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Update F20TRC5-CMIP6 SST and sea ice settings

	* Change to use the CMIP6 SST and sea ice file
	* Update the year align, start, and end settings accordingly

[BFB] - non-BFB for  F20TRC5-CMIP6 only
[NML] -  ice_in, docn_in and docn.stream diff with F20TRC5-CMIP6 