### PR TITLE
Fix restart NBFB when clubb_ipdf_call_placement=2

### DIFF
--- a/components/eam/src/physics/clubb/advance_clubb_core_module.F90
+++ b/components/eam/src/physics/clubb/advance_clubb_core_module.F90
@@ -106,6 +106,8 @@ module advance_clubb_core_module
     ipdf_pre_post_advance_fields = 3   ! Call both before and after advancing
                                        ! predictive fields
 
+  public :: ipdf_post_advance_fields
+
   private ! Default Scope
 
   contains


### PR DESCRIPTION
Restart tests would fail when clubb_ipdf_call_placement=2 is used.

Five component variables (w_1, w_2, varnce_w_1, varnce_w_2, and
mixt_frac.) in pdf_params_zm after returning  from
advance_clubb_core must be saved to restart file and read back
to preserve BFB upon restart, when ipdf_call_placement equals
ipdf_post_advance_fields (=2)

The addition of these 5 variables increase the eam.r file size  by 1.6%

[BFB] for existing tests before #4033, but they are to be merged together.
      #4033 will be responsible for all the diffs for tests involving active
      atmos except for wcprod tests.

Fixes #4064