### PR TITLE
Re-enabled MEGAN biogenic emissions in ELM

### DIFF
--- a/components/elm/src/biogeochem/MEGANFactorsMod.F90
+++ b/components/elm/src/biogeochem/MEGANFactorsMod.F90
@@ -273,11 +273,11 @@ contains
 
     hash = gen_hash_key_offset
 
-    if ( len(string) /= 19 ) then
+    if ( len_trim(string) /= 19 ) then
        !
        ! Process arbitrary string length.
        !
-       do i = 1, len(string)
+       do i = 1, len_trim(string)
           hash = ieor(hash , (ichar(string(i:i)) * tbl_gen_hash_key(iand(i-1,tbl_max_idx))))
        end do
     else
@@ -287,7 +287,7 @@ contains
        do i = 1, tbl_max_idx+1
           hash = ieor(hash , ichar(string(i:i))   * tbl_gen_hash_key(i-1)) 
        end do
-       do i = tbl_max_idx+2, len(string)
+       do i = tbl_max_idx+2, len_trim(string)
           hash = ieor(hash , ichar(string(i:i))   * tbl_gen_hash_key(i-tbl_max_idx-2)) 
        end do
     end if

--- a/components/elm/src/biogeochem/VOCEmissionMod.F90
+++ b/components/elm/src/biogeochem/VOCEmissionMod.F90
@@ -489,7 +489,7 @@ contains
          fsun24        => canopystate_vars%fsun24_patch         , & ! Input:  [real(r8) (:)   ]  sunlit fraction of canopy last 24 hrs             
          fsun240       => canopystate_vars%fsun240_patch        , & ! Input:  [real(r8) (:)   ]  sunlit fraction of canopy last 240 hrs            
          elai          => canopystate_vars%elai_patch           , & ! Input:  [real(r8) (:)   ]  one-sided leaf area index with burying by snow
-         elai_p        => canopystate_vars%elai_p_patch         , & ! Input:  [real(r8) (:)   ]  one-sided leaf area index from previous timestep  
+         elai240       => canopystate_vars%elai240_patch        , & ! Input:  [real(r8) (:)   ]  one-sided leaf area index with burying by snow 240 hrs  
 
          cisun_z       => photosyns_vars%cisun_z_patch          , & ! Input:  [real(r8) (:,:) ]  sunlit intracellular CO2 (Pa)
          cisha_z       => photosyns_vars%cisha_z_patch          , & ! Input:  [real(r8) (:,:) ]  shaded intracellular CO2 (Pa)
@@ -594,7 +594,7 @@ contains
                                    betaT(class_num),LDF(class_num), Ceo(class_num), Eopt, topt)
 
              ! Activity factor for Leaf Age
-             gamma_a = get_gamma_A(veg_pp%itype(p), elai_p(p),elai(p),class_num)
+             gamma_a = get_gamma_A(veg_pp%itype(p), elai240(p),elai(p),class_num)
 
              ! Activity factor for CO2 (only for isoprene)
              if (trim(meg_cmp%name) == 'isoprene') then 
@@ -943,7 +943,7 @@ contains
   end function get_gamma_T
 
   !-----------------------------------------------------------------------
-  function get_gamma_A(ivt_in, elai_p_in,elai_in,nclass_in)
+  function get_gamma_A(ivt_in, elai240_in,elai_in,nclass_in)
 
     ! Activity factor for leaf age (Guenther et al., 2006)
     !-----------------------------
@@ -957,7 +957,7 @@ contains
     implicit none
     integer,intent(in)  :: ivt_in
     integer,intent(in)  :: nclass_in
-    real(r8),intent(in) :: elai_p_in
+    real(r8),intent(in) :: elai240_in
     real(r8),intent(in) :: elai_in
     !
     ! !LOCAL VARIABLES:
@@ -967,8 +967,8 @@ contains
     !-----------------------------------------------------------------------
     if ( (ivt_in == ndllf_dcd_brl_tree) .or. (ivt_in >= nbrdlf_dcd_trp_tree) ) then  ! non-evergreen
        
-       if ( (elai_p_in > 0.0_r8) .and. (elai_p_in < 1.e30_r8) )then 
-          elai_prev = 2._r8*elai_p_in-elai_in  ! have accumulated average lai over last timestep
+       if ( (elai240_in > 0.0_r8) .and. (elai240_in < 1.e30_r8) )then 
+          elai_prev = 2._r8*elai240_in-elai_in  ! have accumulated average lai over last timestep
           if (elai_prev == elai_in) then
              fnew = 0.0_r8
              fgro = 0.0_r8

--- a/components/elm/src/data_types/TopounitDataType.F90
+++ b/components/elm/src/data_types/TopounitDataType.F90
@@ -430,21 +430,21 @@ module TopounitDataType
             subgrid_type='topounit', numlev=1, init_value=0._r8)
     end if
     ! Accumulator variables for radiation fluxes
-    !call init_accum_field (name='FSD24H', units='W/m2',                                             &
-    !     desc='24hr average of direct solar radiation',  accum_type='runmean', accum_period=-1,    &
-    !     subgrid_type='topounit', numlev=1, init_value=0._r8)
+    call init_accum_field (name='FSD24H', units='W/m2',                                             &
+         desc='24hr average of direct solar radiation',  accum_type='runmean', accum_period=-1,    &
+         subgrid_type='topounit', numlev=1, init_value=0._r8)
 
-    !call init_accum_field (name='FSD240H', units='W/m2',                                            &
-    !     desc='240hr average of direct solar radiation',  accum_type='runmean', accum_period=-10,  &
-    !     subgrid_type='topounit', numlev=1, init_value=0._r8)
+    call init_accum_field (name='FSD240H', units='W/m2',                                            &
+         desc='240hr average of direct solar radiation',  accum_type='runmean', accum_period=-10,  &
+         subgrid_type='topounit', numlev=1, init_value=0._r8)
 
