### PR TITLE
Use the same compiler for chemistry pre-processor and the model

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -59,6 +59,7 @@ _TESTS = {
             "PET_Ln5.ne4_ne4.FC5AV1C-L.allactive-mach-pet",
             "PEM_Ln5.ne4_ne4.FC5AV1C-L",
             "SMS_D_Ln5.ne4_ne4.FC5AV1C-L.cam-cosplite_nhtfrq5",
+            "SMS_Ln1.ne4_ne4.FC5AV1C-L.cam-chem_pp",
             "ERS_Ld5.ne4_ne4.FC5AV1C-L.cam-rrtmgp",
             "ERS_Ld5.ne4_ne4.FC5AV1C-L.cam-gust_param",
             "REP_Ln5.ne4_ne4.FC5AV1C-L",

--- a/components/cam/bld/perl5lib/Build/ChemPreprocess.pm
+++ b/components/cam/bld/perl5lib/Build/ChemPreprocess.pm
@@ -125,6 +125,11 @@ sub chem_preprocess
 		chmod 0555, "$chem_preprocessor/$chem_proc_exe";
 		if ($print) { print "creating $chem_preprocessor/$chem_proc_exe \n"; }
 	    }
+	} else {
+          my $log_file = "$chem_proc_bld/MAKE.out";
+          open OUT,">> $log_file"  || die "Failed to open $log_file\n";
+          print OUT  "Use pre-built chem-preprocessor: $proc_exe_path\n";
+          close OUT;
 	}
 
 	run_chem_preproc($chem_proc_bld,$proc_exe_path,$chem_mech_infile,$chem_proc_src,$cam_bld);

--- a/components/cam/chem_proc/inputs/pp_linoz_mam4_resus_mom_soag.in
+++ b/components/cam/chem_proc/inputs/pp_linoz_mam4_resus_mom_soag.in
@@ -1,12 +1,3 @@
-BEGSIM
-output_unit_number = 7
-output_file        = linoz_mam4_resus_mom_soag.doc
-procout_path       = ../output/
-src_path           = ../bkend/
-procfiles_path     = ../procfiles/cam/
-sim_dat_path       = ../output/
-sim_dat_filename   = linoz_mam4_resus_mom_soag.dat
-
 Comments
      E3SMv1 DECK chemistry.
 End Comments

--- a/components/cam/chem_proc/src/Makefile
+++ b/components/cam/chem_proc/src/Makefile
@@ -1,6 +1,7 @@
 #-----------------------------------------------------------------------
 # This Makefile is for building MOZART2 Pre-processor
 #------------------------------------------------------------------------
+# 04/04/2020, update to use the same compiler as the model
 
 # Set up special characters
 null  :=
@@ -99,6 +100,11 @@ endif
 #------------------------------------------------------------------------
 #------------------------------------------------------------------------
 
+endif
+
+# use USER_FC (if defined) to overwrite default compiler
+ifneq ($(USER_FC),$(null))
+  COMPILER := $(USER_FC)
 endif
 
 #------------------------------------------------------------------------

--- a/components/cam/chem_proc/src/Makefile
+++ b/components/cam/chem_proc/src/Makefile
@@ -108,63 +108,64 @@ ifneq ($(USER_FC),$(null))
 endif
 
 #------------------------------------------------------------------------
-#------------------------------------------------------------------------
-# set compiler flags ...
-#------------------------------------------------------------------------
-ifeq ($(COMPILER),ifort)
-  FFLAGS      :=  -O2 -c -132 -ftz -g -FR  -I $(OBJ_DIR)
-  ifeq ($(DEBUG),TRUE)
-    FFLAGS    += -CB
-  endif
-endif
-ifeq ($(COMPILER),lf95)
-  ifeq ($(DEBUG),TRUE)
-    FFLAGS    := --nfix --nap --chk --g --npca --nsav --trace --trap -c --mod $(OBJ_DIR) -O
-  else
-    FFLAGS    := --nfix --nap --nchk --ng --npca --nsav --ntrace -c --mod $(OBJ_DIR) -O2
-  endif
-endif
-ifeq ($(COMPILER),pgf90)
-  FFLAGS      := -O2 -c -g -Mfree -module $(OBJ_DIR)
-  ifeq ($(DEBUG),TRUE)
-    FFLAGS    += -C
-  endif
-endif
-ifeq ($(COMPILER),pgf95)
-  FFLAGS      := -O2 -c -g -Mfree -module $(OBJ_DIR)
-  ifeq ($(DEBUG),TRUE)
-    FFLAGS    += -C
-  endif
-endif
-ifeq ($(COMPILER),f90)
-  FFLAGS      := -c -freeform -I $(OBJ_DIR) -O2 $(MACHFLGS)
-endif
-ifeq ($(COMPILER),f95)
-  FFLAGS      := -O4 -c -tune host -arch host -free -module $(OBJ_DIR) -I $(OBJ_DIR)
-endif
-ifeq ($(COMPILER),xlf95)
-  FFLAGS      := -g -c -qarch=auto -qnosave -qfree=f90 -qmoddir=$(OBJ_DIR) -I $(OBJ_DIR) -qstrict -O3
-endif
-ifeq ($(COMPILER),gfortran)
-  FFLAGS      := -g -c -ffree-form -J $(OBJ_DIR)
-endif
-ifeq ($(COMPILER),g95)
-  FFLAGS      := -g -c -ffree-form
-endif
-ifeq ($(COMPILER),ftn)
-  FFLAGS      := -f free
-endif
-
-#------------------------------------------------------------------------
-#------------------------------------------------------------------------
-#------------------------------------------------------------------------
-
 FC := $(COMPILER)
 
 # if compiler is intel, change to ifort
 ifeq ($(COMPILER),intel)
   FC := ifort
 endif
