### PR TITLE
Move USE_CBOOL macro from testmods to IBM compiler EAM CPPDEFS

### DIFF
--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -260,6 +260,7 @@ flags should be captured within MPAS CMake files.
   -qinitauto=...  => initializes automatic variables
   -->
     <append> -DFORTRAN_SAME -DCPRIBM</append>
+    <append COMP_NAME="eam"> -DUSE_CBOOL </append>
   </CPPDEFS>
   <CPRE>-WF,-D</CPRE>
   <FC_AUTO_R8>
@@ -1743,6 +1744,7 @@ flags should be captured within MPAS CMake files.
   </CFLAGS>
   <CPPDEFS>
     <append> -DFORTRAN_SAME -DCPRIBM</append>
+    <append COMP_NAME="eam"> -DUSE_CBOOL </append>
     <append> -DLINUX  </append>
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
@@ -1973,6 +1975,7 @@ flags should be captured within MPAS CMake files.
   </CFLAGS>
   <CPPDEFS>
     <append> -DFORTRAN_SAME -DCPRIBM</append>
+    <append COMP_NAME="eam"> -DUSE_CBOOL </append>
     <append> -DLINUX  </append>
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -161,9 +161,9 @@ _TESTS = {
             "SMS_Ld2.ne30_oECv3.BGCEXP_BCRC_CNPRDCTC_1850.elm-bgcexp",
             "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
             "SMS_D_Ld1.ne30_r05_oECv3.A_WCYCL1850",
-            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMFXX.eam-cbool",
-            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMFOMP.eam-cbool",
-            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-RCEMIP.eam-cbool",
+            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMFXX",
+            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMFOMP",
+            "ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMF1-RCEMIP",
             )
         },
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/cbool/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/cbool/shell_commands
@@ -1,3 +1,0 @@
-if [ `./xmlquery --value COMPILER` == ibm ]; then
-  ./xmlchange --force --append CAM_CONFIG_OPTS='-cppdefs -DUSE_CBOOL'
-fi

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/crmout/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/crmout/shell_commands
@@ -1,4 +1,1 @@
 ./xmlchange NTHRDS=1
-if [ `./xmlquery --value COMPILER` == ibm ]; then
-  ./xmlchange --append CAM_CONFIG_OPTS='-cppdefs -DUSE_CBOOL'
-fi

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/rrtmgp/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/rrtmgp/shell_commands
@@ -1,5 +1,2 @@
 #!/bin/bash
 ./xmlchange --append CAM_CONFIG_OPTS='-rad rrtmgp'
-if [ `./xmlquery --value COMPILER` == ibm ]; then
-  ./xmlchange --append CAM_CONFIG_OPTS='-cppdefs -DUSE_CBOOL'
-fi

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -889,7 +889,7 @@ contains
 
          call mpas_log_write(&
             'Invalid choice for config_cvmix_background_scheme.  Choices are: none, &
-             constant, BryanLewis')
+             &constant, BryanLewis')
 
          err = 1
 


### PR DESCRIPTION
The macro is needed by RRTMGP in IBM builds.
Also, fix string line continuation in OCN for IBM compiler.

[BFB]