### PR TITLE
Adding the diffusion wave routing method to MOSART

### DIFF
--- a/components/mosart/src/inundation/MOSARTinund_Core_MOD.F90
+++ b/components/mosart/src/inundation/MOSARTinund_Core_MOD.F90
@@ -74,7 +74,7 @@ MODULE MOSARTinund_Core_MOD
     
     ! Channel routing computation :     
     ! Diffusion wave method :
-    if ( Tctl%RoutingMethod .eq. 4 ) then               
+    if ( Tctl%RoutingMethod .eq. 2 ) then               
       
       ! --------------------------------- 
       ! Need code to retrieve values of TRunoff%yr_exchg_dstrm(:) and TRunoff%wr_exchg_dstrm(:) .

--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -58,7 +58,8 @@ MODULE MOSART_physics_mod
     
     integer :: iunit, idam, m, k, unitUp, cnt, ier, dd, nSubStep   !local index
     real(r8) :: temp_erout, localDeltaT, temp_haout, temp_Tt, temp_Tr, temp_T, temp_ha
-    real(r8) :: negchan, numSubSteps
+    real(r8) :: negchan
+	integer  :: numSubSteps
     integer  :: yr,mon,day,tod
     real(r8) :: myTINYVALUE
     character(len=*),parameter :: subname = '(Euler)'
@@ -372,14 +373,12 @@ MODULE MOSART_physics_mod
        if (TUnit%euler_calc(nt)) then
        do iunit=rtmCTL%begr,rtmCTL%endr
           if(TUnit%mask(iunit) > 0) then
-                                                                          
              temp_erout = 0._r8
              temp_haout = 0._r8
              temp_Tr = 0._r8
              if(Tctl%RoutingMethod==1) then  ! local stepping method only applicable for kinamatic wave routing method
                  numSubSteps = TUnit%numDT_r(iunit)
                  localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R/numSubSteps
-                 TRunoff%rslp_energy(iunit) = TUnit%rslp(iunit)
                  do k=1,numSubSteps
                     call mainchannelRouting(iunit,nt,localDeltaT)    
                     TRunoff%wr(iunit,nt) = TRunoff%wr(iunit,nt) + TRunoff%dwr(iunit,nt) * localDeltaT
@@ -392,7 +391,7 @@ MODULE MOSART_physics_mod
                     temp_erout = temp_erout + TRunoff%erout(iunit,nt) ! erout here might be inflow to some downstream subbasin, so treat it differently than erlateral
                  end do
              elseif(Tctl%RoutingMethod==2) then ! diffusion wave routing method
-                 numSubSteps = 1 ! now set as 1, could be increased as needed.
+                 numSubSteps = 20 ! now set as 20, could be adjusted as needed.
                  localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R/numSubSteps
                  TRunoff%rslp_energy(iunit) = CRRSLP(iunit)
                  do k=1,numSubSteps

--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -298,7 +298,7 @@ MODULE MOSART_physics_mod
           end if
        enddo
        
-       if (Tctl%RoutingMethod == 4 ) then
+       if (Tctl%RoutingMethod == 2 ) then
           ! retrieve water depth in downstream channels
           call mct_aVect_zero(avsrc_dnstrm)
           cnt = 0
@@ -383,25 +383,25 @@ MODULE MOSART_physics_mod
                  do k=1,numSubSteps
                     call mainchannelRouting(iunit,nt,localDeltaT)    
                     TRunoff%wr(iunit,nt) = TRunoff%wr(iunit,nt) + TRunoff%dwr(iunit,nt) * localDeltaT
-                    ! check for negative channel storage
-                    if(TRunoff%wr(iunit,1) < -1.e-10) then
-                       write(iulog,*) 'Negative channel storage! ', iunit, TRunoff%wr(iunit,1), TRunoff%erin(iunit,1), TRunoff%erout(iunit,1), rtmCTL%nUp(iunit)
-                       call shr_sys_abort('mosart: negative channel storage')
-                    end if
+                    !! check for negative channel storage
+                    !if(TRunoff%wr(iunit,1) < -1.e-10) then
+                    !   write(iulog,*) 'Negative channel storage! ', iunit, TRunoff%wr(iunit,1), TRunoff%erin(iunit,1), TRunoff%erout(iunit,1), rtmCTL%nUp(iunit)
+                    !   call shr_sys_abort('mosart: negative channel storage')
+                    !end if
                     call UpdateState_mainchannel(iunit,nt)
                     temp_erout = temp_erout + TRunoff%erout(iunit,nt) ! erout here might be inflow to some downstream subbasin, so treat it differently than erlateral
                  end do
-             elseif(Tctl%RoutingMethod==4) then
-                 numSubSteps = 1 
+             elseif(Tctl%RoutingMethod==2) then ! diffusion wave routing method
+                 numSubSteps = 1 ! now set as 1, could be increased as needed.
                  localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R/numSubSteps
                  TRunoff%rslp_energy(iunit) = CRRSLP(iunit)
                  do k=1,numSubSteps
                     call Leapfrog(iunit,nt,localDeltaT)  ! note updating wr and other states are done in Leapfrog
-                    ! check for negative channel storage
-                    if(TRunoff%wr(iunit,1) < -1.e-10) then
-                       write(iulog,*) 'Negative channel storage! ', iunit, TRunoff%wr(iunit,1), TRunoff%erin(iunit,1), TRunoff%erout(iunit,1), rtmCTL%nUp(iunit)
-                       call shr_sys_abort('mosart: negative channel storage')
-                    end if
+                    !! check for negative channel storage
+                    !if(TRunoff%wr(iunit,1) < -1.e-10) then
+                    !   write(iulog,*) 'Negative channel storage! ', iunit, TRunoff%wr(iunit,1), TRunoff%erin(iunit,1), TRunoff%erout(iunit,1), rtmCTL%nUp(iunit)
+                    !   call shr_sys_abort('mosart: negative channel storage')
+                    !end if
                     temp_erout = temp_erout + TRunoff%erout(iunit,nt) ! erout here might be inflow to some downstream subbasin, so treat it differently than erlateral
                  end do
              end if
@@ -628,13 +628,10 @@ MODULE MOSART_physics_mod
     if(Tctl%RoutingMethod == 1) then
        call Routing_KW(iunit, nt, theDeltaT)
     else if(Tctl%RoutingMethod == 2) then
-       call Routing_MC(iunit, nt, theDeltaT)
-    else if(Tctl%RoutingMethod == 3) then
-       call Routing_THREW(iunit, nt, theDeltaT)
-    else if(Tctl%RoutingMethod == 4) then
        call Routing_DW(iunit, nt, theDeltaT)
     else
