### PR TITLE
CIME fix for setting maximum I/O requests automatically

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component.xml
+++ b/cime/src/drivers/mct/cime_config/config_component.xml
@@ -2430,7 +2430,7 @@
     <default_value>64</default_value>
     <group>run_pio</group>
     <file>env_run.xml</file>
-    <desc>pio rearranger communication max pending requests (io2comp) : -1 implies no bound on max pending requests </desc>
+    <desc>pio rearranger communication max pending requests (io2comp) : 0 implies that CIME internally calculates the value (= 64), -1 implies no bound on max pending requests </desc>
   </entry>
 
   <!-- Handshaking is a very bad idea for large process counts and for -->

--- a/cime/src/drivers/nuopc/cime_config/config_component.xml
+++ b/cime/src/drivers/nuopc/cime_config/config_component.xml
@@ -1989,7 +1989,7 @@
     <default_value>64</default_value>
     <group>run_pio</group>
     <file>env_run.xml</file>
-    <desc>pio rearranger communication max pending requests (io2comp) : -1 implies no bound on max pending requests </desc>
+    <desc>pio rearranger communication max pending requests (io2comp) : 0 implies that CIME internally calculates the value (= 64), -1 implies no bound on max pending requests </desc>
   </entry>
 
   <!-- Handshaking is a very bad idea for large process counts and for -->

--- a/cime/src/share/util/shr_pio_mod.F90
+++ b/cime/src/share/util/shr_pio_mod.F90
@@ -812,7 +812,7 @@ contains
       end select
 
       ! buf(3) = max_pend_req_comp2io
