### PR TITLE
Add Chrysalis machine config files

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1395,7 +1395,7 @@
     </mach>
   </grid>
   <grid name="a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3">
-    <mach name="sandiatoss3">
+    <mach name="sandiatoss3|chrysalis">
       <pes compset="any" pesize="any">
         <comment>none</comment>
         <ntasks>

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -341,18 +341,6 @@
     </queues>
   </batch_system>
 
-    <batch_system MACH="mira" type="cobalt">
-      <queues>
-        <queue walltimemax="03:00:00" default="true">default</queue>
-      </queues>
-    </batch_system>
-
-    <batch_system MACH="cetus" type="cobalt">
-      <queues>
-        <queue walltimemax="01:00:00" default="true">default</queue>
-      </queues>
-    </batch_system>
-
     <batch_system MACH="theta" type="cobalt_theta">
       <queues>
         <queue walltimemax="01:00:00" nodemin="1" nodemax="8" strict="true">debug-cache-quad</queue>

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -279,6 +279,12 @@
       </queues>
     </batch_system>
 
+    <batch_system MACH="chrysalis" type="slurm" >
+      <queues>
+	<queue walltimemax="03:00:00" nodemin="1" nodemax="512" default="true" strict="true">compute</queue>
+      </queues>
+    </batch_system>
+
     <batch_system MACH="bebop" type="slurm" >
       <queues>
 	<queue walltimemax="00:30:00" nodemax="64" strict="true">debug</queue>

--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -823,9 +823,6 @@ flags should be captured within MPAS CMake files.
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
   <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
-  <MPICC  MPILIB="impi">mpiicc</MPICC>
-  <MPICXX MPILIB="impi">mpiicpc</MPICXX>
-  <MPIFC  MPILIB="impi">mpiifort</MPIFC>
   <CFLAGS>
     <append>-static-intel</append>
   </CFLAGS>

--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -809,6 +809,50 @@ flags should be captured within MPAS CMake files.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
+<compiler MACH="chrysalis" COMPILER="intel">
+  <CPPDEFS>
+    <append COMP_NAME="gptl">-DHAVE_SLASHPROC</append>
+  </CPPDEFS>
+  <FFLAGS>
+    <append DEBUG="FALSE">-O2 -debug minimal -qno-opt-dynamic-align</append>
+  </FFLAGS>
+  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  <SLIBS>
+    <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} $SHELL{$ENV{NETCDF_C_PATH}/bin/nc-config --libs} -mkl</append>
+  </SLIBS>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
+  <MPICC  MPILIB="impi">mpiicc</MPICC>
+  <MPICXX MPILIB="impi">mpiicpc</MPICXX>
+  <MPIFC  MPILIB="impi">mpiifort</MPIFC>
+  <CFLAGS>
+    <append>-static-intel</append>
+  </CFLAGS>
+  <FFLAGS>
+    <append>-static-intel</append>
+  </FFLAGS>
+  <LDFLAGS>
+    <append>-static-intel </append>
+  </LDFLAGS>
+</compiler>
+
+<compiler MACH="chrysalis" COMPILER="gnu">
+  <CPPDEFS>
+    <append COMP_NAME="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY  </append>
+  </CPPDEFS>
+  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
+  <SLIBS>
+    <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} $SHELL{$ENV{NETCDF_C_PATH}/bin/nc-config --libs}</append>
+    <append>-Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group -lpthread -lm -ldl</append>
+  </SLIBS>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+</compiler>
+
 <compiler MACH="bebop" COMPILER="intel">
   <ALBANY_PATH>/soft/climate/AlbanyTrilinos_06262017/Albany/buildintel/install</ALBANY_PATH>
   <CPPDEFS>

--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -851,6 +851,7 @@ flags should be captured within MPAS CMake files.
   </CXX_LIBS>
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
 </compiler>
 
 <compiler MACH="bebop" COMPILER="intel">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1015,14 +1015,14 @@
     <COMPILERS>intel,intel18,gnu</COMPILERS>
     <MPILIBS>mvapich</MPILIBS>
     <PROJECT>condo</PROJECT>
