### PR TITLE
MPAS-Ocean: GM fixes

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -566,7 +566,6 @@ add_default($nl, 'config_GM_kappa');
 add_default($nl, 'config_GM_closure');
 add_default($nl, 'config_GM_baroclinic_mode');
 add_default($nl, 'config_GM_visbeck_alpha');
-add_default($nl, 'config_GM_visbeck_min_depth');
 add_default($nl, 'config_GM_visbeck_max_depth');
 add_default($nl, 'config_GM_visbeck_min_kappa');
 add_default($nl, 'config_GM_visbeck_max_kappa');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -107,7 +107,6 @@ add_default($nl, 'config_GM_kappa');
 add_default($nl, 'config_GM_closure');
 add_default($nl, 'config_GM_baroclinic_mode');
 add_default($nl, 'config_GM_visbeck_alpha');
-add_default($nl, 'config_GM_visbeck_min_depth');
 add_default($nl, 'config_GM_visbeck_max_depth');
 add_default($nl, 'config_GM_visbeck_min_kappa');
 add_default($nl, 'config_GM_visbeck_max_kappa');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -146,7 +146,6 @@
 <config_GM_closure>'visbeck'</config_GM_closure>
 <config_GM_baroclinic_mode>3.0</config_GM_baroclinic_mode>
 <config_GM_visbeck_alpha>0.13</config_GM_visbeck_alpha>
-<config_GM_visbeck_min_depth>50.0</config_GM_visbeck_min_depth>
 <config_GM_visbeck_max_depth>1000.0</config_GM_visbeck_max_depth>
 <config_GM_visbeck_min_kappa>300.0</config_GM_visbeck_min_kappa>
 <config_GM_visbeck_max_kappa>1200.0</config_GM_visbeck_max_kappa>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -474,14 +474,6 @@ Valid values: small positive numbers
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_GM_visbeck_min_depth" type="real"
-	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
-minimum depth for calculation of vertical average
-
-Valid values: values between zero and bottom depth
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_GM_visbeck_max_depth" type="real"
 	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
 minimum depth for calculation of vertical average


### PR DESCRIPTION
See https://github.com/MPAS-Dev/MPAS-Model/pull/643

Integrals for computing GM kappa and the phase speed have been reworked to mitigate failures in ISMF simulations without redi. With this PR all configurations of GM work and the old 3DGM (N2_dependent) is recoverable to its original configuration.

This PR will be non BFB in WC and Cryo configs.

fixes #3719

[non-BFB]
[NML]