### PR TITLE
Update two-way irrigation scheme to fit tri-grid configuration

### DIFF
--- a/cime/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/cime/src/drivers/mct/shr/seq_flds_mod.F90
@@ -2117,6 +2117,14 @@ contains
        units    = 'kg m-2 s-1'
        attname  = 'Flrr_supply'
        call metadata_set(attname, longname, stdname, units)
+	   
+       call seq_flds_add(r2x_fluxes,'Flrr_deficit')
+       call seq_flds_add(x2l_fluxes,'Flrr_deficit')
+       longname = 'River model supply deficit'
+       stdname  = 'rtm_deficit'
+       units    = 'kg m-2 s-1'
+       attname  = 'Flrr_deficit'
+       call metadata_set(attname, longname, stdname, units)
     endif
     !-----------------------------
     ! wav->ocn and ocn->wav

--- a/cime/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/cime/src/drivers/mct/shr/seq_flds_mod.F90
@@ -2117,7 +2117,9 @@ contains
        units    = 'kg m-2 s-1'
        attname  = 'Flrr_supply'
        call metadata_set(attname, longname, stdname, units)
-	   
+    endif
+    
+	if (trim(cime_model) == 'e3sm') then   
        call seq_flds_add(r2x_fluxes,'Flrr_deficit')
        call seq_flds_add(x2l_fluxes,'Flrr_deficit')
        longname = 'River model supply deficit'

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -44,6 +44,12 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- twowayirrigation default -->
 <tw_irr>.false.</tw_irr>
 
+<!-- extra gw pumping for irrigation default -->
+<extra_gw_irr>.false.</extra_gw_irr>
+
+<!-- firrig from surface data default -->
+<firrig_data>.false.</firrig_data>
+
 <!-- Supplmental Nitrogen mode -->
 <suplnitro use_cn=".true." >NONE</suplnitro>
 <suplnitro use_fates=".true." >NONE</suplnitro>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -196,6 +196,18 @@ If TRUE, irrigation will be two-way coupled with MOSART.
 irrigation supply will be constrained by surface water availability from MOSART
 </entry>
 
+<entry id="extra_gw_irr" type="logical" category="clm_physics"
+       group="clm_inparm"  >
+Only effective when tw_irr is TRUE. If TRUE, extra groundwater pumping will be performed to meet the irrigation demand.
+surface water irrigation supply will still be constrained by surface water availability from MOSART
+</entry>
+
+<entry id="firrig_data" type="logical" category="clm_physics"
+       group="clm_inparm"  >
+If TRUE, Firrig, Fsurf, and Fgrnd will be read from the ELM surface data.
+If False, use constant values.
+</entry>
+
 <entry id="maxpatch_glcmec" type="integer"  category="clm_physics"
        group="clm_inparm" valid_values="0,1,3,5,10,36" >
 Number of  multiple elevation classes over glacier points.

--- a/components/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
+++ b/components/clm/bld/test_build_namelist/t/input/namelist_definition_clm4_5_test.xml
@@ -97,6 +97,18 @@ If TRUE, irrigation will be two-way coupled with MOSART.
 irrigation supply will be constrained by surface water availability from MOSART
 </entry>
 
+<entry id="extra_gw_irr" type="logical" category="clm_physics"
+       group="clm_inparm"  >
+Only effective when tw_irr is TRUE. If TRUE, extra groundwater pumping will be performed to meet the irrigation demand.
+surface water irrigation supply will still be constrained by surface water availability from MOSART
+</entry>
+
+<entry id="firrig_data" type="logical" category="clm_physics"
+       group="clm_inparm"  >
+If TRUE, Firrig, Fsurf, and Fgrnd will be read from the ELM surface data.
+If False, use constant values.
+</entry>
+
 <entry id="maxpatch_glcmec" type="integer"  category="clm_physics"
        group="clm_inparm" valid_values="0,1,3,5,10,36" >
 Number of  multiple elevation classes over glacier points.

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -9,7 +9,7 @@ module BalanceCheckMod
   use shr_log_mod        , only : errMsg => shr_log_errMsg
   use decompMod          , only : bounds_type
   use abortutils         , only : endrun
-  use clm_varctl         , only : iulog, use_var_soil_thick, tw_irr
+  use clm_varctl         , only : iulog, use_var_soil_thick
   use clm_varcon         , only : namep, namec
   use GetGlobalValuesMod , only : GetGlobalIndex
   use atm2lndType        , only : atm2lnd_type

--- a/components/clm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/clm/src/biogeophys/CanopyFluxesMod.F90
@@ -151,7 +151,7 @@ contains
     integer , parameter :: itmin = 2        ! minimum number of iteration [-]
     real(r8), parameter :: irrig_min_lai = 0.0_r8           ! Minimum LAI for irrigation
     real(r8), parameter :: irrig_btran_thresh = 0.999999_r8 ! Irrigate when btran falls below 0.999999 rather than 1 to allow for round-off error
-    integer , parameter :: irrig_start_time = isecspday/4   ! Time of day to check whether we need irrigation, seconds (0 = midnight). 
+    integer , parameter :: irrig_start_time = isecspday/4   ! (6AM) Time of day to check whether we need irrigation, seconds (0 = midnight). 
 
     ! We start applying the irrigation in the time step FOLLOWING this time, 
     ! since we won't begin irrigating until the next call to CanopyHydrology
@@ -412,6 +412,7 @@ contains
          rh_ref2m             => veg_ws%rh_ref2m            , & ! Output: [real(r8) (:)   ]  2 m height surface relative humidity (%)                              
          rhaf                 => veg_ws%rh_af               , & ! Output: [real(r8) (:)   ]  fractional humidity of canopy air [dimensionless]                     
 
