### PR TITLE
Set default atmos parameters for v2 in existing compsets

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_cam5_CMIP6.xml
@@ -58,44 +58,70 @@
 <!-- Tunable parameters for 72 layer model -->
 
 <ice_sed_ai              > 500.0     </ice_sed_ai>
-<cldfrc_dp1              > 0.045D0   </cldfrc_dp1>
-<clubb_ice_deep          > 16.e-6    </clubb_ice_deep>
 <clubb_ice_sh            > 50.e-6    </clubb_ice_sh>
 <clubb_liq_deep          > 8.e-6     </clubb_liq_deep>  
 <clubb_liq_sh            > 10.e-6    </clubb_liq_sh>
 <clubb_C2rt              > 1.75D0    </clubb_C2rt>
-<zmconv_c0_lnd           > 0.007     </zmconv_c0_lnd>
-<zmconv_c0_ocn           > 0.007     </zmconv_c0_ocn>
 <zmconv_dmpdz            >-0.7e-3    </zmconv_dmpdz>
-<zmconv_ke               > 5E-6      </zmconv_ke>
-<effgw_oro               > 0.25      </effgw_oro>
-<seasalt_emis_scale      > 0.85      </seasalt_emis_scale>
-<dust_emis_fact          > 1.38D0    </dust_emis_fact>
-<clubb_gamma_coef        > 0.32      </clubb_gamma_coef>
-<clubb_gamma_coefb> 0.32      </clubb_gamma_coefb>
-<clubb_C8                > 4.3       </clubb_C8>
+<zmconv_ke               > 5.0E-6      </zmconv_ke>
 <cldfrc2m_rhmaxi         > 1.05D0    </cldfrc2m_rhmaxi>
-<clubb_c_K10             > 0.3       </clubb_c_K10>
-<clubb_c_K10h             > 0.3       </clubb_c_K10h>
-<effgw_beres             > 0.4       </effgw_beres>
 <do_tms                  > .false.   </do_tms>
-<so4_sz_thresh_icenuc    > 0.05e-6   </so4_sz_thresh_icenuc>
 <n_so4_monolayers_pcage  > 8.0D0     </n_so4_monolayers_pcage>
-<micro_mg_accre_enhan_fac> 1.5D0     </micro_mg_accre_enhan_fac>
 <zmconv_tiedke_add       > 0.8D0     </zmconv_tiedke_add>
 <zmconv_cape_cin         > 1         </zmconv_cape_cin>
-<zmconv_mx_bot_lyr_adj   > 2         </zmconv_mx_bot_lyr_adj>
 <taubgnd                 > 2.5D-3    </taubgnd>
-<clubb_C1                > 1.335     </clubb_C1>
-<clubb_C1b                > 1.335     </clubb_C1b>
 <raytau0                 > 5.0D0     </raytau0>
 <prc_coef1               > 30500.0D0 </prc_coef1>
 <prc_exp                 > 3.19D0    </prc_exp>
-<prc_exp1                > -1.2D0    </prc_exp1>
-<clubb_C14               > 1.06D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>
 <rrtmg_temp_fix          > .true.    </rrtmg_temp_fix>
