### PR TITLE
Support for SCM functionality for multiple columns

### DIFF
--- a/components/data_comps/docn/src/docn_comp_mod.F90
+++ b/components/data_comps/docn/src/docn_comp_mod.F90
@@ -95,7 +95,7 @@ CONTAINS
        seq_flds_x2o_fields, seq_flds_o2x_fields, &
        SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, inst_name, logunit, read_restart, &
-       scmMode, iop_mode, scmlat, scmlon)
+       scmMode, scm_multcols, scmlat, scmlon, scm_nx, scm_ny)
 
     ! !DESCRIPTION: initialize docn model
     use pio        , only : iosystem_desc_t
@@ -119,11 +119,13 @@ CONTAINS
     integer(IN)            , intent(in)    :: logunit             ! logging unit number
     logical                , intent(in)    :: read_restart        ! start from restart
     logical                , intent(in)    :: scmMode             ! single column mode
-    logical                , intent(in)    :: iop_mode            ! IOP mode
-                                                                  ! cover planet with
-                                                                  ! identical surface
+    logical                , intent(in)    :: scm_multcols        ! single column functionality but
+                                                                  ! extrapolated over multiple columns
     real(R8)               , intent(in)    :: scmLat              ! single column lat
     real(R8)               , intent(in)    :: scmLon              ! single column lon
+    integer(IN)            , intent(in)    :: scm_nx              ! number of points for SCM
+                                                                  ! functionality (x direction)
+    integer(IN)            , intent(in)    :: scm_ny              ! same but for y direction
 
     !--- local variables ---
     integer(IN)   :: n,k      ! generic counters
@@ -175,7 +177,8 @@ CONTAINS
        if (my_task == master_task) &
             write(logunit,F05) ' scm lon lat = ',scmlon,scmlat
        call shr_strdata_init(SDOCN,mpicom,compid,name='ocn', &
-            scmmode=scmmode,iop_mode=iop_mode,scmlon=scmlon,scmlat=scmlat, &
+            scmmode=scmmode,scm_multcols=scm_multcols,scmlon=scmlon,scmlat=scmlat, &
+            scm_nx=scm_nx,scm_ny=scm_ny, &
             calendar=calendar, reset_domain_mask=.true.)
     else
        if (datamode == 'SST_AQUAPANAL' .or. datamode == 'SST_AQUAPFILE' .or. &

--- a/components/data_comps/docn/src/ocn_comp_mct.F90
+++ b/components/data_comps/docn/src/ocn_comp_mct.F90
@@ -74,9 +74,12 @@ CONTAINS
     integer(IN)       :: shrloglev                 ! original log level
     integer(IN)       :: ierr                      ! error code
     logical           :: scmMode = .false.         ! single column mode
-    logical           :: iop_mode = .false.        ! IOP mode
+    logical           :: scm_multcols = .false.    ! SCM functionality for multiple columns
     real(R8)          :: scmLat  = shr_const_SPVAL ! single column lat
     real(R8)          :: scmLon  = shr_const_SPVAL ! single column lon
+    integer(IN)       :: scm_nx = -1               ! number of points to use SCM
+                                                   ! functionality (x-direction)
+    integer(IN)       :: scm_ny = -1               ! same but for y-direction
     character(*), parameter :: F00   = "('(docn_comp_init) ',8a)"
     character(*), parameter :: subName = "(ocn_init_mct) "
     !-------------------------------------------------------------------------------
@@ -92,8 +95,9 @@ CONTAINS
     ! Obtain infodata variables
     call seq_infodata_getData(infodata, &
          single_column=scmMode, &
-         iop_mode=iop_mode, &
+         scm_multcols=scm_multcols, &
          scmlat=scmlat, scmlon=scmLon, &
+         scm_nx=scm_nx,scm_ny=scm_ny, &
          read_restart=read_restart)
 
     ! Determine instance information
@@ -156,7 +160,7 @@ CONTAINS
          seq_flds_x2o_fields, seq_flds_o2x_fields, &
          SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
          inst_suffix, inst_name, logunit, read_restart, &
-         scmMode, iop_mode, scmlat, scmlon)
+         scmMode, scm_multcols, scmlat, scmlon, scm_nx, scm_ny)
 
     !----------------------------------------------------------------------------
     ! Fill infodata that needs to be returned from docn

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -1151,13 +1151,29 @@
     <desc>grid mask - DO NOT EDIT (for experts only)</desc>
   </entry>
 
