### PR TITLE
Fixing CFL-related crash in long ne4 F compset runs

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1497,7 +1497,7 @@
 <nu_div> -1.0 </nu_div>
 
 <!-- theta-l dycore uses nu_div=-1, except for historical ne4 test cases -->
-<nu_div hgrid="ne4np4" >  5.0e17 </nu_div>
+<nu_div hgrid="ne4np4" >  1.25e18 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne11np4" >  5.0e16 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne16np4" > 15.5e15 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne30np4" >  2.5e15 </nu_div>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1497,7 +1497,7 @@
 <nu_div> -1.0 </nu_div>
 
 <!-- theta-l dycore uses nu_div=-1, except for historical ne4 test cases -->
-<nu_div hgrid="ne4np4" >  1.25e18 </nu_div>
+<nu_div hgrid="ne4np4" >  5.0e17 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne11np4" >  5.0e16 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne16np4" > 15.5e15 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne30np4" >  2.5e15 </nu_div>
@@ -1565,11 +1565,11 @@
 
 <qsplit dyn_target="preqx">  1 </qsplit>
 
-<rsplit dyn_target="preqx" hgrid="ne4np4" >   2 </rsplit>
+<rsplit dyn_target="preqx" hgrid="ne4np4" >   1 </rsplit>
 <rsplit dyn_target="preqx" hgrid="ne11np4" >  2 </rsplit>
 <rsplit dyn_target="preqx">  3 </rsplit>
 
-<se_nsplit dyn_target="preqx" hgrid="ne4np4" >   2 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne4np4" >   4 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne11np4" >  4 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne16np4" >  1 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne30np4" >  2 </se_nsplit>


### PR DESCRIPTION
Reducing remap dt. This ran for 10 years.

Fixes #3430 .

[nonbfb] for most of ne4 tests.