### PR TITLE
Adding 'CRYO1850' compset

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -316,14 +316,12 @@
   <lname>20TR_EAM%CMIP6_ELM%CNPECACNTBC_MPASSI%BGC_MPASO%OIECOOIDMS_MOSART_SGLC_SWAV_BGC%BDRD</lname>
 </compset>
 
-<!-- E3SM v2 cryosphere compsets -->
+<!-- E3SM cryosphere compsets -->
 
 <compset>
   <alias>CRYO1850</alias>
   <lname>1850SOI_EAM%CMIP6_ELM%SPBC_MPASSI%DIB_MPASO%IBISMF_MOSART_SGLC_SWAV</lname>
 </compset>
-
-<!-- E3SM v1 cryosphere compsets -->
 
 <compset>
   <alias>A_WCYCL1850-DIB</alias>

--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -316,12 +316,14 @@
   <lname>20TR_EAM%CMIP6_ELM%CNPECACNTBC_MPASSI%BGC_MPASO%OIECOOIDMS_MOSART_SGLC_SWAV_BGC%BDRD</lname>
 </compset>
 
-<!-- E3SM v1 cryosphere compsets -->
+<!-- E3SM v2 cryosphere compsets -->
 
 <compset>
   <alias>CRYO1850</alias>
   <lname>1850SOI_EAM%CMIP6_ELM%SPBC_MPASSI%DIB_MPASO%IBISMF_MOSART_SGLC_SWAV</lname>
 </compset>
+
+<!-- E3SM v1 cryosphere compsets -->
 
 <compset>
   <alias>A_WCYCL1850-DIB</alias>

--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -319,6 +319,11 @@
 <!-- E3SM v1 cryosphere compsets -->
 
 <compset>
+  <alias>CRYO1850</alias>
+  <lname>1850SOI_EAM%CMIP6_ELM%SPBC_MPASSI%DIB_MPASO%IBISMF_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
   <alias>A_WCYCL1850-DIB</alias>
   <lname>1850_EAM%AV1C-L_ELM%SPBC_MPASSI%DIB_MPASO%IB_MOSART_SGLC_SWAV</lname>
 </compset>


### PR DESCRIPTION
Adds a new Cryosphere compset that is similar to `WCYCL1850`, except uses Cryosphere settings for Antarctic runoff (disables Antarctic runoff from the coupler to the ocn, includes ice-shelf melt fluxes and data icebergs). This compset points to spun-up ocn/ice initial conditions (restarts from a one month G-case).

[BFB] for all currently tested configurations.