### PR TITLE
Turn off O3 dry deposition in F2010SC5-CMIP6 compset

### DIFF
--- a/components/cam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
@@ -153,6 +153,9 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
+
 <!-- sim_year used for CLM datasets -->
 <sim_year>2015</sim_year>
 


### PR DESCRIPTION
The F2010SC5-CMIP6 compset was added to master from maint-1.0 after O3v2 was added in master. We need to turn off ozone dry deposition to make this compset work correctly with O3v2.

[Non-BFB] - Non Bit-For-Bit