### PR TITLE
update XML defaults for theta-l dycore (V2)

### DIFF
--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -4023,10 +4023,10 @@ if ($cfg->get('dyn') =~ /se/) {
     my @vars = qw(se_nsplit hypervis_order phys_loadbalance
                   hypervis_subcycle hypervis_subcycle_q hypervis_subcycle_tom
                   statefreq se_partmethod se_topology se_ftype
-                  integration nu nu_div nu_p nu_q nu_top
+                  integration nu nu_div nu_p nu_q nu_s nu_top
                   vert_remap_q_alg se_limiter_option qsplit rsplit tstep_type
                   hypervis_scaling mesh_file vthreads
-                  theta_hydrostatic_mode transport_alg
+                  theta_hydrostatic_mode transport_alg theta_advect_form
                   se_tstep dt_tracer_factor dt_remap_factor 
                   );
 

--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -4028,6 +4028,7 @@ if ($cfg->get('dyn') =~ /se/) {
                   hypervis_scaling mesh_file vthreads
                   theta_hydrostatic_mode transport_alg theta_advect_form
                   se_tstep dt_tracer_factor dt_remap_factor 
+                  cubed_sphere_map
                   );
 
     foreach my $var (@vars) {

--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -4021,11 +4021,14 @@ if ($cfg->get('dyn') =~ /se/) {
     }
 
     my @vars = qw(se_nsplit hypervis_order phys_loadbalance
-                  hypervis_subcycle hypervis_subcycle_q
+                  hypervis_subcycle hypervis_subcycle_q hypervis_subcycle_tom
                   statefreq se_partmethod se_topology se_ftype
-                  integration nu nu_div nu_p nu_q nu_top  se_phys_tscale
+                  integration nu nu_div nu_p nu_q nu_top
                   vert_remap_q_alg se_limiter_option qsplit rsplit tstep_type
-                  hypervis_scaling mesh_file vthreads);
+                  hypervis_scaling mesh_file vthreads
+                  theta_hydrostatic_mode transport_alg
+                  se_tstep dt_tracer_factor dt_remap_factor 
+                  );
 
     foreach my $var (@vars) {
 	add_default($nl, $var);

--- a/components/cam/bld/config_files/defaults_se.xml
+++ b/components/cam/bld/config_files/defaults_se.xml
@@ -3,6 +3,7 @@
 <config_definition>
 
 <entry id="dyn"   value="se"  />
+<entry id="dyn_target"   value="preqx"  />
 <entry id="hgrid" value="ne16np4" />
 <entry id="pcols" value="16" />
 

--- a/components/cam/bld/config_files/definition.xml
+++ b/components/cam/bld/config_files/definition.xml
@@ -26,6 +26,9 @@ Component interfaces: mct or esmf.  Default: mct.
 <entry id="dyn" valid_values="eul,sld,fv,homme,se" value="">
 Dynamics package: eul, sld, fv, or se.
 </entry>
+<entry id="dyn_target" valid_values="preqx,theta-l,preqx_acc,preqx_kokkos" value="">          
+SE dynamical core option.
+</entry>        
 <entry id="waccm_phys" valid_values="0,1" value="0">
 Switch to turn on waccm physics: 0 => no, 1 => yes.
 </entry>

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -756,6 +756,9 @@ if (defined $opts{'dyn'}) {
     } else {
       $cfg_ref->set('dyn', lc($opts{'dyn'}) );
     }
+    if (defined $opts{'dyn_target'}) {                                                        
+        $cfg_ref->set('dyn_target', $opts{'dyn_target'});                                     
+    }                                                                                         
 }
 
 my $dyn_pkg = $cfg_ref->get('dyn');
@@ -1843,7 +1846,7 @@ if ($offline_dyn) { $cfg_cppdefs .= ' -DOFFLINE_DYN'; }
 # Spectral Element dycore
 if($dyn_pkg eq 'se'){
     if ($spmd eq 'ON'){	$cfg_cppdefs .=" -D_MPI"; }
-    $cfg_cppdefs .= " -DCAM  -D_WK_GRAD -D_PRIM ";
+    $cfg_cppdefs .= " -DCAM -D_PRIM ";
 }
 
 # -DSPMD only added for CESM build.  The CAM Makefile has a separate SPMD macro.

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -757,8 +757,20 @@ if (defined $opts{'dyn'}) {
       $cfg_ref->set('dyn', lc($opts{'dyn'}) );
     }
     if (defined $opts{'dyn_target'}) {                                                        
-        $cfg_ref->set('dyn_target', $opts{'dyn_target'});                                     
-    }                                                                                         
+        #$cfg_ref->set('dyn_target', $opts{'dyn_target'});
+        if (substr($opts{'dyn_target'},0,5) eq 'preqx') {
+            # preqx, preqx_acc, preqx_kokkos use 'preqx' namelist defaults
+            $cfg_ref->set('dyn_target', 'preqx');
+        }
+        if (substr($opts{'dyn_target'},0,5) eq 'theta') {
+            # theta_* uses 'theta-l' namelist defaults
+            $cfg_ref->set('dyn_target', 'theta-l');
+        }
+        print  "SE dycore target options:\n";
+        print  "  build target:    $opts{'dyn_target'}\n";
+        my $temp = $cfg_ref->get('dyn_target');
+        print  "  namelist target: $temp\n";
+    }
 }
 
 my $dyn_pkg = $cfg_ref->get('dyn');

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1455,16 +1455,24 @@
 <!-- viscosity  -->
 
 <nu_top> 2.5e5 </nu_top>
-<nu_top hgrid="ne240np4"> 1.0e5 </nu_top>
+<nu_top dyn_target="preqx" hgrid="ne240np4"> 1.0e5 </nu_top>
+<nu_top dyn_target="theta-l" hgrid="ne120np4"> 1e5 </nu_top>
+<nu_top dyn_target="theta-l" hgrid="ne240np4"> 4.3e4 </nu_top>
+<nu_top dyn_target="theta-l" hgrid="ne256np4"> 4e4 </nu_top>
+<nu_top dyn_target="theta-l" hgrid="ne512np4"> 2e4 </nu_top>
+<nu_top dyn_target="theta-l" hgrid="ne1024np4"> 1e4 </nu_top>
+
 
 <nu>                   1.0e15 </nu>
 <nu hgrid="ne4np4" >   5.0e17 </nu>
 <nu hgrid="ne11np4" >  2.0e16 </nu>
 <nu hgrid="ne16np4" >  7.0e15 </nu>
 <nu hgrid="ne30np4" >  1.0e15 </nu>
-<nu hgrid="ne60np4" >  1.0e14 </nu>
+<nu hgrid="ne60np4" >  1.25e14 </nu>
 <nu hgrid="ne120np4">  1.0e13 </nu>
-<nu hgrid="ne240np4">  1.1e12 </nu>
+<nu dyn_target="theta-l" hgrid="ne120np4">  1.5e13 </nu>
+<nu hgrid="ne240np4">  1.9e12 </nu>
+<nu hgrid="ne256np4">  1.6e12 </nu>
 <nu hgrid="ne512np4">  2.0e11 </nu>
 <nu hgrid="ne1024np4"> 2.5e10 </nu>
 <nu hgrid="ne0np4_arm_x8v3_lowcon"  > 8.0e-8</nu>
@@ -1481,22 +1489,23 @@
 <nu_p> -1.0 </nu_p>
 <nu_div> -1.0 </nu_div>
 
+<!-- theta-l dycore uses nu_div=-1, except for historical ne4 test cases -->
 <nu_div hgrid="ne4np4" >  1.25e18 </nu_div>
-<nu_div hgrid="ne11np4" >  5.0e16 </nu_div>
-<nu_div hgrid="ne16np4" > 15.5e15 </nu_div>
-<nu_div hgrid="ne30np4" >  2.5e15 </nu_div>
-<nu_div hgrid="ne60np4" >  2.5e14 </nu_div>
-<nu_div hgrid="ne120np4">  2.5e13 </nu_div>
-<nu_div hgrid="ne240np4">  2.5e12 </nu_div>
-<nu_div hgrid="ne512np4">  5.0e11 </nu_div>
-<nu_div hgrid="ne1024np4"> 6.25e10 </nu_div>
-<nu_div hgrid="ne0np4_arm_x8v3_lowcon"  > 20.0e-8</nu_div>
-<nu_div hgrid="ne0np4_conus_x4v1_lowcon"  > 20.0e-8</nu_div>
-<nu_div hgrid="ne0np4_northamericax4v1"  > 20.0e-8</nu_div>
-<nu_div hgrid="ne0np4_svalbard_x8v1_lowcon"  > 20.0e-8</nu_div>
-<nu_div hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 20.0e-8</nu_div>
-<nu_div hgrid="ne0np4_enax4v1">20.0e-8</nu_div>
-<nu_div hgrid="ne0np4_twpx4v1" >20.0e-8</nu_div>
+<nu_div dyn_target="preqx" hgrid="ne11np4" >  5.0e16 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne16np4" > 15.5e15 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne30np4" >  2.5e15 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne60np4" >  2.5e14 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne120np4">  2.5e13 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne240np4">  2.5e12 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne512np4">  5.0e11 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne1024np4"> 6.25e10 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne0np4_arm_x8v3_lowcon"  > 20.0e-8</nu_div>
+<nu_div dyn_target="preqx" hgrid="ne0np4_conus_x4v1_lowcon"  > 20.0e-8</nu_div>
+<nu_div dyn_target="preqx" hgrid="ne0np4_northamericax4v1"  > 20.0e-8</nu_div>
+<nu_div dyn_target="preqx" hgrid="ne0np4_svalbard_x8v1_lowcon"  > 20.0e-8</nu_div>
+<nu_div dyn_target="preqx" hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 20.0e-8</nu_div>
+<nu_div dyn_target="preqx" hgrid="ne0np4_enax4v1">20.0e-8</nu_div>
+<nu_div dyn_target="preqx" hgrid="ne0np4_twpx4v1" >20.0e-8</nu_div>
 
 <hypervis_order >     2 </hypervis_order>
 

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1409,6 +1409,39 @@
 <statefreq> 480 </statefreq>
 <integration> "explicit" </integration>
 
