### PR TITLE
Mass and heat conserving frazil coupling

### DIFF
--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -1684,8 +1684,8 @@ contains
 !    o  swndf    -- sw: nir diffuse downward
 !    o  swvdf    -- sw: vis diffuse downward
 !    o  swnet    -- sw: net
-!    o  q        -- ocn freeze/melt heat flux
-!    o  frazil   -- ocn frazil production
+!    o  q        -- ocn frazil heat flux(+) / melt potential(-)
+!    o  frazil   -- ocn frazil mass flux 
 !    o  bcphidry -- Black Carbon hydrophilic dry deposition flux
 !    o  bcphodry -- Black Carbon hydrophobic dry deposition flux
 !    o  bcphiwet -- Black Carbon hydrophilic wet deposition flux
@@ -1973,19 +1973,19 @@ contains
         if (trim(config_ocean_surface_type) == "free") then ! free surface (MPAS-O)
         
            ! freezingMeltingPotential(i) is the ocean energy associated with frazil formation 
-           ! when it is positive and frazilMassFlux is positive, and negative  when there is 
-           ! a melting potential in which case frazilMassFlux is zero
+           ! when it is positive and frazilMassFlux is positive. Conversely, freezingMeltingPotential(i)
+           ! is negative when there is the melting potential in which case frazilMassFlux is zero.
 
            freezingMeltingPotential(i) = x2i_i % rAttr(index_x2i_Fioo_q, n)
 
            frazilMassFlux              = x2i_i % rAttr(index_x2i_Fioo_frazil, n)
 
-           ! We calculate a second energy associated with frazil production that is 
-           ! the sea ice model's version, which is passed to sea ice column physics as 
-           ! the frazilProduction, which is positive when frazil forms, otherwise zero.
-           ! frazilProduction is used to balance the mass budget according to what 
-           ! the sea ice model needs to complete the conversion of frazil to sea ice for
-           ! the given quantity of energy the ocean model has passed to the sea ice model.
+           ! Now determine the sea ice mass associated with the frazil heat flux given when
+           ! freezingMeltingPotential(i) is positive. This produces a revised mass flux, given 
+           ! in frazilMassFluxRev for the given sea surface salinity. The resulting difference
+           ! is assigned to frazilMassAdjust(i) which is exported to the ocean in the subsequent
+           ! coupling step as a freshwater and salt flux. This step is required to balance mass
+           ! and heat with the ocean.
 
            call frazil_mass(freezingMeltingPotential(i), frazilMassFluxRev, seaSurfaceSalinity(i), &
                                    config_thermodynamics_type)
@@ -2233,6 +2233,8 @@ contains
       endif
    endif
 
+! REVISION HISTORY:
+! Revised Andrew Roberts May 2021
 !-----------------------------------------------------------------------
 !EOC
 
@@ -2545,7 +2547,9 @@ contains
                i2x_i % rAttr(index_i2x_Faii_swnet,n) = absorbedShortwaveFlux(i)
             endif
 
-            !--- i/o fluxes computed by ice
+            ! i/o fluxes computed by ice, as well as additional freshwater and salt calculated at the last 
+            ! coupling import and needed to grow sea ice from frazil passed from the ocean model in the
+            ! field frazilMassAdjust.
             i2x_i % rAttr(index_i2x_Fioi_melth,n) = oceanHeatFlux(i)
             i2x_i % rAttr(index_i2x_Fioi_swpen,n) = oceanShortwaveFlux(i)
             i2x_i % rAttr(index_i2x_Fioi_meltw,n) = oceanFreshWaterFlux(i) + frazilMassAdjust(i)
@@ -2583,6 +2587,8 @@ contains
       block_ptr => block_ptr % next
    enddo
 
+! REVISION HISTORY:
+! Revised Andrew Roberts May 2021
 !-----------------------------------------------------------------------
 !EOC
 
@@ -2725,7 +2731,11 @@ contains
                                  config_thermodynamics_type)
 !
 ! !DESCRIPTION:
