### PR TITLE
add rrtmgp_enable_limiter_warnings namelist flag

### DIFF
--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -1596,6 +1596,16 @@ if ($rad_pkg eq 'rrtmgp') {
     add_default($nl, 'rrtmgp_coefficients_file_lw');
 }
 
+# RRTMGP limiter warnings
+if ($rad_pkg eq 'rrtmgp') {
+  if ($aqua_mode) {
+    # disable warnings for aqua planet to avoid filling up the logs
+    add_default($nl, 'rrtmgp_enable_limiter_warnings', 'val'=>".false.");
+  } else {
+    add_default($nl, 'rrtmgp_enable_limiter_warnings');
+  }
+}
+
 # Volcanic Aerosol Mass climatology dataset
 if ($nl->get_value('strat_volcanic')) { add_default($nl, 'bndtvvolc'); }
 

--- a/components/cam/bld/build-namelist
+++ b/components/cam/bld/build-namelist
@@ -1600,9 +1600,9 @@ if ($rad_pkg eq 'rrtmgp') {
 if ($rad_pkg eq 'rrtmgp') {
   if ($aqua_mode) {
     # disable warnings for aqua planet to avoid filling up the logs
-    add_default($nl, 'rrtmgp_enable_limiter_warnings', 'val'=>".false.");
+    add_default($nl, 'rrtmgp_enable_temperature_warnings', 'val'=>".false.");
   } else {
-    add_default($nl, 'rrtmgp_enable_limiter_warnings');
+    add_default($nl, 'rrtmgp_enable_temperature_warnings');
   }
 }
 

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -504,7 +504,9 @@
 <rrtmgp_coefficients_file_lw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_lw_20181204.nc</rrtmgp_coefficients_file_lw>
 <rrtmgp_coefficients_file_sw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_sw_20181204.nc</rrtmgp_coefficients_file_sw>
 
-<rrtmgp_enable_limiter_warnings rad="rrtmgp">.true.</rrtmgp_enable_limiter_warnings>
+<rrtmgp_enable_temperature_warnings rad="rrtmgp"               >.true.</rrtmgp_enable_temperature_warnings>
+<rrtmgp_enable_temperature_warnings rad="rrtmgp" aquaplanet="1">.false.</rrtmgp_enable_temperature_warnings>
+
 
 <!-- CAM-RT absorptivity/emissivity lookup table -->
 <absems_data>atm/cam/rad/abs_ems_factors_fastvx.c030508.nc</absems_data>

--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -504,6 +504,8 @@
 <rrtmgp_coefficients_file_lw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_lw_20181204.nc</rrtmgp_coefficients_file_lw>
 <rrtmgp_coefficients_file_sw rad="rrtmgp">atm/cam/rad/rrtmgp_coefficients_sw_20181204.nc</rrtmgp_coefficients_file_sw>
 
+<rrtmgp_enable_limiter_warnings rad="rrtmgp">.true.</rrtmgp_enable_limiter_warnings>
+
 <!-- CAM-RT absorptivity/emissivity lookup table -->
 <absems_data>atm/cam/rad/abs_ems_factors_fastvx.c030508.nc</absems_data>
 

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -3760,7 +3760,7 @@ File path for RRTMGP longwave gaseous absorption coefficients file.
 File path for RRTMGP shortwave gaseous absorption coefficients file.
 </entry>
 
-<entry id="rrtmgp_enable_limiter_warnings" type="logical"
+<entry id="rrtmgp_enable_temperature_warnings" type="logical"
        category="radiation" group="radiation_nl" valid_values="">
 Enables low temperature warnings in RRTMGP.
 Disabling this is useful to avoid filling up logs for aqua planet cases.

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -3760,6 +3760,13 @@ File path for RRTMGP longwave gaseous absorption coefficients file.
 File path for RRTMGP shortwave gaseous absorption coefficients file.
 </entry>
 
+<entry id="rrtmgp_enable_limiter_warnings" type="logical"
+       category="radiation" group="radiation_nl" valid_values="">
+Enables low temperature warnings in RRTMGP.
+Disabling this is useful to avoid filling up logs for aqua planet cases.
+Default: TRUE
+</entry>
+
 <!-- Rayleigh Friction Parameterization -->
 
 <entry id="rayk0" type="integer" category="rayleigh_friction"

--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -114,8 +114,8 @@ module radiation
    ! The RRTMGP warnings are printed when the state variables need to be limted,
    ! such as when the temperature drops too low. This is not normally an issue,
    ! but in aquaplanet and RCE configurations these situations occur much more 
-   ! frequently, so this flag was added to be able to disable the warning messages.
-   logical :: rrtmgp_enable_limiter_warnings = .true.
+   ! frequently, so this flag was added to be able to disable those messages.
+   logical :: rrtmgp_enable_temperature_warnings = .true.
 
    ! Model data that is not controlled by namelist fields specifically follows
    ! below.
@@ -223,7 +223,7 @@ contains
                               use_rad_dt_cosz, spectralflux,   &
                               do_aerosol_rad,                  &
                               fixed_total_solar_irradiance,    &
-                              rrtmgp_enable_limiter_warnings
+                              rrtmgp_enable_temperature_warnings
 
       ! Read the namelist, only if called from master process
       ! TODO: better documentation and cleaner logic here?
@@ -252,7 +252,7 @@ contains
       call mpibcast(spectralflux, 1, mpi_logical, mstrid, mpicom, ierr)
       call mpibcast(do_aerosol_rad, 1, mpi_logical, mstrid, mpicom, ierr)
       call mpibcast(fixed_total_solar_irradiance, 1, mpi_real8, mstrid, mpicom, ierr)
-      call mpibcast(rrtmgp_enable_limiter_warnings, 1, mpi_logical, mstrid, mpicom, ierr)
+      call mpibcast(rrtmgp_enable_temperature_warnings, 1, mpi_logical, mstrid, mpicom, ierr)
 #endif
 
       ! Set module data
@@ -276,7 +276,7 @@ contains
                          iradsw, iradlw, irad_always, &
                          use_rad_dt_cosz, spectralflux, &
                          do_aerosol_rad, fixed_total_solar_irradiance, &
-                         rrtmgp_enable_limiter_warnings
+                         rrtmgp_enable_temperature_warnings
       end if
    10 format('  LW coefficents file: ',                                a/, &
              '  SW coefficents file: ',                                a/, &
@@ -1530,11 +1530,11 @@ contains
                      call handle_error(clip_values( &
                         tmid_col(1:ncol,1:nlev_rad), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
                         trim(subname) // ' tmid' &
-                     ), fatal=.false.)
+                     ), fatal=.false., warn=rrtmgp_enable_temperature_warnings)
                      call handle_error(clip_values( &
                         tint_col(1:ncol,1:nlev_rad+1), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
                         trim(subname) // ' tint' &
-                     ), fatal=.false.)
+                     ), fatal=.false., warn=rrtmgp_enable_temperature_warnings)
                      call t_stopf('rad_check_temperatures')
 
                      ! Set gas concentrations

