### PR TITLE
Fix MMF explicit scalar momentum transport (ESMT)

### DIFF
--- a/components/cam/src/physics/crm/crm_physics.F90
+++ b/components/cam/src/physics/crm/crm_physics.F90
@@ -716,6 +716,11 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
       crm_input%ul(1:ncol,1:pver) = state%u(1:ncol,1:pver)
       crm_input%vl(1:ncol,1:pver) = state%v(1:ncol,1:pver)
       crm_input%ocnfrac(1:ncol) = cam_in%ocnfrac(1:ncol)
+#if defined( MMF_ESMT )
+      ! Set the input wind for ESMT
+      crm_input%ul_esmt(1:ncol,1:pver) = state%u(1:ncol,1:pver)
+      crm_input%vl_esmt(1:ncol,1:pver) = state%v(1:ncol,1:pver)
+#endif /* MMF_ESMT */
       do i = 1,ncol
 #ifdef MAML
          tau00_avg =0._r8
@@ -772,11 +777,6 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
          do k = 1,pver
             crm_input%ul(i,k) = state%u(i,k) * cos( crm_angle(i) ) + state%v(i,k) * sin( crm_angle(i) )
             crm_input%vl(i,k) = state%v(i,k) * cos( crm_angle(i) ) - state%u(i,k) * sin( crm_angle(i) )
-#if defined( MMF_ESMT )
-            ! Set the input wind for ESMT
-            crm_input%ul_esmt(i,k) = state%u(i,k)
-            crm_input%vl_esmt(i,k) = state%v(i,k)
-#endif /* MMF_ESMT */
          end do ! k=1,pver
       end do ! i=1,ncol
 

--- a/components/cam/src/physics/crm/sam/scalar_momentum.F90
+++ b/components/cam/src/physics/crm/sam/scalar_momentum.F90
@@ -55,16 +55,16 @@ subroutine allocate_scalar_momentum(ncrms)
    implicit none
    integer, intent(in) :: ncrms
 
-   allocate( u_esmt(ncrms,dimx1_s:dimx2_s, dimy1_s:dimy2_s, nzm) )
-   allocate( v_esmt(ncrms,dimx1_s:dimx2_s, dimy1_s:dimy2_s, nzm) )
-   allocate( fluxb_u_esmt (nx, ny,ncrms) )
-   allocate( fluxb_v_esmt (nx, ny,ncrms) )
-   allocate( fluxt_u_esmt (nx, ny,ncrms) )
-   allocate( fluxt_v_esmt (nx, ny,ncrms) )
-   allocate( u_esmt_sgs   (nz,ncrms)  )
-   allocate( v_esmt_sgs   (nz,ncrms)  )
-   allocate( u_esmt_diff  (nz,ncrms)  )
-   allocate( v_esmt_diff  (nz,ncrms)  )
+   allocate( u_esmt(ncrms, dimx1_s:dimx2_s, dimy1_s:dimy2_s, nzm) )
+   allocate( v_esmt(ncrms, dimx1_s:dimx2_s, dimy1_s:dimy2_s, nzm) )
+   allocate( fluxb_u_esmt (ncrms, nx, ny) )
+   allocate( fluxb_v_esmt (ncrms, nx, ny) )
+   allocate( fluxt_u_esmt (ncrms, nx, ny) )
+   allocate( fluxt_v_esmt (ncrms, nx, ny) )
+   allocate( u_esmt_sgs   (ncrms, nz) )
+   allocate( v_esmt_sgs   (ncrms, nz) )
+   allocate( u_esmt_diff  (ncrms, nz) )
+   allocate( v_esmt_diff  (ncrms, nz) )
 
    call prefetch( u_esmt )
    call prefetch( v_esmt )
@@ -329,6 +329,7 @@ subroutine esmt_fft_forward(nx,nzm,dx,arr_in,k_out,arr_out)
    ! adapted from SP-WRF code provided by Stefan Tulich
    !------------------------------------------------------------------
    use fftpack51D
+   use params, only: pi
    implicit none
    integer                          , intent(in ) :: nx
    integer                          , intent(in ) :: nzm
@@ -339,12 +340,10 @@ subroutine esmt_fft_forward(nx,nzm,dx,arr_in,k_out,arr_out)
    ! local variables
    integer :: lensave, ier, nh, n1, i, j, k
    integer :: lot, jump, n, inc, lenr, lensav, lenwrk
-   real(crm_rknd) :: pi
    real(crm_rknd), dimension(nx+15)  :: wsave
    real(crm_rknd), dimension(nx,nzm) :: work
 
    ! naming convention follows fftpack5 routines
-   pi = 2.*asin(1.0)
    n = nx
    lot = 1
    lensav = n+15


### PR DESCRIPTION
A few fixes to enable the scalar momentum transport scheme (ESMT) in the MMF. The main change is to just update the dimension ordering which were switched during the refactoring to support running the MMF on GPUs. 

[BFB] since we currently don't test this feature.