### PR TITLE
template.case.run.sh: improve robustness

### DIFF
--- a/cime/config/e3sm/machines/template.case.run.sh
+++ b/cime/config/e3sm/machines/template.case.run.sh
@@ -13,17 +13,17 @@ cd {{ caseroot }}
 LIBDIR={{ cimeroot }}/scripts/lib
 export PYTHONPATH=$LIBDIR:$PYTHONPATH
 
+# setup environment
+source .env_mach_specific.sh
+
 # get new lid
 lid=$(python -c 'import CIME.utils; print CIME.utils.new_lid()')
 export LID=$lid
 
-# setup environment
-source .env_mach_specific.sh
-
 # Clean/make timing dirs
 RUNDIR=$(./xmlquery RUNDIR --value)
 if [ -e $RUNDIR/timing ]; then
-    /bin/rm $RUNDIR/timing
+    /bin/rm -rf $RUNDIR/timing
 fi
 mkdir -p $RUNDIR/timing/checkpoints
 


### PR DESCRIPTION
Setup environment before doing python stuff in case env is needed
for python.

Removing the timing tree should be recursive.

[BFB]