### PR TITLE
Three small BFB fixes.

### DIFF
--- a/components/homme/src/share/bndry_mod_base.F90
+++ b/components/homme/src/share/bndry_mod_base.F90
@@ -71,9 +71,11 @@ contains
     character*(80) errorstring
 
     logical(kind=log_kind),parameter              :: Debug=.FALSE.
-    logical(kind=log_kind) :: singlethread_copy = .false.
+    logical(kind=log_kind) :: singlethread_copy
 
     integer        :: i,j
+
+    singlethread_copy = .false.
 
     pSchedule => Schedule(1)
     nlyr = buffer%nlyr       
@@ -187,9 +189,10 @@ contains
     character*(80) errorstring
 
     logical(kind=log_kind),parameter              :: Debug=.FALSE.
-    logical :: singlethread_copy=.false.
+    logical :: singlethread_copy
     integer        :: i,j
 
+    singlethread_copy = .false.
     pSchedule => Schedule(1)
     nlyr = buffer%nlyr       
 
@@ -370,9 +373,10 @@ contains
     character*(80) errorstring
 
     logical(kind=log_kind),parameter              :: Debug=.FALSE.
-    logical :: singlethread_copy=.false.
+    logical :: singlethread_copy
     integer        :: i,j
 
+    singlethread_copy = .false.
     pSchedule => Schedule(1)
     nlyr = buffer%nlyr       
 

--- a/components/homme/src/share/sl_advection.F90
+++ b/components/homme/src/share/sl_advection.F90
@@ -339,7 +339,7 @@ contains
     !  x(t-ts) = x(t)) -ts * [ 1/2( U(x(t),t-ts)+U(x(t),t)) - ts 1/2 U(x(t),t) gradU(x(t),t-ts) ]
 
     nlyr = 2*nlev
-    if (independent_time_steps) nlyr = nlyr + nlevp
+    if (independent_time_steps) nlyr = nlyr + nlev
 
     do ie = nets,nete
        ! vstarn0 = U(x,t)
@@ -361,7 +361,7 @@ contains
           end if
        enddo
        call edgeVpack_nlyr(edge_g,elem(ie)%desc,elem(ie)%derived%vstar,2*nlev,0,nlyr)
-       if (independent_time_steps) call edgeVpack_nlyr(edge_g,elem(ie)%desc,elem(ie)%derived%divdp,nlevp,2*nlev,nlyr)
+       if (independent_time_steps) call edgeVpack_nlyr(edge_g,elem(ie)%desc,elem(ie)%derived%divdp,nlev,2*nlev,nlyr)
     enddo
 
     call t_startf('ALE_RKdss_bexchV')


### PR DESCRIPTION
This PR fixes three innocuous bugs, in three separate commits:

1. SL transport was exchanging one more level than necessary in its trajectory calculation. The data were ignored, so fixing this reduces comm by a little but does not change the answer.
1. The dynamics-physics remap module can do a total-area calculation on each grid independent of phys_grid.F90, but previously this was possible only in unit testing and not full simulations. Fix this. 
1. Threading was not working properly from a performance perspective in HOMME's boundary exchange. But it was still giving the correct answer.

Fixes #3587.

[BFB]