### PR TITLE
Changes sign of iceberg latent heat flux.

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
@@ -1797,7 +1797,7 @@ contains
        do iCell = 1, nCellsSolve
 
           bergFreshwaterFlux(iCell) = bergFreshwaterFluxData(iCell)
-          bergLatentHeatFlux(iCell) = bergFreshwaterFluxData(iCell) * &
+          bergLatentHeatFlux(iCell) = -bergFreshwaterFluxData(iCell) * &
                                      (seaiceLatentHeatMelting - specificHeatFreshIce*bergTemperature)
 
        enddo


### PR DESCRIPTION
Changes the sign of the iceberg latent heat flux in MPAS-Seaice, which is then sent to MPAS-Ocean.

Fixes https://github.com/E3SM-Project/E3SM/issues/4347

[non-BFB] for all Cryosphere configurations, currently the `CRYO1850` compset, and v1 compsets with `DIB` in the compset name.