### PR TITLE
Enable FATES harvest using fdyndat data passed from ELM to FATES

### DIFF
--- a/components/elm/bld/ELMBuildNamelist.pm
+++ b/components/elm/bld/ELMBuildNamelist.pm
@@ -2636,11 +2636,8 @@ sub setup_logic_do_harvest {
   if (string_is_undef_or_empty($nl->get_value('flanduse_timeseries'))) {
     $cannot_be_true = "$var can only be set to true when running a transient case (flanduse_timeseries non-blank)";
   }
-  elsif (!value_is_true($nl->get_value('use_cn'))) {
-    $cannot_be_true = "$var can only be set to true when running with CN (use_cn = true)";
-  }
-  elsif (value_is_true($nl->get_value('use_fates'))) {
-    $cannot_be_true = "$var currently doesn't work with FATES";
+  elsif (!( value_is_true($nl->get_value('use_cn')) || value_is_true($nl->get_value('use_fates')) )) {
+    $cannot_be_true = "$var can only be set to true when running with CN (use_cn == true) or when using FATES (use_fates == true)";
   }
   
   if ($cannot_be_true) {

--- a/components/elm/src/dyn_subgrid/dynHarvestMod.F90
+++ b/components/elm/src/dyn_subgrid/dynHarvestMod.F90
@@ -25,17 +25,22 @@ module dynHarvestMod
   use ColumnDataType        , only : col_cf, col_nf, col_pf  
   use VegetationType        , only : veg_pp                
   use VegetationDataType    , only : veg_cs, veg_cf, veg_ns, veg_nf  
-  use VegetationDataType    , only : veg_ps, veg_pf  
   use topounit_varcon      , only : max_topounits
-  
+  use VegetationDataType    , only : veg_ps, veg_pf  
+  use VegetationDataType    , only : veg_ps, veg_pf
+  use elm_varctl            , only : use_cn, use_fates
+  use FatesConstantsMod      , only : hlm_harvest_area_fraction
+  use FatesConstantsMod      , only : hlm_harvest_carbon
+
+  !
   ! !PUBLIC MEMBER FUNCTIONS:
   implicit none
   private
   save
   public :: dynHarvest_init    ! initialize data structures for harvest information
-  public :: dynHarvest_interp  ! get harvest data for current time step, if needed
-  public :: CNHarvest          ! harvest mortality routine for CN code
-  
+  public :: dynHarvest_interp_harvest_types  ! get harvest data for each harvest type, if needed
+  public :: CNHarvest          ! harvest mortality routine for CN code (non-FATES)
+  !
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: CNHarvestPftToColumn   ! gather pft-level harvest fluxes to the column level
   
@@ -46,15 +51,37 @@ module dynHarvestMod
   ! the pftdyn data
   type(dyn_file_type), target :: dynHarvest_file ! information for the file containing harvest data
 
-  ! Define the underlying harvest variables
+  ! Define the underlying input harvest variables
+  ! these are hardcoded to match the LUH input data
+  ! these are fraction of vegetated area harvested, split into five harvest type variables
+  ! in next iteration (v3) change these to fraction of grid cell
+  ! HARVEST_VH1 = harvest from primary forest
+  ! HARVEST_VH2 = harvest from primary non-forest
+  ! HARVEST_SH1 = harvest from secondary mature forest
+  ! HARVEST_SH2 = harvest from secondary young forest
+  ! HARVEST_SH3 = harvest from secondary non-forest
+  ! note that these are summed for CNHarvest in harvest(:) and applied to total forest area only
+  ! the individual category rates are passed to fates in harvest_rates(:,:)
+
+  ! for FATES: capacity for passing harvest data in units of carbon harvested per year (per grid cell) has been added
+  ! but these data are not yet included in the input file
+  ! the code here can be changed to wood_harvest_units = harvest_carbon to pass carbon data to FATES if:
+  !  the carbon data are in the same input variables as listed below
+  !  and the carbon units in the input file match that expected by FATES
+
   integer, public, parameter :: num_harvest_vars = 5
   character(len=64), public, parameter :: harvest_varnames(num_harvest_vars) = &
-       [character(len=64) :: 'HARVEST_VH1', 'HARVEST_VH2', 'HARVEST_SH1', 'HARVEST_SH2', 'HARVEST_SH3']
+       [character(len=64)  :: 'HARVEST_VH1', 'HARVEST_VH2', 'HARVEST_SH1', 'HARVEST_SH2', 'HARVEST_SH3']
+  ! the units flag must match the units of harvest_varnames
+  ! set this here because dynHarvest_init is called after alm_fates%init
+  ! this flag is accessed only if namelist do_harvest is TRUE
+  integer, public          :: wood_harvest_units = hlm_harvest_area_fraction
   
   type(dyn_var_time_uninterp_type) :: harvest_vars(num_harvest_vars)   ! value of each harvest variable
 
-  real(r8) , allocatable   :: harvest(:,:) ! harvest rates
-  logical                  :: do_harvest ! whether we're in a period when we should do harvest
+  real(r8) , allocatable, public   :: harvest_rates(:,:) ! category harvest rates (d1) in each gridcell (d2)
+
+  logical, private         :: do_harvest ! whether we're in a period when we should do harvest
   !---------------------------------------------------------------------------
 
 contains
@@ -65,10 +92,7 @@ contains
     ! !DESCRIPTION:
     ! Initialize data structures for harvest information.
     ! This should be called once, during model initialization.
-     
-    ! This also calls dynHarvest_interp for the initial time
-    
-    ! !USES:
+    !
     use elm_varctl            , only : use_cn
     use dynVarTimeUninterpMod , only : dyn_var_time_uninterp_type
     use dynTimeInfoMod        , only : YEAR_POSITION_START_OF_TIMESTEP
@@ -89,65 +113,64 @@ contains
 
     SHR_ASSERT_ALL(bounds%level == BOUNDS_LEVEL_PROC, subname // ': argument must be PROC-level bounds')
 
-    allocate(harvest(bounds%begg:bounds%endg,max_topounits),stat=ier) 
+    allocate(harvest_rates(num_harvest_vars,bounds%begg:bounds%endg),stat=ier)
+    harvest_rates(:,bounds%begg:bounds%endg) = 0._r8
     if (ier /= 0) then
-       call endrun(msg=' allocation error for harvest'//errMsg(__FILE__, __LINE__))
+       call endrun(msg=' allocation error for harvest_rates'//errMsg(__FILE__, __LINE__))
     end if
 
     !dynHarvest_file = dyn_file_type(harvest_filename, YEAR_POSITION_START_OF_TIMESTEP)
     dynHarvest_file = dyn_file_type(harvest_filename, YEAR_POSITION_END_OF_TIMESTEP)
     
     ! Get initial harvest data
-    if (use_cn) then
-       num_points = (bounds%endg - bounds%begg + 1)  
-       harvest_shape = [num_points, max_topounits]       
+    if (use_cn .or. use_fates) then
+       num_points = (bounds%endg - bounds%begg + 1)
        do varnum = 1, num_harvest_vars
           harvest_vars(varnum) = dyn_var_time_uninterp_type( &
                dyn_file=dynHarvest_file, varname=harvest_varnames(varnum), &
                dim1name=grlnd, conversion_factor=1.0_r8, &
                do_check_sums_equal_1=.false., data_shape=harvest_shape)
        end do
-       call dynHarvest_interp(bounds)
+
     end if
     
   end subroutine dynHarvest_init
 
-
-  !-----------------------------------------------------------------------
-  subroutine dynHarvest_interp(bounds)
-    
+!-----------------------------------------------------------------------
+  subroutine dynHarvest_interp_harvest_types(bounds)
+    !
     ! !DESCRIPTION:
-    ! Get harvest data for model time, when needed.
-    
+    ! Get harvest data for model time, by land category, when needed.
+    ! this function called only for CN (non-FATES) or FATES
+    !
     ! Note that harvest data are stored as rates (not weights) and so time interpolation
     ! is not necessary - the harvest rate is held constant through the year.  This is
     ! consistent with the treatment of changing PFT weights, where interpolation of the
     ! annual endpoint weights leads to a constant rate of change in PFT weight through the
     ! year, with abrupt changes in the rate at annual boundaries.
-    
+    !
+    ! Note the difference between this and the old dynHarvest_interp is that here, we keep the different
+    ! forcing sets distinct (e.g., for passing to FATES which has distinct primary and secondary lands)
+    ! and thus store it in harvest_rates
+    !
     ! !USES:
-    use elm_varctl     , only : use_cn
     use dynTimeInfoMod , only : time_info_type
-    
+    use elm_varctl            , only : use_cn, use_fates
+    !
     ! !ARGUMENTS:
     type(bounds_type), intent(in) :: bounds  ! proc-level bounds
     
     ! !LOCAL VARIABLES:
     integer               :: varnum       ! counter for harvest variables
-    real(r8), allocatable :: this_data(:,:) ! data for a single harvest variable
-
-    character(len=*), parameter :: subname = 'dynHarvest_interp'
+    real(r8), allocatable :: this_data(:) ! data for a single harvest variable
+    character(len=*), parameter :: subname = 'dynHarvest_interp_harvest_types'
     !-----------------------------------------------------------------------
-
     SHR_ASSERT_ALL(bounds%level == BOUNDS_LEVEL_PROC, subname // ': argument must be PROC-level bounds')
 
-    ! As a workaround for an internal compiler error with ifort 13.1.2 on goldbach, call
-    ! the specific name of this procedure rather than using its generic name
-    call dynHarvest_file%time_info%set_current_year_get_year()
-
-    ! Get total harvest for this time step
-    if (use_cn) then
-       harvest(bounds%begg:bounds%endg,:) = 0._r8    
+    ! input harvest data for current year are stored in year+1 in the file
+    call dynHarvest_file%time_info%set_current_year_get_year(1)
+    if (use_cn .or. use_fates) then
+       harvest_rates(1:num_harvest_vars,bounds%begg:bounds%endg) = 0._r8
 
        if (dynHarvest_file%time_info%is_before_time_series()) then
           ! Turn off harvest before the start of the harvest time series
@@ -157,17 +180,15 @@ contains
           ! means that harvest rates will be maintained at the rate given in the last
           ! year of the file for all years past the end of this specified time series.
           do_harvest = .true.
-          allocate(this_data(bounds%begg:bounds%endg,max_topounits))   
+          allocate(this_data(bounds%begg:bounds%endg))   
           do varnum = 1, num_harvest_vars
              call harvest_vars(varnum)%get_current_data(this_data)
-             harvest(bounds%begg:bounds%endg,:) = harvest(bounds%begg:bounds%endg,:) + &    
-                                                this_data(bounds%begg:bounds%endg,:)      
+             harvest_rates(varnum,bounds%begg:bounds%endg) = this_data(bounds%begg:bounds%endg)
           end do
           deallocate(this_data)
        end if
     end if
-
-  end subroutine dynHarvest_interp
+  end subroutine dynHarvest_interp_harvest_types
 
 
   !-----------------------------------------------------------------------
@@ -196,6 +217,7 @@ contains
     real(r8):: am                        ! rate for fractional harvest mortality (1/yr)
     real(r8):: m                         ! rate for fractional harvest mortality (1/s)
     real(r8):: days_per_year             ! days per year
+    integer :: varnum                    ! counter for harvest variables
     !-----------------------------------------------------------------------
 
    associate(& 
@@ -354,7 +376,10 @@ contains
       if (ivt(p) > noveg .and. ivt(p) < nbrdlf_evr_shrub) then
 
          if (do_harvest) then
-            am = harvest(g,ti)
+            am = 0._r8
+            do varnum = 1, num_harvest_vars
+               am = am + harvest_rates(varnum,g)
+            end do
             m  = am/(days_per_year * secspday)
          else
             m = 0._r8

--- a/components/elm/src/dyn_subgrid/dynHarvestMod.F90
+++ b/components/elm/src/dyn_subgrid/dynHarvestMod.F90
@@ -28,7 +28,7 @@ module dynHarvestMod
   use topounit_varcon      , only : max_topounits
   use VegetationDataType    , only : veg_ps, veg_pf  
   use VegetationDataType    , only : veg_ps, veg_pf
-  use elm_varctl            , only : use_cn, use_fates
+  use elm_varctl            , only : use_cn, use_fates, iulog
   use FatesConstantsMod      , only : hlm_harvest_area_fraction
   use FatesConstantsMod      , only : hlm_harvest_carbon
 
@@ -104,7 +104,7 @@ contains
     
     ! !LOCAL VARIABLES:
     integer :: varnum     ! counter for harvest variables
-    integer :: harvest_shape(2)  ! harvest shape 
+    integer :: harvest_shape(1)  ! harvest shape 
     integer :: num_points ! number of spatial points
     integer :: ier        ! error code
     
@@ -125,6 +125,7 @@ contains
     ! Get initial harvest data
     if (use_cn .or. use_fates) then
        num_points = (bounds%endg - bounds%begg + 1)
+       harvest_shape(1) = num_points
        do varnum = 1, num_harvest_vars
           harvest_vars(varnum) = dyn_var_time_uninterp_type( &
                dyn_file=dynHarvest_file, varname=harvest_varnames(varnum), &

--- a/components/elm/src/dyn_subgrid/dynSubgridControlMod.F90
+++ b/components/elm/src/dyn_subgrid/dynSubgridControlMod.F90
@@ -231,12 +231,8 @@ contains
     end if
 
     if (dyn_subgrid_control_inst%do_harvest) then
-       if (.not. use_cn) then
-          write(iulog,*) 'ERROR: do_harvest can only be true if use_cn is true'
-          call endrun(msg=errMsg(sourcefile, __LINE__))
-       end if
-       if (use_fates) then
-          write(iulog,*) 'ERROR: do_harvest currently does not work with use_fates'
+       if (.not. (use_cn .or. use_fates)) then
+          write(iulog,*) 'ERROR: do_harvest can be true only if use_cn is true or use_fates is true'
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end if
     end if

--- a/components/elm/src/dyn_subgrid/dynSubgridDriverMod.F90
+++ b/components/elm/src/dyn_subgrid/dynSubgridDriverMod.F90
@@ -160,7 +160,7 @@ contains
     use dynConsBiogeophysMod , only : dyn_hwcontent_init, dyn_hwcontent_final
     use dynConsBiogeochemMod , only : dyn_cnbal_patch, dyn_cnbal_column
     use dynpftFileMod        , only : dynpft_interp
-    use dynHarvestMod        , only : dynHarvest_interp
+    use dynHarvestMod        , only : dynHarvest_interp_harvest_types
     use dynEDMod             , only : dyn_ED
     use reweightMod          , only : reweight_wrapup
     use subgridWeightsMod    , only : compute_higher_order_weights, set_subgrid_diagnostic_fields
@@ -241,7 +241,7 @@ contains
     end if
 
     if (get_do_harvest()) then
-       call dynHarvest_interp(bounds_proc)
+       call dynHarvest_interp_harvest_types(bounds_proc)
     end if
 
     ! ==========================================================================

--- a/components/elm/src/dyn_subgrid/dynVarTimeUninterpMod.F90.in
+++ b/components/elm/src/dyn_subgrid/dynVarTimeUninterpMod.F90.in
@@ -121,7 +121,7 @@ contains
     
     ! Should be called once per time step, AFTER calling set_current_year on the
     ! underlying dyn_file variable
-    
+   
     ! !ARGUMENTS:
     class(dyn_var_time_uninterp_type) , intent(inout) :: this             ! this object
     real(r8)                          , intent(out)   :: cur_data{DIMSTR} ! current value of data
@@ -134,6 +134,7 @@ contains
     
     ! Do some error checking
     ndims = size(this%get_data_shape())
+
     SHR_ASSERT({DIMS} == ndims, subname//' ERROR: # dims of output argument must match ndims')
     SHR_ASSERT_ALL((shape(cur_data) == this%get_data_shape()), subname//' ERROR: shape of cur_data must match shape of data')
 

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -934,8 +934,8 @@ contains
     ! --------------------------------------------------------------
     ! Initialise the FATES model state structure cold-start
     ! --------------------------------------------------------------
-   
-    if ( use_fates .and. .not.is_restart() .and. finidat == ' ') then
+
+    if ( use_fates .and. .not.is_restart() .and. finidat == ' ' .and. nsrest /= nsrBranch) then
        call alm_fates%init_coldstart(canopystate_vars, soilstate_vars, frictionvel_vars)
     end if
 

--- a/components/elm/src/main/elm_instMod.F90
+++ b/components/elm/src/main/elm_instMod.F90
@@ -245,7 +245,7 @@ contains
 
     ! Initialize the Functionaly Assembled Terrestrial Ecosystem Simulator (FATES)
     if (use_fates) then
-       call alm_fates%Init(bounds_proc)
+       call alm_fates%init(bounds_proc)
     end if
 
     call hist_printflds()

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -54,6 +54,7 @@ module ELMFatesInterfaceMod
    use elm_varctl        , only : use_fates_logging
    use elm_varctl        , only : use_fates_inventory_init
    use elm_varctl        , only : use_fates_fixed_biogeog
+   use elm_varctl        , only : nsrest, nsrBranch
    use elm_varctl        , only : fates_inventory_ctrl_filename
    use elm_varcon        , only : tfrz
    use elm_varcon        , only : spval 
@@ -145,8 +146,14 @@ module ELMFatesInterfaceMod
    use FatesPlantHydraulicsMod, only : InitHydrSites
    use FatesPlantHydraulicsMod, only : RestartHydrStates
 
-   use dynHarvestMod          , only : num_harvest_vars, harvest_varnames
-   
+   use dynHarvestMod          , only : harvest_rates ! these are dynamic in space and time
+   use dynHarvestMod          , only : num_harvest_vars, harvest_varnames, wood_harvest_units
+
+   use FatesConstantsMod      , only : hlm_harvest_area_fraction
+   use FatesConstantsMod      , only : hlm_harvest_carbon
+
+   use dynSubgridControlMod, only : get_do_harvest ! this gets the namelist value
+
    use FatesInterfaceTypesMod , only : bc_in_type, bc_out_type
    use CLMFatesParamInterfaceMod         , only : FatesReadParameters
 
@@ -255,7 +262,7 @@ contains
      integer                                        :: pass_is_restart
      integer                                        :: pass_cohort_age_tracking
      integer                                        :: pass_biogeog
-     integer                                        :: pass_num_lu_harvest_cats
+     integer                                        :: pass_num_lu_harvest_types
      integer                                        :: pass_lu_harvest
      ! ----------------------------------------------------------------------------------
      ! FATES lightning definitions
@@ -281,7 +288,7 @@ contains
      
      if (use_fates) then
 
-        verbose_output = .false.
+verbose_output = .false.
         call FatesInterfaceInit(iulog, verbose_output)
 
         ! Force FATES parameters that are recieve type, to the unset value
@@ -319,7 +326,7 @@ contains
         call set_fates_ctrlparms('phosphorus_spec',ival=1)
            
         
-        if(is_restart()) then
+        if(is_restart() .or. nsrest .eq. nsrBranch) then
            pass_is_restart = 1
         else
            pass_is_restart = 0
@@ -370,18 +377,18 @@ contains
            pass_logging = 0
         end if
 
-        if(do_elm_fates_harvest) then
-!        if(get_do_harvest()) then
+!        if(do_elm_fates_harvest) then
+        if(get_do_harvest()) then
            pass_logging = 1
-           pass_num_lu_harvest_cats = num_harvest_vars
+           pass_num_lu_harvest_types = num_harvest_vars
            pass_lu_harvest = 1
         else
            pass_lu_harvest = 0
-           pass_num_lu_harvest_cats = 0
+           pass_num_lu_harvest_types = 0
         end if
 
         call set_fates_ctrlparms('use_lu_harvest',ival=pass_lu_harvest)
-        call set_fates_ctrlparms('num_lu_harvest_cats',ival=pass_num_lu_harvest_cats)
+        call set_fates_ctrlparms('num_lu_harvest_cats',ival=pass_num_lu_harvest_types)
         call set_fates_ctrlparms('use_logging',ival=pass_logging)
         
         if(use_fates_ed_st3) then
@@ -715,6 +722,7 @@ contains
       integer  :: t                        ! topounit index (HLM)
       integer  :: ifp                      ! patch index
       integer  :: p                        ! HLM patch index
+      integer  :: g                        ! HLM grid index
       integer  :: nc                       ! clump index
       integer  :: nlevsoil                 ! number of soil layers at the site
 
@@ -783,7 +791,17 @@ contains
             this%fates(nc)%bc_in(s)%bsw_sisl(1:nlevsoil)    = soilstate_inst%bsw_col(c,1:nlevsoil)
             this%fates(nc)%bc_in(s)%h2o_liq_sisl(1:nlevsoil) =  col_ws%h2osoi_liq(c,1:nlevsoil)
          end if
-         
+
+         ! get the harvest data, which is by gridcell
+         ! for now there is one veg column per gridcell, so store all harvest data in each site
+         ! this will eventually change
+         ! the harvest data are zero if today is before the start of the harvest time series
+         g = col_pp%gridcell(c)
+         if (get_do_harvest()) then
+            this%fates(nc)%bc_in(s)%hlm_harvest_rates = harvest_rates(:,g)
+            this%fates(nc)%bc_in(s)%hlm_harvest_catnames = harvest_varnames
+            this%fates(nc)%bc_in(s)%hlm_harvest_units = wood_harvest_units
+         end if
 
       end do
 

--- a/components/elm/src/main/pftvarcon.F90
+++ b/components/elm/src/main/pftvarcon.F90
@@ -1008,14 +1008,17 @@ contains
        ! (FATES-INTERF) Later, depending on how the team plans to structure the crop model
        ! or other modules that co-exist while FATES is on, we may want to preserve these pft definitions
        ! on non-fates columns.  For now, they are incompatible, and this check is warranted (rgk 04-2017)
-       if(.not. use_fates)then
+
+       ! avd - this should be independent of FATES because it fails for non-crop config otherwise
+
+       !if(.not. use_fates)then
           if(.not. use_crop .and. i > mxpft_nc) EXIT ! exit the do loop
           if ( trim(adjustl(pftname(i))) /= trim(expected_pftnames(i)) )then
              write(iulog,*)'pftconrd: pftname is NOT what is expected, name = ', &
                   trim(pftname(i)), ', expected name = ', trim(expected_pftnames(i))
              call endrun(msg='pftconrd: bad name for pft on paramfile dataset'//errMsg(__FILE__, __LINE__))
           end if
-       end if
+       !end if
 
        if ( trim(pftname(i)) == 'not_vegetated'                       ) noveg                = i
        if ( trim(pftname(i)) == 'needleleaf_evergreen_temperate_tree' ) ndllf_evr_tmp_tree   = i


### PR DESCRIPTION
ELM code (for harvest control and FATES harvest control) has been updated so that ELM 
input harvest can be passed to FATES to drive FATES harvest code. The ELM namelist 
variables do_harvest and fdyndat can now be used to drive FATES harvest. The FATES 
code has not been modified, as it has already been updated for this purpose. Modifications
to the harvest read and get year functions were required to ensure that the correct harvest
year data are read in. ELM harvest results are unchanged, and FATES harvest matches 
the input based on secondary forest fraction. Branch run control has been updated to enable
branch runs.

[non-BFB] only for FATES and BGC cases