### PR TITLE
Three BFB mods for SCREAM

### DIFF
--- a/components/eam/src/chemistry/utils/mo_util.F90
+++ b/components/eam/src/chemistry/utils/mo_util.F90
@@ -5,7 +5,7 @@ module mo_util
   implicit none
 
   private
-  public :: rebin
+  public :: rebin, rebin_fast
 
 contains
 
@@ -74,8 +74,200 @@ contains
           trg(i) = 0._r8
        end if
     end do
-
   end subroutine rebin
 
+  subroutine rebin_fast( nsrc, ntrg, ncol, src_x, trg_x, src, trg, status )
+    !---------------------------------------------------------------
+    !	... rebin src to trg
+    !
+    ! This version increments the pointers on the source and target
+    ! grids so that the overall algorithm cost is
+    !     O(max(nsrc,ntgt))
+    ! instead of
+    !     O(nsrc*ntgt)
+    ! like original rebin. It also takes multiple src and trg
+    ! columns so the remap bookkeeping can be amortized over
+    ! multiple quantities. The implementation is intended to be BFB
+    ! with rebin_orig if src_x and trg_x are each monotonically
+    ! increasing.
+    ! ---------------------------------------------------------------
+
+    implicit none
+
+    !---------------------------------------------------------------
+    !	... dummy arguments
+    !---------------------------------------------------------------
+    integer , intent(in)  :: nsrc            ! spatial dimension source array
+    integer , intent(in)  :: ntrg            ! spatial dimension target array
+    integer , intent(in)  :: ncol            ! number of columns to rebin
+    real(r8), intent(in)  :: src_x(nsrc+1)   ! source coordinates
+    real(r8), intent(in)  :: trg_x(ntrg+1)   ! target coordinates
+    real(r8), intent(in)  :: src(ncol,nsrc)  ! source array
+    real(r8), intent(out) :: trg(ncol,ntrg)  ! target array
+    integer , intent(out) :: status          !  0 if all is well;
+                                             ! -1 if trg grid is not monotonically increasing
+                                             !  1 if src grid is not monotonically increasing
+
+    !---------------------------------------------------------------
+    !	... local variables
+    !---------------------------------------------------------------
+    integer  :: i
+    integer  :: si, si1
+    integer  :: sil, siu
+    real(r8) :: y(ncol)
+    real(r8) :: sl, su
+    real(r8) :: tl, tu
+
+    sil = 1
+    siu = 1
+    do i = 1,ntrg
+       tl = trg_x(i)
+       if (tl < src_x(nsrc+1) ) then
+          do while (sil < nsrc+1)
+             if (tl <= src_x(sil)) exit
+             sil = sil + 1
+          end do
+          tu = trg_x(i+1)
+          if (tl >= tu) then
+             status = -1
+             return
+          end if
+          do while (siu < nsrc+1)
+             if (src_x(siu) >= src_x(siu+1)) then
+                status = 1
+                return
+             end if
+             if (tu <= src_x(siu)) exit
+             siu = siu + 1
+          end do
+          y   = 0._r8
+          sil = max(sil, 2     )
+          siu = min(siu, nsrc+1)
+          do si = sil,siu
+             si1 = si - 1
+             sl = max(tl, src_x(si1))
+             su = min(tu, src_x(si ))
+             y  = y + (su - sl)*src(:,si1)
+          end do
+          trg(:,i) = y/(trg_x(i+1) - trg_x(i))
+       else
+          trg(:,i) = 0._r8
+       end if
+    end do
+    status = 0
+  end subroutine rebin_fast
+
+  subroutine test_rebin()
+    integer :: nzs, nzt, ncol, ne
+
+    ne = 0
+    ne = ne + test_rebin1(1, 1, 1)
+    ne = ne + test_rebin1(1, 1, 11)
+    do nzs = 7, 337, 41
+       do nzt = 5, 331, 57
+          do ncol = 1, 17, 16
+             ne = ne + test_rebin1(nzs, nzt, ncol)
+          end do
+       end do
+    end do
+    ne = ne + test_rebin1(32, 32, 4, bad_src=.true.)
+    ne = ne + test_rebin1(32, 32, 4, bad_tgt=.true.)
+    if (ne > 0) print *, 'test_rebin FAILed: nerr', ne
+  end subroutine test_rebin
+
+  function test_rebin1(nzs, nzt, ncol, bad_src, bad_tgt) result(nerr)
+    integer, intent(in) :: nzs, nzt, ncol
+    logical, intent(in), optional :: bad_src, bad_tgt
+
+    real(r8), allocatable :: zs(:), zt(:), vs(:,:), vt(:,:), vso(:,:), vto(:,:)
+    real(r8) :: u, maxerr, zt1, i_src, i_tgt
+    integer :: i, j, nerr, status
+    logical :: bs, bt
+
+    bs = .false.
+    bt = .false.
+    if (present(bad_src)) bs = bad_src
+    if (present(bad_tgt)) bt = bad_tgt
+
+    nerr = 0
+
+    allocate(zs(nzs+1), zt(nzt+1), vso(nzs,ncol), vto(nzt,ncol), vs(ncol,nzs), vt(ncol,nzt))
+
+    do i = 1, nzs+1
+       call random_number(zs(i))
+    end do
+    if (bs) zs(2) = -zs(2)
+    do i = 2, nzs+1
+       zs(i) = zs(i) + zs(i-1)
+    end do
+    do i = 1, nzt+1
+       call random_number(zt(i))
+    end do
+    if (bt) zt(2) = -zt(2)
+    do i = 2, nzt+1
+       zt(i) = zt(i) + zt(i-1)
+    end do
+    do i = 1, nzs
+       do j = 1, ncol
+          call random_number(vs(j,i))
+          call random_number(u)
+          if (u < 0.1) vs(j,i) = -vs(j,i)
+          vso(i,j) = vs(j,i)
+       end do
+    end do
+
+    do j = 1, ncol
+       call rebin(nzs, nzt, zs, zt, vso(:,j), vto(:,j))
+    end do
+    call rebin_fast(nzs, nzt, ncol, zs, zt, vs, vt, status)
+    ! Test that the output status from rebin_fast is the expected one.
+    if (bs .and. status /=  1) nerr = nerr + 1
+    if (bt .and. status /= -1) nerr = nerr + 1
+    if (.not. (bs .or. bt) .and. status /= 0) nerr = nerr + 1
+    ! Test that rebin_fast is BFB with rebin.
+    if (.not. (bs .or. bt)) then
+       maxerr = 0
+       do i = 1, nzt
+          do j = 1, ncol
+             if (vt(j,i) /= vto(i,j)) then
+                nerr = nerr + 1
+                maxerr = max(maxerr, abs(vt(j,i) - vto(i,j)))
+             end if
+          end do
+       end do
+    end if
+    if (.not. (bs .or. bt)) then
+       ! Test the conservation of the integral.
+       ! Make the grids cover same interval.
+       u = (zs(nzs+1) - zs(1))/(zt(nzt+1) - zt(1))
+       zt1 = zt(1)
+       do i = 1, nzt+1
+          zt(i) = zs(1) + u*(zt(i) - zt1)
+       end do
+       zt(nzt+1) = zs(nzs+1)
+       if (zt(nzt) >= zt(nzt+1)) nerr = nerr + 1
+       call rebin_fast(nzs, nzt, ncol, zs, zt, vs, vt, status)
+       do j = 1, ncol
+          i_src = 0
+          do i = 1, nzs
+             i_src = i_src + (zs(i+1) - zs(i))*vs(j,i)
+          end do
+          i_tgt = 0
+          do i = 1, nzt
+             i_tgt = i_tgt + (zt(i+1) - zt(i))*vt(j,i)
+          end do
+          if (abs(i_tgt - i_src) > 1.e3_r8*max(abs(i_tgt), abs(i_src))*epsilon(1._r8)) then
+             nerr = nerr + 1
+             print '(a,es10.3,es10.3,es10.3)', 'integral error:', i_src, i_tgt, i_tgt-i_src
+          end if
+       end do
+    end if
+
+    deallocate(zs, zt, vs, vt, vso, vto)
+
+    if (nerr > 0) then
+       print '(a,i4,i4,i4,l2,l2,i4,es9.2)', '> ', nzs, nzt, ncol, bs, bt, nerr, maxerr
+    end if
+  end function test_rebin1
 
 end module mo_util

