### PR TITLE
Fix bugs for running E3SM with trop_strat_mam3/mam7

### DIFF
--- a/components/cam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/cam/src/chemistry/modal_aero/aero_model.F90
@@ -232,13 +232,14 @@ contains
        if ( convproc_do_aer ) then 
           do m = 1,gas_pcnst
              call cnst_get_ind( solsym(m), l, abort=.false. )
-             if ( ( history_aerosol ) .and. &
-                  (species_class(l) == spec_class_gas) ) then !RCE - only output WD_xxx and DF_xxx for gases
-                wetdep_name = 'WD_'//trim(solsym(m))
-                depflx_name = 'DF_'//trim(solsym(m)) 
-                nspc = get_het_ndx(solsym(m)) 
-                if (nspc > 0) call add_default( wetdep_name, 1, ' ' )
-                call add_default( depflx_name, 1, ' ' )
+             if ( ( history_aerosol ) .and. (l > 0) ) then
+                if  ( species_class(l) == spec_class_gas ) then !RCE - only output WD_xxx and DF_xxx for gases
+                   wetdep_name = 'WD_'//trim(solsym(m))
+                   depflx_name = 'DF_'//trim(solsym(m)) 
+                   nspc = get_het_ndx(solsym(m)) 
+                   if (nspc > 0) call add_default( wetdep_name, 1, ' ' )
+                   call add_default( depflx_name, 1, ' ' )
+                endif
              endif
           end do ! m = 1,gas_pcnst
        endif

--- a/components/cam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
+++ b/components/cam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
@@ -520,10 +520,8 @@ contains
           ! set the undefined ones to gas, and leave the aerosol ones as is
           if (imozart <= 0) then
              call endrun( '*** modal_aero_initialize_data -- bad imozart' )
-          else if (imozart+gas_pcnst-1 > pcnst) then
-             call endrun( '*** modal_aero_initialize_data -- bad imozart+gas_pcnst-1' )
           end if
-          do i = imozart, imozart+gas_pcnst-1
+          do i = imozart, pcnst
              if (species_class(i) == spec_class_undefined) then
                 species_class(i) = spec_class_gas
              end if

--- a/components/cam/src/chemistry/mozart/mo_neu_wetdep.F90
+++ b/components/cam/src/chemistry/mozart/mo_neu_wetdep.F90
@@ -1339,9 +1339,16 @@ upper_level : &
                    write(*,*) ' '
                  endif
                endif
-               DCA = (RCXA*FCXA*CLOLDPCT)/(RCA*FCA)*DCXA + & 
-                     (RCXB*FCXB*CLNEWPCT)/(RCA*FCA)*DCXB + &
-                     (RAX*FAX*AMCLPCT)/(RCA*FCA)*DAX
+
+               if (RCA > zero) then
+                  DCA = (RCXA*FCXA*CLOLDPCT)/(RCA*FCA)*DCXA + & 
+                        (RCXB*FCXB*CLNEWPCT)/(RCA*FCA)*DCXB + &
+                        (RAX*FAX*AMCLPCT)/(RCA*FCA)*DAX
+               else
+                  DCA = zero
+                  FCA = zero
+               endif
+
              else
                FCA = zero
                DCA = zero

--- a/components/cam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/cam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -424,6 +424,23 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
    ! constituents in these lists is arbitrary.
 
    if (nmodes == MAM3_nmodes) then
+#if (defined RAIN_EVAP_TO_COARSE_AERO)
+      ncnst = 14
+      so4_accum  =  1
+      bc_accum   =  2
+      pom_accum  =  3
+      soa_accum  =  4
+      dst_accum  =  5
+      ncl_accum  =  6
+      num_accum  =  7
+      dst_coarse =  8
+      ncl_coarse =  9
+      so4_coarse =  10
+      bc_coarse  =  11
+      pom_coarse =  12
+      soa_coarse =  13
+      num_coarse =  14
+#else
       ncnst = 11
       so4_accum  =  1
       bc_accum   =  2
@@ -436,6 +453,7 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
       ncl_coarse =  9
       so4_coarse = 10
       num_coarse = 11
+#endif
    else if (nmodes == MAM7_nmodes) then
       ncnst = 15
       so4_accum    =  1

--- a/components/clm/src/biogeochem/DryDepVelocity.F90
+++ b/components/clm/src/biogeochem/DryDepVelocity.F90
@@ -464,18 +464,18 @@ CONTAINS
                   rclx(ispec) = cts + 1._r8/((heff(ispec)/(1.e5_r8*rcls(index_season,wesveg))) + & 
                        (foxd(ispec)/rclo(index_season,wesveg))) 
                   rlux(ispec) = cts + rlu(index_season,wesveg)/(1.e-5_r8*heff(ispec)+foxd(ispec)) 
+                  
+                  !-------------------------------------------------------------------------------------
+                  ! jfl : special case for PAN
+                  !-------------------------------------------------------------------------------------
+                  if( ispec == index_pan .or. ispec == index_xpan ) then
+                     dv_pan =  c0_pan(wesveg) * (1._r8 - exp( -k_pan(wesveg)*(dewm*rs*drat(ispec))*1.e-2_r8 ))
+                     if( dv_pan > 0._r8 .and. index_season /= 4 ) then
+                        rsmx(ispec) = ( 1._r8/dv_pan )
+                     end if
+                  end if
 
                endif
-
-               !-------------------------------------------------------------------------------------
-               ! jfl : special case for PAN
-               !-------------------------------------------------------------------------------------
-               if( ispec == index_pan .or. ispec == index_xpan ) then
-                  dv_pan =  c0_pan(wesveg) * (1._r8 - exp( -k_pan(wesveg)*(dewm*rs*drat(ispec))*1.e-2_r8 ))
-                  if( dv_pan > 0._r8 .and. index_season /= 4 ) then
-                     rsmx(ispec) = ( 1._r8/dv_pan )
-                  end if
-               end if
 
             end do species_loop1
 


### PR DESCRIPTION
Current model can't run with MOZART chemistry (trop_strat_mam3/mam7) as well as MAM3/MAM7 (trop_mam3/trop_mam7). These modifications don't change the results for default configurations (linoz_mam4_resus_mom_soag).

To run E3SM with trop_strat_mam7, one also needs to modify namelist setting for now.

linoz_data_file = ''
linoz_data_path = ''
demott_ice_nuc = .false.
gas_wetdep_method = 'NEU'

For running trop_strat_mam3, one also needs to either modify chem_mech.in or resetting CAM_CONFIG_OPTS (remove resus).

