### PR TITLE
Implement pcols as a runtime option in EAM

### DIFF
--- a/components/cam/bld/config_files/definition.xml
+++ b/components/cam/bld/config_files/definition.xml
@@ -211,7 +211,7 @@ Maximum number of sub-columns in a column (physics data structure).
 </entry>
 <entry id="ppcols" value="FALSE">
 Whether pcols is a compile time parameter. Otherwise it is the default value
-for the runtime parameter phys_chunk_fdim.
+for the runtime parameter phys_chnk_fdim.
 </entry>
 <entry id="cam_exe" value="cam">
 Name of CAM executable.

--- a/components/cam/bld/config_files/definition.xml
+++ b/components/cam/bld/config_files/definition.xml
@@ -209,6 +209,10 @@ Maximum number of columns in a chunk (physics data structure).
 <entry id="psubcols" value="1">
 Maximum number of sub-columns in a column (physics data structure).
 </entry>
+<entry id="ppcols" value="FALSE">
+Whether pcols is a compile time parameter. Otherwise it is the default value
+for the runtime parameter phys_chunk_fdim.
+</entry>
 <entry id="cam_exe" value="cam">
 Name of CAM executable.
 </entry>

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -1294,16 +1294,21 @@ set_horiz_grid("$cfgdir/$horiz_grid_file", $cfg_ref);
 if ($print>=2) { print "Horizontal grid specifier: $hgrid$eol"; }
 
 #-----------------------------------------------------------------------------------------------
-# Maximum number of columns in a chunk.
+# Maximum number of columns in a chunk. If set as an option, then it is a compile-time parameter
+# (ppcols == 'TRUE'). Otherwise, pcols is just the default value for a runtime parameter.
 if (defined $opts{'pcols'}) {
     $cfg_ref->set('pcols', $opts{'pcols'});
+    $cfg_ref->set('ppcols', 'TRUE');
+} else {
+    $cfg_ref->set('ppcols', 'FALSE');
 }
 my $pcols = $cfg_ref->get('pcols');
 
-# Override PCOLS setting if configuring for SCAM
+# Override PCOLS setting if configuring for SCAM. Also make it a compile-time parameter.
 if ($scam eq 'ON') {
     $pcols = 1;
     $cfg_ref->set('pcols', $pcols);
+    $cfg_ref->set('ppcols', 'TRUE');
 }
 
 # Check valid value of pcols
@@ -1863,6 +1868,11 @@ my $nadv = $cfg_ref->get('nadv');
 my $pcols = $cfg_ref->get('pcols');
 my $psubcols = $cfg_ref->get('psubcols');
 $cfg_cppdefs .= " -DPLEV=$nlev -DPCNST=$nadv -DPCOLS=$pcols -DPSUBCOLS=$psubcols";
+
+# PCOLS is a compile-time parameter if set in CAM_CONFIG_OPTS. Otherwise it is a runtime parameter
+# and PCOLS just specifies the default for the runtime parameter.
+my $ppcols = $cfg_ref->get('ppcols');
+if ($ppcols eq 'TRUE') { $cfg_cppdefs .= " -DPPCOLS"; }
 
 # Radiatively active constituent number
 $cfg_cppdefs .= " -DN_RAD_CNST=$max_n_rad_cnst";

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -494,6 +494,28 @@ Default: FALSE
 
 <!-- Coupler between Physics and Dynamics -->
 
+<entry id="phys_chunk_fdim" type="integer"  category="perf_dp_coup"
+       group="cam_inparm" valid_values="">
+The basic data structure for fields in the physics is the chunk. The
+horizontal (column) dimension is factored between the first chunk dimension
+and the number of chunks, with the size of the first dimension influencing
+serial performance (e.g. vectorization or fit into cache) and the
+number of chunks limiting the available MPI and OpenMP parallelism. 
+The number of chunks is always chosen to provide an equal number of chunks
+per computational thread (subject to the constraint that each chunk is
+assigned at least one column). However, the declared size of the first
+dimension is a free parameter, indicating the maximum number of columns
+that can be assigned to a chunk (thus also impacting the total number of
+chunks). This was originally specified at compile-time, based on 
+experiments in the early 2000s indicating that the compilers at the time
+generated more efficient code when the first dimension was known
+at compile time, perhaps for improved alignment in memory layout or improved
+vectorization. This is now exposed as a runtime parameter, and the
+previous compile-time maximum (PCOLS) is simply used to define the default
+value of the runtime variable. Must be greater than or equal to 1.
+Default: PCOLS
+</entry>
+
 <entry id="phys_alltoall" type="integer"  category="perf_dp_coup"
        group="cam_inparm" valid_values="0,1,2,11,12,13">
 Dynamics/physics transpose method for nonlocal load-balance.  0: use

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -494,7 +494,7 @@ Default: FALSE
 
 <!-- Coupler between Physics and Dynamics -->
 
-<entry id="phys_chunk_fdim" type="integer"  category="perf_dp_coup"
+<entry id="phys_chnk_fdim" type="integer"  category="perf_dp_coup"
        group="cam_inparm" valid_values="">
 The basic data structure for fields in the physics is the chunk. The
 horizontal (column) dimension is factored between the first chunk dimension

--- a/components/cam/src/chemistry/aerosol/wetdep.F90
+++ b/components/cam/src/chemistry/aerosol/wetdep.F90
@@ -11,6 +11,7 @@ use ppgrid,       only: pcols, pver
 use physconst,    only: gravit, rair, tmelt
 use phys_control, only: cam_physpkg_is
 use cam_logfile,  only: iulog
+use cam_abortutils, only: endrun
 
 implicit none
 save
@@ -25,6 +26,7 @@ public :: faer_resusp_vs_fprec_evap_mpln
 public :: wetdep_inputs_t
 public :: wetdep_init
 public :: wetdep_inputs_set
+public :: wetdep_inputs_unset
 
 real(r8), parameter :: cmftau = 3600._r8
 real(r8), parameter :: rhoh2o = 1000._r8            ! density of water
@@ -35,14 +37,14 @@ type wetdep_inputs_t
    real(r8), pointer :: qme(:,:) => null()
    real(r8), pointer :: prain(:,:) => null()
    real(r8), pointer :: evapr(:,:) => null()
