### PR TITLE
Integrate with Travis CI and the E3SM singularity container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+os: linux
+
+dist: bionic
+
+git:
+  submodules: false
+
+python:
+    - "3.7"
+
+addons:
+  apt:
+    packages:
+      - flawfinder
+      - squashfs-tools
+      - build-essential
+      - uuid-dev
+      - libuuid1
+      - libffi-dev
+      - libssl-dev
+      - libssl1.0.0
+      - libarchive-dev
+      - libgpgme11-dev
+      - libseccomp-dev
+      - pkg-config
+      - cryptsetup-bin
+  homebrew:
+    packages:
+      - squashfs
+    update: true
+
+sudo: required
+
+before_install:
+    # Replace all ssh URLs to submodules with HTTP URLs
+    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+    - git submodule update --init
+    - cd components/mpas-source
+    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+    - git submodule update --init --recursive
+    - cd ../..
+    # Download the E3SM Singularity container
+    - wget https://dabdceba-6d04-11e5-ba46-22000b92c6ec.e.globus.org/containers/public/e3sm.sif
+    # Install Singularity
+    - sudo chmod u+x .travis/*.sh
+    - .travis/setup.sh
+
+script:
+    # Build a case
+    - travis_wait 30 singularity exec --hostname singularity e3sm.sif .travis/run.sh

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+
+function command_yellow
+{
+    echo -e "\e[33m\$ $1\e[0m"
+    eval $1
+    return $?
+}
+
+function command_yellow_rc
+{
+    command_yellow "$1"
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        exit $rc
+    fi
+}
+
+command_yellow_rc "mkdir -p $HOME/projects/e3sm/cesm-inputdata"
+command_yellow_rc 'cd cime/scripts'
+command_yellow_rc './create_newcase --case master.A_WCYCL1850.ne4_oQU240.baseline --compset A_WCYCL1850 --res ne4_oQU240'
+command_yellow_rc 'cd master.A_WCYCL1850.ne4_oQU240.baseline'
+command_yellow_rc './case.setup'
+command_yellow './case.build'
+rc=$?
+if [ $rc -ne 0 ]; then
+    log=`ls ${HOME}/projects/e3sm/scratch/master.A_WCYCL1850.ne4_oQU240.baseline/bld/pio.bldlog*`
+    command_yellow "cat $log"
+    exit $rc
+fi

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Remove the pre-installed Go 1.11 from the environment
+go version
+for p in $(xargs -n1 -d: <<< $PATH); do
+    echo $p | grep '/go' > /dev/null
+    if [ $? -ne 0 ]; then
+        TMPPATH="$p:$TMPPATH"
+    fi
+done
+export PATH="$TMPPATH"
+unset GOPATH
+unset GOROOT
+
+# Install Go 1.13.5
+export VERSION=1.13.5 OS=linux ARCH=amd64 && \
+    wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
+    sudo tar -C /usr/local -xzf go$VERSION.$OS-$ARCH.tar.gz && \
+    rm go$VERSION.$OS-$ARCH.tar.gz
+
+export GOPATH="${HOME}/go"
+export PATH="/usr/local/go/bin:${PATH}:${GOPATH}/bin"
+go version
+
+# Install Singularity
+export VERSION=3.5.3 && # adjust this as necessary \
+    wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+    tar -xzf singularity-${VERSION}.tar.gz && \
+    cd singularity
+./mconfig && \
+    make -C ./builddir && \
+    sudo make -C ./builddir install
+
+singularity --version


### PR DESCRIPTION
The PR integrates the E3SM repository with Travis CI. The .travis.yml file describes a Travis CI deployment environment and how to clone the E3SM repository with all submodules. It also tells Travis CI, that after the environment is set up, to run
1) .travis/setup.sh script to install Go and Singularity,
2) .travis/run.sh script to create, set up, and build A_WCYCL1850.ne4_oQU240 case
Step 2) takes from 5 to 15 minutes on the Travis CI platform. Such a wide range of execution time can be caused by different total compute load and memory consumption on a machine where a VM for the deployment environment is launched.

[BFB]
