### PR TITLE
Add MMF-RCE compset

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -156,6 +156,7 @@ _TESTS = {
             "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
             "SMS_D_Ld1.ne30_r05_oECv3.A_WCYCL1850",
             "ERP_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-TEST.cam-crmout",
+            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-RCE",
             )
         },
 

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -156,7 +156,7 @@ _TESTS = {
             "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
             "SMS_D_Ld1.ne30_r05_oECv3.A_WCYCL1850",
             "ERP_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-TEST.cam-crmout",
-            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-RCE",
+            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-RCEMIP",
             )
         },
 

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -131,6 +131,8 @@
       <value compset="_CAM5%MMF[12]-TEST_"     >-crm_nx  8 -crm_nx_rad  2 -crm_ny 1 -crm_ny_rad 1 </value>
       <value compset="_CAM5%MMF[12]-MAML-TEST" >-crm_nx  8 -crm_nx_rad  8 -crm_ny 1 -crm_ny_rad 1 </value>
       <value compset="_CAM5%MMF2-ECPP-TEST"    >-crm_nx  8 -crm_nx_rad  1 -crm_ny 1 -crm_ny_rad 1 </value>
+      <value compset="_CAM5%MMF[12]-RCE_"      >-crm_nx 64 -crm_nx_rad 16 -crm_ny 1 -crm_ny_rad 1 </value>
+      <value compset="_CAM5%MMF[12]-RCE_"      >-aquaplanet -rce </value>
       <!--  -->
       <value compset="GEOS_CAM"       >-offline_dyn</value>
       <value compset="GEOS_CAM4"      >-nlev 56</value>
@@ -294,6 +296,7 @@
       <value compset="2000_CAM5%SP2"     >2000_cam5_av1c-04p2-MMF-2mom</value>
       <value compset="2000_CAM5%MMF1"    >2000_cam5_av1c-04p2-MMF-1mom</value>
       <value compset="2000_CAM5%MMF2"    >2000_cam5_av1c-04p2-MMF-2mom</value>
+      <value compset="_CAM5%MMF1-RCE" >RCEMIP_EAMv1</value>
     </values>
     <group>run_component_cam</group>
     <file>env_run.xml</file>
@@ -427,6 +430,7 @@
     <value compset="DOCN%AQP">$SRCROOT/components/cam/cime_config/usermods_dirs/aquap</value>
     <value compset="DOCN%SOMAQP">$SRCROOT/components/cam/cime_config/usermods_dirs/aquap</value>
     <value compset="CAM5%RCE">$SRCROOT/components/cam/cime_config/usermods_dirs/rcemip</value>
+    <value compset="CAM5%MMF1-RCE">$SRCROOT/components/cam/cime_config/usermods_dirs/rcemip</value>
     <!-- MAML uses this for setting NINST, NINST_LAYOUT -->
     <value compset="SP1V1-MAML_">$SRCROOT/components/cam/cime_config/usermods_dirs/maml</value>
     <value compset="SP1V1-MAML-TEST">$SRCROOT/components/cam/cime_config/usermods_dirs/maml-test</value>

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -296,7 +296,7 @@
       <value compset="2000_CAM5%SP2"     >2000_cam5_av1c-04p2-MMF-2mom</value>
       <value compset="2000_CAM5%MMF1"    >2000_cam5_av1c-04p2-MMF-1mom</value>
       <value compset="2000_CAM5%MMF2"    >2000_cam5_av1c-04p2-MMF-2mom</value>
-      <value compset="_CAM5%MMF1-RCE" >RCEMIP_EAMv1</value>
+      <value compset="_CAM5%MMF[12]-RCE" >RCEMIP_EAMv1</value>
     </values>
     <group>run_component_cam</group>
     <file>env_run.xml</file>
@@ -430,7 +430,7 @@
     <value compset="DOCN%AQP">$SRCROOT/components/cam/cime_config/usermods_dirs/aquap</value>
     <value compset="DOCN%SOMAQP">$SRCROOT/components/cam/cime_config/usermods_dirs/aquap</value>
     <value compset="CAM5%RCE">$SRCROOT/components/cam/cime_config/usermods_dirs/rcemip</value>
-    <value compset="CAM5%MMF1-RCE">$SRCROOT/components/cam/cime_config/usermods_dirs/rcemip</value>
+    <value compset="CAM5%MMF[12]-RCE">$SRCROOT/components/cam/cime_config/usermods_dirs/rcemip</value>
     <!-- MAML uses this for setting NINST, NINST_LAYOUT -->
     <value compset="SP1V1-MAML_">$SRCROOT/components/cam/cime_config/usermods_dirs/maml</value>
     <value compset="SP1V1-MAML-TEST">$SRCROOT/components/cam/cime_config/usermods_dirs/maml-test</value>

--- a/components/cam/cime_config/config_compsets.xml
+++ b/components/cam/cime_config/config_compsets.xml
@@ -351,6 +351,11 @@
     <lname>2000_CAM5%RCE_SLND_SICE_DOCN%AQPCONST_SROF_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>F-MMF1-RCEMIP</alias>
