### PR TITLE
add ne45pg2 grid support

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -972,6 +972,60 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%ne45np4.pg2">
+    <mach name="cori-knl">
+      <pes compset="any" pesize="L">
+        <comment>cori-knl, generic ne45pg2, 85 nodes, 64x1</comment>
+        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>5440</ntasks_atm>
+          <ntasks_lnd>5440</ntasks_lnd>
+          <ntasks_rof>5440</ntasks_rof>
+          <ntasks_ice>4800</ntasks_ice>
+          <ntasks_ocn>4800</ntasks_ocn>
+          <ntasks_glc>64</ntasks_glc>
+          <ntasks_wav>64</ntasks_wav>
+          <ntasks_cpl>5440</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+      </pes>
+      <pes compset="any" pesize="any">
+        <comment>cori-knl, generic ne45, 43 nodes, 32x4</comment>
+        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>1350</ntasks_atm>
+          <ntasks_lnd>1350</ntasks_lnd>
+          <ntasks_rof>1350</ntasks_rof>
+          <ntasks_ice>1200</ntasks_ice>
+          <ntasks_ocn>1200</ntasks_ocn>
+          <ntasks_glc>32</ntasks_glc>
+          <ntasks_wav>32</ntasks_wav>
+          <ntasks_cpl>1350</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>4</nthrds_atm>
+          <nthrds_lnd>4</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>4</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
+  </grid>
   <grid name="a%ne30np4_">
     <mach name="eos">
       <pes compset="any" pesize="any">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1215,7 +1215,7 @@
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
-      <mask>gx1v6</mask>
+      <mask>oEC60to30v3</mask>
     </model_grid>
     <model_grid alias="ne45pg2_ne45pg2" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne45np4.pg2</grid>
@@ -1224,7 +1224,7 @@
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
-      <mask>gx1v6</mask>
+      <mask>oEC60to30v3</mask>
     </model_grid>
 
     <model_grid alias="ne120_oRRS18v3_ICG" compset="(CAM5.+CLM.+MPASO%SPUNUP)">
@@ -1815,6 +1815,16 @@
       <mask>oRRS30to10v3wLI</mask>
     </model_grid>
 
+    <model_grid alias="ne45pg2_r05_oECv3">
+      <grid name="atm">ne45np4.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
+
     <model_grid alias="twpx4v1_twpx4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne0np4_twpx4v1</grid>
       <grid name="lnd">ne0np4_twpx4v1</grid>
@@ -2196,6 +2206,16 @@
       <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg4_oEC60to30v3.200330.nc</file>
       <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg4_oEC60to30v3.200330.nc</file>
       <desc>ne30np4.pg4 is Spectral Elem 1-deg grid w/ 4x4 FV physics grid per element:</desc>
+    </domain>
+
+    <!--=====================================================================-->
+    <!-- ne45 -->
+    <domain name="ne45np4.pg2">
+      <nx>48600</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne45pg2_oEC60to30v3.200615.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne45pg2_oEC60to30v3.200615.nc</file>
+      <desc>ne45np4.pg2 is Spectral Elem w/ 1-deg FV physics grid:</desc>
     </domain>
 
     <!--=====================================================================-->
