### PR TITLE
Implement runtime calculation of pcols in EAM

### DIFF
--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -4185,6 +4185,7 @@ if ($cfg->get('dyn') =~ /se/) {
     }
 
     my @vars = qw(se_nsplit hypervis_order phys_loadbalance
+                  phys_chnk_fdim_max phys_chnk_fdim_mult
                   hypervis_subcycle hypervis_subcycle_q hypervis_subcycle_tom
                   statefreq se_partmethod se_topology se_ftype
                   integration nu nu_div nu_p nu_q nu_s nu_top

--- a/components/cam/bld/config_files/definition.xml
+++ b/components/cam/bld/config_files/definition.xml
@@ -210,8 +210,7 @@ Maximum number of columns in a chunk (physics data structure).
 Maximum number of sub-columns in a column (physics data structure).
 </entry>
 <entry id="ppcols" value="FALSE">
-Whether pcols is a compile time parameter. Otherwise it is the default value
-for the runtime parameter phys_chnk_fdim.
+Whether pcols is a compile time parameter.
 </entry>
 <entry id="cam_exe" value="cam">
 Name of CAM executable.
@@ -318,6 +317,13 @@ in Perl's $OSNAME variable.  This parameter allows the user to override
 that setting to allow for cross-compilation, and for instances where the
 $OSNAME value is too generic.  For example, currently on both cray-xt and
 bluegene systems $OSNAME has the value "linux".
+</entry>
+<entry id="mach" value="">
+System name for which CAM is being built.  The default value is the first
+part (delimited by '.') of the name returned by Perl's Sys:Hostname hostname
+routine.  This parameter allows the user to override that setting to allow
+for system-specific namelist defaults when the hostname does not return the
+desired name.
 </entry>
 <entry id="use_MMF" valid_values="0,1" value="0">
 Switch to enable or disable MMF/super-parameterization: 0=off, 1=on.

--- a/components/cam/bld/configure
+++ b/components/cam/bld/configure
@@ -94,6 +94,7 @@ use FindBin qw($Bin);
 use lib "$Bin/perl5lib";
 use Build::ChemPreprocess qw(chem_preprocess chem_number_adv);
 use File::Copy;
+use Sys::Hostname;
 
 #-----------------------------------------------------------------------------------------------
 
@@ -143,6 +144,7 @@ OPTIONS
                         dlatxdlon for fv grids (dlat and dlon are the grid cell size
 			in degrees for latitude and longitude respectively); nexnp for
                         se grids.
+     -mach <name>       Name of target system, for setting system-specific namelist defaults
      -max_n_rad_cnst <n> Maximum number of constituents that are either radiatively
                         active, or in any single diagnostic list for the radiation.    
      -microphys <name>  Specify the microphysics option [mg1 | mg1.5 | mg2 | rk].
@@ -379,6 +381,7 @@ GetOptions(
     "ldflags=s"                 => \$opts{'ldflags'},
     "linker=s"                  => \$opts{'linker'},
     "lnd=s"                     => \$opts{'lnd'},
+    "mach=s"                    => \$opts{'mach'},
     "max_n_rad_cnst=s"          => \$opts{'max_n_rad_cnst'},
     "microphys=s"               => \$opts{'microphys'},
     "mpi_inc=s"                 => \$opts{'mpi_inc'},
@@ -689,6 +692,16 @@ if ($print>=2) { print "Configuration cache file: $config_cache_file$eol"; }
 #-----------------------------------------------------------------------------------------------
 # Platform properties ##########################################################################
 #-----------------------------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------------------------
+# Determine target system name, using hostname if not otherwsie specified
+my ($mach) = split /\./, hostname();
+if (defined $opts{'mach'}) {
+    $mach = $opts{'mach'};
+}
+$cfg_ref->set('mach', $mach);
+
+if ($print>=2) { print "MACH: $mach$eol"; }
 
 #-----------------------------------------------------------------------------------------------
 # Determine target OS -- allow cross compilation only if target_os is specified on commandline.
@@ -1348,7 +1361,8 @@ if ($print>=2) { print "Horizontal grid specifier: $hgrid$eol"; }
 
 #-----------------------------------------------------------------------------------------------
 # Maximum number of columns in a chunk. If set as an option, then it is a compile-time parameter
-# (ppcols == 'TRUE'). Otherwise, pcols is just the default value for a runtime parameter.
+# (ppcols == 'TRUE'). Otherwise, pcols is a runtime parameter set by the namelist parameter
+# phys_chnk_fdim.
 if (defined $opts{'pcols'}) {
     $cfg_ref->set('pcols', $opts{'pcols'});
     $cfg_ref->set('ppcols', 'TRUE');

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1418,6 +1418,17 @@
 <phys_loadbalance dyn="se"> 2 </phys_loadbalance>
 <phys_loadbalance dyn="eul"> 3 </phys_loadbalance>
 
+<!-- physics chunk first dimension upper bound,
+     encoding empirically-determined defaults -->
+<phys_chnk_fdim_max > -1 </phys_chnk_fdim_max>
+<phys_chnk_fdim_max dyn="se" npg="2"> 16 </phys_chnk_fdim_max>
+<phys_chnk_fdim_max mach="compy" dyn="se" npg="0"> 24 </phys_chnk_fdim_max>
+
+<!-- physics chunk first dimension factor,
+     encoding empirically-determined defaults -->
+<phys_chnk_fdim_mult > 1 </phys_chnk_fdim_mult>
+<phys_chnk_fdim_mult mach="cori-knl" dyn="se"> 2 </phys_chnk_fdim_mult>
+
 <!-- Control output to history file(s) -->
 <history_amwg>                 .true.   </history_amwg>
 <history_verbose>              .false.  </history_verbose>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1420,9 +1420,10 @@
 
 <!-- physics chunk first dimension upper bound,
      encoding empirically-determined defaults -->
-<phys_chnk_fdim_max > -1 </phys_chnk_fdim_max>
+<phys_chnk_fdim_max > 16 </phys_chnk_fdim_max>
 <phys_chnk_fdim_max dyn="se" npg="2"> 16 </phys_chnk_fdim_max>
 <phys_chnk_fdim_max mach="compy" dyn="se" npg="0"> 24 </phys_chnk_fdim_max>
+<phys_chnk_fdim_max mach="cori-knl" dyn="se" npg="0"> 128 </phys_chnk_fdim_max>
 
 <!-- physics chunk first dimension factor,
      encoding empirically-determined defaults -->

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1421,9 +1421,10 @@
 <!-- physics chunk first dimension upper bound,
      encoding empirically-determined defaults -->
 <phys_chnk_fdim_max > 16 </phys_chnk_fdim_max>
-<phys_chnk_fdim_max dyn="se" npg="2"> 16 </phys_chnk_fdim_max>
 <phys_chnk_fdim_max mach="compy" dyn="se" npg="0"> 24 </phys_chnk_fdim_max>
+<phys_chnk_fdim_max mach="compy" dyn="se" npg="2"> 20 </phys_chnk_fdim_max>
 <phys_chnk_fdim_max mach="cori-knl" dyn="se" npg="0"> 128 </phys_chnk_fdim_max>
+<phys_chnk_fdim_max mach="cori-knl" dyn="se" npg="2"> 30 </phys_chnk_fdim_max>
 
 <!-- physics chunk first dimension factor,
      encoding empirically-determined defaults -->

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -347,10 +347,38 @@ chunks). This was originally specified at compile-time, based on
 experiments in the early 2000s indicating that the compilers at the time
 generated more efficient code when the first dimension was known
 at compile time, perhaps for improved alignment in memory layout or improved
-vectorization. This is now exposed as a runtime parameter, and the
-previous compile-time maximum (PCOLS) is simply used to define the default
-value of the runtime variable. Must be greater than or equal to 1.
-Default: PCOLS
+vectorization. This is now exposed as a runtime parameter. If phys_chnk_fdim
+is greater then 0, then the runtime pcols parameter is set to phys_chnk_fdim.
+If phys_chnk_fdim is less than or equal to 0, then pcols is calculated based
+on the values of the namelist variables phys_loadbalance, phys_chnk_fdim_max,
+and phys_chnk_fdim_mult, and on the problem specifics, attempting to
+minimize load imbalance between chunks, wasted space within chunks, and the
+number of chunks. The original compile-time behavior can be restored by
+defining the CPP token PPCOLS when building the model, in which case the
+original compile-time maximum (PCOLS) is still used. Note that PPCOLS is
+defined when the '-pcols' option is specifed in the call to CAM configure,
+in which case PCOLS is set to value of the '-pcols' argument.
+Default: 0
+</entry>
+
+<entry id="phys_chnk_fdim_max" type="integer"  category="perf_dp_coup"
+       group="cam_inparm" valid_values="">
+If phys_chnk_fdim is less than 1 (so runtime pcols is calculated)
+and phys_chnk_fdim_max is greater than 0, then phys_chnk_fdim_max
+is an upper bound on the size of the runtime pcols parameter.
+Otherwise it is ignored.
+Default: -1
+</entry>
+
+<entry id="phys_chnk_fdim_mult" type="integer"  category="perf_dp_coup"
+       group="cam_inparm" valid_values="">
+If phys_chnk_fdim is less than 1 (so runtime pcols is calculated) and 
+phys_chnk_fdim_mult is greater than 1 and either phys_chnk_fdim_max is
+less than 1 (so ignored) or phys_chnk_fdim_mult is less than or equal to 
+phys_chnk_fdim_max, then the runtime pcols is required to be an integer
+multiple of phys_chnk_fdim_mult. This can be useful for memory alignment
+of local variables. 
+Default: 1
 </entry>
 
 <entry id="phys_alltoall" type="integer"  category="perf_dp_coup"

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -367,7 +367,7 @@ If phys_chnk_fdim is less than 1 (so runtime pcols is calculated)
 and phys_chnk_fdim_max is greater than 0, then phys_chnk_fdim_max
 is an upper bound on the size of the runtime pcols parameter.
 Otherwise it is ignored.
-Default: -1
+Default: 16 when no overriding rules. See namelist_defaults_cam.xml
 </entry>
 
 <entry id="phys_chnk_fdim_mult" type="integer"  category="perf_dp_coup"
@@ -378,7 +378,7 @@ less than 1 (so ignored) or phys_chnk_fdim_mult is less than or equal to
 phys_chnk_fdim_max, then the runtime pcols is required to be an integer
 multiple of phys_chnk_fdim_mult. This can be useful for memory alignment
 of local variables. 
-Default: 1
+Default: 1 when no overriding rules. See namelist_defaults_cam.xml
 </entry>
 
 <entry id="phys_alltoall" type="integer"  category="perf_dp_coup"
@@ -399,7 +399,7 @@ Default: -1
 <entry id="phys_chnk_cost_write" type="logical"  category="perf_dp_coup"
        group="cam_inparm" valid_values="">
 Enable/disable output of measured physics cost per chunk.
-Default: .false.
+Default: .true.
 </entry>
 
 <entry id="phys_chnk_per_thd" type="integer"  category="perf_dp_coup"

--- a/components/cam/cime_config/config_component.xml
+++ b/components/cam/cime_config/config_component.xml
@@ -40,6 +40,7 @@
     <valid_values></valid_values>
     <default_value></default_value>
     <values modifier='additive'>
+      <value compset=""               >-mach $MACH</value>              
       <value compset="_CAM4"          >-phys cam4</value>              
       <value compset="_CAM5"          >-phys cam5</value> 
       <value compset="_CAM5%MAM4"     >-chem trop_mam4</value>

--- a/components/cam/src/control/cam_comp.F90
+++ b/components/cam/src/control/cam_comp.F90
@@ -84,7 +84,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    use inital,           only: cam_initial
    use cam_restart,      only: cam_read_restart
    use stepon,           only: stepon_init
-   use physpkg,          only: phys_init, phys_register
+   use physpkg,          only: phys_init
    
    use dycore,           only: dycore_is
 #if (defined E3SM_SCM_REPLAY)
@@ -140,10 +140,6 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    !
    call trunc()
    !
-   ! Initialize index values for advected and non-advected tracers
-   !
-   call phys_register ()
-   !
    ! Determine input namelist filename
    !
    filein = "atm_in" // trim(inst_suffix)
@@ -173,7 +169,6 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
       call initialize_iop_history()
 #endif
    end if
-
 
    call phys_init( phys_state, phys_tend, pbuf2d,  cam_out )
 

--- a/components/cam/src/control/cam_restart.F90
+++ b/components/cam/src/control/cam_restart.F90
@@ -288,7 +288,6 @@ end subroutine restart_printopts
       use restart_physics,  only: read_restart_physics
       use restart_dynamics, only: read_restart_dynamics
       use chem_surfvals,    only: chem_surfvals_init
-      use phys_grid,        only: phys_grid_init
       use camsrfexch,       only: hub2atm_alloc, atm2hub_alloc
 #if (defined SPMD)
       use spmd_dyn,         only: spmdbuf
@@ -395,8 +394,6 @@ end subroutine restart_printopts
 
    call initcom ()
    call read_restart_dynamics(File, dyn_in, dyn_out, NLFileName)   
-
-   call phys_grid_init
 
    call hub2atm_alloc( cam_in )
    call atm2hub_alloc( cam_out )

--- a/components/cam/src/control/runtime_opts.F90
+++ b/components/cam/src/control/runtime_opts.F90
@@ -97,8 +97,19 @@ character(len=256) :: cam_branch_file = ' '
 !                      wheter it includes a custom seed or not. Default .false.
 ! 
 ! phys_chnk_fdim       Declared first dimension for physics variables (chunks).
+!                      If <= 0, then value calculated based on problem specifics.
 !                      See phys_grid module.  
 integer :: phys_chnk_fdim
+!
+! phys_chnk_fdim_max   Upper bound on declared first dimension for physics
+!                      variables (chunks), for when phys_chnk_fdim <= 0. 
+!                      See phys_grid module.  
+integer :: phys_chnk_fdim_max
+!
+! phys_chnk_fdim_mult  Restriction on declared first dimension for physics
+!                      variables (chunks) to be a multiple of this value,
+!                      for when phys_chnk_fdim <= 0. See phys_grid module.  
+integer :: phys_chnk_fdim_mult
 !
 ! phys_alltoall        Dynamics/physics transpose option. See phys_grid module.
 !
@@ -306,6 +317,8 @@ contains
                      indirect, &
                      print_step_cost,  &
                      phys_chnk_fdim,  &
+                     phys_chnk_fdim_max,  &
+                     phys_chnk_fdim_mult,  &
                      phys_alltoall, phys_loadbalance, phys_twin_algorithm, &
                      phys_chnk_per_thd, phys_chnk_cost_write
 
@@ -340,6 +353,8 @@ contains
    ! Get default values of runtime options for physics chunking.
    call phys_grid_defaultopts(                      &
       phys_chnk_fdim_out      =phys_chnk_fdim,      &
+      phys_chnk_fdim_max_out  =phys_chnk_fdim_max,  &
+      phys_chnk_fdim_mult_out =phys_chnk_fdim_mult, &
       phys_loadbalance_out    =phys_loadbalance,    &
       phys_twin_algorithm_out =phys_twin_algorithm, &
       phys_alltoall_out       =phys_alltoall,       &
@@ -413,6 +428,8 @@ contains
    ! Set runtime options for physics chunking.
    call phys_grid_setopts(                          &
        phys_chnk_fdim_in      =phys_chnk_fdim,      &
+       phys_chnk_fdim_max_in  =phys_chnk_fdim_max,  &
+       phys_chnk_fdim_mult_in =phys_chnk_fdim_mult, &
        phys_loadbalance_in    =phys_loadbalance,    &
        phys_twin_algorithm_in =phys_twin_algorithm, &
        phys_alltoall_in       =phys_alltoall,       &
@@ -633,11 +650,13 @@ subroutine distnl
    call mpibcast (indirect     , 1 ,mpilog, 0,mpicom)
 
    ! Physics chunk tuning
-   call mpibcast (phys_chnk_fdim     ,1,mpiint,0,mpicom)
-   call mpibcast (phys_loadbalance   ,1,mpiint,0,mpicom)
-   call mpibcast (phys_twin_algorithm,1,mpiint,0,mpicom)
-   call mpibcast (phys_alltoall      ,1,mpiint,0,mpicom)
-   call mpibcast (phys_chnk_per_thd  ,1,mpiint,0,mpicom)
+   call mpibcast (phys_chnk_fdim      ,1,mpiint,0,mpicom)
+   call mpibcast (phys_chnk_fdim_max  ,1,mpiint,0,mpicom)
+   call mpibcast (phys_chnk_fdim_mult ,1,mpiint,0,mpicom)
+   call mpibcast (phys_loadbalance    ,1,mpiint,0,mpicom)
+   call mpibcast (phys_twin_algorithm ,1,mpiint,0,mpicom)
+   call mpibcast (phys_alltoall       ,1,mpiint,0,mpicom)
+   call mpibcast (phys_chnk_per_thd   ,1,mpiint,0,mpicom)
    call mpibcast (phys_chnk_cost_write,1,mpilog,0,mpicom)
 
    ! Physics buffer

--- a/components/cam/src/dynamics/eul/dyn_comp.F90
+++ b/components/cam/src/dynamics/eul/dyn_comp.F90
@@ -48,11 +48,8 @@ CONTAINS
 !#######################################################################
 
 subroutine dyn_init(file, nlfilename)
-   use phys_control, only : use_gw_front
    use dyn_grid,     only: define_cam_grids, initgrid
    use scamMod,      only: single_column
-   use physics_buffer,  only : pbuf_add_field, dtype_r8
-   use ppgrid,          only : pcols, pver
 
    ! ARGUMENTS:
    type(file_desc_t), intent(in) :: file       ! PIO file handle for initial or restart file
@@ -79,13 +76,6 @@ subroutine dyn_init(file, nlfilename)
 #endif 
 
   !----------------------------------------------------------------------
-
-  if (use_gw_front) then
-     call pbuf_add_field("FRONTGF", "global", dtype_r8, (/pcols,pver/), &
-          frontgf_idx)
-     call pbuf_add_field("FRONTGA", "global", dtype_r8, (/pcols,pver/), &
-          frontga_idx)
-  end if
 
    ! Initialize hybrid coordinate arrays
    call hycoef_init(file)

--- a/components/cam/src/dynamics/eul/inital.F90
+++ b/components/cam/src/dynamics/eul/inital.F90
@@ -13,9 +13,14 @@ contains
 
 subroutine cam_initial(dyn_in, dyn_out, nlfilename)
 
-   use dyn_comp,             only: dyn_import_t, dyn_export_t, dyn_init
+   use dyn_comp,             only: dyn_import_t, dyn_export_t, dyn_init, &
+                                   frontgf_idx, frontga_idx
    use prognostics,          only: initialize_prognostics
    use phys_grid,            only: phys_grid_init
+   use physpkg,              only: phys_register
+   use phys_control,         only: use_gw_front
+   use physics_buffer,       only: pbuf_add_field, dtype_r8
+   use ppgrid,               only: pcols, pver
    use chem_surfvals,        only: chem_surfvals_init
    use scanslt,              only: scanslt_alloc
    use cam_initfiles,        only: initial_file_get_id
@@ -32,20 +37,31 @@ subroutine cam_initial(dyn_in, dyn_out, nlfilename)
    character(len=*), intent(in) :: nlfilename
    !-----------------------------------------------------------------------
 
+   call dyn_init(initial_file_get_id(), nlfilename)
+
+   ! Define physics data structures
+   call phys_grid_init()
+
+   ! Initialize index values for advected and non-advected tracers
+   call phys_register()
+
+   ! Frontogenesis indices
+   if (use_gw_front) then
+      call pbuf_add_field("FRONTGF", "global", dtype_r8, (/pcols,pver/), &
+           frontgf_idx)
+      call pbuf_add_field("FRONTGA", "global", dtype_r8, (/pcols,pver/), &
+           frontga_idx)
+   end if
+
    ! Initialize ghg surface values before default initial distributions
    ! are set in inidat.
    call chem_surfvals_init()
-
-   call dyn_init(initial_file_get_id(), nlfilename)
 
    ! Initialize prognostics variables
    call initialize_prognostics
    call scanslt_alloc()
 
    call initcom
-
-   ! Define physics data structures
-   call phys_grid_init
 
 #if (defined SPMD)
    ! Allocate communication buffers for

--- a/components/cam/src/dynamics/fv/dyn_comp.F90
+++ b/components/cam/src/dynamics/fv/dyn_comp.F90
@@ -198,10 +198,6 @@ subroutine dyn_init(file, dyn_state, dyn_in, dyn_out, NLFileName )
                                cpair,             &
                                zvir,              &
                                pi
-   use phys_control,    only : use_gw_front
-   use qbo,             only : qbo_use_forcing
-   use physics_buffer,  only : pbuf_add_field, dtype_r8
-   use ppgrid,          only : pcols, pver
 
    ! ARGUMENTS:
    type(file_desc_t),       intent(in)  :: file       ! PIO file handle for initial or restart file
@@ -261,18 +257,6 @@ subroutine dyn_init(file, dyn_state, dyn_in, dyn_out, NLFileName )
 #endif
 
   !----------------------------------------------------------------------
-
-  if (use_gw_front) then
-     call pbuf_add_field("FRONTGF", "global", dtype_r8, (/pcols,pver/), &
-          frontgf_idx)
-     call pbuf_add_field("FRONTGA", "global", dtype_r8, (/pcols,pver/), &
-          frontga_idx)
-  end if
-
-  if (qbo_use_forcing) then
-     call pbuf_add_field("UZM", "global", dtype_r8, (/pcols,pver/), &
-          uzm_idx)
-  end if
 
   ! Initialize hybrid coordinate arrays
   call hycoef_init(file)

--- a/components/cam/src/dynamics/fv/inital.F90
+++ b/components/cam/src/dynamics/fv/inital.F90
@@ -13,8 +13,15 @@ contains
 
 subroutine cam_initial( dyn_in, dyn_out, NLFileName )
 
-   use dyn_comp,             only : dyn_import_t, dyn_export_t, dyn_init
+   use dyn_comp,             only : dyn_import_t, dyn_export_t, &
+                                    dyn_init, frontgf_idx, frontga_idx, &
+                                    uzm_idx
    use phys_grid,            only : phys_grid_init
+   use physpkg,              only : phys_register
+   use phys_control,         only : use_gw_front
+   use physics_buffer,       only : pbuf_add_field, dtype_r8
+   use ppgrid,               only : pcols, pver
+   use qbo,                  only : qbo_use_forcing
    use chem_surfvals,        only : chem_surfvals_init
    use cam_initfiles,        only : initial_file_get_id
    use startup_initialconds, only : initial_conds
@@ -41,7 +48,23 @@ subroutine cam_initial( dyn_in, dyn_out, NLFileName )
    call dyn_init(initial_file_get_id(), dyn_state, dyn_in, dyn_out, NLFileName )
 
    ! Define physics data structures
-   call phys_grid_init
+   call phys_grid_init()
+
+   ! Initialize index values for advected and non-advected tracers
+   call phys_register()
+
+   ! Frontogenesis indices
+   if (use_gw_front) then
+      call pbuf_add_field("FRONTGF", "global", dtype_r8, (/pcols,pver/), &
+           frontgf_idx)
+      call pbuf_add_field("FRONTGA", "global", dtype_r8, (/pcols,pver/), &
+           frontga_idx)
+   end if
+
+   if (qbo_use_forcing) then
+      call pbuf_add_field("UZM", "global", dtype_r8, (/pcols,pver/), &
+           uzm_idx)
+   end if
 
    ! Initialize ghg surface values before default initial distributions
    ! are set in inidat.

--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -98,10 +98,7 @@ CONTAINS
     use control_mod,      only: runtype, qsplit, rsplit, dt_tracer_factor, dt_remap_factor, &
          timestep_make_eam_parameters_consistent
     use time_mod,         only: tstep
-    use phys_control,     only: use_gw_front
-    use physics_buffer,   only: pbuf_add_field, dtype_r8
-    use ppgrid,           only: pcols, pver
-    use cam_abortutils,   only : endrun
+    use cam_abortutils,   only: endrun
 
     ! PARAMETERS:
     type(file_desc_t),   intent(in)  :: fh       ! PIO file handle for initial or restart file
@@ -114,13 +111,6 @@ CONTAINS
     integer :: npes_se_stride
 
     !----------------------------------------------------------------------
-
-    if (use_gw_front) then
-       call pbuf_add_field("FRONTGF", "global", dtype_r8, (/pcols,pver/), &
-            frontgf_idx)
-       call pbuf_add_field("FRONTGA", "global", dtype_r8, (/pcols,pver/), &
-            frontga_idx)
-    end if
 
     ! Initialize dynamics grid variables
     call dyn_grid_init()

--- a/components/cam/src/dynamics/se/inital.F90
+++ b/components/cam/src/dynamics/se/inital.F90
@@ -13,8 +13,13 @@ contains
 
 subroutine cam_initial(dyn_in, dyn_out, NLFileName)
 
-   use dyn_comp,             only: dyn_init1, dyn_init2, dyn_import_t, dyn_export_t
+   use dyn_comp,             only: dyn_init1, dyn_init2, dyn_import_t, &
+                                   dyn_export_t, frontgf_idx, frontga_idx
    use phys_grid,            only: phys_grid_init
+   use physpkg,              only: phys_register
+   use phys_control,         only: use_gw_front
+   use physics_buffer,       only: pbuf_add_field, dtype_r8
+   use ppgrid,               only: pcols, pver
    use chem_surfvals,        only: chem_surfvals_init
    use cam_initfiles,        only: initial_file_get_id
    use startup_initialconds, only: initial_conds
@@ -32,7 +37,18 @@ subroutine cam_initial(dyn_in, dyn_out, NLFileName)
 
    ! Define physics data structures
    if(par%masterproc  ) write(iulog,*) 'Running phys_grid_init()'
-   call phys_grid_init( )
+   call phys_grid_init()
+
+   ! Initialize index values for advected and non-advected tracers
+   call phys_register()
+
+   ! Frontogenesis indices
+   if (use_gw_front) then
+      call pbuf_add_field("FRONTGF", "global", dtype_r8, (/pcols,pver/), &
+           frontgf_idx)
+      call pbuf_add_field("FRONTGA", "global", dtype_r8, (/pcols,pver/), &
+           frontga_idx)
+   end if
 
    ! Initialize ghg surface values before default initial distributions
    ! are set in inidat.

--- a/components/cam/src/dynamics/sld/inital.F90
+++ b/components/cam/src/dynamics/sld/inital.F90
@@ -16,6 +16,7 @@ subroutine cam_initial(dyn_in, dyn_out, nlfilename)
    use dyn_comp,             only: dyn_import_t, dyn_export_t, dyn_init
    use prognostics,          only: initialize_prognostics
    use phys_grid,            only: phys_grid_init
+   use physpkg,              only: phys_register
    use chem_surfvals,        only: chem_surfvals_init
    use scanslt,              only: slt_alloc
    use cam_initfiles,        only: initial_file_get_id
@@ -31,20 +32,23 @@ subroutine cam_initial(dyn_in, dyn_out, nlfilename)
    character(len=*), intent(in) :: nlfilename
    !-----------------------------------------------------------------------
 
+   call dyn_init(initial_file_get_id(), nlfilename)
+
+   ! Define physics data structures
+   call phys_grid_init()
+
+   ! Initialize index values for advected and non-advected tracers
+   call phys_register()
+
    ! Initialize ghg surface values before default initial distributions
    ! are set in inidat.
    call chem_surfvals_init()
-
-   call dyn_init(initial_file_get_id(), nlfilename)
 
    ! Initialize prognostics variables
    call initialize_prognostics
    call slt_alloc()
 
    call initcom
-
-   ! Define physics data structures
-   call phys_grid_init
 
 #if (defined SPMD)
    ! Allocate communication buffers for

--- a/components/cam/src/dynamics/sld/restart_dynamics.F90
+++ b/components/cam/src/dynamics/sld/restart_dynamics.F90
@@ -442,8 +442,9 @@ CONTAINS
 
   subroutine read_restart_dynamics (File, dyn_in, dyn_out, NLFileName)
     use dyn_comp,        only: dyn_init, dyn_import_t, dyn_export_t
+    use phys_grid,       only: phys_grid_init
+    use physpkg,         only: phys_register
     use cam_pio_utils,   only: pio_subsystem
-    use dyn_comp,        only: dyn_init
     use prognostics,     only: initialize_prognostics, n3, n3m1
     use pmgrid,          only: plon, plat, plevp, plev, beglat, endlat
     use constituents,    only: pcnst
@@ -476,6 +477,12 @@ CONTAINS
     integer, pointer :: ldof(:)
 
     call dyn_init(file, NLFileName)
+
+    ! Define physics data structures
+    call phys_grid_init()
+
+    ! Initialize index values for advected and non-advected tracers
+    call phys_register()
 
     call initialize_prognostics
     call slt_alloc()

--- a/components/cam/src/physics/cam/phys_grid.F90
+++ b/components/cam/src/physics/cam/phys_grid.F90
@@ -91,7 +91,7 @@ module phys_grid
 !-----------------------------------------------------------------------
    use shr_kind_mod,     only: r8 => shr_kind_r8, r4 => shr_kind_r4
    use physconst,        only: pi
-   use ppgrid,           only: ppcols, pcols, pver, begchunk, endchunk
+   use ppgrid,           only: pcols, pver, begchunk, endchunk
 #if ( defined SPMD )
    use spmd_dyn,         only: block_buf_nrecs, chunk_buf_nrecs, &
                                local_dp_map
@@ -279,7 +279,10 @@ module phys_grid
 
 ! Physics fields data structure (chunk) first dimension:
    integer, private, parameter :: min_pcols = 1
-   integer, private, parameter :: def_pcols = ppcols               ! default 
+!pw   integer, private, parameter :: def_pcols = ppcols             ! default 
+!pw++
+   integer, private, parameter :: def_pcols = -1                 ! default 
+!pw--
 
 ! Physics grid decomposition options:  
 ! -1: each chunk is a dynamics block
@@ -677,7 +680,10 @@ contains
     allocate( gs_col_num(0:npes-1) )
     npchunks(:) = 0
     gs_col_num(:) = 0
-
+!pw++
+!pw temporary, for development purposes
+    pcols = 16
+!pw--
     !
     ! Option -1: each dynamics block is a single chunk
     !          
@@ -1557,16 +1563,16 @@ logical function phys_grid_initialized ()
         endif
 #else
         pcols = phys_chnk_fdim_in
-        if (pcols < min_pcols) then
-           if (masterproc) then
-              write(iulog,*)                                          &
-                 'PHYS_GRID_SETOPTS:  ERROR:  phys_chnk_fdim=', &
-                 phys_chnk_fdim_in,                             &
-                 '  is out of range.  It must be at least as large as ',      &
-                 min_pcols
-           endif
-           call endrun
-        endif
+!pw        if (pcols < min_pcols) then
+!pw           if (masterproc) then
+!pw              write(iulog,*)                                          &
+!pw                 'PHYS_GRID_SETOPTS:  ERROR:  phys_chnk_fdim=', &
+!pw                 phys_chnk_fdim_in,                             &
+!pw                 '  is out of range.  It must be at least as large as ',      &
+!pw                 min_pcols
+!pw           endif
+!pw           call endrun
+!pw        endif
 #endif
      endif
 !

--- a/components/cam/src/physics/cam/phys_grid.F90
+++ b/components/cam/src/physics/cam/phys_grid.F90
@@ -323,7 +323,7 @@ module phys_grid
 ! Physics grid load balancing output options:  
 !  T: write out both estimated (normalized) and actual (seconds) cost per chunk
 !  F: do not write out costs
-   logical, private, parameter :: def_output_chunk_costs = .false.
+   logical, private, parameter :: def_output_chunk_costs = .true.
    logical, private :: output_chunk_costs = def_output_chunk_costs
 
 ! target number of chunks per thread

--- a/components/cam/src/physics/cam/ppgrid.F90
+++ b/components/cam/src/physics/cam/ppgrid.F90
@@ -18,7 +18,6 @@ module ppgrid
   public begchunk
   public endchunk
   public pcols
-  public ppcols
   public psubcols
   public pver
   public pverp
@@ -29,7 +28,6 @@ module ppgrid
 #ifdef PPCOLS
    integer pcols      ! max number of columns per chunk (set at compile-time)
 #endif
-   integer ppcols     ! max number of columns per chunk (default for runtime-set pcols)
    integer psubcols   ! number of sub-columns (max)
    integer pver       ! number of vertical levels
    integer pverp      ! pver + 1
@@ -37,7 +35,6 @@ module ppgrid
 #ifdef PPCOLS
    parameter (pcols     = PCOLS)
 #endif
-   parameter (ppcols    = PCOLS)
    parameter (psubcols  = PSUBCOLS)
    parameter (pver      = PLEV)
    parameter (pverp     = pver + 1  )
@@ -51,7 +48,7 @@ module ppgrid
 #ifndef PPCOLS
 !
 ! pcols set in physgrid_init
-   integer :: pcols = PCOLS    ! max number of columns per chunk (set at runtime)
+   integer :: pcols = -1    ! max number of columns per chunk (set at runtime)
 #endif
 
 end module ppgrid


### PR DESCRIPTION
In PR #3620, EAM was modified to allow setting pcols, the first
dimension of the chunk data structure, at runtime. See the discussion
in this previous PR and in the associated issue #3538 for a
description as to why this decision was made.

Here, support for setting pcols at runtime is generalized to allow a
default to be calculated that

a) minimizes the number of chunks subject to constructing
chunks all with approximately the same cost (based on either number of
columns or on a user-specified relative cost per column) and
assigning the same number of chunks to each computational thead,
constrained by the physics load balancing option (-1, 0, 1, 2, 3, 4,
or 5) and the target number of chunks per thread; and

b) minimizes the difference between pcols and ncols, where ncols is
the actual number of columns assigned to a chunk, thus minimizing
wasted space and increasing cache locality. This minimization is done
per process, as pcols only needs to be the same for chunks assigned to
a process.

The current options are still supported:

1) set pcols to a specific value at compile-time for all processes by
   adding -pcols <pcols value> to CAM_CONFIG_OPTS in env_build.xml

2) set pcols to a specific value at runtime for all processes by
   adding

       phys_chnk_fdim = <pcols value>

   to user_nl_cam.

