### PR TITLE
Fixes a bug in dry size calculations and these calculations now use current state

### DIFF
--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1529,7 +1529,7 @@ contains
     ! for prognostic modal aerosols the transfer of mass between aitken and 
     ! accumulation modes is done in conjunction with the dry radius calculation
     call t_startf('calcsize')
-    call modal_aero_calcsize_sub(state, ptend, dt, pbuf)
+    call modal_aero_calcsize_sub(state, dt, pbuf, ptend)
     call t_stopf('calcsize')
     
     ! Aerosol water uptake

--- a/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
+++ b/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
@@ -510,7 +510,6 @@ subroutine modal_aero_calcsize_sub(state, deltat, pbuf, ptend, do_adjust_in, &
 
    integer  :: lchnk                ! chunk identifier
    integer  :: ncol                 ! number of columns
-   integer  :: list_idx_local
 
    real(r8), pointer :: t(:,:)      ! Temperature in Kelvin
    real(r8), pointer :: pmid(:,:)   ! pressure at model levels (Pa)
@@ -609,10 +608,9 @@ subroutine modal_aero_calcsize_sub(state, deltat, pbuf, ptend, do_adjust_in, &
       do_aitacc_transfer = do_aitacc_transfer_default
    end if
 
-   list_idx_local = 0
    if(present(list_idx_in)) then
-      if(.not. present(dgnumdry_m)) call endrun('list_idx_in is present but dgnumdry_m pointer is missing'//errmsg(__FILE__,__LINE__))
-      list_idx_local = list_idx_in
+      if(.not. present(dgnumdry_m)) call endrun('list_idx_in is present but dgnumdry_m' // &
+      ' pointer is missing'//errmsg(__FILE__,__LINE__))
    endif
 
    lchnk = state%lchnk
@@ -1481,7 +1479,7 @@ subroutine modal_aero_calcsize_diag(state, pbuf, list_idx_in, dgnum_m)
 
    call rad_cnst_get_info(list_idx, nmodes=nmodes)
 
-   if (list_idx /= 0) then
+   if (present(list_idx_in)) then
       if (.not. present(dgnum_m)) then
          call endrun('modal_aero_calcsize_diag called for'// &
                      'diagnostic list but dgnum_m pointer not present')
@@ -1494,7 +1492,7 @@ subroutine modal_aero_calcsize_diag(state, pbuf, list_idx_in, dgnum_m)
 
    do n = 1, nmodes
 
-      if (list_idx == 0) then
+      if (.not.present(dgnum_m)) then
          call pbuf_get_field(pbuf, dgnum_idx, dgncur_a, start=(/1,1,n/), kount=(/pcols,pver,1/))
       else
          dgncur_a => dgnum_m(:,:,n)

--- a/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
+++ b/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
@@ -470,8 +470,10 @@ end subroutine modal_aero_calcsize_init
 
 !===============================================================================
 
-subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
-   do_aitacc_transfer_in)
+subroutine modal_aero_calcsize_sub(state, deltat, pbuf, ptend, do_adjust_in, &
+   do_aitacc_transfer_in, list_idx_in, dgnumdry_m)
+
+  use shr_log_mod ,  only: errMsg => shr_log_errMsg
 
    !-----------------------------------------------------------------------
    !
@@ -490,12 +492,14 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
 
    ! arguments
    type(physics_state), target, intent(in)    :: state       ! Physics state variables
-   type(physics_ptend), target, intent(inout) :: ptend       ! indivdual parameterization tendencies
    real(r8),                    intent(in)    :: deltat      ! model time-step size (s)
    type(physics_buffer_desc),   pointer       :: pbuf(:)     ! physics buffer
 
-   logical, optional :: do_adjust_in
-   logical, optional :: do_aitacc_transfer_in
+   type(physics_ptend), optional, target, intent(inout) :: ptend       ! indivdual parameterization tendencies
+   logical,  optional :: do_adjust_in
+   logical,  optional :: do_aitacc_transfer_in
+   integer,  optional :: list_idx_in
+   real(r8), optional, pointer :: dgnumdry_m(:,:,:) ! interstital aerosol dry number mode radius (m)
 
 #ifdef MODAL_AERO
 
@@ -506,6 +510,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
 
    integer  :: lchnk                ! chunk identifier
    integer  :: ncol                 ! number of columns
+   integer  :: list_idx_local
 
    real(r8), pointer :: t(:,:)      ! Temperature in Kelvin
    real(r8), pointer :: pmid(:,:)   ! pressure at model levels (Pa)
@@ -528,6 +533,8 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
 
    logical  :: dotendqqcw(pcnst)
    logical  :: noxf_acc2ait(ntot_aspectype)
+   logical  :: ptend_present
+
 
    character(len=fieldname_len)   :: tmpnamea, tmpnameb
    character(len=fieldname_len+3) :: fieldname
@@ -602,6 +609,12 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
       do_aitacc_transfer = do_aitacc_transfer_default
    end if
 
+   list_idx_local = 0
+   if(present(list_idx_in)) then
+      if(.not. present(dgnumdry_m)) call endrun('list_idx_in is present but dgnumdry_m pointer is missing'//errmsg(__FILE__,__LINE__))
+      list_idx_local = list_idx_in
+   endif
+
    lchnk = state%lchnk
    ncol  = state%ncol
 
@@ -609,15 +622,21 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    pmid => state%pmid
    pdel => state%pdel
    q    => state%q
-      
-   dotend => ptend%lq
-   dqdt   => ptend%q
 
-   call pbuf_get_field(pbuf, dgnum_idx, dgncur_a)
-
-   dotendqqcw(:) = .false.
-   dqqcwdt(:,:,:) = 0.0_r8
-   qsrflx(:,:,:,:) = 0.0_r8
+   if(present(ptend)) then
+      ptend_present = .true.
+      dotend => ptend%lq
+      dqdt   => ptend%q
+      call pbuf_get_field(pbuf, dgnum_idx, dgncur_a)
+      dotendqqcw(:) = .false.
+      dqqcwdt(:,:,:) = 0.0_r8
+      qsrflx(:,:,:,:) = 0.0_r8
+   else
+      dgncur_a => dgnumdry_m
+      ptend_present = .false.
+      dqqcwdt(:,:,:)  = huge(dqqcwdt)
+      qsrflx(:,:,:,:) = huge(qsrflx)
+   endif
 
    nait = modeptr_aitken
    nacc = modeptr_accum
@@ -626,7 +645,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    ! tadj = adjustment time scale for number, surface when they are prognosed
    !           currently set to deltat
    tadj = deltat
-   tadj = 86400
+   tadj = 86400.0_r8
    tadj = max( tadj, deltat )
    tadjinv = 1.0_r8/(tadj*(1.0_r8 + 1.0e-15_r8))
    fracadj = deltat*tadjinv
@@ -693,7 +712,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
          !    compute number tendencies that will bring numbers to their
          !    current diagnosed values
          !
-         if (lna > 0) then
+         if (lna > 0 .and. ptend_present) then
             dotend(lna) = .true.
             do k=top_lev,pver
                do i=1,ncol
@@ -702,7 +721,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                end do
             end do
          end if
-         if (lnc > 0) then
+         if (lnc > 0 .and. ptend_present) then
             dotendqqcw(lnc) = .true.
             do k=top_lev,pver
                do i=1,ncol
@@ -762,7 +781,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
          v2nyyrl = v2nyy*frelaxadj   ! NEW
       end if
 
-      if (do_adjust) then
+      if (do_adjust .and. ptend_present) then
          dotend(lna) = .true.
          dotendqqcw(lnc) = .true.
       end if
@@ -792,25 +811,25 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                   num_a = 0.0_r8
                   dqdt(i,k,lna) = -num_a0*deltatinv
                   num_c = 0.0_r8
-                  dqqcwdt(i,k,lnc) = -num_c0*deltatinv
+                  if(ptend_present) dqqcwdt(i,k,lnc) = -num_c0*deltatinv
                else if (drv_c <= 0.0_r8) then
                   ! activated volume is zero, so interstitial number/volume == total/combined
                   ! apply step 1 and 3, but skip the relaxed adjustment (step 2, see below)
                   num_c = 0.0_r8
-                  dqqcwdt(i,k,lnc) = -num_c0*deltatinv
+                  if(ptend_present) dqqcwdt(i,k,lnc) = -num_c0*deltatinv
                   num_a1 = num_a
                   numbnd = max( drv_a*v2nxx, min( drv_a*v2nyy, num_a1 ) )
                   num_a  = num_a1 + (numbnd - num_a1)*fracadj
-                  dqdt(i,k,lna) = (num_a - num_a0)*deltatinv
+                  if(ptend_present) dqdt(i,k,lna) = (num_a - num_a0)*deltatinv
 
                else if (drv_a <= 0.0_r8) then
                   ! interstitial volume is zero, treat similar to above
                   num_a = 0.0_r8
-                  dqdt(i,k,lna) = -num_a0*deltatinv
+                  if(ptend_present) dqdt(i,k,lna) = -num_a0*deltatinv
                   num_c1 = num_c
                   numbnd = max( drv_c*v2nxx, min( drv_c*v2nyy, num_c1 ) )
                   num_c  = num_c1 + (numbnd - num_c1)*fracadj
-                  dqqcwdt(i,k,lnc) = (num_c - num_c0)*deltatinv
+                  if(ptend_present) dqqcwdt(i,k,lnc) = (num_c - num_c0)*deltatinv
                else
                   ! both volumes are positive
                   ! apply 3 adjustment steps
@@ -866,9 +885,9 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                      end if
                   end if
                   num_a = num_a2 + delnum_a3
-                  dqdt(i,k,lna) = (num_a - num_a0)*deltatinv
+                  if(ptend_present) dqdt(i,k,lna) = (num_a - num_a0)*deltatinv
                   num_c = num_c2 + delnum_c3
-                  dqqcwdt(i,k,lnc) = (num_c - num_c0)*deltatinv
+                  if(ptend_present) dqqcwdt(i,k,lnc) = (num_c - num_c0)*deltatinv
                end if
 
             end if ! do_adjust
@@ -890,8 +909,10 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
             end if
             pdel_fac = pdel(i,k)/gravit   ! = rho*dz
             jac = 1
-            qsrflx(i,lna,1,jac) = qsrflx(i,lna,1,jac) + max(0.0_r8,dqdt(i,k,lna))*pdel_fac
-            qsrflx(i,lna,2,jac) = qsrflx(i,lna,2,jac) + min(0.0_r8,dqdt(i,k,lna))*pdel_fac
+            if(ptend_present) then
+               qsrflx(i,lna,1,jac) = qsrflx(i,lna,1,jac) + max(0.0_r8,dqdt(i,k,lna))*pdel_fac
+               qsrflx(i,lna,2,jac) = qsrflx(i,lna,2,jac) + min(0.0_r8,dqdt(i,k,lna))*pdel_fac
+            endif
 
             if (drv_c > 0.0_r8) then
                if (num_c <= drv_c*v2nxx) then
@@ -906,8 +927,10 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                end if
             end if
             jac = 2
-            qsrflx(i,lnc,1,jac) = qsrflx(i,lnc,1,jac) + max(0.0_r8,dqqcwdt(i,k,lnc))*pdel_fac
-            qsrflx(i,lnc,2,jac) = qsrflx(i,lnc,2,jac) + min(0.0_r8,dqqcwdt(i,k,lnc))*pdel_fac
+            if(ptend_present) then
+               qsrflx(i,lnc,1,jac) = qsrflx(i,lnc,1,jac) + max(0.0_r8,dqqcwdt(i,k,lnc))*pdel_fac
+               qsrflx(i,lnc,2,jac) = qsrflx(i,lnc,2,jac) + min(0.0_r8,dqqcwdt(i,k,lnc))*pdel_fac
+            endif
 
 
             ! save number and dryvol for aitken <--> accum transfer
@@ -977,13 +1000,13 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
       do iq = 1, nspecfrm_csizxf(ipair)
          lsfrm = lspecfrma_csizxf(iq,ipair)
          lstoo = lspectooa_csizxf(iq,ipair)
-         if ((lsfrm > 0) .and. (lstoo > 0)) then
+         if ((lsfrm > 0) .and. (lstoo > 0) .and. ptend_present) then
             dotend(lsfrm) = .true.
             dotend(lstoo) = .true.
          end if
          lsfrm = lspecfrmc_csizxf(iq,ipair)
          lstoo = lspectooc_csizxf(iq,ipair)
-         if ((lsfrm > 0) .and. (lstoo > 0)) then
+         if ((lsfrm > 0) .and. (lstoo > 0) .and. ptend_present) then
             dotendqqcw(lsfrm) = .true.
             dotendqqcw(lstoo) = .true.
          end if
@@ -1149,6 +1172,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                      drv_c = drv_c_acc
                   end if
 
+                  dumfac = exp(4.5_r8*alnsg_amode(n)**2)*pi/6.0_r8
                   if (drv_a > 0.0_r8) then
                      if (num_a <= drv_a*voltonumbhi_amode(n)) then
                         dgncur_a(i,k,n) = dgnumhi_amode(n)
@@ -1267,8 +1291,10 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                                  else
                                     xfertend = max(0.0_r8,q(i,k,lsfrm))*xfercoef
                                  end if
-                                 dqdt(i,k,lsfrm) = dqdt(i,k,lsfrm) - xfertend
-                                 dqdt(i,k,lstoo) = dqdt(i,k,lstoo) + xfertend
+                                 if(ptend_present) then
+                                    dqdt(i,k,lsfrm) = dqdt(i,k,lsfrm) - xfertend
+                                    dqdt(i,k,lstoo) = dqdt(i,k,lstoo) + xfertend
+                                 endif
                               else
                                  if (iq .eq. 1) then
                                     xfertend = xfertend_num(j,jac)
@@ -1276,11 +1302,15 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                                     fldcw => qqcw_get_field(pbuf,lsfrm,lchnk)
                                     xfertend = max(0.0_r8,fldcw(i,k))*xfercoef
                                  end if
-                                 dqqcwdt(i,k,lsfrm) = dqqcwdt(i,k,lsfrm) - xfertend
-                                 dqqcwdt(i,k,lstoo) = dqqcwdt(i,k,lstoo) + xfertend
+                                 if(ptend_present) then
+                                    dqqcwdt(i,k,lsfrm) = dqqcwdt(i,k,lsfrm) - xfertend
+                                    dqqcwdt(i,k,lstoo) = dqqcwdt(i,k,lstoo) + xfertend
+                                 endif
                               end if
-                              qsrflx(i,lsfrm,jsrflx,jac) = qsrflx(i,lsfrm,jsrflx,jac) - xfertend*pdel_fac
-                              qsrflx(i,lstoo,jsrflx,jac) = qsrflx(i,lstoo,jsrflx,jac) + xfertend*pdel_fac
+                              if(ptend_present) then
+                                 qsrflx(i,lsfrm,jsrflx,jac) = qsrflx(i,lsfrm,jsrflx,jac) - xfertend*pdel_fac
+                                 qsrflx(i,lstoo,jsrflx,jac) = qsrflx(i,lstoo,jsrflx,jac) + xfertend*pdel_fac
+                              endif
                            end if
 
                         end do
@@ -1300,18 +1330,20 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    !
    ! apply tendencies to cloud-borne species MRs
    !
-   do l = 1, pcnst
-      lc = l
-      if ( lc>0 .and. dotendqqcw(lc) ) then
-         fldcw=> qqcw_get_field(pbuf,l,lchnk)
-         do k = top_lev, pver
-            do i = 1, ncol
-               fldcw(i,k) = max( 0.0_r8,   &
-                  (fldcw(i,k) + dqqcwdt(i,k,lc)*deltat) )
+   if(ptend_present) then
+      do l = 1, pcnst
+         lc = l
+         if ( lc>0 .and. dotendqqcw(lc) ) then
+            fldcw=> qqcw_get_field(pbuf,l,lchnk)
+            do k = top_lev, pver
+               do i = 1, ncol
+                  fldcw(i,k) = max( 0.0_r8,   &
+                       (fldcw(i,k) + dqqcwdt(i,k,lc)*deltat) )
+               end do
             end do
-         end do
-      end if
-   end do
+         end if
+      end do
+   endif
 
    !
    ! do outfld calls

--- a/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
+++ b/components/eam/src/chemistry/utils/modal_aero_calcsize.F90
@@ -1345,6 +1345,8 @@ subroutine modal_aero_calcsize_sub(state, deltat, pbuf, ptend, do_adjust_in, &
       end do
    endif
 
+   !Do not call outfld if ptend is not present
+   if(.not. ptend_present) return
    !
    ! do outfld calls
    !

--- a/components/eam/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/components/eam/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -253,7 +253,7 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    hygro(:,:,:)    = 0._r8
 
 
-   if (list_idx == 0) then
+   if (.not. present(list_idx_in)) then
       call pbuf_get_field(pbuf, dgnum_idx,      dgncur_a )
       call pbuf_get_field(pbuf, dgnumwet_idx,   dgncur_awet )
       call pbuf_get_field(pbuf, wetdens_ap_idx, wetdens)
@@ -423,7 +423,7 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    !----------------------------------------------------------------------------
    ! write history output if not in diagnostic mode
 
-   if (list_idx == 0) then
+   if (.not.present(list_idx_in)) then
 
       aerosol_water(:ncol,:) = 0._r8
       do m = 1, nmodes

--- a/components/eam/src/physics/cam/aer_rad_props.F90
+++ b/components/eam/src/physics/cam/aer_rad_props.F90
@@ -124,7 +124,7 @@ end subroutine aer_rad_props_init
 !==============================================================================
 
 subroutine aer_rad_props_sw(list_idx, dt, state, pbuf,  nnite, idxnite, is_cmip6_volc, &
-                            tau, tau_w, tau_w_g, tau_w_f)
+                            tau, tau_w, tau_w_g, tau_w_f, clear_rh)
 
    ! Return bulk layer tau, omega, g, f for all spectral intervals.
 
@@ -137,6 +137,8 @@ subroutine aer_rad_props_sw(list_idx, dt, state, pbuf,  nnite, idxnite, is_cmip6
    integer,             intent(in) :: idxnite(:)           ! local column indices of night columns
    logical,             intent(in) :: is_cmip6_volc        ! true if cmip6 style volcanic file is read otherwise false
    real(r8),            intent(in) :: dt                   ! time step (s)
+   real(r8), optional,  intent(in) :: clear_rh(pcols,pver) ! optional clear air relative humidity
+                                                              ! that gets passed to modal_aero_wateruptake_dr
 
    real(r8), intent(out) :: tau    (pcols,0:pver,nswbands) ! aerosol extinction optical depth
    real(r8), intent(out) :: tau_w  (pcols,0:pver,nswbands) ! aerosol single scattering albedo * tau
@@ -263,8 +265,13 @@ subroutine aer_rad_props_sw(list_idx, dt, state, pbuf,  nnite, idxnite, is_cmip6
 
    ! Contributions from modal aerosols.
    if (nmodes > 0) then
-      call modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw(:,:,idx_sw_diag), trop_level, &
-                         tau, tau_w, tau_w_g, tau_w_f)
+      if(present(clear_rh)) then
+         call modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw(:,:,idx_sw_diag), trop_level, &
+              tau, tau_w, tau_w_g, tau_w_f, clear_rh=clear_rh)
+      else
+         call modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw(:,:,idx_sw_diag), trop_level, &
+              tau, tau_w, tau_w_g, tau_w_f)
+      endif
    else
       tau    (1:ncol,:,:) = 0._r8
       tau_w  (1:ncol,:,:) = 0._r8
@@ -347,7 +354,7 @@ end subroutine aer_rad_props_sw
 
 !==============================================================================
 
-subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, dt, state, pbuf,  odap_aer)
+subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, dt, state, pbuf,  odap_aer, clear_rh)
 
    use radconstants,  only: ot_length
 
@@ -366,6 +373,8 @@ subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, dt, state, pbuf,  odap_aer)
    
    type(physics_buffer_desc), pointer :: pbuf(:)
    real(r8),            intent(out) :: odap_aer(pcols,pver,nlwbands) ! [fraction] absorption optical depth, per layer
