### PR TITLE
Change crm_rad type to allocatable

### DIFF
--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -50,10 +50,10 @@ module crm_physics
    integer :: crm_cld_rad_idx  = -1
    integer :: crm_qrad_idx     = -1
 
-   integer :: crm_rad_idx_nc   = -1
-   integer :: crm_rad_idx_ni   = -1
-   integer :: crm_rad_idx_qs   = -1
-   integer :: crm_rad_idx_ns   = -1
+   integer :: crm_nc_rad_idx   = -1
+   integer :: crm_ni_rad_idx   = -1
+   integer :: crm_qs_rad_idx   = -1
+   integer :: crm_ns_rad_idx   = -1
 
 contains
 !===================================================================================================
@@ -198,10 +198,10 @@ subroutine crm_physics_register()
    call pbuf_add_field('CONCLD',       'global', dtype_r8,dims_gcm_3D,idx)  ! convective cloud fraction
 
    if (MMF_microphysics_scheme .eq. 'm2005') then
-      call pbuf_add_field('CRM_NC_RAD','physpkg',dtype_r8,dims_crm_rad,crm_rad_idx_nc)
-      call pbuf_add_field('CRM_NI_RAD','physpkg',dtype_r8,dims_crm_rad,crm_rad_idx_ni)
-      call pbuf_add_field('CRM_QS_RAD','physpkg',dtype_r8,dims_crm_rad,crm_rad_idx_qs)
-      call pbuf_add_field('CRM_NS_RAD','physpkg',dtype_r8,dims_crm_rad,crm_rad_idx_ns)
+      call pbuf_add_field('CRM_NC_RAD','physpkg',dtype_r8,dims_crm_rad,crm_nc_rad_idx)
+      call pbuf_add_field('CRM_NI_RAD','physpkg',dtype_r8,dims_crm_rad,crm_ni_rad_idx)
+      call pbuf_add_field('CRM_QS_RAD','physpkg',dtype_r8,dims_crm_rad,crm_qs_rad_idx)
+      call pbuf_add_field('CRM_NS_RAD','physpkg',dtype_r8,dims_crm_rad,crm_ns_rad_idx)
 
       call pbuf_add_field('CRM_QT',    'global', dtype_r8,dims_crm_3D,idx)
       call pbuf_add_field('CRM_NC',    'global', dtype_r8,dims_crm_3D,idx)
@@ -381,10 +381,10 @@ subroutine crm_physics_init(state, pbuf2d, species_class)
       call pbuf_set_field(pbuf2d, crm_cld_rad_idx,0._r8)
       call pbuf_set_field(pbuf2d, crm_qrad_idx,   0._r8)
       if (MMF_microphysics_scheme .eq. 'm2005') then
-         call pbuf_set_field(pbuf2d, crm_rad_idx_nc,0._r8)
-         call pbuf_set_field(pbuf2d, crm_rad_idx_ni,0._r8)
-         call pbuf_set_field(pbuf2d, crm_rad_idx_qs,0._r8)
-         call pbuf_set_field(pbuf2d, crm_rad_idx_ns,0._r8)
+         call pbuf_set_field(pbuf2d, crm_nc_rad_idx,0._r8)
+         call pbuf_set_field(pbuf2d, crm_ni_rad_idx,0._r8)
+         call pbuf_set_field(pbuf2d, crm_qs_rad_idx,0._r8)
+         call pbuf_set_field(pbuf2d, crm_ns_rad_idx,0._r8)
       end if
 
       call pbuf_set_field(pbuf2d, pbuf_get_index('CLDO')       , 0._r8)
@@ -795,10 +795,10 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
       call pbuf_get_field(pbuf, crm_cld_rad_idx,crm_cld_rad)
       call pbuf_get_field(pbuf, crm_qrad_idx,   crm_qrad)
       if (MMF_microphysics_scheme .eq. 'm2005') then
