### PR TITLE
NA RRM tri-grid support for F2010SC5-CMIP6 compset

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
@@ -5,7 +5,8 @@
 <cosp_lite>.true.</cosp_lite>
 
 <!-- Atmosphere initial condition -->
-<ncdata>atm/cam/inic/homme/20180716.DECKv1b_A3.ne30_oEC.edison.cam.i.2010-01-01-00000.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4" nlev="72" >atm/cam/inic/homme/20180716.DECKv1b_A3.ne30_oEC.edison.cam.i.2010-01-01-00000.nc</ncdata>
+<ncdata dyn="se" hgrid="ne0np4_northamericax4v1" nlev="72" >atm/cam/inic/homme/cami_0001-01-01_northamericax4v1_c190709.nc</ncdata>
 
 <!-- Solar constant from CMIP6 input4MIPS -->
 <solar_data_file>atm/cam/solar/Solar_2010control_input4MIPS_c20181017.nc</solar_data_file>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6_control.xml
@@ -19,6 +19,7 @@
 
 <!-- CMIP6 DECK compsets -->
 <fsurdat hgrid="ne30np4" >lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2010_c20181025.nc </fsurdat>
+<fsurdat hgrid="r0125" >lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr2010_c191025.nc </fsurdat>
 <finidat hgrid="ne30np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC.edison.clm2.r.2010-01-01-00000.nc </finidat>
 
 </namelist_defaults>


### PR DESCRIPTION
The F2010SC5-CMIP6 compset needs new input files to be able to run on the North
America (NA) RRM tri-grid

	* Add the atm initial condition (ncdata) file for the northamericax4v1 grids
	* Add the land surface data in year 2010 for r0125 grids

[NML] - Namelist Changing