@@ -3000,6 +3020,24 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_oRRS18to6v3_mono.200707.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne30pg2/map_oRRS18to6v3_to_ne30pg2_mono.200707.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne30pg2/map_oRRS18to6v3_to_ne30pg2_mono.200707.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne45np4.pg2" ocn_grid="oEC60to30v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne45pg2/map_ne45pg2_to_oEC60to30v3_mono.200610.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne45pg2/map_ne45pg2_to_oEC60to30v3_bilin.200610.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne45pg2/map_ne45pg2_to_oEC60to30v3_bilin.200610.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne45pg2_mono.200610.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne45pg2_mono.200610.nc</map>
+    </gridmap>
+    <gridmap atm_grid="ne45np4.pg2" lnd_grid="r05">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne45pg2/map_ne45pg2_to_r05_mono.200610.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne45pg2/map_ne45pg2_to_r05_bilin.200610.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne45pg2/map_r05_to_ne45pg2_mono.200610.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne45pg2/map_r05_to_ne45pg2_mono.200610.nc</map>
+    </gridmap>
+    <gridmap atm_grid="ne45np4.pg2" rof_grid="r05">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne45pg2/map_ne45pg2_to_r05_mono.200610.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne45pg2/map_ne45pg2_to_r05_bilin.200610.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne60np4" ocn_grid="gx1v6">

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -76,6 +76,7 @@ _TESTS = {
             "SMS_D_Ln5.ne30_ne30.FC5AV1C-L",
             "ERP_Ln7.ne30_ne30.FC5AV1C-L",
             "SMS_Ly1.ne4_ne4.FC5AV1C-L",
+	    "SMS_D_Ln5.ne45pg2_ne45pg2.F-EAMv1-AQP1",
             )
         },
 

--- a/components/cam/bld/config_files/horiz_grid.xml
+++ b/components/cam/bld/config_files/horiz_grid.xml
@@ -53,6 +53,7 @@
 <horiz_grid dyn="se"    hgrid="ne30np4.pg2"  ncol="21600"   csne="30"  csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne30np4.pg3"  ncol="48600"   csne="30"  csnp="4" npg="3" />
 <horiz_grid dyn="se"    hgrid="ne30np4.pg4"  ncol="86400"   csne="30"  csnp="4" npg="4" />
+<horiz_grid dyn="se"    hgrid="ne45np4.pg2"  ncol="48600"   csne="45"  csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne60np4"      ncol="194402"  csne="60"  csnp="4" npg="0" />
 <horiz_grid dyn="se"    hgrid="ne60np4.pg2"  ncol="86400"   csne="60"  csnp="4" npg="2" />
 <horiz_grid dyn="se"    hgrid="ne120np4"     ncol="777602"  csne="120" csnp="4" npg="0" />

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1540,8 +1540,6 @@
 <!-- viscosity  -->
 
 <nu_top> 2.5e5 </nu_top>
-<nu_top dyn_target="preqx"   hgrid="ne45np4"> 2.5e5 </nu_top>
-<nu_top dyn_target="theta-l" hgrid="ne45np4"> 2.5e5 </nu_top>
 <nu_top dyn_target="preqx" hgrid="ne240np4"> 1.0e5 </nu_top>
 <nu_top dyn_target="theta-l" hgrid="ne120np4"> 1e5 </nu_top>
 <nu_top dyn_target="theta-l" hgrid="ne240np4"> 4.3e4 </nu_top>
@@ -1557,7 +1555,7 @@
 <nu hgrid="ne16np4" >  7.0e15 </nu>
 <nu hgrid="ne30np4" >  1.0e15 </nu>
 <nu dyn_target="preqx"   hgrid="ne45np4" > 3.0E+14 </nu>
-<nu dyn_target="theta-l" hgrid="ne45np4" > 3.5e-8 </nu>
+<nu dyn_target="theta-l" hgrid="ne45np4" > 3.4e-8 </nu>
 <nu hgrid="ne60np4" >  1.25e14 </nu>
 <nu hgrid="ne120np4">  1.0e13 </nu>
 <nu dyn_target="theta-l" hgrid="ne120np4">  1.5e13 </nu>
@@ -1656,16 +1654,24 @@
 <hypervis_subcycle_q dyn_target="preqx"> 1 </hypervis_subcycle_q>
 <hypervis_subcycle_tom dyn_target="preqx"> 0 </hypervis_subcycle_tom>
 
+<!-- ne45 defaults to new time step interface -->
+<dt_remap_factor  dyn_target="preqx" hgrid="ne45np4"> 2 </dt_remap_factor>
+<dt_tracer_factor dyn_target="preqx" hgrid="ne45np4"> 1 </dt_tracer_factor>
+
 <qsplit dyn_target="preqx">  1 </qsplit>
