### PR TITLE
add support for ne30pg2, WCAtl12to45E2r4 configuration

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -8442,7 +8442,7 @@
           <ntasks_lnd>64</ntasks_lnd>
           <ntasks_rof>64</ntasks_rof>
           <ntasks_ice>2688</ntasks_ice>
-          <ntasks_ocn>2368</ntasks_ocn>
+          <ntasks_ocn>2880</ntasks_ocn>
           <ntasks_cpl>2752</ntasks_cpl>
         </ntasks>
         <nthrds>

--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -8433,6 +8433,37 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%ne30np4.pg.+_oi%WCAtl12to45E2r4">
+    <mach name="chrysalis">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="M">
+        <comment> -compset WCYCL* -res ne30pg*WCAtl* on 80 nodes pure-MPI, ~8.5 sypd </comment>
+        <ntasks>
+          <ntasks_atm>2700</ntasks_atm>
+          <ntasks_lnd>64</ntasks_lnd>
+          <ntasks_rof>64</ntasks_rof>
+          <ntasks_ice>2688</ntasks_ice>
+          <ntasks_ocn>2368</ntasks_ocn>
+          <ntasks_cpl>2752</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>2688</rootpe_lnd>
+          <rootpe_rof>2688</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>2752</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
   <grid name="a%ne30np4_l%.+_oi%oEC60to30">
     <mach name="anvil|bebop">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV" pesize="S">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1131,7 +1131,7 @@
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
-      <mask>oRRS18to6v3</mask>
+      <mask>WCAtl12to45E2r4</mask>
     </model_grid>
 
     <model_grid alias="northamericax4v1_r0125_northamericax4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
@@ -2326,8 +2326,8 @@
       <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_EC30to60E2r2.201005.nc</file>
       <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WC14to60E2r3.200929.nc</file>
       <file grid="ice|ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_WC14to60E2r3.200929.nc</file>
-      <file grid="atm|lnd" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WCAtl12to45E2r4.2103XX.nc</file>
-      <file grid="ice|ocn" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_WCAtl12to45E2r4.2103XX.nc</file>
+      <file grid="atm|lnd" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WCAtl12to45E2r4.210318.nc</file>
+      <file grid="ice|ocn" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_WCAtl12to45E2r4.210318.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_gx1v6.190806.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
@@ -2594,8 +2594,8 @@
     <domain name="WCAtl12to45E2r4">
       <nx>851664</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WCAtl12to45E2r4.2103XX.nc</file>
-      <desc>WCAtl12to45E2r4 is an MPAS ice/ocean grid with enhanced resolution of 12km over most of the Atlantic basin, XXkm in the Northern Atlantic subpolar gyre, and XX km in the Arctic Ocean. For the Southern Atlantic and Southern Ocean, resolution is 12km at high latitudes (near ice shelves). Elsewhere in the Southern Ocean, high resolution transitions smoothly to the background resolution of the standard low resolution 60to30km grid:</desc>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WCAtl12to45E2r4.210318.nc</file>
+      <desc>WCAtl12to45E2r4 is an MPAS ice/ocean grid with enhanced resolution of 45km over most of the equatorial Atlantic basin, 12km in the Northern Atlantic subpolar gyre, 12km in the Arctic Ocean, with coarsest resolution of 45km in the Pacific mid-latitudes. For the Southern Atlantic and Southern Ocean, resolution is 12km at high latitudes. High resolution transitions smoothly to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
 
@@ -3037,11 +3037,11 @@
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="WCAtl12to45E2r4">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WCAtl12to45E2r4_mono.2103XX.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WCAtl12to45E2r4_bilin.2103XX.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WCAtl12to45E2r4_bilin.2103XX.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_ne30pg2_mono.2103XX.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_ne30pg2_mono.2103XX.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WCAtl12to45E2r4_mono.210318.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WCAtl12to45E2r4_bilin.210318.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WCAtl12to45E2r4_bilin.210318.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_ne30pg2_mono.210318.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_ne30pg2_mono.210318.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
@@ -4260,8 +4260,8 @@
     </gridmap>
 
     <gridmap ocn_grid="WCAtl12to45E2r4" rof_grid="r05">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WCAtl12to45E2r4_smoothed.r150e300.2103XX.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WCAtl12to45E2r4_smoothed.r150e300.2103XX.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WCAtl12to45E2r4_smoothed.r150e300.210318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WCAtl12to45E2r4_smoothed.r150e300.210318.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="r0125">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1124,6 +1124,16 @@
       <mask>oRRS18to6v3</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_WCAtl12to45E2r4">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">ne30np4.pg2</grid>