--- a/components/eam/src/chemistry/utils/read_volc_radiation_data.F90
+++ b/components/eam/src/chemistry/utils/read_volc_radiation_data.F90
@@ -230,7 +230,7 @@ contains
     ierr = pio_inq_varid( piofile, 'altitude_int', old_dimid )
     ierr = pio_get_var( piofile, old_dimid, alts_int )
 
-    allocate(wrk_sw(nlats,2,nalts,nswbands,mxnflds_sw))!BALLI- handle erros for allocate everywhere!!
+    allocate(wrk_sw(nlats,2,nalts,nswbands,mxnflds_sw))
     allocate(wrk_lw(nlats,2,nalts,nlwbands,mxnflds_lw))
 
 
@@ -256,10 +256,10 @@ contains
     allocate(pbuf_idx_sw(mxnflds_sw),pbuf_idx_lw(mxnflds_lw))
 
     do ifld = 1, mxnflds_sw
-       pbuf_idx_sw(ifld) = pbuf_get_index(trim(specifier_sw(ifld)),errcode)!BALLI handle error?
+       pbuf_idx_sw(ifld) = pbuf_get_index(trim(specifier_sw(ifld)),errcode)
     enddo 
     do ifld = 1, mxnflds_lw
-       pbuf_idx_lw(ifld) = pbuf_get_index(trim(specifier_lw(ifld)),errcode)!BALLI handle error?
+       pbuf_idx_lw(ifld) = pbuf_get_index(trim(specifier_lw(ifld)),errcode)
     enddo
 
   end subroutine read_volc_radiation_data_init
