### PR TITLE
v2 SL and physgrid remap performance, mass conservation

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1234,6 +1234,12 @@ flags should be captured within MPAS CMake files.
     <append DEBUG="FALSE"> -O2 -debug minimal </append>
     <append DEBUG="TRUE"> -O0 -g </append>
   </CFLAGS>
+  <CXXFLAGS>
+    <base> -std=c++11 -fp-model consistent </base>
+    <append compile_threaded="TRUE"> -qopenmp </append>
+    <append DEBUG="TRUE"> -O0 -g </append>
+    <append DEBUG="FALSE"> -O2 </append>
+  </CXXFLAGS>
   <CONFIG_ARGS>
     <base> --host=Linux </base>
   </CONFIG_ARGS>

--- a/components/cam/src/dynamics/se/gravity_waves_sources.F90
+++ b/components/cam/src/dynamics/se/gravity_waves_sources.F90
@@ -130,11 +130,10 @@ CONTAINS
     integer :: k,kptr,i,j,ie,component
     real(kind=real_kind) :: frontgf_gll(np,np,nlev,nets:nete)
     real(kind=real_kind) :: gradth_gll(np,np,2,nlev,nets:nete)  ! grad(theta)
-    real(kind=real_kind) :: gradth_fv(fv_nphys,fv_nphys,nlev,2) ! grad(theta)
     real(kind=real_kind) :: p(np,np)        ! pressure at mid points
     real(kind=real_kind) :: theta(np,np)    ! potential temperature at mid points
     real(kind=real_kind) :: temperature(np,np,nlev)  ! Temperature
-    real(kind=real_kind) :: C(np,np,2)     
+    real(kind=real_kind) :: C(np,np,2), wf1(nphys*nphys,nlev), wf2(nphys*nphys,nlev)
     !---------------------------------------------------------------------------
 
     do ie = nets,nete
@@ -180,14 +179,14 @@ CONTAINS
         end if
       end do ! k
       if (fv_nphys > 0) then
-        call gfr_g2f_scalar(ie, elem(ie)%metdet, frontgf_gll(:,:,:,ie), &
-             frontgf(:,:,:,ie))
+        call gfr_g2f_scalar(ie, elem(ie)%metdet, frontgf_gll(:,:,:,ie), wf1)
+        frontgf(:,:,:,ie) = reshape(wf1, (/nphys,nphys,nlev/))
         call gfr_g2f_vector(ie, elem, &
              gradth_gll(:,:,1,:,ie), gradth_gll(:,:,2,:,ie), &
-             gradth_fv(:,:,:,1), gradth_fv(:,:,:,2))
-        frontga(:fv_nphys,:fv_nphys,:,ie) = &
-             atan2(gradth_fv(:,:,:,2) , &
-                   gradth_fv(:,:,:,1) + 1.e-10_real_kind)
+             wf1, wf2)
+        frontga(:,:,:,ie) = reshape( &
+             atan2(wf2, wf1 + 1.e-10_real_kind), &
+             (/nphys,nphys,nlev/))
       end if
     end do ! ie
 

--- a/components/homme/src/preqx/share/prim_state_mod.F90
+++ b/components/homme/src/preqx/share/prim_state_mod.F90
@@ -133,7 +133,7 @@ contains
     real (kind=real_kind) :: KEvert,IEvert,T1,T2,T2_s,T2_m,S1,S2,S1_wet
     real (kind=real_kind) :: KEhorz,IEhorz,IEhorz_wet,IEvert_wet
     real (kind=real_kind) :: ddt_tot,ddt_diss
-    integer               :: n0, nm1, np1
+    integer               :: n0, n0q, nm1, np1
     integer               :: npts,n,q
     
     call t_startf('prim_printstate')
@@ -148,6 +148,7 @@ contains
     IEner_wet = 0
     ! dynamics timelevels
     n0=tl%n0
+    call TimeLevel_Qdp( tl, qsplit, n0q) !get n0 level into t2_qdp 
 
     dt=tstep*qsplit
     if (rsplit>0) dt = tstep*qsplit*rsplit  ! vertical REMAP timestep 
@@ -182,7 +183,11 @@ contains
        qvmax_p(q) = ParallelMax(tmp1,hybrid)
 
        do ie=nets,nete
-          global_shared_buf(ie,1) = SUM(elem(ie)%state%Q(:,:,:,q))
+          global_shared_buf(ie,1) = 0
+          do k=1,nlev
+             global_shared_buf(ie,1) = global_shared_buf(ie,1) + &
+                  SUM(elem(ie)%spheremp*elem(ie)%state%Qdp(:,:,k,q,n0q))
+          enddo
        enddo
        call wrap_repro_sum(nvars=1, comm=hybrid%par%comm)
        qvsum_p(q) = global_shared_sum(1)
@@ -338,7 +343,7 @@ contains
        write(iulog,100) "dp    = ",dpmin_p,dpmax_p,dpsum_p
 
        do q=1,qsize
