### PR TITLE
Update sandiatoss3 pe-layouts for failing tri-grid tests

### DIFF
--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -1277,7 +1277,7 @@
     </mach>
   </grid>
   <grid name="a%ne30np4_l%r05_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3">
-    <mach name="sandiatoss3">
+    <mach name="sandiatoss3|cori-knl|cori-haswell|theta|anvil|bebop">
       <pes compset="any" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -1314,7 +1314,7 @@
     </mach>
   </grid>
   <grid name="a%r05_l%r05_oi%null_r%r05_g%null_w%null_z%null_m%oEC60to30v3">
-    <mach name="sandiatoss3">
+    <mach name="sandiatoss3|cori-knl|cori-haswell|theta|anvil|bebop">
       <pes compset="any" pesize="any">
         <comment>none</comment>
         <ntasks>

--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -1313,7 +1313,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%r05_l%r05_oi%r05_r%r05_g%null_w%null_z%null_m%oEC60to30v3">
+  <grid name="a%r05_l%r05_oi%null_r%r05_g%null_w%null_z%null_m%oEC60to30v3">
     <mach name="sandiatoss3">
       <pes compset="any" pesize="any">
         <comment>none</comment>

--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -1276,6 +1276,80 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%ne30np4_l%r05_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3">
+    <mach name="sandiatoss3">
+      <pes compset="any" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>256</ntasks_atm>
+          <ntasks_lnd>256</ntasks_lnd>
+          <ntasks_rof>256</ntasks_rof>
+          <ntasks_ice>256</ntasks_ice>
+          <ntasks_ocn>256</ntasks_ocn>
+          <ntasks_glc>256</ntasks_glc>
+          <ntasks_wav>256</ntasks_wav>
+          <ntasks_cpl>256</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%r05_l%r05_oi%r05_r%r05_g%null_w%null_z%null_m%oEC60to30v3">
+    <mach name="sandiatoss3">
+      <pes compset="any" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>256</ntasks_atm>
+          <ntasks_lnd>256</ntasks_lnd>
+          <ntasks_rof>256</ntasks_rof>
+          <ntasks_ice>256</ntasks_ice>
+          <ntasks_ocn>256</ntasks_ocn>
+          <ntasks_glc>256</ntasks_glc>
+          <ntasks_wav>256</ntasks_wav>
+          <ntasks_cpl>256</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
   <grid name="any">
     <mach name="anlworkstation">
       <pes compset="any" pesize="any">


### PR DESCRIPTION
This PR adds two specific pe-layouts for sandiatoss3 to run two failing tri-grid tests:
* SMS.r05_r05.I1850CLM45CN.sandiatoss3_intel
* SMS_D_Ld1.ne30_r05_oECv3.A_WCYCL1850.sandiatoss3_intel
These layouts were tested in [SES-875](https://acme-climate.atlassian.net/servicedesk/customer/portal/2/SES-875) and now pass.

[BFB] for all previously tested configurations