### PR TITLE
Add options to affect surface stress and gustiness calculations.

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -81,6 +81,9 @@ _TESTS = {
             "ERP_Ln7.ne30_ne30.FC5AV1C-L",
             "SMS_Ly1.ne4_ne4.FC5AV1C-L",
 	    "SMS_D_Ln5.ne45pg2_ne45pg2.F-EAM-AQP1",
+            "SMS_Ln5.ne4_ne4.FC5AV1C-L.eam-gust_export",
+            "SMS_D_Ln5.ne4_ne4.FC5AV1C-L.eam-implicit_stress",
+            "ERS_Ld5.ne30_ne30.FC5AV1C-L.eam-implicit_stress",
             )
         },
 

--- a/components/cice/src/drivers/cice4/CICE_RunMod.F90
+++ b/components/cice/src/drivers/cice4/CICE_RunMod.F90
@@ -415,6 +415,7 @@
                                    potT(:,:,iblk),                 &
                                    uatm(:,:,iblk), vatm(:,:,iblk), &
                                    wsresp(:,:,iblk),tau_est(:,:,iblk),&
+                                   ugust(:,:,iblk),                &
                                    wind(:,:,iblk), zlvl(:,:,iblk), &
                                    Qa  (:,:,iblk), rhoa(:,:,iblk), &
                                    strairxn,       strairyn,       &

--- a/components/cice/src/drivers/cice4/CICE_RunMod.F90
+++ b/components/cice/src/drivers/cice4/CICE_RunMod.F90
@@ -414,6 +414,7 @@
                                    trcrn(:,:,nt_Tsfc,n,iblk),      &
                                    potT(:,:,iblk),                 &
                                    uatm(:,:,iblk), vatm(:,:,iblk), &
+                                   wsresp(:,:,iblk),tau_est(:,:,iblk),&
                                    wind(:,:,iblk), zlvl(:,:,iblk), &
                                    Qa  (:,:,iblk), rhoa(:,:,iblk), &
                                    strairxn,       strairyn,       &

--- a/components/cice/src/drivers/cpl/CICE_RunMod.F90
+++ b/components/cice/src/drivers/cpl/CICE_RunMod.F90
@@ -310,6 +310,7 @@
                                         trcrn(:,:,nt_Tsfc,n,iblk),      &
                                         potT(:,:,iblk),                 &
                                         uatm(:,:,iblk), vatm(:,:,iblk), &
+                                        wsresp(:,:,iblk),tau_est(:,:,iblk),&
                                         uvel(:,:,iblk), vvel(:,:,iblk), &
                                         wind(:,:,iblk), zlvl(:,:,iblk), &
                                         Qa  (:,:,iblk), rhoa(:,:,iblk), &

--- a/components/cice/src/drivers/cpl/CICE_RunMod.F90
+++ b/components/cice/src/drivers/cpl/CICE_RunMod.F90
@@ -311,6 +311,7 @@
                                         potT(:,:,iblk),                 &
                                         uatm(:,:,iblk), vatm(:,:,iblk), &
                                         wsresp(:,:,iblk),tau_est(:,:,iblk),&
+                                        ugust(:,:,iblk),                &
                                         uvel(:,:,iblk), vvel(:,:,iblk), &
                                         wind(:,:,iblk), zlvl(:,:,iblk), &
                                         Qa  (:,:,iblk), rhoa(:,:,iblk), &

--- a/components/cice/src/drivers/cpl/ice_cpl_indices.F90
+++ b/components/cice/src/drivers/cpl/ice_cpl_indices.F90
@@ -45,6 +45,7 @@ module ice_cpl_indices
   integer :: index_x2i_Sa_v            ! bottom atm level mer wind
   integer :: index_x2i_Sa_wsresp       ! wind response to stress
   integer :: index_x2i_Sa_tau_est      ! estimated tau at equilibrium w/ wind
+  integer :: index_x2i_Sa_ugust        ! wind response to stress
   integer :: index_x2i_Sa_tbot         ! bottom atm level temp
   integer :: index_x2i_Sa_pbot         ! bottom atm level pressure
   integer :: index_x2i_Sa_ptem         ! bottom atm level pot temp
@@ -120,9 +121,9 @@ contains
     index_x2i_Sa_z          = mct_avect_indexra(x2i,'Sa_z')
     index_x2i_Sa_u          = mct_avect_indexra(x2i,'Sa_u')
     index_x2i_Sa_v          = mct_avect_indexra(x2i,'Sa_v')
-    ! These two variables are absent if the stress calculation is explicit.
     index_x2i_Sa_wsresp     = mct_avect_indexra(x2i,'Sa_wsresp', perrWith='quiet')
     index_x2i_Sa_tau_est    = mct_avect_indexra(x2i,'Sa_tau_est', perrWith='quiet')
+    index_x2i_Sa_ugust      = mct_avect_indexra(x2i,'Sa_ugust', perrWith='quiet')
     index_x2i_Sa_tbot       = mct_avect_indexra(x2i,'Sa_tbot')
     index_x2i_Sa_ptem       = mct_avect_indexra(x2i,'Sa_ptem')
     index_x2i_Sa_pbot       = mct_avect_indexra(x2i,'Sa_pbot')

--- a/components/cice/src/drivers/cpl/ice_cpl_indices.F90
+++ b/components/cice/src/drivers/cpl/ice_cpl_indices.F90
@@ -43,6 +43,8 @@ module ice_cpl_indices
   integer :: index_x2i_Sa_z            ! bottom atm level height
   integer :: index_x2i_Sa_u            ! bottom atm level zon wind
   integer :: index_x2i_Sa_v            ! bottom atm level mer wind
+  integer :: index_x2i_Sa_wsresp       ! wind response to stress
+  integer :: index_x2i_Sa_tau_est      ! estimated tau at equilibrium w/ wind
   integer :: index_x2i_Sa_tbot         ! bottom atm level temp
   integer :: index_x2i_Sa_pbot         ! bottom atm level pressure
   integer :: index_x2i_Sa_ptem         ! bottom atm level pot temp
@@ -118,6 +120,9 @@ contains
     index_x2i_Sa_z          = mct_avect_indexra(x2i,'Sa_z')
     index_x2i_Sa_u          = mct_avect_indexra(x2i,'Sa_u')
     index_x2i_Sa_v          = mct_avect_indexra(x2i,'Sa_v')
+    ! These two variables are absent if the stress calculation is explicit.
+    index_x2i_Sa_wsresp     = mct_avect_indexra(x2i,'Sa_wsresp', perrWith='quiet')
+    index_x2i_Sa_tau_est    = mct_avect_indexra(x2i,'Sa_tau_est', perrWith='quiet')
     index_x2i_Sa_tbot       = mct_avect_indexra(x2i,'Sa_tbot')
     index_x2i_Sa_ptem       = mct_avect_indexra(x2i,'Sa_ptem')
     index_x2i_Sa_pbot       = mct_avect_indexra(x2i,'Sa_pbot')

--- a/components/cice/src/drivers/cpl/ice_import_export.F90
+++ b/components/cice/src/drivers/cpl/ice_import_export.F90
@@ -43,7 +43,7 @@ contains
     integer     :: i, j, iblk, n
     integer     :: ilo, ihi, jlo, jhi !beginning and end of physical domain
     type(block) :: this_block         ! block information for current block
-    integer,parameter                :: nflds=15,nfldv=6
+    integer,parameter                :: nflds=17,nfldv=6
     real (kind=dbl_kind),allocatable :: aflds(:,:,:,:)
     real (kind=dbl_kind)             :: workx, worky
     logical (kind=log_kind)          :: first_call = .true.
@@ -91,7 +91,16 @@ contains
              aflds(i,j,13,iblk)   = x2i(index_x2i_Faxa_lwdn,n)
              aflds(i,j,14,iblk)   = x2i(index_x2i_Faxa_rain,n)
              aflds(i,j,15,iblk)   = x2i(index_x2i_Faxa_snow,n)
-
+             if (index_x2i_Sa_wsresp == 0) then
+                aflds(i,j,16,iblk) = 0._dbl_kind
+             else
+                aflds(i,j,16,iblk) = x2i(index_x2i_Sa_wsresp,n)
+             end if
+             if (index_x2i_Sa_tau_est == 0) then
+                aflds(i,j,17,iblk) = 0._dbl_kind
+             else
+                aflds(i,j,17,iblk) = x2i(index_x2i_Sa_tau_est,n)
+             end if
           enddo    !i
        enddo    !j
 

--- a/components/cice/src/drivers/cpl/ice_import_export.F90
+++ b/components/cice/src/drivers/cpl/ice_import_export.F90
@@ -43,7 +43,7 @@ contains
     integer     :: i, j, iblk, n
     integer     :: ilo, ihi, jlo, jhi !beginning and end of physical domain
     type(block) :: this_block         ! block information for current block
-    integer,parameter                :: nflds=17,nfldv=6
+    integer,parameter                :: nflds=18,nfldv=6
     real (kind=dbl_kind),allocatable :: aflds(:,:,:,:)
     real (kind=dbl_kind)             :: workx, worky
     logical (kind=log_kind)          :: first_call = .true.
@@ -100,6 +100,11 @@ contains
                 aflds(i,j,17,iblk) = 0._dbl_kind
              else
                 aflds(i,j,17,iblk) = x2i(index_x2i_Sa_tau_est,n)
+             end if
+             if (index_x2i_Sa_ugust == 0) then
+                aflds(i,j,18,iblk) = 0._dbl_kind
+             else
+                aflds(i,j,18,iblk) = x2i(index_x2i_Sa_ugust,n)
              end if
           enddo    !i
        enddo    !j

--- a/components/cice/src/source/ice_atmo.F90
+++ b/components/cice/src/source/ice_atmo.F90
@@ -53,6 +53,7 @@
                                       indxi,    indxj,    & 
                                       Tsf,      potT,     &
                                       uatm,     vatm,     &  
+                                      wsresp,   tau_est,  &
                                       uvel,     vvel,     &  
                                       wind,     zlvl,     &  
                                       Qa,       rhoa,     &
@@ -80,6 +81,9 @@
 !
 ! !USES:
 !
+#ifdef CCSMCOUPLED
+        use shr_flux_mod, only: shr_flux_update_stress
+#endif
 ! !INPUT/OUTPUT PARAMETERS:
 !
       integer (kind=int_kind), intent(in) :: &
@@ -98,6 +102,8 @@
          potT     , & ! air potential temperature  (K)
          uatm     , & ! x-direction wind speed (m/s)
          vatm     , & ! y-direction wind speed (m/s)
+         wsresp   , & ! response of atmospheric boundary layer to stress (m/s/Pa)
+         tau_est  , & ! estimated boundary layer equilibrium stress (Pa)
          uvel     , & ! x-direction ice speed (m/s)
          vvel     , & ! y-direction ice speed (m/s)
          wind     , & ! wind speed (m/s)
@@ -130,7 +136,7 @@
          TsfK  , & ! surface temperature in Kelvin (K)
          xqq   , & ! temporary variable
          psimh , & ! stability function at zlvl   (momentum)
-         tau   , & ! stress at zlvl
+         taufac, & ! factor limiting changes in tau during iteration
          fac   , & ! interpolation factor
          al2   , & ! ln(z10   /zTrf)
          psix2 , & ! stability function at zTrf   (heat and water)
@@ -152,6 +158,13 @@
          re    , & ! sqrt of exchange coefficient (water)
          rh    , & ! sqrt of exchange coefficient (heat)
          vmag  , & ! surface wind magnitude   (m/s)
+         vmagit, & ! iteration loop surface wind magnitude   (m/s)
+         wind0 , & ! original wind without limiter   (m/s)
+         windit, & ! iteration loop wind without limiter   (m/s)
+         tau   , & ! stress at zlvl (Pa)
+         taupr , & ! stress from previous iteration (Pa)
+         dtau  , & ! difference in stress vs previous iteration (Pa)
+         dtaupr, & ! difference in stress over previous iteration (Pa)
          alz   , & ! ln(zlvl  /z10)
          thva  , & ! virtual temperature      (K)
          cp    , & ! specific heat of moist air
@@ -215,9 +228,10 @@
          do ij = 1, icells
             i = indxi(ij)
             j = indxj(ij)
-            vmag(ij) = max(umin, wind(i,j))
+            wind0(ij) = max(wind(i,j), 0.01_dbl_kind)
+            vmag(ij) = max(umin, wind0(ij))
 !---------- (3b) option by Andrew Roberts
-!            vmag(ij)   = max(umin, sqrt( (uatm(i,j)-uvel(i,j))**2 + (vatm(i,j)-vvel(i,j))**2) )
+!            wind0(ij)   = sqrt( (uatm(i,j)-uvel(i,j))**2 + (vatm(i,j)-vvel(i,j))**2)
 !---------- (3b) option end
             rdn(ij)  = vonkar/log(zref/iceruf) ! neutral coefficient
          enddo   ! ij
@@ -230,9 +244,10 @@
          do ij = 1, icells
             i = indxi(ij)
             j = indxj(ij)
-            vmag(ij) = max(umin, wind(i,j))
+            wind0(ij) = max(wind(i,j), 0.01_dbl_kind)
+            vmag(ij) = max(umin, wind0(ij))
 !---------- (3b) option by Andrew Roberts
-!            vmag(ij)   = max(umin, sqrt( (uatm(i,j)-uvel(i,j))**2 + (vatm(i,j)-vvel(i,j))**2) )
+!            wind0(ij)   = sqrt( (uatm(i,j)-uvel(i,j))**2 + (vatm(i,j)-vvel(i,j))**2)
 !---------- (3b) option end
             rdn(ij)  = sqrt(0.0027_dbl_kind/vmag(ij) &
                     + .000142_dbl_kind + .0000764_dbl_kind*vmag(ij))
@@ -271,6 +286,12 @@
          tstar(ij) = rhn(ij) * delt(i,j)
          qstar(ij) = ren(ij) * delq(i,j)
 
+         ! Set up variables for velocity iteration.
+         vmagit(ij) = vmag(ij)
+         windit(ij) = wind0(ij)
+         taupr(ij) = tau_est(i,j)
+         dtau(ij) = 1.e100_dbl_kind
+
       enddo                     ! ij
 
       !------------------------------------------------------------
@@ -308,9 +329,16 @@
             re(ij) = ren(ij) / (c1+ren(ij)/vonkar*(alz(ij)-psixh(ij)))
 
         ! update ustar, tstar, qstar using updated, shifted coeffs
-            ustar(ij) = rd(ij) * vmag(ij)
+            ustar(ij) = rd(ij) * vmagit(ij)
             tstar(ij) = rh(ij) * delt(i,j)
             qstar(ij) = re(ij) * delq(i,j)
+
+#ifdef CCSMCOUPLED
+            tau(ij) = rhoa(i,j) * ustar(ij) * rd(ij) * windit(ij)
+            call shr_flux_update_stress(wind0(ij), wsresp(i,j), tau_est(i,j), &
+                 tau(ij), taupr(ij), dtau(ij), dtaupr(ij), windit(ij))
+            vmagit(ij) = max(umin, windit(ij))
+#endif
 
          enddo                  ! ij
       enddo                     ! end iteration
@@ -342,9 +370,9 @@
       ! stry = tau * vatm(i,j) / vmag
       !------------------------------------------------------------
 
-         tau = rhoa(i,j) * ustar(ij) * rd(ij) ! not the stress at zlvl(i,j)
-         strx(i,j) = tau * (uatm(i,j)-uvel(i,j))
-         stry(i,j) = tau * (vatm(i,j)-vvel(i,j))
+         tau(ij) = rhoa(i,j) * ustar(ij) * rd(ij) ! not the stress at zlvl(i,j)
+         strx(i,j) = tau(ij) * (uatm(i,j)-uvel(i,j)) * (windit(ij) / wind0(ij))
+         stry(i,j) = tau(ij) * (vatm(i,j)-vvel(i,j)) * (windit(ij) / wind0(ij))
 
       enddo                     ! ij
 

--- a/components/cice/src/source/ice_atmo.F90
+++ b/components/cice/src/source/ice_atmo.F90
@@ -54,6 +54,7 @@
                                       Tsf,      potT,     &
                                       uatm,     vatm,     &  
                                       wsresp,   tau_est,  &
+                                      ugust,              &
                                       uvel,     vvel,     &  
                                       wind,     zlvl,     &  
                                       Qa,       rhoa,     &
@@ -104,6 +105,7 @@
          vatm     , & ! y-direction wind speed (m/s)
          wsresp   , & ! response of atmospheric boundary layer to stress (m/s/Pa)
          tau_est  , & ! estimated boundary layer equilibrium stress (Pa)
+         ugust    , & ! gustiness from atmosphere (m/s)
          uvel     , & ! x-direction ice speed (m/s)
          vvel     , & ! y-direction ice speed (m/s)
          wind     , & ! wind speed (m/s)
@@ -229,7 +231,7 @@
             i = indxi(ij)
             j = indxj(ij)
             wind0(ij) = max(wind(i,j), 0.01_dbl_kind)
-            vmag(ij) = max(umin, wind0(ij))
+            vmag(ij) = max(umin, wind0(ij) + ugust(i,j))
 !---------- (3b) option by Andrew Roberts
 !            wind0(ij)   = sqrt( (uatm(i,j)-uvel(i,j))**2 + (vatm(i,j)-vvel(i,j))**2)
 !---------- (3b) option end
@@ -245,7 +247,7 @@
             i = indxi(ij)
             j = indxj(ij)
             wind0(ij) = max(wind(i,j), 0.01_dbl_kind)
-            vmag(ij) = max(umin, wind0(ij))
+            vmag(ij) = max(umin, wind0(ij) + ugust(i,j))
 !---------- (3b) option by Andrew Roberts
 !            wind0(ij)   = sqrt( (uatm(i,j)-uvel(i,j))**2 + (vatm(i,j)-vvel(i,j))**2)
 !---------- (3b) option end
@@ -337,7 +339,7 @@
             tau(ij) = rhoa(i,j) * ustar(ij) * rd(ij) * windit(ij)
             call shr_flux_update_stress(wind0(ij), wsresp(i,j), tau_est(i,j), &
                  tau(ij), taupr(ij), dtau(ij), dtaupr(ij), windit(ij))
-            vmagit(ij) = max(umin, windit(ij))
+            vmagit(ij) = max(umin, windit(ij) + ugust(i,j))
 #endif
 
          enddo                  ! ij

--- a/components/cice/src/source/ice_flux.F90
+++ b/components/cice/src/source/ice_flux.F90
@@ -125,7 +125,9 @@
          swvdf   , & ! sw down, visible, diffuse (W/m^2)
          swidr   , & ! sw down, near IR, direct  (W/m^2)
          swidf   , & ! sw down, near IR, diffuse (W/m^2)
-         flw         ! incoming longwave radiation (W/m^2)
+         flw     , & ! incoming longwave radiation (W/m^2)
+         wsresp  , & ! response of atmospheric boundary layer to wind (m/s/Pa)
+         tau_est     ! estimated stress at equilibrium with wind (Pa)
 
        ! in from atmosphere (if .not. Tsfc_calc)
        ! required for coupling to HadGEM3
@@ -390,6 +392,8 @@
       rhoa  (:,:,:) = 1.3_dbl_kind    ! air density (kg/m^3)
       uatm  (:,:,:) = c5              ! wind velocity    (m/s)
       vatm  (:,:,:) = c5
