### PR TITLE
Fix issue with unallocated elem structure in dynamics initialization

### DIFF
--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -167,6 +167,9 @@ CONTAINS
        neltmp(1) = 0
        neltmp(2) = 0
        neltmp(3) = 0
+       allocate(elem(nelemd))
+       dyn_in%elem => elem
+       dyn_out%elem => elem
     endif
 
     dyndecomp_set = .true.


### PR DESCRIPTION
This commit addresses an issue with passing a null pointer as input to
a subroutine when the number of MPI ranks is greater than the number
of dynamics elements.

The element structure "elem" is unitialized on all MPI ranks that are
not tagged to solve dynamics.  Thus keeping the original declaration as
a null pointer.

In some cases with certain compiler flags active this can cause the
simulation to halt with an error related to passing the null pointer
"elem" as an input.

This fix allocates the elem pointer to be empty.

[BFB]