### PR TITLE
Add support for land on bi-grid ne1024pg2_oRRS18to6v3

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2579,8 +2579,8 @@
     <domain name="ne1024np4.pg2">
       <nx>25165824</nx>
       <ny>1</ny>
-      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne1024pg2_oRRS18to6v3.210523.nc</file>
-      <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne1024pg2_oRRS18to6v3.210523.nc</file>
+      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne1024pg2_oRRS18to6v3.200212.nc</file>
+      <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne1024pg2_oRRS18to6v3.200212.nc</file>
       <desc>ne1024np4.pg2 is Spectral Elem 3km grid w/ 2x2 FV physics grid per element:</desc>
     </domain>
 

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1537,6 +1537,16 @@
       <mask>oRRS18to6v3</mask>
     </model_grid>
 
+    <model_grid alias="ne1024pg2_oRRS18to6v3">
+      <grid name="atm">ne1024np4.pg2</grid>
+      <grid name="lnd">ne1024np4.pg2</grid>
+      <grid name="ocnice">oRRS18to6v3</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6v3</mask>
+    </model_grid>
+
     <model_grid alias="ne1024np4_360x720cru_oRRS15to5" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne1024np4</grid>
       <grid name="lnd">360x720cru</grid>
@@ -3542,7 +3552,6 @@
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne1024pg2/map_r0125_to_ne1024pg2_mono.200212.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne1024pg2/map_r0125_to_ne1024pg2_bilin.200212.nc</map>
     </gridmap>
-
 
     <gridmap atm_grid="ne0np4_conus_x4v1_lowcon" ocn_grid="oEC60to30v3">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_oEC60to30v3_mono.200514.nc</map>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2579,8 +2579,8 @@
     <domain name="ne1024np4.pg2">
       <nx>25165824</nx>
       <ny>1</ny>
-      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne1024pg2_oRRS18to6v3.200212.nc</file>
-      <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne1024pg2_oRRS18to6v3.200212.nc</file>
+      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne1024pg2_oRRS18to6v3.210523.nc</file>
+      <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne1024pg2_oRRS18to6v3.210523.nc</file>
       <desc>ne1024np4.pg2 is Spectral Elem 3km grid w/ 2x2 FV physics grid per element:</desc>
     </domain>
 
@@ -3553,6 +3553,11 @@
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne1024pg2/map_r0125_to_ne1024pg2_bilin.200212.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne1024np4.pg2" rof_grid="r0125">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne1024pg2/map_ne1024pg2_to_r0125_mono.200212.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne1024pg2/map_ne1024pg2_to_r0125_mono.200212.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="ne0np4_conus_x4v1_lowcon" ocn_grid="oEC60to30v3">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_oEC60to30v3_mono.200514.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/conusx4v1/map_conusx4v1_to_oEC60to30v3_bilin.200514.nc</map>
@@ -4198,6 +4203,11 @@
     <gridmap lnd_grid="ne240np4" rof_grid="r05">
       <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne240np4/map_ne240np4_nomask_to_0.5x0.5_nomask_aave_da_c110922.nc</map>
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne240np4/map_0.5x0.5_nomask_to_ne240np4_nomask_aave_da_c121019.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="ne1024np4.pg2" rof_grid="r0125">
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne1024pg2/map_ne1024pg2_to_r0125_mono.200212.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne1024pg2/map_r0125_to_ne1024pg2_mono.200212.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="0.23x0.31" rof_grid="r05">

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -238,6 +238,8 @@ lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr2010_c191025.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr2010_c191025.nc</fsurdat>
 <fsurdat hgrid="ne30np4.pg2"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr2010_c201210.nc</fsurdat>
+<fsurdat hgrid="ne1024np4.pg2"   sim_year="2010" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_ne1024pg2_simyr2010_c210607.nc</fsurdat>
 
 <!-- for present day simulations - year 2000 -->
 <fsurdat hgrid="360x720cru"   sim_year="2000" use_crop=".false." >

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1249,7 +1249,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"  
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne240np4,ne1024np4.pg2,1km-merge-10min,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry> 

--- a/components/elm/cime_config/config_component.xml
+++ b/components/elm/cime_config/config_component.xml
@@ -77,6 +77,7 @@
       <value compset="1950(?:SOI)?_EAM%CMIP6-LR.*_ELM">1950_CMIP6LR_control</value>
       <value compset="1950(?:SOI)?_EAM%CMIP6-HR_ELM">1950_CMIP6HR_control</value>
       <value compset="2010(?:SOI)?_EAM%CMIP6_ELM">2010_CMIP6_control</value>
