### PR TITLE
Enable COSP with RRTMGP

### DIFF
--- a/components/cam/src/physics/rrtmg/radiation.F90
+++ b/components/cam/src/physics/rrtmg/radiation.F90
@@ -1565,16 +1565,16 @@ end function radiation_nextsw_cday
           cosp_cnt(lchnk) = cosp_cnt(lchnk) + 1
 
           !! if counter is the same as cosp_nradsteps, run cosp and reset counter
-           if (cosp_nradsteps .eq. cosp_cnt(lchnk)) then
-              !call should be compatible with camrt radiation.F90 interface too, should be with (in),optional
-              ! N.B.: For snow optical properties, the GRID-BOX MEAN shortwave and longwave optical depths are passed.
-              call t_startf ('cosp_run')
-	      call cospsimulator_intr_run(state,  pbuf, cam_in, emis, coszrs, &
-                   cld_swtau_in=cld_tau(rrtmg_sw_cloudsim_band,:,:),&
-                   snow_tau_in=gb_snow_tau,snow_emis_in=gb_snow_lw)
-              cosp_cnt(lchnk) = 0  !! reset counter
-              call t_stopf ('cosp_run')
-           end if
+          if (cosp_nradsteps .eq. cosp_cnt(lchnk)) then
+             !call should be compatible with camrt radiation.F90 interface too, should be with (in),optional
+             ! N.B.: For snow optical properties, the GRID-BOX MEAN shortwave and longwave optical depths are passed.
+             call t_startf ('cosp_run')
+             call cospsimulator_intr_run(state,  pbuf, cam_in, emis, coszrs, &
+                  cld_swtau_in=cld_tau(rrtmg_sw_cloudsim_band,:,:),&
+                  snow_tau_in=gb_snow_tau,snow_emis_in=gb_snow_lw)
+             cosp_cnt(lchnk) = 0  !! reset counter
+             call t_stopf ('cosp_run')
+          end if
        end if
 
     else   !  if (dosw .or. dolw) then

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -66,30 +66,30 @@ contains
       integer :: iband, ilev, icol
 
       ! Initialize outputs
-      tau_out = 0
-      ssa_out = 0
-      asm_out = 0
-      liq_tau_out = 0
-      ice_tau_out = 0
-      snw_tau_out = 0
+      tau_out = 0._r8
+      ssa_out = 0._r8
+      asm_out = 0._r8
+      liq_tau_out = 0._r8
+      ice_tau_out = 0._r8
+      snw_tau_out = 0._r8
 
       ! Initialize local variables
-      ice_tau = 0
-      ice_tau_ssa = 0
-      ice_tau_ssa_g = 0
-      ice_tau_ssa_f = 0
-      liq_tau = 0
-      liq_tau_ssa = 0
-      liq_tau_ssa_g = 0
-      liq_tau_ssa_f = 0
-      snow_tau = 0
-      snow_tau_ssa = 0
-      snow_tau_ssa_g = 0
-      snow_tau_ssa_f = 0
-      combined_tau = 0
-      combined_tau_ssa = 0
-      combined_tau_ssa_g = 0
-      combined_tau_ssa_f = 0
+      ice_tau = 0._r8
+      ice_tau_ssa = 0._r8
+      ice_tau_ssa_g = 0._r8
+      ice_tau_ssa_f = 0._r8
+      liq_tau = 0._r8
+      liq_tau_ssa = 0._r8
+      liq_tau_ssa_g = 0._r8
+      liq_tau_ssa_f = 0._r8
+      snow_tau = 0._r8
+      snow_tau_ssa = 0._r8
+      snow_tau_ssa_g = 0._r8
+      snow_tau_ssa_f = 0._r8
+      combined_tau = 0._r8
+      combined_tau_ssa = 0._r8
+      combined_tau_ssa_g = 0._r8
+      combined_tau_ssa_f = 0._r8
 
       ! Get ice cloud optics
       if (trim(icecldoptics) == 'mitchell') then
@@ -163,10 +163,10 @@ contains
       else
          ! We are not doing snow optics, so set these to zero so we can still use 
          ! the arrays without additional logic
