### PR TITLE
Updates the SMS.r05_r05.I1850CLM45CN test

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -32,7 +32,7 @@ _TESTS = {
             "ERS.f19_g16.I1850GSWCNPRDCTCBC.clm-ctc_f19_g16_I1850GSWCNPRDCTCBC",
             "ERS.f19_g16.I20TRGSWCNPRDCTCBC.clm-ctc_f19_g16_I20TRGSWCNPRDCTCBC",
             "ERS.f09_g16.ICLM45BC",
-            "SMS.r05_r05.I1850CLM45CN",
+            "SMS.r05_r05.I1850CLM45CN.clm-qian_1948",
             "SMS_Ly2_P1x1.1x1_smallvilleIA.ICLM45CNCROP.clm-lulcc_sville",
             )
         },

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/qian_1948/shell_commands
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/qian_1948/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange DATM_CLMNCEP_YR_END=1948


### PR DESCRIPTION
Updates the `SMS.r05_r05.I1850CLM45CN` test to
`SMS.r05_r05.I1850CLM45CN.clm-qian_1948` to avoid downloading
multiple DATAM files by setting the end year to be the same as
the start year.

[BFB]