+      <value compset="2010_DATM.*_ELM"      >2010_CMIP6_control</value> 
       <value compset="2010S.*_EAM%CMIP6_ELM">2010_CMIP6_control</value>
       <value compset="SSP585(?:SOI)?_EAM%CMIP6_ELM">2015-2100_SSP585_transient</value>
       <value compset="SSP585(?:SOI)?_EAM%CMIP6_ELM*_BGC%B">2015-2100_SSP585_CMIP6bgc_transient</value> 

--- a/components/elm/cime_config/config_compsets.xml
+++ b/components/elm/cime_config/config_compsets.xml
@@ -307,6 +307,11 @@
   </compset>
 
   <compset>
+    <alias>I2010CRUELM</alias>
+    <lname>2010_DATM%CRU_ELM_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>I1850CRUELMCN</alias>
     <lname>1850_DATM%CRU_ELM%CN_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -44,6 +44,7 @@ contains
     use clm_time_manager , only : get_nstep, get_step_size, set_timemgr_init, set_nextsw_cday
     use elm_initializeMod, only : initialize1, initialize2, initialize3
     use elm_instMod      , only : lnd2atm_vars, lnd2glc_vars
+    use elm_instance     , only : elm_instance_init
     use elm_varctl       , only : finidat,single_column, elm_varctl_set, iulog, noland
     use elm_varctl       , only : inst_index, inst_suffix, inst_name
     use elm_varorb       , only : eccen, obliqr, lambm0, mvelpp
@@ -121,6 +122,10 @@ contains
 
     call seq_cdata_setptrs(cdata_l, ID=LNDID, mpicom=mpicom_lnd, &
          gsMap=GSMap_lnd, dom=dom_l, infodata=infodata)
+
+    ! Set and save LNDID for easy access by other modules
+
+    call elm_instance_init( LNDID )
 
     ! Determine attriute vector indices
 

--- a/components/elm/src/main/elm_instance.F90
+++ b/components/elm/src/main/elm_instance.F90
@@ -8,7 +8,7 @@ save
 
 public :: elm_instance_init
 
-integer,           public :: lnd_id
+integer,           public :: lnd_id      ! land component identifier for the current instance
 integer,           public :: inst_index
 character(len=16), public :: inst_name
 character(len=16), public :: inst_suffix

--- a/components/elm/src/main/elm_instance.F90
+++ b/components/elm/src/main/elm_instance.F90
@@ -1,0 +1,31 @@
+module elm_instance
+
+use seq_comm_mct, only: seq_comm_suffix, seq_comm_inst, seq_comm_name
+
+implicit none
+private
+save
+
+public :: elm_instance_init
+
+integer,           public :: lnd_id
+integer,           public :: inst_index
+character(len=16), public :: inst_name
+character(len=16), public :: inst_suffix
+
+!===============================================================================
+CONTAINS
+!===============================================================================
+
+subroutine elm_instance_init(in_lnd_id)
+
+   integer, intent(in) :: in_lnd_id
+
+   lnd_id      = in_lnd_id
+   inst_name   = seq_comm_name(lnd_id)
+   inst_index  = seq_comm_inst(lnd_id)
+   inst_suffix = seq_comm_suffix(lnd_id)
+
+end subroutine elm_instance_init
+
+end module elm_instance

--- a/components/elm/src/main/ncdio_pio.F90.in
+++ b/components/elm/src/main/ncdio_pio.F90.in
@@ -238,7 +238,7 @@ contains
     logical :: l_avoid_pnetcdf  ! local version of avoid_pnetcdf
     integer :: my_io_type
     integer :: ierr
-    integer :: mode
+    integer :: mode             ! IO mode according to netcdf format used
     !-----------------------------------------------------------------------
 
     l_avoid_pnetcdf = .false.

--- a/components/elm/src/main/ncdio_pio.F90.in
+++ b/components/elm/src/main/ncdio_pio.F90.in
@@ -2188,7 +2188,7 @@ end subroutine ncd_io_{DIMS}d_{TYPE}_glob
     integer*8 :: gsmap_gsize                   ! global size of gsmap
     integer*8 :: fullsize                      ! size of entire array on cdf
     integer*8 :: gsize                         ! global size of elmlevel
-    integer   :: vsize                         ! other dimensions
+    integer*8 :: vsize                         ! other dimensions
     integer   :: vsize1, vsize2                ! other dimensions
     integer   :: status                        ! error status
     logical   :: found                         ! true => found created iodescriptor