-    <SAVE_TIMING_DIR>/lcrc/group/acme</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR>/lcrc/group/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>/lcrc/group/acme/$USER/acme_scratch/anvil</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/home/ccsm-data/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>/lcrc/group/acme/$USER/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/lcrc/group/acme/tools/cprnc/cprnc</CCSM_CPRNC>
+    <CIME_OUTPUT_ROOT>/lcrc/group/e3sm/$USER/scratch/anvil</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/lcrc/group/e3sm/data/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lcrc/group/e3sm/data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/lcrc/group/e3sm/$USER/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/lcrc/group/e3sm/baselines/anvil/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/lcrc/group/e3sm/soft/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_integration</TESTS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -1094,7 +1094,7 @@
     <environment_variables>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
-      <env name="PATH">/lcrc/group/acme/soft/perl/5.26.0/bin:$ENV{PATH}</env>
+      <env name="PATH">/lcrc/group/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
@@ -1204,6 +1204,9 @@
       <env name="KMP_AFFINITY">granularity=core,scatter</env>
       <env name="KMP_HOT_TEAMS_MODE">1</env>
     </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+      <env name="OMP_PLACES">cores</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="blues">
@@ -1212,14 +1215,14 @@
     <COMPILERS>pgigpu</COMPILERS>
     <MPILIBS>mvapich</MPILIBS>
     <PROJECT>e3sm</PROJECT>
-    <SAVE_TIMING_DIR>/lcrc/group/acme</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR>/lcrc/group/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>/lcrc/group/acme/$USER/acme_scratch/blues</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/home/ccsm-data/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>/lcrc/group/acme/$USER/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/blues/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/lcrc/group/acme/tools/cprnc/cprnc</CCSM_CPRNC>
+    <CIME_OUTPUT_ROOT>/lcrc/group/e3sm/$USER/scratch/blues</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/lcrc/group/e3sm/data/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lcrc/group/e3sm/data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/lcrc/group/e3sm/$USER/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/lcrc/group/e3sm/baselines/blues/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/lcrc/group/e3sm/soft/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_integration</TESTS>
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
@@ -1266,7 +1269,7 @@
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
-      <env name="PATH">/lcrc/group/acme/soft/perl/5.26.0/bin:$ENV{PATH}</env>
+      <env name="PATH">/lcrc/group/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
     </environment_variables>
     <environment_variables mpilib="mvapich">
       <env name="MV2_ENABLE_AFFINITY">0</env>
@@ -1288,13 +1291,13 @@
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
     <MPILIBS>impi,mvapich</MPILIBS>
-    <PROJECT>acme</PROJECT>
-    <CIME_OUTPUT_ROOT>/lcrc/group/acme/$USER/acme_scratch/bebop</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/home/ccsm-data/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/bebop/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/lcrc/group/acme/tools/cprnc/cprnc</CCSM_CPRNC>
+    <PROJECT>e3sm</PROJECT>
+    <CIME_OUTPUT_ROOT>/lcrc/group/e3sm/$USER/scratch/bebop</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/lcrc/group/e3sm/data/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lcrc/group/e3sm/data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/lcrc/group/e3sm/$USER/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/lcrc/group/e3sm/baselines/bebop/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/lcrc/group/e3sm/soft/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_integration</TESTS>
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
@@ -1367,12 +1370,12 @@
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
     <environment_variables>
-      <env name="NETCDF_C_PATH">$SHELL{which nc-config | xargs dirname | xargs dirname}</env>
-      <env name="NETCDF_FORTRAN_PATH">$SHELL{which nf-config | xargs dirname | xargs dirname}</env>
-      <env name="PATH">/lcrc/group/acme/soft/perl/5.26.0/bin:$ENV{PATH}</env>
+      <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
+      <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
+      <env name="PATH">/lcrc/group/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
-      <env name="PNETCDF_PATH">$SHELL{which pnetcdf_version | xargs dirname | xargs dirname}</env>
+      <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
@@ -1381,69 +1384,6 @@
     </environment_variables>
     <environment_variables mpilib="impi">
       <env name="I_MPI_FABRICS">shm:tmi</env>