+<se_ftype> 2 </se_ftype>
+
+<se_limiter_option> 9 </se_limiter_option>
+<se_limiter_option dyn_target="preqx"> 8 </se_limiter_option>
+
+<vert_remap_q_alg> 10 </vert_remap_q_alg>
+<vert_remap_q_alg dyn_target="preqx"> 1 </vert_remap_q_alg>
+
+
+<theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
+
+<interpolate_analysis> .false. </interpolate_analysis>
+<interp_nlon> 0 </interp_nlon>
+<interp_nlat> 0 </interp_nlat>
+<interp_type> 1 </interp_type>
+<interp_gridtype> 1 </interp_gridtype>
+<vthreads> 1 </vthreads>
+
+<transport_alg> 12 </transport_alg>
+<transport_alg dyn_target="preqx"> 0 </transport_alg>
+
+<se_fv_phys_remap_alg> 1 </se_fv_phys_remap_alg>
+
+<!-- RRM grids  -->
+
+<se_ne hgrid="ne0np4_arm_x8v3_lowcon"  > 0 </se_ne>
+<se_ne hgrid="ne0np4_conus_x4v1_lowcon"  > 0 </se_ne>
+<se_ne hgrid="ne0np4_northamericax4v1"  > 0 </se_ne>
+<se_ne hgrid="ne0np4_svalbard_x8v1_lowcon"  > 0 </se_ne>
+<se_ne hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 0 </se_ne>
+<se_ne hgrid="ne0np4_enax4v1">0</se_ne>
+<se_ne hgrid="ne0np4_twpx4v1" > 0 </se_ne>
+
 <mesh_file>/dev/null</mesh_file>
 <mesh_file hgrid="ne0np4_arm_x8v3_lowcon"  >atm/cam/inic/homme/arm_x8v3_lowcon.g</mesh_file>
 <mesh_file hgrid="ne0np4_conus_x4v1_lowcon"  >atm/cam/inic/homme/conusx4v1.g</mesh_file>
@@ -1417,6 +1450,9 @@
 <mesh_file hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  >atm/cam/inic/homme/sooberingoax4x8v1.g</mesh_file>
 <mesh_file hgrid="ne0np4_enax4v1">atm/cam/inic/homme/enax4v1.g</mesh_file>
 <mesh_file hgrid="ne0np4_twpx4v1" >atm/cam/inic/homme/twpx4v1.g</mesh_file>
+
+
+<!-- viscosity  -->
 
 <nu_top> 2.5e5 </nu_top>
 <nu_top hgrid="ne240np4"> 1.0e5 </nu_top>
@@ -1442,27 +1478,9 @@
 
 <!-- This will set nu_q to nu internally. -->
 <nu_q> -1.0 </nu_q>
+<nu_p> -1.0 </nu_p>
+<nu_div> -1.0 </nu_div>
 
-<nu_p>                   1.0e15 </nu_p>
-<nu_p hgrid="ne4np4" >   5.0e17 </nu_p>
-<nu_p hgrid="ne11np4" >  2.0e16 </nu_p>
-<nu_p hgrid="ne16np4" >  7.0e15 </nu_p>
-<nu_p hgrid="ne30np4" >  1.0e15 </nu_p>
-<nu_p hgrid="ne60np4" >  1.0e14 </nu_p>
-<nu_p hgrid="ne120np4">  1.0e13 </nu_p>
-<nu_p hgrid="ne240np4">  1.1e12 </nu_p>
-<nu_p hgrid="ne512np4">  2.0e11 </nu_p>
-<nu_p hgrid="ne1024np4"> 2.5e10 </nu_p>
-<nu_p hgrid="ne0np4_arm_x8v3_lowcon"  > 8.0e-8</nu_p>
-<nu_p hgrid="ne0np4_conus_x4v1_lowcon"  > 8.0e-8</nu_p>
-<nu_p hgrid="ne0np4_northamericax4v1"  > 8.0e-8</nu_p>
-<nu_p hgrid="ne0np4_svalbard_x8v1_lowcon"  > 8.0e-8</nu_p>
-<nu_p hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 8.0e-8</nu_p>
-<nu_p hgrid="ne0np4_enax4v1">8.0e-8</nu_p>
-<nu_p hgrid="ne0np4_twpx4v1" >8.0e-8</nu_p>
-
-
-<nu_div>                   2.5e15 </nu_div>
 <nu_div hgrid="ne4np4" >  1.25e18 </nu_div>
 <nu_div hgrid="ne11np4" >  5.0e16 </nu_div>
 <nu_div hgrid="ne16np4" > 15.5e15 </nu_div>
@@ -1482,67 +1500,6 @@
 
 <hypervis_order >     2 </hypervis_order>
 
-<hypervis_subcycle>                   3 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne4np4" >   3 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne11np4" >  3 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne16np4" >  3 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne30np4" >  3 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne60np4" >  4 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne120np4">  4 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne240np4">  4 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne512np4">  10 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne1024np4"> 20 </hypervis_subcycle>
-<hypervis_subcycle dyn="se" waccm_phys="1">  1 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne0np4_arm_x8v3_lowcon"  > 8 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne0np4_conus_x4v1_lowcon"  > 7 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne0np4_northamericax4v1"  > 7 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne0np4_svalbard_x8v1_lowcon"  > 8 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 8 </hypervis_subcycle>
-<hypervis_subcycle hgrid="ne0np4_enax4v1">7</hypervis_subcycle>
-<hypervis_subcycle hgrid="ne0np4_twpx4v1" > 7 </hypervis_subcycle>
-
-<hypervis_subcycle_q> 1 </hypervis_subcycle_q>
-
-<tstep_type > 5 </tstep_type>
-
-<qsplit > 1 </qsplit>
-
-<rsplit >                  3 </rsplit>
-<rsplit hgrid="ne4np4" >   2 </rsplit>
-<rsplit hgrid="ne11np4" >  2 </rsplit>
-<rsplit hgrid="ne16np4" >  3 </rsplit>
-<rsplit hgrid="ne30np4" >  3 </rsplit>
-<rsplit hgrid="ne60np4" >  3 </rsplit>
-<rsplit hgrid="ne120np4">  3 </rsplit>
-<rsplit hgrid="ne240np4">  3 </rsplit>
-<rsplit hgrid="ne512np4">  3 </rsplit>
-<rsplit hgrid="ne1024np4"> 3 </rsplit>
-
-<se_nsplit>                   2 </se_nsplit>
-<se_nsplit hgrid="ne4np4" >   2 </se_nsplit>
-<se_nsplit hgrid="ne11np4" >  4 </se_nsplit>
-<se_nsplit hgrid="ne16np4" >  1 </se_nsplit>
-<se_nsplit hgrid="ne30np4" >  2 </se_nsplit>
-<se_nsplit hgrid="ne60np4" >  4 </se_nsplit>
-<se_nsplit hgrid="ne120np4">  4 </se_nsplit>
-<se_nsplit hgrid="ne240np4">  5 </se_nsplit>
-<se_nsplit hgrid="ne512np4">  5 </se_nsplit>
-<se_nsplit hgrid="ne1024np4"> 10 </se_nsplit>
-<se_nsplit hgrid="ne0np4_arm_x8v3_lowcon"  > 5 </se_nsplit>
-<se_nsplit hgrid="ne0np4_conus_x4v1_lowcon"  > 4 </se_nsplit>
-<se_nsplit hgrid="ne0np4_northamericax4v1"  > 4 </se_nsplit>
-<se_nsplit hgrid="ne0np4_svalbard_x8v1_lowcon"  > 5 </se_nsplit>
-<se_nsplit hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 5 </se_nsplit>
-<se_nsplit hgrid="ne0np4_enax4v1">4</se_nsplit>
-<se_nsplit hgrid="ne0np4_twpx4v1" > 4 </se_nsplit>
-
-<se_nsplit hgrid="ne11np4"  waccm_phys="1">  5 </se_nsplit>
-<se_nsplit hgrid="ne16np4"  waccm_phys="1">  5 </se_nsplit>
-<se_nsplit hgrid="ne30np4"  waccm_phys="1">  10 </se_nsplit>
-<se_nsplit hgrid="ne60np4"  waccm_phys="1">  20 </se_nsplit>
-<se_nsplit hgrid="ne120np4" waccm_phys="1">  20 </se_nsplit>
-<se_nsplit hgrid="ne240np4" waccm_phys="1">  25 </se_nsplit>
-
 <hypervis_scaling> 0 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_arm_x8v3_lowcon"  > 3.2 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_conus_x4v1_lowcon"  > 3.2 </hypervis_scaling>
@@ -1552,36 +1509,94 @@
 <hypervis_scaling  hgrid="ne0np4_enax4v1">3.2</hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_twpx4v1" > 3.2 </hypervis_scaling>
 
