### PR TITLE
Adds support for NA RRM grid on ELM

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -1756,37 +1756,37 @@ this mask will have smb calculated over the entire global land surface
 <map frm_hgrid="0.5x0.5"    frm_lmask="GSDTG2000"  to_hgrid="ne240np4"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/ne240np4/map_0.5x0.5_GSDTG2000_to_ne240np4_nomask_aave_da_c170821.nc</map>
 
-<map frm_hgrid="0.5x0.5"    frm_lmask="AVHRR"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="0.5x0.5"    frm_lmask="AVHRR"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.5x0.5_AVHRR_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="0.5x0.5"    frm_lmask="MODIS"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="0.5x0.5"    frm_lmask="MODIS"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.5x0.5_MODIS_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="0.5x0.5"    frm_lmask="nomask"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="0.5x0.5"    frm_lmask="nomask"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.5x0.5_nomask_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="10x10min"    frm_lmask="nomask"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="10x10min"    frm_lmask="nomask"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_10x10min_nomask_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="3x3min"    frm_lmask="MODIS"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="3x3min"    frm_lmask="MODIS"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_MODIS_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="3x3min"    frm_lmask="USGS"   to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="3x3min"    frm_lmask="USGS"   to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_USGS_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="3x3min"    frm_lmask="LandScan2004" to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="3x3min"    frm_lmask="LandScan2004" to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_LandScan2004_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="5x5min"    frm_lmask="IGBP-GSDP"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="5x5min"    frm_lmask="IGBP-GSDP"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_5x5min_IGBP-GSDP_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="5x5min"    frm_lmask="ISRIC-WISE"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="5x5min"    frm_lmask="ISRIC-WISE"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_5x5min_ISRIC-WISE_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="5x5min"    frm_lmask="nomask"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="5x5min"    frm_lmask="nomask"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_5x5min_nomask_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="3x3min"   frm_lmask="GLOBE-Gardner" to_hgrid="northamericax4v1pg2" to_lmask="nomask"
+<map frm_hgrid="3x3min"   frm_lmask="GLOBE-Gardner" to_hgrid="ne0np4_northamericax4v1.pg2" to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_GLOBE-Gardner_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="3x3min"   frm_lmask="GLOBE-Gardner-mergeGIS" to_hgrid="northamericax4v1pg2" to_lmask="nomask"
+<map frm_hgrid="3x3min"   frm_lmask="GLOBE-Gardner-mergeGIS" to_hgrid="ne0np4_northamericax4v1.pg2" to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_GLOBE-Gardner-mergeGIS_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="0.9x1.25"    frm_lmask="GRDC"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="0.9x1.25"    frm_lmask="GRDC"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.9x1.25_GRDC_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="360x720cru"    frm_lmask="cruncep"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="360x720cru"    frm_lmask="cruncep"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_360x720cru_cruncep_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="1km-merge-10min"    frm_lmask="HYDRO1K-merge-nomask"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="1km-merge-10min"    frm_lmask="HYDRO1K-merge-nomask"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_1km-merge-10min_HYDRO1K-merge-nomask_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
-<map frm_hgrid="0.5x0.5"    frm_lmask="GSDTG2000"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+<map frm_hgrid="0.5x0.5"    frm_lmask="GSDTG2000"  to_hgrid="ne0np4_northamericax4v1.pg2"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.5x0.5_GSDTG2000_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
 
 <!-- mapping files for r0125xr0125 START added on Fri Aug  1 15:44:32 2014-->

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -200,12 +200,12 @@ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICRUCLM45SP.2000-01-01.ne240np4_tx0.1v2.162cd32_simyr2000_c170910.nc
 </finidat>
 
-<!-- northamericax4v1pg2 -->
+<!-- ne0np4_northamericax4v1.pg2 -->
 <fsurdat hgrid="northamericax4v1pg2"   sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_northamericax4v1pg2_simyr1850_c210112.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr1850_c210112.nc</fsurdat>
 
 <fsurdat hgrid="northamericax4v1pg2"   sim_year="2010" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_northamericax4v1pg2_simyr2010_c210112.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr2010_c210112.nc</fsurdat>
 
 <!-- f10 resolution -->
 

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -201,10 +201,10 @@ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 </finidat>
 
 <!-- ne0np4_northamericax4v1.pg2 -->