+
+<!-- Revised and new tunable parameters for v2 -->
+
+<clubb_ipdf_call_placement> 2         </clubb_ipdf_call_placement>
+<zmconv_trigdcape_ull    > .true.     </zmconv_trigdcape_ull>
+<cld_sed                 > 1.0D0      </cld_sed>
+<effgw_beres             > 0.35       </effgw_beres>
+<gw_convect_hcf          > 12.5       </gw_convect_hcf>
+<effgw_oro               > 0.375      </effgw_oro>
+<clubb_C14               > 2.5D0      </clubb_C14>
+<clubb_tk1               > 253.15D0   </clubb_tk1>
+<dust_emis_fact          > 1.50D0     </dust_emis_fact>
+<linoz_psc_T             > 197.5      </linoz_psc_T>
+<micro_mincdnc           > 10.D6      </micro_mincdnc>
+<clubb_C1                > 2.4        </clubb_C1>
+<clubb_C11               > 0.70       </clubb_C11>
+<clubb_C11b              > 0.20       </clubb_C11b>
+<clubb_C11c              > 0.85       </clubb_C11c>
+<clubb_C1b               > 2.8        </clubb_C1b>
+<clubb_C1c               > 0.75       </clubb_C1c>
+<clubb_C6rtb             > 7.50       </clubb_C6rtb>
+<clubb_C6rtc             > 0.50       </clubb_C6rtc>
+<clubb_C6thlb            > 7.50       </clubb_C6thlb>
+<clubb_C6thlc            > 0.50       </clubb_C6thlc>
+<clubb_C8                > 5.2        </clubb_C8>
+<clubb_c_K10             > 0.35       </clubb_c_K10>
+<clubb_c_K10h            > 0.35       </clubb_c_K10h>
+<clubb_gamma_coef        > 0.12D0     </clubb_gamma_coef>
+<clubb_gamma_coefb       > 0.28D0     </clubb_gamma_coefb>
+<clubb_gamma_coefc       > 1.2        </clubb_gamma_coefc>
+<clubb_mu                > 0.0005     </clubb_mu>
+<clubb_wpxp_l_thresh     > 100.0D0    </clubb_wpxp_l_thresh>
+<clubb_ice_deep          > 14.e-6     </clubb_ice_deep>
+<clubb_use_sgv           > .true.     </clubb_use_sgv>
+<seasalt_emis_scale      > 0.6        </seasalt_emis_scale>
+<zmconv_c0_lnd           > 0.0020     </zmconv_c0_lnd>
+<zmconv_c0_ocn           > 0.0020     </zmconv_c0_ocn>
+<zmconv_alfa             > 0.14D0     </zmconv_alfa>
+<zmconv_tp_fac           > 2.0D0      </zmconv_tp_fac>
+<zmconv_mx_bot_lyr_adj   > 1          </zmconv_mx_bot_lyr_adj>
+<prc_exp1                > -1.40D0    </prc_exp1>
+<micro_mg_accre_enhan_fac> 1.75D0     </micro_mg_accre_enhan_fac>
+<microp_aero_wsubmin     > 0.001D0    </microp_aero_wsubmin>
+<so4_sz_thresh_icenuc    > 0.080e-6   </so4_sz_thresh_icenuc>
+<micro_mg_berg_eff_factor> 0.7D0      </micro_mg_berg_eff_factor>
+<cldfrc_dp1              > 0.018D0    </cldfrc_dp1>
 
 <!-- Energy fixer options -->
 <ieflx_opt  > 2     </ieflx_opt>

--- a/components/eam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
@@ -62,44 +62,70 @@
 <!-- Tunable parameters for 72 layer model -->
 
 <ice_sed_ai              > 500.0     </ice_sed_ai>
-<cldfrc_dp1              > 0.045D0   </cldfrc_dp1>
-<clubb_ice_deep          > 16.e-6    </clubb_ice_deep>
 <clubb_ice_sh            > 50.e-6    </clubb_ice_sh>
 <clubb_liq_deep          > 8.e-6     </clubb_liq_deep>  
 <clubb_liq_sh            > 10.e-6    </clubb_liq_sh>
 <clubb_C2rt              > 1.75D0    </clubb_C2rt>
-<zmconv_c0_lnd           > 0.007     </zmconv_c0_lnd>
-<zmconv_c0_ocn           > 0.007     </zmconv_c0_ocn>
 <zmconv_dmpdz            >-0.7e-3    </zmconv_dmpdz>
-<zmconv_ke               > 5E-6      </zmconv_ke>
-<effgw_oro               > 0.25      </effgw_oro>
-<seasalt_emis_scale      > 0.85      </seasalt_emis_scale>
-<dust_emis_fact          > 1.38D0    </dust_emis_fact>
-<clubb_gamma_coef        > 0.32      </clubb_gamma_coef>
-<clubb_gamma_coefb       > 0.32      </clubb_gamma_coefb>
-<clubb_C8                > 4.3       </clubb_C8>
+<zmconv_ke               > 5.0E-6      </zmconv_ke>
 <cldfrc2m_rhmaxi         > 1.05D0    </cldfrc2m_rhmaxi>
-<clubb_c_K10             > 0.3       </clubb_c_K10>
-<clubb_c_K10h             > 0.3       </clubb_c_K10h>
-<effgw_beres             > 0.4       </effgw_beres>
 <do_tms                  > .false.   </do_tms>