-         call pbuf_get_field(pbuf, crm_rad_idx_nc,crm_nc_rad)
-         call pbuf_get_field(pbuf, crm_rad_idx_ni,crm_ni_rad)
-         call pbuf_get_field(pbuf, crm_rad_idx_qs,crm_qs_rad)
-         call pbuf_get_field(pbuf, crm_rad_idx_ns,crm_ns_rad)
+         call pbuf_get_field(pbuf, crm_nc_rad_idx,crm_nc_rad)
+         call pbuf_get_field(pbuf, crm_ni_rad_idx,crm_ni_rad)
+         call pbuf_get_field(pbuf, crm_qs_rad_idx,crm_qs_rad)
+         call pbuf_get_field(pbuf, crm_ns_rad_idx,crm_ns_rad)
       end if
       do k = 1,crm_nz
          m = pver-k+1
@@ -1245,10 +1245,10 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
       call pbuf_get_field(pbuf, crm_qrad_idx,   crm_qrad)
 
       if (MMF_microphysics_scheme .eq. 'm2005') then
-         call pbuf_get_field(pbuf, crm_rad_idx_nc, crm_nc_rad, start=(/1,1,1,1/), kount=(/pcols,crm_nx_rad, crm_ny_rad, crm_nz/))
-         call pbuf_get_field(pbuf, crm_rad_idx_ni, crm_ni_rad, start=(/1,1,1,1/), kount=(/pcols,crm_nx_rad, crm_ny_rad, crm_nz/))
-         call pbuf_get_field(pbuf, crm_rad_idx_qs, crm_qs_rad, start=(/1,1,1,1/), kount=(/pcols,crm_nx_rad, crm_ny_rad, crm_nz/))
-         call pbuf_get_field(pbuf, crm_rad_idx_ns, crm_ns_rad, start=(/1,1,1,1/), kount=(/pcols,crm_nx_rad, crm_ny_rad, crm_nz/))
+         call pbuf_get_field(pbuf, crm_nc_rad_idx, crm_nc_rad, start=(/1,1,1,1/), kount=(/pcols,crm_nx_rad, crm_ny_rad, crm_nz/))
+         call pbuf_get_field(pbuf, crm_ni_rad_idx, crm_ni_rad, start=(/1,1,1,1/), kount=(/pcols,crm_nx_rad, crm_ny_rad, crm_nz/))
+         call pbuf_get_field(pbuf, crm_qs_rad_idx, crm_qs_rad, start=(/1,1,1,1/), kount=(/pcols,crm_nx_rad, crm_ny_rad, crm_nz/))
+         call pbuf_get_field(pbuf, crm_ns_rad_idx, crm_ns_rad, start=(/1,1,1,1/), kount=(/pcols,crm_nx_rad, crm_ny_rad, crm_nz/))
       end if
 
       do i = 1,ncol

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -689,7 +689,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    ! Retrieve pbuf fields and constituent indices
    !------------------------------------------------------------------------------------------------
    call pbuf_get_field(pbuf, pbuf_get_index('CRM_QRAD'),    crm_qrad)
-   crm_rad%qrad(:,:,:,:) = crm_qrad(:,:,:,:)
+   crm_rad%qrad(1:ncol,:,:,:) = crm_qrad(1:ncol,:,:,:)
 
    call pbuf_get_field(pbuf, pbuf_get_index('PREC_DP'),  prec_dp  )
    call pbuf_get_field(pbuf, pbuf_get_index('SNOW_DP'),  snow_dp  )

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -688,7 +688,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    !------------------------------------------------------------------------------------------------
    ! Retrieve pbuf fields and constituent indices
    !------------------------------------------------------------------------------------------------
-   call pbuf_get_field(pbuf, pbuf_get_index('CRM_QRAD'),    crm_qrad)
+   call pbuf_get_field(pbuf, crm_qrad_idx,    crm_qrad)
    crm_rad%qrad(1:ncol,:,:,:) = crm_qrad(1:ncol,:,:,:)
 
    call pbuf_get_field(pbuf, pbuf_get_index('PREC_DP'),  prec_dp  )

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -1237,7 +1237,6 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
       !---------------------------------------------------------------------------------------------
       ! put rad data back in pbuf
       !---------------------------------------------------------------------------------------------
-
       call pbuf_get_field(pbuf, crm_rad_idx_t,    crm_rad_tmp_temperature)
       call pbuf_get_field(pbuf, crm_rad_idx_qv,   crm_rad_tmp_qv)
       call pbuf_get_field(pbuf, crm_rad_idx_qc,   crm_rad_tmp_qc)

