### PR TITLE
Update maint1.2: add 3D varying GM 

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -358,6 +358,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="output"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         if ocn_grid.startswith("oRRS1"):
             lines.append('        io_type="pnetcdf,cdf5"')
         else:
@@ -637,6 +638,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="eddyProductVariablesOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         if ocn_grid.startswith("oRRS1"):
             lines.append('        io_type="pnetcdf,cdf5"')
         else:
@@ -659,6 +661,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="highFrequencyOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.highFrequencyOutput.$Y-$M-$D_$h.$m.$s.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')
@@ -706,6 +709,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="mixedLayerDepthsOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.mixedLayerDepths.$Y-$M-$D.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')
@@ -722,6 +726,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsDailyOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.timeSeriesStatsDaily.$Y-$M-$D.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')
@@ -771,6 +776,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsMonthlyOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         if ocn_grid.startswith("oRRS1"):
             lines.append('        io_type="pnetcdf,cdf5"')
         else:
@@ -963,6 +969,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsClimatologyOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.timeSeriesStatsClimatology.$Y-$M-$D.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')
@@ -976,6 +983,7 @@ def buildnml(case, caseroot, compname):
         lines.append('')
         lines.append('<stream name="timeSeriesStatsCustomOutput"')
         lines.append('        type="output"')
+        lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
         lines.append('        filename_template="mpaso.hist.am.timeSeriesStatsCustom.$Y-$M-$D.nc"')
         lines.append('        filename_interval="00-01-00_00:00:00"')


### PR DESCRIPTION
This update adds the following PRs from MPAS ocean/develop:

-    Adds options for 3d varying GM bolus and 2d varying phase speed https://github.com/MPAS-Dev/MPAS-Model/pull/288
-    Add GM bolus eddy stats https://github.com/MPAS-Dev/MPAS-Model/pull/339
-    Fix threading issue in MPAS-O GM routine https://github.com/MPAS-Dev/MPAS-Model/pull/376
-    compute landIceMask using geometric_features https://github.com/MPAS-Dev/MPAS-Model/pull/447
-    bug fixes for the nonlocal source term in KPP https://github.com/MPAS-Dev/MPAS-Model/pull/305

and from E3SM master:
- Change all ocean output files to single precision #3360

[non-BFB]