### PR TITLE
Fix SCORPIO link errors with Intel MPI on Cori

### DIFF
--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -622,7 +622,7 @@ flags should be captured within MPAS CMake files.
 
 <compiler OS="CNL">
   <CMAKE_OPTS>
-    <base> -DCMAKE_SYSTEM_NAME=Catamount</base>
+    <append MPILIB="!impi"> -DCMAKE_SYSTEM_NAME=Catamount </append>
   </CMAKE_OPTS>
   <CPPDEFS>
     <append> -DLINUX </append>


### PR DESCRIPTION
CMake option CMAKE_SYSTEM_NAME=Catamount should only
be used for Cray compiler wrappers.

When using Intel MPI, we have to explicitly use the native Intel
compilers instead of Cray wrappers. In this case, we should not
set CMAKE_SYSTEM_NAME to Catamount.

This fix is required for E3SM to build SCORPIO with Intel MPI
on Cori.

Fixes #3543

[BFB]