### PR TITLE
Update the spunup initial conditions files for RRS18to6v3

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -230,8 +230,8 @@ def buildnml(case, caseroot, compname):
         ic_date = '171116'
         ic_prefix = 'oRRS18to6v3'
         if ocn_ic_mode == 'spunup':
-            ic_date = '171031'
-            ic_prefix = 'oRRS18to6v3_80Layer.restartFromAnvil'
+            ic_date = '210321'
+            ic_prefix = 'oRRS18to6v3_80Layer.restartFromChrysalis'
 
     elif ocn_grid == 'oRRS15to5':
         decomp_date = '151209'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -231,8 +231,8 @@ def buildnml(case, caseroot, compname):
         grid_date = '170111'
         grid_prefix = 'seaice.RRS18to6v3'
         if ice_ic_mode == 'spunup':
-            grid_date = '171031'
-            grid_prefix = 'seaice.RRS18to6v3_80Layer.restartFromAnvil'
+            grid_date = '210321'
+            grid_prefix = 'seaice.RRS18to6v3_80Layer.restartFromChrysalis'
 
     elif ice_grid == 'oRRS15to5':
         decomp_date = '151209'


### PR DESCRIPTION
Updates the spunup initial condition files for oRRS18to6v3 configurations. The new default number of snow layers in the seaice made the old files inconsistent with current master. These new files are from a one-month GMPAS-IAF case using T62_oRRS18to6v3 on chrysalis, and are staged on the inputdata repo.

Fixes #3894 

[non-BFB] for RRS18to6v3 configurations using spunup ICs