### PR TITLE
Updating Scorpio to 1.2.1

### DIFF
--- a/cime/src/drivers/mct/cime_config/config_component.xml
+++ b/cime/src/drivers/mct/cime_config/config_component.xml
@@ -2072,7 +2072,7 @@
 
   <entry id="PIO_VERSION">
     <type>integer</type>
-    <default_value>1</default_value>
+    <default_value>2</default_value>
     <valid_values>1,2</valid_values>
     <group>build_macros</group>
     <file>env_build.xml</file>


### PR DESCRIPTION
Updating Scorpio from v1.0.1 to v1.2.1 and changing
the default I/O library to Scorpio (PIO_VERSION=2)

Scorpio v1.2.1 includes the following changes after
v1.0.1,

* Scorpio I/O performance statistics
* Performance improvments for the data rearrangers
* Multiple fixes and performance enhancements for
  ADIOS (including the ADIOS to NetCDF converter)
* Updates to use MPI_Isends() by default (instead
  of MPI_Irsends)
* Fixes for standalone HOMME
* Fixes for E3SM ultra high resolution simulations
* Misc bug fixes

Fixes #4174 

[BFB]