### PR TITLE
Fix PIO xml case setup

### DIFF
--- a/cime/scripts/lib/CIME/case/case.py
+++ b/cime/scripts/lib/CIME/case/case.py
@@ -1131,7 +1131,8 @@ class Case(object):
         mach = self.get_value("MACH")
         compset = self.get_value("COMPSET")
         mpilib = self.get_value("MPILIB")
-        defaults = pioobj.get_defaults(grid=grid,compset=compset,mach=mach,compiler=compiler, mpilib=mpilib)
+
+        defaults = pioobj.get_defaults(grid=grid, compset=compset, mach=mach, compiler=compiler, mpilib=mpilib)
 
         for vid, value in defaults.items():
             self.set_value(vid,value)

--- a/cime/scripts/lib/CIME/case/case.py
+++ b/cime/scripts/lib/CIME/case/case.py
@@ -1125,7 +1125,7 @@ class Case(object):
         return batchobj.get_jobs()
 
     def _set_pio_xml(self):
-        pioobj = PIO()
+        pioobj = PIO(self._component_classes)
         grid = self.get_value("GRID")
         compiler = self.get_value("COMPILER")
         mach = self.get_value("MACH")


### PR DESCRIPTION
Component-specific settings need to be set after generic
settings so that they take precedence.

Fixes #3550 

[BFB]