### PR TITLE
Fix chunk cost calc. to be thread safe and add decomposition diagnostics

### DIFF
--- a/cime/src/share/util/shr_sys_mod.F90
+++ b/cime/src/share/util/shr_sys_mod.F90
@@ -213,8 +213,10 @@ integer(SHR_KIND_I8) FUNCTION shr_sys_irtc( rate )
    integer(SHR_KIND_IN)      :: count
    integer(SHR_KIND_IN)      :: count_rate
    integer(SHR_KIND_IN)      :: count_max
+
    integer(SHR_KIND_IN),save :: last_count   = -1
    integer(SHR_KIND_I8),save :: count_offset =  0
+!$OMP THREADPRIVATE (last_count, count_offset)
 
    !----- formats -----
    character(*),parameter :: subName =   '(shr_sys_irtc) '

--- a/cime/src/share/util/shr_sys_mod.F90
+++ b/cime/src/share/util/shr_sys_mod.F90
@@ -224,6 +224,14 @@ integer(SHR_KIND_I8) FUNCTION shr_sys_irtc( rate )
 
 !-------------------------------------------------------------------------------
 ! emulates Cray/SGI irtc function (returns clock tick since last reboot)
+!
+! This function is not intended to measure elapsed time between
+! multi-threaded regions with different numbers of threads. However,
+! use of the threadprivate declaration does guarantee accurate
+! measurement per thread within a single multi-threaded region as
+! long as the number of threads is not changed dynamically during
+! execution within the multi-threaded region.
+!
 !-------------------------------------------------------------------------------
 
    call system_clock(count=count,count_rate=count_rate, count_max=count_max)

--- a/components/cam/src/physics/cam/phys_grid.F90
+++ b/components/cam/src/physics/cam/phys_grid.F90
@@ -271,6 +271,12 @@ module phys_grid
    integer, private :: nproc_busy_d    ! number of processes active during the dynamics
                                        !  (assigned a dynamics block)
 
+! Physics grid decomposition environment
+   integer, private :: nlthreads       ! number of OpenMP threads available to this process
+   integer, dimension(:), allocatable, private :: npthreads
+                                       ! number of OpenMP threads available to each process
+                                       !  (deallocated at end of phys_grid_init)
+
 ! Physics grid decomposition options:  
 ! -1: each chunk is a dynamics block
 !  0: chunk definitions and assignments do not require interprocess comm.
@@ -409,6 +415,10 @@ contains
     integer :: chunk_ncols                ! number of columns assigned to a chunk
     integer :: min_chunk_ncols            ! min number of columns assigned to a chunk
     integer :: max_chunk_ncols            ! max number of columns assigned to a chunk
+    integer :: min_process_nthreads       ! min number of threads available to a process
+    integer :: max_process_nthreads       ! max number of threads available to a process
+    integer :: min_process_nchunks        ! min number of chunks assigned to a process
+    integer :: max_process_nchunks        ! max number of chunks assigned to a process
     integer :: min_process_ncols          ! min number of columns assigned to a process
     integer :: max_process_ncols          ! max number of columns assigned to a process
     integer, dimension(:), allocatable :: process_ncols ! number of columns per process
@@ -427,6 +437,11 @@ contains
     character(len=hcoord_len)           :: copy_gridname
     logical                             :: unstructured
     real(r8)                            :: lonmin, latmin
+
+#if ( defined _OPENMP )
+    integer omp_get_max_threads
+    external omp_get_max_threads
+#endif
 
     nullify(lonvals)
     nullify(latvals)
@@ -627,6 +642,24 @@ contains
     deallocate( clat_d )
     deallocate( clon_d )
     deallocate( cdex )
+
+    !
+    ! Determine number of threads per process, for use in create_chunks
+    ! and in output of decomposition statistics
+    !
+    allocate( npthreads(0:npes-1) )
+    npthreads(:) = 0
+
+    nlthreads = 1
+#if ( defined _OPENMP )
+    nlthreads = OMP_GET_MAX_THREADS()
+#endif
+!
+#if ( defined SPMD )
+    call mpiallgatherint(nlthreads, 1, npthreads, 1, mpicom)
+#else
+    npthreads(0) = nlthreads
+#endif
 
     !
     ! Determine block index bounds
