### PR TITLE
Initialize SH_FLXPRC/SH_FLXSNW arrays for shallow convection

### DIFF
--- a/components/cam/src/physics/cam/convect_shallow.F90
+++ b/components/cam/src/physics/cam/convect_shallow.F90
@@ -631,6 +631,12 @@ end subroutine convect_shallow_init_cnst
       evapcsh     = 0._r8
       snow        = 0._r8
 
+      call pbuf_get_field(pbuf, sh_flxprc_idx, flxprec)
+      call pbuf_get_field(pbuf, sh_flxsnw_idx, flxsnow)
+
+      flxprec(:ncol,:) = 0._r8
+      flxsnow(:ncol,:) = 0._r8
+
    case('Hack') ! Hack scheme
                                    
       lq(:) = .TRUE.


### PR DESCRIPTION
When shallow convection scheme is 'off' or 'CLUBB_SGS',
SH_FLXPRC/SH_FLXSNW arrays should be initialized to
avoid possible NaNs in debug runs.

[BFB]
Fixes #3317