### PR TITLE
theta-l dycore fixes: POTTEMP initialization, default ne4 nu_div value

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1542,7 +1542,7 @@
 <nu_div> -1.0 </nu_div>
 
 <!-- theta-l dycore uses nu_div=-1, except for historical ne4 test cases -->
-<nu_div hgrid="ne4np4" >  1.25e18 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne4np4" >  1.25e18 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne11np4" >  5.0e16 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne16np4" > 15.5e15 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne30np4" >  2.5e15 </nu_div>

--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -96,8 +96,9 @@ CONTAINS
     use parallel_mod,     only: par, initmp
     use namelist_mod,     only: readnl
     use control_mod,      only: runtype, qsplit, rsplit, dt_tracer_factor, dt_remap_factor, &
-         timestep_make_eam_parameters_consistent
+         timestep_make_eam_parameters_consistent, moisture, use_moisture
     use time_mod,         only: tstep
+    use cam_control_mod,  only: moist_physics
     use phys_control,     only: use_gw_front
     use physics_buffer,   only: pbuf_add_field, dtype_r8
     use ppgrid,           only: pcols, pver
@@ -135,6 +136,9 @@ CONTAINS
 
     ! override the setting in the SE namelist, it's redundant anyway
     if (.not. is_first_step()) runtype = 1
+    use_moisture = moist_physics
+    moisture='dry'
+    if (use_moisture) moisture='wet'
 
     ! Initialize hybrid coordinate arrays.
     call hycoef_init(fh)
@@ -225,7 +229,7 @@ CONTAINS
     use hycoef,           only: ps0
     use parallel_mod,     only: par
     use time_mod,         only: time_at
-    use control_mod,      only: moisture, runtype
+    use control_mod,      only: runtype
     use cam_control_mod,  only: aqua_planet, ideal_phys, adiabatic
     use comsrf,           only: landm, sgh, sgh30
     use cam_instance,     only: inst_index
@@ -257,10 +261,8 @@ CONTAINS
        nete=dom_mt(ithr)%end
        hybrid = hybrid_create(par,ithr,hthreads)
 
-       moisture='moist'
 
        if(adiabatic) then
-          moisture='dry'
           if(runtype == 0) then
              do ie=nets,nete
                 elem(ie)%state%q(:,:,:,:)=0.0_r8
@@ -268,7 +270,6 @@ CONTAINS
              end do
           end if
        else if(ideal_phys) then
-          moisture='dry'
           if(runtype == 0) then
              do ie=nets,nete
                 elem(ie)%state%ps_v(:,:,:) =ps0

--- a/components/cam/src/dynamics/se/inidat.F90
+++ b/components/cam/src/dynamics/se/inidat.F90
@@ -578,7 +578,7 @@ contains
        ps=elem(ie)%state%ps_v(:,:,tl)
 #ifdef MODEL_THETA_L
        elem(ie)%state%w_i = 0.0
-       call set_thermostate(elem(ie),ps,elem(ie)%derived%FT,hvcoord)
+       call set_thermostate(elem(ie),ps,elem(ie)%derived%FT,hvcoord,elem(ie)%state%Q(:,:,:,1))
        !FT used as tmp array - reset
        elem(ie)%derived%FT = 0.0
 #else

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -77,6 +77,7 @@ module namelist_mod
     initial_total_mass,   & ! set > 0 to set the initial_total_mass
     u_perturb,     &        ! J&W baroclinic test perturbation size
     moisture,      &
+    use_moisture,      &
     vform,         &
     vfile_mid,     &
     vfile_int,     &
@@ -781,6 +782,12 @@ module namelist_mod
     call MPI_bcast(calc_nonlinear_stats, 1, MPIlogical_t, par%root, par%comm, ierr)
     call MPI_bcast(use_column_solver, 1, MPIlogical_t, par%root, par%comm, ierr)
 #endif
+
+    ! should we assume Q(:,:,:,1) has water vapor:
+    use_moisture = ( moisture /= "dry") 
+    if (qsize<1) use_moisture = .false.  
+
+
 
     ! use maximum available:
     if (NThreads == -1) NThreads = omp_get_max_threads()

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -690,7 +690,7 @@ contains
                                     debug_level, vfile_int, vform, vfile_mid, &
                                     topology, dt_remap_factor, dt_tracer_factor,&
                                     sub_case, limiter_option, nu, nu_q, nu_div, tstep_type, hypervis_subcycle, &
-                                    hypervis_subcycle_q, moisture, use_moisture, hypervis_subcycle_tom
+                                    hypervis_subcycle_q, hypervis_subcycle_tom
     use global_norms_mod,     only: test_global_integral, print_cfl
     use hybvcoord_mod,        only: hvcoord_t
     use parallel_mod,         only: parallel_t, haltmp, syncmp, abortmp
@@ -778,10 +778,6 @@ contains
     if (topology == "cube") then
        call test_global_integral(elem, hybrid,nets,nete)
     end if
-
-    ! should we assume Q(:,:,:,1) has water vapor:
-    use_moisture = ( moisture /= "dry") 
-    if (qsize<1) use_moisture = .false.  
 
 
     ! compute most restrictive dt*nu for use by variable res viscosity:

--- a/components/homme/src/theta-l/element_ops.F90
+++ b/components/homme/src/theta-l/element_ops.F90
@@ -398,7 +398,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
 
   !_____________________________________________________________________
-  subroutine set_thermostate(elem,ps,temperature,hvcoord)
+  subroutine set_thermostate(elem,ps,temperature,hvcoord,Q1)
   !
   ! Assuming a hydrostatic intital state and given surface pressure,
   ! and no moisture, compute theta and phi 
