### PR TITLE
Fix for unused kokkos in mpas

### DIFF
--- a/components/cmake/build_mpas_model.cmake
+++ b/components/cmake/build_mpas_model.cmake
@@ -1,5 +1,8 @@
 function(build_mpas_models)
 
+  # fix for new kokkos version; undo when mpas uses new kokkos build infrastructure
+  set(USE_KOKKOS FALSE)
+
   file(GLOB MPASCONFS "${BUILDCONF}/mpas*conf" "${BUILDCONF}/maliconf")
 
   foreach(ITEM IN LISTS MPASCONFS)


### PR DESCRIPTION
Newer version of kokkos submodule does not use kokkos_generated_settings.cmake . So when needed replace using this file in MPAS in src/CMakeLists.txt with newer kokkos cmake file.


[bfb]