+    <lname>2000_CAM5%MMF1-RCE_SLND_SICE_DOCN%AQPCONST_SROF_SGLC_SWAV</lname>
+  </compset>
+
   <!-- *********************************** -->
   <!-- idealized / adiabatic -->
   <!-- *********************************** -->

--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -1623,10 +1623,17 @@ contains
                         cld_optics_sw%tau(j,ktop:kbot,:) = cld_tau_gpt_sw(ic,:,:)
                         cld_optics_sw%ssa(j,ktop:kbot,:) = cld_ssa_gpt_sw(ic,:,:)
                         cld_optics_sw%g  (j,ktop:kbot,:) = cld_asm_gpt_sw(ic,:,:)
-                        aer_optics_lw%tau(j,ktop:kbot,:) = aer_tau_bnd_lw(ic,:,:)
-                        aer_optics_sw%tau(j,ktop:kbot,:) = aer_tau_bnd_sw(ic,:,:)
-                        aer_optics_sw%ssa(j,ktop:kbot,:) = aer_ssa_bnd_sw(ic,:,:)
-                        aer_optics_sw%g  (j,ktop:kbot,:) = aer_asm_bnd_sw(ic,:,:)
+                        if (do_aerosol_rad) then
+                           aer_optics_lw%tau(j,ktop:kbot,:) = aer_tau_bnd_lw(ic,:,:)
+                           aer_optics_sw%tau(j,ktop:kbot,:) = aer_tau_bnd_sw(ic,:,:)
+                           aer_optics_sw%ssa(j,ktop:kbot,:) = aer_ssa_bnd_sw(ic,:,:)
+                           aer_optics_sw%g  (j,ktop:kbot,:) = aer_asm_bnd_sw(ic,:,:)
+                        else
+                           aer_optics_lw%tau(j,ktop:kbot,:) = 0
+                           aer_optics_sw%tau(j,ktop:kbot,:) = 0
+                           aer_optics_sw%ssa(j,ktop:kbot,:) = 0
+                           aer_optics_sw%g  (j,ktop:kbot,:) = 0
+                        end if
                         vmr_all(:,j,:) = vmr_col(:,ic,:)
                         j = j + 1
                      end do  ! ic = 1,ncol
@@ -1639,8 +1646,15 @@ contains
             ! Do shortwave stuff...
             if (radiation_do('sw')) then
 
-               ! Get orbital eccentricity factor to scale total sky irradiance
-               tsi_scaling = get_eccentricity_factor()
+               if (fixed_total_solar_irradiance<0) then
+                  ! Get orbital eccentricity factor to scale total sky irradiance
+                  tsi_scaling = get_eccentricity_factor()
+               else
+                  ! For fixed TSI we divide by the default solar constant of 1360.9
+                  ! At some point we will want to replace this with a method that 
+                  ! retrieves the solar constant
+                  tsi_scaling = fixed_total_solar_irradiance / 1360.9_r8
+               end if
 
                ! Allocate shortwave fluxes (allsky and clearsky)
                ! NOTE: fluxes defined at interfaces, so initialize to have vertical

--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -1316,6 +1316,9 @@ contains
          aer_tau_bnd_sw, aer_ssa_bnd_sw, aer_asm_bnd_sw
       real(r8), dimension(pcols,pver,nswgpts) :: &
          cld_tau_gpt_sw, cld_ssa_gpt_sw, cld_asm_gpt_sw
+      ! NOTE: these are diagnostic only
+      real(r8), dimension(pcols,pver,nswbands) :: liq_tau_bnd_sw, ice_tau_bnd_sw, snw_tau_bnd_sw
+      real(r8), dimension(pcols,pver,nlwbands) :: liq_tau_bnd_lw, ice_tau_bnd_lw, snw_tau_bnd_lw
 
       !----------------------------------------------------------------------
 
@@ -1570,7 +1573,8 @@ contains
                            ncol, pver, nswbands, do_snow_optics(), &
                            cld, cldfsnow, iclwp, iciwp, icswp, &
                            lambdac, mu, dei, des, rel, rei, &
-                           cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw &
+                           cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw, &
+                           liq_tau_bnd_sw, ice_tau_bnd_sw, snw_tau_bnd_sw &
                         )
                         call sample_cloud_optics_sw( &
                            ncol, pver, nswgpts, k_dist_sw%get_gpoint_bands(), &
@@ -1595,7 +1599,7 @@ contains
                         call get_cloud_optics_lw( &
                            ncol, pver, nlwbands, do_snow_optics(), cld, cldfsnow, iclwp, iciwp, icswp, &
                            lambdac, mu, dei, des, rei, &
-                           cld_tau_bnd_lw &
+                           cld_tau_bnd_lw, liq_tau_bnd_lw, ice_tau_bnd_lw, snw_tau_bnd_lw &
                         )
                         call sample_cloud_optics_lw( &
                            ncol, pver, nlwgpts, k_dist_lw%get_gpoint_bands(), &


### PR DESCRIPTION
This includes the new MMF-RCE compset as well as a couple minor fixes in the version of radiation.F90 that is used for MMF, which did not include the ability to reduce the solar constant and disable aerosol radiative effects, which were implemented in the non-MMF version of RRTMGP. 