-<se_ne hgrid="ne0np4_arm_x8v3_lowcon"  > 0 </se_ne>
-<se_ne hgrid="ne0np4_conus_x4v1_lowcon"  > 0 </se_ne>
-<se_ne hgrid="ne0np4_northamericax4v1"  > 0 </se_ne>
-<se_ne hgrid="ne0np4_svalbard_x8v1_lowcon"  > 0 </se_ne>
-<se_ne hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 0 </se_ne>
-<se_ne hgrid="ne0np4_enax4v1">0</se_ne>
-<se_ne hgrid="ne0np4_twpx4v1" > 0 </se_ne>
+<!-- ================================================================== -->
+<!-- timesteps  -->
+<!-- ================================================================== -->
+<tstep_type > 5 </tstep_type>
+<se_tstep > -1 </se_tstep>
+<hypervis_subcycle > 1 </hypervis_subcycle>
 
 
-<se_ftype> 0 </se_ftype>
+<!-- new interface used for E3SM v2 and later compsets  --> 
+<!-- enabed by setting se_tstep, dt_tracer_factor, dt_remap_factor   -->
+<!-- se_nsplit, rsplit, qsplit set to -1 -->
+<dt_tracer_factor > 2 </dt_tracer_factor>
+<dt_remap_factor dyn_target="theta-l">  6  </dt_remap_factor>
+<hypervis_subcycle_q dyn_target="theta-l"> 6 </hypervis_subcycle_q>
+<hypervis_subcycle_tom dyn_target="theta-l"> 1 </hypervis_subcycle_tom>
+<qsplit > -1 </qsplit>
+<rsplit > -1 </rsplit>
+<se_nsplit > -1 </se_nsplit>
 
-<se_phys_tscale> 0 </se_phys_tscale>
-<se_limiter_option> 8 </se_limiter_option>
-<vert_remap_q_alg> 1 </vert_remap_q_alg>
+<se_tstep dyn_target="theta-l" hgrid="ne4np4" >   600 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne11np4" >  600 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne16np4" >  600 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne30np4" >  300 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne30pg2" >  300 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne60np4" >  150 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne120np4">  75 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne120pg2">  75 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne240np4">  40 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne240pg2">  40 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne256np4">  40 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne256pg2">  40 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne512np4">  20 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne512pg2">  20 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne1024np4"> 10 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne1024pg2"> 10 </se_tstep>
 
-<theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
 
-<interpolate_analysis> .false. </interpolate_analysis>
-<interp_nlon> 0 </interp_nlon>
-<interp_nlat> 0 </interp_nlat>
-<interp_type> 1 </interp_type>
-<interp_gridtype> 1 </interp_gridtype>
-<vthreads> 1 </vthreads>
+<!-- old interface, used by preqx.  timesteps controlled by se_nsplit, rsplit, qsplit -->
+<!-- se_tstep, dt_remap_factor, dt_tracer_factor set to -1 -->
+<dt_tracer_factor dyn_target="preqx"> -1 </dt_tracer_factor>
+<dt_remap_factor  dyn_target="preqx">  -1  </dt_remap_factor>
+<hypervis_subcycle_q dyn_target="preqx"> 1 </hypervis_subcycle_q>
+<hypervis_subcycle_tom dyn_target="preqx"> 0 </hypervis_subcycle_tom>
 
-<transport_alg> 0 </transport_alg>
-<semi_lagrange_cdr_alg> 20 </semi_lagrange_cdr_alg>
-<semi_lagrange_cdr_check> .false. </semi_lagrange_cdr_check>
-<semi_lagrange_nearest_point_lev> 0 </semi_lagrange_nearest_point_lev>
+<qsplit dyn_target="preqx">  1 </qsplit>
 
-<se_fv_phys_remap_alg> 1 </se_fv_phys_remap_alg>
+<rsplit dyn_target="preqx" hgrid="ne4np4" >   2 </rsplit>
+<rsplit dyn_target="preqx" hgrid="ne11np4" >  2 </rsplit>
+<rsplit dyn_target="preqx">  3 </rsplit>
+
+<se_nsplit dyn_target="preqx" hgrid="ne4np4" >   2 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne11np4" >  4 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne16np4" >  1 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne30np4" >  2 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne60np4" >  4 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne120np4">  4 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne240np4">  5 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne512np4">  5 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne1024np4"> 10 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne0np4_arm_x8v3_lowcon"  > 5 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne0np4_conus_x4v1_lowcon"  > 4 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne0np4_northamericax4v1"  > 4 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne0np4_svalbard_x8v1_lowcon"  > 5 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 5 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne0np4_enax4v1">4</se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne0np4_twpx4v1" > 4 </se_nsplit>
+<se_nsplit dyn_target="preqx"> 2 </se_nsplit>
+
+<hypervis_subcycle hgrid="ne4np4" dyn_target="preqx">   3 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne11np4" dyn_target="preqx" >  3 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne16np4" dyn_target="preqx">  3 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne30np4" dyn_target="preqx">  3 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne60np4" dyn_target="preqx">  4 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne120np4" dyn_target="preqx">  4 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne240np4" dyn_target="preqx">  4 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne512np4" dyn_target="preqx">  10 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne1024np4" dyn_target="preqx"> 20 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne0np4_arm_x8v3_lowcon" dyn_target="preqx" > 8 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne0np4_conus_x4v1_lowcon" dyn_target="preqx" > 7 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne0np4_northamericax4v1" dyn_target="preqx"  > 7 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne0np4_svalbard_x8v1_lowcon" dyn_target="preqx" > 8 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne0np4_sooberingoa_x4x8v1_lowcon" dyn_target="preqx"  > 8 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne0np4_enax4v1" dyn_target="preqx">7</hypervis_subcycle>
+<hypervis_subcycle hgrid="ne0np4_twpx4v1" dyn_target="preqx"> 7 </hypervis_subcycle>
+
+
+
+
 
 <!-- ================================================================== -->
 <!-- Defaults for driver namelist seq_infodata_inparm                   -->

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1419,6 +1419,7 @@
 
 
 <theta_hydrostatic_mode>.true.</theta_hydrostatic_mode>
+<theta_advect_form> 1 </theta_advect_form>
 
 <interpolate_analysis> .false. </interpolate_analysis>
 <interp_nlon> 0 </interp_nlon>
@@ -1484,9 +1485,10 @@
 <nu hgrid="ne0np4_twpx4v1" >8.0e-8</nu>
 
 
-<!-- This will set nu_q to nu internally. -->
+<!-- -1.0 indicates use the value for nu -->
 <nu_q> -1.0 </nu_q>
 <nu_p> -1.0 </nu_p>
+<nu_s> -1.0 </nu_s>
 <nu_div> -1.0 </nu_div>
 
 <!-- theta-l dycore uses nu_div=-1, except for historical ne4 test cases -->
@@ -1529,8 +1531,8 @@
 <!-- new interface used for E3SM v2 and later compsets  --> 
 <!-- enabed by setting se_tstep, dt_tracer_factor, dt_remap_factor   -->
 <!-- se_nsplit, rsplit, qsplit set to -1 -->
-<dt_tracer_factor > 2 </dt_tracer_factor>
-<dt_remap_factor dyn_target="theta-l">  6  </dt_remap_factor>
+<dt_tracer_factor > 6 </dt_tracer_factor>
+<dt_remap_factor dyn_target="theta-l">  2  </dt_remap_factor>
 <hypervis_subcycle_q dyn_target="theta-l"> 6 </hypervis_subcycle_q>
 <hypervis_subcycle_tom dyn_target="theta-l"> 1 </hypervis_subcycle_tom>
 <qsplit > -1 </qsplit>
@@ -1541,18 +1543,12 @@
 <se_tstep dyn_target="theta-l" hgrid="ne11np4" >  600 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne16np4" >  600 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne30np4" >  300 </se_tstep>
-<se_tstep dyn_target="theta-l" hgrid="ne30pg2" >  300 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne60np4" >  150 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne120np4">  75 </se_tstep>
-<se_tstep dyn_target="theta-l" hgrid="ne120pg2">  75 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne240np4">  40 </se_tstep>
-<se_tstep dyn_target="theta-l" hgrid="ne240pg2">  40 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne256np4">  40 </se_tstep>
-<se_tstep dyn_target="theta-l" hgrid="ne256pg2">  40 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne512np4">  20 </se_tstep>
-<se_tstep dyn_target="theta-l" hgrid="ne512pg2">  20 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne1024np4"> 10 </se_tstep>
-<se_tstep dyn_target="theta-l" hgrid="ne1024pg2"> 10 </se_tstep>
 
 
 <!-- old interface, used by preqx.  timesteps controlled by se_nsplit, rsplit, qsplit -->

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1433,6 +1433,10 @@
 
 <se_fv_phys_remap_alg> 1 </se_fv_phys_remap_alg>
 
+<cubed_sphere_map> 2 </cubed_sphere_map>
+<cubed_sphere_map npg="0"> 0 </cubed_sphere_map>
+
+
 <!-- RRM grids  -->
 
 <se_ne hgrid="ne0np4_arm_x8v3_lowcon"  > 0 </se_ne>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1410,6 +1410,7 @@
 <integration> "explicit" </integration>
 
 <se_ftype> 2 </se_ftype>
+<se_ftype scam="1" > 0 </se_ftype>
 
 <se_limiter_option> 9 </se_limiter_option>
 <se_limiter_option dyn_target="preqx"> 8 </se_limiter_option>

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -5817,19 +5817,6 @@ Default: TRUE
 
 <!-- SE dycore -->
 
-<entry id="se_nsplit" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Number of dynamics steps per physics timestep.
-Default: Set by build-namelist.
-</entry>
-
-<entry id="se_phys_tscale" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Physics timescale (in seconds) used to compute physics tendencies
-If 0, feature is disabled (use dtime).
-Default: Set by build-namelist. 
-</entry>
-
 <entry id="se_limiter_option" type="integer" category="se"
        group="ctl_nl" valid_values="0,4,8,9" >
 Limiter used for horizontal tracer advection:
