### PR TITLE
Add JRA1p4 cryo compsets

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -410,6 +410,16 @@
       <mask>oEC60to30v3</mask>
     </model_grid>
 
+    <model_grid alias="TL319_oEC60to30v3wLI" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">oEC60to30v3wLI</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3wLI</mask>
+    </model_grid>
+
     <model_grid alias="TL319_oARRM60to10" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -2080,6 +2090,8 @@
       <ny>320</ny>
       <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oEC60to30v3.181203.nc</file>
       <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oEC60to30v3.181203.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oEC60to30v3wLI.200108.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oEC60to30v3wLI.200108.nc</file>
       <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oARRM60to10.180905.nc</file>
       <file grid="ice|ocn" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to10.180905.nc</file>
       <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oARRM60to6.180905.nc</file>
@@ -3480,6 +3492,14 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_TL319_aave.181203.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3wLI">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3wLI_aave.200108.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3wLI-nomask_bilin.200108.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3wLI_patch.200108.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_to_TL319_aave.200108.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_to_TL319_aave.200108.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="TL319" ocn_grid="oARRM60to10">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oARRM60to10_aave.180904.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oARRM60to10_bilin.180904.nc</map>
@@ -3891,6 +3911,11 @@
     <gridmap ocn_grid="oEC60to30v3" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="oEC60to30v3wLI" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3wLI_smoothed.r150e300.200115.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3wLI_smoothed.r150e300.200115.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oARRM60to10" rof_grid="JRA025">

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -47,6 +47,21 @@
   </compset>
 
   <compset>
+    <alias>GMPAS-JRA1p4-ISMF</alias>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI_MPASO%ISMFDATMFORCED_DROF%JRA-1p4-2018-AIS0LIQ_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GMPAS-JRA1p4-DIB</alias>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI%DIB_MPASO%IBDATMFORCED_DROF%JRA-1p4-2018-AIS0ICE_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GMPAS-JRA1p4-DIB-ISMF</alias>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI%DIB_MPASO%IBISMFDATMFORCED_DROF%JRA-1p4-2018-AIS0ROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>GMPAS-IAF-ISMF</alias>
     <lname>2000_DATM%IAF_SLND_MPASSI_MPASO%ISMFDATMFORCED_DROF%IAFAIS45_SGLC_SWAV</lname>
   </compset>


### PR DESCRIPTION
This PR adds new G-case compsets that use JRAv1.4 forcing for cryosphere configurations, as well as adding support for JRA forcing on the oEC60to30v3wLI grid.

This PR is dependent on CIME changes in [PR #3644](https://github.com/ESMCI/cime/pull/3644), which has subsequently been merged to master.

[BFB]