-   real(r8) :: cldcu(pcols,pver)     ! convective cloud fraction, currently empty
-   real(r8) :: evapc(pcols,pver)     ! Evaporation rate of convective precipitation
-   real(r8) :: cmfdqr(pcols,pver)    ! convective production of rain
-   real(r8) :: conicw(pcols,pver)    ! convective in-cloud water
-   real(r8) :: totcond(pcols, pver)  ! total condensate
-   real(r8) :: cldv(pcols,pver)      ! cloudy volume undergoing wet chem and scavenging
-   real(r8) :: cldvcu(pcols,pver)    ! Convective precipitation area at the top interface of current layer
-   real(r8) :: cldvst(pcols,pver)    ! Stratiform precipitation area at the top interface of current layer 
+   real(r8), allocatable :: cldcu(:,:)  ! convective cloud fraction, currently empty
+   real(r8), allocatable :: evapc(:,:)  ! Evaporation rate of convective precipitation
+   real(r8), allocatable :: cmfdqr(:,:) ! convective production of rain
+   real(r8), allocatable :: conicw(:,:) ! convective in-cloud water
+   real(r8), allocatable :: totcond(:,:)! total condensate
+   real(r8), allocatable :: cldv(:,:)   ! cloudy volume undergoing wet chem and scavenging
+   real(r8), allocatable :: cldvcu(:,:) ! Convective precipitation area at the top interface of current layer
+   real(r8), allocatable :: cldvst(:,:) ! Stratiform precipitation area at the top interface of current layer 
 end type wetdep_inputs_t
 
 integer :: cld_idx             = 0
@@ -122,9 +124,34 @@ subroutine wetdep_inputs_set( state, pbuf, inputs )
   real(r8) :: cldst(pcols,pver)        ! Stratiform cloud fraction
 
   integer :: itim, ncol
+  integer :: ierror
 
   ncol = state%ncol
   itim = pbuf_old_tim_idx()
