### PR TITLE
Add switch for expanded snowpack model (use_extrasnowlayers)

### DIFF
--- a/cime/config/e3sm/tests.py
+++ b/cime/config/e3sm/tests.py
@@ -104,6 +104,7 @@ _TESTS = {
         "tests" : (
             "ERS_P480_Ld5.T62_oEC60to30v3wLI.GMPAS-DIB-IAF-ISMF",
             "PEM_P480_Ld5.T62_oEC60to30v3wLI.GMPAS-DIB-IAF-ISMF",
+            "SMS.ne30_oECv3_gis.IGCLM45_MLI.clm-extrasnowlayers",
             )
         },
 

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -631,6 +631,13 @@ The same snow shortwave algorithm can be turned on for sea-ice simulation
 with config_use_snicar_ad in mpas-seaic namelist
 </entry>
 
+<entry id="use_extrasnowlayers" type="logical" category="physics"
+       group="clm_inparm" valid_values="" value=".false.">
+Toggle to use 16 snow layers instead of 5.  This option enables more realistic
+snowpack conditions on glaciers and ice sheets, including a semi-empirical
+firn densification model.
+</entry>
+
 <entry id="use_noio" type="logical" category="default_settings"
        group="clm_inparm" valid_values="" value=".false." >
 Toggle to turn all history output completely OFF (possibly used for testing)

--- a/components/clm/cime_config/config_component.xml
+++ b/components/clm/cime_config/config_component.xml
@@ -54,7 +54,9 @@
       <value compset="RCP2.*_CLM"       >1850-2100_rcp2.6_transient</value> 
       <value compset="RCP8.*_CLM"       >1850-2100_rcp8.5_transient</value> 
       <value compset="1850.*_CLM.*_CISM">1850_glacierMEC_control</value> 
-      <value compset="2000.*_CLM.*_CISM">2000_glacierMEC_control</value> 
+      <value compset="2000.*_CLM.*_CISM">2000_glacierMEC_control</value>
+      <value compset="1850.*_CLM.*_MALI">1850_glacierMEC_control</value>
+      <value compset="20TR.*_CLM.*_MALI">20thC_glacierMEC_transient</value> 
       <value compset="2000.*_CLM.*_MALI">2000_glacierMEC_control</value>
       <value compset="PDAY.*_CLM.*_CISM">2000_glacierMEC_control</value> 
       <value compset="4804.*_CLM.*_CISM">2000_glacierMEC_control</value> 

--- a/components/clm/cime_config/config_compsets.xml
+++ b/components/clm/cime_config/config_compsets.xml
@@ -755,6 +755,21 @@
   </compset>
 
   <!---IG compsets with MALI -->
+  
+  <compset>
+    <alias>IG1850CRUCLM45_MLI</alias>
+    <lname>1850_DATM%CRU_CLM45%SP_SICE_SOCN_MOSART_MALI%SIA_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>IG20TRCRUCLM45_MLI</alias>
+    <lname>20TR_DATM%CRU_CLM45%SP_SICE_SOCN_MOSART_MALI%SIA_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>IGCRUCLM45_MLI</alias>
+    <lname>2000_DATM%CRU_CLM45%SP_SICE_SOCN_MOSART_MALI%SIA_SWAV</lname>
+  </compset>
 
   <compset>
     <alias>IGCLM45_MLI</alias>

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/extrasnowlayers/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/extrasnowlayers/user_nl_clm
@@ -1,4 +1,1 @@
 use_extrasnowlayers = .true.
-
-! Use cold start, because can't change number of snow layers for existing initial conditions file
-finidat = ' '

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/extrasnowlayers/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/extrasnowlayers/user_nl_clm
@@ -1,0 +1,4 @@
+use_extrasnowlayers = .true.
+
+! Use cold start, because can't change number of snow layers for existing initial conditions file
+finidat = ' '

--- a/components/clm/src/biogeophys/AerosolMod.F90
+++ b/components/clm/src/biogeophys/AerosolMod.F90
@@ -4,7 +4,8 @@ module AerosolMod
   use shr_kind_mod     , only : r8 => shr_kind_r8
   use shr_log_mod      , only : errMsg => shr_log_errMsg
   use decompMod        , only : bounds_type
-  use clm_varpar       , only : nlevsno 
+  use clm_varpar       , only : nlevsno
+  use clm_varctl       , only : use_extrasnowlayers
   use clm_time_manager , only : get_step_size
   use atm2lndType      , only : atm2lnd_type
   use WaterfluxType    , only : waterflux_type
@@ -109,24 +110,26 @@ contains
             ! layer mass of snow:
             snowmass = h2osoi_ice(c,j) + h2osoi_liq(c,j)
 
-            ! Correct the top layer aerosol mass to account for snow capping. 
-            ! This approach conserves the aerosol mass concentration
-            ! (but not the aerosol amss) when snow-capping is invoked
+            if (.not. use_extrasnowlayers) then
+               ! Correct the top layer aerosol mass to account for snow capping. 
+               ! This approach conserves the aerosol mass concentration
+               ! (but not the aerosol amss) when snow-capping is invoked
 
-            if (j == snl(c)+1) then
-               if (do_capsnow(c)) then 
+               if (j == snl(c)+1) then
+                  if (do_capsnow(c)) then 
 
-                  snowcap_scl_fct = snowmass / (snowmass + (qflx_snwcp_ice(c)*dtime))
+                     snowcap_scl_fct = snowmass / (snowmass + (qflx_snwcp_ice(c)*dtime))
 
-                  mss_bcpho(c,j) = mss_bcpho(c,j)*snowcap_scl_fct
-                  mss_bcphi(c,j) = mss_bcphi(c,j)*snowcap_scl_fct
-                  mss_ocpho(c,j) = mss_ocpho(c,j)*snowcap_scl_fct
-                  mss_ocphi(c,j) = mss_ocphi(c,j)*snowcap_scl_fct
+                     mss_bcpho(c,j) = mss_bcpho(c,j)*snowcap_scl_fct
+                     mss_bcphi(c,j) = mss_bcphi(c,j)*snowcap_scl_fct
+                     mss_ocpho(c,j) = mss_ocpho(c,j)*snowcap_scl_fct
+                     mss_ocphi(c,j) = mss_ocphi(c,j)*snowcap_scl_fct
 
-                  mss_dst1(c,j)  = mss_dst1(c,j)*snowcap_scl_fct
-                  mss_dst2(c,j)  = mss_dst2(c,j)*snowcap_scl_fct
-                  mss_dst3(c,j)  = mss_dst3(c,j)*snowcap_scl_fct
-                  mss_dst4(c,j)  = mss_dst4(c,j)*snowcap_scl_fct
+                     mss_dst1(c,j)  = mss_dst1(c,j)*snowcap_scl_fct
+                     mss_dst2(c,j)  = mss_dst2(c,j)*snowcap_scl_fct
+                     mss_dst3(c,j)  = mss_dst3(c,j)*snowcap_scl_fct
+                     mss_dst4(c,j)  = mss_dst4(c,j)*snowcap_scl_fct
+                  endif
                endif
             endif
 

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -444,21 +444,23 @@ contains
                      + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) + qflx_sl_top_soil(c)
 
                 if (lun_pp%itype(l) == istdlak) then 
-                   if ( do_capsnow(c) .and. .not. use_extrasnowlayers) then
-                      snow_sources(c) = qflx_snow_grnd_col(c) &
-                           + frac_sno_eff(c) * (qflx_dew_snow(c) + qflx_dew_grnd(c) ) 
+                   if (.not. use_extrasnowlayers) then
+                      if ( do_capsnow(c)) then
+                         snow_sources(c) = qflx_snow_grnd_col(c) &
+                              + frac_sno_eff(c) * (qflx_dew_snow(c) + qflx_dew_grnd(c) ) 
 
-                      snow_sinks(c)   = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c) ) &
-                           + (qflx_snwcp_ice(c) + qflx_snwcp_liq(c) - qflx_prec_grnd(c))  &
-                           + qflx_snow_melt(c)  + qflx_sl_top_soil(c)
-                   else if (.not. use_extrasnowlayers) then
-                      snow_sources(c) = qflx_snow_grnd_col(c) &
-                           + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
-                           +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) 
+                         snow_sinks(c)   = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c) ) &
+                              + (qflx_snwcp_ice(c) + qflx_snwcp_liq(c) - qflx_prec_grnd(c))  &
+                              + qflx_snow_melt(c)  + qflx_sl_top_soil(c)
+                      else
+                         snow_sources(c) = qflx_snow_grnd_col(c) &
+                              + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
+                              +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) 
 
-                      snow_sinks(c)  = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c) ) &
-                           + qflx_snow_melt(c)  + qflx_sl_top_soil(c)
-                   else if (use_extrasnowlayers) then !++ams i.e., firn model
+                         snow_sinks(c)  = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c) ) &
+                              + qflx_snow_melt(c)  + qflx_sl_top_soil(c)
+                      endif
+                   else ! firn model
                       snow_sources(c) = qflx_snow_grnd_col(c) &
                            + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
                            +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) 
@@ -470,21 +472,23 @@ contains
                 endif
 
                 if (lun_pp%itype(l) == istsoil .or. lun_pp%itype(l) == istcrop .or. lun_pp%itype(l) == istwet ) then
-                   if ( do_capsnow(c) .and. .not. use_extrasnowlayers) then
-                      snow_sources(c) = frac_sno_eff(c) * (qflx_dew_snow(c) + qflx_dew_grnd(c) ) &
-                           + qflx_h2osfc_to_ice(c) + qflx_prec_grnd(c)
+                   if (.not. use_extrasnowlayers) then
+                      if (do_capsnow(c)) then
+                         snow_sources(c) = frac_sno_eff(c) * (qflx_dew_snow(c) + qflx_dew_grnd(c) ) &
+                              + qflx_h2osfc_to_ice(c) + qflx_prec_grnd(c)
 
-                      snow_sinks(c) = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c)) &
-                           + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
-                           + qflx_snow_melt(c) + qflx_sl_top_soil(c)
-                   else if (.not. use_extrasnowlayers) then
-                      snow_sources(c) = (qflx_snow_grnd_col(c) - qflx_snow_h2osfc(c) ) &
-                           + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
-                           +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) + qflx_h2osfc_to_ice(c)
+                         snow_sinks(c) = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c)) &
+                              + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
+                              + qflx_snow_melt(c) + qflx_sl_top_soil(c)
+                      else
+                         snow_sources(c) = (qflx_snow_grnd_col(c) - qflx_snow_h2osfc(c) ) &
+                              + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
+                              +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) + qflx_h2osfc_to_ice(c)
 
-                      snow_sinks(c) = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c)) &
-                           + qflx_snow_melt(c) + qflx_sl_top_soil(c)
-                   else if (use_extrasnowlayers) then !++ams i.e., firn model
+                         snow_sinks(c) = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c)) &
+                              + qflx_snow_melt(c) + qflx_sl_top_soil(c)
+                      endif
+                   else ! firn model
                       snow_sources(c) = (qflx_snow_grnd_col(c) - qflx_snow_h2osfc(c) ) &
                            + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
                            +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) + qflx_h2osfc_to_ice(c)

--- a/components/clm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/clm/src/biogeophys/BalanceCheckMod.F90
@@ -9,7 +9,7 @@ module BalanceCheckMod
   use shr_log_mod        , only : errMsg => shr_log_errMsg
   use decompMod          , only : bounds_type
   use abortutils         , only : endrun
-  use clm_varctl         , only : iulog, use_var_soil_thick
+  use clm_varctl         , only : iulog, use_var_soil_thick, use_extrasnowlayers
   use clm_varcon         , only : namep, namec
   use GetGlobalValuesMod , only : GetGlobalIndex
   use atm2lndType        , only : atm2lnd_type
@@ -444,37 +444,53 @@ contains
                      + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) + qflx_sl_top_soil(c)
 
                 if (lun_pp%itype(l) == istdlak) then 
-                   if ( do_capsnow(c) ) then
+                   if ( do_capsnow(c) .and. .not. use_extrasnowlayers) then
                       snow_sources(c) = qflx_snow_grnd_col(c) &
                            + frac_sno_eff(c) * (qflx_dew_snow(c) + qflx_dew_grnd(c) ) 
 
                       snow_sinks(c)   = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c) ) &
                            + (qflx_snwcp_ice(c) + qflx_snwcp_liq(c) - qflx_prec_grnd(c))  &
                            + qflx_snow_melt(c)  + qflx_sl_top_soil(c)
-                   else
+                   else if (.not. use_extrasnowlayers) then
                       snow_sources(c) = qflx_snow_grnd_col(c) &
                            + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
                            +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) 
 
                       snow_sinks(c)  = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c) ) &
                            + qflx_snow_melt(c)  + qflx_sl_top_soil(c)
+                   else if (use_extrasnowlayers) then !++ams i.e., firn model
+                      snow_sources(c) = qflx_snow_grnd_col(c) &
+                           + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
+                           +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) 
+
+                      snow_sinks(c)  = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c) ) &
+                           + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
+                           + qflx_snow_melt(c) + qflx_sl_top_soil(c)
                    endif
                 endif
 
                 if (lun_pp%itype(l) == istsoil .or. lun_pp%itype(l) == istcrop .or. lun_pp%itype(l) == istwet ) then
-                   if ( do_capsnow(c) ) then
+                   if ( do_capsnow(c) .and. .not. use_extrasnowlayers) then
                       snow_sources(c) = frac_sno_eff(c) * (qflx_dew_snow(c) + qflx_dew_grnd(c) ) &
                            + qflx_h2osfc_to_ice(c) + qflx_prec_grnd(c)
 
                       snow_sinks(c) = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c)) &
                            + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
                            + qflx_snow_melt(c) + qflx_sl_top_soil(c)
-                   else
+                   else if (.not. use_extrasnowlayers) then
                       snow_sources(c) = (qflx_snow_grnd_col(c) - qflx_snow_h2osfc(c) ) &
                            + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
                            +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) + qflx_h2osfc_to_ice(c)
 
                       snow_sinks(c) = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c)) &
+                           + qflx_snow_melt(c) + qflx_sl_top_soil(c)
+                   else if (use_extrasnowlayers) then !++ams i.e., firn model
+                      snow_sources(c) = (qflx_snow_grnd_col(c) - qflx_snow_h2osfc(c) ) &
+                           + frac_sno_eff(c) * (qflx_rain_grnd_col(c) &
+                           +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) + qflx_h2osfc_to_ice(c)
+
+                      snow_sinks(c) = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c)) &
+                           + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
                            + qflx_snow_melt(c) + qflx_sl_top_soil(c)
                    endif
                 endif

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -422,18 +422,23 @@ contains
 
           qflx_prec_grnd(p) = qflx_prec_grnd_snow(p) + qflx_prec_grnd_rain(p)
 
-          if (do_capsnow(c)) then
-             qflx_snwcp_liq(p) = qflx_prec_grnd_rain(p)
-             qflx_snwcp_ice(p) = qflx_prec_grnd_snow(p)
+          if (.not. use_extrasnowlayers) then
+             if (do_capsnow(c)) then
+                qflx_snwcp_liq(p) = qflx_prec_grnd_rain(p)
+                qflx_snwcp_ice(p) = qflx_prec_grnd_snow(p)
 
-             qflx_snow_grnd_patch(p) = 0._r8
-             qflx_rain_grnd(p) = 0._r8
+                qflx_snow_grnd_patch(p) = 0._r8
+                qflx_rain_grnd(p) = 0._r8
+             else
+                qflx_snwcp_liq(p) = 0._r8
+                qflx_snwcp_ice(p) = 0._r8
+                qflx_snow_grnd_patch(p) = qflx_prec_grnd_snow(p)           ! ice onto ground (mm/s)
+                qflx_rain_grnd(p)     = qflx_prec_grnd_rain(p)           ! liquid water onto ground (mm/s)
+             end if
           else
-             qflx_snwcp_liq(p) = 0._r8
-             qflx_snwcp_ice(p) = 0._r8
              qflx_snow_grnd_patch(p) = qflx_prec_grnd_snow(p)           ! ice onto ground (mm/s)
-             qflx_rain_grnd(p)     = qflx_prec_grnd_rain(p)           ! liquid water onto ground (mm/s)
-          end if
+             qflx_rain_grnd(p)     = qflx_prec_grnd_rain(p)           ! liquid water onto ground (mm/s)       
+          endif
 
        end do ! (end pft loop)
 
@@ -501,7 +506,7 @@ contains
              swe_old(c,j)=h2osoi_liq(c,j)+h2osoi_ice(c,j)
           enddo
 
-          if (do_capsnow(c)) then
+          if (do_capsnow(c) .and. .not. use_extrasnowlayers) then
              dz_snowf = 0._r8
              newsnow(c) = qflx_snow_grnd_col(c) * dtime
              frac_sno(c)=1._r8
@@ -646,21 +651,40 @@ contains
           ! as the surface air temperature
 
           newnode = 0    ! flag for when snow node will be initialized
-          if (snl(c) == 0 .and. qflx_snow_grnd_col(c) > 0.0_r8 .and. frac_sno(c)*snow_depth(c) >= 0.01_r8) then
-             newnode = 1
-             snl(c) = -1
-             dz(c,0) = snow_depth(c)                       ! meter
-             z(c,0) = -0.5_r8*dz(c,0)
-             zi(c,-1) = -dz(c,0)
-             t_soisno(c,0) = min(tfrz, forc_t(t))      ! K
-             h2osoi_ice(c,0) = h2osno(c)               ! kg/m2
-             h2osoi_liq(c,0) = 0._r8                   ! kg/m2
-             frac_iceold(c,0) = 1._r8
+          if (.not. use_extrasnowlayers) then
+             if (snl(c) == 0 .and. qflx_snow_grnd_col(c) > 0.0_r8 .and. frac_sno(c)*snow_depth(c) >= 0.01_r8) then
+                newnode = 1
+                snl(c) = -1
+                dz(c,0) = snow_depth(c)                       ! meter
+                z(c,0) = -0.5_r8*dz(c,0)
+                zi(c,-1) = -dz(c,0)
+                t_soisno(c,0) = min(tfrz, forc_t(t))      ! K
+                h2osoi_ice(c,0) = h2osno(c)               ! kg/m2
+                h2osoi_liq(c,0) = 0._r8                   ! kg/m2
+                frac_iceold(c,0) = 1._r8
 
-             ! intitialize SNICAR variables for fresh snow:
-             call aerosol_vars%Reset(column=c)
-             ! call waterstate_vars%Reset(column=c)
-             col_ws%snw_rds(c,0) = snw_rds_min
+                ! intitialize SNICAR variables for fresh snow:
+                call aerosol_vars%Reset(column=c)
+                ! call waterstate_vars%Reset(column=c)
+                col_ws%snw_rds(c,0) = snw_rds_min
+             end if
+          else
+             if (snl(c) == 0 .and. frac_sno(c)*snow_depth(c) >= 0.01_r8) then
+                newnode = 1
+                snl(c) = -1
+                dz(c,0) = snow_depth(c)                       ! meter
+                z(c,0) = -0.5_r8*dz(c,0)
+                zi(c,-1) = -dz(c,0)
+                t_soisno(c,0) = min(tfrz, forc_t(t))      ! K
+                h2osoi_ice(c,0) = h2osno(c)               ! kg/m2
+                h2osoi_liq(c,0) = 0._r8                   ! kg/m2
+                frac_iceold(c,0) = 1._r8
+
+                ! intitialize SNICAR variables for fresh snow:
+                call aerosol_vars%Reset(column=c)
+                ! call waterstate_vars%Reset(column=c)
+                col_ws%snw_rds(c,0) = snw_rds_min
+             end if             
           end if
 
           ! The change of ice partial density of surface node due to precipitation.

--- a/components/clm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/clm/src/biogeophys/CanopyHydrologyMod.F90
@@ -16,7 +16,7 @@ module CanopyHydrologyMod
   use shr_sys_mod       , only : shr_sys_flush
   use decompMod         , only : bounds_type
   use abortutils        , only : endrun
-  use clm_varctl        , only : iulog, tw_irr, extra_gw_irr
+  use clm_varctl        , only : iulog, tw_irr, extra_gw_irr, use_extrasnowlayers
   use LandunitType      , only : lun_pp                
   use atm2lndType       , only : atm2lnd_type
   use AerosolType       , only : aerosol_type
@@ -125,6 +125,7 @@ contains
      use clm_time_manager   , only : get_step_size
      use subgridAveMod      , only : p2c,p2g
      use clm_time_manager   , only : get_step_size, get_prev_date, get_nstep
+     use SnowHydrologyMod   , only : NewSnowBulkDensity
      !
      ! !ARGUMENTS:
      type(bounds_type)      , intent(in)    :: bounds     
@@ -153,7 +154,7 @@ contains
      real(r8) :: fpi                                          ! coefficient of interception
      real(r8) :: xrun                                         ! excess water that exceeds the leaf capacity [mm/s]
      real(r8) :: dz_snowf                                     ! layer thickness rate change due to precipitation [mm/s]
-     real(r8) :: bifall                                       ! bulk density of newly fallen dry snow [kg/m3]
+     real(r8) :: bifall(bounds%begc:bounds%endc)              ! bulk density of newly fallen dry snow [kg/m3]
      real(r8) :: fracsnow(bounds%begp:bounds%endp)            ! frac of precipitation that is snow
      real(r8) :: fracrain(bounds%begp:bounds%endp)            ! frac of precipitation that is rain
      real(r8) :: qflx_candrip(bounds%begp:bounds%endp)        ! rate of canopy runoff and snow falling off canopy [mm/s]
@@ -201,6 +202,7 @@ contains
           forc_rain            => top_af%rain                              , & ! Input:  [real(r8) (:)   ]  rain rate (kg H2O/m**2/s, or mm liquid H2O/s)                        
           forc_snow            => top_af%snow                              , & ! Input:  [real(r8) (:)   ]  snow rate (kg H2O/m**2/s, or mm liquid H2O/s)                        
           forc_t               => top_as%tbot                              , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)        
+          forc_wind            => top_as%windbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed (m/s)
           qflx_floodg          => atm2lnd_vars%forc_flood_grc              , & ! Input:  [real(r8) (:)   ]  gridcell flux of flood water from RTM   
 
           dewmx                => canopystate_vars%dewmx_patch             , & ! Input:  [real(r8) (:)   ]  Maximum allowed dew [mm]                
@@ -472,6 +474,11 @@ contains
        enddo
 
        ! Determine snow height and snow water
+       
+       if (use_extrasnowlayers) then
+          call NewSnowBulkDensity(bounds, num_nolakec, filter_nolakec, &
+                                  top_as, bifall(bounds%begc:bounds%endc))
+       end if
 
        do f = 1, num_nolakec
           c = filter_nolakec(f)
@@ -500,12 +507,14 @@ contains
              frac_sno(c)=1._r8
              int_snow(c) = 5.e2_r8
           else
-             if (forc_t(t) > tfrz + 2._r8) then
-                bifall=50._r8 + 1.7_r8*(17.0_r8)**1.5_r8
-             else if (forc_t(t) > tfrz - 15._r8) then
-                bifall=50._r8 + 1.7_r8*(forc_t(t) - tfrz + 15._r8)**1.5_r8
-             else
-                bifall=50._r8
+             if (.not. use_extrasnowlayers) then
+                if (forc_t(t) > tfrz + 2._r8) then
+                   bifall(c)=50._r8 + 1.7_r8*(17.0_r8)**1.5_r8
+                else if (forc_t(t) > tfrz - 15._r8) then
+                   bifall(c)=50._r8 + 1.7_r8*(forc_t(t) - tfrz + 15._r8)**1.5_r8
+                else
+                   bifall(c)=50._r8
+                end if
              end if
 
              ! all snow falls on ground, no snow on h2osfc
@@ -549,13 +558,13 @@ contains
                 ! for subgrid fluxes
                 if (subgridflag ==1 .and. .not. urbpoi(l)) then
                    if (frac_sno(c) > 0._r8)then
-                      snow_depth(c)=snow_depth(c) + newsnow(c)/(bifall * frac_sno(c))
+                      snow_depth(c)=snow_depth(c) + newsnow(c)/(bifall(c) * frac_sno(c))
                    else
                       snow_depth(c)=0._r8
                    end if
                 else
                    ! for uniform snow cover
-                   snow_depth(c)=snow_depth(c)+newsnow(c)/bifall
+                   snow_depth(c)=snow_depth(c)+newsnow(c)/bifall(c)
                 endif
 
                 ! use original fsca formulation (n&y 07)
@@ -573,7 +582,7 @@ contains
              else !h2osno == 0
                 ! initialize frac_sno and snow_depth when no snow present initially
                 if (newsnow(c) > 0._r8) then 
-                   z_avg = newsnow(c)/bifall
+                   z_avg = newsnow(c)/bifall(c)
                    fmelt=newsnow(c)
                    frac_sno(c) = tanh(accum_factor*newsnow(c))
 
@@ -587,7 +596,7 @@ contains
                    if (subgridflag ==1 .and. .not. urbpoi(l)) then
                       snow_depth(c)=z_avg/frac_sno(c)
                    else
-                      snow_depth(c)=newsnow(c)/bifall
+                      snow_depth(c)=newsnow(c)/bifall(c)
                    endif
                    ! use n&y07 formulation
                    if (oldfflag == 1) then 

--- a/components/clm/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/components/clm/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -22,6 +22,7 @@ Module HydrologyNoDrainageMod
   use ColumnType        , only : col_pp
   use ColumnDataType    , only : col_es, col_ws                
   use VegetationType    , only : veg_pp                
+  use TopounitDataType  , only : top_as, top_af ! Atmospheric state and flux variables
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -130,6 +131,8 @@ contains
          snl                => col_pp%snl                                , & ! Input:  [integer  (:)   ]  number of snow layers                    
          nlev2bed           => col_pp%nlevbed                           , & ! Input:  [integer  (:)   ]  number of layers to bedrock                     
          ctype              => col_pp%itype                              , & ! Input:  [integer  (:)   ]  column type                              
+
+         forc_wind          => top_as%windbot         , & ! Input:  [real(r8) (:) ]  atmospheric wind speed (m/s)
 
          t_h2osfc           => col_es%t_h2osfc          , & ! Input:  [real(r8) (:)   ]  surface water temperature               
          dTdz_top           => col_es%dTdz_top          , & ! Output: [real(r8) (:)   ]  temperature gradient in top layer (col) [K m-1] !
@@ -296,7 +299,7 @@ contains
       endif           
       ! Natural compaction and metamorphosis.
       call SnowCompaction(bounds, num_snowc, filter_snowc, &
-           temperature_vars, waterstate_vars)
+           temperature_vars, waterstate_vars, top_as)
 
       ! Combine thin snow elements
       call CombineSnowLayers(bounds, num_snowc, filter_snowc, &

--- a/components/clm/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/components/clm/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -61,6 +61,7 @@ contains
     !    -> SnowCompaction:        compaction of snow layers
     !    -> CombineSnowLayers:     combine snow layers that are thinner than minimum
     !    -> DivideSnowLayers:      subdivide snow layers that are thicker than maximum
+    !    -> DivideExtraSnowLayers: subdivide up to 16 snow layers that are thicker than maximum
     !
     ! !USES:
     use clm_varcon           , only : denh2o, denice, hfus, grav, tfrz
@@ -70,7 +71,7 @@ contains
     use clm_varctl           , only : use_cn, use_betr, use_fates, use_pflotran, pf_hmode
     use clm_varpar           , only : nlevgrnd, nlevsno, nlevsoi, nlevurb
     use clm_time_manager     , only : get_step_size, get_nstep
-    use SnowHydrologyMod     , only : SnowCompaction, CombineSnowLayers, DivideSnowLayers, SnowCapping
+    use SnowHydrologyMod     , only : SnowCompaction, CombineSnowLayers, DivideSnowLayers, DivideExtraSnowLayers, SnowCapping
     use SnowHydrologyMod     , only : SnowWater, BuildSnowFilter 
     use SoilHydrologyMod     , only : CLMVICMap, SurfaceRunoff, Infiltration, WaterTable
     use SoilWaterMovementMod , only : SoilWater 
@@ -312,9 +313,14 @@ contains
            aerosol_vars, temperature_vars, waterflux_vars, waterstate_vars)
 
       ! Divide thick snow elements
-      call DivideSnowLayers(bounds, num_snowc, filter_snowc, &
-           aerosol_vars, temperature_vars, waterstate_vars, is_lake=.false.)
-
+      if (.not. use_extrasnowlayers) then
+         call DivideSnowLayers(bounds, num_snowc, filter_snowc, &
+              aerosol_vars, temperature_vars, waterstate_vars, is_lake=.false.)
+      else
+         call DivideExtraSnowLayers(bounds, num_snowc, filter_snowc, &
+              aerosol_vars, temperature_vars, waterstate_vars, is_lake=.false.)
+      endif
+      
       ! Set empty snow layers to zero
       do j = -nlevsno+1,0
          do fc = 1, num_snowc

--- a/components/clm/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/components/clm/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -7,7 +7,7 @@ Module HydrologyNoDrainageMod
   use shr_kind_mod      , only : r8 => shr_kind_r8
   use shr_log_mod       , only : errMsg => shr_log_errMsg
   use decompMod         , only : bounds_type
-  use clm_varctl        , only : iulog, use_vichydro
+  use clm_varctl        , only : iulog, use_vichydro, use_extrasnowlayers
   use clm_varcon        , only : e_ice, denh2o, denice, rpi, spval
   use atm2lndType       , only : atm2lnd_type
   use AerosolType       , only : aerosol_type
@@ -70,7 +70,7 @@ contains
     use clm_varctl           , only : use_cn, use_betr, use_fates, use_pflotran, pf_hmode
     use clm_varpar           , only : nlevgrnd, nlevsno, nlevsoi, nlevurb
     use clm_time_manager     , only : get_step_size, get_nstep
-    use SnowHydrologyMod     , only : SnowCompaction, CombineSnowLayers, DivideSnowLayers
+    use SnowHydrologyMod     , only : SnowCompaction, CombineSnowLayers, DivideSnowLayers, SnowCapping
     use SnowHydrologyMod     , only : SnowWater, BuildSnowFilter 
     use SoilHydrologyMod     , only : CLMVICMap, SurfaceRunoff, Infiltration, WaterTable
     use SoilWaterMovementMod , only : SoilWater 
@@ -297,6 +297,12 @@ contains
          !Jinyun Tang, Feb 4, 2015
          call ep_betr%CalcDewSubFlux(bounds, col_pp, num_hydrologyc, filter_hydrologyc)
       endif           
+      
+      if (use_extrasnowlayers) then
+         call SnowCapping(bounds, num_nolakec, filter_nolakec, num_snowc, filter_snowc, &
+                          aerosol_vars, waterflux_vars, waterstate_vars)
+      end if
+      
       ! Natural compaction and metamorphosis.
       call SnowCompaction(bounds, num_snowc, filter_snowc, &
            temperature_vars, waterstate_vars, top_as)

--- a/components/clm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/clm/src/biogeophys/LakeFluxesMod.F90
@@ -50,7 +50,7 @@ contains
     use clm_varpar          , only : nlevlak
     use clm_varcon          , only : hvap, hsub, hfus, cpair, cpliq, tkwat, tkice, tkair
     use clm_varcon          , only : sb, vkc, grav, denh2o, tfrz, spval, zsno
-    use clm_varctl          , only : use_lch4
+    use clm_varctl          , only : use_lch4, use_extrasnowlayers
     use LakeCon             , only : betavis, z0frzlake, tdmax, emg_lake
     use LakeCon             , only : lake_use_old_fcrit_minz0
     use LakeCon             , only : minz0lake, cur0, cus, curm, fcrit
@@ -634,10 +634,12 @@ contains
          qflx_dirct_rain(p) = 0._r8
          qflx_leafdrip(p) = 0._r8
 