-<fsurdat hgrid="northamericax4v1pg2"   sim_year="1850" use_crop=".false." >
+<fsurdat hgrid="ne0np4_northamericax4v1.pg2"   sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr1850_c210112.nc</fsurdat>
 
-<fsurdat hgrid="northamericax4v1pg2"   sim_year="2010" use_crop=".false." >
+<fsurdat hgrid="ne0np4_northamericax4v1.pg2"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr2010_c210112.nc</fsurdat>
 
 <!-- f10 resolution -->

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -200,6 +200,13 @@ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICRUCLM45SP.2000-01-01.ne240np4_tx0.1v2.162cd32_simyr2000_c170910.nc
 </finidat>
 
+<!-- northamericax4v1pg2 -->
+<fsurdat hgrid="northamericax4v1pg2"   sim_year="1850" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_northamericax4v1pg2_simyr1850_c210112.nc</fsurdat>
+
+<fsurdat hgrid="northamericax4v1pg2"   sim_year="2010" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_northamericax4v1pg2_simyr2010_c210112.nc</fsurdat>
+
 <!-- f10 resolution -->
 
 <finidat hgrid="10x15"    maxpft="25"  mask="USGS" use_cn=".true." use_cndv=".false." ic_ymd="00010101" more_vertlayers=".false." use_nitrif_denitrif=".true." use_vertsoilc=".true."
@@ -1748,6 +1755,39 @@ this mask will have smb calculated over the entire global land surface
 >lnd/clm2/mappingdata/maps/ne240np4/map_ne240np4_nomask_to_0.5x0.5_nomask_aave_da_c110922.nc</map>
 <map frm_hgrid="0.5x0.5"    frm_lmask="GSDTG2000"  to_hgrid="ne240np4"   to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/ne240np4/map_0.5x0.5_GSDTG2000_to_ne240np4_nomask_aave_da_c170821.nc</map>
+
+<map frm_hgrid="0.5x0.5"    frm_lmask="AVHRR"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.5x0.5_AVHRR_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="0.5x0.5"    frm_lmask="MODIS"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.5x0.5_MODIS_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="0.5x0.5"    frm_lmask="nomask"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.5x0.5_nomask_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="10x10min"    frm_lmask="nomask"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_10x10min_nomask_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="MODIS"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_MODIS_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="USGS"   to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_USGS_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="LandScan2004" to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_LandScan2004_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="5x5min"    frm_lmask="IGBP-GSDP"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_5x5min_IGBP-GSDP_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="5x5min"    frm_lmask="ISRIC-WISE"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_5x5min_ISRIC-WISE_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="5x5min"    frm_lmask="nomask"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_5x5min_nomask_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="3x3min"   frm_lmask="GLOBE-Gardner" to_hgrid="northamericax4v1pg2" to_lmask="nomask"
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_GLOBE-Gardner_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="3x3min"   frm_lmask="GLOBE-Gardner-mergeGIS" to_hgrid="northamericax4v1pg2" to_lmask="nomask"
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_3x3min_GLOBE-Gardner-mergeGIS_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="0.9x1.25"    frm_lmask="GRDC"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.9x1.25_GRDC_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="360x720cru"    frm_lmask="cruncep"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_360x720cru_cruncep_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="1km-merge-10min"    frm_lmask="HYDRO1K-merge-nomask"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_1km-merge-10min_HYDRO1K-merge-nomask_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
+<map frm_hgrid="0.5x0.5"    frm_lmask="GSDTG2000"  to_hgrid="northamericax4v1pg2"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/northamericax4v1pg2/map_0.5x0.5_GSDTG2000_to_northamericax4v1pg2_nomask_aave_da_c210112.nc</map>
 
 <!-- mapping files for r0125xr0125 START added on Fri Aug  1 15:44:32 2014-->
 <!-- Created by lnd/clm/bld/namelist_files/createMapEntry.pl--> 

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1256,7 +1256,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"  
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r05,r0125,NLDAS">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r05,r0125,NLDAS,northamericax4v1pg2">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry> 

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1256,7 +1256,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"  
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r05,r0125,NLDAS,northamericax4v1pg2">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry> 


### PR DESCRIPTION
- Adds northamericax4v1pg2 as a valid resolution
- Adds mapping files needed to create surface datasets at northamericax4v1pg2
- Adds surface dataset for 1850 and 2010

[BFB]
Fixes #4029
