### PR TITLE
Replace 'sqs -f' call with 'scontrol show jobid' on NERSC systems

### DIFF
--- a/cime/scripts/lib/CIME/provenance.py
+++ b/cime/scripts/lib/CIME/provenance.py
@@ -170,7 +170,7 @@ def _save_prerun_timing_e3sm(case, lid):
                 run_cmd_no_fail(cmd, arg_stdout=filename, from_dir=full_timing_dir)
                 gzip_existing_file(os.path.join(full_timing_dir, filename))
         elif mach in ["cori-haswell", "cori-knl"]:
-            for cmd, filename in [("sinfo -a -l", "sinfol"), ("sqs -f %s" % job_id, "sqsf_jobid"),
+            for cmd, filename in [("sinfo -a -l", "sinfol"), ("scontrol show jobid %s" % job_id, "sqsf_jobid"),
                                   # ("sqs -f", "sqsf"),
                                   ("squeue -o '%.10i %.15P %.20j %.10u %.7a %.2t %.6D %.8C %.10M %.10l %.20S %.20V'", "squeuef"),
                                   ("squeue -t R -o '%.10i %R'", "squeues")]:

--- a/cime_config/machines/syslog.cori-haswell
+++ b/cime_config/machines/syslog.cori-haswell
@@ -13,7 +13,7 @@ set dir = $6
 # Target length was determined empirically (maximum number of lines before job mapping 
 #  information starts + number of nodes), and it may need to be adjusted in the future.
 # (Note that calling script 'touch'es the e3sm log file before spawning this script, so that 'wc' does not fail.)
-set nnodes = `sqs -f $jid | grep -F NumNodes | sed 's/ *NumNodes=\([0-9]*\) .*/\1/' `
+set nnodes = `scontrol show jobid $jid | grep -F NumNodes | sed 's/ *NumNodes=\([0-9]*\) .*/\1/' `
 @ target_lines = 150 + $nnodes
 sleep 10
 set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
@@ -22,7 +22,7 @@ while ($outlth < $target_lines)
   set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
 end
 
-set TimeLimit   = `sqs -f $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set TimeLimit   = `scontrol show jobid $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set limit_hours = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set limit_mins  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set limit_secs  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -31,7 +31,7 @@ if ("X$limit_mins" == "X")  set limit_mins  = 0
 if ("X$limit_secs" == "X")  set limit_secs  = 0
 @ limit = 3600 * $limit_hours + 60 * $limit_mins + $limit_secs
 
-set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -78,7 +78,7 @@ while ($remaining > 0)
    @ sleep_remaining = $sleep_remaining - 120
   end
   sleep $sleep_remaining
-  set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+  set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
   set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
   set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
   set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `

--- a/cime_config/machines/syslog.cori-knl
+++ b/cime_config/machines/syslog.cori-knl
@@ -13,7 +13,7 @@ set dir = $6
 # Target length was determined empirically (maximum number of lines before job mapping 
 #  information starts + number of nodes), and it may need to be adjusted in the future.
 # (Note that calling script 'touch'es the e3sm log file before spawning this script, so that 'wc' does not fail.)
-set nnodes = `sqs -f $jid | grep -F NumNodes | sed 's/ *NumNodes=\([0-9]*\) .*/\1/' `
+set nnodes = `scontrol show jobid $jid | grep -F NumNodes | sed 's/ *NumNodes=\([0-9]*\) .*/\1/' `
 @ target_lines = 150 + $nnodes
 sleep 10
 set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
@@ -22,7 +22,7 @@ while ($outlth < $target_lines)
   set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
 end
 
-set TimeLimit   = `sqs -f $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set TimeLimit   = `scontrol show jobid $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set limit_hours = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set limit_mins  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set limit_secs  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -31,7 +31,7 @@ if ("X$limit_mins" == "X")  set limit_mins  = 0
 if ("X$limit_secs" == "X")  set limit_secs  = 0
 @ limit = 3600 * $limit_hours + 60 * $limit_mins + $limit_secs
 
-set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -78,7 +78,7 @@ while ($remaining > 0)
    @ sleep_remaining = $sleep_remaining - 120
   end
   sleep $sleep_remaining
-  set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+  set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
   set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
   set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
   set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `


### PR DESCRIPTION
A recent update to NERSC system software removed the '-f' option
from the sqs command. 'sqs -f' is called from provenance.py for
both cori-knl and cori-haswell, causing job submission to fail
on those systems. 'sqs -f' is also called within the job progress
monitoring scripts syslog.cori-knl and syslog.cori-haswell,
which will cause these scripts to abort (though this will not affect
a running model). 'sqs -f' is equivalent to 'scontrol show jobid',
so here 'sqs -f' is replaced by 'scontrol show jobid' in provenance.py
and in the job progress monitoring scripts. Note that the output
from 'scontrol show jobid' that is captured in provenance.py is
still saved in a file with the original name (sqsf_jobid.$lid),
because this name is looked for in the performance archiving
postprocessing scripts.

[BFB]

Fixes #3699 