-         ! Because they will be used in pft2col initialize here.
-         ! This will be overwritten in LakeHydrology
-         qflx_snwcp_ice(p) = 0._r8
-         qflx_snwcp_liq(p) = 0._r8
+         if (.not. use_extrasnowlayers) then
+            ! Because they will be used in pft2col initialize here.
+            ! This will be overwritten in LakeHydrology
+            qflx_snwcp_ice(p) = 0._r8
+            qflx_snwcp_liq(p) = 0._r8
+         end if
 
       end do
 

--- a/components/clm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/clm/src/biogeophys/LakeHydrologyMod.F90
@@ -135,6 +135,7 @@ contains
          forc_rain            =>  top_af%rain                           , & ! Input:  [real(r8) (:)   ]  rain rate (kg H2O/m**2/s, or mm liquid H2O/s)                        
          forc_snow            =>  top_af%snow                           , & ! Input:  [real(r8) (:)   ]  snow rate (kg H2O/m**2/s, or mm liquid H2O/s)                        
          forc_t               =>  top_as%tbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)        
+         forc_wind            =>  top_as%windbot                        , & ! Input:  [real(r8) (:) ]  atmospheric wind speed (m/s)
          qflx_floodg          =>  atm2lnd_vars%forc_flood_grc           , & ! Input:  [real(r8) (:)   ]  gridcell flux of flood water from RTM   
 
          watsat               =>  soilstate_vars%watsat_col             , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)
@@ -495,7 +496,7 @@ contains
       ! Natural compaction and metamorphosis.
 
       call SnowCompaction(bounds, num_shlakesnowc, filter_shlakesnowc, &
-           temperature_vars, waterstate_vars)
+           temperature_vars, waterstate_vars, top_as)
 
       ! Combine thin snow elements
 

--- a/components/clm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/clm/src/biogeophys/LakeHydrologyMod.F90
@@ -695,7 +695,7 @@ contains
             qflx_qrgwl(c)     = forc_rain(t) + forc_snow(t) - qflx_evap_tot(p) - qflx_snwcp_ice(p) - &
               (endwb(c)-begwb(c))/dtime + qflx_floodg(g)
          else ! qlfx_snwcp_ice(c) has been computed in routine SnowCapping
-            qflx_qrgwl(c)     = forc_rain(t) + forc_snow(t) - qflx_evap_tot(p) - qflx_snwcp_ice(c) - &
+            qflx_qrgwl(c)     = forc_rain(t) + forc_snow(t) - qflx_evap_tot(p) - qflx_snwcp_ice_col(c) - &
               (endwb(c)-begwb(c))/dtime + qflx_floodg(g)
          end if
          qflx_floodc(c)    = qflx_floodg(g)

--- a/components/clm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/clm/src/biogeophys/LakeHydrologyMod.F90
@@ -63,6 +63,7 @@ contains
     !    -> SnowCompaction:        compaction of snow layers
     !    -> CombineSnowLayers:     combine snow layers that are thinner than minimum
     !    -> DivideSnowLayers:      subdivide snow layers that are thicker than maximum
+    !    -> DivideExtraSnowLayers: subdivide up to 16 snow layers that are thicker than maximum    
     !
     !    Add water to soil if melting has left it with open pore space.
     !    If snow layers are found above a lake with unfrozen top layer, whose top
@@ -76,7 +77,7 @@ contains
     use clm_varctl      , only : iulog, use_extrasnowlayers
     use clm_time_manager, only : get_step_size
     use SnowHydrologyMod, only : SnowCompaction, CombineSnowLayers, SnowWater, BuildSnowFilter
-    use SnowHydrologyMod, only : DivideSnowLayers, SnowCapping
+    use SnowHydrologyMod, only : DivideSnowLayers, DivideExtraSnowLayers, SnowCapping
     use LakeCon         , only : lsadz
     !
     ! !ARGUMENTS:
@@ -514,10 +515,14 @@ contains
            aerosol_vars, temperature_vars, waterflux_vars, waterstate_vars)
 
       ! Divide thick snow elements
-
-      call DivideSnowLayers(bounds, num_shlakesnowc, filter_shlakesnowc, &
-           aerosol_vars, temperature_vars, waterstate_vars, is_lake=.true.)
-
+      if (.not. use_extrasnowlayers) then
+         call DivideSnowLayers(bounds, num_shlakesnowc, filter_shlakesnowc, &
+              aerosol_vars, temperature_vars, waterstate_vars, is_lake=.true.)
+      else
+         call DivideExtraSnowLayers(bounds, num_shlakesnowc, filter_shlakesnowc, &
+              aerosol_vars, temperature_vars, waterstate_vars, is_lake=.true.)
+      endif
+      
       ! Check for single completely unfrozen snow layer over lake.  Modeling this ponding is unnecessary and
       ! can cause instability after the timestep when melt is completed, as the temperature after melt can be
       ! excessive because the fluxes were calculated with a fixed ground temperature of freezing, but the 

--- a/components/clm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/clm/src/biogeophys/LakeHydrologyMod.F90
@@ -73,10 +73,10 @@ contains
     ! !USES:
     use clm_varcon      , only : denh2o, denice, spval, hfus, tfrz, cpliq, cpice
     use clm_varpar      , only : nlevsno, nlevgrnd, nlevsoi
-    use clm_varctl      , only : iulog
+    use clm_varctl      , only : iulog, use_extrasnowlayers
     use clm_time_manager, only : get_step_size
     use SnowHydrologyMod, only : SnowCompaction, CombineSnowLayers, SnowWater, BuildSnowFilter
-    use SnowHydrologyMod, only : DivideSnowLayers
+    use SnowHydrologyMod, only : DivideSnowLayers, SnowCapping
     use LakeCon         , only : lsadz
     !
     ! !ARGUMENTS:
@@ -247,15 +247,19 @@ contains
 
          qflx_dirct_rain(p) = 0._r8
          qflx_leafdrip(p) = 0._r8
-
-         if (do_capsnow(c)) then
-            qflx_snwcp_ice(p) = qflx_prec_grnd_snow(p)
-            qflx_snwcp_liq(p) = qflx_prec_grnd_rain(p)
-            qflx_snow_grnd_patch(p) = 0._r8
-            qflx_rain_grnd(p) = 0._r8
+         if (.not. use_extrasnowlayers) then
+            if (do_capsnow(c)) then
+               qflx_snwcp_ice(p) = qflx_prec_grnd_snow(p)
+               qflx_snwcp_liq(p) = qflx_prec_grnd_rain(p)
+               qflx_snow_grnd_patch(p) = 0._r8
+               qflx_rain_grnd(p) = 0._r8
+            else
+               qflx_snwcp_ice(p) = 0._r8
+               qflx_snwcp_liq(p) = 0._r8
+               qflx_snow_grnd_patch(p) = qflx_prec_grnd_snow(p)           ! ice onto ground (mm/s)
+               qflx_rain_grnd(p)     = qflx_prec_grnd_rain(p)           ! liquid water onto ground (mm/s)
+            end if
          else
-            qflx_snwcp_ice(p) = 0._r8
-            qflx_snwcp_liq(p) = 0._r8
             qflx_snow_grnd_patch(p) = qflx_prec_grnd_snow(p)           ! ice onto ground (mm/s)
             qflx_rain_grnd(p)     = qflx_prec_grnd_rain(p)           ! liquid water onto ground (mm/s)
          end if
@@ -275,7 +279,7 @@ contains
          ! U.S.Department of Agriculture Forest Service, Project F,
          ! Progress Rep. 1, Alta Avalanche Study Center:Snow Layer Densification.
 
-         if (do_capsnow(c)) then
+         if (do_capsnow(c) .and. .not. use_extrasnowlayers) then
             dz_snowf = 0._r8
          else
             if (forc_t(t) > tfrz + 2._r8) then
@@ -368,7 +372,7 @@ contains
             ! Update the pft-level qflx_snowcap
             ! This was moved in from Hydrology2 to keep all pft-level
             ! calculations out of Hydrology2
-            if (do_capsnow(c)) then
+            if (do_capsnow(c) .and. .not. use_extrasnowlayers) then
                qflx_snwcp_ice(p) = qflx_snwcp_ice(p) + qflx_dew_snow(p) 
                qflx_snwcp_liq(p) = qflx_snwcp_liq(p) + qflx_dew_grnd(p)
             end if
@@ -390,7 +394,7 @@ contains
             ! Update snow pack for dew & sub.
 
             h2osno_temp = h2osno(c)
-            if (do_capsnow(c)) then
+            if (do_capsnow(c) .and. .not. use_extrasnowlayers) then
                h2osno(c) = h2osno(c) - qflx_sub_snow(p)*dtime
                qflx_snwcp_ice(p) = qflx_snwcp_ice(p) + qflx_dew_snow(p) 
                qflx_snwcp_liq(p) = qflx_snwcp_liq(p) + qflx_dew_grnd(p)
@@ -406,9 +410,10 @@ contains
             h2osno(c) = max(h2osno(c), 0._r8)
          end if
 
-         qflx_snwcp_ice_col(c) = qflx_snwcp_ice(p)
-         qflx_snwcp_liq_col(c) = qflx_snwcp_liq(p)
-
+         if (.not. use_extrasnowlayers) then
+            qflx_snwcp_ice_col(c) = qflx_snwcp_ice(p)
+            qflx_snwcp_liq_col(c) = qflx_snwcp_liq(p)
+         end if
 
       end do
 
@@ -452,6 +457,11 @@ contains
       call SnowWater(bounds, &
            num_shlakesnowc, filter_shlakesnowc, num_shlakenosnowc, filter_shlakenosnowc, &
            atm2lnd_vars, waterflux_vars, waterstate_vars, aerosol_vars)
+           
+      if (use_extrasnowlayers) then
+         call SnowCapping(bounds, num_lakec, filter_lakec, num_shlakesnowc, filter_shlakesnowc, &
+                          aerosol_vars, waterflux_vars, waterstate_vars)
+      end if
 
       ! Determine soil hydrology
       ! Here this consists only of making sure that soil is saturated even as it melts and
@@ -676,8 +686,13 @@ contains
          qflx_irrig_col(c)     = 0._r8
 
          ! Insure water balance using qflx_qrgwl
-         qflx_qrgwl(c)     = forc_rain(t) + forc_snow(t) - qflx_evap_tot(p) - qflx_snwcp_ice(p) - &
+         if (.not. use_extrasnowlayers) then
+            qflx_qrgwl(c)     = forc_rain(t) + forc_snow(t) - qflx_evap_tot(p) - qflx_snwcp_ice(p) - &
               (endwb(c)-begwb(c))/dtime + qflx_floodg(g)
+         else ! qlfx_snwcp_ice(c) has been computed in routine SnowCapping
+            qflx_qrgwl(c)     = forc_rain(t) + forc_snow(t) - qflx_evap_tot(p) - qflx_snwcp_ice(c) - &
+              (endwb(c)-begwb(c))/dtime + qflx_floodg(g)
+         end if
          qflx_floodc(c)    = qflx_floodg(g)
          qflx_runoff(c)    = qflx_drain(c) + qflx_qrgwl(c)
          qflx_top_soil(c)  = qflx_prec_grnd_rain(p) + qflx_snomelt(c)

--- a/components/clm/src/biogeophys/SnowHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SnowHydrologyMod.F90
@@ -18,7 +18,7 @@ module SnowHydrologyMod
   use decompMod       , only : bounds_type
   use abortutils      , only : endrun
   use clm_varpar      , only : nlevsno
-  use clm_varctl      , only : iulog
+  use clm_varctl      , only : iulog, use_extrasnowlayers
   use clm_varcon      , only : namec
   use atm2lndType     , only : atm2lnd_type
   use AerosolType     , only : aerosol_type
@@ -40,6 +40,7 @@ module SnowHydrologyMod
   public :: CombineSnowLayers          ! Combine snow layers less than a min thickness
   public :: DivideSnowLayers           ! Subdivide snow layers if they exceed maximum thickness
   public :: BuildSnowFilter            ! Construct snow/no-snow filters
+  public :: InitSnowLayers             ! Initialize cold-start snow layer thickness  
   !
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: Combo            ! Returns the combined variables: dz, t, wliq, wice.
@@ -77,6 +78,25 @@ module SnowHydrologyMod
   !real(r8), public, parameter :: scvng_fct_mlt_dst3  = 0.03_r8   ! scavenging factor for dust species 3 inclusion in meltwater [frc]
   !real(r8), public, parameter :: scvng_fct_mlt_dst4  = 0.03_r8   ! scavenging factor for dust species 4 inclusion in meltwater [frc]
   ! ++
+  
+  !++ams (from CESM2)
+  ! Definition of snow pack vertical structure
+  ! Hardcoded maximum of 16 snowlayers
+  ! The bottom layer has no limit on thickness, hence the last element of the dzmax_*
+  ! arrays is 'huge'.
+  real(r8), parameter :: dzmin16(16) = &      ! minimum of top snow layer
+               (/ 0.010_r8, 0.015_r8, 0.025_r8, 0.055_r8, 0.115_r8, 0.235_r8, &
+                  0.475_r8, 0.955_r8, 1.915_r8, 1.915_r8, 1.915_r8, 1.915_r8, &
+                  1.915_r8, 1.915_r8, 1.915_r8, 1.915_r8 /)
+  real(r8), parameter :: dzmax_l(16) = &    ! maximum thickness of layer when no layers beneath
+               (/ 0.03_r8, 0.07_r8, 0.18_r8, 0.41_r8, 0.88_r8, 1.83_r8, &
+                  3.74_r8, 7.57_r8, 15.24_r8, 15.24_r8, 15.24_r8, 15.24_r8, &
+                  15.24_r8, 15.24_r8, 15.24_r8, huge(1._r8)  /)
+  real(r8), parameter :: dzmax_u(16) = &    ! maximum thickness of layer when layers beneath
+               (/ 0.02_r8, 0.05_r8, 0.11_r8, 0.23_r8, 0.47_r8, 0.95_r8, &
+                  1.91_r8, 3.83_r8, 7.67_r8, 7.67_r8, 7.67_r8, 7.67_r8, & 
+                  7.67_r8, 7.67_r8, 7.67_r8, huge(1._r8)  /)
+  !ams++
 
 contains
 
@@ -704,13 +724,16 @@ contains
      integer :: msn_old(bounds%begc:bounds%endc) ! number of top snow layer
      integer :: mssi(bounds%begc:bounds%endc)    ! node index
      integer :: neibor                           ! adjacent node selected for combination
+     real(r8):: dzminloc_mssi_c                  ! dzminloc evaluated at mssi(c)
      real(r8):: zwice(bounds%begc:bounds%endc)   ! total ice mass in snow
      real(r8):: zwliq (bounds%begc:bounds%endc)  ! total liquid water in snow
      real(r8):: dzmin(5)                         ! minimum of top snow layer
-     real(r8):: dzminloc(5)                      ! minimum of top snow layer (local)
+     real(r8):: dzminloc(5)                ! minimum of top snow layer (local)
+     real(r8):: dzminloc16(16)             ! minimum of top snow layer (local)
      real(r8):: dtime                            !land model time step (sec)
 
      data dzmin /0.010_r8, 0.015_r8, 0.025_r8, 0.055_r8, 0.115_r8/
+
      !-----------------------------------------------------------------------
 
      associate(                                                     & 
@@ -754,7 +777,12 @@ contains
        ! Check the mass of ice lens of snow, when the total is less than a small value,
        ! combine it with the underlying neighbor.
 
-       dzminloc(:) = dzmin(:) ! dzmin will stay constant between timesteps
+       ! dzmin will stay constant between timesteps
+       if (.not. use_extrasnowlayers) then
+         dzminloc(:) = dzmin(:)
+       else
+         dzminloc16(:) = dzmin16(:)
+       endif
 
        ! Add lsadz to dzmin for lakes
        ! Determine whether called from LakeHydrology
@@ -763,7 +791,11 @@ contains
           c = filter_snowc(1)
           l = col_pp%landunit(c)
           if (ltype(l) == istdlak) then ! Called from LakeHydrology
-             dzminloc(:) = dzmin(:) + lsadz
+            if (.not. use_extrasnowlayers) then
+               dzminloc(:) = dzmin(:) + lsadz
+            else
+               dzminloc16(:) = dzmin16(:) + lsadz
+            end if
           end if
        end if
 
@@ -942,7 +974,12 @@ contains
              mssi(c) = 1
 
              do i = msn_old(c)+1,0
-                if ((frac_sno_eff(c)*dz(c,i) < dzminloc(mssi(c))) .or. &
+                if (.not. use_extrasnowlayers) then
+                    dzminloc_mssi_c = dzminloc(mssi(c))
+                else
+                    dzminloc_mssi_c = dzminloc16(mssi(c))
+                end if
+                if ((frac_sno_eff(c)*dz(c,i) < dzminloc_mssi_c) .or. &
                      ((h2osoi_ice(c,i) + h2osoi_liq(c,i))/(frac_sno_eff(c)*dz(c,i)) < 50._r8)) then
                    if (i == snl(c)+1) then
                       ! If top node is removed, combine with bottom neighbor.
@@ -1058,7 +1095,7 @@ contains
      logical                , intent(in)    :: is_lake  !TODO - this should be examined and removed in the future
      !
      ! !LOCAL VARIABLES:
-     integer  :: j, c, fc                                 ! indices
+     integer  :: j, c, fc, k                              ! indices
      real(r8) :: drr                                      ! thickness of the combined [m]
      integer  :: msno                                     ! number of snow layer 1 (top) to msno (bottom)
      real(r8) :: dzsno(bounds%begc:bounds%endc,nlevsno)   ! Snow layer thickness [m]
@@ -1167,475 +1204,612 @@ contains
           end do
        end do
 
-       do fc = 1, num_snowc
-          c = filter_snowc(fc)
+       if (.not. use_extrasnowlayers) then
+           do fc = 1, num_snowc
+              c = filter_snowc(fc)
 
-          msno = abs(snl(c))
+              msno = abs(snl(c))
 
-          if (msno == 1) then
-             ! Specify a new snow layer
-             if (is_lake) then
-                offset = 2._r8 * lsadz
-             else
-                offset = 0._r8
-             end if
-             if (dzsno(c,1) > 0.03_r8 + offset) then
-                msno = 2
-                dzsno(c,1) = dzsno(c,1)/2._r8
-                swice(c,1) = swice(c,1)/2._r8
-                swliq(c,1) = swliq(c,1)/2._r8
-                dzsno(c,2) = dzsno(c,1)
-                swice(c,2) = swice(c,1)
-                swliq(c,2) = swliq(c,1)
-                tsno(c,2)  = tsno(c,1)
+              if (msno == 1) then
+                 ! Specify a new snow layer
+                 if (is_lake) then
+                    offset = 2._r8 * lsadz
+                 else
+                    offset = 0._r8
+                 end if
+                 if (dzsno(c,1) > 0.03_r8 + offset) then
+                    msno = 2
+                    dzsno(c,1) = dzsno(c,1)/2._r8
+                    swice(c,1) = swice(c,1)/2._r8
+                    swliq(c,1) = swliq(c,1)/2._r8
+                    dzsno(c,2) = dzsno(c,1)
+                    swice(c,2) = swice(c,1)
+                    swliq(c,2) = swliq(c,1)
+                    tsno(c,2)  = tsno(c,1)
 
-                mbc_phi(c,1) = mbc_phi(c,1)/2._r8
-                mbc_phi(c,2) = mbc_phi(c,1)
-                mbc_pho(c,1) = mbc_pho(c,1)/2._r8
-                mbc_pho(c,2) = mbc_pho(c,1)
-                moc_phi(c,1) = moc_phi(c,1)/2._r8
-                moc_phi(c,2) = moc_phi(c,1)
-                moc_pho(c,1) = moc_pho(c,1)/2._r8
-                moc_pho(c,2) = moc_pho(c,1)
-                mdst1(c,1) = mdst1(c,1)/2._r8
-                mdst1(c,2) = mdst1(c,1)
-                mdst2(c,1) = mdst2(c,1)/2._r8
-                mdst2(c,2) = mdst2(c,1)
-                mdst3(c,1) = mdst3(c,1)/2._r8
-                mdst3(c,2) = mdst3(c,1)
-                mdst4(c,1) = mdst4(c,1)/2._r8
-                mdst4(c,2) = mdst4(c,1)
-                rds(c,2) = rds(c,1)
+                    mbc_phi(c,1) = mbc_phi(c,1)/2._r8
+                    mbc_phi(c,2) = mbc_phi(c,1)
+                    mbc_pho(c,1) = mbc_pho(c,1)/2._r8
+                    mbc_pho(c,2) = mbc_pho(c,1)
+                    moc_phi(c,1) = moc_phi(c,1)/2._r8
+                    moc_phi(c,2) = moc_phi(c,1)
+                    moc_pho(c,1) = moc_pho(c,1)/2._r8
+                    moc_pho(c,2) = moc_pho(c,1)
+                    mdst1(c,1) = mdst1(c,1)/2._r8
+                    mdst1(c,2) = mdst1(c,1)
+                    mdst2(c,1) = mdst2(c,1)/2._r8
+                    mdst2(c,2) = mdst2(c,1)
+                    mdst3(c,1) = mdst3(c,1)/2._r8
+                    mdst3(c,2) = mdst3(c,1)
+                    mdst4(c,1) = mdst4(c,1)/2._r8
+                    mdst4(c,2) = mdst4(c,1)
+                    rds(c,2) = rds(c,1)
 
-             end if
-          end if
+                 end if
+              end if
 
-          if (msno > 1) then
-             if (is_lake) then
-                offset = lsadz
-             else
-                offset = 0._r8
-             end if
-             if (dzsno(c,1) > 0.02_r8 + offset) then
-                if (is_lake) then
-                   drr = dzsno(c,1) - 0.02_r8 - lsadz
-                else
-                   drr = dzsno(c,1) - 0.02_r8
-                end if
-                propor = drr/dzsno(c,1)
-                zwice = propor*swice(c,1)
-                zwliq = propor*swliq(c,1)
+              if (msno > 1) then
+                 if (is_lake) then
+                    offset = lsadz
+                 else
+                    offset = 0._r8
+                 end if
+                 if (dzsno(c,1) > 0.02_r8 + offset) then
+                    if (is_lake) then
+                       drr = dzsno(c,1) - 0.02_r8 - lsadz
+                    else
+                       drr = dzsno(c,1) - 0.02_r8
+                    end if
+                    propor = drr/dzsno(c,1)
+                    zwice = propor*swice(c,1)
+                    zwliq = propor*swliq(c,1)
 
-                zmbc_phi = propor*mbc_phi(c,1)
-                zmbc_pho = propor*mbc_pho(c,1)
-                zmoc_phi = propor*moc_phi(c,1)
-                zmoc_pho = propor*moc_pho(c,1)
-                zmdst1 = propor*mdst1(c,1)
-                zmdst2 = propor*mdst2(c,1)
-                zmdst3 = propor*mdst3(c,1)
-                zmdst4 = propor*mdst4(c,1)
+                    zmbc_phi = propor*mbc_phi(c,1)
+                    zmbc_pho = propor*mbc_pho(c,1)
+                    zmoc_phi = propor*moc_phi(c,1)
+                    zmoc_pho = propor*moc_pho(c,1)
+                    zmdst1 = propor*mdst1(c,1)
+                    zmdst2 = propor*mdst2(c,1)
+                    zmdst3 = propor*mdst3(c,1)
+                    zmdst4 = propor*mdst4(c,1)
 
-                if (is_lake) then
-                   propor = (0.02_r8+lsadz)/dzsno(c,1)
-                else
-                   propor = 0.02_r8/dzsno(c,1)
-                endif 
+                    if (is_lake) then
+                       propor = (0.02_r8+lsadz)/dzsno(c,1)
+                    else
+                       propor = 0.02_r8/dzsno(c,1)
+                    endif 
 
-                swice(c,1) = propor*swice(c,1)
-                swliq(c,1) = propor*swliq(c,1)
+                    swice(c,1) = propor*swice(c,1)
+                    swliq(c,1) = propor*swliq(c,1)
 
-                mbc_phi(c,1) = propor*mbc_phi(c,1)
-                mbc_pho(c,1) = propor*mbc_pho(c,1)
-                moc_phi(c,1) = propor*moc_phi(c,1)
-                moc_pho(c,1) = propor*moc_pho(c,1)
-                mdst1(c,1) = propor*mdst1(c,1)
-                mdst2(c,1) = propor*mdst2(c,1)
-                mdst3(c,1) = propor*mdst3(c,1)
-                mdst4(c,1) = propor*mdst4(c,1)
+                    mbc_phi(c,1) = propor*mbc_phi(c,1)
+                    mbc_pho(c,1) = propor*mbc_pho(c,1)
+                    moc_phi(c,1) = propor*moc_phi(c,1)
+                    moc_pho(c,1) = propor*moc_pho(c,1)
+                    mdst1(c,1) = propor*mdst1(c,1)
+                    mdst2(c,1) = propor*mdst2(c,1)
+                    mdst3(c,1) = propor*mdst3(c,1)
+                    mdst4(c,1) = propor*mdst4(c,1)
 
-                if (is_lake) then
-                   dzsno(c,1) = 0.02_r8 + lsadz
-                else
-                   dzsno(c,1) = 0.02_r8
-                end if
+                    if (is_lake) then
+                       dzsno(c,1) = 0.02_r8 + lsadz
+                    else
+                       dzsno(c,1) = 0.02_r8
+                    end if
 
-                mbc_phi(c,2) = mbc_phi(c,2)+zmbc_phi  ! (combo)
-                mbc_pho(c,2) = mbc_pho(c,2)+zmbc_pho  ! (combo)
-                moc_phi(c,2) = moc_phi(c,2)+zmoc_phi  ! (combo)
-                moc_pho(c,2) = moc_pho(c,2)+zmoc_pho  ! (combo)
-                mdst1(c,2) = mdst1(c,2)+zmdst1  ! (combo)
-                mdst2(c,2) = mdst2(c,2)+zmdst2  ! (combo)
-                mdst3(c,2) = mdst3(c,2)+zmdst3  ! (combo)
-                mdst4(c,2) = mdst4(c,2)+zmdst4  ! (combo)
+                    mbc_phi(c,2) = mbc_phi(c,2)+zmbc_phi  ! (combo)
+                    mbc_pho(c,2) = mbc_pho(c,2)+zmbc_pho  ! (combo)
+                    moc_phi(c,2) = moc_phi(c,2)+zmoc_phi  ! (combo)
+                    moc_pho(c,2) = moc_pho(c,2)+zmoc_pho  ! (combo)
+                    mdst1(c,2) = mdst1(c,2)+zmdst1  ! (combo)
+                    mdst2(c,2) = mdst2(c,2)+zmdst2  ! (combo)
+                    mdst3(c,2) = mdst3(c,2)+zmdst3  ! (combo)
+                    mdst4(c,2) = mdst4(c,2)+zmdst4  ! (combo)
 #ifdef MODAL_AER
-             !mgf++ bugfix
-             rds(c,2) = (rds(c,2)*(swliq(c,2)+swice(c,2)) + rds(c,1)*(zwliq+zwice))/(swliq(c,2)+swice(c,2)+zwliq+zwice)
-               if ((rds(c,2) < 30.) .or. (rds(c,2) > 1500.)) then
-                  write (iulog,*) "2. SNICAR ERROR: snow grain radius of",rds(c,2),rds(c,1)
-                  write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,2), swice(c,2),zwliq, zwice
-                  write (iulog,*) "layers ", msno
-               endif
-             !mgf--
-#else
-             rds(c,2) = rds(c,1) ! (combo)
-#endif
-
-                call Combo (dzsno(c,2), swliq(c,2), swice(c,2), tsno(c,2), drr, &
-                     zwliq, zwice, tsno(c,1))
-
-                ! Subdivide a new layer
-                if (is_lake) then
-                   offset = 2._r8*lsadz
-                else
-                   offset = 0._r8
-                end if
-                if (msno <= 2 .and. dzsno(c,2) > 0.07_r8 + offset) then
-                   msno = 3
-                   dtdz = (tsno(c,1) - tsno(c,2))/((dzsno(c,1)+dzsno(c,2))/2._r8) 
-                   dzsno(c,2) = dzsno(c,2)/2._r8
-                   swice(c,2) = swice(c,2)/2._r8
-                   swliq(c,2) = swliq(c,2)/2._r8
-                   dzsno(c,3) = dzsno(c,2)
-                   swice(c,3) = swice(c,2)
-                   swliq(c,3) = swliq(c,2)
-                   tsno(c,3) = tsno(c,2) - dtdz*dzsno(c,2)/2._r8
-                   if (tsno(c,3) >= tfrz) then 
-                      tsno(c,3)  = tsno(c,2)
-                   else
-                      tsno(c,2) = tsno(c,2) + dtdz*dzsno(c,2)/2._r8 
+                 !mgf++ bugfix
+                 rds(c,2) = (rds(c,2)*(swliq(c,2)+swice(c,2)) + rds(c,1)*(zwliq+zwice))/(swliq(c,2)+swice(c,2)+zwliq+zwice)
+                   if ((rds(c,2) < 30.) .or. (rds(c,2) > 1500.)) then
+                      write (iulog,*) "2. SNICAR ERROR: snow grain radius of",rds(c,2),rds(c,1)
+                      write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,2), swice(c,2),zwliq, zwice
+                      write (iulog,*) "layers ", msno
                    endif
-
-                   mbc_phi(c,2) = mbc_phi(c,2)/2._r8
-                   mbc_phi(c,3) = mbc_phi(c,2)
-                   mbc_pho(c,2) = mbc_pho(c,2)/2._r8
-                   mbc_pho(c,3) = mbc_pho(c,2)
-                   moc_phi(c,2) = moc_phi(c,2)/2._r8
-                   moc_phi(c,3) = moc_phi(c,2)
-                   moc_pho(c,2) = moc_pho(c,2)/2._r8
-                   moc_pho(c,3) = moc_pho(c,2)
-                   mdst1(c,2) = mdst1(c,2)/2._r8
-                   mdst1(c,3) = mdst1(c,2)
-                   mdst2(c,2) = mdst2(c,2)/2._r8
-                   mdst2(c,3) = mdst2(c,2)
-                   mdst3(c,2) = mdst3(c,2)/2._r8
-                   mdst3(c,3) = mdst3(c,2)
-                   mdst4(c,2) = mdst4(c,2)/2._r8
-                   mdst4(c,3) = mdst4(c,2)
-                   rds(c,3) = rds(c,2)
-
-                end if
-             end if
-          end if
-
-          if (msno > 2) then
-             if (is_lake) then
-                offset = lsadz
-             else
-                offset = 0._r8
-             end if
-             if (dzsno(c,2) > 0.05_r8+offset) then
-                if (is_lake) then
-                   drr = dzsno(c,2) - 0.05_r8 - lsadz
-                else
-                   drr = dzsno(c,2) - 0.05_r8
-                end if
-                propor = drr/dzsno(c,2)
-                zwice = propor*swice(c,2)
-                zwliq = propor*swliq(c,2)
-
-                zmbc_phi = propor*mbc_phi(c,2)
-                zmbc_pho = propor*mbc_pho(c,2)
-                zmoc_phi = propor*moc_phi(c,2)
-                zmoc_pho = propor*moc_pho(c,2)
-                zmdst1 = propor*mdst1(c,2)
-                zmdst2 = propor*mdst2(c,2)
-                zmdst3 = propor*mdst3(c,2)
-                zmdst4 = propor*mdst4(c,2)
-
-                if (is_lake) then
-                   propor = (0.05_r8+lsadz)/dzsno(c,2)
-                else
-                   propor = 0.05_r8/dzsno(c,2)
-                end if
-                swice(c,2) = propor*swice(c,2)
-                swliq(c,2) = propor*swliq(c,2)
-
-                mbc_phi(c,2) = propor*mbc_phi(c,2)
-                mbc_pho(c,2) = propor*mbc_pho(c,2)
-                moc_phi(c,2) = propor*moc_phi(c,2)
-                moc_pho(c,2) = propor*moc_pho(c,2)
-                mdst1(c,2) = propor*mdst1(c,2)
-                mdst2(c,2) = propor*mdst2(c,2)
-                mdst3(c,2) = propor*mdst3(c,2)
-                mdst4(c,2) = propor*mdst4(c,2)
-
-                if (is_lake) then
-                   dzsno(c,2) = 0.05_r8+lsadz
-                else
-                   dzsno(c,2) = 0.05_r8
-                end if
-
-                mbc_phi(c,3) = mbc_phi(c,3)+zmbc_phi  ! (combo)
-                mbc_pho(c,3) = mbc_pho(c,3)+zmbc_pho  ! (combo)
-                moc_phi(c,3) = moc_phi(c,3)+zmoc_phi  ! (combo)
-                moc_pho(c,3) = moc_pho(c,3)+zmoc_pho  ! (combo)
-                mdst1(c,3) = mdst1(c,3)+zmdst1  ! (combo)
-                mdst2(c,3) = mdst2(c,3)+zmdst2  ! (combo)
-                mdst3(c,3) = mdst3(c,3)+zmdst3  ! (combo)
-                mdst4(c,3) = mdst4(c,3)+zmdst4  ! (combo)
-#ifdef MODAL_AER
-             !mgf++ bugfix
-             rds(c,3) = (rds(c,3)*(swliq(c,3)+swice(c,3)) + rds(c,2)*(zwliq+zwice))/(swliq(c,3)+swice(c,3)+zwliq+zwice)
-               if ((rds(c,3) < 30.) .or. (rds(c,3) > 1500.)) then
-                  write (iulog,*) "3. SNICAR ERROR: snow grain radius of",rds(c,3),rds(c,2)
-                  write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,3), swice(c,3),zwliq, zwice
-                  write (iulog,*) "layers ", msno
-               endif
-             !mgf--
+                 !mgf--
 #else