-         snow_tau(:,:,:) = 0.0
-         snow_tau_ssa(:,:,:) = 0.0
-         snow_tau_ssa_g(:,:,:) = 0.0
-         snow_tau_ssa_f(:,:,:) = 0.0
+         snow_tau(:,:,:) = 0._r8
+         snow_tau_ssa(:,:,:) = 0._r8
+         snow_tau_ssa_g(:,:,:) = 0._r8
+         snow_tau_ssa_f(:,:,:) = 0._r8
       end if
 
       ! Combine all cloud optics from CAM routines
@@ -207,13 +207,13 @@ contains
             ssa_out(:ncol,:nlev,iband) &
                = combined_tau_ssa(iband,:ncol,:nlev) / combined_tau(iband,:ncol,:nlev)
          elsewhere
-            ssa_out(:ncol,:nlev,iband) = 1.0
+            ssa_out(:ncol,:nlev,iband) = 1._r8
          endwhere
          where (combined_tau_ssa(iband,:ncol,:nlev) > 0)
             asm_out(:ncol,:nlev,iband) &
                = combined_tau_ssa_g(iband,:ncol,:nlev) / combined_tau_ssa(iband,:ncol,:nlev)
          elsewhere
-            asm_out(:ncol,:nlev,iband) = 0.0
+            asm_out(:ncol,:nlev,iband) = 0._r8
          end where
 
          ! Re-order diagnostics outputs
@@ -259,17 +259,17 @@ contains
       integer :: iband
 
       ! Initialize outputs
-      tau_out = 0
-      liq_tau_out = 0
-      ice_tau_out = 0
-      snw_tau_out = 0
+      tau_out = 0._r8
+      liq_tau_out = 0._r8
+      ice_tau_out = 0._r8
+      snw_tau_out = 0._r8
 
       ! Initialize local variables
-      ice_tau(:,:,:) = 0
-      liq_tau(:,:,:) = 0
-      snow_tau(:,:,:) = 0
-      cld_tau(:,:,:) = 0
-      combined_tau(:,:,:) = 0
+      ice_tau(:,:,:) = 0._r8
+      liq_tau(:,:,:) = 0._r8
+      snow_tau(:,:,:) = 0._r8
+      cld_tau(:,:,:) = 0._r8
+      combined_tau(:,:,:) = 0._r8
 
       ! Get ice optics
       if (trim(icecldoptics) == 'mitchell') then
@@ -351,7 +351,7 @@ contains
       combined_fraction = max(fraction1, fraction2)
 
       ! Combine optical properties by weighting by amount of cloud and snow
-      combined_property = 0
+      combined_property = 0._r8
       do ilev = 1,nlevs
          do icol = 1,ncols
             do iband = 1,nbands
@@ -361,7 +361,7 @@ contains
                    + fraction2(icol,ilev) * property2(iband,icol,ilev) &
                   ) / combined_fraction(icol,ilev)
                else
-                  combined_property(iband,icol,ilev) = 0
+                  combined_property(iband,icol,ilev) = 0._r8
                end if
             end do
          end do
@@ -410,9 +410,9 @@ contains
                   ssa_gpt(icol,ilev,igpt) = ssa_bnd(icol,ilev,gpt2bnd(igpt))
                   asm_gpt(icol,ilev,igpt) = asm_bnd(icol,ilev,gpt2bnd(igpt))
                else
-                  tau_gpt(icol,ilev,igpt) = 0
-                  ssa_gpt(icol,ilev,igpt) = 1
-                  asm_gpt(icol,ilev,igpt) = 0
+                  tau_gpt(icol,ilev,igpt) = 0._r8
+                  ssa_gpt(icol,ilev,igpt) = 1._r8
+                  asm_gpt(icol,ilev,igpt) = 0._r8
                end if
             end do
          end do
@@ -488,7 +488,7 @@ contains
                if (iscloudy(igpt,icol,ilev) .and. combined_cld(icol,ilev) > 0._r8) then
                   tau_gpt(icol,ilev,igpt) = tau_bnd(icol,ilev,gpt2bnd(igpt))
                else
-                  tau_gpt(icol,ilev,igpt) = 0
+                  tau_gpt(icol,ilev,igpt) = 0._r8
                end if
             end do
          end do
@@ -531,10 +531,10 @@ contains
       ncol = state%ncol
 
       ! Get aerosol absorption optical depth from CAM routine
