### PR TITLE
Additional physgrid support files

### DIFF
--- a/cime/config/e3sm/allactive/config_pesall.xml
+++ b/cime/config/e3sm/allactive/config_pesall.xml
@@ -8659,33 +8659,6 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne4np4.pg1">
-    <mach name="any">
-      <pes compset="any" pesize="any">
-        <comment>any compset on ne4np4.pg1 grid</comment>
-        <ntasks>
-          <ntasks_atm>96</ntasks_atm>
-          <ntasks_lnd>96</ntasks_lnd>
-          <ntasks_rof>96</ntasks_rof>
-          <ntasks_ice>96</ntasks_ice>
-          <ntasks_ocn>96</ntasks_ocn>
-          <ntasks_cpl>96</ntasks_cpl>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_wav>1</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%ne4np4.pg2">
     <mach name="any">
       <pes compset="any" pesize="any">

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1665,6 +1665,16 @@
       <mask>oEC60to30v3</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg1_r05_oECv3">
+      <grid name="atm">ne30np4.pg1</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg2_r05_oECv3">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">r05</grid>
@@ -1683,6 +1693,26 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>oARRM60to10</mask>
+    </model_grid>
+
+    <model_grid alias="ne30pg3_r05_oECv3">
+      <grid name="atm">ne30np4.pg3</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
+
+    <model_grid alias="ne30pg4_r05_oECv3">
+      <grid name="atm">ne30np4.pg4</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
     </model_grid>
 
     <model_grid alias="ne30pg2_r05_ne30pg2" compset="(DOCN|XOCN|SOCN|AQP1)">
@@ -2105,8 +2135,8 @@
     <domain name="ne30np4.pg1">
       <nx>5400</nx>
       <ny>1</ny>
-      <file grid="atm|lnd" mask="gx1v6">DUMMY</file>
-      <file grid="ice|ocn" mask="gx1v6">DUMMY</file>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg1_oEC60to30v3.200330.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg1_oEC60to30v3.200330.nc</file>
       <desc>ne30np4.pg1 is Spectral Elem 1-deg grid w/ 1x1 FV physics grid per element:</desc>
     </domain>
     <domain name="ne30np4.pg2">
@@ -2119,6 +2149,20 @@
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_gx1v6.190806.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
+    </domain>
+    <domain name="ne30np4.pg3">
+      <nx>48600</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg3_oEC60to30v3.200330.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg3_oEC60to30v3.200330.nc</file>
+      <desc>ne30np4.pg3 is Spectral Elem 1-deg grid w/ 3x3 FV physics grid per element:</desc>
+    </domain>
+    <domain name="ne30np4.pg4">
+      <nx>86400</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg4_oEC60to30v3.200330.n</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg4_oEC60to30v3.200330.nc</file>
+      <desc>ne30np4.pg4 is Spectral Elem 1-deg grid w/ 4x4 FV physics grid per element:</desc>
     </domain>
 
     <!--=====================================================================-->