+   real(r8), optional,  intent(in)  :: clear_rh(pcols,pver) ! optional clear air relative humidity
+                                                           ! that gets passed to modal_aero_wateruptake_dr
 
    ! Local variables
 
@@ -420,7 +429,11 @@ subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, dt, state, pbuf,  odap_aer)
 
    ! Contributions from modal aerosols.
    if (nmodes > 0) then
-      call modal_aero_lw(list_idx, dt, state, pbuf, odap_aer)
+      if (present(clear_rh)) then
+         call modal_aero_lw(list_idx, dt, state, pbuf, odap_aer,clear_rh)
+      else
+         call modal_aero_lw(list_idx, dt, state, pbuf, odap_aer)
+      endif
    else
       odap_aer = 0._r8
    end if

--- a/components/eam/src/physics/cam/aer_rad_props.F90
+++ b/components/eam/src/physics/cam/aer_rad_props.F90
@@ -123,7 +123,7 @@ end subroutine aer_rad_props_init
 
 !==============================================================================
 
-subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, is_cmip6_volc, &
+subroutine aer_rad_props_sw(list_idx, dt, state, pbuf,  nnite, idxnite, is_cmip6_volc, &
                             tau, tau_w, tau_w_g, tau_w_f)
 
    ! Return bulk layer tau, omega, g, f for all spectral intervals.