+      <grid name="ocnice">WCAtl12to45E2r4</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6v3</mask>
+    </model_grid>
+
     <model_grid alias="northamericax4v1_r0125_northamericax4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne0np4_northamericax4v1</grid>
       <grid name="lnd">r0125</grid>
@@ -2316,6 +2326,8 @@
       <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_EC30to60E2r2.201005.nc</file>
       <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WC14to60E2r3.200929.nc</file>
       <file grid="ice|ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_WC14to60E2r3.200929.nc</file>
+      <file grid="atm|lnd" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WCAtl12to45E2r4.2103XX.nc</file>
+      <file grid="ice|ocn" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_WCAtl12to45E2r4.2103XX.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_gx1v6.190806.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
@@ -2578,6 +2590,14 @@
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WC14to60E2r3.200929.nc</file>
       <desc>WC14to60E2r3 is a MPAS ice/ocean grid with enhanced resolution of 14km along the coast of North America, the Northern Atlantic subpolar gyre, and the Arctic Ocean. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
+
+    <domain name="WCAtl12to45E2r4">
+      <nx>851664</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.WCAtl12to45E2r4.2103XX.nc</file>
+      <desc>WCAtl12to45E2r4 is an MPAS ice/ocean grid with enhanced resolution of 12km over most of the Atlantic basin, XXkm in the Northern Atlantic subpolar gyre, and XX km in the Arctic Ocean. For the Southern Atlantic and Southern Ocean, resolution is 12km at high latitudes (near ice shelves). Elsewhere in the Southern Ocean, high resolution transitions smoothly to the background resolution of the standard low resolution 60to30km grid:</desc>
+    </domain>
+
 
     <!-- ROF (river) grids-->
 
@@ -3014,6 +3034,14 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WC14to60E2r3_bilin.200928.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200928.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_ne30pg2_mono.200928.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg2" ocn_grid="WCAtl12to45E2r4">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WCAtl12to45E2r4_mono.2103XX.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WCAtl12to45E2r4_bilin.2103XX.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_WCAtl12to45E2r4_bilin.2103XX.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_ne30pg2_mono.2103XX.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_ne30pg2_mono.2103XX.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
@@ -4229,6 +4257,11 @@
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="r05">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="WCAtl12to45E2r4" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_WCAtl12to45E2r4_smoothed.r150e300.2103XX.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_WCAtl12to45E2r4_smoothed.r150e300.2103XX.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="r0125">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2211,7 +2211,7 @@
       <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to6.180803.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_EC30to60E2r2.201005.nc</file>
       <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WC14to60E2r3.200929.nc</file>
-      <file grid="atm|lnd" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WCAtl12to45E2r4.210318</file>
+      <file grid="atm|lnd" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WCAtl12to45E2r4.210318.nc</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -430,6 +430,16 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
+    <model_grid alias="T62_WCAtl12to45E2r4" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">WCAtl12to45E2r4</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>WCAtl12to45E2r4</mask>
+    </model_grid>
+
     <model_grid alias="TL319_oEC60to30v3" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -498,6 +508,16 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>WC14to60E2r3</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_WCAtl12to45E2r4" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">WCAtl12to45E2r4</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>WCAtl12to45E2r4</mask>
     </model_grid>
 
     <!-- finite volume grids -->
@@ -2191,6 +2211,7 @@
       <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to6.180803.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_EC30to60E2r2.201005.nc</file>
       <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WC14to60E2r3.200929.nc</file>
