### PR TITLE
Adds saving of GM induced MOC streamfunction

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -1464,8 +1464,6 @@ add_default($nl, 'config_AM_mocStreamfunction_write_on_startup');
 add_default($nl, 'config_AM_mocStreamfunction_min_bin');
 add_default($nl, 'config_AM_mocStreamfunction_max_bin');
 add_default($nl, 'config_AM_mocStreamfunction_num_bins');
-add_default($nl, 'config_AM_mocStreamfunction_vertical_velocity_value');
-add_default($nl, 'config_AM_mocStreamfunction_normal_velocity_value');
 add_default($nl, 'config_AM_mocStreamfunction_region_group');
 add_default($nl, 'config_AM_mocStreamfunction_transect_group');
 

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -939,8 +939,6 @@ add_default($nl, 'config_AM_mocStreamfunction_write_on_startup');
 add_default($nl, 'config_AM_mocStreamfunction_min_bin');
 add_default($nl, 'config_AM_mocStreamfunction_max_bin');
 add_default($nl, 'config_AM_mocStreamfunction_num_bins');
-add_default($nl, 'config_AM_mocStreamfunction_vertical_velocity_value');
-add_default($nl, 'config_AM_mocStreamfunction_normal_velocity_value');
 add_default($nl, 'config_AM_mocStreamfunction_region_group');
 add_default($nl, 'config_AM_mocStreamfunction_transect_group');
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -889,8 +889,6 @@
 <config_AM_mocStreamfunction_min_bin>-1.0e34</config_AM_mocStreamfunction_min_bin>
 <config_AM_mocStreamfunction_max_bin>-1.0e34</config_AM_mocStreamfunction_max_bin>
 <config_AM_mocStreamfunction_num_bins>180</config_AM_mocStreamfunction_num_bins>
-<config_AM_mocStreamfunction_vertical_velocity_value>'vertVelocityTop'</config_AM_mocStreamfunction_vertical_velocity_value>
-<config_AM_mocStreamfunction_normal_velocity_value>'normalVelocity'</config_AM_mocStreamfunction_normal_velocity_value>
 <config_AM_mocStreamfunction_region_group>'all'</config_AM_mocStreamfunction_region_group>
 <config_AM_mocStreamfunction_transect_group>'all'</config_AM_mocStreamfunction_transect_group>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -5132,22 +5132,6 @@ Valid values: Any positive integer value less than or equal to nMocStreamfunctio
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_AM_mocStreamfunction_vertical_velocity_value" type="char*1024"
-	category="AM_mocStreamfunction" group="AM_mocStreamfunction">
-The vertical velocity variable used for the computation of the MOC Streamfunction.
-
-Valid values: Either of 'vertVelocityTop', 'vertTransportVelocityTop' or 'vertGMBolusVelocityTop' (all from diagnostics pool).
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_AM_mocStreamfunction_normal_velocity_value" type="char*1024"
-	category="AM_mocStreamfunction" group="AM_mocStreamfunction">
-The normal velocity variable used for the computation of the MOC Streamfunction.
-
-Valid values: Either of 'vertVelocityTop', 'vertTransportVelocityTop' or 'vertGMBolusVelocityTop' (all from diagnostics pool).
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_AM_mocStreamfunction_region_group" type="char*1024"
 	category="AM_mocStreamfunction" group="AM_mocStreamfunction">
 The name of the region group, for which the moc should be computed in addition to the global MOC.

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1029,6 +1029,8 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var name="normalGMBolusVelocitySquared"/>')
             lines.append('    <var name="gmKappaScaling"/>')
             lines.append('    <var name="gmBolusKappa"/>')
+            lines.append('    <var name="mocStreamvalLatAndDepthGM"/>')
+            lines.append('    <var name="mocStreamvalLatAndDepthRegionGM"/>')
 
         lines.append('    <var_struct name="tracersSurfaceFlux"/>')
         lines.append('    <var name="penetrativeTemperatureFlux"/>')


### PR DESCRIPTION
This PR adds the ability to compute and separately save the MOC stream function due to GM bolus velocity. This is saved separately from the MOC from the resolved velocity. See https://github.com/MPAS-Dev/MPAS-Model/pull/726

[BFB]
[NML]