### PR TITLE
Fix reproducibility in modpes runs on haswells

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -84,7 +84,7 @@
       <executable>srun</executable>
       <arguments>
         <arg name="label"> --label</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ num_nodes }}</arg>
         <arg name="thread_count">-c $SHELL{echo 64/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
         <arg name="binding"> $SHELL{if [ 32 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
         <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
@@ -233,7 +233,7 @@
       <executable>srun</executable>
       <arguments>
         <arg name="label"> --label</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ num_nodes }}</arg>
         <arg name="thread_count">-c $SHELL{mpn=`./xmlquery --value MAX_MPITASKS_PER_NODE`; if [ 68 -ge $mpn ]; then c0=`expr 272 / $mpn`; c1=`expr $c0 / 4`; cflag=`expr $c1 \* 4`; echo $cflag|bc ; else echo 272/$mpn|bc;fi;} </arg>
         <arg name="binding"> $SHELL{if [ 68 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
         <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>

--- a/components/cam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/cam/src/chemistry/modal_aero/aero_model.F90
@@ -2963,7 +2963,9 @@ do_lphase2_conditional: &
 
           ! in the MMF NaN's were occurring here but the root cause was not
           ! identified, so this check was added to work around the issue
-          if ( ieee_is_nan(vlc_grv(i,k)) ) vlc_grv(i,k) = 0.0_r8 
+          if (use_MMF) then
+             if ( ieee_is_nan(vlc_grv(i,k)) ) vlc_grv(i,k) = 0.0_r8 
+          end if
 
           vlc_dry(i,k)=vlc_grv(i,k)
        enddo


### PR DESCRIPTION
Fix reproducibility in modpes runs on haswells:
* Revert modal_aero chemistry init
* Compact mpi tasks in multi-step jobs

Fixes E3SM-Project/E3SM#3772

[non-BFB] - for 3 e3sm_prod_next_intel (cori-knl) tests