@@ -2732,6 +2776,14 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg2_mono.200220.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne30np4.pg1" ocn_grid="oEC60to30v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_oEC60to30v3_mono.200331.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_oEC60to30v3_bilin.200331.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_oEC60to30v3_bilin.200331.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg1_mono.200331.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg1_mono.200331.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="oEC60to30v3">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_oEC60to30v3_mono.200220.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_oEC60to30v3_bilin.200220.nc</map>
@@ -2754,6 +2806,22 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_ARRM60to10_bilin.200527.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to10/map_ARRM60to10_to_ne30pg2_mono.200527.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to10/map_ARRM60to10_to_ne30pg2_mono.200527.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_to_oEC60to30v3_mono.200331.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_to_oEC60to30v3_bilin.200331.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_to_oEC60to30v3_bilin.200331.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg3_mono.200331.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg3_mono.200331.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg4" ocn_grid="oEC60to30v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg4/map_ne30pg4_to_oEC60to30v3_mono.200331.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg4/map_ne30pg4_to_oEC60to30v3_bilin.200331.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg4/map_ne30pg4_to_oEC60to30v3_bilin.200331.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg4_mono.200331.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg4_mono.200331.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oEC60to30wLI">
@@ -2817,11 +2885,32 @@
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne30np4/map_r05_to_ne30np4_mono.191016.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne30np4.pg1" lnd_grid="r05">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_r05_mono.200331.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_r05_bilin.200331.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne30pg1/map_r05_to_ne30pg1_mono.200331.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne30pg1/map_r05_to_ne30pg1_mono.200331.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="ne30np4.pg2" lnd_grid="r05">
       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_mono.200220.nc</map>
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_bilin.200220.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne30pg2/map_r05_to_ne30pg2_mono.200220.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne30pg2/map_r05_to_ne30pg2_mono.200220.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg3" lnd_grid="r05">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_to_r05_mono.200331.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_to_r05_bilin.200331.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne30pg3/map_r05_to_ne30pg3_mono.200331.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne30pg3/map_r05_to_ne30pg3_mono.200331.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg4" lnd_grid="r05">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne30pg4/map_ne30pg4_to_r05_mono.200331.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne30pg4/map_ne30pg4_to_r05_bilin.200331.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne30pg4/map_r05_to_ne30pg4_mono.200331.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne30pg4/map_r05_to_ne30pg4_mono.200331.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" lnd_grid="r0125">
@@ -3293,9 +3382,24 @@
       <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/ne30np4/map_ne30np4_to_0.5x0.5rtm_aave_da_110320.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne30np4.pg1" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_r05_mono.200331.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_r05_mono.200331.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="ne30np4.pg2" rof_grid="r05">
       <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_mono.200220.nc</map>
       <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_mono.200220.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg3" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_to_r05_mono.200331.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_to_r05_mono.200331.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg4" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne30pg4/map_ne30pg4_to_r05_mono.200331.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne30pg4/map_ne30pg4_to_r05_mono.200331.nc</map>
     </gridmap>
 
     <gridmap atm_grid="0.9x1.25" rof_grid="r05">

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -774,16 +774,6 @@
       <mask>oQU240</mask>
     </model_grid>
 
-    <model_grid alias="ne4pg1_ne4pg1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne4np4.pg1</grid>
-      <grid name="lnd">ne4np4.pg1</grid>
-      <grid name="ocnice">ne4np4.pg1</grid>
-      <grid name="rof">r05</grid>
-      <grid name="glc">null</grid>
-      <grid name="wav">null</grid>
-      <mask>oQU240</mask>
-    </model_grid>
-
     <model_grid alias="ne4pg2_ne4pg2" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne4np4.pg2</grid>
       <grid name="lnd">ne4np4.pg2</grid>
@@ -798,16 +788,6 @@
       <grid name="atm">ne8np4</grid>
       <grid name="lnd">ne8np4</grid>
       <grid name="ocnice">ne8np4</grid>
-      <grid name="rof">r05</grid>
-      <grid name="glc">null</grid>
-      <grid name="wav">null</grid>
-      <mask>oQU240</mask>
-    </model_grid>
-
-    <model_grid alias="ne8pg1_ne8pg1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne8np4.pg1</grid>
-      <grid name="lnd">ne8np4.pg1</grid>
-      <grid name="ocnice">ne8np4.pg1</grid>
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -914,16 +894,6 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16pg1_ne16pg1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne16np4.pg1</grid>
-      <grid name="lnd">ne16np4.pg1</grid>
-      <grid name="ocnice">ne16np4.pg1</grid>
-      <grid name="rof">r05</grid>
-      <grid name="glc">null</grid>
-      <grid name="wav">null</grid>
-      <mask>gx3v7</mask>
-    </model_grid>
-
     <model_grid alias="ne16pg2_ne16pg2" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne16np4.pg2</grid>
       <grid name="lnd">ne16np4.pg2</grid>
@@ -992,16 +962,6 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>oRRS15to5</mask>
-    </model_grid>
-
-    <model_grid alias="ne30pg1_ne30pg1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne30np4.pg1</grid>
-      <grid name="lnd">ne30np4.pg1</grid>
-      <grid name="ocnice">ne30np4.pg1</grid>
-      <grid name="rof">r05</grid>
-      <grid name="glc">null</grid>
-      <grid name="wav">null</grid>
-      <mask>gx1v6</mask>
     </model_grid>
 
     <model_grid alias="ne30pg2_ne30pg2" compset="(DOCN|XOCN|SOCN|AQP1)">
@@ -1201,16 +1161,6 @@
       <grid name="atm">ne60np4</grid>
       <grid name="lnd">ne60np4</grid>
       <grid name="ocnice">ne60np4</grid>
-      <grid name="rof">r05</grid>
-      <grid name="glc">null</grid>
-      <grid name="wav">null</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="ne60pg1_ne60pg1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne60np4.pg1</grid>
-      <grid name="lnd">ne60np4.pg1</grid>
-      <grid name="ocnice">ne60np4.pg1</grid>
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -1675,16 +1625,6 @@
       <mask>oEC60to30v3</mask>
     </model_grid>
 