+
+  allocate (inputs%cldcu(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cldcu')
+
+  allocate (inputs%evapc(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error evapc')
+
+  allocate (inputs%cmfdqr(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cmfdqr')
+
+  allocate (inputs%conicw(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error conicw')
+
+  allocate (inputs%totcond(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error totcond')
+
+  allocate (inputs%cldv(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cldv')
+
+  allocate (inputs%cldvcu(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cldvcu')
+
+  allocate (inputs%cldvst(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cldvst')
 
   call pbuf_get_field(pbuf, cld_idx,         inputs%cldt, start=(/1,1,itim/), kount=(/pcols,pver,1/) )
   call pbuf_get_field(pbuf, qme_idx,         inputs%qme     )
@@ -161,6 +188,25 @@ subroutine wetdep_inputs_set( state, pbuf, inputs )
                 state%ncol )
 
 end subroutine wetdep_inputs_set
+
+!==============================================================================
+! deallocate storage assoicated with wetdep_inputs_t type variable
+!==============================================================================
+subroutine wetdep_inputs_unset(inputs)
+
+  ! args
+  type(wetdep_inputs_t), intent(inout) :: inputs          !! collection of wetdepa inputs
+
+  deallocate(inputs%cldcu)
+  deallocate(inputs%evapc)
+  deallocate(inputs%cmfdqr)
+  deallocate(inputs%conicw)
+  deallocate(inputs%totcond)
+  deallocate(inputs%cldv)
+  deallocate(inputs%cldvcu)
+  deallocate(inputs%cldvst)
+
+end subroutine wetdep_inputs_unset
 
 subroutine clddiag(t, pmid, pdel, cmfdqr, evapc, &
                    cldt, cldcu, cldst, cme, evapr, &

--- a/components/cam/src/chemistry/bulk_aero/aero_model.F90
+++ b/components/cam/src/chemistry/bulk_aero/aero_model.F90
@@ -535,7 +535,8 @@ contains
        pbuf,                                                                    & !Pointer
        ptend                                                                    ) !Intent-out
 
-    use wetdep,        only : wetdepa_v1, wetdep_inputs_set, wetdep_inputs_t
+    use wetdep,        only : wetdepa_v1, wetdep_inputs_set, &
+                              wetdep_inputs_unset, wetdep_inputs_t
     use dust_model,    only : dust_names
     use seasalt_model, only : sslt_names=>seasalt_names
 
@@ -969,6 +970,8 @@ contains
 
        enddo col_loop
     enddo ver_loop
+
+    call wetdep_inputs_unset(dep_inputs)
 
   end subroutine aero_model_surfarea
 

--- a/components/cam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/cam/src/chemistry/modal_aero/aero_model.F90
@@ -1360,7 +1360,8 @@ contains
        ptend                                                                    ) !Intent-out
 
     use modal_aero_deposition, only: set_srf_wetdep
-    use wetdep,                only: wetdepa_v2, wetdep_inputs_set, wetdep_inputs_t
+    use wetdep,                only: wetdepa_v2, wetdep_inputs_set, &
+                                     wetdep_inputs_unset, wetdep_inputs_t
     use modal_aero_data
     use modal_aero_calcsize,   only: modal_aero_calcsize_sub
     use modal_aero_wateruptake,only: modal_aero_wateruptake_dr
@@ -2252,6 +2253,7 @@ do_lphase2_conditional: &
        call t_stopf('ma_convproc')       
     endif
 
+    call wetdep_inputs_unset(dep_inputs)
 
   endsubroutine aero_model_wetdep
 

--- a/components/cam/src/control/camsrfexch.F90
+++ b/components/cam/src/control/camsrfexch.F90
@@ -43,41 +43,41 @@ module camsrfexch
   type cam_out_t 
      integer  :: lchnk               ! chunk index
      integer  :: ncol                ! number of columns in chunk
-     real(r8) :: tbot(pcols)         ! bot level temperature
-     real(r8) :: zbot(pcols)         ! bot level height above surface
-     real(r8) :: ubot(pcols)         ! bot level u wind
-     real(r8) :: vbot(pcols)         ! bot level v wind
-     real(r8) :: qbot(pcols,pcnst)   ! bot level specific humidity
-     real(r8) :: pbot(pcols)         ! bot level pressure
-     real(r8) :: rho(pcols)          ! bot level density	
-     real(r8) :: netsw(pcols)        !	
-     real(r8) :: flwds(pcols)        ! 
-     real(r8) :: precsc(pcols)       !
-     real(r8) :: precsl(pcols)       !
-     real(r8) :: precc(pcols)        ! 
-     real(r8) :: precl(pcols)        ! 
-     real(r8) :: soll(pcols)         ! 
-     real(r8) :: sols(pcols)         ! 
-     real(r8) :: solld(pcols)        !
-     real(r8) :: solsd(pcols)        !
-     real(r8) :: thbot(pcols)        ! 
-     real(r8) :: co2prog(pcols)      ! prognostic co2
-     real(r8) :: co2diag(pcols)      ! diagnostic co2
-     real(r8) :: psl(pcols)
-     real(r8) :: bcphiwet(pcols)     ! wet deposition of hydrophilic black carbon
-     real(r8) :: bcphidry(pcols)     ! dry deposition of hydrophilic black carbon
-     real(r8) :: bcphodry(pcols)     ! dry deposition of hydrophobic black carbon
-     real(r8) :: ocphiwet(pcols)     ! wet deposition of hydrophilic organic carbon
-     real(r8) :: ocphidry(pcols)     ! dry deposition of hydrophilic organic carbon
-     real(r8) :: ocphodry(pcols)     ! dry deposition of hydrophobic organic carbon
-     real(r8) :: dstwet1(pcols)      ! wet deposition of dust (bin1)
-     real(r8) :: dstdry1(pcols)      ! dry deposition of dust (bin1)
-     real(r8) :: dstwet2(pcols)      ! wet deposition of dust (bin2)
-     real(r8) :: dstdry2(pcols)      ! dry deposition of dust (bin2)
-     real(r8) :: dstwet3(pcols)      ! wet deposition of dust (bin3)
-     real(r8) :: dstdry3(pcols)      ! dry deposition of dust (bin3)
-     real(r8) :: dstwet4(pcols)      ! wet deposition of dust (bin4)
-     real(r8) :: dstdry4(pcols)      ! dry deposition of dust (bin4)
+     real(r8), allocatable :: tbot(:)     ! bot level temperature
+     real(r8), allocatable :: zbot(:)     ! bot level height above surface
+     real(r8), allocatable :: ubot(:)     ! bot level u wind
+     real(r8), allocatable :: vbot(:)     ! bot level v wind
+     real(r8), allocatable :: qbot(:,:)   ! bot level specific humidity
+     real(r8), allocatable :: pbot(:)     ! bot level pressure
+     real(r8), allocatable :: rho(:)      ! bot level density	
+     real(r8), allocatable :: netsw(:)    !	
+     real(r8), allocatable :: flwds(:)    ! 
+     real(r8), allocatable :: precsc(:)   !
+     real(r8), allocatable :: precsl(:)   !
+     real(r8), allocatable :: precc(:)    ! 
+     real(r8), allocatable :: precl(:)    ! 
+     real(r8), allocatable :: soll(:)     ! 
+     real(r8), allocatable :: sols(:)     ! 
+     real(r8), allocatable :: solld(:)    !
+     real(r8), allocatable :: solsd(:)    !
+     real(r8), allocatable :: thbot(:)    ! 
+     real(r8), allocatable :: co2prog(:)  ! prognostic co2
+     real(r8), allocatable :: co2diag(:)  ! diagnostic co2
+     real(r8), allocatable :: psl(:)
+     real(r8), allocatable :: bcphiwet(:) ! wet deposition of hydrophilic black carbon
+     real(r8), allocatable :: bcphidry(:) ! dry deposition of hydrophilic black carbon
+     real(r8), allocatable :: bcphodry(:) ! dry deposition of hydrophobic black carbon
+     real(r8), allocatable :: ocphiwet(:) ! wet deposition of hydrophilic organic carbon
+     real(r8), allocatable :: ocphidry(:) ! dry deposition of hydrophilic organic carbon
+     real(r8), allocatable :: ocphodry(:) ! dry deposition of hydrophobic organic carbon
+     real(r8), allocatable :: dstwet1(:)  ! wet deposition of dust (bin1)
+     real(r8), allocatable :: dstdry1(:)  ! dry deposition of dust (bin1)
+     real(r8), allocatable :: dstwet2(:)  ! wet deposition of dust (bin2)
+     real(r8), allocatable :: dstdry2(:)  ! dry deposition of dust (bin2)
+     real(r8), allocatable :: dstwet3(:)  ! wet deposition of dust (bin3)
+     real(r8), allocatable :: dstdry3(:)  ! dry deposition of dust (bin3)
+     real(r8), allocatable :: dstwet4(:)  ! wet deposition of dust (bin4)
+     real(r8), allocatable :: dstdry4(:)  ! dry deposition of dust (bin4)
   end type cam_out_t 
 
 !---------------------------------------------------------------------------
@@ -87,37 +87,37 @@ module camsrfexch
   type cam_in_t    
      integer  :: lchnk                   ! chunk index
      integer  :: ncol                    ! number of active columns
-     real(r8) :: asdir(pcols)            ! albedo: shortwave, direct
-     real(r8) :: asdif(pcols)            ! albedo: shortwave, diffuse
-     real(r8) :: aldir(pcols)            ! albedo: longwave, direct
-     real(r8) :: aldif(pcols)            ! albedo: longwave, diffuse
-     real(r8) :: lwup(pcols)             ! longwave up radiative flux
-     real(r8) :: lhf(pcols)              ! latent heat flux
-     real(r8) :: shf(pcols)              ! sensible heat flux
-     real(r8) :: wsx(pcols)              ! surface u-stress (N)
-     real(r8) :: wsy(pcols)              ! surface v-stress (N)
-     real(r8) :: tref(pcols)             ! ref height surface air temp
-     real(r8) :: qref(pcols)             ! ref height specific humidity 
-     real(r8) :: u10(pcols)              ! 10m wind speed
-     real(r8) :: ts(pcols)               ! merged surface temp 
-     real(r8) :: sst(pcols)              ! sea surface temp
-     real(r8) :: snowhland(pcols)        ! snow depth (liquid water equivalent) over land 
-     real(r8) :: snowhice(pcols)         ! snow depth over ice
-     real(r8) :: fco2_lnd(pcols)         ! co2 flux from lnd
-     real(r8) :: fco2_ocn(pcols)         ! co2 flux from ocn
-     real(r8) :: fdms(pcols)             ! dms flux
-     real(r8) :: landfrac(pcols)         ! land area fraction
-     real(r8) :: icefrac(pcols)          ! sea-ice areal fraction
-     real(r8) :: ocnfrac(pcols)          ! ocean areal fraction
-     real(r8), pointer, dimension(:) :: ram1  !aerodynamical resistance (s/m) (pcols)
-     real(r8), pointer, dimension(:) :: fv    !friction velocity (m/s) (pcols)
-     real(r8), pointer, dimension(:) :: soilw !volumetric soil water (m3/m3)
-     real(r8) :: cflx(pcols,pcnst)       ! constituent flux (emissions)
-     real(r8) :: ustar(pcols)            ! atm/ocn saved version of ustar
-     real(r8) :: re(pcols)               ! atm/ocn saved version of re
-     real(r8) :: ssq(pcols)              ! atm/ocn saved version of ssq
-     real(r8), pointer, dimension(:,:) :: depvel ! deposition velocities
-     real(r8), pointer, dimension(:,:) :: dstflx ! dust fluxes
+     real(r8), allocatable :: asdir(:)      ! albedo: shortwave, direct
+     real(r8), allocatable :: asdif(:)      ! albedo: shortwave, diffuse
+     real(r8), allocatable :: aldir(:)      ! albedo: longwave, direct
+     real(r8), allocatable :: aldif(:)      ! albedo: longwave, diffuse
+     real(r8), allocatable :: lwup(:)       ! longwave up radiative flux
+     real(r8), allocatable :: lhf(:)        ! latent heat flux
+     real(r8), allocatable :: shf(:)        ! sensible heat flux
+     real(r8), allocatable :: wsx(:)        ! surface u-stress (N)
+     real(r8), allocatable :: wsy(:)        ! surface v-stress (N)
+     real(r8), allocatable :: tref(:)       ! ref height surface air temp
+     real(r8), allocatable :: qref(:)       ! ref height specific humidity 
+     real(r8), allocatable :: u10(:)        ! 10m wind speed
+     real(r8), allocatable :: ts(:)         ! merged surface temp 
+     real(r8), allocatable :: sst(:)        ! sea surface temp
+     real(r8), allocatable :: snowhland(:)  ! snow depth (liquid water equivalent) over land
+     real(r8), allocatable :: snowhice(:)   ! snow depth over ice
+     real(r8), allocatable :: fco2_lnd(:)   ! co2 flux from lnd
+     real(r8), allocatable :: fco2_ocn(:)   ! co2 flux from ocn
+     real(r8), allocatable :: fdms(:)       ! dms flux
+     real(r8), allocatable :: landfrac(:)   ! land area fraction
+     real(r8), allocatable :: icefrac(:)    ! sea-ice areal fraction
+     real(r8), allocatable :: ocnfrac(:)    ! ocean areal fraction
+     real(r8), pointer, dimension(:) :: ram1       !aerodynamical resistance (s/m) (pcols)
+     real(r8), pointer, dimension(:) :: fv         !friction velocity (m/s) (pcols)
+     real(r8), pointer, dimension(:) :: soilw      !volumetric soil water (m3/m3)
+     real(r8), allocatable :: cflx(:,:)     ! constituent flux (emissions)
+     real(r8), allocatable :: ustar(:)      ! atm/ocn saved version of ustar
+     real(r8), allocatable :: re(:)         ! atm/ocn saved version of re
+     real(r8), allocatable :: ssq(:)        ! atm/ocn saved version of ssq
+     real(r8), pointer, dimension(:,:) :: depvel   ! deposition velocities
+     real(r8), pointer, dimension(:,:) :: dstflx   ! dust fluxes
      real(r8), pointer, dimension(:,:) :: meganflx ! MEGAN fluxes
   end type cam_in_t    
 
@@ -175,6 +175,72 @@ CONTAINS
        nullify(cam_in(c)%meganflx)
     enddo  
     do c = begchunk,endchunk 
+       allocate (cam_in(c)%asdir(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error asdir')
+
+       allocate (cam_in(c)%asdif(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error asdif')
+
+       allocate (cam_in(c)%aldir(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error aldir')
+
+       allocate (cam_in(c)%aldif(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error aldif')
+
+       allocate (cam_in(c)%lwup(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error lwup')
+
+       allocate (cam_in(c)%lhf(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error lhf')
+
+       allocate (cam_in(c)%shf(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error shf')
+
+       allocate (cam_in(c)%wsx(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsx')
+
+       allocate (cam_in(c)%wsy(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsy')
+
+       allocate (cam_in(c)%tref(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error tref')
+
+       allocate (cam_in(c)%qref(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error qref')
+
+       allocate (cam_in(c)%u10(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error u10')
+
+       allocate (cam_in(c)%ts(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ts')
+
+       allocate (cam_in(c)%sst(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error sst')
+
+       allocate (cam_in(c)%snowhland(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error snowhland')
+
+       allocate (cam_in(c)%snowhice(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error snowhice')
+
+       allocate (cam_in(c)%fco2_lnd(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error fco2_lnd')
+
+       allocate (cam_in(c)%fco2_ocn(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error fco2_ocn')
+
+       allocate (cam_in(c)%fdms(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error fdms')
+
+       allocate (cam_in(c)%landfrac(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error landfrac')
+
+       allocate (cam_in(c)%icefrac(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error icefrac')
+
+       allocate (cam_in(c)%ocnfrac(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ocnfrac')
+
        if (index_x2a_Sl_ram1>0) then
           allocate (cam_in(c)%ram1(pcols), stat=ierror)
           if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ram1')
@@ -187,6 +253,19 @@ CONTAINS
           allocate (cam_in(c)%soilw(pcols), stat=ierror)
           if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error soilw')
        end if
+
+       allocate (cam_in(c)%cflx(pcols,pcnst), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error cflx')
+
+       allocate (cam_in(c)%ustar(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ustar')
+
+       allocate (cam_in(c)%re(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error re')
+
+       allocate (cam_in(c)%ssq(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ssq')
+
        if (index_x2a_Fall_flxdst1>0) then
           ! Assume 4 bins from surface model ....
           allocate (cam_in(c)%dstflx(pcols,4), stat=ierror)
@@ -294,6 +373,113 @@ CONTAINS
       call endrun('ATM2HUB_ALLOC error: allocation error')
     end if
 
+    do c = begchunk,endchunk 
+       allocate (cam_out(c)%tbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error tbot')
+
+       allocate (cam_out(c)%zbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error zbot')
+
+       allocate (cam_out(c)%ubot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ubot')
+
+       allocate (cam_out(c)%vbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error vbot')
+
+       allocate (cam_out(c)%qbot(pcols,pcnst), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error qbot')
+
+       allocate (cam_out(c)%pbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error pbot')
+
+       allocate (cam_out(c)%rho(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error rho')
+
+       allocate (cam_out(c)%netsw(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error netsw')
+
+       allocate (cam_out(c)%flwds(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error flwds')
+
+       allocate (cam_out(c)%precsc(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precsc')
+
+       allocate (cam_out(c)%precsl(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precsl')
+
+       allocate (cam_out(c)%precc(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precc')
+
+       allocate (cam_out(c)%precl(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precl')
+
+       allocate (cam_out(c)%soll(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error soll')
+
+       allocate (cam_out(c)%sols(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error sols')
+
+       allocate (cam_out(c)%solld(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error solld')
+
+       allocate (cam_out(c)%solsd(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error solsd')
+
+       allocate (cam_out(c)%thbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error thbot')
+
+       allocate (cam_out(c)%co2prog(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error co2prog')
+
+       allocate (cam_out(c)%co2diag(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error co2diag')
+
+       allocate (cam_out(c)%psl(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB ALLOC error: allocation error psl')
+
+       allocate (cam_out(c)%bcphiwet(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error bcphiwet')
+
+       allocate (cam_out(c)%bcphidry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error bcphidry')
+
+       allocate (cam_out(c)%bcphodry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error bcphodry')
+
+       allocate (cam_out(c)%ocphiwet(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ocphiwet')
+
+       allocate (cam_out(c)%ocphidry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ocphidry')
+
+       allocate (cam_out(c)%ocphodry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ocphodry')
+
+       allocate (cam_out(c)%dstwet1(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet1')
+
+       allocate (cam_out(c)%dstdry1(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry1')
+
+       allocate (cam_out(c)%dstwet2(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet2')
+
+       allocate (cam_out(c)%dstdry2(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry2')
+
+       allocate (cam_out(c)%dstwet3(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet3')
+
+       allocate (cam_out(c)%dstdry3(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry3')
+
+       allocate (cam_out(c)%dstwet4(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet4')
+
+       allocate (cam_out(c)%dstdry4(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry4')
+    enddo  
+
     do c = begchunk,endchunk
        cam_out(c)%lchnk       = c
        cam_out(c)%ncol        = get_ncols_p(c)
@@ -338,7 +524,46 @@ CONTAINS
 
   subroutine atm2hub_deallocate(cam_out)
     type(cam_out_t), pointer :: cam_out(:)    ! Atmosphere to surface input
+    integer :: c
+
     if(associated(cam_out)) then
+       do c = begchunk,endchunk
+          deallocate(cam_out(c)%tbot)
+          deallocate(cam_out(c)%zbot)
+          deallocate(cam_out(c)%ubot)
+          deallocate(cam_out(c)%vbot)
+          deallocate(cam_out(c)%qbot)
+          deallocate(cam_out(c)%pbot)
+          deallocate(cam_out(c)%rho)
+          deallocate(cam_out(c)%netsw)
+          deallocate(cam_out(c)%flwds)
+          deallocate(cam_out(c)%precsc)
+          deallocate(cam_out(c)%precsl)
+          deallocate(cam_out(c)%precc)
+          deallocate(cam_out(c)%precl)
+          deallocate(cam_out(c)%soll)
+          deallocate(cam_out(c)%sols)
+          deallocate(cam_out(c)%solld)
+          deallocate(cam_out(c)%solsd)
+          deallocate(cam_out(c)%thbot)
+          deallocate(cam_out(c)%co2prog)
+          deallocate(cam_out(c)%co2diag)
+          deallocate(cam_out(c)%bcphiwet)
+          deallocate(cam_out(c)%bcphidry)
+          deallocate(cam_out(c)%bcphodry)
+          deallocate(cam_out(c)%ocphiwet)
+          deallocate(cam_out(c)%ocphidry)
+          deallocate(cam_out(c)%ocphodry)
+          deallocate(cam_out(c)%dstwet1)
+          deallocate(cam_out(c)%dstdry1)
+          deallocate(cam_out(c)%dstwet2)
+          deallocate(cam_out(c)%dstdry2)
+          deallocate(cam_out(c)%dstwet3)
+          deallocate(cam_out(c)%dstdry3)
+          deallocate(cam_out(c)%dstwet4)
+          deallocate(cam_out(c)%dstdry4)
+       enddo  
+
        deallocate(cam_out)
     end if
     nullify(cam_out)
@@ -350,6 +575,29 @@ CONTAINS
 
     if(associated(cam_in)) then
        do c=begchunk,endchunk
+          deallocate(cam_in(c)%asdir)
+          deallocate(cam_in(c)%asdif)
+          deallocate(cam_in(c)%aldir)
+          deallocate(cam_in(c)%aldif)
+          deallocate(cam_in(c)%lwup)
+          deallocate(cam_in(c)%lhf)
+          deallocate(cam_in(c)%shf)
+          deallocate(cam_in(c)%wsx)
+          deallocate(cam_in(c)%wsy)
+          deallocate(cam_in(c)%tref)
+          deallocate(cam_in(c)%qref)
+          deallocate(cam_in(c)%u10)
+          deallocate(cam_in(c)%ts)
+          deallocate(cam_in(c)%sst)
+          deallocate(cam_in(c)%snowhland)
+          deallocate(cam_in(c)%snowhice)
+          deallocate(cam_in(c)%fco2_lnd)
+          deallocate(cam_in(c)%fco2_ocn)
+          deallocate(cam_in(c)%fdms)
+          deallocate(cam_in(c)%landfrac)
+          deallocate(cam_in(c)%icefrac)
+          deallocate(cam_in(c)%ocnfrac)
+
           if(associated(cam_in(c)%ram1)) then
              deallocate(cam_in(c)%ram1)
              nullify(cam_in(c)%ram1)
@@ -362,6 +610,12 @@ CONTAINS
              deallocate(cam_in(c)%soilw)
              nullify(cam_in(c)%soilw)
           end if
+
+          deallocate(cam_in(c)%cflx)
+          deallocate(cam_in(c)%ustar)
+          deallocate(cam_in(c)%re)
+          deallocate(cam_in(c)%ssq)
+
           if(associated(cam_in(c)%dstflx)) then
              deallocate(cam_in(c)%dstflx)
              nullify(cam_in(c)%dstflx)
@@ -374,7 +628,6 @@ CONTAINS
              deallocate(cam_in(c)%depvel)
              nullify(cam_in(c)%depvel)
           end if
-          
        enddo
 
        deallocate(cam_in)

--- a/components/cam/src/control/runtime_opts.F90
+++ b/components/cam/src/control/runtime_opts.F90
@@ -95,6 +95,10 @@ character(len=256) :: cam_branch_file = ' '
 !
 ! seed_clock           logical: if .true., XOR the system_clock with the seed,
 !                      wheter it includes a custom seed or not. Default .false.
+! 
+! phys_chunk_fdim      Declared first dimension for physics variables (chunks).
+!                      See phys_grid module.  
+integer :: phys_chunk_fdim
 !
 ! phys_alltoall        Dynamics/physics transpose option. See phys_grid module.
 !
@@ -301,6 +305,7 @@ contains
                      tracers_flag, &
                      indirect, &
                      print_step_cost,  &
+                     phys_chunk_fdim,  &
                      phys_alltoall, phys_loadbalance, phys_twin_algorithm, &
                      phys_chnk_per_thd, phys_chnk_cost_write
 
@@ -334,6 +339,7 @@ contains
 
    ! Get default values of runtime options for physics chunking.
    call phys_grid_defaultopts(                      &
+      phys_chunk_fdim_out     =phys_chunk_fdim,     &
       phys_loadbalance_out    =phys_loadbalance,    &
       phys_twin_algorithm_out =phys_twin_algorithm, &
       phys_alltoall_out       =phys_alltoall,       &
@@ -406,6 +412,7 @@ contains
 
    ! Set runtime options for physics chunking.
    call phys_grid_setopts(                          &
+       phys_chunk_fdim_in     =phys_chunk_fdim,     &
        phys_loadbalance_in    =phys_loadbalance,    &
        phys_twin_algorithm_in =phys_twin_algorithm, &
        phys_alltoall_in       =phys_alltoall,       &
@@ -626,6 +633,7 @@ subroutine distnl
    call mpibcast (indirect     , 1 ,mpilog, 0,mpicom)
 
    ! Physics chunk tuning
+   call mpibcast (phys_chunk_fdim    ,1,mpiint,0,mpicom)
    call mpibcast (phys_loadbalance   ,1,mpiint,0,mpicom)
    call mpibcast (phys_twin_algorithm,1,mpiint,0,mpicom)
    call mpibcast (phys_alltoall      ,1,mpiint,0,mpicom)

--- a/components/cam/src/control/runtime_opts.F90
+++ b/components/cam/src/control/runtime_opts.F90
@@ -96,9 +96,9 @@ character(len=256) :: cam_branch_file = ' '
 ! seed_clock           logical: if .true., XOR the system_clock with the seed,
 !                      wheter it includes a custom seed or not. Default .false.
 ! 
-! phys_chunk_fdim      Declared first dimension for physics variables (chunks).
+! phys_chnk_fdim       Declared first dimension for physics variables (chunks).
 !                      See phys_grid module.  
-integer :: phys_chunk_fdim
+integer :: phys_chnk_fdim
 !
 ! phys_alltoall        Dynamics/physics transpose option. See phys_grid module.
 !
@@ -305,7 +305,7 @@ contains
                      tracers_flag, &
                      indirect, &
                      print_step_cost,  &
-                     phys_chunk_fdim,  &
+                     phys_chnk_fdim,  &
                      phys_alltoall, phys_loadbalance, phys_twin_algorithm, &
                      phys_chnk_per_thd, phys_chnk_cost_write
 
@@ -339,7 +339,7 @@ contains
 
    ! Get default values of runtime options for physics chunking.
    call phys_grid_defaultopts(                      &
-      phys_chunk_fdim_out     =phys_chunk_fdim,     &
+      phys_chnk_fdim_out      =phys_chnk_fdim,      &
       phys_loadbalance_out    =phys_loadbalance,    &
       phys_twin_algorithm_out =phys_twin_algorithm, &
       phys_alltoall_out       =phys_alltoall,       &
@@ -412,7 +412,7 @@ contains
 
    ! Set runtime options for physics chunking.
    call phys_grid_setopts(                          &
-       phys_chunk_fdim_in     =phys_chunk_fdim,     &
+       phys_chnk_fdim_in      =phys_chnk_fdim,      &
        phys_loadbalance_in    =phys_loadbalance,    &
        phys_twin_algorithm_in =phys_twin_algorithm, &
        phys_alltoall_in       =phys_alltoall,       &
@@ -633,7 +633,7 @@ subroutine distnl
    call mpibcast (indirect     , 1 ,mpilog, 0,mpicom)
 
    ! Physics chunk tuning
-   call mpibcast (phys_chunk_fdim    ,1,mpiint,0,mpicom)
+   call mpibcast (phys_chnk_fdim     ,1,mpiint,0,mpicom)
    call mpibcast (phys_loadbalance   ,1,mpiint,0,mpicom)
    call mpibcast (phys_twin_algorithm,1,mpiint,0,mpicom)
    call mpibcast (phys_alltoall      ,1,mpiint,0,mpicom)

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -1566,7 +1566,7 @@ subroutine diag_surf (cam_in, cam_out, ps, trefmxav, trefmnav )
 
     call outfld('SHFLX',    cam_in%shf,       pcols, lchnk)
     call outfld('LHFLX',    cam_in%lhf,       pcols, lchnk)
-    call outfld('QFLX',     cam_in%cflx(1,1), pcols, lchnk)
+    call outfld('QFLX',     cam_in%cflx,      pcols, lchnk)
 
     call outfld('TAUX',     cam_in%wsx,       pcols, lchnk)
     call outfld('TAUY',     cam_in%wsy,       pcols, lchnk)

--- a/components/cam/src/physics/cam/check_energy.F90
+++ b/components/cam/src/physics/cam/check_energy.F90
@@ -54,6 +54,7 @@ module check_energy
   public :: check_energy_fix       ! add global mean energy difference as a heating
   public :: check_tracers_init      ! initialize tracer integrals and cumulative boundary fluxes
   public :: check_tracers_chng      ! check changes in integrals against cumulative boundary fluxes
+  public :: check_tracers_fini      ! free memory associated with check_tracers_data type variable
 
   public :: qflx_gmean              ! calculate global mean of qflx for water conservation check 
   public :: check_qflx              ! output qflx at certain locations for water conservation check  
@@ -82,8 +83,8 @@ module check_energy
   integer  :: dtcore_idx = 0       ! dtcore index in physics buffer 
 
   type check_tracers_data
-     real(r8) :: tracer(pcols,pcnst)       ! initial vertically integrated total (kinetic + static) energy
-     real(r8) :: tracer_tnd(pcols,pcnst)   ! cumulative boundary flux of total energy
+     real(r8), allocatable :: tracer(:,:) ! initial vertically integrated total (kinetic + static) energy
+     real(r8), allocatable :: tracer_tnd(:,:) ! cumulative boundary flux of total energy
      integer :: count(pcnst)               ! count of values with significant imbalances
   end type check_tracers_data
 
@@ -887,6 +888,7 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
     real(r8) :: trpdel(pcols, pver)                ! pdel for tracer
 
     integer ncol                                   ! number of atmospheric columns
+    integer ierror                                 ! allocate status return
     integer  i,k,m                                 ! column, level,constituent indices
     integer :: ixcldice, ixcldliq                  ! CLDICE and CLDLIQ and tracer indices
     integer :: ixrain, ixsnow                      ! RAINQM and SNOWQM indices
@@ -894,6 +896,12 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
 !-----------------------------------------------------------------------
 
     ncol  = state%ncol
+    allocate (tracerint%tracer(pcols,pcnst), stat=ierror)
+    if ( ierror /= 0 ) call endrun('CHECK_TRACERS_INIT error: allocation error tracer')
+
+    allocate (tracerint%tracer_tnd(pcols,pcnst), stat=ierror)
+    if ( ierror /= 0 ) call endrun('CHECK_TRACERS_INIT error: allocation error tracer_tnd')
+
     call cnst_get_ind('CLDICE', ixcldice, abort=.false.)
     call cnst_get_ind('CLDLIQ', ixcldliq, abort=.false.)
     call cnst_get_ind('RAINQM', ixrain,   abort=.false.)
@@ -932,6 +940,25 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
 
     return
   end subroutine check_tracers_init
+
+!===============================================================================
+  subroutine check_tracers_fini(tracerint)
+
+!-----------------------------------------------------------------------
+! Deallocate storage assoicated with check_tracers_data type variable
+!-----------------------------------------------------------------------
+
+!------------------------------Arguments--------------------------------
+
+    type(check_tracers_data), intent(inout)   :: tracerint
+
+!-----------------------------------------------------------------------
+
+    deallocate(tracerint%tracer)
+    deallocate(tracerint%tracer_tnd)
+
+    return
+  end subroutine check_tracers_fini
 
 !===============================================================================
   subroutine check_tracers_chng(state, tracerint, name, nstep, ztodt, cflx)

--- a/components/cam/src/physics/cam/convect_shallow.F90
+++ b/components/cam/src/physics/cam/convect_shallow.F90
@@ -442,7 +442,10 @@ end subroutine convect_shallow_init_cnst
    use constituents,    only : pcnst, cnst_get_ind, cnst_get_type_byind
    use hk_conv,         only : cmfmca
    use uwshcu,          only : compute_uwshcu_inv
-   use unicon_cam,      only : unicon_out_t, unicon_cam_tend
+!pw   use unicon_cam,      only : unicon_out_t, unicon_cam_tend
+!pw++
+   use unicon_cam,      only : unicon_out_t, unicon_cam_tend, unicon_cam_tend_free
+!pw--
 
    use time_manager,    only : get_nstep, is_first_step
    use wv_saturation,   only : qsat
@@ -763,6 +766,9 @@ end subroutine convect_shallow_init_cnst
       cmflq(:ncol,:) = unicon_out%qtflx(:ncol,:) * latvap
 
       call outfld( 'PRECSH' , precc  , pcols, lchnk )
+!pw++
+      call unicon_cam_tend_free(unicon_out)
+!pw--
 
    end select
 

--- a/components/cam/src/physics/cam/phys_grid.F90
+++ b/components/cam/src/physics/cam/phys_grid.F90
@@ -169,9 +169,9 @@ module phys_grid
 ! chunk data structures
    type chunk
      integer  :: ncols                 ! number of vertical columns
-     integer  :: gcol(pcols)           ! global physics column indices
-     integer  :: lon(pcols)            ! global longitude indices
-     integer  :: lat(pcols)            ! global latitude indices
+     integer, allocatable :: gcol(:) ! global physics column indices
+     integer, allocatable :: lon(:)  ! global longitude indices
+     integer, allocatable :: lat(:)  ! global latitude indices
      integer  :: owner                 ! id of process where chunk assigned
      integer  :: lcid                  ! local chunk index
      real(r8) :: estcost               ! estimated computational cost (normalized)
@@ -190,9 +190,9 @@ module phys_grid
    type lchunk
      integer  :: ncols                 ! number of vertical columns
      integer  :: cid                   ! global chunk index
-     integer  :: gcol(pcols)           ! global physics column indices
-     real(r8) :: area(pcols)           ! column surface area (from dynamics)
-     real(r8) :: wght(pcols)           ! column integration weight (from dynamics)
+     integer,  allocatable :: gcol(:) ! global physics column indices
+     real(r8), allocatable :: area(:) ! column surface area (from dynamics)
+     real(r8), allocatable :: wght(:) ! column integration weight (from dynamics)
      real(r8) :: cost                  ! measured computational cost (seconds)
    end type lchunk
 
@@ -432,7 +432,7 @@ contains
     integer(iMap),          allocatable :: coord_map(:)
     type(horiz_coord_t),        pointer :: lat_coord
     type(horiz_coord_t),        pointer :: lon_coord
-    integer                             :: gcols(pcols)
+    integer,                allocatable :: gcols(:)
     character(len=hcoord_len),  pointer :: copy_attributes(:)
     character(len=hcoord_len)           :: copy_gridname
     logical                             :: unstructured
@@ -714,6 +714,11 @@ contains
        !
        allocate( cdex(1:maxblksiz) )
        allocate( chunks(1:nchunks) )
+       do cid=1,nchunks
+          allocate( chunks(cid)%gcol(pcols) )
+          allocate( chunks(cid)%lon(pcols) )
+          allocate( chunks(cid)%lat(pcols) )
+       enddo
        chunks(:)%estcost = 0.0_r8
 
        do cid=1,nchunks
@@ -898,6 +903,12 @@ contains
     endchunk = pchunkid(iam+1) + lastblock - 1
     !
     allocate( lchunks(begchunk:endchunk) )
+    do lcid=begchunk,endchunk
+       allocate( lchunks(lcid)%gcol(pcols) )
+       allocate( lchunks(lcid)%area(pcols) )
+       allocate( lchunks(lcid)%wght(pcols) )
+    enddo
+
     lchunks(:)%cost = 0.0_r8
     do cid=1,nchunks
        if (chunks(cid)%owner == iam) then
@@ -1092,6 +1103,7 @@ contains
       allocate(grid_map(4, pcols * (endchunk - begchunk + 1)))
     end if
     grid_map = 0
+    allocate( gcols(pcols) )
     allocate(latvals(size(grid_map, 2)))
     allocate(lonvals(size(grid_map, 2)))
     p = 0
@@ -1181,6 +1193,7 @@ contains
     nullify(latvals)
     deallocate(lonvals)
     nullify(lonvals)
+    deallocate(gcols)
     ! Cleanup, we are responsible for copy attributes
     if (associated(copy_attributes)) then
       deallocate(copy_attributes)
@@ -4552,6 +4565,11 @@ logical function phys_grid_initialized ()
 ! Allocate chunks and knuhcs data structures
 !
       allocate( chunks(1:nchunks) )
+      do cid=1,nchunks
+         allocate( chunks(cid)%gcol(pcols) )
+         allocate( chunks(cid)%lon(pcols) )
+         allocate( chunks(cid)%lat(pcols) )
+      enddo
       allocate( knuhcs(1:ngcols) )
 !
 ! Initialize chunks and knuhcs data structures
@@ -4775,6 +4793,11 @@ logical function phys_grid_initialized ()
 ! Allocate chunks and knuhcs data structures
 !
       allocate( chunks(1:nchunks) )
+      do cid=1,nchunks
+         allocate( chunks(cid)%gcol(pcols) )
+         allocate( chunks(cid)%lon(pcols) )
+         allocate( chunks(cid)%lat(pcols) )
+      enddo
       allocate( knuhcs(1:ngcols) )
 !
 ! Initialize chunks and knuhcs data structures

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1384,7 +1384,8 @@ subroutine tphysac (ztodt,   cam_in,  &
                                   check_water, & 
                                   check_prect, &
                                   check_qflx 
-    use check_energy,       only: check_tracers_data, check_tracers_init, check_tracers_chng
+    use check_energy,       only: check_tracers_data, check_tracers_init, &
+                                  check_tracers_chng, check_tracers_fini
     use time_manager,       only: get_nstep
     use cam_abortutils,         only: endrun
     use dycore,             only: dycore_is
@@ -1417,12 +1418,10 @@ subroutine tphysac (ztodt,   cam_in,  &
     type(physics_tend ), intent(inout) :: tend
     type(physics_buffer_desc), pointer :: pbuf(:)
 
-
-    type(check_tracers_data):: tracerint             ! tracer mass integrals and cummulative boundary fluxes
-
     !
     !---------------------------Local workspace-----------------------------
     !
+    type(check_tracers_data):: tracerint           ! tracer mass integrals and cummulative boundary fluxes
     type(physics_ptend)     :: ptend               ! indivdual parameterization tendencies
 
     integer  :: nstep                              ! current timestep number
@@ -1837,6 +1836,8 @@ end if ! l_ac_energy_chk
     end do
     water_vap_ac_2d(:ncol) = ftem(:ncol,1)
 
+    call check_tracers_fini(tracerint)
+
 end subroutine tphysac
 
 subroutine tphysbc (ztodt,               &
@@ -1892,7 +1893,8 @@ subroutine tphysbc (ztodt,               &
                                check_water, & 
                                check_prect, & 
                                check_energy_timestep_init
-    use check_energy,    only: check_tracers_data, check_tracers_init, check_tracers_chng
+    use check_energy,    only: check_tracers_data, check_tracers_init, &
+                               check_tracers_chng, check_tracers_fini
     use dycore,          only: dycore_is
     use aero_model,      only: aero_model_wetdep
     use carma_intr,      only: carma_wetdep_tend, carma_timestep_tend
@@ -2799,6 +2801,8 @@ end if ! l_rad
     call t_startf('diag_export')
     call diag_export(cam_out)
     call t_stopf('diag_export')
+
+    call check_tracers_fini(tracerint)
 
 end subroutine tphysbc
 

--- a/components/cam/src/physics/cam/ppgrid.F90
+++ b/components/cam/src/physics/cam/ppgrid.F90
@@ -26,11 +26,17 @@ module ppgrid
 
 ! Grid point resolution parameters
 
-   integer ppcols     ! number of columns (default for runtime-set max pcols)
+#ifdef PPCOLS
+   integer pcols      ! max number of columns per chunk (set at compile-time)
+#endif
+   integer ppcols     ! max number of columns per chunk (default for runtime-set pcols)
    integer psubcols   ! number of sub-columns (max)
    integer pver       ! number of vertical levels
    integer pverp      ! pver + 1
 
+#ifdef PPCOLS
+   parameter (pcols     = PCOLS)
+#endif
    parameter (ppcols    = PCOLS)
    parameter (psubcols  = PSUBCOLS)
    parameter (pver      = PLEV)
@@ -42,8 +48,10 @@ module ppgrid
    integer :: begchunk = 0            ! 
    integer :: endchunk = -1           ! 
 
+#ifndef PPCOLS
 !
 ! pcols set in physgrid_init
-   integer :: pcols = PCOLS    ! number of columns (runtime-set max)
+   integer :: pcols = PCOLS    ! max number of columns per chunk (set at runtime)
+#endif
 
 end module ppgrid

--- a/components/cam/src/physics/cam/ppgrid.F90
+++ b/components/cam/src/physics/cam/ppgrid.F90
@@ -18,6 +18,7 @@ module ppgrid
   public begchunk
   public endchunk
   public pcols
+  public ppcols
   public psubcols
   public pver
   public pverp
@@ -25,12 +26,12 @@ module ppgrid
 
 ! Grid point resolution parameters
 
-   integer pcols      ! number of columns (max)
+   integer ppcols     ! number of columns (default for runtime-set max pcols)
    integer psubcols   ! number of sub-columns (max)
    integer pver       ! number of vertical levels
    integer pverp      ! pver + 1
 
-   parameter (pcols     = PCOLS)
+   parameter (ppcols    = PCOLS)
    parameter (psubcols  = PSUBCOLS)
    parameter (pver      = PLEV)
    parameter (pverp     = pver + 1  )
@@ -40,5 +41,9 @@ module ppgrid
 !
    integer :: begchunk = 0            ! 
    integer :: endchunk = -1           ! 
+
+!
+! pcols set in physgrid_init
+   integer :: pcols = PCOLS    ! number of columns (runtime-set max)
 
 end module ppgrid


### PR DESCRIPTION
In the earlier 2000's, empirical experiments indicated that setting
the first dimension of the chunk data structure (pcols) at
compile-time allowed the compiler to generate more
performance-efficient code, and this motivated this design choice in
CAM. However, CAM/EAM has evolved significantly since then, and, for
example, physics_types now uses psetcols to define this first
dimension, and the compiler never sees a compile-time parameter. So
the compile-time setting of pcols may no longer serve a useful
purpose. Extensive experiments indicate that there is still a
small performance advantage from setting pcols at compile-time, but
also that being able to set pcols at runtime greatly simplifies the
process of optimizing over the pcols parameter.

Here pcols is implemented as a runtime option, currently specified
via the user_nl_cam namelist variable phys_chnk_fdim. phys_chnk_fdim
must be at least as large as 1, but there is no specified upper
bound. The current compile-time value of the CPP variable PCOLS is used
to define the default value for phys_chunk_fdim (and pcols). PCOLS is
now represented in EAM as the parameter ppcols, but is only referenced	
in defining the default for phys_chunk_fdim.

To restore the compile-time setting of pcols, and also to specify
a pcols value of PCOLS, add -pcols <PCOLS> to CAM_CONFIG_OPTS in
env_build.xml . For example, to specify 32 as the compile-time value
of pcols, add '-pcols 32' . This allows the recovery of any lost
performance from the runtime-specification of pcols.

Note that this is the first part of a two-part introduction of runtime
pcols. This PR sets the runtime pcols during the call to
read_namelist. To calculate a better default than the compile-time
PCOLS CPP variable requires that it be calculated in phys_grid_init,
and this requires changing the order of certain steps in the
initialization of EAM. The current PR, however, stands on its own, and
is acceptable even if the second part PR is never submitted.

BFB

This addresses some aspects of Issue #3538 , but not all. The issue
will be resolved by a second runtime pcols PR. If we decide
not to submit this follow-on PR, the issue will also be closed.