### PR TITLE
Fixes F compsets to support ne4np4

### DIFF
--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -140,6 +140,12 @@ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICRUCLM45.ne16_oQU240.1155ba0.clm2.r.nc
 </finidat>
 
+<!-- HOMME grid ne30 resolution -->
+
+<finidat hgrid="ne30np4"   maxpft="17"  mask="gx1v6" use_cn=".false." ic_ymd="20150101" more_vertlayers=".false."
+ic_tod="0" sim_year="2015" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC.edison.clm2.r.2010-01-01-00000.nc
+</finidat>
+
 <!-- HOMME grid ne120 resolution -->
 
 <finidat hgrid="ne120np4"   maxpft="17"  mask="gx1v6" use_cn=".false." ic_ymd="18500101" more_vertlayers=".false."
@@ -250,6 +256,11 @@ lnd/clm2/surfdata_map/surfdata_1x1_vancouverCAN_simyr2000_c130927.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_1x1_mexicocityMEX_simyr2000_c130927.nc</fsurdat>
 <fsurdat hgrid="1x1_urbanc_alpha"    sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_1x1_urbanc_alpha_simyr2000_c130927.nc</fsurdat>
+
+<fsurdat hgrid="ne30np4" sim_year="2015" use_crop=".false.">
+lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2010_c20181025.nc</fsurdat>
+<fsurdat hgrid="ne4np4" sim_year="2015" use_crop=".false.">
+lnd/clm2/surfdata_map/surfdata_ne4np4_simyr2000_c160614.nc</fsurdat>
 
 <!-- for pre-industrial simulations - year 1850 -->
 <fsurdat hgrid="360x720cru"   sim_year="1850" use_crop=".false."                           >

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -172,6 +172,10 @@ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICRUCLM45.ne120_oRRS18v3.be55494.clm2.r.nc
 </finidat>
 
+<finidat hgrid="ne120np4"   maxpft="17"  mask="gx1v6" use_cn=".false." ic_ymd="20150101" more_vertlayers=".false."
+ic_tod="0" sim_year="2015" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/cori-knl.20190214_maint-1.0.F2010-CMIP6-HR.noCNT.ARE.nudgeUV.ne120_oRRS18v3.clm2.r.2011-01-01-00000.nc
+</finidat>
+
 <!-- HOMME grid ne240 resolution -->
 <finidat hgrid="ne240np4"   maxpft="17"  mask="tx0.1v2" use_cn=".false." ic_ymd="18500101" more_vertlayers=".false."
 ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.I1850CLM45.0521-01-01.ne240np4_tx0.1v2.162cd32_simyr1850_c170910.nc
@@ -199,6 +203,14 @@ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".true." irrigate=".true." nu_co
 <finidat hgrid="ne0np4_conus_x4v1_lowcon" ic_ymd="101" sim_year="2000">lnd/clm2/initdata_map/clmi.ICRUCLM45.0021-01-01.conusx4v1.0ac6464_simyr2000_c161130.nc</finidat>
 <finidat hgrid="ne0np4_enax4v1" sim_year="2000">lnd/clm2/initdata_map/clmi.ICRUCLM45SP.2000-01-01.enax4v1_oRRS18to6_simyr2000_c170621.nc</finidat>
 <finidat hgrid="ne0np4_twpx4v1" ic_ymd="101" sim_year="2000">lnd/clm2/initdata_map/clmi.ICRUCLM45SP.2000-01-01.twpx4v1_oRRS18to6v3_simyr2000_c170712.nc</finidat>
+
+<!-- for present day simulations - year 1950 -->
+<fsurdat hgrid="ne120np4"     sim_year="1950" >
+lnd/clm2/surfdata_map/surfdata_ne120np4_simyr1950_c20180108.nc</fsurdat>
+
+<!-- for present day simulations - year 2015 -->
+<fsurdat hgrid="ne120np4"     sim_year="2015" >
+lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc</fsurdat>
 
 <!-- for present day simulations - year 2000 -->
 <fsurdat hgrid="360x720cru"   sim_year="2000" use_crop=".false." >
@@ -282,7 +294,7 @@ lnd/clm2/surfdata_map/surfdata_1x1_brazil_simyr1850_c140610.nc</fsurdat>
 
 
 <fsurdat hgrid="ne30np4"      sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_c180306.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc</fsurdat>
 <fsurdat hgrid="ne16np4"      sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne16np4_simyr1850_c160108.nc</fsurdat>
 <fsurdat hgrid="ne120np4"     sim_year="1850" >
