### PR TITLE
Update SAMXX to work with new FFTs in YAKL

### DIFF
--- a/components/eam/src/physics/crm/crm_input_module.F90
+++ b/components/eam/src/physics/crm/crm_input_module.F90
@@ -103,7 +103,7 @@ contains
       call prefetch(input%fluxt00)
       call prefetch(input%fluxq00)
 
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (.not. allocated(input%naermod))  allocate(input%naermod(ncrms,nlev,ntot_amode))
          if (.not. allocated(input%vaerosol)) allocate(input%vaerosol(ncrms,nlev,ntot_amode))
          if (.not. allocated(input%hygro))    allocate(input%hygro(ncrms,nlev,ntot_amode))
@@ -146,7 +146,7 @@ contains
       input%fluxt00 = 0
       input%fluxq00 = 0
 
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          input%naermod  = 0
          input%vaerosol = 0
          input%hygro    = 0
@@ -189,7 +189,7 @@ contains
       if (allocated(input%fluxt00)) deallocate(input%fluxt00)
       if (allocated(input%fluxq00)) deallocate(input%fluxq00)
 
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (allocated(input%naermod))    deallocate(input%naermod)
          if (allocated(input%vaerosol))   deallocate(input%vaerosol)
          if (allocated(input%hygro))      deallocate(input%hygro)

--- a/components/eam/src/physics/crm/crm_input_module.F90
+++ b/components/eam/src/physics/crm/crm_input_module.F90
@@ -54,14 +54,11 @@ module crm_input_module
 contains
    !------------------------------------------------------------------------------------------------
    ! Type-bound procedures for crm_input_type
-   subroutine crm_input_initialize(input, ncrms, nlev)
-      use phys_control, only: phys_getopts
+   subroutine crm_input_initialize(input, ncrms, nlev, MMF_microphysics_scheme)
       type(crm_input_type), intent(inout) :: input
       integer, intent(in) :: ncrms, nlev
-      character(len=16) :: MMF_microphysics_scheme    ! CRM microphysics scheme
+      character(len=*), intent(in) :: MMF_microphysics_scheme    ! CRM microphysics scheme
 
-      call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
-      
       if (.not. allocated(input%zmid))     allocate(input%zmid(ncrms,nlev))
       if (.not. allocated(input%zint))     allocate(input%zint(ncrms,nlev+1))
       if (.not. allocated(input%tl))       allocate(input%tl(ncrms,nlev))
@@ -165,12 +162,9 @@ contains
 
    end subroutine crm_input_initialize
    !------------------------------------------------------------------------------------------------
-   subroutine crm_input_finalize(input)
-      use phys_control, only: phys_getopts
+   subroutine crm_input_finalize(input, MMF_microphysics_scheme)
       type(crm_input_type), intent(inout) :: input
-      character(len=16) :: MMF_microphysics_scheme    ! CRM microphysics scheme
-
-      call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
+      character(len=*), intent(in) :: MMF_microphysics_scheme    ! CRM microphysics scheme
 
       if (allocated(input%zmid))    deallocate(input%zmid)
       if (allocated(input%zint))    deallocate(input%zint)

--- a/components/eam/src/physics/crm/crm_output_module.F90
+++ b/components/eam/src/physics/crm/crm_output_module.F90
@@ -217,7 +217,7 @@ contains
       call prefetch(output%qg_mean)
       call prefetch(output%qr_mean)
 
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (.not. allocated(output%nc_mean)) allocate(output%nc_mean(ncol,nlev))
          if (.not. allocated(output%ni_mean)) allocate(output%ni_mean(ncol,nlev))
          if (.not. allocated(output%ns_mean)) allocate(output%ns_mean(ncol,nlev))
@@ -382,7 +382,7 @@ contains
       output%qg_mean = 0
       output%qr_mean = 0
 
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          output%nc_mean = 0
          output%ni_mean = 0
          output%ns_mean = 0
@@ -502,7 +502,7 @@ contains
       if (allocated(output%qg_mean)) deallocate(output%qg_mean)
       if (allocated(output%qr_mean)) deallocate(output%qr_mean)
       
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (allocated(output%nc_mean)) deallocate(output%nc_mean)
          if (allocated(output%ni_mean)) deallocate(output%ni_mean)
          if (allocated(output%ns_mean)) deallocate(output%ns_mean)

