### PR TITLE
Add limiters on RRTMGP cloud and aerosol optics

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -4274,12 +4274,6 @@ File path for RRTMGP longwave gaseous absorption coefficients file.
 File path for RRTMGP shortwave gaseous absorption coefficients file.
 </entry>
 
-<entry id="rrtmgp_clip_temperatures" type="logical"
-       category="radiation" group="radiation_nl" valid_values="">
-Flag to determine whether temperatures should be clipped or limited when
-outside the range of the absorption coefficient look-up table values.
-</entry>
-
 <!-- Rayleigh Friction Parameterization -->
 
 <entry id="rayk0" type="integer" category="rayleigh_friction"

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -4280,12 +4280,6 @@ Flag to determine whether temperatures should be clipped or limited when
 outside the range of the absorption coefficient look-up table values.
 </entry>
 
-<entry id="rrtmgp_clip_optics" type="logical"
-       category="radiation" group="radiation_nl" valid_values="">
-Flag to determine whether optical properties should be clipped or limited when
-outside the expected range.
-</entry>
-
 <!-- Rayleigh Friction Parameterization -->
 
 <entry id="rayk0" type="integer" category="rayleigh_friction"

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -4274,6 +4274,18 @@ File path for RRTMGP longwave gaseous absorption coefficients file.
 File path for RRTMGP shortwave gaseous absorption coefficients file.
 </entry>
 
+<entry id="rrtmgp_clip_temperatures" type="logical"
+       category="radiation" group="radiation_nl" valid_values="">
+Flag to determine whether temperatures should be clipped or limited when
+outside the range of the absorption coefficient look-up table values.
+</entry>
+
+<entry id="rrtmgp_clip_optics" type="logical"
+       category="radiation" group="radiation_nl" valid_values="">
+Flag to determine whether optical properties should be clipped or limited when
+outside the expected range.
+</entry>
+
 <!-- Rayleigh Friction Parameterization -->
 
 <entry id="rayk0" type="integer" category="rayleigh_friction"

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1353,12 +1353,12 @@ contains
 
                ! Check (and possibly clip) values before passing to RRTMGP driver
                if (rrtmgp_clip_optics) then