-       print*, "Please check the routing method! There are only 4 methods available."
+       print*, "Please check the routing method! There are only 2 methods available. 1==KW, 2==DW."
+	   call shr_sys_abort('Error in selecting routing method!')
     end if
 
   end subroutine mainchannelRouting

--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -15,7 +15,7 @@ MODULE MOSART_physics_mod
   use shr_sys_mod   , only : shr_sys_abort
   use RtmVar        , only : iulog, barrier_timers, wrmflag, inundflag, sediflag, heatflag, rstraflag
   use RunoffMod     , only : Tctl, TUnit, TRunoff, Theat, TPara, rtmCTL, &
-                             SMatP_upstrm, avsrc_upstrm, avdst_upstrm
+                             SMatP_upstrm, avsrc_upstrm, avdst_upstrm, SMatP_dnstrm, avsrc_dnstrm, avdst_dnstrm
   use MOSART_heat_mod
   use MOSART_stra_mod
   use RtmSpmd       , only : masterproc, mpicom_rof, iam
@@ -58,7 +58,7 @@ MODULE MOSART_physics_mod
     
     integer :: iunit, idam, m, k, unitUp, cnt, ier, dd, nSubStep   !local index
     real(r8) :: temp_erout, localDeltaT, temp_haout, temp_Tt, temp_Tr, temp_T, temp_ha
-    real(r8) :: negchan
+    real(r8) :: negchan, numSubSteps
     integer  :: yr,mon,day,tod
     real(r8) :: myTINYVALUE
     character(len=*),parameter :: subname = '(Euler)'
@@ -259,8 +259,8 @@ MODULE MOSART_physics_mod
        if (heatflag) THeat%Ha_eroutUp = 0._r8
 #ifdef NO_MCT
        do iunit=rtmCTL%begr,rtmCTL%endr
-       do k=1,TUnit%nUp(iunit)
-          unitUp = Tunit%iUp(iunit,k)
+       do k=1,rtmCTL%nUp(iunit)
+          unitUp = rtmCTL%iUp(iunit,k)
           do nt=1,nt_rtm
              TRunoff%eroutUp(iunit,nt) = TRunoff%eroutUp(iunit,nt) + TRunoff%erout(unitUp,nt)
           end do
@@ -297,6 +297,62 @@ MODULE MOSART_physics_mod
               THeat%Ha_eroutUp(iunit) = avdst_upstrm%rAttr(nt_rtm+1,cnt)
           end if
        enddo
+       
+       if (Tctl%RoutingMethod == 4 ) then
+          ! retrieve water depth in downstream channels
+          call mct_aVect_zero(avsrc_dnstrm)
+          cnt = 0
+          do iunit = rtmCTL%begr,rtmCTL%endr
+             cnt = cnt + 1
+             avsrc_dnstrm%rAttr(nt_nliq,cnt) = TRunoff%yr(iunit,nt_nliq)
+          enddo
+          call mct_aVect_zero(avdst_dnstrm)
+          call mct_sMat_avMult(avsrc_dnstrm, sMatP_dnstrm, avdst_dnstrm)
+          cnt = 0
+          do iunit = rtmCTL%begr,rtmCTL%endr
+             cnt = cnt + 1
+             TRunoff%yr_dstrm(iunit) = avdst_dnstrm%rAttr(nt_nliq,cnt)
+          enddo
+          
+          ! retrieve water storage in downstream channels
+          call mct_aVect_zero(avsrc_dnstrm)
+          cnt = 0
+          do iunit = rtmCTL%begr,rtmCTL%endr
+             cnt = cnt + 1
+             do nt = 1,nt_rtm
+                 avsrc_dnstrm%rAttr(nt,cnt) = TRunoff%wr(iunit,nt)
+             enddo
+          enddo
+          call mct_aVect_zero(avdst_dnstrm)
+          call mct_sMat_avMult(avsrc_dnstrm, sMatP_dnstrm, avdst_dnstrm)
+          cnt = 0
+          do iunit = rtmCTL%begr,rtmCTL%endr
+             cnt = cnt + 1
+             do nt = 1,nt_rtm
+                 TRunoff%wr_dstrm(iunit,nt) = avdst_dnstrm%rAttr(nt,cnt)
+             enddo
+          enddo
+
+          ! retrieve total inflow in downstream channels
+          call mct_aVect_zero(avsrc_dnstrm)
+          cnt = 0
+          do iunit = rtmCTL%begr,rtmCTL%endr
+             cnt = cnt + 1
+             do nt = 1,nt_rtm
+                 avsrc_dnstrm%rAttr(nt,cnt) = TRunoff%erin(iunit,nt)
+             end do
+          enddo
+          call mct_aVect_zero(avdst_dnstrm)
+          call mct_sMat_avMult(avsrc_dnstrm, sMatP_dnstrm, avdst_dnstrm)
+          cnt = 0
+          do iunit = rtmCTL%begr,rtmCTL%endr
+             cnt = cnt + 1
+             do nt = 1,nt_rtm
+                 TRunoff%erin_dstrm(iunit, nt) = avdst_dnstrm%rAttr(nt,cnt)
+             end do
+          enddo
+
+       end if
 #endif
        call t_stopf('mosartr_SMeroutUp')    
 
@@ -316,22 +372,41 @@ MODULE MOSART_physics_mod
        if (TUnit%euler_calc(nt)) then
        do iunit=rtmCTL%begr,rtmCTL%endr
           if(TUnit%mask(iunit) > 0) then
-             localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R/TUnit%numDT_r(iunit)
+                                                                          
              temp_erout = 0._r8
              temp_haout = 0._r8
              temp_Tr = 0._r8
