### PR TITLE
ocean: alter 3D GM

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -549,10 +549,12 @@ add_default($nl, 'config_Leith_visc2_max');
 
 add_default($nl, 'config_use_Redi');
 add_default($nl, 'config_Redi_kappa');
+add_default($nl, 'config_Redi_set_RediKappa_to_GMKappa');
 add_default($nl, 'config_Redi_maximum_slope');
 add_default($nl, 'config_Redi_closure');
 add_default($nl, 'config_Redi_use_slope_taper');
 add_default($nl, 'config_Redi_use_surface_taper');
+add_default($nl, 'config_Redi_use_N2_based_taper');
 add_default($nl, 'config_Redi_N2_limit_term1');
 
 ############################################
@@ -562,6 +564,12 @@ add_default($nl, 'config_Redi_N2_limit_term1');
 add_default($nl, 'config_use_GM');
 add_default($nl, 'config_GM_kappa');
 add_default($nl, 'config_GM_closure');
+add_default($nl, 'config_GM_baroclinic_mode');
+add_default($nl, 'config_GM_visbeck_alpha');
+add_default($nl, 'config_GM_visbeck_min_depth');
+add_default($nl, 'config_GM_visbeck_max_depth');
+add_default($nl, 'config_GM_visbeck_min_kappa');
+add_default($nl, 'config_GM_visbeck_max_kappa');
 add_default($nl, 'config_GM_min_stratification_ratio');
 add_default($nl, 'config_GM_constant_gravWaveSpeed');
 

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -90,10 +90,12 @@ add_default($nl, 'config_Leith_visc2_max');
 
 add_default($nl, 'config_use_Redi');
 add_default($nl, 'config_Redi_kappa');
+add_default($nl, 'config_Redi_set_RediKappa_to_GMKappa');
 add_default($nl, 'config_Redi_maximum_slope');
 add_default($nl, 'config_Redi_closure');
 add_default($nl, 'config_Redi_use_slope_taper');
 add_default($nl, 'config_Redi_use_surface_taper');
+add_default($nl, 'config_Redi_use_N2_based_taper');
 add_default($nl, 'config_Redi_N2_limit_term1');
 
 ############################################
@@ -103,6 +105,12 @@ add_default($nl, 'config_Redi_N2_limit_term1');
 add_default($nl, 'config_use_GM');
 add_default($nl, 'config_GM_kappa');
 add_default($nl, 'config_GM_closure');
+add_default($nl, 'config_GM_baroclinic_mode');
+add_default($nl, 'config_GM_visbeck_alpha');
+add_default($nl, 'config_GM_visbeck_min_depth');
+add_default($nl, 'config_GM_visbeck_max_depth');
+add_default($nl, 'config_GM_visbeck_min_kappa');
+add_default($nl, 'config_GM_visbeck_max_kappa');
 add_default($nl, 'config_GM_min_stratification_ratio');
 add_default($nl, 'config_GM_constant_gravWaveSpeed');
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -114,13 +114,22 @@
 <config_Leith_visc2_max>2.5e3</config_Leith_visc2_max>
 
 <!-- Redi_isopycnal_mixing -->
-<config_use_Redi>.false.</config_use_Redi>
-<config_Redi_kappa>1800.0</config_Redi_kappa>
-<config_Redi_kappa ocn_forcing="datm_forced_restoring">600.0</config_Redi_kappa>
-<config_Redi_maximum_slope>0.3</config_Redi_maximum_slope>
+<config_use_Redi>.true.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS30to10">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS30to10v3">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS30to10wLI">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS30to10v3wLI">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS18to6">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS18to6v3">.false.</config_use_Redi>
+<config_use_Redi ocn_grid="oRRS15to5">.false.</config_use_Redi>
+<config_Redi_kappa>400.0</config_Redi_kappa>
+<config_Redi_kappa ocn_forcing="datm_forced_restoring">400.0</config_Redi_kappa>
+<config_Redi_set_RediKappa_to_GMKappa>.false.</config_Redi_set_RediKappa_to_GMKappa>
+<config_Redi_maximum_slope>0.01</config_Redi_maximum_slope>
 <config_Redi_closure>'constant'</config_Redi_closure>
 <config_Redi_use_slope_taper>.true.</config_Redi_use_slope_taper>
 <config_Redi_use_surface_taper>.true.</config_Redi_use_surface_taper>
+<config_Redi_use_N2_based_taper>.true.</config_Redi_use_N2_based_taper>
 <config_Redi_N2_limit_term1>.true.</config_Redi_N2_limit_term1>
 
 <!-- GM_eddy_parameterization -->