@@ -136,6 +136,7 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, is_cmip6_vol
    integer,             intent(in) :: nnite                ! number of night columns
    integer,             intent(in) :: idxnite(:)           ! local column indices of night columns
    logical,             intent(in) :: is_cmip6_volc        ! true if cmip6 style volcanic file is read otherwise false
+   real(r8),            intent(in) :: dt                   ! time step (s)
 
    real(r8), intent(out) :: tau    (pcols,0:pver,nswbands) ! aerosol extinction optical depth
    real(r8), intent(out) :: tau_w  (pcols,0:pver,nswbands) ! aerosol single scattering albedo * tau
@@ -262,7 +263,7 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, is_cmip6_vol
 
    ! Contributions from modal aerosols.
    if (nmodes > 0) then
-      call modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw(:,:,idx_sw_diag), trop_level, &
+      call modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw(:,:,idx_sw_diag), trop_level, &
                          tau, tau_w, tau_w_g, tau_w_f)
    else
       tau    (1:ncol,:,:) = 0._r8
@@ -346,7 +347,7 @@ end subroutine aer_rad_props_sw
 
 !==============================================================================
 
-subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, state, pbuf,  odap_aer)
+subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, dt, state, pbuf,  odap_aer)
 
    use radconstants,  only: ot_length
 
