### PR TITLE
fates bgc bugfixes

### DIFF
--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -7785,7 +7785,7 @@ contains
     allocate(this%actual_immob_nh4                (begc:endc))                    ; this%actual_immob_nh4              (:)   = nan
     allocate(this%smin_no3_to_plant               (begc:endc))                    ; this%smin_no3_to_plant             (:)   = nan
     allocate(this%smin_nh4_to_plant               (begc:endc))                    ; this%smin_nh4_to_plant             (:)   = nan 
-    allocate(this%plant_to_litter_nflux           (begc:endc))                    ; this%plant_to_litter_nflux         (:)   = nan
+    allocate(this%plant_to_litter_nflux           (begc:endc))                    ; this%plant_to_litter_nflux         (:)   = 0._r8
     allocate(this%plant_to_cwd_nflux              (begc:endc))                    ; this%plant_to_cwd_nflux            (:)   = nan
     ! C4MIP output variable
     allocate(this%plant_n_to_cwdn                  (begc:endc))                   ; this%plant_n_to_cwdn               (:)  =nan
@@ -9543,7 +9543,7 @@ contains
     allocate(this%soil_p_immob_flux_vr             (begc:endc,1:nlevdecomp_full)) ; this%soil_p_immob_flux_vr          (:,:) = nan
     allocate(this%soil_p_grossmin_flux             (begc:endc))                   ; this%soil_p_grossmin_flux          (:)   = nan
     allocate(this%smin_p_to_plant                  (begc:endc))                   ; this%smin_p_to_plant               (:)   = nan
-    allocate(this%plant_to_litter_pflux            (begc:endc))                   ; this%plant_to_litter_pflux         (:)   = nan
+    allocate(this%plant_to_litter_pflux            (begc:endc))                   ; this%plant_to_litter_pflux         (:)   = 0._r8
     allocate(this%plant_to_cwd_pflux               (begc:endc))                   ; this%plant_to_cwd_pflux            (:)   = nan
     allocate(this%plant_pdemand                    (begc:endc))                   ; this%plant_pdemand                 (:)   = nan
     allocate(this%plant_pdemand_vr                 (begc:endc,1:nlevdecomp_full)) ; this%plant_pdemand_vr              (:,:) = nan

--- a/components/elm/src/dyn_subgrid/dynEDMod.F90
+++ b/components/elm/src/dyn_subgrid/dynEDMod.F90
@@ -30,7 +30,7 @@ contains
     
     do p = bounds%begp,bounds%endp
        c = veg_pp%column(p)
-       if (col_pp%itype(c) == istsoil) then 
+       if (col_pp%itype(c) == istsoil .and. col_pp%active(c) ) then 
           if ( veg_pp%is_veg(p) .or. veg_pp%is_bareground(p)) then
              veg_pp%wtcol(p) = veg_pp%wt_ed(p)
           else

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -534,7 +534,8 @@ contains
 
             ! INTERF-TODO: WE HAVE NOT FILTERED OUT FATES SITES ON INACTIVE COLUMNS.. YET
             ! NEED A RUN-TIME ROUTINE THAT CLEARS AND REWRITES THE SITE LIST
-            if ( lun_pp%itype(l) == istsoil ) then
+
+            if ( (lun_pp%itype(l) == istsoil) .and. (col_pp%active(c)) ) then
                s = s + 1
                collist(s) = c
                this%f2hmap(nc)%hsites(c) = s
@@ -546,7 +547,7 @@ contains
             endif
             
          enddo
-
+         
          if(debug)then
             write(iulog,*) 'alm_fates%init(): thread',nc,': allocated ',s,' sites'
          end if
@@ -1013,14 +1014,15 @@ contains
        ! variables is to inform patch%wtcol(p).  wt_ed is imposed on wtcol,
        ! but only for FATES columns.
 
-       veg_pp%is_veg(bounds_clump%begp:bounds_clump%endp)        = .false.
-       veg_pp%is_bareground(bounds_clump%begp:bounds_clump%endp) = .false.
-       veg_pp%wt_ed(bounds_clump%begp:bounds_clump%endp)         = 0.0_r8
-
        do s = 1,this%fates(nc)%nsites
           
           c = this%f2hmap(nc)%fcolumn(s)
 
