### PR TITLE
Mass test: Double tol on CO2_FF global mass based on compy_pgi change.

### DIFF
--- a/components/homme/utils/e3sm_test/check_mass_conservation.py
+++ b/components/homme/utils/e3sm_test/check_mass_conservation.py
@@ -91,7 +91,7 @@ tracer_idx = parse_tracer_index(atm_fn, tracer_name)
 print('Tracer {} has index {}'.format(tracer_name, tracer_idx))
 d = gather_mass_data(atm_fn, tracer_idx)
 good = (conservative('dry M', d['day'], d['dryM'], 1e-11, True) and
-        conservative('tracer {}'.format(tracer_idx), d['day'], d['qmass'], 1e-13, True))
+        conservative('tracer {}'.format(tracer_idx), d['day'], d['qmass'], 2e-13, True))
 
 if good:
     print('PASS')


### PR DESCRIPTION
Fixes the postrun-script failure in the mass conservation test. A 2x increase in the tolerance is reasonable.

[BFB]