-    !call init_accum_field (name='FSI24H', units='W/m2',                                             &
-    !     desc='24hr average of diffuse solar radiation',  accum_type='runmean', accum_period=-1,   &
-    !     subgrid_type='topounit', numlev=1, init_value=0._r8)
+    call init_accum_field (name='FSI24H', units='W/m2',                                             &
+         desc='24hr average of diffuse solar radiation',  accum_type='runmean', accum_period=-1,   &
+         subgrid_type='topounit', numlev=1, init_value=0._r8)
 
-    !call init_accum_field (name='FSI240H', units='W/m2',                                            &
-    !     desc='240hr average of diffuse solar radiation',  accum_type='runmean', accum_period=-10, &
-    !     subgrid_type='topounit', numlev=1, init_value=0._r8)
+    call init_accum_field (name='FSI240H', units='W/m2',                                            &
+         desc='240hr average of diffuse solar radiation',  accum_type='runmean', accum_period=-10, &
+         subgrid_type='topounit', numlev=1, init_value=0._r8)
   end subroutine init_acc_buffer_top_af
   
   !-----------------------------------------------------------------------
@@ -483,17 +483,17 @@ module TopounitDataType
     ! Determine time step
     nstep = get_nstep()
 
-    !call extract_accum_field ('FSD24H', rbufslt, nstep)
-    !this%fsd24h(begt:endt) = rbufslt(begt:endt)
+    call extract_accum_field ('FSD24H', rbufslt, nstep)
+    this%fsd24h(begt:endt) = rbufslt(begt:endt)
 
-    !call extract_accum_field ('FSD240H', rbufslt, nstep)
-    !this%fsd240h(begt:endt) = rbufslt(begt:endt)
+    call extract_accum_field ('FSD240H', rbufslt, nstep)
+    this%fsd240h(begt:endt) = rbufslt(begt:endt)
 
-    !call extract_accum_field ('FSI24H', rbufslt, nstep)
-    !this%fsi24h(begt:endt) = rbufslt(begt:endt)
+    call extract_accum_field ('FSI24H', rbufslt, nstep)
+    this%fsi24h(begt:endt) = rbufslt(begt:endt)
 
-    !call extract_accum_field ('FSI240H', rbufslt, nstep)
-    !this%fsi240h(begt:endt) = rbufslt(begt:endt)
+    call extract_accum_field ('FSI240H', rbufslt, nstep)
+    this%fsi240h(begt:endt) = rbufslt(begt:endt)
 
     if (use_cn) then
        call extract_accum_field ('PREC10D', rbufslt, nstep)
@@ -547,19 +547,19 @@ module TopounitDataType
     do t = begt,endt
        rbufslt(t) = this%solad(t,1)
     end do
-    !call update_accum_field  ('FSD240H', rbufslt              , nstep)
-    !call extract_accum_field ('FSD240H', this%fsd240h         , nstep)
-    !call update_accum_field  ('FSD24H' , rbufslt              , nstep)
-    !call extract_accum_field ('FSD24H' , this%fsd24h          , nstep)
+    call update_accum_field  ('FSD240H', rbufslt              , nstep)
+    call extract_accum_field ('FSD240H', this%fsd240h         , nstep)
+    call update_accum_field  ('FSD24H' , rbufslt              , nstep)
+    call extract_accum_field ('FSD24H' , this%fsd24h          , nstep)
 
     ! Accumulate and extract forc_solai24 & forc_solai240 
     do t = begt,endt
        rbufslt(t) = this%solai(t,1)
     end do
-    !call update_accum_field  ('FSI24H' , rbufslt              , nstep)
-    !call extract_accum_field ('FSI24H' , this%fsi24h          , nstep)
-    !call update_accum_field  ('FSI240H', rbufslt              , nstep)
-    !call extract_accum_field ('FSI240H', this%fsi240h         , nstep)
+    call update_accum_field  ('FSI24H' , rbufslt              , nstep)
+    call extract_accum_field ('FSI24H' , this%fsi24h          , nstep)
+    call update_accum_field  ('FSI240H', rbufslt              , nstep)
+    call extract_accum_field ('FSI240H', this%fsi240h         , nstep)
 
     ! Accumulate and extract total precip
     do t = begt,endt


### PR DESCRIPTION
Re-enabled MEGAN biogenic gas emissions. It is important for running E3SM with gas chemistry. The problem could be reproduced by running FC5AV1C-L with trop_strat_mam7. You would need to add -megan for land configuration.  
See runscripts on Compy: /compyfs/wumi635/tmp/megan_fix/

1) MEGANFactorsMod.F90
Solve the issue which the model fails to read the megan input table.
megan_factors_file = '/compyfs/inputdata/atm/cam/chem/trop_mozart/emis/megan21_emis_factors_c20130304.nc'

Comparing FC5AV1C-L_TS1-MAM7_test01 vs FC5AV1C-L_TS1-MAM7_test02 on
/compyfs/wumi635/archive

2) TopounitDataType.F90
top_af%fsd24h, top_af%fsd240h, top_af%fsi24h, top_af%fsi240h are not initialized and get updated

Comparing elm results (MEG_*, PAR24_sun, PAR240_sun, PAR24_shade, PAR240_shade, etc) FC5AV1C-L_TS1-MAM7_test02 vs FC5AV1C-L_TS1-MAM7_test03/04/05 

3) VOCEmissionMod.F90 and CanopyStateType.F90
Using elai240 instead of elai_p for calculations in get_gamma_A of VOCEmissionMod.F90

Code changes in 1) and 3) follow CESM2 CLM code

