### PR TITLE
Adding compset for JRA55 v1.4 through 2018.

### DIFF
--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -42,6 +42,11 @@
   </compset>
 
   <compset>
+    <alias>GMPAS-JRA1p4</alias>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI_MPASO%DATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>GMPAS-IAF-ISMF</alias>
     <lname>2000_DATM%IAF_SLND_MPASSI_MPASO%ISMFDATMFORCED_DROF%IAFAIS45_SGLC_SWAV</lname>
   </compset>


### PR DESCRIPTION
This PR adds support for the JRA55v1.4 forcing dataset through year 2018 by adding the GMPAS-JRA1p4 compset.

[BFB]