### PR TITLE
Enable CRM friction 

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1174,7 +1174,7 @@
 <srf_flux_avg eddy_scheme="HBR"      >0</srf_flux_avg>
 <srf_flux_avg eddy_scheme="diag_TKE" >0</srf_flux_avg>
 <srf_flux_avg eddy_scheme="CLUBB_SGS">0</srf_flux_avg>
-<srf_flux_avg use_MMF="1"          >1</srf_flux_avg>
+<srf_flux_avg use_MMF="1"          >0</srf_flux_avg>
 
 <!-- MMF CRM mean state acceleration -->
 <use_crm_accel    use_MMF="0">.false.</use_crm_accel>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2-MMF-1mom.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2-MMF-1mom.xml
@@ -86,10 +86,6 @@
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
 
-<!-- Super-Parameterization -->
-<!-- Without srf_flux_avg=1 the SP model develops unstable oscillations near the surface -->
-<srf_flux_avg>1</srf_flux_avg>>
-
 <!-- Prescribed aerosols -->
 <prescribed_aero_datapath>atm/cam/chem/trop_mam/aero</prescribed_aero_datapath>
 <prescribed_aero_file>mam4_0.9x1.2_L72_2000clim_c170323.nc</prescribed_aero_file>

--- a/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2-MMF-2mom.xml
+++ b/components/cam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2-MMF-2mom.xml
@@ -86,10 +86,6 @@
 <mg_prc_coeff_fix        >.true.</mg_prc_coeff_fix>
 <rrtmg_temp_fix          >.true.</rrtmg_temp_fix>
 
-<!-- Super-Parameterization -->
-<!-- Without srf_flux_avg=1 the SP model develops unstable oscillations near the surface -->
-<srf_flux_avg>1</srf_flux_avg>>
-
 <!-- External forcing for BAM or MAM -->
 <soag_ext_file	 ver="mam" >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_2000_c160427.nc</soag_ext_file>
 

--- a/components/cam/src/physics/crm/sam/params.F90
+++ b/components/cam/src/physics/crm/sam/params.F90
@@ -59,7 +59,7 @@ module params
   logical:: doprecip      = .true.    ! allow precipitation
   logical:: dodamping     = .true.    ! Newtonian damping for upper levels
   logical:: dosgs         = .true.    ! sub-grid turbulence scheme
-  logical:: dosurface     = .false.   ! surface scheme to calculate friction within CRM
+  logical:: dosurface     = .true.    ! surface scheme to calculate friction within CRM
 
   logical:: docoriolis    = .false.   ! not normally used for MMF
   logical:: dowallx       = .false.   ! not normally used for MMF


### PR DESCRIPTION
The MMF is almost always run in a 2D configuration in which momentum fields are un-coupled, and so surface friction is felt very indirectly and often does not match the direction of near-surface wind in the CRM, which can lead to unrealistic boundary layer structures. This PR enables a pre-existing CRM friction calculation to be on by default, which does not affect the MMF coupling or double count the actual friction because the momentum fields remain uncoupled. Eventually the ESMT scheme will handle all convective momentum transport in all MMF configurations after we port it to SAM++ and validate that it runs well on GPUs. 

[non-BFB]