### PR TITLE
Enable DCAPE or ULL to be used alone

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1382,6 +1382,8 @@
 
 <zmconv_trigmem                                                       >.false. </zmconv_trigmem>
 <zmconv_trigdcape_ull                                                 >.false. </zmconv_trigdcape_ull>
+<zmconv_trig_dcape_only                                               >.false. </zmconv_trig_dcape_only>
+<zmconv_trig_ull_only                                                 >.false. </zmconv_trig_ull_only>
 <zmconv_tiedke_add                                                    >0.5D0   </zmconv_tiedke_add>
 <zmconv_cape_cin                                                      >5       </zmconv_cape_cin>
 <zmconv_mx_bot_lyr_adj                                                >0       </zmconv_mx_bot_lyr_adj>

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -2430,6 +2430,19 @@ DCAPE trigger along with unrestricted launching level for ZM deep convection sch
 Default: FALSE
 </entry>
 
+<entry id="zmconv_trig_dcape_only" type="logical" category="conv"
+       group="zmconv_nl" valid_values="" >
+DCAPE only trigger for ZM deep convection scheme.
+Default: FALSE
+</entry>
+
+<entry id="zmconv_trig_ull_only" type="logical" category="conv"
+       group="zmconv_nl" valid_values="" >
+Use unrestricted launching level (ULL) only trigger  for ZM deep convection scheme. This is on top of standard CAPE-based ZM trigger
+This is in contrast with zmconv_trigdcape_ull which uses both DCAPE and ULL for trigger
+Default: FALSE
+</entry>
+
 <entry id="zmconv_tiedke_add" type="real" category="conv"
        group="zmconv_nl" valid_values="" >
 A ZM deep convection parameter

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -29,7 +29,8 @@ module physpkg
 
   use cam_control_mod,  only: ideal_phys, adiabatic
   use phys_control,     only: phys_do_flux_avg, phys_getopts, waccmx_is
-  use zm_conv,          only: trigmem, do_zmconv_dcape_ull => trigdcape_ull
+  use zm_conv,          only: trigmem, do_zmconv_dcape_ull => trigdcape_ull, &
+                              do_zmconv_dcape_only => trig_dcape_only
   use scamMod,          only: single_column, scm_crm_mode
   use flux_avg,         only: flux_avg_init
 #ifdef SPMD
@@ -1489,8 +1490,7 @@ subroutine tphysac (ztodt,   cam_in,  &
     !DCAPE-ULL: physics buffer fields to compute tendencies for dcape
     real(r8), pointer, dimension(:,:) :: t_star   ! temperature
     real(r8), pointer, dimension(:,:) :: q_star   ! moisture
-    logical :: do_zmconv_trigdcape_ull            ! switch if using dcape-ull as trigger for ZM convection
-                                                  ! default to false, to bbe made controllable by nml
+
     ! Debug physics_state.
     logical :: state_debug_checks
 
@@ -1829,7 +1829,7 @@ end if ! l_ac_energy_chk
 
     ! DCAPE-ULL: record current state of T and q for computing dynamical tendencies
     !            the calculation follows the same format as in diag_phys_tend_writeout
-    if (do_zmconv_dcape_ull) then
+    if (do_zmconv_dcape_ull .or. do_zmconv_dcape_only) then
       ifld = pbuf_get_index('T_STAR')
       call pbuf_get_field(pbuf, ifld, t_star, (/1,1/),(/pcols,pver/))
       ifld = pbuf_get_index('Q_STAR')

--- a/components/cam/src/physics/cam/zm_conv_intr.F90
+++ b/components/cam/src/physics/cam/zm_conv_intr.F90
@@ -15,7 +15,7 @@ module zm_conv_intr
    use physconst,    only: cpair                              
    use physconst,    only: latvap, gravit   !songxl 2014-05-20
    use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
-   use zm_conv,      only: zm_conv_evap, zm_convr, convtran, momtran, trigmem, trigdcape_ull
+   use zm_conv,      only: zm_conv_evap, zm_convr, convtran, momtran, trigmem, trigdcape_ull, trig_dcape_only
    use cam_history,  only: outfld, addfld, horiz_only, add_default
    use perf_mod
    use cam_logfile,  only: iulog
@@ -105,7 +105,7 @@ subroutine zm_conv_register
 
 ! DCAPE-UPL
 
-   if (trigdcape_ull) then
+   if (trigdcape_ull .or. trig_dcape_only) then
     ! temperature from physics in n-1 time step
     call pbuf_add_field('T_STAR','global',dtype_r8,(/pcols,pver/), t_star_idx)
     ! moisturetendency from physics in n-1 time step 
@@ -437,7 +437,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 !<songxl 2014-05-20-----------------
 
 ! DCAPE-ULL
-   if(trigdcape_ull)then
+   if(trigdcape_ull .or. trig_dcape_only)then
      call pbuf_get_field(pbuf, t_star_idx,     t_star)
      call pbuf_get_field(pbuf, q_star_idx,     q_star)
      if ( is_first_step()) then


### PR DESCRIPTION
Existing DCAPE-ULL trigger is bound to work together.
This update enables DCAPE or ULL to be used alone via two
new namelist variables: zmconv_trig_dcape_only and
zmconv_trig_ull_only. When zmconv_trig_ull_only is true,
ULL will be used along with default CAPE-based trigger.

[BFB]