### PR TITLE
Switch on sea ice defaults and snicar on lnd to match snow on sea ice

### DIFF
--- a/components/elm/bld/CLMBuildNamelist.pm
+++ b/components/elm/bld/CLMBuildNamelist.pm
@@ -99,15 +99,15 @@ OPTIONS
                                 bgc   = Carbon Nitrogen with methane, nitrification, vertical soil C,
                                         CENTURY decomposition
                                         (or CLM45BGC if phys=clm4_5/clm5_0, use_cn=true, use_vertsoilc=true,
-                                         use_century_decomp=true, use_nitrif_denitrif=true, and use_lch4=true,
-                                         use_dynroot)
+                                         use_century_decomp=true, use_nitrif_denitrif=true, use_lch4=true,
+                                         and use_snicar_ad=true, use_dynroot)
                                         This toggles on the namelist variables:
-                                         use_cn, use_lch4, use_nitrif_denitrif, use_vertsoilc, use_century_decomp,
+                                         use_cn, use_lch4, use_nitrif_denitrif, use_vertsoilc, use_century_decomp, use_snicar_ad
                                          use_dynroot
                                 fates    = functionaly assembled terrestrial ecosystem simulator
                                           with native below ground bgc
                                           This toggles on the namelist variables:
-                                          use_fates, use_vertsoilc, use_century_decomp
+                                          use_fates, use_vertsoilc, use_snicar_ad, use_century_decomp
 
      -bgc_spinup "on|off"     CLM 4.5 Only. For CLM 4.0, spinup is controlled from configure.
                               Turn on given spinup mode for BGC setting of CN
