### PR TITLE
Add theta-SL-pg2 config for EAM Antarctica RRM

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -3542,7 +3542,7 @@
 
     <gridmap atm_grid="ne0np4_antarcticax4v1.pg2" lnd_grid="r0125">
       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/antarcticax4v1np4/map_antarcticax4v1pg2_to_r0125_mono.20200925.nc</map>
-      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/antarcticax4v1np4/map_antarcticax4v1pg2_to_r0125_mono.20200925.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/antarcticax4v1np4/map_antarcticax4v1pg2_to_r0125_bilin.20200925.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/r0125/map_r0125_to_antarcticax4v1pg2_mono.20200925.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/r0125/map_r0125_to_antarcticax4v1pg2_mono.20200925.nc</map>
     </gridmap>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1094,6 +1094,16 @@
       <mask>oRRS15to5</mask>
     </model_grid>
 
+    <model_grid alias="antarcticax4v1pg2_r0125_antarcticax4v1pg2" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne0np4_antarcticax4v1.pg2</grid>
+      <grid name="lnd">r0125</grid>
+      <grid name="ocnice">ne0np4_antarcticax4v1.pg2</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS15to5</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg2_ne30pg2" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">ne30np4.pg2</grid>
@@ -2771,6 +2781,14 @@
       <desc>1-deg with 1/4-deg over Antarctica (version 1):</desc>
     </domain>
 
+    <domain name="ne0np4_antarcticax4v1.pg2">
+      <nx>48836</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.antarcticax4v1pg2_oRRS15to5.200926.nc</file>
+      <file grid="ice|ocn" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.ocn.antarcticax4v1pg2_oRRS15to5.200926.nc</file>
+      <desc>1-deg with 1/4-deg over Antarctica (version 1) pg2:</desc>
+    </domain>
+
     <domain name="tx0.1v2">
       <nx>3600</nx>
       <ny>2400</ny>
@@ -3520,6 +3538,18 @@
     <gridmap atm_grid="ne0np4_antarcticax4v1" rof_grid="r0125">
       <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/antarcticax4v1np4/map_antarcticax4v1_to_r0125_mono.20191127.nc</map>
       <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/antarcticax4v1np4/map_antarcticax4v1_to_r0125_mono.20191127.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne0np4_antarcticax4v1.pg2" lnd_grid="r0125">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/antarcticax4v1np4/map_antarcticax4v1pg2_to_r0125_mono.20200925.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/antarcticax4v1np4/map_antarcticax4v1pg2_to_r0125_mono.20200925.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/r0125/map_r0125_to_antarcticax4v1pg2_mono.20200925.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/r0125/map_r0125_to_antarcticax4v1pg2_mono.20200925.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne0np4_antarcticax4v1.pg2" rof_grid="r0125">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/antarcticax4v1np4/map_antarcticax4v1pg2_to_r0125_mono.20200925.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/antarcticax4v1np4/map_antarcticax4v1pg2_to_r0125_mono.20200925.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="gx3v7">

--- a/components/eam/bld/config_files/horiz_grid.xml
+++ b/components/eam/bld/config_files/horiz_grid.xml
@@ -74,7 +74,7 @@
 <horiz_grid dyn="se" hgrid="ne0np4_northamericax4v1"          ncol="130088" csne="0" csnp="4" npg="0" />
 <horiz_grid dyn="se" hgrid="ne0np4_northamericax4v1.pg2"      ncol="57816"  csne="0" csnp="4" npg="2" />
 <horiz_grid dyn="se" hgrid="ne0np4_antarcticax4v1"            ncol="109883" csne="0" csnp="4" npg="0" />
-<horiz_grid dyn="se" hgrid="ne0np4_antarcticax4v1.pg2"        ncol="48836"  csne="0" csnp="4" npg="0" />
+<horiz_grid dyn="se" hgrid="ne0np4_antarcticax4v1.pg2"        ncol="48836"  csne="0" csnp="4" npg="2" />
 <horiz_grid dyn="se" hgrid="ne0np4_svalbard_x8v1_lowcon"      ncol="71912"  csne="0" csnp="4" npg="0" />
 <horiz_grid dyn="se" hgrid="ne0np4_enax4v1"                   ncol="78788"  csne="0" csnp="4" npg="0" />
 <horiz_grid dyn="se" hgrid="ne0np4_twpx4v1"                   ncol="81434"  csne="0" csnp="4" npg="0" />

