### PR TITLE
[WIP] HOMME: added possibility of building libraries instead of execs

### DIFF
--- a/components/homme/CMakeLists.txt
+++ b/components/homme/CMakeLists.txt
@@ -12,15 +12,17 @@ IF (NOT DEFINED PROJECT_NAME)
   SET (LAST_GIT_COMMIT_SHA ${LAST_GIT_COMMIT_SHA} CACHE STRING "The sha of the last git commit.")
   MESSAGE (STATUS "The sha of the last commit is ${LAST_GIT_COMMIT_SHA}")
 
-  # Build executables/tests
-  SET (HOMME_BUILD_EXECS TRUE)
+  # By default, build executables/tests, and do not build 'library-style' targets
+  OPTION (HOMME_BUILD_EXECS "Whether Homme should build executables and tests." ON)
+  OPTION (HOMME_BUILD_LIBS  "Whether Homme should build a library for each dycore target." OFF)
 ELSE ()
   # Manually enable languages, in case they were not enabled by host project
   ENABLE_LANGUAGE(C)
   ENABLE_LANGUAGE(Fortran)
 
-  # Do not build executables/tests
-  SET (HOMME_BUILD_EXECS FALSE)
+  # By default, do not build executables/tests, and build 'library-style' targets
+  OPTION (HOMME_BUILD_EXECS "Whether Homme should build executables and tests." OFF)
+  OPTION (HOMME_BUILD_LIBS  "Whether Homme should build a library for each dycore target." ON)
 ENDIF ()
 
 INCLUDE(FortranCInterface)
@@ -364,7 +366,7 @@ IF (${HOMME_USE_KOKKOS})
   INCLUDE(Kokkos)
 ENDIF ()
 
-IF (${HOMME_USE_KOKKOS} AND ${HOMME_BUILD_EXECS} AND ${ENABLE_PREQX_KOKKOS_BFB_TESTS})
+IF (${HOMME_USE_KOKKOS} AND ${HOMME_BUILD_EXECS})
   # Add unit tests for C++ code
   ADD_SUBDIRECTORY(test/unit_tests)
 ENDIF ()

