### PR TITLE
Adds ocean semi-implicit barotropic mode solver

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -787,14 +787,19 @@ add_default($nl, 'config_eos_linear_Tref');
 add_default($nl, 'config_eos_linear_Sref');
 add_default($nl, 'config_eos_linear_densityref');
 
-#####################################
-# Namelist group: split_explicit_ts #
-#####################################
+########################################
+# Namelist group: split_timestep_share #
+########################################
 
 add_default($nl, 'config_n_ts_iter');
 add_default($nl, 'config_n_bcl_iter_beg');
 add_default($nl, 'config_n_bcl_iter_mid');
 add_default($nl, 'config_n_bcl_iter_end');
+
+#####################################
+# Namelist group: split_explicit_ts #
+#####################################
+
 add_default($nl, 'config_btr_dt');
 add_default($nl, 'config_n_btr_cor_iter');
 add_default($nl, 'config_vel_correction');
@@ -803,6 +808,14 @@ add_default($nl, 'config_btr_gam1_velWt1');
 add_default($nl, 'config_btr_gam2_SSHWt1');
 add_default($nl, 'config_btr_gam3_velWt2');
 add_default($nl, 'config_btr_solve_SSH2');
+
+####################################
+# Namelist group: semi_implicit_ts #
+####################################
+
+add_default($nl, 'config_btr_si_preconditioner');
+add_default($nl, 'config_btr_si_tolerance');
+add_default($nl, 'config_n_btr_si_outer_iter');
 
 #####################################
 # Namelist group: ALE_vertical_grid #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -816,7 +816,7 @@ add_default($nl, 'config_btr_solve_SSH2');
 add_default($nl, 'config_btr_si_preconditioner');
 add_default($nl, 'config_btr_si_tolerance');
 add_default($nl, 'config_n_btr_si_outer_iter');
-add_default($nl, 'config_btr_si_thread_match_mode');
+add_default($nl, 'config_btr_si_partition_match_mode');
 
 #####################################
 # Namelist group: ALE_vertical_grid #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -1594,7 +1594,9 @@ my @groups = qw(run_modes
                 pressure_gradient
                 eos
                 eos_linear
+                split_timestep_share
                 split_explicit_ts
+                semi_implicit_ts
                 ale_vertical_grid
                 ale_frequency_filtered_thickness
                 debug

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -816,6 +816,7 @@ add_default($nl, 'config_btr_solve_SSH2');
 add_default($nl, 'config_btr_si_preconditioner');
 add_default($nl, 'config_btr_si_tolerance');
 add_default($nl, 'config_n_btr_si_outer_iter');