-          write(iulog,100) "qv= ",qvmin_p(q), qvmax_p(q), qvsum_p(q)
+          write(iulog,102) "qv(",q,")= ",qvmin_p(q), qvmax_p(q), qvsum_p(q)
        enddo
        write(iulog,100) "ps= ",psmin_p,psmax_p,pssum_p
        write(iulog,'(a,E23.15,a,E23.15,a)') "      M = ",Mass,' kg/m^2',Mass2,' mb     '
@@ -621,7 +626,7 @@ contains
     endif
     
 100 format (A10,3(E23.15))
-    
+102 format (A4,I3,A3,3(E23.15))
     
     ! initialize "E0" for printout of E-E0/E0
     ! energy is computed in timestep loop.  Save the value 

--- a/components/homme/src/share/gllfvremap_mod.F90
+++ b/components/homme/src/share/gllfvremap_mod.F90
@@ -33,7 +33,7 @@ module gllfvremap_mod
   ! dcmip2016_test1_pg2 and dcmip2016_test1 (np4). pg2 and np4 fields are
   ! nearly identical out to day 30, whereas pg1 fields differ visibly.
   !
-  ! AMB 2019/07 Initial
+  ! AMB 2019/07-2020/05 Initial
 
   use hybrid_mod, only: hybrid_t
   use kinds, only: real_kind

--- a/components/homme/src/share/gllfvremap_mod.F90
+++ b/components/homme/src/share/gllfvremap_mod.F90
@@ -339,6 +339,18 @@ contains
     ! dt is not used; if it is not, then q is Qdp tendency, and dt
     ! must be the correct physics time step.
 
+#ifdef __INTEL_COMPILER
+# if __INTEL_COMPILER >= 1700 && __INTEL_COMPILER < 1800
+    ! On Anvil with Intel 17, and reproduced on one other platform
+    ! using specfically
+    !   icpc version 17.0.0 (gcc version 4.7.4 compatibility)
+    ! -O3 causes buggy code to be emitted for the limiter block near
+    ! the end of this routine. Work around this by asking the compiler
+    ! to compile this routine no higher than -O2.
+    !DIR$ OPTIMIZE:2
+# endif
+#endif
+
     use element_ops, only: get_field
     use dimensions_mod, only: nlev
     use hybvcoord_mod, only: hvcoord_t

--- a/components/homme/src/share/gllfvremap_util_mod.F90
+++ b/components/homme/src/share/gllfvremap_util_mod.F90
@@ -3,6 +3,22 @@
 #endif
 
 module gllfvremap_util_mod
+  ! Utilities and extended tests for high-order, mass-conserving, optionally
+  ! shape-preserving
+  !     FV physics <-> GLL dynamics
+  ! remap.
+  !
+  ! Tests operate at the level of gllfvremap_mod's API.
+  !
+  ! Utilities are to support homme_tool. So far these focus on creating
+  ! topography files.
+  !   A topography file contains FV data -- PHIS, SGH*, etc -- plus ncol_d and
+  ! PHIS_d that are the original GLL data. The FV PHIS data are consistent with
+  ! PHIS_d in the sense that an integral of either one over a finite volume
+  ! subcell has the same value.
+  !
+  ! AMB 2019/07-2020/05 Initial
+
   use hybrid_mod, only: hybrid_t
   use kinds, only: real_kind
   use dimensions_mod, only: nelemd, np, nlev, nlevp, qsize
@@ -567,11 +583,6 @@ contains
 
   subroutine gfr_convert_topo(par, elem, nphys, intopofn, outtopoprefix)
     ! Read a pure-GLL topography file. Remap all fields to physgrid. Write a new
-    ! topography file that contains physgrid data, plus ncol_d and PHIS_d that
-    ! are the original GLL data.
-    !   The resulting file has physgrid PHIS data that are consistent with
-    ! PHIS_d in the sense that an integral of either one over a finite volume
-    ! subcell has the same value.
 
 #ifndef CAM
     use common_io_mod, only: varname_len

--- a/components/homme/src/test_src/dcmip16_wrapper.F90
+++ b/components/homme/src/test_src/dcmip16_wrapper.F90
@@ -101,7 +101,7 @@ subroutine dcmip2016_test1(elem,hybrid,hvcoord,nets,nete)
 
   if (hybrid%masterthread) write(iulog,*) 'initializing dcmip2016 test 1: moist baroclinic wave'
 
-  if (qsize<5) call abortmp('ERROR: test requires qsize>=5')
+  if (qsize<6) call abortmp('ERROR: test requires qsize>=6')
 
   ! set initial conditions
   do ie = nets,nete