@@ -360,6 +361,7 @@ subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, state, pbuf,  odap_aer)
    ! Arguments
    logical,             intent(in)  :: is_cmip6_volc
    integer,             intent(in)  :: list_idx                      ! index of the climate or a diagnostic list
+   real(r8),            intent(in)  :: dt                            ! time step(s)
    type(physics_state), intent(in), target :: state
    
    type(physics_buffer_desc), pointer :: pbuf(:)
@@ -418,7 +420,7 @@ subroutine aer_rad_props_lw(is_cmip6_volc, list_idx, state, pbuf,  odap_aer)
 
    ! Contributions from modal aerosols.
    if (nmodes > 0) then
-      call modal_aero_lw(list_idx, state, pbuf, odap_aer)
+      call modal_aero_lw(list_idx, dt, state, pbuf, odap_aer)
    else
       odap_aer = 0._r8
    end if

--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -33,7 +33,7 @@ use perf_mod,          only: t_startf, t_stopf
 use cam_abortutils,        only: endrun
 
 use modal_aero_wateruptake, only: modal_aero_wateruptake_dr
-use modal_aero_calcsize,    only: modal_aero_calcsize_diag
+use modal_aero_calcsize,    only: modal_aero_calcsize_diag,modal_aero_calcsize_sub
 
 implicit none
 private
