### PR TITLE
Remove SSH Filtering between ocean and sea ice in E3SM

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -263,7 +263,7 @@
 <config_flux_attenuation_coefficient_runoff>10.0</config_flux_attenuation_coefficient_runoff>
 
 <!-- coupling -->
-<config_ssh_grad_relax_timescale>0.0</config_ssh_grad_relax_timescale>
+<config_ssh_grad_relax_timescale ocn_grid="EC30to60E2r2">0.0</config_ssh_grad_relax_timescale>
 <config_remove_AIS_coupler_runoff>.false.</config_remove_AIS_coupler_runoff>
 
 <!-- shortwaveRadiation -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -263,6 +263,7 @@
 <config_flux_attenuation_coefficient_runoff>10.0</config_flux_attenuation_coefficient_runoff>
 
 <!-- coupling -->
+<config_ssh_grad_relax_timescale>86400.0</config_ssh_grad_relax_timescale>
 <config_ssh_grad_relax_timescale ocn_grid="EC30to60E2r2">0.0</config_ssh_grad_relax_timescale>
 <config_remove_AIS_coupler_runoff>.false.</config_remove_AIS_coupler_runoff>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -263,7 +263,7 @@
 <config_flux_attenuation_coefficient_runoff>10.0</config_flux_attenuation_coefficient_runoff>
 
 <!-- coupling -->
-<config_ssh_grad_relax_timescale>86400.0</config_ssh_grad_relax_timescale>
+<config_ssh_grad_relax_timescale>0.0</config_ssh_grad_relax_timescale>
 <config_remove_AIS_coupler_runoff>.false.</config_remove_AIS_coupler_runoff>
 
 <!-- shortwaveRadiation -->


### PR DESCRIPTION
This PR is to turn of sea surface height filtering between ocean and sea ice, since it is no longer needed to maintain stability in fully coupled model.  For further information, please refer to https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/2633269275/20210409.v2beta4.SSHFilterOff.ne30pg2+EC30to60E2r2.chrysalis

[non-BFB] for test with the EC30to60E2r2 mesh