### PR TITLE
make PSC T threshold a namelist variable

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -5560,6 +5560,12 @@ Tunable Linoz e-fold time scale (in seconds) in the boundary layer
 Default: 172800.0
 </entry>
 
+<entry id="linoz_psc_T" type="real" category="linoz"
+       group="linoz_nl" valid_values="" >
+Tunable Linoz PSC ozone loss temperature (K) threshold
+Default: 193.0
+</entry>
+
 <entry id="tracer_cnst_datapath" type="char*256" input_pathname="abs" category="cam_chem"
        group="chem_inparm" valid_values="" >
 Full pathname of the directory that contains the files specified in


### PR DESCRIPTION
This PR makes the hard-coded T threshold of PSC ozone loss a name list variable to facilitate model tuning. The default T threshold is set to 193 K, the same as the hard-coded value, so it won't change the model results by default.

(cherry picked from commit 17aa44dd9e5e05bd8491d3468dc45e32e9a2c0b9)