### PR TITLE
Make one of homme targets noio

### DIFF
--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -147,7 +147,9 @@ contains
     use quadrature_mod, only : test_gauss, test_gausslobatto
     use repro_sum_mod,  only : repro_sum_defaultopts, repro_sum_setopts
     use time_mod,       only : nmax, time_at
+#ifndef HOMME_WITHOUT_PIOLIBRARY
     use common_io_mod,  only : homme_pio_init
+#endif
     !
     ! Inputs
     !
@@ -170,7 +172,9 @@ contains
     else
        total_nelem = CubeElemCount()
     end if
+#ifndef HOMME_WITHOUT_PIOLIBRARY
     call homme_pio_init(par%rank,par%comm)
+#endif
 
     approx_elements_per_task = dble(total_nelem)/dble(par%nprocs)
     if  (approx_elements_per_task < 1.0D0) then

--- a/components/homme/test_execs/stt/CMakeLists.txt
+++ b/components/homme/test_execs/stt/CMakeLists.txt
@@ -1,5 +1,7 @@
 preqx_setup()
 
+ADD_DEFINITIONS(-DHOMME_WITHOUT_PIOLIBRARY)
+
 # Set the variables for this test executable
 #                           NP  NC PLEV USE_PIO  WITH_ENERGY  QSIZE_D
 createTestExec(stt preqx 4   4   3   FALSE        TRUE     5)


### PR DESCRIPTION
To keep no-io-builds functionality in tests.
This also fixes no-io build in the current master.

[bfb]