-  <entry id="IOP_MODE">
+  <entry id="PTS_MULTCOLS_MODE">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>Propogate a single point to the global grid  - DO NOT EDIT (for experts only)</desc>
+    <desc>Use a single point of the global grid but propogate that point to multiple columns  - DO NOT EDIT (for experts only)</desc>
+  </entry>
+
+  <entry id="PTS_NX">
+    <type>integer</type>
+    <default_value>0</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>number of cells for single point mode when operating on multiple columns in i direction</desc>
+  </entry>
+
+  <entry id="PTS_NY">
+    <type>integer</type>
+    <default_value>0</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>number of cells for single point mode when operating on multiple columns in j directions</desc>
   </entry>
 
   <entry id="PTS_MODE">

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -1484,17 +1484,46 @@
     </values>
   </entry>
 
-  <entry id="iop_mode" modify_via_xml="IOP_MODE">
+  <entry id="scm_multcols" modify_via_xml="PTS_MULTCOLS_MODE">
     <type>logical</type>
     <category>seq_infodata_inparm</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      turns on Intensive Observation Period (IOP) mode, a planet covered
-      with homogenous surface and forced identically with a forcing file,
-      set by IOP_MODE in env_case.xml, default: false
+      Uses SCM functionality for multiple columns. Specifically, it takes the column
+      on the globe intended to be run in SCM mode, but propogates that point (i.e.
+      meaning surface type and properties etc.) to multiple columns, as defined by the
+      user.  All columns are then forced identically according to the Intensive Observation
+      Period (IOP) file, which is typically required to run in SCM mode.  This option
+      originally implemented to support running a doubly periodic cloud resolving model, but
+      could be used for other applications.
+      set by PTS_MULTCOLS_MODE in env_case.xml, default: false
     </desc>
     <values>
-      <value>$IOP_MODE</value>
+      <value>$PTS_MULTCOLS_MODE</value>
+    </values>
+  </entry>
+
+  <entry id="scm_nx" modify_via_xml="PTS_NX">
+    <type>integer</type>
+    <category>seq_infodata_inparm</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      number of points in x direction when using SCM functionality for multiple columns
+    </desc>
+    <values>
+      <value>$PTS_NX</value>
+    </values>
+  </entry>
+
+  <entry id="scm_ny" modify_via_xml="PTS_NY">
+    <type>integer</type>
+    <category>seq_infodata_inparm</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      number of points in Y direction when using SCM functionality for multiple columns
+    </desc>
+    <values>
+      <value>$PTS_NY</value>
     </values>
   </entry>
 

--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -451,8 +451,11 @@ module cime_comp_mod
   logical  :: areafact_samegrid      ! areafact samegrid flag
   logical  :: single_column          ! scm mode logical
   logical  :: iop_mode               ! iop mode logical
+  logical  :: scm_multcols           ! scm mode over multiple columns logical
   real(r8) :: scmlon                 ! single column lon
   real(r8) :: scmlat                 ! single column lat
+  integer  :: scm_nx                 ! points in x direction for SCM functionality
+  integer  :: scm_ny                 ! points in y direction for SCM functionality
   logical  :: aqua_planet            ! aqua planet mode
   real(r8) :: nextsw_cday            ! radiation control
   logical  :: atm_aero               ! atm provides aerosol data
@@ -1113,6 +1116,9 @@ contains
          esp_present=esp_present                   , &
          iac_present=iac_present                   , &
          single_column=single_column               , &
+         scm_multcols=scm_multcols                 , &
+         scm_nx=scm_nx                             , &
+         scm_ny=scm_ny                             , &
          iop_mode=iop_mode                         , &
          aqua_planet=aqua_planet                   , &
          cpl_seq_option=cpl_seq_option             , &