-    <model_grid alias="ne30pg1_r05_oECv3">
-      <grid name="atm">ne30np4.pg1</grid>
-      <grid name="lnd">r05</grid>
-      <grid name="ocnice">oEC60to30v3</grid>
-      <grid name="rof">r05</grid>
-      <grid name="glc">null</grid>
-      <grid name="wav">null</grid>
-      <mask>oEC60to30v3</mask>
-    </model_grid>
-
     <model_grid alias="ne30pg2_r05_oECv3">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">r05</grid>
@@ -2063,13 +2003,6 @@
       <file grid="ice|ocn" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.ocn.ne4np4_oQU240.160614.nc</file>
       <desc>ne4np4 is Spectral Elem  7.5-deg grid:</desc>
     </domain>
-    <domain name="ne4np4.pg1">
-      <nx>96</nx>
-      <ny>1</ny>
-      <file grid="atm|lnd" mask="oQU240">DUMMY</file>
-      <file grid="ice|ocn" mask="oQU240">DUMMY</file>
-      <desc>ne4np4.pg1 is Spectral Elem 7.5-deg grid w/ 1x1 FV physics grid per element:</desc>
-    </domain>
     <domain name="ne4np4.pg2">
       <nx>384</nx>
       <ny>1</ny>
@@ -2098,13 +2031,6 @@
       <file grid="ice|ocn" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne16np4_gx3v7.121113.nc</file>
       <file grid="ice|ocn" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.ocn.ne16np4_oQU240.151211.nc</file>
       <desc>ne16np4 is Spectral Elem 2-deg grid:</desc>
-    </domain>
-    <domain name="ne16np4.pg1">
-      <nx>1536</nx>
-      <ny>1</ny>
-      <file grid="atm|lnd" mask="gx1v6">DUMMY</file>
-      <file grid="ice|ocn" mask="gx1v6">DUMMY</file>
-      <desc>ne16np4.pg1 is Spectral Elem 2-deg grid w/ 1x1 FV physics grid per element:</desc>
     </domain>
     <domain name="ne16np4.pg2">
       <nx>6144</nx>
@@ -2142,13 +2068,6 @@
       <file grid="lnd" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oEC60to30v3wLI_mask.170802.nc</file>
       <desc>ne30np4 is Spectral Elem 1-deg grid:</desc>
     </domain>
-    <domain name="ne30np4.pg1">
-      <nx>5400</nx>
-      <ny>1</ny>
-      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg1_oEC60to30v3.200330.nc</file>
-      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg1_oEC60to30v3.200330.nc</file>
-      <desc>ne30np4.pg1 is Spectral Elem 1-deg grid w/ 1x1 FV physics grid per element:</desc>
-    </domain>
     <domain name="ne30np4.pg2">
       <nx>21600</nx>
       <ny>1</ny>
@@ -2183,13 +2102,6 @@
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne60np4_gx1v6.120406.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne60np4_gx1v6.121113.nc</file>
       <desc>ne60np4 is Spectral Elem 1/2-deg grid:</desc>
-    </domain>
-    <domain name="ne60np4.pg1">
-      <nx>21600</nx>
-      <ny>1</ny>
-      <file grid="atm|lnd" mask="gx1v6">DUMMY</file>
-      <file grid="ice|ocn" mask="gx1v6">DUMMY</file>
-      <desc>ne60np4.pg1 is Spectral Elem 1/2-deg grid w/ 1x1 FV physics grid per element:</desc>
     </domain>
     <domain name="ne60np4.pg2">
       <nx>86400</nx>
@@ -2786,14 +2698,6 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg2_mono.200220.nc</map>
     </gridmap>
 
-    <gridmap atm_grid="ne30np4.pg1" ocn_grid="oEC60to30v3">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_oEC60to30v3_mono.200331.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_oEC60to30v3_bilin.200331.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_oEC60to30v3_bilin.200331.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg1_mono.200331.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30pg1_mono.200331.nc</map>
-    </gridmap>
-
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="oEC60to30v3">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_oEC60to30v3_mono.200220.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_oEC60to30v3_bilin.200220.nc</map>
@@ -2893,13 +2797,6 @@
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_r05_mono.191016.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne30np4/map_r05_to_ne30np4_mono.191016.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne30np4/map_r05_to_ne30np4_mono.191016.nc</map>
-    </gridmap>
-
-    <gridmap atm_grid="ne30np4.pg1" lnd_grid="r05">
-      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_r05_mono.200331.nc</map>
-      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_r05_bilin.200331.nc</map>
-      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne30pg1/map_r05_to_ne30pg1_mono.200331.nc</map>
-      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne30pg1/map_r05_to_ne30pg1_mono.200331.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" lnd_grid="r05">
@@ -3410,11 +3307,6 @@
     <gridmap atm_grid="ne30np4" rof_grid="r05">
       <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne30np4/map_ne30np4_to_0.5x0.5rtm_aave_da_110320.nc</map>
       <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/ne30np4/map_ne30np4_to_0.5x0.5rtm_aave_da_110320.nc</map>