+      <file grid="atm|lnd" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WCAtl12to45E2r4.210318</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
@@ -2225,6 +2246,8 @@
       <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_EC30to60E2r2.201005.nc</file>
       <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_WC14to60E2r3.200929.nc</file>
       <file grid="ice|ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_WC14to60E2r3.200929.nc</file>
+      <file grid="atm|lnd" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_WCAtl12to45E2r4.210318.nc</file>
+      <file grid="ice|ocn" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_WCAtl12to45E2r4.210318.nc</file>
       <desc>TL319 is JRA lat/lon grid:</desc>
     </domain>
 
@@ -3706,6 +3729,14 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_T62_aave.200928.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="T62" ocn_grid="WCAtl12to45E2r4">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_WCAtl12to45E2r4_aave.210318.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_WCAtl12to45E2r4_bilin.210318.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_WCAtl12to45E2r4_patch.210318.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_T62_aave.210318.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_T62_aave.210318.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_aave.181203.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_bilin.181203.nc</map>
@@ -3760,6 +3791,14 @@
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WC14to60E2r3_patch.200928.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_TL319_aave.200928.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WC14to60E2r3/map_WC14to60E2r3_to_TL319_aave.200928.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="WCAtl12to45E2r4">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WCAtl12to45E2r4_aave.210318.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WCAtl12to45E2r4_bilin.210318.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_WCAtl12to45E2r4_patch.210318.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_TL319_aave.210318.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/WCAtl12to45E2r4/map_WCAtl12to45E2r4_to_TL319_aave.210318.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T31" ocn_grid="gx3v7">
@@ -4179,6 +4218,11 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
     </gridmap>
 
+    <gridmap ocn_grid="WCAtl12to45E2r4" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_WCAtl12to45E2r4_smoothed.r150e300.210318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_WCAtl12to45E2r4_smoothed.r150e300.210318.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="oEC60to30v3" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
@@ -4212,6 +4256,11 @@
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_WC14to60E2r3_smoothed.r150e300.200929.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="WCAtl12to45E2r4" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_WCAtl12to45E2r4_smoothed.r150e300.210318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_WCAtl12to45E2r4_smoothed.r150e300.210318.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oQU480" rof_grid="r05">

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1270,7 +1270,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*20" category="default_settings"
        group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2">
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30,oEC60to30v3,oEC60to30wLI,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,WCAtl12to45E2r4,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,mp120v1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10,oRRS30to10v3,oRRS30to10wLI,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2">
 Land mask description
 </entry> 
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -48,6 +48,7 @@
 <config_dt ocn_grid="oARRM60to6">'00:05:00'</config_dt>
 <config_dt ocn_grid="EC30to60E2r2">'00:30:00'</config_dt>
 <config_dt ocn_grid="WC14to60E2r3">'00:10:00'</config_dt>
+<config_dt ocn_grid="WCAtl12to45E2r4">'00:10:00'</config_dt>
 <config_time_integrator>'split_explicit'</config_time_integrator>
 
 <!-- hmix -->
@@ -71,6 +72,7 @@
 <config_hmix_scaleWithMesh ocn_grid="oARRM60to6">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="EC30to60E2r2">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="WC14to60E2r3">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="WCAtl12to45E2r4">.true.</config_hmix_scaleWithMesh>
 <config_maxMeshDensity>-1.0</config_maxMeshDensity>
 <config_hmix_use_ref_cell_width>.false.</config_hmix_use_ref_cell_width>
 <config_hmix_ref_cell_width>30.0e3</config_hmix_ref_cell_width>
@@ -85,6 +87,7 @@
 <config_use_mom_del2 ocn_grid="ECwISC30to60E1r2">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="EC30to60E2r2">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="WC14to60E2r3">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="WCAtl12to45E2r4">.true.</config_use_mom_del2>
 <config_mom_del2>10.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3">1000.0</config_mom_del2>
@@ -93,6 +96,7 @@
 <config_mom_del2 ocn_grid="ECwISC30to60E1r2">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="EC30to60E2r2">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="WC14to60E2r3">462.0</config_mom_del2>