-             do k=1,TUnit%numDT_r(iunit)
-                call mainchannelRouting(iunit,nt,localDeltaT)    
-                TRunoff%wr(iunit,nt) = TRunoff%wr(iunit,nt) + TRunoff%dwr(iunit,nt) * localDeltaT
-! check for negative channel storage
-!                if(TRunoff%wr(iunit,1) < -1.e-10) then
-!                   write(iulog,*) 'Negative channel storage! ', iunit, TRunoff%wr(iunit,1)
-!                   call shr_sys_abort('mosart: negative channel storage')
-!                end if
-                call UpdateState_mainchannel(iunit,nt)
-                temp_erout = temp_erout + TRunoff%erout(iunit,nt) ! erout here might be inflow to some downstream subbasin, so treat it differently than erlateral                
-             end do
-             temp_erout = temp_erout / TUnit%numDT_r(iunit)
+             if(Tctl%RoutingMethod==1) then  ! local stepping method only applicable for kinamatic wave routing method
+                 numSubSteps = TUnit%numDT_r(iunit)
+                 localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R/numSubSteps
+                 TRunoff%rslp_energy(iunit) = TUnit%rslp(iunit)
+                 do k=1,numSubSteps
+                    call mainchannelRouting(iunit,nt,localDeltaT)    
+                    TRunoff%wr(iunit,nt) = TRunoff%wr(iunit,nt) + TRunoff%dwr(iunit,nt) * localDeltaT
+                    ! check for negative channel storage
+                    if(TRunoff%wr(iunit,1) < -1.e-10) then
+                       write(iulog,*) 'Negative channel storage! ', iunit, TRunoff%wr(iunit,1), TRunoff%erin(iunit,1), TRunoff%erout(iunit,1), rtmCTL%nUp(iunit)
+                       call shr_sys_abort('mosart: negative channel storage')
+                    end if
+                    call UpdateState_mainchannel(iunit,nt)
+                    temp_erout = temp_erout + TRunoff%erout(iunit,nt) ! erout here might be inflow to some downstream subbasin, so treat it differently than erlateral
+                 end do
+             elseif(Tctl%RoutingMethod==4) then
+                 numSubSteps = 1 
+                 localDeltaT = Tctl%DeltaT/Tctl%DLevelH2R/numSubSteps
+                 TRunoff%rslp_energy(iunit) = CRRSLP(iunit)
+                 do k=1,numSubSteps
+                    call Leapfrog(iunit,nt,localDeltaT)  ! note updating wr and other states are done in Leapfrog
+                    ! check for negative channel storage
+                    if(TRunoff%wr(iunit,1) < -1.e-10) then
+                       write(iulog,*) 'Negative channel storage! ', iunit, TRunoff%wr(iunit,1), TRunoff%erin(iunit,1), TRunoff%erout(iunit,1), rtmCTL%nUp(iunit)
+                       call shr_sys_abort('mosart: negative channel storage')
+                    end if
+                    temp_erout = temp_erout + TRunoff%erout(iunit,nt) ! erout here might be inflow to some downstream subbasin, so treat it differently than erlateral
+                 end do
+             end if
+             
+             temp_erout = temp_erout / numSubSteps
              TRunoff%erout(iunit,nt) = temp_erout
              if (heatflag) then
              if (nt==nt_nliq) then
@@ -666,6 +741,125 @@ MODULE MOSART_physics_mod
     integer, intent(in) :: iunit, nt
     real(r8), intent(in) :: theDeltaT
     character(len=*),parameter :: subname = '(Routing_DW)'
