### PR TITLE
Upgrade the software stack for anlworkstation

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -711,31 +711,28 @@
         <command name="add">+cmake-3.12.4</command>
       </modules>
       <modules compiler="gnu">
-        <command name="add">+gcc-6.2.0</command>
-        <command name="add">+szip-2.1-gcc-6.2.0</command>
-      </modules>
-      <modules compiler="gnu" mpilib="mpi-serial">
-        <command name="add">+netcdf-4.4.1c-4.2cxx-4.4.4f-serial-gcc6.2.0</command>
-      </modules>
-      <modules compiler="gnu" mpilib="!mpi-serial">
-        <command name="add">+mpich-3.2-gcc-6.2.0</command>
-        <command name="add">+hdf5-1.8.16-gcc-6.2.0-mpich-3.2-parallel</command>
-        <command name="add">+netcdf-4.4.1c-4.2cxx-4.4.4f-parallel-gcc6.2.0-mpich-3.2</command>
+        <command name="add">+gcc-8.2.0</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-    <environment_variables>
-      <env name="NETCDF_PATH">$SHELL{dirname $(dirname $(which ncdump))}</env>
-    </environment_variables>
     <environment_variables mpilib="mpi-serial">
-      <!-- We currently don't have a soft env for serial hdf5 -->
-      <env name="LD_LIBRARY_PATH">/soft/apps/packages/climate/hdf5/1.8.16-serial/gcc-6.2.0/lib:$ENV{LD_LIBRARY_PATH}</env>
+      <!-- We currently don't have a soft env for serial hdf5 and szip built with gcc 8.2.0 -->
+      <env name="LD_LIBRARY_PATH">/soft/apps/packages/climate/hdf5/1.8.16-serial/gcc-8.2.0/lib:/soft/apps/packages/climate/szip/2.1/gcc-8.2.0/lib:$ENV{LD_LIBRARY_PATH}</env>
+      <!-- We currently don't have a soft env for netcdf serial built with gcc 8.2.0 -->
+      <env name="NETCDF_PATH">/soft/apps/packages/climate/netcdf/4.4.1c-4.2cxx-4.4.4f-serial/gcc-8.2.0</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
-      <env name="HDF5_PATH">$SHELL{dirname $(dirname $(which h5dump))}</env>
-      <!-- We currently don't have a soft env for pnetcdf 1.8.1 -->
-      <env name="PNETCDF_PATH">/soft/apps/packages/climate/pnetcdf/1.8.1/gcc-6.2.0</env>
+      <!-- We currently don't have a soft env for parallel hdf5 and szip built with gcc 8.2.0 -->
+      <env name="LD_LIBRARY_PATH">/soft/apps/packages/climate/hdf5/1.8.16-parallel/mpich-3.3.2/gcc-8.2.0/lib:/soft/apps/packages/climate/szip/2.1/gcc-8.2.0/lib:$ENV{LD_LIBRARY_PATH}</env>
+      <!-- We currently don't have a soft env for mpich 3.3.2 built with gcc 8.2.0 -->
+      <env name="PATH">/soft/apps/packages/climate/mpich/3.3.2/gcc-8.2.0/bin:$ENV{PATH}</env>
+      <!-- We currently don't have a soft env for parallel hdf5 built with mpich 3.3.2 and gcc 8.2.0 -->
+      <env name="HDF5_PATH">/soft/apps/packages/climate/hdf5/1.8.16-parallel/mpich-3.3.2/gcc-8.2.0</env>
+      <!-- We currently don't have a soft env for netcdf parallel built with mpich 3.3.2 and gcc 8.2.0 -->
+      <env name="NETCDF_PATH">/soft/apps/packages/climate/netcdf/4.4.1c-4.2cxx-4.4.4f-parallel/mpich-3.3.2/gcc-8.2.0</env>
+      <!-- We currently don't have a soft env for pnetcdf built with mpich 3.3.2 and gcc 8.2.0 -->
+      <env name="PNETCDF_PATH">/soft/apps/packages/climate/pnetcdf/1.12.0/mpich-3.3.2/gcc-8.2.0</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">64M</env>

--- a/components/homme/cmake/machineFiles/anlworkstation.cmake
+++ b/components/homme/cmake/machineFiles/anlworkstation.cmake
@@ -8,9 +8,9 @@ SET (CMAKE_CXX_COMPILER mpicxx CACHE FILEPATH "")
 #SET (FORCE_Fortran_FLAGS "-WF,-C!" CACHE STRING "")
 SET (ENABLE_OPENMP TRUE CACHE BOOL "")
 
-SET (PNETCDF_DIR /soft/apps/packages/climate/pnetcdf/1.8.1/gcc-6.2.0 CACHE FILEPATH "")
-SET (NETCDF_DIR /soft/apps/packages/climate/netcdf/4.4.1c-4.2cxx-4.4.4f-parallel/gcc-6.2.0 CACHE FILEPATH "")
-SET (ENV{HDF5} /soft/apps/packages/climate/hdf5/1.8.16-parallel/gcc-6.2.0 CACHE FILEPATH "")
+SET (PNETCDF_DIR /soft/apps/packages/climate/pnetcdf/1.12.0/mpich-3.3.2/gcc-8.2.0 CACHE FILEPATH "")
+SET (NETCDF_DIR /soft/apps/packages/climate/netcdf/4.4.1c-4.2cxx-4.4.4f-parallel/mpich-3.3.2/gcc-8.2.0 CACHE FILEPATH "")
+SET (ENV{HDF5} /soft/apps/packages/climate/hdf5/1.8.16-parallel/mpich-3.3.2/gcc-8.2.0 CACHE FILEPATH "")
 #SET (ENV{LIBZ} /soft/libraries/alcf/current/xl/ZLIB CACHE FILEPATH "")
 SET (CPRNC_DIR /home/climate1/acme/cprnc/build/cprnc CACHE FILEPATH "")
 
@@ -19,7 +19,7 @@ SET (USE_MPIEXEC mpiexec CACHE FILEPATH "")
 
 SET (HOMME_FIND_BLASLAPACK TRUE CACHE BOOL "")
 #SET (ENV{PATH} "/soft/libraries/alcf/current/xl/BLAS/lib:/soft/libraries/alcf/current/xl/LAPACK/lib:$ENV{PATH}")
-SET (ENV{PATH} "/soft/apps/packages/climate/netcdf/4.4.1c-4.2cxx-4.4.4f-parallel:$ENV{PATH}")
-SET (ENV{LD_LIBRARY_PATH} "/soft/apps/packages/climate/hdf5/1.8.16-serial/gcc-6.2.0/lib:$ENV{LD_LIBRARY_PATH}")
+SET (ENV{PATH} "/soft/apps/packages/climate/netcdf/4.4.1c-4.2cxx-4.4.4f-parallel/mpich-3.3.2:$ENV{PATH}")
+SET (ENV{LD_LIBRARY_PATH} "/soft/apps/packages/climate/hdf5/1.8.16-serial/gcc-8.2.0/lib:$ENV{LD_LIBRARY_PATH}")
 
 SET (BUILD_HOMME_SWEQX FALSE CACHE BOOL "")


### PR DESCRIPTION
This PR upgrades some modules used by anlworkstation.

gcc is upgraded to 8.2.0 (from 6.2.0) via softenv.

mpich/szip/hdf5/netcdf/pnetcdf are built with gcc 8.2.0 (parallel
libs are built with mpich 3.3.2). Currently, these new modules are
not supported yet in softenv.

mpich is upgraded to 3.3.2 (from 3.2).

pnetcdf is upgraded to 1.12.0 (from 1.8.1).

[BFB]