### PR TITLE
Merge PR #3569 to maint-1.0 for nudging bug fixes

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -283,11 +283,11 @@
        group="nudging_nl" valid_values="" >
        Use user-defined relaxation time scale (unit: hour).
        If Nudge_Tau > 0, the relaxation time scale is determined by Nudge_Tau;
-       If not, the relaxation time scale is determined by Nudge_Times_Per_Day;
+       If not, the relaxation time scale is determined by Nudge_Times_Per_Day and nudging strength specified in the namelist (e.g. Nudge_Ucoef).
        Default: -999
        </entry>
 
-<entry id="Nudge_Loc" type="logical" category="nudging"
+<entry id="Nudge_Loc_Same" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
        If TRUE, change the location of calculation of nudging tendency to 
        the same location where the nudging data is written out.
@@ -303,13 +303,13 @@
        Default: FALSE
        </entry>
 
-<entry id="Num_Slice" type="integer" category="nudging"
+<entry id="Nudge_File_Ntime" type="integer" category="nudging"
        group="nudging_nl" valid_values="" >
        Number of time slices per nudging data file
        The current nudging code only works for the nudging data file with one-day data. 
        It does not work correctly when the nudging data file contains multiple-day data.
-       Thus, Num_Slice has to equal to 1 or Nudge_Times_Per_Day.
-       Set default Num_Slice to 0 to force the user to set its value correctly.
+       Thus, Num_File_Ntime has to equal to 1 or Nudge_Times_Per_Day.
+       Set default Num_File_Ntime to 0 to force the user to set its value correctly.
        Default: 0
        </entry>
 

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -269,13 +269,13 @@
        group="nudging_nl" valid_values="" >
        Method to perform Nudging analyses.
        1. Step: the model meteorology is nudged toward the same (future) time 
-          slice of the constraining data within each nudging window (e.g., 6-hr)
+          slice of the constraining data within each nudging window (e.g., 6-hr).
        2. Linear: the model meteorology is nudged toward the state at the next 
           model time step, which is linearly interpolated between two neighboring 
-          time slices of the constraining data 
+          time slices of the constraining data. 
        3. IMT: the model meteorology is nudged toward the constraining data at 
           the same model time step and nudging is only applied when the constrainging 
-          data is available
+          data is available.
        Default: Linear
        </entry>
 
@@ -289,22 +289,28 @@
 
 <entry id="Nudge_Loc" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       If TRUE, change the location of calculation of nudging tendency to the same location
-       where the nudging data is written out
-       If FALSE, calculate the nudging tendency at the beginning of tphysbc (the same as the default model)
+       If TRUE, change the location of calculation of nudging tendency to 
+       the same location where the nudging data is written out.
+       If FALSE, calculate the nudging tendency at the beginning of 
+       tphysbc (the same as the default model).
        Default: TRUE
        </entry>
 
 <entry id="Nudge_Curr" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       Linearly interpolate nudging data to current (set to TRUE) or future (set to FALSE, used by the default model) model time step
+       Linearly interpolate nudging data to current (set to TRUE) or future 
+       (set to FALSE, used by the default model) model time step.
        Default: FALSE
        </entry>
 
 <entry id="Num_Slice" type="integer" category="nudging"
        group="nudging_nl" valid_values="" >
        Number of time slices per nudging data file
-       Default: 1 
+       The current nudging code only works for the nudging data file with one-day data. 
+       It does not work correctly when the nudging data file contains multiple-day data.
+       Thus, Num_Slice has to equal to 1 or Nudge_Times_Per_Day.
+       Set default Num_Slice to 0 to force the user to set its value correctly.
+       Default: 0
        </entry>
 
 <!-- Aerosols: Data (CAM version) -->

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -265,217 +265,35 @@
        Default: none
        </entry>
 
-
-<!-- Nudging Parameters -->
-
-<entry id="Nudge_Model" type="logical" category="nudging"
+<entry id="Nudge_Method" type="char*80" category="nudging"
        group="nudging_nl" valid_values="" >
