### PR TITLE
Update RRTMGP to point to latest version on remote repo

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -477,8 +477,8 @@
 <liqopticsfile rad="rrtmgp">atm/cam/physprops/F_nwvl200_mu20_lam50_res64_t298_c080428.nc</liqopticsfile>
 
 <!-- Gas absorption coefficients for RRTMGP -->
-<rrtmgp_coefficients_file_lw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_lw_c181004.nc</rrtmgp_coefficients_file_lw>
-<rrtmgp_coefficients_file_sw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_sw_c181004.nc</rrtmgp_coefficients_file_sw>
+<rrtmgp_coefficients_file_lw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_lw_20181204.nc</rrtmgp_coefficients_file_lw>
+<rrtmgp_coefficients_file_sw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_sw_20181204.nc</rrtmgp_coefficients_file_sw>
 
 <!-- CAM-RT absorptivity/emissivity lookup table -->
 <absems_data>atm/cam/rad/abs_ems_factors_fastvx.c030508.nc</absems_data>

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -2244,17 +2244,16 @@ contains
       real(r8), parameter :: n2_vol_mix_ratio = 0.7906_r8
 
       ! Loop indices
-      integer :: igas, iday, icol
+      integer :: igas
 
       ! Number of columns and daytime columns
       integer :: ncol, nday
 
-      character(len=32) :: subname = 'set_gas_concentrations'
-
-      ! Indices to model top on the RADIATION VERTICAL GRID
-      integer :: k, k_cam
-
+      ! Character array to hold lowercase gas names
       character(len=32), allocatable :: gas_names(:)
+
+      ! Name of subroutine for error messages
+      character(len=32) :: subname = 'set_gas_concentrations'
 
       ! Number of columns in chunk
       ncol = state%ncol

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -2254,8 +2254,6 @@ contains
       ! Indices to model top on the RADIATION VERTICAL GRID
       integer :: k, k_cam
 
-      real(wp), allocatable, dimension(:,:,:) :: vmr
-
       character(len=32), allocatable :: gas_names(:)
 
       ! Number of columns in chunk


### PR DESCRIPTION
Update RRTMGP submodule to point to latest version on external repository. This brings in a number of fixes for OpenACC, which we will need downstream on ACME-ECP to get the MMF configuration on the GPU, and will need eventually for SCREAM as well. This will cause BFB differences for the `cam-rrtmgp` test. These differences are due to only two changes:

1) Commit de24173cc97ec2e2d7eb30810ef205789c27e2bb in the external repo refactors the `get_col_dry` routine to put the calculations on the GPU via OpenACC. This requires splitting a computation into two parts, and this causes floating point differences that will produce a DIFF.

2) The absorption coefficient data is updated to the most recent version available from the remote repository. This also causes small differences.

Manually reverting both of these brings the test back to BFB, so we can be sure that the diff is resulting from these trivial changes and is acceptable. All other tests should be BFB.

[NBFB]