### PR TITLE
Allow dynamic crop fraction taking effect when crop model turned off 

### DIFF
--- a/components/elm/bld/CLMBuildNamelist.pm
+++ b/components/elm/bld/CLMBuildNamelist.pm
@@ -2766,6 +2766,11 @@ sub setup_logic_do_transient_crops {
       if (string_is_undef_or_empty($nl->get_value('flanduse_timeseries'))) {
          $cannot_be_true = "$var can only be set to true when running a transient case (flanduse_timeseries non-blank)";
       }
+      
+      elsif (!value_is_true($nl->get_value("irrigate"))) {
+         $cannot_be_true = "$var should be set to true when running with irrigate = true";
+      }
+      
       elsif (value_is_true($nl->get_value('use_fates'))) {
          # In principle, use_fates should be compatible with
          # do_transient_crops. However, this hasn't been tested, so to be safe,

--- a/components/elm/bld/CLMBuildNamelist.pm
+++ b/components/elm/bld/CLMBuildNamelist.pm
@@ -2766,9 +2766,6 @@ sub setup_logic_do_transient_crops {
       if (string_is_undef_or_empty($nl->get_value('flanduse_timeseries'))) {
          $cannot_be_true = "$var can only be set to true when running a transient case (flanduse_timeseries non-blank)";
       }
-      elsif (!value_is_true($nl->get_value('use_crop'))) {
-         $cannot_be_true = "$var can only be set to true when running with use_crop = true";
-      }
       elsif (value_is_true($nl->get_value('use_fates'))) {
          # In principle, use_fates should be compatible with
          # do_transient_crops. However, this hasn't been tested, so to be safe,

--- a/components/elm/src/data_types/VegetationDataType.F90
+++ b/components/elm/src/data_types/VegetationDataType.F90
@@ -5379,26 +5379,16 @@ module VegetationDataType
     call hist_addfld1d (fname='QIRRIG_REAL', units='mm/s', &
          avgflag='A', long_name='actual water added through irrigation (surface + ground)', &
          ptr_patch=this%qflx_real_irrig_patch)
-    
-    this%qflx_supply_patch(begp:endp) = spval     
-    call hist_addfld1d (fname='QSUPPLY', units='mm/s', &
-         avgflag='A', long_name='irrigation supply from MOSART', &
-         ptr_patch=this%qflx_supply_patch)
          
     this%qflx_surf_irrig_patch(begp:endp) = spval    
-    call hist_addfld1d (fname='QSURF_IRRIG', units='mm/s', &
+    call hist_addfld1d (fname='QIRRIG_SURF', units='mm/s', &
          avgflag='A', long_name='Surface water irrigation', &
          ptr_patch=this%qflx_surf_irrig_patch)
     
     this%qflx_grnd_irrig_patch(begp:endp) = spval   
-    call hist_addfld1d (fname='QGRND_IRRIG', units='mm/s', &
+    call hist_addfld1d (fname='QIRRIG_GRND', units='mm/s', &
          avgflag='A', long_name='Groundwater irrigation', &
-         ptr_patch=this%qflx_grnd_irrig_patch)
-		 
-    this%qflx_over_supply_patch(begp:endp) = spval   
-    call hist_addfld1d (fname='QOVER_SUPPLY', units='mm/s', &
-         avgflag='A', long_name='Over supplied irrigation due to remapping, added to irrigation to conserve mass', &
-         ptr_patch=this%qflx_over_supply_patch)
+         ptr_patch=this%qflx_grnd_irrig_patch)	 
 
     this%qflx_prec_intr(begp:endp) = spval
     call hist_addfld1d (fname='QINTR', units='mm/s',  &

--- a/components/elm/src/dyn_subgrid/dynSubgridControlMod.F90
+++ b/components/elm/src/dyn_subgrid/dynSubgridControlMod.F90
@@ -221,10 +221,6 @@ contains
     end if
 
     if (dyn_subgrid_control_inst%do_transient_crops) then
-       if (.not. use_crop) then
-          write(iulog,*) 'ERROR: do_transient_crops can only be true if use_crop is true'
-          call endrun(msg=errMsg(sourcefile, __LINE__))
-       end if
        if (use_fates) then
           ! NOTE(wjs, 2017-01-13) ED / FATES does not currently have a mechanism for
           ! changing its column areas, with the consequent changes in aboveground biomass

--- a/components/elm/src/dyn_subgrid/dyncropFileMod.F90
+++ b/components/elm/src/dyn_subgrid/dyncropFileMod.F90
@@ -12,7 +12,7 @@ module dyncropFileMod
   use decompMod             , only : bounds_type, BOUNDS_LEVEL_PROC
   use dynFileMod            , only : dyn_file_type
   use dynVarTimeUninterpMod , only : dyn_var_time_uninterp_type
-  use clm_varctl            , only : iulog
+  use clm_varctl            , only : iulog, use_crop
   use clm_varcon            , only : grlnd, namec
   use abortutils            , only : endrun
   use spmdMod               , only : masterproc, mpicom
@@ -188,7 +188,9 @@ contains
           end if
           
           col_pp%wtlunit(c) = wtcft_cur(g,m)
-          crop_inst%fertnitro_patch(p) = fertcft_cur(g,m)
+          if (use_crop) then                  
+            crop_inst%fertnitro_patch(p) = fertcft_cur(g,m)
+          end if   
           col_set(c) = .true.
        end if
     end do

--- a/components/elm/src/dyn_subgrid/dyncropFileMod.F90
+++ b/components/elm/src/dyn_subgrid/dyncropFileMod.F90
@@ -16,7 +16,7 @@ module dyncropFileMod
   use clm_varcon            , only : grlnd, namec
   use abortutils            , only : endrun
   use spmdMod               , only : masterproc, mpicom
-  use LandunitType          , only : lun_pp                
+  use LandunitType          , only : lun_pp
   use ColumnType            , only : col_pp
   use VegetationType        , only : veg_pp
   !
@@ -43,7 +43,6 @@ module dyncropFileMod
   !---------------------------------------------------------------------------
 
 contains
-  
   !-----------------------------------------------------------------------
   subroutine dyncrop_init(bounds, dyncrop_filename)
     !
@@ -64,10 +63,8 @@ contains
     integer :: num_points     ! number of spatial points
     integer :: wtcft_shape(2) ! shape of the wtcft data
     integer :: fertcft_shape(2) ! shape of the fertcft data
-    
     character(len=*), parameter :: subname = 'dyncrop_init'
     !-----------------------------------------------------------------------
-    
     SHR_ASSERT(bounds%level == BOUNDS_LEVEL_PROC, subname // ': argument must be PROC-level bounds')
 
     if (masterproc) then
@@ -81,7 +78,6 @@ contains
     ! prescribed ahead of time.
     dyncrop_file = dyn_file_type(dyncrop_filename, YEAR_POSITION_START_OF_TIMESTEP)
     call check_dim(dyncrop_file, 'cft', cft_size)
-    
     ! read data PCT_CROP and PCT_CFT corresponding to correct year
     !
     ! Note: if you want to change transient crops so that they are interpolated, rather
@@ -119,7 +115,7 @@ contains
     ! Note that crop cover currently jumps to its new value at the start of the year.
     ! However, as mentioned above, this behavior can be changed to time interpolation
     ! simply by making wtcrop and wtcft dyn_var_time_interp_type variables rather than
-    ! dyn_var_time_uninterp_type. 
+    ! dyn_var_time_uninterp_type.
     !
     ! !USES:
     use CropType          , only : crop_type
@@ -139,7 +135,6 @@ contains
     real(r8), allocatable :: wtcft_cur(:,:) ! current cft weights
     real(r8), allocatable :: fertcft_cur(:,:) ! current cft fertilizer
     logical , allocatable :: col_set(:)     ! whether we have set the weight for each column
-    
     character(len=*), parameter :: subname = 'dyncrop_interp'
     !-----------------------------------------------------------------------
 
@@ -180,17 +175,15 @@ contains
 
           ! The following assumes there is a single CFT on each crop column. The
           ! error-check with col_set helps ensure this is the case.
-          
           if (col_set(c)) then
              write(iulog,*) subname//' ERROR: attempt to set a column that has already been set.'
              write(iulog,*) 'This may happen if there are multiple crops on a single column.'
              call endrun(decomp_index=c, clmlevel=namec, msg=errMsg(sourcefile, __LINE__))
           end if
-          
           col_pp%wtlunit(c) = wtcft_cur(g,m)
-          if (use_crop) then                  
+          if (use_crop) then
             crop_inst%fertnitro_patch(p) = fertcft_cur(g,m)
-          end if   
+          end if
           col_set(c) = .true.
        end if
     end do

--- a/components/elm/src/main/clm_initializeMod.F90
+++ b/components/elm/src/main/clm_initializeMod.F90
@@ -357,7 +357,7 @@ contains
     ! Some things are kept until the end of initialize2; urban_valid is kept through the
     ! end of the run for error checking.
 
-    deallocate (wt_lunit, wt_cft, wt_glc_mec)
+    deallocate (wt_cft, wt_glc_mec)
 
     call t_stopf('clm_init1')
 

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -865,6 +865,8 @@ contains
     write(iulog,*) '    use_century_decomp = ', use_century_decomp
     write(iulog,*) '    use_cn = ', use_cn
     write(iulog,*) '    use_crop = ', use_crop
+    write(iulog,*) '    irrigate = ', irrigate
+    write(iulog,*) '    two-way irrigation = ', tw_irr
     write(iulog,*) '    use_snicar_frc = ', use_snicar_frc
     write(iulog,*) '    use_snicar_ad = ', use_snicar_ad
     write(iulog,*) '    use_vancouver = ', use_vancouver

--- a/components/mosart/src/cpl/rof_comp_esmf.F90
+++ b/components/mosart/src/cpl/rof_comp_esmf.F90
@@ -25,7 +25,7 @@ module rof_comp_esmf
   use seq_flds_mod
   use esmf
   use esmfshr_mod
-  use RunoffMod        , only : rtmCTL, TRunoff, THeat
+  use RunoffMod        , only : rtmCTL, TRunoff, THeat, TUnit
   use RtmVar           , only : rtmlon, rtmlat, ice_runoff, iulog, &
                                 nsrStartup, nsrContinue, nsrBranch, & 
                                 inst_index, inst_suffix, inst_name, RtmVarSet, heatflag
@@ -705,7 +705,7 @@ contains
        else
           rtmCTL%qdto(n,nliq) = 0.0_r8
        endif
-       rtmCTL%qdem(n,nliq) = fptr(index_x2r_Flrl_demand,n2) * (rtmCTL%area(n)*0.001_r8)
+       rtmCTL%qdem(n,nliq) = fptr(index_x2r_Flrl_demand,n2) / TUnit%domainfrac(n) * (rtmCTL%area(n)*0.001_r8)
 
        rtmCTL%qsur(n,nfrz) = fptr(index_x2r_Flrl_rofi,n2) * (rtmCTL%area(n)*0.001_r8)
        rtmCTL%qsub(n,nfrz) = 0.0_r8

--- a/components/mosart/src/cpl/rof_comp_esmf.F90
+++ b/components/mosart/src/cpl/rof_comp_esmf.F90
@@ -705,8 +705,11 @@ contains
        else
           rtmCTL%qdto(n,nliq) = 0.0_r8
        endif
-       rtmCTL%qdem(n,nliq) = fptr(index_x2r_Flrl_demand,n2) / TUnit%domainfrac(n) * (rtmCTL%area(n)*0.001_r8)
-
+       if (wrmflag) then
+        rtmCTL%qdem(n,nliq) = fptr(index_x2r_Flrl_demand,n2) / TUnit%domainfrac(n) * (rtmCTL%area(n)*0.001_r8)
+       else
+        rtmCTL%qdem(n,nliq) = 0.0_r8
+       endif
        rtmCTL%qsur(n,nfrz) = fptr(index_x2r_Flrl_rofi,n2) * (rtmCTL%area(n)*0.001_r8)
        rtmCTL%qsub(n,nfrz) = 0.0_r8
        rtmCTL%qgwl(n,nfrz) = 0.0_r8

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -596,7 +596,11 @@ contains
        else
           rtmCTL%qdto(n,nliq) = 0.0_r8
        endif
-       rtmCTL%qdem(n,nliq) = x2r_r%rAttr(index_x2r_Flrl_demand,n2) / TUnit%domainfrac(n) * (rtmCTL%area(n)*0.001_r8)
+       if (wrmflag) then
+          rtmCTL%qdem(n,nliq) = x2r_r%rAttr(index_x2r_Flrl_demand,n2) / TUnit%domainfrac(n) * (rtmCTL%area(n)*0.001_r8)
+       else
+          rtmCTL%qdem(n,nliq) = 0.0_r8
+       endif
        rtmCTL%qsur(n,nfrz) = x2r_r%rAttr(index_x2r_Flrl_rofi,n2) * (rtmCTL%area(n)*0.001_r8)
        rtmCTL%qsub(n,nfrz) = 0.0_r8
        rtmCTL%qgwl(n,nfrz) = 0.0_r8

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -21,7 +21,7 @@ module rof_comp_mct
                                 seq_infodata_start_type_start, seq_infodata_start_type_cont,   &
                                 seq_infodata_start_type_brnch
   use seq_comm_mct     , only : seq_comm_suffix, seq_comm_inst, seq_comm_name
-  use RunoffMod        , only : rtmCTL, TRunoff, THeat
+  use RunoffMod        , only : rtmCTL, TRunoff, THeat, TUnit
   use RtmVar           , only : rtmlon, rtmlat, ice_runoff, iulog, &
                                 nsrStartup, nsrContinue, nsrBranch, & 
                                 inst_index, inst_suffix, inst_name, RtmVarSet, wrmflag, heatflag
@@ -596,7 +596,7 @@ contains
        else
           rtmCTL%qdto(n,nliq) = 0.0_r8
        endif
-       rtmCTL%qdem(n,nliq) = x2r_r%rAttr(index_x2r_Flrl_demand,n2) * (rtmCTL%area(n)*0.001_r8)
+       rtmCTL%qdem(n,nliq) = x2r_r%rAttr(index_x2r_Flrl_demand,n2) / TUnit%domainfrac(n) * (rtmCTL%area(n)*0.001_r8)
        rtmCTL%qsur(n,nfrz) = x2r_r%rAttr(index_x2r_Flrl_rofi,n2) * (rtmCTL%area(n)*0.001_r8)
        rtmCTL%qsub(n,nfrz) = 0.0_r8
        rtmCTL%qgwl(n,nfrz) = 0.0_r8

--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -482,6 +482,7 @@ MODULE MOSART_physics_mod
        call estimate_returnflow_deficit()
        if (ctlSubwWRM%ExtractionFlag > 0) then
           StorWater%deficit = StorWater%demand
+          StorWater%deficit = StorWater%deficit/Tctl%DeltaT !change it back from mm/timestep to mm/s for output
        endif
        call t_stopf('mosartr_wrm_estrfdef')
     endif

--- a/components/mosart/src/riverroute/RtmHistFlds.F90
+++ b/components/mosart/src/riverroute/RtmHistFlds.F90
@@ -164,7 +164,7 @@ contains
          avgflag='A', long_name='WRM supply provided ', &
          ptr_rof=StorWater%Supply, default='active')                                                                                                                              
 
-      call RtmHistAddfld (fname='WRM_DEMAND', units='m3/s',  &
+      call RtmHistAddfld (fname='WRM_DEMAND', units='m3/timestep',  &
          avgflag='A', long_name='WRM new demand after supply: same as deficit ', &
          ptr_rof=StorWater%demand, default='active')
 
@@ -172,7 +172,7 @@ contains
          avgflag='A', long_name='WRM demand requested ', &
          ptr_rof=StorWater%demand0, default='active')
 
-      call RtmHistAddfld (fname='WRM_DEFICIT', units='m3/s',  &
+      call RtmHistAddfld (fname='WRM_DEFICIT', units='m3/timestep',  &
          avgflag='A', long_name='WRM deficit ', &
          ptr_rof=StorWater%deficit, default='active')
 

--- a/components/mosart/src/riverroute/RtmHistFlds.F90
+++ b/components/mosart/src/riverroute/RtmHistFlds.F90
@@ -160,19 +160,15 @@ contains
 
     if (wrmflag) then
 
-      call RtmHistAddfld (fname='WRM_SUPPLY', units='m3/s',  &
+      call RtmHistAddfld (fname='WRM_IRR_SUPPLY', units='m3/s',  &
          avgflag='A', long_name='WRM supply provided ', &
          ptr_rof=StorWater%Supply, default='active')                                                                                                                              
 
-      call RtmHistAddfld (fname='WRM_DEMAND', units='m3/timestep',  &
-         avgflag='A', long_name='WRM new demand after supply: same as deficit ', &
-         ptr_rof=StorWater%demand, default='active')
-
-      call RtmHistAddfld (fname='WRM_DEMAND0', units='m3/s',  &
+      call RtmHistAddfld (fname='WRM_IRR_DEMAND', units='m3/s',  &
          avgflag='A', long_name='WRM demand requested ', &
          ptr_rof=StorWater%demand0, default='active')
 
-      call RtmHistAddfld (fname='WRM_DEFICIT', units='m3/timestep',  &
+      call RtmHistAddfld (fname='WRM_IRR_DEFICIT', units='m3/s',  &
          avgflag='A', long_name='WRM deficit ', &
          ptr_rof=StorWater%deficit, default='active')
 

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -3267,6 +3267,13 @@ contains
         else
            call shr_sys_abort(subname//' Tunit mask error')
         endif
+        
+        if (Tunit%domainfrac(n) == 0) then
+          Tunit%domainfrac(n) = 1
+        elseif (Tunit%domainfrac(n) < 0) then
+          write(iulog,*) subname,' ERROR domain frac < 0',n,Tunit%domainfrac(n)
+          call shr_sys_abort(subname//' Tunit domainfrac error')
+        endif
      enddo
 
      allocate(TUnit%ID0(begr:endr))  

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -3233,12 +3233,14 @@ contains
      if (masterproc) write(iulog,FORMR) trim(subname),' read frac ',minval(Tunit%frac),maxval(Tunit%frac)
      call shr_sys_flush(iulog)
      
-     allocate(TUnit%domainfrac(begr:endr))
-     ier = pio_inq_varid(ncid, name='domainfrac', vardesc=vardesc)
-     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%domainfrac, ier)
-     if (masterproc) write(iulog,FORMR) trim(subname),' read domainfrac ',minval(Tunit%domainfrac),maxval(Tunit%domainfrac)
-     call shr_sys_flush(iulog)
-
+     if (wrmflag) then
+       allocate(TUnit%domainfrac(begr:endr))
+       ier = pio_inq_varid(ncid, name='domainfrac', vardesc=vardesc)
+       call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%domainfrac, ier)
+       if (masterproc) write(iulog,FORMR) trim(subname),' read domainfrac ',minval(Tunit%domainfrac),maxval(Tunit%domainfrac)
+       call shr_sys_flush(iulog)
+     endif
+     
      ! read fdir, convert to mask
      ! fdir <0 ocean, 0=outlet, >0 land
      ! tunit mask is 0=ocean, 1=land, 2=outlet for mosart calcs
@@ -3267,13 +3269,15 @@ contains
         else
            call shr_sys_abort(subname//' Tunit mask error')
         endif
-        
+       
+       if (wrmflag) then       
         if (Tunit%domainfrac(n) == 0) then
           Tunit%domainfrac(n) = 1
         elseif (Tunit%domainfrac(n) < 0) then
           write(iulog,*) subname,' ERROR domain frac < 0',n,Tunit%domainfrac(n)
           call shr_sys_abort(subname//' Tunit domainfrac error')
         endif
+       endif
      enddo
 
      allocate(TUnit%ID0(begr:endr))  

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -2742,7 +2742,6 @@ contains
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input subsurf = ',nt,budget_global(br_qsub,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input gwl     = ',nt,budget_global(br_qgwl,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input dto     = ',nt,budget_global(br_qdto,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input demand -not included-  = ',nt,budget_global(br_qdem,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' * input total   = ',nt,budget_input
           if (output_all_budget_terms) then
             write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x input check   = ',nt,budget_input - &
@@ -3232,6 +3231,12 @@ contains
      ier = pio_inq_varid(ncid, name='frac', vardesc=vardesc)
      call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%frac, ier)
      if (masterproc) write(iulog,FORMR) trim(subname),' read frac ',minval(Tunit%frac),maxval(Tunit%frac)
+     call shr_sys_flush(iulog)
+     
+     allocate(TUnit%domainfrac(begr:endr))
+     ier = pio_inq_varid(ncid, name='domainfrac', vardesc=vardesc)
+     call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%domainfrac, ier)
+     if (masterproc) write(iulog,FORMR) trim(subname),' read domainfrac ',minval(Tunit%domainfrac),maxval(Tunit%domainfrac)
      call shr_sys_flush(iulog)
 
      ! read fdir, convert to mask

--- a/components/mosart/src/riverroute/RunoffMod.F90
+++ b/components/mosart/src/riverroute/RunoffMod.F90
@@ -222,6 +222,7 @@ module RunoffMod
      real(r8), pointer :: rlenTotal(:) ! length of all reaches, [m]
      real(r8), pointer :: Gxr(:)       ! drainage density within the cell, [1/m]
      real(r8), pointer :: frac(:)      ! fraction of cell included in the study area, [-]
+     real(r8), pointer :: domainfrac(:)! fraction of cell included in the study area from domain file, [-]
      logical , pointer :: euler_calc(:)! flag for calculating tracers in euler
 
      ! hillslope properties

--- a/components/mosart/src/wrm/WRM_modules.F90
+++ b/components/mosart/src/wrm/WRM_modules.F90
@@ -1022,7 +1022,7 @@ MODULE WRM_modules
 
         if (iter > 2) done = .true.
 
-        if (masterproc) write(iulog,'(2a,i6,g20.10,l4)') subname,' iteration ',iter,sum(dam_uptake_sum),done
+        !if (masterproc) write(iulog,'(2a,i6,g20.10,l4)') subname,' iteration ',iter,sum(dam_uptake_sum),done
 
      enddo
 


### PR DESCRIPTION
Allow `do_transient_crops = T` to take effect when prognostic crop model is turned off.
In addition to the dynamic crop fraction, this PR also corrects the inconsistency between
land domain file and MOSART input parameter, in terms of land fraction along the coastal line. 
Without this fix, the irrigation demand at coastal grid will be incorrectly assigned in MOSART.

[BFB]