### PR TITLE
implement revised nudging code

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -283,11 +283,11 @@
        group="nudging_nl" valid_values="" >
        Use user-defined relaxation time scale (unit: hour).
        If Nudge_Tau > 0, the relaxation time scale is determined by Nudge_Tau;
-       If not, the relaxation time scale is determined by Nudge_Times_Per_Day;
+       If not, the relaxation time scale is determined by Nudge_Times_Per_Day and nudging strength specified in the namelist (e.g. Nudge_Ucoef).
        Default: -999
        </entry>
 
-<entry id="Nudge_Loc" type="logical" category="nudging"
+<entry id="Nudge_Loc_Same" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
        If TRUE, change the location of calculation of nudging tendency to 
        the same location where the nudging data is written out.
@@ -303,13 +303,13 @@
        Default: FALSE
        </entry>
 
-<entry id="Num_Slice" type="integer" category="nudging"
+<entry id="Nudge_File_Ntime" type="integer" category="nudging"
        group="nudging_nl" valid_values="" >
        Number of time slices per nudging data file
        The current nudging code only works for the nudging data file with one-day data. 
        It does not work correctly when the nudging data file contains multiple-day data.
-       Thus, Num_Slice has to equal to 1 or Nudge_Times_Per_Day.
-       Set default Num_Slice to 0 to force the user to set its value correctly.
+       Thus, Num_File_Ntime has to equal to 1 or Nudge_Times_Per_Day.
+       Set default Num_File_Ntime to 0 to force the user to set its value correctly.
        Default: 0
        </entry>
 

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -269,13 +269,13 @@
        group="nudging_nl" valid_values="" >
        Method to perform Nudging analyses.
        1. Step: the model meteorology is nudged toward the same (future) time 
-          slice of the constraining data within each nudging window (e.g., 6-hr)
+          slice of the constraining data within each nudging window (e.g., 6-hr).
        2. Linear: the model meteorology is nudged toward the state at the next 
           model time step, which is linearly interpolated between two neighboring 
-          time slices of the constraining data 
+          time slices of the constraining data. 
        3. IMT: the model meteorology is nudged toward the constraining data at 
           the same model time step and nudging is only applied when the constrainging 
-          data is available
+          data is available.
        Default: Linear
        </entry>
 
@@ -289,22 +289,28 @@
 
 <entry id="Nudge_Loc" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       If TRUE, change the location of calculation of nudging tendency to the same location
-       where the nudging data is written out
-       If FALSE, calculate the nudging tendency at the beginning of tphysbc (the same as the default model)
+       If TRUE, change the location of calculation of nudging tendency to 
+       the same location where the nudging data is written out.
+       If FALSE, calculate the nudging tendency at the beginning of 
+       tphysbc (the same as the default model).
        Default: TRUE
        </entry>
 
 <entry id="Nudge_Curr" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       Linearly interpolate nudging data to current (set to TRUE) or future (set to FALSE, used by the default model) model time step
+       Linearly interpolate nudging data to current (set to TRUE) or future 
+       (set to FALSE, used by the default model) model time step.
        Default: FALSE
        </entry>
 
 <entry id="Num_Slice" type="integer" category="nudging"
        group="nudging_nl" valid_values="" >
        Number of time slices per nudging data file
-       Default: 1 
+       The current nudging code only works for the nudging data file with one-day data. 
+       It does not work correctly when the nudging data file contains multiple-day data.
+       Thus, Num_Slice has to equal to 1 or Nudge_Times_Per_Day.
+       Set default Num_Slice to 0 to force the user to set its value correctly.
+       Default: 0
        </entry>
 
 <!-- Aerosols: Data (CAM version) -->

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -265,217 +265,35 @@
        Default: none
        </entry>
 
-
-<!-- Nudging Parameters -->
-
-<entry id="Nudge_Model" type="logical" category="nudging"
+<entry id="Nudge_Method" type="char*80" category="nudging"
        group="nudging_nl" valid_values="" >
-       Toggle Model Nudging ON/OFF.
+       Method to perform Nudging analyses.
+       Default: Step
+       </entry>
+
+<entry id="Nudge_Tau" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Use user-defined relaxation time scale. 
+       Default: -999
+       </entry>
+
+<entry id="Nudge_Loc" type="logical" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Change the location of calculation of nudging tendency to the same location 
+       where the nudging data is written out
        Default: FALSE
        </entry>
 
