### PR TITLE
Update LANL IC machine files to fix small issues

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -2307,7 +2307,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <append>$ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -lz </append>
   </SLIBS>
   <CXX_LIBS>
-    <base> -lstdc++ -lmpi_cxx </base>
+    <base> -lstdc++</base>
   </CXX_LIBS>
   <NETCDF_C_PATH>$ENV{NETCDF_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_PATH}</NETCDF_FORTRAN_PATH>
@@ -2376,7 +2376,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <append>-mkl -lpthread</append>
   </SLIBS>
   <CXX_LIBS>
-    <base>-lstdc++ -lmpi_cxx</base>
+    <base>-lstdc++</base>
   </CXX_LIBS>
   <NETCDF_C_PATH>$ENV{NETCDF_ROOT}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_ROOT}</NETCDF_FORTRAN_PATH>

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -2352,7 +2352,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <append>$ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm -lz </append>
   </SLIBS>
   <CXX_LIBS>
-    <base> -lstdc++ -lmpi_cxx </base>
+    <base> -lstdc++ </base>
   </CXX_LIBS>
   <NETCDF_C_PATH>$ENV{NETCDF_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_PATH}</NETCDF_FORTRAN_PATH>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -2327,7 +2327,7 @@
     <NODENAME_REGEX>gr-fe.*.lanl.gov</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>impi,mvapich,openmpi</MPILIBS>
+    <MPILIBS>openmpi,impi,mvapich</MPILIBS>
     <PROJECT>climateacme</PROJECT>
     <CIME_OUTPUT_ROOT>/lustre/scratch4/turquoise/$ENV{USER}/E3SM/scratch</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data</DIN_LOC_ROOT>
@@ -2406,8 +2406,8 @@
     <DESC>LANL Linux Cluster, 36 pes/node, batch system slurm</DESC>
     <NODENAME_REGEX>ba-fe.*.lanl.gov</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>gnu,intel</COMPILERS>
-    <MPILIBS>impi,mvapich,openmpi</MPILIBS>
+    <COMPILERS>intel,gnu</COMPILERS>
+    <MPILIBS>openmpi,impi,mvapich</MPILIBS>
     <PROJECT>climateacme</PROJECT>
     <CIME_OUTPUT_ROOT>/lustre/scratch4/turquoise/$ENV{USER}/E3SM/scratch</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/E3SM/input_data</DIN_LOC_ROOT>


### PR DESCRIPTION
This PR fixes two small issues on the LANL IC machines badger and grizzly. Specifically, it:
* removes -lmpi_cxx from c++ libraries for the gnu compiler on both machines
* removes -lmpi_cxx from c++ libraries for the intel compiler on badger
* reorders the options for compiler on badger, so intel is default
* reorders the options for mpi on both machines, so openmpi is default
No tests are run on either of these platforms, so there should be no impact on E3SM tested configurations.

[BFB]