--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -111,6 +111,12 @@ module radiation
    ! Disabled when value is less than 0.
    real(r8) :: fixed_total_solar_irradiance = -1
 
+   ! The RRTMGP warnings are printed when the state variables need to be limted,
+   ! such as when the temperature drops too low. This is not normally an issue,
+   ! but in aquaplanet and RCE configurations these situations occur much more 
+   ! frequently, so this flag was added to be able to disable the warning messages.
+   logical :: rrtmgp_enable_limiter_warnings = .true.
+
    ! Model data that is not controlled by namelist fields specifically follows
    ! below.
 
@@ -215,7 +221,9 @@ contains
                               rrtmgp_coefficients_file_sw,     &
                               iradsw, iradlw, irad_always,     &
                               use_rad_dt_cosz, spectralflux,   &
-                              do_aerosol_rad, fixed_total_solar_irradiance
+                              do_aerosol_rad,                  &
+                              fixed_total_solar_irradiance,    &
+                              rrtmgp_enable_limiter_warnings
 
       ! Read the namelist, only if called from master process
       ! TODO: better documentation and cleaner logic here?
@@ -244,6 +252,7 @@ contains
       call mpibcast(spectralflux, 1, mpi_logical, mstrid, mpicom, ierr)
       call mpibcast(do_aerosol_rad, 1, mpi_logical, mstrid, mpicom, ierr)
       call mpibcast(fixed_total_solar_irradiance, 1, mpi_real8, mstrid, mpicom, ierr)
