### PR TITLE
Changes NTASKS for ELM-USRDAT test

### DIFF
--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/usrdat/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/usrdat/shell_commands
@@ -3,4 +3,5 @@
 ./xmlchange LND_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
 ./xmlchange ATM_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
 ./xmlchange DATM_CLMNCEP_YR_END=1948
+./xmlchange NTASKS=1
 


### PR DESCRIPTION
ELM-USRDAT is a single-point test, so NTASKS are set to 1.

[BFB]