### PR TITLE
Fix units attribute of 4 cosp dimension variables

### DIFF
--- a/components/eam/src/physics/cam/cospsimulator_intr.F90
+++ b/components/eam/src/physics/cam/cospsimulator_intr.F90
@@ -609,7 +609,7 @@ CONTAINS
     ! register non-standard variable dimensions
     if (lisccp_sim .or. lmodis_sim) then
        call add_hist_coord('cosp_prs', nprs_cosp, 'COSP Mean ISCCP pressure',  &
-            'hPa', prsmid_cosp, bounds_name='cosp_prs_bnds', bounds=prslim_cosp)
+            'Pa', prsmid_cosp, bounds_name='cosp_prs_bnds', bounds=prslim_cosp)
     end if
     
     if (lisccp_sim .or. lmisr_sim) then
@@ -649,7 +649,7 @@ CONTAINS
     
     if (lmisr_sim) then
        call add_hist_coord('cosp_htmisr', nhtmisr_cosp, 'COSP MISR height', &
-            'km', htmisrmid_cosp,                                           &
+            'm', htmisrmid_cosp,                                           &
             bounds_name='cosp_htmisr_bnds', bounds=htmisrlim_cosp)
     end if
     
@@ -658,10 +658,10 @@ CONTAINS
             'COSP Mean MODIS optical depth', '1', taumid_cosp_modis,           &
             bounds_name='cosp_tau_modis_bnds', bounds=taulim_cosp_modis)
        call add_hist_coord('cosp_reffice',numMODISReffIceBins,                 &
-            'COSP Mean MODIS effective radius (ice)', 'microns', reffICE_binCenters_cosp, &
+            'COSP Mean MODIS effective radius (ice)', 'm', reffICE_binCenters_cosp, &
             bounds_name='cosp_reffice_bnds',bounds=reffICE_binEdges_cosp)
        call add_hist_coord('cosp_reffliq',numMODISReffLiqBins,                 &
-            'COSP Mean MODIS effective radius (liquid)', 'microns', reffLIQ_binCenters_cosp, &
+            'COSP Mean MODIS effective radius (liquid)', 'm', reffLIQ_binCenters_cosp, &
             bounds_name='cosp_reffliq_bnds',bounds=reffLIQ_binEdges_cosp)      
     end if
     


### PR DESCRIPTION
The units and values for four COSP dimension variables (cosp_prs, cosp_htmisr, cosp_reffliq and cosp_reffice) are inconsistent. The units are changed to 'Pa' for cosp_prs and 'm' for cosp_htmisr, cosp_reffliq and cosp_reffice.

Fixes: https://github.com/E3SM-Project/E3SM/issues/4176
