### PR TITLE
Update mpas-source: ocean drag parameterizations

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -755,10 +755,13 @@ add_default($nl, 'config_monotonic');
 
 add_default($nl, 'config_use_implicit_bottom_drag');
 add_default($nl, 'config_implicit_bottom_drag_coeff');
+add_default($nl, 'config_use_implicit_bottom_roughness');
 add_default($nl, 'config_use_implicit_bottom_drag_variable');
 add_default($nl, 'config_use_implicit_bottom_drag_variable_mannings');
 add_default($nl, 'config_use_explicit_bottom_drag');
 add_default($nl, 'config_explicit_bottom_drag_coeff');
+add_default($nl, 'config_use_topographic_wave_drag');
+add_default($nl, 'config_topographic_wave_drag_coeff');
 
 ###################################
 # Namelist group: ocean_constants #
@@ -882,6 +885,7 @@ add_default($nl, 'config_disable_vel_coriolis');
 add_default($nl, 'config_disable_vel_pgrad');
 add_default($nl, 'config_disable_vel_hmix');
 add_default($nl, 'config_disable_vel_surface_stress');
+add_default($nl, 'config_disable_vel_topographic_wave_drag');
 add_default($nl, 'config_disable_vel_explicit_bottom_drag');
 add_default($nl, 'config_disable_vel_vmix');
 add_default($nl, 'config_disable_vel_vadv');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -286,10 +286,13 @@ add_default($nl, 'config_monotonic');
 
 add_default($nl, 'config_use_implicit_bottom_drag');
 add_default($nl, 'config_implicit_bottom_drag_coeff');
+add_default($nl, 'config_use_implicit_bottom_roughness');
 add_default($nl, 'config_use_implicit_bottom_drag_variable');
 add_default($nl, 'config_use_implicit_bottom_drag_variable_mannings');
 add_default($nl, 'config_use_explicit_bottom_drag');
 add_default($nl, 'config_explicit_bottom_drag_coeff');
+add_default($nl, 'config_use_topographic_wave_drag');
+add_default($nl, 'config_topographic_wave_drag_coeff');
 
 ###################################
 # Namelist group: ocean_constants #
@@ -413,6 +416,7 @@ add_default($nl, 'config_disable_vel_coriolis');
 add_default($nl, 'config_disable_vel_pgrad');
 add_default($nl, 'config_disable_vel_hmix');
 add_default($nl, 'config_disable_vel_surface_stress');
+add_default($nl, 'config_disable_vel_topographic_wave_drag');
 add_default($nl, 'config_disable_vel_explicit_bottom_drag');
 add_default($nl, 'config_disable_vel_vmix');
 add_default($nl, 'config_disable_vel_vadv');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -352,10 +352,13 @@
 <!-- bottom_drag -->
 <config_use_implicit_bottom_drag>.true.</config_use_implicit_bottom_drag>
 <config_implicit_bottom_drag_coeff>1.0e-3</config_implicit_bottom_drag_coeff>
+<config_use_implicit_bottom_roughness>.false.</config_use_implicit_bottom_roughness>
 <config_use_implicit_bottom_drag_variable>.false.</config_use_implicit_bottom_drag_variable>
 <config_use_implicit_bottom_drag_variable_mannings>.false.</config_use_implicit_bottom_drag_variable_mannings>
 <config_use_explicit_bottom_drag>.false.</config_use_explicit_bottom_drag>
 <config_explicit_bottom_drag_coeff>1.0e-3</config_explicit_bottom_drag_coeff>
+<config_use_topographic_wave_drag>.false.</config_use_topographic_wave_drag>
+<config_topographic_wave_drag_coeff>5.0e-4</config_topographic_wave_drag_coeff>
 
 <!-- ocean_constants -->
 <config_density0>1026.0</config_density0>
@@ -474,6 +477,7 @@
 <config_disable_vel_pgrad>.false.</config_disable_vel_pgrad>
 <config_disable_vel_hmix>.false.</config_disable_vel_hmix>
 <config_disable_vel_surface_stress>.false.</config_disable_vel_surface_stress>
+<config_disable_vel_topographic_wave_drag>.false.</config_disable_vel_topographic_wave_drag>
 <config_disable_vel_explicit_bottom_drag>.false.</config_disable_vel_explicit_bottom_drag>
 <config_disable_vel_vmix>.false.</config_disable_vel_vmix>
 <config_disable_vel_vadv>.false.</config_disable_vel_vadv>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1462,6 +1462,14 @@ Valid values: any positive real, typically 1.0e-3
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_use_implicit_bottom_roughness" type="logical"
+	category="bottom_drag" group="bottom_drag">
+If true, depends on bottom roughness z0
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_use_implicit_bottom_drag_variable" type="logical"
 	category="bottom_drag" group="bottom_drag">
 If true, spatially-variable implicit bottom drag is used on the momentum equation.
@@ -1491,6 +1499,22 @@ Default: Defined in namelist_defaults.xml
 Dimensionless bottom drag coefficient, $c_{drag}$.
 
 Valid values: any positive real, typically 1.0e-3
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_topographic_wave_drag" type="logical"
+	category="bottom_drag" group="bottom_drag">
+If true, topographic wave drag is used on the momentum equation.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_topographic_wave_drag_coeff" type="real"
+	category="bottom_drag" group="bottom_drag">
+Dimensionless topographic wave drag coefficient, $c_{topo}$.
+
+Valid values: any positive real, typically 5.0e-4
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2066,6 +2090,14 @@ Default: Defined in namelist_defaults.xml
 <entry id="config_disable_vel_surface_stress" type="logical"
 	category="debug" group="debug">
 Disables tendencies on the velocity field from horizontal surface stresses (e.g. wind stress and top drag).
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_disable_vel_topographic_wave_drag" type="logical"
+	category="debug" group="debug">
+Disables tendencies on the velocity field from topographic wave drag
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml


### PR DESCRIPTION
Adds wave drag parameterization and bottom roughness, default off. See https://github.com/MPAS-Dev/MPAS-Model/pull/607

[NML]
[BFB]