### PR TITLE
update to fates api 8.1

### DIFF
--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -105,7 +105,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
-<fates_paramfile >lnd/clm2/paramdata/fates_params_default_12pft_c190905.nc</fates_paramfile>
+<fates_paramfile >lnd/clm2/paramdata/fates_params_default_12pft_api8.1.c200106.nc</fates_paramfile>
 
 
 <!-- soil order related parameters (relative to {csmdata}) -->


### PR DESCRIPTION
This set of changes points E3SM to an updated fates tag, sci1.31.1_api8.1.0, which
has an updated parameter file format, now loaded on blues.

[non-BFB]
