### PR TITLE
Add SGS for ESMT scalars in SAM++

### DIFF
--- a/components/eam/src/physics/crm/samxx/sgs.cpp
+++ b/components/eam/src/physics/crm/samxx/sgs.cpp
@@ -97,12 +97,8 @@ void sgs_scalars() {
   }
 
 #if defined(MMF_ESMT)
-  for (int k=0; k<nmicro_fields; k++) {
-    if (k==index_water_vapor || (docloud && flag_precip(k)!=1) || (doprecip && flag_precip(k)==1)) {
-      diffuse_scalar(sgs_field_diag,1,u_esmt,k,fluxb_u_esmt,k,fluxt_u_esmt,k,u_esmt_diff,k,u_esmt_sgs,k);
-      diffuse_scalar(sgs_field_diag,1,v_esmt,k,fluxb_v_esmt,k,fluxt_v_esmt,k,v_esmt_diff,k,v_esmt_sgs,k);
-    }
-  }
+  diffuse_scalar(sgs_field_diag,1,u_esmt,fluxb_u_esmt,fluxt_u_esmt,u_esmt_diff,u_esmt_sgs);
+  diffuse_scalar(sgs_field_diag,1,v_esmt,fluxb_v_esmt,fluxt_v_esmt,v_esmt_diff,v_esmt_sgs);
 #endif
 }
 

--- a/components/eam/src/physics/crm/samxx/sgs.cpp
+++ b/components/eam/src/physics/crm/samxx/sgs.cpp
@@ -95,6 +95,15 @@ void sgs_scalars() {
       diffuse_scalar(sgs_field_diag,1,micro_field,k,fluxbmk,k,fluxtmk,k,mkdiff,k,mkwsb,k);
     }
   }
+
+#if defined(MMF_ESMT)
+  for (int k=0; k<nmicro_fields; k++) {
+    if (k==index_water_vapor || (docloud && flag_precip(k)!=1) || (doprecip && flag_precip(k)==1)) {
+      diffuse_scalar(sgs_field_diag,1,u_esmt,k,fluxb_u_esmt,k,fluxt_u_esmt,k,u_esmt_diff,k,u_esmt_sgs,k);
+      diffuse_scalar(sgs_field_diag,1,v_esmt,k,fluxb_v_esmt,k,fluxt_v_esmt,k,v_esmt_diff,k,v_esmt_sgs,k);
+    }
+  }
+#endif
 }
 
 


### PR DESCRIPTION
Add a missing turbulent diffusion calculation for ESMT scalars in SAM++

[BFB] (except for MMFXX with ESMT enabled)