-<entry id="Nudge_Path" type="char*256" input_pathname="abs" category="nudging"
+<entry id="Nudge_Curr" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       Full pathname of analyses data to use for nudging.
-       Default: none
+       Linearly interpolate nudging data to current or future model time step
+       Default: FALSE
        </entry>
 
-<entry id="Nudge_File_Template" type="char*80" category="nudging"
+<entry id="Num_Slice" type="integer" category="nudging"
        group="nudging_nl" valid_values="" >
-       Template for Nudging analyses file names.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Times_Per_Day" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Number of analyses files per day.
-       Default: none
-       </entry>
-
-<entry id="Model_Times_Per_Day" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Number of time to update model data per day.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Uprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for U nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Ucoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for U nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for V nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vcoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for V nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Tprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for T nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Tcoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for T nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Qprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for Q nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Qcoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for Q nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_PSprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for PS nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_PScoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for PS nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Beg_Year" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Year at which Nudging Begins.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Beg_Month" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Month at which Nudging Begins.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Beg_Day" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Day at which Nudging Begins.
-       Default: none
-       </entry>
-
-<entry id="Nudge_End_Year" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Year at which Nudging Ends.
-       Default: none
-       </entry>
-
-<entry id="Nudge_End_Month" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Month at which Nudging Ends.
-       Default: none
-       </entry>
-
-<entry id="Nudge_End_Day" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Day at which Nudging Ends.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lo" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LOW Coeffcient for Horizontal Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_hi" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       HIGH Coeffcient for Horizontal Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lat0" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LAT0 of Horizonalt Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_latWidth" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Width of LAT Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_latDelta" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Steepness of LAT Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lon0" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LON0 of Horizontal Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lonWidth" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Width of LON Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lonDelta" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Steepness of LON Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_lo" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LOW Coeffcient for Vertical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_hi" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       HIGH Coeffcient for Vertical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_Hindex" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       HIGH Level Index for Verical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_Hdelta" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Steepness of HIGH end of Vertical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_Lindex" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LOW Level Index for Verical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_Ldelta" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Steepness of LOW end of Vertical Window.
-       Default: none
+       Number of time slices per nudging data file; Must be 1 or Nudge_Times_Per_Day
+       Default: 1 
        </entry>
 
 <!-- Aerosols: Data (CAM version) -->

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -308,8 +308,8 @@
        Number of time slices per nudging data file
        The current nudging code only works for the nudging data file with one-day data. 
        It does not work correctly when the nudging data file contains multiple-day data.
-       Thus, Num_File_Ntime has to equal to 1 or Nudge_Times_Per_Day.
-       Set default Num_File_Ntime to 0 to force the user to set its value correctly.
+       Thus, Nudge_File_Ntime has to equal to 1 or Nudge_Times_Per_Day.
+       Set default Nudge_File_Ntime to 0 to force the user to set its value correctly.
        Default: 0
        </entry>
 

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -268,31 +268,42 @@
 <entry id="Nudge_Method" type="char*80" category="nudging"
        group="nudging_nl" valid_values="" >
        Method to perform Nudging analyses.
-       Default: Step
+       1. Step: the model meteorology is nudged toward the same (future) time 
+          slice of the constraining data within each nudging window (e.g., 6-hr)
+       2. Linear: the model meteorology is nudged toward the state at the next 
+          model time step, which is linearly interpolated between two neighboring 
+          time slices of the constraining data 
+       3. IMT: the model meteorology is nudged toward the constraining data at 
+          the same model time step and nudging is only applied when the constrainging 
+          data is available
+       Default: Linear
        </entry>
 
 <entry id="Nudge_Tau" type="real" category="nudging"
        group="nudging_nl" valid_values="" >
-       Use user-defined relaxation time scale. 
+       Use user-defined relaxation time scale (unit: hour).
+       If Nudge_Tau > 0, the relaxation time scale is determined by Nudge_Tau;
+       If not, the relaxation time scale is determined by Nudge_Times_Per_Day;
        Default: -999
        </entry>
 
 <entry id="Nudge_Loc" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       Change the location of calculation of nudging tendency to the same location 
+       If TRUE, change the location of calculation of nudging tendency to the same location
        where the nudging data is written out
