### PR TITLE
Fix compy layouts for G-cases with oEC60to30v3wLI

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -9538,7 +9538,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%T62.+_oi%oEC60to30.*">
+  <grid name="a%T62.+_oi%EC30to60E2r2|oi%oEC60to30v3.*">
     <mach name="compy">
       <pes compset=".*MPASSI.+MPASO.+" pesize="S">
         <comment>compy, lowres (60to30v3) G case on 12 nodes 40 ppn pure-MPI, sypd=10</comment>
@@ -10137,38 +10137,6 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_ice>0</rootpe_ice>
           <rootpe_ocn>324</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-    <mach name="compy">
-      <pes compset=".+DATM.+MPASO" pesize="any">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>320</ntasks_atm>
-          <ntasks_lnd>320</ntasks_lnd>
-          <ntasks_rof>320</ntasks_rof>
-          <ntasks_ice>320</ntasks_ice>
-          <ntasks_ocn>640</ntasks_ocn>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_cpl>120</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>320</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_cpl>0</rootpe_cpl>
         </rootpe>


### PR DESCRIPTION
Removes a redundant part of config_pesall.xml that was introduced mainly for the new EC30to60E2r2 grid and instead reuses older layouts for oEC60to30v3*. It removes an issue where an oEC60to30v3wLI case was failing with  an error for "More than one PE layout matches given PE specs".

[BFB]