### PR TITLE
Update production test for v2

### DIFF
--- a/cime_config/testmods_dirs/allactive/wcprod/README
+++ b/cime_config/testmods_dirs/allactive/wcprod/README
@@ -1,0 +1,6 @@
+These modifications should result in a case that has the same namelist settings as the
+water cycle production sims
+
+Run these for at least 1 day to see all output.
+Also use the CMIP6 compsets.
+If running longer, change the nhtfrq for the first history file.

--- a/cime_config/testmods_dirs/allactive/wcprod/shell_commands
+++ b/cime_config/testmods_dirs/allactive/wcprod/shell_commands
@@ -1,0 +1,5 @@
+#!/bin/bash
+./xmlchange CAM_TARGET=theta-l
+./xmlchange --append CAM_CONFIG_OPTS='-cosp'
+./xmlchange --id BUDGETS --val TRUE
+

--- a/cime_config/testmods_dirs/allactive/wcprod/user_nl_eam
+++ b/cime_config/testmods_dirs/allactive/wcprod/user_nl_eam
@@ -1,0 +1,96 @@
+! Users should add all user specific namelist changes below in the form of 
+! namelist_var = new_namelist_value 
+ 
+ nhtfrq =   -24,-24,-6,-6,-3,-24
+ mfilt  = 1,30,120,120,240,30
+ avgflag_pertape = 'A','A','I','A','A','A'
+ fexcl1 = 'CFAD_SR532_CAL'
+ fincl1 = 'extinct_sw_inp','extinct_lw_bnd7','extinct_lw_inp','CLD_CAL', 'TREFMNAV', 'TREFMXAV'
+ fincl2 = 'FLUT','PRECT','U200','V200','U850','V850','Z500','OMEGA500','UBOT','VBOT','TREFHT','TREFHTMN','TREFHTMX','QREFHT','TS','PS','TMQ','TUQ','TVQ','TOZ'
+ fincl3 = 'PSL','T200','T500','U850','V850','UBOT','VBOT','TREFHT'
+ fincl4 = 'FLUT','U200','U850','PRECT','OMEGA500'
+ fincl5 = 'PRECT','PRECC'
+ fincl6 = 'CLDTOT_ISCCP','MEANCLDALB_ISCCP','MEANTAU_ISCCP','MEANPTOP_ISCCP','MEANTB_ISCCP','CLDTOT_CAL','CLDTOT_CAL_LIQ','CLDTOT_CAL_ICE','CLDTOT_CAL_UN','CLDHGH_CAL','CLDHGH_CAL_LIQ','CLDHGH_CAL_ICE','CLDHGH_CAL_UN','CLDMED_CAL','CLDMED_CAL_LIQ','CLDMED_CAL_ICE','CLDMED_CAL_UN','CLDLOW_CAL','CLDLOW_CAL_LIQ','CLDLOW_CAL_ICE','CLDLOW_CAL_UN'
+
+ ieflx_opt = 2 ! =0 AMIP simulations, = 2 for coupled
+ zmconv_trigdcape_ull = .true.
+ ice_sed_ai = 500
+ cld_sed   = 1.0D0
+ effgw_beres  = 0.35
+ gw_convect_hcf  = 12.5
+ effgw_oro  = 0.375
+ zmconv_dmpdz  = -0.7e-3 
+ clubb_c14   = 2.5D0      
+ 
+ clubb_tk1 = 253.15D0
+ dust_emis_fact =  1.50D0
+ linoz_psc_T = 197.5
+
+!!Nc_min
+ micro_mincdnc = 10.D6
+!
+!- v1p tuning
+!
+ clubb_c1               = 2.4        !! same as in alpha22
+ clubb_c11              = 0.70       !! same as in alpha22
+ clubb_c11b             = 0.20       !! same as in alpha22
+ clubb_c11c             = 0.85       !! same as in alpha22
+! clubb_c14              = 2.0D0      !! same as in alpha22
+ clubb_c1b              = 2.8        !! same as in alpha22
+ clubb_c1c              = 0.75       !! same as in alpha22
+ clubb_c6rtb            = 7.50       !! same as in alpha22
+ clubb_c6rtc            = 0.50       !! same as in alpha22
+ clubb_c6thlb           = 7.50       !! same as in alpha22
+ clubb_c6thlc           = 0.50       !! same as in alpha22
+ clubb_c8               = 5.2        !! same as in alpha22
+ clubb_c_k10            = 0.35       !! same as in alpha22
+ clubb_c_k10h           = 0.35       !! should be the same as clubb_c_k10
+ clubb_gamma_coef       = 0.12D0     !! same as in alpha22
+ clubb_gamma_coefb      = 0.28D0     !! same as in alpha22
+ clubb_gamma_coefc      = 1.2        !! same as in alpha22
+ clubb_mu               = 0.0005     !! same as in alpha22
+ clubb_wpxp_l_thresh    = 100.0D0    !! same as in alpha22
+ clubb_ice_deep         = 14.e-6     !! same as in alpha22
+ clubb_ice_sh           = 50.e-6     !! same as in default
+ clubb_liq_deep         = 8.e-6      !! same as in default
+ clubb_liq_sh           = 10.e-6     !! same as in default
+ clubb_C2rt             = 1.75D0     !! same as in default
+ clubb_use_sgv          = .true.
+ seasalt_emis_scale     = 0.6
+!
+!- zm
+!
+ zmconv_c0_lnd          = 0.0020     !! 0.007 in default
+ zmconv_c0_ocn          = 0.0020     !! 0.007 in default
+! zmconv_dmpdz           =-1.2e-3     !! -0.7e-3 in default
+ zmconv_ke              = 5.0E-6     !! same as in default
+ zmconv_alfa            = 0.14D0
+ zmconv_tp_fac          = 2.0D0
+ zmconv_tiedke_add      = 0.8D0      !! same as in default
+ zmconv_cape_cin        = 1          !! same as in default
+ zmconv_mx_bot_lyr_adj  = 1          !! 2 in default
+!
+!- microphysics
+!
+!
+ prc_coef1               = 30500.0D0 !! same as in default
+ prc_exp                 = 3.19D0    !! same as in default
+ prc_exp1                = -1.40D0   !! -1.2D0  in default
+ micro_mg_accre_enhan_fac = 1.75D0   !! 1.5D0   in default
+ microp_aero_wsubmin     = 0.001D0   !! was missing
+ so4_sz_thresh_icenuc    = 0.080e-6  !! 0.05e-6 in default
+ relvar_fix              = .true.    !! same as in default
+ mg_prc_coeff_fix        = .true.    !! same as in default
+ rrtmg_temp_fix          = .true.    !! same as in default
+ micro_mg_berg_eff_factor = 0.7D0    !! same in v1p and alpha22
+! ice_sed_ai              = 1200.0    !! 500.0   in default
+! cld_sed                 = 1.8D0
+ cldfrc_dp1              = 0.018D0   !! alpha22 0.1D0
+! effgw_oro               = 0.25      !! same as in default
+! effgw_beres             = 0.4       !! same as in default
+ do_tms                  = .false.   !! same as in default
+ cldfrc2m_rhmaxi         = 1.05D0    !! same as in default
+ n_so4_monolayers_pcage  = 8.0D0     !! same as in default
+ taubgnd                 = 2.5D-3    !! same as in default
+ raytau0                 = 5.0D0     !! same as in default 
+