+      wsresp(:,:,:) = c0              ! response of wind to stress (m/s/Pa)
+      tau_est(:,:,:)= c0              ! stress in equilibrium with wind (Pa)
       strax (:,:,:) = 0.05_dbl_kind
       stray (:,:,:) = 0.05_dbl_kind
       if (l_winter) then

--- a/components/cice/src/source/ice_flux.F90
+++ b/components/cice/src/source/ice_flux.F90
@@ -127,7 +127,8 @@
          swidf   , & ! sw down, near IR, diffuse (W/m^2)
          flw     , & ! incoming longwave radiation (W/m^2)
          wsresp  , & ! response of atmospheric boundary layer to wind (m/s/Pa)
-         tau_est     ! estimated stress at equilibrium with wind (Pa)
+         tau_est , & ! estimated stress at equilibrium with wind (Pa)
+         ugust       ! gustiness from atmosphere (m/s)
 
        ! in from atmosphere (if .not. Tsfc_calc)
        ! required for coupling to HadGEM3
@@ -394,6 +395,7 @@
       vatm  (:,:,:) = c5
       wsresp(:,:,:) = c0              ! response of wind to stress (m/s/Pa)
       tau_est(:,:,:)= c0              ! stress in equilibrium with wind (Pa)
+      ugust (:,:,:) = c0              ! gustiness from atmosphere (m/s)
       strax (:,:,:) = 0.05_dbl_kind
       stray (:,:,:) = 0.05_dbl_kind
       if (l_winter) then

--- a/components/cice/src/source/ice_ocean.F90
+++ b/components/cice/src/source/ice_ocean.F90
@@ -156,6 +156,8 @@
                                       potT       (:,:,iblk), &
                                       uatm       (:,:,iblk), &   
                                       vatm       (:,:,iblk), &   
+                                      wsresp     (:,:,iblk), &
+                                      tau_est    (:,:,iblk), &
                                       uvel       (:,:,iblk), &   
                                       vvel       (:,:,iblk), &   
                                       wind       (:,:,iblk), &   

--- a/components/cice/src/source/ice_ocean.F90
+++ b/components/cice/src/source/ice_ocean.F90
@@ -158,6 +158,7 @@
                                       vatm       (:,:,iblk), &   
                                       wsresp     (:,:,iblk), &
                                       tau_est    (:,:,iblk), &
+                                      ugust      (:,:,iblk), &
                                       uvel       (:,:,iblk), &   
                                       vvel       (:,:,iblk), &   
                                       wind       (:,:,iblk), &   

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3736,6 +3736,9 @@ if ( $linearize_pbl_winds =~ /$TRUE/io ) {
     }
 }
 