-! Calculate freezing potential for a cell
+! Calculate frazil mass based on on the sea surface salinity, and frazil heat flux 
+! from the ocean, otherwise referred to as to as the freeze-melt potential. When 
+! freezingPotential is positive, it gives the heat flux, according to the ocean model
+! associated with the frazil mass passed from the ocean.  This function calculates
+! the frazil mass based on the freezingPotential according to sea ice model thermodynamics,
 !
 ! !USES:
       use ice_mushy_physics, only:  &
@@ -2772,9 +2782,6 @@ contains
          qi0new = -seaiceDensityIce*seaiceLatentHeatMelting
       endif    ! ktherm
 
-      !vi0new = max (frazilMassFlux, 0.0_RKIND) / seaiceDensityIce
-      !freezingPotential = -vi0new*qi0new ! note sign convention, qi < 0
-
       frazilMassFlux = -freezingPotential*seaiceDensityIce/qi0new
 
    else
@@ -2783,6 +2790,8 @@ contains
 
    endif
 
+! REVISION HISTORY:
+! Revised Andrew Roberts May 2021
 !-----------------------------------------------------------------------
 !EOC
 

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -57,7 +57,7 @@ module ice_comp_mct
    use seaice_time_integration
    use seaice_error, only: seaice_check_critical_error
 
-   use ice_constants_colpkg, only: Tffresh
+   use ice_constants_colpkg, only: Tffresh, ice_ref_salinity, p001
 
    use ice_colpkg, only: colpkg_sea_freezing_temperature
 
@@ -1759,9 +1759,8 @@ contains
       i,n
 
    real (kind=RKIND) :: &
-      frazilProduction, &
-      meltingPotential, &
-      freezingPotential
+      frazilMassFlux, &
+      frazilMassFluxRev
 
    type (block_type), pointer :: block_ptr
 
@@ -1790,6 +1789,7 @@ contains
       seaSurfaceSalinityField,          &
       seaFreezingTemperatureField,      &
       freezingMeltingPotentialField,    &
+      frazilMassAdjustField,            &
       uOceanVelocityField,              &
       vOceanVelocityField,              &
       seaSurfaceTiltUField,             &
@@ -1832,6 +1832,7 @@ contains
       seaSurfaceSalinity,          &
       seaFreezingTemperature,      &
       freezingMeltingPotential,    &
+      frazilMassAdjust,            &
       uOceanVelocity,              &
       vOceanVelocity,              &
       seaSurfaceTiltU,             &
@@ -1905,6 +1906,7 @@ contains
       call mpas_pool_get_array(oceanCoupling, 'seaSurfaceSalinity', seaSurfaceSalinity)
       call mpas_pool_get_array(oceanCoupling, 'seaFreezingTemperature', seaFreezingTemperature)
       call mpas_pool_get_array(oceanCoupling, 'freezingMeltingPotential', freezingMeltingPotential)
+      call mpas_pool_get_array(oceanCoupling, 'frazilMassAdjust', frazilMassAdjust)
       call mpas_pool_get_array(oceanCoupling, 'uOceanVelocity', uOceanVelocity)
       call mpas_pool_get_array(oceanCoupling, 'vOceanVelocity', vOceanVelocity)
       call mpas_pool_get_array(oceanCoupling, 'seaSurfaceTiltU', seaSurfaceTiltU)
@@ -1970,13 +1972,25 @@ contains
 
         if (trim(config_ocean_surface_type) == "free") then ! free surface (MPAS-O)
         
-           meltingPotential            = x2i_i % rAttr(index_x2i_Fioo_q, n)
+           ! freezingMeltingPotential(i) is the ocean energy associated with frazil formation 
+           ! when it is positive and frazilMassFlux is positive, and negative  when there is 
+           ! a melting potential in which case frazilMassFlux is zero
 
