### PR TITLE
Updating Scorpio to version 1.1.2

### DIFF
--- a/components/homme/CMakeLists.txt
+++ b/components/homme/CMakeLists.txt
@@ -104,7 +104,7 @@ OPTION(BUILD_HOMME_SWIM  "Shallow water equations implicit" OFF)
 OPTION(BUILD_HOMME_PRIM  "Primitive equations implicit" OFF)
 OPTION(BUILD_HOMME_TOOL  "Offline tool" ON)
 OPTION(HOMME_ENABLE_COMPOSE "Build COMPOSE semi-Lagrangian tracer transport code" ON)
-OPTION(HOMME_USE_SCORPIO  "Use Scorpio as the I/O library (the default I/O library used is \"Scorpio classic\")" OFF)
+OPTION(HOMME_USE_SCORPIO  "Use Scorpio as the I/O library (Disable to use Scorpio classic)" ON)
 
 #by default we don't need cxx
 SET(HOMME_USE_CXX FALSE)


### PR DESCRIPTION
Updating the version of Scorpio to 1.1.2 . This new release
includes,

* Fix for a memory corruption issue with the BOX rearranger
  This fix is required for ne30 pg2 production runs (see #3684),
  ne1024 pg2 runs (see E3SM-Project/scorpio#323) and standalone
  HOMME (see E3SM-Project/scorpio#324)
* Increases the range of I/O decomposition ids allowed. This fix
  is required for some long running simulations
  (see E3SM-Project/scorpio#315)

Also changing the default I/O library in HOMME to Scorpio.

Fixes #3684 

[BFB]