### PR TITLE
Fix Redi mixing in ocean

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -598,28 +598,34 @@ add_default($nl, 'config_Leith_parameter');
 add_default($nl, 'config_Leith_dx');
 add_default($nl, 'config_Leith_visc2_max');
 
-###################################################
-# Namelist group: mesoscale_eddy_parameterization #
-###################################################
+#########################################
+# Namelist group: Redi_isopycnal_mixing #
+#########################################
 
-add_default($nl, 'config_use_standardGM');
-add_default($nl, 'config_gm_lat_variable_c2');
-add_default($nl, 'config_gm_kappa_lat_depth_variable');
-add_default($nl, 'config_gm_min_stratification_ratio');
-add_default($nl, 'config_gm_min_phase_speed');
-add_default($nl, 'config_use_Redi_surface_layer_tapering');
-add_default($nl, 'config_Redi_surface_layer_tapering_extent');
-add_default($nl, 'config_use_Redi_bottom_layer_tapering');
-add_default($nl, 'config_Redi_bottom_layer_tapering_depth');
-add_default($nl, 'config_GM_Bolus_kappa_function');
-add_default($nl, 'config_standardGM_tracer_kappa');
-add_default($nl, 'config_GM_Bolus_kappa_min');
-add_default($nl, 'config_GM_Bolus_kappa_max');
-add_default($nl, 'config_GM_Bolus_cell_size_min');
-add_default($nl, 'config_GM_Bolus_cell_size_max');
+add_default($nl, 'config_use_Redi');
 add_default($nl, 'config_Redi_kappa');
-add_default($nl, 'config_gravWaveSpeed_trunc');
-add_default($nl, 'config_max_relative_slope');
+add_default($nl, 'config_Redi_closure');
+add_default($nl, 'config_Redi_surface_taper_layers');
+add_default($nl, 'config_Redi_bottom_taper_height');
+
+############################################
+# Namelist group: GM_eddy_parameterization #
+############################################
+
+add_default($nl, 'config_use_GM');
+add_default($nl, 'config_GM_kappa');
+add_default($nl, 'config_GM_closure');
+add_default($nl, 'config_GM_min_stratification_ratio');
+add_default($nl, 'config_GM_constant_gravWaveSpeed');
+
+####################################################
+# Namelist group: mesoscale_eddy_parameterizations #
+####################################################
+
+add_default($nl, 'config_mesoscale_eddy_isopycnal_slope_limit');
+add_default($nl, 'config_eddying_resolution_taper');
+add_default($nl, 'config_eddying_resolution_ramp_min');
+add_default($nl, 'config_eddying_resolution_ramp_max');
 
 ####################################
 # Namelist group: hmix_del2_tensor #
@@ -641,6 +647,7 @@ add_default($nl, 'config_mom_del4_tensor');
 
 add_default($nl, 'config_Rayleigh_friction');
 add_default($nl, 'config_Rayleigh_damping_coeff');
+add_default($nl, 'config_Rayleigh_damping_depth_variable');
 add_default($nl, 'config_Rayleigh_bottom_friction');
 add_default($nl, 'config_Rayleigh_bottom_damping_coeff');
 
@@ -936,10 +943,6 @@ add_default($nl, 'config_tensor_test_function');
 # Namelist group: debug #
 #########################
 
-add_default($nl, 'config_disable_redi_k33');
-add_default($nl, 'config_disable_redi_horizontal_term1');
-add_default($nl, 'config_disable_redi_horizontal_term2');
-add_default($nl, 'config_disable_redi_horizontal_term3');
 add_default($nl, 'config_check_zlevel_consistency');
 add_default($nl, 'config_check_ssh_consistency');
 add_default($nl, 'config_filter_btr_mode');
@@ -966,6 +969,7 @@ add_default($nl, 'config_disable_tr_hmix');
 add_default($nl, 'config_disable_tr_vmix');
 add_default($nl, 'config_disable_tr_sflux');
 add_default($nl, 'config_disable_tr_nonlocalflux');
+add_default($nl, 'config_disable_redi_k33');
 add_default($nl, 'config_read_nearest_restart');
 
 ##########################################
@@ -1015,6 +1019,8 @@ add_default($nl, 'config_use_activeTracers_ttd_forcing');
 ###############################################
 
 add_default($nl, 'config_use_debugTracers');
+add_default($nl, 'config_reset_debugTracers_near_surface');
+add_default($nl, 'config_reset_debugTracers_top_nLayers');
 add_default($nl, 'config_use_debugTracers_surface_bulk_forcing');
 add_default($nl, 'config_use_debugTracers_surface_restoring');
 add_default($nl, 'config_use_debugTracers_interior_restoring');