@@ -5837,7 +5824,7 @@ Limiter used for horizontal tracer advection:
 4: Sign-preserving limiter.
 8: Monotone limiter.
 9: CAAS monotone limiter.
-Default: Set by build-namelist (probably 8).
+Default: 9
 </entry>
 
 <entry id="vert_remap_q_alg" type="integer" category="se"
@@ -5849,7 +5836,8 @@ CAM-SE vertical remap algorithm
 2: PPM vertical remap without mirroring at the boundaries
    (no bc's enforced, first-order at two cells bordering top and bottom
    boundaries)
-Default: Set by build-namelist.
+10: PPM with 2nd order boundary treatment
+Default: 10
 </entry>
 
 <entry id="se_ftype" type="integer" category="se"
@@ -5862,127 +5850,28 @@ Default: Set by build-namelist.
 </entry>
 
 <entry id="integration" type="char*80" category="se"
-       group="ctl_nl" valid_values="explicit,semi_implicit" >
+       group="ctl_nl" valid_values="explicit" >
 Time integration method.
-Default: Set by build-namelist ("explicit").
+Default: explicit.
 </entry>
 
 <entry id="se_ne" type="integer" category="se"
        group="ctl_nl" valid_values="" >
-Element width of resolution.
-Must match value of grid. Do NOT set this yourself.
+Use internally generated cubed sphere mesh of size 6 x se_ne x se_ne.                         
+If se_ne=0 (RRM grids), read mesh from Exodus file.          
 Default: Set by build-namelist.
 </entry>
 
-<entry id="qsplit" type="integer" category="se"
+<entry id="mesh_file" type="char*256" input_pathname="abs" category="se"
        group="ctl_nl" valid_values="" >
-Tracer advection is done every qsplit dynamics timesteps.
-Default: Set by build-namelist.
-</entry>
-
-<entry id="rsplit" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Vertically lagrangian code updates every rsplit tracer timesteps.
-If rsplit=0, vertically lagrangian code is off.
-Default: Set by build-namelist.
-</entry>
-
-<entry id="se_tstep" type="real" category="se"
-       group="ctl_nl" valid_values="" >
-Dynamics timestep.
-</entry>
-
-<entry id="dt_tracer_factor" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Tracer advection is done every dt_tracer_factor dynamics timesteps.
-Default: Set by build-namelist.
-</entry>
-
-<entry id="dt_remap_factor" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Vertically lagrangian code updates every dt_remap_factor dynamics timesteps.
-If dt_remap_factor=0, vertically lagrangian code is off.
-</entry>
-
-<entry id="tstep_type" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Time stepping method for SE dycore
-tstep_type=0  pure Leapfrog except for very first timestep
-tstep_type=1  RK2 followed by qsplit-1 Leapfrog steps; second-order accurate in time (CESM1.2.0 setting)
-tstep_type=2  RK2-SSP 3 stage (as used by tracers)
-tstep_type=3  classic Runga-Kutta (RK) 3 stage
-tstep_type=4  Kinnmark&Gray Runga-Kutta (RK) 4 stage
-tstep_type=5  Kinnmark&Gray Runga-Kutta (RK) 5 stage (3rd order accurate in time)
-tstep_type=7  Kinnmark&Gray Runga-Kutta IMEX
-Default: Set by build-namelist.
-</entry>
-
-
-<entry id="hypervis_order" type="integer" category="se"
-       group="ctl_nl" valid_values="2" >
-Hyperviscosity operator is the Laplacian^hypervis_order.
-The only supported value in CAM is "2".
-Default: Set by build-namelist.
-</entry>
-
-<entry id="hypervis_subcycle" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Number of hyperviscosity subcycles per dynamics timestep.
-Default: Set by build-namelist (probably 2).
-</entry>
-
-<entry id="hypervis_subcycle_tom" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Number of viscosity subcycles per dynamics timestep.
-Default in homme: 0 (does not use time split wrt HV).
-</entry>
-
-<entry id="hypervis_subcycle_q" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Number of hyperviscosity subcycles done in tracer advection code.
-The only supported value in CAM is 1.
-Default: Set by build-namelist.
-</entry>
-
-
-<entry id="nu" type="real" category="se"
-       group="ctl_nl" valid_values="" >
-Dynamics hyperviscosity [m^4/s].
-Default: Set by build-namelist.
-</entry>
-
-<entry id="nu_div" type="real" category="se"
-       group="ctl_nl" valid_values="" >
-Weighting of divergence component when applying hyperviscosity.
-If < 0, uses nu.
-Default: Set by build-namelist.
-</entry>
-
-<entry id="nu_p" type="real" category="se"
-       group="ctl_nl" valid_values="" >
-Hyperviscosity applied to dp3d (layer thickness when running
-vertically lagrangian dynamics) [m^4/s].
-Default: Set by build-namelist.
-</entry>
-
-<entry id="nu_q" type="real" category="se"
-       group="ctl_nl" valid_values="" >
-Hyperviscosity applied during tracer advection [m^4/s].
-If < 0, uses nu.
-Default: Set by build-namelist.
-</entry>
-
-<entry id="nu_top" type="real" category="se"
-       group="ctl_nl" valid_values="" >
-Second-order viscosity applied only near the model top [m^2/s].
+Exodus format grid file used when se_ne=0
 Default: Set by build-namelist.
 </entry>
 
 <entry id="se_partmethod" type="integer" category="se"
        group="ctl_nl" valid_values="4" >
-Mesh partitioning method (METIS).
-The only supported value in CAM is 4 (space-filling).
-Default: Set by build-namelist.
+Mesh partitioning method.  The only supported value in CAM is 4 (space-filling).
+Default: 4
 </entry>
 
 <entry id="statefreq" type="integer" category="se"
@@ -5999,16 +5888,156 @@ Only "cube" is supported in CAM.
 Default: Set by build-namelist.
 </entry>
 
+<entry id="vthreads" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Number of vertical threads.
+Default: 1.
+</entry>
+
+<entry id="theta_hydrostatic_mode" type="logical" category="se"
+       group="ctl_nl" valid_values="" >
+Run theta model in hydrostatic mode.
+Default: true. 
+</entry>
+
+<entry id="theta_advect_form" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Indicates form of eqn. for vtheta in theta model.
+0 is conservation form, 1 is expanded div form.
+Default: 1.
+</entry>
+	
+<entry id="cubed_sphere_map" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Defines which map is used for referene element in homme.
+Must be 2 for compsets using TempestRemap mapping files.          
+Default: 0
+</entry>
+
+
+<!-- timestep parameters -->
+
+<entry id="se_nsplit" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Number of dynamics steps per physics timestep.
+dt_remap = dtime/se_nsplit                                                                    
+dt_tracer = dt_remap / rsplit                                                                 
+dt_dyn = dt_tracer / qsplit                                                                   
+dt_dyn_vis = dt_dyn / hypervis_subcycle                                                       
+dt_tracer_vis = dt_tracer / hypervis_subcycle_q     
+Default: Set by build-namelist.
+</entry>
+
+<entry id="rsplit" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Number of tracer steps per remap step.   
+If rsplit=0, vertically lagrangian code is off.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="qsplit" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Number of dynamics steps per tracer step. 
+Default: Set by build-namelist.
+</entry>
+
+<entry id="se_tstep" type="real" category="se"
+       group="ctl_nl" valid_values="" >
+Dynamics timestep.  Replaces se_nsplit.  
+</entry>
+
+<entry id="dt_tracer_factor" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Tracer advection is done every dt_tracer_factor dynamics timesteps.
+Replaces qsplit, rsplit.
+Default: Set by build-namelist.
+</entry>
+
+<entry id="dt_remap_factor" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Vertically lagrangian code updates every dt_remap_factor dynamics timesteps.
+Replaces qsplit, rsplit.
+If dt_remap_factor=0, vertically lagrangian code is off.
+</entry>
+
+<entry id="tstep_type" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Time stepping method for SE dycore
+tstep_type=1  RK2 followed by qsplit-1 Leapfrog steps; second-order accurate in time (CESM1.2.0 setting)
+tstep_type=2  RK2-SSP 3 stage (as used by tracers)
+tstep_type=3  classic Runga-Kutta (RK) 3 stage
+tstep_type=5  Kinnmark&Gray Runga-Kutta (RK) 5 stage (3rd order accurate in time)
+tstep_type=9  Kinnmark&Gray Runga-Kutta IMEX
+Default: Set by build-namelist.
+</entry>
+
+
+<!-- viscosity parameters -->
+
+<entry id="hypervis_order" type="integer" category="se"
+       group="ctl_nl" valid_values="2" >
+Hyperviscosity operator is the Laplacian^hypervis_order.
+The only supported value in CAM is "2".
+Default: Set by build-namelist.
+</entry>
+
+<entry id="hypervis_subcycle" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Number of hyperviscosity subcycles per dynamics timestep.
+Default: Set by build-namelist (probably 2).
+</entry>
+
+<entry id="hypervis_subcycle_tom" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+If non-zero, subcycle TOM diffusion operator separately from hyperviscsoity                   
+with dt_vis_tom=dt_dyn/hypervis_subcycle_tom.               
+Default: 1
+</entry>
+
+<entry id="hypervis_subcycle_q" type="integer" category="se"
+       group="ctl_nl" valid_values="" >
+Number of hyperviscosity subcycles done in tracer advection code.
+Default: Set by build-namelist.
+</entry>
+
+
+<entry id="nu" type="real" category="se"
+       group="ctl_nl" valid_values="" >
+Dynamics hyperviscosity [m^4/s].
+Default: Set by build-namelist.
+</entry>
+
+<entry id="nu_div" type="real" category="se"
+       group="ctl_nl" valid_values="" >
+Weighting of divergence component when applying hyperviscosity.
+If < 0, uses nu.
+Default: -1.
+</entry>
+
+<entry id="nu_p" type="real" category="se"
+       group="ctl_nl" valid_values="" >
+Hyperviscosity applied to dp3d (layer thickness when running
+vertically lagrangian dynamics) [m^4/s].
+If < 0, uses nu.
+Default: -1.
+</entry>
+
+<entry id="nu_q" type="real" category="se"
+       group="ctl_nl" valid_values="" >
+Hyperviscosity applied during tracer advection [m^4/s].
+If < 0, uses nu.
+Default: -1.
+</entry>
+
+<entry id="nu_top" type="real" category="se"
+       group="ctl_nl" valid_values="" >
+Second-order viscosity applied only near the model top [m^2/s].
+Default: Set by build-namelist.
+</entry>
 
 <entry id="fine_ne" type="integer" category="se"
        group="ctl_nl" valid_values="" >
 baseline ne for scalar hypervis tuning
