### PR TITLE
Update Cades machine file for switch to Slurm

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -470,13 +470,14 @@
          </queues>
    </batch_system>
 
-   <batch_system MACH="cades" type="pbs" >
-         <directives>
-                 <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
-                 <directive>-W group_list=cades-ccsi</directive>
-         </directives>
+   <batch_system MACH="cades" type="slurm" >
+         <submit_args>
+           <arg flag="-A ccsi"/>
+           <arg flag="--mem=128G"/>
+           <arg flag="--ntasks-per-node 32"/>
+         </submit_args>
          <queues>
-           <queue default="true">batch</queue>
+           <queue default="true">burst</queue>
          </queues>
    </batch_system>
 

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2009,7 +2009,7 @@
     <CCSM_CPRNC>/lustre/or-hydra/cades-ccsi/proj-shared/tools/cprnc.orcondo</CCSM_CPRNC>
     <GMAKE_J>4</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
-    <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>yinj -at- ornl.gov</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
@@ -2018,7 +2018,6 @@
       <executable>mpirun</executable>
       <arguments>
         <arg name="num_tasks"> -np {{ total_tasks }}</arg>
-        <arg name="machine_file">--hostfile $ENV{PBS_NODEFILE}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpi-serial">
@@ -2041,9 +2040,9 @@
       </modules>
       <modules>
         <command name="load">mkl/2017</command>
-        <command name="load">/lustre/or-hydra/cades-ccsi/proj-shared/tools/cmake/3.6.1</command>
+        <command name="load">cmake/3.12.0</command>
         <command name="load">python/2.7.12</command>
-        <command name="load">/lustre/or-hydra/cades-ccsi/proj-shared/tools/nco/4.6.4</command>
+        <command name="load">nco/4.6.9</command>
         <command name="load">hdf5-parallel/1.8.17</command>
         <command name="load">netcdf-hdf5parallel/4.3.3.1</command>
         <command name="load">pnetcdf/1.9.0</command>
@@ -2059,6 +2058,10 @@
     <environment_variables compiler="gnu" mpilib="openmpi">
       <env name="PETSC_PATH">/software/user_tools/current/cades-ccsi/petsc4pf/openmpi-1.10-gcc-5.3</env>
     </environment_variables>
+    <environment_variables>
+      <env name="PERL5LIB">/software/user_tools/current/cades-ccsi/perl5/lib/perl5/</env>
+    </environment_variables>
+
   </machine>
 
   <machine MACH="titan">


### PR DESCRIPTION
The ORNL Cades system recently switched to a Slurm scheduling system.
This PR provides the necessary machine file updates and also updates the modules for cmake and nco.
[bfb]