+# Export gustiness to surface components.
+add_default($nl, 'export_gustiness');
+
 # Use Convective water in radiation
 add_default($nl, 'conv_water_in_rad');
 

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3727,6 +3727,15 @@ if ( $do_tms =~ /$TRUE/io ) {
 # Implicit Turbulent Surface Stress
 add_default($nl, 'do_iss');
 
+# PBL linearization
+add_default($nl, 'linearize_pbl_winds');
+my $linearize_pbl_winds = $nl->get_value('linearize_pbl_winds');
+if ( $linearize_pbl_winds =~ /$TRUE/io ) {
+    if (!($eddy_scheme =~ /clubb_sgs/i)) {
+        die "$ProgName - ERROR: linearize_pbl_winds = .true. but linearization is not implemented for eddy_scheme=$eddy_scheme.\n";
+    }
+}
+
 # Use Convective water in radiation
 add_default($nl, 'conv_water_in_rad');
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1003,6 +1003,9 @@
 <!-- Linearization of boundary layer winds -->
 <linearize_pbl_winds>.false.</linearize_pbl_winds>
 
+<!-- Export gustiness value -->
+<export_gustiness>.false.</export_gustiness>
+
 <!-- MMF CRM mean state acceleration -->
 <use_crm_accel    use_MMF="0">.false.</use_crm_accel>
 <crm_accel_uv     use_MMF="0">.false.</crm_accel_uv>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1000,6 +1000,9 @@
 <srf_flux_avg             >0</srf_flux_avg>
 <srf_flux_avg use_MMF="1" >1</srf_flux_avg>
 
+<!-- Linearization of boundary layer winds -->
+<linearize_pbl_winds>.false.</linearize_pbl_winds>
+
 <!-- MMF CRM mean state acceleration -->
 <use_crm_accel    use_MMF="0">.false.</use_crm_accel>
 <crm_accel_uv     use_MMF="0">.false.</crm_accel_uv>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3508,7 +3508,15 @@ is sent to the coupler every time step, using the fields 'wsresp' and 'tau_est'.
 
 <entry id="export_gustiness" type="logical" category="pbl"
        group="phys_ctl_nl" valid_values="" >
-If .true., a gustiness value will be exported to the coupler.
+If .true., a gustiness value will be exported to the coupler, which allows
+surface components to distinguish between the effect of mean wind and gustiness
+when calculating fluxes (and in particular surface drag).
+
+If .false., no extra value is exported, and gustiness is instead applied by the
+atmosphere by scaling up the exported wind fields (ubot and vbot). This is
+simpler and requires slightly less coupling overhead, but produces numerical
+artifacts (oscillations) in surface stresses, particularly when the gustiness is
+large compared with the mean wind.
 </entry>
 
 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3500,6 +3500,12 @@ Bretherton; 'HBR' for Rasch modified version of 'HB'.
 Default: 'HB'
 </entry>
 
+<entry id="linearize_pbl_winds" type="logical" category="pbl"
+       group="phys_ctl_nl" valid_values="" >
+If .true., a linearization of the response of the pbl scheme to surface stresses
+is sent to the coupler every time step, using the fields 'wsresp' and 'tau_est'.
+</entry>
+
 
 <!-- Flags for implementing code modifications under polar project -->
 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3506,6 +3506,11 @@ If .true., a linearization of the response of the pbl scheme to surface stresses
 is sent to the coupler every time step, using the fields 'wsresp' and 'tau_est'.
 </entry>
 
+<entry id="export_gustiness" type="logical" category="pbl"
+       group="phys_ctl_nl" valid_values="" >
+If .true., a gustiness value will be exported to the coupler.
+</entry>
+
 
 <!-- Flags for implementing code modifications under polar project -->
 

--- a/components/eam/cime_config/buildnml
+++ b/components/eam/cime_config/buildnml
@@ -25,6 +25,7 @@ def buildnml(case, caseroot, compname):
 
     # Gather case parameters
     atm_flux_method     = case.get_value("ATM_FLUX_INTEGRATION_METHOD")
+    atm_gustiness       = case.get_value("ATM_SUPPLIES_GUSTINESS")
     atm_grid		= case.get_value("ATM_GRID")
     atm_ncpl		= case.get_value("ATM_NCPL")
     build_complete	= case.get_value("BUILD_COMPLETE")
@@ -190,6 +191,7 @@ def buildnml(case, caseroot, compname):
         if cam_branch_file: infile_text += " cam_branch_file = {} \n".format(cam_branch_file)
         if debug:           infile_text += " state_debug_checks = .true. \n"
         if linearize_pbl_winds: infile_text += " linearize_pbl_winds = .true. \n"
+        if atm_gustiness: infile_text += " export_gustiness = .true. \n"
 
         create_namelist_infile(case,
                                "{}/user_nl_eam{}".format(caseroot, inst_string),

--- a/components/eam/cime_config/buildnml
+++ b/components/eam/cime_config/buildnml
@@ -24,6 +24,7 @@ def buildnml(case, caseroot, compname):
     os.chdir(caseroot)
 
     # Gather case parameters
+    atm_flux_method     = case.get_value("ATM_FLUX_INTEGRATION_METHOD")
     atm_grid		= case.get_value("ATM_GRID")
     atm_ncpl		= case.get_value("ATM_NCPL")
     build_complete	= case.get_value("BUILD_COMPLETE")
@@ -175,6 +176,11 @@ def buildnml(case, caseroot, compname):
         start_ymd = run_startdate.replace("-", "")
         ntasks = ntasks_atm / ninst_atm
 
+        if atm_flux_method == 'implicit_stress':
+            linearize_pbl_winds = True
+        else:
+            linearize_pbl_winds = False
+
         infile_text = ""
         infile_text += " dtime = {} \n".format(dtime)
         infile_text += " co2vmr = {:f}e-6\n".format(ccsm_co2_ppmv)
@@ -183,6 +189,7 @@ def buildnml(case, caseroot, compname):
         if ncdata:          infile_text += " ncdata = {} \n".format(ncdata)
         if cam_branch_file: infile_text += " cam_branch_file = {} \n".format(cam_branch_file)
         if debug:           infile_text += " state_debug_checks = .true. \n"
+        if linearize_pbl_winds: infile_text += " linearize_pbl_winds = .true. \n"
 
         create_namelist_infile(case,
                                "{}/user_nl_eam{}".format(caseroot, inst_string),

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/gust_export/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/gust_export/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange ATM_SUPPLIES_GUSTINESS="TRUE"

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/implicit_stress/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/implicit_stress/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange ATM_SUPPLIES_GUSTINESS="TRUE"
+./xmlchange ATM_FLUX_INTEGRATION_METHOD="implicit_stress"

--- a/components/eam/src/control/camsrfexch.F90
+++ b/components/eam/src/control/camsrfexch.F90
@@ -79,7 +79,8 @@ module camsrfexch
      real(r8), allocatable :: dstwet4(:)  ! wet deposition of dust (bin4)
      real(r8), allocatable :: dstdry4(:)  ! dry deposition of dust (bin4)
      real(r8), allocatable :: wsresp(:)   ! first-order response of low-level wind to surface fluxes
-     real(r8), allocatable :: tau_est(:)   ! stress estimated to be in equilibrium with ubot/vbot
+     real(r8), allocatable :: tau_est(:)  ! stress estimated to be in equilibrium with ubot/vbot
+     real(r8), allocatable :: ugust(:)    ! gustiness value
   end type cam_out_t 
 
 !---------------------------------------------------------------------------
@@ -491,6 +492,9 @@ CONTAINS
 
        allocate (cam_out(c)%tau_est(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error tau_est')
+
+       allocate (cam_out(c)%ugust(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error ugust')
     enddo  
 
     do c = begchunk,endchunk
@@ -533,6 +537,7 @@ CONTAINS
        cam_out(c)%dstwet4(:)  = 0._r8
        cam_out(c)%wsresp(:)   = 0._r8
        cam_out(c)%tau_est(:)  = 0._r8
+       cam_out(c)%ugust(:)    = 0._r8
     end do
 
   end subroutine atm2hub_alloc
@@ -579,6 +584,7 @@ CONTAINS
           deallocate(cam_out(c)%dstdry4)
           deallocate(cam_out(c)%wsresp)
           deallocate(cam_out(c)%tau_est)
+          deallocate(cam_out(c)%ugust)
        enddo  
 
        deallocate(cam_out)
@@ -700,6 +706,7 @@ subroutine cam_export(state,cam_out,pbuf)
    integer :: vmag_gust_idx, wsresp_idx, tau_est_idx
    real(r8) :: umb(pcols), vmb(pcols),vmag(pcols)
    logical :: linearize_pbl_winds ! Send wsresp and tau_est to coupler.
+   logical :: export_gustiness ! Send vmag_gust to coupler
 
    real(r8), pointer :: prec_dp(:)                 ! total precipitation   from ZM convection
    real(r8), pointer :: snow_dp(:)                 ! snow from ZM   convection
@@ -718,7 +725,8 @@ subroutine cam_export(state,cam_out,pbuf)
    lchnk = state%lchnk
    ncol  = state%ncol
 
-   call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds)
+   call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds, &
+                     export_gustiness_out=export_gustiness)
 
    prec_dp_idx = pbuf_get_index('PREC_DP')
    snow_dp_idx = pbuf_get_index('SNOW_DP')
@@ -750,14 +758,21 @@ subroutine cam_export(state,cam_out,pbuf)
 !PMA adds gustiness to surface scheme c20181128
 
    do i=1,ncol
-      umb(i)           = state%u(i,pver)
-      vmb(i)           = state%v(i,pver)
-      vmag(i)          = max(1.e-5_r8,sqrt( umb(i)**2._r8 + vmb(i)**2._r8))
+      if (export_gustiness) then
+         cam_out%ubot(i)  = state%u(i,pver)
+         cam_out%vbot(i)  = state%v(i,pver)
+         cam_out%ugust(i) = vmag_gust(i)
+      else
+         ! If not exporting gustiness as a separate field, we apply it here.
+         umb(i)           = state%u(i,pver)
+         vmb(i)           = state%v(i,pver)
+         vmag(i)          = max(1.e-5_r8,sqrt( umb(i)**2._r8 + vmb(i)**2._r8))
+         cam_out%ubot(i)  = state%u(i,pver) * ((vmag_gust(i)+vmag(i))/vmag(i))
+         cam_out%vbot(i)  = state%v(i,pver) * ((vmag_gust(i)+vmag(i))/vmag(i))
+      end if
       cam_out%tbot(i)  = state%t(i,pver)
       cam_out%thbot(i) = state%t(i,pver) * state%exner(i,pver)
       cam_out%zbot(i)  = state%zm(i,pver)
-      cam_out%ubot(i)  = state%u(i,pver) * ((vmag_gust(i)+vmag(i))/vmag(i))
-      cam_out%vbot(i)  = state%v(i,pver) * ((vmag_gust(i)+vmag(i))/vmag(i))
       cam_out%pbot(i)  = state%pmid(i,pver)
       cam_out%rho(i)   = cam_out%pbot(i)/(rair*cam_out%tbot(i))
       if (linearize_pbl_winds) then

--- a/components/eam/src/control/camsrfexch.F90
+++ b/components/eam/src/control/camsrfexch.F90
@@ -78,6 +78,8 @@ module camsrfexch
      real(r8), allocatable :: dstdry3(:)  ! dry deposition of dust (bin3)
      real(r8), allocatable :: dstwet4(:)  ! wet deposition of dust (bin4)
      real(r8), allocatable :: dstdry4(:)  ! dry deposition of dust (bin4)
+     real(r8), allocatable :: wsresp(:)   ! first-order response of low-level wind to surface fluxes
+     real(r8), allocatable :: tau_est(:)   ! stress estimated to be in equilibrium with ubot/vbot
   end type cam_out_t 
 
 !---------------------------------------------------------------------------
@@ -483,6 +485,12 @@ CONTAINS
 
        allocate (cam_out(c)%dstdry4(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error dstdry4')
+
+       allocate (cam_out(c)%wsresp(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error wsresp')
+
+       allocate (cam_out(c)%tau_est(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('ATM2HUB_ALLOC error: allocation error tau_est')
     enddo  
 
     do c = begchunk,endchunk
@@ -523,6 +531,8 @@ CONTAINS
        cam_out(c)%dstwet3(:)  = 0._r8
        cam_out(c)%dstdry4(:)  = 0._r8
        cam_out(c)%dstwet4(:)  = 0._r8
+       cam_out(c)%wsresp(:)   = 0._r8
+       cam_out(c)%tau_est(:)  = 0._r8
     end do
 
   end subroutine atm2hub_alloc
@@ -567,6 +577,8 @@ CONTAINS
           deallocate(cam_out(c)%dstdry3)
           deallocate(cam_out(c)%dstwet4)
           deallocate(cam_out(c)%dstdry4)
+          deallocate(cam_out(c)%wsresp)
+          deallocate(cam_out(c)%tau_est)
        enddo  
 
        deallocate(cam_out)
@@ -665,6 +677,7 @@ subroutine cam_export(state,cam_out,pbuf)
    use constituents,     only: pcnst
    use cam_control_mod,  only: rair
    use physics_buffer,   only: pbuf_get_index, pbuf_get_field, physics_buffer_desc
+   use phys_control,     only: phys_getopts
    implicit none
 
    !------------------------------Arguments--------------------------------
@@ -684,8 +697,9 @@ subroutine cam_export(state,cam_out,pbuf)
    integer :: ncol
    integer :: prec_dp_idx, snow_dp_idx, prec_sh_idx, snow_sh_idx
    integer :: prec_sed_idx,snow_sed_idx,prec_pcw_idx,snow_pcw_idx
-   integer :: vmag_gust_idx
+   integer :: vmag_gust_idx, wsresp_idx, tau_est_idx
    real(r8) :: umb(pcols), vmb(pcols),vmag(pcols)
+   logical :: linearize_pbl_winds ! Send wsresp and tau_est to coupler.
 
    real(r8), pointer :: prec_dp(:)                 ! total precipitation   from ZM convection
    real(r8), pointer :: snow_dp(:)                 ! snow from ZM   convection
@@ -696,11 +710,15 @@ subroutine cam_export(state,cam_out,pbuf)
    real(r8), pointer :: prec_pcw(:)                ! total precipitation   from Hack convection
    real(r8), pointer :: snow_pcw(:)                ! snow from Hack   convection
    real(r8), pointer :: vmag_gust(:)
+   real(r8), pointer :: wsresp(:)                  ! First-order response of wind to surface stress
+   real(r8), pointer :: tau_est(:)                 ! Estimated stress in equilibrium with ubot/vbot
 
    !-----------------------------------------------------------------------
 
    lchnk = state%lchnk
    ncol  = state%ncol
+
+   call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds)
 
    prec_dp_idx = pbuf_get_index('PREC_DP')
    snow_dp_idx = pbuf_get_index('SNOW_DP')
@@ -722,6 +740,13 @@ subroutine cam_export(state,cam_out,pbuf)
    call pbuf_get_field(pbuf, snow_pcw_idx, snow_pcw)
    call pbuf_get_field(pbuf, vmag_gust_idx, vmag_gust)
 
+   if (linearize_pbl_winds) then
+      wsresp_idx = pbuf_get_index('wsresp')
+      tau_est_idx = pbuf_get_index('tau_est')
+      call pbuf_get_field(pbuf, wsresp_idx, wsresp)
+      call pbuf_get_field(pbuf, tau_est_idx, tau_est)
+   end if
+
 !PMA adds gustiness to surface scheme c20181128
 
    do i=1,ncol
@@ -735,6 +760,10 @@ subroutine cam_export(state,cam_out,pbuf)
       cam_out%vbot(i)  = state%v(i,pver) * ((vmag_gust(i)+vmag(i))/vmag(i))
       cam_out%pbot(i)  = state%pmid(i,pver)
       cam_out%rho(i)   = cam_out%pbot(i)/(rair*cam_out%tbot(i))
+      if (linearize_pbl_winds) then
+         cam_out%wsresp(i)= max(wsresp(i), 0._r8)
+         cam_out%tau_est(i)= tau_est(i)
+      end if
       psm1(i,lchnk)    = state%ps(i)
       srfrpdel(i,lchnk)= state%rpdel(i,pver)
    end do

--- a/components/eam/src/cpl/atm_import_export.F90
+++ b/components/eam/src/cpl/atm_import_export.F90
@@ -241,10 +241,11 @@ contains
     integer :: avsize, avnat
     integer :: i,m,c,n,ig       ! indices
     integer :: ncols            ! Number of columns
-    logical :: linearize_pbl_winds
+    logical :: linearize_pbl_winds, export_gustiness
     !-----------------------------------------------------------------------
 
-    call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds)
+    call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds, &
+                      export_gustiness_out=export_gustiness)
 
     ! Copy from component arrays into chunk array data structure
     ! Rearrange data from chunk structure into lat-lon buffer and subsequently
@@ -261,6 +262,9 @@ contains
           if (linearize_pbl_winds) then
              a2x(index_a2x_Sa_wsresp ,ig) = cam_out(c)%wsresp(i)
              a2x(index_a2x_Sa_tau_est,ig) = cam_out(c)%tau_est(i)
+          end if
+          if (export_gustiness) then
+             a2x(index_a2x_Sa_ugust  ,ig) = cam_out(c)%ugust(i)
           end if
           a2x(index_a2x_Sa_tbot   ,ig) = cam_out(c)%tbot(i)   
           a2x(index_a2x_Sa_ptem   ,ig) = cam_out(c)%thbot(i)  

--- a/components/eam/src/cpl/atm_import_export.F90
+++ b/components/eam/src/cpl/atm_import_export.F90
@@ -229,6 +229,7 @@ contains
     use phys_grid , only: get_ncols_p
     use ppgrid    , only: begchunk, endchunk       
     use cam_cpl_indices
+    use phys_control, only: phys_getopts
     !
     ! Arguments
     !
@@ -240,7 +241,10 @@ contains
     integer :: avsize, avnat
     integer :: i,m,c,n,ig       ! indices
     integer :: ncols            ! Number of columns
+    logical :: linearize_pbl_winds
     !-----------------------------------------------------------------------
+
+    call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds)
 
     ! Copy from component arrays into chunk array data structure
     ! Rearrange data from chunk structure into lat-lon buffer and subsequently
@@ -253,7 +257,11 @@ contains
           a2x(index_a2x_Sa_pslv   ,ig) = cam_out(c)%psl(i)
           a2x(index_a2x_Sa_z      ,ig) = cam_out(c)%zbot(i)   
           a2x(index_a2x_Sa_u      ,ig) = cam_out(c)%ubot(i)   
-          a2x(index_a2x_Sa_v      ,ig) = cam_out(c)%vbot(i)   
+          a2x(index_a2x_Sa_v      ,ig) = cam_out(c)%vbot(i)
+          if (linearize_pbl_winds) then
+             a2x(index_a2x_Sa_wsresp ,ig) = cam_out(c)%wsresp(i)
+             a2x(index_a2x_Sa_tau_est,ig) = cam_out(c)%tau_est(i)
+          end if
           a2x(index_a2x_Sa_tbot   ,ig) = cam_out(c)%tbot(i)   
           a2x(index_a2x_Sa_ptem   ,ig) = cam_out(c)%thbot(i)  
           a2x(index_a2x_Sa_pbot   ,ig) = cam_out(c)%pbot(i)   

--- a/components/eam/src/cpl/cam_cpl_indices.F90
+++ b/components/eam/src/cpl/cam_cpl_indices.F90
@@ -13,6 +13,8 @@ module cam_cpl_indices
   integer :: index_a2x_Sa_z            ! bottom atm level height
   integer :: index_a2x_Sa_u            ! bottom atm level zon wind
   integer :: index_a2x_Sa_v            ! bottom atm level mer wind
+  integer :: index_a2x_Sa_wsresp       ! first order response of wind to stress
+  integer :: index_a2x_Sa_tau_est      ! estimated stress in equilibrium with ubot/vbot
   integer :: index_a2x_Sa_tbot         ! bottom atm level temp
   integer :: index_a2x_Sa_ptem         ! bottom atm level pot temp
   integer :: index_a2x_Sa_shum         ! bottom atm level spec hum
@@ -153,6 +155,8 @@ contains
     index_a2x_Sa_z          = mct_avect_indexra(a2x,'Sa_z')
     index_a2x_Sa_u          = mct_avect_indexra(a2x,'Sa_u')
     index_a2x_Sa_v          = mct_avect_indexra(a2x,'Sa_v')
+    index_a2x_Sa_wsresp     = mct_avect_indexra(a2x,'Sa_wsresp', perrWith='quiet')
+    index_a2x_Sa_tau_est    = mct_avect_indexra(a2x,'Sa_tau_est', perrWith='quiet')
     index_a2x_Sa_tbot       = mct_avect_indexra(a2x,'Sa_tbot')
     index_a2x_Sa_ptem       = mct_avect_indexra(a2x,'Sa_ptem')
     index_a2x_Sa_pbot       = mct_avect_indexra(a2x,'Sa_pbot')

--- a/components/eam/src/cpl/cam_cpl_indices.F90
+++ b/components/eam/src/cpl/cam_cpl_indices.F90
@@ -15,6 +15,7 @@ module cam_cpl_indices
   integer :: index_a2x_Sa_v            ! bottom atm level mer wind
   integer :: index_a2x_Sa_wsresp       ! first order response of wind to stress
   integer :: index_a2x_Sa_tau_est      ! estimated stress in equilibrium with ubot/vbot
+  integer :: index_a2x_Sa_ugust        ! magnitude of gustiness at surface
   integer :: index_a2x_Sa_tbot         ! bottom atm level temp
   integer :: index_a2x_Sa_ptem         ! bottom atm level pot temp
   integer :: index_a2x_Sa_shum         ! bottom atm level spec hum
@@ -157,6 +158,7 @@ contains
     index_a2x_Sa_v          = mct_avect_indexra(a2x,'Sa_v')
     index_a2x_Sa_wsresp     = mct_avect_indexra(a2x,'Sa_wsresp', perrWith='quiet')
     index_a2x_Sa_tau_est    = mct_avect_indexra(a2x,'Sa_tau_est', perrWith='quiet')
+    index_a2x_Sa_ugust      = mct_avect_indexra(a2x,'Sa_ugust', perrWith='quiet')
     index_a2x_Sa_tbot       = mct_avect_indexra(a2x,'Sa_tbot')
     index_a2x_Sa_ptem       = mct_avect_indexra(a2x,'Sa_ptem')
     index_a2x_Sa_pbot       = mct_avect_indexra(a2x,'Sa_pbot')

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -2940,7 +2940,12 @@ end subroutine clubb_init_cnst
       do i = 1, ncol
          wsresp(i) = sfc_v_diff_tau(i) / pert_tau
          ! Estimated tau in balance with wind is the tau we just used.
-         tau_est(i) = hypot(cam_in%wsx(i), cam_in%wsy(i))
+         if (cam_in%wsx(i) == 0._r8 .or. cam_in%wsy(i) == 0._r8) then
+            ! Work around an odd FPE issue with intel compiler.
+            tau_est(i) = abs(cam_in%wsx(i)) + abs(cam_in%wsy(i))
+         else
+            tau_est(i) = hypot(cam_in%wsx(i), cam_in%wsy(i))
+         end if
       end do
    end if
 

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -128,6 +128,7 @@ module clubb_intr
     l_host_applies_sfc_fluxes = .false.  ! Whether the host model applies the surface fluxes
 
   logical            :: do_tms
+  logical            :: linearize_pbl_winds
   logical            :: lq(pcnst)
   logical            :: lq2(pcnst)
   logical            :: prog_modal_aero
@@ -155,6 +156,10 @@ module clubb_intr
     vp2_idx, &          ! variance of north-south wind
     upwp_idx, &         ! east-west momentum flux
     vpwp_idx, &         ! north-south momentum flux
+    um_pert_idx, &      ! perturbed east-west momentum flux
+    vm_pert_idx, &      ! perturbed north-south momentum flux
+    upwp_pert_idx, &    ! perturbed east-west momentum flux
+    vpwp_pert_idx, &    ! perturbed north-south momentum flux
     thlm_idx, &         ! mean thetal
     rtm_idx, &          ! mean total water mixing ratio
     um_idx, &           ! mean of east-west wind
@@ -202,7 +207,9 @@ module clubb_intr
   integer :: &          !PMA adds pbuf fields for ZM gustiness
     prec_dp_idx, &
     snow_dp_idx, &
-    vmag_gust_idx
+    vmag_gust_idx, &
+    wsresp_idx, &
+    tau_est_idx
 
   integer, public :: &
     ixthlp2 = 0, &
@@ -264,6 +271,7 @@ module clubb_intr
     call phys_getopts( eddy_scheme_out                 = eddy_scheme, &
                        deep_scheme_out                 = deep_scheme, &
                        do_tms_out                      = do_tms,      &
+                       linearize_pbl_winds_out         = linearize_pbl_winds,      &
                        history_budget_out              = history_budget, &
                        history_budget_histfile_num_out = history_budget_histfile_num, &
                        micro_do_icesupersat_out        = micro_do_icesupersat, &
@@ -315,6 +323,12 @@ module clubb_intr
 
     call pbuf_add_field('UPWP',       'global', dtype_r8, (/pcols,pverp,dyn_time_lvls/), upwp_idx)
     call pbuf_add_field('VPWP',       'global', dtype_r8, (/pcols,pverp,dyn_time_lvls/), vpwp_idx)
+    if (linearize_pbl_winds) then
+       call pbuf_add_field('UM_PERT',    'physpkg', dtype_r8, (/pcols,pverp/), um_pert_idx)
+       call pbuf_add_field('VM_PERT',    'physpkg', dtype_r8, (/pcols,pverp/), vm_pert_idx)
+       call pbuf_add_field('UPWP_PERT',  'physpkg', dtype_r8, (/pcols,pverp/), upwp_pert_idx)
+       call pbuf_add_field('VPWP_PERT',  'physpkg', dtype_r8, (/pcols,pverp/), vpwp_pert_idx)
+    end if
     call pbuf_add_field('THLM',       'global', dtype_r8, (/pcols,pverp,dyn_time_lvls/), thlm_idx)
     call pbuf_add_field('RTM',        'global', dtype_r8, (/pcols,pverp,dyn_time_lvls/), rtm_idx)
     call pbuf_add_field('UM',         'global', dtype_r8, (/pcols,pverp,dyn_time_lvls/), um_idx)
@@ -334,6 +348,11 @@ module clubb_intr
     call pbuf_add_field('pdf_zm_mixt_frac',  'global', dtype_r8, (/pcols,pverp,dyn_time_lvls/), pdf_zm_mixt_frac_idx)
 
     call pbuf_add_field('vmag_gust',       'global', dtype_r8, (/pcols/),      vmag_gust_idx) !PMA total gustiness
+
+    if (linearize_pbl_winds) then
+       call pbuf_add_field('wsresp',          'global', dtype_r8, (/pcols/),      wsresp_idx)
+       call pbuf_add_field('tau_est',         'global', dtype_r8, (/pcols/),      tau_est_idx)
+    end if
 #endif
 
   end subroutine clubb_register_cam
@@ -994,6 +1013,12 @@ end subroutine clubb_init_cnst
 
        call pbuf_set_field(pbuf2d, upwp_idx,    0.0_r8)
        call pbuf_set_field(pbuf2d, vpwp_idx,    0.0_r8)
+       if (linearize_pbl_winds) then
+          call pbuf_set_field(pbuf2d, um_pert_idx, 0.0_r8)
+          call pbuf_set_field(pbuf2d, vm_pert_idx, 0.0_r8)
+          call pbuf_set_field(pbuf2d, upwp_pert_idx, 0.0_r8)
+          call pbuf_set_field(pbuf2d, vpwp_pert_idx, 0.0_r8)
+       end if
        call pbuf_set_field(pbuf2d, tke_idx,     0.0_r8)
        call pbuf_set_field(pbuf2d, kvh_idx,     0.0_r8)
        call pbuf_set_field(pbuf2d, fice_idx,    0.0_r8)
@@ -1015,6 +1040,10 @@ end subroutine clubb_init_cnst
 
        call pbuf_set_field(pbuf2d, vmag_gust_idx,    1.0_r8)
 
+       if (linearize_pbl_winds) then
+          call pbuf_set_field(pbuf2d, wsresp_idx,    0.0_r8)
+          call pbuf_set_field(pbuf2d, tau_est_idx,   0.0_r8)
+       end if
     endif
 
     ! --------------- !
@@ -1282,6 +1311,9 @@ end subroutine clubb_init_cnst
    real(r8) :: zt_out(pcols,pverp)              ! output for the thermo CLUBB grid              [m]
    real(r8) :: zi_out(pcols,pverp)              ! output for momentum CLUBB grid                [m]
 
+   real(r8), pointer :: upwp_sfc_pert           ! u'w' at surface                               [m^2/s^2]
+   real(r8), pointer :: vpwp_sfc_pert           ! v'w' at surface                               [m^2/s^2]
+
    real(r8) :: pdf_zm_w_1_inout(pverp)          ! work array for pdf_params_zm%w_1
    real(r8) :: pdf_zm_w_2_inout(pverp)          ! work array for pdf_params_zm%w_2
    real(r8) :: pdf_zm_varnce_w_1_inout(pverp)   ! work array for pdf_params_zm%varnce_w_1
@@ -1376,6 +1408,10 @@ end subroutine clubb_init_cnst
 
    real(r8), pointer, dimension(:,:) :: upwp     ! east-west momentum flux                      [m^2/s^2]
    real(r8), pointer, dimension(:,:) :: vpwp     ! north-south momentum flux                    [m^2/s^2]
+   real(r8), pointer, dimension(:,:) :: um_pert  ! perturbed meridional wind                    [m/s]
+   real(r8), pointer, dimension(:,:) :: vm_pert  ! perturbed zonal wind                         [m/s]
+   real(r8), pointer, dimension(:,:) :: upwp_pert! perturbed meridional wind flux               [m^2/s^2]
+   real(r8), pointer, dimension(:,:) :: vpwp_pert! perturbed zonal wind flux                    [m^2/s^2]
    real(r8), pointer, dimension(:,:) :: thlm     ! mean temperature                             [K]
    real(r8), pointer, dimension(:,:) :: rtm      ! mean moisture mixing ratio                   [kg/kg]
    real(r8), pointer, dimension(:,:) :: um       ! mean east-west wind                          [m/s]
@@ -1398,6 +1434,13 @@ end subroutine clubb_init_cnst
    real(r8), pointer, dimension(:,:) :: accre_enhan ! accretion enhancement factor              [-]
    real(r8), pointer, dimension(:,:) :: cmeliq
    real(r8), pointer, dimension(:,:) :: cmfmc_sh ! Shallow convective mass flux--m subc (pcols,pverp) [kg/m2/s/]
+
+   ! These pointers point to specific columns of the corresponding field, if
+   ! these fields are actually needed.
+   real(r8), pointer, dimension(:) :: um_pert_col
+   real(r8), pointer, dimension(:) :: vm_pert_col
+   real(r8), pointer, dimension(:) :: upwp_pert_col
+   real(r8), pointer, dimension(:) :: vpwp_pert_col
 
    type(pdf_parameter), pointer :: pdf_params    ! PDF parameters (thermo. levs.) [units vary]
    type(pdf_parameter), pointer :: pdf_params_zm ! PDF parameters on momentum levs. [units vary]
@@ -1423,6 +1466,8 @@ end subroutine clubb_init_cnst
    real(r8), pointer :: prec_dp(:)                 ! total precipitation from ZM convection
    real(r8), pointer :: snow_dp(:)                 ! snow precipitation from ZM convection
    real(r8), pointer :: vmag_gust(:)
+   real(r8), pointer :: wsresp(:)
+   real(r8), pointer :: tau_est(:)
    real(r8), pointer :: tpert(:)
 
    real(r8) :: ugust  ! function: gustiness as a function of convective rainfall
@@ -1436,6 +1481,9 @@ end subroutine clubb_init_cnst
    real(r8),parameter :: gust_facl = 1.2_r8 !gust fac for land
    real(r8),parameter :: gust_faco = 0.9_r8 !gust fac for ocean
    real(r8),parameter :: gust_facc = 1.5_r8 !gust fac for clubb
+
+   real(r8) :: sfc_v_diff_tau(pcols) ! Response to tau perturbation, m/s
+   real(r8), parameter :: pert_tau = 0.1_r8 ! tau perturbation, Pa
 
 ! ZM gustiness equation below from Redelsperger et al. (2000)
 ! numbers are coefficients of the empirical equation
@@ -1560,6 +1608,17 @@ end subroutine clubb_init_cnst
 
    call pbuf_get_field(pbuf, upwp_idx,    upwp,    start=(/1,1,itim_old/), kount=(/pcols,pverp,1/))
    call pbuf_get_field(pbuf, vpwp_idx,    vpwp,    start=(/1,1,itim_old/), kount=(/pcols,pverp,1/))
+   if (linearize_pbl_winds) then
+      call pbuf_get_field(pbuf, um_pert_idx, um_pert, start=(/1,1/),          kount=(/pcols,pverp/))
+      call pbuf_get_field(pbuf, vm_pert_idx, vm_pert, start=(/1,1/),          kount=(/pcols,pverp/))
+      call pbuf_get_field(pbuf, upwp_pert_idx,upwp_pert,start=(/1,1/),        kount=(/pcols,pverp/))
+      call pbuf_get_field(pbuf, vpwp_pert_idx,vpwp_pert,start=(/1,1/),        kount=(/pcols,pverp/))
+   else
+      nullify(um_pert)
+      nullify(vm_pert)
+      nullify(upwp_pert)
+      nullify(vpwp_pert)
+   end if
    call pbuf_get_field(pbuf, thlm_idx,    thlm,    start=(/1,1,itim_old/), kount=(/pcols,pverp,1/))
    call pbuf_get_field(pbuf, rtm_idx,     rtm,     start=(/1,1,itim_old/), kount=(/pcols,pverp,1/))
    call pbuf_get_field(pbuf, um_idx,      um,      start=(/1,1,itim_old/), kount=(/pcols,pverp,1/))
@@ -1607,6 +1666,11 @@ end subroutine clubb_init_cnst
    call pbuf_get_field(pbuf, prec_dp_idx, prec_dp)
    call pbuf_get_field(pbuf, snow_dp_idx, snow_dp)
    call pbuf_get_field(pbuf, vmag_gust_idx, vmag_gust)
+
+   if (linearize_pbl_winds) then
+      call pbuf_get_field(pbuf, wsresp_idx, wsresp)
+      call pbuf_get_field(pbuf, tau_est_idx, tau_est)
+   end if
 
    ! Intialize the apply_const variable (note special logic is due to eularian backstepping)
    if (clubb_do_adv .and. (is_first_step() .or. all(wpthlp(1:ncol,1:pver) .eq. 0._r8))) then
@@ -2037,6 +2101,43 @@ end subroutine clubb_init_cnst
 
       enddo
 
+      if (linearize_pbl_winds) then
+         ! Each host model time step, reset the perturbed variables to be equal to
+         ! the unperturbed values.
+         if (macmic_it == 1) then
+            um_pert(i,:) = um_in
+            vm_pert(i,:) = vm_in
+            upwp_pert(i,:) = upwp_in
+            vpwp_pert(i,:) = vpwp_in
+         end if
+         um_pert_col => um_pert(i,:)
+         vm_pert_col => vm_pert(i,:)
+         upwp_pert_col => upwp_pert(i,:)
+         vpwp_pert_col => vpwp_pert(i,:)
+
+         allocate(upwp_sfc_pert)
+         allocate(vpwp_sfc_pert)
+         ! Prefer to perturb wind/stress in the direction of the existing stress.
+         ! However, if there's no existing surface stress, just perturb zonal
+         ! wind/stress.
+         if (abs(cam_in%wsx(i)) < 1.e-12 .and. abs(cam_in%wsy(i)) < 1.e-12) then
+            upwp_sfc_pert = upwp_sfc + pert_tau / rho_ds_zm(1)
+            vpwp_sfc_pert = vpwp_sfc
+         else
+            upwp_sfc_pert = upwp_sfc + cam_in%wsx(i) * &
+                 (pert_tau / (rho_ds_zm(1) * hypot(cam_in%wsx(i), cam_in%wsy(i))))
+            vpwp_sfc_pert = vpwp_sfc + cam_in%wsy(i) * &
+                 (pert_tau / (rho_ds_zm(1) * hypot(cam_in%wsx(i), cam_in%wsy(i))))
+         end if
+      else
+         nullify(upwp_sfc_pert)
+         nullify(vpwp_sfc_pert)
+         nullify(um_pert_col)
+         nullify(vm_pert_col)
+         nullify(upwp_pert_col)
+         nullify(vpwp_pert_col)
+      end if
+
       pre_in(1) = pre_in(2)
 
       !  Initialize these to prevent crashing behavior
@@ -2177,7 +2278,9 @@ end subroutine clubb_init_cnst
               pdf_params, pdf_params_zm, &                                 ! intent(inout)
               khzm_out, khzt_out, qclvar_out, thlprcp_out, &               ! intent(out)
               wprcp_out, ice_supersat_frac, &                              ! intent(out)
-              rcm_in_layer_out, cloud_cover_out)                           ! intent(out)
+              rcm_in_layer_out, cloud_cover_out, &                         ! intent(out)
+              upwp_sfc_pert, vpwp_sfc_pert, &                              ! intent(in)
+              um_pert_col, vm_pert_col, upwp_pert_col, vpwp_pert_col)      ! intent(inout)
          call t_stopf('advance_clubb_core')
 
          if ( err_code == clubb_fatal_error ) then
@@ -2259,6 +2362,18 @@ end subroutine clubb_init_cnst
             enddo
          endif
       endif
+
+      if (linearize_pbl_winds) then
+         if (abs(cam_in%wsx(i)) < 1.e-12 .and. abs(cam_in%wsy(i)) < 1.e-12) then
+            sfc_v_diff_tau(i) = um_pert(i,2) - um_in(2)
+         else
+            sfc_v_diff_tau(i) = ((um_pert(i,2) - um_in(2))*cam_in%wsx(i) &
+                 + (vm_pert(i,2) - vm_in(2))*cam_in%wsy(i)) &
+                 / hypot(cam_in%wsx(i), cam_in%wsy(i))
+         end if
+         deallocate(upwp_sfc_pert)
+         deallocate(vpwp_sfc_pert)
+      end if
 
       !  Arrays need to be "flipped" to CAM grid
       do k=1,pverp
@@ -2820,6 +2935,14 @@ end subroutine clubb_init_cnst
                     /max(state1%exner(i,ktopi(i)),1.e-3_r8)) !proxy for tpert
        end do
     end if
+
+   if (linearize_pbl_winds .and. macmic_it == cld_macmic_num_steps) then
+      do i = 1, ncol
+         wsresp(i) = sfc_v_diff_tau(i) / pert_tau
+         ! Estimated tau in balance with wind is the tau we just used.
+         tau_est(i) = hypot(cam_in%wsx(i), cam_in%wsy(i))
+      end do
+   end if
 
    call outfld('VMAGGUST', vmag_gust, pcols, lchnk)
    call outfld('VMAGDP', vmag_gust_dp, pcols, lchnk)

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -116,6 +116,7 @@ logical           :: micro_do_icesupersat
 logical           :: state_debug_checks   = .false.    ! Extra checks for validity of physics_state objects
                                                        ! in physics_update.
 logical           :: linearize_pbl_winds  = .false.
+logical           :: export_gustiness  = .false.
 logical, public, protected :: use_mass_borrower    = .false.     ! switch on tracer borrower, instead of using the QNEG3 clipping
 logical, public, protected :: use_qqflx_fixer      = .false.     ! switch on water vapor fixer to compensate changes in qflx
 logical, public, protected :: print_fixer_message  = .false.     ! switch on error message printout in log file
@@ -194,7 +195,7 @@ subroutine phys_ctl_readnl(nlfile)
       history_aerosol, history_aero_optics, &
       history_eddy, history_budget,  history_budget_histfile_num, history_waccm, &
       conv_water_in_rad, history_clubb, do_clubb_sgs, do_tms, state_debug_checks, &
-      linearize_pbl_winds, &
+      linearize_pbl_winds, export_gustiness, &
       use_mass_borrower, do_aerocom_ind3, &
       ieflx_opt, &
       use_qqflx_fixer, & 
@@ -267,6 +268,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(micro_do_icesupersat,            1 , mpilog,  0, mpicom)
    call mpibcast(state_debug_checks,              1 , mpilog,  0, mpicom)
    call mpibcast(linearize_pbl_winds,             1 , mpilog,  0, mpicom)
+   call mpibcast(export_gustiness,                1 , mpilog,  0, mpicom)
    call mpibcast(use_hetfrz_classnuc,             1 , mpilog,  0, mpicom)
    call mpibcast(use_gw_oro,                      1 , mpilog,  0, mpicom)
    call mpibcast(use_gw_front,                    1 , mpilog,  0, mpicom)
@@ -449,7 +451,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
                         use_MMF_VT_out, MMF_VT_wn_max_out, &
                         use_crm_accel_out, crm_accel_factor_out, crm_accel_uv_out, &
                         do_clubb_sgs_out, do_tms_out, state_debug_checks_out, &
-                        linearize_pbl_winds_out, &
+                        linearize_pbl_winds_out, export_gustiness_out, &
                         do_aerocom_ind3_out,  &
                         use_mass_borrower_out, & 
                         use_qqflx_fixer_out, & 
@@ -510,6 +512,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    logical,           intent(out), optional :: print_fixer_message_out
    logical,           intent(out), optional :: state_debug_checks_out
    logical,           intent(out), optional :: linearize_pbl_winds_out
+   logical,           intent(out), optional :: export_gustiness_out
    logical,           intent(out), optional :: fix_g1_err_ndrop_out!BSINGH - bugfix for ndrop.F90
    logical,           intent(out), optional :: ssalt_tuning_out    
    logical,           intent(out), optional :: resus_fix_out       
@@ -586,6 +589,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(print_fixer_message_out ) ) print_fixer_message_out  = print_fixer_message
    if ( present(state_debug_checks_out  ) ) state_debug_checks_out   = state_debug_checks
    if ( present(linearize_pbl_winds_out ) ) linearize_pbl_winds_out  = linearize_pbl_winds
+   if ( present(export_gustiness_out    ) ) export_gustiness_out     = export_gustiness
    if ( present(fix_g1_err_ndrop_out    ) ) fix_g1_err_ndrop_out     = fix_g1_err_ndrop
    if ( present(ssalt_tuning_out        ) ) ssalt_tuning_out         = ssalt_tuning   
    if ( present(resus_fix_out           ) ) resus_fix_out            = resus_fix      

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -115,6 +115,7 @@ logical           :: do_tms
 logical           :: micro_do_icesupersat
 logical           :: state_debug_checks   = .false.    ! Extra checks for validity of physics_state objects
                                                        ! in physics_update.
+logical           :: linearize_pbl_winds  = .false.
 logical, public, protected :: use_mass_borrower    = .false.     ! switch on tracer borrower, instead of using the QNEG3 clipping
 logical, public, protected :: use_qqflx_fixer      = .false.     ! switch on water vapor fixer to compensate changes in qflx
 logical, public, protected :: print_fixer_message  = .false.     ! switch on error message printout in log file
@@ -193,6 +194,7 @@ subroutine phys_ctl_readnl(nlfile)
       history_aerosol, history_aero_optics, &
       history_eddy, history_budget,  history_budget_histfile_num, history_waccm, &
       conv_water_in_rad, history_clubb, do_clubb_sgs, do_tms, state_debug_checks, &
+      linearize_pbl_winds, &
       use_mass_borrower, do_aerocom_ind3, &
       ieflx_opt, &
       use_qqflx_fixer, & 
@@ -264,6 +266,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(print_fixer_message,             1 , mpilog,  0, mpicom)
    call mpibcast(micro_do_icesupersat,            1 , mpilog,  0, mpicom)
    call mpibcast(state_debug_checks,              1 , mpilog,  0, mpicom)
+   call mpibcast(linearize_pbl_winds,             1 , mpilog,  0, mpicom)
    call mpibcast(use_hetfrz_classnuc,             1 , mpilog,  0, mpicom)
    call mpibcast(use_gw_oro,                      1 , mpilog,  0, mpicom)
    call mpibcast(use_gw_front,                    1 , mpilog,  0, mpicom)
@@ -446,6 +449,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
                         use_MMF_VT_out, MMF_VT_wn_max_out, &
                         use_crm_accel_out, crm_accel_factor_out, crm_accel_uv_out, &
                         do_clubb_sgs_out, do_tms_out, state_debug_checks_out, &
+                        linearize_pbl_winds_out, &
                         do_aerocom_ind3_out,  &
                         use_mass_borrower_out, & 
                         use_qqflx_fixer_out, & 
@@ -505,6 +509,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    logical,           intent(out), optional :: use_qqflx_fixer_out
    logical,           intent(out), optional :: print_fixer_message_out
    logical,           intent(out), optional :: state_debug_checks_out
+   logical,           intent(out), optional :: linearize_pbl_winds_out
    logical,           intent(out), optional :: fix_g1_err_ndrop_out!BSINGH - bugfix for ndrop.F90
    logical,           intent(out), optional :: ssalt_tuning_out    
    logical,           intent(out), optional :: resus_fix_out       
@@ -580,6 +585,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(use_qqflx_fixer_out     ) ) use_qqflx_fixer_out      = use_qqflx_fixer
    if ( present(print_fixer_message_out ) ) print_fixer_message_out  = print_fixer_message
    if ( present(state_debug_checks_out  ) ) state_debug_checks_out   = state_debug_checks
+   if ( present(linearize_pbl_winds_out ) ) linearize_pbl_winds_out  = linearize_pbl_winds
    if ( present(fix_g1_err_ndrop_out    ) ) fix_g1_err_ndrop_out     = fix_g1_err_ndrop
    if ( present(ssalt_tuning_out        ) ) ssalt_tuning_out         = ssalt_tuning   
    if ( present(resus_fix_out           ) ) resus_fix_out            = resus_fix      

--- a/components/eam/src/physics/clubb/advance_clubb_core_module.F90
+++ b/components/eam/src/physics/clubb/advance_clubb_core_module.F90
@@ -162,7 +162,9 @@ module advance_clubb_core_module
                qclvar, thlprcp_out, &                               ! intent(out)
 #endif
                wprcp, ice_supersat_frac, &                          ! intent(out)
-               rcm_in_layer, cloud_cover )                          ! intent(out)
+               rcm_in_layer, cloud_cover, &                         ! intent(out)
+               upwp_sfc_pert, vpwp_sfc_pert, &                      ! intent(in)
+               um_pert, vm_pert, upwp_pert, vpwp_pert )             ! intent(inout)
 
     ! Description:
     !   Subroutine to advance CLUBB one timestep
@@ -633,6 +635,16 @@ module advance_clubb_core_module
     logical, intent(in)                 ::  do_liquid_only_in_clubb
 ! <--- h1g, 2012-06-14
 #endif
+
+    real( kind = core_rknd ), intent(in), pointer ::  &
+      upwp_sfc_pert,     & ! pertubed u'w' at surface          [m^2/s^2]
+      vpwp_sfc_pert        ! pertubed v'w' at surface          [m^2/s^2]
+    real( kind = core_rknd ), intent(inout), dimension(:), pointer ::  &
+      um_pert,      & ! pertubed eastward grid-mean wind component (thermodynamic levels)   [m/s]
+      vm_pert,      & ! pertubed northward grid-mean wind component (thermodynamic levels)   [m/s]
+      upwp_pert,    & ! pertubed u'w' (momentum levels)                         [m^2/s^2]
+      vpwp_pert       ! pertubed v'w' (momentum levels)                         [m^2/s^2]
+
     ! Local Variables
     integer :: i, k
 
@@ -890,6 +902,11 @@ module advance_clubb_core_module
       wprtp(1)  = wprtp_sfc
       upwp(1)   = upwp_sfc
       vpwp(1)   = vpwp_sfc
+      if (associated(upwp_sfc_pert) .and. associated(vpwp_sfc_pert) .and. &
+           associated(upwp_pert) .and. associated(vpwp_pert)) then
+         upwp_pert(1) = upwp_sfc_pert
+         vpwp_pert(1) = vpwp_sfc_pert
+      end if
 
       ! Set fluxes for passive scalars (if enabled)
       if ( sclr_dim > 0 ) then
@@ -1519,7 +1536,8 @@ module advance_clubb_core_module
                             fcor, um_ref, vm_ref, up2, vp2,                  & ! intent(in)
                             uprcp, vprcp, rc_coef,                           & ! intent(in)
                             rtm, wprtp, thlm, wpthlp,                        & ! intent(inout)
-                            sclrm, wpsclrp, um, upwp, vm, vpwp )               ! intent(inout)
+                            sclrm, wpsclrp, um, upwp, vm, vpwp,              & ! intent(inout)
+                            um_pert, vm_pert, upwp_pert, vpwp_pert)            ! intent(inout)
 
       if ( clubb_at_least_debug_level( 0 ) ) then
           if ( err_code == clubb_fatal_error ) then
