### PR TITLE
Fix temporary Singularity repository error

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -4,9 +4,9 @@ go version
 
 # Install Singularity
 export VERSION=3.5.3 && # adjust this as necessary \
-    wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+    wget https://dabdceba-6d04-11e5-ba46-22000b92c6ec.e.globus.org/containers/public/singularity-${VERSION}.tar.gz && \
     tar -xzf singularity-${VERSION}.tar.gz && \
-    cd singularity
+    cd singularity/
 ./mconfig && \
     make -C ./builddir && \
     sudo make -C ./builddir install


### PR DESCRIPTION
The download repo with Singularity tarballs has been unreachable since yesterday (05/04/2021). This is a temporary fix. The Singularity tarball used by the Circle CI tests is going to be downloaded from the Petrel E3SM endpoint until the download repo with Singularity tarballs is fixed.