--- a/components/eam/bld/config_files/horiz_grid.xml
+++ b/components/eam/bld/config_files/horiz_grid.xml
@@ -74,6 +74,7 @@
 <horiz_grid dyn="se" hgrid="ne0np4_northamericax4v1"          ncol="130088" csne="0" csnp="4" npg="0" />
 <horiz_grid dyn="se" hgrid="ne0np4_northamericax4v1.pg2"      ncol="57816"  csne="0" csnp="4" npg="2" />
 <horiz_grid dyn="se" hgrid="ne0np4_antarcticax4v1"            ncol="109883" csne="0" csnp="4" npg="0" />
+<horiz_grid dyn="se" hgrid="ne0np4_antarcticax4v1.pg2"        ncol="48836"  csne="0" csnp="4" npg="0" />
 <horiz_grid dyn="se" hgrid="ne0np4_svalbard_x8v1_lowcon"      ncol="71912"  csne="0" csnp="4" npg="0" />
 <horiz_grid dyn="se" hgrid="ne0np4_enax4v1"                   ncol="78788"  csne="0" csnp="4" npg="0" />
 <horiz_grid dyn="se" hgrid="ne0np4_twpx4v1"                   ncol="81434"  csne="0" csnp="4" npg="0" />

--- a/components/eam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_cam.xml
@@ -259,6 +259,7 @@
 <bnd_topo hgrid="ne0np4_northamericax4v1"  >atm/cam/topo/USGS_northamericax4v1_12xdel2_consistentSGH_191023.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_northamericax4v1" npg="2">atm/cam/topo/USGS_northamericax4v1pg2_12xdel2_consistentSGH_20020209.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_antarcticax4v1"  >atm/cam/topo/USGS-gtopo30_antarcticax4v1_12xdel2_consistentSGH_191120.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4_antarcticax4v1"  npg="2">atm/cam/topo/USGS_gtopo30_aantarcticax4v1pg2_12xdel2_consistentSGH_20200925.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_svalbard_x8v1_lowcon"  >atm/cam/topo/USGS_svalbardx8v1-tensor12x_c150612.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  >atm/cam/topo/USGS_sooberingoax4x8v1-tensor12x_c150612.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_enax4v1">atm/cam/topo/USGS_enax4v1_tensorx12_consistentSGH_170522.nc</bnd_topo>
@@ -849,6 +850,7 @@
 <drydep_srf_file hgrid="ne0np4_northamericax4v1">atm/cam/chem/trop_mam/atmsrf_northamericax4v1np4_20191023.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_northamericax4v1" npg="2">atm/cam/chem/trop_mam/atmsrf_northamericax4v1pg2_20020209.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_antarcticax4v1">atm/cam/chem/trop_mam/atmsrf_antarcticax4v1np4_20191127.nc</drydep_srf_file>
+<drydep_srf_file hgrid="ne0np4_antarcticax4v1" npg="2">atm/cam/chem/trop_mam/atmsrf_antarcticax4v1pg2_20020925.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_svalbard_x8v1_lowcon">atm/cam/chem/trop_mam/atmsrf_svalbardx8v1.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_sooberingoa_x4x8v1_lowcon">atm/cam/chem/trop_mam/atmsrf_sooberingoax4x8v1.nc</drydep_srf_file>
 <drydep_srf_file hgrid="ne0np4_twpx4v1">atm/cam/chem/trop_mam/atmsrf_twpx4v1_170629.nc</drydep_srf_file>
@@ -1532,6 +1534,7 @@
 <nu_top dyn_target="theta-l" hgrid="ne512np4"> 2e4 </nu_top>
 <nu_top dyn_target="theta-l" hgrid="ne1024np4"> 1e4 </nu_top>
 <nu_top dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"> 1e5 </nu_top>
+<nu_top dyn_target="theta-l" hgrid="ne0np4_antarcticax4v1"> 1e5 </nu_top>
 
 
 <nu>                   1.0e15 </nu>
