### PR TITLE
For Cori, add perl5-extras module to allow cases to find the LibXML perl module

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -175,6 +175,7 @@
       <modules>
         <command name="rm">cmake</command>
         <command name="load">cmake/3.14.4</command>
+        <command name="load">perl5-extras</command>
       </modules>
     </module_system>
 
@@ -326,6 +327,7 @@
       <modules>
         <command name="rm">cmake</command>
         <command name="load">cmake/3.14.4</command>
+        <command name="load">perl5-extras</command>
       </modules>
 
       <!--command name="list">&gt;&amp; ml.txt</command-->


### PR DESCRIPTION
For Cori, add perl5-extras module to allow cases to find the LibXML perl module.

Same fix applied to E3SM master.

[bfb]