### PR TITLE
Refactor RRTMGP cloud optics to remove dependence on state/pbuf

### DIFF
--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/oldoptics/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/oldoptics/user_nl_cam
@@ -1,0 +1,2 @@
+liqcldoptics = 'slingo'
+icecldoptics = 'ebertcurry'

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/rrtmgp_oldcldoptics/shell_commands
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/rrtmgp_oldcldoptics/shell_commands
@@ -1,0 +1,2 @@
+#!/bin/bash
+./xmlchange --append CAM_CONFIG_OPTS='-rad rrtmgp'

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/rrtmgp_oldcldoptics/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/rrtmgp_oldcldoptics/user_nl_cam
@@ -1,0 +1,2 @@
+liqcldoptics = 'slingo'
+icecldoptics = 'ebertcurry'

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -351,9 +351,13 @@ contains
       real(r8), intent(in), dimension(:,:) :: pmid, cld, cldfsnow
       real(r8), intent(in), dimension(:,:,:) :: tau_bnd, ssa_bnd, asm_bnd
       real(r8), intent(out), dimension(:,:,:) :: tau_gpt, ssa_gpt, asm_gpt
-      logical, dimension(ngpt,ncol,nlev) :: iscloudy
       real(r8), dimension(ncol,nlev) :: combined_cld
-      integer, parameter :: changeseed = 1  ! how many times to permute random seed
+      logical, dimension(ngpt,ncol,nlev) :: iscloudy
+
+      ! For MCICA sampling routine, how many times to permute random seed
+      integer, parameter :: changeseed = 1
+
+      ! Loop variables
       integer :: icol, ilev, igpt
 
       ! Combined snow and cloud fraction
@@ -423,10 +427,10 @@ contains
       real(r8), intent(in), dimension(:,:) :: pmid, cld, cldfsnow
       real(r8), intent(in), dimension(:,:,:) :: tau_bnd
       real(r8), intent(out), dimension(:,:,:) :: tau_gpt
-      real(r8) :: combined_cld(ncol,nlev)
-      logical :: iscloudy(ngpt,ncol,nlev)
+      real(r8), dimension(ncol,nlev) :: combined_cld
+      logical, dimension(ngpt,ncol,nlev) :: iscloudy
 
-      ! For MCICA sampling routine
+      ! For MCICA sampling routine, how many times to permute random seed
       integer, parameter :: changeseed = 1
 
       ! Loop variables

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -2,8 +2,6 @@ module cam_optics
 
    use shr_kind_mod, only: r8=>shr_kind_r8
    use assertions, only: assert, assert_valid, assert_range
-   use radiation_state, only: nlev_rad, ktop, kbot
-   use radiation_utils, only: handle_error
    use radconstants, only: nswbands, nlwbands
    use rad_constituents, only: icecldoptics, liqcldoptics
    use ebert_curry, only: ec_ice_optics_sw, ec_ice_optics_lw
@@ -35,7 +33,7 @@ contains
          lambdac, mu, dei, des, rel, rei, &
          tau_out, ssa_out, asm_out)
 
-      use ppgrid, only: pcols, pver
+      use ppgrid, only: pcols
       use physics_types, only: physics_state
       use cloud_rad_props, only: mitchell_ice_optics_sw, &
                                  gammadist_liq_optics_sw
@@ -85,7 +83,7 @@ contains
       ! Get ice cloud optics
       if (trim(icecldoptics) == 'mitchell') then
          call mitchell_ice_optics_sw( &
-            ncol, iciwp, dei, &
+            ncol, nlev, iciwp, dei, &
             ice_tau, ice_tau_ssa, &
             ice_tau_ssa_g, ice_tau_ssa_f &
          )
@@ -101,7 +99,7 @@ contains
             end do
          end do
       else if (trim(icecldoptics) == 'ebertcurry') then
-         call ec_ice_optics_sw(ncol, cld, iciwp, rei, ice_tau, ice_tau_ssa, ice_tau_ssa_g, ice_tau_ssa_f)
+         call ec_ice_optics_sw(ncol, nlev, cld, iciwp, rei, ice_tau, ice_tau_ssa, ice_tau_ssa_g, ice_tau_ssa_f)
       else
          call endrun('icecldoptics ' // trim(icecldoptics) // ' not supported.')
       end if
@@ -111,7 +109,7 @@ contains
       ! Get liquid cloud optics
       if (trim(liqcldoptics) == 'gammadist') then
          call gammadist_liq_optics_sw( &
-            ncol, iclwp, lambdac, mu, &
+            ncol, nlev, iclwp, lambdac, mu, &
             liq_tau, liq_tau_ssa, &
             liq_tau_ssa_g, liq_tau_ssa_f &
          )
@@ -125,7 +123,7 @@ contains
          end do
       else if (trim(liqcldoptics) == 'slingo') then
          call slingo_liq_optics_sw( &
-            ncol, cld, iclwp, rel, &
+            ncol, nlev, cld, iclwp, rel, &
             liq_tau, liq_tau_ssa, &
             liq_tau_ssa_g, liq_tau_ssa_f &
          )
@@ -139,7 +137,7 @@ contains
       ! Get snow cloud optics
       if (do_snow_optics()) then
          call mitchell_ice_optics_sw( &
-            ncol, icswp, des, &
+            ncol, nlev, icswp, des, &
             snow_tau, snow_tau_ssa, &
             snow_tau_ssa_g, snow_tau_ssa_f &
          )
@@ -218,7 +216,7 @@ contains
          lambdac, mu, dei, des, rei, &
          tau_out)
 
-      use ppgrid, only: pcols, pver
+      use ppgrid, only: pcols
       use cloud_rad_props, only: gammadist_liq_optics_lw, &
                                  mitchell_ice_optics_lw
       use radconstants, only: nlwbands
@@ -245,25 +243,25 @@ contains
 
       ! Get ice optics
       if (trim(icecldoptics) == 'mitchell') then
-         call mitchell_ice_optics_lw(ncol, iciwp, dei, ice_tau)
+         call mitchell_ice_optics_lw(ncol, nlev, iciwp, dei, ice_tau)
       else if (trim(icecldoptics) == 'ebertcurry') then
-         call ec_ice_optics_lw(ncol, cld, iclwp, iciwp, rei, ice_tau)
+         call ec_ice_optics_lw(ncol, nlev, cld, iclwp, iciwp, rei, ice_tau)
       else
          call endrun('icecldoptics ' // trim(icecldoptics) // ' not supported.')
       end if
 
       ! Get liquid optics
       if (trim(liqcldoptics) == 'gammadist') then
-         call gammadist_liq_optics_lw(ncol, iclwp, lambdac, mu, liq_tau)
+         call gammadist_liq_optics_lw(ncol, nlev, iclwp, lambdac, mu, liq_tau)
       else if (trim(liqcldoptics) == 'slingo') then
-         call slingo_liq_optics_lw(ncol, cld, iclwp, iciwp, liq_tau)
+         call slingo_liq_optics_lw(ncol, nlev, cld, iclwp, iciwp, liq_tau)
       else
          call endrun('liqcldoptics ' // trim(liqcldoptics) // ' not supported.')
       end if
 
       ! Get snow optics?
       if (do_snow_optics()) then
-         call mitchell_ice_optics_lw(ncol, icswp, des, snow_tau)
+         call mitchell_ice_optics_lw(ncol, nlev, icswp, des, snow_tau)
 
          ! Combined cloud optics
          cld_tau = liq_tau + ice_tau
@@ -411,7 +409,7 @@ contains
          ncol, nlev, ngpt, gpt2bnd, &
          pmid, cld, cldfsnow, &
          tau_bnd, tau_gpt)
-      use ppgrid, only: pcols, pver
+      use ppgrid, only: pcols
       use mcica_subcol_gen, only: mcica_subcol_mask
 
       integer, intent(in) :: ncol, nlev, ngpt

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -13,22 +13,10 @@ module cam_optics
    implicit none
    private
 
-   public cam_optics_type, &
-          set_cloud_optics_sw, &
+   public set_cloud_optics_sw, &
           set_cloud_optics_lw, &
           set_aerosol_optics_sw, &
           set_aerosol_optics_lw
-
-   type cam_optics_type
-      integer :: nbands, ncolumns, nlevels
-      real(r8), allocatable :: optical_depth(:,:,:)
-      real(r8), allocatable :: single_scattering_albedo(:,:,:)
-      real(r8), allocatable :: assymmetry_parameter(:,:,:)
-      real(r8), allocatable :: forward_scattering_fraction(:,:,:)
-   contains
-      procedure :: initialize => cam_optics_initialize
-      procedure :: finalize => cam_optics_finalize
-   end type cam_optics_type
 
    ! Mapping from old RRTMG sw bands to new band ordering in RRTMGP
    integer, dimension(14) :: map_rrtmg_to_rrtmgp_swbands = (/ &
@@ -36,40 +24,13 @@ module cam_optics
    /)
 
 contains
-   !-------------------------------------------------------------------------------
-   ! Type-bound procedures for cam_optics_type
-   subroutine cam_optics_initialize(this, nbands, ncolumns, nlevels)
-      class(cam_optics_type), intent(inout) :: this
-      integer, intent(in) :: nbands, ncolumns, nlevels
 
-      this%nbands = nbands
-      this%ncolumns = ncolumns
-      this%nlevels = nlevels
-
-      allocate(this%optical_depth(ncolumns,nlevels,nbands), &
-               this%single_scattering_albedo(ncolumns,nlevels,nbands), &
-               this%assymmetry_parameter(ncolumns,nlevels,nbands), &
-               this%forward_scattering_fraction(ncolumns,nlevels,nbands))
-
-      this%optical_depth = 0
-      this%single_scattering_albedo = 1
-      this%assymmetry_parameter = 0
-      this%forward_scattering_fraction = 0
-   end subroutine cam_optics_initialize
-   !-------------------------------------------------------------------------------
-   subroutine cam_optics_finalize(this)
-      class(cam_optics_type), intent(inout) :: this
-      deallocate(this%optical_depth, &
-                 this%single_scattering_albedo, &
-                 this%assymmetry_parameter, &
-                 this%forward_scattering_fraction)
-   end subroutine cam_optics_finalize
    !-------------------------------------------------------------------------------
 
    subroutine get_cloud_optics_sw( &
          ncol, cld, cldfsnow, iclwp, iciwp, icswp, &
          lambdac, mu, dei, des, rel, rei, &
-         optics_out)
+         tau_out, ssa_out, asm_out)
 
       use ppgrid, only: pcols, pver
       use physics_types, only: physics_state
@@ -87,13 +48,10 @@ contains
       ! corresponding fields were defined for all indices of pver. This
       ! isn't the case right now I don't think, as cloud_rad_props makes explicit
       ! assumptions about array sizes.
-      type(cam_optics_type), intent(inout) :: optics_out
+      real(r8), intent(out), dimension(:,:,:) :: tau_out, ssa_out, asm_out
 
       ! Temporary variables to hold cloud optical properties before combining into
       ! output arrays. Same shape as output arrays, so get shapes from output.
-      !real(r8), dimension(size(optics_out%optical_depth,1), &
-      !                    size(optics_out%optical_depth,2), &
-      !                    size(optics_out%optical_depth,3)) :: &
       real(r8), dimension(nswbands,pcols,pver) :: &
             liq_tau, liq_tau_ssa, liq_tau_ssa_g, liq_tau_ssa_f, &
             ice_tau, ice_tau_ssa, ice_tau_ssa_g, ice_tau_ssa_f, &
@@ -226,28 +184,28 @@ contains
       ! albedo, and assymmetry parameter from the products that the CAM routines
       ! return. Make sure we do not try to divide by zero...
       do iband = 1,nswbands
-         optics_out%optical_depth(:ncol,:pver,iband) = combined_tau(iband,:ncol,:pver)
+         tau_out(:ncol,:pver,iband) = combined_tau(iband,:ncol,:pver)
          where (combined_tau(iband,:ncol,:pver) > 0)
-            optics_out%single_scattering_albedo(:ncol,:pver,iband) &
+            ssa_out(:ncol,:pver,iband) &
                = combined_tau_ssa(iband,:ncol,:pver) / combined_tau(iband,:ncol,:pver)
          elsewhere
-            optics_out%single_scattering_albedo(:ncol,:pver,iband) = 1.0
+            ssa_out(:ncol,:pver,iband) = 1.0
          endwhere
          where (combined_tau_ssa(iband,:ncol,:pver) > 0)
-            optics_out%assymmetry_parameter(:ncol,:pver,iband) &
+            asm_out(:ncol,:pver,iband) &
                = combined_tau_ssa_g(iband,:ncol,:pver) / combined_tau_ssa(iband,:ncol,:pver)
          elsewhere
-            optics_out%assymmetry_parameter(:ncol,:pver,iband) = 0.0
+            asm_out(:ncol,:pver,iband) = 0.0
          end where
       end do
 
       ! Check values
-      call assert_range(optics_out%optical_depth, 0._r8, 1e20_r8, &
-                        'get_cloud_optics_sw: optics_out%optical_depth')
-      call assert_range(optics_out%single_scattering_albedo, 0._r8, 1._r8, &
-                        'get_cloud_optics_sw: optics_out%single_scattering_albedo')
-      call assert_range(optics_out%assymmetry_parameter, -1._r8, 1._r8, &
-                        'get_cloud_optics_sw: optics_out%assymmetry_parameter')
+      call assert_range(tau_out, 0._r8, 1e20_r8, &
+                        'get_cloud_optics_sw: tau_out')
+      call assert_range(ssa_out, 0._r8, 1._r8, &
+                        'get_cloud_optics_sw: ssa_out')
+      call assert_range(asm_out, -1._r8, 1._r8, &
+                        'get_cloud_optics_sw: asm_out')
    end subroutine get_cloud_optics_sw
 
    !----------------------------------------------------------------------------
@@ -255,7 +213,7 @@ contains
    subroutine get_cloud_optics_lw( &
          ncol, cld, cldfsnow, iclwp, iciwp, icswp, &
          lambdac, mu, dei, des, rei, &
-         optics_out)
+         tau_out)
 
       use ppgrid, only: pcols, pver
       use physics_types, only: physics_state
@@ -270,7 +228,7 @@ contains
          cld, cldfsnow, &
          iclwp, iciwp, icswp, &
          mu, lambdac, dei, des, rei
-      type(cam_optics_type), intent(inout) :: optics_out
+      real(r8), intent(out), dimension(:,:,:) :: tau_out
 
       ! Temporary variables to hold absorption optical depth
       real(r8), dimension(nlwbands,pcols,pver) :: &
@@ -318,15 +276,14 @@ contains
          combined_tau(1:nlwbands,1:ncol,1:pver) = cld_tau(1:nlwbands,1:ncol,1:pver)
       end if
 
-      ! Set optics_out
+      ! Set output optics
       do iband = 1,nlwbands
-         optics_out%optical_depth(1:ncol,1:pver,iband) &
-            = combined_tau(iband,1:ncol,1:pver)
+         tau_out(1:ncol,1:pver,iband) = combined_tau(iband,1:ncol,1:pver)
       end do
 
       ! Check values
-      call assert_range(optics_out%optical_depth, 0._r8, 1e20_r8, &
-                        'get_cloud_optics_lw: optics_out%optical_depth')
+      call assert_range(tau_out, 0._r8, 1e20_r8, &
+                        'get_cloud_optics_lw: tau_out')
 
    end subroutine get_cloud_optics_lw
 
@@ -400,8 +357,8 @@ contains
       type(ty_gas_optics_rrtmgp), intent(in) :: kdist
       type(ty_optical_props_2str), intent(inout) :: optics_out
 
-      ! Type to hold optics on CAM grid
-      type(cam_optics_type) :: optics_cam
+      ! Cloud optics by band
+      real(r8), dimension(pcols, pver, nswbands) :: tau_bnd, ssa_bnd, asm_bnd
 
       ! Pointers to fields on the physics buffer
       real(r8), pointer, dimension(:,:) :: &
