### PR TITLE
NH IMEX improvements

### DIFF
--- a/components/homme/src/theta-l/eos.F90
+++ b/components/homme/src/theta-l/eos.F90
@@ -112,6 +112,7 @@ implicit none
   integer :: i,j,k,k2
   logical :: ierr
 
+
   ! check for bad state that will crash exponential function below
   if (theta_hydrostatic_mode) then
     ierr= any(dp3d(:,:,:) < 0 )

--- a/components/homme/src/theta-l/eos.F90
+++ b/components/homme/src/theta-l/eos.F90
@@ -112,30 +112,6 @@ implicit none
   integer :: i,j,k,k2
   logical :: ierr
 
-#if 0
-  do k=1,nlev
-     do j=1,np
-     do i=1,np
-        ! let y = 1/x    x=-dphi                                                                               
-        !                                                                                                      
-        ! for x > g:                                                                                           
-        !     y=1/x                                                                                            
-        !     dphi = -1/y                                                                                      
-        ! for x < 1/g:                                                                                         
-        !      y = -(1/g^2)*(x-g) + 1/g                                                                        
-        !      dphi = -1/y                                                                                     
-        ! check:  dphi=-100             dphi=-100  (unchanged)    -1/dphi =                                    
-        !         dphi=-g   then y=1/g, dphi=-g                                                                
-        !         dphi=0    then y=2/g, dphi=-g/2                                                              
-        !         dphi=g    then y=3/g, dphi=-g/3                                                              
-        if (dphi(i,j,k) > -g ) then
-           dphi(i,j,k)=-1/((dphi(i,j,k)+g)/g**2 + 1/g)
-        endif
-     enddo
-     enddo
-  enddo
-#endif
-
   ! check for bad state that will crash exponential function below
   if (theta_hydrostatic_mode) then
     ierr= any(dp3d(:,:,:) < 0 )

--- a/components/homme/src/theta-l/eos.F90
+++ b/components/homme/src/theta-l/eos.F90
@@ -112,6 +112,29 @@ implicit none
   integer :: i,j,k,k2
   logical :: ierr
 
+#if 0
+  do k=1,nlev
+     do j=1,np
+     do i=1,np
+        ! let y = 1/x    x=-dphi                                                                               
+        !                                                                                                      
+        ! for x > g:                                                                                           
+        !     y=1/x                                                                                            
+        !     dphi = -1/y                                                                                      
+        ! for x < 1/g:                                                                                         
+        !      y = -(1/g^2)*(x-g) + 1/g                                                                        
+        !      dphi = -1/y                                                                                     
+        ! check:  dphi=-100             dphi=-100  (unchanged)    -1/dphi =                                    
+        !         dphi=-g   then y=1/g, dphi=-g                                                                
+        !         dphi=0    then y=2/g, dphi=-g/2                                                              
+        !         dphi=g    then y=3/g, dphi=-g/3                                                              
+        if (dphi(i,j,k) > -g ) then
+           dphi(i,j,k)=-1/((dphi(i,j,k)+g)/g**2 + 1/g)
+        endif
+     enddo
+     enddo
+  enddo
+#endif
 
   ! check for bad state that will crash exponential function below
   if (theta_hydrostatic_mode) then

--- a/components/homme/src/theta-l/imex_mod.F90
+++ b/components/homme/src/theta-l/imex_mod.F90
@@ -508,7 +508,7 @@ contains
 
           do i=1,np
              do j=1,np
-                x(1:nlev,i,j) = -Fn(i,j,1:nlev)  !+Fn(i,j,nlev+1:2*nlev,1)/(g*dt2))
+                x(1:nlev,i,j) = -Fn(i,j,1:nlev)  
 #ifdef NEWTONCOND
                 ! nlev condition number: 500e3 with phi, 850e3 with dphi
                 anorm=DLANGT('1-norm', nlev, JacL(:,i,j),jacD(:,i,j),jacU(:,i,j))
@@ -534,7 +534,7 @@ contains
           call pnh_and_exner_from_eos2(hvcoord,vtheta_dp,dp3d,dphi,pnh,exner,dpnh_dp_i,'dirk2')
           Fn(:,:,1:nlev) = w_np1(:,:,1:nlev) - (w_n0(:,:,1:nlev) + g*dt2 * (dpnh_dp_i(:,:,1:nlev)-1))
 
-          reserr=maxval(abs(Fn))/(wmax*abs(dt2)) ! residual error in phi tendency, relative to source term gw
+          reserr=maxval(abs(Fn))/(wmax*abs(dt2)) 
           deltaerr=maxval(abs(x))/wmax
 
 
@@ -559,10 +559,6 @@ contains
 
        if (itercount >= maxiter) then
           write(iulog,*) 'WARNING:IMEX solver failed b/c max iteration count was met',deltaerr,reserr
-          do k=1,nlev
-             i=1 ; j=1
-             !print *,k,( abs(Fn(i,j,k))/wgdtmax
-          enddo
        end if
     end do ! end do for the ie=nets,nete loop
 #ifdef NEWTONCOND

--- a/components/homme/src/theta-l/imex_mod.F90
+++ b/components/homme/src/theta-l/imex_mod.F90
@@ -150,7 +150,7 @@ contains
           nt=n0
           call pnh_and_exner_from_eos(hvcoord,elem(ie)%state%vtheta_dp(:,:,:,nt), &
                elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%phinh_i(:,:,:,nt),pnh,   &
-               exner,dpnh_dp_i,caller='dirk0')
+               exner,dpnh_dp_i,caller='dirkn0')
           w_n0(:,:,1:nlev)     = w_n0(:,:,1:nlev) + &
                dt3*g*(dpnh_dp_i(:,:,1:nlev)-1d0)
 
@@ -166,7 +166,7 @@ contains
           nt=nm1
           call pnh_and_exner_from_eos(hvcoord,elem(ie)%state%vtheta_dp(:,:,:,nt), &
                elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%phinh_i(:,:,:,nt),pnh,   &
-               exner,dpnh_dp_i,caller='dirk0')
+               exner,dpnh_dp_i,caller='dirknm1')
           w_n0(:,:,1:nlev)     = w_n0(:,:,1:nlev) + &
                dt3*g*(dpnh_dp_i(:,:,1:nlev)-1d0)
 

--- a/components/homme/src/theta-l/imex_mod.F90
+++ b/components/homme/src/theta-l/imex_mod.F90
@@ -46,6 +46,9 @@ contains
     enddo
   end subroutine compute_gwphis
 
+
+
+#if 0
   subroutine compute_stage_value_dirk(nm1,alphadt_nm1,n0,alphadt_n0,np1,dt2,qn0,elem,hvcoord,hybrid,&
        deriv,nets,nete,itercount,itererr)
     !===================================================================================
@@ -251,7 +254,7 @@ contains
                 enddo
                 dphi(i,j,nlev)=dphi(i,j,nlev) + (0 - x(nlev,i,j) )
 
-                alpha = 0
+                alpha = 1
                 do nsafe=1,8
                    if (all(dphi(i,j,1:nlev) < -g ))  exit
                    ! remove the last netwon increment, try reduced increment
@@ -265,7 +268,7 @@ contains
                 ! if nsafe>8, code will crash in next call to pnh_and_exner_from_eos
 #define NOSCAN
 #ifdef NOSCAN
-                phi_np1(i,j,1:nlev) = phi_np1(i,j,1:nlev) + (1 - alpha)*x(1:nlev,i,j)
+                phi_np1(i,j,1:nlev) = phi_np1(i,j,1:nlev) + alpha*x(1:nlev,i,j)
 #endif
              end do
           end do
@@ -284,7 +287,7 @@ contains
                (1.0-dpnh_dp_i(:,:,1:nlev))
 
           do k=1,nlev
-             Fn(:,:,k) = (phi_np1(:,:,k) - phi_n0(:,:,k)) - dt2*g*(elem(ie)%state%w_i(:,:,k,np1))
+             Fn(:,:,k) = phi_np1(:,:,k) - (phi_n0(:,:,k) + dt2*g*(elem(ie)%state%w_i(:,:,k,np1)))
           enddo
           reserr=maxval(abs(Fn))/wgdtmax   ! residual error in phi tendency, relative to source term gw
 
@@ -331,6 +334,256 @@ contains
 
     call t_stopf('compute_stage_value_dirk')
   end subroutine compute_stage_value_dirk