-       Toggle Model Nudging ON/OFF.
+       Method to perform Nudging analyses.
+       Default: Step
+       </entry>
+
+<entry id="Nudge_Tau" type="real" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Use user-defined relaxation time scale. 
+       Default: -999
+       </entry>
+
+<entry id="Nudge_Loc" type="logical" category="nudging"
+       group="nudging_nl" valid_values="" >
+       Change the location of calculation of nudging tendency to the same location 
+       where the nudging data is written out
        Default: FALSE
        </entry>
 
-<entry id="Nudge_Path" type="char*256" input_pathname="abs" category="nudging"
+<entry id="Nudge_Curr" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       Full pathname of analyses data to use for nudging.
-       Default: none
+       Linearly interpolate nudging data to current or future model time step
+       Default: FALSE
        </entry>
 
-<entry id="Nudge_File_Template" type="char*80" category="nudging"
+<entry id="Num_Slice" type="integer" category="nudging"
        group="nudging_nl" valid_values="" >
-       Template for Nudging analyses file names.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Times_Per_Day" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Number of analyses files per day.
-       Default: none
-       </entry>
-
-<entry id="Model_Times_Per_Day" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Number of time to update model data per day.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Uprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for U nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Ucoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for U nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for V nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vcoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for V nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Tprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for T nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Tcoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for T nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Qprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for Q nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Qcoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for Q nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_PSprof" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Profile index for PS nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_PScoef" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Coeffcient for PS nudging.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Beg_Year" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Year at which Nudging Begins.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Beg_Month" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Month at which Nudging Begins.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Beg_Day" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Day at which Nudging Begins.
-       Default: none
-       </entry>
-
-<entry id="Nudge_End_Year" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Year at which Nudging Ends.
-       Default: none
-       </entry>
-
-<entry id="Nudge_End_Month" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Month at which Nudging Ends.
-       Default: none
-       </entry>
-
-<entry id="Nudge_End_Day" type="integer" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Day at which Nudging Ends.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lo" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LOW Coeffcient for Horizontal Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_hi" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       HIGH Coeffcient for Horizontal Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lat0" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LAT0 of Horizonalt Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_latWidth" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Width of LAT Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_latDelta" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Steepness of LAT Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lon0" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LON0 of Horizontal Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lonWidth" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Width of LON Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Hwin_lonDelta" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Steepness of LON Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_lo" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LOW Coeffcient for Vertical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_hi" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       HIGH Coeffcient for Vertical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_Hindex" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       HIGH Level Index for Verical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_Hdelta" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Steepness of HIGH end of Vertical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_Lindex" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       LOW Level Index for Verical Window.
-       Default: none
-       </entry>
-
-<entry id="Nudge_Vwin_Ldelta" type="real" category="nudging"
-       group="nudging_nl" valid_values="" >
-       Steepness of LOW end of Vertical Window.
-       Default: none
+       Number of time slices per nudging data file; Must be 1 or Nudge_Times_Per_Day
+       Default: 1 
        </entry>
 
 <!-- Aerosols: Data (CAM version) -->

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -308,8 +308,8 @@
        Number of time slices per nudging data file
        The current nudging code only works for the nudging data file with one-day data. 
        It does not work correctly when the nudging data file contains multiple-day data.
-       Thus, Num_File_Ntime has to equal to 1 or Nudge_Times_Per_Day.
-       Set default Num_File_Ntime to 0 to force the user to set its value correctly.
+       Thus, Nudge_File_Ntime has to equal to 1 or Nudge_Times_Per_Day.
+       Set default Nudge_File_Ntime to 0 to force the user to set its value correctly.
        Default: 0
        </entry>
 

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -290,7 +290,7 @@
 <entry id="Nudge_Loc_PhysOut" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
        If TRUE, change the location of calculation of nudging tendency to 
-       the same location where the nudging data is written out.
+       the same location where the model state variables are written out.
        If FALSE, calculate the nudging tendency at the beginning of 
        tphysbc (the same as the default model).
        Default: TRUE

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -287,7 +287,7 @@
        Default: -999
        </entry>
 