@@ -453,30 +410,21 @@ contains
       ! properties interface (cloud_rad_props). This retrieves cloud optical
       ! properties by *band* -- these will be mapped to g-points when doing
       ! the subcolumn sampling to account for cloud overlap.
-      call optics_cam%initialize(nswbands, ncol, pver)
       call get_cloud_optics_sw( &
          ncol, cld, cldfsnow, iclwp, iciwp, icswp, &
          lambdac, mu, dei, des, rel, rei, &
-         optics_cam &
+         tau_bnd, ssa_bnd, asm_bnd &
       )
 
       ! Send in-cloud optical depth for visible band to history buffer
-      call output_cloud_optics_sw(state, optics_cam)
+      call output_cloud_optics_sw(state, tau_bnd, ssa_bnd, asm_bnd)
 
       ! Initialize (or reset) output cloud optics object
       optics_out%tau = 0.0
       optics_out%ssa = 1.0
       optics_out%g = 0.0
 
-      ! Set pointer to cloud fraction; this is used by McICA routines
-      ! TODO: why the extra arguments to pbuf_get_field here? Are these necessary?
-      !call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cld, &
-      !                    start=(/1,1,pbuf_old_tim_idx()/), &
-      !                    kount=(/pcols,pver,1/))
-
       ! Get cloud and snow fractions, and combine
-      call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cld)
-      call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), cldfsnow)
       combined_cld(1:ncol,1:pver) = max(cld(1:ncol,1:pver), &
                                                    cldfsnow(1:ncol,1:pver))
 
@@ -513,9 +461,9 @@ contains
                    combined_cld(icol,ilev_cam) > 0._r8) then
                
                   iband = kdist%convert_gpt2band(igpt)
-                  optics_out%tau(iday,ilev_rad,igpt) = optics_cam%optical_depth(icol,ilev_cam,iband)
-                  optics_out%ssa(iday,ilev_rad,igpt) = optics_cam%single_scattering_albedo(icol,ilev_cam,iband)
-                  optics_out%g(iday,ilev_rad,igpt) = optics_cam%assymmetry_parameter(icol,ilev_cam,iband)
+                  optics_out%tau(iday,ilev_rad,igpt) = tau_bnd(icol,ilev_cam,iband)
+                  optics_out%ssa(iday,ilev_rad,igpt) = ssa_bnd(icol,ilev_cam,iband)
+                  optics_out%g(iday,ilev_rad,igpt) = asm_bnd(icol,ilev_cam,iband)
                else
                   optics_out%tau(iday,ilev_rad,igpt) = 0._r8
                   optics_out%ssa(iday,ilev_rad,igpt) = 1._r8
@@ -536,8 +484,6 @@ contains
 
       ! Check cloud optics_sw
       call handle_error(optics_out%validate())
-
-      call optics_cam%finalize()
 
       deallocate(iscloudy)
 
@@ -560,7 +506,7 @@ contains
       type(ty_gas_optics_rrtmgp), intent(in) :: kdist
       type(ty_optical_props_1scl), intent(inout) :: optics_out
 
-      type(cam_optics_type) :: optics_cam
+      real(r8), dimension(pcols,pver,nlwbands) :: tau_bnd
       real(r8) :: combined_cld(pcols,pver)
 
       ! Pointers for pbuf fields
@@ -611,19 +557,18 @@ contains
 
       ! Get cloud optics using CAM routines. This should combine cloud with snow
       ! optics, if "snow clouds" are being considered
-      call optics_cam%initialize(nlwbands, ncol, pver)
       call get_cloud_optics_lw( &
          ncol, cld, cldfsnow, iclwp, iciwp, icswp, &
          lambdac, mu, dei, des, rei, &
-         optics_cam &
+         tau_bnd &
       )
 
       ! Check values
-      call assert_range(optics_cam%optical_depth, 0._r8, 1e20_r8, &
-                        'set_cloud_optics_lw: optics_cam%optical_depth')
+      call assert_range(tau_bnd, 0._r8, 1e20_r8, &
+                        'set_cloud_optics_lw: tau_bnd')
 
       ! Send cloud optics to history buffer
-      call output_cloud_optics_lw(state, optics_cam)
+      call output_cloud_optics_lw(state, tau_bnd)
 
       ! Get cloud and snow fractions, and combine
       call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cld)
@@ -661,7 +606,7 @@ contains
             do igpt = 1,ngpt
                if (iscloudy(igpt,icol,ilev_cam) .and. (combined_cld(icol,ilev_cam) > 0._r8) ) then
                   iband = kdist%convert_gpt2band(igpt)
-                  optics_out%tau(icol,ilev_rad,igpt) = optics_cam%optical_depth(icol,ilev_cam,iband)
+                  optics_out%tau(icol,ilev_rad,igpt) = tau_bnd(icol,ilev_cam,iband)
                else
                   optics_out%tau(icol,ilev_rad,igpt) = 0._r8
                end if
@@ -684,8 +629,6 @@ contains
 
       ! Check cloud optics
       call handle_error(optics_out%validate())
-
-      call optics_cam%finalize()
 
       deallocate(iscloudy)
 
@@ -850,56 +793,56 @@ contains
 
    !----------------------------------------------------------------------------
 
-   subroutine output_cloud_optics_sw(state, optics)
+   subroutine output_cloud_optics_sw(state, tau, ssa, asm)
       use ppgrid, only: pver
       use physics_types, only: physics_state
       use cam_history, only: outfld
       use radconstants, only: idx_sw_diag
 
       type(physics_state), intent(in) :: state
-      type(cam_optics_type), intent(in) :: optics
+      real(r8), intent(in), dimension(:,:,:) :: tau, ssa, asm
       character(len=*), parameter :: subname = 'output_cloud_optics_sw'
 
       ! Check values