@@ -1329,6 +1335,7 @@ contains
        call seq_comm_getinfo(OCNID(ens1), mpicom=mpicom_OCNID)
 
        call shr_scam_checkSurface(scmlon, scmlat, &
+            scm_multcols,scm_nx,scm_ny,           &
             iop_mode,                             &
             OCNID(ens1), mpicom_OCNID,            &
             lnd_present=lnd_present,              &

--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -450,7 +450,6 @@ module cime_comp_mod
 
   logical  :: areafact_samegrid      ! areafact samegrid flag
   logical  :: single_column          ! scm mode logical
-  logical  :: iop_mode               ! iop mode logical
   logical  :: scm_multcols           ! scm mode over multiple columns logical
   real(r8) :: scmlon                 ! single column lon
   real(r8) :: scmlat                 ! single column lat
@@ -1119,7 +1118,6 @@ contains
          scm_multcols=scm_multcols                 , &
          scm_nx=scm_nx                             , &
          scm_ny=scm_ny                             , &
-         iop_mode=iop_mode                         , &
          aqua_planet=aqua_planet                   , &
          cpl_seq_option=cpl_seq_option             , &
          drv_threading=drv_threading               , &
@@ -1336,7 +1334,6 @@ contains
 
        call shr_scam_checkSurface(scmlon, scmlat, &
             scm_multcols,scm_nx,scm_ny,           &
-            iop_mode,                             &
             OCNID(ens1), mpicom_OCNID,            &
             lnd_present=lnd_present,              &
             ocn_present=ocn_present,              &

--- a/driver-mct/shr/seq_infodata_mod.F90
+++ b/driver-mct/shr/seq_infodata_mod.F90
@@ -83,9 +83,11 @@ MODULE seq_infodata_mod
      character(SHR_KIND_CL)  :: restart_pfile   ! Restart pointer file
      character(SHR_KIND_CL)  :: restart_file    ! Full archive path to restart file
      logical                 :: single_column   ! single column mode
-     logical                 :: iop_mode        ! IOP mode
+     logical                 :: scm_multcols    ! SCM mode extrapolated to multiple columns
      real (SHR_KIND_R8)      :: scmlat          ! single column lat
      real (SHR_KIND_R8)      :: scmlon          ! single column lon
+     integer(SHR_KIND_IN)    :: scm_nx          ! points in x direction for SCM functionality
+     integer(SHR_KIND_IN)    :: scm_ny          ! points in y direction for SCM functionality
      character(SHR_KIND_CS)  :: logFilePostFix  ! postfix for output log files
      character(SHR_KIND_CL)  :: outPathRoot     ! root for output log files
      logical                 :: perpetual       ! perpetual flag
@@ -332,9 +334,11 @@ CONTAINS
     character(SHR_KIND_CL) :: restart_file       ! Restart filename
 
     logical                :: single_column      ! single column mode
-    logical                :: iop_mode           ! IOP mode
+    logical                :: scm_multcols       ! SCM mode extrapolated to multiple columns
     real (SHR_KIND_R8)     :: scmlat             ! single column mode latitude
     real (SHR_KIND_R8)     :: scmlon             ! single column mode longitude
+    integer(SHR_KIND_IN)   :: scm_nx             ! points in x direction for SCM functionality
+    integer(SHR_KIND_IN)   :: scm_ny             ! points in y direction for SCM functionality
     character(SHR_KIND_CS) :: logFilePostFix     ! postfix for output log files
     character(SHR_KIND_CL) :: outPathRoot        ! root output files
     logical                :: perpetual          ! perpetual mode
@@ -430,7 +434,8 @@ CONTAINS
          brnch_retain_casename, info_debug, bfbflag,       &
          restart_pfile, restart_file, run_barriers,        &
          single_column, scmlat, force_stop_at,             &
-         scmlon, iop_mode, logFilePostFix, outPathRoot, flux_diurnal,&
+         scmlon, logFilePostFix, outPathRoot, flux_diurnal,&
+         scm_multcols, scm_nx, scm_ny,                     &
          ocn_surface_flux_scheme, &
          coldair_outbreak_mod, &
          flux_convergence, flux_max_iteration,             &
@@ -493,9 +498,11 @@ CONTAINS
        restart_pfile         = 'rpointer.drv'
        restart_file          = trim(sp_str)
        single_column         = .false.
-       iop_mode              = .false.
+       scm_multcols          = .false.
        scmlat                = -999.
        scmlon                = -999.
+       scm_nx                = -1
+       scm_ny                = -1
        logFilePostFix        = '.log'
        outPathRoot           = './'
        perpetual             = .false.
@@ -629,9 +636,11 @@ CONTAINS
           infodata%restart_file       = restart_file
        end if
        infodata%single_column         = single_column
-       infodata%iop_mode              = iop_mode
+       infodata%scm_multcols          = scm_multcols
        infodata%scmlat                = scmlat
        infodata%scmlon                = scmlon
+       infodata%scm_nx                = scm_nx
+       infodata%scm_ny                = scm_ny
        infodata%logFilePostFix        = logFilePostFix
        infodata%outPathRoot           = outPathRoot
        infodata%perpetual             = perpetual
@@ -968,7 +977,8 @@ CONTAINS
        model_version, username, hostname, rest_case_name, tchkpt_dir,     &
        start_type, restart_pfile, restart_file, perpetual, perpetual_ymd, &
        aqua_planet,aqua_planet_sst, brnch_retain_casename, &
-       single_column, scmlat,scmlon,iop_mode,logFilePostFix, outPathRoot,&
+       single_column, scmlat,scmlon,logFilePostFix, outPathRoot,&
+       scm_multcols, scm_nx, scm_ny,                                      &
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic,                                       &
@@ -1037,7 +1047,9 @@ CONTAINS
     logical,                optional, intent(OUT) :: single_column
     real (SHR_KIND_R8),     optional, intent(OUT) :: scmlat
     real (SHR_KIND_R8),     optional, intent(OUT) :: scmlon
-    logical,                optional, intent(OUT) :: iop_mode
+    logical,                optional, intent(OUT) :: scm_multcols
+    integer,                optional, intent(OUT) :: scm_nx
+    integer,                optional, intent(OUT) :: scm_ny
     character(len=*),       optional, intent(OUT) :: logFilePostFix          ! output log file postfix
     character(len=*),       optional, intent(OUT) :: outPathRoot             ! output file root
     logical,                optional, intent(OUT) :: perpetual               ! If this is perpetual
@@ -1213,9 +1225,11 @@ CONTAINS
     if ( present(restart_pfile)  ) restart_pfile  = infodata%restart_pfile
     if ( present(restart_file)   ) restart_file   = infodata%restart_file
     if ( present(single_column)  ) single_column  = infodata%single_column
-    if ( present(iop_mode  )     ) iop_mode       = infodata%iop_mode
+    if ( present(scm_multcols)   ) scm_multcols   = infodata%scm_multcols
     if ( present(scmlat)         ) scmlat         = infodata%scmlat
     if ( present(scmlon)         ) scmlon         = infodata%scmlon
+    if ( present(scm_nx)         ) scm_nx         = infodata%scm_nx
+    if ( present(scm_ny)         ) scm_ny         = infodata%scm_ny
     if ( present(logFilePostFix) ) logFilePostFix = infodata%logFilePostFix
     if ( present(outPathRoot)    ) outPathRoot    = infodata%outPathRoot
     if ( present(perpetual)      ) perpetual      = infodata%perpetual
@@ -1505,7 +1519,8 @@ CONTAINS
        model_version, username, hostname, rest_case_name, tchkpt_dir,     &
        start_type, restart_pfile, restart_file, perpetual, perpetual_ymd, &
        aqua_planet,aqua_planet_sst, brnch_retain_casename, &
-       single_column, scmlat,scmlon,iop_mode,logFilePostFix, outPathRoot,          &
+       single_column, scmlat,scmlon,logFilePostFix, outPathRoot,          &
+       scm_multcols, scm_nx, scm_ny,                                      &
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic,                                       &
@@ -1573,7 +1588,9 @@ CONTAINS
     logical,                optional, intent(IN)    :: single_column
     real (SHR_KIND_R8),     optional, intent(IN)    :: scmlat
     real (SHR_KIND_R8),     optional, intent(IN)    :: scmlon
-    logical,                optional, intent(IN)    :: iop_mode
+    logical,                optional, intent(IN)    :: scm_multcols
+    integer,                optional, intent(IN)    :: scm_nx
+    integer,                optional, intent(IN)    :: scm_ny
     character(len=*),       optional, intent(IN)    :: logFilePostFix          ! output log file postfix
     character(len=*),       optional, intent(IN)    :: outPathRoot             ! output file root
     logical,                optional, intent(IN)    :: perpetual               ! If this is perpetual
@@ -1746,9 +1763,11 @@ CONTAINS
     if ( present(restart_pfile)  ) infodata%restart_pfile  = restart_pfile
     if ( present(restart_file)   ) infodata%restart_file   = restart_file
     if ( present(single_column)  ) infodata%single_column  = single_column
-    if ( present(iop_mode)       ) infodata%iop_mode       = iop_mode
+    if ( present(scm_multcols)   ) infodata%scm_multcols   = scm_multcols
     if ( present(scmlat)         ) infodata%scmlat         = scmlat
     if ( present(scmlon)         ) infodata%scmlon         = scmlon
+    if ( present(scm_nx)         ) infodata%scm_nx         = scm_nx
+    if ( present(scm_ny)         ) infodata%scm_ny         = scm_ny
     if ( present(logFilePostFix) ) infodata%logFilePostFix = logFilePostFix
     if ( present(outPathRoot)    ) infodata%outPathRoot    = outPathRoot
     if ( present(perpetual)      ) infodata%perpetual      = perpetual
@@ -2049,9 +2068,11 @@ CONTAINS
     call shr_mpi_bcast(infodata%restart_pfile,           mpicom)
     call shr_mpi_bcast(infodata%restart_file,            mpicom)
     call shr_mpi_bcast(infodata%single_column,           mpicom)
-    call shr_mpi_bcast(infodata%iop_mode,                mpicom)
+    call shr_mpi_bcast(infodata%scm_multcols,            mpicom)
     call shr_mpi_bcast(infodata%scmlat,                  mpicom)
     call shr_mpi_bcast(infodata%scmlon,                  mpicom)
+    call shr_mpi_bcast(infodata%scm_nx,                  mpicom)
+    call shr_mpi_bcast(infodata%scm_ny,                  mpicom)
     call shr_mpi_bcast(infodata%logFilePostFix,          mpicom)
     call shr_mpi_bcast(infodata%outPathRoot,             mpicom)
     call shr_mpi_bcast(infodata%perpetual,               mpicom)
@@ -2732,9 +2753,11 @@ CONTAINS
     write(logunit,F0A) subname,'Restart file (full path) = ', trim(infodata%restart_file)
 
     write(logunit,F0L) subname,'single_column            = ', infodata%single_column
-    write(logunit,F0L) subname,'iop_mode                 = ', infodata%iop_mode
+    write(logunit,F0L) subname,'scm_multcols             = ', infodata%scm_multcols
     write(logunit,F0R) subname,'scmlat                   = ', infodata%scmlat
     write(logunit,F0R) subname,'scmlon                   = ', infodata%scmlon
+    write(logunit,F0I) subname,'scm_nx                   = ', infodata%scm_nx
+    write(logunit,F0I) subname,'scm_ny                   = ', infodata%scm_ny
 
     write(logunit,F0A) subname,'Log output end name      = ', trim(infodata%logFilePostFix)
     write(logunit,F0A) subname,'Output path dir          = ', trim(infodata%outPathRoot)

--- a/share/streams/shr_strdata_mod.F90
+++ b/share/streams/shr_strdata_mod.F90
@@ -154,7 +154,8 @@ contains
 !===============================================================================
 
   subroutine shr_strdata_init( &
-       SDAT,mpicom,compid,name,scmmode,iop_mode,scmlon,scmlat, &
+       SDAT,mpicom,compid,name,scmmode,scm_multcols,scmlon,scmlat, &
+       scm_nx,scm_ny, &
        gsmap, ggrid, nxg, nyg, nzg, &
        calendar, reset_domain_mask, dmodel_domain_fracname_from_stream)
 
@@ -168,9 +169,11 @@ contains
     integer(IN)           ,intent(in)          :: compid
     character(len=*)      ,intent(in),optional :: name
     logical               ,intent(in),optional :: scmmode
-    logical               ,intent(in),optional :: iop_mode
+    logical               ,intent(in),optional :: scm_multcols
     real(R8)              ,intent(in),optional :: scmlon
     real(R8)              ,intent(in),optional :: scmlat
+    integer(IN)           ,intent(in),optional :: scm_nx
+    integer(IN)           ,intent(in),optional :: scm_ny
     type(mct_gsmap)       ,intent(in),optional :: gsmap
     type(mct_ggrid)       ,intent(in),optional :: ggrid
     integer(IN)           ,intent(in),optional :: nxg
@@ -213,7 +216,8 @@ contains
          gsmap=gsmap, ggrid=ggrid, nxg=nxg, nyg=nyg, nzg=nzg, &
          reset_domain_mask=reset_domain_mask, &
          dmodel_domain_fracname_from_stream=dmodel_domain_fracname_from_stream, &
-         scmmode=scmmode, iop_mode=iop_mode, scmlon=scmlon, scmlat=scmlat)
+         scmmode=scmmode, scm_multcols=scm_multcols, scmlon=scmlon, scmlat=scmlat, &
+         scm_nx=scm_nx,scm_ny=scm_ny)
 
     !------------------------------------------------------
     ! --- (2) initialize streams and stream domains ---
