### PR TITLE
cam: fix bug in bld/configure

### DIFF
--- a/components/cam/bld/config_files/definition.xml
+++ b/components/cam/bld/config_files/definition.xml
@@ -13,6 +13,9 @@ Directory where CAM executable will be created.
 <entry id="cam_root" value="">
 Root directory of CAM source distribution.
 </entry>
+<entry id="caseroot" value="">
+Root directory of the case.
+</entry>
 <entry id="usr_src" value="" list="1">
 User source directories to prepend to the filepath.  Multiple directories
 are specified as a comma separated list with no embedded white space.

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -309,6 +309,7 @@ GetOptions(
     "cam_bld=s"                 => \$opts{'cam_bld'},
     "cam_exe=s"                 => \$opts{'cam_exe'},
     "cam_exedir=s"              => \$opts{'cam_exedir'},
+    "caseroot=s"                => \$opts{'caseroot'},
     "e3smreplay"                => \$opts{'e3smreplay'},
     "cc=s"                      => \$opts{'cc'},
     "ccsm_seq"                  => \$opts{'ccsm_seq'},
@@ -609,6 +610,10 @@ EOF
     }
 
     if ($print>=2) { print "CAM executable will be created in: $cam_exedir$eol"; }
+}
+
+if (defined $opts{'caseroot'}) {
+    $cfg_ref->set('caseroot', $opts{'caseroot'})
 }
 
 #-----------------------------------------------------------------------------------------------
@@ -2231,6 +2236,7 @@ if ($print>=2) { print "CPP definitions set by configure: \'$cfg_cppdefs\'$eol";
 
 #-----------------------------------------------------------------------------------------------
 # COSP library.
+# JGF: We can get rid of this stuff once the legacy build system is removed
 if ($cosp) {
 
     # Set the directory used to build cosp.  Add location and library name
@@ -2502,6 +2508,7 @@ sub write_filepath
     my $lnd           = $cfg_ref->get('lnd');
     my $ice           = $cfg_ref->get('ice');
     my $rof           = $cfg_ref->get('rof');
+    my $caseroot      = $cfg_ref->get('caseroot');
 
     # Root directory
     my $camsrcdir = "$cam_root/components";
@@ -2523,8 +2530,7 @@ sub write_filepath
 
     # CESM has a standard source mods location.
     if ($ccsm_seq) {
-	my $CASEROOT = "$ENV{'CASEROOT'}";
-	print $fh "$CASEROOT/SourceMods/src.cam\n";
+	print $fh "$caseroot/SourceMods/src.cam\n";
     }
 
     # offline unit driver (defaults to stub)

--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -104,7 +104,9 @@ def buildnml(case, caseroot, compname):
         os_opt = "-target_os bgq" if os_ == 'bgq' else ""
 
         # TODO: cam/bld/configure needs to be converted to python
-        run_cmd_no_fail("{} -s -ccsm_seq -ice none -ocn {} -comp_intf {} {} -spmd {} -smp {} -dyn {} -dyn_target {} -res {} {} {} {} {}".format(os.path.join(srcroot, "components/cam/bld/configure"), ocn, comp, scm, spmd, smp, cam_dycore, cam_target, atm_grid, nlev, cam_lib_dirs, cam_config_opts, os_opt), from_dir=camconf_dir)
+        config_cmd = "{} -s -ccsm_seq -ice none -ocn {} -caseroot {} -comp_intf {} {} -spmd {} -smp {} -dyn {} -dyn_target {} -res {} {} {} {} {}".\
+            format(os.path.join(srcroot, "components/cam/bld/configure"), ocn, caseroot, comp, scm, spmd, smp, cam_dycore, cam_target, atm_grid, nlev, cam_lib_dirs, cam_config_opts, os_opt)
+        run_cmd_no_fail(config_cmd, from_dir=camconf_dir)
 
     else:
 

--- a/components/cmake/build_model.cmake
+++ b/components/cmake/build_model.cmake
@@ -55,7 +55,7 @@ function(build_model COMP_CLASS COMP_NAME)
     # their compilation.
     set(NOOPT_FILES "cam/src/physics/rrtmg/ext/rrtmg_lw/rrtmg_lw_k_g.f90;cam/src/physics/rrtmg/ext/rrtmg_sw/rrtmg_sw_k_g.f90")
 
-    if (COSP_LIBDIR)
+    if (USE_COSP)
       include(${PROJECT_SOURCE_DIR}/cam/src/physics/cosp/Cosp.cmake)
     endif()
 

--- a/components/cmake/common_setup.cmake
+++ b/components/cmake/common_setup.cmake
@@ -353,7 +353,7 @@ list(APPEND INCLDIR "${INSTALL_SHAREDPATH}/include")
 string(FIND "${CAM_CONFIG_OPTS}" "-cosp" HAS_COSP)
 if (NOT HAS_COSP EQUAL -1)
   # The following is for the COSP simulator code:
-  get_filename_component(COSP_LIBDIR ${EXEROOT}/atm/obj/cam/src/physics/cosp ABSOLUTE)
+  set(USE_COSP TRUE)
 endif()
 
 # System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)


### PR DESCRIPTION
Get caseroot via cli argument instead of from environment.

Also a minor cleanup of cmake handling of cosp lib.

[BFB]