--- a/components/elm/src/main/ncdio_pio.F90.in
+++ b/components/elm/src/main/ncdio_pio.F90.in
@@ -223,6 +223,8 @@ contains
     !
     ! !USES:
     use pio, only : pio_iotype_pnetcdf, pio_iotype_netcdf
+    use elm_instance,   only: lnd_id
+    use shr_pio_mod,    only: shr_pio_getioformat
     !
     ! !ARGUMENTS:
     class(file_desc_t), intent(inout) :: file    ! PIO file descriptor
@@ -236,6 +238,7 @@ contains
     logical :: l_avoid_pnetcdf  ! local version of avoid_pnetcdf
     integer :: my_io_type
     integer :: ierr
+    integer :: mode
     !-----------------------------------------------------------------------
 
     l_avoid_pnetcdf = .false.
@@ -255,7 +258,8 @@ contains
        end if
     end if
 
-    ierr = pio_createfile(pio_subsystem, file, my_io_type, fname, ior(PIO_CLOBBER,PIO_64BIT_OFFSET))
+    mode = shr_pio_getioformat(lnd_id)
+    ierr = pio_createfile(pio_subsystem, file, my_io_type, fname, ior(PIO_CLOBBER,mode))
 
     if(ierr/= PIO_NOERR) then
        call shr_sys_abort( ' ncd_pio_createfile ERROR: Failed to open file to write: '//trim(fname))
@@ -2178,22 +2182,22 @@ end subroutine ncd_io_{DIMS}d_{TYPE}_glob
     logical,optional   , intent(in)    :: switchdim  ! switch level dimension and first dim 
     !
     ! !LOCAL VARIABLES:
-    integer :: k,m,n,cnt                     ! indices
-    integer :: basetype                      ! pio basetype
-    integer :: gsmap_lsize                   ! local size of gsmap
-    integer :: gsmap_gsize                   ! global size of gsmap
-    integer :: fullsize                      ! size of entire array on cdf
-    integer :: gsize                         ! global size of elmlevel
-    integer :: vsize                         ! other dimensions
-    integer :: vsize1, vsize2                ! other dimensions
-    integer :: status                        ! error status
-    logical :: found                         ! true => found created iodescriptor
-    integer :: ndims_file                    ! temporary
+    integer   :: k,m,n,cnt                     ! indices
+    integer   :: basetype                      ! pio basetype
+    integer   :: gsmap_lsize                   ! local size of gsmap
+    integer*8 :: gsmap_gsize                   ! global size of gsmap
+    integer*8 :: fullsize                      ! size of entire array on cdf
+    integer*8 :: gsize                         ! global size of elmlevel
+    integer   :: vsize                         ! other dimensions
+    integer   :: vsize1, vsize2                ! other dimensions
+    integer   :: status                        ! error status
+    logical   :: found                         ! true => found created iodescriptor
+    integer   :: ndims_file                    ! temporary
     character(len=64) dimname_file           ! dimension name on file
     character(len=64) dimname_iodesc         ! dimension name from io descriptor
     type(mct_gsMap),pointer       :: gsmap   ! global seg map
     integer, pointer,dimension(:) :: gsmOP   ! gsmap ordered points
-    integer, pointer  :: compDOF(:)
+    integer*8, pointer  :: compDOF(:)
     character(len=32) :: subname = 'ncd_getiodesc'
     !------------------------------------------------------------------------
 
@@ -2278,7 +2282,7 @@ end subroutine ncd_io_{DIMS}d_{TYPE}_glob
 
     vsize = fullsize / gsize
     if (mod(fullsize,gsize) /= 0) then
-       write(iulog,*) subname,' ERROR in vsize ',fullsize,gsize,vsize
+       write(iulog,*) subname,' ERROR in vsize ',fullsize,gsize,vsize,ndims,dims
        call shr_sys_abort(errMsg(__FILE__, __LINE__))
     endif
 


### PR DESCRIPTION
This is to support land on ne1024pg2 grid as the atmosphere. River model
for this grid configuration continues to use r0125.

Land restart file at ne1024pg2 has to use 64bit_data format. To enable,
Changes are made to have ELM use the netcdf format as specified via
PIO_LND_NETCDF_FORMAT. Existing codes are hardwired to use 64BIT_OFFSET.

To support creating large land files at ne1024pg2, mainly restart files,
changes are also made to use 8-byte long integer for resolving the fullsize
of the data array and indexing the associated segments.

Fixes #4311.
 [BFB]
