### PR TITLE
fix float invalidation error of eca_bgc

### DIFF
--- a/components/clm/src/data_types/ColumnDataType.F90
+++ b/components/clm/src/data_types/ColumnDataType.F90
@@ -10020,13 +10020,14 @@ contains
        if (lun_pp%ifspecial(l)) then
           num_special_col = num_special_col + 1
           special_col(num_special_col) = c
+       else
+          this%col_plant_pdemand_vr (c,1:nlevdecomp) = 0._r8
        end if
     end do
 
     do fc = 1,num_special_col
        c = special_col(fc)
        this%dwt_ploss(c) = 0._r8
-       this%col_plant_pdemand_vr (c,1:nlevdecomp) = 0._r8
     end do
 
     call this%SetValues (num_column=num_special_col, filter_column=special_col, value_column=0._r8)


### PR DESCRIPTION
By initializing col_plant_pdmeand_vr properly, it fixes
a NaN triggered error of float invalidation when running
ECACNP with DEBUG=TRUE.

[non-BFB]
Fixes #3296 