### PR TITLE
better control of vertical remap options

### DIFF
--- a/components/homme/src/preqx/share/vertremap_mod.F90
+++ b/components/homme/src/preqx/share/vertremap_mod.F90
@@ -114,7 +114,7 @@ contains
         ttmp(:,:,:,1)=ttmp(:,:,:,1)*dp_star
 
         call t_startf('vertical_remap1_1')
-        call remap1(ttmp,np,1,dp_star,dp)
+        call remap1(ttmp,np,1,dp_star,dp,vert_remap_q_alg)
         call t_stopf('vertical_remap1_1')
 
         elem(ie)%state%t(:,:,:,np1)=ttmp(:,:,:,1)/dp
@@ -123,7 +123,7 @@ contains
         ttmp(:,:,:,2)=elem(ie)%state%v(:,:,2,:,np1)*dp_star
 
         call t_startf('vertical_remap1_2')
-        call remap1(ttmp,np,2,dp_star,dp)
+        call remap1(ttmp,np,2,dp_star,dp,vert_remap_q_alg)
         call t_stopf('vertical_remap1_2')
 
         elem(ie)%state%v(:,:,1,:,np1)=ttmp(:,:,:,1)/dp
@@ -141,7 +141,7 @@ contains
      if (qsize>0 .and. np1_qdp > 0) then
 
        call t_startf('vertical_remap1_3')
-       call remap1(elem(ie)%state%Qdp(:,:,:,:,np1_qdp),np,qsize,dp_star,dp)
+       call remap1(elem(ie)%state%Qdp(:,:,:,:,np1_qdp),np,qsize,dp_star,dp,vert_remap_q_alg)
        call t_stopf('vertical_remap1_3')
 
        !dir$ simd

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -73,12 +73,16 @@ module control_mod
                                           ! 0 = disabled
 
 ! vert_remap_q_alg:   -1  remap without monotone filter, used for some test cases
-!                      0  default value, Zerroukat monotonic splines
+!                      0  Zerroukat monotonic splines
 !                      1  PPM vertical remap with mirroring at the boundaries
 !                         (solid wall bc's, high-order throughout)
-!                      2  PPM vertical remap without mirroring at the boundaries
-!                         (no bc's enforced, first-order at two cells bordering top and bottom boundaries)
- integer, public :: vert_remap_q_alg = 0
+!                     10  linear extrapolation at boundaries, with limiter
+!                     11  linear extrapolation, no limiter
+ integer, public :: vert_remap_q_alg = 0    ! tracers
+! for vert_remap_q_alg=2, use 1st order reconstruction in
+! the specified number of layers near model top and surface
+ integer, public :: vert_remap_tom = 1   
+ integer, public :: vert_remap_bl = 1
 
 ! advect theta 0: conservation form 
 !              1: expanded divergence form (less noisy, non-conservative)

--- a/components/homme/src/share/sl_advection.F90
+++ b/components/homme/src/share/sl_advection.F90
@@ -120,7 +120,7 @@ contains
     use bndry_mod,              only : ghost_exchangevfull
     use interpolate_mod,        only : interpolate_tracers, minmax_tracers
     use control_mod,            only : dt_tracer_factor, nu_q, transport_alg, semi_lagrange_hv_q, &
-         semi_lagrange_cdr_alg, semi_lagrange_cdr_check
+         semi_lagrange_cdr_alg, semi_lagrange_cdr_check, vert_remap_q_alg
     ! For DCMIP16 supercell test case.
     use control_mod,            only : dcmip16_mu_q
     use prim_advection_base,    only : advance_physical_vis
@@ -166,7 +166,7 @@ contains
                deriv, dp_tol, elem(ie)%derived%divdp)
           wr(:,:,:,1) = elem(ie)%derived%vn0(:,:,1,:)*elem(ie)%state%dp3d(:,:,:,tl%np1)
           wr(:,:,:,2) = elem(ie)%derived%vn0(:,:,2,:)*elem(ie)%state%dp3d(:,:,:,tl%np1)
-          call remap1(wr, np, 2, elem(ie)%state%dp3d(:,:,:,tl%np1), elem(ie)%derived%divdp)
+          call remap1(wr, np, 2, elem(ie)%state%dp3d(:,:,:,tl%np1), elem(ie)%derived%divdp,vert_remap_q_alg)
           elem(ie)%derived%vn0(:,:,1,:) = wr(:,:,:,1)/elem(ie)%derived%divdp
           elem(ie)%derived%vn0(:,:,2,:) = wr(:,:,:,2)/elem(ie)%derived%divdp
        end do
@@ -986,7 +986,7 @@ contains
     ! vertical remap time step for dynamics is shorter than the tracer
     ! time step.
 
-    use control_mod, only: dt_tracer_factor
+    use control_mod, only: dt_tracer_factor, vert_remap_q_alg
     use vertremap_base, only: remap1
     use parallel_mod, only: abortmp
     use kinds, only: iulog
@@ -1020,7 +1020,7 @@ contains
        end if
 #endif
        call remap1(elem(ie)%state%Qdp(:,:,:,:,np1_qdp), np, qsize, elem(ie)%derived%divdp, &
-            elem(ie)%state%dp3d(:,:,:,tl%np1))
+            elem(ie)%state%dp3d(:,:,:,tl%np1),vert_remap_q_alg)
        do q = 1,qsize
           elem(ie)%state%Q(:,:,:,q) = elem(ie)%state%Qdp(:,:,:,q,np1_qdp)/ &
                                       elem(ie)%state%dp3d(:,:,:,tl%np1)

--- a/components/homme/src/theta-l/share/vertremap_mod.F90
+++ b/components/homme/src/theta-l/share/vertremap_mod.F90
@@ -123,7 +123,7 @@ contains
         !ttmp(:,:,:,5)=ttmp(:,:,:,5) !*dp_star
     
         call t_startf('vertical_remap1_1')
-        call remap1(ttmp,np,5,dp_star,dp)
+        call remap1(ttmp,np,5,dp_star,dp,vert_remap_q_alg)
         call t_stopf('vertical_remap1_1')
 
         elem(ie)%state%v(:,:,1,:,np1)=ttmp(:,:,:,1)/dp
@@ -154,7 +154,7 @@ contains
      if (qsize>0 .and. np1_qdp > 0) then
 
        call t_startf('vertical_remap1_3')
-       call remap1(elem(ie)%state%Qdp(:,:,:,:,np1_qdp),np,qsize,dp_star,dp)
+       call remap1(elem(ie)%state%Qdp(:,:,:,:,np1_qdp),np,qsize,dp_star,dp,vert_remap_q_alg)
        call t_stopf('vertical_remap1_3')
 
        !dir$ simd


### PR DESCRIPTION
reorg vertical remap code and add new options

vert_remap_q_alg=0          unchanged
vert_remap_q_alg=1           unchanged
vert_remap_q_alg=2          change default region of 1st order to 1 layer from 2 layers
vert_remap_q_alg=3          removed (it was identical to 1)
vert_remap_q_alg=10        unchanged
vert_remap_q_alg=11         new: q_alg=10 with out limiters, for research

[BFB]