### PR TITLE
Fix preqx_kokkos/HOMMEBFB

### DIFF
--- a/components/homme/src/preqx_kokkos/CMakeLists.txt
+++ b/components/homme/src/preqx_kokkos/CMakeLists.txt
@@ -55,7 +55,7 @@ SET (SRC_SHARE_F90
   ${SRC_SHARE_DIR}/edgetype_mod.F90
   ${SRC_SHARE_DIR}/element_mod.F90
   ${SRC_SHARE_DIR}/gllfvremap_mod.F90
-  ${SRC_SHARE_DIR}/gllfvremap_test_mod.F90
+  ${SRC_SHARE_DIR}/gllfvremap_util_mod.F90
   ${SRC_SHARE_DIR}/global_norms_mod.F90
   ${SRC_SHARE_DIR}/gridgraph_mod.F90
   ${SRC_SHARE_DIR}/hybrid_mod.F90


### PR DESCRIPTION
Minor fix to use gllfvremap_util_mod in preqx_kokkos. Issue happened because a PR that affects this file was merged to master very recently, so, clone with hommebfb test did not have that change.