### PR TITLE
Fixes IC for BGC test for CMIP6 compset

### DIFF
--- a/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
+++ b/components/clm/bld/namelist_files/use_cases/1850_CMIP6_control.xml
@@ -33,6 +33,6 @@
       
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_2015_c171018.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_c20171102.nc </flanduse_timeseries>
-<finidat mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
+<finidat use_cn=".false." mask="oEC60to30v3">lnd/clm2/initdata_map/I1850CLM45.ne30_oECv3.edison.intel.36b43c9.clm2.r.0001-01-06-00000_c20171023.nc </finidat>
 
 </namelist_defaults>


### PR DESCRIPTION
The SMS.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850 test was using an incorrect
land initial condition, which corresponded to SP mode. Now the test
does a cold start in the land model.

Fixes #3272
[BFB]