### PR TITLE
Update pgigpu tests on Blues

### DIFF
--- a/cime_config/machines/Depends.ibmgpu.cmake
+++ b/cime_config/machines/Depends.ibmgpu.cmake
@@ -53,7 +53,7 @@ set(FILES_NEED_OPENMP_FLAGS
   eam/src/physics/crm/samomp/params.F90
   eam/src/physics/crm/samomp/dmdf.F90
   eam/src/physics/crm/samomp/domain.F90
-  eam/src/physics/crm/samomp/ecppvars.F90
+  eam/src/physics/crm/ecppvars.F90
   eam/src/physics/crm/samomp/fft.F90
   eam/src/physics/crm/samomp/fftpack5.F90
   eam/src/physics/crm/samomp/fftpack5_1d.F90

--- a/cime_config/machines/Depends.pgigpu.cmake
+++ b/cime_config/machines/Depends.pgigpu.cmake
@@ -52,7 +52,7 @@ set(FILES_NEED_OPENACC_FLAGS
   eam/src/physics/crm/sam/params.F90
   eam/src/physics/crm/sam/dmdf.F90
   eam/src/physics/crm/sam/domain.F90
-  eam/src/physics/crm/sam/ecppvars.F90
+  eam/src/physics/crm/ecppvars.F90
   eam/src/physics/crm/sam/fft.F90
   eam/src/physics/crm/sam/fftpack5.F90
   eam/src/physics/crm/sam/fftpack5_1d.F90

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -383,8 +383,8 @@ _TESTS = {
 
     "e3sm_gpu" : {
         "tests"    : (
-                 "SMS_P36x1_Ld1.T62_oEC60to30v3.CMPASO-NYF",
-                 "SMS_P36x1_Ld1.T62_oEC60to30v3.DTESTM",
+                 "SMS_P16x1_Ld1.T62_oEC60to30v3.CMPASO-NYF",
+                 "SMS_P16x1_Ld1.T62_oEC60to30v3.DTESTM",
                  )
     },
 


### PR DESCRIPTION
Update pgigpu tests on Blues:
- update path in cime_config/machines/Depends.ibmgpu.cmake and Depends.pgigpu.cmake;
- reduce num_nodes in `pgigpu` tests from 3 to 1 for better queue throughput.

[BFB]