### PR TITLE
Update ICG file datestamps for EC30to60E2r2 and e3sm_prod

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -210,7 +210,7 @@ _TESTS = {
     #e3sm tests to mimic production runs
     "e3sm_prod" : {
         "inherit" : "e3sm_atm_prod",
-        "tests"   : "SMS_Ld2.ne30_oECv3_ICG.A_WCYCL1850S_CMIP6.allactive-v1cmip6"
+        "tests"   : "SMS_Ld1.ne30pg2_r05_EC30to60E2r2-1900_ICG.A_WCYCL1850S_CMIP6"
         },
 
     #e3sm tests to mimic BGC production runs

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -220,13 +220,13 @@ def buildnml(case, caseroot, compname):
         restoring_file += 'sss.PHC2_monthlyClimatology.EC30to60E2r2.200910.nc'
         analysis_mask_file += 'EC30to60E2r2_moc_masks_and_transects.nc'
     elif ocn_grid == 'EC30to60E2r2_ICG':
-        ic_date += '200910'
+        ic_date += '201001'
         ic_prefix += 'mpaso.EC30to60E2r2.rstFromG-anvil'
         decomp_date += '200904'
         decomp_prefix += 'mpas-o.graph.info.'
         analysis_mask_file += 'EC30to60E2r2_moc_masks_and_transects.nc'
     elif ocn_grid == 'EC30to60E2r2-1900_ICG':
-        ic_date += '200910'
+        ic_date += '201001'
         ic_prefix += 'mpaso.EC30to60E2r2-1900.rstFromG-anvil'
         decomp_date += '200904'
         decomp_prefix += 'mpas-o.graph.info.'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -201,12 +201,12 @@ def buildnml(case, caseroot, compname):
         decomp_date += '200908'
         decomp_prefix += 'mpas-seaice.graph.info.'
     elif ice_grid == 'EC30to60E2r2_ICG':
-        grid_date += '200910'
+        grid_date += '201001'
         grid_prefix += 'mpassi.EC30to60E2r2.rstFromG-anvil'
         decomp_date += '200908'
         decomp_prefix += 'mpas-seaice.graph.info.'
     elif ice_grid == 'EC30to60E2r2-1900_ICG':
-        grid_date += '200910'
+        grid_date += '201001'
         grid_prefix += 'mpassi.EC30to60E2r2-1900.rstFromG-anvil'
         decomp_date += '200908'
         decomp_prefix += 'mpas-seaice.graph.info.'


### PR DESCRIPTION
This PR updates the datestamps for the ICG files used by mpas-ocean and mpas-seaice to provide initial conditions from G-case spinups to fully-coupled configurations. This is necessary because the number of snow levels in seaice has changed and the older sets of ICG files are no longer valid.

Update e3sm_prod to test SMS_Ld1.ne30pg2_r05_EC30to60E2r2-1900_ICG.A_WCYCL1850S_CMIP6 with new ICG files

Fixes #3858

[BFB] for all tested configurations