### PR TITLE
Update Cori modules for mpich and netcdf/hdf

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -63,7 +63,7 @@
     <MPILIBS>mpt</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
-    <SAVE_TIMING_DIR_PROJECTS>e3sm,acme,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
+    <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-haswell</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
@@ -119,7 +119,6 @@
         <command name="rm">craype-sandybridge</command>
         <command name="rm">craype-ivybridge</command>
         <command name="rm">craype</command>
-        <command name="rm">craype-hugepages2M</command>
         <command name="rm">papi</command>
         <command name="rm">cmake</command>
         <command name="rm">cray-petsc</command>
@@ -137,7 +136,7 @@
       </modules>
 
       <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
       </modules>
 
       <modules compiler="intel">
@@ -149,9 +148,9 @@
       <modules compiler="gnu">
         <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.2.0</command>
+        <command name="load">gcc/8.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.02.1</command>
+        <command name="load">cray-libsci/19.06.1</command>
       </modules>
 
       <modules>
@@ -166,14 +165,14 @@
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
         <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
 
       <modules>
@@ -212,7 +211,7 @@
     <MPILIBS>mpt,impi</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
-    <SAVE_TIMING_DIR_PROJECTS>e3sm,e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
+    <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-knl</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
@@ -250,7 +249,6 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="rm">craype</command>
-        <command name="rm">craype-hugepages2M</command>
         <command name="rm">craype-mic-knl</command>
         <command name="rm">craype-haswell</command>
         <command name="rm">PrgEnv-intel</command>
@@ -285,11 +283,11 @@
       </modules>
 
       <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
       </modules>
 
       <modules mpilib="impi">
-        <command name="swap">cray-mpich impi/2019.up3</command>
+        <command name="swap">cray-mpich impi/2020</command>
       </modules>
 
       <modules compiler="intel">
@@ -301,15 +299,15 @@
       <modules compiler="intel19">
         <command name="load">PrgEnv-intel/6.0.5</command>
         <command name="rm">intel</command>
-        <command name="load">intel/19.0.3.199</command>
+        <command name="load">intel/19.1.1.217</command>
       </modules>
 
       <modules compiler="gnu">
         <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.2.0</command>
+        <command name="load">gcc/8.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.02.1</command>
+        <command name="load">cray-libsci/19.06.1</command>
       </modules>
 
       <modules>
@@ -324,14 +322,14 @@
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
         <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
 
       <modules>


### PR DESCRIPTION
Update Cori (cori-knl and cori-haswell) modules to be current defaults for the following:

cray-mpich/7.7.6 -> cray-mpich/7.7.10
cray-netcdf-hdf5parallel/4.6.1.3 -> cray-netcdf-hdf5parallel/4.6.3.2
cray-hdf5-parallel/1.10.2.0 -> cray-hdf5-parallel/1.10.5.2
cray-parallel-netcdf/1.8.1.4 -> cray-parallel-netcdf/1.11.1.1

gcc/8.2.0 -> gcc/8.3.0
cray-libsci/19.02.1 -> cray-libsci/19.06.1
impi/2019.up3 -> impi/2020

And only affecting builds with intel19 compiler, use the latest version of intel19
which is intel/19.1.1.217.

Not updating craype or the default intel compiler (still intel18).
Those will be in another PR.

[bfb]