### PR TITLE
MOSART-inundation restart fix and other minor bug fixes

### DIFF
--- a/components/elm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/elm/src/biogeophys/WaterBudgetMod.F90
@@ -35,8 +35,9 @@ module WaterBudgetMod
   integer, parameter :: f_evap = 3
   integer, parameter :: f_roff = 4
   integer, parameter :: f_ioff = 5
+  integer, parameter :: f_irri = 6
 
-  integer, parameter, public :: f_size = f_ioff
+  integer, parameter, public :: f_size = f_irri
 
   character(len=12),parameter :: fname(f_size) = &
        (/&
@@ -44,7 +45,8 @@ module WaterBudgetMod
        '        snow', &
        '        evap', &
        '      runoff', &
-       '      frzrof'  &
+       '      frzrof', &
+       '       irrig'  &
        /)
 
   !--- S for state ---
@@ -285,6 +287,7 @@ contains
     associate(                                                             &
          forc_rain          => atm2lnd_vars%forc_rain_not_downscaled_grc , &
          forc_snow          => atm2lnd_vars%forc_snow_not_downscaled_grc , &
+         qflx_irrig_supply  => atm2lnd_vars%supply_grc                   , &
          qflx_evap_tot      => lnd2atm_vars%qflx_evap_tot_grc            , &
          qflx_rofice        => lnd2atm_vars%qflx_rofice_grc              , &
          qflx_rofliq_qsur   => lnd2atm_vars%qflx_rofliq_qsur_grc         , &
@@ -327,6 +330,7 @@ contains
               - qflx_rofliq_qsub(g)*af - qflx_rofliq_qsubp(g)*af &
               - qflx_rofliq_qgwl(g)*af
          nf = f_ioff; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - qflx_rofice(g)*af
+         nf = f_irri; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) + qflx_irrig_supply(g)*af
 
          nf = s_w_beg     ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + begwb_grc(g)          *af
          nf = s_w_end     ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + endwb_grc(g)          *af

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -445,10 +445,10 @@ contains
             errMsg(__FILE__, __LINE__))
        end if
        
