### PR TITLE
cmake: add much-improved support for removing flags and deoptimizing files

### DIFF
--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -779,7 +779,7 @@ flags should be captured within MPAS CMake files.
     <base>-lstdc++</base>
   </CXX_LIBS>
   <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} $SHELL{$ENV{NETCDF_C_PATH}/bin/nc-config --libs}</append> 
+    <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} $SHELL{$ENV{NETCDF_C_PATH}/bin/nc-config --libs}</append>
     <append>-L$ENV{MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_gf_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl</append>
   </SLIBS>
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
@@ -957,33 +957,6 @@ flags should be captured within MPAS CMake files.
   </SLIBS>
 </compiler>
 
-<compiler MACH="cetus" COMPILER="ibm">
-  <ALBANY_PATH>/projects/ccsm/libs/AlbanyTrilinos/Albany/build/install</ALBANY_PATH>
-  <CPPDEFS>
-    <append> -DMPASLI_EXTERNAL_INTERFACE_DISABLE_MANGLING </append>
-  </CPPDEFS>
-  <CXX_LIBS>
-    <base> -llapack -lblas -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </base>
-  </CXX_LIBS>
-  <CXX_LINKER>CXX</CXX_LINKER>
-  <HDF5_PATH>/soft/libraries/hdf5/1.8.14/cnk-xl/current/</HDF5_PATH>
-  <LD> mpixlf77_r </LD>
-  <MPICC> mpixlc_r </MPICC>
-  <MPICXX> /soft/compilers/bgclang/mpi/bgclang/bin/mpic++11 </MPICXX>
-  <MPIFC> mpixlf2003_r </MPIFC>
-  <NETCDF_PATH>/soft/libraries/netcdf/4.3.3-f4.4.1/cnk-xl/current/</NETCDF_PATH>
-  <PETSC_PATH>/soft/libraries/petsc/3.5.3.1</PETSC_PATH>
-  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH>/soft/libraries/pnetcdf/1.6.0/cnk-xl/current/</PNETCDF_PATH>
-  <SCC> mpixlc_r </SCC>
-  <SFC> mpixlf2003_r </SFC>
-  <SLIBS>
-    <append>-L$NETCDF_PATH/lib -lnetcdff -lnetcdf -L$HDF5_PATH/lib -lhdf5_hl -lhdf5 -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
-    <append compile_threaded="TRUE"> -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
-  </SLIBS>
-  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
-</compiler>
-
 <compiler MACH="constance" COMPILER="intel">
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
@@ -1123,7 +1096,7 @@ flags should be captured within MPAS CMake files.
     <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="TRUE"> -O0 -g </append>
     <append DEBUG="FALSE"> -O2 </append>
-  </CXXFLAGS>    
+  </CXXFLAGS>
   <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
   <SCC> icc </SCC>
   <SCXX> icpc </SCXX>
@@ -1156,7 +1129,7 @@ flags should be captured within MPAS CMake files.
     <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="TRUE"> -O0 -g </append>
     <append DEBUG="FALSE"> -O2 </append>
-  </CXXFLAGS>  
+  </CXXFLAGS>
   <MPICC MPILIB="impi"> mpiicc </MPICC>
   <MPICXX MPILIB="impi"> mpiicpc </MPICXX>
   <MPIFC MPILIB="impi"> mpiifort </MPIFC>
@@ -1169,59 +1142,6 @@ flags should be captured within MPAS CMake files.
   <SLIBS>
     <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
     <append> -mkl -lpthread </append>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="eastwind" COMPILER="pgi">
-  <CFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <CPPDEFS>
-    <append> -DLINUX </append>
-  </CPPDEFS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </FFLAGS>
-  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
-  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <SLIBS>
-    <base> -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -lpmi </base>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="eddi" COMPILER="gnu">
-  <CPPDEFS>
-    <append COMP_NAME="gptl"> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY -DHAVE_BACKTRACE </append>
-  </CPPDEFS>
-  <NETCDF_PATH>$ENV{NETCDF_HOME}</NETCDF_PATH>
-  <SLIBS>
-    <append> -L$ENV{NETCDF_HOME}/lib/ -lnetcdff -lnetcdf -lcurl -llapack -lblas </append>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="eos" COMPILER="intel">
-  <CFLAGS>
-    <append DEBUG="FALSE"> -O2  </append>
-  </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <CPPDEFS>
-    <append COMP_NAME="gptl"> -DHAVE_PAPI </append>
-  </CPPDEFS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2  </append>
-    <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </append>
-  </FFLAGS>
-  <MPICC> cc </MPICC>
-  <MPICXX> CC </MPICXX>
-  <MPIFC> ftn </MPIFC>
-  <SLIBS>
-    <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
-    <append> $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </append>
   </SLIBS>
 </compiler>
 
@@ -1453,7 +1373,7 @@ flags should be captured within MPAS CMake files.
   </SLIBS>
 </compiler>
 
-<compiler COMPILER="gnu" MACH="snl-white">
+<compiler MACH="snl-white" COMPILER="gnu">
   <SCXX>$ENV{E3SM_SRCROOT}/externals/kokkos/bin/nvcc_wrapper</SCXX>
   <MPICXX>$ENV{E3SM_SRCROOT}/externals/kokkos/bin/nvcc_wrapper</MPICXX>
   <KOKKOS_OPTIONS> --arch=Pascal60 --with-cuda=$ENV{CUDA_ROOT} --with-cuda-options=enable_lambda </KOKKOS_OPTIONS>
@@ -1466,7 +1386,7 @@ flags should be captured within MPAS CMake files.
   </SLIBS>
 </compiler>
 
-<compiler COMPILER="intel18" MACH="snl-blake">
+<compiler MACH="snl-blake" COMPILER="intel18">
   <CPPDEFS>
     <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL </append>
   </CPPDEFS>
@@ -1512,137 +1432,6 @@ flags should be captured within MPAS CMake files.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
-<compiler MACH="mesabi" COMPILER="intel">
-  <CFLAGS>
-    <base> -O2 -fp-model precise -I/soft/intel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/inc
-lude </base>
-    <append compile_threaded="TRUE"> -openmp </append>
-  </CFLAGS>
-  <CPPDEFS>
-    <append> -DFORTRANUNDERSCORE -DNO_R16</append>
-    <append> -DCPRINTEL </append>
-  </CPPDEFS>
-  <CXX_LDFLAGS>
-    <base> -cxxlib </base>
-  </CXX_LDFLAGS>
-  <CXX_LINKER>FORTRAN</CXX_LINKER>
-  <FC_AUTO_R8>
-    <base> -r8 </base>
-  </FC_AUTO_R8>
-  <FFLAGS>
-    <base> -fp-model source -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -I/soft/i
-ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
-    <append compile_threaded="TRUE"> -openmp </append>
-    <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 </append>
-    <append DEBUG="FALSE"> -O2 </append>
-  </FFLAGS>
-  <FIXEDFLAGS>
-    <base> -fixed -132 </base>
-  </FIXEDFLAGS>
-  <FREEFLAGS>
-    <base> -free </base>
-  </FREEFLAGS>
-  <LDFLAGS>
-    <append compile_threaded="TRUE"> -openmp </append>
-    <append> -lnetcdff </append>
-  </LDFLAGS>
-  <MPICC> mpiicc  </MPICC>
-  <MPICXX> mpiicpc </MPICXX>
-  <MPIFC> mpiifort </MPIFC>
-  <SCC> icc </SCC>
-  <SCXX> icpc </SCXX>
-  <SFC> ifort </SFC>
-  <SLIBS>
-    <append>-L/soft/netcdf/fortran-4.4-intel-sp1-update3-parallel/lib -lnetcdff -L/soft/hdf5/hdf5-1.8.13-intel-2013-sp1-update3-impi-5.0.0.028/lib -openmp -fPIC -lnetcdf -lnetcdf -L/soft/intel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_intel_thread -lpthread -lm </append>
-  </SLIBS>
-  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
-</compiler>
-
-<compiler MACH="mira" COMPILER="ibm">
-  <ALBANY_PATH>/projects/ccsm/libs/AlbanyTrilinos/Albany/build/install</ALBANY_PATH>
-  <CPPDEFS>
-    <append> -DMPASLI_EXTERNAL_INTERFACE_DISABLE_MANGLING </append>
-  </CPPDEFS>
-  <CXX_LIBS>
-    <base> -llapack -lblas -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </base>
-  </CXX_LIBS>
-  <CXX_LINKER>CXX</CXX_LINKER>
-  <HDF5_PATH>/soft/libraries/hdf5/1.8.14/cnk-xl/current/</HDF5_PATH>
-  <!-- This LD is a workaround for darshan initialization on mira (Darshan does -->
-  <!-- not run if f90 or higher is used for linking -->
-  <LD> mpixlf77_r </LD>
-  <MPICC> mpixlc_r </MPICC>
-  <MPICXX> /soft/compilers/bgclang/mpi/bgclang/bin/mpic++11 </MPICXX>
-  <MPIFC> mpixlf2003_r </MPIFC>
-  <NETCDF_PATH>/soft/libraries/netcdf/4.3.3-f4.4.1/cnk-xl/current/</NETCDF_PATH>
-  <PETSC_PATH>/soft/libraries/petsc/3.5.3.1</PETSC_PATH>
-  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH>/soft/libraries/pnetcdf/1.6.0/cnk-xl/current/</PNETCDF_PATH>
-  <SCC> mpixlc_r </SCC>
-  <SFC> mpixlf2003_r </SFC>
-  <SLIBS>
-    <append>-L$NETCDF_PATH/lib -lnetcdff -lnetcdf -L$HDF5_PATH/lib -lhdf5_hl -lhdf5 -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
-    <append compile_threaded="TRUE"> -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
-  </SLIBS>
-  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
-</compiler>
-
-<compiler MACH="oic5" COMPILER="gnu">
-  <MPICC>/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpicc</MPICC>
-  <MPIFC>/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpif90</MPIFC>
-  <NETCDF_PATH>/projects/cesm/devtools/netcdf-4.1.3-gcc4.8.1-mpich3.0.4/</NETCDF_PATH>
-  <SCC>/projects/cesm/devtools/gcc-4.8.1/bin/gcc</SCC>
-  <SCXX>/projects/cesm/devtools/gcc-4.8.1/bin/g++</SCXX>
-  <SFC>/projects/cesm/devtools/gcc-4.8.1/bin/gfortran</SFC>
-  <SLIBS>
-    <append>-L/user/lib64 -llapack -lblas -lnetcdff </append>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="oic5" COMPILER="pgi">
-  <NETCDF_PATH>/home/zdr/opt/netcdf-4.1.3_pgf95</NETCDF_PATH>
-</compiler>
-
-<compiler MACH="olympus" COMPILER="intel">
-  <CFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <CPPDEFS>
-    <append> -DLINUX </append>
-  </CPPDEFS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </FFLAGS>
-  <NETCDF_PATH> $ENV{NETCDF_LIB}/..</NETCDF_PATH>
-  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <SLIBS>
-    <base> -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -lpmi </base>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="olympus" COMPILER="pgi">
-  <CFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <CPPDEFS>
-    <append> -DLINUX </append>
-  </CPPDEFS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </FFLAGS>
-  <NETCDF_PATH> $ENV{NETCDF_LIB}/..</NETCDF_PATH>
-  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <SLIBS>
-    <base> -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -lpmi </base>
-  </SLIBS>
-</compiler>
-
 <compiler MACH="sandiatoss3" COMPILER="intel">
   <ALBANY_PATH>/projects/ccsm/AlbanyTrilinos_20190904/albany-build/install</ALBANY_PATH>
   <CPPDEFS>
@@ -1667,48 +1456,6 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
     <append>$SHELL{$NETCDF_PATH/bin/nf-config --flibs} -L/projects/ccsm/BLAS-intel -lblas_LINUX -L$ENV{MKL_LIBS} -lmkl_rt</append>
     <append MPILIB="openmpi"> -mkl=cluster </append>
     <append MPILIB="mpi-serial"> -mkl </append>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="sooty" COMPILER="intel">
-  <CFLAGS>
-    <append> -std=c99 </append>
-  </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <CPPDEFS>
-    <append> -DLINUX -DCPRINTEL </append>
-  </CPPDEFS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2 -debug minimal </append>
-    <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </append>
-  </FFLAGS>
-  <NETCDF_PATH>$ENV{NETCDF_PATH}</NETCDF_PATH>
-  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
-  <SLIBS>
-    <base> -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -lpmi -L$ENV{MKLROOT} -lmkl_rt</base>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="sooty" COMPILER="pgi">
-  <CFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <CPPDEFS>
-    <append> -DLINUX </append>
-  </CPPDEFS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </FFLAGS>
-  <NETCDF_PATH> $ENV{NETCDF_LIB}/..</NETCDF_PATH>
-  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <SLIBS>
-    <base> -L$NETCDF_PATH/lib -lnetcdf -lnetcdff -lpmi </base>
   </SLIBS>
 </compiler>
 
@@ -2226,7 +1973,7 @@ ntel/x86_64/2013/composer_xe_2013/composer_xe_2013_sp1.3.174/mkl/include </base>
   <PNETCDF_PATH>$ENV{PNETCDF_ROOT}</PNETCDF_PATH>
 </compiler>
 
-<compiler COMPILER="gnu" MACH="modex">
+<compiler MACH="modex" COMPILER="gnu">
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
   <CPPDEFS>
      <append MODEL="gptl"> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY -DHAVE_BACKTRACE </append>

--- a/components/cmake/build_model.cmake
+++ b/components/cmake/build_model.cmake
@@ -127,6 +127,8 @@ function(build_model COMP_CLASS COMP_NAME)
 
   # Flags are slightly different for different fortran extensions
   foreach (SOURCE_FILE IN LISTS SOURCES)
+    e3sm_add_flags("${SOURCE_FILE}" "${FFLAGS}")
+
     # Cosp manages its own flags
     if (NOT SOURCE_FILE IN_LIST COSP_SOURCES)
       get_filename_component(SOURCE_EXT ${SOURCE_FILE} EXT)
@@ -153,7 +155,7 @@ function(build_model COMP_CLASS COMP_NAME)
 
   # Disable optimizations on some files that would take too long to compile, expect these to all be fortran files
   foreach (SOURCE_FILE IN LISTS NOOPT_FILES)
-    e3sm_add_flags("${SOURCE_FILE}" "${FFLAGS_NOOPT}")
+    e3sm_deoptimize_file("${SOURCE_FILE}" "${FFLAGS_NOOPT}")
   endforeach()
 
   #-------------------------------------------------------------------------------

--- a/components/cmake/build_model.cmake
+++ b/components/cmake/build_model.cmake
@@ -125,19 +125,30 @@ function(build_model COMP_CLASS COMP_NAME)
     list(APPEND SOURCES ${CMAKE_CURRENT_BINARY_DIR}/${BASENAME})
   endforeach ()
 
-  # Flags are slightly different for different fortran extensions
+  # Set compiler flags for source files
   foreach (SOURCE_FILE IN LISTS SOURCES)
-    e3sm_add_flags("${SOURCE_FILE}" "${FFLAGS}")
+    get_filename_component(SOURCE_EXT ${SOURCE_FILE} EXT)
 
-    # Cosp manages its own flags
-    if (NOT SOURCE_FILE IN_LIST COSP_SOURCES)
-      get_filename_component(SOURCE_EXT ${SOURCE_FILE} EXT)
-      if (SOURCE_EXT STREQUAL ".F" OR SOURCE_EXT STREQUAL ".f")
-        e3sm_add_flags("${SOURCE_FILE}" "${FIXEDFLAGS}")
-      elseif(SOURCE_EXT STREQUAL ".f90")
-        e3sm_add_flags("${SOURCE_FILE}" "${FREEFLAGS}")
-      elseif(SOURCE_EXT STREQUAL ".F90")
-        e3sm_add_flags("${SOURCE_FILE}" "${FREEFLAGS} ${CONTIGUOUS_FLAG}")
+    # Set flags based on file extension. File extensions may change if the globs used by
+    # gather_sources changes.
+    if (SOURCE_EXT STREQUAL ".c")
+      e3sm_add_flags("${SOURCE_FILE}" "${CFLAGS}")
+    elseif (SOURCE_EXT STREQUAL ".cpp")
+      e3sm_add_flags("${SOURCE_FILE}" "${CXXFLAGS}")
+    else()
+      # This is a fortran source
+      e3sm_add_flags("${SOURCE_FILE}" "${FFLAGS}")
+
+      # Cosp manages its own flags
+      if (NOT SOURCE_FILE IN_LIST COSP_SOURCES)
+        # Flags are slightly different for different fortran extensions
+        if (SOURCE_EXT STREQUAL ".F" OR SOURCE_EXT STREQUAL ".f")
+          e3sm_add_flags("${SOURCE_FILE}" "${FIXEDFLAGS}")
+        elseif (SOURCE_EXT STREQUAL ".f90")
+          e3sm_add_flags("${SOURCE_FILE}" "${FREEFLAGS}")
+        elseif (SOURCE_EXT STREQUAL ".F90")
+          e3sm_add_flags("${SOURCE_FILE}" "${FREEFLAGS} ${CONTIGUOUS_FLAG}")
+        endif()
       endif()
     endif()
   endforeach()

--- a/components/cmake/cmake_util.cmake
+++ b/components/cmake/cmake_util.cmake
@@ -80,6 +80,7 @@ function(e3sm_deoptimize_file FILE_ARG FFLAGS_NOOPT)
     # we have to remove the optimization flags first
 
     # Until we know which particular flags are related to optimization, we have to guess.
+    e3sm_remove_flags(${FILE_ARG} "-O1")
     e3sm_remove_flags(${FILE_ARG} "-O2")
     e3sm_remove_flags(${FILE_ARG} "-O3")
   endif()

--- a/components/cmake/cmake_util.cmake
+++ b/components/cmake/cmake_util.cmake
@@ -66,10 +66,22 @@ function(e3sm_remove_flags FILE_ARG FLAGS_ARG)
     if (NOT EXISTS ${PROJECT_SOURCE_DIR}/${FILE_ARG})
       message(FATAL_ERROR "Trying to set flags on non-existent source: ${FILE_ARG}")
     endif()
-    set(REAL_FILE "../../${FILE_ARG}")
+    set(REAL_FILE "${SOURCE_PATH}/${FILE_ARG}")
   endif()
 
   get_property(ITEM_FLAGS SOURCE ${REAL_FILE} PROPERTY COMPILE_FLAGS)
   string(REPLACE "${FLAGS_ARG}" "" ITEM_FLAGS "${ITEM_FLAGS}")
   set_property(SOURCE ${REAL_FILE} PROPERTY COMPILE_FLAGS "${ITEM_FLAGS}")
+endfunction()
+
+function(e3sm_deoptimize_file FILE_ARG FFLAGS_NOOPT)
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
+    # PGI does not support bulk-disabling of optimization by appending -O0,
+    # we have to remove the optimization flags first
+
+    # Until we know which particular flags are related to optimization, we have to guess.
+    e3sm_remove_flags(${FILE_ARG} "-O2")
+    e3sm_remove_flags(${FILE_ARG} "-O3")
+  endif()
+  e3sm_add_flags(${FILE_ARG} "${FFLAGS_NOOPT}")
 endfunction()

--- a/components/cmake/common_setup.cmake
+++ b/components/cmake/common_setup.cmake
@@ -467,6 +467,4 @@ set(GPTLLIB "${GPTL_LIBDIR}/libgptl.a")
 #------------------------------------------------------------------------------
 # Set key cmake vars
 #------------------------------------------------------------------------------
-set(CMAKE_C_FLAGS "${CFLAGS}" PARENT_SCOPE)
-set(CMAKE_CXX_FLAGS "${CXXFLAGS}" PARENT_SCOPE)
 set(CMAKE_EXE_LINKER_FLAGS "${LDFLAGS}" PARENT_SCOPE)

--- a/components/cmake/common_setup.cmake
+++ b/components/cmake/common_setup.cmake
@@ -467,7 +467,6 @@ set(GPTLLIB "${GPTL_LIBDIR}/libgptl.a")
 #------------------------------------------------------------------------------
 # Set key cmake vars
 #------------------------------------------------------------------------------
-set(CMAKE_Fortran_FLAGS "${FFLAGS}" PARENT_SCOPE)
 set(CMAKE_C_FLAGS "${CFLAGS}" PARENT_SCOPE)
 set(CMAKE_CXX_FLAGS "${CXXFLAGS}" PARENT_SCOPE)
 set(CMAKE_EXE_LINKER_FLAGS "${LDFLAGS}" PARENT_SCOPE)


### PR DESCRIPTION
Flags added via the global CMAKE_<LANG>_FLAGS cannot be easily removed from
individual files. This was impacting PGI users especially because -O0 does not
override previous -O2 flags, so the -O2 flag must be removed from the compile
command in order to deoptimize the compilation.

This PR switches from managing f90 flags via the global CMAKE_Fortran_FLAGS
to managing them through individual source file properties. This will allow
e3sm_remove_flags to work properly for all flags.

Also, remove some old blocks in config_compilers.xml.

Fixes #3648 

[BFB]