### PR TITLE
Update mpas-source: compiler flag changes

### DIFF
--- a/components/cmake/build_mpas_model.cmake
+++ b/components/cmake/build_mpas_model.cmake
@@ -26,6 +26,9 @@ function(build_mpas_models)
     set(ALBANY True)
   endif()
 
+  # set CIME source path relative to components
+  set(CIMESRC_PATH "../cime/src")
+
   if (CORES)
     add_subdirectory("mpas-source/src")
   endif()


### PR DESCRIPTION
Compiler flag changes for PGI+OpenMP workaround and updating shared MPAS make system for E3SM Builds.

This includes MPAS PRs:
- https://github.com/MPAS-Dev/MPAS-Model/pull/670 for PGI+OpenMP bug workaround
- https://github.com/MPAS-Dev/MPAS-Model/pull/654 and https://github.com/MPAS-Dev/MPAS-Model/pull/673 for shared MPAS make system changes for E3SM builds.

Fixes #3793 

[BFB]