### PR TITLE
Advance name ccsm cppdefs to cime cppdefs & Update CIME submodule

### DIFF
--- a/components/cice/bld/configure
+++ b/components/cice/bld/configure
@@ -518,8 +518,7 @@ if ($print>=2) { print "CPP definitions set by configure: \'$cfg_cppdefs\'$eol";
 #-----------------------------------------------------------------------------------------------
 
 my $fp_filename      = 'Filepath';             # name of output filepath file
-my $cpp_filename     = 'CCSM_cppdefs';         # name of output file for cice's cppdefs
-my $cpp_filenameB     = 'CIME_cppdefs';         # name of output file for cice's cppdefs
+my $cpp_filename     = 'CIME_cppdefs';         # name of output file for cice's cppdefs
 
 # Write the filepath file 
 write_filepath("$cice_bld/$fp_filename", $cesmroot);
@@ -530,10 +529,6 @@ my $CASEROOT = "$ENV{'CASEROOT'}";
 # Write the file for cice's cppdefs 
 write_cppdefs("$cice_bld/$cpp_filename", $make_cppdefs);
 if ($print>=2) { print "creating $cice_bld/$cpp_filename\n"; }#
-
-# Write the file for cice's cppdefs CIME_cppdefs
-write_cppdefs("$cice_bld/$cpp_filenameB", $make_cppdefs);
-if ($print>=2) { print "creating $cice_bld/$cpp_filenameB\n"; }#
 
 # Write the configuration file.
 $cfg_ref->write_file("$config_cache_file", $commandline);

--- a/components/cice/bld/configure
+++ b/components/cice/bld/configure
@@ -518,7 +518,8 @@ if ($print>=2) { print "CPP definitions set by configure: \'$cfg_cppdefs\'$eol";
 #-----------------------------------------------------------------------------------------------
 
 my $fp_filename      = 'Filepath';             # name of output filepath file
-my $cpp_filename     = 'CCSM_cppdefs';         # name of output file for cice's cppdefs 
+my $cpp_filename     = 'CCSM_cppdefs';         # name of output file for cice's cppdefs
+my $cpp_filenameB     = 'CIME_cppdefs';         # name of output file for cice's cppdefs
 
 # Write the filepath file 
 write_filepath("$cice_bld/$fp_filename", $cesmroot);
@@ -529,6 +530,10 @@ my $CASEROOT = "$ENV{'CASEROOT'}";
 # Write the file for cice's cppdefs 
 write_cppdefs("$cice_bld/$cpp_filename", $make_cppdefs);
 if ($print>=2) { print "creating $cice_bld/$cpp_filename\n"; }#
+
+# Write the file for cice's cppdefs CIME_cppdefs
+write_cppdefs("$cice_bld/$cpp_filenameB", $make_cppdefs);
+if ($print>=2) { print "creating $cice_bld/$cpp_filenameB\n"; }#
 
 # Write the configuration file.
 $cfg_ref->write_file("$config_cache_file", $commandline);

--- a/components/cice/cime_config/buildlib
+++ b/components/cice/cime_config/buildlib
@@ -42,7 +42,7 @@ if (-f "Filepath") {
 #  force gmake to recompile if any of the cppdefs are different 
 #-------------------------------------------------------------- 
 my $recompile = 'FALSE';
-my $sysmod = 1;
+my $sysmod = "cp -f $OBJROOT/ice/obj/CCSM_cppdefs.new $OBJROOT/ice/obj/CCSM_cppdefs";
 if (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
     if (compare("$OBJROOT/ice/obj/CCSM_cppdefs.new", "$OBJROOT/ice/obj/CCSM_cppdefs") != 0) {
         $recompile = 'TRUE'; 

--- a/components/cice/cime_config/buildlib
+++ b/components/cice/cime_config/buildlib
@@ -42,7 +42,7 @@ if (-f "Filepath") {
 #  force gmake to recompile if any of the cppdefs are different 
 #-------------------------------------------------------------- 
 my $recompile = 'FALSE';
-my $recompile = 1;
+my $sysmod = 1;
 if (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
     if (compare("$OBJROOT/ice/obj/CCSM_cppdefs.new", "$OBJROOT/ice/obj/CCSM_cppdefs") != 0) {
         $recompile = 'TRUE'; 

--- a/components/cice/cime_config/buildlib
+++ b/components/cice/cime_config/buildlib
@@ -62,6 +62,28 @@ my $cppdefs = `./xmlquery CICE_CPPDEFS -value`;
 chomp($cppdefs);
 $cppdefs = "$cppdefs -DBLCKX=$CICE_BLCKX -DBLCKY=$CICE_BLCKY -DMXBLCKS=$CICE_MXBLCKS";
 
+# CIME_cppdefs
+my $recompile = 'FALSE';
+if (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
+    if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/CIME_cppdefs") != 0) {
+        $recompile = 'TRUE';
+    }
+    # NOTE - the following remove statements are what force cice to recompile if
+    # the cppdefs are different
+    print "recompile is $recompile \n";
+    if ($recompile eq 'TRUE') {
+        my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
+        system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
+    }
+}
+my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/CIME_cppdefs";
+system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
+
+chdir $CASEROOT;
+my $cppdefs = `./xmlquery CICE_CPPDEFS -value`;
+chomp($cppdefs);
+$cppdefs = "$cppdefs -DBLCKX=$CICE_BLCKX -DBLCKY=$CICE_BLCKY -DMXBLCKS=$CICE_MXBLCKS";
+
 #-------------------------------------------------------
 # Build the library
 #-------------------------------------------------------

--- a/components/cice/cime_config/buildlib
+++ b/components/cice/cime_config/buildlib
@@ -42,22 +42,15 @@ if (-f "Filepath") {
 #  force gmake to recompile if any of the cppdefs are different 
 #-------------------------------------------------------------- 
 my $recompile = 'FALSE';
-my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/CIME_cppdefs";
+my $cppdefsfile;
 if (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
-    if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/CIME_cppdefs") != 0) {
-        $recompile = 'TRUE';
-    }
-    # NOTE - the following remove statements are what force cice to recompile if
-    # the cppdefs are different
-    print "recompile is $recompile \n";
-    if ($recompile eq 'TRUE') {
-        my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
-        system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
-    }
-    my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/CIME_cppdefs";
+    $cppdefsfile = 'CIME_cppdefs';
 }
 elsif (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
-    if (compare("$OBJROOT/ice/obj/CCSM_cppdefs.new", "$OBJROOT/ice/obj/CCSM_cppdefs") != 0) {
+    $cppdefsfile = 'CCSM_cppdefs';
+}
+if (-e "$OBJROOT/ice/obj/$cppdefsfile") {
+    if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/$cppdefsfile") != 0) {
         $recompile = 'TRUE';
     }
     # NOTE - the following remove statements are what force cice to recompile if
@@ -67,8 +60,8 @@ elsif (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
         my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
         system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
     }
-    my $sysmod = "cp -f $OBJROOT/ice/obj/CCSM_cppdefs.new $OBJROOT/ice/obj/CCSM_cppdefs";
 }
+my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/$cppdefsfile";
 system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
 
 chdir $CASEROOT;

--- a/components/cice/cime_config/buildlib
+++ b/components/cice/cime_config/buildlib
@@ -42,21 +42,8 @@ if (-f "Filepath") {
 #  force gmake to recompile if any of the cppdefs are different 
 #-------------------------------------------------------------- 
 my $recompile = 'FALSE';
-my $sysmod = "cp -f $OBJROOT/ice/obj/CCSM_cppdefs.new $OBJROOT/ice/obj/CCSM_cppdefs";
-if (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
-    if (compare("$OBJROOT/ice/obj/CCSM_cppdefs.new", "$OBJROOT/ice/obj/CCSM_cppdefs") != 0) {
-        $recompile = 'TRUE'; 
-    }   
-    # NOTE - the following remove statements are what force cice to recompile if
-    # the cppdefs are different
-    print "recompile is $recompile \n";
-    if ($recompile eq 'TRUE') {
-        my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
-        system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
-    }
-    my $sysmod = "cp -f $OBJROOT/ice/obj/CCSM_cppdefs.new $OBJROOT/ice/obj/CCSM_cppdefs";
-}
-elsif (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
+my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/CIME_cppdefs";
+if (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
     if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/CIME_cppdefs") != 0) {
         $recompile = 'TRUE';
     }
@@ -68,6 +55,19 @@ elsif (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
         system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
     }
     my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/CIME_cppdefs";
+}
+elsif (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
+    if (compare("$OBJROOT/ice/obj/CCSM_cppdefs.new", "$OBJROOT/ice/obj/CCSM_cppdefs") != 0) {
+        $recompile = 'TRUE';
+    }
+    # NOTE - the following remove statements are what force cice to recompile if
+    # the cppdefs are different
+    print "recompile is $recompile \n";
+    if ($recompile eq 'TRUE') {
+        my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
+        system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
+    }
+    my $sysmod = "cp -f $OBJROOT/ice/obj/CCSM_cppdefs.new $OBJROOT/ice/obj/CCSM_cppdefs";
 }
 system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
 

--- a/components/cice/cime_config/buildlib
+++ b/components/cice/cime_config/buildlib
@@ -42,6 +42,7 @@ if (-f "Filepath") {
 #  force gmake to recompile if any of the cppdefs are different 
 #-------------------------------------------------------------- 
 my $recompile = 'FALSE';
+my $recompile = 1;
 if (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
     if (compare("$OBJROOT/ice/obj/CCSM_cppdefs.new", "$OBJROOT/ice/obj/CCSM_cppdefs") != 0) {
         $recompile = 'TRUE'; 
@@ -54,7 +55,6 @@ if (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
         system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
     }
     my $sysmod = "cp -f $OBJROOT/ice/obj/CCSM_cppdefs.new $OBJROOT/ice/obj/CCSM_cppdefs";
-    system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
 }
 elsif (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
     if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/CIME_cppdefs") != 0) {
@@ -68,9 +68,8 @@ elsif (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
         system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
     }
     my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/CIME_cppdefs";
-    system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
 }
-
+system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
 
 chdir $CASEROOT;
 my $cppdefs = `./xmlquery CICE_CPPDEFS -value`;

--- a/components/cice/cime_config/buildlib
+++ b/components/cice/cime_config/buildlib
@@ -49,17 +49,15 @@ if (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
 elsif (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
     $cppdefsfile = 'CCSM_cppdefs';
 }
-if (-e "$OBJROOT/ice/obj/$cppdefsfile") {
-    if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/$cppdefsfile") != 0) {
-        $recompile = 'TRUE';
-    }
-    # NOTE - the following remove statements are what force cice to recompile if
-    # the cppdefs are different
-    print "recompile is $recompile \n";
-    if ($recompile eq 'TRUE') {
-        my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
-        system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
-    }
+if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/$cppdefsfile") != 0) {
+    $recompile = 'TRUE';
+}
+# NOTE - the following remove statements are what force cice to recompile if
+# the cppdefs are different
+print "recompile is $recompile \n";
+if ($recompile eq 'TRUE') {
+    my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
+    system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
 }
 my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/$cppdefsfile";
 system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}

--- a/components/cice/cime_config/buildlib
+++ b/components/cice/cime_config/buildlib
@@ -52,19 +52,11 @@ if (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
     if ($recompile eq 'TRUE') {
         my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
         system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
-    }   
+    }
+    my $sysmod = "cp -f $OBJROOT/ice/obj/CCSM_cppdefs.new $OBJROOT/ice/obj/CCSM_cppdefs";
+    system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
 }
-my $sysmod = "cp -f $OBJROOT/ice/obj/CCSM_cppdefs.new $OBJROOT/ice/obj/CCSM_cppdefs";
-system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
-
-chdir $CASEROOT;
-my $cppdefs = `./xmlquery CICE_CPPDEFS -value`;
-chomp($cppdefs);
-$cppdefs = "$cppdefs -DBLCKX=$CICE_BLCKX -DBLCKY=$CICE_BLCKY -DMXBLCKS=$CICE_MXBLCKS";
-
-# CIME_cppdefs
-my $recompile = 'FALSE';
-if (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
+elsif (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
     if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/CIME_cppdefs") != 0) {
         $recompile = 'TRUE';
     }
@@ -75,9 +67,10 @@ if (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
         my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
         system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
     }
+    my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/CIME_cppdefs";
+    system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
 }
-my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/CIME_cppdefs";
-system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}
+
 
 chdir $CASEROOT;
 my $cppdefs = `./xmlquery CICE_CPPDEFS -value`;

--- a/components/cice/cime_config/buildlib
+++ b/components/cice/cime_config/buildlib
@@ -49,15 +49,17 @@ if (-e "$OBJROOT/ice/obj/CIME_cppdefs") {
 elsif (-e "$OBJROOT/ice/obj/CCSM_cppdefs") {
     $cppdefsfile = 'CCSM_cppdefs';
 }
-if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/$cppdefsfile") != 0) {
-    $recompile = 'TRUE';
-}
-# NOTE - the following remove statements are what force cice to recompile if
-# the cppdefs are different
-print "recompile is $recompile \n";
-if ($recompile eq 'TRUE') {
-    my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
-    system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
+if (-e "$OBJROOT/ice/obj/$cppdefsfile") {
+    if (compare("$OBJROOT/ice/obj/CIME_cppdefs.new", "$OBJROOT/ice/obj/$cppdefsfile") != 0) {
+        $recompile = 'TRUE';
+    }
+    # NOTE - the following remove statements are what force cice to recompile if
+    # the cppdefs are different
+    print "recompile is $recompile \n";
+    if ($recompile eq 'TRUE') {
+        my $sysmod = "rm -f $OBJROOT/ice/obj/*.o";
+        system($sysmod) == 0 or die "ERROR cice buildlib: $sysmod failed: $?\n";
+    }
 }
 my $sysmod = "cp -f $OBJROOT/ice/obj/CIME_cppdefs.new $OBJROOT/ice/obj/$cppdefsfile";
 system($sysmod) == 0 or die "ERROR: cice buidlib $sysmod failed: $?\n";}

--- a/components/cice/cime_config/buildlib_cmake
+++ b/components/cice/cime_config/buildlib_cmake
@@ -29,12 +29,10 @@ def buildlib(bldroot, installpath, case):
     cppdefs      = case.get_value("CICE_CPPDEFS")
 
     #-------------------------------------------------------
-    # compute all cppdefs, unlike other components, needs to make a CCSM_cppdefs and CIME_cppdefs file
+    # compute all cppdefs, unlike other components, needs to make a CIME_cppdefs file
     #-------------------------------------------------------
 
     cppdefs += " -DBLCKX={} -DBLCKY={} -DMXBLCKS={}\n".format(cice_blckx, cice_blcky, cice_mxblcks)
-    with open(os.path.join(casebuild, "ciceconf", "CCSM_cppdefs"), "w") as fd:
-        fd.write(cppdefs)
     with open(os.path.join(casebuild, "ciceconf", "CIME_cppdefs"), "w") as fd:
         fd.write(cppdefs)
 

--- a/components/cice/cime_config/buildlib_cmake
+++ b/components/cice/cime_config/buildlib_cmake
@@ -29,11 +29,13 @@ def buildlib(bldroot, installpath, case):
     cppdefs      = case.get_value("CICE_CPPDEFS")
 
     #-------------------------------------------------------
-    # compute all cppdefs, unlike other components, needs to make a CCSM_cppdefs file
+    # compute all cppdefs, unlike other components, needs to make a CCSM_cppdefs and CIME_cppdefs file
     #-------------------------------------------------------
 
     cppdefs += " -DBLCKX={} -DBLCKY={} -DMXBLCKS={}\n".format(cice_blckx, cice_blcky, cice_mxblcks)
     with open(os.path.join(casebuild, "ciceconf", "CCSM_cppdefs"), "w") as fd:
+        fd.write(cppdefs)
+    with open(os.path.join(casebuild, "ciceconf", "CIME_cppdefs"), "w") as fd:
         fd.write(cppdefs)
 
 ###############################################################################

--- a/components/cice/cime_config/buildnml
+++ b/components/cice/cime_config/buildnml
@@ -86,6 +86,7 @@ def buildnml(case, caseroot, compname):
     # determine the actual CPP definitions (these have been determined by the call to configure)
 
     cppdefs = open(os.path.join(ciceconf_dir, "CCSM_cppdefs"), "r").read().strip()
+    #cppdefs = open(os.path.join(ciceconf_dir, "CIME_cppdefs"), "r").read().strip()
     cppdefs += " -DBLCKX={} -DBLCKY={} -DMXBLCKS={}".format(cice_blckx, cice_blcky, cice_mxblcks)
 
     # write out cppdefs to env_build.xml
@@ -100,6 +101,8 @@ def buildnml(case, caseroot, compname):
 
     if testcase != "SBN":
         with open(os.path.join(objroot, "ice/obj/CCSM_cppdefs.new"), "w") as fd:
+            fd.write(cppdefs + "\n")
+        with open(os.path.join(objroot, "ice/obj/CIME_cppdefs.new"), "w") as fd:
             fd.write(cppdefs + "\n")
 
     #--------------------------------------------------------------------

--- a/components/cice/cime_config/buildnml
+++ b/components/cice/cime_config/buildnml
@@ -84,9 +84,10 @@ def buildnml(case, caseroot, compname):
     #--------------------------------------------------------------
 
     # determine the actual CPP definitions (these have been determined by the call to configure)
-
-    cppdefs = open(os.path.join(ciceconf_dir, "CCSM_cppdefs"), "r").read().strip()
-    #cppdefs = open(os.path.join(ciceconf_dir, "CIME_cppdefs"), "r").read().strip()
+    if os.path.isfile(os.path.join(ciceconf_dir, "CIME_cppdefs")):
+        cppdefs = open(os.path.join(ciceconf_dir, "CIME_cppdefs"), "r").read().strip()
+    elif os.path.isfile(os.path.join(ciceconf_dir, "CCSM_cppdefs")):
+        cppdefs = open(os.path.join(ciceconf_dir, "CCSM_cppdefs"), "r").read().strip()
     cppdefs += " -DBLCKX={} -DBLCKY={} -DMXBLCKS={}".format(cice_blckx, cice_blcky, cice_mxblcks)
 
     # write out cppdefs to env_build.xml
@@ -100,8 +101,6 @@ def buildnml(case, caseroot, compname):
     # this will force gmake to rebuild when $CASE.buildexe is called
 
     if testcase != "SBN":
-        with open(os.path.join(objroot, "ice/obj/CCSM_cppdefs.new"), "w") as fd:
-            fd.write(cppdefs + "\n")
         with open(os.path.join(objroot, "ice/obj/CIME_cppdefs.new"), "w") as fd:
             fd.write(cppdefs + "\n")
 

--- a/components/cmake/build_model.cmake
+++ b/components/cmake/build_model.cmake
@@ -12,11 +12,17 @@ function(build_model COMP_CLASS COMP_NAME)
   list(APPEND CPP_DIRS ".")
 
   # Load cppdefs
+  # Tries CCSM_cppdefs first, and if the file does not exist then tries CIME_cppdefs
   set(CCSM_CPPDEFS_FILE "${MODELCONF_DIR}/CCSM_cppdefs")
+  set(CIME_CPPDEFS_FILE "${MODELCONF_DIR}/CIME_cppdefs")
   if (EXISTS ${CCSM_CPPDEFS_FILE})
     file(READ ${CCSM_CPPDEFS_FILE} CCSM_CPPDEFS)
     string(STRIP "${CCSM_CPPDEFS}" CCSM_CPPDEFS)
     set(CPPDEFS "${CPPDEFS} ${CCSM_CPPDEFS}")
+  elseif (EXISTS ${CIME_CPPDEFS_FILE})
+    file(READ ${CIME_CPPDEFS_FILE} CIME_CPPDEFS)
+    string(STRIP "${CIME_CPPDEFS}" CIME_CPPDEFS)
+    set(CPPDEFS "${CPPDEFS} ${CIME_CPPDEFS}")
   endif()
 
   if (COMP_NAME STREQUAL "cpl")

--- a/components/cmake/build_model.cmake
+++ b/components/cmake/build_model.cmake
@@ -12,17 +12,17 @@ function(build_model COMP_CLASS COMP_NAME)
   list(APPEND CPP_DIRS ".")
 
   # Load cppdefs
-  # Tries CCSM_cppdefs first, and if the file does not exist then tries CIME_cppdefs
-  set(CCSM_CPPDEFS_FILE "${MODELCONF_DIR}/CCSM_cppdefs")
+  # Tries CIME_cppdefs first, and if the file does not exist then tries CCSM_cppdefs
   set(CIME_CPPDEFS_FILE "${MODELCONF_DIR}/CIME_cppdefs")
-  if (EXISTS ${CCSM_CPPDEFS_FILE})
-    file(READ ${CCSM_CPPDEFS_FILE} CCSM_CPPDEFS)
-    string(STRIP "${CCSM_CPPDEFS}" CCSM_CPPDEFS)
-    set(CPPDEFS "${CPPDEFS} ${CCSM_CPPDEFS}")
-  elseif (EXISTS ${CIME_CPPDEFS_FILE})
+  set(CCSM_CPPDEFS_FILE "${MODELCONF_DIR}/CCSM_cppdefs")
+  if (EXISTS ${CIME_CPPDEFS_FILE})
     file(READ ${CIME_CPPDEFS_FILE} CIME_CPPDEFS)
     string(STRIP "${CIME_CPPDEFS}" CIME_CPPDEFS)
     set(CPPDEFS "${CPPDEFS} ${CIME_CPPDEFS}")
+  elseif (EXISTS ${CCSM_CPPDEFS_FILE})
+    file(READ ${CCSM_CPPDEFS_FILE} CCSM_CPPDEFS)
+    string(STRIP "${CCSM_CPPDEFS}" CCSM_CPPDEFS)
+    set(CPPDEFS "${CPPDEFS} ${CCSM_CPPDEFS}")
   endif()
 
   if (COMP_NAME STREQUAL "cpl")

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -2469,6 +2469,7 @@ EOF
 
 my $fp_filename      = 'Filepath';             # name of output filepath file
 my $cpp_filename     = 'CCSM_cppdefs';         # name of output file for eam's cppdefs in ccsm
+my $cpp_filenameB     = 'CIME_cppdefs';         # name of output file for eam's cppdefs in CIME
 
 # Write the filepath file.
 write_filepath("$cam_bld/$fp_filename", $cfg_ref);
@@ -2479,6 +2480,10 @@ if (($ccsm_seq)) {
     # Write the file for cam's cppdefs needed in ccsm.
     write_cppdefs("$cam_bld/$cpp_filename", $make_cppdefs, $cfg_ref);
     if ($print) { print "creating $cam_bld/$cpp_filename\n"; }
+
+    # Write the file for cam's cppdefs needed in cime.
+    write_cppdefs("$cam_bld/$cpp_filenameB", $make_cppdefs, $cfg_ref);
+    if ($print) { print "creating $cam_bld/$cpp_filenameB\n"; }
 
 } else {
 

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -2468,8 +2468,7 @@ EOF
 #-----------------------------------------------------------------------------------------------
 
 my $fp_filename      = 'Filepath';             # name of output filepath file
-my $cpp_filename     = 'CCSM_cppdefs';         # name of output file for eam's cppdefs in ccsm
-my $cpp_filenameB     = 'CIME_cppdefs';         # name of output file for eam's cppdefs in CIME
+my $cpp_filename     = 'CIME_cppdefs';         # name of output file for eam's cppdefs in cime
 
 # Write the filepath file.
 write_filepath("$cam_bld/$fp_filename", $cfg_ref);
@@ -2477,13 +2476,9 @@ if ($print) { print "creating $cam_bld/$fp_filename\n"; }
 
 if (($ccsm_seq)) {
 
-    # Write the file for cam's cppdefs needed in ccsm.
+    # Write the file for cam's cppdefs needed in cime.
     write_cppdefs("$cam_bld/$cpp_filename", $make_cppdefs, $cfg_ref);
     if ($print) { print "creating $cam_bld/$cpp_filename\n"; }
-
-    # Write the file for cam's cppdefs needed in cime.
-    write_cppdefs("$cam_bld/$cpp_filenameB", $make_cppdefs, $cfg_ref);
-    if ($print) { print "creating $cam_bld/$cpp_filenameB\n"; }
 
 } else {
 

--- a/components/eam/cime_config/buildlib
+++ b/components/eam/cime_config/buildlib
@@ -34,6 +34,7 @@ if (-f "Filepath") {
 }
 
 my $camdefs = `cat $CASEBUILD/eamconf/CCSM_cppdefs`;
+#my $camdefs = `cat $CASEBUILD/eamconf/CIME_cppdefs`;
 chomp($camdefs);
 my $sysmod = "$GMAKE complib -j ${GMAKE_J} MODEL=eam COMPLIB=${LIBROOT}/libatm.a USER_CPPDEFS=\"${camdefs}\" -f ${CASETOOLS}/Makefile ${MAKE_ARGS}";
 system($sysmod) == 0 or die "ERROR: eam buildlib $sysmod failed: $?\n";

--- a/components/eam/cime_config/buildlib
+++ b/components/eam/cime_config/buildlib
@@ -33,8 +33,12 @@ if (-f "Filepath") {
     system($sysmod) == 0 or die "ERROR eam buildlib: $sysmod failed: $?\n";
 }
 
-my $camdefs = `cat $CASEBUILD/eamconf/CCSM_cppdefs`;
-#my $camdefs = `cat $CASEBUILD/eamconf/CIME_cppdefs`;
+if (-e "$CASEBUILD/eamconf/CIME_cppdefs") {
+    my $camdefs = `cat $CASEBUILD/eamconf/CIME_cppdefs`
+}
+elsif (-e "$CASEBUILD/eamconf/CCSM_cppdefs") {
+    my $camdefs = `cat $CASEBUILD/eamconf/CCSM_cppdefs`;
+}
 chomp($camdefs);
 my $sysmod = "$GMAKE complib -j ${GMAKE_J} MODEL=eam COMPLIB=${LIBROOT}/libatm.a USER_CPPDEFS=\"${camdefs}\" -f ${CASETOOLS}/Makefile ${MAKE_ARGS}";
 system($sysmod) == 0 or die "ERROR: eam buildlib $sysmod failed: $?\n";

--- a/components/elm/bld/configure
+++ b/components/elm/bld/configure
@@ -575,6 +575,7 @@ if ($print>=2) { print "CPP definitions set by configure: \'$cfg_cppdefs\'$eol";
 
 my $fp_filename      = 'Filepath';             # name of output filepath file
 my $cpp_filename     = 'CCSM_cppdefs';         # name of output file for clm's cppdefs in cesm
+my $cpp_filenameB     = 'CIME_cppdefs';         # name of output file for eam's cppdefs in CIME
 
 # Write the filepath file for cesm.
 write_filepath_cesmbld("$clm_bld/$fp_filename", $cfg_ref, $phys, allowEnv=>0 );
@@ -583,6 +584,10 @@ if ($print>=2) { print "creating $clm_bld/$fp_filename\n"; }
 # Write the file for clm's cppdefs needed in cesm.
 write_cppdefs("$clm_bld/$cpp_filename", $make_cppdefs);
 if ($print>=2) { print "creating $clm_bld/$cpp_filename\n"; }
+
+# Write the file for clm's cppdefs needed in cime.
+write_cppdefs("$clm_bld/$cpp_filenameB", $make_cppdefs);
+if ($print>=2) { print "creating $clm_bld/$cpp_filenameB\n"; }
 
 # Write the configuration file.
 $cfg_ref->write_file($config_cache_file, $commandline);

--- a/components/elm/bld/configure
+++ b/components/elm/bld/configure
@@ -574,20 +574,15 @@ if ($print>=2) { print "CPP definitions set by configure: \'$cfg_cppdefs\'$eol";
 #-----------------------------------------------------------------------------------------------
 
 my $fp_filename      = 'Filepath';             # name of output filepath file
-my $cpp_filename     = 'CCSM_cppdefs';         # name of output file for clm's cppdefs in cesm
-my $cpp_filenameB     = 'CIME_cppdefs';         # name of output file for eam's cppdefs in CIME
+my $cpp_filename     = 'CIME_cppdefs';         # name of output file for clm's cppdefs in cime
 
 # Write the filepath file for cesm.
 write_filepath_cesmbld("$clm_bld/$fp_filename", $cfg_ref, $phys, allowEnv=>0 );
 if ($print>=2) { print "creating $clm_bld/$fp_filename\n"; }
 
-# Write the file for clm's cppdefs needed in cesm.
+# Write the file for clm's cppdefs needed in cime.
 write_cppdefs("$clm_bld/$cpp_filename", $make_cppdefs);
 if ($print>=2) { print "creating $clm_bld/$cpp_filename\n"; }
-
-# Write the file for clm's cppdefs needed in cime.
-write_cppdefs("$clm_bld/$cpp_filenameB", $make_cppdefs);
-if ($print>=2) { print "creating $clm_bld/$cpp_filenameB\n"; }
 
 # Write the configuration file.
 $cfg_ref->write_file($config_cache_file, $commandline);

--- a/components/elm/bld/configure
+++ b/components/elm/bld/configure
@@ -574,13 +574,13 @@ if ($print>=2) { print "CPP definitions set by configure: \'$cfg_cppdefs\'$eol";
 #-----------------------------------------------------------------------------------------------
 
 my $fp_filename      = 'Filepath';             # name of output filepath file
-my $cpp_filename     = 'CIME_cppdefs';         # name of output file for clm's cppdefs in cime
+my $cpp_filename     = 'CIME_cppdefs';         # name of output file for clm's cppdefs in cesm
 
 # Write the filepath file for cesm.
 write_filepath_cesmbld("$clm_bld/$fp_filename", $cfg_ref, $phys, allowEnv=>0 );
 if ($print>=2) { print "creating $clm_bld/$fp_filename\n"; }
 
-# Write the file for clm's cppdefs needed in cime.
+# Write the file for clm's cppdefs needed in cesm.
 write_cppdefs("$clm_bld/$cpp_filename", $make_cppdefs);
 if ($print>=2) { print "creating $clm_bld/$cpp_filename\n"; }
 

--- a/components/elm/cime_config/buildlib
+++ b/components/elm/cime_config/buildlib
@@ -54,13 +54,13 @@ def _main_func():
     # create the library in libroot
     #-------------------------------------------------------
 
-    # Note that casebuild/clmconf/CCSM_cppdefs (or CIME_cppdefs) is created
+    # Note that casebuild/clmconf/CIME_cppdefs is created
     # by the call to clm's bld/configure in clm's cime_config/buildnml
     cppdefs_file = ""
-    if os.path.isfile(os.path.join(casebuild, "clmconf", "CCSM_cppdefs")):
-        cppdefs_file = os.path.join(casebuild, "clmconf", "CCSM_cppdefs")
-    elif os.path.isfile(os.path.join(casebuild, "clmconf", "CIME_cppdefs")):
+    if os.path.isfile(os.path.join(casebuild, "clmconf", "CIME_cppdefs")):
         cppdefs_file = os.path.join(casebuild, "clmconf", "CIME_cppdefs")
+    elif os.path.isfile(os.path.join(casebuild, "clmconf", "CCSM_cppdefs")):
+        cppdefs_file = os.path.join(casebuild, "clmconf", "CCSM_cppdefs"))
     user_cppdefs = ""
     with open(cppdefs_file, 'r') as f:
         cppdefs = f.readline()

--- a/components/elm/cime_config/buildlib
+++ b/components/elm/cime_config/buildlib
@@ -54,10 +54,13 @@ def _main_func():
     # create the library in libroot
     #-------------------------------------------------------
 
-    # Note that casebuild/clmconf/CCSM_cppdefs is created
+    # Note that casebuild/clmconf/CCSM_cppdefs (or CIME_cppdefs) is created
     # by the call to clm's bld/configure in clm's cime_config/buildnml
-
-    cppdefs_file = os.path.join(casebuild, "clmconf", "CCSM_cppdefs")
+    cppdefs_file = ""
+    if os.path.isfile(os.path.join(casebuild, "clmconf", "CCSM_cppdefs")):
+        cppdefs_file = os.path.join(casebuild, "clmconf", "CCSM_cppdefs")
+    elif os.path.isfile(os.path.join(casebuild, "clmconf", "CIME_cppdefs")):
+        cppdefs_file = os.path.join(casebuild, "clmconf", "CIME_cppdefs")
     user_cppdefs = ""
     with open(cppdefs_file, 'r') as f:
         cppdefs = f.readline()

--- a/components/mosart/cime_config/buildlib_cmake
+++ b/components/mosart/cime_config/buildlib_cmake
@@ -42,9 +42,6 @@ def buildlib(bldroot, installpath, case):
 
     with open(os.path.join(casebuild, "mosartconf", "Filepath"), "w") as fd:
         fd.write(filepaths)
-
-    with open(os.path.join(casebuild, "mosartconf", "CCSM_cppdefs"), "w") as fd:
-        fd.write("")
     with open(os.path.join(casebuild, "mosartconf", "CIME_cppdefs"), "w") as fd:
         fd.write("")
 

--- a/components/mosart/cime_config/buildlib_cmake
+++ b/components/mosart/cime_config/buildlib_cmake
@@ -42,7 +42,7 @@ def buildlib(bldroot, installpath, case):
 
     with open(os.path.join(casebuild, "mosartconf", "Filepath"), "w") as fd:
         fd.write(filepaths)
-        
+
     with open(os.path.join(casebuild, "mosartconf", "CIME_cppdefs"), "w") as fd:
         fd.write("")
 

--- a/components/mosart/cime_config/buildlib_cmake
+++ b/components/mosart/cime_config/buildlib_cmake
@@ -45,6 +45,8 @@ def buildlib(bldroot, installpath, case):
 
     with open(os.path.join(casebuild, "mosartconf", "CCSM_cppdefs"), "w") as fd:
         fd.write("")
+    with open(os.path.join(casebuild, "mosartconf", "CIME_cppdefs"), "w") as fd:
+        fd.write("")
 
 ###############################################################################
 def _main_func():

--- a/components/mosart/cime_config/buildlib_cmake
+++ b/components/mosart/cime_config/buildlib_cmake
@@ -42,6 +42,7 @@ def buildlib(bldroot, installpath, case):
 
     with open(os.path.join(casebuild, "mosartconf", "Filepath"), "w") as fd:
         fd.write(filepaths)
+        
     with open(os.path.join(casebuild, "mosartconf", "CIME_cppdefs"), "w") as fd:
         fd.write("")
 


### PR DESCRIPTION
I improved the e3sm commits to
1)Execute new writes to the new renamed CIME_cppdefs file,
2)Open and safe copy the new CIME_cppdefs file, if the file exists
3)Open and safecopy the old CCSM_cppdefs file, if the system can not find the CIME_cppdefs file. 
This supports Rob Jacob's proposal to keep both, CIME_cppdefs and CCSM_cppdefs,
for some time to give models time to adjust.

===================================================================

I also updated the CIME submodule.

EAM and ELM rename changes now on cime master:
   Add EAM case for 20TR CMIP6 docn component
   Allow for different atm names in chem_mech file generation
   Make necessary changes in E3SM cime config files and other files to allow switching cam to eam for E3SM.
   Change name of clm to elm in E3SM

Other changes:
    Advance name of CCSM_cppdefs to CIME_cppdefs
    Add a no-submit option to jenkins_generic_job
    Add "force turning off success update" option to jenkins_generic_job
    In MEMLEAK checks, skip first day memory highwater while initializing.
    Some updates to E3SM test infrastructure
    change permissions on ref case rpointer files
    Add mpi_init timer and ouput memory usage before CIME Run loop
    Add Support csh source cmd
    Add JRA Repeat Year Forcing data modes

Fixes:
    Current mods test, Y_TestUserConcurrentMods.
    Fix check_input_data to fail over to svn when a wget download fails
    Skip preview namelist flag is now honored by case.submit
    Fix mct build issue
    Correctly attribute scorpio timers in cime_pre_init2
    Fix path to cmeps buildexe

No impact on E3SM:
    Fix path to FMS in CESM
    Fix path to cdeps buildlib for cesm
    Update cmeps paths for cesm 
    Add support for MPAS-A grids from @brian-eaton.
    Downgrade Intel Compiler for UFS applications
    Update impi version for ufs model
    Add S2sport

Details:
Updates cime submodule from 54ef8b8b to 7b9ba680af

[BFB]