### PR TITLE
Make dtime calculation dependent on value of NCPL_BASE_PERIOD

### DIFF
--- a/components/cam/cime_config/buildnml
+++ b/components/cam/cime_config/buildnml
@@ -41,6 +41,7 @@ def buildnml(case, caseroot, compname):
     din_loc_root	= case.get_value("DIN_LOC_ROOT")
     exeroot		= case.get_value("EXEROOT")
     mpilib		= case.get_value("MPILIB")
+    ncpl_base_period	= case.get_value("NCPL_BASE_PERIOD")
     nthrds_atm		= case.get_value("NTHRDS_ATM")
     ntasks_atm		= case.get_value("NTASKS_ATM")
     ninst_atm		= case.get_value("NINST_ATM")
@@ -162,7 +163,15 @@ def buildnml(case, caseroot, compname):
                 if inst_string != "":
                     logger.warning("WARNING: {} is being used".format(cam_branch_file))
 
-        dtime = ( 3600 * 24 ) // atm_ncpl
+        if ncpl_base_period == 'year':
+            dtime = ( 3600 * 24 * 365 ) // atm_ncpl
+        elif ncpl_base_period == 'day':
+            dtime = ( 3600 * 24 ) // atm_ncpl
+        elif ncpl_base_period == 'hour':
+            dtime = ( 3600 ) // atm_ncpl
+        else:
+            logger.warning("WARNING: {} is being used".format(ncpl_base_period))
+
         start_ymd = run_startdate.replace("-", "")
         ntasks = ntasks_atm / ninst_atm
 


### PR DESCRIPTION
This PR modifies the EAM namelist build system so that the coupling frequency it computes, in the form of variable dtime, is dependent on the value of NCPL_BASE_PERIOD that is set in env_run.xml. Previously it was hard-wired to assume the base period was one day and ATM_NCPL was the number of couplings per day. This update was necessary for getting IG cases working, where the NCPL_BASE_PERIOD is often a year so that the landice code can run on order of days.

Tested by @stephenprice during BG-case development

[BFB]