### PR TITLE
Add activeTracerHorMixTendency to the timeSeriesStatsMonthlyOutput stream

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -998,6 +998,7 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var_array name="activeTracerHorizontalAdvectionTendency"/>')
         lines.append('    <var_array name="activeTracerVerticalAdvectionTendency"/>')
         lines.append('    <var_array name="activeTracerVertMixTendency"/>')
+        lines.append('    <var_array name="activeTracerHorMixTendency"/>')
         lines.append('    <var_array name="activeTracerSurfaceFluxTendency"/>')
         lines.append('    <var_array name="temperatureShortWaveTendency"/>')
         lines.append('    <var_array name="activeTracerNonLocalTendency"/>')


### PR DESCRIPTION
This PR adds one line to the mpas-ocean buildnml script to include the activeTracerHorMixTendency array in the timeSeriesStatsMonthlyOutput stream.

[BFB]