### PR TITLE
Clean up use of LDFLAGS in config_compilers.xml

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -6,15 +6,13 @@ This file defines compiler flags for building CIME.  General flags are listed fi
 followed by flags specific to particular operating systems, followed by particular machines.
 
 More general flags are replaced by more specific flags.
-Flags of the sort ADD_FLAG indicate that the field should be appended to an already existing FLAG definition.
+Flags of the sort <append> indicate that the field should be appended to an already existing FLAG definition.
 
 Attributes indicate that an if clause should be added to the Macros so that these flags are added
 only under the conditions described by the attribute(s).
 
 The env_mach_specific file may set environment variables or load modules which set environment variables
 which are then  used in the Makefile.   For example the NETCDF_PATH on many machines is set by a module.
-
-Do not use variables CPPDEFS and SLIBS here, instead use ADD_CPPDEFS and ADD_SLIBS
 
 ========================================================================
  Serial/MPI compiler specification
@@ -67,8 +65,8 @@ a C++ linker. If CXX_LINKER=FORTRAN, then the above CXX_LDFLAGS line
 should specify extra LDFLAGS needed when linking C++ and fortran code
 using a fortran linker.
 
-These should NOT be specified via <ADD_SLIBS USE_CXX="true"> or
-<ADD_LDFLAGS USE_CXX="true">, because those mess up the configure step
+These should NOT be specified via <SLIBS> <append USE_CXX="true"> or
+<LDFLAGS> <append USE_CXX="true">, because those mess up the configure step
 for mct, etc.
 
 ========================================================================
@@ -287,12 +285,6 @@ flags should be captured within MPAS CMake files.
   <FFLAGS>
     <base>  -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source </base>
     <append compile_threaded="TRUE"> -qopenmp </append>
-    <!-- WJS (8-11-14): For some reason, yellowstone-intel has starting giving lots of
-       messages about array temporaries, leading to a ton of standard output, and
-       sometimes causing runs to die. Adding '-check noarg_temp_created' to suppress these
-       diagnostics. This is a band-aid fix, which should really be addressed at the
-       system-level. (Note: I could not add this in the yellowstone-specific section,
-       beacuse apparently that overrides rather than adds to this ADD_FFLAGS list.) -->
     <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
     <append DEBUG="FALSE"> -O2 -debug minimal </append>
   </FFLAGS>
@@ -984,9 +976,11 @@ flags should be captured within MPAS CMake files.
   <LAPACK_LIBDIR>/software/tools/compilers/intel_2017/mkl/lib/intel64</LAPACK_LIBDIR>
   <LDFLAGS>
     <append compile_threaded="TRUE"> -fopenmp </append>
-    <append COMP_CLASS="cpl"> -L$NETCDF_PATH/lib -Wl,-rpath=$NETCDF_PATH/lib -lnetcdff -lnetcdf </append>
     <!-- <append COMP_CLASS="cpl"> -L$ENV{CLM_PFLOTRAN_SOURCE_DIR} -lpflotran $ENV{PETSC_LIB} </append> -->
   </LDFLAGS>
+  <SLIBS>
+    <append> -L$NETCDF_PATH/lib -Wl,-rpath=$NETCDF_PATH/lib -lnetcdff -lnetcdf </append>
+  </SLIBS>
   <MPICC>mpicc</MPICC>
   <MPICXX>mpic++</MPICXX>
   <MPIFC>mpif90</MPIFC>
@@ -1021,17 +1015,9 @@ flags should be captured within MPAS CMake files.
     <append> -DnoI8 </append>
   </CPPDEFS>
   <FFLAGS>
-    <!--  -C=Undefined flag doesn't work as it requires MPI and NETCDF to be
-      compiled with this flag, which is not available now. NAG has the following debug flags
-      <ADD_FFLAGS DEBUG="TRUE">  -gline  -C=all  -g  -C=undefined -C=recursion -nan -O0 -v  </ADD_FFLAGS>
-      "-nan" is an important flag. currently, it doesn't work for pio, it is only used for "cam" model.
- -->
     <append DEBUG="TRUE">  -C=all  -g  -O0 -v  </append>
     <append DEBUG="TRUE" COMP_NAME="cam">  -C=all  -g  -nan -O0 -v  </append>
   </FFLAGS>
