### PR TITLE
update mpas-source: make ocean init mode optional

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -883,6 +883,12 @@ add_default($nl, 'config_conduct_tests');
 add_default($nl, 'config_test_tensors');
 add_default($nl, 'config_tensor_test_function');
 
+#########################################
+# Namelist group: init_mode_vert_levels #
+#########################################
+
+add_default($nl, 'config_vert_levels');
+
 ################################################
 # Namelist group: tracer_forcing_activeTracers #
 ################################################
@@ -1602,6 +1608,7 @@ my @groups = qw(run_modes
                 ale_frequency_filtered_thickness
                 debug
                 testing
+                init_mode_vert_levels
                 tracer_forcing_activetracers
                 tracer_forcing_debugtracers
                 tracer_forcing_ecosystracers

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -31,6 +31,7 @@ my @groups = qw(run_modes
                 ale_frequency_filtered_thickness
                 debug
                 testing
+                init_mode_vert_levels
                 tracer_forcing_activetracers
                 tracer_forcing_debugtracers
                 tracer_forcing_ecosystracers

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -414,6 +414,12 @@ add_default($nl, 'config_conduct_tests');
 add_default($nl, 'config_test_tensors');
 add_default($nl, 'config_tensor_test_function');
 
+#########################################
+# Namelist group: init_mode_vert_levels #
+#########################################
+
+add_default($nl, 'config_vert_levels');
+
 ################################################
 # Namelist group: tracer_forcing_activeTracers #
 ################################################

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -443,6 +443,9 @@
 <config_test_tensors>.false.</config_test_tensors>
 <config_tensor_test_function>'sph_uCosCos'</config_tensor_test_function>
 
+<!-- init_mode_vert_levels -->
+<config_vert_levels>-1</config_vert_levels>
+
 <!-- tracer_forcing_activeTracers -->
 <config_use_activeTracers>.true.</config_use_activeTracers>
 <config_use_activeTracers_surface_bulk_forcing>.true.</config_use_activeTracers_surface_bulk_forcing>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -2109,6 +2109,17 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
+<!-- init_mode_vert_levels -->
+
+<entry id="config_vert_levels" type="integer"
+	category="init_mode_vert_levels" group="init_mode_vert_levels">
+Number of vertical levels to create within the configuration.
+
+Valid values: Any positive non-zero integer. A value of -1 causes this to be overwritten with the configurations vertical level definition.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
 <!-- tracer_forcing_activeTracers -->
 
 <entry id="config_use_activeTracers" type="logical"


### PR DESCRIPTION
MPAS-Ocean init mode is used for the generation of initial conditions. It is not ever executed within E3SM simulations. See https://github.com/MPAS-Dev/MPAS-Model/pull/600

Currently, when MPAS is run in E3SM, it looks for all the init mode namelists in the namelist file. When they are not found, the MPAS framework writes lengthy warnings to the ocean log file that are not relevant to E3SM, and are confusing to the E3SM user.

This PR adds the option to exclude init mode in both the Make and cmake systems. For E3SM, it is set to simply not compile the init mode code, and not include the init mode namelists. For MPAS stand-alone, this is controlled with a compile-time Make flag.

[NML]
[BFB]