### PR TITLE
Fix to allow continued support for microp_scheme != MG2

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -806,7 +806,7 @@ add_default($nl,'ieflx_opt');
 add_default($nl,'use_hetfrz_classnuc');
 add_default($nl,'hist_hetfrz_classnuc');
 add_default($nl,'gw_convect_hcf');
-add_default($nl,'linoz_psc_t');
+add_default($nl,'linoz_psc_T');
 if ($cfg->get('microphys') =~ /^mg2/) {
     add_default($nl,'micro_mg_dcs_tdep');
     add_default($nl,'micro_mincdnc');
@@ -4637,7 +4637,7 @@ sub add_default {
                     print "key=$key  val=$opts{$key}\n";
                 }
             }
-            die;
+            die "$ProgName - ERROR: No default value found for $var\n";;
         } else {
             return;
         }

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -807,8 +807,10 @@ add_default($nl,'use_hetfrz_classnuc');
 add_default($nl,'hist_hetfrz_classnuc');
 add_default($nl,'gw_convect_hcf');
 add_default($nl,'linoz_psc_t');
-add_default($nl,'micro_mg_dcs_tdep');
-add_default($nl,'micro_mincdnc');
+if ($cfg->get('microphys') =~ /^mg2/) {
+    add_default($nl,'micro_mg_dcs_tdep');
+    add_default($nl,'micro_mincdnc');
+}
 add_default($nl,'microp_aero_wsub_scheme');
 add_default($nl,'microp_aero_wsubmin');
 add_default($nl,'use_preexisting_ice');


### PR DESCRIPTION
This fix is a response to an issue we found in SCREAM when doing an
upstream merge.  Because SCREAM uses the P3 microphysics scheme and
not MG2 the case build would fail during the namelist setup.

The reason was that the variable micro_mincdnc had no default defined
when the microphysics scheme was not mg2.  Since this and one other
new namelist variable are only defined in mg2 the solution was to have
build-namelist ignore these variables for non-MG2 cases.

[BFB]