### PR TITLE
Improve performance of print_cost_p routine

### DIFF
--- a/components/cam/src/control/cam_comp.F90
+++ b/components/cam/src/control/cam_comp.F90
@@ -455,11 +455,18 @@ subroutine cam_final( cam_out, cam_in )
    real(r8) :: mpi_wtime
 #endif
 
+   call t_startf ('phys_final')
    call phys_final( phys_state, phys_tend , pbuf2d)
+   call t_stopf ('phys_final')
+
+   call t_startf ('stepon_final')
    call stepon_final(dyn_in, dyn_out)
+   call t_stopf ('stepon_final')
 
    if(nsrest==0) then
+      call t_startf ('cam_initfiles_close')
       call cam_initfiles_close()
+      call t_stopf ('cam_initfiles_close')
    end if
 
    call hub2atm_deallocate(cam_in)

--- a/components/cam/src/cpl/atm_comp_mct.F90
+++ b/components/cam/src/cpl/atm_comp_mct.F90
@@ -644,7 +644,9 @@ CONTAINS
     type(mct_aVect)             ,intent(inout) :: x2a_a
     type(mct_aVect)             ,intent(inout) :: a2x_a
 
+    call t_startf("cam_final")
     call cam_final( cam_out, cam_in )
+    call t_stopf("cam_final")
 
   end subroutine atm_final_mct
 

--- a/components/cam/src/physics/cam/physpkg.F90
+++ b/components/cam/src/physics/cam/physpkg.F90
@@ -1345,9 +1345,18 @@ subroutine phys_final( phys_state, phys_tend, pbuf2d )
     end if
     deallocate(phys_state)
     deallocate(phys_tend)
+
+    call t_startf ('chem_final')
     call chem_final
+    call t_stopf ('chem_final')
+
+    call t_startf ('wv_sat_final')
     call wv_sat_final
+    call t_stopf ('wv_sat_final')
+
+    call t_startf ('print_cost_p')
     call print_cost_p
+    call t_stopf ('print_cost_p')
 
 end subroutine phys_final
 

--- a/components/cam/src/physics/crm/physpkg.F90
+++ b/components/cam/src/physics/crm/physpkg.F90
@@ -1359,9 +1359,18 @@ subroutine phys_final( phys_state, phys_tend, pbuf2d )
     end if
     deallocate(phys_state)
     deallocate(phys_tend)
+
+    call t_startf ('chem_final')
     call chem_final
+    call t_stopf ('chem_final')
+
+    call t_startf ('wv_sat_final')
     call wv_sat_final
+    call t_stopf ('wv_sat_final')
+
+    call t_startf ('print_cost_p')
     call print_cost_p
+    call t_stopf ('print_cost_p')
 
 end subroutine phys_final
 


### PR DESCRIPTION
The current algorithm used in print_cost_p has each process, in turn,
open the file atm_chunk_cost.txt, write out the measured cost
assocated with each chunk to the end of the file, and then close the
file. This approach is efficient with respect to memory usage, but is
costly in terms of runtime for large process counts on systems such as
Cori-KNL at NERSC. For example, for an F case using the ne256pg2 
mesh and 32768 processes, this algorithm took 18 minutes to complete.

Here an alternative algorithm is implemented. All data
to be written out is first gathered to the ATM masterproc. The
file atm_chunk_cost.txt is then opened/created once, the data
is written out by masterproc, and the file is then closed. The memory
requirements are higher with this approach, but, at scale, this
alternative approach has been observed to be almost 300 times faster
on Cori-KNL, decreasing the runtime of print_cost_p for the previously 
mentioned case to less than 6 seconds.

Some timers are also added, to better attribute where time is
being spent during the finalization of the ATM component.

Fixes #3766 

[BFB]