+
+    integer  :: k, myflag 
+    real(r8) :: temp_gwl, temp_dwr, temp_gwl0
+    real(r8) :: temp1, temp2, w_temp
+    real(r8 ) :: y_c, len_c, slp_c             ! Water depth (m), length (m) and bed slope (dimensionless) of the current channel.
+    real(r8 ) :: y_down, len_down, slp_down    ! Water depth (m), length (m) and bed slope (dimensionless) of the downstream channel.
+    
+    ! estimate the inflow from upstream units
+    TRunoff%erin(iunit,nt) = 0._r8
+
+    TRunoff%erin(iunit,nt) = TRunoff%erin(iunit,nt) - TRunoff%eroutUp(iunit,nt)
+    !do k=1, rtmCTL%nUp(iunit)
+    !    TRunoff%erin(iunit,nt) = TRunoff%erin(iunit,nt) - TRunoff%erout(rtmCTL%iUp(iunit,k),nt)
+    !enddo
+
+    ! estimate the outflow
+    if(TUnit%rlen(iunit) <= 0._r8) then ! no river network, no channel routing
+       TRunoff%vr(iunit,nt) = 0._r8
+       TRunoff%erout(iunit,nt) = -TRunoff%erin(iunit,nt)-TRunoff%erlateral(iunit,nt)
+    elseif(TUnit%areaTotal2(iunit)/TUnit%rwidth(iunit)/TUnit%rlen(iunit) > 1e6_r8) then ! skip the channel routing if possible numerical instability
+       TRunoff%vr(iunit,nt) = 0._r8
+       TRunoff%erout(iunit,nt) = -TRunoff%erin(iunit,nt)-TRunoff%erlateral(iunit,nt)
+    else
+       !TODO. If this channel is at basin outlet (downstream is ocean), use the KW method
+	   if(rtmCTL%mask(iunit) .eq. 3) then 
+          call Routing_KW(iunit, nt, theDeltaT)
+       else         
+          if(TRunoff%rslp_energy(iunit) >= TINYVALUE) then ! flow is from current channel to downstream
+            TRunoff%vr(iunit,nt) = CRVRMAN(TRunoff%rslp_energy(iunit), TUnit%nr(iunit), TRunoff%rr(iunit,nt))
+            TRunoff%erout(iunit,nt) = -TRunoff%vr(iunit,nt) * TRunoff%mr(iunit,nt)
+            if(TRunoff%erin(iunit,nt)*theDeltaT + TRunoff%wr(iunit,nt) <= TINYVALUE) then! much negative inflow from upstream, 
+               TRunoff%vr(iunit,nt) = 0._r8
+               TRunoff%erout(iunit,nt) = 0._r8
+            elseif(TRunoff%erout(iunit,nt) <= -TINYVALUE .and. TRunoff%wr(iunit,nt) + &
+               (TRunoff%erlateral(iunit,nt) + TRunoff%erin(iunit,nt) + TRunoff%erout(iunit,nt)) * theDeltaT < TINYVALUE) then
+               TRunoff%erout(iunit,nt) = -(TRunoff%erlateral(iunit,nt) + TRunoff%erin(iunit,nt) + TRunoff%wr(iunit,nt)*0.95_r8 / theDeltaT)
+               if(TRunoff%mr(iunit,nt) > TINYVALUE) then
+                  TRunoff%vr(iunit,nt) = -TRunoff%erout(iunit,nt) / TRunoff%mr(iunit,nt)
+               end if
+            end if
+          elseif(TRunoff%rslp_energy(iunit) <= -TINYVALUE) then ! flow is from downstream to current channel
+             TRunoff%vr(iunit,nt) = -CRVRMAN(abs(TRunoff%rslp_energy(iunit)), TUnit%nr(iunit), TRunoff%rr(iunit,nt))
+             TRunoff%erout(iunit,nt) = -TRunoff%vr(iunit,nt) * TRunoff%mr(iunit,nt)
+             if(rtmCTL%nUp_dstrm(iunit) > 1) then
+                 if(TRunoff%erin_dstrm(iunit,nt)*theDeltaT + TRunoff%wr_dstrm(iunit,nt)/rtmCTL%nUp_dstrm(iunit) <= TINYVALUE) then! much negative inflow from upstream,
+                     TRunoff%vr(iunit,nt) = 0._r8
+                     TRunoff%erout(iunit,nt) = 0._r8
+                 elseif(TRunoff%erout(iunit,nt) >= TINYVALUE .and. TRunoff%wr_dstrm(iunit,nt)/rtmCTL%nUp_dstrm(iunit)- TRunoff%erout(iunit,nt) * theDeltaT < TINYVALUE) then
+                    TRunoff%erout(iunit,nt) = TRunoff%wr_dstrm(iunit,nt)*0.95_r8 / theDeltaT / rtmCTL%nUp_dstrm(iunit)
+                   if(TRunoff%mr(iunit,nt) > TINYVALUE) then
+                       TRunoff%vr(iunit,nt) = -TRunoff%erout(iunit,nt) / TRunoff%mr(iunit,nt)
+                    end if
+                 end if    
+             else
+                 if(TRunoff%erin_dstrm(iunit,nt)*theDeltaT + TRunoff%wr_dstrm(iunit,nt) <= TINYVALUE) then! much negative inflow from upstream,
+                     TRunoff%vr(iunit,nt) = 0._r8
+                     TRunoff%erout(iunit,nt) = 0._r8
+                 elseif(TRunoff%erout(iunit,nt) >= TINYVALUE .and. TRunoff%wr_dstrm(iunit,nt) &
+                   - TRunoff%erout(iunit,nt) * theDeltaT < TINYVALUE) then
+                    TRunoff%erout(iunit,nt) = TRunoff%wr_dstrm(iunit,nt)*0.95_r8 / theDeltaT
+                   if(TRunoff%mr(iunit,nt) > TINYVALUE) then
+                       TRunoff%vr(iunit,nt) = -TRunoff%erout(iunit,nt) / TRunoff%mr(iunit,nt)
+                    end if
+                 end if
+             end if                 
+             !TRunoff%vr(iunit,nt) = 0._r8
+             !TRunoff%erout(iunit,nt) = 0._r8
+          else  ! no flow between current channel and downstream
+            TRunoff%vr(iunit,nt) = 0._r8
+            TRunoff%erout(iunit,nt) = 0._r8
+          end if
+       end if  
+    end if
+    
+    if(TRunoff%erin(iunit,nt) < -TINYVALUE .and. TRunoff%erout(iunit,nt) < -TINYVALUE) then
+        if((TRunoff%erin(iunit,nt) + TRunoff%erout(iunit,nt)) * theDeltaT + TRunoff%wr(iunit,nt) < 0._r8) then
+            TRunoff%erout(iunit,nt) = 0._r8
+        end if
+    end if
+              
+    temp_dwr = TRunoff%erlateral(iunit,nt) + TRunoff%erin(iunit,nt) + TRunoff%erout(iunit,nt)
+    temp_gwl = TRunoff%qgwl(iunit,nt) * TUnit%area(iunit) * TUnit%frac(iunit)
+    temp_gwl0 = temp_gwl
+    if(abs(temp_gwl) <= TINYVALUE) then
+!       write(iulog,*) 'mosart: ERROR dropping temp_gwl too small'
+!       call shr_sys_abort('mosart: ERROR temp_gwl too small')
+       temp_gwl = 0._r8
+    end if 
+    if(temp_gwl < -TINYVALUE) then 
+       write(iulog,*) 'mosart: ERROR temp_gwl negative',iunit,nt,TRunoff%qgwl(iunit,nt)
+       call shr_sys_abort('mosart: ERROR temp_gwl negative ')
+       if(TRunoff%wr(iunit,nt) < TINYVALUE) then
+          temp_gwl = 0._r8
+       else 
+          if(TRunoff%wr(iunit,nt)/theDeltaT + temp_dwr + temp_gwl < -TINYVALUE) then
+          !write(iulog,*) 'adjust! ', temp_gwl, -(temp_dwr+TRunoff%wr(iunit,nt)/theDeltaT)
+             temp_gwl = -(temp_dwr + TRunoff%wr(iunit,nt) / theDeltaT)
+          end if
+       end if
+    end if
+           
+    TRunoff%dwr(iunit,nt) = TRunoff%erlateral(iunit,nt) + TRunoff%erin(iunit,nt) + TRunoff%erout(iunit,nt) + temp_gwl
+
+    !if(iunit==103833) then
+    !    write(unit=2110,fmt="(i10,9(e12.3))") myflag, TRunoff%wr(iunit,1), TRunoff%dwr(iunit,nt), TRunoff%erlateral(iunit,1), TRunoff%erin(iunit,1), TRunoff%erout(iunit,1), TRunoff%rslp_energy(iunit),TUnit%rslp(iunit), TRunoff%vr(iunit, nt_nliq), TRunoff%yr(iunit, nt_nliq)
+    !     write(unit=4111,fmt="(i10, 7(e12.3))") myflag, TRunoff%rslp_energy(iunit), TRunoff%vr(iunit, nt_nliq),TUnit%rslp(iunit), TRunoff%erin(iunit,1), TRunoff%erout(iunit,1), TUnit%nr(iunit), TRunoff%rr(iunit,nt)
+    !    write(unit=2112,fmt="(4(i10), 2(e12.3))") myflag,rtmCTL%mask(iunit), rtmCTL%nUp(iunit), rtmCTL%iUp(iunit,1), TUnit%rlen(iunit), TRunoff%erout(rtmCTL%iUp(iunit,1),1) 
+    !end if
+
+! check for stability
+!    if(TRunoff%vr(iunit,nt) < -TINYVALUE .or. TRunoff%vr(iunit,nt) > 30) then
+!       write(iulog,*) "Numerical error inRouting_DW, ", iunit,nt,TRunoff%vr(iunit,nt)
+!    end if
+
+ !check for negative wr
+   ! if((TRunoff%wr(iunit,nt)/theDeltaT + TRunoff%dwr(iunit,nt))/TRunoff%wr(iunit,nt) < -TINYVALUE) then
+   !    write(iulog,*) 'negative wr! -- Routing_DW', iunit, TRunoff%wr(iunit,nt), TRunoff%erlateral(iunit,nt), TRunoff%erin(iunit,nt), TRunoff%erout(iunit,nt), temp_gwl
+       !stop          
+   ! end if     
    
   end subroutine Routing_DW
 
@@ -722,6 +916,30 @@ MODULE MOSART_physics_mod
           TRunoff%rr(iunit,nt) = 0._r8
        end if
   end subroutine updateState_mainchannel
