### PR TITLE
Bug fix to account for snow backscattering in COSPv1.4

### DIFF
--- a/components/cam/src/physics/cosp/actsim/lidar_simulator.F90
+++ b/components/cam/src/physics/cosp/actsim/lidar_simulator.F90
@@ -485,7 +485,9 @@ pnorm_perp_tot(:,:)=0
            betatot_ice(:,:) = betatot_ice(:,:)+ kp_part(:,:,i)*alpha_part(:,:,i)
            tautot_ice(:,:) = tautot_ice(:,:)  + tau_part(:,:,i)
       ENDDO ! i
-      DO i = 1, npart,2
+      betatot_ice(:,:) = betatot_ice(:,:)+ kp_part(:,:,5)*alpha_part(:,:,5)
+      tautot_ice(:,:) = tautot_ice(:,:)  + tau_part(:,:,5)
+      DO i = 1, npart-1,2
            betatot_liq(:,:) = betatot_liq(:,:)+ kp_part(:,:,i)*alpha_part(:,:,i)
            tautot_liq(:,:) = tautot_liq(:,:)  + tau_part(:,:,i)
       ENDDO ! i


### PR DESCRIPTION
Fix a bug related to the calculation of separated ice attenuated
backscatter in lidar simulator. The issue was found by Greg Cesana.

The snow is not well accounted for in the separated ice and liquid
attenuated backscatter signal (although it's fine for the total
attenuated backscatter). It has to do with the "npart" indices.
The snow index is 5 but is accounted for in the liquid component.
This has potentially large impact on cloud phase diagnostics from the
lidar simulator.

[BFB] except for COSP diagnostics