### PR TITLE
Add user_nl_mpassi for elm bgcexp testmod in order to pass automated tests

### DIFF
--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/bgcexp/user_nl_mpassi
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/bgcexp/user_nl_mpassi
@@ -1,0 +1,1 @@
+config_nsnowlayers = 1


### PR DESCRIPTION
This PR adds user_nl_mpassi to the elm bgcexp tested, with a single setting to make nSnowLayers = 1. This will allow two BGC tests in the automated suites to pass, that have otherwise been failing since [PR #3846](https://github.com/E3SM-Project/E3SM/pull/3846) was merged. 

Note: this PR is for testing use only and not to be used for science runs.

Fixes #3883 

[NML]
[non-BFB] for the two automated tests, because #3846 will have changed answers once these tests run again