+         pgwgt                => veg_pp%wtgcell              , & ! Input:  [integer  (:)   ]  pft's weight in gridcell
          n_irrig_steps_left   => veg_wf%n_irrig_steps_left   , & ! Output: [integer  (:)   ]  number of time steps for which we still need to irrigate today              
          irrig_rate           => veg_wf%irrig_rate           , & ! Output: [real(r8) (:)   ]  current irrigation rate [mm/s]                                        
          qflx_tran_veg        => veg_wf%qflx_tran_veg        , & ! Output: [real(r8) (:)   ]  vegetation transpiration (mm H2O/s) (+ = to atm)                      
@@ -453,7 +454,7 @@ contains
 
       dtime = get_step_size()
       irrig_nsteps_per_day = ((irrig_length + (dtime - 1))/dtime)  ! round up
-
+      ! irrig_nsteps_per_day = 12 !6 hrs
       ! First - set the following values over points where frac vegetation covered by snow is zero
       ! (e.g. btran, t_veg, rootr, rresis)
 
@@ -611,6 +612,7 @@ contains
             
             ! see if it's the right time of day to start irrigating:
             local_time = modulo(time + nint(grc_pp%londeg(g)/degpsec), isecspday)
+            ! local_time = time ! if not using local time
             seconds_since_irrig_start_time = modulo(local_time - irrig_start_time, isecspday)
             if (seconds_since_irrig_start_time < dtime) then
                ! it's time to start irrigating

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -255,7 +255,7 @@ contains
        dtime = get_step_size()
 
        do gg = bounds%begg,bounds%endg
-          irrigated_ppg(gg) = 0
+          irrigated_ppg(gg) = 0._r8
        end do
          
        do f = 1, num_nolakep
@@ -389,9 +389,6 @@ contains
 
              if (qflx_irrig(p) > 0._r8 .or. qflx_supply(p) > 0._r8) then	!this pft needs water or have supply             
                if  (irrigated(veg_pp%itype(p)) == 1._r8) then ! this pft is irrigated
-                 !if (irrigated_ppg(g)<1) then
-                 !   write (iulog,*) 'DEBUG irrigated_ppg(g)', irrigated_ppg(g)
-                 !endif
                qflx_surf_irrig(p) = qflx_supply(p)/irrigated_ppg(g)  ! surface water irrgation from MOSART, with time step shift                   
                qflx_grnd_irrig(p) = ldomain%f_grd(g)*qflx_irrig(p) ! groundwater irrigation based on demand in ELM, same time step
  

--- a/components/clm/src/cpl/clm_cpl_indices.F90
+++ b/components/clm/src/cpl/clm_cpl_indices.F90
@@ -238,6 +238,7 @@ contains
     index_x2l_Flrr_volr     = mct_avect_indexra(x2l,'Flrr_volr')
     index_x2l_Flrr_volrmch  = mct_avect_indexra(x2l,'Flrr_volrmch')
     index_x2l_Flrr_supply   = mct_avect_indexra(x2l,'Flrr_supply')
+    index_x2l_Flrr_deficit  = mct_avect_indexra(x2l,'Flrr_deficit')
 	
     index_x2l_Faxa_lwdn     = mct_avect_indexra(x2l,'Faxa_lwdn')
     index_x2l_Faxa_rainc    = mct_avect_indexra(x2l,'Faxa_rainc')

--- a/components/clm/src/cpl/clm_cpl_indices.F90
+++ b/components/clm/src/cpl/clm_cpl_indices.F90
@@ -108,6 +108,7 @@ module clm_cpl_indices
   integer, public ::index_x2l_Flrr_volr       ! rtm->lnd rof volr total volume
   integer, public ::index_x2l_Flrr_volrmch    ! rtm->lnd rof volr main channel volume
   integer, public ::index_x2l_Flrr_supply     ! rtm->lnd rof supply for land use
+  integer, public ::index_x2l_Flrr_deficit    ! rtm->lnd supply deficit
 
   ! In the following, index 0 is bare land, other indices are glc elevation classes
   integer, public ::index_x2l_Sg_frac(0:glc_nec_max)   = 0   ! Fraction of glacier from glc model

--- a/components/clm/src/cpl/lnd_import_export.F90
+++ b/components/clm/src/cpl/lnd_import_export.F90
@@ -188,6 +188,7 @@ contains
        atm2lnd_vars%volr_grc(g)   = x2l(index_x2l_Flrr_volr,i) * (ldomain%area(g) * 1.e6_r8)
        atm2lnd_vars%volrmch_grc(g)= x2l(index_x2l_Flrr_volrmch,i) * (ldomain%area(g) * 1.e6_r8)
        atm2lnd_vars%supply_grc(g) = x2l(index_x2l_Flrr_supply,i)
+       atm2lnd_vars%deficit_grc(g) = x2l(index_x2l_Flrr_deficit,i)
 
        ! Determine required receive fields
 

--- a/components/clm/src/main/atm2lndType.F90
+++ b/components/clm/src/main/atm2lndType.F90
@@ -112,6 +112,7 @@ module atm2lndType
      real(r8), pointer :: volr_grc                      (:)   => null() ! rof volr total volume (m3)
      real(r8), pointer :: volrmch_grc                   (:)   => null() ! rof volr main channel (m3)
      real(r8), pointer :: supply_grc                    (:)   => null() ! rof volr supply (mm/s)
+     real(r8), pointer :: deficit_grc                   (:)   => null() ! rof volr deficit (mm/s)
 	 
      ! anomaly forcing
      real(r8), pointer :: af_precip_grc                 (:)   => null() ! anomaly forcing 
@@ -266,6 +267,7 @@ contains
     allocate(this%volr_grc                      (begg:endg))        ; this%volr_grc                      (:)   = ival
     allocate(this%volrmch_grc                   (begg:endg))        ; this%volrmch_grc                   (:)   = ival
     allocate(this%supply_grc                    (begg:endg))        ; this%supply_grc                    (:)   = ival
+    allocate(this%deficit_grc                   (begg:endg))        ; this%deficit_grc                   (:)   = ival
 
     ! anomaly forcing
     allocate(this%bc_precip_grc                 (begg:endg))        ; this%bc_precip_grc                 (:)   = ival
