### PR TITLE
Change TFREEZE_SALTWATER_OPTION default to mushy

### DIFF
--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -174,7 +174,7 @@
   <entry id="TFREEZE_SALTWATER_OPTION">
     <type>char</type>
     <valid_values>minus1p8,linear_salt,mushy</valid_values>
-    <default_value>minus1p8</default_value>
+    <default_value>mushy</default_value>
     <group>run_physics</group>
     <file>env_run.xml</file>
     <desc>Freezing point calculation for salt water.</desc>


### PR DESCRIPTION
Changes the default value of TFREEZE_SALTWATER_OPTION from "minus1p8" to "mushy". This variable is used to determine how shr_frz_freezetemp is calculated, and is referenced by the docn and dice data models. So it should change answers only for configurations using those models, including some A-, C-, D-, and E-cases.

Fixes #4162 

[NML]
[non-BFB] for some A-, C-, and D-cases