### PR TITLE
Set GMAKE_J to 4 for 'singularity' machine

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -521,7 +521,7 @@
     <BASELINE_ROOT>$ENV{HOME}/projects/e3sm/baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
     <GMAKE>make</GMAKE>
-    <GMAKE_J>16</GMAKE_J>
+    <GMAKE_J>4</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <SUPPORTED_BY>lukasz at uchicago dot edu</SUPPORTED_BY>


### PR DESCRIPTION
By default, GMAKE assumes 16 threads/CPUs available on the 'singularity' machine. It sometimes causes a failure when building kokkos on hardware that has less CPUs like small workstations and laptops. Then, a user is required to set explicitly GMAKE_J to a value that matches the user's hardware. To avoid that additional step, this PR changes GMAKE_J default value, 16, to 4 which should work for most small workstations and laptops.