+          veg_pp%is_veg(col_pp%pfti(c):col_pp%pftf(c))        = .false.
+          veg_pp%is_bareground(col_pp%pfti(c):col_pp%pftf(c)) = .false.
+          veg_pp%wt_ed(col_pp%pfti(c):col_pp%pftf(c))         = 0.0_r8
+
+          
           ! Other modules may have AI's we only flush values
           ! that are on the naturally vegetated columns
           elai(col_pp%pfti(c):col_pp%pftf(c)) = 0.0_r8

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -719,6 +719,12 @@ contains
 
       !-----------------------------------------------------------------------
 
+
+      if (masterproc) then
+         write(iulog, *) 'FATES dynamics start'
+      end if
+
+      
       nc = bounds_clump%clump_index
 
       ! ---------------------------------------------------------------------------------
@@ -828,8 +834,7 @@ contains
                                               this%fates(nc)%sites) 
 
       if (masterproc) then
-         write(iulog, *) 'clm: leaving ED model', bounds_clump%begg, &
-                                                  bounds_clump%endg
+         write(iulog, *) 'FATES dynamics complete'
       end if
 
       

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -810,14 +810,7 @@ contains
       enddo
 
       ! ---------------------------------------------------------------------------------
-      ! Part III: Process FATES output into the dimensions and structures that are part
-      ! of the HLMs API.  (column, depth, and litter fractions)
-      
-      ! ---------------------------------------------------------------------------------
-!      call this%UpdateLitterFluxes(bounds_clump)
-
-      ! ---------------------------------------------------------------------------------
-      ! Part III.2 (continued).
+      ! Part III
       ! Update diagnostics of the FATES ecosystem structure that are used in the HLM.
       ! ---------------------------------------------------------------------------------
       call this%wrap_update_hlmfates_dyn(nc,               &
@@ -1348,9 +1341,6 @@ contains
                        this%fates(nc)%bc_out(s))
                end do
 
-               ! this call transfers fates output bcs to the HLM
-!               call this%UpdateLitterFluxes(bounds_clump)
-
                ! ------------------------------------------------------------------------
                ! Re-populate all the hydraulics variables that are dependent
                ! on the key hydro state variables and plant carbon/geometry
@@ -1525,8 +1515,6 @@ contains
                    this%fates(nc)%bc_in(s), & 
                    this%fates(nc)%bc_out(s))
            end do
-
-!           call this%UpdateLitterFluxes(bounds_clump)
 
            ! ------------------------------------------------------------------------
            ! Update diagnostics of FATES ecosystem structure used in HLM.

--- a/components/elm/src/main/elmfates_paraminterfaceMod.F90
+++ b/components/elm/src/main/elmfates_paraminterfaceMod.F90
@@ -229,7 +229,9 @@ contains
             write(fates_log(),*) 'dimension shape:',dimension_shape
             call endrun(msg='unsupported number of dimensions reading parameters.')
          end select
-         write(fates_log(), *) 'clmfates_interfaceMod.F90:: reading '//trim(name)
+         if(DEBUG) then
+            write(fates_log(), *) 'clmfates_interfaceMod.F90:: reading '//trim(name)
+         end if
          call readNcdio(ncid, name, dimension_shape, dimension_names, subname, data(1:size_dim_1, 1:size_dim_2))
          call fates_params%SetData(i, data(1:size_dim_1, 1:size_dim_2))
       end if


### PR DESCRIPTION
These are bug fixes for bgc coupling of fates. FATES is now instantiated only on active columns,
which is consistent with the soil column filter upon which CNP biogeochemistry is active. 
Also, a litter flux was zero'd upon allocation which is critical for mass balance checks when FATES
is active.  Finally, the FATES submodule pointer is updated to its most recent tag: sci.1.43.3_api.14.2.0

Fixes: #4186 

[non-BFB] for only FATES