@@ -332,6 +334,11 @@ contains
     call hist_addfld1d (fname='SUPPLY',  units='mm/s',  &
          avgflag='A', long_name='runoff supply for land use', &
          ptr_lnd=this%supply_grc)
+         
+    this%deficit_grc(begg:endg) = spval
+    call hist_addfld1d (fname='DEFICIT',  units='mm/s',  &
+         avgflag='A', long_name='runoff supply deficit', &
+         ptr_lnd=this%deficit_grc)
 
 !    this%forc_wind_grc(begg:endg) = spval
 !    call hist_addfld1d (fname='WIND', units='m/s',  &

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -130,6 +130,20 @@ module clm_varctl
 
   ! True is 2way, false is 1way
   logical, public :: tw_irr = .false.  
+  
+  !----------------------------------------------------------
+  ! Extra groundwater pumping for irrigation
+  !----------------------------------------------------------
+
+  ! True is extra pumping, false is stick with the gw fraction
+  logical, public :: extra_gw_irr = .false. 
+  
+  !----------------------------------------------------------
+  ! FIRRIG data
+  !----------------------------------------------------------
+
+  ! True is read from surface data, false is constant
+  logical, public :: firrig_data = .false. 
 
   !----------------------------------------------------------
   ! Landunit logic

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -222,7 +222,7 @@ contains
     namelist /clm_inparm/  &
          clump_pproc, wrtdia, &
          create_crop_landunit, nsegspc, co2_ppmv, override_nsrest, &
-         albice, more_vertlayers, subgridflag, irrigate, tw_irr, all_active
+         albice, more_vertlayers, subgridflag, irrigate, tw_irr, extra_gw_irr, firrig_data, all_active
     ! Urban options
 
     namelist /clm_inparm/  &
@@ -635,6 +635,8 @@ contains
     ! Irrigation
     call mpi_bcast(irrigate, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast(tw_irr, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast(extra_gw_irr, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast(firrig_data, 1, MPI_LOGICAL, 0, mpicom, ier)
 
     ! Landunit generation
     call mpi_bcast(create_crop_landunit, 1, MPI_LOGICAL, 0, mpicom, ier)

--- a/components/clm/src/main/surfrdMod.F90
+++ b/components/clm/src/main/surfrdMod.F90
@@ -12,7 +12,7 @@ module surfrdMod
   use clm_varpar      , only : nlevsoifl, numpft, numcft
   use landunit_varcon , only : numurbl
   use clm_varcon      , only : grlnd
-  use clm_varctl      , only : iulog, scmlat, scmlon, single_column, tw_irr
+  use clm_varctl      , only : iulog, scmlat, scmlon, single_column, firrig_data
   use clm_varctl      , only : create_glacier_mec_landunit
   use surfrdUtilsMod  , only : check_sums_equal_1
   use ncdio_pio       , only : file_desc_t, var_desc_t, ncd_pio_openfile, ncd_pio_closefile
@@ -548,7 +548,7 @@ contains
     !    o real % abundance PFTs (as a percent of vegetated area)
     !
     ! !USES:
-    use clm_varctl  , only : create_crop_landunit, tw_irr
+    use clm_varctl  , only : create_crop_landunit, firrig_data
     use fileutils   , only : getfil
     use domainMod   , only : domain_type, domain_init, domain_clean
     use clm_varsur  , only : wt_lunit, topo_glc_mec
@@ -655,7 +655,7 @@ contains
     call surfrd_special(begg, endg, ncid, ldomain%ns)
 	
 	! Obtain firrig and surface/grnd irrigation fraction
-    if (tw_irr) then
+    if (firrig_data) then
      call ncd_io(ncid=ncid, varname='FIRRIG', flag='read', data=ldomain%firrig, &
           dim1name=grlnd, readvar=readvar)
      if (.not. readvar) call endrun( trim(subname)//' ERROR: FIRRIG NOT on surfdata file' )!

--- a/components/mosart/src/cpl/rof_comp_esmf.F90
+++ b/components/mosart/src/cpl/rof_comp_esmf.F90
@@ -49,7 +49,8 @@ module rof_comp_esmf
                                 index_r2x_Forr_rofl, index_r2x_Forr_rofi, &
                                 index_r2x_Flrr_flood, &
                                 index_r2x_Flrr_volr, index_r2x_Flrr_volrmch, &
-                                index_r2x_Flrr_supply, index_x2r_Flrl_demand
+                                index_r2x_Flrr_supply, index_x2r_Flrl_demand, &
+                                index_r2x_Flrr_deficit
   use perf_mod         , only : t_startf, t_stopf, t_barrierf
 !
 ! !PUBLIC MEMBER FUNCTIONS:
@@ -830,6 +831,7 @@ contains
 
        if (wrmflag) then
           fptr(index_r2x_Flrr_supply,ni)  = StorWater%Supply(n) / (rtmCTL%area(n)*0.001_r8)    ! convert m3/s to mm/s
+          fptr(index_r2x_Flrr_deficit,ni)  = (abs(rtmCTL%qdem(n,nliq)) - abs(StorWater%Supply(n))) / (rtmCTL%area(n)*0.001_r8)   !send deficit back to ELM
        endif
 
     end do

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -46,7 +46,7 @@ module rof_comp_mct
                                 index_r2x_Forr_rofl, index_r2x_Forr_rofi, &
                                 index_r2x_Flrr_flood, &
                                 index_r2x_Flrr_volr, index_r2x_Flrr_volrmch, &
-                                index_r2x_Flrr_supply
+                                index_r2x_Flrr_supply, index_r2x_Flrr_deficit
 
   use mct_mod
   use ESMF
@@ -720,9 +720,11 @@ contains
        r2x_r%rattr(index_r2x_Flrr_flood,ni)   = -rtmCTL%flood(n) / (rtmCTL%area(n)*0.001_r8)
        r2x_r%rattr(index_r2x_Flrr_volr,ni)    = (Trunoff%wr(n,nliq) + Trunoff%wt(n,nliq)) / rtmCTL%area(n)
        r2x_r%rattr(index_r2x_Flrr_volrmch,ni) = Trunoff%wr(n,nliq) / rtmCTL%area(n)
-       r2x_r%rattr(index_r2x_Flrr_supply,ni)  = 0._r8 
+       r2x_r%rattr(index_r2x_Flrr_supply,ni)  = 0._r8
+       r2x_r%rattr(index_r2x_Flrr_deficit,ni)  = 0._r8
        if (wrmflag) then
-          r2x_r%rattr(index_r2x_Flrr_supply,ni)  = StorWater%Supply(n) / (rtmCTL%area(n)*0.001_r8)   !converted to mm/s (Tian)
+          r2x_r%rattr(index_r2x_Flrr_supply,ni)  = StorWater%Supply(n) / (rtmCTL%area(n)*0.001_r8)   !converted to mm/s
+          r2x_r%rattr(index_r2x_Flrr_deficit,ni)  = (abs(rtmCTL%qdem(n,nliq)) - abs(StorWater%Supply(n))) / (rtmCTL%area(n)*0.001_r8)   !send deficit back to ELM
        endif
     end do
 

--- a/components/mosart/src/cpl/rof_cpl_indices.F90
+++ b/components/mosart/src/cpl/rof_cpl_indices.F90
@@ -41,7 +41,6 @@ module rof_cpl_indices
   integer, public :: index_x2r_Faxa_swvdf = 0   ! atm->rof shorwave visible diffus flux
   integer, public :: index_x2r_Faxa_swndr = 0   ! atm->rof shorwave near-ir direct flux
   integer, public :: index_x2r_Faxa_swndf = 0   ! atm->rof shorwave near-ir diffus flux
-
   integer, public :: nflds_x2r = 0
 
   !TODO - nt_rtm and rtm_tracers need to be removed and set by access to the index array
@@ -58,6 +57,7 @@ module rof_cpl_indices
   integer, public :: index_r2x_Flrr_volr = 0    ! rof->lnd volr total volume back to land
   integer, public :: index_r2x_Flrr_volrmch = 0 ! rof->lnd volr main channel back to land
   integer, public :: index_r2x_Flrr_supply = 0  ! rof->lnd supply flux for land use
+  integer, public :: index_r2x_Flrr_deficit = 0 ! rof->lnd supply deficit
   integer, public :: nflds_r2x = 0
 
 !=======================================================================
@@ -127,6 +127,7 @@ contains
     index_r2x_Flrr_volr  = mct_avect_indexra(avtmp,'Flrr_volr')
     index_r2x_Flrr_volrmch = mct_avect_indexra(avtmp,'Flrr_volrmch')
     index_r2x_Flrr_supply = mct_avect_indexra(avtmp,'Flrr_supply')
+    index_r2x_Flrr_deficit = mct_avect_indexra(avtmp,'Flrr_deficit')
     nflds_r2x = mct_avect_nRattr(avtmp)
 
     call mct_aVect_clean(avtmp)

--- a/components/mosart/src/inundation/MOSARTinund_Core_MOD.F90
+++ b/components/mosart/src/inundation/MOSARTinund_Core_MOD.F90
@@ -18,13 +18,13 @@ MODULE MOSARTinund_Core_MOD
       SMatP_upstrm, avsrc_upstrm, avdst_upstrm, SMatP_dnstrm
   use MOSARTinund_PreProcs_MOD, only: con1Em3
   use RtmVar, only: barrier_timers, iulog, inundflag
-  use RtmSpmd, only: mpicom_rof
+  use RtmSpmd, only: mpicom_rof, masterproc
   use mct_mod
   
   implicit none
   private
   
-  public MOSARTinund_simulate, ManningEq
+  public MOSARTinund_simulate, ManningEq, ChnlFPexchg
                    
   contains
   
@@ -400,7 +400,7 @@ MODULE MOSARTinund_Core_MOD
           endif      ! if ( wr + wf > wr_bf )
         
           ! Channel--floodplain exchange amount (Positive: flow from channel to floodplain; vice versa) (m^3) :
-          TRunoff%se_rf(iu) = wr_rcd - TRunoff%wr_exchg(iu)
+          TRunoff%netchange(iu) = wr_rcd - TRunoff%wr_exchg(iu)
         
         ! ---------------------------------  
         ! No channel--floodplain exchange for two situations: 
@@ -412,7 +412,7 @@ MODULE MOSARTinund_Core_MOD
           TRunoff%yr_exchg( iu ) = TRunoff%yr( iu, 1 )
           TRunoff%wf_exchg( iu ) = TRunoff%wf_ini( iu )
           TRunoff%hf_exchg( iu ) = TRunoff%hf_ini( iu )          
-          TRunoff%se_rf( iu ) = 0._r8
+          TRunoff%netchange( iu ) = 0._r8
         end if    ! if ( the channel water level is higher than the floodplain water level, or on the contrary )
       end if      ! if ( TUnit%mask( iu ) .gt. 0 )
     end do

--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -28,6 +28,7 @@ MODULE MOSART_physics_mod
                              insert_returnflow_soilcolumn, &
                              estimate_returnflow_deficit
   use WRM_subw_io_mod, only : WRM_readDemand, WRM_computeRelease
+  use MOSARTinund_Core_MOD, only: ChnlFPexchg
   use rof_cpl_indices, only : nt_rtm, rtm_tracers, nt_nliq, nt_nice
   use perf_mod, only: t_startf, t_stopf
   use mct_mod
@@ -136,7 +137,11 @@ MODULE MOSART_physics_mod
        THeat%Tt_avg = 0._r8
        THeat%Tr_avg = 0._r8
     endif
+    if (inundflag) then
+       TRunoff%se_rf = 0._r8
+    endif
     negchan = 9999.0_r8
+    !subcycling begins
     do m=1,Tctl%DLevelH2R
 
        !------------------
@@ -152,7 +157,6 @@ MODULE MOSART_physics_mod
           temp_Tt = 0._r8
           if(TUnit%mask(iunit) > 0) then
 !extraction from subnetwork here from wt
-!#ifdef INCLUDE_WRM
              if (wrmflag) then
                 if (nt == nt_nliq) then
                    if  (ctlSubwWRM%ExtractionFlag > 0 .and. TRunoff%yt(iunit,nt_nliq) >= 0.1_r8) then
@@ -162,7 +166,6 @@ MODULE MOSART_physics_mod
                    endif
                 endif
              endif
-!#endif
              localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R/TUnit%numDT_t(iunit)
              do k=1,TUnit%numDT_t(iunit)
                 call subnetworkRouting(iunit,nt,localDeltaT)
@@ -212,6 +215,25 @@ MODULE MOSART_physics_mod
        end do ! nt
        call t_stopf('mosartr_subnetwork')    
 
+        if (inundflag) then
+          ! Channel -- floodplain exchange computation :      
+          call ChnlFPexchg ( )
+            ! update variables after channel-floodplain exchanges
+            ! Floodplain water volume :
+              TRunoff%wf_ini = TRunoff%wf_exchg
+            ! Floodplain max water depth :
+              TRunoff%hf_ini = TRunoff%hf_exchg     
+            ! Floodplain area fraction (not including channel)
+              TRunoff%ff_ini = TRunoff%ff_fp
+            ! Flooded area fraction (including channel):
+              TRunoff%ffunit_ini = TRunoff%ff_unit
+            ! Channel water depth
+              TRunoff%yr(:,1) = TRunoff%yr_exchg
+            ! Channel storage
+              TRunoff%wr(:,1) = TRunoff%wr_exchg
+            ! Aggregate net floodplain storage change from subcycle to timestep 
+              TRunoff%se_rf = TRunoff%se_rf + TRunoff%netchange
+        end if
        !------------------
        ! upstream interactions
        !------------------

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -462,8 +462,9 @@ contains
     end if
 
     if (wrmflag .and. inundflag) then
-       write(iulog,*) subname,' ERROR MOSART wrmflag and inundflag cannot both be true'
-       call shr_sys_abort( subname//' ERROR: wrmflag and inundflag both set' )
+       !write(iulog,*) subname,' ERROR MOSART wrmflag and inundflag cannot both be true'
+       write(iulog,*) subname,' MOSART wrmflag and inundflag both set to be true'
+       !call shr_sys_abort( subname//' ERROR: wrmflag and inundflag both set' )
     endif
 
     if (coupling_period <= 0) then
@@ -1572,7 +1573,7 @@ contains
              TRunoff%wf_ini(:) = rtmCTL%inundwf(:)
              ! Inundation floodplain water depth (m)
              TRunoff%hf_ini(:) = rtmCTL%inundhf(:)
-             ! Inundation floodplain fraction      ! added by Tian
+             ! Inundation floodplain fraction
              TRunoff%ff_ini(:) = rtmCTL%inundff(:)
              ! Inundation flooded fraction      
              TRunoff%ffunit_ini(:) = rtmCTL%inundffunit(:)
@@ -1711,15 +1712,15 @@ contains
        endif
     else
 
-    do nt = 1,nt_rtm
-    do nr = rtmCTL%begr,rtmCTL%endr
+     do nt = 1,nt_rtm
+      do nr = rtmCTL%begr,rtmCTL%endr
        call UpdateState_hillslope(nr,nt)
        call UpdateState_subnetwork(nr,nt)
        call UpdateState_mainchannel(nr,nt)
        rtmCTL%volr(nr,nt) = (TRunoff%wt(nr,nt) + TRunoff%wr(nr,nt) + &
                              TRunoff%wh(nr,nt)*rtmCTL%area(nr))
-    enddo
-    enddo
+      enddo
+     enddo
     endif
 
     call t_stopf('mosarti_restart')
@@ -1995,7 +1996,7 @@ contains
        end if
 
        if (wrmflag) then
-          StorWater%supply = 0._r8             !initial supply at the start of Tian Feb 2018
+          StorWater%supply = 0._r8             !initial supply at the start
           nt = 1
           do nr = rtmCTL%begr,rtmCTL%endr
              budget_terms(bv_dsupp_i,nt) = budget_terms(bv_dsupp_i,nt) + StorWater%supply(nr)
@@ -2013,7 +2014,7 @@ contains
        TRunoff%qsur(nr,nt) = rtmCTL%qsur(nr,nt)
        TRunoff%qsub(nr,nt) = rtmCTL%qsub(nr,nt)
        TRunoff%qgwl(nr,nt) = rtmCTL%qgwl(nr,nt)
-       TRunoff%qdem(nr,nt) = rtmCTL%qdem(nr,nt) !added by Yuna 1/29/2018
+       TRunoff%qdem(nr,nt) = rtmCTL%qdem(nr,nt)
     enddo
     enddo
   
@@ -2213,7 +2214,7 @@ contains
        TRunoff%qsur(nr,nt) = TRunoff%qsur(nr,nt) / rtmCTL%area(nr)
        TRunoff%qsub(nr,nt) = TRunoff%qsub(nr,nt) / rtmCTL%area(nr)
        TRunoff%qgwl(nr,nt) = TRunoff%qgwl(nr,nt) / rtmCTL%area(nr)
-       TRunoff%qdem(nr,nt) = TRunoff%qdem(nr,nt) / rtmCTL%area(nr) !m3 to m added by Yuna 1/29/2018
+       TRunoff%qdem(nr,nt) = TRunoff%qdem(nr,nt) / rtmCTL%area(nr) !m3 to m
     enddo
     enddo
 
@@ -2233,11 +2234,11 @@ contains
           write(iulog,'(2a,i4,a,i10,i6)') trim(subname),' subcycling=',ns,': model date=',ymd,tod
        endif
      
-       if (inundflag) then
-          call t_startf('mosartr_inund_sim')
-          call MOSARTinund_simulate ( )
-          call t_stopf('mosartr_inund_sim')
-       else
+       !if (inundflag .and. wrmflag .eq. 0) then !use Luo's scheme when inundation is on and WM is off (keep it for now - tz)
+       !   call t_startf('mosartr_inund_sim')
+       !   call MOSARTinund_simulate ( )
+       !   call t_stopf('mosartr_inund_sim')
+       !else ! other cases
           call t_startf('mosartr_euler')
           ! debug 
 #ifdef DEBUG
@@ -2245,7 +2246,7 @@ contains
 #endif
           call Euler()
           call t_stopf('mosartr_euler')
-       endif
+       !endif
 
 ! tcraig - NOT using this now, but leave it here in case it's useful in the future
 !   for some runoff terms.
@@ -2633,8 +2634,7 @@ contains
           budget_volume =  budget_terms(bv_volt_f,nt) - budget_terms(bv_volt_i,nt) + &
                            budget_terms(bv_dstor_f,nt) - budget_terms(bv_dstor_i,nt)             ! (Volume change during a coupling period. --Inund.)
           budget_input  =  budget_terms(br_qsur,nt) + budget_terms(br_qsub,nt) + &
-                           budget_terms(br_qgwl,nt) + budget_terms(br_qdto,nt) !+ &
-                           ! budget_terms(br_qdem,nt) commented out by Tian 3/13/2018
+                           budget_terms(br_qgwl,nt) + budget_terms(br_qdto,nt)
           budget_output =  budget_terms(br_ocnout,nt) + budget_terms(br_flood,nt) + &
                            budget_terms(br_direct,nt) + &
                            budget_terms(bv_dsupp_f,nt) - budget_terms(bv_dsupp_i,nt)
@@ -2663,8 +2663,7 @@ contains
             budget_volume = (budget_global(bv_volt_f,nt) - budget_global(bv_volt_i,nt) + &
                              budget_global(bv_dstor_f,nt) - budget_global(bv_dstor_i,nt))   !(Global volume change during a coupling period. --Inund.)
             budget_input  = (budget_global(br_qsur,nt) + budget_global(br_qsub,nt) + &
-                             budget_global(br_qgwl,nt) + budget_global(br_qdto,nt)) !+ &
-                             ! budget_global(br_qdem,nt)) commented out by Tian 3/13/2018
+                             budget_global(br_qgwl,nt) + budget_global(br_qdto,nt))
             budget_output = (budget_global(br_ocnout,nt) + budget_global(br_flood,nt) + &
                              budget_global(br_direct,nt) + &
                              budget_global(bv_dsupp_f,nt) - budget_global(bv_dsupp_i,nt))
@@ -2718,7 +2717,6 @@ contains
                                                                              (budget_global(br_qsur,nt)+budget_global(br_qsub,nt)+ &
                                                                               budget_global(br_qgwl,nt)+budget_global(br_qdto,nt)), &
                      ' (should be zero)'
-                     ! + budget_global(br_qdem,nt)), commented out by Tian 3/13/2018
                                                                              
           endif
             write(iulog,'(2a)') trim(subname),'----------------'
@@ -3482,7 +3480,7 @@ contains
           allocate (TUnit%rslp_dstrm(begr:endr))
 
           ! --------------------------------- 
-          ! Need code to retrieve values of TUnit%rlen_dstrm(:) and TUnit%rslp_dstrm(:) .
+          ! retrieve downstream values (TUnit%rlen_dstrm(:) and TUnit%rslp_dstrm(:)) for DW routing.
           ! --------------------------------- 
 
           call mct_aVect_init(avsrc,rList='rlen:rslp',lsize=rtmCTL%lnumr)
@@ -3520,7 +3518,7 @@ contains
 
           allocate( TUnit%e_eprof_in2( 11, begr:endr ) )    
           ! --------------------------------- 
-          ! (assign elevation values to TUnit%e_eprof_in2( :, : ) ). Tian Apr. 2018
+          ! (assign elevation values to TUnit%e_eprof_in2( :, : ) ).
            
           ier = pio_inq_varid(ncid, name='ele0', vardesc=vardesc)
           call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%e_eprof_in2(1,:), ier)
@@ -3787,10 +3785,12 @@ contains
            TRunoff%hf_ini = 0.0_r8
            
            allocate (TRunoff%ff_ini(begr:endr))
-           TRunoff%ff_ini = 0.0_r8 ! added by Tian Dec 2017
+           TRunoff%ff_ini = 0.0_r8
 
            allocate (TRunoff%ffunit_ini(begr:endr))
            TRunoff%ffunit_ini = 0.0_r8
+           allocate (TRunoff%netchange(begr:endr))
+           TRunoff%netchange = 0.0_r8
            allocate (TRunoff%se_rf(begr:endr))
            TRunoff%se_rf = 0.0_r8
 

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -462,9 +462,7 @@ contains
     end if
 
     if (wrmflag .and. inundflag) then
-       !write(iulog,*) subname,' ERROR MOSART wrmflag and inundflag cannot both be true'
        write(iulog,*) subname,' MOSART wrmflag and inundflag both set to be true'
-       !call shr_sys_abort( subname//' ERROR: wrmflag and inundflag both set' )
     endif
 
     if (coupling_period <= 0) then
@@ -2239,14 +2237,14 @@ contains
        !   call MOSARTinund_simulate ( )
        !   call t_stopf('mosartr_inund_sim')
        !else ! other cases
-          call t_startf('mosartr_euler')
-          ! debug 
+       
+       call t_startf('mosartr_euler')
 #ifdef DEBUG
-          write(iulog,*) 'clm-mosart subT: (call Euler) ns=', ns
+       write(iulog,*) 'clm-mosart subT: (call Euler) ns=', ns
 #endif
-          call Euler()
-          call t_stopf('mosartr_euler')
-       !endif
+       call Euler()
+       call t_stopf('mosartr_euler')
+
 
 ! tcraig - NOT using this now, but leave it here in case it's useful in the future
 !   for some runoff terms.

--- a/components/mosart/src/riverroute/RunoffMod.F90
+++ b/components/mosart/src/riverroute/RunoffMod.F90
@@ -373,7 +373,8 @@ module RunoffMod
     real(r8), pointer :: ff_ini(:)      ! Floodplain water area fraction at beginning of step (dimensionless).
     real(r8), pointer :: ffunit_ini(:)      ! Flooded water area fraction at beginning of step (dimensionless).
 
-    real(r8), pointer :: se_rf(:)       ! Amount of channel--floodplain exchange (positive: flow from channel to floodplain; vice versa ) (m^3).
+    real(r8), pointer :: netchange(:)   ! Amount of channel--floodplain exchange during one subcycle in MOSART timestep (positive: flow from channel to floodplain; vice versa ) (m^3).
+    real(r8), pointer :: se_rf(:)       ! Amount of channel--floodplain exchange during one MOSART timestep(positive: flow from channel to floodplain; vice versa ) (m^3).
     real(r8), pointer :: ff_unit(:)       ! = area of inundated area (including channel area) divided by the computation-unit total area (dimensionless).
 
     real(r8), pointer :: ff_fp(:)       ! = area of inundated floodplain (not including channel area) divided by the computation-unit total area (dimensionless).

--- a/components/mosart/src/wrm/WRM_subw_IO_mod.F90
+++ b/components/mosart/src/wrm/WRM_subw_IO_mod.F90
@@ -548,8 +548,6 @@ MODULE WRM_subw_IO_mod
      StorWater%demand0=0._r8
      allocate (StorWater%supply(begr:endr))
      StorWater%supply=0._r8
-     !allocate (StorWater%SupplyFrac(begr:endr)) !supply fraction relative to the demand Tian June 2018
-     !StorWater%SupplyFrac=0._r8
      allocate (StorWater%deficit(begr:endr))
      StorWater%deficit=0._r8
      allocate (StorWater%storageG(begr:endr))
@@ -752,17 +750,6 @@ MODULE WRM_subw_IO_mod
 
         end do
 
-!NV
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Jan',minval(StorWater%pre_release(:,1)),maxval(StorWater%pre_release(:,1)) 
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Apr', minval(StorWater%pre_release(:,4)),maxval(StorWater%pre_release(:,4))
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Jul',minval(StorWater%pre_release(:,7)),maxval(StorWater%pre_release(:,7))
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Oct', minval(StorWater%pre_release(:,10)),maxval(StorWater%pre_release(:,10))
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee',StorWater%pre_release(80,1),StorWater%pre_release(80,3)
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee',StorWater%pre_release(80,5),StorWater%pre_release(80,9)
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Flow',WRMUnit%MeanMthFlow(80,13), WRMUnit%MeanMthFlow(80,8)
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Demand',WRMUnit%MeanMthFlow(80,1),WRMUnit%MeanMthFlow(80,3)
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Demand',WRMUnit%MeanMthFlow(80,5),WRMUnit%MeanMthFlow(80,7)
-          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Means Flow Demand',WRMUnit%MeanMthDemand(80,13),WRMUnit%MeanMthFlow(80,13)
            call shr_sys_flush(iulog)
 
         !--- initialize start of the operational year based on long term simulation
@@ -775,10 +762,6 @@ MODULE WRM_subw_IO_mod
 
      ! check
      write(iulog,*) subname, "Done with WM init ..."
-     !write(iulog,*) subname, WRMUnit%DamName(59), WRMUnit%Surfarea(59)
-     !write(iulog,*) subname,WRMUnit%isDam(1), WRMUnit%icell(1) 
-     !write(iulog,*) subname, WRMUnit%dam_Ndepend(1), WRMUnit%dam_depend(1,2)
-     !write(iulog,*) subname, "sub = 49",  TUnit%icell(49, 1),WRMUnit%subw_Ndepend(49),  WRMUnit%subw_depend(49,1) 
   end subroutine WRM_init
 
 !-----------------------------------------------------------------------
@@ -802,9 +785,6 @@ MODULE WRM_subw_IO_mod
      if (ctlSubwWRM%ExtractionFlag > 0) then
 
         call get_curr_date(yr, mon, day, tod)
-      !  write(iulog,'(2a,4i6)') subname,'at ',yr,mon,day,tod    
-      !  write(strYear,'(I4.4)') yr
-      !  write(strMonth,'(I2.2)') mon
         !fname = trim(ctlSubwWRM%demandPath)// strYear//'_'//strMonth//'.nc'
         fname = trim(ctlSubwWRM%demandPath)//'1980_'//strMonth//'.nc'   ! constant 1980 demand
 
@@ -842,18 +822,13 @@ MODULE WRM_subw_IO_mod
      character(len=*),parameter :: subname = '(WRM_computeRelease)'
 
      call get_curr_date(yr, mon, day, tod)
-    ! write(iulog,'(2a,4i6)') subname,'at ',yr,mon,day,tod
      do idam=1,ctlSubwWRM%localNumDam
         if ( mon .eq. WRMUnit%MthStOp(idam)) then
            WRMUnit%StorMthStOp(idam) = StorWater%storage(idam)
     end if
      enddo
      call RegulationRelease()
-    ! write(iulog,*) 'Start Coulee ',mon,day,tod,WRMUnit%MeanMthFlow(80,13)
-    ! write(iulog,*) 'start Op mon, storage ', WRMUnit%MthStOp(80),WRMUnit%StorMthStOp(80)
-    ! write(iulog,*)  'storage, release pre targets ',StorWater%storage(80), StorWater%release(80)
      call WRM_storage_targets()
-    ! write(iulog,*) 'Coulee targets ',StorWater%release(80)
 
   end subroutine WRM_computeRelease
 

--- a/components/mosart/src/wrm/WRM_subw_IO_mod.F90
+++ b/components/mosart/src/wrm/WRM_subw_IO_mod.F90
@@ -753,17 +753,16 @@ MODULE WRM_subw_IO_mod
         end do
 
 !NV
-           if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Jan',minval(StorWater%pre_release(:,1)),maxval(StorWater%pre_release(:,1)) 
-
-           if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Apr', minval(StorWater%pre_release(:,4)),maxval(StorWater%pre_release(:,4))
-           if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Jul',minval(StorWater%pre_release(:,7)),maxval(StorWater%pre_release(:,7))
-           if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Oct', minval(StorWater%pre_release(:,10)),maxval(StorWater%pre_release(:,10))
-           if (masterproc) write(iulog,FORMR) trim(subname),'Coulee',StorWater%pre_release(80,1),StorWater%pre_release(80,3)
-           if (masterproc) write(iulog,FORMR) trim(subname),'Coulee',StorWater%pre_release(80,5),StorWater%pre_release(80,9)
-           if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Flow',WRMUnit%MeanMthFlow(80,13), WRMUnit%MeanMthFlow(80,8)
-           if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Demand',WRMUnit%MeanMthFlow(80,1),WRMUnit%MeanMthFlow(80,3)
-           if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Demand',WRMUnit%MeanMthFlow(80,5),WRMUnit%MeanMthFlow(80,7)
-           if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Means Flow Demand',WRMUnit%MeanMthDemand(80,13),WRMUnit%MeanMthFlow(80,13)
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Jan',minval(StorWater%pre_release(:,1)),maxval(StorWater%pre_release(:,1)) 
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Apr', minval(StorWater%pre_release(:,4)),maxval(StorWater%pre_release(:,4))
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Jul',minval(StorWater%pre_release(:,7)),maxval(StorWater%pre_release(:,7))
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'prerelease Oct', minval(StorWater%pre_release(:,10)),maxval(StorWater%pre_release(:,10))
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee',StorWater%pre_release(80,1),StorWater%pre_release(80,3)
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee',StorWater%pre_release(80,5),StorWater%pre_release(80,9)
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Flow',WRMUnit%MeanMthFlow(80,13), WRMUnit%MeanMthFlow(80,8)
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Demand',WRMUnit%MeanMthFlow(80,1),WRMUnit%MeanMthFlow(80,3)
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Demand',WRMUnit%MeanMthFlow(80,5),WRMUnit%MeanMthFlow(80,7)
+          ! if (masterproc) write(iulog,FORMR) trim(subname),'Coulee Means Flow Demand',WRMUnit%MeanMthDemand(80,13),WRMUnit%MeanMthFlow(80,13)
            call shr_sys_flush(iulog)
 
         !--- initialize start of the operational year based on long term simulation
@@ -803,10 +802,9 @@ MODULE WRM_subw_IO_mod
      if (ctlSubwWRM%ExtractionFlag > 0) then
 
         call get_curr_date(yr, mon, day, tod)
-        write(iulog,'(2a,4i6)') subname,'at ',yr,mon,day,tod
-    
-        write(strYear,'(I4.4)') yr
-        write(strMonth,'(I2.2)') mon
+      !  write(iulog,'(2a,4i6)') subname,'at ',yr,mon,day,tod    
+      !  write(strYear,'(I4.4)') yr
+      !  write(strMonth,'(I2.2)') mon
         !fname = trim(ctlSubwWRM%demandPath)// strYear//'_'//strMonth//'.nc'
         fname = trim(ctlSubwWRM%demandPath)//'1980_'//strMonth//'.nc'   ! constant 1980 demand
 
@@ -844,18 +842,18 @@ MODULE WRM_subw_IO_mod
      character(len=*),parameter :: subname = '(WRM_computeRelease)'
 
      call get_curr_date(yr, mon, day, tod)
-     write(iulog,'(2a,4i6)') subname,'at ',yr,mon,day,tod
+    ! write(iulog,'(2a,4i6)') subname,'at ',yr,mon,day,tod
      do idam=1,ctlSubwWRM%localNumDam
         if ( mon .eq. WRMUnit%MthStOp(idam)) then
            WRMUnit%StorMthStOp(idam) = StorWater%storage(idam)
     end if
      enddo
      call RegulationRelease()
-     write(iulog,*) 'Start Coulee ',mon,day,tod,WRMUnit%MeanMthFlow(80,13)
-     write(iulog,*) 'start Op mon, storage ', WRMUnit%MthStOp(80),WRMUnit%StorMthStOp(80)
-     write(iulog,*)  'storage, release pre targets ',StorWater%storage(80), StorWater%release(80)
+    ! write(iulog,*) 'Start Coulee ',mon,day,tod,WRMUnit%MeanMthFlow(80,13)
+    ! write(iulog,*) 'start Op mon, storage ', WRMUnit%MthStOp(80),WRMUnit%StorMthStOp(80)
+    ! write(iulog,*)  'storage, release pre targets ',StorWater%storage(80), StorWater%release(80)
      call WRM_storage_targets()
-     write(iulog,*) 'Coulee targets ',StorWater%release(80)
+    ! write(iulog,*) 'Coulee targets ',StorWater%release(80)
 
   end subroutine WRM_computeRelease
 


### PR DESCRIPTION
The two-way irrigation scheme between land and river models is updated to fit the tri-grid 
configuration. The temporary water conservation solution developed for different land and river 
grid is removed. Two additional flags are added to the land model to make the irrigation scheme 
more flexible: extra_gw_irr (for extra groundwater pumping) and firrig_data (for using 
prepossessed parameter).  Also some modifications were made to couple MOSART-WM and 
MOSART-inundation.

[BFB]