### PR TITLE
Add ATM2ROF maps for ne120np4 to r0125

### DIFF
--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -3034,6 +3034,11 @@
       <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/360x720/map_360x720_nomask_to_0.5x0.5_nomask_aave_da_c130103.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne120np4" rof_grid="r0125">
+      <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_ne120np4_to_0.125_nomask_aave.160613.nc</map>
+      <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_ne120np4_to_0.125_nomask_aave.160613.nc</map>
+    </gridmap>
+
     <!--  QL, 150525, wav to ocn, atm, ice mapping files  -->
 
     <gridmap ocn_grid="gx3v7" wav_grid="ww3a">


### PR DESCRIPTION
This PR adds ATM2ROF mapping files for high-res configurations with ne120np4 and r0125, to fix issues with missing mapping files required by mosart-heat.

Fixes: #3343

[NML] for ne120np4 B-cases
[BFB] 
