### PR TITLE
update mpas-source: Simplifies the shortwave fixer formulation

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -247,7 +247,7 @@
 <config_sw_absorption_type>'jerlov'</config_sw_absorption_type>
 <config_jerlov_water_type>3</config_jerlov_water_type>
 <config_surface_buoyancy_depth>1</config_surface_buoyancy_depth>
-<config_enable_shortwave_energy_fixer>.false.</config_enable_shortwave_energy_fixer>
+<config_enable_shortwave_energy_fixer>.true.</config_enable_shortwave_energy_fixer>
 
 <!-- tidal_potential_forcing -->
 <config_use_tidal_potential_forcing>.false.</config_use_tidal_potential_forcing>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1082,6 +1082,7 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var name="rainFlux"/>')
         lines.append('    <var name="snowFlux"/>')
         lines.append('    <var name="vertNonLocalFlux"/>')
+        lines.append('    <var name="bottomLayerShortwaveTemperatureFlux"/>')
         lines.append('    <var_array name="activeTracersTend"/>')
         lines.append('    <var name="salinitySurfaceRestoringTendency"/>')
         lines.append('    <var_array name="activeTracerHorizontalAdvectionTendency"/>')


### PR DESCRIPTION
Makes the shortwave fixer add energy at bottom of column instead of
spreading throughout. This is more physically correct.
See https://github.com/MPAS-Dev/MPAS-Model/pull/822

[NML]
[non-BFB]