### PR TITLE
Fix RRTMGP aerosol optical depth

### DIFF
--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -1991,6 +1991,7 @@ contains
 
       ! Apply delta scaling to account for forward-scattering
       call handle_error(cld_optics_day%delta_scale())
+      call handle_error(aer_optics_day%delta_scale())
 
       ! Check incoming optical properties
       call handle_error(cld_optics_day%validate())
@@ -2011,9 +2012,6 @@ contains
       end do
       deallocate(gas_names_lower)
 
-      call handle_error(cld_optics_day%validate())
-      call handle_error(aer_optics_day%validate())
-        
       ! Compute fluxes
       call t_startf('rad_rte_sw')
       call handle_error(rte_sw(k_dist_sw, gas_concs, &
@@ -2103,6 +2101,9 @@ contains
       end do
       deallocate(gas_names_lower)
 
+      ! Apply delta-scaling to account for forward scattering
+      call handle_error(cld_optics%delta_scale())
+      call handle_error(aer_optics%delta_scale())
 
       ! Do longwave radiative transfer calculations
       call t_startf('rad_rte_lw')

--- a/components/cam/src/physics/rrtmg/radconstants.F90
+++ b/components/cam/src/physics/rrtmg/radconstants.F90
@@ -95,11 +95,7 @@ real(r8), parameter :: wavenumber2_longwave(nlwbands) = &! Longwave spectral ban
     (/  350._r8,  500._r8,  630._r8,  700._r8,  820._r8,  980._r8, 1080._r8, 1180._r8, &
        1390._r8, 1480._r8, 1800._r8, 2080._r8, 2250._r8, 2390._r8, 2600._r8, 3250._r8 /)
 
-!These can go away when old camrt disappears
-! Index of volc. abs., H2O non-window
-integer, public, parameter :: idx_LW_H2O_NONWND=1
-! Index of volc. abs., H2O window
-integer, public, parameter :: idx_LW_H2O_WINDOW=2
+! These can go away when old camrt disappears
 ! Index of volc. cnt. abs. 0500--0650 cm-1
 integer, public, parameter :: idx_LW_0500_0650=3
 ! Index of volc. cnt. abs. 0650--0800 cm-1
@@ -118,10 +114,6 @@ integer, public, parameter :: gasnamelength = 5
 integer, public, parameter :: nradgas = 8
 character(len=gasnamelength), public, parameter :: gaslist(nradgas) &
    = (/'H2O  ','O3   ', 'O2   ', 'CO2  ', 'N2O  ', 'CH4  ', 'CFC11', 'CFC12'/)
-
-! what is the minimum mass mixing ratio that can be supported by radiation implementation?
-real(r8), public, parameter :: minmmr(nradgas) &
-   = epsilon(1._r8)
 
 ! Length of "optics type" string specified in optics files.
 integer, parameter, public :: ot_length = 32

--- a/components/cam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/cam/src/physics/rrtmgp/cam_optics.F90
@@ -18,11 +18,6 @@ module cam_optics
           set_aerosol_optics_sw, &
           set_aerosol_optics_lw
 
-   ! Mapping from old RRTMG sw bands to new band ordering in RRTMGP
-   integer, dimension(14) :: map_rrtmg_to_rrtmgp_swbands = (/ &
-      14, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 &
-   /)
-
 contains
 
    !-------------------------------------------------------------------------------
@@ -98,17 +93,6 @@ contains
             ice_tau, ice_tau_ssa, &
             ice_tau_ssa_g, ice_tau_ssa_f &
          )
-         ! We need to fix band ordering because the old input files assume RRTMG band
-         ! ordering, but this has changed in RRTMGP.
-         ! TODO: fix the input files themselves!
-         do ilev = 1,nlev
-            do icol = 1,ncol
-               ice_tau      (:,icol,ilev) = reordered(ice_tau      (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-               ice_tau_ssa  (:,icol,ilev) = reordered(ice_tau_ssa  (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-               ice_tau_ssa_g(:,icol,ilev) = reordered(ice_tau_ssa_g(:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-               ice_tau_ssa_f(:,icol,ilev) = reordered(ice_tau_ssa_f(:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-            end do
-         end do
       else if (trim(icecldoptics) == 'ebertcurry') then
          call ec_ice_optics_sw(ncol, nlev, cld, iciwp, rei, ice_tau, ice_tau_ssa, ice_tau_ssa_g, ice_tau_ssa_f)
       else
@@ -124,14 +108,6 @@ contains
             liq_tau, liq_tau_ssa, &
             liq_tau_ssa_g, liq_tau_ssa_f &
          )
-         do ilev = 1,nlev
-            do icol = 1,ncol
-               liq_tau      (:,icol,ilev) = reordered(liq_tau      (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-               liq_tau_ssa  (:,icol,ilev) = reordered(liq_tau_ssa  (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-               liq_tau_ssa_g(:,icol,ilev) = reordered(liq_tau_ssa_g(:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-               liq_tau_ssa_f(:,icol,ilev) = reordered(liq_tau_ssa_f(:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-            end do
-         end do
       else if (trim(liqcldoptics) == 'slingo') then
          call slingo_liq_optics_sw( &
             ncol, nlev, cld, iclwp, rel, &
@@ -152,14 +128,6 @@ contains
             snow_tau, snow_tau_ssa, &
             snow_tau_ssa_g, snow_tau_ssa_f &
          )
-         do ilev = 1,nlev
-            do icol = 1,ncol
-               snow_tau      (:,icol,ilev) = reordered(snow_tau      (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-               snow_tau_ssa  (:,icol,ilev) = reordered(snow_tau_ssa  (:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-               snow_tau_ssa_g(:,icol,ilev) = reordered(snow_tau_ssa_g(:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-               snow_tau_ssa_f(:,icol,ilev) = reordered(snow_tau_ssa_f(:,icol,ilev), map_rrtmg_to_rrtmgp_swbands)
-            end do
-         end do
       else
          ! We are not doing snow optics, so set these to zero so we can still use 
          ! the arrays without additional logic
@@ -559,17 +527,6 @@ contains
          endwhere
       end do
 
-      ! We need to fix band ordering because the old input files assume RRTMG band
-      ! ordering, but this has changed in RRTMGP.
-      ! TODO: fix the input files themselves!
-      do icol = 1,size(tau_out,1)
-         do ilay = 1,size(tau_out,2)
-            tau_out(icol,ilay,:) = reordered(tau_out(icol,ilay,:), map_rrtmg_to_rrtmgp_swbands)
-            ssa_out(icol,ilay,:) = reordered(ssa_out(icol,ilay,:), map_rrtmg_to_rrtmgp_swbands)
-            asm_out(icol,ilay,:) = reordered(asm_out(icol,ilay,:), map_rrtmg_to_rrtmgp_swbands)
-         end do
-      end do
-
    end subroutine set_aerosol_optics_sw
 
    !----------------------------------------------------------------------------
@@ -599,30 +556,6 @@ contains
    end subroutine set_aerosol_optics_lw
 
    !----------------------------------------------------------------------------
-
-   ! Utility function to reorder an array given a new indexing
-   function reordered(array_in, new_indexing) result(array_out)
-
-      ! Inputs
-      real(r8), intent(in) :: array_in(:)
-      integer, intent(in) :: new_indexing(:)
-
-      ! Output, reordered array
-      real(r8), dimension(size(array_in)) :: array_out
-
-      ! Loop index
-      integer :: ii
-
-      ! Check inputs
-      call assert(size(array_in) == size(new_indexing), 'reorder_array: sizes inconsistent')
-
-      ! Reorder array based on input index mapping, which maps old indices to new
-      do ii = 1,size(new_indexing)
-         array_out(ii) = array_in(new_indexing(ii))
-      end do
-
-   end function reordered
-
    !----------------------------------------------------------------------------
 
 end module cam_optics

--- a/components/cam/src/physics/rrtmgp/radconstants.F90
+++ b/components/cam/src/physics/rrtmgp/radconstants.F90
@@ -79,7 +79,6 @@ integer, parameter, public :: idx_nir_diag = 8 ! index to sw near infrared (778-
 integer, parameter, public :: idx_uv_diag = 11 ! index to sw uv (345-441 nm) band
 integer, parameter, public :: rrtmg_sw_cloudsim_band = 9  ! rrtmg band for .67 micron
 
-
 ! Number of evenly spaced intervals in rh
 ! The globality of this mesh may not be necessary
 ! Perhaps it could be specific to the aerosol
@@ -97,14 +96,9 @@ integer, parameter, public :: nrh = 1000
 
 ! These are indices to the band for diagnostic output
 integer, parameter, public :: idx_lw_diag = 7 ! index to (H20 window) LW band
-
 integer, parameter, public :: rrtmg_lw_cloudsim_band = 6  ! rrtmg band for 10.5 micron
 
-!These can go away when old camrt disappears
-! Index of volc. abs., H2O non-window
-integer, public, parameter :: idx_LW_H2O_NONWND=1
-! Index of volc. abs., H2O window
-integer, public, parameter :: idx_LW_H2O_WINDOW=2
+! These can go away when old camrt disappears
 ! Index of volc. cnt. abs. 0500--0650 cm-1
 integer, public, parameter :: idx_LW_0500_0650=3
 ! Index of volc. cnt. abs. 0650--0800 cm-1
@@ -123,10 +117,6 @@ integer, public, parameter :: gasnamelength = 5
 integer, public, parameter :: nradgas = 8
 character(len=gasnamelength), public, parameter :: gaslist(nradgas) &
    = (/'H2O  ','O3   ', 'O2   ', 'CO2  ', 'N2O  ', 'CH4  ', 'CFC11', 'CFC12'/)
-
-! what is the minimum mass mixing ratio that can be supported by radiation implementation?
-real(r8), public, parameter :: minmmr(nradgas) &
-   = epsilon(1._r8)
 
 ! Length of "optics type" string specified in optics files.
 integer, parameter, public :: ot_length = 32

--- a/components/cam/src/physics/rrtmgp/radconstants.F90
+++ b/components/cam/src/physics/rrtmgp/radconstants.F90
@@ -33,19 +33,36 @@ integer, parameter, public :: nlwbands = 16
 ! Note: Currently rad_solar_var extends the lowest band down to
 ! 100 cm^-1 if it is too high to cover the far-IR. Any changes meant
 ! to affect IR solar variability should take note of this.
-!real(r8), dimension(nswbands) :: wavenum_sw_lower, wavenum_sw_upper
-real(r8) :: wavenum_sw_lower(nswbands) = & ! in cm^-1
-  (/ 820._r8, 2680._r8, 3250._r8, 4000._r8, 4650._r8, 5150._r8, 6150._r8, &
-    7700._r8, 8050._r8,12850._r8,16000._r8,22650._r8,29000._r8,38000._r8/)
-real(r8) :: wavenum_sw_upper(nswbands) = & ! in cm^-1
-  (/2680._r8, 3250._r8, 4000._r8, 4650._r8, 5150._r8, 6150._r8, 7700._r8, &
-    8050._r8,12850._r8,16000._r8,22650._r8,29000._r8,38000._r8,50000._r8/)
-real(r8) :: wavenum_lw_lower(nlwbands) = &! Longwave spectral band limits (cm-1)
+!
+! Note: These band limits should correspond to the optical property look-up
+! table bands, and may not correspond directly to the RRTMGP absorption
+! coefficient bands. This is to workaround the issue where aerosol optical
+! properties are output before bands are reordered to the expected RRTMGP order.
+! Optical properties should be reordered to RRTMGP order in the RRTMGP driver
+! interface codes.
+!real(r8) :: wavenum_sw_lower(nswbands) = & ! in cm^-1
+!  (/ 820._r8, 2680._r8, 3250._r8, 4000._r8, 4650._r8, 5150._r8, 6150._r8, &
+!    7700._r8, 8050._r8,12850._r8,16000._r8,22650._r8,29000._r8,38000._r8/)
+!real(r8) :: wavenum_sw_upper(nswbands) = & ! in cm^-1
+!  (/2680._r8, 3250._r8, 4000._r8, 4650._r8, 5150._r8, 6150._r8, 7700._r8, &
+!    8050._r8,12850._r8,16000._r8,22650._r8,29000._r8,38000._r8,50000._r8/)
+real(r8), parameter :: wavenum_sw_lower(nswbands) = & ! in cm^-1
+  (/2600._r8, 3250._r8, 4000._r8, 4650._r8, 5150._r8, 6150._r8, 7700._r8, &
+    8050._r8,12850._r8,16000._r8,22650._r8,29000._r8,38000._r8,  820._r8/)
+real(r8), parameter :: wavenum_sw_upper(nswbands) = & ! in cm^-1
+  (/3250._r8, 4000._r8, 4650._r8, 5150._r8, 6150._r8, 7700._r8, 8050._r8, &
+   12850._r8,16000._r8,22650._r8,29000._r8,38000._r8,50000._r8, 2600._r8/)
+real(r8), parameter :: wavenum_lw_lower(nlwbands) = &! Longwave spectral band limits (cm-1)
     (/   10._r8,  250._r8, 500._r8,   630._r8,  700._r8,  820._r8,  980._r8, 1080._r8, &
        1180._r8, 1390._r8, 1480._r8, 1800._r8, 2080._r8, 2250._r8, 2390._r8, 2680._r8 /)
-real(r8) :: wavenum_lw_upper(nlwbands) = &! Longwave spectral band limits (cm-1)
+real(r8), parameter :: wavenum_lw_upper(nlwbands) = &! Longwave spectral band limits (cm-1)
     (/  250._r8,  500._r8,  630._r8,  700._r8,  820._r8,  980._r8, 1080._r8, 1180._r8, &
        1390._r8, 1480._r8, 1800._r8, 2080._r8, 2250._r8, 2390._r8, 2680._r8, 3250._r8 /)
+
+! Mapping from old RRTMG sw bands to new band ordering in RRTMGP
+integer, parameter, dimension(14), public :: rrtmg_to_rrtmgp_swbands = (/ &
+   14, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 &
+/)
 
 ! Solar irradiance at 1 A.U. in W/m^2 assumed by radiation code
 ! Rescaled so that sum is precisely 1368.22 and fractional amounts sum to 1.0
@@ -59,10 +76,20 @@ real(r8), parameter :: solar_ref_band_irradiance(nswbands) = &
    /)
 
 ! These are indices to the band for diagnostic output
-integer, parameter, public :: idx_sw_diag = 11 ! index to sw visible band
-integer, parameter, public :: idx_nir_diag = 9 ! index to sw near infrared (778-1240 nm) band
-integer, parameter, public :: idx_uv_diag = 12 ! index to sw uv (345-441 nm) band
-integer, parameter, public :: rrtmg_sw_cloudsim_band = 10  ! rrtmg band for .67 micron
+!integer, parameter, public :: idx_sw_diag = 11 ! index to sw visible band (550 nm)
+!integer, parameter, public :: idx_nir_diag = 9 ! index to sw near infrared (778-1240 nm) band
+!integer, parameter, public :: idx_uv_diag = 12 ! index to sw uv (345-441 nm) band
+!integer, parameter, public :: rrtmg_sw_cloudsim_band = 10  ! rrtmg band for .67 micron
+! These are indices to the band for diagnostic output
+! NOTE: these are consistent with the RRTMG optical property input data, NOT the
+! RRTMGP absorption coefficient data. This is because optical property
+! diagnostics are output in buried places in the code (i.e., aerosol optics
+! codes) before the bands can be transformed to the RRTMGP bands.
+integer, parameter, public :: idx_sw_diag = 10 ! index to sw visible band
+integer, parameter, public :: idx_nir_diag = 8 ! index to sw near infrared (778-1240 nm) band
+integer, parameter, public :: idx_uv_diag = 11 ! index to sw uv (345-441 nm) band
+integer, parameter, public :: rrtmg_sw_cloudsim_band = 9  ! rrtmg band for .67 micron
+
 
 ! Number of evenly spaced intervals in rh
 ! The globality of this mesh may not be necessary
@@ -118,8 +145,6 @@ integer, parameter, public :: ot_length = 32
 public :: rad_gas_index
 
 public :: get_number_sw_bands, &
-          set_sw_spectral_boundaries, &
-          set_lw_spectral_boundaries, &
           get_sw_spectral_boundaries, &
           get_lw_spectral_boundaries, &
           get_sw_spectral_midpoints, &
@@ -180,28 +205,6 @@ subroutine get_number_sw_bands(number_of_bands)
    number_of_bands = nswbands
 
 end subroutine get_number_sw_bands
-
-!------------------------------------------------------------------------------
-
-subroutine set_sw_spectral_boundaries(wavenum_bnds)
-   real(r8), intent(in), dimension(:,:) :: wavenum_bnds
-   integer :: ibnd
-   do ibnd = 1,nswbands
-      wavenum_sw_lower(ibnd) = wavenum_bnds(1,ibnd)
-      wavenum_sw_upper(ibnd) = wavenum_bnds(2,ibnd)
-   end do
-end subroutine
-
-!------------------------------------------------------------------------------
-
-subroutine set_lw_spectral_boundaries(wavenum_bnds)
-   real(r8), intent(in), dimension(:,:) :: wavenum_bnds
-   integer :: ibnd
-   do ibnd = 1,nlwbands
-      wavenum_lw_lower(ibnd) = wavenum_bnds(1,ibnd)
-      wavenum_lw_upper(ibnd) = wavenum_bnds(2,ibnd)
-   end do
-end subroutine
 
 !------------------------------------------------------------------------------
 

--- a/components/cam/src/physics/rrtmgp/radconstants.F90
+++ b/components/cam/src/physics/rrtmgp/radconstants.F90
@@ -40,12 +40,6 @@ integer, parameter, public :: nlwbands = 16
 ! properties are output before bands are reordered to the expected RRTMGP order.
 ! Optical properties should be reordered to RRTMGP order in the RRTMGP driver
 ! interface codes.
-!real(r8) :: wavenum_sw_lower(nswbands) = & ! in cm^-1
-!  (/ 820._r8, 2680._r8, 3250._r8, 4000._r8, 4650._r8, 5150._r8, 6150._r8, &
-!    7700._r8, 8050._r8,12850._r8,16000._r8,22650._r8,29000._r8,38000._r8/)
-!real(r8) :: wavenum_sw_upper(nswbands) = & ! in cm^-1
-!  (/2680._r8, 3250._r8, 4000._r8, 4650._r8, 5150._r8, 6150._r8, 7700._r8, &
-!    8050._r8,12850._r8,16000._r8,22650._r8,29000._r8,38000._r8,50000._r8/)
 real(r8), parameter :: wavenum_sw_lower(nswbands) = & ! in cm^-1
   (/2600._r8, 3250._r8, 4000._r8, 4650._r8, 5150._r8, 6150._r8, 7700._r8, &
     8050._r8,12850._r8,16000._r8,22650._r8,29000._r8,38000._r8,  820._r8/)
@@ -75,11 +69,6 @@ real(r8), parameter :: solar_ref_band_irradiance(nswbands) = &
    129.49_r8,  50.15_r8,   3.08_r8 &
    /)
 
-! These are indices to the band for diagnostic output
-!integer, parameter, public :: idx_sw_diag = 11 ! index to sw visible band (550 nm)
-!integer, parameter, public :: idx_nir_diag = 9 ! index to sw near infrared (778-1240 nm) band
-!integer, parameter, public :: idx_uv_diag = 12 ! index to sw uv (345-441 nm) band
-!integer, parameter, public :: rrtmg_sw_cloudsim_band = 10  ! rrtmg band for .67 micron
 ! These are indices to the band for diagnostic output
 ! NOTE: these are consistent with the RRTMG optical property input data, NOT the
 ! RRTMGP absorption coefficient data. This is because optical property

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -19,8 +19,8 @@ module radiation
    use rad_constituents, only: N_DIAG
    use radconstants,     only: nswbands, nlwbands, &
       get_band_index_sw, get_band_index_lw, test_get_band_index, &
-      set_sw_spectral_boundaries, set_lw_spectral_boundaries, &
-      get_sw_spectral_midpoints, get_lw_spectral_midpoints
+      get_sw_spectral_midpoints, get_lw_spectral_midpoints, &
+      rrtmg_to_rrtmgp_swbands
 
    ! RRTMGP gas optics object to store coefficient information. This is imported
    ! here so that we can make the k_dist objects module data and only load them
@@ -497,10 +497,6 @@ contains
       ! Number of gpoints depend on inputdata, so initialize here
       nswgpts = k_dist_sw%get_ngpt()
       nlwgpts = k_dist_lw%get_ngpt()
-
-      ! Set band intervals based on inputdata
-      call set_sw_spectral_boundaries(k_dist_sw%get_band_lims_wavenumber())
-      call set_lw_spectral_boundaries(k_dist_lw%get_band_lims_wavenumber())
 
       ! Set number of levels used in radiation calculations
 #ifdef NO_EXTRA_RAD_LEVEL
@@ -1160,6 +1156,8 @@ contains
       integer :: icall
       logical :: active_calls(0:N_DIAG)
 
+      integer :: icol, ilay
+
       ! Everyone needs a name
       character(*), parameter :: subname = 'radiation_tend'
 
@@ -1263,13 +1261,29 @@ contains
             cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw, &
             liq_tau_bnd_sw, ice_tau_bnd_sw, snw_tau_bnd_sw &
          )
+         ! Output the band-by-band cloud optics BEFORE we reorder bands, because
+         ! we hard-coded the indices for diagnostic bands in radconstants.F90 to
+         ! correspond to the optical property look-up tables.
+         call output_cloud_optics_sw(state, cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw)
+         ! Now reorder bands to be consistent with RRTMGP
+         ! We need to fix band ordering because the old input files assume RRTMG
+         ! band ordering, but this has changed in RRTMGP.
+         ! TODO: fix the input files themselves!
+         do icol = 1,size(cld_tau_bnd_sw,1)
+            do ilay = 1,size(cld_tau_bnd_sw,2)
+               cld_tau_bnd_sw(icol,ilay,:) = reordered(cld_tau_bnd_sw(icol,ilay,:), rrtmg_to_rrtmgp_swbands)
+               cld_ssa_bnd_sw(icol,ilay,:) = reordered(cld_ssa_bnd_sw(icol,ilay,:), rrtmg_to_rrtmgp_swbands)
+               cld_asm_bnd_sw(icol,ilay,:) = reordered(cld_asm_bnd_sw(icol,ilay,:), rrtmg_to_rrtmgp_swbands)
+            end do
+         end do
+         ! And now do the MCICA sampling to get cloud optical properties by
+         ! gpoint/cloud state
          call sample_cloud_optics_sw( &
             ncol, pver, nswgpts, k_dist_sw%get_gpoint_bands(), &
             state%pmid, cld, cldfsnow, &
             cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw, &
             cld_tau_gpt_sw, cld_ssa_gpt_sw, cld_asm_gpt_sw &
          )
-         call output_cloud_optics_sw(state, cld_tau_bnd_sw, cld_ssa_bnd_sw, cld_asm_bnd_sw)
          call t_stopf('rad_cld_optics_sw')
 
          ! Aerosol needs night indices
@@ -1298,6 +1312,15 @@ contains
                      is_cmip6_volc, &
                      aer_tau_bnd_sw, aer_ssa_bnd_sw, aer_asm_bnd_sw &
                   )
+                  ! Now reorder bands to be consistent with RRTMGP
+                  ! TODO: fix the input files themselves!
+                  do icol = 1,size(aer_tau_bnd_sw,1)
+                     do ilay = 1,size(aer_tau_bnd_sw,2)
+                        aer_tau_bnd_sw(icol,ilay,:) = reordered(aer_tau_bnd_sw(icol,ilay,:), rrtmg_to_rrtmgp_swbands)
+                        aer_ssa_bnd_sw(icol,ilay,:) = reordered(aer_ssa_bnd_sw(icol,ilay,:), rrtmg_to_rrtmgp_swbands)
+                        aer_asm_bnd_sw(icol,ilay,:) = reordered(aer_asm_bnd_sw(icol,ilay,:), rrtmg_to_rrtmgp_swbands)
+                     end do
+                  end do
                   call t_stopf('rad_aer_optics_sw')
                else
                   aer_tau_bnd_sw = 0
@@ -1716,6 +1739,31 @@ contains
 
    !----------------------------------------------------------------------------
 
+   ! Utility function to reorder an array given a new indexing
+   function reordered(array_in, new_indexing) result(array_out)
+
+      ! Inputs
+      real(r8), intent(in) :: array_in(:)
+      integer, intent(in) :: new_indexing(:)
+
+      ! Output, reordered array
+      real(r8), dimension(size(array_in)) :: array_out
+
+      ! Loop index
+      integer :: ii
+
+      ! Check inputs
+      call assert(size(array_in) == size(new_indexing), 'reorder_array: sizes inconsistent')
+
+      ! Reorder array based on input index mapping, which maps old indices to new
+      do ii = 1,size(new_indexing)
+         array_out(ii) = array_in(new_indexing(ii))
+      end do
+
+   end function reordered
+
+   !----------------------------------------------------------------------------
+
    subroutine output_cloud_optics_sw(state, tau, ssa, asm)
       use ppgrid, only: pver
       use physics_types, only: physics_state
@@ -1725,6 +1773,7 @@ contains
       type(physics_state), intent(in) :: state
       real(r8), intent(in), dimension(:,:,:) :: tau, ssa, asm
       character(len=*), parameter :: subname = 'output_cloud_optics_sw'
+      integer :: sw_band_index
 
       ! Check values
       call assert_valid(tau(1:state%ncol,1:pver,1:nswbands), &
@@ -1744,8 +1793,9 @@ contains
       call outfld('CLOUD_G_SW', &
                   asm(1:state%ncol,1:pver,1:nswbands), &
                   state%ncol, state%lchnk)
+      sw_band_index = get_band_index_sw(550._r8, 'nm')
       call outfld('TOT_ICLD_VISTAU', &
-                  tau(1:state%ncol,1:pver,idx_sw_diag), &
+                  tau(1:state%ncol,1:pver,sw_band_index), &
                   state%ncol, state%lchnk)
    end subroutine output_cloud_optics_sw
 

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -1629,6 +1629,7 @@ contains
          name='shortwave aerosol optics' &
       ))
 
+      ! Populate aerosol optics (and compress to daytime only)
       if (do_aerosol_rad) then
          aer_optics_sw%tau = 0
          aer_optics_sw%ssa = 1
@@ -1642,6 +1643,8 @@ contains
             aer_optics_sw%ssa(1:nday,2:nlev_rad,:), &
             aer_optics_sw%g  (1:nday,2:nlev_rad,:)  &
          )
+         ! Apply delta scaling to account for forward-scattering
+         call handle_error(aer_optics_sw%delta_scale())
       else
          aer_optics_sw%tau(:,:,:) = 0
          aer_optics_sw%ssa(:,:,:) = 0
@@ -1843,6 +1846,8 @@ contains
          call t_startf('rad_aer_optics_lw')
          aer_optics_lw%tau(:,:,:) = 0
          aer_optics_lw%tau(1:ncol,ktop:kbot,1:nlwbands) = aer_tau_bnd(1:ncol,1:pver,1:nlwbands)
+         ! Apply delta scaling to account for forward-scattering
+         call handle_error(aer_optics_lw%delta_scale())
          call t_stopf('rad_aer_optics_lw')
       else
          aer_optics_lw%tau(:,:,:) = 0


### PR DESCRIPTION
Fix missing delta-scaling calculation in aerosol optical depth that is input to RRTMGP, and fix band indices used for diagnostic aerosol optical property outputs. The delta-scaling calculation accounts for forward scattering from aerosol in the shortwave flux computations, and *does* affect the climate (to the tune of ~0.12 W/m^2 net TOA flux in a 10 year AMIP-style run at ne30). Omission of this calculation was simply an oversight. The diagnostic band bug arose because RRTMG and RRTMGP have different band ordering, and in order to continue using the existing RRTMG optical property look-up tables, we simply re-order the spectral dimension after computing the optics using the old look-up tables. However, the output of the aerosol optical properties happens in some routines buried a few levels down in the aerosol optics code, which happened before we had a chance to re-order the spectral dimension, so the diagnostic band indices we were using (which were setup to be consistent with the new RRTMGP band ordering) were inconsistent with the order of the optical properties at this point in the code, so we were outputting the wrong bands. In order to fix this, we now assume the RRTMG band ordering throughout the E3SM side of the code, and only re-order at the last moment (after all diagnostic outputs have finished). The band index fix is actually BFB, other than for the purely diagnostic aerosol optical property outputs (such as AODVIS, the 500 nm wavelength aerosol optical depth). The first fix brings the net TOA flux into closer agreement with RRTMG, although differences are still expected due to differences in the solar spectral flux and differences in atmospheric absorption. The second fix brings the visible wavelength optical depth into much better agreement with RRTMG as well. @yfenganl has documented the effects of these changes on Confluence [here](https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/1659240982/20200701.v1like-fixer2.F2010.ne30pg2+r05+oECv3.compy). Will affect any atmosphere configuration using RRTMGP, including those using MMF. Expected diffs:

ERS_Ld5.ne4_ne4.FC5AV1C-L.cam-rrtmgp
ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1.cam-crmout

[non-BFB]