-    </gridmap>
-
-    <gridmap atm_grid="ne30np4.pg1" rof_grid="r05">
-      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_r05_mono.200331.nc</map>
-      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne30pg1/map_ne30pg1_to_r05_mono.200331.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" rof_grid="r05">

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -2109,7 +2109,7 @@
     <domain name="ne30np4.pg4">
       <nx>86400</nx>
       <ny>1</ny>
-      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg4_oEC60to30v3.200330.n</file>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg4_oEC60to30v3.200330.nc</file>
       <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg4_oEC60to30v3.200330.nc</file>
       <desc>ne30np4.pg4 is Spectral Elem 1-deg grid w/ 4x4 FV physics grid per element:</desc>
     </domain>

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -1267,6 +1267,16 @@
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="ne120pg2_r05_oECv3">
+      <grid name="atm">ne120np4.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
+
     <model_grid alias="ne240_ne240" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">ne240np4</grid>
@@ -2208,8 +2218,8 @@
     <domain name="ne120np4.pg2">
       <nx>345600</nx>
       <ny>1</ny>
-      <file grid="atm|lnd" mask="gx1v6">DUMMY</file>
-      <file grid="ice|ocn" mask="gx1v6">DUMMY</file>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_oEC60to30v3.200511.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_oEC60to30v3.200511.nc</file>
       <desc>ne120np4 is Spectral Elem 1/4-deg grid w/ 2x2 FV physics grid</desc>
     </domain>
 
@@ -2955,6 +2965,26 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_conserve.170111.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne120np4.pg2" ocn_grid="oEC60to30v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_oEC60to30v3_mono.200331.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_oEC60to30v3_bilin.200331.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_oEC60to30v3_bilin.200331.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne120pg2_mono.200331.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne120pg2_mono.200331.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne120np4.pg2" lnd_grid="r05">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_r05_mono.200331.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_r05_bilin.200331.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne120pg2/map_r05_to_ne120pg2_mono.200331.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne120pg2/map_r05_to_ne120pg2_mono.200331.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne120np4.pg2" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_r05_mono.200331.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_r05_bilin.200331.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne240np4" ocn_grid="gx1v6">

--- a/cime/config/e3sm/config_grids.xml
+++ b/cime/config/e3sm/config_grids.xml
@@ -834,6 +834,26 @@
       <mask>tx0.1v2</mask>
     </model_grid>
 
+    <model_grid alias="conusx4v1_r05_oECv3">
+      <grid name="atm">ne0np4_conus_x4v1_lowcon</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
+
+    <model_grid alias="conusx4v1pg2_r05_oECv3">
+      <grid name="atm">ne0np4_conus_x4v1_lowcon.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
+
     <model_grid alias="northamericax4v1_r0125_oRRS15to5">
       <grid name="atm">ne0np4_northamericax4v1</grid>
       <grid name="lnd">r0125</grid>
@@ -2456,6 +2476,16 @@
       <ny>1</ny>
       <file grid="atm|lnd" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.lnd.conusx4v1_tx0.1v2.161129.nc</file>
       <file grid="ice|ocn" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.ocn.conusx4v1_tx0.1v2.161129.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.conusx4v1_oEC60to30v3.200518.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.conusx4v1_oEC60to30v3.200518.nc</file>
+      <desc>1-deg with 1/4-deg over CONUS (version 1):</desc>
+    </domain>
+
+    <domain name="ne0np4_conus_x4v1_lowcon.pg2">
+      <nx>39620</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.conusx4v1pg2_oEC60to30v3.200518.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.conusx4v1pg2_oEC60to30v3.200518.nc</file>
       <desc>1-deg with 1/4-deg over CONUS (version 1):</desc>
     </domain>
 