+
+!-----------------------------------------------------------------------
+    
+  function CRRSLP(iunit_) result(rslp_)
+  ! ! Function for calculating the water surface slope between the current and downstream grids
+    implicit none
+    integer, intent(in) :: iunit_ ! local index of current grid
+    real(r8)             :: rslp_            ! rslp_ is  slope [-]
+    
+    real(r8 ) :: y_c, len_c, slp_c             ! Water depth (m), length (m) and bed slope (dimensionless) of the current channel.
+    real(r8 ) :: y_down, len_down, slp_down    ! Water depth (m), length (m) and bed slope (dimensionless) of the downstream channel.
+    character(len=*),parameter :: subname = '(CRRSLP)'
+
+    y_c = TRunoff%yr(iunit_,nt_nliq)
+    len_c = TUnit%rlen(iunit_)
+    slp_c = TUnit%rslp(iunit_)
+    y_down = TRunoff%yr_dstrm(iunit_)
+    len_down = TUnit%rlen_dstrm(iunit_)
+    slp_down = TUnit%rslp_dstrm(iunit_)
+       
+    ! Calculate water surface slope ( from current-channel surface mid-point to downstream-channel surface mid-point ) :
+    rslp_ = (len_down * slp_down + len_c * slp_c + 2._r8 * y_c - 2._r8 * y_down) / (len_c + len_down)
+
+  end function CRRSLP
 
 !-----------------------------------------------------------------------
     
@@ -959,6 +1177,35 @@ MODULE MOSART_physics_mod
   
 !-----------------------------------------------------------------------
 
+  subroutine Leapfrog(iunit_, nt_, deltaT_)
+  ! !DESCRIPTION: Purpose: leapfrog method for channel routing
+    implicit none
+    integer, intent(in) :: iunit_, nt_    !
+    real(r8), intent(in) :: deltaT_ ! 
+
+    real(r8) :: wrtemp_, k1_, k2_
+    real(r8) :: erout1_, erout2_
+    
+    
+    wrtemp_ = TRunoff%wr(iunit_,nt_)
+    call mainchannelRouting(iunit_,nt_,deltaT_)
+    erout1_ = TRunoff%erout(iunit_,nt_)
+    k1_ = TRunoff%dwr(iunit_,nt_)
+    TRunoff%wr(iunit_,nt_) = TRunoff%wr(iunit_,nt_) + k1_ * deltaT_ * 0.5_r8
+    call UpdateState_mainchannel(iunit_,nt_)
+    call mainchannelRouting(iunit_,nt_,deltaT_)
+    erout2_ = TRunoff%erout(iunit_,nt_)
+    k2_ = TRunoff%dwr(iunit_,nt_)
+    !TRunoff%dwr(iunit_,nt_) =k1_ * 0.75_r8 + k2_ * 0.25_r8
+    TRunoff%wr(iunit_,nt_) = wrtemp_ + (k1_ * 0.75_r8 + k2_ * 0.25_r8) * deltaT_
+    TRunoff%erout(iunit_,nt_) = erout1_ * 0.75_r8 + erout2_ * 0.25_r8
+    call UpdateState_mainchannel(iunit_,nt_)
+    
+    !call mainchannelRouting(iunit_,nt_,deltaT_)
+
+  end subroutine Leapfrog
+
+!-----------------------------------------------------------------------
   subroutine createFile(nio, fname)
   ! !DESCRIPTION: create a new file. if a file with the same name exists, delete it then create a new one
     implicit none

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -271,7 +271,7 @@ contains
     rstraflag   = .false.
     rinittemp   = 283.15_r8
     ngeom       = 50  
-    nlayers     = 30				  
+    nlayers     = 30                  
     inundflag   = .false.
     sediflag    = .false.
     heatflag    = .false.
@@ -1610,7 +1610,7 @@ contains
        call t_startf('mosarti_wrm_init')
     end if
     if (wrmflag .and. heatflag .and. rstraflag) then
-       call regeom					
+       call regeom                    
     end if  
 
     !-------------------------------------------------------
@@ -3953,10 +3953,10 @@ contains
              allocate(TPara%t_mu(begr:endr))
            TPara%t_mu = 0.5278_r8
         end if
-		
+        
         allocate (THeat%coszen(begr:endr))
         THeat%coszen = 0._r8
-		
+        
      end if
     
      call pio_freedecomp(ncid, iodesc_dbl)
@@ -4272,53 +4272,53 @@ contains
 !----------------------------------------------------------------------------
 
   subroutine regeom
-	
+    
 ! Calculate reservoir layer average area (km2) 
  use shr_sys_mod   , only : shr_sys_flush
  use WRM_type_mod  , only : WRMUnit
  use RunoffMod     , only : rtmCTL
  use RtmVar         , only : iulog, ngeom, nlayers
-	
+    
  implicit none
  real(r8) :: M_W,M_L,gm_j,d_res,dd_in,C_a,C_v
  real(r8),dimension(ngeom+1) :: d_zi0,v_zti0,a_di0
- real(r8) ::dd_zz(ngeom),a_dd(ngeom+1),a_zi(ngeom+1),C_aa(ngeom+1), ar_f = 1.0e6             	! Factor to convert area to m^2
- real(r8) :: pi      = 3.141593_r8  	! pi
- real(r8) :: d_s	= 1.0_r8		!0.60_r8		           								! Surface layer depth (m)
+ real(r8) ::dd_zz(ngeom),a_dd(ngeom+1),a_zi(ngeom+1),C_aa(ngeom+1), ar_f = 1.0e6                 ! Factor to convert area to m^2
+ real(r8) :: pi      = 3.141593_r8      ! pi
+ real(r8) :: d_s    = 1.0_r8        !0.60_r8                                                   ! Surface layer depth (m)
  real(r8) :: dv,da,dz
- real(r8) :: d_v(nlayers)			   			! Reservoir volume change at layer (m^3)
- real(r8) :: rho_z(nlayers)			   			! Reservoir layer density (kg/m^3), taken constant for furture revision 
- real(r8) :: delta_z                        		! depth change to calculate corresponding area/volume(m)
- integer :: i,j,k,iunit,damID							! indices
+ real(r8) :: d_v(nlayers)                           ! Reservoir volume change at layer (m^3)
+ real(r8) :: rho_z(nlayers)                           ! Reservoir layer density (kg/m^3), taken constant for furture revision 
+ real(r8) :: delta_z                                ! depth change to calculate corresponding area/volume(m)
+ integer :: i,j,k,iunit,damID                            ! indices
  real(r8) :: s_tin,s_lum,a_sur,fac                 ! Initial total storage (10*6m^3), Lumped storage for grids with multiple reservoirs (m^3)
