### PR TITLE
Turn on ocean Redi mixing. Includes minor bug fixes.

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -114,7 +114,7 @@
 <config_Leith_visc2_max>2.5e3</config_Leith_visc2_max>
 
 <!-- Redi_isopycnal_mixing -->
-<config_use_Redi>.false.</config_use_Redi>
+<config_use_Redi>.true.</config_use_Redi>
 <config_use_Redi ocn_grid="oRRS30to10">.false.</config_use_Redi>
 <config_use_Redi ocn_grid="oRRS30to10v3">.false.</config_use_Redi>
 <config_use_Redi ocn_grid="oRRS30to10wLI">.false.</config_use_Redi>


### PR DESCRIPTION
Turn on Redi mixing by default, making this non-bfb.

Several bug fixes during testing with Redi on:
1. Fixes Redi decomposition error in k33. See https://github.com/MPAS-Dev/MPAS-Model/pull/620
1. improves Redi Kappa variable names and descriptions
1. Use of k rather than N after a k loop. This is a typo, but turns out to be bit-for-bit change. See https://github.com/MPAS-Dev/MPAS-Model/pull/567
1. Index fix to remove warnings from analysis members



[NML]
[non-BFB]