### PR TITLE
Make dtime calculation dependent on value of NCPL_BASE_PERIOD

### DIFF
--- a/components/clm/bld/CLMBuildNamelist.pm
+++ b/components/clm/bld/CLMBuildNamelist.pm
@@ -2188,27 +2188,22 @@ sub setup_logic_delta_time {
     if ( $l_ncpl <= 0 ) {
       fatal_error("bad value for -l_ncpl option.\n");
     }
-    if ( defined($opts->{'ncpl_base_period'}) ) {
-      my $ncpl_base_period = $opts->{'ncpl_base_period'};
-      if ( $ncpl_base_period eq "null" ) {
+    my $ncpl_base_period = $opts->{'ncpl_base_period'};
+    my $val = 0;
+    if ($ncpl_base_period eq "year") {
+        $val = ( 3600 * 24 *365 ) / $l_ncpl;
+    } elsif ($ncpl_base_period eq "day") {
+        $val = ( 3600 * 24 ) / $l_ncpl;
+    } elsif ($ncpl_base_period eq "hour") {
+        $val = ( 3600 ) / $l_ncpl;
+    } else {
         fatal_error("bad value for -ncpl_base_period option.\n");
-      }
-      my $val = 0;
-      if ($ncpl_base_period eq "year") {
-          $val = ( 3600 * 24 *365 ) / $l_ncpl;
-      } elsif ($ncpl_base_period eq "day") {
-          $val = ( 3600 * 24 ) / $l_ncpl;
-      } elsif ($ncpl_base_period eq "hour") {
-          $val = ( 3600 ) / $l_ncpl;
-      } else {
-          fatal_error("bad value for -ncpl_base_period option.\n");
-      }
-      my $dtime = $nl->get_value('dtime');
-      if ( ! defined($dtime)  ) {
-        add_default($opts->{'test'}, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'dtime', 'val'=>$val);
-      } elsif ( $dtime ne $val ) {
-        fatal_error("can NOT set both -l_ncpl option (via LND_NCPL env variable) AND dtime namelist variable.\n");
-      }
+    }
+    my $dtime = $nl->get_value('dtime');
+    if ( ! defined($dtime)  ) {
+      add_default($opts->{'test'}, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'dtime', 'val'=>$val);
+    } elsif ( $dtime ne $val ) {
+      fatal_error("can NOT set both -l_ncpl option (via LND_NCPL env variable) AND dtime namelist variable.\n");
     }
   } else {
     add_default($opts->{'test'}, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'dtime', 'hgrid'=>$nl_flags->{'res'});

--- a/components/clm/cime_config/buildnml
+++ b/components/clm/cime_config/buildnml
@@ -42,6 +42,7 @@ def buildnml(case, caseroot, compname):
     lnd_domain_path     = case.get_value("LND_DOMAIN_PATH")
     lnd_domain_file     = case.get_value("LND_DOMAIN_FILE")
     mask_grid           = case.get_value("MASK_GRID")
+    ncpl_base_period    = case.get_value("NCPL_BASE_PERIOD")
     ninst_lnd           = case.get_value("NINST_LND")
     rundir              = case.get_value("RUNDIR")
     run_type            = case.get_value("RUN_TYPE")
@@ -176,6 +177,7 @@ def buildnml(case, caseroot, compname):
         sysmod += " {} {} -res {} {} -clm_start_type {}".format(usecase, glc_opts, resolution, clmusr, start_type)
         sysmod += " -envxml_dir {} -l_ncpl {} -lnd_frac {}/{}".format(caseroot, lnd_ncpl, lnd_domain_path, lnd_domain_file)
         sysmod += " -glc_nec {} -co2_ppmv {} -co2_type {} ".format(glc_nec, ccsm_co2_ppmv, clm_co2_type)
+        sysmod += " -ncpl_base_period {} ".format(ncpl_base_period)
         sysmod += " -config {}/config_cache.xml {}".format(clmconf_dir, clm_bldnml_opts)
         if mask_grid != "reg":
             sysmod += " -mask {}".format(mask_grid)


### PR DESCRIPTION
This PR modifies the ELM namelist build system so that the coupling frequency it computes, in the form of variable dtime, is dependent on the value of NCPL_BASE_PERIOD. Previously it was hard-wired to assume the base period was one day and LND_NCPL was the number of couplings per day. This update was necessary for getting IG cases working, where the NCPL_BASE_PERIOD is often a year so that the landice code can run on order of days.

Tested by @stephenprice during IG-case development

[BFB]