### PR TITLE
Allow MOSART to read/write in unstructured grid format

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -36,6 +36,7 @@ _TESTS = {
             "SMS_Ly2_P1x1.1x1_smallvilleIA.ICLM45CNCROP.clm-lulcc_sville",
             "ERS.r05_r05.RMOSGPCC.mosart-gpcc_1972",
             "ERS.MOS_USRDAT.RMOSGPCC.mosart-mos_usrdat",
+            "SMS.MOS_USRDAT.RMOSGPCC.mosart-unstructure",
             )
         },
 

--- a/components/mosart/cime_config/testdefs/testmods_dirs/mosart/unstructure/shell_commands
+++ b/components/mosart/cime_config/testdefs/testmods_dirs/mosart/unstructure/shell_commands
@@ -1,0 +1,6 @@
+./xmlchange LND_DOMAIN_FILE=domain.lnd.r05_oEC60to30v3.190418.nc
+./xmlchange ATM_DOMAIN_FILE=domain.lnd.r05_oEC60to30v3.190418.nc
+./xmlchange LND_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains"
+./xmlchange ATM_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains"
+./xmlchange DATM_CLMNCEP_YR_START=1972
+./xmlchange DATM_CLMNCEP_YR_END=1972

--- a/components/mosart/cime_config/testdefs/testmods_dirs/mosart/unstructure/user_nl_mosart
+++ b/components/mosart/cime_config/testdefs/testmods_dirs/mosart/unstructure/user_nl_mosart
@@ -1,2 +1,3 @@
 frivinp_rtm = '$DIN_LOC_ROOT/rof/mosart/MOSART_Global_half_unstructured_c200728.nc'
-
+inundflag = .true.
+opt_elevprof = 1

--- a/components/mosart/cime_config/testdefs/testmods_dirs/mosart/unstructure/user_nl_mosart
+++ b/components/mosart/cime_config/testdefs/testmods_dirs/mosart/unstructure/user_nl_mosart
@@ -1,0 +1,2 @@
+frivinp_rtm = '$DIN_LOC_ROOT/rof/mosart/MOSART_Global_half_unstructured_c200728.nc'
+

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -4084,6 +4084,7 @@ contains
     enddo
 
     deallocate(ele)
+    call pio_freedecomp(ncid, iodesc)
 
   end subroutine read_elevation_profile
 

--- a/components/mosart/src/riverroute/RtmVar.F90
+++ b/components/mosart/src/riverroute/RtmVar.F90
@@ -60,6 +60,7 @@ module RtmVar
   ! Rtm grid size
   integer :: rtmlon = 1 ! number of rtm longitudes (initialize)
   integer :: rtmlat = 1 ! number of rtm latitudes  (initialize)
+  logical :: isgrid2d = .true. ! Determine if the inputs are 1d or 2d
 
   character(len=256), public :: rpntfil = 'rpointer.rof' ! file name for local restart pointer file
 


### PR DESCRIPTION
Following changes are made:

1. If there are lat/lon dimensions in the input file, MOSART will read/write in a structured grid format. If the dimension is `gridcell`, MOSART will read/write in an unstructured grid format.

2. Put elevation profiles into one input variable.

3. Adds a test of MOSART for an unstructured global domain. 

[BFB]