### PR TITLE
Add script support for new ocn/ice WC14to60E2r3 grid

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2210,7 +2210,7 @@
       <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to10.180716.nc</file>
       <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to6.180803.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_EC30to60E2r2.200908.nc</file>
-      <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WC14to60E2r3.200714.nc</file>
+      <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WC14to60E2r3.200929.nc</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
@@ -2243,8 +2243,8 @@
       <file grid="ice|ocn" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to6.180905.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_EC30to60E2r2.200908.nc</file>
       <file grid="ice/ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_EC30to60E2r2.200908.nc</file>
-      <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_WC14to60E2r3.200813.nc</file>
-      <file grid="ice/ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_WC14to60E2r3.200813.nc</file>
+      <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_WC14to60E2r3.200929.nc</file>
+      <file grid="ice/ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_WC14to60E2r3.200929.nc</file>
       <desc>TL319 is JRA lat/lon grid:</desc>
     </domain>
 
@@ -2344,8 +2344,8 @@
       <file grid="ice|ocn" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_ARRM60to10.200527.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_EC30to60E2r2.200908.nc</file>
       <file grid="ice/ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_EC30to60E2r2.200908.nc</file>
-      <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WC14to60E2r3.200714.nc</file>
-      <file grid="ice/ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_WC14to60E2r3.200714.nc</file>
+      <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WC14to60E2r3.200929.nc</file>
+      <file grid="ice/ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_WC14to60E2r3.200929.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_gx1v6.190806.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
@@ -2654,14 +2654,14 @@
     <domain name="WC14to60E2r3">
       <nx>407420</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200714.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200929.nc</file>
       <desc>WC14to60E2r3 is a MPAS ice/ocean grid with enhanced resolution of 14km along the coast of North America, the Northern Atlantic subpolar gyre, and the Arctic Ocean. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
     <domain name="WC14to60E2r3_ICG">
       <nx>407420</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200714.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200929.nc</file>
       <desc>WC14to60E2r3 is a MPAS ice/ocean grid with enhanced resolution of 14km along the coast of North America, the Northern Atlantic subpolar gyre, and the Arctic Ocean. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid. This version of initial conditions is spun-up from a G compset run:</desc>
     </domain>
 
@@ -2686,8 +2686,8 @@
       <file grid="lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_ARRM60to10.200602.nc</file>
       <file grid="atm" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_EC30to60E2r2.200908.nc</file>
       <file grid="lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_EC30to60E2r2.200908.nc</file>
-      <file grid="atm" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_WC14to60E2r3.200714.nc</file>
-      <file grid="lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_WC14to60E2r3.200714.nc</file>
+      <file grid="atm" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_WC14to60E2r3.200929.nc</file>
+      <file grid="lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_WC14to60E2r3.200929.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_gx1v6.191014.nc</file>
       <desc>r05 is 1/2 degree river routing grid:</desc>
     </domain>
@@ -3124,19 +3124,19 @@
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="WC14to60E2r3_ICG">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_mono.200714.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200714.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200714.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200714.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200714.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_mono.200928.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200928.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200928.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200928.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200928.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="WC14to60E2r3">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_mono.200714.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200714.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200714.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200714.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200714.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_mono.200928.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200928.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200928.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200928.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200928.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
@@ -3784,11 +3784,11 @@
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="WC14to60E2r3">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_WC14to60E2r3_aave.200714.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_WC14to60E2r3_bilin.200714.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_WC14to60E2r3_patch.200714.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_T62_aave.200714.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_T62_aave.200714.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_WC14to60E2r3_aave.200928.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_WC14to60E2r3_bilin.200928.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_WC14to60E2r3_patch.200928.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_T62_aave.200928.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_T62_aave.200928.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3">
@@ -3840,11 +3840,11 @@
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="WC14to60E2r3">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_aave.200813.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_bilin.200813.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_patch.200813.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_TL319_aave.200813.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_TL319_aave.200813.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_aave.200928.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_bilin.200928.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_patch.200928.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_TL319_aave.200928.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_TL319_aave.200928.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T31" ocn_grid="gx3v7">
@@ -4250,8 +4250,8 @@
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="rx1">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oEC60to30v3" rof_grid="JRA025">
@@ -4285,8 +4285,8 @@
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="JRA025">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r3_smoothed.r150e300.200813.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r2_smoothed.r150e300.200813.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r2_smoothed.r150e300.200929.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oQU480" rof_grid="r05">
@@ -4355,13 +4355,13 @@
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="r05">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3_ICG" rof_grid="r05">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oEC60to30v3" rof_grid="r0125">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1214,6 +1214,16 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_r05_WC14to60E2r3-1900_ICG" compset="(CAM5.+ELM.+MPASO%SPUNUP)">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">WC14to60E2r3-1900_ICG</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>WC14to60E2r3</mask>
+    </model_grid>
+
     <model_grid alias="ne30_r05_oECv3_ICG" compset="(EAM.+ELM.+MPASO%SPUNUP)">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">r05</grid>
