### PR TITLE
Make sure land surface data is set for r0125 grid

### DIFF
--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -265,6 +265,8 @@ lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne240np4_simyr2000_c170821.nc</fsurdat>
 <fsurdat hgrid="r05"         sim_year="2000" >
 lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr2000_c190418.nc</fsurdat>
+<fsurdat hgrid="r0125"       sim_year="2000" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr2000_c190730.nc</fsurdat>
 
 <!-- Crop surface datasets -->
 <fsurdat hgrid="1.9x2.5"   sim_year="2000" use_crop=".true." >


### PR DESCRIPTION
Fix setting of fsurdat for `sim_year=2000` and `hgrid=r0125`. This was previously unset, so resolutions like 
`ne30_r0125_ne30` with compset `FC5AV1C-L` would fail at setup. Partially fixes an issue with high resolution 
SCREAM compsets downstream.

[BFB]