### PR TITLE
For NERSC machines, edit directory names to reflect the repo name change from "acme" to "e3sm"

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -55,169 +55,22 @@
    This allows using a different mpirun command to launch unit tests
 
 -->
-<machine MACH="edison">
-  <DESC>NERSC XC30, os is CNL, 24 pes/node, batch system is SLURM</DESC>
-  <NODENAME_REGEX>edison</NODENAME_REGEX>
-  <TESTS>e3sm_developer</TESTS>
-  <COMPILERS>intel,intel18,gnu,gnu7</COMPILERS>
-  <MPILIBS>mpt</MPILIBS>
-  <CIME_OUTPUT_ROOT>$ENV{CSCRATCH}/acme_scratch/edison</CIME_OUTPUT_ROOT>
-  <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
-  <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-  <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-  <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <OS>CNL</OS>
-  <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
-  <SUPPORTED_BY>e3sm</SUPPORTED_BY>
-  <GMAKE_J>3</GMAKE_J>
-  <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
-  <MAX_MPITASKS_PER_NODE>24</MAX_MPITASKS_PER_NODE>
-  <PROJECT>acme</PROJECT>
-  <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-  <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
-  <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-  <BASELINE_ROOT>/project/projectdirs/acme/baselines/$COMPILER</BASELINE_ROOT>
-  <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.edison/cprnc</CCSM_CPRNC>
-  <SAVE_TIMING_DIR>/project/projectdirs/acme</SAVE_TIMING_DIR>
-  <SAVE_TIMING_DIR_PROJECTS>acme,m2830,m2833</SAVE_TIMING_DIR_PROJECTS>
-  <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
-  <mpirun mpilib="default">
-    <executable>srun</executable>
-    <arguments>
-      <arg name="label"> --label</arg>
-      <arg name="num_tasks" > -n $TOTALPES</arg>
-      <arg name="thread_count"> -c $SHELL{echo 48/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
-      <arg name="binding"> $SHELL{if [ 24 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
-    </arguments>
-  </mpirun>
-  <module_system type="module">
-    <init_path lang="perl">/opt/modules/default/init/perl.pm</init_path>
-    <init_path lang="python">/opt/modules/default/init/python.py</init_path>
-    <init_path lang="sh">/opt/modules/default/init/sh</init_path>
-    <init_path lang="csh">/opt/modules/default/init/csh</init_path>
-    <cmd_path lang="perl">/opt/modules/default/bin/modulecmd perl</cmd_path>
-    <cmd_path lang="python">/opt/modules/default/bin/modulecmd python</cmd_path>
-    <cmd_path lang="sh">module</cmd_path>
-    <cmd_path lang="csh">module</cmd_path>
-    <modules>
-      <command name="rm">PrgEnv-intel</command>
-      <command name="rm">PrgEnv-cray</command>
-      <command name="rm">PrgEnv-gnu</command>
-      <command name="rm">intel</command>
-      <command name="rm">cce</command>
-      <command name="rm">gcc</command>
-      <command name="rm">cray-parallel-netcdf</command>
-      <command name="rm">cray-parallel-hdf5</command>
-      <command name="rm">pmi</command>
-      <command name="rm">cray-libsci</command>
-      <command name="rm">cray-mpich2</command>
-      <command name="rm">cray-mpich</command>
-      <command name="rm">cray-netcdf</command>
-      <command name="rm">cray-hdf5</command>
-      <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="rm">craype-sandybridge</command>
-      <command name="rm">craype-ivybridge</command>
-      <command name="rm">craype</command>
-      <command name="rm">papi</command>
-      <command name="rm">cray-petsc</command>
-      <command name="rm">esmf</command>
-    </modules>
-
-    <modules>
-      <command name="rm">craype</command>
-      <command name="load">craype/2.5.12</command>
-      <command name="load">craype-ivybridge</command>
-      <command name="rm">pmi</command>
-      <command name="load">pmi/5.0.12</command>
-      <command name="rm">cray-mpich</command>
-      <command name="load">pe_archive/append-path</command>
-      <command name="load">cray-mpich/7.6.0</command>
-    </modules>
-
-    <modules compiler="intel">
-      <command name="load">PrgEnv-intel/6.0.4</command>
-      <command name="rm">intel</command>
-      <command name="load">intel/17.0.2.174</command>
-      <command name="rm">cray-libsci</command>
-    </modules>
-
-    <modules compiler="intel18">
-      <command name="load">PrgEnv-intel/6.0.4</command>
-      <command name="rm">intel</command>
-      <command name="load">intel/18.0.2.199</command>
-      <command name="rm">cray-libsci</command>
-    </modules>
-
-    <modules compiler="gnu">
-      <command name="rm">PrgEnv-intel</command>
-      <command name="load">PrgEnv-gnu/6.0.4</command>
-      <command name="rm">gcc</command>
-      <command name="load">gcc/6.3.0</command>
-      <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/17.06.1</command>
-    </modules>
-
-    <modules compiler="gnu7">
-      <command name="rm">PrgEnv-intel</command>
-      <command name="load">PrgEnv-gnu/6.0.4</command>
-      <command name="rm">gcc</command>
-      <command name="load">gcc/7.3.0</command>
-      <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/18.03.1</command>
-    </modules>
-
-    <modules mpilib="mpi-serial">
-      <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="rm">cray-hdf5-parallel</command>
-      <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-netcdf/4.4.1.1.6</command>
-      <command name="load">cray-hdf5/1.10.1.1</command>
-    </modules>
-    <modules mpilib="!mpi-serial">
-      <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-      <command name="load">cray-hdf5-parallel/1.10.1.1</command>
-      <command name="load">cray-parallel-netcdf/1.8.1.3</command>
-    </modules>
-  </module_system>
-
-  <environment_variables>
-    <env name="MPICH_ENV_DISPLAY">1</env>
-    <env name="MPICH_VERSION_DISPLAY">1</env>
-    <env name="MPICH_CPUMASK_DISPLAY">1</env>
-
-    <env name="OMP_STACKSIZE">64M</env>
-    <env name="OMP_PROC_BIND">spread</env>
-    <env name="OMP_PLACES">threads</env>
-
-    <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
-    <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
-  </environment_variables>
-  <environment_variables compiler="intel">
-    <env name="FORT_BUFFERED">yes</env>
-  </environment_variables>
-  <environment_variables compiler="intel18">
-    <env name="FORT_BUFFERED">yes</env>
-  </environment_variables>
-
-</machine>
-
 <machine MACH="cori-haswell">
   <DESC>Cori. XC40 Cray system at NERSC. Haswell partition. os is CNL, 32 pes/node, batch system is SLURM</DESC>
   <NODENAME_REGEX>cori-knl-is-default</NODENAME_REGEX>
   <TESTS>e3sm_developer</TESTS>
   <COMPILERS>intel,gnu</COMPILERS>
   <MPILIBS>mpt</MPILIBS>
-  <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/cori-haswell</CIME_OUTPUT_ROOT>
+  <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-haswell</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-  <DIN_LOC_ROOT>/global/cfs/cdirs/acme/inputdata</DIN_LOC_ROOT>
-  <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+  <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
+  <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <BASELINE_ROOT>/global/cfs/cdirs/acme/baselines/$COMPILER</BASELINE_ROOT>
-  <CCSM_CPRNC>/global/cfs/cdirs/acme/tools/cprnc.cori/cprnc</CCSM_CPRNC>
-  <SAVE_TIMING_DIR>/global/cfs/cdirs/acme</SAVE_TIMING_DIR>
+  <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+  <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+  <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
   <SAVE_TIMING_DIR_PROJECTS>e3sm,acme,m2830,m2833</SAVE_TIMING_DIR_PROJECTS>
   <OS>CNL</OS>
   <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
@@ -355,16 +208,16 @@
   <TESTS>e3sm_developer</TESTS>
   <COMPILERS>intel,gnu</COMPILERS>
   <MPILIBS>mpt,impi</MPILIBS>
-  <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/cori-knl</CIME_OUTPUT_ROOT>
+  <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-knl</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-  <DIN_LOC_ROOT>/global/cfs/cdirs/acme/inputdata</DIN_LOC_ROOT>
-  <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+  <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
+  <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
   <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-  <CCSM_CPRNC>/global/cfs/cdirs/acme/tools/cprnc.cori/cprnc</CCSM_CPRNC>
-  <SAVE_TIMING_DIR>/global/cfs/cdirs/acme</SAVE_TIMING_DIR>
+  <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+  <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
   <SAVE_TIMING_DIR_PROJECTS>e3sm,acme,m2830,m2833</SAVE_TIMING_DIR_PROJECTS>
   <OS>CNL</OS>
   <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>


### PR DESCRIPTION
For NERSC machines, edit directory names to reflect the repo name change from "acme" to "e3sm".
Also remove the machine entry for edison as it is retired.

[bfb]