### PR TITLE
Disable Gravity Wave Latitude Taper for SE dycore

### DIFF
--- a/components/cam/src/physics/cam/gw_drag.F90
+++ b/components/cam/src/physics/cam/gw_drag.F90
@@ -574,6 +574,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   use gw_oro,     only: gw_oro_src
   use gw_front,   only: gw_cm_src
   use gw_convect, only: gw_beres_src
+  use dycore,     only: dycore_is
   !------------------------------Arguments--------------------------------
   type(physics_state), intent(in) :: state      ! physics state structure
   ! Standard deviation of orography.
@@ -809,7 +810,11 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
         call gw_cm_src(ncol, pgwv, kbotbg, u, v, frontgf, &
              src_level, tend_level, tau, ubm, ubi, xv, yv, c)
 
-        do_latitude_taper = .true.
+        if (dycore_is('UNSTRUCTURED')) then
+          do_latitude_taper = .false.
+        else
+          do_latitude_taper = .true.
+        end if
 
         ! Solve for the drag profile with C&M source spectrum.
         call gw_drag_prof(ncol, pgwv, src_level, tend_level, do_latitude_taper, dt, &

--- a/components/cam/src/physics/cam/gw_drag.F90
+++ b/components/cam/src/physics/cam/gw_drag.F90
@@ -669,6 +669,8 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   ! local override option for constituents cnst_type
   character(len=3), dimension(pcnst) :: cnst_type_loc
 
+  logical :: do_latitude_taper
+
   !------------------------------------------------------------------------
 
   ! Make local copy of input state.
@@ -748,8 +750,10 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
              zm, src_level, tend_level, tau, ubm, ubi, xv, yv, c, &
              hdepth, maxq0, gw_convect_hcf)
 
+        do_latitude_taper = .false.
+
         ! Solve for the drag profile with Beres source spectrum.
-        call gw_drag_prof(ncol, pgwv, src_level, tend_level, .false., dt, &
+        call gw_drag_prof(ncol, pgwv, src_level, tend_level, do_latitude_taper, dt, &
              state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
              piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
              effgw_beres, c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
@@ -805,8 +809,10 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
         call gw_cm_src(ncol, pgwv, kbotbg, u, v, frontgf, &
              src_level, tend_level, tau, ubm, ubi, xv, yv, c)
 
+        do_latitude_taper = .true.
+
         ! Solve for the drag profile with C&M source spectrum.
-        call gw_drag_prof(ncol, pgwv, src_level, tend_level, .true., dt, &
+        call gw_drag_prof(ncol, pgwv, src_level, tend_level, do_latitude_taper, dt, &
              state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
              piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
              effgw_cm,    c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
@@ -858,8 +864,10 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
           u, v, t, sgh(:ncol), pmid, pint, dpm, zm, nm, &
           src_level, tend_level, tau, ubm, ubi, xv, yv, c)
 
+     do_latitude_taper = .false.
+
      ! Solve for the drag profile with orographic sources.
-     call gw_drag_prof(ncol, 0, src_level, tend_level, .false., dt, &
+     call gw_drag_prof(ncol, 0, src_level, tend_level, do_latitude_taper, dt, &
           state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
           piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
           effgw_oro,   c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &


### PR DESCRIPTION
This disables the latitude taper used by the frontal gravity wave scheme. According to a conversation with Julio Bacmeister, this was added for stability in CAM when using a lat-lon grid with a polar filter. This is not required for an unstructured grid, so this disables the taper when dycore_is("UNSTRUCTURED") returns true.

[non-BFB]