-    </environment_variables>
-  </machine>
-
-  <machine MACH="cetus">
-    <DESC>ANL IBM BG/Q, os is BGQ, 16 cores/node, batch system is cobalt</DESC>
-    <NODENAME_REGEX>cetus</NODENAME_REGEX>
-    <OS>BGQ</OS>
-    <COMPILERS>ibm</COMPILERS>
-    <MPILIBS>ibm</MPILIBS>
-    <PROJECT>ClimateEnergy_2</PROJECT>
-    <CHARGE_ACCOUNT>ClimateEnergy</CHARGE_ACCOUNT>
-    <CIME_OUTPUT_ROOT>/projects/$PROJECT/$USER</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/projects/ccsm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/projects/ccsm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>/projects/$PROJECT/$USER/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/projects/ccsm/ccsm_baselines//$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/projects/ccsm/tools/cprnc/cprnc</CCSM_CPRNC>
-    <GMAKE_J>8</GMAKE_J>
-    <TESTS>e3sm_developer</TESTS>
-    <BATCH_SYSTEM>cobalt</BATCH_SYSTEM>
-    <SUPPORTED_BY>jayesh -at- mcs.anl.gov</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
-    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="default">
-      <executable>/usr/bin/runjob</executable>
-      <arguments>
-        <arg name="label">--label short</arg>
-        <arg name="tasks_per_node">--ranks-per-node $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="num_tasks">--np {{ total_tasks }}</arg>
-        <arg name="locargs">--block $COBALT_PARTNAME $LOCARGS</arg>
-        <arg name="bgq_smp_vars">$ENV{BGQ_SMP_VARS}</arg>
-        <arg name="stacksize">$ENV{BGQ_STACKSIZE}</arg>
-      </arguments>
-    </mpirun>
-    <module_system type="soft">
-      <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
-      <init_path lang="sh">/etc/profile.d/00softenv.sh</init_path>
-      <cmd_path lang="csh">soft</cmd_path>
-      <cmd_path lang="sh">soft</cmd_path>
-      <modules>
-        <command name="add">+mpiwrapper-xl</command>
-        <command name="add">@ibm-compilers-2016-05</command>
-        <command name="add">+cmake</command>
-        <command name="add">+python</command>
-      </modules>
-    </module_system>
-    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
-    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
-    <environment_variables>
-      <env name="MPI_TYPE_MAX">10000</env>
-      <env name="BGQ_SMP_VARS"> </env>
-      <env name="BGQ_STACKSIZE"> </env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
-      <env name="BGQ_SMP_VARS">--envs BG_THREADLAYOUT=1 XL_BG_SPREADLAYOUT=YES OMP_DYNAMIC=FALSE OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" MAX_MPITASKS_PER_NODE="!16">
-      <env name="BGQ_STACKSIZE">--envs OMP_STACKSIZE=64M</env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" MAX_MPITASKS_PER_NODE="16">
-      <env name="BGQ_STACKSIZE">--envs OMP_STACKSIZE=16M</env>
     </environment_variables>
   </machine>
 
@@ -1548,70 +1488,6 @@
     </environment_variables>
     <environment_variables compiler="intel" mpilib="!mpi-serial">
       <env name="PNETCDFROOT">/usr/tce/packages/pnetcdf/pnetcdf-1.9.0-intel-18.0.1-mvapich2-2.2/</env>