@@ -1598,7 +1616,8 @@ module advance_clubb_core_module
       call clip_covars_denom( dt, rtp2, thlp2, up2, vp2, wp2,           & ! intent(in)
                               sclrp2, wprtp_cl_num, wpthlp_cl_num,      & ! intent(in)
                               wpsclrp_cl_num, upwp_cl_num, vpwp_cl_num, & ! intent(in)
-                              wprtp, wpthlp, upwp, vpwp, wpsclrp )        ! intent(inout)
+                              wprtp, wpthlp, upwp, vpwp, wpsclrp,       & ! intent(inout)
+                              upwp_pert, vpwp_pert )                      ! intent(inout)
 
 
       !----------------------------------------------------------------
@@ -1647,7 +1666,8 @@ module advance_clubb_core_module
       call clip_covars_denom( dt, rtp2, thlp2, up2, vp2, wp2,           & ! intent(in)
                               sclrp2, wprtp_cl_num, wpthlp_cl_num,      & ! intent(in)
                               wpsclrp_cl_num, upwp_cl_num, vpwp_cl_num, & ! intent(in)
-                              wprtp, wpthlp, upwp, vpwp, wpsclrp )        ! intent(inout)
+                              wprtp, wpthlp, upwp, vpwp, wpsclrp,       & ! intent(inout)
+                              upwp_pert, vpwp_pert )                      ! intent(inout)
 
       !----------------------------------------------------------------
       ! Advance or otherwise calculate <thl'^3>, <rt'^3>, and
@@ -1737,7 +1757,8 @@ module advance_clubb_core_module
                                   rho_ds_zm, invrs_rho_ds_zt,                   & ! intent(in)
                                   fcor, l_implemented,                          & ! intent(in)
                                   um, vm, edsclrm,                              & ! intent(inout)
-                                  upwp, vpwp, wpedsclrp )                         ! intent(inout)
+                                  upwp, vpwp, wpedsclrp, &                        ! intent(inout)
+                                  um_pert, vm_pert, upwp_pert, vpwp_pert)         ! intent(inout)
 
       if ( l_do_expldiff_rtm_thlm ) then
         call pvertinterp(gr%nz, p_in_Pa, 70000.0_core_rknd, thlm, thlm700)

--- a/components/eam/src/physics/clubb/advance_windm_edsclrm_module.F90
+++ b/components/eam/src/physics/clubb/advance_windm_edsclrm_module.F90
@@ -37,7 +37,8 @@ module advance_windm_edsclrm_module
                rho_ds_zm, invrs_rho_ds_zt, &
                fcor, l_implemented, &
                um, vm, edsclrm, &
-               upwp, vpwp, wpedsclrp )
+               upwp, vpwp, wpedsclrp, &
+               um_pert, vm_pert, upwp_pert, vpwp_pert)
 
     ! Description:
     ! Solves for both mean horizontal wind components, um and vm, and for the
@@ -160,6 +161,13 @@ module advance_windm_edsclrm_module
     real( kind = core_rknd ), dimension(gr%nz,edsclr_dim), intent(inout) ::  &
       wpedsclrp      ! w'edsclr' (momentum levels)           [m/s {units vary}]
 
+    ! Variables used to track perturbed version of winds.
+    real( kind = core_rknd ), intent(inout), dimension(:), pointer ::  & 
+      um_pert,   & ! perturbed <u>    [m/s]
+      vm_pert,   & ! perturbed <v>    [m/s]
+      upwp_pert, & ! perturbed <u'w'> [m^2/s^2]
+      vpwp_pert    ! perturbed <v'w'> [m^2/s^2]
+
     ! Local Variables
     real( kind = core_rknd ), dimension(gr%nz) ::  &
       um_tndcy,    & ! u wind component tendency                    [m/s^2]
@@ -177,10 +185,12 @@ module advance_windm_edsclrm_module
       solution  ! The solution to the tridiagonal matrix            [units vary]
 
     real( kind = core_rknd ), dimension(gr%nz) :: &
-      wind_speed  ! wind speed; sqrt(u^2 + v^2)                     [m/s]
+      wind_speed, &   ! wind speed; sqrt(u^2 + v^2)                 [m/s]
+      wind_speed_pert ! pertubed wind speed; sqrt(u^2 + v^2)        [m/s]
 
     real( kind = core_rknd ) :: &
-      u_star_sqd  ! Surface friction velocity, u_star, squared      [m/s]
+      u_star_sqd, &   ! Surface friction velocity, u_star, squared  [m/s]
+      u_star_sqd_pert ! perturbed u_star, squared                   [m/s]
 
     logical :: &
       l_imp_sfc_momentum_flux  ! Flag for implicit momentum surface fluxes.
@@ -191,7 +201,13 @@ module advance_windm_edsclrm_module
 
     logical :: l_first_clip_ts, l_last_clip_ts ! flags for clip_covar
 
+    ! Whether perturbed winds are being solved.
+    logical :: l_perturbed_wind
+
     !--------------------------- Begin Code ------------------------------------
+    l_perturbed_wind = (.not. l_predict_upwp_vpwp) .and. associated(um_pert) &
+         .and. associated(vm_pert) .and. associated(upwp_pert) .and. &
+         associated(vpwp_pert)
 
     dummy_nu = 0._core_rknd
 
@@ -435,6 +451,182 @@ module advance_windm_edsclrm_module
           call clip_covar( clip_vpwp, l_first_clip_ts,      & ! intent(in)
                            l_last_clip_ts, dt, wp2, wp2,    & ! intent(in)
                            vpwp, vpwp_chnge )                 ! intent(inout)
