### PR TITLE
Define default pe-layout for T62_oEC60to30v3 DTESTM on sandiatoss3

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -9404,5 +9404,40 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="sandiatoss3">
+      <pes compset=".*MPASSI.*DOCN.+" pesize="any">
+        <comment>--res T62_oEC60to30v3 --compset DTESTM on 4 nodes</comment>
+        <ntasks>
+          <ntasks_atm>64</ntasks_atm>
+          <ntasks_lnd>64</ntasks_lnd>
+          <ntasks_rof>64</ntasks_rof>
+          <ntasks_ice>64</ntasks_ice>
+          <ntasks_ocn>64</ntasks_ocn>
+          <ntasks_glc>64</ntasks_glc>
+          <ntasks_wav>64</ntasks_wav>
+          <ntasks_cpl>64</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
   </grid>
 </config_pes>


### PR DESCRIPTION
This PR adds a default pe-layout for sandiatoss3 running a T62_oEC60to30v3 DTESTM configuration to avoid an automated test failure which currently runs on 16-pes. The system requirements for seaice were apparently changed by [PR #3846](https://github.com/E3SM-Project/E3SM/pull/3846) and the test can no longer complete successfully on the smaller layout.

[BFB]