### PR TITLE
Fix Depends-file usage for legacy build system

### DIFF
--- a/cime/scripts/lib/CIME/BuildTools/configure.py
+++ b/cime/scripts/lib/CIME/BuildTools/configure.py
@@ -64,10 +64,11 @@ def _copy_depends_files(machine_name, machines_dir, output_dir, compiler):
             basename = "Depends.{}{}".format(suffix, extra_suffix)
             dfile = os.path.join(machines_dir, basename)
             outputdfile = os.path.join(output_dir, basename)
-            if os.path.isfile(dfile) and not os.path.exists(outputdfile):
-                safe_copy(dfile, outputdfile)
+            if os.path.isfile(dfile):
                 if suffix == both and extra_suffix == "":
                     makefiles_done = True
+                if not os.path.exists(outputdfile):
+                    safe_copy(dfile, outputdfile)
 
 class FakeCase(object):
 

--- a/cime/scripts/lib/CIME/BuildTools/configure.py
+++ b/cime/scripts/lib/CIME/BuildTools/configure.py
@@ -53,13 +53,21 @@ def _copy_depends_files(machine_name, machines_dir, output_dir, compiler):
     Copy any system or compiler Depends files if they do not exist in the output directory
     If there is a match for Depends.machine_name.compiler copy that and ignore the others
     """
-    for suffix in [machine_name, compiler, "{}.{}".format(machine_name, compiler)]:
+    # Note, the cmake build system does not stop if Depends.mach.compiler.cmake is found
+    makefiles_done = False
+    both = "{}.{}".format(machine_name, compiler)
+    for suffix in [both, machine_name, compiler]:
         for extra_suffix in ["", ".cmake"]:
+            if extra_suffix == "" and makefiles_done:
+                continue
+
             basename = "Depends.{}{}".format(suffix, extra_suffix)
             dfile = os.path.join(machines_dir, basename)
             outputdfile = os.path.join(output_dir, basename)
             if os.path.isfile(dfile) and not os.path.exists(outputdfile):
                 safe_copy(dfile, outputdfile)
+                if suffix == both and extra_suffix == "":
+                    makefiles_done = True
 
 class FakeCase(object):
 


### PR DESCRIPTION
The legacy system only used the Depends.mach.compiler file if
it existed. The Cmake system does not work that way and changes
were implemented that caused all matching Depends files to be
used in both build systems.

This commit restores the legacy behavior to the legacy system.

[BFB]