@@ -2665,6 +2675,13 @@
       <desc>WC14to60E2r3 is a MPAS ice/ocean grid with enhanced resolution of 14km along the coast of North America, the Northern Atlantic subpolar gyre, and the Arctic Ocean. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid. This version of initial conditions is spun-up from a G compset run:</desc>
     </domain>
 
+    <domain name="WC14to60E2r3-1900_ICG">
+      <nx>407420</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200929.nc</file>
+      <desc>WC14to60E2r3 is a MPAS ice/ocean grid with enhanced resolution of 14km along the coast of North America, the Northern Atlantic subpolar gyre, and the Arctic Ocean. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid. This version of initial conditions is spun-up from a G compset run:</desc>
+    </domain>
+
     <!-- ROF (river) grids-->
 
     <domain name="rx1">
@@ -3124,6 +3141,14 @@
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="WC14to60E2r3_ICG">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_mono.200928.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200928.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200928.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200928.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200928.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg2" ocn_grid="WC14to60E2r3-1900_ICG">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_mono.200928.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200928.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200928.nc</map>
@@ -4360,6 +4385,11 @@
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3_ICG" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="WC14to60E2r3-1900_ICG" rof_grid="r05">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
     </gridmap>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -420,6 +420,16 @@
       <mask>EC30to60E2r2</mask>
     </model_grid>
 
+    <model_grid alias="T62_WC14to60E2r3" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">WC14to60E2r3</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>WC14to60E2r3</mask>
+    </model_grid>
+
     <model_grid alias="TL319_oEC60to30v3" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -478,6 +488,16 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>EC30to60E2r2</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_WC14to60E2r3" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">WC14to60E2r3</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>WC14to60E2r3</mask>
     </model_grid>
 
     <!-- finite volume grids -->
@@ -1174,7 +1194,7 @@
       <mask>EC30to60E2r2</mask>
     </model_grid>
 	
-	<model_grid alias="ne30pg2_r05_EC30to60E2r2-1900_ICG" compset="(EAM.+ELM.+MPASO%SPUNUP)">
+    <model_grid alias="ne30pg2_r05_EC30to60E2r2-1900_ICG" compset="(EAM.+ELM.+MPASO%SPUNUP)">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">r05</grid>
       <grid name="ocnice">EC30to60E2r2-1900_ICG</grid>
@@ -1182,6 +1202,16 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>EC30to60E2r2</mask>
+    </model_grid>
+
+    <model_grid alias="ne30pg2_r05_WC14to60E2r3_ICG" compset="(CAM5.+ELM.+MPASO%SPUNUP)">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">WC14to60E2r3_ICG</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>WC14to60E2r3</mask>
     </model_grid>
 
     <model_grid alias="ne30_r05_oECv3_ICG" compset="(EAM.+ELM.+MPASO%SPUNUP)">
@@ -1845,6 +1875,16 @@
       <mask>EC30to60E2r2</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_r05_WC14to60E2r3">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">WC14to60E2r3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>WC14to60E2r3</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg3_r05_oECv3">
       <grid name="atm">ne30np4.pg3</grid>
       <grid name="lnd">r05</grid>
@@ -2170,6 +2210,7 @@
       <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to10.180716.nc</file>
       <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to6.180803.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_EC30to60E2r2.200908.nc</file>
+      <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WC14to60E2r3.200714.nc</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
@@ -2202,6 +2243,8 @@
       <file grid="ice|ocn" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to6.180905.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_EC30to60E2r2.200908.nc</file>
       <file grid="ice/ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_EC30to60E2r2.200908.nc</file>
