### PR TITLE
switch default dycore to theta-l

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -46,7 +46,7 @@ _TESTS = {
             "ERP_Ln9.ne4_ne4.FC5AV1C-L",
             "SMS_Ln9.ne4_ne4.FC5AV1C-L.eam-outfrq9s",
             "SMS.ne4_ne4.FC5AV1C-L.eam-cosplite",
-            "SMS_R_Ld5.ne4_ne4.FSCM5A97",
+            "SMS_R_Ld5.ne4_ne4.FSCM5A97.eam-scm",
             "SMS_D_Ln5.ne4_ne4.FC5AV1C-L",
             "SMS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L"
             )

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -159,8 +159,8 @@ _TESTS = {
             "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
             "SMS_D_Ld1.ne30_r05_oECv3.A_WCYCL1850",
             "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1.eam-crmout",
-            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMFXX",
-            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-RCEMIP",
+            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMFXX.eam-genmmf",
+            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-RCEMIP.eam-genmmf",
             )
         },
 

--- a/components/cmake/build_model.cmake
+++ b/components/cmake/build_model.cmake
@@ -249,7 +249,7 @@ function(build_model COMP_CLASS COMP_NAME)
       endif()
     endif()
     if (USE_KOKKOS)
-      target_link_libraries (${TARGET_NAME} Kokkos::kokkos)
+      target_link_libraries (${TARGET_NAME} PRIVATE Kokkos::kokkos)
     endif ()
   endif()
 

--- a/components/eam/bld/config_files/defaults_se.xml
+++ b/components/eam/bld/config_files/defaults_se.xml
@@ -3,7 +3,7 @@
 <config_definition>
 
 <entry id="dyn"   value="se"  />
-<entry id="dyn_target"   value="preqx"  />
+<entry id="dyn_target"   value="theta-l"  />
 <entry id="hgrid" value="ne16np4" />
 <entry id="pcols" value="16" />
 

--- a/components/eam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1539,7 +1539,7 @@
 <!-- tensor hyperviscsoity -->
 <nu>                   3.4e-8 </nu>
 <hypervis_order >     2 </hypervis_order>
-<hypervis_scaling> 3 </hypervis_scaling>
+<hypervis_scaling> 3.0 </hypervis_scaling>
 
 <!-- special defaults for V2 NE30 -->
 <nu hgrid="ne30np4">  1.0e15 </nu>

--- a/components/eam/bld/namelist_files/namelist_defaults_cam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_cam.xml
@@ -1535,6 +1535,7 @@
 <nu_top dyn_target="theta-l" hgrid="ne1024np4"> 1e4 </nu_top>
 <nu_top dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"> 1e5 </nu_top>
 <nu_top dyn_target="theta-l" hgrid="ne0np4_antarcticax4v1"> 1e5 </nu_top>
+<nu_top dyn_target="theta-l" hgrid="ne0np4_conus_x4v1_lowcon"> 1e5 </nu_top>
 
 
 <nu>                   1.0e15 </nu>
@@ -1553,6 +1554,7 @@
 <nu hgrid="ne1024np4"> 2.5e10 </nu>
 <nu hgrid="ne0np4_arm_x8v3_lowcon"  > 8.0e-8</nu>
 <nu hgrid="ne0np4_conus_x4v1_lowcon"  > 8.0e-8</nu>
+<nu dyn_target="theta-l" hgrid="ne0np4_conus_x4v1_lowcon" > 3.4e-8</nu>
 <nu hgrid="ne0np4_northamericax4v1"  > 8.0e-8</nu>
 <nu dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"  > 3.4e-8</nu>
 <nu hgrid="ne0np4_antarcticax4v1"  > 8.0e-8</nu>
@@ -1595,6 +1597,7 @@
 <hypervis_scaling dyn_target="theta-l"  hgrid="ne45np4"> 3.0 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_arm_x8v3_lowcon"  > 3.2 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_conus_x4v1_lowcon"  > 3.2 </hypervis_scaling>
+<hypervis_scaling dyn_target="theta-l"  hgrid="ne0np4_conus_x4v1_lowcon"  > 3.0 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_northamericax4v1"  > 3.2 </hypervis_scaling>
 <hypervis_scaling dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"  > 3.0 </hypervis_scaling>
 <hypervis_scaling  hgrid="ne0np4_antarcticax4v1"  > 3.2 </hypervis_scaling>
@@ -1636,6 +1639,7 @@
 <se_tstep dyn_target="theta-l" hgrid="ne1024np4"> 10 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"> 75 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne0np4_antarcticax4v1"> 75 </se_tstep>
+<se_tstep dyn_target="theta-l" hgrid="ne0np4_conus_x4v1_lowcon"> 75 </se_tstep>
 
 
 <!-- old interface, used by preqx.  timesteps controlled by se_nsplit, rsplit, qsplit -->
@@ -1690,6 +1694,7 @@
 <hypervis_subcycle hgrid="ne1024np4" dyn_target="preqx"> 20 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_arm_x8v3_lowcon" dyn_target="preqx" > 8 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_conus_x4v1_lowcon" dyn_target="preqx" > 7 </hypervis_subcycle>
+<hypervis_subcycle hgrid="ne0np4_conus_x4v1_lowcon" dyn_target="theta-l" > 2 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_northamericax4v1" dyn_target="preqx"  > 7 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_northamericax4v1" dyn_target="theta-l"> 2 </hypervis_subcycle>
 <hypervis_subcycle hgrid="ne0np4_antarcticax4v1" dyn_target="preqx"  > 7 </hypervis_subcycle>
