### PR TITLE
Add "module load perl5-extras" which sets PERL5LIB environment variable on Cori machines

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -180,6 +180,7 @@
         <command name="load">git</command>
         <command name="rm">cmake</command>
         <command name="load">cmake/3.14.4</command>
+        <command name="load">perl5-extras</command>
       </modules>
     </module_system>
 
@@ -197,7 +198,6 @@
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="CRAYPE_LINK_TYPE">static</env>
-      <env name="PERL5LIB">/global/common/cori/software/perl5/lib/perl5</env>
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="FORT_BUFFERED">yes</env>
@@ -333,6 +333,7 @@
         <command name="load">git</command>
         <command name="rm">cmake</command>
         <command name="load">cmake/3.14.4</command>
+        <command name="load">perl5-extras</command>
       </modules>
 
       <!--command name="list">&gt;&amp; ml.txt</command-->
@@ -352,7 +353,6 @@
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="CRAYPE_LINK_TYPE">static</env>
-      <env name="PERL5LIB">/global/common/cori/software/perl5/lib/perl5</env>      
     </environment_variables>
 
     <environment_variables mpilib="mpt">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -197,6 +197,7 @@
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="CRAYPE_LINK_TYPE">static</env>
+      <env name="PERL5LIB">/global/common/cori/software/perl5/lib/perl5</env>
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="FORT_BUFFERED">yes</env>
@@ -350,7 +351,8 @@
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
-      <env name="CRAYPE_LINK_TYPE">static</env>      
+      <env name="CRAYPE_LINK_TYPE">static</env>
+      <env name="PERL5LIB">/global/common/cori/software/perl5/lib/perl5</env>      
     </environment_variables>
 
     <environment_variables mpilib="mpt">


### PR DESCRIPTION
Add "module load perl5-extras" which simply sets PERL5LIB environment variable on Cori machines that points
to `/global/common/cori/software/perl5/lib/perl5` allowing the perl module `XML::LibXML` to be found (which is not part of the standard perl distribution)

Fixes #4240
[bfb]