### PR TITLE
Add omp master to a section of code in init that would otherwise have race condition

### DIFF
--- a/components/homme/src/theta-l/share/model_init_mod.F90
+++ b/components/homme/src/theta-l/share/model_init_mod.F90
@@ -111,12 +111,11 @@ contains
          call test_imex_jacobian(elem,hybrid,hvcoord,tl,nets,nete)
 #endif
 
-    nlev_tom=0
-
     !$omp master
     ! 
     ! compute scaling of sponge layer damping 
     !
+    nlev_tom=0
     if (hybrid%masterthread) write(iulog,*) "sponge layer nu_top viscosity scaling factor"
     do k=1,nlev
        !press = (hvcoord%hyam(k)+hvcoord%hybm(k))*hvcoord%ps0
@@ -158,7 +157,7 @@ contains
     if (hybrid%masterthread) then
        write(iulog,*) "  nlev_tom ",nlev_tom
     end if
-    !$omp master
+    !$omp end master
     !$omp barrier
 
   end subroutine 

--- a/components/homme/src/theta-l/share/model_init_mod.F90
+++ b/components/homme/src/theta-l/share/model_init_mod.F90
@@ -39,7 +39,7 @@ contains
     type(derivative_t), intent(in)    :: deriv
     type (hvcoord_t)  , intent(in)    :: hvcoord
     type (TimeLevel_t), intent(in)    :: tl
-    integer                           :: nets,nete
+    integer,            intent(in)    :: nets,nete
 
     ! local variables
     integer :: ie,t,k
@@ -111,11 +111,13 @@ contains
          call test_imex_jacobian(elem,hybrid,hvcoord,tl,nets,nete)
 #endif
 
+    nlev_tom=0
+
+    !$omp master
     ! 
     ! compute scaling of sponge layer damping 
     !
     if (hybrid%masterthread) write(iulog,*) "sponge layer nu_top viscosity scaling factor"
-    nlev_tom=0
     do k=1,nlev
        !press = (hvcoord%hyam(k)+hvcoord%hybm(k))*hvcoord%ps0
        !ptop  = hvcoord%hyai(1)*hvcoord%ps0
@@ -156,6 +158,8 @@ contains
     if (hybrid%masterthread) then
        write(iulog,*) "  nlev_tom ",nlev_tom
     end if
+    !$omp master
+    !$omp barrier
 
   end subroutine 
 


### PR DESCRIPTION
Add omp master to a section of code in init that would otherwise have race condition.
DEBUG builds would see the issue, but a chance could also happen without DEBUG.
Also add omp barrier after the omp master section.

Fixes E3SM-Project/E3SM#3628

[BFB]