-       Default: FALSE
+       If FALSE, calculate the nudging tendency at the beginning of tphysbc (the same as the default model)
+       Default: TRUE
        </entry>
 
 <entry id="Nudge_Curr" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       Linearly interpolate nudging data to current or future model time step
+       Linearly interpolate nudging data to current (set to TRUE) or future (set to FALSE, used by the default model) model time step
        Default: FALSE
        </entry>
 
 <entry id="Num_Slice" type="integer" category="nudging"
        group="nudging_nl" valid_values="" >
-       Number of time slices per nudging data file; Must be 1 or Nudge_Times_Per_Day
+       Number of time slices per nudging data file
        Default: 1 
        </entry>
 

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -164,6 +164,9 @@ module nudging
 !                        Example: Nudge_Curr = FALSE 
 !
 !        Num_Slice:      Number of time slices per nudging data file
+!                        The current nudging code only works for the nudging data file with one-day data.
+!                        It does not work correctly when the nudging data file contains multiple-day data.
+!                        Thus, Num_Slice has to equal to 1 or Nudge_Times_Per_Day.
 !
 !                        Example: Num_Slice = 1
 !
@@ -218,7 +221,7 @@ module nudging
 !      Nudge_Loc           - LOGICAL change the location of calculation of nudging tendency 
 !      Nudge_Curr          - LOGICAL linearly interpolate nudging data to current
 !                                    or future model time step
-!      Num_Slice           - Number of time slices per nudging data file
+!      Num_Slice           - INT  Number of time slices per nudging data file
 !    /
 !
 !================
@@ -462,7 +465,7 @@ contains
    Nudge_Loc          = .true.
    Nudge_Tau          = -999._r8
    Nudge_Curr         = .false.
-   Num_Slice          = 1
+   Num_Slice          = 0
    ! Read in namelist values
    !------------------------
    if(masterproc) then
@@ -532,11 +535,11 @@ contains
      call endrun('nudging_readnl:: ERROR in namelist')
    endif
 
-!   if ( (Num_Slice .ne. Nudge_Times_Per_Day) .and. (Num_Slice .ne. 1) ) then
-!     write(iulog,*) 'NUDGING: Num_Slice=',Num_Slice 
-!     write(iulog,*) 'NUDGING: Num_Slice must equal to Nudge_Times_Per_Day or 1'
-!     call endrun('nudging_readnl:: ERROR in namelist')
-!   end if
+   if ( (Num_Slice .ne. Nudge_Times_Per_Day) .and. (Num_Slice .ne. 1) ) then
+     write(iulog,*) 'NUDGING: Num_Slice=',Num_Slice 
+     write(iulog,*) 'NUDGING: Num_Slice must equal to Nudge_Times_Per_Day or 1'
+     call endrun('nudging_readnl:: ERROR in namelist')
+   end if
 
    ! Broadcast namelist variables
    !------------------------------

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -542,12 +542,6 @@ contains
      call endrun('nudging_readnl:: ERROR in namelist')
    endif
 
-   if ( (Nudge_File_Ntime .ne. Nudge_Times_Per_Day) .and. (Nudge_File_Ntime .ne. 1) ) then
-     write(iulog,*) 'NUDGING: Nudge_File_Ntime=',Nudge_File_Ntime 
-     write(iulog,*) 'NUDGING: Nudge_File_Ntime must equal to Nudge_Times_Per_Day or 1'
-     call endrun('nudging_readnl:: ERROR in namelist')
-   end if
-
    ! Broadcast namelist variables
    !------------------------------
 #ifdef SPMD
@@ -597,6 +591,12 @@ contains
    call mpibcast(Nudge_Curr,1,mpilog,0,mpicom)
    call mpibcast(Nudge_File_Ntime,1,mpiint,0,mpicom)
 #endif