-      if((pio_rearr_comm_max_pend_req_comp2io < 0) .and. &
+      if((pio_rearr_comm_max_pend_req_comp2io <= 0) .and. &
           (pio_rearr_comm_max_pend_req_comp2io /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
 
         ! Small multiple of pio_numiotasks has proven to perform
@@ -844,7 +844,7 @@ contains
       end if
 
       ! buf(6) = max_pend_req_io2comp
-      if((pio_rearr_comm_max_pend_req_io2comp < 0) .and. &
+      if((pio_rearr_comm_max_pend_req_io2comp <= 0) .and. &
           (pio_rearr_comm_max_pend_req_io2comp /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
         write(shr_log_unit, *) "Invalid PIO rearranger comm max pend req (io2comp), ", pio_rearr_comm_max_pend_req_io2comp
         write(shr_log_unit, *) "Resetting PIO rearranger comm max pend req (io2comp) to ", PIO_REARR_COMM_DEF_MAX_PEND_REQ

--- a/cime/src/share/util/shr_pio_mod.F90
+++ b/cime/src/share/util/shr_pio_mod.F90
@@ -867,16 +867,6 @@ contains
         buf(8) = 0
       end if
 
-      ! Log the rearranger options
-      write(shr_log_unit, *) "PIO rearranger options:"
-      write(shr_log_unit, *) "  comm type     =", pio_rearr_comm_type
-      write(shr_log_unit, *) "  comm fcd      =", pio_rearr_comm_fcd
-      write(shr_log_unit, *) "  max pend req (comp2io)  =", pio_rearr_comm_max_pend_req_comp2io
-      write(shr_log_unit, *) "  enable_hs (comp2io)     =", pio_rearr_comm_enable_hs_comp2io
-      write(shr_log_unit, *) "  enable_isend (comp2io)  =", pio_rearr_comm_enable_isend_comp2io
-      write(shr_log_unit, *) "  max pend req (io2comp)  =", pio_rearr_comm_max_pend_req_io2comp
-      write(shr_log_unit, *) "  enable_hs (io2comp)    =", pio_rearr_comm_enable_hs_io2comp
-      write(shr_log_unit, *) "  enable_isend (io2comp)  =", pio_rearr_comm_enable_isend_io2comp
     end if
 
     call shr_mpi_bcast(buf, comm)
@@ -912,6 +902,27 @@ contains
       pio_rearr_opt_i2c_enable_isend = .false.
     else
       pio_rearr_opt_i2c_enable_isend = .true.
+    end if
+
+    if(rank == 0) then
+      ! Log the rearranger options
+      write(shr_log_unit, *) "PIO rearranger options:"
+      write(shr_log_unit, *) "  comm type     = ", trim(pio_rearr_comm_type)
+      write(shr_log_unit, *) "  comm fcd      = ", trim(pio_rearr_comm_fcd)
+      if(pio_rearr_opt_c2i_max_pend_req == PIO_REARR_COMM_UNLIMITED_PEND_REQ) then
+        write(shr_log_unit, *) "  max pend req (comp2io)  = PIO_REARR_COMM_UNLIMITED_PEND_REQ (-1)"
+      else
+        write(shr_log_unit, *) "  max pend req (comp2io)  = ", pio_rearr_opt_c2i_max_pend_req
+      end if
+      write(shr_log_unit, *) "  enable_hs (comp2io)     = ", pio_rearr_opt_c2i_enable_hs
+      write(shr_log_unit, *) "  enable_isend (comp2io)  = ", pio_rearr_opt_c2i_enable_isend
+      if(pio_rearr_opt_i2c_max_pend_req == PIO_REARR_COMM_UNLIMITED_PEND_REQ) then
+        write(shr_log_unit, *) "  max pend req (io2comp)  = PIO_REARR_COMM_UNLIMITED_PEND_REQ (-1)"
+      else
+        write(shr_log_unit, *) "  max pend req (io2comp)  = ", pio_rearr_opt_i2c_max_pend_req
+      end if
+      write(shr_log_unit, *) "  enable_hs (io2comp)    = ", pio_rearr_opt_i2c_enable_hs
+      write(shr_log_unit, *) "  enable_isend (io2comp)  = ", pio_rearr_opt_i2c_enable_isend
     end if
   end subroutine
 !===============================================================================

--- a/cime/src/share/util/shr_pio_mod.F90
+++ b/cime/src/share/util/shr_pio_mod.F90
@@ -765,6 +765,8 @@ contains
     character(*), parameter :: subname = '(shr_pio_rearr_opts_set) '
     integer, parameter :: NUM_REARR_COMM_OPTS = 8
     integer, parameter :: PIO_REARR_COMM_DEF_MAX_PEND_REQ = 64
+    ! Automatically reset if the number of maximum pending requests is set to 0
+    integer, parameter :: REARR_COMM_DEF_MAX_PEND_REQ_RESET = 0
     integer(SHR_KIND_IN), dimension(NUM_REARR_COMM_OPTS) :: buf
     integer :: rank, ierr
 
@@ -815,13 +817,19 @@ contains
       if((pio_rearr_comm_max_pend_req_comp2io <= 0) .and. &
           (pio_rearr_comm_max_pend_req_comp2io /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
 
+        if(pio_rearr_comm_max_pend_req_comp2io /= REARR_COMM_DEF_MAX_PEND_REQ_RESET) then
+          write(shr_log_unit, *) "Invalid PIO rearranger comm max pend req (comp2io), ",&
+               pio_rearr_comm_max_pend_req_comp2io
+        else
+          write(shr_log_unit, *) "User-specified PIO rearranger comm max pend req (comp2io), ",&
+               pio_rearr_comm_max_pend_req_comp2io, " (value will be reset as requested) "
+        end if
+
         ! Small multiple of pio_numiotasks has proven to perform
         ! well empirically, and we do not want to allow maximum for
         ! very large process count runs. Can improve this by
         ! communicating between iotasks first, and then non-iotasks
         ! to iotasks (TO DO)
-        write(shr_log_unit, *) "Invalid PIO rearranger comm max pend req (comp2io), ",&
-             pio_rearr_comm_max_pend_req_comp2io
         write(shr_log_unit, *) "Resetting PIO rearranger comm max pend req (comp2io) to ", &
              max(PIO_REARR_COMM_DEF_MAX_PEND_REQ, 2 * pio_numiotasks)
         buf(3) = max(PIO_REARR_COMM_DEF_MAX_PEND_REQ, 2 * pio_numiotasks)
@@ -846,7 +854,15 @@ contains
       ! buf(6) = max_pend_req_io2comp
       if((pio_rearr_comm_max_pend_req_io2comp <= 0) .and. &
           (pio_rearr_comm_max_pend_req_io2comp /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
-        write(shr_log_unit, *) "Invalid PIO rearranger comm max pend req (io2comp), ", pio_rearr_comm_max_pend_req_io2comp
+
+        if(pio_rearr_comm_max_pend_req_io2comp /= REARR_COMM_DEF_MAX_PEND_REQ_RESET) then
+          write(shr_log_unit, *) "Invalid PIO rearranger comm max pend req (io2comp), ",&
+               pio_rearr_comm_max_pend_req_io2comp
+        else
+          write(shr_log_unit, *) "User-specified PIO rearranger comm max pend req (io2comp), ",&
+               pio_rearr_comm_max_pend_req_io2comp, " (value will be reset as requested) "
+        end if
+
         write(shr_log_unit, *) "Resetting PIO rearranger comm max pend req (io2comp) to ", PIO_REARR_COMM_DEF_MAX_PEND_REQ
         buf(6) = PIO_REARR_COMM_DEF_MAX_PEND_REQ
       else


### PR DESCRIPTION
The maximum I/O pending requests setting in env_run.xml,
PIO_REARR_COMM_MAX_PEND_REQ_COMP2IO, is by
default set to 0. CIME needs to set the variable to an
appropriate value in this case (when its set to 0).
Re-introducing this behavior that was disabled by
ESMCI/cime#3499.

Also updating the logging of the I/O rearranger options
to make it more intuitive to the user

Also see ESMCI/cime#3597 that fixes the disabling of
automatic setting of I/O requests in CIME

Fixes #3658 

[BFB]