### PR TITLE
Move MPAS standalone make from mpas-framework to mpas-CORE directories

### DIFF
--- a/components/mpas-albany-landice/Makefile
+++ b/components/mpas-albany-landice/Makefile
@@ -1,0 +1,1 @@
+../mpas-framework/Makefile

--- a/components/mpas-albany-landice/src/build_options.mk
+++ b/components/mpas-albany-landice/src/build_options.mk
@@ -3,7 +3,7 @@ ifeq "$(ROOT_DIR)" ""
 endif
 EXE_NAME=landice_model
 NAMELIST_SUFFIX=landice
-FCINCLUDES += -I$(ROOT_DIR)/core_landice/mode_forward -I$(ROOT_DIR)/core_landice/shared -I$(ROOT_DIR)/core_landice/analysis_members
+FCINCLUDES += -I$(ROOT_DIR)/mode_forward -I$(ROOT_DIR)/shared -I$(ROOT_DIR)/analysis_members
 override CPPFLAGS += -DCORE_LANDICE
 
 # ===================================

--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -1,5 +1,19 @@
 MODEL_FORMULATION =
 
+#
+# Autodetect CORE from path
+#
+override CORE =
+ifneq ($(findstring components/mpas-ocean,$(PWD)),)
+	override CORE = ocean
+endif
+ifneq ($(findstring components/mpas-seaice,$(PWD)),)
+	override CORE = seaice
+endif
+ifneq ($(findstring components/mpas-albany-landice,$(PWD)),)
+	override CORE = landice
+endif
+
 ifneq "${MPAS_SHELL}" ""
         SHELL = ${MPAS_SHELL}
 endif
@@ -671,12 +685,15 @@ RM = rm -f
 CPP = cpp -P -traditional
 RANLIB = ranlib
 
+COREPATH=$(PWD)/src
+FWPATH=$(PWD)/../mpas-framework/src
+
 ifdef CORE
 
-ifneq ($(wildcard src/core_$(CORE)), ) # CHECK FOR EXISTENCE OF CORE DIRECTORY
+ifneq ($(wildcard src), ) # CHECK FOR EXISTENCE OF CORE DIRECTORY
 
-ifneq ($(wildcard src/core_$(CORE)/build_options.mk), ) # Check for build_options.mk
-include src/core_$(CORE)/build_options.mk
+ifneq ($(wildcard src/build_options.mk), ) # Check for build_options.mk
+include src/build_options.mk
 else # ELSE Use Default Options
 EXE_NAME=$(CORE)_model
 NAMELIST_SUFFIX=$(CORE)
@@ -913,25 +930,11 @@ ifdef MPAS_EXTERNAL_CPPFLAGS
 endif
 ####################################################
 
-ifeq ($(wildcard src/core_$(CORE)), ) # CHECK FOR EXISTENCE OF CORE DIRECTORY
-
-all: core_error
-
-else
-
-ifeq ($(wildcard src/core_$(CORE)/build_options.mk), ) # Check for build_options.mk
-report_builds:
-	@echo "CORE=$(CORE)"
-endif
-
 ifeq "$(CONTINUE)" "true"
 all: mpas_main
 else
 all: clean_core
 endif
-
-endif
-
 
 openmp_test:
 ifeq "$(OPENMP)" "true"
@@ -990,11 +993,13 @@ endif
 	@rm -rf pio[12].f90 pio[12].out
 
 
