### PR TITLE
 Ocean: Reduce pointer retrievals in shared directory

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1347,8 +1347,6 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var name="snowFlux"/>')
         lines.append('    <var name="iceFraction"/>')
         lines.append('    <var name="nAccumulatedCoupled"/>')
-        lines.append('    <var name="thermalExpansionCoeff"/>')
-        lines.append('    <var name="salineContractionCoeff"/>')
         lines.append('</stream>')
         lines.append('')
         lines.append('</streams>')


### PR DESCRIPTION
See https://github.com/MPAS-Dev/MPAS-Model/pull/457 by @mattdturner 

Reduce pointer retrievals. This includes scratch allocates and config pointers. We are taking a staged approach, so this PR only alters the `src/core_ocean/shared` directory. See similar changes for analysis and init in previous PR, #3717. Here, we:
1. replace almost all calls to `mpas_allocate_scratch_field` in the ocean model with straight Fortran allocates.  This is done as part of the MPAS framework rewrite, per @philipwjones .  
2. replace almost all calls to `mpas_pool_get_config` in subroutines with definitions in `ocn_config` via `use ocn_config`. 

This PR is labelled as non-BFB, because there could be machine-precision changes that accumulate. In MPAS-Ocean stand-alone testing, comparisons compiled in intel debug, gnu debug, and gnu optimized are all BFB. Comparisons with intel optimized had small differences.

[non-BFB]