+      <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_WC14to60E2r3.200813.nc</file>
+      <file grid="ice/ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_WC14to60E2r3.200813.nc</file>
       <desc>TL319 is JRA lat/lon grid:</desc>
     </domain>
 
@@ -2301,6 +2344,8 @@
       <file grid="ice|ocn" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_ARRM60to10.200527.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_EC30to60E2r2.200908.nc</file>
       <file grid="ice/ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_EC30to60E2r2.200908.nc</file>
+      <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WC14to60E2r3.200714.nc</file>
+      <file grid="ice/ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_WC14to60E2r3.200714.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_gx1v6.190806.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
@@ -2606,6 +2651,20 @@
       <desc>EC30to60E2r2 is a MPAS ocean grid generated with the jigsaw/compass process using the eddy closure density function that is roughly comparable to the pop 1 degree resolution. This version of initial conditions is spun-up from a G compset run:</desc>
     </domain>
 
+    <domain name="WC14to60E2r3">
+      <nx>407420</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200714.nc</file>
+      <desc>WC14to60E2r3 is a MPAS ocean grid generated with the jigsaw/compass process using the eddy closure density function that is roughly comparable to the pop 1 degree resolution:</desc>
+    </domain>
+
+    <domain name="WC14to60E2r3_ICG">
+      <nx>407420</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200714.nc</file>
+      <desc>WC14to60E2r3 is a MPAS ocean grid generated with the jigsaw/compass process using the eddy closure density function that is roughly comparable to the pop 1 degree resolution. This version of initial conditions is spun-up from a G compset run:</desc>
+    </domain>
+
     <!-- ROF (river) grids-->
 
     <domain name="rx1">
@@ -2627,6 +2686,8 @@
       <file grid="lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_ARRM60to10.200602.nc</file>
       <file grid="atm" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_EC30to60E2r2.200908.nc</file>
       <file grid="lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_EC30to60E2r2.200908.nc</file>
+      <file grid="atm" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_WC14to60E2r3.200714.nc</file>
+      <file grid="lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_WC14to60E2r3.200714.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_gx1v6.191014.nc</file>
       <desc>r05 is 1/2 degree river routing grid:</desc>
     </domain>
@@ -3046,7 +3107,7 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne30pg2_mono.200908.nc</map>
     </gridmap>
   
-	<gridmap atm_grid="ne30np4.pg2" ocn_grid="EC30to60E2r2-1900_ICG">
+    <gridmap atm_grid="ne30np4.pg2" ocn_grid="EC30to60E2r2-1900_ICG">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_mono.200908.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_bilin.200908.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_bilin.200908.nc</map>
@@ -3060,6 +3121,22 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_bilin.200908.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne30pg2_mono.200908.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne30pg2_mono.200908.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg2" ocn_grid="WC14to60E2r3_ICG">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_mono.200714.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200714.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200714.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200714.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200714.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg2" ocn_grid="WC14to60E2r3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_mono.200714.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200714.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200714.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200714.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200714.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
@@ -3706,6 +3783,14 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_T62_aave.200908.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="T62" ocn_grid="WC14to60E2r3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_WC14to60E2r3_aave.200714.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_WC14to60E2r3_bilin.200714.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_WC14to60E2r3_patch.200714.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_T62_aave.200714.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_T62_aave.200714.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_aave.181203.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_bilin.181203.nc</map>
@@ -3752,6 +3837,14 @@
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_EC30to60E2r2_patch.200908.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_TL319_aave.200908.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_TL319_aave.200908.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="WC14to60E2r3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_aave.200813.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_bilin.200813.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_patch.200813.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_TL319_aave.200813.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_TL319_aave.200813.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T31" ocn_grid="gx3v7">
@@ -4156,6 +4249,11 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_EC30to60E2r2_smoothed.r150e300.200908.nc</map>
     </gridmap>
 
+    <gridmap ocn_grid="WC14to60E2r3" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="oEC60to30v3" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
@@ -4184,6 +4282,11 @@
     <gridmap ocn_grid="EC30to60E2r2" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_EC30to60E2r2_smoothed.r150e300.200908.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_EC30to60E2r2_smoothed.r150e300.200908.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="WC14to60E2r3" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r3_smoothed.r150e300.200813.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r2_smoothed.r150e300.200813.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oQU480" rof_grid="r05">
