### PR TITLE
Minimum droplet number conc. option and cleanup

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1009,6 +1009,7 @@
 <mg_prc_coeff_fix     microphys="mg2">  .false.     </mg_prc_coeff_fix>
 <micro_nccons         microphys="mg2">  100.D6      </micro_nccons>
 <micro_nicons         microphys="mg2">  0.1D6       </micro_nicons>
+<micro_mincdnc        microphys="mg2">  -999.       </micro_mincdnc>
 
 <rrtmg_temp_fix                      > .false.      </rrtmg_temp_fix>
 

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -2055,6 +2055,12 @@ Ice crystal concentration (in #/cc) when micro_do_nicons=.true.
 Default: set by build-namelist
 </entry> 
 
+<entry id="micro_mincdnc" type="real" category="microphys"
+       group="micro_mg_nl" valid_values="" >
+Minimum droplet number conc (#/m3) imposed when micro_mincdnc > 0. 
+Default: -999.
+</entry>
+
 <entry id="micro_mg_version" type="integer" category="microphys"
        group="micro_mg_nl" valid_values="" >
 Version number for MG microphysics

--- a/components/cam/src/physics/cam/micro_mg2_0.F90
+++ b/components/cam/src/physics/cam/micro_mg2_0.F90
@@ -135,9 +135,7 @@ real(r8), parameter :: minrefl = 1.26e-10_r8    ! minrefl = 10._r8**(mindbz/10._
 ! autoconversion size threshold for cloud ice to snow (m)
 real(r8) :: dcs
 
-!!== KZ_DCS 
 logical :: dcs_tdep
-!!== KZ_DCS 
 
 ! minimum mass of new crystal due to freezing of cloud droplets done
 ! externally (kg)
@@ -175,6 +173,8 @@ logical :: use_hetfrz_classnuc
 
 real(r8) :: ncnst ! constant droplet concentration
 real(r8) :: ninst ! constant ice concentration
+
+real(r8) :: mincdnc     ! if mincdnc > 0, then impose a minimum droplet number conc.  
 
 real(r8) :: rhosu       ! typical 850mn air density
 
@@ -223,11 +223,9 @@ contains
 subroutine micro_mg_init( &
      kind, gravit, rair, rh2o, cpair,    &
      tmelt_in, latvap, latice,           &
-!!== KZ_DCS 
      rhmini_in, micro_mg_dcs, micro_mg_dcs_tdep, &
-!!== KZ_DCS 
      microp_uniform_in, do_cldice_in, use_hetfrz_classnuc_in, &
-     do_nccons_in, do_nicons_in, ncnst_in, ninst_in, &
+     do_nccons_in, do_nicons_in, ncnst_in, ninst_in, mincdnc_in, &
      micro_mg_precip_frac_method_in, micro_mg_berg_eff_factor_in, &
      allow_sed_supersat_in, ice_sed_ai, prc_coef1_in,prc_exp_in,  &
      prc_exp1_in, cld_sed_in, mg_prc_coeff_fix_in, alpha_grad_in, &
@@ -255,9 +253,7 @@ subroutine micro_mg_init( &
   real(r8), intent(in)  :: rhmini_in    ! Minimum rh for ice cloud fraction > 0.
   real(r8), intent(in)  :: micro_mg_dcs
   real(r8), intent(in)  :: ice_sed_ai   !Fall speed parameter for cloud ice
-!!== KZ_DCS 
   logical,  intent(in)  :: micro_mg_dcs_tdep
-!!== KZ_DCS 
 
   logical,  intent(in)  :: microp_uniform_in    ! .true. = configure uniform for sub-columns
                                             ! .false. = use w/o sub-columns (standard)
@@ -281,6 +277,7 @@ subroutine micro_mg_init( &
 
   real(r8), intent(in)  :: ncnst_in
   real(r8), intent(in)  :: ninst_in        
+  real(r8), intent(in)  :: mincdnc_in
 
   character(128), intent(out) :: errstring    ! Output status (non-blank for error return)
 
@@ -288,9 +285,7 @@ subroutine micro_mg_init( &
 
   dcs = micro_mg_dcs
 
-!!== KZ_DCS 
   dcs_tdep = micro_mg_dcs_tdep 
-!!== KZ_DCS 
 
  prc_coef1 = prc_coef1_in
  prc_exp   = prc_exp_in
@@ -332,6 +327,7 @@ subroutine micro_mg_init( &
   nicons = do_nicons_in
   ncnst = ncnst_in
   ninst = ninst_in
+  mincdnc = mincdnc_in
   use_hetfrz_classnuc = use_hetfrz_classnuc_in
 
   ! typical air density at 850 mb
@@ -427,9 +423,7 @@ subroutine micro_mg_tend ( &
   ! Size calculation functions.
   use micro_mg_utils, only: &
        size_dist_param_liq, &
-!!== KZ_DCS 
        size_dist_param_ice, &
-!!== KZ_DCS 
        size_dist_param_basic, &
        avg_diameter
 
@@ -760,9 +754,7 @@ subroutine micro_mg_tend ( &
   ! relative humidity
   real(r8) :: relhum(mgncol,nlev)
 
-!!== KZ_DCS 
   real(r8) :: dcst(mgncol,nlev)        ! t-dependent dcs
-!!== KZ_DCS 
 
   ! parameters for cloud water and cloud ice sedimentation calculations
   real(r8) :: fc(nlev)
@@ -865,9 +857,7 @@ subroutine micro_mg_tend ( &
   qs = qsn
   ns = nsn
 
-!!== KZ_DCS
   call get_dcst(mgncol,nlev,t,dcst)
-!!== KZ_DCS
 
 
   ! cldn: used to set cldm, unused for subcolumns
@@ -1217,6 +1207,11 @@ subroutine micro_mg_tend ( &
            qcic(i,k)=min(qc(i,k)/lcldm(i,k),5.e-3_r8)
            ncic(i,k)=max(nc(i,k)/lcldm(i,k),0._r8)
 
+           ! impose minimum droplet number conc (in-cloud) 
+           if (mincdnc.gt.0.) then
+              ncic(i,k)=max(ncic(i,k),mincdnc/rho(i,k))
+           end if
+
            ! specify droplet concentration
            if (nccons) then
               ncic(i,k)=ncnst/rho(i,k)
@@ -1346,7 +1341,6 @@ subroutine micro_mg_tend ( &
 
      nric(:,k)=max(nric(:,k),0._r8)
 
-!!== KZ_DCS
      if(dcs_tdep) then
         ! Get size distribution parameters for cloud ice
         call size_dist_param_ice(mg_ice_props, dcst(:,k), qiic(:,k), niic(:,k), &
@@ -1356,7 +1350,6 @@ subroutine micro_mg_tend ( &
         call size_dist_param_basic(mg_ice_props, qiic(:,k), niic(:,k), &
              lami(:,k), n0i(:,k))
      end if
-!!== KZ_DCS 
 
      !.......................................................................
      ! Autoconversion of cloud ice to snow
@@ -1364,9 +1357,7 @@ subroutine micro_mg_tend ( &
 
      if (do_cldice) then
         call ice_autoconversion(t(:,k), qiic(:,k), lami(:,k), n0i(:,k), &
-!!== KZ_DCS 
              dcs, dcst(:,k), dcs_tdep, prci(:,k), nprci(:,k))
-!!== KZ_DCS 
      else
         ! Add in the particles that we have already converted to snow, and
         ! don't do any further autoconversion of ice.
@@ -1554,9 +1545,7 @@ subroutine micro_mg_tend ( &
      if (do_cldice) then
 
         call ice_deposition_sublimation(t(:,k), q(:,k), qi(:,k), ni(:,k), &
-!!== KZ_DCS 
              icldm(:,k), rho(:,k), dv(:,k), qvl(:,k), qvi(:,k), dcst(:,k), dcs_tdep, &
-!!== KZ_DCS 
              berg(:,k), vap_dep(:,k), ice_sublim(:,k))
 
         berg(:,k)=berg(:,k)*micro_mg_berg_eff_factor
@@ -2092,6 +2081,10 @@ subroutine micro_mg_tend ( &
         dums(i,k) = (qs(i,k)+qstend(i,k)*deltat)/precip_frac(i,k)
         dumns(i,k) = max((ns(i,k)+nstend(i,k)*deltat)/precip_frac(i,k),0._r8)
 
+        ! impose minimum droplet number conc (in-cloud) 
+        if (mincdnc.gt.0._r8) then
+           dumnc(i,k)=max(dumnc(i,k),mincdnc/rho(i,k))
+        end if
 
         ! switch for specification of droplet and crystal number
         if (nccons) then
@@ -2491,6 +2484,11 @@ subroutine micro_mg_tend ( &
         dums(i,k) = max(qs(i,k)+qstend(i,k)*deltat,0._r8)
         dumns(i,k) = max(ns(i,k)+nstend(i,k)*deltat,0._r8)
 
+        ! impose minimum droplet number conc (in-cloud) 
+        if (mincdnc.gt.0._r8) then
+           dumnc(i,k) = max(dumnc(i,k),mincdnc/rho(i,k)*lcldm(i,k))
+        end if
+
         ! switch for specification of droplet and crystal number
         if (nccons) then
            dumnc(i,k)=ncnst/rho(i,k)*lcldm(i,k)
@@ -2702,6 +2700,11 @@ subroutine micro_mg_tend ( &
         dums(i,k) = max(qs(i,k)+qstend(i,k)*deltat,0._r8)/precip_frac(i,k)
         dumns(i,k) = max(ns(i,k)+nstend(i,k)*deltat,0._r8)/precip_frac(i,k)
 
+        ! impose minimum droplet number conc (in-cloud) 
+        if (mincdnc.gt.0._r8) then
+           dumnc(i,k) = max(dumnc(i,k),mincdnc/rho(i,k))
+        end if
+
         ! switch for specification of droplet and crystal number
         if (nccons) then
            dumnc(i,k)=ncnst/rho(i,k)
@@ -2753,6 +2756,11 @@ subroutine micro_mg_tend ( &
         !-----------------------------------------------------------------
         if (dumc(i,k).ge.qsmall) then
 
+
+           ! impose minimum droplet number conc (in-cloud) 
+           if (mincdnc.gt.0._r8) then
+              nctend(i,k)=( max(nc(i,k)+nctend(i,k)*deltat, mincdnc/rho(i,k)) - nc(i,k))/deltat
+           end if
 
            ! switch for specification of droplet and crystal number
            if (nccons) then
@@ -3095,7 +3103,6 @@ pure subroutine micro_mg_get_cols(ncol, nlev, top_lev, qcn, qin, &
 end subroutine micro_mg_get_cols
 
 
-!!== KZ_DCS
 subroutine get_dcst(ncol,pver,temp,dcst)
 
 implicit none
@@ -3127,7 +3134,6 @@ end do
 return
 
 end subroutine get_dcst
-!!== KZ_DCS
 
 
 

--- a/components/cam/src/physics/cam/micro_mg2_0.F90
+++ b/components/cam/src/physics/cam/micro_mg2_0.F90
@@ -2759,7 +2759,7 @@ subroutine micro_mg_tend ( &
 
            ! impose minimum droplet number conc (in-cloud) 
            if (mincdnc.gt.0._r8) then
-              nctend(i,k)=( max(nc(i,k)+nctend(i,k)*deltat, mincdnc/rho(i,k)) - nc(i,k))/deltat
+              nctend(i,k)=( max(nc(i,k)+nctend(i,k)*deltat, mincdnc/rho(i,k)*lcldm(i,k)) - nc(i,k))/deltat
            end if
 
            ! switch for specification of droplet and crystal number

--- a/components/cam/src/physics/cam/micro_mg_cam.F90
+++ b/components/cam/src/physics/cam/micro_mg_cam.F90
@@ -119,10 +119,7 @@ real(r8) :: micro_mg_dcs = -1._r8
 
 logical :: microp_uniform
 
-!!== KZ_DCS
 logical :: micro_mg_dcs_tdep  = .false.! if set to true, use temperature dependent dcs
-!!== KZ_DCS
-
 
 character(len=16) :: micro_mg_precip_frac_method = 'max_overlap' ! type of precipitation fraction method
 real(r8) :: micro_mg_mass_gradient_alpha = -1._r8                ! Parameters used in mass_gradient method.
@@ -249,6 +246,7 @@ integer :: &
    real(r8) :: cld_sed_in               = huge(1.0_r8) !scale fac for cloud sedimentation velocity
    real(r8) :: nccons                   = huge(1.0_r8)
    real(r8) :: nicons                   = huge(1.0_r8)
+   real(r8) :: mincdnc                  = huge(1.0_r8)
    logical  :: mg_prc_coeff_fix_in      = .false. !temporary variable to maintain BFB, MUST be removed
    logical  :: rrtmg_temp_fix           = .false. !temporary variable to maintain BFB, MUST be removed
 
@@ -277,6 +275,7 @@ subroutine micro_mg_cam_readnl(nlfile)
   logical :: micro_do_nicons    = .false.! micro_do_nicons = .true.,MG does NOT predict numice
   integer :: micro_mg_num_steps = 1      ! Number of substepping iterations done by MG (1.5 only for now).
   real(r8) :: micro_nccons, micro_nicons
+  real(r8) :: micro_mincdnc     = -999.  ! namelist for mincdnc 
 
   ! Local variables
   integer :: unitn, ierr
@@ -284,13 +283,11 @@ subroutine micro_mg_cam_readnl(nlfile)
 
   namelist /micro_mg_nl/ micro_mg_version, micro_mg_sub_version, &
        micro_mg_do_cldice, micro_mg_do_cldliq, micro_mg_num_steps, ice_sed_ai,&
-!!== KZ_DCS
        micro_mg_dcs_tdep, & 
-!!== KZ_DCS
        microp_uniform, micro_mg_dcs, micro_mg_precip_frac_method, &
        micro_mg_mass_gradient_alpha, micro_mg_mass_gradient_beta, &
        micro_mg_berg_eff_factor, micro_do_nccons, micro_do_nicons, &
-       micro_nccons, micro_nicons
+       micro_nccons, micro_nicons, micro_mincdnc 
 
   !-----------------------------------------------------------------------------
 
@@ -314,6 +311,7 @@ subroutine micro_mg_cam_readnl(nlfile)
      do_nicons = micro_do_nicons
      nccons = micro_nccons
      nicons = micro_nicons
+     mincdnc = micro_mincdnc
      
      num_steps = micro_mg_num_steps
      
@@ -373,6 +371,7 @@ subroutine micro_mg_cam_readnl(nlfile)
   call mpibcast(ice_sed_ai,                  1, mpir8,  0, mpicom)
   call mpibcast(nccons,                      1, mpir8,  0, mpicom)
   call mpibcast(nicons,                      1, mpir8,  0, mpicom)
+  call mpibcast(mincdnc,                     1, mpir8,  0, mpicom)
   call mpibcast(micro_mg_precip_frac_method, 16, mpichar,0, mpicom)
   call mpibcast(micro_mg_mass_gradient_alpha, 1, mpir8, 0, mpicom)
   call mpibcast(micro_mg_mass_gradient_beta, 1, mpir8,  0, mpicom)
@@ -721,7 +720,7 @@ subroutine micro_mg_cam_init(pbuf2d)
               micro_mg_dcs,                  &
               micro_mg_dcs_tdep,             &
               microp_uniform, do_cldice, use_hetfrz_classnuc, &
-	      do_nccons, do_nicons, nccons, nicons, &
+	      do_nccons, do_nicons, nccons, nicons, mincdnc, &
               micro_mg_precip_frac_method, micro_mg_berg_eff_factor, &
               allow_sed_supersat, ice_sed_ai, prc_coef1_in,prc_exp_in, &
               prc_exp1_in, cld_sed_in, mg_prc_coeff_fix_in, &
@@ -859,9 +858,7 @@ subroutine micro_mg_cam_init(pbuf2d)
    call addfld ('CV_REFFLIQ', (/ 'lev' /), 'A', 'micron', 'convective cloud liq effective radius')
    call addfld ('CV_REFFICE', (/ 'lev' /), 'A', 'micron', 'convective cloud ice effective radius')
 
-!!== KZ_DCS
    call addfld ('DCST',(/ 'lev' /), 'A','m','dcs')
-!!== KZ_DCS
    ! diagnostic precip
    call addfld ('QRAIN',(/ 'lev' /), 'A','kg/kg','Diagnostic grid-mean rain mixing ratio'         )
    call addfld ('QSNOW',(/ 'lev' /), 'A','kg/kg','Diagnostic grid-mean snow mixing ratio'         )


### PR DESCRIPTION
Implemented an option to impose a minimum droplet number conc. (in-cloud value) in the simulation. Also cleaned up some unnecessary comments added during v1 development. 

Example: To impose a minimum droplet number concentration of 10 cm-3, set 

micro_mincdnc = 10.D6

[Non-BFB] only when micro_mincdnc (by default -999.) is specified to a
       positive number or CDNC is prescribed.