### PR TITLE
For Cori, add module load perl5-extras to allow for finding perl module XML::LibXML

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -182,6 +182,7 @@
       <command name="load">git</command>
       <command name="rm">cmake</command>
       <command name="load">cmake/3.14.4</command>
+      <command name="load">perl5-extras</command>
     </modules>
   </module_system>
 
@@ -331,6 +332,7 @@
       <command name="load">git</command>
       <command name="rm">cmake</command>
       <command name="load">cmake/3.14.4</command>
+      <command name="load">perl5-extras</command>
     </modules>
 
     <!--command name="list">&gt;&amp; ml.txt</command-->


### PR DESCRIPTION
For Cori, add module load perl5-extras to allow for finding the perl module XML::LibXML.

Same fix as https://github.com/E3SM-Project/E3SM/pull/4243

[bfb]