### PR TITLE
Updated CLUBBv2 paramters and flags

### DIFF
--- a/components/cam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/cam/bld/namelist_files/namelist_defaults_cam.xml
@@ -957,7 +957,8 @@
 <clubb_wpxp_L_thresh                              > 60.0D0   </clubb_wpxp_L_thresh>
 <relvar_fix                                       > .false.  </relvar_fix>      
 <clubb_use_sgv                                    > .false. </clubb_use_sgv>
-
+<clubb_vert_avg_closure                           > .true.  </clubb_vert_avg_closure>
+<clubb_ipdf_call_placement                        > 1       </clubb_ipdf_call_placement>
 
 <!-- CLUBB_history -->
 <clubb_history               > .false. </clubb_history>

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -2864,6 +2864,19 @@ Temporary variable for a bug fix. Introduced to maintain BFB, must be REMOVED la
 Default: FALSE
 </entry>
 
+<!--Clubb config flags  -->
+<entry id="clubb_vert_avg_closure" type="logical" category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="" >
+CLUBB flag to determine 1) if the trapezoidal rule is called for the thermodynamic-level variables output from pdf_closure; 2) if the trapezoidal rule is called for three momentum-level variables output from pdf_closure; and 3) if call subroutine pdf_closure twice. True means all three options are True, while FALSE means all three options are false.
+Default: TRUE
+</entry>
+
+<entry id="clubb_ipdf_call_placement" type="integer" category="pblrad"
+       group="clubbpbl_diff_nl" valid_values="1,2,3" >
+Select the placement of the call to CLUBB's PDF: 1) ipdf_pre_advance_fields --> Call before advancing predictive fields ; 2) ipdf_post_advance_fields --> Call after advancing predictive fields ; 3) ipdf_pre_post_advance_fields --> Call both before and after advancing predictive fields 
+Default: 1
+</entry>
+
 
 <!-- Clubb tunable parameters -->
 
@@ -3116,6 +3129,11 @@ Lscale threshold: damp C6 & C7  [m]
 Default: 60.0D0
 </entry>
 
+<entry id="clubb_altitude_thresh"  type="real" category="pblrad"
+       group="clubb_param_nl" valid_values="" >
+Lscale threshold: prevent large damping at low altitudes where Lscale is small
+Default: 100.0D0
+</entry>
 
 =======
 <!-- Ozone: Data (original CAM version) -->

--- a/components/cam/src/physics/cam/clubb_intr.F90
+++ b/components/cam/src/physics/cam/clubb_intr.F90
@@ -391,7 +391,11 @@ end subroutine clubb_init_cnst
     use cam_abortutils,  only: endrun
     use stats_variables, only: l_stats, l_output_rad_files
     use mpishorthand
-    use model_flags,     only: l_diffuse_rtm_and_thlm, l_stability_correct_Kh_N2_zm
+    use model_flags,     only: l_diffuse_rtm_and_thlm, l_stability_correct_Kh_N2_zm, &
+                               l_vert_avg_closure, l_trapezoidal_rule_zt, &
+                               l_trapezoidal_rule_zm, l_call_pdf_closure_twice,&
+                               ipdf_call_placement
+
     use parameters_tunable, only: clubb_param_readnl
 #endif
 
@@ -401,14 +405,18 @@ end subroutine clubb_init_cnst
     logical :: clubb_history, clubb_rad_history, clubb_cloudtop_cooling, clubb_rainevap_turb, &
                clubb_stabcorrect, clubb_expldiff ! Stats enabled (T/F)      
     logical :: clubb_use_sgv !PMA This flag controls tuning for tpert and gustiness
-
+    logical :: clubb_vert_avg_closure !XZheng This flag sets four clubb config flags for pdf_closure and the trapezoidal rule to  compute the varibles that are output from high order closure
+    integer :: clubb_ipdf_call_placement  !XZheng This flag sets options for the placement of the call to CLUBB's PDF. 
+ 
     integer :: iunit, read_status
 
     namelist /clubb_his_nl/ clubb_history, clubb_rad_history
     namelist /clubbpbl_diff_nl/ clubb_cloudtop_cooling, clubb_rainevap_turb, clubb_expldiff, &
                                 clubb_do_adv, clubb_do_deep, clubb_timestep, clubb_stabcorrect, &
                                 clubb_rnevap_effic, clubb_liq_deep, clubb_liq_sh, clubb_ice_deep, &