@@ -390,10 +390,10 @@ contains
           if (it == itp1_old) then
              wrk_sw(:,1,:,:,ifld) = wrk_sw(:,2,:,:,ifld)
           else
-             ierr = pio_get_var( piofile, var_id, strt_t, cnt_sw, rdata )!BALLI: handle error?
+             ierr = pio_get_var( piofile, var_id, strt_t, cnt_sw, rdata )
              call transpose(rdata, wrk_sw(:,1,:,:,ifld))
           endif
-          ierr = pio_get_var( piofile, var_id, strt_tp1, cnt_sw, rdata )!BALLI: handle error?
+          ierr = pio_get_var( piofile, var_id, strt_tp1, cnt_sw, rdata )
           call transpose(rdata, wrk_sw(:,2,:,:,ifld))
        end do
        deallocate(rdata)
@@ -414,10 +414,10 @@ contains
           if (it == itp1_old) then
              wrk_lw(:,1,:,:,ifld) = wrk_lw(:,2,:,:,ifld)
           else
-             ierr = pio_get_var( piofile, var_id, strt_t, cnt_lw, rdata )!BALLI: handle error?
+             ierr = pio_get_var( piofile, var_id, strt_t, cnt_lw, rdata )
              call transpose(rdata, wrk_lw(:,1,:,:,ifld))
           endif
-          ierr = pio_get_var( piofile, var_id, strt_tp1, cnt_lw, rdata )!BALLI: handle error?
+          ierr = pio_get_var( piofile, var_id, strt_tp1, cnt_lw, rdata )
           call transpose(rdata, wrk_lw(:,2,:,:,ifld))
        end do
        deallocate(rdata)

--- a/components/eam/src/chemistry/utils/read_volc_radiation_data.F90
+++ b/components/eam/src/chemistry/utils/read_volc_radiation_data.F90
@@ -107,7 +107,6 @@ contains
 
     real(r8) :: time1, time2                !times to compute "one_yr"
 
-
     !BALLI- add comment
 
     !Currently only handles cyclic or serial data types; exit if some other data_type detected
@@ -231,8 +230,8 @@ contains
     ierr = pio_inq_varid( piofile, 'altitude_int', old_dimid )
     ierr = pio_get_var( piofile, old_dimid, alts_int )
 
-    allocate(wrk_sw(2,mxnflds_sw,nalts,nlats,nswbands))!BALLI- handle erros for allocate everywhere!!
-    allocate(wrk_lw(2,mxnflds_lw,nalts,nlats,nlwbands))
+    allocate(wrk_sw(nlats,2,nalts,nswbands,mxnflds_sw))!BALLI- handle erros for allocate everywhere!!
+    allocate(wrk_lw(nlats,2,nalts,nlwbands,mxnflds_lw))
 
 
     ierr = pio_inq_dimid( piofile, 'solar_bands', old_dimid)
@@ -293,6 +292,7 @@ contains
     integer :: errcode, yr, mon, day, ncsec, it, itp1, itp1_old, banddim
 
     real(r8) :: data_time, curr_mdl_time, fact1, fact2, deltat_cyc