+
+       endif ! l_tke_aniso
+
+    endif ! .not. l_predict_upwp_vpwp
+
+    if ( l_perturbed_wind ) then
+
+       !----------------------------------------------------------------
+       ! Prepare tridiagonal system for horizontal winds, um and vm
+       !----------------------------------------------------------------
+
+       ! Momentum surface fluxes, u'w'|_sfc and v'w'|_sfc, are applied through
+       ! an implicit method, such that:
+       !    x'w'|_sfc = - ( u_star(t)^2 / wind_speed(t) ) * xm(t+1).
+       l_imp_sfc_momentum_flux = .true.
+       ! Compute wind speed (use threshold "eps" to prevent divide-by-zero
+       ! error).
+       wind_speed_pert = max( sqrt( (um_pert)**2 + (vm_pert)**2 ), eps )
+       ! Compute u_star_sqd according to the definition of u_star.
+       u_star_sqd_pert = sqrt( upwp_pert(1)**2 + vpwp_pert(1)**2 )
+
+       ! Compute the explicit portion of the um equation.
+       ! Build the right-hand side vector.
+       call windm_edsclrm_rhs( windm_edsclrm_um, dt, nu10_vert_res_dep, & ! In
+                               Km_zm, um_pert, um_tndcy,                & ! In
+                               rho_ds_zm, invrs_rho_ds_zt,              & ! In
+                               l_imp_sfc_momentum_flux, upwp_pert(1),   & ! In
+                               rhs(:,windm_edsclrm_um)                  ) ! Out
+
+       ! Compute the explicit portion of the vm equation.
+       ! Build the right-hand side vector.
+       call windm_edsclrm_rhs( windm_edsclrm_vm, dt, nu10_vert_res_dep, & ! In
+                               Km_zm, vm_pert, vm_tndcy,                & ! In
+                               rho_ds_zm, invrs_rho_ds_zt,              & ! In
+                               l_imp_sfc_momentum_flux, vpwp_pert(1),   & ! In
+                               rhs(:,windm_edsclrm_vm)                  ) ! Out
+
+
+       ! Store momentum flux (explicit component)
+
+       ! The surface flux, x'w'(1) = x'w'|_sfc, is set elsewhere in the model.
+!      upwp(1) = upwp_sfc
+!      vpwp(1) = vpwp_sfc
+
+       ! Solve for x'w' at all intermediate model levels.
+       ! A Crank-Nicholson timestep is used.
+
+       upwp_pert(2:gr%nz-1) &
+       = -one_half &
+          * xpwp_fnc( Km_zm(2:gr%nz-1) + nu10_vert_res_dep(2:gr%nz-1), & ! in
+                      um_pert(2:gr%nz-1), um_pert(3:gr%nz), & ! in
+                      gr%invrs_dzm(2:gr%nz-1) )
+
+       vpwp_pert(2:gr%nz-1) &
+       = -one_half &
+          * xpwp_fnc( Km_zm(2:gr%nz-1) + nu10_vert_res_dep(2:gr%nz-1), & ! in
+                      vm_pert(2:gr%nz-1), vm_pert(3:gr%nz), & ! in
+                      gr%invrs_dzm(2:gr%nz-1) )
+
+       ! A zero-flux boundary condition at the top of the model, d(xm)/dz = 0,
+       ! means that x'w' at the top model level is 0,
+       ! since x'w' = - K_zm * d(xm)/dz.
+       upwp_pert(gr%nz) = zero
+       vpwp_pert(gr%nz) = zero
+
+
+       ! Compute the implicit portion of the um and vm equations.
+       ! Build the left-hand side matrix.
+       call windm_edsclrm_lhs( dt, nu10_vert_res_dep, wm_zt, Km_zm,    & ! In
+                               wind_speed_pert, u_star_sqd_pert,       & ! In
+                               rho_ds_zm, invrs_rho_ds_zt,             & ! In
+                               l_implemented, l_imp_sfc_momentum_flux, & ! In
+                               lhs )                                     ! Out
+
+       ! Decompose and back substitute for um and vm
+       nrhs = 2
+       call windm_edsclrm_solve( nrhs, iwindm_matrix_condt_num, & ! In
+                                 lhs, rhs, &                      ! In/out
+                                 solution )                       ! Out
+
+       ! Check for singular matrices and bad LAPACK arguments
+       if ( clubb_at_least_debug_level( 0 ) ) then
+          if ( err_code == clubb_fatal_error ) then
+             write(fstderr,*) "Fatal error solving for um_pert/vm_pert"
+             return
+          endif
+       endif
+
+       !----------------------------------------------------------------
+       ! Update zonal (west-to-east) component of mean wind, um
+       !----------------------------------------------------------------
+       um_pert(1:gr%nz) = solution(1:gr%nz,windm_edsclrm_um)
+
+       !----------------------------------------------------------------
+       ! Update meridional (south-to-north) component of mean wind, vm
+       !----------------------------------------------------------------
+       vm_pert(1:gr%nz) = solution(1:gr%nz,windm_edsclrm_vm)
+    
+       ! The values of um(1) and vm(1) are located below the model surface and
+       ! do not affect the rest of the model.  The values of um(1) or vm(1) are
+       ! simply set to the values of um(2) and vm(2), respectively, after the
+       ! equation matrices has been solved.  Even though um and vm would sharply
+       ! decrease to a value of 0 at the surface, this is done to avoid
+       ! confusion on plots of the vertical profiles of um and vm.
+       um_pert(1) = um_pert(2)
+       vm_pert(1) = vm_pert(2)
+
+       ! Second part of momentum (implicit component)
+
+       ! Solve for x'w' at all intermediate model levels.
+       ! A Crank-Nicholson timestep is used.
+
+       upwp_pert(2:gr%nz-1) &
+       = upwp_pert(2:gr%nz-1) &
+         - one_half * xpwp_fnc( Km_zm(2:gr%nz-1)+nu10_vert_res_dep(2:gr%nz-1), &
+                                um_pert(2:gr%nz-1), um_pert(3:gr%nz), &
+                                gr%invrs_dzm(2:gr%nz-1) )
+
+       vpwp_pert(2:gr%nz-1) &
+       = vpwp_pert(2:gr%nz-1) &
+         - one_half * xpwp_fnc( Km_zm(2:gr%nz-1)+nu10_vert_res_dep(2:gr%nz-1), &
+                                vm_pert(2:gr%nz-1), vm_pert(3:gr%nz), &
+                                gr%invrs_dzm(2:gr%nz-1) )
+
+       if ( l_tke_aniso ) then
+
+          ! Clipping for u'w'
+          !
+          ! Clipping u'w' at each vertical level, based on the
+          ! correlation of u and w at each vertical level, such that:
+          ! corr_(u,w) = u'w' / [ sqrt(u'^2) * sqrt(w'^2) ];
+          ! -1 <= corr_(u,w) <= 1.
+          !
+          ! Since u'^2, w'^2, and u'w' are each advanced in different
+          ! subroutines from each other in advance_clubb_core, clipping for u'w'
+          ! has to be done three times during each timestep (once after each
+          ! variable has been updated).
+          ! This is the third instance of u'w' clipping.
+          l_first_clip_ts = .false.
+          l_last_clip_ts = .true.
+          call clip_covar( clip_upwp, l_first_clip_ts,      & ! intent(in)
+                           l_last_clip_ts, dt, wp2, up2,    & ! intent(in)
+                           upwp_pert, upwp_chnge )            ! intent(inout)
+
+          ! Clipping for v'w'
+          !
+          ! Clipping v'w' at each vertical level, based on the
+          ! correlation of v and w at each vertical level, such that:
+          ! corr_(v,w) = v'w' / [ sqrt(v'^2) * sqrt(w'^2) ];
+          ! -1 <= corr_(v,w) <= 1.
+          !
+          ! Since v'^2, w'^2, and v'w' are each advanced in different
+          ! subroutines from each other in advance_clubb_core, clipping for v'w'
+          ! has to be done three times during each timestep (once after each
+          ! variable has been updated).
+          ! This is the third instance of v'w' clipping.
+          l_first_clip_ts = .false.
+          l_last_clip_ts = .true.
+          call clip_covar( clip_vpwp, l_first_clip_ts,      & ! intent(in)
+                           l_last_clip_ts, dt, wp2, vp2,    & ! intent(in)
+                           vpwp_pert, vpwp_chnge )            ! intent(inout)
+
+       else
+
+          ! In this case, it is assumed that
+          !   u'^2 == v'^2 == w'^2, and the variables `up2' and `vp2' do not
+          ! interact with any other variables.
+          l_first_clip_ts = .false.
+          l_last_clip_ts = .true.
+          call clip_covar( clip_upwp, l_first_clip_ts,      & ! intent(in)
+                           l_last_clip_ts, dt, wp2, wp2,    & ! intent(in)
+                           upwp_pert, upwp_chnge )            ! intent(inout)
+
+          call clip_covar( clip_vpwp, l_first_clip_ts,      & ! intent(in)
+                           l_last_clip_ts, dt, wp2, wp2,    & ! intent(in)
+                           vpwp_pert, vpwp_chnge )            ! intent(inout)
 
        endif ! l_tke_aniso
 

--- a/components/eam/src/physics/clubb/advance_windm_edsclrm_module.F90
+++ b/components/eam/src/physics/clubb/advance_windm_edsclrm_module.F90
@@ -255,13 +255,6 @@ module advance_windm_edsclrm_module
                                l_imp_sfc_momentum_flux, vpwp(1),        & ! In
                                rhs(:,windm_edsclrm_vm)                  ) ! Out
 
-
-       ! Store momentum flux (explicit component)
-
-       ! The surface flux, x'w'(1) = x'w'|_sfc, is set elsewhere in the model.
-!      upwp(1) = upwp_sfc
-!      vpwp(1) = vpwp_sfc
-
        ! Solve for x'w' at all intermediate model levels.
        ! A Crank-Nicholson timestep is used.
 
@@ -487,13 +480,6 @@ module advance_windm_edsclrm_module
                                rho_ds_zm, invrs_rho_ds_zt,              & ! In
                                l_imp_sfc_momentum_flux, vpwp_pert(1),   & ! In
                                rhs(:,windm_edsclrm_vm)                  ) ! Out
-
-
-       ! Store momentum flux (explicit component)
-
-       ! The surface flux, x'w'(1) = x'w'|_sfc, is set elsewhere in the model.
-!      upwp(1) = upwp_sfc
-!      vpwp(1) = vpwp_sfc
 
        ! Solve for x'w' at all intermediate model levels.
        ! A Crank-Nicholson timestep is used.

--- a/components/eam/src/physics/clubb/clip_explicit.F90
+++ b/components/eam/src/physics/clubb/clip_explicit.F90
@@ -40,7 +40,8 @@ module clip_explicit
   subroutine clip_covars_denom( dt, rtp2, thlp2, up2, vp2, wp2, &
                                 sclrp2, wprtp_cl_num, wpthlp_cl_num, &
                                 wpsclrp_cl_num, upwp_cl_num, vpwp_cl_num, &
-                                wprtp, wpthlp, upwp, vpwp, wpsclrp )
+                                wprtp, wpthlp, upwp, vpwp, wpsclrp, &
+                                upwp_pert, vpwp_pert)
 
     ! Description:
     ! Some of the covariances found in the CLUBB model code need to be clipped
@@ -105,6 +106,10 @@ module clip_explicit
 
     real( kind = core_rknd ), dimension(gr%nz,sclr_dim), intent(inout) :: &
       wpsclrp ! w'sclr'         [units m/s]
+
+    real( kind = core_rknd ), dimension(:), intent(inout), pointer :: &
+      upwp_pert,   & ! u'w'          [m^2/s^2]
+      vpwp_pert      ! v'w'          [m^2/s^2]
 
     ! Local Variables
     logical :: & 
@@ -273,11 +278,21 @@ module clip_explicit
       call clip_covar( clip_upwp, l_first_clip_ts,   & ! intent(in)
                        l_last_clip_ts, dt, wp2, up2, & ! intent(in)
                        upwp, upwp_chnge )              ! intent(inout)
+      if ( associated(upwp_pert) ) then
+         call clip_covar( clip_upwp, l_first_clip_ts,   & ! intent(in)
+                          l_last_clip_ts, dt, wp2, up2, & ! intent(in)
+                          upwp_pert, upwp_chnge )         ! intent(inout)
+      end if
     else
       ! In this case, up2 = wp2, and the variable `up2' does not interact
       call clip_covar( clip_upwp, l_first_clip_ts,   & ! intent(in)
                        l_last_clip_ts, dt, wp2, wp2, & ! intent(in)
                        upwp, upwp_chnge )              ! intent(inout)
+      if ( associated(upwp_pert) ) then
+         call clip_covar( clip_upwp, l_first_clip_ts,   & ! intent(in)
+                          l_last_clip_ts, dt, wp2, wp2, & ! intent(in)
+                          upwp_pert, upwp_chnge )         ! intent(inout)
+      end if
     end if
 
 
@@ -317,11 +332,21 @@ module clip_explicit
       call clip_covar( clip_vpwp, l_first_clip_ts,   & ! intent(in)
                        l_last_clip_ts, dt, wp2, vp2, & ! intent(in)
                        vpwp, vpwp_chnge )              ! intent(inout)