@@ -232,8 +236,8 @@ contains
   !===============================================================================
 
   subroutine shr_strdata_init_model_domain(SDAT, mpicom, compid, my_task, &
-       gsmap, ggrid, nxg, nyg, nzg, scmmode, iop_mode, scmlon, scmlat, &
-       reset_domain_mask, dmodel_domain_fracname_from_stream)
+       gsmap, ggrid, nxg, nyg, nzg, scmmode, scm_multcols, scmlon, scmlat, &
+       scm_nx, scm_ny, reset_domain_mask, dmodel_domain_fracname_from_stream)
 
     ! input/output variables
     type(shr_strdata_type),intent(inout)       :: SDAT
@@ -246,9 +250,11 @@ contains
     integer(IN)           ,intent(in),optional :: nyg
     integer(IN)           ,intent(in),optional :: nzg
     logical               ,intent(in),optional :: scmmode
-    logical               ,intent(in),optional :: iop_mode
+    logical               ,intent(in),optional :: scm_multcols
     real(R8)              ,intent(in),optional :: scmlon
     real(R8)              ,intent(in),optional :: scmlat
+    integer(IN)           ,intent(in),optional :: scm_nx
+    integer(IN)           ,intent(in),optional :: scm_ny
     logical               ,intent(in),optional :: reset_domain_mask
     character(len=*)      ,intent(in),optional :: dmodel_domain_fracname_from_stream
 
