### PR TITLE
EAM: Remove Q from cam/dynamics/se restart.

### DIFF
--- a/components/homme/src/share/sl_advection.F90
+++ b/components/homme/src/share/sl_advection.F90
@@ -829,15 +829,6 @@ contains
     real(real_kind) :: dp_neg_min
     integer :: i, j, k, k1, k2, d, t
 
-#ifndef NDEBUG
-    if (abs(hvcoord%hybi(1)) > 10*eps .or. hvcoord%hyai(nlevp) > 10*eps) then
-       if (hybrid%masterthread) &
-            print *, 'calc_vertically_lagrangian_levels: bi(1)', hvcoord%hybi(1), 'ai(nlevp)', &
-            hvcoord%hyai(nlevp)
-       call abortmp('hvcoord has unexpected non-0 entries at the bottom and/or top')
-    end if
-#endif
-
     ! Reconstruct an approximation to endpoint eta_dot_dpdn on
     ! Eulerian levels.
     do t = 1,2
@@ -902,13 +893,6 @@ contains
 
     dp_neg_min = reconstruct_and_limit_dp(elem%state%dp3d(:,:,:,tl%np1), &
          dt, dp_tol, eta_dot_dpdn(:,:,:,1), dprecon)
-#ifndef NDEBUG
-    if (dp_neg_min < dp_tol) then
-       write(iulog, '(a,i7,i7,es11.4)') &
-            'sl_advection: reconstruct_and_limit_dp (rank,ie) returned', &
-            hybrid%par%rank, ie, dp_neg_min
-    end if
-#endif
   end subroutine calc_vertically_lagrangian_levels
 
   subroutine eval_lagrange_poly_derivative(n, xs, ys, xi, yp)


### PR DESCRIPTION
Previously, the restart file contained both Q and Qdp. These fields are redundant and numerous. This PR removes Q. This will reduce restart file size and write and read time. This should benefit both SCREAM and RRM in v2.

Also remove some debug-build output from SL transport that I had meant to remove a while ago.

The model with this PR can restart from old restart files since this PR simply makes the read ignore Q. But of course old code won't be able to restart from the trimmed restart file.

[BFB]