-                  call clip_values(cld_tau_gpt_sw,  0._r8, huge(cld_tau_gpt_sw), trim(subname) // ' cld_tau_gpt_sw', warn=.true.)
-                  call clip_values(cld_ssa_gpt_sw,  0._r8,                1._r8, trim(subname) // ' cld_ssa_gpt_sw', warn=.true.)
-                  call clip_values(cld_asm_gpt_sw, -1._r8,                1._r8, trim(subname) // ' cld_asm_gpt_sw', warn=.true.)
-                  call clip_values(aer_tau_bnd_sw,  0._r8, huge(aer_tau_bnd_sw), trim(subname) // ' aer_tau_bnd_sw', warn=.true.)
-                  call clip_values(aer_ssa_bnd_sw,  0._r8,                1._r8, trim(subname) // ' aer_ssa_bnd_sw', warn=.true.)
-                  call clip_values(aer_asm_bnd_sw, -1._r8,                1._r8, trim(subname) // ' aer_asm_bnd_sw', warn=.true.)
+                  call clip_values(cld_tau_gpt_sw,  0._r8, huge(cld_tau_gpt_sw), trim(subname) // ' cld_tau_gpt_sw', warn=.true., tolerance=1e-10_r8)
+                  call clip_values(cld_ssa_gpt_sw,  0._r8,                1._r8, trim(subname) // ' cld_ssa_gpt_sw', warn=.true., tolerance=1e-10_r8)
+                  call clip_values(cld_asm_gpt_sw, -1._r8,                1._r8, trim(subname) // ' cld_asm_gpt_sw', warn=.true., tolerance=1e-10_r8)
+                  call clip_values(aer_tau_bnd_sw,  0._r8, huge(aer_tau_bnd_sw), trim(subname) // ' aer_tau_bnd_sw', warn=.true., tolerance=1e-10_r8)
+                  call clip_values(aer_ssa_bnd_sw,  0._r8,                1._r8, trim(subname) // ' aer_ssa_bnd_sw', warn=.true., tolerance=1e-10_r8)
+                  call clip_values(aer_asm_bnd_sw, -1._r8,                1._r8, trim(subname) // ' aer_asm_bnd_sw', warn=.true., tolerance=1e-10_r8)
                end if
 
                ! Call the shortwave radiation driver
@@ -1438,8 +1438,8 @@ contains
 
                ! Check (and possibly clip) values before passing to RRTMGP driver
                if (rrtmgp_clip_optics) then
-                  call clip_values(cld_tau_gpt_lw,  0._r8, huge(cld_tau_gpt_lw), trim(subname) // ' cld_tau_gpt_lw', warn=.true.)
-                  call clip_values(aer_tau_bnd_lw,  0._r8, huge(aer_tau_bnd_lw), trim(subname) // ' aer_tau_bnd_lw', warn=.true.)
+                  call clip_values(cld_tau_gpt_lw,  0._r8, huge(cld_tau_gpt_lw), trim(subname) // ' cld_tau_gpt_lw', warn=.true., tolerance=1e-10_r8)
+                  call clip_values(aer_tau_bnd_lw,  0._r8, huge(aer_tau_bnd_lw), trim(subname) // ' aer_tau_bnd_lw', warn=.true., tolerance=1e-10_r8)
                end if
 
                ! Call the longwave radiation driver to calculate fluxes and heating rates

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -2266,7 +2266,7 @@ contains
 
       ! Check values and clip if necessary (albedos should not be larger than 1)
       ! NOTE: this does actually issue warnings for albedos larger than 1, but this
-      ! was never checked for RRTMG, so albedos will probably be slight different
+      ! was never checked for RRTMG, so albedos will probably be slightly different
       ! than the implementation in RRTMG!
       call clip_values(albedo_dir, 0._r8, 1._r8, varname='albedo_dir')
       call clip_values(albedo_dif, 0._r8, 1._r8, varname='albedo_dif')

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1258,14 +1258,14 @@ contains
          ! rrtmgp_clip_temperatures)
          if (rrtmgp_clip_temperatures .or. aqua_planet) then
             call t_startf('rrtmgp_check_temperatures')
-            call clip_values( &
+            call handle_error(clip_values( &
                tmid(1:ncol,1:nlev_rad), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
                trim(subname) // ' tmid' &
-            )
-            call clip_values( &
+            ), fatal=.false.)
+            call handle_error(clip_values( &
                tint(1:ncol,1:nlev_rad+1), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
                trim(subname) // ' tint' &
-            )
+            ), fatal=.false.)
             call t_stopf('rrtmgp_check_temperatures')
          end if
       end if
@@ -1347,12 +1347,12 @@ contains
                end if
 
                ! Check (and possibly clip) values before passing to RRTMGP driver
-               call clip_values(cld_tau_gpt_sw,  0._r8, huge(cld_tau_gpt_sw), trim(subname) // ' cld_tau_gpt_sw', tolerance=1e-10_r8)
-               call clip_values(cld_ssa_gpt_sw,  0._r8,                1._r8, trim(subname) // ' cld_ssa_gpt_sw', tolerance=1e-10_r8)
-               call clip_values(cld_asm_gpt_sw, -1._r8,                1._r8, trim(subname) // ' cld_asm_gpt_sw', tolerance=1e-10_r8)
-               call clip_values(aer_tau_bnd_sw,  0._r8, huge(aer_tau_bnd_sw), trim(subname) // ' aer_tau_bnd_sw', tolerance=1e-10_r8)
-               call clip_values(aer_ssa_bnd_sw,  0._r8,                1._r8, trim(subname) // ' aer_ssa_bnd_sw', tolerance=1e-10_r8)
-               call clip_values(aer_asm_bnd_sw, -1._r8,                1._r8, trim(subname) // ' aer_asm_bnd_sw', tolerance=1e-10_r8)
+               call handle_error(clip_values(cld_tau_gpt_sw,  0._r8, huge(cld_tau_gpt_sw), trim(subname) // ' cld_tau_gpt_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(cld_ssa_gpt_sw,  0._r8,                1._r8, trim(subname) // ' cld_ssa_gpt_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(cld_asm_gpt_sw, -1._r8,                1._r8, trim(subname) // ' cld_asm_gpt_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_tau_bnd_sw,  0._r8, huge(aer_tau_bnd_sw), trim(subname) // ' aer_tau_bnd_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_ssa_bnd_sw,  0._r8,                1._r8, trim(subname) // ' aer_ssa_bnd_sw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_asm_bnd_sw, -1._r8,                1._r8, trim(subname) // ' aer_asm_bnd_sw', tolerance=1e-10_r8))
 
                ! Call the shortwave radiation driver
                call radiation_driver_sw( &
@@ -1430,8 +1430,8 @@ contains
                end if
 
                ! Check (and possibly clip) values before passing to RRTMGP driver
-               call clip_values(cld_tau_gpt_lw,  0._r8, huge(cld_tau_gpt_lw), trim(subname) // ': cld_tau_gpt_lw', tolerance=1e-10_r8)
-               call clip_values(aer_tau_bnd_lw,  0._r8, huge(aer_tau_bnd_lw), trim(subname) // ': aer_tau_bnd_lw', tolerance=1e-10_r8)
+               call handle_error(clip_values(cld_tau_gpt_lw,  0._r8, huge(cld_tau_gpt_lw), trim(subname) // ': cld_tau_gpt_lw', tolerance=1e-10_r8))
+               call handle_error(clip_values(aer_tau_bnd_lw,  0._r8, huge(aer_tau_bnd_lw), trim(subname) // ': aer_tau_bnd_lw', tolerance=1e-10_r8))
 
                ! Call the longwave radiation driver to calculate fluxes and heating rates
                call radiation_driver_lw( &
@@ -1528,7 +1528,7 @@ contains
       use mo_fluxes_byband, only: ty_fluxes_byband
       use mo_optical_props, only: ty_optical_props_2str
       use mo_gas_concentrations, only: ty_gas_concs
-      use radiation_utils, only: calculate_heating_rate, clip_values
+      use radiation_utils, only: calculate_heating_rate
       use cam_optics, only: get_cloud_optics_sw, sample_cloud_optics_sw, &
                             compress_optics_sw, set_aerosol_optics_sw
 
@@ -1822,7 +1822,7 @@ contains
       use mo_optical_props, only: ty_optical_props_1scl
       use mo_gas_concentrations, only: ty_gas_concs
       use radiation_state, only: set_rad_state
-      use radiation_utils, only: calculate_heating_rate, clip_values
+      use radiation_utils, only: calculate_heating_rate
 
       ! Inputs
       integer, intent(in) :: ncol
@@ -2260,8 +2260,12 @@ contains
       ! NOTE: this does actually issue warnings for albedos larger than 1, but this
       ! was never checked for RRTMG, so albedos will probably be slightly different
       ! than the implementation in RRTMG!
-      call clip_values(albedo_dir, 0._r8, 1._r8, trim(subname) // ': albedo_dir', tolerance=0.01_r8)
-      call clip_values(albedo_dif, 0._r8, 1._r8, trim(subname) // ': albedo_dif', tolerance=0.01_r8)
+      call handle_error(clip_values( &
+         albedo_dir, 0._r8, 1._r8, trim(subname) // ': albedo_dir', tolerance=0.01_r8) &
+      )
+      call handle_error(clip_values( &
+         albedo_dif, 0._r8, 1._r8, trim(subname) // ': albedo_dif', tolerance=0.01_r8) &
+      )
 
    end subroutine set_albedo
 

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -178,21 +178,14 @@ contains
    ! warn flag is set *and* the values fall outside the expected range plus the
    ! tolerance. In other words, no warning is issued when clipping values
    ! outside the valid range plus/minus the tolerance.
-   subroutine clip_values_1d(x, min_x, max_x, varname, warn, tolerance)
+   subroutine clip_values_1d(x, min_x, max_x, varname, tolerance)
       real(r8), intent(inout) :: x(:)
       real(r8), intent(in) :: min_x
       real(r8), intent(in) :: max_x
-      character(len=*), intent(in), optional :: varname
-      logical, intent(in), optional :: warn
+      character(len=*), intent(in) :: varname
       real(r8), intent(in), optional :: tolerance
-
-      logical :: warn_local
       real(r8) :: tolerance_local
 
-      warn_local = .false.
-      if (present(warn)) then
-         warn_local = warn
-      end if
       tolerance_local = 0._r8
       if (present(tolerance)) then
          tolerance_local = tolerance
@@ -200,18 +193,12 @@ contains
 
       ! look for values less than threshold
       if (any(x < min_x)) then
-         ! Raise warning? Only if we specify to, and only if outside tolerance
-         if (warn_local .and. any(x < (min_x - tolerance_local))) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x < (min_x - tolerance_local)), ' values are below threshold for variable ', &
-                        trim(varname), '; min = ', minval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x < (min_x - tolerance_local)), ' values are below threshold; min = ', minval(x)
-            end if
+         ! Raise warning? Only if outside tolerance
+         if (any(x < (min_x - tolerance_local))) then
+            print *, 'WARNING: ' // trim(varname) // ': ', &
+                     count(x < (min_x - tolerance_local)), ' values below threshold ', &
+                     '; min = ', minval(x)
          end if
-
          ! Clip values
          where (x < min_x)
             x = min_x
@@ -220,18 +207,12 @@ contains
 
       ! Look for values greater than threshold
       if (any(x > max_x)) then
-         ! Raise warning? Only if we specify to, and only if outside tolerance
-         if (warn_local .and. any(x > (max_x + tolerance_local))) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x > (max_x + tolerance_local)), ' values are above threshold for variable ', &
-                        trim(varname), '; max = ', maxval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x > (max_x + tolerance_local)), ' values are above threshold; max = ', maxval(x)
-            end if
+         ! Raise warning? Only if outside tolerance
+         if (any(x > (max_x + tolerance_local))) then
+            print *, 'WARNING: ' // trim(varname) // ': ', &
+                     count(x > (max_x + tolerance_local)), ' values above threshold ', &
+                     '; max = ', maxval(x)
          end if
-
          ! Clip values
          where (x > max_x)
             x = max_x
@@ -239,21 +220,14 @@ contains
       end if
    end subroutine clip_values_1d
    !-------------------------------------------------------------------------------
-   subroutine clip_values_2d(x, min_x, max_x, varname, warn, tolerance)
+   subroutine clip_values_2d(x, min_x, max_x, varname, tolerance)
       real(r8), intent(inout) :: x(:,:)
       real(r8), intent(in) :: min_x
       real(r8), intent(in) :: max_x
-      character(len=*), intent(in), optional :: varname
-      logical, intent(in), optional :: warn
+      character(len=*), intent(in) :: varname
       real(r8), intent(in), optional :: tolerance
-
-      logical :: warn_local
       real(r8) :: tolerance_local
 
-      warn_local = .false.
-      if (present(warn)) then
-         warn_local = warn
-      end if
       tolerance_local = 0._r8
       if (present(tolerance)) then
          tolerance_local = tolerance
@@ -261,18 +235,12 @@ contains
 
       ! look for values less than threshold
       if (any(x < min_x)) then
-         ! Raise warning? Only if we specify to, and only if outside tolerance
-         if (warn_local .and. any(x < (min_x - tolerance_local))) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x < (min_x - tolerance_local)), ' values are below threshold for variable ', &
-                        trim(varname), '; min = ', minval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x < (min_x - tolerance_local)), ' values are below threshold; min = ', minval(x)
-            end if
+         ! Raise warning? Only if outside tolerance
+         if (any(x < (min_x - tolerance_local))) then
+            print *, 'WARNING: ' // trim(varname) // ': ', &
+                     count(x < (min_x - tolerance_local)), ' values below threshold ', &
+                     '; min = ', minval(x)
          end if
-
          ! Clip values
          where (x < min_x)
             x = min_x
@@ -281,18 +249,12 @@ contains
 
       ! Look for values greater than threshold
       if (any(x > max_x)) then
-         ! Raise warning? Only if we specify to, and only if outside tolerance
-         if (warn_local .and. any(x > (max_x + tolerance_local))) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x > (max_x + tolerance_local)), ' values are above threshold for variable ', &
-                        trim(varname), '; max = ', maxval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x > (max_x + tolerance_local)), ' values are above threshold; max = ', maxval(x)
-            end if
+         ! Raise warning? Only if outside tolerance
+         if (any(x > (max_x + tolerance_local))) then
+            print *, 'WARNING: ' // trim(varname) // ': ', &
+                     count(x > (max_x + tolerance_local)), ' values above threshold ', &
+                     '; max = ', maxval(x)
          end if
-
          ! Clip values
          where (x > max_x)
             x = max_x
@@ -300,21 +262,14 @@ contains
       end if
    end subroutine clip_values_2d
    !-------------------------------------------------------------------------------
-   subroutine clip_values_3d(x, min_x, max_x, varname, warn, tolerance)
+   subroutine clip_values_3d(x, min_x, max_x, varname, tolerance)
       real(r8), intent(inout) :: x(:,:,:)
       real(r8), intent(in) :: min_x
       real(r8), intent(in) :: max_x
-      character(len=*), intent(in), optional :: varname
-      logical, intent(in), optional :: warn
+      character(len=*), intent(in) :: varname
       real(r8), intent(in), optional :: tolerance
-
-      logical :: warn_local
       real(r8) :: tolerance_local
 
-      warn_local = .false.
-      if (present(warn)) then
-         warn_local = warn
-      end if
       tolerance_local = 0._r8
       if (present(tolerance)) then
          tolerance_local = tolerance
@@ -322,18 +277,12 @@ contains
 
       ! look for values less than threshold
       if (any(x < min_x)) then
-         ! Raise warning? Only if we specify to, and only if outside tolerance
-         if (warn_local .and. any(x < (min_x - tolerance_local))) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x < (min_x - tolerance_local)), ' values are below threshold for variable ', &
-                        trim(varname), '; min = ', minval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x < (min_x - tolerance_local)), ' values are below threshold; min = ', minval(x)
-            end if
+         ! Raise warning? Only if outside tolerance
+         if (any(x < (min_x - tolerance_local))) then
+            print *, 'WARNING: ' // trim(varname) // ': ', &
+                     count(x < (min_x - tolerance_local)), ' values below threshold ', &
+                     '; min = ', minval(x)
          end if
-
          ! Clip values
          where (x < min_x)
             x = min_x
@@ -342,18 +291,12 @@ contains
 
       ! Look for values greater than threshold
       if (any(x > max_x)) then
-         ! Raise warning? Only if we specify to, and only if outside tolerance
-         if (warn_local .and. any(x > (max_x + tolerance_local))) then
-            if (present(varname)) then
-               print *, module_name // ' warning: ', &
-                        count(x > (max_x + tolerance_local)), ' values are above threshold for variable ', &
-                        trim(varname), '; max = ', maxval(x)
-            else
-               print *, module_name // ' warning: ', &
-                        count(x > (max_x + tolerance_local)), ' values are above threshold; max = ', maxval(x)
-            end if
+         ! Raise warning? Only if outside tolerance
+         if (any(x > (max_x + tolerance_local))) then
+            print *, 'WARNING: ' // trim(varname) // ': ', &
+                     count(x > (max_x + tolerance_local)), ' values above threshold ', &
+                     '; max = ', maxval(x)
          end if
-
          ! Clip values
          where (x > max_x)
             x = max_x

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -23,6 +23,9 @@ module radiation_utils
       module procedure clip_values_1d, clip_values_2d, clip_values_3d
    end interface clip_values
 
+   ! Max length for character strings
+   integer, parameter :: max_char_len = 512
+
    ! Name of this module for error messages
    character(len=*), parameter :: module_name = 'radiation_utils'
 
@@ -170,22 +173,23 @@ contains
 
    ! Routines to clip array values if they are outside of an expected range,
    ! defined by min_x and max_x. Allow passing a varname argument, which will be
-   ! appended to warning message, a warn logical flag that determines whether or
-   ! not to issue a warning when values are clipped, and tolerance argument that
-   ! sets a minimum threshold tolerance above which a warning will be issued.
-   ! That is, these routines will *always* clip values outside expected range
-   ! and allow the simulation to continue, but a warning will be issued if the
-   ! warn flag is set *and* the values fall outside the expected range plus the
-   ! tolerance. In other words, no warning is issued when clipping values
-   ! outside the valid range plus/minus the tolerance.
-   subroutine clip_values_1d(x, min_x, max_x, varname, tolerance)
+   ! appended to warning message and tolerance argument that sets a maximum
+   ! tolerance above which a warning or error will be thrown. That is, these 
+   ! routines will *always* clip values outside expected range and allow the 
+   ! simulation to continue, but a warning will be issued if the values fall 
+   ! outside the expected range plus the tolerance. In other words, no warning 
+   ! is issued when clipping values outside the valid range plus/minus the 
+   ! tolerance.
+   function clip_values_1d(x, min_x, max_x, varname, tolerance) result(error_message)
       real(r8), intent(inout) :: x(:)
       real(r8), intent(in) :: min_x
       real(r8), intent(in) :: max_x
       character(len=*), intent(in) :: varname
       real(r8), intent(in), optional :: tolerance
       real(r8) :: tolerance_local
+      character(max_char_len) :: error_message
 
+      error_message = ''
       tolerance_local = 0._r8
       if (present(tolerance)) then
          tolerance_local = tolerance
@@ -195,7 +199,7 @@ contains
       if (any(x < min_x)) then
          ! Raise warning? Only if outside tolerance
          if (any(x < (min_x - tolerance_local))) then
-            print *, 'WARNING: ' // trim(varname) // ': ', &
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
                      count(x < (min_x - tolerance_local)), ' values below threshold ', &
                      '; min = ', minval(x)
          end if
@@ -209,7 +213,7 @@ contains
       if (any(x > max_x)) then
          ! Raise warning? Only if outside tolerance
          if (any(x > (max_x + tolerance_local))) then
-            print *, 'WARNING: ' // trim(varname) // ': ', &
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
                      count(x > (max_x + tolerance_local)), ' values above threshold ', &
                      '; max = ', maxval(x)
          end if
@@ -218,16 +222,18 @@ contains
             x = max_x
          end where
       end if
-   end subroutine clip_values_1d
+   end function clip_values_1d
    !-------------------------------------------------------------------------------
-   subroutine clip_values_2d(x, min_x, max_x, varname, tolerance)
+   function clip_values_2d(x, min_x, max_x, varname, tolerance) result(error_message)
       real(r8), intent(inout) :: x(:,:)
       real(r8), intent(in) :: min_x
       real(r8), intent(in) :: max_x
       character(len=*), intent(in) :: varname
       real(r8), intent(in), optional :: tolerance
       real(r8) :: tolerance_local
+      character(max_char_len) :: error_message
 
+      error_message = ''
       tolerance_local = 0._r8
       if (present(tolerance)) then
          tolerance_local = tolerance
@@ -237,7 +243,7 @@ contains
       if (any(x < min_x)) then
          ! Raise warning? Only if outside tolerance
          if (any(x < (min_x - tolerance_local))) then
-            print *, 'WARNING: ' // trim(varname) // ': ', &
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
                      count(x < (min_x - tolerance_local)), ' values below threshold ', &
                      '; min = ', minval(x)
          end if
@@ -251,7 +257,7 @@ contains
       if (any(x > max_x)) then
          ! Raise warning? Only if outside tolerance
          if (any(x > (max_x + tolerance_local))) then
-            print *, 'WARNING: ' // trim(varname) // ': ', &
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
                      count(x > (max_x + tolerance_local)), ' values above threshold ', &
                      '; max = ', maxval(x)
          end if
@@ -260,16 +266,18 @@ contains
             x = max_x
          end where
       end if
-   end subroutine clip_values_2d
+   end function clip_values_2d
    !-------------------------------------------------------------------------------
-   subroutine clip_values_3d(x, min_x, max_x, varname, tolerance)
+   function clip_values_3d(x, min_x, max_x, varname, tolerance) result(error_message)
       real(r8), intent(inout) :: x(:,:,:)
       real(r8), intent(in) :: min_x
       real(r8), intent(in) :: max_x
       character(len=*), intent(in) :: varname
       real(r8), intent(in), optional :: tolerance
       real(r8) :: tolerance_local
+      character(max_char_len) :: error_message
 
+      error_message = ''
       tolerance_local = 0._r8
       if (present(tolerance)) then
          tolerance_local = tolerance
@@ -279,7 +287,7 @@ contains
       if (any(x < min_x)) then
          ! Raise warning? Only if outside tolerance
          if (any(x < (min_x - tolerance_local))) then
-            print *, 'WARNING: ' // trim(varname) // ': ', &
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
                      count(x < (min_x - tolerance_local)), ' values below threshold ', &
                      '; min = ', minval(x)
          end if
@@ -293,7 +301,7 @@ contains
       if (any(x > max_x)) then
          ! Raise warning? Only if outside tolerance
          if (any(x > (max_x + tolerance_local))) then
-            print *, 'WARNING: ' // trim(varname) // ': ', &
+            write(error_message,*) 'WARNING: ' // trim(varname) // ': ', &
                      count(x > (max_x + tolerance_local)), ' values above threshold ', &
                      '; max = ', maxval(x)
          end if
@@ -302,32 +310,32 @@ contains
             x = max_x
          end where
       end if
-   end subroutine clip_values_3d
+   end function clip_values_3d
    !-------------------------------------------------------------------------------
-   subroutine handle_error(error_message, stop_on_error)
+   subroutine handle_error(error_message, fatal)
       use cam_abortutils, only: endrun
       character(len=*), intent(in) :: error_message
-      logical, intent(in), optional :: stop_on_error
-      logical :: stop_on_error_local = .true.
+      logical, intent(in), optional :: fatal
+      logical :: fatal_local = .true.
 
       ! Allow passing of an optional flag to not stop the run if an error is
       ! encountered. This allows this subroutine to be used when inquiring if a
       ! variable exists without failing.
-      if (present(stop_on_error)) then
-         stop_on_error_local = stop_on_error
+      if (present(fatal)) then
+         fatal_local = fatal
       else
-         stop_on_error_local = .true.
+         fatal_local = .true.
       end if
 
       ! If we encounter an error, fail if we require success. Otherwise do
       ! nothing and return silently.
       if (len(trim(error_message)) > 0) then
-         if (stop_on_error_local) then
-            call endrun(module_name // ': ' // error_message)
+         if (fatal_local) then
+            call endrun(trim(error_message))
+         else
+            print *, trim(error_message)
          end if
       end if
    end subroutine handle_error
-
    !----------------------------------------------------------------------------
-
 end module radiation_utils


### PR DESCRIPTION
Add limiters on RRTMGP cloud and aerosol optical properties. This prevents the internal RRTMGP sanity checks from aborting the run with these quantities go *slightly* outside the expected range. The behavior is now to always clip these values, but to throw an error and abort when they fall outside the expected range plus/minus an accepted tolerance. This fixes an error that arose in some coupled runs where single scattering albedo would go slightly above 1.0, possibly due to floating point precision issues.

[BFB]