### PR TITLE
Fix an issue in nudging code 

### DIFF
--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -66,14 +66,14 @@
 <entry id="Nudge_Allow_Missing_File" type="logical" category="nudging"
        group="nudging_nl" valid_values="" >
        User-defined flag to inform Nudging if all nudged data files exist.
-       1. If .true.: all nudged data files must show up during the 
+       1. If .false.: all nudged data files must show up during the 
            whole nudging period. Otherwise, the model will exit if a 
 	   nudged data file is not found.  
-       2. If .false: the user allows the model to continue to run even if a
+       2. If .true.: user allows the model to continue to run even if a
           nudged data file is not found. The model will continue to run with the 
 	  nudging turned off, and only a warning message will be added to the 
 	  simulation log file.     
-       Default: TRUE
+       Default: FALSE
        </entry>
 
 <entry id="Nudge_Path" type="char*256" input_pathname="abs" category="nudging"

--- a/components/cam/bld/namelist_files/namelist_definition.xml
+++ b/components/cam/bld/namelist_files/namelist_definition.xml
@@ -63,6 +63,19 @@
        Default: FALSE
        </entry>
 
+<entry id="Nudge_Allow_Missing_File" type="logical" category="nudging"
+       group="nudging_nl" valid_values="" >
+       User-defined flag to inform Nudging if all nudged data files exist.
+       1. If .true.: all nudged data files must show up during the 
+           whole nudging period. Otherwise, the model will exit if a 
+	   nudged data file is not found.  
+       2. If .false: the user allows the model to continue to run even if a
+          nudged data file is not found. The model will continue to run with the 
+	  nudging turned off, and only a warning message will be added to the 
+	  simulation log file.     
+       Default: TRUE
+       </entry>
+
 <entry id="Nudge_Path" type="char*256" input_pathname="abs" category="nudging"
        group="nudging_nl" valid_values="" >
        Full pathname of analyses data to use for nudging.

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -413,7 +413,7 @@ module nudging
   logical::         Nudge_File_Present=.false.
   logical::         Nudge_Initialized =.false.
   character(len=cl) Nudge_Path
-  character(len=cs) Nudge_File,Nudge_File_Template
+  character(len=cl) Nudge_File,Nudge_File_Template
   integer           Nudge_Times_Per_Day
   integer           Model_Times_Per_Day
   real(r8)          Nudge_Ucoef,Nudge_Vcoef
@@ -1675,7 +1675,7 @@ contains
 
    integer :: cnt3(3)               ! array of counts for each dimension
    integer :: strt3(3)              ! array of starting indices
-   character(len=cs) :: nudge_file1
+   character(len=cl) :: nudge_file1
    integer :: n, n_cnt, ncid1, ind
    integer :: timesiz               ! size of time dimension on dataset
    integer :: Year, Month, Day, Sec
@@ -2388,7 +2388,7 @@ contains
 
    integer :: cnt4(4)               ! array of counts for each dimension
    integer :: strt4(4)              ! array of starting indices
-   character(len=cs) :: nudge_file1
+   character(len=cl) :: nudge_file1
    integer :: n, n_cnt, ncid1, ind
    integer :: Year, Month, Day, Sec
 
@@ -3118,7 +3118,7 @@ contains
   ! local variable  
   integer :: YMD3, YMD4, Nudge_Next1_Sec, Nudge_Next1_Year, &
              Nudge_Next1_Month, Nudge_Next1_Day, istat
-  character(len=cs)       :: nudge_file
+  character(len=cl)       :: nudge_file
 
   YMD3 = (Nudge_Next_Year*10000) + &
          (Nudge_NEXT_Month*100) + Nudge_Next_Day

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -414,7 +414,7 @@ module nudging
   logical::         Nudge_ON          =.false.
   logical::         Nudge_File_Present=.false.
   logical::         Nudge_Initialized =.false.
-  logical::         Nudge_Allow_Missing_File = .true.  
+  logical::         Nudge_Allow_Missing_File = .false.  
   character(len=cl) Nudge_Path
   character(len=cl) Nudge_File,Nudge_File_Template
   integer           Nudge_Times_Per_Day
@@ -555,7 +555,7 @@ contains
    ! Set Default Namelist values
    !-----------------------------
    Nudge_Model        =.false.
-   Nudge_Allow_Missing_File = .true.
+   Nudge_Allow_Missing_File = .false.
    Nudge_Path         ='./Data/YOTC_ne30np4_001/'
    Nudge_File_Template='YOTC_ne30np4_L30.cam2.i.%y-%m-%d-%s.nc'
    Nudge_Times_Per_Day=4

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -1401,13 +1401,13 @@ contains
      else
        Nudge_ON=.false.
        if(Nudge_Allow_Missing_File) then
-         write(err_str,*) 'NUDGING: Nudging data file NOT FOUND; ', errmsg(__FILE__, __LINE__)
-         call endrun(err_str)
-       else
          if(masterproc) then
            write(iulog,*) 'NUDGING: WARNING - Nudging data file NOT FOUND. Switching '
            write(iulog,*) 'NUDGING:           nudging OFF to coast thru the gap. '
-         endif               
+         endif   
+       else
+         write(err_str,*) 'NUDGING: Nudging data file (',trim(adjustl(Nudge_File)),') NOT FOUND; ', errmsg(__FILE__, __LINE__)
+         call endrun(err_str)
        endif 
      endif
    else

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -1391,10 +1391,7 @@ contains
        Nudge_ON=.true.
      else
        Nudge_ON=.false.
-       if(masterproc) then
-         write(iulog,*) 'NUDGING: WARNING - analyses file NOT FOUND. Switching '
-         write(iulog,*) 'NUDGING:           nudging OFF to coast thru the gap. '
-       endif
+       call endrun('NUDGING: Nudging data file NOT FOUND')
      endif
    else
      Nudge_ON=.false.