-           ! frazil calculation
-           frazilProduction            = x2i_i % rAttr(index_x2i_Fioo_frazil, n)
-           call freezing_potential(freezingPotential, frazilProduction, seaSurfaceSalinity(i), &
+           freezingMeltingPotential(i) = x2i_i % rAttr(index_x2i_Fioo_q, n)
+
+           frazilMassFlux              = x2i_i % rAttr(index_x2i_Fioo_frazil, n)
+
+           ! We calculate a second energy associated with frazil production that is 
+           ! the sea ice model's version, which is passed to sea ice column physics as 
+           ! the frazilProduction, which is positive when frazil forms, otherwise zero.
+           ! frazilProduction is used to balance the mass budget according to what 
+           ! the sea ice model needs to complete the conversion of frazil to sea ice for
+           ! the given quantity of energy the ocean model has passed to the sea ice model.
+
+           call frazil_mass(freezingMeltingPotential(i), frazilMassFluxRev, seaSurfaceSalinity(i), &
                                    config_thermodynamics_type)
-           freezingMeltingPotential(i) = freezingPotential + min(meltingPotential,0.0_RKIND)
+
+           frazilMassAdjust(i) = frazilMassFlux-frazilMassFluxRev 
 
         else ! non-free surface (SOM)
 
@@ -2095,6 +2109,7 @@ contains
 !
 !-----------------------------------------------------------------------
       do i = 1, nCellsSolve
+
         seaSurfaceTemperature(i)  = seaSurfaceTemperature(i) - seaiceFreshWaterFreezingPoint
 
         if (config_use_column_biogeochemistry) then
@@ -2120,6 +2135,7 @@ contains
    call mpas_pool_get_field(oceanCoupling, 'seaSurfaceSalinity', seaSurfaceSalinityField)
    call mpas_pool_get_field(oceanCoupling, 'seaFreezingTemperature', seaFreezingTemperatureField)
    call mpas_pool_get_field(oceanCoupling, 'freezingMeltingPotential', freezingMeltingPotentialField)
+   call mpas_pool_get_field(oceanCoupling, 'frazilMassAdjust', frazilMassAdjustField)
    call mpas_pool_get_field(oceanCoupling, 'uOceanVelocity', uOceanVelocityField)
    call mpas_pool_get_field(oceanCoupling, 'vOceanVelocity', vOceanVelocityField)
    call mpas_pool_get_field(oceanCoupling, 'seaSurfaceTiltU', seaSurfaceTiltUField)
@@ -2172,6 +2188,7 @@ contains
    call mpas_dmpar_exch_halo_field(seaSurfaceSalinityField)
    call mpas_dmpar_exch_halo_field(seaFreezingTemperatureField)
    call mpas_dmpar_exch_halo_field(freezingMeltingPotentialField)
+   call mpas_dmpar_exch_halo_field(frazilMassAdjustField)
    call mpas_dmpar_exch_halo_field(uOceanVelocityField)
    call mpas_dmpar_exch_halo_field(vOceanVelocityField)
    call mpas_dmpar_exch_halo_field(seaSurfaceTiltUField)
@@ -2273,6 +2290,7 @@ contains
       velocitySolver,   &
       shortwave,        &
       atmosCoupling,    &
+      oceanCoupling,    &
       atmosFluxes,      &
       oceanFluxes,      &
       icebergFluxes,    &
@@ -2324,6 +2342,7 @@ contains
       oceanShortwaveFlux,          &
       oceanFreshWaterFlux,         &
       oceanSaltFlux,               &
+      frazilMassAdjust,            &
       bergFreshwaterFlux,          &
       bergLatentHeatFlux,          &
       oceanNitrateFlux,            &
@@ -2364,6 +2383,7 @@ contains
       call MPAS_pool_get_subpool(block_ptr % structs, "velocity_solver", velocitySolver)
       call MPAS_pool_get_subpool(block_ptr % structs, "shortwave", shortwave)
       call MPAS_pool_get_subpool(block_ptr % structs, 'atmos_coupling', atmosCoupling)
+      call MPAS_pool_get_subpool(block_ptr % structs, 'ocean_coupling', oceanCoupling)
       call MPAS_pool_get_subpool(block_ptr % structs, "atmos_fluxes", atmosFluxes)
       call MPAS_pool_get_subpool(block_ptr % structs, "ocean_fluxes", oceanFluxes)
 
@@ -2397,6 +2417,8 @@ contains
       call MPAS_pool_get_array(atmosCoupling, 'atmosReferenceSpeed10m', atmosReferenceSpeed10m)
       call MPAS_pool_get_array(atmosCoupling, 'atmosReferenceTemperature2m', atmosReferenceTemperature2m)
       call MPAS_pool_get_array(atmosCoupling, 'atmosReferenceHumidity2m', atmosReferenceHumidity2m)
+
+      call MPAS_pool_get_array(oceanCoupling, 'frazilMassAdjust', frazilMassAdjust)
 
       call MPAS_pool_get_array(atmosFluxes, 'latentHeatFlux', latentHeatFlux)
       call MPAS_pool_get_array(atmosFluxes, 'sensibleHeatFlux', sensibleHeatFlux)
@@ -2526,8 +2548,8 @@ contains
             !--- i/o fluxes computed by ice
             i2x_i % rAttr(index_i2x_Fioi_melth,n) = oceanHeatFlux(i)
             i2x_i % rAttr(index_i2x_Fioi_swpen,n) = oceanShortwaveFlux(i)
-            i2x_i % rAttr(index_i2x_Fioi_meltw,n) = oceanFreshWaterFlux(i)
-            i2x_i % rAttr(index_i2x_Fioi_salt ,n) = oceanSaltFlux(i)
+            i2x_i % rAttr(index_i2x_Fioi_meltw,n) = oceanFreshWaterFlux(i) + frazilMassAdjust(i)
+            i2x_i % rAttr(index_i2x_Fioi_salt ,n) = oceanSaltFlux(i) + ice_ref_salinity*p001*frazilMassAdjust(i)
             i2x_i % rAttr(index_i2x_Fioi_taux ,n) = tauxo
             i2x_i % rAttr(index_i2x_Fioi_tauy ,n) = tauyo
 
@@ -2696,10 +2718,10 @@ contains
 !***********************************************************************
 !BOP
 !
-! !IROUTINE: freezing_potential
+! !IROUTINE: frazil_mass
 !
-! !INTERFACE:
-   subroutine freezing_potential(freezingPotential, frazilProduction, seaSurfaceSalinity, &
+! !INTERFACE
+   subroutine frazil_mass(freezingPotential, frazilMassFlux, seaSurfaceSalinity, &
                                  config_thermodynamics_type)
 !
 ! !DESCRIPTION:
@@ -2715,12 +2737,12 @@ contains
          phi_init
 
 ! !INPUT PARAMETERS:
-      real (kind=RKIND),      intent(in)  :: frazilProduction
-      real (kind=RKIND),      intent(in)  :: seaSurfaceSalinity
-      character(len=strKIND), intent(in)  :: config_thermodynamics_type
+      real (kind=RKIND),      intent(in)   :: freezingPotential
+      real (kind=RKIND),      intent(in)   :: seaSurfaceSalinity
+      character(len=strKIND), intent(in)   :: config_thermodynamics_type
 
 ! !OUTPUT PARAMETERS:
-      real (kind=RKIND),      intent(out) :: freezingPotential
+      real (kind=RKIND),      intent(out)  :: frazilMassFlux
 
 !EOP
 !BOC
@@ -2736,7 +2758,7 @@ contains
       vi0new
 
 
-   if (frazilProduction > 0.0_RKIND) then
+   if (freezingPotential > 0.0_RKIND) then
 
       if (trim(config_thermodynamics_type) == "mushy") then  ! mushy
          if (seaSurfaceSalinity > 2.0_RKIND * dSin0_frazil) then
@@ -2744,25 +2766,27 @@ contains
          else
              Si0new = seaSurfaceSalinity**2 / (4.0_RKIND*dSin0_frazil)
          endif
-         Ti = min(liquidus_temperature_mush(Si0new/phi_init), -0.1_RKIND)
+         Ti = liquidus_temperature_mush(Si0new/phi_init)
          qi0new = enthalpy_mush(Ti, Si0new)
       else
          qi0new = -seaiceDensityIce*seaiceLatentHeatMelting
       endif    ! ktherm
 
-      vi0new = max (frazilProduction, 0.0_RKIND) / seaiceDensityIce
-      freezingPotential = -vi0new*qi0new ! note sign convention, qi < 0
+      !vi0new = max (frazilMassFlux, 0.0_RKIND) / seaiceDensityIce
+      !freezingPotential = -vi0new*qi0new ! note sign convention, qi < 0
+
+      frazilMassFlux = -freezingPotential*seaiceDensityIce/qi0new
 
    else
 
-      freezingPotential = 0.0_RKIND
+      frazilMassFlux = 0.0_RKIND
 
    endif
 
 !-----------------------------------------------------------------------
 !EOC
 
-   end subroutine freezing_potential!}}}
+   end subroutine frazil_mass!}}}
 
 !***********************************************************************
 !BOP

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -3660,6 +3660,7 @@
 		<var name="seaSurfaceSalinity"			type="real"	dimensions="nCells Time"		name_in_code="seaSurfaceSalinity"		default_value="34.0"/>
 		<var name="seaFreezingTemperature"		type="real"	dimensions="nCells Time"		name_in_code="seaFreezingTemperature"/>
 		<var name="freezingMeltingPotential"		type="real"	dimensions="nCells Time"		name_in_code="freezingMeltingPotential"/>
