### PR TITLE
Homme: Fix a restart bug.

### DIFF
--- a/components/cam/src/dynamics/se/restart_dynamics.F90
+++ b/components/cam/src/dynamics/se/restart_dynamics.F90
@@ -642,6 +642,9 @@ CONTAINS
     endif
 #endif
 
+    do ie = 1,nelemd
+       elem(ie)%state%Qdp = 0
+    end do
     do q=1,qsize_d
        call pio_setframe(File,qdesc(q), t)
        call pio_read_darray(File, qdesc(q), iodesc3d, var3d, ierr)

--- a/components/cam/src/dynamics/se/restart_dynamics.F90
+++ b/components/cam/src/dynamics/se/restart_dynamics.F90
@@ -605,7 +605,12 @@ CONTAINS
     end do
 
 #ifdef MODEL_THETA_L
-    if ( .not. theta_hydrostatic_mode )then
+    if ( theta_hydrostatic_mode ) then
+       do ie=1,nelemd
+          elem(ie)%state%w_i = 0
+          elem(ie)%state%phinh_i = 0
+       end do       
+    else
        call pio_setframe(File,Wdesc, t)
        call pio_read_darray(File, Wdesc, iodesc3dp, var3dp, ierr)
        cnt=0


### PR DESCRIPTION
When restarting with theta_hydrostatic_mode = true, init w_i to phinh_i to
0. This prevents a possible NaN dection in prim_printstate. This PR does not
change answers because w_i and phinh_i are not actually used in hydrostatic
mode.

I detected a second source of potential NaNs in prim_printstate: When Qdp is
written at restart, the unused time slot is uninitialized. This can then lead to
NaNs in repro_sum. Fix this by 0'ing out all of Qdp before writing restart data
to it.

Fixes #3582

[BFB]