-mpas_main: openmp_test pio_test
-ifeq "$(AUTOCLEAN)" "true"
-	$(RM) .mpas_core_*
-endif
-	cd src; $(MAKE) FC="$(FC)" \
+dycore: $(AUTOCLEAN_DEPS) framework
+	@echo "Auto-detected core from path: " $(CORE)
+	@echo "START DYCORE: $(PWD)"
+	( cd src; $(MAKE) CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" REG_PARSE="$(FWPATH)/tools/registry/parse" gen_includes )
+	( cd src; $(MAKE) CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" NL_GEN="$(FWPATH)/tools/input_gen/namelist_gen" ST_GEN="$(FWPATH)/tools/input_gen/streams_gen" core_input_gen )
+	( cd src; $(MAKE) \
+	         FC="$(FC)" \
                  CC="$(CC)" \
                  CXX="$(CXX)" \
                  SFC="$(SFC)" \
@@ -1012,13 +1017,65 @@ endif
                  FCINCLUDES="$(FCINCLUDES)" \
                  CORE="$(CORE)"\
                  AUTOCLEAN="$(AUTOCLEAN)" \
-                 GEN_F90="$(GEN_F90)" \
-                 NAMELIST_SUFFIX="$(NAMELIST_SUFFIX)" \
-                 EXE_NAME="$(EXE_NAME)"
+                 GEN_F90="$(GEN_F90)" )
+
+
+drver:  $(AUTOCLEAN_DEPS) framework dycore
+	( cd $(FWPATH)/driver; $(MAKE) COREPATH="$(COREPATH)" \
+                 FC="$(FC)" \
+                 CC="$(CC)" \
+                 CXX="$(CXX)" \
+                 SFC="$(SFC)" \
+                 SCC="$(SCC)" \
+                 LINKER="$(LINKER)" \
+                 CFLAGS="$(CFLAGS)" \
+                 CXXFLAGS="$(CXXFLAGS)" \
+                 FFLAGS="$(FFLAGS)" \
+                 LDFLAGS="$(LDFLAGS)" \
+                 RM="$(RM)" \
+                 CPP="$(CPP)" \
+                 CPPFLAGS="$(CPPFLAGS)" \
+                 LIBS="$(LIBS)" \
+                 CPPINCLUDES="$(CPPINCLUDES)" \
+                 FCINCLUDES="$(FCINCLUDES)" \
+                 CORE="$(CORE)"\
+                 AUTOCLEAN="$(AUTOCLEAN)" \
+                 GEN_F90="$(GEN_F90)" )
+
+
+mpas: $(AUTOCLEAN_DEPS) framework dycore drver
+	$(LINKER) $(LDFLAGS) -o $(EXE_NAME) $(FWPATH)/driver/*.o -L$(FWPATH) -Lsrc -ldycore -lops -lframework $(LIBS) -I./external/esmf_time_f90 -L$(FWPATH)/external/esmf_time_f90 -lesmf_time
+
+framework:
+	cd $(FWPATH); $(MAKE) \
+                 FC="$(FC)" \
+                 CC="$(CC)" \
+                 CXX="$(CXX)" \
+                 SFC="$(SFC)" \
+                 SCC="$(SCC)" \
+                 LINKER="$(LINKER)" \
+                 CFLAGS="$(CFLAGS)" \
+                 CXXFLAGS="$(CXXFLAGS)" \
+                 FFLAGS="$(FFLAGS)" \
+                 LDFLAGS="$(LDFLAGS)" \
+                 RM="$(RM)" \
+                 CPP="$(CPP)" \
+                 CPPFLAGS="$(CPPFLAGS)" \
+                 LIBS="$(LIBS)" \
+                 CPPINCLUDES="$(CPPINCLUDES)" \
+                 FCINCLUDES="$(FCINCLUDES)" \
+                 CORE="$(CORE)"\
+                 AUTOCLEAN="$(AUTOCLEAN)" \
+                 GEN_F90="$(GEN_F90)"
+
+mpas_main: openmp_test pio_test mpas
+ifeq "$(AUTOCLEAN)" "true"
+	$(RM) .mpas_core_*
+endif
 
 	@echo "$(EXE_NAME)" > .mpas_core_$(CORE)
 	if [ -e src/$(EXE_NAME) ]; then mv src/$(EXE_NAME) .; fi
-	( cd src/core_$(CORE); $(MAKE) ROOT_DIR="$(PWD)" post_build )
+	( cd src; $(MAKE) ROOT_DIR="$(PWD)" post_build )
 	@echo "*******************************************************************************"
 	@echo $(PRECISION_MESSAGE)
 	@echo $(DEBUG_MESSAGE)
@@ -1037,19 +1094,13 @@ endif
 	@echo $(PIO_MESSAGE)
 	@echo "*******************************************************************************"
 clean:
+	cd $(FWPATH); $(MAKE) clean RM="$(RM)" CORE="$(CORE)"
 	cd src; $(MAKE) clean RM="$(RM)" CORE="$(CORE)"
 	$(RM) .mpas_core_*
 	$(RM) $(EXE_NAME)
 	$(RM) namelist.$(NAMELIST_SUFFIX).defaults
 	$(RM) streams.$(NAMELIST_SUFFIX).defaults
-core_error:
-	@echo ""
-	@echo "*******************************************************************************"
-	@echo "     The directory src/core_$(CORE) does not exist."
-	@echo "     $(CORE) is not a valid core choice."
-	@echo "*******************************************************************************"
-	@echo ""
-	exit 1
+
 error: errmsg
 
 clean_core:
@@ -1075,29 +1126,27 @@ clean_core:
 else # CORE IF
 
 all: error
-clean: errmsg
+clean: error
 	exit 1
-error: errmsg
-	@echo "************ ERROR ************"
-	@echo "No CORE specified. Quitting."
-	@echo "************ ERROR ************"
-	@echo ""
+error:
+	@echo "ERROR: You must execute make within one of the mpas-ocean, mpas-seaice, or mpas-albany-landice directories."
+	@echo "Quitting."
 	exit 1
 
 endif # CORE IF
 
 errmsg:
 	@echo ""
-	@echo "Usage: $(MAKE) target CORE=[core] [options]"
+	@echo "Usage: $(MAKE) target [options]"
+	@echo ""
+	@echo "You must execute make within one of the mpas-ocean, mpas-seaice, or mpas-albany-landice directories."
+	@echo "CORE is auto-detected from mpas-CORE directory in your path."
 	@echo ""
 	@echo "Example targets:"
 	@echo "    ifort"
 	@echo "    gfortran"
 	@echo "    xlf"
 	@echo "    pgi"
-	@echo ""
-	@echo "Availabe Cores:"
-	@cd src; ls -d core_* | grep ".*" | sed "s/core_/    /g"
 	@echo ""
 	@echo "Available Options:"
 	@echo "    DEBUG=true    - builds debug version. Default is optimized version."

--- a/components/mpas-framework/src/Makefile
+++ b/components/mpas-framework/src/Makefile
@@ -12,16 +12,11 @@ else
 AUTOCLEAN_DEPS=
 endif
 
-all: mpas
-
-mpas: $(AUTOCLEAN_DEPS) externals frame ops dycore drver
-	$(LINKER) $(LDFLAGS) -o $(EXE_NAME) driver/*.o -L. -ldycore -lops -lframework $(LIBS) -I./external/esmf_time_f90 -L./external/esmf_time_f90 -lesmf_time
+all: build_tools externals frame ops
 
 externals: $(AUTOCLEAN_DEPS)
 	( cd external; $(MAKE) FC="$(FC)" SFC="$(SFC)" CC="$(CC)" SCC="$(SCC)" FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" CPP="$(CPP)" NETCDF="$(NETCDF)" CORE="$(CORE)" all )
 
-drver:  $(AUTOCLEAN_DEPS) externals frame ops dycore
-	( cd driver; $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 
 endif
 
 build_tools: externals
@@ -35,19 +30,7 @@ ops: $(AUTOCLEAN_DEPS) externals frame
 	( cd operators; $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 
 	ln -sf operators/libops.a libops.a
 
-dycore: $(AUTOCLEAN_DEPS) build_tools externals frame ops
-	( cd core_$(CORE); $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" REG_PARSE="$(PWD)/tools/registry/parse" gen_includes )
-	( cd core_$(CORE); $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" NL_GEN="$(PWD)/tools/input_gen/namelist_gen" ST_GEN="$(PWD)/tools/input_gen/streams_gen" core_input_gen )
-	( cd core_$(CORE); $(MAKE) CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)" all ) 
-	ln -sf core_$(CORE)/libdycore.a libdycore.a
-
-
-clean: clean_shared clean_core
-
-clean_core:
-	if [ -d core_$(CORE) ] ; then \
-	   ( cd core_$(CORE); $(MAKE) clean ) \
-	fi;
+clean: clean_shared
 
 clean_shared:
 ifeq "$(AUTOCLEAN)" "true"

--- a/components/mpas-framework/src/driver/Makefile
+++ b/components/mpas-framework/src/driver/Makefile
@@ -23,7 +23,7 @@ clean:
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../operators -I../core_$(CORE) -I../external/esmf_time_f90
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../operators -I../external/esmf_time_f90
 else
-	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../operators -I../core_$(CORE) -I../external/esmf_time_f90
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../operators -I../external/esmf_time_f90
 endif

--- a/components/mpas-ocean/Makefile
+++ b/components/mpas-ocean/Makefile
@@ -1,0 +1,1 @@
+../mpas-framework/Makefile

--- a/components/mpas-ocean/src/Makefile
+++ b/components/mpas-ocean/src/Makefile
@@ -35,15 +35,15 @@ core_reg:
 
 core_input_gen:
 	if [ ! -e default_inputs ]; then  mkdir default_inputs; fi
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean )
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.forward mode=forward )
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.analysis mode=analysis )
-	(cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.ocean stream_list.ocean. mutable )
-	(cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.ocean.forward stream_list.ocean.forward. mutable mode=forward )
-	(cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.ocean.analysis stream_list.ocean.analysis. mutable mode=analysis )
+	(cd default_inputs; $(NL_GEN) ../../../mpas-ocean/src/Registry_processed.xml namelist.ocean )
+	(cd default_inputs; $(NL_GEN) ../../../mpas-ocean/src/Registry_processed.xml namelist.ocean.forward mode=forward )
+	(cd default_inputs; $(NL_GEN) ../../../mpas-ocean/src/Registry_processed.xml namelist.ocean.analysis mode=analysis )
+	(cd default_inputs; $(ST_GEN) ../../../mpas-ocean/src/Registry_processed.xml streams.ocean stream_list.ocean. mutable )
+	(cd default_inputs; $(ST_GEN) ../../../mpas-ocean/src/Registry_processed.xml streams.ocean.forward stream_list.ocean.forward. mutable mode=forward )
+	(cd default_inputs; $(ST_GEN) ../../../mpas-ocean/src/Registry_processed.xml streams.ocean.analysis stream_list.ocean.analysis. mutable mode=analysis )
 ifneq "$(EXCLUDE_INIT_MODE)" "true"
-	(cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.ocean.init mode=init )
-	(cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.ocean.init stream_list.ocean.init. mutable mode=init )
+	(cd default_inputs; $(NL_GEN) ../../../mpas-ocean/src/Registry_processed.xml namelist.ocean.init mode=init )
+	(cd default_inputs; $(ST_GEN) ../../../mpas-ocean/src/Registry_processed.xml streams.ocean.init stream_list.ocean.init. mutable mode=init )
 endif
 
 gen_includes:
@@ -87,7 +87,7 @@ libgotm:
 			(sed -i.bk "s/\#define STDERR write(stderr,\*)/\#define STDERR if (.false.) write(stderr,\*)/" gotm/include/cppdefs.h; mkdir gotm/build; cd gotm/build; cmake ../src $(GOTM_CMAKE_FLAGS); make) \
 		fi \
 	else \
-		(pwd ; echo "Missing core_ocean/gotm/.git, did you forget to 'git submodule update --init --recursive' ?"; exit 1) \
+		(pwd ; echo "Missing mpas-ocean/src/gotm/.git, did you forget to 'git submodule update --init --recursive' ?"; exit 1) \
 	fi
 
 shared: libcvmix libBGC libgotm

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_TEMPLATE.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_TEMPLATE.F
@@ -37,7 +37,7 @@
 !>      - Adding a restart if test can subroutine call
 !>      - Adding a finalize if test can subroutine call
 !>
-!>  5. In src/core_ocean/analysis_members/Makefile, add your
+!>  5. In src/analysis_members/Makefile, add your
 !>     new analysis member to the list of members. See another analysis member
 !>     in that file for an example.
 !>     NOTE: If your analysis member depends on other files, add a dependency

--- a/components/mpas-ocean/src/build_options.mk
+++ b/components/mpas-ocean/src/build_options.mk
@@ -3,12 +3,12 @@ ifeq "$(ROOT_DIR)" ""
 endif
 EXE_NAME=ocean_model
 NAMELIST_SUFFIX=ocean
-FCINCLUDES += -I$(ROOT_DIR)/core_ocean/driver
-FCINCLUDES += -I$(ROOT_DIR)/core_ocean/mode_forward -I$(ROOT_DIR)/core_ocean/mode_analysis -I$(ROOT_DIR)/core_ocean/mode_init
-FCINCLUDES += -I$(ROOT_DIR)/core_ocean/shared -I$(ROOT_DIR)/core_ocean/analysis_members
-FCINCLUDES += -I$(ROOT_DIR)/core_ocean/cvmix/src/shared
-FCINCLUDES += -I$(ROOT_DIR)/core_ocean/BGC
-FCINCLUDES += -I$(ROOT_DIR)/core_ocean/gotm/build/modules
+FCINCLUDES += -I$(ROOT_DIR)/driver
+FCINCLUDES += -I$(ROOT_DIR)/mode_forward -I$(ROOT_DIR)/mode_analysis -I$(ROOT_DIR)/mode_init
+FCINCLUDES += -I$(ROOT_DIR)/shared -I$(ROOT_DIR)/analysis_members
+FCINCLUDES += -I$(ROOT_DIR)/cvmix/src/shared
+FCINCLUDES += -I$(ROOT_DIR)/BGC
+FCINCLUDES += -I$(ROOT_DIR)/gotm/include
 override CPPFLAGS += -DCORE_OCEAN
 
 report_builds:

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_TEMPLATE.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_TEMPLATE.F
@@ -17,7 +17,7 @@
 !>  TEMPLATE initial condition
 !>
 !>  In order to add a new initial condition, do the following:
-!>  1. In src/core_ocean/mode_init, copy these to your new initial condition name:
+!>  1. In src/mode_init, copy these to your new initial condition name:
 !>     cp mpas_ocn_init_TEMPLATE.F mpas_ocn_init_your_new_name.F
 !>     cp Registry_TEMPLATE.xml Registry_ocn_your_new_name.xml
 !>
@@ -26,12 +26,12 @@
 !>     TEMPLATE uses underscores (subroutine names), like your_new_name.
 !>
 !>  3. Add a #include line for your registry to
-!>     src/core_ocean/mode_init/Registry.xml
+!>     src/mode_init/Registry.xml
 !>
-!>  4. Copy and change TEMPLATE lines in src/core_ocean/mode_init/mpas_ocn_init_mode.F
+!>  4. Copy and change TEMPLATE lines in src/mode_init/mpas_ocn_init_mode.F
 !>
 !>  5. Add these dependency lines by following TEMPLATE examples in:
-!>     in src/core_ocean/mode_init/Makefile
+!>     in src/mode_init/Makefile
 !
 !-----------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tidal_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tidal_forcing.F
@@ -271,7 +271,7 @@ contains
           end do
           ! else if
           ! using the 'direct' option to immediately force the free surface as a prescribe boundary
-          ! in src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+          ! in mpas_ocn_time_integration_rk4.F
         end if
 
         ! store tidal boundary cell values (e.g., for config_tidal_forcing_type == 'direct')

--- a/components/mpas-seaice/Makefile
+++ b/components/mpas-seaice/Makefile
@@ -1,0 +1,1 @@
+../mpas-framework/Makefile

--- a/components/mpas-seaice/src/build_options.mk
+++ b/components/mpas-seaice/src/build_options.mk
@@ -3,7 +3,7 @@ ifeq "$(ROOT_DIR)" ""
 endif
 EXE_NAME=seaice_model
 NAMELIST_SUFFIX=seaice
-FCINCLUDES += -I$(ROOT_DIR)/core_seaice/column -I$(ROOT_DIR)/core_seaice/shared -I$(ROOT_DIR)/core_seaice/analysis_members -I$(ROOT_DIR)/core_seaice/model_forward
+FCINCLUDES += -I$(ROOT_DIR)/column -I$(ROOT_DIR)/shared -I$(ROOT_DIR)/analysis_members -I$(ROOT_DIR)/model_forward
 override CPPFLAGS += -DCORE_SEAICE
 ifneq "$(ESM)" ""
 override CPPFLAGS += -Dcoupled -DCCSMCOUPLED


### PR DESCRIPTION
Change make process for stand-alone MPAS components from:
```
cd components/mpas-framework
make clean CORE=ocean 
make gfortran CORE=ocean
````
to (for the ocean core)
```
cd components/mpas-ocean
make clean 
make gfortran 
```
where other cores are similar.

This does not touch any E3SM cmake files.

[BFB]