@@ -282,14 +288,14 @@ contains
     logical        :: readfrac     ! whether to read fraction from the first stream file
     integer        :: kmask, kfrac
     logical        :: lscmmode
-    logical        :: liop_mode
+    logical        :: lscm_multcols
     integer(IN)      ,parameter :: master_task = 0
     character(*)     ,parameter :: F00 = "('(shr_strdata_init) ',8a)"
     character(len=*) ,parameter :: subname = "(shr_strdata_init) "
     !-------------------------------------------------------------------------------
 
     lscmmode = .false.
-    liop_mode = .false.
+    lscm_multcols = .false.
     if (present(scmmode)) then
        lscmmode = scmmode
        if (lscmmode) then
@@ -300,8 +306,8 @@ contains
        endif
     endif
 
-    if (present(iop_mode)) then
-      liop_mode=iop_mode
+    if (present(scm_multcols)) then
+      lscm_multcols=scm_multcols
     endif
 
     if (present(gsmap) .and. present(ggrid) .and. present(nxg) .and. present(nyg) .and. present(nzg)) then
@@ -355,7 +361,7 @@ contains
                      decomp=decomp, lonName=lonName, latName=latName, hgtName=hgtName, &
                      maskName=maskName, areaName=areaName, &
                      fracname=dmodel_domain_fracname_from_stream, readfrac=readfrac, &
