### PR TITLE
Updates for Cori to use maint-1.1

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -61,15 +61,15 @@
   <TESTS>e3sm_developer</TESTS>
   <COMPILERS>intel,gnu</COMPILERS>
   <MPILIBS>mpt</MPILIBS>
-  <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/cori-haswell</CIME_OUTPUT_ROOT>
+  <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-haswell</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-  <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
-  <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+  <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
+  <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <BASELINE_ROOT>/project/projectdirs/acme/baselines/$COMPILER</BASELINE_ROOT>
-  <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+  <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+  <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
   <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
   <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
   <OS>CNL</OS>
@@ -78,7 +78,7 @@
   <GMAKE_J>8</GMAKE_J>
   <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
   <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-  <PROJECT>acme</PROJECT>
+  <PROJECT>e3sm</PROJECT>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
   <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
@@ -86,7 +86,7 @@
     <executable>srun</executable>
     <arguments>
       <arg name="label"> --label</arg>
-      <arg name="num_tasks" > -n {{ total_tasks }}</arg>
+      <arg name="num_tasks" > -n $TOTALPES</arg>
       <arg name="thread_count">-c $SHELL{echo 64/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
       <arg name="binding"> $SHELL{if [ 32 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
       <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
@@ -110,7 +110,7 @@
       <command name="rm">cce</command>
       <command name="rm">gcc</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="rm">cray-parallel-hdf5</command>
+      <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">pmi</command>
       <command name="rm">cray-libsci</command>
       <command name="rm">cray-mpich2</command>
@@ -126,17 +126,19 @@
       <command name="rm">cray-petsc</command>
       <command name="rm">esmf</command>
       <command name="rm">zlib</command>
+      <command name="rm">craype-hugepages2M</command>
+      <command name="rm">darshan</command>
 
-        <!-- first load basic defaults, then remove/swap/load as necessary -->
-        <command name="load">craype</command>
-        <command name="load">PrgEnv-intel</command>
-        <command name="load">cray-mpich</command>
-        <command name="rm">craype-mic-knl</command>
-        <command name="load">craype-haswell</command>
+      <!-- first load basic defaults, then remove/swap/load as necessary -->
+      <command name="load">craype</command>
+      <command name="load">PrgEnv-intel</command>
+      <command name="load">cray-mpich</command>
+      <command name="rm">craype-mic-knl</command>
+      <command name="load">craype-haswell</command>
     </modules>
-    
+
     <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+      <command name="swap">cray-mpich cray-mpich/7.7.6</command>
     </modules>
 
     <modules compiler="intel">
@@ -187,14 +189,12 @@
 
     <env name="MPICH_ENV_DISPLAY">1</env>
     <env name="MPICH_VERSION_DISPLAY">1</env>
-    <env name="MPICH_CPUMASK_DISPLAY">1</env>
+    <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
 
     <env name="OMP_STACKSIZE">128M</env>
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
     <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
-
-    <env name="PERL5LIB">/project/projectdirs/acme/perl5/lib/perl5/x86_64-linux-thread-multi</env>
   </environment_variables>
   <environment_variables compiler="intel">
     <env name="FORT_BUFFERED">yes</env>
@@ -208,15 +208,15 @@
   <TESTS>e3sm_developer</TESTS>
   <COMPILERS>intel,gnu,gnu7</COMPILERS>
   <MPILIBS>mpt,impi</MPILIBS>
-  <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/cori-knl</CIME_OUTPUT_ROOT>
+  <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-knl</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-  <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
-  <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+  <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
+  <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <BASELINE_ROOT>/project/projectdirs/acme/baselines/$COMPILER</BASELINE_ROOT>
-  <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+  <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+  <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
   <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
   <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
   <OS>CNL</OS>
@@ -225,7 +225,7 @@
   <GMAKE_J>8</GMAKE_J>
   <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
   <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-  <PROJECT>acme</PROJECT>
+  <PROJECT>e3sm</PROJECT>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
   <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
@@ -233,8 +233,8 @@
     <executable>srun</executable>
     <arguments>
       <arg name="label"> --label</arg>
-      <arg name="num_tasks" > -n {{ total_tasks }}</arg>
-      <arg name="thread_count">-c $SHELL{echo 272/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
+      <arg name="num_tasks" > -n $TOTALPES</arg>
+      <arg name="thread_count">-c $SHELL{mpn=`./xmlquery --value MAX_MPITASKS_PER_NODE`; if [ 68 -ge $mpn ]; then c0=`expr 272 / $mpn`; c1=`expr $c0 / 4`; cflag=`expr $c1 \* 4`; echo $cflag|bc ; else echo 272/$mpn|bc;fi;} </arg>
       <arg name="binding"> $SHELL{if [ 68 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
       <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
     </arguments>
@@ -259,7 +259,7 @@
       <command name="rm">cce</command>
       <command name="rm">gcc</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="rm">cray-parallel-hdf5</command>
+      <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">pmi</command>
       <command name="rm">cray-mpich2</command>
       <command name="rm">cray-mpich</command>
@@ -272,6 +272,8 @@
       <command name="rm">cray-petsc</command>
       <command name="rm">esmf</command>
       <command name="rm">zlib</command>
+      <command name="rm">craype-hugepages2M</command>
+      <command name="rm">darshan</command>
 
       <!-- first load basic defaults, then remove/swap/load as necessary -->
       <command name="load">craype</command>
@@ -338,14 +340,12 @@
   <environment_variables>
     <env name="MPICH_ENV_DISPLAY">1</env>
     <env name="MPICH_VERSION_DISPLAY">1</env>
-    <env name="MPICH_CPUMASK_DISPLAY">1</env>
+    <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
 
     <env name="OMP_STACKSIZE">128M</env>
     <env name="OMP_PROC_BIND">spread</env>
     <env name="OMP_PLACES">threads</env>
     <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
-
-    <env name="PERL5LIB">/project/projectdirs/acme/perl5/lib/perl5/x86_64-linux-thread-multi</env>
   </environment_variables>
 
   <environment_variables mpilib="mpt">

--- a/cime/config/e3sm/machines/syslog.cori-haswell
+++ b/cime/config/e3sm/machines/syslog.cori-haswell
@@ -13,7 +13,7 @@ set dir = $6
 # Target length was determined empirically (maximum number of lines before job mapping 
 #  information starts + number of nodes), and it may need to be adjusted in the future.
 # (Note that calling script 'touch'es the e3sm log file before spawning this script, so that 'wc' does not fail.)
-set nnodes = `sqs -f $jid | grep -F NumNodes | sed 's/ *NumNodes=\([0-9]*\) .*/\1/' `
+set nnodes = `scontrol show jobid $jid | grep -F NumNodes | sed 's/ *NumNodes=\([0-9]*\) .*/\1/' `
 @ target_lines = 150 + $nnodes
 sleep 10
 set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
@@ -22,7 +22,7 @@ while ($outlth < $target_lines)
   set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
 end
 
-set TimeLimit   = `sqs -f $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set TimeLimit   = `scontrol show jobid $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set limit_hours = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set limit_mins  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set limit_secs  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -31,7 +31,7 @@ if ("X$limit_mins" == "X")  set limit_mins  = 0
 if ("X$limit_secs" == "X")  set limit_secs  = 0
 @ limit = 3600 * $limit_hours + 60 * $limit_mins + $limit_secs
 
-set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -78,7 +78,7 @@ while ($remaining > 0)
    @ sleep_remaining = $sleep_remaining - 120
   end
   sleep $sleep_remaining
-  set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+  set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
   set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
   set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
   set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `

--- a/cime/config/e3sm/machines/syslog.cori-knl
+++ b/cime/config/e3sm/machines/syslog.cori-knl
@@ -13,7 +13,7 @@ set dir = $6
 # Target length was determined empirically (maximum number of lines before job mapping 
 #  information starts + number of nodes), and it may need to be adjusted in the future.
 # (Note that calling script 'touch'es the e3sm log file before spawning this script, so that 'wc' does not fail.)
-set nnodes = `sqs -f $jid | grep -F NumNodes | sed 's/ *NumNodes=\([0-9]*\) .*/\1/' `
+set nnodes = `scontrol show jobid $jid | grep -F NumNodes | sed 's/ *NumNodes=\([0-9]*\) .*/\1/' `
 @ target_lines = 150 + $nnodes
 sleep 10
 set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
@@ -22,7 +22,7 @@ while ($outlth < $target_lines)
   set outlth = `wc \-l $run/e3sm.log.$lid | sed 's/ *\([0-9]*\) *.*/\1/' `
 end
 
-set TimeLimit   = `sqs -f $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set TimeLimit   = `scontrol show jobid $jid | grep -F TimeLimit | sed 's/^ *RunTime=.*TimeLimit=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set limit_hours = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set limit_mins  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set limit_secs  = `echo $TimeLimit | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -31,7 +31,7 @@ if ("X$limit_mins" == "X")  set limit_mins  = 0
 if ("X$limit_secs" == "X")  set limit_secs  = 0
 @ limit = 3600 * $limit_hours + 60 * $limit_mins + $limit_secs
 
-set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
 set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
 set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
 set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `
@@ -78,7 +78,7 @@ while ($remaining > 0)
    @ sleep_remaining = $sleep_remaining - 120
   end
   sleep $sleep_remaining
-  set RunTime    = `sqs -f $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
+  set RunTime    = `scontrol show jobid $jid | grep -F RunTime | sed 's/^ *RunTime=\([0-9]*:[0-9]*:[0-9]*\) .*/\1/' `
   set runt_hours = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\1/' `
   set runt_mins  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\2/' `
   set runt_secs  = `echo $RunTime | sed 's/^0*\([0-9]*\):0*\([0-9]*\):0*\([0-9]*\)/\3/' `

--- a/cime/scripts/lib/CIME/provenance.py
+++ b/cime/scripts/lib/CIME/provenance.py
@@ -163,8 +163,8 @@ def _save_prerun_timing_e3sm(case, lid):
                 run_cmd_no_fail(cmd, arg_stdout=filename, from_dir=full_timing_dir)
                 gzip_existing_file(os.path.join(full_timing_dir, filename))
         elif mach in ["cori-haswell", "cori-knl"]:
-            for cmd, filename in [("sinfo -a -l", "sinfol"), ("sqs -f %s" % job_id, "sqsf_jobid"),
-                                  # ("sqs -f", "sqsf"),
+            for cmd, filename in [("sinfo -a -l", "sinfol"), ("scontrol show jobid %s" % job_id, "sqsf_jobid"),
+                                  # ("scontrol show jobid", "sqsf"),
                                   ("squeue -o '%.10i %.15P %.20j %.10u %.7a %.2t %.6D %.8C %.10M %.10l %.20S %.20V'", "squeuef"),
                                   ("squeue -t R -o '%.10i %R'", "squeues")]:
                 filename = "%s.%s" % (filename, lid)


### PR DESCRIPTION
Several accumulated changes for Cori that are part of maint-1.0.
These changes should have no impact on results or performance.

Use scontrol instead of sqs for provenance.
Use CFS filesystem instead of projectdirs
Use e3sm_scratch instead of acme_scratch
Use project name of e3sm instead of acme
Change the way number of processors specified on srun line which can impact tests like PEM.
For cori-knl include fancier way of computing the -c flag which only affects certain cases.
Fix typo on module name.
Don't load darshan or hugepages module
Comment MPICH_CPUMASK_DISPLAY env variable as it's too verbose.
Remove PERL5LIB env var setting as that was temporary solution

[bfb]

I verified that the following test builds/runs on cori-knl:
SMS_D_P64x2_Ln5.ne4_ne4.FC5AV1C-L
