### PR TITLE
ne120 CMIP6 Historical Transient Compset (A_WCYCL20TRS_CMIP6_HR)

### DIFF
--- a/cime/config/e3sm/allactive/config_compsets.xml
+++ b/cime/config/e3sm/allactive/config_compsets.xml
@@ -69,6 +69,11 @@
   <lname>1950_CAM5%CMIP6-LRtunedHR_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</lname>
 </compset>
 
+<compset>
+  <alias>A_WCYCL20TRS_CMIP6_HR</alias>
+  <lname>20TR_CAM5%CMIP6-HR_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</lname>
+</compset>
+
 <!-- E3SM v1 science compsets -->
 
 <compset>
@@ -127,7 +132,6 @@
   <alias>A_WCYCL1850_H01AS</alias>
   <lname>1850_CAM5%AV1C-H01A_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV</lname>
 </compset>
-
 
 <compset>
   <alias>A_WCYCL20TR_H01A</alias>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6-HR.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20181106.nc</solar_data_file>
+<solar_data_type>SERIAL</solar_data_type>
+
+<!-- GHG values from CMIP6 input4MIPS -->
+<bndtvghg>atm/cam/ggas/GHG_CMIP-1-2-0_Annual_Global_0000-2014_c20181106.nc</bndtvghg>
+<scenario_ghg>RAMPED</scenario_ghg>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_DOE-ACME_radiation_1850-2014_v3_c20171205.nc</prescribed_volcaero_file>
+<prescribed_volcaero_filetype>VOLC_CMIP6</prescribed_volcaero_filetype>
+<prescribed_volcaero_type>SERIAL</prescribed_volcaero_type>
+
+<!-- Sea Surface Temperatures (SST) are specified using SSTICE in config_compsets.xml -->
+
+<!-- Ice nucleation mods-->
+<use_hetfrz_classnuc    >.true.</use_hetfrz_classnuc>
+<use_preexisting_ice    >.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc   >.false.</hist_hetfrz_classnuc>
+<micro_mg_dcs_tdep      >.true.</micro_mg_dcs_tdep>
+<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
+
+<!-- For Polar mods-->
+<sscav_tuning            >.true.</sscav_tuning>
+<convproc_do_aer         >.true.</convproc_do_aer>
+<convproc_do_gas         >.false.</convproc_do_gas>
+<convproc_method_activate>2</convproc_method_activate>
+<demott_ice_nuc          >.true.</demott_ice_nuc>
+<liqcf_fix               >.true.</liqcf_fix>
+<regen_fix               >.true.</regen_fix>
+<resus_fix               >.true.</resus_fix>
+<mam_amicphys_optaa      >1</mam_amicphys_optaa>
+
+<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
+<ssalt_tuning    >.true.</ssalt_tuning>
+
+<!-- For comprehensive history -->
+<history_amwg       >.true.</history_amwg>
+<history_aerosol    >.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- File for BC dep in snow feature -->
+<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
+
+<!-- Radiation bugfix -->
+<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
+
+<!-- Tunable parameters for 72 layer model -->
+
+<ice_sed_ai>         500.0  </ice_sed_ai>
+<clubb_ice_deep>     12.e-6 </clubb_ice_deep>
+<clubb_ice_sh>       50.e-6 </clubb_ice_sh>
+<clubb_liq_deep>     8.e-6  </clubb_liq_deep>  
+<clubb_liq_sh>       10.e-6 </clubb_liq_sh>
+<clubb_C2rt>         1.75D0 </clubb_C2rt>
+<effgw_oro>          0.25    </effgw_oro>
+<seasalt_emis_scale> 0.85   </seasalt_emis_scale>
+<dust_emis_fact>     2.5D0 </dust_emis_fact>
+<clubb_gamma_coef>   0.32   </clubb_gamma_coef>
+<cldfrc2m_rhmaxi>    1.05D0 </cldfrc2m_rhmaxi>
+<clubb_c_K10>        0.3    </clubb_c_K10>
+<effgw_beres>        0.4    </effgw_beres>
+<do_tms>             .false.</do_tms>
+<so4_sz_thresh_icenuc>0.05e-6</so4_sz_thresh_icenuc>
+<n_so4_monolayers_pcage>8.0D0 </n_so4_monolayers_pcage>
+<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
+<zmconv_tiedke_add       >0.8D0</zmconv_tiedke_add>
+<zmconv_cape_cin         >1</zmconv_cape_cin>
+<zmconv_mx_bot_lyr_adj   >2</zmconv_mx_bot_lyr_adj>
+<taubgnd                 >2.5D-3 </taubgnd>
+<clubb_C1                >1.5</clubb_C1>
+<raytau0                 >5.0D0</raytau0>
+<prc_coef1               >30500.0D0</prc_coef1>
+<prc_exp                 >3.19D0</prc_exp>
+<prc_exp1                >-1.2D0</prc_exp1>
+<se_ftype                >2</se_ftype>
+<relvar_fix              >.true.</relvar_fix>
+<mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
+<rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
+
+<!-- Parameters further tuned for ne120 L72 configuration based on AV1C-04P2 -->
+
+<zmconv_alfa         >0.2D0</zmconv_alfa>
+<zmconv_c0_lnd       >0.0035D0</zmconv_c0_lnd>
+<zmconv_c0_ocn       >0.0043D0</zmconv_c0_ocn>
+<zmconv_dmpdz        >-0.2e-3</zmconv_dmpdz>
+<zmconv_ke           >6.0E-6</zmconv_ke>
+<cldfrc_dp1          >0.039D0</cldfrc_dp1>
+<clubb_C8            >4.73D0</clubb_C8>
+<clubb_C14           >1.75D0</clubb_C14>
+<se_nsplit           >6</se_nsplit>
+<rsplit              >2</rsplit>
+<qsplit              >1</qsplit>
+<cld_macmic_num_steps>3</cld_macmic_num_steps>
+
+<!-- Energy fixer options -->
+<ieflx_opt  > 2     </ieflx_opt>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+
+<ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_elev_1850-2014_c20191108.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_soag_elev_1850-2014_c20191108.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_elev_1850-2014_c20191108.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_elev_1850-2014_c20191108.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_elev_1850-2014_c20191108.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_elev_1850-2014_c20191108.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_elev_1850-2014_c20191108.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_elev_1850-2014_c20191108.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_elev_1850-2014_c20191108.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so2_surf_1850-2014_c20191108.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_bc_a4_surf_1850-2014_c20191108.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a1_surf_1850-2014_c20191108.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a2_surf_1850-2014_c20191108.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_num_a4_surf_1850-2014_c20191108.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_pom_a4_surf_1850-2014_c20191108.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a1_surf_1850-2014_c20191108.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne120/cmip6_mam4_so4_a2_surf_1850-2014_c20191108.nc </so4_a2_emis_file>
+
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_type      >SERIAL</chlorine_loading_type>
+<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<!-- <sim_year>1850-2000</sim_year>  ***NOT USED*** -->
+
+</namelist_defaults>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -57,8 +57,8 @@
       <value compset="_CAM5%AV1C-H01B">-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%AV1C-H01C">-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
