### PR TITLE
Specify OpenMPI transport on Chrysalis

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1223,6 +1223,9 @@
     <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>
     </environment_variables>
+    <environment_variables mpilib="openmpi">
+      <env name="UCX_TLS">sm,ud</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="blues">


### PR DESCRIPTION
Explicitly specifying the UCX transport to use with OpenMPI on
Chrysalis. This change fixes the data corruption issue with
OpenMPI on Chrysalis.

See Issue #4021 

[BFB]