-  <LDFLAGS>
-    <append compile_threaded="TRUE">  </append>
-  </LDFLAGS>
   <MPI_PATH MPILIB="mvapich2"> $ENV{MPI_LIB}</MPI_PATH>
   <NETCDF_PATH>$ENV{NETCDF_ROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
@@ -1183,9 +1169,9 @@ flags should be captured within MPAS CMake files.
   <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH>$ENV{PNETCDF_HOME}</PNETCDF_PATH>
-  <LDFLAGS>
+  <SLIBS>
     <append> -lpmi -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH}/lib/intel64/ -lmkl_rt $ENV{PNETCDF_LIBRARIES} </append>
-  </LDFLAGS>
+  </SLIBS>
   <MPICC  MPILIB="impi">mpipgcc</MPICC>
   <MPICXX MPILIB="impi">mpipgcxx</MPICXX>
   <MPIFC  MPILIB="impi">mpipgf90</MPIFC>
@@ -1403,7 +1389,6 @@ flags should be captured within MPAS CMake files.
   </FREEFLAGS>
   <LDFLAGS>
     <append compile_threaded="TRUE"> -openmp </append>
-    <append> -lnetcdff </append>
   </LDFLAGS>
   <MPICC> mpiicc  </MPICC>
   <MPICXX> mpiicpc </MPICXX>
@@ -1541,12 +1526,9 @@ flags should be captured within MPAS CMake files.
   <CXXFLAGS>
     <append>-expt-extended-lambda -DCUDA_BUILD</append>
   </CXXFLAGS>
-  <LDFLAGS>
-    <append> -lstdc++ -lcudart </append>
-  </LDFLAGS>
   <NETCDF_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_PATH>
   <SLIBS>
-    <append>$SHELL{$NETCDF_PATH/bin/nf-config --flibs} -lblas -llapack</append>
+    <append>$SHELL{$NETCDF_PATH/bin/nf-config --flibs} -lblas -llapack -lcudart -lstdc++</append>
   </SLIBS>
 </compiler>
 
@@ -1574,7 +1556,7 @@ flags should be captured within MPAS CMake files.
   <LDFLAGS>
     <base> -mkl -lstdc++ </base>
     <append compile_threaded="TRUE"> -qopenmp </append>
-    <append COMP_CLASS="cpl">-L$(NETCDF_FORTRAN_PATH)/lib64</append>
+    <append>-L$(NETCDF_FORTRAN_PATH)/lib64</append>
   </LDFLAGS>
   <FIXEDFLAGS>
     <base> -fixed -132 </base>
@@ -1795,7 +1777,6 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
 
 <compiler MACH="stampede2" COMPILER="intel">
   <CFLAGS>
-    <!--ADD_FFLAGS DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align -qopt-zmm-usage=high</ADD_FFLAGS-->
     <append> -xCORE-AVX2 </append>
   </CFLAGS>
   <CONFIG_ARGS>
@@ -1809,8 +1790,6 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <FFLAGS>
     <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml </base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align</append>
-    <!--ADD_FFLAGS> -xCORE-AVX512 </ADD_FFLAGS-->
-    <!--ADD_CFLAGS> -xCORE-AVX512 </ADD_CFLAGS-->
     <append> -xCORE-AVX2 </append>
   </FFLAGS>
   <HDF5_PATH>$ENV{TACC_HDF5_DIR}</HDF5_PATH>
@@ -1842,10 +1821,10 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <LDFLAGS>
+  <SLIBS>
     <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
     <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 </append>
-  </LDFLAGS>
+  </SLIBS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>
   <MPIFC> mpif90 </MPIFC>
@@ -1869,11 +1848,11 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <append> -qzerosize -qfree=f90 -qxlf2003=polymorphic</append>
     <append> -qspillsize=2500 -qextname=flush </append>
   </FFLAGS>
-  <LDFLAGS>
+  <SLIBS>
     <append>-lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
     <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 </append>
     <append>  -Wl,--relax -Wl,--allow-multiple-definition </append>
