### PR TITLE
Correct melt potential in ocean coupling file for MPAS-Ocean

### DIFF
--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2306,7 +2306,7 @@ contains
 
    integer, dimension(:), pointer :: landIceMask
 
-   real (kind=RKIND), dimension(:), pointer :: seaIceEnergy, freezingTemp, accumulatedFrazilIceMass, frazilSurfacePressure, &
+   real (kind=RKIND), dimension(:), pointer :: seaIceEnergy, accumulatedFrazilIceMass, frazilSurfacePressure, &
                                                filteredSSHGradientZonal, filteredSSHGradientMeridional, &
                                                avgCO2_gas_flux, DMSFlux, surfaceUpwardCO2Flux, &
                                                avgOceanSurfaceDIC, &
@@ -2323,6 +2323,8 @@ contains
    real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                  avgOceanSurfacePhytoC, &
                                                  avgOceanSurfaceDOC, layerThickness
+
+   real (kind=RKIND) :: SurfacefreezingTemp
 
    logical, pointer :: frazilIceActive,          &
                        config_use_ecosysTracers, &
@@ -2437,10 +2439,13 @@ contains
 
           if ( keepFrazil ) then
 
-             SurfacefreezingTemp(i) = ocn_freezing_temperature(index_salinitySurfaceValue, 1, i), &
-                               pressure=0.0_RKIND,  inLandIceCavity=.false.) 
+             ! We assume here that avgTracersSurfaceValue represents only the
+             ! top layer of the ocean.
 
-             seaIceEnergy(i) = min( rho_sw * cp_sw * layerThickness(1, i) * ( SurfacefreezingTemp(i) + T0_Kelvin &
+             SurfacefreezingTemp = ocn_freezing_temperature(salinity=avgTracersSurfaceValue(index_salinitySurfaceValue, i), &
+                 pressure=0.0_RKIND,  inLandIceCavity=.false.) 
+
+             seaIceEnergy(i) = min(rho_sw*cp_sw*layerThickness(1, i)*( SurfacefreezingTemp + T0_Kelvin &
                              - avgTracersSurfaceValue(index_temperatureSurfaceValue, i) ), 0.0_RKIND )
              if ( accumulatedFrazilIceMass(i) > 0.0_RKIND ) seaIceEnergy(i) = 0.0_RKIND
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -49,6 +49,7 @@ module ocn_comp_mct
    use ocn_time_integration
    use ocn_time_average_coupled
    use ocn_frazil_forcing
+   use ocn_equation_of_state
    use ocn_surface_land_ice_fluxes
    use ocn_diagnostics
    use ocn_diagnostics_variables
@@ -2305,7 +2306,7 @@ contains
 
    integer, dimension(:), pointer :: landIceMask
 
-   real (kind=RKIND), dimension(:), pointer :: seaIceEnergy, accumulatedFrazilIceMass, frazilSurfacePressure, &
+   real (kind=RKIND), dimension(:), pointer :: seaIceEnergy, freezingTemp, accumulatedFrazilIceMass, frazilSurfacePressure, &
                                                filteredSSHGradientZonal, filteredSSHGradientMeridional, &
                                                avgCO2_gas_flux, DMSFlux, surfaceUpwardCO2Flux, &
                                                avgOceanSurfaceDIC, &
@@ -2435,7 +2436,11 @@ contains
           end if
 
           if ( keepFrazil ) then
-             seaIceEnergy(i) = min( rho_sw * cp_sw * layerThickness(1, i) * ( -1.8_RKIND + T0_Kelvin &
+
+             SurfacefreezingTemp(i) = ocn_freezing_temperature(index_salinitySurfaceValue, 1, i), &
+                               pressure=0.0_RKIND,  inLandIceCavity=.false.) 
+
+             seaIceEnergy(i) = min( rho_sw * cp_sw * layerThickness(1, i) * ( SurfacefreezingTemp(i) + T0_Kelvin &
                              - avgTracersSurfaceValue(index_temperatureSurfaceValue, i) ), 0.0_RKIND )
              if ( accumulatedFrazilIceMass(i) > 0.0_RKIND ) seaIceEnergy(i) = 0.0_RKIND
 


### PR DESCRIPTION
This PR corrects the sea ice melt potential being passed from the ocean model to the sea ice model in E3SM so that it references the MPAS-Ocean's salinity-dependent freezing temperature in ocn_comp_mct.F and makes the melt potential coupling consistent with MPAS-SeaIce.  The code change has been tested in a 170-year run on Chrysalis and produces a comparable climate to a simulation without this bug fix. The change is nevertheless required for consistency with mushy-layer sea ice thermodynamics.   Melt potential is calculated as the energy in the first layer of the ocean above freezing temperature available to melt sea ice.  Refer to simulation: https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/2477457498/20210316.v2beta3GM900.OcnMctIce.ne30pg2+oECv3.chrysalis for more information.  No changes are required in MPAS-Ocean to match this change in E3SM.

[non-BFB]