### PR TITLE
Fix issue with sqs on Cori in maint-1.0

### DIFF
--- a/cime/config/e3sm/machines/syslog.cori-haswell
+++ b/cime/config/e3sm/machines/syslog.cori-haswell
@@ -20,7 +20,7 @@ while ($outlth < $outtarget)
   set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
 end
 
-set TimeLimit   = `sqs -f $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set TimeLimit   = `scontrol show jobid $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set limit_hours = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set limit_mins  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set limit_secs  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -29,7 +29,7 @@ if ("X$limit_mins" == "X")  set limit_mins  = 0
 if ("X$limit_secs" == "X")  set limit_secs  = 0
 @ limit = 3600 * $limit_hours + 60 * $limit_mins + $limit_secs
 
-set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -68,7 +68,7 @@ while ($remaining > 0)
   # squeue -t R -o  "%.10i %R" > $dir/squeueR.$lid.$remaining
   chmod a+r $dir/*
   sleep $sample_interval
-  set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+  set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
   set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
   set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
   set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `

--- a/cime/config/e3sm/machines/syslog.cori-knl
+++ b/cime/config/e3sm/machines/syslog.cori-knl
@@ -20,7 +20,7 @@ while ($outlth < $outtarget)
   set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
 end
 
-set TimeLimit   = `sqs -f $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set TimeLimit   = `scontrol show jobid $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set limit_hours = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set limit_mins  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set limit_secs  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -29,7 +29,7 @@ if ("X$limit_mins" == "X")  set limit_mins  = 0
 if ("X$limit_secs" == "X")  set limit_secs  = 0
 @ limit = 3600 * $limit_hours + 60 * $limit_mins + $limit_secs
 
-set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -68,7 +68,7 @@ while ($remaining > 0)
   # squeue -t R -o  "%.10i %R" > $dir/squeueR.$lid.$remaining
   chmod a+r $dir/*
   sleep $sample_interval
-  set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+  set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
   set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
   set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
   set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `

--- a/cime/scripts/lib/CIME/provenance.py
+++ b/cime/scripts/lib/CIME/provenance.py
@@ -148,8 +148,8 @@ def _save_prerun_timing_e3sm(case, lid):
                 run_cmd_no_fail(cmd, arg_stdout=filename, from_dir=full_timing_dir)
                 gzip_existing_file(os.path.join(full_timing_dir, filename))
         elif mach in ["edison", "cori-haswell", "cori-knl"]:
-            for cmd, filename in [("sinfo -a -l", "sinfol"), ("sqs -f %s" % job_id, "sqsf_jobid"),
-                                  # ("sqs -f", "sqsf"),
+            for cmd, filename in [("sinfo -a -l", "sinfol"), ("scontrol show jobid %s" % job_id, "sqsf_jobid"),
+                                  # ("scontrol show jobid", "sqsf"),
                                   ("squeue -o '%.10i %.15P %.20j %.10u %.7a %.2t %.6D %.8C %.10M %.10l %.20S %.20V'", "squeuef"),
                                   ("squeue -t R -o '%.10i %R'", "squeues")]:
                 filename = "%s.%s" % (filename, lid)

--- a/cime/src/components/data_comps/datm/cime_config/buildlib
+++ b/cime/src/components/data_comps/datm/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/data_comps/desp/cime_config/buildlib
+++ b/cime/src/components/data_comps/desp/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/data_comps/dice/cime_config/buildlib
+++ b/cime/src/components/data_comps/dice/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/data_comps/dlnd/cime_config/buildlib
+++ b/cime/src/components/data_comps/dlnd/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/data_comps/docn/cime_config/buildlib
+++ b/cime/src/components/data_comps/docn/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/data_comps/drof/cime_config/buildlib
+++ b/cime/src/components/data_comps/drof/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/data_comps/dwav/cime_config/buildlib
+++ b/cime/src/components/data_comps/dwav/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/stub_comps/satm/cime_config/buildlib
+++ b/cime/src/components/stub_comps/satm/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/stub_comps/sesp/cime_config/buildlib
+++ b/cime/src/components/stub_comps/sesp/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/stub_comps/sglc/cime_config/buildlib
+++ b/cime/src/components/stub_comps/sglc/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/stub_comps/sice/cime_config/buildlib
+++ b/cime/src/components/stub_comps/sice/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/stub_comps/slnd/cime_config/buildlib
+++ b/cime/src/components/stub_comps/slnd/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/stub_comps/socn/cime_config/buildlib
+++ b/cime/src/components/stub_comps/socn/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/stub_comps/srof/cime_config/buildlib
+++ b/cime/src/components/stub_comps/srof/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/stub_comps/swav/cime_config/buildlib
+++ b/cime/src/components/stub_comps/swav/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/xcpl_comps/xatm/cime_config/buildlib
+++ b/cime/src/components/xcpl_comps/xatm/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/xcpl_comps/xglc/cime_config/buildlib
+++ b/cime/src/components/xcpl_comps/xglc/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/xcpl_comps/xice/cime_config/buildlib
+++ b/cime/src/components/xcpl_comps/xice/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/xcpl_comps/xlnd/cime_config/buildlib
+++ b/cime/src/components/xcpl_comps/xlnd/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/xcpl_comps/xocn/cime_config/buildlib
+++ b/cime/src/components/xcpl_comps/xocn/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/xcpl_comps/xrof/cime_config/buildlib
+++ b/cime/src/components/xcpl_comps/xrof/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/cime/src/components/xcpl_comps/xwav/cime_config/buildlib
+++ b/cime/src/components/xcpl_comps/xwav/cime_config/buildlib
@@ -1,1 +1,35 @@
-../../../../build_scripts/buildlib.internal_components
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = dir1.split('.')[1]
+        build_cime_component_lib(case, compname, libroot, bldroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    buildlib(caseroot, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)


### PR DESCRIPTION
After Cori maintenance, the version of slurm was updated which no longer supports the `-f` option to `sqs`
This command is used for job provenance.

This PR simply replaces "sqs -f" with "scontrol show jobid" in a few files.

[bfb]