### PR TITLE
Change optimizations of modal_aero_calcsize.F90 to -O1 for Compy's PGI

### DIFF
--- a/cime_config/machines/Depends.compy.pgi.cmake
+++ b/cime_config/machines/Depends.compy.pgi.cmake
@@ -2,6 +2,7 @@
 set(O1MODELSRC
   eam/src/chemistry/aerosol/dust_sediment_mod.F90
   eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+  eam/src/chemistry/utils/modal_aero_calcsize.F90
   eam/src/physics/cam/zm_conv.F90)
 
 if (NOT DEBUG)


### PR DESCRIPTION
In prepration for the PR which refactors calcsize,
modal_aero_calcsize.F90 needs to be compiled with level 1 optimizations
(-O1). This applies only to the PGI compiler. GNU and Intel work fine
 with the default optimizations. Further investigations show that if we
use just the "-nofma" flag (no "fused multiply and add" optimization),
the results stay BFB. "-O1" optimizations implies "-nofma", so compiling
with -O1 is also sufficient for maintaing BFB answers with the PGI
compiler.

[Non-BFB] for compy's PGI compiler only