--- a/components/eam/src/physics/crm/crm_output_module.F90
+++ b/components/eam/src/physics/crm/crm_output_module.F90
@@ -140,13 +140,10 @@ module crm_output_module
 contains
 
    !------------------------------------------------------------------------------------------------
-   subroutine crm_output_initialize(output, ncol, nlev, crm_nx, crm_ny, crm_nz)
-      use phys_control, only: phys_getopts
+   subroutine crm_output_initialize(output, ncol, nlev, crm_nx, crm_ny, crm_nz, MMF_microphysics_scheme)
       type(crm_output_type), intent(inout) :: output
       integer,               intent(in   ) :: ncol, nlev, crm_nx, crm_ny, crm_nz
-      character(len=16) :: MMF_microphysics_scheme    ! CRM microphysics scheme
-
-      call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
+      character(len=*),      intent(in   ) :: MMF_microphysics_scheme    ! CRM microphysics scheme
 
       ! Allocate instantaneous outputs
       if (.not. allocated(output%qcl)) allocate(output%qcl(ncol,crm_nx,crm_ny,crm_nz))
@@ -467,12 +464,9 @@ contains
 
    end subroutine crm_output_initialize
    !------------------------------------------------------------------------------------------------
-   subroutine crm_output_finalize(output)
-      use phys_control, only: phys_getopts
+   subroutine crm_output_finalize(output, MMF_microphysics_scheme)
       type(crm_output_type), intent(inout) :: output
-      character(len=16) :: MMF_microphysics_scheme    ! CRM microphysics scheme
-
-      call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
+      character(len=*), intent(in) :: MMF_microphysics_scheme    ! CRM microphysics scheme
 
       if (allocated(output%qcl)) deallocate(output%qcl)
       if (allocated(output%qci)) deallocate(output%qci)

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -23,6 +23,7 @@ module crm_physics
 
    public :: crm_physics_register
    public :: crm_physics_init
+   public :: crm_physics_final
    public :: crm_physics_tend
    public :: crm_surface_flux_bypass_tend
    public :: m2005_effradius
@@ -425,6 +426,11 @@ subroutine crm_physics_init(state, pbuf2d, species_class)
    end if
 
 end subroutine crm_physics_init
+
+subroutine crm_physics_final()
+   use gator_mod, only: gator_finalize
+   call gator_finalize()
+end subroutine crm_physics_final
 
 !===================================================================================================
 !===================================================================================================

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -663,7 +663,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    !------------------------------------------------------------------------------------------------
    call crm_state_initialize(crm_state, pcols, crm_nx, crm_ny, crm_nz)
    call crm_rad_initialize(crm_rad, pcols, crm_nx_rad, crm_ny_rad, crm_nz)
-   call crm_input_initialize(crm_input, pcols, pver)
+   call crm_input_initialize(crm_input, pcols, pver, MMF_microphysics_scheme)
    call crm_output_initialize(crm_output, pcols, pver, crm_nx, crm_ny, crm_nz)
 
    !------------------------------------------------------------------------------------------------
@@ -1500,7 +1500,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
 
    call crm_state_finalize(crm_state)
    call crm_rad_finalize(crm_rad)
-   call crm_input_finalize(crm_input)
+   call crm_input_finalize(crm_input, MMF_microphysics_scheme)
    call crm_output_finalize(crm_output)
 
 end subroutine crm_physics_tend

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -661,10 +661,10 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    !------------------------------------------------------------------------------------------------
    ! Initialize CRM state (nullify pointers, allocate memory, etc)
    !------------------------------------------------------------------------------------------------
-   call crm_state_initialize(crm_state, pcols, crm_nx, crm_ny, crm_nz)
-   call crm_rad_initialize(crm_rad, pcols, crm_nx_rad, crm_ny_rad, crm_nz)
+   call crm_state_initialize(crm_state, pcols, crm_nx, crm_ny, crm_nz, MMF_microphysics_scheme)
+   call crm_rad_initialize(crm_rad, pcols, crm_nx_rad, crm_ny_rad, crm_nz, MMF_microphysics_scheme)
    call crm_input_initialize(crm_input, pcols, pver, MMF_microphysics_scheme)
