### PR TITLE
Change default location for SAVE_TIMING_DIR on Chrysalis

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1126,7 +1126,7 @@
     <COMPILERS>intel,gnu</COMPILERS>
     <MPILIBS>impi,openmpi</MPILIBS>
     <PROJECT>e3sm</PROJECT>
-    <SAVE_TIMING_DIR>/lcrc/group/e3sm</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR>/lcrc/group/e3sm/PERF_Chrysalis</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>/lcrc/group/e3sm/$USER/scratch/chrys</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/lcrc/group/e3sm/data/inputdata</DIN_LOC_ROOT>


### PR DESCRIPTION
Currently, jobs on Anvil and Chrysalis archive performance data
in the same location. This may cause errors if Jenkins jobs,
one on Anvil and one on Chrysalis, attempt to access these
performance data simultaneously. To avoid this possibility,
the default location for archiving performance data, specified
in SAVE_TIMING_DIR, is changed for Chrysalis.

[BFB]