### PR TITLE
Modifies chem pp optimization level from O2 to O1 for PGI compilers

### DIFF
--- a/components/cam/chem_proc/src/Makefile
+++ b/components/cam/chem_proc/src/Makefile
@@ -133,13 +133,13 @@ ifeq ($(FC),lf95)
   endif
 endif
 ifeq ($(FC),pgf90)
-  FFLAGS      := -O2 -c -g -Mfree -module $(OBJ_DIR)
+  FFLAGS      := -O1 -c -g -Mfree -module $(OBJ_DIR)
   ifeq ($(DEBUG),TRUE)
     FFLAGS    += -C
   endif
 endif
 ifeq ($(FC),pgf95)
-  FFLAGS      := -O2 -c -g -Mfree -module $(OBJ_DIR)
+  FFLAGS      := -O1 -c -g -Mfree -module $(OBJ_DIR)
   ifeq ($(DEBUG),TRUE)
     FFLAGS    += -C
   endif


### PR DESCRIPTION
Chem pp was hanging on Compy when compiled with the PGI compiler.
An easy fix is to decrease the optimization level from 2 to 1.

It works fine on all other testing machines and it also works fine
on Compy with the Intel compiler with O2 optimizations.

[BFB] - Bit-For-Bit