@@ -2986,6 +3016,43 @@
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne1024pg2/map_ne1024pg2_to_r0125_mono.200212.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne1024pg2/map_r0125_to_ne1024pg2_mono.200212.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne1024pg2/map_r0125_to_ne1024pg2_bilin.200212.nc</map>
+    </gridmap>
+
+
+    <gridmap atm_grid="ne0np4_conus_x4v1_lowcon" ocn_grid="oEC60to30v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_oEC60to30v3_mono.200514.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_oEC60to30v3_bilin.200514.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_oEC60to30v3_bilin.200514.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_conusx4v1_monotr.200514.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_conusx4v1_monotr.200514.nc</map>
+    </gridmap>
+    <gridmap atm_grid="ne0np4_conus_x4v1_lowcon" lnd_grid="r05">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_r05_mono.200514.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_r05_bilin.200514.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/conusx4v1/map_r05_to_conusx4v1_monotr.200514.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/conusx4v1/map_r05_to_conusx4v1_bilin.200514.nc</map>
+    </gridmap>
+    <gridmap atm_grid="ne0np4_conus_x4v1_lowcon" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_r05_mono.200514.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_r05_bilin.200514.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne0np4_conus_x4v1_lowcon.pg2" ocn_grid="oEC60to30v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/conusx4v1pg2/map_conusx4v1pg2_to_oEC60to30v3_mono.200514.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/conusx4v1pg2/map_conusx4v1pg2_to_oEC60to30v3_bilin.200514.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/conusx4v1pg2/map_conusx4v1pg2_to_oEC60to30v3_bilin.200514.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_conusx4v1pg2_mono.200514.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_conusx4v1pg2_mono.200514.nc</map>
+    </gridmap>
+    <gridmap atm_grid="ne0np4_conus_x4v1_lowcon.pg2" lnd_grid="r05">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/conusx4v1pg2/map_conusx4v1pg2_to_r05_mono.200514.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/conusx4v1pg2/map_conusx4v1pg2_to_r05_bilin.200514.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/conusx4v1pg2/map_r05_to_conusx4v1pg2_mono.200514.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/conusx4v1pg2/map_r05_to_conusx4v1pg2_mono.200514.nc</map>
+    </gridmap>
+    <gridmap atm_grid="ne0np4_conus_x4v1_lowcon.pg2" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/conusx4v1pg2/map_conusx4v1pg2_to_r05_mono.200514.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/conusx4v1pg2/map_conusx4v1pg2_to_r05_bilin.200514.nc</map>
     </gridmap>
 
 

--- a/components/cam/bld/config_files/horiz_grid.xml
+++ b/components/cam/bld/config_files/horiz_grid.xml
@@ -69,6 +69,7 @@
 <!-- Spectral Element w/ Regional Refinement -->
 <horiz_grid dyn="se" hgrid="ne0np4_arm_x8v3_lowcon"           ncol="92558"  csne="0" csnp="4" npg="0" />
 <horiz_grid dyn="se" hgrid="ne0np4_conus_x4v1_lowcon"         ncol="89147"  csne="0" csnp="4" npg="0" />
+<horiz_grid dyn="se" hgrid="ne0np4_conus_x4v1_lowcon.pg2"     ncol="39620"  csne="0" csnp="4" npg="2" />
 <horiz_grid dyn="se" hgrid="ne0np4_northamericax4v1"          ncol="130088" csne="0" csnp="4" npg="0" />
 <horiz_grid dyn="se" hgrid="ne0np4_northamericax4v1.pg2"      ncol="57816"  csne="0" csnp="4" npg="2" />
 <horiz_grid dyn="se" hgrid="ne0np4_antarcticax4v1"            ncol="109883" csne="0" csnp="4" npg="0" />

--- a/components/cam/bld/config_files/horiz_grid.xml
+++ b/components/cam/bld/config_files/horiz_grid.xml
@@ -34,8 +34,8 @@
 <!-- if npg=0 then physics is done on GLL nodes -->
 <!-- if npg=N>0 then physics is done FV grid with NxN cells per element -->
 <!-- Formualas for ncol:           -->
-<!--   np4: ncol = (np-1)*6*ne^2+2 -->
-<!--   pgN: ncol = 6*ne^2*npg^2    -->
+<!--   GLL grid (np4): ncol = (np-1)*6*ne^2+2 -->
+<!--   FV physgrid   : ncol = 6*ne^2*npg^2    -->
 <horiz_grid dyn="se"    hgrid="ne2np4"       ncol="218"     csne="2"   csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne4np4"       ncol="866"     csne="4"   csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne4np4.pg2"   ncol="384"     csne="4"   csnp="4" npg="2" />