-    </environment_variables>
-  </machine>
-
-  <machine MACH="mira">
-    <DESC>ANL IBM BG/Q, os is BGQ, 16 cores/node, batch system is cobalt</DESC>
-    <NODENAME_REGEX>mira.*</NODENAME_REGEX>
-    <OS>BGQ</OS>
-    <COMPILERS>ibm</COMPILERS>
-    <MPILIBS>ibm</MPILIBS>
-    <PROJECT>ClimateEnergy_2</PROJECT>
-    <SAVE_TIMING_DIR>/projects/$PROJECT</SAVE_TIMING_DIR>
-    <SAVE_TIMING_DIR_PROJECTS>ClimateEnergy_2</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>/projects/$PROJECT/$USER</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/projects/ccsm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/projects/ccsm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>/projects/$PROJECT/$USER/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/projects/ccsm/ccsm_baselines//$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/projects/ccsm/tools/cprnc/cprnc</CCSM_CPRNC>
-    <GMAKE_J>8</GMAKE_J>
-    <TESTS>e3sm_developer</TESTS>
-    <BATCH_SYSTEM>cobalt</BATCH_SYSTEM>
-    <SUPPORTED_BY>mickelso -at- mcs.anl.gov</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
-    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="default">
-      <executable>/usr/bin/runjob</executable>
-      <arguments>
-        <arg name="label">--label short</arg>
-        <arg name="tasks_per_node">--ranks-per-node $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="num_tasks">--np {{ total_tasks }}</arg>
-        <arg name="locargs">--block $COBALT_PARTNAME $LOCARGS</arg>
-        <arg name="bgq_smp_vars">$ENV{BGQ_SMP_VARS}</arg>
-        <arg name="stacksize">$ENV{BGQ_STACKSIZE}</arg>
-      </arguments>
-    </mpirun>
-    <module_system type="soft">
-      <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
-      <init_path lang="sh">/etc/profile.d/00softenv.sh</init_path>
-      <cmd_path lang="csh">soft</cmd_path>
-      <cmd_path lang="sh">soft</cmd_path>
-      <modules>
-        <command name="add">+mpiwrapper-xl</command>
-        <command name="add">@ibm-compilers-2016-05</command>
-        <command name="add">+cmake</command>
-        <command name="add">+python</command>
-      </modules>
-    </module_system>
-    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
-    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
-    <environment_variables>
-      <env name="MPI_TYPE_MAX">10000</env>
-      <env name="BGQ_SMP_VARS"> </env>
-      <env name="BGQ_STACKSIZE"> </env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
-      <env name="BGQ_SMP_VARS">--envs BG_THREADLAYOUT=1 XL_BG_SPREADLAYOUT=YES OMP_DYNAMIC=FALSE OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" MAX_MPITASKS_PER_NODE="!16">
-      <env name="BGQ_STACKSIZE">--envs OMP_STACKSIZE=64M</env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" MAX_MPITASKS_PER_NODE="16">
-      <env name="BGQ_STACKSIZE">--envs OMP_STACKSIZE=16M</env>
     </environment_variables>
   </machine>
 

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1123,7 +1123,7 @@
     <DESC>ANL LCRC cluster 512-node AMD Epyc 7532 2-sockets 64-cores per node</DESC>
     <NODENAME_REGEX>chrlogin.*</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>intel</COMPILERS>
+    <COMPILERS>intel,gnu</COMPILERS>
     <MPILIBS>openmpi</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/lcrc/group/e3sm</SAVE_TIMING_DIR>
@@ -1133,7 +1133,7 @@
     <DIN_LOC_ROOT_CLMFORC>/lcrc/group/e3sm/data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/lcrc/group/e3sm/$USER/scratch/chrys/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/lcrc/group/e3sm/baselines/chrys/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/lcrc/group/e3sm/soft/tools/cprnc/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/lcrc/group/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_integration</TESTS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -1160,6 +1160,7 @@
       <modules>
         <command name="purge"/>
         <command name="load">subversion/1.14.0-e4smcy3</command>
+        <command name="load">perl/5.32.0-bsnc6lt</command>
       </modules>
       <modules compiler="intel">
         <command name="load">intel/20.0.4-kodw73g</command>
@@ -1173,13 +1174,25 @@
         <command name="load">netcdf-fortran/4.5.3-3i4qf2w</command>
         <command name="load">parallel-netcdf/1.12.1-sr56aqs</command>
       </modules>
