### PR TITLE
Modify PGI compiler flags to eliminate non-reproducibility on Compy

### DIFF
--- a/cime_config/machines/Depends.compy.pgi
+++ b/cime_config/machines/Depends.compy.pgi
@@ -1,0 +1,10 @@
+# Files that cannot be compiled with -O2 without losing reproducibility
+O1MODELSRC=\
+dust_sediment_mod.o \
+modal_aero_convproc.o \
+zm_conv.o
+
+ifeq ($(DEBUG),FALSE)
+  $(O1MODELSRC): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O1 -Mnovect $<
+endif

--- a/cime_config/machines/Depends.compy.pgi.cmake
+++ b/cime_config/machines/Depends.compy.pgi.cmake
@@ -1,0 +1,13 @@
+# Files that cannot be compiled with -O2 without losing reproducibility
+set(O1MODELSRC
+  cam/src/chemistry/aerosol/dust_sediment_mod.F90
+  cam/src/chemistry/modal_aero/modal_aero_convproc.F90
+  cam/src/physics/cam/zm_conv.F90)
+
+if (NOT DEBUG)
+  foreach(ITEM IN LISTS O1MODELSRC)
+    e3sm_remove_flags("${ITEM}" "-O2")
+    e3sm_add_flags("${ITEM}" "-O1 -Mnovect")
+  endforeach()
+
+endif()

--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -1069,6 +1069,7 @@ flags should be captured within MPAS CMake files.
     <append DEBUG="FALSE"> -O2 </append>
     <append DEBUG="TRUE">-C -Mbounds -traceback -Mchkfpstk -Mchkstk -Mdalign  -Mdepchk  -Mextend -Miomutex -Mrecursive  -Ktrap=fp -O0 -g -byteswapio -Meh_frame</append>
     <append COMP_NAME="cam">-Mnovect</append>
+    <append COMP_NAME="cice">-Mnovect</append>
   </FFLAGS>
   <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>


### PR DESCRIPTION
a) An F case

      -res ne4pg2_ne4pg2 -compset FC5AV1C-L -mach compy -compiler pgi

is not BFB with respect to changes in PE layout, for example,
64x1 compared to 96x1, with the current optimization flags.
Reproducibility can be restored by compiling the CICE component
with the flag -Mnovect. This is implemented by adding the rule

         <append COMP_NAME="cice">-Mnovect</append>

to config_compilers.xml, which adds

       if("${COMP_NAME}" STREQUAL "cam")
         set(FFLAGS "${FFLAGS} -Mnovect")
       endif()

to Macros.cmake and

       ifeq ($(COMP_NAME),cice)
         FFLAGS := $(FFLAGS) -Mnovect
       endif

Macros.make in a case directory.

b) F cases on Compy when using the PGI compiler are not reproducible with
respect to setting pcols at runtime (the default) as compared to
setting pcols at compile-time, via the -pcols option in
CAM_CONFIG_OPTS in env_builds.xml.

This issue is resolved by lowering the optimization from -O2 to -O1
for three files

   cam/src/chemistry/aerosol/dust_sediment_mod.F90
   cam/src/chemistry/modal_aero/modal_aero_convproc.F90
   cam/src/physics/cam/zm_conv.F90

This is implemented in a Depends file for compy
when using the PGI compiler (Depends.compy.pgi and
Depends.compy.pgi.cmake),

Fixes #3739 
Fixes #3746 

[Non-BFB] (for Compy jobs using PGI)


