### PR TITLE
update anvil queues for time limits depending on size

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -284,9 +284,9 @@
 
     <batch_system MACH="anvil-centos7" type="slurm" >
       <queues>
-	<queue walltimemax="02:00:00" nodemax="5" default="true">acme-small</queue>
-	<queue walltimemax="01:00:00" nodemin="6" nodemax="60">acme-medium</queue>
-	<queue walltimemax="00:12:00" nodemin="61">acme-large</queue>
+	<queue walltimemax="02:00:00" nodemax="5" default="true" strict="true">acme-small</queue>
+	<queue walltimemax="01:00:00" nodemin="6" nodemax="60" strict="true">acme-medium</queue>
+	<queue walltimemax="00:12:00" nodemin="61" strict="true">acme-large</queue>
       </queues>
     </batch_system>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -284,7 +284,9 @@
 
     <batch_system MACH="anvil-centos7" type="slurm" >
       <queues>
-	<queue walltimemax="01:00:00" default="true">acme-centos7</queue>
+	<queue walltimemax="02:00:00" nodemax="5" default="true">acme-small</queue>
+	<queue walltimemax="01:00:00" nodemin="6" nodemax="60">acme-medium</queue>
+	<queue walltimemax="00:12:00" nodemin="61">acme-large</queue>
       </queues>
     </batch_system>
 

--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -284,9 +284,9 @@
 
     <batch_system MACH="anvil-centos7" type="slurm" >
       <queues>
-	<queue walltimemax="02:00:00" nodemax="5" default="true" strict="true">acme-small</queue>
-	<queue walltimemax="01:00:00" nodemin="6" nodemax="60" strict="true">acme-medium</queue>
-	<queue walltimemax="00:12:00" nodemin="61" strict="true">acme-large</queue>
+	<queue walltimemax="48:00:00" nodemax="5" default="true" strict="true">acme-small</queue>
+	<queue walltimemax="24:00:00" nodemin="6" nodemax="60" strict="true">acme-medium</queue>
+	<queue walltimemax="12:00:00" nodemin="61" strict="true">acme-large</queue>
       </queues>
     </batch_system>
 


### PR DESCRIPTION

acme-large Jobs with > 60 nodes have a max time of 12 hours
acme-medium Jobs with 6-60 nodes have a max time of 24 hours
acme-small (default) Jobs with 1-5 nodes have a max time of 48 hours
 