+      <modules compiler="gnu">
+        <command name="load">gcc/9.2.0-ugetvbp</command>
+        <command name="load">intel-mkl/2020.4.304-n3b5fye</command>
+      </modules>
+      <modules compiler="gnu" mpilib="openmpi">
+        <command name="load">openmpi/4.0.4-hpcx-hghvhj5</command>
+        <command name="load">hdf5/1.10.7-sbsigon</command>
+        <command name="load">netcdf-c/4.7.4-a4uk6zy</command>
+        <command name="load">netcdf-cxx/4.2-fz347dw</command>
+        <command name="load">netcdf-fortran/4.5.3-i5ah7u2</command>
+        <command name="load">parallel-netcdf/1.12.1-e7w4x32</command>
+      </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
     <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
-      <env name="PERL5LIB">/lcrc/group/e3sm/soft/perl5/lib/perl5</env>
+      <env name="PERL5LIB">/lcrc/group/e3sm/soft/perl/chrys/lib/perl5</env>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1120,20 +1120,20 @@
   </machine>
 
   <machine MACH="chrysalis">
-    <DESC>ANL LCRC Linux Cluster</DESC>
+    <DESC>ANL LCRC cluster 512-node AMD Epyc 7532 2-sockets 64-cores per node</DESC>
     <NODENAME_REGEX>chrlogin.*</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>openmpi,impi</MPILIBS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>openmpi</MPILIBS>
     <PROJECT>e3sm</PROJECT>
-    <SAVE_TIMING_DIR>/disk/e3sm</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR>/lcrc/group/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>/disk/e3sm/$USER/scratch/chrys</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/disk/e3sm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/disk/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>/disk/e3sm/$USER/scratch/chrys/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/disk/e3sm/baselines/chrys/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/disk/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
+    <CIME_OUTPUT_ROOT>/lcrc/group/e3sm/$USER/scratch/chrys</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/lcrc/group/e3sm/data/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lcrc/group/e3sm/data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/lcrc/group/e3sm/$USER/scratch/chrys/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/lcrc/group/e3sm/baselines/chrys/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/lcrc/group/e3sm/soft/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_integration</TESTS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -1151,42 +1151,27 @@
       </arguments>
     </mpirun>
     <module_system type="module">
-      <init_path lang="sh">/nfs/spack-0.15.4/opt/spack/linux-centos8-x86_64/gcc-8.3.1/lmod-8.3-527cd5e/lmod/lmod/init/sh</init_path>
-      <init_path lang="csh">/nfs/spack-0.15.4/opt/spack/linux-centos8-x86_64/gcc-8.3.1/lmod-8.3-527cd5e/lmod/lmod/init/csh</init_path>
-      <init_path lang="python">/nfs/spack-0.15.4/opt/spack/linux-centos8-x86_64/gcc-8.3.1/lmod-8.3-527cd5e/lmod/lmod/init/env_modules_python.py</init_path>
-      <cmd_path lang="python">/nfs/spack-0.15.4/opt/spack/linux-centos8-x86_64/gcc-8.3.1/lmod-8.3-527cd5e/lmod/lmod/libexec/lmod python</cmd_path>
+      <init_path lang="sh">/gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/lmod-8.3-5be73rg/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/lmod-8.3-5be73rg/lmod/lmod/init/csh</init_path>
+      <init_path lang="python">/gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/lmod-8.3-5be73rg/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="python">/gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/lmod-8.3-5be73rg/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">python/3.8.5-ethv5xz</command>
-        <command name="load">cmake/3.18.2-vuj6hkm</command>
-        <command name="load">gmake/4.2.1-7u3ryez</command>
-        <command name="load">perl/5.30.3-ed3remr</command>
-        <command name="load">subversion/1.14.0-btjqlun</command>
+        <command name="load">subversion/1.14.0-e4smcy3</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/20.0.4-xkafm4q</command>
-        <command name="load">intel-mkl/2020.4.304-g4cokjh</command>
-        <command name="load">hdf5/1.10.6-z5e442p</command>
-        <command name="load">netcdf-c/4.7.4-3w4cjar</command>
-        <command name="load">netcdf-cxx/4.2-wrqvzln</command>
-        <command name="load">netcdf-fortran/4.5.3-gdijef3</command>
-      </modules>
-      <modules compiler="gnu"><!-- /bin/gcc v.8.3.1 -->
-        <command name="load">intel-mkl/2019.5.281-vati572</command>
-        <command name="load">hdf5/1.10.6-n354s2k</command>
-        <command name="load">netcdf-c/4.7.4-fy6qxb3</command>
-        <command name="load">netcdf-cxx/4.2-z2ssgxi</command>
-        <command name="load">netcdf-fortran/4.5.3-o2rbyue</command>
+        <command name="load">intel/20.0.4-kodw73g</command>
+        <command name="load">intel-mkl/2020.4.304-g2qaxzf</command>
       </modules>
       <modules compiler="intel" mpilib="openmpi">