-                                clubb_ice_sh, clubb_tk1, clubb_tk2, relvar_fix, clubb_use_sgv
+                                clubb_ice_sh, clubb_tk1, clubb_tk2, relvar_fix, clubb_use_sgv, &
+                                clubb_vert_avg_closure, clubb_ipdf_call_placement
+
 
     !----- Begin Code -----
 
@@ -423,6 +431,9 @@ end subroutine clubb_init_cnst
     clubb_do_adv       = .false.   ! Initialize to false
     clubb_do_deep      = .false.   ! Initialize to false
     use_sgv            = .false.
+    clubb_vert_avg_closure = .true.
+    clubb_ipdf_call_placement = -999
+
 
     !  Read namelist to determine if CLUBB history should be called
     if (masterproc) then
@@ -469,9 +480,12 @@ end subroutine clubb_init_cnst
       call mpibcast(clubb_tk2,                1,   mpir8,   0, mpicom)
       call mpibcast(relvar_fix,               1,   mpilog,  0, mpicom)
       call mpibcast(clubb_use_sgv,            1,   mpilog,   0, mpicom)
+      call mpibcast(clubb_vert_avg_closure,   1,   mpilog,   0, mpicom)
+      call mpibcast(clubb_ipdf_call_placement,   1,   mpilog,   0, mpicom)
 #endif
 
     !  Overwrite defaults if they are true
+    if (clubb_ipdf_call_placement > 0) ipdf_call_placement = clubb_ipdf_call_placement
     if (clubb_history) l_stats = .true.
     if (clubb_rad_history) l_output_rad_files = .true. 
     if (clubb_cloudtop_cooling) do_cldcool = .true.
@@ -486,7 +500,19 @@ end subroutine clubb_init_cnst
       l_diffuse_rtm_and_thlm       = .true.   ! CLUBB flag set to true
       l_stability_correct_Kh_N2_zm = .true.   ! CLUBB flag set to true
     endif
-      
+
+    if (clubb_vert_avg_closure) then
+      l_vert_avg_closure       = .true.   ! CLUBB flag set to true
+      l_trapezoidal_rule_zt    = .true.   ! CLUBB flag set to true
+      l_trapezoidal_rule_zm    = .true.   ! CLUBB flag set to true
+      l_call_pdf_closure_twice = .true.   ! CLUBB flag set to true
+    else
+      l_vert_avg_closure       = .false.   ! CLUBB flag set to false
+      l_trapezoidal_rule_zt    = .false.   ! CLUBB flag set to false
+      l_trapezoidal_rule_zm    = .false.   ! CLUBB flag set to false
+      l_call_pdf_closure_twice = .false.   ! CLUBB flag set to false
+    endif
+    
     ! read tunable parameters from namelist, handlings of masterproc vs others
     ! are done within clubb_param_readnl
     call clubb_param_readnl(nlfile)

--- a/components/cam/src/physics/cam/clubb_intr.F90
+++ b/components/cam/src/physics/cam/clubb_intr.F90
@@ -481,7 +481,7 @@ end subroutine clubb_init_cnst
       call mpibcast(relvar_fix,               1,   mpilog,  0, mpicom)
       call mpibcast(clubb_use_sgv,            1,   mpilog,   0, mpicom)
       call mpibcast(clubb_vert_avg_closure,   1,   mpilog,   0, mpicom)
-      call mpibcast(clubb_ipdf_call_placement,   1,   mpilog,   0, mpicom)
+      call mpibcast(clubb_ipdf_call_placement,   1,   mpiint,   0, mpicom)
 #endif
 
     !  Overwrite defaults if they are true

--- a/components/cam/src/physics/clubb/advance_clubb_core_module.F90
+++ b/components/cam/src/physics/clubb/advance_clubb_core_module.F90
@@ -88,6 +88,8 @@ module advance_clubb_core_module
 ! Joshua Fasching, Adam Smith, and Michael Falk).
 !-----------------------------------------------------------------------
 
+  use model_flags, only: ipdf_call_placement 
+
   implicit none
 
   public ::  &
@@ -105,8 +107,8 @@ module advance_clubb_core_module
                                        ! predictive fields
 
   ! Select the placement of the call to CLUBB's PDF.
-  integer, parameter :: &
-    ipdf_call_placement = ipdf_pre_advance_fields
+  !integer, parameter :: &
+  !  ipdf_call_placement = ipdf_pre_advance_fields
 
   private ! Default Scope
 

--- a/components/cam/src/physics/clubb/advance_clubb_core_module.F90
+++ b/components/cam/src/physics/clubb/advance_clubb_core_module.F90
@@ -106,10 +106,6 @@ module advance_clubb_core_module
     ipdf_pre_post_advance_fields = 3   ! Call both before and after advancing
                                        ! predictive fields
 
