### PR TITLE
Change passing of heat associated with frazil between ocean and ice

### DIFF
--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -16,7 +16,7 @@ module mpaso_cpl_indices
   integer :: index_o2x_So_s
   integer :: index_o2x_So_dhdx
   integer :: index_o2x_So_dhdy
-  integer :: index_o2x_Fioo_meltp
+  integer :: index_o2x_Fioo_q
   integer :: index_o2x_Fioo_frazil
   integer :: index_o2x_Faoo_h2otemp
   integer :: index_o2x_Faoo_fco2_ocn
@@ -153,7 +153,7 @@ contains
     index_o2x_So_s          = mct_avect_indexra(o2x,'So_s')
     index_o2x_So_dhdx       = mct_avect_indexra(o2x,'So_dhdx')
     index_o2x_So_dhdy       = mct_avect_indexra(o2x,'So_dhdy')
-    index_o2x_Fioo_meltp    = mct_avect_indexra(o2x,'Fioo_meltp',perrWith='quiet')
+    index_o2x_Fioo_q        = mct_avect_indexra(o2x,'Fioo_q',perrWith='quiet')
     index_o2x_Fioo_frazil   = mct_avect_indexra(o2x,'Fioo_frazil',perrWith='quiet')
     index_o2x_Faoo_h2otemp  = mct_avect_indexra(o2x,'Faoo_h2otemp',perrWith='quiet')
     index_o2x_Faoo_fco2_ocn = mct_avect_indexra(o2x,'Faoo_fco2_ocn',perrWith='quiet')

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2328,6 +2328,7 @@ contains
    real (kind=RKIND) :: surfaceFreezingTemp
 
    logical, pointer :: frazilIceActive,          &
+                       config_frazil_heat_of_fusion, &
                        config_use_ecosysTracers, &
                        config_use_DMSTracers,    &
                        config_use_MacroMoleculesTracers,  &
@@ -2343,6 +2344,7 @@ contains
 
    ! get configure options
    call mpas_pool_get_package(domain % packages, 'frazilIceActive', frazilIceActive)
+   call mpas_pool_get_config(domain % configs, 'config_frazil_heat_of_fusion', config_frazil_heat_of_fusion)
    call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers', config_use_ecosysTracers)
    call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
    call mpas_pool_get_config(domain % configs, 'config_use_DMSTracers', config_use_DMSTracers)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2325,7 +2325,7 @@ contains
                                                  avgOceanSurfacePhytoC, &
                                                  avgOceanSurfaceDOC, layerThickness
 
-   real (kind=RKIND) :: SurfacefreezingTemp
+   real (kind=RKIND) :: surfaceFreezingTemp
 
    logical, pointer :: frazilIceActive,          &
                        config_use_ecosysTracers, &
@@ -2444,21 +2444,31 @@ contains
 
           if ( keepFrazil ) then
 
-             ! We assume here that avgTracersSurfaceValue represents only the
-             ! top layer of the ocean.
+             ! Calculate energy associated with frazil mass transfer to sea ice if frazil has accumulated
+             if ( accumulatedFrazilIceMass(i) > 0.0_RKIND ) then
 
