### PR TITLE
Adds surface dataset for ne4pg2 2010

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -271,6 +271,8 @@ lnd/clm2/surfdata_map/surfdata_ne11np4_simyr2000_c160614.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne4np4_simyr2000_c160614.nc</fsurdat>
 <fsurdat hgrid="ne4np4.pg2" sim_year="2000" >
 lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620.nc</fsurdat>
+<fsurdat hgrid="ne4np4.pg2" sim_year="2010" >
+lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620.nc</fsurdat>
 <fsurdat hgrid="ne240np4"      sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne240np4_simyr2000_c170821.nc</fsurdat>
 <fsurdat hgrid="r05"         sim_year="2000" >


### PR DESCRIPTION
Surface dataset for 2000 is used as surface dataset for 2010.
The ne4pg2 compset is for model testing, thus using 2000 dataset
for 2010 is valid

Fixes #4076
[BFB]