-Default: Set by build-namelist.
-</entry>
-
-<entry id="mesh_file" type="char*256" input_pathname="abs" category="se"
-       group="ctl_nl" valid_values="" >
-Exodus format grid file
 Default: Set by build-namelist.
 </entry>
 
@@ -6027,36 +6056,14 @@ Default: Set by build-namelist.
 Default: Set by build-namelist.
 </entry>
 
-<entry id="vthreads" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Number of vertical threads.
-Default: 1.
-</entry>
-
-<entry id="theta_hydrostatic_mode" type="logical" category="se"
-       group="ctl_nl" valid_values="" >
-Indicates hydrostatic regime for atm. theta-l model.
-Default: true. 
-</entry>
-
-<entry id="theta_advect_form" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Indicates form of eqn. for vtheta in theta-l model.
-0 is conservation form, 1 is expanded div form.
-Default: 0.
-</entry>
-	
-<entry id="cubed_sphere_map" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-Defines which map is used for ref. element in homme.
-Default for preqx target: 0.
-</entry>
+<!-- tracer transport options -->
 
 <entry id="transport_alg" type="integer" category="se"
        group="ctl_nl" valid_values="0,12" >
 Tracer transport algorithm:
 0: Eulerian flux-form.
 12: COMPOSE semi-Lagrangian.
+Default: 0 (preqx), 12 (theta)
 </entry>
 
 <entry id="semi_lagrange_cdr_alg" type="integer" category="se"
@@ -6067,20 +6074,20 @@ Constrained density reconstuctor (CDR) for property preservation:
 20: QLT with superlevels of 8 levels.
 21: QLT with superlevels of 8 levels; use local CAAS over sublevels.
 30: CAAS with superlevels of 8 levels.
-Default: 20
+Default: 20 (set by dycore)
 </entry>
 
 <entry id="semi_lagrange_cdr_check" type="logical" category="se"
        group="ctl_nl" valid_values="">
 Correctness check the CDR.
-Default: False
+Default: False (set by dycore)
 </entry>
 
 <entry id="semi_lagrange_nearest_point_lev" type="integer" category="se"
        group="ctl_nl" valid_values="">
 Number of levels, counting from the top, that are allowed to use the
 nearest point in the halo to the departure point, when necessary.
-Default: 0
+Default: 256 (set by dycore)
 </entry>
 
 <entry id="semi_lagrange_hv_q" type="integer" category="se"
@@ -6088,6 +6095,7 @@ Default: 0
 Number of tracers, starting from 1, to which to apply hyperviscosity. For
 example, to apply hyperviscosity to moisture, the first tracer, set the value to
 1. Hyperviscosity is applied using nu_q as the coefficient.
+Default: 1 (set by dycore)
 </entry>
 
 <!-- Physics grid -->
@@ -6097,6 +6105,7 @@ example, to apply hyperviscosity to moisture, the first tracer, set the value to
 Remap algorithm to use to map between FV physics grid and GLL dynamics
 grid. 0, default, provides the original algorithms; 1 provides
 high-order algorithms implemented in gllfvremap_mod.
+Default: 1.  
 </entry>
 
 <entry id="se_fv_nphys" type="integer" category="se"
@@ -6105,7 +6114,7 @@ Number of equally-spaced horizontal physics points per spectral
 element. A number greater than zero will define [se_fv_nphys] equally
 spaced physics points in each direction (e.g., se_fv_nphys = 2 will
 result in 4 equally-spaced physics points per element).
-Default: 0 = feature disabled, use dynamics GLL points.
+Default: set based on atmosphere grid
 </entry>
 
 <!-- CAM I/O  -->

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -6081,20 +6081,20 @@ Constrained density reconstuctor (CDR) for property preservation:
 20: QLT with superlevels of 8 levels.
 21: QLT with superlevels of 8 levels; use local CAAS over sublevels.
 30: CAAS with superlevels of 8 levels.
-Default: 20 (set by dycore)
+Default: (set by dycore)
 </entry>
 
 <entry id="semi_lagrange_cdr_check" type="logical" category="se"
        group="ctl_nl" valid_values="">
 Correctness check the CDR.
-Default: False (set by dycore)
+Default: (set by dycore)
 </entry>
 
 <entry id="semi_lagrange_nearest_point_lev" type="integer" category="se"
        group="ctl_nl" valid_values="">
 Number of levels, counting from the top, that are allowed to use the
 nearest point in the halo to the departure point, when necessary.
-Default: 256 (set by dycore)
+Default: (set by dycore)
 </entry>
 
 <entry id="semi_lagrange_hv_q" type="integer" category="se"
@@ -6102,7 +6102,7 @@ Default: 256 (set by dycore)
 Number of tracers, starting from 1, to which to apply hyperviscosity. For
 example, to apply hyperviscosity to moisture, the first tracer, set the value to
 1. Hyperviscosity is applied using nu_q as the coefficient.
-Default: 1 (set by dycore)
+Default: (set by dycore)
 </entry>
 
 <!-- Physics grid -->
@@ -6112,7 +6112,7 @@ Default: 1 (set by dycore)
 Remap algorithm to use to map between FV physics grid and GLL dynamics
 grid. 0, default, provides the original algorithms; 1 provides
 high-order algorithms implemented in gllfvremap_mod.
-Default: 1.  
+Default: (set by dycore).  
 </entry>
 
 <entry id="se_fv_nphys" type="integer" category="se"

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -6014,6 +6014,13 @@ If < 0, uses nu.
 Default: -1.
 </entry>
 