-<entry id="Nudge_Loc_Same" type="logical" category="nudging"
+<entry id="Nudge_Loc_PhysOut" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
        If TRUE, change the location of calculation of nudging tendency to 
        the same location where the nudging data is written out.
@@ -296,7 +296,7 @@
        Default: TRUE
        </entry>
 
-<entry id="Nudge_Curr" type="logical" category="nudging"
+<entry id="Nudge_CurrentStep" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
        Linearly interpolate nudging data to current (set to TRUE) or future 
        (set to FALSE, used by the default model) model time step.

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -268,31 +268,42 @@
 <entry id="Nudge_Method" type="char*80" category="nudging"
        group="nudging_nl" valid_values="" >
        Method to perform Nudging analyses.
-       Default: Step
+       1. Step: the model meteorology is nudged toward the same (future) time 
+          slice of the constraining data within each nudging window (e.g., 6-hr)
+       2. Linear: the model meteorology is nudged toward the state at the next 
+          model time step, which is linearly interpolated between two neighboring 
+          time slices of the constraining data 
+       3. IMT: the model meteorology is nudged toward the constraining data at 
+          the same model time step and nudging is only applied when the constrainging 
+          data is available
+       Default: Linear
        </entry>
 
 <entry id="Nudge_Tau" type="real" category="nudging"
        group="nudging_nl" valid_values="" >
-       Use user-defined relaxation time scale. 
+       Use user-defined relaxation time scale (unit: hour).
+       If Nudge_Tau > 0, the relaxation time scale is determined by Nudge_Tau;
+       If not, the relaxation time scale is determined by Nudge_Times_Per_Day;
        Default: -999
        </entry>
 
 <entry id="Nudge_Loc" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       Change the location of calculation of nudging tendency to the same location 
+       If TRUE, change the location of calculation of nudging tendency to the same location
        where the nudging data is written out
-       Default: FALSE
+       If FALSE, calculate the nudging tendency at the beginning of tphysbc (the same as the default model)
+       Default: TRUE
        </entry>
 
 <entry id="Nudge_Curr" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
-       Linearly interpolate nudging data to current or future model time step
+       Linearly interpolate nudging data to current (set to TRUE) or future (set to FALSE, used by the default model) model time step
        Default: FALSE
        </entry>
 
 <entry id="Num_Slice" type="integer" category="nudging"
        group="nudging_nl" valid_values="" >
-       Number of time slices per nudging data file; Must be 1 or Nudge_Times_Per_Day
+       Number of time slices per nudging data file
        Default: 1 
        </entry>
 

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -53,6 +53,8 @@
           This is an optional attribute that is mainly useful for variables
           that have only a small number of allowed values.
                                                                         -->
+<!-- There is a duplicated nml definitions for nudging parameters 
+     in the current master branch, and it is removed in the PR          -->
 <!-- Nudging Parameters -->
 
 <entry id="Nudge_Model" type="logical" category="nudging"

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -715,7 +715,7 @@ contains
    call mpibcast(Nudge_File_Ntime,1,mpiint,0,mpicom)
 #endif
 
-   if ( (Nudge_File_Ntime .ne. Nudge_Times_Per_Day) .and. (Nudge_File_Ntime .ne. 1) ) then
+   if ( Nudge_ON .eq. .true. .and. (Nudge_File_Ntime .ne. Nudge_Times_Per_Day) .and. (Nudge_File_Ntime .ne. 1) ) then
      write(iulog,*) 'NUDGING: Nudge_File_Ntime=',Nudge_File_Ntime
      write(iulog,*) 'NUDGING: Nudge_File_Ntime must equal to Nudge_Times_Per_Day or 1'
      call endrun('nudging_readnl:: ERROR in namelist')

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -164,6 +164,9 @@ module nudging
 !                        Example: Nudge_Curr = FALSE 
 !
 !        Num_Slice:      Number of time slices per nudging data file
