### PR TITLE
Reorder check for bgc and spunup options to get the correct ICs

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -97,14 +97,14 @@ def buildnml(case, caseroot, compname):
         analysis_mask_file = 'oEC60to30v3_Atlantic_region_and_southern_transect.nc'
         ic_date = '170905'
         ic_prefix = 'oEC60to30v3_60layer'
+        if ocn_ic_mode == 'spunup':
+            ic_date = '200927'
+            ic_prefix = 'oEC60to30v3.restartFrom_anvilG'
         #  modify initial condition file if ocean BGC is turned on
         if ocn_bgc in ['eco_only', 'eco_and_dms', 'eco_and_macromolecules', 'eco_and_dms_and_macromolecules']:
             ic_date = '180418'
             ic_prefix = 'mpaso.rst.BCRC_CNPECACNT_1850_anvil02.0066-01-01.no-xtime'
             eco_forcing_file = 'oEC60to30v3.monthlySurfaceForcingBGC.171120.nc'
-        if ocn_ic_mode == 'spunup':
-            ic_date = '200927'
-            ic_prefix = 'oEC60to30v3.restartFrom_anvilG'
 
     elif ocn_grid == 'oEC60to30wLI':
         decomp_date = '160830'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -88,13 +88,13 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-cice.graph.info.'
         grid_date = '161222'
         grid_prefix = 'seaice.EC60to30v3'
+        if ice_ic_mode == 'spunup':
+            grid_date = '200927'
+            grid_prefix = 'seaice.EC60to30v3.restartFrom_anvilG'
         if ice_bgc == 'ice_bgc':
             grid_date = '180418'
             grid_prefix = 'mpassi.rst.BCRC_CNPECACNT_1850_anvil02.0066-01-01.no-xtime'
             points_file = 'seaice_points_EC.60to30v3_netcdf3_05152018.nc'
-        if ice_ic_mode == 'spunup':
-            grid_date = '200927'
-            grid_prefix = 'seaice.EC60to30v3.restartFrom_anvilG'
 
     elif ice_grid == 'oEC60to30wLI':
         decomp_date = '160830'


### PR DESCRIPTION
Reorders the logic for assigning ICs in the mpas-ocean and mpas-seaice components to make sure BGC runs get the correct initial files.

Fixes #4123

[non-BFB] only for marine BGC configurations