### PR TITLE
add code to compute NH pressure at interfaces

### DIFF
--- a/components/homme/src/theta-l/share/element_ops.F90
+++ b/components/homme/src/theta-l/share/element_ops.F90
@@ -156,6 +156,8 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
       field = elem%state%phinh_i(:,:,1:nlevp,nt)
     case('mu_i');
       call get_dpnh_dp_i(elem,field,hvcoord,nt)
+    case('pnh_i');
+      call get_nonhydro_pressure_i(elem,field,hvcoord,nt)
     case default
       print *,'name = ',trim(name)
       call abortmp('ERROR: get_field_i name not supported in this model')
@@ -308,7 +310,25 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
     call pnh_and_exner_from_eos(hvcoord,elem%state%vtheta_dp(:,:,:,nt),&
          elem%state%dp3d(:,:,:,nt),elem%state%phinh_i(:,:,:,nt),&
-         pnh,exner,dpnh_dp_i)
+         pnh,exner,dpnh_dp_i,caller="get_nonhydro_pressire")
+
+  end subroutine
+
+
+  subroutine get_nonhydro_pressure_i(elem,pnh_i,hvcoord,nt)
+    implicit none
+    
+    type (element_t),       intent(in)  :: elem
+    real (kind=real_kind),  intent(out) :: pnh_i(np,np,nlevp)
+    type (hvcoord_t),       intent(in)  :: hvcoord
+    integer,                intent(in)  :: nt
+    
+    real (kind=real_kind), dimension(np,np,nlevp) :: dpnh_dp_i
+    real (kind=real_kind), dimension(np,np,nlev) :: pnh,exner
+
+    call pnh_and_exner_from_eos(hvcoord,elem%state%vtheta_dp(:,:,:,nt),&
+         elem%state%dp3d(:,:,:,nt),elem%state%phinh_i(:,:,:,nt),&
+         pnh,exner,dpnh_dp_i,pnh_i,"get_nonhydro_pressure_i")
 
   end subroutine
 

--- a/components/homme/src/theta-l/share/eos.F90
+++ b/components/homme/src/theta-l/share/eos.F90
@@ -209,11 +209,17 @@ implicit none
    
 
    if (present(pnh_i_out)) then
-      ! boundary values already computed.  interior only:
+      ! boundary values already computed. interpolate interior
       do k=2,nlev
-         pnh_i(:,:,k)=(hvcoord%d_etam(k)*pnh(:,:,k)+hvcoord%d_etam(k-1)*pnh(:,:,k-1))/&
-              (hvcoord%d_etai(k)*2)
+         pnh_i(:,:,k)=(hvcoord%d_etam(k-1)*pnh(:,:,k)+hvcoord%d_etam(k)*pnh(:,:,k-1))/&
+              (hvcoord%d_etam(k-1)+hvcoord%d_etam(k))
       enddo
+#if 0
+      ! scan, to invert  pnh(k)= .5*(pnh_i(k+1)+pnh_i(k)), using ptop
+      do k=1,nlev
+         pnh_i(:,:,k+1)=2*pnh(:,:,k)-pnh_i(:,:,k)
+      enddo
+#endif
       pnh_i_out=pnh_i    
    endif
    

--- a/components/homme/src/theta-l/share/eos.F90
+++ b/components/homme/src/theta-l/share/eos.F90
@@ -210,16 +210,12 @@ implicit none
 
    if (present(pnh_i_out)) then
       ! boundary values already computed. interpolate interior
+      ! use linear interpolation in hydrostatic pressure coordinate
+      ! if pnh=pi, then pnh_i will recover pi_i
       do k=2,nlev
-         pnh_i(:,:,k)=(hvcoord%d_etam(k-1)*pnh(:,:,k)+hvcoord%d_etam(k)*pnh(:,:,k-1))/&
-              (hvcoord%d_etam(k-1)+hvcoord%d_etam(k))
+         pnh_i(:,:,k)=(dp3d(:,:,k-1)*pnh(:,:,k)+dp3d(:,:,k)*pnh(:,:,k-1))/&
+              (dp3d(:,:,k-1)+dp3d(:,:,k))
       enddo
-#if 0
-      ! scan, to invert  pnh(k)= .5*(pnh_i(k+1)+pnh_i(k)), using ptop
-      do k=1,nlev
-         pnh_i(:,:,k+1)=2*pnh(:,:,k)-pnh_i(:,:,k)
-      enddo
-#endif
       pnh_i_out=pnh_i    
    endif
    


### PR DESCRIPTION
add an interface to the dycore's nonhydrostatic pressure on layer interfaces

based on the analysis here:
https://acme-climate.atlassian.net/wiki/spaces/NGDNA/pages/2579530246/NH+surface+pressure

we do not change the current approach at the surface (using the mu=1 approximation), but this does switch from a cell average type algorithm to more accurate interpolation for the interior interface values.

[BFB] since this is a diagnostic not currently used