### PR TITLE
Minor fix to HOMME for IBM compiler on Summit

### DIFF
--- a/components/homme/src/share/sl_advection.F90
+++ b/components/homme/src/share/sl_advection.F90
@@ -1136,7 +1136,7 @@ contains
     nerr = nerr + test_lagrange()
     nerr = nerr + test_reconstruct_and_limit_dp()
 
-    if (nerr > 0 .and. par%masterproc) write(iulog,'(a,i3)'), 'sl_unittest FAIL', nerr
+    if (nerr > 0 .and. par%masterproc) write(iulog,'(a,i3)') 'sl_unittest FAIL', nerr
   end subroutine sl_unittest
 
 end module sl_advection


### PR DESCRIPTION
Removes a comma after write statement.

Fixes #3355 
[BFB]