-                     scmmode=lscmmode, iop_mode=liop_mode, scmlon=scmlon, scmlat=scmlat)
+                     scmmode=lscmmode, scm_multcols=lscm_multcols, scmlon=scmlon, scmlat=scmlat)
              else
                 call shr_dmodel_readgrid(SDAT%grid,SDAT%gsmap, SDAT%nxg, SDAT%nyg, SDAT%nzg, &
                      fileName, compid, mpicom, &
@@ -380,8 +386,8 @@ contains
           if (lscmmode) then
              call shr_dmodel_readgrid(SDAT%grid,SDAT%gsmap,SDAT%nxg,SDAT%nyg,SDAT%nzg, &
                   SDAT%domainfile, compid, mpicom, &
-                  decomp=decomp, readfrac=.true., scmmode=lscmmode, iop_mode=liop_mode, &
-                  scmlon=scmlon, scmlat=scmlat)
+                  decomp=decomp, readfrac=.true., scmmode=lscmmode, scm_multcols=lscm_multcols, &
+                  scmlon=scmlon, scmlat=scmlat, scm_nx=scm_nx, scm_ny=scm_ny)
           else
              call shr_dmodel_readgrid(SDAT%grid, SDAT%gsmap, SDAT%nxg, SDAT%nyg, SDAT%nzg, &
                   SDAT%domainfile, compid, mpicom, &

--- a/share/util/shr_scam_mod.F90
+++ b/share/util/shr_scam_mod.F90
@@ -587,8 +587,8 @@ end subroutine shr_scam_getCloseLatLonFile
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, ocn_compid, ocn_mpicom, &
-     lnd_present, sno_present, ocn_present, ice_present, &
+subroutine shr_scam_checkSurface(scmlon, scmlat, scm_multcols, scm_nx, scm_ny, &
+     ocn_compid, ocn_mpicom, lnd_present, sno_present, ocn_present, ice_present, &
      rof_present, flood_present, rofice_present)
 
 ! !USES:
@@ -601,7 +601,9 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, ocn_compid, ocn_mpico
 ! !INPUT/OUTPUT PARAMETERS:
 
    real(R8),                     intent(in)  :: scmlon,scmlat ! single column lat lon
-   logical,                      intent(in)  :: iop_mode     ! iop mode logical
+   logical,                      intent(in)  :: scm_multcols ! SCM over domain logical
+   integer(IN),                  intent(in)  :: scm_nx       ! number points in x direction
+   integer(IN),                  intent(in)  :: scm_ny       ! number points in y direction
    integer(IN),                  intent(in)  :: ocn_compid   ! id for ocean model
    integer(IN),                  intent(in)  :: ocn_mpicom   ! mpi communicator for ocean
    logical,            optional, intent(inout) :: lnd_present  ! land point
@@ -713,7 +715,8 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, ocn_compid, ocn_mpico
       call shr_strdata_readnml(SCAMSDAT,'docn_in')
       call shr_dmodel_readgrid(SCAMSDAT%grid,SCAMSDAT%gsmap,SCAMSDAT%nxg,SCAMSDAT%nyg,SCAMSDAT%nzg, &
            SCAMSDAT%domainfile, ocn_compid, ocn_mpicom, '2d1d', readfrac=.true., &
-           scmmode=.true.,iop_mode=iop_mode,scmlon=scmlon,scmlat=scmlat)
+           scmmode=.true.,scm_multcols=scm_multcols,scmlon=scmlon,scmlat=scmlat, &
+           scm_nx=scm_nx,scm_ny=scm_ny)
       nfrac = mct_aVect_indexRA(SCAMSDAT%grid%data,'frac')
 
       ocn_point = (SCAMSDAT%grid%data%rAttr(nfrac,1) > 0._r8)


### PR DESCRIPTION
PR changes the name of the ambiguously named flag “iop_mode” with “scm_multcols”, which turns on single column model (SCM) functionality but for multiple columns. Specifically, its purpose is to take the column on the globe intended to be run in SCM mode, but propagates that point (i.e. meaning surface type and location etc.) to multiple columns, as defined by the user. All columns are then forced identically according to the Intensive Observation Period (IOP) file, which is typically required to run in SCM mode. This PR also adds the flexibility for the user to determine the number of columns in the x & y direction (PTS_NX, PTX_NY and scm_nx, scm_ny).  

Background/Motivation for changes: This PR is intended to support running a doubly periodic cloud resolving model with the planar version of HOMME (specifically, the doubly periodic version of SCREAM) but could be potentially useful for other applications.

All e3sm_developer tests pass as expected on cori-knl

[BFB]