@@ -4246,9 +4349,19 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_EC30to60E2r2_smoothed.r150e300.200908.nc</map>
     </gridmap>
 	
-	<gridmap ocn_grid="EC30to60E2r2-1900_ICG" rof_grid="r05">
+    <gridmap ocn_grid="EC30to60E2r2-1900_ICG" rof_grid="r05">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_EC30to60E2r2_smoothed.r150e300.200908.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_EC30to60E2r2_smoothed.r150e300.200908.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="WC14to60E2r3" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="WC14to60E2r3_ICG" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200714.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oEC60to30v3" rof_grid="r0125">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2655,14 +2655,14 @@
       <nx>407420</nx>
       <ny>1</ny>
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200714.nc</file>
-      <desc>WC14to60E2r3 is a MPAS ocean grid generated with the jigsaw/compass process using the eddy closure density function that is roughly comparable to the pop 1 degree resolution:</desc>
+      <desc>WC14to60E2r3 is a MPAS ice/ocean grid with enhanced resolution of 14km along the coast of North America, the Northern Atlantic subpolar gyre, and the Arctic Ocean. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
     <domain name="WC14to60E2r3_ICG">
       <nx>407420</nx>
       <ny>1</ny>
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200714.nc</file>
-      <desc>WC14to60E2r3 is a MPAS ocean grid generated with the jigsaw/compass process using the eddy closure density function that is roughly comparable to the pop 1 degree resolution. This version of initial conditions is spun-up from a G compset run:</desc>
+      <desc>WC14to60E2r3 is a MPAS ice/ocean grid with enhanced resolution of 14km along the coast of North America, the Northern Atlantic subpolar gyre, and the Arctic Ocean. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid. This version of initial conditions is spun-up from a G compset run:</desc>
     </domain>
 
     <!-- ROF (river) grids-->

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1204,7 +1204,7 @@
       <mask>EC30to60E2r2</mask>
     </model_grid>
 
-    <model_grid alias="ne30pg2_r05_WC14to60E2r3_ICG" compset="(CAM5.+ELM.+MPASO%SPUNUP)">
+    <model_grid alias="ne30pg2_r05_WC14to60E2r3_ICG" compset="(EAM.+ELM.+MPASO%SPUNUP)">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">r05</grid>
       <grid name="ocnice">WC14to60E2r3_ICG</grid>
@@ -1214,7 +1214,7 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
-    <model_grid alias="ne30pg2_r05_WC14to60E2r3-1900_ICG" compset="(CAM5.+ELM.+MPASO%SPUNUP)">
+    <model_grid alias="ne30pg2_r05_WC14to60E2r3-1900_ICG" compset="(EAM.+ELM.+MPASO%SPUNUP)">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">r05</grid>
       <grid name="ocnice">WC14to60E2r3-1900_ICG</grid>

--- a/components/elm/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/components/elm/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1270,7 +1270,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*20" category="default_settings"
        group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2">
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2">
 Land mask description
 </entry> 
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -73,6 +73,7 @@
 <config_hmix_scaleWithMesh ocn_grid="WC14to60E2r3">.true.</config_hmix_scaleWithMesh>
 <config_maxMeshDensity>-1.0</config_maxMeshDensity>
 <config_hmix_use_ref_cell_width>.false.</config_hmix_use_ref_cell_width>
+<config_hmix_use_ref_cell_width ocn_grid="WC14to60E2r3">.true.</config_hmix_use_ref_cell_width>
 <config_hmix_ref_cell_width>30.0e3</config_hmix_ref_cell_width>
 <config_apvm_scale_factor>0.0</config_apvm_scale_factor>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -47,7 +47,7 @@
 <config_dt ocn_grid="oARRM60to10">'00:10:00'</config_dt>
 <config_dt ocn_grid="oARRM60to6">'00:05:00'</config_dt>
 <config_dt ocn_grid="EC30to60E2r2">'00:30:00'</config_dt>
-<config_dt ocn_grid="WC14to60E2r3">'00:30:00'</config_dt>
+<config_dt ocn_grid="WC14to60E2r3">'00:10:00'</config_dt>
 <config_time_integrator>'split_explicit'</config_time_integrator>
 
 <!-- hmix -->
