### PR TITLE
Update Chrysalis on maint-1.0

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -991,7 +991,7 @@
 
 <machine MACH="chrysalis">
     <DESC>ANL LCRC cluster 512-node AMD Epyc 7532 2-sockets 64-cores per node</DESC>
-    <NODENAME_REGEX>chrlogin.*</NODENAME_REGEX>
+    <NODENAME_REGEX>chr.*</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
     <MPILIBS>impi,openmpi</MPILIBS>
@@ -1011,13 +1011,7 @@
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-    <mpirun mpilib="impi">
-      <executable>mpirun</executable>
-      <arguments>
-        <arg name="num_tasks"> -l -n {{ total_tasks }}</arg>
-      </arguments>
-    </mpirun>
-    <mpirun mpilib="openmpi">
+    <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
         <arg name="num_tasks">--mpi=pmi2 -l -n {{ total_tasks }} -N {{ num_nodes }} --kill-on-bad-exit </arg>
@@ -1070,6 +1064,14 @@
         <command name="load">netcdf-fortran/4.5.3-i5ah7u2</command>
         <command name="load">parallel-netcdf/1.12.1-e7w4x32</command>
       </modules>
+      <modules compiler="gnu" mpilib="impi">
+        <command name="load">intel-mpi/2019.9.304-jdih7h5</command>
+        <command name="load">hdf5/1.8.16-dtbpce3</command>
+        <command name="load">netcdf-c/4.4.1-zcoa44z</command>
+        <command name="load">netcdf-cxx/4.2-ayxg4c7</command>
+        <command name="load">netcdf-fortran/4.4.4-2lfr2lr</command>
+        <command name="load">parallel-netcdf/1.11.0-ifdodru</command>
+      </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1090,14 +1092,6 @@
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>
-    </environment_variables>
-    <environment_variables mpilib="impi">
-      <env name="I_MPI_PIN_DOMAIN">omp</env>
-      <env name="I_MPI_PIN_ORDER">spread</env>
-      <env name="I_MPI_PIN_CELL">core</env>
-    </environment_variables>
-    <environment_variables mpilib="impi" DEBUG="TRUE">
-      <env name="I_MPI_DEBUG">10</env>
     </environment_variables>
 </machine>
 

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -1023,7 +1023,7 @@
         <arg name="num_tasks">--mpi=pmi2 -l -n {{ total_tasks }} -N {{ num_nodes }} --kill-on-bad-exit </arg>
         <arg name="binding">--cpu_bind=cores</arg>
         <arg name="thread_count">-c $ENV{OMP_NUM_THREADS}</arg>
-        <arg name="placement">-m plane={{ tasks_per_node }}</arg>
+        <arg name="placement">-m plane=$MAX_MPITASKS_PER_NODE</arg>
       </arguments>
     </mpirun>
     <module_system type="module">

--- a/components/homme/src/share/metagraph_mod.F90
+++ b/components/homme/src/share/metagraph_mod.F90
@@ -8,7 +8,6 @@ module metagraph_mod
   use kinds, only : int_kind, iulog
   use gridgraph_mod, only : gridvertex_t, gridedge_t, &
        allocate_gridvertex_nbrs, assignment ( = )
-  use pio_types ! _EXTERNAL
 
   implicit none 
   private 


### PR DESCRIPTION
Update Chrysalis on maint-1.0:
- Make srun default with intel-mpi
- Add gnu+impi modules

[BFB]