+		<var name="frazilMassAdjust"		        type="real"	dimensions="nCells Time"		name_in_code="frazilMassAdjust"/>
 		<var name="uOceanVelocity"			type="real"	dimensions="nCells Time"		name_in_code="uOceanVelocity"/>
 		<var name="vOceanVelocity"			type="real"	dimensions="nCells Time"		name_in_code="vOceanVelocity"/>
 		<var name="seaSurfaceTiltU"			type="real"	dimensions="nCells Time"		name_in_code="seaSurfaceTiltU"/>

--- a/components/mpas-seaice/src/column/ice_therm_itd.F90
+++ b/components/mpas-seaice/src/column/ice_therm_itd.F90
@@ -1237,7 +1237,7 @@
          do k = 1, nilyr
             Sprofile(k) = Si0new
          enddo
-         Ti = min(liquidus_temperature_mush(Si0new/phi_init), -p1)
+         Ti = liquidus_temperature_mush(Si0new/phi_init)
          qi0new = enthalpy_mush(Ti, Si0new)
       else
          do k = 1, nilyr


### PR DESCRIPTION
This PR ensures the conservation of heat and mass in frazil coupling between MPAS-Ocean and MPAS-SeaIce. The code changes has been tested on Chrysalis in an E3SM B-case simulation, and full documentation of the test out to year 40 is provided at: https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/2781544502/20210518.v2rc1a.Frazil3.ne30pg2+EC30to60E2r2.chrysalis
A comparison is also provided in a companion test that still includes the limit on frazil liquidus temperature of -0.1˚C: https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/2773353093/20210516.v2rc1a.Frazil2.ne30pg2+EC30to60E2r2.chrysalis
Relatively accurate conservation is achieved with this PR in the coupled model, indicated at the former link, and there is significantly less heat uptake in the ocean relative to previous E3SM simulations in both test simulations.  The sea ice climate is generally thicker, as indicated in the above links, too.  The -0.1˚C limit was applied to CICE in 2013 as part of efforts to stabilize POP in low salinity environments, but the main change there was included in the associated code, and no justification for an additional  -0.1˚C limit could be found in the documentation.  Removal of the 0.1˚C limit significantly influences year-to-year variations in AMOC for the years provided in the above simualtions.

[non-BFB]