+add_default($nl, 'config_btr_si_thread_match_mode');
 
 #####################################
 # Namelist group: ALE_vertical_grid #

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -24,7 +24,9 @@ my @groups = qw(run_modes
                 pressure_gradient
                 eos
                 eos_linear
+                split_timestep_share
                 split_explicit_ts
+                semi_implicit_ts
                 ale_vertical_grid
                 ale_frequency_filtered_thickness
                 debug

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -318,14 +318,19 @@ add_default($nl, 'config_eos_linear_Tref');
 add_default($nl, 'config_eos_linear_Sref');
 add_default($nl, 'config_eos_linear_densityref');
 
-#####################################
-# Namelist group: split_explicit_ts #
-#####################################
+########################################
+# Namelist group: split_timestep_share #
+########################################
 
 add_default($nl, 'config_n_ts_iter');
 add_default($nl, 'config_n_bcl_iter_beg');
 add_default($nl, 'config_n_bcl_iter_mid');
 add_default($nl, 'config_n_bcl_iter_end');
+
+#####################################
+# Namelist group: split_explicit_ts #
+#####################################
+
 add_default($nl, 'config_btr_dt');
 add_default($nl, 'config_n_btr_cor_iter');
 add_default($nl, 'config_vel_correction');
@@ -334,6 +339,14 @@ add_default($nl, 'config_btr_gam1_velWt1');
 add_default($nl, 'config_btr_gam2_SSHWt1');
 add_default($nl, 'config_btr_gam3_velWt2');
 add_default($nl, 'config_btr_solve_SSH2');
+
+####################################
+# Namelist group: semi_implicit_ts #
+####################################
+
+add_default($nl, 'config_btr_si_preconditioner');
+add_default($nl, 'config_btr_si_tolerance');
+add_default($nl, 'config_n_btr_si_outer_iter');
 
 #####################################
 # Namelist group: ALE_vertical_grid #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -347,6 +347,7 @@ add_default($nl, 'config_btr_solve_SSH2');
 add_default($nl, 'config_btr_si_preconditioner');
 add_default($nl, 'config_btr_si_tolerance');
 add_default($nl, 'config_n_btr_si_outer_iter');
+add_default($nl, 'config_btr_si_thread_match_mode');
 
 #####################################
 # Namelist group: ALE_vertical_grid #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -347,7 +347,7 @@ add_default($nl, 'config_btr_solve_SSH2');
 add_default($nl, 'config_btr_si_preconditioner');
 add_default($nl, 'config_btr_si_tolerance');
 add_default($nl, 'config_n_btr_si_outer_iter');
-add_default($nl, 'config_btr_si_thread_match_mode');
+add_default($nl, 'config_btr_si_partition_match_mode');
 
 #####################################
 # Namelist group: ALE_vertical_grid #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -385,6 +385,7 @@
 <config_btr_si_preconditioner>'ras'</config_btr_si_preconditioner>
 <config_btr_si_tolerance>1.0e-9</config_btr_si_tolerance>
 <config_n_btr_si_outer_iter>2</config_n_btr_si_outer_iter>
+<config_btr_si_thread_match_mode>.false.</config_btr_si_thread_match_mode>
 
 <!-- ALE_vertical_grid -->
 <config_vert_coord_movement>'uniform_stretching'</config_vert_coord_movement>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -345,11 +345,13 @@
 <config_eos_linear_Sref>35.0</config_eos_linear_Sref>
 <config_eos_linear_densityref>1000.0</config_eos_linear_densityref>
 
-<!-- split_explicit_ts -->
+<!-- split_timestep_share -->
 <config_n_ts_iter>2</config_n_ts_iter>
 <config_n_bcl_iter_beg>1</config_n_bcl_iter_beg>
 <config_n_bcl_iter_mid>2</config_n_bcl_iter_mid>
 <config_n_bcl_iter_end>2</config_n_bcl_iter_end>
+
+<!-- split_explicit_ts -->
 <config_btr_dt>'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU480">'0000_00:05:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU240">'0000_00:03:00'</config_btr_dt>
@@ -378,6 +380,11 @@
 <config_btr_gam2_SSHWt1>1.0</config_btr_gam2_SSHWt1>
 <config_btr_gam3_velWt2>1.0</config_btr_gam3_velWt2>
 <config_btr_solve_SSH2>.false.</config_btr_solve_SSH2>
+
+<!-- semi_implicit_ts -->
+<config_btr_si_preconditioner>'ras'</config_btr_si_preconditioner>
+<config_btr_si_tolerance>1.0e-9</config_btr_si_tolerance>
+<config_n_btr_si_outer_iter>2</config_n_btr_si_outer_iter>
 
 <!-- ALE_vertical_grid -->
 <config_vert_coord_movement>'uniform_stretching'</config_vert_coord_movement>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -385,7 +385,7 @@
 <config_btr_si_preconditioner>'ras'</config_btr_si_preconditioner>
 <config_btr_si_tolerance>1.0e-9</config_btr_si_tolerance>
 <config_n_btr_si_outer_iter>2</config_n_btr_si_outer_iter>
-<config_btr_si_thread_match_mode>.false.</config_btr_si_thread_match_mode>
+<config_btr_si_partition_match_mode>.false.</config_btr_si_partition_match_mode>
 
 <!-- ALE_vertical_grid -->
 <config_vert_coord_movement>'uniform_stretching'</config_vert_coord_movement>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -196,7 +196,7 @@ Default: Defined in namelist_defaults.xml
 	category="time_integration" group="time_integration">
 Time integration method.
 
-Valid values: 'split_explicit', 'RK4', 'unsplit_explicit'
+Valid values: 'split_explicit', 'RK4', 'unsplit_explicit' 'semi_implicit'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1600,10 +1600,10 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- split_explicit_ts -->
+<!-- split_timestep_share -->
 
 <entry id="config_n_ts_iter" type="integer"
-	category="split_explicit_ts" group="split_explicit_ts">
+	category="split_timestep_share" group="split_timestep_share">
 number of large iterations over stages 1-3
 
 Valid values: any positive integer, but typically 1, 2, or 3
@@ -1611,28 +1611,30 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_n_bcl_iter_beg" type="integer"
-	category="split_explicit_ts" group="split_explicit_ts">
-number of iterations of stage 1 (baroclinic solve) on the first split-explicit iteration
+	category="split_timestep_share" group="split_timestep_share">
+number of iterations of stage 1 (baroclinic solve) on the first split timestepping iteration
 
 Valid values: any positive integer, but typically 1, 2, or 3
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_n_bcl_iter_mid" type="integer"
-	category="split_explicit_ts" group="split_explicit_ts">
-number of iterations of stage 1 (baroclinic solve) on any split-explicit iterations between first and last
+	category="split_timestep_share" group="split_timestep_share">
+number of iterations of stage 1 (baroclinic solve) on any split timestepping iterations between first and last
 
 Valid values: any positive integer, but typically 1, 2, or 3
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_n_bcl_iter_end" type="integer"
-	category="split_explicit_ts" group="split_explicit_ts">
-number of iterations of stage 1 (baroclinic solve) on the last split-explicit iteration
+	category="split_timestep_share" group="split_timestep_share">
+number of iterations of stage 1 (baroclinic solve) on the last split timestepping iteration
 
 Valid values: any positive integer, but typically 1, 2, or 3
 Default: Defined in namelist_defaults.xml
 </entry>
+
+<!-- split_explicit_ts -->
 
 <entry id="config_btr_dt" type="char*1024"
 	category="split_explicit_ts" group="split_explicit_ts">
@@ -1695,6 +1697,32 @@ Default: Defined in namelist_defaults.xml
 If true, execute the SSH corrector step in stage 2
 
 Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<!-- semi_implict_ts -->
+
+<entry id="config_btr_si_preconditioner" type="char*1024"
+       category="semi_implicit_ts" group="semi_implicit_ts">
+Type of preconditioner for the barotropic mode solver
+
+Valid values: 'ras', 'block_jacobi', 'jacobi', or 'none'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_btr_si_tolerance" type="real"
+       category="semi_implicit_ts" group="semi_implicit_ts">
+Tolerance for the barotropic mode solver
+
+Valid values: any positive real, but typically less than 1.0e-9
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_n_btr_si_outer_iter" type="integer"
+       category="semi_implicit_ts" group="semi_implicit_ts">
+number of outer iterations
+
+Valid values: any positive integer, but typically 2
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -196,7 +196,7 @@ Default: Defined in namelist_defaults.xml
 	category="time_integration" group="time_integration">
 Time integration method.
 
-Valid values: 'split_explicit', 'RK4', 'unsplit_explicit' 'semi_implicit'
+Valid values: 'split_explicit', 'RK4', 'unsplit_explicit', 'semi_implicit'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1634,6 +1634,7 @@ Valid values: any positive integer, but typically 1, 2, or 3
 Default: Defined in namelist_defaults.xml
 </entry>
 
+
 <!-- split_explicit_ts -->
 
 <entry id="config_btr_dt" type="char*1024"
@@ -1700,18 +1701,19 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<!-- semi_implict_ts -->
+
+<!-- semi_implicit_ts -->
 
 <entry id="config_btr_si_preconditioner" type="char*1024"
-       category="semi_implicit_ts" group="semi_implicit_ts">
+	category="semi_implicit_ts" group="semi_implicit_ts">
 Type of preconditioner for the barotropic mode solver
 
-Valid values: 'ras', 'block_jacobi', 'jacobi', or 'none'
+Valid values: ras, block_jacobi, jacobi, none
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_btr_si_tolerance" type="real"
-       category="semi_implicit_ts" group="semi_implicit_ts">
+	category="semi_implicit_ts" group="semi_implicit_ts">
 Tolerance for the barotropic mode solver
 
 Valid values: any positive real, but typically less than 1.0e-9
@@ -1719,7 +1721,7 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_n_btr_si_outer_iter" type="integer"
-       category="semi_implicit_ts" group="semi_implicit_ts">
+	category="semi_implicit_ts" group="semi_implicit_ts">
 number of outer iterations
 
 Valid values: any positive integer, but typically 2
@@ -1727,9 +1729,8 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_btr_si_partition_match_mode" type="logical"
-       category="semi_implicit_ts" group="semi_implicit_ts">
-If true, the semi-implicit method uses the Jacobi preconditioner
-with the bit-for-bit allreduce.
+	category="semi_implicit_ts" group="semi_implicit_ts">
+If true, the semi-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1726,6 +1726,15 @@ Valid values: any positive integer, but typically 2
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_btr_si_thread_match_mode" type="logical"
+       category="semi_implicit_ts" group="semi_implicit_ts">
+If true, the semi-implicit method uses the Jacobi preconditioner
+with the bit-for-bit allreduce.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- ALE_vertical_grid -->
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1726,7 +1726,7 @@ Valid values: any positive integer, but typically 2
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_btr_si_thread_match_mode" type="logical"
+<entry id="config_btr_si_partition_match_mode" type="logical"
        category="semi_implicit_ts" group="semi_implicit_ts">
 If true, the semi-implicit method uses the Jacobi preconditioner
 with the bit-for-bit allreduce.


### PR DESCRIPTION
This adds a semi-implicit barotropic solver for ocean time-stepping. Current default is split explicit, and this new option is default off. 

See https://github.com/MPAS-Dev/MPAS-Model/pull/422

[BFB]
[NML]