### PR TITLE
EAM: Improve definitions and checks related to time stepping

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -5618,16 +5618,20 @@ Dynamics timestep.  Replaces se_nsplit.
 
 <entry id="dt_tracer_factor" type="integer" category="se"
        group="ctl_nl" valid_values="" >
-Tracer advection is done every dt_tracer_factor dynamics timesteps.
+The tracer advection timestep is dt_tracer_factor*se_tstep, where se_tstep is
+the dynamics timesteps. dt_tracer_factor*se_tstep must divide dtime, and one of
+dt_remap_factor and dt_tracer_factor must divide the other.
 Replaces qsplit, rsplit.
 Default: Set by build-namelist.
 </entry>
 
 <entry id="dt_remap_factor" type="integer" category="se"
        group="ctl_nl" valid_values="" >
-Vertically lagrangian code updates every dt_remap_factor dynamics timesteps.
+The vertically Lagrangian remap timestep is dt_remap_factor*se_tstep, where
+se_tstep is the dynamics timesteps. dt_remap_factor*se_tstep must divide dtime,
+and one of dt_remap_factor and dt_tracer_factor must divide the other.
 Replaces qsplit, rsplit.
-If dt_remap_factor=0, vertically lagrangian code is off.
+If dt_remap_factor=0, vertically Lagrangian code is off.
 </entry>
 
 <entry id="tstep_type" type="integer" category="se"

--- a/components/homme/src/share/compose/compose_cedr.cpp
+++ b/components/homme/src/share/compose/compose_cedr.cpp
@@ -5018,6 +5018,8 @@ struct InputParser {
 # endif
 #endif
 
+typedef Kokkos::DefaultHostExecutionSpace ComposeDefaultExecutionSpace;
+
 namespace homme {
 namespace compose {
 
@@ -5834,7 +5836,7 @@ private:
 
 struct CDR {
   typedef std::shared_ptr<CDR> Ptr;
-  typedef compose::QLT<Kokkos::DefaultExecutionSpace> QLTT;
+  typedef compose::QLT<ComposeDefaultExecutionSpace> QLTT;
   typedef compose::CAAS CAAST;
 
   struct Alg {

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -455,16 +455,19 @@ contains
           nstep_factor = dt_max_factor*nsplit
           if (abs(nsplit_real - nsplit) > divisible_tol*nsplit_real) then
              if (par%masterproc .and. .not. silent_in) then
-                write(iulog,'(a,es11.4,a,i7,a,es11.4,a)') &
+                write(iulog,'(a,es11.4,a,i7,a,es11.4,a,i2,a,i2,a,i2,a)') &
                      'nsplit was computed as ', nsplit_real, ' based on dtime ', dtime, &
-                     ' and tstep ', tstep, ', which is outside the divisibility tolerance. Set &
-                     &tstep so that it divides dtime.'
+                     ', tstep ', tstep, &
+                     ', and dt_max_factor = max(dt_remap_factor, dt_tracer_factor) = max(', &
+                     dt_remap_factor, ',', dt_tracer_factor, ') =', dt_max_factor, &
+                     ', which is outside the divisibility tolerance. &
+                     &Set tstep, dt_remap_factor, and dt_tracer_factor so that &
+                     &tstep and dt_max_factor*tstep divide dtime.'
              end if
              if (abort_in) call abortmp('timestep_make_parameters_consistent: divisibility error')
              return
           end if
        else
-          print *,'um>',par%rank,par%masterproc,silent_in,nsplit,dtime,tstep
           if (par%masterproc .and. .not. silent_in) then
              write(iulog,*) 'If dtime is set to >0, then either nsplit or tstep must be >0.'
           end if


### PR DESCRIPTION
This PR has no runtime ramifications other than output in the case of a time step misspecification.

* Expand the definitions of dt_remap_factor, dt_tracer_factor in the XML.
* Add full details to an error message in a time step consistency check routine.
* Separately, add a typedef that permits the SL transport code to build and run properly on CPU when Kokkos provides the Cuda execution space. If Cuda is not enabled, the type is equivalent to the existing type, so there is no runtime change from the code change.

[BFB]