### PR TITLE
Allow up to 10 atm history tapes

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -1284,7 +1284,7 @@ Default: none
 
 <!-- History and Initial Conditions Output -->
 
-<entry id="avgflag_pertape" type="char*1(6)"  category="history"
+<entry id="avgflag_pertape" type="char*1(10)"  category="history"
        group="cam_history_nl" valid_values="A,B,I,X,M" >
 Sets the averaging flag for all variables on a particular history file
 series. Valid values are:
@@ -1344,6 +1344,30 @@ List of fields to exclude from the 6th history file (by default the name
 of this file contains the string "h5").
 Default: none
 </entry>
+<entry id="fexcl7" type="char*24(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 7th history file (by default the name
+of this file contains the string "h6").
+Default: none
+</entry>
+<entry id="fexcl8" type="char*24(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 8th history file (by default the name
+of this file contains the string "h7").
+Default: none
+</entry>
+<entry id="fexcl9" type="char*24(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 9th history file (by default the name
+of this file contains the string "h8").
+Default: none
+</entry>
+<entry id="fexcl10" type="char*24(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 10th history file (by default the name
+of this file contains the string "h9").
+Default: none
+</entry>
 
 <entry id="fincl1" type="char*26(750)"  category="history"
        group="cam_history_nl" valid_values="" >
@@ -1389,6 +1413,30 @@ Default: none.
        group="cam_history_nl" valid_values="" >
 Same as <varname>fincl1</varname>, but for the 6th history file (by default
 the name of this file contains the string "h5").
+Default: none.
+</entry>
+<entry id="fincl7" type="char*26(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1</varname>, but for the 7th history file (by default
+the name of this file contains the string "h6").
+Default: none.
+</entry>
+<entry id="fincl8" type="char*26(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1</varname>, but for the 8th history file (by default
+the name of this file contains the string "h7").
+Default: none.
+</entry>
+<entry id="fincl9" type="char*26(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1</varname>, but for the 9th history file (by default
+the name of this file contains the string "h8").
+Default: none.
+</entry>
+<entry id="fincl10" type="char*26(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1</varname>, but for the 10th history file (by default
+the name of this file contains the string "h9").
 Default: none.
 </entry>
 
@@ -1438,7 +1486,7 @@ Name of the IOP case so case specific adjustments can be made in CLUBB.
 Default: none.
 </entry>
 
-<entry id="collect_column_output" type="logical(6)" category="history"
+<entry id="collect_column_output" type="logical(10)" category="history"
    group="cam_history_nl" valid_values="">
 Collect all column data into a single field and output in ncol format,
 much faster than default when you have a lot of columns.
@@ -1479,6 +1527,22 @@ Same as <varname>fincl1lonlat</varname>, but for 5th history file.
        group="cam_history_nl" valid_values="" >
 Same as <varname>fincl1lonlat</varname>, but for 6th history file.
 </entry>
+<entry id="fincl7lonlat" type="char*128(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1lonlat</varname>, but for 7th history file.
+</entry>
+<entry id="fincl8lonlat" type="char*128(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1lonlat</varname>, but for 8th history file.
+</entry>
+<entry id="fincl9lonlat" type="char*128(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1lonlat</varname>, but for 9th history file.
+</entry>
+<entry id="fincl10lonlat" type="char*128(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1lonlat</varname>, but for 10th history file.
+</entry>
 
 
 <entry id="fwrtpr1" type="char*26(750)"  category="history"
@@ -1518,15 +1582,15 @@ the 6th history file.
 Default: none
 </entry>
 
-<entry id="hfilename_spec" type="char*256(6)"  category="history"
+<entry id="hfilename_spec" type="char*256(10)"  category="history"
        group="cam_history_nl" valid_values="" >
 
-Array of history filename specifiers.  The filenames of up to six history
+Array of history filename specifiers.  The filenames of up to ten history
 output files can be controlled via this variable.  Filename specifiers give
 generic formats for the filenames with specific date and time components,