-       if (.not. use_crop .and. irrigate) then
-          call endrun(msg=' ERROR: irrigate = .true. requires CROP model active.'//&
-            errMsg(__FILE__, __LINE__))
-       end if
+       !if (.not. use_crop .and. irrigate) then
+       !   call endrun(msg=' ERROR: irrigate = .true. requires CROP model active.'//&
+       !     errMsg(__FILE__, __LINE__))
+       !end if
 
        if (.not. use_erosion .and. ero_ccycle) then
           call endrun(msg=' ERROR: ero_ccycle = .true. requires erosion model active.'//&

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -444,11 +444,6 @@ contains
           call endrun(msg=' ERROR: prognostic crop Patches require create_crop_landunit=.true.'//&
             errMsg(__FILE__, __LINE__))
        end if
-       
-       !if (.not. use_crop .and. irrigate) then
-       !   call endrun(msg=' ERROR: irrigate = .true. requires CROP model active.'//&
-       !     errMsg(__FILE__, __LINE__))
-       !end if
 
        if (.not. use_erosion .and. ero_ccycle) then
           call endrun(msg=' ERROR: ero_ccycle = .true. requires erosion model active.'//&

--- a/components/mosart/src/inundation/MOSARTinund_Core_MOD.F90
+++ b/components/mosart/src/inundation/MOSARTinund_Core_MOD.F90
@@ -411,7 +411,10 @@ MODULE MOSARTinund_Core_MOD
           TRunoff%wr_exchg( iu ) = TRunoff%wr( iu, 1 )
           TRunoff%yr_exchg( iu ) = TRunoff%yr( iu, 1 )
           TRunoff%wf_exchg( iu ) = TRunoff%wf_ini( iu )
-          TRunoff%hf_exchg( iu ) = TRunoff%hf_ini( iu )          
+          TRunoff%hf_exchg( iu ) = TRunoff%hf_ini( iu )
+          TRunoff%ff_fp( iu ) = TRunoff%ff_ini ( iu )
+          TRunoff%fa_fp( iu ) = TUnit%area(iu) * TUnit%frac(iu) * TRunoff%ff_fp(iu)
+          TRunoff%ff_unit( iu ) = TRunoff%ffunit_ini( iu )
           TRunoff%netchange( iu ) = 0._r8
         end if    ! if ( the channel water level is higher than the floodplain water level, or on the contrary )
       end if      ! if ( TUnit%mask( iu ) .gt. 0 )

--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -221,26 +221,6 @@ MODULE MOSART_physics_mod
        endif  ! euler_calc
        end do ! nt
        call t_stopf('mosartr_subnetwork')    
-
-        if (inundflag) then
-          ! Channel -- floodplain exchange computation :      
-          call ChnlFPexchg ( )
-            ! update variables after channel-floodplain exchanges
-            ! Floodplain water volume :
-              TRunoff%wf_ini = TRunoff%wf_exchg
-            ! Floodplain max water depth :
-              TRunoff%hf_ini = TRunoff%hf_exchg     
-            ! Floodplain area fraction (not including channel)
-              TRunoff%ff_ini = TRunoff%ff_fp
-            ! Flooded area fraction (including channel):
-              TRunoff%ffunit_ini = TRunoff%ff_unit
-            ! Channel water depth
-              TRunoff%yr(:,1) = TRunoff%yr_exchg
-            ! Channel storage
-              TRunoff%wr(:,1) = TRunoff%wr_exchg
-            ! Aggregate net floodplain storage change from subcycle to timestep 
-              TRunoff%se_rf = TRunoff%se_rf + TRunoff%netchange
-        end if
        !------------------
        ! upstream interactions
        !------------------
@@ -407,7 +387,26 @@ MODULE MOSART_physics_mod
 
        end do ! iunit
        endif  ! euler_calc
-       end do ! nt
+       end do ! nt       
+       if (inundflag) then
+            ! Channel -- floodplain exchange computation :      
+              call ChnlFPexchg ( )
+            ! update variables after channel-floodplain exchanges
+            ! Floodplain water volume :
+              TRunoff%wf_ini = TRunoff%wf_exchg
+            ! Floodplain max water depth :
+              TRunoff%hf_ini = TRunoff%hf_exchg     
+            ! Floodplain area fraction (not including channel) ! will be deleted
+              TRunoff%ff_ini = TRunoff%ff_fp
+            ! Flooded area fraction (including channel):
+              TRunoff%ffunit_ini = TRunoff%ff_unit
+            ! Channel water depth
+              TRunoff%yr(:,1) = TRunoff%yr_exchg
+            ! Channel storage
+              TRunoff%wr(:,1) = TRunoff%wr_exchg
+            ! Aggregate net floodplain storage change from subcycle to timestep 
+              TRunoff%se_rf = TRunoff%se_rf + TRunoff%netchange
+        end if                   
        negchan = min(negchan, minval(TRunoff%wr(:,:)))
        call t_stopf('mosartr_chanroute') 
     end do  ! DLevelH2R

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -1779,7 +1779,7 @@ contains
 !EOP
     integer  :: i, j, n, nr, ns, nt, n2, nf, idam ! indices
     integer, parameter :: budget_terms_total = 80
-    logical  :: output_all_budget_terms = .false.   ! output flag
+    logical  :: output_all_budget_terms = .true.   ! output flag
     real(r8) :: budget_terms (budget_terms_total,nt_rtm)    ! local budget sums
     real(r8) :: budget_global(budget_terms_total,nt_rtm)    ! global budget sums
 
@@ -2460,7 +2460,7 @@ contains
     ! BUDGET
     !-----------------------------------
 
-    budget_write = .false.
+    budget_write = .true.
     if (day == 1 .and. mon == 1) budget_write = .true.
     if (tod == 0) budget_write = .true.
 

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -1779,7 +1779,7 @@ contains
 !EOP
     integer  :: i, j, n, nr, ns, nt, n2, nf, idam ! indices
     integer, parameter :: budget_terms_total = 80
-    logical  :: output_all_budget_terms = .true.   ! output flag
+    logical  :: output_all_budget_terms = .false.   ! output flag
     real(r8) :: budget_terms (budget_terms_total,nt_rtm)    ! local budget sums
     real(r8) :: budget_global(budget_terms_total,nt_rtm)    ! global budget sums
 
@@ -1804,7 +1804,7 @@ contains
     ! budget_input = input
     ! budget_output = output
     ! budget_other = other terms
-    ! budget_total = budget_volume - budget_input + budget_output - budget_other
+    ! budget_total = budget_volume - budget_inpu/t + budget_output - budget_other
     ! bv_ generally accumulates a volume (m3)
     ! br_ generally accumulates a rate (m3/s)
 
@@ -2460,7 +2460,7 @@ contains
     ! BUDGET
     !-----------------------------------
 
-    budget_write = .true.
+    budget_write = .false.
     if (day == 1 .and. mon == 1) budget_write = .true.
     if (tod == 0) budget_write = .true.
 

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -1804,7 +1804,7 @@ contains
     ! budget_input = input
     ! budget_output = output
     ! budget_other = other terms
-    ! budget_total = budget_volume - budget_inpu/t + budget_output - budget_other
+    ! budget_total = budget_volume - budget_input + budget_output - budget_other
     ! bv_ generally accumulates a volume (m3)
     ! br_ generally accumulates a rate (m3/s)
 

--- a/components/mosart/src/riverroute/RtmRestFile.F90
+++ b/components/mosart/src/riverroute/RtmRestFile.F90
@@ -397,10 +397,10 @@ contains
     stormth_read = .true.
 
 if (wrmflag) then
-    nvmax = 10
+    nvmax = 18
 else
 
-    nvmax = 7
+    nvmax = 15
 endif
 
 
@@ -445,6 +445,50 @@ endif
           uname = 'm3/s'
           dfld  => rtmCTL%erout(:,nt)
        elseif (nv == 8 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'RTM_INUNDFFU_'//trim(rtm_tracers(nt))
+          lname = 'inundation area fraction include channel'
+          uname = 'no unit'
+          dfld  => rtmCTL%inundffunit(:)
+       elseif (nv == 9 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'RTM_INUNDWF_'//trim(rtm_tracers(nt))
+          lname = 'inundation fp water volume'
+          uname = 'm3'
+          dfld  => rtmCTL%inundwf(:)
+       elseif (nv == 10 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'RTM_INUNDHF_'//trim(rtm_tracers(nt))
+          lname = 'inundation fp water depth'
+          uname = 'm'
+          dfld  => rtmCTL%inundhf(:)
+       elseif (nv == 11 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'RTM_INUNDFF_'//trim(rtm_tracers(nt))
+          lname = 'inundation fp area fraction'
+          uname = 'no unit'
+          dfld  => rtmCTL%inundff(:)
+          
+          
+       elseif (nv == 12 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'RTM_MR_'//trim(rtm_tracers(nt))
+          lname = 'mr'
+          uname = 'no unit'
+          dfld  => rtmCTL%mr(:,nt)   
+       elseif (nv == 13 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'RTM_YR_'//trim(rtm_tracers(nt))
+          lname = 'yr'
+          uname = 'no unit'
+          dfld  => rtmCTL%yr(:,nt)   
+       elseif (nv == 14 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'RTM_PR_'//trim(rtm_tracers(nt))
+          lname = 'pr'
+          uname = 'no unit'
+          dfld  => rtmCTL%pr(:,nt)   
+       elseif (nv == 15 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'RTM_RR_'//trim(rtm_tracers(nt))
+          lname = 'rr'
+          uname = 'no unit'
+          dfld  => rtmCTL%rr(:,nt)
+
+          
+       elseif (nv == 16 .and. trim(rtm_tracers(nt)) == 'LIQ') then
           varok = .false.
           if (wrmflag) then
              varok = .true.
@@ -460,7 +504,7 @@ endif
              uname = 'm3'
              dfld  => StorWater%storageG(:)
           endif
-       elseif (nv == 9 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+       elseif (nv == 17 .and. trim(rtm_tracers(nt)) == 'LIQ') then
           varok = .false.
           if (wrmflag) then
              varok = .true.
@@ -476,7 +520,7 @@ endif
              uname = 'm3'
              dfld  => StorWater%releaseG(:)
           endif
-       elseif (nv == 10 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+       elseif (nv == 18 .and. trim(rtm_tracers(nt)) == 'LIQ') then
           varok = .false.
           if (wrmflag) then
              varok = .true.
@@ -536,6 +580,10 @@ endif
              if (abs(rtmCTL%wt(n,nt))      > 1.e30) rtmCTL%wt(n,nt) = 0.
              if (abs(rtmCTL%wr(n,nt))      > 1.e30) rtmCTL%wr(n,nt) = 0.
              if (abs(rtmCTL%erout(n,nt))   > 1.e30) rtmCTL%erout(n,nt) = 0.
+             if (abs(rtmCTL%inundffunit(n))> 1.e30) rtmCTL%inundffunit(n) = 0.
+             if (abs(rtmCTL%inundwf(n))    > 1.e30) rtmCTL%inundwf(n) = 0.
+             if (abs(rtmCTL%inundhf(n))    > 1.e30) rtmCTL%inundhf(n) = 0.
+             if (abs(rtmCTL%inundff(n))    > 1.e30) rtmCTL%inundff(n) = 0.
           end do  ! nt
 
           if (wrmflag) then

--- a/components/mosart/src/riverroute/RunoffMod.F90
+++ b/components/mosart/src/riverroute/RunoffMod.F90
@@ -72,12 +72,16 @@ module RunoffMod
      real(r8), pointer :: inundffunit(:)   ! Inundation  water volume (m3) 
      real(r8), pointer :: inundwf(:)       ! Inundation floodplain water volume (m3)
      real(r8), pointer :: inundhf(:)       ! Inundation floodplain water depth (m)
-     real(r8), pointer :: inundff(:)       ! Inundation floodplain water area fraction (no unit) added by Tian Dec 2017
+     real(r8), pointer :: inundff(:)       ! Inundation floodplain water area fraction (no unit)
 
      !    - restarts
      real(r8), pointer :: wh(:,:)          ! MOSART hillslope surface water storage (m)
      real(r8), pointer :: wt(:,:)          ! MOSART sub-network water storage (m3)
      real(r8), pointer :: wr(:,:)          ! MOSART main channel water storage (m3)
+     real(r8), pointer :: mr(:,:)          ! MOSART channel area
+     real(r8), pointer :: yr(:,:)          ! MOSART channel water depth
+     real(r8), pointer :: pr(:,:)          ! MOSART channel wetted p
+     real(r8), pointer :: rr(:,:)          ! MOSART channel hydraulic r
      real(r8), pointer :: erout(:,:)       ! MOSART flow out of the main channel, instantaneous (m3/s) (negative is out)
      real(r8), pointer :: Tqsur(:)         ! MOSART hillslope surface runoff water temperature (K)
      real(r8), pointer :: Tqsub(:)         ! MOSART hillslope subsurface runoff water temperature (K)
@@ -539,6 +543,10 @@ contains
              rtmCTL%wh(begr:endr,nt_rtm),         &
              rtmCTL%wt(begr:endr,nt_rtm),         &
              rtmCTL%wr(begr:endr,nt_rtm),         &
+             rtmCTL%mr(begr:endr,nt_rtm),         &
+             rtmCTL%yr(begr:endr,nt_rtm),         &
+             rtmCTL%pr(begr:endr,nt_rtm),         &
+             rtmCTL%rr(begr:endr,nt_rtm),         &
              rtmCTL%erout(begr:endr,nt_rtm),      &
              rtmCTL%qsur(begr:endr,nt_rtm),       & 
              rtmCTL%qsub(begr:endr,nt_rtm),       &

--- a/components/mosart/src/wrm/WRM_modules.F90
+++ b/components/mosart/src/wrm/WRM_modules.F90
@@ -355,7 +355,7 @@ MODULE WRM_modules
      call get_curr_date(yr, month, day, tod)
 
      do idam=1,ctlSubwWRM%LocalNumDam
-      if (WRMUnit%active_stage(idam) < 2) then
+      if (StorWater%active_stage(idam) < 2) then
          StorWater%release(idam) = 0._r8
        else
         !if ( WRMUnit%use_FCon(idam) > 0 .or. WRMUnit%use_Supp(idam) > 0) then
@@ -428,7 +428,7 @@ MODULE WRM_modules
      character(len=*),parameter :: subname='(WRM_storage_targets)'
 
      call get_curr_date(yr, month, day, tod)
-   if (WRMUnit%active_stage(idam) == 2) then !only do this when dam is fully functional
+   if (StorWater%active_stage(idam) == 2) then !only do this when dam is fully functional
      do idam=1,ctlSubwWRM%LocalNumDam
 
         drop = 0
@@ -627,7 +627,7 @@ MODULE WRM_modules
      endif
 
      !print*, "preregulation", damID, StorWater%storage(damID), flow_vol, flow_res, min_flow, month
-    if (WRMUnit%active_stage(damID) == 2) then
+    if (StorWater%active_stage(damID) == 2) then
      if ( ( flow_vol + StorWater%storage(damID) - flow_res- evap) >= max_stor ) then
         flow_res =  flow_vol + StorWater%storage(damID) - max_stor - evap
         StorWater%storage(damID) = max_stor
@@ -651,7 +651,7 @@ MODULE WRM_modules
      else
         StorWater%storage(damID) = StorWater%storage(damID) + flow_vol - flow_res - evap 
      end if
-   elseif (WRMUnit%active_stage(damID) == 1) then
+   elseif (StorWater%active_stage(damID) == 1) then
      if (flow_vol < min_flow * 2._r8) then
          flow_res = flow_vol
       else

--- a/components/mosart/src/wrm/WRM_subw_IO_mod.F90
+++ b/components/mosart/src/wrm/WRM_subw_IO_mod.F90
@@ -558,6 +558,8 @@ MODULE WRM_subw_IO_mod
      StorWater%releaseG=0._r8
      allocate (WRMUnit%StorMthStOpG(begr:endr))
      WRMUnit%StorMthStOpG = 0
+     allocate (StorWater%active_stageG(begr:endr))
+     StorWater%active_stageG=0
 
      allocate (StorWater%WithDemIrrig(begr:endr))
      StorWater%WithDemIrrig=0._r8

--- a/components/mosart/src/wrm/WRM_type_mod.F90
+++ b/components/mosart/src/wrm/WRM_type_mod.F90
@@ -79,7 +79,6 @@ MODULE WRM_type_mod
      real(r8), pointer :: MaxStorTarget(:)  ! (nd)
 
      integer , pointer :: YEAR(:)           ! (nd) year dam was constructed and operationnal
-     integer , pointer :: active_stage(:)   ! (nd) whether dam is not functional (before construction) or during filling (<10 yrs after built and <80% of capacity) or fully functional (10 yrs after built or >80% of capacity) 
      integer , pointer :: use_Irrig(:)      ! (nd) reservoir purpose irrigation 
      integer , pointer :: use_Elec(:)       ! (nd) hydropower
      integer , pointer :: use_FCon(:)       ! (nd) flood control
@@ -144,7 +143,6 @@ MODULE WRM_type_mod
 !constraints based on points of extractions along the maoin stem. Here ensure the release is the environmental flow.
 
      real(r8), pointer :: supply(:)         ! (b:e) supply of surface water [m3]
-	 !real(r8), pointer :: SupplyFrac(:)     ! (b:e) supply fraction relative to the demand ! Tian June 2018
      real(r8), pointer :: deficit(:)        ! (b:e) unmet demand [m3]
      real(r8), pointer :: demand(:)         ! (b:e) total withdrawl water demand [m3]
      real(r8), pointer :: demand0(:)        ! (b:e) baseline total withdrawl water rate demand [m3/s]
@@ -167,6 +165,7 @@ MODULE WRM_type_mod
      real(r8), pointer :: FCrelease (:)     ! (nd) Flood control release to get to storage target
      real(r8), pointer :: pot_evap(:)       ! (b:e) potential evaporation in mm from the grid
      real(r8), pointer :: Conveyance (:)    ! (nd) Conveyance loss flux
+     integer , pointer :: active_stage(:)   ! (nd) whether dam is not functional (before construction) or during filling (<10 yrs after built and <80% of capacity) or fully functional (10 yrs after built or >80% of capacity)
   end type WRMwater
 
   ! parameters to be calibrated. Ideally, these parameters are supposed to be uniform for one region

--- a/components/mosart/src/wrm/WRM_type_mod.F90
+++ b/components/mosart/src/wrm/WRM_type_mod.F90
@@ -166,6 +166,7 @@ MODULE WRM_type_mod
      real(r8), pointer :: pot_evap(:)       ! (b:e) potential evaporation in mm from the grid
      real(r8), pointer :: Conveyance (:)    ! (nd) Conveyance loss flux
      integer , pointer :: active_stage(:)   ! (nd) whether dam is not functional (before construction) or during filling (<10 yrs after built and <80% of capacity) or fully functional (10 yrs after built or >80% of capacity)
+     integer , pointer :: active_stageG(:)  ! (b:e) active_stage on gridcell
   end type WRMwater
 
   ! parameters to be calibrated. Ideally, these parameters are supposed to be uniform for one region


### PR DESCRIPTION
This PR consists of multiple bug fixes and improvements:
- Added variables relative to MOSART-inundation into MOSART restart file.
- Fixed a restart bug for MOSART-WM so that the model can generate BFB results when simulation is less than a month. 
- Fixed a bug for dam construction in MOSART-WM.
- Added irrigation term to ELM water budget report.
- Revert some changes in ELM to allow irrigation when crop model is off.

[non-BFB] only for SMS.MOS_USRDAT.RMOSGPCC._.mosart-unstructure