+!                        The current nudging code only works for the nudging data file with one-day data.
+!                        It does not work correctly when the nudging data file contains multiple-day data.
+!                        Thus, Num_Slice has to equal to 1 or Nudge_Times_Per_Day.
 !
 !                        Example: Num_Slice = 1
 !
@@ -218,7 +221,7 @@ module nudging
 !      Nudge_Loc           - LOGICAL change the location of calculation of nudging tendency 
 !      Nudge_Curr          - LOGICAL linearly interpolate nudging data to current
 !                                    or future model time step
-!      Num_Slice           - Number of time slices per nudging data file
+!      Num_Slice           - INT  Number of time slices per nudging data file
 !    /
 !
 !================
@@ -462,7 +465,7 @@ contains
    Nudge_Loc          = .true.
    Nudge_Tau          = -999._r8
    Nudge_Curr         = .false.
-   Num_Slice          = 1
+   Num_Slice          = 0
    ! Read in namelist values
    !------------------------
    if(masterproc) then
@@ -532,11 +535,11 @@ contains
      call endrun('nudging_readnl:: ERROR in namelist')
    endif
 
-!   if ( (Num_Slice .ne. Nudge_Times_Per_Day) .and. (Num_Slice .ne. 1) ) then
-!     write(iulog,*) 'NUDGING: Num_Slice=',Num_Slice 
-!     write(iulog,*) 'NUDGING: Num_Slice must equal to Nudge_Times_Per_Day or 1'
-!     call endrun('nudging_readnl:: ERROR in namelist')
-!   end if
+   if ( (Num_Slice .ne. Nudge_Times_Per_Day) .and. (Num_Slice .ne. 1) ) then
+     write(iulog,*) 'NUDGING: Num_Slice=',Num_Slice 
+     write(iulog,*) 'NUDGING: Num_Slice must equal to Nudge_Times_Per_Day or 1'
+     call endrun('nudging_readnl:: ERROR in namelist')
+   end if
 
    ! Broadcast namelist variables
    !------------------------------

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -1201,7 +1201,6 @@ contains
    use dycore       ,only: dycore_is
    use ppgrid       ,only: pver,pcols,begchunk,endchunk
    use filenames    ,only: interpret_filename_spec
-   use physconst    ,only: cpair
 
    ! Arguments
    !-----------
@@ -1491,7 +1490,6 @@ contains
    use physics_types,only: physics_state
    use constituents ,only: cnst_get_ind
    use ppgrid       ,only: pver,pcols
-   use physconst    ,only: cpair
 
    ! Arguments
    !-----------
@@ -1583,6 +1581,7 @@ contains
    use constituents ,only: cnst_get_ind,pcnst
    use ppgrid       ,only: pver,pcols,begchunk,endchunk
    use cam_history  ,only: outfld
+   use physconst    ,only: cpair
 
    ! Arguments
    !-------------
@@ -1636,7 +1635,7 @@ contains
 
      call outfld('Nudge_U',phys_tend%u          ,pcols,lchnk)
      call outfld('Nudge_V',phys_tend%v          ,pcols,lchnk)