+
+#else
+
+
+
+
+
+
+
+  subroutine compute_stage_value_dirk(nm1,alphadt_nm1,n0,alphadt_n0,np1,dt2,qn0,elem,hvcoord,hybrid,&
+       deriv,nets,nete,itercount,itererr)
+    !===================================================================================
+    ! this subroutine solves a stage value equation for a DIRK method which takes the form
+    !
+    ! gi = un0 + dt* sum(1:i-1)(aij n(gj)+a2ij s(gj)) + dt *a2ii s(gi) := y + dt a2ii s(gi)
+    !
+    ! It is assumed that un0 has the value of y and the computed value of gi is stored at
+    ! unp1
+    ! 
+    ! w_0 = w(np1)
+    ! phi_0 = phi(np1)
+    ! Then solve (ovewriting w(np1),phi(np1): 
+    ! w(np1) = w_0 + alphadt_n0 * SW(n0)  + alphadt_nm1*SW(nm1) +  dt2*SW(np1)
+    ! phi(np1) = phi_0 + alphadt_n0 * SPHI(n0)  + alphadt_nm1*SPHI(nm1) +  dt2*SPHI(np1)
+    !
+    ! SW(nt) = g*dpnh_dp_i(nt)-1
+    ! SPHI(nt) = g*w(nt) -g*a(k) u(nt) dot grad_phis
+    !
+    ! pnh_and_exner_from_eos()   used to compute dpnh_dp_i(nt) in SW(nt)
+    ! compute_gwphis()            used to compute g*a(k) u(nt) dot grad_phis  in SPHI(nt)   
+    !
+    ! We then precompute:
+    !  w_rhs = w_0 + alphadt_n0 * SW(n0)  + alphadt_nm1*SW(nm1) 
+    !  phi_rhs = w_0 + alphad_n0 * SPHI(n0)  + alphadt1_nm1*SPHI(nm1) -  dt2*compute_gwphi(np1)
+    ! and solve, via Newton iteraiton:
+    !   w(np1) = w_rhs + dt2*SW(np1)
+    !   phi(np1) = phi_rhs + dt2*g*w(np1)
+    !
+    !===================================================================================
+
+    integer, intent(in) :: nm1,n0,np1,qn0,nets,nete
+    real (kind=real_kind), intent(in) :: dt2
+    integer :: itercount
+    real (kind=real_kind) :: itererr
+    real (kind=real_kind), intent(in) :: alphadt_n0,alphadt_nm1
+
+    type (hvcoord_t)     , intent(in) :: hvcoord
+    type (hybrid_t)      , intent(in) :: hybrid
+    type (element_t)     , intent(inout), target :: elem(:)
+    type (derivative_t)  , intent(in) :: deriv
+
+
+    ! local
+    real (kind=real_kind), pointer, dimension(:,:,:)   :: phi_np1
+    real (kind=real_kind), pointer, dimension(:,:,:)   :: w_np1
+    real (kind=real_kind), pointer, dimension(:,:,:)   :: dp3d
+    real (kind=real_kind), pointer, dimension(:,:,:)   :: vtheta_dp
+    real (kind=real_kind) :: JacD(nlev,np,np)  , JacL(nlev-1,np,np)
+    real (kind=real_kind) :: JacU(nlev-1,np,np), JacU2(nlev-2,np,np)
+    real (kind=real_kind) :: pnh(np,np,nlev)     ! nh (nonydro) pressure
+    real (kind=real_kind) :: dpnh_dp_i(np,np,nlevp)
+    real (kind=real_kind) :: exner(np,np,nlev)     ! exner nh pressure
+    real (kind=real_kind) :: w_n0(np,np,nlevp)    
+    real (kind=real_kind) :: dphi(np,np,nlev)    
+    real (kind=real_kind) :: dphi_n0(np,np,nlev)    
+    real (kind=real_kind) :: phi_n0(np,np,nlevp)    
+    real (kind=real_kind) :: Ipiv(nlev,np,np)
+    real (kind=real_kind) :: Fn(np,np,nlev),x(nlev,np,np)
+    real (kind=real_kind) :: gwh_i(np,np,nlevp)  ! w hydrostatic
+    real (kind=real_kind) :: v_i(np,np,2,nlevp)  ! w hydrostatic
+
+    real (kind=real_kind) :: Jac2D(nlev,np,np)  , Jac2L(nlev-1,np,np)
+    real (kind=real_kind) :: Jac2U(nlev-1,np,np)
+
+
+    real (kind=real_kind) :: wmax
+    integer :: maxiter
+    real*8 :: deltatol,restol,deltaerr,reserr,rcond,min_rcond,anorm,dt3,alpha
+
+    integer :: i,j,k,l,ie,info(np,np),nt
+    integer :: nsafe
+#undef NEWTONCOND
+#ifdef NEWTONCOND
+    real*8 :: DLANGT  ! external
+    real (kind=real_kind) :: work(2*nlev)
+    integer :: iwork(nlev),info2
+#endif
+
+    call t_startf('compute_stage_value_dirk')
+
+    ! dirk settings
+    maxiter=20
+    deltatol=1.0e-11_real_kind  ! exit if newton increment < deltatol
+    !deltatol=1e-8 ! good   imex residual .2e-9
+!    deltatol=1e-6 ! good   imex resedual .4e-6
+    !deltatol=1e-4 ! good   imex residual .3e-2
+
+    !restol=1.0e-13_real_kind    ! exit if residual < restol  
+    ! condition number and thus residual depends strongly on dt and min(dz)
+    ! more work needed to exit iteration early based on residual error
+    min_rcond=1.0e20_real_kind
+
+    do ie=nets,nete
+       w_n0 = elem(ie)%state%w_i(:,:,:,np1)
+       wmax=max(1d0,maxval(abs(w_n0)))
+       ! approximate the initial error of f(x) \approx 0
+       vtheta_dp  => elem(ie)%state%vtheta_dp(:,:,:,np1)
+       phi_np1 => elem(ie)%state%phinh_i(:,:,:,np1)
+       w_np1 => elem(ie)%state%w_i(:,:,:,np1)
+       phi_n0 = elem(ie)%state%phinh_i(:,:,:,np1)
+
+       if (alphadt_n0.ne.0d0) then ! add dt*alpha*S(un0) to the rhs
+          dt3=alphadt_n0
+          nt=n0
+          call pnh_and_exner_from_eos(hvcoord,elem(ie)%state%vtheta_dp(:,:,:,nt), &
+               elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%phinh_i(:,:,:,nt),pnh,   &
+               exner,dpnh_dp_i,caller='dirkn0')
+          w_n0(:,:,1:nlev)     = w_n0(:,:,1:nlev) + &
+               dt3*g*(dpnh_dp_i(:,:,1:nlev)-1)
+
+          call compute_gwphis(gwh_i,elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%v(:,:,:,:,nt),&
+               elem(ie)%derived%gradphis,hvcoord)
+          phi_n0(:,:,1:nlev) = phi_n0(:,:,1:nlev) + &
+               dt3*g*elem(ie)%state%w_i(:,:,1:nlev,nt) -  dt3*gwh_i(:,:,1:nlev)
+       end if
+
+
+       if (alphadt_nm1.ne.0d0) then ! add dt*alpha*S(unm1) to the rhs
+          dt3=alphadt_nm1
+          nt=nm1
+          call pnh_and_exner_from_eos(hvcoord,elem(ie)%state%vtheta_dp(:,:,:,nt), &
+               elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%phinh_i(:,:,:,nt),pnh,   &
+               exner,dpnh_dp_i,caller='dirknm1')
+          w_n0(:,:,1:nlev)     = w_n0(:,:,1:nlev) + &
+               dt3*g*(dpnh_dp_i(:,:,1:nlev)-1)
+
+          call compute_gwphis(gwh_i,elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%v(:,:,:,:,nt),&
+               elem(ie)%derived%gradphis,hvcoord)
+          phi_n0(:,:,1:nlev) = phi_n0(:,:,1:nlev) + &
+               dt3*g*elem(ie)%state%w_i(:,:,1:nlev,nt) -  dt3*gwh_i(:,:,1:nlev)
+       end if
+
+       ! add just the wphis(np1) term to the RHS
+       nt=np1
+       call compute_gwphis(gwh_i,elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%v(:,:,:,:,nt),&
+            elem(ie)%derived%gradphis,hvcoord)
+       phi_n0(:,:,1:nlev) = phi_n0(:,:,1:nlev) -  dt2*gwh_i(:,:,1:nlev)
+
+       dp3d  => elem(ie)%state%dp3d(:,:,:,np1)
+
+       ! initial residual
+       w_np1(:,:,1:nlev)=gwh_i(:,:,1:nlev)/g  ! safer initial guess then w(np1)
+       phi_np1(:,:,1:nlev) =  phi_n0(:,:,1:nlev) +  dt2*g*w_np1(:,:,1:nlev)
+       do k=1,nlev
+          dphi(:,:,k)=phi_np1(:,:,k+1)-phi_np1(:,:,k)
+          dphi_n0(:,:,k)=phi_n0(:,:,k+1)-phi_n0(:,:,k)
+       enddo
+       call pnh_and_exner_from_eos2(hvcoord,vtheta_dp,dp3d,dphi,pnh,exner,dpnh_dp_i,'dirk1')
+       Fn(:,:,1:nlev) = w_np1(:,:,1:nlev) - &
+            (w_n0(:,:,1:nlev) + g*dt2 * (dpnh_dp_i(:,:,1:nlev)-1))
+
+
+
+       itercount=0
+       do while (itercount < maxiter) 
+
+          info(:,:) = 0
+          ! numerical J:
+          !call get_dirk_jacobian(JacL,JacD,JacU,dt2,dp3d,dphi,pnh,0,1d-4,hvcoord,dpnh_dp_i,vtheta_dp) 
+          ! analytic J:
+          call get_dirk_jacobian(JacL,JacD,JacU,dt2,dp3d,dphi,pnh,1) 
+
+          do i=1,np
+             do j=1,np
+                x(1:nlev,i,j) = -Fn(i,j,1:nlev)  !+Fn(i,j,nlev+1:2*nlev,1)/(g*dt2))
+#ifdef NEWTONCOND
+                ! nlev condition number: 500e3 with phi, 850e3 with dphi
+                anorm=DLANGT('1-norm', nlev, JacL(:,i,j),jacD(:,i,j),jacU(:,i,j))
+                call DGTTRF(nlev, JacL(:,i,j), JacD(:,i,j),JacU(:,i,j),JacU2(:,i,j), Ipiv(:,i,j), info )
+                call DGTCON('1',nlev,JacL(:,i,j),JacD(:,i,j),JacU(:,i,j),jacU2(:,i,j),Ipiv(:,i,j),&
+                     ANORM, RCOND, WORK, IWORK, info2 )
+#else
+                call DGTTRF(nlev, JacL(:,i,j), JacD(:,i,j),JacU(:,i,j),JacU2(:,i,j), Ipiv(:,i,j), info(i,j) )
+#endif
+                ! Tridiagonal solve
+                call DGTTRS( 'N', nlev,1, JacL(:,i,j), JacD(:,i,j), JacU(:,i,j), JacU2(:,i,j), Ipiv(:,i,j),x(:,i,j), nlev, info(i,j) )
+                ! update approximate solution of w
+                w_np1(i,j,1:nlev) = w_np1(i,j,1:nlev) + x(1:nlev,i,j)
+
+             end do
+          end do
+
+          do k=1,nlev-1
+             dphi(:,:,k)=dphi_n0(:,:,k) + dt2*g*( w_np1(:,:,k+1)-w_np1(:,:,k) )
+          enddo
+          dphi(:,:,nlev)=dphi_n0(:,:,nlev) + dt2*g*( 0-w_np1(:,:,k) )
+
+          call pnh_and_exner_from_eos2(hvcoord,vtheta_dp,dp3d,dphi,pnh,exner,dpnh_dp_i,'dirk2')
+          Fn(:,:,1:nlev) = w_np1(:,:,1:nlev) - (w_n0(:,:,1:nlev) + g*dt2 * (dpnh_dp_i(:,:,1:nlev)-1))
+
+          reserr=maxval(abs(Fn))/(wmax*abs(dt2)) ! residual error in phi tendency, relative to source term gw
+          deltaerr=maxval(abs(x))/wmax
+
+
+          ! update iteration count and error measure
+          itercount=itercount+1
+          !if (reserr < restol) exit
+          if (deltaerr<deltatol) exit
+       end do ! end do for the do while loop
+
+       ! update phi:
+       phi_np1(:,:,1:nlev) =  phi_n0(:,:,1:nlev) +  dt2*g*w_np1(:,:,1:nlev)
+
+
+       ! keep track of running  max iteraitons and max error (reset after each diagnostics output)
+       max_itercnt=max(itercount,max_itercnt)
+       max_deltaerr=max(deltaerr,max_deltaerr)
+       max_reserr=max(reserr,max_reserr)
+#ifdef NEWTONCOND
+       min_rcond=min(rcond,min_rcond)
+#endif
+       itererr=min(max_reserr,max_deltaerr) ! passed back to ARKODE
+
+       if (itercount >= maxiter) then
+          write(iulog,*) 'WARNING:IMEX solver failed b/c max iteration count was met',deltaerr,reserr
+          do k=1,nlev
+             i=1 ; j=1
+             !print *,k,( abs(Fn(i,j,k))/wgdtmax
+          enddo
+       end if
+    end do ! end do for the ie=nets,nete loop
+#ifdef NEWTONCOND
+    if (hybrid%masterthread) print *,'max J condition number (mpi task0): ',1/min_rcond
+#endif
+
+    call t_stopf('compute_stage_value_dirk')
+  end subroutine compute_stage_value_dirk
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
 
   subroutine get_dirk_jacobian(JacL,JacD,JacU,dt2,dp3d,dphi,pnh,exact,&
      epsie,hvcoord,dpnh_dp_i,vtheta_dp)

--- a/components/homme/src/theta-l/imex_mod.F90
+++ b/components/homme/src/theta-l/imex_mod.F90
@@ -48,299 +48,6 @@ contains
 
 
 
-#if 0
-  subroutine compute_stage_value_dirk(nm1,alphadt_nm1,n0,alphadt_n0,np1,dt2,qn0,elem,hvcoord,hybrid,&
-       deriv,nets,nete,itercount,itererr)
-    !===================================================================================
-    ! this subroutine solves a stage value equation for a DIRK method which takes the form
-    !
-    ! gi = un0 + dt* sum(1:i-1)(aij n(gj)+a2ij s(gj)) + dt *a2ii s(gi) := y + dt a2ii s(gi)
-    !
-    ! It is assumed that un0 has the value of y and the computed value of gi is stored at
-    ! unp1
-    ! 
-    ! w_0 = w(np1)
-    ! phi_0 = phi(np1)
-    ! Then solve (ovewriting w(np1),phi(np1): 
-    ! w(np1) = w_0 + alphadt_n0 * SW(n0)  + alphadt_nm1*SW(nm1) +  dt2*SW(np1)
-    ! phi(np1) = phi_0 + alphadt_n0 * SPHI(n0)  + alphadt_nm1*SPHI(nm1) +  dt2*SPHI(np1)
-    !
-    ! SW(nt) = g*dpnh_dp_i(nt)-1
-    ! SPHI(nt) = g*w(nt) -g*a(k) u(nt) dot grad_phis
-    !
-    ! pnh_and_exner_from_eos()   used to compute dpnh_dp_i(nt) in SW(nt)
-    ! compute_gwphis()            used to compute g*a(k) u(nt) dot grad_phis  in SPHI(nt)   
-    !
-    ! We then precompute:
-    !  w_rhs = w_0 + alphadt_n0 * SW(n0)  + alphadt_nm1*SW(nm1) 
-    !  phi_rhs = w_0 + alphad_n0 * SPHI(n0)  + alphadt1_nm1*SPHI(nm1) -  dt2*compute_gwphi(np1)
-    ! and solve, via Newton iteraiton:
-    !   w(np1) = w_rhs + dt2*SW(np1)
-    !   phi(np1) = phi_rhs + dt2*g*w(np1)
-    !
-    !===================================================================================
-
-    integer, intent(in) :: nm1,n0,np1,qn0,nets,nete
-    real (kind=real_kind), intent(in) :: dt2
-    integer :: itercount
-    real (kind=real_kind) :: itererr
-    real (kind=real_kind), intent(in) :: alphadt_n0,alphadt_nm1
-
-    type (hvcoord_t)     , intent(in) :: hvcoord
-    type (hybrid_t)      , intent(in) :: hybrid
-    type (element_t)     , intent(inout), target :: elem(:)
-    type (derivative_t)  , intent(in) :: deriv
-
-
-    ! local
-    real (kind=real_kind), pointer, dimension(:,:,:)   :: phi_np1
-    real (kind=real_kind), pointer, dimension(:,:,:)   :: dp3d
-    real (kind=real_kind), pointer, dimension(:,:,:)   :: vtheta_dp
-    real (kind=real_kind) :: JacD(nlev,np,np)  , JacL(nlev-1,np,np)
-    real (kind=real_kind) :: JacU(nlev-1,np,np), JacU2(nlev-2,np,np)
-    real (kind=real_kind) :: pnh(np,np,nlev)     ! nh (nonydro) pressure
-    real (kind=real_kind) :: dpnh_dp_i(np,np,nlevp)
-    real (kind=real_kind) :: exner(np,np,nlev)     ! exner nh pressure
-    real (kind=real_kind) :: w_n0(np,np,nlevp)    
-    real (kind=real_kind) :: dphi(np,np,nlev)    
-    real (kind=real_kind) :: dphi_n0(np,np,nlev)    
-    real (kind=real_kind) :: phi_n0(np,np,nlevp)    
-    real (kind=real_kind) :: Ipiv(nlev,np,np)
-    real (kind=real_kind) :: Fn(np,np,nlev),x(nlev,np,np)
-    real (kind=real_kind) :: gwh_i(np,np,nlevp)  ! w hydrostatic
-    real (kind=real_kind) :: v_i(np,np,2,nlevp)  ! w hydrostatic
-
-    real (kind=real_kind) :: Jac2D(nlev,np,np)  , Jac2L(nlev-1,np,np)
-    real (kind=real_kind) :: Jac2U(nlev-1,np,np)
-
-
-    real (kind=real_kind) :: wgdtmax
-    integer :: maxiter
-    real*8 :: deltatol,restol,deltaerr,reserr,rcond,min_rcond,anorm,dt3,alpha
-
-    integer :: i,j,k,l,ie,info(np,np),nt
-    integer :: nsafe
-#undef NEWTONCOND
-#ifdef NEWTONCOND
-    real*8 :: DLANGT  ! external
-    real (kind=real_kind) :: work(2*nlev)
-    integer :: iwork(nlev),info2
-#endif
-
-    call t_startf('compute_stage_value_dirk')
-
-    ! dirk settings
-    maxiter=20
-    deltatol=1.0e-13_real_kind  ! exit if newton increment < deltatol
-
-    !restol=1.0e-13_real_kind    ! exit if residual < restol  
-    ! condition number and thus residual depends strongly on dt and min(dz)
-    ! more work needed to exit iteration early based on residual error
-    min_rcond=1.0e20_real_kind
-
-    do ie=nets,nete
-       w_n0 = elem(ie)%state%w_i(:,:,:,np1)
-       wgdtmax=max(1d0,maxval(abs(w_n0)))*abs(dt2)*g
-       ! approximate the initial error of f(x) \approx 0
-       vtheta_dp  => elem(ie)%state%vtheta_dp(:,:,:,np1)
-       phi_np1 => elem(ie)%state%phinh_i(:,:,:,np1)
-
-       phi_n0 = phi_np1
-
-       if (alphadt_n0.ne.0d0) then ! add dt*alpha*S(un0) to the rhs
-          dt3=alphadt_n0
-          nt=n0
-          call pnh_and_exner_from_eos(hvcoord,elem(ie)%state%vtheta_dp(:,:,:,nt), &
-               elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%phinh_i(:,:,:,nt),pnh,   &
-               exner,dpnh_dp_i,caller='dirkn0')
-          w_n0(:,:,1:nlev)     = w_n0(:,:,1:nlev) + &
-               dt3*g*(dpnh_dp_i(:,:,1:nlev)-1d0)
-
-          call compute_gwphis(gwh_i,elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%v(:,:,:,:,nt),&
-               elem(ie)%derived%gradphis,hvcoord)
-          phi_n0(:,:,1:nlev) = phi_n0(:,:,1:nlev) + &
-               dt3*g*elem(ie)%state%w_i(:,:,1:nlev,nt) -  dt3*gwh_i(:,:,1:nlev)
-       end if
-
-
-       if (alphadt_nm1.ne.0d0) then ! add dt*alpha*S(unm1) to the rhs
-          dt3=alphadt_nm1
-          nt=nm1
-          call pnh_and_exner_from_eos(hvcoord,elem(ie)%state%vtheta_dp(:,:,:,nt), &
-               elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%phinh_i(:,:,:,nt),pnh,   &
-               exner,dpnh_dp_i,caller='dirknm1')
-          w_n0(:,:,1:nlev)     = w_n0(:,:,1:nlev) + &
-               dt3*g*(dpnh_dp_i(:,:,1:nlev)-1d0)
-
-          call compute_gwphis(gwh_i,elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%v(:,:,:,:,nt),&
-               elem(ie)%derived%gradphis,hvcoord)
-          phi_n0(:,:,1:nlev) = phi_n0(:,:,1:nlev) + &
-               dt3*g*elem(ie)%state%w_i(:,:,1:nlev,nt) -  dt3*gwh_i(:,:,1:nlev)
-       end if
-
-       ! add just the wphis(np1) term to the RHS
-       nt=np1
-       call compute_gwphis(gwh_i,elem(ie)%state%dp3d(:,:,:,nt),elem(ie)%state%v(:,:,:,:,nt),&
-            elem(ie)%derived%gradphis,hvcoord)
-       phi_n0(:,:,1:nlev) = phi_n0(:,:,1:nlev) -  dt2*gwh_i(:,:,1:nlev)
-
-       dp3d  => elem(ie)%state%dp3d(:,:,:,np1)
-#if 0
-       ! use hydrostatic for initial guess
-       call phi_from_eos(hvcoord,elem(ie)%state%phis,vtheta_dp,dp3d,phi_np1)
-#endif
-
-       ! newton iteration will iterate of d(phi)/deta.  initialize:
-       do k=1,nlev
-          dphi_n0(:,:,k)=phi_n0(:,:,k+1)-phi_n0(:,:,k)
-          dphi(:,:,k)=phi_np1(:,:,k+1)-phi_np1(:,:,k)
-       enddo
-
-       nsafe=0
-       do k=1,nlev
-          do j=1,np
-             do i=1,np
-                if ( dphi(i,j,k)  > -g) then
-                   write(iulog,*) 'WARNING:IMEX inital PHI is bad, delta z < 1m. ie,i,j,k=',ie,i,j,k
-                   write(iulog,*) 'dphi(i,j,k)=  ',dphi(i,j,k)
-                   dphi(i,j,k)=-g
-                   nsafe=1
-                endif
-             enddo
-          enddo
-       enddo
-       if (nsafe==1) then
-          ! in rare cases when limter was triggered, just recompute:
-          do k=nlev,1,-1  ! scan                                                                                                      
-             phi_np1(:,:,k) = phi_np1(:,:,k+1)-dphi(:,:,k)
-          enddo
-       endif
-
-       ! initial residual
-       call pnh_and_exner_from_eos2(hvcoord,vtheta_dp,dp3d,dphi,pnh,exner,dpnh_dp_i,'dirk1')
-       elem(ie)%state%w_i(:,:,1:nlev,np1) = w_n0(:,:,1:nlev) - g*dt2 * &
-            (1.0-dpnh_dp_i(:,:,1:nlev))
-       do k=1,nlev
-          Fn(:,:,k) = (phi_np1(:,:,k) - phi_n0(:,:,k)) - dt2*g*(elem(ie)%state%w_i(:,:,k,np1))
-       enddo
-
-
-       itercount=0
-       do while (itercount < maxiter) 
-
-          info(:,:) = 0
-          ! numerical J:
-          !call get_dirk_jacobian(JacL,JacD,JacU,dt2,dp3d,dphi,pnh,0,1d-4,hvcoord,dpnh_dp_i,vtheta_dp) 
-          ! analytic J:
-          call get_dirk_jacobian(JacL,JacD,JacU,dt2,dp3d,dphi,pnh,1) 
-
-          do i=1,np
-             do j=1,np
-                x(1:nlev,i,j) = -Fn(i,j,1:nlev)  !+Fn(i,j,nlev+1:2*nlev,1)/(g*dt2))
-#ifdef NEWTONCOND
-                ! nlev condition number: 500e3 with phi, 850e3 with dphi
-                anorm=DLANGT('1-norm', nlev, JacL(:,i,j),jacD(:,i,j),jacU(:,i,j))
-                call DGTTRF(nlev, JacL(:,i,j), JacD(:,i,j),JacU(:,i,j),JacU2(:,i,j), Ipiv(:,i,j), info )
-                call DGTCON('1',nlev,JacL(:,i,j),JacD(:,i,j),JacU(:,i,j),jacU2(:,i,j),Ipiv(:,i,j),&
-                     ANORM, RCOND, WORK, IWORK, info2 )
-#else
-                call DGTTRF(nlev, JacL(:,i,j), JacD(:,i,j),JacU(:,i,j),JacU2(:,i,j), Ipiv(:,i,j), info(i,j) )
-#endif
-                ! Tridiagonal solve
-                call DGTTRS( 'N', nlev,1, JacL(:,i,j), JacD(:,i,j), JacU(:,i,j), JacU2(:,i,j), Ipiv(:,i,j),x(:,i,j), nlev, info(i,j) )
-                ! update approximate solution of phi
-                do k=1,nlev-1
-                   dphi(i,j,k)=dphi(i,j,k) + x(k+1,i,j)-x(k,i,j)
-                enddo
-                dphi(i,j,nlev)=dphi(i,j,nlev) + (0 - x(nlev,i,j) )
-
-                alpha = 1
-                do nsafe=1,8
-                   if (all(dphi(i,j,1:nlev) < -g ))  exit
-                   ! remove the last netwon increment, try reduced increment
-                   alpha = 1.0_real_kind/(2**nsafe)
-                   do k=1,nlev-1
-                      dphi(i,j,k)=dphi(i,j,k) - (x(k+1,i,j)-x(k,i,j))*alpha
-                   enddo
-                   dphi(i,j,nlev)=dphi(i,j,nlev) - (0-x(nlev,i,j))*alpha
-                enddo
-                if (nsafe>1) write(iulog,*) 'WARNING:IMEX reducing newton increment, nsafe=',nsafe
-                ! if nsafe>8, code will crash in next call to pnh_and_exner_from_eos
-#undef NOSCAN
-#ifdef NOSCAN
-                phi_np1(i,j,1:nlev) = phi_np1(i,j,1:nlev) + alpha*x(1:nlev,i,j)
-#endif
-             end do
-          end do
-#ifdef NOSCAN
-          do k=1,nlev
-             dphi(:,:,k) = phi_np1(:,:,k+1) - phi_np1(:,:,k)
-          end do
-#else
-          do k=nlev,1,-1  ! scan                                                                                                      
-             phi_np1(:,:,k) = phi_np1(:,:,k+1)-dphi(:,:,k)
-          enddo
-#endif
-          call pnh_and_exner_from_eos2(hvcoord,vtheta_dp,dp3d,dphi,pnh,exner,dpnh_dp_i,'dirk2')
-          ! update approximate solution of w
-          elem(ie)%state%w_i(:,:,1:nlev,np1) = w_n0(:,:,1:nlev) - g*dt2 * &
-               (1.0-dpnh_dp_i(:,:,1:nlev))
-
-          do k=1,nlev
-             Fn(:,:,k) = phi_np1(:,:,k) - (phi_n0(:,:,k) + dt2*g*(elem(ie)%state%w_i(:,:,k,np1)))
-          enddo
-          reserr=maxval(abs(Fn))/wgdtmax   ! residual error in phi tendency, relative to source term gw
-
-          deltaerr=0
-          do k=1,nlev
-             ! delta residual:
-             do i=1,np
-                do j=1,np
-#ifdef NOSCAN
-                   deltaerr=max(deltaerr, abs(x(k,i,j))/max(g,abs(phi_n0(i,j,k))) )
-#else
-                   deltaerr=max(deltaerr, abs(x(k,i,j))/max(g,abs(dphi_n0(i,j,k))) )
-#endif
-                enddo
-             enddo
-          enddo
-
-          ! update iteration count and error measure
-          itercount=itercount+1
-          !if (reserr < restol) exit
-          if (deltaerr<deltatol) exit
-       end do ! end do for the do while loop
-
-       ! keep track of running  max iteraitons and max error (reset after each diagnostics output)
-       max_itercnt=max(itercount,max_itercnt)
-       max_deltaerr=max(deltaerr,max_deltaerr)
-       max_reserr=max(reserr,max_reserr)
-#ifdef NEWTONCOND
-       min_rcond=min(rcond,min_rcond)
-#endif
-       itererr=min(max_reserr,max_deltaerr) ! passed back to ARKODE
-
-       if (itercount >= maxiter) then
-          write(iulog,*) 'WARNING:IMEX solver failed b/c max iteration count was met',deltaerr,reserr
-          do k=1,nlev
-             i=1 ; j=1
-             !print *,k,( abs(Fn(i,j,k))/wgdtmax
-          enddo
-       end if
-    end do ! end do for the ie=nets,nete loop
-#ifdef NEWTONCOND
-    if (hybrid%masterthread) print *,'max J condition number (mpi task0): ',1/min_rcond
-#endif
-
-    call t_stopf('compute_stage_value_dirk')
-  end subroutine compute_stage_value_dirk
-
-#else
-
-
-
-
-
 
 
   subroutine compute_stage_value_dirk(nm1,alphadt_nm1,n0,alphadt_n0,np1,dt2,qn0,elem,hvcoord,hybrid,&
@@ -481,7 +188,7 @@ contains
        ! w(np1) as initial guess:
        phi_np1(:,:,1:nlev) =  phi_n0(:,:,1:nlev) +  dt2*g*w_np1(:,:,1:nlev)
 #endif
-#if 1
+#if 0
        ! phi_np1 as initial guess:
        w_np1(:,:,1:nlev) = (phi_np1(:,:,1:nlev) -  phi_n0(:,:,1:nlev) )/(dt2*g)
 #endif
@@ -489,6 +196,12 @@ contains
        ! wh_i as initial guess:
        w_np1(:,:,1:nlev)=gwh_i(:,:,1:nlev)/g  
        phi_np1(:,:,1:nlev) =  phi_n0(:,:,1:nlev) +  dt2*g*w_np1(:,:,1:nlev)
+#endif
+#if 1
+       ! use hydrostatic for initial guess
+       call phi_from_eos(hvcoord,elem(ie)%state%phis,elem(ie)%state%vtheta_dp(:,:,:,np1),&
+            elem(ie)%state%dp3d(:,:,:,np1),phi_np1)
+       w_np1(:,:,1:nlev) = (phi_np1(:,:,1:nlev) -  phi_n0(:,:,1:nlev) )/(dt2*g)
 #endif
 
        ! initial residual
@@ -595,15 +308,6 @@ contains
 
     call t_stopf('compute_stage_value_dirk')
   end subroutine compute_stage_value_dirk
-#endif
-
-
-
-
-
-
-
-
 
 
 

--- a/components/homme/src/theta-l/imex_mod.F90
+++ b/components/homme/src/theta-l/imex_mod.F90
@@ -75,7 +75,7 @@ contains
     ! We then precompute:
     !  w_rhs = w_0 + alphadt_n0 * SW(n0)  + alphadt_nm1*SW(nm1) 
     !  phi_rhs = w_0 + alphad_n0 * SPHI(n0)  + alphadt1_nm1*SPHI(nm1) -  dt2*compute_gwphi(np1)
-    ! and solve, via Newton iteraiton:
+    ! and solve, via Newton iteration:
     !   w(np1) = w_rhs + dt2*SW(np1)
     !   phi(np1) = phi_rhs + dt2*g*w(np1)
     !
@@ -116,7 +116,7 @@ contains
 
     real (kind=real_kind) :: wmax
     integer :: maxiter
-    real*8 :: deltatol,restol,deltaerr,reserr,rcond,min_rcond,anorm,dt3,alpha
+    real (kind=real_kind) :: deltatol,restol,deltaerr,reserr,rcond,min_rcond,anorm,dt3,alpha
     real (kind=real_kind) :: dw,dx,alpha_k
     integer :: i,j,k,l,ie,info(np,np),nt
     integer :: nsafe

--- a/components/homme/src/theta-l/imex_mod.F90
+++ b/components/homme/src/theta-l/imex_mod.F90
@@ -253,7 +253,7 @@ contains
 
                 alpha = 0
                 do nsafe=1,8
-                   if (all(dphi(i,j,1:nlev) < 0 ))  exit
+                   if (all(dphi(i,j,1:nlev) < -g ))  exit
                    ! remove the last netwon increment, try reduced increment
                    alpha = 1.0_real_kind/(2**nsafe)
                    do k=1,nlev-1

--- a/components/homme/src/theta-l/model_init_mod.F90
+++ b/components/homme/src/theta-l/model_init_mod.F90
@@ -67,7 +67,7 @@ contains
       enddo
 
       ! initialize reference states used by hyberviscosity
-#define HV_REFSTATES_V1
+#define HV_REFSTATES_V2
 #ifdef HV_REFSTATES_V0
       elem(ie)%derived%dp_ref=0
       elem(ie)%derived%phi_ref=0
@@ -84,6 +84,19 @@ contains
       call phi_from_eos(hvcoord,elem(ie)%state%phis,&
            temp,elem(ie)%derived%dp_ref,elem(ie)%derived%phi_ref)
       elem(ie)%derived%theta_ref=0
+#endif
+#ifdef HV_REFSTATES_V2
+      ps_ref(:,:) = hvcoord%ps0 * exp ( -elem(ie)%state%phis(:,:)/(Rgas*TREF)) 
+      do k=1,nlev
+         elem(ie)%derived%dp_ref(:,:,k) = ( hvcoord%hyai(k+1) - hvcoord%hyai(k) )*hvcoord%ps0 + &
+              (hvcoord%hybi(k+1)-hvcoord%hybi(k))*ps_ref(:,:)
+      enddo
+      call set_theta_ref(hvcoord,elem(ie)%derived%dp_ref,elem(ie)%derived%theta_ref)
+      temp=elem(ie)%derived%theta_ref*elem(ie)%derived%dp_ref
+      call phi_from_eos(hvcoord,elem(ie)%state%phis,&
+           temp,elem(ie)%derived%dp_ref,elem(ie)%derived%phi_ref)
+      elem(ie)%derived%theta_ref=0
+      elem(ie)%derived%dp_ref=0
 #endif
     enddo 
 

--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -658,7 +658,7 @@ contains
       call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG353)
 
     else if (tstep_type==41) then ! ARKode IMKG 3rd-order, 6 stage (4 implicit)
-v      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG354)
+      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG354)
 
     else 
        call abortmp('ERROR: bad choice of tstep_type')