+<config_mom_del2 ocn_grid="WCAtl12to45E2r4">462.0</config_mom_del2>
 <config_use_tracer_del2>.false.</config_use_tracer_del2>
 <config_tracer_del2>10.0</config_tracer_del2>
 
@@ -118,6 +122,7 @@
 <config_mom_del4 ocn_grid="oARRM60to6">3.2e09</config_mom_del4>
 <config_mom_del4 ocn_grid="EC30to60E2r2">1.2e11</config_mom_del4>
 <config_mom_del4 ocn_grid="WC14to60E2r3">1.18e10</config_mom_del4>
+<config_mom_del4 ocn_grid="WCAtl12to45E2r4">1.18e10</config_mom_del4>
 <config_mom_del4_div_factor>1.0</config_mom_del4_div_factor>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
 <config_tracer_del4>0.0</config_tracer_del4>
@@ -164,11 +169,13 @@
 <config_GM_closure>'EdenGreatbatch'</config_GM_closure>
 <config_GM_closure ocn_grid="EC30to60E2r2">'constant'</config_GM_closure>
 <config_GM_closure ocn_grid="WC14to60E2r3">'constant'</config_GM_closure>
+<config_GM_closure ocn_grid="WCAtl12to45E2r4">'constant'</config_GM_closure>
 <config_GM_constant_kappa>1800.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E1r2">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="EC30to60E2r2">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="WC14to60E2r3">600.0</config_GM_constant_kappa>
+<config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="WCAtl12to45E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_gravWaveSpeed>0.3</config_GM_constant_gravWaveSpeed>
 <config_GM_spatially_variable_min_kappa>300.0</config_GM_spatially_variable_min_kappa>
 <config_GM_spatially_variable_max_kappa>1800.0</config_GM_spatially_variable_max_kappa>
@@ -376,6 +383,7 @@
 <config_btr_dt ocn_grid="oARRM60to6">'0000_00:00:10'</config_btr_dt>
 <config_btr_dt ocn_grid="EC30to60E2r2">'0000_00:01:00'</config_btr_dt>
 <config_btr_dt ocn_grid="WC14to60E2r3">'0000_00:00:15'</config_btr_dt>
+<config_btr_dt ocn_grid="WCAtl12to45E2r4">'0000_00:00:15'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>
@@ -898,6 +906,7 @@
 <config_AM_mocStreamfunction_enable ocn_grid="oARRM60to6">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="EC30to60E2r2">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="WC14to60E2r3">.true.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="WCAtl12to45E2r4">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_compute_interval>'0000-00-00_01:00:00'</config_AM_mocStreamfunction_compute_interval>
 <config_AM_mocStreamfunction_output_stream>'mocStreamfunctionOutput'</config_AM_mocStreamfunction_output_stream>
 <config_AM_mocStreamfunction_compute_on_startup>.true.</config_AM_mocStreamfunction_compute_on_startup>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -136,7 +136,9 @@
 <!-- mesoscale_eddy_parameterizations -->
 <config_eddying_resolution_taper>'ramp'</config_eddying_resolution_taper>
 <config_eddying_resolution_ramp_min>20e3</config_eddying_resolution_ramp_min>
+<config_eddying_resolution_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_eddying_resolution_ramp_min>
 <config_eddying_resolution_ramp_max>30e3</config_eddying_resolution_ramp_max>
+<config_eddying_resolution_ramp_max ocn_grid="WCAtl12to45E2r4">40e3</config_eddying_resolution_ramp_max>
 
 <!-- Redi_isopycnal_mixing -->
 <config_use_Redi>.true.</config_use_Redi>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -286,6 +286,17 @@ def buildnml(case, caseroot, compname):
             ic_date = '210226'
             ic_prefix = 'mpaso.WC14to60E2r3.rstFromG-anvil'
 
