### PR TITLE
theta model uses omega, not omega/p

### DIFF
--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -161,7 +161,7 @@ CONTAINS
 
        neltmp(1) = nelemdmax
        neltmp(2) = nelem
-       neltmp(3) = get_dyn_grid_parm('plon')
+       neltmp(3) = GlobalUniqueCols ! get_dyn_grid_parm('plon')
     else
        nelemd = 0
        neltmp(1) = 0

--- a/components/cam/src/dynamics/se/interp_mod.F90
+++ b/components/cam/src/dynamics/se/interp_mod.F90
@@ -5,7 +5,7 @@ module interp_mod
   use interpolate_mod,     only: interpdata_t
   use interpolate_mod,     only: interp_lat => lat, interp_lon => lon
   use interpolate_mod,     only: interp_gweight => gweight
-  use dyn_grid,            only: elem
+  use dyn_grid,            only: elem,fv_nphys
   use spmd_utils,          only: masterproc, iam, npes
   use cam_history_support, only: fillvalue
   use hybrid_mod,          only: hybrid_t, hybrid_create
@@ -74,6 +74,11 @@ CONTAINS
           write(iulog,*) 'Atmopshere MPI tasks:  atm_ntasks=',npes
           write(iulog,*) 'SE dycore MPI tasks, number of elements:',par%nprocs,nelem
           call endrun('setup_history_interpolation: interpolated output not supported if atm_ntasks>dyn_npes')
+       endif
+       if (fv_nphys /= 0  ) then
+          write(iulog,*) 'Atmopshere MPI tasks:  atm_ntasks=',npes
+          write(iulog,*) 'SE dycore MPI tasks, number of elements:',par%nprocs,nelem
+          call endrun('setup_history_interpolation: interpolated output not supported with physgrid')
        endif
     endif
 

--- a/components/homme/src/share/gllfvremap_mod.F90
+++ b/components/homme/src/share/gllfvremap_mod.F90
@@ -305,8 +305,11 @@ contains
        call gfr_g2f_scalar(ie, elem(ie)%metdet, wr2, wr1)
        ! When omega_p is switched to omega, remove the division by
        ! p_fv.
+#ifdef MODEL_THETA_L
+       omega_p(:ncol,:,ie) = reshape(wr1(:nf,:nf,:), (/ncol,nlev/))
+#else       
        omega_p(:ncol,:,ie) = reshape(wr1(:nf,:nf,:)/p_fv(:nf,:nf,:), (/ncol,nlev/))
-
+#endif
        do qi = 1,qsize
           call gfr_g2f_mixing_ratio(gfr, ie, elem(ie)%metdet, dp, dp_fv, &
                dp*elem(ie)%state%Q(:,:,:,qi), wr1)

--- a/components/homme/src/share/gllfvremap_mod.F90
+++ b/components/homme/src/share/gllfvremap_mod.F90
@@ -303,11 +303,10 @@ contains
 
        call get_field(elem(ie), 'omega', wr2, hvcoord, nt, -1)
        call gfr_g2f_scalar(ie, elem(ie)%metdet, wr2, wr1)
-       ! When omega_p is switched to omega, remove the division by
-       ! p_fv.
 #ifdef MODEL_THETA_L
        omega_p(:ncol,:,ie) = reshape(wr1(:nf,:nf,:), (/ncol,nlev/))
-#else       
+#else
+       ! for preqx, omega_p = omega/p
        omega_p(:ncol,:,ie) = reshape(wr1(:nf,:nf,:)/p_fv(:nf,:nf,:), (/ncol,nlev/))
 #endif
        do qi = 1,qsize

--- a/components/homme/src/share/gllfvremap_util_mod.F90
+++ b/components/homme/src/share/gllfvremap_util_mod.F90
@@ -304,7 +304,11 @@ contains
                 !  is removed, remove the pressure calculations here.
                 call get_field(elem(ie), 'p', pressure, hvcoord, nt1, -1)
                 call gfr_g2f_scalar(ie, elem(ie)%metdet, pressure, p_fv)
+#ifdef MODEL_THETA_L
+                wr1(:nf,:nf,:) = reshape(pg_data%omega_p(:,:,ie), (/nf,nf,nlev/))
+#else                
                 wr1(:nf,:nf,:) = reshape(pg_data%omega_p(:,:,ie), (/nf,nf,nlev/))*p_fv(:nf,:nf,:)
+#endif                
                 !  Compare.
                 global_shared_buf(ie,1) = sum((wr1(:nf,:nf,:) - wr2(:nf,:nf,:))**2)
                 global_shared_buf(ie,2) = sum(wr2(:nf,:nf,:)**2)

--- a/components/homme/src/share/gllfvremap_util_mod.F90
+++ b/components/homme/src/share/gllfvremap_util_mod.F90
@@ -300,8 +300,7 @@ contains
                 !  True omega on GLL and FV grids.
                 call get_field(elem(ie), 'omega', wr1, hvcoord, nt1, -1)
                 call gfr_g2f_scalar(ie, elem(ie)%metdet, wr1, wr2)
-                !  Convert omega_p on FV grid to omega. When omega_p
-                !  is removed, remove the pressure calculations here.
+                !  Convert omega_p on FV grid to omega for preqx
                 call get_field(elem(ie), 'p', pressure, hvcoord, nt1, -1)
                 call gfr_g2f_scalar(ie, elem(ie)%metdet, pressure, p_fv)
 #ifdef MODEL_THETA_L


### PR DESCRIPTION
pg2 bugfixes

1. theta model uses omega, not omega/p
2. bugfix when dynpes<npes GLL  grid dimension not set correctly on non-dyn PEs
3. add an abort if physgrid is used with interpolated output (not yet supported)

[nonBFB] for SMS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.cam-thetahy_sl_pg2 and all other theta tests