-             rds(c,3) = rds(c,2) ! (combo)
+                 rds(c,2) = rds(c,1) ! (combo)
 #endif
 
-                call Combo (dzsno(c,3), swliq(c,3), swice(c,3), tsno(c,3), drr, &
-                     zwliq, zwice, tsno(c,2))
+                    call Combo (dzsno(c,2), swliq(c,2), swice(c,2), tsno(c,2), drr, &
+                         zwliq, zwice, tsno(c,1))
 
-                ! Subdivided a new layer
-                if (is_lake) then
-                   offset = 2._r8*lsadz
-                else
-                   offset = 0._r8
-                end if
-                if (msno <= 3 .and. dzsno(c,3) > 0.18_r8+offset) then
-                   msno =  4
-                   dtdz = (tsno(c,2) - tsno(c,3))/((dzsno(c,2)+dzsno(c,3))/2._r8) 
-                   dzsno(c,3) = dzsno(c,3)/2._r8
-                   swice(c,3) = swice(c,3)/2._r8
-                   swliq(c,3) = swliq(c,3)/2._r8
-                   dzsno(c,4) = dzsno(c,3)
-                   swice(c,4) = swice(c,3)
-                   swliq(c,4) = swliq(c,3)
-                   tsno(c,4) = tsno(c,3) - dtdz*dzsno(c,3)/2._r8
-                   if (tsno(c,4) >= tfrz) then 
-                      tsno(c,4)  = tsno(c,3)
-                   else
-                      tsno(c,3) = tsno(c,3) + dtdz*dzsno(c,3)/2._r8 
+                    ! Subdivide a new layer
+                    if (is_lake) then
+                       offset = 2._r8*lsadz
+                    else
+                       offset = 0._r8
+                    end if
+                    if (msno <= 2 .and. dzsno(c,2) > 0.07_r8 + offset) then
+                       msno = 3
+                       dtdz = (tsno(c,1) - tsno(c,2))/((dzsno(c,1)+dzsno(c,2))/2._r8) 
+                       dzsno(c,2) = dzsno(c,2)/2._r8
+                       swice(c,2) = swice(c,2)/2._r8
+                       swliq(c,2) = swliq(c,2)/2._r8
+                       dzsno(c,3) = dzsno(c,2)
+                       swice(c,3) = swice(c,2)
+                       swliq(c,3) = swliq(c,2)
+                       tsno(c,3) = tsno(c,2) - dtdz*dzsno(c,2)/2._r8
+                       if (tsno(c,3) >= tfrz) then 
+                          tsno(c,3)  = tsno(c,2)
+                       else
+                          tsno(c,2) = tsno(c,2) + dtdz*dzsno(c,2)/2._r8 
+                       endif
+
+                       mbc_phi(c,2) = mbc_phi(c,2)/2._r8
+                       mbc_phi(c,3) = mbc_phi(c,2)
+                       mbc_pho(c,2) = mbc_pho(c,2)/2._r8
+                       mbc_pho(c,3) = mbc_pho(c,2)
+                       moc_phi(c,2) = moc_phi(c,2)/2._r8
+                       moc_phi(c,3) = moc_phi(c,2)
+                       moc_pho(c,2) = moc_pho(c,2)/2._r8
+                       moc_pho(c,3) = moc_pho(c,2)
+                       mdst1(c,2) = mdst1(c,2)/2._r8
+                       mdst1(c,3) = mdst1(c,2)
+                       mdst2(c,2) = mdst2(c,2)/2._r8
+                       mdst2(c,3) = mdst2(c,2)
+                       mdst3(c,2) = mdst3(c,2)/2._r8
+                       mdst3(c,3) = mdst3(c,2)
+                       mdst4(c,2) = mdst4(c,2)/2._r8
+                       mdst4(c,3) = mdst4(c,2)
+                       rds(c,3) = rds(c,2)
+
+                    end if
+                 end if
+              end if
+
+              if (msno > 2) then
+                 if (is_lake) then
+                    offset = lsadz
+                 else
+                    offset = 0._r8
+                 end if
+                 if (dzsno(c,2) > 0.05_r8+offset) then
+                    if (is_lake) then
+                       drr = dzsno(c,2) - 0.05_r8 - lsadz
+                    else
+                       drr = dzsno(c,2) - 0.05_r8
+                    end if
+                    propor = drr/dzsno(c,2)
+                    zwice = propor*swice(c,2)
+                    zwliq = propor*swliq(c,2)
+
+                    zmbc_phi = propor*mbc_phi(c,2)
+                    zmbc_pho = propor*mbc_pho(c,2)
+                    zmoc_phi = propor*moc_phi(c,2)
+                    zmoc_pho = propor*moc_pho(c,2)
+                    zmdst1 = propor*mdst1(c,2)
+                    zmdst2 = propor*mdst2(c,2)
+                    zmdst3 = propor*mdst3(c,2)
+                    zmdst4 = propor*mdst4(c,2)
+
+                    if (is_lake) then
+                       propor = (0.05_r8+lsadz)/dzsno(c,2)
+                    else
+                       propor = 0.05_r8/dzsno(c,2)
+                    end if
+                    swice(c,2) = propor*swice(c,2)
+                    swliq(c,2) = propor*swliq(c,2)
+
+                    mbc_phi(c,2) = propor*mbc_phi(c,2)
+                    mbc_pho(c,2) = propor*mbc_pho(c,2)
+                    moc_phi(c,2) = propor*moc_phi(c,2)
+                    moc_pho(c,2) = propor*moc_pho(c,2)
+                    mdst1(c,2) = propor*mdst1(c,2)
+                    mdst2(c,2) = propor*mdst2(c,2)
+                    mdst3(c,2) = propor*mdst3(c,2)
+                    mdst4(c,2) = propor*mdst4(c,2)
+
+                    if (is_lake) then
+                       dzsno(c,2) = 0.05_r8+lsadz
+                    else
+                       dzsno(c,2) = 0.05_r8
+                    end if
+
+                    mbc_phi(c,3) = mbc_phi(c,3)+zmbc_phi  ! (combo)
+                    mbc_pho(c,3) = mbc_pho(c,3)+zmbc_pho  ! (combo)
+                    moc_phi(c,3) = moc_phi(c,3)+zmoc_phi  ! (combo)
+                    moc_pho(c,3) = moc_pho(c,3)+zmoc_pho  ! (combo)
+                    mdst1(c,3) = mdst1(c,3)+zmdst1  ! (combo)
+                    mdst2(c,3) = mdst2(c,3)+zmdst2  ! (combo)
+                    mdst3(c,3) = mdst3(c,3)+zmdst3  ! (combo)
+                    mdst4(c,3) = mdst4(c,3)+zmdst4  ! (combo)
+#ifdef MODAL_AER
+                 !mgf++ bugfix
+                 rds(c,3) = (rds(c,3)*(swliq(c,3)+swice(c,3)) + rds(c,2)*(zwliq+zwice))/(swliq(c,3)+swice(c,3)+zwliq+zwice)
+                   if ((rds(c,3) < 30.) .or. (rds(c,3) > 1500.)) then
+                      write (iulog,*) "3. SNICAR ERROR: snow grain radius of",rds(c,3),rds(c,2)
+                      write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,3), swice(c,3),zwliq, zwice
+                      write (iulog,*) "layers ", msno
                    endif
-
-                   mbc_phi(c,3) = mbc_phi(c,3)/2._r8
-                   mbc_phi(c,4) = mbc_phi(c,3)
-                   mbc_pho(c,3) = mbc_pho(c,3)/2._r8
-                   mbc_pho(c,4) = mbc_pho(c,3)
-                   moc_phi(c,3) = moc_phi(c,3)/2._r8
-                   moc_phi(c,4) = moc_phi(c,3)
-                   moc_pho(c,3) = moc_pho(c,3)/2._r8
-                   moc_pho(c,4) = moc_pho(c,3)
-                   mdst1(c,3) = mdst1(c,3)/2._r8
-                   mdst1(c,4) = mdst1(c,3)
-                   mdst2(c,3) = mdst2(c,3)/2._r8
-                   mdst2(c,4) = mdst2(c,3)
-                   mdst3(c,3) = mdst3(c,3)/2._r8
-                   mdst3(c,4) = mdst3(c,3)
-                   mdst4(c,3) = mdst4(c,3)/2._r8
-                   mdst4(c,4) = mdst4(c,3)
-                   rds(c,4) = rds(c,3)
-
-                end if
-             end if
-          end if
-
-          if (msno > 3) then
-             if (is_lake) then
-                offset = lsadz
-             else
-                offset = 0._r8
-             end if
-             if (dzsno(c,3) > 0.11_r8 + offset) then
-                if (is_lake) then
-                   drr = dzsno(c,3) - 0.11_r8 - lsadz
-                else
-                   drr = dzsno(c,3) - 0.11_r8
-                end if
-                propor = drr/dzsno(c,3)
-                zwice = propor*swice(c,3)
-                zwliq = propor*swliq(c,3)
-
-                zmbc_phi = propor*mbc_phi(c,3)
-                zmbc_pho = propor*mbc_pho(c,3)
-                zmoc_phi = propor*moc_phi(c,3)
-                zmoc_pho = propor*moc_pho(c,3)
-                zmdst1 = propor*mdst1(c,3)
-                zmdst2 = propor*mdst2(c,3)
-                zmdst3 = propor*mdst3(c,3)
-                zmdst4 = propor*mdst4(c,3)
-
-                if (is_lake) then
-                   propor = (0.11_r8+lsadz)/dzsno(c,3)
-                else
-                   propor = 0.11_r8/dzsno(c,3)
-                end if
-                swice(c,3) = propor*swice(c,3)
-                swliq(c,3) = propor*swliq(c,3)
-
-                mbc_phi(c,3) = propor*mbc_phi(c,3)
-                mbc_pho(c,3) = propor*mbc_pho(c,3)
-                moc_phi(c,3) = propor*moc_phi(c,3)
-                moc_pho(c,3) = propor*moc_pho(c,3)
-                mdst1(c,3) = propor*mdst1(c,3)
-                mdst2(c,3) = propor*mdst2(c,3)
-                mdst3(c,3) = propor*mdst3(c,3)
-                mdst4(c,3) = propor*mdst4(c,3)
-
-                if (is_lake) then
-                   dzsno(c,3) = 0.11_r8 + lsadz
-                else
-                   dzsno(c,3) = 0.11_r8
-                end if
-
-                mbc_phi(c,4) = mbc_phi(c,4)+zmbc_phi  ! (combo)
-                mbc_pho(c,4) = mbc_pho(c,4)+zmbc_pho  ! (combo)
-                moc_phi(c,4) = moc_phi(c,4)+zmoc_phi  ! (combo)
-                moc_pho(c,4) = moc_pho(c,4)+zmoc_pho  ! (combo)
-                mdst1(c,4) = mdst1(c,4)+zmdst1  ! (combo)
-                mdst2(c,4) = mdst2(c,4)+zmdst2  ! (combo)
-                mdst3(c,4) = mdst3(c,4)+zmdst3  ! (combo)
-                mdst4(c,4) = mdst4(c,4)+zmdst4  ! (combo)
-#ifdef MODAL_AER
-             !mgf++ bugfix
-             rds(c,4) = (rds(c,4)*(swliq(c,4)+swice(c,4)) + rds(c,3)*(zwliq+zwice))/(swliq(c,4)+swice(c,4)+zwliq+zwice)
-               if ((rds(c,4) < 30.) .or. (rds(c,4) > 1500.)) then
-                  write (iulog,*) "4. SNICAR ERROR: snow grain radius of",rds(c,4),rds(c,3)
-                  write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,4), swice(c,4),zwliq, zwice
-                  write (iulog,*) "layers ", msno
-               endif
-             !mgf--
+                 !mgf--
 #else
-             rds(c,4) = rds(c,3) ! (combo)
+                 rds(c,3) = rds(c,2) ! (combo)
 #endif
 
-                call Combo (dzsno(c,4), swliq(c,4), swice(c,4), tsno(c,4), drr, &
-                     zwliq, zwice, tsno(c,3))
+                    call Combo (dzsno(c,3), swliq(c,3), swice(c,3), tsno(c,3), drr, &
+                         zwliq, zwice, tsno(c,2))
 
-                ! Subdivided a new layer
-                if (is_lake) then
-                   offset = 2._r8*lsadz
-                else
-                   offset = 0._r8
-                end if
-                if (msno <= 4 .and. dzsno(c,4) > 0.41_r8 + offset) then
-                   msno = 5
-                   dtdz = (tsno(c,3) - tsno(c,4))/((dzsno(c,3)+dzsno(c,4))/2._r8) 
-                   dzsno(c,4) = dzsno(c,4)/2._r8
-                   swice(c,4) = swice(c,4)/2._r8
-                   swliq(c,4) = swliq(c,4)/2._r8
-                   dzsno(c,5) = dzsno(c,4)
-                   swice(c,5) = swice(c,4)
-                   swliq(c,5) = swliq(c,4)
-                   tsno(c,5) = tsno(c,4) - dtdz*dzsno(c,4)/2._r8 
-                   if (tsno(c,5) >= tfrz) then 
-                      tsno(c,5)  = tsno(c,4)
-                   else
-                      tsno(c,4) = tsno(c,4) + dtdz*dzsno(c,4)/2._r8 
+                    ! Subdivided a new layer
+                    if (is_lake) then
+                       offset = 2._r8*lsadz
+                    else
+                       offset = 0._r8
+                    end if
+                    if (msno <= 3 .and. dzsno(c,3) > 0.18_r8+offset) then
+                       msno =  4
+                       dtdz = (tsno(c,2) - tsno(c,3))/((dzsno(c,2)+dzsno(c,3))/2._r8) 
+                       dzsno(c,3) = dzsno(c,3)/2._r8
+                       swice(c,3) = swice(c,3)/2._r8
+                       swliq(c,3) = swliq(c,3)/2._r8
+                       dzsno(c,4) = dzsno(c,3)
+                       swice(c,4) = swice(c,3)
+                       swliq(c,4) = swliq(c,3)
+                       tsno(c,4) = tsno(c,3) - dtdz*dzsno(c,3)/2._r8
+                       if (tsno(c,4) >= tfrz) then 
+                          tsno(c,4)  = tsno(c,3)
+                       else
+                          tsno(c,3) = tsno(c,3) + dtdz*dzsno(c,3)/2._r8 
+                       endif
+
+                       mbc_phi(c,3) = mbc_phi(c,3)/2._r8
+                       mbc_phi(c,4) = mbc_phi(c,3)
+                       mbc_pho(c,3) = mbc_pho(c,3)/2._r8
+                       mbc_pho(c,4) = mbc_pho(c,3)
+                       moc_phi(c,3) = moc_phi(c,3)/2._r8
+                       moc_phi(c,4) = moc_phi(c,3)
+                       moc_pho(c,3) = moc_pho(c,3)/2._r8
+                       moc_pho(c,4) = moc_pho(c,3)
+                       mdst1(c,3) = mdst1(c,3)/2._r8
+                       mdst1(c,4) = mdst1(c,3)
+                       mdst2(c,3) = mdst2(c,3)/2._r8
+                       mdst2(c,4) = mdst2(c,3)
+                       mdst3(c,3) = mdst3(c,3)/2._r8
+                       mdst3(c,4) = mdst3(c,3)
+                       mdst4(c,3) = mdst4(c,3)/2._r8
+                       mdst4(c,4) = mdst4(c,3)
+                       rds(c,4) = rds(c,3)
+
+                    end if
+                 end if
+              end if
+
+              if (msno > 3) then
+                 if (is_lake) then
+                    offset = lsadz
+                 else
+                    offset = 0._r8
+                 end if
+                 if (dzsno(c,3) > 0.11_r8 + offset) then
+                    if (is_lake) then
+                       drr = dzsno(c,3) - 0.11_r8 - lsadz
+                    else
+                       drr = dzsno(c,3) - 0.11_r8
+                    end if
+                    propor = drr/dzsno(c,3)
+                    zwice = propor*swice(c,3)
+                    zwliq = propor*swliq(c,3)
+
+                    zmbc_phi = propor*mbc_phi(c,3)
+                    zmbc_pho = propor*mbc_pho(c,3)
+                    zmoc_phi = propor*moc_phi(c,3)
+                    zmoc_pho = propor*moc_pho(c,3)
+                    zmdst1 = propor*mdst1(c,3)
+                    zmdst2 = propor*mdst2(c,3)
+                    zmdst3 = propor*mdst3(c,3)
+                    zmdst4 = propor*mdst4(c,3)
+
+                    if (is_lake) then
+                       propor = (0.11_r8+lsadz)/dzsno(c,3)
+                    else
+                       propor = 0.11_r8/dzsno(c,3)
+                    end if
+                    swice(c,3) = propor*swice(c,3)
+                    swliq(c,3) = propor*swliq(c,3)
+
+                    mbc_phi(c,3) = propor*mbc_phi(c,3)
+                    mbc_pho(c,3) = propor*mbc_pho(c,3)
+                    moc_phi(c,3) = propor*moc_phi(c,3)
+                    moc_pho(c,3) = propor*moc_pho(c,3)
+                    mdst1(c,3) = propor*mdst1(c,3)
+                    mdst2(c,3) = propor*mdst2(c,3)
+                    mdst3(c,3) = propor*mdst3(c,3)
+                    mdst4(c,3) = propor*mdst4(c,3)
+
+                    if (is_lake) then
+                       dzsno(c,3) = 0.11_r8 + lsadz
+                    else
+                       dzsno(c,3) = 0.11_r8
+                    end if
+
+                    mbc_phi(c,4) = mbc_phi(c,4)+zmbc_phi  ! (combo)
+                    mbc_pho(c,4) = mbc_pho(c,4)+zmbc_pho  ! (combo)
+                    moc_phi(c,4) = moc_phi(c,4)+zmoc_phi  ! (combo)
+                    moc_pho(c,4) = moc_pho(c,4)+zmoc_pho  ! (combo)
+                    mdst1(c,4) = mdst1(c,4)+zmdst1  ! (combo)
+                    mdst2(c,4) = mdst2(c,4)+zmdst2  ! (combo)
+                    mdst3(c,4) = mdst3(c,4)+zmdst3  ! (combo)
+                    mdst4(c,4) = mdst4(c,4)+zmdst4  ! (combo)
+#ifdef MODAL_AER
+                 !mgf++ bugfix
+                 rds(c,4) = (rds(c,4)*(swliq(c,4)+swice(c,4)) + rds(c,3)*(zwliq+zwice))/(swliq(c,4)+swice(c,4)+zwliq+zwice)
+                   if ((rds(c,4) < 30.) .or. (rds(c,4) > 1500.)) then
+                      write (iulog,*) "4. SNICAR ERROR: snow grain radius of",rds(c,4),rds(c,3)
+                      write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,4), swice(c,4),zwliq, zwice
+                      write (iulog,*) "layers ", msno
                    endif
-
-                   mbc_phi(c,4) = mbc_phi(c,4)/2._r8
-                   mbc_phi(c,5) = mbc_phi(c,4)
-                   mbc_pho(c,4) = mbc_pho(c,4)/2._r8
-                   mbc_pho(c,5) = mbc_pho(c,4)              
-                   moc_phi(c,4) = moc_phi(c,4)/2._r8
-                   moc_phi(c,5) = moc_phi(c,4)
-                   moc_pho(c,4) = moc_pho(c,4)/2._r8
-                   moc_pho(c,5) = moc_pho(c,4)
-                   mdst1(c,4) = mdst1(c,4)/2._r8
-                   mdst1(c,5) = mdst1(c,4)
-                   mdst2(c,4) = mdst2(c,4)/2._r8
-                   mdst2(c,5) = mdst2(c,4)
-                   mdst3(c,4) = mdst3(c,4)/2._r8
-                   mdst3(c,5) = mdst3(c,4)
-                   mdst4(c,4) = mdst4(c,4)/2._r8
-                   mdst4(c,5) = mdst4(c,4)
-                   rds(c,5) = rds(c,4)
-
-                end if
-             end if
-          end if
-
-          if (msno > 4) then
-             if (is_lake) then
-                offset = lsadz
-             else
-                offset = 0._r8
-             end if
-             if (dzsno(c,4) > 0.23_r8+offset) then
-                if (is_lake) then
-                   drr = dzsno(c,4) - 0.23_r8 - lsadz
-                else
-                   drr = dzsno(c,4) - 0.23_r8
-                end if
-                propor = drr/dzsno(c,4)
-                zwice = propor*swice(c,4)
-                zwliq = propor*swliq(c,4)
-
-                zmbc_phi = propor*mbc_phi(c,4)
-                zmbc_pho = propor*mbc_pho(c,4)
-                zmoc_phi = propor*moc_phi(c,4)
-                zmoc_pho = propor*moc_pho(c,4)
-                zmdst1 = propor*mdst1(c,4)
-                zmdst2 = propor*mdst2(c,4)
-                zmdst3 = propor*mdst3(c,4)
-                zmdst4 = propor*mdst4(c,4)
-
-                if (is_lake) then
-                   propor = (0.23_r8+lsadz)/dzsno(c,4)
-                else
-                   propor = 0.23_r8/dzsno(c,4)
-                end if
-                swice(c,4) = propor*swice(c,4)
-                swliq(c,4) = propor*swliq(c,4)
-
-                mbc_phi(c,4) = propor*mbc_phi(c,4)
-                mbc_pho(c,4) = propor*mbc_pho(c,4)
-                moc_phi(c,4) = propor*moc_phi(c,4)
-                moc_pho(c,4) = propor*moc_pho(c,4)
-                mdst1(c,4) = propor*mdst1(c,4)
-                mdst2(c,4) = propor*mdst2(c,4)
-                mdst3(c,4) = propor*mdst3(c,4)
-                mdst4(c,4) = propor*mdst4(c,4)
-
-                if (is_lake) then
-                   dzsno(c,4) = 0.23_r8 + lsadz
-                else
-                   dzsno(c,4) = 0.23_r8
-                end if
-
-                mbc_phi(c,5) = mbc_phi(c,5)+zmbc_phi  ! (combo)
-                mbc_pho(c,5) = mbc_pho(c,5)+zmbc_pho  ! (combo)
-                moc_phi(c,5) = moc_phi(c,5)+zmoc_phi  ! (combo)
-                moc_pho(c,5) = moc_pho(c,5)+zmoc_pho  ! (combo)
-                mdst1(c,5) = mdst1(c,5)+zmdst1  ! (combo)
-                mdst2(c,5) = mdst2(c,5)+zmdst2  ! (combo)
-                mdst3(c,5) = mdst3(c,5)+zmdst3  ! (combo)
-                mdst4(c,5) = mdst4(c,5)+zmdst4  ! (combo)
-#ifdef MODAL_AER
-             !mgf++ bugfix
-             rds(c,5) = (rds(c,5)*(swliq(c,5)+swice(c,5)) + rds(c,4)*(zwliq+zwice))/(swliq(c,5)+swice(c,5)+zwliq+zwice)
-               if ((rds(c,5) < 30.) .or. (rds(c,5) > 1500.)) then
-                  write (iulog,*) "5. SNICAR ERROR: snow grain radius of",rds(c,5),rds(c,4)
-                  write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,5), swice(c,5),zwliq, zwice
-                  write (iulog,*) "layers ", msno
-               endif
-             !mgf--
+                 !mgf--
 #else
-             rds(c,5) = rds(c,4) ! (combo)
+                 rds(c,4) = rds(c,3) ! (combo)
 #endif
 
-                call Combo (dzsno(c,5), swliq(c,5), swice(c,5), tsno(c,5), drr, &
-                     zwliq, zwice, tsno(c,4))
-             end if
-          end if
+                    call Combo (dzsno(c,4), swliq(c,4), swice(c,4), tsno(c,4), drr, &
+                         zwliq, zwice, tsno(c,3))
 
-          snl(c) = -msno
+                    ! Subdivided a new layer
+                    if (is_lake) then
+                       offset = 2._r8*lsadz
+                    else
+                       offset = 0._r8
+                    end if
+                    if (msno <= 4 .and. dzsno(c,4) > 0.41_r8 + offset) then
+                       msno = 5
+                       dtdz = (tsno(c,3) - tsno(c,4))/((dzsno(c,3)+dzsno(c,4))/2._r8) 
+                       dzsno(c,4) = dzsno(c,4)/2._r8
+                       swice(c,4) = swice(c,4)/2._r8
+                       swliq(c,4) = swliq(c,4)/2._r8
+                       dzsno(c,5) = dzsno(c,4)
+                       swice(c,5) = swice(c,4)
+                       swliq(c,5) = swliq(c,4)
+                       tsno(c,5) = tsno(c,4) - dtdz*dzsno(c,4)/2._r8 
+                       if (tsno(c,5) >= tfrz) then 
+                          tsno(c,5)  = tsno(c,4)
+                       else
+                          tsno(c,4) = tsno(c,4) + dtdz*dzsno(c,4)/2._r8 
+                       endif
 
