### PR TITLE
Implement pcols as a runtime option in EAM

### DIFF
--- a/components/cam/bld/config_files/definition.xml
+++ b/components/cam/bld/config_files/definition.xml
@@ -209,6 +209,10 @@ Maximum number of columns in a chunk (physics data structure).
 <entry id="psubcols" value="1">
 Maximum number of sub-columns in a column (physics data structure).
 </entry>
+<entry id="ppcols" value="FALSE">
+Whether pcols is a compile time parameter. Otherwise it is the default value
+for the runtime parameter phys_chnk_fdim.
+</entry>
 <entry id="cam_exe" value="cam">
 Name of CAM executable.
 </entry>

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -1347,16 +1347,21 @@ set_horiz_grid("$cfgdir/$horiz_grid_file", $cfg_ref);
 if ($print>=2) { print "Horizontal grid specifier: $hgrid$eol"; }
 
 #-----------------------------------------------------------------------------------------------
-# Maximum number of columns in a chunk.
+# Maximum number of columns in a chunk. If set as an option, then it is a compile-time parameter
+# (ppcols == 'TRUE'). Otherwise, pcols is just the default value for a runtime parameter.
 if (defined $opts{'pcols'}) {
     $cfg_ref->set('pcols', $opts{'pcols'});
+    $cfg_ref->set('ppcols', 'TRUE');
+} else {
+    $cfg_ref->set('ppcols', 'FALSE');
 }
 my $pcols = $cfg_ref->get('pcols');
 
-# Override PCOLS setting if configuring for SCAM
+# Override PCOLS setting if configuring for SCAM. Also make it a compile-time parameter.
 if ($scam eq 'ON') {
     $pcols = 1;
     $cfg_ref->set('pcols', $pcols);
+    $cfg_ref->set('ppcols', 'TRUE');
 }
 
 # Check valid value of pcols
@@ -1946,6 +1951,11 @@ my $nadv = $cfg_ref->get('nadv');
 my $pcols = $cfg_ref->get('pcols');
 my $psubcols = $cfg_ref->get('psubcols');
 $cfg_cppdefs .= " -DPLEV=$nlev -DPCNST=$nadv -DPCOLS=$pcols -DPSUBCOLS=$psubcols";
+
+# PCOLS is a compile-time parameter if set in CAM_CONFIG_OPTS. Otherwise it is a runtime parameter
+# and PCOLS just specifies the default for the runtime parameter.
+my $ppcols = $cfg_ref->get('ppcols');
+if ($ppcols eq 'TRUE') { $cfg_cppdefs .= " -DPPCOLS"; }
 
 # Radiatively active constituent number
 $cfg_cppdefs .= " -DN_RAD_CNST=$max_n_rad_cnst";

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -494,6 +494,28 @@ Default: FALSE
 
 <!-- Coupler between Physics and Dynamics -->
 
+<entry id="phys_chnk_fdim" type="integer"  category="perf_dp_coup"
+       group="cam_inparm" valid_values="">
+The basic data structure for fields in the physics is the chunk. The
+horizontal (column) dimension is factored between the first chunk dimension
+and the number of chunks, with the size of the first dimension influencing
+serial performance (e.g. vectorization or fit into cache) and the
+number of chunks limiting the available MPI and OpenMP parallelism. 
+The number of chunks is always chosen to provide an equal number of chunks
+per computational thread (subject to the constraint that each chunk is
+assigned at least one column). However, the declared size of the first
+dimension is a free parameter, indicating the maximum number of columns
+that can be assigned to a chunk (thus also impacting the total number of
+chunks). This was originally specified at compile-time, based on 
+experiments in the early 2000s indicating that the compilers at the time
+generated more efficient code when the first dimension was known
+at compile time, perhaps for improved alignment in memory layout or improved
+vectorization. This is now exposed as a runtime parameter, and the
+previous compile-time maximum (PCOLS) is simply used to define the default
+value of the runtime variable. Must be greater than or equal to 1.
+Default: PCOLS
+</entry>
+
 <entry id="phys_alltoall" type="integer"  category="perf_dp_coup"
        group="cam_inparm" valid_values="0,1,2,11,12,13">
 Dynamics/physics transpose method for nonlocal load-balance.  0: use

--- a/components/cam/src/chemistry/aerosol/wetdep.F90
+++ b/components/cam/src/chemistry/aerosol/wetdep.F90
@@ -11,6 +11,7 @@ use ppgrid,       only: pcols, pver
 use physconst,    only: gravit, rair, tmelt
 use phys_control, only: cam_physpkg_is
 use cam_logfile,  only: iulog
+use cam_abortutils, only: endrun
 
 implicit none
 save
@@ -25,6 +26,7 @@ public :: faer_resusp_vs_fprec_evap_mpln
 public :: wetdep_inputs_t
 public :: wetdep_init
 public :: wetdep_inputs_set
+public :: wetdep_inputs_unset
 
 real(r8), parameter :: cmftau = 3600._r8
 real(r8), parameter :: rhoh2o = 1000._r8            ! density of water
@@ -35,14 +37,14 @@ type wetdep_inputs_t
    real(r8), pointer :: qme(:,:) => null()
    real(r8), pointer :: prain(:,:) => null()
    real(r8), pointer :: evapr(:,:) => null()
-   real(r8) :: cldcu(pcols,pver)     ! convective cloud fraction, currently empty
-   real(r8) :: evapc(pcols,pver)     ! Evaporation rate of convective precipitation
-   real(r8) :: cmfdqr(pcols,pver)    ! convective production of rain
-   real(r8) :: conicw(pcols,pver)    ! convective in-cloud water
-   real(r8) :: totcond(pcols, pver)  ! total condensate
-   real(r8) :: cldv(pcols,pver)      ! cloudy volume undergoing wet chem and scavenging
-   real(r8) :: cldvcu(pcols,pver)    ! Convective precipitation area at the top interface of current layer
-   real(r8) :: cldvst(pcols,pver)    ! Stratiform precipitation area at the top interface of current layer 
+   real(r8), allocatable :: cldcu(:,:)  ! convective cloud fraction, currently empty
+   real(r8), allocatable :: evapc(:,:)  ! Evaporation rate of convective precipitation
+   real(r8), allocatable :: cmfdqr(:,:) ! convective production of rain
+   real(r8), allocatable :: conicw(:,:) ! convective in-cloud water
+   real(r8), allocatable :: totcond(:,:)! total condensate
+   real(r8), allocatable :: cldv(:,:)   ! cloudy volume undergoing wet chem and scavenging
+   real(r8), allocatable :: cldvcu(:,:) ! Convective precipitation area at the top interface of current layer
+   real(r8), allocatable :: cldvst(:,:) ! Stratiform precipitation area at the top interface of current layer 
 end type wetdep_inputs_t
 
 integer :: cld_idx             = 0
@@ -122,9 +124,34 @@ subroutine wetdep_inputs_set( state, pbuf, inputs )
   real(r8) :: cldst(pcols,pver)        ! Stratiform cloud fraction
 
   integer :: itim, ncol
+  integer :: ierror
 
   ncol = state%ncol
   itim = pbuf_old_tim_idx()