+      if ( associated(vpwp_pert) ) then
+         call clip_covar( clip_vpwp, l_first_clip_ts,   & ! intent(in)
+                          l_last_clip_ts, dt, wp2, vp2, & ! intent(in)
+                          vpwp_pert, vpwp_chnge )         ! intent(inout)
+      end if
     else
       ! In this case, vp2 = wp2, and the variable `vp2' does not interact
       call clip_covar( clip_vpwp, l_first_clip_ts,   & ! intent(in)
                        l_last_clip_ts, dt, wp2, wp2, & ! intent(in)
                        vpwp, vpwp_chnge )              ! intent(inout)
+      if ( associated(vpwp_pert) ) then
+         call clip_covar( clip_vpwp, l_first_clip_ts,   & ! intent(in)
+                          l_last_clip_ts, dt, wp2, wp2, & ! intent(in)
+                          vpwp_pert, vpwp_chnge )              ! intent(inout)
+      end if
     end if
 
 

--- a/components/eam/src/physics/clubb/clubb_api_module.F90
+++ b/components/eam/src/physics/clubb/clubb_api_module.F90
@@ -543,7 +543,9 @@ contains
     qclvar, thlprcp_out, &                                  ! intent(out)
 #endif
     wprcp, ice_supersat_frac, &                             ! intent(out)
-    rcm_in_layer, cloud_cover )                             ! intent(out)
+    rcm_in_layer, cloud_cover, &                            ! intent(out)
+    upwp_sfc_pert, vpwp_sfc_pert, &                         ! intent(in)
+    um_pert, vm_pert, upwp_pert, vpwp_pert )                ! intent(inout)
 
     use advance_clubb_core_module, only : advance_clubb_core
 
@@ -716,6 +718,14 @@ contains
       RH_crit  ! critical relative humidity for droplet and ice nucleation
     logical, intent(in)                 ::  do_liquid_only_in_clubb
 #endif
+    real( kind = core_rknd ), intent(in), pointer ::  &
+      upwp_sfc_pert,     & ! pertubed u'w' at surface          [m^2/s^2]
+      vpwp_sfc_pert        ! pertubed v'w' at surface          [m^2/s^2]
+    real( kind = core_rknd ), intent(inout), dimension(:), pointer ::  &
+      um_pert,      & ! pertubed eastward grid-mean wind component (thermodynamic levels)   [m/s]
+      vm_pert,      & ! pertubed northward grid-mean wind component (thermodynamic levels)   [m/s]
+      upwp_pert,    & ! pertubed u'w' (momentum levels)                         [m^2/s^2]
+      vpwp_pert       ! pertubed v'w' (momentum levels)                         [m^2/s^2]
     call advance_clubb_core( &
       l_implemented, dt, fcor, sfc_elevation, hydromet_dim, & ! intent(in)
       thlm_forcing, rtm_forcing, um_forcing, vm_forcing, &    ! intent(in)
@@ -757,7 +767,9 @@ contains
                qclvar, thlprcp_out, &                         ! intent(out)
 #endif
       wprcp, ice_supersat_frac, &                             ! intent(out)
-      rcm_in_layer, cloud_cover )                             ! intent(out)
+      rcm_in_layer, cloud_cover, &                            ! intent(out)
+      upwp_sfc_pert, vpwp_sfc_pert, &                         ! intent(in)
+      um_pert, vm_pert, upwp_pert, vpwp_pert )                ! intent(inout)
 
     err_code_api = err_code
 

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -85,6 +85,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <!-- Use implicit method for stress sent to atmosphere -->
 <implicit_stress>.false.</implicit_stress>
+<!-- The atmosphere provides gustiness separate from mean wind. -->
+<atm_gustiness>.false.</atm_gustiness>
 
 <!-- ========================================================================================  -->
 <!-- VSFM default                                                                              -->

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -83,6 +83,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <glc_snow_persistence_max_days>7300</glc_snow_persistence_max_days>
 
+<!-- Use implicit method for stress sent to atmosphere -->
+<implicit_stress>.false.</implicit_stress>
+
 <!-- ========================================================================================  -->
 <!-- VSFM default                                                                              -->
 <!-- ========================================================================================  -->

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -566,6 +566,11 @@ Subgrid fluxes for snow
 If TRUE, use implicit method to calculate stresses output to atmosphere.
 </entry>
 
+<entry id="atm_gustiness" type="logical" category="elm_physics"
+       group="elm_inparm" valid_values="">
+If TRUE, use an extra gustiness supplied by the atmosphere in addition to mean wind.
+</entry>
+
 <!-- ========================================================================================  -->
 <!-- Former CPP tokens -->
 <!-- ========================================================================================  -->

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -561,6 +561,11 @@ If TRUE, write diagnostic of global radiative temperature written to ELM log fil
 Subgrid fluxes for snow
 </entry>
 
+<entry id="implicit_stress" type="logical" category="elm_physics"
+       group="elm_inparm" valid_values="">
+If TRUE, use implicit method to calculate stresses output to atmosphere.
+</entry>
+
 <!-- ========================================================================================  -->
 <!-- Former CPP tokens -->
 <!-- ========================================================================================  -->

--- a/components/elm/cime_config/buildnml
+++ b/components/elm/cime_config/buildnml
@@ -25,6 +25,7 @@ def buildnml(case, caseroot, compname):
 
     srcroot             = case.get_value("SRCROOT")
     compset             = case.get_value("COMPSET")
+    atm_flux_method     = case.get_value("ATM_FLUX_INTEGRATION_METHOD")
     ccsm_co2_ppmv       = case.get_value("CCSM_CO2_PPMV")
     elm_co2_type        = case.get_value("ELM_CO2_TYPE")
     elm_usrdat_name     = case.get_value("ELM_USRDAT_NAME")
@@ -150,6 +151,13 @@ def buildnml(case, caseroot, compname):
 
         infile_text = ""
         if elmicfile: infile_text = "{} = '{}' \n".format(startfiletype, elm_startfile)
+
+        if atm_flux_method == 'implicit_stress':
+            implicit_stress = True
+        else:
+            implicit_stress = False
+
+        if implicit_stress: infile_text += " implicit_stress = .true. \n"
 
         create_namelist_infile(case,
                                "{}/user_nl_elm{}".format(caseroot, inst_string),

--- a/components/elm/cime_config/buildnml
+++ b/components/elm/cime_config/buildnml
@@ -26,6 +26,7 @@ def buildnml(case, caseroot, compname):
     srcroot             = case.get_value("SRCROOT")
     compset             = case.get_value("COMPSET")
     atm_flux_method     = case.get_value("ATM_FLUX_INTEGRATION_METHOD")
+    atm_gustiness       = case.get_value("ATM_SUPPLIES_GUSTINESS")
     ccsm_co2_ppmv       = case.get_value("CCSM_CO2_PPMV")
     elm_co2_type        = case.get_value("ELM_CO2_TYPE")
     elm_usrdat_name     = case.get_value("ELM_USRDAT_NAME")
@@ -158,6 +159,7 @@ def buildnml(case, caseroot, compname):
             implicit_stress = False
 
         if implicit_stress: infile_text += " implicit_stress = .true. \n"
+        if atm_gustiness: infile_text += " atm_gustiness = .true. \n"
 
         create_namelist_infile(case,
                                "{}/user_nl_elm{}".format(caseroot, inst_string),

--- a/components/elm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/elm/src/biogeophys/BareGroundFluxesMod.F90
@@ -134,6 +134,7 @@ contains
          forc_v           =>    top_as%vbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)
          wsresp           =>    top_as%wsresp                         , & ! Input:  [real(r8) (:)   ]  response of wind to surface stress (m/s/Pa)
          tau_est          =>    top_as%tau_est                        , & ! Input:  [real(r8) (:)   ]  approximate atmosphere change to zonal wind (m/s)
+         ugust            =>    top_as%ugust                          , & ! Input:  [real(r8) (:)   ]  gustiness from atmosphere (m/s)
          forc_th          =>    top_as%thbot                          , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)
          forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)
          forc_rho         =>    top_as%rhobot                         , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)
@@ -233,11 +234,11 @@ contains
          if (implicit_stress) then
             wind_speed0(p) = max(0.01_r8, hypot(forc_u(t), forc_v(t)))
             wind_speed_adj(p) = wind_speed0(p)
-            ur(p) = max(1.0_r8, wind_speed_adj(p))
+            ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
 
             prev_tau(p) = tau_est(t)
          else
-            ur(p)    = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
+            ur(p)    = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)) + ugust(t))
          end if
          tau_diff(p) = 1.e100_r8
 
@@ -292,7 +293,7 @@ contains
                call shr_flux_update_stress(wind_speed0(p), wsresp(t), tau_est(t), &
                     tau(p), prev_tau(p), tau_diff(p), prev_tau_diff(p), &
                     wind_speed_adj(p))
-               ur(p) = max(1.0_r8, wind_speed_adj(p))
+               ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
             end if
 
             tstar = temp1(p)*dth(p)

--- a/components/elm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/elm/src/biogeophys/BareGroundFluxesMod.F90
@@ -46,13 +46,15 @@ contains
     !
     ! !USES:
     use shr_const_mod        , only : SHR_CONST_RGAS
+    use shr_flux_mod         , only : shr_flux_update_stress
     use elm_varpar           , only : nlevgrnd
     use elm_varcon           , only : cpair, vkc, grav, denice, denh2o
-    use elm_varctl           , only : use_lch4
+    use elm_varctl           , only : iulog, use_lch4
     use landunit_varcon      , only : istsoil, istcrop
-    use FrictionVelocityMod  , only : FrictionVelocity, MoninObukIni
+    use FrictionVelocityMod  , only : FrictionVelocity, MoninObukIni, implicit_stress
     use QSatMod              , only : QSat
     use SurfaceResistanceMod , only : do_soilevap_beta
+    use clm_time_manager     , only : get_nstep
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds
@@ -69,12 +71,19 @@ contains
     type(waterstate_type)  , intent(inout) :: waterstate_vars
     !
     ! !LOCAL VARIABLES:
-    integer, parameter  :: niters = 3            ! maximum number of iterations for surface temperature
+    real(r8), parameter :: dtaumin = 0.01_r8     ! max limit for stress convergence [Pa]
+    integer, parameter  :: itmin = 3             ! minimum number of iterations
+    integer, parameter  :: itmax = 30            ! maximum number of iterations
     integer  :: p,c,t,g,f,j,l                    ! indices
     integer  :: filterp(bounds%endp-bounds%begp+1) ! patch filter for vegetated patches
     integer  :: fn                               ! number of values in local pft filter
+    integer  :: filterp0(bounds%endp-bounds%begp+1) ! pre-iteration filterp
+    integer  :: fn0                              ! pre-iteration fn
+    integer  :: fnold                            ! previous iteration fn
     integer  :: fp                               ! lake filter pft index
     integer  :: iter                             ! iteration index
+    integer  :: iter_final                       ! number of iterations used
+    integer  :: loopmax                          ! maximum number of iterations for this configuration
     real(r8) :: zldis(bounds%begp:bounds%endp)   ! reference height "minus" zero displacement height [m]
     real(r8) :: displa(bounds%begp:bounds%endp)  ! displacement height [m]
     real(r8) :: zeta                             ! dimensionless height used in Monin-Obukhov theory
@@ -109,6 +118,12 @@ contains
     real(r8) :: qsat_ref2m             ! 2 m height surface saturated specific humidity [kg/kg]
     real(r8) :: dqsat2mdT              ! derivative of 2 m height surface saturated specific humidity on t_ref2m
     real(r8) :: www                    ! surface soil wetness [-]
+    real(r8) :: wind_speed0(bounds%begp:bounds%endp) ! Wind speed from atmosphere at start of iteration
+    real(r8) :: wind_speed_adj(bounds%begp:bounds%endp) ! Adjusted wind speed for iteration
+    real(r8) :: tau(bounds%begp:bounds%endp)      ! Stress used in iteration
+    real(r8) :: tau_diff(bounds%begp:bounds%endp) ! Difference from previous iteration tau
+    real(r8) :: prev_tau(bounds%begp:bounds%endp) ! Previous iteration tau
+    real(r8) :: prev_tau_diff(bounds%begp:bounds%endp) ! Previous difference in iteration tau
     !------------------------------------------------------------------------------
 
     associate(                                                          &
@@ -117,6 +132,8 @@ contains
          zii              =>    col_pp%zii                            , & ! Input:  [real(r8) (:)   ]  convective boundary height [m]
          forc_u           =>    top_as%ubot                           , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)
          forc_v           =>    top_as%vbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)
+         wsresp           =>    top_as%wsresp                         , & ! Input:  [real(r8) (:)   ]  response of wind to surface stress (m/s/Pa)
+         tau_est          =>    top_as%tau_est                        , & ! Input:  [real(r8) (:)   ]  approximate atmosphere change to zonal wind (m/s)
          forc_th          =>    top_as%thbot                          , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)
          forc_pbot        =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)
          forc_rho         =>    top_as%rhobot                         , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)
@@ -212,7 +229,18 @@ contains
          dlrad(p)  = 0._r8
          ulrad(p)  = 0._r8
 
-         ur(p)    = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
+         ! Initialize winds for iteration.
+         if (implicit_stress) then
+            wind_speed0(p) = max(0.01_r8, hypot(forc_u(t), forc_v(t)))
+            wind_speed_adj(p) = wind_speed0(p)
+            ur(p) = max(1.0_r8, wind_speed_adj(p))
+
+            prev_tau(p) = tau_est(t)
+         else
+            ur(p)    = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
+         end if
+         tau_diff(p) = 1.e100_r8
+
          dth(p)   = thm(p)-t_grnd(c)
          dqh(p)   = forc_q(t) - qg(c)
          dthv     = dth(p)*(1._r8+0.61_r8*forc_q(t))+0.61_r8*forc_th(t)*dqh(p)
@@ -234,7 +262,16 @@ contains
       ! Determine friction velocity, and potential temperature and humidity
       ! profiles of the surface boundary layer
 
-      do iter = 1, niters
+      fn0 = fn
+      filterp0(1:fn) = filterp(1:fn)
+
+      if (implicit_stress) then
+         loopmax = itmax
+      else
+         loopmax = itmin
+      end if
+
+      ITERATION: do iter = 1, loopmax
 
          call FrictionVelocity(begp, endp, fn, filterp, &
               displa(begp:endp), z0mg_patch(begp:endp), z0hg_patch(begp:endp), z0qg_patch(begp:endp), &
@@ -247,6 +284,16 @@ contains
             c = veg_pp%column(p)
             t = veg_pp%topounit(p)
             g = veg_pp%gridcell(p)
+
+            ! Calculate magnitude of stress and update wind speed.
+            if (implicit_stress) then
+               ram = 1._r8/(ustar(p)*ustar(p)/um(p))
+               tau(p) = forc_rho(t)*wind_speed_adj(p)/ram
+               call shr_flux_update_stress(wind_speed0(p), wsresp(t), tau_est(t), &
+                    tau(p), prev_tau(p), tau_diff(p), prev_tau_diff(p), &
+                    wind_speed_adj(p))
+               ur(p) = max(1.0_r8, wind_speed_adj(p))
+            end if
 
             tstar = temp1(p)*dth(p)
             qstar = temp2(p)*dqh(p)
@@ -266,7 +313,27 @@ contains
             obu(p) = zldis(p)/zeta
          end do
 
-      end do ! end stability iteration
+         ! Test for convergence
+         iter_final = iter
+         if (iter >= itmin) then
+            fnold = fn
+            fn = 0
+            do f = 1, fnold
+               p = filterp(f)
+               if (.not. (abs(tau_diff(p)) < dtaumin)) then
+                  fn = fn + 1
+                  filterp(fn) = p
+               end if
+            end do
+            if (fn == 0) then
+               exit ITERATION
+            end if
+         end if
+
+      end do ITERATION ! end stability iteration
+
+      fn = fn0
+      filterp(1:fn) = filterp0(1:fn)
 
       do f = 1, fn
          p = filterp(f)
@@ -311,6 +378,10 @@ contains
          ! using ground temperatures from previous time step
          taux(p)          = -forc_rho(t)*forc_u(t)/ram
          tauy(p)          = -forc_rho(t)*forc_v(t)/ram
+         if (implicit_stress) then
+            taux(p)          = taux(p) * (wind_speed_adj(p) / wind_speed0(p))
+            tauy(p)          = tauy(p) * (wind_speed_adj(p) / wind_speed0(p))
+         end if
          eflx_sh_grnd(p)  = -raih*dth(p)
          eflx_sh_tot(p)   = eflx_sh_grnd(p)
 
@@ -342,6 +413,16 @@ contains
          if (lun_pp%itype(l) == istsoil .or. lun_pp%itype(l) == istcrop) then
             rh_ref2m_r(p) = rh_ref2m(p)
             t_ref2m_r(p) = t_ref2m(p)
+         end if
+
+         ! Check for convergence of stress.
+         if (implicit_stress .and. abs(tau_diff(p)) > dtaumin) then
+            if (get_nstep() > 0) then ! Suppress common warnings on the first time step.
+               write(iulog,*)'WARNING: Stress did not converge for bare ground ',&
+                    ' nstep = ',get_nstep(),' p= ',p,' prev_tau_diff= ',prev_tau_diff(p),&
+                    ' tau_diff= ',tau_diff(p),' tau= ',tau(p),&
+                    ' wind_speed_adj= ',wind_speed_adj(p),' iter_final= ',iter_final
+            end if
          end if
 
       end do

--- a/components/elm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/elm/src/biogeophys/CanopyFluxesMod.F90
@@ -348,6 +348,7 @@ contains
          forc_v               => top_as%vbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
          wsresp               => top_as%wsresp                             , & ! Input:  [real(r8) (:)   ]  response of wind to surface stress (m/s/Pa)
          tau_est              => top_as%tau_est                            , & ! Input:  [real(r8) (:)   ]  approximate atmosphere change to zonal wind (m/s)
+         ugust                => top_as%ugust                              , & ! Input:  [real(r8) (:)   ]  gustiness from atmosphere (m/s)
          forc_pco2            => top_as%pco2bot                            , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
          forc_pc13o2          => top_as%pc13o2bot                          , & ! Input:  [real(r8) (:)   ]  partial pressure c13o2 (Pa)                                           
          forc_po2             => top_as%po2bot                             , & ! Input:  [real(r8) (:)   ]  partial pressure o2 (Pa)                                              
@@ -729,11 +730,11 @@ contains
          if (implicit_stress) then
             wind_speed0(p) = max(0.01_r8, hypot(forc_u(t), forc_v(t)))
             wind_speed_adj(p) = wind_speed0(p)
-            ur(p) = max(1.0_r8, wind_speed_adj(p))
+            ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
 
             prev_tau(p) = tau_est(t)
          else
-            ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
+            ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)) + ugust(t))
          end if
          tau_diff(p) = 1.e100_r8
 
@@ -811,7 +812,7 @@ contains
                call shr_flux_update_stress(wind_speed0(p), wsresp(t), tau_est(t), &
                     tau(p), prev_tau(p), tau_diff(p), prev_tau_diff(p), &
                     wind_speed_adj(p))
-               ur(p) = max(1.0_r8, wind_speed_adj(p))
+               ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
             end if
 
             ! Bulk boundary layer resistance of leaves

--- a/components/elm/src/biogeophys/FrictionVelocityMod.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityMod.F90
@@ -17,6 +17,8 @@ module FrictionVelocityMod
   ! !PUBLIC TYPES:
   implicit none
   save
+
+  logical, public :: implicit_stress = .false.
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: FrictionVelocity       ! Calculate friction velocity

--- a/components/elm/src/biogeophys/FrictionVelocityMod.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityMod.F90
@@ -19,6 +19,7 @@ module FrictionVelocityMod
   save
 
   logical, public :: implicit_stress = .false.
+  logical, public :: atm_gustiness = .false.
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: FrictionVelocity       ! Calculate friction velocity

--- a/components/elm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/elm/src/biogeophys/LakeFluxesMod.F90
@@ -178,6 +178,7 @@ contains
          forc_v           =>    top_as%vbot                            , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)   
          wsresp           =>    top_as%wsresp                          , & ! Input:  [real(r8) (:)   ]  response of wind to surface stress (m/s/Pa)
          tau_est          =>    top_as%tau_est                         , & ! Input:  [real(r8) (:)   ]  approximate atmosphere change to zonal wind (m/s)
+         ugust            =>    top_as%ugust                           , & ! Input:  [real(r8) (:)   ]  gustiness from atmosphere (m/s)
          
          fsds_nir_d       =>    solarabs_vars%fsds_nir_d_patch         , & ! Input:  [real(r8) (:)   ]  incident direct beam nir solar radiation (W/m**2) 
          fsds_nir_i       =>    solarabs_vars%fsds_nir_i_patch         , & ! Input:  [real(r8) (:)   ]  incident diffuse nir solar radiation (W/m**2)     
@@ -355,11 +356,11 @@ contains
          if (implicit_stress) then
             wind_speed0(p) = max(0.01_r8, hypot(forc_u(t), forc_v(t)))
             wind_speed_adj(p) = wind_speed0(p)
-            ur(p) = max(1.0_r8, wind_speed_adj(p))
+            ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
 
             prev_tau(p) = tau_est(t)
          else
-            ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
+            ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)) + ugust(t))
          end if
          tau_diff(p) = 1.e100_r8
 
@@ -436,7 +437,7 @@ contains
                call shr_flux_update_stress(wind_speed0(p), wsresp(t), tau_est(t), &
                     tau(p), prev_tau(p), tau_diff(p), prev_tau_diff(p), &
                     wind_speed_adj(p))
-               ur(p) = max(1.0_r8, wind_speed_adj(p))
+               ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
             end if
 
             ! Get derivative of fluxes with respect to ground temperature

--- a/components/elm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/elm/src/biogeophys/UrbanFluxesMod.F90
@@ -342,7 +342,7 @@ contains
          else
             ur(l) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)) + ugust(t))
          end if
-         tau_diff(l) = 1.100_r8
+         tau_diff(l) = 1.e100_r8
 
       end do
 
@@ -936,17 +936,19 @@ contains
       end if
 
       ! Check for convergence of stress.
-      do fl = 1, num_urbanl
-         l = filter_urbanl(fl)
-         if (implicit_stress .and. abs(tau_diff(l)) > dtaumin) then
-            if (nstep > 0) then ! Suppress common warnings on the first time step.
-               write(iulog,*)'WARNING: Stress did not converge for urban columns ',&
-                    ' nstep = ',nstep,' indexl= ',l,' prev_tau_diff= ',prev_tau_diff(l),&
-                    ' tau_diff= ',tau_diff(l),' tau= ',tau(l),&
-                    ' wind_speed_adj= ',wind_speed_adj(l),' iter_final= ',iter_final
+      if (implicit_stress) then
+         do fl = 1, num_urbanl
+            l = filter_urbanl(fl)
+            if (abs(tau_diff(l)) > dtaumin) then
+               if (nstep > 0) then ! Suppress common warnings on the first time step.
+                  write(iulog,*)'WARNING: Stress did not converge for urban columns ',&
+                       ' nstep = ',nstep,' indexl= ',l,' prev_tau_diff= ',prev_tau_diff(l),&
+                       ' tau_diff= ',tau_diff(l),' tau= ',tau(l),&
+                       ' wind_speed_adj= ',wind_speed_adj(l),' iter_final= ',iter_final
+               end if
             end if
-         end if
-      end do
+         end do
+      end if
 
       ! Gather terms required to determine internal building temperature
 

--- a/components/elm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/elm/src/biogeophys/UrbanFluxesMod.F90
@@ -221,6 +221,7 @@ contains
          forc_v              =>   top_as%vbot                               , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)   
          wsresp              =>   top_as%wsresp                             , & ! Input:  [real(r8) (:)   ]  response of wind to surface stress (m/s/Pa)
          tau_est             =>   top_as%tau_est                            , & ! Input:  [real(r8) (:)   ]  approximate atmosphere change to zonal wind (m/s)
+         ugust               =>   top_as%ugust                              , & ! Input:  [real(r8) (:)   ]  gustiness from atmosphere (m/s)
 
          wind_hgt_canyon     =>   urbanparams_vars%wind_hgt_canyon          , & ! Input:  [real(r8) (:)   ]  height above road at which wind in canyon is to be computed (m)
          eflx_traffic_factor =>   urbanparams_vars%eflx_traffic_factor      , & ! Input:  [real(r8) (:)   ]  multiplicative urban traffic factor for sensible heat flux
@@ -335,11 +336,11 @@ contains
          if (implicit_stress) then
             wind_speed0(l) = max(0.01_r8, hypot(forc_u(t), forc_v(t)))
             wind_speed_adj(l) = wind_speed0(l)
-            ur(l) = max(1.0_r8, wind_speed_adj(l))
+            ur(l) = max(1.0_r8, wind_speed_adj(l) + ugust(t))
 
             prev_tau(l) = tau_est(t)
          else
-            ur(l) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)))
+            ur(l) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)) + ugust(t))
          end if
          tau_diff(l) = 1.100_r8
 
@@ -431,7 +432,7 @@ contains
                call shr_flux_update_stress(wind_speed0(l), wsresp(t), tau_est(t), &
                     tau(l), prev_tau(l), tau_diff(l), prev_tau_diff(l), &
                     wind_speed_adj(l))
-               ur(l) = max(1.0_r8, wind_speed_adj(l))
+               ur(l) = max(1.0_r8, wind_speed_adj(l) + ugust(t))
             end if
 
             ! Canyon top wind

--- a/components/elm/src/cpl/elm_cpl_indices.F90
+++ b/components/elm/src/cpl/elm_cpl_indices.F90
@@ -74,6 +74,8 @@ module elm_cpl_indices
   integer, public ::index_x2l_Sa_z            ! bottom atm level height
   integer, public ::index_x2l_Sa_u            ! bottom atm level zon wind
   integer, public ::index_x2l_Sa_v            ! bottom atm level mer wind
+  integer, public ::index_x2l_Sa_wsresp       ! first order response of wind to stress
+  integer, public ::index_x2l_Sa_tau_est      ! estimate of stress in equilibrium with wind
   integer, public ::index_x2l_Sa_ptem         ! bottom atm level pot temp
   integer, public ::index_x2l_Sa_shum         ! bottom atm level spec hum
   integer, public ::index_x2l_Sa_pbot         ! bottom atm level pressure
@@ -226,6 +228,8 @@ contains
     index_x2l_Sa_z          = mct_avect_indexra(x2l,'Sa_z')
     index_x2l_Sa_u          = mct_avect_indexra(x2l,'Sa_u')
     index_x2l_Sa_v          = mct_avect_indexra(x2l,'Sa_v')
+    index_x2l_Sa_wsresp     = mct_avect_indexra(x2l,'Sa_wsresp',perrwith='quiet')
+    index_x2l_Sa_tau_est    = mct_avect_indexra(x2l,'Sa_tau_est',perrwith='quiet')
     index_x2l_Sa_ptem       = mct_avect_indexra(x2l,'Sa_ptem')
     index_x2l_Sa_pbot       = mct_avect_indexra(x2l,'Sa_pbot')
     index_x2l_Sa_tbot       = mct_avect_indexra(x2l,'Sa_tbot')

--- a/components/elm/src/cpl/elm_cpl_indices.F90
+++ b/components/elm/src/cpl/elm_cpl_indices.F90
@@ -76,6 +76,7 @@ module elm_cpl_indices
   integer, public ::index_x2l_Sa_v            ! bottom atm level mer wind
   integer, public ::index_x2l_Sa_wsresp       ! first order response of wind to stress
   integer, public ::index_x2l_Sa_tau_est      ! estimate of stress in equilibrium with wind
+  integer, public ::index_x2l_Sa_ugust        ! gustiness from atm
   integer, public ::index_x2l_Sa_ptem         ! bottom atm level pot temp
   integer, public ::index_x2l_Sa_shum         ! bottom atm level spec hum
   integer, public ::index_x2l_Sa_pbot         ! bottom atm level pressure
@@ -230,6 +231,7 @@ contains
     index_x2l_Sa_v          = mct_avect_indexra(x2l,'Sa_v')
     index_x2l_Sa_wsresp     = mct_avect_indexra(x2l,'Sa_wsresp',perrwith='quiet')
     index_x2l_Sa_tau_est    = mct_avect_indexra(x2l,'Sa_tau_est',perrwith='quiet')
+    index_x2l_Sa_ugust      = mct_avect_indexra(x2l,'Sa_ugust',perrwith='quiet')
     index_x2l_Sa_ptem       = mct_avect_indexra(x2l,'Sa_ptem')
     index_x2l_Sa_pbot       = mct_avect_indexra(x2l,'Sa_pbot')
     index_x2l_Sa_tbot       = mct_avect_indexra(x2l,'Sa_tbot')

--- a/components/elm/src/cpl/lnd_import_export.F90
+++ b/components/elm/src/cpl/lnd_import_export.F90
@@ -38,6 +38,7 @@ contains
     use fileutils        , only: getavu, relavu
     use spmdmod          , only: masterproc, mpicom, iam, npes, MPI_REAL8, MPI_INTEGER, MPI_STATUS_SIZE
     use elm_nlUtilsMod   , only : find_nlgroup_name
+    use FrictionVelocityMod, only: implicit_stress
     use netcdf
     !
     ! !ARGUMENTS:
@@ -1029,6 +1030,10 @@ contains
          top_as%qbot(topo)    = atm2lnd_vars%forc_q_not_downscaled_grc(g)      ! forc_qxy  Atm state kg/kg
          top_as%ubot(topo)    = atm2lnd_vars%forc_u_grc(g)                     ! forc_uxy  Atm state m/s
          top_as%vbot(topo)    = atm2lnd_vars%forc_v_grc(g)                     ! forc_vxy  Atm state m/s
+         if (implicit_stress) then
+            top_as%wsresp(topo)  = 0._r8                                          !           Atm state m/s/Pa
+            top_as%tau_est(topo) = 0._r8                                          !           Atm state Pa
+         end if
          top_as%zbot(topo)    = atm2lnd_vars%forc_hgt_grc(g)                   ! zgcmxy    Atm state m
          ! assign the state forcing fields derived from other inputs
          ! Horizontal windspeed (m/s)
@@ -1107,6 +1112,10 @@ contains
          top_as%qbot(topo)    = x2l(index_x2l_Sa_shum,i)      ! forc_qxy  Atm state kg/kg
          top_as%ubot(topo)    = x2l(index_x2l_Sa_u,i)         ! forc_uxy  Atm state m/s
          top_as%vbot(topo)    = x2l(index_x2l_Sa_v,i)         ! forc_vxy  Atm state m/s
+         if (implicit_stress) then
+            top_as%wsresp(topo)  = x2l(index_x2l_Sa_wsresp,i)    !           Atm state m/s/Pa
+            top_as%tau_est(topo) = x2l(index_x2l_Sa_tau_est,i)   !           Atm state Pa
+         end if
          top_as%zbot(topo)    = x2l(index_x2l_Sa_z,i)         ! zgcmxy    Atm state m
          ! assign the state forcing fields derived from other inputs
          ! Horizontal windspeed (m/s)

--- a/components/elm/src/cpl/lnd_import_export.F90
+++ b/components/elm/src/cpl/lnd_import_export.F90
@@ -38,7 +38,7 @@ contains
     use fileutils        , only: getavu, relavu
     use spmdmod          , only: masterproc, mpicom, iam, npes, MPI_REAL8, MPI_INTEGER, MPI_STATUS_SIZE
     use elm_nlUtilsMod   , only : find_nlgroup_name
-    use FrictionVelocityMod, only: implicit_stress
+    use FrictionVelocityMod, only: implicit_stress, atm_gustiness
     use netcdf
     !
     ! !ARGUMENTS:
@@ -1031,13 +1031,17 @@ contains
          top_as%ubot(topo)    = atm2lnd_vars%forc_u_grc(g)                     ! forc_uxy  Atm state m/s
          top_as%vbot(topo)    = atm2lnd_vars%forc_v_grc(g)                     ! forc_vxy  Atm state m/s
          if (implicit_stress) then
-            top_as%wsresp(topo)  = 0._r8                                          !           Atm state m/s/Pa
-            top_as%tau_est(topo) = 0._r8                                          !           Atm state Pa
+            top_as%wsresp(topo)  = 0._r8                                       !           Atm state m/s/Pa
+            top_as%tau_est(topo) = 0._r8                                       !           Atm state Pa
          end if
+         top_as%ugust(topo) = 0._r8                                            !           Atm state m/s
          top_as%zbot(topo)    = atm2lnd_vars%forc_hgt_grc(g)                   ! zgcmxy    Atm state m
          ! assign the state forcing fields derived from other inputs
          ! Horizontal windspeed (m/s)
          top_as%windbot(topo) = sqrt(top_as%ubot(topo)**2 + top_as%vbot(topo)**2)
+         if (atm_gustiness) then
+            top_as%windbot(topo) = top_as%windbot(topo) + top_as%ugust(topo)
+         end if
          ! Relative humidity (percent)
          if (top_as%tbot(topo) > SHR_CONST_TKFRZ) then
             e = esatw(tdc(top_as%tbot(topo)))
@@ -1113,13 +1117,21 @@ contains
          top_as%ubot(topo)    = x2l(index_x2l_Sa_u,i)         ! forc_uxy  Atm state m/s
          top_as%vbot(topo)    = x2l(index_x2l_Sa_v,i)         ! forc_vxy  Atm state m/s
          if (implicit_stress) then
-            top_as%wsresp(topo)  = x2l(index_x2l_Sa_wsresp,i)    !           Atm state m/s/Pa
-            top_as%tau_est(topo) = x2l(index_x2l_Sa_tau_est,i)   !           Atm state Pa
+            top_as%wsresp(topo)  = x2l(index_x2l_Sa_wsresp,i) !           Atm state m/s/Pa
+            top_as%tau_est(topo) = x2l(index_x2l_Sa_tau_est,i)!           Atm state Pa
+         end if
+         if (atm_gustiness) then
+            top_as%ugust(topo)  = x2l(index_x2l_Sa_ugust,i)   !           Atm state m/s
+         else
+            top_as%ugust(topo) = 0._r8
          end if
          top_as%zbot(topo)    = x2l(index_x2l_Sa_z,i)         ! zgcmxy    Atm state m
          ! assign the state forcing fields derived from other inputs
          ! Horizontal windspeed (m/s)
          top_as%windbot(topo) = sqrt(top_as%ubot(topo)**2 + top_as%vbot(topo)**2)
+         if (atm_gustiness) then
+            top_as%windbot(topo) = top_as%windbot(topo) + top_as%ugust(topo)
+         end if
          ! Relative humidity (percent)
          if (top_as%tbot(topo) > SHR_CONST_TKFRZ) then
             e = esatw(tdc(top_as%tbot(topo)))

--- a/components/elm/src/data_types/TopounitDataType.F90
+++ b/components/elm/src/data_types/TopounitDataType.F90
@@ -36,6 +36,7 @@ module TopounitDataType
     real(r8), pointer :: vbot       (:) => null() ! wind speed in V (north) direction at atmospheric forcing height (m/s)
     real(r8), pointer :: wsresp     (:) => null() ! first-order response of wind to surface stress (m/s/Pa)
     real(r8), pointer :: tau_est    (:) => null() ! estimate of stress in equilibrium with winds (Pa)
+    real(r8), pointer :: ugust      (:) => null() ! extra gustiness from atmosphere (m/s)
     real(r8), pointer :: windbot    (:) => null() ! horizontal component of wind at atmospheric forcing height (m/s)
     real(r8), pointer :: zbot       (:) => null() ! atmospheric forcing height (m)
     real(r8), pointer :: po2bot     (:) => null() ! partial pressure of O2 at atmospheric forcing height (Pa)
@@ -113,6 +114,7 @@ module TopounitDataType
     allocate(this%vbot     (begt:endt)) ; this%vbot      (:) = spval
     allocate(this%wsresp   (begt:endt)) ; this%wsresp    (:) = spval
     allocate(this%tau_est  (begt:endt)) ; this%tau_est   (:) = spval
+    allocate(this%ugust    (begt:endt)) ; this%ugust     (:) = spval
     allocate(this%windbot  (begt:endt)) ; this%windbot   (:) = spval
     allocate(this%zbot     (begt:endt)) ; this%zbot      (:) = spval
     allocate(this%po2bot   (begt:endt)) ; this%po2bot    (:) = spval
@@ -191,6 +193,7 @@ module TopounitDataType
     deallocate(this%vbot)
     deallocate(this%wsresp)
     deallocate(this%tau_est)
+    deallocate(this%ugust)
     deallocate(this%windbot)
     deallocate(this%zbot)
     deallocate(this%po2bot)

--- a/components/elm/src/data_types/TopounitDataType.F90
+++ b/components/elm/src/data_types/TopounitDataType.F90
@@ -34,6 +34,8 @@ module TopounitDataType
     real(r8), pointer :: rhbot      (:) => null() ! relative humidity at atmospheric forcing height (%)
     real(r8), pointer :: ubot       (:) => null() ! wind speed in U (east) direction at atmospheric forcing height (m/s)
     real(r8), pointer :: vbot       (:) => null() ! wind speed in V (north) direction at atmospheric forcing height (m/s)
+    real(r8), pointer :: wsresp     (:) => null() ! first-order response of wind to surface stress (m/s/Pa)
+    real(r8), pointer :: tau_est    (:) => null() ! estimate of stress in equilibrium with winds (Pa)
     real(r8), pointer :: windbot    (:) => null() ! horizontal component of wind at atmospheric forcing height (m/s)
     real(r8), pointer :: zbot       (:) => null() ! atmospheric forcing height (m)
     real(r8), pointer :: po2bot     (:) => null() ! partial pressure of O2 at atmospheric forcing height (Pa)
@@ -109,6 +111,8 @@ module TopounitDataType
     allocate(this%rhbot    (begt:endt)) ; this%rhbot     (:) = spval
     allocate(this%ubot     (begt:endt)) ; this%ubot      (:) = spval
     allocate(this%vbot     (begt:endt)) ; this%vbot      (:) = spval
+    allocate(this%wsresp   (begt:endt)) ; this%wsresp    (:) = spval
+    allocate(this%tau_est  (begt:endt)) ; this%tau_est   (:) = spval
     allocate(this%windbot  (begt:endt)) ; this%windbot   (:) = spval
     allocate(this%zbot     (begt:endt)) ; this%zbot      (:) = spval
     allocate(this%po2bot   (begt:endt)) ; this%po2bot    (:) = spval
@@ -185,6 +189,8 @@ module TopounitDataType
     deallocate(this%rhbot)
     deallocate(this%ubot)
     deallocate(this%vbot)
+    deallocate(this%wsresp)
+    deallocate(this%tau_est)
     deallocate(this%windbot)
     deallocate(this%zbot)
     deallocate(this%po2bot)

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -38,6 +38,7 @@ module controlMod
   use CanopyHydrologyMod      , only: CanopyHydrology_readnl
   use SurfaceAlbedoMod        , only: albice, lake_melt_icealb
   use UrbanParamsType         , only: urban_hac, urban_traffic
+  use FrictionVelocityMod     , only: implicit_stress
   use elm_varcon              , only: h2osno_max
   use elm_varctl              , only: use_dynroot
   use AllocationMod         , only: nu_com_phosphatase,nu_com_nfix 
@@ -227,6 +228,10 @@ contains
 
     namelist /elm_inparm/  &
          urban_hac, urban_traffic
+
+    ! Stress options
+    namelist /elm_inparm/ &
+         implicit_stress
 
     ! vertical soil mixing variables
     namelist /elm_inparm/  &
@@ -760,6 +765,7 @@ contains
     ! physics variables
     call mpi_bcast (urban_hac, len(urban_hac), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (urban_traffic , 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (implicit_stress, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (nsegspc, 1, MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (subgridflag , 1, MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (wrtdia, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -1037,6 +1043,7 @@ contains
     write(iulog,*) '   land-ice albedos      (unitless 0-1)   = ', albice
     write(iulog,*) '   urban air conditioning/heating and wasteheat   = ', urban_hac
     write(iulog,*) '   urban traffic flux   = ', urban_traffic
+    write(iulog,*) '   implicit_stress   = ', implicit_stress
     write(iulog,*) '   more vertical layers = ', more_vertlayers
     if (nsrest == nsrContinue) then
        write(iulog,*) 'restart warning:'

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -38,7 +38,7 @@ module controlMod
   use CanopyHydrologyMod      , only: CanopyHydrology_readnl
   use SurfaceAlbedoMod        , only: albice, lake_melt_icealb
   use UrbanParamsType         , only: urban_hac, urban_traffic
-  use FrictionVelocityMod     , only: implicit_stress
+  use FrictionVelocityMod     , only: implicit_stress, atm_gustiness
   use elm_varcon              , only: h2osno_max
   use elm_varctl              , only: use_dynroot
   use AllocationMod         , only: nu_com_phosphatase,nu_com_nfix 
@@ -231,7 +231,7 @@ contains
 
     ! Stress options
     namelist /elm_inparm/ &
-         implicit_stress
+         implicit_stress, atm_gustiness
 
     ! vertical soil mixing variables
     namelist /elm_inparm/  &
@@ -766,6 +766,7 @@ contains
     call mpi_bcast (urban_hac, len(urban_hac), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (urban_traffic , 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (implicit_stress, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (atm_gustiness, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (nsegspc, 1, MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (subgridflag , 1, MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (wrtdia, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -1044,6 +1045,7 @@ contains
     write(iulog,*) '   urban air conditioning/heating and wasteheat   = ', urban_hac
     write(iulog,*) '   urban traffic flux   = ', urban_traffic
     write(iulog,*) '   implicit_stress   = ', implicit_stress
+    write(iulog,*) '   atm_gustiness   = ', atm_gustiness
     write(iulog,*) '   more vertical layers = ', more_vertlayers
     if (nsrest == nsrContinue) then
        write(iulog,*) 'restart warning:'

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -199,6 +199,17 @@
     </desc>
   </entry>
 
+  <entry id="ATM_SUPPLIES_GUSTINESS">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>
+      Whether or not the atmosphere should supply an extra gustiness field.
+    </desc>
+  </entry>
+
   <!-- ===================================================================== -->
   <!-- component coupling options and frequencies -->
   <!-- ===================================================================== -->

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -180,6 +180,25 @@
     <desc>Freezing point calculation for salt water.</desc>
   </entry>
 
+  <entry id="ATM_FLUX_INTEGRATION_METHOD">
+    <type>char</type>
+    <valid_values>explicit,implicit_stress</valid_values>
+    <default_value>explicit</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>
+      Time integration method for calculation of fluxes to the atmosphere.
+
+      explicit: Fluxes are calculated using the atmosphere's lowest-level state
+          at the current time step.
+
+      implicit_stress: The atmosphere model exports a linearization of the
+          response of the boundary layer scheme to surface stress, and other
+          components use this linearization to solve for surface stress at the
+          next time step implicitly.
+    </desc>
+  </entry>
+
   <!-- ===================================================================== -->
   <!-- component coupling options and frequencies -->
   <!-- ===================================================================== -->

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -159,6 +159,16 @@
     </values>
   </entry>
 
+  <entry id="atm_gustiness" modify_via_xml="ATM_SUPPLIES_GUSTINESS">
+    <type>logical</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>Set to .true. if the atmosphere produces a gustiness velocity. Set by the xml variable ATM_SUPPLIES_GUSTINESS in env_run.xml</desc>
+    <values>
+      <value>$ATM_SUPPLIES_GUSTINESS</value>
+    </values>
+  </entry>
+
   <entry  id="glc_nec" modify_via_xml="GLC_NEC">
     <type>integer</type>
     <category>seq_flds</category>

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -149,6 +149,16 @@
     </values>
   </entry>
 
+  <entry id="atm_flux_method" modify_via_xml="ATM_FLUX_INTEGRATION_METHOD">
+    <type>char</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>Time integration method for atmospheric fluxes. Set by the xml variable ATM_FLUX_INTEGRATION_METHOD in env_run.xml</desc>
+    <values>
+      <value>$ATM_FLUX_INTEGRATION_METHOD</value>
+    </values>
+  </entry>
+
   <entry  id="glc_nec" modify_via_xml="GLC_NEC">
     <type>integer</type>
     <category>seq_flds</category>
@@ -763,11 +773,13 @@
     <category>control</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      Iterate atmocn flux calculation a max of this value
+      Maximum number of iterations in atmosphere-ocean flux calculation.
+      Setting this value to -1 will cause the model to use a default that
+      depends on the setting of atm_flux_method.
     </desc>
     <values>
       <value cime_model='cesm'>5</value>
-      <value cime_model='e3sm'>2</value>
+      <value cime_model='e3sm'>-1</value>
     </values>
   </entry>
 

--- a/driver-mct/main/seq_flux_mct.F90
+++ b/driver-mct/main/seq_flux_mct.F90
@@ -47,6 +47,7 @@ module seq_flux_mct
   real(r8), allocatable ::  vbot (:)  ! atm velocity, meridional
   real(r8), allocatable ::  wsresp(:) ! atm response to surface stress
   real(r8), allocatable ::  tau_est(:)! estimation of tau in equilibrium with wind
+  real(r8), allocatable ::  ugust_atm(:)  ! atm gustiness
   real(r8), allocatable ::  thbot(:)  ! atm potential T
   real(r8), allocatable ::  shum (:)  ! atm specific humidity
   real(r8), allocatable ::  shum_16O (:)  ! atm H2O tracer
@@ -122,6 +123,7 @@ module seq_flux_mct
   integer :: index_a2x_Sa_v
   integer :: index_a2x_Sa_wsresp
   integer :: index_a2x_Sa_tau_est
+  integer :: index_a2x_Sa_ugust
   integer :: index_a2x_Sa_tbot
   integer :: index_a2x_Sa_ptem
   integer :: index_a2x_Sa_shum
@@ -240,12 +242,17 @@ contains
     if(ier/=0) call mct_die(subName,'allocate vbot',ier)
     vbot = 0.0_r8
     if (atm_flux_method == 'implicit_stress') then
-       allocate( wsresp(nloc))
+       allocate(wsresp(nloc))
        if(ier/=0) call mct_die(subName,'allocate wsresp',ier)
        wsresp = 0.0_r8
-       allocate( tau_est(nloc))
+       allocate(tau_est(nloc))
        if(ier/=0) call mct_die(subName,'allocate tau_est',ier)
        tau_est = 0.0_r8
+    end if
+    if (atm_gustiness) then
+       allocate(ugust_atm(nloc))
+       if(ier/=0) call mct_die(subName,'allocate ugust_atm',ier)
+       ugust_atm = 0.0_r8
     end if
     allocate(thbot(nloc),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate thbot',ier)
@@ -679,6 +686,10 @@ contains
        allocate( tau_est(nloc_a2o),stat=ier)
        if(ier/=0) call mct_die(subName,'allocate tau_est',ier)
     end if
+    if (atm_gustiness) then
+       allocate( ugust_atm(nloc_a2o),stat=ier)
+       if(ier/=0) call mct_die(subName,'allocate ugust_atm',ier)
+    end if
     allocate(thbot(nloc_a2o),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate thbot',ier)
     allocate(shum(nloc_a2o),stat=ier)
@@ -1044,6 +1055,9 @@ contains
              wsresp(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
              tau_est(n) = 0.0_r8 ! estimation of stress in equilibrium with ubot/vbot ~ Pa
           end if
+          if (atm_gustiness) then
+             ugust_atm(n) = 0.0_r8 ! gustiness                ~ m/s
+          end if
           thbot(n)= 301.0_r8 ! atm potential temperature  ~ Kelvin
           shum(n) = 1.e-2_r8 ! atm specific humidity      ~ kg/kg
           shum_16O(n) = 1.e-2_r8 ! H216O specific humidity    ~ kg/kg
@@ -1083,6 +1097,9 @@ contains
           if (atm_flux_method == 'implicit_stress') then
              wsresp(n) = a2x_e%rAttr(index_a2x_Sa_wsresp,ia)
              tau_est(n) = a2x_e%rAttr(index_a2x_Sa_tau_est,ia)
+          end if
+          if (atm_gustiness) then
+             ugust_atm(n) = a2x_e%rAttr(index_a2x_Sa_ugust,ia)
           end if
           thbot(n)= a2x_e%rAttr(index_a2x_Sa_ptem,ia)
           shum(n) = a2x_e%rAttr(index_a2x_Sa_shum,ia)
@@ -1141,7 +1158,7 @@ contains
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
             ocn_surface_flux_scheme, &
             duu10n,ustar, re  , ssq , missval = 0.0_r8, &
-            wsresp=wsresp, tau_est=tau_est)
+            wsresp=wsresp, tau_est=tau_est, ugust=ugust)
     endif
 
     !--- create temporary aVects on exchange, atm, or ocn decomp as needed
@@ -1389,6 +1406,9 @@ contains
           index_a2x_Sa_wsresp = mct_aVect_indexRA(a2x,'Sa_wsresp')
           index_a2x_Sa_tau_est = mct_aVect_indexRA(a2x,'Sa_tau_est')
        end if
+       if (atm_gustiness) then
+          index_a2x_Sa_ugust = mct_aVect_indexRA(a2x,'Sa_ugust')
+       end if
        index_a2x_Sa_tbot   = mct_aVect_indexRA(a2x,'Sa_tbot')
        index_a2x_Sa_pslv   = mct_aVect_indexRA(a2x,'Sa_pslv')
        index_a2x_Sa_ptem   = mct_aVect_indexRA(a2x,'Sa_ptem')
@@ -1446,6 +1466,9 @@ contains
              wsresp(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
              tau_est(n) = 0.0_r8 ! stress consistent w/ u/v  ~ Pa
           end if
+          if (atm_gustiness) then
+             ugust_atm(n) = 0.0_r8 ! gustiness                ~ m/s
+          end if
           thbot(n)= 301.0_r8 ! atm potential temperature  ~ Kelvin
           shum(n) = 1.e-2_r8 ! atm specific humidity      ~ kg/kg
           !wiso note: shum_* should be multiplied by Rstd_* here?
@@ -1496,6 +1519,9 @@ contains
              if (atm_flux_method == 'implicit_stress') then
                 wsresp(n) = a2x%rAttr(index_a2x_Sa_wsresp,n)
                 tau_est(n) = a2x%rAttr(index_a2x_Sa_tau_est,n)
+             end if
+             if (atm_gustiness) then
+                ugust_atm(n) = a2x%rAttr(index_a2x_Sa_ugust,n)
              end if
              thbot(n)= a2x%rAttr(index_a2x_Sa_ptem,n)
              shum(n) = a2x%rAttr(index_a2x_Sa_shum,n)
@@ -1592,7 +1618,7 @@ contains
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             ocn_surface_flux_scheme, &
             duu10n,ustar, re  , ssq, &
-            wsresp=wsresp, tau_est=tau_est)
+            wsresp=wsresp, tau_est=tau_est, ugust=ugust_atm)
        !missval should not be needed if flux calc
        !consistent with mrgx2a fraction
        !duu10n,ustar, re  , ssq, missval = 0.0_r8 )

--- a/driver-mct/main/seq_flux_mct.F90
+++ b/driver-mct/main/seq_flux_mct.F90
@@ -45,6 +45,8 @@ module seq_flux_mct
   real(r8), allocatable ::  zbot (:)  ! atm level height
   real(r8), allocatable ::  ubot (:)  ! atm velocity, zonal
   real(r8), allocatable ::  vbot (:)  ! atm velocity, meridional
+  real(r8), allocatable ::  wsresp(:) ! atm response to surface stress
+  real(r8), allocatable ::  tau_est(:)! estimation of tau in equilibrium with wind
   real(r8), allocatable ::  thbot(:)  ! atm potential T
   real(r8), allocatable ::  shum (:)  ! atm specific humidity
   real(r8), allocatable ::  shum_16O (:)  ! atm H2O tracer
@@ -118,6 +120,8 @@ module seq_flux_mct
   integer :: index_a2x_Sa_z
   integer :: index_a2x_Sa_u
   integer :: index_a2x_Sa_v
+  integer :: index_a2x_Sa_wsresp
+  integer :: index_a2x_Sa_tau_est
   integer :: index_a2x_Sa_tbot
   integer :: index_a2x_Sa_ptem
   integer :: index_a2x_Sa_shum
@@ -235,6 +239,14 @@ contains
     allocate( vbot(nloc))
     if(ier/=0) call mct_die(subName,'allocate vbot',ier)
     vbot = 0.0_r8
+    if (atm_flux_method == 'implicit_stress') then
+       allocate( wsresp(nloc))
+       if(ier/=0) call mct_die(subName,'allocate wsresp',ier)
+       wsresp = 0.0_r8
+       allocate( tau_est(nloc))
+       if(ier/=0) call mct_die(subName,'allocate tau_est',ier)
+       tau_est = 0.0_r8
+    end if
     allocate(thbot(nloc),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate thbot',ier)
     thbot = 0.0_r8
@@ -659,8 +671,14 @@ contains
     if(ier/=0) call mct_die(subName,'allocate zbot',ier)
     allocate( ubot(nloc_a2o),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate ubot',ier)
-    allocate( vbot(nloc_a2o))
+    allocate( vbot(nloc_a2o),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate vbot',ier)
+    if (atm_flux_method == 'implicit_stress') then
+       allocate( wsresp(nloc_a2o),stat=ier)
+       if(ier/=0) call mct_die(subName,'allocate wsresp',ier)
+       allocate( tau_est(nloc_a2o),stat=ier)
+       if(ier/=0) call mct_die(subName,'allocate tau_est',ier)
+    end if
     allocate(thbot(nloc_a2o),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate thbot',ier)
     allocate(shum(nloc_a2o),stat=ier)
@@ -1022,6 +1040,10 @@ contains
           zbot(n) =  55.0_r8 ! atm height of bottom layer ~ m
           ubot(n) =   0.0_r8 ! atm velocity, zonal        ~ m/s
           vbot(n) =   2.0_r8 ! atm velocity, meridional   ~ m/s
+          if (atm_flux_method == 'implicit_stress') then
+             wsresp(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
+             tau_est(n) = 0.0_r8 ! estimation of stress in equilibrium with ubot/vbot ~ Pa
+          end if
           thbot(n)= 301.0_r8 ! atm potential temperature  ~ Kelvin
           shum(n) = 1.e-2_r8 ! atm specific humidity      ~ kg/kg
           shum_16O(n) = 1.e-2_r8 ! H216O specific humidity    ~ kg/kg
@@ -1058,6 +1080,10 @@ contains
           zbot(n) = a2x_e%rAttr(index_a2x_Sa_z   ,ia)
           ubot(n) = a2x_e%rAttr(index_a2x_Sa_u   ,ia)
           vbot(n) = a2x_e%rAttr(index_a2x_Sa_v   ,ia)
+          if (atm_flux_method == 'implicit_stress') then
+             wsresp(n) = a2x_e%rAttr(index_a2x_Sa_wsresp,ia)
+             tau_est(n) = a2x_e%rAttr(index_a2x_Sa_tau_est,ia)
+          end if
           thbot(n)= a2x_e%rAttr(index_a2x_Sa_ptem,ia)
           shum(n) = a2x_e%rAttr(index_a2x_Sa_shum,ia)
           shum_16O(n) = a2x_e%rAttr(index_a2x_Sa_shum_16O,ia)
@@ -1096,14 +1122,15 @@ contains
             tbulk, tskin, tskin_day, tskin_night, &
             cskin, cskin_night, tod, dt,          &
             duu10n,ustar, re  , ssq , missval = 0.0_r8, &
-            cold_start=cold_start)
+            cold_start=cold_start, wsresp=wsresp, tau_est=tau_est)
     else if (ocn_surface_flux_scheme.eq.2) then
        call shr_flux_atmOcn_UA(nloc_a2o , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, pslv, &
             uocn, vocn , tocn , emask, sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
-            duu10n,ustar, re  , ssq , missval = 0.0_r8 )
+            duu10n,ustar, re  , ssq , missval = 0.0_r8, &
+            wsresp=wsresp, tau_est=tau_est)
     else
 
        call shr_flux_atmocn (nloc_a2o , zbot , ubot, vbot, thbot, &
@@ -1113,7 +1140,8 @@ contains
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
             ocn_surface_flux_scheme, &
-            duu10n,ustar, re  , ssq , missval = 0.0_r8 )
+            duu10n,ustar, re  , ssq , missval = 0.0_r8, &
+            wsresp=wsresp, tau_est=tau_est)
     endif
 
     !--- create temporary aVects on exchange, atm, or ocn decomp as needed
@@ -1303,6 +1331,17 @@ contains
          flux_convergence=flux_convergence, &
          flux_max_iteration=flux_max_iteration)
 
+       ! If flux_max_iteration is not set, choose a value based on
+       ! atm_flux_method.
+       if (flux_max_iteration == -1) then
+          select case(atm_flux_method)
+          case('implicit_stress')
+             flux_max_iteration = 30
+          case default
+             flux_max_iteration = 2
+          end select
+       end if
+
        if (.not.read_restart) cold_start = .true.
        index_xao_So_tref   = mct_aVect_indexRA(xao,'So_tref')
        index_xao_So_qref   = mct_aVect_indexRA(xao,'So_qref')
@@ -1346,6 +1385,10 @@ contains
        index_a2x_Sa_z      = mct_aVect_indexRA(a2x,'Sa_z')
        index_a2x_Sa_u      = mct_aVect_indexRA(a2x,'Sa_u')
        index_a2x_Sa_v      = mct_aVect_indexRA(a2x,'Sa_v')
+       if (atm_flux_method == 'implicit_stress') then
+          index_a2x_Sa_wsresp = mct_aVect_indexRA(a2x,'Sa_wsresp')
+          index_a2x_Sa_tau_est = mct_aVect_indexRA(a2x,'Sa_tau_est')
+       end if
        index_a2x_Sa_tbot   = mct_aVect_indexRA(a2x,'Sa_tbot')
        index_a2x_Sa_pslv   = mct_aVect_indexRA(a2x,'Sa_pslv')
        index_a2x_Sa_ptem   = mct_aVect_indexRA(a2x,'Sa_ptem')
@@ -1399,6 +1442,10 @@ contains
           zbot(n) =  55.0_r8 ! atm height of bottom layer ~ m
           ubot(n) =   0.0_r8 ! atm velocity, zonal        ~ m/s
           vbot(n) =   2.0_r8 ! atm velocity, meridional   ~ m/s
+          if (atm_flux_method == 'implicit_stress') then
+             wsresp(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
+             tau_est(n) = 0.0_r8 ! stress consistent w/ u/v  ~ Pa
+          end if
           thbot(n)= 301.0_r8 ! atm potential temperature  ~ Kelvin
           shum(n) = 1.e-2_r8 ! atm specific humidity      ~ kg/kg
           !wiso note: shum_* should be multiplied by Rstd_* here?
@@ -1446,6 +1493,10 @@ contains
              zbot(n) = a2x%rAttr(index_a2x_Sa_z   ,n)
              ubot(n) = a2x%rAttr(index_a2x_Sa_u   ,n)
              vbot(n) = a2x%rAttr(index_a2x_Sa_v   ,n)
+             if (atm_flux_method == 'implicit_stress') then
+                wsresp(n) = a2x%rAttr(index_a2x_Sa_wsresp,n)
+                tau_est(n) = a2x%rAttr(index_a2x_Sa_tau_est,n)
+             end if
              thbot(n)= a2x%rAttr(index_a2x_Sa_ptem,n)
              shum(n) = a2x%rAttr(index_a2x_Sa_shum,n)
              if ( index_a2x_Sa_shum_16O /= 0 ) shum_16O(n) = a2x%rAttr(index_a2x_Sa_shum_16O,n)
@@ -1524,14 +1575,14 @@ contains
                                 !missval should not be needed if flux calc
                                 !consistent with mrgx2a fraction
                                 !duu10n,ustar, re  , ssq, missval = 0.0_r8 )
-            cold_start=cold_start)
+            cold_start=cold_start, wsresp=wsresp, tau_est=tau_est)
     else if (ocn_surface_flux_scheme.eq.2) then
        call shr_flux_atmOcn_UA(nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, pslv, &
             uocn, vocn , tocn , emask, sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
-            duu10n,ustar, re  , ssq)
+            duu10n,ustar, re  , ssq, wsresp=wsresp, tau_est=tau_est)
     else
        call shr_flux_atmocn (nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
@@ -1540,7 +1591,8 @@ contains
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             ocn_surface_flux_scheme, &
-            duu10n,ustar, re  , ssq)
+            duu10n,ustar, re  , ssq, &
+            wsresp=wsresp, tau_est=tau_est)
        !missval should not be needed if flux calc
        !consistent with mrgx2a fraction
        !duu10n,ustar, re  , ssq, missval = 0.0_r8 )

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -121,7 +121,7 @@ module seq_flds_mod
   ! variables CCSM_VOC, CCSM_BGC and GLC_NEC.
   !====================================================================
 
-  use shr_kind_mod      , only : CX => shr_kind_CX, CXX => shr_kind_CXX
+  use shr_kind_mod      , only : CS => shr_kind_CS, CX => shr_kind_CX, CXX => shr_kind_CXX
   use shr_sys_mod       , only : shr_sys_abort
   use seq_comm_mct      , only : seq_comm_iamroot, seq_comm_setptrs, logunit
   use seq_drydep_mod    , only : seq_drydep_init, seq_drydep_readnl, lnd_drydep
@@ -150,6 +150,9 @@ module seq_flds_mod
 
   logical            :: rof_heat            ! .true. if river model includes temperature
   logical            :: add_ndep_fields     ! .true. => add ndep fields
+
+  character(len=CS)  :: atm_flux_method     ! explicit => no extra fields needed
+                                            ! implicit_stress => atm provides wsresp and tau_est
 
   !----------------------------------------------------------------------------
   ! metadata
@@ -368,7 +371,7 @@ contains
     namelist /seq_cplflds_inparm/  &
          flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, glc_nec, &
          ice_ncat, seq_flds_i2o_per_cat, flds_bgc_oi, &
-         nan_check_component_fields, rof_heat
+         nan_check_component_fields, rof_heat, atm_flux_method
 
     ! user specified new fields
     integer,  parameter :: nfldmax = 200
@@ -404,6 +407,7 @@ contains
        seq_flds_i2o_per_cat = .false.
        nan_check_component_fields = .false.
        rof_heat = .false.
+       atm_flux_method = 'explicit'
 
        unitn = shr_file_getUnit()
        write(logunit,"(A)") subname//': read seq_cplflds_inparm namelist from: '&
@@ -431,6 +435,7 @@ contains
     call shr_mpi_bcast(seq_flds_i2o_per_cat, mpicom)
     call shr_mpi_bcast(nan_check_component_fields, mpicom)
     call shr_mpi_bcast(rof_heat    , mpicom)
+    call shr_mpi_bcast(atm_flux_method, mpicom)
 
     call glc_elevclass_init(glc_nec)
 
@@ -637,6 +642,28 @@ contains
     units    = 'm s-1'
     attname  = 'Sa_v'
     call metadata_set(attname, longname, stdname, units)
+
+    if (atm_flux_method == 'implicit_stress') then
+       ! first-order response of wind to surface stresses (m/s/Pa)
+       call seq_flds_add(a2x_states,"Sa_wsresp")
+       call seq_flds_add(x2l_states,"Sa_wsresp")
+       call seq_flds_add(x2i_states,"Sa_wsresp")
+       longname = 'Response of wind to surface stress'
+       stdname  = 'wsresp'
+       units    = 'm s-1 Pa-1'
+       attname  = 'Sa_wsresp'
+       call metadata_set(attname, longname, stdname, units)
+
+       ! surface stress compatible with low level wind (Pa)
+       call seq_flds_add(a2x_states,"Sa_tau_est")
+       call seq_flds_add(x2l_states,"Sa_tau_est")
+       call seq_flds_add(x2i_states,"Sa_tau_est")
+       longname = 'estimate of surface stress in equilibrium with boundary layer'
+       stdname  = 'tau_est'
+       units    = 'Pa'
+       attname  = 'Sa_tau_est'
+       call metadata_set(attname, longname, stdname, units)
+    end if
 
     ! temperature at the lowest model level (K)
     call seq_flds_add(a2x_states,"Sa_tbot")


### PR DESCRIPTION
This PR adds two options to env_run.xml that affect the calculation of surface stresses. Both options are off by default, and this PR should be a BFB change unless these options are activated.

The first of these options is ATM_SUPPLIES_GUSTINESS, which causes the atmosphere to export a new field `ugust` to the coupler (and relevant surface components). This extra gustiness is then used in the calculation of the stress by the surface components.

The second option added in this PR is `ATM_FLUX_INTEGRATION_METHOD`. The default is `explicit`, which uses the existing stress calculations. If this option is set to `implicit_stress`, an implicit method is used to calculate the surface stresses, which reduces the instability due to a coarse time step. This requires two additional fields to be exported from the coupler (`wsresp` and `tau_est`), which represent a linearization of the response of the boundary layer scheme to the surface stresses. This commit provides a partial solution to issue #4073.