### PR TITLE
Updates FATES test to use one thread

### DIFF
--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/fates/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/fates/shell_commands
@@ -1,2 +1,3 @@
 #!/bin/bash
 if [ `./xmlquery --value MACH` == bebop ]; then ./xmlchange --id LND_PIO_TYPENAME --val netcdf; fi
+./xmlchange NTHRDS=1


### PR DESCRIPTION
Explicitly specify the FATES test to use one thread because
on Chrysalis the FATES test is using two threads and reporting
an error in carbon balance.

[BFB]