+<qsplit dyn_target="preqx" hgrid="ne45np4"> -1 </qsplit>
 
-<rsplit dyn_target="preqx" hgrid="ne4np4" >   1 </rsplit>
-<rsplit dyn_target="preqx" hgrid="ne11np4" >  2 </rsplit>
 <rsplit dyn_target="preqx">  3 </rsplit>
+<rsplit dyn_target="preqx" hgrid="ne4np4" >  1 </rsplit>
+<rsplit dyn_target="preqx" hgrid="ne11np4">  2 </rsplit>
+<rsplit dyn_target="preqx" hgrid="ne45np4"> -1 </rsplit>
 
+<se_nsplit dyn_target="preqx"> 2 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne4np4" >   4 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne11np4" >  4 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne16np4" >  1 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne30np4" >  2 </se_nsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne45np4">  -1 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne60np4" >  4 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne120np4">  4 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne240np4">  5 </se_nsplit>
@@ -1679,15 +1685,6 @@
 <se_nsplit dyn_target="preqx" hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 5 </se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne0np4_enax4v1">4</se_nsplit>
 <se_nsplit dyn_target="preqx" hgrid="ne0np4_twpx4v1" > 4 </se_nsplit>
-<se_nsplit dyn_target="preqx"> 2 </se_nsplit>
-
-<!-- ne45 defaults to new time step interface -->
-<se_tstep hgrid="ne45np4">  200 </se_tstep>
-<dt_remap_factor  dyn_target="preqx" hgrid="ne45np4"> 2 </dt_remap_factor>
-<dt_tracer_factor dyn_target="preqx" hgrid="ne45np4"> 1 </dt_tracer_factor>
-<qsplit    dyn_target="preqx" hgrid="ne45np4"> -1 </qsplit>
-<rsplit    dyn_target="preqx" hgrid="ne45np4"> -1 </rsplit>
-<se_nsplit dyn_target="preqx" hgrid="ne45np4"> -1 </se_nsplit>
 
 
 <hypervis_subcycle hgrid="ne4np4" dyn_target="preqx">   3 </hypervis_subcycle>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -19,6 +19,7 @@
 <dtime dyn="se"    hgrid="ne11np4" >7200</dtime>
 <dtime dyn="se"    hgrid="ne16np4" >1800</dtime>
 <dtime dyn="se"    hgrid="ne30np4" >1800</dtime>
+<dtime dyn="se"    hgrid="ne45np4" >1200</dtime>
 <dtime dyn="se"    hgrid="ne60np4" >1800</dtime>
 <dtime dyn="se"    hgrid="ne120np4">900 </dtime>
 <dtime dyn="se"    hgrid="ne240np4">600 </dtime>
@@ -154,6 +155,7 @@
 <ncdata dyn="se" hgrid="ne30np4"  nlev="26"             ic_ymd="901" >atm/cam/inic/homme/cami_0000-09-01_ne30np4_L26_c040422.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="30"             ic_ymd="101" >atm/cam/inic/homme/cami-mam3_0000-01-01_ne30np4_L30_c130424.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="72"             ic_ymd="101" >atm/cam/inic/homme/cami_mam3_Linoz_ne30np4_L72_c160214.nc</ncdata>
+<ncdata dyn="se" hgrid="ne45np4"  nlev="72"             ic_ymd="101" >atm/cam/inic/homme/cami_mam3_Linoz_ne45np4_L72_c20200611.nc</ncdata>
 <ncdata dyn="se" hgrid="ne60np4"  nlev="30"             ic_ymd="101" >atm/cam/inic/homme/cami-mam3_0000-01-ne60np4_L30_c090306.nc</ncdata>
 <ncdata dyn="se" hgrid="ne120np4" nlev="26"             ic_ymd="901" >atm/cam/inic/homme/cami_0000-09-01_ne120np4_L26_c061106.nc</ncdata>
 <ncdata dyn="se" hgrid="ne120np4" nlev="26"             ic_ymd="101" >atm/cam/inic/homme/cami_0000-01-01_ne120np4_L26_c110304.nc</ncdata>
