### PR TITLE
Fixes a performance bug that is already on E3SM master.

### DIFF
--- a/components/homme/src/share/bndry_mod_base.F90
+++ b/components/homme/src/share/bndry_mod_base.F90
@@ -66,10 +66,12 @@ contains
     character*(80) errorstring
 
     logical(kind=log_kind),parameter              :: Debug=.FALSE.
-    logical(kind=log_kind) :: singlethread_copy = .false.
+    logical(kind=log_kind) :: singlethread_copy
 
     integer        :: i,j
 
+    singlethread_copy = .false.
+    
     pSchedule => Schedule(1)
     nlyr = buffer%nlyr
 
@@ -181,9 +183,10 @@ contains
     character*(80) errorstring
 
     logical(kind=log_kind),parameter              :: Debug=.FALSE.
-    logical :: singlethread_copy=.false.
+    logical :: singlethread_copy
     integer        :: i,j
 
+    singlethread_copy = .false.
     pSchedule => Schedule(1)
     nlyr = buffer%nlyr
 
@@ -363,9 +366,10 @@ contains
     character*(80) errorstring
 
     logical(kind=log_kind),parameter              :: Debug=.FALSE.
-    logical :: singlethread_copy=.false.
+    logical :: singlethread_copy
     integer        :: i,j
 
+    singlethread_copy = .false.
     pSchedule => Schedule(1)
     nlyr = buffer%nlyr
 


### PR DESCRIPTION
A logical variable is set at declaration, when it should be set in the routine.
Fixing this will avoid a thread sync and the performance improvement
will be larger with more threads (especially useful for KNL)

[bfb]