-       end do
+                       mbc_phi(c,4) = mbc_phi(c,4)/2._r8
+                       mbc_phi(c,5) = mbc_phi(c,4)
+                       mbc_pho(c,4) = mbc_pho(c,4)/2._r8
+                       mbc_pho(c,5) = mbc_pho(c,4)              
+                       moc_phi(c,4) = moc_phi(c,4)/2._r8
+                       moc_phi(c,5) = moc_phi(c,4)
+                       moc_pho(c,4) = moc_pho(c,4)/2._r8
+                       moc_pho(c,5) = moc_pho(c,4)
+                       mdst1(c,4) = mdst1(c,4)/2._r8
+                       mdst1(c,5) = mdst1(c,4)
+                       mdst2(c,4) = mdst2(c,4)/2._r8
+                       mdst2(c,5) = mdst2(c,4)
+                       mdst3(c,4) = mdst3(c,4)/2._r8
+                       mdst3(c,5) = mdst3(c,4)
+                       mdst4(c,4) = mdst4(c,4)/2._r8
+                       mdst4(c,5) = mdst4(c,4)
+                       rds(c,5) = rds(c,4)
+
+                    end if
+                 end if
+              end if
+
+              if (msno > 4) then
+                 if (is_lake) then
+                    offset = lsadz
+                 else
+                    offset = 0._r8
+                 end if
+                 if (dzsno(c,4) > 0.23_r8+offset) then
+                    if (is_lake) then
+                       drr = dzsno(c,4) - 0.23_r8 - lsadz
+                    else
+                       drr = dzsno(c,4) - 0.23_r8
+                    end if
+                    propor = drr/dzsno(c,4)
+                    zwice = propor*swice(c,4)
+                    zwliq = propor*swliq(c,4)
+
+                    zmbc_phi = propor*mbc_phi(c,4)
+                    zmbc_pho = propor*mbc_pho(c,4)
+                    zmoc_phi = propor*moc_phi(c,4)
+                    zmoc_pho = propor*moc_pho(c,4)
+                    zmdst1 = propor*mdst1(c,4)
+                    zmdst2 = propor*mdst2(c,4)
+                    zmdst3 = propor*mdst3(c,4)
+                    zmdst4 = propor*mdst4(c,4)
+
+                    if (is_lake) then
+                       propor = (0.23_r8+lsadz)/dzsno(c,4)
+                    else
+                       propor = 0.23_r8/dzsno(c,4)
+                    end if
+                    swice(c,4) = propor*swice(c,4)
+                    swliq(c,4) = propor*swliq(c,4)
+
+                    mbc_phi(c,4) = propor*mbc_phi(c,4)
+                    mbc_pho(c,4) = propor*mbc_pho(c,4)
+                    moc_phi(c,4) = propor*moc_phi(c,4)
+                    moc_pho(c,4) = propor*moc_pho(c,4)
+                    mdst1(c,4) = propor*mdst1(c,4)
+                    mdst2(c,4) = propor*mdst2(c,4)
+                    mdst3(c,4) = propor*mdst3(c,4)
+                    mdst4(c,4) = propor*mdst4(c,4)
+
+                    if (is_lake) then
+                       dzsno(c,4) = 0.23_r8 + lsadz
+                    else
+                       dzsno(c,4) = 0.23_r8
+                    end if
+
+                    mbc_phi(c,5) = mbc_phi(c,5)+zmbc_phi  ! (combo)
+                    mbc_pho(c,5) = mbc_pho(c,5)+zmbc_pho  ! (combo)
+                    moc_phi(c,5) = moc_phi(c,5)+zmoc_phi  ! (combo)
+                    moc_pho(c,5) = moc_pho(c,5)+zmoc_pho  ! (combo)
+                    mdst1(c,5) = mdst1(c,5)+zmdst1  ! (combo)
+                    mdst2(c,5) = mdst2(c,5)+zmdst2  ! (combo)
+                    mdst3(c,5) = mdst3(c,5)+zmdst3  ! (combo)
+                    mdst4(c,5) = mdst4(c,5)+zmdst4  ! (combo)
+#ifdef MODAL_AER
+                 !mgf++ bugfix
+                 rds(c,5) = (rds(c,5)*(swliq(c,5)+swice(c,5)) + rds(c,4)*(zwliq+zwice))/(swliq(c,5)+swice(c,5)+zwliq+zwice)
+                   if ((rds(c,5) < 30.) .or. (rds(c,5) > 1500.)) then
+                      write (iulog,*) "5. SNICAR ERROR: snow grain radius of",rds(c,5),rds(c,4)
+                      write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,5), swice(c,5),zwliq, zwice
+                      write (iulog,*) "layers ", msno
+                   endif
+                 !mgf--
+#else
+                 rds(c,5) = rds(c,4) ! (combo)
+#endif
+
+                    call Combo (dzsno(c,5), swliq(c,5), swice(c,5), tsno(c,5), drr, &
+                         zwliq, zwice, tsno(c,4))
+                 end if
+              end if
+
+              snl(c) = -msno
+
+           end do
+       else
+           !++ams
+           loop_snowcolumns: do fc = 1, num_snowc
+              c = filter_snowc(fc)
+
+              msno = abs(snl(c))
+
+              ! Now traverse layers from top to bottom in a dynamic way, as the total
+              ! number of layers (msno) may increase during the loop.
+              ! Impose k < nlevsno; the special case 'k == nlevsno' is not relevant,
+              ! as it is neither allowed to subdivide nor does it have layers below.
+              k = 1
+              loop_layers: do while( k <= msno .and. k < nlevsno )
+
+                 ! Current layer is bottom layer
+                 if (k == msno) then
+
+                    if (is_lake) then
+                       offset = 2._r8 * lsadz
+                    else
+                       offset = 0._r8
+                    end if
+
+                    if (dzsno(c,k) > dzmax_l(k) + offset) then
+                       ! Subdivide layer into two layers with equal thickness, water
+                       ! content, ice content and temperature
+                       msno = msno + 1
+                       dzsno(c,k)     = dzsno(c,k) / 2.0_r8
+                       dzsno(c,k+1)   = dzsno(c,k)
+                       swice(c,k)     = swice(c,k) / 2.0_r8
+                       swice(c,k+1)   = swice(c,k)
+                       swliq(c,k)     = swliq(c,k) / 2.0_r8
+                       swliq(c,k+1)   = swliq(c,k)
+
+                       if (k == 1) then
+                          ! special case
+                          tsno(c,k+1)    = tsno(c,k)
+                       else
+                          ! use temperature gradient
+                          dtdz           = (tsno(c,k-1) - tsno(c,k))/((dzsno(c,k-1)+2*dzsno(c,k))/2.0_r8)
+                          tsno(c,k+1) = tsno(c,k) - dtdz*dzsno(c,k)/2.0_r8
+                          if (tsno(c,k+1) >= tfrz) then
+                             tsno(c,k+1)  = tsno(c,k)
+                          else
+                             tsno(c,k) = tsno(c,k) + dtdz*dzsno(c,k)/2.0_r8
+                          endif
+                       end if
+
+                       mbc_phi(c,k)   = mbc_phi(c,k) / 2.0_r8
+                       mbc_phi(c,k+1) = mbc_phi(c,k)
+                       mbc_pho(c,k)   = mbc_pho(c,k) / 2.0_r8
+                       mbc_pho(c,k+1) = mbc_pho(c,k)
+                       moc_phi(c,k)   = moc_phi(c,k) / 2.0_r8
+                       moc_phi(c,k+1) = moc_phi(c,k)
+                       moc_pho(c,k)   = moc_pho(c,k) / 2.0_r8
+                       moc_pho(c,k+1) = moc_pho(c,k)
+                       mdst1(c,k)     = mdst1(c,k) / 2.0_r8
+                       mdst1(c,k+1)   = mdst1(c,k)
+                       mdst2(c,k)     = mdst2(c,k) / 2.0_r8
+                       mdst2(c,k+1)   = mdst2(c,k)
+                       mdst3(c,k)     = mdst3(c,k) / 2.0_r8
+                       mdst3(c,k+1)   = mdst3(c,k)
+                       mdst4(c,k)     = mdst4(c,k) / 2.0_r8
+                       mdst4(c,k+1)   = mdst4(c,k)
+
+                       rds(c,k+1)     = rds(c,k)
+                    end if
+                 end if
+
+                 ! There are layers below (note this is not exclusive with previous
+                 ! if-statement, since msno may have increased in the previous if-statement)
+                 if (k < msno) then
+
+                    if (is_lake) then
+                       offset = lsadz
+                    else
+                       offset = 0._r8
+                    end if
+
+                    if (dzsno(c,k) > dzmax_u(k) + offset ) then
+                       ! Only dump excess snow to underlying layer in a conservative fashion.
+                       ! Other quantities will depend on the height of the excess snow: a ratio is used for this.
+                       drr      = dzsno(c,k) - dzmax_u(k) - offset
+
+                       propor   = drr/dzsno(c,k)
+                       zwice    = propor*swice(c,k)
+                       zwliq    = propor*swliq(c,k)
+                       zmbc_phi = propor*mbc_phi(c,k)
+                       zmbc_pho = propor*mbc_pho(c,k)
+                       zmoc_phi = propor*moc_phi(c,k)
+                       zmoc_pho = propor*moc_pho(c,k)
+                       zmdst1   = propor*mdst1(c,k)
+                       zmdst2   = propor*mdst2(c,k)
+                       zmdst3   = propor*mdst3(c,k)
+                       zmdst4   = propor*mdst4(c,k)
+
+                       propor         = (dzmax_u(k)+offset)/dzsno(c,k)
+                       swice(c,k)     = propor*swice(c,k)
+                       swliq(c,k)     = propor*swliq(c,k)
+                       mbc_phi(c,k)   = propor*mbc_phi(c,k)
+                       mbc_pho(c,k)   = propor*mbc_pho(c,k)
+                       moc_phi(c,k)   = propor*moc_phi(c,k)
+                       moc_pho(c,k)   = propor*moc_pho(c,k)
+                       mdst1(c,k)     = propor*mdst1(c,k)
+                       mdst2(c,k)     = propor*mdst2(c,k)
+                       mdst3(c,k)     = propor*mdst3(c,k)
+                       mdst4(c,k)     = propor*mdst4(c,k)
+
+                       ! Set depth layer k to maximum allowed value
+                       dzsno(c,k)  = dzmax_u(k)  + offset
+
+                       mbc_phi(c,k+1) = mbc_phi(c,k+1)+zmbc_phi  ! (combo)
+                       mbc_pho(c,k+1) = mbc_pho(c,k+1)+zmbc_pho  ! (combo)
+                       moc_phi(c,k+1) = moc_phi(c,k+1)+zmoc_phi  ! (combo)
+                       moc_pho(c,k+1) = moc_pho(c,k+1)+zmoc_pho  ! (combo)
+                       mdst1(c,k+1)   = mdst1(c,k+1)+zmdst1  ! (combo)
+                       mdst2(c,k+1)   = mdst2(c,k+1)+zmdst2  ! (combo)
+                       mdst3(c,k+1)   = mdst3(c,k+1)+zmdst3  ! (combo)
+                       mdst4(c,k+1)   = mdst4(c,k+1)+zmdst4  ! (combo)
+
+                       ! Mass-weighted combination of radius
+                       rds(c,k+1) = MassWeightedSnowRadius( rds(c,k), rds(c,k+1), &
+                            (swliq(c,k+1)+swice(c,k+1)), (zwliq+zwice) )
+
+                       call Combo (dzsno(c,k+1), swliq(c,k+1), swice(c,k+1), tsno(c,k+1), drr, &
+                            zwliq, zwice, tsno(c,k))
+                    end if
+                 end if
+                 k = k+1
+              end do loop_layers
+
+              snl(c) = -msno
+
+           end do loop_snowcolumns
+       end if
+       !ams++
 
        do j = -nlevsno+1,0
           do fc = 1, num_snowc
@@ -1700,6 +1874,109 @@ contains
      end associate
 
    end subroutine DivideSnowLayers
+   
+   !-----------------------------------------------------------------------
+   !++ams (from CESM2)
+   subroutine InitSnowLayers (bounds, snow_depth)
+    ! !DESCRIPTION:
+    ! Initialize snow layer depth from specified total depth.
+    !
+    ! !USES:
+    use clm_varcon         , only : spval
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)      , intent(in)    :: bounds
+    real(r8)               , intent(in)    :: snow_depth(bounds%begc:)
+    !
+    ! LOCAL VARAIBLES:
+    integer               :: c,l,j              ! indices
+    real(r8)              :: minbound, maxbound ! helper variables
+   
+    !SHR_ASSERT_ALL((ubound(snow_depth)  == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
+
+    associate( &
+         snl => col_pp%snl,   & ! Output: [integer (:)    ]  number of snow layers
+         dz  => col_pp%dz,    & ! Output: [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevgrnd)
+         z   => col_pp%z,     & ! Output: [real(r8) (:,:) ]  layer depth (m) (-nlevsno+1:nlevgrnd)
+         zi  => col_pp%zi     & ! Output: [real(r8) (:,:) ]  interface level below a "z" level (m) (-nlevsno+0:nlevgrnd)
+    )
+    loop_columns: do c = bounds%begc,bounds%endc
+       l = col_pp%landunit(c)
+
+       dz(c,-nlevsno+1: 0) = spval
+       z (c,-nlevsno+1: 0) = spval
+       zi(c,-nlevsno  :-1) = spval
+    
+       ! Special case: lake
+       if (lun_pp%lakpoi(l)) then
+          snl(c)              = 0
+          dz(c,-nlevsno+1:0)  = 0._r8
+          z(c,-nlevsno+1:0)   = 0._r8
+          zi(c,-nlevsno+0:0)  = 0._r8
+          cycle
+       end if
+       
+       ! LvK 9-JUN-2015: in CanopyHydrologyMod , snow_depth is scaled with frac_sno
+       ! Here we do not apply scaling to snow_depth, so inconsistent? TODO
+       
+       ! Special case: too little snow for snowpack existence
+       if (snow_depth(c) < dzmin16(1)) then
+          snl(c)              = 0
+          dz(c,-nlevsno+1:0)  = 0._r8
+          z(c,-nlevsno+1:0)   = 0._r8
+          zi(c,-nlevsno+0:0)  = 0._r8
+          cycle
+       end if
+       
+       ! There has to be at least one snow layer
+       snl(c)   = -1
+       minbound = dzmin16(1)
+       maxbound = dzmax_l(1)
+
+       if (snow_depth(c) >= minbound .and. snow_depth(c) <= maxbound) then
+          ! Special case: single layer
+          dz(c,0) = snow_depth(c)
+
+       else
+          ! Search for appropriate number of layers (snl) by increasing the
+          ! number of layers and check for matching bounds.
+          snl(c) = snl(c) - 1
+          minbound = maxbound
+          maxbound = sum(dzmax_u(1:-snl(c)))
+
+          do while(snow_depth(c) > maxbound .and. -snl(c) < nlevsno )
+             snl(c) = snl(c) - 1
+             minbound = maxbound
+             maxbound = sum(dzmax_u(1:-snl(c)))
+          end do
+
+          ! Set thickness of all layers except bottom two
+          do j = 1, -snl(c)-2
+             dz(c,j+snl(c))  = dzmax_u(j)
+          end do
+
+          ! Determine whether the two bottom layers should be equal in size,
+          ! or not. The rule here is: always create equal size when possible.
+          if (snow_depth(c) <= sum(dzmax_u(1:-snl(c)-2)) + 2 * dzmax_u(-snl(c)-1)) then
+             dz(c,-1) = (snow_depth(c) - sum(dzmax_u(1:-snl(c)-2))) / 2._r8
+             dz(c,0)  = dz(c,-1)
+          else
+             dz(c,-1) = dzmax_u(-snl(c)-1)
+             dz(c,0)  = snow_depth(c) - sum(dzmax_u(1:-snl(c)-1))
+          endif
+       endif
+
+       ! Initialize the node depth and the depth of layer interface
+       do j = 0, snl(c)+1, -1
+          z(c,j)    = zi(c,j) - 0.5_r8*dz(c,j)
+          zi(c,j-1) = zi(c,j) - dz(c,j)
+       end do
+
+    end do loop_columns
+
+    end associate
+   end subroutine InitSnowLayers
+   !ams++   
 
    !-----------------------------------------------------------------------
    subroutine Combo(dz,  wliq,  wice, t, dz2, wliq2, wice2, t2)
@@ -1750,8 +2027,37 @@ contains
      t = tc
 
    end subroutine Combo
-
    !-----------------------------------------------------------------------
+   
+   !++ams (from CESM2)
+   function MassWeightedSnowRadius( rds1, rds2, swtot, zwtot ) result(mass_weighted_snowradius)
+     !
+     ! !DESCRIPTION:
+     ! Calculate the mass weighted snow radius when two layers are combined
+     !
+     ! !USES:
+     use AerosolMod   , only : snw_rds_min
+     use SnowSnicarMod, only : snw_rds_max
+     implicit none
+     ! !ARGUMENTS:
+     real(r8), intent(IN) :: rds1         ! Layer 1 radius
+     real(r8), intent(IN) :: rds2         ! Layer 2 radius
+     real(r8), intent(IN) :: swtot        ! snow water total layer 2
+     real(r8), intent(IN) :: zwtot        ! snow water total layer 1
+     real(r8) :: mass_weighted_snowradius ! resulting bounded mass weighted snow radius
+
+     !SHR_ASSERT( (swtot+zwtot > 0.0_r8), errMsg(sourcefile, __LINE__))
+     mass_weighted_snowradius = (rds2*swtot + rds1*zwtot)/(swtot+zwtot)
+
+     if (      mass_weighted_snowradius > snw_rds_max ) then
+        mass_weighted_snowradius = snw_rds_max
+     else if ( mass_weighted_snowradius < snw_rds_min ) then
+        mass_weighted_snowradius = snw_rds_min
+     end if
+   end function MassWeightedSnowRadius
+   !ams++
+   !-----------------------------------------------------------------------
+   
    subroutine BuildSnowFilter(bounds, num_nolakec, filter_nolakec, &
         num_snowc, filter_snowc, num_nosnowc, filter_nosnowc)
      !

--- a/components/clm/src/biogeophys/SnowHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SnowHydrologyMod.F90
@@ -534,7 +534,7 @@ contains
 
    !-----------------------------------------------------------------------
    subroutine SnowCompaction(bounds, num_snowc, filter_snowc, &
-        temperature_vars, waterstate_vars)
+        temperature_vars, waterstate_vars, top_as_inst)
      !
      ! !DESCRIPTION:
      ! Determine the change in snow layer thickness due to compaction and
@@ -547,7 +547,7 @@ contains
      !
      ! !USES:
      use clm_time_manager, only : get_step_size
-     use clm_varcon      , only : denice, denh2o, tfrz, rpi
+     use clm_varcon      , only : denice, denh2o, tfrz, rpi, grav, rgas
      use landunit_varcon , only : istice_mec, istdlak, istsoil, istcrop
      use clm_varctl      , only : subgridflag
      !
@@ -557,25 +557,36 @@ contains
      integer                , intent(in) :: filter_snowc(:) ! column filter for snow points
      type(temperature_type) , intent(in) :: temperature_vars
      type(waterstate_type)  , intent(in) :: waterstate_vars
+     type(topounit_atmospheric_state), intent(in) :: top_as_inst
      !
      ! !LOCAL VARIABLES:
-     integer :: j, l, c, fc                      ! indices
+     integer :: j, l, c, fc, t                   ! indices
      real(r8):: dtime                            ! land model time step (sec)
      ! parameters
      real(r8), parameter :: c2 = 23.e-3_r8       ! [m3/kg]
      real(r8), parameter :: c3 = 2.777e-6_r8     ! [1/s]
+     real(r8), parameter :: c3_ams = 5.8e-7_r8   ! Schneider et al., 2020 [1/s]
      real(r8), parameter :: c4 = 0.04_r8         ! [1/K]
      real(r8), parameter :: c5 = 2.0_r8          !
      real(r8), parameter :: dm = 100.0_r8        ! Upper Limit on Destructive Metamorphism Compaction [kg/m3]
+     real(r8), parameter :: rho_dm = 150.0_r8    ! Upper limit on destructive metamorphism compaction [kg/m3] (Anderson, 1976; Schneider et al., 2020)
      real(r8), parameter :: eta0 = 9.e+5_r8      ! The Viscosity Coefficient Eta0 [kg-s/m2]
+     real(r8), parameter :: k_creep_snow = 1.4e-9_r8 ! Creep coefficient for snow (bi < 550 kg / m3) [m3-s/kg]
+     real(r8), parameter :: k_creep_firn = 1.2e-9_r8 ! Creep coefficient for firn (bi > 550 kg / m3)
      !
+     real(r8) :: p_gls                           ! grain load stress [kg / m-s2]
      real(r8) :: burden(bounds%begc:bounds%endc) ! pressure of overlying snow [kg/m2]
+     real(r8) :: zpseudo(bounds%begc:bounds%endc)! wind drift compaction / pseudo depth
+     logical  :: mobile(bounds%begc:bounds%endc) ! current snow layer is mobile, i.e. susceptible to wind drift
+     real(r8) :: snw_ssa                         ! Equivalent snow specific surface area [m2/kg] 
+     real(r8) :: ddz1_fresh                      ! Rate of settling of dendritic snowpack (Lehning et al., 2002) [1/s]
      real(r8) :: ddz1                            ! Rate of settling of snowpack due to destructive metamorphism.
-     real(r8) :: ddz2                            ! Rate of compaction of snowpack due to overburden.
+     real(r8) :: ddz2                            ! Rate of compaction of snowpack due to overburden. [1/s]
      real(r8) :: ddz3                            ! Rate of compaction of snowpack due to melt [1/s]
+     real(r8) :: ddz4                            ! Rate of compaction of snowpack due to wind drift [1/s]
      real(r8) :: dexpf                           ! expf=exp(-c4*(273.15-t_soisno)).
      real(r8) :: fi                              ! Fraction of ice relative to the total water content at current time step
-     real(r8) :: td                              ! t_soisno - tfrz [K]
+     real(r8) :: td                              ! tfrz - t_soisno [K]
      real(r8) :: pdzdtc                          ! Nodal rate of change in fractional-thickness due to compaction [fraction/s]
      real(r8) :: void                            ! void (1 - vol_ice - vol_liq)
      real(r8) :: wx                              ! water mass (ice+liquid) [kg/m2]
@@ -589,6 +600,8 @@ contains
           n_melt       => col_pp%n_melt                       , & ! Input:  [real(r8) (:)   ] SCA shape parameter                      
           ltype        => lun_pp%itype                        , & ! Input:  [integer (:)    ] landunit type                             
 
+          forc_wind    => top_as_inst%windbot                 , & ! Input:  [real(r8) (:) ]  atmospheric wind speed (m/s)
+
           t_soisno     => col_es%t_soisno    , & ! Input:  [real(r8) (:,:) ] soil temperature (Kelvin)              
           imelt        => col_ef%imelt       , & ! Input:  [integer (:,:)  ] flag for melting (=1), freezing (=2), Not=0
 
@@ -599,7 +612,7 @@ contains
           frac_iceold  => col_ws%frac_iceold  , & ! Input:  [real(r8) (:,:) ] fraction of ice relative to the tot water
           h2osoi_ice   => col_ws%h2osoi_ice   , & ! Input:  [real(r8) (:,:) ] ice lens (kg/m2)                       
           h2osoi_liq   => col_ws%h2osoi_liq   , & ! Input:  [real(r8) (:,:) ] liquid water (kg/m2)                   
-          
+          snw_rds      => col_ws%snw_rds      , & ! Output: [real(r8) (:,:) ] effective snow grain radius (col,lyr) [microns, m^-6]
           dz           => col_pp%dz                             & ! Output: [real(r8) (: ,:) ] layer depth (m)                        
           )
 
@@ -609,24 +622,46 @@ contains
 
        ! Begin calculation - note that the following column loops are only invoked if snl(c) < 0
 
-       burden(bounds%begc : bounds%endc) = 0._r8
+       if (use_extrasnowlayers) then
+          do fc = 1, num_snowc
+             c = filter_snowc(fc)
+             burden(c) = 0._r8
+             zpseudo(c) = 0._r8
+             mobile(c) = .true.
+          end do
+       else
+          burden(bounds%begc : bounds%endc) = 0._r8
+       end if
 
        do j = -nlevsno+1, 0
           do fc = 1, num_snowc
              c = filter_snowc(fc)
+             if (use_extrasnowlayers) then
+                t = col_pp%topounit(c)
+             end if
              if (j >= snl(c)+1) then
 
-                wx = h2osoi_ice(c,j) + h2osoi_liq(c,j)
-                void = 1._r8 - (h2osoi_ice(c,j)/denice + h2osoi_liq(c,j)/denh2o) / dz(c,j)
+                if (.not. use_extrasnowlayers) then
+                   ! ++ams this is redundant and should be removed
+                   wx = h2osoi_ice(c,j) + h2osoi_liq(c,j)
+                   void = 1._r8 - (h2osoi_ice(c,j)/denice + h2osoi_liq(c,j)/denh2o) / dz(c,j)
+                   ! ams++
+                end if
+                
                 wx = (h2osoi_ice(c,j) + h2osoi_liq(c,j))
                 void = 1._r8 - (h2osoi_ice(c,j)/denice + h2osoi_liq(c,j)/denh2o)&
                      /(frac_sno(c) * dz(c,j))
                 ! If void is negative, then increase dz such that void = 0.
                 ! This should be done for any landunit, but for now is done only for glacier_mec 1andunits.
-                l = col_pp%landunit(c)
-                if (ltype(l)==istice_mec .and. void < 0._r8) then
-                   dz(c,j) = h2osoi_ice(c,j)/denice + h2osoi_liq(c,j)/denh2o
-                   void = 0._r8
+                
+                if (.not. use_extrasnowlayers) then
+                   ! ++ams I don't think this is necessary (removed in CLMv5)
+                   l = col_pp%landunit(c)
+                   if (ltype(l)==istice_mec .and. void < 0._r8) then
+                      dz(c,j) = h2osoi_ice(c,j)/denice + h2osoi_liq(c,j)/denh2o
+                      void = 0._r8
+                   endif
+                   ! ams++
                 endif
 
                 ! Allow compaction only for non-saturated node and higher ice lens node.
@@ -638,17 +673,42 @@ contains
                    dexpf = exp(-c4*td)
 
                    ! Settling as a result of destructive metamorphism
-
-                   ddz1 = -c3*dexpf
-                   if (bi > dm) ddz1 = ddz1*exp(-46.0e-3_r8*(bi-dm))
+                   if (.not. use_extrasnowlayers) then
+                      ddz1 = -c3*dexpf 
+                      if (bi > dm) ddz1 = ddz1*exp(-46.0e-3_r8*(bi-dm))
+                   else
+                      ddz1_fresh = (-grav * (burden(c) + wx/2._r8)) / &
+                                   (0.007_r8 * bi**(4.75_r8 + td/40._r8))
+                      snw_ssa = 3.e6_r8 / (denice * snw_rds(c,j))
+                      if (snw_ssa < 50._r8) then
+                          ddz1_fresh = ddz1_fresh * exp(-46.e-2_r8 * (50._r8 - snw_ssa))
+                      endif
+                      ddz1 = -c3_ams*dexpf
+                      if (bi > rho_dm) ddz1 = ddz1*exp(-46.0e-3_r8*(bi-rho_dm))
+                      ddz1 = ddz1 + ddz1_fresh
+                   endif
 
                    ! Liquid water term
 
                    if (h2osoi_liq(c,j) > 0.01_r8*dz(c,j)*frac_sno(c)) ddz1=ddz1*c5
 
                    ! Compaction due to overburden
-
-                   ddz2 = -(burden(c)+wx/2._r8)*exp(-0.08_r8*td - c2*bi)/eta0 
+                   if (.not. use_extrasnowlayers) then
+                      ddz2 = -(burden(c)+wx/2._r8)*exp(-0.08_r8*td - c2*bi)/eta0 
+                   else
+                      p_gls = max(denice / bi, 1._r8) * grav * (burden(c) + wx/2._r8)
+                      if (bi <= 550._r8) then ! Low density, i.e. snow
+                         ddz2 = (-k_creep_snow * (max(denice / bi, 1._r8) - 1._r8) * &
+                                 exp(-60.e6_r8 / (rgas * t_soisno(c,j))) * p_gls) / &
+                                 (snw_rds(c,j) * 1.e-6_r8 * snw_rds(c,j) * 1.e-6_r8) - &
+                                 2.02e-10_r8
+                      else ! High density, i.e. firn
+                         ddz2 = (-k_creep_firn * (max(denice / bi, 1._r8) - 1._r8) * &
+                                 exp(-60.e6_r8 / (rgas * t_soisno(c,j))) * p_gls) / &
+                                 (snw_rds(c,j) * 1.e-6_r8 * snw_rds(c,j) * 1.e-6_r8) - &
+                                 2.7e-11_r8
+                      endif
+                   endif
 
                    ! Compaction occurring during melt
 
@@ -671,15 +731,35 @@ contains
                    else
                       ddz3 = 0._r8
                    end if
-
+                   
+                   if (use_extrasnowlayers) then
+                      ! Compaction occurring due to wind drift
+                      call WindDriftCompaction( &
+                           bi = bi, &
+                           forc_wind = forc_wind(t), &
+                           dz = dz(c,j), &
+                           zpseudo = zpseudo(c), &
+                           mobile = mobile(c), &
+                           compaction_rate = ddz4)
+                   else
+                      ddz4 = 0.0_r8
+                   end if
+                   
                    ! Time rate of fractional change in dz (units of s-1)
 
-                   pdzdtc = ddz1 + ddz2 + ddz3
+                   pdzdtc = ddz1 + ddz2 + ddz3 + ddz4
 
                    ! The change in dz due to compaction
                    ! Limit compaction to be no greater than fully saturated layer thickness
 
                    dz(c,j) = max(dz(c,j) * (1._r8+pdzdtc*dtime),(h2osoi_ice(c,j)/denice+ h2osoi_liq(c,j)/denh2o)/frac_sno(c))
+                
+                else ! ++ams from CLMv5
+                   ! saturated node is immobile
+                   !
+                   ! This is only needed if wind_dependent_snow_density is true, but it's
+                   ! simplest just to update mobile always
+                   mobile(c) = .false.
                 end if
 
                 ! Pressure of overlying snow
@@ -2052,7 +2132,78 @@ contains
       end associate
 
    end subroutine NewSnowBulkDensity
-   !ams++
+   
+   !-----------------------------------------------------------------------
+   ! ++ams from CLMv5
+   subroutine WindDriftCompaction(bi, forc_wind, dz, &
+        zpseudo, mobile, compaction_rate)
+     !
+     ! !DESCRIPTION:
+     !
+     ! Compute wind drift compaction for a single column and level.
+     !
+     ! Also updates zpseudo and mobile for this column. However, zpseudo remains unchanged
+     ! if mobile is already false or becomes false within this subroutine.
+     !
+     ! The structure of the updates done here for zpseudo and mobile requires that this
+     ! subroutine be called first for the top layer of snow, then for the 2nd layer down,
+     ! etc. - and finally for the bottom layer. Before beginning the loops over layers,
+     ! mobile should be initialized to .true. and zpseudo should be initialized to 0.
+     !
+     ! !USES:
+     !
+     ! !ARGUMENTS:
+     real(r8) , intent(in)    :: bi              ! partial density of ice [kg/m3]
+     real(r8) , intent(in)    :: forc_wind       ! atmospheric wind speed [m/s]
+     real(r8) , intent(in)    :: dz              ! layer depth for this column and level [m]
+     real(r8) , intent(inout) :: zpseudo         ! wind drift compaction / pseudo depth for this column at this layer
+     logical  , intent(inout) :: mobile          ! whether this snow column is still mobile at this layer (i.e., susceptible to wind drift)
+     real(r8) , intent(out)   :: compaction_rate ! rate of compaction of snowpack due to wind drift, for the current column and layer
+     !
+     ! !LOCAL VARIABLES:
+     real(r8) :: Frho        ! Mobility density factor [-]
+     real(r8) :: MO          ! Mobility index [-]
+     real(r8) :: SI          ! Driftability index [-]
+     real(r8) :: gamma_drift ! Scaling factor for wind drift time scale [-]
+     real(r8) :: tau_inverse ! Inverse of the effective time scale [1/s]
+
+     real(r8), parameter :: rho_min = 50._r8      ! wind drift compaction / minimum density [kg/m3]
+     real(r8), parameter :: rho_max = 350._r8     ! wind drift compaction / maximum density [kg/m3]
+     real(r8), parameter :: drift_gs = 0.35e-3_r8 ! wind drift compaction / grain size (fixed value for now)
+     real(r8), parameter :: drift_sph = 1.0_r8    ! wind drift compaction / sphericity
+     real(r8), parameter :: tau_ref = 48._r8 * 3600._r8  ! wind drift compaction / reference time [s]
+
+     character(len=*), parameter :: subname = 'WindDriftCompaction'
+     !-----------------------------------------------------------------------
+
+     if (mobile) then
+        Frho = 1.25_r8 - 0.0042_r8*(max(rho_min, bi)-rho_min)
+        ! assuming dendricity = 0, sphericity = 1, grain size = 0.35 mm Non-dendritic snow
+        MO = 0.34_r8 * (-0.583_r8*drift_gs - 0.833_r8*drift_sph + 0.833_r8) + 0.66_r8*Frho
+        SI = -2.868_r8 * exp(-0.085_r8*forc_wind) + 1._r8 + MO
+
+        if (SI > 0.0_r8) then
+           SI = min(SI, 3.25_r8)
+           ! Increase zpseudo (wind drift / pseudo depth) to the middle of
+           ! the pseudo-node for the sake of the following calculation
+           zpseudo = zpseudo + 0.5_r8 * dz * (3.25_r8 - SI)
+           gamma_drift = SI*exp(-zpseudo/0.1_r8)
+           tau_inverse = gamma_drift / tau_ref
+           compaction_rate = -max(0.0_r8, rho_max-bi) * tau_inverse
+           ! Further increase zpseudo to the bottom of the pseudo-node for
+           ! the sake of calculations done on the underlying layer (i.e.,
+           ! the next time through the j loop).
+           zpseudo = zpseudo + 0.5_r8 * dz * (3.25_r8 - SI)
+        else  ! SI <= 0
+           mobile = .false.
+           compaction_rate = 0._r8
+        end if
+     else  ! .not. mobile
+        compaction_rate = 0._r8
+     end if
+
+   end subroutine WindDriftCompaction 
+   
    !-----------------------------------------------------------------------
    subroutine Combo(dz,  wliq,  wice, t, dz2, wliq2, wice2, t2)
      !

--- a/components/clm/src/biogeophys/SnowHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SnowHydrologyMod.F90
@@ -19,7 +19,7 @@ module SnowHydrologyMod
   use abortutils      , only : endrun
   use clm_varpar      , only : nlevsno
   use clm_varctl      , only : iulog, use_extrasnowlayers
-  use clm_varcon      , only : namec
+  use clm_varcon      , only : namec, h2osno_max
   use atm2lndType     , only : atm2lnd_type
   use AerosolType     , only : aerosol_type
   use TemperatureType , only : temperature_type
@@ -43,6 +43,7 @@ module SnowHydrologyMod
   public :: BuildSnowFilter            ! Construct snow/no-snow filters
   public :: InitSnowLayers             ! Initialize cold-start snow layer thickness  
   public :: NewSnowBulkDensity         ! Compute bulk density of any newly-fallen snow
+  public :: SnowCapping                ! Remove snow mass for capped columns
   !
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: Combo            ! Returns the combined variables: dz, t, wliq, wice.
@@ -225,7 +226,7 @@ contains
          c = filter_snowc(fc)
          l=col_pp%landunit(c)
 
-         if (do_capsnow(c)) then
+         if (do_capsnow(c) .and. .not. use_extrasnowlayers) then
             wgdif = h2osoi_ice(c,snl(c)+1) - frac_sno_eff(c)*qflx_sub_snow(c)*dtime
             h2osoi_ice(c,snl(c)+1) = wgdif
             if (wgdif < 0._r8) then
@@ -2058,7 +2059,127 @@ contains
 
     end associate
    end subroutine InitSnowLayers
