### PR TITLE
Update MMF radiation_tend for cam_optics changes

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -155,7 +155,7 @@ _TESTS = {
             "SMS.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850.clm-bgcexp",
             "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
             "SMS_D_Ld1.ne30_r05_oECv3.A_WCYCL1850",
-            "ERP_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-TEST.cam-crmout",
+            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-TEST.cam-crmout",
             )
         },
 

--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -475,7 +475,7 @@ contains
       ! methods).
       type(ty_gas_concs) :: available_gases
 
-      real(r8), target :: sw_band_midpoints(nswbands), lw_band_midpoints(nlwbands)
+      real(r8), allocatable :: sw_band_midpoints(:), lw_band_midpoints(:)
       character(len=32) :: subname = 'radiation_init'
 
       character(len=10), dimension(3) :: dims_crm_rad = (/'crm_nx_rad','crm_ny_rad','crm_nz    '/)
@@ -588,11 +588,13 @@ contains
       !
       
       ! Register new dimensions
+      allocate(sw_band_midpoints(nswbands), lw_band_midpoints(nlwbands))
       sw_band_midpoints(:) = get_band_midpoints(nswbands, k_dist_sw)
       lw_band_midpoints(:) = get_band_midpoints(nlwbands, k_dist_lw)
       call assert(all(sw_band_midpoints > 0), subname // ': negative sw_band_midpoints')
       call add_hist_coord('swband', nswbands, 'Shortwave band', 'wavelength', sw_band_midpoints)
       call add_hist_coord('lwband', nlwbands, 'Longwave band', 'wavelength', lw_band_midpoints)
+      deallocate(sw_band_midpoints, lw_band_midpoints)
 
       ! Shortwave radiation
       call addfld('TOT_CLD_VISTAU', (/ 'lev' /), 'A',   '1', &

--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -1316,6 +1316,9 @@ contains
          aer_tau_bnd_sw, aer_ssa_bnd_sw, aer_asm_bnd_sw
       real(r8), dimension(pcols,pver,nswgpts) :: &
          cld_tau_gpt_sw, cld_ssa_gpt_sw, cld_asm_gpt_sw
+      ! NOTE: these are diagnostic only
+      real(r8), dimension(pcols,pver,nswbands) :: liq_tau_bnd_sw, ice_tau_bnd_sw, snw_tau_bnd_sw
+      real(r8), dimension(pcols,pver,nlwbands) :: liq_tau_bnd_lw, ice_tau_bnd_lw, snw_tau_bnd_lw
 
       !----------------------------------------------------------------------
 
@@ -1570,7 +1573,8 @@ contains
                            ncol, pver, nswbands, do_snow_optics(), &
                            cld, cldfsnow, iclwp, iciwp, icswp, &
                            lambdac, mu, dei, des, rel, rei, &
-                           cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw &
+                           cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw, &
+                           liq_tau_bnd_sw, ice_tau_bnd_sw, snw_tau_bnd_sw &
                         )
                         call sample_cloud_optics_sw( &
                            ncol, pver, nswgpts, k_dist_sw%get_gpoint_bands(), &
@@ -1595,7 +1599,7 @@ contains
                         call get_cloud_optics_lw( &
                            ncol, pver, nlwbands, do_snow_optics(), cld, cldfsnow, iclwp, iciwp, icswp, &
                            lambdac, mu, dei, des, rei, &
-                           cld_tau_bnd_lw &
+                           cld_tau_bnd_lw, liq_tau_bnd_lw, ice_tau_bnd_lw, snw_tau_bnd_lw &
                         )
                         call sample_cloud_optics_lw( &
                            ncol, pver, nlwgpts, k_dist_lw%get_gpoint_bands(), &


### PR DESCRIPTION
Fixes the MMF-specific `radiation_tend` to use the new optics interfaces, which commit a4eea9c222f26dd2d98664259c07aaf141b3c862 modified to provide additional outputs to use with COSP. Commit 417e7cdd495d90df975d7f4b4df0e753c5732fcc then broke the MMF build because it relied on the old interface, so this fixes the broken build. Also switches the MMF test in the integration suite from an ERP test to an ERS test so that we have a test that works in master for MMF until we can track down the ERP fail.

[BFB]