### PR TITLE
Update modules on Theta

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1568,7 +1568,7 @@
         <command name="load">cmake/3.14.5</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/18.0.0.128</command>
+        <command name="load">intel/19.0.5.281</command>
         <command name="load">PrgEnv-intel/6.0.5</command>
       </modules>
       <modules compiler="gnu">
@@ -1592,6 +1592,7 @@
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
     <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
+      <env name="PERL5LIB">/projects/ccsm/acme/libs/perl5</env>
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
       <env name="MPAS_TOOL_DIR">/projects/ccsm/acme/tools/mpas</env>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1576,14 +1576,15 @@
         <command name="load">PrgEnv-gnu/6.0.7</command>
       </modules>
       <modules compiler="!intel">
+        <command name="rm">cray-libsci</command>
         <command name="load">cray-libsci/20.06.1</command>
       </modules>
       <modules>
         <command name="load">darshan</command>
         <command name="load">craype-mic-knl</command>
         <command name="load">cray-mpich/7.7.14</command>
-        <command name="load">cray-hdf5/1.10.6.1</command>
-        <command name="load">cray-netcdf/4.7.3.3</command>
+        <command name="load">cray-hdf5-parallel/1.10.6.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.7.3.3</command>
         <command name="load">cray-parallel-netcdf/1.12.0.1</command>
       </modules>
     </module_system>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1564,27 +1564,27 @@
         <command name="rm">craype</command>
         <command name="rm">perftools-base</command>
         <command name="rm">darshan</command>
-        <command name="load">craype/2.6.1</command>
+        <command name="load">craype/2.6.5</command>
         <command name="load">cmake/3.14.5</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/19.0.5.281</command>
-        <command name="load">PrgEnv-intel/6.0.5</command>
+        <command name="load">intel/19.1.0.166</command>
+        <command name="load">PrgEnv-intel/6.0.7</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gcc/8.3.0</command>
-        <command name="load">PrgEnv-gnu/6.0.5</command>
+        <command name="load">gcc/9.3.0</command>
+        <command name="load">PrgEnv-gnu/6.0.7</command>
       </modules>
       <modules compiler="!intel">
-        <command name="load">cray-libsci/19.06.1</command>
+        <command name="load">cray-libsci/20.06.1</command>
       </modules>
       <modules>
         <command name="load">darshan</command>
         <command name="load">craype-mic-knl</command>
-        <command name="load">cray-mpich/7.7.10</command>
-        <command name="load">cray-hdf5/1.10.5.1</command>
-        <command name="load">cray-netcdf/4.6.3.1</command>
-        <command name="load">cray-parallel-netcdf/1.11.1.0</command>
+        <command name="load">cray-mpich/7.7.14</command>
+        <command name="load">cray-hdf5/1.10.6.1</command>
+        <command name="load">cray-netcdf/4.7.3.3</command>
+        <command name="load">cray-parallel-netcdf/1.12.0.1</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>


### PR DESCRIPTION
Update intel compiler on Theta to latest available default module after PM.

Fixes E3SM-Project/E3SM#3731

[non-BFB]