@@ -92,7 +92,7 @@
 <config_mom_del2 ocn_grid="oEC60to30v3wLI">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="ECwISC30to60E1r2">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="EC30to60E2r2">1000.0</config_mom_del2>
-<config_mom_del2 ocn_grid="WC14to60E2r3">1000.0</config_mom_del2>
+<config_mom_del2 ocn_grid="WC14to60E2r3">250.0</config_mom_del2>
 <config_use_tracer_del2>.false.</config_use_tracer_del2>
 <config_tracer_del2>10.0</config_tracer_del2>
 
@@ -117,7 +117,7 @@
 <config_mom_del4 ocn_grid="oARRM60to10">1.5e10</config_mom_del4>
 <config_mom_del4 ocn_grid="oARRM60to6">3.2e09</config_mom_del4>
 <config_mom_del4 ocn_grid="EC30to60E2r2">1.2e11</config_mom_del4>
-<config_mom_del4 ocn_grid="WC14to60E2r3">1.2e11</config_mom_del4>
+<config_mom_del4 ocn_grid="WC14to60E2r3">1.5e10</config_mom_del4>
 <config_mom_del4_div_factor>1.0</config_mom_del4_div_factor>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
 <config_tracer_del4>0.0</config_tracer_del4>
@@ -366,7 +366,7 @@
 <config_btr_dt ocn_grid="oARRM60to10">'0000_00:00:24'</config_btr_dt>
 <config_btr_dt ocn_grid="oARRM60to6">'0000_00:00:10'</config_btr_dt>
 <config_btr_dt ocn_grid="EC30to60E2r2">'0000_00:01:00'</config_btr_dt>
-<config_btr_dt ocn_grid="WC14to60E2r3">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="WC14to60E2r3">'0000_00:00:15'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -47,6 +47,7 @@
 <config_dt ocn_grid="oARRM60to10">'00:10:00'</config_dt>
 <config_dt ocn_grid="oARRM60to6">'00:05:00'</config_dt>
 <config_dt ocn_grid="EC30to60E2r2">'00:30:00'</config_dt>
+<config_dt ocn_grid="WC14to60E2r3">'00:30:00'</config_dt>
 <config_time_integrator>'split_explicit'</config_time_integrator>
 
 <!-- hmix -->
@@ -69,6 +70,7 @@
 <config_hmix_scaleWithMesh ocn_grid="oARRM60to10">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oARRM60to6">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="EC30to60E2r2">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="WC14to60E2r3">.true.</config_hmix_scaleWithMesh>
 <config_maxMeshDensity>-1.0</config_maxMeshDensity>
 <config_hmix_use_ref_cell_width>.false.</config_hmix_use_ref_cell_width>
 <config_hmix_ref_cell_width>30.0e3</config_hmix_ref_cell_width>
@@ -82,6 +84,7 @@
 <config_use_mom_del2 ocn_grid="oEC60to30v3wLI">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="ECwISC30to60E1r2">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="EC30to60E2r2">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="WC14to60E2r3">.true.</config_use_mom_del2>
 <config_mom_del2>10.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3">1000.0</config_mom_del2>
@@ -89,6 +92,7 @@
 <config_mom_del2 ocn_grid="oEC60to30v3wLI">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="ECwISC30to60E1r2">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="EC30to60E2r2">1000.0</config_mom_del2>
+<config_mom_del2 ocn_grid="WC14to60E2r3">1000.0</config_mom_del2>
 <config_use_tracer_del2>.false.</config_use_tracer_del2>
 <config_tracer_del2>10.0</config_tracer_del2>
 
@@ -113,6 +117,7 @@
 <config_mom_del4 ocn_grid="oARRM60to10">1.5e10</config_mom_del4>
 <config_mom_del4 ocn_grid="oARRM60to6">3.2e09</config_mom_del4>
 <config_mom_del4 ocn_grid="EC30to60E2r2">1.2e11</config_mom_del4>
+<config_mom_del4 ocn_grid="WC14to60E2r3">1.2e11</config_mom_del4>
 <config_mom_del4_div_factor>1.0</config_mom_del4_div_factor>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
 <config_tracer_del4>0.0</config_tracer_del4>
@@ -155,6 +160,7 @@
 <config_GM_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_kappa>
 <config_GM_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E1r2">600.0</config_GM_kappa>
 <config_GM_kappa ocn_forcing="datm_forced_restoring" ocn_grid="EC30to60E2r2">600.0</config_GM_kappa>