-   !ams++   
+   !ams++
+   
+   !ams++ from CLM (clm4_5_12_r190)
+   !-----------------------------------------------------------------------
+   subroutine SnowCapping(bounds, num_nolakec, filter_initc, num_snowc, filter_snowc, &
+        aerosol_vars, waterflux_vars, waterstate_vars )
+     !
+     ! !DESCRIPTION:
+     ! Removes mass from bottom snow layer for columns that exceed the maximum snow depth.
+     ! This routine is called twice: once for non-lake columns and once for lake columns. 
+     ! The initialization of the snow capping fluxes should only be done ONCE for each group,
+     ! therefore they are a passed as an extra argument (filter_initc). 
+     ! Density and temperature of the layer are conserved (density needs some work, temperature is a state
+     ! variable)
+     !
+     ! !USES:
+     use clm_time_manager   , only : get_step_size
+     !
+     ! !ARGUMENTS:
+     type(bounds_type)      , intent(in)    :: bounds          
+     integer                , intent(in)    :: num_nolakec       ! number of column points that need to be initialized
+     integer                , intent(in)    :: filter_initc(:) ! column filter for points that need to be initialized
+     integer                , intent(in)    :: num_snowc       ! number of column snow points in column filter
+     integer                , intent(in)    :: filter_snowc(:) ! column filter for snow points
+     type(aerosol_type)     , intent(inout) :: aerosol_vars
+     type(waterflux_type)   , intent(inout) :: waterflux_vars 
+     type(waterstate_type)  , intent(inout) :: waterstate_vars
+     !
+     ! !LOCAL VARIABLES:
+     real(r8)   :: dtime                            ! land model time step (sec)
+     real(r8)   :: mss_snwcp_tot                    ! total snow capping mass [kg/m2] 
+     real(r8)   :: mss_snow_bottom_lyr              ! total snow mass (ice+liquid) in bottom layer [kg/m2]
+     real(r8)   :: icefrac                          ! fraction of ice mass w.r.t. total mass [unitless]
+     real(r8)   :: frac_adjust                      ! fraction of mass remaining after capping
+     real(r8)   :: rho                              ! partial density of ice (not scaled with frac_sno) [kg/m3]
+     integer    :: fc, c                            ! counters
+     ! Always keep at least this fraction of the bottom snow layer when doing snow capping
+     ! This needs to be slightly greater than 0 to avoid roundoff problems
+     real(r8), parameter :: min_snow_to_keep = 1.e-9  ! fraction of bottom snow layer to keep with capping
+
+     !-----------------------------------------------------------------------
+     associate( &
+         qflx_snwcp_ice     => col_wf%qflx_snwcp_ice               , & ! Output: [real(r8) (:)   ]  excess solid h2o due to snow capping (outgoing) (mm H2O /s) [+]
+         qflx_snwcp_liq     => col_wf%qflx_snwcp_liq               , & ! Output: [real(r8) (:)   ]  excess liquid h2o due to snow capping (outgoing) (mm H2O /s) [+]
+         h2osoi_ice         => col_ws%h2osoi_ice                   , & ! In/Out: [real(r8) (:,:) ] ice lens (kg/m2)                       
+         h2osoi_liq         => col_ws%h2osoi_liq                   , & ! In/Out: [real(r8) (:,:) ] liquid water (kg/m2)                   
+         h2osno             => col_ws%h2osno                       , & ! Input:  [real(r8) (:)   ] snow water (mm H2O)
+         mss_bcphi          => aerosol_vars%mss_bcphi_col          , & ! In/Out: [real(r8) (:,:) ] hydrophilic BC mass in snow (col,lyr) [kg]
+         mss_bcpho          => aerosol_vars%mss_bcpho_col          , & ! In/Out: [real(r8) (:,:) ] hydrophobic BC mass in snow (col,lyr) [kg]
+         mss_ocphi          => aerosol_vars%mss_ocphi_col          , & ! In/Out: [real(r8) (:,:) ] hydrophilic OC mass in snow (col,lyr) [kg]
+         mss_ocpho          => aerosol_vars%mss_ocpho_col          , & ! In/Out: [real(r8) (:,:) ] hydrophobic OC mass in snow (col,lyr) [kg]
+         mss_dst1           => aerosol_vars%mss_dst1_col           , & ! In/Out: [real(r8) (:,:) ] dust species 1 mass in snow (col,lyr) [kg]
+         mss_dst2           => aerosol_vars%mss_dst2_col           , & ! In/Out: [real(r8) (:,:) ] dust species 2 mass in snow (col,lyr) [kg]
+         mss_dst3           => aerosol_vars%mss_dst3_col           , & ! In/Out: [real(r8) (:,:) ] dust species 3 mass in snow (col,lyr) [kg]
+         mss_dst4           => aerosol_vars%mss_dst4_col           , & ! In/Out: [real(r8) (:,:) ] dust species 4 mass in snow (col,lyr) [kg]
+         dz                 => col_pp%dz                             & ! In/Out: [real(r8) (:,:) ] layer thickness (m)
+     )
+
+     ! Determine model time step
+     dtime = get_step_size()
+
+     ! Initialize capping fluxes for all columns in domain (lake or non-lake)
+     do fc = 1, num_nolakec
+        c = filter_initc(fc)
+        qflx_snwcp_ice(c) = 0.0_r8
+        qflx_snwcp_liq(c) = 0.0_r8
+     end do
+
+     loop_columns: do fc = 1, num_snowc
+        c = filter_snowc(fc)
+
+        if (h2osno(c) > h2osno_max) then
+           mss_snow_bottom_lyr = h2osoi_ice(c,0) + h2osoi_liq(c,0) 
+           mss_snwcp_tot = min(h2osno(c)-h2osno_max, mss_snow_bottom_lyr * (1._r8 - min_snow_to_keep)) ! Can't remove more mass than available
+
+           ! Ratio of snow/liquid in bottom layer determines partitioning of runoff fluxes
+           icefrac = h2osoi_ice(c,0) / mss_snow_bottom_lyr
+           qflx_snwcp_ice(c) = mss_snwcp_tot/dtime * icefrac
+           qflx_snwcp_liq(c) = mss_snwcp_tot/dtime * (1._r8 - icefrac)
+
+           rho = h2osoi_ice(c,0) / dz(c,0) ! ice only
+
+           ! Adjust water content
+           h2osoi_ice(c,0) = h2osoi_ice(c,0) - qflx_snwcp_ice(c)*dtime
+           h2osoi_liq(c,0) = h2osoi_liq(c,0) - qflx_snwcp_liq(c)*dtime
+
+           ! Scale dz such that ice density (or: pore space) is conserved
+           !
+           ! Avoid scaling dz for very low ice densities. This can occur, in principle, if
+           ! the layer is mostly liquid water. Furthermore, this check is critical in the
+           ! unlikely event that rho is 0, which can happen if the layer is entirely liquid
+           ! water.
+           if (rho > 1.0_r8) then
+             dz(c,0) = h2osoi_ice(c,0) / rho 
+           end if
+
+           ! Check that water capacity is still positive
+           if (h2osoi_ice(c,0) < 0._r8 .or. h2osoi_liq(c,0) < 0._r8 ) then
+              write(iulog,*)'ERROR: capping procedure failed (negative mass remaining) c = ',c
+              write(iulog,*)'h2osoi_ice = ', h2osoi_ice(c,0), ' h2osoi_liq = ', h2osoi_liq(c,0)
+              call endrun(decomp_index=c, clmlevel=namec, msg=errmsg(__FILE__, __LINE__))
+           end if
+
+           ! Correct the top layer aerosol mass to account for snow capping.
+           ! This approach conserves the aerosol mass concentration but not aerosol mass. 
+           frac_adjust = (mss_snow_bottom_lyr - mss_snwcp_tot) / mss_snow_bottom_lyr
+           mss_bcphi(c,0)   = mss_bcphi(c,0) * frac_adjust 
+           mss_bcpho(c,0)   = mss_bcpho(c,0) * frac_adjust
+           mss_ocphi(c,0)   = mss_ocphi(c,0) * frac_adjust
+           mss_ocpho(c,0)   = mss_ocpho(c,0) * frac_adjust
+           mss_dst1(c,0)    = mss_dst1(c,0) * frac_adjust
+           mss_dst2(c,0)    = mss_dst2(c,0) * frac_adjust
+           mss_dst3(c,0)    = mss_dst3(c,0) * frac_adjust
+           mss_dst4(c,0)    = mss_dst4(c,0) * frac_adjust
+        end if
+
+     end do loop_columns
+
+     end associate
+   end subroutine SnowCapping
+   
    !ams++ (subroutine from CESM2)
    !-----------------------------------------------------------------------
    subroutine NewSnowBulkDensity(bounds, num_c, filter_c, top_as_inst, bifall)

--- a/components/clm/src/biogeophys/SnowHydrologyMod.F90
+++ b/components/clm/src/biogeophys/SnowHydrologyMod.F90
@@ -40,6 +40,7 @@ module SnowHydrologyMod
   public :: SnowCompaction             ! Change in snow layer thickness due to compaction
   public :: CombineSnowLayers          ! Combine snow layers less than a min thickness
   public :: DivideSnowLayers           ! Subdivide snow layers if they exceed maximum thickness
+  public :: DivideExtraSnowLayers      ! Subdivide up to 16 snow layers if they exceed maximum thickness
   public :: BuildSnowFilter            ! Construct snow/no-snow filters
   public :: InitSnowLayers             ! Initialize cold-start snow layer thickness  
   public :: NewSnowBulkDensity         ! Compute bulk density of any newly-fallen snow
@@ -82,8 +83,8 @@ module SnowHydrologyMod
   !real(r8), public, parameter :: scvng_fct_mlt_dst4  = 0.03_r8   ! scavenging factor for dust species 4 inclusion in meltwater [frc]
   ! ++
   
-  !++ams (from CESM2)
   ! Definition of snow pack vertical structure
+  ! (adapted from CLMv5)
   ! Hardcoded maximum of 16 snowlayers
   ! The bottom layer has no limit on thickness, hence the last element of the dzmax_*
   ! arrays is 'huge'.
@@ -99,7 +100,6 @@ module SnowHydrologyMod
                (/ 0.02_r8, 0.05_r8, 0.11_r8, 0.23_r8, 0.47_r8, 0.95_r8, &
                   1.91_r8, 3.83_r8, 7.67_r8, 7.67_r8, 7.67_r8, 7.67_r8, & 
                   7.67_r8, 7.67_r8, 7.67_r8, huge(1._r8)  /)
-  !ams++
 
 contains
 
@@ -641,14 +641,6 @@ contains
                 t = col_pp%topounit(c)
              end if
              if (j >= snl(c)+1) then
-
-                if (.not. use_extrasnowlayers) then
-                   ! ++ams this is redundant and should be removed
-                   wx = h2osoi_ice(c,j) + h2osoi_liq(c,j)
-                   void = 1._r8 - (h2osoi_ice(c,j)/denice + h2osoi_liq(c,j)/denh2o) / dz(c,j)
-                   ! ams++
-                end if
-                
                 wx = (h2osoi_ice(c,j) + h2osoi_liq(c,j))
                 void = 1._r8 - (h2osoi_ice(c,j)/denice + h2osoi_liq(c,j)/denh2o)&
                      /(frac_sno(c) * dz(c,j))
@@ -656,13 +648,12 @@ contains
                 ! This should be done for any landunit, but for now is done only for glacier_mec 1andunits.
                 
                 if (.not. use_extrasnowlayers) then
-                   ! ++ams I don't think this is necessary (removed in CLMv5)
+                   ! I don't think the next 5 lines are necessary (removed in CLMv5)
                    l = col_pp%landunit(c)
                    if (ltype(l)==istice_mec .and. void < 0._r8) then
                       dz(c,j) = h2osoi_ice(c,j)/denice + h2osoi_liq(c,j)/denh2o
                       void = 0._r8
                    endif
-                   ! ams++
                 endif
 
                 ! Allow compaction only for non-saturated node and higher ice lens node.
@@ -755,7 +746,7 @@ contains
 
                    dz(c,j) = max(dz(c,j) * (1._r8+pdzdtc*dtime),(h2osoi_ice(c,j)/denice+ h2osoi_liq(c,j)/denh2o)/frac_sno(c))
                 
-                else ! ++ams from CLMv5
+                else ! from CLMv5
                    ! saturated node is immobile
                    !
                    ! This is only needed if wind_dependent_snow_density is true, but it's
@@ -1287,612 +1278,475 @@ contains
           end do
        end do
 
-       if (.not. use_extrasnowlayers) then
-           do fc = 1, num_snowc
-              c = filter_snowc(fc)
+       do fc = 1, num_snowc
+           c = filter_snowc(fc)
 
-              msno = abs(snl(c))
+           msno = abs(snl(c))
 
-              if (msno == 1) then
-                 ! Specify a new snow layer
-                 if (is_lake) then
-                    offset = 2._r8 * lsadz
-                 else
-                    offset = 0._r8
-                 end if
-                 if (dzsno(c,1) > 0.03_r8 + offset) then
-                    msno = 2
-                    dzsno(c,1) = dzsno(c,1)/2._r8
-                    swice(c,1) = swice(c,1)/2._r8
-                    swliq(c,1) = swliq(c,1)/2._r8
-                    dzsno(c,2) = dzsno(c,1)
-                    swice(c,2) = swice(c,1)
-                    swliq(c,2) = swliq(c,1)
-                    tsno(c,2)  = tsno(c,1)
-
-                    mbc_phi(c,1) = mbc_phi(c,1)/2._r8
-                    mbc_phi(c,2) = mbc_phi(c,1)
-                    mbc_pho(c,1) = mbc_pho(c,1)/2._r8
-                    mbc_pho(c,2) = mbc_pho(c,1)
-                    moc_phi(c,1) = moc_phi(c,1)/2._r8
-                    moc_phi(c,2) = moc_phi(c,1)
-                    moc_pho(c,1) = moc_pho(c,1)/2._r8
-                    moc_pho(c,2) = moc_pho(c,1)
-                    mdst1(c,1) = mdst1(c,1)/2._r8
-                    mdst1(c,2) = mdst1(c,1)
-                    mdst2(c,1) = mdst2(c,1)/2._r8
-                    mdst2(c,2) = mdst2(c,1)
-                    mdst3(c,1) = mdst3(c,1)/2._r8
-                    mdst3(c,2) = mdst3(c,1)
-                    mdst4(c,1) = mdst4(c,1)/2._r8
-                    mdst4(c,2) = mdst4(c,1)
-                    rds(c,2) = rds(c,1)
-
-                 end if
+           if (msno == 1) then
+              ! Specify a new snow layer
+              if (is_lake) then
+                 offset = 2._r8 * lsadz
+              else
+                 offset = 0._r8
               end if
+              if (dzsno(c,1) > 0.03_r8 + offset) then
+                 msno = 2
+                 dzsno(c,1) = dzsno(c,1)/2._r8
+                 swice(c,1) = swice(c,1)/2._r8
+                 swliq(c,1) = swliq(c,1)/2._r8
+                 dzsno(c,2) = dzsno(c,1)
+                 swice(c,2) = swice(c,1)
+                 swliq(c,2) = swliq(c,1)
+                 tsno(c,2)  = tsno(c,1)
 
-              if (msno > 1) then
+                 mbc_phi(c,1) = mbc_phi(c,1)/2._r8
+                 mbc_phi(c,2) = mbc_phi(c,1)
+                 mbc_pho(c,1) = mbc_pho(c,1)/2._r8
+                 mbc_pho(c,2) = mbc_pho(c,1)
+                 moc_phi(c,1) = moc_phi(c,1)/2._r8
+                 moc_phi(c,2) = moc_phi(c,1)
+                 moc_pho(c,1) = moc_pho(c,1)/2._r8
+                 moc_pho(c,2) = moc_pho(c,1)
+                 mdst1(c,1) = mdst1(c,1)/2._r8
+                 mdst1(c,2) = mdst1(c,1)
+                 mdst2(c,1) = mdst2(c,1)/2._r8
+                 mdst2(c,2) = mdst2(c,1)
+                 mdst3(c,1) = mdst3(c,1)/2._r8
+                 mdst3(c,2) = mdst3(c,1)
+                 mdst4(c,1) = mdst4(c,1)/2._r8
+                 mdst4(c,2) = mdst4(c,1)
+                 rds(c,2) = rds(c,1)
+
+              end if
+           end if
+
+           if (msno > 1) then
+              if (is_lake) then
+                 offset = lsadz
+              else
+                 offset = 0._r8
+              end if
+              if (dzsno(c,1) > 0.02_r8 + offset) then
                  if (is_lake) then
-                    offset = lsadz
+                    drr = dzsno(c,1) - 0.02_r8 - lsadz
                  else
-                    offset = 0._r8
+                    drr = dzsno(c,1) - 0.02_r8
                  end if
-                 if (dzsno(c,1) > 0.02_r8 + offset) then
-                    if (is_lake) then
-                       drr = dzsno(c,1) - 0.02_r8 - lsadz
-                    else
-                       drr = dzsno(c,1) - 0.02_r8
-                    end if
-                    propor = drr/dzsno(c,1)
-                    zwice = propor*swice(c,1)
-                    zwliq = propor*swliq(c,1)
+                 propor = drr/dzsno(c,1)
+                 zwice = propor*swice(c,1)
+                 zwliq = propor*swliq(c,1)
 
-                    zmbc_phi = propor*mbc_phi(c,1)
-                    zmbc_pho = propor*mbc_pho(c,1)
-                    zmoc_phi = propor*moc_phi(c,1)
-                    zmoc_pho = propor*moc_pho(c,1)
-                    zmdst1 = propor*mdst1(c,1)
-                    zmdst2 = propor*mdst2(c,1)
-                    zmdst3 = propor*mdst3(c,1)
-                    zmdst4 = propor*mdst4(c,1)
+                 zmbc_phi = propor*mbc_phi(c,1)
+                 zmbc_pho = propor*mbc_pho(c,1)
+                 zmoc_phi = propor*moc_phi(c,1)
+                 zmoc_pho = propor*moc_pho(c,1)
+                 zmdst1 = propor*mdst1(c,1)
+                 zmdst2 = propor*mdst2(c,1)
+                 zmdst3 = propor*mdst3(c,1)
+                 zmdst4 = propor*mdst4(c,1)
 
-                    if (is_lake) then
-                       propor = (0.02_r8+lsadz)/dzsno(c,1)
-                    else
-                       propor = 0.02_r8/dzsno(c,1)
-                    endif 
+                 if (is_lake) then
+                    propor = (0.02_r8+lsadz)/dzsno(c,1)
+                 else
+                    propor = 0.02_r8/dzsno(c,1)
+                 endif 
 
-                    swice(c,1) = propor*swice(c,1)
-                    swliq(c,1) = propor*swliq(c,1)
+                 swice(c,1) = propor*swice(c,1)
+                 swliq(c,1) = propor*swliq(c,1)
 
-                    mbc_phi(c,1) = propor*mbc_phi(c,1)
-                    mbc_pho(c,1) = propor*mbc_pho(c,1)
-                    moc_phi(c,1) = propor*moc_phi(c,1)
-                    moc_pho(c,1) = propor*moc_pho(c,1)
-                    mdst1(c,1) = propor*mdst1(c,1)
-                    mdst2(c,1) = propor*mdst2(c,1)
-                    mdst3(c,1) = propor*mdst3(c,1)
-                    mdst4(c,1) = propor*mdst4(c,1)
+                 mbc_phi(c,1) = propor*mbc_phi(c,1)
+                 mbc_pho(c,1) = propor*mbc_pho(c,1)
+                 moc_phi(c,1) = propor*moc_phi(c,1)
+                 moc_pho(c,1) = propor*moc_pho(c,1)
+                 mdst1(c,1) = propor*mdst1(c,1)
+                 mdst2(c,1) = propor*mdst2(c,1)
+                 mdst3(c,1) = propor*mdst3(c,1)
+                 mdst4(c,1) = propor*mdst4(c,1)
 
-                    if (is_lake) then
-                       dzsno(c,1) = 0.02_r8 + lsadz
-                    else
-                       dzsno(c,1) = 0.02_r8
-                    end if
+                 if (is_lake) then
+                    dzsno(c,1) = 0.02_r8 + lsadz
+                 else
+                    dzsno(c,1) = 0.02_r8
+                 end if
 
-                    mbc_phi(c,2) = mbc_phi(c,2)+zmbc_phi  ! (combo)
-                    mbc_pho(c,2) = mbc_pho(c,2)+zmbc_pho  ! (combo)
-                    moc_phi(c,2) = moc_phi(c,2)+zmoc_phi  ! (combo)
-                    moc_pho(c,2) = moc_pho(c,2)+zmoc_pho  ! (combo)
-                    mdst1(c,2) = mdst1(c,2)+zmdst1  ! (combo)
-                    mdst2(c,2) = mdst2(c,2)+zmdst2  ! (combo)
-                    mdst3(c,2) = mdst3(c,2)+zmdst3  ! (combo)
-                    mdst4(c,2) = mdst4(c,2)+zmdst4  ! (combo)
+                 mbc_phi(c,2) = mbc_phi(c,2)+zmbc_phi  ! (combo)
+                 mbc_pho(c,2) = mbc_pho(c,2)+zmbc_pho  ! (combo)
+                 moc_phi(c,2) = moc_phi(c,2)+zmoc_phi  ! (combo)
+                 moc_pho(c,2) = moc_pho(c,2)+zmoc_pho  ! (combo)
+                 mdst1(c,2) = mdst1(c,2)+zmdst1  ! (combo)
+                 mdst2(c,2) = mdst2(c,2)+zmdst2  ! (combo)
+                 mdst3(c,2) = mdst3(c,2)+zmdst3  ! (combo)
+                 mdst4(c,2) = mdst4(c,2)+zmdst4  ! (combo)
 #ifdef MODAL_AER
-                 !mgf++ bugfix
-                 rds(c,2) = (rds(c,2)*(swliq(c,2)+swice(c,2)) + rds(c,1)*(zwliq+zwice))/(swliq(c,2)+swice(c,2)+zwliq+zwice)
-                   if ((rds(c,2) < 30.) .or. (rds(c,2) > 1500.)) then
-                      write (iulog,*) "2. SNICAR ERROR: snow grain radius of",rds(c,2),rds(c,1)
-                      write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,2), swice(c,2),zwliq, zwice
-                      write (iulog,*) "layers ", msno
-                   endif
-                 !mgf--
+              !mgf++ bugfix
+              rds(c,2) = (rds(c,2)*(swliq(c,2)+swice(c,2)) + rds(c,1)*(zwliq+zwice))/(swliq(c,2)+swice(c,2)+zwliq+zwice)
+                if ((rds(c,2) < 30.) .or. (rds(c,2) > 1500.)) then
+                   write (iulog,*) "2. SNICAR ERROR: snow grain radius of",rds(c,2),rds(c,1)
+                   write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,2), swice(c,2),zwliq, zwice
+                   write (iulog,*) "layers ", msno
+                endif
+              !mgf--
 #else
-                 rds(c,2) = rds(c,1) ! (combo)
+              rds(c,2) = rds(c,1) ! (combo)
 #endif
 
-                    call Combo (dzsno(c,2), swliq(c,2), swice(c,2), tsno(c,2), drr, &
-                         zwliq, zwice, tsno(c,1))
+                 call Combo (dzsno(c,2), swliq(c,2), swice(c,2), tsno(c,2), drr, &
+                      zwliq, zwice, tsno(c,1))
 
-                    ! Subdivide a new layer
-                    if (is_lake) then
-                       offset = 2._r8*lsadz
-                    else
-                       offset = 0._r8
-                    end if
-                    if (msno <= 2 .and. dzsno(c,2) > 0.07_r8 + offset) then
-                       msno = 3
-                       dtdz = (tsno(c,1) - tsno(c,2))/((dzsno(c,1)+dzsno(c,2))/2._r8) 
-                       dzsno(c,2) = dzsno(c,2)/2._r8
-                       swice(c,2) = swice(c,2)/2._r8
-                       swliq(c,2) = swliq(c,2)/2._r8
-                       dzsno(c,3) = dzsno(c,2)
-                       swice(c,3) = swice(c,2)
-                       swliq(c,3) = swliq(c,2)
-                       tsno(c,3) = tsno(c,2) - dtdz*dzsno(c,2)/2._r8
-                       if (tsno(c,3) >= tfrz) then 
-                          tsno(c,3)  = tsno(c,2)
-                       else
-                          tsno(c,2) = tsno(c,2) + dtdz*dzsno(c,2)/2._r8 
-                       endif
-
-                       mbc_phi(c,2) = mbc_phi(c,2)/2._r8
-                       mbc_phi(c,3) = mbc_phi(c,2)
-                       mbc_pho(c,2) = mbc_pho(c,2)/2._r8
-                       mbc_pho(c,3) = mbc_pho(c,2)
-                       moc_phi(c,2) = moc_phi(c,2)/2._r8
-                       moc_phi(c,3) = moc_phi(c,2)
-                       moc_pho(c,2) = moc_pho(c,2)/2._r8
-                       moc_pho(c,3) = moc_pho(c,2)
-                       mdst1(c,2) = mdst1(c,2)/2._r8
-                       mdst1(c,3) = mdst1(c,2)
-                       mdst2(c,2) = mdst2(c,2)/2._r8
-                       mdst2(c,3) = mdst2(c,2)
-                       mdst3(c,2) = mdst3(c,2)/2._r8
-                       mdst3(c,3) = mdst3(c,2)
-                       mdst4(c,2) = mdst4(c,2)/2._r8
-                       mdst4(c,3) = mdst4(c,2)
-                       rds(c,3) = rds(c,2)
-
-                    end if
-                 end if
-              end if
-
-              if (msno > 2) then
+                 ! Subdivide a new layer
                  if (is_lake) then
-                    offset = lsadz
+                    offset = 2._r8*lsadz
                  else
                     offset = 0._r8
                  end if
-                 if (dzsno(c,2) > 0.05_r8+offset) then
-                    if (is_lake) then
-                       drr = dzsno(c,2) - 0.05_r8 - lsadz
+                 if (msno <= 2 .and. dzsno(c,2) > 0.07_r8 + offset) then
+                    msno = 3
+                    dtdz = (tsno(c,1) - tsno(c,2))/((dzsno(c,1)+dzsno(c,2))/2._r8) 
+                    dzsno(c,2) = dzsno(c,2)/2._r8
+                    swice(c,2) = swice(c,2)/2._r8
+                    swliq(c,2) = swliq(c,2)/2._r8
+                    dzsno(c,3) = dzsno(c,2)
+                    swice(c,3) = swice(c,2)
+                    swliq(c,3) = swliq(c,2)
+                    tsno(c,3) = tsno(c,2) - dtdz*dzsno(c,2)/2._r8
+                    if (tsno(c,3) >= tfrz) then 
+                       tsno(c,3)  = tsno(c,2)
                     else
-                       drr = dzsno(c,2) - 0.05_r8
-                    end if
-                    propor = drr/dzsno(c,2)
-                    zwice = propor*swice(c,2)
-                    zwliq = propor*swliq(c,2)
+                       tsno(c,2) = tsno(c,2) + dtdz*dzsno(c,2)/2._r8 
+                    endif
 
-                    zmbc_phi = propor*mbc_phi(c,2)
-                    zmbc_pho = propor*mbc_pho(c,2)
-                    zmoc_phi = propor*moc_phi(c,2)
-                    zmoc_pho = propor*moc_pho(c,2)
-                    zmdst1 = propor*mdst1(c,2)
-                    zmdst2 = propor*mdst2(c,2)
-                    zmdst3 = propor*mdst3(c,2)
-                    zmdst4 = propor*mdst4(c,2)
+                    mbc_phi(c,2) = mbc_phi(c,2)/2._r8
+                    mbc_phi(c,3) = mbc_phi(c,2)
+                    mbc_pho(c,2) = mbc_pho(c,2)/2._r8
+                    mbc_pho(c,3) = mbc_pho(c,2)
+                    moc_phi(c,2) = moc_phi(c,2)/2._r8
+                    moc_phi(c,3) = moc_phi(c,2)
+                    moc_pho(c,2) = moc_pho(c,2)/2._r8
+                    moc_pho(c,3) = moc_pho(c,2)
+                    mdst1(c,2) = mdst1(c,2)/2._r8
+                    mdst1(c,3) = mdst1(c,2)
+                    mdst2(c,2) = mdst2(c,2)/2._r8
+                    mdst2(c,3) = mdst2(c,2)
+                    mdst3(c,2) = mdst3(c,2)/2._r8
+                    mdst3(c,3) = mdst3(c,2)
+                    mdst4(c,2) = mdst4(c,2)/2._r8
+                    mdst4(c,3) = mdst4(c,2)
+                    rds(c,3) = rds(c,2)
 
-                    if (is_lake) then
-                       propor = (0.05_r8+lsadz)/dzsno(c,2)
-                    else
-                       propor = 0.05_r8/dzsno(c,2)
-                    end if
-                    swice(c,2) = propor*swice(c,2)
-                    swliq(c,2) = propor*swliq(c,2)
-
-                    mbc_phi(c,2) = propor*mbc_phi(c,2)
-                    mbc_pho(c,2) = propor*mbc_pho(c,2)
-                    moc_phi(c,2) = propor*moc_phi(c,2)
-                    moc_pho(c,2) = propor*moc_pho(c,2)
-                    mdst1(c,2) = propor*mdst1(c,2)
-                    mdst2(c,2) = propor*mdst2(c,2)
-                    mdst3(c,2) = propor*mdst3(c,2)
-                    mdst4(c,2) = propor*mdst4(c,2)
-
-                    if (is_lake) then
-                       dzsno(c,2) = 0.05_r8+lsadz
-                    else
-                       dzsno(c,2) = 0.05_r8
-                    end if
-
-                    mbc_phi(c,3) = mbc_phi(c,3)+zmbc_phi  ! (combo)
-                    mbc_pho(c,3) = mbc_pho(c,3)+zmbc_pho  ! (combo)
-                    moc_phi(c,3) = moc_phi(c,3)+zmoc_phi  ! (combo)
-                    moc_pho(c,3) = moc_pho(c,3)+zmoc_pho  ! (combo)
-                    mdst1(c,3) = mdst1(c,3)+zmdst1  ! (combo)
-                    mdst2(c,3) = mdst2(c,3)+zmdst2  ! (combo)
-                    mdst3(c,3) = mdst3(c,3)+zmdst3  ! (combo)
-                    mdst4(c,3) = mdst4(c,3)+zmdst4  ! (combo)
-#ifdef MODAL_AER
-                 !mgf++ bugfix
-                 rds(c,3) = (rds(c,3)*(swliq(c,3)+swice(c,3)) + rds(c,2)*(zwliq+zwice))/(swliq(c,3)+swice(c,3)+zwliq+zwice)
-                   if ((rds(c,3) < 30.) .or. (rds(c,3) > 1500.)) then
-                      write (iulog,*) "3. SNICAR ERROR: snow grain radius of",rds(c,3),rds(c,2)
-                      write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,3), swice(c,3),zwliq, zwice
-                      write (iulog,*) "layers ", msno
-                   endif
-                 !mgf--
-#else
-                 rds(c,3) = rds(c,2) ! (combo)
-#endif
-
-                    call Combo (dzsno(c,3), swliq(c,3), swice(c,3), tsno(c,3), drr, &
-                         zwliq, zwice, tsno(c,2))
-
-                    ! Subdivided a new layer
-                    if (is_lake) then
-                       offset = 2._r8*lsadz
-                    else
-                       offset = 0._r8
-                    end if
-                    if (msno <= 3 .and. dzsno(c,3) > 0.18_r8+offset) then
-                       msno =  4
-                       dtdz = (tsno(c,2) - tsno(c,3))/((dzsno(c,2)+dzsno(c,3))/2._r8) 
-                       dzsno(c,3) = dzsno(c,3)/2._r8
-                       swice(c,3) = swice(c,3)/2._r8
-                       swliq(c,3) = swliq(c,3)/2._r8
-                       dzsno(c,4) = dzsno(c,3)
-                       swice(c,4) = swice(c,3)
-                       swliq(c,4) = swliq(c,3)
-                       tsno(c,4) = tsno(c,3) - dtdz*dzsno(c,3)/2._r8
-                       if (tsno(c,4) >= tfrz) then 
-                          tsno(c,4)  = tsno(c,3)
-                       else
-                          tsno(c,3) = tsno(c,3) + dtdz*dzsno(c,3)/2._r8 
-                       endif
-
-                       mbc_phi(c,3) = mbc_phi(c,3)/2._r8
-                       mbc_phi(c,4) = mbc_phi(c,3)
-                       mbc_pho(c,3) = mbc_pho(c,3)/2._r8
-                       mbc_pho(c,4) = mbc_pho(c,3)
-                       moc_phi(c,3) = moc_phi(c,3)/2._r8
-                       moc_phi(c,4) = moc_phi(c,3)
-                       moc_pho(c,3) = moc_pho(c,3)/2._r8
-                       moc_pho(c,4) = moc_pho(c,3)
-                       mdst1(c,3) = mdst1(c,3)/2._r8
-                       mdst1(c,4) = mdst1(c,3)
-                       mdst2(c,3) = mdst2(c,3)/2._r8
-                       mdst2(c,4) = mdst2(c,3)
-                       mdst3(c,3) = mdst3(c,3)/2._r8
-                       mdst3(c,4) = mdst3(c,3)
-                       mdst4(c,3) = mdst4(c,3)/2._r8
-                       mdst4(c,4) = mdst4(c,3)
-                       rds(c,4) = rds(c,3)
-
-                    end if
                  end if
               end if
