### PR TITLE
Default to Scorpio-classic on Chrysalis with OpenMPI-HPCX

### DIFF
--- a/cime_config/machines/config_pio.xml
+++ b/cime_config/machines/config_pio.xml
@@ -6,6 +6,7 @@
     <values>
       <value>2</value>
       <value mach="sooty">1</value>
+      <value mach="chrysalis" mpilib="openmpi">1</value>
     </values>
   </entry>
 


### PR DESCRIPTION
Default to Scorpio-classic on Chrysalis with OpenMPI-HPCX

Addresses E3SM-Project/E3SM#4021 (as a workaround).

[BFB]