### PR TITLE
Initialize mixing ratio when reading restarts

### DIFF
--- a/components/eam/src/control/cam_history.F90
+++ b/components/eam/src/control/cam_history.F90
@@ -1779,6 +1779,7 @@ CONTAINS
         tape(t)%hlist(f)%field%name = tmpname(f,t)
         tape(t)%hlist(f)%field%decomp_type = decomp(f,t)
         tape(t)%hlist(f)%field%numlev = tmpnumlev(f,t)
+        tape(t)%hlist(f)%field%mixing_ratio = ''
         tape(t)%hlist(f)%hwrt_prec = tmpprec(f,t)
 
         mdimcnt = count(allmdims(:,f,t) > 0)


### PR DESCRIPTION
Initialize mixing ratio for fields in the history list while
reading data from restart files.

This PR fixes the issue with mixing ratio (with invalid
values) being written out as field attributes for the
variables in the EAM history files.

Also see Issue #3966 

[BFB]