+    real(r8), allocatable :: rdata(:,:,:)
 
   !------------------------------------------------------------------------------------------------
 
@@ -381,45 +381,58 @@ contains
 
     fact2 = 1._r8-fact1
 
-    do ifld = 1,mxnflds_sw
-       if (read_data) then
+    if (read_data) then
+       allocate(rdata(nalts,nlats,nswbands))
+       do ifld = 1,mxnflds_sw
           !Get netcdf variable id for the field
           ierr = pio_inq_varid(piofile, trim(adjustl(specifier_sw(ifld))),var_id) !get id of the variable to read from iput file
           ! If current itp matches previous itp1, copy rather than reading from file
           if (it == itp1_old) then
-             wrk_sw(1,ifld,:,:,:) = wrk_sw(2,ifld,:,:,:)
+             wrk_sw(:,1,:,:,ifld) = wrk_sw(:,2,:,:,ifld)
           else
-             ierr = pio_get_var( piofile, var_id, strt_t, cnt_sw, wrk_sw(1,ifld,:,:,:) )!BALLI: handle error?
+             ierr = pio_get_var( piofile, var_id, strt_t, cnt_sw, rdata )!BALLI: handle error?
+             call transpose(rdata, wrk_sw(:,1,:,:,ifld))
           endif
-          ierr = pio_get_var( piofile, var_id, strt_tp1, cnt_sw, wrk_sw(2,ifld,:,:,:) )!BALLI: handle error?
-       endif
+          ierr = pio_get_var( piofile, var_id, strt_tp1, cnt_sw, rdata )!BALLI: handle error?
+          call transpose(rdata, wrk_sw(:,2,:,:,ifld))
+       end do
+       deallocate(rdata)
+    endif
 
+    do ifld = 1,mxnflds_sw
        !we always have to do interpolation as current model time changes time factors-fact1 and fact2
        !interpolate in lats, time and vertical
-       call interpolate_lats_time_vert(state, wrk_sw(:,ifld,:,:,:), nswbands, pbuf_idx_sw(ifld), fact1, fact2, pbuf2d )
+       call interpolate_lats_time_vert(state, wrk_sw(:,:,:,:,ifld), nswbands, pbuf_idx_sw(ifld), fact1, fact2, pbuf2d )
     enddo
 
-    do ifld = 1,mxnflds_lw
-       !Note that we have to reverse (compared with how they are mentioned in the netcdf file) the array dim sizes
-       if(read_data) then
+    if(read_data) then
+       allocate(rdata(nalts,nlats,nlwbands))
+       do ifld = 1,mxnflds_lw
+          !Note that we have to reverse (compared with how they are mentioned in the netcdf file) the array dim sizes
           ierr = pio_inq_varid(piofile, trim(adjustl(specifier_lw(ifld))),var_id) !get id of the variable to read from iput file
           ! If current itp matches previous itp1, copy rather than reading from file
           if (it == itp1_old) then
-             wrk_lw(1,ifld,:,:,:) = wrk_lw(2,ifld,:,:,:)
+             wrk_lw(:,1,:,:,ifld) = wrk_lw(:,2,:,:,ifld)
           else
-             ierr = pio_get_var( piofile, var_id, strt_t, cnt_lw, wrk_lw(1,ifld,:,:,:) )!BALLI: handle error?
+             ierr = pio_get_var( piofile, var_id, strt_t, cnt_lw, rdata )!BALLI: handle error?
+             call transpose(rdata, wrk_lw(:,1,:,:,ifld))
           endif
-          ierr = pio_get_var( piofile, var_id, strt_tp1, cnt_lw, wrk_lw(2,ifld,:,:,:) )!BALLI: handle error?
-       endif
+          ierr = pio_get_var( piofile, var_id, strt_tp1, cnt_lw, rdata )!BALLI: handle error?
+          call transpose(rdata, wrk_lw(:,2,:,:,ifld))
+       end do
+       deallocate(rdata)
+    endif
+
+    do ifld = 1,mxnflds_lw
        !we always have to do interpolation as current model time changes time factors-fact1 and fact2 
        !interpolate in lats, time and vertical