@@ -1702,6 +1707,7 @@
 
 <hypervis_subcycle_tom dyn_target="theta-l" hgrid="ne0np4_northamericax4v1"> 3 </hypervis_subcycle_tom>
 <hypervis_subcycle_tom dyn_target="theta-l" hgrid="ne0np4_antarcticax4v1"> 3 </hypervis_subcycle_tom>
+<hypervis_subcycle_tom dyn_target="theta-l" hgrid="ne0np4_conus_x4v1"> 3 </hypervis_subcycle_tom>
 
 
 <!-- ================================================================== -->

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -29,7 +29,7 @@
   <entry id="CAM_TARGET">
          <type>char</type>
          <valid_values>preqx,preqx_kokkos,preqx_acc,theta-l</valid_values>
-         <default_value>preqx</default_value>
+         <default_value>theta-l</default_value>
          <group>build_component_cam</group>
          <file>env_build.xml</file>
          <desc>EAM-SE cmake target (only used with EAM_DYCORE == 'se')</desc>

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/crmout/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/crmout/user_nl_eam
@@ -11,3 +11,14 @@ fincl2lonlat = '120w:100w_20n:40n'
 ! Global grid variables on a subset of the globe
 fincl3 = 'PS:I','PRECT:I','LHFLX:I','FSNT:I','UBOT:I','MMF_DT:I','MMF_TLS:I','MMF_MC:I','MMF_TKE:I','MMF_SUBCYCLE_FAC'
 fincl3lonlat = '60e:120e_00n:60n'
+
+transport_alg=0
+se_nsplit=4
+dt_remap_factor=1
+dt_tracer_factor=1
+hypervis_subcycle_q=1
+hypervis_subcycle=3
+hypervis_subcycle_tom=0
+
+
+

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/genmmf/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/genmmf/user_nl_eam
@@ -1,0 +1,11 @@
+!generic mmf
+transport_alg=0
+se_nsplit=4
+dt_remap_factor=1
+dt_tracer_factor=1
+hypervis_subcycle_q=1
+hypervis_subcycle=3
+hypervis_subcycle_tom=0
+
+
+

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/scm/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/scm/shell_commands
@@ -1,0 +1,2 @@
+#!/bin/bash
+./xmlchange CAM_TARGET=preqx

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype0/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype0/user_nl_eam
@@ -2,16 +2,4 @@ se_ftype=0
 cubed_sphere_map=0
 theta_hydrostatic_mode=.true.
 
-se_nsplit=2
-se_limiter_option = 8
-transport_alg=0
-vert_remap_q_alg=1
-se_tstep=-1
-dt_remap_factor=-1
-dt_tracer_factor=-1
-qsplit=1
-rsplit=2
-hypervis_subcycle=3
-hypervis_subcycle_q=1
-hypervis_subcycle_tom=0
 theta_advect_form=0

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype1/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype1/user_nl_eam
@@ -2,18 +2,4 @@ se_ftype=1
 cubed_sphere_map=0
 theta_hydrostatic_mode=.true.
 
-se_nsplit=2
-se_limiter_option = 8
-transport_alg=0
-vert_remap_q_alg=1
-se_tstep=-1
-dt_remap_factor=-1
-dt_tracer_factor=-1
-qsplit=1
-rsplit=2
-hypervis_subcycle=3
-hypervis_subcycle_q=1
-hypervis_subcycle_tom=0
-theta_advect_form=0
-
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype2/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype2/user_nl_eam
@@ -2,17 +2,4 @@ se_ftype=2
 cubed_sphere_map=0
 theta_hydrostatic_mode=.true.
 
-se_nsplit=2
-se_limiter_option = 8
-transport_alg=0
-vert_remap_q_alg=1
-se_tstep=-1
-dt_remap_factor=-1
-dt_tracer_factor=-1
-qsplit=1
-rsplit=2
-hypervis_subcycle=3
-hypervis_subcycle_q=1
-hypervis_subcycle_tom=0
-theta_advect_form=0
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype4/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype4/user_nl_eam
@@ -2,17 +2,4 @@ se_ftype=4
 cubed_sphere_map=0
 theta_hydrostatic_mode=.true.
 
-se_nsplit=2
-se_limiter_option = 8
-transport_alg=0
-vert_remap_q_alg=1
-se_tstep=-1
-dt_remap_factor=-1
-dt_tracer_factor=-1
-qsplit=1
-rsplit=2
-hypervis_subcycle=3
-hypervis_subcycle_q=1
-hypervis_subcycle_tom=0
-theta_advect_form=0
 

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/bgcexp/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/bgcexp/shell_commands
@@ -1,1 +1,2 @@
 ./xmlchange PIO_TYPENAME=netcdf
+./xmlchange CAM_TARGET=preqx

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/bgcexp/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/bgcexp/shell_commands
@@ -1,2 +1,1 @@
 ./xmlchange PIO_TYPENAME=netcdf
-./xmlchange CAM_TARGET=preqx


### PR DESCRIPTION
Make theta-l default dycore.

Keep SCM test with preqx.

switch to tensor HV for most grids.

[nbfb] for most cime tests with atmosphere.