-   call crm_output_initialize(crm_output, pcols, pver, crm_nx, crm_ny, crm_nz)
+   call crm_output_initialize(crm_output, pcols, pver, crm_nx, crm_ny, crm_nz, MMF_microphysics_scheme)
 
    !------------------------------------------------------------------------------------------------
    ! Set CRM orientation angle
@@ -1498,10 +1498,10 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    ! Free memory in derived types
    !------------------------------------------------------------------------------------------------
 
-   call crm_state_finalize(crm_state)
-   call crm_rad_finalize(crm_rad)
+   call crm_state_finalize(crm_state, MMF_microphysics_scheme)
+   call crm_rad_finalize(crm_rad, MMF_microphysics_scheme)
    call crm_input_finalize(crm_input, MMF_microphysics_scheme)
-   call crm_output_finalize(crm_output)
+   call crm_output_finalize(crm_output, MMF_microphysics_scheme)
 
 end subroutine crm_physics_tend
 

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -428,8 +428,10 @@ subroutine crm_physics_init(state, pbuf2d, species_class)
 end subroutine crm_physics_init
 
 subroutine crm_physics_final()
+#if defined(MMF_SAMXX)
    use gator_mod, only: gator_finalize
    call gator_finalize()
+#endif
 end subroutine crm_physics_final
 
 !===================================================================================================

