### PR TITLE
Fix vertical remap algorithm 10 in homme, PPM with linextrap boundaries.

### DIFF
--- a/components/homme/src/share/vertremap_base.F90
+++ b/components/homme/src/share/vertremap_base.F90
@@ -622,8 +622,8 @@ subroutine remap_Q_ppm(Qdp,nx,qsize,dp1,dp2)
               endif
             enddo
          elseif (vert_remap_q_alg == 10) then
-            ext(1) = minval(ao)
-            ext(2) = maxval(ao)
+            ext(1) = minval(ao(1:nlev))
+            ext(2) = maxval(ao(1:nlev))
             call linextrap(dpo(2), dpo(1), dpo(0), dpo(-1), ao(2), ao(1), ao(0), ao(-1), ext(1), ext(2))
             call linextrap(dpo(nlev-1), dpo(nlev), dpo(nlev+1), dpo(nlev+2),&
                  ao(nlev-1), ao(nlev), ao(nlev+1), ao(nlev+2), ext(1), ext(2))


### PR DESCRIPTION
Previously, minval and maxval were over all entries of ao, but they should be
over `ao(1:nlev)`.

[non-BFB] for 2 standalone Homme tests and SMS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.sandiatoss3_intel.cam-thetahy_sl_pg2