### PR TITLE
Adding variable soil thickness to CTC

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -32,6 +32,7 @@ _TESTS = {
             "ERS.f19_g16.I1850GSWCNPRDCTCBC.clm-ctc_f19_g16_I1850GSWCNPRDCTCBC",
             "ERS.f19_g16.I20TRGSWCNPRDCTCBC.clm-ctc_f19_g16_I20TRGSWCNPRDCTCBC",
             "ERS.f09_g16.ICLM45BC",
+            "ERS.f09_g16.I1850GSWCNPRDCTCBC.clm-vstrd",
             "SMS.r05_r05.I1850CLM45CN",
             )
         },

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/vst-rd/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/vst-rd/user_nl_clm
@@ -1,0 +1,2 @@
+finidat            = ''
+use_var_soil_thick = .true.

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/vstrd/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/vstrd/user_nl_clm
@@ -1,0 +1,2 @@
+finidat            = ''
+use_var_soil_thick = .true.

--- a/components/clm/src/biogeochem/NitrogenDynamicsMod.F90
+++ b/components/clm/src/biogeochem/NitrogenDynamicsMod.F90
@@ -518,7 +518,7 @@ contains
 
          fpg              =>  cnstate_vars%fpg_col                   , & ! Input:  [real(r8) (:) ]  fraction of potential gpp (no units)              
          gddmaturity      =>  cnstate_vars%gddmaturity_patch         , & ! Input:  [real(r8) (:) ]  gdd needed to harvest                             
-         croplive         =>  cnstate_vars%croplive_patch            , & ! Input:  [logical  (:) ]  true if planted and not harvested                  
+         croplive         =>  crop_vars%croplive_patch            , & ! Input:  [logical  (:) ]  true if planted and not harvested                  
 
          sminn            =>  col_ns%sminn           , & ! Input:  [real(r8) (:) ]  (kgN/m2) soil mineral N                           
          plant_ndemand    =>  veg_nf%plant_ndemand  , & ! Input:  [real(r8) (:) ]  N flux required to support initial GPP (gN/m2/s)  

--- a/components/clm/src/biogeochem/NitrogenDynamicsMod.F90
+++ b/components/clm/src/biogeochem/NitrogenDynamicsMod.F90
@@ -292,9 +292,9 @@ contains
       ! calculate the total soil water
       tot_water(bounds%begc:bounds%endc) = 0._r8
       do fc = 1,num_soilc
-      	 c = filter_soilc(fc)
-	 nlevbed = nlev2bed(c)
-      	 do j = 1,nlevbed
+         c = filter_soilc(fc)
+         nlevbed = nlev2bed(c)
+         do j = 1,nlevbed
             tot_water(c) = tot_water(c) + h2osoi_liq(c,j)
          end do
       end do
@@ -302,14 +302,14 @@ contains
       ! for runoff calculation; calculate total water to a given depth
       surface_water(bounds%begc:bounds%endc) = 0._r8
       do fc = 1,num_soilc
-      	 c = filter_soilc(fc)
-	 nlevbed = nlev2bed(c)
-      	 do j = 1,nlevbed
+         c = filter_soilc(fc)
+         nlevbed = nlev2bed(c)
+         do j = 1,nlevbed
             if ( zisoi(j) <= depth_runoff_Nloss)  then
                surface_water(c) = surface_water(c) + h2osoi_liq(c,j)
             elseif ( zisoi(j-1) < depth_runoff_Nloss)  then
                surface_water(c) = surface_water(c) + h2osoi_liq(c,j) * ( (depth_runoff_Nloss - zisoi(j-1)) / col_pp%dz(c,j))
-	    end if
+            end if
          end do
       end do
 
@@ -676,7 +676,8 @@ contains
           do p = col_pp%pfti(c), col_pp%pftf(c)
               if (veg_pp%active(p).and. (veg_pp%itype(p) .ne. noveg)) then
                   ! calculate c cost of n2 fixation: fisher 2010 gbc doi:10.1029/2009gb003621
-                  r_fix = -6.25_r8*(exp(-3.62_r8 + 0.27_r8*(t_soi10cm_col(c)-273.15_r8)*(1.0_r8-0.5_r8*(t_soi10cm_col(c)-273.15_r8)/25.15_r8))-2.0_r8) 
+                  r_fix = -6.25_r8*(exp(-3.62_r8 + 0.27_r8*(t_soi10cm_col(c)-273.15_r8)*(1.0_r8-0.5_r8&
+                       *(t_soi10cm_col(c)-273.15_r8)/25.15_r8))-2.0_r8) 
                   ! calculate c cost of root n uptake: rastetter 2001, ecosystems, 4(4), 369-388.
                   r_nup = benefit_pgpp_pleafc(p) / max(pnup_pfrootc(p),1e-20_r8)
                   ! calculate fraction of root that is nodulated: wang 2007 gbc doi:10.1029/2006gb002797