@@ -345,7 +357,7 @@ lnd/clm2/surfdata_map/surfdata_twpx4v1_simyr2000_c170706.nc</fsurdat>
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_1x1_brazil_rcp8.5_simyr1850-2100_c140610.nc</flanduse_timeseries>
 
 <flanduse_timeseries hgrid="ne30np4"       sim_year_range="1850-2000" 
- use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850-2015_c180306.nc</flanduse_timeseries>
+ use_crop=".false."  >landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc</flanduse_timeseries>
 <flanduse_timeseries hgrid="ne16np4" sim_year_range="1850-2000"
  use_crop=".false."  >lnd/clm2/surfdata_map/surfdata.pftdyn_ne16np4_hist_simyr1850-2005_c160803.nc</flanduse_timeseries>
 <flanduse_timeseries hgrid="ne11np4" sim_year_range="1850-2000"

--- a/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
@@ -31,8 +31,6 @@
 
 <!-- CMIP6 DECK compsets -->
       
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
-<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
 <finidat mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/1850_CMIP6bgc_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_CMIP6bgc_control.xml
@@ -31,6 +31,5 @@
 
 <!-- CMIP6 DECK compsets -->
       
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_SCMIP6_control.xml
@@ -31,8 +31,6 @@
 
 <!-- CMIP6 DECK compsets -->
       
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
-<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
 <finidat mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
 <check_finidat_year_consistency>.false.</check_finidat_year_consistency>
 

--- a/components/clm/bld/namelist_files/use_cases/1950_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1950_CMIP6HR_control.xml
@@ -18,7 +18,6 @@
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >1955</stream_year_last_popdens>
 
 <!-- CMIP6 HighResMIP compsets -->
-<fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr1950_c20180108.nc </fsurdat>
 <finidat hgrid="ne120np4" >lnd/clm2/initdata_map/clmi.A_WCYCL1950.ne120np4_oRRS18to6v3_ICG_simyr1950_c20180124.nc </finidat>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6HR_control.xml
@@ -18,8 +18,6 @@
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_popdens>
 
 <!-- CMIP6 HighResMIP compsets -->
-<fsurdat hgrid="ne120np4" >lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc </fsurdat>
-<finidat hgrid="ne120np4" >lnd/clm2/initdata_map/cori-knl.20190214_maint-1.0.F2010-CMIP6-HR.noCNT.ARE.nudgeUV.ne120_oRRS18v3.clm2.r.2011-01-01-00000.nc </finidat>
 <check_finidat_pct_consistency>.false.</check_finidat_pct_consistency>
 
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2010_CMIP6LR_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/2010_CMIP6LR_control.xml
@@ -17,8 +17,4 @@
 <stream_year_first_popdens phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" use_cn=".true." ndepsrc="stream" >2015</stream_year_last_popdens>
 
-<!-- CMIP6 DECK compsets -->
-<fsurdat hgrid="ne30np4" >lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2010_c20181025.nc </fsurdat>
-<finidat hgrid="ne30np4" >lnd/clm2/initdata_map/20180716.DECKv1b_A3.ne30_oEC.edison.clm2.r.2010-01-01-00000.nc </finidat>
-
 </namelist_defaults>

--- a/components/clm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -32,7 +32,6 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_ssp5_rcp8.5_simyr2015-2100_c190411.nc</flanduse_timeseries>
 <finidat>lnd/clm2/initdata_map/20180215.DECKv1b_H1.ne30_oEC.edison.clm2.r.2015-01-01-00000.nc</finidat>
 <check_finidat_year_consistency>.true.</check_finidat_year_consistency>

--- a/components/clm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -45,7 +45,6 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_2015_c20171018.nc</flanduse_timeseries>
 <finidat mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc</finidat>
 <check_finidat_year_consistency>.false.</check_finidat_year_consistency>

--- a/components/clm/bld/namelist_files/use_cases/20thC_CMIP6bgc_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/20thC_CMIP6bgc_transient.xml
@@ -45,7 +45,6 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
 
 </namelist_defaults>


### PR DESCRIPTION
Fixes F1850SC5-CMIP6, F2010C5-CMIP6-HR and F2010C5-CMIP6-LR.
Moves the definition of fsurdat and finidat from use_cases namelist to
land model default namelist

[BFB]