### PR TITLE
Fixes support for user-defined ELM grid

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -37,6 +37,7 @@ _TESTS = {
             "ERS.r05_r05.RMOSGPCC.mosart-gpcc_1972",
             "ERS.MOS_USRDAT.RMOSGPCC.mosart-mos_usrdat",
             "SMS.MOS_USRDAT.RMOSGPCC.mosart-unstructure",
+            "ERS.ELM_USRDAT.I1850ELM.elm-usrdat"
             )
         },
 

--- a/components/elm/cime_config/buildnml
+++ b/components/elm/cime_config/buildnml
@@ -26,13 +26,13 @@ def buildnml(case, caseroot, compname):
     srcroot             = case.get_value("SRCROOT")
     compset             = case.get_value("COMPSET")
     ccsm_co2_ppmv       = case.get_value("CCSM_CO2_PPMV")
-    clm_co2_type        = case.get_value("CLM_CO2_TYPE")
-    clm_usrdat_name     = case.get_value("CLM_USRDAT_NAME")
-    clm_config_opts     = case.get_value("CLM_CONFIG_OPTS")
-    clm_namelist_opts   = case.get_value("CLM_NAMELIST_OPTS")
-    clm_bldnml_opts     = case.get_value("CLM_BLDNML_OPTS")
-    clm_nml_use_case    = case.get_value("CLM_NML_USE_CASE")
-    clm_force_coldstart = case.get_value("CLM_FORCE_COLDSTART")
+    elm_co2_type        = case.get_value("CLM_CO2_TYPE")
+    elm_usrdat_name     = case.get_value("CLM_USRDAT_NAME")
+    elm_config_opts     = case.get_value("CLM_CONFIG_OPTS")
+    elm_namelist_opts   = case.get_value("CLM_NAMELIST_OPTS")
+    elm_bldnml_opts     = case.get_value("CLM_BLDNML_OPTS")
+    elm_nml_use_case    = case.get_value("CLM_NML_USE_CASE")
+    elm_force_coldstart = case.get_value("CLM_FORCE_COLDSTART")
     comp_interface      = case.get_value("COMP_INTERFACE")
     comp_glc            = case.get_value("COMP_GLC")
     din_loc_root        = case.get_value("DIN_LOC_ROOT")
@@ -85,15 +85,15 @@ def buildnml(case, caseroot, compname):
 
     if lnd_grid == "ELM_USRDAT":
         config_opts = " "
-        resolution = clm_usrdat_name
-        clmusr     = " -clm_usr_name {}".format(clm_usrdat_name)
+        resolution = elm_usrdat_name
+        clmusr     = " -clm_usr_name {}".format(elm_usrdat_name)
 
     if "1PT" in compset:
         config_opts = " -sitespf_pt reg"
 
     # TODO: clm/bld/configure needs to be converted to python
     sysmod = "{}/components/elm/bld/configure".format(srcroot)
-    sysmod += "  {} -comp_intf {} {}".format(config_opts, comp_interface, clm_config_opts)
+    sysmod += "  {} -comp_intf {} {}".format(config_opts, comp_interface, elm_config_opts)
     sysmod += " -usr_src {}/SourceMods/src.elm".format(caseroot)
     run_cmd_no_fail(sysmod, from_dir=elmconf_dir)
 
@@ -104,7 +104,7 @@ def buildnml(case, caseroot, compname):
     startfiletype = "finidat"
     start_type = "default"
     if run_type == "startup":
-        if clm_force_coldstart == "on": start_type = "cold"
+        if elm_force_coldstart == "on": start_type = "cold"
     else:
         if run_type == "hybrid":
             start_type = "startup"
@@ -166,19 +166,19 @@ def buildnml(case, caseroot, compname):
             glc_opts = "-glc_present -glc_smb .{}. ".format(glc_smb)
 
         usecase = " "
-        if clm_nml_use_case != "UNSET": usecase = "-use_case {}".format(clm_nml_use_case)
+        if elm_nml_use_case != "UNSET": usecase = "-use_case {}".format(elm_nml_use_case)
 
         start_ymd = run_startdate.replace("-", "")
         ignore = "-ignore_ic_year" if ("-01-01" in run_startdate or "-09-01" in run_startdate) else "-ignore_ic_date"
 
         sysmod =  "{}/components/elm/bld/build-namelist -infile {}/Buildconf/elmconf/namelist ".format(srcroot, caseroot)
         sysmod += " -csmdata {} -inputdata {}/Buildconf/elm.input_data_list {}".format(din_loc_root, caseroot, ignore)
-        sysmod += ' -namelist " &elm_inparm  start_ymd={} {} /"'.format(start_ymd, clm_namelist_opts)
+        sysmod += ' -namelist " &elm_inparm  start_ymd={} {} /"'.format(start_ymd, elm_namelist_opts)
         sysmod += " {} {} -res {} {} -clm_start_type {}".format(usecase, glc_opts, resolution, clmusr, start_type)
         sysmod += " -envxml_dir {} -l_ncpl {} -lnd_frac {}/{}".format(caseroot, lnd_ncpl, lnd_domain_path, lnd_domain_file)
-        sysmod += " -glc_nec {} -co2_ppmv {} -co2_type {} ".format(glc_nec, ccsm_co2_ppmv, clm_co2_type)
+        sysmod += " -glc_nec {} -co2_ppmv {} -co2_type {} ".format(glc_nec, ccsm_co2_ppmv, elm_co2_type)
         sysmod += " -ncpl_base_period {} ".format(ncpl_base_period)
-        sysmod += " -config {}/config_cache.xml {}".format(elmconf_dir, clm_bldnml_opts)
+        sysmod += " -config {}/config_cache.xml {}".format(elmconf_dir, elm_bldnml_opts)
         if mask_grid != "reg":
             sysmod += " -mask {}".format(mask_grid)
 

--- a/components/elm/cime_config/buildnml
+++ b/components/elm/cime_config/buildnml
@@ -83,7 +83,7 @@ def buildnml(case, caseroot, compname):
         resolution  = lnd_grid
         clmusr      = ""
 
-    if lnd_grid == "CLM_USRDAT":
+    if lnd_grid == "ELM_USRDAT":
         config_opts = " "
         resolution = clm_usrdat_name
         clmusr     = " -clm_usr_name {}".format(clm_usrdat_name)

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/usrdat/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/usrdat/shell_commands
@@ -1,0 +1,6 @@
+./xmlchange LND_DOMAIN_FILE=domain.lnd.1x1pt-brazil_navy.090715.nc
+./xmlchange ATM_DOMAIN_FILE=domain.lnd.1x1pt-brazil_navy.090715.nc
+./xmlchange LND_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains"
+./xmlchange ATM_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains"
+./xmlchange DATM_CLMNCEP_YR_END=1948
+

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/usrdat/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/usrdat/user_nl_elm
@@ -1,0 +1,1 @@
+fsurdat = '$DIN_LOC_ROOT/clm2/surfdata_map/surfdata_1x1_brazil_simyr1850_c140610.nc'


### PR DESCRIPTION
This code modification restores the support for user-defined land grid that
was broken when the name of the land model was changed. A new test is
added for `--res ELM_USRDAT`.

[BFB]