### PR TITLE
fix python rounding issue

### DIFF
--- a/cime/scripts/lib/CIME/XML/env_batch.py
+++ b/cime/scripts/lib/CIME/XML/env_batch.py
@@ -417,7 +417,7 @@ class EnvBatch(EnvBase):
 
                     # We don't want floating-point data
                     try:
-                        rval = round(float(rval))
+                        rval = int(round(float(rval)))
                     except ValueError:
                         pass
 


### PR DESCRIPTION
Fixes issue #3342  
round() returns an integer for python3 and a float
for python2, this forces an integer for either case