+      call mpibcast(rrtmgp_enable_limiter_warnings, 1, mpi_logical, mstrid, mpicom, ierr)
 #endif
 
       ! Set module data
@@ -266,7 +275,8 @@ contains
          write(iulog,10) trim(coefficients_file_lw), trim(coefficients_file_sw), &
                          iradsw, iradlw, irad_always, &
                          use_rad_dt_cosz, spectralflux, &
-                         do_aerosol_rad, fixed_total_solar_irradiance
+                         do_aerosol_rad, fixed_total_solar_irradiance, &
+                         rrtmgp_enable_limiter_warnings
       end if
    10 format('  LW coefficents file: ',                                a/, &
              '  SW coefficents file: ',                                a/, &
@@ -276,7 +286,8 @@ contains
              '  Use average zenith angle:                           ',l5/, &
              '  Output spectrally resolved fluxes:                  ',l5/, &
              '  Do aerosol radiative calculations:                  ',l5/, &
-             '  Fixed solar consant (disabled with -1):             ',f10.4/ )
+             '  Fixed solar consant (disabled with -1):             ',f10.4/, &
+             '  Enable limiter warnings:                            ',l5/ )
 
    end subroutine radiation_readnl
 

--- a/components/cam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/crm/rrtmgp/radiation.F90
@@ -287,7 +287,7 @@ contains
              '  Output spectrally resolved fluxes:                  ',l5/, &
              '  Do aerosol radiative calculations:                  ',l5/, &
              '  Fixed solar consant (disabled with -1):             ',f10.4/, &
-             '  Enable limiter warnings:                            ',l5/ )
+             '  Enable temperature warnings:                        ',l5/ )
 
    end subroutine radiation_readnl
 

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -111,8 +111,8 @@ module radiation
    ! The RRTMGP warnings are printed when the state variables need to be limted,
    ! such as when the temperature drops too low. This is not normally an issue,
    ! but in aquaplanet and RCE configurations these situations occur much more 
-   ! frequently, so this flag was added to be able to disable the warning messages.
-   logical :: rrtmgp_enable_limiter_warnings = .true.
+   ! frequently, so this flag was added to be able to disable those messages.
+   logical :: rrtmgp_enable_temperature_warnings = .true.
 
    ! Model data that is not controlled by namelist fields specifically follows
    ! below.
@@ -222,7 +222,7 @@ contains
                               use_rad_dt_cosz, spectralflux,   &
                               do_aerosol_rad,                  &
                               fixed_total_solar_irradiance,    &
-                              rrtmgp_enable_limiter_warnings
+                              rrtmgp_enable_temperature_warnings
 
       ! Read the namelist, only if called from master process
       ! TODO: better documentation and cleaner logic here?
@@ -251,7 +251,7 @@ contains
       call mpibcast(spectralflux, 1, mpi_logical, mstrid, mpicom, ierr)
       call mpibcast(do_aerosol_rad, 1, mpi_logical, mstrid, mpicom, ierr)
       call mpibcast(fixed_total_solar_irradiance, 1, mpi_real8, mstrid, mpicom, ierr)
-      call mpibcast(rrtmgp_enable_limiter_warnings, 1, mpi_logical, mstrid, mpicom, ierr)
+      call mpibcast(rrtmgp_enable_temperature_warnings, 1, mpi_logical, mstrid, mpicom, ierr)
 #endif
 
       ! Convert iradsw, iradlw and irad_always from hours to timesteps if necessary
