### PR TITLE
Update mappy to gcc-8.1.0 to match summit

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -673,7 +673,7 @@
         <command name="load">sems-cmake/3.12.2</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">sems-gcc/7.3.0</command>
+        <command name="load">acme-gcc/8.1.0</command>
       </modules>
       <modules compiler="intel">
         <command name="load">sems-intel/19.0.5</command>


### PR DESCRIPTION
Causes roundoff diffs (only on mappy) for:

```
DIFF SMS_D_Ln5.ne4_ne4.FC5AV1C-L.mappy_gnu (phase RUN)
DIFF SMS_R_Ld5.ne4_ne4.FSCM5A97.mappy_gnu.eam-scm (phase RUN)
```

[non-BFB]