### PR TITLE
Ocean global limiting options for FCT vertical tracer advection

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -882,7 +882,7 @@ if ($OCN_FORCING eq 'datm_forced_restoring') {
 	add_default($nl, 'config_salinity_restoring_constant_piston_velocity', 'val'=>"1.585e-6");
 	add_default($nl, 'config_salinity_restoring_max_difference', 'val'=>"100.");
 	add_default($nl, 'config_salinity_restoring_under_sea_ice', 'val'=>".false.");
-	add_default($nl, 'config_activeTracer_vert_limiter', 'val'=>"'standard_FCT'");
+	add_default($nl, 'config_activeTracer_vert_limiter', 'val'=>"'fixed_global_limit'");
 	add_default($nl, 'config_vert_limiter_temperature_min', 'val'=>"-1.8");
 	add_default($nl, 'config_vert_limiter_temperature_max', 'val'=>"34");
 	add_default($nl, 'config_vert_limiter_salinity_min', 'val'=>"0");

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -737,6 +737,7 @@ add_default($nl, 'config_vert_tracer_adv_order');
 add_default($nl, 'config_horiz_tracer_adv_order');
 add_default($nl, 'config_coef_3rd_order');
 add_default($nl, 'config_monotonic');
+add_default($nl, 'config_adv_first_direction');
 
 ###############################
 # Namelist group: bottom_drag #
@@ -881,12 +882,22 @@ if ($OCN_FORCING eq 'datm_forced_restoring') {
 	add_default($nl, 'config_salinity_restoring_constant_piston_velocity', 'val'=>"1.585e-6");
 	add_default($nl, 'config_salinity_restoring_max_difference', 'val'=>"100.");
 	add_default($nl, 'config_salinity_restoring_under_sea_ice', 'val'=>".false.");
+	add_default($nl, 'config_activeTracer_vert_limiter', 'val'=>"'standard_FCT'");
+	add_default($nl, 'config_vert_limiter_temperature_min', 'val'=>"-1.8");
+	add_default($nl, 'config_vert_limiter_temperature_max', 'val'=>"34");
+	add_default($nl, 'config_vert_limiter_salinity_min', 'val'=>"0");
+	add_default($nl, 'config_vert_limiter_salinity_max', 'val'=>"45");
 } else {
 	add_default($nl, 'config_use_activeTracers_surface_restoring');
 	add_default($nl, 'config_use_surface_salinity_monthly_restoring');
 	add_default($nl, 'config_salinity_restoring_constant_piston_velocity');
 	add_default($nl, 'config_salinity_restoring_max_difference');
 	add_default($nl, 'config_salinity_restoring_under_sea_ice');
+	add_default($nl, 'config_activeTracer_vert_limiter');
+	add_default($nl, 'config_vert_limiter_temperature_min');
+	add_default($nl, 'config_vert_limiter_temperature_max');
+	add_default($nl, 'config_vert_limiter_salinity_min');
+	add_default($nl, 'config_vert_limiter_salinity_max');
 }
 add_default($nl, 'config_surface_salinity_monthly_restoring_compute_interval');
 add_default($nl, 'config_use_activeTracers_interior_restoring');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -268,6 +268,7 @@ add_default($nl, 'config_vert_tracer_adv_order');
 add_default($nl, 'config_horiz_tracer_adv_order');
 add_default($nl, 'config_coef_3rd_order');
 add_default($nl, 'config_monotonic');
+add_default($nl, 'config_adv_first_direction');
 
 ###############################
 # Namelist group: bottom_drag #
@@ -416,6 +417,11 @@ add_default($nl, 'config_surface_salinity_monthly_restoring_compute_interval');
 add_default($nl, 'config_salinity_restoring_constant_piston_velocity');
 add_default($nl, 'config_salinity_restoring_max_difference');
 add_default($nl, 'config_salinity_restoring_under_sea_ice');
+add_default($nl, 'config_activeTracer_vert_limiter');
+add_default($nl, 'config_vert_limiter_temperature_min');
+add_default($nl, 'config_vert_limiter_temperature_max');
+add_default($nl, 'config_vert_limiter_salinity_min');
+add_default($nl, 'config_vert_limiter_salinity_max');
 
 ###############################################
 # Namelist group: tracer_forcing_debugTracers #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -308,7 +308,7 @@
 <config_horiz_tracer_adv_order>3</config_horiz_tracer_adv_order>
 <config_coef_3rd_order>0.25</config_coef_3rd_order>
 <config_monotonic>.true.</config_monotonic>
-<config_adv_first_direction>'vertical'</config_adv_first_direction>
+<config_adv_first_direction>'horizontal'</config_adv_first_direction>
 
 <!-- bottom_drag -->
 <config_use_implicit_bottom_drag>.true.</config_use_implicit_bottom_drag>
@@ -447,7 +447,7 @@
 <config_salinity_restoring_constant_piston_velocity>1.585e-6</config_salinity_restoring_constant_piston_velocity>
 <config_salinity_restoring_max_difference>0.5</config_salinity_restoring_max_difference>
 <config_salinity_restoring_under_sea_ice>.false.</config_salinity_restoring_under_sea_ice>
-<config_activeTracer_vert_limiter>'fixed_global_limit'</config_activeTracer_vert_limiter>
+<config_activeTracer_vert_limiter>'standard_FCT'</config_activeTracer_vert_limiter>
 <config_vert_limiter_temperature_min>-1.8</config_vert_limiter_temperature_min>
 <config_vert_limiter_temperature_max>34</config_vert_limiter_temperature_max>
 <config_vert_limiter_salinity_min>0</config_vert_limiter_salinity_min>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -308,6 +308,7 @@
 <config_horiz_tracer_adv_order>3</config_horiz_tracer_adv_order>
 <config_coef_3rd_order>0.25</config_coef_3rd_order>
 <config_monotonic>.true.</config_monotonic>
+<config_adv_first_direction>'vertical'</config_adv_first_direction>
 
 <!-- bottom_drag -->
 <config_use_implicit_bottom_drag>.true.</config_use_implicit_bottom_drag>
@@ -446,6 +447,11 @@
 <config_salinity_restoring_constant_piston_velocity>1.585e-6</config_salinity_restoring_constant_piston_velocity>
 <config_salinity_restoring_max_difference>0.5</config_salinity_restoring_max_difference>
 <config_salinity_restoring_under_sea_ice>.false.</config_salinity_restoring_under_sea_ice>
+<config_activeTracer_vert_limiter>'fixed_global_limit'</config_activeTracer_vert_limiter>
+<config_vert_limiter_temperature_min>-1.8</config_vert_limiter_temperature_min>
+<config_vert_limiter_temperature_max>34</config_vert_limiter_temperature_max>
+<config_vert_limiter_salinity_min>0</config_vert_limiter_salinity_min>
+<config_vert_limiter_salinity_max>45</config_vert_limiter_salinity_max>
 
 <!-- tracer_forcing_debugTracers -->
 <config_use_debugTracers>.false.</config_use_debugTracers>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1392,6 +1392,14 @@ Valid values: .true. and .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_adv_first_direction" type="character"
+	category="advection" group="advection">
+If 'horizontal', advection is done with horizontal first, then vertical. If 'vertical', then the opposite.
+
+Valid values: 'horizontal' and 'vertical'
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- bottom_drag -->
 
@@ -2166,6 +2174,46 @@ Default: Defined in namelist_defaults.xml
 Flag to enable salinity restoring under sea ice.  The default setting is false, where salinity restoring tapers from full restoring in the open ocean (iceFraction=0.0) to zero restoring below full sea ice coverage (iceFraction=1.0); below partial sea ice coverage, restoring is in proportion to iceFraction.  If true, full salinity restoring is used everywhere, regardless of iceFraction value
 
 Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_activeTracer_vert_limiter" type="character"
+	category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+See options.
+
+Valid values: 'standard_FCT', 'fixed_global_limit', 'always_high_order', 'always_low_order'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_vert_limiter_temperature_min" type="real"
+	category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+Min value for vertical advection tracer limiter, when config_activeTracer_vert_limiter='fixed_global_limit'
+
+Valid values: any real number
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_vert_limiter_temperature_max" type="real"
+	category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+Max value for vertical advection tracer limiter, when config_activeTracer_vert_limiter='fixed_global_limit'
+
+Valid values: any real number
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_vert_limiter_salinity_min" type="real"
+	category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+Min value for vertical advection tracer limiter, when config_activeTracer_vert_limiter='fixed_global_limit'
+
+Valid values: any real number
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_vert_limiter_salinity_max" type="real"
+	category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+Max value for vertical advection tracer limiter, when config_activeTracer_vert_limiter='fixed_global_limit'
+
+Valid values: any real number
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1392,7 +1392,7 @@ Valid values: .true. and .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_adv_first_direction" type="character"
+<entry id="config_adv_first_direction" type="char*1024"
 	category="advection" group="advection">
 If 'horizontal', advection is done with horizontal first, then vertical. If 'vertical', then the opposite.
 
@@ -2177,7 +2177,7 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_activeTracer_vert_limiter" type="character"
+<entry id="config_activeTracer_vert_limiter" type="char*1024"
 	category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
 See options.
 


### PR DESCRIPTION
See https://github.com/MPAS-Dev/MPAS-Model/pull/774. This adds two new options:
- `config_adv_first_direction = 'horizontal'` (default, bfb with previous) and `'vertical'` (new option)
- `config_activeTracer_vert_limiter = 'standard_FCT'` (bfb with previous) and `'fixed_global_limit'` (proposed new default)

nonBFB