### PR TITLE
Add -fimf_use_svml flag to Intel Theta builds

### DIFF
--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -1945,7 +1945,7 @@ flags should be captured within MPAS CMake files.
     <append> -DARCH_MIC_KNL </append>
   </CPPDEFS>
   <FFLAGS>
-    <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf_use_svml=true</base>
+    <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml=true</base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align -fp-speculation=off</append>
     <append> -DHAVE_ERF_INTRINSICS </append>
   </FFLAGS>

--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -1945,7 +1945,7 @@ flags should be captured within MPAS CMake files.
     <append> -DARCH_MIC_KNL </append>
   </CPPDEFS>
   <FFLAGS>
-    <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent</base>
+    <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf_use_svml</base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align -fp-speculation=off</append>
     <append> -DHAVE_ERF_INTRINSICS </append>
   </FFLAGS>

--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -1945,7 +1945,7 @@ flags should be captured within MPAS CMake files.
     <append> -DARCH_MIC_KNL </append>
   </CPPDEFS>
   <FFLAGS>
-    <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf_use_svml</base>
+    <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf_use_svml=true</base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align -fp-speculation=off</append>
     <append> -DHAVE_ERF_INTRINSICS </append>
   </FFLAGS>


### PR DESCRIPTION
Add `-fimf-use-svml=true` flag to Intel Theta builds.
This flag is already used for Intel builds on cori-knl.
We see an improvement with this flag for SCREAM compsets (in scream repo) as well as `ne30_ne30.F-EAM-AQP1` and `ne30pg2_ne30pg2.FC5AV1C-L` in E3SM.

Fixes E3SM-Project/E3SM#4258

[non-BFB] - SMS_P64.ne4_ne4.FC5AV1C-L, SMS_P64_Ld1.ne30_ne30.F-EAM-AQP1