--- a/components/homme/cmake/HommeMacros.cmake
+++ b/components/homme/cmake/HommeMacros.cmake
@@ -150,7 +150,6 @@ macro(createTestExec execName execType macroNP macroNC
   ELSE()
     IF (NOT HOMME_FIND_BLASLAPACK)
       TARGET_LINK_LIBRARIES(${execName} lapack blas)
-      ADD_DEPENDENCIES(${execName} blas lapack)
     ENDIF()
   ENDIF()
 
@@ -173,6 +172,93 @@ macro(createTestExec execName execType macroNP macroNC
   INSTALL(TARGETS ${execName} RUNTIME DESTINATION tests)
 
 endmacro(createTestExec)
+
+# Create a library instead of an executable, so Homme can be used by
+# another cmake project as a dycore library
+macro(createExecLib libName execType libSrcs inclDirs macroNP
+                    macroPLEV macroWITH_ENERGY macroQSIZE_D)
+
+  # Set the include directories
+  SET(modulesDir "${CMAKE_CURRENT_BINARY_DIR}/${libName}_modules")
+
+  MESSAGE(STATUS "Building ${libName} library derived from ${execType} with:")
+  MESSAGE(STATUS "  NP = ${macroNP}")
+  MESSAGE(STATUS "  PLEV = ${macroPLEV}")
+  MESSAGE(STATUS "  QSIZE_D = ${macroQSIZE_D}")
+  MESSAGE(STATUS "  ENERGY = ${macroWITH_ENERGY}")
+
+  # Set the variable to the macro variables
+  SET(NUM_POINTS ${macroNP})
+  SET(NUM_PLEV ${macroPLEV})
+
+  IF (${macroWITH_ENERGY})
+    SET(ENERGY_DIAGNOSTICS TRUE)
+  ELSE()
+    SET(ENERGY_DIAGNOSTICS)
+  ENDIF ()
+
+  IF (${macroQSIZE_D})
+    SET(QSIZE_D ${macroQSIZE_D})
+  ELSE()
+    SET(QSIZE_D)
+  ENDIF ()
+
+  # This is needed to compile the test executables with the correct options
+  SET(THIS_CONFIG_IN ${HOMME_SOURCE_DIR}/src/${execType}/config.h.cmake.in)
+  SET(THIS_CONFIG_HC ${CMAKE_CURRENT_BINARY_DIR}/config.h.c)
+  SET(THIS_CONFIG_H ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
+  # First configure the file (which formats the file as C)
+  HommeConfigFile (${THIS_CONFIG_IN} ${THIS_CONFIG_HC} ${THIS_CONFIG_H} )
+
+  ADD_DEFINITIONS(-DHAVE_CONFIG_H)
+
+  ADD_LIBRARY(${libName} ${libSrcs})
+  TARGET_INCLUDE_DIRECTORIES (${libName} PUBLIC ${inclDirs} ${modulesDir} ${CMAKE_CURRENT_BINARY_DIR})
+  SET_TARGET_PROPERTIES(${libName} PROPERTIES Fortran_MODULE_DIRECTORY ${modulesDir})
+  SET_TARGET_PROPERTIES(${libName} PROPERTIES LINKER_LANGUAGE Fortran)
+
+  IF (CXXLIB_SUPPORTED_CACHE)
+    MESSAGE(STATUS "   Linking Fortran with -cxxlib")
+    TARGET_LINK_LIBRARIES(${libName} -cxxlib)
+  ENDIF ()
+
+  STRING(TOUPPER "${PERFORMANCE_PROFILE}" PERF_PROF_UPPER)
+  IF ("${PERF_PROF_UPPER}" STREQUAL "VTUNE")
+    TARGET_LINK_LIBRARIES(${libName} ittnotify)
+  ENDIF ()
+
+  TARGET_LINK_LIBRARIES(${libName} timing ${COMPOSE_LIBRARY} ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+
+  IF (HOMME_USE_KOKKOS)
+    link_to_kokkos(${libName})
+  ENDIF ()
+
+  IF (NOT HOMME_USE_MKL)
+    IF (NOT HOMME_FIND_BLASLAPACK)
+      TARGET_LINK_LIBRARIES(${libName} lapack blas)
+    ENDIF()
+  ENDIF()
+
+  IF (HAVE_EXTRAE)
+    TARGET_LINK_LIBRARIES(${libName} ${Extrae_LIBRARY})
+  ENDIF ()
+
+  IF (HOMME_USE_TRILINOS)
+    TARGET_LINK_LIBRARIES(${libName} ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES})
+  ENDIF()
+
+  IF (HOMME_USE_ARKODE AND "${execType}" STREQUAL "theta-l")
+    TARGET_LINK_LIBRARIES(${libName} sundials_farkode)
+    TARGET_LINK_LIBRARIES(${libName} sundials_arkode)
+    TARGET_LINK_LIBRARIES(${libName} sundials_nvecserial)
+    TARGET_LINK_LIBRARIES(${libName} sundials_fnvecserial)
+  ENDIF ()
+
+  INSTALL(TARGETS ${libName} RUNTIME DESTINATION tests)
+
+endmacro(createExecLib)
+
 
 macro (copyDirFiles testDir)
   # Copy all of the files into the binary dir
@@ -563,8 +649,10 @@ macro(createTest testFile)
     # Baseline target
     ADD_DEPENDENCIES(baseline ${EXEC_NAME})
 
-    # Force cprnc to be built when the individual test is run
-    ADD_DEPENDENCIES(${THIS_TEST_INDIV} cprnc)
+    IF (TARGET cprnc)
+      # Force cprnc to be built when the individual test is run
+      ADD_DEPENDENCIES(${THIS_TEST_INDIV} cprnc)
+    ENDIF ()
 
     # This helped in some builds on GPU, where the test hanged for a VERY long time
     IF (NOT "${TIMEOUT}" STREQUAL "")

--- a/components/homme/src/preqx_kokkos/CMakeLists.txt
+++ b/components/homme/src/preqx_kokkos/CMakeLists.txt
@@ -2,223 +2,232 @@
 
 MACRO(PREQX_KOKKOS_SETUP)
 
-INCLUDE_DIRECTORIES ( SYSTEM ${Trilinos_INCLUDE_DIRS} ${Trilinos_TPL_INCLUDE_DIRS} )
-LINK_DIRECTORIES    ( ${Trilinos_LIBRARY_DIRS} ${Trilinos_TPL_LIBRARY_DIRS} )
+  INCLUDE_DIRECTORIES ( SYSTEM ${Trilinos_INCLUDE_DIRS} ${Trilinos_TPL_INCLUDE_DIRS} )
+  LINK_DIRECTORIES    ( ${Trilinos_LIBRARY_DIRS} ${Trilinos_TPL_LIBRARY_DIRS} )
 
-SET(PREQX_SHARE_DIR       ${HOMME_SOURCE_DIR}/src/preqx/share)
-SET(TARGET_DIR            ${HOMME_SOURCE_DIR}/src/preqx_kokkos)
-SET(UTILS_SHARE_DIR       ${HOMME_SOURCE_DIR}/utils/csm_share)
-SET(SRC_DIR               ${HOMME_SOURCE_DIR}/src)
-SET(SRC_SHARE_DIR         ${HOMME_SOURCE_DIR}/src/share)
-SET(TRILINOS_ZOLTAN_DIR   ${HOMME_SOURCE_DIR}/src/zoltan)
-SET(TEST_SRC_DIR          ${HOMME_SOURCE_DIR}/src/test_src)
+  SET(PREQX_SHARE_DIR       ${HOMME_SOURCE_DIR}/src/preqx/share)
+  SET(TARGET_DIR            ${HOMME_SOURCE_DIR}/src/preqx_kokkos)
+  SET(UTILS_SHARE_DIR       ${HOMME_SOURCE_DIR}/utils/csm_share)
+  SET(SRC_DIR               ${HOMME_SOURCE_DIR}/src)
+  SET(SRC_SHARE_DIR         ${HOMME_SOURCE_DIR}/src/share)
+  SET(TRILINOS_ZOLTAN_DIR   ${HOMME_SOURCE_DIR}/src/zoltan)
+  SET(TEST_SRC_DIR          ${HOMME_SOURCE_DIR}/src/test_src)
 
-SET(UTILS_TIMING_SRC_DIR  ${HOMME_SOURCE_DIR}/utils/cime/src/share/timing)
-SET(UTILS_TIMING_DIR      ${HOMME_BINARY_DIR}/utils/cime/src/share/timing)
+  SET(UTILS_TIMING_SRC_DIR  ${HOMME_SOURCE_DIR}/utils/cime/src/share/timing)
+  SET(UTILS_TIMING_DIR      ${HOMME_BINARY_DIR}/utils/cime/src/share/timing)
 
-# Make INCLUDE_DIRS global so the tests can access it
-SET (EXEC_INCLUDE_DIRS
-  ${PIO_INCLUDE_DIRS}
-  ${UTILS_TIMING_DIR}
-  ${UTILS_TIMING_SRC_DIR}
-  ${PREQX_SHARE_DIR}
-  ${SRC_SHARE_DIR}/cxx
-  ${HOMME_BINARY_DIR}/src/share/cxx)
+  # Make INCLUDE_DIRS global so the tests can access it
+  SET (EXEC_LIB_INCLUDE_DIRS
+    ${UTILS_TIMING_DIR}
+    ${UTILS_TIMING_SRC_DIR}
+    ${PREQX_SHARE_DIR}
+    ${SRC_SHARE_DIR}/cxx
+    ${HOMME_BINARY_DIR}/src/share/cxx)
 
-SET (TARGET_F90
-  ${TARGET_DIR}/bndry_mod.F90
-  ${TARGET_DIR}/derivative_mod.F90
-  ${TARGET_DIR}/edge_mod.F90
-  ${TARGET_DIR}/element_state.F90
-  ${TARGET_DIR}/model_init_mod.F90
-  ${TARGET_DIR}/prim_advection_mod.F90
-  ${TARGET_DIR}/prim_driver_mod.F90
-  ${TARGET_DIR}/viscosity_mod.F90
-  ${PREQX_SHARE_DIR}/element_ops.F90
-  ${PREQX_SHARE_DIR}/prim_advance_mod.F90
-  ${PREQX_SHARE_DIR}/prim_state_mod.F90
-  ${PREQX_SHARE_DIR}/viscosity_preqx_base.F90
-  ${PREQX_SHARE_DIR}/vertremap_mod.F90
-)
+  SET (EXEC_INCLUDE_DIRS
+    ${EXEC_LIB_INCLUDE_DIRS}
+    ${PIO_INCLUDE_DIRS}
+  )
 
-SET (SRC_SHARE_F90
-  ${SRC_SHARE_DIR}/bndry_mod_base.F90
-  ${SRC_SHARE_DIR}/cg_mod.F90
-  ${SRC_SHARE_DIR}/control_mod.F90
-  ${SRC_SHARE_DIR}/coordinate_systems_mod.F90
-  ${SRC_SHARE_DIR}/cube_mod.F90
-  ${SRC_SHARE_DIR}/derivative_mod_base.F90
-  ${SRC_SHARE_DIR}/dimensions_mod.F90
-  ${SRC_SHARE_DIR}/dof_mod.F90
-  ${SRC_SHARE_DIR}/domain_mod.F90
-  ${SRC_SHARE_DIR}/edge_mod_base.F90
-  ${SRC_SHARE_DIR}/edgetype_mod.F90
-  ${SRC_SHARE_DIR}/element_mod.F90
-  ${SRC_SHARE_DIR}/gllfvremap_mod.F90
-  ${SRC_SHARE_DIR}/gllfvremap_util_mod.F90
-  ${SRC_SHARE_DIR}/global_norms_mod.F90
-  ${SRC_SHARE_DIR}/gridgraph_mod.F90
-  ${SRC_SHARE_DIR}/hybrid_mod.F90
-  ${SRC_SHARE_DIR}/hybvcoord_mod.F90
-  ${SRC_SHARE_DIR}/interpolate_mod.F90
-  ${SRC_SHARE_DIR}/kinds.F90
-  ${SRC_SHARE_DIR}/ll_mod.F90
-  ${SRC_SHARE_DIR}/mass_matrix_mod.F90
-  ${SRC_SHARE_DIR}/mesh_mod.F90
-  ${SRC_SHARE_DIR}/sort_mod.F90
-  ${SRC_SHARE_DIR}/metagraph_mod.F90
-  ${SRC_SHARE_DIR}/metis_mod.F90
-  ${SRC_SHARE_DIR}/namelist_mod.F90
-  ${SRC_SHARE_DIR}/parallel_mod.F90
-  ${SRC_SHARE_DIR}/params_mod.F90
-  ${SRC_SHARE_DIR}/physical_constants.F90
-  ${SRC_SHARE_DIR}/physics_mod.F90
-  ${SRC_SHARE_DIR}/prim_advection_base.F90
-  ${SRC_SHARE_DIR}/prim_derived_type_mod.F90
-  ${SRC_SHARE_DIR}/prim_driver_base.F90
-  ${SRC_SHARE_DIR}/prim_implicit_mod.F90
-  ${SRC_SHARE_DIR}/prim_si_mod.F90
-  ${SRC_SHARE_DIR}/quadrature_mod.F90
-  ${SRC_SHARE_DIR}/reduction_mod.F90
-  ${SRC_SHARE_DIR}/schedtype_mod.F90
-  ${SRC_SHARE_DIR}/schedule_mod.F90
-  ${SRC_SHARE_DIR}/solver_mod.F90
-  ${SRC_SHARE_DIR}/spacecurve_mod.F90
-  ${SRC_SHARE_DIR}/thread_mod.F90
-  ${SRC_SHARE_DIR}/time_mod.F90
-  ${SRC_SHARE_DIR}/unit_tests_mod.F90
-  ${SRC_SHARE_DIR}/vertremap_base.F90
-  ${SRC_SHARE_DIR}/viscosity_base.F90
-  ${SRC_SHARE_DIR}/zoltan_mod.F90
-  ${SRC_SHARE_DIR}/sl_advection.F90
-  ${SRC_SHARE_DIR}/compose_mod.F90
-  ${SRC_SHARE_DIR}/compose_test_mod.F90
-  ${SRC_SHARE_DIR}/scalable_grid_init_mod.F90
-)
+  SET (TARGET_F90
+    ${TARGET_DIR}/bndry_mod.F90
+    ${TARGET_DIR}/derivative_mod.F90
+    ${TARGET_DIR}/edge_mod.F90
+    ${TARGET_DIR}/element_state.F90
+    ${TARGET_DIR}/model_init_mod.F90
+    ${TARGET_DIR}/prim_advection_mod.F90
+    ${TARGET_DIR}/prim_driver_mod.F90
+    ${TARGET_DIR}/viscosity_mod.F90
+    ${PREQX_SHARE_DIR}/element_ops.F90
+    ${PREQX_SHARE_DIR}/prim_advance_mod.F90
+    ${PREQX_SHARE_DIR}/prim_state_mod.F90
+    ${PREQX_SHARE_DIR}/viscosity_preqx_base.F90
+    ${PREQX_SHARE_DIR}/vertremap_mod.F90
+  )
 
-SET(TEST_SRC_F90
-  ${TEST_SRC_DIR}/asp_tests.F90
-  ${TEST_SRC_DIR}/baroclinic_inst_mod.F90
-  ${TEST_SRC_DIR}/dcmip12_wrapper.F90
-  ${TEST_SRC_DIR}/dcmip16_wrapper.F90
-  ${TEST_SRC_DIR}/dcmip2012_test1_2_3.F90
-  ${TEST_SRC_DIR}/dcmip2012_test1_conv.F90
-  ${TEST_SRC_DIR}/dcmip2012_test4.F90
-  ${TEST_SRC_DIR}/dcmip2012_test5.F90
-  ${TEST_SRC_DIR}/dcmip2016-baroclinic.F90
-  ${TEST_SRC_DIR}/dcmip2016-kessler.F90
-  ${TEST_SRC_DIR}/dcmip2016-physics-z.F90
-  ${TEST_SRC_DIR}/dcmip2016-simple-physics-v5.F90
-  ${TEST_SRC_DIR}/dcmip2016-simple-physics-v6.F90
-  ${TEST_SRC_DIR}/dcmip2016-supercell.F90
-  ${TEST_SRC_DIR}/dcmip2016-terminator.F90
-  ${TEST_SRC_DIR}/dcmip2016-tropical-cyclone.F90
-  ${TEST_SRC_DIR}/held_suarez_mod.F90
-  ${TEST_SRC_DIR}/mtests.F90
-)
+  SET (SRC_SHARE_F90
+    ${SRC_SHARE_DIR}/bndry_mod_base.F90
+    ${SRC_SHARE_DIR}/cg_mod.F90
+    ${SRC_SHARE_DIR}/control_mod.F90
+    ${SRC_SHARE_DIR}/coordinate_systems_mod.F90
+    ${SRC_SHARE_DIR}/cube_mod.F90
+    ${SRC_SHARE_DIR}/derivative_mod_base.F90
+    ${SRC_SHARE_DIR}/dimensions_mod.F90
+    ${SRC_SHARE_DIR}/dof_mod.F90
+    ${SRC_SHARE_DIR}/domain_mod.F90
+    ${SRC_SHARE_DIR}/edge_mod_base.F90
+    ${SRC_SHARE_DIR}/edgetype_mod.F90
+    ${SRC_SHARE_DIR}/element_mod.F90
+    ${SRC_SHARE_DIR}/gllfvremap_mod.F90
+    ${SRC_SHARE_DIR}/gllfvremap_util_mod.F90
+    ${SRC_SHARE_DIR}/global_norms_mod.F90
+    ${SRC_SHARE_DIR}/gridgraph_mod.F90
+    ${SRC_SHARE_DIR}/hybrid_mod.F90
+    ${SRC_SHARE_DIR}/hybvcoord_mod.F90
+    ${SRC_SHARE_DIR}/interpolate_mod.F90
+    ${SRC_SHARE_DIR}/kinds.F90
+    ${SRC_SHARE_DIR}/ll_mod.F90
+    ${SRC_SHARE_DIR}/mass_matrix_mod.F90
+    ${SRC_SHARE_DIR}/mesh_mod.F90
+    ${SRC_SHARE_DIR}/sort_mod.F90
+    ${SRC_SHARE_DIR}/metagraph_mod.F90
+    ${SRC_SHARE_DIR}/metis_mod.F90
+    ${SRC_SHARE_DIR}/namelist_mod.F90
+    ${SRC_SHARE_DIR}/parallel_mod.F90
+    ${SRC_SHARE_DIR}/params_mod.F90
+    ${SRC_SHARE_DIR}/physical_constants.F90
+    ${SRC_SHARE_DIR}/physics_mod.F90
+    ${SRC_SHARE_DIR}/prim_advection_base.F90
+    ${SRC_SHARE_DIR}/prim_derived_type_mod.F90
+    ${SRC_SHARE_DIR}/prim_driver_base.F90
+    ${SRC_SHARE_DIR}/prim_implicit_mod.F90
+    ${SRC_SHARE_DIR}/prim_si_mod.F90
+    ${SRC_SHARE_DIR}/quadrature_mod.F90
+    ${SRC_SHARE_DIR}/reduction_mod.F90
+    ${SRC_SHARE_DIR}/schedtype_mod.F90
+    ${SRC_SHARE_DIR}/schedule_mod.F90
+    ${SRC_SHARE_DIR}/solver_mod.F90
+    ${SRC_SHARE_DIR}/spacecurve_mod.F90
+    ${SRC_SHARE_DIR}/thread_mod.F90
+    ${SRC_SHARE_DIR}/time_mod.F90
+    ${SRC_SHARE_DIR}/unit_tests_mod.F90
+    ${SRC_SHARE_DIR}/vertremap_base.F90
+    ${SRC_SHARE_DIR}/viscosity_base.F90
+    ${SRC_SHARE_DIR}/zoltan_mod.F90
+    ${SRC_SHARE_DIR}/sl_advection.F90
+    ${SRC_SHARE_DIR}/compose_mod.F90
+    ${SRC_SHARE_DIR}/compose_test_mod.F90
+    ${SRC_SHARE_DIR}/scalable_grid_init_mod.F90
+  )
 
-SET(PREQX_DEPS_F90
-  ${TARGET_F90}
-  ${SRC_SHARE_F90}
-  ${TEST_SRC_F90}
-  ${SRC_DIR}/checksum_mod.F90
-  ${SRC_DIR}/common_io_mod.F90
-  ${SRC_DIR}/common_movie_mod.F90
-  ${SRC_DIR}/interpolate_driver_mod.F90
-  ${SRC_DIR}/interp_movie_mod.F90
-  ${SRC_DIR}/netcdf_io_mod.F90
-  ${SRC_DIR}/pio_io_mod.F90
-  ${SRC_DIR}/prim_movie_mod.F90
-  ${SRC_DIR}/prim_restart_mod.F90
-  ${SRC_DIR}/repro_sum_mod.F90
-  ${SRC_DIR}/restart_io_mod.F90
-  ${SRC_DIR}/surfaces_mod.F90
-  ${SRC_DIR}/test_mod.F90
-  ${UTILS_SHARE_DIR}/shr_const_mod.F90
-  ${UTILS_SHARE_DIR}/shr_file_mod.F90
-  ${UTILS_SHARE_DIR}/shr_kind_mod.F90
-  ${UTILS_SHARE_DIR}/shr_mpi_mod.F90
-  ${UTILS_SHARE_DIR}/shr_spfn_mod.F90
-  ${UTILS_SHARE_DIR}/shr_sys_mod.F90
-  ${UTILS_SHARE_DIR}/shr_vmath_mod.F90
-)
+  SET(TEST_SRC_F90
+    ${TEST_SRC_DIR}/asp_tests.F90
+    ${TEST_SRC_DIR}/baroclinic_inst_mod.F90
+    ${TEST_SRC_DIR}/dcmip12_wrapper.F90
+    ${TEST_SRC_DIR}/dcmip16_wrapper.F90
+    ${TEST_SRC_DIR}/dcmip2012_test1_2_3.F90
+    ${TEST_SRC_DIR}/dcmip2012_test1_conv.F90
+    ${TEST_SRC_DIR}/dcmip2012_test4.F90
+    ${TEST_SRC_DIR}/dcmip2012_test5.F90
+    ${TEST_SRC_DIR}/dcmip2016-baroclinic.F90
+    ${TEST_SRC_DIR}/dcmip2016-kessler.F90
+    ${TEST_SRC_DIR}/dcmip2016-physics-z.F90
+    ${TEST_SRC_DIR}/dcmip2016-simple-physics-v5.F90
+    ${TEST_SRC_DIR}/dcmip2016-simple-physics-v6.F90
+    ${TEST_SRC_DIR}/dcmip2016-supercell.F90
+    ${TEST_SRC_DIR}/dcmip2016-terminator.F90
+    ${TEST_SRC_DIR}/dcmip2016-tropical-cyclone.F90
+    ${TEST_SRC_DIR}/held_suarez_mod.F90
+    ${TEST_SRC_DIR}/mtests.F90
+  )
 
-SET(PREQX_DEPS_CXX
-  ${SRC_SHARE_DIR}/cxx/CaarFunctor.cpp
-  ${SRC_SHARE_DIR}/cxx/CamForcing.cpp
-  ${SRC_SHARE_DIR}/cxx/Context.cpp
-  ${SRC_SHARE_DIR}/cxx/Derivative.cpp
-  ${SRC_SHARE_DIR}/cxx/Diagnostics.cpp
-  ${SRC_SHARE_DIR}/cxx/Elements.cpp
-  ${SRC_SHARE_DIR}/cxx/ErrorDefs.cpp
-  ${SRC_SHARE_DIR}/cxx/EulerStepFunctor.cpp
-  ${SRC_SHARE_DIR}/cxx/ExecSpaceDefs.cpp
-  ${SRC_SHARE_DIR}/cxx/Hommexx_Session.cpp
-  ${SRC_SHARE_DIR}/cxx/HybridVCoord.cpp
-  ${SRC_SHARE_DIR}/cxx/HyperviscosityFunctor.cpp
-  ${SRC_SHARE_DIR}/cxx/HyperviscosityFunctorImpl.cpp
-  ${SRC_SHARE_DIR}/cxx/Tracers.cpp
-  ${SRC_SHARE_DIR}/cxx/VerticalRemapManager.cpp
-  ${SRC_SHARE_DIR}/cxx/cxx_f90_interface.cpp
-  ${SRC_SHARE_DIR}/cxx/mpi/BoundaryExchange.cpp
-  ${SRC_SHARE_DIR}/cxx/mpi/BuffersManager.cpp
-  ${SRC_SHARE_DIR}/cxx/mpi/Comm.cpp
-  ${SRC_SHARE_DIR}/cxx/mpi/Connectivity.cpp
-  ${SRC_SHARE_DIR}/cxx/mpi/MpiContext.cpp
-  ${SRC_SHARE_DIR}/cxx/mpi/mpi_cxx_f90_interface.cpp
-  ${SRC_SHARE_DIR}/cxx/prim_advance_exp.cpp
-  ${SRC_SHARE_DIR}/cxx/prim_advec_tracers_remap.cpp
-  ${SRC_SHARE_DIR}/cxx/prim_driver.cpp
-  ${SRC_SHARE_DIR}/cxx/prim_step.cpp
-  ${SRC_SHARE_DIR}/cxx/vertical_remap.cpp
-)
+  SET(PREQX_DEPS_F90
+    ${TARGET_F90}
+    ${SRC_SHARE_F90}
+    ${TEST_SRC_F90}
+    ${SRC_DIR}/checksum_mod.F90
+    ${SRC_DIR}/repro_sum_mod.F90
+    ${SRC_DIR}/surfaces_mod.F90
+    ${UTILS_TIMING_SRC_DIR}/perf_mod.F90
+    ${UTILS_TIMING_SRC_DIR}/perf_utils.F90
+    ${UTILS_SHARE_DIR}/shr_kind_mod.F90
+    ${UTILS_SHARE_DIR}/shr_sys_mod.F90
+    ${UTILS_SHARE_DIR}/shr_mpi_mod.F90
+  )
 
-IF (${HOMME_USE_TRILINOS})
-  SET (PREQX_SRCS_ZOLTAN   ${TRILINOS_ZOLTAN_DIR}/zoltan_interface.c  ${TRILINOS_ZOLTAN_DIR}/zoltan_cppinterface.cpp)
-  SET_SOURCE_FILES_PROPERTIES( ${TRILINOS_ZOLTAN_DIR}/zoltan_cppinterface.cpp PROPERTIES LANGUAGE CXX )
-ENDIF()
+  SET(PREQX_DEPS_CXX
+    ${SRC_SHARE_DIR}/cxx/CaarFunctor.cpp
+    ${SRC_SHARE_DIR}/cxx/CamForcing.cpp
+    ${SRC_SHARE_DIR}/cxx/Context.cpp
+    ${SRC_SHARE_DIR}/cxx/Derivative.cpp
+    ${SRC_SHARE_DIR}/cxx/Diagnostics.cpp
+    ${SRC_SHARE_DIR}/cxx/Elements.cpp
+    ${SRC_SHARE_DIR}/cxx/ErrorDefs.cpp
+    ${SRC_SHARE_DIR}/cxx/EulerStepFunctor.cpp
+    ${SRC_SHARE_DIR}/cxx/ExecSpaceDefs.cpp
+    ${SRC_SHARE_DIR}/cxx/Hommexx_Session.cpp
+    ${SRC_SHARE_DIR}/cxx/HybridVCoord.cpp
+    ${SRC_SHARE_DIR}/cxx/HyperviscosityFunctor.cpp
+    ${SRC_SHARE_DIR}/cxx/HyperviscosityFunctorImpl.cpp
+    ${SRC_SHARE_DIR}/cxx/Tracers.cpp
+    ${SRC_SHARE_DIR}/cxx/VerticalRemapManager.cpp
+    ${SRC_SHARE_DIR}/cxx/cxx_f90_interface.cpp
+    ${SRC_SHARE_DIR}/cxx/mpi/BoundaryExchange.cpp
+    ${SRC_SHARE_DIR}/cxx/mpi/BuffersManager.cpp
+    ${SRC_SHARE_DIR}/cxx/mpi/Comm.cpp
+    ${SRC_SHARE_DIR}/cxx/mpi/Connectivity.cpp
+    ${SRC_SHARE_DIR}/cxx/mpi/MpiContext.cpp
+    ${SRC_SHARE_DIR}/cxx/mpi/mpi_cxx_f90_interface.cpp
+    ${SRC_SHARE_DIR}/cxx/prim_advance_exp.cpp
+    ${SRC_SHARE_DIR}/cxx/prim_advec_tracers_remap.cpp
+    ${SRC_SHARE_DIR}/cxx/prim_driver.cpp
+    ${SRC_SHARE_DIR}/cxx/prim_step.cpp
+    ${SRC_SHARE_DIR}/cxx/vertical_remap.cpp
+  )
 
-# If the user specified a file for custom compiler options use those
-IF (DEFINED PREQX_CUSTOM_FLAGS_FILE)
-  setCustomCompilerFlags(PREQX_CUSTOM_FLAGS_FILE PREQX_SRCS_F90)
-ENDIF ()
+  IF (${HOMME_USE_TRILINOS})
+    SET (PREQX_SRCS_ZOLTAN   ${TRILINOS_ZOLTAN_DIR}/zoltan_interface.c  ${TRILINOS_ZOLTAN_DIR}/zoltan_cppinterface.cpp)
+    SET_SOURCE_FILES_PROPERTIES( ${TRILINOS_ZOLTAN_DIR}/zoltan_cppinterface.cpp PROPERTIES LANGUAGE CXX )
+  ENDIF()
 
-# We pulled prim_main off the deps cause it would create a main function
-# clash when building the unit test (a main in prim_main.F90 and one in tester.cpp)
-SET(PREQX_DEPS
-  ${TARGET_F90}
-  ${PREQX_DEPS_F90}
-  ${PREQX_DEPS_CXX}
-)
+  # If the user specified a file for custom compiler options use those
+  IF (DEFINED PREQX_CUSTOM_FLAGS_FILE)
+    setCustomCompilerFlags(PREQX_CUSTOM_FLAGS_FILE PREQX_SRCS_F90)
+  ENDIF ()
 
-SET(EXEC_SOURCES ${PREQX_DEPS} ${SRC_DIR}/prim_main.F90)
+  # We pulled prim_main off the deps cause it would create a main function
+  # clash when building the unit test (a main in prim_main.F90 and one in tester.cpp)
+  SET(PREQX_DEPS
+    ${TARGET_F90}
+    ${PREQX_DEPS_F90}
+    ${PREQX_DEPS_CXX}
+  )
 
-# Set up defaults if they are not given
-IF (NOT PREQX_NP)
-  SET (PREQX_NP 4)
-ENDIF ()
-IF (NOT PREQX_PLEV)
-  SET (PREQX_PLEV 20)
-ENDIF ()
-IF (NOT PREQX_USE_PIO)
-  SET (PREQX_USE_PIO FALSE)
-ENDIF ()
-IF (NOT PREQX_USE_ENERGY)
-  SET (PREQX_USE_ENERGY FALSE)
-ENDIF ()
-#this should be removed later
-IF (NOT PREQX_NC)
-  SET (PREQX_NC 4)
-ENDIF ()
-IF (NOT QSIZE_D)
-  SET (QSIZE_D 4)
-ENDIF ()
-# for some of matt's old scripts which use preqx_qsize_d
-IF (PREQX_QSIZE_D)      
-  SET (QSIZE_D ${PREQX_QSIZE_D})
-ENDIF ()
+  SET(EXEC_SOURCES
+      ${PREQX_DEPS}
+      ${UTILS_SHARE_DIR}/shr_const_mod.F90
+      ${UTILS_SHARE_DIR}/shr_file_mod.F90
+      ${UTILS_SHARE_DIR}/shr_spfn_mod.F90
+      ${UTILS_SHARE_DIR}/shr_vmath_mod.F90
+      ${SRC_DIR}/test_mod.F90
+      ${SRC_DIR}/restart_io_mod.F90
+      ${SRC_DIR}/common_io_mod.F90
+      ${SRC_DIR}/common_movie_mod.F90
+      ${SRC_DIR}/interpolate_driver_mod.F90
+      ${SRC_DIR}/interp_movie_mod.F90
+      ${SRC_DIR}/netcdf_io_mod.F90
+      ${SRC_DIR}/pio_io_mod.F90
+      ${SRC_DIR}/prim_movie_mod.F90
+      ${SRC_DIR}/prim_restart_mod.F90
+      ${SRC_DIR}/prim_main.F90
+  )
 
-SET(USE_OPENACC FALSE)
+  # Set up defaults if they are not given
+  IF (NOT PREQX_NP)
+    SET (PREQX_NP 4)
+  ENDIF ()
+  IF (NOT PREQX_PLEV)
+    SET (PREQX_PLEV 20)
+  ENDIF ()
+  IF (NOT PREQX_USE_PIO)
+    SET (PREQX_USE_PIO FALSE)
+  ENDIF ()
+  IF (NOT PREQX_USE_ENERGY)
+    SET (PREQX_USE_ENERGY FALSE)
+  ENDIF ()
+  #this should be removed later
+  IF (NOT PREQX_NC)
+    SET (PREQX_NC 4)
+  ENDIF ()
+  IF (NOT QSIZE_D)
+    SET (QSIZE_D 4)
+  ENDIF ()
+  # for some of matt's old scripts which use preqx_qsize_d
+  IF (PREQX_QSIZE_D)
+    SET (QSIZE_D ${PREQX_QSIZE_D})
+  ENDIF ()
+
+  SET(USE_OPENACC FALSE)
 
 ENDMACRO(PREQX_KOKKOS_SETUP)
 
@@ -234,3 +243,8 @@ IF (${HOMME_BUILD_EXECS})
   createTestExec(preqx_kokkos preqx_kokkos ${PREQX_NP} ${PREQX_NC} ${PREQX_PLEV} ${PREQX_USE_PIO}  ${PREQX_USE_ENERGY} ${QSIZE_D})
 ENDIF ()
 
+IF (HOMME_BUILD_LIBS)
+  PREQX_KOKKOS_SETUP()
+  createExecLib(preqx_kokkos_lib preqx_kokkos "${PREQX_DEPS}" "${EXEC_LIB_INCLUDE_DIRS}"
+      ${PREQX_NP} ${PREQX_PLEV} ${PREQX_USE_ENERGY} ${QSIZE_D})
+ENDIF ()

--- a/components/homme/test_execs/CMakeLists.txt
+++ b/components/homme/test_execs/CMakeLists.txt
@@ -134,7 +134,9 @@ ADD_CUSTOM_TARGET(check
                   COMMAND ${CMAKE_CTEST_COMMAND} "--output-on-failure")
 
 # Force cprnc to be built when make check is run
-ADD_DEPENDENCIES(check cprnc)
+IF (TARGET cprnc)
+  ADD_DEPENDENCIES(check cprnc)
+ENDIF ()
 
 # Create a target for making the reference data
 ADD_CUSTOM_TARGET(baseline


### PR DESCRIPTION
This PR allows one to configure Homme via cmake, without building executables, and building 'libraries' instead.

This can be handy if Homme is built as part of a larger cmake project (namely, E3SM, or SCREAM), so that we can simply link against homme's pre-built library, without injecting much of its targets setting into the host project (i.e., simply doing `target_link_library(my_tgt $my_homme_lib)` should be all you need).