### PR TITLE
HOMMEXX: fix some valgrind errors when unit-testing the remap functor

### DIFF
--- a/components/homme/src/theta-l_kokkos/cxx/RemapStateProvider.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/RemapStateProvider.hpp
@@ -85,13 +85,10 @@ struct RemapStateProvider {
       return;
     }
 
-    using temp_type = decltype(m_temp);
-    const int temp_size = temp_type::shmem_size(num_teams)/sizeof(Real);
-
     Scalar* mem = reinterpret_cast<Scalar*>(fbm.get_memory());
 
     m_temp = decltype(m_temp)(mem,num_teams);
-    mem += temp_size;
+    mem += m_temp.size();
 
     m_phi_ref = decltype(m_phi_ref)(mem,num_teams);
   }


### PR DESCRIPTION
There was an error when setting the scratch mem buffer inside the `RemapStateProvider` struct, which caused a view to be a bit further down in the buffer than originally planned. This was completely harmless in actual runs, since the mem buffer was much bigger than `RemapStateProvider` needed, so the view still ended inside the allocated memory. However, when unit testing the remap functor, we allocated only enough memory to fit the remap needs, so the error in the view creation was exposed. This PR fixes this error.

Additionally, our remap unit testing was not comparing the tracers after the remap. I added those checks as well.

[bfb]