### PR TITLE
FATES API 13

### DIFF
--- a/components/clm/bld/CLMBuildNamelist.pm
+++ b/components/clm/bld/CLMBuildNamelist.pm
@@ -791,9 +791,9 @@ sub setup_cmdl_fates_mode {
 
       # The following variables may be set by the user and are compatible with use_fates
       # no need to set defaults, covered in a different routine
-      my @list  = (  "use_fates_spitfire", "use_vertsoilc", "use_century_decomp",
+      my @list  = (  "fates_spitfire_mode", "use_vertsoilc", "use_century_decomp",
                      "use_fates_planthydro", "use_fates_ed_st3", "use_fates_ed_prescribed_phys", 
-		     "use_fates_inventory_init", "fates_inventory_ctrl_filename","use_fates_logging",
+		     "use_fates_inventory_init", "use_fates_fixed_biogeog", "fates_inventory_ctrl_filename","use_fates_logging",
 		     "use_fates_parteh_mode","use_fates_cohort_age_tracking");
       foreach my $var ( @list ) {
 	  if ( defined($nl->get_value($var))  ) {
@@ -813,11 +813,15 @@ sub setup_cmdl_fates_mode {
 
     } else {
 	# we only dis-allow ed_spitfire with non-ed runs
-       $var = "use_fates_spitfire";
+       $var = "fates_spitfire_mode";
        if ( defined($nl->get_value($var)) ) {
            fatal_error("$var is being set, but can ONLY be set when -bgc ed option is used.\n");
        }
        $var = "use_fates_cohort_age_tracking";
+       if ( defined($nl->get_value($var)) ) {
+           fatal_error("$var is being set, but can ONLY be set when -bgc ed option is used.\n");
+       }
+	   $var = "use_fates_fixed_biogeog";
        if ( defined($nl->get_value($var)) ) {
            fatal_error("$var is being set, but can ONLY be set when -bgc ed option is used.\n");
        }
@@ -3361,7 +3365,8 @@ sub setup_logic_fates {
     my ($test_files, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
 
     if ($physv->as_long() >= $physv->as_long("clm4_5") && value_is_true( $nl_flags->{'use_fates'})  ) {
- 	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_spitfire', 'use_fates'=>$nl_flags->{'use_fates'} );
+ 	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fates_spitfire_mode',          'use_fates'=>$nl_flags->{'use_fates'} );
+	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_fixed_biogeog',      'use_fates'=>$nl_flags->{'use_fates'} );
 	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_logging',            'use_fates'=>$nl_flags->{'use_fates'});
 	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_planthydro',         'use_fates'=>$nl_flags->{'use_fates'});
 	add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fates_parteh_mode',            'use_fates'=>$nl_flags->{'use_fates'});

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -111,7 +111,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
-<fates_paramfile >lnd/clm2/paramdata/fates_params_default_12pft_api10.c200501.nc</fates_paramfile>
+<fates_paramfile >lnd/clm2/paramdata/fates_params_default_12pft_api13.c200731.nc</fates_paramfile>
 
 
 <!-- soil order related parameters (relative to {csmdata}) -->

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -1776,7 +1776,8 @@ this mask will have smb calculated over the entire global land surface
 <!-- =========================================  -->
 <!-- Defaults for FATES interface -->
 <!-- =========================================  -->
-<use_fates_spitfire            use_fates=".true.">.false.</use_fates_spitfire>
+<fates_spitfire_mode           use_fates=".true.">0</fates_spitfire_mode>
+<use_fates_fixed_biogeog       use_fates=".true.">.false.</use_fates_fixed_biogeog>
 <use_fates_planthydro          use_fates=".true.">.false.</use_fates_planthydro>
 <use_fates_ed_st3              use_fates=".true.">.false.</use_fates_ed_st3>
 <use_fates_ed_prescribed_phys  use_fates=".true.">.false.</use_fates_ed_prescribed_phys>

--- a/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -297,16 +297,20 @@ Toggle to turn on the FATES
 (ED = 'on' is EXPERIMENTAL NOT SUPPORTED!)
 </entry>
 
-<entry id="use_fates_spitfire" type="logical" category="physics"
-        group="clm_inparm" valid_values="" value=".false.">
-Toggle to turn on spitfire (only relevant if FATES is being used).
+<entry id="fates_spitfire_mode" type="integer" category="physics"
+        group="clm_inparm" valid_values="0,1" >
+Set to 0 to keep fire off. Set to 1 to turn on fates spitfire module (only relevant if FATES is being used).
 </entry>
 
 <entry id="fates_parteh_mode" type="integer" category="physics"
-       group="clm_inparm" valid_values="">
+       group="clm_inparm" valid_values="1">
 Switch deciding which nutrient model to use in FATES.
 </entry>
 
+<entry id="use_fates_fixed_biogeog" type="logical" category="physics"
+        group="clm_inparm" valid_values=".false." value=".false."> 
+Toggle to turn on FATES fixed biogeography mode (STUB ONLY, MUST BE FALSE).
+</entry>
 
 <entry id="use_fates_logging" type="logical" category="physics"
         group="clm_inparm" valid_values="" value=".false.">

--- a/components/clm/bld/unit_testers/build-namelist_test.pl
+++ b/components/clm/bld/unit_testers/build-namelist_test.pl
@@ -523,7 +523,7 @@ my %failtest = (
                                      conopts=>"-phys clm4_0",
                                    },
      "usespitfireButNOTED"       =>{ options=>"-envxml_dir .",
-                                     namelst=>"use_fates_spitfire=.true.",
+                                     namelst=>"fates_spitfire_mode>0",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      conopts=>"-phys clm4_5",
                                    },

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/fates/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/fates/user_nl_clm
@@ -3,7 +3,7 @@ finidat           = ''
 hist_mfilt        = 365
 hist_nhtfrq       = -24
 hist_empty_htapes = .true.
-use_fates_spitfire = .true.
+fates_spitfire_mode = 1
 hist_fincl1       = 'NPP','GPP','BTRAN','H2OSOI','TLAI','LITTER_IN_ELEM','LITTER_OUT_ELEM',
    'FIRE_AREA','SCORCH_HEIGHT','FIRE_INTENSITY','FIRE_TFC_ROS','FIRE_FUEL_MEF',
    'FIRE_FUEL_BULKD','FIRE_FUEL_SAV','FIRE_NESTEROV_INDEX','PFTbiomass',

--- a/components/clm/cime_config/testdefs/testmods_dirs/clm/fateshydro/user_nl_clm
+++ b/components/clm/cime_config/testdefs/testmods_dirs/clm/fateshydro/user_nl_clm
@@ -4,7 +4,7 @@ hist_mfilt        = 365
 hist_nhtfrq       = -24
 hist_empty_htapes = .true.
 use_fates_planthydro = .true.
-use_fates_spitfire = .true.
+fates_spitfire_mode = 1
 hist_fincl1       = 'NPP','GPP','BTRAN','H2OSOI','TLAI','LITTER_IN_ELEM','LITTER_OUT_ELEM',
    'FIRE_AREA','SCORCH_HEIGHT','FIRE_INTENSITY','FIRE_TFC_ROS','FIRE_FUEL_MEF',
    'FIRE_FUEL_BULKD','FIRE_FUEL_SAV','FIRE_NESTEROV_INDEX','PFTbiomass',

--- a/components/clm/src/dyn_subgrid/dynHarvestMod.F90
+++ b/components/clm/src/dyn_subgrid/dynHarvestMod.F90
@@ -53,8 +53,8 @@ module dynHarvestMod
   type(dyn_file_type), target :: dynHarvest_file ! information for the file containing harvest data
 
   ! Define the underlying harvest variables
-  integer, parameter :: num_harvest_vars = 5
-  character(len=64), parameter :: harvest_varnames(num_harvest_vars) = &
+  integer, public, parameter :: num_harvest_vars = 5
+  character(len=64), public, parameter :: harvest_varnames(num_harvest_vars) = &
        [character(len=64) :: 'HARVEST_VH1', 'HARVEST_VH2', 'HARVEST_SH1', 'HARVEST_SH2', 'HARVEST_SH3']
   
   type(dyn_var_time_uninterp_type) :: harvest_vars(num_harvest_vars)   ! value of each harvest variable

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -213,7 +213,9 @@ module clm_varctl
   !----------------------------------------------------------
 
   logical, public            :: use_fates = .false.              ! true => use  ED
-  logical, public            :: use_fates_spitfire = .false.  ! true => use spitfire model
+  integer, public            :: fates_spitfire_mode = 0                ! 0 for no fire; 1 for constant ignitions
+  logical, public            :: use_fates_fixed_biogeog = .false.           ! true => use fixed biogeography mode
+  logical, public            :: use_fates_spitfire = .false.           ! true => use spitfire model
   logical, public            :: use_fates_logging = .false.            ! true => turn on logging module
   logical, public            :: use_fates_planthydro = .false.         ! true => turn on fates hydro
   logical, public            :: use_fates_cohort_age_tracking = .false. ! true => turn on cohort age tracking

--- a/components/clm/src/main/clm_varctl.F90
+++ b/components/clm/src/main/clm_varctl.F90
@@ -215,7 +215,6 @@ module clm_varctl
   logical, public            :: use_fates = .false.              ! true => use  ED
   integer, public            :: fates_spitfire_mode = 0                ! 0 for no fire; 1 for constant ignitions
   logical, public            :: use_fates_fixed_biogeog = .false.           ! true => use fixed biogeography mode
-  logical, public            :: use_fates_spitfire = .false.           ! true => use spitfire model
   logical, public            :: use_fates_logging = .false.            ! true => turn on logging module
   logical, public            :: use_fates_planthydro = .false.         ! true => turn on fates hydro
   logical, public            :: use_fates_cohort_age_tracking = .false. ! true => turn on cohort age tracking

--- a/components/clm/src/main/clmfates_interfaceMod.F90
+++ b/components/clm/src/main/clmfates_interfaceMod.F90
@@ -1319,6 +1319,9 @@ contains
      integer :: s
      integer :: c
 
+     ! Set the FATES global time and date variables
+     call GetAndSetTime
+     
      nclumps = get_proc_clumps()
 
      !$OMP PARALLEL DO PRIVATE (nc,bounds_clump,s,c,j,vol_ice,eff_porosity)

--- a/components/clm/src/main/clmfates_interfaceMod.F90
+++ b/components/clm/src/main/clmfates_interfaceMod.F90
@@ -211,6 +211,12 @@ module CLMFatesInterfaceMod
    ! developer will at least question its usage (RGK)
    private :: hlm_bounds_to_fates_bounds
 
+   ! The GetAndSetTime function is used to get the current time from the CLM 
+   ! time procedures and then set to the fates global time variables during restart, 
+   ! init_coldstart, and dynamics_driv function calls
+   private :: GetAndSetTime
+
+   
    logical :: debug  = .false.
 
    character(len=*), parameter, private :: sourcefile = &
@@ -680,21 +686,8 @@ contains
       integer  :: ifp                      ! patch index
       integer  :: p                        ! HLM patch index
       integer  :: nc                       ! clump index
-      integer  :: yr                       ! year (0, ...)
-      integer  :: mon                      ! month (1, ..., 12)
-      integer  :: day                      ! day of month (1, ..., 31)
-      integer  :: sec                      ! seconds of the day
       integer  :: nlevsoil                 ! number of soil layers at the site
-      integer  :: current_year             
-      integer  :: current_month
-      integer  :: current_day
-      integer  :: current_tod
-      integer  :: current_date
-      integer  :: jan01_curr_year
-      integer  :: reference_date
-      integer  :: days_per_year
-      real(r8) :: model_day
-      real(r8) :: day_of_year
+
       !-----------------------------------------------------------------------
 
       nc = bounds_clump%clump_index
@@ -708,23 +701,8 @@ contains
       ! and it keeps all the boundaries in one location
       ! ---------------------------------------------------------------------------------
 
-      days_per_year = get_days_per_year()
-      call get_curr_date(current_year,current_month,current_day,current_tod)
-      current_date = current_year*10000 + current_month*100 + current_day
-      jan01_curr_year = current_year*10000 + 100 + 1
-
-      call get_ref_date(yr, mon, day, sec)
-      reference_date = yr*10000 + mon*100 + day
-
-      call timemgr_datediff(reference_date, sec, current_date, current_tod, model_day)
-
-      call timemgr_datediff(jan01_curr_year,0,current_date,sec,day_of_year)
-      
-      call SetFatesTime(current_year, current_month, &
-                        current_day, current_tod, &
-                        current_date, reference_date, &
-                        model_day, floor(day_of_year), &
-                        days_per_year, 1.0_r8/dble(days_per_year))
+      ! Set the FATES global time and date variables
+      call GetAndSetTime
 
 
       do s=1,this%fates(nc)%nsites
@@ -1093,6 +1071,9 @@ contains
       ! I think that is it...
       ! ---------------------------------------------------------------------------------
 
+      ! Set the FATES global time and date variables
+      call GetAndSetTime
+      
       if(.not.initialized) then
 
          initialized=.true.
@@ -2573,4 +2554,63 @@ contains
    
  end subroutine hlm_bounds_to_fates_bounds
 
+! ======================================================================================
+
+ subroutine GetAndSetTime()
+
+   ! CLM MODULES
+   use clm_time_manager  , only : get_days_per_year, &
+                                  get_curr_date,     &
+                                  get_ref_date,      &
+                                  timemgr_datediff
+
+   ! FATES MODULES
+   use FatesInterfaceMod     , only : SetFatesTime
+
+   ! LOCAL VARIABLES
+   integer  :: yr                       ! year (0, ...)
+   integer  :: mon                      ! month (1, ..., 12)
+   integer  :: day                      ! day of month (1, ..., 31)
+   integer  :: sec                      ! seconds of the day
+   integer  :: current_year             
+   integer  :: current_month
+   integer  :: current_day
+   integer  :: current_tod
+   integer  :: current_date
+   integer  :: jan01_curr_year
+   integer  :: reference_date
+   integer  :: days_per_year
+   real(r8) :: model_day
+   real(r8) :: day_of_year
+
+   
+   ! Get the current date and determine the set the start of the current year
+   call get_curr_date(current_year,current_month,current_day,current_tod)
+   current_date = current_year*10000 + current_month*100 + current_day
+   jan01_curr_year = current_year*10000 + 100 + 1
+
+   ! Get the reference date components and compute the date
+   call get_ref_date(yr, mon, day, sec)
+   reference_date = yr*10000 + mon*100 + day
+
+   ! Get the defined number of days per year 
+   days_per_year = get_days_per_year()
+
+   ! Determine the model day
+   call timemgr_datediff(reference_date, sec, current_date, current_tod, model_day)
+
+   ! Determine the current DOY
+   call timemgr_datediff(jan01_curr_year,0,current_date,sec,day_of_year)
+   
+   ! Set the FATES global time variables
+   call SetFatesTime(current_year, current_month, &
+                     current_day, current_tod, &
+                     current_date, reference_date, &
+                     model_day, floor(day_of_year), &
+                     days_per_year, 1.0_r8/dble(days_per_year))
+
+ end subroutine GetAndSetTime
+
+
+ 
 end module CLMFatesInterfaceMod

--- a/components/clm/src/main/controlMod.F90
+++ b/components/clm/src/main/controlMod.F90
@@ -241,12 +241,13 @@ contains
     namelist /clm_inparm / use_c13, use_c14
 
     namelist /clm_inparm/ fates_paramfile, use_fates,      &
-          use_fates_spitfire, use_fates_logging,        &
+          fates_spitfire_mode, use_fates_logging,        &
           use_fates_planthydro, use_fates_ed_st3,       &
           use_fates_cohort_age_tracking,                &
           use_fates_ed_prescribed_phys,                 &
           use_fates_inventory_init,                     &
           fates_inventory_ctrl_filename,                &
+          use_fates_fixed_biogeog, &
           fates_parteh_mode
 
     namelist /clm_inparm / use_betr
@@ -676,12 +677,13 @@ contains
     call mpi_bcast (use_c14, 1, MPI_LOGICAL, 0, mpicom, ier)
 
     call mpi_bcast (use_fates, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (use_fates_spitfire, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (fates_spitfire_mode, 1, MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (fates_paramfile, len(fates_paramfile) , MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (use_fates_logging, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_fates_planthydro, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_fates_cohort_age_tracking, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_fates_ed_st3, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (use_fates_fixed_biogeog, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_fates_ed_prescribed_phys,  1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_fates_inventory_init, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (fates_inventory_ctrl_filename, len(fates_inventory_ctrl_filename), &
@@ -1042,7 +1044,7 @@ contains
     ! FATES
     write(iulog, *) '    use_fates = ', use_fates
     if (use_fates) then
-       write(iulog, *) '    use_fates_spitfire = ', use_fates_spitfire
+       write(iulog, *) '    fates_spitfire_mode = ', fates_spitfire_mode
        write(iulog, *) '    use_fates_logging = ', use_fates_logging
        write(iulog, *) '    fates_paramfile = ', fates_paramfile
        write(iulog, *) '    use_fates_planthydro = ', use_fates_planthydro
@@ -1051,6 +1053,7 @@ contains
        write(iulog, *) '    use_fates_ed_st3 = ',use_fates_ed_st3
        write(iulog, *) '    use_fates_ed_prescribed_phys = ',use_fates_ed_prescribed_phys
        write(iulog, *) '    use_fates_inventory_init = ',use_fates_inventory_init
+       write(iulog, *) '    use_fates_fixed_biogeog = ', use_fates_fixed_biogeog
        write(iulog, *) '    fates_inventory_ctrl_filename = ',fates_inventory_ctrl_filename
     end if
 


### PR DESCRIPTION
This set of changes updates E3SM compatibility with FATES API 13. 
Noteable changes are interface hooks for fixed biogreography, external 
lightning datasets and land-use datasets. The first two interface changes
 are just hooks, and will forgo functionality until work is allocated to do so. 
The land-use dataset read functionality is forthcoming.

[non-BFB]