@@ -64,6 +64,14 @@ integer :: qaerwat_idx  = -1
 
 character(len=4) :: diag(0:n_diag) = (/'    ','_d1 ','_d2 ','_d3 ','_d4 ','_d5 ', &
                                        '_d6 ','_d7 ','_d8 ','_d9 ','_d10'/)
+
+!Declare the following threadprivate variables to be used for calcsize and water uptake
+!These are defined as module level variables to aviod allocation-deallocation in a loop
+real(r8), pointer :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
+real(r8), pointer :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
+real(r8), pointer :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
+real(r8), pointer :: wetdens_m(:,:,:)  ! aerosol water (g/g) for all modes
+!$OMP THREADPRIVATE(dgnumdry_m, dgnumwet_m, qaerwat_m)
 
 !===============================================================================
 CONTAINS
@@ -111,6 +119,7 @@ subroutine modal_aer_opt_init()
 
    use ioFileMod,        only: getfil
    use phys_control,     only: phys_getopts
+   use shr_log_mod ,     only: errmsg => shr_log_errmsg
 
    ! Local variables
 
@@ -124,7 +133,7 @@ subroutine modal_aer_opt_init()
 
    logical :: call_list(0:n_diag)
    integer :: ilist, nmodes, m_ncoef, m_prefr, m_prefi
-   integer :: errcode
+   integer :: errcode, istat
 
    character(len=*), parameter :: routine='modal_aer_opt_init'
    !----------------------------------------------------------------------------
@@ -173,6 +182,19 @@ subroutine modal_aer_opt_init()
    call phys_getopts(history_amwg_out        = history_amwg, &
                      history_verbose_out = history_verbose, &
                      history_aero_optics_out = history_aero_optics )
+
+   !Allocate dry and wet size variables in an OMP PARRALLEL region as these
+   !arrays are private for each thread and needs to be allocated for each OMP thread
+   !$OMP PARALLEL
+   allocate(dgnumdry_m(pcols,pver,nmodes),stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate dgnumdry_m: "//errmsg(__FILE__,__LINE__) )
+   allocate(dgnumwet_m(pcols,pver,nmodes),stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate dgnumwet_m: "//errmsg(__FILE__,__LINE__) )
+   allocate(qaerwat_m(pcols,pver,nmodes),stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate qaerwat_m: "//errmsg(__FILE__,__LINE__) )
+   allocate(wetdens_m(pcols,pver,nmodes),stat=istat)
+   if (istat .ne. 0) call endrun("Unable to allocate wetdens_m: "//errmsg(__FILE__,__LINE__) )
+   !$OMP END PARALLEL
 
    ! Add diagnostic fields to history output.
 
@@ -371,20 +393,21 @@ end subroutine modal_aer_opt_init
 
 !===============================================================================
 
-subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw, trop_level,  &
+subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_volc, ext_cmip6_sw, trop_level,  &
                          tauxar, wa, ga, fa)
 
    ! calculates aerosol sw radiative properties
 
    integer,             intent(in) :: list_idx       ! index of the climate or a diagnostic list
+   real(r8),            intent(in) :: dt             !timestep (s)
    type(physics_state), intent(in), target :: state          ! state variables
    
    type(physics_buffer_desc), pointer :: pbuf(:)
    integer,             intent(in) :: nnite          ! number of night columns
    integer,             intent(in) :: idxnite(nnite) ! local column indices of night columns
    integer,             intent(in) :: trop_level(pcols)!tropopause level for each column
-   real(r8),            intent(in) :: ext_cmip6_sw(pcols,pver) !balli comments
-   logical,             intent(in) :: is_cmip6_volc !BALLI-comments
+   real(r8),            intent(in) :: ext_cmip6_sw(pcols,pver)
+   logical,             intent(in) :: is_cmip6_volc
 
    real(r8), intent(out) :: tauxar(pcols,0:pver,nswbands) ! layer extinction optical depth
    real(r8), intent(out) :: wa(pcols,0:pver,nswbands)     ! layer single-scatter albedo
@@ -410,11 +433,6 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
 
    real(r8), pointer :: dgnumwet(:,:)     ! number mode wet diameter
    real(r8), pointer :: qaerwat(:,:)      ! aerosol water (g/g)
-
-   real(r8), pointer :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
-   real(r8), pointer :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
-   real(r8), pointer :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
-   real(r8), pointer :: wetdens_m(:,:,:)  ! 
 
    real(r8) :: sigma_logr_aer         ! geometric standard deviation of number distribution
    real(r8) :: radsurf(pcols,pver)    ! aerosol surface mode radius
@@ -586,16 +604,13 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
 
    if (list_idx == 0) then
       ! water uptake and wet radius for the climate list has already been calculated
-      call pbuf_get_field(pbuf, dgnumwet_idx, dgnumwet_m)
-      call pbuf_get_field(pbuf, qaerwat_idx,  qaerwat_m)
+      call modal_aero_calcsize_sub(state, dt, pbuf,list_idx_in=list_idx, dgnumdry_m=dgnumdry_m)
+      call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
+           qaerwat_m, wetdens_m)
    else
+      call endrun('BALLI-no diag support')
       ! If doing a diagnostic calculation then need to calculate the wet radius
       ! and water uptake for the diagnostic modes
-      allocate(dgnumdry_m(pcols,pver,nmodes), dgnumwet_m(pcols,pver,nmodes), &
-               qaerwat_m(pcols,pver,nmodes),  wetdens_m(pcols,pver,nmodes), stat=istat)
-      if (istat > 0) then
-         call endrun('modal_aero_sw: allocation FAILURE: arrays for diagnostic calcs')
-      end if
       call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m)  
       call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
                                      qaerwat_m, wetdens_m)