@@ -173,6 +175,7 @@
 <ncdata dyn="se" hgrid="ne4np4"   nlev="72"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/homme/cami_aquaplanet_ne4np4_L72_c190218.nc</ncdata>
 <ncdata dyn="se" hgrid="ne16np4"  nlev="72"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/homme/cami_aquaplanet_ne16np4_L72_c190311.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="72"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/homme/cami_aquaplanet_ne30np4_L72_c190215.nc</ncdata>
+<ncdata dyn="se" hgrid="ne45np4"  nlev="72"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/homme/cami_aquaplanet_ne45np4_L72_c20200611.nc</ncdata>
 
 <!-- E3SM RCE -->
 <ncdata dyn="se" hgrid="ne4np4"   nlev="72"  aquaplanet="1" rce="1" ic_ymd="101" >atm/cam/inic/homme/cami_rcemip_ne4np4_L72_c190919.nc</ncdata>
@@ -240,6 +243,7 @@
 <bnd_topo hgrid="ne30np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne30np4pg2_16xdel2.c20200108.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="3">atm/cam/topo/USGS-gtopo30_ne30np4pg3_16xdel2.c20200504.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="4">atm/cam/topo/USGS-gtopo30_ne30np4pg4_16xdel2.c20200504.nc</bnd_topo>
+<bnd_topo hgrid="ne45np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne45np4pg2_16xdel2.c20200615.nc</bnd_topo>
 <bnd_topo hgrid="ne60np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne60np4_16xconsistentSGH.c20140517.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="0">atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="2">atm/cam/topo/USGS-gtopo30_ne120np4pg2_16xdel2.nc</bnd_topo>
@@ -840,6 +844,7 @@
 <drydep_srf_file hgrid="ne30np4" npg="2">atm/cam/chem/trop_mam/atmsrf_ne30pg2_200129.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne30np4" npg="3">atm/cam/chem/trop_mam/atmsrf_ne30pg3_200501.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne30np4" npg="4">atm/cam/chem/trop_mam/atmsrf_ne30pg4_200501.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne45np4" npg="2">atm/cam/chem/trop_mam/atmsrf_ne45pg2_200527.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne60np4" >atm/cam/chem/trop_mam/atmsrf_ne60np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne120np4">atm/cam/chem/trop_mam/atmsrf_ne120np4_110920.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne240np4">atm/cam/chem/trop_mam/atmsrf_ne240np4_110920.nc</drydep_srf_file>
@@ -1094,6 +1099,7 @@
 <!-- dust emission tuning factor -->
 <dust_emis_fact                                                         >2.76D0</dust_emis_fact>
 <dust_emis_fact          hgrid="ne30np4"   phys="cam5"                  >1.38D0</dust_emis_fact>
+<dust_emis_fact          hgrid="ne45np4"   phys="cam5"                  >1.38D0</dust_emis_fact>
 <dust_emis_fact          hgrid="ne120np4"  phys="cam5"                  >1.2D0</dust_emis_fact>
 
 <dust_emis_fact                                         chem="trop_bam"	>4.2D0 </dust_emis_fact>
@@ -1534,6 +1540,8 @@
 <!-- viscosity  -->
 
 <nu_top> 2.5e5 </nu_top>
+<nu_top dyn_target="preqx"   hgrid="ne45np4"> 2.5e5 </nu_top>
+<nu_top dyn_target="theta-l" hgrid="ne45np4"> 2.5e5 </nu_top>
 <nu_top dyn_target="preqx" hgrid="ne240np4"> 1.0e5 </nu_top>
 <nu_top dyn_target="theta-l" hgrid="ne120np4"> 1e5 </nu_top>
 <nu_top dyn_target="theta-l" hgrid="ne240np4"> 4.3e4 </nu_top>
