### PR TITLE
Disable calls to shr_taskmap_write when INFO_TASKMAP_COMP is zero

### DIFF
--- a/components/clm/src/cpl/lnd_comp_mct.F90
+++ b/components/clm/src/cpl/lnd_comp_mct.F90
@@ -85,7 +85,6 @@ contains
     integer  :: dtime_sync                           ! coupling time-step from the input synchronization clock
     integer  :: dtime_clm                            ! clm time-step
     logical  :: exists                               ! true if file exists
-    logical  :: no_taskmap_output                    ! true then do not write out task-to-node mapping
     logical  :: verbose_taskmap_output               ! true then use verbose task-to-node mapping format
     logical  :: atm_aero                             ! Flag if aerosol data sent from atm model
     logical  :: atm_present                          ! Flag if atmosphere model present
@@ -164,8 +163,6 @@ contains
 
     if (info_taskmap_comp > 0) then
 
-       no_taskmap_output = .false.
-
        if (info_taskmap_comp == 1) then
           verbose_taskmap_output = .false.
        else
@@ -182,19 +179,13 @@ contains
           call shr_sys_flush(iulog)
        endif
 
-    else
-
-       no_taskmap_output = .true.
-       verbose_taskmap_output = .false.
+       call t_startf("shr_taskmap_write")
+       call shr_taskmap_write(iulog, mpicom_lnd,                    &
+                              'LND #'//trim(adjustl(c_inst_index)), &
+                              verbose=verbose_taskmap_output        )
+       call t_stopf("shr_taskmap_write")
 
     endif
-
-    call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(iulog, mpicom_lnd,                    &
-                           'LND #'//trim(adjustl(c_inst_index)), &
-                           verbose=verbose_taskmap_output,       &
-                           no_output=no_taskmap_output           )
-    call t_stopf("shr_taskmap_write")
 
     ! Use infodata to set orbital values
 

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -103,7 +103,6 @@ contains
     integer :: lsize                                 ! size of attribute vector
     integer :: g,i,j,n                               ! indices
     logical :: exists                                ! true if file exists
-    logical :: no_taskmap_output                     ! true then do not write out task-to-node mapping
     logical :: verbose_taskmap_output                ! true then use verbose task-to-node mapping format
     integer :: nsrest                                ! restart type
     integer :: ref_ymd                               ! reference date (YYYYMMDD)
@@ -179,8 +178,6 @@ contains
 
     if (info_taskmap_comp > 0) then
 
-       no_taskmap_output = .false.
-
        if (info_taskmap_comp == 1) then
           verbose_taskmap_output = .false.
        else
@@ -197,19 +194,13 @@ contains
           call shr_sys_flush(iulog)
        endif
 
-    else
-
-       no_taskmap_output = .true.
-       verbose_taskmap_output = .false.
+       call t_startf("shr_taskmap_write")
+       call shr_taskmap_write(iulog, mpicom_rof,                    &
+                              'ROF #'//trim(adjustl(c_inst_index)), &
+                              verbose=verbose_taskmap_output        )
+       call t_stopf("shr_taskmap_write")
 
     endif