-             SurfacefreezingTemp = ocn_freezing_temperature(salinity=avgTracersSurfaceValue(index_salinitySurfaceValue, i), &
+              seaIceEnergy(i) = accumulatedFrazilIceMass(i) * config_frazil_heat_of_fusion 
+
+             ! Otherwise calculate the melt potential where avgTracersSurfaceValue represents only the
+             ! top layer of the ocean
+             else
+
+              surfaceFreezingTemp = ocn_freezing_temperature(salinity=avgTracersSurfaceValue(index_salinitySurfaceValue, i), &
                  pressure=0.0_RKIND,  inLandIceCavity=.false.) 
 
-             seaIceEnergy(i) = min(rho_sw*cp_sw*layerThickness(1, i)*( SurfacefreezingTemp + T0_Kelvin &
-                             - avgTracersSurfaceValue(index_temperatureSurfaceValue, i) ), 0.0_RKIND )
-             if ( accumulatedFrazilIceMass(i) > 0.0_RKIND ) seaIceEnergy(i) = 0.0_RKIND
+              seaIceEnergy(i) = min(rho_sw*cp_sw*layerThickness(1, i)*( surfaceFreezingTemp + T0_Kelvin &
+                              - avgTracersSurfaceValue(index_temperatureSurfaceValue, i) ), 0.0_RKIND )
 
-             o2x_o % rAttr(index_o2x_Fioo_meltp, n)  = seaIceEnergy(i) / ocn_cpl_dt
+             end if
+
+             o2x_o % rAttr(index_o2x_Fioo_q, n)  = seaIceEnergy(i) / ocn_cpl_dt
              o2x_o % rAttr(index_o2x_Fioo_frazil, n) = accumulatedFrazilIceMass(i) / ocn_cpl_dt
+
           else
-             o2x_o % rAttr(index_o2x_Fioo_meltp, n)  = 0.0_RKIND
+
+             o2x_o % rAttr(index_o2x_Fioo_q, n)  = 0.0_RKIND
              o2x_o % rAttr(index_o2x_Fioo_frazil, n) = 0.0_RKIND
+
           end if
 
           ! Reset SeaIce Energy and Accumulated Frazil Ice

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2328,7 +2328,6 @@ contains
    real (kind=RKIND) :: surfaceFreezingTemp
 
    logical, pointer :: frazilIceActive,          &
-                       config_frazil_heat_of_fusion, &
                        config_use_ecosysTracers, &
                        config_use_DMSTracers,    &
                        config_use_MacroMoleculesTracers,  &
@@ -2344,7 +2343,6 @@ contains
 
    ! get configure options
    call mpas_pool_get_package(domain % packages, 'frazilIceActive', frazilIceActive)
-   call mpas_pool_get_config(domain % configs, 'config_frazil_heat_of_fusion', config_frazil_heat_of_fusion)
    call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers', config_use_ecosysTracers)
    call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
    call mpas_pool_get_config(domain % configs, 'config_use_DMSTracers', config_use_DMSTracers)

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -1642,7 +1642,7 @@ contains
 !    o  swndf    -- sw: nir diffuse downward
 !    o  swvdf    -- sw: vis diffuse downward
 !    o  swnet    -- sw: net
-!    o  meltp    -- ocn melt heat  
+!    o  q        -- ocn freeze/melt heat flux
 !    o  frazil   -- ocn frazil production
 !    o  bcphidry -- Black Carbon hydrophilic dry deposition flux
 !    o  bcphodry -- Black Carbon hydrophobic dry deposition flux
@@ -1928,13 +1928,13 @@ contains
 
         if (trim(config_ocean_surface_type) == "free") then ! free surface (MPAS-O)
         
-           meltingPotential            = x2i_i % rAttr(index_x2i_Fioo_meltp, n)
+           meltingPotential            = x2i_i % rAttr(index_x2i_Fioo_q, n)
 
            ! frazil calculation
            frazilProduction            = x2i_i % rAttr(index_x2i_Fioo_frazil, n)
            call freezing_potential(freezingPotential, frazilProduction, seaSurfaceSalinity(i), &
                                    config_thermodynamics_type)
-           freezingMeltingPotential(i) = freezingPotential + meltingPotential
+           freezingMeltingPotential(i) = freezingPotential + min(meltingPotential,0)
 
         else ! non-free surface (SOM)
 

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -1934,7 +1934,7 @@ contains
            frazilProduction            = x2i_i % rAttr(index_x2i_Fioo_frazil, n)
            call freezing_potential(freezingPotential, frazilProduction, seaSurfaceSalinity(i), &
                                    config_thermodynamics_type)
-           freezingMeltingPotential(i) = freezingPotential + min(meltingPotential,0)
+           freezingMeltingPotential(i) = freezingPotential + min(meltingPotential,0.0_RKIND)
 
         else ! non-free surface (SOM)
 

--- a/components/mpas-seaice/driver/mpassi_cpl_indices.F
+++ b/components/mpas-seaice/driver/mpassi_cpl_indices.F
@@ -84,9 +84,8 @@ module mpassi_cpl_indices
   integer :: index_x2i_Faxa_swndf      ! sw: nir diffuse downward
   integer :: index_x2i_Faxa_swvdf      ! sw: vis diffuse downward
   integer :: index_x2i_Faxa_swnet      ! sw: net
-  integer :: index_x2i_Fioo_meltp      ! ocn melt heat  
-  integer :: index_x2i_Fioo_frazil     ! ocn frazil ice formation 
   integer :: index_x2i_Fioo_q          ! ocn freezing melting potential
+  integer :: index_x2i_Fioo_frazil     ! ocn frazil ice formation 
   integer :: index_x2i_Faxa_bcphidry   ! flux: Black Carbon hydrophilic dry deposition
   integer :: index_x2i_Faxa_bcphodry   ! flux: Black Carbon hydrophobic dry deposition
   integer :: index_x2i_Faxa_bcphiwet   ! flux: Black Carbon hydrophilic wet deposition
@@ -211,9 +210,8 @@ contains
     index_x2i_Faxa_swvdr    = mct_avect_indexra(x2i,'Faxa_swvdr')
     index_x2i_Faxa_swndf    = mct_avect_indexra(x2i,'Faxa_swndf')
     index_x2i_Faxa_swvdf    = mct_avect_indexra(x2i,'Faxa_swvdf')
-    index_x2i_Fioo_meltp    = mct_avect_indexra(x2i,'Fioo_meltp')
-    index_x2i_Fioo_frazil   = mct_avect_indexra(x2i,'Fioo_frazil')
     index_x2i_Fioo_q        = mct_avect_indexra(x2i,'Fioo_q')
+    index_x2i_Fioo_frazil   = mct_avect_indexra(x2i,'Fioo_frazil')
     index_x2i_Faxa_bcphidry = mct_avect_indexra(x2i,'Faxa_bcphidry')
     index_x2i_Faxa_bcphodry = mct_avect_indexra(x2i,'Faxa_bcphodry')
     index_x2i_Faxa_bcphiwet = mct_avect_indexra(x2i,'Faxa_bcphiwet')

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -277,6 +277,7 @@ module seq_diag_mct
 
   integer :: index_o2x_Faoo_h2otemp
   integer :: index_o2x_Fioo_frazil
+  integer :: index_o2x_Fioo_q
 
   integer :: index_xao_Faox_lwup
   integer :: index_xao_Faox_lat
@@ -313,6 +314,7 @@ module seq_diag_mct
   integer :: index_x2i_Faxa_rain
   integer :: index_x2i_Faxa_snow
   integer :: index_x2i_Fioo_frazil
+  integer :: index_x2i_Fioo_q
   integer :: index_x2i_Fixx_rofi
 
   integer :: index_g2x_Fogg_rofl
@@ -1336,6 +1338,7 @@ contains
     if (present(do_o2x)) then
        if (first_time) then
           index_o2x_Fioo_frazil  = mct_aVect_indexRA(o2x_o,'Fioo_frazil')
+          index_o2x_Fioo_q       = mct_aVect_indexRA(o2x_o,'Fioo_q')
           index_o2x_Faoo_h2otemp = mct_aVect_indexRA(o2x_o,'Faoo_h2otemp')
        end if
 
@@ -1346,9 +1349,9 @@ contains
           ca_i =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ki,n)
           nf = f_area; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_o
           nf = f_wfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_frazil,n))
