### PR TITLE
Homme: Fix a missing return value.

### DIFF
--- a/components/homme/src/share/compose/compose_cedr.cpp
+++ b/components/homme/src/share/compose/compose_cedr.cpp
@@ -5136,8 +5136,8 @@ class QLT : public cedr::qlt::QLT<ES> {
 
   static Int solve (const Int nlev, const VerticalLevelsData& vld,
                     const Real& tot_mass) {
-    solve(nlev, vld.ones.data(), tot_mass, vld.lo.data(), vld.hi.data(),
-          vld.mass.data(), vld.wrk.data());    
+    return solve(nlev, vld.ones.data(), tot_mass, vld.lo.data(), vld.hi.data(),
+                 vld.mass.data(), vld.wrk.data());    
   }
 
   static Int solve_unittest () {


### PR DESCRIPTION
This is in a configuration unused in E3SM but tested in
standalone Homme tests.

Fixes SL tests in
    create_test HOMME_P24.f19_g16_rx1.A --compiler gnu --machine mappy

[BFB]