-      <value compset="_CAM5%CMIP6-HR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
-      <value compset="_CAM5%CMIP6-LR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
+      <value compset="_CAM5%CMIP6-HR" >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
+      <value compset="_CAM5%CMIP6-LR" >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_CAM5%CMIP6-LRtunedHR"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="1950_CAM5%CMIP6-[LH]R"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -cppdefs -DAPPLY_POST_DECK_BUGFIXES -nlev 72</value>
       <value compset="2010_CAM5%CMIP6-[LH]R"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -cppdefs -DAPPLY_POST_DECK_BUGFIXES -nlev 72</value>
@@ -201,9 +201,10 @@
       <value compset="20TR_CAM5.*AV1C-H01A">20TR_cam5_av1c-h01a</value>
       <value compset="20TR_CAM5.*AV1C-H01B">20TR_cam5_av1c-h01b</value>
       <value compset="20TR_CAM5.*AV1C-H01C">20TR_cam5_av1c-h01c</value>
-      <value compset="20TR_CAM5.*CMIP6"  >20TR_cam5_CMIP6</value>
-      <value compset="2010_CAM5.*CMIP6-LR"  >2010_cam5_CMIP6-LR</value>
-      <value compset="2010_CAM5.*CMIP6-HR"  >2010_cam5_CMIP6-HR</value>
+      <value compset="20TR_CAM5.*CMIP6"    >20TR_cam5_CMIP6</value>
+      <value compset="20TR_CAM5.*CMIP6-HR" >20TR_cam5_CMIP6-HR</value>
+      <value compset="2010_CAM5.*CMIP6-LR" >2010_cam5_CMIP6-LR</value>
+      <value compset="2010_CAM5.*CMIP6-HR" >2010_cam5_CMIP6-HR</value>
       <value compset="20TR_CAM5.*CMIP6*_BGC%B"  >20TR_cam5_CMIP6_bgc</value>
       <value compset="SSP585_CAM5.*CMIP6"  >SSP585_cam5_CMIP6</value>          <!-- PJC -->
       <value compset="2000_CAM5%COSP"   >2000_cam5_cosp</value>