--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -306,7 +306,7 @@ contains
             deriv,nets,nete,maxiter,itertol)
 
 
-       ! u5 = u0 + dt 3/4 RHS(u4)
+       ! u5 = u1 + dt 3/4 RHS(u4)
        call compute_andor_apply_rhs(np1,nm1,np1,qn0,3*dt/4,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,3*eta_ave_w/4,1.d0,0.d0,1.d0)
        ! u(np1) = [u1 + 3dt/4 RHS(u4)] +  1/4 (u1 - u0)    STABLE
@@ -321,6 +321,8 @@ contains
               (elem(ie)%state%w_i(:,:,1:nlevp,nm1)-elem(ie)%state%w_i(:,:,1:nlevp,n0))/4
           elem(ie)%state%phinh_i(:,:,1:nlev,np1)=elem(ie)%state%phinh_i(:,:,1:nlev,np1)+&
                (elem(ie)%state%phinh_i(:,:,1:nlev,nm1)-elem(ie)%state%phinh_i(:,:,1:nlev,n0))/4
+          call limiter_dp3d_k(elem(ie)%state%dp3d(:,:,:,np1),elem(ie)%state%vtheta_dp(:,:,:,np1),&
+               elem(ie)%spheremp,hvcoord%dp0)
        enddo
 
        !  n0          nm1       np1 

