### PR TITLE
Change all ocean output files to single precision

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -641,6 +641,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="eddyProductVariablesOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         if ocn_grid.startswith("oRRS1"):
             lines.append('        io_type="pnetcdf,cdf5"')
         else:
@@ -663,6 +664,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="highFrequencyOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.highFrequencyOutput.$Y-$M-$D_$h.$m.$s.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')
@@ -710,6 +712,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="mixedLayerDepthsOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.mixedLayerDepths.$Y-$M-$D.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')
@@ -726,6 +729,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsDailyOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.timeSeriesStatsDaily.$Y-$M-$D.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')
@@ -775,6 +779,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsMonthlyOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         if ocn_grid.startswith("oRRS1"):
             lines.append('        io_type="pnetcdf,cdf5"')
         else:
@@ -973,6 +978,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsMonthlyMaxOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         if ocn_grid.startswith("oRRS1"):
             lines.append('        io_type="pnetcdf,cdf5"')
         else:
@@ -1024,6 +1030,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsMonthlyMinOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         if ocn_grid.startswith("oRRS1"):
             lines.append('        io_type="pnetcdf,cdf5"')
         else:
@@ -1075,6 +1082,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsClimatologyOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.timeSeriesStatsClimatology.$Y-$M-$D.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')
@@ -1088,6 +1096,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsCustomOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.timeSeriesStatsCustom.$Y-$M-$D.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')


### PR DESCRIPTION
Currently, all MPAS-Ocean output files are double precision. This is simply not needed, and doubles file space and write time. I added the single line to specify single precision to all output streams with 2D and 3D fields. For standard simulations, this only alters:
- monthly time averages, used for MPAS-Analysis
- high frequency stats, used for animations

Restart files remain double precision, of course. The time average is computed in double precision, and the final value is then written in single precision.

This will be bit-for-bit for comparison of restart and coupler files, but not for ocean output files.

[BFB]