--- a/components/eam/src/physics/crm/crm_rad_module.F90
+++ b/components/eam/src/physics/crm/crm_rad_module.F90
@@ -63,7 +63,7 @@ contains
       rad%qi          = 0
       rad%cld         = 0
 
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (.not. allocated(rad%nc)) allocate(rad%nc(ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
          if (.not. allocated(rad%ni)) allocate(rad%ni(ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
          if (.not. allocated(rad%qs)) allocate(rad%qs(ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
@@ -93,7 +93,7 @@ contains
       if (allocated(rad%qi))          deallocate(rad%qi)
       if (allocated(rad%cld))         deallocate(rad%cld)
 
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (allocated(rad%nc))       deallocate(rad%nc)
          if (allocated(rad%ni))       deallocate(rad%ni)
          if (allocated(rad%qs))       deallocate(rad%qs)

--- a/components/eam/src/physics/crm/crm_rad_module.F90
+++ b/components/eam/src/physics/crm/crm_rad_module.F90
@@ -37,14 +37,10 @@ contains
 
    !------------------------------------------------------------------------------------------------
    ! Type-bound procedures for crm_rad_type
-   subroutine crm_rad_initialize(rad, ncrms, crm_nx_rad, crm_ny_rad, crm_nz)
-      use phys_control, only: phys_getopts
-      class(crm_rad_type), intent(inout) :: rad
+   subroutine crm_rad_initialize(rad, ncrms, crm_nx_rad, crm_ny_rad, crm_nz, MMF_microphysics_scheme)
+      type(crm_rad_type),  intent(inout) :: rad
       integer,             intent(in   ) :: ncrms, crm_nx_rad, crm_ny_rad, crm_nz
-
-      character(len=16) :: MMF_microphysics_scheme    ! CRM microphysics scheme
-
-      call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
+      character(len=*),    intent(in   ) :: MMF_microphysics_scheme    ! CRM microphysics scheme
 
       if (.not. allocated(rad%qrad))        allocate(rad%qrad       (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
       if (.not. allocated(rad%temperature)) allocate(rad%temperature(ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
@@ -86,13 +82,9 @@ contains
 
    end subroutine crm_rad_initialize
    !------------------------------------------------------------------------------------------------
-   subroutine crm_rad_finalize(rad)
-      use phys_control, only: phys_getopts
-      class(crm_rad_type), intent(inout) :: rad
-
-      character(len=16) :: MMF_microphysics_scheme    ! CRM microphysics scheme
-
-      call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
+   subroutine crm_rad_finalize(rad, MMF_microphysics_scheme)
+      type(crm_rad_type), intent(inout) :: rad
+      character(len=*), intent(in) :: MMF_microphysics_scheme    ! CRM microphysics scheme
 
       if (allocated(rad%qrad))        deallocate(rad%qrad)
       if (allocated(rad%temperature)) deallocate(rad%temperature)

--- a/components/eam/src/physics/crm/crm_state_module.F90
+++ b/components/eam/src/physics/crm/crm_state_module.F90
@@ -49,13 +49,10 @@ contains
 
    !------------------------------------------------------------------------------------------------
    ! Type-bound procedures for crm_state_type
-   subroutine crm_state_initialize(state,ncrms,crm_nx,crm_ny,crm_nz)
-      use phys_control, only: phys_getopts
+   subroutine crm_state_initialize(state,ncrms,crm_nx,crm_ny,crm_nz,MMF_microphysics_scheme)
       type(crm_state_type), intent(inout) :: state
       integer,              intent(in   ) :: ncrms, crm_nx, crm_ny, crm_nz
-      character(len=16) :: MMF_microphysics_scheme    ! CRM microphysics scheme
-
-      call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
+      character(len=16),    intent(in   ) :: MMF_microphysics_scheme    ! CRM microphysics scheme
 
       ! Nullify pointers
       if (.not. allocated(state%u_wind))      allocate(state%u_wind(ncrms,crm_nx,crm_ny,crm_nz))
@@ -101,12 +98,9 @@ contains
 
    end subroutine crm_state_initialize
    !------------------------------------------------------------------------------------------------
-   subroutine crm_state_finalize(state)
-      use phys_control, only: phys_getopts
+   subroutine crm_state_finalize(state, MMF_microphysics_scheme)
       type(crm_state_type), intent(inout) :: state
-      character(len=16) :: MMF_microphysics_scheme    ! CRM microphysics scheme
-
-      call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
+      character(len=*), intent(in) :: MMF_microphysics_scheme    ! CRM microphysics scheme
 
       ! Nullify pointers
       if (allocated(state%u_wind))      deallocate(state%u_wind)

--- a/components/eam/src/physics/crm/crm_state_module.F90
+++ b/components/eam/src/physics/crm/crm_state_module.F90
@@ -52,9 +52,9 @@ contains
    subroutine crm_state_initialize(state,ncrms,crm_nx,crm_ny,crm_nz,MMF_microphysics_scheme)
       type(crm_state_type), intent(inout) :: state
       integer,              intent(in   ) :: ncrms, crm_nx, crm_ny, crm_nz
-      character(len=16),    intent(in   ) :: MMF_microphysics_scheme    ! CRM microphysics scheme
+      character(len=*),    intent(in   ) :: MMF_microphysics_scheme    ! CRM microphysics scheme
 
-      ! Nullify pointers
+      ! Allocate memory
       if (.not. allocated(state%u_wind))      allocate(state%u_wind(ncrms,crm_nx,crm_ny,crm_nz))
       if (.not. allocated(state%v_wind))      allocate(state%v_wind(ncrms,crm_nx,crm_ny,crm_nz))
       if (.not. allocated(state%w_wind))      allocate(state%w_wind(ncrms,crm_nx,crm_ny,crm_nz))
@@ -67,7 +67,7 @@ contains
       call prefetch(state%temperature)
       call prefetch(state%qt)
 
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (.not. allocated(state%qc))          allocate(state%qc(ncrms,crm_nx,crm_ny,crm_nz))
          if (.not. allocated(state%qi))          allocate(state%qi(ncrms,crm_nx,crm_ny,crm_nz))
          if (.not. allocated(state%qr))          allocate(state%qr(ncrms,crm_nx,crm_ny,crm_nz))
@@ -89,7 +89,7 @@ contains
          call prefetch(state%ns)
          call prefetch(state%ng)
       end if
-      if (MMF_microphysics_scheme .eq. 'sam1mom') then
+      if (trim(MMF_microphysics_scheme) .eq. 'sam1mom') then
          if (.not. allocated(state%qp))          allocate(state%qp(ncrms,crm_nx,crm_ny,crm_nz))
          if (.not. allocated(state%qn))          allocate(state%qn(ncrms,crm_nx,crm_ny,crm_nz))
          call prefetch(state%qp)
@@ -109,7 +109,7 @@ contains
       if (allocated(state%temperature)) deallocate(state%temperature)
       if (allocated(state%qt))          deallocate(state%qt)
 
-      if (MMF_microphysics_scheme .eq. 'm2005') then
+      if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (allocated(state%qc)) deallocate(state%qc)
          if (allocated(state%qi)) deallocate(state%qi)
          if (allocated(state%qr)) deallocate(state%qr)
@@ -121,7 +121,7 @@ contains
          if (allocated(state%ns)) deallocate(state%ns)
          if (allocated(state%ng)) deallocate(state%ng)
       end if
-      if (MMF_microphysics_scheme .eq. 'sam1mom') then
+      if (trim(MMF_microphysics_scheme) .eq. 'sam1mom') then
          if (allocated(state%qp)) deallocate(state%qp)
          if (allocated(state%qn)) deallocate(state%qn)
       end if

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -888,6 +888,7 @@ subroutine phys_final( phys_state, phys_tend, pbuf2d )
   use physics_buffer, only : physics_buffer_desc, pbuf_deallocate
   use chemistry,      only : chem_final
   use wv_saturation,  only : wv_sat_final
+  use crm_physics, only: crm_physics_final
   !----------------------------------------------------------------------- 
   ! Purpose: Finalization of physics package
   !-----------------------------------------------------------------------
@@ -912,6 +913,10 @@ subroutine phys_final( phys_state, phys_tend, pbuf2d )
   call t_startf ('wv_sat_final')
   call wv_sat_final
   call t_stopf ('wv_sat_final')
+
+  call t_startf ('crm_physics_final')
+  call crm_physics_final()
+  call t_stopf ('crm_physics_final')
 
   call t_startf ('print_cost_p')
   call print_cost_p

--- a/components/eam/src/physics/crm/samxx/pressure.cpp
+++ b/components/eam/src/physics/crm/samxx/pressure.cpp
@@ -49,21 +49,22 @@ void pressure() {
 
   #ifndef USE_ORIG_FFT
 
-    yakl::FFT<nx> fftx;
-    yakl::FFT<fftySize> ffty;
+    yakl::RealFFT1D<nx> fftx;
+    yakl::RealFFT1D<fftySize> ffty;
+    fftx.init(fftx.trig);
+    ffty.init(ffty.trig);
 
     // for (int k=0; k<nzslab; k++) {
     //  for (int j=0; j<ny; j++) {
     //      for (int icrm=0; icrm<ncrms; icrm++) {
     parallel_for( SimpleBounds<3>(nzslab,ny,ncrms) , YAKL_LAMBDA (int k, int j, int icrm) {
-      real ftmp[nx+2];
-      real tmp [nx];
+      SArray<real,1,nx+2> ftmp;
 
-      for (int i=0; i<nx ; i++) { ftmp[i] = f(k,j,i,icrm); }
+      for (int i=0; i<nx ; i++) { ftmp(i) = f(k,j,i,icrm); }
 
-      fftx.forward(ftmp, tmp);
+      fftx.forward(ftmp, fftx.trig, yakl::FFT_SCALE_ECMWF);
 
-      for (int i=0; i<nx2; i++) { f(k,j,i,icrm) = ftmp[i]; }
+      for (int i=0; i<nx2; i++) { f(k,j,i,icrm) = ftmp(i); }
     });
 
     if (RUN3D) {
@@ -72,14 +73,13 @@ void pressure() {
       //    for(int l=0; l<ny2; l++) {
       //      for (int icrm=0; icrm<ncrms; icrm++) {
       parallel_for( SimpleBounds<3>(nzslab,nx+1,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
-        real ftmp[ny+2];
-        real tmp [ny];
+        SArray<real,1,ny+2> ftmp;
 
-        for (int j=0; j<ny ; j++) { ftmp[j] = f(k,j,i,icrm); }
+        for (int j=0; j<ny ; j++) { ftmp(j) = f(k,j,i,icrm); }
 
-        ffty.forward(ftmp, tmp);
+        ffty.forward(ftmp, ffty.trig, yakl::FFT_SCALE_ECMWF);
 
-        for (int j=0; j<ny2; j++) { f(k,j,i,icrm) = ftmp[j]; }
+        for (int j=0; j<ny2; j++) { f(k,j,i,icrm) = ftmp(j); }
       });
     }
 
@@ -210,14 +210,13 @@ void pressure() {
       //   for (int i=0; i<nx+1; i++) {
       //     for (int icrm=0; icrm<ncrms; icrm++) {
       parallel_for( SimpleBounds<3>(nzslab,nx+1,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
-        real ftmp[ny+2];
-        real tmp [ny];
+        SArray<real,1,ny+2> ftmp;
         
-        for(int j=0; j<ny+2; j++) { ftmp[j] = f(k,j,i,icrm); }
+        for(int j=0; j<ny+2; j++) { ftmp(j) = f(k,j,i,icrm); }
 
-        ffty.inverse(ftmp,tmp);
+        ffty.inverse(ftmp, ffty.trig, yakl::FFT_SCALE_ECMWF);
 
-        for(int j=0; j<ny  ; j++) { f(k,j,i,icrm) = ftmp[j]; } 
+        for(int j=0; j<ny  ; j++) { f(k,j,i,icrm) = ftmp(j); } 
       });
     }
 
@@ -225,14 +224,13 @@ void pressure() {
     //   for (int j=0; i<ny; i++) {
     //     for (int icrm=0; icrm<ncrms; icrm++) {
     parallel_for( SimpleBounds<3>(nzslab,ny,ncrms) , YAKL_LAMBDA (int k, int j, int icrm) {
-      real ftmp[nx+2];
-      real tmp [nx];
+      SArray<real,1,nx+2> ftmp;
 
-      for(int i=0; i<nx+2; i++) { ftmp[i] = f(k,j,i,icrm); }
+      for(int i=0; i<nx+2; i++) { ftmp(i) = f(k,j,i,icrm); }
 
-      fftx.inverse(ftmp,tmp);
+      fftx.inverse(ftmp, fftx.trig, yakl::FFT_SCALE_ECMWF);
 
-      for(int i=0; i<nx  ; i++) { f(k,j,i,icrm) = ftmp[i]; }
+      for(int i=0; i<nx  ; i++) { f(k,j,i,icrm) = ftmp(i); }
     });
 
   #else

--- a/components/eam/src/physics/crm/samxx/test/cpp2d/CMakeLists.txt
+++ b/components/eam/src/physics/crm/samxx/test/cpp2d/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(cpp2d ../dmdf.F90 ../cpp_driver.F90
                ../../../crm_output_module.F90
                ../../../crm_rad_module.F90
                ../../../crm_state_module.F90
+               ../../../crm_ecpp_output_module.F90
+               ../../../ecppvars.F90
                ../../../openacc_utils.F90
                ${CPP_SRC})
 target_link_libraries(cpp2d yakl ${NCFLAGS})

--- a/components/eam/src/physics/crm/samxx/test/cpp3d/CMakeLists.txt
+++ b/components/eam/src/physics/crm/samxx/test/cpp3d/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(cpp3d ../dmdf.F90 ../cpp_driver.F90
                ../../../crm_output_module.F90
                ../../../crm_rad_module.F90
                ../../../crm_state_module.F90
+               ../../../crm_ecpp_output_module.F90
+               ../../../ecppvars.F90
                ../../../openacc_utils.F90
                ${CPP_SRC})
 target_link_libraries(cpp3d yakl ${NCFLAGS})

--- a/components/eam/src/physics/crm/samxx/test/cpp_driver.F90
+++ b/components/eam/src/physics/crm/samxx/test/cpp_driver.F90
@@ -62,6 +62,7 @@ program driver
 
   logical(c_bool):: use_MMF_VT      ! flag for MMF variance transport
   integer        :: MMF_VT_wn_max   ! wavenumber cutoff for filtered variance transport
+  character(len=7) :: microphysics_scheme = 'sam1mom'
 
 #if HAVE_MPI
   call mpi_init(ierr)
@@ -88,8 +89,8 @@ program driver
   endif
 
   ! Allocate model data
-  call crm_input%initialize (           ncrms,plev)
-  call crm_output_initialize(crm_output,ncrms,plev)
+  call crm_input_initialize (crm_input, ncrms,plev,microphysics_scheme)
+  call crm_output_initialize(crm_output,ncrms,plev,crm_nx,crm_ny,crm_nz,trim(microphysics_scheme))
   ! These are normally allocated by pbuf, so we have to do it explicitly
   allocate( crm_state%u_wind     (ncrms,crm_nx,crm_ny,crm_nz) )
   allocate( crm_state%v_wind     (ncrms,crm_nx,crm_ny,crm_nz) )

--- a/components/eam/src/physics/crm/samxx/test/cpp_driver.F90
+++ b/components/eam/src/physics/crm/samxx/test/cpp_driver.F90
@@ -89,22 +89,12 @@ program driver
   endif
 
   ! Allocate model data
-  call crm_input_initialize (crm_input, ncrms,plev,microphysics_scheme)
-  call crm_output_initialize(crm_output,ncrms,plev,crm_nx,crm_ny,crm_nz,trim(microphysics_scheme))
+  call crm_state_initialize(crm_state  , ncrms, crm_nx, crm_ny, crm_nz, trim(microphysics_scheme))
+  call crm_rad_initialize  (crm_rad    , ncrms, crm_nx_rad, crm_ny_rad, crm_nz, trim(microphysics_scheme))
+  call crm_input_initialize(crm_input  , ncrms, plev, trim(microphysics_scheme))
+  call crm_output_initialize(crm_output, ncrms, plev, crm_nx, crm_ny, crm_nz, trim(microphysics_scheme))
+
   ! These are normally allocated by pbuf, so we have to do it explicitly
-  allocate( crm_state%u_wind     (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%v_wind     (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%w_wind     (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%temperature(ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%qt         (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%qp         (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%qn         (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_rad%qrad         (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%temperature  (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%qv           (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%qc           (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%qi           (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%cld          (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
   allocate( lat0                 (ncrms) )
   allocate( long0                (ncrms) )
   allocate( dt_gl                (ncrms) )

--- a/components/eam/src/physics/crm/samxx/test/fortran2d/CMakeLists.txt
+++ b/components/eam/src/physics/crm/samxx/test/fortran2d/CMakeLists.txt
@@ -7,6 +7,8 @@ add_executable(fortran2d ../shr_const_mod.F90 ../perf_mod.F90 ../fortran_driver.
                ../../../crm_output_module.F90
                ../../../crm_rad_module.F90
                ../../../crm_state_module.F90
+               ../../../crm_ecpp_output_module.F90
+               ../../../ecppvars.F90
                ../../../openacc_utils.F90
                ${FORTRAN_SRC})
 target_link_libraries(fortran2d ${NCFLAGS})

--- a/components/eam/src/physics/crm/samxx/test/fortran3d/CMakeLists.txt
+++ b/components/eam/src/physics/crm/samxx/test/fortran3d/CMakeLists.txt
@@ -7,6 +7,8 @@ add_executable(fortran3d ../shr_const_mod.F90 ../perf_mod.F90 ../fortran_driver.
                ../../../crm_output_module.F90
                ../../../crm_rad_module.F90
                ../../../crm_state_module.F90
+               ../../../crm_ecpp_output_module.F90
+               ../../../ecppvars.F90
                ../../../openacc_utils.F90
                ${FORTRAN_SRC})
 target_link_libraries(fortran3d ${NCFLAGS})

--- a/components/eam/src/physics/crm/samxx/test/fortran_driver.F90
+++ b/components/eam/src/physics/crm/samxx/test/fortran_driver.F90
@@ -58,6 +58,7 @@ program driver
 
   logical :: use_MMF_VT                    ! flag for MMF variance transport
   integer :: MMF_VT_wn_max                 ! wavenumber cutoff for filtered variance transport
+  character(len=7) :: microphysics_scheme = 'sam1mom'
 
 #if HAVE_MPI
   call mpi_init(ierr)
@@ -88,8 +89,8 @@ program driver
   endif
 
   ! Allocate model data
-  call crm_input%initialize (           ncrms,plev)
-  call crm_output_initialize(crm_output,ncrms,plev)
+  call crm_input_initialize (crm_input, ncrms,plev,trim(microphysics_scheme))
+  call crm_output_initialize(crm_output,ncrms,plev,crm_nx,crm_ny,crm_nz,trim(microphysics_scheme))
   ! These are normally allocated by pbuf, so we have to do it explicitly
   allocate( crm_state%u_wind     (ncrms,crm_nx,crm_ny,crm_nz) )
   allocate( crm_state%v_wind     (ncrms,crm_nx,crm_ny,crm_nz) )

--- a/components/eam/src/physics/crm/samxx/test/fortran_driver.F90
+++ b/components/eam/src/physics/crm/samxx/test/fortran_driver.F90
@@ -89,22 +89,12 @@ program driver
   endif
 
   ! Allocate model data
-  call crm_input_initialize (crm_input, ncrms,plev,trim(microphysics_scheme))
-  call crm_output_initialize(crm_output,ncrms,plev,crm_nx,crm_ny,crm_nz,trim(microphysics_scheme))
+  call crm_state_initialize (crm_state , ncrms, crm_nx, crm_ny, crm_nz, trim(microphysics_scheme))
+  call crm_rad_initialize   (crm_rad   , ncrms, crm_nx_rad, crm_ny_rad, crm_nz, trim(microphysics_scheme))
+  call crm_input_initialize (crm_input , ncrms, plev, trim(microphysics_scheme))
+  call crm_output_initialize(crm_output, ncrms, plev, crm_nx, crm_ny, crm_nz, trim(microphysics_scheme))
+
   ! These are normally allocated by pbuf, so we have to do it explicitly
-  allocate( crm_state%u_wind     (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%v_wind     (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%w_wind     (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%temperature(ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%qt         (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%qp         (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_state%qn         (ncrms,crm_nx,crm_ny,crm_nz) )
-  allocate( crm_rad%qrad         (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%temperature  (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%qv           (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%qc           (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%qi           (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
-  allocate( crm_rad%cld          (ncrms,crm_nx_rad,crm_ny_rad,crm_nz) )
   allocate( lat0                 (ncrms) )
   allocate( long0                (ncrms) )
   allocate( dt_gl                (ncrms) )
@@ -180,6 +170,7 @@ program driver
   call dmdf_read( crm_input%fluxq00          , fname_in , trim("in_fluxq00       ") , myTasks_beg , myTasks_end , .false. , .false. )
   call dmdf_read( crm_output%subcycle_factor   , fname_in , trim("out_subcycle_factor") , myTasks_beg , myTasks_end , .false. , .true.  )
 
+  print *, 'Reading crm_input...'
   do icrm = 1 , ncrms
     crm_input%zmid       (icrm,:)     = read_crm_input_zmid       (:    ,icrm)                       
     crm_input%zint       (icrm,:)     = read_crm_input_zint       (:    ,icrm)                       
@@ -192,6 +183,9 @@ program driver
     crm_input%pdel       (icrm,:)     = read_crm_input_pdel       (:    ,icrm)                       
     crm_input%ul         (icrm,:)     = read_crm_input_ul         (:    ,icrm)                       
     crm_input%vl         (icrm,:)     = read_crm_input_vl         (:    ,icrm)                       
+  enddo
+  print *, 'Reading crm_state...'
+  do icrm = 1 , ncrms
     crm_state%u_wind     (icrm,:,:,:) = read_crm_state_u_wind     (:,:,:,icrm) 
     crm_state%v_wind     (icrm,:,:,:) = read_crm_state_v_wind     (:,:,:,icrm) 
     crm_state%w_wind     (icrm,:,:,:) = read_crm_state_w_wind     (:,:,:,icrm) 
@@ -199,6 +193,9 @@ program driver
     crm_state%qt         (icrm,:,:,:) = read_crm_state_qt         (:,:,:,icrm) 
     crm_state%qp         (icrm,:,:,:) = read_crm_state_qp         (:,:,:,icrm) 
     crm_state%qn         (icrm,:,:,:) = read_crm_state_qn         (:,:,:,icrm) 
+  enddo
+  print *, 'Reading crm_rad...'
+  do icrm = 1 , ncrms
     crm_rad%qrad         (icrm,:,:,:) = read_crm_rad_qrad         (:,:,:,icrm) 
     crm_rad%temperature  (icrm,:,:,:) = read_crm_rad_temperature  (:,:,:,icrm) 
     crm_rad%qv           (icrm,:,:,:) = read_crm_rad_qv           (:,:,:,icrm) 


### PR DESCRIPTION
Update SAMXX code to work with the new FFT interface in the latest YAKL. Also updates YAKL to the latest version, which is needed for the RRTMGPXX port. The new FFT calculation is non-BFB, but differences appear to be near machine precision. Also fixes the SAMXX standalone driver to work with changes implemented in #4301.

[non-BFB] (only for F-MMFXX test)