### PR TITLE
Switch on high-frequency coupling in sea ice at 10 iterations

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -375,8 +375,8 @@
 <config_calc_surface_stresses>true</config_calc_surface_stresses>
 <config_calc_surface_temperature>true</config_calc_surface_temperature>
 <config_use_form_drag>false</config_use_form_drag>
-<config_use_high_frequency_coupling>false</config_use_high_frequency_coupling>
-<config_boundary_layer_iteration_number>5</config_boundary_layer_iteration_number>
+<config_use_high_frequency_coupling>true</config_use_high_frequency_coupling>
+<config_boundary_layer_iteration_number>10</config_boundary_layer_iteration_number>
 
 <!-- ocean -->
 <config_use_ocean_mixed_layer>false</config_use_ocean_mixed_layer>


### PR DESCRIPTION
This PR is part of a final set of changes to E3SM Version 2 polar changes, and matches a PR from MPAS-SeaIce recently accepted into E3SM Master. It switches on high-frequency coupling in MPAS-SeaIce with an increased number of iterations.

[non-BFB]