+
+  allocate (inputs%cldcu(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cldcu')
+
+  allocate (inputs%evapc(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error evapc')
+
+  allocate (inputs%cmfdqr(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cmfdqr')
+
+  allocate (inputs%conicw(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error conicw')
+
+  allocate (inputs%totcond(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error totcond')
+
+  allocate (inputs%cldv(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cldv')
+
+  allocate (inputs%cldvcu(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cldvcu')
+
+  allocate (inputs%cldvst(pcols,pver), stat=ierror)
+  if ( ierror /= 0 ) call endrun('WETDEP_INPUTS_SET error: allocation error cldvst')
 
   call pbuf_get_field(pbuf, cld_idx,         inputs%cldt, start=(/1,1,itim/), kount=(/pcols,pver,1/) )
   call pbuf_get_field(pbuf, qme_idx,         inputs%qme     )
@@ -161,6 +188,25 @@ subroutine wetdep_inputs_set( state, pbuf, inputs )
                 state%ncol )
 
 end subroutine wetdep_inputs_set
+
+!==============================================================================
+! deallocate storage assoicated with wetdep_inputs_t type variable
+!==============================================================================
+subroutine wetdep_inputs_unset(inputs)
+
+  ! args
+  type(wetdep_inputs_t), intent(inout) :: inputs          !! collection of wetdepa inputs
+
+  deallocate(inputs%cldcu)
+  deallocate(inputs%evapc)
+  deallocate(inputs%cmfdqr)
+  deallocate(inputs%conicw)
+  deallocate(inputs%totcond)
+  deallocate(inputs%cldv)
+  deallocate(inputs%cldvcu)
+  deallocate(inputs%cldvst)
+
+end subroutine wetdep_inputs_unset
 
 subroutine clddiag(t, pmid, pdel, cmfdqr, evapc, &
                    cldt, cldcu, cldst, cme, evapr, &

--- a/components/cam/src/chemistry/bulk_aero/aero_model.F90
+++ b/components/cam/src/chemistry/bulk_aero/aero_model.F90
@@ -535,7 +535,8 @@ contains
        pbuf,                                                                    & !Pointer
        ptend                                                                    ) !Intent-out
 
-    use wetdep,        only : wetdepa_v1, wetdep_inputs_set, wetdep_inputs_t
+    use wetdep,        only : wetdepa_v1, wetdep_inputs_set, &
+                              wetdep_inputs_unset, wetdep_inputs_t
     use dust_model,    only : dust_names
     use seasalt_model, only : sslt_names=>seasalt_names
 
@@ -686,6 +687,8 @@ contains
     if (dust_active) then
        call outfld( 'DSTSFWET', sflx_tot_dst, pcols, lchnk)
     endif
+
+    call wetdep_inputs_unset(dep_inputs)
 
   endsubroutine aero_model_wetdep
 

--- a/components/cam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/cam/src/chemistry/modal_aero/aero_model.F90
@@ -1368,7 +1368,8 @@ contains
        ptend                                                                    ) !Intent-out
 
     use modal_aero_deposition, only: set_srf_wetdep
-    use wetdep,                only: wetdepa_v2, wetdep_inputs_set, wetdep_inputs_t
+    use wetdep,                only: wetdepa_v2, wetdep_inputs_set, &
+                                     wetdep_inputs_unset, wetdep_inputs_t
     use modal_aero_data
     use modal_aero_calcsize,   only: modal_aero_calcsize_sub
     use modal_aero_wateruptake,only: modal_aero_wateruptake_dr
@@ -2260,8 +2261,9 @@ do_lphase2_conditional: &
        call t_stopf('ma_convproc')       
     endif
 
+    call wetdep_inputs_unset(dep_inputs)
 
-  endsubroutine aero_model_wetdep
+  end subroutine aero_model_wetdep
 
 
   !=============================================================================

--- a/components/cam/src/control/camsrfexch.F90
+++ b/components/cam/src/control/camsrfexch.F90
@@ -43,41 +43,41 @@ module camsrfexch
   type cam_out_t 
      integer  :: lchnk               ! chunk index
      integer  :: ncol                ! number of columns in chunk
-     real(r8) :: tbot(pcols)         ! bot level temperature
-     real(r8) :: zbot(pcols)         ! bot level height above surface
-     real(r8) :: ubot(pcols)         ! bot level u wind
-     real(r8) :: vbot(pcols)         ! bot level v wind
-     real(r8) :: qbot(pcols,pcnst)   ! bot level specific humidity
-     real(r8) :: pbot(pcols)         ! bot level pressure
-     real(r8) :: rho(pcols)          ! bot level density	
-     real(r8) :: netsw(pcols)        !	
-     real(r8) :: flwds(pcols)        ! 
-     real(r8) :: precsc(pcols)       !
-     real(r8) :: precsl(pcols)       !
-     real(r8) :: precc(pcols)        ! 
-     real(r8) :: precl(pcols)        ! 
-     real(r8) :: soll(pcols)         ! 
-     real(r8) :: sols(pcols)         ! 
-     real(r8) :: solld(pcols)        !
-     real(r8) :: solsd(pcols)        !
-     real(r8) :: thbot(pcols)        ! 
-     real(r8) :: co2prog(pcols)      ! prognostic co2
-     real(r8) :: co2diag(pcols)      ! diagnostic co2
-     real(r8) :: psl(pcols)
-     real(r8) :: bcphiwet(pcols)     ! wet deposition of hydrophilic black carbon
-     real(r8) :: bcphidry(pcols)     ! dry deposition of hydrophilic black carbon
-     real(r8) :: bcphodry(pcols)     ! dry deposition of hydrophobic black carbon
-     real(r8) :: ocphiwet(pcols)     ! wet deposition of hydrophilic organic carbon
-     real(r8) :: ocphidry(pcols)     ! dry deposition of hydrophilic organic carbon
-     real(r8) :: ocphodry(pcols)     ! dry deposition of hydrophobic organic carbon
-     real(r8) :: dstwet1(pcols)      ! wet deposition of dust (bin1)
-     real(r8) :: dstdry1(pcols)      ! dry deposition of dust (bin1)
-     real(r8) :: dstwet2(pcols)      ! wet deposition of dust (bin2)
-     real(r8) :: dstdry2(pcols)      ! dry deposition of dust (bin2)
-     real(r8) :: dstwet3(pcols)      ! wet deposition of dust (bin3)
-     real(r8) :: dstdry3(pcols)      ! dry deposition of dust (bin3)
-     real(r8) :: dstwet4(pcols)      ! wet deposition of dust (bin4)
-     real(r8) :: dstdry4(pcols)      ! dry deposition of dust (bin4)
+     real(r8), allocatable :: tbot(:)     ! bot level temperature
+     real(r8), allocatable :: zbot(:)     ! bot level height above surface
+     real(r8), allocatable :: ubot(:)     ! bot level u wind
+     real(r8), allocatable :: vbot(:)     ! bot level v wind
+     real(r8), allocatable :: qbot(:,:)   ! bot level specific humidity
+     real(r8), allocatable :: pbot(:)     ! bot level pressure
+     real(r8), allocatable :: rho(:)      ! bot level density	
+     real(r8), allocatable :: netsw(:)    !	
+     real(r8), allocatable :: flwds(:)    ! 
+     real(r8), allocatable :: precsc(:)   !
+     real(r8), allocatable :: precsl(:)   !
+     real(r8), allocatable :: precc(:)    ! 
+     real(r8), allocatable :: precl(:)    ! 
+     real(r8), allocatable :: soll(:)     ! 
+     real(r8), allocatable :: sols(:)     ! 
+     real(r8), allocatable :: solld(:)    !
+     real(r8), allocatable :: solsd(:)    !
+     real(r8), allocatable :: thbot(:)    ! 
+     real(r8), allocatable :: co2prog(:)  ! prognostic co2
+     real(r8), allocatable :: co2diag(:)  ! diagnostic co2
+     real(r8), allocatable :: psl(:)
+     real(r8), allocatable :: bcphiwet(:) ! wet deposition of hydrophilic black carbon
+     real(r8), allocatable :: bcphidry(:) ! dry deposition of hydrophilic black carbon
+     real(r8), allocatable :: bcphodry(:) ! dry deposition of hydrophobic black carbon
+     real(r8), allocatable :: ocphiwet(:) ! wet deposition of hydrophilic organic carbon
+     real(r8), allocatable :: ocphidry(:) ! dry deposition of hydrophilic organic carbon
+     real(r8), allocatable :: ocphodry(:) ! dry deposition of hydrophobic organic carbon
+     real(r8), allocatable :: dstwet1(:)  ! wet deposition of dust (bin1)
+     real(r8), allocatable :: dstdry1(:)  ! dry deposition of dust (bin1)
+     real(r8), allocatable :: dstwet2(:)  ! wet deposition of dust (bin2)
+     real(r8), allocatable :: dstdry2(:)  ! dry deposition of dust (bin2)
+     real(r8), allocatable :: dstwet3(:)  ! wet deposition of dust (bin3)
+     real(r8), allocatable :: dstdry3(:)  ! dry deposition of dust (bin3)
+     real(r8), allocatable :: dstwet4(:)  ! wet deposition of dust (bin4)
+     real(r8), allocatable :: dstdry4(:)  ! dry deposition of dust (bin4)
   end type cam_out_t 
 
 !---------------------------------------------------------------------------
@@ -87,37 +87,37 @@ module camsrfexch
   type cam_in_t    
      integer  :: lchnk                   ! chunk index
      integer  :: ncol                    ! number of active columns
-     real(r8) :: asdir(pcols)            ! albedo: shortwave, direct
-     real(r8) :: asdif(pcols)            ! albedo: shortwave, diffuse
-     real(r8) :: aldir(pcols)            ! albedo: longwave, direct
-     real(r8) :: aldif(pcols)            ! albedo: longwave, diffuse
-     real(r8) :: lwup(pcols)             ! longwave up radiative flux
-     real(r8) :: lhf(pcols)              ! latent heat flux
-     real(r8) :: shf(pcols)              ! sensible heat flux
-     real(r8) :: wsx(pcols)              ! surface u-stress (N)
-     real(r8) :: wsy(pcols)              ! surface v-stress (N)
-     real(r8) :: tref(pcols)             ! ref height surface air temp
-     real(r8) :: qref(pcols)             ! ref height specific humidity 
-     real(r8) :: u10(pcols)              ! 10m wind speed
-     real(r8) :: ts(pcols)               ! merged surface temp 
-     real(r8) :: sst(pcols)              ! sea surface temp
-     real(r8) :: snowhland(pcols)        ! snow depth (liquid water equivalent) over land 
-     real(r8) :: snowhice(pcols)         ! snow depth over ice
-     real(r8) :: fco2_lnd(pcols)         ! co2 flux from lnd
-     real(r8) :: fco2_ocn(pcols)         ! co2 flux from ocn
-     real(r8) :: fdms(pcols)             ! dms flux
-     real(r8) :: landfrac(pcols)         ! land area fraction
-     real(r8) :: icefrac(pcols)          ! sea-ice areal fraction
-     real(r8) :: ocnfrac(pcols)          ! ocean areal fraction
-     real(r8), pointer, dimension(:) :: ram1  !aerodynamical resistance (s/m) (pcols)
-     real(r8), pointer, dimension(:) :: fv    !friction velocity (m/s) (pcols)
-     real(r8), pointer, dimension(:) :: soilw !volumetric soil water (m3/m3)
-     real(r8) :: cflx(pcols,pcnst)       ! constituent flux (emissions)
-     real(r8) :: ustar(pcols)            ! atm/ocn saved version of ustar
-     real(r8) :: re(pcols)               ! atm/ocn saved version of re
-     real(r8) :: ssq(pcols)              ! atm/ocn saved version of ssq
-     real(r8), pointer, dimension(:,:) :: depvel ! deposition velocities
-     real(r8), pointer, dimension(:,:) :: dstflx ! dust fluxes
+     real(r8), allocatable :: asdir(:)      ! albedo: shortwave, direct
+     real(r8), allocatable :: asdif(:)      ! albedo: shortwave, diffuse
+     real(r8), allocatable :: aldir(:)      ! albedo: longwave, direct
+     real(r8), allocatable :: aldif(:)      ! albedo: longwave, diffuse
+     real(r8), allocatable :: lwup(:)       ! longwave up radiative flux
+     real(r8), allocatable :: lhf(:)        ! latent heat flux
+     real(r8), allocatable :: shf(:)        ! sensible heat flux
+     real(r8), allocatable :: wsx(:)        ! surface u-stress (N)
+     real(r8), allocatable :: wsy(:)        ! surface v-stress (N)
+     real(r8), allocatable :: tref(:)       ! ref height surface air temp
+     real(r8), allocatable :: qref(:)       ! ref height specific humidity 
+     real(r8), allocatable :: u10(:)        ! 10m wind speed
+     real(r8), allocatable :: ts(:)         ! merged surface temp 
+     real(r8), allocatable :: sst(:)        ! sea surface temp
+     real(r8), allocatable :: snowhland(:)  ! snow depth (liquid water equivalent) over land
+     real(r8), allocatable :: snowhice(:)   ! snow depth over ice
+     real(r8), allocatable :: fco2_lnd(:)   ! co2 flux from lnd
+     real(r8), allocatable :: fco2_ocn(:)   ! co2 flux from ocn
+     real(r8), allocatable :: fdms(:)       ! dms flux
+     real(r8), allocatable :: landfrac(:)   ! land area fraction
+     real(r8), allocatable :: icefrac(:)    ! sea-ice areal fraction
+     real(r8), allocatable :: ocnfrac(:)    ! ocean areal fraction
+     real(r8), pointer, dimension(:) :: ram1       !aerodynamical resistance (s/m) (pcols)
+     real(r8), pointer, dimension(:) :: fv         !friction velocity (m/s) (pcols)
+     real(r8), pointer, dimension(:) :: soilw      !volumetric soil water (m3/m3)
+     real(r8), allocatable :: cflx(:,:)     ! constituent flux (emissions)
+     real(r8), allocatable :: ustar(:)      ! atm/ocn saved version of ustar
+     real(r8), allocatable :: re(:)         ! atm/ocn saved version of re
+     real(r8), allocatable :: ssq(:)        ! atm/ocn saved version of ssq
+     real(r8), pointer, dimension(:,:) :: depvel   ! deposition velocities
+     real(r8), pointer, dimension(:,:) :: dstflx   ! dust fluxes
      real(r8), pointer, dimension(:,:) :: meganflx ! MEGAN fluxes
   end type cam_in_t    
 
@@ -175,6 +175,72 @@ CONTAINS
        nullify(cam_in(c)%meganflx)
     enddo  
     do c = begchunk,endchunk 
+       allocate (cam_in(c)%asdir(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error asdir')
+
+       allocate (cam_in(c)%asdif(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error asdif')
+
+       allocate (cam_in(c)%aldir(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error aldir')
+
+       allocate (cam_in(c)%aldif(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error aldif')
+
+       allocate (cam_in(c)%lwup(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error lwup')
+
+       allocate (cam_in(c)%lhf(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error lhf')
+
+       allocate (cam_in(c)%shf(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error shf')
+
+       allocate (cam_in(c)%wsx(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsx')
+
+       allocate (cam_in(c)%wsy(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsy')
+
+       allocate (cam_in(c)%tref(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error tref')
+
+       allocate (cam_in(c)%qref(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error qref')
+
+       allocate (cam_in(c)%u10(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error u10')
+
+       allocate (cam_in(c)%ts(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ts')
+
+       allocate (cam_in(c)%sst(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error sst')
+
+       allocate (cam_in(c)%snowhland(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error snowhland')
+
+       allocate (cam_in(c)%snowhice(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error snowhice')
+
+       allocate (cam_in(c)%fco2_lnd(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error fco2_lnd')
+
+       allocate (cam_in(c)%fco2_ocn(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error fco2_ocn')
+
+       allocate (cam_in(c)%fdms(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error fdms')
+
+       allocate (cam_in(c)%landfrac(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error landfrac')
+
+       allocate (cam_in(c)%icefrac(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error icefrac')
+
+       allocate (cam_in(c)%ocnfrac(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ocnfrac')
+
        if (index_x2a_Sl_ram1>0) then
           allocate (cam_in(c)%ram1(pcols), stat=ierror)
           if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ram1')
@@ -187,6 +253,19 @@ CONTAINS
           allocate (cam_in(c)%soilw(pcols), stat=ierror)
           if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error soilw')
        end if
+
+       allocate (cam_in(c)%cflx(pcols,pcnst), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error cflx')
+
+       allocate (cam_in(c)%ustar(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ustar')
+
+       allocate (cam_in(c)%re(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error re')
+
+       allocate (cam_in(c)%ssq(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ssq')
+
        if (index_x2a_Fall_flxdst1>0) then
           ! Assume 4 bins from surface model ....
           allocate (cam_in(c)%dstflx(pcols,4), stat=ierror)
@@ -294,6 +373,113 @@ CONTAINS
       call endrun('ATM2HUB_ALLOC error: allocation error')
     end if
 
+    do c = begchunk,endchunk 
+       allocate (cam_out(c)%tbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error tbot')
+
+       allocate (cam_out(c)%zbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error zbot')
+
+       allocate (cam_out(c)%ubot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ubot')
+
+       allocate (cam_out(c)%vbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error vbot')
+
+       allocate (cam_out(c)%qbot(pcols,pcnst), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error qbot')
+
+       allocate (cam_out(c)%pbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error pbot')
+
+       allocate (cam_out(c)%rho(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error rho')
+
+       allocate (cam_out(c)%netsw(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error netsw')
+
+       allocate (cam_out(c)%flwds(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error flwds')
+
+       allocate (cam_out(c)%precsc(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precsc')
+
+       allocate (cam_out(c)%precsl(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precsl')
+
+       allocate (cam_out(c)%precc(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precc')
+
+       allocate (cam_out(c)%precl(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precl')
+
+       allocate (cam_out(c)%soll(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error soll')
+
+       allocate (cam_out(c)%sols(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error sols')
+
+       allocate (cam_out(c)%solld(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error solld')
+
+       allocate (cam_out(c)%solsd(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error solsd')
+
+       allocate (cam_out(c)%thbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error thbot')
+
+       allocate (cam_out(c)%co2prog(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error co2prog')
+
+       allocate (cam_out(c)%co2diag(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error co2diag')
+
+       allocate (cam_out(c)%psl(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB ALLOC error: allocation error psl')
+
+       allocate (cam_out(c)%bcphiwet(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error bcphiwet')
+
+       allocate (cam_out(c)%bcphidry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error bcphidry')
+
+       allocate (cam_out(c)%bcphodry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error bcphodry')
+
+       allocate (cam_out(c)%ocphiwet(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ocphiwet')
+
+       allocate (cam_out(c)%ocphidry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ocphidry')
+
+       allocate (cam_out(c)%ocphodry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ocphodry')
+
+       allocate (cam_out(c)%dstwet1(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet1')
+
+       allocate (cam_out(c)%dstdry1(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry1')
+
+       allocate (cam_out(c)%dstwet2(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet2')
+
+       allocate (cam_out(c)%dstdry2(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry2')
+
+       allocate (cam_out(c)%dstwet3(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet3')
+
+       allocate (cam_out(c)%dstdry3(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry3')
+
+       allocate (cam_out(c)%dstwet4(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet4')
+
+       allocate (cam_out(c)%dstdry4(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry4')
+    enddo  
+
     do c = begchunk,endchunk
        cam_out(c)%lchnk       = c
        cam_out(c)%ncol        = get_ncols_p(c)
@@ -338,7 +524,46 @@ CONTAINS
 
   subroutine atm2hub_deallocate(cam_out)
     type(cam_out_t), pointer :: cam_out(:)    ! Atmosphere to surface input
+    integer :: c
+
     if(associated(cam_out)) then
+       do c = begchunk,endchunk
+          deallocate(cam_out(c)%tbot)
+          deallocate(cam_out(c)%zbot)
+          deallocate(cam_out(c)%ubot)
+          deallocate(cam_out(c)%vbot)
+          deallocate(cam_out(c)%qbot)
+          deallocate(cam_out(c)%pbot)
+          deallocate(cam_out(c)%rho)
+          deallocate(cam_out(c)%netsw)
+          deallocate(cam_out(c)%flwds)
+          deallocate(cam_out(c)%precsc)
+          deallocate(cam_out(c)%precsl)
+          deallocate(cam_out(c)%precc)
+          deallocate(cam_out(c)%precl)
+          deallocate(cam_out(c)%soll)
+          deallocate(cam_out(c)%sols)
+          deallocate(cam_out(c)%solld)
+          deallocate(cam_out(c)%solsd)
+          deallocate(cam_out(c)%thbot)
+          deallocate(cam_out(c)%co2prog)
+          deallocate(cam_out(c)%co2diag)
+          deallocate(cam_out(c)%bcphiwet)
+          deallocate(cam_out(c)%bcphidry)
+          deallocate(cam_out(c)%bcphodry)
+          deallocate(cam_out(c)%ocphiwet)
+          deallocate(cam_out(c)%ocphidry)
+          deallocate(cam_out(c)%ocphodry)
+          deallocate(cam_out(c)%dstwet1)
+          deallocate(cam_out(c)%dstdry1)
+          deallocate(cam_out(c)%dstwet2)
+          deallocate(cam_out(c)%dstdry2)
+          deallocate(cam_out(c)%dstwet3)
+          deallocate(cam_out(c)%dstdry3)
+          deallocate(cam_out(c)%dstwet4)
+          deallocate(cam_out(c)%dstdry4)
+       enddo  
+
        deallocate(cam_out)
     end if
     nullify(cam_out)
@@ -350,6 +575,29 @@ CONTAINS
 
     if(associated(cam_in)) then
        do c=begchunk,endchunk
+          deallocate(cam_in(c)%asdir)
+          deallocate(cam_in(c)%asdif)
+          deallocate(cam_in(c)%aldir)
+          deallocate(cam_in(c)%aldif)
+          deallocate(cam_in(c)%lwup)
+          deallocate(cam_in(c)%lhf)
+          deallocate(cam_in(c)%shf)
+          deallocate(cam_in(c)%wsx)
+          deallocate(cam_in(c)%wsy)
+          deallocate(cam_in(c)%tref)
+          deallocate(cam_in(c)%qref)
+          deallocate(cam_in(c)%u10)
+          deallocate(cam_in(c)%ts)
+          deallocate(cam_in(c)%sst)
+          deallocate(cam_in(c)%snowhland)
+          deallocate(cam_in(c)%snowhice)
+          deallocate(cam_in(c)%fco2_lnd)
+          deallocate(cam_in(c)%fco2_ocn)
+          deallocate(cam_in(c)%fdms)
+          deallocate(cam_in(c)%landfrac)
+          deallocate(cam_in(c)%icefrac)
+          deallocate(cam_in(c)%ocnfrac)
+
           if(associated(cam_in(c)%ram1)) then
              deallocate(cam_in(c)%ram1)
              nullify(cam_in(c)%ram1)
@@ -362,6 +610,12 @@ CONTAINS
              deallocate(cam_in(c)%soilw)
              nullify(cam_in(c)%soilw)
           end if
+
+          deallocate(cam_in(c)%cflx)
+          deallocate(cam_in(c)%ustar)
+          deallocate(cam_in(c)%re)
+          deallocate(cam_in(c)%ssq)
+
           if(associated(cam_in(c)%dstflx)) then
              deallocate(cam_in(c)%dstflx)
              nullify(cam_in(c)%dstflx)
@@ -374,7 +628,6 @@ CONTAINS
              deallocate(cam_in(c)%depvel)
              nullify(cam_in(c)%depvel)
           end if
-          
        enddo
 
        deallocate(cam_in)

--- a/components/cam/src/control/runtime_opts.F90
+++ b/components/cam/src/control/runtime_opts.F90
@@ -95,6 +95,10 @@ character(len=256) :: cam_branch_file = ' '
 !
 ! seed_clock           logical: if .true., XOR the system_clock with the seed,
 !                      wheter it includes a custom seed or not. Default .false.
+! 
+! phys_chnk_fdim       Declared first dimension for physics variables (chunks).
+!                      See phys_grid module.  
+integer :: phys_chnk_fdim
 !
 ! phys_alltoall        Dynamics/physics transpose option. See phys_grid module.
 !
@@ -301,6 +305,7 @@ contains
                      tracers_flag, &
                      indirect, &
                      print_step_cost,  &
+                     phys_chnk_fdim,  &
                      phys_alltoall, phys_loadbalance, phys_twin_algorithm, &
                      phys_chnk_per_thd, phys_chnk_cost_write
 
@@ -334,6 +339,7 @@ contains
 
    ! Get default values of runtime options for physics chunking.
    call phys_grid_defaultopts(                      &
+      phys_chnk_fdim_out      =phys_chnk_fdim,      &
       phys_loadbalance_out    =phys_loadbalance,    &
       phys_twin_algorithm_out =phys_twin_algorithm, &
       phys_alltoall_out       =phys_alltoall,       &
@@ -406,6 +412,7 @@ contains
 
    ! Set runtime options for physics chunking.
    call phys_grid_setopts(                          &
+       phys_chnk_fdim_in      =phys_chnk_fdim,      &
        phys_loadbalance_in    =phys_loadbalance,    &
        phys_twin_algorithm_in =phys_twin_algorithm, &
        phys_alltoall_in       =phys_alltoall,       &
@@ -626,6 +633,7 @@ subroutine distnl
    call mpibcast (indirect     , 1 ,mpilog, 0,mpicom)
 
    ! Physics chunk tuning
+   call mpibcast (phys_chnk_fdim     ,1,mpiint,0,mpicom)
    call mpibcast (phys_loadbalance   ,1,mpiint,0,mpicom)
    call mpibcast (phys_twin_algorithm,1,mpiint,0,mpicom)
    call mpibcast (phys_alltoall      ,1,mpiint,0,mpicom)

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -1952,7 +1952,7 @@ subroutine diag_surf (cam_in, cam_out, ps, trefmxav, trefmnav )
 
     call outfld('SHFLX',    cam_in%shf,       pcols, lchnk)
     call outfld('LHFLX',    cam_in%lhf,       pcols, lchnk)
-    call outfld('QFLX',     cam_in%cflx,      pcols, lchnk)
+    call outfld('QFLX',     cam_in%cflx(1,1), pcols, lchnk)
 
     call outfld('TAUX',     cam_in%wsx,       pcols, lchnk)
     call outfld('TAUY',     cam_in%wsy,       pcols, lchnk)

--- a/components/cam/src/physics/cam/cam_diagnostics.F90
+++ b/components/cam/src/physics/cam/cam_diagnostics.F90
@@ -1952,7 +1952,7 @@ subroutine diag_surf (cam_in, cam_out, ps, trefmxav, trefmnav )
 
     call outfld('SHFLX',    cam_in%shf,       pcols, lchnk)
     call outfld('LHFLX',    cam_in%lhf,       pcols, lchnk)
-    call outfld('QFLX',     cam_in%cflx(1,1), pcols, lchnk)
+    call outfld('QFLX',     cam_in%cflx,      pcols, lchnk)
 
     call outfld('TAUX',     cam_in%wsx,       pcols, lchnk)
     call outfld('TAUY',     cam_in%wsy,       pcols, lchnk)

--- a/components/cam/src/physics/cam/check_energy.F90
+++ b/components/cam/src/physics/cam/check_energy.F90
@@ -54,6 +54,7 @@ module check_energy
   public :: check_energy_fix       ! add global mean energy difference as a heating
   public :: check_tracers_init      ! initialize tracer integrals and cumulative boundary fluxes
   public :: check_tracers_chng      ! check changes in integrals against cumulative boundary fluxes
+  public :: check_tracers_fini      ! free memory associated with check_tracers_data type variable
 
   public :: qflx_gmean              ! calculate global mean of qflx for water conservation check 
   public :: check_qflx              ! output qflx at certain locations for water conservation check  
@@ -82,8 +83,8 @@ module check_energy
   integer  :: dtcore_idx = 0       ! dtcore index in physics buffer 
 
   type check_tracers_data
-     real(r8) :: tracer(pcols,pcnst)       ! initial vertically integrated total (kinetic + static) energy
-     real(r8) :: tracer_tnd(pcols,pcnst)   ! cumulative boundary flux of total energy
+     real(r8), allocatable :: tracer(:,:) ! initial vertically integrated total (kinetic + static) energy
+     real(r8), allocatable :: tracer_tnd(:,:) ! cumulative boundary flux of total energy
      integer :: count(pcnst)               ! count of values with significant imbalances
   end type check_tracers_data
 
@@ -887,6 +888,7 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
     real(r8) :: trpdel(pcols, pver)                ! pdel for tracer
 
     integer ncol                                   ! number of atmospheric columns
+    integer ierror                                 ! allocate status return
     integer  i,k,m                                 ! column, level,constituent indices
     integer :: ixcldice, ixcldliq                  ! CLDICE and CLDLIQ and tracer indices
     integer :: ixrain, ixsnow                      ! RAINQM and SNOWQM indices
@@ -894,6 +896,12 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
 !-----------------------------------------------------------------------
 
     ncol  = state%ncol
+    allocate (tracerint%tracer(pcols,pcnst), stat=ierror)
+    if ( ierror /= 0 ) call endrun('CHECK_TRACERS_INIT error: allocation error tracer')
+
+    allocate (tracerint%tracer_tnd(pcols,pcnst), stat=ierror)
+    if ( ierror /= 0 ) call endrun('CHECK_TRACERS_INIT error: allocation error tracer_tnd')
+
     call cnst_get_ind('CLDICE', ixcldice, abort=.false.)
     call cnst_get_ind('CLDLIQ', ixcldliq, abort=.false.)
     call cnst_get_ind('RAINQM', ixrain,   abort=.false.)
@@ -932,6 +940,25 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
 
     return
   end subroutine check_tracers_init
+
+!===============================================================================
+  subroutine check_tracers_fini(tracerint)
+
+!-----------------------------------------------------------------------
+! Deallocate storage assoicated with check_tracers_data type variable
+!-----------------------------------------------------------------------
+
+!------------------------------Arguments--------------------------------
+
+    type(check_tracers_data), intent(inout)   :: tracerint
+
+!-----------------------------------------------------------------------
+
+    deallocate(tracerint%tracer)
+    deallocate(tracerint%tracer_tnd)
+
+    return
+  end subroutine check_tracers_fini
 
 !===============================================================================
   subroutine check_tracers_chng(state, tracerint, name, nstep, ztodt, cflx)

--- a/components/cam/src/physics/cam/convect_shallow.F90
+++ b/components/cam/src/physics/cam/convect_shallow.F90
@@ -442,7 +442,7 @@ end subroutine convect_shallow_init_cnst
    use constituents,    only : pcnst, cnst_get_ind, cnst_get_type_byind
    use hk_conv,         only : cmfmca
    use uwshcu,          only : compute_uwshcu_inv
-   use unicon_cam,      only : unicon_out_t, unicon_cam_tend
+   use unicon_cam,      only : unicon_out_t, unicon_cam_tend, unicon_cam_tend_free
 
    use time_manager,    only : get_nstep, is_first_step
    use wv_saturation,   only : qsat
@@ -763,6 +763,8 @@ end subroutine convect_shallow_init_cnst
       cmflq(:ncol,:) = unicon_out%qtflx(:ncol,:) * latvap
 
       call outfld( 'PRECSH' , precc  , pcols, lchnk )
+
+      call unicon_cam_tend_free(unicon_out)
 
    end select
 

--- a/components/cam/src/physics/cam/phys_grid.F90
+++ b/components/cam/src/physics/cam/phys_grid.F90
@@ -265,7 +265,7 @@ module phys_grid
                                        ! swap partner in each step of 
                                        !  transpose algorithm
    logical :: physgrid_set = .false.   ! flag indicates physics grid has been set
-   integer, private :: max_nproc_smpx  ! maximum number of processes assigned to a
+   integer, private :: max_nproc_vsmp  ! maximum number of processes assigned to a
                                        !  single virtual SMP used to define physics 
                                        !  load balancing
    integer, private :: nproc_busy_d    ! number of processes active during the dynamics
@@ -316,7 +316,7 @@ module phys_grid
    integer, private :: chunks_per_thread = def_chunks_per_thread
 
 ! Dynamics/physics transpose method for nonlocal load-balance:
-! -1: use "0" if max_nproc_smpx and nproc_busy_d are both > npes/2; otherwise use "1"
+! -1: use "0" if max_nproc_vsmp and nproc_busy_d are both > npes/2; otherwise use "1"
 !  0: use mpi_alltoallv
 !  1: use point-to-point MPI-1 two-sided implementation
 !  2: use point-to-point MPI-2 one-sided implementation if supported, 
@@ -711,7 +711,7 @@ contains
        !
        ! Set max virtual SMP node size
        !
-       max_nproc_smpx = 1
+       max_nproc_vsmp = 1
 
        !
        ! Allocate and initialize chunks data structure
@@ -3730,7 +3730,7 @@ logical function phys_grid_initialized ()
 !
    call t_barrierf('sync_tran_btoc', mpicom)
    if (phys_alltoall < 0) then
-      if ((max_nproc_smpx > npes/2) .and. (nproc_busy_d > npes/2)) then
+      if ((max_nproc_vsmp > npes/2) .and. (nproc_busy_d > npes/2)) then
          lopt = 0
       else
          lopt = 1
@@ -4060,7 +4060,7 @@ logical function phys_grid_initialized ()
 !
    call t_barrierf('sync_tran_ctob', mpicom)
    if (phys_alltoall < 0) then
-      if ((max_nproc_smpx > npes/2) .and. (nproc_busy_d > npes/2)) then
+      if ((max_nproc_vsmp > npes/2) .and. (nproc_busy_d > npes/2)) then
          lopt = 0
       else
          lopt = 1
@@ -4250,16 +4250,16 @@ logical function phys_grid_initialized ()
                                          !  thread
 !---------------------------Local workspace-----------------------------
    integer :: i, j, p                    ! loop indices
-   integer :: proc_smp_mapx(0:npes-1)    ! process/virtual SMP node map
+   integer :: proc_vsmp_map(0:npes-1)    ! process/virtual SMP node map
    integer :: firstblock, lastblock      ! global block index bounds
    integer :: maxblksiz                  ! maximum number of columns in a dynamics block
    integer :: block_cnt                  ! number of blocks containing data
                                          ! for a given vertical column
    integer :: blockids(plev+1)           ! block indices
    integer :: bcids(plev+1)              ! block column indices
-   integer :: nsmpx, nsmpy               ! virtual SMP node counts and indices
+   integer :: nvsmp, nvsmp2              ! virtual SMP node counts and indices
    integer :: curgcol, twingcol          ! global physics and dynamics column indices
-   integer :: smp                        ! SMP node index
+   integer :: smp                        ! SMP node index (both virtual and actual)
    integer :: cid                        ! chunk id
    integer :: jb, ib                     ! global block and columns indices
    integer :: blksiz                     ! current block size
@@ -4273,7 +4273,7 @@ logical function phys_grid_initialized ()
    ! indices for dynamics columns in given block
    integer, dimension(:), allocatable :: cols_d
 
-   ! number of MPI processes per virtual SMP node (0:nsmpx-1)
+   ! number of MPI processes per virtual SMP node (0:nvsmp-1)
    integer, dimension(:), allocatable :: nsmpprocs      
 
    ! flag indicating whether a process is busy or idle during the dynamics (0:npes-1)
@@ -4284,31 +4284,31 @@ logical function phys_grid_initialized ()
    logical, dimension(:), allocatable :: smp_busy_d
 
    ! actual SMP node/virtual SMP node map (0:nsmps-1)    
-   integer, dimension(:), allocatable :: smp_smp_mapx
+   integer, dimension(:), allocatable :: smp_vsmp_map
 
    ! column/virtual SMP node map (ngcols)
-   integer, dimension(:), allocatable :: col_smp_mapx
+   integer, dimension(:), allocatable :: col_vsmp_map
 
-   ! number of columns assigned to a given virtual SMP node (0:nsmpx-1)
-   integer, dimension(:), allocatable :: nsmpcolumns
+   ! number of columns assigned to a given virtual SMP node (0:nvsmp-1)
+   integer, dimension(:), allocatable :: nvsmpcolumns
 
-   ! number of OpenMP threads per virtual SMP node (0:nsmpx-1)
-   integer, dimension(:), allocatable :: nsmpthreads
+   ! number of OpenMP threads per virtual SMP node (0:nvsmp-1)
+   integer, dimension(:), allocatable :: nvsmpthreads
 
-   ! number of chunks assigned to a given virtual SMP node (0:nsmpx-1)
-   integer, dimension(:), allocatable :: nsmpchunks
+   ! number of chunks assigned to a given virtual SMP node (0:nvsmp-1)
+   integer, dimension(:), allocatable :: nvsmpchunks
                                          
-   ! maximum number of columns assigned to a chunk in a given virtual SMP node (0:nsmpx-1)
+   ! maximum number of columns assigned to a chunk in a given virtual SMP node (0:nvsmp-1)
    integer, dimension(:), allocatable :: maxcol_chk
                                          
    ! number of chunks in given virtual SMP node receiving maximum number of columns 
-   ! (0:nsmpx-1)
+   ! (0:nvsmp-1)
    integer, dimension(:), allocatable :: maxcol_chks
 
-   ! chunk id virtual offset (0:nsmpx-1)
+   ! chunk id virtual offset (0:nvsmp-1)
    integer, dimension(:), allocatable :: cid_offset
 
-   ! process-local chunk id (0:nsmpx-1)
+   ! process-local chunk id (0:nvsmp-1)
    integer, dimension(:), allocatable :: local_cid
 
    ! permutation array used to sort columns by their computation cost
@@ -4377,27 +4377,27 @@ logical function phys_grid_initialized ()
    if ((opt <= 0) .or. (opt == 4)) then
 
 !     assign active dynamics processes to virtual SMP nodes
-      nsmpx = 0
+      nvsmp = 0
       do p=0,npes-1
          if (proc_busy_d(p)) then
-            proc_smp_mapx(p) = nsmpx
-            nsmpx = nsmpx + 1
+            proc_vsmp_map(p) = nvsmp
+            nvsmp = nvsmp + 1
          endif
       enddo
 ! 
 !     assign idle dynamics processes to virtual SMP nodes (wrap map)
-      nsmpy = 0
+      nvsmp2 = 0
       do p=0,npes-1
          if (.not. proc_busy_d(p)) then
-            proc_smp_mapx(p) = nsmpy
-            nsmpy = mod(nsmpy+1,nsmpx)
+            proc_vsmp_map(p) = nvsmp2
+            nvsmp2 = mod(nvsmp2+1,nvsmp)
          endif
       enddo
 
    elseif (opt == 1) then
 
       allocate( smp_busy_d(0:nsmps-1) )
-      allocate( smp_smp_mapx(0:nsmps-1) )
+      allocate( smp_vsmp_map(0:nsmps-1) )
 
 !
 !     determine SMP nodes assigned dynamics blocks
@@ -4411,11 +4411,11 @@ logical function phys_grid_initialized ()
 
 !
 !     determine number of SMP nodes assigned dynamics blocks
-      nsmpx = 0
+      nvsmp = 0
       do smp=0,nsmps-1
          if (smp_busy_d(smp)) then
-            smp_smp_mapx(smp) = nsmpx
-            nsmpx = nsmpx + 1
+            smp_vsmp_map(smp) = nvsmp
+            nvsmp = nvsmp + 1
          endif
       enddo
 !
@@ -4423,51 +4423,51 @@ logical function phys_grid_initialized ()
       do p=0,npes-1
          smp = proc_smp_map(p)
          if (smp_busy_d(smp)) then
-            proc_smp_mapx(p) = smp_smp_mapx(smp)
+            proc_vsmp_map(p) = smp_vsmp_map(smp)
          endif
       enddo
 ! 
 !     assign processes in idle dynamics SMP nodes to virtual SMP nodes (wrap map)
-      nsmpy = 0
+      nvsmp2 = 0
       do p=0,npes-1
          smp = proc_smp_map(p)
          if (.not. smp_busy_d(smp)) then
-            proc_smp_mapx(p) = nsmpy
-            nsmpy = mod(nsmpy+1,nsmpx)
+            proc_vsmp_map(p) = nvsmp2
+            nvsmp2 = mod(nvsmp2+1,nvsmp)
          endif
       enddo
 !
       deallocate( smp_busy_d )
-      deallocate( smp_smp_mapx )
+      deallocate( smp_vsmp_map )
 
    elseif (opt == 2) then
 
-      nsmpx = 1
+      nvsmp = 1
       do p=0,npes-1
-         proc_smp_mapx(p) = 0
+         proc_vsmp_map(p) = 0
       enddo
 
    elseif (opt == 3) then
 
 !     find active process partners
-      proc_smp_mapx = -1
-      call find_partners(opt,proc_busy_d,nsmpx,proc_smp_mapx)
+      proc_vsmp_map = -1
+      call find_partners(opt,proc_busy_d,nvsmp,proc_vsmp_map)
 ! 
 !     assign unassigned (idle dynamics) processes to virtual SMP nodes 
 !     (wrap map)
-      nsmpy = 0
+      nvsmp2 = 0
       do p=0,npes-1
-         if (proc_smp_mapx(p) .eq. -1) then
-            proc_smp_mapx(p) = nsmpy
-            nsmpy = mod(nsmpy+1,nsmpx)
+         if (proc_vsmp_map(p) .eq. -1) then
+            proc_vsmp_map(p) = nvsmp2
+            nvsmp2 = mod(nvsmp2+1,nvsmp)
          endif
       enddo
 
    else
 
-      nsmpx = npes
+      nvsmp = npes
       do p=0,npes-1
-         proc_smp_mapx(p) = p
+         proc_vsmp_map(p) = p
       enddo
 
    endif
@@ -4478,14 +4478,14 @@ logical function phys_grid_initialized ()
 ! Determine maximum number of processes assigned to a single 
 ! virtual SMP node
 !
-   allocate( nsmpprocs(0:nsmpx-1) )
+   allocate( nsmpprocs(0:nvsmp-1) )
 !
    nsmpprocs(:) = 0
    do p=0,npes-1
-      smp = proc_smp_mapx(p)
+      smp = proc_vsmp_map(p)
       nsmpprocs(smp) = nsmpprocs(smp) + 1
    enddo
-   max_nproc_smpx = maxval(nsmpprocs)
+   max_nproc_vsmp = maxval(nsmpprocs)
 !
    deallocate( nsmpprocs )   
 
@@ -4493,9 +4493,9 @@ logical function phys_grid_initialized ()
 ! Determine number of columns assigned to each
 ! virtual SMP in block decomposition
 
-   allocate( col_smp_mapx(ngcols) )
+   allocate( col_vsmp_map(ngcols) )
 !
-   col_smp_mapx(:) = -1
+   col_vsmp_map(:) = -1
    error = .false.
    do i=1,ngcols
       if (dyn_to_latlon_gcol_map(i) .ne. -1) then
@@ -4503,9 +4503,9 @@ logical function phys_grid_initialized ()
          call get_gcol_block_d(i,block_cnt,blockids,bcids)
          do jb=1,block_cnt
             p = get_block_owner_d(blockids(jb))
-            if (col_smp_mapx(i) .eq. -1) then
-               col_smp_mapx(i) = proc_smp_mapx(p)
-            elseif (col_smp_mapx(i) .ne. proc_smp_mapx(p)) then
+            if (col_vsmp_map(i) .eq. -1) then
+               col_vsmp_map(i) = proc_vsmp_map(p)
+            elseif (col_vsmp_map(i) .ne. proc_vsmp_map(p)) then
                error = .true.
             endif
          enddo
@@ -4517,15 +4517,15 @@ logical function phys_grid_initialized ()
       call endrun()
    endif  
 !
-   allocate( nsmpcolumns(0:nsmpx-1) )
+   allocate( nvsmpcolumns(0:nvsmp-1) )
 !
-   nsmpcolumns(:) = 0
+   nvsmpcolumns(:) = 0
    error = .false.
    do i=1,ngcols_p
       curgcol = latlon_to_dyn_gcol_map(i)
-      smp = col_smp_mapx(curgcol)
+      smp = col_vsmp_map(curgcol)
       if (smp >= 0) then
-         nsmpcolumns(smp) = nsmpcolumns(smp) + 1
+         nvsmpcolumns(smp) = nvsmpcolumns(smp) + 1
       else
          error = .true.
          exit
@@ -4540,13 +4540,13 @@ logical function phys_grid_initialized ()
 !
 !  Allocate other work space
 !
-   allocate( nsmpthreads(0:nsmpx-1) )
-   allocate( nsmpchunks (0:nsmpx-1) )
-   allocate( maxcol_chk (0:nsmpx-1) )
-   allocate( maxcol_chks(0:nsmpx-1) )
-   allocate( cid_offset (0:nsmpx-1) )
-   allocate( local_cid  (0:nsmpx-1) )
-   allocate( cols_d   (1:maxblksiz) )
+   allocate( nvsmpthreads(0:nvsmp-1) )
+   allocate( nvsmpchunks (0:nvsmp-1) )
+   allocate( maxcol_chk  (0:nvsmp-1) )
+   allocate( maxcol_chks (0:nvsmp-1) )
+   allocate( cid_offset  (0:nvsmp-1) )
+   allocate( local_cid   (0:nvsmp-1) )
+   allocate( cols_d    (1:maxblksiz) )
 
 !
 ! Options 0-3: split local dynamics blocks into chunks,
@@ -4566,45 +4566,45 @@ logical function phys_grid_initialized ()
 !
 ! Calculate number of threads available in each SMP node. 
 !
-      nsmpthreads(:) = 0
+      nvsmpthreads(:) = 0
       do p=0,npes-1
-         smp = proc_smp_mapx(p)
-         nsmpthreads(smp) = nsmpthreads(smp) + npthreads(p)
+         smp = proc_vsmp_map(p)
+         nvsmpthreads(smp) = nvsmpthreads(smp) + npthreads(p)
       enddo
 !
 ! Determine number of chunks to keep all threads busy
 !
       nchunks = 0
-      do smp=0,nsmpx-1
-         nsmpchunks(smp) = nsmpcolumns(smp)/pcols
-         if (mod(nsmpcolumns(smp), pcols) .ne. 0) then
-            nsmpchunks(smp) = nsmpchunks(smp) + 1
+      do smp=0,nvsmp-1
+         nvsmpchunks(smp) = nvsmpcolumns(smp)/pcols
+         if (mod(nvsmpcolumns(smp), pcols) .ne. 0) then
+            nvsmpchunks(smp) = nvsmpchunks(smp) + 1
          endif
-         if (nsmpchunks(smp) < chunks_per_thread*nsmpthreads(smp)) then
-            nsmpchunks(smp) = chunks_per_thread*nsmpthreads(smp)
+         if (nvsmpchunks(smp) < chunks_per_thread*nvsmpthreads(smp)) then
+            nvsmpchunks(smp) = chunks_per_thread*nvsmpthreads(smp)
          endif
-         do while (mod(nsmpchunks(smp), nsmpthreads(smp)) .ne. 0)
-            nsmpchunks(smp) = nsmpchunks(smp) + 1
+         do while (mod(nvsmpchunks(smp), nvsmpthreads(smp)) .ne. 0)
+            nvsmpchunks(smp) = nvsmpchunks(smp) + 1
          enddo
-         if (nsmpchunks(smp) > nsmpcolumns(smp)) then
-            nsmpchunks(smp) = nsmpcolumns(smp)
+         if (nvsmpchunks(smp) > nvsmpcolumns(smp)) then
+            nvsmpchunks(smp) = nvsmpcolumns(smp)
          endif
-         nchunks = nchunks + nsmpchunks(smp)
+         nchunks = nchunks + nvsmpchunks(smp)
       enddo      
 !
 ! Determine maximum number of columns to assign to chunks
 ! in a given SMP
 !
-      do smp=0,nsmpx-1
-         if (nsmpchunks(smp) /= 0) then
-            ntmp1 = nsmpcolumns(smp)/nsmpchunks(smp)
-            ntmp2 = mod(nsmpcolumns(smp),nsmpchunks(smp))
+      do smp=0,nvsmp-1
+         if (nvsmpchunks(smp) /= 0) then
+            ntmp1 = nvsmpcolumns(smp)/nvsmpchunks(smp)
+            ntmp2 = mod(nvsmpcolumns(smp),nvsmpchunks(smp))
             if (ntmp2 > 0) then
                maxcol_chk(smp) = ntmp1 + 1
                maxcol_chks(smp) = ntmp2
             else
                maxcol_chk(smp) = ntmp1
-               maxcol_chks(smp) = nsmpchunks(smp)
+               maxcol_chks(smp) = nvsmpchunks(smp)
             endif
          else
             maxcol_chk(smp) = 0
@@ -4633,8 +4633,8 @@ logical function phys_grid_initialized ()
 !
       cid_offset(0) = 1
       local_cid(0) = 0
-      do smp=1,nsmpx-1
-         cid_offset(smp) = cid_offset(smp-1) + nsmpchunks(smp-1)
+      do smp=1,nvsmp-1
+         cid_offset(smp) = cid_offset(smp-1) + nvsmpchunks(smp-1)
          local_cid(smp) = 0
       enddo    
 
@@ -4693,9 +4693,9 @@ logical function phys_grid_initialized ()
          heap(cid) = cid
       enddo
 
-      allocate( heap_len(0:nsmpx-1) )
-      do smp=0,nsmpx-1
-         heap_len(smp) = nsmpchunks(smp)
+      allocate( heap_len(0:nvsmp-1) )
+      do smp=0,nvsmp-1
+         heap_len(smp) = nvsmpchunks(smp)
       enddo
 
 !
@@ -4703,7 +4703,7 @@ logical function phys_grid_initialized ()
 !
       do i=1,ngcols
          curgcol = cdex(i)
-         smp = col_smp_mapx(i)
+         smp = col_vsmp_map(i)
 !
 ! Assign column to a chunk if not already assigned
          if ((dyn_to_latlon_gcol_map(curgcol) .ne. -1) .and. &
@@ -4731,12 +4731,12 @@ logical function phys_grid_initialized ()
                cid = cid_offset(smp) + local_cid(smp)
                if (maxcol_chks(smp) > 0) then
                   do while (chunks(cid)%ncols >=  maxcol_chk(smp))
-                     local_cid(smp) = mod(local_cid(smp)+1,nsmpchunks(smp))
+                     local_cid(smp) = mod(local_cid(smp)+1,nvsmpchunks(smp))
                      cid = cid_offset(smp) + local_cid(smp)
                   enddo
                else
                   do while (chunks(cid)%ncols >=  maxcol_chk(smp)-1)
-                     local_cid(smp) = mod(local_cid(smp)+1,nsmpchunks(smp))
+                     local_cid(smp) = mod(local_cid(smp)+1,nvsmpchunks(smp))
                      cid = cid_offset(smp) + local_cid(smp)
                   enddo
                endif
@@ -4764,7 +4764,7 @@ logical function phys_grid_initialized ()
                     (maxcol_chks(smp) > 0) .and. (twin_alg > 0)) then
 
                   call find_twin(curgcol, smp, &
-                                 proc_smp_mapx, twingcol)
+                                 proc_vsmp_map, twingcol)
 
                   if (twingcol > 0) then
 !
@@ -4793,7 +4793,7 @@ logical function phys_grid_initialized ()
                else
 !
 ! Move on to next chunk (wrap map)
-                  local_cid(smp) = mod(local_cid(smp)+1,nsmpchunks(smp))
+                  local_cid(smp) = mod(local_cid(smp)+1,nvsmpchunks(smp))
 !
                endif
 !
@@ -4819,7 +4819,7 @@ logical function phys_grid_initialized ()
 ! number of chunks in each "SMP node"
 !  (assuming no vertical decomposition)
       nchunks = 0
-      nsmpchunks(:) = 0
+      nvsmpchunks(:) = 0
       do j=firstblock,lastblock
          blksiz = get_block_gcol_cnt_d(j)
          nlchunks = blksiz/pcols
@@ -4828,15 +4828,15 @@ logical function phys_grid_initialized ()
          endif
          nchunks = nchunks + nlchunks
          p = get_block_owner_d(j) 
-         nsmpchunks(p) = nsmpchunks(p) + nlchunks
+         nvsmpchunks(p) = nvsmpchunks(p) + nlchunks
       enddo
 !
 ! Determine chunk id ranges for each SMP
 !
       cid_offset(0) = 1
       local_cid(0) = 0
-      do smp=1,nsmpx-1
-         cid_offset(smp) = cid_offset(smp-1) + nsmpchunks(smp-1)
+      do smp=1,nvsmp-1
+         cid_offset(smp) = cid_offset(smp-1) + nvsmpchunks(smp-1)
          local_cid(smp) = 0
       enddo
 !
@@ -4859,7 +4859,7 @@ logical function phys_grid_initialized ()
       cid = 0
       do jb=firstblock,lastblock
          p = get_block_owner_d(jb)
-         smp = proc_smp_mapx(p)
+         smp = proc_vsmp_map(p)
          blksiz = get_block_gcol_cnt_d(jb)
          call get_block_gcol_d(jb,blksiz,cols_d)
 
@@ -4895,35 +4895,35 @@ logical function phys_grid_initialized ()
 ! Set number of threads available in each "SMP node". 
 !
       do p=0,npes-1
-         nsmpthreads(p) = npthreads(p)
+         nvsmpthreads(p) = npthreads(p)
       enddo
 !
    endif
 !
 ! Assign chunks to processes.
 !
-   call assign_chunks(npthreads, nsmpx, proc_smp_mapx, &
-                      nsmpthreads, nsmpchunks)		      
+   call assign_chunks(npthreads, nvsmp, proc_vsmp_map, &
+                      nvsmpthreads, nvsmpchunks)		      
 !
 ! Clean up
 !
-   deallocate( col_smp_mapx )
-   deallocate( nsmpcolumns  )
-   deallocate( nsmpthreads  )
-   deallocate( nsmpchunks   )
+   deallocate( col_vsmp_map )
+   deallocate( nvsmpcolumns )
+   deallocate( nvsmpthreads )
+   deallocate( nvsmpchunks  )
    deallocate( maxcol_chk   )
    deallocate( maxcol_chks  )
    deallocate( cid_offset   )
    deallocate( local_cid    )
    deallocate( cols_d       )
-  !deallocate( knuhcs ) !do not deallocate as it is being used in RRTMG radiation.F90
+  !deallocate( knuhcs       ) !do not deallocate as it is being used in RRTMG radiation.F90
 
    return
    end subroutine create_chunks
 !
 !========================================================================
 
-   subroutine find_partners(opt, proc_busy_d, nsmpx, proc_smp_mapx)
+   subroutine find_partners(opt, proc_busy_d, nvsmp, proc_vsmp_map)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: Divide processes into pairs, attempting to maximize the
@@ -4943,9 +4943,9 @@ logical function phys_grid_initialized ()
    integer, intent(in)  :: opt           ! chunking option
    logical, intent(in)  :: proc_busy_d(0:npes-1)
                                          ! active/idle dynamics process flags
-   integer, intent(out) :: nsmpx         ! calculated number of virtual 
+   integer, intent(out) :: nvsmp         ! calculated number of virtual 
                                          !  SMP nodes
-   integer, intent(out) :: proc_smp_mapx(0:npes-1)
+   integer, intent(out) :: proc_vsmp_map(0:npes-1)
                                          ! process/virtual smp map
 !---------------------------Local workspace-----------------------------
    integer :: gcol_latlon                ! physics column index (latlon sorted)
@@ -4960,9 +4960,9 @@ logical function phys_grid_initialized ()
    integer :: bcids(plev+1)              ! block column indices
    integer :: jb                         ! block index
    integer :: p, twp                     ! process indices
-   integer :: col_proc_mapx(ngcols)      ! location of columns in 
+   integer :: col_proc_map(ngcols)       ! location of columns in 
                                          !  dynamics decomposition
-   integer :: twin_proc_mapx(ngcols)     ! location of column twins in 
+   integer :: twin_proc_map(ngcols)      ! location of column twins in 
                                          !  dynamics decomposition
    integer :: twin_cnt(0:npes-1)         ! for each process, number of twins 
                                          !  in each of the other processes
@@ -4976,8 +4976,8 @@ logical function phys_grid_initialized ()
 !
 ! Determine process location of column and its twin in dynamics decomposition
 !
-   col_proc_mapx(:) = -1
-   twin_proc_mapx(:) = -1
+   col_proc_map(:) = -1
+   twin_proc_map(:) = -1
 
    error = .false.
    do gcol_latlon=1,ngcols_p
@@ -4996,9 +4996,9 @@ logical function phys_grid_initialized ()
       call get_gcol_block_d(gcol,block_cnt,blockids,bcids)
       do jb=1,block_cnt
          p = get_block_owner_d(blockids(jb)) 
-         if (col_proc_mapx(gcol) .eq. -1) then
-            col_proc_mapx(gcol) = p
-         elseif (col_proc_mapx(gcol) .ne. p) then
+         if (col_proc_map(gcol) .eq. -1) then
+            col_proc_map(gcol) = p
+         elseif (col_proc_map(gcol) .ne. p) then
             error = .true.
          endif
       enddo
@@ -5007,9 +5007,9 @@ logical function phys_grid_initialized ()
       call get_gcol_block_d(twingcol,block_cnt,blockids,bcids)
       do jb=1,block_cnt
          p = get_block_owner_d(blockids(jb)) 
-         if (twin_proc_mapx(gcol) .eq. -1) then
-            twin_proc_mapx(gcol) = p
-         elseif (twin_proc_mapx(gcol) .ne. p) then
+         if (twin_proc_map(gcol) .eq. -1) then
+            twin_proc_map(gcol) = p
+         elseif (twin_proc_map(gcol) .ne. p) then
             error = .true.
          endif
       enddo
@@ -5030,7 +5030,7 @@ logical function phys_grid_initialized ()
 !
    assigned(:) = .false.
    twin_cnt(:) = 0
-   nsmpx = 0
+   nvsmp = 0
    do p=0,npes-1
       if ((.not. assigned(p)) .and. (proc_busy_d(p))) then
 !
@@ -5039,9 +5039,9 @@ logical function phys_grid_initialized ()
 !
          do gcol_latlon=1,ngcols_p
             gcol = latlon_to_dyn_gcol_map(gcol_latlon)
-            if (col_proc_mapx(gcol) .eq. p) then
-               twin_cnt(twin_proc_mapx(gcol)) = &
-                  twin_cnt(twin_proc_mapx(gcol)) + 1
+            if (col_proc_map(gcol) .eq. p) then
+               twin_cnt(twin_proc_map(gcol)) = &
+                  twin_cnt(twin_proc_map(gcol)) + 1
             endif
          enddo
 !
@@ -5064,9 +5064,9 @@ logical function phys_grid_initialized ()
          if (maxpartner .ne. -1) then
             assigned(p) = .true.
             assigned(maxpartner) = .true.
-            proc_smp_mapx(p) = nsmpx
-            proc_smp_mapx(maxpartner) = nsmpx
-            nsmpx = nsmpx + 1
+            proc_vsmp_map(p) = nvsmp
+            proc_vsmp_map(maxpartner) = nvsmp
+            nvsmp = nvsmp + 1
          else
             if (masterproc) then
                write(iulog,*) "PHYS_GRID_INIT error: opt", opt, "specified, ", &
@@ -5084,13 +5084,13 @@ logical function phys_grid_initialized ()
 !
 !========================================================================
 
-   subroutine find_twin(gcol, smp, proc_smp_mapx, twingcol_f)
+   subroutine find_twin(gcol, smp, proc_vsmp_map, twingcol_f)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: Find column that when paired with gcol in a chunk
 !          balances the load. A column is a candidate to be paired with
 !          gcol if it is in the same SMP node as gcol as defined
-!          by proc_smp_mapx.
+!          by proc_vsmp_map.
 ! 
 ! Method: The day/night and north/south hemisphere complement is
 !         tried first. If it is not a candidate or if it has already been
@@ -5107,7 +5107,7 @@ logical function phys_grid_initialized ()
                                          ! seeking a twin for
    integer, intent(in)  :: smp           ! index of SMP node 
                                          ! currently assigned to
-   integer, intent(in)  :: proc_smp_mapx(0:npes-1)
+   integer, intent(in)  :: proc_vsmp_map(0:npes-1)
                                          ! process/virtual smp map
    integer, intent(out) :: twingcol_f
                                          ! global column index for twin
@@ -5239,7 +5239,7 @@ logical function phys_grid_initialized ()
    found = .false.
    call get_gcol_block_d(twingcol,npes,jbtwin,ibtwin)
    twinproc = get_block_owner_d(jbtwin(1))
-   twinsmp  = proc_smp_mapx(twinproc)
+   twinsmp  = proc_vsmp_map(twinproc)
 !
    if ((twinsmp .eq. smp) .and. &
        (knuhcs(twingcol)%chunkid == -1)) then
@@ -5278,7 +5278,7 @@ logical function phys_grid_initialized ()
 !
       call get_gcol_block_d(twingcol,npes,jbtwin,ibtwin)
       twinproc = get_block_owner_d(jbtwin(1))
-      twinsmp  = proc_smp_mapx(twinproc)
+      twinsmp  = proc_vsmp_map(twinproc)
 !
       if ((twinsmp .eq. smp) .and. &
           (knuhcs(twingcol)%chunkid == -1)) then
@@ -5430,8 +5430,8 @@ logical function phys_grid_initialized ()
 !
 !========================================================================
 
-   subroutine assign_chunks(npthreads, nsmpx, proc_smp_mapx, &
-                            nsmpthreads, nsmpchunks)
+   subroutine assign_chunks(npthreads, nvsmp, proc_vsmp_map, &
+                            nvsmpthreads, nvsmpchunks)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: Assign chunks to processes, balancing the number of
@@ -5450,13 +5450,13 @@ logical function phys_grid_initialized ()
 !------------------------------Arguments--------------------------------
    integer, intent(in)  :: npthreads(0:npes-1)
                                          ! number of OpenMP threads per process
-   integer, intent(in)  :: nsmpx         ! virtual smp count
-   integer, intent(in)  :: proc_smp_mapx(0:npes-1)
+   integer, intent(in)  :: nvsmp         ! virtual smp count
+   integer, intent(in)  :: proc_vsmp_map(0:npes-1)
                                          ! process/virtual smp map
-   integer, intent(in)  :: nsmpthreads(0:nsmpx-1)
+   integer, intent(in)  :: nvsmpthreads(0:nvsmp-1)
                                          ! number of OpenMP threads 
                                          ! per virtual SMP
-   integer, intent(in)  :: nsmpchunks(0:nsmpx-1)
+   integer, intent(in)  :: nvsmpchunks(0:nvsmp-1)
                                          ! number of chunks assigned 
                                          ! to a given virtual SMP
 !---------------------------Local workspace-----------------------------
@@ -5468,18 +5468,18 @@ logical function phys_grid_initialized ()
                                          ! for a given vertical column
    integer :: blockids(plev+1)           ! block indices
    integer :: bcids(plev+1)              ! block column indices
-   integer :: ntsks_smpx(0:nsmpx-1)      ! number of processes per virtual SMP
-   integer :: smp_proc_mapx(max_nproc_smpx,0:nsmpx-1)   
+   integer :: ntsks_vsmp(0:nvsmp-1)      ! number of processes per virtual SMP
+   integer :: vsmp_proc_map(max_nproc_vsmp,0:nvsmp-1)   
                                          ! virtual smp to process id map
-   integer :: cid_offset(0:nsmpx)        ! chunk id virtual smp offset
-   integer :: ntmp1_smp(0:nsmpx-1)       ! minimum number of chunks per thread
+   integer :: cid_offset(0:nvsmp)        ! chunk id virtual smp offset
+   integer :: ntmp1_vsmp(0:nvsmp-1)      ! minimum number of chunks per thread
                                          !  in a virtual SMP
-   integer :: ntmp2_smp(0:nsmpx-1)       ! number of extra chunks to be assigned
+   integer :: ntmp2_vsmp(0:nvsmp-1)      ! number of extra chunks to be assigned
                                          !  in a virtual SMP
-   integer :: ntmp3_smp(0:nsmpx-1)       ! number of processes in a virtual
+   integer :: ntmp3_vsmp(0:nvsmp-1)      ! number of processes in a virtual
                                          !  SMP that get more extra chunks
                                          !  than the others
-   integer :: ntmp4_smp(0:nsmpx-1)       ! number of extra chunks per process
+   integer :: ntmp4_vsmp(0:nvsmp-1)      ! number of extra chunks per process
                                          !  in a virtual SMP
    integer :: ntmp1, ntmp2               ! work variables
 !  integer :: npchunks(0:npes-1)         ! number of chunks to be assigned to
@@ -5489,7 +5489,7 @@ logical function phys_grid_initialized ()
    integer :: column_count(0:npes-1)     ! number of columns from current chunk
                                          !  assigned to each process in dynamics
                                          !  decomposition
-   integer :: first_nonfull              ! first process (in smp_proc_mapx 
+   integer :: first_nonfull              ! first process (in vsmp_proc_map 
                                          !  ordering) that has room to be assigned
                                          !  another chunk
    integer :: ndyn_task                  ! number of processes in the dynamics 
@@ -5503,61 +5503,61 @@ logical function phys_grid_initialized ()
 ! Count number of processes per virtual SMP and determine virtual SMP
 ! to process id map
 !
-   ntsks_smpx(:) = 0
-   smp_proc_mapx(:,:) = -1
+   ntsks_vsmp(:) = 0
+   vsmp_proc_map(:,:) = -1
    do p=0,npes-1
-      smp = proc_smp_mapx(p)
-      ntsks_smpx(smp) = ntsks_smpx(smp) + 1
-      smp_proc_mapx(ntsks_smpx(smp),smp) = p
+      smp = proc_vsmp_map(p)
+      ntsks_vsmp(smp) = ntsks_vsmp(smp) + 1
+      vsmp_proc_map(ntsks_vsmp(smp),smp) = p
    enddo
 !
 ! Determine chunk id ranges for each virtual SMP
 !
    cid_offset(0) = 1
-   do smp=1,nsmpx
-      cid_offset(smp) = cid_offset(smp-1) + nsmpchunks(smp-1)
+   do smp=1,nvsmp
+      cid_offset(smp) = cid_offset(smp-1) + nvsmpchunks(smp-1)
    enddo
 !
 ! Determine number of chunks to assign to each process
 !
-   do smp=0,nsmpx-1
+   do smp=0,nvsmp-1
 !
 ! Minimum number of chunks per thread
-      ntmp1_smp(smp) = nsmpchunks(smp)/nsmpthreads(smp)
+      ntmp1_vsmp(smp) = nvsmpchunks(smp)/nvsmpthreads(smp)
 
 ! Number of extra chunks to be assigned
-      ntmp2_smp(smp) = mod(nsmpchunks(smp),nsmpthreads(smp))
+      ntmp2_vsmp(smp) = mod(nvsmpchunks(smp),nvsmpthreads(smp))
 
 ! Number of processes that get more extra chunks than the others
-      ntmp3_smp(smp) = mod(ntmp2_smp(smp),ntsks_smpx(smp))
+      ntmp3_vsmp(smp) = mod(ntmp2_vsmp(smp),ntsks_vsmp(smp))
 
 ! Number of extra chunks per process
-      ntmp4_smp(smp) = ntmp2_smp(smp)/ntsks_smpx(smp)
-      if (ntmp3_smp(smp) > 0) then
-         ntmp4_smp(smp) = ntmp4_smp(smp) + 1
+      ntmp4_vsmp(smp) = ntmp2_vsmp(smp)/ntsks_vsmp(smp)
+      if (ntmp3_vsmp(smp) > 0) then
+         ntmp4_vsmp(smp) = ntmp4_vsmp(smp) + 1
       endif
    enddo
 
    do p=0,npes-1
-      smp = proc_smp_mapx(p)
+      smp = proc_vsmp_map(p)
 
 ! Update number of extra chunks
-      if (ntmp2_smp(smp) > ntmp4_smp(smp)) then
-         ntmp2_smp(smp) = ntmp2_smp(smp) - ntmp4_smp(smp)
+      if (ntmp2_vsmp(smp) > ntmp4_vsmp(smp)) then
+         ntmp2_vsmp(smp) = ntmp2_vsmp(smp) - ntmp4_vsmp(smp)
       else
-         ntmp4_smp(smp) = ntmp2_smp(smp)
-         ntmp2_smp(smp) = 0
-         ntmp3_smp(smp) = 0
+         ntmp4_vsmp(smp) = ntmp2_vsmp(smp)
+         ntmp2_vsmp(smp) = 0
+         ntmp3_vsmp(smp) = 0
       endif
 
 ! Set number of chunks
-      npchunks(p) = ntmp1_smp(smp)*npthreads(p) + ntmp4_smp(smp)
+      npchunks(p) = ntmp1_vsmp(smp)*npthreads(p) + ntmp4_vsmp(smp)
 
 ! Update extra chunk increment
-      if (ntmp3_smp(smp) > 0) then
-         ntmp3_smp(smp) = ntmp3_smp(smp) - 1
-         if (ntmp3_smp(smp) .eq. 0) then
-            ntmp4_smp(smp) = ntmp4_smp(smp) - 1
+      if (ntmp3_vsmp(smp) > 0) then
+         ntmp3_vsmp(smp) = ntmp3_vsmp(smp) - 1
+         if (ntmp3_vsmp(smp) .eq. 0) then
+            ntmp4_vsmp(smp) = ntmp4_vsmp(smp) - 1
          endif
       endif
    enddo
@@ -5575,9 +5575,9 @@ logical function phys_grid_initialized ()
    cur_npchunks(:) = 0
    column_count(:) = 0
 !
-   do smp=0,nsmpx-1
+   do smp=0,nvsmp-1
 !
-!  Initialize pointer to first process (in smp_proc_mapx ordering) that
+!  Initialize pointer to first process (in vsmp_proc_map ordering) that
 !  has room to be assigned another chunk
       first_nonfull = 1
 !
@@ -5618,8 +5618,8 @@ logical function phys_grid_initialized ()
 !  If no processes found that qualify, identify some other process that can
 !  accept a new chunk
          if (ntmp1 == -1) then
-            do i=first_nonfull,ntsks_smpx(smp)
-               p = smp_proc_mapx(i,smp)
+            do i=first_nonfull,ntsks_vsmp(smp)
+               p = vsmp_proc_map(i,smp)
                if (column_count(p) /= -1) then
                   ntmp2 = p
                   exit
@@ -5648,8 +5648,8 @@ logical function phys_grid_initialized ()
          enddo
 !
 !  Update pointer to first nonfull process
-         do i=first_nonfull,ntsks_smpx(smp)
-            p = smp_proc_mapx(i,smp)
+         do i=first_nonfull,ntsks_vsmp(smp)
+            p = vsmp_proc_map(i,smp)
             if (column_count(p) /= -1) then
                first_nonfull = i
                exit

--- a/components/cam/src/physics/cam/phys_grid.F90
+++ b/components/cam/src/physics/cam/phys_grid.F90
@@ -1548,9 +1548,11 @@ logical function phys_grid_initialized ()
                  pcols,                                          &
                  '  .'
               write(iulog,*)                                     &
-                 '  Must compile without -DPPCOLS to enable runtime'
+                 '  Must compile without -pcols option in'
               write(iulog,*)                                     &
-                 '  option. Ignoring and using PCOLS parameter.'
+                 '  CAM_CONFIG_OPTS in env_build.xml to enable'
+              write(iulog,*)                                     &
+                 '  runtime option. Ignoring and using PCOLS parameter.'
            endif
         endif
 #else

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1380,11 +1380,10 @@ subroutine tphysac (ztodt,   cam_in,  &
     use aero_model,         only: aero_model_drydep
     use carma_intr,         only: carma_emission_tend, carma_timestep_tend
     use carma_flags_mod,    only: carma_do_aerosol, carma_do_emission
-    use check_energy,       only: check_energy_chng, &
-                                  check_water, & 
-                                  check_prect, &
-                                  check_qflx 
-    use check_energy,       only: check_tracers_data, check_tracers_init, check_tracers_chng
+    use check_energy,       only: check_energy_chng, check_water, & 
+                                  check_prect, check_qflx , &
+                                  check_tracers_data, check_tracers_init, &
+                                  check_tracers_chng, check_tracers_fini
     use time_manager,       only: get_nstep
     use cam_abortutils,         only: endrun
     use dycore,             only: dycore_is
@@ -1417,12 +1416,10 @@ subroutine tphysac (ztodt,   cam_in,  &
     type(physics_tend ), intent(inout) :: tend
     type(physics_buffer_desc), pointer :: pbuf(:)
 
-
-    type(check_tracers_data):: tracerint             ! tracer mass integrals and cummulative boundary fluxes
-
     !
     !---------------------------Local workspace-----------------------------
     !
+    type(check_tracers_data):: tracerint           ! tracer mass integrals and cummulative boundary fluxes
     type(physics_ptend)     :: ptend               ! indivdual parameterization tendencies
 
     integer  :: nstep                              ! current timestep number
@@ -1837,6 +1834,8 @@ end if ! l_ac_energy_chk
     end do
     water_vap_ac_2d(:ncol) = ftem(:ncol,1)
 
+    call check_tracers_fini(tracerint)
+
 end subroutine tphysac
 
 subroutine tphysbc (ztodt,               &
@@ -1888,11 +1887,10 @@ subroutine tphysbc (ztodt,               &
     use time_manager,    only: is_first_step, get_nstep
     use convect_shallow, only: convect_shallow_tend
     use check_energy,    only: check_energy_chng, check_energy_fix, &
-                               check_qflx,  & 
-                               check_water, & 
-                               check_prect, & 
-                               check_energy_timestep_init
-    use check_energy,    only: check_tracers_data, check_tracers_init, check_tracers_chng
+                               check_qflx, check_water, check_prect, & 
+                               check_energy_timestep_init, &
+                               check_tracers_data, check_tracers_init, &
+                               check_tracers_chng, check_tracers_fini
     use dycore,          only: dycore_is
     use aero_model,      only: aero_model_wetdep
     use carma_intr,      only: carma_wetdep_tend, carma_timestep_tend
@@ -2799,6 +2797,8 @@ end if ! l_rad
     call t_startf('diag_export')
     call diag_export(cam_out)
     call t_stopf('diag_export')
+
+    call check_tracers_fini(tracerint)
 
 end subroutine tphysbc
 

--- a/components/cam/src/physics/cam/ppgrid.F90
+++ b/components/cam/src/physics/cam/ppgrid.F90
@@ -18,6 +18,7 @@ module ppgrid
   public begchunk
   public endchunk
   public pcols
+  public ppcols
   public psubcols
   public pver
   public pverp
@@ -25,12 +26,18 @@ module ppgrid
 
 ! Grid point resolution parameters
 
-   integer pcols      ! number of columns (max)
+#ifdef PPCOLS
+   integer pcols      ! max number of columns per chunk (set at compile-time)
+#endif
+   integer ppcols     ! max number of columns per chunk (default for runtime-set pcols)
    integer psubcols   ! number of sub-columns (max)
    integer pver       ! number of vertical levels
    integer pverp      ! pver + 1
 
+#ifdef PPCOLS
    parameter (pcols     = PCOLS)
+#endif
+   parameter (ppcols    = PCOLS)
    parameter (psubcols  = PSUBCOLS)
    parameter (pver      = PLEV)
    parameter (pverp     = pver + 1  )
@@ -40,5 +47,11 @@ module ppgrid
 !
    integer :: begchunk = 0            ! 
    integer :: endchunk = -1           ! 
+
+#ifndef PPCOLS
+!
+! pcols set in physgrid_init
+   integer :: pcols = PCOLS    ! max number of columns per chunk (set at runtime)
+#endif
 
 end module ppgrid

--- a/components/cam/src/physics/crm/camsrfexch.F90
+++ b/components/cam/src/physics/crm/camsrfexch.F90
@@ -46,62 +46,61 @@ module camsrfexch
      integer  :: lchnk               ! chunk index
      integer  :: ncol                ! number of columns in chunk
 #ifdef MAML
-     real(r8) :: tbot(pcols,num_inst_atm)         ! bot level temperature
-     real(r8) :: zbot(pcols,num_inst_atm)         ! bot level height above surface
-     real(r8) :: ubot(pcols,num_inst_atm)         ! bot level u wind
-     real(r8) :: vbot(pcols,num_inst_atm)         ! bot level v wind
-     real(r8) :: qbot(pcols,pcnst,num_inst_atm)   ! bot level specific humidity
-     real(r8) :: pbot(pcols,num_inst_atm)         ! bot level pressure
-     real(r8) :: rho(pcols,num_inst_atm)          ! bot level density  
-     real(r8) :: netsw(pcols,num_inst_atm)        !    
-     real(r8) :: flwds(pcols,num_inst_atm)        ! 
-     real(r8) :: precsc(pcols,num_inst_atm)       !
-     real(r8) :: precsl(pcols,num_inst_atm)       !
-     real(r8) :: precc(pcols,num_inst_atm)        ! 
-     real(r8) :: precl(pcols,num_inst_atm)        ! 
-     real(r8) :: soll(pcols,num_inst_atm)         ! 
-     real(r8) :: sols(pcols,num_inst_atm)         ! 
-     real(r8) :: solld(pcols,num_inst_atm)        !
-     real(r8) :: solsd(pcols,num_inst_atm)        !
-     real(r8) :: thbot(pcols,num_inst_atm)        !  
+     real(r8), allocatable :: tbot(:,:)     ! bot level temperature
+     real(r8), allocatable :: zbot(:,:)     ! bot level height above surface
+     real(r8), allocatable :: ubot(:,:)     ! bot level u wind
+     real(r8), allocatable :: vbot(:,:)     ! bot level v wind
+     real(r8), allocatable :: qbot(:,:,:)   ! bot level specific humidity
+     real(r8), allocatable :: pbot(:,:)     ! bot level pressure
+     real(r8), allocatable :: rho(:,:)      ! bot level density	
+     real(r8), allocatable :: netsw(:,:)    !	
+     real(r8), allocatable :: flwds(:,:)    ! 
+     real(r8), allocatable :: precsc(:,:)   !
+     real(r8), allocatable :: precsl(:,:)   !
+     real(r8), allocatable :: precc(:,:)    ! 
+     real(r8), allocatable :: precl(:,:)    ! 
+     real(r8), allocatable :: soll(:,:)     ! 
+     real(r8), allocatable :: sols(:,:)     ! 
+     real(r8), allocatable :: solld(:,:)    !
+     real(r8), allocatable :: solsd(:,:)    !
+     real(r8), allocatable :: thbot(:,:)    ! 
 #else
-     real(r8) :: tbot(pcols)         ! bot level temperature
-     real(r8) :: zbot(pcols)         ! bot level height above surface
-     real(r8) :: ubot(pcols)         ! bot level u wind
-     real(r8) :: vbot(pcols)         ! bot level v wind
-     real(r8) :: qbot(pcols,pcnst)   ! bot level specific humidity
-     real(r8) :: pbot(pcols)         ! bot level pressure
-     real(r8) :: rho(pcols)          ! bot level density	
-     real(r8) :: netsw(pcols)        !	
-     real(r8) :: flwds(pcols)        ! 
-     real(r8) :: precsc(pcols)       !
-     real(r8) :: precsl(pcols)       !
-     real(r8) :: precc(pcols)        ! 
-     real(r8) :: precl(pcols)        ! 
-     real(r8) :: soll(pcols)         ! 
-     real(r8) :: sols(pcols)         ! 
-     real(r8) :: solld(pcols)        !
-     real(r8) :: solsd(pcols)        !
-     real(r8) :: thbot(pcols)        !
+     real(r8), allocatable :: tbot(:)       ! bot level temperature
+     real(r8), allocatable :: zbot(:)       ! bot level height above surface
+     real(r8), allocatable :: ubot(:)       ! bot level u wind
+     real(r8), allocatable :: vbot(:)       ! bot level v wind
+     real(r8), allocatable :: qbot(:,:)     ! bot level specific humidity
+     real(r8), allocatable :: pbot(:)       ! bot level pressure
+     real(r8), allocatable :: rho(:)        ! bot level density	
+     real(r8), allocatable :: netsw(:)      !	
+     real(r8), allocatable :: flwds(:)      ! 
+     real(r8), allocatable :: precsc(:)     !
+     real(r8), allocatable :: precsl(:)     !
+     real(r8), allocatable :: precc(:)      ! 
+     real(r8), allocatable :: precl(:)      ! 
+     real(r8), allocatable :: soll(:)       ! 
+     real(r8), allocatable :: sols(:)       ! 
+     real(r8), allocatable :: solld(:)      !
+     real(r8), allocatable :: solsd(:)      !
+     real(r8), allocatable :: thbot(:)      ! 
 #endif
-
-     real(r8) :: co2prog(pcols)      ! prognostic co2
-     real(r8) :: co2diag(pcols)      ! diagnostic co2
-     real(r8) :: psl(pcols)
-     real(r8) :: bcphiwet(pcols)     ! wet deposition of hydrophilic black carbon
-     real(r8) :: bcphidry(pcols)     ! dry deposition of hydrophilic black carbon
-     real(r8) :: bcphodry(pcols)     ! dry deposition of hydrophobic black carbon
-     real(r8) :: ocphiwet(pcols)     ! wet deposition of hydrophilic organic carbon
-     real(r8) :: ocphidry(pcols)     ! dry deposition of hydrophilic organic carbon
-     real(r8) :: ocphodry(pcols)     ! dry deposition of hydrophobic organic carbon
-     real(r8) :: dstwet1(pcols)      ! wet deposition of dust (bin1)
-     real(r8) :: dstdry1(pcols)      ! dry deposition of dust (bin1)
-     real(r8) :: dstwet2(pcols)      ! wet deposition of dust (bin2)
-     real(r8) :: dstdry2(pcols)      ! dry deposition of dust (bin2)
-     real(r8) :: dstwet3(pcols)      ! wet deposition of dust (bin3)
-     real(r8) :: dstdry3(pcols)      ! dry deposition of dust (bin3)
-     real(r8) :: dstwet4(pcols)      ! wet deposition of dust (bin4)
-     real(r8) :: dstdry4(pcols)      ! dry deposition of dust (bin4)
+     real(r8), allocatable :: co2prog(:)    ! prognostic co2
+     real(r8), allocatable :: co2diag(:)    ! diagnostic co2
+     real(r8), allocatable :: psl(:)
+     real(r8), allocatable :: bcphiwet(:)   ! wet deposition of hydrophilic black carbon
+     real(r8), allocatable :: bcphidry(:)   ! dry deposition of hydrophilic black carbon
+     real(r8), allocatable :: bcphodry(:)   ! dry deposition of hydrophobic black carbon
+     real(r8), allocatable :: ocphiwet(:)   ! wet deposition of hydrophilic organic carbon
+     real(r8), allocatable :: ocphidry(:)   ! dry deposition of hydrophilic organic carbon
+     real(r8), allocatable :: ocphodry(:)   ! dry deposition of hydrophobic organic carbon
+     real(r8), allocatable :: dstwet1(:)    ! wet deposition of dust (bin1)
+     real(r8), allocatable :: dstdry1(:)    ! dry deposition of dust (bin1)
+     real(r8), allocatable :: dstwet2(:)    ! wet deposition of dust (bin2)
+     real(r8), allocatable :: dstdry2(:)    ! dry deposition of dust (bin2)
+     real(r8), allocatable :: dstwet3(:)    ! wet deposition of dust (bin3)
+     real(r8), allocatable :: dstdry3(:)    ! dry deposition of dust (bin3)
+     real(r8), allocatable :: dstwet4(:)    ! wet deposition of dust (bin4)
+     real(r8), allocatable :: dstdry4(:)    ! dry deposition of dust (bin4)
   end type cam_out_t 
 
 !---------------------------------------------------------------------------
@@ -113,50 +112,50 @@ module camsrfexch
      integer  :: ncol                    ! number of active columns
 #ifdef MAML
      !modifying the CLM-input vars to reflect the added CRM columns
-     real(r8) :: asdir(pcols,num_inst_atm)            ! albedo: shortwave, direct
-     real(r8) :: asdif(pcols,num_inst_atm)            ! albedo: shortwave, diffuse
-     real(r8) :: aldir(pcols,num_inst_atm)            ! albedo: longwave, direct
-     real(r8) :: aldif(pcols,num_inst_atm)            ! albedo: longwave, diffuse
-     real(r8) :: lwup(pcols,num_inst_atm)             ! longwave up radiative flux
-     real(r8) :: lhf(pcols,num_inst_atm)              ! latent heat flux
-     real(r8) :: shf(pcols,num_inst_atm)              ! sensible heat flux
-     real(r8) :: wsx(pcols,num_inst_atm)              ! surface u-stress (N)
-     real(r8) :: wsy(pcols,num_inst_atm)              ! surface v-stress (N)
-     real(r8) :: snowhland(pcols,num_inst_atm)        ! snow depth (liquid water equivalent) over land 
+     real(r8), allocatable :: asdir(:,:)      ! albedo: shortwave, direct
+     real(r8), allocatable :: asdif(:,:)      ! albedo: shortwave, diffuse
+     real(r8), allocatable :: aldir(:,:)      ! albedo: longwave, direct
+     real(r8), allocatable :: aldif(:,:)      ! albedo: longwave, diffuse
+     real(r8), allocatable :: lwup(:,:)       ! longwave up radiative flux
+     real(r8), allocatable :: lhf(:,:)        ! latent heat flux
+     real(r8), allocatable :: shf(:,:)        ! sensible heat flux
+     real(r8), allocatable :: wsx(:,:)        ! surface u-stress (N)
+     real(r8), allocatable :: wsy(:,:)        ! surface v-stress (N)
+     real(r8), allocatable :: snowhland(:,:)  ! snow depth (liquid water equivalent) over land
      !modifying the CLM-input vars to reflect the added CRM columns
 #else
-     real(r8) :: asdir(pcols)            ! albedo: shortwave, direct
-     real(r8) :: asdif(pcols)            ! albedo: shortwave, diffuse
-     real(r8) :: aldir(pcols)            ! albedo: longwave, direct
-     real(r8) :: aldif(pcols)            ! albedo: longwave, diffuse
-     real(r8) :: lwup(pcols)             ! longwave up radiative flux
-     real(r8) :: lhf(pcols)              ! latent heat flux
-     real(r8) :: shf(pcols)              ! sensible heat flux
-     real(r8) :: wsx(pcols)              ! surface u-stress (N)
-     real(r8) :: wsy(pcols)              ! surface v-stress (N)
-     real(r8) :: snowhland(pcols)        ! snow depth (liquid water equivalent) over land 
+     real(r8), allocatable :: asdir(:)        ! albedo: shortwave, direct
+     real(r8), allocatable :: asdif(:)        ! albedo: shortwave, diffuse
+     real(r8), allocatable :: aldir(:)        ! albedo: longwave, direct
+     real(r8), allocatable :: aldif(:)        ! albedo: longwave, diffuse
+     real(r8), allocatable :: lwup(:)         ! longwave up radiative flux
+     real(r8), allocatable :: lhf(:)          ! latent heat flux
+     real(r8), allocatable :: shf(:)          ! sensible heat flux
+     real(r8), allocatable :: wsx(:)          ! surface u-stress (N)
+     real(r8), allocatable :: wsy(:)          ! surface v-stress (N)
+     real(r8), allocatable :: snowhland(:)    ! snow depth (liquid water equivalent) over land
 #endif
-     real(r8) :: tref(pcols)             ! ref height surface air temp
-     real(r8) :: qref(pcols)             ! ref height specific humidity 
-     real(r8) :: u10(pcols)              ! 10m wind speed
-     real(r8) :: ts(pcols)               ! merged surface temp 
-     real(r8) :: sst(pcols)              ! sea surface temp
-     real(r8) :: snowhice(pcols)         ! snow depth over ice
-     real(r8) :: fco2_lnd(pcols)         ! co2 flux from lnd
-     real(r8) :: fco2_ocn(pcols)         ! co2 flux from ocn
-     real(r8) :: fdms(pcols)             ! dms flux
-     real(r8) :: landfrac(pcols)         ! land area fraction
-     real(r8) :: icefrac(pcols)          ! sea-ice areal fraction
-     real(r8) :: ocnfrac(pcols)          ! ocean areal fraction
-     real(r8), pointer, dimension(:) :: ram1  !aerodynamical resistance (s/m) (pcols)
-     real(r8), pointer, dimension(:) :: fv    !friction velocity (m/s) (pcols)
-     real(r8), pointer, dimension(:) :: soilw !volumetric soil water (m3/m3)
-     real(r8) :: cflx(pcols,pcnst)       ! constituent flux (emissions)
-     real(r8) :: ustar(pcols)            ! atm/ocn saved version of ustar
-     real(r8) :: re(pcols)               ! atm/ocn saved version of re
-     real(r8) :: ssq(pcols)              ! atm/ocn saved version of ssq
-     real(r8), pointer, dimension(:,:) :: depvel ! deposition velocities
-     real(r8), pointer, dimension(:,:) :: dstflx ! dust fluxes
+     real(r8), allocatable :: tref(:)         ! ref height surface air temp
+     real(r8), allocatable :: qref(:)         ! ref height specific humidity 
+     real(r8), allocatable :: u10(:)          ! 10m wind speed
+     real(r8), allocatable :: ts(:)           ! merged surface temp 
+     real(r8), allocatable :: sst(:)          ! sea surface temp
+     real(r8), allocatable :: snowhice(:)     ! snow depth over ice
+     real(r8), allocatable :: fco2_lnd(:)     ! co2 flux from lnd
+     real(r8), allocatable :: fco2_ocn(:)     ! co2 flux from ocn
+     real(r8), allocatable :: fdms(:)         ! dms flux
+     real(r8), allocatable :: landfrac(:)     ! land area fraction
+     real(r8), allocatable :: icefrac(:)      ! sea-ice areal fraction
+     real(r8), allocatable :: ocnfrac(:)      ! ocean areal fraction
+     real(r8), pointer, dimension(:) :: ram1  ! aerodynamical resistance (s/m) (pcols)
+     real(r8), pointer, dimension(:) :: fv    ! friction velocity (m/s) (pcols)
+     real(r8), pointer, dimension(:) :: soilw ! volumetric soil water (m3/m3)
+     real(r8), allocatable :: cflx(:,:)       ! constituent flux (emissions)
+     real(r8), allocatable :: ustar(:)        ! atm/ocn saved version of ustar
+     real(r8), allocatable :: re(:)           ! atm/ocn saved version of re
+     real(r8), allocatable :: ssq(:)          ! atm/ocn saved version of ssq
+     real(r8), pointer, dimension(:,:) :: depvel   ! deposition velocities
+     real(r8), pointer, dimension(:,:) :: dstflx   ! dust fluxes
      real(r8), pointer, dimension(:,:) :: meganflx ! MEGAN fluxes
 
   end type cam_in_t    
@@ -215,6 +214,104 @@ CONTAINS
        nullify(cam_in(c)%meganflx)
     enddo  
     do c = begchunk,endchunk 
+#ifdef MAML
+       allocate (cam_in(c)%asdir(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error asdir')
+
+       allocate (cam_in(c)%asdif(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error asdif')
+
+       allocate (cam_in(c)%aldir(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error aldir')
+
+       allocate (cam_in(c)%aldif(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error aldif')
+
+       allocate (cam_in(c)%lwup(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error lwup')
+
+       allocate (cam_in(c)%lhf(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error lhf')
+
+       allocate (cam_in(c)%shf(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error shf')
+
+       allocate (cam_in(c)%wsx(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsx')
+
+       allocate (cam_in(c)%wsy(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsy')
+
+       allocate (cam_in(c)%snowhland(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error snowhland')
+#else
+       allocate (cam_in(c)%asdir(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error asdir')
+
+       allocate (cam_in(c)%asdif(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error asdif')
+
+       allocate (cam_in(c)%aldir(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error aldir')
+
+       allocate (cam_in(c)%aldif(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error aldif')
+
+       allocate (cam_in(c)%lwup(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error lwup')
+
+       allocate (cam_in(c)%lhf(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error lhf')
+
+       allocate (cam_in(c)%shf(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error shf')
+
+       allocate (cam_in(c)%wsx(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsx')
+
+       allocate (cam_in(c)%wsy(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsy')
+
+       allocate (cam_in(c)%snowhland(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error snowhland')
+#endif
+
+       allocate (cam_in(c)%tref(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error tref')
+
+       allocate (cam_in(c)%qref(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error qref')
+
+       allocate (cam_in(c)%u10(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error u10')
+
+       allocate (cam_in(c)%ts(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ts')
+
+       allocate (cam_in(c)%sst(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error sst')
+
+       allocate (cam_in(c)%snowhice(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error snowhice')
+
+       allocate (cam_in(c)%fco2_lnd(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error fco2_lnd')
+
+       allocate (cam_in(c)%fco2_ocn(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error fco2_ocn')
+
+       allocate (cam_in(c)%fdms(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error fdms')
+
+       allocate (cam_in(c)%landfrac(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error landfrac')
+
+       allocate (cam_in(c)%icefrac(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error icefrac')
+
+       allocate (cam_in(c)%ocnfrac(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ocnfrac')
+
        if (index_x2a_Sl_ram1>0) then
           allocate (cam_in(c)%ram1(pcols), stat=ierror)
           if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ram1')
@@ -227,6 +324,19 @@ CONTAINS
           allocate (cam_in(c)%soilw(pcols), stat=ierror)
           if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error soilw')
        end if
+
+       allocate (cam_in(c)%cflx(pcols,pcnst), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error cflx')
+
+       allocate (cam_in(c)%ustar(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ustar')
+
+       allocate (cam_in(c)%re(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error re')
+
+       allocate (cam_in(c)%ssq(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ssq')
+
        if (index_x2a_Fall_flxdst1>0) then
           ! Assume 4 bins from surface model ....
           allocate (cam_in(c)%dstflx(pcols,4), stat=ierror)
@@ -348,6 +458,169 @@ CONTAINS
       call endrun('ATM2HUB_ALLOC error: allocation error')
     end if
 
+    do c = begchunk,endchunk 
+#ifdef MAML
+       allocate (cam_out(c)%tbot(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error tbot')
+
+       allocate (cam_out(c)%zbot(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error zbot')
+
+       allocate (cam_out(c)%ubot(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ubot')
+
+       allocate (cam_out(c)%vbot(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error vbot')
+
+       allocate (cam_out(c)%qbot(pcols,pcnst,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error qbot')
+
+       allocate (cam_out(c)%pbot(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error pbot')
+
+       allocate (cam_out(c)%rho(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error rho')
+
+       allocate (cam_out(c)%netsw(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error netsw')
+
+       allocate (cam_out(c)%flwds(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error flwds')
+
+       allocate (cam_out(c)%precsc(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precsc')
+
+       allocate (cam_out(c)%precsl(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precsl')
+
+       allocate (cam_out(c)%precc(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precc')
+
+       allocate (cam_out(c)%precl(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precl')
+
+       allocate (cam_out(c)%soll(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error soll')
+
+       allocate (cam_out(c)%sols(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error sols')
+
+       allocate (cam_out(c)%solld(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error solld')
+
+       allocate (cam_out(c)%solsd(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error solsd')
+
+       allocate (cam_out(c)%thbot(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error thbot')
+#else
+       allocate (cam_out(c)%tbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error tbot')
+
+       allocate (cam_out(c)%zbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error zbot')
+
+       allocate (cam_out(c)%ubot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ubot')
+
+       allocate (cam_out(c)%vbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error vbot')
+
+       allocate (cam_out(c)%qbot(pcols,pcnst), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error qbot')
+
+       allocate (cam_out(c)%pbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error pbot')
+
+       allocate (cam_out(c)%rho(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error rho')
+
+       allocate (cam_out(c)%netsw(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error netsw')
+
+       allocate (cam_out(c)%flwds(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error flwds')
+
+       allocate (cam_out(c)%precsc(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precsc')
+
+       allocate (cam_out(c)%precsl(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precsl')
+
+       allocate (cam_out(c)%precc(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precc')
+
+       allocate (cam_out(c)%precl(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error precl')
+
+       allocate (cam_out(c)%soll(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error soll')
+
+       allocate (cam_out(c)%sols(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error sols')
+
+       allocate (cam_out(c)%solld(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error solld')
+
+       allocate (cam_out(c)%solsd(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error solsd')
+
+       allocate (cam_out(c)%thbot(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error thbot')
+#endif
+
+       allocate (cam_out(c)%co2prog(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error co2prog')
+
+       allocate (cam_out(c)%co2diag(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error co2diag')
+
+       allocate (cam_out(c)%psl(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB ALLOC error: allocation error psl')
+
+       allocate (cam_out(c)%bcphiwet(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error bcphiwet')
+
+       allocate (cam_out(c)%bcphidry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error bcphidry')
+
+       allocate (cam_out(c)%bcphodry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error bcphodry')
+
+       allocate (cam_out(c)%ocphiwet(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ocphiwet')
+
+       allocate (cam_out(c)%ocphidry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ocphidry')
+
+       allocate (cam_out(c)%ocphodry(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ocphodry')
+
+       allocate (cam_out(c)%dstwet1(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet1')
+
+       allocate (cam_out(c)%dstdry1(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry1')
+
+       allocate (cam_out(c)%dstwet2(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet2')
+
+       allocate (cam_out(c)%dstdry2(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry2')
+
+       allocate (cam_out(c)%dstwet3(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet3')
+
+       allocate (cam_out(c)%dstdry3(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry3')
+
+       allocate (cam_out(c)%dstwet4(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstwet4')
+
+       allocate (cam_out(c)%dstdry4(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry4')
+    enddo  
+
     do c = begchunk,endchunk
        cam_out(c)%lchnk       = c
        cam_out(c)%ncol        = get_ncols_p(c)
@@ -413,7 +686,46 @@ CONTAINS
 
   subroutine atm2hub_deallocate(cam_out)
     type(cam_out_t), pointer :: cam_out(:)    ! Atmosphere to surface input
+    integer :: c
+
     if(associated(cam_out)) then
+       do c = begchunk,endchunk
+          deallocate(cam_out(c)%tbot)
+          deallocate(cam_out(c)%zbot)
+          deallocate(cam_out(c)%ubot)
+          deallocate(cam_out(c)%vbot)
+          deallocate(cam_out(c)%qbot)
+          deallocate(cam_out(c)%pbot)
+          deallocate(cam_out(c)%rho)
+          deallocate(cam_out(c)%netsw)
+          deallocate(cam_out(c)%flwds)
+          deallocate(cam_out(c)%precsc)
+          deallocate(cam_out(c)%precsl)
+          deallocate(cam_out(c)%precc)
+          deallocate(cam_out(c)%precl)
+          deallocate(cam_out(c)%soll)
+          deallocate(cam_out(c)%sols)
+          deallocate(cam_out(c)%solld)
+          deallocate(cam_out(c)%solsd)
+          deallocate(cam_out(c)%thbot)
+          deallocate(cam_out(c)%co2prog)
+          deallocate(cam_out(c)%co2diag)
+          deallocate(cam_out(c)%bcphiwet)
+          deallocate(cam_out(c)%bcphidry)
+          deallocate(cam_out(c)%bcphodry)
+          deallocate(cam_out(c)%ocphiwet)
+          deallocate(cam_out(c)%ocphidry)
+          deallocate(cam_out(c)%ocphodry)
+          deallocate(cam_out(c)%dstwet1)
+          deallocate(cam_out(c)%dstdry1)
+          deallocate(cam_out(c)%dstwet2)
+          deallocate(cam_out(c)%dstdry2)
+          deallocate(cam_out(c)%dstwet3)
+          deallocate(cam_out(c)%dstdry3)
+          deallocate(cam_out(c)%dstwet4)
+          deallocate(cam_out(c)%dstdry4)
+       enddo  
+
        deallocate(cam_out)
     end if
     nullify(cam_out)
@@ -425,6 +737,29 @@ CONTAINS
 
     if(associated(cam_in)) then
        do c=begchunk,endchunk
+          deallocate(cam_in(c)%asdir)
+          deallocate(cam_in(c)%asdif)
+          deallocate(cam_in(c)%aldir)
+          deallocate(cam_in(c)%aldif)
+          deallocate(cam_in(c)%lwup)
+          deallocate(cam_in(c)%lhf)
+          deallocate(cam_in(c)%shf)
+          deallocate(cam_in(c)%wsx)
+          deallocate(cam_in(c)%wsy)
+          deallocate(cam_in(c)%tref)
+          deallocate(cam_in(c)%qref)
+          deallocate(cam_in(c)%u10)
+          deallocate(cam_in(c)%ts)
+          deallocate(cam_in(c)%sst)
+          deallocate(cam_in(c)%snowhland)
+          deallocate(cam_in(c)%snowhice)
+          deallocate(cam_in(c)%fco2_lnd)
+          deallocate(cam_in(c)%fco2_ocn)
+          deallocate(cam_in(c)%fdms)
+          deallocate(cam_in(c)%landfrac)
+          deallocate(cam_in(c)%icefrac)
+          deallocate(cam_in(c)%ocnfrac)
+
           if(associated(cam_in(c)%ram1)) then
              deallocate(cam_in(c)%ram1)
              nullify(cam_in(c)%ram1)
@@ -437,6 +772,12 @@ CONTAINS
              deallocate(cam_in(c)%soilw)
              nullify(cam_in(c)%soilw)
           end if
+
+          deallocate(cam_in(c)%cflx)
+          deallocate(cam_in(c)%ustar)
+          deallocate(cam_in(c)%re)
+          deallocate(cam_in(c)%ssq)
+
           if(associated(cam_in(c)%dstflx)) then
              deallocate(cam_in(c)%dstflx)
              nullify(cam_in(c)%dstflx)

--- a/components/cam/src/physics/crm/physpkg.F90
+++ b/components/cam/src/physics/crm/physpkg.F90
@@ -1421,11 +1421,10 @@ subroutine tphysac (ztodt,   cam_in,  &
     use aero_model,         only: aero_model_drydep
     use carma_intr,         only: carma_emission_tend, carma_timestep_tend
     use carma_flags_mod,    only: carma_do_aerosol, carma_do_emission
-    use check_energy,       only: check_energy_chng, &
-                                  check_water, & 
-                                  check_prect, &
-                                  check_qflx 
-    use check_energy,       only: check_tracers_data, check_tracers_init, check_tracers_chng
+    use check_energy,       only: check_energy_chng, check_water, & 
+                                  check_prect, check_qflx , &
+                                  check_tracers_data, check_tracers_init, &
+                                  check_tracers_chng, check_tracers_fini
     use time_manager,       only: get_nstep
     use cam_abortutils,         only: endrun
     use dycore,             only: dycore_is
@@ -1913,6 +1912,8 @@ end if ! l_ac_energy_chk
     end do
     water_vap_ac_2d(:ncol) = ftem(:ncol,1)
 
+    call check_tracers_fini(tracerint)
+
 end subroutine tphysac
 
 subroutine tphysbc (ztodt,               &
@@ -1964,11 +1965,10 @@ subroutine tphysbc (ztodt,               &
     use time_manager,    only: is_first_step, get_nstep
     use convect_shallow, only: convect_shallow_tend
     use check_energy,    only: check_energy_chng, check_energy_fix, &
-                               check_qflx,  & 
-                               check_water, & 
-                               check_prect, & 
-                               check_energy_timestep_init
-    use check_energy,    only: check_tracers_data, check_tracers_init, check_tracers_chng
+                               check_qflx, check_water, check_prect, & 
+                               check_energy_timestep_init, &
+                               check_tracers_data, check_tracers_init, &
+                               check_tracers_chng, check_tracers_fini
     use dycore,          only: dycore_is
     use aero_model,      only: aero_model_wetdep
     use carma_intr,      only: carma_wetdep_tend, carma_timestep_tend
@@ -3110,6 +3110,8 @@ end if ! l_rad
     call t_startf('diag_export')
     call diag_export(cam_out)
     call t_stopf('diag_export')
+
+    call check_tracers_fini(tracerint)
 
 end subroutine tphysbc
 


### PR DESCRIPTION
In the earlier 2000's, empirical experiments indicated that setting
the first dimension of the chunk data structure (pcols) at
compile-time allowed the compiler to generate more
performance-efficient code, and this motivated this design choice in
CAM. However, CAM/EAM has evolved significantly since then, and, for
example, physics_types now uses psetcols to define this first
dimension, and the compiler never sees a compile-time parameter. So
the compile-time setting of pcols may no longer serve a useful
purpose. Extensive experiments indicate that there is still a
small performance advantage from setting pcols at compile-time, but
also that being able to set pcols at runtime greatly simplifies the
process of optimizing over the pcols parameter.

Here pcols is implemented as a runtime option, currently specified
via the user_nl_cam namelist variable phys_chnk_fdim. phys_chnk_fdim
must be at least as large as 1, but there is no specified upper
bound. The current compile-time value of the CPP variable PCOLS is used
to define the default value for phys_chunk_fdim (and pcols). PCOLS is
now represented in EAM as the parameter ppcols, but is only referenced
in defining the default for phys_chunk_fdim.

To restore the compile-time setting of pcols, and also to specify
a pcols value of PCOLS, add -pcols to CAM_CONFIG_OPTS in
env_build.xml . For example, to specify 32 as the compile-time value
of pcols, add '-pcols 32' . This allows the recovery of any lost
performance from the runtime-specification of pcols.

Note that this is the first part of a two-part introduction of runtime
pcols. This PR sets the runtime pcols during the call to
read_namelist. To calculate a better default than the compile-time
PCOLS CPP variable requires that it be calculated in phys_grid_init,
and this requires changing the order of certain steps in the
initialization of EAM. The current PR, however, stands on its own, and
is acceptable even if the second part PR is never submitted.

[BFB]

This addresses some aspects of Issue #3538 , but not all. The issue
will be resolved by a second runtime pcols PR. If we decide
not to submit this follow-on PR, the issue will also be closed.