### PR TITLE
Remove limit on shr_frz_freezetemp and replace it with an abort

### DIFF
--- a/share/util/shr_frz_mod.F90.in
+++ b/share/util/shr_frz_mod.F90.in
@@ -105,11 +105,11 @@ contains
     endif
 
 #if ({DIMS}==0)
-    if (shr_frz_freezetemp < -2.5_R8) &
-       call shr_sys_abort(subname//' ERROR: shr_frz_freezetemp is less than -2.5')
+    if (shr_frz_freezetemp < -2.6_R8) &
+       call shr_sys_abort(subname//' ERROR: shr_frz_freezetemp is less than -2.6')
 #else
-    if (minval(shr_frz_freezetemp) < -2.5_R8) &
-       call shr_sys_abort(subname//' ERROR: shr_frz_freezetemp is less than -2.5')
+    if (minval(shr_frz_freezetemp) < -2.6_R8) &
+       call shr_sys_abort(subname//' ERROR: shr_frz_freezetemp is less than -2.6')
 #endif
 
   end function shr_frz_freezetemp_{DIMS}d

--- a/share/util/shr_frz_mod.F90.in
+++ b/share/util/shr_frz_mod.F90.in
@@ -104,7 +104,8 @@ contains
             &call shr_frz_freezetemp_init first with a valid tfreeze_option')
     endif
 
-    shr_frz_freezetemp = max(shr_frz_freezetemp,-2.0_R8)
+    if (shr_frz_freezetemp<-2.0_R8 .and. s_loglev > 0) &
+       write(s_logunit,F00) 'WARNING shr_frz_freezetemp is less than -2'
 
   end function shr_frz_freezetemp_{DIMS}d
 

--- a/share/util/shr_frz_mod.F90.in
+++ b/share/util/shr_frz_mod.F90.in
@@ -104,8 +104,13 @@ contains
             &call shr_frz_freezetemp_init first with a valid tfreeze_option')
     endif
 
-    if (shr_frz_freezetemp<-2.5_R8) &
+#if ({DIMS}==0)
+    if (shr_frz_freezetemp < -2.5_R8) &
        call shr_sys_abort(subname//' ERROR: shr_frz_freezetemp is less than -2.5')
+#else
+    if (minval(shr_frz_freezetemp) < -2.5_R8) &
+       call shr_sys_abort(subname//' ERROR: shr_frz_freezetemp is less than -2.5')
+#endif
 
   end function shr_frz_freezetemp_{DIMS}d
 

--- a/share/util/shr_frz_mod.F90.in
+++ b/share/util/shr_frz_mod.F90.in
@@ -104,8 +104,8 @@ contains
             &call shr_frz_freezetemp_init first with a valid tfreeze_option')
     endif
 
-    if (shr_frz_freezetemp<-2.0_R8 .and. s_loglev > 0) &
-       write(s_logunit,F00) 'WARNING shr_frz_freezetemp is less than -2'
+    if (shr_frz_freezetemp<-2.5_R8) &
+       call shr_sys_abort(subname//' ERROR: shr_frz_freezetemp is less than -2.5')
 
   end function shr_frz_freezetemp_{DIMS}d
 


### PR DESCRIPTION
The share code in the coupler currently calculates shr_frz_freezetemp based on a seawater freezing temperature option, but then limits it to not allow a freezing temperature below -2.0. This PR removes that limit and replaces it with an abort if the shr_frz_freezetemp is calculated to be below -2.6C.

[non-BFB] for some A-, C-, and D-cases