### PR TITLE
Fixes Radiation diagnostic bug and refactors modal_aero_calcsize

### DIFF
--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1529,7 +1529,7 @@ contains
     ! for prognostic modal aerosols the transfer of mass between aitken and 
     ! accumulation modes is done in conjunction with the dry radius calculation
     call t_startf('calcsize')
-    call modal_aero_calcsize_sub(state, ptend, dt, pbuf)
+    call modal_aero_calcsize_sub(state, pbuf, dt, ptend)
     call t_stopf('calcsize')
     
     ! Aerosol water uptake

--- a/components/eam/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/components/eam/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -377,8 +377,8 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
 
    if (present(clear_rh_in)) then
 
-   itim_old    =  pbuf_old_tim_idx()
-   call pbuf_get_field(pbuf, cld_idx, cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
+      ! use input relative humidity
+      rh(1:ncol,1:pver) = clear_rh_in(1:ncol,1:pver)
 
       ! check that values are reasonable and apply upper limit
       do k = top_lev, pver

--- a/components/eam/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/components/eam/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -39,6 +39,23 @@ integer :: wetdens_ap_idx = 0
 integer :: qaerwat_idx    = 0
 
 logical :: pergro_mods         = .false.
+
+real(r8), allocatable :: maer(:,:,:)      ! aerosol wet mass MR (including water) (kg/kg-air)
+real(r8), allocatable :: hygro(:,:,:)     ! volume-weighted mean hygroscopicity (--)
+real(r8), allocatable :: naer(:,:,:)      ! aerosol number MR (bounded!) (#/kg-air)
+real(r8), allocatable :: dryvol(:,:,:)    ! single-particle-mean dry volume (m3)
+real(r8), allocatable :: drymass(:,:,:)   ! single-particle-mean dry mass  (kg)
+real(r8), allocatable :: dryrad(:,:,:)    ! dry volume mean radius of aerosol (m)
+
+real(r8), allocatable :: wetrad(:,:,:)    ! wet radius of aerosol (m)
+real(r8), allocatable :: wetvol(:,:,:)    ! single-particle-mean wet volume (m3)
+real(r8), allocatable :: wtrvol(:,:,:)    ! single-particle-mean water volume in wet aerosol (m3)
+
+real(r8), allocatable :: rhcrystal(:)
+real(r8), allocatable :: rhdeliques(:)
+real(r8), allocatable :: specdens_1(:)
+!$OMP THREADPRIVATE(maer, hygro, naer, dryvol, drymass, dryrad, wetrad, wetvol, wtrvol, rhcrystal, rhdeliques, specdens_1)
+
 !===============================================================================
 contains
 !===============================================================================
@@ -63,12 +80,13 @@ end subroutine modal_aero_wateruptake_reg
 !===============================================================================
 
 subroutine modal_aero_wateruptake_init(pbuf2d)
-   use time_manager,  only: is_first_step
-   use physics_buffer,only: pbuf_set_field
+   use time_manager,   only: is_first_step
+   use physics_buffer, only: pbuf_set_field
+   use shr_log_mod ,   only: errmsg => shr_log_errmsg
 
    type(physics_buffer_desc), pointer :: pbuf2d(:,:)
 
-   integer :: m, nmodes
+   integer :: m, nmodes, istat
    logical :: history_aerosol      ! Output the MAM aerosol variables and tendencies
    logical :: history_verbose      ! produce verbose history output
 
@@ -81,6 +99,34 @@ subroutine modal_aero_wateruptake_init(pbuf2d)
    ! assume for now that will compute wateruptake for climate list modes only
 
    call rad_cnst_get_info(0, nmodes=nmodes)
+
+   !$OMP PARALLEL
+   allocate(maer(pcols,pver,nmodes),stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate maer:       "//errmsg(__FILE__,__LINE__) )
+   allocate(hygro(pcols,pver,nmodes),   stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate hygro:      "//errmsg(__FILE__,__LINE__) )
+   allocate(naer(pcols,pver,nmodes),    stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate naer:       "//errmsg(__FILE__,__LINE__) )
+   allocate(dryvol(pcols,pver,nmodes),  stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate dryvol:     "//errmsg(__FILE__,__LINE__) )
+   allocate(drymass(pcols,pver,nmodes), stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate drymass:    "//errmsg(__FILE__,__LINE__) )
+   allocate(dryrad(pcols,pver,nmodes),  stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate dryradr:    "//errmsg(__FILE__,__LINE__) )
+   allocate(wetrad(pcols,pver,nmodes),  stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate wetrad:     "//errmsg(__FILE__,__LINE__) )
+   allocate(wetvol(pcols,pver,nmodes),  stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate wetvol:     "//errmsg(__FILE__,__LINE__) )
+   allocate(wtrvol(pcols,pver,nmodes),  stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate wtrvol:     "//errmsg(__FILE__,__LINE__) )
+   allocate(rhcrystal(nmodes),          stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate rhcrystal:  "//errmsg(__FILE__,__LINE__) )
+   allocate(rhdeliques(nmodes),         stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate rhdeliques: "//errmsg(__FILE__,__LINE__) )
+   allocate(specdens_1(nmodes),         stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate specdens_1: "//errmsg(__FILE__,__LINE__) )
+   !$OMP END PARALLEL
+
 
    ! determine default variables
    call phys_getopts(history_aerosol_out = history_aerosol, &
@@ -171,21 +217,6 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    real(r8), pointer :: wetdens(:,:,:)
    real(r8), pointer :: qaerwat(:,:,:)
 
-   real(r8), allocatable :: maer(:,:,:)      ! aerosol wet mass MR (including water) (kg/kg-air)
-   real(r8), allocatable :: hygro(:,:,:)     ! volume-weighted mean hygroscopicity (--)
-   real(r8), allocatable :: naer(:,:,:)      ! aerosol number MR (bounded!) (#/kg-air)
-   real(r8), allocatable :: dryvol(:,:,:)    ! single-particle-mean dry volume (m3)
-   real(r8), allocatable :: drymass(:,:,:)   ! single-particle-mean dry mass  (kg)
-   real(r8), allocatable :: dryrad(:,:,:)    ! dry volume mean radius of aerosol (m)
-
-   real(r8), allocatable :: wetrad(:,:,:)    ! wet radius of aerosol (m)
-   real(r8), allocatable :: wetvol(:,:,:)    ! single-particle-mean wet volume (m3)
-   real(r8), allocatable :: wtrvol(:,:,:)    ! single-particle-mean water volume in wet aerosol (m3)
-
-   real(r8), allocatable :: rhcrystal(:)
-   real(r8), allocatable :: rhdeliques(:)
-   real(r8), allocatable :: specdens_1(:)
-
    real(r8) :: dryvolmr(pcols,pver)          ! volume MR for aerosol mode (m3/kg)
    real(r8) :: specdens
    real(r8) :: spechygro, spechygro_1
@@ -202,6 +233,7 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    real(r8) :: aerosol_water(pcols,pver) !sum of aerosol water (wat_a1 + wat_a2 + wat_a3 + wat_a4)
    logical :: history_aerosol      ! Output the MAM aerosol variables and tendencies
    logical :: history_verbose      ! produce verbose history output
+   logical :: compute_wetdens
 
    character(len=3) :: trnum       ! used to hold mode number (as characters)
    !----------------------------------------------------------------------------
@@ -219,14 +251,14 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
 
       ! check that all optional args for diagnostic mode are present
       if (.not. present(dgnumdry_m) .or. .not. present(dgnumwet_m) .or. &
-          .not. present(qaerwat_m)  .or. .not. present(wetdens_m)) then
+          .not. present(qaerwat_m)) then
          call endrun('modal_aero_wateruptake_dr called for'// &
                      'diagnostic list but required args not present')
       end if
 
       ! arrays for diagnostic calculations must be associated
       if (.not. associated(dgnumdry_m) .or. .not. associated(dgnumwet_m) .or. &
-          .not. associated(qaerwat_m)  .or. .not. associated(wetdens_m)) then
+          .not. associated(qaerwat_m)) then
          call endrun('modal_aero_wateruptake_dr called for'// &
                      'diagnostic list but required args not associated')
       end if
@@ -235,25 +267,24 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    ! loop over all aerosol modes
    call rad_cnst_get_info(list_idx, nmodes=nmodes)
 
-   allocate( &
-      maer(pcols,pver,nmodes),     &
-      hygro(pcols,pver,nmodes),    &
-      naer(pcols,pver,nmodes),     &
-      dryvol(pcols,pver,nmodes),   &
-      drymass(pcols,pver,nmodes),  &
-      dryrad(pcols,pver,nmodes),   &
-      wetrad(pcols,pver,nmodes),   &
-      wetvol(pcols,pver,nmodes),   &
-      wtrvol(pcols,pver,nmodes),   &
-      rhcrystal(nmodes),           &
-      rhdeliques(nmodes),          &
-      specdens_1(nmodes)           )
+   !initialize to an invalid value
+   naer(:,:,:)    = huge(1.0_r8)
+   dryvol(:,:,:)  = huge(1.0_r8)
+   drymass(:,:,:) = huge(1.0_r8)
+   dryrad(:,:,:)  = huge(1.0_r8)
+   wetrad(:,:,:)  = huge(1.0_r8)
+   wetvol(:,:,:)  = huge(1.0_r8)
+   wtrvol(:,:,:)  = huge(1.0_r8)
+
+   rhcrystal(:)   = huge(1.0_r8)
+   rhdeliques(:)  = huge(1.0_r8)
+   specdens_1(:)  = huge(1.0_r8)
 
    maer(:,:,:)     = 0._r8
    hygro(:,:,:)    = 0._r8
 
 
-   if (list_idx == 0) then
+   if (.not. present(list_idx_in)) then
       call pbuf_get_field(pbuf, dgnum_idx,      dgncur_a )
       call pbuf_get_field(pbuf, dgnumwet_idx,   dgncur_awet )
       call pbuf_get_field(pbuf, wetdens_ap_idx, wetdens)
@@ -262,8 +293,11 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
       dgncur_a    => dgnumdry_m
       dgncur_awet => dgnumwet_m
       qaerwat     => qaerwat_m
-      wetdens     => wetdens_m
+      if(present(wetdens_m)) wetdens     => wetdens_m
    end if
+
+   compute_wetdens = .false.
+   if(associated(wetdens)) compute_wetdens = .true.
 
    !----------------------------------------------------------------------------
    ! retreive aerosol properties
@@ -336,15 +370,15 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
          end do ! i = 1, ncol
       end do ! k = top_lev, pver
 
-   end do ! m = 1, nmodes
+   end do    ! modes
 
    !----------------------------------------------------------------------------
    ! specify clear air relative humidity
 
    if (present(clear_rh_in)) then
 
-      ! use input relative humidity
-      rh(1:ncol,1:pver) = clear_rh_in(1:ncol,1:pver)
+   itim_old    =  pbuf_old_tim_idx()
+   call pbuf_get_field(pbuf, cld_idx, cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
 
       ! check that values are reasonable and apply upper limit
       do k = top_lev, pver
@@ -409,12 +443,13 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
             qaerwat(i,k,m)     = rhoh2o*naer(i,k,m)*wtrvol(i,k,m)
 
             ! compute aerosol wet density (kg/m3)
-            if (wetvol(i,k,m) > 1.0e-30_r8) then
-               wetdens(i,k,m) = (drymass(i,k,m) + rhoh2o*wtrvol(i,k,m))/wetvol(i,k,m)
-            else
-               wetdens(i,k,m) = specdens_1(m)
-            end if
-
+            if(compute_wetdens) then
+               if (wetvol(i,k,m) > 1.0e-30_r8) then
+                  wetdens(i,k,m) = (drymass(i,k,m) + rhoh2o*wtrvol(i,k,m))/wetvol(i,k,m)
+               else
+                  wetdens(i,k,m) = specdens_1(m)
+               end if
+            endif
          end do ! i = 1, ncol
       end do ! k = top_lev, pver
 
@@ -423,7 +458,7 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    !----------------------------------------------------------------------------
    ! write history output if not in diagnostic mode
 
-   if (list_idx == 0) then
+   if (.not.present(list_idx_in)) then
 
       aerosol_water(:ncol,:) = 0._r8
       do m = 1, nmodes
@@ -440,13 +475,6 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
          call outfld( 'aero_water',  aerosol_water(:ncol,:),    ncol, lchnk)
 
    end if
-
-   !----------------------------------------------------------------------------
-   ! clean up
-
-   deallocate( &
-      maer,   hygro,  naer,   dryvol,    drymass,    dryrad, &
-      wetrad, wetvol, wtrvol, rhcrystal, rhdeliques, specdens_1)
 
 end subroutine modal_aero_wateruptake_dr
 

--- a/components/eam/src/physics/cam/aer_rad_props.F90
+++ b/components/eam/src/physics/cam/aer_rad_props.F90
@@ -123,7 +123,7 @@ end subroutine aer_rad_props_init
 
 !==============================================================================
 
-subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, is_cmip6_volc, &
+subroutine aer_rad_props_sw(list_idx, dt, state, pbuf,  nnite, idxnite, is_cmip6_volc, &
                             tau, tau_w, tau_w_g, tau_w_f)
 
    ! Return bulk layer tau, omega, g, f for all spectral intervals.
@@ -136,6 +136,7 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, is_cmip6_vol
    integer,             intent(in) :: nnite                ! number of night columns
    integer,             intent(in) :: idxnite(:)           ! local column indices of night columns
    logical,             intent(in) :: is_cmip6_volc        ! true if cmip6 style volcanic file is read otherwise false
+   real(r8),            intent(in) :: dt
 
    real(r8), intent(out) :: tau    (pcols,0:pver,nswbands) ! aerosol extinction optical depth
    real(r8), intent(out) :: tau_w  (pcols,0:pver,nswbands) ! aerosol single scattering albedo * tau
@@ -262,7 +263,7 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, is_cmip6_vol
 
    ! Contributions from modal aerosols.
    if (nmodes > 0) then
-      call modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw(:,:,idx_sw_diag), trop_level, &
+      call modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw(:,:,idx_sw_diag), trop_level, &
                          tau, tau_w, tau_w_g, tau_w_f)
    else
       tau    (1:ncol,:,:) = 0._r8
@@ -346,7 +347,7 @@ end subroutine aer_rad_props_sw
 
 !==============================================================================
 
-subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, state, pbuf,  odap_aer)
+subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, dt, state, pbuf,  odap_aer)
 
    use radconstants,  only: ot_length
 
@@ -360,6 +361,7 @@ subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, state, pbuf,  odap_aer)
    ! Arguments
    logical,             intent(in)  :: is_cmip6_volc
    integer,             intent(in)  :: list_idx                      ! index of the climate or a diagnostic list
+   real(r8),            intent(in)  :: dt
    type(physics_state), intent(in), target :: state
    
    type(physics_buffer_desc), pointer :: pbuf(:)
@@ -418,7 +420,7 @@ subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, state, pbuf,  odap_aer)
 
    ! Contributions from modal aerosols.
    if (nmodes > 0) then
-      call modal_aero_lw(list_idx, state, pbuf, odap_aer)
+      call modal_aero_lw(list_idx, dt, state, pbuf, odap_aer)
    else
       odap_aer = 0._r8
    end if

--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -33,7 +33,7 @@ use perf_mod,          only: t_startf, t_stopf
 use cam_abortutils,        only: endrun
 
 use modal_aero_wateruptake, only: modal_aero_wateruptake_dr
-use modal_aero_calcsize,    only: modal_aero_calcsize_diag
+use modal_aero_calcsize,    only: modal_aero_calcsize_sub
 
 implicit none
 private
@@ -64,6 +64,13 @@ integer :: qaerwat_idx  = -1
 
 character(len=4) :: diag(0:n_diag) = (/'    ','_d1 ','_d2 ','_d3 ','_d4 ','_d5 ', &
                                        '_d6 ','_d7 ','_d8 ','_d9 ','_d10'/)
+
+!Declare the following threadprivate variables to be used for calcsize and water uptake
+!These are defined as module level variables to aviod allocation-deallocation in a loop
+real(r8), pointer :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
+real(r8), pointer :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
+real(r8), pointer :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
+!$OMP THREADPRIVATE(dgnumdry_m, dgnumwet_m, qaerwat_m)
 
 !===============================================================================
 CONTAINS
@@ -111,6 +118,7 @@ subroutine modal_aer_opt_init()
 
    use ioFileMod,        only: getfil
    use phys_control,     only: phys_getopts
+   use shr_log_mod ,     only: errmsg => shr_log_errmsg
 
    ! Local variables
 
@@ -124,7 +132,7 @@ subroutine modal_aer_opt_init()
 
    logical :: call_list(0:n_diag)
    integer :: ilist, nmodes, m_ncoef, m_prefr, m_prefi
-   integer :: errcode
+   integer :: errcode, istat
 
    character(len=*), parameter :: routine='modal_aer_opt_init'
    !----------------------------------------------------------------------------
@@ -173,6 +181,17 @@ subroutine modal_aer_opt_init()
    call phys_getopts(history_amwg_out        = history_amwg, &
                      history_verbose_out = history_verbose, &
                      history_aero_optics_out = history_aero_optics )
+
+   !Allocate dry and wet size variables in an OMP PARRALLEL region as these
+   !arrays are private for each thread and needs to be allocated for each OMP thread
+   !$OMP PARALLEL
+   allocate(dgnumdry_m(pcols,pver,nmodes),stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate dgnumdry_m: "//errmsg(__FILE__,__LINE__) )
+   allocate(dgnumwet_m(pcols,pver,nmodes),stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate dgnumwet_m: "//errmsg(__FILE__,__LINE__) )
+   allocate(qaerwat_m(pcols,pver,nmodes),stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate qaerwat_m: "//errmsg(__FILE__,__LINE__) )
+   !$OMP END PARALLEL
 
    ! Add diagnostic fields to history output.
 
@@ -371,7 +390,7 @@ end subroutine modal_aer_opt_init
 
 !===============================================================================
 
-subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw, trop_level,  &
+subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw, trop_level,  &
                          tauxar, wa, ga, fa)
 
    ! calculates aerosol sw radiative properties
@@ -383,7 +402,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
    integer,             intent(in) :: nnite          ! number of night columns
    integer,             intent(in) :: idxnite(nnite) ! local column indices of night columns
    integer,             intent(in) :: trop_level(pcols)!tropopause level for each column
-   real(r8),            intent(in) :: ext_cmip6_sw(pcols,pver) !balli comments
+   real(r8),            intent(in) :: ext_cmip6_sw(pcols,pver), dt
    logical,             intent(in) :: is_cmip6_volc !BALLI-comments
 
    real(r8), intent(out) :: tauxar(pcols,0:pver,nswbands) ! layer extinction optical depth
@@ -410,11 +429,6 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
 
    real(r8), pointer :: dgnumwet(:,:)     ! number mode wet diameter
    real(r8), pointer :: qaerwat(:,:)      ! aerosol water (g/g)
-
-   real(r8), pointer :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
-   real(r8), pointer :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
-   real(r8), pointer :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
-   real(r8), pointer :: wetdens_m(:,:,:)  ! 
 
    real(r8) :: sigma_logr_aer         ! geometric standard deviation of number distribution
    real(r8) :: radsurf(pcols,pver)    ! aerosol surface mode radius
@@ -584,22 +598,20 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
    ! loop over all aerosol modes
    call rad_cnst_get_info(list_idx, nmodes=nmodes)
 
-   if (list_idx == 0) then
-      ! water uptake and wet radius for the climate list has already been calculated
-      call pbuf_get_field(pbuf, dgnumwet_idx, dgnumwet_m)
-      call pbuf_get_field(pbuf, qaerwat_idx,  qaerwat_m)
-   else
-      ! If doing a diagnostic calculation then need to calculate the wet radius
-      ! and water uptake for the diagnostic modes
-      allocate(dgnumdry_m(pcols,pver,nmodes), dgnumwet_m(pcols,pver,nmodes), &
-               qaerwat_m(pcols,pver,nmodes),  wetdens_m(pcols,pver,nmodes), stat=istat)
-      if (istat > 0) then
-         call endrun('modal_aero_sw: allocation FAILURE: arrays for diagnostic calcs')
-      end if
-      call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m)  
-      call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
-                                     qaerwat_m, wetdens_m)
-   endif
+   !BSINGH-Future work:
+   !1. Deallocate dgnumdry_m etc. variables in a finalize call
+
+   !Assign unphysical values to detect any inadvertant use of these variables
+   dgnumdry_m(:,:,:) = huge(1.0_r8)
+   dgnumwet_m(:,:,:) = huge(1.0_r8)
+   qaerwat_m(:,:,:)  = huge(1.0_r8)
+
+   !Compute new sizes (dry diameters as dgnumdry_m) of aerosol particles
+   call modal_aero_calcsize_sub(state, pbuf, dt, do_adjust_in=.true., do_aitacc_transfer_in=.true., &
+        list_idx_in=list_idx, update_mmr_in = .false., dgnumdry_m=dgnumdry_m)
+
+   !Compute water uptake by particles to reach their new size "dgnumwet_m"
+   call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, qaerwat_m)
 
    do m = 1, nmodes
 
@@ -1058,13 +1070,6 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
 
    end do ! nmodes
 
-   if (list_idx > 0) then
-      deallocate(dgnumdry_m)
-      deallocate(dgnumwet_m)
-      deallocate(qaerwat_m)
-      deallocate(wetdens_m)
-   end if
-
    !Add contributions from volcanic aerosols directly read in extinction
    if(is_cmip6_volc) then
       !update tropopause layer first
@@ -1190,11 +1195,14 @@ end subroutine modal_aero_sw
 
 !===============================================================================
 
-subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
+subroutine modal_aero_lw(list_idx, dt, state, pbuf, tauxar)
+
+  use shr_log_mod ,     only: errmsg => shr_log_errmsg
 
    ! calculates aerosol lw radiative properties
 
    integer,             intent(in)  :: list_idx ! index of the climate or a diagnostic list
+   real(r8),            intent(in)  :: dt
    type(physics_state), intent(in), target :: state    ! state variables
    
    type(physics_buffer_desc), pointer :: pbuf(:)
@@ -1211,11 +1219,6 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
 
    real(r8), pointer :: dgnumwet(:,:)  ! wet number mode diameter (m)
    real(r8), pointer :: qaerwat(:,:)   ! aerosol water (g/g)
-
-   real(r8), pointer :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
-   real(r8), pointer :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
-   real(r8), pointer :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
-   real(r8), pointer :: wetdens_m(:,:,:)  ! 
 
    real(r8) :: sigma_logr_aer          ! geometric standard deviation of number distribution
    real(r8) :: alnsg_amode
@@ -1264,22 +1267,20 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
    ! loop over all aerosol modes
    call rad_cnst_get_info(list_idx, nmodes=nmodes)
 
-   if (list_idx == 0) then
-      ! water uptake and wet radius for the climate list has already been calculated
-      call pbuf_get_field(pbuf, dgnumwet_idx, dgnumwet_m)
-      call pbuf_get_field(pbuf, qaerwat_idx,  qaerwat_m)
-   else
-      ! If doing a diagnostic calculation then need to calculate the wet radius
-      ! and water uptake for the diagnostic modes
-      allocate(dgnumdry_m(pcols,pver,nmodes), dgnumwet_m(pcols,pver,nmodes), &
-               qaerwat_m(pcols,pver,nmodes),  wetdens_m(pcols,pver,nmodes), stat=istat)
-      if (istat > 0) then
-         call endrun('modal_aero_lw: allocation FAILURE: arrays for diagnostic calcs')
-      end if
-      call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m)  
-      call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
-                                     qaerwat_m, wetdens_m)
-   endif
+   !BSINGH-Future work:
+   !1. Deallocate dgnumdry_m etc. variables in a finalize call
+
+   !Assign unphysical values to detect any inadvertant use of these variables
+   dgnumdry_m(:,:,:) = huge(1.0_r8)
+   dgnumwet_m(:,:,:) = huge(1.0_r8)
+   qaerwat_m(:,:,:)  = huge(1.0_r8)
+
+   !Compute new sizes (dry diameters as dgnumdry_m) of aerosol particles
+   call modal_aero_calcsize_sub(state, pbuf, dt, do_adjust_in=.true., do_aitacc_transfer_in=.true., &
+        list_idx_in=list_idx, update_mmr_in = .false., dgnumdry_m=dgnumdry_m)
+
+   !Compute water uptake by particles to reach their new size "dgnumwet_m"
+   call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, qaerwat_m)
 
    do m = 1, nmodes
 
@@ -1418,13 +1419,6 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
       end do  ! nlwbands
 
    end do ! m = 1, nmodes
-
-   if (list_idx > 0) then
-      deallocate(dgnumdry_m)
-      deallocate(dgnumwet_m)
-      deallocate(qaerwat_m)
-      deallocate(wetdens_m)
-   end if
 
 end subroutine modal_aero_lw
 

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2707,7 +2707,7 @@ if (l_rad) then
          cam_out, cam_in, &
          cam_in%landfrac,landm,cam_in%icefrac, cam_in%snowhland, &
          fsns,    fsnt, flns,    flnt,  &
-         fsds, net_flx,is_cmip6_volc)
+         fsds, net_flx,is_cmip6_volc, ztodt)
 
     ! Set net flux used by spectral dycores
     do i=1,ncol

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -2822,7 +2822,7 @@ end if
 
       ! set all ptend%lq to false as they will be set in modal_aero_calcsize_sub
       ptend%lq(:) = .false.
-      call modal_aero_calcsize_sub (state, ptend, ztodt, pbuf)
+      call modal_aero_calcsize_sub (state, pbuf, ztodt, ptend)
       call modal_aero_wateruptake_dr(state, pbuf, clear_rh_in=mmf_clear_rh)
 
       ! ECPP handles aerosol wet deposition, so tendency from wet depostion is 

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -793,7 +793,7 @@ end function radiation_nextsw_cday
        cam_out, cam_in, &
        landfrac,landm,icefrac,snowh, &
        fsns,    fsnt, flns,    flnt,  &
-       fsds, net_flx, is_cmip6_volc)
+       fsds, net_flx, is_cmip6_volc, dt)
 
     !----------------------------------------------------------------------- 
     ! 
@@ -850,7 +850,7 @@ end function radiation_nextsw_cday
 
     ! Arguments
     logical,  intent(in)    :: is_cmip6_volc    ! true if cmip6 style volcanic file is read otherwise false 
-    real(r8), intent(in)    :: landfrac(pcols)  ! land fraction
+    real(r8), intent(in)    :: landfrac(pcols),dt  ! land fraction
     real(r8), intent(in)    :: landm(pcols)     ! land fraction ramp
     real(r8), intent(in)    :: icefrac(pcols)   ! land fraction
     real(r8), intent(in)    :: snowh(pcols)     ! Snow depth (liquid water equivalent)
@@ -1276,7 +1276,7 @@ end function radiation_nextsw_cday
                   ! update the concentrations in the RRTMG state object
                   call  rrtmg_state_update( state, pbuf, icall, r_state )
 
-                  call aer_rad_props_sw( icall, state, pbuf, nnite, idxnite, is_cmip6_volc, &
+                  call aer_rad_props_sw( icall, dt, state, pbuf, nnite, idxnite, is_cmip6_volc, &
                                          aer_tau, aer_tau_w, aer_tau_w_g, aer_tau_w_f)
 
                   call t_startf ('rad_rrtmg_sw')
@@ -1429,7 +1429,7 @@ end function radiation_nextsw_cday
                   ! update the conctrations in the RRTMG state object
                   call  rrtmg_state_update( state, pbuf, icall, r_state)
 
-                  call aer_rad_props_lw(is_cmip6_volc, icall, state, pbuf,  aer_lw_abs)
+                  call aer_rad_props_lw(is_cmip6_volc, icall, dt, state, pbuf,  aer_lw_abs)
                   
                   call t_startf ('rad_rrtmg_lw')
                   call rad_rrtmg_lw( &

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -850,7 +850,8 @@ end function radiation_nextsw_cday
 
     ! Arguments
     logical,  intent(in)    :: is_cmip6_volc    ! true if cmip6 style volcanic file is read otherwise false 
-    real(r8), intent(in)    :: landfrac(pcols),dt  ! land fraction
+    real(r8), intent(in)    :: dt               !time step(s)
+    real(r8), intent(in)    :: landfrac(pcols)  ! land fraction
     real(r8), intent(in)    :: landm(pcols)     ! land fraction ramp
     real(r8), intent(in)    :: icefrac(pcols)   ! land fraction
     real(r8), intent(in)    :: snowh(pcols)     ! Snow depth (liquid water equivalent)


### PR DESCRIPTION
Fixes a bug where radiation diagnostic call with the same aerosol species 
as radiation climate call was producing NBFB answers with respect to
radiation climate call. The bug is fixed by eliminating calls to
modal_aero_calcsize_diag subroutine in modal_aer_opt.F90. This subroutine
was called for radiation diagnostic calls. Now, modal_aero_calcsize_sub is
called for both diagnostic and prognostic calls.

I have refactored modal_aero_calcsize_sub subroutine extensively, so that
it is easy to understand different processes taking place in this subroutine.
While doing the refactor, I found another bug which was causing the model to
use incorrect log of sigma g (geometric std. dev. of aerosol mode) during 
accumulation<->aitken transfer.

I have also modified code to avoid "allocation" and "deallocation" of arrays 
in a loop so that multiple radiation diagnostic calls do not run out of
memory.

This PR is NBFB as both prognostic and diagnostic calls for calculating
aerosol sizes and water uptake are now using the current "state" (mass
mixing ratios of the species). Earlier, an older "state" was used to compute 
these quantities.

Fixes: #3468
Fixes: #2575
[NBFB]