@@ -1171,9 +1204,23 @@ contains
         process_ncols(owner_p) = process_ncols(owner_p) + chunk_ncols
       enddo
 
-      min_process_ncols = process_ncols(0)
-      max_process_ncols = process_ncols(0)
+      min_process_nthreads = npthreads(0)
+      max_process_nthreads = npthreads(0)
+      min_process_nchunks  = npchunks(0)
+      max_process_nchunks  = npchunks(0)
+      min_process_ncols    = process_ncols(0)
+      max_process_ncols    = process_ncols(0)
       do p=1,npes-1
+        if (npthreads(p) < min_process_nthreads) &
+          min_process_nthreads = npthreads(p)
+        if (npthreads(p) > max_process_nthreads) &
+          max_process_nthreads = npthreads(p)
+
+        if (npchunks(p) < min_process_nchunks) &
+          min_process_nchunks = npchunks(p)
+        if (npchunks(p) > max_process_nchunks) &
+          max_process_nchunks = npchunks(p)
+
         if (process_ncols(p) < min_process_ncols) &
           min_process_ncols = process_ncols(p)
         if (process_ncols(p) > max_process_ncols) &
@@ -1188,14 +1235,21 @@ contains
       write(iulog,*) '  phys_alltoall=      ',phys_alltoall
       write(iulog,*) '  chunks_per_thread=  ',chunks_per_thread
       write(iulog,*) 'PHYS_GRID_INIT:  Decomposition Statistics:'
-      write(iulog,*) '  ngcols_p=',ngcols_p
-      write(iulog,*) '  nchunks= ',nchunks
-      write(iulog,*) '  (min,max) columns per chunk:   (',        &
+      write(iulog,*) '  total number of physics columns=   ',ngcols_p
+      write(iulog,*) '  total number of chunks=            ',nchunks
+      write(iulog,*) '  total number of physics processes= ',npes
+      write(iulog,*) '  (min,max) # of threads per physics process: (',  &
+                        min_process_nthreads,',',max_process_nthreads,')'
+      write(iulog,*) '  (min,max) # of physics columns per chunk:   (',  &
                         min_chunk_ncols,',',max_chunk_ncols,')'
-      write(iulog,*) '  (min,max) columns per process: (',        &
+      write(iulog,*) '  (min,max) # of chunks per process:          (',  &
+                        min_process_nchunks,',',max_process_nchunks,')'
+      write(iulog,*) '  (min,max) # of physics columns per process: (',  &
                         min_process_ncols,',',max_process_ncols,')'
     endif
-    !
+
+    ! Clean-up
+    deallocate(npthreads)
 
     call t_stopf("phys_grid_init")
     call t_adj_detailf(+2)
@@ -4133,8 +4187,6 @@ logical function phys_grid_initialized ()
                                          !  thread
 !---------------------------Local workspace-----------------------------
    integer :: i, j, p                    ! loop indices
-   integer :: nlthreads                  ! number of local OpenMP threads
-   integer :: npthreads(0:npes-1)        ! number of OpenMP threads per process
    integer :: proc_smp_mapx(0:npes-1)    ! process/virtual SMP node map
    integer :: firstblock, lastblock      ! global block index bounds
    integer :: maxblksiz                  ! maximum number of columns in a dynamics block
@@ -4209,24 +4261,10 @@ logical function phys_grid_initialized ()
    integer, dimension(:), allocatable :: heap
    integer, dimension(:), allocatable :: heap_len
 
-#if ( defined _OPENMP )
-   integer omp_get_max_threads
-   external omp_get_max_threads
-#endif
-
 !-----------------------------------------------------------------------
-!
-! Determine number of threads per process
-!
-   nlthreads = 1
-#if ( defined _OPENMP )
-   nlthreads = OMP_GET_MAX_THREADS()
-#endif
-!
-#if ( defined SPMD )
-   call mpiallgatherint(nlthreads, 1, npthreads, 1, mpicom)
-#else
-   npthreads(0) = nlthreads
+
+! Make sure that proc_smp_map is set appropriately even if not using MPI
+#if ( ! defined SPMD )
    proc_smp_map(0) = 0
 #endif
 

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1030,7 +1030,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
        call t_startf ('bc_physics')
        !call t_adj_detailf(+1)
 