-file series number (0-5), and caseid, filled in when the files are
+file series number (0-9), and caseid, filled in when the files are
 created. The following strings are expanded when the filename is created:
-%c=caseid; %t=file series number (0-5); %y=year (normally 4 digits, more
+%c=caseid; %t=file series number (0-9); %y=year (normally 4 digits, more
 digits if needed); %m=month; %d=day; %s=seconds into current day; %%=%
 symbol.  Note that the caseid may be set using the namelist
 variable <varname>case_name</varname>.
@@ -1541,7 +1605,7 @@ in the specifier, it will be interpreted as a directory name and the
 corresponding directories will have to be created in the model execution
 directory (directory given to configure with -cam_exedir option) before
 model execution.  The first element is for the primary history file which
-is output by default as a monthly history file.  Entries 2 through 6 are
+is output by default as a monthly history file.  Entries 2 through 10 are
 user specified auxilliary output files.
 
 Defaults: "%c.cam2.h0.%y-%m.nc", "%c.cam2.h1.%y-%m-%d-%s.nc", ...,
@@ -1606,15 +1670,15 @@ include required AND optional fields on IC file.
 Default: FALSE
 </entry>
 
-<entry id="mfilt" type="integer(6)"  category="history"
+<entry id="mfilt" type="integer(10)"  category="history"
        group="cam_history_nl" valid_values="" >
 Array containing the maximum number of time samples written to a history
 file.  The first value applies to the primary history file, the second
 through sixth to the auxillary history files.
-Default: 1,30,30,30,30,30
+Default: 1,30,30,30,30,30,30,30,30,30
 </entry>
 
-<entry id="lcltod_start" type="integer(6)"  category="history"
+<entry id="lcltod_start" type="integer(10)"  category="history"
        group="cam_history_nl" valid_values="" >
 Array containing the starting time of day for local time history averaging. 
 Used in conjuction with lcltod_stop. If lcltod_stop is less than lcltod_start, 
@@ -1624,7 +1688,7 @@ applies to the primary hist. file, the second to the first aux. hist. file, etc.
 Default: none
 </entry>
 
-<entry id="lcltod_stop" type="integer(6)"  category="history"
+<entry id="lcltod_stop" type="integer(10)"  category="history"
        group="cam_history_nl" valid_values="" >
 Array containing the stopping time of day for local time history averaging. 
 Used in conjuction with lcltod_start. If lcltod_stop is less than lcltod_start, 
@@ -1634,18 +1698,18 @@ applies to the primary hist. file, the second to the first aux. hist. file, etc.
 Default: none
 </entry>
 
-<entry id="ndens" type="integer(6)"  category="history"
+<entry id="ndens" type="integer(10)"  category="history"
        group="cam_history_nl" valid_values="1,2" > 
 
 Array specifying the precision of real data written to each history file
 series. Valid values are 1 or 2. '1' implies output real values are 8-byte
 and '2' implies output real values are 4-byte.
 
-Default: 2,2,2,2,2,2
+Default: 2,2,2,2,2,2,2,2,2,2
 </entry>
 
 
-<entry id="nhtfrq" type="integer(6)"  category="history"
+<entry id="nhtfrq" type="integer(10)"  category="history"
        group="cam_history_nl" valid_values="" > 
 
 Array of write frequencies for each history file series.
@@ -1655,7 +1719,7 @@ Only the first file series may be a monthly average.  If
 timesteps.  If <varname>nhtfrq(i)</varname> &lt; 0, frequency is specified
 as number of hours.
 
-Default: 0,-24,-24,-24,-24,-24
+Default: 0,-24,-24,-24,-24,-24,-24,-24,-24,-24
 </entry>
 
 <entry id="interpolate_output" type="logical(10)" category="history"


### PR DESCRIPTION
This PR changes the maximum number of history files the atmosphere can output from six to ten.  Most of the code was already setup, but namelist variables needed to be created or updated to make use of the higher number of tapes.

[BFB]