### PR TITLE
Add support for ne30pg2_oRRS18to6v3 fully-coupled configurations

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1945,6 +1945,16 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_oRRS18to6v3">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">ne30np4.pg2</grid>
+      <grid name="ocnice">oRRS18to6v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6v3</mask>
+    </model_grid>
+
     <model_grid alias="ne30_r05_oECv3">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">r05</grid>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1945,6 +1945,7 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
+<!-- WARNING: THIS GRID COMBINATION IS NOT SCIENTIFICALLY SUPPORTED -->
     <model_grid alias="ne30pg2_oRRS18to6v3">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">ne30np4.pg2</grid>
@@ -1953,6 +1954,7 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>oRRS18to6v3</mask>
+      <support>Experimental for ocn/ice testing</support>
     </model_grid>
 
     <model_grid alias="ne30_r05_oECv3">


### PR DESCRIPTION
Adds a new grid alias for ne30pg2_oRRS18to6v3, to allow testing of the v1 high-res ocean grid with the v2 low-res atm. The mapping files were already in place for a trigrid setup with lnd/rof on r0125.