-  </LDFLAGS>
+  </SLIBS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>
   <MPIFC> mpif90 </MPIFC>
@@ -1896,10 +1875,10 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 -DSUMMITDEV_PGI </append>
   </FFLAGS>
-  <LDFLAGS>
+  <SLIBS>
     <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
     <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 </append>
-  </LDFLAGS>
+  </SLIBS>
   <CXX_LINKER>FORTRAN</CXX_LINKER>
   <CXX_LIBS>
     <base>-lstdc++</base>
@@ -1938,9 +1917,11 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <KOKKOS_OPTIONS> --arch=Power9,Volta70 --with-cuda=$ENV{CUDA_DIR} --with-cuda-options=enable_lambda</KOKKOS_OPTIONS>
   <LDFLAGS>
     <append>-ta=tesla:cc70,pinned</append>
+  </LDFLAGS>
+  <SLIBS>
     <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
     <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 </append>
-  </LDFLAGS>
+  </SLIBS>
   <CXX_LINKER>FORTRAN</CXX_LINKER>
   <CXX_LIBS>
     <base>-lstdc++</base>
@@ -1963,9 +1944,9 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <FFLAGS>
     <append> -qzerosize -qfree=f90 -qxlf2003=polymorphic</append>
   </FFLAGS>
-  <LDFLAGS>
+  <SLIBS>
     <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib64 -llapack</append>
-  </LDFLAGS>
+  </SLIBS>
   <MPICC> mpixlc </MPICC>
   <MPICXX> mpixlC </MPICXX>
   <MPIFC> mpixlf </MPIFC>
@@ -1984,9 +1965,9 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 -DSUMMITDEV_PGI </append>
   </FFLAGS>
-  <LDFLAGS>
+  <SLIBS>
     <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
-  </LDFLAGS>
+  </SLIBS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>
   <MPIFC> mpif90 </MPIFC>
@@ -2008,8 +1989,10 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <LDFLAGS>
     <!-- Specifying cc60 implies cuda8.0, just making sure -->
     <append>-ta=tesla:cc60,cuda8.0,pinned</append>
-    <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
   </LDFLAGS>
+  <SLIBS>
+    <append>-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
+  </SLIBS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>
   <MPIFC> mpif90 </MPIFC>
@@ -2032,9 +2015,9 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <append DEBUG="FALSE"> -O2 </append>
     <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </append>
   </FFLAGS>
-  <LDFLAGS>
+  <SLIBS>
     <append> -llapack -lblas</append>
-  </LDFLAGS>
+  </SLIBS>
   <MPI_LIB_NAME> mpich</MPI_LIB_NAME>
   <MPI_PATH>/usr/tce/packages/mvapich2/mvapich2-2.2-intel-18.0.1/</MPI_PATH>
   <NETCDF_PATH>/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-18.0.1/</NETCDF_PATH>
@@ -2057,9 +2040,9 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <append DEBUG="FALSE"> -O2 </append>
     <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </append>
   </FFLAGS>
-  <LDFLAGS>
+  <SLIBS>
     <append> -llapack -lblas</append>
-  </LDFLAGS>
+  </SLIBS>
   <MPI_LIB_NAME> mpich</MPI_LIB_NAME>
   <MPI_PATH>/usr/tce/packages/mvapich2/mvapich2-2.2-intel-18.0.1/</MPI_PATH>
   <NETCDF_PATH>/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-18.0.1/</NETCDF_PATH>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1848,10 +1848,12 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <append> -qzerosize -qfree=f90 -qxlf2003=polymorphic</append>
     <append> -qspillsize=2500 -qextname=flush </append>
   </FFLAGS>
+  <LDFLAGS>
+    <append>  -Wl,--relax -Wl,--allow-multiple-definition </append>
+  </LDFLAGS>
   <SLIBS>
     <append>-lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
     <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 </append>
-    <append>  -Wl,--relax -Wl,--allow-multiple-definition </append>
   </SLIBS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>


### PR DESCRIPTION
LDFLAGS should be used for adding general linker flags.

SLIBS should be used for adding libs to be linked.

Fixes #3356 

[BFB]