-      tau = 0.0
-      tau_w = 0.0
-      tau_w_g = 0.0
-      tau_w_f = 0.0
+      tau = 0._r8
+      tau_w = 0._r8
+      tau_w_g = 0._r8
+      tau_w_f = 0._r8
       call aer_rad_props_sw(icall, state, pbuf, &
                             count(night_indices > 0), night_indices, is_cmip6_volc, &
                             tau, tau_w, tau_w_g, tau_w_f)
@@ -548,14 +548,14 @@ contains
             ssa_out(icol,1:pver,1:nswbands) &
                = tau_w(icol,1:pver,1:nswbands) / tau(icol,1:pver,1:nswbands)
          elsewhere
-            ssa_out(icol,1:pver,1:nswbands) = 1
+            ssa_out(icol,1:pver,1:nswbands) = 1._r8
          endwhere
          ! Extract assymmetry parameter from the product-defined fields
          where (tau_w(icol,1:pver,1:nswbands) > 0)
             asm_out(icol,1:pver,1:nswbands) &
                = tau_w_g(icol,1:pver,1:nswbands) / tau_w(icol,1:pver,1:nswbands)
          elsewhere
-            asm_out(icol,1:pver,1:nswbands) = 0
+            asm_out(icol,1:pver,1:nswbands) = 0._r8
          endwhere
       end do
 
@@ -593,7 +593,7 @@ contains
       character(len=*), parameter :: subroutine_name = 'set_aerosol_optics_lw'
 
       ! Get aerosol absorption optical depth from CAM routine
-      tau = 0.0
+      tau = 0._r8
       call aer_rad_props_lw(is_cmip6_volc, icall, state, pbuf, tau)
 
    end subroutine set_aerosol_optics_lw

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -17,7 +17,8 @@ module radiation
    use scamMod,          only: scm_crm_mode, single_column, swrad_off
    use rad_constituents, only: N_DIAG
    use radconstants,     only: &
-      set_sw_spectral_boundaries, set_lw_spectral_boundaries, check_wavenumber_bounds
+      set_sw_spectral_boundaries, set_lw_spectral_boundaries, check_wavenumber_bounds, &
+      get_band_index_sw, get_band_index_lw, test_get_band_index
 
    ! RRTMGP gas optics object to store coefficient information. This is imported
    ! here so that we can make the k_dist objects module data and only load them
@@ -961,7 +962,6 @@ contains
        endif
           
        if (is_first_restart_step()) then
-          cosp_cnt(begchunk:endchunk)=cosp_cnt_init
           if (pergro_mods) then
              !--------------------------------------
              !Read seeds from restart file
@@ -979,7 +979,6 @@ contains
              enddo
           endif
        else
-          cosp_cnt(begchunk:endchunk)=0           
           if (pergro_mods) then
              !---------------------------------------
              !create seeds based off of column ids
@@ -1106,6 +1105,9 @@ contains
                             set_aerosol_optics_sw
       use aer_rad_props, only: aer_rad_props_lw
 
+      ! For running CFMIP Observation Simulator Package (COSP)
+      use cospsimulator_intr, only: docosp, cospsimulator_intr_run, cosp_nradsteps
+
       ! ---------------------------------------------------------------------------
       ! Arguments
       ! ---------------------------------------------------------------------------
@@ -1171,12 +1173,21 @@ contains
       ! Cosine solar zenith angle for all columns in chunk
       real(r8) :: coszrs(pcols)
 
-      ! Cloud optical properties
+      ! Cloud, snow, and aerosol optical properties
       real(r8), dimension(pcols,pver,nswgpts ) :: cld_tau_gpt_sw, cld_ssa_gpt_sw, cld_asm_gpt_sw
       real(r8), dimension(pcols,pver,nswbands) :: cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw
       real(r8), dimension(pcols,pver,nswbands) :: aer_tau_bnd_sw, aer_ssa_bnd_sw, aer_asm_bnd_sw
       real(r8), dimension(pcols,pver,nlwbands) :: cld_tau_bnd_lw, aer_tau_bnd_lw
       real(r8), dimension(pcols,pver,nlwgpts ) :: cld_tau_gpt_lw
