### PR TITLE
Makes short queue on Compy the default for small jobs

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -398,7 +398,8 @@
 
    <batch_system MACH="compy" type="slurm">
     <queues>
-      <queue walltimemax="00:59:00" default="true">slurm</queue>
+      <queue walltimemax="00:30:00" nodemax="40" default="true">short</queue>
+      <queue walltimemax="01:00:00" >slurm</queue>
     </queues>
    </batch_system>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -398,8 +398,8 @@
 
    <batch_system MACH="compy" type="slurm">
     <queues>
-      <queue walltimemax="02:00:00" nodemax="40" default="true">short</queue>
-      <queue walltimemax="06:00:00">slurm</queue>
+      <queue walltimemax="02:00:00" strict="true" nodemin="1" nodemax="40" default="true">short</queue>
+      <queue walltimemax="06:00:00" nodemin="1" nodemax="460">slurm</queue>
     </queues>
    </batch_system>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -398,8 +398,8 @@
 
    <batch_system MACH="compy" type="slurm">
     <queues>
-      <queue walltimemax="00:30:00" nodemax="40" default="true">short</queue>
-      <queue walltimemax="01:00:00" >slurm</queue>
+      <queue walltimemax="02:00:00" nodemax="40" default="true">short</queue>
+      <queue walltimemax="06:00:00">slurm</queue>
     </queues>
    </batch_system>
 


### PR DESCRIPTION
Short queue is now default with a nodemax count of 40. Jobs over 40
nodes will go to slurm queue. This is done so that most tests can run 
in the short queue.

[BFB] - Bit-For-Bit