### PR TITLE
Update OpenMPI modules for Chrysalis on maint-1.0

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -996,7 +996,7 @@
     <NODENAME_REGEX>chr.*</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>impi,openmpi</MPILIBS>
+    <MPILIBS>openmpi,impi</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/lcrc/group/e3sm/PERF_Chrysalis</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
@@ -1010,16 +1010,16 @@
     <TESTS>e3sm_integration</TESTS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>E3SM</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
         <arg name="num_tasks">--mpi=pmi2 -l -n {{ total_tasks }} -N {{ num_nodes }} --kill-on-bad-exit </arg>
-        <arg name="binding">--cpu_bind=cores</arg>
-        <arg name="thread_count">-c $ENV{OMP_NUM_THREADS}</arg>
-        <arg name="placement">-m plane=$MAX_MPITASKS_PER_NODE</arg>
+        <arg name="binding"> $SHELL{if [ 64 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
+        <arg name="thread_count">-c $SHELL{echo 128/ {{ tasks_per_node }} |bc}</arg>
+        <arg name="placement">-m plane=$SHELL{echo "{{ tasks_per_node }}/1"|bc}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1039,12 +1039,12 @@
         <command name="load">intel-mkl/2020.4.304-g2qaxzf</command>
       </modules>
       <modules compiler="intel" mpilib="openmpi">
-        <command name="load">openmpi/4.0.4-hpcx-cy5n3ft</command>
-        <command name="load">hdf5/1.8.16-m3bsibs</command>
-        <command name="load">netcdf-c/4.4.1-7ejgpdm</command>
-        <command name="load">netcdf-cxx/4.2-sag6n3x</command>
-        <command name="load">netcdf-fortran/4.4.4-sjzkwoc</command>
-        <command name="load">parallel-netcdf/1.11.0-l362p2g</command>
+        <command name="load">openmpi/4.1.1-qiqkjbu</command>
+        <command name="load">hdf5/1.8.16-35xugty</command>
+        <command name="load">netcdf-c/4.4.1-2vngykq</command>
+        <command name="load">netcdf-cxx/4.2-gzago6i</command>
+        <command name="load">netcdf-fortran/4.4.4-2kddbib</command>
+        <command name="load">parallel-netcdf/1.11.0-go65een</command>
       </modules>
       <modules compiler="intel" mpilib="impi">
         <command name="load">intel-mpi/2019.9.304-tkzvizk</command>
@@ -1059,12 +1059,12 @@
         <command name="load">intel-mkl/2020.4.304-n3b5fye</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-        <command name="load">openmpi/4.0.4-hpcx-hghvhj5</command>
-        <command name="load">hdf5/1.10.7-sbsigon</command>
-        <command name="load">netcdf-c/4.7.4-a4uk6zy</command>
-        <command name="load">netcdf-cxx/4.2-fz347dw</command>
-        <command name="load">netcdf-fortran/4.5.3-i5ah7u2</command>
-        <command name="load">parallel-netcdf/1.12.1-e7w4x32</command>
+        <command name="load">openmpi/4.1.1-73gbwq4</command>
+        <command name="load">hdf5/1.8.16-dqjdy2d</command>
+        <command name="load">netcdf-c/4.4.1-y6dun2a</command>
+        <command name="load">netcdf-cxx/4.2-vwlvgn6</command>
+        <command name="load">netcdf-fortran/4.4.4-4lnfxki</command>
+        <command name="load">parallel-netcdf/1.11.0-3x2favk</command>
       </modules>
       <modules compiler="gnu" mpilib="impi">
         <command name="load">intel-mpi/2019.9.304-jdih7h5</command>
@@ -1088,9 +1088,11 @@
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="intel">
-      <env name="KMP_AFFINITY">granularity=core,scatter</env>
-      <env name="KMP_HOT_TEAMS_MODE">1</env>
+    <environment_variables SMP_PRESENT="TRUE" compiler="intel" MAX_TASKS_PER_NODE="!128">
+      <env name="KMP_AFFINITY">granularity=core,balanced</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="intel" MAX_TASKS_PER_NODE="128">
+      <env name="KMP_AFFINITY">granularity=thread,balanced</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>


### PR DESCRIPTION
Update OpenMPI modules for Chrysalis on maint-1.0 and also
* make OpenMPI the default MPI library
* make SMT the default when multi-threading: MAX_TASKS_PER_NODE=128
* adjust MPI task affinity with SMT: --cpu_bind=threads when MAX_MPITASKS_PER_NODE =128
* calculate Slurm's -c/--cpus-per-task depending on tasks_per_node
* adjust Slurm's -m plane option for tasks_per_node
* set granularity of OMP threading depending on MAX_TASKS_PER_NODE

[non-BFB] for some ocean diagnostics and only on Chrysalis.