+           end if
 
-              if (msno > 3) then
+           if (msno > 2) then
+              if (is_lake) then
+                 offset = lsadz
+              else
+                 offset = 0._r8
+              end if
+              if (dzsno(c,2) > 0.05_r8+offset) then
                  if (is_lake) then
-                    offset = lsadz
+                    drr = dzsno(c,2) - 0.05_r8 - lsadz
+                 else
+                    drr = dzsno(c,2) - 0.05_r8
+                 end if
+                 propor = drr/dzsno(c,2)
+                 zwice = propor*swice(c,2)
+                 zwliq = propor*swliq(c,2)
+
+                 zmbc_phi = propor*mbc_phi(c,2)
+                 zmbc_pho = propor*mbc_pho(c,2)
+                 zmoc_phi = propor*moc_phi(c,2)
+                 zmoc_pho = propor*moc_pho(c,2)
+                 zmdst1 = propor*mdst1(c,2)
+                 zmdst2 = propor*mdst2(c,2)
+                 zmdst3 = propor*mdst3(c,2)
+                 zmdst4 = propor*mdst4(c,2)
+
+                 if (is_lake) then
+                    propor = (0.05_r8+lsadz)/dzsno(c,2)
+                 else
+                    propor = 0.05_r8/dzsno(c,2)
+                 end if
+                 swice(c,2) = propor*swice(c,2)
+                 swliq(c,2) = propor*swliq(c,2)
+
+                 mbc_phi(c,2) = propor*mbc_phi(c,2)
+                 mbc_pho(c,2) = propor*mbc_pho(c,2)
+                 moc_phi(c,2) = propor*moc_phi(c,2)
+                 moc_pho(c,2) = propor*moc_pho(c,2)
+                 mdst1(c,2) = propor*mdst1(c,2)
+                 mdst2(c,2) = propor*mdst2(c,2)
+                 mdst3(c,2) = propor*mdst3(c,2)
+                 mdst4(c,2) = propor*mdst4(c,2)
+
+                 if (is_lake) then
+                    dzsno(c,2) = 0.05_r8+lsadz
+                 else
+                    dzsno(c,2) = 0.05_r8
+                 end if
+
+                 mbc_phi(c,3) = mbc_phi(c,3)+zmbc_phi  ! (combo)
+                 mbc_pho(c,3) = mbc_pho(c,3)+zmbc_pho  ! (combo)
+                 moc_phi(c,3) = moc_phi(c,3)+zmoc_phi  ! (combo)
+                 moc_pho(c,3) = moc_pho(c,3)+zmoc_pho  ! (combo)
+                 mdst1(c,3) = mdst1(c,3)+zmdst1  ! (combo)
+                 mdst2(c,3) = mdst2(c,3)+zmdst2  ! (combo)
+                 mdst3(c,3) = mdst3(c,3)+zmdst3  ! (combo)
+                 mdst4(c,3) = mdst4(c,3)+zmdst4  ! (combo)
+#ifdef MODAL_AER
+              !mgf++ bugfix
+              rds(c,3) = (rds(c,3)*(swliq(c,3)+swice(c,3)) + rds(c,2)*(zwliq+zwice))/(swliq(c,3)+swice(c,3)+zwliq+zwice)
+                if ((rds(c,3) < 30.) .or. (rds(c,3) > 1500.)) then
+                   write (iulog,*) "3. SNICAR ERROR: snow grain radius of",rds(c,3),rds(c,2)
+                   write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,3), swice(c,3),zwliq, zwice
+                   write (iulog,*) "layers ", msno
+                endif
+              !mgf--
+#else
+              rds(c,3) = rds(c,2) ! (combo)
+#endif
+
+                 call Combo (dzsno(c,3), swliq(c,3), swice(c,3), tsno(c,3), drr, &
+                      zwliq, zwice, tsno(c,2))
+
+                 ! Subdivided a new layer
+                 if (is_lake) then
+                    offset = 2._r8*lsadz
                  else
                     offset = 0._r8
                  end if
-                 if (dzsno(c,3) > 0.11_r8 + offset) then
-                    if (is_lake) then
-                       drr = dzsno(c,3) - 0.11_r8 - lsadz
+                 if (msno <= 3 .and. dzsno(c,3) > 0.18_r8+offset) then
+                    msno =  4
+                    dtdz = (tsno(c,2) - tsno(c,3))/((dzsno(c,2)+dzsno(c,3))/2._r8) 
+                    dzsno(c,3) = dzsno(c,3)/2._r8
+                    swice(c,3) = swice(c,3)/2._r8
+                    swliq(c,3) = swliq(c,3)/2._r8
+                    dzsno(c,4) = dzsno(c,3)
+                    swice(c,4) = swice(c,3)
+                    swliq(c,4) = swliq(c,3)
+                    tsno(c,4) = tsno(c,3) - dtdz*dzsno(c,3)/2._r8
+                    if (tsno(c,4) >= tfrz) then 
+                       tsno(c,4)  = tsno(c,3)
                     else
-                       drr = dzsno(c,3) - 0.11_r8
-                    end if
-                    propor = drr/dzsno(c,3)
-                    zwice = propor*swice(c,3)
-                    zwliq = propor*swliq(c,3)
+                       tsno(c,3) = tsno(c,3) + dtdz*dzsno(c,3)/2._r8 
+                    endif
 
-                    zmbc_phi = propor*mbc_phi(c,3)
-                    zmbc_pho = propor*mbc_pho(c,3)
-                    zmoc_phi = propor*moc_phi(c,3)
-                    zmoc_pho = propor*moc_pho(c,3)
-                    zmdst1 = propor*mdst1(c,3)
-                    zmdst2 = propor*mdst2(c,3)
-                    zmdst3 = propor*mdst3(c,3)
-                    zmdst4 = propor*mdst4(c,3)
+                    mbc_phi(c,3) = mbc_phi(c,3)/2._r8
+                    mbc_phi(c,4) = mbc_phi(c,3)
+                    mbc_pho(c,3) = mbc_pho(c,3)/2._r8
+                    mbc_pho(c,4) = mbc_pho(c,3)
+                    moc_phi(c,3) = moc_phi(c,3)/2._r8
+                    moc_phi(c,4) = moc_phi(c,3)
+                    moc_pho(c,3) = moc_pho(c,3)/2._r8
+                    moc_pho(c,4) = moc_pho(c,3)
+                    mdst1(c,3) = mdst1(c,3)/2._r8
+                    mdst1(c,4) = mdst1(c,3)
+                    mdst2(c,3) = mdst2(c,3)/2._r8
+                    mdst2(c,4) = mdst2(c,3)
+                    mdst3(c,3) = mdst3(c,3)/2._r8
+                    mdst3(c,4) = mdst3(c,3)
+                    mdst4(c,3) = mdst4(c,3)/2._r8
+                    mdst4(c,4) = mdst4(c,3)
+                    rds(c,4) = rds(c,3)
 
-                    if (is_lake) then
-                       propor = (0.11_r8+lsadz)/dzsno(c,3)
-                    else
-                       propor = 0.11_r8/dzsno(c,3)
-                    end if
-                    swice(c,3) = propor*swice(c,3)
-                    swliq(c,3) = propor*swliq(c,3)
-
-                    mbc_phi(c,3) = propor*mbc_phi(c,3)
-                    mbc_pho(c,3) = propor*mbc_pho(c,3)
-                    moc_phi(c,3) = propor*moc_phi(c,3)
-                    moc_pho(c,3) = propor*moc_pho(c,3)
-                    mdst1(c,3) = propor*mdst1(c,3)
-                    mdst2(c,3) = propor*mdst2(c,3)
-                    mdst3(c,3) = propor*mdst3(c,3)
-                    mdst4(c,3) = propor*mdst4(c,3)
-
-                    if (is_lake) then
-                       dzsno(c,3) = 0.11_r8 + lsadz
-                    else
-                       dzsno(c,3) = 0.11_r8
-                    end if
-
-                    mbc_phi(c,4) = mbc_phi(c,4)+zmbc_phi  ! (combo)
-                    mbc_pho(c,4) = mbc_pho(c,4)+zmbc_pho  ! (combo)
-                    moc_phi(c,4) = moc_phi(c,4)+zmoc_phi  ! (combo)
-                    moc_pho(c,4) = moc_pho(c,4)+zmoc_pho  ! (combo)
-                    mdst1(c,4) = mdst1(c,4)+zmdst1  ! (combo)
-                    mdst2(c,4) = mdst2(c,4)+zmdst2  ! (combo)
-                    mdst3(c,4) = mdst3(c,4)+zmdst3  ! (combo)
-                    mdst4(c,4) = mdst4(c,4)+zmdst4  ! (combo)
-#ifdef MODAL_AER
-                 !mgf++ bugfix
-                 rds(c,4) = (rds(c,4)*(swliq(c,4)+swice(c,4)) + rds(c,3)*(zwliq+zwice))/(swliq(c,4)+swice(c,4)+zwliq+zwice)
-                   if ((rds(c,4) < 30.) .or. (rds(c,4) > 1500.)) then
-                      write (iulog,*) "4. SNICAR ERROR: snow grain radius of",rds(c,4),rds(c,3)
-                      write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,4), swice(c,4),zwliq, zwice
-                      write (iulog,*) "layers ", msno
-                   endif
-                 !mgf--
-#else
-                 rds(c,4) = rds(c,3) ! (combo)
-#endif
-
-                    call Combo (dzsno(c,4), swliq(c,4), swice(c,4), tsno(c,4), drr, &
-                         zwliq, zwice, tsno(c,3))
-
-                    ! Subdivided a new layer
-                    if (is_lake) then
-                       offset = 2._r8*lsadz
-                    else
-                       offset = 0._r8
-                    end if
-                    if (msno <= 4 .and. dzsno(c,4) > 0.41_r8 + offset) then
-                       msno = 5
-                       dtdz = (tsno(c,3) - tsno(c,4))/((dzsno(c,3)+dzsno(c,4))/2._r8) 
-                       dzsno(c,4) = dzsno(c,4)/2._r8
-                       swice(c,4) = swice(c,4)/2._r8
-                       swliq(c,4) = swliq(c,4)/2._r8
-                       dzsno(c,5) = dzsno(c,4)
-                       swice(c,5) = swice(c,4)
-                       swliq(c,5) = swliq(c,4)
-                       tsno(c,5) = tsno(c,4) - dtdz*dzsno(c,4)/2._r8 
-                       if (tsno(c,5) >= tfrz) then 
-                          tsno(c,5)  = tsno(c,4)
-                       else
-                          tsno(c,4) = tsno(c,4) + dtdz*dzsno(c,4)/2._r8 
-                       endif
-
-                       mbc_phi(c,4) = mbc_phi(c,4)/2._r8
-                       mbc_phi(c,5) = mbc_phi(c,4)
-                       mbc_pho(c,4) = mbc_pho(c,4)/2._r8
-                       mbc_pho(c,5) = mbc_pho(c,4)              
-                       moc_phi(c,4) = moc_phi(c,4)/2._r8
-                       moc_phi(c,5) = moc_phi(c,4)
-                       moc_pho(c,4) = moc_pho(c,4)/2._r8
-                       moc_pho(c,5) = moc_pho(c,4)
-                       mdst1(c,4) = mdst1(c,4)/2._r8
-                       mdst1(c,5) = mdst1(c,4)
-                       mdst2(c,4) = mdst2(c,4)/2._r8
-                       mdst2(c,5) = mdst2(c,4)
-                       mdst3(c,4) = mdst3(c,4)/2._r8
-                       mdst3(c,5) = mdst3(c,4)
-                       mdst4(c,4) = mdst4(c,4)/2._r8
-                       mdst4(c,5) = mdst4(c,4)
-                       rds(c,5) = rds(c,4)
-
-                    end if
                  end if
               end if
+           end if
 
-              if (msno > 4) then
+           if (msno > 3) then
+              if (is_lake) then
+                 offset = lsadz
+              else
+                 offset = 0._r8
+              end if
+              if (dzsno(c,3) > 0.11_r8 + offset) then
                  if (is_lake) then
-                    offset = lsadz
+                    drr = dzsno(c,3) - 0.11_r8 - lsadz
+                 else
+                    drr = dzsno(c,3) - 0.11_r8
+                 end if
+                 propor = drr/dzsno(c,3)
+                 zwice = propor*swice(c,3)
+                 zwliq = propor*swliq(c,3)
+
+                 zmbc_phi = propor*mbc_phi(c,3)
+                 zmbc_pho = propor*mbc_pho(c,3)
+                 zmoc_phi = propor*moc_phi(c,3)
+                 zmoc_pho = propor*moc_pho(c,3)
+                 zmdst1 = propor*mdst1(c,3)
+                 zmdst2 = propor*mdst2(c,3)
+                 zmdst3 = propor*mdst3(c,3)
+                 zmdst4 = propor*mdst4(c,3)
+
+                 if (is_lake) then
+                    propor = (0.11_r8+lsadz)/dzsno(c,3)
+                 else
+                    propor = 0.11_r8/dzsno(c,3)
+                 end if
+                 swice(c,3) = propor*swice(c,3)
+                 swliq(c,3) = propor*swliq(c,3)
+
+                 mbc_phi(c,3) = propor*mbc_phi(c,3)
+                 mbc_pho(c,3) = propor*mbc_pho(c,3)
+                 moc_phi(c,3) = propor*moc_phi(c,3)
+                 moc_pho(c,3) = propor*moc_pho(c,3)
+                 mdst1(c,3) = propor*mdst1(c,3)
+                 mdst2(c,3) = propor*mdst2(c,3)
+                 mdst3(c,3) = propor*mdst3(c,3)
+                 mdst4(c,3) = propor*mdst4(c,3)
+
+                 if (is_lake) then
+                    dzsno(c,3) = 0.11_r8 + lsadz
+                 else
+                    dzsno(c,3) = 0.11_r8
+                 end if
+
+                 mbc_phi(c,4) = mbc_phi(c,4)+zmbc_phi  ! (combo)
+                 mbc_pho(c,4) = mbc_pho(c,4)+zmbc_pho  ! (combo)
+                 moc_phi(c,4) = moc_phi(c,4)+zmoc_phi  ! (combo)
+                 moc_pho(c,4) = moc_pho(c,4)+zmoc_pho  ! (combo)
+                 mdst1(c,4) = mdst1(c,4)+zmdst1  ! (combo)
+                 mdst2(c,4) = mdst2(c,4)+zmdst2  ! (combo)
+                 mdst3(c,4) = mdst3(c,4)+zmdst3  ! (combo)
+                 mdst4(c,4) = mdst4(c,4)+zmdst4  ! (combo)
+#ifdef MODAL_AER
+              !mgf++ bugfix
+              rds(c,4) = (rds(c,4)*(swliq(c,4)+swice(c,4)) + rds(c,3)*(zwliq+zwice))/(swliq(c,4)+swice(c,4)+zwliq+zwice)
+                if ((rds(c,4) < 30.) .or. (rds(c,4) > 1500.)) then
+                   write (iulog,*) "4. SNICAR ERROR: snow grain radius of",rds(c,4),rds(c,3)
+                   write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,4), swice(c,4),zwliq, zwice
+                   write (iulog,*) "layers ", msno
+                endif
+              !mgf--
+#else
+              rds(c,4) = rds(c,3) ! (combo)
+#endif
+
+                 call Combo (dzsno(c,4), swliq(c,4), swice(c,4), tsno(c,4), drr, &
+                      zwliq, zwice, tsno(c,3))
+
+                 ! Subdivided a new layer
+                 if (is_lake) then
+                    offset = 2._r8*lsadz
                  else
                     offset = 0._r8
                  end if
-                 if (dzsno(c,4) > 0.23_r8+offset) then
-                    if (is_lake) then
-                       drr = dzsno(c,4) - 0.23_r8 - lsadz
+                 if (msno <= 4 .and. dzsno(c,4) > 0.41_r8 + offset) then
+                    msno = 5
+                    dtdz = (tsno(c,3) - tsno(c,4))/((dzsno(c,3)+dzsno(c,4))/2._r8) 
+                    dzsno(c,4) = dzsno(c,4)/2._r8
+                    swice(c,4) = swice(c,4)/2._r8
+                    swliq(c,4) = swliq(c,4)/2._r8
+                    dzsno(c,5) = dzsno(c,4)
+                    swice(c,5) = swice(c,4)
+                    swliq(c,5) = swliq(c,4)
+                    tsno(c,5) = tsno(c,4) - dtdz*dzsno(c,4)/2._r8 
+                    if (tsno(c,5) >= tfrz) then 
+                       tsno(c,5)  = tsno(c,4)
                     else
-                       drr = dzsno(c,4) - 0.23_r8
-                    end if
-                    propor = drr/dzsno(c,4)
-                    zwice = propor*swice(c,4)
-                    zwliq = propor*swliq(c,4)
+                       tsno(c,4) = tsno(c,4) + dtdz*dzsno(c,4)/2._r8 
+                    endif
 
-                    zmbc_phi = propor*mbc_phi(c,4)
-                    zmbc_pho = propor*mbc_pho(c,4)
-                    zmoc_phi = propor*moc_phi(c,4)
-                    zmoc_pho = propor*moc_pho(c,4)
-                    zmdst1 = propor*mdst1(c,4)
-                    zmdst2 = propor*mdst2(c,4)
-                    zmdst3 = propor*mdst3(c,4)
-                    zmdst4 = propor*mdst4(c,4)
+                    mbc_phi(c,4) = mbc_phi(c,4)/2._r8
+                    mbc_phi(c,5) = mbc_phi(c,4)
+                    mbc_pho(c,4) = mbc_pho(c,4)/2._r8
+                    mbc_pho(c,5) = mbc_pho(c,4)              
+                    moc_phi(c,4) = moc_phi(c,4)/2._r8
+                    moc_phi(c,5) = moc_phi(c,4)
+                    moc_pho(c,4) = moc_pho(c,4)/2._r8
+                    moc_pho(c,5) = moc_pho(c,4)
+                    mdst1(c,4) = mdst1(c,4)/2._r8
+                    mdst1(c,5) = mdst1(c,4)
+                    mdst2(c,4) = mdst2(c,4)/2._r8
+                    mdst2(c,5) = mdst2(c,4)
+                    mdst3(c,4) = mdst3(c,4)/2._r8
+                    mdst3(c,5) = mdst3(c,4)
+                    mdst4(c,4) = mdst4(c,4)/2._r8
+                    mdst4(c,5) = mdst4(c,4)
+                    rds(c,5) = rds(c,4)
 
-                    if (is_lake) then
-                       propor = (0.23_r8+lsadz)/dzsno(c,4)
-                    else
-                       propor = 0.23_r8/dzsno(c,4)
-                    end if
-                    swice(c,4) = propor*swice(c,4)
-                    swliq(c,4) = propor*swliq(c,4)
-
-                    mbc_phi(c,4) = propor*mbc_phi(c,4)
-                    mbc_pho(c,4) = propor*mbc_pho(c,4)
-                    moc_phi(c,4) = propor*moc_phi(c,4)
-                    moc_pho(c,4) = propor*moc_pho(c,4)
-                    mdst1(c,4) = propor*mdst1(c,4)
-                    mdst2(c,4) = propor*mdst2(c,4)
-                    mdst3(c,4) = propor*mdst3(c,4)
-                    mdst4(c,4) = propor*mdst4(c,4)
-
-                    if (is_lake) then
-                       dzsno(c,4) = 0.23_r8 + lsadz
-                    else
-                       dzsno(c,4) = 0.23_r8
-                    end if
-
-                    mbc_phi(c,5) = mbc_phi(c,5)+zmbc_phi  ! (combo)
-                    mbc_pho(c,5) = mbc_pho(c,5)+zmbc_pho  ! (combo)
-                    moc_phi(c,5) = moc_phi(c,5)+zmoc_phi  ! (combo)
-                    moc_pho(c,5) = moc_pho(c,5)+zmoc_pho  ! (combo)
-                    mdst1(c,5) = mdst1(c,5)+zmdst1  ! (combo)
-                    mdst2(c,5) = mdst2(c,5)+zmdst2  ! (combo)
-                    mdst3(c,5) = mdst3(c,5)+zmdst3  ! (combo)
-                    mdst4(c,5) = mdst4(c,5)+zmdst4  ! (combo)
-#ifdef MODAL_AER
-                 !mgf++ bugfix
-                 rds(c,5) = (rds(c,5)*(swliq(c,5)+swice(c,5)) + rds(c,4)*(zwliq+zwice))/(swliq(c,5)+swice(c,5)+zwliq+zwice)
-                   if ((rds(c,5) < 30.) .or. (rds(c,5) > 1500.)) then
-                      write (iulog,*) "5. SNICAR ERROR: snow grain radius of",rds(c,5),rds(c,4)
-                      write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,5), swice(c,5),zwliq, zwice
-                      write (iulog,*) "layers ", msno
-                   endif
-                 !mgf--
-#else
-                 rds(c,5) = rds(c,4) ! (combo)
-#endif
-
-                    call Combo (dzsno(c,5), swliq(c,5), swice(c,5), tsno(c,5), drr, &
-                         zwliq, zwice, tsno(c,4))
                  end if
               end if
+           end if
 
-              snl(c) = -msno
+           if (msno > 4) then
+              if (is_lake) then
+                 offset = lsadz
+              else
+                 offset = 0._r8
+              end if
+              if (dzsno(c,4) > 0.23_r8+offset) then
+                 if (is_lake) then
+                    drr = dzsno(c,4) - 0.23_r8 - lsadz
+                 else
+                    drr = dzsno(c,4) - 0.23_r8
+                 end if
+                 propor = drr/dzsno(c,4)
+                 zwice = propor*swice(c,4)
+                 zwliq = propor*swliq(c,4)
 
-           end do
-       else
-           !++ams
-           loop_snowcolumns: do fc = 1, num_snowc
-              c = filter_snowc(fc)
+                 zmbc_phi = propor*mbc_phi(c,4)
+                 zmbc_pho = propor*mbc_pho(c,4)
+                 zmoc_phi = propor*moc_phi(c,4)
+                 zmoc_pho = propor*moc_pho(c,4)
+                 zmdst1 = propor*mdst1(c,4)
+                 zmdst2 = propor*mdst2(c,4)
+                 zmdst3 = propor*mdst3(c,4)
+                 zmdst4 = propor*mdst4(c,4)
 
-              msno = abs(snl(c))
+                 if (is_lake) then
+                    propor = (0.23_r8+lsadz)/dzsno(c,4)
+                 else
+                    propor = 0.23_r8/dzsno(c,4)
+                 end if
+                 swice(c,4) = propor*swice(c,4)
+                 swliq(c,4) = propor*swliq(c,4)
 
-              ! Now traverse layers from top to bottom in a dynamic way, as the total
-              ! number of layers (msno) may increase during the loop.
-              ! Impose k < nlevsno; the special case 'k == nlevsno' is not relevant,
-              ! as it is neither allowed to subdivide nor does it have layers below.
-              k = 1
-              loop_layers: do while( k <= msno .and. k < nlevsno )
+                 mbc_phi(c,4) = propor*mbc_phi(c,4)
+                 mbc_pho(c,4) = propor*mbc_pho(c,4)
+                 moc_phi(c,4) = propor*moc_phi(c,4)
+                 moc_pho(c,4) = propor*moc_pho(c,4)
+                 mdst1(c,4) = propor*mdst1(c,4)
+                 mdst2(c,4) = propor*mdst2(c,4)
+                 mdst3(c,4) = propor*mdst3(c,4)
+                 mdst4(c,4) = propor*mdst4(c,4)
 
-                 ! Current layer is bottom layer
-                 if (k == msno) then
-
-                    if (is_lake) then
-                       offset = 2._r8 * lsadz
-                    else
-                       offset = 0._r8
-                    end if
-
-                    if (dzsno(c,k) > dzmax_l(k) + offset) then
-                       ! Subdivide layer into two layers with equal thickness, water
-                       ! content, ice content and temperature
-                       msno = msno + 1
-                       dzsno(c,k)     = dzsno(c,k) / 2.0_r8
-                       dzsno(c,k+1)   = dzsno(c,k)
-                       swice(c,k)     = swice(c,k) / 2.0_r8
-                       swice(c,k+1)   = swice(c,k)
-                       swliq(c,k)     = swliq(c,k) / 2.0_r8
-                       swliq(c,k+1)   = swliq(c,k)
-
-                       if (k == 1) then
-                          ! special case
-                          tsno(c,k+1)    = tsno(c,k)
-                       else
-                          ! use temperature gradient
-                          dtdz           = (tsno(c,k-1) - tsno(c,k))/((dzsno(c,k-1)+2*dzsno(c,k))/2.0_r8)
-                          tsno(c,k+1) = tsno(c,k) - dtdz*dzsno(c,k)/2.0_r8
-                          if (tsno(c,k+1) >= tfrz) then
-                             tsno(c,k+1)  = tsno(c,k)
-                          else
-                             tsno(c,k) = tsno(c,k) + dtdz*dzsno(c,k)/2.0_r8
-                          endif
-                       end if
-
-                       mbc_phi(c,k)   = mbc_phi(c,k) / 2.0_r8
-                       mbc_phi(c,k+1) = mbc_phi(c,k)
-                       mbc_pho(c,k)   = mbc_pho(c,k) / 2.0_r8
-                       mbc_pho(c,k+1) = mbc_pho(c,k)
-                       moc_phi(c,k)   = moc_phi(c,k) / 2.0_r8
-                       moc_phi(c,k+1) = moc_phi(c,k)
-                       moc_pho(c,k)   = moc_pho(c,k) / 2.0_r8
-                       moc_pho(c,k+1) = moc_pho(c,k)
-                       mdst1(c,k)     = mdst1(c,k) / 2.0_r8
-                       mdst1(c,k+1)   = mdst1(c,k)
-                       mdst2(c,k)     = mdst2(c,k) / 2.0_r8
-                       mdst2(c,k+1)   = mdst2(c,k)
-                       mdst3(c,k)     = mdst3(c,k) / 2.0_r8
-                       mdst3(c,k+1)   = mdst3(c,k)
-                       mdst4(c,k)     = mdst4(c,k) / 2.0_r8
-                       mdst4(c,k+1)   = mdst4(c,k)
-
-                       rds(c,k+1)     = rds(c,k)
-                    end if
+                 if (is_lake) then
+                    dzsno(c,4) = 0.23_r8 + lsadz
+                 else
+                    dzsno(c,4) = 0.23_r8
                  end if
 
-                 ! There are layers below (note this is not exclusive with previous
-                 ! if-statement, since msno may have increased in the previous if-statement)
-                 if (k < msno) then
+                 mbc_phi(c,5) = mbc_phi(c,5)+zmbc_phi  ! (combo)
+                 mbc_pho(c,5) = mbc_pho(c,5)+zmbc_pho  ! (combo)
+                 moc_phi(c,5) = moc_phi(c,5)+zmoc_phi  ! (combo)
+                 moc_pho(c,5) = moc_pho(c,5)+zmoc_pho  ! (combo)
+                 mdst1(c,5) = mdst1(c,5)+zmdst1  ! (combo)
+                 mdst2(c,5) = mdst2(c,5)+zmdst2  ! (combo)
+                 mdst3(c,5) = mdst3(c,5)+zmdst3  ! (combo)
+                 mdst4(c,5) = mdst4(c,5)+zmdst4  ! (combo)
+#ifdef MODAL_AER
+              !mgf++ bugfix
+              rds(c,5) = (rds(c,5)*(swliq(c,5)+swice(c,5)) + rds(c,4)*(zwliq+zwice))/(swliq(c,5)+swice(c,5)+zwliq+zwice)
+                if ((rds(c,5) < 30.) .or. (rds(c,5) > 1500.)) then
+                   write (iulog,*) "5. SNICAR ERROR: snow grain radius of",rds(c,5),rds(c,4)
+                   write (iulog,*) "swliq, swice, zwliq, zwice", swliq(c,5), swice(c,5),zwliq, zwice
+                   write (iulog,*) "layers ", msno
+                endif
+              !mgf--
+#else
+              rds(c,5) = rds(c,4) ! (combo)
+#endif
 
-                    if (is_lake) then
-                       offset = lsadz
-                    else
-                       offset = 0._r8
-                    end if
+                 call Combo (dzsno(c,5), swliq(c,5), swice(c,5), tsno(c,5), drr, &
+                      zwliq, zwice, tsno(c,4))
+              end if
+           end if
 
-                    if (dzsno(c,k) > dzmax_u(k) + offset ) then
-                       ! Only dump excess snow to underlying layer in a conservative fashion.
-                       ! Other quantities will depend on the height of the excess snow: a ratio is used for this.
-                       drr      = dzsno(c,k) - dzmax_u(k) - offset
+           snl(c) = -msno
 
-                       propor   = drr/dzsno(c,k)
-                       zwice    = propor*swice(c,k)
-                       zwliq    = propor*swliq(c,k)
-                       zmbc_phi = propor*mbc_phi(c,k)
-                       zmbc_pho = propor*mbc_pho(c,k)
-                       zmoc_phi = propor*moc_phi(c,k)
-                       zmoc_pho = propor*moc_pho(c,k)
-                       zmdst1   = propor*mdst1(c,k)
-                       zmdst2   = propor*mdst2(c,k)
-                       zmdst3   = propor*mdst3(c,k)
-                       zmdst4   = propor*mdst4(c,k)
-
-                       propor         = (dzmax_u(k)+offset)/dzsno(c,k)
-                       swice(c,k)     = propor*swice(c,k)
-                       swliq(c,k)     = propor*swliq(c,k)
-                       mbc_phi(c,k)   = propor*mbc_phi(c,k)
-                       mbc_pho(c,k)   = propor*mbc_pho(c,k)
-                       moc_phi(c,k)   = propor*moc_phi(c,k)
-                       moc_pho(c,k)   = propor*moc_pho(c,k)
-                       mdst1(c,k)     = propor*mdst1(c,k)
-                       mdst2(c,k)     = propor*mdst2(c,k)
-                       mdst3(c,k)     = propor*mdst3(c,k)
-                       mdst4(c,k)     = propor*mdst4(c,k)
-
-                       ! Set depth layer k to maximum allowed value
-                       dzsno(c,k)  = dzmax_u(k)  + offset
-
-                       mbc_phi(c,k+1) = mbc_phi(c,k+1)+zmbc_phi  ! (combo)
-                       mbc_pho(c,k+1) = mbc_pho(c,k+1)+zmbc_pho  ! (combo)
-                       moc_phi(c,k+1) = moc_phi(c,k+1)+zmoc_phi  ! (combo)
-                       moc_pho(c,k+1) = moc_pho(c,k+1)+zmoc_pho  ! (combo)
-                       mdst1(c,k+1)   = mdst1(c,k+1)+zmdst1  ! (combo)
-                       mdst2(c,k+1)   = mdst2(c,k+1)+zmdst2  ! (combo)
-                       mdst3(c,k+1)   = mdst3(c,k+1)+zmdst3  ! (combo)
-                       mdst4(c,k+1)   = mdst4(c,k+1)+zmdst4  ! (combo)
-
-                       ! Mass-weighted combination of radius
-                       rds(c,k+1) = MassWeightedSnowRadius( rds(c,k), rds(c,k+1), &
-                            (swliq(c,k+1)+swice(c,k+1)), (zwliq+zwice) )
-
-                       call Combo (dzsno(c,k+1), swliq(c,k+1), swice(c,k+1), tsno(c,k+1), drr, &
-                            zwliq, zwice, tsno(c,k))
-                    end if
-                 end if
-                 k = k+1
-              end do loop_layers
-
-              snl(c) = -msno
-
-           end do loop_snowcolumns
-       end if
-       !ams++
+       end do
 
        do j = -nlevsno+1,0
           do fc = 1, num_snowc