@@ -1548,6 +1556,8 @@
 <nu hgrid="ne11np4" >  2.0e16 </nu>
 <nu hgrid="ne16np4" >  7.0e15 </nu>
 <nu hgrid="ne30np4" >  1.0e15 </nu>
+<nu dyn_target="preqx"   hgrid="ne45np4" > 3.0E+14 </nu>
+<nu dyn_target="theta-l" hgrid="ne45np4" > 3.5e-8 </nu>
 <nu hgrid="ne60np4" >  1.25e14 </nu>
 <nu hgrid="ne120np4">  1.0e13 </nu>
 <nu dyn_target="theta-l" hgrid="ne120np4">  1.5e13 </nu>
@@ -1577,6 +1587,7 @@
 <nu_div dyn_target="preqx" hgrid="ne11np4" >  5.0e16 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne16np4" > 15.5e15 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne30np4" >  2.5e15 </nu_div>
+<nu_div dyn_target="preqx" hgrid="ne45np4" > 7.4E+14 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne60np4" >  2.5e14 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne120np4">  2.5e13 </nu_div>
 <nu_div dyn_target="preqx" hgrid="ne240np4">  2.5e12 </nu_div>
@@ -1594,6 +1605,7 @@
 <hypervis_order >     2 </hypervis_order>
 
 <hypervis_scaling> 0 </hypervis_scaling>
+<hypervis_scaling dyn_target="theta-l"  hgrid="ne45np4"> 3.0 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_arm_x8v3_lowcon"  > 3.2 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_conus_x4v1_lowcon"  > 3.2 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_northamericax4v1"  > 3.2 </hypervis_scaling>
@@ -1627,6 +1639,7 @@
 <se_tstep dyn_target="theta-l" hgrid="ne11np4" >  600 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne16np4" >  600 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne30np4" >  300 </se_tstep>
+<se_tstep                      hgrid="ne45np4" >  200 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne60np4" >  150 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne120np4">  75 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne240np4">  40 </se_tstep>
@@ -1668,10 +1681,20 @@
 <se_nsplit dyn_target="preqx" hgrid="ne0np4_twpx4v1" > 4 </se_nsplit>
 <se_nsplit dyn_target="preqx"> 2 </se_nsplit>
 
+<!-- ne45 defaults to new time step interface -->
+<se_tstep hgrid="ne45np4">  200 </se_tstep>
+<dt_remap_factor  dyn_target="preqx" hgrid="ne45np4"> 2 </dt_remap_factor>
+<dt_tracer_factor dyn_target="preqx" hgrid="ne45np4"> 1 </dt_tracer_factor>
+<qsplit    dyn_target="preqx" hgrid="ne45np4"> -1 </qsplit>
+<rsplit    dyn_target="preqx" hgrid="ne45np4"> -1 </rsplit>
+<se_nsplit dyn_target="preqx" hgrid="ne45np4"> -1 </se_nsplit>
+
+
 <hypervis_subcycle hgrid="ne4np4" dyn_target="preqx">   3 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne11np4" dyn_target="preqx" >  3 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne16np4" dyn_target="preqx">  3 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne30np4" dyn_target="preqx">  3 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne45np4" dyn_target="preqx">  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne60np4" dyn_target="preqx">  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne120np4" dyn_target="preqx">  4 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne240np4" dyn_target="preqx">  4 </hypervis_subcycle>


### PR DESCRIPTION
Add support for the ne45pg2 grid, and specifically the ne45pg2_r05_oECv3 tri-grid. 

ne45pg2 has a similar number of columns to ne30np4 and almost exactly 1 degree uniform resolution. (Do not add support for a ne45np4 grid as this is  not planned to be used.) The namelist settings for ne45 follow the new protocol for setting the dynamics time step directly in seconds. Dycor hyperviscosity settings have been specified for both preqx and theta-l options and verified to work with the initial condition file generated through an iterative spin-up process. The physics time step for ne45 is reduced to 20 min.

[BFB]