### PR TITLE
Update modules on Cori (cori-knl and cori-haswell) to reflect the currents defaults

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -119,7 +119,6 @@
         <command name="rm">craype-sandybridge</command>
         <command name="rm">craype-ivybridge</command>
         <command name="rm">craype</command>
-        <command name="rm">craype-hugepages2M</command>
         <command name="rm">papi</command>
         <command name="rm">cmake</command>
         <command name="rm">cray-petsc</command>
@@ -199,6 +198,7 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
     </environment_variables>
     <environment_variables compiler="intel">
+      <env name="CRAYPE_LINK_TYPE">static</env>
       <env name="FORT_BUFFERED">yes</env>
     </environment_variables>
   </machine>
@@ -362,10 +362,12 @@
       <env name="MPICH_GNI_DYNAMIC_CONN">disabled</env>
     </environment_variables>
     <environment_variables compiler="intel">
+      <env name="CRAYPE_LINK_TYPE">static</env>
       <env name="FORT_BUFFERED">yes</env>
       <env name="MPICH_MEMORY_REPORT">1</env>
     </environment_variables>
     <environment_variables compiler="intel19">
+      <env name="CRAYPE_LINK_TYPE">static</env>
       <env name="MPICH_MEMORY_REPORT">1</env>
     </environment_variables>
   </machine>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -63,7 +63,7 @@
     <MPILIBS>mpt</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
-    <SAVE_TIMING_DIR_PROJECTS>e3sm,acme,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
+    <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-haswell</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
@@ -137,7 +137,7 @@
       </modules>
 
       <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
       </modules>
 
       <modules compiler="intel">
@@ -149,13 +149,13 @@
       <modules compiler="gnu">
         <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.2.0</command>
+        <command name="load">gcc/8.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.02.1</command>
+        <command name="load">cray-libsci/19.06.1</command>
       </modules>
 
       <modules>
-        <command name="swap">craype craype/2.5.18</command>
+        <command name="swap">craype craype/2.6.2</command>
         <command name="rm">pmi</command>
         <command name="load">pmi/5.0.14</command>
         <command name="rm">craype-mic-knl</command>
@@ -166,14 +166,14 @@
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
         <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
 
       <modules>
@@ -212,7 +212,7 @@
     <MPILIBS>mpt,impi</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
-    <SAVE_TIMING_DIR_PROJECTS>e3sm,e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
+    <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-knl</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
@@ -250,7 +250,6 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="rm">craype</command>
-        <command name="rm">craype-hugepages2M</command>
         <command name="rm">craype-mic-knl</command>
         <command name="rm">craype-haswell</command>
         <command name="rm">PrgEnv-intel</command>
@@ -285,11 +284,11 @@
       </modules>
 
       <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
       </modules>
 
       <modules mpilib="impi">
-        <command name="swap">cray-mpich impi/2019.up3</command>
+        <command name="swap">cray-mpich impi/2020</command>
       </modules>
 
       <modules compiler="intel">
@@ -301,19 +300,19 @@
       <modules compiler="intel19">
         <command name="load">PrgEnv-intel/6.0.5</command>
         <command name="rm">intel</command>
-        <command name="load">intel/19.0.3.199</command>
+        <command name="load">intel/19.1.1.217</command>
       </modules>
 
       <modules compiler="gnu">
         <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.2.0</command>
+        <command name="load">gcc/8.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.02.1</command>
+        <command name="load">cray-libsci/19.06.1</command>
       </modules>
 
       <modules>
-        <command name="swap">craype craype/2.5.18</command>
+        <command name="swap">craype craype/2.6.2</command>
         <command name="rm">pmi</command>
         <command name="load">pmi/5.0.14</command>
         <command name="rm">craype-haswell</command>
@@ -324,14 +323,14 @@
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
         <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
 
       <modules>


### PR DESCRIPTION
Update modules on Cori (cori-knl and cori-haswell) to reflect the currents defaults.

Except for the Intel compiler -- leaving this as-is at v18.
We will update the compiler version in a different PR.

This PR updates
 cray-mpich/7.7.6 -> cray-mpich/7.7.10
 craype/2.5.18 -> craype/2.6.2
 cray-netcdf-hdf5parallel/4.6.1.3 -> cray-netcdf-hdf5parallel/4.6.3.2
 cray-hdf5-parallel/1.10.2.0 -> cray-hdf5-parallel/1.10.5.2
 cray-parallel-netcdf/1.8.1.4 -> cray-parallel-netcdf/1.11.1.1

These changes should be BFB and have been with testing so far (e3sm_developer plus maint-1.0 tests)

The performance and memory use are still under investigation. 

[bfb]