### PR TITLE
Correct the marine BGC settings for future BGC compsets

### DIFF
--- a/components/mpas-ocean/cime_config/config_component.xml
+++ b/components/mpas-ocean/cime_config/config_component.xml
@@ -65,10 +65,10 @@
            <value compset="20TR_CAM5.*_MPASO%OIECO.*_BGC%BCRD">bcrd</value>
            <value compset="20TR_CAM5.*_MPASO%OIECO.*_BGC%BDRC">bdrc</value>
            <value compset="20TR_CAM5.*_MPASO%OIECO.*_BGC%BDRD">bdrd</value>
-           <value compset="SSP5_CAM5.*_MPASO%OIECO.*_BGC%BCRC">bcrc</value>
-           <value compset="SSP5_CAM5.*_MPASO%OIECO.*_BGC%BCRD">bcrd</value>
-           <value compset="SSP5_CAM5.*_MPASO%OIECO.*_BGC%BDRC">bdrc</value>
-           <value compset="SSP5_CAM5.*_MPASO%OIECO.*_BGC%BDRD">bdrd</value>
+           <value compset="SSP585_CAM5.*_MPASO%OIECO.*_BGC%BCRC">bcrc</value>
+           <value compset="SSP585_CAM5.*_MPASO%OIECO.*_BGC%BCRD">bcrd</value>
+           <value compset="SSP585_CAM5.*_MPASO%OIECO.*_BGC%BDRC">bdrc</value>
+           <value compset="SSP585_CAM5.*_MPASO%OIECO.*_BGC%BDRD">bdrd</value>
         </values>
         <group>case_comp</group>
         <file>env_case.xml</file>


### PR DESCRIPTION
This PR corrects the marine BGC settings for future BGC compsets. For maint-1.1 only

[BFB] for all tested compsets