+<entry id="nu_s" type="real" category="se"
+       group="ctl_nl" valid_values="" >
+Hyperviscosity applied to dynamics scalars [m^4/s].
+If < 0, uses nu.
+Default: -1.
+</entry>
+
 <entry id="nu_p" type="real" category="se"
        group="ctl_nl" valid_values="" >
 Hyperviscosity applied to dp3d (layer thickness when running

--- a/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850S_cam5_CMIP6.xml
@@ -94,7 +94,6 @@
 <prc_coef1               > 30500.0D0 </prc_coef1>
 <prc_exp                 > 3.19D0    </prc_exp>
 <prc_exp1                > -1.2D0    </prc_exp1>
-<se_ftype                > 2         </se_ftype>
 <clubb_C14               > 1.06D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
@@ -91,7 +91,6 @@
 <prc_coef1               > 30500.0D0 </prc_coef1>
 <prc_exp                 > 3.19D0    </prc_exp>
 <prc_exp1                > -1.2D0    </prc_exp1>
-<se_ftype                > 2         </se_ftype>
 <clubb_C14               > 1.06D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6_bgc.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_CMIP6_bgc.xml
@@ -91,7 +91,6 @@
 <prc_coef1               > 30500.0D0 </prc_coef1>
 <prc_exp                 > 3.19D0    </prc_exp>
 <prc_exp1                > -1.2D0    </prc_exp1>
-<se_ftype                > 2         </se_ftype>
 <clubb_C14               > 1.17D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-04p.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-04p.xml
@@ -81,7 +81,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 
 <!-- 1850 ozone data is from Jean-Francois Lamarque -->
 <!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-04p2.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-04p2.xml
@@ -81,7 +81,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <clubb_C14               >1.3D0</clubb_C14>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01a.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01a.xml
@@ -75,7 +75,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01b.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01b.xml
@@ -75,7 +75,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01c.xml
+++ b/components/cam/bld/namelist_files/use_cases/1850_cam5_av1c-h01c.xml
@@ -70,7 +70,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-HR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-HR.xml
@@ -85,7 +85,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LR.xml
@@ -91,7 +91,6 @@
 <prc_coef1               > 30500.0D0 </prc_coef1>
 <prc_exp                 > 3.19D0    </prc_exp>
 <prc_exp1                > -1.2D0    </prc_exp1>
-<se_ftype                > 2         </se_ftype>
 <clubb_C14               > 1.06D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
+++ b/components/cam/bld/namelist_files/use_cases/1950_cam5_CMIP6-LRtunedHR.xml
@@ -85,7 +85,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p.xml
@@ -81,7 +81,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 
 
 <!-- External forcing for BAM or MAM -->

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2.xml
@@ -81,7 +81,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <clubb_C14               >1.3D0</clubb_C14>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2_bgc.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2_bgc.xml
@@ -84,7 +84,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <clubb_C14               >1.3D0</clubb_C14>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2_gust.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2_gust.xml
@@ -97,7 +97,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.40D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <clubb_C14               >2.0D0</clubb_C14>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01a.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01a.xml
@@ -75,7 +75,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01b.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01b.xml
@@ -75,7 +75,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01c.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-h01c.xml
@@ -70,7 +70,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
@@ -95,7 +95,6 @@
 <prc_coef1               > 30500.0D0 </prc_coef1>
 <prc_exp                 > 3.19D0    </prc_exp>
 <prc_exp1                > -1.2D0    </prc_exp1>
-<se_ftype                > 2         </se_ftype>
 <clubb_C14               > 1.06D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
@@ -88,7 +88,6 @@
 <prc_coef1>30500.0D0</prc_coef1>
 <prc_exp>3.19D0</prc_exp>
 <prc_exp1>-1.2D0</prc_exp1>
-<se_ftype>2</se_ftype>
 <clubb_C14>1.06D0</clubb_C14>
 <relvar_fix>.true.</relvar_fix>
 <mg_prc_coeff_fix>.true.</mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6_bgc.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_CMIP6_bgc.xml
@@ -88,7 +88,6 @@
 <prc_coef1               > 30500.0D0 </prc_coef1>
 <prc_exp                 > 3.19D0    </prc_exp>
 <prc_exp1                > -1.2D0    </prc_exp1>
-<se_ftype                > 2         </se_ftype>
 <clubb_C14               > 1.17D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-04p.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-04p.xml
@@ -86,7 +86,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 
 <!-- 1850 ozone data is from Jean-Francois Lamarque -->
 <!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-04p2.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-04p2.xml
@@ -86,7 +86,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <clubb_C14               >1.3D0</clubb_C14>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01a.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01a.xml
@@ -80,7 +80,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01b.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01b.xml
@@ -80,7 +80,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01c.xml
+++ b/components/cam/bld/namelist_files/use_cases/20TR_cam5_av1c-h01c.xml
@@ -75,7 +75,6 @@
 <prc_coef1               >30500.0D0</prc_coef1>
 <prc_exp                 >3.19D0</prc_exp>
 <prc_exp1                >-1.2D0</prc_exp1>
-<se_ftype                >2</se_ftype>
 <relvar_fix              >.true.</relvar_fix>
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>

--- a/components/cam/bld/namelist_files/use_cases/SSP585_cam5_CMIP6.xml
+++ b/components/cam/bld/namelist_files/use_cases/SSP585_cam5_CMIP6.xml
@@ -89,7 +89,6 @@
 <prc_coef1>30500.0D0</prc_coef1>
 <prc_exp>3.19D0</prc_exp>
 <prc_exp1>-1.2D0</prc_exp1>
-<se_ftype>2</se_ftype>
 <clubb_C14>1.06D0</clubb_C14>
 <relvar_fix>.true.</relvar_fix>
 <mg_prc_coeff_fix>.true.</mg_prc_coeff_fix>

--- a/components/cam/bld/namelist_files/use_cases/aquaplanet_EAMv1.xml
+++ b/components/cam/bld/namelist_files/use_cases/aquaplanet_EAMv1.xml
@@ -147,7 +147,6 @@
 <prc_coef1               >30500.0D0 </prc_coef1>
 <prc_exp                 >3.19D0    </prc_exp>
 <prc_exp1                >-1.2D0    </prc_exp1>
-<se_ftype                >2         </se_ftype>
 <clubb_C14               >1.3D0     </clubb_C14>
 <relvar_fix              >.true.    </relvar_fix>
 <mg_prc_coeff_fix        >.true.    </mg_prc_coeff_fix>

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype0/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype0/user_nl_cam
@@ -14,7 +14,4 @@ rsplit=2
 hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
-
-
-
-
+theta_advect_form=0

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype0/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype0/user_nl_cam
@@ -2,3 +2,19 @@ se_ftype=0
 cubed_sphere_map=0
 theta_hydrostatic_mode=.true.
 
+se_nsplit=2
+se_limiter_option = 8
+transport_alg=0
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
+qsplit=1
+rsplit=2
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
+
+
+
+

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype1/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype1/user_nl_cam
@@ -2,3 +2,17 @@ se_ftype=1
 cubed_sphere_map=0
 theta_hydrostatic_mode=.true.
 
+se_nsplit=2
+se_limiter_option = 8
+transport_alg=0
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
+qsplit=1
+rsplit=2
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
+
+

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype1/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype1/user_nl_cam
@@ -14,5 +14,6 @@ rsplit=2
 hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
+theta_advect_form=0
 
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype2/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype2/user_nl_cam
@@ -14,4 +14,5 @@ rsplit=2
 hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
+theta_advect_form=0
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype2/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype2/user_nl_cam
@@ -2,3 +2,16 @@ se_ftype=2
 cubed_sphere_map=0
 theta_hydrostatic_mode=.true.
 
+se_nsplit=2
+se_limiter_option = 8
+transport_alg=0
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
+qsplit=1
+rsplit=2
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
+

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype4/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype4/user_nl_cam
@@ -14,4 +14,5 @@ rsplit=2
 hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
+theta_advect_form=0
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype4/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_ftype4/user_nl_cam
@@ -2,3 +2,16 @@ se_ftype=4
 cubed_sphere_map=0
 theta_hydrostatic_mode=.true.
 
+se_nsplit=2
+se_limiter_option = 8
+transport_alg=0
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
+qsplit=1
+rsplit=2
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
+

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_pg2/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_pg2/user_nl_cam
@@ -1,2 +1,17 @@
 theta_hydrostatic_mode=.true.
 se_fv_phys_remap_alg=1
+
+
+se_nsplit=2
+se_limiter_option = 8
+transport_alg=0
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
+qsplit=1
+rsplit=2
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
+theta_advect_form=0

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_sl/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_sl/user_nl_cam
@@ -13,5 +13,13 @@ qsplit=4
 nu_q=0
 semi_lagrange_nearest_point_lev = 100
 
+se_nsplit = 2
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
 
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_sl/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_sl/user_nl_cam
@@ -21,5 +21,3 @@ dt_tracer_factor=-1
 hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
-
-

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype0/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype0/user_nl_cam
@@ -16,5 +16,6 @@ rsplit=2
 hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
+theta_advect_form=0
 
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype0/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype0/user_nl_cam
@@ -5,3 +5,16 @@ tstep_type=7
 se_nsplit=10
 
 
+se_limiter_option = 8
+transport_alg=0
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
+qsplit=1
+rsplit=2
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
+
+

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype1/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype1/user_nl_cam
@@ -5,3 +5,17 @@ tstep_type=7
 se_nsplit=10
 
 
+se_limiter_option = 8
+transport_alg=0
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
+qsplit=1
+rsplit=2
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
+
+
+

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype1/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype1/user_nl_cam
@@ -16,6 +16,7 @@ rsplit=2
 hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
+theta_advect_form=0
 
 
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype2/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype2/user_nl_cam
@@ -14,5 +14,5 @@ hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
 se_limiter_option = 8
-theta_advect_form=1
+theta_advect_form=0
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype2/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype2/user_nl_cam
@@ -2,6 +2,16 @@ se_ftype=2
 cubed_sphere_map=0
 theta_hydrostatic_mode=.false.
 tstep_type=7
+transport_alg=0
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
 se_nsplit=10
-
+qsplit=1
+rsplit=2
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
+se_limiter_option = 8
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype2/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype2/user_nl_cam
@@ -14,4 +14,5 @@ hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
 se_limiter_option = 8
+theta_advect_form=1
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype4/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype4/user_nl_cam
@@ -15,6 +15,7 @@ rsplit=2
 hypervis_subcycle=3
 hypervis_subcycle_q=1
 hypervis_subcycle_tom=0
+theta_advect_form=0
 
 
 

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype4/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetanh_ftype4/user_nl_cam
@@ -4,4 +4,17 @@ theta_hydrostatic_mode=.false.
 tstep_type=7
 se_nsplit=10
 
+se_limiter_option = 8
+transport_alg=0
+vert_remap_q_alg=1
+se_tstep=-1
+dt_remap_factor=-1
+dt_tracer_factor=-1
+qsplit=1
+rsplit=2
+hypervis_subcycle=3
+hypervis_subcycle_q=1
+hypervis_subcycle_tom=0
+
+
 

--- a/components/homme/README.cmake
+++ b/components/homme/README.cmake
@@ -1,6 +1,7 @@
 03/2013 BFJ
 02/2016 MT
 10/2016 DMH
+12/2019 MT  document some common cmake options
 
 The CMAKE build system supports a number of user-configurable targets:
 sweqx, preqx, preqx_acc, theta-l, swim, prim
@@ -12,9 +13,21 @@ targets, see:
 
 A typical CMAKE command might look like:
 cd $WDIR
-cmake -C ~/acme/components/cmake/machineFiles/edison.cmake \
+cmake -C ~/e3sm/components/homme/cmake/machineFiles/edison.cmake \
     -DPREQX_PLEV=30 -DPREQX_NP=4 ~/acme/components/homme
 
+The -C argument is machine specific settings. See the machineFile directory                   
+for examples.  Most DOE machines are suported, as well as Darwin and RHEL.                    
+                                                                                              
+Some commonly used cmake options: (for both preqx and theta targets):                         
+-DPREQX_USE_ENERGY=TRUE   add extra diagnostics to the log file                               
+-DPREQX_USE_PIO=TRUE      turn on native grid output                                          
+                          (default is interpolated lat/lon output)                            
+                                                                                              
+For performance testing, the model can be built without file output.  This                    
+removes the need to link with PIO and netcdf.  See the astra.cmake machine                    
+file and variable BUILD_HOMME_WITHOUT_PIOLIBRARY.                                             
+                                                          
 After running cmake with suitable command line options from a working directory WDIR,
 it will create 
 
@@ -55,35 +68,4 @@ The CMAKE code could use some cleanup.
   with cmake's tree-like directory approach, the tests should be associated with their
   test executable
 
-
-************************************************************************************************
-
-***OBSOLETE***
-
-Please see the HOMME wiki for information on how to build HOMME using the CMake build system.
-https://wiki.ucar.edu/display/homme/The+HOMME+CMake+build+and+testing+system
-
-
-03/2013 CGB and KJE and JER
-
-HOMME now has a CMake build option for sweqx, swim, and preqx.
-It is in the BETA test mode, alert Chris Baker or Kate Evans or Jennifer Ribbeckof problems/unclear instructions
-(swim is the SW version of HOMME that uses trilinos in the implicit solve option)
-
-1. mkdir BUILD_DIR somewhere, usually the main trunk directory
-2. cp /bld/cmake-script/$APPROPRIATE_BUILD_SCRIPT into $BUILD_DIR 
-3. export HOMME_ROOT="location_of trunk"
-3. JAGUAR ONLY: export XTPE_LINK_TYPE='dynamic' needed right now TODO: put into script build process
-3. Linux box ONLY: export Z_DIR='/usr/lib64' needed right now TODO: put into script build process
-4. Modify script as appropriate (DEBUG or not etc)
- a. PLEV=# vertical levels
- b. NUM_POINTS=np
- c. -D CMAKE_INSTALL_PREFIX=where /bin/$EXE will sit 
-5. ./$APPROPRIATE_BUILD_SCRIPT
-5. make -j4
-6. make install (where you told it to go)
-
-most build failures are due to residual build info. In the build directory:
-rm -rf CMakeCache.txt CMakeFiles src utils cmake_install.cmake Makefile bin install_manifest.txt *.h
-to get a fresh build starting point.
 

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -34,11 +34,11 @@ module control_mod
   ! rather than just those that couple to the dynamics at the dynamical time
   ! step. These latter are 'active' tracers, in contrast to 'passive' tracers
   ! that directly couple only to the physics.
-  integer, public  :: semi_lagrange_hv_q = 0
+  integer, public  :: semi_lagrange_hv_q = 1
   ! If >= 1, then the SL algorithm may choose a nearby point inside the element
   ! halo available to it if the actual point is outside the halo. This is done
   ! in levels <= this parameter.
-  integer, public :: semi_lagrange_nearest_point_lev = 0
+  integer, public :: semi_lagrange_nearest_point_lev = 256
 
 ! flag used by preqx, theta-l and theta-c models
 ! should be renamed to "hydrostatic_mode"
@@ -147,7 +147,7 @@ module control_mod
   real (kind=real_kind), public :: nu_div  = -1               ! viscsoity (momentum equ, div component)
   real (kind=real_kind), public :: nu_s    = -1               ! default = nu   T equ. viscosity
   real (kind=real_kind), public :: nu_q    = -1               ! default = nu   tracer viscosity
-  real (kind=real_kind), public :: nu_p    = 0.0D5            ! default = 0    ps equ. viscosity
+  real (kind=real_kind), public :: nu_p    = -1               ! default = nu   ps equ. viscosity
   real (kind=real_kind), public :: nu_top  = 0.0D5            ! top-of-the-model viscosity
 
   integer, public :: hypervis_subcycle=1                      ! number of subcycles for hyper viscsosity timestep

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -255,7 +255,7 @@ contains
     use reduction_mod, only : ParallelMin,ParallelMax
     use physical_constants, only : rrearth, rearth,dd_pi
     use control_mod, only : nu, nu_q, nu_div, hypervis_order, nu_top, hypervis_power, &
-                            fine_ne, rk_stage_user, max_hypervis_courant, hypervis_scaling, dcmip16_mu,dcmip16_mu_s,dcmip16_mu_q
+                            fine_ne, max_hypervis_courant, hypervis_scaling, dcmip16_mu,dcmip16_mu_s,dcmip16_mu_q
     use control_mod, only : tstep_type
     use parallel_mod, only : abortmp, global_shared_buf, global_shared_sum
     use edgetype_mod, only : EdgeBuffer_t 
@@ -525,13 +525,10 @@ contains
      if (hybrid%masterthread) then
        write(iulog,'(a,f10.2)') 'CFL estimates in terms of S=time step stability region'
        write(iulog,'(a,f10.2)') '(i.e. advection w/leapfrog: S=1, viscosity w/forward Euler: S=2)'
-       if (rk_stage_user>0) then
-          write(iulog,'(a,f10.2,a)') 'SSP preservation (120m/s) RKSSP euler step dt  < S *', &
-               min_gw/(120.0d0*max_normDinv*rrearth),'s'
-       endif
-       if (qsize>0) &
-          write(iulog,'(a,f10.2,a)') 'Stability: advective (120m/s)   dt_tracer < S *',&
-               1/(120.0d0*max_normDinv*lambda_max*rrearth),'s'
+       write(iulog,'(a,f10.2,a)') 'SSP preservation (120m/s) RKSSP euler step dt  < S *', &
+            min_gw/(120.0d0*max_normDinv*rrearth),'s'
+       write(iulog,'(a,f10.2,a)') 'Stability: advective (120m/s)   dt_tracer < S *',&
+            1/(120.0d0*max_normDinv*lambda_max*rrearth),'s'
        write(iulog,'(a,f10.2,a)') 'Stability: advective (120m/s)   dt_tracer < S *', &
                                    1/(120.0d0*max_normDinv*lambda_max*rrearth),'s'
        write(iulog,'(a,f10.2,a)') 'Stability: gravity wave(342m/s)   dt_dyn  < S *', &

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -849,11 +849,8 @@ module namelist_mod
 #else
        cubed_sphere_map=0  ! default is equi-angle gnomonic
 #endif
-       if (ne.eq.0) cubed_sphere_map=2  ! must use element_local for var-res grids
-#ifdef CAM
-       if (fv_nphys.gt.0) cubed_sphere_map=2  ! must use element_local for FV physics grid
-#endif
     endif
+    if (ne.eq.0) cubed_sphere_map=2  ! must use element_local for var-res grids
     if (par%masterproc) write (iulog,*) "Reference element projection: cubed_sphere_map=",cubed_sphere_map
 
 !logic around different hyperviscosity options

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -108,9 +108,9 @@ module namelist_mod
   use thread_mod,     only: nthreads, omp_set_num_threads, omp_get_max_threads, vthreads
   use dimensions_mod, only: ne, np, nnodes, nmpi_per_node, npart, qsize, qsize_d, set_mesh_dimensions
 #ifdef CAM
-  use time_mod,       only: tstep, nsplit, smooth, phys_tscale
+  use time_mod,       only: tstep, nsplit, smooth
 #else
-  use time_mod,       only: tstep, ndays,nmax, nendstep,secpday, smooth, secphr, nsplit, phys_tscale
+  use time_mod,       only: tstep, ndays,nmax, nendstep,secpday, smooth, secphr, nsplit
 #endif
   use parallel_mod,   only: parallel_t,  iam, abortmp, &
        partitionfornodes, mpireal_t, mpilogical_t, mpiinteger_t, mpichar_t
@@ -178,7 +178,7 @@ module namelist_mod
     type (parallel_t), intent(in) ::  par
     character(len=MAX_FILE_LEN) :: mesh_file
     integer :: se_ftype, se_limiter_option
-    integer :: se_phys_tscale, se_nsplit
+    integer :: se_nsplit
     integer :: interp_nlat, interp_nlon, interp_gridtype, interp_type
     integer :: i, ii, j
     integer  :: ierr
@@ -273,7 +273,6 @@ module namelist_mod
 
 #ifdef CAM
     namelist  /ctl_nl/ SE_NSPLIT,  &                ! number of dynamics steps per physics timestep
-      se_phys_tscale, &
       se_tstep
 #else
     namelist /ctl_nl/test_case,       &             ! test case idenitfier
@@ -351,32 +350,16 @@ module namelist_mod
     ! Set the default partmethod
     ! ==========================
     PARTMETHOD    = SFCURVE
-!    PARTMETHOD    = RECURSIVE
     COORD_TRANSFORM_METHOD = SPHERE_COORDS
     Z2_MAP_METHOD = Z2_NO_TASK_MAPPING
     npart         = 1
     uselapi       = .TRUE.
-#ifdef CAM
-    ! set all CAM defaults
-    ! CAM requires forward-in-time, subcycled dynamics
-    ! RK2 3 stage tracers, sign-preserving conservative
-    tstep_type              = 1      ! forward-in-time RK methods
-    qsplit=4; rk_stage_user=3
-    se_limiter_option=4
-    se_ftype = 2
-    se_partmethod = -1
-    se_ne       = -1
-    se_topology = 'none'
-    se_phys_tscale=0
-    se_nsplit = 1
-    se_tstep = -1
-    qsize = qsize_d
-#else
+    se_tstep=-1
+#ifndef CAM
     ndays         = 0
     nmax          = 12
     nthreads = 1
     se_ftype = ftype   ! MNL: For non-CAM runs, ftype=0 in control_mod
-    phys_tscale=0
     nsplit = 1
     pertlim = 0.0_real_kind
 #endif
@@ -394,10 +377,10 @@ module namelist_mod
     mesh_file='none'
     ne              = 0
     transport_alg = 0
-    semi_lagrange_cdr_alg = 2
+    semi_lagrange_cdr_alg = 21
     semi_lagrange_cdr_check = .false.
-    semi_lagrange_hv_q = 0
-    semi_lagrange_nearest_point_lev = 0
+    semi_lagrange_hv_q = 1
+    semi_lagrange_nearest_point_lev = 256
     disable_diagnostics = .false.
     se_fv_phys_remap_alg = 1
 
@@ -631,9 +614,21 @@ module namelist_mod
     end if
 
 #ifdef CAM
-    if(se_partmethod /= -1) partmethod = se_partmethod
-    if(se_ne /= -1) ne = se_ne
-    if(se_topology .ne. 'none') topology = se_topology
+    partmethod = se_partmethod
+    ne = se_ne
+    topology = se_topology
+    qsize=qsize_d
+    limiter_option=se_limiter_option
+    nsplit=se_nsplit
+    tstep           = se_tstep
+    if (tstep > 0) then
+       if (par%masterproc .and. nsplit > 0) then
+          write(iulog,'(a,i3,a)') &
+               'se_tstep and se_nsplit were specified; changing se_nsplit from ', &
+               nsplit, ' to -1.'
+       end if
+       nsplit = -1
+    end if
 #endif
 
     call MPI_barrier(par%comm,ierr)
@@ -655,21 +650,7 @@ module namelist_mod
     call MPI_bcast(restartfreq,     1,MPIinteger_t,par%root,par%comm,ierr)
     call MPI_bcast(runtype,         1,MPIinteger_t,par%root,par%comm,ierr)
 
-#ifdef CAM
-    phys_tscale     = se_phys_tscale
-    limiter_option  = se_limiter_option
-    nsplit          = se_nsplit
-    tstep           = se_tstep
-    if (se_tstep > 0) then
-       if (par%masterproc .and. se_nsplit > 0) then
-          write(iulog,'(a,i3,a)') &
-               'se_tstep and se_nsplit were specified; changing se_nsplit from ', &
-               se_nsplit, ' to -1.'
-       end if
-       se_nsplit = -1
-       nsplit = -1
-    end if
-#else
+#ifndef CAM
     if(test_case == "dcmip2012_test4") then
        rearth = rearth/dcmip4_X
        omega = omega*dcmip4_X
@@ -697,7 +678,6 @@ module namelist_mod
 #endif
     call MPI_bcast(vthreads  ,      1, MPIinteger_t, par%root,par%comm,ierr)
     call MPI_bcast(smooth,          1, MPIreal_t,    par%root,par%comm,ierr)
-    call MPI_bcast(phys_tscale,     1, MPIreal_t,    par%root,par%comm,ierr)
     call MPI_bcast(NSPLIT,          1, MPIinteger_t, par%root,par%comm,ierr)
     call MPI_bcast(tstep,           1, MPIreal_t   , par%root,par%comm,ierr)
     call MPI_bcast(limiter_option,  1, MPIinteger_t, par%root,par%comm,ierr)
@@ -891,7 +871,6 @@ module namelist_mod
     ftype = se_ftype
 
 #ifdef _PRIM
-    rk_stage_user=3  ! 3d PRIM code only supports 3 stage RK tracer advection
     if (limiter_option==8 .or. limiter_option==84 .or. limiter_option == 9) then
        if (hypervis_subcycle_q/=1 .and. transport_alg == 0) then
           call abortmp('limiter 8,84,9 require hypervis_subcycle_q=1')
@@ -951,6 +930,13 @@ module namelist_mod
     if(nu_s<0)    nu_s  = nu
     if(nu_q<0)    nu_q  = nu
     if(nu_div<0)  nu_div= nu
+    if(nu_p<0) then                                                                           
+       if (rsplit==0) then                                                                    
+          nu_p=0  ! eulerian code traditionally run with nu_p=0                               
+       else                                                                                   
+          nu_p=nu                                                                             
+       endif                                                                                  
+    endif 
     if(dcmip16_mu_s<0)    dcmip16_mu_s  = dcmip16_mu
     if(dcmip16_mu_q<0)    dcmip16_mu_q  = dcmip16_mu_s
 
@@ -1043,7 +1029,6 @@ module namelist_mod
        write(iulog,*)"hypervis_subcycle     = ",hypervis_subcycle
        write(iulog,*)"hypervis_subcycle_tom = ",hypervis_subcycle_tom
        write(iulog,*)"hypervis_subcycle_q   = ",hypervis_subcycle_q
-       !write(iulog,*)"psurf_vis: ",psurf_vis
        write(iulog,'(a,2e9.2)')"viscosity:  nu (vor/div) = ",nu,nu_div
        write(iulog,'(a,2e9.2)')"viscosity:  nu_s      = ",nu_s
        write(iulog,'(a,2e9.2)')"viscosity:  nu_q      = ",nu_q

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -611,25 +611,26 @@ module namelist_mod
 ! ^ ifndef CAM
        ierr = timestep_make_subcycle_parameters_consistent(par, rsplit, qsplit, &
             dt_remap_factor, dt_tracer_factor)
-    end if
 
 #ifdef CAM
-    partmethod = se_partmethod
-    ne = se_ne
-    topology = se_topology
-    qsize=qsize_d
-    limiter_option=se_limiter_option
-    nsplit=se_nsplit
-    tstep           = se_tstep
-    if (tstep > 0) then
-       if (par%masterproc .and. nsplit > 0) then
-          write(iulog,'(a,i3,a)') &
-               'se_tstep and se_nsplit were specified; changing se_nsplit from ', &
-               nsplit, ' to -1.'
+       limiter_option=se_limiter_option
+       partmethod = se_partmethod
+       ne         = se_ne
+       topology   = se_topology
+       qsize      = qsize_d
+       nsplit     = se_nsplit
+       tstep      = se_tstep
+       if (tstep > 0) then
+          if (par%masterproc .and. nsplit > 0) then
+             write(iulog,'(a,i3,a)') &
+                  'se_tstep and se_nsplit were specified; changing se_nsplit from ', &
+                  nsplit, ' to -1.'
+          end if
+          nsplit = -1
        end if
-       nsplit = -1
-    end if
 #endif
+    end if
+
 
     call MPI_barrier(par%comm,ierr)
 

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -689,16 +689,16 @@ contains
 
     use control_mod,          only: runtype, test_case, &
                                     debug_level, vfile_int, vform, vfile_mid, &
-                                    topology, dt_remap_factor, dt_tracer_factor, rk_stage_user,&
+                                    topology, dt_remap_factor, dt_tracer_factor,&
                                     sub_case, limiter_option, nu, nu_q, nu_div, tstep_type, hypervis_subcycle, &
-                                    hypervis_subcycle_q, moisture, use_moisture
+                                    hypervis_subcycle_q, moisture, use_moisture, hypervis_subcycle_tom
     use global_norms_mod,     only: test_global_integral, print_cfl
     use hybvcoord_mod,        only: hvcoord_t
     use parallel_mod,         only: parallel_t, haltmp, syncmp, abortmp
     use prim_state_mod,       only: prim_printstate, prim_diag_scalars
     use prim_advection_mod,   only: prim_advec_init2
     use model_init_mod,       only: model_init2
-    use time_mod,             only: timelevel_t, tstep, phys_tscale, timelevel_init, nendstep, smooth, nsplit, TimeLevel_Qdp
+    use time_mod,             only: timelevel_t, tstep, timelevel_init, nendstep, smooth, nsplit, TimeLevel_Qdp
     use control_mod,          only: smooth_phis_numcycle
 
 #ifdef TRILINOS
@@ -955,17 +955,20 @@ contains
        write(iulog,'(a,2f9.2)') "dt_remap: (0=disabled)   ",tstep*dt_remap_factor
        if (qsize>0) then
           write(iulog,'(a,2f9.2)') "dt_tracer (SE), per RK stage: ", &
-               tstep*dt_tracer_factor,(tstep*dt_tracer_factor)/(rk_stage_user-1)
+               tstep*dt_tracer_factor,(tstep*dt_tracer_factor)/2
        end if
        write(iulog,'(a,2f9.2)')    "dt_dyn:                  ",tstep
        write(iulog,'(a,2f9.2)')    "dt_dyn (viscosity):      ",dt_dyn_vis
        write(iulog,'(a,2f9.2)')    "dt_tracer (viscosity):   ",dt_tracer_vis
+       if (hypervis_subcycle_tom==0) then                                                     
+          ! applied with hyperviscosity                                                       
+          write(iulog,'(a,2f9.2)') "dt_vis_TOM:  ",dt_dyn_vis                                 
+       else                                                                                   
+          write(iulog,'(a,2f9.2)') "dt_vis_TOM:  ",tstep/hypervis_subcycle_tom               
+       endif                                                                 
 
 
 #ifdef CAM
-       if (phys_tscale/=0) then
-          write(iulog,'(a,2f9.2)') "CAM physics timescale:       ",phys_tscale
-       endif
        write(iulog,'(a,2f9.2)') "CAM dtime (dt_phys):         ",tstep*nsplit*max(dt_remap_factor, dt_tracer_factor)
 #endif
     end if

--- a/components/homme/src/share/time_mod.F90
+++ b/components/homme/src/share/time_mod.F90
@@ -13,7 +13,6 @@ module time_mod
   integer,public                :: ndays          ! Max number of days
   integer,public                :: nextOutputStep ! Next timestep where output will occur
   real (kind=real_kind), public :: tstep          ! Dynamics timestep
-  real (kind=real_kind), public :: phys_tscale=0. ! Physics time scale
 
   real (kind=real_kind), public, parameter :: secphr = 3600.0D0 ! Timestep filter
   real (kind=real_kind), public, parameter :: secpday = 86400.0D0 ! Timestep filter


### PR DESCRIPTION
Add XML defaults for theta-l dycore
Remove unused/obsolete dycore variables from XML defaults
Add code to allow namelist defaults to be set based on value of cam_target 
Removed se_ftype=2 from all use cases (and made this a default)
Support new timestep interface (se_tstep, dt_tracer_factor, dt_remap_factor) for theta-l dycore
Update all theta "testmods" test cases to preserve original settings

[BFB] with nlfails. 