### PR TITLE
Add NCPL_BASE_PERIOD set to year as an option for determining config_dt

### DIFF
--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -240,10 +240,14 @@ def buildnml(case, caseroot, compname):
         # create mpassiconf/cesm_namelist
         # -----------------------------------------------------
 
-        if ncpl_base_period == 'day': 
+        if ncpl_base_period == 'year':
+            config_dt = ( 3600 * 24 * 365 ) // atm_ncpl
+        elif ncpl_base_period == 'day':
             config_dt = ( 3600 * 24 ) // atm_ncpl
-        if ncpl_base_period == 'hour': 
-            config_dt =  3600  // atm_ncpl
+        elif ncpl_base_period == 'hour':
+            config_dt = ( 3600 ) // atm_ncpl
+        else:
+            logger.warning("WARNING: {} is being used".format(ncpl_base_period))
 
         config_dt = float(config_dt)
         infile_text = ""


### PR DESCRIPTION
This PR adds the NCPL_BASE_PERIOD of a year as an option to the mpas-seaice config_dt calculation logic. It had previously been modified for base period options of an hour or a day, but recent BG cases show it needs to add the year option as well.

[BFB]