### PR TITLE
Adds a new land test

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -32,6 +32,7 @@ _TESTS = {
             "ERS.f19_g16.I1850GSWCNPRDCTCBC.clm-ctc_f19_g16_I1850GSWCNPRDCTCBC",
             "ERS.f19_g16.I20TRGSWCNPRDCTCBC.clm-ctc_f19_g16_I20TRGSWCNPRDCTCBC",
             "ERS.f09_g16.ICLM45BC",
+            "SMS.r05_r05.I1850CLM45CN.clm-qian_1948",
             "SMS_Ly2_P1x1.1x1_smallvilleIA.ICLM45CNCROP.clm-lulcc_sville",
             "ERS.r05_r05.RMOSGPCC.mosart-gpcc_1972",
             "ERS.MOS_USRDAT.RMOSGPCC.mosart-mos_usrdat",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -158,7 +158,6 @@ _TESTS = {
             "SMS_D_Ld1.ne30_r05_oECv3.A_WCYCL1850",
             "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-TEST.cam-crmout",
             "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-RCEMIP",
-            "SMS.r05_r05.I1850CLM45CN",
             )
         },
 

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/qian_1948/shell_commands
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/qian_1948/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange DATM_CLMNCEP_YR_END=1948


### PR DESCRIPTION
Adds tests mod to SMS.r05_r05.I1850CLM45CN, clm-qian_1948, that avoids
downloading multiple DATAM files by setting the end year to be
the same as the start year. Also move test back to land_developer

[BFB]