### PR TITLE
Defines core kind for configurations not using CLUBB_SGS

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -129,7 +129,7 @@ _TESTS = {
             "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
             "SMS.f09_g16_a.IGELM_MLI",
             "SMS_P12x2.ne4_oQU240.A_WCYCL1850.allactive-mach_mods",
-            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1.eam-crmout",
+            "ERS_Ln9.ne4pg2_ne4pg2.F-MMF1.eam-crmout",
             "SMS_B.ne4_ne4.F-EAM-AQP1.eam-hommexx",
             )
         },

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -129,6 +129,7 @@ _TESTS = {
             "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
             "SMS.f09_g16_a.IGELM_MLI",
             "SMS_P12x2.ne4_oQU240.A_WCYCL1850.allactive-mach_mods",
+            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1.eam-crmout",
             "SMS_B.ne4_ne4.F-EAM-AQP1.eam-hommexx",
             )
         },
@@ -160,7 +161,6 @@ _TESTS = {
             "SMS_Ld2.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850.elm-bgcexp",
             "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
             "SMS_D_Ld1.ne30_r05_oECv3.A_WCYCL1850",
-            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1.eam-crmout",
             "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMFXX.eam-genmmf",
             "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-RCEMIP.eam-genmmf",
             )

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -31,6 +31,8 @@ module clubb_intr
 #ifdef CLUBB_SGS
   use clubb_api_module, only: pdf_parameter
   use clubb_precision,  only: core_rknd
+#else
+  use shr_kind_mod,     only: core_rknd=>shr_kind_r8
 #endif
 
   implicit none


### PR DESCRIPTION
MMF tests were breaking as CLUBB_SGS is not defined for MMF like configurations.
[BFB]