@@ -1959,8 +1813,336 @@ contains
    end subroutine DivideSnowLayers
    
    !-----------------------------------------------------------------------
-   !++ams (from CESM2)
+   subroutine DivideExtraSnowLayers(bounds, num_snowc, filter_snowc, &
+        aerosol_vars, temperature_vars, waterstate_vars, is_lake)
+     !
+     ! !DESCRIPTION:
+     ! Subdivides up to 16 snow layers if they exceed their prescribed maximum thickness.
+     ! This alternate subroutine is needed if "use_extrasnowlayers" is true.
+     !
+     ! !USES:
+     use clm_varcon,  only : tfrz 
+     use LakeCon   ,  only : lsadz
+     !
+     ! !ARGUMENTS:
+     type(bounds_type)      , intent(in)    :: bounds          
+     integer                , intent(in)    :: num_snowc       ! number of column snow points in column filter
+     integer                , intent(in)    :: filter_snowc(:) ! column filter for snow points
+     type(aerosol_type)     , intent(inout) :: aerosol_vars
+     type(temperature_type) , intent(inout) :: temperature_vars
+     type(waterstate_type)  , intent(inout) :: waterstate_vars
+     logical                , intent(in)    :: is_lake  !TODO - this should be examined and removed in the future
+     !
+     ! !LOCAL VARIABLES:
+     integer  :: j, c, fc, k                              ! indices
+     real(r8) :: drr                                      ! thickness of the combined [m]
+     integer  :: msno                                     ! number of snow layer 1 (top) to msno (bottom)
+     real(r8) :: dzsno(bounds%begc:bounds%endc,nlevsno)   ! Snow layer thickness [m]
+     real(r8) :: swice(bounds%begc:bounds%endc,nlevsno)   ! Partial volume of ice [m3/m3]
+     real(r8) :: swliq(bounds%begc:bounds%endc,nlevsno)   ! Partial volume of liquid water [m3/m3]
+     real(r8) :: tsno(bounds%begc:bounds%endc ,nlevsno)   ! Nodel temperature [K]
+     real(r8) :: zwice                                    ! temporary
+     real(r8) :: zwliq                                    ! temporary
+     real(r8) :: propor                                   ! temporary
+     real(r8) :: dtdz                                     ! temporary
+     ! temporary variables mimicking the structure of other layer division variables
+     real(r8) :: mbc_phi(bounds%begc:bounds%endc,nlevsno) ! mass of BC in each snow layer
+     real(r8) :: zmbc_phi                                 ! temporary
+     real(r8) :: mbc_pho(bounds%begc:bounds%endc,nlevsno) ! mass of BC in each snow layer
+     real(r8) :: zmbc_pho                                 ! temporary
+     real(r8) :: moc_phi(bounds%begc:bounds%endc,nlevsno) ! mass of OC in each snow layer
+     real(r8) :: zmoc_phi                                 ! temporary
+     real(r8) :: moc_pho(bounds%begc:bounds%endc,nlevsno) ! mass of OC in each snow layer
+     real(r8) :: zmoc_pho                                 ! temporary
+     real(r8) :: mdst1(bounds%begc:bounds%endc,nlevsno)   ! mass of dust 1 in each snow layer
+     real(r8) :: zmdst1                                   ! temporary
+     real(r8) :: mdst2(bounds%begc:bounds%endc,nlevsno)   ! mass of dust 2 in each snow layer
+     real(r8) :: zmdst2                                   ! temporary
+     real(r8) :: mdst3(bounds%begc:bounds%endc,nlevsno)   ! mass of dust 3 in each snow layer
+     real(r8) :: zmdst3                                   ! temporary
+     real(r8) :: mdst4(bounds%begc:bounds%endc,nlevsno)   ! mass of dust 4 in each snow layer
+     real(r8) :: zmdst4                                   ! temporary
+     real(r8) :: rds(bounds%begc:bounds%endc,nlevsno)
+     ! Variables for consistency check
+     real(r8) :: dztot(bounds%begc:bounds%endc)
+     real(r8) :: snwicetot(bounds%begc:bounds%endc)
+     real(r8) :: snwliqtot(bounds%begc:bounds%endc)
+     real(r8) :: offset ! temporary
+     !-----------------------------------------------------------------------
+     
+     associate(                                            & 
+          t_soisno   => col_es%t_soisno    , & ! Output: [real(r8) (:,:) ] soil temperature (Kelvin)              
+
+          h2osoi_ice => col_ws%h2osoi_ice   , & ! Output: [real(r8) (:,:) ] ice lens (kg/m2)                       
+          h2osoi_liq => col_ws%h2osoi_liq   , & ! Output: [real(r8) (:,:) ] liquid water (kg/m2)                   
+          frac_sno   => col_ws%frac_sno_eff , & ! Output: [real(r8) (:)   ] fraction of ground covered by snow (0 to 1)
+          snw_rds    => col_ws%snw_rds      , & ! Output: [real(r8) (:,:) ] effective snow grain radius (col,lyr) [microns, m^-6]
+
+          mss_bcphi  => aerosol_vars%mss_bcphi_col       , & ! Output: [real(r8) (:,:) ] hydrophilic BC mass in snow (col,lyr) [kg]
+          mss_bcpho  => aerosol_vars%mss_bcpho_col       , & ! Output: [real(r8) (:,:) ] hydrophobic BC mass in snow (col,lyr) [kg]
+          mss_ocphi  => aerosol_vars%mss_ocphi_col       , & ! Output: [real(r8) (:,:) ] hydrophilic OC mass in snow (col,lyr) [kg]
+          mss_ocpho  => aerosol_vars%mss_ocpho_col       , & ! Output: [real(r8) (:,:) ] hydrophobic OC mass in snow (col,lyr) [kg]
+          mss_dst1   => aerosol_vars%mss_dst1_col        , & ! Output: [real(r8) (:,:) ] dust species 1 mass in snow (col,lyr) [kg]
+          mss_dst2   => aerosol_vars%mss_dst2_col        , & ! Output: [real(r8) (:,:) ] dust species 2 mass in snow (col,lyr) [kg]
+          mss_dst3   => aerosol_vars%mss_dst3_col        , & ! Output: [real(r8) (:,:) ] dust species 3 mass in snow (col,lyr) [kg]
+          mss_dst4   => aerosol_vars%mss_dst4_col        , & ! Output: [real(r8) (:,:) ] dust species 4 mass in snow (col,lyr) [kg]
+
+          snl        => col_pp%snl                          , & ! Output: [integer  (:)   ] number of snow layers                     
+          dz         => col_pp%dz                           , & ! Output: [real(r8) (:,:) ] layer depth (m)                        
+          zi         => col_pp%zi                           , & ! Output: [real(r8) (:,:) ] interface level below a "z" level (m)  
+          z          => col_pp%z                              & ! Output: [real(r8) (:,:) ] layer thickness (m)                   
+          )
+
+       if ( is_lake ) then
+          ! Initialize for consistency check
+          do j = -nlevsno+1,0
+             do fc = 1, num_snowc
+                c = filter_snowc(fc)
+                
+                if (j == -nlevsno+1) then
+                   dztot(c) = 0._r8
+                   snwicetot(c) = 0._r8
+                   snwliqtot(c) = 0._r8
+                end if
+                
+                if (j >= snl(c)+1) then
+                   dztot(c) = dztot(c) + dz(c,j)
+                   snwicetot(c) = snwicetot(c) + h2osoi_ice(c,j)
+                   snwliqtot(c) = snwliqtot(c) + h2osoi_liq(c,j)
+                end if
+             end do
+          end do
+       end if
+
+       ! Begin calculation - note that the following column loops are only invoked
+       ! for snow-covered columns
+
+       do j = 1,nlevsno
+          do fc = 1, num_snowc
+             c = filter_snowc(fc)
+             if (j <= abs(snl(c))) then
+                if (is_lake) then
+                   dzsno(c,j) = dz(c,j+snl(c))
+                else
+                   dzsno(c,j) = frac_sno(c)*dz(c,j+snl(c))
+                end if
+                swice(c,j) = h2osoi_ice(c,j+snl(c))
+                swliq(c,j) = h2osoi_liq(c,j+snl(c))
+                tsno(c,j)  = t_soisno(c,j+snl(c))
+
+                mbc_phi(c,j) = mss_bcphi(c,j+snl(c))
+                mbc_pho(c,j) = mss_bcpho(c,j+snl(c))
+                moc_phi(c,j) = mss_ocphi(c,j+snl(c))
+                moc_pho(c,j) = mss_ocpho(c,j+snl(c))
+                mdst1(c,j)   = mss_dst1(c,j+snl(c))
+                mdst2(c,j)   = mss_dst2(c,j+snl(c))
+                mdst3(c,j)   = mss_dst3(c,j+snl(c))
+                mdst4(c,j)   = mss_dst4(c,j+snl(c))
+                rds(c,j)     = snw_rds(c,j+snl(c))
+             end if
+          end do
+       end do
+
+       loop_snowcolumns: do fc = 1, num_snowc
+           c = filter_snowc(fc)
+
+           msno = abs(snl(c))
+
+           ! Now traverse layers from top to bottom in a dynamic way, as the total
+           ! number of layers (msno) may increase during the loop.
+           ! Impose k < nlevsno; the special case 'k == nlevsno' is not relevant,
+           ! as it is neither allowed to subdivide nor does it have layers below.
+           k = 1
+           loop_layers: do while( k <= msno .and. k < nlevsno )
+
+              ! Current layer is bottom layer
+              if (k == msno) then
+
+                 if (is_lake) then
+                    offset = 2._r8 * lsadz
+                 else
+                    offset = 0._r8
+                 end if
+
+                 if (dzsno(c,k) > dzmax_l(k) + offset) then
+                    ! Subdivide layer into two layers with equal thickness, water
+                    ! content, ice content and temperature
+                    msno = msno + 1
+                    dzsno(c,k)     = dzsno(c,k) / 2.0_r8
+                    dzsno(c,k+1)   = dzsno(c,k)
+                    swice(c,k)     = swice(c,k) / 2.0_r8
+                    swice(c,k+1)   = swice(c,k)
+                    swliq(c,k)     = swliq(c,k) / 2.0_r8
+                    swliq(c,k+1)   = swliq(c,k)
+
+                    if (k == 1) then
+                       ! special case
+                       tsno(c,k+1)    = tsno(c,k)
+                    else
+                       ! use temperature gradient
+                       dtdz           = (tsno(c,k-1) - tsno(c,k))/((dzsno(c,k-1)+2*dzsno(c,k))/2.0_r8)
+                       tsno(c,k+1) = tsno(c,k) - dtdz*dzsno(c,k)/2.0_r8
+                       if (tsno(c,k+1) >= tfrz) then
+                          tsno(c,k+1)  = tsno(c,k)
+                       else
+                          tsno(c,k) = tsno(c,k) + dtdz*dzsno(c,k)/2.0_r8
+                       endif
+                    end if
+
+                    mbc_phi(c,k)   = mbc_phi(c,k) / 2.0_r8
+                    mbc_phi(c,k+1) = mbc_phi(c,k)
+                    mbc_pho(c,k)   = mbc_pho(c,k) / 2.0_r8
+                    mbc_pho(c,k+1) = mbc_pho(c,k)
+                    moc_phi(c,k)   = moc_phi(c,k) / 2.0_r8
+                    moc_phi(c,k+1) = moc_phi(c,k)
+                    moc_pho(c,k)   = moc_pho(c,k) / 2.0_r8
+                    moc_pho(c,k+1) = moc_pho(c,k)
+                    mdst1(c,k)     = mdst1(c,k) / 2.0_r8
+                    mdst1(c,k+1)   = mdst1(c,k)
+                    mdst2(c,k)     = mdst2(c,k) / 2.0_r8
+                    mdst2(c,k+1)   = mdst2(c,k)
+                    mdst3(c,k)     = mdst3(c,k) / 2.0_r8
+                    mdst3(c,k+1)   = mdst3(c,k)
+                    mdst4(c,k)     = mdst4(c,k) / 2.0_r8
+                    mdst4(c,k+1)   = mdst4(c,k)
+
+                    rds(c,k+1)     = rds(c,k)
+                 end if
+              end if
+
+              ! There are layers below (note this is not exclusive with previous
+              ! if-statement, since msno may have increased in the previous if-statement)
+              if (k < msno) then
+
+                 if (is_lake) then
+                    offset = lsadz
+                 else
+                    offset = 0._r8
+                 end if
+
+                 if (dzsno(c,k) > dzmax_u(k) + offset ) then
+                    ! Only dump excess snow to underlying layer in a conservative fashion.
+                    ! Other quantities will depend on the height of the excess snow: a ratio is used for this.
+                    drr      = dzsno(c,k) - dzmax_u(k) - offset
+
+                    propor   = drr/dzsno(c,k)
+                    zwice    = propor*swice(c,k)
+                    zwliq    = propor*swliq(c,k)
+                    zmbc_phi = propor*mbc_phi(c,k)
+                    zmbc_pho = propor*mbc_pho(c,k)
+                    zmoc_phi = propor*moc_phi(c,k)
+                    zmoc_pho = propor*moc_pho(c,k)
+                    zmdst1   = propor*mdst1(c,k)
+                    zmdst2   = propor*mdst2(c,k)
+                    zmdst3   = propor*mdst3(c,k)
+                    zmdst4   = propor*mdst4(c,k)
+
+                    propor         = (dzmax_u(k)+offset)/dzsno(c,k)
+                    swice(c,k)     = propor*swice(c,k)
+                    swliq(c,k)     = propor*swliq(c,k)
+                    mbc_phi(c,k)   = propor*mbc_phi(c,k)
+                    mbc_pho(c,k)   = propor*mbc_pho(c,k)
+                    moc_phi(c,k)   = propor*moc_phi(c,k)
+                    moc_pho(c,k)   = propor*moc_pho(c,k)
+                    mdst1(c,k)     = propor*mdst1(c,k)
+                    mdst2(c,k)     = propor*mdst2(c,k)
+                    mdst3(c,k)     = propor*mdst3(c,k)
+                    mdst4(c,k)     = propor*mdst4(c,k)
+
+                    ! Set depth layer k to maximum allowed value
+                    dzsno(c,k)  = dzmax_u(k)  + offset
+
+                    mbc_phi(c,k+1) = mbc_phi(c,k+1)+zmbc_phi  ! (combo)
+                    mbc_pho(c,k+1) = mbc_pho(c,k+1)+zmbc_pho  ! (combo)
+                    moc_phi(c,k+1) = moc_phi(c,k+1)+zmoc_phi  ! (combo)
+                    moc_pho(c,k+1) = moc_pho(c,k+1)+zmoc_pho  ! (combo)
+                    mdst1(c,k+1)   = mdst1(c,k+1)+zmdst1  ! (combo)
+                    mdst2(c,k+1)   = mdst2(c,k+1)+zmdst2  ! (combo)
+                    mdst3(c,k+1)   = mdst3(c,k+1)+zmdst3  ! (combo)
+                    mdst4(c,k+1)   = mdst4(c,k+1)+zmdst4  ! (combo)
+
+                    ! Mass-weighted combination of radius
+                    rds(c,k+1) = MassWeightedSnowRadius( rds(c,k), rds(c,k+1), &
+                         (swliq(c,k+1)+swice(c,k+1)), (zwliq+zwice) )
+
+                    call Combo (dzsno(c,k+1), swliq(c,k+1), swice(c,k+1), tsno(c,k+1), drr, &
+                         zwliq, zwice, tsno(c,k))
+                 end if
+              end if
+              k = k+1
+           end do loop_layers
+
+           snl(c) = -msno
+
+       end do loop_snowcolumns
+
+       do j = -nlevsno+1,0
+          do fc = 1, num_snowc
+             c = filter_snowc(fc)
+             if (j >= snl(c)+1) then
+                if (is_lake) then
+                   dz(c,j) = dzsno(c,j-snl(c))
+                else
+                   dz(c,j) = dzsno(c,j-snl(c))/frac_sno(c)
+                end if
+                h2osoi_ice(c,j) = swice(c,j-snl(c))
+                h2osoi_liq(c,j) = swliq(c,j-snl(c))
+                t_soisno(c,j)   = tsno(c,j-snl(c))
+                mss_bcphi(c,j)   = mbc_phi(c,j-snl(c))
+                mss_bcpho(c,j)   = mbc_pho(c,j-snl(c))
+                mss_ocphi(c,j)   = moc_phi(c,j-snl(c))
+                mss_ocpho(c,j)   = moc_pho(c,j-snl(c))
+                mss_dst1(c,j)    = mdst1(c,j-snl(c))
+                mss_dst2(c,j)    = mdst2(c,j-snl(c))
+                mss_dst3(c,j)    = mdst3(c,j-snl(c))
+                mss_dst4(c,j)    = mdst4(c,j-snl(c))
+                snw_rds(c,j)     = rds(c,j-snl(c))
+
+             end if
+          end do
+       end do
+
+       ! Consistency check
+       if (is_lake) then
+          do j = -nlevsno + 1, 0
+             do fc = 1, num_snowc
+                c = filter_snowc(fc)
+
+                if (j >= snl(c)+1) then
+                   dztot(c) = dztot(c) - dz(c,j)
+                   snwicetot(c) = snwicetot(c) - h2osoi_ice(c,j)
+                   snwliqtot(c) = snwliqtot(c) - h2osoi_liq(c,j)
+                end if
+
+                if (j == 0) then
+                   if ( abs(dztot(c)) > 1.e-10_r8 .or. abs(snwicetot(c)) > 1.e-7_r8 .or. &
+                        abs(snwliqtot(c)) > 1.e-7_r8 ) then
+                      write(iulog,*)'Inconsistency in SnowDivision_Lake! c, remainders', &
+                           'dztot, snwicetot, snwliqtot = ',c,dztot(c),snwicetot(c),snwliqtot(c)
+                      call endrun(decomp_index=c, clmlevel=namec, msg=errmsg(__FILE__, __LINE__))
+                   end if
+                end if
+             end do
+          end do
+       end if
+
+       do j = 0, -nlevsno+1, -1
+          do fc = 1, num_snowc
+             c = filter_snowc(fc)
+             if (j >= snl(c)+1) then
+                z(c,j)    = zi(c,j) - 0.5_r8*dz(c,j)
+                zi(c,j-1) = zi(c,j) - dz(c,j)
+             end if
+          end do
+       end do
+
+     end associate
+
+   end subroutine DivideExtraSnowLayers   
+   
+   !-----------------------------------------------------------------------
    subroutine InitSnowLayers (bounds, snow_depth)
+    ! (from CLMv5)
     ! !DESCRIPTION:
     ! Initialize snow layer depth from specified total depth.
     !
@@ -2059,13 +2241,11 @@ contains
 
     end associate
    end subroutine InitSnowLayers
-   !ams++
    
-   !ams++ from CLM (clm4_5_12_r190)
    !-----------------------------------------------------------------------
    subroutine SnowCapping(bounds, num_nolakec, filter_initc, num_snowc, filter_snowc, &
         aerosol_vars, waterflux_vars, waterstate_vars )
-     !
+     ! from CLM (clm4_5_12_r190)
      ! !DESCRIPTION:
      ! Removes mass from bottom snow layer for columns that exceed the maximum snow depth.
      ! This routine is called twice: once for non-lake columns and once for lake columns. 
@@ -2180,10 +2360,9 @@ contains
      end associate
    end subroutine SnowCapping
    
-   !ams++ (subroutine from CESM2)
    !-----------------------------------------------------------------------
    subroutine NewSnowBulkDensity(bounds, num_c, filter_c, top_as_inst, bifall)
-      !
+      ! (subroutine from CLMv5)
       ! !DESCRIPTION:
       ! Compute the bulk density of any newly-fallen snow.
       !
@@ -2207,32 +2386,26 @@ contains
       character(len=*), parameter :: subname = 'NewSnowBulkDensity'
       !-----------------------------------------------------------------------
 
-      !SHR_ASSERT_ALL((ubound(bifall) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))   
-
       associate(forc_t    => top_as_inst%tbot   , & ! Input:  [real(r8) (:) ]  atmospheric temperature (Kelvin)
                 forc_wind => top_as_inst%windbot  & ! Input:  [real(r8) (:) ]  atmospheric wind speed (m/s)
                 )
 
       do fc = 1, num_c
          c = filter_c(fc)
-         !g = col_pp%gridcell(c)
          t = col_pp%topounit(c)
 
          if (forc_t(t) > tfrz + 2._r8) then
             bifall(c) = 50._r8 + 1.7_r8*(17.0_r8)**1.5_r8
          else if (forc_t(t) > tfrz - 15._r8) then
             bifall(c) = 50._r8 + 1.7_r8*(forc_t(t) - tfrz + 15._r8)**1.5_r8
-         !else if ( new_snow_density == LoTmpDnsTruncatedAnderson1976 ) then
-            !bifall(c) = 50._r8
-         !else if (new_snow_density == LoTmpDnsSlater2017) then 
-         else ! below comment from CESM2
+         else ! below comment from CLMv5
             ! Andrew Slater: A temp of about -15C gives the nicest
             ! "blower" powder, but as you get colder the flake size decreases so
             ! density goes up. e.g. the smaller snow crystals from the Arctic and Antarctic
             ! winters
             if (forc_t(t) > tfrz - 57.55_r8) then
                t_for_bifall_degC = (forc_t(t)-tfrz)
-            else ! below comment from CESM2
+            else ! below comment from CLMv5
                ! Below -57.55 deg C, the following function starts to decrease with
                ! decreasing temperatures. Limit the function to avoid this turning over.
                t_for_bifall_degC = -57.55_r8
@@ -2240,7 +2413,6 @@ contains
             bifall(c) = -(50._r8/15._r8 + 0.0333_r8*15_r8)*t_for_bifall_degC - 0.0333_r8*t_for_bifall_degC**2
          end if
 
-         !if (wind_dependent_snow_density .and. forc_wind(t) > 0.1_r8 ) then
          if (forc_wind(t) > 0.1_r8) then
             ! Density offset for wind-driven compaction, initial ideas based on Liston et. al (2007) J. Glaciology,
             ! 53(181), 241-255. Modified for a continuous wind impact and slightly more sensitive
@@ -2255,10 +2427,9 @@ contains
    end subroutine NewSnowBulkDensity
    
    !-----------------------------------------------------------------------
-   ! ++ams from CLMv5
    subroutine WindDriftCompaction(bi, forc_wind, dz, &
         zpseudo, mobile, compaction_rate)
-     !
+     ! from CLMv5
      ! !DESCRIPTION:
      !
      ! Compute wind drift compaction for a single column and level.
@@ -2376,9 +2547,8 @@ contains
    end subroutine Combo
    !-----------------------------------------------------------------------
    
-   !++ams (from CESM2)
    function MassWeightedSnowRadius( rds1, rds2, swtot, zwtot ) result(mass_weighted_snowradius)
-     !
+     ! (from CLMv5)
      ! !DESCRIPTION:
      ! Calculate the mass weighted snow radius when two layers are combined
      !
@@ -2393,7 +2563,6 @@ contains
      real(r8), intent(IN) :: zwtot        ! snow water total layer 1
      real(r8) :: mass_weighted_snowradius ! resulting bounded mass weighted snow radius
 
-     !SHR_ASSERT( (swtot+zwtot > 0.0_r8), errMsg(sourcefile, __LINE__))
      mass_weighted_snowradius = (rds2*swtot + rds1*zwtot)/(swtot+zwtot)
 
      if (      mass_weighted_snowradius > snw_rds_max ) then
@@ -2402,7 +2571,6 @@ contains
         mass_weighted_snowradius = snw_rds_min
      end if
    end function MassWeightedSnowRadius
