### PR TITLE
Remove coupled sea surface height filtering for all E3SM configurations

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -270,7 +270,7 @@
 <config_flux_attenuation_coefficient_runoff>10.0</config_flux_attenuation_coefficient_runoff>
 
 <!-- coupling -->
-<config_ssh_grad_relax_timescale>86400.0</config_ssh_grad_relax_timescale>
+<config_ssh_grad_relax_timescale>0.0</config_ssh_grad_relax_timescale>
 <config_remove_AIS_coupler_runoff>.false.</config_remove_AIS_coupler_runoff>
 
 <!-- shortwaveRadiation -->

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1086,14 +1086,15 @@ contains
          call mpas_pool_get_config(domain % configs, 'config_ssh_grad_relax_timescale', &
                                                       config_ssh_grad_relax_timescale)
          if (config_ssh_grad_relax_timescale < real(ocn_cpl_dt,RKIND)) then
-            timeFilterFactor = 1.0_RKIND
+            filteredSSHGradientZonal = avgSSHGradient(index_avgZonalSSHGradient, :)
+            filteredSSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
          else
             timeFilterFactor = real(ocn_cpl_dt,RKIND) / config_ssh_grad_relax_timescale
+            filteredSSHGradientZonal = filteredSSHGradientZonal * (1.0_RKIND - timeFilterFactor) + &
+                 avgSSHGradient(index_avgZonalSSHGradient, :) * timeFilterFactor
+            filteredSSHGradientMeridional = filteredSSHGradientMeridional * (1.0_RKIND - timeFilterFactor) + &
+                 avgSSHGradient(index_avgMeridionalSSHGradient, :) * timeFilterFactor
          endif
-         filteredSSHGradientZonal = filteredSSHGradientZonal * (1.0_RKIND - timeFilterFactor) + &
-              avgSSHGradient(index_avgZonalSSHGradient, :) * timeFilterFactor
-         filteredSSHGradientMeridional = filteredSSHGradientMeridional * (1.0_RKIND - timeFilterFactor) + &
-              avgSSHGradient(index_avgMeridionalSSHGradient, :) * timeFilterFactor
          block_ptr => block_ptr % next
       end do
 


### PR DESCRIPTION
This PR is to turn off sea surface height filtering between ocean and sea ice for all versions of E3SM, since it is no longer needed to maintain stability in the fully coupled model. This change has been tested in two mesh configurations:  ne30pg2_EC30to60E2r2 and ne30pg2_WC14to60E2r3 for which the simulation pages, and analysis of sea ice results, can be viewed at:  https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/2633269275/20210409.v2beta4.SSHFilterOff.ne30pg2+EC30to60E2r2.chrysalis and https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/2666463322/20210423.v2rc1a.piControl.ne30pg2+WC14to60E2r3.cori-knl.  In both cases, the lack of filtering changes the sea ice climatology, and there are no abnormal high-frequency instabilities, fracturing, nor oscillations apparent in the sea ice analysis, including at 14km resolution in the Arctic.  The previous need for this filtering is probably related to a combination of an advection bug in the ocean, a fixed ocean basal temperature under sea ice as compared to a variable basal temperature in mushy-layer thermodynamics, and further bug fixes and changes to the sea ice and ocean models that have been addressed for E3SM Version 2.  

[NML]
[non-BFB]