### PR TITLE
Add ne4pg2_r2_QU480 bigrid and trigrid configurations

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -894,6 +894,26 @@
       <mask>oQU480</mask>
     </model_grid>
 
+    <model_grid alias="ne4pg2_oQU480" compset="(EAM.+ELM.+MPASO)">
+      <grid name="atm">ne4np4.pg2</grid>
+      <grid name="lnd">ne4np4.pg2</grid>
+      <grid name="ocnice">oQU480</grid>
+      <grid name="rof">r2</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU480</mask>
+    </model_grid>
+
+    <model_grid alias="ne4pg2_r2_oQU480" compset="(EAM.+ELM.+MPASO)">
+      <grid name="atm">ne4np4.pg2</grid>
+      <grid name="lnd">r2</grid>
+      <grid name="ocnice">oQU480</grid>
+      <grid name="rof">r2</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU480</mask>
+    </model_grid>
+
     <model_grid alias="ne8_ne8" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne8np4</grid>
       <grid name="lnd">ne8np4</grid>
@@ -3783,6 +3803,11 @@
       <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/ne4np4/map_ne4np4_TO_r05_aave.160621.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne4np4.pg2" rof_grid="r2">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne4pg2/map_ne4pg2_to_r2_mono.210211.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne4pg2/map_ne4pg2_to_r2_mono.210211.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="ne4np4.pg2" rof_grid="r05">
       <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne4pg2/map_ne4pg2_to_r05_mono.200527.nc</map>
       <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne4pg2/map_ne4pg2_to_r05_mono.200527.nc</map>
@@ -3904,6 +3929,11 @@
     <gridmap lnd_grid="ne4np4" rof_grid="r05">
       <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne4np4/map_ne4np4_TO_r05_aave.160621.nc</map>
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne4np4/map_r05_TO_ne4np4_aave.160621.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="ne4np4.pg2" rof_grid="r2">
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne4pg2/map_ne4pg2_to_r2_mono.210211.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne4pg2/map_r2_to_ne4pg2_mono.210211.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne4np4.pg2" rof_grid="r05">
@@ -4184,6 +4214,11 @@
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="oQU480" rof_grid="r2">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r2_to_oQU480_nn.210211.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r2_to_oQU480_nn.210211.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oQU480" rof_grid="r05">

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1256,7 +1256,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"  
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry> 


### PR DESCRIPTION
Adds support for ne4pg2_r2_QU480 configurations for ultra-low-res testing, both as bigrid (ne4pg2 atm/lnd, r2 rof, QU480 ocn/ice) and trigrid (ne4pg2 atm, r2 lnd/rof, QU480 one/ice).

[BFB] for all tested configurations