@@ -620,7 +620,7 @@ subroutine dcmip2016_test1_pg_forcing(elem,hybrid,hvcoord,nets,nete,nt,ntQ,dt,tl
   real(rl), dimension(nlev)       :: u_c,v_c,p_c,qv_c,qc_c,qr_c,rho_c,z_c, th_c
   real(rl) :: max_w, max_precl, min_ps
   real(rl) :: lat, lon, dz_top(np,np),zi(np,np,nlevp),zi_c(nlevp), ps(np,np), &
-       wrk(np,np), rd, wrk3(np,np,nlev), wrk4(np,np,nlev,2)
+       wrk(np,np), rd, wrk3(np,np,nlev), wrk4(np,np,nlev,2), wf(np*np,1)
 
   integer :: nf, ncol
   real(rl), dimension(np,np,nlev) :: dp_fv, p_fv, u_fv, v_fv, T_fv, exner_kess_fv, &
@@ -751,7 +751,8 @@ subroutine dcmip2016_test1_pg_forcing(elem,hybrid,hvcoord,nets,nete,nt,ntQ,dt,tl
 
      ! These gfr calls are special to this routine, to handle
      ! DCMIP-specific precl.
-     call gfr_f2g_scalar(ie, elem(ie)%metdet, precl_fv, wrk3(:,:,:1))
+     wf(:ncol,1) = reshape(precl_fv(:nf,:nf,1), (/ncol/))
+     call gfr_f2g_scalar(ie, elem(ie)%metdet, wf(:,:1), wrk3(:,:,:1))
      call gfr_g_make_nonnegative(elem(ie)%metdet, wrk3(:,:,:1))
      precl(:,:,ie) = wrk3(:,:,1)
 

--- a/components/homme/src/theta-l/prim_state_mod.F90
+++ b/components/homme/src/theta-l/prim_state_mod.F90
@@ -206,7 +206,11 @@ contains
        enddo
        qvmax_p(q) = ParallelMax(tmp1,hybrid)
        do ie=nets,nete
-          global_shared_buf(ie,1) = SUM(elem(ie)%state%Q(:,:,:,q))
+          global_shared_buf(ie,1) = 0
+          do k=1,nlev
+             global_shared_buf(ie,1) = global_shared_buf(ie,1) + &
+                  SUM(elem(ie)%spheremp*elem(ie)%state%Qdp(:,:,k,q,n0q))
+          enddo
        enddo
        call wrap_repro_sum(nvars=1, comm=hybrid%par%comm)
        qvsum_p(q) = global_shared_sum(1)
@@ -417,7 +421,7 @@ contains
        endif
 
        do q=1,qsize
-          write(iulog,100) "qv= ",qvmin_p(q), qvmax_p(q), qvsum_p(q)
+          write(iulog,102) "qv(",q,")= ",qvmin_p(q), qvmax_p(q), qvsum_p(q)
        enddo
        write(iulog,100) "ps= ",psmin_p,psmax_p,pssum_p
        write(iulog,'(a,E23.15,a,E23.15,a)') "      M = ",Mass,' kg/m^2',Mass2,'mb     '
@@ -425,6 +429,7 @@ contains
     end if
  
 100 format (A10,3(E23.15))
+102 format (A4,I3,A3,3(E23.15))
 108 format (A10,E23.15,A6,E23.15,A6,E23.15)
 109 format (A10,E23.15,A2,I3,A1,E23.15,A2,I3,A1,E23.15)
 110 format (A33,E23.15,A2,I3,A1)

--- a/components/homme/src/theta-l/prim_state_mod.F90
+++ b/components/homme/src/theta-l/prim_state_mod.F90
@@ -429,7 +429,7 @@ contains
     end if
  
 100 format (A10,3(E23.15))
-102 format (A4,I3,A3,3(E23.15))
+102 format (A4,I3,A3,3(E24.16))
 108 format (A10,E23.15,A6,E23.15,A6,E23.15)
 109 format (A10,E23.15,A2,I3,A1,E23.15,A2,I3,A1,E23.15)
 110 format (A33,E23.15,A2,I3,A1)


### PR DESCRIPTION
Improve vectorization and threading in SL transport, physgrid remap, and theta-l.

Fix a mass conservation error due to finite precision effects.

These code mods would cause no answer change in exact arithmetic but are non-BFB in finite precision.

Summary:
- Physgrid remap: Switch indexing from (:nf,:nf) to (:nf2) to improve vectorization.
- SL transport:
   * Speed up global CAAS by locally reducing what can be reduced decomp-BFB.
   * Improve own_q, rmt_q thread load balance.
   * Flip level, q indexing to improve memory locality.
   * After a performance regression to calc_q a few months ago to work around a compiler bug, address the performance issue in a different way. I avoid using pragma ivdep but get the performance that annotation provides by explicitly blocking. The result is effective vectorization of a key computation in SL transport.
- Fix dp_fv so it agrees numerically with the pdel calculation in dp_coupling.F90: derived_physics.
- Add a C++ block to the cori-knl/intel19 block in config_compilers.xml.
- Work around an Intel 17 -O3 bug to fix a standalone-Homme test on Anvil.

Fixes #3588.

[non-BFB] 4 EAM tests and 3 standalone Homme tests