### PR TITLE
update mpas-source: Removes shortwave energy conservation fix

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -669,6 +669,7 @@ if (($OCN_ICEBERG eq 'true') && ($OCN_FORCING eq 'active_atm')) {
 add_default($nl, 'config_sw_absorption_type');
 add_default($nl, 'config_jerlov_water_type');
 add_default($nl, 'config_surface_buoyancy_depth');
+add_default($nl, 'config_enable_shortwave_energy_fixer');
 
 ###########################################
 # Namelist group: tidal_potential_forcing #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -206,6 +206,7 @@ add_default($nl, 'config_remove_AIS_coupler_runoff');
 add_default($nl, 'config_sw_absorption_type');
 add_default($nl, 'config_jerlov_water_type');
 add_default($nl, 'config_surface_buoyancy_depth');
+add_default($nl, 'config_enable_shortwave_energy_fixer');
 
 ###########################################
 # Namelist group: tidal_potential_forcing #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -247,6 +247,7 @@
 <config_sw_absorption_type>'jerlov'</config_sw_absorption_type>
 <config_jerlov_water_type>3</config_jerlov_water_type>
 <config_surface_buoyancy_depth>1</config_surface_buoyancy_depth>
+<config_enable_shortwave_energy_fixer>.false.</config_enable_shortwave_energy_fixer>
 
 <!-- tidal_potential_forcing -->
 <config_use_tidal_potential_forcing>.false.</config_use_tidal_potential_forcing>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1044,6 +1044,14 @@ Valid values: Real Values greater than zero less than bottomDepth
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_enable_shortwave_energy_fixer" type="logical"
+	category="shortwaveRadiation" group="shortwaveRadiation">
+Flag to enable the shortwave energy fixer for shallow ocean cells
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- tidal_potential_forcing -->
 


### PR DESCRIPTION
See https://github.com/MPAS-Dev/MPAS-Model/pull/820

Coupled testing showed unexpected extremely strong sensitivity to the
previous shortwave radiation energy fixer. In that fix the excess
energy was used to heat the bottom layer. This yielded a strong
response in tropical precipitation, dramatically increasing the double
ITCZ bias. This removes that energy fixer and only tracks the solar
radiation that is discarded for extremely shallow cells

[NML]
[non-BFB]