@@ -794,7 +794,8 @@ sub setup_cmdl_fates_mode {
       my @list  = (  "fates_spitfire_mode", "use_vertsoilc", "use_century_decomp",
                      "use_fates_planthydro", "use_fates_ed_st3", "use_fates_ed_prescribed_phys", 
 		     "use_fates_inventory_init", "use_fates_fixed_biogeog", "fates_inventory_ctrl_filename","use_fates_logging",
-		     "use_fates_parteh_mode","use_fates_cohort_age_tracking");
+		     "use_fates_parteh_mode","use_fates_cohort_age_tracking",
+	             "use_snicar_ad");
       foreach my $var ( @list ) {
 	  if ( defined($nl->get_value($var))  ) {
 	      $nl_flags->{$var} = $nl->get_value($var);
@@ -1005,7 +1006,7 @@ sub setup_cmdl_bgc {
     }
 
     # If the variable has already been set use it, if not set to the value defined by the bgc_mode
-    my @list  = (  "use_lch4", "use_nitrif_denitrif", "use_vertsoilc", "use_century_decomp" );
+    my @list  = (  "use_lch4", "use_nitrif_denitrif", "use_vertsoilc", "use_century_decomp", "use_snicar_ad" );
     my $ndiff = 0;
     foreach my $var ( @list ) {
        if ( ! defined($nl->get_value($var))  ) {
@@ -1017,6 +1018,9 @@ sub setup_cmdl_bgc {
           $nl_flags->{$var} = $nl->get_value($var);
        }
        if ($var eq "use_vertsoilc") {
+          $nl_flags->{$var} = ".true.";
+       }
+       if ($var eq "use_snicar_ad") {
           $nl_flags->{$var} = ".true.";
        }
        $val = $nl_flags->{$var};
@@ -2244,6 +2248,7 @@ sub setup_logic_snow {
   add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fsnowaging' );
 }
 
+
 #-------------------------------------------------------------------------------
 
 sub setup_logic_glacier {
@@ -2475,6 +2480,7 @@ sub setup_logic_demand {
     $settings{'use_lch4'}            = $nl_flags->{'use_lch4'};
     $settings{'use_nitrif_denitrif'} = $nl_flags->{'use_nitrif_denitrif'};
     $settings{'use_vertsoilc'}       = $nl_flags->{'use_vertsoilc'};
+    $settings{'use_snicar_ad'}       = $nl_flags->{'use_snicar_ad'};
     $settings{'use_century_decomp'}  = $nl_flags->{'use_century_decomp'};
     $settings{'use_crop'}            = $nl_flags->{'use_crop'};
   }
@@ -2593,6 +2599,7 @@ sub setup_logic_initial_conditions {
                     'use_cn'=>$nl_flags->{'use_cn'}, 'use_cndv'=>$nl_flags->{'use_cndv'},
                     'use_nitrif_denitrif'=>$nl_flags->{'use_nitrif_denitrif'},
                     'use_vertsoilc'=>$nl_flags->{'use_vertsoilc'},
+                    'use_snicar_ad'=>$nl_flags->{'use_snicar_ad'},
                     'use_century_decomp'=>$nl_flags->{'use_century_decomp'},
                     'sim_year'=>$nl_flags->{'sim_year'}, 'maxpft'=>$nl_flags->{'maxpft'},
                     'more_vertlayers'=>$nl_flags->{'more_vert'},
@@ -2619,6 +2626,7 @@ sub setup_logic_initial_conditions {
                     'use_cn'=>$nl_flags->{'use_cn'}, 'use_cndv'=>$nl_flags->{'use_cndv'},
                     'use_nitrif_denitrif'=>$nl_flags->{'use_nitrif_denitrif'},
                     'use_vertsoilc'=>$nl_flags->{'use_vertsoilc'},
+                    'use_snicar_ad'=>$nl_flags->{'use_snicar_ad'},
                     'use_century_decomp'=>$nl_flags->{'use_century_decomp'},
                     'sim_year'=>$nl_flags->{'sim_year'}, 'maxpft'=>$nl_flags->{'maxpft'},
                     'more_vertlayers'=>$nl_flags->{'more_vert'},
@@ -2645,6 +2653,7 @@ sub setup_logic_initial_conditions {
                     'use_cn'=>$nl_flags->{'use_cn'}, 'use_cndv'=>$nl_flags->{'use_cndv'},
                     'use_nitrif_denitrif'=>$nl_flags->{'use_nitrif_denitrif'},
                     'use_vertsoilc'=>$nl_flags->{'use_vertsoilc'},
+                    'use_snicar_ad'=>$nl_flags->{'use_snicar_ad'},
                     'use_century_decomp'=>$nl_flags->{'use_century_decomp'},
                     'sim_year'=>$nl_flags->{'sim_year'}, 'maxpft'=>$nl_flags->{'maxpft'},
                     'more_vertlayers'=>$nl_flags->{'more_vert'},

--- a/components/elm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -498,6 +498,7 @@ this mask will have smb calculated over the entire global land surface
 <!--  ***********  Resolution independent:   ***********  -->
 <fsnowoptics >lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
 <fsnowaging  >lnd/clm2/snicardata/snicar_drdt_bst_fit_60_c070416.nc</fsnowaging>
+<use_snicar_ad>.true.</use_snicar_ad>
 
 <!-- Nitrogen deposition streams namelist defaults -->
 <stream_year_first_ndep use_cn=".true."   sim_year="2000" >2000</stream_year_first_ndep>

--- a/components/elm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/elm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -629,10 +629,10 @@ Toggle to turn on calculation of SNow and Ice Aerosol Radiation model (SNICAR) r
 </entry>
 
 <entry id="use_snicar_ad" type="logical" category="physics"
-       group="clm_inparm" valid_values="" value=".false.">
+       group="clm_inparm" valid_values="" value=".true.">
 Toggle to turn on SNICAR_AD snow shortwave algorithms
 The same snow shortwave algorithm can be turned on for sea-ice simulation
-with config_use_snicar_ad in mpas-seaic namelist
+with config_use_snicar_ad in mpas-seaice namelist
 </entry>
 
 <entry id="use_noio" type="logical" category="default_settings"

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -94,8 +94,8 @@ def buildnml(case, caseroot, compname):
         restoring_file += 'sss.monthlyClimatology.PHC2_salx_040803.oEC60to30v3.nc'
         analysis_mask_file += 'oEC60to30v3_Atlantic_region_and_southern_transect.nc'
     elif ocn_grid == 'oEC60to30v3_ICG':
-        ic_date += '171101'
-        ic_prefix += 'oEC60to30v3_60layer.restartFrom_anvil0926'
+        ic_date += '200927'
+        ic_prefix += 'oEC60to30v3.restartFrom_anvilG'
         decomp_date += '161222'
         decomp_prefix += 'mpas-o.graph.info.'
         analysis_mask_file += 'oEC60to30v3_Atlantic_region_and_southern_transect.nc'

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -61,7 +61,7 @@
 <!-- dimensions -->
 <config_nCategories>5</config_nCategories>
 <config_nIceLayers>7</config_nIceLayers>
-<config_nSnowLayers>1</config_nSnowLayers>
+<config_nSnowLayers>5</config_nSnowLayers>
 
 <!-- initialize -->
 <config_initial_condition_type>'cice_default'</config_initial_condition_type>
@@ -150,7 +150,7 @@
 <config_use_column_biogeochemistry>false</config_use_column_biogeochemistry>
 <config_use_column_itd_thermodynamics>true</config_use_column_itd_thermodynamics>
 <config_use_column_ridging>true</config_use_column_ridging>
-<config_use_column_snow_tracers>false</config_use_column_snow_tracers>
+<config_use_column_snow_tracers>true</config_use_column_snow_tracers>
 
 <!-- column_tracers -->
 <config_use_ice_age>true</config_use_ice_age>
@@ -160,8 +160,8 @@
 <config_use_level_meltponds>true</config_use_level_meltponds>
 <config_use_topo_meltponds>false</config_use_topo_meltponds>
 <config_use_aerosols>false</config_use_aerosols>
-<config_use_effective_snow_density>false</config_use_effective_snow_density>
-<config_use_snow_grain_radius>false</config_use_snow_grain_radius>
+<config_use_effective_snow_density>true</config_use_effective_snow_density>
+<config_use_snow_grain_radius>true</config_use_snow_grain_radius>
 
 <!-- biogeochemistry -->
 <config_use_brine>false</config_use_brine>
@@ -311,7 +311,7 @@
 <!-- shortwave -->
 <config_shortwave_type>'dEdd'</config_shortwave_type>
 <config_albedo_type>'ccsm3'</config_albedo_type>
-<config_use_snicar_ad>false</config_use_snicar_ad>
+<config_use_snicar_ad>true</config_use_snicar_ad>
 <config_visible_ice_albedo>0.78</config_visible_ice_albedo>
 <config_infrared_ice_albedo>0.36</config_infrared_ice_albedo>
 <config_visible_snow_albedo>0.98</config_visible_snow_albedo>
@@ -325,9 +325,9 @@
 <config_algae_absorption_coefficient>0.6</config_algae_absorption_coefficient>
 
 <!-- snow -->
-<config_snow_redistribution_scheme>'none'</config_snow_redistribution_scheme>
-<config_fallen_snow_radius>54.4</config_fallen_snow_radius>
-<config_use_snow_liquid_ponds>false</config_use_snow_liquid_ponds>
+<config_snow_redistribution_scheme>'ITDrdg'</config_snow_redistribution_scheme>
+<config_fallen_snow_radius>54.526</config_fallen_snow_radius>
+<config_use_snow_liquid_ponds>true</config_use_snow_liquid_ponds>
 <config_new_snow_density>100.0</config_new_snow_density>
 <config_max_snow_density>450.0</config_max_snow_density>
 <config_minimum_wind_compaction>10.0</config_minimum_wind_compaction>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -83,8 +83,8 @@ def buildnml(case, caseroot, compname):
             points_file = 'seaice_points_EC.60to30v3_netcdf3_05152018.nc'
 
     elif ice_grid == 'oEC60to30v3_ICG':
-        grid_date += '171101'
-        grid_prefix += 'seaice.EC60to30v3.restartFrom_anvil0926'
+        grid_date += '200927'
+        grid_prefix += 'seaice.EC60to30v3.restartFrom_anvilG'
         decomp_date += '161222'
         decomp_prefix += 'mpas-cice.graph.info.'
     elif ice_grid == 'oEC60to30wLI':


### PR DESCRIPTION
This pull request switches on several new features in the sea ice and land models for E3SM V2 that are already on master and have been tested in multiple B-case simulations, individually and together:

1) Switch on snicar on sea ice as the new default in mpassi_in:  
config_use_snicar_ad = true

2) Switch on snicar in elm so that radiative transfer over snow on land and sea ice are identical:
use_snicar_ad = .true.

3) Increase the number of snow layers on sea ice from 1 to 5 layers:
config_nsnowlayers = 5

4) Switch on the snow morphology and adjust defaults:
config_fallen_snow_radius = 54.526
config_snow_redistribution_scheme = 'ITDrdg'
config_use_column_snow_tracers = true
config_use_effective_snow_density = true
config_use_snow_grain_radius = true
config_use_snow_liquid_ponds = true

The changes have been tested in a 30 year B-case simulation on Compy, as indicated here:
https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/1638957185/20200720.snow5Snicar2.A+WCYCL1850S.ne30+r05+oEC60to30v3.compy

They have also passed a five-day B-case smoke test on this branch in the following configuration on Cori:
-compset A_WCYCL1850 -mach cori-knl -res ne30pg2_r05_EC30to60E2r2

[NML]
[non-BFB]