--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -363,7 +363,7 @@ contains
       a2=10d0/22
       call compute_andor_apply_rhs(np1,n0,np1,qn0,dt,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,eta_ave_w*1d0,1.d0,0d0,1.d0)
-      call compute_stage_value_dirk(nm1,0d0,n0,a1*dt,np1,a2*dt,qn0,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,a1*dt,n0,a1*dt,np1,a2*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
       !  u0 saved in elem(n0)
       !  u2 saved in elem(nm1)

--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -120,7 +120,7 @@ contains
 !                 (K&G 2nd order method has CFL=4. tiny CFL improvement not worth 2nd order)
 !   tstep_type=7  IMKG254a
 !   tstep_type=8  KG3+BE/CN  KG3 2nd order explicit, 1st order off-centering implicit
-!   tstep_type=9  KGU53+BE/CN  KGU53 3rd order explicit, 1st order off-centering implicit
+!   tstep_type=9  KGU53+BE/CN  KGU53 3rd order explicit, 2st order implicit
 !   tstep_type=10 KG5+BE/CN  KG5(2nd order, 4.0CFL) + BE/CN,  2nd order IMEX
 !
 

--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -118,10 +118,9 @@ contains
 !                 optimal: for windspeeds ~120m/s,gravity: 340m/2
 !                 run with qsplit=1
 !                 (K&G 2nd order method has CFL=4. tiny CFL improvement not worth 2nd order)
-!   tstep_type=6  KG4+BE/CN  2nd order
 !   tstep_type=7  IMKG254a
 !   tstep_type=8  KG3+BE/CN  KG3 2nd order explicit, 1st order off-centering implicit
-!   tstep_type=9  KG5+BE/CN  KG5(3rd order linear, 3.87CFL) + BE/CN,  2nd order IMEX
+!   tstep_type=9  KGU53+BE/CN  KGU53 3rd order explicit, 1st order off-centering implicit
 !   tstep_type=10 KG5+BE/CN  KG5(2nd order, 4.0CFL) + BE/CN,  2nd order IMEX
 !
 
@@ -204,32 +203,6 @@ contains
        ! final method is the same as:
        ! u5 = u0 +  dt/4 RHS(u0)) + 3dt/4 RHS(u4)
 !=========================================================================================