+
+#------------------------------------------------------------------------
+#------------------------------------------------------------------------
+# set compiler flags ...
+#------------------------------------------------------------------------
+ifeq ($(FC),ifort)
+  FFLAGS      :=  -O2 -c -132 -ftz -g -FR  -I $(OBJ_DIR)
+  ifeq ($(DEBUG),TRUE)
+    FFLAGS    += -CB
+  endif
+endif
+ifeq ($(FC),lf95)
+  ifeq ($(DEBUG),TRUE)
+    FFLAGS    := --nfix --nap --chk --g --npca --nsav --trace --trap -c --mod $(OBJ_DIR) -O
+  else
+    FFLAGS    := --nfix --nap --nchk --ng --npca --nsav --ntrace -c --mod $(OBJ_DIR) -O2
+  endif
+endif
+ifeq ($(FC),pgf90)
+  FFLAGS      := -O2 -c -g -Mfree -module $(OBJ_DIR)
+  ifeq ($(DEBUG),TRUE)
+    FFLAGS    += -C
+  endif
+endif
+ifeq ($(FC),pgf95)
+  FFLAGS      := -O2 -c -g -Mfree -module $(OBJ_DIR)
+  ifeq ($(DEBUG),TRUE)
+    FFLAGS    += -C
+  endif
+endif
+ifeq ($(FC),f90)
+  FFLAGS      := -c -freeform -I $(OBJ_DIR) -O2 $(MACHFLGS)
+endif
+ifeq ($(FC),f95)
+  FFLAGS      := -O4 -c -tune host -arch host -free -module $(OBJ_DIR) -I $(OBJ_DIR)
+endif
+ifeq ($(FC),xlf95)
+  FFLAGS      := -g -c -qarch=auto -qnosave -qfree=f90 -qmoddir=$(OBJ_DIR) -I $(OBJ_DIR) -qstrict -O3
+endif
+ifeq ($(FC),gfortran)
+  FFLAGS      := -g -c -ffree-form -J $(OBJ_DIR)
+endif
+ifeq ($(FC),g95)
+  FFLAGS      := -g -c -ffree-form
+endif
+ifeq ($(FC),ftn)
+  FFLAGS      := -f free
+endif
+
+#------------------------------------------------------------------------
+#------------------------------------------------------------------------
+#------------------------------------------------------------------------
 
 #------------------------------------------------------------------------
 # Default rules

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/chem_pp/shell_commands
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/chem_pp/shell_commands
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#Remove exe if chem pp exe (campp) already exists (it ensures that exe is always built)
+/bin/rm -f $CIMEROOT/../components/cam/chem_proc/campp
+
+#Modify campp input file so that it starts from "SPECIES" and creates "chem_inp_tmp" file
+sed -n '/^\s*SPECIES$/,$p' $CIMEROOT/../components/cam/chem_proc/inputs/pp_linoz_mam4_resus_mom_soag.inp >& chem_inp_tmp
+
+#Invoke campp (chem_inp_tmp file is at $CASEROOT and campp exe is at Buildconf/camconf, move back two directories)
+./xmlchange --append CAM_CONFIG_OPTS='-usr_mech_infile ../../chem_inp_tmp'
+

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/chem_pp/shell_commands
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/chem_pp/shell_commands
@@ -3,9 +3,6 @@
 #Remove exe if chem pp exe (campp) already exists (it ensures that exe is always built)
 /bin/rm -f $CIMEROOT/../components/cam/chem_proc/campp
 
-#Modify campp input file so that it starts from "SPECIES" and creates "chem_inp_tmp" file
-sed -n '/^\s*SPECIES$/,$p' $CIMEROOT/../components/cam/chem_proc/inputs/pp_linoz_mam4_resus_mom_soag.inp >& chem_inp_tmp
-
-#Invoke campp (chem_inp_tmp file is at $CASEROOT and campp exe is at Buildconf/camconf, move back two directories)
-./xmlchange --append CAM_CONFIG_OPTS='-usr_mech_infile ../../chem_inp_tmp'
+#Invoke campp (using v1 mechanism file)
+./xmlchange --append CAM_CONFIG_OPTS='-usr_mech_infile $CIMEROOT/../components/cam/chem_proc/inputs/pp_linoz_mam4_resus_mom_soag.in'
 


### PR DESCRIPTION
Following @wlin7 's suggestion, this PR solves the issue https://github.com/E3SM-Project/E3SM/issues/3536 to use the same compiler for the chemistry pre-processor (PP) and the model.

This PR also makes it easier to implement a routine test for the PP.

The tests are successful on both cori and compy. But the log file (MAKE.out) is only saved on compy. Need to add some changes to this PR to save MAKE.out on all machines.