--- a/components/cam/bld/config_files/horiz_grid.xml
+++ b/components/cam/bld/config_files/horiz_grid.xml
@@ -35,11 +35,9 @@
 <!-- if npg=N>0 then physics is done FV grid with NxN cells per element -->
 <!-- Formualas for ncol:           -->
 <!--   np4: ncol = (np-1)*6*ne^2+2 -->
-<!--   pg1: ncol = 6*ne^2          -->
-<!--   pg2: ncol = 6*ne^2*4        -->
+<!--   pgN: ncol = 6*ne^2*npg^2    -->
 <horiz_grid dyn="se"    hgrid="ne2np4"       ncol="218"     csne="2"   csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne4np4"       ncol="866"     csne="4"   csnp="4" npg="0" />
-<horiz_grid dyn="se"    hgrid="ne4np4.pg1"   ncol="96"      csne="4"   csnp="4" npg="1" />
 <horiz_grid dyn="se"    hgrid="ne4np4.pg2"   ncol="384"     csne="4"   csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne5np8"       ncol="7352"    csne="5"   csnp="8" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne7np8"       ncol="14408"   csne="7"   csnp="8" npg="0" />
@@ -52,7 +50,6 @@
 <horiz_grid dyn="se"    hgrid="ne16np8"      ncol="75266"   csne="16"  csnp="8" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne21np4"      ncol="23816"   csne="21"  csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne30np4"      ncol="48602"   csne="30"  csnp="4" npg="0" />
-<horiz_grid dyn="se"    hgrid="ne30np4.pg1"  ncol="5400"    csne="30"  csnp="4" npg="1" />
 <horiz_grid dyn="se"    hgrid="ne30np4.pg2"  ncol="21600"   csne="30"  csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne30np4.pg3"  ncol="48600"   csne="30"  csnp="4" npg="3" />
 <horiz_grid dyn="se"    hgrid="ne30np4.pg4"  ncol="86400"   csne="30"  csnp="4" npg="4" />

--- a/components/cam/bld/config_files/horiz_grid.xml
+++ b/components/cam/bld/config_files/horiz_grid.xml
@@ -54,6 +54,8 @@
 <horiz_grid dyn="se"    hgrid="ne30np4"      ncol="48602"   csne="30"  csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne30np4.pg1"  ncol="5400"    csne="30"  csnp="4" npg="1" />
 <horiz_grid dyn="se"    hgrid="ne30np4.pg2"  ncol="21600"   csne="30"  csnp="4" npg="2" />
+<horiz_grid dyn="se"    hgrid="ne30np4.pg3"  ncol="48600"   csne="30"  csnp="4" npg="3" />
+<horiz_grid dyn="se"    hgrid="ne30np4.pg4"  ncol="86400"   csne="30"  csnp="4" npg="4" />
 <horiz_grid dyn="se"    hgrid="ne60np4"      ncol="194402"  csne="60"  csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne60np4.pg2"  ncol="86400"   csne="60"  csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne120np4"     ncol="777602"  csne="120" csnp="4" npg="0" />

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -236,7 +236,10 @@
 <bnd_topo hgrid="ne11np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne11np4_16xconsistentSGH.c20160612.nc</bnd_topo>
 <bnd_topo hgrid="ne16np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne16np4_16xconsistentSGH.c20160612.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne30np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
+<bnd_topo hgrid="ne30np4"  npg="1">atm/cam/topo/USGS-gtopo30_ne30np4pg1_16xdel2.c20200504.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne30np4pg2_16xdel2.c20200108.nc</bnd_topo>
+<bnd_topo hgrid="ne30np4"  npg="3">atm/cam/topo/USGS-gtopo30_ne30np4pg3_16xdel2.c20200504.nc</bnd_topo>
+<bnd_topo hgrid="ne30np4"  npg="4">atm/cam/topo/USGS-gtopo30_ne30np4pg4_16xdel2.c20200504.nc</bnd_topo>
 <bnd_topo hgrid="ne60np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne60np4_16xconsistentSGH.c20140517.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="0">atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
 <bnd_topo hgrid="ne240np4" npg="0">atm/cam/topo/USGS-gtopo30_ne240np4_16xconsistentSGH.c20130724.nc</bnd_topo>