--- a/components/clm/src/biogeochem/PhosphorusDynamicsMod.F90
+++ b/components/clm/src/biogeochem/PhosphorusDynamicsMod.F90
@@ -606,6 +606,7 @@ contains
     use pftvarcon              , only : noveg
     use clm_varpar             , only : ndecomp_pools
     use clm_time_manager       , only : get_step_size
+    use CNDecompCascadeConType , only : decomp_cascade_con
     
     !
     ! !ARGUMENTS:
@@ -640,8 +641,8 @@ contains
          decomp_ppools_vr_col => col_ps%decomp_ppools_vr, &
          lamda_ptase          => veg_vp%lamda_ptase                   ,  & ! critical value of nitrogen cost of phosphatase activity induced phosphorus uptake
          cn_scalar             => cnstate_vars%cn_scalar               , &
-         cp_scalar             => cnstate_vars%cp_scalar                 &
-         )
+         cp_scalar             => cnstate_vars%cp_scalar               , &
+         is_soil               => decomp_cascade_con%is_soil)
 
     dt = real( get_step_size(), r8 )
 
@@ -716,6 +717,7 @@ contains
                if (is_soil(l)) then
                      biochem_pmin_to_ecosysp_vr_col(c,j) = biochem_pmin_to_ecosysp_vr_col(c,j)+ &
                                           biochem_pmin_ppools_vr_col(c,j,l)
+               endif
             enddo
         enddo
     end do
@@ -777,17 +779,3 @@ contains
   end subroutine PhosphorusBiochemMin_balance
 
 end module PhosphorusDynamicsMod
-               
-                
-     
-
-      
-
-
-
-
-
-
-
-
->>>>>>> Adds variable soil thickness to CNP:components/clm/src/biogeochem/PDynamicsMod.F90

--- a/components/clm/src/biogeochem/PhosphorusDynamicsMod.F90
+++ b/components/clm/src/biogeochem/PhosphorusDynamicsMod.F90
@@ -410,9 +410,9 @@ contains
       ! calculate the total soil water
       tot_water(bounds%begc:bounds%endc) = 0._r8
       do fc = 1,num_soilc
-      	 c = filter_soilc(fc)
-	 nlevbed = nlev2bed(c)
-      	 do j = 1,nlevbed
+         c = filter_soilc(fc)
+         nlevbed = nlev2bed(c)
+         do j = 1,nlevbed
             tot_water(c) = tot_water(c) + h2osoi_liq(c,j)
          end do
       end do
@@ -421,11 +421,11 @@ contains
       surface_water(bounds%begc:bounds%endc) = 0._r8
       do fc = 1,num_soilc
          c = filter_soilc(fc)
-	 nlevbed = nlev2bed(c)
-      	 do j = 1,nlevbed
+         nlevbed = nlev2bed(c)
+         do j = 1,nlevbed
             if ( zisoi(j) <= depth_runoff_Ploss)  then
                surface_water(c) = surface_water(c) + h2osoi_liq(c,j)
-	    elseif ( zisoi(j-1) < depth_runoff_Ploss)  then
+            elseif ( zisoi(j-1) < depth_runoff_Ploss)  then
                surface_water(c) = surface_water(c) + h2osoi_liq(c,j) * ((depth_runoff_Ploss - zisoi(j-1)) / col_pp%dz(c,j))
             end if
          end do

--- a/components/clm/src/biogeochem/RootDynamicsMod.F90
+++ b/components/clm/src/biogeochem/RootDynamicsMod.F90
@@ -148,7 +148,7 @@ contains
                end if
             else
                ! this can be changed to any depth (i.e. the maximum soil depth)
-               root_depth(p) = min(altmax_lastyear(c), min(zi(c,nlevsoi), root_dmx(ivt(p))))
+               root_depth(p) = min(altmax_lastyear(c), min(zi(c,nlevbed(c)), root_dmx(ivt(p))))
             end if
          else
             root_depth(p) = 0._r8

--- a/components/clm/src/biogeophys/RootBiophysMod.F90
+++ b/components/clm/src/biogeophys/RootBiophysMod.F90
@@ -127,6 +127,7 @@ contains
           end do
           rootfr(p,ubj) = .5_r8*( exp(-roota_par(veg_pp%itype(p)) * col_pp%zi(c,ubj-1))  &
                + exp(-rootb_par(veg_pp%itype(p)) * col_pp%zi(c,ubj-1)) )
+          totrootfr = totrootfr + rootfr(p, ubj)
 
           ! Adjust layer root fractions if nlev2bed < nlevsoi
           if (use_var_soil_thick .and. nlevbed < ubj) then

--- a/components/clm/src/biogeophys/SoilStateType.F90
+++ b/components/clm/src/biogeophys/SoilStateType.F90
@@ -542,6 +542,7 @@ contains
     do c = bounds%begc, bounds%endc
        g = col_pp%gridcell(c)
        l = col_pp%landunit(c)