+      ! NOTE: these are diagnostic only
+      real(r8), dimension(pcols,pver,nswbands) :: liq_tau_bnd_sw, ice_tau_bnd_sw, snw_tau_bnd_sw
+      real(r8), dimension(pcols,pver,nlwbands) :: liq_tau_bnd_lw, ice_tau_bnd_lw, snw_tau_bnd_lw
+
+      ! Needed for COSP: cloud lw emissivity and gridbox mean snow sw and lw optical depth
+      real(r8), dimension(pcols,pver) :: cld_emis_lw, gb_snow_tau_sw, gb_snow_tau_lw
+
+      ! COSP simulator bands
+      integer :: cosp_swband, cosp_lwband
 
       ! Gas volume mixing ratios
       real(r8), dimension(size(active_gases),pcols,pver) :: gas_vmr
@@ -1281,7 +1292,8 @@ contains
          call get_cloud_optics_sw( &
             ncol, pver, nswbands, do_snow_optics(), cld, cldfsnow, iclwp, iciwp, icswp, &
             lambdac, mu, dei, des, rel, rei, &
-            cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw &
+            cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw, &
+            liq_tau_bnd_sw, ice_tau_bnd_sw, snw_tau_bnd_sw &
          )
          call sample_cloud_optics_sw( &
             ncol, pver, nswgpts, k_dist_sw%get_gpoint_bands(), &
@@ -1368,7 +1380,7 @@ contains
          call get_cloud_optics_lw( &
             ncol, pver, nlwbands, do_snow_optics(), cld, cldfsnow, iclwp, iciwp, icswp, &
             lambdac, mu, dei, des, rei, &
-            cld_tau_bnd_lw &
+            cld_tau_bnd_lw, liq_tau_bnd_lw, ice_tau_bnd_lw, snw_tau_bnd_lw &
          )
          call sample_cloud_optics_lw( &
             ncol, pver, nlwgpts, k_dist_lw%get_gpoint_bands(), &
@@ -1437,6 +1449,40 @@ contains
       if (conserve_energy) then
          qrs(1:ncol,1:pver) = qrs(1:ncol,1:pver) * state%pdel(1:ncol,1:pver)
          qrl(1:ncol,1:pver) = qrl(1:ncol,1:pver) * state%pdel(1:ncol,1:pver)
+      end if
+
+      ! If we ran radiation this timestep, check if we should run COSP
+      if (radiation_do('sw') .or. radiation_do('lw')) then
+         if (docosp) then
+            ! Advance counter and run COSP if new count value is equal to cosp_nradsteps
+            cosp_cnt(state%lchnk) = cosp_cnt(state%lchnk) + 1
+            if (cosp_cnt(state%lchnk) == cosp_nradsteps) then
+
+               ! Find bands used for cloud simulator calculations
+               cosp_lwband = get_band_index_lw(10.5_r8, 'micron')
+               cosp_swband = get_band_index_sw(0.67_r8, 'micron')
+
+               ! Compute quantities needed for COSP
+               cld_emis_lw = 1._r8 - exp(-cld_tau_bnd_lw(:,:,cosp_lwband))
+               gb_snow_tau_sw = cldfsnow * snw_tau_bnd_sw(:,:,cosp_swband)
+               gb_snow_tau_lw = cldfsnow * snw_tau_bnd_lw(:,:,cosp_lwband)
+
+               ! Run COSP; note that "snow" is passed as LW absorption optical depth, even though
+               ! the argument name in "snow_emis_in". Optical depth is apparently converted to
+               ! emissivity somewhere in the COSP routines. This should probably be changed in the
+               ! future for clarity, but is consistent with the implementation in RRTMG.
+               call t_startf('cospsimulator_intr_run')
+               call cospsimulator_intr_run( &
+                  state, pbuf, cam_in, cld_emis_lw, coszrs, &
+                  cld_swtau_in=cld_tau_bnd_sw(:,:,cosp_swband), &
+                  snow_tau_in=gb_snow_tau_sw, snow_emis_in=gb_snow_tau_lw &
+               )
+               call t_stopf('cospsimulator_intr_run')
+
+               ! Reset counter
+               cosp_cnt(state%lchnk) = 0
+            end if
+         end if
       end if
 
    end subroutine radiation_tend


### PR DESCRIPTION
Enable running the CFMIP Observation Simulator Package (COSP) with RRTMGP. This provides a number of additional diagnostics that are directly comparable to satellite retrievals of cloud properties from a number of different instruments. To build with COSP, simply add `-cosp` to `CAM_CONFIG_OPTS` in `env_build.xml` (i.e., `./xmlchange --append CAM_CONFIG_OPTS='-cosp'`). No other action should need to be taken, and h0 output files should include a selection of COSP outputs. 

[BFB]