### PR TITLE
Adding E3SM support for 3DGM namelist options to maint-1.2

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -600,6 +600,10 @@ add_default($nl, 'config_Leith_visc2_max');
 ###################################################
 
 add_default($nl, 'config_use_standardGM');
+add_default($nl, 'config_gm_lat_variable_c2');
+add_default($nl, 'config_gm_kappa_lat_depth_variable');
+add_default($nl, 'config_gm_min_stratification_ratio');
+add_default($nl, 'config_gm_min_phase_speed');
 add_default($nl, 'config_use_Redi_surface_layer_tapering');
 add_default($nl, 'config_Redi_surface_layer_tapering_extent');
 add_default($nl, 'config_use_Redi_bottom_layer_tapering');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -141,6 +141,10 @@ add_default($nl, 'config_Leith_visc2_max');
 ###################################################
 
 add_default($nl, 'config_use_standardGM');
+add_default($nl, 'config_gm_lat_variable_c2');
+add_default($nl, 'config_gm_kappa_lat_depth_variable');
+add_default($nl, 'config_gm_min_stratification_ratio');
+add_default($nl, 'config_gm_min_phase_speed');
 add_default($nl, 'config_use_Redi_surface_layer_tapering');
 add_default($nl, 'config_Redi_surface_layer_tapering_extent');
 add_default($nl, 'config_use_Redi_bottom_layer_tapering');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -165,6 +165,10 @@
 <config_use_standardGM ocn_grid="oRRS15to5">.false.</config_use_standardGM>
 <config_use_standardGM ocn_grid="oARRM60to10">.false.</config_use_standardGM>
 <config_use_standardGM ocn_grid="oARRM60to6">.false.</config_use_standardGM>
+<config_gm_lat_variable_c2>.true.</config_gm_lat_variable_c2>
+<config_gm_kappa_lat_depth_variable>.true.</config_gm_kappa_lat_depth_variable>
+<config_gm_min_stratification_ratio>0.1</config_gm_min_stratification_ratio>
+<config_gm_min_phase_speed>0.1</config_gm_min_phase_speed>
 <config_use_Redi_surface_layer_tapering>.false.</config_use_Redi_surface_layer_tapering>
 <config_Redi_surface_layer_tapering_extent>0.0</config_Redi_surface_layer_tapering_extent>
 <config_use_Redi_bottom_layer_tapering>.false.</config_use_Redi_bottom_layer_tapering>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -561,6 +561,38 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_gm_lat_variable_c2" type="logical"
+	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+If true, spatially variable phase speed is used Following Ferrari et al (2010)
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gm_kappa_lat_depth_variable" type="logical"
+	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+If true, spatitally and deph varying Bolus Kappa is used, following Danabasoglu et al (2007)
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gm_min_stratification_ratio" type="real"
+	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+minimum value for N2/Nmax2 ratio
+
+Valid values: small positive reals
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gm_min_phase_speed" type="real"
+	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
+minimum allowed phase speed for spatially variable computation
+
+Valid values: small positive reals
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_use_Redi_surface_layer_tapering" type="logical"
 	category="mesoscale_eddy_parameterization" group="mesoscale_eddy_parameterization">
 If true, the Redi K33 vertical mixing is limited in and just below the ocean boundary layer.

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -830,6 +830,12 @@ def buildnml(case, caseroot, compname):
         if not ocn_grid.startswith("oRRS1"):
             lines.append('    <var name="normalGMBolusVelocity"/>')
             lines.append('    <var name="vertGMBolusVelocityTop"/>')
+            lines.append('    <var name="GMBolusVelocityZonal"/>')
+            lines.append('    <var name="GMBolusVelocityMeridional"/>')
+            lines.append('    <var name="kappaGM3D"/>')
+            lines.append('    <var name="cGMphaseSpeed"/>')
+            lines.append('    <var name="velocityZonalTimesTemperature_GM"/>')
+            lines.append('    <var name="velocityMeridionalTimesTemperature_GM"/>')
 
         lines.append('    <var_struct name="tracersSurfaceFlux"/>')
         lines.append('    <var name="penetrativeTemperatureFlux"/>')


### PR DESCRIPTION
This adds changes from #3057 for E3SM support of 3DGM namelist options to the maint-1.2 branch. As part of this, 3DGM is turned on by default (as it was in #3057), so it is not BFB. The changes were copied directly from the E3SM (non mpas-source) file changes in #3057 (hash 
9fc9d6f).

[non-BFB]
[NML]