### PR TITLE
Deallocate local vector that is not deallocated automatically

### DIFF
--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -733,10 +733,12 @@ CONTAINS
     !
     allocate(data(lsize))
     !
-    ! Initialize attribute vector with special value
+    ! Initialize attribute vector with special value,
+    ! then deallocate storage pointed to by idata
     !
     call mct_gsMap_orderedPoints(gsMap_a, iam, idata)
     call mct_gGrid_importIAttr(dom_a,'GlobGridNum',idata,lsize)
+    if (associated(idata)) deallocate(idata)
     !
     ! Determine domain (numbering scheme is: West to East and South to North to South pole)
     ! Initialize attribute vector with special value


### PR DESCRIPTION
A vector is allocated inside of a call to the routine mct_gsMap_orderedPoints
and pointed to by a local pointer variable in the routine atm_domain_mct.
This allocated storage is not automatically deallocated when returning
from atm_domain_mct. This is corrected here with an explicit deallocate.

Fixes #3854 

[BFB]