@@ -412,6 +412,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   real (kind=real_kind), intent(in) :: temperature(np,np,nlev)
   type (hvcoord_t),     intent(in)  :: hvcoord                      ! hybrid vertical coordinate struct
   real (kind=real_kind), intent(in) :: ps(np,np)
+  real (kind=real_kind), intent(in), optional :: Q1(np,np,nlev)
   
   !   local
   real (kind=real_kind) :: p(np,np,nlev)
@@ -433,11 +434,16 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   enddo
   elem%state%ps_v(:,:,nt)=ps
 
+
+  if (present(Q1)) then
+     call get_R_star(dp,elem%state%Q(:,:,:,1))  ! compute Rstar, store in dp
+     elem%state%vtheta_dp(:,:,:,nt)=elem%state%vtheta_dp(:,:,:,nt)*dp(:,:,:)/Rgas
+  endif
+
 !set phi, copy from 1st timelevel to all
   call tests_finalize(elem,hvcoord)
 
   end subroutine set_thermostate
-
 
 
   !_____________________________________________________________________

--- a/components/homme/src/theta-l/element_ops.F90
+++ b/components/homme/src/theta-l/element_ops.F90
@@ -436,7 +436,8 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
 
   if (present(qv)) then
-     call get_R_star(dp,qv(:,:,:))! get ideal gas constant for moist air
+     ! get ideal gas constant for moist air, store in variable "dp"
+     call get_R_star(dp,qv(:,:,:))
      elem%state%vtheta_dp(:,:,:,nt)=elem%state%vtheta_dp(:,:,:,nt)*dp(:,:,:)/Rgas
   endif
 

--- a/components/homme/src/theta-l/element_ops.F90
+++ b/components/homme/src/theta-l/element_ops.F90
@@ -417,6 +417,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   !   local
   real (kind=real_kind) :: p(np,np,nlev)
   real (kind=real_kind) :: dp(np,np,nlev)
+  real (kind=real_kind) :: Rstar(np,np,nlev)
   integer :: k, nt
 
   nt = 1
@@ -436,9 +437,8 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
 
   if (present(qv)) then
-     ! get ideal gas constant for moist air, store in variable "dp"
-     call get_R_star(dp,qv(:,:,:))
-     elem%state%vtheta_dp(:,:,:,nt)=elem%state%vtheta_dp(:,:,:,nt)*dp(:,:,:)/Rgas
+     call get_R_star(Rstar,qv)
+     elem%state%vtheta_dp(:,:,:,nt)=elem%state%vtheta_dp(:,:,:,nt)*Rstar(:,:,:)/Rgas
   endif
 
 !set phi, copy from 1st timelevel to all

--- a/components/homme/src/theta-l/element_ops.F90
+++ b/components/homme/src/theta-l/element_ops.F90
@@ -398,7 +398,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
 
   !_____________________________________________________________________
-  subroutine set_thermostate(elem,ps,temperature,hvcoord,Q1)
+  subroutine set_thermostate(elem,ps,temperature,hvcoord,qv)
   !
   ! Assuming a hydrostatic intital state and given surface pressure,
   ! and no moisture, compute theta and phi 
@@ -412,7 +412,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   real (kind=real_kind), intent(in) :: temperature(np,np,nlev)
   type (hvcoord_t),     intent(in)  :: hvcoord                      ! hybrid vertical coordinate struct
   real (kind=real_kind), intent(in) :: ps(np,np)
-  real (kind=real_kind), intent(in), optional :: Q1(np,np,nlev)
+  real (kind=real_kind), intent(in), optional :: qv(np,np,nlev)  ! water vapor mixing ratio
   
   !   local
   real (kind=real_kind) :: p(np,np,nlev)
@@ -435,8 +435,8 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   elem%state%ps_v(:,:,nt)=ps
 
 
-  if (present(Q1)) then
-     call get_R_star(dp,Q1(:,:,:))  ! compute Rstar, store in dp
+  if (present(qv)) then
+     call get_R_star(dp,qv(:,:,:))! get ideal gas constant for moist air
      elem%state%vtheta_dp(:,:,:,nt)=elem%state%vtheta_dp(:,:,:,nt)*dp(:,:,:)/Rgas
   endif
 

--- a/components/homme/src/theta-l/element_ops.F90
+++ b/components/homme/src/theta-l/element_ops.F90
@@ -436,7 +436,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
 
   if (present(Q1)) then
-     call get_R_star(dp,elem%state%Q(:,:,:,1))  ! compute Rstar, store in dp
+     call get_R_star(dp,Q1(:,:,:))  ! compute Rstar, store in dp
      elem%state%vtheta_dp(:,:,:,nt)=elem%state%vtheta_dp(:,:,:,nt)*dp(:,:,:)/Rgas
   endif
 


### PR DESCRIPTION
Dont neglict moisture when initializing theta-l dycore's virtural potential temperature
variable.

Also added a T/theta conversion consistency check of the initial condition.  

theta-l ne4 was accidently picking up the preqx value of nu_div=2.5*nu.  theta-l should
be using nu_div=nu.

tested by running for 1 year using the F2010SC5-CMIP6 compset on ne4np4_ne4np4 and ne4pg2_ne4pg2 grids with theta-l dycore in hydrostatic mode and nonhydrostatic mode (all 4 combinations run for 1 year).  

Running ne4pg2_ne4pg2 required PR #3606 and uses CLM cold start.

[non-BFB] but only for theta-l tests.