### PR TITLE
Allows crops of to be put on separate land units

### DIFF
--- a/components/elm/bld/CLMBuildNamelist.pm
+++ b/components/elm/bld/CLMBuildNamelist.pm
@@ -1546,9 +1546,6 @@ sub setup_cmdl_irrigation {
                   "both irrigation and crop can NOT be on.\n");
     }
   } else {
-    if ( $nl_flags->{'irrig'} =~ /$TRUE/i && $nl_flags->{'use_crop'} =~ /$FALSE/i ) {
-      fatal_error("The -irrig=.true. option requires -crop");
-    }
     if ( defined($nl->get_value("irrigate")) && $nl->get_value("irrigate") ne $nl_flags->{'irrig'} ) {
       my $irrigate = $nl->get_value("irrigate");
       fatal_error("The namelist value 'irrigate=$irrigate' contradicts the command line option '-irrig=$val'");
@@ -2143,11 +2140,6 @@ sub setup_logic_irrigate {
   if ( $physv->as_long() >= $physv->as_long("clm4_5") ) {
     if ( $nl_flags->{'use_crop'} eq ".true." ) {
       add_default($opts->{'test'}, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'irrigate', 'val'=>$nl_flags->{'irrig'});
-    }
-    elsif ( defined($nl->get_value('irrigate')) ) {
-      if ($nl->get_value('irrigate') =~ /$TRUE/i ) {
-        fatal_error("irrigate TRUE needs crop TRUE but it is not\n");
-      }
     }
     $nl_flags->{'irrigate'} = lc($nl->get_value('irrigate'));
   }

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -418,11 +418,6 @@ contains
             errMsg(__FILE__, __LINE__))
        end if
        
-       if (.not. use_crop .and. irrigate) then
-          call endrun(msg=' ERROR: irrigate = .true. requires CROP model active.'//&
-            errMsg(__FILE__, __LINE__))
-       end if
-
        if (.not. use_erosion .and. ero_ccycle) then
           call endrun(msg=' ERROR: ero_ccycle = .true. requires erosion model active.'//&
             errMsg(__FILE__, __LINE__))

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -434,7 +434,7 @@ contains
 
        ! Note that we cannot simply use the 'ltype' argument to set itype here,
        ! because ltype will always indicate istcrop
-       if ( crop_prog )then
+       if (create_crop_landunit) then
           my_ltype = istcrop
        else
           my_ltype = istsoil

--- a/components/elm/src/main/surfrdUtilsMod.F90
+++ b/components/elm/src/main/surfrdUtilsMod.F90
@@ -147,7 +147,6 @@ contains
             do c = cft_lb, cft_ub
                wt_cft(g,c) = wt_cft(g,c)/wtcft_sum * 100._r8
                tmp = tmp + wt_cft(g,c);
-               wt_nat_patch(g,c) = 0.0_r8
             enddo
             if (abs(tmp - 100._r8) > eps) then
                do c = cft_lb, cft_ub

--- a/components/elm/src/main/surfrdUtilsMod.F90
+++ b/components/elm/src/main/surfrdUtilsMod.F90
@@ -21,6 +21,7 @@ module surfrdUtilsMod
   public :: check_sums_equal_1  ! Confirm that sum(arr(n,:)) == 1 for all n
   public :: convert_cft_to_pft  ! Conversion of crop CFT to natural veg PFT:w
   public :: collapse_crop_types ! Collapse unused crop types into types used in this run
+  public :: convert_pft_to_cft  ! Conversion of crops from natural veg to CFT
   
   !-----------------------------------------------------------------------
 
@@ -102,7 +103,84 @@ contains
 
   end subroutine convert_cft_to_pft
 
-  !-----------------------------------------------------------------------
+!-----------------------------------------------------------------------
+  subroutine convert_pft_to_cft( begg, endg )
+   !
+   ! !DESCRIPTION:
+   !        Moves the crops from the PFT landunit to their own landunit.
+   !        The PCT of natural vegetation and crops are updated after creating
+   !        the new crop landunit 
+   ! !USES:
+   use clm_varsur      , only : wt_lunit, wt_nat_patch, wt_cft
+   use clm_varpar      , only : cft_size, natpft_size
+   use clm_varpar      , only : cft_size, cft_lb, cft_ub, natpft_lb, natpft_ub
+   use pftvarcon       , only : nc3crop
+   use landunit_varcon , only : istsoil, istcrop
+   ! !ARGUMENTS:
+   implicit none
+   integer          , intent(in)    :: begg, endg
+   !
+   ! !LOCAL VARIABLES:
+   integer  :: g, c    ! index
+   real(r8) :: wtpft_sum, wtcft_sum
+   !-----------------------------------------------------------------------
+
+   do g = begg, endg
+
+      if ( wt_lunit(g,istsoil) > 0.0_r8 ) then
+
+         ! Determine the wt of CFTs
+         wtcft_sum = 0.0_r8
+         do c = cft_lb, cft_ub
+            wtcft_sum = wtcft_sum + wt_cft(g,c)
+         enddo
+
+         if (wtcft_sum > 0.0_r8) then ! Crops are present in the PFTs
+
+            ! Set the CFT landunit fraction and update the PFT landunit fraction
+            wt_lunit(g,istcrop) = wtcft_sum * wt_lunit(g,istsoil)
+            wt_lunit(g,istsoil) = wt_lunit(g,istsoil) - wt_lunit(g,istcrop)
+
+            ! Update the CFT fraction w.r.t. CFT landunit
+            do c = cft_lb, cft_ub
+               wt_cft(g,c) = wt_cft(g,c)/wtcft_sum * 100._r8
+               wt_nat_patch(g,c) = 0.0_r8
+            enddo
+
+            ! Determine the PFT fraction
+            wtpft_sum = 0.0_r8
+            do c = natpft_lb, natpft_ub
+               wtpft_sum = wtpft_sum + wt_nat_patch(g,c)
+            enddo
+
+            if (wtpft_sum > 0.0_r8) then ! PFTs are present
+               ! Update the PFT fraction w.r.t. new PFT landunit
+               do c = natpft_lb, natpft_ub
+                  wt_nat_patch(g,c) = wt_nat_patch(g,c)/wtpft_sum * 100._r8
+               enddo
+            else
+               do c = natpft_lb, natpft_ub
+                  wt_nat_patch(g,c) = 0._r8
+               enddo
+            endif
+         else
+            ! Crops are not present, so zero out the fraction of crops.
+            ! Assign first CFT 100% and This will not have an impact because the
+            ! fraction of crop landunit is zero.
+            wt_cft(g,:) = 0.0_r8
+            wt_cft(g,cft_lb) = 100.0_r8
+         endif
+
+      else
+         ! Natural vegetation landunit is not present, so crop landunit is also
+         ! not present
+         wt_cft(g,:) = 0.0_r8
+      end if
+   end do
+
+ end subroutine convert_pft_to_cft
+
+ !-----------------------------------------------------------------------
   subroutine collapse_crop_types(wt_cft, fert_cft, begg, endg, verbose)
     !
     ! !DESCRIPTION:


### PR DESCRIPTION
The default model configuration when the prognostic crop model is off is for the
crops to share the landunit with natural vegetation. In this default configuration, the
irrigated water for the crops is also used by natural vegetation. These code modifications
allow for crops and natural vegetation to be on separate landunits when the prognostic
crop model is off.

[BFB]