### PR TITLE
Single Column Model (SCM) time level index bug fix

### DIFF
--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -1063,7 +1063,6 @@ contains
        ! homme.
        call compute_test_forcing(elem,hybrid,hvcoord,tl%n0,n0_qdp,dt_remap,nets,nete,tl)
 #endif
-
        call applyCAMforcing_remap(elem,hvcoord,tl%n0,n0_qdp,dt_remap,nets,nete)
 
        ! E(1) Energy after CAM forcing
@@ -1145,7 +1144,9 @@ contains
     ! =================================
     ! update dynamics time level pointers
     ! =================================
+
     call TimeLevel_update(tl,"leapfrog")
+
     ! now we have:
     !   u(nm1)   dynamics at  t+dt_remap - dt       
     !   u(n0)    dynamics at  t+dt_remap
@@ -1891,9 +1892,13 @@ contains
     !   needs to be updated with the new floating levels
 #ifdef MODEL_THETA_L
     do k=1,nlev
-      elem(1)%state%vtheta_dp(:,:,k,np1) = (elem(1)%state%vtheta_dp(:,:,k,np1)/ &
+      elem(1)%state%vtheta_dp(:,:,k,np1) = (elem(1)%state%vtheta_dp(:,:,k,n0)/ &
                 elem(1)%state%dp3d(:,:,k,n0))*elem(1)%state%dp3d(:,:,k,np1)
     enddo
+#else
+   do k=1,nlev
+     elem(1)%state%T(:,:,k,np1) = elem(1)%state%T(:,:,k,n0)
+   enddo
 #endif
 
     do p=1,qsize

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -1887,8 +1887,7 @@ contains
         + dt*(eta_dot_dpdn(:,:,k+1) - eta_dot_dpdn(:,:,k))
     enddo
 
-    ! If running theta_l model then the floating potential temperature
-    !   needs to be updated with the new floating levels
+    ! Update temperature variable for the theta-l or preqx implementation
 #ifdef MODEL_THETA_L
     do k=1,nlev
       elem(1)%state%vtheta_dp(:,:,k,np1) = (elem(1)%state%vtheta_dp(:,:,k,n0)/ &

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -1063,6 +1063,7 @@ contains
        ! homme.
        call compute_test_forcing(elem,hybrid,hvcoord,tl%n0,n0_qdp,dt_remap,nets,nete,tl)
 #endif
+
        call applyCAMforcing_remap(elem,hvcoord,tl%n0,n0_qdp,dt_remap,nets,nete)
 
        ! E(1) Energy after CAM forcing
@@ -1144,9 +1145,7 @@ contains
     ! =================================
     ! update dynamics time level pointers
     ! =================================
-
     call TimeLevel_update(tl,"leapfrog")
-
     ! now we have:
     !   u(nm1)   dynamics at  t+dt_remap - dt       
     !   u(n0)    dynamics at  t+dt_remap


### PR DESCRIPTION
This PR fixes a bug for the SCM when the dynamical core computes the large scale vertical advection.  The time level indices are fixed for temperature (both for preqx and theta-l versions of the SCM).  Previously the dynamics state was not seeing the correct physics tendencies at some time steps.  

It should be noted that the vast majority of E3SM SCM cases are NOT effected by this bug fix as most cases include the 3D large scale tendencies and thus negates the need to call this block of code.  The cases which ARE effected by this bug fix are: ARM GCSS Shallow Convection, BOMEX, DYCOMS-RF01 & RF02, GATE, MPACEB, and ATEX.  Furthermore, the effect is not large for most of these cases that are steady state boundary layers, but there is a more significant impact for ARM GCSS Shallow Convection case. 

Maria Chinitas and Mikael Witte (JPL) are thanked for bring the odd behavior to my attention which led to uncovering this bug.

All e3sm_developer tests pass (including the SMS_R_Ld5.ne4_ne4.FSCM5A97 test, since this code bock is not executed for the ARM97 case).