### PR TITLE
Update ELM and MOSART variables and global metadata

### DIFF
--- a/components/elm/src/biogeochem/CH4Mod.F90
+++ b/components/elm/src/biogeochem/CH4Mod.F90
@@ -353,12 +353,12 @@ contains
     end if
 
     this%finundated_col(begc:endc) = spval
-    call hist_addfld1d (fname='FINUNDATED', units='unitless', &
+    call hist_addfld1d (fname='FINUNDATED', units='1', &
          avgflag='A', long_name='fractional inundated area of vegetated columns', &
          ptr_col=this%finundated_col)
 
     this%finundated_lag_col(begc:endc) = spval
-    call hist_addfld1d (fname='FINUNDATED_LAG', units='unitless',  &
+    call hist_addfld1d (fname='FINUNDATED_LAG', units='1',  &
          avgflag='A', long_name='time-lagged inundated fraction of vegetated columns', &
          ptr_col=this%finundated_lag_col)
 
@@ -523,28 +523,28 @@ contains
 
     if (hist_wrtch4diag) then
        this%o2stress_sat_col(begc:endc,1:nlevgrnd) = spval
-       call hist_addfld2d (fname='O2STRESS_SAT', units='unitless', type2d='levgrnd',  &
+       call hist_addfld2d (fname='O2STRESS_SAT', units='1', type2d='levgrnd',  &
             avgflag='A', long_name='Ratio of oxygen available to demanded for non-inundated area', &
             ptr_col=this%o2stress_sat_col)
     end if
 
     if (hist_wrtch4diag) then
        this%o2stress_unsat_col(begc:endc,1:nlevgrnd) = spval
-       call hist_addfld2d (fname='O2STRESS_UNSAT', units='unitless', type2d='levgrnd',  &
+       call hist_addfld2d (fname='O2STRESS_UNSAT', units='1', type2d='levgrnd',  &
             avgflag='A', long_name='Ratio of oxygen available to demanded for inundated / lake area', &
             ptr_col=this%o2stress_unsat_col)
     end if
 
     if (hist_wrtch4diag) then
        this%ch4stress_unsat_col(begc:endc,1:nlevgrnd) = spval
-       call hist_addfld2d (fname='CH4STRESS_UNSAT', units='unitless', type2d='levgrnd',  &
+       call hist_addfld2d (fname='CH4STRESS_UNSAT', units='1', type2d='levgrnd',  &
             avgflag='A', long_name='Ratio of methane available to total potential sink for inundated / lake area', &
             ptr_col=this%ch4stress_unsat_col)
     end if
 
     if (hist_wrtch4diag) then
        this%ch4stress_sat_col(begc:endc,1:nlevgrnd) = spval
-       call hist_addfld2d (fname='CH4STRESS_SAT', units='unitless', type2d='levgrnd',  &
+       call hist_addfld2d (fname='CH4STRESS_SAT', units='1', type2d='levgrnd',  &
             avgflag='A', long_name='Ratio of methane available to total potential sink for non-inundated area', &
             ptr_col=this%ch4stress_sat_col)
     end if
@@ -593,21 +593,21 @@ contains
 
     if (hist_wrtch4diag) then
        this%layer_sat_lag_col(begc:endc,1:nlevgrnd) = spval
-       call hist_addfld2d (fname='LAYER_SAT_LAG', units='unitless', type2d='levgrnd',  &
+       call hist_addfld2d (fname='LAYER_SAT_LAG', units='1', type2d='levgrnd',  &
             avgflag='A', long_name='lagged saturation status of layer in unsat. zone', &
             ptr_col=this%layer_sat_lag_col)
     end if
 
     if (hist_wrtch4diag) then
        this%annavg_finrw_col(begc:endc) = spval
-       call hist_addfld1d (fname='ANNAVG_FINRW', units='unitless',  &
+       call hist_addfld1d (fname='ANNAVG_FINRW', units='1',  &
             avgflag='A', long_name='annual average respiration-weighted FINUNDATED', &
             ptr_col=this%annavg_finrw_col)
     end if
 
     if (hist_wrtch4diag) then
        this%sif_col(begc:endc) = spval
-       call hist_addfld1d (fname='SIF', units='unitless',  &
+       call hist_addfld1d (fname='SIF', units='1',  &
             avgflag='A', long_name='seasonal inundation factor calculated for sat. CH4 prod. (non-lake)', &
             ptr_col=this%sif_col)
     end if

--- a/components/elm/src/biogeochem/CropType.F90
+++ b/components/elm/src/biogeochem/CropType.F90
@@ -191,17 +191,17 @@ contains
          ptr_patch=this%dmyield_patch)
 
     this%cvt_patch(begp:endp) = spval
-    call hist_addfld1d (fname='CVT', units='none', &
+    call hist_addfld1d (fname='CVT', units='1', &
          avgflag='X', long_name='Temperature Coefficient of Variance', &
          ptr_patch=this%cvt_patch, default = 'inactive')
 
     this%cvp_patch(begp:endp) = spval
-    call hist_addfld1d (fname='CVP', units='none', &
+    call hist_addfld1d (fname='CVP', units='1', &
          avgflag='X', long_name='Precipitation Coefficient of Variance', &
          ptr_patch=this%cvp_patch, default = 'inactive')
 
     this%plantmonth_patch(begp:endp) = spval
-    call hist_addfld1d (fname='PLANTMONTH', units='none', &
+    call hist_addfld1d (fname='PLANTMONTH', units='1', &
          avgflag='X', long_name='Month of planting', &
          ptr_patch=this%plantmonth_patch)
 
@@ -482,17 +482,17 @@ contains
        end if
        call restartvar(ncid=ncid, flag=flag, varname='cvt', xtype=ncd_double,  &
             dim1name='pft', &
-            long_name='temperature coefficient of variance', units='unitless', &
+            long_name='temperature coefficient of variance', units='1', &
             interpinic_flag='interp', readvar=readvar, data=this%cvt_patch)
 
        call restartvar(ncid=ncid, flag=flag, varname='cvp', xtype=ncd_double,  &
             dim1name='pft', &
-            long_name='precipitation coefficient of variance', units='unitless', &
+            long_name='precipitation coefficient of variance', units='1', &
             interpinic_flag='interp', readvar=readvar, data=this%cvp_patch)
 
        call restartvar(ncid=ncid, flag=flag, varname='plantmonth', xtype=ncd_double,  &
             dim1name='pft', &
-            long_name='Month of planting', units='unitless', &
+            long_name='Month of planting', units='1', &
             interpinic_flag='interp', readvar=readvar, data=this%plantmonth_patch)
 
        ptr2d => this%xt_patch(:,:)
@@ -540,13 +540,13 @@ contains
        ptr2d => this%p2ETo_bar_patch(:,:)
        call restartvar(ncid=ncid, flag=flag, varname='p2ETo_bar', xtype=ncd_double, &
             dim1name='pft',dim2name='month', switchdim=.true., &
-            long_name='ewma P:PET', units='none', &
+            long_name='ewma P:PET', units='1', &
             interpinic_flag='interp', readvar=readvar, data=ptr2d)
 
        ptr2d => this%prev_p2ETo_bar_patch(:,:)
        call restartvar(ncid=ncid, flag=flag, varname='prev_p2ETo_bar', xtype=ncd_double, &
             dim1name='pft',dim2name='month', switchdim=.true., &
-            long_name='previous ewma P:PET', units='none', &
+            long_name='previous ewma P:PET', units='1', &
             interpinic_flag='interp', readvar=readvar, data=ptr2d)
 
        ptr2d => this%P2E_rm_patch(:,:)

--- a/components/elm/src/biogeophys/CanopyStateType.F90
+++ b/components/elm/src/biogeophys/CanopyStateType.F90
@@ -174,12 +174,12 @@ contains
          ptr_patch=this%esai_patch)
 
     this%tlai_patch(begp:endp) = spval
-    call hist_addfld1d (fname='TLAI', units='none', &
+    call hist_addfld1d (fname='TLAI', units='1', &
          avgflag='A', long_name='total projected leaf area index', &
          ptr_patch=this%tlai_patch)
 
     this%tsai_patch(begp:endp) = spval
-    call hist_addfld1d (fname='TSAI', units='none', &
+    call hist_addfld1d (fname='TSAI', units='1', &
          avgflag='A', long_name='total projected stem area index', &
          ptr_patch=this%tsai_patch)
 
@@ -191,12 +191,12 @@ contains
     end if
 
     this%laisun_patch(begp:endp) = spval
-    call hist_addfld1d (fname='LAISUN', units='none', &
+    call hist_addfld1d (fname='LAISUN', units='1', &
          avgflag='A', long_name='sunlit projected leaf area index', &
          ptr_patch=this%laisun_patch, set_urb=0._r8)
 
     this%laisha_patch(begp:endp) = spval
-    call hist_addfld1d (fname='LAISHA', units='none', &
+    call hist_addfld1d (fname='LAISHA', units='1', &
          avgflag='A', long_name='shaded projected leaf area index', &
          ptr_patch=this%laisha_patch, set_urb=0._r8)
 

--- a/components/elm/src/biogeophys/EnergyFluxType.F90
+++ b/components/elm/src/biogeophys/EnergyFluxType.F90
@@ -297,7 +297,7 @@ contains
     begg = bounds%begg; endg= bounds%endg
 
     this%btran_patch(begp:endp) = spval
-    call hist_addfld1d (fname='BTRAN', units='unitless',  &
+    call hist_addfld1d (fname='BTRAN', units='1',  &
          avgflag='A', long_name='transpiration beta factor', &
          ptr_patch=this%btran_patch, set_lake=spval, set_urb=spval)
 

--- a/components/elm/src/biogeophys/SoilStateType.F90
+++ b/components/elm/src/biogeophys/SoilStateType.F90
@@ -223,7 +223,7 @@ contains
 
     if (use_cn) then
        this%bsw_col(begc:endc,:) = spval 
-       call hist_addfld2d (fname='bsw', units='unitless', type2d='levgrnd', &
+       call hist_addfld2d (fname='bsw', units='1', type2d='levgrnd', &
             avgflag='A', long_name='clap and hornberger B', &
             ptr_col=this%bsw_col, default='inactive')
     end if
@@ -276,12 +276,12 @@ contains
          ptr_col=this%hk_l_col, set_spec=spval, l2g_scale_type='veg', default='inactive')
 
     this%soilalpha_col(begc:endc) = spval
-    call hist_addfld1d (fname='SoilAlpha',  units='unitless',  &
+    call hist_addfld1d (fname='SoilAlpha',  units='1',  &
          avgflag='A', long_name='factor limiting ground evap', &
          ptr_col=this%soilalpha_col, set_urb=spval)
 
     this%soilalpha_u_col(begc:endc) = spval
-    call hist_addfld1d (fname='SoilAlpha_U',  units='unitless',  &
+    call hist_addfld1d (fname='SoilAlpha_U',  units='1',  &
          avgflag='A', long_name='urban factor limiting ground evap', &
          ptr_col=this%soilalpha_u_col, set_nourb=spval)
 

--- a/components/elm/src/biogeophys/SurfaceAlbedoType.F90
+++ b/components/elm/src/biogeophys/SurfaceAlbedoType.F90
@@ -175,7 +175,7 @@ contains
     begc = bounds%begc; endc = bounds%endc
 
     this%coszen_col(begc:endc) = spval
-    call hist_addfld1d (fname='COSZEN', units='none', &
+    call hist_addfld1d (fname='COSZEN', units='1', &
          avgflag='A', long_name='cosine of solar zenith angle', &
          ptr_col=this%coszen_col, default='inactive')
 
@@ -286,7 +286,7 @@ contains
 
     call restartvar(ncid=ncid, flag=flag, varname='coszen', xtype=ncd_double,  & 
          dim1name='column', &
-         long_name='cosine of solar zenith angle', units='unitless', &
+         long_name='cosine of solar zenith angle', units='1', &
          interpinic_flag='interp', readvar=readvar, data=this%coszen_col)
 
     call restartvar(ncid=ncid, flag=flag, varname='albd', xtype=ncd_double,  & 

--- a/components/elm/src/biogeophys/WaterStateType.F90
+++ b/components/elm/src/biogeophys/WaterStateType.F90
@@ -335,7 +335,7 @@ contains
     ! snow layer existed by running the snow averaging routine on a field whose value is 1
     ! everywhere
     data2dptr => this%snow_layer_unity_col(:,-nlevsno+1:0)
-    call hist_addfld2d (fname='SNO_EXISTENCE', units='unitless', type2d='levsno', &
+    call hist_addfld2d (fname='SNO_EXISTENCE', units='1', type2d='levsno', &
          avgflag='A', long_name='Fraction of averaging period for which each snow layer existed', &
          ptr_col=data2dptr, no_snow_behavior=no_snow_zero, default='inactive')
 

--- a/components/elm/src/data_types/CNStateType.F90
+++ b/components/elm/src/data_types/CNStateType.F90
@@ -520,7 +520,7 @@ contains
          ptr_patch=this%tempavg_t2m_patch, default='inactive')
 
     this%dormant_flag_patch(begp:endp) = spval
-    call hist_addfld1d (fname='DORMANT_FLAG', units='none', &
+    call hist_addfld1d (fname='DORMANT_FLAG', units='1', &
          avgflag='A', long_name='dormancy flag', &
          ptr_patch=this%dormant_flag_patch, default='inactive')
 
@@ -530,7 +530,7 @@ contains
          ptr_patch=this%days_active_patch, default='inactive')
 
     this%onset_flag_patch(begp:endp) = spval
-    call hist_addfld1d (fname='ONSET_FLAG', units='none', &
+    call hist_addfld1d (fname='ONSET_FLAG', units='1', &
          avgflag='A', long_name='onset flag', &
          ptr_patch=this%onset_flag_patch, default='inactive')
 
@@ -540,7 +540,7 @@ contains
          ptr_patch=this%onset_counter_patch, default='inactive')
 
     this%onset_gddflag_patch(begp:endp) = spval
-    call hist_addfld1d (fname='ONSET_GDDFLAG', units='none', &
+    call hist_addfld1d (fname='ONSET_GDDFLAG', units='1', &
          avgflag='A', long_name='onset flag for growing degree day sum', &
          ptr_patch=this%onset_gddflag_patch, default='inactive')
 
@@ -555,12 +555,12 @@ contains
          ptr_patch=this%onset_gdd_patch, default='inactive')
 
     this%onset_swi_patch(begp:endp) = spval
-    call hist_addfld1d (fname='ONSET_SWI', units='none', &
+    call hist_addfld1d (fname='ONSET_SWI', units='1', &
          avgflag='A', long_name='onset soil water index', &
          ptr_patch=this%onset_swi_patch, default='inactive')
 
     this%offset_flag_patch(begp:endp) = spval
-    call hist_addfld1d (fname='OFFSET_FLAG', units='none', &
+    call hist_addfld1d (fname='OFFSET_FLAG', units='1', &
          avgflag='A', long_name='offset flag', &
          ptr_patch=this%offset_flag_patch, default='inactive')
 
@@ -575,7 +575,7 @@ contains
          ptr_patch=this%offset_fdd_patch, default='inactive')
 
     this%offset_swi_patch(begp:endp) = spval
-    call hist_addfld1d (fname='OFFSET_SWI', units='none', &
+    call hist_addfld1d (fname='OFFSET_SWI', units='1', &
          avgflag='A', long_name='offset soil water index', &
          ptr_patch=this%offset_swi_patch, default='inactive')
 
@@ -605,12 +605,12 @@ contains
          ptr_patch=this%alloc_pnow_patch, default='inactive')
 
     this%c_allometry_patch(begp:endp) = spval
-    call hist_addfld1d (fname='C_ALLOMETRY', units='none', &
+    call hist_addfld1d (fname='C_ALLOMETRY', units='1', &
          avgflag='A', long_name='C allocation index', &
          ptr_patch=this%c_allometry_patch, default='inactive')
 
     this%n_allometry_patch(begp:endp) = spval
-    call hist_addfld1d (fname='N_ALLOMETRY', units='none', &
+    call hist_addfld1d (fname='N_ALLOMETRY', units='1', &
          avgflag='A', long_name='N allocation index', &
          ptr_patch=this%n_allometry_patch, default='inactive')
 
@@ -642,7 +642,7 @@ contains
 
     !! add phosphorus -X.YANG
     this%p_allometry_patch(begp:endp) = spval
-    call hist_addfld1d (fname='P_ALLOMETRY', units='none', &
+    call hist_addfld1d (fname='P_ALLOMETRY', units='1', &
          avgflag='A', long_name='P allocation index', &
          ptr_patch=this%p_allometry_patch, default='inactive')
 
@@ -677,7 +677,7 @@ contains
        ptr_patch=this%cp_scalar_runmean, default='active')
 
     this%r_mort_cal_patch(begp:endp) = spval
-    call hist_addfld1d (fname='R_MORT_CAL', units='none', &
+    call hist_addfld1d (fname='R_MORT_CAL', units='1', &
          avgflag='A', long_name='calcualted annual mortality rate', &
          ptr_patch=this%r_mort_cal_patch, default='inactive')
 
@@ -1137,7 +1137,7 @@ contains
   
     call restartvar(ncid=ncid, flag=flag, varname='dormant_flag', xtype=ncd_double,  &
          dim1name='pft', &
-         long_name='dormancy flag', units='unitless', &
+         long_name='dormancy flag', units='1', &
          interpinic_flag='interp', readvar=readvar, data=this%dormant_flag_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='days_active', xtype=ncd_double,  &
@@ -1147,7 +1147,7 @@ contains
 
     call restartvar(ncid=ncid, flag=flag, varname='onset_flag', xtype=ncd_double,  &
          dim1name='pft', &
-         long_name='flag if critical growing degree-day sum is exceeded', units='unitless' , &
+         long_name='flag if critical growing degree-day sum is exceeded', units='1' , &
          interpinic_flag='interp', readvar=readvar, data=this%onset_flag_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='onset_counter', xtype=ncd_double,  &
@@ -1177,7 +1177,7 @@ contains
 
     call restartvar(ncid=ncid, flag=flag, varname='offset_flag', xtype=ncd_double,  &
          dim1name='pft', &
-         long_name='offset flag', units='unitless' , &
+         long_name='offset flag', units='1' , &
          interpinic_flag='interp', readvar=readvar, data=this%offset_flag_patch) 
 
     call restartvar(ncid=ncid, flag=flag, varname='offset_counter', xtype=ncd_double,  &
@@ -1290,23 +1290,23 @@ contains
        ptr2d => this%fpi_vr_col
        call restartvar(ncid=ncid, flag=flag, varname='fpi_vr', xtype=ncd_double,  &
             dim1name='column',dim2name='levgrnd', switchdim=.true., &
-            long_name='fraction of potential immobilization of nitrogen',  units='unitless', &
+            long_name='fraction of potential immobilization of nitrogen',  units='1', &
             interpinic_flag='interp', readvar=readvar, data=ptr2d)
        ptr2d => this%fpi_p_vr_col
        call restartvar(ncid=ncid, flag=flag, varname='fpi_p_vr', xtype=ncd_double,  &
             dim1name='column',dim2name='levgrnd', switchdim=.true., &
-            long_name='fraction of potential immobilization of phosphorus',  units='unitless', &
+            long_name='fraction of potential immobilization of phosphorus',  units='1', &
             interpinic_flag='interp', readvar=readvar, data=ptr2d)
     else
        ptr1d => this%fpi_vr_col(:,1) ! nlevdecomp = 1; so treat as 1D variable
        call restartvar(ncid=ncid, flag=flag, varname='fpi', xtype=ncd_double,  &
             dim1name='column', &
-            long_name='fraction of potential immobilization of nitrogen',  units='unitless', &
+            long_name='fraction of potential immobilization of nitrogen',  units='1', &
             interpinic_flag='interp' , readvar=readvar, data=ptr1d)
        ptr1d => this%fpi_p_vr_col(:,1) ! nlevdecomp = 1; so treat as 1D variable
        call restartvar(ncid=ncid, flag=flag, varname='fpi_p', xtype=ncd_double,  &
             dim1name='column', &
-            long_name='fraction of potential immobilization of phosphorus',  units='unitless', &
+            long_name='fraction of potential immobilization of phosphorus',  units='1', &
             interpinic_flag='interp' , readvar=readvar, data=ptr1d)
     end if
 
@@ -1359,7 +1359,7 @@ contains
     ptr2d => this%scalaravg_col
     call restartvar(ncid=ncid, flag=flag, varname='scalaravg_col', xtype=ncd_double,  &
             dim1name='column',dim2name='levgrnd', switchdim=.true., &
-            long_name='fraction of potential immobilization of phosphorus', units='unitless', &
+            long_name='fraction of potential immobilization of phosphorus', units='1', &
             interpinic_flag='interp', readvar=readvar, data=ptr2d)
 
     if (crop_prog) then

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1441,12 +1441,12 @@ contains
     end if
 
     this%frac_sno(begc:endc) = spval
-    call hist_addfld1d (fname='FSNO',  units='unitless',  &
+    call hist_addfld1d (fname='FSNO',  units='1',  &
          avgflag='A', long_name='fraction of ground covered by snow', &
          ptr_col=this%frac_sno, c2l_scale_type='urbanf')
 
     this%frac_sno_eff(begc:endc) = spval
-    call hist_addfld1d (fname='FSNO_EFF',  units='unitless',  &
+    call hist_addfld1d (fname='FSNO_EFF',  units='1',  &
          avgflag='A', long_name='effective fraction of ground covered by snow', &
          ptr_col=this%frac_sno_eff, c2l_scale_type='urbanf')!, default='inactive')
 
@@ -1458,7 +1458,7 @@ contains
     end if
 
     this%frac_h2osfc(begc:endc) = spval
-    call hist_addfld1d (fname='FH2OSFC',  units='unitless',  &
+    call hist_addfld1d (fname='FH2OSFC',  units='1',  &
          avgflag='A', long_name='fraction of ground covered by surface water', &
          ptr_col=this%frac_h2osfc)
 
@@ -1755,12 +1755,12 @@ contains
 
     call restartvar(ncid=ncid, flag=flag, varname='frac_sno', xtype=ncd_double,  & 
          dim1name='column', &
-         long_name='fraction of ground covered by snow (0 to 1)',units='unitless',&
+         long_name='fraction of ground covered by snow (0 to 1)',units='1',&
          interpinic_flag='interp', readvar=readvar, data=this%frac_sno)
 
     call restartvar(ncid=ncid, flag=flag, varname='frac_sno_eff', xtype=ncd_double,  & 
          dim1name='column', &
-         long_name='fraction of ground covered by snow (0 to 1)',units='unitless', &
+         long_name='fraction of ground covered by snow (0 to 1)',units='1', &
          interpinic_flag='interp', readvar=readvar, data=this%frac_sno_eff)
     if (flag == 'read' .and. .not. readvar) then
        this%frac_sno_eff(bounds%begc:bounds%endc) = 0.0_r8
@@ -5673,7 +5673,7 @@ contains
     else if (carbon_type == 'c12') then
        if (hist_wrtch4diag) then
           this%fphr(begc:endc,1:nlevgrnd) = spval
-          call hist_addfld_decomp (fname='FPHR'//trim(vr_suffix), units='unitless', type2d='levdcmp', &
+          call hist_addfld_decomp (fname='FPHR'//trim(vr_suffix), units='1', type2d='levdcmp', &
                avgflag='A', long_name='fraction of potential HR due to N limitation', &
                ptr_col=this%fphr)
        end if
@@ -5895,17 +5895,17 @@ contains
        ! still in C12 block
 
        this%t_scalar(begc:endc,:) = spval
-       call hist_addfld_decomp (fname='T_SCALAR', units='unitless',  type2d='levdcmp', &
+       call hist_addfld_decomp (fname='T_SCALAR', units='1',  type2d='levdcmp', &
             avgflag='A', long_name='temperature inhibition of decomposition', &
             ptr_col=this%t_scalar)
 
        this%w_scalar(begc:endc,:) = spval
-       call hist_addfld_decomp (fname='W_SCALAR', units='unitless',  type2d='levdcmp', &
+       call hist_addfld_decomp (fname='W_SCALAR', units='1',  type2d='levdcmp', &
             avgflag='A', long_name='Moisture (dryness) inhibition of decomposition', &
             ptr_col=this%w_scalar)
 
        this%o_scalar(begc:endc,:) = spval
-       call hist_addfld_decomp (fname='O_SCALAR', units='unitless', type2d='levdcmp', &
+       call hist_addfld_decomp (fname='O_SCALAR', units='1', type2d='levdcmp', &
             avgflag='A', long_name='fraction by which decomposition is reduced due to anoxia', &
             ptr_col=this%o_scalar)
 
@@ -8251,21 +8251,21 @@ contains
 
     if (use_nitrif_denitrif) then
        this%k_nitr_t_vr(begc:endc,:) = spval
-       call hist_addfld_decomp (fname='K_NITR_T', units='unitless', type2d='levdcmp', &
+       call hist_addfld_decomp (fname='K_NITR_T', units='1', type2d='levdcmp', &
             avgflag='A', long_name='K_NITR_T', &
             ptr_col=this%k_nitr_t_vr, default='inactive')
     end if
 
     if (use_nitrif_denitrif) then
        this%k_nitr_ph_vr(begc:endc,:) = spval
-       call hist_addfld_decomp (fname='K_NITR_PH', units='unitless', type2d='levdcmp', &
+       call hist_addfld_decomp (fname='K_NITR_PH', units='1', type2d='levdcmp', &
             avgflag='A', long_name='K_NITR_PH', &
             ptr_col=this%k_nitr_ph_vr, default='inactive')
     end if
 
     if (use_nitrif_denitrif) then
        this%k_nitr_h2o_vr(begc:endc,:) = spval
-       call hist_addfld_decomp (fname='K_NITR_H2O', units='unitless', type2d='levdcmp', &
+       call hist_addfld_decomp (fname='K_NITR_H2O', units='1', type2d='levdcmp', &
             avgflag='A', long_name='K_NITR_H2O', &
             ptr_col=this%k_nitr_h2o_vr, default='inactive')
     end if
@@ -8314,7 +8314,7 @@ contains
 
     if (use_nitrif_denitrif) then
        this%ratio_k1(begc:endc,:) = spval
-       call hist_addfld_decomp (fname='ratio_k1', units='none', type2d='levdcmp', &
+       call hist_addfld_decomp (fname='ratio_k1', units='1', type2d='levdcmp', &
             avgflag='A', long_name='ratio_k1', &
             ptr_col=this%ratio_k1, default='inactive')
     end if

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1043,7 +1043,7 @@ contains
     this%t_soisno(begc:endc,:) = spval
     call hist_addfld2d (fname='TSOI',  units='K', type2d='levgrnd', &
          avgflag='A', long_name='soil temperature (vegetated landunits only)', &
-         ptr_col=this%t_soisno, l2g_scale_type='veg')
+         standard_name='soil_temperature',ptr_col=this%t_soisno, l2g_scale_type='veg')
 
     this%t_soisno(begc:endc,:) = spval
     call hist_addfld2d (fname='TSOI_ICE',  units='K', type2d='levgrnd', &
@@ -1396,7 +1396,8 @@ contains
     this%h2osoi_liqice_10cm(begc:endc) = spval
     call hist_addfld1d (fname='SOILWATER_10CM',  units='kg/m2', &
          avgflag='A', long_name='soil liquid water + ice in top 10cm of soil (veg landunits only)', &
-         ptr_col=this%h2osoi_liqice_10cm, set_urb=spval, set_lake=spval, l2g_scale_type='veg')
+         standard_name='mass_content_of_water_in_soil_layer',ptr_col=this%h2osoi_liqice_10cm,  &
+         set_urb=spval, set_lake=spval, l2g_scale_type='veg')
 
     call hist_addfld1d (fname='H2OSNO',  units='mm',  &
          avgflag='A', long_name='snow depth (liquid water)', &

--- a/components/elm/src/main/elm_varcon.F90
+++ b/components/elm/src/main/elm_varcon.F90
@@ -77,7 +77,7 @@ module elm_varcon
   real(r8), public, parameter :: degpsec = 15._r8/3600.0_r8 ! Degree's earth rotates per second
   real(r8), public, parameter ::  secspday= SHR_CONST_CDAY  ! Seconds per day
   integer,  public, parameter :: isecspday= secspday        ! Integer seconds per day
-  real(r8), public, parameter ::  spval = 1.e36_r8          ! special value for real data
+  real(r8), public, parameter ::  spval = 1.e20_r8          ! special value for real data
   integer , public, parameter :: ispval = -9999             ! special value for int data 
                                                             ! (keep this negative to avoid conflicts with possible valid values)
 

--- a/components/elm/src/main/elm_varcon.F90
+++ b/components/elm/src/main/elm_varcon.F90
@@ -77,7 +77,7 @@ module elm_varcon
   real(r8), public, parameter :: degpsec = 15._r8/3600.0_r8 ! Degree's earth rotates per second
   real(r8), public, parameter ::  secspday= SHR_CONST_CDAY  ! Seconds per day
   integer,  public, parameter :: isecspday= secspday        ! Integer seconds per day
-  real(r8), public, parameter ::  spval = 1.e20_r8          ! special value for real data
+  real(r8), public, parameter ::  spval = 1.e36_r8          ! special value for real data
   integer , public, parameter :: ispval = -9999             ! special value for int data 
                                                             ! (keep this negative to avoid conflicts with possible valid values)
 

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -69,7 +69,7 @@ module elm_varctl
   character(len=256), public :: version  = " "                           
 
   ! dataset conventions
-  character(len=256), public :: conventions = "CF-1.0"                   
+  character(len=256), public :: conventions = "CF-1.7"
 
   !----------------------------------------------------------
   ! Unit Numbers

--- a/components/elm/src/main/glc2lndMod.F90
+++ b/components/elm/src/main/glc2lndMod.F90
@@ -142,7 +142,7 @@ contains
     
     if (maxpatch_glcmec > 0) then
        this%icemask_grc(begg:endg) = spval
-       call hist_addfld1d (fname='ICE_MASK',  units='unitless',  &
+       call hist_addfld1d (fname='ICE_MASK',  units='1',  &
             avgflag='I', long_name='Ice sheet mask coverage', &
             ptr_gcell=this%icemask_grc)
     end if

--- a/components/elm/src/main/glcDiagnosticsMod.F90
+++ b/components/elm/src/main/glcDiagnosticsMod.F90
@@ -100,7 +100,7 @@ contains
     if (create_glacier_mec_landunit) then
 
        this%gris_mask_grc(begg:endg) = spval
-       call hist_addfld1d (fname='gris_mask',  units='unitless',  &
+       call hist_addfld1d (fname='gris_mask',  units='1',  &
             avgflag='A', long_name='Greenland mask', &
             ptr_gcell= this%gris_mask_grc)
 
@@ -110,7 +110,7 @@ contains
             ptr_gcell= this%gris_area_grc)
 
        this%aais_mask_grc(begg:endg) = spval
-       call hist_addfld1d (fname='aais_mask',  units='unitless',  &
+       call hist_addfld1d (fname='aais_mask',  units='1',  &
             avgflag='A', long_name='Antarctic mask', &
             ptr_gcell= this%aais_mask_grc)
 

--- a/components/elm/src/main/histFileMod.F90
+++ b/components/elm/src/main/histFileMod.F90
@@ -2117,9 +2117,9 @@ contains
           else if (ifld == 4) then
              long_name='saturated soil matric potential'; units = 'mm'
           else if (ifld == 5) then
-             long_name='slope of soil water retention curve'; units = 'unitless'
+             long_name='slope of soil water retention curve'; units = '1'
           else if (ifld == 6) then
-             long_name='saturated hydraulic conductivity'; units = 'unitless'
+             long_name='saturated hydraulic conductivity'; units = '1'
           else
              call endrun(msg=' ERROR: bad 3D time-constant field index'//errMsg(__FILE__, __LINE__))
           end if
@@ -2791,7 +2791,7 @@ contains
           case ('A')
              avgstr = 'mean'
           case ('I')
-             avgstr = 'instantaneous'
+             avgstr = 'point'
           case ('X')
              avgstr = 'maximum'
           case ('M')
@@ -3626,7 +3626,7 @@ contains
                units="absolute value of negative is in hours, 0=monthly, positive is time-steps",     &
                dim1name='scalar')
           call ncd_defvar(ncid=ncid_hist(t), varname='mfilt', xtype=ncd_int, &
-               long_name="Number of history time samples on a file", units="unitless",     &
+               long_name="Number of history time samples on a file", units="1",     &
                comment="Namelist item", &
                dim1name='scalar')
           call ncd_defvar(ncid=ncid_hist(t), varname='ncprec', xtype=ncd_int, &
@@ -3649,7 +3649,7 @@ contains
                dim1name='fname_lenp2', dim2name='max_flds' )
 
           call ncd_defvar(ncid=ncid_hist(t), varname='nflds', xtype=ncd_int, &
-               long_name="Number of fields on file", units="unitless",        &
+               long_name="Number of fields on file", units="1",        &
                dim1name='scalar')
           call ncd_defvar(ncid=ncid_hist(t), varname='ntimes', xtype=ncd_int, &
                long_name="Number of time steps on file", units="time-step",     &
@@ -3661,10 +3661,10 @@ contains
                dim1name='scalar')
    
           call ncd_defvar(ncid=ncid_hist(t), varname='num2d', xtype=ncd_int, &
-               long_name="Size of second dimension", units="unitless",     &
+               long_name="Size of second dimension", units="1",     &
                dim1name='max_nflds' )
           call ncd_defvar(ncid=ncid_hist(t), varname='hpindex', xtype=ncd_int, &
-               long_name="History pointer index", units="unitless",     &
+               long_name="History pointer index", units="1",     &
                dim1name='max_nflds' )
 
           call ncd_defvar(ncid=ncid_hist(t), varname='avgflag', xtype=ncd_char, &

--- a/components/elm/src/main/histFileMod.F90
+++ b/components/elm/src/main/histFileMod.F90
@@ -2728,6 +2728,7 @@ contains
     integer :: numdims                   ! number of dimensions
     character(len=1)         :: avgflag  ! time averaging flag
     character(len=max_chars) :: long_name! long name
+    character(len=max_chars) :: standard_name! standard name
     character(len=max_chars) :: units    ! units
     character(len=max_namlen):: varname  ! variable name
     character(len=32) :: avgstr          ! time averaging type
@@ -2758,6 +2759,7 @@ contains
 
        varname    = tape(t)%hlist(f)%field%name
        long_name  = tape(t)%hlist(f)%field%long_name
+       standard_name  = tape(t)%hlist(f)%field%standard_name
        units      = tape(t)%hlist(f)%field%units
        avgflag    = tape(t)%hlist(f)%avgflag
        type1d_out = tape(t)%hlist(f)%field%type1d_out
@@ -2799,25 +2801,25 @@ contains
              if (numdims == 1) then
                 call ncd_defvar(ncid=nfid(t), varname=varname, xtype=tape(t)%ncprec, &
                      dim1name=dim1name, dim2name='time', &
-                     long_name=long_name, units=units, cell_method=avgstr, &
-                     missing_value=spval, fill_value=spval)
+                     long_name=long_name, standard_name=standard_name,units=units,&
+                     cell_method=avgstr,  missing_value=spval, fill_value=spval)
              else
                 call ncd_defvar(ncid=nfid(t), varname=varname, xtype=tape(t)%ncprec, &
                      dim1name=dim1name, dim2name=type2d, dim3name='time', &
-                     long_name=long_name, units=units, cell_method=avgstr, &
-                     missing_value=spval, fill_value=spval)
+                     long_name=long_name,standard_name=standard_name, units=units, &
+                     cell_method=avgstr,  missing_value=spval, fill_value=spval)
              end if
           else
              if (numdims == 1) then
                 call ncd_defvar(ncid=nfid(t), varname=varname, xtype=tape(t)%ncprec, &
                      dim1name=dim1name, dim2name=dim2name, dim3name='time', &
-                     long_name=long_name, units=units, cell_method=avgstr, &
-                     missing_value=spval, fill_value=spval)
+                     long_name=long_name, standard_name=standard_name, &
+                     units=units, cell_method=avgstr, missing_value=spval, fill_value=spval)
              else
                 call ncd_defvar(ncid=nfid(t), varname=varname, xtype=tape(t)%ncprec, &
                      dim1name=dim1name, dim2name=dim2name, dim3name=type2d, dim4name='time', &
-                     long_name=long_name, units=units, cell_method=avgstr, &
-                     missing_value=spval, fill_value=spval)
+                     long_name=long_name, standard_name=standard_name, units=units,&
+                     cell_method=avgstr, missing_value=spval, fill_value=spval)
              end if
           endif
 
@@ -3410,6 +3412,7 @@ contains
     character(len=max_namlen) :: name            ! variable name
     character(len=max_namlen) :: name_acc        ! accumulator variable name
     character(len=max_namlen) :: long_name       ! long name of variable
+    character(len=max_namlen) :: standard_name       ! standard_name of var
     character(len=max_chars)  :: long_name_acc   ! long name for accumulator
     character(len=max_chars)  :: units           ! units of variable
     character(len=max_chars)  :: units_acc       ! accumulator units
@@ -3531,6 +3534,7 @@ contains
              do f = 1,tape(t)%nflds
                 name           =  tape(t)%hlist(f)%field%name
                 long_name      =  tape(t)%hlist(f)%field%long_name
+                standard_name      =  tape(t)%hlist(f)%field%standard_name
                 units          =  tape(t)%hlist(f)%field%units
                 name_acc       =  trim(name) // "_acc"
                 units_acc      =  "unitless positive integer"
@@ -3555,14 +3559,16 @@ contains
                    if (num2d == 1) then
                       call ncd_defvar(ncid=ncid_hist(t), varname=trim(name), xtype=ncd_double, & 
                            dim1name=dim1name, &
-                           long_name=trim(long_name), units=trim(units))
+                           long_name=trim(long_name), &
+                           standard_name=standard_name, units=trim(units))
                       call ncd_defvar(ncid=ncid_hist(t), varname=trim(name_acc), xtype=ncd_int,  &
                            dim1name=dim1name, &
                            long_name=trim(long_name_acc), units=trim(units_acc))
                    else
                       call ncd_defvar(ncid=ncid_hist(t), varname=trim(name), xtype=ncd_double, &
                            dim1name=dim1name, dim2name=type2d, &
-                           long_name=trim(long_name), units=trim(units))
+                           long_name=trim(long_name), &
+                           standard_name=standard_name, units=trim(units))
                       call ncd_defvar(ncid=ncid_hist(t), varname=trim(name_acc), xtype=ncd_int,  &
                            dim1name=dim1name, dim2name=type2d, &
                            long_name=trim(long_name_acc), units=trim(units_acc))
@@ -3571,14 +3577,16 @@ contains
                    if (num2d == 1) then
                       call ncd_defvar(ncid=ncid_hist(t), varname=trim(name), xtype=ncd_double, &
                            dim1name=dim1name, dim2name=dim2name, &
-                           long_name=trim(long_name), units=trim(units))
+                           long_name=trim(long_name), &
+                           standard_name=standard_name, units=trim(units))
                       call ncd_defvar(ncid=ncid_hist(t), varname=trim(name_acc), xtype=ncd_int,  &
                            dim1name=dim1name, dim2name=dim2name, &
                            long_name=trim(long_name_acc), units=trim(units_acc))
                    else
                       call ncd_defvar(ncid=ncid_hist(t), varname=trim(name), xtype=ncd_double, &
                            dim1name=dim1name, dim2name=dim2name, dim3name=type2d, &
-                           long_name=trim(long_name), units=trim(units))
+                           long_name=trim(long_name), &
+                           standard_name=standard_name, units=trim(units))
                       call ncd_defvar(ncid=ncid_hist(t), varname=trim(name_acc), xtype=ncd_int,  &
                            dim1name=dim1name, dim2name=dim2name, dim3name=type2d, &
                            long_name=trim(long_name_acc), units=trim(units_acc))

--- a/components/elm/src/main/histFileMod.F90
+++ b/components/elm/src/main/histFileMod.F90
@@ -1820,6 +1820,9 @@ contains
     ! data set as a whole, as opposed to a single variable
 
     call ncd_putatt(lnfid, ncd_global, 'source'  , trim(source))
+    call ncd_putatt(lnfid, ncd_global, 'source_id'  , trim(version))
+    call ncd_putatt(lnfid, ncd_global, 'product'  , 'model-output')
+    call ncd_putatt(lnfid, ncd_global, 'realm'  , 'land')
     call ncd_putatt(lnfid, ncd_global, 'case', trim(caseid))
     call ncd_putatt(lnfid, ncd_global, 'username', trim(username))
     call ncd_putatt(lnfid, ncd_global, 'hostname', trim(hostname))
@@ -1828,6 +1831,17 @@ contains
     str = 'created on ' // curdate // ' ' // curtime
     call ncd_putatt(lnfid, ncd_global, 'history' , trim(str))
     call ncd_putatt(lnfid, ncd_global, 'institution_id', 'E3SM-Project')
+    call ncd_putatt(lnfid, ncd_global, 'institution', &
+    'LLNL (Lawrence Livermore National Laboratory, Livermore, CA 94550, USA); &
+    &ANL (Argonne National Laboratory, Argonne, IL 60439, USA); &
+    &BNL (Brookhaven National Laboratory, Upton, NY 11973, USA); &
+    &LANL (Los Alamos National Laboratory, Los Alamos, NM 87545, USA); &
+    &LBNL (Lawrence Berkeley National Laboratory, Berkeley, CA 94720, USA); &
+    &ORNL (Oak Ridge National Laboratory, Oak Ridge, TN 37831, USA); &
+    &PNNL (Pacific Northwest National Laboratory, Richland, WA 99352, USA); &
+    &SNL (Sandia National Laboratories, Albuquerque, NM 87185, USA). &
+    &Mailing address: LLNL Climate Program, c/o David C. Bader, &
+    &Principal Investigator, L-103, 7000 East Avenue, Livermore, CA 94550, USA')
     call ncd_putatt(lnfid, ncd_global, 'contact', &
           'e3sm-data-support@listserv.llnl.gov')
     call ncd_putatt(lnfid, ncd_global, 'Conventions', trim(conventions))

--- a/components/elm/src/main/ncdio_pio.F90.in
+++ b/components/elm/src/main/ncdio_pio.F90.in
@@ -139,7 +139,7 @@ module ncdio_pio
   integer,parameter,private :: debug = 0             ! local debug level
 
   integer , parameter  , public  :: max_string_len = 256     ! length of strings
-  real(r8), parameter  , public  :: fillvalue = 1.e20_r8     ! fill value for netcdf fields
+  real(r8), parameter  , public  :: fillvalue = 1.e36_r8     ! fill value for netcdf fields
 
   integer, public :: io_type
 

--- a/components/elm/src/main/ncdio_pio.F90.in
+++ b/components/elm/src/main/ncdio_pio.F90.in
@@ -139,7 +139,7 @@ module ncdio_pio
   integer,parameter,private :: debug = 0             ! local debug level
 
   integer , parameter  , public  :: max_string_len = 256     ! length of strings
-  real(r8), parameter  , public  :: fillvalue = 1.e36_r8     ! fill value for netcdf fields
+  real(r8), parameter  , public  :: fillvalue = 1.e20_r8     ! fill value for netcdf fields
 
   integer, public :: io_type
 

--- a/components/elm/src/main/ncdio_pio.F90.in
+++ b/components/elm/src/main/ncdio_pio.F90.in
@@ -915,7 +915,7 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine ncd_defvar_bynf(ncid, varname, xtype, ndims, dimid, varid, &
-       long_name, units, cell_method, missing_value, fill_value, &
+       long_name, standard_name, units, cell_method, missing_value, fill_value, &
        imissing_value, ifill_value, comment, flag_meanings, &
        flag_values, nvalid_range )
     !
@@ -930,6 +930,7 @@ contains
     integer            , intent(inout) :: varid                 ! returned var id
     integer            , intent(in), optional :: dimid(:)       ! dimids
     character(len=*)   , intent(in), optional :: long_name      ! attribute
+    character(len=*)   , intent(in), optional :: standard_name  ! attribute
     character(len=*)   , intent(in), optional :: units          ! attribute
     character(len=*)   , intent(in), optional :: cell_method    ! attribute
     character(len=*)   , intent(in), optional :: comment        ! attribute
@@ -994,6 +995,11 @@ contains
     if (present(long_name)) then
        call ncd_putatt(ncid, varid, 'long_name', trim(long_name))
     end if
+    if (present(standard_name)) then
+       if (standard_name /= ' ') then
+          call ncd_putatt(ncid, varid, 'standard_name', trim(standard_name))
+       end if
+    end if
     if (present(flag_values)) then
        status = PIO_put_att(ncid,varid,'flag_values',flag_values)
        if ( .not. present(flag_meanings)) then
@@ -1056,7 +1062,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine ncd_defvar_bygrid(ncid, varname, xtype, &
        dim1name, dim2name, dim3name, dim4name, dim5name, &
-       long_name, units, cell_method, missing_value, fill_value, &
+       long_name, standard_name, units, cell_method, missing_value, fill_value, &
        imissing_value, ifill_value, switchdim, comment, &
        flag_meanings, flag_values, nvalid_range )
     !
@@ -1073,6 +1079,7 @@ contains
     character(len=*)   , intent(in), optional :: dim4name       ! dimension name
     character(len=*)   , intent(in), optional :: dim5name       ! dimension name
     character(len=*)   , intent(in), optional :: long_name      ! attribute
+    character(len=*)   , intent(in), optional :: standard_name  ! attribute
     character(len=*)   , intent(in), optional :: units          ! attribute
     character(len=*)   , intent(in), optional :: cell_method    ! attribute
     character(len=*)   , intent(in), optional :: comment        ! attribute
@@ -1123,7 +1130,7 @@ contains
     end if
 
     call ncd_defvar_bynf(ncid,varname,xtype,ndims,dimid,varid, &
-         long_name=long_name, units=units, cell_method=cell_method, &
+         long_name=long_name, standard_name=standard_name,units=units, cell_method=cell_method, &
          missing_value=missing_value, fill_value=fill_value, &
          imissing_value=imissing_value, ifill_value=ifill_value, &
          comment=comment, flag_meanings=flag_meanings, &

--- a/components/elm/src/main/subgridRestMod.F90
+++ b/components/elm/src/main/subgridRestMod.F90
@@ -444,7 +444,7 @@ contains
 
     call restartvar(ncid=ncid, flag=flag, varname='SNLSNO', xtype=ncd_int,  & 
          dim1name='column', &
-         long_name='number of snow layers', units='unitless', &
+         long_name='number of snow layers', units='1', &
          interpinic_flag='interp', readvar=readvar, data=col_pp%snl)
 
     allocate(temp2d(bounds%begc:bounds%endc,-nlevsno+1:0))

--- a/components/elm/src/utils/elm_time_manager.F90
+++ b/components/elm/src/utils/elm_time_manager.F90
@@ -466,7 +466,7 @@ contains
        end if
     end if
     call restartvar(ncid=ncid, flag=flag, varname='timemgr_rst_type', xtype=ncd_int,  &
-         long_name='calendar type', units='unitless', flag_meanings=(/ "NO_LEAP_C", "GREGORIAN" /), &
+         long_name='calendar type', units='1', flag_meanings=(/ "NO_LEAP_C", "GREGORIAN" /), &
          flag_values=(/ noleap, gregorian /), ifill_value=uninit_int, &
          interpinic_flag='skip', readvar=readvar, data=rst_caltype)
     if (flag == 'read') then

--- a/components/mosart/src/riverroute/RtmHistFile.F90
+++ b/components/mosart/src/riverroute/RtmHistFile.F90
@@ -677,6 +677,8 @@ contains
     ! data set as a whole, as opposed to a single variable
 
     call ncd_putatt(lnfid, ncd_global, 'source'  , trim(source))
+    call ncd_putatt(lnfid, ncd_global, 'source_id'  , trim(version))
+    call ncd_putatt(lnfid, ncd_global, 'product'  , 'model-output')
     call ncd_putatt(lnfid, ncd_global, 'case', trim(caseid))
     call ncd_putatt(lnfid, ncd_global, 'username', trim(username))
     call ncd_putatt(lnfid, ncd_global, 'hostname', trim(hostname))
@@ -685,6 +687,17 @@ contains
     str = 'created on ' // curdate // ' ' // curtime
     call ncd_putatt(lnfid, ncd_global, 'history' , trim(str))
     call ncd_putatt(lnfid, ncd_global, 'institution_id' , 'E3SM-Project')
+    call ncd_putatt(lnfid, ncd_global, 'institution', &
+    'LLNL (Lawrence Livermore National Laboratory, Livermore, CA 94550, USA); &
+    &ANL (Argonne National Laboratory, Argonne, IL 60439, USA); &
+    &BNL (Brookhaven National Laboratory, Upton, NY 11973, USA); &
+    &LANL (Los Alamos National Laboratory, Los Alamos, NM 87545, USA); &
+    &LBNL (Lawrence Berkeley National Laboratory, Berkeley, CA 94720, USA); &
+    &ORNL (Oak Ridge National Laboratory, Oak Ridge, TN 37831, USA); &
+    &PNNL (Pacific Northwest National Laboratory, Richland, WA 99352, USA); &
+    &SNL (Sandia National Laboratories, Albuquerque, NM 87185, USA). &
+    &Mailing address: LLNL Climate Program, c/o David C. Bader, &
+    &Principal Investigator, L-103, 7000 East Avenue, Livermore, CA 94550, USA')
     call ncd_putatt(lnfid, ncd_global, 'contact' ,  &
              'e3sm-data-support@listserv.llnl.gov')
     call ncd_putatt(lnfid, ncd_global, 'Conventions', trim(conventions))
@@ -812,7 +825,7 @@ contains
          call ncd_defvar(varname='lat', xtype=tape(t)%ncprec, dim1name='lat', &
               long_name='runoff coordinate latitude', units='degrees_north', ncid=nfid(t))
          call ncd_defvar(varname='mask', xtype=ncd_int, dim1name='lon', dim2name='lat', &
-              long_name='runoff mask', units='unitless', ncid=nfid(t))
+              long_name='runoff mask', units='1', ncid=nfid(t))
          call ncd_defvar(varname='area', xtype=tape(t)%ncprec, dim1name='lon', dim2name='lat', &
               long_name='runoff grid area', units='m2', ncid=nfid(t))
          call ncd_defvar(varname='areatotal', xtype=tape(t)%ncprec, dim1name='lon', dim2name='lat', &
@@ -825,7 +838,7 @@ contains
          call ncd_defvar(varname='lat', xtype=tape(t)%ncprec, dim1name='gridcell',       &
               long_name='runoff coordinate latitude', units='degrees_north', ncid=nfid(t))
          call ncd_defvar(varname='mask', xtype=ncd_int, dim1name='gridcell',             &
-              long_name='runoff mask', units='unitless', ncid=nfid(t))
+              long_name='runoff mask', units='1', ncid=nfid(t))
          call ncd_defvar(varname='area', xtype=tape(t)%ncprec, dim1name='gridcell',      &
               long_name='runoff grid area', units='m2', ncid=nfid(t))
          call ncd_defvar(varname='areatotal', xtype=tape(t)%ncprec, dim1name='gridcell', &
@@ -1011,7 +1024,7 @@ contains
                 case ('A')
                    avgstr = 'mean'
                 case ('I')
-                   avgstr = 'instantaneous'
+                   avgstr = 'point'
                 case ('X')
                    avgstr = 'maximum'
                 case ('M')
@@ -1268,7 +1281,7 @@ contains
                units="absolute value of negative is in hours, 0=monthly, positive is time-steps",     &
                dim1name='scalar')
           call ncd_defvar(ncid=ncid_hist(t), varname='mfilt', xtype=ncd_int, &
-               long_name="Number of history time samples on a file", units="unitless",     &
+               long_name="Number of history time samples on a file", units="1",     &
                comment="Namelist item", &
                dim1name='scalar')
           call ncd_defvar(ncid=ncid_hist(t), varname='ncprec', xtype=ncd_int, &
@@ -1287,7 +1300,7 @@ contains
                dim1name='fname_lenp2', dim2name='max_flds' )
 
           call ncd_defvar(ncid=ncid_hist(t), varname='nflds', xtype=ncd_int, &
-               long_name="Number of fields on file", units="unitless",        &
+               long_name="Number of fields on file", units="1",        &
                dim1name='scalar')
           call ncd_defvar(ncid=ncid_hist(t), varname='ntimes', xtype=ncd_int, &
                long_name="Number of time steps on file", units="time-step",     &
@@ -1299,7 +1312,7 @@ contains
                dim1name='scalar')
    
           call ncd_defvar(ncid=ncid_hist(t), varname='hpindex', xtype=ncd_int, &
-               long_name="History pointer index", units="unitless",     &
+               long_name="History pointer index", units="1",     &
                dim1name='max_nflds' )
 
           call ncd_defvar(ncid=ncid_hist(t), varname='avgflag', xtype=ncd_char, &

--- a/components/mosart/src/riverroute/RtmHistFlds.F90
+++ b/components/mosart/src/riverroute/RtmHistFlds.F90
@@ -42,19 +42,19 @@ contains
     implicit none
     !-------------------------------------------------------
 
-    call RtmHistAddfld (fname='MASK', units='none',  &
+    call RtmHistAddfld (fname='MASK', units='1',  &
          avgflag='A', long_name='MOSART mask 1=land 2=ocean 3=outlet ', &
          ptr_rof=rtmCTL%rmask, default='active')
 
-    call RtmHistAddfld (fname='GINDEX', units='none',  &
+    call RtmHistAddfld (fname='GINDEX', units='1',  &
          avgflag='A', long_name='MOSART global index ', &
          ptr_rof=rtmCTL%rgindex, default='active')
 
-    call RtmHistAddfld (fname='DSIG', units='none',  &
+    call RtmHistAddfld (fname='DSIG', units='1',  &
          avgflag='A', long_name='MOSART downstream index ', &
          ptr_rof=rtmCTL%rdsig, default='active')
 
-    call RtmHistAddfld (fname='OUTLETG', units='none',  &
+    call RtmHistAddfld (fname='OUTLETG', units='1',  &
          avgflag='A', long_name='MOSART outlet index ', &
          ptr_rof=rtmCTL%routletg, default='active')
 
@@ -184,10 +184,10 @@ contains
       call RtmHistAddfld (fname='FLOODPLAIN_DEPTH', units='m',  &
          avgflag='A', long_name='MOSART floodplain water depth', &
          ptr_rof=rtmCTL%inundhf, default='active')
-      call RtmHistAddfld (fname='FLOODPLAIN_FRACTION', units='none',  &
+      call RtmHistAddfld (fname='FLOODPLAIN_FRACTION', units='1',  &
          avgflag='A', long_name='MOSART floodplain water area fraction', &
          ptr_rof=rtmCTL%inundff, default='active')
-      call RtmHistAddfld (fname='FLOODED_FRACTION', units='none',  &
+      call RtmHistAddfld (fname='FLOODED_FRACTION', units='1',  &
          avgflag='A', long_name='MOSART flooded water area fraction', &
          ptr_rof=rtmCTL%inundffunit, default='active')
     endif

--- a/components/mosart/src/riverroute/RtmIO.F90
+++ b/components/mosart/src/riverroute/RtmIO.F90
@@ -111,7 +111,7 @@ module RtmIO
   integer,parameter,private :: debug = 0             ! local debug level
 
   integer , parameter  , public  :: max_string_len = 256     ! length of strings
-  real(r8), parameter  , public  :: fillvalue = 1.e36_r8     ! fill value for netcdf fields
+  real(r8), parameter  , public  :: fillvalue = 1.e20_r8     ! fill value for netcdf fields
 
   integer, public :: io_type
 

--- a/components/mosart/src/riverroute/RtmTimeManager.F90
+++ b/components/mosart/src/riverroute/RtmTimeManager.F90
@@ -356,7 +356,7 @@ subroutine timemgr_restart(ncid, flag)
   varname = 'timemgr_rst_type'
   if (flag == 'define') then
      call ncd_defvar(ncid=ncid, varname=varname, xtype=ncd_int,  &
-          long_name='calendar type', units='unitless', flag_meanings=(/ "NO_LEAP_C", "GREGORIAN" /), &
+          long_name='calendar type', units='1', flag_meanings=(/ "NO_LEAP_C", "GREGORIAN" /), &
           flag_values=(/ noleap, gregorian /), ifill_value=uninit_int )
   else if (flag == 'read' .or. flag == 'write') then
      if (flag== 'write') then

--- a/components/mosart/src/riverroute/RtmVar.F90
+++ b/components/mosart/src/riverroute/RtmVar.F90
@@ -13,7 +13,7 @@ module RtmVar
 
   real(r8), public, parameter :: secspday = SHR_CONST_CDAY  ! Seconds per day
   integer,  public, parameter :: isecspday= secspday        ! Integer seconds per day
-  real(r8), public, parameter :: spval    = 1.e36_r8        ! special value for real data
+  real(r8), public, parameter :: spval    = 1.e20_r8        ! special value for real data
   integer , public, parameter :: ispval   = -9999           ! special value for int data
   real(r8) :: re = SHR_CONST_REARTH*0.001_r8                ! radius of earth (km)
   logical , public :: barrier_timers                        ! barrier timers
@@ -44,7 +44,7 @@ module RtmVar
   character(len=256), public :: hostname = ' '         ! Hostname of machine running on
   character(len=256), public :: username = ' '         ! username of user running program
   character(len=256), public :: version  = " "         ! version of program
-  character(len=256), public :: conventions = "CF-1.0" ! dataset conventions
+  character(len=256), public :: conventions = "CF-1.7" ! dataset conventions
   character(len=256), public :: source   = "MOSART in E3SM" ! description of this source
 
   ! Unit Numbers


### PR DESCRIPTION
Update ELM and MOSART history files for CF and CMIP

Replace non-compliant units like "none" and "unitless" with "1".
Add ability to add standard_name to ELM history and define a couple
Add some CMIP global attributes.
In MOSART, change spval and fillvalue to CMIP standard 1.e+20

[BFB]