-  ! Select the placement of the call to CLUBB's PDF.
-  !integer, parameter :: &
-  !  ipdf_call_placement = ipdf_pre_advance_fields
-
   private ! Default Scope
 
   contains

--- a/components/cam/src/physics/clubb/advance_xm_wpxp_module.F90
+++ b/components/cam/src/physics/clubb/advance_xm_wpxp_module.F90
@@ -4314,6 +4314,9 @@ module advance_xm_wpxp_module
     use grid_class, only: & 
         gr ! Variable(s)
 
+    use parameters_tunable, only: &
+        altitude_threshold ! Variable(s)   
+
     implicit none
 
     ! Input variables
@@ -4327,9 +4330,9 @@ module advance_xm_wpxp_module
       Cx_Skw_fnc            ! Initial skewness function before damping
 
     ! Local variables
-    real( kind = core_rknd ), parameter :: &
+!    real( kind = core_rknd ), parameter :: &
       ! Added to prevent large damping at low altitudes where Lscale is small
-      altitude_threshold = one_hundred  ! Altitude above which damping should occur
+!      altitude_threshold = one_hundred  ! Altitude above which damping should occur
 
     ! Return Variable
     real( kind = core_rknd ), dimension(gr%nz) :: damped_value

--- a/components/cam/src/physics/clubb/advance_xm_wpxp_module.F90
+++ b/components/cam/src/physics/clubb/advance_xm_wpxp_module.F90
@@ -4329,11 +4329,6 @@ module advance_xm_wpxp_module
       Lscale,           &   ! Current value of Lscale
       Cx_Skw_fnc            ! Initial skewness function before damping
 
-    ! Local variables
-!    real( kind = core_rknd ), parameter :: &
-      ! Added to prevent large damping at low altitudes where Lscale is small
-!      altitude_threshold = one_hundred  ! Altitude above which damping should occur
-
     ! Return Variable
     real( kind = core_rknd ), dimension(gr%nz) :: damped_value
 

--- a/components/cam/src/physics/clubb/model_flags.F90
+++ b/components/cam/src/physics/clubb/model_flags.F90
@@ -133,6 +133,13 @@ module model_flags
     saturation_gfdl   = 2, & ! Constant for the GFDL approximation of saturation
     saturation_flatau = 3    ! Constant for Flatau approximations of saturation
 
+  integer, public :: &
+    ipdf_call_placement = 1 !Options for the placement of the call to CLUBB's PDF. 
+                            !1 ipdf_pre_advance_fields, 
+                            !2 ipdf_post_advance_fields, 
+                            !3 ipdf_pre_post_advance_fields
+ 
+
   !-----------------------------------------------------------------------------
   ! Options that can be changed at runtime 
   ! The default values are chosen below and overwritten if desired by the user
@@ -171,7 +178,7 @@ module model_flags
 
   ! Use 2 calls to pdf_closure and the trapezoidal rule to  compute the 
   ! varibles that are output from high order closure
-  logical, private :: &
+  logical, public :: &
     l_vert_avg_closure  = .true.
 !$omp threadprivate(l_vert_avg_closure)
 

--- a/components/cam/src/physics/clubb/parameter_indices.F90
+++ b/components/cam/src/physics/clubb/parameter_indices.F90
@@ -26,7 +26,7 @@ module parameter_indices
   private ! Default Scope
 
   integer, parameter, public ::  & 
-    nparams = 82 ! Total tunable parameters
+    nparams = 83 ! Total tunable parameters
 
 !***************************************************************
 !                    ***** IMPORTANT *****
@@ -124,7 +124,8 @@ module parameter_indices
     iC_invrs_tau_bkgnd            = 79, &
     iC_invrs_tau_sfc              = 80, &
     iC_invrs_tau_shear            = 81, &
-    iC_invrs_tau_N2               = 82
+    iC_invrs_tau_N2               = 82, &
+    ialtitude_thresh              = 83 
 
 
 end module parameter_indices


### PR DESCRIPTION
Converted several local CLUBB parameters and flags to namelist variables.
 Local variables include altitude_threshold, ipdf_call_placement, and l_vert_avg_closure. 
The corresponding new namelist variables are clubb_vert_avg_closure, 
clubb_ipdf_call_placement, and clubb_altitude_thresh

[NML] New namelist variables are not added to atm_in by default
[BFB] when the revised variables are the default values