@@ -1553,6 +1556,7 @@
 <nu hgrid="ne0np4_northamericax4v1"  > 8.0e-8</nu>
 <nu dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"  > 3.4e-8</nu>
 <nu hgrid="ne0np4_antarcticax4v1"  > 8.0e-8</nu>
+<nu dyn_target="theta-l" hgrid="ne0np4_antarcticax4v1"  > 3.4e-8</nu>
 <nu hgrid="ne0np4_svalbard_x8v1_lowcon"  > 8.0e-8</nu>
 <nu hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 8.0e-8</nu>
 <nu hgrid="ne0np4_enax4v1">8.0e-8</nu>
@@ -1594,6 +1598,7 @@
 <hypervis_scaling  hgrid="ne0np4_northamericax4v1"  > 3.2 </hypervis_scaling>
 <hypervis_scaling dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"  > 3.0 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_antarcticax4v1"  > 3.2 </hypervis_scaling>
+<hypervis_scaling dyn_target="theta-l" hgrid="ne0np4_antarcticax4v1"  > 3.0 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_svalbard_x8v1_lowcon"  > 3.2 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  > 3.2 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_enax4v1">3.2</hypervis_scaling>
@@ -1630,6 +1635,7 @@
 <se_tstep dyn_target="theta-l" hgrid="ne512np4">  20 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne1024np4"> 10 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"> 75 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne0np4_antarcticax4v1"> 75 </se_tstep>
 
 
 <!-- old interface, used by preqx.  timesteps controlled by se_nsplit, rsplit, qsplit -->
@@ -1687,6 +1693,7 @@
 <hypervis_subcycle hgrid="ne0np4_northamericax4v1" dyn_target="preqx"  > 7 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_northamericax4v1" dyn_target="theta-l"> 2 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_antarcticax4v1" dyn_target="preqx"  > 7 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne0np4_antarcticax4v1" dyn_target="theta-l"> 2 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_svalbard_x8v1_lowcon" dyn_target="preqx" > 8 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_sooberingoa_x4x8v1_lowcon" dyn_target="preqx"  > 8 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_enax4v1" dyn_target="preqx">7</hypervis_subcycle>
@@ -1694,6 +1701,7 @@
 
 
 <hypervis_subcycle_tom dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"> 3 </hypervis_subcycle_tom>
+<hypervis_subcycle_tom dyn_target="theta-l" hgrid="ne0np4_antarcticax4v1"> 3 </hypervis_subcycle_tom>
 
 
 <!-- ================================================================== -->

--- a/components/eam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_cam.xml
@@ -259,7 +259,7 @@
 <bnd_topo hgrid="ne0np4_northamericax4v1"  >atm/cam/topo/USGS_northamericax4v1_12xdel2_consistentSGH_191023.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_northamericax4v1" npg="2">atm/cam/topo/USGS_northamericax4v1pg2_12xdel2_consistentSGH_20020209.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_antarcticax4v1"  >atm/cam/topo/USGS-gtopo30_antarcticax4v1_12xdel2_consistentSGH_191120.nc</bnd_topo>
-<bnd_topo hgrid="ne0np4_antarcticax4v1"  npg="2">atm/cam/topo/USGS_gtopo30_aantarcticax4v1pg2_12xdel2_consistentSGH_20200925.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4_antarcticax4v1"  npg="2">atm/cam/topo/USGS_gtopo30_antarcticax4v1pg2_12xdel2_consistentSGH_20200925.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_svalbard_x8v1_lowcon"  >atm/cam/topo/USGS_svalbardx8v1-tensor12x_c150612.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_sooberingoa_x4x8v1_lowcon"  >atm/cam/topo/USGS_sooberingoax4x8v1-tensor12x_c150612.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_enax4v1">atm/cam/topo/USGS_enax4v1_tensorx12_consistentSGH_170522.nc</bnd_topo>


### PR DESCRIPTION
theta-SL-pg2 configuration and supporting files are added for grid
ne0np4_antarcticax4v1.pg2_r0125_ne0np4_antarcticax4v1.pg2
with ocean mask oRRS15to5.

[BFB]