### PR TITLE
Remove references to "cam" in submodule paths comment strings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	path = externals/kokkos
 	url = git@github.com:E3SM-Project/kokkos.git
 	branch = e3sm/kokkos
-[submodule "components/cam/src/physics/rrtmgp/external"]
+[submodule "RRMGP"]
 	path = components/eam/src/physics/rrtmgp/external
 	url = git@github.com:RobertPincus/rte-rrtmgp.git
 	branch = develop
@@ -27,7 +27,7 @@
 	path = externals/scorpio_classic
 	url = git@github.com:E3SM-Project/scorpio.git
 	branch = scorpio_classic
-[submodule "components/cam/src/physics/cosp2/external"]
+[submodule "COSP2"]
 	path = components/eam/src/physics/cosp2/external
 	url = git@github.com:CFMIP/COSPv2.0.git
 	branch = CESM_v2.1.4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "components/clm/src/external_models/fates"]
+[submodule "fates"]
 	path = components/elm/src/external_models/fates
 	url = git@github.com:NGEET/fates.git
 [submodule "alm-mpp"]
@@ -15,7 +15,7 @@
 	path = externals/kokkos
 	url = git@github.com:E3SM-Project/kokkos.git
 	branch = e3sm/kokkos
-[submodule "RRMGP"]
+[submodule "rrtmgp"]
 	path = components/eam/src/physics/rrtmgp/external
 	url = git@github.com:RobertPincus/rte-rrtmgp.git
 	branch = develop
@@ -27,7 +27,7 @@
 	path = externals/scorpio_classic
 	url = git@github.com:E3SM-Project/scorpio.git
 	branch = scorpio_classic
-[submodule "COSP2"]
+[submodule "cosp2"]
 	path = components/eam/src/physics/cosp2/external
 	url = git@github.com:CFMIP/COSPv2.0.git
 	branch = CESM_v2.1.4


### PR DESCRIPTION
Replace references to "cam" and shorten submodule names in .gitmodules file