### PR TITLE
Explicitly remove the darshan module for Cori

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -126,6 +126,7 @@
         <command name="rm">esmf</command>
         <command name="rm">zlib</command>
         <command name="rm">craype-hugepages2M</command>
+        <command name="rm">darshan</command>
         
         <!-- first load basic defaults, then remove/swap/load as necessary -->
         <command name="load">craype</command>
@@ -196,8 +197,6 @@
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
-
-      <env name="PERL5LIB">/project/projectdirs/acme/perl5/lib/perl5/x86_64-linux-thread-multi</env>
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="FORT_BUFFERED">yes</env>
@@ -275,7 +274,8 @@
         <command name="rm">esmf</command>
         <command name="rm">zlib</command>
         <command name="rm">craype-hugepages2M</command>
-
+        <command name="rm">darshan</command>
+        
         <!-- first load basic defaults, then remove/swap/load as necessary -->
         <command name="load">craype</command>
         <command name="load">PrgEnv-intel</command>
@@ -357,8 +357,6 @@
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
-
-      <env name="PERL5LIB">/project/projectdirs/acme/perl5/lib/perl5/x86_64-linux-thread-multi</env>
     </environment_variables>
 
     <environment_variables mpilib="mpt">


### PR DESCRIPTION
Explicitly remove the darshan module for Cori.
This module does some IO statistics for NERSC, but is currently causing issues.
We do not need this module, so removing.

Also removing the setting of a PERL environment variable that was only
there temporarily while NERSC completed the perl install.

[bfb]