-
-    call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(iulog, mpicom_rof,                    &
-                           'ROF #'//trim(adjustl(c_inst_index)), &
-                           verbose=verbose_taskmap_output,       &
-                           no_output=no_taskmap_output           )
-    call t_stopf("shr_taskmap_write")
 
     ! Initialize mosart
     call seq_timemgr_EClockGetData(EClock,                               &

--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -153,7 +153,6 @@ contains
                                       averagePool
 
     logical :: exists
-    logical :: no_taskmap_output                     ! true then do not write out task-to-node mapping
     logical :: verbose_taskmap_output                ! true then use verbose task-to-node mapping format
 
     character(kind=c_char), dimension(StrKIND+1) :: c_filename       ! StrKIND+1 for C null-termination character
@@ -296,8 +295,6 @@ contains
 
     if (info_taskmap_comp > 0) then
 
-       no_taskmap_output = .false.
-
        if (info_taskmap_comp == 1) then
           verbose_taskmap_output = .false.
        else
@@ -315,19 +312,13 @@ contains
           call shr_sys_flush(glcLogUnit)
        endif
 
-    else
-
-       no_taskmap_output = .true.
-       verbose_taskmap_output = .false.
+       call t_startf("shr_taskmap_write")
+       call shr_taskmap_write(glcLogUnit, mpicom_g,                 &
+                              'GLC #'//trim(adjustl(c_inst_index)), &
+                              verbose=verbose_taskmap_output        )
+       call t_stopf("shr_taskmap_write")
 
     endif
-
-    call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(glcLogUnit, mpicom_g,                 &
-                           'GLC #'//trim(adjustl(c_inst_index)), &
-                           verbose=verbose_taskmap_output,       &
-                           no_output=no_taskmap_output           )
-    call t_stopf("shr_taskmap_write")
 
     ! Setup function pointers for MALI core and domain types
     call li_setup_core(corelist)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -164,7 +164,6 @@ contains
                                       averagePool, scratchPool
 
     logical :: exists
-    logical :: no_taskmap_output                     ! true then do not write out task-to-node mapping
     logical :: verbose_taskmap_output                ! true then use verbose task-to-node mapping format
 
     character(kind=c_char), dimension(StrKIND+1) :: c_filename       ! StrKIND+1 for C null-termination character
@@ -329,8 +328,6 @@ contains
 
     if (info_taskmap_comp > 0) then
 
-       no_taskmap_output = .false.
-
        if (info_taskmap_comp == 1) then
           verbose_taskmap_output = .false.
        else
@@ -348,19 +345,13 @@ contains
           call shr_sys_flush(ocnLogUnit)
        endif
 
-    else
-
-       no_taskmap_output = .true.
-       verbose_taskmap_output = .false.
+       call t_startf("shr_taskmap_write")
+       call shr_taskmap_write(ocnLogUnit, mpicom_o,                 &
+                              'OCN #'//trim(adjustl(c_inst_index)), &
+                              verbose=verbose_taskmap_output        )
+       call t_stopf("shr_taskmap_write")
 
     endif
-
-    call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(ocnLogUnit, mpicom_o,                 &
-                           'OCN #'//trim(adjustl(c_inst_index)), &
-                           verbose=verbose_taskmap_output,       &
-                           no_output=no_taskmap_output           )
-    call t_stopf("shr_taskmap_write")
 
     ! Setup function pointers for MPASO core and domain types
     call ocn_setup_core(corelist)

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -163,7 +163,6 @@ contains
     type (MPAS_Pool_Type), pointer :: shortwave
 
     logical :: exists
-    logical :: no_taskmap_output                     ! true then do not write out task-to-node mapping
     logical :: verbose_taskmap_output                ! true then use verbose task-to-node mapping format
 
     character(kind=c_char), dimension(StrKIND+1) :: c_filename       ! StrKIND+1 for C null-termination character
@@ -310,8 +309,6 @@ contains
 
     if (info_taskmap_comp > 0) then
 
-       no_taskmap_output = .false.
-
        if (info_taskmap_comp == 1) then
           verbose_taskmap_output = .false.
        else
@@ -329,19 +326,13 @@ contains
           call shr_sys_flush(iceLogUnit)
        endif
 
-    else
-
-       no_taskmap_output = .true.
-       verbose_taskmap_output = .false.
+       call t_startf("shr_taskmap_write")
+       call shr_taskmap_write(iceLogUnit, mpicom_i,                 &
+                              'ICE #'//trim(adjustl(c_inst_index)), &
+                              verbose=verbose_taskmap_output        )
+       call t_stopf("shr_taskmap_write")
 
     endif
-
-    call t_startf("shr_taskmap_write")
-    call shr_taskmap_write(iceLogUnit, mpicom_i,                 &
-                           'ICE #'//trim(adjustl(c_inst_index)), &
-                           verbose=verbose_taskmap_output,       &
-                           no_output=no_taskmap_output           )
-    call t_stopf("shr_taskmap_write")
 
     ! Setup function pointers for MPASSI core and domain types
     call seaice_setup_core(corelist)


### PR DESCRIPTION
If INFO_TASKMAP_COMP in env_run.xml is zero (the default), then the mapping
of MPI tasks to cores is not output, but it is still calculated, for
CAM, CLM, Mosart, MPAS-ALBANY-LANDICE, MPAS-OCEAN, and MPAS-SEAICE. For
large task counts, this can be expensive, and it is not necessary for
any of these components except for CAM.  For example, these unnecessary calls to
shr_taskmap_write add approximately one minute to the cost of initialization for a high
resolution A_WCYCL case using 64000 processes for each component (except CAM)
on Cori-KNL (approximately 15 seconds for each unnecessary call: CLM, Mosart, 
MPAS-OCEAN, MPAS-SEAICE). Here this is addressed, and
shr_taskmap_write is no longer called when INFO_TASKMAP_COMP is zero
for any of the above mentioned component models except for CAM. 

Fixes #3438 

[BFB]