-<so4_sz_thresh_icenuc    > 0.05e-6   </so4_sz_thresh_icenuc>
 <n_so4_monolayers_pcage  > 8.0D0     </n_so4_monolayers_pcage>
-<micro_mg_accre_enhan_fac> 1.5D0     </micro_mg_accre_enhan_fac>
 <zmconv_tiedke_add       > 0.8D0     </zmconv_tiedke_add>
 <zmconv_cape_cin         > 1         </zmconv_cape_cin>
-<zmconv_mx_bot_lyr_adj   > 2         </zmconv_mx_bot_lyr_adj>
 <taubgnd                 > 2.5D-3    </taubgnd>
-<clubb_C1                > 1.335     </clubb_C1>
-<clubb_C1b               > 1.335     </clubb_C1b>
 <raytau0                 > 5.0D0     </raytau0>
 <prc_coef1               > 30500.0D0 </prc_coef1>
 <prc_exp                 > 3.19D0    </prc_exp>
-<prc_exp1                > -1.2D0    </prc_exp1>
-<clubb_C14               > 1.06D0     </clubb_C14>
 <relvar_fix              > .true.    </relvar_fix>
 <mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>
 <rrtmg_temp_fix          > .true.    </rrtmg_temp_fix>
+
+<!-- Revised and new tunable parameters for v2 -->
+
+<clubb_ipdf_call_placement> 2         </clubb_ipdf_call_placement>
+<zmconv_trigdcape_ull    > .true.     </zmconv_trigdcape_ull>
+<cld_sed                 > 1.0D0      </cld_sed>
+<effgw_beres             > 0.35       </effgw_beres>
+<gw_convect_hcf          > 12.5       </gw_convect_hcf>
+<effgw_oro               > 0.375      </effgw_oro>
+<clubb_C14               > 2.5D0      </clubb_C14>
+<clubb_tk1               > 253.15D0   </clubb_tk1>
+<dust_emis_fact          > 1.50D0     </dust_emis_fact>
+<linoz_psc_T             > 197.5      </linoz_psc_T>
+<micro_mincdnc           > 10.D6      </micro_mincdnc>
+<clubb_C1                > 2.4        </clubb_C1>
+<clubb_C11               > 0.70       </clubb_C11>
+<clubb_C11b              > 0.20       </clubb_C11b>
+<clubb_C11c              > 0.85       </clubb_C11c>
+<clubb_C1b               > 2.8        </clubb_C1b>
+<clubb_C1c               > 0.75       </clubb_C1c>
+<clubb_C6rtb             > 7.50       </clubb_C6rtb>
+<clubb_C6rtc             > 0.50       </clubb_C6rtc>
+<clubb_C6thlb            > 7.50       </clubb_C6thlb>
+<clubb_C6thlc            > 0.50       </clubb_C6thlc>
+<clubb_C8                > 5.2        </clubb_C8>
+<clubb_c_K10             > 0.35       </clubb_c_K10>
+<clubb_c_K10h            > 0.35       </clubb_c_K10h>
+<clubb_gamma_coef        > 0.12D0     </clubb_gamma_coef>
+<clubb_gamma_coefb       > 0.28D0     </clubb_gamma_coefb>
+<clubb_gamma_coefc       > 1.2        </clubb_gamma_coefc>
+<clubb_mu                > 0.0005     </clubb_mu>
+<clubb_wpxp_l_thresh     > 100.0D0    </clubb_wpxp_l_thresh>
+<clubb_ice_deep          > 14.e-6     </clubb_ice_deep>
+<clubb_use_sgv           > .true.     </clubb_use_sgv>
+<seasalt_emis_scale      > 0.6        </seasalt_emis_scale>
+<zmconv_c0_lnd           > 0.0020     </zmconv_c0_lnd>
+<zmconv_c0_ocn           > 0.0020     </zmconv_c0_ocn>
+<zmconv_alfa             > 0.14D0     </zmconv_alfa>
+<zmconv_tp_fac           > 2.0D0      </zmconv_tp_fac>
+<zmconv_mx_bot_lyr_adj   > 1          </zmconv_mx_bot_lyr_adj>
+<prc_exp1                > -1.40D0    </prc_exp1>
+<micro_mg_accre_enhan_fac> 1.75D0     </micro_mg_accre_enhan_fac>
+<microp_aero_wsubmin     > 0.001D0    </microp_aero_wsubmin>
+<so4_sz_thresh_icenuc    > 0.080e-6   </so4_sz_thresh_icenuc>
+<micro_mg_berg_eff_factor> 0.7D0      </micro_mg_berg_eff_factor>
+<cldfrc_dp1              > 0.018D0    </cldfrc_dp1>
 
 <!-- Energy fixer options -->
 <ieflx_opt  > 0     </ieflx_opt>