-   !ams++
    !-----------------------------------------------------------------------
    
    subroutine BuildSnowFilter(bounds, num_nolakec, filter_nolakec, &

--- a/components/clm/src/biogeophys/SnowSnicarMod.F90
+++ b/components/clm/src/biogeophys/SnowSnicarMod.F90
@@ -316,6 +316,7 @@ contains
     integer :: j                                  ! aerosol number index [idx]
     integer :: n                                  ! tridiagonal matrix index [idx]
     integer :: m                                  ! secondary layer index [idx]
+    integer :: nint_snw_rds_min                   ! nearest integer value of snw_rds_min
    
     real(r8):: F_direct(-nlevsno+1:0)             ! direct-beam radiation at bottom of layer interface (lyr) [W/m^2]
     real(r8):: F_net(-nlevsno+1:0)                ! net radiative flux at bottom of layer interface (lyr) [W/m^2]
@@ -388,6 +389,7 @@ contains
 
       ! Define constants
       pi = SHR_CONST_PI
+      nint_snw_rds_min = nint(snw_rds_min)
 
       ! always use Delta approximation for snow
       DELTA = 1
@@ -430,7 +432,7 @@ contains
                   snl_lcl           =  -1
                   h2osno_ice_lcl(0) =  h2osno_lcl
                   h2osno_liq_lcl(0) =  0._r8
-                  snw_rds_lcl(0)    =  nint(snw_rds_min)
+                  snw_rds_lcl(0)    =  nint_snw_rds_min
                else
                   flg_nosnl         =  0
                   snl_lcl           =  snl(c_idx)

--- a/components/clm/src/biogeophys/SnowSnicarMod.F90
+++ b/components/clm/src/biogeophys/SnowSnicarMod.F90
@@ -11,7 +11,7 @@ module SnowSnicarMod
   use shr_kind_mod    , only : r8 => shr_kind_r8
   use shr_sys_mod     , only : shr_sys_flush
   use shr_log_mod     , only : errMsg => shr_log_errMsg
-  use clm_varctl      , only : iulog
+  use clm_varctl      , only : iulog, use_extrasnowlayers
   use clm_varcon      , only : namec 
   use shr_const_mod   , only : SHR_CONST_RHOICE
   use abortutils      , only : endrun
@@ -1353,7 +1353,7 @@ contains
             !               RE-FREEZING
             !
             ! new snowfall [kg/m2]
-            if (do_capsnow(c_idx)) then
+            if (do_capsnow(c_idx) .and. .not. use_extrasnowlayers) then
                newsnow = max(0._r8, (qflx_snwcp_ice(c_idx)*dtime))
             else
                newsnow = max(0._r8, (qflx_snow_grnd_col(c_idx)*dtime))

--- a/components/clm/src/biogeophys/SoilFluxesMod.F90
+++ b/components/clm/src/biogeophys/SoilFluxesMod.F90
@@ -10,7 +10,7 @@ module SoilFluxesMod
   use decompMod		, only : bounds_type
   use abortutils	, only : endrun
   use perf_mod		, only : t_startf, t_stopf
-  use clm_varctl	, only : iulog
+  use clm_varctl	, only : iulog, use_extrasnowlayers
   use clm_varpar	, only : nlevsno, nlevgrnd, nlevurb, max_patch_per_col
   use atm2lndType	, only : atm2lnd_type
   use CanopyStateType   , only : canopystate_type
@@ -350,7 +350,7 @@ contains
          ! This was moved in from Hydrology2 to keep all pft-level
          ! calculations out of Hydrology2
 
-         if (col_pp%snl(c) < 0 .and. do_capsnow(c)) then
+         if (col_pp%snl(c) < 0 .and. do_capsnow(c) .and. .not. use_extrasnowlayers) then
             qflx_snwcp_liq(p) = qflx_snwcp_liq(p)+frac_sno_eff(c)*qflx_dew_grnd(p)
             qflx_snwcp_ice(p) = qflx_snwcp_ice(p)+frac_sno_eff(c)*qflx_dew_snow(p)
          end if

--- a/components/clm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/clm/src/biogeophys/SoilTemperatureMod.F90
@@ -3384,8 +3384,8 @@ end subroutine SolveTemperature
        c = filter(fc)
 
        ! Snow
-       bmatrix(c,2:3,-5   ) = bmatrix_snow(c,2:3,-5   )
-       bmatrix(c,2:4,-4:-2) = bmatrix_snow(c,2:4,-4:-2)
+	   bmatrix(c,2:3,-nlevsno) = bmatrix_snow(c,2:3,-nlevsno)
+       bmatrix(c,2:4,-nlevsno+1:-2) = bmatrix_snow(c,2:4,-nlevsno+1:-2)
        bmatrix(c,3:4,-1   ) = bmatrix_snow(c,3:4,-1   )
 
        ! Snow-Soil

--- a/components/clm/src/biogeophys/SurfaceRadiationMod.F90
+++ b/components/clm/src/biogeophys/SurfaceRadiationMod.F90
@@ -629,10 +629,10 @@ contains
              ! change condition to match sabg_snow isntead of sabg
              if (abs(sabg_snl_sum-sabg_snow(p)) > 0.00001_r8) then
                 if (snl(c) == 0) then
-                   sabg_lyr(p,-4:0) = 0._r8
+                   sabg_lyr(p,-nlevsno+1:0) = 0._r8
                    sabg_lyr(p,1) = sabg(p)
                 elseif (snl(c) == -1) then
-                   sabg_lyr(p,-4:-1) = 0._r8
+                   sabg_lyr(p,-nlevsno+1:-1) = 0._r8
                    sabg_lyr(p,0) = sabg_snow(p)*0.6_r8
                    sabg_lyr(p,1) = sabg_snow(p)*0.4_r8
                 else
@@ -647,10 +647,10 @@ contains
              if (subgridflag == 0 .or. lun_pp%itype(l) == istdlak) then 
                 if (snow_depth(c) < 0.10_r8) then
                    if (snl(c) == 0) then
-                      sabg_lyr(p,-4:0) = 0._r8
+                      sabg_lyr(p,-nlevsno+1:0) = 0._r8
                       sabg_lyr(p,1) = sabg(p)
                    elseif (snl(c) == -1) then
-                      sabg_lyr(p,-4:-1) = 0._r8
+                      sabg_lyr(p,-nlevsno+1:-1) = 0._r8
                       sabg_lyr(p,0) = sabg(p)
                       sabg_lyr(p,1) = 0._r8
                    else

--- a/components/clm/src/data_types/ColumnDataType.F90
+++ b/components/clm/src/data_types/ColumnDataType.F90
@@ -1346,11 +1346,21 @@ contains
     call hist_addfld2d (fname='SOILLIQ',  units='kg/m2', type2d='levgrnd', &
          avgflag='A', long_name='soil liquid water (vegetated landunits only)', &
          ptr_col=this%h2osoi_liq, l2g_scale_type='veg')
+         
+    this%h2osoi_liq(begc:endc,:) = spval
+    call hist_addfld2d (fname='SOILLIQ_ICE',  units='kg/m2', type2d='levgrnd', &
+         avgflag='A', long_name='soil liquid water (ice landunits only)', &
+         ptr_col=this%h2osoi_liq, l2g_scale_type='ice')
 
     this%h2osoi_ice(begc:endc,:) = spval
     call hist_addfld2d (fname='SOILICE',  units='kg/m2', type2d='levgrnd', &
          avgflag='A', long_name='soil ice (vegetated landunits only)', &
          ptr_col=this%h2osoi_ice, l2g_scale_type='veg')
+         
+    this%h2osoi_ice(begc:endc,:) = spval
+        call hist_addfld2d (fname='SOILICE_ICE',  units='kg/m2', type2d='levgrnd', &
+        avgflag='A', long_name='soil ice (ice landunits only)', &
+        ptr_col=this%h2osoi_ice, l2g_scale_type='ice')
 
     this%h2osfc(begc:endc) = spval
     call hist_addfld1d (fname='H2OSFC',  units='mm',  &

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -1559,7 +1559,7 @@ contains
             else
                do_capsnow(c) = .false.
             end if
-         !++ams !else ! snow capping subroutine in SnowHydrologyMod
+         ! else, snow capping subroutine in SnowHydrologyMod
          end if
 
          ! Reset flux from beneath soil/ice column 

--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -11,7 +11,7 @@ module clm_driver
   use shr_kind_mod           , only : r8 => shr_kind_r8
   use shr_sys_mod            , only : shr_sys_flush
   use shr_log_mod            , only : errMsg => shr_log_errMsg
-  use clm_varctl             , only : wrtdia, iulog, create_glacier_mec_landunit, use_fates
+  use clm_varctl             , only : wrtdia, iulog, create_glacier_mec_landunit, use_fates, use_extrasnowlayers
   use clm_varpar             , only : nlevtrc_soil, nlevsoi
   use clm_varctl             , only : wrtdia, iulog, create_glacier_mec_landunit, use_fates, use_betr  
   use clm_varctl             , only : use_cn, use_lch4, use_voc, use_noio, use_c13, use_c14
@@ -1552,11 +1552,14 @@ contains
          ! Save snow mass at previous time step
          h2osno_old(c) = h2osno(c)
 
-         ! Decide whether to cap snow
-         if (h2osno(c) > h2osno_max) then
-            do_capsnow(c) = .true.
-         else
-            do_capsnow(c) = .false.
+         if (.not. use_extrasnowlayers) then
+            ! Decide whether to cap snow
+            if (h2osno(c) > h2osno_max) then
+               do_capsnow(c) = .true.
+            else
+               do_capsnow(c) = .false.
+            end if
+         !++ams !else ! snow capping subroutine in SnowHydrologyMod
          end if
 
          ! Reset flux from beneath soil/ice column 
@@ -1680,23 +1683,25 @@ contains
          veg_wf%qflx_snow_grnd(bounds%begp:bounds%endp), &
          col_wf%qflx_snow_grnd(bounds%begc:bounds%endc))
     
-    call p2c (bounds, num_allc, filter_allc, &
-         veg_wf%qflx_snwcp_liq(bounds%begp:bounds%endp), &
-         col_wf%qflx_snwcp_liq(bounds%begc:bounds%endc))
-    !TODO - WJS has suggested that at this point qflx_snwcp_liq_patch should
-    ! now be set to nan in order to ensure that this variable is not used
-    ! for the remainder of the timestep - other variables where this should
-    ! occur in this routine should be examined as well
+    if (.not. use_extrasnowlayers) then
+       call p2c (bounds, num_allc, filter_allc, &
+            veg_wf%qflx_snwcp_liq(bounds%begp:bounds%endp), &
+            col_wf%qflx_snwcp_liq(bounds%begc:bounds%endc))
+            !TODO - WJS has suggested that at this point qflx_snwcp_liq_patch should
+            ! now be set to nan in order to ensure that this variable is not used
+            ! for the remainder of the timestep - other variables where this should
+            ! occur in this routine should be examined as well
 
-    ! For lakes, this field is initially set in LakeFluxesMod (which
-    ! is called before this routine; hence it is appropriate to
-    ! include lake columns in this p2c call.  However, it is later
-    ! overwritten in LakeHydrologyMod, both on the patch and the column
-    ! level.
+            ! For lakes, this field is initially set in LakeFluxesMod (which
+            ! is called before this routine; hence it is appropriate to
+            ! include lake columns in this p2c call.  However, it is later
+            ! overwritten in LakeHydrologyMod, both on the patch and the column
+            ! level.
 
-    call p2c (bounds, num_allc, filter_allc, &
-         veg_wf%qflx_snwcp_ice(bounds%begp:bounds%endp), &
-         col_wf%qflx_snwcp_ice(bounds%begc:bounds%endc))
+       call p2c (bounds, num_allc, filter_allc, &
+            veg_wf%qflx_snwcp_ice(bounds%begp:bounds%endp), &
+            col_wf%qflx_snwcp_ice(bounds%begc:bounds%endc))
+    end if
 
     call p2c (bounds, num_nolakec, filter_nolakec, &
          veg_wf%qflx_tran_veg(bounds%begp:bounds%endp), &

--- a/components/clm/src/main/clm_instMod.F90
+++ b/components/clm/src/main/clm_instMod.F90
@@ -291,7 +291,6 @@ contains
        l = col_pp%landunit(c)
        g = col_pp%gridcell(c)
 
-       !++ams
        if (.not. use_extrasnowlayers) then ! original 5 layer shallow snowpack model
            if (lun_pp%itype(l)==istice) then
                h2osno_col(c) = h2osno_max
@@ -306,7 +305,7 @@ contains
            endif
        else ! With a deeper firn model, we can no longer depend on "h2osno_max," because this will
            !  potentially be large, resulting in a lot of artificial firn at initialization.
-           ! However... (below docstring from CESM2.0)
+           ! However... (below docstring from CLMv5)
            ! In areas that should be snow-covered, it can be problematic to start with 0 snow
            ! cover, because this can affect the long-term state through soil heating, albedo
            ! feedback, etc. On the other hand, we would introduce hysteresis by putting too
@@ -324,7 +323,6 @@ contains
               h2osno_col(c) = 0._r8
            endif
        endif
-       !ams++
        snow_depth_col(c)  = h2osno_col(c) / bdsno
     end do
 

--- a/components/clm/src/main/clm_instMod.F90
+++ b/components/clm/src/main/clm_instMod.F90
@@ -53,6 +53,7 @@ module clm_instMod
   use GridcellDataType           , only : grc_cf, c13_grc_cf, c14_grc_cf
   use GridcellDataType           , only : grc_ns, grc_nf
   use GridcellDataType           , only : grc_ps, grc_pf
+  use GridcellType               , only : grc_pp
   use LandunitType               , only : lun_pp
   use LandunitDataType           , only : lun_es, lun_ef, lun_ws
   use ColumnType                 , only : col_pp
@@ -249,7 +250,7 @@ contains
     use clm_varcon                        , only : h2osno_max, bdsno
     use domainMod                         , only : ldomain
     use clm_varpar                        , only : nlevsno, numpft
-    use clm_varctl                        , only : single_column, fsurdat, scmlat, scmlon
+    use clm_varctl                        , only : single_column, fsurdat, scmlat, scmlon, use_extrasnowlayers
     use controlMod                        , only : nlfilename
     use SoilWaterRetentionCurveFactoryMod , only : create_soil_water_retention_curve
     use fileutils                         , only : getfil
@@ -290,17 +291,40 @@ contains
        l = col_pp%landunit(c)
        g = col_pp%gridcell(c)
 
-       if (lun_pp%itype(l)==istice) then
-          h2osno_col(c) = h2osno_max
-       elseif (lun_pp%itype(l)==istice_mec .or. &
-              (lun_pp%itype(l)==istsoil .and. ldomain%glcmask(g) > 0._r8)) then
-          ! Initialize a non-zero snow thickness where the ice sheet can/potentially operate.
-          ! Using glcmask to capture all potential vegetated points around GrIS (ideally
-          ! we would use icemask from CISM, but that isn't available until after initialization.)
-          h2osno_col(c) = 1.0_r8 * h2osno_max   ! start with full snow column so +SMB can begin immediately
-       else
-          h2osno_col(c) = 0._r8
+       !++ams
+       if (.not. use_extrasnowlayers) then ! original 5 layer shallow snowpack model
+           if (lun_pp%itype(l)==istice) then
+               h2osno_col(c) = h2osno_max
+           elseif (lun_pp%itype(l)==istice_mec .or. &
+               (lun_pp%itype(l)==istsoil .and. ldomain%glcmask(g) > 0._r8)) then
+               ! Initialize a non-zero snow thickness where the ice sheet can/potentially operate.
+               ! Using glcmask to capture all potential vegetated points around GrIS (ideally
+               ! we would use icemask from CISM, but that isn't available until after initialization.)
+               h2osno_col(c) = 1.0_r8 * h2osno_max   ! start with full snow column so +SMB can begin immediately
+           else
+              h2osno_col(c) = 0._r8
+           endif
+       else ! With a deeper firn model, we can no longer depend on "h2osno_max," because this will
+           !  potentially be large, resulting in a lot of artificial firn at initialization.
+           ! However... (below docstring from CESM2.0)
+           ! In areas that should be snow-covered, it can be problematic to start with 0 snow
+           ! cover, because this can affect the long-term state through soil heating, albedo
+           ! feedback, etc. On the other hand, we would introduce hysteresis by putting too
+           ! much snow in places that are in a net melt regime, because the melt-albedo
+           ! feedback may not activate on time (or at all). So, as a compromise, we start with
+           ! a small amount of snow in places that are likely to be snow-covered for much or
+           ! all of the year.
+           if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec) then
+              ! land ice (including multiple elevation classes, i.e. glacier_mec) 
+              h2osno_col(c) = 50._r8
+           else if (lun_pp%itype(l)==istsoil .and. grc_pp%latdeg(g) >= 44._r8) then
+              ! Northern hemisphere seasonal snow
+              h2osno_col(c) = 50._r8
+           else
+              h2osno_col(c) = 0._r8
+           endif
        endif
+       !ams++
        snow_depth_col(c)  = h2osno_col(c) / bdsno
     end do
 

--- a/components/clm/src/main/clm_varcon.F90
+++ b/components/clm/src/main/clm_varcon.F90
@@ -131,7 +131,7 @@ module clm_varcon
   real(r8) :: ac_wasteheat_factor = 0.0_r8  !wasteheat factor for urban air conditioning (-)
   real(r8) :: wasteheat_limit = 100._r8  !limit on wasteheat (W/m2)
 
-  real(r8), parameter :: h2osno_max = 1000._r8    ! max allowed snow thickness (mm H2O)
+  real(r8) :: h2osno_max = 1000._r8      ! max allowed snow thickness (mm H2O)
   real(r8), parameter :: lapse_glcmec = 0.006_r8  ! surface temperature lapse rate (deg m-1)
                                                   ! Pritchard et al. (GRL, 35, 2008) use 0.006  
   real(r8), parameter :: glcmec_rain_snow_threshold = SHR_CONST_TKFRZ  ! temperature dividing rain & snow in downscaling (K)
@@ -233,6 +233,7 @@ contains
     !
     ! USES
     use clm_varpar, only: nlevgrnd, nlevlak, nlevdecomp_full, nlevsoifl, nlayer
+    use clm_varctl, only: use_extrasnowlayers
     !------------------------------------------------------------------------------
 
     allocate( zlak(1:nlevlak                 ))
@@ -246,6 +247,10 @@ contains
     allocate( zsoifl(1:nlevsoifl             ))
     allocate( zisoifl(0:nlevsoifl            ))
     allocate( dzsoifl(1:nlevsoifl            ))
+
+    if (use_extrasnowlayers) then
+       h2osno_max = 10000._r8
+    end if
 
   end subroutine clm_varcon_init
 

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -337,6 +337,7 @@ module clm_varctl
   logical, public :: use_crop            = .false.
   logical, public :: use_snicar_frc      = .false.
   logical, public :: use_snicar_ad       = .false.
+  logical, public :: use_extrasnowlayers = .false.
   logical, public :: use_vancouver       = .false.
   logical, public :: use_mexicocity      = .false.
   logical, public :: use_noio            = .false.

--- a/components/clm/src/main/clm_varpar.F90
+++ b/components/clm/src/main/clm_varpar.F90
@@ -33,7 +33,7 @@ module clm_varpar
   integer            :: nlevtrc_soil
   integer            :: nlevtrc_full
   
-  integer, parameter :: nlevsno     =   5     ! maximum number of snow layers
+  integer, parameter :: nlevsno     =   5   ! maximum number of snow layers
   integer, parameter :: ngases      =   3     ! CH4, O2, & CO2
   integer, parameter :: nlevcan     =   1     ! number of leaf layers in canopy layer
   integer, parameter :: nvegwcs     =   4     ! number of vegetation water conductance segments
@@ -175,6 +175,12 @@ contains
     else
        nlevlak     =  25     ! number of lake layers (Yields better results for site simulations)
     end if
+
+    !if (.not. use_extrasnowlayers) then
+    !   nlevsno     =  5     ! maximum number of snow layers
+    !else
+    !   nlevsno     =  16    ! maximum number of snow layers (for firn model)
+    !end if
 
     if ( use_fates ) then
        i_cwd = 0

--- a/components/clm/src/main/clm_varpar.F90
+++ b/components/clm/src/main/clm_varpar.F90
@@ -176,12 +176,6 @@ contains
        nlevlak     =  25     ! number of lake layers (Yields better results for site simulations)
     end if
 
-    !if (.not. use_extrasnowlayers) then
-    !   nlevsno     =  5     ! maximum number of snow layers
-    !else
-    !   nlevsno     =  16    ! maximum number of snow layers (for firn model)
-    !end if
-
     if ( use_fates ) then
        i_cwd = 0
        i_met_lit = 1
@@ -215,8 +209,6 @@ contains
 
     endif
     
-
-
   end subroutine clm_varpar_init
 
 end module clm_varpar

--- a/components/clm/src/main/clm_varpar.F90
+++ b/components/clm/src/main/clm_varpar.F90
@@ -10,6 +10,7 @@ module clm_varpar
   use clm_varctl   , only: use_century_decomp, use_c13, use_c14, use_fates
   use clm_varctl   , only: iulog, create_crop_landunit, irrigate
   use clm_varctl   , only: use_vichydro
+  use clm_varctl   , only: use_extrasnowlayers
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -33,7 +34,7 @@ module clm_varpar
   integer            :: nlevtrc_soil
   integer            :: nlevtrc_full
   
-  integer, parameter :: nlevsno     =   5   ! maximum number of snow layers
+  integer            :: nlevsno               ! maximum number of snow layers
   integer, parameter :: ngases      =   3     ! CH4, O2, & CO2
   integer, parameter :: nlevcan     =   1     ! number of leaf layers in canopy layer
   integer, parameter :: nvegwcs     =   4     ! number of vegetation water conductance segments
@@ -154,6 +155,12 @@ contains
     if (use_vichydro) then
        nlayert     =  nlayer + (nlevgrnd -nlevsoi)
     endif
+
+    if (.not. use_extrasnowlayers) then
+       nlevsno     =  5     ! maximum number of snow layers
+    else
+       nlevsno     =  16    ! maximum number of snow layers (for firn model)
+    end if
 
     ! here is a switch to set the number of soil levels for the biogeochemistry calculations.
     ! currently it works on either a single level or on nlevsoi and nlevgrnd levels

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -608,6 +608,7 @@ contains
     call mpi_bcast (use_nitrif_denitrif, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_vertsoilc, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_extralakelayers, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (use_extrasnowlayers, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_vichydro, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_century_decomp, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_cn, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -864,6 +865,7 @@ contains
     write(iulog,*) '    use_vertsoilc = ', use_vertsoilc
     write(iulog,*) '    use_var_soil_thick = ', use_var_soil_thick
     write(iulog,*) '    use_extralakelayers = ', use_extralakelayers
+    write(iulog,*) '    use_extrasnowlayers = ', use_extrasnowlayers
     write(iulog,*) '    use_vichydro = ', use_vichydro
     write(iulog,*) '    use_century_decomp = ', use_century_decomp
     write(iulog,*) '    use_cn = ', use_cn

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -264,7 +264,7 @@ contains
     namelist /clm_inparm/ &
          use_nofire, use_lch4, use_nitrif_denitrif, use_vertsoilc, use_extralakelayers, &
          use_vichydro, use_century_decomp, use_cn, use_crop, use_snicar_frc, &
-         use_snicar_ad, use_vancouver, use_mexicocity, use_noio
+         use_snicar_ad, use_extrasnowlayers, use_vancouver, use_mexicocity, use_noio
 
     ! cpl_bypass variables
     namelist /clm_inparm/ metdata_type, metdata_bypass, metdata_biases, &

--- a/components/clm/src/main/histFileMod.F90
+++ b/components/clm/src/main/histFileMod.F90
@@ -12,7 +12,7 @@ module histFileMod
   use shr_sys_mod    , only : shr_sys_flush
   use spmdMod        , only : masterproc
   use abortutils     , only : endrun
-  use clm_varctl     , only : iulog, use_vertsoilc, use_fates
+  use clm_varctl     , only : iulog, use_vertsoilc, use_fates, use_extrasnowlayers
   use clm_varcon     , only : spval, ispval, dzsoi_decomp 
   use clm_varcon     , only : grlnd, nameg, namet, namel, namec, namep
   use decompMod      , only : get_proc_bounds, get_proc_global, bounds_type
@@ -1627,13 +1627,21 @@ contains
        ! Fill output field appropriately for each layer
        ! When only a subset of snow layers exist, it is the LAST num_snow_layers that exist
 
-       do level = 1, num_nonexistent_layers
-          field_out(point, level) = no_snow_val
-       end do
-       do level = (num_nonexistent_layers + 1), num_levels
-          field_out(point, level) = field_in(point, level)
-       end do
-          
+       if (.not. use_extrasnowlayers) then
+          do level = 1, num_nonexistent_layers
+             field_out(point, level) = no_snow_val
+          end do
+          do level = (num_nonexistent_layers + 1), num_levels
+             field_out(point, level) = field_in(point, level)
+          end do
+       else ! Levels are rearranged such that the top snow layer (surface layer) becomes level 1, etc.
+          do level = num_levels, (num_levels-num_nonexistent_layers+1), -1
+             field_out(point, level) = no_snow_val
+          end do
+          do level = (num_levels-num_nonexistent_layers), 1, -1
+             field_out(point, level) = field_in(point, level+num_nonexistent_layers)
+          end do
+       end if
     end do
 
     end associate

--- a/components/clm/src/main/initVerticalMod.F90
+++ b/components/clm/src/main/initVerticalMod.F90
@@ -16,7 +16,7 @@ module initVerticalMod
   use clm_varpar     , only : toplev_equalspace, nlev_equalspace
   use clm_varpar     , only : nlevsoi, nlevsoifl, nlevurb, nlevslp 
   use clm_varctl     , only : fsurdat, iulog, use_var_soil_thick
-  use clm_varctl     , only : use_vancouver, use_mexicocity, use_vertsoilc, use_extralakelayers
+  use clm_varctl     , only : use_vancouver, use_mexicocity, use_vertsoilc, use_extralakelayers, use_extrasnowlayers
   use clm_varctl     , only : use_erosion
   use clm_varcon     , only : zlak, dzlak, zsoi, dzsoi, zisoi, dzsoi_decomp, spval, grlnd 
   use column_varcon  , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
@@ -24,6 +24,7 @@ module initVerticalMod
   use fileutils      , only : getfil
   use LandunitType   , only : lun_pp                
   use ColumnType     , only : col_pp                
+  use SnowHydrologyMod, only : InitSnowLayers
   use ncdio_pio
   !
   ! !PUBLIC TYPES:
@@ -468,82 +469,91 @@ contains
     ! Set cold-start values for snow levels, snow layers and snow interfaces 
     !-----------------------------------------------
 
-    associate(snl => col_pp%snl) ! Output: [integer (:)    ]  number of snow layers   
+    if (.not. use_extrasnowlayers) then
+    
+        associate(snl => col_pp%snl) ! Output: [integer (:)    ]  number of snow layers   
 
-      do c = bounds%begc,bounds%endc
-         l = col_pp%landunit(c)
+          do c = bounds%begc,bounds%endc
+             l = col_pp%landunit(c)
 
-         col_pp%dz(c,-nlevsno+1: 0) = spval
-         col_pp%z (c,-nlevsno+1: 0) = spval
-         col_pp%zi(c,-nlevsno  :-1) = spval
+             col_pp%dz(c,-nlevsno+1: 0) = spval
+             col_pp%z (c,-nlevsno+1: 0) = spval
+             col_pp%zi(c,-nlevsno  :-1) = spval
 
-         if (.not. lun_pp%lakpoi(l)) then
-            if (snow_depth(c) < 0.01_r8) then
-               snl(c)             = 0
-               col_pp%dz(c,-nlevsno+1:0) = 0._r8
-               col_pp%z (c,-nlevsno+1:0) = 0._r8
-               col_pp%zi(c,-nlevsno+0:0) = 0._r8
-            else
-               if ((snow_depth(c) >= 0.01_r8) .and. (snow_depth(c) <= 0.03_r8)) then
-                  snl(c)  = -1
-                  col_pp%dz(c,0) = snow_depth(c)
-               else if ((snow_depth(c) > 0.03_r8) .and. (snow_depth(c) <= 0.04_r8)) then
-                  snl(c)   = -2
-                  col_pp%dz(c,-1) = snow_depth(c)/2._r8
-                  col_pp%dz(c, 0) = col_pp%dz(c,-1)
-               else if ((snow_depth(c) > 0.04_r8) .and. (snow_depth(c) <= 0.07_r8)) then
-                  snl(c)   = -2
-                  col_pp%dz(c,-1) = 0.02_r8
-                  col_pp%dz(c, 0) = snow_depth(c) - col_pp%dz(c,-1)
-               else if ((snow_depth(c) > 0.07_r8) .and. (snow_depth(c) <= 0.12_r8)) then
-                  snl(c)   = -3
-                  col_pp%dz(c,-2) = 0.02_r8
-                  col_pp%dz(c,-1) = (snow_depth(c) - 0.02_r8)/2._r8
-                  col_pp%dz(c, 0) = col_pp%dz(c,-1)
-               else if ((snow_depth(c) > 0.12_r8) .and. (snow_depth(c) <= 0.18_r8)) then
-                  snl(c)   = -3
-                  col_pp%dz(c,-2) = 0.02_r8
-                  col_pp%dz(c,-1) = 0.05_r8
-                  col_pp%dz(c, 0) = snow_depth(c) - col_pp%dz(c,-2) - col_pp%dz(c,-1)
-               else if ((snow_depth(c) > 0.18_r8) .and. (snow_depth(c) <= 0.29_r8)) then
-                  snl(c)   = -4
-                  col_pp%dz(c,-3) = 0.02_r8
-                  col_pp%dz(c,-2) = 0.05_r8
-                  col_pp%dz(c,-1) = (snow_depth(c) - col_pp%dz(c,-3) - col_pp%dz(c,-2))/2._r8
-                  col_pp%dz(c, 0) = col_pp%dz(c,-1)
-               else if ((snow_depth(c) > 0.29_r8) .and. (snow_depth(c) <= 0.41_r8)) then
-                  snl(c)   = -4
-                  col_pp%dz(c,-3) = 0.02_r8
-                  col_pp%dz(c,-2) = 0.05_r8
-                  col_pp%dz(c,-1) = 0.11_r8
-                  col_pp%dz(c, 0) = snow_depth(c) - col_pp%dz(c,-3) - col_pp%dz(c,-2) - col_pp%dz(c,-1)
-               else if ((snow_depth(c) > 0.41_r8) .and. (snow_depth(c) <= 0.64_r8)) then
-                  snl(c)   = -5
-                  col_pp%dz(c,-4) = 0.02_r8
-                  col_pp%dz(c,-3) = 0.05_r8
-                  col_pp%dz(c,-2) = 0.11_r8
-                  col_pp%dz(c,-1) = (snow_depth(c) - col_pp%dz(c,-4) - col_pp%dz(c,-3) - col_pp%dz(c,-2))/2._r8
-                  col_pp%dz(c, 0) = col_pp%dz(c,-1)
-               else if (snow_depth(c) > 0.64_r8) then
-                  snl(c)   = -5
-                  col_pp%dz(c,-4) = 0.02_r8
-                  col_pp%dz(c,-3) = 0.05_r8
-                  col_pp%dz(c,-2) = 0.11_r8
-                  col_pp%dz(c,-1) = 0.23_r8
-                  col_pp%dz(c, 0) = snow_depth(c)-col_pp%dz(c,-4)-col_pp%dz(c,-3)-col_pp%dz(c,-2)-col_pp%dz(c,-1)
-               endif
-            end if
-            do j = 0, snl(c)+1, -1
-               col_pp%z(c,j)    = col_pp%zi(c,j) - 0.5_r8*col_pp%dz(c,j)
-               col_pp%zi(c,j-1) = col_pp%zi(c,j) - col_pp%dz(c,j)
-            end do
-         else !lake
-            snl(c)             = 0
-            col_pp%dz(c,-nlevsno+1:0) = 0._r8
-            col_pp%z (c,-nlevsno+1:0) = 0._r8
-            col_pp%zi(c,-nlevsno+0:0) = 0._r8
-         end if
-      end do
+             if (.not. lun_pp%lakpoi(l)) then
+                if (snow_depth(c) < 0.01_r8) then
+                   snl(c)             = 0
+                   col_pp%dz(c,-nlevsno+1:0) = 0._r8
+                   col_pp%z (c,-nlevsno+1:0) = 0._r8
+                   col_pp%zi(c,-nlevsno+0:0) = 0._r8
+                else
+                   if ((snow_depth(c) >= 0.01_r8) .and. (snow_depth(c) <= 0.03_r8)) then
+                      snl(c)  = -1
+                      col_pp%dz(c,0) = snow_depth(c)
+                   else if ((snow_depth(c) > 0.03_r8) .and. (snow_depth(c) <= 0.04_r8)) then
+                      snl(c)   = -2
+                      col_pp%dz(c,-1) = snow_depth(c)/2._r8
+                      col_pp%dz(c, 0) = col_pp%dz(c,-1)
+                   else if ((snow_depth(c) > 0.04_r8) .and. (snow_depth(c) <= 0.07_r8)) then
+                      snl(c)   = -2
+                      col_pp%dz(c,-1) = 0.02_r8
+                      col_pp%dz(c, 0) = snow_depth(c) - col_pp%dz(c,-1)
+                   else if ((snow_depth(c) > 0.07_r8) .and. (snow_depth(c) <= 0.12_r8)) then
+                      snl(c)   = -3
+                      col_pp%dz(c,-2) = 0.02_r8
+                      col_pp%dz(c,-1) = (snow_depth(c) - 0.02_r8)/2._r8
+                      col_pp%dz(c, 0) = col_pp%dz(c,-1)
+                   else if ((snow_depth(c) > 0.12_r8) .and. (snow_depth(c) <= 0.18_r8)) then
+                      snl(c)   = -3
+                      col_pp%dz(c,-2) = 0.02_r8
+                      col_pp%dz(c,-1) = 0.05_r8
+                      col_pp%dz(c, 0) = snow_depth(c) - col_pp%dz(c,-2) - col_pp%dz(c,-1)
+                   else if ((snow_depth(c) > 0.18_r8) .and. (snow_depth(c) <= 0.29_r8)) then
+                      snl(c)   = -4
+                      col_pp%dz(c,-3) = 0.02_r8
+                      col_pp%dz(c,-2) = 0.05_r8
+                      col_pp%dz(c,-1) = (snow_depth(c) - col_pp%dz(c,-3) - col_pp%dz(c,-2))/2._r8
+                      col_pp%dz(c, 0) = col_pp%dz(c,-1)
+                   else if ((snow_depth(c) > 0.29_r8) .and. (snow_depth(c) <= 0.41_r8)) then
+                      snl(c)   = -4
+                      col_pp%dz(c,-3) = 0.02_r8
+                      col_pp%dz(c,-2) = 0.05_r8
+                      col_pp%dz(c,-1) = 0.11_r8
+                      col_pp%dz(c, 0) = snow_depth(c) - col_pp%dz(c,-3) - col_pp%dz(c,-2) - col_pp%dz(c,-1)
+                   else if ((snow_depth(c) > 0.41_r8) .and. (snow_depth(c) <= 0.64_r8)) then
+                      snl(c)   = -5
+                      col_pp%dz(c,-4) = 0.02_r8
+                      col_pp%dz(c,-3) = 0.05_r8
+                      col_pp%dz(c,-2) = 0.11_r8
+                      col_pp%dz(c,-1) = (snow_depth(c) - col_pp%dz(c,-4) - col_pp%dz(c,-3) - col_pp%dz(c,-2))/2._r8
+                      col_pp%dz(c, 0) = col_pp%dz(c,-1)
+                   else if (snow_depth(c) > 0.64_r8) then
+                      snl(c)   = -5
+                      col_pp%dz(c,-4) = 0.02_r8
+                      col_pp%dz(c,-3) = 0.05_r8
+                      col_pp%dz(c,-2) = 0.11_r8
+                      col_pp%dz(c,-1) = 0.23_r8
+                      col_pp%dz(c, 0) = snow_depth(c)-col_pp%dz(c,-4)-col_pp%dz(c,-3)-col_pp%dz(c,-2)-col_pp%dz(c,-1)
+                   endif
+                end if
+                do j = 0, snl(c)+1, -1
+                   col_pp%z(c,j)    = col_pp%zi(c,j) - 0.5_r8*col_pp%dz(c,j)
+                   col_pp%zi(c,j-1) = col_pp%zi(c,j) - col_pp%dz(c,j)
+                end do
+             else !lake
+                snl(c)             = 0
+                col_pp%dz(c,-nlevsno+1:0) = 0._r8
+                col_pp%z (c,-nlevsno+1:0) = 0._r8
+                col_pp%zi(c,-nlevsno+0:0) = 0._r8
+             end if
+          end do
+      
+        end associate
+          
+      else ! use extra (16) snow layers, for firn model
+          call InitSnowLayers(bounds, snow_depth(bounds%begc:bounds%endc))
+      
+      end if
 
       !-----------------------------------------------
       ! Read in topographic index and slope
@@ -670,8 +680,6 @@ contains
          slope0 = slopemax**(-1._r8/slopebeta)
          col_pp%micro_sigma(c) = (col_pp%topo_slope(c) + slope0)**(-slopebeta)
       end do
-
-    end associate
 
     call ncd_pio_closefile(ncid)
 


### PR DESCRIPTION
Several developments necessary to add a switch that will toggle on an expanded snowpack model valid for use on ice sheets.  This switch, called "use_extrasnowlayers," will also toggle on a new snowcapping routine (adapted from CLMv5) that removes snow from the bottom of the column, rather than diverting fresh new snow to an export term, and brings in improvements to the snowpack (and firn) densification scheme.  The switch is set to false by default, as this PR is designed to maintain BFB reproducibility unless a user sets the switch to true.  The switch, even when true, does not currently change the maximum number of snow layers (equal to 5) nor the maximum snowpack mass (equal to 1 m SWE).  This PR provides the control logic and software necessary to use up to 16 total snow layers, but the user will still have to increase these values (nlevsno and h2osnomax) in the clm_varpar.F90 and clm_varcon.F90 files (before, there was no way to increase the number of snow layers above 5).  Results from these developments, including simulated firn density profiles, are being submitted for publication in Geoscientific Model Development.

[BFB]