### PR TITLE
Bug fix for COSP2 MODIS simulator

### DIFF
--- a/components/cam/src/physics/cam/cospsimulator_intr.F90
+++ b/components/cam/src/physics/cam/cospsimulator_intr.F90
@@ -500,7 +500,7 @@ CONTAINS
        lmisr_sim = .true.
     end if
     if (cosp_lmodis_sim) then
-       lmodis_sim = .false.
+       lmodis_sim = .true.
     end if
     
     if (cosp_histfile_aux .and. cosp_histfile_aux_num == -1) then
@@ -512,7 +512,7 @@ CONTAINS
        lparasol_sim = .true.
        lisccp_sim = .true.
        lmisr_sim = .true.
-       lmodis_sim = .false.
+       lmodis_sim = .true.
        cosp_ncolumns = 10
        cosp_nradsteps = 3
     end if
@@ -520,7 +520,7 @@ CONTAINS
     if (cosp_passive) then
        lisccp_sim = .true.
        lmisr_sim = .true.
-       lmodis_sim = .false.
+       lmodis_sim = .true.
        cosp_ncolumns = 10
        cosp_nradsteps = 3
     end if
@@ -545,7 +545,7 @@ CONTAINS
        lparasol_sim = .true.
        lisccp_sim = .true.
        lmisr_sim = .true.
-       lmodis_sim = .false.
+       lmodis_sim = .true.
        lfrac_out = .true.
     end if
     
@@ -560,7 +560,7 @@ CONTAINS
        lparasol_sim = .true.
        lisccp_sim = .true.
        lmisr_sim = .true.
-       lmodis_sim = .false.
+       lmodis_sim = .true.
        cosp_ncolumns = 10
        cosp_nradsteps = 3
     end if
@@ -585,7 +585,7 @@ CONTAINS
           write(iulog,*)'  Enable calipso simulator                   = ', llidar_sim
           write(iulog,*)'  Enable ISCCP simulator                   = ', lisccp_sim
           write(iulog,*)'  Enable MISR simulator                    = ', lmisr_sim
-          write(iulog,*)'  Disable MODIS simulator until a hidden bug fixed (simulated cloud amount too low)     = ', lmodis_sim
+          write(iulog,*)'  Enable MODIS simulator                   = ', lmodis_sim
           write(iulog,*)'  RADAR_SIM microphysics scheme            = ', trim(cloudsat_micro_scheme)
           write(iulog,*)'  Write COSP output to history file        = ', cosp_histfile_num
           write(iulog,*)'  Write COSP input fields                  = ', cosp_histfile_aux

--- a/components/cam/src/physics/cosp2/optics/cosp_optics.F90
+++ b/components/cam/src/physics/cosp2/optics/cosp_optics.F90
@@ -34,7 +34,7 @@ module cosp_optics
   USE COSP_KINDS, ONLY: wp,dp
   USE COSP_MATH_CONSTANTS,  ONLY: pi
   USE COSP_PHYS_CONSTANTS,  ONLY: rholiq,km,rd,grav
-  USE MOD_MODIS_SIM,        ONLY: phaseIsLiquid,phaseIsIce,get_g_nir=>get_g_nir_old,get_ssa_nir=>get_ssa_nir_old
+  USE MOD_MODIS_SIM,        ONLY: phaseIsLiquid,phaseIsIce,get_g_nir,get_ssa_nir
   implicit none
   
   real(wp),parameter ::        & !
@@ -202,14 +202,14 @@ contains
           ! Combine ice, snow and water optical properties
           tau(1:nLevels) = tauICE(j,i,1:nLevels) + tauLIQ(j,i,1:nLevels) + tauSNOW(j,i,1:nLevels)
           where (tau(1:nLevels) > 0) 
-             g(j,i,1:nLevels)  = (tauLIQ(j,i,1:nLevels)*water_g(1:nLevels)  + &
-                                  tauICE(j,i,1:nLevels)*ice_g(1:nLevels)    + &
-                                  tauSNOW(j,i,1:nLevels)*snow_g(1:nLevels)) / & 
+             w0(j,i,1:nLevels) = (tauLIQ(j,i,1:nLevels)*water_w0(1:nLevels)  + &
+                                  tauICE(j,i,1:nLevels)*ice_w0(1:nLevels)    + &
+                                  tauSNOW(j,i,1:nLevels)*snow_w0(1:nLevels)) / & 
                                   tau(1:nLevels) 
-             w0(j,i,1:nLevels) = (tauLIQ(j,i,1:nLevels)*water_g(1:nLevels)*water_w0(1:nLevels) + &
+             g(j,i,1:nLevels)  = (tauLIQ(j,i,1:nLevels)*water_g(1:nLevels)*water_w0(1:nLevels) + &
                                   tauICE(j,i,1:nLevels)*ice_g(1:nLevels)*ice_w0(1:nLevels)    + &
                                   tauSNOW(j,i,1:nLevels)*snow_g(1:nLevels)*snow_w0(1:nLevels)) / &
-                                  (g(j,i,1:nLevels) * tau(1:nLevels))
+                                  (w0(j,i,1:nLevels) * tau(1:nLevels))
           end where
        enddo
     enddo


### PR DESCRIPTION
This is to incorporate bug fix by Dustin Swales for MODIS simulator
in COSP2 as described at https://github.com/ESCOMP/CAM/pull/95.

Issue 1:
From COSP1.4 to COSP2 there was a change in the LUTs used by the particle-size
retrieval within the MODIS simulator, but this change was not accounted for on
the EAM side. This mismatch in LUTs resulted in the retrieval failing more often,
hence the reduction in MODIS total cloud fraction.
Solution 1:
Use the new LUTs in the COSP/EAM interface (cosp2/optics/cosp_optics.F90).

Additionally there was a bug-fix to the MODIS optics in COSP2 that hadn't
yet been propagated into EAM. The implementation of COSP2 in EAM occurred
around the same time when this fix was implemented in COSP2
(and as a patch to COSP1.4)

Issue 2: The combining of the MODIS optical fields, single-scattering
albedo and asymmetry parameter, were incorrect.
Solution 2: Propagate changes in the computation of optical properties into CAM.

[BFB] except for COSP-MODIS diagnostics