### PR TITLE
Fix extrasnowlayers test, using corrected compset and updated name

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -111,7 +111,7 @@ _TESTS = {
         "tests" : (
             "ERS_P480_Ld5.T62_oEC60to30v3wLI.GMPAS-DIB-IAF-ISMF",
             "PEM_P480_Ld5.T62_oEC60to30v3wLI.GMPAS-DIB-IAF-ISMF",
-            "SMS.ne30_oECv3_gis.IGCLM45_MLI.clm-extrasnowlayers",
+            "SMS.ne30_oECv3_gis.IGELM_MLI.elm-extrasnowlayers",
             )
         },
 


### PR DESCRIPTION
Fixes a mis-named test in the e3sm_ocnice_extra_coverage suite, which had an incorrect compset and was using "clm" instead of "elm" for the testmod.

[BFB]