### PR TITLE
Fix F2010SC5-CMIP6.northamericax4v1_r0125_northamericax4v1

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -2763,6 +2763,11 @@
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/r0125/map_r0125_to_northamericax4v1_mono.20191022.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne0np4_northamericax4v1" rof_grid="r0125">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1_to_r0125_mono.20191022.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1_to_r0125_mono.20191022.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="T62" ocn_grid="gx3v7">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_gx3v7_aave.130322.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_gx3v7_blin.130322.nc</map>

--- a/cime/src/drivers/mct/main/cime_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cime_comp_mod.F90
@@ -1588,7 +1588,7 @@ contains
 
     if (atm_present) then
        if (lnd_prognostic) atm_c2_lnd = .true.
-       if (rof_prognostic) atm_c2_rof = .true.
+       if (rof_prognostic .and. (.not. atm_prognostic)) atm_c2_rof = .true.
        if (ocn_prognostic) atm_c2_ocn = .true.
        if (ocn_present   ) atm_c2_ocn = .true. ! needed for aoflux calc if aoflux=ocn
        if (ice_prognostic) atm_c2_ice = .true.

--- a/cime/src/drivers/mct/main/cime_comp_mod.F90
+++ b/cime/src/drivers/mct/main/cime_comp_mod.F90
@@ -1588,7 +1588,7 @@ contains
 
     if (atm_present) then
        if (lnd_prognostic) atm_c2_lnd = .true.
-       if (rof_prognostic .and. (.not. atm_prognostic)) atm_c2_rof = .true.
+       if (rof_prognostic) atm_c2_rof = .true.
        if (ocn_prognostic) atm_c2_ocn = .true.
        if (ocn_present   ) atm_c2_ocn = .true. ! needed for aoflux calc if aoflux=ocn
        if (ice_prognostic) atm_c2_ice = .true.


### PR DESCRIPTION
The fix includes two parts: 1) adding ATM2ROF maps between the northamericax4v1 atm grid and the r0125 land grid; 2) turn off atm_c2_rof coupling when atm_prognostic is true.