### PR TITLE
EAM mass conservation test

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -271,7 +271,8 @@ _TESTS = {
         "tests"    : (
                  "SMS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.cam-thetahy_pg2",
                  "SMS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.cam-thetahy_sl_pg2",
-                 "ERS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.cam-thetahy_sl_pg2"
+                 "ERS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.cam-thetahy_sl_pg2",
+                 "SMS_Ld9.ne4pg2_ne4pg2.FC5AV1C-04P2.cam-thetahy_sl_pg2_mass",
                  )
     },
     "e3sm_bench_hires_g" : {

--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -62,6 +62,7 @@ _TESTS = {
             "ERS_Ld5.ne4_ne4.FC5AV1C-L.cam-rrtmgp",
             "ERS_Ld5.ne4_ne4.FC5AV1C-L.cam-gust_param",
             "REP_Ln5.ne4_ne4.FC5AV1C-L",
+            "SMS_Ld9.ne4pg2_ne4pg2.FC5AV1C-04P2.cam-thetahy_sl_pg2_mass",
             )
         },
 
@@ -271,8 +272,7 @@ _TESTS = {
         "tests"    : (
                  "SMS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.cam-thetahy_pg2",
                  "SMS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.cam-thetahy_sl_pg2",
-                 "ERS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.cam-thetahy_sl_pg2",
-                 "SMS_Ld9.ne4pg2_ne4pg2.FC5AV1C-04P2.cam-thetahy_sl_pg2_mass",
+                 "ERS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.cam-thetahy_sl_pg2"
                  )
     },
     "e3sm_bench_hires_g" : {

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_sl_pg2_mass/shell_commands
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_sl_pg2_mass/shell_commands
@@ -1,0 +1,5 @@
+#!/bin/bash
+./xmlchange CAM_TARGET=theta-l
+./xmlchange --append CAM_CONFIG_OPTS="-co2_cycle"
+./xmlchange RUN_STARTDATE=1950-02-14
+./xmlchange POSTRUN_SCRIPT="$CIMEROOT/../components/homme/utils/e3sm_test/check_mass_conservation.py"

--- a/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_sl_pg2_mass/user_nl_cam
+++ b/components/cam/cime_config/testdefs/testmods_dirs/cam/thetahy_sl_pg2_mass/user_nl_cam
@@ -1,0 +1,2 @@
+semi_lagrange_cdr_check = .true.
+statefreq = 144

--- a/components/homme/src/preqx/share/prim_state_mod.F90
+++ b/components/homme/src/preqx/share/prim_state_mod.F90
@@ -148,7 +148,7 @@ contains
     IEner_wet = 0
     ! dynamics timelevels
     n0=tl%n0
-    call TimeLevel_Qdp( tl, qsplit, n0q) !get n0 level into t2_qdp 
+    call TimeLevel_Qdp(tl, qsplit, n0q) ! get n0 level into n0q
 
     dt=tstep*qsplit
     if (rsplit>0) dt = tstep*qsplit*rsplit  ! vertical REMAP timestep 

--- a/components/homme/src/theta-l/prim_state_mod.F90
+++ b/components/homme/src/theta-l/prim_state_mod.F90
@@ -170,7 +170,7 @@ contains
     IEner    = 0
     ! dynamics timelevels
     n0=tl%n0
-    call TimeLevel_Qdp( tl, qsplit, n0q) !get n0 level into t2_qdp 
+    call TimeLevel_Qdp(tl, qsplit, n0q) ! get n0 level into n0q
 
 
     dt=tstep*qsplit

--- a/components/homme/utils/e3sm_test/check_mass_conservation.py
+++ b/components/homme/utils/e3sm_test/check_mass_conservation.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 
 import os, sys, re
 

--- a/components/homme/utils/e3sm_test/check_mass_conservation.py
+++ b/components/homme/utils/e3sm_test/check_mass_conservation.py
@@ -1,0 +1,84 @@
+#!/bin/python
+
+import os, sys, re
+
+def readall(fn):
+    with open(fn,'r') as f:
+        txt = f.read()
+    return txt
+
+def greptxt(pattern, txt):
+    return re.findall('(?:' + pattern + ').*', txt, flags=re.MULTILINE)
+
+def grep(pattern, fn):
+    txt = readall(fn)
+    return greptxt(pattern, txt)
+
+def read_atm_modelio(case_dir):
+    filename = case_dir + os.path.sep + 'CaseDocs' + os.path.sep + 'atm_modelio.nml'
+    ln = grep('diro = ', filename)[0]
+    return ln.split()[2].split('"')[1]
+
+def get_atm_log(run_dir):
+    filenames = os.listdir(run_dir)
+    atm_fn = None
+    for f in filenames:
+        if 'atm.log' in f:
+            atm_fn = f
+            break
+    return run_dir + os.path.sep + atm_fn
+
+def uncompress(filename):
+    if '.gz' in filename:
+        os.system('gunzip {}'.format(filename))
+        return filename[:-3]
+    return filename
+
+def parsetime(ln):
+    toks = ln.split()
+    val = float(toks[3])
+    unit = toks[4]
+    if unit == '[s]': val = val/86400.0
+    return val
+
+def parseqmass(ln):
+    toks = ln.split()
+    return float(toks[-1])
+    
+def gather_mass_data(atm_log_fn, tracer_idx):
+    d = {'day': [], 'dryM': [], 'qmass': []}
+    qline = 'qv({:3d})='.format(tracer_idx)
+    with open(atm_log_fn, 'r') as f:
+        for ln in f:
+            if 'nstep=' in ln: t = parsetime(ln)
+            elif qline in ln: qmass = parseqmass(ln)
+            elif 'dry M' in ln:
+                dryM = float(ln.split()[3])
+                d['day'].append(t)
+                d['qmass'].append(qmass)
+                d['dryM'].append(dryM)
+    return d
+
+def conservative(label, time, mass, tol_per_year, verbose):
+    t_delta = (time[-1] - time[0])/365.0
+    mass_rel = abs(mass[-1] - mass[0])/abs(mass[0])
+    thr = tol_per_year*t_delta
+    if (verbose):
+        print('{:20s}: mass rel err {:1.3e} tol: {:1.3e}'.format(label, mass_rel, thr))
+    return mass_rel <= thr
+
+case_dir = sys.argv[1]
+run_dir = read_atm_modelio(case_dir)
+atm_fn = get_atm_log(run_dir)
+atm_fn = uncompress(atm_fn)
+tracer_idx = 42
+d = gather_mass_data(atm_fn, tracer_idx)
+good = (conservative('dry M', d['day'], d['dryM'], 1e-11, True) and
+        conservative('tracer {}'.format(tracer_idx), d['day'], d['qmass'], 1e-13, True))
+
+if good:
+    print('PASS')
+    sys.exit(0)
+else:
+    print('FAIL')
+    sys.exit(1) # non-0 exit will make test RUN phase fail, as desired


### PR DESCRIPTION
Set up a theta-sl-pg2 ne4pg2 test with -co2_cycle. Use POSTRUN_SCRIPT to run a
python-2/3-compatible script to read "qv( 42)" and "dry M" output from Homme's
prim_state_mod. Tracer 42 is CO2_FFF in this test. Check mass conservation for
tracer 42 and dry air in the script. If they are fine, exit with 0; if bad, 1. A
non-0 exit in a POSTRUN_SCRIPT makes the RUN phase fail.

The new test is SMS_Ld9.ne4pg2_ne4pg2.FC5AV1C-04P2.cam-thetahy_sl_pg2_mass

Addresses verification part of #3588

[non-BFB] BFB for all existing tests, but adds one new test