@@ -1604,7 +1610,9 @@ my @groups = qw(run_modes
                 hmix_del2
                 hmix_del4
                 hmix_leith
-                mesoscale_eddy_parameterization
+                redi_isopycnal_mixing
+                gm_eddy_parameterization
+                mesoscale_eddy_parameterizations
                 hmix_del2_tensor
                 hmix_del4_tensor
                 rayleigh_damping

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -606,7 +606,9 @@ add_default($nl, 'config_use_Redi');
 add_default($nl, 'config_Redi_kappa');
 add_default($nl, 'config_Redi_closure');
 add_default($nl, 'config_Redi_surface_taper_layers');
-add_default($nl, 'config_Redi_bottom_taper_height');
+add_default($nl, 'config_Redi_bottom_taper_layers');
+add_default($nl, 'config_Redi_zero_in_boundary_layer');
+add_default($nl, 'config_Redi_BLD_taper_layers');
 
 ############################################
 # Namelist group: GM_eddy_parameterization #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -498,31 +498,6 @@ add_default($nl, 'config_number_of_blocks');
 add_default($nl, 'config_explicit_proc_decomp');
 add_default($nl, 'config_proc_decomp_file_prefix');
 
-##############################
-# Namelist group: init_setup #
-##############################
-
-add_default($nl, 'config_vert_levels');
-add_default($nl, 'config_init_configuration');
-add_default($nl, 'config_expand_sphere');
-add_default($nl, 'config_realistic_coriolis_parameter');
-add_default($nl, 'config_write_cull_cell_mask');
-add_default($nl, 'config_vertical_grid');
-
-################################
-# Namelist group: CVTgenerator #
-################################
-
-add_default($nl, 'config_1dCVTgenerator_stretch1');
-add_default($nl, 'config_1dCVTgenerator_stretch2');
-add_default($nl, 'config_1dCVTgenerator_dzSeed');
-
-################################################
-# Namelist group: init_ssh_and_landIcePressure #
-################################################
-
-add_default($nl, 'config_iterative_init_variable');
-
 ####################################
 # Namelist group: time_integration #
 ####################################
@@ -604,11 +579,11 @@ add_default($nl, 'config_Leith_visc2_max');
 
 add_default($nl, 'config_use_Redi');
 add_default($nl, 'config_Redi_kappa');
+add_default($nl, 'config_Redi_maximum_slope');
 add_default($nl, 'config_Redi_closure');
-add_default($nl, 'config_Redi_surface_taper_layers');
-add_default($nl, 'config_Redi_bottom_taper_layers');
-add_default($nl, 'config_Redi_zero_in_boundary_layer');
-add_default($nl, 'config_Redi_BLD_taper_layers');
+add_default($nl, 'config_Redi_use_slope_taper');
+add_default($nl, 'config_Redi_use_surface_taper');
+add_default($nl, 'config_Redi_N2_limit_term1');
 
 ############################################
 # Namelist group: GM_eddy_parameterization #
@@ -624,7 +599,6 @@ add_default($nl, 'config_GM_constant_gravWaveSpeed');
 # Namelist group: mesoscale_eddy_parameterizations #
 ####################################################
 
-add_default($nl, 'config_mesoscale_eddy_isopycnal_slope_limit');
 add_default($nl, 'config_eddying_resolution_taper');
 add_default($nl, 'config_eddying_resolution_ramp_min');
 add_default($nl, 'config_eddying_resolution_ramp_max');
@@ -1601,9 +1575,6 @@ my @groups = qw(run_modes
                 time_management
                 io
                 decomposition
-                init_setup
-                cvtgenerator
-                init_ssh_and_landicepressure
                 time_integration
                 ale_vertical_grid
                 ale_frequency_filtered_thickness

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -13,7 +13,9 @@ my @groups = qw(run_modes
                 hmix_del2
                 hmix_del4
                 hmix_leith
-                mesoscale_eddy_parameterization
+                redi_isopycnal_mixing
+                gm_eddy_parameterization
+                mesoscale_eddy_parameterizations
                 hmix_del2_tensor
                 hmix_del4_tensor
                 rayleigh_damping

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -2,9 +2,6 @@ my @groups = qw(run_modes
                 time_management
                 io
                 decomposition
-                init_setup
-                cvtgenerator
-                init_ssh_and_landicepressure
                 time_integration
                 ale_vertical_grid
                 ale_frequency_filtered_thickness

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -39,31 +39,6 @@ add_default($nl, 'config_number_of_blocks');
 add_default($nl, 'config_explicit_proc_decomp');
 add_default($nl, 'config_proc_decomp_file_prefix');
 
-##############################
-# Namelist group: init_setup #
-##############################
-
-add_default($nl, 'config_vert_levels');
-add_default($nl, 'config_init_configuration');
-add_default($nl, 'config_expand_sphere');
-add_default($nl, 'config_realistic_coriolis_parameter');
-add_default($nl, 'config_write_cull_cell_mask');
-add_default($nl, 'config_vertical_grid');
-
-################################
-# Namelist group: CVTgenerator #
-################################
-
-add_default($nl, 'config_1dCVTgenerator_stretch1');
-add_default($nl, 'config_1dCVTgenerator_stretch2');
-add_default($nl, 'config_1dCVTgenerator_dzSeed');
-
-################################################
-# Namelist group: init_ssh_and_landIcePressure #
-################################################
-
-add_default($nl, 'config_iterative_init_variable');
-
 ####################################
 # Namelist group: time_integration #
 ####################################
@@ -145,9 +120,11 @@ add_default($nl, 'config_Leith_visc2_max');
 
 add_default($nl, 'config_use_Redi');
 add_default($nl, 'config_Redi_kappa');
+add_default($nl, 'config_Redi_maximum_slope');
 add_default($nl, 'config_Redi_closure');
-add_default($nl, 'config_Redi_surface_taper_layers');
-add_default($nl, 'config_Redi_bottom_taper_height');
+add_default($nl, 'config_Redi_use_slope_taper');
+add_default($nl, 'config_Redi_use_surface_taper');
+add_default($nl, 'config_Redi_N2_limit_term1');
 
 ############################################
 # Namelist group: GM_eddy_parameterization #
@@ -163,7 +140,6 @@ add_default($nl, 'config_GM_constant_gravWaveSpeed');
 # Namelist group: mesoscale_eddy_parameterizations #
 ####################################################
 
-add_default($nl, 'config_mesoscale_eddy_isopycnal_slope_limit');
 add_default($nl, 'config_eddying_resolution_taper');
 add_default($nl, 'config_eddying_resolution_ramp_min');
 add_default($nl, 'config_eddying_resolution_ramp_max');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -139,28 +139,34 @@ add_default($nl, 'config_Leith_parameter');
 add_default($nl, 'config_Leith_dx');
 add_default($nl, 'config_Leith_visc2_max');
 
-###################################################
-# Namelist group: mesoscale_eddy_parameterization #
-###################################################
+#########################################
+# Namelist group: Redi_isopycnal_mixing #
+#########################################
 
-add_default($nl, 'config_use_standardGM');
-add_default($nl, 'config_gm_lat_variable_c2');
-add_default($nl, 'config_gm_kappa_lat_depth_variable');
-add_default($nl, 'config_gm_min_stratification_ratio');
-add_default($nl, 'config_gm_min_phase_speed');
-add_default($nl, 'config_use_Redi_surface_layer_tapering');
-add_default($nl, 'config_Redi_surface_layer_tapering_extent');
-add_default($nl, 'config_use_Redi_bottom_layer_tapering');
-add_default($nl, 'config_Redi_bottom_layer_tapering_depth');
-add_default($nl, 'config_GM_Bolus_kappa_function');
-add_default($nl, 'config_standardGM_tracer_kappa');
-add_default($nl, 'config_GM_Bolus_kappa_min');
-add_default($nl, 'config_GM_Bolus_kappa_max');
-add_default($nl, 'config_GM_Bolus_cell_size_min');
-add_default($nl, 'config_GM_Bolus_cell_size_max');
+add_default($nl, 'config_use_Redi');
 add_default($nl, 'config_Redi_kappa');
-add_default($nl, 'config_gravWaveSpeed_trunc');
-add_default($nl, 'config_max_relative_slope');
+add_default($nl, 'config_Redi_closure');
+add_default($nl, 'config_Redi_surface_taper_layers');
+add_default($nl, 'config_Redi_bottom_taper_height');
+
+############################################
+# Namelist group: GM_eddy_parameterization #
+############################################
+
+add_default($nl, 'config_use_GM');
+add_default($nl, 'config_GM_kappa');
+add_default($nl, 'config_GM_closure');
+add_default($nl, 'config_GM_min_stratification_ratio');
+add_default($nl, 'config_GM_constant_gravWaveSpeed');
+
+####################################################
+# Namelist group: mesoscale_eddy_parameterizations #
+####################################################
+
+add_default($nl, 'config_mesoscale_eddy_isopycnal_slope_limit');
+add_default($nl, 'config_eddying_resolution_taper');
+add_default($nl, 'config_eddying_resolution_ramp_min');
+add_default($nl, 'config_eddying_resolution_ramp_max');
 
 ####################################
 # Namelist group: hmix_del2_tensor #
@@ -182,6 +188,7 @@ add_default($nl, 'config_mom_del4_tensor');
 
 add_default($nl, 'config_Rayleigh_friction');
 add_default($nl, 'config_Rayleigh_damping_coeff');
+add_default($nl, 'config_Rayleigh_damping_depth_variable');
 add_default($nl, 'config_Rayleigh_bottom_friction');
 add_default($nl, 'config_Rayleigh_bottom_damping_coeff');
 
@@ -414,10 +421,6 @@ add_default($nl, 'config_tensor_test_function');
 # Namelist group: debug #
 #########################
 
-add_default($nl, 'config_disable_redi_k33');
-add_default($nl, 'config_disable_redi_horizontal_term1');
-add_default($nl, 'config_disable_redi_horizontal_term2');
-add_default($nl, 'config_disable_redi_horizontal_term3');
 add_default($nl, 'config_check_zlevel_consistency');
 add_default($nl, 'config_check_ssh_consistency');
 add_default($nl, 'config_filter_btr_mode');
@@ -444,6 +447,7 @@ add_default($nl, 'config_disable_tr_hmix');
 add_default($nl, 'config_disable_tr_vmix');
 add_default($nl, 'config_disable_tr_sflux');
 add_default($nl, 'config_disable_tr_nonlocalflux');
+add_default($nl, 'config_disable_redi_k33');
 add_default($nl, 'config_read_nearest_restart');
 
 ##########################################
@@ -485,6 +489,8 @@ add_default($nl, 'config_salinity_restoring_under_sea_ice');
 ###############################################
 
 add_default($nl, 'config_use_debugTracers');
+add_default($nl, 'config_reset_debugTracers_near_surface');
+add_default($nl, 'config_reset_debugTracers_top_nLayers');
 add_default($nl, 'config_use_debugTracers_surface_bulk_forcing');
 add_default($nl, 'config_use_debugTracers_surface_restoring');
 add_default($nl, 'config_use_debugTracers_interior_restoring');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -27,22 +27,6 @@
 <config_explicit_proc_decomp>.false.</config_explicit_proc_decomp>
 <config_proc_decomp_file_prefix>'graph.info.part.'</config_proc_decomp_file_prefix>
 
-<!-- init_setup -->
-<config_vert_levels>-1</config_vert_levels>
-<config_init_configuration>'none'</config_init_configuration>
-<config_expand_sphere>.false.</config_expand_sphere>
-<config_realistic_coriolis_parameter>.false.</config_realistic_coriolis_parameter>
-<config_write_cull_cell_mask>.true.</config_write_cull_cell_mask>
-<config_vertical_grid>'uniform'</config_vertical_grid>
-
-<!-- CVTgenerator -->
-<config_1dCVTgenerator_stretch1>1.0770</config_1dCVTgenerator_stretch1>
-<config_1dCVTgenerator_stretch2>1.0275</config_1dCVTgenerator_stretch2>
-<config_1dCVTgenerator_dzSeed>1.2</config_1dCVTgenerator_dzSeed>
-
-<!-- init_ssh_and_landIcePressure -->
-<config_iterative_init_variable>'landIcePressure'</config_iterative_init_variable>
-
 <!-- time_integration -->
 <config_dt ocn_grid="oQU480">'02:00:00'</config_dt>
 <config_dt ocn_grid="oQU240">'01:00:00'</config_dt>
@@ -151,13 +135,30 @@
 <config_Leith_visc2_max>2.5e3</config_Leith_visc2_max>
 
 <!-- Redi_isopycnal_mixing -->
-<config_use_Redi>.false.</config_use_Redi>
-<config_Redi_kappa>0.0</config_Redi_kappa>
+<config_use_Redi ocn_grid="oQU480">.true.</config_use_Redi>
+<config_use_Redi ocn_grid="oQU240">.true.</config_use_Redi>
+<config_use_Redi ocn_grid="oQU240wLI">.true.</config_use_Redi>
+<config_use_Redi ocn_grid="oQU120">.true.</config_use_Redi>
+<config_use_Redi ocn_grid="oEC60to30">.true.</config_use_Redi>
+<config_use_Redi ocn_grid="oEC60to30v3">.true.</config_use_Redi>
+<config_use_Redi ocn_grid="oEC60to30wLI">.true.</config_use_Redi>
+<config_use_Redi ocn_grid="oEC60to30v3wLI">.true.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS30to10">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS30to10v3">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS30to10wLI">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS30to10v3wLI">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS18to6">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS18to6v3">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS15to5">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oARRM60to10">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oARRM60to6">.false.</config_use_Redi>
+<config_Redi_kappa>1800.0</config_Redi_kappa>
+<config_Redi_kappa ocn_forcing="datm_forced_restoring">600.0</config_Redi_kappa>
+<config_Redi_maximum_slope>0.3</config_Redi_maximum_slope>
 <config_Redi_closure>'constant'</config_Redi_closure>
-<config_Redi_surface_taper_layers>5</config_Redi_surface_taper_layers>
-<config_Redi_bottom_taper_layers>5</config_Redi_bottom_taper_layers>
-<config_Redi_zero_in_boundary_layer>.true.</config_Redi_zero_in_boundary_layer>
-<config_Redi_BLD_taper_layers>5</config_Redi_BLD_taper_layers>
+<config_Redi_use_slope_taper>.true.</config_Redi_use_slope_taper>
+<config_Redi_use_surface_taper>.true.</config_Redi_use_surface_taper>
+<config_Redi_N2_limit_term1>.true.</config_Redi_N2_limit_term1>
 
 <!-- GM_eddy_parameterization -->
 <config_use_GM ocn_grid="oQU480">.true.</config_use_GM>
@@ -184,8 +185,7 @@
 <config_GM_constant_gravWaveSpeed>0.3</config_GM_constant_gravWaveSpeed>
 
 <!-- mesoscale_eddy_parameterizations -->
-<config_mesoscale_eddy_isopycnal_slope_limit>0.01</config_mesoscale_eddy_isopycnal_slope_limit>
-<config_eddying_resolution_taper>'none'</config_eddying_resolution_taper>
+<config_eddying_resolution_taper>'ramp'</config_eddying_resolution_taper>
 <config_eddying_resolution_ramp_min>20e3</config_eddying_resolution_ramp_min>
 <config_eddying_resolution_ramp_max>30e3</config_eddying_resolution_ramp_max>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -150,42 +150,42 @@
 <config_Leith_dx>15000.0</config_Leith_dx>
 <config_Leith_visc2_max>2.5e3</config_Leith_visc2_max>
 
-<!-- mesoscale_eddy_parameterization -->
-<config_use_standardGM ocn_grid="oQU480">.true.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oQU240">.true.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oQU240wLI">.true.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oQU120">.true.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oEC60to30">.true.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oEC60to30v3">.true.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oEC60to30wLI">.true.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oEC60to30v3wLI">.true.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oRRS30to10">.false.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oRRS30to10v3">.false.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oRRS30to10wLI">.false.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oRRS30to10v3wLI">.false.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oRRS18to6">.false.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oRRS18to6v3">.false.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oRRS15to5">.false.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oARRM60to10">.false.</config_use_standardGM>
-<config_use_standardGM ocn_grid="oARRM60to6">.false.</config_use_standardGM>
-<config_gm_lat_variable_c2>.true.</config_gm_lat_variable_c2>
-<config_gm_kappa_lat_depth_variable>.true.</config_gm_kappa_lat_depth_variable>
-<config_gm_min_stratification_ratio>0.1</config_gm_min_stratification_ratio>
-<config_gm_min_phase_speed>0.1</config_gm_min_phase_speed>
-<config_use_Redi_surface_layer_tapering>.false.</config_use_Redi_surface_layer_tapering>
-<config_Redi_surface_layer_tapering_extent>0.0</config_Redi_surface_layer_tapering_extent>
-<config_use_Redi_bottom_layer_tapering>.false.</config_use_Redi_bottom_layer_tapering>
-<config_Redi_bottom_layer_tapering_depth>0.0</config_Redi_bottom_layer_tapering_depth>
-<config_GM_Bolus_kappa_function>'constant'</config_GM_Bolus_kappa_function>
-<config_standardGM_tracer_kappa>1800.0</config_standardGM_tracer_kappa>
-<config_standardGM_tracer_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_standardGM_tracer_kappa>
-<config_GM_Bolus_kappa_min>0.0</config_GM_Bolus_kappa_min>
-<config_GM_Bolus_kappa_max>600.0</config_GM_Bolus_kappa_max>
-<config_GM_Bolus_cell_size_min>20e3</config_GM_Bolus_cell_size_min>
-<config_GM_Bolus_cell_size_max>30e3</config_GM_Bolus_cell_size_max>
+<!-- Redi_isopycnal_mixing -->
+<config_use_Redi>.false.</config_use_Redi>
 <config_Redi_kappa>0.0</config_Redi_kappa>
-<config_gravWaveSpeed_trunc>0.3</config_gravWaveSpeed_trunc>
-<config_max_relative_slope>0.01</config_max_relative_slope>
+<config_Redi_closure>'constant'</config_Redi_closure>
+<config_Redi_surface_taper_layers>10</config_Redi_surface_taper_layers>
+<config_Redi_bottom_taper_height>200.0</config_Redi_bottom_taper_height>
+
+<!-- GM_eddy_parameterization -->
+<config_use_GM ocn_grid="oQU480">.true.</config_use_GM>
+<config_use_GM ocn_grid="oQU240">.true.</config_use_GM>
+<config_use_GM ocn_grid="oQU240wLI">.true.</config_use_GM>
+<config_use_GM ocn_grid="oQU120">.true.</config_use_GM>
+<config_use_GM ocn_grid="oEC60to30">.true.</config_use_GM>
+<config_use_GM ocn_grid="oEC60to30v3">.true.</config_use_GM>
+<config_use_GM ocn_grid="oEC60to30wLI">.true.</config_use_GM>
+<config_use_GM ocn_grid="oEC60to30v3wLI">.true.</config_use_GM>
+<config_use_GM ocn_grid="oRRS30to10">.false.</config_use_GM>
+<config_use_GM ocn_grid="oRRS30to10v3">.false.</config_use_GM>
+<config_use_GM ocn_grid="oRRS30to10wLI">.false.</config_use_GM>
+<config_use_GM ocn_grid="oRRS30to10v3wLI">.false.</config_use_GM>
+<config_use_GM ocn_grid="oRRS18to6">.false.</config_use_GM>
+<config_use_GM ocn_grid="oRRS18to6v3">.false.</config_use_GM>
+<config_use_GM ocn_grid="oRRS15to5">.false.</config_use_GM>
+<config_use_GM ocn_grid="oARRM60to10">.false.</config_use_GM>
+<config_use_GM ocn_grid="oARRM60to6">.false.</config_use_GM>
+<config_GM_kappa>1800.0</config_GM_kappa>
+<config_GM_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_kappa>
+<config_GM_closure>'N2_dependent'</config_GM_closure>
+<config_GM_min_stratification_ratio>0.1</config_GM_min_stratification_ratio>
+<config_GM_constant_gravWaveSpeed>0.3</config_GM_constant_gravWaveSpeed>
+
+<!-- mesoscale_eddy_parameterizations -->
+<config_mesoscale_eddy_isopycnal_slope_limit>0.01</config_mesoscale_eddy_isopycnal_slope_limit>
+<config_eddying_resolution_taper>'constant'</config_eddying_resolution_taper>
+<config_eddying_resolution_ramp_min>20e3</config_eddying_resolution_ramp_min>
+<config_eddying_resolution_ramp_max>30e3</config_eddying_resolution_ramp_max>
 
 <!-- hmix_del2_tensor -->
 <config_use_mom_del2_tensor>.false.</config_use_mom_del2_tensor>
@@ -198,6 +198,7 @@
 <!-- Rayleigh_damping -->
 <config_Rayleigh_friction>.false.</config_Rayleigh_friction>
 <config_Rayleigh_damping_coeff>0.0</config_Rayleigh_damping_coeff>
+<config_Rayleigh_damping_depth_variable>.false.</config_Rayleigh_damping_depth_variable>
 <config_Rayleigh_bottom_friction>.false.</config_Rayleigh_bottom_friction>
 <config_Rayleigh_bottom_damping_coeff>1.0e-4</config_Rayleigh_bottom_damping_coeff>
 
@@ -398,10 +399,6 @@
 <config_tensor_test_function>'sph_uCosCos'</config_tensor_test_function>
 
 <!-- debug -->
-<config_disable_redi_k33>.true.</config_disable_redi_k33>
-<config_disable_redi_horizontal_term1>.false.</config_disable_redi_horizontal_term1>
-<config_disable_redi_horizontal_term2>.false.</config_disable_redi_horizontal_term2>
-<config_disable_redi_horizontal_term3>.false.</config_disable_redi_horizontal_term3>
 <config_check_zlevel_consistency>.false.</config_check_zlevel_consistency>
 <config_check_ssh_consistency>.true.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="oEC60to30v3wLI">.false.</config_check_ssh_consistency>
@@ -430,6 +427,7 @@
 <config_disable_tr_vmix>.false.</config_disable_tr_vmix>
 <config_disable_tr_sflux>.false.</config_disable_tr_sflux>
 <config_disable_tr_nonlocalflux>.false.</config_disable_tr_nonlocalflux>
+<config_disable_redi_k33>.false.</config_disable_redi_k33>
 <config_read_nearest_restart>.false.</config_read_nearest_restart>
 
 <!-- constrain_Haney_number -->
@@ -462,6 +460,8 @@
 
 <!-- tracer_forcing_debugTracers -->
 <config_use_debugTracers>.false.</config_use_debugTracers>
+<config_reset_debugTracers_near_surface>.false.</config_reset_debugTracers_near_surface>
+<config_reset_debugTracers_top_nLayers>20</config_reset_debugTracers_top_nLayers>
 <config_use_debugTracers_surface_bulk_forcing>.false.</config_use_debugTracers_surface_bulk_forcing>
 <config_use_debugTracers_surface_restoring>.false.</config_use_debugTracers_surface_restoring>
 <config_use_debugTracers_interior_restoring>.false.</config_use_debugTracers_interior_restoring>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -154,8 +154,10 @@
 <config_use_Redi>.false.</config_use_Redi>
 <config_Redi_kappa>0.0</config_Redi_kappa>
 <config_Redi_closure>'constant'</config_Redi_closure>
-<config_Redi_surface_taper_layers>10</config_Redi_surface_taper_layers>
-<config_Redi_bottom_taper_height>200.0</config_Redi_bottom_taper_height>
+<config_Redi_surface_taper_layers>5</config_Redi_surface_taper_layers>
+<config_Redi_bottom_taper_layers>5</config_Redi_bottom_taper_layers>
+<config_Redi_zero_in_boundary_layer>.true.</config_Redi_zero_in_boundary_layer>
+<config_Redi_BLD_taper_layers>5</config_Redi_BLD_taper_layers>
 
 <!-- GM_eddy_parameterization -->
 <config_use_GM ocn_grid="oQU480">.true.</config_use_GM>
@@ -183,7 +185,7 @@
 
 <!-- mesoscale_eddy_parameterizations -->
 <config_mesoscale_eddy_isopycnal_slope_limit>0.01</config_mesoscale_eddy_isopycnal_slope_limit>
-<config_eddying_resolution_taper>'constant'</config_eddying_resolution_taper>
+<config_eddying_resolution_taper>'none'</config_eddying_resolution_taper>
 <config_eddying_resolution_ramp_min>20e3</config_eddying_resolution_ramp_min>
 <config_eddying_resolution_ramp_max>30e3</config_eddying_resolution_ramp_max>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -145,14 +145,7 @@
 <config_Redi_N2_limit_term1>.true.</config_Redi_N2_limit_term1>
 
 <!-- GM_eddy_parameterization -->
-<config_use_GM ocn_grid="oQU480">.true.</config_use_GM>
-<config_use_GM ocn_grid="oQU240">.true.</config_use_GM>
-<config_use_GM ocn_grid="oQU240wLI">.true.</config_use_GM>
-<config_use_GM ocn_grid="oQU120">.true.</config_use_GM>
-<config_use_GM ocn_grid="oEC60to30">.true.</config_use_GM>
-<config_use_GM ocn_grid="oEC60to30v3">.true.</config_use_GM>
-<config_use_GM ocn_grid="oEC60to30wLI">.true.</config_use_GM>
-<config_use_GM ocn_grid="oEC60to30v3wLI">.true.</config_use_GM>
+<config_use_GM>.true.</config_use_GM>
 <config_use_GM ocn_grid="oRRS30to10">.false.</config_use_GM>
 <config_use_GM ocn_grid="oRRS30to10v3">.false.</config_use_GM>
 <config_use_GM ocn_grid="oRRS30to10wLI">.false.</config_use_GM>
@@ -160,8 +153,6 @@
 <config_use_GM ocn_grid="oRRS18to6">.false.</config_use_GM>
 <config_use_GM ocn_grid="oRRS18to6v3">.false.</config_use_GM>
 <config_use_GM ocn_grid="oRRS15to5">.false.</config_use_GM>
-<config_use_GM ocn_grid="oARRM60to10">.false.</config_use_GM>
-<config_use_GM ocn_grid="oARRM60to6">.false.</config_use_GM>
 <config_GM_kappa>1800.0</config_GM_kappa>
 <config_GM_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_kappa>
 <config_GM_closure>'N2_dependent'</config_GM_closure>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -135,23 +135,7 @@
 <config_Leith_visc2_max>2.5e3</config_Leith_visc2_max>
 
 <!-- Redi_isopycnal_mixing -->
-<config_use_Redi ocn_grid="oQU480">.true.</config_use_Redi>
-<config_use_Redi ocn_grid="oQU240">.true.</config_use_Redi>
-<config_use_Redi ocn_grid="oQU240wLI">.true.</config_use_Redi>
-<config_use_Redi ocn_grid="oQU120">.true.</config_use_Redi>
-<config_use_Redi ocn_grid="oEC60to30">.true.</config_use_Redi>
-<config_use_Redi ocn_grid="oEC60to30v3">.true.</config_use_Redi>
-<config_use_Redi ocn_grid="oEC60to30wLI">.true.</config_use_Redi>
-<config_use_Redi ocn_grid="oEC60to30v3wLI">.true.</config_use_Redi>
-<config_use_Redi ocn_grid="oRRS30to10">.false.</config_use_Redi>
-<config_use_Redi ocn_grid="oRRS30to10v3">.false.</config_use_Redi>
-<config_use_Redi ocn_grid="oRRS30to10wLI">.false.</config_use_Redi>
-<config_use_Redi ocn_grid="oRRS30to10v3wLI">.false.</config_use_Redi>
-<config_use_Redi ocn_grid="oRRS18to6">.false.</config_use_Redi>
-<config_use_Redi ocn_grid="oRRS18to6v3">.false.</config_use_Redi>
-<config_use_Redi ocn_grid="oRRS15to5">.false.</config_use_Redi>
-<config_use_Redi ocn_grid="oARRM60to10">.false.</config_use_Redi>
-<config_use_Redi ocn_grid="oARRM60to6">.false.</config_use_Redi>
+<config_use_Redi>.false.</config_use_Redi>
 <config_Redi_kappa>1800.0</config_Redi_kappa>
 <config_Redi_kappa ocn_forcing="datm_forced_restoring">600.0</config_Redi_kappa>
 <config_Redi_maximum_slope>0.3</config_Redi_maximum_slope>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -625,7 +625,7 @@
 
 <!-- AM_mixedLayerDepths -->
 <config_AM_mixedLayerDepths_enable>.true.</config_AM_mixedLayerDepths_enable>
-<config_AM_mixedLayerDepths_compute_interval>'0000-00-00_01:00:00'</config_AM_mixedLayerDepths_compute_interval>
+<config_AM_mixedLayerDepths_compute_interval>'dt'</config_AM_mixedLayerDepths_compute_interval>
 <config_AM_mixedLayerDepths_output_stream>'mixedLayerDepthsOutput'</config_AM_mixedLayerDepths_output_stream>
 <config_AM_mixedLayerDepths_write_on_startup>.false.</config_AM_mixedLayerDepths_write_on_startup>
 <config_AM_mixedLayerDepths_compute_on_startup>.true.</config_AM_mixedLayerDepths_compute_on_startup>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -182,95 +182,6 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- init_setup -->
-
-<entry id="config_vert_levels" type="integer"
-	category="init_setup" group="init_setup">
-Number of vertical levels to create within the configuration.
-
-Valid values: Any positive non-zero integer. A value of -1 causes this to be overwritten with the configurations vertical level definition.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_init_configuration" type="char*1024"
-	category="init_setup" group="init_setup">
-Name of configuration to create.
-
-Valid values: Any configuration name
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_expand_sphere" type="logical"
-	category="init_setup" group="init_setup">
-Logical flag that controls if a spherical mesh is expanded to an earth sized sphere or not.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_realistic_coriolis_parameter" type="logical"
-	category="init_setup" group="init_setup">
-Logical flag that controls if a spherical mesh will get realistic coriolis parameters or not.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_write_cull_cell_mask" type="logical"
-	category="init_setup" group="init_setup">
-Logicial flag that controls if the cullCell field is written to output.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_vertical_grid" type="char*1024"
-	category="init_setup" group="init_setup">
-Name of vertical grid to use in configuration generation
-
-Valid values: 'uniform', '60layerPHC', '42layerWOCE', '100layerE3SMv1', '1dCVTgenerator', ...
-Default: Defined in namelist_defaults.xml
-</entry>
-
-
-<!-- CVTgenerator -->
-
-<entry id="config_1dCVTgenerator_stretch1" type="real"
-	category="CVTgenerator" group="CVTgenerator">
-Parameter for the 1D CVT vertical grid generator.
-
-Valid values: Any positive non-zero integer.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_1dCVTgenerator_stretch2" type="real"
-	category="CVTgenerator" group="CVTgenerator">
-Parameter for the 1D CVT vertical grid generator.
-
-Valid values: Any positive non-zero integer.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_1dCVTgenerator_dzSeed" type="real"
-	category="CVTgenerator" group="CVTgenerator">
-Seed thickness of the first layer for the 1D CVT vertical grid generator.
-
-Valid values: Any positive non-zero integer.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-
-<!-- init_ssh_and_landIcePressure -->
-
-<entry id="config_iterative_init_variable" type="char*1024"
-	category="init_ssh_and_landIcePressure" group="init_ssh_and_landIcePressure">
-Which variable, ssh or landIcePressure, is computed from the other.  If landIcePressure is to be computed, 'landIcePressure_from_top_density' indicates that the top density (rather than the mean density displaced by land ice) should be used to compute the landIcePressure.
-
-Valid values: 'ssh', 'landIcePressure_from_top_density' or 'landIcePressure'
-Default: Defined in namelist_defaults.xml
-</entry>
-
-
 <!-- time_integration -->
 
 <entry id="config_dt" type="char*1024"
@@ -412,7 +323,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_alter_ICs_for_pbcs" type="logical"
 	category="partial_bottom_cells" group="partial_bottom_cells">
-If true, initial conditions are altered according to the config_pbc_alteration_type flag. The alteration of layer thickness only occurs when config_do_restart is false, i.e. on an initial run.
+If true, initial conditions are altered according to the config_pbc_alteration_type flag.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
@@ -428,7 +339,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_min_pbc_fraction" type="real"
 	category="partial_bottom_cells" group="partial_bottom_cells">
-Determines the minimum fraction of a cell altering the initial conditions can create. The alteration of layer thickness only occurs when config_do_restart is false, i.e. on an initial run.
+Determines the minimum fraction of a cell altering the initial conditions can create.
 
 Valid values: Any real between 0 and 1.
 Default: Defined in namelist_defaults.xml
@@ -593,6 +504,14 @@ Valid values: Positive real numbers
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_Redi_maximum_slope" type="real"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+value of maximum allowed isopycnal slope from Danabasoglu et al 2008 equation (2)
+
+Valid values: positive real numbers, but small
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_Redi_closure" type="char*1024"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
 Control what type of function is used for Redi $\kappa$. Only 'constant' is currently supported.
@@ -601,35 +520,27 @@ Valid values: 'constant', 'data', 'match_GM'
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_Redi_surface_taper_layers" type="integer"
+<entry id="config_Redi_use_slope_taper" type="logical"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-Number of layers below boundary layer depth where surface tapering ends.
-
-Valid values: Any positive real value, typically between 1 and 2.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_Redi_bottom_taper_layers" type="integer"
-	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-Number of layers below boundary layer depth where surface tapering ends.
-
-Valid values: Any positive real value, typically between 1 and 2.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_Redi_zero_in_boundary_layer" type="logical"
-	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-If true, Redi kappa is set to zero above the boundary layer depth
+If true, Redi is tapered based on Danabasoglu and McWilliams 1995 (slope tapering)
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_Redi_BLD_taper_layers" type="integer"
+<entry id="config_Redi_use_surface_taper" type="logical"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-Number of layers below boundary layer depth where surface tapering ends.
+If true, Redi slope is tapered near sfc based on Large et al 1997
 
-Valid values: Any positive real value, typically between 1 and 2.
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_N2_limit_term1" type="logical"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+If true, the N2 limiting is applied to the horizontal diffusion term
+
+Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -654,15 +565,15 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_GM_closure" type="char*1024"
 	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
-Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependant' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependant' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006).
+Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006).
 
-Valid values: 'N2_dependant', 'constant'
+Valid values: 'N2_dependent', 'constant'
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_GM_min_stratification_ratio" type="real"
 	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
-When using config_GM_closure='N2_dependant', the minimum value for N2/Nmax2 ratio.
+When using config_GM_closure='N2_dependent', the minimum value for N2/Nmax2 ratio.
 
 Valid values: small positive reals
 Default: Defined in namelist_defaults.xml
@@ -679,19 +590,11 @@ Default: Defined in namelist_defaults.xml
 
 <!-- mesoscale_eddy_parameterizations -->
 
-<entry id="config_mesoscale_eddy_isopycnal_slope_limit" type="real"
-	category="mesoscale_eddy_parameterizations" group="mesoscale_eddy_parameterizations">
-Maximum value of isopycnal slope allowed for Redi and GM schemes. Slopes greater than this value (positive or negative) are capped at this value.
-
-Valid values: Positive real numbers
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_eddying_resolution_taper" type="char*1024"
 	category="mesoscale_eddy_parameterizations" group="mesoscale_eddy_parameterizations">
 Control how the Redi and GM Bolus $\kappa$ value varies as a function of horizontal resolution
 
-Valid values: 'constant' and 'ramp'
+Valid values: 'none' and 'ramp'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2372,7 +2275,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_reset_debugTracers_top_nLayers" type="integer"
 	category="tracer_forcing_debugTracers" group="tracer_forcing_debugTracers">
-Integer specifying number of layers at top to reset from 0 to 1 at end of each timestep. Default is 20, chosen to be near a typical mixed layer depth of 200m.
+Integer specifying number of layers at top to reset 2 at end of each timestep. Default is 20, chosen to be near a typical mixed layer depth of 200m.
 
 Valid values: Any positive integer value greater than or equal to 0.
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -609,11 +609,27 @@ Valid values: Any positive real value, typically between 1 and 2.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_Redi_bottom_taper_height" type="real"
+<entry id="config_Redi_bottom_taper_layers" type="integer"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-Height above bottom of water column where bottom tapering ends.
+Number of layers below boundary layer depth where surface tapering ends.
 
-Valid values: Any positive real value, typically between 100 and 500 m.
+Valid values: Any positive real value, typically between 1 and 2.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_zero_in_boundary_layer" type="logical"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+If true, Redi kappa is set to zero above the boundary layer depth
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_BLD_taper_layers" type="integer"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+Number of layers below boundary layer depth where surface tapering ends.
+
+Valid values: Any positive real value, typically between 1 and 2.
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -575,149 +575,123 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- mesoscale_eddy_parameterization -->
+<!-- Redi_isopycnal_mixing -->
 
-<entry id="config_use_standardGM" type="logical"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-If true, the standard GM for the tracer advection and mixing is turned on. This includes the redi portion which is captured in hmix.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_gm_lat_variable_c2" type="logical"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-If true, spatially variable phase speed is used Following Ferrari et al (2010)
+<entry id="config_use_Redi" type="logical"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+If true, Redi isopycnal mixing is turned on
 
 Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_gm_kappa_lat_depth_variable" type="logical"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-If true, spatitally and deph varying Bolus Kappa is used, following Danabasoglu et al (2007)
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_gm_min_stratification_ratio" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-minimum value for N2/Nmax2 ratio
-
-Valid values: small positive reals
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_gm_min_phase_speed" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-minimum allowed phase speed for spatially variable computation
-
-Valid values: small positive reals
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_use_Redi_surface_layer_tapering" type="logical"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-If true, the Redi K33 vertical mixing is limited in and just below the ocean boundary layer.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_Redi_surface_layer_tapering_extent" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Vertical component of Redi mixing limited in top config_Redi_surface_layer_tapering_extent*boundaryLayerDepth
-
-Valid values: Any positive real value, typically between 1 and 2.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_use_Redi_bottom_layer_tapering" type="logical"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-If true, the Redi K33 vertical mixing is limited in bottom boundary layer.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_Redi_bottom_layer_tapering_depth" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Vertical component of Redi mixing limited in bottom config_Redi_surface_layer_tapering_depth
-
-Valid values: Any positive real value, typically between 100 and 500 m.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_GM_Bolus_kappa_function" type="char*1024"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Control what type of function is used for GM Bolus $\kappa$
-
-Valid values: 'constant' and 'ramp'
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_standardGM_tracer_kappa" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Used when config_GM_Bolus_kappa_function is set to constant.
-
-Valid values: MISSING POSSIBLE VALUES
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_GM_Bolus_kappa_min" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$, min value in ramp as a function of dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp.
-
-Valid values: Any positive real value.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_GM_Bolus_kappa_max" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$, min value in ramp as a function of dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp.
-
-Valid values: Any positive real value.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_GM_Bolus_cell_size_min" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Minimum value in grid cell size for GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp.
-
-Valid values: Any positive real value.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_GM_Bolus_cell_size_max" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Maximum value in grid cell size for GM $\kappa$ ramp function.  Here cell size refers to dcEdge
-
-Valid values: Any positive real value.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_Redi_kappa" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
 The Redi diffusion coefficient
 
 Valid values: Positive real numbers
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_gravWaveSpeed_trunc" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Gravity wave speed truncation threshold for the vertical stream function boundary value problem, $c$
+<entry id="config_Redi_closure" type="char*1024"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+Control what type of function is used for Redi $\kappa$. Only 'constant' is currently supported.
 
-Valid values: Positive real numbers that represents the gravity wave speed of the first, second, etc., baroclinic modes
+Valid values: 'constant', 'data', 'match_GM'
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_max_relative_slope" type="real"
-	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
-Tapering parameter for Redi diffusion coeffient.  Tapering occurs when relativeSlopeTopOfEdge is greater than config_max_relative_slope
+<entry id="config_Redi_surface_taper_layers" type="integer"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+Number of layers below boundary layer depth where surface tapering ends.
+
+Valid values: Any positive real value, typically between 1 and 2.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_bottom_taper_height" type="real"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+Height above bottom of water column where bottom tapering ends.
+
+Valid values: Any positive real value, typically between 100 and 500 m.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
+<!-- GM_eddy_parameterization -->
+
+<entry id="config_use_GM" type="logical"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+If true, the standard GM for the tracer advection and mixing is turned on.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_kappa" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Used when config_GM_kappa_function is set to constant.
+
+Valid values: MISSING POSSIBLE VALUES
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_closure" type="char*1024"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependant' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependant' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006).
+
+Valid values: 'N2_dependant', 'constant'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_min_stratification_ratio" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+When using config_GM_closure='N2_dependant', the minimum value for N2/Nmax2 ratio.
+
+Valid values: small positive reals
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_constant_gravWaveSpeed" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+Gravity wave speed for the vertical stream function boundary value problem. This appears as $c$ in eqn 16a of Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004).
 
 Valid values: Positive real numbers
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
+<!-- mesoscale_eddy_parameterizations -->
+
+<entry id="config_mesoscale_eddy_isopycnal_slope_limit" type="real"
+	category="mesoscale_eddy_parameterizations" group="mesoscale_eddy_parameterizations">
+Maximum value of isopycnal slope allowed for Redi and GM schemes. Slopes greater than this value (positive or negative) are capped at this value.
+
+Valid values: Positive real numbers
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_eddying_resolution_taper" type="char*1024"
+	category="mesoscale_eddy_parameterizations" group="mesoscale_eddy_parameterizations">
+Control how the Redi and GM Bolus $\kappa$ value varies as a function of horizontal resolution
+
+Valid values: 'constant' and 'ramp'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_eddying_resolution_ramp_min" type="real"
+	category="mesoscale_eddy_parameterizations" group="mesoscale_eddy_parameterizations">
+Minimum value in grid cell size for Redi and GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_eddying_resolution_taper is set to ramp.
+
+Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_eddying_resolution_ramp_max" type="real"
+	category="mesoscale_eddy_parameterizations" group="mesoscale_eddy_parameterizations">
+Maximum value in grid cell size for Redi and GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_eddying_resolution_taper is set to ramp.
+
+Valid values: Any positive real value.
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -775,6 +749,14 @@ Default: Defined in namelist_defaults.xml
 Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level.
 
 Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Rayleigh_damping_depth_variable" type="logical"
+	category="Rayleigh_damping" group="Rayleigh_damping">
+If true applies r h^-1 instead of just r.
+
+Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1654,9 +1636,9 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_pressure_gradient_type" type="char*1024"
 	category="pressure_gradient" group="pressure_gradient">
-Form of pressure gradient terms in momentum equation. For most applications, the gradient of pressure and layer mid-depth are appropriate.  For isopycnal coordinates, one may use the gradient of the Montgomery potential.
+Form of pressure gradient terms in momentum equation. For most applications, the gradient of pressure and layer mid-depth are appropriate.  For isopycnal coordinates, one may use the gradient of the Montgomery potential.  The sea surface height gradient (ssh_gradient) option is for barotropic, depth-averaged pressure.
 
-Valid values: 'pressure_and_zmid' or 'Jacobian_from_density' or 'Jacobian_from_TS' or 'MontgomeryPotential'
+Valid values: 'ssh_gradient', 'pressure_and_zmid' or 'Jacobian_from_density' or 'Jacobian_from_TS' or 'MontgomeryPotential'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1931,38 +1913,6 @@ Default: Defined in namelist_defaults.xml
 
 <!-- debug -->
 
-<entry id="config_disable_redi_k33" type="logical"
-	category="debug" group="debug">
-If true, disables k33 portion of Redi neutral surface mixing.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_disable_redi_horizontal_term1" type="logical"
-	category="debug" group="debug">
-If true, disables first term in horizonal mixing of Redi neutral surface mixing.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_disable_redi_horizontal_term2" type="logical"
-	category="debug" group="debug">
-If true, disables first term in horizonal mixing of Redi neutral surface mixing.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_disable_redi_horizontal_term3" type="logical"
-	category="debug" group="debug">
-If true, disables first term in horizonal mixing of Redi neutral surface mixing.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_check_zlevel_consistency" type="logical"
 	category="debug" group="debug">
 Enables a run-time check for consistency for a zlevel grid. Ensures relevant variables correctly define the bottom of the ocean.
@@ -2166,6 +2116,14 @@ Default: Defined in namelist_defaults.xml
 <entry id="config_disable_tr_nonlocalflux" type="logical"
 	category="debug" group="debug">
 Disables tendencies on the tracer fields from CVMix/KPP nonlocal fluxes.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_disable_redi_k33" type="logical"
+	category="debug" group="debug">
+If true, disables k33 portion of Redi neutral surface mixing.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
@@ -2385,6 +2343,22 @@ Default: Defined in namelist_defaults.xml
 if true, the 'debugTracers' category is enabled for the run
 
 Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_reset_debugTracers_near_surface" type="logical"
+	category="tracer_forcing_debugTracers" group="tracer_forcing_debugTracers">
+if true, the reset 'debugTracers' in the top n layers, where n is set by config_reset_debugTracers_top_nLayers
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_reset_debugTracers_top_nLayers" type="integer"
+	category="tracer_forcing_debugTracers" group="tracer_forcing_debugTracers">
+Integer specifying number of layers at top to reset from 0 to 1 at end of each timestep. Default is 20, chosen to be near a typical mixed layer depth of 200m.
+
+Valid values: Any positive integer value greater than or equal to 0.
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -826,7 +826,6 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var name="vertGMBolusVelocityTop"/>')
             lines.append('    <var name="GMBolusVelocityZonal"/>')
             lines.append('    <var name="GMBolusVelocityMeridional"/>')
-            lines.append('    <var name="kappaGM3D"/>')
             lines.append('    <var name="cGMphaseSpeed"/>')
             lines.append('    <var name="velocityZonalTimesTemperature_GM"/>')
             lines.append('    <var name="velocityMeridionalTimesTemperature_GM"/>')

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -55,7 +55,8 @@ module ocn_comp_mct
    use ocn_tracer_short_wave_absorption_variable
    use ocn_tracer_ecosys
    use ocn_tracer_surface_restoring
-
+   use ocn_gm
+   use ocn_config
 !
 ! !PUBLIC MEMBER FUNCTIONS:
   implicit none
@@ -961,6 +962,12 @@ contains
             call mpas_timer_stop("land_ice_build_arrays")
 
             call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, diagnosticsPool, statePool, ierr)
+
+            ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
+            if (config_use_Redi.or.config_use_GM) then
+              call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, meshPool, scratchPool, timeLevelIn=1)
+            endif
+
             block_ptr => block_ptr % next
          end do
          if (debugOn) call mpas_log_write('   Finished building forcing arrays')


### PR DESCRIPTION
Add capability to the Redi isopycnal mixing scheme, which is required for non-eddying resolutions. It includes:
1. Change to triad formulation to compute the isopycnal slope.
2. Linear expansion of density in T,S at each triad corner.
3. Several bug fixes, including a missing factor in the vertical mixing term.
4. Tapering Redi diffusion coefficient at top and bottom of each column.
5. Add ability for Redi diffusion coefficient to be a 3D field, rather than just constant.
6. Two new Redi verification test cases in the COMPASS suite.

According to [Griffies et al 1998](https://pdfs.semanticscholar.org/ba9d/8cfa2baf553ec2dc9bc28b609c90fa111ca2.pdf) this triad expansion of the slope calculation (my steps 1 and 2, his eqns 30-34) is total variance diminishing, and essential when using a nonlinear equation of state. It was used in MOM and POP. Though noise may still exist, it is much reduced. 

This PR leaves Redi mixing off by default, but is non-BFB due to mixing changes. After tuning exercises we will have a later PR that turns Redi mixing on for low resolution, with the proper settings.

[NML]
[non-BFB]