### PR TITLE
Initialize phys_proc_cost

### DIFF
--- a/components/cam/src/physics/cam/phys_grid.F90
+++ b/components/cam/src/physics/cam/phys_grid.F90
@@ -354,8 +354,9 @@ module phys_grid
    integer, private, parameter :: def_alltoall = 1                ! default
    integer, private :: phys_alltoall = def_alltoall
 
-! Physics computational cost
-   real(r8), public :: phys_proc_cost ! measured physics cost on this process
+! Physics computational cost on this process
+! (running total of time measured over loops over chunks in physpkg.F90)
+   real(r8), public :: phys_proc_cost = 0.0_r8
 
 contains
 !========================================================================


### PR DESCRIPTION
The variable phys_proc_cost was introduced in PR #3689 to measure
the time spent in the loops over chunks in physpkg.F90. This captures
a running total of the form

    phys_proc_cost = phys_proc_cost + <update>

after each exection of the indicated loops over chunks, and so assumes
that phys_proc_cost is initialized to 0.0_r8. However, this
initialization is missing. During testing, compilers (by default)
initialized this variable to zero, but this is not guaranteed, and
tests with DEBUG set to TRUE in env_build.xml failed due to this
uninitialized variable. Here the required initialization is
introduced.

[BFB]

Fixes #3741 