--- a/components/clm/bld/namelist_files/use_cases/20thC_CMIP6HR_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/20thC_CMIP6HR_transient.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc                 >Simulate ne120 transient land-use, and aerosol deposition changes from 1850 to 2014</use_case_desc>
+<use_case_desc bgc="cn"        >Simulate ne120 transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2014</use_case_desc>
+<use_case_desc bgc="cndv"      >Simulate ne120 transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2014</use_case_desc>
+<use_case_desc use_cn=".true." >Simulate ne120 transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2014</use_case_desc>
+
+<!-- sim_year is not used 
+<sim_year>1955</sim_year>
+<sim_year_range>1850-2000</sim_year_range>
+-->
+
+
+<clm_start_type>arb_ic</clm_start_type>
+
+<clm_demand >flanduse_timeseries</clm_demand>
+
+<!-- ndep, pdep, and popdens are not used for watercycle configuration
+<stream_year_first_ndep phys="clm4_5" use_cn=".true."   >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true."   >2005</stream_year_last_ndep>
+<model_year_align_ndep  phys="clm4_5" use_cn=".true."   >1850</model_year_align_ndep>
+
+<stream_year_first_pdep phys="clm4_5" use_cn=".true."   >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="clm4_5" use_cn=".true."   >2000</stream_year_last_pdep>
+<model_year_align_pdep  phys="clm4_5" use_cn=".true."   >2000</model_year_align_pdep>
+
+<stream_year_first_popdens phys="clm4_5" use_cn=".true."   >1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5" use_cn=".true."   >2010</stream_year_last_popdens>
+<model_year_align_popdens  phys="clm4_5" use_cn=".true."   >1850</model_year_align_popdens>
+-->
+
+
+<!-- CMIP6 DECK compsets -->
+
+<!-- CMIP6 HighResMIP compsets -->
+<fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr1850_c190904.nc </fsurdat>
+<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/theta.20180906.branch_noCNT.A_WCYCL1950S_CMIP6_HR.ne120_oRRS18v3_ICG.clm2.r.0056-01-01-00000.nc </finidat>
+<flanduse_timeseries hgrid="ne120np4">lnd/clm2/surfdata_map/landuse.timeseries_ne120np4_historical_simyr1850-2015_c190904.nc</flanduse_timeseries>
+
+
+<!-- ELM Consistency Checks -->
+<check_finidat_year_consistency>.false.</check_finidat_year_consistency>
+
+<!-- NOTE: When using initial condiditions from another simulation, it may be necessary to add the following to the user_nl_clm: -->
+<!-- check_dynpft_consistency          = .false. -->
+<!-- check_finidat_fsurdat_consistency = .false. -->
+
+
+</namelist_defaults>

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -26,6 +26,7 @@
       <value compset="_CLM45%[^_]*BC" >-phys clm4_5 -cppdefs -DMODAL_AER</value>
       <value compset="1950_CAM5%CMIP6-[LH]R[^_]*_CLM45%[^_]*BC"                >-phys clm4_5 -cppdefs '-DMODAL_AER -DAPPLY_POST_DECK_BUGFIXES'</value>
       <value compset="2010_CAM5%CMIP6-[LH]R[^_]*_CLM45%[^_]*BC"                >-phys clm4_5 -cppdefs '-DMODAL_AER -DAPPLY_POST_DECK_BUGFIXES'</value>
+      <value compset="20TR_CAM5%CMIP6-[LH]R[^_]*_CLM45%[^_]*BC"                >-phys clm4_5 -cppdefs '-DMODAL_AER -DAPPLY_POST_DECK_BUGFIXES'</value>
     </values>
     <group>build_component_clm</group>
     <file>env_build.xml</file>
@@ -83,6 +84,7 @@
       <value compset="1950_CAM5%CMIP6-HR_CLM">1950_CMIP6HR_control</value>
       <value compset="2010_CAM5%CMIP6-LR_CLM">2010_CMIP6LR_control</value>
       <value compset="2010_CAM5%CMIP6-HR_CLM">2010_CMIP6HR_control</value>
+      <value compset="20TR_CAM5%CMIP6-HR_CLM">20thC_CMIP6HR_transient</value>
       <value compset="SSP585_CAM5%CMIP6_CLM">2015-2100_SSP585_transient</value>
     </values>
     <group>run_component_clm</group>


### PR DESCRIPTION
This commit implements the hi-res (ne120) compset
A_WCYCL20TRS_CMIP6_HR for historical transient CMIP6 simulations.
The compset covers 1850-2014.

[BFB, except for the A_WCYCL20TRS_CMIP6_HR compset]