### PR TITLE
Provide clear messages about dycore and physgrid.

### DIFF
--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -7825,7 +7825,7 @@
   <grid name="a%ne30np4.pg2_l%.+_oi%oEC60to30">
     <mach name="compy">
       <pes compset=".*CAM5.+CLM45.+MPASSI.+MPASO.+MOSART.+" pesize="XS">
-        <comment> -compset A_WCYCL* -res ne30pg2_oEC* on 11 nodes pure-MPI </comment>
+        <comment> -compset A_WCYCL* -res ne30pg2_oEC* on 11 nodes pure-MPI, ~2.8 sypd </comment>
         <ntasks>
           <ntasks_atm>320</ntasks_atm>
           <ntasks_lnd>80</ntasks_lnd>

--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -7824,6 +7824,33 @@
   </grid>
   <grid name="a%ne30np4.pg2_l%.+_oi%oEC60to30">
     <mach name="compy">
+      <pes compset=".*CAM5.+CLM45.+MPASSI.+MPASO.+MOSART.+" pesize="XS">
+        <comment> -compset A_WCYCL* -res ne30pg2_oEC* on 11 nodes pure-MPI </comment>
+        <ntasks>
+          <ntasks_atm>320</ntasks_atm>
+          <ntasks_lnd>80</ntasks_lnd>
+          <ntasks_rof>80</ntasks_rof>
+          <ntasks_ice>240</ntasks_ice>
+          <ntasks_ocn>120</ntasks_ocn>
+          <ntasks_cpl>320</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>240</rootpe_lnd>
+          <rootpe_rof>240</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>320</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
       <pes compset=".*CAM5.+CLM45.+MPASSI.+MPASO.+MOSART.+" pesize="S">
         <comment> -compset A_WCYCL* -res ne30pg2_oEC* on 21 nodes pure-MPI, ~5.5 sypd </comment>
         <ntasks>

--- a/components/homme/src/share/gllfvremap_mod.F90
+++ b/components/homme/src/share/gllfvremap_mod.F90
@@ -186,6 +186,7 @@ contains
 
     gfr%tolfac = one
     if (par%masterproc) then
+       write(iulog,*) 'gfr> Running with dynamics and physics on separate grids (physgrid).'
        write(iulog, '(a,i3,a,l2,a,i2,a,l2)') 'gfr> init nphys', nphys, ' check', gfr%check, &
             ' ftype', ftype, ' boost_pg1', gfr%boost_pg1
        if (nphys == 1) then

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -1105,10 +1105,26 @@ module namelist_mod
 #endif
 #endif
 
+      call print_clear_message()
 
 !=======================================================================================================!
     endif
 
   end subroutine readnl
+
+  subroutine print_clear_message()
+    ! Those familiar with Homme can deduce dycore and transport type from
+    ! options. But we should provide friendly message for others.
+#if defined MODEL_THETA_L
+    write(iulog,*) 'Running dycore: theta-l'
+#elif defined _PRIM
+    write(iulog,*) 'Running dycore: preqx'
+#endif
+    if (transport_alg == 0) then
+       write(iulog,*) 'Running tracer transport method: horizonatally Eulerian'
+    else
+       write(iulog,*) 'Running tracer transport method: semi-Lagrangian'
+    end if
+  end subroutine print_clear_message
 
 end module namelist_mod


### PR DESCRIPTION
In v2, a fair bit is changing in EAM. Help keep track of these changes by providing clear output of each. Example output:
```
 Running dycore: theta-l
 Running tracer transport method: semi-Lagrangian
... other messages ...
 gfr> Running with dynamics and physics on separate grids (physgrid).
```
In an E3SM run, these messages will appear in atm.log.

Also provide an XS PE layout for the pg2 coupled compset on Compy.

fixes #3493

[BFB]