@@ -134,7 +143,13 @@
 <config_use_GM ocn_grid="oRRS15to5">.false.</config_use_GM>
 <config_GM_kappa>1800.0</config_GM_kappa>
 <config_GM_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_kappa>
-<config_GM_closure>'N2_dependent'</config_GM_closure>
+<config_GM_closure>'visbeck'</config_GM_closure>
+<config_GM_baroclinic_mode>3.0</config_GM_baroclinic_mode>
+<config_GM_visbeck_alpha>0.005</config_GM_visbeck_alpha>
+<config_GM_visbeck_min_depth>50.0</config_GM_visbeck_min_depth>
+<config_GM_visbeck_max_depth>1000.0</config_GM_visbeck_max_depth>
+<config_GM_visbeck_min_kappa>300.0</config_GM_visbeck_min_kappa>
+<config_GM_visbeck_max_kappa>1200.0</config_GM_visbeck_max_kappa>
 <config_GM_min_stratification_ratio>0.1</config_GM_min_stratification_ratio>
 <config_GM_constant_gravWaveSpeed>0.3</config_GM_constant_gravWaveSpeed>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -114,7 +114,7 @@
 <config_Leith_visc2_max>2.5e3</config_Leith_visc2_max>
 
 <!-- Redi_isopycnal_mixing -->
-<config_use_Redi>.true.</config_use_Redi>
+<config_use_Redi>.false.</config_use_Redi>
 <config_use_Redi ocn_grid="oRRS30to10">.false.</config_use_Redi>
 <config_use_Redi ocn_grid="oRRS30to10v3">.false.</config_use_Redi>
 <config_use_Redi ocn_grid="oRRS30to10wLI">.false.</config_use_Redi>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -145,7 +145,7 @@
 <config_GM_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_kappa>
 <config_GM_closure>'visbeck'</config_GM_closure>
 <config_GM_baroclinic_mode>3.0</config_GM_baroclinic_mode>
-<config_GM_visbeck_alpha>0.005</config_GM_visbeck_alpha>
+<config_GM_visbeck_alpha>0.13</config_GM_visbeck_alpha>
 <config_GM_visbeck_min_depth>50.0</config_GM_visbeck_min_depth>
 <config_GM_visbeck_max_depth>1000.0</config_GM_visbeck_max_depth>
 <config_GM_visbeck_min_kappa>300.0</config_GM_visbeck_min_kappa>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -375,6 +375,14 @@ Valid values: Positive real numbers
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_Redi_set_RediKappa_to_GMKappa" type="logical"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+If true RediKappa is forced to be equal to gmBolusKappa
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_Redi_maximum_slope" type="real"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
 value of maximum allowed isopycnal slope from Danabasoglu et al 2008 equation (2)
@@ -402,6 +410,14 @@ Default: Defined in namelist_defaults.xml
 <entry id="config_Redi_use_surface_taper" type="logical"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
 If true, Redi slope is tapered near sfc based on Large et al 1997
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_use_N2_based_taper" type="logical"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+If true apply the N2 limiting of Danabasoglu and Marshall 2007
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
@@ -436,9 +452,57 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_GM_closure" type="char*1024"
 	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
-Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006).
+Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006). 'visbeck' implements a horizontally varying diffusivity of Visbeck et al 1997
 
-Valid values: 'N2_dependent', 'constant'
+Valid values: 'N2_dependent', 'constant', 'visbeck'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_baroclinic_mode" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+baroclinic wave mode chosen for the ferrari et al 2010 calculation
+
+Valid values: small positive numbers
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_visbeck_alpha" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+scaling factor on the visbeck diffusivity parameterization
+
+Valid values: small positive numbers
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_visbeck_min_depth" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+minimum depth for calculation of vertical average
+
+Valid values: values between zero and bottom depth
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_visbeck_max_depth" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+minimum depth for calculation of vertical average
+
+Valid values: values between zero and bottom depth
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_visbeck_min_kappa" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+minimum value of bolus diffusivity for visbeck scheme
+
+Valid values: values around 100s
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_visbeck_max_kappa" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+minimum value of bolus diffusivity for visbeck scheme
+
+Valid values: values around 100s
 Default: Defined in namelist_defaults.xml
 </entry>
 


### PR DESCRIPTION
See https://github.com/MPAS-Dev/MPAS-Model/pull/537

Adds horizontal variability of GM bolus kappa value of Visbeck et al 1997. The Danabasoglu and Marshall 2007 modifications still function independently of this option. The scheme contains options for min and max bolus value and more work is needed to properly pair this scheme with the ramp function for variable resolution.

[non-BFB]
[NML]