- real(r8) :: A_cf,V_cf						!Area and volume correcting factor for error from geometry estimation
+ real(r8) :: A_cf,V_cf                        !Area and volume correcting factor for error from geometry estimation
  character(len=*),parameter :: subname = '(regeom)'        
-						    
+                            
 !**************************************************************************************************************************************************
-	
- do iunit = rtmCTL%begr,rtmCTL%endr	
-		
+    
+ do iunit = rtmCTL%begr,rtmCTL%endr    
+        
      damID = WRMUnit%INVicell(iunit)
      if (damID>0.0_r8 .and. WRMUnit%d_ns(damID) >= 1) then ! .and. WRMUnit%Depth(damID) > 0.0_r8 .and. WRMUnit%Height(damID) > 0.0_r8
           if (WRMUnit%Depth(damID) <= 2.0_r8)WRMUnit%Depth(damID) = 2._r8
           if (WRMUnit%Height(damID) <= 2.0_r8)WRMUnit%Height(damID) = WRMUnit%Depth(damID)
           WRMUnit%d_resrv(damID) = 0.95_r8*WRMUnit%Height(damID)
           WRMUnit%h_resrv(damID) = 0.95_r8*WRMUnit%Height(damID)
-	  
+      
           s_lum = WRMUnit%StorCap(damID)
           s_tin = WRMUnit%V_str(damID)
           a_sur = WRMUnit%SurfArea(damID)
-				
+                
           if (s_lum <= 0.0_r8 .or. s_tin <= 0.0_r8 .or. ((s_lum/1.0e6) - s_tin)<0_r8) then
                fac = 0.0_r8
           elseif  (((s_lum/1.0e6) - s_tin)>=0_r8) then
                fac = ((s_lum/1.0e6) - s_tin)/s_tin
           endif
-				
-          !	Calculate layer depth	
+                
+          !    Calculate layer depth    
           if (WRMUnit%Width_r(damID) <= 0.0_r8)WRMUnit%Width_r(damID) = 1._r8
           if (WRMUnit%Length_r(damID) <= 0.0_r8)WRMUnit%Length_r(damID) = 1._r8
-						
+                        
           ! Area and volume correcting factors for relative error as compared to GRanD
           if (WRMUnit%A_dfs(damID)>=0_r8) then
                A_cf = 1._r8 + (abs(WRMUnit%A_errs(damID))/100._r8)
@@ -4332,92 +4332,92 @@ contains
           end if
           if (A_cf<=0._r8)A_cf = 0.1_r8
           if (V_cf<=0._r8)V_cf = 0.1_r8
-				
+                
           M_W   = WRMUnit%Width_r(damID)
           M_L   = WRMUnit%Length_r(damID)
           if (M_W<1._r8)M_W = 1.0_r8
           if (M_L<1._r8)M_L = 1.0_r8
           gm_j  = WRMUnit%geometry(damID)
-          d_res = WRMUnit%d_resrv(damID)		
+          d_res = WRMUnit%d_resrv(damID)        
           C_a   = WRMUnit%C_as(damID)
           C_v   = WRMUnit%C_vs(damID)
-				
+                
           if (WRMUnit%A_str(damID)<= 0._r8) WRMUnit%A_str(damID)= 1._r8
-				
+                
           if (WRMUnit%A_str(damID)<= 2._r8) then
                C_a  = 2.0_r8*WRMUnit%C_as(damID)
           end if
-							
-          ! Uniform subsurface layer depth for initialization	and limit maximum layer thickness 
+                            
+          ! Uniform subsurface layer depth for initialization    and limit maximum layer thickness 
           dd_in = d_res/ngeom !bottom layers evenly descritized
-							
-          ! Calculate reservoir geometry to establish depth-area-volume relationship			
-					
-          ! Calculate depth area	
+                            
+          ! Calculate reservoir geometry to establish depth-area-volume relationship            
+                    
+          ! Calculate depth area    
           !********** Curved Lake Bottom 
-				
-          do j = 1, ngeom!	
-               if (gm_j == 1.0_r8) then	
+                
+          do j = 1, ngeom!    
+               if (gm_j == 1.0_r8) then    
                      a_dd(j) = C_a*M_L*M_W*(ar_f)*(1-((dd_in*(j-1))/d_res)**2._r8)
-               else if (gm_j == 2.0_r8) then	
+               else if (gm_j == 2.0_r8) then    
                      a_dd(j) = C_a*M_L*M_W*(ar_f)*(1-((dd_in*(j-1))/d_res)**2._r8)*(1-((dd_in*(j-1))/d_res))
-               else if (gm_j == 3.0_r8) then	
+               else if (gm_j == 3.0_r8) then    
                      a_dd(j) = C_a*M_L*M_W*(ar_f)*(1-((dd_in*(j-1))/d_res)**2._r8)*((d_res-(dd_in*(j-1)))/d_res)**0.5_r8
-               else if (gm_j == 4.0_r8) then	
+               else if (gm_j == 4.0_r8) then    
                      a_dd(j) = C_a*(2._r8/3._r8)*M_L*M_W*(ar_f)*(1-((dd_in*(j-1))/d_res)**2._r8)*(1-((dd_in*(j-1)))/d_res)
-               else if (gm_j == 5.0_r8) then	
+               else if (gm_j == 5.0_r8) then    
                      a_dd(j) = C_a*pi*0.25_r8*M_L*M_W*(ar_f)*(1-((dd_in*(j-1))/d_res)**2._r8)*((d_res-(dd_in*(j-1)))/d_res)**0.5_r8
-               end if					
+               end if                    
           end do
-					
-          a_dd(ngeom+1) = a_dd(ngeom)*0.001_r8			!Bottom area given non-zero value
-					
+                    
+          a_dd(ngeom+1) = a_dd(ngeom)*0.001_r8            !Bottom area given non-zero value
+                    
           ! Reverse indexing so that bottom is 1 and top is d_n+1 and convert to m2
           do j = 1,ngeom+1
                k =ngeom+2-j  
                a_di0(k) = ((a_dd(j)))
                if (a_di0(k)==0._r8) a_di0(k)=1._r8
-               WRMUnit%a_di(damID,k)  = (A_cf*a_di0(k)) 	!Area corrected for error for optimal geometry
+               WRMUnit%a_di(damID,k)  = (A_cf*a_di0(k))     !Area corrected for error for optimal geometry
                if (WRMUnit%a_di(damID,k)==0._r8) WRMUnit%a_di(damID,k)=1._r8