@@ -830,7 +833,10 @@
 <drydep_srf_file hgrid="ne11np4" >atm/cam/chem/trop_mam/atmsrf_ne11np4_c151204.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne16np4" >atm/cam/chem/trop_mam/atmsrf_ne16np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne30np4" npg="0">atm/cam/chem/trop_mam/atmsrf_ne30np4_110920.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne30np4" npg="1">atm/cam/chem/trop_mam/atmsrf_ne30pg1_200501.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne30np4" npg="2">atm/cam/chem/trop_mam/atmsrf_ne30pg2_200129.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne30np4" npg="3">atm/cam/chem/trop_mam/atmsrf_ne30pg3_200501.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne30np4" npg="4">atm/cam/chem/trop_mam/atmsrf_ne30pg4_200501.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne60np4" >atm/cam/chem/trop_mam/atmsrf_ne60np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne120np4">atm/cam/chem/trop_mam/atmsrf_ne120np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne240np4">atm/cam/chem/trop_mam/atmsrf_ne240np4_110920.nc</drydep_srf_file>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -242,6 +242,7 @@
 <bnd_topo hgrid="ne30np4"  npg="4">atm/cam/topo/USGS-gtopo30_ne30np4pg4_16xdel2.c20200504.nc</bnd_topo>
 <bnd_topo hgrid="ne60np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne60np4_16xconsistentSGH.c20140517.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="0">atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
+<bnd_topo hgrid="ne120np4" npg="2">atm/cam/topo/USGS-gtopo30_ne120np4pg2_16xdel2.nc</bnd_topo>
 <bnd_topo hgrid="ne240np4" npg="0">atm/cam/topo/USGS-gtopo30_ne240np4_16xconsistentSGH.c20130724.nc</bnd_topo>
 <bnd_topo hgrid="ne512np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne512np4_16xconsistentSGH_20190212.nc</bnd_topo>
 <bnd_topo hgrid="ne1024np4" npg="0">atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH_20190528.nc</bnd_topo>
@@ -842,6 +843,7 @@
 <drydep_srf_file hgrid="ne240np4">atm/cam/chem/trop_mam/atmsrf_ne240np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne512np4">atm/cam/chem/trop_mam/atmsrf_ne512np4_interp_20190409.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne1024np4">atm/cam/chem/trop_mam/atmsrf_ne1024np4_20190621.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne120np4"  npg="2">atm/cam/chem/trop_mam/atmsrf_ne120pg2_200511.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne256np4"  npg="2">atm/cam/chem/trop_mam/atmsrf_ne256pg2_200212.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne512np4"  npg="2">atm/cam/chem/trop_mam/atmsrf_ne512pg2_200212.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne1024np4" npg="2">atm/cam/chem/trop_mam/atmsrf_ne1024pg2_200212.nc</drydep_srf_file>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -250,7 +250,8 @@
 <bnd_topo hgrid="ne1024np4" npg="2">atm/cam/topo/USGS-gtopo30_ne1024np4pg2_16xconsistentSGH_20190528_converted.nc</bnd_topo>
 
 <bnd_topo hgrid="ne0np4_arm_x8v3_lowcon"  >atm/cam/inic/homme/USGS-gtopo30_arm_x8v3_lowcon_tensor12xconsistentSGH.nc</bnd_topo>
-<bnd_topo hgrid="ne0np4_conus_x4v1_lowcon"  >atm/cam/topo/USGS_conusx4v1-tensor12x_consistentSGH_c150924.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4_conus_x4v1_lowcon"        >atm/cam/topo/USGS_conusx4v1-tensor12x_consistentSGH_c150924.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4_conus_x4v1_lowcon" npg="2">atm/cam/topo/USGS_conusx4v1pg2_12x_consistentSGH_20200609.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_northamericax4v1"  >atm/cam/topo/USGS_northamericax4v1_12xdel2_consistentSGH_191023.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_northamericax4v1" npg="2">atm/cam/topo/USGS_northamericax4v1pg2_12xdel2_consistentSGH_20020209.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_antarcticax4v1"  >atm/cam/topo/USGS-gtopo30_antarcticax4v1_12xdel2_consistentSGH_191120.nc</bnd_topo>
@@ -847,7 +848,8 @@
 <drydep_srf_file hgrid="ne1024np4" npg="2">atm/cam/chem/trop_mam/atmsrf_ne1024pg2_200212.nc</drydep_srf_file>
 
 <drydep_srf_file hgrid="ne0np4_arm_x8v3_lowcon">atm/cam/chem/trop_mam/atmsrf_armx8v3.nc</drydep_srf_file>
