### PR TITLE
Enable ieflx_opt=3 for water temperature heat flux from ocean

### DIFF
--- a/components/eam/src/control/camsrfexch.F90
+++ b/components/eam/src/control/camsrfexch.F90
@@ -94,6 +94,7 @@ module camsrfexch
      real(r8), allocatable :: lwup(:)       ! longwave up radiative flux
      real(r8), allocatable :: lhf(:)        ! latent heat flux
      real(r8), allocatable :: shf(:)        ! sensible heat flux
+     real(r8), allocatable :: h2otemp(:)    ! water temperature heat flux from ocean
      real(r8), allocatable :: wsx(:)        ! surface u-stress (N)
      real(r8), allocatable :: wsy(:)        ! surface v-stress (N)
      real(r8), allocatable :: tref(:)       ! ref height surface air temp
@@ -196,6 +197,9 @@ CONTAINS
        allocate (cam_in(c)%shf(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error shf')
 
+       allocate (cam_in(c)%h2otemp(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error h2otemp')
+
        allocate (cam_in(c)%wsx(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsx')
 
@@ -294,6 +298,7 @@ CONTAINS
        cam_in(c)%lwup     (:) = 0._r8
        cam_in(c)%lhf      (:) = 0._r8
        cam_in(c)%shf      (:) = 0._r8
+       cam_in(c)%h2otemp  (:) = 0._r8
        cam_in(c)%wsx      (:) = 0._r8
        cam_in(c)%wsy      (:) = 0._r8
        cam_in(c)%tref     (:) = 0._r8
@@ -582,6 +587,7 @@ CONTAINS
           deallocate(cam_in(c)%lwup)
           deallocate(cam_in(c)%lhf)
           deallocate(cam_in(c)%shf)
+          deallocate(cam_in(c)%h2otemp)
           deallocate(cam_in(c)%wsx)
           deallocate(cam_in(c)%wsy)
           deallocate(cam_in(c)%tref)

--- a/components/eam/src/cpl/atm_import_export.F90
+++ b/components/eam/src/cpl/atm_import_export.F90
@@ -67,6 +67,11 @@ contains
              cam_in(c)%cflx(i,1) = -x2a(index_x2a_Faxx_evap,ig)                
              cam_in(c)%lhf(i)    = -x2a(index_x2a_Faxx_lat, ig)     
           endif
+
+          if (index_x2a_Faoo_h2otemp /= 0) then
+             cam_in(c)%h2otemp(i) = -x2a(index_x2a_Faoo_h2otemp,ig)
+          end if
+           
           cam_in(c)%wsx(i)    = -x2a(index_x2a_Faxx_taux,ig)     
           cam_in(c)%wsy(i)    = -x2a(index_x2a_Faxx_tauy,ig)     
           cam_in(c)%lwup(i)      = -x2a(index_x2a_Faxx_lwup,ig)    
@@ -83,7 +88,7 @@ contains
           cam_in(c)%u10(i)       =  x2a(index_x2a_Sx_u10,   ig)
           cam_in(c)%icefrac(i)   =  x2a(index_x2a_Sf_ifrac, ig)  
           cam_in(c)%ocnfrac(i)   =  x2a(index_x2a_Sf_ofrac, ig)
-	  cam_in(c)%landfrac(i)  =  x2a(index_x2a_Sf_lfrac, ig)
+          cam_in(c)%landfrac(i)  =  x2a(index_x2a_Sf_lfrac, ig)
           if ( associated(cam_in(c)%ram1) ) &
                cam_in(c)%ram1(i) =  x2a(index_x2a_Sl_ram1 , ig)
           if ( associated(cam_in(c)%fv) ) &

--- a/components/eam/src/cpl/cam_cpl_indices.F90
+++ b/components/eam/src/cpl/cam_cpl_indices.F90
@@ -76,6 +76,7 @@ module cam_cpl_indices
   integer :: index_x2a_Fall_fco2_lnd   ! co2 flux from land   
   integer :: index_x2a_Faoo_fco2_ocn   ! co2 flux from ocean  
   integer :: index_x2a_Faoo_fdms_ocn   ! dms flux from ocean
+  integer :: index_x2a_Faoo_h2otemp    ! water temperature heat flux from ocean  
   integer :: index_x2a_So_ustar	       ! surface friction velocity in ocean
   integer :: index_x2a_So_re           ! square of atm/ocn exch. coeff 
   integer :: index_x2a_So_ssq          ! surface saturation specific humidity in ocean 
@@ -135,6 +136,7 @@ contains
     index_x2a_Fall_fco2_lnd = mct_avect_indexra(x2a,'Fall_fco2_lnd',perrWith='quiet')
     index_x2a_Faoo_fco2_ocn = mct_avect_indexra(x2a,'Faoo_fco2_ocn',perrWith='quiet')
     index_x2a_Faoo_fdms_ocn = mct_avect_indexra(x2a,'Faoo_fdms_ocn',perrWith='quiet')
+    index_x2a_Faoo_h2otemp  = mct_avect_indexra(x2a,'Faoo_h2otemp',perrWith='quiet')
 
     if (shr_megan_mechcomps_n>0) then
        index_x2a_Fall_flxvoc = mct_avect_indexra(x2a,trim(shr_megan_fields_token))

--- a/components/eam/src/physics/cam/check_energy.F90
+++ b/components/eam/src/physics/cam/check_energy.F90
@@ -702,6 +702,8 @@ subroutine ieflx_gmean(state, tend, pbuf2d, cam_in, cam_out, nstep)
        case(2) 
           ienet(:ncol,lchnk) = cpsw * qflx(:ncol,lchnk) * cam_in(lchnk)%ts(:ncol) - & 
                                cpsw * rhow * ( rain(:ncol,lchnk) + snow(:ncol,lchnk) ) * cam_in(lchnk)%ts(:ncol)
+       case(3) 
+          ienet(:ncol,lchnk) = cam_in(lchnk)%h2otemp(:ncol)
        case default 
           call endrun('*** incorrect ieflx_opt ***')
        end select 

--- a/components/eam/src/physics/crm/camsrfexch.F90
+++ b/components/eam/src/physics/crm/camsrfexch.F90
@@ -119,6 +119,7 @@ module camsrfexch
      real(r8), allocatable :: lwup(:,:)       ! longwave up radiative flux
      real(r8), allocatable :: lhf(:,:)        ! latent heat flux
      real(r8), allocatable :: shf(:,:)        ! sensible heat flux
+     real(r8), allocatable :: h2otemp(:,:)    ! water temperature heat flux from ocean
      real(r8), allocatable :: wsx(:,:)        ! surface u-stress (N)
      real(r8), allocatable :: wsy(:,:)        ! surface v-stress (N)
      real(r8), allocatable :: snowhland(:,:)  ! snow depth (liquid water equivalent) over land
@@ -131,6 +132,7 @@ module camsrfexch
      real(r8), allocatable :: lwup(:)         ! longwave up radiative flux
      real(r8), allocatable :: lhf(:)          ! latent heat flux
      real(r8), allocatable :: shf(:)          ! sensible heat flux
+     real(r8), allocatable :: h2otemp(:)      ! water temperature heat flux from ocean
      real(r8), allocatable :: wsx(:)          ! surface u-stress (N)
      real(r8), allocatable :: wsy(:)          ! surface v-stress (N)
      real(r8), allocatable :: snowhland(:)    ! snow depth (liquid water equivalent) over land
@@ -236,6 +238,9 @@ CONTAINS
        allocate (cam_in(c)%shf(pcols,num_inst_atm), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error shf')
 
+       allocate (cam_in(c)%h2otemp(pcols,num_inst_atm), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error h2otemp')
+
        allocate (cam_in(c)%wsx(pcols,num_inst_atm), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsx')
 
@@ -265,6 +270,9 @@ CONTAINS
 
        allocate (cam_in(c)%shf(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error shf')
+
+       allocate (cam_in(c)%h2otemp(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error h2otemp')
 
        allocate (cam_in(c)%wsx(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsx')
@@ -366,6 +374,7 @@ CONTAINS
        cam_in(c)%lwup     (:,:) = 0._r8
        cam_in(c)%lhf      (:,:) = 0._r8
        cam_in(c)%shf      (:,:) = 0._r8
+       cam_in(c)%h2otemp  (:,:) = 0._r8
        cam_in(c)%wsx      (:,:) = 0._r8
        cam_in(c)%wsy      (:,:) = 0._r8
        cam_in(c)%snowhland(:,:) = 0._r8
@@ -377,6 +386,7 @@ CONTAINS
        cam_in(c)%lwup     (:) = 0._r8
        cam_in(c)%lhf      (:) = 0._r8
        cam_in(c)%shf      (:) = 0._r8
+       cam_in(c)%h2otemp  (:) = 0._r8
        cam_in(c)%wsx      (:) = 0._r8
        cam_in(c)%wsy      (:) = 0._r8
        cam_in(c)%snowhland(:) = 0._r8
@@ -744,6 +754,7 @@ CONTAINS
           deallocate(cam_in(c)%lwup)
           deallocate(cam_in(c)%lhf)
           deallocate(cam_in(c)%shf)
+          deallocate(cam_in(c)%h2otemp)
           deallocate(cam_in(c)%wsx)
           deallocate(cam_in(c)%wsy)
           deallocate(cam_in(c)%tref)

--- a/components/eam/src/physics/crm/camsrfexch.F90
+++ b/components/eam/src/physics/crm/camsrfexch.F90
@@ -119,7 +119,6 @@ module camsrfexch
      real(r8), allocatable :: lwup(:,:)       ! longwave up radiative flux
      real(r8), allocatable :: lhf(:,:)        ! latent heat flux
      real(r8), allocatable :: shf(:,:)        ! sensible heat flux
-     real(r8), allocatable :: h2otemp(:,:)    ! water temperature heat flux from ocean
      real(r8), allocatable :: wsx(:,:)        ! surface u-stress (N)
      real(r8), allocatable :: wsy(:,:)        ! surface v-stress (N)
      real(r8), allocatable :: snowhland(:,:)  ! snow depth (liquid water equivalent) over land
@@ -132,7 +131,6 @@ module camsrfexch
      real(r8), allocatable :: lwup(:)         ! longwave up radiative flux
      real(r8), allocatable :: lhf(:)          ! latent heat flux
      real(r8), allocatable :: shf(:)          ! sensible heat flux
-     real(r8), allocatable :: h2otemp(:)      ! water temperature heat flux from ocean
      real(r8), allocatable :: wsx(:)          ! surface u-stress (N)
      real(r8), allocatable :: wsy(:)          ! surface v-stress (N)
      real(r8), allocatable :: snowhland(:)    ! snow depth (liquid water equivalent) over land
@@ -238,9 +236,6 @@ CONTAINS
        allocate (cam_in(c)%shf(pcols,num_inst_atm), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error shf')
 
-       allocate (cam_in(c)%h2otemp(pcols,num_inst_atm), stat=ierror)
-       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error h2otemp')
-
        allocate (cam_in(c)%wsx(pcols,num_inst_atm), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsx')
 
@@ -270,9 +265,6 @@ CONTAINS
 
        allocate (cam_in(c)%shf(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error shf')
-
-       allocate (cam_in(c)%h2otemp(pcols), stat=ierror)
-       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error h2otemp')
 
        allocate (cam_in(c)%wsx(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error wsx')
@@ -374,7 +366,6 @@ CONTAINS
        cam_in(c)%lwup     (:,:) = 0._r8
        cam_in(c)%lhf      (:,:) = 0._r8
        cam_in(c)%shf      (:,:) = 0._r8
-       cam_in(c)%h2otemp  (:,:) = 0._r8
        cam_in(c)%wsx      (:,:) = 0._r8
        cam_in(c)%wsy      (:,:) = 0._r8
        cam_in(c)%snowhland(:,:) = 0._r8
@@ -386,7 +377,6 @@ CONTAINS
        cam_in(c)%lwup     (:) = 0._r8
        cam_in(c)%lhf      (:) = 0._r8
        cam_in(c)%shf      (:) = 0._r8
-       cam_in(c)%h2otemp  (:) = 0._r8
        cam_in(c)%wsx      (:) = 0._r8
        cam_in(c)%wsy      (:) = 0._r8
        cam_in(c)%snowhland(:) = 0._r8
@@ -754,7 +744,6 @@ CONTAINS
           deallocate(cam_in(c)%lwup)
           deallocate(cam_in(c)%lhf)
           deallocate(cam_in(c)%shf)
-          deallocate(cam_in(c)%h2otemp)
           deallocate(cam_in(c)%wsx)
           deallocate(cam_in(c)%wsy)
           deallocate(cam_in(c)%tref)


### PR DESCRIPTION
Internal energy carried by precipitation is accounted for in the ocean,
but not in the atmosphere. This implementation provides the option to
distribute globally uniformly the apparent heat flux from the ocean due
to the disparity in treating precipitation water temperature.

[BFB] for existing F and B configurations, i.e., ieflx=0 or 2.