### PR TITLE
For Theta, update module versions after OS upgrade (on maint-1.0)

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1368,10 +1368,7 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="rm">craype-mic-knl</command>
-        <command name="rm">PrgEnv-intel</command>
         <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">intel</command>
         <command name="rm">cce</command>
         <command name="rm">cray-mpich</command>
         <command name="rm">cray-parallel-netcdf</command>
@@ -1387,8 +1384,9 @@
         <command name="load">cmake/3.14.5</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/19.1.0.166</command>
+        <command name="rm">PrgEnv-gnu</command>
         <command name="load">PrgEnv-intel/6.0.7</command>
+        <command name="swap">intel/19.1.0.166</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">gcc/9.3.0</command>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1343,6 +1343,7 @@
       </arguments>
     </mpirun>
     <environment_variables>
+      <env name="PERL5LIB">/projects/ccsm/acme/libs/perl5</env>
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
       <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
@@ -1380,38 +1381,30 @@
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="rm">cray-libsci</command>
         <command name="rm">craype</command>
-      </modules>
-      <modules>
-        <command name="load">archive/0.0.1</command>
-        <command name="load">craype/2.5.12</command>
+        <command name="rm">perftools-base</command>
+        <command name="rm">darshan</command>
+        <command name="load">craype/2.6.5</command>
+        <command name="load">cmake/3.14.5</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/18.0.0.128</command>
-        <command name="load">PrgEnv-intel/6.0.4</command>
-      </modules>
-      <modules compiler="cray">
-        <command name="load">cce/8.6.2</command>
-        <command name="load">PrgEnv-cray/6.0.4</command>
+        <command name="load">intel/19.1.0.166</command>
+        <command name="load">PrgEnv-intel/6.0.7</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gcc/6.3.0</command>
-        <command name="load">PrgEnv-gnu/6.0.4</command>
+        <command name="load">gcc/9.3.0</command>
+        <command name="load">PrgEnv-gnu/6.0.7</command>
       </modules>
       <modules compiler="!intel">
-        <command name="switch">cray-libsci/17.09.1</command>
+        <command name="rm">cray-libsci</command>
+        <command name="load">cray-libsci/20.06.1</command>
       </modules>
       <modules>
+        <command name="load">darshan</command>
         <command name="load">craype-mic-knl</command>
-        <command name="load">cray-mpich/7.6.2</command>
-      </modules>
-      <modules mpilib="mpt">
-        <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
-        <command name="load">cray-hdf5-parallel/1.10.0.3</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.3</command>
-      </modules>
-      <modules mpilib="mpi-serial">
-        <command name="load">cray-hdf5/1.10.0.3</command>
-        <command name="load">cray-netcdf/4.4.1.1.3</command>
+        <command name="load">cray-mpich/7.7.14</command>
+        <command name="load">cray-hdf5-parallel/1.10.6.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.7.3.3</command>
+        <command name="load">cray-parallel-netcdf/1.12.0.1</command>
       </modules>
     </module_system>
 </machine>


### PR DESCRIPTION
For Theta, update module versions after OS upgrade (on maint-1.0).
Use the current machine defaults, which is currently the same versions as master.

We are currently unable to use certain older modules to allow for BFB results,
so this change will not be BFB (includes using intel version 19 over version 18).

Fixes #3744 
