### PR TITLE
Adding dam construction year to MOSART Water Management scheme

### DIFF
--- a/components/mosart/bld/build-namelist
+++ b/components/mosart/bld/build-namelist
@@ -349,8 +349,9 @@ else {
     add_default($nl, 'ReturnFlowFlag');
     add_default($nl, 'TotalDemandFlag');
     add_default($nl, 'GroundWaterFlag');
-    add_default($nl, 'ExternalDemandFlag');   # added by Tian Apr. 2018
-    add_default($nl, 'DemandVariableName');   # added by Tian Apr. 2018
+    add_default($nl, 'ExternalDemandFlag');
+    add_default($nl, 'DemandVariableName');
+    add_default($nl, 'DamConstructionFlag');
 
     add_default($nl, 'OPT_inund');
     add_default($nl, 'OPT_trueDW');

--- a/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
+++ b/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
@@ -52,6 +52,7 @@ for the CLM data in the CESM distribution
 <GroundWaterFlag>0</GroundWaterFlag>
 <ExternalDemandFlag>0</ExternalDemandFlag>
 <DemandVariableName>cons_total</DemandVariableName>
+<DamConstructionFlag>0</DamConstructionFlag>
 
 <!-- inund -->
 <OPT_inund>1</OPT_inund>

--- a/components/mosart/bld/namelist_files/namelist_definition_mosart.xml
+++ b/components/mosart/bld/namelist_files/namelist_definition_mosart.xml
@@ -359,6 +359,14 @@ External Demand Flag, 0 = false
 Demand variable from external file
 </entry>
 
+<entry id="DamConstructionFlag" 
+       type="integer" 
+       category="wrm"
+       group="wrm_inparm" 
+       valid_values="" >
+Dam construction, 0 = false
+</entry>
+
 <!-- ========================================================================================  -->
 <!-- Inundation Namelist -->
 <!-- ========================================================================================  -->

--- a/components/mosart/src/wrm/WRM_modules.F90
+++ b/components/mosart/src/wrm/WRM_modules.F90
@@ -355,7 +355,9 @@ MODULE WRM_modules
      call get_curr_date(yr, month, day, tod)
 
      do idam=1,ctlSubwWRM%LocalNumDam
-
+      if (WRMUnit%active(idam) < 2) then
+         StorWater%release(idam) = 0._r8
+       else
         !if ( WRMUnit%use_FCon(idam) > 0 .or. WRMUnit%use_Supp(idam) > 0) then
            StorWater%release(idam) = WRMUnit%MeanMthFlow(idam,13)
         !endif
@@ -406,6 +408,7 @@ MODULE WRM_modules
  !      write(iulog,*) 'flows', WRMUnit%MeanMthFlow(idam,month),WRMUnit%MeanMthFlow(idam,13)
  !      write(iulog,*) 'storages',StorWater%storage(idam)
  !      endif
+       endif
      end do
 
   end subroutine RegulationRelease
@@ -425,7 +428,7 @@ MODULE WRM_modules
      character(len=*),parameter :: subname='(WRM_storage_targets)'
 
      call get_curr_date(yr, month, day, tod)
-
+   if (WRMUnit%YEAR(idam) > yr) then
      do idam=1,ctlSubwWRM%LocalNumDam
 
         drop = 0
@@ -571,7 +574,7 @@ MODULE WRM_modules
            !print*,WRMUnit%MeanMthFlow(idam,month),WRMUnit%MeanMthFlow(idam,13),StorWater%storage(idam),WRMUnit%StorTarget(idam,month)
         endif
      end do
-
+   endif
   end subroutine WRM_storage_targets
 
 !-----------------------------------------------------------------------
@@ -624,7 +627,7 @@ MODULE WRM_modules
      endif
 
      !print*, "preregulation", damID, StorWater%storage(damID), flow_vol, flow_res, min_flow, month
-
+    if (WRMUnit%active(damID) == 2) then
      if ( ( flow_vol + StorWater%storage(damID) - flow_res- evap) >= max_stor ) then
         flow_res =  flow_vol + StorWater%storage(damID) - max_stor - evap
         StorWater%storage(damID) = max_stor
@@ -648,7 +651,16 @@ MODULE WRM_modules
      else
         StorWater%storage(damID) = StorWater%storage(damID) + flow_vol - flow_res - evap 
      end if
-
+   elseif (WRMUnit%active(damID) == 1) then
+      flow_res = min_flow * 5
+      evap = 0._r8
+      StorWater%storage(damID) = StorWater%storage(damID) + flow_vol - flow_res - evap
+   else
+      flow_res = flow_vol
+      evap = 0._r8
+      StorWater%storage(damID) = StorWater%storage(damID) + flow_vol - flow_res - evap
+   endif
+   
      Trunoff%erout(iunit,nt_nliq) = -flow_res / (theDeltaT)
 
      if (check_local_budget) then

--- a/components/mosart/src/wrm/WRM_modules.F90
+++ b/components/mosart/src/wrm/WRM_modules.F90
@@ -428,7 +428,7 @@ MODULE WRM_modules
      character(len=*),parameter :: subname='(WRM_storage_targets)'
 
      call get_curr_date(yr, month, day, tod)
-   if (WRMUnit%YEAR(idam) > yr) then
+   if (WRMUnit%active(idam) == 2) then !only do this when dam is fully functional
      do idam=1,ctlSubwWRM%LocalNumDam
 
         drop = 0

--- a/components/mosart/src/wrm/WRM_modules.F90
+++ b/components/mosart/src/wrm/WRM_modules.F90
@@ -355,7 +355,7 @@ MODULE WRM_modules
      call get_curr_date(yr, month, day, tod)
 
      do idam=1,ctlSubwWRM%LocalNumDam
-      if (WRMUnit%active(idam) < 2) then
+      if (WRMUnit%active_stage(idam) < 2) then
          StorWater%release(idam) = 0._r8
        else
         !if ( WRMUnit%use_FCon(idam) > 0 .or. WRMUnit%use_Supp(idam) > 0) then
@@ -428,7 +428,7 @@ MODULE WRM_modules
      character(len=*),parameter :: subname='(WRM_storage_targets)'
 
      call get_curr_date(yr, month, day, tod)
-   if (WRMUnit%active(idam) == 2) then !only do this when dam is fully functional
+   if (WRMUnit%active_stage(idam) == 2) then !only do this when dam is fully functional
      do idam=1,ctlSubwWRM%LocalNumDam
 
         drop = 0
@@ -627,7 +627,7 @@ MODULE WRM_modules
      endif
 
      !print*, "preregulation", damID, StorWater%storage(damID), flow_vol, flow_res, min_flow, month
-    if (WRMUnit%active(damID) == 2) then
+    if (WRMUnit%active_stage(damID) == 2) then
      if ( ( flow_vol + StorWater%storage(damID) - flow_res- evap) >= max_stor ) then
         flow_res =  flow_vol + StorWater%storage(damID) - max_stor - evap
         StorWater%storage(damID) = max_stor
@@ -651,7 +651,7 @@ MODULE WRM_modules
      else
         StorWater%storage(damID) = StorWater%storage(damID) + flow_vol - flow_res - evap 
      end if
-   elseif (WRMUnit%active(damID) == 1) then
+   elseif (WRMUnit%active_stage(damID) == 1) then
      if (flow_vol < min_flow * 2._r8) then
          flow_res = flow_vol
       else

--- a/components/mosart/src/wrm/WRM_modules.F90
+++ b/components/mosart/src/wrm/WRM_modules.F90
@@ -652,7 +652,11 @@ MODULE WRM_modules
         StorWater%storage(damID) = StorWater%storage(damID) + flow_vol - flow_res - evap 
      end if
    elseif (WRMUnit%active(damID) == 1) then
-      flow_res = min_flow * 5
+     if (flow_vol < min_flow * 2._r8) then
+         flow_res = flow_vol
+      else
+         flow_res = min_flow * 2._r8 ! outflow during filling period is twice of minimum flow
+      endif     
       evap = 0._r8
       StorWater%storage(damID) = StorWater%storage(damID) + flow_vol - flow_res - evap
    else

--- a/components/mosart/src/wrm/WRM_subw_IO_mod.F90
+++ b/components/mosart/src/wrm/WRM_subw_IO_mod.F90
@@ -835,8 +835,8 @@ MODULE WRM_subw_IO_mod
 
      call get_curr_date(yr, mon, day, tod)
 
-   if (ctlSubwWRM%DamConstructionFlag .eq. 1) then ! allow reseroirs to be filled to 80% of storage within 10 years after construction
-     do idam = 1, ctlSubwWRM%localNumDam
+   do idam = 1, ctlSubwWRM%localNumDam
+    if (ctlSubwWRM%DamConstructionFlag .eq. 1) then ! allow reseroirs to be filled to 80% of storage within 10 years after construction
       if (WRMUnit%active(idam) < 2) then ! 2 means fully functional, 1 means during filling, 0 means not built yet
        if (WRMUnit%YEAR(idam) <= yr .and. WRMUnit%YEAR(idam) > yr-10) then
            WRMUnit%active(idam) = 1
@@ -848,11 +848,11 @@ MODULE WRM_subw_IO_mod
        if (WRMUnit%YEAR(idam) <= yr-10) then
          WRMUnit%active(idam) = 2
        endif
-      endif 
-     enddo
-   else
+      endif     
+    else
       WRMUnit%active(idam) = 2
-   endif
+    endif
+   enddo    
 
      do idam=1,ctlSubwWRM%localNumDam
         if ( mon .eq. WRMUnit%MthStOp(idam)) then

--- a/components/mosart/src/wrm/WRM_subw_IO_mod.F90
+++ b/components/mosart/src/wrm/WRM_subw_IO_mod.F90
@@ -486,8 +486,8 @@ MODULE WRM_subw_IO_mod
 
      allocate (WRMUnit%YEAR(ctlSubwWRM%localNumDam))
      WRMUnit%YEAR = 1900
-     allocate (WRMUnit%active(ctlSubwWRM%localNumDam))
-     WRMUnit%active = 0
+     allocate (WRMUnit%active_stage(ctlSubwWRM%localNumDam))
+     WRMUnit%active_stage = 0
      allocate (WRMUnit%SurfArea(ctlSubwWRM%localNumDam))
      WRMUnit%SurfArea = 0._r8
      allocate (WRMUnit%InstCap(ctlSubwWRM%localNumDam))
@@ -837,20 +837,20 @@ MODULE WRM_subw_IO_mod
 
    do idam = 1, ctlSubwWRM%localNumDam
     if (ctlSubwWRM%DamConstructionFlag .eq. 1) then ! allow reseroirs to be filled to 80% of storage within 10 years after construction
-      if (WRMUnit%active(idam) < 2) then ! 2 means fully functional, 1 means during filling, 0 means not built yet
+      if (WRMUnit%active_stage(idam) < 2) then ! 2 means fully functional, 1 means during filling, 0 means not built yet
        if (WRMUnit%YEAR(idam) <= yr .and. WRMUnit%YEAR(idam) > yr-10) then
-           WRMUnit%active(idam) = 1
+           WRMUnit%active_stage(idam) = 1
            if (StorWater%storage(idam) > 0.8_r8 * WRMUnit%StorCap(idam)) then
-             WRMUnit%active(idam) = 2
+             WRMUnit%active_stage(idam) = 2
            endif
        endif
        
        if (WRMUnit%YEAR(idam) <= yr-10) then
-         WRMUnit%active(idam) = 2
+         WRMUnit%active_stage(idam) = 2
        endif
       endif     
     else
-      WRMUnit%active(idam) = 2
+      WRMUnit%active_stage(idam) = 2
     endif
    enddo    
 

--- a/components/mosart/src/wrm/WRM_subw_IO_mod.F90
+++ b/components/mosart/src/wrm/WRM_subw_IO_mod.F90
@@ -76,12 +76,12 @@ MODULE WRM_subw_IO_mod
 
      character(len=350) :: paraFile, demandPath, DemandVariableName
      integer :: ExtractionFlag, ExtractionMainChannelFlag, RegulationFlag, &
-        ReturnFlowFlag, TotalDemandFlag, GroundWaterFlag, ExternalDemandFlag
+        ReturnFlowFlag, TotalDemandFlag, GroundWaterFlag, ExternalDemandFlag, DamConstructionFlag
 
      namelist /wrm_inparm/  &
         paraFile, demandPath, DemandVariableName, &
         ExtractionFlag, ExtractionMainChannelFlag, RegulationFlag, &
-        ReturnFlowFlag, TotalDemandFlag, GroundWaterFlag, ExternalDemandFlag
+        ReturnFlowFlag, TotalDemandFlag, GroundWaterFlag, ExternalDemandFlag, DamConstructionFlag
 
      character(len=*),parameter :: subname='(WRM_init)'
 
@@ -122,6 +122,7 @@ MODULE WRM_subw_IO_mod
      call mpi_bcast(TotalDemandFlag,  1, MPI_INTEGER, 0, mpicom_rof, ier)
      call mpi_bcast(GroundWaterFlag,  1, MPI_INTEGER, 0, mpicom_rof, ier)
      call mpi_bcast(ExternalDemandFlag,  1, MPI_INTEGER, 0, mpicom_rof, ier)
+     call mpi_bcast(DamConstructionFlag,  1, MPI_INTEGER, 0, mpicom_rof, ier)
 
      ctlSubwWRM%paraFile = paraFile
      ctlSubwWRM%demandPath = demandPath
@@ -133,6 +134,7 @@ MODULE WRM_subw_IO_mod
      ctlSubwWRM%GroundWaterFlag = GroundWaterFlag
      ctlSubwWRM%ExternalDemandFlag = ExternalDemandFlag
      ctlSubwWRM%DemandVariableName = DemandVariableName
+     ctlSubwWRM%DamConstructionFlag = DamConstructionFlag
 
      if (masterproc) then
         write(iulog,*) subname," paraFile        = ",trim(ctlSubwWRM%paraFile)
@@ -145,6 +147,7 @@ MODULE WRM_subw_IO_mod
         write(iulog,*) subname," TotalDemandFlag = ",ctlSubwWRM%TotalDemandFlag
         write(iulog,*) subname," GroundWaterFlag = ",ctlSubwWRM%GroundWaterFlag
         write(iulog,*) subname," ExternalDemandFlag = ",ctlSubwWRM%ExternalDemandFlag
+        write(iulog,*) subname," DamConstructionFlag = ",ctlSubwWRM%DamConstructionFlag
      endif
 
      !-------------------
@@ -483,7 +486,8 @@ MODULE WRM_subw_IO_mod
 
      allocate (WRMUnit%YEAR(ctlSubwWRM%localNumDam))
      WRMUnit%YEAR = 1900
-
+     allocate (WRMUnit%active(ctlSubwWRM%localNumDam))
+     WRMUnit%active = 0
      allocate (WRMUnit%SurfArea(ctlSubwWRM%localNumDam))
      WRMUnit%SurfArea = 0._r8
      allocate (WRMUnit%InstCap(ctlSubwWRM%localNumDam))
@@ -743,6 +747,11 @@ MODULE WRM_subw_IO_mod
            if (WRMUnit%StorageCalibFlag(idam).eq.1) then
               StorWater%storage(idam)  = WRMUnit%StorTarget(idam,13)
            endif
+
+           if (ctlSubwWRM%DamConstructionFlag .eq. 1) then
+             StorWater%storage(idam) = 0._r8 * WRMUnit%StorCap(idam)
+           endif
+
            if ( WRMUnit%StorCap(idam) <= 0 ) then
               write(iulog,*) subname, "Error negative max cap for reservoir ", idam, WRMUnit%StorCap(idam)
               call shr_sys_abort(subname//' ERROR: negative max cap for reservoir')
@@ -825,6 +834,26 @@ MODULE WRM_subw_IO_mod
      character(len=*),parameter :: subname = '(WRM_computeRelease)'
 
      call get_curr_date(yr, mon, day, tod)
+
+   if (ctlSubwWRM%DamConstructionFlag .eq. 1) then ! allow reseroirs to be filled to 80% of storage within 10 years after construction
+     do idam = 1, ctlSubwWRM%localNumDam
+      if (WRMUnit%active(idam) < 2) then ! 2 means fully functional, 1 means during filling, 0 means not built yet
+       if (WRMUnit%YEAR(idam) <= yr .and. WRMUnit%YEAR(idam) > yr-10) then
+           WRMUnit%active(idam) = 1
+           if (StorWater%storage(idam) > 0.8_r8 * WRMUnit%StorCap(idam)) then
+             WRMUnit%active(idam) = 2
+           endif
+       endif
+       
+       if (WRMUnit%YEAR(idam) <= yr-10) then
+         WRMUnit%active(idam) = 2
+       endif
+      endif 
+     enddo
+   else
+      WRMUnit%active(idam) = 2
+   endif
+
      do idam=1,ctlSubwWRM%localNumDam
         if ( mon .eq. WRMUnit%MthStOp(idam)) then
            WRMUnit%StorMthStOp(idam) = StorWater%storage(idam)

--- a/components/mosart/src/wrm/WRM_type_mod.F90
+++ b/components/mosart/src/wrm/WRM_type_mod.F90
@@ -79,7 +79,7 @@ MODULE WRM_type_mod
      real(r8), pointer :: MaxStorTarget(:)  ! (nd)
 
      integer , pointer :: YEAR(:)           ! (nd) year dam was constructed and operationnal
-     integer , pointer :: active(:)         ! (nd) whether dam is not functional (before construction) or during filling (<10 yrs after built and <80% of capacity) or fully functional (10 yrs after built or >80% of capacity) 
+     integer , pointer :: active_stage(:)   ! (nd) whether dam is not functional (before construction) or during filling (<10 yrs after built and <80% of capacity) or fully functional (10 yrs after built or >80% of capacity) 
      integer , pointer :: use_Irrig(:)      ! (nd) reservoir purpose irrigation 
      integer , pointer :: use_Elec(:)       ! (nd) hydropower
      integer , pointer :: use_FCon(:)       ! (nd) flood control

--- a/components/mosart/src/wrm/WRM_type_mod.F90
+++ b/components/mosart/src/wrm/WRM_type_mod.F90
@@ -32,6 +32,7 @@ MODULE WRM_type_mod
      integer :: TotalDemandFlag  ! Flag to indicate if the demand includes irrigation and non irrigation demands
      integer :: GroundWaterFlag  ! Flag to know if demand needs to be separated with GW-SW
      integer :: ExternalDemandFlag  ! Flag to decide where does the demand come from, external files or ELM
+     integer :: DamConstructionFlag  ! Flag to indicate if the dam construction year is considered
 
      character(len=256) :: paraFile         ! the path of the parameter files
      character(len=256) :: demandPath       ! the path of the water demand data
@@ -78,6 +79,7 @@ MODULE WRM_type_mod
      real(r8), pointer :: MaxStorTarget(:)  ! (nd)
 
      integer , pointer :: YEAR(:)           ! (nd) year dam was constructed and operationnal
+     integer , pointer :: active(:)         ! (nd) whether dam is not functional (before construction) or during filling (<10 yrs after built and <80% of capacity) or fully functional (10 yrs after built or >80% of capacity) 
      integer , pointer :: use_Irrig(:)      ! (nd) reservoir purpose irrigation 
      integer , pointer :: use_Elec(:)       ! (nd) hydropower
      integer , pointer :: use_FCon(:)       ! (nd) flood control


### PR DESCRIPTION
Add dam construction feature to MOSART-WM to allow dams taking effects after construction. 
This feature is particularly useful for historical transient runs with water management on.
Dam built year was from GRaND database.

[BFB] (namelist will change as new flag is added)