--- a/components/cam/src/physics/cam/nudging.F90
+++ b/components/cam/src/physics/cam/nudging.F90
@@ -379,6 +379,7 @@ module nudging
   use cam_abortutils  ,only:endrun
   use spmd_utils  ,only:masterproc
   use cam_logfile ,only:iulog
+  use shr_log_mod, only:errMsg => shr_log_errMsg
   use perf_mod
 #ifdef SPMD
   use mpishorthand
@@ -391,6 +392,7 @@ module nudging
   private
 
   public:: Nudge_Model,Nudge_ON
+  public:: Nudge_Allow_Missing_File
   public:: nudging_readnl
   public:: nudging_init
   public:: nudging_timestep_init
@@ -412,6 +414,7 @@ module nudging
   logical::         Nudge_ON          =.false.
   logical::         Nudge_File_Present=.false.
   logical::         Nudge_Initialized =.false.
+  logical::         Nudge_Allow_Missing_File = .true.  
   character(len=cl) Nudge_Path
   character(len=cl) Nudge_File,Nudge_File_Template
   integer           Nudge_Times_Per_Day
@@ -520,6 +523,7 @@ contains
    integer ierr,unitn
 
    namelist /nudging_nl/ Nudge_Model,Nudge_Path,                       &
+                         Nudge_Allow_Missing_File,                     &
                          Nudge_File_Template,Nudge_Times_Per_Day,      &
                          Model_Times_Per_Day,                          &
                          Nudge_Ucoef ,Nudge_Uprof,                     &
@@ -551,6 +555,7 @@ contains
    ! Set Default Namelist values
    !-----------------------------
    Nudge_Model        =.false.
+   Nudge_Allow_Missing_File = .true.
    Nudge_Path         ='./Data/YOTC_ne30np4_001/'
    Nudge_File_Template='YOTC_ne30np4_L30.cam2.i.%y-%m-%d-%s.nc'
    Nudge_Times_Per_Day=4
@@ -674,6 +679,7 @@ contains
    call mpibcast(Nudge_Initialized  , 1, mpilog, 0, mpicom)
    call mpibcast(Nudge_ON           , 1, mpilog, 0, mpicom)
    call mpibcast(Nudge_File_Present , 1, mpilog, 0, mpicom)
+   call mpibcast(Nudge_Allow_Missing_File,1, mpilog, 0, mpicom)
    call mpibcast(Nudge_Times_Per_Day, 1, mpiint, 0, mpicom)
    call mpibcast(Model_Times_Per_Day, 1, mpiint, 0, mpicom)
    call mpibcast(Nudge_Ucoef    , 1, mpir8 , 0, mpicom)
@@ -970,6 +976,7 @@ contains
      write(iulog,*) '  MODEL NUDGING INITIALIZED WITH THE FOLLOWING SETTINGS: '
      write(iulog,*) '---------------------------------------------------------'
      write(iulog,*) 'NUDGING: Nudge_Model=',Nudge_Model
+     write(iulog,*) 'NUDGING: Nudge_Allow_Missing_File=',Nudge_Allow_Missing_File
      write(iulog,*) 'NUDGING: Nudge_Path=',Nudge_Path
      write(iulog,*) 'NUDGING: Nudge_File_Template=',Nudge_File_Template
      write(iulog,*) 'NUDGING: Nudge_Times_Per_Day=',Nudge_Times_Per_Day
@@ -1035,6 +1042,7 @@ contains
    call mpibcast(Nudge_Next_Day      , 1, mpiint, 0, mpicom)
    call mpibcast(Nudge_Next_Sec      , 1, mpiint, 0, mpicom)
    call mpibcast(Nudge_Model         , 1, mpilog, 0, mpicom)
+   call mpibcast(Nudge_Allow_Missing_File, 1, mpilog, 0, mpicom)
    call mpibcast(Nudge_ON            , 1, mpilog, 0, mpicom)
    call mpibcast(Nudge_Initialized   , 1, mpilog, 0, mpicom)
    call mpibcast(Nudge_ncol          , 1, mpiint, 0, mpicom)
@@ -1213,6 +1221,7 @@ contains
    logical Update_Model,Update_Nudge,Sync_Error
    logical After_Beg   ,Before_End
    integer lchnk,ncol,indw
+   character(len=2000) err_str
 
    ! Check if Nudging is initialized
    !---------------------------------
@@ -1391,7 +1400,15 @@ contains
        Nudge_ON=.true.
      else
        Nudge_ON=.false.
-       call endrun('NUDGING: Nudging data file NOT FOUND')
+       if(Nudge_Allow_Missing_File) then
+         write(err_str,*) 'NUDGING: Nudging data file NOT FOUND; ', errmsg(__FILE__, __LINE__)
+         call endrun(err_str)
+       else
+         if(masterproc) then
+           write(iulog,*) 'NUDGING: WARNING - Nudging data file NOT FOUND. Switching '
+           write(iulog,*) 'NUDGING:           nudging OFF to coast thru the gap. '
+         endif               
+       endif 
      endif
    else
      Nudge_ON=.false.


### PR DESCRIPTION
-- In current nudging.F90 the character length of the nudging file name is defined as 80,
   when the nudging file name is longer than 80 characters, the nudging code can not
   get the full name for the nudging file. In this way, nudging will not be applied.
   To avoid this problem, code changes are made to extend the character length of
   the nudging file name to 256.

-- Note that: when the filename can not be identified by the nudging.F90, nudging will
   complain that the nudging data does not exist, and nudging will be automatically
   switched off. This can be only identified by checking the atm.log file. 

[BFB]