--- a/components/eam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_cam5_CMIP6.xml
@@ -54,48 +54,74 @@
 
 <!-- Tunable parameters for 72 layer model -->
 
-<ice_sed_ai>500.0</ice_sed_ai>
-<cldfrc_dp1>0.045D0</cldfrc_dp1>
-<clubb_ice_deep>16.e-6</clubb_ice_deep>
-<clubb_ice_sh>50.e-6</clubb_ice_sh>
-<clubb_liq_deep>8.e-6</clubb_liq_deep>  
-<clubb_liq_sh>10.e-6</clubb_liq_sh>
-<clubb_C2rt>1.75D0</clubb_C2rt>
-<zmconv_c0_lnd>0.007</zmconv_c0_lnd>
-<zmconv_c0_ocn>0.007</zmconv_c0_ocn>
-<zmconv_dmpdz>-0.7e-3</zmconv_dmpdz>
-<zmconv_ke>5.e-6</zmconv_ke>
-<effgw_oro>0.25</effgw_oro>
-<seasalt_emis_scale>0.85</seasalt_emis_scale>
-<dust_emis_fact>1.38D0</dust_emis_fact>
-<clubb_gamma_coef>0.32</clubb_gamma_coef>
-<clubb_gamma_coefb>0.32</clubb_gamma_coefb>
-<clubb_C8>4.3</clubb_C8>
-<cldfrc2m_rhmaxi>1.05D0</cldfrc2m_rhmaxi>
-<clubb_c_K10>0.3</clubb_c_K10>
-<clubb_c_K10h>0.3</clubb_c_K10h>
-<effgw_beres>0.4</effgw_beres>
-<do_tms>.false.</do_tms>
-<so4_sz_thresh_icenuc>0.05e-6</so4_sz_thresh_icenuc>
-<n_so4_monolayers_pcage>8.0D0</n_so4_monolayers_pcage>
-<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
-<zmconv_tiedke_add>0.8D0</zmconv_tiedke_add>
-<zmconv_cape_cin>1</zmconv_cape_cin>
-<zmconv_mx_bot_lyr_adj>2</zmconv_mx_bot_lyr_adj>
-<taubgnd>2.5D-3</taubgnd>
-<clubb_C1>1.335</clubb_C1>
-<clubb_C1b>1.335</clubb_C1b>
-<raytau0>5.0D0</raytau0>
-<prc_coef1>30500.0D0</prc_coef1>
-<prc_exp>3.19D0</prc_exp>
-<prc_exp1>-1.2D0</prc_exp1>
-<clubb_C14>1.06D0</clubb_C14>
-<relvar_fix>.true.</relvar_fix>
-<mg_prc_coeff_fix>.true.</mg_prc_coeff_fix>
-<rrtmg_temp_fix>.true.</rrtmg_temp_fix>
+<ice_sed_ai              > 500.0     </ice_sed_ai>
+<clubb_ice_sh            > 50.e-6    </clubb_ice_sh>
+<clubb_liq_deep          > 8.e-6     </clubb_liq_deep>  
+<clubb_liq_sh            > 10.e-6    </clubb_liq_sh>
+<clubb_C2rt              > 1.75D0    </clubb_C2rt>
+<zmconv_dmpdz            >-0.7e-3    </zmconv_dmpdz>
+<zmconv_ke               > 5.0E-6      </zmconv_ke>
+<cldfrc2m_rhmaxi         > 1.05D0    </cldfrc2m_rhmaxi>
+<do_tms                  > .false.   </do_tms>
+<n_so4_monolayers_pcage  > 8.0D0     </n_so4_monolayers_pcage>
+<zmconv_tiedke_add       > 0.8D0     </zmconv_tiedke_add>
+<zmconv_cape_cin         > 1         </zmconv_cape_cin>
+<taubgnd                 > 2.5D-3    </taubgnd>
+<raytau0                 > 5.0D0     </raytau0>
+<prc_coef1               > 30500.0D0 </prc_coef1>
+<prc_exp                 > 3.19D0    </prc_exp>
+<relvar_fix              > .true.    </relvar_fix>
+<mg_prc_coeff_fix        > .true.    </mg_prc_coeff_fix>
+<rrtmg_temp_fix          > .true.    </rrtmg_temp_fix>
+
+<!-- Revised and new tunable parameters for v2 -->
+
+<clubb_ipdf_call_placement> 2         </clubb_ipdf_call_placement>
+<zmconv_trigdcape_ull    > .true.     </zmconv_trigdcape_ull>
+<cld_sed                 > 1.0D0      </cld_sed>
+<effgw_beres             > 0.35       </effgw_beres>
+<gw_convect_hcf          > 12.5       </gw_convect_hcf>
+<effgw_oro               > 0.375      </effgw_oro>
+<clubb_C14               > 2.5D0      </clubb_C14>
+<clubb_tk1               > 253.15D0   </clubb_tk1>
+<dust_emis_fact          > 1.50D0     </dust_emis_fact>
+<linoz_psc_T             > 197.5      </linoz_psc_T>
+<micro_mincdnc           > 10.D6      </micro_mincdnc>
+<clubb_C1                > 2.4        </clubb_C1>
+<clubb_C11               > 0.70       </clubb_C11>
+<clubb_C11b              > 0.20       </clubb_C11b>
+<clubb_C11c              > 0.85       </clubb_C11c>
+<clubb_C1b               > 2.8        </clubb_C1b>
+<clubb_C1c               > 0.75       </clubb_C1c>
+<clubb_C6rtb             > 7.50       </clubb_C6rtb>
+<clubb_C6rtc             > 0.50       </clubb_C6rtc>
+<clubb_C6thlb            > 7.50       </clubb_C6thlb>
+<clubb_C6thlc            > 0.50       </clubb_C6thlc>
+<clubb_C8                > 5.2        </clubb_C8>
+<clubb_c_K10             > 0.35       </clubb_c_K10>
+<clubb_c_K10h            > 0.35       </clubb_c_K10h>
+<clubb_gamma_coef        > 0.12D0     </clubb_gamma_coef>
+<clubb_gamma_coefb       > 0.28D0     </clubb_gamma_coefb>
+<clubb_gamma_coefc       > 1.2        </clubb_gamma_coefc>
+<clubb_mu                > 0.0005     </clubb_mu>
+<clubb_wpxp_l_thresh     > 100.0D0    </clubb_wpxp_l_thresh>
+<clubb_ice_deep          > 14.e-6     </clubb_ice_deep>
+<clubb_use_sgv           > .true.     </clubb_use_sgv>
+<seasalt_emis_scale      > 0.6        </seasalt_emis_scale>
+<zmconv_c0_lnd           > 0.0020     </zmconv_c0_lnd>
+<zmconv_c0_ocn           > 0.0020     </zmconv_c0_ocn>
+<zmconv_alfa             > 0.14D0     </zmconv_alfa>
+<zmconv_tp_fac           > 2.0D0      </zmconv_tp_fac>
+<zmconv_mx_bot_lyr_adj   > 1          </zmconv_mx_bot_lyr_adj>
+<prc_exp1                > -1.40D0    </prc_exp1>
+<micro_mg_accre_enhan_fac> 1.75D0     </micro_mg_accre_enhan_fac>
+<microp_aero_wsubmin     > 0.001D0    </microp_aero_wsubmin>
+<so4_sz_thresh_icenuc    > 0.080e-6   </so4_sz_thresh_icenuc>
+<micro_mg_berg_eff_factor> 0.7D0      </micro_mg_berg_eff_factor>
+<cldfrc_dp1              > 0.018D0    </cldfrc_dp1>
 
 <!-- Energy fixer options -->
-<ieflx_opt  > 2     </ieflx_opt>
+<ieflx_opt  > 0     </ieflx_opt>
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>


### PR DESCRIPTION
Set default atmos parameter values for the following three compsets that
are used  for v2 finalization simulations based on alpha5_59

   A_WCYCL1850S_CMIP6, F20TRC5-CMIP6 and  F2010SC5-CMIP6

[NBFB] non-BFB for simulations using these  compsets