### PR TITLE
Add CASE_HASH env setting to driver-mct config

### DIFF
--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -178,6 +178,13 @@
     </desc>
   </entry>
 
+  <entry id="CASE_HASH">
+    <type>char</type>
+    <group>case_desc</group>
+    <file>env_case.xml</file>
+    <desc>Unique identifier for case</desc>
+  </entry>
+
   <!-- ===================================================================== -->
   <!-- definitions runtimes -->
   <!-- ===================================================================== -->


### PR DESCRIPTION
Newer versions of CIME will require it.

[BFB]