### PR TITLE
remove sub-optimal IMEX methods

### DIFF
--- a/components/homme/test/reg_test/namelists/thetanh-TC-nudiv.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-TC-nudiv.nl
@@ -14,7 +14,7 @@
   runtype           = 0                         ! 0 => new run
   tstep             = 450                      ! largest timestep in seconds
   integration       = 'explicit'                ! explicit time integration
-  tstep_type        = 7
+  tstep_type        = 9
   rsplit            = 2
   qsplit            = 2
   nu                = 3e16                      ! default= 1e15*(ne30/ne8)**3.2 = 6.9e16

--- a/components/homme/test/reg_test/namelists/thetanh-TC-nutop.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-TC-nutop.nl
@@ -14,7 +14,7 @@
   runtype           = 0                         ! 0 => new run
   tstep             = 450                      ! largest timestep in seconds
   integration       = 'explicit'                ! explicit time integration
-  tstep_type        = 7
+  tstep_type        = 9
   rsplit            = 2
   qsplit            = 2
   nu                = 3e16                      ! default= 1e15*(ne30/ne8)**3.2 = 6.9e16

--- a/components/homme/test/reg_test/namelists/thetanh-TC.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-TC.nl
@@ -14,7 +14,7 @@
   runtype           = 0                         ! 0 => new run
   tstep             = 450                      ! largest timestep in seconds
   integration       = 'explicit'                ! explicit time integration
-  tstep_type        = 7
+  tstep_type        = 9
   rsplit            = 2
   qsplit            = 2
   nu                = 3e16                      ! default= 1e15*(ne30/ne8)**3.2 = 6.9e16

--- a/components/homme/test/reg_test/namelists/thetanh-c-TC.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-c-TC.nl
@@ -14,7 +14,7 @@
   runtype           = 0                         ! 0 => new run
   tstep             = 450                      ! largest timestep in seconds
   integration       = 'explicit'                ! explicit time integration
-  tstep_type        = 7
+  tstep_type        = 9
   rsplit            = 1
   qsplit            = 2
   nu                = 3e16                      ! default= 1e15*(ne30/ne8)**3.2 = 6.9e16

--- a/components/homme/test/reg_test/namelists/thetanhwet-TC.nl
+++ b/components/homme/test/reg_test/namelists/thetanhwet-TC.nl
@@ -14,7 +14,7 @@
   runtype           = 0                         ! 0 => new run
   tstep             = 450                      ! largest timestep in seconds
   integration       = 'explicit'                ! explicit time integration
-  tstep_type        = 7
+  tstep_type        = 9
   rsplit            = 2
   qsplit            = 2
   nu                = 3e16                      ! default= 1e15*(ne30/ne8)**3.2 = 6.9e16


### PR DESCRIPTION
Remove sub-optimal IMEX methods:
    
    remove tstep_type=7
    remove tstep_type=10
    replace tstep_type7 with KG52 + BE version (1st order, not recommended
    but with maximal stability and useful for testing)
    
    changed NH regression tests to use tstep_type=9

[BFB] except for HOMME NH tests and eam_theta NH tests

Note: this is a branch from PR #3666.   this PR should be reviewed after #3666 is merged 