-<drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon">atm/cam/chem/trop_mam/atmsrf_conusx4v1.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon"      >atm/cam/chem/trop_mam/atmsrf_conusx4v1.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon" npg=2>atm/cam/chem/trop_mam/atmsrf_conusx4v1pg2_20020609.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_northamericax4v1">atm/cam/chem/trop_mam/atmsrf_northamericax4v1np4_20191023.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_northamericax4v1" npg="2">atm/cam/chem/trop_mam/atmsrf_northamericax4v1pg2_20020209.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_antarcticax4v1">atm/cam/chem/trop_mam/atmsrf_antarcticax4v1np4_20191127.nc</drydep_srf_file>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -848,8 +848,8 @@
 <drydep_srf_file hgrid="ne1024np4" npg="2">atm/cam/chem/trop_mam/atmsrf_ne1024pg2_200212.nc</drydep_srf_file>
 
 <drydep_srf_file hgrid="ne0np4_arm_x8v3_lowcon">atm/cam/chem/trop_mam/atmsrf_armx8v3.nc</drydep_srf_file>
-<drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon"      >atm/cam/chem/trop_mam/atmsrf_conusx4v1.nc</drydep_srf_file>
-<drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon" npg=2>atm/cam/chem/trop_mam/atmsrf_conusx4v1pg2_20020609.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon" >atm/cam/chem/trop_mam/atmsrf_conusx4v1.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon" npg=2 >atm/cam/chem/trop_mam/atmsrf_conusx4v1pg2_20020609.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_northamericax4v1">atm/cam/chem/trop_mam/atmsrf_northamericax4v1np4_20191023.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_northamericax4v1" npg="2">atm/cam/chem/trop_mam/atmsrf_northamericax4v1pg2_20020209.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_antarcticax4v1">atm/cam/chem/trop_mam/atmsrf_antarcticax4v1np4_20191127.nc</drydep_srf_file>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -236,7 +236,6 @@
 <bnd_topo hgrid="ne11np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne11np4_16xconsistentSGH.c20160612.nc</bnd_topo>
 <bnd_topo hgrid="ne16np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne16np4_16xconsistentSGH.c20160612.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne30np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
-<bnd_topo hgrid="ne30np4"  npg="1">atm/cam/topo/USGS-gtopo30_ne30np4pg1_16xdel2.c20200504.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne30np4pg2_16xdel2.c20200108.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="3">atm/cam/topo/USGS-gtopo30_ne30np4pg3_16xdel2.c20200504.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="4">atm/cam/topo/USGS-gtopo30_ne30np4pg4_16xdel2.c20200504.nc</bnd_topo>
@@ -834,7 +833,6 @@
 <drydep_srf_file hgrid="ne11np4" >atm/cam/chem/trop_mam/atmsrf_ne11np4_c151204.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne16np4" >atm/cam/chem/trop_mam/atmsrf_ne16np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne30np4" npg="0">atm/cam/chem/trop_mam/atmsrf_ne30np4_110920.nc</drydep_srf_file>
-<drydep_srf_file hgrid="ne30np4" npg="1">atm/cam/chem/trop_mam/atmsrf_ne30pg1_200501.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne30np4" npg="2">atm/cam/chem/trop_mam/atmsrf_ne30pg2_200129.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne30np4" npg="3">atm/cam/chem/trop_mam/atmsrf_ne30pg3_200501.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne30np4" npg="4">atm/cam/chem/trop_mam/atmsrf_ne30pg4_200501.nc</drydep_srf_file>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -849,7 +849,7 @@
 
 <drydep_srf_file hgrid="ne0np4_arm_x8v3_lowcon">atm/cam/chem/trop_mam/atmsrf_armx8v3.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon" >atm/cam/chem/trop_mam/atmsrf_conusx4v1.nc</drydep_srf_file>
-<drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon" npg=2 >atm/cam/chem/trop_mam/atmsrf_conusx4v1pg2_20020609.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4_conus_x4v1_lowcon" npg="2" >atm/cam/chem/trop_mam/atmsrf_conusx4v1pg2_20020609.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_northamericax4v1">atm/cam/chem/trop_mam/atmsrf_northamericax4v1np4_20191023.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_northamericax4v1" npg="2">atm/cam/chem/trop_mam/atmsrf_northamericax4v1pg2_20020209.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_antarcticax4v1">atm/cam/chem/trop_mam/atmsrf_antarcticax4v1np4_20191127.nc</drydep_srf_file>


### PR DESCRIPTION
Add mapping/domain/topo/drydep files for running with certain tri-grid+physgrid configurations, and removes support for "pg1" grids. The new grids are:
ne30pg3_r05_oECv3
ne30pg4_r05_oECv3
ne120pg2_r05_oECv3
conusx4v1_r05_oECv3
conusx4v1pg2_r05_oECv3

[BFB]