### PR TITLE
Init qrl_idx to 0.0 in first step 

### DIFF
--- a/components/cam/src/physics/cam/clubb_intr.F90
+++ b/components/cam/src/physics/cam/clubb_intr.F90
@@ -925,6 +925,7 @@ end subroutine clubb_init_cnst
        call pbuf_set_field(pbuf2d, kvh_idx,     0.0_r8)
        call pbuf_set_field(pbuf2d, fice_idx,    0.0_r8)
        call pbuf_set_field(pbuf2d, radf_idx,    0.0_r8)
+       call pbuf_set_field(pbuf2d, qrl_idx,     0.0_r8)
 
        call pbuf_set_field(pbuf2d, vmag_gust_idx,    1.0_r8)
 


### PR DESCRIPTION
Add one line (in clubb_intr.F90) that initializes array qrl_idx on the first step.

`call pbuf_set_field(pbuf2d, qrl_idx,     0.0_r8)`

Fixes #3142 
Fixes #3061 

[BFB]