### PR TITLE
Add procs-per-node option to intel-mpi mpirun on Chrysalis

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1145,6 +1145,7 @@
       <executable>mpirun</executable>
       <arguments>
         <arg name="num_tasks"> -l -n {{ total_tasks }}</arg>
+        <arg name="placement">-ppn {{ tasks_per_node }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">


### PR DESCRIPTION
Add procs-per-node option to intel-mpi mpirun on Chrysalis

[BFB]