### PR TITLE
For Cori, update module version of the craype module and force static linking

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -154,7 +154,7 @@
       </modules>
 
       <modules>
-        <command name="swap">craype craype/2.5.18</command>
+        <command name="swap">craype craype/2.6.2</command>
         <command name="rm">pmi</command>
         <command name="load">pmi/5.0.14</command>
         <command name="rm">craype-mic-knl</command>
@@ -196,6 +196,7 @@
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+      <env name="CRAYPE_LINK_TYPE">static</env>
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="FORT_BUFFERED">yes</env>
@@ -311,7 +312,7 @@
       </modules>
 
       <modules>
-        <command name="swap">craype craype/2.5.18</command>
+        <command name="swap">craype craype/2.6.2</command>
         <command name="rm">pmi</command>
         <command name="load">pmi/5.0.14</command>
         <command name="rm">craype-haswell</command>
@@ -355,6 +356,7 @@
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+      <env name="CRAYPE_LINK_TYPE">static</env>      
     </environment_variables>
 
     <environment_variables mpilib="mpt">


### PR DESCRIPTION
For Cori, update module version of the craype module and force static linking.

With this newer version of craype (2.6.2), the new default is to use dynamic linking.
E3SM still works with dynamic linking, but the performance was degraded.
Forcing static linking seems to resolve this (by setting an environment variable
CRAYPE_LINK_TYPE to static).

[bfb]