-       call interpolate_lats_time_vert(state, wrk_lw(:,ifld,:,:,:), nlwbands, pbuf_idx_lw(ifld), fact1, fact2, pbuf2d )
+       call interpolate_lats_time_vert(state, wrk_lw(:,:,:,:,ifld), nlwbands, pbuf_idx_lw(ifld), fact1, fact2, pbuf2d )
     enddo
 
     ! Chris Golaz: for debugging
     !if (masterproc) write(iulog,'(a,i5,2i3,i6,3f9.2,l2,2f8.4)')'advance_volc_radiation_data:', &
     !  yr,mon,day,ncsec,curr_mdl_time,datatimem,datatimep,read_data,fact1,fact2
-        
+
   end subroutine advance_volc_radiation_data
 
   !------------------------------------------------------------------------------------------------
@@ -487,26 +500,26 @@ contains
     use physics_buffer,   only: pbuf_get_field, physics_buffer_desc
     use physics_types,    only: physics_state
     use interpolate_data, only: lininterp_init, lininterp, interp_type, lininterp_finish    
-    use mo_util,          only: rebin
+    use mo_util,          only: rebin_fast
 
     !Arguments
     !--intent(in)
     type(physics_state), intent(in) :: state(begchunk:endchunk)
     integer,  intent(in) :: banddim, pbuf_idx
-    real(r8), intent(in) :: fact1, fact2, wrk(ntslc,nalts,nlats,banddim)
+    real(r8), intent(in) :: fact1, fact2, wrk(nlats,ntslc,nalts,banddim)
 
     !--intent (out)
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
 
     !Local variables
     type(interp_type) :: lat_wgts
-    integer  :: ichnk, ncols, k, iband, icol
+    integer  :: ichnk, ncols, k, iband, icol, status
 
     real(r8), parameter :: m2km  = 1.e-3_r8
 
-    real(r8) :: wrk_1d(ntslc,pcols), to_lats(pcols)
-    real(r8) :: datain(pcols,nalts,banddim)
-    real(r8) :: model_z(pverp),data_out_tmp(pcols,pver,banddim)    
+    real(r8) :: wrk_1d(pcols,ntslc), to_lats(pcols)
+    real(r8) :: datain(banddim,nalts,pcols)
+    real(r8) :: model_z(pverp),data_out_tmp(banddim,pver)
 
     real(r8), pointer :: data_out(:,:,:)
 
@@ -518,26 +531,41 @@ contains
        do iband = 1 , banddim 
           do k = 1, nalts
              !lats interpolation
-             call lininterp(wrk(1,k,:,iband), nlats, wrk_1d(1,1:ncols), ncols, lat_wgts)
-             call lininterp(wrk(2,k,:,iband), nlats, wrk_1d(2,1:ncols), ncols, lat_wgts)
-
+             call lininterp(wrk(:,1,k,iband), nlats, wrk_1d(1:ncols,1), ncols, lat_wgts)
+             call lininterp(wrk(:,2,k,iband), nlats, wrk_1d(1:ncols,2), ncols, lat_wgts)
              !time interpolation
-             datain(1:ncols,k,iband) = fact1*wrk_1d(1,1:ncols) + fact2*wrk_1d(2,1:ncols)
+             datain(iband,k,1:ncols) = fact1*wrk_1d(1:ncols,1) + fact2*wrk_1d(1:ncols,2)
           end do
        enddo       
        call lininterp_finish(lat_wgts)
        !vertical interpolation
-       do iband = 1, banddim
-          do icol = 1, ncols
-             !convert model's vertical coordinate from m to km and flip it to match data
-             model_z(1:pverp) = m2km * state(ichnk)%zi(icol,pverp:1:-1)
-             call rebin( nalts, pver, alts_int, model_z, datain(icol,:,iband), data_out_tmp(icol,:,iband) )
-             !flip in vertical to match model
-             data_out(icol,:,iband) = data_out_tmp(icol,pver:1:-1,iband)
-          enddo
+       do icol = 1, ncols
+          !convert model's vertical coordinate from m to km and flip it to match data
+          model_z(1:pverp) = m2km * state(ichnk)%zi(icol,pverp:1:-1)
+          call rebin_fast( nalts, pver, banddim, alts_int, model_z, datain(:,:,icol), data_out_tmp, status )
+          if (status /= 0) then
+             call endrun('read_volc_radiation_data.F90: rebin_fast detected nonmonotonic grids')
+          end if
+          !flip in vertical to match model
+          do iband = 1, banddim
+             data_out(icol,1:pver,iband) = data_out_tmp(iband,pver:1:-1)
+          end do
        enddo
     end do
 
   end subroutine interpolate_lats_time_vert
