### PR TITLE
Update module version on cori in preparation for the new default CDT 19.11

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -137,7 +137,7 @@
       </modules>
 
       <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
       </modules>
 
       <modules compiler="intel">
@@ -149,13 +149,13 @@
       <modules compiler="gnu">
         <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.2.0</command>
+        <command name="load">gcc/8.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.02.1</command>
+        <command name="load">cray-libsci/19.06.1</command>
       </modules>
 
       <modules>
-        <command name="swap">craype craype/2.5.18</command>
+        <command name="swap">craype craype/2.6.2</command>
         <command name="rm">pmi</command>
         <command name="load">pmi/5.0.14</command>
         <command name="rm">craype-mic-knl</command>
@@ -166,14 +166,14 @@
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
         <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
 
       <modules>
@@ -285,7 +285,7 @@
       </modules>
 
       <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
       </modules>
 
       <modules mpilib="impi">
@@ -307,13 +307,13 @@
       <modules compiler="gnu">
         <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.2.0</command>
+        <command name="load">gcc/8.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.02.1</command>
+        <command name="load">cray-libsci/19.06.1</command>
       </modules>
 
       <modules>
-        <command name="swap">craype craype/2.5.18</command>
+        <command name="swap">craype craype/2.6.2</command>
         <command name="rm">pmi</command>
         <command name="load">pmi/5.0.14</command>
         <command name="rm">craype-haswell</command>
@@ -324,14 +324,14 @@
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
         <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
 
       <modules>


### PR DESCRIPTION
Update module version on cori in preparation for the new default CDT 19.11

This means updating to the following versions:

craype/2.6.2
cray-mpich/7.7.10
cray-netcdf-hdf5parallel/4.6.3.2
cray-hdf5-parallel/1.10.5.2
cray-parallel-netcdf/1.11.1.1
gcc/8.3.0
cray-libsci/19.06.1

Additionally, for CDT 19.11, the default is to use dynamic linking.
The tests I ran are passing without any additional modifications regarding linking.

Affects both cori-knl and cori-haswell