### PR TITLE
Update fields in ocean monthly output

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1006,6 +1006,8 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var name="velocityMeridionalTimesTemperature_GM"/>')
             lines.append('    <var name="normalGMBolusVelocityTimesTemperature"/>')
             lines.append('    <var name="normalGMBolusVelocitySquared"/>')
+            lines.append('    <var name="gmKappaScaling"/>')
+            lines.append('    <var name="gmBolusKappa"/>')
 
         lines.append('    <var_struct name="tracersSurfaceFlux"/>')
         lines.append('    <var name="penetrativeTemperatureFlux"/>')

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -728,6 +728,7 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var name="barotropicSpeed"/>')
         lines.append('    <var name="landIceFreshwaterFlux"/>')
         lines.append('    <var name="pressureAdjustedSSH"/>')
+        lines.append('    <var name="atmosphericPressure"/>')
         if ocn_bgc in ['eco_only', 'eco_and_dms', 'eco_and_macromolecules', 'eco_and_dms_and_macromolecules']:
             lines.append('    <var name="CO2_gas_flux"/>')
             lines.append('    <var name="CO2_alt_gas_flux"/>')
@@ -966,6 +967,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('    <var name="daysSinceStartOfSim"/>')
         lines.append('    <var name="binBoundaryMerHeatTrans"/>')
+        lines.append('    <var name="binBoundaryZonalMean"/>')
         lines.append('    <var name="ssh"/>')
         lines.append('    <var_struct name="tracers"/>')
         lines.append('    <var name="velocityMeridional"/>')
@@ -992,6 +994,8 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var name="dThreshMLD"/>')
         lines.append('    <var name="normalVelocity"/>')
         lines.append('    <var name="vertVelocityTop"/>')
+        lines.append('    <var name="zMid"/>')
+        lines.append('    <var name="atmosphericPressure"/>')
         if not ocn_grid.startswith("oRRS1"):
             lines.append('    <var name="normalGMBolusVelocity"/>')
             lines.append('    <var name="vertGMBolusVelocityTop"/>')
@@ -1067,6 +1071,7 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var name="activeTracerHorAdvectionMLTend"/>')
         lines.append('    <var name="activeTracerVertMixMLTend"/>')
         lines.append('    <var name="activeTracersML"/>')
+        lines.append('    <var name="BruntVaisalaFreqTop"/>')
         lines.append('    <var name="bruntVaisalaFreqML"/>')
         lines.append('    <var name="activeTracersTendML"/>')
         lines.append('    <var_array name="activeTracerVerticalAdvectionTopFlux"/>')


### PR DESCRIPTION
With V2 just around this corner, it is a good time to double-check our variables in the monthly time-averaged output stream.

If all fields in ocean monthly time-averaged file
`mpaso.hist.am.timeSeriesStatsMonthly.$Y-$M-$D.nc`
are compared, then this is non-bit-for-bit.