### PR TITLE
Fix diagnostic outputs for ozone columns

### DIFF
--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1455,7 +1455,7 @@ end function chem_is_active
     call t_startf( 'chemdr' )
     call gas_phase_chemdr(lchnk, ncol, imozart, state%q, &
                           state%phis, state%zm, state%zi, calday, &
-                          state%t, state%pmid, state%pdel, state%pint, &
+                          state%t, state%pmid, state%pdel, state%pdeldry, state%pint, &
                           cldw, tropLev, ncldwtr, state%u, state%v, &
                           chem_dt, state%ps, xactive_prates, &
                           fsds, cam_in%ts, cam_in%asdir, cam_in%ocnfrac, cam_in%icefrac, &

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -398,6 +398,7 @@ contains
     real(r8), dimension(ncol)      :: df_noy, df_sox, df_nhx
 
     real(r8) :: area(ncol), mass(ncol,pver), drymass(ncol,pver)
+    real(r8) :: wrk1d(ncol)
     real(r8) :: wgt
     character(len=16) :: spc_name
     real(r8), pointer :: fldcw(:,:)  !working pointer to extract data from pbuf for sum of mass for aerosol classes
@@ -465,35 +466,35 @@ contains
     ! convert ozone from mol/mol (w.r.t. dry air mass) to DU
     wrk(:ncol,:) = pdeldry(:ncol,:)*vmr(:ncol,:,id_o3)*avogadro*rgrav/mwdry/DUfac*1.e3_r8
     ! total column ozone
-    do k = 2,pver
-       wrk(:ncol,1) = wrk(:ncol,1) + wrk(:ncol,k)
+    wrk1d(:) = 0._r8
+    do k = 1,pver ! loop from top of atmosphere to surface
+       wrk1d(:) = wrk1d(:) + wrk(:ncol,k)
     end do
-    call outfld( 'TOZ', wrk,   ncol, lchnk )
+    call outfld( 'TOZ', wrk1d,   ncol, lchnk )
 
     ! stratospheric column ozone
-    wrk(:ncol,:) = pdeldry(:ncol,:)*vmr(:ncol,:,id_o3)*avogadro*rgrav/mwdry/DUfac*1.e3_r8
+    wrk1d(:) = 0._r8
     do i = 1,ncol
-       do k = 2,pver
+       do k = 1,pver
           if (k > ltrop(i)) then
             exit
           end if
-          wrk(i,1) = wrk(i,1) + wrk(i,k)
+          wrk1d(i) = wrk1d(i) + wrk(i,k)
        end do
     end do
-    call outfld( 'SCO', wrk,   ncol, lchnk )
+    call outfld( 'SCO', wrk1d,   ncol, lchnk )
 
     ! tropospheric column ozone
-    wrk(:ncol,:) = pdeldry(:ncol,:)*vmr(:ncol,:,id_o3)*avogadro*rgrav/mwdry/DUfac*1.e3_r8
+    wrk1d(:) = 0._r8
     do i = 1,ncol
-       wrk(i,1) = 0._r8
-       do k = 2,pver
+       do k = 1,pver
           if (k <= ltrop(i)) then
             cycle
           end if
-          wrk(i,1) = wrk(i,1) + wrk(i,k)
+          wrk1d(i) = wrk1d(i) + wrk(i,k)
        end do
     end do
-    call outfld( 'TCO', wrk,   ncol, lchnk )
+    call outfld( 'TCO', wrk1d,   ncol, lchnk )
 
     do m = 1,gas_pcnst
 

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -46,7 +46,6 @@ module mo_chm_diags
   real(r8), parameter :: S_molwgt = 32.066_r8
 
   ! constants for converting O3 mixing ratio to DU
-  real(r8), parameter :: air_molwgt = 28.97_r8 ! molar mass of dry air, g/mol
   real(r8), parameter :: DUfac = 2.687e20_r8   ! 1 DU in molecules per m^2
 
   character(len=32) :: chempkg
@@ -350,6 +349,7 @@ contains
     use constituents, only : pcnst
     use constituents, only : cnst_get_ind
     use phys_grid,    only : get_area_all_p, pcols
+    use physconst,    only : mwdry                   ! molecular weight of dry air
     use physics_buffer, only : physics_buffer_desc
 
 ! here and below for the calculations of total aerosol mass mixing ratios for each aerosol class
@@ -454,7 +454,7 @@ contains
     call outfld( 'MASS', mass(:ncol,:), ncol, lchnk )
 
     ! convert ozone from mol/mol to DU
-    wrk(:ncol,:) = pdel(:ncol,:)*vmr(:ncol,:,id_o3)*avogadro*rgrav/air_molwgt/DUfac*1.e3_r8
+    wrk(:ncol,:) = pdel(:ncol,:)*vmr(:ncol,:,id_o3)*avogadro*rgrav/mwdry/DUfac*1.e3_r8
     ! total column ozone, vertical integration
     do k = 2,pver
        wrk(:ncol,1) = wrk(:ncol,1) + wrk(:ncol,k)

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -4,7 +4,7 @@ module mo_chm_diags
   use chem_mods,    only : gas_pcnst
   use mo_tracname,  only : solsym
   use chem_mods,    only : rxntot, nfs, gas_pcnst, indexm, adv_mass
-  use ppgrid,       only : pver
+  use ppgrid,       only : pcols, pver
   use mo_constants, only : pi, rgrav, rearth, avogadro
   use mo_chem_utls, only : get_rxt_ndx, get_spc_ndx
   use cam_history,  only : fieldname_len
@@ -338,10 +338,12 @@ contains
     call addfld( 'DF_NHX', horiz_only, 'I', 'kg/m2/s', 'NHx dry deposition flux ' )
 
     call addfld( 'TOZ', horiz_only,    'A', 'DU', 'Total column ozone' )
+    call addfld( 'TCO', horiz_only,    'A', 'DU', 'Tropospheric column ozone based on chemistry tropopause' )
+    call addfld( 'SCO', horiz_only,    'A', 'DU', 'Stratospheric column ozone based on chemistry tropopause' )
 
   end subroutine chm_diags_inti
 
-  subroutine chm_diags( lchnk, ncol, vmr, mmr, rxt_rates, invariants, depvel, depflx, mmr_tend, pdel, pdeldry, pbuf )
+  subroutine chm_diags( lchnk, ncol, vmr, mmr, rxt_rates, invariants, depvel, depflx, mmr_tend, pdel, pdeldry, pbuf, ltrop )
     !--------------------------------------------------------------------
     !	... utility routine to output chemistry diagnostic variables
     !--------------------------------------------------------------------
@@ -378,6 +380,7 @@ contains
     real(r8), intent(in)  :: mmr_tend(ncol,pver,gas_pcnst)
     real(r8), intent(in)  :: pdel(ncol,pver)
     real(r8), intent(in)  :: pdeldry(ncol,pver)
+    integer,  intent(in)  :: ltrop(pcols)  ! index of the lowest stratospheric level
     type(physics_buffer_desc), pointer :: pbuf(:)
 
     !--------------------------------------------------------------------
@@ -459,11 +462,36 @@ contains
 
     ! convert ozone from mol/mol (w.r.t. dry air mass) to DU
     wrk(:ncol,:) = pdeldry(:ncol,:)*vmr(:ncol,:,id_o3)*avogadro*rgrav/mwdry/DUfac*1.e3_r8
-    ! total column ozone, vertical integration
+    ! total column ozone
     do k = 2,pver
        wrk(:ncol,1) = wrk(:ncol,1) + wrk(:ncol,k)
     end do
     call outfld( 'TOZ', wrk,   ncol, lchnk )
+
+    ! stratospheric column ozone
+    wrk(:ncol,:) = pdeldry(:ncol,:)*vmr(:ncol,:,id_o3)*avogadro*rgrav/mwdry/DUfac*1.e3_r8
+    do i = 1,ncol
+       do k = 2,pver
+          if (k > ltrop(i)) then
+            exit
+          end if
+          wrk(i,1) = wrk(i,1) + wrk(i,k)
+       end do
+    end do
+    call outfld( 'SCO', wrk,   ncol, lchnk )
+
+    ! tropospheric column ozone
+    wrk(:ncol,:) = pdeldry(:ncol,:)*vmr(:ncol,:,id_o3)*avogadro*rgrav/mwdry/DUfac*1.e3_r8
+    do i = 1,ncol
+       wrk(i,1) = 0._r8
+       do k = 2,pver
+          if (k <= ltrop(i)) then
+            cycle
+          end if
+          wrk(i,1) = wrk(i,1) + wrk(i,k)
+       end do
+    end do
+    call outfld( 'TCO', wrk,   ncol, lchnk )
 
     do m = 1,gas_pcnst
 

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -339,7 +339,9 @@ contains
 
     call addfld( 'TOZ', horiz_only,    'A', 'DU', 'Total column ozone' )
     call addfld( 'TCO', horiz_only,    'A', 'DU', 'Tropospheric column ozone based on chemistry tropopause' )
+    call add_default( 'TCO', 1, ' ' )
     call addfld( 'SCO', horiz_only,    'A', 'DU', 'Stratospheric column ozone based on chemistry tropopause' )
+    call add_default( 'SCO', 1, ' ' )
 
   end subroutine chm_diags_inti
 

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -937,7 +937,7 @@ contains
     call t_startf('chemdr_diags')
     call chm_diags( lchnk, ncol, vmr(:ncol,:,:), mmr_new(:ncol,:,:), &
                     reaction_rates(:ncol,:,:), invariants(:ncol,:,:), depvel(:ncol,:),  sflx(:ncol,:), &
-                    mmr_tend(:ncol,:,:), pdel(:ncol,:), pdeldry(:ncol,:), pbuf  )
+                    mmr_tend(:ncol,:,:), pdel(:ncol,:), pdeldry(:ncol,:), pbuf, troplev(:ncol)  )
 
     call rate_diags_calc( reaction_rates(:,:,:), vmr(:,:,:), invariants(:,:,indexm), ncol, lchnk )
     call t_stopf('chemdr_diags')

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -172,7 +172,7 @@ contains
 !-----------------------------------------------------------------------
   subroutine gas_phase_chemdr(lchnk, ncol, imozart, q, &
                               phis, zm, zi, calday, &
-                              tfld, pmid, pdel, pint,  &
+                              tfld, pmid, pdel, pdeldry, pint,  &
                               cldw, troplev, &
                               ncldwtr, ufld, vfld,  &
                               delt, ps, xactive_prates, &
@@ -259,6 +259,7 @@ contains
     real(r8),       intent(in)    :: tfld(pcols,pver)               ! midpoint temperature (K)
     real(r8),       intent(in)    :: pmid(pcols,pver)               ! midpoint pressures (Pa)
     real(r8),       intent(in)    :: pdel(pcols,pver)               ! pressure delta about midpoints (Pa)
+    real(r8),       intent(in)    :: pdeldry(pcols,pver)            ! dry pressure delta about midpoints (Pa)
     real(r8),       intent(in)    :: ufld(pcols,pver)               ! zonal velocity (m/s)
     real(r8),       intent(in)    :: vfld(pcols,pver)               ! meridional velocity (m/s)
     real(r8),       intent(in)    :: cldw(pcols,pver)               ! cloud water (kg/kg)
@@ -936,7 +937,7 @@ contains
     call t_startf('chemdr_diags')
     call chm_diags( lchnk, ncol, vmr(:ncol,:,:), mmr_new(:ncol,:,:), &
                     reaction_rates(:ncol,:,:), invariants(:ncol,:,:), depvel(:ncol,:),  sflx(:ncol,:), &
-                    mmr_tend(:ncol,:,:), pdel(:ncol,:), pbuf  )
+                    mmr_tend(:ncol,:,:), pdel(:ncol,:), pdeldry(:ncol,:), pbuf  )
 
     call rate_diags_calc( reaction_rates(:,:,:), vmr(:,:,:), invariants(:,:,indexm), ncol, lchnk )
     call t_stopf('chemdr_diags')


### PR DESCRIPTION
This PR adds the online calculations of the ozone column data needed by this e3sm diags plot (https://github.com/E3SM-Project/e3sm_diags/issues/395). These online diagnostics of ozone columns are more accurate than the offline calculations.

- Fix the existing total column ozone (TOZ) diagnostic by replacing the wet air mass with the dry air mass
- Add the online integrations for the stratospheric column ozone (SCO) and tropospheric column ozone (TCO) diagnostics

[BFB] except for tests that compare eam.h0 which will new diagnostic variables in SCO and TCO and changes in TOZ.