-        <command name="load">openmpi/4.0.4-hpcx-x3pasa6</command>
-        <command name="load">parallel-netcdf/1.12.1-hkhbopc</command>
-      </modules>
-      <modules compiler="intel" mpilib="impi">
-        <command name="load">intel-mpi/2019.9.304-fz3d3rc</command>
-        <command name="load">parallel-netcdf/1.12.1-7maf7i6</command>
+        <command name="load">openmpi/4.0.4-hpcx-cy5n3ft</command>
+        <command name="load">hdf5/1.10.7-ticiopc</command>
+        <command name="load">netcdf-c/4.7.4-h26ravg</command>
+        <command name="load">netcdf-cxx/4.2-wmjjndn</command>
+        <command name="load">netcdf-fortran/4.5.3-3i4qf2w</command>
+        <command name="load">parallel-netcdf/1.12.1-sr56aqs</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -1194,23 +1179,13 @@
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
     <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
-      <env name="PERL5LIB">/nfs/e3sm/soft/perl5/lib/perl5</env>
+      <env name="PERL5LIB">/lcrc/group/e3sm/soft/perl5/lib/perl5</env>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
-    <environment_variables compiler="gnu" mpilib="openmpi">
-      <env name="PATH">/usr/mpi/gcc/openmpi-4.0.4rc3/bin:$ENV{PATH}</env>
-      <env name="LD_LIBRARY_PATH">/usr/mpi/gcc/openmpi-4.0.4rc3/lib64:$ENV{LD_LIBRARY_PATH}</env>
-    </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
-    </environment_variables>
-    <environment_variables mpilib="impi">
-      <env name="I_MPI_PIN_DOMAIN">omp</env>
-      <env name="I_MPI_PIN_ORDER">spread</env>
-      <env name="I_MPI_PIN_CELL">core</env>
-      <env name="I_MPI_DEBUG">10</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="intel">
       <env name="KMP_AFFINITY">granularity=core,scatter</env>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1119,6 +1119,105 @@
     </environment_variables>
   </machine>
 
