### PR TITLE
update mpas-source: add GOTM vertical mixing library

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -641,6 +641,16 @@ add_default($nl, 'config_cvmix_kpp_use_theory_wave');
 add_default($nl, 'config_cvmix_kpp_langmuir_mixing_opt');
 add_default($nl, 'config_cvmix_kpp_langmuir_entrainment_opt');
 
+########################
+# Namelist group: gotm #
+########################
+
+add_default($nl, 'config_use_gotm');
+add_default($nl, 'config_gotm_namelist_file');
+add_default($nl, 'config_gotm_constant_surface_roughness_length');
+add_default($nl, 'config_gotm_constant_bottom_roughness_length');
+add_default($nl, 'config_gotm_constant_bottom_drag_coeff');
+
 ###########################
 # Namelist group: forcing #
 ###########################
@@ -762,6 +772,8 @@ add_default($nl, 'config_density0');
 
 add_default($nl, 'config_pressure_gradient_type');
 add_default($nl, 'config_common_level_weight');
+add_default($nl, 'config_zonal_ssh_grad');
+add_default($nl, 'config_meridional_ssh_grad');
 
 #######################
 # Namelist group: eos #
@@ -1596,6 +1608,7 @@ my @groups = qw(run_modes
                 mesoscale_eddy_parameterizations
                 rayleigh_damping
                 cvmix
+                gotm
                 forcing
                 coupling
                 shortwaveradiation

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -12,6 +12,7 @@ my @groups = qw(run_modes
                 gm_eddy_parameterization
                 rayleigh_damping
                 cvmix
+                gotm
                 forcing
                 coupling
                 shortwaveradiation

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -182,6 +182,16 @@ add_default($nl, 'config_cvmix_kpp_use_theory_wave');
 add_default($nl, 'config_cvmix_kpp_langmuir_mixing_opt');
 add_default($nl, 'config_cvmix_kpp_langmuir_entrainment_opt');
 
+########################
+# Namelist group: gotm #
+########################
+
+add_default($nl, 'config_use_gotm');
+add_default($nl, 'config_gotm_namelist_file');
+add_default($nl, 'config_gotm_constant_surface_roughness_length');
+add_default($nl, 'config_gotm_constant_bottom_roughness_length');
+add_default($nl, 'config_gotm_constant_bottom_drag_coeff');
+
 ###########################
 # Namelist group: forcing #
 ###########################
@@ -293,6 +303,8 @@ add_default($nl, 'config_density0');
 
 add_default($nl, 'config_pressure_gradient_type');
 add_default($nl, 'config_common_level_weight');
+add_default($nl, 'config_zonal_ssh_grad');
+add_default($nl, 'config_meridional_ssh_grad');
 
 #######################
 # Namelist group: eos #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -255,6 +255,13 @@
 <config_cvmix_kpp_langmuir_mixing_opt>'NONE'</config_cvmix_kpp_langmuir_mixing_opt>
 <config_cvmix_kpp_langmuir_entrainment_opt>'NONE'</config_cvmix_kpp_langmuir_entrainment_opt>
 
+<!-- gotm -->
+<config_use_gotm>.false.</config_use_gotm>
+<config_gotm_namelist_file>'gotmturb.nml'</config_gotm_namelist_file>
+<config_gotm_constant_surface_roughness_length>0.02</config_gotm_constant_surface_roughness_length>
+<config_gotm_constant_bottom_roughness_length>0.0015</config_gotm_constant_bottom_roughness_length>
+<config_gotm_constant_bottom_drag_coeff>1.e-3</config_gotm_constant_bottom_drag_coeff>
+
 <!-- forcing -->
 <config_use_variable_drag>.false.</config_use_variable_drag>
 <config_use_bulk_wind_stress>.true.</config_use_bulk_wind_stress>
@@ -356,6 +363,8 @@
 <!-- pressure_gradient -->
 <config_pressure_gradient_type>'Jacobian_from_TS'</config_pressure_gradient_type>
 <config_common_level_weight>0.5</config_common_level_weight>
+<config_zonal_ssh_grad>0.0</config_zonal_ssh_grad>
+<config_meridional_ssh_grad>0.0</config_meridional_ssh_grad>
 
 <!-- eos -->
 <config_eos_type>'jm'</config_eos_type>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -956,6 +956,49 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
+<!-- gotm -->
+
+<entry id="config_use_gotm" type="logical"
+	category="gotm" group="gotm">
+If true, use the General Ocean Turbulence Model routines to compute vertical diffusivity and viscosity
+
+Valid values: True or False
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gotm_namelist_file" type="char*1024"
+	category="gotm" group="gotm">
+File name of GOTM turbulence namelist
+
+Valid values: gotmturb.nml
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gotm_constant_surface_roughness_length" type="real"
+	category="gotm" group="gotm">
+The constant surface roughness length scale.
+
+Valid values: Any positive real number.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gotm_constant_bottom_roughness_length" type="real"
+	category="gotm" group="gotm">
+The constant bottom roughness length scale.
+
+Valid values: Any positive real number.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_gotm_constant_bottom_drag_coeff" type="real"
+	category="gotm" group="gotm">
+The constant bottom drag coefficient.
+
+Valid values: Any positive real number.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
 <!-- forcing -->
 
 <entry id="config_use_variable_drag" type="logical"
@@ -1469,7 +1512,7 @@ Default: Defined in namelist_defaults.xml
 	category="pressure_gradient" group="pressure_gradient">
 Form of pressure gradient terms in momentum equation. For most applications, the gradient of pressure and layer mid-depth are appropriate.  For isopycnal coordinates, one may use the gradient of the Montgomery potential.  The sea surface height gradient (ssh_gradient) option is for barotropic, depth-averaged pressure.
 
-Valid values: 'ssh_gradient', 'pressure_and_zmid' or 'Jacobian_from_density' or 'Jacobian_from_TS' or 'MontgomeryPotential'
+Valid values: 'ssh_gradient', 'pressure_and_zmid' or 'Jacobian_from_density' or 'Jacobian_from_TS' or 'MontgomeryPotential' or 'constant_forced'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1478,6 +1521,22 @@ Default: Defined in namelist_defaults.xml
 The weight between standard Jacobian and weighted Jacobian, $\gamma$.
 
 Valid values: any real between 0 and 1
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_zonal_ssh_grad" type="real"
+	category="pressure_gradient" group="pressure_gradient">
+The zonal (x) ssh gradient to be applied.
+
+Valid values: any real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_meridional_ssh_grad" type="real"
+	category="pressure_gradient" group="pressure_gradient">
+The meridional (y) ssh gradient to be applied.
+
+Valid values: any real
 Default: Defined in namelist_defaults.xml
 </entry>
 


### PR DESCRIPTION
This PR adds the General Ocean Turbulence Model (GOTM) in MPAS-Ocean as an additional option for the vertical turbulence closure, especially for coastal simulations in which the present implementation of KPP in CVMix does not work well. GOTM is a turbulence closure library that includes a set of two equation models such as k-epsilon and the generic length scale model (GLS; Umlauf and Burchard, 2003). See https://github.com/MPAS-Dev/MPAS-Model/pull/704

GOTM is default off, but is compiled by E3SM.

[BFB]
[NML]