-    elseif (tstep_type == 6) then  ! IMEX-KG4 + CN 
- 
-      call compute_andor_apply_rhs(nm1,n0,n0,qn0,dt/4,elem,hvcoord,hybrid,&
-        deriv,nets,nete,compute_diagnostics,0d0,1d0,0d0,1d0)
-      call compute_stage_value_dirk(n0,nm1,0d0,qn0,dt/4,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
- 
-      call compute_andor_apply_rhs(np1,n0,nm1,qn0,dt/3,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,0d0,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dt/3,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol) 
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt/2,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,0d0,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dt/2,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
-
-      a1=2d0/7
-      a2=3d0/7
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,eta_ave_w,1d0,0d0,1d0)
-      call compute_stage_value_dirk(n0,np1,a1*dt,qn0,a2*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol,nm1)
-
-
-!==============================================================================================
     elseif (tstep_type == 7) then  ! imkg254, most robust of the methods
  
       a1 = 1/4d0
@@ -255,22 +228,22 @@ contains
 
       call compute_andor_apply_rhs(np1,n0,n0,qn0,a1*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,compute_diagnostics,0d0,1d0,0d0,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat1*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dhat1*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       call compute_andor_apply_rhs(np1,n0,np1,qn0,a2*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,.false.,0d0,1d0,ahat2/a2,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat2*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dhat2*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       call compute_andor_apply_rhs(np1,n0,np1,qn0,a3*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,.false.,0d0,1d0,ahat3/a3,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat3*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dhat3*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       call compute_andor_apply_rhs(np1,n0,np1,qn0,a4*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,.false.,0d0,1d0,ahat4/a4,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat4*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dhat4*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
       call compute_andor_apply_rhs(np1,n0,np1,qn0,a5*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,.false.,eta_ave_w,1d0,ahat5/a5,1d0)
@@ -286,13 +259,13 @@ contains
       call compute_andor_apply_rhs(np1,n0,n0,qn0,dt/2,elem,hvcoord,hybrid,&
         deriv,nets,nete,compute_diagnostics,0d0,1d0,0d0,1d0) !   aphat/ap,1d0)               
 
-      call compute_stage_value_dirk(n0,np1,aphat*dt/2,qn0,dhat3*dt/2,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,aphat*dt/2,np1,dhat3*dt/2,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       call compute_andor_apply_rhs(np1,n0,np1,qn0,dt/2,elem,hvcoord,hybrid,&
         deriv,nets,nete,.false.,0d0,1d0,0d0,1d0)
 
-      call compute_stage_value_dirk(n0,np1,aphat*dt/2,qn0,dhat3*dt/2,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,aphat*dt/2,np1,dhat3*dt/2,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       ! introduce 1st order offcentering
@@ -302,81 +275,95 @@ contains
 
       call compute_andor_apply_rhs(np1,n0,np1,qn0,dt,elem,hvcoord,hybrid,&
            deriv,nets,nete,.false.,eta_ave_w,1d0,0d0,1d0)
-      call compute_stage_value_dirk(n0,np1,aphat*dt,qn0,dhat3*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,aphat*dt,np1,dhat3*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
-    else if (tstep_type==9) then ! KG5(3rd order linear) + CN + offcenter
-      a1=0d0
-      a2=1-a1
-      dt2=dt/5     
-      call compute_andor_apply_rhs(nm1,n0,n0,qn0,dt2,elem,hvcoord,hybrid,&
-            deriv,nets,nete,compute_diagnostics,0d0,1.d0,0.d0,1.d0)
-      call compute_stage_value_dirk(n0,nm1,a1*dt2,qn0,a2*dt2,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
+    else if (tstep_type==9) then 
+       ! KGU5-3 (3rd order) with IMEX backward euler (2nd order)
+       ! 
+       ! u1 = u0 + dt/5 RHS(u0)  (save u1 in timelevel nm1)
+       call compute_andor_apply_rhs(nm1,n0,n0,qn0,dt/5,elem,hvcoord,hybrid,&
+            deriv,nets,nete,compute_diagnostics,eta_ave_w/4,1.d0,0.d0,1.d0)
+       call compute_stage_value_dirk(nm1,0d0,n0,0d0,nm1,dt/5,qn0,elem,hvcoord,hybrid,&
+            deriv,nets,nete,maxiter,itertol)
 
-      dt2=dt/5     
-      call compute_andor_apply_rhs(np1,n0,nm1,qn0,dt2,elem,hvcoord,hybrid,&
+       ! u2 = u0 + dt/5 RHS(u1)
+       call compute_andor_apply_rhs(np1,n0,nm1,qn0,dt/5,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,0d0,1.d0,0.d0,1.d0)
-      call compute_stage_value_dirk(n0,np1,a1*dt2,qn0,a2*dt2,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
+       call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dt/5,qn0,elem,hvcoord,hybrid,&
+            deriv,nets,nete,maxiter,itertol)
 
-      dt2=dt/3
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt2,elem,hvcoord,hybrid,&
+       ! u3 = u0 + dt/3 RHS(u2)
+       call compute_andor_apply_rhs(np1,n0,np1,qn0,dt/3,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,0d0,1.d0,0.d0,1.d0)
-      call compute_stage_value_dirk(n0,np1,a1*dt2,qn0,a2*dt2,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
+       call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dt/3,qn0,elem,hvcoord,hybrid,&
+            deriv,nets,nete,maxiter,itertol)
 
-
-      dt2=dt/2
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt2,elem,hvcoord,hybrid,&
+       ! u4 = u0 + 2dt/3 RHS(u3)
+       call compute_andor_apply_rhs(np1,n0,np1,qn0,2*dt/3,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,0d0,1.d0,0.d0,1.d0)
-      call compute_stage_value_dirk(n0,np1,a1*dt2,qn0,a2*dt2,elem,hvcoord,hybrid,&
+       call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,2*dt/3,qn0,elem,hvcoord,hybrid,&
+            deriv,nets,nete,maxiter,itertol)
+
+
+       ! u5 = u0 + dt 3/4 RHS(u4)
+       call compute_andor_apply_rhs(np1,nm1,np1,qn0,3*dt/4,elem,hvcoord,hybrid,&
+            deriv,nets,nete,.false.,3*eta_ave_w/4,1.d0,0.d0,1.d0)
+       ! u(np1) = [u1 + 3dt/4 RHS(u4)] +  1/4 (u1 - u0)    STABLE
+       do ie=nets,nete
+          elem(ie)%state%v(:,:,:,:,np1)=elem(ie)%state%v(:,:,:,:,np1)+&
+               (elem(ie)%state%v(:,:,:,:,nm1)-elem(ie)%state%v(:,:,:,:,n0))/4
+          elem(ie)%state%vtheta_dp(:,:,:,np1)=elem(ie)%state%vtheta_dp(:,:,:,np1)+&
+               (elem(ie)%state%vtheta_dp(:,:,:,nm1)-elem(ie)%state%vtheta_dp(:,:,:,n0))/4
+          elem(ie)%state%dp3d(:,:,:,np1)=elem(ie)%state%dp3d(:,:,:,np1)+&
+               (elem(ie)%state%dp3d(:,:,:,nm1)-elem(ie)%state%dp3d(:,:,:,n0))/4
+          elem(ie)%state%w_i(:,:,1:nlevp,np1)=elem(ie)%state%w_i(:,:,1:nlevp,np1)+&
+              (elem(ie)%state%w_i(:,:,1:nlevp,nm1)-elem(ie)%state%w_i(:,:,1:nlevp,n0))/4
+          elem(ie)%state%phinh_i(:,:,1:nlev,np1)=elem(ie)%state%phinh_i(:,:,1:nlev,np1)+&
+               (elem(ie)%state%phinh_i(:,:,1:nlev,nm1)-elem(ie)%state%phinh_i(:,:,1:nlev,n0))/4
+       enddo
+
+       !  n0          nm1       np1 
+       ! u0*5/18  + u1*1/36  + u5*8/18
+       a1=5*dt/18
+       a2=dt/36
+       a3=8*dt/18
+       call compute_stage_value_dirk(nm1,a2,n0,a1,np1,a3,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
-      a1=5d0/18
-      a2=8d0/18
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt,elem,hvcoord,hybrid,&
-            deriv,nets,nete,.false.,eta_ave_w*1d0,1.d0,0d0,1.d0)
-      call compute_stage_value_dirk(n0,np1,a1*dt,qn0,a2*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol,nm1)
-      !  u0 saved in elem(n0)
-      !  u1 saved in elem(nm1)
-      !  u4 saved in elem(np1)
-      !  u5 = u0 + dt*N(u4) + dt*5/18*S(u0) + dt*5/18 S(u1) + dt*8/18* S(u5)
-      
     else if (tstep_type==10) then ! KG5(2nd order CFL=4) + CN + offcenter
       a1=0d0
       a2=1-a1
       dt2=dt/4
       call compute_andor_apply_rhs(np1,n0,n0,qn0,dt2,elem,hvcoord,hybrid,&
             deriv,nets,nete,compute_diagnostics,0d0,1.d0,0.d0,1.d0)
-      call compute_stage_value_dirk(n0,np1,a1*dt2,qn0,a2*dt2,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,a1*dt2,np1,a2*dt2,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       dt2=dt/6
       call compute_andor_apply_rhs(nm1,n0,np1,qn0,dt2,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,0d0,1.d0,0.d0,1.d0)
-      call compute_stage_value_dirk(n0,nm1,a1*dt2,qn0,a2*dt2,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,a1*dt2,nm1,a2*dt2,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       dt2=3*dt/8
       call compute_andor_apply_rhs(np1,n0,nm1,qn0,dt2,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,0d0,1.d0,0.d0,1.d0)
-      call compute_stage_value_dirk(n0,np1,a1*dt2,qn0,a2*dt2,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,a1*dt2,np1,a2*dt2,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
 
       dt2=dt/2
       call compute_andor_apply_rhs(np1,n0,np1,qn0,dt2,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,0d0,1.d0,0.d0,1.d0)
-      call compute_stage_value_dirk(n0,np1,a1*dt2,qn0,a2*dt2,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,a1*dt2,np1,a2*dt2,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       a1=6d0/22 
       a2=10d0/22
       call compute_andor_apply_rhs(np1,n0,np1,qn0,dt,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,eta_ave_w*1d0,1.d0,0d0,1.d0)
-      call compute_stage_value_dirk(n0,np1,a1*dt,qn0,a2*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,a1*dt,np1,a2*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol,nm1)
       !  u0 saved in elem(n0)
       !  u2 saved in elem(nm1)
@@ -475,7 +462,6 @@ contains
 !                 optimal: for windspeeds ~120m/s,gravity: 340m/2
 !                 run with qsplit=1
 !                 (K&G 2nd order method has CFL=4. tiny CFL improvement not worth 2nd order)
-!   tstep_type=6  IMEX-KG243 
 !   tstep_type=7  IMEX-KG254
 !   
 
@@ -558,54 +544,6 @@ contains
        ! final method is the same as:
        ! u5 = u0 +  dt/4 RHS(u0)) + 3dt/4 RHS(u4)
 !=========================================================================================
-    elseif (tstep_type == 6) then  ! IMEX-KG243
-
-      a1 = 1./4.
-      a2 = 1./3.
-      a3 = 1./2.
-      a4 = 1.0
-
-      ahat4 = 1.
-      ahat1 = 0.
-      ! IMEX-KGNO243
-      dhat2 = (1.+sqrt(3.)/3.)/2.
-      dhat3 = dhat2
-      ahat3 = 1./2.-dhat3
-      dhat1 = (ahat3-dhat2+dhat2*dhat3)/(1.-dhat2-dhat3)
-      ahat2 = (dhat1-dhat1*dhat3-dhat1*dhat2+dhat1*dhat2*dhat3)/(1.-dhat3)
-
-      call compute_andor_apply_rhs(np1,n0,n0,qn0,dt*a1,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,0d0,1d0)
-  
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat1*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
-      sumiter = maxiter 
-
- 
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt*a2,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,ahat2/a2,1d0)
-
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat2*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol) 
-      sumiter = sumiter + maxiter
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt*a3,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,ahat3/a3,1d0)
-
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat3*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
-      sumiter = sumiter + maxiter
-
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt*a4,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,eta_ave_w,1d0,ahat4/a4,1d0)
-      if (calc_nonlinear_stats) then
-        call update_nonlinear_stats(1, sumiter)
-      end if
-
-
-!==============================================================================================
-!==============================================================================================
     elseif (tstep_type == 7) then  ! imkg254, most robust of the methods
  
       a1 = 1/4d0
@@ -631,122 +569,26 @@ contains
 
       call compute_andor_apply_rhs(np1,n0,n0,qn0,a1*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,compute_diagnostics,0d0,1d0,0d0,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat1*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dhat1*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       call compute_andor_apply_rhs(np1,n0,np1,qn0,a2*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,.false.,0d0,1d0,ahat2/a2,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat2*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dhat2*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       call compute_andor_apply_rhs(np1,n0,np1,qn0,a3*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,.false.,0d0,1d0,ahat3/a3,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat3*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dhat3*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       call compute_andor_apply_rhs(np1,n0,np1,qn0,a4*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,.false.,0d0,1d0,ahat4/a4,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat4*dt,elem,hvcoord,hybrid,&
+      call compute_stage_value_dirk(nm1,0d0,n0,0d0,np1,dhat4*dt,qn0,elem,hvcoord,hybrid,&
         deriv,nets,nete,maxiter,itertol)
 
       call compute_andor_apply_rhs(np1,n0,np1,qn0,a5*dt,elem,hvcoord,hybrid,&
         deriv,nets,nete,.false.,eta_ave_w,1d0,ahat5/a5,1d0)
-
-!================================================================================
-    elseif (tstep_type == 8) then ! IMKG253, might be more efficient than IMKG254, might be a teeny bit bad at coarse resolution
-
-      a1 = 1/4d0
-      a2 = 1/6d0
-      a3 = 3/8d0
-      a4 = 1/2d0
-      a5 = 1d0
-      ahat5 = 1d0
-
-      dhat4 = 1d0
-      dhat3 = 1d0
-      ahat4 = -1d0/2d0
-      dhat2= (ahat4*ahat5 - ahat5*dhat1 - ahat5*dhat3 + dhat1*dhat3+ dhat1*dhat4 + dhat3*dhat4)/(ahat5-dhat1-dhat3-dhat4)
-      ahat3 = (-ahat4*ahat5*dhat2+ahat5*dhat2*dhat3- dhat2*dhat3*dhat4)/(-ahat4*ahat5)
-
-      call compute_andor_apply_rhs(np1,n0,n0,qn0,a1*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,compute_diagnostics,0d0,1d0,0d0,1d0)
- 
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,a2*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,0d0,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat2*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,a3*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,ahat3/a3,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat3*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,a4*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,ahat4/a4,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat4*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,a5*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,eta_ave_w,1d0,ahat5/a5,1d0)
-
-!================================================================================
-    elseif (tstep_type == 9) then ! IMKG252, use if feeling lucky, might be bad at coarse resolution
- 
-      a1 = 1/4d0
-      a2 = 1/6d0
-      a3 = 3/8d0
-      a4 = 1/2d0
-      a5 = 1d0
-      ahat5 = 1d0
-
-      dhat3 = (2d0+sqrt(2d0))/2d0
-      dhat4 = (2d0+sqrt(2d0))/2d0
-      ahat4 = -(1d0+sqrt(2d0))/2d0
-
-      call compute_andor_apply_rhs(np1,n0,n0,qn0,a1*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,compute_diagnostics,0d0,1d0,0d0,1d0)
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,a2*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,0d0,1d0)
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,a3*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,0d0,1d0) 
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat3*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,a4*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,ahat4/a4,1d0)
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat4*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,a5*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,eta_ave_w,1d0,ahat5/a5,1d0)
-
-! ==================================================================================
-    elseif (tstep_type == 10) then ! IMKG232b
-      a1 = 1d0/2d0
-      a2 = 1d0/2d0
-      a3 = 1d0
-      ahat3 = 1d0
-      dhat2 = .5d0*(2d0+sqrt(2d0))
-      dhat1 = dhat2
-      ahat2 = -(1d0+sqrt(2d0))/2d0
-
-      call compute_andor_apply_rhs(np1,n0,n0,qn0,dt*a1,elem,hvcoord,hybrid,&
-        deriv,nets,nete,compute_diagnostics,0d0,1d0,0d0,1d0)  
-
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat1*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol)
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt*a2,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,ahat2/a2,1d0)
-
-      call compute_stage_value_dirk(n0,np1,0d0,qn0,dhat2*dt,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol) 
-
-      call compute_andor_apply_rhs(np1,n0,np1,qn0,dt*a3,elem,hvcoord,hybrid,&
-        deriv,nets,nete,.false.,0d0,1d0,ahat3/a3,1d0)
-
 
 
 !=========================================================================================
@@ -814,7 +656,7 @@ contains
       call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG353)
 
     else if (tstep_type==41) then ! ARKode IMKG 3rd-order, 6 stage (4 implicit)
-      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG354)
+v      call set_Butcher_tables(arkode_parameters, arkode_tables%IMKG354)
 
     else 
        call abortmp('ERROR: bad choice of tstep_type')

--- a/components/homme/src/theta-l/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/prim_advance_mod.F90
@@ -364,7 +364,7 @@ contains
       call compute_andor_apply_rhs(np1,n0,np1,qn0,dt,elem,hvcoord,hybrid,&
             deriv,nets,nete,.false.,eta_ave_w*1d0,1.d0,0d0,1.d0)
       call compute_stage_value_dirk(nm1,0d0,n0,a1*dt,np1,a2*dt,qn0,elem,hvcoord,hybrid,&
-        deriv,nets,nete,maxiter,itertol,nm1)
+        deriv,nets,nete,maxiter,itertol)
       !  u0 saved in elem(n0)
       !  u2 saved in elem(nm1)
       !  u4 saved in elem(np1)

--- a/components/homme/test/held_suarez0/hsave.ncl
+++ b/components/homme/test/held_suarez0/hsave.ncl
@@ -9,7 +9,7 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 
 begin
 
-tmin=200
+tmin=100
 tmax=38000
 
 


### PR DESCRIPTION
1.  Switch newton iteration to iterate on w instead of PHI.   This formulation removes all scans (for improved GPU performance), improves precision (allowing residuals down to 1e-11) and makes for better normalization of the Newton increment and residual norms.  

2.  Add "tstep_type=9", an IMEX method based on the KGU53 explicit table used by the hydrostatic code, and adding a 2nd order implicit table.

3.  adjust reference profiles to those found best for HS+topo simulations (but resulting in a degradation in the DCMIP Shar mountain test case)

4. remove obsolete IMEX timestepping algorithms.  

[non-BFB] for theta-l H and NH tests

testing and documentation of KGU53-IMEX method:
https://acme-climate.atlassian.net/wiki/spaces/NGDNA/pages/1041401881/IMEX+methods
