### PR TITLE
Eliminate call-by-reference argument error in call to proc_heap_adjust

### DIFF
--- a/components/eam/src/physics/cam/phys_grid.F90
+++ b/components/eam/src/physics/cam/phys_grid.F90
@@ -6384,6 +6384,9 @@ logical function phys_grid_initialized ()
             proc_heap_remove = .true.
          endif
          if ((proc_heap_update) .or. (proc_heap_remove)) then
+            ! Pass scalar 'updated' to 'proc_heap_adjust' instead of
+            ! 'inv_proc_heap(ntmp2)' to prevent this argument from changing
+            ! value when 'inv_proc_heap' is modified inside of 'proc_heap_adjust'
             updated = inv_proc_heap(ntmp2)
             call proc_heap_adjust(updated, proc_heap_remove,   &
                                   max_nvsmptasks, proc_heap_len, proc_heap, &

--- a/components/eam/src/physics/cam/phys_grid.F90
+++ b/components/eam/src/physics/cam/phys_grid.F90
@@ -6488,9 +6488,9 @@ logical function phys_grid_initialized ()
    integer :: proc_last    ! process id of last element
    integer :: proc_updated ! process id of updated element
    integer :: proc_i       ! process id of current element
-   real(r8):: proc_ip      ! process id of parent of current element
-   real(r8):: proc_il      ! process id of left child of current element
-   real(r8):: proc_ir      ! process id of right child of current
+   integer :: proc_ip      ! process id of parent of current element
+   integer :: proc_il      ! process id of left child of current element
+   integer :: proc_ir      ! process id of right child of current
                            !  element
 
    integer :: last_nonleaf ! index of last non-leaf in heap

--- a/components/eam/src/physics/cam/phys_grid.F90
+++ b/components/eam/src/physics/cam/phys_grid.F90
@@ -6154,6 +6154,9 @@ logical function phys_grid_initialized ()
    integer :: max_nvsmptasks             ! maximum number of processes associated
                                          !  with any virtual SMP
    integer :: proc_heap_len              ! current process heap length
+   integer :: updated                    ! index in heap for process whose cost has
+                                         !  been updated or which needs to be
+                                         !  removed from the heap
    integer, dimension(:), allocatable  :: proc_heap
                                          ! process heap to process id map
    integer, dimension(:), allocatable  :: inv_proc_heap
@@ -6381,7 +6384,8 @@ logical function phys_grid_initialized ()
             proc_heap_remove = .true.
          endif
          if ((proc_heap_update) .or. (proc_heap_remove)) then
-            call proc_heap_adjust(inv_proc_heap(ntmp2), proc_heap_remove,   &
+            updated = inv_proc_heap(ntmp2)
+            call proc_heap_adjust(updated, proc_heap_remove,   &
                                   max_nvsmptasks, proc_heap_len, proc_heap, &
                                   proc_cost, inv_proc_heap)
          endif


### PR DESCRIPTION
a) Replace array reference argument with a scalar

The call to

  call proc_heap_adjust(inv_proc_heap(ntmp2), proc_heap_remove,   &
                        max_nvsmptasks, proc_heap_len, proc_heap, &
                        proc_cost, inv_proc_heap)

in phys_grid.F90 where

  subroutine proc_heap_adjust(updated, remove, heap_dlen, &
                              heap_len, heap, cost, inv_heap)
  ...
  integer, intent(in)     :: updated
  ...
  integer, intent(inout)  :: inv_heap(0:npes-1)

modifies 'inv_heap' in the routine proc_heap_adjust, and changes the
value at the location 'inv_proc_heap(ntmp2)'. Compilation with
optimization greater than -O0 apparently caches this value (since it
is declared 'intent(in)'), so 'updated' is not changed within the
scope of the 'proc_heap_adjust' routine. -O0 compilation does not,
changing the value on 'updated' internally when 'inv_proc_heap(ntmp2)'
is changed, which causes a failure. This bug is fixed by changing
the call as follows:

  integer :: updated
  ...
  updated = inv_proc_heap(ntmp2)
  call proc_heap_adjust(updated, proc_heap_remove,   &
                        max_nvsmptasks, proc_heap_len, proc_heap, &
                        proc_cost, inv_proc_heap)

b) Fix mis-declared variables

The local variables 

   real(r8):: proc_ip      ! process id of parent of current element
   real(r8):: proc_il      ! process id of left child of current element
   real(r8):: proc_ir      ! process id of right child of current element

in the routine proc_heap_adjust in phys_grid.F90 are mis-declared. These
should be integer (though the error is innocuous except for the Cray
compiler).

[BFB]

Fixes #3961 
