### PR TITLE
Update northamericax4v1 settings

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -2257,10 +2257,8 @@
       <ny>1440</ny>
       <file grid="atm" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_oEC60to30v3.190812.nc</file>
       <file grid="lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_oEC60to30v3.190812.nc</file>
-      <file grid="atm" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_oRRS15to5.191022.nc</file>
-      <file grid="lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_oRRS15to5.191022.nc</file>
-      <!--file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_gx1v6.191017.nc</file-->
-      <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_gx1v6.191113.nc</file>
+      <file grid="lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_oRRS15to5.191122.nc</file>
+      <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_gx1v6.191017.nc</file>
       <desc>r0125 is 1/8 degree river routing grid:</desc>
     </domain>
 

--- a/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/cime/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1400,6 +1400,7 @@
     </desc>
     <values>
       <value>$EPS_AGRID</value>
+      <value atm_grid="ne0np4_northamericax4v1">3.e-10</value>
     </values>
   </entry>
 

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6_control.xml
@@ -20,5 +20,6 @@
 <!-- CMIP6 DECK compsets -->
 <fsurdat hgrid="ne30np4" >lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2010_c20181025.nc </fsurdat>
 <finidat hgrid="ne30np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC.edison.clm2.r.2010-01-01-00000.nc </finidat>
+<fsurdat hgrid="r0125" >lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr2010_c191025.nc </fsurdat>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6_control.xml
@@ -20,6 +20,5 @@
 <!-- CMIP6 DECK compsets -->
 <fsurdat hgrid="ne30np4" >lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2010_c20181025.nc </fsurdat>
 <finidat hgrid="ne30np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC.edison.clm2.r.2010-01-01-00000.nc </finidat>
-<fsurdat hgrid="r0125" >lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr2010_c191025.nc </fsurdat>
 
 </namelist_defaults>


### PR DESCRIPTION
Some of the North America RRM settings need to be updated. In particular, the old land domain file is created with the bad overlap mesh file. This PR updates it to the correct file. 
Also preset the EPS_AGRID threshold for this RRM grid.
    
[BFB] except for northamericax4v1
[NML] no change except for northamericax4v1