### PR TITLE
Add required C++ libs for GNU compiler on Cori to build E3SM

### DIFF
--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -1215,6 +1215,9 @@ flags should be captured within MPAS CMake files.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
 </compiler>
 
 <compiler MACH="cori-knl" COMPILER="intel">
@@ -1262,6 +1265,9 @@ flags should be captured within MPAS CMake files.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
 </compiler>
 
 <compiler MACH="ghost" COMPILER="intel">


### PR DESCRIPTION
This fix is required for GNU compiler on Cori to build e3sm.exe with latest
release of SCORPIO (not required for Intel compiler).

Similar CXX_LIBS settings have been applied to GNU compilers on Theta
(see PR #3293) and Summit (see PR #4141).