### PR TITLE
For cori-knl, update the version of default intel compiler to be version 19

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1176,7 +1176,7 @@ flags should be captured within MPAS CMake files.
   <MPICC MPILIB="impi"> mpiicc </MPICC>
   <MPICXX MPILIB="impi"> mpiicpc </MPICXX>
   <MPIFC MPILIB="impi"> mpiifort </MPIFC>
-  <!-- When using Intel MPI, can't use the Cray compiler wrappers. Must also set environment variables in config_machines.xml -->
+  <!-- When using Intel MPI, can't use the Cray compiler wrappers. -->
   <MPI_LIB_NAME MPILIB="impi">impi</MPI_LIB_NAME>
   <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
   <SCC> icc </SCC>
@@ -1186,65 +1186,6 @@ flags should be captured within MPAS CMake files.
     <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
     <append> -mkl -lpthread </append>
   </SLIBS>
-</compiler>
-
-<compiler MACH="cori-knl" COMPILER="intel19">
-  <CFLAGS>
-    <base> -O2 -fp-model precise -std=gnu99 </base>
-    <append compile_threaded="TRUE"> -qopenmp </append>
-    <append DEBUG="FALSE"> -O2 -debug minimal </append>
-    <append DEBUG="TRUE"> -O0 -g </append>
-  </CFLAGS>
-  <CXXFLAGS>
-    <base> -std=c++11 -fp-model consistent </base>
-    <append compile_threaded="TRUE"> -qopenmp </append>
-    <append DEBUG="TRUE"> -O0 -g </append>
-    <append DEBUG="FALSE"> -O2 </append>
-  </CXXFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <CPPDEFS>
-    <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL</append>
-  </CPPDEFS>
-  <CXX_LDFLAGS>
-    <base> -cxxlib </base>
-  </CXX_LDFLAGS>
-  <CXX_LINKER>FORTRAN</CXX_LINKER>
-  <FC_AUTO_R8>
-    <base> -r8 </base>
-  </FC_AUTO_R8>
-  <FFLAGS>
-    <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml </base>
-    <append compile_threaded="TRUE"> -qopenmp </append>
-    <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
-    <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
-    <append MPILIB="impi"> -xMIC-AVX512 </append>
-  </FFLAGS>
-  <FIXEDFLAGS>
-    <base> -fixed -132 </base>
-  </FIXEDFLAGS>
-  <FREEFLAGS>
-    <base> -free </base>
-  </FREEFLAGS>
-  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
-  <LDFLAGS>
-    <append compile_threaded="TRUE"> -qopenmp </append>
-  </LDFLAGS>
-  <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
-  <SCC> icc </SCC>
-  <SCXX> icpc </SCXX>
-  <SFC> ifort </SFC>
-  <MPICC MPILIB="impi"> mpiicc </MPICC>
-  <MPICXX MPILIB="impi"> mpiicpc </MPICXX>
-  <MPIFC MPILIB="impi"> mpiifort </MPIFC>
-  <!-- When using Intel MPI, can't use the Cray compiler wrappers. Must also set environment variables in config_machines.xml -->
-  <MPI_LIB_NAME MPILIB="impi">impi</MPI_LIB_NAME>
-  <SLIBS>
-    <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
-    <append> -mkl -lpthread </append>
-  </SLIBS>
-  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
 <compiler MACH="eastwind" COMPILER="pgi">

--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -1146,6 +1146,12 @@ flags should be captured within MPAS CMake files.
     <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml </base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
   </FFLAGS>
+  <CXXFLAGS>
+    <base> -std=c++11 -fp-model consistent </base>
+    <append compile_threaded="TRUE"> -qopenmp </append>
+    <append DEBUG="TRUE"> -O0 -g </append>
+    <append DEBUG="FALSE"> -O2 </append>
+  </CXXFLAGS>    
   <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
   <SCC> icc </SCC>
   <SCXX> icpc </SCXX>
@@ -1173,6 +1179,12 @@ flags should be captured within MPAS CMake files.
     <append MPILIB="impi"> -xMIC-AVX512 </append>
     <append> -DHAVE_ERF_INTRINSICS </append>
   </FFLAGS>
+  <CXXFLAGS>
+    <base> -std=c++11 -fp-model consistent </base>
+    <append compile_threaded="TRUE"> -qopenmp </append>
+    <append DEBUG="TRUE"> -O0 -g </append>
+    <append DEBUG="FALSE"> -O2 </append>
+  </CXXFLAGS>  
   <MPICC MPILIB="impi"> mpiicc </MPICC>
   <MPICXX MPILIB="impi"> mpiicpc </MPICXX>
   <MPIFC MPILIB="impi"> mpiifort </MPIFC>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -208,7 +208,7 @@
     <DESC>Cori. XC40 Cray system at NERSC. KNL partition. os is CNL, 68 pes/node (for now only use 64), batch system is SLURM</DESC>
     <NODENAME_REGEX>cori</NODENAME_REGEX>
     <OS>CNL</OS>
-    <COMPILERS>intel,gnu,intel19</COMPILERS>
+    <COMPILERS>intel,gnu</COMPILERS>
     <MPILIBS>mpt,impi</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
@@ -294,13 +294,7 @@
       <modules compiler="intel">
         <command name="load">PrgEnv-intel/6.0.5</command>
         <command name="rm">intel</command>
-        <command name="load">intel/18.0.1.163</command>
-      </modules>
-
-      <modules compiler="intel19">
-        <command name="load">PrgEnv-intel/6.0.5</command>
-        <command name="rm">intel</command>
-        <command name="load">intel/19.1.1.217</command>
+        <command name="load">intel/19.0.3.199</command>
       </modules>
 
       <modules compiler="gnu">
@@ -363,10 +357,7 @@
       <env name="MPICH_GNI_DYNAMIC_CONN">disabled</env>
     </environment_variables>
     <environment_variables compiler="intel">
-      <env name="FORT_BUFFERED">yes</env>
-      <env name="MPICH_MEMORY_REPORT">1</env>
-    </environment_variables>
-    <environment_variables compiler="intel19">
+      <!--env name="FORT_BUFFERED">yes</env-->
       <env name="MPICH_MEMORY_REPORT">1</env>
     </environment_variables>
   </machine>


### PR DESCRIPTION
For cori-knl, update the version of default intel compiler to be version 19.
The specific version is intel/19.0.3.199 which is the current machine default.
We also remove the "intel19" compiler option from cori-knl to simplify.

Also adjust the C++ flags to use -fp-model consistent for cori-knl and cori-haswell just to be the same as the current fortran flags, however, we intend on revisiting the compiler flag settings as a whole.

This change is NOT bit-for-bit, but all the tests are passing otherwise.