### PR TITLE
Fix uninitialized pblt600 and replace a remaining FC5AV1C-04P2 test

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -66,7 +66,7 @@ _TESTS = {
             "ERS_Ld5.ne4_ne4.FC5AV1C-L.eam-rrtmgp",
             "ERS_Ld5.ne4_ne4.FC5AV1C-L.eam-gust_param",
             "REP_Ln5.ne4_ne4.FC5AV1C-L",
-            "SMS_Ld9.ne4pg2_ne4pg2.FC5AV1C-04P2.eam-thetahy_sl_pg2_mass",
+            "SMS_Ld9.ne4pg2_ne4pg2.FC5AV1C-L.eam-thetahy_sl_pg2_mass",
             )
         },
 

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -3408,6 +3408,7 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 
 !DCAPE-ULL
    if (trigdcape_ull .or. trig_ull_only) then
+      pblt600(:ncol) = 1.0_r8
       do k = pver - 1,msg + 1,-1
       do i = 1,ncol
          if ((p(i,k).le.600._r8) .and. (p(i,k+1).gt.600._r8)) pblt600(i) = dble(k)


### PR DESCRIPTION
Uninitialized pblt600 could be used when dCCAPE_ULL is used and surface
pressure of the column is above 6000 hPa. It would impact how convective
adjustment is performed, which could lead to instability. It is now initialized
to 1.

Also replace a remaining test that uses the now non-existent compset FC5AV1C-04P2
with FC5AV1C-L. The test name changes but the results will not.

[BFB] except with dCAPE_ULL trigger -- as for v2 default setting -- on some systems

Fixes #4045 
Fixes #4046.