+       nlevbed = col_pp%nlevbed(c)
 
        if (lun_pp%itype(l)==istwet .or. lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec) then
 
@@ -568,7 +569,7 @@ contains
              this%tkmg_col(c,lev)   = spval
              this%tksatu_col(c,lev) = spval
              this%tkdry_col(c,lev)  = spval
-             if (lun_pp%itype(l)==istwet .and. lev > nlevsoi) then
+             if (lun_pp%itype(l)==istwet .and. lev > nlevbed) then
                 this%csol_col(c,lev) = csol_bedrock
              else
                 this%csol_col(c,lev)= spval

--- a/components/clm/src/biogeophys/SoilWaterMovementMod.F90
+++ b/components/clm/src/biogeophys/SoilWaterMovementMod.F90
@@ -306,6 +306,7 @@ contains
     integer  :: jtop(bounds%begc:bounds%endc)                ! top level at each column
     integer  :: jbot(bounds%begc:bounds%endc)                ! bottom level at each column
     real(r8) :: dtime                                        ! land model time step (sec)
+    real(r8) :: delta_z_zwt
     real(r8) :: hk(bounds%begc:bounds%endc,1:nlevgrnd)        ! hydraulic conductivity [mm h2o/s]
     real(r8) :: dhkdw(bounds%begc:bounds%endc,1:nlevgrnd)     ! d(hk)/d(vol_liq)
     real(r8) :: amx(bounds%begc:bounds%endc,1:nlevgrnd+1)     ! "a" left off diagonal of tridiagonal matrix
@@ -496,7 +497,9 @@ contains
          if(jwt(c) == nlevbed) then 
             tempi = 1._r8
             temp0 = (((sucsat(c,j)+zwtmm(c)-zimm(c,j))/sucsat(c,j)))**(1._r8-1._r8/bsw(c,j))
-            vol_eq(c,j+1) = -sucsat(c,j)*watsat(c,j)/(1._r8-1._r8/bsw(c,j))/(zwtmm(c)-zimm(c,j))*(tempi-temp0)
+            delta_z_zwt = zwtmm(c) - zimm(c,j)
+            if(delta_z_zwt == 0._r8) delta_z_zwt = 1._r8
+            vol_eq(c,j+1) = -sucsat(c,j)*watsat(c,j)/(1._r8-1._r8/bsw(c,j))/(delta_z_zwt)*(tempi-temp0)
             vol_eq(c,j+1) = max(vol_eq(c,j+1),0.0_r8)
             vol_eq(c,j+1) = min(watsat(c,j),vol_eq(c,j+1))
             zq(c,j+1) = -sucsat(c,j)*(max(vol_eq(c,j+1)/watsat(c,j),0.01_r8))**(-bsw(c,j))

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -403,6 +403,11 @@ contains
                    errMsg(__FILE__, __LINE__))
           end if
 
+          if ( use_var_soil_thick ) then
+             call endrun(msg=' ERROR: use_var_soil_thick and use_fates cannot both be set to true.'//&
+                   errMsg(__FILE__, __LINE__))
+          end if
+
        end if
 
 
@@ -457,6 +462,17 @@ contains
                 ! but NOT to implement 'nitrif_denitrif'
                 use_nitrif_denitrif = .true.
             end if
+       end if
+
+       if (use_pflotran) then
+          if (use_var_soil_thick) then
+             use_var_soil_thick = .false.
+          end if
+       end if
+
+       if (use_betr .and. use_var_soil_thick ) then
+          call endrun(msg=' ERROR: use_var_soil_thick and use_betr cannot both be set to true.'//&
+                   errMsg(__FILE__, __LINE__))
        end if
 
     endif   ! end of if-masterproc if-block
@@ -532,6 +548,11 @@ contains
     end if
 
     ! Consistency settings for vsfm settings
+    if (use_vsfm .and. use_var_soil_thick) then
+       call endrun(msg=' ERROR:: use_vsfm and use_var_soil_thick cannot both be set to true.'//&
+            errMsg(__FILE__, __LINE__))
+    end if
+
     if (vsfm_satfunc_type /= 'brooks_corey'             .and. &
         vsfm_satfunc_type /= 'smooth_brooks_corey_bz2'  .and. &
         vsfm_satfunc_type /= 'smooth_brooks_corey_bz3'  .and. &

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -466,7 +466,9 @@ contains
 
        if (use_pflotran) then
           if (use_var_soil_thick) then
-             use_var_soil_thick = .false.
+             call endrun(msg='ERROR: use_var_soil_thick and use_pflotran cannot
+both be set to true.'//&
+                      errMsg(__FILE__, __LINE__))
           end if
        end if
 


### PR DESCRIPTION
Adds consistency to run variable soil thickness with CTC, fixes a few remaining bugs in variable soil thickness.  The code is ready to be reviewed, but tests with variable soil and CTC turned on need to be added.  Also, aveDTB needs to be added to surfdata by Teklu Tesfa so that the variable soil tests actually use the variable soil thickness.