### PR TITLE
CIME: make buildlib return a cmake string for cmake build

### DIFF
--- a/cime/scripts/lib/CIME/build.py
+++ b/cime/scripts/lib/CIME/build.py
@@ -169,6 +169,8 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
         if not os.path.exists(build_dir):
             os.makedirs(build_dir)
 
+    # Components-specific cmake args
+    cmp_cmake_args = ""
     for model, _, _, _, config_dir in complist:
         if buildlist is not None and model.lower() not in buildlist:
             continue
@@ -177,7 +179,7 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
         if model == "cpl":
             config_dir = os.path.join(cimeroot, "src", "drivers", comp_interface, "cime_config")
 
-        _create_build_metadata_for_component(config_dir, libroot, bldroot, case)
+        cmp_cmake_args += _create_build_metadata_for_component(config_dir, libroot, bldroot, case)
 
     # Call CMake
     cmake_args = get_standard_cmake_args(case, sharedpath)
@@ -187,7 +189,12 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
         cmake_args += " -GNinja "
         cmake_env += "PATH={}:$PATH ".format(ninja_path)
 
-    cmake_cmd = "{}cmake {} {}/components".format(cmake_env, cmake_args, srcroot)
+    # Glue all pieces together:
+    #  - cmake environment
+    #  - common (i.e. project-wide) cmake args
+    #  - component-specific cmake args
+    #  - path to src folder
+    cmake_cmd = "{}cmake {} {} {}/components".format(cmake_env, cmake_args, cmp_cmake_args, srcroot)
     stat = 0
     if dry_run:
         logger.info("CMake cmd:\ncd {} && {}\n\n".format(bldroot, cmake_cmd))
@@ -433,7 +440,8 @@ def _create_build_metadata_for_component(config_dir, libroot, bldroot, case):
     In many cases, the bld/configure script will have already created these.
     """
     buildlib = imp.load_source("buildlib_cmake", os.path.join(config_dir, "buildlib_cmake"))
-    buildlib.buildlib(bldroot, libroot, case)
+    cmake_args = buildlib.buildlib(bldroot, libroot, case)
+    return "" if cmake_args is None else cmake_args
 
 ###############################################################################
 def _clean_impl(case, cleanlist, clean_all, clean_depends):


### PR DESCRIPTION
The string returned by buildlib from buildlib_cmake scripts is intended to contain cmake flags for the current component/lib. In cime's build.py we then append those flags to the standard (i.e., model-wide) cmake args.

This allows each component to do all its specific cmake stuff in their buildlib_cmake file, so that build.py can stay component-agnostic.

Note: on my laptop, cime_tiny and cime_developer pass up until submit. The failure are because some files are not found on the server `https://web.lcrc.anl.gov/public/e3sm/inputdata`. I manually checked, and those files are indeed not present on that server, not sure if that's intended or not.

For instance, the tests outputs look like this:

```
  ERIO.f09_g16.X.marzemino_gnu (Overall: FAIL) details:
    PASS ERIO.f09_g16.X.marzemino_gnu CREATE_NEWCASE
    PASS ERIO.f09_g16.X.marzemino_gnu XML
    PASS ERIO.f09_g16.X.marzemino_gnu SETUP
    PASS ERIO.f09_g16.X.marzemino_gnu SHAREDLIB_BUILD time=45
    PASS ERIO.f09_g16.X.marzemino_gnu MODEL_BUILD time=15
    FAIL ERIO.f09_g16.X.marzemino_gnu SUBMIT
```
I suspect tests will pass on machines that have the e3sm data available, since the mods in this PR should only affect what happens at build time. There is no real tangible change in the configuration of current components/libs, since they all return empty strings. It would be nice to move them to actually produce a cmake config string for cime to digest, though.