### PR TITLE
Make coupling_period calculation dependent on NCPL_BASE_PERIOD

### DIFF
--- a/components/mosart/bld/build-namelist
+++ b/components/mosart/bld/build-namelist
@@ -283,6 +283,7 @@ my $MOSART_FLOOD_MODE  = $xmlvars{'MOSART_FLOOD_MODE'};
 my $ROF_GRID        = $xmlvars{'ROF_GRID'};
 my $LND_GRID        = $xmlvars{'LND_GRID'};
 my $ROF_NCPL        = $xmlvars{'ROF_NCPL'};
+my $NCPL_BASE_PERIOD = $xmlvars{'NCPL_BASE_PERIOD'};
 
 (-d $DIN_LOC_ROOT)  or  mkdir $DIN_LOC_ROOT;
 if ($print>=2) { 
@@ -323,7 +324,16 @@ else {
     add_default($nl, 'DLevelH2R');
     add_default($nl, 'DLevelR');
 #    add_default($nl, 'finidat_rtm' , 'rof_grid'=>$ROF_GRID, 'simyr'=>$opts{'simyr'}, 'nofail'=>1 );
-    my $val = ( 3600 * 24 ) / $ROF_NCPL;
+    my $val = 0;
+    if ($NCPL_BASE_PERIOD eq "year") {
+        $val = ( 3600 * 24 *365 ) / $ROF_NCPL;
+    } elsif ($NCPL_BASE_PERIOD eq "day") {
+        $val = ( 3600 * 24 ) / $ROF_NCPL;
+    } elsif ($NCPL_BASE_PERIOD eq "hour") {
+        $val = ( 3600 ) / $ROF_NCPL;
+    } else {
+        die "$ProgName ERROR:: NCPL_BASE_PERIOD not valid.\n";
+    }
     add_default($nl, 'coupling_period', 'val'=>$val);
     if ($print>=2) { 
         print "River Transport Model (MOSART) mode is $MOSART_MODE \n"; 


### PR DESCRIPTION
This PR modifies the MOSART build-namelist so that the coupling frequency it computes, in the form of variable coupling_period, is dependent on the value of NCPL_BASE_PERIOD. Previously it was hard-wired to assume the base period was one day and ROF_NCPL was the number of couplings per day. This update was necessary for getting IG cases working, where the NCPL_BASE_PERIOD is often a year so that the landice code can run on order of days.

[BFB]