### PR TITLE
Change source of h2osno and frac_sno in SNICAR_AD_RT

### DIFF
--- a/components/clm/src/biogeophys/SnowSnicarMod.F90
+++ b/components/clm/src/biogeophys/SnowSnicarMod.F90
@@ -1914,10 +1914,9 @@ contains
      SHR_ASSERT_ALL((ubound(flx_abs)        == (/bounds%endc, 1, numrad/)),      errMsg(__FILE__, __LINE__))
 
      associate(&
-          snl         =>   col_pp%snl                           , & ! Input:  [integer (:)]  negative number of snow layers (col) [nbr]
-
-          h2osno      =>   waterstate_vars%h2osno_col        , & ! Input:  [real(r8) (:)]  snow liquid water equivalent (col) [kg/m2]
-          frac_sno    =>   waterstate_vars%frac_sno_eff_col    & ! Input:  [real(r8) (:)]  fraction of ground covered by snow (0 to 1)
+          snl         =>   col_pp%snl           , & ! Input:  [integer (:)]  negative number of snow layers (col) [nbr]
+          h2osno      =>   col_ws%h2osno        , & ! Input:  [real(r8) (:)]  snow liquid water equivalent (col) [kg/m2]
+          frac_sno    =>   col_ws%frac_sno_eff    & ! Input:  [real(r8) (:)]  fraction of ground covered by snow (0 to 1)
           )
 
        ! Define constants


### PR DESCRIPTION
This PR changes the source of two associated arrays, h2osno and frac_sno, in subroutine SNICAR_AD_RT. Previously the two arrays had pointed at the waterstate_vars derived type, but subroutine SNICAR_RT, which it optionally replaces, pointed those arrays to derived type col_ws. When using the waterstate_vars derived type and use_snicar_ad set to true (meaning CLM was using SNICAR_AD_RT instead of SNICAR_RT), tests would fail after a couple of years with a traceback into subroutine TwoStream. Debugging indicated the problem was due to a 0 snow albedo in a cell whose snow fraction was 1, and more analysis found the 0 albedo was coming from SNICAR_AD_RT. Apparently the water state_vars value for h2osno for that cell was 0 and subsequently no albedo was calculated, though the col_ws value was non-zero and is used elsewhere in the calculation. With the current patch, the same test that had previously failed was run 20 years.

[BFB]