+
+   if ( (Nudge_File_Ntime .ne. Nudge_Times_Per_Day) .and. (Nudge_File_Ntime .ne. 1) ) then
+     write(iulog,*) 'NUDGING: Nudge_File_Ntime=',Nudge_File_Ntime
+     write(iulog,*) 'NUDGING: Nudge_File_Ntime must equal to Nudge_Times_Per_Day or 1'
+     call endrun('nudging_readnl:: ERROR in namelist')
+   end if
 
    ! End Routine
    !------------

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1910,7 +1910,7 @@ subroutine tphysbc (ztodt,               &
     use subcol,          only: subcol_gen, subcol_ptend_avg
     use subcol_utils,    only: subcol_ptend_copy, is_subcol_on
     use phys_control,    only: use_qqflx_fixer, use_mass_borrower
-    use nudging,         only: Nudge_Model,Nudge_Loc,nudging_calc_tend
+    use nudging,         only: Nudge_Model,Nudge_Loc_Same,nudging_calc_tend
 
     implicit none
 
@@ -2751,7 +2751,7 @@ end if ! l_tracer_aero
     !===================================
     ! Update Nudging tendency if needed
     !===================================
-    if (Nudge_Model .and. Nudge_Loc) then
+    if (Nudge_Model .and. Nudge_Loc_Same) then
        call nudging_calc_tend(state)
     endif
 

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1731,6 +1731,14 @@ if (l_gw_drag) then
 
 end if ! l_gw_drag
 
+    !===================================================
+    ! Update Nudging values, if needed
+    !===================================================
+    if((Nudge_Model).and.(Nudge_ON)) then
+      call nudging_timestep_tend(state,ptend)
+      call physics_update(state,ptend,ztodt,tend)
+    endif
+
 if (l_ac_energy_chk) then
     !-------------- Energy budget checks vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 
@@ -1790,14 +1798,6 @@ end if ! l_ac_energy_chk
        if (labort) then
           call endrun ('TPHYSAC error:  grid contains non-ocean point')
        endif
-    endif
-
-    !===================================================
-    ! Update Nudging values, if needed
-    !===================================================
-    if((Nudge_Model).and.(Nudge_ON)) then
-      call nudging_timestep_tend(state,ptend)
-      call physics_update(state,ptend,ztodt,tend)
     endif
 
     call diag_phys_tend_writeout (state, pbuf,  tend, ztodt, tmp_q, tmp_cldliq, tmp_cldice, &
@@ -1910,6 +1910,7 @@ subroutine tphysbc (ztodt,               &
     use subcol,          only: subcol_gen, subcol_ptend_avg
     use subcol_utils,    only: subcol_ptend_copy, is_subcol_on
     use phys_control,    only: use_qqflx_fixer, use_mass_borrower
+    use nudging,         only: Nudge_Model,Nudge_Loc,nudging_calc_tend
 
     implicit none
 
@@ -2746,6 +2747,13 @@ end if ! l_tracer_aero
     call diag_conv(state, ztodt, pbuf)
 
     call t_stopf('bc_history_write')
+
+    !===================================
+    ! Update Nudging tendency if needed
+    !===================================
+    if (Nudge_Model .and. Nudge_Loc) then
+       call nudging_calc_tend(state)
+    endif
 
     !===================================================
     ! Write cloud diagnostics on history file


### PR DESCRIPTION
We have implemented a revised version of nudging code in E3SM to fix the issue #3565. 

Changes include: 
1. add linear interpolation for nudging input data
2. flexible handling of nudging input data (e.g., multiple time slices per file; but do not support multiple-day data per file)
3. bugfixes
- reset the nudging tendency to zero for intermittent nudging (in nudging.F90)
- location of calculation of nudging tendency (in nudging.F90 and physpkg.F90)
- location of update of nudging tendency (in physpkg.F90, affect FV dycore only)
- duplicate namelist definitions (in namelist_definition.xml)
4. suggest to use the following default settings for the newly added namelist variables
- Nudge_Method = 'Linear'
- Nudge_Loc_Same = .TRUE.
- Nudge_Tau             = -999.
- Nudge_Curr           = .FALSE.
- Nudge_File_Ntime = 0
5. More details about these changes could be found in the comments of namelist_definition.xml and nudging.F90

    modified:   components/cam/bld/namelist_files/namelist_definition.xml
    modified:   components/cam/src/physics/cam/nudging.F90
    modified:   components/cam/src/physics/cam/physpkg.F90

Original development branch can be found here: 
https://github.com/E3SM-Project/E3SM/tree/jiansunpnnl/ndg_loc

The revised nudging implementation has been evaluated in Sun et al. (2019). 

[BFB] when nudging is not switched on 
[BFB] when nudging is switched on, but use nudge_method = step, nudge_loc_same = .false., nudge_tau = -999, nudge_file_ntime = 1, nudge_curr = .false. and one time slice per nudging input data file