-          end do	
-				
+          end do    
+                
           ! Calculate layer depth,area,and volume from bottom 
           d_zi0(1) = 0._r8
           WRMUnit%d_zi(damID,1)  = d_zi0(1)
-          do j = 2, ngeom+1	
+          do j = 2, ngeom+1    
                d_zi0(j) = d_zi0(j-1) + dd_in
                WRMUnit%d_zi(damID,j)  = d_zi0(j) 
           end do
-						
+                        
           ! Calculate layer average area,and total volume from bottom
-          v_zti0(1) = (0.001_r8*0.5_r8*(WRMUnit%a_di(damID,1)+WRMUnit%a_di(damID,2))*dd_in)!	
-          WRMUnit%v_zti(damID,1) = (V_cf*v_zti0(1)) 	!lower Volume corrected for error
+          v_zti0(1) = (0.001_r8*0.5_r8*(WRMUnit%a_di(damID,1)+WRMUnit%a_di(damID,2))*dd_in)!    
+          WRMUnit%v_zti(damID,1) = (V_cf*v_zti0(1))     !lower Volume corrected for error
           if (WRMUnit%v_zti(damID,1)==0._r8) WRMUnit%v_zti(damID,1)=1._r8
-          do j = 2, ngeom+1	 
+          do j = 2, ngeom+1     
                a_zi(j) = 0.5_r8*(WRMUnit%a_di(damID,j)+WRMUnit%a_di(damID,j-1)) !Area converted to m^2
                v_zti0(j) = v_zti0(j-1) + ((C_v*a_zi(j)*dd_in))
-               WRMUnit%v_zti(damID,j) = (V_cf*v_zti0(j)) 	!Volume corrected for error
+               WRMUnit%v_zti(damID,j) = (V_cf*v_zti0(j))     !Volume corrected for error
                if (WRMUnit%v_zti(damID,j)==0._r8) WRMUnit%v_zti(damID,j)=1._r8
                if (WRMUnit%a_di(damID,j)<0._r8 .or. WRMUnit%v_zti(damID,j)<0._r8) write(iulog,*) 'geom negative',iunit,WRMUnit%grandid(damID)
           end do
-				
+                
           !Initial reservoir storage 
           do j = WRMUnit%d_ns(damID),1,-1
                if (j == WRMUnit%d_ns(damID) .and. WRMUnit%d_ns(damID) == 1) then
                      WRMUnit%dd_z(damID,j) = WRMUnit%d_resrv(damID)
                elseif (j == WRMUnit%d_ns(damID) .and. WRMUnit%d_ns(damID) > 1) then !top layer depth kept constant
-                     WRMUnit%dd_z(damID,j) = d_s		!0.6_r8
+                     WRMUnit%dd_z(damID,j) = d_s        !0.6_r8
                elseif ((WRMUnit%d_ns(damID)>1 .and.j < WRMUnit%d_ns(damID)).and.(WRMUnit%d_resrv(damID) - WRMUnit%dd_z(damID,WRMUnit%d_ns(damID)))>0._r8) then
                      WRMUnit%dd_z(damID,j) = (WRMUnit%d_resrv(damID) - WRMUnit%dd_z(damID,WRMUnit%d_ns(damID))) / (WRMUnit%d_ns(damID) - 1) !bottom layers evenly descritized
                endif
-          end do	
-			
+          end do    
+            
           if (WRMUnit%d_ns(damID)>1 .and. WRMUnit%dd_z(damID,WRMUnit%d_ns(damID)-1)<d_s)then !layer thickness too small
                WRMUnit%d_ns(damID)=int((WRMUnit%d_resrv(damID)/d_s)+1) 
                do j=1,nlayers!WRMUnit%d_ns(damID)
                      WRMUnit%dd_z(damID,j) = 0._r8
                end do
-					
+                    
                ! Reinitialize layer thickness
                do j = WRMUnit%d_ns(damID),1,-1
                      if (j == WRMUnit%d_ns(damID)) then
@@ -4425,24 +4425,24 @@ contains
                      else
                          WRMUnit%dd_z(damID,j) = (WRMUnit%d_resrv(damID) - WRMUnit%dd_z(damID,WRMUnit%d_ns(damID)))/(WRMUnit%d_ns(damID) - 1) !bottom layers evenly descritized
                      end if
-               end do	
+               end do    
           end if
-		
+        
           if (WRMUnit%d_ns(damID)>1) then
                WRMUnit%ddz_local(damID) = WRMUnit%dd_z(damID,WRMUnit%d_ns(damID)-1)
           else
                WRMUnit%ddz_local(damID) = WRMUnit%dd_z(damID,WRMUnit%d_ns(damID))
           end if
-				
-          ! Calculate layer depth (minimum at bottom)	
+                
+          ! Calculate layer depth (minimum at bottom)    
           WRMUnit%d_z(damID,1)=0._r8
-          do j = 2, nlayers	
+          do j = 2, nlayers    
                if (j<=WRMUnit%d_ns(damID)+1) then
                      WRMUnit%d_z(damID,j) = WRMUnit%d_z(damID,j-1) + WRMUnit%dd_z(damID,j-1)
                else 
                      WRMUnit%d_z(damID,j) = 0._r8
                end if
-          end do	
+          end do    
           ! Assign layer area and volume based on depth-area-volume relationship
           WRMUnit%a_d(damID,1)=(WRMUnit%a_di(damID,1))
           WRMUnit%v_zt(damID,1)=(WRMUnit%v_zti(damID,1))
@@ -4465,12 +4465,12 @@ contains
                      WRMUnit%v_zt(damID,i) = 0._r8
                end if
           end do
-								
+                                
           ! Calculate layer volume(m^3)
-          do j = 1, nlayers	
+          do j = 1, nlayers    
                if (j<=WRMUnit%d_ns(damID)) then
-                     WRMUnit%d_v(damID,j) = ((WRMUnit%v_zt(damID,j+1) - WRMUnit%v_zt(damID,j)))	
-                     if (WRMUnit%d_v(damID,j)==0._r8) WRMUnit%d_v(damID,j)=1._r8	
+                     WRMUnit%d_v(damID,j) = ((WRMUnit%v_zt(damID,j+1) - WRMUnit%v_zt(damID,j)))    
+                     if (WRMUnit%d_v(damID,j)==0._r8) WRMUnit%d_v(damID,j)=1._r8    
                      WRMUnit%dd_z(damID,j) = WRMUnit%d_z(damID,j+1) - WRMUnit%d_z(damID,j)
                      if (WRMUnit%d_v(damID,j)<0.0_r8) then 
                          write(iulog,*) subname,'Layer volume negative:Check geometry data for dam',WRMUnit%grandid(damID)