@@ -271,7 +271,7 @@ contains
                          iradsw, iradlw, irad_always, &
                          use_rad_dt_cosz, spectralflux, &
                          do_aerosol_rad, fixed_total_solar_irradiance, &
-                         rrtmgp_enable_limiter_warnings
+                         rrtmgp_enable_temperature_warnings
       end if
    10 format('  LW coefficents file: ',                                a/, &
              '  SW coefficents file: ',                                a/, &
@@ -1230,11 +1230,11 @@ contains
          call handle_error(clip_values( &
             tmid(1:ncol,1:nlev_rad), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
             trim(subname) // ' tmid' &
-         ), fatal=.false., warn=rrtmgp_enable_limiter_warnings)
+         ), fatal=.false., warn=rrtmgp_enable_temperature_warnings)
          call handle_error(clip_values( &
             tint(1:ncol,1:nlev_rad+1), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
             trim(subname) // ' tint' &
-         ), fatal=.false., warn=rrtmgp_enable_limiter_warnings)
+         ), fatal=.false., warn=rrtmgp_enable_temperature_warnings)
          call t_stopf('rrtmgp_check_temperatures')
       end if
      

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -108,6 +108,12 @@ module radiation
    ! Disabled when value is less than 0.
    real(r8) :: fixed_total_solar_irradiance = -1
 
+   ! The RRTMGP warnings are printed when the state variables need to be limted,
+   ! such as when the temperature drops too low. This is not normally an issue,
+   ! but in aquaplanet and RCE configurations these situations occur much more 
+   ! frequently, so this flag was added to be able to disable the warning messages.
+   logical :: rrtmgp_enable_limiter_warnings = .true.
+
    ! Model data that is not controlled by namelist fields specifically follows
    ! below.
 
@@ -214,7 +220,9 @@ contains
                               rrtmgp_coefficients_file_sw,     &
                               iradsw, iradlw, irad_always,     &
                               use_rad_dt_cosz, spectralflux,   &
-                              do_aerosol_rad, fixed_total_solar_irradiance
+                              do_aerosol_rad,                  &
+                              fixed_total_solar_irradiance,    &
+                              rrtmgp_enable_limiter_warnings
 
       ! Read the namelist, only if called from master process
       ! TODO: better documentation and cleaner logic here?
@@ -243,6 +251,7 @@ contains
       call mpibcast(spectralflux, 1, mpi_logical, mstrid, mpicom, ierr)
       call mpibcast(do_aerosol_rad, 1, mpi_logical, mstrid, mpicom, ierr)
       call mpibcast(fixed_total_solar_irradiance, 1, mpi_real8, mstrid, mpicom, ierr)
+      call mpibcast(rrtmgp_enable_limiter_warnings, 1, mpi_logical, mstrid, mpicom, ierr)
 #endif
 
       ! Convert iradsw, iradlw and irad_always from hours to timesteps if necessary
@@ -261,7 +270,8 @@ contains
          write(iulog,10) trim(rrtmgp_coefficients_file_lw), trim(rrtmgp_coefficients_file_sw), &
                          iradsw, iradlw, irad_always, &
                          use_rad_dt_cosz, spectralflux, &
-                         do_aerosol_rad, fixed_total_solar_irradiance
+                         do_aerosol_rad, fixed_total_solar_irradiance, &
+                         rrtmgp_enable_limiter_warnings
       end if
    10 format('  LW coefficents file: ',                                a/, &
              '  SW coefficents file: ',                                a/, &
@@ -271,7 +281,8 @@ contains
              '  Use average zenith angle:                           ',l5/, &
              '  Output spectrally resolved fluxes:                  ',l5/, &
              '  Do aerosol radiative calculations:                  ',l5/, &
-             '  Fixed solar consant (disabled with -1):             ',f10.4/ )
+             '  Fixed solar consant (disabled with -1):             ',f10.4/, &
+             '  Enable limiter warnings:                            ',l5/ )
 
    end subroutine radiation_readnl
 