-!$OMP PARALLEL DO PRIVATE (C, beg_count, phys_buffer_chunk, end_count, chunk_cost)
+!$OMP PARALLEL DO PRIVATE (C, irtc_rate, beg_count, phys_buffer_chunk, end_count, chunk_cost)
        do c=begchunk, endchunk
 
 !$OMP critical(sys_irtc)
@@ -1126,7 +1126,7 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
        first_exec_of_phys_run1_adiabatic_or_ideal  = .FALSE.
     endif
 
-!$OMP PARALLEL DO PRIVATE (C, beg_count, FLX_HEAT, end_count, chunk_cost)
+!$OMP PARALLEL DO PRIVATE (C, irtc_rate, beg_count, FLX_HEAT, end_count, chunk_cost)
     do c=begchunk, endchunk
 
 !$OMP critical(sys_irtc)
@@ -1255,7 +1255,7 @@ subroutine phys_run2(phys_state, ztodt, phys_tend, pbuf2d,  cam_out, &
        call ieflx_gmean(phys_state, phys_tend, pbuf2d, cam_in, cam_out, nstep)
     end if
 
-!$OMP PARALLEL DO PRIVATE (C, beg_count, NCOL, phys_buffer_chunk, end_count, chunk_cost)
+!$OMP PARALLEL DO PRIVATE (C, irtc_rate, beg_count, NCOL, phys_buffer_chunk, end_count, chunk_cost)
     do c=begchunk,endchunk
 
 !$OMP critical(sys_irtc)

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1033,7 +1033,9 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
 !$OMP PARALLEL DO PRIVATE (C, beg_count, phys_buffer_chunk, end_count, chunk_cost)
        do c=begchunk, endchunk
 
+!$OMP critical(sys_irtc)
           beg_count = shr_sys_irtc(irtc_rate)
+!$OMP end critical(sys_irtc)
 
           !
           ! Output physics terms to IC file
@@ -1048,7 +1050,9 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
                        phys_tend(c), phys_buffer_chunk,  fsds(1,c), landm(1,c),          &
                        sgh(1,c), sgh30(1,c), cam_out(c), cam_in(c) )
 
+!$OMP critical(sys_irtc)
           end_count = shr_sys_irtc(irtc_rate)
+!$OMP end critical(sys_irtc)
           chunk_cost = real( (end_count-beg_count), r8)/real(irtc_rate, r8)
           call update_cost_p(c, chunk_cost)
 
@@ -1125,7 +1129,9 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
 !$OMP PARALLEL DO PRIVATE (C, beg_count, FLX_HEAT, end_count, chunk_cost)
     do c=begchunk, endchunk
 
+!$OMP critical(sys_irtc)
        beg_count = shr_sys_irtc(irtc_rate)
+!$OMP end critical(sys_irtc)
 
        ! Initialize the physics tendencies to zero.
        call physics_tend_init(phys_tend(c))
@@ -1150,7 +1156,9 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
        ! Save total enery after physics for energy conservation checks
        call pbuf_set_field(pbuf_get_chunk(pbuf2d, c), teout_idx, phys_state(c)%te_cur)
 
+!$OMP critical(sys_irtc)
        end_count = shr_sys_irtc(irtc_rate)
+!$OMP end critical(sys_irtc)
        chunk_cost = real( (end_count-beg_count), r8)/real(irtc_rate, r8)
        call update_cost_p(c, chunk_cost)
 
