### PR TITLE
Bug fix to account for snow backscattering in COSPv2

### DIFF
--- a/components/eam/src/physics/cosp2/optics/cosp_optics.F90
+++ b/components/eam/src/physics/cosp2/optics/cosp_optics.F90
@@ -462,10 +462,12 @@ contains
        ! Ice
        betatot_ice(1:npoints,icol,1:nlev) = betatot_ice(1:npoints,icol,1:nlev)+ &
             kp_part(1:npoints,1:nlev,INDX_LSICE)*alpha_part(1:npoints,1:nlev,INDX_LSICE)+ &
-            kp_part(1:npoints,1:nlev,INDX_CVICE)*alpha_part(1:npoints,1:nlev,INDX_CVICE)
+            kp_part(1:npoints,1:nlev,INDX_CVICE)*alpha_part(1:npoints,1:nlev,INDX_CVICE)+ &
+            kp_part(1:npoints,1:nlev,INDX_LSSNOW)*alpha_part(1:npoints,1:nlev,INDX_LSSNOW)
        tautot_ice(1:npoints,icol,1:nlev) = tautot_ice(1:npoints,icol,1:nlev)  + &
             tau_part(1:npoints,1:nlev,INDX_LSICE) + &
-            tau_part(1:npoints,1:nlev,INDX_CVICE)
+            tau_part(1:npoints,1:nlev,INDX_CVICE) + &
+            tau_part(1:npoints,1:nlev,INDX_LSSNOW)
           
        ! Liquid
        betatot_liq(1:npoints,icol,1:nlev) = betatot_liq(1:npoints,icol,1:nlev)+ &


### PR DESCRIPTION
Fix a bug related to the calculation of separated ice attenuated
backscatter in lidar simulator. The issue was found by Greg Cesana.

The snow is not well accounted for in the separated ice and liquid
attenuated backscatter signal. It has to do with the "npart" indices.
The snow index is 5 and is not accounted for in COSPv2.  This has
potentially large impact on cloud phase diagnostics from the
lidar simulator.

[BFB] except for COSP diagnostics