@@ -4479,18 +4479,18 @@ contains
                      WRMUnit%d_v(damID,j) = 0._r8
                      WRMUnit%dd_z(damID,j) = 0._r8
                end if
-          end do		
-				
-          ! 	Intitialize layer temperature and total storage					
-          do j=1,WRMUnit%d_ns(damID)					
+          end do        
+                
+          !     Intitialize layer temperature and total storage                    
+          do j=1,WRMUnit%d_ns(damID)                    
                rho_z(j) = 1000._r8*( 1._r8 - 1.9549e-05*(abs(WRMUnit%temp_resrv(damID,j)-277._r8))**1.68_r8) 
                WRMUnit%v_zn(damID,j) = (WRMUnit%d_v(damID,j))
                WRMUnit%m_zo(damID,j) = (WRMUnit%d_v(damID,j)*rho_z(j)) 
                WRMUnit%m_zn(damID,j) = (WRMUnit%d_v(damID,j)*rho_z(j))
           end do
      end if
- end do	
- end subroutine regeom 				   
+ end do    
+ end subroutine regeom                    
 !---------------------------------------------------------------------------- 
 
   subroutine SubTimestep
@@ -4526,6 +4526,7 @@ contains
           end if
        end if
        if(TUnit%numDT_t(iunit) < 1) TUnit%numDT_t(iunit) = 1
+    
     end do
   end subroutine SubTimestep
 

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -183,7 +183,7 @@ contains
     integer  :: mon                           ! month (1, ..., 12)
     integer  :: day                           ! day of month (1, ..., 31)
     integer  :: numr                          ! tot num of roff pts on all pes
-    integer  :: RoutingMethod                 ! 1 = KW, 4 = DW
+    integer  :: RoutingMethod                 ! 1 = KW, 2 = DW
     integer  :: DLevelH2R                     !
     integer  :: DLevelR                       !
     integer  :: OPT_inund                     ! Options for inundation
@@ -3558,17 +3558,8 @@ contains
 
      end if
 
-     allocate(TUnit%nUp(begr:endr))
-     TUnit%nUp = 0
-
-     allocate(TUnit%iUp(begr:endr,8))
-     TUnit%iUp = 0
-
-     allocate(TUnit%indexDown(begr:endr))
-     TUnit%indexDown = 0
-   
      if (inundflag) then
-       if ( Tctl%RoutingMethod == 4 ) then       ! Use diffusion wave method in channel routing computation.
+       if ( Tctl%RoutingMethod == 2 ) then       ! Use diffusion wave method in channel routing computation.
           allocate (TUnit%rlen_dstrm(begr:endr))
           allocate (TUnit%rslp_dstrm(begr:endr))
 
@@ -3787,7 +3778,7 @@ contains
      allocate (TPara%c_twid(begr:endr))
      TPara%c_twid = 1.0_r8
 
-     if ( Tctl%RoutingMethod == 4 ) then       ! Use diffusion wave method in channel routing computation.
+     if ( Tctl%RoutingMethod == 2 ) then       ! Use diffusion wave method in channel routing computation.
         allocate (TRunoff%rslp_energy(begr:endr))
         TRunoff%rslp_energy = 0.0_r8
         
@@ -3824,7 +3815,7 @@ contains
         allocate (TRunoff%yr_exchg(begr:endr))
         TRunoff%yr_exchg = 0.0_r8
 
-        if ( Tctl%RoutingMethod == 4 ) then       ! Use diffusion wave method in channel routing computation.
+        if ( Tctl%RoutingMethod == 2 ) then       ! Use diffusion wave method in channel routing computation.
            allocate (TRunoff%wr_exchg_dstrm(begr:endr))
            TRunoff%wr_exchg_dstrm = 0.0_r8
 
@@ -4054,7 +4045,7 @@ contains
   end if  ! endr >= begr
 
   ! retrieve the downstream channel attributes after some post-processing above
-  if (Tctl%RoutingMethod == 4 ) then       ! Use diffusion wave method in channel routing computation.
+  if (Tctl%RoutingMethod == 2 ) then       ! Use diffusion wave method in channel routing computation.
      allocate (TUnit%rlen_dstrm(begr:endr))
      allocate (TUnit%rslp_dstrm(begr:endr))
 

--- a/components/mosart/src/riverroute/RunoffMod.F90
+++ b/components/mosart/src/riverroute/RunoffMod.F90
@@ -160,7 +160,7 @@ module RunoffMod
                                   ! Usually channel routing requires small time steps than hillslope routing.
      integer  :: DLevelR          ! The number of channel routing sub-time-steps at a higher level within one channel routing step at a lower level. 
      integer  :: Restart          ! flag, Restart=1 means starting from the state of last run, =0 means starting from model-inset initial state.
-     integer  :: RoutingMethod    ! Flag for routing methods. 1 --> variable storage method from SWAT model; 2 --> Muskingum method?  ( 1 -- Kinematic wave method; 4 -- Diffusion wave method. --Inund. )
+     integer  :: RoutingMethod    ! Flag for routing methods. 1 --> Kinematic wave routing method; 2 --> Diffusion wave method.
      integer  :: RoutingFlag      ! Flag for whether including hillslope and sub-network routing. 1--> include routing through hillslope, sub-network and main channel; 0--> main channel routing only.
  
      character(len=100) :: baseName    ! name of the case study, e.g., columbia
@@ -253,10 +253,6 @@ module RunoffMod
      integer , pointer :: dnID(:)      ! IDs of the downstream units, corresponding to the subbasin ID in the input table
      integer , pointer :: nUp(:)       ! number of upstream units, maximum 8
      integer , pointer :: iUp(:,:)     ! IDs of upstream units, corresponding to the subbasin ID in the input table
-  
-     integer , pointer :: indexDown(:) ! indices of the downstream units in the ID array. sometimes subbasins IDs may not be continuous
-     integer , pointer :: iDown(:)     ! indices of the downstream units, local
-     integer , pointer :: nUp_dstrm(:) ! number of upstream units, maximum 8
   
      integer , pointer :: numDT_r(:)   ! for a main reach, the number of sub-time-steps needed for numerical stability
      integer , pointer :: numDT_t(:)   ! for a subnetwork reach, the number of sub-time-steps needed for numerical stability


### PR DESCRIPTION
This diffusion wave routing method will capture the backwater effects, hence allow better
simulation of river-ocean interactions, particularly the propagation of tidal waves from the ocean
into the rivers. 

[BFB]