### PR TITLE
Changing modified CORE runoff files time interpolation to be consistent with standard CORE runoff.

### DIFF
--- a/cime/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/cime/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -533,7 +533,13 @@
     <values>
       <value>linear</value>
       <value stream="rof.diatren_ann_rx1">upper</value>
+      <value stream="rof.diatren_ann_ais00_rx1">upper</value>
+      <value stream="rof.diatren_ann_ais45_rx1">upper</value>
+      <value stream="rof.diatren_ann_ais55_rx1">upper</value>
       <value stream="rof.diatren_iaf_rx1">upper</value>
+      <value stream="rof.diatren_iaf_ais00_rx1">upper</value>
+      <value stream="rof.diatren_iaf_ais45_rx1">upper</value>
+      <value stream="rof.diatren_iaf_ais55_rx1">upper</value>
       <value stream="rof.iaf_jra">upper</value>
       <value stream="rof.cplhist">nearest</value>
     </values>


### PR DESCRIPTION
This adds entries for time interpolation for the modified CORE runoff files used by cryosphere compsets to be 'upper' (from the default 'linear'), to be consistent with the default CORE runoff file.

[non-BFB] For Cryosphere compsets only (G-cases using the 'ISMF' or 'DIB' tags).