+<config_GM_kappa ocn_forcing="datm_forced_restoring" ocn_grid="WC14to60E2r3">600.0</config_GM_kappa>
 <config_GM_closure>'visbeck'</config_GM_closure>
 <config_GM_baroclinic_mode>3.0</config_GM_baroclinic_mode>
 <config_GM_Visbeck_alpha>0.13</config_GM_Visbeck_alpha>
@@ -360,6 +366,7 @@
 <config_btr_dt ocn_grid="oARRM60to10">'0000_00:00:24'</config_btr_dt>
 <config_btr_dt ocn_grid="oARRM60to6">'0000_00:00:10'</config_btr_dt>
 <config_btr_dt ocn_grid="EC30to60E2r2">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="WC14to60E2r3">'0000_00:01:00'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>
@@ -872,6 +879,7 @@
 <config_AM_mocStreamfunction_enable ocn_grid="oARRM60to10">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="oARRM60to6">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="EC30to60E2r2">.false.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="WC14to60E2r3">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_compute_interval>'0000-00-00_01:00:00'</config_AM_mocStreamfunction_compute_interval>
 <config_AM_mocStreamfunction_output_stream>'mocStreamfunctionOutput'</config_AM_mocStreamfunction_output_stream>
 <config_AM_mocStreamfunction_compute_on_startup>.true.</config_AM_mocStreamfunction_compute_on_startup>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -239,13 +239,13 @@ def buildnml(case, caseroot, compname):
         restoring_file += 'sss.PHC2_monthlyClimatology.WC14to60E2r3.200715.nc'
         analysis_mask_file += 'WC14to60E2r3_moc_masks_and_transects.nc'
     elif ocn_grid == 'WC14to60E2r3_ICG':
-        ic_date += '201001'
+        ic_date += '201002'
         ic_prefix += 'mpaso.WC14to60E2r3.rstFromG-anvil'
         decomp_date += '200714'
         decomp_prefix += 'mpas-o.graph.info.'
         analysis_mask_file += 'WC14to60E2r3_moc_masks_and_transects.nc'
     elif ocn_grid == 'WC14to60E2r3-1900_ICG':
-        ic_date += '201001'
+        ic_date += '201002'
         ic_prefix += 'mpaso.WC14to60E2r3-1900.rstFromG-anvil'
         decomp_date += '200714'
         decomp_prefix += 'mpas-o.graph.info.'

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -231,6 +231,19 @@ def buildnml(case, caseroot, compname):
         decomp_date += '200904'
         decomp_prefix += 'mpas-o.graph.info.'
         analysis_mask_file += 'EC30to60E2r2_moc_masks_and_transects.nc'
+    elif ocn_grid == 'WC14to60E2r3':
+        ic_date += '200714'
+        ic_prefix += 'ocean.WC14to60E2r3'
+        decomp_date += '200714'
+        decomp_prefix += 'mpas-o.graph.info.'
+        restoring_file += 'sss.PHC2_monthlyClimatology.WC14to60E2r3.200715.nc'
+        analysis_mask_file += 'WC14to60E2r3_moc_masks_and_transects.nc'
+    elif ocn_grid == 'WC14to60E2r3_ICG':
+        ic_date += '200910'
+        ic_prefix += 'mpaso.WC14to60E2r3.rstFromG-anvil'
+        decomp_date += '200714'
+        decomp_prefix += 'mpas-o.graph.info.'
+        analysis_mask_file += 'WC14to60E2r3_moc_masks_and_transects.nc'
 
     #--------------------------------------------------------------------
     # Set OCN_FORCING = datm_forced_restoring if restoring file is available

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -239,8 +239,14 @@ def buildnml(case, caseroot, compname):
         restoring_file += 'sss.PHC2_monthlyClimatology.WC14to60E2r3.200715.nc'
         analysis_mask_file += 'WC14to60E2r3_moc_masks_and_transects.nc'
     elif ocn_grid == 'WC14to60E2r3_ICG':
-        ic_date += '200910'
+        ic_date += '201001'
         ic_prefix += 'mpaso.WC14to60E2r3.rstFromG-anvil'
