### PR TITLE
Rework NLDAS to better match existing implementation

### DIFF
--- a/cime/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/datm/cime_config/config_component.xml
@@ -10,13 +10,12 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%NLDAS][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
     <desc option="CRUv7"> CLM CRU NCEP v7 data set </desc>
     <desc option="GSWP3v1"> GSWP3v1 data set </desc>
-    <desc option="NLDAS"> NLDAS data set </desc>
     <desc option="NLDAS2"> NLDAS2 regional 0.125 degree data set over the U.S. (25-53N, 235-293E). WARNING: Garbage data will be produced for runs extending beyond this regional domain. </desc>
     <desc option="CPLHIST"> Coupler hist data set (in this mode, it is strongly recommended that the model domain and the coupler history forcing are on the same domain)</desc>
     <desc option="1PT">single point tower site data set </desc>
@@ -36,13 +35,13 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMNLDAS,CLMNLDAS2,CPLHIST,CORE_IAF_JRA</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMNLDAS2,CPLHIST,CORE_IAF_JRA</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
     <desc>Mode for data atmosphere component.
       CORE2_NYF (CORE2 normal year forcing) are modes used in forcing prognostic ocean/sea-ice components.
-      CLM_QIAN, CLMCRUNCEP, CLMCRUNCEPv7, CLMGSWP3v1, CLMNLDAS, CLMNLDAS2 and CLM1PT are modes using observational data for forcing prognostic land components.
+      CLM_QIAN, CLMCRUNCEP, CLMCRUNCEPv7, CLMGSWP3v1, CLMNLDAS2 and CLM1PT are modes using observational data for forcing prognostic land components.
       WARNING for CLMNLDAS2: This is a regional forcing dataset over the U.S. (25-53N, 235-293E). Garbage data will be produced for runs extending beyond this regional domain. </desc>
     <values match="last">
       <value compset="%NYF">CORE2_NYF</value>
@@ -53,7 +52,6 @@
       <value compset="%CRU">CLMCRUNCEP</value>
       <value compset="%CRUv7">CLMCRUNCEPv7</value>
       <value compset="%GSWP3v1">CLMGSWP3v1</value>
-      <value compset="%NLDAS">CLMNLDAS</value>
       <value compset="%NLDAS2">CLMNLDAS2</value>
       <value compset="%1PT">CLM1PT</value>
       <value compset="%CPLHIST">CPLHIST</value>

--- a/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/cime/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -36,7 +36,6 @@
     CLMCRUNCEP		= Run with the CLM CRU NCEP V4 ( default ) forcing valid from 1900 to 2010 (force CLM)
     CLMCRUNCEPv7 	= Run with the CLM CRU NCEP V7 forcing valid from 1900 to 2010 (force CLM)
     CLMGSWP3v1		= Run with the CLM GSWP3 V1 forcing (force CLM)
-    CLMNLDAS        	= Run with the CLM NLDAS data (force CLM)
     CLMNLDAS2		= Run with the CLM NLDAS2 regional forcing valid from 1980 to 2018 (force CLM)
     CLM1PT		= Run with supplied single point data (force CLM)
     CORE2_NYF		= CORE2 normal year forcing (for forcing POP and CICE)
@@ -97,8 +96,6 @@
     CLMGSWP3v1.Solar
     CLMGSWP3v1.Precip
     CLMGSWP3v1.TPQW
-
-    CLMNLDAS
 
     CLMNLDAS2.Solar
     CLMNLDAS2.Precip
@@ -195,7 +192,6 @@
       <value datm_mode="CLMCRUNCEP$">CLMCRUNCEP.Solar,CLMCRUNCEP.Precip,CLMCRUNCEP.TPQW</value>
       <value datm_mode="CLMCRUNCEPv7">CLMCRUNCEPv7.Solar,CLMCRUNCEPv7.Precip,CLMCRUNCEPv7.TPQW</value>
       <value datm_mode="CLMGSWP3v1">CLMGSWP3v1.Solar,CLMGSWP3v1.Precip,CLMGSWP3v1.TPQW</value>
-      <value datm_mode="CLMNLDAS">CLMNLDAS</value>
       <value datm_mode="CLMNLDAS2">CLMNLDAS2.Solar,CLMNLDAS2.Precip,CLMNLDAS2.TPQW</value>
       <value datm_mode="CORE2_NYF" >CORE2_NYF.GISS,CORE2_NYF.GXGXS,CORE2_NYF.NCEP</value>
       <value datm_mode="CORE2_IAF" >CORE2_IAF.GCGCS.PREC,CORE2_IAF.GISS.LWDN,CORE2_IAF.GISS.SWDN,CORE2_IAF.GISS.SWUP,CORE2_IAF.NCEP.DN10,CORE2_IAF.NCEP.Q_10,CORE2_IAF.NCEP.SLP_,CORE2_IAF.NCEP.T_10,CORE2_IAF.NCEP.U_10,CORE2_IAF.NCEP.V_10,CORE2_IAF.CORE2.ArcFactor</value>
@@ -222,7 +218,6 @@
       <value stream="CLMCRUNCEP\.">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CLMCRUNCEP_V5">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.V5.c140715</value>
       <value stream="CLMGSWP3">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516</value>
-      <value stream="CLMNLDAS">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CLMNLDAS2">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CORE2_NYF">$DIN_LOC_ROOT/atm/datm7/NYF</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">$DIN_LOC_ROOT/atm/datm7/CORE2</value>
@@ -290,7 +285,6 @@
       <value stream="CLMCRUNCEP">domain.lnd.360x720.130305.nc</value>
       <value stream="CLMGSWP3v1">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
       <value stream="CLMGSWP3">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
-      <value stream="CLMNLDAS">domain.lnd.nldas2_0224x0464_c110415.nc</value>
       <value stream="CLMNLDAS2">domain.lnd.0.125nldas2_0.125nldas2.190410.nc</value>
       <value stream="CORE2_NYF.GISS">nyf.giss.T62.051007.nc</value>
       <value stream="CORE2_NYF.GXGXS">nyf.gxgxs.T62.051007.nc</value>
@@ -459,7 +453,6 @@
       <value stream="CLMGSWP3.Solar">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/Solar3Hrly</value>
       <value stream="CLMGSWP3.Precip">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/Precip3Hrly</value>
       <value stream="CLMGSWP3.TPQW">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/TPHWL3Hrly</value>
-      <value stream="CLMNLDAS">$DIN_LOC_ROOT/atm/datm7/NLDAS</value>
       <value stream="CLMNLDAS2.Solar">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/Solar</value>
       <value stream="CLMNLDAS2.Precip">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/Precip</value>
       <value stream="CLMNLDAS2.TPQW">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/TPQWL</value>
@@ -537,7 +530,6 @@
       <value  stream="CLMGSWP3v1.Solar">clmforc.GSWP3.c2011.0.5x0.5.Solr.%ym.nc</value>
       <value  stream="CLMGSWP3v1.Precip">clmforc.GSWP3.c2011.0.5x0.5.Prec.%ym.nc</value>
       <value  stream="CLMGSWP3v1.TPQW">clmforc.GSWP3.c2011.0.5x0.5.TPQWL.%ym.nc</value>
-      <value  stream="CLMNLDAS">clmforc.nldas.%ym.nc</value>
       <value  stream="CLMNLDAS2.Solar">ctsmforc.NLDAS2.0.125d.v1.Solr.%ym.nc</value>
       <value  stream="CLMNLDAS2.Precip">ctsmforc.NLDAS2.0.125d.v1.Prec.%ym.nc</value>
       <value  stream="CLMNLDAS2.TPQW">ctsmforc.NLDAS2.0.125d.v1.TPQWL.%ym.nc</value>
@@ -1890,15 +1882,6 @@
         PSRF     pbot
         FLDS     lwdn
       </value>
-      <value  stream="CLMNLDAS">
-        TBOT     tbot
-        WIND     wind
-        QBOT     shum
-        PSRF     pbot
-        FLDS     lwdn
-        PRECTmms precn
-        FSDS     swdn
-      </value>
       <value  stream="CLMNLDAS2.Solar">
         FSDS swdn
       </value>
@@ -2110,7 +2093,6 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_ALIGN</value>
-      <value stream="CLMNLDAS">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMNLDAS2">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1</value>
@@ -2152,7 +2134,6 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_START</value>
-      <value stream="CLMNLDAS">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMNLDAS2">$DATM_CLMNCEP_YR_START</value>
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.NCEP.DENS.SOFS">2010</value>
@@ -2220,7 +2201,6 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_END  </value>
-      <value stream="CLMNLDAS">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMNLDAS2">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.NCEP.DENS.SOFS">2011</value>

--- a/cime/src/components/data_comps/dlnd/cime_config/config_component.xml
+++ b/cime/src/components/data_comps/dlnd/cime_config/config_component.xml
@@ -30,12 +30,12 @@
 
   <entry id="DLND_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,CLMNLDAS,GLC_CPLHIST,NULL</valid_values>
+    <valid_values>CPLHIST,CLMNLDAS2,GLC_CPLHIST,NULL</valid_values>
     <default_value>NULL</default_value>
     <values match="last">
       <value compset="DLND%NULL">NULL</value>
       <value compset="DLND%LCPL">CPLHIST</value>
-      <value compset="DLND%LCLMR">CLMNLDAS</value>
+      <value compset="DLND%LCLMR">CLMNLDAS2</value>
       <value compset="DLND%SCPL">GLC_CPLHIST</value>
     </values>
     <group>run_component_dlnd</group>

--- a/cime/src/components/data_comps/dlnd/cime_config/namelist_definition_dlnd.xml
+++ b/cime/src/components/data_comps/dlnd/cime_config/namelist_definition_dlnd.xml
@@ -69,7 +69,7 @@
     <values>
       <value dlnd_mode="NULL">NULL</value>
       <value dlnd_mode="^CPLHIST$">lnd.cplhist</value>
-      <value dlnd_mode="CLMNLDAS">clm.nldas</value>
+      <value dlnd_mode="CLMNLDAS2">clm.nldas</value>
       <value dlnd_mode="GLC_CPLHIST">sno.cplhist</value>
     </values>
   </entry>
@@ -228,7 +228,7 @@
       <value dlnd_mode="NULL">NULL</value>
       <value dlnd_mode="GLC_CPLHIST">COPYALL</value>
       <value dlnd_mode="CPLHIST">COPYALL</value>
-      <value dlnd_mode="CLMNLDAS">COPYALL</value>
+      <value dlnd_mode="CLMNLDAS2">COPYALL</value>
     </values>
   </entry>
 
@@ -261,7 +261,7 @@
     </desc>
     <values>
       <value>nn</value>
-      <value dlnd_mode="CLMNLDAS">copy</value>
+      <value dlnd_mode="CLMNLDAS2">copy</value>
     </values>
   </entry>
 

--- a/components/clm/cime_config/config_compsets.xml
+++ b/components/clm/cime_config/config_compsets.xml
@@ -230,8 +230,18 @@
    </compset>
 
    <compset>
-     <alias>INLDASCNPECACNTBC</alias>
-     <lname>2000_DATM%NLDAS_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <alias>INLDAS2CNPECACNTBC</alias>
+     <lname>2000_DATM%NLDAS2_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+   </compset>
+
+   <compset>
+     <alias>I2003NLDAS2CNPECACNTBC</alias>
+     <lname>2003_DATM%NLDAS2_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+   </compset>
+
+   <compset>
+     <alias>I2010NLDAS2CNPECACNTBC</alias>
+     <lname>2010_DATM%NLDAS2_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
  
    <compset>
@@ -255,8 +265,8 @@
    </compset>
 
    <compset>
-     <alias>IM20TRNLDASCNPECACNTBC</alias>
-     <lname>20TR_DATM%NLDAS_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+     <alias>IM20TRNLDAS2CNPECACNTBC</alias>
+     <lname>20TR_DATM%NLDAS2_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
    </compset>
 
    <compset>


### PR DESCRIPTION
This PR changes the scripts to get rid of the NLDAS configurations, which offered potential conflicts and confusion with NLDAS2 configurations already available in CIME. The NLDAS2 dataset also covers a longer time period and is more complete. The compsets change from:

- INLDASCNPECACNTBC
  (2000_DATM%NLDAS_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV)
- IM20TRNLDASCNPECACNTBC
  (20TR_DATM%NLDAS_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV)

to:

- INLDAS2CNPECACNTBC
  (2000_DATM%NLDAS2_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV)
- I2003NLDAS2CNPECACNTBC
  (2003_DATM%NLDAS2_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV)
- I2010NLDAS2CNPECACNTBC
  (2010_DATM%NLDAS2_CLM45%CNPECACNTBC_SICE_SOCN_MOSART_SGLC_SWAV)

The MOSART-only compset RMOSARTNLDAS keeps its same name and forcing file. NOTE: this compset is currently broken and is under analysis.

[BFB] for all currently tested configurations