@@ -1058,13 +1073,6 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, is_cmip6_volc, e
 
    end do ! nmodes
 
-   if (list_idx > 0) then
-      deallocate(dgnumdry_m)
-      deallocate(dgnumwet_m)
-      deallocate(qaerwat_m)
-      deallocate(wetdens_m)
-   end if
-
    !Add contributions from volcanic aerosols directly read in extinction
    if(is_cmip6_volc) then
       !update tropopause layer first
@@ -1190,11 +1198,14 @@ end subroutine modal_aero_sw
 
 !===============================================================================
 
-subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
+subroutine modal_aero_lw(list_idx, dt, state, pbuf, tauxar)
+
+  use shr_log_mod ,     only: errmsg => shr_log_errmsg
 
    ! calculates aerosol lw radiative properties
 
    integer,             intent(in)  :: list_idx ! index of the climate or a diagnostic list
+   real(r8),            intent(in)  :: dt       ! time step(s)
    type(physics_state), intent(in), target :: state    ! state variables
    
    type(physics_buffer_desc), pointer :: pbuf(:)
@@ -1211,11 +1222,6 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
 
    real(r8), pointer :: dgnumwet(:,:)  ! wet number mode diameter (m)
    real(r8), pointer :: qaerwat(:,:)   ! aerosol water (g/g)
-
-   real(r8), pointer :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
-   real(r8), pointer :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
-   real(r8), pointer :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
-   real(r8), pointer :: wetdens_m(:,:,:)  ! 
 
    real(r8) :: sigma_logr_aer          ! geometric standard deviation of number distribution
    real(r8) :: alnsg_amode
@@ -1266,16 +1272,12 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
 
    if (list_idx == 0) then
       ! water uptake and wet radius for the climate list has already been calculated
-      call pbuf_get_field(pbuf, dgnumwet_idx, dgnumwet_m)
-      call pbuf_get_field(pbuf, qaerwat_idx,  qaerwat_m)
+      call modal_aero_calcsize_sub(state, dt, pbuf,list_idx_in=list_idx, dgnumdry_m=dgnumdry_m)
+      call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
+           qaerwat_m, wetdens_m)
    else
       ! If doing a diagnostic calculation then need to calculate the wet radius
       ! and water uptake for the diagnostic modes
-      allocate(dgnumdry_m(pcols,pver,nmodes), dgnumwet_m(pcols,pver,nmodes), &
-               qaerwat_m(pcols,pver,nmodes),  wetdens_m(pcols,pver,nmodes), stat=istat)
-      if (istat > 0) then
-         call endrun('modal_aero_lw: allocation FAILURE: arrays for diagnostic calcs')
-      end if
       call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m)  
       call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
                                      qaerwat_m, wetdens_m)
@@ -1418,13 +1420,6 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
       end do  ! nlwbands
 
    end do ! m = 1, nmodes
-
-   if (list_idx > 0) then
-      deallocate(dgnumdry_m)
-      deallocate(dgnumwet_m)
-      deallocate(qaerwat_m)
-      deallocate(wetdens_m)
-   end if
 
 end subroutine modal_aero_lw
 

--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -34,6 +34,7 @@ use cam_abortutils,        only: endrun
 
 use modal_aero_wateruptake, only: modal_aero_wateruptake_dr
 use modal_aero_calcsize,    only: modal_aero_calcsize_diag,modal_aero_calcsize_sub
+use shr_log_mod ,           only: errmsg => shr_log_errmsg
 
 implicit none
 private
@@ -119,7 +120,6 @@ subroutine modal_aer_opt_init()
 
    use ioFileMod,        only: getfil
    use phys_control,     only: phys_getopts
-   use shr_log_mod ,     only: errmsg => shr_log_errmsg
 
    ! Local variables
 
@@ -608,7 +608,8 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
       call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
            qaerwat_m, wetdens_m)
    else
-      call endrun('BALLI-no diag support')
+      call endrun('Radiation diagnostic calls are temporarily not supported,' // &
+                 ' please remove rad_diag_* specifier(s) from the namelist '//errmsg(__FILE__,__LINE__))
       ! If doing a diagnostic calculation then need to calculate the wet radius
       ! and water uptake for the diagnostic modes
       call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m)  
@@ -1276,6 +1277,8 @@ subroutine modal_aero_lw(list_idx, dt, state, pbuf, tauxar)
       call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
            qaerwat_m, wetdens_m)
    else
