### PR TITLE
Updates WC14 and EC30to60 initial conditions

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -272,7 +272,7 @@ def buildnml(case, caseroot, compname):
         ic_date = '210210'
         ic_prefix = 'ocean.EC30to60E2r2'
         if ocn_ic_mode == 'spunup':
-            ic_date = '210210'
+            ic_date = '201001'
             ic_prefix = 'mpaso.EC30to60E2r2.rstFromG-anvil'
 
     elif ocn_grid == 'WC14to60E2r3':
@@ -283,7 +283,7 @@ def buildnml(case, caseroot, compname):
         ic_date = '210210'
         ic_prefix = 'ocean.WC14to60E2r3'
         if ocn_ic_mode == 'spunup':
-            ic_date = '210210'
+            ic_date = '210226'
             ic_prefix = 'mpaso.WC14to60E2r3.rstFromG-anvil'
 
 

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -267,7 +267,7 @@ def buildnml(case, caseroot, compname):
         grid_date = '210210'
         grid_prefix = 'seaice.EC30to60E2r2'
         if ice_ic_mode == 'spunup':
-            grid_date = '210210'
+            grid_date = '201001'
             grid_prefix = 'mpassi.EC30to60E2r2.rstFromG-anvil'
 
     elif ice_grid == 'WC14to60E2r3':
@@ -276,7 +276,7 @@ def buildnml(case, caseroot, compname):
         grid_date = '210210'
         grid_prefix = 'seaice.WC14to60E2r3'
         if ice_ic_mode == 'spunup':
-            grid_date = '210210'
+            grid_date = '210226'
             grid_prefix = 'mpassi.WC14to60E2r3.rstFromG-anvil'
 
 


### PR DESCRIPTION
This PR updates the WC14 and EC30to60 initial conditions so they are consistent for WCv2

[non-BFB] for tests with either of these grids