+  <machine MACH="chrysalis">
+    <DESC>ANL LCRC Linux Cluster</DESC>
+    <NODENAME_REGEX>chrlogin.*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel,gnu</COMPILERS>
+    <MPILIBS>openmpi,impi</MPILIBS>
+    <PROJECT>e3sm</PROJECT>
+    <SAVE_TIMING_DIR>/disk/e3sm</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>/disk/e3sm/$USER/scratch/chrys</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/disk/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/disk/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/disk/e3sm/$USER/scratch/chrys/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/disk/e3sm/baselines/chrys/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/disk/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_integration</TESTS>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>E3SM</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="num_tasks">--mpi=pmi2 -l -n {{ total_tasks }} -N {{ num_nodes }} --kill-on-bad-exit </arg>
+        <arg name="binding">--cpu_bind=cores</arg>
+        <arg name="thread_count">-c $ENV{OMP_NUM_THREADS}</arg>
+        <arg name="placement">-m plane={{ tasks_per_node }}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="sh">/nfs/spack-0.15.4/opt/spack/linux-centos8-x86_64/gcc-8.3.1/lmod-8.3-527cd5e/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/nfs/spack-0.15.4/opt/spack/linux-centos8-x86_64/gcc-8.3.1/lmod-8.3-527cd5e/lmod/lmod/init/csh</init_path>
+      <init_path lang="python">/nfs/spack-0.15.4/opt/spack/linux-centos8-x86_64/gcc-8.3.1/lmod-8.3-527cd5e/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="python">/nfs/spack-0.15.4/opt/spack/linux-centos8-x86_64/gcc-8.3.1/lmod-8.3-527cd5e/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="load">python/3.8.5-ethv5xz</command>
+        <command name="load">cmake/3.18.2-vuj6hkm</command>
+        <command name="load">gmake/4.2.1-7u3ryez</command>
+        <command name="load">perl/5.30.3-ed3remr</command>
+        <command name="load">subversion/1.14.0-btjqlun</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">intel/20.0.4-xkafm4q</command>
+        <command name="load">intel-mkl/2020.4.304-g4cokjh</command>
+        <command name="load">hdf5/1.10.6-z5e442p</command>
+        <command name="load">netcdf-c/4.7.4-3w4cjar</command>
+        <command name="load">netcdf-cxx/4.2-wrqvzln</command>
+        <command name="load">netcdf-fortran/4.5.3-gdijef3</command>
+      </modules>
+      <modules compiler="gnu"><!-- /bin/gcc v.8.3.1 -->
+        <command name="load">intel-mkl/2019.5.281-vati572</command>
+        <command name="load">hdf5/1.10.6-n354s2k</command>
+        <command name="load">netcdf-c/4.7.4-fy6qxb3</command>
+        <command name="load">netcdf-cxx/4.2-z2ssgxi</command>
+        <command name="load">netcdf-fortran/4.5.3-o2rbyue</command>
+      </modules>
+      <modules compiler="intel" mpilib="openmpi">
+        <command name="load">openmpi/4.0.4-hpcx-x3pasa6</command>
+        <command name="load">parallel-netcdf/1.12.1-hkhbopc</command>
+      </modules>
+      <modules compiler="intel" mpilib="impi">
+        <command name="load">intel-mpi/2019.9.304-fz3d3rc</command>
+        <command name="load">parallel-netcdf/1.12.1-7maf7i6</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
+    <environment_variables>
+      <env name="PERL5LIB">/nfs/e3sm/soft/perl5/lib/perl5</env>
+      <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
+      <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
+      <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
+    </environment_variables>
+    <environment_variables compiler="gnu" mpilib="openmpi">
+      <env name="PATH">/usr/mpi/gcc/openmpi-4.0.4rc3/bin:$ENV{PATH}</env>
+      <env name="LD_LIBRARY_PATH">/usr/mpi/gcc/openmpi-4.0.4rc3/lib64:$ENV{LD_LIBRARY_PATH}</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE">
+      <env name="OMP_STACKSIZE">128M</env>
+    </environment_variables>
+    <environment_variables mpilib="impi">
+      <env name="I_MPI_PIN_DOMAIN">omp</env>
+      <env name="I_MPI_PIN_ORDER">spread</env>
+      <env name="I_MPI_PIN_CELL">core</env>
+      <env name="I_MPI_DEBUG">10</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="intel">
+      <env name="KMP_AFFINITY">granularity=core,scatter</env>
+      <env name="KMP_HOT_TEAMS_MODE">1</env>
+    </environment_variables>
+  </machine>
+
   <machine MACH="blues">
     <DESC>ANL/LCRC Linux Cluster</DESC>
     <OS>LINUX</OS>


### PR DESCRIPTION
Add Chrysalis machine config files.
Change anvil paths to use new /lcrc/group/e3sm disk.   Remove "acme" from paths.
Change "acme_scratch" to just "scratch".

Update CIME submodule to hash  5cef5558c4e7bebfc8ec8f3b507e7e583e6a669c
  - Print TPUTCOMP difference to TestStatus.log
  - Update OS process id error-checking in GPTL's get_memusage

CIME changes that are only for CESM
- Changes to implement ESMF aware threading in the nuopc driver. Correct issues with nuopc timing file.
- Update modules on cheyenne.
- Changes for nuopc xcpl_comps needed for new ice sheets capability
- Make the default pio_version = 2

[NML] - on Anvil due to inputdata file pathname changes in seq_maps.rc namelist