### PR TITLE
Add 1e-15 to fEdge to avoid divide by zero at equator

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -636,7 +636,7 @@ contains
            do iEdge=1,nEdges
               cell1 = cellsOnEdge(1, iEdge)
               cell2 = cellsOnEdge(2, iEdge)
-              Lr = min(cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)),          &
+              Lr = min(cGMphaseSpeed(iEdge) / (1.0E-15_RKIND + abs(fEdge(iEdge))), &
                        sqrt(cGMphaseSpeed(iEdge) / (2.0_RKIND*betaEdge(iEdge))))
 
               do k=minLevelEdgeBot(iEdge)+1,maxLevelEdgeTop(iEdge)


### PR DESCRIPTION
This fixes a divide by zero error in the ocean parameterizations, but it only occurs on an edge if latEdge is very close to zero, so it is dependent on the mesh. This bug makes QU240 stand-alone nightly tests fail, but only with debug on. With this fix it passes.

Fixes #4308
[non-BFB]