However, the new default is

      phys_chnk_fdim = 0

which causes phys_grid_init to compute a pcols value satisfying the
above criteria ( (a) and (b) ), subject to constraints defined by two
new namelist variables:

     phys_chnk_fdim_max:  an upper bound on pcols
     phys_chnk_fdim_mult: a requirement that pcols be a multiple of this value

Note that if phys_chnk_fdim > 1 or if -pcols is specified in
CAM_CONFIG_OPTS, then these namelist variables are ignored.

There is now also support for specifying the defaults for
phys_chnk_fdim_max and phys_chnk_fdim_mult by system, dycore, and
physics grid type. The following rules are included in this PR
(from namelist_defaults_cam.xml):

     <!-- physics chunk first dimension upper bound,                                                  
          encoding empirically-determined defaults -->
     <phys_chnk_fdim_max > 16 </phys_chnk_fdim_max>
     <phys_chnk_fdim_max dyn="se" npg="2"> 16 </phys_chnk_fdim_max>
     <phys_chnk_fdim_max mach="compy" dyn="se" npg="0"> 24 </phys_chnk_fdim_max>
     <phys_chnk_fdim_max mach="cori-knl" dyn="se" npg="0"> 128 </phys_chnk_fdim_max>

     <!-- physics chunk first dimension factor,                                                       
          encoding empirically-determined defaults -->
     <phys_chnk_fdim_mult > 1 </phys_chnk_fdim_mult>
     <phys_chnk_fdim_mult mach="cori-knl" dyn="se"> 2 </phys_chnk_fdim_mult>

Based on these, the current default (pcols = 16) is still approximated
by the "generic" default for phys_chnk_fdim_max, in that the calculated
pcols will be <= 16, and this will determine the total number of
chunks, so there may necessarily be more than one chunk per
thread. This is simply meant to be a conservative choice, given that
pcols=16 has been working in CAM/EAM for a long time. However, this is
now an upper bound, and pcols could be smaller for a given process for
a given case (grid resolution and number of computational threads).

The other rules are the results of extensive empirical experiments on
Compy and Cori-KNL for the indicated set of options. Appropriate
defaults for other systems or problem settings can be evaluated and
then implemented in the same way. However, these can always be
overridden by setting these variables in user_nl_cam.

There were some subtleties in implementing this capability, requiring,
for example, reordering steps in the atmosphere intialization to allow
pcols to be set in phys_grid_init, and adding the system name to the
EAM/CAM configure command. See the commit messages for the details.

[BFB]
[NML]

Fixes #3538
Fixes #3485
