### PR TITLE
Fix frazil mass leak

### DIFF
--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -2560,8 +2560,8 @@ contains
             ! field frazilMassAdjust.
             i2x_i % rAttr(index_i2x_Fioi_melth,n) = oceanHeatFlux(i)
             i2x_i % rAttr(index_i2x_Fioi_swpen,n) = oceanShortwaveFlux(i)
-            i2x_i % rAttr(index_i2x_Fioi_meltw,n) = oceanFreshWaterFlux(i) + frazilMassAdjust(i)
-            i2x_i % rAttr(index_i2x_Fioi_salt ,n) = oceanSaltFlux(i) + ice_ref_salinity*p001*frazilMassAdjust(i)
+            i2x_i % rAttr(index_i2x_Fioi_meltw,n) = oceanFreshWaterFlux(i) + frazilMassAdjust(i)/ailohi
+            i2x_i % rAttr(index_i2x_Fioi_salt ,n) = oceanSaltFlux(i) + ice_ref_salinity*p001*frazilMassAdjust(i)/ailohi
             i2x_i % rAttr(index_i2x_Fioi_taux ,n) = tauxo
             i2x_i % rAttr(index_i2x_Fioi_tauy ,n) = tauyo
 


### PR DESCRIPTION
This corrects a mistake made in https://github.com/E3SM-Project/E3SM/pull/4295, whereby the adjustment to meltwater and salt were not weighted by the inverse of concentration to counter their subsequent weighting by sea ice concentration after export to the coupler.  The code now conserves to 10^-16 kg/m^2/s in mass and 10^10 in W/m^2 in heat.  The code has passed a ten-year sanity check. Output is available on Chrysalis /lcrc/group/e3sm/ac.afroberts/E3SM_simulations/20210527.v2rc2c.Fix2.ne30pg2_EC30to60E2r2.chrysalis from this test.  Graphics are provided in subsequent comments in this pull request to demonstrate model sanity and conservation.   Basic ten-year sanity check with MPAS analysis available at https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.afroberts/E3SM/v2/frazil/20210527.v2rc2c.Fix2.ne30pg2_EC30to60E2r2.chrysalis/mpas_analysis/ts_0001-0009_climo_0001-0009

[non-BFB]

Tagged: @stephenprice @darincomeau 