### PR TITLE
Add debug queue on Chrysalis

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -281,7 +281,8 @@
 
     <batch_system MACH="chrysalis" type="slurm" >
       <queues>
-	<queue walltimemax="03:00:00" nodemin="1" nodemax="512" default="true" strict="true">compute</queue>
+	<queue walltimemax="48:00:00" strict="true" nodemin="1" nodemax="492">compute</queue>
+	<queue walltimemax="04:00:00" strict="true" nodemin="1" nodemax="20" default="true">debug</queue>
       </queues>
     </batch_system>
 


### PR DESCRIPTION
* Default queue for jobs up to 20 nodes and wall-time up to 4 hours is `debug`, otherwise `compute`.
* Override the default queue with `create_[newcase,test] -q compute`.

[BFB]