@@ -1250,7 +1258,9 @@ subroutine phys_run2(phys_state, ztodt, phys_tend, pbuf2d,  cam_out, &
 !$OMP PARALLEL DO PRIVATE (C, beg_count, NCOL, phys_buffer_chunk, end_count, chunk_cost)
     do c=begchunk,endchunk
 
+!$OMP critical(sys_irtc)
        beg_count = shr_sys_irtc(irtc_rate)
+!$OMP end critical(sys_irtc)
 
        ncol = get_ncols_p(c)
        phys_buffer_chunk => pbuf_get_chunk(pbuf2d, c)
@@ -1275,7 +1285,9 @@ subroutine phys_run2(phys_state, ztodt, phys_tend, pbuf2d,  cam_out, &
             phys_state(c), phys_tend(c), phys_buffer_chunk,&
             fsds(1,c))
 
+!$OMP critical(sys_irtc)
        end_count = shr_sys_irtc(irtc_rate)
+!$OMP end critical(sys_irtc)
        chunk_cost = real( (end_count-beg_count), r8)/real(irtc_rate, r8)
        call update_cost_p(c, chunk_cost)
 

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1033,9 +1033,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
 !$OMP PARALLEL DO PRIVATE (C, irtc_rate, beg_count, phys_buffer_chunk, end_count, chunk_cost)
        do c=begchunk, endchunk
 
-!$OMP critical(sys_irtc)
           beg_count = shr_sys_irtc(irtc_rate)
-!$OMP end critical(sys_irtc)
 
           !
           ! Output physics terms to IC file
@@ -1050,9 +1048,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
                        phys_tend(c), phys_buffer_chunk,  fsds(1,c), landm(1,c),          &
                        sgh(1,c), sgh30(1,c), cam_out(c), cam_in(c) )
 
-!$OMP critical(sys_irtc)
           end_count = shr_sys_irtc(irtc_rate)
-!$OMP end critical(sys_irtc)
           chunk_cost = real( (end_count-beg_count), r8)/real(irtc_rate, r8)
           call update_cost_p(c, chunk_cost)
 
@@ -1129,9 +1125,7 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
 !$OMP PARALLEL DO PRIVATE (C, irtc_rate, beg_count, FLX_HEAT, end_count, chunk_cost)
     do c=begchunk, endchunk
 
-!$OMP critical(sys_irtc)
        beg_count = shr_sys_irtc(irtc_rate)
-!$OMP end critical(sys_irtc)
 
        ! Initialize the physics tendencies to zero.
        call physics_tend_init(phys_tend(c))
@@ -1156,9 +1150,7 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
        ! Save total enery after physics for energy conservation checks
        call pbuf_set_field(pbuf_get_chunk(pbuf2d, c), teout_idx, phys_state(c)%te_cur)
 
-!$OMP critical(sys_irtc)
        end_count = shr_sys_irtc(irtc_rate)
-!$OMP end critical(sys_irtc)
        chunk_cost = real( (end_count-beg_count), r8)/real(irtc_rate, r8)
        call update_cost_p(c, chunk_cost)
 