+    elif ocn_grid == 'WCAtl12to45E2r4':
+        decomp_date = '210318'
+        decomp_prefix = 'mpas-o.graph.info.'
+        restoring_file = 'sss.PHC2_monthlyClimatology.WCAtl12to45E2r4.21XXXX.nc'
+        analysis_mask_file = 'WCAtl12to45E2r4_moc_masks_and_transects.nc'
+        ic_date = '210318'
+        ic_prefix = 'ocean.WCAtl12to45E2r4'
+        if ocn_ic_mode == 'spunup':
+            ic_date = '210318'
+            ic_prefix = 'mpaso.WCAtl12to45E2r4.rstFromG-anvil'
+
 
     #--------------------------------------------------------------------
     # Set OCN_FORCING = datm_forced_restoring if restoring file is available

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -289,7 +289,7 @@ def buildnml(case, caseroot, compname):
     elif ocn_grid == 'WCAtl12to45E2r4':
         decomp_date = '210318'
         decomp_prefix = 'mpas-o.graph.info.'
-        restoring_file = 'sss.PHC2_monthlyClimatology.WCAtl12to45E2r4.21XXXX.nc'
+        restoring_file = 'sss.PHC2_monthlyClimatology.WCAtl12to45E2r4.210325.nc'
         analysis_mask_file = 'WCAtl12to45E2r4_moc_masks_and_transects.nc'
         ic_date = '210318'
         ic_prefix = 'ocean.WCAtl12to45E2r4'

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -26,6 +26,7 @@
 <config_dt ice_grid="oARRM60to6">900.0</config_dt>
 <config_dt ice_grid="EC30to60E2r2">1800.0</config_dt>
 <config_dt ice_grid="WC14to60E2r3">1800.0</config_dt>
+<config_dt ice_grid="WCAtl12to45E2r4">1800.0</config_dt>
 <config_calendar_type>'gregorian_noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
@@ -129,6 +130,7 @@
 <config_dynamics_subcycle_number ice_grid="oARRM60to6">2</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="EC30to60E2r2">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="WC14to60E2r3">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="WCAtl12to45E2r4">1</config_dynamics_subcycle_number>
 <config_rotate_cartesian_grid>true</config_rotate_cartesian_grid>
 <config_include_metric_terms>true</config_include_metric_terms>
 <config_elastic_subcycle_number>120</config_elastic_subcycle_number>
@@ -377,9 +379,11 @@
 <config_use_form_drag>false</config_use_form_drag>
 <config_use_high_frequency_coupling>true</config_use_high_frequency_coupling>
 <config_use_high_frequency_coupling ice_grid="WC14to60E2r3">false</config_use_high_frequency_coupling>
+<config_use_high_frequency_coupling ice_grid="WCAtl12to45E2r4">false</config_use_high_frequency_coupling>
 <config_use_high_frequency_coupling ice_grid="EC30to60E2r2">false</config_use_high_frequency_coupling>
 <config_boundary_layer_iteration_number>10</config_boundary_layer_iteration_number>
 <config_boundary_layer_iteration_number ice_grid="WC14to60E2r3">5</config_boundary_layer_iteration_number>
+<config_boundary_layer_iteration_number ice_grid="WCAtl12to45E2r4">5</config_boundary_layer_iteration_number>
 <config_boundary_layer_iteration_number ice_grid="EC30to60E2r2">5</config_boundary_layer_iteration_number>
 
 <!-- ocean -->

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -279,6 +279,15 @@ def buildnml(case, caseroot, compname):
             grid_date = '210226'
             grid_prefix = 'mpassi.WC14to60E2r3.rstFromG-anvil'
 
+    elif ice_grid == 'WCAtl12to45E2r4':
+        decomp_date = '210318'
+        decomp_prefix = 'mpas-seaice.graph.info.'
+        grid_date = '210318'
+        grid_prefix = 'seaice.WCAtl12to45E2r4'
+        if ice_ic_mode == 'spunup':
+            grid_date = '210318'
+            grid_prefix = 'mpassi.WCAtl12to45E2r4.rstFromG-anvil'
+
 
     #--------------------------------------------------------------------
     # Set the initial file, changing to a restart file for branch and hybrid runs


### PR DESCRIPTION
Adds grid, domain, mapping file, data forcing (JRA, CORE), ocean restoring file, and ocean/ice namelist default support for new ne30pg2 (atmos) and WCAtl12to45E2r4 (ocean/ice) configuration.

[BFB]