+
+  subroutine transpose(rd, ud)
+    real(r8), intent(in ) :: rd(:,:,:)
+    real(r8), intent(out) :: ud(:,:,:)
+
+    integer :: i, j
+
+    do j = 1, size(rd,1)
+       do i = 1, size(rd,2)
+          ud(i,j,:) = rd(j,i,:)
+       end do
+    end do
+  end subroutine transpose
   
 end module read_volc_radiation_data

--- a/components/homme/src/share/compose_mod.F90
+++ b/components/homme/src/share/compose_mod.F90
@@ -269,10 +269,12 @@ contains
        rank2sfc => null_target
     end if
     if (use_sgi) then
+       if (.not. allocated(owned_ids)) allocate(owned_ids(1))
        call cedr_init_impl(par%comm, semi_lagrange_cdr_alg, &
             use_sgi, owned_ids, rank2sfc, nelem, nelemd, nlev, &
             independent_time_steps, hard_zero, size(owned_ids), size(rank2sfc))
     else
+       if (.not. allocated(sc2gci)) allocate(sc2gci(1), sc2rank(1))
        call cedr_init_impl(par%comm, semi_lagrange_cdr_alg, &
             use_sgi, sc2gci, sc2rank, nelem, nelemd, nlev, &
             independent_time_steps, hard_zero, size(sc2gci), size(sc2rank))

--- a/components/homme/src/theta-l/share/imex_mod.F90
+++ b/components/homme/src/theta-l/share/imex_mod.F90
@@ -330,10 +330,10 @@ contains
           dphi(:,:,nlev) = dphi_n0(:,:,nlev) - dt2*g*(w_np1(:,:,nlev) + x(:,:,nlev))
 
           alphas = 1
-          if (maxval(dphi(:,:,1:nlev)) >= 0) then
+          if (any(dphi(:,:,1:nlev) >= 0)) then
              do j=1,np
                 do i=1,np
-                   if (maxval(dphi(i,j,1:nlev)) < 0) cycle
+                   if (.not. any(dphi(i,j,1:nlev) >= 0)) cycle
 
                    ! Step halfway to the distance at which at least one dphi is 0.
                    alpha = 1
@@ -372,7 +372,8 @@ contains
                elem(ie)%state%dp3d(:,:,:,np1),dphi,pnh,exner,dpnh_dp_i,'dirk2')
           Fn(:,:,1:nlev) = w_np1(:,:,1:nlev) - (w_n0(:,:,1:nlev) + g*dt2 * (dpnh_dp_i(:,:,1:nlev)-1))
 
-          reserr=maxval(abs(Fn))/(wmax*abs(dt2)) 
+          ! this is not used in this loop, so move out of loop
+          !reserr=maxval(abs(Fn))/(wmax*abs(dt2)) 
           deltaerr=maxval(abs(x))/wmax
 
           ! update iteration count and error measure
@@ -388,6 +389,7 @@ contains
        ! keep track of running  max iteraitons and max error (reset after each diagnostics output)
        max_itercnt=max(itercount,max_itercnt)
        max_deltaerr=max(deltaerr,max_deltaerr)
+       reserr=maxval(abs(Fn))/(wmax*abs(dt2))
        max_reserr=max(reserr,max_reserr)
 #ifdef NEWTONCOND
        min_rcond=min(rcond,min_rcond)


### PR DESCRIPTION
This PR implements two optimizations for SCREAM following from Noel's performance analysis:
* Noel determined that `maxval` in Homme's `compute_stage_value_dirk` is expensive. It can be replaced by `any` in two cases and moved out of the Newton iteration in another.
* Noel found that `advance_volc_radiation_data` is an expensive additional routine used in SCREAM'S DYAMOND2 configuration relative to DYAMOND1. This turned out to be for two reasons: poor index order and an O(n^2) rebin implementation. Fix both of these.

In addition, Noel pointed out that some F90-C++ interface calls in an RRM debug build were failing due to unallocated arrays. These are not used but F90 requires them to be allocated in the call. Fix this.

[BFB] for CIME E3SM and SCREAM tests; possibly non-BFB for standalone Homme theta-l tests, depending on optimization level on the machine; see comment below.