+      call endrun('Radiation diagnostic calls are temporarily not supported,' // &
+                 ' please remove rad_diag_* specifier(s) from the namelist '//errmsg(__FILE__,__LINE__))
       ! If doing a diagnostic calculation then need to calculate the wet radius
       ! and water uptake for the diagnostic modes
       call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m)  

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2707,7 +2707,7 @@ if (l_rad) then
          cam_out, cam_in, &
          cam_in%landfrac,landm,cam_in%icefrac, cam_in%snowhland, &
          fsns,    fsnt, flns,    flnt,  &
-         fsds, net_flx,is_cmip6_volc)
+         fsds, net_flx,is_cmip6_volc, ztodt)
 
     ! Set net flux used by spectral dycores
     do i=1,ncol

--- a/components/eam/src/physics/cam/rad_constituents.F90
+++ b/components/eam/src/physics/cam/rad_constituents.F90
@@ -249,6 +249,7 @@ subroutine rad_cnst_readnl(nlfile)
 
    use namelist_utils,  only: find_group_name
    use units,           only: getunit, freeunit
+   use shr_log_mod ,    only: errmsg => shr_log_errmsg
    use mpishorthand
 
    character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
@@ -359,6 +360,9 @@ subroutine rad_cnst_readnl(nlfile)
    do i = 0, N_DIAG
       if (active_calls(i)) then
          if (i > 0) then
+            !Temporarily block radiation diagnostic calls until we place a fix for these calls
+            call endrun('Radiation diagnostic calls are temporarily not supported,' // &
+                 ' please remove rad_diag_* specifier(s) from the namelist '//errmsg(__FILE__,__LINE__))
             write(suffix, fmt = '(i2.2)') i
          else
             suffix='  '

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -2985,7 +2985,7 @@ if (l_rad) then
          cam_out, cam_in, &
          cam_in%landfrac,landm,cam_in%icefrac, cam_in%snowhland, &
          fsns,    fsnt, flns,    flnt,  &
-         fsds, net_flx,is_cmip6_volc)
+         fsds, net_flx,is_cmip6_volc, ztodt, clear_rh=mmf_clear_rh)
 
     ! Set net flux used by spectral dycores
     do i=1,ncol

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -793,7 +793,7 @@ end function radiation_nextsw_cday
        cam_out, cam_in, &
        landfrac,landm,icefrac,snowh, &
        fsns,    fsnt, flns,    flnt,  &
-       fsds, net_flx, is_cmip6_volc)
+       fsds, net_flx, is_cmip6_volc, dt)
 
     !----------------------------------------------------------------------- 
     ! 
@@ -851,6 +851,7 @@ end function radiation_nextsw_cday
     ! Arguments
     logical,  intent(in)    :: is_cmip6_volc    ! true if cmip6 style volcanic file is read otherwise false 
     real(r8), intent(in)    :: landfrac(pcols)  ! land fraction
+    real(r8), intent(in)    :: dt               ! time step(s)
     real(r8), intent(in)    :: landm(pcols)     ! land fraction ramp
     real(r8), intent(in)    :: icefrac(pcols)   ! land fraction
     real(r8), intent(in)    :: snowh(pcols)     ! Snow depth (liquid water equivalent)
@@ -1276,7 +1277,7 @@ end function radiation_nextsw_cday
                   ! update the concentrations in the RRTMG state object
                   call  rrtmg_state_update( state, pbuf, icall, r_state )
 