--- a/components/eam/src/physics/crm/crm_rad_module.F90
+++ b/components/eam/src/physics/crm/crm_rad_module.F90
@@ -102,10 +102,10 @@ contains
       if (allocated(rad%cld))         deallocate(rad%cld)
 
       if (MMF_microphysics_scheme .eq. 'm2005') then
-         if (allocated(rad%nc)        deallocate(rad%nc)
-         if (allocated(rad%ni)        deallocate(rad%ni)
-         if (allocated(rad%qs)        deallocate(rad%qs)
-         if (allocated(rad%ns)        deallocate(rad%ns)
+         if (allocated(rad%nc))       deallocate(rad%nc)
+         if (allocated(rad%ni))       deallocate(rad%ni)
+         if (allocated(rad%qs))       deallocate(rad%qs)
+         if (allocated(rad%ns))       deallocate(rad%ns)
       end if
 
    end subroutine crm_rad_finalize

--- a/components/eam/src/physics/crm/crm_rad_module.F90
+++ b/components/eam/src/physics/crm/crm_rad_module.F90
@@ -8,6 +8,7 @@ module crm_rad_module
    ! update the radiation in the future, should we choose to put the radiation
    ! calculations on the CRM.
    use params_kind, only: crm_rknd, r8
+   use openacc_utils
 
    implicit none
 
@@ -15,58 +16,83 @@ module crm_rad_module
 
    type crm_rad_type
       ! Radiative heating
-      real(crm_rknd), pointer :: qrad(:,:,:,:)
+      real(crm_rknd), allocatable :: qrad(:,:,:,:)
 
       ! Quantities used by the radiation code. Note that these are strange in that they are 
       ! time-averages, but spatially-resolved.
-      real(crm_rknd), pointer :: temperature(:,:,:,:) ! rad temperature
-      real(crm_rknd), pointer :: qv (:,:,:,:) ! rad vapor
-      real(crm_rknd), pointer :: qc (:,:,:,:) ! rad cloud water
-      real(crm_rknd), pointer :: qi (:,:,:,:) ! rad cloud ice
-      real(crm_rknd), pointer :: cld(:,:,:,:) ! rad cloud fraction
+      real(crm_rknd), allocatable :: temperature(:,:,:,:) ! rad temperature
+      real(crm_rknd), allocatable :: qv (:,:,:,:) ! rad vapor
+      real(crm_rknd), allocatable :: qc (:,:,:,:) ! rad cloud water
+      real(crm_rknd), allocatable :: qi (:,:,:,:) ! rad cloud ice
+      real(crm_rknd), allocatable :: cld(:,:,:,:) ! rad cloud fraction
 
       ! Only relevant when using 2-moment microphysics
-      real(crm_rknd), pointer :: nc(:,:,:,:) ! rad cloud droplet number (#/kg)
-      real(crm_rknd), pointer :: ni(:,:,:,:) ! rad cloud ice crystal number (#/kg)
-      real(crm_rknd), pointer :: qs(:,:,:,:) ! rad cloud snow (kg/kg)
-      real(crm_rknd), pointer :: ns(:,:,:,:) ! rad cloud snow crystal number (#/kg)
+      real(crm_rknd), allocatable :: nc(:,:,:,:) ! rad cloud droplet number (#/kg)
+      real(crm_rknd), allocatable :: ni(:,:,:,:) ! rad cloud ice crystal number (#/kg)
+      real(crm_rknd), allocatable :: qs(:,:,:,:) ! rad cloud snow (kg/kg)
+      real(crm_rknd), allocatable :: ns(:,:,:,:) ! rad cloud snow crystal number (#/kg)
    end type crm_rad_type
 
 contains
 
    !------------------------------------------------------------------------------------------------
    ! Type-bound procedures for crm_rad_type
-   subroutine crm_rad_initialize(rad)
+   subroutine crm_rad_initialize(rad, ncrms, crm_nx_rad, crm_ny_rad, crm_nz)
       class(crm_rad_type), intent(inout) :: rad
+      integer, intent(in) :: ncrms, crm_nx_rad, crm_ny_rad, crm_nz
 
-      ! Nullify pointers
-      rad%qrad => null()
-      rad%temperature => null()
-      rad%qv => null()
-      rad%qi => null()
-      rad%cld => null()
+      if (.not. allocated(rad%qrad))        allocate(rad%qrad       (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
+      if (.not. allocated(rad%temperature)) allocate(rad%temperature(ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
+      if (.not. allocated(rad%qv))          allocate(rad%qv         (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
+      if (.not. allocated(rad%qc))          allocate(rad%qc         (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
+      if (.not. allocated(rad%qi))          allocate(rad%qi         (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
+      if (.not. allocated(rad%cld))         allocate(rad%cld        (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
+      
+      if (.not. allocated(rad%nc))          allocate(rad%nc         (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
+      if (.not. allocated(rad%ni))          allocate(rad%ni         (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
+      if (.not. allocated(rad%qs))          allocate(rad%qs         (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
+      if (.not. allocated(rad%ns))          allocate(rad%ns         (ncrms, crm_nx_rad, crm_ny_rad, crm_nz))
 
-      rad%nc => null()
-      rad%ni => null()
-      rad%qs => null()
-      rad%ns => null()
+      call prefetch(rad%qrad)
+      call prefetch(rad%temperature)
+      call prefetch(rad%qv)
+      call prefetch(rad%qc)
+      call prefetch(rad%qi)
+      call prefetch(rad%cld)
+
+      call prefetch(rad%nc)
+      call prefetch(rad%ni)
+      call prefetch(rad%qs)
+      call prefetch(rad%ns)
+
+      rad%qrad           = 0
+      rad%temperature    = 0
+      rad%qv             = 0
+      rad%qc             = 0
+      rad%qi             = 0
+      rad%cld            = 0
+
+      rad%nc             = 0
+      rad%ni             = 0
+      rad%qs             = 0
+      rad%ns             = 0
 
    end subroutine crm_rad_initialize
    !------------------------------------------------------------------------------------------------
    subroutine crm_rad_finalize(rad)
       class(crm_rad_type), intent(inout) :: rad
 
-      ! Nullify pointers
-      rad%qrad => null()
-      rad%temperature => null()
-      rad%qv => null()
-      rad%qi => null()
-      rad%cld => null()
+      deallocate(rad%qrad)
+      deallocate(rad%temperature)
+      deallocate(rad%qv)
+      deallocate(rad%qc)
+      deallocate(rad%qi)
+      deallocate(rad%cld)
 
-      rad%nc => null()
-      rad%ni => null()
-      rad%qs => null()
-      rad%ns => null()
+      deallocate(rad%nc)
+      deallocate(rad%ni)
+      deallocate(rad%qs)
+      deallocate(rad%ns)
 
    end subroutine crm_rad_finalize
    !------------------------------------------------------------------------------------------------

--- a/components/eam/src/physics/crm/crm_rad_module.F90
+++ b/components/eam/src/physics/crm/crm_rad_module.F90
@@ -82,17 +82,17 @@ contains
    subroutine crm_rad_finalize(rad)
       class(crm_rad_type), intent(inout) :: rad
 
-      deallocate(rad%qrad)
-      deallocate(rad%temperature)
-      deallocate(rad%qv)
-      deallocate(rad%qc)
-      deallocate(rad%qi)
-      deallocate(rad%cld)
+      if (allocated(rad%qrad))        deallocate(rad%qrad)
+      if (allocated(rad%temperature)) deallocate(rad%temperature)
+      if (allocated(rad%qv))          deallocate(rad%qv)
+      if (allocated(rad%qc))          deallocate(rad%qc)
+      if (allocated(rad%qi))          deallocate(rad%qi)
+      if (allocated(rad%cld))         deallocate(rad%cld)
 
-      deallocate(rad%nc)
-      deallocate(rad%ni)
-      deallocate(rad%qs)
-      deallocate(rad%ns)
+      if (allocated(rad%nc)           deallocate(rad%nc)
+      if (allocated(rad%ni)           deallocate(rad%ni)
+      if (allocated(rad%qs)           deallocate(rad%qs)
+      if (allocated(rad%ns)           deallocate(rad%ns)
 
    end subroutine crm_rad_finalize
    !------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change is needed looking forward to changes to accommodate running the MMF with OpenMP CPU threads. The crm_rad type is changed from a collection of pointers to a collection of allocatable variables. 

[BFB]