+        decomp_date += '200714'
+        decomp_prefix += 'mpas-o.graph.info.'
+        analysis_mask_file += 'WC14to60E2r3_moc_masks_and_transects.nc'
+    elif ocn_grid == 'WC14to60E2r3-1900_ICG':
+        ic_date += '201001'
+        ic_prefix += 'mpaso.WC14to60E2r3-1900.rstFromG-anvil'
         decomp_date += '200714'
         decomp_prefix += 'mpas-o.graph.info.'
         analysis_mask_file += 'WC14to60E2r3_moc_masks_and_transects.nc'

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -25,6 +25,7 @@
 <config_dt ice_grid="oARRM60to10">900.0</config_dt>
 <config_dt ice_grid="oARRM60to6">900.0</config_dt>
 <config_dt ice_grid="EC30to60E2r2">1800.0</config_dt>
+<config_dt ice_grid="WC14to60E2r3">1800.0</config_dt>
 <config_calendar_type>'gregorian_noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
@@ -124,6 +125,7 @@
 <config_dynamics_subcycle_number ice_grid="oARRM60to10">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="oARRM60to6">2</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="EC30to60E2r2">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="WC14to60E2r3">1</config_dynamics_subcycle_number>
 <config_rotate_cartesian_grid>true</config_rotate_cartesian_grid>
 <config_include_metric_terms>true</config_include_metric_terms>
 <config_elastic_subcycle_number>120</config_elastic_subcycle_number>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -216,8 +216,13 @@ def buildnml(case, caseroot, compname):
         decomp_date += '200714'
         decomp_prefix += 'mpas-seaice.graph.info.'
     elif ice_grid == 'WC14to60E2r3_ICG':
-        grid_date += '200910'
+        grid_date += '201001'
         grid_prefix += 'mpassi.WC14to60E2r3.rstFromG-anvil'
+        decomp_date += '200714'
+        decomp_prefix += 'mpas-seaice.graph.info.'
+    elif ice_grid == 'WC14to60E2r3-1900_ICG':
+        grid_date += '201001'
+        grid_prefix += 'mpassi.WC14to60E2r3-1900.rstFromG-anvil'
         decomp_date += '200714'
         decomp_prefix += 'mpas-seaice.graph.info.'
 

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -216,12 +216,12 @@ def buildnml(case, caseroot, compname):
         decomp_date += '200714'
         decomp_prefix += 'mpas-seaice.graph.info.'
     elif ice_grid == 'WC14to60E2r3_ICG':
-        grid_date += '201001'
+        grid_date += '201002'
         grid_prefix += 'mpassi.WC14to60E2r3.rstFromG-anvil'
         decomp_date += '200714'
         decomp_prefix += 'mpas-seaice.graph.info.'
     elif ice_grid == 'WC14to60E2r3-1900_ICG':
-        grid_date += '201001'
+        grid_date += '201002'
         grid_prefix += 'mpassi.WC14to60E2r3-1900.rstFromG-anvil'
         decomp_date += '200714'
         decomp_prefix += 'mpas-seaice.graph.info.'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -210,6 +210,16 @@ def buildnml(case, caseroot, compname):
         grid_prefix += 'mpassi.EC30to60E2r2-1900.rstFromG-anvil'
         decomp_date += '200908'
         decomp_prefix += 'mpas-seaice.graph.info.'
+    elif ice_grid == 'WC14to60E2r3':
+        grid_date += '200714'
+        grid_prefix += 'seaice.WC14to60E2r3'
+        decomp_date += '200714'
+        decomp_prefix += 'mpas-seaice.graph.info.'
+    elif ice_grid == 'WC14to60E2r3_ICG':
+        grid_date += '200910'
+        grid_prefix += 'mpassi.WC14to60E2r3.rstFromG-anvil'
+        decomp_date += '200714'
+        decomp_prefix += 'mpas-seaice.graph.info.'
 
 
     #--------------------------------------------------------------------


### PR DESCRIPTION
Bring in the initial support for the new ocn/ice WC14to60E2r3 grid, which has enhanced resolution of 14km along the coast of North America, the Northern Atlantic subpolar gyre, and the Arctic Ocean. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid. All new mapping and other required files have been staged on the inputdata server, with the exception of seaice and ocean initial condition files for the spunup _ICG configuration.

[BFB] for all currently tested configurations