-                  call aer_rad_props_sw( icall, state, pbuf, nnite, idxnite, is_cmip6_volc, &
+                  call aer_rad_props_sw( icall, dt, state, pbuf, nnite, idxnite, is_cmip6_volc, &
                                          aer_tau, aer_tau_w, aer_tau_w_g, aer_tau_w_f)
 
                   call t_startf ('rad_rrtmg_sw')
@@ -1429,7 +1430,7 @@ end function radiation_nextsw_cday
                   ! update the conctrations in the RRTMG state object
                   call  rrtmg_state_update( state, pbuf, icall, r_state)
 
-                  call aer_rad_props_lw(is_cmip6_volc, icall, state, pbuf,  aer_lw_abs)
+                  call aer_rad_props_lw(is_cmip6_volc, icall, dt, state, pbuf,  aer_lw_abs)
                   
                   call t_startf ('rad_rrtmg_lw')
                   call rad_rrtmg_lw( &

--- a/components/eam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/eam/src/physics/rrtmgp/cam_optics.F90
@@ -465,7 +465,7 @@ contains
 
    !----------------------------------------------------------------------------
 
-   subroutine set_aerosol_optics_sw(icall, state, pbuf, &
+   subroutine set_aerosol_optics_sw(icall, dt, state, pbuf, &
                                     night_indices, &
                                     is_cmip6_volc, &
                                     tau_out, ssa_out, asm_out)
@@ -475,6 +475,7 @@ contains
       use aer_rad_props, only: aer_rad_props_sw
       use radconstants, only: nswbands
       integer, intent(in) :: icall
+      real(r8), intent(in):: dt
       type(physics_state), intent(in) :: state
       type(physics_buffer_desc), pointer :: pbuf(:)
       integer, intent(in) :: night_indices(:)
@@ -503,7 +504,7 @@ contains
       tau_w = 0._r8
       tau_w_g = 0._r8
       tau_w_f = 0._r8
-      call aer_rad_props_sw(icall, state, pbuf, &
+      call aer_rad_props_sw(icall, dt, state, pbuf, &
                             count(night_indices > 0), night_indices, is_cmip6_volc, &
                             tau, tau_w, tau_w_g, tau_w_f)
 
@@ -531,7 +532,7 @@ contains
 
    !----------------------------------------------------------------------------
 
-   subroutine set_aerosol_optics_lw(icall, state, pbuf, is_cmip6_volc, tau)
+   subroutine set_aerosol_optics_lw(icall, dt, state, pbuf, is_cmip6_volc, tau)
      
       use ppgrid, only: pcols, pver
       use physics_types, only: physics_state
@@ -541,6 +542,7 @@ contains
       use radconstants, only: nlwbands
 
       integer, intent(in) :: icall
+      real(r8), intent(in) :: dt   ! time step(s)
       type(physics_state), intent(in) :: state
       type(physics_buffer_desc), pointer :: pbuf(:)
       logical, intent(in) :: is_cmip6_volc
@@ -551,7 +553,7 @@ contains
 
       ! Get aerosol absorption optical depth from CAM routine
       tau = 0._r8
-      call aer_rad_props_lw(is_cmip6_volc, icall, state, pbuf, tau)
+      call aer_rad_props_lw(is_cmip6_volc, icall, dt, state, pbuf, tau)
 
    end subroutine set_aerosol_optics_lw
 

--- a/components/eam/src/physics/rrtmgp/cam_optics.F90
+++ b/components/eam/src/physics/rrtmgp/cam_optics.F90
@@ -468,7 +468,8 @@ contains
    subroutine set_aerosol_optics_sw(icall, dt, state, pbuf, &
                                     night_indices, &
                                     is_cmip6_volc, &
-                                    tau_out, ssa_out, asm_out)
+                                    tau_out, ssa_out, asm_out, &
+                                    clear_rh)
       use ppgrid, only: pcols, pver
       use physics_types, only: physics_state
       use physics_buffer, only: physics_buffer_desc
@@ -481,6 +482,8 @@ contains
       integer, intent(in) :: night_indices(:)
       logical, intent(in) :: is_cmip6_volc
       real(r8), intent(out), dimension(:,:,:) :: tau_out, ssa_out, asm_out
+      real(r8), optional,  intent(in)    :: clear_rh(pcols,pver) ! optional clear air relative humidity
+                                                                 ! that gets passed to modal_aero_wateruptake_dr
 
       ! NOTE: aer_rad_props expects 0:pver indexing on these! It appears this is to
       ! account for the extra layer added above model top, but it is not entirely
@@ -504,9 +507,15 @@ contains
       tau_w = 0._r8
       tau_w_g = 0._r8
       tau_w_f = 0._r8
-      call aer_rad_props_sw(icall, dt, state, pbuf, &
-                            count(night_indices > 0), night_indices, is_cmip6_volc, &
-                            tau, tau_w, tau_w_g, tau_w_f)
+      if(present(clear_rh)) then
+         call aer_rad_props_sw(icall, dt, state, pbuf, &
+              count(night_indices > 0), night_indices, is_cmip6_volc, &
+              tau, tau_w, tau_w_g, tau_w_f, clear_rh=clear_rh)
+      else
+         call aer_rad_props_sw(icall, dt, state, pbuf, &
+              count(night_indices > 0), night_indices, is_cmip6_volc, &
+              tau, tau_w, tau_w_g, tau_w_f)
+      endif
 
       ! Extract quantities from products
       do icol = 1,ncol

--- a/components/eam/src/physics/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/rrtmgp/radiation.F90
@@ -1029,7 +1029,7 @@ contains
    subroutine radiation_tend(state,   ptend,    pbuf,          cam_out, cam_in,  &
                              landfrac,landm,    icefrac,       snowh,            &
                              fsns,    fsnt,     flns,          flnt,             &
-                             fsds,    net_flux, is_cmip6_volc                    )
+                             fsds,    net_flux, is_cmip6_volc, dt                )
 
       ! Performance module needed for timing functions
       use perf_mod, only: t_startf, t_stopf
@@ -1092,6 +1092,8 @@ contains
       ! This should be module data or something specific to aerosol where it is
       ! used?
       logical,  intent(in)    :: is_cmip6_volc    ! true if cmip6 style volcanic file is read otherwise false 
+
+      real(r8),  intent(in)   :: dt               ! time step(s) - needed for aerosol optics call
 
       ! These are not used anymore and exist only because the radiation call is
       ! inflexible
@@ -1318,7 +1320,7 @@ contains
                   aer_ssa_bnd_sw = 0._r8
                   aer_asm_bnd_sw = 0._r8
                   call set_aerosol_optics_sw( &
-                     icall, state, pbuf, &
+                     icall, dt, state, pbuf, &
                      night_indices(1:nnight), &
                      is_cmip6_volc, &
                      aer_tau_bnd_sw, aer_ssa_bnd_sw, aer_asm_bnd_sw &
@@ -1416,7 +1418,7 @@ contains
                if (do_aerosol_rad) then
                   call t_startf('rad_aer_optics_lw')
                   aer_tau_bnd_lw = 0._r8
-                  call aer_rad_props_lw(is_cmip6_volc, icall, state, pbuf, aer_tau_bnd_lw)
+                  call aer_rad_props_lw(is_cmip6_volc, icall, dt, state, pbuf, aer_tau_bnd_lw)
                   call t_stopf('rad_aer_optics_lw')
                else
                   aer_tau_bnd_lw = 0


### PR DESCRIPTION
Dry aerosol size calculations were using an incorrect log of 
sigma g (geometric std. dev. of aerosol mode) during
accumulation<->aitken transfer. This Pr fixes that bug.

This PR is NBFB as dry aerosol sizes and water uptake are 
now using the current "state" (mass mixing ratios of the 
species). Earlier, an older "state" was used to compute
these quantities. I have modified RRTMGP and CRM codes
to accommodate this change.

An extensive refactor of modal_aero_calcsize is not included
in this PR so that it is easier to understand where the NBFB
differences are coming from. Code in this branch is now
BFB with the code where modal_aero_calcsize is refactored
extensively. I will port those changes as a separate PR which
will be BFB.

[NBFB]