### PR TITLE
Update CIME submodule

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -4788,6 +4788,9 @@ sub check_input_files {
 		my $pathname = $nl->get_variable_value($group, $var);
 		# Need to strip the quotes
 		$pathname =~ s/['"]//g;
+                if ($pathname eq '') {
+                    $pathname = "/dev/null"
+                }
 
 		if ($input_pathname_type eq 'abs') {
                     if ($inputdata_rootdir) {

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -1893,7 +1893,7 @@ this mask will have smb calculated over the entire global land surface
 <use_fates_cohort_age_tracking use_fates=".true.">.false.</use_fates_cohort_age_tracking>
 <fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>
 <use_fates_inventory_init      use_fates=".true.">.false.</use_fates_inventory_init>
-<fates_inventory_ctrl_filename use_fates=".true."> " " </fates_inventory_ctrl_filename>
+<fates_inventory_ctrl_filename use_fates=".true."> "/dev/null" </fates_inventory_ctrl_filename>
 <use_vertsoilc                 bgc_mode="fates"  >.true.</use_vertsoilc>
 <use_century_decomp            bgc_mode="fates"  >.true.</use_century_decomp>
 <use_lch4                      bgc_mode="fates"  >.false.</use_lch4>


### PR DESCRIPTION
To 1e705ee391aa61b050666d5de2b602e22179d5f5

Changes:
1) Switch e3sm config to COMP_ROOT_DIR
2) Logs tail of cprnc outputs to TestStatus.log
3) Disable kokkos tests when building for E3SM
4) Add header row and perf-archiving to memory profiling logs
5) Add run scripts to provenance capture
6) PIO: Makes the 64bit_data format the default.
7) Update PIO2
8) Enable 2010 SST climatology for all variants of F-2010 compsets

Bug fixes:
1) Fix format descriptor in mem-logging for IBM compiler
2) check-input-data: better-distinguish between correct files and directories.
3) primary_component computation was not handling ROF

NOTE: Stricter input-list checking required a small change in fates default NML values, so this PR will have some minor NML diffs. I also had to make some minor changes to EAM along these same lines.

[BFB-nml]