### PR TITLE
Change defaults for ieflx_opt and do_budgets

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -139,9 +139,9 @@
 <bnd_topo hgrid="ne0np4_enax4v1">atm/cam/topo/USGS_enax4v1_tensorx12_consistentSGH_170522.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_twpx4v1" >atm/cam/topo/USGS_twpx4v1_tensor12x_consistentSGH_170629.nc</bnd_topo>
 
-<!-- ieflx_opt 0: atmonly, 2: coupled -->
+<!-- ieflx_opt 0: atmonly, 3: coupled -->
 <ieflx_opt  ocn="docn" >0</ieflx_opt>
-<ieflx_opt  ocn="mpaso" >2</ieflx_opt>
+<ieflx_opt  ocn="mpaso" >3</ieflx_opt>
 
 <!-- Bulk aerosol physical properties (includes optics) -->
 

--- a/components/elm/bld/ELMBuildNamelist.pm
+++ b/components/elm/bld/ELMBuildNamelist.pm
@@ -1829,6 +1829,7 @@ sub process_namelist_inline_logic {
   setup_logic_irrigate($opts, $nl_flags, $definition, $defaults, $nl, $physv);
   setup_logic_start_type($nl_flags, $nl);
   setup_logic_delta_time($opts, $nl_flags, $definition, $defaults, $nl);
+  setup_logic_do_budgets($opts, $nl_flags, $definition, $defaults, $nl);
   setup_logic_decomp_performance($opts->{'test'}, $nl_flags, $definition, $defaults, $nl);
   setup_logic_snow($opts, $nl_flags, $definition, $defaults, $nl, $physv);
   setup_logic_glacier($opts, $nl_flags, $definition, $defaults, $nl,  $envxml_ref, $physv);
@@ -2074,6 +2075,19 @@ sub setup_logic_delta_time {
   }
 }
 
+#-------------------------------------------------------------------------------
+
+sub setup_logic_do_budgets {
+  my ($opts, $nl_flags, $definition, $defaults, $nl) = @_;
+
+    my $do_budgets = $defaults->get_value('do_budgets');
+    if ( ! defined($do_budgets)  ) {
+      # default to .false. if not set in namelist_defaults.xml
+      add_default($opts->{'test'}, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'do_budgets', 'val'=>".false.");
+    } else {
+      add_default($opts->{'test'}, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'do_budgets', 'val'=>"$do_budgets");
+    }
+}
 #-------------------------------------------------------------------------------
 
 sub setup_logic_decomp_performance {

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -17,6 +17,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Default time step -->
 <dtime>1800</dtime>
 
+<!-- Defaults for performing diagnostic water and energy budgets -->
+<do_budgets>.true.</do_budgets>
+
 <!-- CO2 volume mixing ratio -->
 <co2_ppmv sim_year="1000"      >379.0</co2_ppmv>
 <co2_ppmv sim_year="2000"      >379.0</co2_ppmv>


### PR DESCRIPTION
Use ieflx_opt=3 as default for coupled configurations.

Set do_budgets=.true. for elm to perform diagnostic calculations
of water and energy budgets.

[BFB] for F-cases
[non-BFB] for B-cases
[NML] namelist changes for all B and I cases