@@ -1219,11 +1230,11 @@ contains
          call handle_error(clip_values( &
             tmid(1:ncol,1:nlev_rad), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
             trim(subname) // ' tmid' &
-         ), fatal=.false.)
+         ), fatal=.false., warn=rrtmgp_enable_limiter_warnings)
          call handle_error(clip_values( &
             tint(1:ncol,1:nlev_rad+1), k_dist_lw%get_temp_min(), k_dist_lw%get_temp_max(), &
             trim(subname) // ' tint' &
-         ), fatal=.false.)
+         ), fatal=.false., warn=rrtmgp_enable_limiter_warnings)
          call t_stopf('rrtmgp_check_temperatures')
       end if
      

--- a/components/cam/src/physics/rrtmgp/radiation.F90
+++ b/components/cam/src/physics/rrtmgp/radiation.F90
@@ -282,7 +282,7 @@ contains
              '  Output spectrally resolved fluxes:                  ',l5/, &
              '  Do aerosol radiative calculations:                  ',l5/, &
              '  Fixed solar consant (disabled with -1):             ',f10.4/, &
-             '  Enable limiter warnings:                            ',l5/ )
+             '  Enable temperature warnings:                        ',l5/ )
 
    end subroutine radiation_readnl
 

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -312,10 +312,11 @@ contains
       end if
    end function clip_values_3d
    !-------------------------------------------------------------------------------
-   subroutine handle_error(error_message, fatal)
+   subroutine handle_error(error_message, fatal, warn)
       use cam_abortutils, only: endrun
       character(len=*), intent(in) :: error_message
       logical, intent(in), optional :: fatal
+      logical, intent(in), optional :: warn
       logical :: fatal_local = .true.
 
       ! Allow passing of an optional flag to not stop the run if an error is
@@ -333,7 +334,9 @@ contains
          if (fatal_local) then
             call endrun(trim(error_message))
          else
-            print *, trim(error_message)
+            if (present(warn)) then
+               print *, trim(error_message)
+            end if
          end if
       end if
    end subroutine handle_error

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -318,6 +318,9 @@ contains
       logical, intent(in), optional :: fatal
       logical, intent(in), optional :: warn
       logical :: fatal_local = .true.
+      logical :: warn_local = .true.
+
+      if (present(warn)) warn_local = warn
 
       ! Allow passing of an optional flag to not stop the run if an error is
       ! encountered. This allows this subroutine to be used when inquiring if a
@@ -333,10 +336,8 @@ contains
       if (len(trim(error_message)) > 0) then
          if (fatal_local) then
             call endrun(trim(error_message))
-         else
-            if (present(warn)) then
-               print *, trim(error_message)
-            end if
+         else if (warn_local) then
+            print *, trim(error_message)
          end if
       end if
    end subroutine handle_error

--- a/components/cam/src/physics/rrtmgp/radiation_utils.F90
+++ b/components/cam/src/physics/rrtmgp/radiation_utils.F90
@@ -317,10 +317,8 @@ contains
       character(len=*), intent(in) :: error_message
       logical, intent(in), optional :: fatal
       logical, intent(in), optional :: warn
-      logical :: fatal_local = .true.
-      logical :: warn_local = .true.
-
-      if (present(warn)) warn_local = warn
+      logical :: fatal_local
+      logical :: warn_local
 
       ! Allow passing of an optional flag to not stop the run if an error is
       ! encountered. This allows this subroutine to be used when inquiring if a
@@ -329,6 +327,14 @@ contains
          fatal_local = fatal
       else
          fatal_local = .true.
+      end if
+
+      ! Allow optional flag to disable warning messages.
+      ! Useful for avoiding low temperature messages in aquaplanet cases.
+      if (present(warn)) then
+         warn_local = warn
+      else
+         warn_local = .true.
       end if
 
       ! If we encounter an error, fail if we require success. Otherwise do


### PR DESCRIPTION
This adds a flag to enable limiter warnings in RRTMGP. The flag is true by default, maintaining the previous behavior, but is automatically set to false for aqua planet cases, because these cases often produce very low temperatures aloft that can lead to very large log files full of unhelpful warnings. 

[BFB]