@@ -1258,9 +1250,7 @@ subroutine phys_run2(phys_state, ztodt, phys_tend, pbuf2d,  cam_out, &
 !$OMP PARALLEL DO PRIVATE (C, irtc_rate, beg_count, NCOL, phys_buffer_chunk, end_count, chunk_cost)
     do c=begchunk,endchunk
 
-!$OMP critical(sys_irtc)
        beg_count = shr_sys_irtc(irtc_rate)
-!$OMP end critical(sys_irtc)
 
        ncol = get_ncols_p(c)
        phys_buffer_chunk => pbuf_get_chunk(pbuf2d, c)
@@ -1285,9 +1275,7 @@ subroutine phys_run2(phys_state, ztodt, phys_tend, pbuf2d,  cam_out, &
             phys_state(c), phys_tend(c), phys_buffer_chunk,&
             fsds(1,c))
 
-!$OMP critical(sys_irtc)
        end_count = shr_sys_irtc(irtc_rate)
-!$OMP end critical(sys_irtc)
        chunk_cost = real( (end_count-beg_count), r8)/real(irtc_rate, r8)
        call update_cost_p(c, chunk_cost)
 

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1030,10 +1030,10 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
        call t_startf ('bc_physics')
        !call t_adj_detailf(+1)
 
-!$OMP PARALLEL DO PRIVATE (C, irtc_rate, beg_count, phys_buffer_chunk, end_count, chunk_cost)
+!$OMP PARALLEL DO PRIVATE (C, beg_count, phys_buffer_chunk, irtc_rate, end_count, chunk_cost)
        do c=begchunk, endchunk
 
-          beg_count = shr_sys_irtc(irtc_rate)
+          beg_count = shr_sys_irtc()
 
           !
           ! Output physics terms to IC file
@@ -1122,10 +1122,10 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
        first_exec_of_phys_run1_adiabatic_or_ideal  = .FALSE.
     endif
 
-!$OMP PARALLEL DO PRIVATE (C, irtc_rate, beg_count, FLX_HEAT, end_count, chunk_cost)
+!$OMP PARALLEL DO PRIVATE (C, beg_count, FLX_HEAT, irtc_rate, end_count, chunk_cost)
     do c=begchunk, endchunk
 
-       beg_count = shr_sys_irtc(irtc_rate)
+       beg_count = shr_sys_irtc()
 
        ! Initialize the physics tendencies to zero.
        call physics_tend_init(phys_tend(c))
@@ -1247,10 +1247,10 @@ subroutine phys_run2(phys_state, ztodt, phys_tend, pbuf2d,  cam_out, &
        call ieflx_gmean(phys_state, phys_tend, pbuf2d, cam_in, cam_out, nstep)
     end if
 
-!$OMP PARALLEL DO PRIVATE (C, irtc_rate, beg_count, NCOL, phys_buffer_chunk, end_count, chunk_cost)
+!$OMP PARALLEL DO PRIVATE (C, beg_count, NCOL, phys_buffer_chunk, irtc_rate, end_count, chunk_cost)
     do c=begchunk,endchunk
 
-       beg_count = shr_sys_irtc(irtc_rate)
+       beg_count = shr_sys_irtc()
 
        ncol = get_ncols_p(c)
        phys_buffer_chunk => pbuf_get_chunk(pbuf2d, c)


### PR DESCRIPTION
a) Modify chunk cost calculation logic to make it thread safe.

Errors occur in the logic calculating the cost per chunk when threading
over the chunk loops in physpkg.F90, confirmed on both Cori-KNL and
Compy. This error is only obvious when the user_nl_cam option

     phys_chnk_cost_write = .true.

is set, but it is occurring in every threaded run (just not causing
any other problems, that we are aware of).

There are two sources of the error (both of which must be corrected to
eliminate the problem). First, the CIME utility routine shr_sys_irtc,
used to capture the wallclock time, is not thread safe. Second, a
parameter in the shr_sys_irtc call is set within the function and
so needs to be added to the list of PRIVATE variables for each of the
3 relevant OpenMP parallelized loops.

To make shr_sys_irtc thread safe for this use case requires only
adding a threadprivate declaration for two local save variables. As
this does not make shr_sys_irtc thread safe in all possible scenarios,
a comment is added describing use cases for which the routine is
thread safe, and use cases for which it is not. These modifications
are part of this PR, so as to eliminate what was heretofore
unrecognized failure case.

shr_sys_irtc uses the fortran command system_clock in its
implementation. Upon examining the context of the use of shr_sys_irtc
to calculate the chunk cost, it was decided that it was just as
convenient to use system_clock directly, declaring a few additional
variables and including them in the list of PRIVATE variables for the
associated OpenMP parallelized loops. This also eliminates any
ambiguity about thread safety.

b) Add atmospheric physics decomposition diagnostics

In recent investigations into the performance impact on atmospheric
physics of changing the PCOLS setting, it was determined that output
of some physics decomposition specifics was very useful, i.e.,

     - the total number of mesh columns used in the atmospheric physics (physics columns),
     - the total number of chunks,
     - the number of processes active during the physics (same as ATM processes currently)
     - the minimum and maximum number of threads available per physics processes,
     - the minimum and maximum number of physics columns per chunk,
     - the minimum and maximum number of chunks per physics process, and
     - the minimum and maximum number of physics columns per process.

As optimizing over PCOLS will likely become more common in the future,
this output is added at the end of phys_grid_init. The format of the
immediately preceding phys_grid_init output is also modified, to be
consistent with the new output (and to be easier to read).

Fixes #3395
Fixes #3401

[BFB]