-      call assert_valid(optics%optical_depth(1:state%ncol,1:pver,1:nswbands), &
+      call assert_valid(tau(1:state%ncol,1:pver,1:nswbands), &
                         trim(subname) // ': optics%optical_depth')
-      call assert_valid(optics%single_scattering_albedo(1:state%ncol,1:pver,1:nswbands), &
+      call assert_valid(ssa(1:state%ncol,1:pver,1:nswbands), &
                         trim(subname) // ': optics%single_scattering_albedo')
-      call assert_valid(optics%assymmetry_parameter(1:state%ncol,1:pver,1:nswbands), &
+      call assert_valid(asm(1:state%ncol,1:pver,1:nswbands), &
                         trim(subname) // ': optics%assymmetry_parameter')
 
       ! Send outputs to history buffer
       call outfld('CLOUD_TAU_SW', &
-                  optics%optical_depth(1:state%ncol,1:pver,1:nswbands), &
+                  tau(1:state%ncol,1:pver,1:nswbands), &
                   state%ncol, state%lchnk)
       call outfld('CLOUD_SSA_SW', &
-                  optics%single_scattering_albedo(1:state%ncol,1:pver,1:nswbands), &
+                  ssa(1:state%ncol,1:pver,1:nswbands), &
                   state%ncol, state%lchnk)
       call outfld('CLOUD_G_SW', &
-                  optics%assymmetry_parameter(1:state%ncol,1:pver,1:nswbands), &
+                  asm(1:state%ncol,1:pver,1:nswbands), &
                   state%ncol, state%lchnk)
       call outfld('TOT_ICLD_VISTAU', &
-                  optics%optical_depth(1:state%ncol,1:pver,idx_sw_diag), &
+                  tau(1:state%ncol,1:pver,idx_sw_diag), &
                   state%ncol, state%lchnk)
    end subroutine output_cloud_optics_sw
 
    !----------------------------------------------------------------------------
 
-   subroutine output_cloud_optics_lw(state, optics)
+   subroutine output_cloud_optics_lw(state, tau)
 
       use ppgrid, only: pver
       use physics_types, only: physics_state
       use cam_history, only: outfld
 
       type(physics_state), intent(in) :: state
-      type(cam_optics_type), intent(in) :: optics
+      real(r8), intent(in), dimension(:,:,:) :: tau
 
       ! Check values
-      call assert_valid(optics%optical_depth(1:state%ncol,1:pver,1:nlwbands), 'cld_tau_lw')
+      call assert_valid(tau(1:state%ncol,1:pver,1:nlwbands), 'cld_tau_lw')
 
       ! Output
       call outfld('CLOUD_TAU_LW', &
-                  optics%optical_depth(1:state%ncol,1:pver,1:nlwbands), &
+                  tau(1:state%ncol,1:pver,1:nlwbands), &
                   state%ncol, state%lchnk)
 
    end subroutine output_cloud_optics_lw

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -67,8 +67,8 @@ contains
       use ppgrid, only: pcols, pver
       use physics_types, only: physics_state
       use physics_buffer, only: physics_buffer_desc, pbuf_get_field, pbuf_get_index
-      use cloud_rad_props, only: get_ice_optics_sw, &
-                                 get_liquid_optics_sw, &
+      use cloud_rad_props, only: get_mitchell_ice_optics_sw, &
+                                 get_gammadist_liq_optics_sw, &
                                  get_snow_optics_sw
 
       ! Inputs. Right now, this uses state and pbuf, and passes these along to the
@@ -134,14 +134,14 @@ contains
       !call pbuf_get_field(pbuf, pbuf_get_index('ICIWP'), iciwp)
       !call pbuf_get_field(pbuf, pbuf_get_index('DEI'), dei)
       ncol = state%ncol
-      call get_ice_optics_sw(state, pbuf, &
+      call get_mitchell_ice_optics_sw(state, pbuf, &
                              ice_tau, ice_tau_ssa, &
                              ice_tau_ssa_g, ice_tau_ssa_f)
       call assert_range(ice_tau(1:nswbands,1:ncol,1:pver), 0._r8, 1e20_r8, &
                         'get_cloud_optics_sw: ice_tau')
       
       ! Get liquid cloud optics
-      call get_liquid_optics_sw(state, pbuf, &
+      call get_gammadist_liq_optics_sw(state, pbuf, &
                                 liquid_tau, liquid_tau_ssa, &
                                 liquid_tau_ssa_g, liquid_tau_ssa_f)
       call assert_range(liquid_tau(1:nswbands,1:ncol,1:pver), 0._r8, 1e20_r8, &
@@ -239,8 +239,8 @@ contains
       use physics_types, only: physics_state
       use physics_buffer, only: physics_buffer_desc, pbuf_get_field, &
                                 pbuf_get_index
-      use cloud_rad_props, only: get_liquid_optics_lw, &
-                                 get_ice_optics_lw, &
+      use cloud_rad_props, only: get_gammadist_liq_optics_lw, &
+                                 get_mitchell_ice_optics_lw, &
                                  get_snow_optics_lw
       use radconstants, only: nlwbands
 
@@ -269,10 +269,10 @@ contains
       combined_tau(:,:,:) = 0.0
 
       ! Get ice optics
-      call get_ice_optics_lw(state, pbuf, ice_tau)
+      call get_mitchell_ice_optics_lw(state, pbuf, ice_tau)
 
       ! Get liquid optics
-      call get_liquid_optics_lw(state, pbuf, liq_tau)
+      call get_gammadist_liq_optics_lw(state, pbuf, liq_tau)
 
       ! Get snow optics?
       call get_snow_optics_lw(state, pbuf, snow_tau)

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -9,12 +9,16 @@ module cam_optics
    use ebert_curry, only: ec_ice_optics_sw, ec_ice_optics_lw
    use slingo, only: slingo_liq_optics_sw, slingo_liq_optics_lw
    use cam_abortutils, only: endrun
+   use ppgrid, only: pcols, pver
 
    implicit none
    private
 
-   public set_cloud_optics_sw, &
-          set_cloud_optics_lw, &
+   public get_cloud_optics_sw, &
+          get_cloud_optics_lw, &
+          sample_cloud_optics_sw, &
+          sample_cloud_optics_lw, &
+          compress_optics_sw, &
           set_aerosol_optics_sw, &
           set_aerosol_optics_lw
 
@@ -28,7 +32,7 @@ contains
    !-------------------------------------------------------------------------------
 
    subroutine get_cloud_optics_sw( &
-         ncol, cld, cldfsnow, iclwp, iciwp, icswp, &
+         ncol, nlev, nbnd, cld, cldfsnow, iclwp, iciwp, icswp, &
          lambdac, mu, dei, des, rel, rei, &
          tau_out, ssa_out, asm_out)
 
@@ -37,22 +41,22 @@ contains
       use cloud_rad_props, only: mitchell_ice_optics_sw, &
                                  gammadist_liq_optics_sw
 
-      integer, intent(in) :: ncol
+      integer, intent(in) :: ncol, nlev, nbnd
       real(r8), intent(in), dimension(:,:) :: &
          cld, cldfsnow, iclwp, iciwp, icswp, &
          lambdac, mu, dei, des, rel, rei
 
       ! Outputs are shortwave cloud optical properties *by band*. Dimensions should
-      ! be nswbands,ncol,pver. Generally, this should be able to handle cases were
-      ! ncol might be something like nday, and pver could be arbitrary so long as
-      ! corresponding fields were defined for all indices of pver. This
+      ! be nswbands,ncol,nlev. Generally, this should be able to handle cases were
+      ! ncol might be something like nday, and nlev could be arbitrary so long as
+      ! corresponding fields were defined for all indices of nlev. This
       ! isn't the case right now I don't think, as cloud_rad_props makes explicit
       ! assumptions about array sizes.
       real(r8), intent(out), dimension(:,:,:) :: tau_out, ssa_out, asm_out
 
       ! Temporary variables to hold cloud optical properties before combining into
       ! output arrays. Same shape as output arrays, so get shapes from output.
-      real(r8), dimension(nswbands,pcols,pver) :: &
+      real(r8), dimension(nbnd,pcols,nlev) :: &
             liq_tau, liq_tau_ssa, liq_tau_ssa_g, liq_tau_ssa_f, &
             ice_tau, ice_tau_ssa, ice_tau_ssa_g, ice_tau_ssa_f, &
             cld_tau, cld_tau_ssa, cld_tau_ssa_g, cld_tau_ssa_f, &
@@ -89,7 +93,7 @@ contains
          ! We need to fix band ordering because the old input files assume RRTMG band
          ! ordering, but this has changed in RRTMGP.
          ! TODO: fix the input files themselves!
-         do ilev = 1,pver
+         do ilev = 1,nlev
             do icol = 1,ncol
                ice_tau      (:,icol,ilev) = reordered(ice_tau      (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
                ice_tau_ssa  (:,icol,ilev) = reordered(ice_tau_ssa  (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
@@ -102,7 +106,7 @@ contains
       else
          call endrun('icecldoptics ' // trim(icecldoptics) // ' not supported.')
       end if
-      call assert_range(ice_tau(1:nswbands,1:ncol,1:pver), 0._r8, 1e20_r8, &
+      call assert_range(ice_tau(1:nbnd,1:ncol,1:nlev), 0._r8, 1e20_r8, &
                         'get_cloud_optics_sw: ice_tau')
       
       ! Get liquid cloud optics
@@ -112,7 +116,7 @@ contains
             liq_tau, liq_tau_ssa, &
             liq_tau_ssa_g, liq_tau_ssa_f &
          )
-         do ilev = 1,pver
+         do ilev = 1,nlev
             do icol = 1,ncol
                liq_tau      (:,icol,ilev) = reordered(liq_tau      (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
                liq_tau_ssa  (:,icol,ilev) = reordered(liq_tau_ssa  (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
@@ -130,7 +134,7 @@ contains
          call endrun('liqcldoptics ' // trim(liqcldoptics) // ' not supported.')
       end if
 
-      call assert_range(liq_tau(1:nswbands,1:ncol,1:pver), 0._r8, 1e20_r8, &
+      call assert_range(liq_tau(1:nbnd,1:ncol,1:nlev), 0._r8, 1e20_r8, &
                         'get_cloud_optics_sw: liq_tau')
 
       ! Get snow cloud optics
@@ -140,7 +144,7 @@ contains
             snow_tau, snow_tau_ssa, &
             snow_tau_ssa_g, snow_tau_ssa_f &
          )
-         do ilev = 1,pver
+         do ilev = 1,nlev
             do icol = 1,ncol
                snow_tau      (:,icol,ilev) = reordered(snow_tau      (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
                snow_tau_ssa  (:,icol,ilev) = reordered(snow_tau_ssa  (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
@@ -162,68 +166,65 @@ contains
       cld_tau_ssa = ice_tau_ssa + liq_tau_ssa
       cld_tau_ssa_g = ice_tau_ssa_g + liq_tau_ssa_g
       call combine_properties( &
-         nswbands, ncol, pver, &
-         cld(1:ncol,1:pver), cld_tau(1:nswbands,1:ncol,1:pver), &
-         cldfsnow(1:ncol,1:pver), snow_tau(1:nswbands,1:ncol,1:pver), &
-         combined_tau(1:nswbands,1:ncol,1:pver) &
+         nbnd, ncol, nlev, &
+         cld(1:ncol,1:nlev), cld_tau(1:nbnd,1:ncol,1:nlev), &
+         cldfsnow(1:ncol,1:nlev), snow_tau(1:nbnd,1:ncol,1:nlev), &
+         combined_tau(1:nbnd,1:ncol,1:nlev) &
       )
       call combine_properties( &
-         nswbands, ncol, pver, &
-         cld(1:ncol,1:pver), cld_tau_ssa(1:nswbands,1:ncol,1:pver), &
-         cldfsnow(1:ncol,1:pver), snow_tau_ssa(1:nswbands,1:ncol,1:pver), &
-         combined_tau_ssa(1:nswbands,1:ncol,1:pver) &
+         nbnd, ncol, nlev, &
+         cld(1:ncol,1:nlev), cld_tau_ssa(1:nbnd,1:ncol,1:nlev), &
+         cldfsnow(1:ncol,1:nlev), snow_tau_ssa(1:nbnd,1:ncol,1:nlev), &
+         combined_tau_ssa(1:nbnd,1:ncol,1:nlev) &
       )
       call combine_properties( &
-         nswbands, ncol, pver, &
-         cld(1:ncol,1:pver), cld_tau_ssa_g(1:nswbands,1:ncol,1:pver), &
-         cldfsnow(1:ncol,1:pver), snow_tau_ssa_g(1:nswbands,1:ncol,1:pver), &
-         combined_tau_ssa_g(1:nswbands,1:ncol,1:pver) &
+         nbnd, ncol, nlev, &
+         cld(1:ncol,1:nlev), cld_tau_ssa_g(1:nbnd,1:ncol,1:nlev), &
+         cldfsnow(1:ncol,1:nlev), snow_tau_ssa_g(1:nbnd,1:ncol,1:nlev), &
+         combined_tau_ssa_g(1:nbnd,1:ncol,1:nlev) &
       )
       
       ! Copy to output arrays, converting to optical depth, single scattering
       ! albedo, and assymmetry parameter from the products that the CAM routines
       ! return. Make sure we do not try to divide by zero...
-      do iband = 1,nswbands
-         tau_out(:ncol,:pver,iband) = combined_tau(iband,:ncol,:pver)
-         where (combined_tau(iband,:ncol,:pver) > 0)
-            ssa_out(:ncol,:pver,iband) &
-               = combined_tau_ssa(iband,:ncol,:pver) / combined_tau(iband,:ncol,:pver)
+      do iband = 1,nbnd
+         tau_out(:ncol,:nlev,iband) = combined_tau(iband,:ncol,:nlev)
+         where (combined_tau(iband,:ncol,:nlev) > 0)
+            ssa_out(:ncol,:nlev,iband) &
+               = combined_tau_ssa(iband,:ncol,:nlev) / combined_tau(iband,:ncol,:nlev)
          elsewhere
-            ssa_out(:ncol,:pver,iband) = 1.0
+            ssa_out(:ncol,:nlev,iband) = 1.0
          endwhere
-         where (combined_tau_ssa(iband,:ncol,:pver) > 0)
-            asm_out(:ncol,:pver,iband) &
-               = combined_tau_ssa_g(iband,:ncol,:pver) / combined_tau_ssa(iband,:ncol,:pver)
+         where (combined_tau_ssa(iband,:ncol,:nlev) > 0)
+            asm_out(:ncol,:nlev,iband) &
+               = combined_tau_ssa_g(iband,:ncol,:nlev) / combined_tau_ssa(iband,:ncol,:nlev)
          elsewhere
-            asm_out(:ncol,:pver,iband) = 0.0
+            asm_out(:ncol,:nlev,iband) = 0.0
          end where
       end do
 
       ! Check values
-      call assert_range(tau_out, 0._r8, 1e20_r8, &
+      call assert_range(tau_out(:ncol,:nlev,:nbnd), 0._r8, 1e20_r8, &
                         'get_cloud_optics_sw: tau_out')
-      call assert_range(ssa_out, 0._r8, 1._r8, &
+      call assert_range(ssa_out(:ncol,:nlev,:nbnd), 0._r8, 1._r8, &
                         'get_cloud_optics_sw: ssa_out')
-      call assert_range(asm_out, -1._r8, 1._r8, &
+      call assert_range(asm_out(:ncol,:nlev,:nbnd), -1._r8, 1._r8, &
                         'get_cloud_optics_sw: asm_out')
    end subroutine get_cloud_optics_sw
 
    !----------------------------------------------------------------------------
 
    subroutine get_cloud_optics_lw( &
-         ncol, cld, cldfsnow, iclwp, iciwp, icswp, &
+         ncol, nlev, nbnd, cld, cldfsnow, iclwp, iciwp, icswp, &
          lambdac, mu, dei, des, rei, &
          tau_out)
 
       use ppgrid, only: pcols, pver
-      use physics_types, only: physics_state
-      use physics_buffer, only: physics_buffer_desc, pbuf_get_field, &
-                                pbuf_get_index
       use cloud_rad_props, only: gammadist_liq_optics_lw, &
                                  mitchell_ice_optics_lw
       use radconstants, only: nlwbands
 
-      integer, intent(in) :: ncol
+      integer, intent(in) :: ncol, nlev, nbnd
       real(r8), intent(in), dimension(:,:) :: &
          cld, cldfsnow, &
          iclwp, iciwp, icswp, &
@@ -231,7 +232,7 @@ contains
       real(r8), intent(out), dimension(:,:,:) :: tau_out
 
       ! Temporary variables to hold absorption optical depth
-      real(r8), dimension(nlwbands,pcols,pver) :: &
+      real(r8), dimension(nbnd,pcols,nlev) :: &
             ice_tau, liq_tau, snow_tau, cld_tau, combined_tau
 
       integer :: iband
@@ -267,22 +268,22 @@ contains
 
          ! Combined cloud optics
          cld_tau = liq_tau + ice_tau
-         call combine_properties(nlwbands, ncol, pver, &
-            cld(1:ncol,1:pver), cld_tau(1:nlwbands,1:ncol,1:pver), &
-            cldfsnow(1:ncol,1:pver), snow_tau(1:nlwbands,1:ncol,1:pver), &
-            combined_tau(1:nlwbands,1:ncol,1:pver) &
+         call combine_properties(nbnd, ncol, nlev, &
+            cld(1:ncol,1:nlev), cld_tau(1:nbnd,1:ncol,1:nlev), &
+            cldfsnow(1:ncol,1:nlev), snow_tau(1:nbnd,1:ncol,1:nlev), &
+            combined_tau(1:nbnd,1:ncol,1:nlev) &
          )
       else
-         combined_tau(1:nlwbands,1:ncol,1:pver) = cld_tau(1:nlwbands,1:ncol,1:pver)
+         combined_tau(1:nbnd,1:ncol,1:nlev) = cld_tau(1:nbnd,1:ncol,1:nlev)
       end if
 
       ! Set output optics
-      do iband = 1,nlwbands
-         tau_out(1:ncol,1:pver,iband) = combined_tau(iband,1:ncol,1:pver)
+      do iband = 1,nbnd
+         tau_out(1:ncol,1:nlev,iband) = combined_tau(iband,1:ncol,1:nlev)
       end do
 
       ! Check values
-      call assert_range(tau_out, 0._r8, 1e20_r8, &
+      call assert_range(tau_out(:ncol,:nlev,:nbnd), 0._r8, 1e20_r8, &
                         'get_cloud_optics_lw: tau_out')
 
    end subroutine get_cloud_optics_lw
@@ -340,299 +341,120 @@ contains
 
    !----------------------------------------------------------------------------
 
-   subroutine set_cloud_optics_sw(state, pbuf, day_indices, kdist, optics_out)
-      
-      use ppgrid, only: pcols, pver, pverp
-      use physics_types, only: physics_state
-      use physics_buffer, only: physics_buffer_desc, &
-                                pbuf_get_field, &
-                                pbuf_get_index
-      use mo_optical_props, only: ty_optical_props_2str
-      use mo_gas_optics_rrtmgp, only: ty_gas_optics_rrtmgp
+   ! Do MCICA sampling of optics here. This will map bands to gpoints,
+   ! while doing stochastic sampling of cloud state
+   subroutine sample_cloud_optics_sw( &
+         ncol, nlev, ngpt, gpt2bnd, &
+         pmid, cld, cldfsnow, &
+         tau_bnd, ssa_bnd, asm_bnd, &
+         tau_gpt, ssa_gpt, asm_gpt)
       use mcica_subcol_gen, only: mcica_subcol_mask
+      integer, intent(in) :: ncol, nlev, ngpt
+      integer, intent(in), dimension(:) :: gpt2bnd
+      real(r8), intent(in), dimension(:,:) :: pmid, cld, cldfsnow
+      real(r8), intent(in), dimension(:,:,:) :: tau_bnd, ssa_bnd, asm_bnd
+      real(r8), intent(out), dimension(:,:,:) :: tau_gpt, ssa_gpt, asm_gpt
+      logical, dimension(ngpt,ncol,nlev) :: iscloudy
+      real(r8), dimension(ncol,nlev) :: combined_cld
+      integer, parameter :: changeseed = 1  ! how many times to permute random seed
+      integer :: icol, ilev, igpt
 
-      type(physics_state), intent(in) :: state
-      type(physics_buffer_desc), pointer :: pbuf(:)
-      integer, intent(in) :: day_indices(:)
-      type(ty_gas_optics_rrtmgp), intent(in) :: kdist
-      type(ty_optical_props_2str), intent(inout) :: optics_out
-
-      ! Cloud optics by band
-      real(r8), dimension(pcols, pver, nswbands) :: tau_bnd, ssa_bnd, asm_bnd
-
-      ! Pointers to fields on the physics buffer
-      real(r8), pointer, dimension(:,:) :: &
-         cld, cldfsnow, &
-         iclwp, iciwp, icswp, dei, des, lambdac, mu, &
-         rei, rel
-
-      ! Combined cloud and snow fraction
-      real(r8) :: combined_cld(pcols,pver)
-
-      ! For MCICA sampling routine
-      integer, parameter :: changeseed = 1
-
-      ! Dimension sizes
-      integer :: ngpt, ncol, nday, nlay
-
-      ! McICA subcolumn cloud flag
-      logical, allocatable :: iscloudy(:,:,:)
-
-      ! Loop variables
-      integer :: icol, ilev, igpt, iband, iday, ilev_cam, ilev_rad
-
-      ! Set a name for this subroutine to write to error messages
-      character(len=32) :: subname = 'set_cloud_optics_sw'
-
-      ncol = state%ncol
-      ngpt = kdist%get_ngpt()
-
-      ! Allocate array to hold subcolumn cloud flag
-      allocate(iscloudy(ngpt,ncol,pver))
-
-      ! Initialize output cloud optics object
-      nday = count(day_indices > 0)
-
-      ! Get fields from pbuf
-      call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cld)
-      call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), cldfsnow)
-      call pbuf_get_field(pbuf, pbuf_get_index('ICLWP'), iclwp)
-      call pbuf_get_field(pbuf, pbuf_get_index('ICIWP'), iciwp)
-      call pbuf_get_field(pbuf, pbuf_get_index('ICSWP'), icswp)
-      call pbuf_get_field(pbuf, pbuf_get_index('DEI'), dei)
-      call pbuf_get_field(pbuf, pbuf_get_index('DES'), des)
-      call pbuf_get_field(pbuf, pbuf_get_index('REL'), rel)
-      call pbuf_get_field(pbuf, pbuf_get_index('REI'), rei)
-      call pbuf_get_field(pbuf, pbuf_get_index('LAMBDAC'), lambdac)
-      call pbuf_get_field(pbuf, pbuf_get_index('MU'), mu)
-
-      ! Retrieve the mean in-cloud optical properties via CAM cloud radiative
-      ! properties interface (cloud_rad_props). This retrieves cloud optical
-      ! properties by *band* -- these will be mapped to g-points when doing
-      ! the subcolumn sampling to account for cloud overlap.
-      call get_cloud_optics_sw( &
-         ncol, cld, cldfsnow, iclwp, iciwp, icswp, &
-         lambdac, mu, dei, des, rel, rei, &
-         tau_bnd, ssa_bnd, asm_bnd &
-      )
-
-      ! Send in-cloud optical depth for visible band to history buffer
-      call output_cloud_optics_sw(state, tau_bnd, ssa_bnd, asm_bnd)
-
-      ! Initialize (or reset) output cloud optics object
-      optics_out%tau = 0.0
-      optics_out%ssa = 1.0
-      optics_out%g = 0.0
-
-      ! Get cloud and snow fractions, and combine
-      combined_cld(1:ncol,1:pver) = max(cld(1:ncol,1:pver), &
-                                                   cldfsnow(1:ncol,1:pver))
-
-      ! Do MCICA sampling of optics here. This will map bands to gpoints,
-      ! while doing stochastic sampling of cloud state
-      call mcica_subcol_mask(ngpt, ncol, pver, changeseed, &
-                             state%pmid(1:ncol,1:pver), &
-                             combined_cld(1:ncol,1:pver), &
-                             iscloudy(1:ngpt,1:ncol,1:pver))
-      
-      ! -- generate subcolumns for homogeneous clouds -----
-      ! where there is a cloud, set the subcolumn cloud properties;
-      optics_out%tau(:,:,:) = 0
-      optics_out%ssa(:,:,:) = 1
-      optics_out%g(:,:,:) = 0
-      do ilev_cam = 1,pver  ! Loop over indices on the CAM grid
-
-         ! Index to radiation grid
-         ilev_rad = ilev_cam + (nlev_rad - pver)
-
-         ! Loop over columns and map CAM columns to those on radiation grid
-         ! (daytime-only columns)
-         do iday = 1,size(day_indices)
-
-            ! Map daytime to column indices
-            icol = day_indices(iday)
-
-            ! Loop over g-points and map bands to g-points; each subcolumn
-            ! corresponds to a single g-point. This is how this code implements the
-            ! McICA assumptions: simultaneously sampling over cloud state and
-            ! g-point.
-            do igpt = 1,ngpt
-               if (iscloudy(igpt,icol,ilev_cam) .and. &
-                   combined_cld(icol,ilev_cam) > 0._r8) then
-               
-                  iband = kdist%convert_gpt2band(igpt)
-                  optics_out%tau(iday,ilev_rad,igpt) = tau_bnd(icol,ilev_cam,iband)
-                  optics_out%ssa(iday,ilev_rad,igpt) = ssa_bnd(icol,ilev_cam,iband)
-                  optics_out%g(iday,ilev_rad,igpt) = asm_bnd(icol,ilev_cam,iband)
+      ! Combined snow and cloud fraction
+      combined_cld(1:ncol,1:nlev) = max(cld(1:ncol,1:nlev), &
+                                        cldfsnow(1:ncol,1:nlev))
+      ! Get stochastic subcolumn cloud mask
+      call mcica_subcol_mask(ngpt, ncol, nlev, changeseed, &
+                             pmid(1:ncol,1:nlev), &
+                             combined_cld(1:ncol,1:nlev), &
+                             iscloudy(1:ngpt,1:ncol,1:nlev))
+      ! Generate subcolumns for homogeneous clouds
+      do igpt = 1,ngpt
+         do ilev = 1,nlev
+            do icol = 1,ncol
+               if (iscloudy(igpt,icol,ilev)) then
+                  tau_gpt(icol,ilev,igpt) = tau_bnd(icol,ilev,gpt2bnd(igpt))
+                  ssa_gpt(icol,ilev,igpt) = ssa_bnd(icol,ilev,gpt2bnd(igpt))
+                  asm_gpt(icol,ilev,igpt) = asm_bnd(icol,ilev,gpt2bnd(igpt))
                else
-                  optics_out%tau(iday,ilev_rad,igpt) = 0._r8
-                  optics_out%ssa(iday,ilev_rad,igpt) = 1._r8
-                  optics_out%g(iday,ilev_rad,igpt) = 0._r8
-               end if
-            end do  ! igpt
-         end do  ! iday
-      end do  ! ilev_cam
-
-      ! Apply delta scaling to account for forward-scattering
-      ! TODO: delta_scale takes the forward scattering fraction as an optional
-      ! parameter. In the current cloud optics_sw scheme, forward scattering is taken
-      ! just as g^2, which delta_scale assumes if forward scattering fraction is
-      ! omitted in the function call. In the future, we should explicitly pass
-      ! this. This just requires modifying the get_cloud_optics_sw procedures to also
-      ! pass the foward scattering fraction that the CAM cloud optics_sw assumes.
-      call handle_error(optics_out%delta_scale())
-
-      ! Check cloud optics_sw
-      call handle_error(optics_out%validate())
-
-      deallocate(iscloudy)
-
-   end subroutine set_cloud_optics_sw
-
-   !----------------------------------------------------------------------------
-
-   subroutine set_cloud_optics_lw(state, pbuf, kdist, optics_out)
-      
-      use ppgrid, only: pcols, pver
-      use physics_types, only: physics_state
-      use physics_buffer, only: physics_buffer_desc, &
-                                pbuf_get_field, pbuf_get_index
-      use mo_optical_props, only: ty_optical_props_1scl
-      use mo_gas_optics_rrtmgp, only: ty_gas_optics_rrtmgp
-      use mcica_subcol_gen, only: mcica_subcol_mask
-
-      type(physics_state), intent(in) :: state
-      type(physics_buffer_desc), pointer :: pbuf(:)
-      type(ty_gas_optics_rrtmgp), intent(in) :: kdist
-      type(ty_optical_props_1scl), intent(inout) :: optics_out
-
-      real(r8), dimension(pcols,pver,nlwbands) :: tau_bnd
-      real(r8) :: combined_cld(pcols,pver)
-
-      ! Pointers for pbuf fields
-      real(r8), pointer, dimension(:,:) :: &
-         cld, cldfsnow, &
-         iclwp, iciwp, icswp, mu, lambdac, dei, des, &
-         rel, rei
-
-      ! For MCICA sampling routine
-      integer, parameter :: changeseed = 1
-
-      ! Dimension sizes
-      integer :: ngpt, ncol
-
-      ! Temporary arrays to hold mcica-sampled cloud optics (ngpt,ncol,pver)
-      logical, allocatable :: iscloudy(:,:,:)
-
-      ! Loop variables
-      integer :: icol, ilev_rad, igpt, iband, ilev_cam
-
-      ! Initialize (or reset) output cloud optics object
-      optics_out%tau = 0.0
-
-      ! Set dimension size working variables
-      ngpt = kdist%get_ngpt()
-      ncol = state%ncol
-
-      ! Allocate array to hold subcolumn cloudy flag
-      allocate(iscloudy(ngpt,ncol,pver))
-
-      ! Get fields from pbuf
-      call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cld)
-      call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), cldfsnow)
-      call pbuf_get_field(pbuf, pbuf_get_index('ICLWP'), iclwp)
-      call pbuf_get_field(pbuf, pbuf_get_index('ICIWP'), iciwp)
-      call pbuf_get_field(pbuf, pbuf_get_index('ICSWP'), icswp)
-      call pbuf_get_field(pbuf, pbuf_get_index('DEI'), dei)
-      call pbuf_get_field(pbuf, pbuf_get_index('DES'), des)
-      call pbuf_get_field(pbuf, pbuf_get_index('REI'), rei)
-      call pbuf_get_field(pbuf, pbuf_get_index('LAMBDAC'), lambdac)
-      call pbuf_get_field(pbuf, pbuf_get_index('MU'), mu)
-
-      ! Initialize cloud optics object; cloud_optics_lw will be indexed by
-      ! g-point, rather than by band, and subcolumn routines will associate each
-      ! g-point with a stochastically-sampled cloud state
-      call handle_error(optics_out%alloc_1scl(ncol, nlev_rad, kdist))
-      call optics_out%set_name('longwave cloud optics')
-
-      ! Get cloud optics using CAM routines. This should combine cloud with snow
-      ! optics, if "snow clouds" are being considered
-      call get_cloud_optics_lw( &
-         ncol, cld, cldfsnow, iclwp, iciwp, icswp, &
-         lambdac, mu, dei, des, rei, &
-         tau_bnd &
-      )
-
-      ! Check values
-      call assert_range(tau_bnd, 0._r8, 1e20_r8, &
-                        'set_cloud_optics_lw: tau_bnd')
-
-      ! Send cloud optics to history buffer
-      call output_cloud_optics_lw(state, tau_bnd)
-
-      ! Get cloud and snow fractions, and combine
-      call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cld)
-      call pbuf_get_field(pbuf, pbuf_get_index('CLDFSNOW'), cldfsnow)
-
-      ! Combine cloud and snow fractions for MCICA sampling
-      combined_cld(1:ncol,1:pver) = max(cld(1:ncol,1:pver), &
-                                        cldfsnow(1:ncol,1:pver))
-
-      ! Do MCICA sampling of optics here. This will map bands to gpoints,
-      ! while doing stochastic sampling of cloud state
-      !
-      ! First, just get the stochastic subcolumn cloudy mask...
-      call mcica_subcol_mask(ngpt, ncol, pver, changeseed, &
-                             state%pmid(1:ncol,1:pver), &
-                             combined_cld(1:ncol,1:pver), &
-                             iscloudy(1:ngpt,1:ncol,1:pver))
-
-      ! ... and now map optics to g-points, selecting a single subcolumn for each
-      ! g-point. This implementation generates homogeneous clouds, but it would be
-      ! straightforward to extend this to handle horizontally heterogeneous clouds
-      ! as well.
-      ! NOTE: incoming optics should be in-cloud quantites and not grid-averaged 
-      ! quantities!
-      optics_out%tau = 0
-      do ilev_cam = 1,pver
-
-         ! Get level index on CAM grid (i.e., the index that this rad level
-         ! corresponds to in CAM fields). If this index is above the model top
-         ! (index less than 0) then skip setting the optical properties for this
-         ! level (leave set to zero)
-         ilev_rad = ilev_cam + (nlev_rad - pver)
-
-         do icol = 1,ncol
-            do igpt = 1,ngpt
-               if (iscloudy(igpt,icol,ilev_cam) .and. (combined_cld(icol,ilev_cam) > 0._r8) ) then
-                  iband = kdist%convert_gpt2band(igpt)
-                  optics_out%tau(icol,ilev_rad,igpt) = tau_bnd(icol,ilev_cam,iband)
-               else
-                  optics_out%tau(icol,ilev_rad,igpt) = 0._r8
+                  tau_gpt(icol,ilev,igpt) = 0
+                  ssa_gpt(icol,ilev,igpt) = 1
+                  asm_gpt(icol,ilev,igpt) = 0
                end if
             end do
          end do
       end do
+   end subroutine sample_cloud_optics_sw
 
-      ! Apply delta scaling to account for forward-scattering
-      ! TODO: delta_scale takes the forward scattering fraction as an optional
-      ! parameter. In the current cloud optics_lw scheme, forward scattering is taken
-      ! just as g^2, which delta_scale assumes if forward scattering fraction is
-      ! omitted in the function call. In the future, we should explicitly pass
-      ! this. This just requires modifying the get_cloud_optics_lw procedures to also
-      ! pass the foward scattering fraction that the CAM cloud optics_lw assumes.
-      call handle_error(optics_out%delta_scale())
+   !----------------------------------------------------------------------------
 
-      ! Check values
-      call assert_range(optics_out%tau, 0._r8, 1e20_r8, &
-                        'set_cloud_optics_lw: optics_out%tau')
+   subroutine compress_optics_sw(day_indices, tau, ssa, asm, tau_day, ssa_day, asm_day)
+      integer, intent(in), dimension(:) :: day_indices
+      real(r8), intent(in), dimension(:,:,:) :: tau, ssa, asm
+      real(r8), intent(out), dimension(:,:,:) :: tau_day, ssa_day, asm_day
+      integer :: nday, iday, ilev, ibnd
+      nday = count(day_indices > 0)
+      do ibnd = 1,size(tau,3)
+         do ilev = 1,size(tau,2)
+            do iday = 1,nday
+               tau_day(iday,ilev,ibnd) = tau(day_indices(iday),ilev,ibnd)
+               ssa_day(iday,ilev,ibnd) = ssa(day_indices(iday),ilev,ibnd)
+               asm_day(iday,ilev,ibnd) = asm(day_indices(iday),ilev,ibnd)
+            end do
+         end do
+      end do
+   end subroutine compress_optics_sw
 
-      ! Check cloud optics
-      call handle_error(optics_out%validate())
+   !----------------------------------------------------------------------------
 
-      deallocate(iscloudy)
+   ! Do MCICA sampling of optics here. This will map bands to gpoints,
+   ! while doing stochastic sampling of cloud state
+   subroutine sample_cloud_optics_lw( &
+         ncol, nlev, ngpt, gpt2bnd, &
+         pmid, cld, cldfsnow, &
+         tau_bnd, tau_gpt)
+      use ppgrid, only: pcols, pver
+      use mcica_subcol_gen, only: mcica_subcol_mask
 
-   end subroutine set_cloud_optics_lw
+      integer, intent(in) :: ncol, nlev, ngpt
+      integer, intent(in), dimension(:) :: gpt2bnd
+      real(r8), intent(in), dimension(:,:) :: pmid, cld, cldfsnow
+      real(r8), intent(in), dimension(:,:,:) :: tau_bnd
+      real(r8), intent(out), dimension(:,:,:) :: tau_gpt
+      real(r8) :: combined_cld(ncol,nlev)
+      logical :: iscloudy(ngpt,ncol,nlev)
+
+      ! For MCICA sampling routine
+      integer, parameter :: changeseed = 1
+
+      ! Loop variables
+      integer :: icol, ilev, igpt
+
+      ! Combine cloud and snow fractions for MCICA sampling
+      combined_cld(1:ncol,1:nlev) = max(cld(1:ncol,1:nlev), &
+                                        cldfsnow(1:ncol,1:nlev))
+
+      ! Get the stochastic subcolumn cloudy mask
+      call mcica_subcol_mask(ngpt, ncol, nlev, changeseed, &
+                             pmid(1:ncol,1:nlev), &
+                             combined_cld(1:ncol,1:nlev), &
+                             iscloudy(1:ngpt,1:ncol,1:nlev))
+
+      ! Map optics to g-points, selecting a single subcolumn for each
+      ! g-point. This implementation generates homogeneous clouds, but it would be
+      ! straightforward to extend this to handle horizontally heterogeneous clouds
+      ! as well.
+      do igpt = 1,ngpt
+         do ilev = 1,nlev
+            do icol = 1,ncol
+               if (iscloudy(igpt,icol,ilev)) then
+                  tau_gpt(icol,ilev,igpt) = tau_bnd(icol,ilev,gpt2bnd(igpt))
+               else
+                  tau_gpt(icol,ilev,igpt) = 0
+               end if
+            end do
+         end do
+      end do
+   end subroutine sample_cloud_optics_lw
 
    !----------------------------------------------------------------------------
 
@@ -790,62 +612,6 @@ contains
       end do
 
    end function reordered
-
-   !----------------------------------------------------------------------------
-
-   subroutine output_cloud_optics_sw(state, tau, ssa, asm)
-      use ppgrid, only: pver
-      use physics_types, only: physics_state
-      use cam_history, only: outfld
-      use radconstants, only: idx_sw_diag
-
-      type(physics_state), intent(in) :: state
-      real(r8), intent(in), dimension(:,:,:) :: tau, ssa, asm
-      character(len=*), parameter :: subname = 'output_cloud_optics_sw'
-
-      ! Check values
-      call assert_valid(tau(1:state%ncol,1:pver,1:nswbands), &
-                        trim(subname) // ': optics%optical_depth')
-      call assert_valid(ssa(1:state%ncol,1:pver,1:nswbands), &
-                        trim(subname) // ': optics%single_scattering_albedo')
-      call assert_valid(asm(1:state%ncol,1:pver,1:nswbands), &
-                        trim(subname) // ': optics%assymmetry_parameter')
-
-      ! Send outputs to history buffer
-      call outfld('CLOUD_TAU_SW', &
-                  tau(1:state%ncol,1:pver,1:nswbands), &
-                  state%ncol, state%lchnk)
-      call outfld('CLOUD_SSA_SW', &
-                  ssa(1:state%ncol,1:pver,1:nswbands), &
-                  state%ncol, state%lchnk)
-      call outfld('CLOUD_G_SW', &
-                  asm(1:state%ncol,1:pver,1:nswbands), &
-                  state%ncol, state%lchnk)
-      call outfld('TOT_ICLD_VISTAU', &
-                  tau(1:state%ncol,1:pver,idx_sw_diag), &
-                  state%ncol, state%lchnk)
-   end subroutine output_cloud_optics_sw
-
-   !----------------------------------------------------------------------------
-
-   subroutine output_cloud_optics_lw(state, tau)
-
-      use ppgrid, only: pver
-      use physics_types, only: physics_state
-      use cam_history, only: outfld
-
-      type(physics_state), intent(in) :: state
-      real(r8), intent(in), dimension(:,:,:) :: tau
-
-      ! Check values
-      call assert_valid(tau(1:state%ncol,1:pver,1:nlwbands), 'cld_tau_lw')
-
-      ! Output
-      call outfld('CLOUD_TAU_LW', &
-                  tau(1:state%ncol,1:pver,1:nlwbands), &
-                  state%ncol, state%lchnk)
-
-   end subroutine output_cloud_optics_lw
 
    !----------------------------------------------------------------------------
 

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -4,8 +4,6 @@ module cam_optics
    use assertions, only: assert, assert_valid, assert_range
    use radconstants, only: nswbands, nlwbands
    use rad_constituents, only: icecldoptics, liqcldoptics
-   use ebert_curry, only: ec_ice_optics_sw, ec_ice_optics_lw
-   use slingo, only: slingo_liq_optics_sw, slingo_liq_optics_lw
    use cam_abortutils, only: endrun
    use ppgrid, only: pcols, pver
 
@@ -35,8 +33,9 @@ contains
 
       use ppgrid, only: pcols
       use physics_types, only: physics_state
-      use cloud_rad_props, only: mitchell_ice_optics_sw, &
-                                 gammadist_liq_optics_sw
+      use cloud_rad_props, only: mitchell_ice_optics_sw, gammadist_liq_optics_sw
+      use ebert_curry, only: ec_ice_optics_sw
+      use slingo, only: slingo_liq_optics_sw
 
       integer, intent(in) :: ncol, nlev, nbnd
       real(r8), intent(in), dimension(:,:) :: &
@@ -217,8 +216,9 @@ contains
          tau_out)
 
       use ppgrid, only: pcols
-      use cloud_rad_props, only: gammadist_liq_optics_lw, &
-                                 mitchell_ice_optics_lw
+      use cloud_rad_props, only: gammadist_liq_optics_lw, mitchell_ice_optics_lw
+      use ebert_curry, only: ec_ice_optics_lw
+      use slingo, only: slingo_liq_optics_lw
       use radconstants, only: nlwbands
 
       integer, intent(in) :: ncol, nlev, nbnd

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -384,6 +384,12 @@ contains
 
    !----------------------------------------------------------------------------
 
+   ! Compress optics arrays to smaller arrays containing only daytime columns.
+   ! This is to work with the RRTMGP shortwave routines that will fail if they
+   ! encounter non-sunlit columns, and also allows us to perform less
+   ! computations. This routine is primarily a convenience routine to do all of
+   ! the shortwave optics arrays at once, as we do this for individual arrays
+   ! elsewhere in the code.
    subroutine compress_optics_sw(day_indices, tau, ssa, asm, tau_day, ssa_day, asm_day)
       integer, intent(in), dimension(:) :: day_indices
       real(r8), intent(in), dimension(:,:,:) :: tau, ssa, asm

--- a/components/cam/src/physics/rrtmgp/cloud_rad_props.F90
+++ b/components/cam/src/physics/rrtmgp/cloud_rad_props.F90
@@ -5,15 +5,10 @@ module cloud_rad_props
 
 use shr_kind_mod,     only: r8 => shr_kind_r8
 use ppgrid,           only: pcols, pver, pverp
-use physics_types,    only: physics_state
-use physics_buffer,   only: physics_buffer_desc, pbuf_get_index, pbuf_get_field, pbuf_old_tim_idx
-
-use radconstants,     only: nswbands, nlwbands, idx_sw_diag, ot_length, idx_lw_diag
+use radconstants,     only: nswbands, nlwbands
 use rad_constituents, only: iceopticsfile, liqopticsfile
-
 use interpolate_data, only: interp_type, lininterp_init, lininterp, &
                             extrap_method_bndry, lininterp_finish
-
 use cam_logfile,      only: iulog
 use cam_abortutils,   only: endrun
 
@@ -22,13 +17,11 @@ private
 save
 
 public :: &
-   cloud_rad_props_init,          &
-   get_mitchell_ice_optics_sw,    & ! return Mitchell SW ice radiative properties
-   get_mitchell_ice_optics_lw,    & ! Mitchell LW ice rad props
-   get_gammadist_liq_optics_sw,   & ! return Conley SW rad props
-   get_gammadist_liq_optics_lw,   & ! return Conley LW rad props
-   get_snow_optics_sw,            &
-   get_snow_optics_lw
+   cloud_rad_props_init,    &
+   mitchell_ice_optics_sw,  & ! return Mitchell SW ice radiative properties
+   mitchell_ice_optics_lw,  & ! Mitchell LW ice rad props
+   gammadist_liq_optics_sw, & ! return Conley SW rad props
+   gammadist_liq_optics_lw    ! return Conley LW rad props
 
 integer :: nmu, nlambda
 real(r8), allocatable :: g_mu(:)           ! mu samples on grid
@@ -44,12 +37,6 @@ real(r8), allocatable :: ext_sw_ice(:,:)
 real(r8), allocatable :: ssa_sw_ice(:,:)
 real(r8), allocatable :: asm_sw_ice(:,:)
 real(r8), allocatable :: abs_lw_ice(:,:)
-
-! 
-! indices into pbuf for optical parameters of MG clouds
-! 
-   integer :: i_dei, i_mu, i_lambda, i_iciwp, i_iclwp, i_des, i_icswp
-
 
 !==============================================================================
 contains
@@ -84,27 +71,6 @@ subroutine cloud_rad_props_init()
 
    liquidfile = liqopticsfile 
    icefile = iceopticsfile
-
-   ! Ice effective diameter?
-   i_dei    = pbuf_get_index('DEI',errcode=err)
-
-   ! Snow effective diameter?
-   i_des    = pbuf_get_index('DES',errcode=err)
-
-   ! Shape parameter for droplet distrubtion?
-   i_mu     = pbuf_get_index('MU',errcode=err)
-
-   ! Slope of droplet distribution?
-   i_lambda = pbuf_get_index('LAMBDAC',errcode=err)
-
-   ! In-cloud ice water path
-   i_iciwp  = pbuf_get_index('ICIWP',errcode=err)
-   
-   ! In-cloud liquid water path
-   i_iclwp  = pbuf_get_index('ICLWP',errcode=err)
-
-   ! In-cloud snow water path
-   i_icswp  = pbuf_get_index('ICSWP',errcode=err)
 
    ! read liquid cloud optics
    if(masterproc) then
@@ -267,66 +233,16 @@ end subroutine cloud_rad_props_init
 
 !==============================================================================
 
-subroutine get_mitchell_ice_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
-   type(physics_state), intent(in)   :: state
-   type(physics_buffer_desc),pointer :: pbuf(:)
-
-   ! NOTE: should be nswbands,ncols,pver
-   real(r8),intent(out) :: tau    (nswbands,pcols,pver) ! extinction optical depth
-   real(r8),intent(out) :: tau_w  (nswbands,pcols,pver) ! single scattering albedo * tau
-   real(r8),intent(out) :: tau_w_g(nswbands,pcols,pver) ! assymetry parameter * tau * w
-   real(r8),intent(out) :: tau_w_f(nswbands,pcols,pver) ! forward scattered fraction * tau * w
-
-   real(r8), pointer :: iciwpth(:,:), dei(:,:)
-
-   ! Get relevant pbuf fields, and interpolate optical properties from
-   ! the lookup tables.
-   call pbuf_get_field(pbuf, i_iciwp, iciwpth)
-   call pbuf_get_field(pbuf, i_dei,   dei)
-   call interpolate_ice_optics_sw(state%ncol, iciwpth, dei, tau, tau_w, &
-                                  tau_w_g, tau_w_f)
-
-end subroutine get_mitchell_ice_optics_sw
-
-!==============================================================================
-
-subroutine get_mitchell_ice_optics_lw(state, pbuf, abs_od)
-   type(physics_state), intent(in)     :: state
-   type(physics_buffer_desc), pointer  :: pbuf(:)
-   real(r8), intent(out) :: abs_od(nlwbands,pcols,pver)
-
-   real(r8), pointer :: iciwpth(:,:), dei(:,:)
-
-   ! Get relevant pbuf fields, and interpolate optical properties from
-   ! the lookup tables.
-   call pbuf_get_field(pbuf, i_iciwp, iciwpth)
-   call pbuf_get_field(pbuf, i_dei,   dei)
-
-   call interpolate_ice_optics_lw(state%ncol,iciwpth, dei, abs_od)
-
-end subroutine get_mitchell_ice_optics_lw
-
-!==============================================================================
-
-subroutine get_gammadist_liq_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
-   type(physics_state), intent(in)   :: state
-   type(physics_buffer_desc),pointer :: pbuf(:)
-
+subroutine gammadist_liq_optics_sw(ncol, iclwpth, lamc, pgam, tau, tau_w, tau_w_g, tau_w_f)
+   integer, intent(in) :: ncol
+   real(r8), intent(in), dimension(:,:) :: lamc, pgam, iclwpth
    real(r8),intent(out) :: tau    (nswbands,pcols,pver) ! extinction optical depth
    real(r8),intent(out) :: tau_w  (nswbands,pcols,pver) ! single scattering albedo * tau
    real(r8),intent(out) :: tau_w_g(nswbands,pcols,pver) ! asymetry parameter * tau * w
    real(r8),intent(out) :: tau_w_f(nswbands,pcols,pver) ! forward scattered fraction * tau * w
 
-   real(r8), pointer, dimension(:,:) :: lamc, pgam, iclwpth
    real(r8), dimension(pcols,pver) :: kext
-   integer i,k,swband,lchnk,ncol
-
-   lchnk = state%lchnk
-   ncol = state%ncol
-
-   call pbuf_get_field(pbuf, i_lambda,  lamc)
-   call pbuf_get_field(pbuf, i_mu,      pgam)
-   call pbuf_get_field(pbuf, i_iclwp,   iclwpth)
+   integer i,k,swband
 
    do k = 1,pver
       do i = 1,ncol
@@ -342,29 +258,17 @@ subroutine get_gammadist_liq_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f
       enddo
    enddo
 
-end subroutine get_gammadist_liq_optics_sw
+end subroutine gammadist_liq_optics_sw
 
 !==============================================================================
 
-subroutine get_gammadist_liq_optics_lw(state, pbuf, abs_od)
-   type(physics_state), intent(in)    :: state
-   type(physics_buffer_desc),pointer  :: pbuf(:)
+subroutine gammadist_liq_optics_lw(ncol, iclwpth, lamc, pgam, abs_od)
+   integer, intent(in) :: ncol
+   real(r8), intent(in), dimension(:,:) :: lamc, pgam, iclwpth
    real(r8), intent(out) :: abs_od(nlwbands,pcols,pver)
-
-   integer :: lchnk, ncol
-   real(r8), pointer, dimension(:,:) :: lamc, pgam, iclwpth
-
    integer lwband, i, k
 
    abs_od = 0._r8
-
-   lchnk = state%lchnk
-   ncol = state%ncol
-
-   call pbuf_get_field(pbuf, i_lambda,  lamc)
-   call pbuf_get_field(pbuf, i_mu,      pgam)
-   call pbuf_get_field(pbuf, i_iclwp,   iclwpth)
-
    do k = 1,pver
       do i = 1,ncol
          if(lamc(i,k) > 0._r8) then ! This seems to be the clue for no cloud from microphysics formulation
@@ -374,55 +278,11 @@ subroutine get_gammadist_liq_optics_lw(state, pbuf, abs_od)
          endif
       enddo
    enddo
-
-end subroutine get_gammadist_liq_optics_lw
-
-!==============================================================================
-
-subroutine get_snow_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
-   type(physics_state), intent(in)   :: state
-   type(physics_buffer_desc),pointer :: pbuf(:)
-
-   real(r8),intent(out) :: tau    (nswbands,pcols,pver) ! extinction optical depth
-   real(r8),intent(out) :: tau_w  (nswbands,pcols,pver) ! single scattering albedo * tau
-   real(r8),intent(out) :: tau_w_g(nswbands,pcols,pver) ! assymetry parameter * tau * w
-   real(r8),intent(out) :: tau_w_f(nswbands,pcols,pver) ! forward scattered fraction * tau * w
-
-   real(r8), pointer :: icswpth(:,:), des(:,:)
-
-   ! This does the same thing as get_mitchell_ice_optics_sw, except with a different
-   ! water path and effective diameter.
-   call pbuf_get_field(pbuf, i_icswp, icswpth)
-   call pbuf_get_field(pbuf, i_des,   des)
-
-   call interpolate_ice_optics_sw(state%ncol, icswpth, des, tau, tau_w, &
-        tau_w_g, tau_w_f)
-
-end subroutine get_snow_optics_sw   
+end subroutine gammadist_liq_optics_lw
 
 !==============================================================================
 
-subroutine get_snow_optics_lw(state, pbuf, abs_od)
-   type(physics_state), intent(in)    :: state
-   type(physics_buffer_desc), pointer :: pbuf(:)
-   real(r8), intent(out) :: abs_od(nlwbands,pcols,pver)
-
-   real(r8), pointer :: icswpth(:,:), des(:,:)
-
-   ! This does the same thing as ice_cloud_get_rad_props_lw, except with a
-   ! different water path and effective diameter.
-   call pbuf_get_field(pbuf, i_icswp, icswpth)
-   call pbuf_get_field(pbuf, i_des,   des)
-
-   call interpolate_ice_optics_lw(state%ncol,icswpth, des, abs_od)
-
-end subroutine get_snow_optics_lw
-
-!==============================================================================
-! Private methods
-!==============================================================================
-
-subroutine interpolate_ice_optics_sw(ncol, iciwpth, dei, tau, tau_w, &
+subroutine mitchell_ice_optics_sw(ncol, iciwpth, dei, tau, tau_w, &
      tau_w_g, tau_w_f)
 
   integer, intent(in) :: ncol
@@ -469,11 +329,11 @@ subroutine interpolate_ice_optics_sw(ncol, iciwpth, dei, tau, tau_w, &
      enddo
   enddo
 
-end subroutine interpolate_ice_optics_sw
+end subroutine mitchell_ice_optics_sw
 
 !==============================================================================
 
-subroutine interpolate_ice_optics_lw(ncol, iciwpth, dei, abs_od)
+subroutine mitchell_ice_optics_lw(ncol, iciwpth, dei, abs_od)
 
   integer, intent(in) :: ncol
   real(r8), intent(in) :: iciwpth(pcols,pver)
@@ -506,7 +366,7 @@ subroutine interpolate_ice_optics_lw(ncol, iciwpth, dei, abs_od)
      enddo
   enddo
 
-end subroutine interpolate_ice_optics_lw
+end subroutine mitchell_ice_optics_lw
 
 !==============================================================================
 

--- a/components/cam/src/physics/rrtmgp/cloud_rad_props.F90
+++ b/components/cam/src/physics/rrtmgp/cloud_rad_props.F90
@@ -23,10 +23,10 @@ save
 
 public :: &
    cloud_rad_props_init,          &
-   get_ice_optics_sw,             & ! return Mitchell SW ice radiative properties
-   get_ice_optics_lw,             & ! Mitchell LW ice rad props
-   get_liquid_optics_sw,          & ! return Conley SW rad props
-   get_liquid_optics_lw,          & ! return Conley LW rad props
+   get_mitchell_ice_optics_sw,    & ! return Mitchell SW ice radiative properties
+   get_mitchell_ice_optics_lw,    & ! Mitchell LW ice rad props
+   get_gammadist_liq_optics_sw,   & ! return Conley SW rad props
+   get_gammadist_liq_optics_lw,   & ! return Conley LW rad props
    get_snow_optics_sw,            &
    get_snow_optics_lw
 
@@ -267,7 +267,7 @@ end subroutine cloud_rad_props_init
 
 !==============================================================================
 
-subroutine get_ice_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
+subroutine get_mitchell_ice_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
    type(physics_state), intent(in)   :: state
    type(physics_buffer_desc),pointer :: pbuf(:)
 
@@ -286,11 +286,11 @@ subroutine get_ice_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
    call interpolate_ice_optics_sw(state%ncol, iciwpth, dei, tau, tau_w, &
                                   tau_w_g, tau_w_f)
 
-end subroutine get_ice_optics_sw
+end subroutine get_mitchell_ice_optics_sw
 
 !==============================================================================
 
-subroutine get_ice_optics_lw(state, pbuf, abs_od)
+subroutine get_mitchell_ice_optics_lw(state, pbuf, abs_od)
    type(physics_state), intent(in)     :: state
    type(physics_buffer_desc), pointer  :: pbuf(:)
    real(r8), intent(out) :: abs_od(nlwbands,pcols,pver)
@@ -304,11 +304,11 @@ subroutine get_ice_optics_lw(state, pbuf, abs_od)
 
    call interpolate_ice_optics_lw(state%ncol,iciwpth, dei, abs_od)
 
-end subroutine get_ice_optics_lw
+end subroutine get_mitchell_ice_optics_lw
 
 !==============================================================================
 
-subroutine get_liquid_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
+subroutine get_gammadist_liq_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
    type(physics_state), intent(in)   :: state
    type(physics_buffer_desc),pointer :: pbuf(:)
 
@@ -342,11 +342,11 @@ subroutine get_liquid_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
       enddo
    enddo
 
-end subroutine get_liquid_optics_sw
+end subroutine get_gammadist_liq_optics_sw
 
 !==============================================================================
 
-subroutine get_liquid_optics_lw(state, pbuf, abs_od)
+subroutine get_gammadist_liq_optics_lw(state, pbuf, abs_od)
    type(physics_state), intent(in)    :: state
    type(physics_buffer_desc),pointer  :: pbuf(:)
    real(r8), intent(out) :: abs_od(nlwbands,pcols,pver)
@@ -375,7 +375,7 @@ subroutine get_liquid_optics_lw(state, pbuf, abs_od)
       enddo
    enddo
 
-end subroutine get_liquid_optics_lw
+end subroutine get_gammadist_liq_optics_lw
 
 !==============================================================================
 
@@ -390,7 +390,7 @@ subroutine get_snow_optics_sw(state, pbuf, tau, tau_w, tau_w_g, tau_w_f)
 
    real(r8), pointer :: icswpth(:,:), des(:,:)
 
-   ! This does the same thing as get_ice_optics_sw, except with a different
+   ! This does the same thing as get_mitchell_ice_optics_sw, except with a different
    ! water path and effective diameter.
    call pbuf_get_field(pbuf, i_icswp, icswpth)
    call pbuf_get_field(pbuf, i_des,   des)

--- a/components/cam/src/physics/rrtmgp/ebert_curry.F90
+++ b/components/cam/src/physics/rrtmgp/ebert_curry.F90
@@ -1,0 +1,226 @@
+module ebert_curry
+
+   use shr_kind_mod,     only: r8 => shr_kind_r8
+   use ppgrid,           only: pcols, pver
+   use physics_types,    only: physics_state
+   use physics_buffer,   only: physics_buffer_desc, pbuf_get_index, pbuf_get_field, pbuf_old_tim_idx
+   use radconstants,     only: nswbands, nlwbands, get_sw_spectral_boundaries
+
+   implicit none
+   private
+   save
+
+   public :: &
+      ec_rad_props_init, &
+      ec_ice_optics_sw,  &
+      ec_ice_optics_lw
+
+
+   real, public, parameter:: scalefactor = 1._r8 !500._r8/917._r8
+
+   ! indexes into pbuf for optical parameters of MG clouds
+   integer :: iciwp_idx   = 0 
+   integer :: iclwp_idx   = 0 
+   integer :: cld_idx     = 0  
+   integer :: rei_idx     = 0  
+
+contains
+
+   !===========================================================================
+
+   subroutine ec_rad_props_init()
+
+      iciwp_idx  = pbuf_get_index('ICIWP')
+      iclwp_idx  = pbuf_get_index('ICLWP')
+      cld_idx    = pbuf_get_index('CLD')
+      rei_idx    = pbuf_get_index('REI')
+
+      return
+
+   end subroutine ec_rad_props_init
+
+   !===========================================================================
+
+   subroutine ec_ice_optics_sw(state, pbuf, ice_tau, ice_tau_w, ice_tau_w_g, ice_tau_w_f)
+
+      type(physics_state), intent(in) :: state
+      type(physics_buffer_desc), pointer :: pbuf(:)
+
+      real(r8),intent(out) :: ice_tau    (nswbands,pcols,pver) ! extinction optical depth
+      real(r8),intent(out) :: ice_tau_w  (nswbands,pcols,pver) ! single scattering albedo * tau
+      real(r8),intent(out) :: ice_tau_w_g(nswbands,pcols,pver) ! assymetry parameter * tau * w
+      real(r8),intent(out) :: ice_tau_w_f(nswbands,pcols,pver) ! forward scattered fraction * tau * w
+
+      real(r8), pointer, dimension(:,:) :: rei
+      real(r8), pointer, dimension(:,:) :: cldn
+      real(r8), pointer, dimension(:,:) :: tmpptr
+      real(r8), dimension(pcols,pver) :: cicewp
+      real(r8), dimension(nswbands) :: wavmin
+      real(r8), dimension(nswbands) :: wavmax
+
+      ! ice water coefficients (Ebert and Curry,1992, JGR, 97, 3831-3836)
+      real(r8) :: abari(4) = &     ! a coefficient for extinction optical depth
+         (/ 3.448e-03_r8, 3.448e-03_r8,3.448e-03_r8,3.448e-03_r8/)
+      real(r8) :: bbari(4) = &     ! b coefficient for extinction optical depth
+         (/ 2.431_r8    , 2.431_r8    ,2.431_r8    ,2.431_r8    /)
+      real(r8) :: cbari(4) = &     ! c coefficient for single scat albedo
+         (/ 1.00e-05_r8 , 1.10e-04_r8 ,1.861e-02_r8,.46658_r8   /)
+      real(r8) :: dbari(4) = &     ! d coefficient for single scat albedo
+         (/ 0.0_r8      , 1.405e-05_r8,8.328e-04_r8,2.05e-05_r8 /)
+      real(r8) :: ebari(4) = &     ! e coefficient for asymmetry parameter
+         (/ 0.7661_r8   , 0.7730_r8   ,0.794_r8    ,0.9595_r8   /)
+      real(r8) :: fbari(4) = &     ! f coefficient for asymmetry parameter
+         (/ 5.851e-04_r8, 5.665e-04_r8,7.267e-04_r8,1.076e-04_r8/)
+
+      real(r8) :: abarii           ! A coefficient for current spectral band
+      real(r8) :: bbarii           ! B coefficient for current spectral band
+      real(r8) :: cbarii           ! C coefficient for current spectral band
+      real(r8) :: dbarii           ! D coefficient for current spectral band
+      real(r8) :: ebarii           ! E coefficient for current spectral band
+      real(r8) :: fbarii           ! F coefficient for current spectral band
+
+      ! Minimum cloud amount (as a fraction of the grid-box area) to 
+      ! distinguish from clear sky
+      real(r8), parameter :: cldmin = 1.0e-80_r8
+
+      ! Decimal precision of cloud amount (0 -> preserve full resolution;
+      ! 10^-n -> preserve n digits of cloud amount)
+      real(r8), parameter :: cldeps = 0.0_r8
+
+      ! Optical properties for ice are valid only in the range of
+      ! 13 < rei < 130 micron (Ebert and Curry 92)
+      real(r8), parameter :: rei_min = 13._r8
+      real(r8), parameter :: rei_max = 130._r8
+
+      integer :: ns, i, k, indxsl, lchnk, Nday
+      integer :: itim_old
+      real(r8) :: tmp1i, tmp2i, tmp3i, g
+
+      Nday = state%ncol
+      lchnk = state%lchnk
+
+      itim_old = pbuf_old_tim_idx()
+      call pbuf_get_field(pbuf, cld_idx,cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+      call pbuf_get_field(pbuf, rei_idx,rei)
+      call pbuf_get_field(pbuf, iciwp_idx, tmpptr)
+      cicewp(1:pcols,1:pver) =  1000.0_r8*tmpptr(1:pcols,1:pver)
+      
+      call get_sw_spectral_boundaries(wavmin,wavmax,'microns')
+
+      do ns = 1, nswbands
+
+         if(wavmax(ns) <= 0.7_r8) then
+            indxsl = 1
+         else if(wavmax(ns) <= 1.25_r8) then
+            indxsl = 2
+         else if(wavmax(ns) <= 2.38_r8) then
+            indxsl = 3
+         else if(wavmax(ns) > 2.38_r8) then
+            indxsl = 4
+         end if
+
+         abarii = abari(indxsl)
+         bbarii = bbari(indxsl)
+         cbarii = cbari(indxsl)
+         dbarii = dbari(indxsl)
+         ebarii = ebari(indxsl)
+         fbarii = fbari(indxsl)
+
+         do k=1,pver
+            do i=1,Nday
+
+               ! note that optical properties for ice valid only
+               ! in range of 13 > rei > 130 micron (Ebert and Curry 92)
+               if (cldn(i,k) >= cldmin .and. cldn(i,k) >= cldeps) then
+                  tmp1i = abarii + bbarii/max(rei_min,min(scalefactor*rei(i,k),rei_max))
+                  ice_tau(ns,i,k) = cicewp(i,k)*tmp1i
+               else
+                  ice_tau(ns,i,k) = 0.0_r8
+               endif
+
+               tmp2i = 1._r8 - cbarii - dbarii*min(max(rei_min,scalefactor*rei(i,k)),rei_max)
+               tmp3i = fbarii*min(max(rei_min,scalefactor*rei(i,k)),rei_max)
+               ! Do not let single scatter albedo be 1.  Delta-eddington solution
+               ! for non-conservative case has different analytic form from solution
+               ! for conservative case, and raddedmx is written for non-conservative case.
+               ice_tau_w(ns,i,k) = ice_tau(ns,i,k) * min(tmp2i,.999999_r8)
+               g = ebarii + tmp3i
+               ice_tau_w_g(ns,i,k) = ice_tau_w(ns,i,k) * g
+               ice_tau_w_f(ns,i,k) = ice_tau_w(ns,i,k) * g * g
+
+            end do ! End do i=1,Nday
+         end do    ! End do k=1,pver
+      end do ! nswbands
+
+   end subroutine ec_ice_optics_sw
+
+   !===========================================================================
+
+   subroutine ec_ice_optics_lw(state, pbuf, abs_od)
+
+      type(physics_state), intent(in)   :: state
+      type(physics_buffer_desc),pointer :: pbuf(:)
+      real(r8), intent(out) :: abs_od(nlwbands,pcols,pver)
+
+      real(r8) :: gicewp(pcols,pver)
+      real(r8) :: gliqwp(pcols,pver)
+      real(r8) :: cicewp(pcols,pver)
+      real(r8) :: cliqwp(pcols,pver)
+      real(r8) :: ficemr(pcols,pver)
+      real(r8) :: cwp(pcols,pver)
+      real(r8) :: cldtau(pcols,pver)
+
+      real(r8), pointer, dimension(:,:) :: cldn
+      real(r8), pointer, dimension(:,:) :: rei
+      integer :: ncol, itim_old, lwband, i, k, lchnk
+
+      real(r8) :: kabs, kabsi
+
+      real(r8) kabsl                  ! longwave liquid absorption coeff (m**2/g)
+      parameter (kabsl = 0.090361_r8)
+
+      ! Optical properties for ice are valid only in the range of
+      ! 13 < rei < 130 micron (Ebert and Curry 92)
+      real(r8), parameter :: rei_min = 13._r8
+      real(r8), parameter :: rei_max = 130._r8
+
+      real(r8), pointer, dimension(:,:) :: iclwpth, iciwpth
+
+
+      ncol = state%ncol
+      lchnk = state%lchnk
+
+      itim_old  =  pbuf_old_tim_idx()
+      call pbuf_get_field(pbuf, rei_idx,   rei)
+      call pbuf_get_field(pbuf, cld_idx,   cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+      call pbuf_get_field(pbuf, iclwp_idx, iclwpth)
+      call pbuf_get_field(pbuf, iciwp_idx, iciwpth)
+      do k=1,pver
+         do i = 1,ncol
+            cwp(i,k) = 1000.0_r8 *iciwpth(i,k) + 1000.0_r8 *iclwpth(i,k)
+            ficemr(i,k) = 1000.0_r8*iciwpth(i,k)/(max(1.e-18_r8,cwp(i,k)))
+         end do
+      end do
+
+      do k=1,pver
+         do i=1,ncol
+            ! Note from Andrew Conley:
+            !  Optics for RK no longer supported, This is constructed to get
+            !  close to bit for bit.  Otherwise we could simply use ice water path
+            !note that optical properties for ice valid only
+            !in range of 13 > rei > 130 micron (Ebert and Curry 92)
+            kabsi = 0.005_r8 + 1._r8/min(max(rei_min,scalefactor*rei(i,k)),rei_max)
+            kabs =  kabsi*ficemr(i,k) ! kabsl*(1._r8-ficemr(i,k)) + kabsi*ficemr(i,k)
+            cldtau(i,k) = kabs*cwp(i,k)
+         end do
+      end do
+
+      do lwband = 1,nlwbands
+         abs_od(lwband,1:ncol,1:pver)=cldtau(1:ncol,1:pver)
+      enddo
+
+   end subroutine ec_ice_optics_lw
+
+   !===========================================================================
+
+end module ebert_curry

--- a/components/cam/src/physics/rrtmgp/ebert_curry.F90
+++ b/components/cam/src/physics/rrtmgp/ebert_curry.F90
@@ -1,7 +1,6 @@
 module ebert_curry
 
    use shr_kind_mod,     only: r8 => shr_kind_r8
-   use ppgrid,           only: pcols, pver
    use radconstants,     only: nswbands, nlwbands, get_sw_spectral_boundaries
 
    implicit none
@@ -28,16 +27,16 @@ contains
 
    !===========================================================================
 
-   subroutine ec_ice_optics_sw(ncol, cldn, cicewp, rei, ice_tau, ice_tau_w, ice_tau_w_g, ice_tau_w_f)
+   subroutine ec_ice_optics_sw(ncol, nlev, cldn, cicewp, rei, ice_tau, ice_tau_w, ice_tau_w_g, ice_tau_w_f)
 
-      integer, intent(in) :: ncol
+      integer, intent(in) :: ncol, nlev
       real(r8), intent(in), dimension(:,:) :: rei
       real(r8), intent(in), dimension(:,:) :: cldn
       real(r8), intent(in), dimension(:,:) :: cicewp 
-      real(r8),intent(out) :: ice_tau    (nswbands,pcols,pver) ! extinction optical depth
-      real(r8),intent(out) :: ice_tau_w  (nswbands,pcols,pver) ! single scattering albedo * tau
-      real(r8),intent(out) :: ice_tau_w_g(nswbands,pcols,pver) ! assymetry parameter * tau * w
-      real(r8),intent(out) :: ice_tau_w_f(nswbands,pcols,pver) ! forward scattered fraction * tau * w
+      real(r8),intent(out) :: ice_tau    (:,:,:) ! extinction optical depth
+      real(r8),intent(out) :: ice_tau_w  (:,:,:) ! single scattering albedo * tau
+      real(r8),intent(out) :: ice_tau_w_g(:,:,:) ! assymetry parameter * tau * w
+      real(r8),intent(out) :: ice_tau_w_f(:,:,:) ! forward scattered fraction * tau * w
 
       real(r8), dimension(nswbands) :: wavmin
       real(r8), dimension(nswbands) :: wavmax
@@ -100,7 +99,7 @@ contains
          ebarii = ebari(indxsl)
          fbarii = fbari(indxsl)
 
-         do k=1,pver
+         do k=1,nlev
             do i=1,ncol
 
                ! note that optical properties for ice valid only
@@ -123,21 +122,21 @@ contains
                ice_tau_w_f(ns,i,k) = ice_tau_w(ns,i,k) * g * g
 
             end do ! End do i=1,ncol
-         end do    ! End do k=1,pver
+         end do    ! End do k=1,nlev
       end do ! nswbands
 
    end subroutine ec_ice_optics_sw
 
    !===========================================================================
 
-   subroutine ec_ice_optics_lw(ncol, cldn, iclwpth, iciwpth, rei, abs_od)
+   subroutine ec_ice_optics_lw(ncol, nlev, cldn, iclwpth, iciwpth, rei, abs_od)
 
-      integer, intent(in) :: ncol
+      integer, intent(in) :: ncol, nlev
       real(r8), intent(in), dimension(:,:) :: cldn, iclwpth, iciwpth, rei
-      real(r8), intent(out) :: abs_od(nlwbands,pcols,pver)
-      real(r8) :: ficemr(pcols,pver)
-      real(r8) :: cwp(pcols,pver)
-      real(r8) :: cldtau(pcols,pver)
+      real(r8), intent(out) :: abs_od(:,:,:)
+      real(r8) :: ficemr(ncol,nlev)
+      real(r8) :: cwp(ncol,nlev)
+      real(r8) :: cldtau(ncol,nlev)
       integer :: lwband, i, k
       real(r8) :: kabs, kabsi
 
@@ -149,14 +148,14 @@ contains
       real(r8), parameter :: rei_min = 13._r8
       real(r8), parameter :: rei_max = 130._r8
 
-      do k=1,pver
+      do k=1,nlev
          do i = 1,ncol
             cwp(i,k) = 1000.0_r8 *iciwpth(i,k) + 1000.0_r8 *iclwpth(i,k)
             ficemr(i,k) = 1000.0_r8*iciwpth(i,k)/(max(1.e-18_r8,cwp(i,k)))
          end do
       end do
 
-      do k=1,pver
+      do k=1,nlev
          do i=1,ncol
             ! Note from Andrew Conley:
             !  Optics for RK no longer supported, This is constructed to get
@@ -170,7 +169,7 @@ contains
       end do
 
       do lwband = 1,nlwbands
-         abs_od(lwband,1:ncol,1:pver)=cldtau(1:ncol,1:pver)
+         abs_od(lwband,1:ncol,1:nlev)=cldtau(1:ncol,1:nlev)
       enddo
 
    end subroutine ec_ice_optics_lw

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1472,10 +1472,10 @@ contains
       type(ty_fluxes_byband) :: fluxes_allsky_day, fluxes_clrsky_day
 
       ! Temporary heating rates on radiation vertical grid (and daytime only)
-      real(r8), dimension(pcols,nlev_rad) :: qrs_rad, qrsc_rad
+      real(r8), dimension(ncol,nlev_rad) :: qrs_rad, qrsc_rad
 
       ! Albedo for shortwave calculations
-      real(r8), dimension(nswbands,pcols) :: albedo_dir_day, albedo_dif_day
+      real(r8), dimension(nswbands,ncol) :: albedo_dir_day, albedo_dif_day
 
       ! Cloud and aerosol optics
       type(ty_optical_props_2str) :: aer_optics_sw, cld_optics_sw
@@ -1485,15 +1485,15 @@ contains
 
       ! Incoming solar radiation, scaled for solar zenith angle 
       ! and earth-sun distance
-      real(r8) :: solar_irradiance_by_gpt(pcols,nswgpts)
+      real(r8) :: solar_irradiance_by_gpt(ncol,nswgpts)
 
       ! Gathered indicies of day and night columns 
       ! chunk_column_index = day_indices(daylight_column_index)
       integer :: nday, nnight     ! Number of daylight columns
-      integer :: day_indices(pcols), night_indices(pcols)   ! Indicies of daylight coumns
+      integer :: day_indices(ncol), night_indices(ncol)   ! Indicies of daylight coumns
 
       ! Cosine solar zenith angle for daytime columns
-      real(r8) :: coszrs_day(pcols)  ! cosine solar zenith angle
+      real(r8) :: coszrs_day(ncol)  ! cosine solar zenith angle
 
       ! Scaling factor for total sky irradiance; used to account for orbital
       ! eccentricity, and could be used to scale total sky irradiance for different
@@ -1506,10 +1506,10 @@ contains
       ! State fields that are passed into RRTMGP. Some of these may need to
       ! modified from what exist in the physics_state object, i.e. to clip
       ! temperatures to make sure they are within the valid range.
-      real(r8), dimension(pcols,nlev_rad) :: tmid_day, pmid_day
-      real(r8), dimension(pcols,nlev_rad+1) :: pint_day, tint_day
+      real(r8), dimension(ncol,nlev_rad) :: tmid_day, pmid_day
+      real(r8), dimension(ncol,nlev_rad+1) :: pint_day, tint_day
 
-      real(r8), dimension(size(active_gases),pcols,pver) :: gas_vmr_day
+      real(r8), dimension(size(active_gases),ncol,pver) :: gas_vmr_day
       integer :: igas, iday, icol
 
       ! Everybody needs a name
@@ -1753,10 +1753,10 @@ contains
       character(*), parameter :: subroutine_name = 'radiation_driver_lw'
 
       ! Surface emissivity needed for longwave
-      real(r8) :: surface_emissivity(nlwbands,pcols)
+      real(r8) :: surface_emissivity(nlwbands,ncol)
 
       ! Temporary heating rates on radiation vertical grid
-      real(r8), dimension(pcols,nlev_rad) :: qrl_rad, qrlc_rad
+      real(r8), dimension(ncol,nlev_rad) :: qrl_rad, qrlc_rad
 
       ! RRTMGP types
       type(ty_gas_concs) :: gas_concentrations
@@ -1976,6 +1976,7 @@ contains
 
    end subroutine reset_fluxes
 
+   !----------------------------------------------------------------------------
 
    subroutine set_daynight_indices(coszrs, day_indices, night_indices)
       ! Input: cosine of solar zenith angle
@@ -2024,6 +2025,7 @@ contains
 
    end subroutine set_daynight_indices
 
+   !----------------------------------------------------------------------------
 
    ! Subroutine to calculate the solar insolation, accounting for orbital
    ! eccentricity and solar variability
@@ -2045,6 +2047,7 @@ contains
 
    end function get_eccentricity_factor
 
+   !----------------------------------------------------------------------------
 
    ! Get and set cosine of the solar zenith angle for all columns in a physics chuck
    ! based on input physics_state object and timestep. This routine serves mainly
@@ -2093,6 +2096,7 @@ contains
                   coszrs(1:state%ncol), state%ncol, dt)
    end subroutine set_cosine_solar_zenith_angle
 
+   !----------------------------------------------------------------------------
 
    ! Set surface albedos from cam surface exchange object for direct and diffuse
    ! beam radiation. This code was copied from the RRTMG implementation, but moved
@@ -2256,6 +2260,7 @@ contains
 
    end subroutine output_fluxes_sw
 
+   !----------------------------------------------------------------------------
 
    ! Send longwave fluxes and heating rates to history buffer
    subroutine output_fluxes_lw(icall, state, flux_all, flux_clr, qrl, qrlc)
@@ -2325,6 +2330,7 @@ contains
 
    end subroutine output_fluxes_lw
 
+   !----------------------------------------------------------------------------
 
    ! For some reason the RRTMGP flux objects do not include initialization
    ! routines, but rather expect the user to associate the individual fluxes (which
@@ -2368,6 +2374,8 @@ contains
 
    end subroutine initialize_rrtmgp_fluxes
 
+   !----------------------------------------------------------------------------
+
    subroutine free_fluxes(fluxes)
       use mo_fluxes_byband, only: ty_fluxes_byband
       type(ty_fluxes_byband), intent(inout) :: fluxes
@@ -2381,6 +2389,8 @@ contains
       if (associated(fluxes%bnd_flux_dn_dir)) deallocate(fluxes%bnd_flux_dn_dir)
    end subroutine free_fluxes
 
+   !----------------------------------------------------------------------------
+
    subroutine free_optics_sw(optics)
       use mo_optical_props, only: ty_optical_props_2str
       type(ty_optical_props_2str), intent(inout) :: optics
@@ -2390,6 +2400,8 @@ contains
       call optics%finalize()
    end subroutine free_optics_sw
 
+   !----------------------------------------------------------------------------
+
    subroutine free_optics_lw(optics)
       use mo_optical_props, only: ty_optical_props_1scl
       type(ty_optical_props_1scl), intent(inout) :: optics
@@ -2397,6 +2409,7 @@ contains
       call optics%finalize()
    end subroutine free_optics_lw
 
+   !----------------------------------------------------------------------------
 
    subroutine get_gas_vmr(icall, state, pbuf, gas_names, gas_vmr) 
 
@@ -2495,6 +2508,7 @@ contains
 
    end subroutine get_gas_vmr
 
+   !----------------------------------------------------------------------------
 
    subroutine set_gas_concentrations(ncol, gas_names, gas_vmr, gas_concentrations)
       use mo_gas_concentrations, only: ty_gas_concs
@@ -2541,6 +2555,7 @@ contains
 
    end subroutine set_gas_concentrations
 
+   !----------------------------------------------------------------------------
 
    logical function string_in_list(string, list)
       character(len=*), intent(in) :: string
@@ -2560,6 +2575,7 @@ contains
       end do
    end function string_in_list
 
+   !----------------------------------------------------------------------------
 
    subroutine expand_day_fluxes(daytime_fluxes, expanded_fluxes, day_indices)
       use mo_rte_kind, only: wp

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -435,6 +435,8 @@ contains
 
       ! For optics
       use cloud_rad_props, only: cloud_rad_props_init
+      use ebert_curry, only: ec_rad_props_init
+      use slingo, only: slingo_rad_props_init
 
       ! Physics state is going to be needed for perturbation growth tests, but we
       ! have yet to implement this in RRTMGP. It is a vector because at the point
@@ -473,6 +475,8 @@ contains
 
       ! Initialize cloud optics
       call cloud_rad_props_init()
+      call ec_rad_props_init()
+      call slingo_rad_props_init()
 
       ! Initialize output fields for offline driver.
       ! TODO: do we need to keep this functionality? Where is the offline driver?

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1098,12 +1098,6 @@ contains
       ! buffer to be aggregated and written to disk
       use cam_history, only: outfld
 
-      ! CAM optical properties; includes cam_optics_type class for holding optical
-      ! properties, and subroutines to get CAM aerosol and cloud optical properties
-      ! via CAM parameterizations
-      use cam_optics, only: cam_optics_type
-      use physconst, only: cpair, stebol
-
       ! ---------------------------------------------------------------------------
       ! Arguments
       ! ---------------------------------------------------------------------------

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1642,10 +1642,18 @@ contains
 
       ! Calculate heating rates on the DAYTIME columns
       call t_startf('rad_heating_rate_sw')
-      call calculate_heating_rate(fluxes_allsky_day, pint_day(1:nday,1:nlev_rad+1), &
-                                  qrs_rad(1:nday,1:nlev_rad))
-      call calculate_heating_rate(fluxes_clrsky_day, pint_day(1:nday,1:nlev_rad+1), &
-                                  qrsc_rad(1:nday,1:nlev_rad))
+      call calculate_heating_rate(      &
+         fluxes_allsky_day%flux_up,     &
+         fluxes_allsky_day%flux_dn,     &
+         pint_day(1:nday,1:nlev_rad+1), &
+         qrs_rad(1:nday,1:nlev_rad)     &
+      )
+      call calculate_heating_rate(      &
+         fluxes_clrsky_day%flux_up,     &
+         fluxes_clrsky_day%flux_dn,     &
+         pint_day(1:nday,1:nlev_rad+1), &
+         qrsc_rad(1:nday,1:nlev_rad)    &
+      )
       call t_stopf('rad_heating_rate_sw')
 
       ! Expand fluxes from daytime-only arrays to full chunk arrays
@@ -1822,10 +1830,18 @@ contains
       call t_stopf('rad_calculations_lw')
 
       ! Calculate heating rates
-      call calculate_heating_rate(fluxes_allsky, pint(1:ncol,1:nlev_rad+1), &
-                                  qrl_rad(1:ncol,1:nlev_rad))
-      call calculate_heating_rate(fluxes_clrsky, pint(1:ncol,1:nlev_rad+1), &
-                                  qrlc_rad(1:ncol,1:nlev_rad))
+      call calculate_heating_rate(  &
+         fluxes_allsky%flux_up,     &
+         fluxes_allsky%flux_dn,     &
+         pint(1:ncol,1:nlev_rad+1), &
+         qrl_rad(1:ncol,1:nlev_rad) &
+      )
+      call calculate_heating_rate(   &
+         fluxes_clrsky%flux_up,      &
+         fluxes_clrsky%flux_dn,      &
+         pint(1:ncol,1:nlev_rad+1),  &
+         qrlc_rad(1:ncol,1:nlev_rad) &
+      )
 
       ! Map heating rates to CAM columns and levels
       qrl(1:ncol,1:pver) = qrl_rad(1:ncol,ktop:kbot)

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1298,7 +1298,7 @@ contains
       real(r8) :: albedo_diffuse(nswbands,pcols), albedo_diffuse_day(nswbands,pcols)
 
       ! Cloud and aerosol optics
-      type(ty_optical_props_2str) :: aer_optics_sw, cloud_optics_sw
+      type(ty_optical_props_2str) :: aer_optics_sw, cld_optics_sw
 
       ! Gas concentrations
       type(ty_gas_concs) :: gas_concentrations
@@ -1465,19 +1465,19 @@ contains
          cld_tau_bnd, cld_ssa_bnd, cld_asm_bnd, &
          cld_tau_gpt, cld_ssa_gpt, cld_asm_gpt &
       )
-      call handle_error(cloud_optics_sw%alloc_2str(nday, nlev_rad, k_dist_sw, name='shortwave cloud optics'))
-      cloud_optics_sw%tau = 0
-      cloud_optics_sw%ssa = 1
-      cloud_optics_sw%g   = 0
+      call handle_error(cld_optics_sw%alloc_2str(nday, nlev_rad, k_dist_sw, name='shortwave cloud optics'))
+      cld_optics_sw%tau = 0
+      cld_optics_sw%ssa = 1
+      cld_optics_sw%g   = 0
       call compress_optics_sw( &
          day_indices, cld_tau_gpt, cld_ssa_gpt, cld_asm_gpt, &
-         cloud_optics_sw%tau(1:nday,2:nlev_rad,:), &
-         cloud_optics_sw%ssa(1:nday,2:nlev_rad,:), &
-         cloud_optics_sw%g  (1:nday,2:nlev_rad,:)  &
+         cld_optics_sw%tau(1:nday,2:nlev_rad,:), &
+         cld_optics_sw%ssa(1:nday,2:nlev_rad,:), &
+         cld_optics_sw%g  (1:nday,2:nlev_rad,:)  &
       )
       call output_cloud_optics_sw(state, cld_tau_bnd, cld_ssa_bnd, cld_asm_bnd)
       ! Apply delta scaling to account for forward-scattering
-      call handle_error(cloud_optics_sw%delta_scale())
+      call handle_error(cld_optics_sw%delta_scale())
       call t_stopf('shortwave cloud optics')
 
       ! Initialize aerosol optics; passing only the wavenumber bounds for each
@@ -1545,7 +1545,7 @@ contains
                coszrs_day(1:nday), &
                albedo_direct_day(1:nswbands,1:nday), &
                albedo_diffuse_day(1:nswbands,1:nday), &
-               cloud_optics_sw, &
+               cld_optics_sw, &
                fluxes_allsky_day, fluxes_clrsky_day, &
                aer_props=aer_optics_sw, &
                tsi_scaling=tsi_scaling &
@@ -1579,7 +1579,7 @@ contains
       end do
 
       ! Free fluxes and optical properties
-      call free_optics_sw(cloud_optics_sw)
+      call free_optics_sw(cld_optics_sw)
       call free_optics_sw(aer_optics_sw)
       call free_fluxes(fluxes_allsky_day)
       call free_fluxes(fluxes_clrsky_day)
@@ -1701,7 +1701,7 @@ contains
       ! RRTMGP types
       type(ty_gas_concs) :: gas_concentrations
       type(ty_optical_props_1scl) :: aer_optics_lw
-      type(ty_optical_props_1scl) :: cloud_optics_lw
+      type(ty_optical_props_1scl) :: cld_optics_lw
 
       integer :: ncol, icall
 
@@ -1744,8 +1744,8 @@ contains
 
       ! Do longwave cloud optics calculations
       call t_startf('longwave cloud optics')
-      call handle_error(cloud_optics_lw%alloc_1scl(ncol, nlev_rad, k_dist_lw, name='longwave cloud optics'))
-      cloud_optics_lw%tau = 0.0
+      call handle_error(cld_optics_lw%alloc_1scl(ncol, nlev_rad, k_dist_lw, name='longwave cloud optics'))
+      cld_optics_lw%tau = 0.0
       call get_cloud_optics_lw( &
          ncol, pver, nlwbands, cld, cldfsnow, iclwp, iciwp, icswp, &
          lambdac, mu, dei, des, rei, &
@@ -1754,10 +1754,10 @@ contains
       call sample_cloud_optics_lw( &
          ncol, pver, nlwgpts, k_dist_lw%get_gpoint_bands(), &
          state%pmid, cld, cldfsnow, &
-         cld_tau_bnd, cloud_optics_lw%tau(1:ncol,2:nlev_rad,:) &
+         cld_tau_bnd, cld_optics_lw%tau(1:ncol,2:nlev_rad,:) &
       )
       call output_cloud_optics_lw(state, cld_tau_bnd)
-      call handle_error(cloud_optics_lw%delta_scale())
+      call handle_error(cld_optics_lw%delta_scale())
       call t_stopf('longwave cloud optics')
 
       ! Initialize aerosol optics; passing only the wavenumber bounds for each
@@ -1800,7 +1800,7 @@ contains
                pmid(1:ncol,1:nlev_rad), tmid(1:ncol,1:nlev_rad), &
                pint(1:ncol,1:nlev_rad+1), tint(1:ncol,nlev_rad+1), &
                surface_emissivity(1:nlwbands,1:ncol), &
-               cloud_optics_lw, &
+               cld_optics_lw, &
                fluxes_allsky, fluxes_clrsky, &
                aer_props=aer_optics_lw, &
                t_lev=tint(1:ncol,1:nlev_rad+1), &
@@ -1825,7 +1825,7 @@ contains
       end do  ! loop over diagnostic calls
 
       ! Free fluxes and optical properties
-      call free_optics_lw(cloud_optics_lw)
+      call free_optics_lw(cld_optics_lw)
       call free_optics_lw(aer_optics_lw)
 
    end subroutine radiation_driver_lw

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -118,14 +118,12 @@ contains
 
    !-------------------------------------------------------------------------------
 
-   subroutine calculate_heating_rate(fluxes, pint, heating_rate)
+   subroutine calculate_heating_rate(flux_up, flux_dn, pint, heating_rate)
 
       use physconst, only: gravit
-      use mo_fluxes_byband, only: ty_fluxes_byband
 
       ! Inputs
-      type(ty_fluxes_byband), intent(in) :: fluxes
-      real(r8), intent(in) :: pint(:,:)
+      real(r8), intent(in), dimension(:,:) :: flux_up, flux_dn, pint
 
       ! Output heating rate; same size as pint with one fewer vertical level
       real(r8), intent(out) :: heating_rate(:,:)
@@ -137,10 +135,10 @@ contains
       character(len=32) :: subname = 'calculate_heating_rate'
 
       ! Get dimension sizes and make sure arrays conform
-      call assert(size(pint,1) == size(fluxes%flux_up,1), subname // ': sizes do not conform.')
-      call assert(size(pint,2) == size(fluxes%flux_up,2), subname // ': sizes do not conform.')
-      call assert(size(heating_rate,1) == size(fluxes%flux_up,1), subname // ': sizes do not conform.')
-      call assert(size(heating_rate,2) == size(fluxes%flux_up,2)-1, subname // ': sizes do not conform.')
+      call assert(size(pint,1) == size(flux_up,1), subname // ': sizes do not conform.')
+      call assert(size(pint,2) == size(flux_up,2), subname // ': sizes do not conform.')
+      call assert(size(heating_rate,1) == size(flux_up,1), subname // ': sizes do not conform.')
+      call assert(size(heating_rate,2) == size(flux_up,2)-1, subname // ': sizes do not conform.')
 
       ! Loop over levels and calculate heating rates; note that the fluxes *should*
       ! be defined at interfaces, so the loop ktop,kbot and grabbing the current
@@ -160,8 +158,8 @@ contains
       do ilev = 1,size(pint,2)-1
          do icol = 1,size(pint,1)
             heating_rate(icol,ilev) = ( &
-               fluxes%flux_up(icol,ilev+1) - fluxes%flux_up(icol,ilev) - &
-               fluxes%flux_dn(icol,ilev+1) + fluxes%flux_dn(icol,ilev) &
+               flux_up(icol,ilev+1) - flux_up(icol,ilev) - &
+               flux_dn(icol,ilev+1) + flux_dn(icol,ilev) &
             ) * gravit / (pint(icol,ilev+1) - pint(icol,ilev))
          end do
       end do

--- a/components/cam/src/physics/rrtmgp/slingo.F90
+++ b/components/cam/src/physics/rrtmgp/slingo.F90
@@ -1,0 +1,232 @@
+module slingo
+
+   !------------------------------------------------------------------------------------------------
+   !  Implements Slingo Optics for MG/RRTMG for liquid clouds and
+   !  a copy of the old cloud routine for reference
+   !------------------------------------------------------------------------------------------------
+
+   use shr_kind_mod,     only: r8 => shr_kind_r8
+   use ppgrid,           only: pcols, pver
+   use physics_types,    only: physics_state
+   use physics_buffer,   only: physics_buffer_desc, pbuf_get_index, pbuf_get_field, pbuf_old_tim_idx
+   use radconstants,     only: nswbands, nlwbands, get_sw_spectral_boundaries
+
+   implicit none
+   private
+   save
+
+   public :: &
+      slingo_rad_props_init,        &
+      slingo_liq_optics_lw, &
+      slingo_liq_optics_sw
+
+   ! indexes into pbuf for optical parameters of MG clouds
+   integer :: iclwp_idx  = 0 
+   integer :: iciwp_idx  = 0
+   integer :: cld_idx    = 0 
+   integer :: rel_idx  = 0
+   integer :: rei_idx  = 0
+
+contains
+
+   !===========================================================================
+
+   subroutine slingo_rad_props_init()
+
+      iciwp_idx  = pbuf_get_index('ICIWP')
+      iclwp_idx  = pbuf_get_index('ICLWP')
+      cld_idx    = pbuf_get_index('CLD')
+      rel_idx    = pbuf_get_index('REL')
+      rei_idx    = pbuf_get_index('REI')
+
+      return
+
+   end subroutine slingo_rad_props_init
+
+   !===========================================================================
+
+   subroutine slingo_liq_optics_sw(state, pbuf, liq_tau, liq_tau_w, liq_tau_w_g, liq_tau_w_f)
+
+      type(physics_state), intent(in) :: state
+      type(physics_buffer_desc), pointer :: pbuf(:)
+
+      real(r8),intent(out) :: liq_tau    (nswbands,pcols,pver) ! extinction optical depth
+      real(r8),intent(out) :: liq_tau_w  (nswbands,pcols,pver) ! single scattering albedo * tau
+      real(r8),intent(out) :: liq_tau_w_g(nswbands,pcols,pver) ! assymetry parameter * tau * w
+      real(r8),intent(out) :: liq_tau_w_f(nswbands,pcols,pver) ! forward scattered fraction * tau * w
+
+      real(r8), pointer, dimension(:,:) :: rel
+      real(r8), pointer, dimension(:,:) :: cldn
+      real(r8), pointer, dimension(:,:) :: cliqwp 
+      real(r8), dimension(nswbands)     :: wavmin
+      real(r8), dimension(nswbands)     :: wavmax
+
+      ! Minimum cloud amount (as a fraction of the grid-box area) to 
+      ! distinguish from clear sky
+      real(r8), parameter :: cldmin = 1.0e-80_r8
+
+      ! Decimal precision of cloud amount (0 -> preserve full resolution;
+      ! 10^-n -> preserve n digits of cloud amount)
+      real(r8), parameter :: cldeps = 0.0_r8
+
+      ! A. Slingo's data for cloud particle radiative properties (from 'A GCM
+      ! Parameterization for the Shortwave Properties of Water Clouds' JAS
+      ! vol. 46 may 1989 pp 1419-1427)
+      real(r8) :: abarl(4) = &  ! A coefficient for extinction optical depth
+         (/ 2.817e-02_r8, 2.682e-02_r8,2.264e-02_r8,1.281e-02_r8/)
+      real(r8) :: bbarl(4) = &  ! B coefficient for extinction optical depth
+         (/ 1.305_r8    , 1.346_r8    ,1.454_r8    ,1.641_r8    /)
+      real(r8) :: cbarl(4) = &  ! C coefficient for single scat albedo
+         (/-5.62e-08_r8 ,-6.94e-06_r8 ,4.64e-04_r8 ,0.201_r8    /)
+      real(r8) :: dbarl(4) = &  ! D coefficient for single  scat albedo
+         (/ 1.63e-07_r8 , 2.35e-05_r8 ,1.24e-03_r8 ,7.56e-03_r8 /)
+      real(r8) :: ebarl(4) = &  ! E coefficient for asymmetry parameter
+         (/ 0.829_r8    , 0.794_r8    ,0.754_r8    ,0.826_r8    /)
+      real(r8) :: fbarl(4) = &  ! F coefficient for asymmetry parameter
+         (/ 2.482e-03_r8, 4.226e-03_r8,6.560e-03_r8,4.353e-03_r8/)
+
+      real(r8) :: abarli        ! A coefficient for current spectral band
+      real(r8) :: bbarli        ! B coefficient for current spectral band
+      real(r8) :: cbarli        ! C coefficient for current spectral band
+      real(r8) :: dbarli        ! D coefficient for current spectral band
+      real(r8) :: ebarli        ! E coefficient for current spectral band
+      real(r8) :: fbarli        ! F coefficient for current spectral band
+
+      ! Caution... A. Slingo recommends no less than 4.0 micro-meters nor
+      ! greater than 20 micro-meters. Here we set effective radius limits
+      ! for liquid to the range 4.2 < rel < 16 micron (Slingo 89)
+      real(r8), parameter :: rel_min = 4.2_r8
+      real(r8), parameter :: rel_max = 16._r8
+
+      integer :: ns, i, k, indxsl, Nday
+      integer :: i_rel, lchnk, icld, itim_old
+      real(r8) :: tmp1l, tmp2l, tmp3l, g
+      real(r8) :: kext(pcols,pver)
+      real(r8), pointer, dimension(:,:) :: iclwpth
+
+      Nday = state%ncol
+      lchnk = state%lchnk
+
+      itim_old = pbuf_old_tim_idx()
+      call pbuf_get_field(pbuf, cld_idx, cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+      call pbuf_get_field(pbuf, rel_idx, rel)
+      call pbuf_get_field(pbuf, iclwp_idx, cliqwp)
+      
+      call get_sw_spectral_boundaries(wavmin,wavmax,'microns')
+     
+      do ns = 1, nswbands
+         ! Set index for cloud particle properties based on the wavelength,
+         ! according to A. Slingo (1989) equations 1-3:
+         ! Use index 1 (0.25 to 0.69 micrometers) for visible
+         ! Use index 2 (0.69 - 1.19 micrometers) for near-infrared
+         ! Use index 3 (1.19 to 2.38 micrometers) for near-infrared
+         ! Use index 4 (2.38 to 4.00 micrometers) for near-infrared
+         if(wavmax(ns) <= 0.7_r8) then
+            indxsl = 1
+         else if(wavmax(ns) <= 1.25_r8) then
+            indxsl = 2
+         else if(wavmax(ns) <= 2.38_r8) then
+            indxsl = 3
+         else if(wavmax(ns) > 2.38_r8) then
+            indxsl = 4
+         end if
+
+         ! Set cloud extinction optical depth, single scatter albedo,
+         ! asymmetry parameter, and forward scattered fraction:
+         abarli = abarl(indxsl)
+         bbarli = bbarl(indxsl)
+         cbarli = cbarl(indxsl)
+         dbarli = dbarl(indxsl)
+         ebarli = ebarl(indxsl)
+         fbarli = fbarl(indxsl)
+
+         do k=1,pver
+            do i=1,Nday
+
+               ! note that optical properties for liquid valid only
+               ! in range of 4.2 > rel > 16 micron (Slingo 89)
+               if (cldn(i,k) >= cldmin .and. cldn(i,k) >= cldeps) then
+                  tmp1l = abarli + bbarli/min(max(rel_min,rel(i,k)),rel_max)
+                  liq_tau(ns,i,k) = 1000._r8*cliqwp(i,k)*tmp1l
+               else
+                  liq_tau(ns,i,k) = 0.0_r8
+               endif
+
+               tmp2l = 1._r8 - cbarli - dbarli*min(max(rel_min,rel(i,k)),rel_max)
+               tmp3l = fbarli*min(max(rel_min,rel(i,k)),rel_max)
+               ! Do not let single scatter albedo be 1.  Delta-eddington solution
+               ! for non-conservative case has different analytic form from solution
+               ! for conservative case, and raddedmx is written for non-conservative case.
+               liq_tau_w(ns,i,k) = liq_tau(ns,i,k) * min(tmp2l,.999999_r8)
+               g = ebarli + tmp3l
+               liq_tau_w_g(ns,i,k) = liq_tau_w(ns,i,k) * g
+               liq_tau_w_f(ns,i,k) = liq_tau_w(ns,i,k) * g * g
+
+            end do ! End do i=1,Nday
+         end do ! End do k=1,pver
+      end do ! nswbands
+
+   end subroutine slingo_liq_optics_sw
+
+   !===========================================================================
+
+   subroutine slingo_liq_optics_lw(state, pbuf, abs_od)
+
+      type(physics_state), intent(in)  :: state
+      type(physics_buffer_desc),pointer  :: pbuf(:)
+      real(r8), intent(out) :: abs_od(nlwbands,pcols,pver)
+
+      real(r8) :: gicewp(pcols,pver)
+      real(r8) :: gliqwp(pcols,pver)
+      real(r8) :: cicewp(pcols,pver)
+      real(r8) :: cliqwp(pcols,pver)
+      real(r8) :: ficemr(pcols,pver)
+      real(r8) :: cwp(pcols,pver)
+      real(r8) :: cldtau(pcols,pver)
+
+      real(r8), pointer, dimension(:,:) :: cldn
+      real(r8), pointer, dimension(:,:) :: rei
+      integer :: ncol, icld, itim_old, i_rei, lwband, i, k, lchnk 
+
+      real(r8) :: kabs, kabsi
+      real(r8) kabsl                  ! longwave liquid absorption coeff (m**2/g)
+      parameter (kabsl = 0.090361_r8)
+
+      real(r8), pointer, dimension(:,:) :: iclwpth, iciwpth
+
+      ncol=state%ncol
+      lchnk = state%lchnk
+
+      itim_old  =  pbuf_old_tim_idx()
+      call pbuf_get_field(pbuf, rei_idx,   rei)
+      call pbuf_get_field(pbuf, cld_idx,   cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/))
+      call pbuf_get_field(pbuf, iclwp_idx, iclwpth)
+      call pbuf_get_field(pbuf, iciwp_idx, iciwpth)
+      do k=1,pver
+         do i = 1,ncol
+            cwp   (i,k) = 1000.0_r8 * iclwpth(i,k) + 1000.0_r8 * iciwpth(i, k)
+            ficemr(i,k) = 1000.0_r8 * iciwpth(i,k)/(max(1.e-18_r8, cwp(i,k)))
+         end do
+      end do
+
+      do k=1,pver
+         do i=1,ncol
+            ! Note from Andrew Conley:
+            !  Optics for RK no longer supported, This is constructed to get
+            !  close to bit for bit.  Otherwise we could simply use liquid water path
+            !note that optical properties for ice valid only
+            !in range of 13 > rei > 130 micron (Ebert and Curry 92)
+            kabs = kabsl*(1._r8-ficemr(i,k))
+            cldtau(i,k) = kabs*cwp(i,k)
+         end do
+      end do
+
+      do lwband = 1,nlwbands
+         abs_od(lwband,1:ncol,1:pver)=cldtau(1:ncol,1:pver)
+      enddo
+
+   end subroutine slingo_liq_optics_lw
+
+   !===========================================================================
+
+end module slingo


### PR DESCRIPTION
Refactor RRTMGP interface and cloud optics routines to remove deep-rooted dependencies on state and pbuf. This work benefits the MMF GPU port of the RRTMGP interface (by allowing us to call cloud optics routines with CRM arrays) and also the SCREAM effort to rewrite the atmosphere driver infrastructure. Additionally, it improves transparency in the radiation interface, by making it more obvious what fields from pbuf are being used to derived cloud optical properties. Despite extensive refactoring, this is bit-for-bit with the previous version. Also adds a new testmods directory for running RRTMGP with the "old" cloud optics schemes (Ebert and Curry plus Slingo), which are used with the MMF single-moment microphysics configuration.

[BFB]