-     call outfld('Nudge_T',phys_tend%s/*cpair   ,pcols,lchnk)
+     call outfld('Nudge_T',phys_tend%s/cpair    ,pcols,lchnk)
      call outfld('Nudge_Q',phys_tend%q(1,1,indw),pcols,lchnk)
    endif
 
@@ -3207,7 +3206,7 @@ contains
   use perf_mod         
   use netcdf           
                
-  integer, intent(in)             :: ncid, ndg_prof            
+  integer, intent(in)             :: ncid 
   integer, intent(in)             :: strt4(4), cnt4(4)         
   character (len = *), intent(in) :: vname             
   real(r8), intent(out)           :: out_x(pcols,pver,begchunk:endchunk)               

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -191,6 +191,8 @@ module nudging
 !                           The current nudging code only works for the nudging data file with one-day data.
 !                           It does not work correctly when the nudging data file contains multiple-day data.
 !                           Thus, Nudge_File_Ntime has to equal to 1 or Nudge_Times_Per_Day.
+!                           If there are multiple time slices per file, the revised nudging code assumes 
+!                           that the time slice in a file always starts from 00Z.
 !
 !                           Example: Nudge_File_Ntime = 1
 !
@@ -276,14 +278,14 @@ module nudging
 !      Nudge_File_Template = 'E3SM.cam.h1.%y-%m-%d-%s.nc'
 !      Nudge_File_Ntime    = 1
 !
-! More advanced example settings for the CONUS RRM simulation (i.e., Table 3 of Tang et al. (2019), 
+! More advanced example settings for the CONUS RRM nudged simulation (i.e., Table 3 of Tang et al. (2019), 
 ! using UV-only, tau=6h, four time slices per nudging input data file, nudging spatial window) 
 ! with this revised nudging code are:
 !
 !    &nudging_nl
 !      Nudge_Model         = .true.
 !      Nudge_Path          = 'PATH_TO_DATA'
-!      Nudge_File_Template = ‘interim_se_%y%m%d00_%y%m%d18_TQUV-%s.nc’
+!      Nudge_File_Template = ‘interim_se_%y%m%d00_%y%m%d18_TQUV.nc’
 !      Nudge_Times_Per_Day = 4
 !      Model_Times_Per_Day = 96 
 !      Nudge_Uprof         = 2 

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -542,12 +542,6 @@ contains
      call endrun('nudging_readnl:: ERROR in namelist')
    endif
 
-   if ( (Nudge_File_Ntime .ne. Nudge_Times_Per_Day) .and. (Nudge_File_Ntime .ne. 1) ) then
-     write(iulog,*) 'NUDGING: Nudge_File_Ntime=',Nudge_File_Ntime 
-     write(iulog,*) 'NUDGING: Nudge_File_Ntime must equal to Nudge_Times_Per_Day or 1'
-     call endrun('nudging_readnl:: ERROR in namelist')
-   end if
-
    ! Broadcast namelist variables
    !------------------------------
 #ifdef SPMD
@@ -597,6 +591,12 @@ contains
    call mpibcast(Nudge_Curr,1,mpilog,0,mpicom)
    call mpibcast(Nudge_File_Ntime,1,mpiint,0,mpicom)
 #endif
+
+   if ( (Nudge_File_Ntime .ne. Nudge_Times_Per_Day) .and. (Nudge_File_Ntime .ne. 1) ) then
+     write(iulog,*) 'NUDGING: Nudge_File_Ntime=',Nudge_File_Ntime
+     write(iulog,*) 'NUDGING: Nudge_File_Ntime must equal to Nudge_Times_Per_Day or 1'
+     call endrun('nudging_readnl:: ERROR in namelist')
+   end if
 
    ! End Routine
    !------------

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -715,7 +715,7 @@ contains
    call mpibcast(Nudge_File_Ntime,1,mpiint,0,mpicom)
 #endif
 
-   if ( Nudge_ON .eq. .true. .and. (Nudge_File_Ntime .ne. Nudge_Times_Per_Day) .and. (Nudge_File_Ntime .ne. 1) ) then
+   if ( Nudge_ON .and. (Nudge_File_Ntime .ne. Nudge_Times_Per_Day) .and. (Nudge_File_Ntime .ne. 1) ) then
      write(iulog,*) 'NUDGING: Nudge_File_Ntime=',Nudge_File_Ntime
      write(iulog,*) 'NUDGING: Nudge_File_Ntime must equal to Nudge_Times_Per_Day or 1'
      call endrun('nudging_readnl:: ERROR in namelist')

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1683,6 +1683,14 @@ if (l_gw_drag) then
 
 end if ! l_gw_drag
 
+    !===================================================
+    ! Update Nudging values, if needed
+    !===================================================
+    if((Nudge_Model).and.(Nudge_ON)) then
+      call nudging_timestep_tend(state,ptend)
+      call physics_update(state,ptend,ztodt,tend)
+    endif
+
 if (l_ac_energy_chk) then
     !-------------- Energy budget checks vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 
@@ -1746,14 +1754,6 @@ end if ! l_ac_energy_chk
        if (labort) then
           call endrun ('TPHYSAC error:  grid contains non-ocean point')
        endif
-    endif
-
-    !===================================================
-    ! Update Nudging values, if needed
-    !===================================================
-    if((Nudge_Model).and.(Nudge_ON)) then
-      call nudging_timestep_tend(state,ptend)
-      call physics_update(state,ptend,ztodt,tend)
     endif
 
     call diag_phys_tend_writeout (state, pbuf,  tend, ztodt, tmp_q, tmp_cldliq, tmp_cldice, &
@@ -1853,6 +1853,7 @@ subroutine tphysbc (ztodt,               &
     use subcol,          only: subcol_gen, subcol_ptend_avg
     use subcol_utils,    only: subcol_ptend_copy, is_subcol_on
     use phys_control,    only: use_qqflx_fixer, use_mass_borrower
+    use nudging,         only: Nudge_Model,Nudge_Loc,nudging_calc_tend
 
     implicit none
 
@@ -2671,6 +2672,13 @@ end if ! l_tracer_aero
     call diag_conv(state, ztodt, pbuf)
 
     call t_stopf('bc_history_write')
+
+    !===================================
+    ! Update Nudging tendency if needed
+    !===================================
+    if (Nudge_Model .and. Nudge_Loc) then
+       call nudging_calc_tend(state)
+    endif
 
     !===================================================
     ! Write cloud diagnostics on history file

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1853,7 +1853,7 @@ subroutine tphysbc (ztodt,               &
     use subcol,          only: subcol_gen, subcol_ptend_avg
     use subcol_utils,    only: subcol_ptend_copy, is_subcol_on
     use phys_control,    only: use_qqflx_fixer, use_mass_borrower
-    use nudging,         only: Nudge_Model,Nudge_Loc,nudging_calc_tend
+    use nudging,         only: Nudge_Model,Nudge_Loc_Same,nudging_calc_tend
 
     implicit none
 
@@ -2676,7 +2676,7 @@ end if ! l_tracer_aero
     !===================================
     ! Update Nudging tendency if needed
     !===================================
-    if (Nudge_Model .and. Nudge_Loc) then
+    if (Nudge_Model .and. Nudge_Loc_Same) then
        call nudging_calc_tend(state)
     endif
 

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1853,7 +1853,7 @@ subroutine tphysbc (ztodt,               &
     use subcol,          only: subcol_gen, subcol_ptend_avg
     use subcol_utils,    only: subcol_ptend_copy, is_subcol_on
     use phys_control,    only: use_qqflx_fixer, use_mass_borrower
-    use nudging,         only: Nudge_Model,Nudge_Loc_Same,nudging_calc_tend
+    use nudging,         only: Nudge_Model,Nudge_Loc_PhysOut,nudging_calc_tend
 
     implicit none
 
@@ -2676,7 +2676,7 @@ end if ! l_tracer_aero
     !===================================
     ! Update Nudging tendency if needed
     !===================================
-    if (Nudge_Model .and. Nudge_Loc_Same) then
+    if (Nudge_Model .and. Nudge_Loc_PhysOut) then
        call nudging_calc_tend(state)
     endif
 


### PR DESCRIPTION
Some nudging runs are assigned by the E3SM leaders to use the maint-1.0 code. It requires the bug fixes in PR #3569. These fixes are on master, but not on maint-1.0. Cherry-picked in this PR for maint-1.0

@wlin7 and @jiansunpnnl : It is a bit time sensitive as the first test run is planned for the next week. Since these changes have been tested and merged on master, can we go ahead and merge it into maint-1.0? This part of code is isolated to the other parts, so it should not affect other code. Thanks.