### PR TITLE
Set PIO_ROOT=1 for ne30-coupled cases on sandiatoss3

### DIFF
--- a/cime_config/machines/config_pio.xml
+++ b/cime_config/machines/config_pio.xml
@@ -28,15 +28,13 @@
   <entry id="PIO_STRIDE">
     <values>
       <value>$MAX_MPITASKS_PER_NODE</value>
-      <value mach="yellowstone" grid="a%ne120.+oi%gx1">60</value>
-      <value mach="mira|cetus">128</value>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">-99</value>
     </values>
   </entry>
 
   <entry id="PIO_ROOT">
     <values>
       <value>0</value>
+      <value mach="sandiatoss3" grid="a%ne30" compset=".*EAM.+MPAS.*">1</value>
     </values>
   </entry>
 
@@ -51,6 +49,7 @@
   <entry id="PIO_TYPENAME">
     <values>
       <value>pnetcdf</value>
+      <value mpilib="mpi-serial">netcdf</value>
       <value mach="userdefined">netcdf</value>
       <value mach="melvin">netcdf</value>
       <value mach="mappy">netcdf</value>
@@ -66,7 +65,6 @@
       <value mach="cades">netcdf</value>
       <value mach="grizzly">netcdf</value>
       <value mach="badger">netcdf</value>
-      <value mpilib="mpi-serial">netcdf</value>
       <value mach="bebop" mpilib="impi" compset=".*CAM5.+MPAS.*">netcdf</value>
     </values>
   </entry>
@@ -118,11 +116,11 @@
   </entry>
   -->
 
-  <entry id="OCN_PIO_NUMTASKS">
+  <!--entry id="OCN_PIO_NUMTASKS">
     <values>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">16</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
   <!--- uncomment and fill in relevant sections
   <entry id="OCN_PIO_TYPENAME">
@@ -155,11 +153,11 @@
   </entry>
   -->
 
-  <entry id="LND_PIO_NUMTASKS">
+  <!--entry id="LND_PIO_NUMTASKS">
     <values>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">16</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
   <entry id="LND_PIO_TYPENAME">
     <values>
@@ -184,11 +182,11 @@
   </entry>
   -->
 
-  <entry id="ROF_PIO_NUMTASKS">
+  <!--entry id="ROF_PIO_NUMTASKS">
     <values>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">16</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
   <!--- uncomment and fill in relevant sections
   <entry id="ROF_PIO_TYPENAME">
@@ -214,11 +212,11 @@
   </entry>
   -->
 
-  <entry id="ICE_PIO_NUMTASKS">
+  <!--entry id="ICE_PIO_NUMTASKS">
     <values>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">16</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
   <!--- uncomment and fill in relevant sections
   <entry id="ICE_PIO_TYPENAME">
@@ -244,11 +242,11 @@
   </entry>
   -->
 
-  <entry id="ATM_PIO_NUMTASKS">
+  <!--entry id="ATM_PIO_NUMTASKS">
     <values>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">16</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
   <entry id="ATM_PIO_TYPENAME">
     <values>
@@ -272,17 +270,17 @@
   </entry>
   -->
 
-  <entry id="CPL_PIO_NUMTASKS">
+  <!--entry id="CPL_PIO_NUMTASKS">
     <values>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">16</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
-  <entry id="CPL_PIO_TYPENAME">
+  <!--entry id="CPL_PIO_TYPENAME">
     <values>
-      <value mach="mira" grid="a%ne120">netcdf</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
   <!--- uncomment and fill in relevant sections
   <entry id="GLC_PIO_STRIDE">
@@ -300,11 +298,11 @@
   </entry>
   -->
 
-  <entry id="GLC_PIO_NUMTASKS">
+  <!--entry id="GLC_PIO_NUMTASKS">
     <values>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">1</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
   <!--- uncomment and fill in relevant sections
   <entry id="GLC_PIO_TYPENAME">
@@ -330,11 +328,11 @@
   </entry>
   -->
 
-  <entry id="WAV_PIO_NUMTASKS">
+  <!--entry id="WAV_PIO_NUMTASKS">
     <values>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">1</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
   <!--- uncomment and fill in relevant sections
   <entry id="WAV_PIO_TYPENAME">
@@ -360,11 +358,11 @@
   </entry>
   -->
 
-  <entry id="ESP_PIO_NUMTASKS">
+  <!--entry id="ESP_PIO_NUMTASKS">
     <values>
-      <value mach="mira" grid="a%ne120" compset=".*CAM5.+MPASO.*">1</value>
+      <value></value>
     </values>
-  </entry>
+  </entry-->
 
   <!--- uncomment and fill in relevant sections
   <entry id="ESP_PIO_TYPENAME">


### PR DESCRIPTION
Set PIO_ROOT=1 for ne30-coupled cases on sandiatoss3 to avoid MEMLEAK test issues.

Fixes E3SM-Project/E3SM#3934

[NML] - due to pio_root changes