--- a/cime_config/testmods_dirs/allactive/wcprod/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprod/user_nl_elm
@@ -1,0 +1,26 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of 
+! namelist_var = new_namelist_value 
+!
+! Include namelist variables for drv_flds_in ONLY if -megan and/or -drydep options
+! are set in the CLM_NAMELIST_OPTS env variable.
+!
+! EXCEPTIONS: 
+! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting
+! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting
+! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting
+! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting
+! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting
+! Set irrigate           by the CLM_BLDNML_OPTS -irrig           setting
+! Set co2_ppmv           with CCSM_CO2_PPMV                      option
+! Set dtime              with L_NCPL                             option
+! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options
+! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases
+!                        (includes $inst_string for multi-ensemble cases)
+! Set glc_grid           with CISM_GRID                          option
+! Set glc_smb            with GLC_SMB                            option
+! Set maxpatch_glcmec    with GLC_NEC                            option
+! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable
+!----------------------------------------------------------------------------------
+
+ finidat = ' '

--- a/cime_config/testmods_dirs/allactive/wcprod/user_nl_mpaso
+++ b/cime_config/testmods_dirs/allactive/wcprod/user_nl_mpaso
@@ -1,0 +1,21 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes after these comments 
+! in the form of 
+!   namelist_var = new_namelist_value 
+! *** EXCEPT FOR ***
+! 1. DO NOT CHANGE config_start_time, config_run_duration, config_stop_time,
+!    config_do_restart, config_Restart_timestamp_filename, config_calendar_type, 
+!    config_set_restingThickness_to_IC, config_alter_ICs_for_pbcs 
+! 2. To preview the namelists, invoke $CASEROOT preview-namelists and look at 
+!    $CASEROOT/CaseDocs/mpaso_in
+!
+!
+! Users cannot use this file to configure streams. In order to configure streams, 
+! write a stream configuration file, and place it in 
+! SourceMods/src.mpaso/streams.ocean
+!----------------------------------------------------------------------------------
+
+ config_gm_closure = 'constant'
+ config_eddying_resolution_taper = 'none'
+ config_use_redi = .true.
+ config_am_mocstreamfunction_enable = .false.

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -92,8 +92,8 @@ _TESTS = {
     #atmopheric tests to mimic low res production runs
     "e3sm_atm_prod" : {
         "tests" : (
-            "SMS_Ln5.ne30_ne30.FC5AV1C-L.eam-cosplite",
-            "SMS.ne30_r05_ne30.F20TRC5-CMIP6",
+            "SMS_Ln5.ne30pg2_r05_oECv3.F2010SC5-CMIP6.eam-wcprod",
+            "SMS.ne30pg2_r05_oECv3.F20TRC5-CMIP6.eam-wcprod",
             )
         },
 
@@ -211,7 +211,7 @@ _TESTS = {
     #e3sm tests to mimic production runs
     "e3sm_prod" : {
         "inherit" : "e3sm_atm_prod",
-        "tests"   : "SMS_Ld1.ne30pg2_r05_EC30to60E2r2-1900_ICG.A_WCYCL1850S_CMIP6"
+        "tests"   : "SMS_Ld1.ne30pg2_r05_EC30to60E2r2-1900_ICG.A_WCYCL1850S_CMIP6.allactive-wcprod"
         },
 
     #e3sm tests to mimic BGC production runs

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod/shell_commands
@@ -1,0 +1,4 @@
+#!/bin/bash
+./xmlchange CAM_TARGET=theta-l
+./xmlchange --append CAM_CONFIG_OPTS='-cosp'
+

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod/user_nl_eam
@@ -1,0 +1,81 @@
+ieflx_opt = 0 ! =0 AMIP simulations, = 2 for coupled
+
+zmconv_trigdcape_ull = .true.
+ice_sed_ai = 500
+cld_sed   = 1.0D0
+effgw_beres  = 0.35
+gw_convect_hcf  = 12.5
+effgw_oro  = 0.375
+zmconv_dmpdz  = -0.7e-3
+clubb_c14   = 2.5D0
+
+clubb_tk1 = 253.15D0
+dust_emis_fact =  1.50D0
+linoz_psc_T = 197.5
+
+!!Nc_min
+micro_mincdnc = 10.D6
+!
+!- v1p tuning
+!
+clubb_c1               = 2.4        !! same as in alpha22
+clubb_c11              = 0.70       !! same as in alpha22
+clubb_c11b             = 0.20       !! same as in alpha22
+clubb_c11c             = 0.85       !! same as in alpha22
+! clubb_c14              = 2.0D0      !! same as in alpha22
+clubb_c1b              = 2.8        !! same as in alpha22
+clubb_c1c              = 0.75       !! same as in alpha22
+clubb_c6rtb            = 7.50       !! same as in alpha22
+clubb_c6rtc            = 0.50       !! same as in alpha22
+clubb_c6thlb           = 7.50       !! same as in alpha22
+clubb_c6thlc           = 0.50       !! same as in alpha22
+clubb_c8               = 5.2        !! same as in alpha22
+clubb_c_k10            = 0.35       !! same as in alpha22
+clubb_c_k10h           = 0.35       !! should be the same as clubb_c_k10
+clubb_gamma_coef       = 0.12D0     !! same as in alpha22
+clubb_gamma_coefb      = 0.28D0     !! same as in alpha22
+clubb_gamma_coefc      = 1.2        !! same as in alpha22
+clubb_mu               = 0.0005     !! same as in alpha22
+clubb_wpxp_l_thresh    = 100.0D0    !! same as in alpha22
+clubb_ice_deep         = 14.e-6     !! same as in alpha22
+clubb_ice_sh           = 50.e-6     !! same as in default
+clubb_liq_deep         = 8.e-6      !! same as in default
+clubb_liq_sh           = 10.e-6     !! same as in default
+clubb_C2rt             = 1.75D0     !! same as in default
+clubb_use_sgv          = .true.
+seasalt_emis_scale     = 0.6
+!
+!- zm
+!
+zmconv_c0_lnd          = 0.0020     !! 0.007 in default
+zmconv_c0_ocn          = 0.0020     !! 0.007 in default
+! zmconv_dmpdz           =-1.2e-3     !! -0.7e-3 in default
+zmconv_ke              = 5.0E-6     !! same as in default
+zmconv_alfa            = 0.14D0
+zmconv_tp_fac          = 2.0D0
+zmconv_tiedke_add      = 0.8D0      !! same as in default
+zmconv_cape_cin        = 1          !! same as in default
+zmconv_mx_bot_lyr_adj  = 1          !! 2 in default
+!
+!- microphysics
+!
+prc_coef1               = 30500.0D0 !! same as in default
+prc_exp                 = 3.19D0    !! same as in default
+prc_exp1                = -1.40D0   !! -1.2D0  in default
+micro_mg_accre_enhan_fac = 1.75D0   !! 1.5D0   in default
+microp_aero_wsubmin     = 0.001D0   !! was missing
+so4_sz_thresh_icenuc    = 0.080e-6  !! 0.05e-6 in default
+relvar_fix              = .true.    !! same as in default
+mg_prc_coeff_fix        = .true.    !! same as in default
+rrtmg_temp_fix          = .true.    !! same as in default
+micro_mg_berg_eff_factor = 0.7D0    !! same in v1p and alpha22
+! ice_sed_ai              = 1200.0    !! 500.0   in default
+! cld_sed                 = 1.8D0
+cldfrc_dp1              = 0.018D0   !! alpha22 0.1D0
+! effgw_oro               = 0.25      !! same as in default
+! effgw_beres             = 0.4       !! same as in default
+do_tms                  = .false.   !! same as in default
+cldfrc2m_rhmaxi         = 1.05D0    !! same as in default
+n_so4_monolayers_pcage  = 8.0D0     !! same as in default
+taubgnd                 = 2.5D-3    !! same as in default
+raytau0                 = 5.0D0     !! same as in default

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod/user_nl_elm
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod/user_nl_elm
@@ -1,0 +1,28 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of 
+! namelist_var = new_namelist_value 
+!
+! Include namelist variables for drv_flds_in ONLY if -megan and/or -drydep options
+! are set in the CLM_NAMELIST_OPTS env variable.
+!
+! EXCEPTIONS: 
+! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting
+! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting
+! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting
+! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting
+! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting
+! Set irrigate           by the CLM_BLDNML_OPTS -irrig           setting
+! Set co2_ppmv           with CCSM_CO2_PPMV                      option
+! Set dtime              with L_NCPL                             option
+! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options
+! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases
+!                        (includes $inst_string for multi-ensemble cases)
+! Set glc_grid           with CISM_GRID                          option
+! Set glc_smb            with GLC_SMB                            option
+! Set maxpatch_glcmec    with GLC_NEC                            option
+! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable
+!----------------------------------------------------------------------------------
+check_finidat_year_consistency = .false.
+fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c190418.nc'
+flanduse_timeseries = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/landuse.timeseries_0.5x0.5_hist_simyr1850-2015_c191004.nc'
+finidat = ' '


### PR DESCRIPTION
Update the 2 atm-only and 1 fully coupled cases in the production suite to
use v2 settings.  Use tri-grid resolutions and CMIP6 compsets for all.
Also use a test mod that will turn on theta-l and other settings being used
in v2 testing.

[BFB]