### PR TITLE
Correct ocn_co2_type setting for bcrd case

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -960,7 +960,7 @@ if ($ocn_co2_type eq 'constant' ) {
         add_default($nl, 'config_ecosys_atm_co2_constant_value', 'val'=>$atm_co2_const_val);
 } elsif ($ocn_co2_type eq 'bcrd' ) {
         add_default($nl, 'config_ecosys_atm_co2_option', 'val'=>"constant");
-        add_default($nl, 'config_ecosys_atm_alt_co2_option', 'val'=>"constant");
+        add_default($nl, 'config_ecosys_atm_alt_co2_option', 'val'=>"diagnostic");
         add_default($nl, 'config_ecosys_atm_alt_co2_use_eco', 'val'=>".false.");
         add_default($nl, 'config_ecosys_atm_co2_constant_value', 'val'=>$atm_co2_const_val);
 } elsif ($ocn_co2_type eq 'bdrc' ) {


### PR DESCRIPTION
This PR brings in a bug fix to correct the ocn_co2_type setting for bcrd cases in the maint-1.1 branch

Fixes #3289 

[BFB]