### PR TITLE
fix output bugs in maint-1.1

### DIFF
--- a/components/clm/src/biogeochem/CNNitrogenFluxType.F90
+++ b/components/clm/src/biogeochem/CNNitrogenFluxType.F90
@@ -2931,10 +2931,16 @@ contains
            this%hrv_deadcrootn_storage_to_litter_patch(p)+ &
            this%hrv_deadcrootn_xfer_to_litter_patch(p)
 
-       this%sen_nloss_litter(p) = &
-           this%livestemn_to_litter_patch(p)            + &
-           this%leafn_to_litter_patch(p)                + &
-           this%frootn_to_litter_patch(p)
+      if (crop_prog) then
+         this%sen_nloss_litter(p) = &
+             this%livestemn_to_litter(p)            + &
+             this%leafn_to_litter(p)                + &
+             this%frootn_to_litter(p)
+      else
+         this%sen_nloss_litter(p) = &
+             this%leafn_to_litter(p)                + &
+             this%frootn_to_litter(p)
+      end if
 
     end do
 

--- a/components/clm/src/biogeochem/PhosphorusFluxType.F90
+++ b/components/clm/src/biogeochem/PhosphorusFluxType.F90
@@ -2343,10 +2343,16 @@ contains
            this%hrv_deadcrootp_storage_to_litter_patch(p)+ &
            this%hrv_deadcrootp_xfer_to_litter_patch(p)
 
-       this%sen_ploss_litter(p) = &
-           this%livestemp_to_litter_patch(p)            + &
-           this%leafp_to_litter_patch(p)                + &
-           this%frootp_to_litter_patch(p)
+      if (crop_prog) then
+         this%sen_ploss_litter(p) = &
+             this%livestemp_to_litter(p)            + &
+             this%leafp_to_litter(p)                + &
+             this%frootp_to_litter(p)
+      else
+         this%sen_ploss_litter(p) = &
+             this%leafp_to_litter(p)                + &
+             this%frootp_to_litter(p)
+      end if
 
     end do
 


### PR DESCRIPTION
Two diagnostic variables SEN_NLOSS_LITTER and SEN_PLOSS_LITTER are NaN from historical CBGC runs due to bugs in the calculation. This commit fixes those bugs in the maint-1.1.