### PR TITLE
Fix RRTMGP for MMF

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -154,6 +154,7 @@ _TESTS = {
             "SMS.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850.clm-bgcexp",
             "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
             "SMS_D_Ld1.ne30_r05_oECv3.A_WCYCL1850",
+            "ERP_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-TEST.cam-crmout",
             )
         },
 
@@ -189,11 +190,11 @@ _TESTS = {
         "time" : "02:00:00",
         "tests" : (
             # MMF tests
-            "ERP_Ln9_P96.ne4_ne4.F-MMF1-TEST.cam-crmout",
-            "ERP_Ln9_P96.ne4pg2_ne4pg2.F-MMF2-TEST",
-            "ERP_Ln9_P96.ne4_ne4.F-MMF2-ECPP-TEST",
-            "SMS_D_Ln3_P96.ne4_ne4.F-MMF1-TEST",
-            "SMS_D_Ln3_P96.ne4pg2_ne4pg2.F-MMF2-TEST",
+            "ERP_Ln9_P96x1.ne4_ne4.F-MMF1-TEST.cam-crmout",
+            "ERP_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF2-TEST",
+            "ERP_Ln9_P96x1.ne4_ne4.F-MMF2-ECPP-TEST",
+            "SMS_D_Ln3_P96x1.ne4_ne4.F-MMF1-TEST",
+            "SMS_D_Ln3_P96x1.ne4pg2_ne4pg2.F-MMF2-TEST",
             # non-MMF tests with RRTMGP
             "ERP_Ln9.ne4pg2_ne4pg2.FC5AV1C-L.cam-rrtmgp",
             )

--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -16,6 +16,8 @@ module radiation
    use cam_abortutils,   only: endrun
    use scamMod,          only: scm_crm_mode, single_column, swrad_off
    use rad_constituents, only: N_DIAG
+   use radconstants,     only: &
+      set_sw_spectral_boundaries, set_lw_spectral_boundaries, check_wavenumber_bounds
 
    ! RRTMGP gas optics object to store coefficient information. This is imported
    ! here so that we can make the k_dist objects module data and only load them
@@ -514,6 +516,10 @@ contains
       ! by the absorption coefficient data.
       nswgpts = k_dist_sw%get_ngpt()
       nlwgpts = k_dist_lw%get_ngpt()
+
+      ! Set values in radconstants
+      call set_sw_spectral_boundaries(k_dist_sw%get_band_lims_wavenumber())
+      call set_lw_spectral_boundaries(k_dist_lw%get_band_lims_wavenumber())
 
       ! Set number of levels used in radiation calculations
 #ifdef NO_EXTRA_RAD_LEVEL

--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -1877,6 +1877,10 @@ contains
                   do ix = 1,crm_nx_rad
                      do ic = 1,ncol
                         crm_qrad(ic,ix,iy,iz) = (crm_qrs(ic,ix,iy,iz) + crm_qrl(ic,ix,iy,iz)) / cpair
+                        if (conserve_energy) then
+                           ilev = pver - iz + 1
+                           crm_qrad(ic,ix,iy,iz) = crm_qrad(ic,ix,iy,iz) * state%pdel(ic,ilev)
+                        end if
                      end do
                   end do
                end do


### PR DESCRIPTION
This fixes a bug in RRTMGP with the MMF configuration. The radiative fluxes were not multiplied by the pressure thickness. This caused the radiative heating to have the wrong units. The fix simply mirrors how radiative tendencies are treated for the non-MMF configuration with RRTMGP.

This PR also updates the MMF tests to ensure threading is disabled, and adds a test to the e3sm_integration suite. 

[BFB except for MMF tests]