+          nf = f_hfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Fioo_q,n)
           nf = f_hh2ot; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_h2otemp,n)
        end do
-       budg_dataL(f_hfrz,ic,ip) = -budg_dataL(f_wfrz,ic,ip) * shr_const_latice
     end if
 
     if (present(do_xao)) then
@@ -1654,6 +1657,7 @@ contains
           index_x2i_Faxa_rain   = mct_aVect_indexRA(x2i_i,'Faxa_rain')
           index_x2i_Faxa_snow   = mct_aVect_indexRA(x2i_i,'Faxa_snow')
           index_x2i_Fioo_frazil = mct_aVect_indexRA(x2i_i,'Fioo_frazil')
+          index_x2i_Fioo_q      = mct_aVect_indexRA(x2i_i,'Fioo_q')
           index_x2i_Fixx_rofi   = mct_aVect_indexRA(x2i_i,'Fixx_rofi')
 
           index_x2i_Faxa_rain_16O   = mct_aVect_indexRA(x2i_i,'Faxa_rain_16O', perrWith='quiet')
@@ -1685,6 +1689,8 @@ contains
 
           nf = f_wfrz ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + &
                (ca_o+ca_i)*max(0.0_r8,x2i_i%rAttr(index_x2i_Fioo_frazil,n))
+          nf = f_hfrz ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - &
+               (ca_o+ca_i)*x2i_i%rAttr(index_x2i_Fioo_q,n)
           if ( flds_wiso_ice_x2i )then
              nf  = f_wrain_16O;
              budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + &
@@ -1710,7 +1716,6 @@ contains
        ic = c_inh_is
        budg_dataL(f_hlatf,ic,ip) = -budg_dataL(f_wsnow,ic,ip)*shr_const_latice
        budg_dataL(f_hioff,ic,ip) = -budg_dataL(f_wioff,ic,ip)*shr_const_latice
-       budg_dataL(f_hfrz ,ic,ip) = -budg_dataL(f_wfrz ,ic,ip)*shr_const_latice
 
        ic = c_ish_is
        budg_dataL(f_hlatf,ic,ip) = -budg_dataL(f_wsnow,ic,ip)*shr_const_latice

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1456,17 +1456,6 @@ contains
     call metadata_set(attname, longname, stdname, units)
 
     if (trim(cime_model) == 'e3sm') then
-       ! Ocean melt (q<0) potential
-       call seq_flds_add(o2x_fluxes,"Fioo_meltp")
-       call seq_flds_add(x2i_fluxes,"Fioo_meltp")
-       longname = 'Ocean melt (q<0) potential'
-       stdname  = 'surface_snow_and_ice_melt_heat_flux'
-       units    = 'W m-2'
-       attname  = 'Fioo_meltp'
-       call metadata_set(attname, longname, stdname, units)
-    end if
-
-    if (trim(cime_model) == 'e3sm') then
        ! Ocean frazil production
        call seq_flds_add(o2x_fluxes,"Fioo_frazil")
        call seq_flds_add(x2i_fluxes,"Fioo_frazil")


### PR DESCRIPTION
Brings in changes in both the mpas-ocean and mpas-seaice drivers to change the field passed between them that represents the heat exchange due to frazil formation. There are related changes in the coupler diagnostics, and the field Fioo_meltp is removed since it is no longer used. Because the coupler fields are changed, tests will show DIFFs even though this is not expected to really change answers.

[non-BFB]