### PR TITLE
Update ocean semi-implicit barotropic mode solver

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -830,7 +830,7 @@ add_default($nl, 'config_btr_gam3_velWt2');
 add_default($nl, 'config_btr_solve_SSH2');
 
 ####################################
-# Namelist group: semi_implicit_ts #
+# Namelist group: split_implicit_ts #
 ####################################
 
 add_default($nl, 'config_btr_si_preconditioner');
@@ -1626,7 +1626,7 @@ my @groups = qw(run_modes
                 eos_wright
                 split_timestep_share
                 split_explicit_ts
-                semi_implicit_ts
+                split_implicit_ts
                 ale_vertical_grid
                 ale_frequency_filtered_thickness
                 debug

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -835,7 +835,7 @@ add_default($nl, 'config_btr_solve_SSH2');
 
 add_default($nl, 'config_btr_si_preconditioner');
 add_default($nl, 'config_btr_si_tolerance');
-add_default($nl, 'config_n_btr_si_outer_iter');
+add_default($nl, 'config_n_btr_si_large_iter');
 add_default($nl, 'config_btr_si_partition_match_mode');
 
 #####################################

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -28,7 +28,7 @@ my @groups = qw(run_modes
                 eos_wright
                 split_timestep_share
                 split_explicit_ts
-                semi_implicit_ts
+                split_implicit_ts
                 ale_vertical_grid
                 ale_frequency_filtered_thickness
                 debug

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -363,7 +363,7 @@ add_default($nl, 'config_btr_gam3_velWt2');
 add_default($nl, 'config_btr_solve_SSH2');
 
 ####################################
-# Namelist group: semi_implicit_ts #
+# Namelist group: split_implicit_ts #
 ####################################
 
 add_default($nl, 'config_btr_si_preconditioner');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -368,7 +368,7 @@ add_default($nl, 'config_btr_solve_SSH2');
 
 add_default($nl, 'config_btr_si_preconditioner');
 add_default($nl, 'config_btr_si_tolerance');
-add_default($nl, 'config_n_btr_si_outer_iter');
+add_default($nl, 'config_n_btr_si_large_iter');
 add_default($nl, 'config_btr_si_partition_match_mode');
 
 #####################################

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -430,7 +430,7 @@
 <config_btr_gam3_velWt2>1.0</config_btr_gam3_velWt2>
 <config_btr_solve_SSH2>.false.</config_btr_solve_SSH2>
 
-<!-- semi_implicit_ts -->
+<!-- split_implicit_ts -->
 <config_btr_si_preconditioner>'ras'</config_btr_si_preconditioner>
 <config_btr_si_tolerance>1.0e-9</config_btr_si_tolerance>
 <config_n_btr_si_large_iter>1</config_n_btr_si_large_iter>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -433,7 +433,7 @@
 <!-- semi_implicit_ts -->
 <config_btr_si_preconditioner>'ras'</config_btr_si_preconditioner>
 <config_btr_si_tolerance>1.0e-9</config_btr_si_tolerance>
-<config_n_btr_si_outer_iter>2</config_n_btr_si_outer_iter>
+<config_n_btr_si_large_iter>1</config_n_btr_si_large_iter>
 <config_btr_si_partition_match_mode>.false.</config_btr_si_partition_match_mode>
 
 <!-- ALE_vertical_grid -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1822,11 +1822,11 @@ Valid values: any positive real, but typically less than 1.0e-9
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_n_btr_si_outer_iter" type="integer"
+<entry id="config_n_btr_si_large_iter" type="integer"
 	category="semi_implicit_ts" group="semi_implicit_ts">
-number of outer iterations
+number of large barotropic system iterations
 
-Valid values: any positive integer, but typically 2
+any positive integer, but typically 1 and less than 2
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -196,7 +196,7 @@ Default: Defined in namelist_defaults.xml
 	category="time_integration" group="time_integration">
 Time integration method.
 
-Valid values: 'split_explicit', 'RK4', 'unsplit_explicit', 'semi_implicit'
+Valid values: 'split_explicit', 'RK4', 'unsplit_explicit', 'split_implicit'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1804,10 +1804,10 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- semi_implicit_ts -->
+<!-- split_implicit_ts -->
 
 <entry id="config_btr_si_preconditioner" type="char*1024"
-	category="semi_implicit_ts" group="semi_implicit_ts">
+	category="split_implicit_ts" group="split_implicit_ts">
 Type of preconditioner for the barotropic mode solver
 
 Valid values: ras, block_jacobi, jacobi, none
@@ -1815,7 +1815,7 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_btr_si_tolerance" type="real"
-	category="semi_implicit_ts" group="semi_implicit_ts">
+	category="split_implicit_ts" group="split_implicit_ts">
 Tolerance for the barotropic mode solver
 
 Valid values: any positive real, but typically less than 1.0e-9
@@ -1823,7 +1823,7 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_n_btr_si_large_iter" type="integer"
-	category="semi_implicit_ts" group="semi_implicit_ts">
+	category="split_implicit_ts" group="split_implicit_ts">
 number of large barotropic system iterations
 
 any positive integer, but typically 1 and less than 2
@@ -1831,8 +1831,8 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_btr_si_partition_match_mode" type="logical"
-	category="semi_implicit_ts" group="semi_implicit_ts">
-If true, the semi-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing.
+	category="split_implicit_ts" group="split_implicit_ts">
+If true, the split-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1158,10 +1158,10 @@
 					description="Tolerance for the barotropic mode solver"
 					possible_values="any positive real, but typically less than 1.0e-9"
 		/>
-		<nml_option name="config_n_btr_si_outer_iter" type="integer" default_value="2" units="unitless"
-					description="number of outer iterations"
-					possible_values="any positive integer, but typically 2"
-		/>
+                <nml_option name="config_n_btr_si_large_iter" type="integer" default_value="1" units="unitless"
+                                        description="number of large barotropic system iterations"
+                                        possible_values="any positive integer, but typically 1 and less than 2"
+                />
 		<nml_option name="config_btr_si_partition_match_mode" type="logical" default_value=".false." units="unitless"
 					description="If true, the semi-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing."
 					possible_values=".true. or .false."
@@ -2949,115 +2949,111 @@
 			description="f * uPerp for the semi-implicit time stepping"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_r0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_r0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_r1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_r1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_rh0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_rh0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_rh1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_rh1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_r00" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_r00" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_ph0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_ph0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_ph1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_ph1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_v0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_v0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_v1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_s0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_s0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_s1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_s1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_sh0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_sh0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_sh1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_sh1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_w0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_w0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_w1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_w1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_wh0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_wh0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_wh1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_wh1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_q0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_q0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_q1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_q1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_qh0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_qh0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_qh1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_qh1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_z0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_z0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_z1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_z1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_zh0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_zh0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_zh1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_zh1" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_t0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_t0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_t1" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="CGvec_t1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
-			packages="semiImplicitTimePKG"
-		/>
-		<var name="CGvec_y0" type="real" dimensions="nCells Time" units="unitless"
+		<var name="SIvec_y0" type="real" dimensions="nCells Time" units="unitless"
 			description="A vector used in the semi-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -191,7 +191,7 @@
 		/>
 		<nml_option name="config_time_integrator" type="character" default_value="split_explicit" units="unitless"
 					description="Time integration method."
-					possible_values="'split_explicit', 'RK4', 'unsplit_explicit', 'semi_implicit'"
+					possible_values="'split_explicit', 'RK4', 'unsplit_explicit', 'split_implicit'"
 		/>
 	</nml_record>
 	<nml_record name="hmix" mode="forward">
@@ -1149,7 +1149,7 @@
 					possible_values=".true. or .false."
 		/>
 	</nml_record>
-	<nml_record name="semi_implicit_ts" mode="forward">
+	<nml_record name="split_implicit_ts" mode="forward">
 		<nml_option name="config_btr_si_preconditioner" type="character" default_value="ras" units="unitless"
 					description="Type of preconditioner for the barotropic mode solver"
 					possible_values="ras, block_jacobi, jacobi, none"
@@ -1163,7 +1163,7 @@
                                         possible_values="any positive integer, but typically 1 and less than 2"
                 />
 		<nml_option name="config_btr_si_partition_match_mode" type="logical" default_value=".false." units="unitless"
-					description="If true, the semi-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing."
+					description="If true, the split-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing."
 					possible_values=".true. or .false."
 		/>
 	</nml_record>
@@ -1371,7 +1371,7 @@
 		<package name="variableShortwave" description="This package includes variables required to compute spatially variable shortwave extinction coefficients"/>
 
 		<package name="splitTimeIntegrator" description="This package includes variables required for either the split or unsplit explicit time integrators."/>
-		<package name="semiImplicitTimePKG" description="This package includes variables required for semi-implicit time integrators."/>
+		<package name="semiImplicitTimePKG" description="This package includes variables required for split-implicit time integrators."/>
 		<package name="thicknessFilter" description="This package includes variables required for frequency filtered thickness."/>
 		<package name="windStressBulkPKG" description="This package includes varibles required for bulk wind stress forcing."/>
 		<package name="variableBottomDragPKG" description="This package includes varibles required for variable bottom drag."/>
@@ -2944,117 +2944,117 @@
 		<var name="pressureAdjustedSSH" type="real" dimensions="nCells Time" units="m"
 			 description="sea surface height adjusted by sea surface pressure"
 		/>
-		<!-- FIELD semi_implicit time stepping -->
+		<!-- FIELD split_implicit time stepping -->
 		<var name="barotropicCoriolisTerm" type="real" dimensions="nEdges Time" units="m s^{-2}"
-			description="f * uPerp for the semi-implicit time stepping"
+			description="f * uPerp for the split-implicit time stepping"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_r0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_r1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_rh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_rh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_r00" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_ph0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_ph1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_v0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_s0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_s1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_sh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_sh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_w0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_w1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_wh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_wh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_q0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_q1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_qh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_qh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_z0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_z1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_zh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_zh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_t0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_t1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_y0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 	</var_struct>

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
@@ -351,7 +351,7 @@ contains
 
          ! split explicit specific arrays
          call mpas_pool_get_config(ocnConfigs, 'config_time_integrator', config_time_integrator)
-         if ( config_time_integrator == trim('split_explicit') .or.  config_time_integrator == trim('semi_implicit') ) then
+         if ( config_time_integrator == trim('split_explicit') .or.  config_time_integrator == trim('split_implicit') ) then
            call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocity, 1)
            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocity, 1)
          endif

--- a/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
@@ -208,13 +208,13 @@ module ocn_core_interface
       if ( forwardModeActive ) then
          if (    config_time_integrator == trim('split_explicit') &
             .or. config_time_integrator == trim('unsplit_explicit') &
-            .or. config_time_integrator == trim('semi_implicit') ) then
+            .or. config_time_integrator == trim('split_implicit') ) then
             splitTimeIntegratorActive = .true.
          end if
       endif
       call mpas_pool_get_package(packagePool, 'semiImplicitTimePKGActive', semiImplicitTimePKGActive)
       if ( forwardModeActive ) then
-         if (config_time_integrator == trim('semi_implicit') ) then
+         if (config_time_integrator == trim('split_implicit') ) then
             semiImplicitTimePKGActive = .true.
          end if
       endif

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -778,7 +778,9 @@ module ocn_forward_mode
       ! destroy the ocean mesh structure
       call ocn_meshDestroy(ierr)
 
-      call mpas_dmpar_exch_group_destroy_reusable_buffers(domain, 'subcycleFields')
+      if ( config_time_integrator == 'split_explicit') then
+         call mpas_dmpar_exch_group_destroy_reusable_buffers(domain, 'subcycleFields')
+      end if
 
       call ocn_analysis_finalize(domain, ierr)
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
@@ -200,7 +200,7 @@ module ocn_time_integration
          timeIntegratorChoice = timeIntUnsplitExplicit
          call ocn_time_integration_split_init(domain)
 
-      case ('semi_implicit')
+      case ('split_implicit')
          timeIntegratorChoice = timeIntSemiImplicit
          call ocn_time_integration_si_init(domain, dt)
 
@@ -216,7 +216,7 @@ module ocn_time_integration
             'Incorrect choice for config_time_integrator:' // &
              trim(config_time_integrator) // &
              '   choices are: RK4, split_explicit, ' // &
-                 'unsplit_explicit, semi_implicit', MPAS_LOG_ERR)
+                 'unsplit_explicit, split_implicit', MPAS_LOG_ERR)
 
       end select
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -614,12 +614,12 @@ module ocn_time_integration_si
 
          if (associated(highFreqThicknessNew)) then
             call ocn_vert_transport_velocity_top(meshPool, &
-                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
          else
             call ocn_vert_transport_velocity_top(meshPool, &
-                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
          endif
@@ -2475,12 +2475,12 @@ module ocn_time_integration_si
          call mpas_timer_start('thick vert trans vel top')
          if (associated(highFreqThicknessNew)) then
             call ocn_vert_transport_velocity_top(meshPool, &
-                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
          else
             call ocn_vert_transport_velocity_top(meshPool, &
-                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)
          endif
@@ -3012,14 +3012,15 @@ module ocn_time_integration_si
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_time_integration_si_init(domain)!{{{
+   subroutine ocn_time_integration_si_init(domain, dt)!{{{
 
       !-----------------------------------------------------------------
       ! Input/output variables
       !-----------------------------------------------------------------
 
-      type (domain_type), intent(inout) :: &
-         domain  !< [inout] model state to advance forward
+      real (kind=RKIND), intent(in) :: dt !< [in] time step (sec)
+
+      type (domain_type), intent(inout) :: domain
 
       !-----------------------------------------------------------------
       ! Local variables

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -36,12 +36,12 @@ module ocn_time_integration_si
    use mpas_timekeeping
    use mpas_log
 
-   use ocn_tendency
-   use ocn_diagnostics
-   use ocn_diagnostics_variables
-   use ocn_gm
    use ocn_config
    use ocn_mesh
+   use ocn_tendency
+   use ocn_diagnostics_variables
+   use ocn_diagnostics
+   use ocn_gm
 
    use ocn_equation_of_state
    use ocn_vmix
@@ -79,15 +79,37 @@ module ocn_time_integration_si
       iterGroupName     = 'iterFields',   &! group name for halos
       finalBtrGroupName = 'finalBtrFields' ! group name for halos
 
+   integer, dimension(:), allocatable :: &
+      numClinicIterations  ! number of baroclinic iterations for each
+                           ! outer timestep iteration
+
+   integer :: &
+      numTSIterations ! number of outer timestep iterations
+
+   real (kind=RKIND) :: &
+      useVelocityCorrection ! mask for velocity correction
+
    ! Global variables for the semi-implicit time stepper ---------------
-   real (kind=RKIND), allocatable,dimension(:,:) :: tavg
-   real (kind=RKIND), allocatable,dimension(:)   :: prec_ivmat
-   real (kind=RKIND), allocatable,dimension(:)   :: dt_si
-   real (kind=RKIND), allocatable,dimension(:)   :: R1_alpha1s_g_dts
-   real (kind=RKIND), allocatable,dimension(:)   :: R1_alpha1s_g_dt
-   real (kind=RKIND) :: total_num_cells,mean_num_cells
-   real (kind=RKIND) :: R1_alpha1_g,alpha1,alpha2,crit_main
-   integer :: nPrecVec, si_opt, si_ismf, ncpus
+   real (kind=RKIND), allocatable,dimension(:)   :: &
+      prec_ivmat    ! an inversed preconditioning matrix
+   real (kind=RKIND) :: &
+      R1_alpha1s_g_dts, &! pre-computed coefficients
+      R1_alpha1s_g_dt,  &! pre-computed coefficients
+      R1_alpha1_g,      &! pre-computed coefficients
+      alpha1,           &! implicitness parameter (=alpha)
+      alpha2,           &! implicitness parameter (=1-alpha)
+      tolerance_outer,  &! tolerance for the outer solver iterations
+      tolerance_inner,  &! tolerance for the main solver iterations
+      total_num_cells,  &! total number of surface cells
+      mean_num_cells,   &! mean #cells for each core
+      dt_si              ! dt for the SI btr mode solver
+   integer :: &
+      nPrecVec,         &! vector lenghts for preconditioner
+      si_ismf,          &! SI solver linearization for ISMF cases
+      ncpus,            &! Total number of cores
+      nSiLargeIter       ! #iteration for the barotropic system
+
+!***********************************************************************
 
 !***********************************************************************
 
@@ -108,267 +130,421 @@ module ocn_time_integration_si
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_time_integrator_si(domain, dt)!{{{
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    ! Advance model state forward in time by the specified time step using
-    !   Split_Explicit timestepping scheme
-    !
-    ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:))
-    !                 plus mesh meta-data
-    ! Output: domain - upon exit, time level 2 (e.g., time_levs(2)%state%h(:,:)) contains
-    !                  model state advanced forward in time by dt seconds
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   subroutine ocn_time_integrator_si(domain, dt)!{{{
 
-      implicit none
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
 
-      type (domain_type), intent(inout) :: domain
-      real (kind=RKIND), intent(in) :: dt
+      real (kind=RKIND), intent(in) :: &
+         dt              !< [in] time step (sec) to move forward
 
-      type (mpas_pool_type), pointer :: statePool
-      type (mpas_pool_type), pointer :: tracersPool
-      type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: verticalMeshPool
-      type (mpas_pool_type), pointer :: tendPool
-      type (mpas_pool_type), pointer :: tracersTendPool
-      type (mpas_pool_type), pointer :: forcingPool
-      type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: swForcingPool
+      !-----------------------------------------------------------------
+      ! Input/output variables
+      !-----------------------------------------------------------------
 
-      type (dm_info) :: dminfo
-      integer :: iCell, i,k,j, iEdge, cell1, cell2, split_implicit_step, split, &
-                 eoe, oldBtrSubcycleTime, newBtrSubcycleTime, uPerpTime, BtrCorIter, &
-                 stage1_tend_time,iter,iter_u,iter_max
-      integer, dimension(:), allocatable :: n_bcl_iter
-      type (block_type), pointer :: block
+      type (domain_type), intent(inout) :: &
+         domain  !< [inout] model state to advance forward
 
-      real (kind=RKIND) :: normalThicknessFluxSum, thicknessSum,thicknessSumCur,thicknessSumLag,thicknessSumMid,  &
-                           flux,flux1,flux2, sshEdge,sshEdgeCur,sshEdgeLag,sshEdgeMid, hEdge1, &
-                           CoriolisTerm, normalVelocityCorrection, temp, temp_h, coef, barotropicThicknessFlux_coeff, &
-                           sshDiffCur,sshDiffNew,sshDiffLag,sshDiffMid
-      real (kind=RKIND) :: fluxb1,fluxb2,fluxAx,sshTendb1,sshTendb2,sshTendAx
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
 
-      integer :: useVelocityCorrection, err
-      real (kind=RKIND), dimension(:,:), pointer :: &
-                 vertViscTopOfEdge, vertDiffTopOfCell
-      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
-      real (kind=RKIND), dimension(:), allocatable:: uTemp
-      real (kind=RKIND), dimension(:), pointer :: btrvel_temp
-      logical :: activeTracersOnly ! if true only compute tendencies for active tracers
-      integer :: tsIter
-      integer :: edgeHaloComputeCounter, cellHaloComputeCounter
-      integer :: neededHalos
+      type (block_type), pointer :: &
+         block ! structure with subdomain data
 
-      ! Config options
-      logical, pointer :: config_use_tracerGroup
+      type (mpas_pool_type), pointer :: &
+         statePool,         &! structure holding state variables
+         tracersPool,       &! structure holding tracers
+         meshPool,          &! structure holding mesh variables
+         verticalMeshPool,  &! structure holding vertical mesh variables
+         tendPool,          &! structure holding tendencies
+         tracersTendPool,   &! structure holding tracer tendencies
+         forcingPool,       &! structure holding forcing variables
+         scratchPool,       &! structure holding temporary variables
+         swForcingPool       ! structure holding short-wave forcing vars
 
-      ! Dimensions
-      integer :: nCells, nEdges
-      integer, pointer :: nCellsPtr, nEdgesPtr, nVertLevels, num_tracersGroup, startIndex, endIndex
-      integer, pointer :: indexTemperature, indexSalinity
-      integer, dimension(:), pointer :: nCellsArray, nEdgesArray
+      logical :: &
+         activeTracersOnly   ! only compute tendencies for active tracers
 
-      ! Mesh array pointers
-      integer, dimension(:), pointer :: minLevelCell, maxLevelCell, minLevelEdgeBot, maxLevelEdgeTop, nEdgesOnEdge, nEdgesOnCell
-      integer, dimension(:,:), pointer :: cellsOnEdge, edgeMask, edgesOnEdge
-      integer, dimension(:,:), pointer :: edgesOnCell, edgeSignOnCell
+      logical, pointer :: &
+         config_use_tracerGroup  ! flag for using each tracer group
 
-      real (kind=RKIND), dimension(:), pointer :: dcEdge, fEdge, bottomDepth, refBottomDepthTopOfCell
-      real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
-      real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge
+      integer :: &
+         iCell, iEdge, k, &! loop iterators for cell, edge, vert loops
+         nCells, nEdges,  &! number of cells or edges (incl halos)
+         i,j,             &! generic loop iterators
+         cell1, cell2,    &! neighbor cell addresses
+         eoe,             &! index for edge on edge
+         err,             &! local error flag
+         splitImplicitStep, &! loop index for outer timestep loop
+         oldBtrSubcycleTime,&! time index for old barotropic value
+         newBtrSubcycleTime,&! time index for new barotropic value
+         uPerpTime,       &! time index to use for uPerp calculation
+         BtrCorIter,      &! loop index for barotropic coriolis cycle
+         stage1_tend_time,&! time index for stage 1 tendencies
+         edgeHaloComputeCounter, &! halo counters to reduce
+         cellHaloComputeCounter   ! halo updates during cycling
+
+      real (kind=RKIND) :: &
+         normalThicknessFluxSum, &! sum of thickness flux in column
+         thicknessSum,     &! sum of thicknesses in column
+         thicknessSumCur,  &
+         thicknessSumMid,  &
+         thicknessSumLag,  &
+         flux,             &! temp for computing flux for barotropic
+         sshEdge,          &! sea surface height at edge
+         sshEdgeCur,       &! 
+         sshEdgeMid,       &! 
+         sshEdgeLag,       &! 
+         sshDiffCur,       &! sea surface height difference
+         sshDiffLag,       & 
+         CoriolisTerm,     &! temp for computing coriolis term (fuperp)
+         normalVelocityCorrection, &! velocity correction
+         temp,             &! temp for holding vars at new time
+         temp_h,           &! temporary for phi
+         temp_mask,        &! temporary mask (edgeMask)
+         lat,              &! cell latitude
+         sshCell1,         &! sea sfc height in neighboring cells
+         sshCell2,         &
+         sshCurArea,       &! temp for iterative solver
+         sshLagArea,       &
+         sshTendb1,        &
+         sshTendb2,        &
+         sshTendAx,        &
+         fluxb1,           &
+         fluxb2,           &
+         fluxAx
+
+      real (kind=RKIND), dimension(:), allocatable:: &
+         uTemp
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         btrvel_temp
 
       ! State Array Pointers
-      real (kind=RKIND), dimension(:), pointer :: sshSubcycleCur, sshSubcycleNew
-      real (kind=RKIND), dimension(:), pointer :: sshSubcycleCurWithTides, sshSubcycleNewWithTides
-      real (kind=RKIND), dimension(:), pointer :: normalBarotropicVelocitySubcycleCur, normalBarotropicVelocitySubcycleNew
-      real (kind=RKIND), dimension(:), pointer :: sshCur, sshNew
-      real (kind=RKIND), dimension(:), pointer :: normalBarotropicVelocityCur, normalBarotropicVelocityNew
-      real (kind=RKIND), dimension(:,:), pointer :: normalBaroclinicVelocityCur, normalBaroclinicVelocityNew
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityCur, normalVelocityNew
-      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessCur, layerThicknessNew
-      real (kind=RKIND), dimension(:,:), pointer :: highFreqThicknessCur, highFreqThicknessNew
-      real (kind=RKIND), dimension(:,:), pointer :: lowFreqDivergenceCur, lowFreqDivergenceNew
-      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroupCur, tracersGroupNew
+      real (kind=RKIND), dimension(:), pointer :: &
+         sshSubcycleCur,              &! subcycl ssh    at current time
+         sshSubcycleNew,              &! subcycl ssh    at new     time
+         sshSubcycleCurWithTides,     &! subcycl ssh    at current time
+         sshSubcycleNewWithTides,     &! subcycl ssh    at new     time
+         normalBarotropicVelocitySubcycleCur,&! barotropic vel subcyc
+         normalBarotropicVelocitySubcycleNew,&! at current, new times
+         sshCur,                      &! sea sfc height at current time
+         sshNew,                      &! sea sfc height at new     time
+         normalBarotropicVelocityCur, &! barotropic vel at current time
+         normalBarotropicVelocityNew   ! barotropic vel at new     time
 
-      ! Tend Array Pointers
-      real (kind=RKIND), dimension(:), pointer :: sshTend
-      real (kind=RKIND), dimension(:,:), pointer :: highFreqThicknessTend
-      real (kind=RKIND), dimension(:,:), pointer :: lowFreqDivergenceTend
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocityTend, layerThicknessTend
-      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroupTend, activeTracersTend
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         normalBaroclinicVelocityCur, &! baroclinic vel at current time
+         normalBaroclinicVelocityNew, &! baroclinic vel at new     time
+         normalVelocityCur,           &! full velocity  at current time
+         normalVelocityNew,           &! full velocity  at new     time
+         layerThicknessCur,           &! layer thick    at current time
+         layerThicknessNew,           &! layer thick    at new     time
+         highFreqThicknessCur,        &! high frq thick at current time
+         highFreqThicknessNew,        &! high frq thick at new     time
+         lowFreqDivergenceCur,        &! low frq div    at current time
+         lowFreqDivergenceNew          ! low frq div    at new     time
 
+      type (field1DReal), pointer :: &
+         effectiveDensityField         ! field pointer for halo update
+
+      ! State/Tracer arrays, info
+      real (kind=RKIND), dimension(:,:,:), pointer ::      &!
+         tracersGroupCur,      &! old, new tracer arrays
+         tracersGroupNew
+
+      integer, pointer :: &
+         startIndex, endIndex, &! start, end index for tracer groups
+         indexSalinity          ! tracer index for salinity
+
+      type (mpas_pool_iterator_type) :: &
+         groupItr               ! iterator for tracer groups
+
+      character (len=StrKIND) :: &
+         modifiedGroupName,    &! constructed tracer group names
+         configName             ! constructed config names for tracers
+
+      ! Tendency Array Pointers
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         sshTend                ! sea-surface height tendency
+
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         normalVelocityTend,    &! normal velocity tendency
+         highFreqThicknessTend, &! thickness tendency for high-freq iter
+         lowFreqDivergenceTend, &! thickness tendency for low freq
+         layerThicknessTend      ! main thickness tendency
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: &
+         tracersGroupTend,      &! tendencies for tracer groups
+         activeTracersTend       ! active tracer tendencies
+
+      ! Forcing pool
       real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta
 
       ! Semi-implicit variables
-      real (kind=RKIND), dimension(2) :: CGcst_allreduce2,CGcst_allreduce_global2
-      real (kind=RKIND), dimension(3) :: CGcst_allreduce3,CGcst_allreduce_global3
-      real (kind=RKIND), dimension(5) :: CGcst_allreduce5,CGcst_allreduce_global5
-      real (kind=RKIND), dimension(5) :: CGcst_allreduce_temp5
-      integer          , dimension(5) :: CGcst_allreduce_itemp5
-      real (kind=RKIND) :: CGcst_r00r0       ,CGcst_r00w0       ,CGcst_r00r1       ,CGcst_r00w1
-      real (kind=RKIND) :: CGcst_r00r0_global,CGcst_r00w0_global,CGcst_r00r1_global,CGcst_r00w1_global
-      real (kind=RKIND) :: CGcst_r0r0        ,CGcst_r1r1
-      real (kind=RKIND) :: CGcst_r0r0_global ,CGcst_r1r1_global
-      real (kind=RKIND) :: CGcst_r00s0       ,CGcst_r00z0       ,CGcst_q0y0       ,CGcst_y0y0
-      real (kind=RKIND) :: CGcst_r00s0_global,CGcst_r00z0_global,CGcst_q0y0_global,CGcst_y0y0_global
-      real (kind=RKIND) :: CGcst_alpha0,CGcst_alpha1,CGcst_beta0,CGcst_beta1,CGcst_omega0,CGcst_omega1
-      real (kind=RKIND) :: sshCurArea,sshLagArea,sshTendA,sshTendB,sshTendC,temp1,temp2,resid,wgt
+      real (kind=RKIND), dimension(2) :: &
+         SIcst_allreduce2,       &! array for local  summations
+         SIcst_allreduce_global2  ! array for global summations
+      real (kind=RKIND), dimension(2) :: &
+         SIcst_allreduce_local2   ! array for local  summations
+      real (kind=RKIND), dimension(3) :: &
+         SIcst_allreduce3,       &! array for local  summations
+         SIcst_allreduce_global3  ! array for global summations
+      real (kind=RKIND), dimension(5) :: &
+         SIcst_allreduce5,       &! array for local  summations
+         SIcst_allreduce_global5  ! array for global summations
+      real (kind=RKIND), dimension(9) :: &
+         SIcst_allreduce_local9, &! array for local  summations
+         SIcst_allreduce_global9,&! array for global summations
+         SIcst_allreduce_temp9    !  temp for global summations
+      integer          , dimension(9) :: &
+         SIcst_allreduce_itemp9   !  temp for partition match mode
+      real (kind=RKIND) ::  &
+                                  !  temp scalars for the SI method
+         SIcst_q0y0        , SIcst_y0y0        , SIcst_q0q0        , &
+         SIcst_q0y0_global , SIcst_y0y0_global , SIcst_q0q0_global , &
+         SIcst_r00r0       , SIcst_r00w0       , SIcst_r00w1       , &
+         SIcst_r00r0_global, SIcst_r00w0_global, SIcst_r00w1_global, &
+         SIcst_r00q0       , SIcst_r00t0       , SIcst_r00v0       , &
+         SIcst_r00q0_global, SIcst_r00t0_global, SIcst_r00v0_global, &
+         SIcst_r00y0       , SIcst_r00s0       , SIcst_r00z0       , &
+         SIcst_r00y0_global, SIcst_r00s0_global, SIcst_r00z0_global, &
+         SIcst_alpha0      , SIcst_beta0       , &
+         SIcst_omega0      , SIcst_rho0        , SIcst_rho1        , &
+         SIcst_gamma1,       resid
 
-      ! Field Pointers
-      type (field1DReal), pointer :: effectiveDensityField
+      integer ::     &
+         iter,       &! Number of solver iterations
+         siLargeIter  ! Index of the large btr system iteration
 
-      ! tracer iterators
-      type (mpas_pool_iterator_type) :: groupItr
-      character (len=StrKIND) :: modifiedGroupName
-      character (len=StrKIND) :: configName
-      integer :: threadNum
-      integer :: temp_mask
+      ! These are public variables used from the diagnostics module
+      ! indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
+      ! indexSSHGradientZonal, indexSSHGradientMeridional
+      ! barotropicForcing, barotropicThicknessFlux
+      ! layerThickEdge, normalTransportVelocity, normalGMBolusVelocity
+      ! vertAleTransportTop
+      ! velocityX, velocityY, velocityZ
+      ! velocityZonal, velocityMeridional
+      ! gradSSH, gradSSHX, gradSSHY, gradSSHZ
+      ! gradSSHZonal, gradSSHMeridional
+      ! surfaceVelocity, SSHGradient
+      ! temperatureShortWaveTendency
+      ! activeTracerHorizontalAdvectionTendency
+      ! activeTracerVerticalAdvectionTendency
+      ! activeTracerSurfaceFluxTendency
+      ! activeTracerNonLocalTendency
+      ! activeTracerHorMixTendency
+      ! activeTracerHorizontalAdvectionEdgeFlux
 
-      dminfo = domain % dminfo
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
       call mpas_timer_start("si timestep")
 
-      allocate(n_bcl_iter(config_n_ts_iter))
-
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      !
       !  Prep variables before first iteration
-      !
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
       call mpas_timer_start("si prep")
-      block => domain % blocklist
-      do while (associated(block))
-         call mpas_pool_get_dimension(block % dimensions, 'nCells', nCellsPtr)
-         call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdgesPtr)
-         call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-         call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-         call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
 
-         call mpas_pool_get_subpool(block % structs, 'state', statePool)
-         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      !*** Retrieve model state, pools
+      !*** No longer support sub-blocks so this retrieves the only block
 
-         call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityCur, 1)
-         call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityCur, 1)
-         call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
+      block => domain%blocklist
+      call mpas_pool_get_subpool(block%structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block%structs, 'verticalMesh', &
+                                                 verticalMeshPool)
+      call mpas_pool_get_subpool(block%structs, 'state', &
+                                                 statePool)
+      call mpas_pool_get_subpool(block%structs, 'forcing', &
+                                                 forcingPool)
+      call mpas_pool_get_subpool(block%structs, 'shortwave', &
+                                                 swForcingPool)
+      call mpas_pool_get_subpool(block%structs, 'tend', &
+                                                 tendPool)
+      call mpas_pool_get_subpool(block%structs, 'scratch', &
+                                                 scratchPool)
+      call mpas_pool_get_subpool(statePool, 'tracers', &
+                                             tracersPool)
+      call mpas_pool_get_subpool(tendPool,  'tracersTend', &
+                                             tracersTendPool)
 
-         call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityNew, 2)
-         call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityNew, 2)
-         call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
+      !*** Retrieve state variables at two time levels
 
-         call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
-         call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
+      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
+                                           normalBaroclinicVelocityCur, 1)
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
+                                           normalBarotropicVelocityCur, 1)
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', &
+                                           normalBarotropicVelocitySubcycleCur, 1)
+      call mpas_pool_get_array(statePool, 'normalVelocity', &
+                                           normalVelocityCur, 1)
 
-         call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
-         call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
+      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
+                                           normalBaroclinicVelocityNew, 2)
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
+                                           normalBarotropicVelocityNew, 2)
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', &
+                                           normalBarotropicVelocitySubcycleNew, 2)
+      call mpas_pool_get_array(statePool, 'normalVelocity', &
+                                           normalVelocityNew, 2)
 
-         call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessCur, 1)
-         call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessNew, 2)
+      call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
+      call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
 
-         call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceCur, 1)
-         call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceNew, 2)
+      call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
+      call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
 
-         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-         call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+      call mpas_pool_get_array(statePool, 'layerThickness', &
+                                           layerThicknessCur, 1)
+      call mpas_pool_get_array(statePool, 'layerThickness', &
+                                           layerThicknessNew, 2)
 
-         nCells = nCellsPtr
-         nEdges = nEdgesPtr
+      call mpas_pool_get_array(statePool, 'highFreqThickness', &
+                                           highFreqThicknessCur, 1)
+      call mpas_pool_get_array(statePool, 'highFreqThickness', &
+                                           highFreqThicknessNew, 2)
 
-         ! Initialize * variables that are used to compute baroclinic tendencies below.
+      call mpas_pool_get_array(statePool, 'lowFreqDivergence', &
+                                           lowFreqDivergenceCur, 1)
+      call mpas_pool_get_array(statePool, 'lowFreqDivergence', &
+                                           lowFreqDivergenceNew, 2)
 
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSalinity)
+
+      !*** Retrieve tendency variables
+
+      call mpas_pool_get_array(tendPool, 'highFreqThickness', &
+                                          highFreqThicknessTend)
+      call mpas_pool_get_array(tendPool, 'normalVelocity', &
+                                          normalVelocityTend)
+      call mpas_pool_get_array(tendPool, 'ssh', &
+                                          sshTend)
+      call mpas_pool_get_array(tendPool, 'layerThickness', &
+                                          layerThicknessTend)
+      call mpas_pool_get_array(tendPool, 'normalVelocity', &
+                                          normalVelocityTend)
+      call mpas_pool_get_array(tendPool, 'highFreqThickness', &
+                                          highFreqThicknessTend)
+      call mpas_pool_get_array(tendPool, 'lowFreqDivergence', &
+                                          lowFreqDivergenceTend)
+
+      ! Initialize * variables that are used to compute baroclinic
+      ! tendencies below.
+
+      ! The baroclinic velocity needs be recomputed at the beginning
+      ! of a timestep because the implicit vertical mixing is
+      ! conducted on the total u.  We keep normalBarotropicVelocity
+      ! from the previous timestep.
+      ! Note that normalBaroclinicVelocity may now include a
+      ! barotropic component, because the weights layerThickness
+      ! have changed.  That is OK, because the barotropicForcing
+      ! variable subtracts out the barotropic component from the
+      ! baroclinic.
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+      do iEdge = 1,nEdgesAll
+      do k = 1,nVertLevels
+
+         normalBaroclinicVelocityCur(k,iEdge) = &
+                                 normalVelocityCur(k,iEdge) - &
+                         normalBarotropicVelocityCur(iEdge)
+
+         normalVelocityNew(k,iEdge) = normalVelocityCur(k,iEdge)
+
+         normalBaroclinicVelocityNew(k,iEdge) = &
+         normalBaroclinicVelocityCur(k,iEdge)
+      end do
+      end do
+      !$omp end do
+
+      !$omp do schedule(runtime) private(k)
+      do iCell = 1, nCellsAll
+         sshNew(iCell)         = sshCur(iCell)
+         sshSubcycleCur(iCell) = sshCur(iCell)
+         sshSubcycleNew(iCell) = sshCur(iCell)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
+            layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_pool_begin_iteration(tracersPool)
+      do while ( mpas_pool_get_next_member(tracersPool, groupItr))
+         if ( groupItr % memberType == MPAS_POOL_FIELD ) then
+            call mpas_pool_get_array(tracersPool, groupItr%memberName,&
+                                     tracersGroupCur, 1)
+            call mpas_pool_get_array(tracersPool, groupItr%memberName,&
+                                     tracersGroupNew, 2)
+
+            if ( associated(tracersGroupCur) .and. &
+                 associated(tracersGroupNew) ) then
+
+               !$omp parallel
+               !$omp do schedule(runtime) private(k)
+               do iCell = 1, nCellsAll
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
+                  tracersGroupNew(:,k,iCell) = &
+                  tracersGroupCur(:,k,iCell)
+               end do
+               end do
+               !$omp end do
+               !$omp end parallel
+            end if
+         end if
+      end do
+
+      if (associated(highFreqThicknessNew)) then
          !$omp parallel
          !$omp do schedule(runtime) private(k)
-         do iEdge = 1, nEdges
-            do k = 1, nVertLevels !maxLevelEdgeTop % array(iEdge)
-
-               ! The baroclinic velocity needs be recomputed at the beginning of a
-               ! timestep because the implicit vertical mixing is conducted on the
-               ! total u.  We keep normalBarotropicVelocity from the previous timestep.
-               ! Note that normalBaroclinicVelocity may now include a barotropic component, because the
-               ! weights layerThickness have changed.  That is OK, because the barotropicForcing variable
-               ! subtracts out the barotropic component from the baroclinic.
-               normalBaroclinicVelocityCur(k,iEdge) = normalVelocityCur(k,iEdge) - normalBarotropicVelocityCur(iEdge)
-
-               normalVelocityNew(k,iEdge) = normalVelocityCur(k,iEdge)
-
-               normalBaroclinicVelocityNew(k,iEdge) = normalBaroclinicVelocityCur(k,iEdge)
-            end do
+         do iCell = 1, nCellsAll
+         do k = 1,nVertLevels
+            highFreqThicknessNew(k,iCell) = &
+            highFreqThicknessCur(k,iCell)
          end do
-         !$omp end do
-
-         !$omp do schedule(runtime) private(k)
-         do iCell = 1, nCells
-            sshNew(iCell) = sshCur(iCell)
-            do k = 1, maxLevelCell(iCell)
-               layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
-               ! set vertAleTransportTop to zero for stage 1 velocity tendency, first time through.
-               vertAleTransportTop(k,iCell) = 0.0_RKIND
-            end do
          end do
          !$omp end do
          !$omp end parallel
+      end if
 
-         call mpas_pool_begin_iteration(tracersPool)
-         do while ( mpas_pool_get_next_member(tracersPool, groupItr))
-            if ( groupItr % memberType == MPAS_POOL_FIELD ) then
-               call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupCur, 1)
-               call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupNew, 2)
-
-               if ( associated(tracersGroupCur) .and. associated(tracersGroupNew) ) then
-                  !$omp parallel
-                  !$omp do schedule(runtime) private(k)
-                  do iCell = 1, nCells
-                     do k = 1, maxLevelCell(iCell)
-                        tracersGroupNew(:,k,iCell) = tracersGroupCur(:,k,iCell)
-                     end do
-                  end do
-                  !$omp end do
-                  !$omp end parallel
-               end if
-            end if
+      if (associated(lowFreqDivergenceNew)) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCellsAll
+         do k = 1,nVertLevels
+            lowFreqDivergenceNew(k,iCell) = &
+            lowFreqDivergenceCur(k,iCell)
          end do
-
-
-         if (associated(highFreqThicknessNew)) then
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iCell = 1, nCells
-               highFreqThicknessNew(:, iCell) = highFreqThicknessCur(:, iCell)
-            end do
-            !$omp end do
-            !$omp end parallel
-         end if
-
-         if (associated(lowFreqDivergenceNew)) then
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iCell = 1, nCells
-               lowFreqDivergenceNew(:, iCell) = lowFreqDivergenceCur(:, iCell)
-            end do
-            !$omp end do
-            !$omp end parallel
-         endif
-
-         block => block % next
-      end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      endif
 
       call mpas_timer_stop("si prep")
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      ! BEGIN large iteration loop
+      ! BEGIN large outer timestep iteration loop
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      n_bcl_iter = config_n_bcl_iter_mid
-      n_bcl_iter(1) = config_n_bcl_iter_beg
-      n_bcl_iter(config_n_ts_iter) = config_n_bcl_iter_end
 
-      do split_implicit_step = 1, config_n_ts_iter
+      do splitImplicitStep = 1, numTSIterations
 
-         if (config_disable_thick_all_tend .and. config_disable_vel_all_tend .and. config_disable_tr_all_tend) then
-           exit ! don't compute in loop meant to update velocity, thickness, and tracers
+         if (config_disable_thick_all_tend .and. &
+             config_disable_vel_all_tend .and. &
+             config_disable_tr_all_tend) then
+            exit ! don't compute in loop meant to update velocity,
+                 ! thickness, and tracers
          end if
 
          call mpas_timer_start('si loop')
 
-         stage1_tend_time = min(split_implicit_step,2)
+         stage1_tend_time = min(splitImplicitStep,2)
 
          ! ---  update halos for diagnostic ocean boundary layer depth
          if (config_use_cvmix_kpp) then
@@ -380,7 +556,9 @@ module ocn_time_integration_si
          ! ---  update halos for diagnostic variables
          call mpas_timer_start("si halo diag")
 
-         call mpas_dmpar_field_halo_exch(domain, 'normalizedRelativeVorticityEdge')
+         call mpas_dmpar_field_halo_exch(domain, &
+                                 'normalizedRelativeVorticityEdge')
+
          if (config_mom_del4 > 0.0_RKIND) then
            call mpas_dmpar_field_halo_exch(domain, 'divergence')
            call mpas_dmpar_field_halo_exch(domain, 'relativeVorticity')
@@ -388,192 +566,153 @@ module ocn_time_integration_si
          call mpas_timer_stop("si halo diag")
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         !
-         !  Stage 1: Baroclinic velocity (3D) prediction, explicit with long timestep
-         !
+         !  Stage 1: Baroclinic velocity (3D) prediction, explicit with
+         !           long timestep
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
          if (config_use_freq_filtered_thickness) then
+
             call mpas_timer_start("si freq-filtered-thick computations")
 
+            call ocn_tend_freq_filtered_thickness(tendPool, statePool, &
+                                                  stage1_tend_time)
 
-            block => domain % blocklist
-            do while (associated(block))
-               call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-               call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-               call mpas_pool_get_subpool(block % structs, 'state', statepool)
-               call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-               call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-
-               call ocn_tend_freq_filtered_thickness(tendPool, statePool, stage1_tend_time)
-               block => block % next
-            end do
             call mpas_timer_stop("si freq-filtered-thick computations")
-
 
             call mpas_timer_start("si freq-filtered-thick halo update")
 
-            call mpas_dmpar_field_halo_exch(domain, 'tendHighFreqThickness')
-            call mpas_dmpar_field_halo_exch(domain, 'tendLowFreqDivergence')
+            call mpas_dmpar_field_halo_exch(domain,'tendHighFreqThickness')
+            call mpas_dmpar_field_halo_exch(domain,'tendLowFreqDivergence')
 
             call mpas_timer_stop("si freq-filtered-thick halo update")
 
-            block => domain % blocklist
-            do while (associated(block))
-               call mpas_pool_get_dimension(block % dimensions, 'nCells', nCellsPtr)
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-
-               call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-               call mpas_pool_get_subpool(block % structs, 'state', statePool)
-               call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-               call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-               call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-
-               call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
-               call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessCur, 1)
-               call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessNew, 2)
-
-               call mpas_pool_get_array(tendPool, 'highFreqThickness', highFreqThicknessTend)
-
-               nCells = nCellsPtr
-
-               !$omp parallel
-               !$omp do schedule(runtime) private(k)
-               do iCell = 1, nCells
-                  do k = 1, maxLevelCell(iCell)
-                     ! this is h^{hf}_{n+1}
-                     highFreqThicknessNew(k,iCell) = highFreqThicknessCur(k,iCell) + dt * highFreqThicknessTend(k,iCell)
-                  end do
-               end do
-               !$omp end do
-               !$omp end parallel
-
-               block => block % next
+            !$omp parallel
+            !$omp do schedule(runtime) private(k)
+            do iCell = 1, nCellsAll
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               ! this is h^{hf}_{n+1}
+               highFreqThicknessNew(k,iCell) = &
+               highFreqThicknessCur(k,iCell) + dt* &
+               highFreqThicknessTend(k,iCell)
             end do
+            end do
+            !$omp end do
+            !$omp end parallel
 
-         endif
+         endif ! freq filtered thickness
 
          ! compute velocity tendencies, T(u*,w*,p*)
          call mpas_timer_start("si bcl vel")
-
          call mpas_timer_start('si bcl vel tend')
-         block => domain % blocklist
-         do while (associated(block))
-           call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-           call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-           call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-           call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
-           call mpas_pool_get_subpool(block % structs, 'state', statePool)
-           call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-           call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-           call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
-           call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
-           call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, stage1_tend_time)
-           call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
+         call mpas_pool_get_array(statePool, 'normalVelocity', &
+                           normalVelocityCur, stage1_tend_time)
 
-           call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessNew, 2)
+         ! compute vertAleTransportTop.  Use u (rather than &
+         ! normalTransportVelocity) for momentum advection.
+         ! Use the most recent time level available.
 
-           call ocn_tend_vel(tendPool, statePool, forcingPool, stage1_tend_time, dt)
+         if (associated(highFreqThicknessNew)) then
+            call ocn_vert_transport_velocity_top(meshPool, &
+                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 layerThickEdge, normalVelocityCur, sshCur, dt, &
+                 vertAleTransportTop, err, highFreqThicknessNew)
+         else
+            call ocn_vert_transport_velocity_top(meshPool, &
+                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 layerThickEdge, normalVelocityCur, sshCur, dt, &
+                 vertAleTransportTop, err)
+         endif
 
-           block => block % next
-         end do
+         call ocn_tend_vel(tendPool, statePool, forcingPool, &
+                           stage1_tend_time, dt)
+
          call mpas_timer_stop('si bcl vel tend')
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! BEGIN baroclinic iterations on linear Coriolis term
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         do j=1,n_bcl_iter(split_implicit_step)
 
-            ! Use this G coefficient to avoid an if statement within the iEdge loop.
-            split = 1
+         do j=1,numClinicIterations(splitImplicitStep)
 
             call mpas_timer_start('bcl iters on linear Coriolis')
-            block => domain % blocklist
-            do while (associated(block))
-               call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdgesPtr)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
 
-               call mpas_pool_get_subpool(block % structs, 'state', statePool)
-               call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-               call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-               call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-               call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
+            ! Put f*normalBaroclinicVelocity^{perp} in
+            ! normalVelocityNew as a work variable
+            call ocn_fuperp(statePool, meshPool, 2)
 
-               call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-               call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
-               call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-               call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
+            !TODO: look at loop optimizations here
+            ! Only need to loop over owned cells, since there is a halo
+            ! exchange immediately after this computation.
 
-               call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
-               call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityCur, 1)
-               call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityNew, 2)
-               call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
+            allocate(uTemp(nVertLevels))
 
-               call mpas_pool_get_array(tendPool, 'normalVelocity', normalVelocityTend)
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(k, cell1, cell2, uTemp, &
+            !$omp         normalThicknessFluxSum, thicknessSum)
+            do iEdge = 1, nEdgesOwned
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               ! could put this after with 
+               ! uTemp(maxleveledgetop+1:nvertlevels)=0
+               uTemp = 0.0_RKIND
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
-               ! Only need to loop over the 1 halo, since there is a halo exchange immediately after this computation.
-               nEdges = nEdgesArray( 1 )
+                  ! normalBaroclinicVelocityNew =
+                  ! normalBaroclinicVelocityOld +
+                  !                dt*(-f*normalBaroclinicVelocityPerp
+                  !                    + T(u*,w*,p*) + g*grad(SSH*) )
+                  ! Here uNew is a work variable containing
+                  !  -fEdge(iEdge)*normalBaroclinicVelocityPerp(k,iEdge)
+                  uTemp(k) = normalBaroclinicVelocityCur(k,iEdge) &
+                           + dt * (normalVelocityTend(k,iEdge) &
+                           + normalVelocityNew(k,iEdge) &
+                           + gravity * &
+                             (sshNew(cell2) - sshNew(cell1)) &
+                             /dcEdge(iEdge) )
+               enddo ! vertical
 
-               ! Put f*normalBaroclinicVelocity^{perp} in normalVelocityNew as a work variable
-               call ocn_fuperp(statePool, meshPool, 2)
+               ! thicknessSum is initialized outside the loop because
+               ! on land boundaries maxLevelEdgeTop=0, but we want to
+               ! initialize thicknessSum with a nonzero value to avoid
+               ! a NaN.
+               normalThicknessFluxSum =                          &
+                    layerThickEdge(minLevelEdgeBot(iEdge),iEdge) &
+                  * uTemp(minLevelEdgeBot(iEdge))
+               thicknessSum = &
+                    layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
 
-               allocate(uTemp(nVertLevels))
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
+                  normalThicknessFluxSum = normalThicknessFluxSum + &
+                                 layerThickEdge(k,iEdge)*uTemp(k)
+                  thicknessSum = thicknessSum + &
+                                 layerThickEdge(k,iEdge)
+               enddo
+               barotropicForcing(iEdge) = &
+                              normalThicknessFluxSum/thicknessSum/dt
 
-               !$omp parallel
-               !$omp do schedule(runtime) private(cell1, cell2, uTemp, k, normalThicknessFluxSum, &
-               !$omp             thicknessSum)
-               do iEdge = 1, nEdges
-                  cell1 = cellsOnEdge(1,iEdge)
-                  cell2 = cellsOnEdge(2,iEdge)
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+                  ! These two steps are together here:
+                  !{\bf u}'_{k,n+1} =
+                  !    {\bf u}'_{k,n} - \Delta t {\overline {\bf G}}
+                  !{\bf u}'_{k,n+1/2} = \frac{1}{2}\left(
+                  !        {\bf u}^{'}_{k,n} +{\bf u}'_{k,n+1}\right)
+                  ! so that normalBaroclinicVelocityNew is at time n+1/2
+                  normalBaroclinicVelocityNew(k,iEdge) = 0.5_RKIND*( &
+                  normalBaroclinicVelocityCur(k,iEdge) + uTemp(k) - &
+                         dt * barotropicForcing(iEdge))
+               enddo
 
-                  uTemp = 0.0_RKIND  ! could put this after with uTemp(maxleveledgetop+1:nvertlevels)=0
-                  do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            enddo ! iEdge
+            !$omp end do
+            !$omp end parallel
 
-                     ! normalBaroclinicVelocityNew = normalBaroclinicVelocityOld + dt*(-f*normalBaroclinicVelocityPerp
-                     !                             + T(u*,w*,p*) + g*grad(SSH*) )
-                     ! Here uNew is a work variable containing -fEdge(iEdge)*normalBaroclinicVelocityPerp(k,iEdge)
-                      uTemp(k) = normalBaroclinicVelocityCur(k,iEdge) &
-                         + dt * (normalVelocityTend(k,iEdge) &
-                         + normalVelocityNew(k,iEdge) &  ! this is f*normalBaroclinicVelocity^{perp}
-                         + split * gravity * (  sshNew(cell2) - sshNew(cell1) ) &
-                          / dcEdge(iEdge) )
-                  enddo
-
-                  ! thicknessSum is initialized outside the loop because on land boundaries
-                  ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
-                  ! nonzero value to avoid a NaN.
-                  normalThicknessFluxSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge) * uTemp(minLevelEdgeBot(iEdge))
-                  thicknessSum  = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
-
-                  do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                     normalThicknessFluxSum = normalThicknessFluxSum + layerThickEdge(k,iEdge) * uTemp(k)
-                     thicknessSum  =  thicknessSum + layerThickEdge(k,iEdge)
-                  enddo
-                  barotropicForcing(iEdge) = split * normalThicknessFluxSum / thicknessSum / dt
-
-
-                  do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-                     ! These two steps are together here:
-                     !{\bf u}'_{k,n+1} = {\bf u}'_{k,n} - \Delta t {\overline {\bf G}}
-                     !{\bf u}'_{k,n+1/2} = \frac{1}{2}\left({\bf u}^{'}_{k,n} +{\bf u}'_{k,n+1}\right)
-                     ! so that normalBaroclinicVelocityNew is at time n+1/2
-                     normalBaroclinicVelocityNew(k,iEdge) = 0.5_RKIND*( &
-                       normalBaroclinicVelocityCur(k,iEdge) + uTemp(k) - dt * barotropicForcing(iEdge))
-                  enddo
-               enddo ! iEdge
-               !$omp end do
-               !$omp end parallel
-
-               deallocate(uTemp)
-
-               block => block % next
-            end do
+            deallocate(uTemp)
 
             call mpas_timer_start("si halo normalBaroclinicVelocity")
-            call mpas_dmpar_field_halo_exch(domain, 'normalBaroclinicVelocity', timeLevel=2)
+            call mpas_dmpar_field_halo_exch(domain, &
+                              'normalBaroclinicVelocity', timeLevel=2)
             call mpas_timer_stop("si halo normalBaroclinicVelocity")
 
             call mpas_timer_stop('bcl iters on linear Coriolis')
@@ -585,1991 +724,1770 @@ module ocn_time_integration_si
          call mpas_timer_stop('si halo barotropicForcing')
 
          call mpas_timer_stop("si bcl vel")
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! END baroclinic iterations on linear Coriolis term
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         ! Stage 2: Barotropic velocity (2D) prediction, semi-implicit
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          !
-         !  Stage 2: Barotropic velocity (2D) prediction, semi-implicit
+         ! The semi-implicit barotropic mode solver
+         !    - uses the preconditioned communication-avoiding
+         !      (single-reduction) BiCGStab method 
+         !      (Cool and Vanroose, 2017) as a linear iterative solver
+         !                    
+         !    - solves the nonlinear barotropic system but deals with
+         !      it as the linear system by introducing the outer and                     
+         !      inner solver iteration (the solver matrix is updated                    
+         !      for every time step and inner solver iteration.)                    
+         !                    
+         !    - works with 'ras', 'block_jacobi', 'jacobi', 'none'
+         !      preconditioners
+         !                    
+         !    - consists of seven substages                    
+         !         :Stage 2.1. Initialization and preparation of vars
+         !                     before outer iterations
+         !          Stage 2.2. Computation of the initial residual
+         !          Stage 2.3. The outer solver iteration
+         !          Stage 2.4. The barotropic velocity update
+         !          Stage 2.5. Re-computation of the initial residual
+         !                     using lagged values
+         !          Stage 2.6. Main (inner) solver iterations to 
+         !                     obtain SSH at time (n+1) 
+         !          Stage 2.7. The barotropic velocity update
          !
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         !    - requires 'config_n_ts_iter=2'
+         !         :Time line of variables
          !
-         ! Stage 2.1 : Preparation of varibales before outer two iterations
+         !          Start of large outer time step iteration loop
+         !             splitImplicitStep=1
+         !             |  SSH and BtrVel at time (n)
+         !             |  |  -> Advancing the barotropic system
+         !             |  |     -> SSH and BtrVel at time (n+1)
+         !             |  |        -> Averaging between time (n) 
+         !             |  |                         and time (n+1)
+         !             |  SSH and BtrVel at time (n+1/2)
+         !             |
+         !             splitImplicitStep=2
+         !                SSH and BtrVel at time (n+1/2)
+         !                |  -> Advancing the barotropic system
+         !                |     -> SSH and BtrVel at time (n+3/2)
+         !                |        -> Averaging between time (n+1/2)
+         !                |                         and time (n+3/2)
+         !                SSH and BtrVel at time (n+1)
          !
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         !
+         ! Reference: Kang et al. (2021): A scalable semi-implicit
+         !            barotropic mode solver for the MPAS-Ocean, JAMES
+         !
+         !
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         ! Stage 2.1 : Preparation of variables before outer iterations
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
          call mpas_timer_start("si btr vel")
 
          cellHaloComputeCounter = config_num_halos
          edgeHaloComputeCounter = config_num_halos + 1
 
-         ! Initialize variables for barotropic subcycling
-         call mpas_timer_start('btr vel si init')
+         nCells = nCellsHalo(cellHaloComputeCounter-1)
+         nEdges = nEdgesHalo(edgeHaloComputeCounter-1)
 
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
+         if (config_filter_btr_mode) then
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdges
+               barotropicForcing(iEdge) = 0.0_RKIND
+            end do
+            !$omp end do
+            !$omp end parallel
+         endif
 
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
+         !-------------------------------------------------------------!
+         ! BEGIN Large barotropic system iteration loop
+         !-------------------------------------------------------------!
+         do siLargeIter = 1, nSiLargeIter
+         !-------------------------------------------------------------!
 
-            call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', nEdgesOnEdge)
-            call mpas_pool_get_array(meshPool, 'edgesOnEdge', edgesOnEdge)
-            call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
-            call mpas_pool_get_array(meshPool, 'fEdge' , fEdge)
-
-            call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
-            call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
-            call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityCur, 1)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', normalBarotropicVelocitySubcycleCur, 1)
-
-            nCells = nCellsArray(cellHaloComputeCounter)
-            nEdges = nEdgesArray(edgeHaloComputeCounter)
-
-            if (config_filter_btr_mode) then
+            ! Initialize variables for barotropic subcycling
+            call mpas_timer_start('btr vel si init')
+   
+            if ( splitImplicitStep == 2 .or. siLargeIter > 1 ) then
+               ! Here sshSubcycleNew and normalBarotropicVelocityCur
+               ! are at time n+1/2.
+   
                !$omp parallel
                !$omp do schedule(runtime)
-               do iEdge = 1, nEdges
-                  barotropicForcing(iEdge) = 0.0_RKIND
+               do iCell = 1,nCellsAll
+                  sshSubcycleNew(iCell) = &
+                     0.5_RKIND*( sshSubcycleNew(iCell) &
+                                +sshCur(iCell) )
+                  sshSubcycleCur(iCell) = sshSubcycleNew(iCell)
+               end do
+               !$omp end do
+   
+               !$omp do schedule(runtime)
+               do iEdge = 1,nEdgesAll
+                  normalBarotropicVelocityCur(iEdge) = &
+                     normalBarotropicVelocitySubcycleCur(iEdge)
                end do
                !$omp end do
                !$omp end parallel
-            endif
-
-            if ( split_implicit_step == 1 ) then
-                       sshNew(:) = sshCur(:)
-               sshSubcycleCur(:) = sshCur(:)
-               normalBarotropicVelocitySubcycleCur(:) = normalBarotropicVelocityCur(:)
-            else
-               if ( si_opt == 1 ) then
-                       sshNew(:) = sshCur(:)
-               sshSubcycleCur(:) = sshCur(:)
-               normalBarotropicVelocitySubcycleCur(:) = normalBarotropicVelocityCur(:)
-               else
-                       sshCur(:) = sshNew(:)
-               sshSubcycleCur(:) = sshNew(:)
-               normalBarotropicVelocityCur(:) = normalBarotropicVelocitySubcycleCur(:)
-               endif
-            endif ! split_implicit_step
-
+            endif ! splitImplicitStep
+   
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-            do iEdge = 1, nEdges
+            do iEdge = 1, nEdgesAll
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.d0
                do i = 1, nEdgesOnEdge(iEdge)
                   eoe = edgesOnEdge(i,iEdge)
                   CoriolisTerm = CoriolisTerm + weightsOnEdge(i,iEdge) &
-                               * normalBarotropicVelocityCur(eoe) * fEdge(eoe)
+                               * normalBarotropicVelocityCur(eoe)      &
+                               * fEdge(eoe)
                end do ! i
                   barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do ! iEdge
             !$omp end do
             !$omp end parallel
-
-            block => block % next
-         end do  ! block
-
-         ! Subtract tidal potential from ssh, if needed
-         !   Subtract the tidal potential from the current subcycle ssh and store and a work array.
-         !   Then point sshSubcycleCur to the work array so the tidal potential terms are included
-         !   in the grad operator inside the edge loop.
-         if (config_use_tidal_potential_forcing) then
-
-            block => domain % blocklist
-            do while (associated(block))
-               call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdgesPtr)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-               call mpas_pool_get_subpool(block % structs, 'state', statePool)
-               call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-               call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-
-               call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-               call mpas_pool_get_array(forcingPool, 'sshSubcycleCurWithTides', sshSubcycleCurWithTides)
-               call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', tidalPotentialEta)
-               call mpas_pool_get_dimension(block % dimensions, 'nCells', nCellsPtr)
-
-               nCells = nCellsPtr
-               do iCell = 1, nCells
-                 sshSubcycleCurWithTides(iCell) = sshSubcycleCur(iCell) - tidalPotentialEta(iCell) &
-                                                - config_self_attraction_and_loading_beta * sshSubcycleCur(iCell)
+   
+            ! Subtract tidal potential from ssh, if needed
+            ! Subtract the tidal potential from the current
+            !    subcycle ssh and store and a work array.
+            ! Then point sshSubcycleCur to the work array so the
+            ! tidal potential terms are included in the grad
+            ! operator inside the edge loop.
+            if (config_use_tidal_potential_forcing) then
+   
+               call mpas_pool_get_array(forcingPool,            &
+                                     'sshSubcycleCurWithTides', &
+                                      sshSubcycleCurWithTides)
+               call mpas_pool_get_array(forcingPool,        &
+                                       'tidalPotentialEta', &
+                                        tidalPotentialEta)
+   
+               !$omp parallel
+               !$omp do schedule(runtime)
+               do iCell = 1, nCellsAll
+                 sshSubcycleCurWithTides(iCell) = sshSubcycleCur(iCell) &
+                            - tidalPotentialEta(iCell)                  &
+                            - config_self_attraction_and_loading_beta   &
+                            * sshSubcycleCur(iCell)
                end do
-
-               call mpas_pool_get_array(forcingPool, 'sshSubcycleCurWithTides', sshSubcycleCur)
-
-               block => block % next
-            end do  ! block
-
-         endif !config_use_tidal_potential_forcing
-
-         call mpas_timer_stop('btr vel si init')
-
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         !
-         ! Stage 2.2 : Compute initial residual
-         !
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-         call mpas_timer_start("si btr residual")
-
-         ! SpMV -----------------------------------------------------------------------------------!
-
-         block => domain % blocklist
-         do while (associated(block))
-
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-            call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-            call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-            call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-            call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-            call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-            call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-            call mpas_pool_get_array(statePool, 'ssh', sshCur,1)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityCur,1)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
-            do iCell = 1, nCells
+               !$omp end do
+               !$omp end parallel
+   
+               call mpas_pool_get_array(forcingPool,            &
+                                     'sshSubcycleCurWithTides', &
+                                      sshSubcycleNew)
+   
+               !$omp parallel
+               !$omp do schedule(runtime)
+               do iCell = 1,nCellsAll
+                  sshSubcycleCur(iCell) = sshSubcycleNew(iCell)
+               end do
+               !$omp end do
+               !$omp end parallel
+   
+            endif !config_use_tidal_potential_forcing
+   
+            call mpas_timer_stop('btr vel si init')
+   
+   
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            ! Stage 2.2 : Compution of the initial residual
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   
+            call mpas_timer_start("si btr residual")
+   
+            do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
                sshTendAx = 0.0_RKIND
-
+   
                do i = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
-
+   
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
-
+   
                   ! Interpolation sshEdge
-                  sshEdgeCur = 0.5_RKIND * (sshCur(cell1) + sshCur(cell2))
-
-                  ! method 1, matches method 0 without pbcs, works with pbcs.
-                  thicknessSumCur = si_ismf * sshEdgeCur + min(bottomDepth(cell1), bottomDepth(cell2))
-
+                  sshEdgeCur = 0.5_RKIND * ( sshSubcycleCur(cell1)  &
+                                           + sshSubcycleCur(cell2) )
+   
+                  ! method 1, matches method 0 without pbcs, 
+                  ! works with pbcs.
+                  thicknessSumCur = si_ismf * sshEdgeCur    &
+                                  + min(bottomDepth(cell1), &
+                                        bottomDepth(cell2))
+   
                   ! nabla (ssh^0)
-                  sshDiffCur = (  sshCur(cell2) -   sshCur(cell1)) / dcEdge(iEdge)
-
-                  fluxb1 = thicknessSumCur * normalBarotropicVelocityCur(iEdge)
-                  fluxb2 = thicknessSumCur * (alpha2*gravity*sshDiffCur + (-barotropicCoriolisTerm(iEdge)-barotropicForcing(iEdge)))
+                  sshDiffCur = (  sshSubcycleCur(cell2)   &
+                                - sshSubcycleCur(cell1) ) &
+                               /  dcEdge(iEdge)
+   
+                  fluxb1 = thicknessSumCur &
+                         * normalBarotropicVelocityCur(iEdge)
+                  fluxb2 = thicknessSumCur                    &
+                         * (alpha2*gravity*sshDiffCur         &
+                         + (-barotropicCoriolisTerm(iEdge)    &
+                            -barotropicForcing(iEdge)))
                   fluxAx = thicknessSumCur * sshDiffCur
-
-                  sshTendb1 = sshTendb1 + edgeSignOnCell(i, iCell) * fluxb1 * dvEdge(iEdge)
-                  sshTendb2 = sshTendb2 + edgeSignOnCell(i, iCell) * fluxb2 * dvEdge(iEdge)
-                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
+   
+                  sshTendb1 = sshTendb1 + edgeSignOnCell(i, iCell) &
+                                        * fluxb1 * dvEdge(iEdge)
+                  sshTendb2 = sshTendb2 + edgeSignOnCell(i, iCell) &
+                                        * fluxb2 * dvEdge(iEdge)
+                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                                        * fluxAx * dvEdge(iEdge)
                end do ! i
-
-               sshTendb1  = R1_alpha1s_g_dt(split_implicit_step) * sshTendb1
-               sshTendb2  = R1_alpha1_g * sshTendb2
-               sshCurArea = R1_alpha1s_g_dts(split_implicit_step) *   sshCur(iCell) * areaCell(iCell)
-
-               CGvec_r0(iCell) = (-sshCurArea - sshTendb1 + sshTendb2)   &
+   
+               sshTendb1  = R1_alpha1s_g_dt  * sshTendb1
+               sshTendb2  = R1_alpha1_g      * sshTendb2
+               sshCurArea = R1_alpha1s_g_dts * sshSubcycleCur(iCell) &
+                                             * areaCell(iCell)
+   
+               SIvec_r0(iCell) = (-sshCurArea - sshTendb1 + sshTendb2) &
                                 -(-sshCurArea - sshTendAx)
-               CGvec_r00(iCell) = CGvec_r0(iCell)
+               SIvec_r00(iCell) = SIvec_r0(iCell)
+   
             end do ! iCell
-
-            block => block % next
-         end do  ! block
-
-
-         ! Preconditioning ------------------------------------------------------------------------!
-
-         if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-            call mpas_timer_start("si halo r0")
-            call mpas_dmpar_exch_group_create(domain, iterGroupName)
-            call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_r0', 1)
-            call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-            call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-            call mpas_timer_stop("si halo r0")
-         end if
-
-         block => domain % blocklist
-         do while (associated(block))
-
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
+   
+            ! Preconditioning --------------------------------------------!
+   
             if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               ! RAS preconditioning: Use BLAS for symmetric matrix-vector multiplication
+               ! RAS preconditioning: Use BLAS for the symmetric 
+               !                      matrix-vector multiplication
 #ifdef USE_LAPACK
-               call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_r0(1:nPrecVec),1,0.0_RKIND,CGvec_rh0(1:nPrecVec),1)
+               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_r0(1:nPrecVec) , 1, 0.0_RKIND,  &
+                          SIvec_rh0(1:nPrecVec), 1)
 #endif
-
-            elseif ( trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
-               ! Block-Jacobi preconditioning: Use BLAS for symmetric matrix-vector multiplication
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                              'block_jacobi' ) then
+               ! Block-Jacobi preconditioning: Use BLAS for the symmetric 
+               !                               matrix-vector multiplication
 #ifdef USE_LAPACK
-               call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_r0(1:nPrecVec),1,0.0_RKIND,CGvec_rh0(1:nPrecVec),1)
+               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_r0(1:nPrecVec) , 1, 0.0_RKIND,  &
+                          SIvec_rh0(1:nPrecVec), 1)
 #endif
-
-            elseif ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                                    'jacobi' ) then
                ! Jacobi preconditioning
-               CGvec_rh0(1:nPrecVec) = CGvec_r0(1:nPrecVec) * prec_ivmat(1:nPrecVec)
-
-            elseif ( trim(config_btr_si_preconditioner) == 'none' ) then
+               SIvec_rh0(1:nPrecVec) = SIvec_r0(1:nPrecVec) &
+                                     * prec_ivmat(1:nPrecVec)
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                                      'none' ) then
                ! No preconditioning
-               CGvec_rh0(1:nPrecVec) = CGvec_r0(1:nPrecVec)
+               SIvec_rh0(1:nPrecVec) = SIvec_r0(1:nPrecVec)
             end if
-
-            block => block % next
-         end do  ! block
-
-         call mpas_timer_start("si halo r0")
-         call mpas_dmpar_exch_group_create(domain, iterGroupName)
-         call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_rh0', 1)
-         call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-         call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-         call mpas_timer_stop("si halo r0")
-
-
-         ! SpMV -----------------------------------------------------------------------------------!
-
-         block => domain % blocklist
-         do while (associated(block))
-
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-            call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-            call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-            call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-            call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-            call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell', refBottomDepthTopOfCell)
-            call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-            call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-            call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-            call mpas_pool_get_array(statePool, 'ssh', sshCur,1)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
-            CGcst_r00r0 = 0.0_RKIND
-            CGcst_r00w0 = 0.0_RKIND
-
-            do iCell = 1, nCells
-
+   
+            call mpas_timer_start("si halo r0")
+            call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh0')
+            call mpas_timer_stop("si halo r0")
+   
+            ! SpMV -------------------------------------------------------!
+   
+            do iCell = 1, nPrecVec
+   
                sshTendAx = 0.0_RKIND
-
+   
                do i = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
-
+   
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
-
+   
                   ! Interpolation sshEdge
-                  sshEdgeCur = 0.5_RKIND * (sshCur(cell1) + sshCur(cell2))
-
-                  ! method 1, matches method 0 without pbcs, works with pbcs.
-                  thicknessSumCur = si_ismf * sshEdgeCur + min(bottomDepth(cell1), bottomDepth(cell2))
-
+                  sshEdgeCur = 0.5_RKIND * (  sshSubcycleCur(cell1) &
+                                            + sshSubcycleCur(cell2))
+   
+                  ! method 1, matches method 0 without pbcs,
+                  ! works with pbcs.
+                  thicknessSumCur = si_ismf * sshEdgeCur    &
+                                  + min(bottomDepth(cell1), &
+                                        bottomDepth(cell2))
+   
                   ! nabla (ssh^0)
-                  sshDiffCur = (CGvec_rh0(cell2)- CGvec_rh0(cell1)) / dcEdge(iEdge)
+                  sshDiffCur = (SIvec_rh0(cell2)- SIvec_rh0(cell1)) &
+                             / dcEdge(iEdge)
                       fluxAx = thicknessSumCur * sshDiffCur
-                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
-
+                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                             * fluxAx * dvEdge(iEdge)
                end do ! i
-
-               sshCurArea = (1.0_RKIND/(gravity*dt_si(split_implicit_step)**2.0*alpha1**2.0)) * CGvec_rh0(iCell) * areaCell(iCell)
-
-               CGvec_w0(iCell) = -sshCurArea - sshTendAx
-
-               CGcst_r00r0 = CGcst_r00r0 + CGvec_r00(iCell) * CGvec_r0(iCell)
-               CGcst_r00w0 = CGcst_r00w0 + CGvec_r00(iCell) * CGvec_w0(iCell)
-
+   
+               sshCurArea = (1.0_RKIND/(gravity*dt_si**2.0*alpha1**2.0)) &
+                          * SIvec_rh0(iCell) * areaCell(iCell)
+   
+               SIvec_w0(iCell) = -sshCurArea - sshTendAx
+   
             end do ! iCell
-
-            block => block % next
-         end do  ! block
-
-
-         ! Preconditioning ------------------------------------------------------------------------!
-
-         if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-            call mpas_timer_start("si halo r0")
-            call mpas_dmpar_exch_group_create(domain, iterGroupName)
-            call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_w0', 1)
-            call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-            call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-            call mpas_timer_stop("si halo r0")
-         end if
-
-         block => domain % blocklist
-         do while (associated(block))
-
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
+   
+   
+            ! Preconditioning --------------------------------------------!
+   
             if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               ! RAS preconditioning: Use BLAS for symmetric matrix-vector multiplication
+               ! RAS preconditioning: Use BLAS
+               ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-               call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_w0(1:nPrecVec),1,0.0_RKIND,CGvec_wh0(1:nPrecVec),1)
+               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_w0(1:nPrecVec) , 1, 0.0_RKIND,  &
+                          SIvec_wh0(1:nPrecVec), 1)
 #endif
-
-            elseif ( trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
-               ! Block-Jacobi preconditioning: Use BLAS for symmetric matrix-vector multiplication
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                              'block_jacobi' ) then
+               ! Block-Jacobi preconditioning: Use BLAS 
+               ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-               call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_w0(1:nPrecVec),1,0.0_RKIND,CGvec_wh0(1:nPrecVec),1)
+               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_w0(1:nPrecVec), 1, 0.0_RKIND,   &
+                          SIvec_wh0(1:nPrecVec),1)
 #endif
-
-            elseif ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                                    'jacobi' ) then
                ! Jacobi preconditioning
-               CGvec_wh0(1:nPrecVec) = CGvec_w0(1:nPrecVec) * prec_ivmat(1:nPrecVec)
-
-            elseif ( trim(config_btr_si_preconditioner) == 'none' ) then
+               SIvec_wh0(1:nPrecVec) = SIvec_w0(1:nPrecVec) &
+                                     * prec_ivmat(1:nPrecVec)
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                                      'none' ) then
                ! No preconditioning
-               CGvec_wh0(1:nPrecVec) = CGvec_w0(1:nPrecVec)
+               SIvec_wh0(1:nPrecVec) = SIvec_w0(1:nPrecVec)
             end if
-
-            block => block % next
-         end do  ! block
-
-         call mpas_timer_start("si halo r0")
-         call mpas_dmpar_exch_group_create(domain, iterGroupName)
-         call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_wh0', 1)
-         call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-         call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-         call mpas_timer_stop("si halo r0")
-
-
-         ! SpMV -----------------------------------------------------------------------------------!
-
-         block => domain % blocklist
-         do while (associated(block))
-
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-            call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-            call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-            call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-            call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-            call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-            call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-            call mpas_pool_get_array(statePool, 'ssh', sshCur,1)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
-            do iCell = 1, nCells
-
+   
+            call mpas_timer_start("si halo r0")
+            call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
+            call mpas_timer_stop("si halo r0")
+   
+   
+            ! SpMV -------------------------------------------------------!
+   
+            do iCell = 1, nPrecVec
+   
                sshTendAx = 0.0_RKIND
-
+   
                do i = 1, nEdgesOnCell(iCell)
-
+   
                   iEdge = edgesOnCell(i, iCell)
-
+   
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
-
+   
                   ! Interpolation sshEdge
-                  sshEdgeCur = 0.5_RKIND * (sshCur(cell1) + sshCur(cell2))
-
-                  ! method 1, matches method 0 without pbcs, works with pbcs.
-                  thicknessSumCur = si_ismf * sshEdgeCur + min(bottomDepth(cell1), bottomDepth(cell2))
-
+                  sshEdgeCur = 0.5_RKIND * (  sshSubcycleCur(cell1) &
+                                            + sshSubcycleCur(cell2))
+   
+                  ! method 1, matches method 0 without pbcs,
+                  ! works with pbcs.
+                  thicknessSumCur = si_ismf * sshEdgeCur    &
+                                  + min(bottomDepth(cell1), &
+                                        bottomDepth(cell2))
+   
                   ! nabla (ssh^0)
-                  sshDiffCur = (CGvec_wh0(cell2)- CGvec_wh0(cell1)) / dcEdge(iEdge)
-
-                      fluxAx = thicknessSumCur * sshDiffCur
-                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
-
+                  sshDiffCur = (SIvec_wh0(cell2)- SIvec_wh0(cell1)) &
+                             / dcEdge(iEdge)
+   
+                  fluxAx = thicknessSumCur * sshDiffCur
+   
+                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                            * fluxAx * dvEdge(iEdge)
                end do ! i
-
-               sshCurArea = R1_alpha1s_g_dts(split_implicit_step) * CGvec_wh0(iCell) * areaCell(iCell)
-
-               CGvec_t0(iCell) = -sshCurArea - sshTendAx
-
-               CGvec_ph0(iCell) = 0.0_RKIND
-               CGvec_v0(iCell)  = 0.0_RKIND
-               CGvec_sh0(iCell) = 0.0_RKIND
-               CGvec_z0(iCell)  = 0.0_RKIND
-               CGvec_zh0(iCell) = 0.0_RKIND
-               CGvec_v0(iCell)  = 0.0_RKIND
-               CGvec_s0(iCell)  = 0.0_RKIND
-
+   
+               sshCurArea = R1_alpha1s_g_dts * SIvec_wh0(iCell) &
+                          * areaCell(iCell)
+   
+               SIvec_t0(iCell) = -sshCurArea - sshTendAx
+   
+               SIvec_ph0(iCell) = 0.0_RKIND
+               SIvec_sh0(iCell) = 0.0_RKIND
+               SIvec_z0(iCell)  = 0.0_RKIND
+               SIvec_zh0(iCell) = 0.0_RKIND
+               SIvec_v0(iCell)  = 0.0_RKIND
+               SIvec_s0(iCell)  = 0.0_RKIND
+   
             end do ! iCell
-
-            block => block % next
-         end do  ! block
-
-         CGcst_allreduce2(1) = CGcst_r00r0
-         CGcst_allreduce2(2) = CGcst_r00w0
-
-         ! Global sum across CPUs
-         call mpas_timer_start("si reduction r0")
-         call mpas_dmpar_sum_real_array(dminfo, 2, CGcst_allreduce2, CGcst_allreduce_global2)
-         call mpas_timer_stop ("si reduction r0")
-
-         if ( config_btr_si_partition_match_mode .and. ncpus > 1) then
-            CGcst_allreduce_temp5(:)    = 0.0_RKIND
-            CGcst_allreduce_itemp5(:)   = 0.0_RKIND
-            CGcst_allreduce_itemp5(1:2) = exponent(CGcst_allreduce_global2(:))
-            CGcst_allreduce_temp5(1:2)  = fraction(CGcst_allreduce_global2(:))
-            CGcst_allreduce_temp5(1:2)  = anint(CGcst_allreduce_temp5(1:2)*1.0000000000000000d+8)/1.0000000000000000d+8
-            CGcst_allreduce_global2(:)  = CGcst_allreduce_temp5(1:2) * 2.0_RKIND ** (CGcst_allreduce_itemp5(1:2))
-         endif
-
-         CGcst_r00r0_global = CGcst_allreduce_global2(1)
-         CGcst_r00w0_global = CGcst_allreduce_global2(2)
-
-         CGcst_alpha0 = CGcst_r00r0_global / CGcst_r00w0_global
-         CGcst_beta0  = 0.0_RKIND
-         CGcst_omega0 = 0.0_RKIND
-
-
-         call mpas_timer_stop("si btr residual")
-
-
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         !
-         ! Stage 2.3 : Outer iterations - lagged values are sufficiently up to date
-         !
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-         call mpas_timer_start("si btr iteration")
-
-         !**************************************************************!
-         do iter = 1,config_n_btr_si_outer_iter
-         !**************************************************************!
-
-            block => domain % blocklist
-            do while (associated(block))
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-               call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-               call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
-               do iCell = 1, nCells
-                  CGvec_ph1(iCell) = CGvec_rh0(iCell) + CGcst_beta0  * (CGvec_ph0(iCell)-CGcst_omega0*CGvec_sh0(iCell))
-                  CGvec_s1(iCell)  = CGvec_w0(iCell)  + CGcst_beta0  * (CGvec_s0(iCell)-CGcst_omega0*CGvec_z0(iCell))
-    	          CGvec_sh1(iCell) = CGvec_wh0(iCell) + CGcst_beta0  * (CGvec_sh0(iCell)-CGcst_omega0*CGvec_zh0(iCell))
-    	          CGvec_z1(iCell)  = CGvec_t0(iCell)  + CGcst_beta0  * (CGvec_z0(iCell)-CGcst_omega0*CGvec_v0(iCell))
-    	          CGvec_q0(iCell)  = CGvec_r0(iCell)  - CGcst_alpha0 * CGvec_s1(iCell)
-                  CGvec_qh0(iCell) = CGvec_rh0(iCell) - CGcst_alpha0 * CGvec_sh1(iCell)
-    	          CGvec_y0(iCell)  = CGvec_w0(iCell)  - CGcst_alpha0 * CGvec_z1(iCell)
-               end do ! iCell
-
-
-               ! Begin reduction --------------------------------------------------------------------!
-
-               CGcst_q0y0  = 0.0_RKIND
-               CGcst_y0y0  = 0.0_RKIND
-               CGcst_r00r0 = 0.0_RKIND
-
-               do iCell = 1,nCells
-                  CGcst_q0y0  = CGcst_q0y0  + CGvec_q0(iCell)  * CGvec_y0(iCell)
-                  CGcst_y0y0  = CGcst_y0y0  + CGvec_y0(iCell)  * CGvec_y0(iCell)
-                  CGcst_r00r0 = CGcst_r00r0 + CGvec_r00(iCell) * CGvec_r0(iCell)
-               end do
-
-               block => block % next
-            end do  ! block
-
-            CGcst_allreduce3(1) = CGcst_q0y0
-            CGcst_allreduce3(2) = CGcst_y0y0
-            CGcst_allreduce3(3) = CGcst_r00r0
-
+   
+   
+            ! Reduction --------------------------------------------------!
+            SIcst_r00r0 = 0.0_RKIND
+            SIcst_r00w0 = 0.0_RKIND
+   
+            do iCell = 1, nCellsOwned
+               SIcst_r00r0 = SIcst_r00r0 + SIvec_r00(iCell) &
+                                         * SIvec_r0(iCell)
+               SIcst_r00w0 = SIcst_r00w0 + SIvec_r00(iCell) &
+                                         * SIvec_w0(iCell)
+            end do ! iCell
+   
+            SIcst_allreduce_local2(1) = SIcst_r00r0
+            SIcst_allreduce_local2(2) = SIcst_r00w0
+   
             ! Global sum across CPUs
-            call mpas_timer_start("si reduction iter")
-            call mpas_dmpar_sum_real_array(dminfo, 3, CGcst_allreduce3, CGcst_allreduce_global3)
-            call mpas_timer_stop("si reduction iter")
-
+            call mpas_timer_start("si reduction r0")
+            call mpas_dmpar_sum_real_array(domain % dminfo, 2,      &
+                                           SIcst_allreduce_local2,  &
+                                           SIcst_allreduce_global2)
+            call mpas_timer_stop ("si reduction r0")
+   
             if ( config_btr_si_partition_match_mode .and. ncpus > 1) then
-               CGcst_allreduce_temp5(:)    = 0.0_RKIND
-               CGcst_allreduce_itemp5(:)   = 0.0_RKIND
-               CGcst_allreduce_itemp5(1:3) = exponent(CGcst_allreduce_global3(:))
-               CGcst_allreduce_temp5(1:3)  = fraction(CGcst_allreduce_global3(:))
-               CGcst_allreduce_temp5(1:3)  = anint(CGcst_allreduce_temp5(1:3)*1.0000000000000000d+8)/1.0000000000000000d+8
-               CGcst_allreduce_global3(:)  = CGcst_allreduce_temp5(1:3) * 2.0_RKIND ** (CGcst_allreduce_itemp5(1:3))
+               SIcst_allreduce_temp9(:)    = 0.0_RKIND
+               SIcst_allreduce_itemp9(:)   = 0.0_RKIND
+   
+               SIcst_allreduce_itemp9(1:2) = &
+                                    exponent(SIcst_allreduce_global2(:))
+               SIcst_allreduce_temp9(1:2)  = &
+                                    fraction(SIcst_allreduce_global2(:))
+               SIcst_allreduce_temp9(1:2)  = &
+                                    anint(SIcst_allreduce_temp9(1:2) &
+                                           * 1.0e+4_RKIND  ) &
+                                           / 1.0e+4_RKIND
+   
+               SIcst_allreduce_global2(:) =          &
+                          SIcst_allreduce_temp9(1:2) &
+                        * 2.0_RKIND ** (SIcst_allreduce_itemp9(1:2))
             endif
-
-            CGcst_q0y0_global  = CGcst_allreduce_global3(1)
-            CGcst_y0y0_global  = CGcst_allreduce_global3(2)
-            CGcst_r00r0_global = CGcst_allreduce_global3(3)
-
-
-            ! Preconditioning ------------------------------------------------------------------------!
-
-            if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               call mpas_timer_start("si halo iter")
-               call mpas_dmpar_exch_group_create(domain, iterGroupName)
-               call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_z1', 1)
-               call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-               call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-               call mpas_timer_stop("si halo iter")
-            end if
-
-
-            block => domain % blocklist
-            do while (associated(block))
-
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-               call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-               call mpas_pool_get_subpool(block % structs, 'state', statePool)
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
+   
+            SIcst_r00r0_global = SIcst_allreduce_global2(1)
+            SIcst_r00w0_global = SIcst_allreduce_global2(2)
+   
+            SIcst_rho0   = SIcst_r00r0_global
+            SIcst_alpha0 = SIcst_rho0 / SIcst_r00w0_global
+            SIcst_beta0  = 0.0_RKIND
+            SIcst_omega0 = 0.0_RKIND
+   
+            call mpas_timer_stop("si btr residual")
+   
+   
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            ! Stage 2.3 : Outer iterations 
+            !             - lagged values are sufficiently up to date
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   
+            call mpas_timer_start("si btr iteration")
+   
+            iter = 0
+            resid = (tolerance_outer+100.0)**2.0
+   
+            !-------------------------------------------------------------!
+            do while ( dsqrt(resid) > tolerance_outer )
+            !-------------------------------------------------------------!
+   
+               iter = iter + 1
+   
+               do iCell = 1, nPrecVec
+                  SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
+                                   * (SIvec_ph0(iCell) - SIcst_omega0     &
+                                                       * SIvec_sh0(iCell))
+   
+                  SIvec_s1(iCell)  =  SIvec_w0(iCell)  + SIcst_beta0      &
+                                   * (SIvec_s0(iCell)  - SIcst_omega0     &
+                                                       * SIvec_z0(iCell))
+   
+                  SIvec_sh1(iCell) =  SIvec_wh0(iCell) + SIcst_beta0      &
+                                   * (SIvec_sh0(iCell) - SIcst_omega0     &
+                                                       * SIvec_zh0(iCell))
+   
+                  SIvec_z1(iCell)  =  SIvec_t0(iCell)  + SIcst_beta0      &
+                                   * (SIvec_z0(iCell)  - SIcst_omega0     &
+                                                       * SIvec_v0(iCell))
+   
+                  SIvec_q0(iCell)  =  SIvec_r0(iCell)  - SIcst_alpha0     &
+                                                       * SIvec_s1(iCell)
+   
+                  SIvec_qh0(iCell) =  SIvec_rh0(iCell) - SIcst_alpha0     &
+                                                       * SIvec_sh1(iCell)
+   
+                  SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
+                                                       * SIvec_z1(iCell)
+               end do ! iCell
+   
+   
+               ! Preconditioning -----------------------------------------!
+   
                if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-                  ! RAS preconditioning: Use BLAS for symmetric matrix-vector multiplication
+                  ! RAS preconditioning: Use BLAS 
+                  ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-                  call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_z1(1:nPrecVec),1,0.0_RKIND,CGvec_zh1(1:nPrecVec),1)
+                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                             SIvec_z1(1:nPrecVec), 1, 0.0_RKIND,   &
+                             SIvec_zh1(1:nPrecVec),1)
 #endif
-
-               elseif ( trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
-                  ! Block-Jacobi preconditioning: Use BLAS for symmetric matrix-vector multiplication
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                 'block_jacobi' ) then
+                  ! Block-Jacobi preconditioning: Use BLAS 
+                  ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-                  call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_z1(1:nPrecVec),1,0.0_RKIND,CGvec_zh1(1:nPrecVec),1)
+                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                             SIvec_z1(1:nPrecVec), 1, 0.0_RKIND,   &
+                             SIvec_zh1(1:nPrecVec),1)
 #endif
-
-               elseif ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                       'jacobi' ) then
                   ! Jacobi preconditioning
-                  CGvec_zh1(1:nPrecVec) = CGvec_z1(1:nPrecVec) * prec_ivmat(1:nPrecVec)
-
-               elseif ( trim(config_btr_si_preconditioner) == 'none' ) then
+                  SIvec_zh1(1:nPrecVec) = SIvec_z1(1:nPrecVec) &
+                                        * prec_ivmat(1:nPrecVec)
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                         'none' ) then
                   ! No preconditioning
-                  CGvec_zh1(1:nPrecVec) = cgvec_z1(1:nprecvec)
+                  SIvec_zh1(1:nPrecVec) = SIvec_z1(1:nPrecVec)
                end if
-
-               block => block % next
-            end do  ! block
-
-            call mpas_timer_start("si halo iter")
-            call mpas_dmpar_exch_group_create(domain, iterGroupName)
-            call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_zh1', 1)
-            call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-            call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-            call mpas_timer_stop("si halo iter")
-
-
-            ! SpMV -----------------------------------------------------------------------------------!
-
-            block => domain % blocklist
-            do while (associated(block))
-
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-               call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-               call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
-
-               call mpas_pool_get_array(meshPool, 'nEdgesOnCell',            nEdgesOnCell           )
-               call mpas_pool_get_array(meshPool, 'edgesOnCell',             edgesOnCell            )
-               call mpas_pool_get_array(meshPool, 'cellsOnEdge',             cellsOnEdge            )
-               call mpas_pool_get_array(meshPool, 'dcEdge',                  dcEdge                 )
-               call mpas_pool_get_array(meshPool, 'bottomDepth',             bottomDepth            )
-               call mpas_pool_get_array(meshPool, 'edgeSignOnCell',          edgeSignOnCell         )
-               call mpas_pool_get_array(meshPool, 'dvEdge',                  dvEdge                 )
-               call mpas_pool_get_array(meshPool, 'areaCell',                areaCell               )
-
-               call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
-               call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-               call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
-               do iCell = 1, nCells
+   
+               call mpas_timer_start("si halo iter")
+               call mpas_dmpar_field_halo_exch(domain, 'SIvec_zh1')
+               call mpas_timer_stop("si halo iter")
+   
+   
+               ! SpMV ----------------------------------------------------!
+   
+               do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
-
+   
                   do i = 1, nEdgesOnCell(iCell)
                      iEdge = edgesOnCell(i, iCell)
-
+   
                      cell1 = cellsOnEdge(1, iEdge)
                      cell2 = cellsOnEdge(2, iEdge)
-
+   
                      ! Interpolation sshEdge
-                     sshEdgeLag = 0.5_RKIND * (sshCur(cell1) + sshCur(cell2))
-
-                     ! method 1, matches method 0 without pbcs, works with pbcs.
-                     thicknessSumLag = si_ismf * sshEdgeLag + min(bottomDepth(cell1), bottomDepth(cell2))
-
+                     sshEdgeLag = 0.5_RKIND * (  sshSubcycleCur(cell1)   &
+                                               + sshSubcycleCur(cell2) )
+   
+                     ! method 1, matches method 0 without pbcs,
+                     ! works with pbcs.
+                     thicknessSumLag = si_ismf * sshEdgeLag    &
+                                     + min(bottomDepth(cell1), &
+                                           bottomDepth(cell2))
+   
                      ! nabla (ssh^0)
-                     sshDiffNew = (CGvec_zh1(cell2)-CGvec_zh1(cell1)) / dcEdge(iEdge)
-
-                     fluxAx = thicknessSumLag * sshDiffNew
-
-                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
+                     sshDiffLag = (SIvec_zh1(cell2)-SIvec_zh1(cell1)) &
+                                / dcEdge(iEdge)
+   
+                     fluxAx = thicknessSumLag * sshDiffLag
+   
+                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                               * fluxAx * dvEdge(iEdge)
                   end do ! i
-
-                  sshLagArea = R1_alpha1s_g_dts(split_implicit_step) * CGvec_zh1(iCell) * areaCell(iCell)
-
-                  CGvec_v1(iCell) = -sshLagArea - sshTendAx
-
+   
+                  sshLagArea = R1_alpha1s_g_dts * SIvec_zh1(iCell) &
+                             * areaCell(iCell)
+   
+                  SIvec_v0(iCell) = -sshLagArea - sshTendAx
+   
                end do ! iCell
-
-               ! End reduction -----------------------------------------------------------------------!
-
-               ! Omega1
-               CGcst_omega0 = CGcst_q0y0_global / CGcst_y0y0_global
-
-               do iCell = 1,nCells
-                  sshSubcycleNew(iCell) = sshSubcycleCur(iCell) + CGcst_alpha0 * CGvec_ph1(iCell) &
-                                                                + CGcst_omega0 * CGvec_qh0(iCell)
-                  CGvec_r1(iCell)  = CGvec_q0(iCell)  - CGcst_omega0 * CGvec_y0(iCell)
-                  CGvec_rh1(iCell) = CGvec_qh0(iCell) - CGcst_omega0 * (CGvec_wh0(iCell)-CGcst_alpha0*CGvec_zh1(iCell))
-                  CGvec_w1(iCell)  = CGvec_y0(iCell)  - CGcst_omega0 * (CGvec_t0(iCell)-CGcst_alpha0*CGvec_v1(iCell))
+   
+   
+               ! Reduction -----------------------------------------------!
+               SIcst_r00s0 = 0.0_RKIND
+               SIcst_r00z0 = 0.0_RKIND
+               SIcst_q0y0  = 0.0_RKIND
+               SIcst_y0y0  = 0.0_RKIND
+               SIcst_r00q0 = 0.0_RKIND
+               SIcst_r00y0 = 0.0_RKIND
+               SIcst_r00t0 = 0.0_RKIND
+               SIcst_r00v0 = 0.0_RKIND
+               SIcst_q0q0  = 0.0_RKIND
+   
+               do iCell = 1,nCellsOwned
+                  SIcst_r00s0 = SIcst_r00s0 + SIvec_r00(iCell) &
+                                            * SIvec_s1(iCell) ! s1
+   
+                  SIcst_r00z0 = SIcst_r00z0 + SIvec_r00(iCell) &
+                                            * SIvec_z1(iCell) ! z1
+   
+                  SIcst_q0y0  = SIcst_q0y0  + SIvec_q0(iCell)  &
+                                            * SIvec_y0(iCell)
+   
+                  SIcst_y0y0  = SIcst_y0y0  + SIvec_y0(iCell)  &
+                                            * SIvec_y0(iCell)
+   
+                  SIcst_r00q0 = SIcst_r00q0 + SIvec_r00(iCell) &
+                                            * SIvec_q0(iCell)
+   
+                  SIcst_r00y0 = SIcst_r00y0 + SIvec_r00(iCell) &
+                                            * SIvec_y0(iCell)
+   
+                  SIcst_r00t0 = SIcst_r00t0 + SIvec_r00(iCell) &
+                                            * SIvec_t0(iCell)
+   
+                  SIcst_r00v0 = SIcst_r00v0 + SIvec_r00(iCell) &
+                                            * SIvec_v0(iCell) ! v1
+   
+                  SIcst_q0q0 = SIcst_q0q0   + SIvec_q0(iCell) &
+                                            * SIvec_q0(iCell)
                end do
-
-               block => block % next
-            end do  ! block
-
-
-            ! Begin reduction ------------------------------------------------------------------------!
-
-            CGcst_r00r1 = 0.0_RKIND
-            CGcst_r00w1 = 0.0_RKIND
-            CGcst_r00s0 = 0.0_RKIND
-            CGcst_r00z0 = 0.0_RKIND
-            CGcst_r1r1  = 0.0_RKIND
-
-            do iCell = 1,nCells
-               CGcst_r00r1 = CGcst_r00r1 + CGvec_r00(iCell) * CGvec_r1(iCell)
-               CGcst_r00w1 = CGcst_r00w1 + CGvec_r00(iCell) * CGvec_w1(iCell)
-               CGcst_r00s0 = CGcst_r00s0 + CGvec_r00(iCell) * CGvec_s1(iCell) ! s1
-               CGcst_r00z0 = CGcst_r00z0 + CGvec_r00(iCell) * CGvec_z1(iCell) ! z1
-               CGcst_r1r1  = CGcst_r1r1  + CGvec_r1(iCell)  * CGvec_r1(iCell)
+   
+               SIcst_allreduce_local9(1) = SIcst_r00s0
+               SIcst_allreduce_local9(2) = SIcst_r00z0
+               SIcst_allreduce_local9(3) = SIcst_q0y0 
+               SIcst_allreduce_local9(4) = SIcst_y0y0 
+               SIcst_allreduce_local9(5) = SIcst_r00q0
+               SIcst_allreduce_local9(6) = SIcst_r00y0
+               SIcst_allreduce_local9(7) = SIcst_r00t0
+               SIcst_allreduce_local9(8) = SIcst_r00v0
+               SIcst_allreduce_local9(9) = SIcst_q0q0
+   
+               ! Global sum across CPUs
+               call mpas_timer_start("si reduction iter")
+               call mpas_dmpar_sum_real_array(domain % dminfo, 9,      &
+                                              SIcst_allreduce_local9,  &
+                                              SIcst_allreduce_global9)
+               call mpas_timer_stop("si reduction iter")
+   
+               if ( config_btr_si_partition_match_mode .and. ncpus>1) then
+                  SIcst_allreduce_temp9(:)    = 0.0_RKIND
+                  SIcst_allreduce_itemp9(:)   = 0.0_RKIND
+   
+                  SIcst_allreduce_itemp9(:) = &
+                                     exponent(SIcst_allreduce_global9(:))
+                  SIcst_allreduce_temp9(:)  = &
+                                     fraction(SIcst_allreduce_global9(:))
+                  SIcst_allreduce_temp9(:)  = &
+                                     anint( SIcst_allreduce_temp9(:)  &
+                                           * 1.0e+4_RKIND  ) &
+                                           / 1.0e+4_RKIND
+   
+                  SIcst_allreduce_global9(:)  =                        &
+                              SIcst_allreduce_temp9(:)                 &
+                            * 2.0_RKIND ** (SIcst_allreduce_itemp9(:))
+               endif
+   
+               SIcst_r00s0_global = SIcst_allreduce_global9(1) 
+               SIcst_r00z0_global = SIcst_allreduce_global9(2)
+               SIcst_q0y0_global  = SIcst_allreduce_global9(3)
+               SIcst_y0y0_global  = SIcst_allreduce_global9(4)
+               SIcst_r00q0_global = SIcst_allreduce_global9(5)
+               SIcst_r00y0_global = SIcst_allreduce_global9(6)
+               SIcst_r00t0_global = SIcst_allreduce_global9(7)
+               SIcst_r00v0_global = SIcst_allreduce_global9(8)
+               SIcst_q0q0_global  = SIcst_allreduce_global9(9)
+   
+               ! Omega0
+               SIcst_omega0 = SIcst_q0y0_global / SIcst_y0y0_global
+   
+               ! Residual
+               ! = (r1,r1) = (q0,q0) - 2*Omega*(q0,y0) + Omega**2*(y0,y0)
+               resid = SIcst_q0q0_global &
+                     - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
+                     + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
+   
+               do iCell = 1,nPrecVec
+                  sshSubcycleNew(iCell) = sshSubcycleNew(iCell)           &
+                                        + SIcst_alpha0 * SIvec_ph1(iCell) &
+                                        + SIcst_omega0 * SIvec_qh0(iCell)
+   
+                  SIvec_r1(iCell)  = SIvec_q0(iCell) - SIcst_omega0       &
+                                   * SIvec_y0(iCell)
+   
+                  SIvec_rh1(iCell) =  SIvec_qh0(iCell) - SIcst_omega0     &
+                                   * (SIvec_wh0(iCell) - SIcst_alpha0     &
+                                                       * SIvec_zh1(iCell))
+   
+                  SIvec_w1(iCell)  =   SIvec_y0(iCell) - SIcst_omega0     &
+                                   * ( SIvec_t0(iCell) - SIcst_alpha0     &
+                                                       * SIvec_v0(iCell))
+               end do
+   
+   
+               ! Preconditioning -----------------------------------------!
+   
+               if ( trim(config_btr_si_preconditioner) == 'ras' ) then
+                  ! RAS preconditioning: Use BLAS 
+                  ! for the symmetric matrix-vector multiplication
+#ifdef USE_LAPACK
+                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                             SIvec_w1(1:nPrecVec), 1, 0.0_RKIND,   &
+                             SIvec_wh1(1:nPrecVec),1)
+#endif
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                 'block_jacobi' ) then
+                  ! Block-Jacobi preconditioning: Use BLAS 
+                  ! for the symmetric matrix-vector multiplication
+#ifdef USE_LAPACK
+                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                             SIvec_w1(1:nPrecVec), 1, 0.0_RKIND,   &
+                             SIvec_wh1(1:nPrecVec),1)
+#endif
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                       'jacobi' ) then
+                  ! Jacobi preconditioning
+                  SIvec_wh1(1:nPrecVec) = SIvec_w1(1:nPrecVec)  &
+                                        * prec_ivmat(1:nPrecVec)
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                         'none' ) then
+                  ! No preconditioning
+                  SIvec_wh1(1:nPrecVec) = SIvec_w1(1:nPrecVec)
+               end if
+   
+               call mpas_timer_start("si halo iter")
+               call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh1')
+               call mpas_timer_stop("si halo iter")
+   
+   
+               ! SpMV ----------------------------------------------------!
+   
+               do iCell = 1, nPrecVec
+                  sshTendAx = 0.0_RKIND
+   
+                  do i = 1, nEdgesOnCell(iCell)
+                     iEdge = edgesOnCell(i, iCell)
+   
+                     cell1 = cellsOnEdge(1, iEdge)
+                     cell2 = cellsOnEdge(2, iEdge)
+   
+                     ! Interpolation sshEdge
+                     sshEdgeLag = 0.5_RKIND * (  sshSubcycleCur(cell1)   &
+                                               + sshSubcycleCur(cell2) )
+   
+                     ! method 1, matches method 0 without pbcs,
+                     ! works with pbcs.
+                     thicknessSumLag = si_ismf * sshEdgeLag    &
+                                     + min(bottomDepth(cell1), &
+                                           bottomDepth(cell2))
+   
+                     ! nabla (ssh^0)
+                     sshDiffLag = (SIvec_wh1(cell2)-SIvec_wh1(cell1)) &
+                                / dcEdge(iEdge)
+   
+                     fluxAx = thicknessSumLag * sshDiffLag
+   
+                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                               * fluxAx * dvEdge(iEdge)
+                  end do ! i
+   
+                  sshLagArea = R1_alpha1s_g_dts * SIvec_wh1(iCell) &
+                             * areaCell(iCell)
+   
+                  SIvec_t1(iCell) = -sshLagArea - sshTendAx
+               end do ! iCell
+   
+               ! End reduction -------------------------------------------!
+   
+               SIcst_rho1 = SIcst_r00q0_global - SIcst_omega0 * SIcst_r00y0_global 
+   
+               SIcst_gamma1 = SIcst_r00y0_global - SIcst_omega0 * SIcst_r00t0_global  &
+                                          + SIcst_omega0 * SIcst_alpha0 &
+                                                         * SIcst_r00v0_global
+    
+               SIcst_beta0 = (SIcst_alpha0/SIcst_omega0) &
+                           * (SIcst_rho1 / SIcst_rho0)
+   
+               SIcst_alpha0 = SIcst_rho1 &
+                            / ( SIcst_gamma1 + SIcst_beta0 * SIcst_r00s0_global   &
+                                             - SIcst_beta0 * SIcst_omega0  &
+                                                           * SIcst_r00z0_global )
+   
+               do iCell = 1,nPrecVec
+                  SIvec_r0(iCell) = SIvec_r1(iCell)
+                  SIvec_s0(iCell) = SIvec_s1(iCell)
+                  SIvec_z0(iCell) = SIvec_z1(iCell)
+                  SIvec_w0(iCell) = SIvec_w1(iCell)
+                  SIvec_t0(iCell) = SIvec_t1(iCell)
+   
+                  SIvec_rh0(iCell) = SIvec_rh1(iCell)
+                  SIvec_sh0(iCell) = SIvec_sh1(iCell)
+                  SIvec_ph0(iCell) = SIvec_ph1(iCell)
+                  SIvec_wh0(iCell) = SIvec_wh1(iCell)
+                  SIvec_zh0(iCell) = SIvec_zh1(iCell)
+               end do ! iCell
+   
+               SIcst_rho0         = SIcst_rho1
+   
+            !-------------------------------------------------------------!
+            end do ! do iter
+            !-------------------------------------------------------------!
+    
+   
+            !   boundary update on sshNew
+            call mpas_timer_start("si halo iter")
+            call mpas_dmpar_field_halo_exch(domain, 'sshSubcycle', &
+                                            timeLevel=2)
+            call mpas_timer_stop("si halo iter")
+   
+            call mpas_timer_stop("si btr iteration")
+   
+   
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            ! Stage 2.4 : The barotropic velocity update
+            !             using the lagged SSH
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   
+            call mpas_timer_start("si btr vel update")
+            do iCell = 1,nCellsAll
+               ! Use of sshNew to save the lagged SSH
+               sshNew(iCell) = sshSubcycleNew(iCell)
             end do
-
-            CGcst_allreduce5(1) = CGcst_r00r1
-            CGcst_allreduce5(2) = CGcst_r00w1
-            CGcst_allreduce5(3) = CGcst_r00s0
-            CGcst_allreduce5(4) = CGcst_r00z0
-            CGcst_allreduce5(5) = CGcst_r1r1
-
-            ! Global sum across CPUs
-            call mpas_timer_start("si reduction iter")
-            call mpas_dmpar_sum_real_array(dminfo, 5, CGcst_allreduce5, CGcst_allreduce_global5)
-            call mpas_timer_stop("si reduction iter")
-
-            if ( config_btr_si_partition_match_mode .and. ncpus > 1) then
-               CGcst_allreduce_temp5(:)    = 0.0_RKIND
-               CGcst_allreduce_itemp5(:)   = 0.0_RKIND
-               CGcst_allreduce_itemp5(1:5) = exponent(CGcst_allreduce_global5(:))
-               CGcst_allreduce_temp5(1:5)  = fraction(CGcst_allreduce_global5(:))
-               CGcst_allreduce_temp5(1:5)  = anint(CGcst_allreduce_temp5(1:5)*1.0000000000000000d+8)/1.0000000000000000d+8
-               CGcst_allreduce_global5(:)  = CGcst_allreduce_temp5(1:5) * 2.0_RKIND ** (CGcst_allreduce_itemp5(1:5))
-            endif
-
-            CGcst_r00r1_global = CGcst_allreduce_global5(1)
-            CGcst_r00w1_global = CGcst_allreduce_global5(2)
-            CGcst_r00s0_global = CGcst_allreduce_global5(3)
-            CGcst_r00z0_global = CGcst_allreduce_global5(4)
-                         resid = CGcst_allreduce_global5(5)
-
-
-            ! Preconditioning ------------------------------------------------------------------------!
-
-            if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               call mpas_timer_start("si halo iter")
-               call mpas_dmpar_exch_group_create(domain, iterGroupName)
-               call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_w1', 1)
-               call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-               call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-               call mpas_timer_stop("si halo iter")
-            end if
-
-
-            block => domain % blocklist
-            do while (associated(block))
-
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-               call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-               call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
-               if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-                  ! RAS preconditioning: Use BLAS for symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_w1(1:nPrecVec),1,0.0_RKIND,CGvec_wh1(1:nPrecVec),1)
-#endif
-
-               elseif ( trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
-                  ! Block-Jacobi preconditioning: Use BLAS for symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_w1(1:nPrecVec),1,0.0_RKIND,CGvec_wh1(1:nPrecVec),1)
-#endif
-               elseif ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
-                  ! Jacobi preconditioning
-                  CGvec_wh1(1:nPrecVec) = CGvec_w1(1:nPrecVec) * prec_ivmat(1:nPrecVec)
-
-               elseif ( trim(config_btr_si_preconditioner) == 'none' ) then
-                  ! No preconditioning
-                  CGvec_wh1(1:nPrecVec) = CGvec_w1(1:nPrecVec)
-               end if
-
-               block => block % next
-            end do  ! block
-
-            call mpas_timer_start("si halo iter")
-            call mpas_dmpar_exch_group_create(domain, iterGroupName)
-            call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_wh1', 1)
-            call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-            call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-            call mpas_timer_stop("si halo iter")
-
-
-            ! SpMV -----------------------------------------------------------------------------------!
-
-            block => domain % blocklist
-            do while (associated(block))
-
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-               call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-               call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
-
-               call mpas_pool_get_array(meshPool, 'nEdgesOnCell',            nEdgesOnCell           )
-               call mpas_pool_get_array(meshPool, 'edgesOnCell',             edgesOnCell            )
-               call mpas_pool_get_array(meshPool, 'cellsOnEdge',             cellsOnEdge            )
-               call mpas_pool_get_array(meshPool, 'dcEdge',                  dcEdge                 )
-               call mpas_pool_get_array(meshPool, 'bottomDepth',             bottomDepth            )
-               call mpas_pool_get_array(meshPool, 'edgeSignOnCell',          edgeSignOnCell         )
-               call mpas_pool_get_array(meshPool, 'dvEdge',                  dvEdge                 )
-               call mpas_pool_get_array(meshPool, 'areaCell',                areaCell               )
-
-               call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
-               call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
-               call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-               call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
-               do iCell = 1, nCells
-                  sshTendAx = 0.0_RKIND
-
-                  do i = 1, nEdgesOnCell(iCell)
-                     iEdge = edgesOnCell(i, iCell)
-
-                     cell1 = cellsOnEdge(1, iEdge)
-                     cell2 = cellsOnEdge(2, iEdge)
-
-                     ! Interpolation sshEdge
-                     sshEdgeLag = 0.5_RKIND * (sshCur(cell1) + sshCur(cell2))
-
-                     ! method 1, matches method 0 without pbcs, works with pbcs.
-                     thicknessSumLag = si_ismf * sshEdgeLag + min(bottomDepth(cell1), bottomDepth(cell2))
-
-                     ! nabla (ssh^0)
-                     sshDiffNew = (CGvec_wh1(cell2)-CGvec_wh1(cell1)) / dcEdge(iEdge)
-
-                     fluxAx = thicknessSumLag * sshDiffNew
-
-                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
-                  end do ! i
-
-                  sshLagArea = R1_alpha1s_g_dts(split_implicit_step) * CGvec_wh1(iCell) * areaCell(iCell)
-
-                  CGvec_t1(iCell) = -sshLagArea - sshTendAx
-               end do ! iCell
-
-               ! End reduction -----------------------------------------------------------------------!
-
-               CGcst_beta0 = (CGcst_alpha0/CGcst_omega0) * CGcst_r00r1_global / CGcst_r00r0_global
-               CGcst_alpha1 =  CGcst_r00r1_global / (  CGcst_r00w1_global + CGcst_beta0 * CGcst_r00s0_global  &
-                                                     - CGcst_beta0 * CGcst_omega0 * CGcst_r00z0_global       )
-
-               do iCell = 1,nCells
-                  CGvec_r0(iCell) = CGvec_r1(iCell)
-                  CGvec_s0(iCell) = CGvec_s1(iCell)
-                  CGvec_z0(iCell) = CGvec_z1(iCell)
-                  CGvec_w0(iCell) = CGvec_w1(iCell)
-                  CGvec_t0(iCell) = CGvec_t1(iCell)
-                  CGvec_v0(iCell) = CGvec_v1(iCell)
-
-                  CGvec_rh0(iCell) = CGvec_rh1(iCell)
-                  CGvec_sh0(iCell) = CGvec_sh1(iCell)
-                  CGvec_ph0(iCell) = CGvec_ph1(iCell)
-                  CGvec_wh0(iCell) = CGvec_wh1(iCell)
-                  CGvec_zh0(iCell) = CGvec_zh1(iCell)
-
-                  sshSubcycleCur(iCell) = sshSubcycleNew(iCell)
-               end do ! iCell
-
-               CGcst_r00r0_global = CGcst_r00r1_global
-               CGcst_alpha0       = CGcst_alpha1
-
-               block => block % next
-            end do  ! block
-
-         !**************************************************************!
-         end do ! do iter = 2
-         !**************************************************************!
-
-         !   boundary update on SSHnew
-         call mpas_timer_start("si halo iter")
-         call mpas_dmpar_exch_group_create(domain, iterGroupName)
-         call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'sshSubcycle', timeLevel=1)
-         call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-         call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-         call mpas_timer_stop("si halo iter")
-
-         call mpas_timer_stop("si btr iteration")
-
-         call mpas_timer_start("si btr vel update")
-         ! Update normalBarotropicVelocitySubcycle ------------------------------------------------!
-
-         block => domain % blocklist
-         do while (associated(block))
-
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-            call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', nEdgesOnEdge)
-            call mpas_pool_get_array(meshPool, 'edgesOnEdge', edgesOnEdge)
-            call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
-            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-            call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-            call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', normalBarotropicVelocitySubcycleCur, 1)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', normalBarotropicVelocitySubcycleNew, 2)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityCur,1)
-            call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-            call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
-            call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
-            call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
-
-            nCells = nCellsArray( cellHaloComputeCounter )
-            nEdges = nEdgesArray( edgeHaloComputeCounter )
-
-            sshNew(:) = sshSubcycleCur(:)
-
-            do iEdge = 1, nEdges
+   
+            do iEdge = 1,nEdgesHalo( edgeHaloComputeCounter-1 )
                temp_mask = edgeMask(1, iEdge)
-
+   
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
-               normalBarotropicVelocitySubcycleNew(iEdge) &
-                  = temp_mask &
-                  * (normalBarotropicVelocityCur(iEdge) &
-                  - dt_si(split_implicit_step) * (-barotropicCoriolisTerm(iEdge) + gravity &
-                       * ( (   alpha1*sshNew(cell2)+alpha2*sshCur(cell2)) &
-                            - (alpha1*sshNew(cell1)+alpha2*sshCur(cell1)) ) &
-                       / dcEdge(iEdge) - barotropicForcing(iEdge)))
+                      
+               ! Use of normBtrVelNew as a temp array for sshEdge
+               normalBarotropicVelocityNew(iEdge) =       &
+                          ( 0.5*sshNew(cell2)          &
+                           +0.5*sshSubcycleCur(cell2)) &
+                         -( 0.5*sshNew(cell1)          &
+                           +0.5*sshSubcycleCur(cell1)) 
+    
+               normalBarotropicVelocitySubcycleNew(iEdge)              &
+                  = temp_mask                                          &
+                  * (normalBarotropicVelocityCur(iEdge)                &
+                  - dt_si * (-barotropicCoriolisTerm(iEdge) + gravity     &
+                          *normalBarotropicVelocityNew(iEdge)          &
+                          /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-
-            nEdges = nEdgesArray( edgeHaloComputeCounter-1 )
-
-
+   
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
-            do iEdge = 1, nEdges
+            do iEdge = 1,nEdgesHalo(2)
                ! Compute the barotropic Coriolis term, -f*uPerp
                CoriolisTerm = 0.0_RKIND
                do i = 1, nEdgesOnEdge(iEdge)
                   eoe = edgesOnEdge(i,iEdge)
-                  CoriolisTerm =  CoriolisTerm + weightsOnEdge(i,iEdge)  &
-                                 * normalBarotropicVelocitySubcycleNew(eoe) * fEdge(eoe)
+                  CoriolisTerm = CoriolisTerm + weightsOnEdge(i,iEdge)       &
+                               * 0.5_RKIND                                   &
+                               * ( normalBarotropicVelocitySubcycleNew(eoe)  &
+                                  +normalBarotropicVelocityCur(eoe)        ) &
+                               * fEdge(eoe)
                end do
                barotropicCoriolisTerm(iEdge) = CoriolisTerm
             end do
             !$omp end do
             !$omp end parallel
-
-            block => block % next
-         end do  ! block
-
-         call mpas_timer_stop ("si btr vel update")
-
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         !
-         ! Stage 2.4 : Recompute initial residual with lagged values
-         !
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-         call mpas_timer_start("si btr residual")
-
-         ! SpMV -----------------------------------------------------------------------------------!
-
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-            call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-            call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-            call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-            call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-            call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-            call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-            call mpas_pool_get_array(statePool, 'ssh', sshCur,1)
-            call mpas_pool_get_array(statePool, 'ssh', sshNew,2)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityCur,1)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
-            do iCell = 1, nCells
+   
+            do iEdge = 1,nEdgesHalo(2)
+               temp_mask = edgeMask(1, iEdge)
+   
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               normalBarotropicVelocitySubcycleNew(iEdge)            &
+                  = temp_mask                                        &
+                  * (normalBarotropicVelocityCur(iEdge)              &
+                  - dt_si * (-barotropicCoriolisTerm(iEdge) + gravity   &
+                          *normalBarotropicVelocityNew(iEdge)        &
+                          /dcEdge(iEdge) - barotropicForcing(iEdge)))
+            end do ! iEdge
+   
+            !$omp parallel
+            !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
+            do iEdge = 1,nEdgesOwned
+               ! Compute the barotropic Coriolis term, -f*uPerp
+               CoriolisTerm = 0.0_RKIND
+               do i = 1, nEdgesOnEdge(iEdge)
+                  eoe = edgesOnEdge(i,iEdge)
+                  CoriolisTerm = CoriolisTerm + weightsOnEdge(i,iEdge)      &
+                               * 0.5_RKIND                                  &
+                               * ( normalBarotropicVelocitySubcycleNew(eoe) &
+                                  +normalBarotropicVelocityCur(eoe) )       &
+                               * fEdge(eoe)
+               end do
+               barotropicCoriolisTerm(iEdge) = CoriolisTerm
+            end do
+            !$omp end do
+            !$omp end parallel
+   
+            call mpas_timer_start("si halo btr coriolis")
+            call mpas_dmpar_field_halo_exch(domain, 'barotropicCoriolisTerm')
+            call mpas_timer_stop("si halo btr coriolis")
+   
+            call mpas_timer_stop ("si btr vel update")
+   
+   
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            ! Stage 2.5 : Recompution of the initial residual
+            !             with lagged values
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   
+            call mpas_timer_start("si btr residual")
+   
+            ! SpMV -------------------------------------------------------!
+   
+            do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
                sshTendAx = 0.0_RKIND
-
+   
                do i = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
-
+   
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
-
+   
                   ! Interpolation sshEdge
-                  sshEdgeCur = 0.5_RKIND * (sshCur(cell1) + sshCur(cell2))
+                  sshEdgeCur = 0.5_RKIND * (  sshSubcycleCur(cell1)   &
+                                            + sshSubcycleCur(cell2) )
                   sshEdgeLag = 0.5_RKIND * (sshNew(cell1) + sshNew(cell2))
                   sshEdgeMid = alpha1 * sshEdgeLag + alpha2 * sshEdgeCur
-
-                  ! method 1, matches method 0 without pbcs, works with pbcs.
-                  thicknessSumCur = si_ismf * sshEdgeCur + min(bottomDepth(cell1), bottomDepth(cell2))
-                  thicknessSumLag = si_ismf * sshEdgeLag + min(bottomDepth(cell1), bottomDepth(cell2))
-                  thicknessSumMid = si_ismf * sshEdgeMid + min(bottomDepth(cell1), bottomDepth(cell2))
-
+   
+                  ! method 1, matches method 0 without pbcs,
+                  ! works with pbcs.
+                  thicknessSumCur = si_ismf * sshEdgeCur    &
+                                  + min(bottomDepth(cell1), &
+                                        bottomDepth(cell2))
+                  thicknessSumLag = si_ismf * sshEdgeLag    &
+                                  + min(bottomDepth(cell1), &
+                                        bottomDepth(cell2))
+                  thicknessSumMid = si_ismf * sshEdgeMid    &
+                                  + min(bottomDepth(cell1), &
+                                        bottomDepth(cell2))
+   
                   ! nabla (ssh^0)
-                  sshDiffCur = (sshCur(cell2)-sshCur(cell1)) / dcEdge(iEdge)
-                  sshDiffLag = (sshNew(cell2)-sshNew(cell1)) / dcEdge(iEdge)
-
-                  fluxb1 = thicknessSumMid * normalBarotropicVelocityCur(iEdge)
-                  fluxb2 = thicknessSumLag * (alpha2*gravity*sshDiffCur + (-barotropicCoriolisTerm(iEdge)-barotropicForcing(iEdge)) )
+                  sshDiffCur = ( sshSubcycleCur(cell2)   &
+                                -sshSubcycleCur(cell1) ) &
+                               / dcEdge(iEdge)
+                  sshDiffLag = (sshNew(cell2)-sshNew(cell1)) &
+                               / dcEdge(iEdge)
+   
+                  fluxb1 = thicknessSumMid &
+                         * normalBarotropicVelocityCur(iEdge)
+                  fluxb2 = thicknessSumLag &
+                         * ( alpha2*gravity*sshDiffCur &
+                            + (-barotropicCoriolisTerm(iEdge) &
+                               -barotropicForcing(iEdge)) )
                   fluxAx = thicknessSumLag * sshDiffLag
-
-                  sshTendb1 = sshTendb1 + edgeSignOnCell(i, iCell) * fluxb1 * dvEdge(iEdge)
-                  sshTendb2 = sshTendb2 + edgeSignOnCell(i, iCell) * fluxb2 * dvEdge(iEdge)
-                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
+   
+                  sshTendb1 = sshTendb1 + edgeSignOnCell(i, iCell) &
+                                        * fluxb1 * dvEdge(iEdge)
+                  sshTendb2 = sshTendb2 + edgeSignOnCell(i, iCell) &
+                                        * fluxb2 * dvEdge(iEdge)
+                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                                        * fluxAx * dvEdge(iEdge)
                end do ! i
-
-               sshTendb1  = R1_alpha1s_g_dt(split_implicit_step) * sshTendb1
-               sshTendb2  = R1_alpha1_g * sshTendb2
-               sshCurArea = R1_alpha1s_g_dts(split_implicit_step) *   sshCur(iCell) * areaCell(iCell)
-               sshLagArea = R1_alpha1s_g_dts(split_implicit_step) *   sshNew(iCell) * areaCell(iCell)
-
-               CGvec_r0(iCell) = (-sshCurArea - sshTendb1 + sshTendb2)   &
+   
+               sshTendb1  = R1_alpha1s_g_dt  * sshTendb1
+               sshTendb2  = R1_alpha1_g      * sshTendb2
+               sshCurArea = R1_alpha1s_g_dts * sshSubcycleCur(iCell) &
+                                             * areaCell(iCell)
+               sshLagArea = R1_alpha1s_g_dts * sshNew(iCell) &
+                                             * areaCell(iCell)
+   
+               SIvec_r0(iCell) = (-sshCurArea - sshTendb1 + sshTendb2) &
                                 -(-sshLagArea - sshTendAx)
-               CGvec_r00(iCell) = CGvec_r0(iCell)
+               SIvec_r00(iCell) = SIvec_r0(iCell)
             end do ! iCell
-
-            block => block % next
-         end do  ! block
-
-
-         ! Preconditioning ------------------------------------------------------------------------!
-
-         if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-            call mpas_timer_start("si halo r0")
-            call mpas_dmpar_exch_group_create(domain, iterGroupName)
-            call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_r0', 1)
-            call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-            call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-            call mpas_timer_stop("si halo r0")
-         end if
-
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
+   
+   
+            ! Preconditioning --------------------------------------------!
+   
             if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               ! RAS preconditioning: Use BLAS for symmetric matrix-vector multiplication
+               ! RAS preconditioning: Use BLAS
+               ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-               call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_r0(1:nPrecVec),1,0.0_RKIND,CGvec_rh0(1:nPrecVec),1)
+               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_r0(1:nPrecVec), 1, 0.0_RKIND,   &
+                          SIvec_rh0(1:nPrecVec),1)
 #endif
-
-            elseif ( trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
-               ! Block-Jacobi preconditioning: Use BLAS for symmetric matrix-vector multiplication
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                              'block_jacobi' ) then
+               ! Block-Jacobi preconditioning: Use BLAS 
+               ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-               call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_r0(1:nPrecVec),1,0.0_RKIND,CGvec_rh0(1:nPrecVec),1)
+               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_r0(1:nPrecVec), 1, 0.0_RKIND,   &
+                          SIvec_rh0(1:nPrecVec),1)
 #endif
-
-            elseif ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                                    'jacobi' ) then
                ! Jacobi preconditioning
-               CGvec_rh0(1:nPrecVec) = CGvec_r0(1:nPrecVec) * prec_ivmat(1:nPrecVec)
-
-            elseif ( trim(config_btr_si_preconditioner) == 'none' ) then
+               SIvec_rh0(1:nPrecVec) = SIvec_r0(1:nPrecVec) &
+                                     * prec_ivmat(1:nPrecVec)
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                                      'none' ) then
                ! No preconditioning
-               CGvec_rh0(1:nPrecVec) = CGvec_r0(1:nPrecVec)
-
+               SIvec_rh0(1:nPrecVec) = SIvec_r0(1:nPrecVec)
             end if
-
-            block => block % next
-         end do  ! block
-
-         call mpas_timer_start("si halo r0")
-         call mpas_dmpar_exch_group_create(domain, iterGroupName)
-         call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_rh0', 1)
-         call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-         call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-         call mpas_timer_stop("si halo r0")
-
-
-         ! SpMV -----------------------------------------------------------------------------------!
-
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-            call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-            call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-            call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-            call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-            call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell', refBottomDepthTopOfCell)
-            call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-            call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-            call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-            call mpas_pool_get_array(statePool, 'ssh', sshNew,2)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
-            CGcst_r00r0 = 0.0_RKIND
-            CGcst_r00w0 = 0.0_RKIND
-
-            do iCell = 1, nCells
-
+   
+            call mpas_timer_start("si halo r0")
+            call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh0')
+            call mpas_timer_stop("si halo r0")
+   
+   
+            ! SpMV -------------------------------------------------------!
+   
+            do iCell = 1, nPrecVec
+   
                sshTendAx = 0.0_RKIND
-
+   
                do i = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
-
+   
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
-
+   
                   ! Interpolation sshEdge
                   sshEdgeLag = 0.5_RKIND * (sshNew(cell1) + sshNew(cell2))
-
-                  ! method 1, matches method 0 without pbcs, works with pbcs.
-                  thicknessSumLag = si_ismf * sshEdgeLag + min(bottomDepth(cell1), bottomDepth(cell2))
-
+   
+                  ! method 1, matches method 0 without pbcs,
+                  ! works with pbcs.
+                  thicknessSumLag = si_ismf * sshEdgeLag    &
+                                  + min(bottomDepth(cell1), &
+                                        bottomDepth(cell2))
+   
                   ! nabla (ssh^0)
-                  sshDiffLag = (CGvec_rh0(cell2)- CGvec_rh0(cell1)) / dcEdge(iEdge)
-
+                  sshDiffLag = (SIvec_rh0(cell2)- SIvec_rh0(cell1)) &
+                             / dcEdge(iEdge)
+   
                   fluxAx = thicknessSumLag * sshDiffLag
-
-                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
-
+   
+                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                            * fluxAx * dvEdge(iEdge)
                end do ! i
-
-               sshCurArea = R1_alpha1s_g_dts(split_implicit_step) * CGvec_rh0(iCell) * areaCell(iCell)
-
-               CGvec_w0(iCell) = -sshCurArea - sshTendAx
-
-               CGcst_r00r0 = CGcst_r00r0 + CGvec_r00(iCell) * CGvec_r0(iCell)
-               CGcst_r00w0 = CGcst_r00w0 + CGvec_r00(iCell) * CGvec_w0(iCell)
-
+   
+               sshCurArea = R1_alpha1s_g_dts * SIvec_rh0(iCell) &
+                                             * areaCell(iCell)
+   
+               SIvec_w0(iCell) = -sshCurArea - sshTendAx
+   
             end do ! iCell
-
-            block => block % next
-         end do  ! block
-
-
-         ! Preconditioning ------------------------------------------------------------------------!
-
-         if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-            call mpas_timer_start("si halo r0")
-            call mpas_dmpar_exch_group_create(domain, iterGroupName)
-            call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_w0', 1)
-            call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-            call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-            call mpas_timer_stop("si halo r0")
-         end if
-
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
+   
+   
+            ! Preconditioning --------------------------------------------!
+   
             if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               ! RAS preconditioning: Use BLAS for symmetric matrix-vector multiplication
+               ! RAS preconditioning: Use BLAS
+               ! the for symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-               call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_w0(1:nPrecVec),1,0.0_RKIND,CGvec_wh0(1:nPrecVec),1)
+               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_w0(1:nPrecVec), 1, 0.0_RKIND,   &
+                          SIvec_wh0(1:nPrecVec),1)
 #endif
-
-            elseif ( trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
-               ! Block-Jacobi preconditioning: Use BLAS for symmetric matrix-vector multiplication
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                              'block_jacobi' ) then
+               ! Block-Jacobi preconditioning: Use BLAS
+               ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-               call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_w0(1:nPrecVec),1,0.0_RKIND,CGvec_wh0(1:nPrecVec),1)
+               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                          SIvec_w0(1:nPrecVec), 1, 0.0_RKIND,   &
+                          SIvec_wh0(1:nPrecVec),1)
 #endif
-
-            elseif ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                                    'jacobi' ) then
                ! Jacobi preconditioning
-               CGvec_wh0(1:nPrecVec) = CGvec_w0(1:nPrecVec) * prec_ivmat(1:nPrecVec)
-
-            elseif ( trim(config_btr_si_preconditioner) == 'none' ) then
+               SIvec_wh0(1:nPrecVec) = SIvec_w0(1:nPrecVec) &
+                                     * prec_ivmat(1:nPrecVec)
+   
+            elseif ( trim(config_btr_si_preconditioner) == &
+                                                      'none' ) then
                ! No preconditioning
-               CGvec_wh0(1:nPrecVec) = CGvec_w0(1:nPrecVec)
+               SIvec_wh0(1:nPrecVec) = SIvec_w0(1:nPrecVec)
             end if
-
-           block => block % next
-         end do  ! block
-
-         call mpas_timer_start("si halo r0")
-         call mpas_dmpar_exch_group_create(domain, iterGroupName)
-         call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_wh0', 1)
-         call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-         call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-         call mpas_timer_stop("si halo r0")
-
-
-         ! SpMV -----------------------------------------------------------------------------------!
-
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-            call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-            call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-            call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-            call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-            call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-            call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-            call mpas_pool_get_array(statePool, 'ssh', sshNew,2)
-
-            nCells = nCellsArray( 1 )
-            nEdges = nEdgesArray( 2 )
-
-            do iCell = 1, nCells
-
+   
+            call mpas_timer_start("si halo r0")
+            call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
+            call mpas_timer_stop("si halo r0")
+   
+   
+            ! SpMV -------------------------------------------------------!
+            do iCell = 1, nPrecVec
+   
                sshTendAx = 0.0_RKIND
-
+   
                do i = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
-
+   
                   cell1 = cellsOnEdge(1, iEdge)
                   cell2 = cellsOnEdge(2, iEdge)
-
+   
                   ! Interpolation sshEdge
-                  sshEdgeLag = 0.5_RKIND * (sshNew(cell1) + sshNew(cell2))
-
-                  ! method 1, matches method 0 without pbcs, works with pbcs.
-                  thicknessSumLag = si_ismf * sshEdgeLag + min(bottomDepth(cell1), bottomDepth(cell2))
-
+                  sshEdgeLag = 0.5_RKIND * (  sshNew(cell1)   &
+                                            + sshNew(cell2) )
+   
+                  ! method 1, matches method 0 without pbcs,
+                  ! works with pbcs.
+                  thicknessSumLag = si_ismf * sshEdgeLag    &
+                                  + min(bottomDepth(cell1), &
+                                        bottomDepth(cell2))
+   
                   ! nabla (ssh^0)
-                  sshDiffCur = (CGvec_wh0(cell2)- CGvec_wh0(cell1)) / dcEdge(iEdge)
-
+                  sshDiffCur = (SIvec_wh0(cell2) - SIvec_wh0(cell1)) &
+                             / dcEdge(iEdge)
+   
                   fluxAx = thicknessSumLag * sshDiffCur
-
-                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
+   
+                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                            * fluxAx * dvEdge(iEdge)
                end do ! i
-
-               sshCurArea = R1_alpha1s_g_dts(split_implicit_step) * CGvec_wh0(iCell) * areaCell(iCell)
-
-               CGvec_t0(iCell) = -sshCurArea - sshTendAx
-
-               CGvec_ph0(iCell) = 0.0_RKIND
-               CGvec_sh0(iCell) = 0.0_RKIND
-               CGvec_z0(iCell)  = 0.0_RKIND
-               CGvec_zh0(iCell) = 0.0_RKIND
-               CGvec_v0(iCell)  = 0.0_RKIND
-               CGvec_s0(iCell)  = 0.0_RKIND
-
+   
+               sshCurArea = R1_alpha1s_g_dts * SIvec_wh0(iCell) &
+                          * areaCell(iCell)
+   
+               SIvec_t0(iCell) = -sshCurArea - sshTendAx
+   
+               SIvec_ph0(iCell) = 0.0_RKIND
+               SIvec_sh0(iCell) = 0.0_RKIND
+               SIvec_z0(iCell)  = 0.0_RKIND
+               SIvec_zh0(iCell) = 0.0_RKIND
+               SIvec_v0(iCell)  = 0.0_RKIND
+               SIvec_s0(iCell)  = 0.0_RKIND
+   
             end do ! iCell
-
-            block => block % next
-         end do  ! block
-
-         CGcst_allreduce2(1) = CGcst_r00r0
-         CGcst_allreduce2(2) = CGcst_r00w0
-
-         ! Global sum across CPU
-         call mpas_timer_start("si reduction r0")
-         call mpas_dmpar_sum_real_array(dminfo, 2, CGcst_allreduce2, CGcst_allreduce_global2)
-         call mpas_timer_stop("si reduction r0")
-
-         if ( config_btr_si_partition_match_mode .and. ncpus > 1) then
-            CGcst_allreduce_temp5(:)    = 0.0_RKIND
-            CGcst_allreduce_itemp5(:)   = 0.0_RKIND
-            CGcst_allreduce_itemp5(1:2) = exponent(CGcst_allreduce_global2(:))
-            CGcst_allreduce_temp5(1:2)  = fraction(CGcst_allreduce_global2(:))
-            CGcst_allreduce_temp5(1:2)  = anint(CGcst_allreduce_temp5(1:2)*1.0000000000000000d+8)/1.0000000000000000d+8
-            CGcst_allreduce_global2(:)  = CGcst_allreduce_temp5(1:2) * 2.0_RKIND ** (CGcst_allreduce_itemp5(1:2))
-         endif
-
-         CGcst_r00r0_global = CGcst_allreduce_global2(1)
-         CGcst_r00w0_global = CGcst_allreduce_global2(2)
-
-         CGcst_alpha0 = CGcst_r00r0_global / CGcst_r00w0_global
-         CGcst_beta0  = 0.0_RKIND
-         CGcst_omega0 = 0.0_RKIND
-
-         call mpas_timer_stop("si btr residual")
-
-
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         !
-         ! Stage 2.5 : Main iterations
-         !
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-         call mpas_timer_start("si btr iteration")
-
-         iter = 0
-         resid = (crit_main+100.0)**2.0
-
-         !**************************************************************!
-         do while ( dsqrt(resid) > crit_main )
-         !**************************************************************!
-
-            iter = iter + 1
-
-            block => domain % blocklist
-            do while (associated(block))
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-               call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-               call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
-
-               call mpas_pool_get_subpool(statePool, 'tracers'    , tracersPool    )
-               call mpas_pool_get_subpool(tendPool , 'tracersTend', tracersTendPool)
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
-               do iCell = 1, nCells
-                  CGvec_ph1(iCell) = CGvec_rh0(iCell) + CGcst_beta0  * (CGvec_ph0(iCell)-CGcst_omega0*CGvec_sh0(iCell))
-                  CGvec_s1(iCell)  = CGvec_w0(iCell)  + CGcst_beta0  * (CGvec_s0(iCell)-CGcst_omega0*CGvec_z0(iCell))
-                  CGvec_sh1(iCell) = CGvec_wh0(iCell) + CGcst_beta0  * (CGvec_sh0(iCell)-CGcst_omega0*CGvec_zh0(iCell))
-                  CGvec_z1(iCell)  = CGvec_t0(iCell)  + CGcst_beta0  * (CGvec_z0(iCell)-CGcst_omega0*CGvec_v0(iCell))
-                  CGvec_q0(iCell)  = CGvec_r0(iCell)  - CGcst_alpha0 * CGvec_s1(iCell)
-                  CGvec_qh0(iCell) = CGvec_rh0(iCell) - CGcst_alpha0 * CGvec_sh1(iCell)
-                  CGvec_y0(iCell)  = CGvec_w0(iCell)  - CGcst_alpha0 * CGvec_z1(iCell)
-               end do ! iCell
-
-
-               ! Begin reduction ----------------------------------------------------------------------!
-
-               CGcst_q0y0  = 0.0_RKIND
-               CGcst_y0y0  = 0.0_RKIND
-               CGcst_r00r0 = 0.0_RKIND
-
-               do iCell = 1,nCells
-                  CGcst_q0y0  = CGcst_q0y0  + CGvec_q0(iCell)  * CGvec_y0(iCell)
-                  CGcst_y0y0  = CGcst_y0y0  + CGvec_y0(iCell)  * CGvec_y0(iCell)
-                  CGcst_r00r0 = CGcst_r00r0 + CGvec_r00(iCell) * CGvec_r0(iCell)
-               end do
-
-               block => block % next
-            end do  ! block
-
-            CGcst_allreduce3(1) = CGcst_q0y0
-            CGcst_allreduce3(2) = CGcst_y0y0
-            CGcst_allreduce3(3) = CGcst_r00r0
-
+   
+   
+            ! Reduction -----------------------------------------------!
+            SIcst_r00r0 = 0.0_RKIND
+            SIcst_r00w0 = 0.0_RKIND
+   
+            do iCell = 1, nCellsOwned
+               SIcst_r00r0 = SIcst_r00r0 + SIvec_r00(iCell) &
+                                         * SIvec_r0(iCell)
+               SIcst_r00w0 = SIcst_r00w0 + SIvec_r00(iCell) &
+                                         * SIvec_w0(iCell)
+            end do ! iCell
+   
+            SIcst_allreduce_local2(1) = SIcst_r00r0
+            SIcst_allreduce_local2(2) = SIcst_r00w0
+   
+   
             ! Global sum across CPUs
-            call mpas_timer_start("si reduction iter")
-            call mpas_dmpar_sum_real_array(dminfo, 3, CGcst_allreduce3, CGcst_allreduce_global3)
-            call mpas_timer_stop("si reduction iter")
-
+            call mpas_timer_start("si reduction r0")
+            call mpas_dmpar_sum_real_array(domain % dminfo, 2,      &
+                                           SIcst_allreduce_local2,  &
+                                           SIcst_allreduce_global2)
+            call mpas_timer_stop ("si reduction r0")
+   
+   
             if ( config_btr_si_partition_match_mode .and. ncpus > 1) then
-               CGcst_allreduce_temp5(:)    = 0.0_RKIND
-               CGcst_allreduce_itemp5(:)   = 0.0_RKIND
-               CGcst_allreduce_itemp5(1:3) = exponent(CGcst_allreduce_global3(:))
-               CGcst_allreduce_temp5(1:3)  = fraction(CGcst_allreduce_global3(:))
-               CGcst_allreduce_temp5(1:3)  = anint(CGcst_allreduce_temp5(1:3)*1.0000000000000000d+8)/1.0000000000000000d+8
-               CGcst_allreduce_global3(:)  = CGcst_allreduce_temp5(1:3) * 2.0_RKIND ** (CGcst_allreduce_itemp5(1:3))
+               SIcst_allreduce_temp9(:)    = 0.0_RKIND
+               SIcst_allreduce_itemp9(:)   = 0.0_RKIND
+   
+               SIcst_allreduce_itemp9(1:2) = &
+                                    exponent(SIcst_allreduce_global2(:))
+               SIcst_allreduce_temp9(1:2)  = &
+                                    fraction(SIcst_allreduce_global2(:))
+               SIcst_allreduce_temp9(1:2)  = &
+                                    anint(SIcst_allreduce_temp9(1:2) &
+                                           * 1.0e+4_RKIND  ) &
+                                           / 1.0e+4_RKIND
+   
+               SIcst_allreduce_global2(:) =          &
+                          SIcst_allreduce_temp9(1:2) &
+                        * 2.0_RKIND ** (SIcst_allreduce_itemp9(1:2))
             endif
-
-            CGcst_q0y0_global  = CGcst_allreduce_global3(1)
-            CGcst_y0y0_global  = CGcst_allreduce_global3(2)
-            CGcst_r00r0_global = CGcst_allreduce_global3(3)
-
-
-
-            ! Preconditioning ------------------------------------------------------------------------!
-
-            if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               call mpas_timer_start("si halo iter")
-               call mpas_dmpar_exch_group_create(domain, iterGroupName)
-               call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_z1', 1)
-               call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-               call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-               call mpas_timer_stop("si halo iter")
-            end if
-
-            block => domain % blocklist
-            do while (associated(block))
-
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-               call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-               call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
+   
+   
+            SIcst_r00r0_global = SIcst_allreduce_global2(1)
+            SIcst_r00w0_global = SIcst_allreduce_global2(2)
+   
+            SIcst_rho0   = SIcst_r00r0_global
+            SIcst_alpha0 = SIcst_rho0 / SIcst_r00w0_global
+            SIcst_beta0  = 0.0_RKIND
+            SIcst_omega0 = 0.0_RKIND
+   
+            call mpas_timer_stop("si btr residual")
+   
+   
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            ! Stage 2.6 : Main (inner) solver iterations
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   
+            call mpas_timer_start("si btr iteration")
+   
+            iter = 0
+            resid = SIcst_r00r0_global
+   
+            !-------------------------------------------------------------!
+            do while ( dsqrt(resid) > tolerance_inner )
+            !-------------------------------------------------------------!
+   
+               iter = iter + 1
+   
+               do iCell = 1, nPrecVec
+                  SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
+                                   * (SIvec_ph0(iCell) - SIcst_omega0     &
+                                                       * SIvec_sh0(iCell))
+   
+                  SIvec_s1(iCell)  =  SIvec_w0(iCell)  + SIcst_beta0      &
+                                   * (SIvec_s0(iCell)  - SIcst_omega0     &
+                                                       * SIvec_z0(iCell))
+   
+                  SIvec_sh1(iCell) =  SIvec_wh0(iCell) + SIcst_beta0      &
+                                   * (SIvec_sh0(iCell) - SIcst_omega0     &
+                                                       * SIvec_zh0(iCell))
+   
+                  SIvec_z1(iCell)  =  SIvec_t0(iCell)  + SIcst_beta0      &
+                                   * (SIvec_z0(iCell)  - SIcst_omega0     &
+                                                       * SIvec_v0(iCell))
+   
+                  SIvec_q0(iCell)  =  SIvec_r0(iCell)  - SIcst_alpha0     &
+                                                       * SIvec_s1(iCell)
+   
+                  SIvec_qh0(iCell) =  SIvec_rh0(iCell) - SIcst_alpha0     &
+                                                       * SIvec_sh1(iCell)
+   
+                  SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
+                                                       * SIvec_z1(iCell)
+               end do ! iCell
+   
+   
+               ! Preconditioning -----------------------------------------!
                if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-                  ! RAS preconditioning: Use BLAS for symmetric matrix-vector multiplication
+                  ! RAS preconditioning: Use BLAS
+                  ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-                  call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_z1(1:nPrecVec),1,0.0_RKIND,CGvec_zh1(1:nPrecVec),1)
+                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                             SIvec_z1(1:nPrecVec), 1, 0.0_RKIND,   &
+                             SIvec_zh1(1:nPrecVec),1)
 #endif
-
-               elseif ( trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
-                  ! Block-Jacobi preconditioning: Use BLAS for symmetric matrix-vector multiplication
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                 'block_jacobi' ) then
+                  ! Block-Jacobi preconditioning: Use BLAS 
+                  ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-                  call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_z1(1:nPrecVec),1,0.0_RKIND,CGvec_zh1(1:nPrecVec),1)
+                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                             SIvec_z1(1:nPrecVec), 1, 0.0_RKIND,   &
+                             SIvec_zh1(1:nPrecVec),1)
 #endif
-
-               elseif ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                       'jacobi' ) then
                   ! Jacobi preconditioning
-                  CGvec_zh1(1:nPrecVec) = CGvec_z1(1:nPrecVec) * prec_ivmat(1:nPrecVec)
-
-               elseif ( trim(config_btr_si_preconditioner) == 'none' ) then
+                  SIvec_zh1(1:nPrecVec) = SIvec_z1(1:nPrecVec) &
+                                        * prec_ivmat(1:nPrecVec)
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                         'none' ) then
                   ! No preconditioning
-                  CGvec_zh1(1:nPrecVec) = CGvec_z1(1:nPrecVec)
+                  SIvec_zh1(1:nPrecVec) = SIvec_z1(1:nPrecVec)
                end if
-
-               block => block % next
-            end do  ! block
-
-            call mpas_timer_start("si halo iter")
-            call mpas_dmpar_exch_group_create(domain, iterGroupName)
-            call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_zh1', 1)
-            call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-            call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-            call mpas_timer_stop("si halo iter")
-
-
-            ! SpMV -----------------------------------------------------------------------------------!
-
-            block => domain % blocklist
-            do while (associated(block))
-
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-               call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-               call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
-
-               call mpas_pool_get_array(meshPool, 'nEdgesOnCell',            nEdgesOnCell           )
-               call mpas_pool_get_array(meshPool, 'edgesOnCell',             edgesOnCell            )
-               call mpas_pool_get_array(meshPool, 'cellsOnEdge',             cellsOnEdge            )
-               call mpas_pool_get_array(meshPool, 'dcEdge',                  dcEdge                 )
-               call mpas_pool_get_array(meshPool, 'bottomDepth',             bottomDepth            )
-               call mpas_pool_get_array(meshPool, 'edgeSignOnCell',          edgeSignOnCell         )
-               call mpas_pool_get_array(meshPool, 'dvEdge',                  dvEdge                 )
-               call mpas_pool_get_array(meshPool, 'areaCell',                areaCell               )
-
-               call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
-               call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-               call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
-               do iCell = 1, nCells
+   
+               call mpas_timer_start("si halo iter")
+               call mpas_dmpar_field_halo_exch(domain, 'SIvec_zh1')
+               call mpas_timer_stop("si halo iter")
+   
+   
+               ! SpMV ----------------------------------------------------!
+   
+               do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
-
+   
                   do i = 1, nEdgesOnCell(iCell)
                      iEdge = edgesOnCell(i, iCell)
-
+   
                      cell1 = cellsOnEdge(1, iEdge)
                      cell2 = cellsOnEdge(2, iEdge)
-
+   
                      ! Interpolation sshEdge
-                     sshEdgeLag = 0.5_RKIND * (sshNew(cell1) + sshNew(cell2))
-
-                     ! method 1, matches method 0 without pbcs, works with pbcs.
-                     thicknessSumLag = si_ismf * sshEdgeLag + min(bottomDepth(cell1), bottomDepth(cell2))
-
+                     sshEdgeLag = 0.5_RKIND * (  sshNew(cell1)   &
+                                               + sshNew(cell2) )
+   
+                     ! method 1, matches method 0 without pbcs,
+                     ! works with pbcs.
+                     thicknessSumLag = si_ismf * sshEdgeLag    &
+                                     + min(bottomDepth(cell1), &
+                                           bottomDepth(cell2))
+   
                      ! nabla (ssh^0)
-                     sshDiffNew = (CGvec_zh1(cell2)-CGvec_zh1(cell1)) / dcEdge(iEdge)
-
-                     fluxAx = thicknessSumLag * sshDiffNew
-
-                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
+                     sshDiffLag = (SIvec_zh1(cell2)-SIvec_zh1(cell1)) &
+                                / dcEdge(iEdge)
+   
+                     fluxAx = thicknessSumLag * sshDiffLag
+   
+                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                               * fluxAx * dvEdge(iEdge)
                   end do ! i
-
-                  sshLagArea = R1_alpha1s_g_dts(split_implicit_step) * CGvec_zh1(iCell) * areaCell(iCell)
-
-                  CGvec_v1(iCell) = -sshLagArea - sshTendAx
-
+   
+                  sshLagArea = R1_alpha1s_g_dts * SIvec_zh1(iCell) * areaCell(iCell)
+   
+                  SIvec_v0(iCell) = -sshLagArea - sshTendAx
+   
                end do ! iCell
-
-               ! End reduction ------------------------------------------------------------------------!
-
-               CGcst_omega0 = CGcst_q0y0_global / CGcst_y0y0_global
-
-               do iCell = 1,nCells
-                  sshSubcycleNew(iCell) = sshSubcycleCur(iCell) + CGcst_alpha0 * CGvec_ph1(iCell) &
-                                                                + CGcst_omega0 * CGvec_qh0(iCell)
-                  CGvec_r1(iCell)  = CGvec_q0(iCell)  - CGcst_omega0 * CGvec_y0(iCell)
-                  CGvec_rh1(iCell) = CGvec_qh0(iCell) - CGcst_omega0 * (CGvec_wh0(iCell)-CGcst_alpha0*CGvec_zh1(iCell))
-                  CGvec_w1(iCell)  = CGvec_y0(iCell)  - CGcst_omega0 * (CGvec_t0(iCell)-CGcst_alpha0*CGvec_v1(iCell))
+   
+   
+               ! Reduction -----------------------------------------------!
+               SIcst_r00s0 = 0.0_RKIND
+               SIcst_r00z0 = 0.0_RKIND
+               SIcst_q0y0  = 0.0_RKIND
+               SIcst_y0y0  = 0.0_RKIND
+               SIcst_r00q0 = 0.0_RKIND
+               SIcst_r00y0 = 0.0_RKIND
+               SIcst_r00t0 = 0.0_RKIND
+               SIcst_r00v0 = 0.0_RKIND
+               SIcst_q0q0  = 0.0_RKIND
+   
+               do iCell = 1,nCellsOwned
+                  SIcst_r00s0 = SIcst_r00s0 + SIvec_r00(iCell) &
+                                            * SIvec_s1(iCell) ! s1
+   
+                  SIcst_r00z0 = SIcst_r00z0 + SIvec_r00(iCell) &
+                                            * SIvec_z1(iCell) ! z1
+   
+                  SIcst_q0y0  = SIcst_q0y0  + SIvec_q0(iCell)  &
+                                            * SIvec_y0(iCell)
+   
+                  SIcst_y0y0  = SIcst_y0y0  + SIvec_y0(iCell)  &
+                                            * SIvec_y0(iCell)
+   
+                  SIcst_r00q0 = SIcst_r00q0 + SIvec_r00(iCell) &
+                                            * SIvec_q0(iCell)
+   
+                  SIcst_r00y0 = SIcst_r00y0 + SIvec_r00(iCell) &
+                                            * SIvec_y0(iCell)
+   
+                  SIcst_r00t0 = SIcst_r00t0 + SIvec_r00(iCell) &
+                                            * SIvec_t0(iCell)
+   
+                  SIcst_r00v0 = SIcst_r00v0 + SIvec_r00(iCell) &
+                                            * SIvec_v0(iCell) ! v1
+   
+                  SIcst_q0q0 = SIcst_q0q0   + SIvec_q0(iCell) &
+                                            * SIvec_q0(iCell)
                end do
-
-               block => block % next
-            end do  ! block
-
-
-            ! Begin reduction ------------------------------------------------------------------------!
-
-            CGcst_r00r1 = 0.0_RKIND
-            CGcst_r00w1 = 0.0_RKIND
-            CGcst_r00s0 = 0.0_RKIND
-            CGcst_r00z0 = 0.0_RKIND
-            CGcst_r1r1  = 0.0_RKIND
-
-            do iCell = 1,nCells
-               CGcst_r00r1 = CGcst_r00r1 + CGvec_r00(iCell) * CGvec_r1(iCell)
-               CGcst_r00w1 = CGcst_r00w1 + CGvec_r00(iCell) * CGvec_w1(iCell)
-               CGcst_r00s0 = CGcst_r00s0 + CGvec_r00(iCell) * CGvec_s1(iCell) ! s1
-               CGcst_r00z0 = CGcst_r00z0 + CGvec_r00(iCell) * CGvec_z1(iCell) ! z1
-               CGcst_r1r1  = CGcst_r1r1  + CGvec_r1(iCell)  * CGvec_r1(iCell)
-            end do
-
-            CGcst_allreduce5(1) = CGcst_r00r1
-            CGcst_allreduce5(2) = CGcst_r00w1
-            CGcst_allreduce5(3) = CGcst_r00s0
-            CGcst_allreduce5(4) = CGcst_r00z0
-            CGcst_allreduce5(5) = CGcst_r1r1
-
-            ! Global sum across CPUs
-            call mpas_timer_start("si reduction iter")
-            call mpas_dmpar_sum_real_array(dminfo, 5, CGcst_allreduce5, CGcst_allreduce_global5)
-            call mpas_timer_stop("si reduction iter")
-
-            if ( config_btr_si_partition_match_mode .and. ncpus > 1) then
-               CGcst_allreduce_temp5(:)    = 0.0_RKIND
-               CGcst_allreduce_itemp5(:)   = 0.0_RKIND
-               CGcst_allreduce_itemp5(1:5) = exponent(CGcst_allreduce_global5(:))
-               CGcst_allreduce_temp5(1:5)  = fraction(CGcst_allreduce_global5(:))
-               CGcst_allreduce_temp5(1:5)  = anint(CGcst_allreduce_temp5(1:5)*1.0000000000000000d+8)/1.0000000000000000d+8
-               CGcst_allreduce_global5(:)  = CGcst_allreduce_temp5(1:5) * 2.0_RKIND ** (CGcst_allreduce_itemp5(1:5))
-            endif
-
-            CGcst_r00r1_global = CGcst_allreduce_global5(1)
-            CGcst_r00w1_global = CGcst_allreduce_global5(2)
-            CGcst_r00s0_global = CGcst_allreduce_global5(3)
-            CGcst_r00z0_global = CGcst_allreduce_global5(4)
-                         resid = CGcst_allreduce_global5(5)
-
-            ! Preconditioning ------------------------------------------------------------------------!
-
-            if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               call mpas_timer_start("si halo iter")
-               call mpas_dmpar_exch_group_create(domain, iterGroupName)
-               call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_w1', 1)
-               call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-               call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-               call mpas_timer_stop("si halo iter")
-            end if
-
-            block => domain % blocklist
-            do while (associated(block))
-
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-               call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-               call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
+   
+               SIcst_allreduce_local9(1) = SIcst_r00s0
+               SIcst_allreduce_local9(2) = SIcst_r00z0
+               SIcst_allreduce_local9(3) = SIcst_q0y0 
+               SIcst_allreduce_local9(4) = SIcst_y0y0 
+               SIcst_allreduce_local9(5) = SIcst_r00q0
+               SIcst_allreduce_local9(6) = SIcst_r00y0
+               SIcst_allreduce_local9(7) = SIcst_r00t0
+               SIcst_allreduce_local9(8) = SIcst_r00v0
+               SIcst_allreduce_local9(9) = SIcst_q0q0
+   
+               ! Global sum across CPUs
+               call mpas_timer_start("si reduction iter")
+               call mpas_dmpar_sum_real_array(domain % dminfo, 9,      &
+                                              SIcst_allreduce_local9,  &
+                                              SIcst_allreduce_global9)
+               call mpas_timer_stop("si reduction iter")
+   
+               if ( config_btr_si_partition_match_mode .and. ncpus>1) then
+                  SIcst_allreduce_temp9(:)    = 0.0_RKIND
+                  SIcst_allreduce_itemp9(:)   = 0.0_RKIND
+   
+                  SIcst_allreduce_itemp9(:) = &
+                                     exponent(SIcst_allreduce_global9(:))
+                  SIcst_allreduce_temp9(:)  = &
+                                     fraction(SIcst_allreduce_global9(:))
+                  SIcst_allreduce_temp9(:)  = &
+                                     anint( SIcst_allreduce_temp9(:)  &
+                                           * 1.0e+4_RKIND  ) &
+                                           / 1.0e+4_RKIND
+   
+                  SIcst_allreduce_global9(:)  =                        &
+                              SIcst_allreduce_temp9(:)                 &
+                            * 2.0_RKIND ** (SIcst_allreduce_itemp9(:))
+               endif
+   
+               SIcst_r00s0_global = SIcst_allreduce_global9(1) 
+               SIcst_r00z0_global = SIcst_allreduce_global9(2)
+               SIcst_q0y0_global  = SIcst_allreduce_global9(3)
+               SIcst_y0y0_global  = SIcst_allreduce_global9(4)
+               SIcst_r00q0_global = SIcst_allreduce_global9(5)
+               SIcst_r00y0_global = SIcst_allreduce_global9(6)
+               SIcst_r00t0_global = SIcst_allreduce_global9(7)
+               SIcst_r00v0_global = SIcst_allreduce_global9(8)
+               SIcst_q0q0_global  = SIcst_allreduce_global9(9)
+   
+               ! Omega0
+               SIcst_omega0 = SIcst_q0y0_global / SIcst_y0y0_global
+   
+               ! Residual
+               resid = SIcst_q0q0_global &
+                     - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
+                     + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
+   
+               do iCell = 1,nPrecVec
+                  sshSubcycleNew(iCell) = sshSubcycleNew(iCell)           &
+                                        + SIcst_alpha0 * SIvec_ph1(iCell) &
+                                        + SIcst_omega0 * SIvec_qh0(iCell)
+   
+                  SIvec_r1(iCell)  = SIvec_q0(iCell) - SIcst_omega0       &
+                                   * SIvec_y0(iCell)
+   
+                  SIvec_rh1(iCell) =  SIvec_qh0(iCell) - SIcst_omega0     &
+                                   * (SIvec_wh0(iCell) - SIcst_alpha0     &
+                                                       * SIvec_zh1(iCell))
+   
+                  SIvec_w1(iCell)  =   SIvec_y0(iCell) - SIcst_omega0     &
+                                   * ( SIvec_t0(iCell) - SIcst_alpha0     &
+                                                       * SIvec_v0(iCell))
+               end do
+   
+   
+               ! Preconditioning -----------------------------------------!
                if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-                  ! RAS preconditioning: Use BLAS for symmetric matrix-vector multiplication
+                  ! RAS preconditioning: Use BLAS 
+                  ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-                  call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_w1(1:nPrecVec),1,0.0_RKIND,CGvec_wh1(1:nPrecVec),1)
+                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                             SIvec_w1(1:nPrecVec), 1, 0.0_RKIND,   &
+                             SIvec_wh1(1:nPrecVec),1)
 #endif
-
-               elseif ( trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
-                  ! Block-Jacobi preconditioning: Use BLAS for symmetric matrix-vector multiplication
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                 'block_jacobi' ) then
+                  ! Block-Jacobi preconditioning: Use BLAS
+                  ! for the symmetric matrix-vector multiplication
 #ifdef USE_LAPACK
-                  call DSPMV('U',nPrecVec,1.0_RKIND,prec_ivmat,CGvec_w1(1:nPrecVec),1,0.0_RKIND,CGvec_wh1(1:nPrecVec),1)
+                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                             SIvec_w1(1:nPrecVec), 1, 0.0_RKIND,   &
+                             SIvec_wh1(1:nPrecVec),1)
 #endif
-               elseif ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                       'jacobi' ) then
                   ! Jacobi preconditioning
-                  CGvec_wh1(1:nPrecVec) = CGvec_w1(1:nPrecVec) * prec_ivmat(1:nPrecVec)
-
-               elseif ( trim(config_btr_si_preconditioner) == 'none' ) then
+                  SIvec_wh1(1:nPrecVec) = SIvec_w1(1:nPrecVec) &
+                                        * prec_ivmat(1:nPrecVec)
+   
+               elseif ( trim(config_btr_si_preconditioner) == &
+                                                         'none' ) then
                   ! No preconditioning
-                  CGvec_wh1(1:nPrecVec) = CGvec_w1(1:nPrecVec)
+                  SIvec_wh1(1:nPrecVec) = SIvec_w1(1:nPrecVec)
                end if
-
-               block => block % next
-            end do  ! block
-
-            call mpas_timer_start("si halo iter")
-            call mpas_dmpar_exch_group_create(domain, iterGroupName)
-            call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'CGvec_wh1', 1)
-            call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-            call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-            call mpas_timer_stop("si halo iter")
-
-
-            ! SpMV -----------------------------------------------------------------------------------!
-
-            block => domain % blocklist
-            do while (associated(block))
-
-               call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-               call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-               call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-               call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-               call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
-
-               call mpas_pool_get_array(meshPool, 'nEdgesOnCell',            nEdgesOnCell           )
-               call mpas_pool_get_array(meshPool, 'edgesOnCell',             edgesOnCell            )
-               call mpas_pool_get_array(meshPool, 'cellsOnEdge',             cellsOnEdge            )
-               call mpas_pool_get_array(meshPool, 'dcEdge',                  dcEdge                 )
-               call mpas_pool_get_array(meshPool, 'bottomDepth',             bottomDepth            )
-               call mpas_pool_get_array(meshPool, 'edgeSignOnCell',          edgeSignOnCell         )
-               call mpas_pool_get_array(meshPool, 'dvEdge',                  dvEdge                 )
-               call mpas_pool_get_array(meshPool, 'areaCell',                areaCell               )
-
-               call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
-               call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-               call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
-
-               nCells = nCellsArray(1)
-               nEdges = nEdgesArray(2)
-
-               do iCell = 1, nCells
+   
+               call mpas_timer_start("si halo iter")
+               call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh1')
+               call mpas_timer_stop("si halo iter")
+   
+   
+               ! SpMV ----------------------------------------------------!
+   
+               do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
-
+   
                   do i = 1, nEdgesOnCell(iCell)
                      iEdge = edgesOnCell(i, iCell)
-
+   
                      cell1 = cellsOnEdge(1, iEdge)
                      cell2 = cellsOnEdge(2, iEdge)
-
+   
                      ! Interpolation sshEdge
-                     sshEdgeLag = 0.5_RKIND * (sshNew(cell1) + sshNew(cell2))
-
-                     ! method 1, matches method 0 without pbcs, works with pbcs.
-                     thicknessSumLag = si_ismf * sshEdgeLag + min(bottomDepth(cell1), bottomDepth(cell2))
-
+                     sshEdgeLag = 0.5_RKIND * (  sshNew(cell1)   &
+                                               + sshNew(cell2) )
+   
+                     ! method 1, matches method 0 without pbcs, 
+                     ! works with pbcs.
+                     thicknessSumLag = si_ismf * sshEdgeLag    &
+                                     + min(bottomDepth(cell1), &
+                                           bottomDepth(cell2))
+   
                      ! nabla (ssh^0)
-                     sshDiffNew = (CGvec_wh1(cell2)-CGvec_wh1(cell1)) / dcEdge(iEdge)
-
-                     fluxAx = thicknessSumLag * sshDiffNew
-
-                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) * fluxAx * dvEdge(iEdge)
+                     sshDiffLag = (SIvec_wh1(cell2)-SIvec_wh1(cell1)) &
+                                / dcEdge(iEdge)
+   
+                     fluxAx = thicknessSumLag * sshDiffLag
+   
+                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                               * fluxAx * dvEdge(iEdge)
                   end do ! i
-
-                  sshLagArea = R1_alpha1s_g_dts(split_implicit_step) * CGvec_wh1(iCell) * areaCell(iCell)
-
-                  CGvec_t1(iCell) = -sshLagArea - sshTendAx
+   
+                  sshLagArea = R1_alpha1s_g_dts * SIvec_wh1(iCell) &
+                             * areaCell(iCell)
+   
+                  SIvec_t1(iCell) = -sshLagArea - sshTendAx
                end do ! iCell
-
-               ! End reduction -----------------------------------------------------------------------!
-
-               CGcst_beta0 = (CGcst_alpha0/CGcst_omega0) * CGcst_r00r1_global / CGcst_r00r0_global
-               CGcst_alpha1 =  CGcst_r00r1_global / (  CGcst_r00w1_global + CGcst_beta0 * CGcst_r00s0_global  &
-                                                     - CGcst_beta0 * CGcst_omega0 * CGcst_r00z0_global       )
-
-               do iCell = 1,nCells
-                  CGvec_r0(iCell) = CGvec_r1(iCell)
-                  CGvec_s0(iCell) = CGvec_s1(iCell)
-                  CGvec_z0(iCell) = CGvec_z1(iCell)
-                  CGvec_w0(iCell) = CGvec_w1(iCell)
-                  CGvec_t0(iCell) = CGvec_t1(iCell)
-                  CGvec_v0(iCell) = CGvec_v1(iCell)
-
-                  CGvec_rh0(iCell) = CGvec_rh1(iCell)
-                  CGvec_sh0(iCell) = CGvec_sh1(iCell)
-                  CGvec_ph0(iCell) = CGvec_ph1(iCell)
-                  CGvec_wh0(iCell) = CGvec_wh1(iCell)
-                  CGvec_zh0(iCell) = CGvec_zh1(iCell)
-
-                  sshSubcycleCur(iCell) = sshSubcycleNew(iCell)
+   
+               SIcst_rho1 = SIcst_r00q0_global - SIcst_omega0 * SIcst_r00y0_global 
+   
+               SIcst_gamma1 = SIcst_r00y0_global - SIcst_omega0 * SIcst_r00t0_global  &
+                                          + SIcst_omega0 * SIcst_alpha0 &
+                                                         * SIcst_r00v0_global
+    
+               SIcst_beta0 = (SIcst_alpha0/SIcst_omega0) &
+                           * (SIcst_rho1 / SIcst_rho0)
+   
+               SIcst_alpha0 = SIcst_rho1 &
+                            / ( SIcst_gamma1 + SIcst_beta0 * SIcst_r00s0_global   &
+                                             - SIcst_beta0 * SIcst_omega0  &
+                                                           * SIcst_r00z0_global )
+               do iCell = 1,nPrecVec
+                  SIvec_r0(iCell) = SIvec_r1(iCell)
+                  SIvec_s0(iCell) = SIvec_s1(iCell)
+                  SIvec_z0(iCell) = SIvec_z1(iCell)
+                  SIvec_w0(iCell) = SIvec_w1(iCell)
+                  SIvec_t0(iCell) = SIvec_t1(iCell)
+   
+                  SIvec_rh0(iCell) = SIvec_rh1(iCell)
+                  SIvec_sh0(iCell) = SIvec_sh1(iCell)
+                  SIvec_ph0(iCell) = SIvec_ph1(iCell)
+                  SIvec_wh0(iCell) = SIvec_wh1(iCell)
+                  SIvec_zh0(iCell) = SIvec_zh1(iCell)
                end do ! iCell
-
-               CGcst_r00r0_global = CGcst_r00r1_global
-               CGcst_alpha0       = CGcst_alpha1
-
-               block => block % next
-            end do  ! block
-
-            if ( iter > int(mean_num_cells*5) ) then
-               call mpas_log_write('******************************************************')
-               call mpas_log_write('Iteration number exceeds Max. #iteration: PROGRAM STOP')
-               call mpas_log_write('Current #Iteration = $i ', intArgs=(/ iter /) )
-               call mpas_log_write('Max.    #Iteration = $i ', intArgs=(/ int(mean_num_cells*5) /) )
-               call mpas_log_write('******************************************************')
-               call mpas_log_write('',MPAS_LOG_CRIT)
-            endif
-
-         !**************************************************************!
-         end do ! do iter
-         !**************************************************************!
-
-         ! boundary update on SSHnew
-         call mpas_timer_start("si halo iter")
-         call mpas_dmpar_exch_group_create(domain, iterGroupName)
-         call mpas_dmpar_exch_group_add_field(domain, iterGroupName, 'sshSubcycle', timeLevel=1)
-         call mpas_dmpar_exch_group_full_halo_exch(domain, iterGroupName)
-         call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-         call mpas_timer_stop("si halo iter")
-
-         call mpas_timer_stop("si btr iteration")
-
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         !
-         ! Stage 2.6 : Barotropic velocity update
-         !
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-         call mpas_timer_start("si btr vel update")
-
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-            call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', nEdgesOnEdge)
-            call mpas_pool_get_array(meshPool, 'edgesOnEdge', edgesOnEdge)
-            call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
-            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-            call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-            call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-            call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-
-            call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
-            call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, 1)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', normalBarotropicVelocitySubcycleCur, 1)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', normalBarotropicVelocitySubcycleNew, 2)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityCur,1)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityNew,2)
-
-            nCells = nCellsArray(1)
-            nEdges = nEdgesArray(1)
-
-            do iEdge = 1, nEdges
+   
+               SIcst_rho0         = SIcst_rho1
+   
+               if ( iter > int(mean_num_cells*5) ) then
+                  call mpas_log_write(&
+                  '******************************************************')
+                  call mpas_log_write(&
+                  'Iteration number exceeds Max. #iteration: PROGRAM STOP')
+                  call mpas_log_write(&
+                  'Current #Iteration = $i ', intArgs=(/ iter /) )
+                  call mpas_log_write(&
+                  'Max.    #Iteration = $i ', &
+                  intArgs=(/ int(mean_num_cells*5) /) )
+                  call mpas_log_write(&
+                  '******************************************************')
+                  call mpas_log_write('',MPAS_LOG_CRIT)
+               endif
+   
+            !-------------------------------------------------------------!
+            end do ! do iter
+            !-------------------------------------------------------------!
+   
+            ! boundary update on SSHnew
+            call mpas_timer_start("si halo iter")
+            call mpas_dmpar_field_halo_exch(domain, 'sshSubcycle', timeLevel=2)
+            call mpas_timer_stop("si halo iter")
+   
+            call mpas_timer_stop("si btr iteration")
+   
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            ! Stage 2.7 : The barotropic velocity update
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   
+            call mpas_timer_start("si btr vel update")
+   
+            do iEdge = 1, nEdgesHalo(2)
                temp_mask = edgeMask(1, iEdge)
-
+   
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
-
-               normalBarotropicVelocitySubcycleNew(iEdge) &
-                  = temp_mask &
-                  * (normalBarotropicVelocityCur(iEdge) &
-                  - dt_si(split_implicit_step) * ( -barotropicCoriolisTerm(iEdge) + gravity &
-                         * (  (alpha1*sshSubcycleCur(cell2)+alpha2*sshCur(cell2))   &
-                            - (alpha1*sshSubcycleCur(cell1)+alpha2*sshCur(cell1)) ) &
-                         / dcEdge(iEdge) - barotropicForcing(iEdge)))
+   
+               ! Use of normBtrVelNew as a temp array for sshEdge
+               normalBarotropicVelocityNew(iEdge) =    &
+                          ( 0.5*sshSubcycleNew(cell2)  &
+                           +0.5*sshSubcycleCur(cell2)) &
+                         -( 0.5*sshSubcycleNew(cell1)  &
+                           +0.5*sshSubcycleCur(cell1)) 
+   
+               normalBarotropicVelocitySubcycleNew(iEdge)              &
+                  = temp_mask                                          &
+                  * (normalBarotropicVelocityCur(iEdge)                &
+                  - dt_si * (-barotropicCoriolisTerm(iEdge) + gravity     &
+                          *normalBarotropicVelocityNew(iEdge)          &
+                          /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
-
-            do iEdge = 1, nEdges
-               normalBarotropicVelocitySubcycleCur(iEdge) &
-                  =  tavg(1,split_implicit_step)*normalBarotropicVelocitySubcycleNew(iEdge)  &
-                   + tavg(2,split_implicit_step)*normalBarotropicVelocityCur(iEdge)
-            end do ! iEdge
-
-            do iEdge = 1, nEdges
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-
-               sshEdge =   0.5_RKIND*( 0.5_RKIND * (sshSubcycleCur(cell1) + sshSubcycleCur(cell2)))  &
-                         + 0.5_RKIND*( 0.5_RKIND * (sshCur(cell1) + sshCur(cell2)))
-               thicknessSum = sshEdge + min(bottomDepth(cell1), bottomDepth(cell2))
-               barotropicThicknessFlux(iEdge) = 0.5*( normalBarotropicVelocitySubcycleNew(iEdge) &
-                                                     +normalBarotropicVelocityCur(iEdge)) * thicknessSum
-            end do ! iEdge
-
-            do iEdge = 1, nEdges
-               normalBarotropicVelocityNew(iEdge) = normalBarotropicVelocitySubcycleCur(iEdge)
-            end do ! iEdge
-
-            ! #Iteration  check
-!           if ( split_implicit_step == 2 ) then
-!           call mpas_log_write( 'Iteration $i', intArgs=(/ iter /) )
-!           endif
-
-            block => block % next
-         end do  ! block
-
-         ! boundary update on F
-         call mpas_timer_start("si halo btr vel")
-         call mpas_dmpar_exch_group_create(domain, finalBtrGroupName)
-         call mpas_dmpar_exch_group_add_field(domain, finalBtrGroupName, 'barotropicThicknessFlux')
-         call mpas_dmpar_exch_group_add_field(domain, finalBtrGroupName, 'normalBarotropicVelocity',2)
-         call mpas_dmpar_exch_group_add_field(domain, finalBtrGroupName, 'normalBarotropicVelocitySubcycle',1)
-         call mpas_dmpar_exch_group_full_halo_exch(domain, finalBtrGroupName)
-         call mpas_dmpar_exch_group_destroy(domain, finalBtrGroupName)
-         call mpas_timer_stop("si halo btr vel")
-
-         call mpas_timer_stop("si btr vel update")
-
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         !
-         ! u correct and transport velocity
-         !
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-         ! Check that you can compute SSH using the total sum or the individual increments
-         ! over the barotropic subcycles.
-         ! efficiency: This next block of code is really a check for debugging, and can
-         ! be removed later.
-         call mpas_timer_start('btr si ssh verif')
-
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdgesPtr)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
-
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityNew, 2)
-            call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityNew, 2)
-
-            call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
-            call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-            call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-
-            nEdges = nEdgesPtr
-
-            nEdges = nEdgesArray( config_num_halos )
-
-            allocate(uTemp(nVertLevels))
-
-            ! Correction velocity    normalVelocityCorrection = (Flux - Sum(h u*))/H
-            ! or, for the full latex version:
-            !{\bf u}^{corr} = \left( {\overline {\bf F}}
-            !  - \sum_{k=1}^{N^{edge}} h_{k,*}^{edge}  {\bf u}_k^{avg} \right)
-            ! \left/ \sum_{k=1}^{N^{edge}} h_{k,*}^{edge}   \right.
-
-            if (config_vel_correction) then
-               useVelocityCorrection = 1
-            else
-               useVelocityCorrection = 0
-            endif
-
+   
             !$omp parallel
-            !$omp do schedule(runtime) private(uTemp, normalThicknessFluxSum, thicknessSum, &
-            !$omp             k, normalVelocityCorrection)
-            do iEdge = 1, nEdges
-
-               ! velocity for normalVelocityCorrectionection is normalBarotropicVelocity + normalBaroclinicVelocity + uBolus
-               uTemp(:) = normalBarotropicVelocityNew(iEdge) + normalBaroclinicVelocityNew(:,iEdge) &
-                        + normalGMBolusVelocity(:,iEdge)
-
-               ! thicknessSum is initialized outside the loop because on land boundaries
-               ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
-               ! nonzero value to avoid a NaN.
-               normalThicknessFluxSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge) * uTemp(minLevelEdgeBot(iEdge))
-               thicknessSum  = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
-
-               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                  normalThicknessFluxSum = normalThicknessFluxSum + layerThickEdge(k,iEdge) * uTemp(k)
-                  thicknessSum  =  thicknessSum + layerThickEdge(k,iEdge)
-               enddo
-
-               normalVelocityCorrection = useVelocityCorrection * (( barotropicThicknessFlux(iEdge) - normalThicknessFluxSum) &
-                                        / thicknessSum)
-
-               do k = 1, nVertLevels
-
-                  ! normalTransportVelocity = normalBarotropicVelocity + normalBaroclinicVelocity + normalGMBolusVelocity
-                  !                         + normalVelocityCorrection
-                  ! This is u used in advective terms for layerThickness and tracers
-                  ! in tendency calls in stage 3.
-!mrp note: in QC version, there is an if (config_use_GM) on adding normalGMBolusVelocity
-! I think it is not needed because normalGMBolusVelocity=0 when GM not on.
-                  normalTransportVelocity(k,iEdge) &
-                        = edgeMask(k,iEdge) &
-                        *( normalBarotropicVelocityNew(iEdge) + normalBaroclinicVelocityNew(k,iEdge) &
-                         + normalGMBolusVelocity(k,iEdge) + normalVelocityCorrection )
-               enddo
-
-            end do ! iEdge
+            !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
+            do iEdge = 1,nEdgesHalo(1)
+               ! Compute the barotropic Coriolis term, -f*uPerp
+               CoriolisTerm = 0.0_RKIND
+               do i = 1, nEdgesOnEdge(iEdge)
+                  eoe = edgesOnEdge(i,iEdge)
+                  CoriolisTerm =  CoriolisTerm + weightsOnEdge(i,iEdge)   &
+                               * 0.5_RKIND                                  &
+                               * ( normalBarotropicVelocitySubcycleNew(eoe) &
+                                  +normalBarotropicVelocityCur(eoe) )       &
+                               * fEdge(eoe)
+               end do
+               barotropicCoriolisTerm(iEdge) = CoriolisTerm
+            end do
             !$omp end do
             !$omp end parallel
+   
+            do iEdge = 1, nEdgesOwned
+               temp_mask = edgeMask(1, iEdge)
+   
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+   
+               normalBarotropicVelocitySubcycleNew(iEdge)              &
+                  = temp_mask                                          &
+                  * (normalBarotropicVelocityCur(iEdge)                &
+                  - dt_si * (-barotropicCoriolisTerm(iEdge) + gravity     &
+                          *normalBarotropicVelocityNew(iEdge)          &
+                          /dcEdge(iEdge) - barotropicForcing(iEdge)))
+            end do ! iEdge
+   
+   
+            do iEdge = 1, nEdgesOwned
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+   
+               ! normBtrVelSubCur is at time n+0.5 if splitImplicitStep=1
+               !                     at time n+1.0 if splitImplicitStep=2
+               normalBarotropicVelocitySubcycleCur(iEdge)                &
+                  = 0.5_RKIND*normalBarotropicVelocitySubcycleNew(iEdge) &
+                  + 0.5_RKIND*normalBarotropicVelocityCur(iEdge)
+   
+               normalBarotropicVelocityNew(iEdge) &
+                  = normalBarotropicVelocitySubcycleCur(iEdge)
+   
+                         ! 0.25 = 0.5 * 0.5
+               sshEdge = 0.25_RKIND * (  sshSubcycleCur(cell1)   &
+                                       + sshSubcycleCur(cell2) ) &
+                       + 0.25_RKIND * (  sshSubcycleNew(cell1)   &
+                                       + sshSubcycleNew(cell2) )
+   
+               thicknessSum = sshEdge + min(bottomDepth(cell1), &
+                                            bottomDepth(cell2))
+   
+               barotropicThicknessFlux(iEdge) &
+                  = 0.5*(  normalBarotropicVelocitySubcycleNew(iEdge) &
+                         + normalBarotropicVelocityCur(iEdge) )       &
+                         * thicknessSum
+            end do ! iEdge
+   
+   
+            ! boundary update on F
+            call mpas_timer_start("si halo btr vel")
+            call mpas_dmpar_exch_group_create(domain, finalBtrGroupName)
+            call mpas_dmpar_exch_group_add_field(domain, &
+                      finalBtrGroupName, 'barotropicThicknessFlux')
+            call mpas_dmpar_exch_group_add_field(domain,             &
+                      finalBtrGroupName, 'normalBarotropicVelocity', &
+                                                       timeLevel=2)
+            call mpas_dmpar_exch_group_add_field(domain,             &
+                      finalBtrGroupName,                             &
+                                 'normalBarotropicVelocitySubcycle', &
+                                                       timeLevel=1)
+            call mpas_dmpar_exch_group_full_halo_exch(domain, &
+                      finalBtrGroupName)
+            call mpas_dmpar_exch_group_destroy(domain, finalBtrGroupName)
+            call mpas_timer_stop("si halo btr vel")
+   
+            call mpas_timer_stop("si btr vel update")
 
-            deallocate(uTemp)
+         !-------------------------------------------------------------!
+         end do ! siLargeIter
+         !-------------------------------------------------------------!
+         ! END   Large barotropic system iteration loop
+         !-------------------------------------------------------------!
 
-            block => block % next
-         end do  ! block
+         ! Check that you can compute SSH using the total sum or the
+         ! individual increments over the barotropic subcycles.
+         ! efficiency: This next block of code is really a check for
+         ! debugging, and can be removed later.
+         call mpas_timer_start('btr si ssh verif')
+
+         ! Correction velocity
+         !   normalVelocityCorrection = (Flux - Sum(h u*))/H
+         ! or, for the full latex version:
+         !{\bf u}^{corr} = \left( {\overline {\bf F}}
+         !  - \sum_{k=1}^{N^{edge}} h_{k,*}^{edge}
+         ! {\bf u}_k^{avg} \right)
+         ! \left/ \sum_{k=1}^{N^{edge}} h_{k,*}^{edge}   \right.
+
+         allocate(uTemp(nVertLevels))
+         nEdges = nEdgesHalo(config_num_halos-1 )
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(k, uTemp, normalThicknessFluxSum, &
+         !$omp         thicknessSum, normalVelocityCorrection)
+         do iEdge = 1, nEdges
+
+            ! velocity for normalVelocityCorrectionection is
+            ! normalBarotropicVelocity +
+            ! normalBaroclinicVelocity + uBolus
+            uTemp(:) = normalBarotropicVelocityNew(iEdge) &
+                   + normalBaroclinicVelocityNew(:,iEdge) &
+                   +       normalGMBolusVelocity(:,iEdge)
+
+            ! thicknessSum is initialized outside the loop because
+            ! on land boundaries maxLevelEdgeTop=0, but I want to
+            ! initialize thicknessSum with a nonzero value to avoid
+            ! a NaN.
+            normalThicknessFluxSum  &
+               = layerThickEdge(minLevelEdgeBot(iEdge),iEdge) &
+               * uTemp(minLevelEdgeBot(iEdge))
+            thicknessSum &
+               = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
+
+            do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
+               normalThicknessFluxSum = normalThicknessFluxSum + &
+                                        layerThickEdge(k,iEdge)* &
+                                        uTemp(k)
+               thicknessSum = thicknessSum + &
+                              layerThickEdge(k,iEdge)
+            enddo
+
+            normalVelocityCorrection = useVelocityCorrection* &
+                          ((barotropicThicknessFlux(iEdge) -  &
+                            normalThicknessFluxSum)/thicknessSum)
+
+            do k = 1, nVertLevels
+
+               ! normalTransportVelocity = normalBarotropicVelocity
+               !                         + normalBaroclinicVelocity
+               !                         + normalGMBolusVelocity
+               !                         + normalVelocityCorrection
+               ! This is u used in advective terms for layerThickness
+               ! and tracers in tendency calls in stage 3.
+               !mrp note: in QC version, there is an if
+               !    (config_use_GM) on adding normalGMBolusVelocity
+               !    I think it is not needed because
+               !    normalGMBolusVelocity=0 when GM not on.
+               normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge) &
+                        *(normalBarotropicVelocityNew(iEdge)   + &
+                          normalBaroclinicVelocityNew(k,iEdge) + &
+                          normalGMBolusVelocity(k,iEdge) + &
+                          normalVelocityCorrection )
+            enddo
+
+         end do ! iEdge
+         !$omp end do
+         !$omp end parallel
+
+         deallocate(uTemp)
+
          call mpas_timer_stop('btr si ssh verif')
 
          call mpas_timer_stop("si btr vel")
 
 
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         !
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          !  Stage 3: Tracer, density, pressure, vertical velocity prediction
-         !
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
          ! only compute tendencies for active tracers on last large iteration
-         if (split_implicit_step < config_n_ts_iter) then
+         if (splitImplicitStep < numTSIterations) then
             activeTracersOnly = .true.
          else
             activeTracersOnly = .false.
          endif
 
-         ! Thickness tendency computations and thickness halo updates are completed before tracer
-         ! tendency computations to allow monotonic advection.
+         ! Thickness tendency computations and thickness halo updates
+         ! are completed before tracer tendency computations to allow
+         ! monotonic advection.
+
          call mpas_timer_start('si thick tend')
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
-            call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
-            call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
-            call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessNew, 2)
+         ! compute vertAleTransportTop.  Use normalTransportVelocity
+         ! for advection of layerThickness and tracers.
+         ! Use time level 1 values of layerThickness and
+         ! layerThickEdge because layerThickness has not yet
+         ! been computed for time level 2.
+         call mpas_timer_start('thick vert trans vel top')
+         if (associated(highFreqThicknessNew)) then
+            call ocn_vert_transport_velocity_top(meshPool, &
+                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 layerThickEdge, normalTransportVelocity, sshCur, &
+                 dt, vertAleTransportTop, err, highFreqThicknessNew)
+         else
+            call ocn_vert_transport_velocity_top(meshPool, &
+                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 layerThickEdge, normalTransportVelocity, sshCur, &
+                 dt, vertAleTransportTop, err)
+         endif
+         call mpas_timer_stop('thick vert trans vel top')
 
-            ! compute vertAleTransportTop.  Use normalTransportVelocity for advection of layerThickness and tracers.
-            ! Use time level 1 values of layerThickness and layerThickEdge because
-            ! layerThickness has not yet been computed for time level 2.
-            call mpas_timer_start('thick vert trans vel top')
-            if (associated(highFreqThicknessNew)) then
-               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-                 layerThicknessCur, layerThickEdge, normalTransportVelocity, &
-                 sshCur, dt, vertAleTransportTop, err, highFreqThicknessNew)
-            else
-               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-                 layerThicknessCur, layerThickEdge, normalTransportVelocity, &
-                 sshCur, dt, vertAleTransportTop, err)
-            endif
-            call mpas_timer_stop('thick vert trans vel top')
+         call ocn_tend_thick(tendPool, forcingPool, meshPool)
 
-            call ocn_tend_thick(tendPool, forcingPool, meshPool)
-
-            block => block % next
-         end do
          call mpas_timer_stop('si thick tend')
 
          ! update halo for thickness tendencies
@@ -2580,379 +2498,408 @@ module ocn_time_integration_si
          call mpas_timer_stop("si halo thickness")
 
          call mpas_timer_start('si tracer tend', .false.)
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-            call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-            call mpas_pool_get_subpool(block % structs, 'shortwave', swForcingPool)
-            call ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, &
-                    dt, activeTracersOnly, 2)
 
-            block => block % next
-         end do
+         call ocn_tend_tracer(tendPool, statePool, forcingPool, &
+                              meshPool, swForcingPool, &
+                              dt, activeTracersOnly, 2)
+
          call mpas_timer_stop('si tracer tend')
 
          ! update halo for tracer tendencies
          call mpas_timer_start("si halo tracers")
-         call mpas_pool_get_subpool(domain % blocklist % structs, 'tend', tendPool)
-         call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
 
          call mpas_pool_begin_iteration(tracersTendPool)
-         do while ( mpas_pool_get_next_member(tracersTendPool, groupItr) )
-            if ( groupItr % memberType == MPAS_POOL_FIELD ) then
-               ! Only compute tendencies for active tracers if activeTracersOnly flag is true.
-               if ( .not.activeTracersOnly .or. trim(groupItr % memberName)=='activeTracersTend') then
-                  call mpas_dmpar_field_halo_exch(domain, groupItr % memberName)
+         do while (mpas_pool_get_next_member(tracersTendPool, &
+                                             groupItr) )
+            if (groupItr%memberType == MPAS_POOL_FIELD ) then
+               ! Only compute tendencies for active tracers if
+               ! activeTracersOnly flag is true.
+               if (.not. activeTracersOnly .or. &
+                   trim(groupItr%memberName)=='activeTracersTend') then
+                  call mpas_dmpar_field_halo_exch(domain, &
+                                                  groupItr%memberName)
                end if
             end if
          end do
+
          call mpas_timer_stop("si halo tracers")
 
          call mpas_timer_start('si loop fini')
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_dimension(block % dimensions, 'nCells', nCellsPtr)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdgesPtr)
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
+         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                                tracersGroupCur, 1)
+         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                                tracersGroupNew, 2)
+         call mpas_pool_get_array(statePool,   'normalVelocity', &
+                                                normalVelocityCur, 1)
+         call mpas_pool_get_array(tracersTendPool,'activeTracersTend', &
+                                                   activeTracersTend)
 
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-            call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-            call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-            call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-            call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         !  If iterating, reset variables for next iteration
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-            call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-            call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-            call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-            call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
-            call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+         if (splitImplicitStep < numTSIterations) then
 
-            call mpas_pool_get_array(tracersPool, 'activeTracers', tracersGroupCur, 1)
-            call mpas_pool_get_array(tracersPool, 'activeTracers', tracersGroupNew, 2)
-            call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
-            call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
-            call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
-            call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
-            call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessCur, 1)
-            call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessNew, 2)
-            call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceCur, 1)
-            call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceNew, 2)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityCur, 1)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityNew, 2)
-            call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityCur, 1)
-            call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityNew, 2)
+            ! Get indices for dynamic tracers (Includes T&S).
+            call mpas_pool_get_dimension(tracersPool,'activeGRP_start',&
+                                                      startIndex)
+            call mpas_pool_get_dimension(tracersPool,'activeGRP_end', &
+                                                      endIndex)
 
-            call mpas_pool_get_array(tendPool, 'layerThickness', layerThicknessTend)
-            call mpas_pool_get_array(tendPool, 'normalVelocity', normalVelocityTend)
-            call mpas_pool_get_array(tendPool, 'highFreqThickness', highFreqThicknessTend)
-            call mpas_pool_get_array(tendPool, 'lowFreqDivergence', lowFreqDivergenceTend)
+            ! Only need T & S for earlier iterations,
+            ! then all the tracers needed the last time through.
 
-            call mpas_pool_get_array(tracersTendPool, 'activeTracersTend', activeTracersTend)
+            !$omp parallel
+            !$omp do schedule(runtime) private(i, k, temp_h, temp)
+            do iCell = 1, nCellsAll
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
 
-            nCells = nCellsPtr
-            nEdges = nEdgesPtr
+               ! this is h_{n+1}
+               temp_h = layerThicknessCur(k,iCell) + dt* &
+               layerThicknessTend(k,iCell)
 
-            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            !
-            !  If iterating, reset variables for next iteration
-            !
-            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            if (split_implicit_step < config_n_ts_iter) then
+               ! this is h_{n+1/2}
+               layerThicknessNew(k,iCell) = 0.5* &
+               (layerThicknessCur(k,iCell) + temp_h)
 
-               ! Get indices for dynamic tracers (Includes T&S).
-               call mpas_pool_get_dimension(tracersPool, 'activeGRP_start', startIndex)
-               call mpas_pool_get_dimension(tracersPool, 'activeGRP_end', endIndex)
+               do i = startIndex, endIndex
+                  ! This is Phi at n+1
+                  temp = (tracersGroupCur(i,k,iCell)* &
+                          layerThicknessCur(k,iCell) + dt* &
+                          activeTracersTend(i,k,iCell))/temp_h
 
-               ! Only need T & S for earlier iterations,
-               ! then all the tracers needed the last time through.
+                  ! This is Phi at n+1/2
+                  tracersGroupNew(i,k,iCell) = 0.5_RKIND* &
+                            (tracersGroupCur(i,k,iCell) + temp)
+               end do ! tracer index
+            end do ! vertical
+            end do ! iCell
+            !$omp end do
+            !$omp end parallel
+
+            if (config_use_freq_filtered_thickness) then
 
                !$omp parallel
-               !$omp do schedule(runtime) private(k, temp_h, temp, i)
-               do iCell = 1, nCells
-                  ! sshNew is a pointer, defined above.
-                  do k = minLevelCell(iCell), maxLevelCell(iCell)
+               !$omp do schedule(runtime) private(k, temp)
+               do iCell = 1, nCellsAll
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
 
-                     ! this is h_{n+1}
-                     temp_h = layerThicknessCur(k,iCell) + dt * layerThicknessTend(k,iCell)
+                  ! h^{hf}_{n+1} was computed in Stage 1
 
-                     ! this is h_{n+1/2}
-                     layerThicknessNew(k,iCell) = 0.5*( layerThicknessCur(k,iCell) + temp_h)
+                  ! this is h^{hf}_{n+1/2}
+                  highFreqThicknessNew(k,iCell) = 0.5_RKIND* &
+                             (highFreqThicknessCur(k,iCell) + &
+                              highFreqThicknessNew(k,iCell))
 
-                     do i = startIndex, endIndex
-                        ! This is Phi at n+1
-                        temp = ( tracersGroupCur(i,k,iCell) * layerThicknessCur(k,iCell) + dt * activeTracersTend(i,k,iCell)) &
-                             / temp_h
+                  ! this is D^{lf}_{n+1}
+                  temp = lowFreqDivergenceCur(k,iCell) + dt* &
+                         lowFreqDivergenceTend(k,iCell)
 
-                        ! This is Phi at n+1/2
-                        tracersGroupNew(i,k,iCell) = 0.5_RKIND * ( tracersGroupCur(i,k,iCell) + temp )
-                     end do
-                  end do
-               end do ! iCell
-               !$omp end do
-               !$omp end parallel
-
-               if (config_use_freq_filtered_thickness) then
-                  !$omp parallel
-                  !$omp do schedule(runtime) private(k, temp)
-                  do iCell = 1, nCells
-                     do k = minLevelCell(iCell), maxLevelCell(iCell)
-
-                        ! h^{hf}_{n+1} was computed in Stage 1
-
-                        ! this is h^{hf}_{n+1/2}
-                        highFreqThicknessnew(k,iCell) = 0.5_RKIND * (highFreqThicknessCur(k,iCell) + highFreqThicknessNew(k,iCell))
-
-                        ! this is D^{lf}_{n+1}
-                        temp = lowFreqDivergenceCur(k,iCell) &
-                         + dt * lowFreqDivergenceTend(k,iCell)
-
-                        ! this is D^{lf}_{n+1/2}
-                        lowFreqDivergenceNew(k,iCell) = 0.5_RKIND * (lowFreqDivergenceCur(k,iCell) + temp)
-                     end do
-                  end do
-                  !$omp end do
-                  !$omp end parallel
-               end if
-
-               !$omp parallel
-               !$omp do schedule(runtime) private(k)
-               do iEdge = 1, nEdges
-
-                  do k = 1, nVertLevels
-
-                     ! u = normalBarotropicVelocity + normalBaroclinicVelocity
-                     ! here normalBaroclinicVelocity is at time n+1/2
-                     ! This is u used in next iteration or step
-                     normalVelocityNew(k,iEdge) = edgeMask(k,iEdge) * ( normalBarotropicVelocityNew(iEdge) &
-                                                + normalBaroclinicVelocityNew(k,iEdge) )
-
-                  enddo
-
-               end do ! iEdge
-               !$omp end do
-               !$omp end parallel
-
-               ! Efficiency note: We really only need this to compute layerThickEdge, density, pressure, and SSH
-               ! in this diagnostics solve.
-               call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
-
-
-            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            !
-            !  If large iteration complete, compute all variables at time n+1
-            !
-            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            elseif (split_implicit_step == config_n_ts_iter) then
-
-               !$omp parallel
-               !$omp do schedule(runtime) private(k)
-               do iCell = 1, nCells
-                  do k = minLevelCell(iCell), maxLevelCell(iCell)
-                     ! this is h_{n+1}
-                     layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell) + dt * layerThicknessTend(k,iCell)
-                  end do
+                  ! this is D^{lf}_{n+1/2}
+                  lowFreqDivergenceNew(k,iCell) = 0.5_RKIND* &
+                           (lowFreqDivergenceCur(k,iCell) + temp)
+               end do
                end do
                !$omp end do
                !$omp end parallel
+            end if
 
-               if (config_compute_active_tracer_budgets) then
-                  !$omp parallel
-                  !$omp do schedule(runtime) private(k)
-                  do iEdge = 1, nEdges
-                     do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-                        activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
-                          activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) / &
-                          layerThickEdge(k,iEdge)
-                     enddo
-                  enddo
-                  !$omp end do
+            !$omp parallel
+            !$omp do schedule(runtime) private(k)
+            do iEdge = 1, nEdgesAll
+            do k = 1, nVertLevels
 
-                  !$omp do schedule(runtime) private(k)
-                  do iCell = 1, nCells
-                     do k= minLevelCell(iCell), maxLevelCell(iCell)
-                        activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
-                           activeTracerHorizontalAdvectionTendency(:,k,iCell) / &
-                           layerThicknessNew(k,iCell)
+               ! u = normalBarotropicVelocity + normalBaroclinicVelocity
+               ! here normalBaroclinicVelocity is at time n+1/2
+               ! This is u used in next iteration or step
+               normalVelocityNew(k,iEdge) = edgeMask(k,iEdge)* &
+                         ( normalBarotropicVelocityNew(iEdge) + &
+                           normalBaroclinicVelocityNew(k,iEdge) )
 
-                        activeTracerVerticalAdvectionTendency(:,k,iCell) = &
-                           activeTracerVerticalAdvectionTendency(:,k,iCell) / &
-                           layerThicknessNew(k,iCell)
+            enddo
+            end do ! iEdge
+            !$omp end do
+            !$omp end parallel
 
-                        activeTracerSurfaceFluxTendency(:,k,iCell) = &
-                           activeTracerSurfaceFluxTendency(:,k,iCell) / &
-                           layerThicknessNew(k,iCell)
+            ! Efficiency note: We really only need this to compute
+            ! layerThickEdge, density, pressure, and SSH
+            ! in this diagnostics solve.
+            call ocn_diagnostic_solve(dt, statePool, forcingPool, &
+                                      meshPool, scratchPool, &
+                                      tracersPool, 2, full=.false.)
 
-                        temperatureShortWaveTendency(k,iCell) = &
-                           temperatureShortWaveTendency(k,iCell) / &
-                           layerThicknessNew(k,iCell)
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         ! If large iteration complete, compute all variables at
+         ! time n+1
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-                        activeTracerNonLocalTendency(:,k,iCell) = &
-                           activeTracerNonLocalTendency(:,k,iCell) / &
-                           layerThicknessNew(k,iCell)
+         elseif (splitImplicitStep == numTSIterations) then
+
+            !$omp parallel
+            !$omp do schedule(runtime) private(k)
+            do iCell = 1, nCellsAll
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               ! this is h_{n+1}
+               layerThicknessNew(k,iCell) = &
+                                     layerThicknessCur(k,iCell) + &
+                                  dt*layerThicknessTend(k,iCell)
+            end do
+            end do
+            !$omp end do
+            !$omp end parallel
+
+            if (config_compute_active_tracer_budgets) then
+
+               !$omp parallel
+               !$omp do schedule(runtime) private(k)
+               do iEdge = 1, nEdgesAll
+               do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+                  activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
+                  activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) / &
+                       layerThickEdge(k,iEdge)
+               enddo
+               enddo
+               !$omp end do
+
+               !$omp do schedule(runtime) private(k)
+               do iCell = 1, nCellsAll
+               do k= minLevelCell(iCell), maxLevelCell(iCell)
+                  activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
+                  activeTracerHorizontalAdvectionTendency(:,k,iCell) / &
+                            layerThicknessNew(k,iCell)
+
+                  activeTracerVerticalAdvectionTendency(:,k,iCell) = &
+                  activeTracerVerticalAdvectionTendency(:,k,iCell) / &
+                            layerThicknessNew(k,iCell)
+
+                  activeTracerHorMixTendency(:,k,iCell) = &
+                  activeTracerHorMixTendency(:,k,iCell) / &
+                             layerThicknessNew(k,iCell)
+
+                  activeTracerSurfaceFluxTendency(:,k,iCell) = &
+                  activeTracerSurfaceFluxTendency(:,k,iCell) / &
+                             layerThicknessNew(k,iCell)
+
+                  temperatureShortWaveTendency(k,iCell) = &
+                  temperatureShortWaveTendency(k,iCell) / &
+                             layerThicknessNew(k,iCell)
+
+                  activeTracerNonLocalTendency(:,k,iCell) = &
+                  activeTracerNonLocalTendency(:,k,iCell) / &
+                             layerThicknessNew(k,iCell)
+               end do
+               end do
+               !$omp end do
+               !$omp end parallel
+            endif
+
+            call mpas_pool_begin_iteration(tracersPool)
+            do while (mpas_pool_get_next_member(tracersPool, &
+                                                groupItr) )
+               if (groupItr%memberType == MPAS_POOL_FIELD) then
+                  configName = 'config_use_'//trim(groupItr%memberName)
+                  call mpas_pool_get_config(domain%configs, &
+                                configName, config_use_tracerGroup)
+
+                  if ( config_use_tracerGroup ) then
+                     call mpas_pool_get_array(tracersPool, &
+                                              groupItr%memberName, &
+                                              tracersGroupCur, 1)
+                     call mpas_pool_get_array(tracersPool, &
+                                              groupItr%memberName, &
+                                              tracersGroupNew, 2)
+
+                     modifiedGroupName = &
+                             trim(groupItr % memberName) // 'Tend'
+                     call mpas_pool_get_array(tracersTendPool, &
+                                              modifiedGroupName, &
+                                              tracersGroupTend)
+
+                     !$omp parallel
+                     !$omp do schedule(runtime) private(k)
+                     do iCell = 1, nCellsAll
+                     do k = minLevelCell(iCell), maxLevelCell(iCell)
+                        tracersGroupNew(:,k,iCell) = &
+                       (tracersGroupCur(:,k,iCell) * &
+                        layerThicknessCur(k,iCell) + dt* &
+                       tracersGroupTend(:,k,iCell))/ &
+                        layerThicknessNew(k,iCell)
                      end do
-                  end do
-                  !$omp end do
-                  !$omp end parallel
-               endif
+                     end do
+                     !$omp end do
+                     !$omp end parallel
 
-               call mpas_pool_begin_iteration(tracersPool)
-               do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
-                  if ( groupItr % memberType == MPAS_POOL_FIELD ) then
-                     configName = 'config_use_' // trim(groupItr % memberName)
-                     call mpas_pool_get_config(domain % configs, configName, config_use_tracerGroup)
-
-                     if ( config_use_tracerGroup ) then
-                        call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupCur, 1)
-                        call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupNew, 2)
-
-                        modifiedGroupName = trim(groupItr % memberName) // 'Tend'
-                        call mpas_pool_get_array(tracersTendPool, modifiedGroupName, tracersGroupTend)
-
+                     ! limit salinity in separate loop
+                     if (trim(groupItr%memberName) == &
+                         'activeTracers' ) then
                         !$omp parallel
                         !$omp do schedule(runtime) private(k)
-                        do iCell = 1, nCells
-                           do k = minLevelCell(iCell), maxLevelCell(iCell)
-                              tracersGroupNew(:,k,iCell) = (tracersGroupCur(:,k,iCell) * layerThicknessCur(k,iCell) + dt &
-                                                         * tracersGroupTend(:,k,iCell) ) / layerThicknessNew(k,iCell)
-                           end do
+                        do iCell = 1, nCellsAll
+                        do k = minLevelCell(iCell), maxLevelCell(iCell)
+                           tracersGroupNew(indexSalinity,k,iCell) = &
+                           max(0.001_RKIND,  &
+                           tracersGroupNew(indexSalinity,k,iCell))
+                        end do
                         end do
                         !$omp end do
                         !$omp end parallel
-
-                        ! limit salinity in separate loop
-                        if ( trim(groupItr % memberName) == 'activeTracers' ) then
-                           !$omp parallel
-                           !$omp do schedule(runtime) private(k)
-                           do iCell = 1, nCells
-                              do k = minLevelCell(iCell), maxLevelCell(iCell)
-                                 tracersGroupNew(indexSalinity,k,iCell) = max(0.001_RKIND, tracersGroupNew(indexSalinity,k,iCell))
-                              end do
-                           end do
-                           !$omp end do
-                           !$omp end parallel
-                        end if
-
                      end if
-                  end if
-               end do
 
-               if (config_use_freq_filtered_thickness) then
-                  !$omp parallel
-                  !$omp do schedule(runtime) private(k)
-                  do iCell = 1, nCells
-                     do k = minLevelCell(iCell), maxLevelCell(iCell)
+                     ! Reset debugTracers to fixed value at the surface
+                     if (trim(groupItr % memberName) == &
+                         'debugTracers' .and. &
+                         config_reset_debugTracers_near_surface) then
 
-                        ! h^{hf}_{n+1} was computed in Stage 1
+                        !$omp parallel
+                        !$omp do schedule(runtime) private(k, lat)
+                        do iCell = 1, nCellsAll
 
-                        ! this is D^{lf}_{n+1}
-                        lowFreqDivergenceNew(k,iCell) = lowFreqDivergenceCur(k,iCell) + dt * lowFreqDivergenceTend(k,iCell)
-                     end do
-                  end do
-                  !$omp end do
-                  !$omp end parallel
-               end if
+                           ! Reset tracer1 to 2 in top n layers
+                           do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
+                                tracersGroupNew(1,k,iCell) = 2.0_RKIND
+                           end do
 
+                           ! Reset tracer2 to 2 in top n layers
+                           ! in zonal bands, and 1 outside
+                           lat = latCell(iCell)*180./3.1415
+                           if (     lat>-60.0.and.lat<-55.0 &
+                                .or.lat>-40.0.and.lat<-35.0 &
+                                .or.lat>- 2.5.and.lat<  2.5 &
+                                .or.lat> 35.0.and.lat< 40.0 &
+                                .or.lat> 55.0.and.lat< 60.0 ) then
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
+                                 tracersGroupNew(2,k,iCell) = 2.0_RKIND
+                              end do
+                           else
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
+                                 tracersGroupNew(2,k,iCell) = 1.0_RKIND
+                              end do
+                           end if
 
-               ! Recompute final u to go on to next step.
-               ! u_{n+1} = normalBarotropicVelocity_{n+1} + normalBaroclinicVelocity_{n+1}
-               ! Right now normalBaroclinicVelocityNew is at time n+1/2, so back compute to get normalBaroclinicVelocity
-               !   at time n+1 using normalBaroclinicVelocity_{n+1/2} = 1/2*(normalBaroclinicVelocity_n + u_Bcl_{n+1})
-               ! so the following lines are
-               ! u_{n+1} = normalBarotropicVelocity_{n+1} + 2*normalBaroclinicVelocity_{n+1/2} - normalBaroclinicVelocity_n
-               ! note that normalBaroclinicVelocity is recomputed at the beginning of the next timestep due to Imp Vert mixing,
-               ! so normalBaroclinicVelocity does not have to be recomputed here.
+                           ! Reset tracer3 to 2 in top n layers
+                           ! in zonal bands, and 1 outside
+                           lat = latCell(iCell)*180./3.1415
+                           if (     lat>-55.0.and.lat<-50.0 &
+                                .or.lat>-35.0.and.lat<-30.0 &
+                                .or.lat>-15.0.and.lat<-10.0 &
+                                .or.lat> 10.0.and.lat< 15.0 &
+                                .or.lat> 30.0.and.lat< 35.0 &
+                                .or.lat> 50.0.and.lat< 55.0 ) then
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
+                                 tracersGroupNew(3,k,iCell) = 2.0_RKIND
+                              end do
+                           else
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
+                                 tracersGroupNew(3,k,iCell) = 1.0_RKIND
+                              end do
+                           end if
+                        end do ! cells
+                        !$omp end do
+                        !$omp end parallel
+                     end if ! debug tracers
+                  end if ! use tracer group
+               end if ! tracer
+            end do ! tracer group
 
+            if (config_use_freq_filtered_thickness) then
                !$omp parallel
                !$omp do schedule(runtime) private(k)
-               do iEdge = 1, nEdges
-                  do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-                     normalVelocityNew(k,iEdge) = normalBarotropicVelocityNew(iEdge) + 2 * normalBaroclinicVelocityNew(k,iEdge) &
-                                                - normalBaroclinicVelocityCur(k,iEdge)
-                  end do
-               end do ! iEdges
+               do iCell = 1, nCellsAll
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
+
+                  ! h^{hf}_{n+1} was computed in Stage 1
+
+                  ! this is D^{lf}_{n+1}
+                  lowFreqDivergenceNew(k,iCell) = &
+                  lowFreqDivergenceCur(k,iCell) + dt* &
+                  lowFreqDivergenceTend(k,iCell)
+               end do
+               end do
                !$omp end do
                !$omp end parallel
+            end if
 
-            endif ! split_implicit_step
+            ! Recompute final u to go on to next step.
+            ! u_{n+1} = normalBarotropicVelocity_{n+1} +
+            !           normalBaroclinicVelocity_{n+1}
+            ! Right now normalBaroclinicVelocityNew is at time n+1/2,
+            ! so back compute to get normalBaroclinicVelocity at
+            ! time n+1 using normalBaroclinicVelocity_{n+1/2} =
+            !            1/2*(normalBaroclinicVelocity_n + u_Bcl_{n+1})
+            ! so the following lines are
+            ! u_{n+1} = normalBarotropicVelocity_{n+1} +
+            !         2*normalBaroclinicVelocity_{n+1/2} -
+            !         normalBaroclinicVelocity_n
+            ! note that normalBaroclinicVelocity is recomputed at the
+            ! beginning of the next timestep due to Imp Vert mixing,
+            ! so normalBaroclinicVelocity does not have to be
+            ! recomputed here.
 
-            block => block % next
-         end do
+            !$omp parallel
+            !$omp do schedule(runtime) private(k)
+            do iEdge = 1, nEdgesAll
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+               normalVelocityNew(k,iEdge) = &
+                               normalBarotropicVelocityNew(iEdge) + &
+                             2*normalBaroclinicVelocityNew(k,iEdge) - &
+                               normalBaroclinicVelocityCur(k,iEdge)
+            end do
+            end do ! iEdges
+            !$omp end do
+            !$omp end parallel
+
+            endif ! splitImplicitStep
 
          call mpas_timer_stop('si loop fini')
          call mpas_timer_stop('si loop')
 
-      end do  ! split_implicit_step = 1, config_n_ts_iter
+      end do  ! splitImplicitStep = 1, config_n_ts_iter
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! END large iteration loop
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       call mpas_timer_start("si implicit vert mix")
 
-      block => domain % blocklist
-      do while(associated(block))
-        call mpas_pool_get_subpool(block % structs, 'state', statePool)
-        call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-        call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-        call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-        call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-
-        ! Call ocean diagnostic solve in preparation for vertical mixing.  Note
-        ! it is called again after vertical mixing, because u and tracers change.
-        ! For Richardson vertical mixing, only density, layerThickEdge, and kineticEnergyCell need to
-        ! be computed.  For kpp, more variables may be needed.  Either way, this
-        ! could be made more efficient by only computing what is needed for the
-        ! implicit vmix routine that follows.
-        call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
-
-        block => block % next
-      end do
+      ! Call ocean diagnostic solve in preparation for vertical mixing.
+      ! Note it is called again after vertical mixing, because u and
+      ! tracers change. For Richardson vertical mixing, only density,
+      ! layerThickEdge, and kineticEnergyCell need to be computed.
+      ! For kpp, more variables may be needed.  Either way, this could
+      ! be made more efficient by only computing what is needed for the
+      ! implicit vmix routine that follows.
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+                                scratchPool, tracersPool, 2)
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
 
-      block => domain % blocklist
-      do while(associated(block))
-        call mpas_pool_get_subpool(block % structs, 'state', statePool)
-        call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-        call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-        call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-        call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+      ! Compute normalGMBolusVelocity; it will be added to the
+      ! baroclinic modes in Stage 2 above.
+      !if (config_use_GM.or.config_use_Redi) then
+      !   call ocn_gm_compute_Bolus_velocity(statePool, &
+      !             meshPool, scratchPool, timeLevelIn=2)
+      !end if
+      call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, &
+                             scratchPool, err, 2)
 
-        ! Compute normalGMBolusVelocity; it will be added to the baroclinic modes in Stage 2 above.
-        ! mrp delete these lines, it is called from driver now.
-        !if (config_use_GM) then
-        !   call ocn_gm_compute_Bolus_velocity(meshPool, scratchPool)
-        !end if
-        call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
+      ! Update halo on u and tracers, which were just updated for
+      ! implicit vertical mixing.  If not done, this leads to lack of
+      ! volume conservation.  It is required because halo updates in
+      ! stage 3 are only conducted on tendencies, not on the velocity
+      ! and tracer fields.  So this update is required to communicate
+      ! the change due to implicit vertical mixing across the boundary.
 
-        block => block % next
-      end do
-
-      ! Update halo on u and tracers, which were just updated for implicit vertical mixing.  If not done,
-      ! this leads to lack of volume conservation.  It is required because halo updates in stage 3 are only
-      ! conducted on tendencies, not on the velocity and tracer fields.  So this update is required to
-      ! communicate the change due to implicit vertical mixing across the boundary.
       call mpas_timer_start('si vmix halos')
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
-      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
 
       call mpas_timer_start('si vmix halos normalVelFld')
-      call mpas_dmpar_field_halo_exch(domain, 'normalVelocity', timeLevel=2)
+      call mpas_dmpar_field_halo_exch(domain, 'normalVelocity', &
+                                      timeLevel=2)
       call mpas_timer_stop('si vmix halos normalVelFld')
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
-         if ( groupItr % memberType == MPAS_POOL_FIELD ) then
-            call mpas_dmpar_field_halo_exch(domain, groupItr % memberName, timeLevel=2)
+         if (groupItr%memberType == MPAS_POOL_FIELD) then
+            call mpas_dmpar_field_halo_exch(domain, &
+                         groupItr%memberName, timeLevel=2)
          end if
       end do
       call mpas_timer_stop('si vmix halos')
@@ -2960,105 +2907,92 @@ module ocn_time_integration_si
       call mpas_timer_stop("si implicit vert mix")
 
       call mpas_timer_start('si fini')
-      block => domain % blocklist
-      do while (associated(block))
-         call mpas_pool_get_subpool(block % structs, 'state', statePool)
-         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
-         call mpas_pool_get_dimension(block % dimensions, 'nCells', nCellsPtr)
-         call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdgesPtr)
-         call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-         call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
-
-         call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
-         call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
-         call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
-         call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
-
-         nCells = nCellsPtr
-         nEdges = nEdgesPtr
-
-         if (config_prescribe_velocity) then
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge = 1, nEdges
-               normalVelocityNew(:, iEdge) = normalVelocityCur(:, iEdge)
-            end do
-            !$omp end do
-            !$omp end parallel
-         end if
-
-         if (config_prescribe_thickness) then
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iCell = 1, nCells
-               layerThicknessNew(:, iCell) = layerThicknessCur(:, iCell)
-            end do
-            !$omp end do
-            !$omp end parallel
-         end if
-
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
-
-         ! Update the effective desnity in land ice if we're coupling to land ice
-         call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, err)
-
-         ! Compute normalGMBolusVelocity; it will be added to normalVelocity in Stage 2 of the next cycle.
-         ! mrp delete these lines, it is called from driver now.
-         !if (config_use_GM) then
-         !   call ocn_gm_compute_Bolus_velocity(meshPool, scratchPool)
-         !end if
-
-         call mpas_timer_start('si final mpas reconstruct', .false.)
-
-         call mpas_reconstruct(meshPool, normalVelocityNew,  &
-                          velocityX, velocityY, velocityZ,   &
-                          velocityZonal, velocityMeridional, &
-                          includeHalos = .true.)
-
-         call mpas_reconstruct(meshPool, gradSSH,          &
-                          gradSSHX, gradSSHY, gradSSHZ,    &
-                          gradSSHZonal, gradSSHMeridional, &
-                          includeHalos = .true.)
-
-         call mpas_timer_stop('si final mpas reconstruct')
-
+      if (config_prescribe_velocity) then
          !$omp parallel
-         !$omp do schedule(runtime)
-         do iCell = 1, nCells
-            surfaceVelocity(indexSurfaceVelocityZonal, iCell) = velocityZonal(1, iCell)
-            surfaceVelocity(indexSurfaceVelocityMeridional, iCell) = velocityMeridional(1, iCell)
-
-            SSHGradient(indexSSHGradientZonal, iCell) = gradSSHZonal(iCell)
-            SSHGradient(indexSSHGradientMeridional, iCell) = gradSSHMeridional(iCell)
+         !$omp do schedule(runtime) private(k)
+         do iEdge = 1, nEdgesAll
+         do k=1,nVertLevels
+            normalVelocityNew(k,iEdge) = normalVelocityCur(k,iEdge)
+         end do
          end do
          !$omp end do
          !$omp end parallel
+      end if
 
-         call ocn_time_average_coupled_accumulate(statePool, forcingPool, 2)
+      if (config_prescribe_thickness) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCellsAll
+         do k=1,nVertLevels
+            layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
+         end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
 
-         if (config_use_GM) then
-            call ocn_reconstruct_gm_vectors(meshPool)
-         end if
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+                                scratchPool, tracersPool, 2)
 
-         block => block % next
+      ! Update the effective desnity in land ice if we're coupling to
+      ! land ice
+      call ocn_effective_density_in_land_ice_update(meshPool, &
+                                       forcingPool, statePool, err)
+
+      !! Compute normalGMBolusVelocity; it will be added to
+      !! normalVelocity in Stage 2 of the next cycle.
+      !if (config_use_GM.or.config_use_Redi) then
+      !   call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool,&
+      !                           meshPool, scratchPool, timeLevelIn=2)
+      !end if
+
+      call mpas_timer_start('si final mpas reconstruct', .false.)
+
+      call mpas_reconstruct(meshPool, normalVelocityNew,  &
+                            velocityX, velocityY, velocityZ,   &
+                            velocityZonal, velocityMeridional, &
+                            includeHalos = .true.)
+
+      call mpas_reconstruct(meshPool, gradSSH,               &
+                            gradSSHX, gradSSHY, gradSSHZ,    &
+                            gradSSHZonal, gradSSHMeridional, &
+                            includeHalos = .true.)
+
+      call mpas_timer_stop('si final mpas reconstruct')
+
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCellsAll
+         surfaceVelocity(indexSurfaceVelocityZonal,iCell) = &
+                                   velocityZonal(minLevelCell(iCell),iCell)
+         surfaceVelocity(indexSurfaceVelocityMeridional,iCell) = &
+                                   velocityMeridional(minLevelCell(iCell),iCell)
+
+         SSHGradient(indexSSHGradientZonal,iCell) = gradSSHZonal(iCell)
+         SSHGradient(indexSSHGradientMeridional,iCell) = &
+                                               gradSSHMeridional(iCell)
       end do
+      !$omp end do
+      !$omp end parallel
+
+      call ocn_time_average_coupled_accumulate(statePool,forcingPool,2)
+
+      if (config_use_GM) then
+         call ocn_reconstruct_gm_vectors(meshPool)
+      end if
 
       if (trim(config_land_ice_flux_mode) == 'coupled') then
          call mpas_timer_start("si effective density halo")
-         call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
-         call mpas_pool_get_field(statePool, 'effectiveDensityInLandIce', effectiveDensityField, 2)
+         call mpas_pool_get_field(statePool, &
+                                 'effectiveDensityInLandIce', &
+                                  effectiveDensityField, 2)
          call mpas_dmpar_exch_halo_field(effectiveDensityField)
-         call mpas_timer_stop("se effective density halo")
+         call mpas_timer_stop("si effective density halo")
       end if
 
       call mpas_timer_stop('si fini')
       call mpas_timer_stop("si timestep")
-
-      deallocate(n_bcl_iter)
 
    end subroutine ocn_time_integrator_si!}}}
 
@@ -3069,264 +3003,332 @@ module ocn_time_integration_si
 !> \brief   Initialize semi-implicit time stepping within MPAS-Ocean
 !> \author  Mark Petersen
 !> \date    September 2011
+!
+!> \author  Hyun-Gyu Kang (ORNL, for the semi-implicit code)
+!> \date    September 2019
 !> \details
-!>  This routine initializes variables required for semi-implicit time
-!>  integration. It also calls the routine to compute the preconditioner
-!>  for the implicit solver.
+!>  This routine initializes variables required for the split-implicit
+!>  method of integrating the ocean model forward in time
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_time_integration_si_init(domain, dt)!{{{
+   subroutine ocn_time_integration_si_init(domain)!{{{
 
       !-----------------------------------------------------------------
-      ! Input variables
+      ! Input/output variables
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), intent(in) :: dt !< [in] time step (sec)
-
-      type (domain_type), intent(inout) :: domain
+      type (domain_type), intent(inout) :: &
+         domain  !< [inout] model state to advance forward
 
       !-----------------------------------------------------------------
-      ! local variables
+      ! Local variables
       !-----------------------------------------------------------------
-      integer :: i, iCell, iEdge, iVertex, k
-      type (block_type), pointer :: block
 
-      type (mpas_pool_type), pointer :: statePool, meshPool, tracersPool
-      type (dm_info) :: dminfo
+      type (block_type), pointer :: &
+         block ! structure with subdomain data
 
-      integer :: iTracer, cell, cell1, cell2
-      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, minLevelCell, maxLevelCell
+      type (mpas_pool_type), pointer :: &
+         statePool,         &! structure holding state variables
+         meshPool            ! structure holding mesh variables
+
+      integer, pointer :: nVertLevels
+
+      integer ::         &
+         iCell, iEdge, k,&! loop indices for cell, edge and vertical
+         kmax,           &! index of deepest active edge
+         ierr,           &! local error flag
+         cell1, cell2     ! neighbor cell indices across edge
+
+      integer :: nCells, nEdges, ihh, imm, iss
+
+      integer, dimension(:), pointer :: nCellsArray, nEdgesArray,     &
+         minLevelEdgeBot, maxLevelEdgeTop, minLevelCell, maxLevelCell
+
       integer, dimension(:,:), pointer :: cellsOnEdge
-      real (kind=RKIND) :: normalThicknessFluxSum, layerThicknessSum, layerThickEdge1
-      real (kind=RKIND), dimension(:), pointer :: refBottomDepth, normalBarotropicVelocity
-      real (kind=RKIND), dimension(:), pointer :: sshCur,bottomDepth
 
-      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
-      real (kind=RKIND), dimension(:,:), pointer :: normalBaroclinicVelocity, normalVelocity
-      integer, pointer :: nVertLevels, nCells, nEdges
-      character (len=StrKIND), pointer :: config_time_integrator, config_btr_dt, config_dt
-      logical, pointer :: config_filter_btr_mode, config_do_restart
-      integer, pointer :: config_n_ts_iter
+      real (kind=RKIND) ::       &
+         normalThicknessFluxSum, &! vertical sum of thick flux
+         layerThicknessSum,      &! vertical sum of layer thickness
+         layerThicknessEdge1,    &! layer thickness on edge
+         area_mean,              &! RMS of areaCell
+         local_num_cells,        &! number of cells for each core
+         local_area_sum,         &! local sum of area
+         total_area_sum,         &! total sum of area
+         tmp1,tmp2
 
-      type (mpas_time_type) :: nowTime
-      type (mpas_timeInterval_type) :: fullTimeStep, barotropicTimeStep, remainder, zeroInterval
+      real (kind=RKIND), dimension(:), pointer :: &
+         areaCell,               &! area of each cell
+         bottomDepth,            &! bottom depth
+         refBottomDepth,         &! reference bottom depth
+         normalBarotropicVelocity ! normal barotropic velocity
 
-      integer :: iErr
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         layerThickness,           &! layer thickness cell center
+         normalBaroclinicVelocity, &! normal baroclinic velocity
+         normalVelocity             ! normal velocity (total)
 
-      integer, dimension(:), pointer :: nCellsArray, nEdgesArray
-      real (kind=RKIND) :: local_num_cells,sum1,total_area_sum,local_area_sum,tmp1,tmp2,area_mean
-      real (kind=RKIND), dimension(:), pointer :: areaCell
-      integer :: ihh,imm,iss,isum1,isum2,mpi_ierr
-
-      ! End preamble
-      !-------------
-      ! Begin code
+      real (kind=RKIND), dimension(:), pointer :: sshCur
 
 #ifndef USE_LAPACK
       call mpas_log_write( &
-         'MPAS was not compiled with LAPACK/BLAS: required for SI', &
-          MPAS_LOG_CRIT)
+      'MPAS was not compiled with LAPACK/BLAS. LAPACK required for SI' &
+      , MPAS_LOG_CRIT)
 #endif
 
-      dminfo = domain % dminfo
-      ncpus = dminfo % nprocs
+      !*** Set mask for using velocity correction
+      if (config_vel_correction) then
+         useVelocityCorrection = 1.0_RKIND
+      else
+         useVelocityCorrection = 0.0_RKIND
+      endif
 
-      call mpas_pool_get_config(domain % configs, 'config_do_restart', config_do_restart)
+      !*** Determine the time integration type and set associated masks
 
-      ! Determine the number of barotropic subcycles based on the ratio of time steps
-      call mpas_pool_get_config(domain % configs, 'config_time_integrator', config_time_integrator)
-      call mpas_pool_get_config(domain % configs, 'config_btr_dt', config_btr_dt)
-      call mpas_pool_get_config(domain % configs, 'config_dt', config_dt)
-      call mpas_pool_get_config(domain % configs, 'config_n_ts_iter', config_n_ts_iter)
+      select case (trim(config_time_integrator))
 
-      nowTime = mpas_get_clock_time(domain % clock, MPAS_NOW, ierr)
-      call mpas_set_timeInterval( zeroInterval, S=0 )
+      case ('semi_implicit')
 
-      call mpas_set_timeInterval( fullTimeStep , timeString=config_dt )
+         call mpas_log_write( &
+         '***********************************************************')
+         call mpas_log_write( &
+         'The semi-implicit time integration is configured')
+         call mpas_log_write( &
+         '***********************************************************')
 
-      call mpas_log_write( '*******************************************************************************')
-      call mpas_log_write( 'The semi-implicit time integration is configured')
-      call mpas_log_write( '*******************************************************************************')
+      case default
+         call mpas_log_write('Incorrect choice config_time_integrator',&
+                             MPAS_LOG_CRIT)
 
-         ! Initialize z-level mesh variables from h, read in from input file.
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_config(block % configs, 'config_time_integrator', config_time_integrator)
-            call mpas_pool_get_config(block % configs, 'config_filter_btr_mode', config_filter_btr_mode)
-            call mpas_pool_get_subpool(block % structs, 'state', statePool)
-            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-            call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      end select
 
-            call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
-            call mpas_pool_get_dimension(block % dimensions, 'nCells', nCells)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
-            call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-            call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
+      !*** set number of baroclinic iterations on each outer
+      !*** time step iteration (number can be different on the
+      !*** first and last time step iteration)
 
-            call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
-            call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
-            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocity, 1)
-            call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocity, 1)
+      numTSIterations = config_n_ts_iter
 
-            call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
-            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-            call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
-            call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-            call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-            call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-            call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-            call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-            call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
+      allocate(numClinicIterations(numTSIterations))
 
-            if ( .not. config_do_restart ) then
+      numClinicIterations    = config_n_bcl_iter_mid ! most iterations
+      numClinicIterations(1) = config_n_bcl_iter_beg ! first iteration
+      numClinicIterations(numTSIterations)=config_n_bcl_iter_end !last
 
-            ! Compute barotropic velocity at first timestep
-            ! This is only done upon start-up.
-               if (config_filter_btr_mode) then
-                  do iCell = 1, nCells
-                     layerThickness(1,iCell) = refBottomDepth(1)
-                  enddo
-               endif
+      block => domain % blocklist
 
-               do iEdge = 1, nEdges
-                  cell1 = cellsOnEdge(1,iEdge)
-                  cell2 = cellsOnEdge(2,iEdge)
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'state', statePool)
 
-                  ! normalBarotropicVelocity = sum(h*u)/sum(h) on each edge
-                  ! ocn_diagnostic_solve has not yet been called, so compute hEdge
-                  ! just for this edge.
+      call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', &
+                                                        nVertLevels)
 
-                  ! thicknessSum is initialized outside the loop because on land boundaries
-                  ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
-                  ! nonzero value to avoid a NaN.
-                  layerThickEdge1 = 0.5_RKIND*( layerThickness(minLevelCell(cell1),cell1) + layerThickness(minLevelCell(cell2),cell2) )
-                  normalThicknessFluxSum = layerThickEdge1 * normalVelocity(minLevelEdgeBot(iEdge),iEdge)
-                  layerThicknessSum = layerThickEdge1
+      call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', &
+                                                        nCellsArray)
+      call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', &
+                                                        nEdgesArray)
 
-                  do k=minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                     ! ocn_diagnostic_solve has not yet been called, so compute hEdge
-                     ! just for this edge.
-                     layerThickEdge1 = 0.5_RKIND*( layerThickness(k,cell1) + layerThickness(k,cell2) )
+      call mpas_pool_get_array(statePool, 'layerThickness', &
+                                           layerThickness, 1)
+      call mpas_pool_get_array(statePool, 'normalVelocity', &
+                                           normalVelocity, 1)
+      call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', &
+                                           normalBarotropicVelocity, 1)
+      call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
+                                           normalBaroclinicVelocity, 1)
 
-                     normalThicknessFluxSum = normalThicknessFluxSum &
-                        + layerThickEdge1 * normalVelocity(k,iEdge)
-                     layerThicknessSum = layerThicknessSum + layerThickEdge1
+      call mpas_pool_get_array(meshPool, 'refBottomDepth', &
+                                          refBottomDepth)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', &
+                                          cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', &
+                                          minLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', &
+                                          maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
-                  enddo
-                  normalBarotropicVelocity(iEdge) = normalThicknessFluxSum / layerThicknessSum
+      call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
 
-                  ! normalBaroclinicVelocity(k,iEdge) = normalVelocity(k,iEdge) - normalBarotropicVelocity(iEdge)
-                  do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-                     normalBaroclinicVelocity(k,iEdge) = normalVelocity(k,iEdge) - normalBarotropicVelocity(iEdge)
-                  enddo
+      nCells = nCellsArray(config_num_halos)
+      nEdges = nEdgesArray(config_num_halos+1)
 
-                  ! normalBaroclinicVelocity=0, normalVelocity=0 on land cells
-                  do k = maxLevelEdgeTop(iEdge)+1, nVertLevels
-                     normalBaroclinicVelocity(k,iEdge) = 0.0_RKIND
-                     normalVelocity(k,iEdge) = 0.0_RKIND
-                  enddo
+      if ( .not. config_do_restart ) then
 
-               enddo
-
-               if (config_filter_btr_mode) then
-                  ! filter normalBarotropicVelocity out of initial condition
-
-                   normalVelocity(:,:) = normalBaroclinicVelocity(:,:)
-                   normalBarotropicVelocity(:) = 0.0_RKIND
-
-               endif
-
-            endif ! .not. config_do_restart
-
-            ! Compute the root mean square of areaCell
-            local_num_cells = nCellsArray(1)
-            call mpas_dmpar_sum_real(dminfo,local_num_cells,total_num_cells)
-
-            local_area_sum = 0.0_RKIND
-            do iCell = 1,nCellsArray(1)
-              local_area_sum = local_area_sum + areaCell(iCell)**2.0
-            end do
-
-            call mpas_dmpar_sum_real(dminfo,local_area_sum,total_area_sum)
-
-            area_mean = dsqrt(total_area_sum / total_num_cells)
-            ncpus = domain % dminfo % nprocs
-            mean_num_cells = total_num_cells/ncpus
-
-            ! Tolerance for main iteration
-            if ( config_btr_si_partition_match_mode ) then
-               config_btr_si_tolerance = 1.d-8
-            endif
-            crit_main  = config_btr_si_tolerance * area_mean
-
-            ! Impliciness parameters
-            alpha1=0.50_RKIND
-            alpha2=0.50_RKIND
-
-            ! DT for si
-            allocate(tavg(2,config_n_ts_iter))
-            allocate(dt_si(config_n_ts_iter))
-            allocate(R1_alpha1s_g_dts(config_n_ts_iter))
-            allocate(R1_alpha1s_g_dt(config_n_ts_iter))
-
-            read(config_dt(1:2),*) ihh
-            read(config_dt(4:5),*) imm
-            read(config_dt(7:8),*) iss
-
-            tmp1 = ihh * 3600.0_RKIND + imm * 60.0_RKIND + iss
-
-            if ( tmp1 > 3600.0_RKIND .or. config_n_ts_iter == 1 ) then
-               dt_si(1) = tmp1 * 2.0_RKIND
-               dt_si(2) = tmp1 * 2.0_RKIND
-               si_opt = 1
-            else
-               dt_si(1) = tmp1
-               dt_si(2) = tmp1
-               si_opt = 2
-            endif
-
-            R1_alpha1s_g_dts(1) = 1.0_RKIND/((alpha1**2.0_RKIND) * gravity * (dt_si(1)**2.0_RKIND))
-            R1_alpha1s_g_dt(1)  = 1.0_RKIND/((alpha1**2.0_RKIND) * gravity * dt_si(1))
-            tavg(1,1)=0.50_RKIND
-            tavg(2,1)=0.50_RKIND
-
-            R1_alpha1s_g_dts(2) = 1.0_RKIND/((alpha1**2.0_RKIND) * gravity * (dt_si(2)**2.0_RKIND))
-            R1_alpha1s_g_dt(2)  = 1.0_RKIND/((alpha1**2.0_RKIND) * gravity * dt_si(2))
-            tavg(1,2)=0.50_RKIND
-            tavg(2,2)=0.50_RKIND
-
-            R1_alpha1_g = 1.0_RKIND/(gravity*alpha1)
-
-
-            ! Detection of ISMF (Temporariliy implemented. This will be revised in next SI version)
-            ! Compute ssh first
+      ! Compute barotropic velocity at first timestep
+      ! This is only done upon start-up.
+         if (config_filter_btr_mode) then
             do iCell = 1, nCells
-               k = maxLevelCell(iCell)
-               zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) + layerThickness(k,iCell)
+               layerThickness(minLevelCell(iCell),iCell) = &
+                  refBottomDepth(minLevelCell(iCell))
+            enddo
+         endif
 
-               do k = maxLevelCell(iCell)-1, minLevelCell(iCell), -1
-                  zTop(k,iCell) = zTop(k+1,iCell) + layerThickness(k  ,iCell)
-               end do
+         do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            kmax  = maxLevelEdgeTop(iEdge)
 
-               ! copy zTop(1,iCell) into sea-surface height array
-               sshCur(iCell) = zTop(minLevelCell(iCell),iCell)
-            end do
+            ! normalBarotropicVelocity = sum(h*u)/sum(h) on each edge
+            ! ocn_diagnostic_solve has not yet been called, so
+            ! compute hEdge just for this edge.
 
-            tmp1 = minval(sshCur)
-            call mpas_dmpar_min_real(dminfo, tmp1,tmp2 )
+            ! thicknessSum is initialized outside the loop because on
+            ! land boundaries maxLevelEdgeTop=0, but we want to
+            ! initialize thicknessSum with a nonzero value to avoid
+            ! a NaN.
+            layerThicknessEdge1 = 0.5_RKIND* &
+               (layerThickness(minLevelCell(cell1),cell1) + &
+                layerThickness(minLevelCell(cell2),cell2) )
 
-            si_ismf = 1
-            if ( tmp2 < -10.d0 ) then
-               si_ismf = 0
-            endif
+            normalThicknessFluxSum = layerThicknessEdge1* &
+               normalVelocity(minLevelEdgeBot(iEdge),iEdge)
 
-         ! Reinitialize ssh and zTop
-         sshCur(:) = 0.0
-         zTop(:,:) = 0.0
+            layerThicknessSum = layerThicknessEdge1
 
-         block => block % next
+            do k=minLevelEdgeBot(iEdge)+1, kmax
+               layerThicknessEdge1 = 0.5_RKIND* &
+                                    (layerThickness(k,cell1) + &
+                                     layerThickness(k,cell2))
+
+               normalThicknessFluxSum = normalThicknessFluxSum + &
+                                        layerThicknessEdge1* &
+                                        normalVelocity(k,iEdge)
+               layerThicknessSum = layerThicknessSum + &
+                                   layerThicknessEdge1
+
+            enddo
+            normalBarotropicVelocity(iEdge) = &
+                  normalThicknessFluxSum/layerThicknessSum
+
+            ! normalBaroclinicVelocity = normalVelocity -
+            !     normalBarotropicVelocity
+            do k = minLevelEdgeBot(iEdge), kmax
+               normalBaroclinicVelocity(k,iEdge) = &
+                         normalVelocity(k,iEdge) - &
+                 normalBarotropicVelocity(iEdge)
+            enddo
+
+            ! normalBaroclinicVelocity=0,
+            ! normalVelocity=0 on land cells
+            do k = kmax+1, nVertLevels
+               normalBaroclinicVelocity(k,iEdge) = 0.0_RKIND
+               normalVelocity(k,iEdge) = 0.0_RKIND
+            enddo
+         enddo ! edge loop
+
+         if (config_filter_btr_mode) then
+            ! filter normalBarotropicVelocity out of initial condition
+
+            normalVelocity(:,:) = normalBaroclinicVelocity(:,:)
+            normalBarotropicVelocity(:) = 0.0_RKIND
+
+         endif
+
+      endif ! .not. config_do_restart
+
+      nCells = nCellsArray(1)
+
+      ! Compute the root mean square of areaCell 
+      ! for the solver tolerance
+      local_num_cells = nCells
+      call mpas_dmpar_sum_real(domain % dminfo, local_num_cells, &
+                               total_num_cells)
+
+      local_area_sum = 0.0_RKIND
+      do iCell = 1,nCells
+        local_area_sum = local_area_sum + areaCell(iCell)**2.0
+      end do
+
+      call mpas_dmpar_sum_real(domain % dminfo,local_area_sum, &
+                                               total_area_sum)
+
+      area_mean = dsqrt(total_area_sum / total_num_cells)
+      ncpus = domain % dminfo % nprocs
+      mean_num_cells = total_num_cells/ncpus
+
+      ! Tolerance for the outer iteration
+      tolerance_outer   = 0.01_RKIND * area_mean
+
+      ! Tolerance for the inner iteration
+      if ( config_btr_si_partition_match_mode ) then
+         ! Tolerance for the partition match mode 
+         tolerance_inner  = 1.0e-8_RKIND * area_mean
+      else
+         tolerance_inner  = config_btr_si_tolerance * area_mean
+      endif
+
+
+      ! Detection of ISMF (Temporariliy implemented. 
+      !                    This will be revised in next SI version)
+      ! If ISMF is detected, the semi-implicit barotropic mode solver
+      ! will solve a 'quasi-linear' barotropic system for the more 
+      ! stable solver convergence.
+      do iCell = 1, nCells
+         k = maxLevelCell(iCell)
+         zTop(k:nVertLevels,iCell) = -bottomDepth(iCell)      &
+                                     +layerThickness(k,iCell)
+
+         do k = maxLevelCell(iCell)-1, minLevelCell(iCell), -1
+            zTop(k,iCell) = zTop(k+1,iCell) + layerThickness(k  ,iCell)
          end do
+
+         ! copy zTop(1,iCell) into sea-surface height array
+         sshCur(iCell) = zTop(minLevelCell(iCell),iCell)
+      end do
+
+      tmp1 = minval(sshCur)
+      call mpas_dmpar_min_real(domain % dminfo, tmp1,tmp2 )
+
+      si_ismf = 1
+      if ( tmp2 < -10.d0 ) then
+         si_ismf = 0
+      endif
+
+      ! Reinitialize ssh and zTop
+      sshCur(:) = 0.0
+      zTop(:,:) = 0.0
+
+
+      ! Impliciness parameters
+      alpha1= 0.5_RKIND
+      alpha2= 1.0_RKIND - alpha1
+
+      ! Get time step size to compute coefficients for the SI solver
+      read(config_dt(1:2),*) ihh
+      read(config_dt(4:5),*) imm
+      read(config_dt(7:8),*) iss
+      dt_si = ihh * 3600.0_RKIND + imm * 60.0_RKIND + iss
+
+      ! Determination of nSiLargeIter (the barotropic system 
+      !                                large iteration loop)
+      !    - Currently, it is set as 2 for the ISMF case.
+      !    - Also, nSiLargeIter can be controlled by user if needed.
+      !    - Higher nSiLargeIter can make simulations more stable and
+      !      accurate, but runtime for the barotropic system will 
+      !      increase.
+      !    - Do not set larger than 2. This will be improved in next
+      !      version.
+      nSiLargeIter = config_n_btr_si_large_iter
+
+      if ( tmp2 < -10.d0 .and. nSiLargeIter == 1 ) then ! For ISMF case
+         nSiLargeIter = 2
+         dt_si = dt_si / real(nSiLargeIter)
+      elseif ( numTSIterations == 1 ) then
+         nSiLargeIter = 2
+      else
+         nSiLargeIter = config_n_btr_si_large_iter
+         dt_si = dt_si / real(nSiLargeIter)
+      endif
+
+
+      ! Computation of coefficients which will be used in the SI solver
+      R1_alpha1s_g_dts = 1.0_RKIND/((alpha1**2.0_RKIND) &
+                           * gravity * dt_si**2.0_RKIND)
+      R1_alpha1s_g_dt  = 1.0_RKIND/((alpha1**2.0_RKIND) &
+                           * gravity * dt_si)
+      R1_alpha1_g      = 1.0_RKIND/(gravity*alpha1)
 
       ! Compute preconditioner for the semi-implicit barotropic
       !  mode solver
@@ -3347,262 +3349,268 @@ module ocn_time_integration_si
 !> \author  Hyun-Gyu Kang (Oak Ridge National Laboratory)
 !> \date    September 2019
 !> \details
-!>  This routine constructs a Block-Jacobi preconditioner for the
-!>  split-implicit time stepper.
+!>  This routine constructs preconditioners for the
+!>  semi-implicit time stepper.
 !
 !-----------------------------------------------------------------------
    subroutine ocn_time_integrator_si_preconditioner(domain, dt)!{{{
 
-      implicit none
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
 
-      type (domain_type), intent(inout) :: domain
-      real (kind=RKIND) , intent(in)    :: dt
+      real (kind=RKIND), intent(in) :: &
+         dt              !< [in] time step (sec) to move forward
 
-      type (mpas_pool_type), pointer :: statePool
-      type (mpas_pool_type), pointer :: tracersPool
-      type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: tendPool
-      type (mpas_pool_type), pointer :: tracersTendPool
+      !-----------------------------------------------------------------
+      ! Input/output variables
+      !-----------------------------------------------------------------
 
-      type (dm_info) :: dminfo
-      type (block_type), pointer :: block
-      real (kind=RKIND) :: thicknessSum,fluxAx
-      integer :: iCell, i,k,j, iEdge, cell1, cell2
+      type (domain_type), intent(inout) :: &
+         domain  !< [inout] model state to advance forward
 
-      ! Dimensions
-      integer :: nCells, nEdges
-      integer, pointer :: nCellsPtr, nEdgesPtr
-      integer, dimension(:), pointer :: nCellsArray, nEdgesArray
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
 
-      ! Mesh array pointers
-      integer, dimension(:)  , pointer :: maxLevelCell, maxLevelEdgeTop, nEdgesOnEdge, nEdgesOnCell
-      integer, dimension(:,:), pointer :: cellsOnEdge, edgeMask, edgesOnEdge
-      integer, dimension(:,:), pointer :: edgesOnCell, edgeSignOnCell
-      real (kind=RKIND), dimension(:)  , pointer :: dcEdge,bottomDepth
-      real (kind=RKIND), dimension(:)  , pointer :: dvEdge,areaCell
-      integer,           dimension(:)  , pointer :: globalCellId
+      type (block_type), pointer :: &
+         block ! structure with subdomain data
 
-      real (kind=RKIND) :: temp1,temp2
-      integer :: local_num_cells,total_num_cells
-      integer :: local_start,local_end,nCellsA2,nCellsA3,nPrecMatPacked,info,itmp1
+      type (mpas_pool_type), pointer :: &
+         meshPool ! structure holding mesh variables
 
-      dminfo = domain % dminfo
+      integer,dimension(:),pointer :: &
+         globalCellId ! global index of each cell
+
+      integer ::         &
+         nCells, nEdges, &! number of cells or edges (excl halos) 
+         iCell, iEdge,   &! loop indices for cell and edge
+         cell1, cell2,   &! neighbor cell indices across edge
+         nCellsHalo1st,  &! number of cells within 1st halo layer
+         nCellsHalo2nd,  &! number of cells within 2st halo layer
+         nPrecMatPacked   ! number of matrix elements 
+                          !    of an uppder digonal matrix
+
+      integer ::  i, j, info, itmp1
+      real (kind=RKIND) :: thicknessSum, fluxAx, temp1
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
       block => domain % blocklist
-      do while (associated(block))
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_array(meshPool, 'indexToCellID', globalCellId)
 
-         call mpas_pool_get_dimension(block % dimensions, 'nCells'     , nCellsPtr  )
-         call mpas_pool_get_dimension(block % dimensions, 'nEdges'     , nEdgesPtr  )
-         call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
-         call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
+      nCells   = nCellsOwned
+      nEdges   = nEdgesOwned
+      nCellsHalo1st = nCellsHalo(1)
+      nCellsHalo2nd = nCellsHalo(2)
 
-         call mpas_pool_get_subpool(block % structs, 'tend'       , tendPool       )
-         call mpas_pool_get_subpool(block % structs, 'mesh'       , meshPool       )
-         call mpas_pool_get_subpool(block % structs, 'state'      , statePool      )
+      call mpas_log_write('   config_btr_si_preconditioner: ' &
+                           // trim(config_btr_si_preconditioner) )
 
-         call mpas_pool_get_subpool(statePool, 'tracers'    , tracersPool    )
-         call mpas_pool_get_subpool(tendPool , 'tracersTend', tracersTendPool)
-
-         call mpas_pool_get_array(meshPool, 'nEdgesOnCell',    nEdgesOnCell    )
-         call mpas_pool_get_array(meshPool, 'edgesOnCell',     edgesOnCell     )
-         call mpas_pool_get_array(meshPool, 'cellsOnEdge',     cellsOnEdge     )
-         call mpas_pool_get_array(meshPool, 'dcEdge',          dcEdge          )
-         call mpas_pool_get_array(meshPool, 'bottomDepth',     bottomDepth     )
-         call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop )
-         call mpas_pool_get_array(meshPool, 'edgeSignOnCell',  edgeSignOnCell  )
-         call mpas_pool_get_array(meshPool, 'dvEdge',          dvEdge          )
-         call mpas_pool_get_array(meshPool, 'areaCell',        areaCell        )
-         call mpas_pool_get_array(meshPool, 'nEdgesOnEdge',    nEdgesOnEdge    )
-         call mpas_pool_get_array(meshPool, 'edgesOnEdge',     edgesOnEdge     )
-         call mpas_pool_get_array(meshPool, 'indexToCellID',   globalCellId    )
-
-         nCells   = nCellsArray(1)
-         nEdges   = nEdgesArray(1)
-         nCellsA2 = nCellsArray(2)
-         nCellsA3 = nCellsArray(3)
-
-         call mpas_log_write('   config_btr_si_preconditioner: ' // trim(config_btr_si_preconditioner))
-
-         local_num_cells = nCellsArray(1)
-         call mpas_dmpar_sum_int(dminfo,local_num_cells,total_num_cells)
-
-         if ( trim(config_btr_si_preconditioner) == 'ras' .or. &
-              trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
-            ncpus = domain % dminfo % nprocs
-            itmp1 = int(total_num_cells/ncpus)
-            if ( itmp1 > 3000 ) then
-               call mpas_log_write('      nCells per core is larger than 3000.')
-               call mpas_log_write('      Because of memory and computational efficiency,')
-               call mpas_log_write('      the preconditioner is configured as jacobi.')
-               config_btr_si_preconditioner = 'jacobi'
-            endif
-         endif
-
-         if ( config_btr_si_partition_match_mode ) then
-            call mpas_log_write('       Thread-match mode is turned on.')
-            call mpas_log_write('       The preconditioner is configured as jacobi.')
-            call mpas_log_write('       The bit-for-bit allreduce is used.')
+      if ( trim(config_btr_si_preconditioner) == 'ras' .or. &
+           trim(config_btr_si_preconditioner) == 'block_jacobi') then
+         if ( int(mean_num_cells) > 3000 ) then
+            call mpas_log_write( &
+            '      nCells per core is larger than 3000.')
+            call mpas_log_write( &
+            '      Because of memory and computational efficiency,')
+            call mpas_log_write( &
+            '      the preconditioner is configured as jacobi.')
             config_btr_si_preconditioner = 'jacobi'
          endif
+      endif
 
+      if ( config_btr_si_partition_match_mode ) then
+         call mpas_log_write( &
+         '       Partition-match mode is turned on.')
+         call mpas_log_write( &
+         '       The preconditioner is configured as jacobi.')
+         config_btr_si_preconditioner = 'jacobi'
+         call mpas_log_write( &
+         '       The bit-for-bit allreduce is used.')
+      endif
 
-         ! Restricted Additive Schwarz preconditioner ---------------------------------------------!
-         if ( trim(config_btr_si_preconditioner) == 'ras' ) then
+      ! Restricted Additive Schwarz preconditioner --------------------!
+      if ( trim(config_btr_si_preconditioner) == 'ras' ) then
 
-            nPrecVec = nCellsA3
-            nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
+         nPrecVec = nCellsHalo2nd ! length of preconditioning vector
+         nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
 
-            allocate(prec_ivmat(1:nPrecMatPacked))
-                     prec_ivmat(:) = 0.0_RKIND
+         allocate(prec_ivmat(1:nPrecMatPacked))
+                  prec_ivmat(:) = 0.0_RKIND
 
-            do iCell = 1, nPrecVec
+         do iCell = 1, nPrecVec
 
-               do i = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(i, iCell)
-                  cell1 = cellsOnEdge(1, iEdge)
-                  cell2 = cellsOnEdge(2, iEdge)
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               cell1 = cellsOnEdge(1, iEdge)
+               cell2 = cellsOnEdge(2, iEdge)
 
-                  ! method 1, matches method 0 without pbcs, works with pbcs.
-                  thicknessSum = min(bottomDepth(cell1), bottomDepth(cell2))
-                        fluxAx = edgeSignOnCell(i,iCell)*dvEdge(iEdge)*thicknessSum / dcEdge(iEdge)
+               ! method 1, matches method 0 without pbcs,
+               ! works with pbcs.
+               thicknessSum = min(bottomDepth(cell1), &
+                                  bottomDepth(cell2))
+               fluxAx = edgeSignOnCell(i,iCell) * dvEdge(iEdge) &
+                      * thicknessSum / dcEdge(iEdge)
 
-                  !-------------------------------------------------------------------------------!
-                  if ( globalCellId(cell1) > 0 .and. globalCellId(cell1) < total_num_cells+1 ) then
-                     if ( cell1 >= iCell .and. cell1 <= nPrecVec) then
-                        prec_ivmat(iCell+((cell1-1)*cell1)/2) = prec_ivmat(iCell+((cell1-1)*cell1)/2) + fluxAx
-                     endif
+               if ( globalCellId(cell1) > 0 .and. &
+                    globalCellId(cell1) < total_num_cells+1 ) then
+
+                  if ( cell1 >= iCell .and. cell1 <= nPrecVec) then
+                     prec_ivmat(iCell+((cell1-1)*cell1)/2) = &
+                     prec_ivmat(iCell+((cell1-1)*cell1)/2) + fluxAx
                   endif
+               endif
 
-                  if ( globalCellId(cell2) > 0 .and. globalCellId(cell2) < total_num_cells+1 ) then
-                     if ( cell2 >= iCell .and. cell2 <= nPrecVec) then
-                        prec_ivmat(iCell+((cell2-1)*cell2)/2) = prec_ivmat(iCell+((cell2-1)*cell2)/2) - fluxAx
-                     endif
+               if ( globalCellId(cell2) > 0 .and. &
+                    globalCellId(cell2) < total_num_cells+1 ) then
+
+                  if ( cell2 >= iCell .and. cell2 <= nPrecVec) then
+                     prec_ivmat(iCell+((cell2-1)*cell2)/2) = &
+                     prec_ivmat(iCell+((cell2-1)*cell2)/2) - fluxAx
                   endif
-                  !-------------------------------------------------------------------------------!
+               endif
+            end do ! i
 
-               end do ! i
+            prec_ivmat(iCell+((iCell-1)*iCell)/2) = &
+            prec_ivmat(iCell+((iCell-1)*iCell)/2)   &
+               - (4.0_RKIND/(gravity*dt**2.0)) * areaCell(iCell)
+         end do ! iCell
 
-               prec_ivmat(iCell+((iCell-1)*iCell)/2) = prec_ivmat(iCell+((iCell-1)*iCell)/2)  &
-                                                     - (4.0_RKIND/(gravity*dt**2.0)) * areaCell(iCell)
-
-            end do ! iCell
-
-            ! Inverse
-              ! 1. Cholesky factorization of a real symmetric positive definite matirx A
-            prec_ivmat(:) = -prec_ivmat(:)
+         ! Inversiion
+           ! 1. Cholesky factorization of a real symmetric 
+           !    positive definite matirx A
+         prec_ivmat(:) = -prec_ivmat(:)
 #ifdef USE_LAPACK
-            call DPPTRF('U',nPrecVec,prec_ivmat,info)
+         call DPPTRF('U',nPrecVec,prec_ivmat,info)
 #endif
-              ! 2. Inverse of a real symmetric positive definite matrix A using the Cholesky factorization
+           ! 2. Inversion of a real symmetric positive definite 
+           !    matrix A using the Cholesky factorization
 #ifdef USE_LAPACK
-            call DPPTRI('U',nPrecVec,prec_ivmat,info)
+         call DPPTRI('U',nPrecVec,prec_ivmat,info)
 #endif
-            prec_ivmat(:) = -prec_ivmat(:)
+         prec_ivmat(:) = -prec_ivmat(:)
 
-         ! Block-Jacobi preconditioner ------------------------------------------------------------!
-         elseif ( trim(config_btr_si_preconditioner) == 'block_jacobi' ) then
+         ! Block-Jacobi preconditioner --------------------------------!
+      elseif ( trim(config_btr_si_preconditioner) == &
+                                        'block_jacobi' ) then
 
-            nPrecVec = nCells ! length of preconditioning vector
-            nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
+         nPrecVec = nCells ! length of preconditioning vector
+         nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
 
-            allocate(prec_ivmat(1:nPrecMatPacked))
-                     prec_ivmat(:) = 0.0_RKIND
+         allocate(prec_ivmat(1:nPrecMatPacked))
+                  prec_ivmat(:) = 0.0_RKIND
 
-            do iCell = 1, nPrecVec
+         do iCell = 1, nPrecVec
 
-               do i = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(i, iCell)
-                  cell1 = cellsOnEdge(1, iEdge)
-                  cell2 = cellsOnEdge(2, iEdge)
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               cell1 = cellsOnEdge(1, iEdge)
+               cell2 = cellsOnEdge(2, iEdge)
 
-                  ! method 1, matches method 0 without pbcs, works with pbcs.
-                  thicknessSum = min(bottomDepth(cell1), bottomDepth(cell2))
-                        fluxAx = edgeSignOnCell(i,iCell)*dvEdge(iEdge)*thicknessSum / dcEdge(iEdge)
+               ! method 1, matches method 0 without pbcs,
+               ! works with pbcs.
+               thicknessSum = min(bottomDepth(cell1), &
+                                  bottomDepth(cell2))
+               fluxAx = edgeSignOnCell(i,iCell) * dvEdge(iEdge) &
+                      * thicknessSum / dcEdge(iEdge)
 
-                  !-------------------------------------------------------------------------------!
-                  if ( globalCellId(cell1) > 0 .and. globalCellId(cell1) < total_num_cells+1 ) then
-                     if ( cell1 >= iCell .and. cell1 <= nPrecVec) then
-                        prec_ivmat(iCell+((cell1-1)*cell1)/2) = prec_ivmat(iCell+((cell1-1)*cell1)/2) + fluxAx
-                     endif
+               if ( globalCellId(cell1) > 0 .and. &
+                    globalCellId(cell1) < total_num_cells+1 ) then
+
+                  if ( cell1 >= iCell .and. cell1 <= nPrecVec) then
+                     prec_ivmat(iCell+((cell1-1)*cell1)/2) = &
+                     prec_ivmat(iCell+((cell1-1)*cell1)/2) + fluxAx
                   endif
+               endif
 
-                  if ( globalCellId(cell2) > 0 .and. globalCellId(cell2) < total_num_cells+1 ) then
-                     if ( cell2 >= iCell .and. cell2 <= nPrecVec) then
-                        prec_ivmat(iCell+((cell2-1)*cell2)/2) = prec_ivmat(iCell+((cell2-1)*cell2)/2) - fluxAx
-                     endif
+               if ( globalCellId(cell2) > 0 .and. &
+                    globalCellId(cell2) < total_num_cells+1 ) then
+                  if ( cell2 >= iCell .and. cell2 <= nPrecVec) then
+                     prec_ivmat(iCell+((cell2-1)*cell2)/2) = &
+                     prec_ivmat(iCell+((cell2-1)*cell2)/2) - fluxAx
                   endif
-                  !-------------------------------------------------------------------------------!
-               end do ! i
+               endif
+            end do ! i
 
-               prec_ivmat(iCell+((iCell-1)*iCell)/2) = prec_ivmat(iCell+((iCell-1)*iCell)/2)  &
-                                                     - (4.0_RKIND/(gravity*dt**2.0)) * areaCell(iCell)
-            end do ! iCell
+            prec_ivmat(iCell+((iCell-1)*iCell)/2) = &
+            prec_ivmat(iCell+((iCell-1)*iCell)/2)   &
+               - (4.0_RKIND/(gravity*dt**2.0)) * areaCell(iCell)
+         end do ! iCell
 
-            ! Inverse
-              ! 1. Cholesky factorization of a real symmetric positive definite matirx A
-            prec_ivmat(:) = -prec_ivmat(:)
+         ! Inversion
+           ! 1. Cholesky factorization of a real symmetric 
+           !    positive definite matirx A
+         prec_ivmat(:) = -prec_ivmat(:)
 #ifdef USE_LAPACK
-            call DPPTRF('U',nPrecVec,prec_ivmat,info)
+         call DPPTRF('U',nPrecVec,prec_ivmat,info)
 #endif
-              ! 2. Inverse of a real symmetric positive definite matrix A using the Cholesky factorization
+           ! 2. Inversion of a real symmetric positive definite
+           !    matrix A using the Cholesky factorization
 #ifdef USE_LAPACK
-            call DPPTRI('U',nPrecVec,prec_ivmat,info)
+         call DPPTRI('U',nPrecVec,prec_ivmat,info)
 #endif
-            prec_ivmat(:) = -prec_ivmat(:)
+         prec_ivmat(:) = -prec_ivmat(:)
 
-         ! Jacobi preconditioner ------------------------------------------------------------------!
-         else if ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
+      ! Jacobi preconditioner -----------------------------------------!
+      else if ( trim(config_btr_si_preconditioner) == 'jacobi' ) then
 
-            nPrecVec = nCells ! length of preconditioning vector
+         nPrecVec = nCells ! length of preconditioning vector
 
-            allocate(prec_ivmat(1:nPrecVec))
-                     prec_ivmat(:) = 0.0_RKIND
+         allocate(prec_ivmat(1:nPrecVec))
+                  prec_ivmat(:) = 0.0_RKIND
 
-            do iCell = 1, nPrecVec
+         do iCell = 1, nPrecVec
 
-               do i = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(i, iCell)
-                  cell1 = cellsOnEdge(1, iEdge)
-                  cell2 = cellsOnEdge(2, iEdge)
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               cell1 = cellsOnEdge(1, iEdge)
+               cell2 = cellsOnEdge(2, iEdge)
 
-                  ! method 1, matches method 0 without pbcs, works with pbcs.
-                  thicknessSum =  min(bottomDepth(cell1), bottomDepth(cell2))
+               ! method 1, matches method 0 without pbcs,
+               ! works with pbcs.
+               thicknessSum =  min(bottomDepth(cell1), &
+                                   bottomDepth(cell2))
 
-                  !-------------------------------------------------------------------------!
-                  fluxAx = edgeSignOnCell(i,iCell)*dvEdge(iEdge)*thicknessSum / dcEdge(iEdge)
+               fluxAx = edgeSignOnCell(i,iCell) * dvEdge(iEdge) &
+                      * thicknessSum / dcEdge(iEdge)
 
-                  if (cell1 == iCell) then
-                     prec_ivmat(iCell) = prec_ivmat(iCell) + fluxAx  ! reversed sign
-                  elseif ( cell2 == iCell) then
-                     prec_ivmat(iCell) = prec_ivmat(iCell) - fluxAx  ! reversed sign
-                  endif
-                  !-------------------------------------------------------------------------!
-               end do ! i
+               if (cell1 == iCell) then
+                  prec_ivmat(iCell) = prec_ivmat(iCell) + fluxAx 
+                                                        ! reversed sign
+               elseif ( cell2 == iCell) then
+                  prec_ivmat(iCell) = prec_ivmat(iCell) - fluxAx
+                                                        ! reversed sign
+               endif
+            end do ! i
 
-               temp1 = prec_ivmat(iCell) - (4.0_RKIND/(gravity*dt**2.0))*areaCell(iCell)
+            temp1 = prec_ivmat(iCell) &
+                  - (4.0_RKIND/(gravity*dt**2.0)) * areaCell(iCell)
 
-               prec_ivmat(iCell) = 1.0_RKIND / temp1
+            prec_ivmat(iCell) = 1.0_RKIND / temp1
 
-            end do ! iCell
+         end do ! iCell
 
+      ! No preconditioner ---------------------------------------------!
+      else if ( trim(config_btr_si_preconditioner) == 'none' ) then
 
-         ! No preconditioner ----------------------------------------------------------------------!
-         else if ( trim(config_btr_si_preconditioner) == 'none' ) then
+         nPrecVec = nCells ! length of preconditioning vector
 
-            nPrecVec = nCells ! length of preconditioning vector
+         allocate(prec_ivmat(1))
+         prec_ivmat(:) = 1.0_RKIND
 
-            allocate(prec_ivmat(1))
-            prec_ivmat(:) = 1.0_RKIND ! This array is not used only for 'none'.
+      else
 
-         else
+         call mpas_log_write( &
+         'Incorrect choice for config_btr_si_preconditioner: ' &
+         // trim(config_btr_si_preconditioner) //              &
+         '   choices are: ras, block_jacobi, jacobi, none',    &
+         MPAS_LOG_CRIT)
 
-            call mpas_log_write('Incorrect choice for config_btr_si_preconditioner: ' // trim(config_btr_si_preconditioner) // &
-                                '   choices are: ras, block_jacobi, jacobi, none',MPAS_LOG_CRIT)
-
-         endif ! config_btr_si_preconditioner
-
-         block => block % next
-      end do  ! block
+      endif ! config_btr_si_preconditioner
 
    end subroutine ocn_time_integrator_si_preconditioner !}}}
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -3422,7 +3422,7 @@ module ocn_time_integration_si
 
       ! Determination of nSiLargeIter (the barotropic system 
       !                                large iteration loop)
-      !    - Currently, it is set as 2 for the ISMF case.
+      !    - Currently, it is set as 2 when numTSIterations is 1.
       !    - Also, nSiLargeIter can be controlled by user if needed.
       !    - Higher nSiLargeIter can make simulations more stable and
       !      accurate, but runtime for the barotropic system will 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -286,16 +286,8 @@ module ocn_time_integration_si
 
       ! Semi-implicit variables
       real (kind=RKIND), dimension(2) :: &
-         SIcst_allreduce2,       &! array for local  summations
+         SIcst_allreduce_local2, &! array for local  summations
          SIcst_allreduce_global2  ! array for global summations
-      real (kind=RKIND), dimension(2) :: &
-         SIcst_allreduce_local2   ! array for local  summations
-      real (kind=RKIND), dimension(3) :: &
-         SIcst_allreduce3,       &! array for local  summations
-         SIcst_allreduce_global3  ! array for global summations
-      real (kind=RKIND), dimension(5) :: &
-         SIcst_allreduce5,       &! array for local  summations
-         SIcst_allreduce_global5  ! array for global summations
       real (kind=RKIND), dimension(9) :: &
          SIcst_allreduce_local9, &! array for local  summations
          SIcst_allreduce_global9,&! array for global summations
@@ -612,17 +604,31 @@ module ocn_time_integration_si
          ! normalTransportVelocity) for momentum advection.
          ! Use the most recent time level available.
 
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
+         !$acc update device(layerThickEdge)
+#endif
          if (associated(highFreqThicknessNew)) then
+#ifdef MPAS_OPENACC
+            !$acc enter data copyin(highFreqThicknessNew)
+#endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
+#ifdef MPAS_OPENACC
+            !$acc exit data delete(highFreqThicknessNew)
+#endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
          endif
+#ifdef MPAS_OPENACC
+         !$acc exit data delete(layerThicknessCur, normalVelocityCur, sshCur)
+         !$acc update host(vertAleTransportTop)
+#endif
 
          call ocn_tend_vel(tendPool, statePool, forcingPool, &
                            stage1_tend_time, dt)
@@ -902,6 +908,11 @@ module ocn_time_integration_si
    
             call mpas_timer_start("si btr residual")
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendb1,sshTendb2,sshTendAx,iEdge, &
+            !$omp         cell1,cell2,sshEdgeCur,thicknessSumCur, &
+            !$omp         sshDiffCur,fluxb1,fluxb2,fluxAx,sshCurArea)
             do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
@@ -954,6 +965,8 @@ module ocn_time_integration_si
                SIvec_r00(iCell) = SIvec_r0(iCell)
    
             end do ! iCell
+            !$omp end do
+            !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
    
@@ -994,6 +1007,10 @@ module ocn_time_integration_si
    
             ! SpMV -------------------------------------------------------!
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeCur, &
+            !$omp         thicknessSumCur,sshDiffCur,fluxAx,sshCurArea )
             do iCell = 1, nPrecVec
    
                sshTendAx = 0.0_RKIND
@@ -1028,7 +1045,8 @@ module ocn_time_integration_si
                SIvec_w0(iCell) = -sshCurArea - sshTendAx
    
             end do ! iCell
-   
+            !$omp end do
+            !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
    
@@ -1067,9 +1085,12 @@ module ocn_time_integration_si
             call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
             call mpas_timer_stop("si halo r0")
    
-   
             ! SpMV -------------------------------------------------------!
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeCur, &
+            !$omp         thicknessSumCur,sshDiffCur,fluxAx,sshCurArea )
             do iCell = 1, nPrecVec
    
                sshTendAx = 0.0_RKIND
@@ -1114,7 +1135,8 @@ module ocn_time_integration_si
                SIvec_s0(iCell)  = 0.0_RKIND
    
             end do ! iCell
-   
+            !$omp end do
+            !$omp end parallel
    
             ! Reduction --------------------------------------------------!
             SIcst_r00r0 = 0.0_RKIND
@@ -1182,6 +1204,8 @@ module ocn_time_integration_si
    
                iter = iter + 1
    
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1, nPrecVec
                   SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
                                    * (SIvec_ph0(iCell) - SIcst_omega0     &
@@ -1208,7 +1232,8 @@ module ocn_time_integration_si
                   SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
                                                        * SIvec_z1(iCell)
                end do ! iCell
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Preconditioning -----------------------------------------!
    
@@ -1250,6 +1275,10 @@ module ocn_time_integration_si
    
                ! SpMV ----------------------------------------------------!
    
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
                do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
    
@@ -1285,7 +1314,8 @@ module ocn_time_integration_si
                   SIvec_v0(iCell) = -sshLagArea - sshTendAx
    
                end do ! iCell
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Reduction -----------------------------------------------!
                SIcst_r00s0 = 0.0_RKIND
@@ -1321,12 +1351,12 @@ module ocn_time_integration_si
                                             * SIvec_t0(iCell)
    
                   SIcst_r00v0 = SIcst_r00v0 + SIvec_r00(iCell) &
-                                            * SIvec_v0(iCell) ! v1
+                                            * SIvec_v0(iCell)
    
                   SIcst_q0q0 = SIcst_q0q0   + SIvec_q0(iCell) &
                                             * SIvec_q0(iCell)
                end do
-   
+
                SIcst_allreduce_local9(1) = SIcst_r00s0
                SIcst_allreduce_local9(2) = SIcst_r00z0
                SIcst_allreduce_local9(3) = SIcst_q0y0 
@@ -1381,6 +1411,8 @@ module ocn_time_integration_si
                      - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
                      + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
    
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1,nPrecVec
                   sshSubcycleNew(iCell) = sshSubcycleNew(iCell)           &
                                         + SIcst_alpha0 * SIvec_ph1(iCell) &
@@ -1397,7 +1429,8 @@ module ocn_time_integration_si
                                    * ( SIvec_t0(iCell) - SIcst_alpha0     &
                                                        * SIvec_v0(iCell))
                end do
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Preconditioning -----------------------------------------!
    
@@ -1439,6 +1472,10 @@ module ocn_time_integration_si
    
                ! SpMV ----------------------------------------------------!
    
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
                do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
    
@@ -1473,9 +1510,9 @@ module ocn_time_integration_si
    
                   SIvec_t1(iCell) = -sshLagArea - sshTendAx
                end do ! iCell
-   
-               ! End reduction -------------------------------------------!
-   
+               !$omp end do
+               !$omp end parallel
+
                SIcst_rho1 = SIcst_r00q0_global - SIcst_omega0 * SIcst_r00y0_global 
    
                SIcst_gamma1 = SIcst_r00y0_global - SIcst_omega0 * SIcst_r00t0_global  &
@@ -1489,7 +1526,10 @@ module ocn_time_integration_si
                             / ( SIcst_gamma1 + SIcst_beta0 * SIcst_r00s0_global   &
                                              - SIcst_beta0 * SIcst_omega0  &
                                                            * SIcst_r00z0_global )
-   
+               SIcst_rho0         = SIcst_rho1
+
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1,nPrecVec
                   SIvec_r0(iCell) = SIvec_r1(iCell)
                   SIvec_s0(iCell) = SIvec_s1(iCell)
@@ -1503,13 +1543,12 @@ module ocn_time_integration_si
                   SIvec_wh0(iCell) = SIvec_wh1(iCell)
                   SIvec_zh0(iCell) = SIvec_zh1(iCell)
                end do ! iCell
-   
-               SIcst_rho0         = SIcst_rho1
+               !$omp end do
+               !$omp end parallel
    
             !-------------------------------------------------------------!
             end do ! do iter
             !-------------------------------------------------------------!
-    
    
             !   boundary update on sshNew
             call mpas_timer_start("si halo iter")
@@ -1519,18 +1558,25 @@ module ocn_time_integration_si
    
             call mpas_timer_stop("si btr iteration")
    
-   
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             ! Stage 2.4 : The barotropic velocity update
             !             using the lagged SSH
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    
             call mpas_timer_start("si btr vel update")
+
+            !$omp parallel
+            !$omp do schedule(runtime)
             do iCell = 1,nCellsAll
                ! Use of sshNew to save the lagged SSH
                sshNew(iCell) = sshSubcycleNew(iCell)
             end do
+            !$omp end do
+            !$omp end parallel
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(temp_mask,cell1,cell2)
             do iEdge = 1,nEdgesHalo( edgeHaloComputeCounter-1 )
                temp_mask = edgeMask(1, iEdge)
    
@@ -1551,6 +1597,8 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
@@ -1569,7 +1617,10 @@ module ocn_time_integration_si
             end do
             !$omp end do
             !$omp end parallel
-   
+
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(temp_mask,cell1,cell2)
             do iEdge = 1,nEdgesHalo(2)
                temp_mask = edgeMask(1, iEdge)
    
@@ -1582,6 +1633,8 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)        &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
@@ -1617,6 +1670,13 @@ module ocn_time_integration_si
    
             ! SpMV -------------------------------------------------------!
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendb1,sshTendb2,sshTendAx,iEdge, &
+            !$omp         cell1,cell2,sshEdgeCur,sshEdgeLag,sshEdgeMid, &
+            !$omp         thicknessSumCur,thicknessSumMid, &
+            !$omp         thicknessSumLag,sshDiffCur,sshDiffLag, &
+            !$omp         fluxb1,fluxb2,fluxAx,sshCurArea,sshLagArea)
             do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
@@ -1680,7 +1740,8 @@ module ocn_time_integration_si
                                 -(-sshLagArea - sshTendAx)
                SIvec_r00(iCell) = SIvec_r0(iCell)
             end do ! iCell
-   
+            !$omp end do
+            !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
    
@@ -1722,6 +1783,10 @@ module ocn_time_integration_si
    
             ! SpMV -------------------------------------------------------!
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+            !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
             do iCell = 1, nPrecVec
    
                sshTendAx = 0.0_RKIND
@@ -1751,13 +1816,14 @@ module ocn_time_integration_si
                             * fluxAx * dvEdge(iEdge)
                end do ! i
    
-               sshCurArea = R1_alpha1s_g_dts * SIvec_rh0(iCell) &
+               sshLagArea = R1_alpha1s_g_dts * SIvec_rh0(iCell) &
                                              * areaCell(iCell)
    
-               SIvec_w0(iCell) = -sshCurArea - sshTendAx
+               SIvec_w0(iCell) = -sshLagArea - sshTendAx
    
             end do ! iCell
-   
+            !$omp end do
+            !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
    
@@ -1798,6 +1864,10 @@ module ocn_time_integration_si
    
    
             ! SpMV -------------------------------------------------------!
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+            !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
             do iCell = 1, nPrecVec
    
                sshTendAx = 0.0_RKIND
@@ -1819,19 +1889,19 @@ module ocn_time_integration_si
                                         bottomDepth(cell2))
    
                   ! nabla (ssh^0)
-                  sshDiffCur = (SIvec_wh0(cell2) - SIvec_wh0(cell1)) &
+                  sshDiffLag = (SIvec_wh0(cell2) - SIvec_wh0(cell1)) &
                              / dcEdge(iEdge)
    
-                  fluxAx = thicknessSumLag * sshDiffCur
+                  fluxAx = thicknessSumLag * sshDiffLag
    
                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
                             * fluxAx * dvEdge(iEdge)
                end do ! i
    
-               sshCurArea = R1_alpha1s_g_dts * SIvec_wh0(iCell) &
+               sshLagArea = R1_alpha1s_g_dts * SIvec_wh0(iCell) &
                           * areaCell(iCell)
    
-               SIvec_t0(iCell) = -sshCurArea - sshTendAx
+               SIvec_t0(iCell) = -sshLagArea - sshTendAx
    
                SIvec_ph0(iCell) = 0.0_RKIND
                SIvec_sh0(iCell) = 0.0_RKIND
@@ -1841,6 +1911,8 @@ module ocn_time_integration_si
                SIvec_s0(iCell)  = 0.0_RKIND
    
             end do ! iCell
+            !$omp end do
+            !$omp end parallel
    
    
             ! Reduction -----------------------------------------------!
@@ -1856,7 +1928,6 @@ module ocn_time_integration_si
    
             SIcst_allreduce_local2(1) = SIcst_r00r0
             SIcst_allreduce_local2(2) = SIcst_r00w0
-   
    
             ! Global sum across CPUs
             call mpas_timer_start("si reduction r0")
@@ -1911,6 +1982,8 @@ module ocn_time_integration_si
    
                iter = iter + 1
    
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1, nPrecVec
                   SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
                                    * (SIvec_ph0(iCell) - SIcst_omega0     &
@@ -1937,7 +2010,8 @@ module ocn_time_integration_si
                   SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
                                                        * SIvec_z1(iCell)
                end do ! iCell
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Preconditioning -----------------------------------------!
                if ( trim(config_btr_si_preconditioner) == 'ras' ) then
@@ -1978,6 +2052,10 @@ module ocn_time_integration_si
    
                ! SpMV ----------------------------------------------------!
    
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
                do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
    
@@ -2007,12 +2085,14 @@ module ocn_time_integration_si
                                * fluxAx * dvEdge(iEdge)
                   end do ! i
    
-                  sshLagArea = R1_alpha1s_g_dts * SIvec_zh1(iCell) * areaCell(iCell)
+                  sshLagArea = R1_alpha1s_g_dts * SIvec_zh1(iCell) &
+                             * areaCell(iCell)
    
                   SIvec_v0(iCell) = -sshLagArea - sshTendAx
    
                end do ! iCell
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Reduction -----------------------------------------------!
                SIcst_r00s0 = 0.0_RKIND
@@ -2048,7 +2128,7 @@ module ocn_time_integration_si
                                             * SIvec_t0(iCell)
    
                   SIcst_r00v0 = SIcst_r00v0 + SIvec_r00(iCell) &
-                                            * SIvec_v0(iCell) ! v1
+                                            * SIvec_v0(iCell)
    
                   SIcst_q0q0 = SIcst_q0q0   + SIvec_q0(iCell) &
                                             * SIvec_q0(iCell)
@@ -2107,6 +2187,8 @@ module ocn_time_integration_si
                      - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
                      + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
    
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1,nPrecVec
                   sshSubcycleNew(iCell) = sshSubcycleNew(iCell)           &
                                         + SIcst_alpha0 * SIvec_ph1(iCell) &
@@ -2123,7 +2205,8 @@ module ocn_time_integration_si
                                    * ( SIvec_t0(iCell) - SIcst_alpha0     &
                                                        * SIvec_v0(iCell))
                end do
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Preconditioning -----------------------------------------!
                if ( trim(config_btr_si_preconditioner) == 'ras' ) then
@@ -2161,9 +2244,12 @@ module ocn_time_integration_si
                call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh1')
                call mpas_timer_stop("si halo iter")
    
-   
                ! SpMV ----------------------------------------------------!
    
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
                do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
    
@@ -2198,6 +2284,8 @@ module ocn_time_integration_si
    
                   SIvec_t1(iCell) = -sshLagArea - sshTendAx
                end do ! iCell
+               !$omp end do
+               !$omp end parallel
    
                SIcst_rho1 = SIcst_r00q0_global - SIcst_omega0 * SIcst_r00y0_global 
    
@@ -2212,6 +2300,10 @@ module ocn_time_integration_si
                             / ( SIcst_gamma1 + SIcst_beta0 * SIcst_r00s0_global   &
                                              - SIcst_beta0 * SIcst_omega0  &
                                                            * SIcst_r00z0_global )
+               SIcst_rho0 = SIcst_rho1
+
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1,nPrecVec
                   SIvec_r0(iCell) = SIvec_r1(iCell)
                   SIvec_s0(iCell) = SIvec_s1(iCell)
@@ -2225,8 +2317,8 @@ module ocn_time_integration_si
                   SIvec_wh0(iCell) = SIvec_wh1(iCell)
                   SIvec_zh0(iCell) = SIvec_zh1(iCell)
                end do ! iCell
-   
-               SIcst_rho0         = SIcst_rho1
+               !$omp end do
+               !$omp end parallel
    
                if ( iter > int(mean_num_cells*5) ) then
                   call mpas_log_write(&
@@ -2260,6 +2352,9 @@ module ocn_time_integration_si
    
             call mpas_timer_start("si btr vel update")
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(temp_mask,cell1,cell2)
             do iEdge = 1, nEdgesHalo(2)
                temp_mask = edgeMask(1, iEdge)
    
@@ -2280,6 +2375,8 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
@@ -2299,6 +2396,9 @@ module ocn_time_integration_si
             !$omp end do
             !$omp end parallel
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(temp_mask,cell1,cell2)
             do iEdge = 1, nEdgesOwned
                temp_mask = edgeMask(1, iEdge)
    
@@ -2312,8 +2412,12 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
-   
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(cell1,cell2,sshEdge,thicknessSum)
             do iEdge = 1, nEdgesOwned
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
@@ -2323,9 +2427,6 @@ module ocn_time_integration_si
                normalBarotropicVelocitySubcycleCur(iEdge)                &
                   = 0.5_RKIND*normalBarotropicVelocitySubcycleNew(iEdge) &
                   + 0.5_RKIND*normalBarotropicVelocityCur(iEdge)
-   
-               normalBarotropicVelocityNew(iEdge) &
-                  = normalBarotropicVelocitySubcycleCur(iEdge)
    
                          ! 0.25 = 0.5 * 0.5
                sshEdge = 0.25_RKIND * (  sshSubcycleCur(cell1)   &
@@ -2341,6 +2442,8 @@ module ocn_time_integration_si
                          + normalBarotropicVelocityCur(iEdge) )       &
                          * thicknessSum
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
    
             ! boundary update on F
@@ -2348,9 +2451,6 @@ module ocn_time_integration_si
             call mpas_dmpar_exch_group_create(domain, finalBtrGroupName)
             call mpas_dmpar_exch_group_add_field(domain, &
                       finalBtrGroupName, 'barotropicThicknessFlux')
-            call mpas_dmpar_exch_group_add_field(domain,             &
-                      finalBtrGroupName, 'normalBarotropicVelocity', &
-                                                       timeLevel=2)
             call mpas_dmpar_exch_group_add_field(domain,             &
                       finalBtrGroupName,                             &
                                  'normalBarotropicVelocitySubcycle', &
@@ -2360,6 +2460,15 @@ module ocn_time_integration_si
             call mpas_dmpar_exch_group_destroy(domain, finalBtrGroupName)
             call mpas_timer_stop("si halo btr vel")
    
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdgesAll
+               normalBarotropicVelocityNew(iEdge)              &
+                  = normalBarotropicVelocitySubcycleCur(iEdge) 
+            end do ! iEdge
+            !$omp end do
+            !$omp end parallel
+
             call mpas_timer_stop("si btr vel update")
 
          !-------------------------------------------------------------!
@@ -2473,17 +2582,31 @@ module ocn_time_integration_si
          ! layerThickEdge because layerThickness has not yet
          ! been computed for time level 2.
          call mpas_timer_start('thick vert trans vel top')
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessCur, sshCur)
+         !$acc update device(layerThickEdge, normalTransportVelocity)
+#endif
          if (associated(highFreqThicknessNew)) then
+#ifdef MPAS_OPENACC
+            !$acc enter data copyin(highFreqThicknessNew)
+#endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
+#ifdef MPAS_OPENACC
+            !$acc exit data delete(highFreqThicknessNew)
+#endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)
          endif
+#ifdef MPAS_OPENACC
+         !$acc exit data delete(layerThicknessCur, sshCur)
+         !$acc update host(vertAleTransportTop, normalTransportVelocity)
+#endif
          call mpas_timer_stop('thick vert trans vel top')
 
          call ocn_tend_thick(tendPool, forcingPool, meshPool)
@@ -3069,7 +3192,7 @@ module ocn_time_integration_si
          normalBaroclinicVelocity, &! normal baroclinic velocity
          normalVelocity             ! normal velocity (total)
 
-      real (kind=RKIND), dimension(:), pointer :: sshCur
+      real (kind=RKIND), dimension(:), pointer :: ssh
 
 #ifndef USE_LAPACK
       call mpas_log_write( &
@@ -3150,7 +3273,7 @@ module ocn_time_integration_si
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
-      call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
+      call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
 
       nCells = nCellsArray(config_num_halos)
       nEdges = nEdgesArray(config_num_halos+1)
@@ -3276,21 +3399,16 @@ module ocn_time_integration_si
          end do
 
          ! copy zTop(1,iCell) into sea-surface height array
-         sshCur(iCell) = zTop(minLevelCell(iCell),iCell)
+         ssh(iCell) = zTop(minLevelCell(iCell),iCell)
       end do
 
-      tmp1 = minval(sshCur)
+      tmp1 = minval(ssh)
       call mpas_dmpar_min_real(domain % dminfo, tmp1,tmp2 )
 
       si_ismf = 1
       if ( tmp2 < -10.d0 ) then
          si_ismf = 0
       endif
-
-      ! Reinitialize ssh and zTop
-      sshCur(:) = 0.0
-      zTop(:,:) = 0.0
-
 
       ! Impliciness parameters
       alpha1= 0.5_RKIND
@@ -3313,10 +3431,7 @@ module ocn_time_integration_si
       !      version.
       nSiLargeIter = config_n_btr_si_large_iter
 
-      if ( tmp2 < -10.d0 .and. nSiLargeIter == 1 ) then ! For ISMF case
-         nSiLargeIter = 2
-         dt_si = dt_si / real(nSiLargeIter)
-      elseif ( numTSIterations == 1 ) then
+      if ( numTSIterations == 1 ) then
          nSiLargeIter = 2
       else
          nSiLargeIter = config_n_btr_si_large_iter

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -9,17 +9,17 @@
 !
 !  ocn_time_integration_si
 !
-!> \brief MPAS ocean semi-implicit time integration scheme
+!> \brief MPAS ocean split-implicit time integration scheme
 !> \author Mark Petersen, Doug Jacobsen, Todd Ringler
 !> \date   September 2011 (split explicit base code)
 !
 !> \author Hyun-Gyu Kang (Oak Ridge National Laboratory)
-!> \date   September 2019 (semi-implicit code)
+!> \date   September 2019 (split-implicit code)
 !> \details
-!>  This module contains the routines for the semi-implicit
+!>  This module contains the routines for the split-implicit
 !>  time integration scheme based on the split-explicit code.
 !>  Only stage 2 (barotropic mode) is changed from the explicit
-!>  subcycling scheme to the semi-implicit scheme.
+!>  subcycling scheme to the split-implicit scheme.
 !
 !-----------------------------------------------------------------------
 
@@ -89,7 +89,7 @@ module ocn_time_integration_si
    real (kind=RKIND) :: &
       useVelocityCorrection ! mask for velocity correction
 
-   ! Global variables for the semi-implicit time stepper ---------------
+   ! Global variables for the split-implicit time stepper ---------------
    real (kind=RKIND), allocatable,dimension(:)   :: &
       prec_ivmat    ! an inversed preconditioning matrix
    real (kind=RKIND) :: &
@@ -119,14 +119,14 @@ module ocn_time_integration_si
 !
 !  ocn_time_integration_si
 !
-!> \brief MPAS ocean semi-implicit time integration scheme
+!> \brief MPAS ocean split-implicit time integration scheme
 !> \author Mark Petersen, Doug Jacobsen, Todd Ringler
 !> \date   September 2011 (split explicit base code)
 !> \author Hyun-Gyu Kang (Oak Ridge National Laboratory)
-!> \date   JAN 2019 (semi-implicit code)
+!> \date   JAN 2019 (split-implicit code)
 !> \details
 !>  This routine integrates a master time step (dt) using a
-!>  semi-implicit time integrator.
+!>  split-implicit time integrator.
 !
 !-----------------------------------------------------------------------
 
@@ -736,10 +736,10 @@ module ocn_time_integration_si
 
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         ! Stage 2: Barotropic velocity (2D) prediction, semi-implicit
+         ! Stage 2: Barotropic velocity (2D) prediction, split-implicit
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          !
-         ! The semi-implicit barotropic mode solver
+         ! The split-implicit barotropic mode solver
          !    - uses the preconditioned communication-avoiding
          !      (single-reduction) BiCGStab method 
          !      (Cool and Vanroose, 2017) as a linear iterative solver
@@ -785,7 +785,7 @@ module ocn_time_integration_si
          !                SSH and BtrVel at time (n+1)
          !
          !
-         ! Reference: Kang et al. (2021): A scalable semi-implicit
+         ! Reference: Kang et al. (2021): A scalable split-implicit
          !            barotropic mode solver for the MPAS-Ocean, JAMES
          !
          !
@@ -3123,11 +3123,11 @@ module ocn_time_integration_si
 !
 !  routine ocn_time_integration_si_init
 !
-!> \brief   Initialize semi-implicit time stepping within MPAS-Ocean
+!> \brief   Initialize split-implicit time stepping within MPAS-Ocean
 !> \author  Mark Petersen
 !> \date    September 2011
 !
-!> \author  Hyun-Gyu Kang (ORNL, for the semi-implicit code)
+!> \author  Hyun-Gyu Kang (ORNL, for the split-implicit code)
 !> \date    September 2019
 !> \details
 !>  This routine initializes variables required for the split-implicit
@@ -3211,12 +3211,12 @@ module ocn_time_integration_si
 
       select case (trim(config_time_integrator))
 
-      case ('semi_implicit')
+      case ('split_implicit')
 
          call mpas_log_write( &
          '***********************************************************')
          call mpas_log_write( &
-         'The semi-implicit time integration is configured')
+         'The split-implicit time integration is configured')
          call mpas_log_write( &
          '***********************************************************')
 
@@ -3386,7 +3386,7 @@ module ocn_time_integration_si
 
       ! Detection of ISMF (Temporariliy implemented. 
       !                    This will be revised in next SI version)
-      ! If ISMF is detected, the semi-implicit barotropic mode solver
+      ! If ISMF is detected, the split-implicit barotropic mode solver
       ! will solve a 'quasi-linear' barotropic system for the more 
       ! stable solver convergence.
       do iCell = 1, nCells
@@ -3446,7 +3446,7 @@ module ocn_time_integration_si
                            * gravity * dt_si)
       R1_alpha1_g      = 1.0_RKIND/(gravity*alpha1)
 
-      ! Compute preconditioner for the semi-implicit barotropic
+      ! Compute preconditioner for the split-implicit barotropic
       !  mode solver
       call mpas_log_write(' Building a preconditioning matrix: ')
       call mpas_timer_start("preconditioning matrix build")
@@ -3466,7 +3466,7 @@ module ocn_time_integration_si
 !> \date    September 2019
 !> \details
 !>  This routine constructs preconditioners for the
-!>  semi-implicit time stepper.
+!>  split-implicit time stepper.
 !
 !-----------------------------------------------------------------------
    subroutine ocn_time_integrator_si_preconditioner(domain, dt)!{{{

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -3213,7 +3213,7 @@ contains
          fCoef = 1
       elseif (trim(config_time_integrator) == 'split_explicit' &
         .or.trim(config_time_integrator) == 'unsplit_explicit' &
-        .or.trim(config_time_integrator) == 'semi_implicit') then
+        .or.trim(config_time_integrator) == 'split_implicit') then
           ! For split explicit, PV is eta/h because the Coriolis term
           ! is added separately to the momentum tendencies.
           fCoef = 0

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -586,7 +586,7 @@ contains
                 surfacePressure)
 
       ! Semi-implicit Array Pointer retrievals
-      if (trim(config_time_integrator) == 'semi_implicit') then
+      if (trim(config_time_integrator) == 'split_implicit') then
          call mpas_pool_get_array(diagnosticsPool, 'SIvec_r0', SIvec_r0)
          call mpas_pool_get_array(diagnosticsPool, 'SIvec_r1', SIvec_r1)
          call mpas_pool_get_array(diagnosticsPool, 'SIvec_v0', SIvec_v0)
@@ -763,7 +763,7 @@ contains
          !$acc                   salinitySurfaceRestoringTendency  &
          !$acc                   )
       end if
-      if ( trim(config_time_integrator) == 'semi_implicit' ) then
+      if ( trim(config_time_integrator) == 'split_implicit' ) then
          !$acc enter data copyin(                       &
          !$acc                   SIvec_r0,              &
          !$acc                   SIvec_r00,             &
@@ -1000,7 +1000,7 @@ contains
          !$acc                   salinitySurfaceRestoringTendency  &
          !$acc                   )
       end if
-      if ( trim(config_time_integrator) == 'semi_implicit' ) then
+      if ( trim(config_time_integrator) == 'split_implicit' ) then
          !$acc exit data delete(                        &
          !$acc                   SIvec_r0,              &
          !$acc                   SIvec_r00,             &
@@ -1189,7 +1189,7 @@ contains
       if ( config_use_activeTracers_surface_restoring ) then
          nullify(salinitySurfaceRestoringTendency)
       end if
-      if ( trim(config_time_integrator) == 'semi_implicit' ) then
+      if ( trim(config_time_integrator) == 'split_implicit' ) then
          nullify(SIvec_r0,              &
                  SIvec_r00,             &
                  SIvec_r1,              &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -188,11 +188,11 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: gmResolutionTaper
 
    ! Semi-implicit Array Pointers
-   real (kind=RKIND), dimension(:), pointer :: CGvec_r0,CGvec_r00,CGvec_r1 ,CGvec_rh0,CGvec_rh1,CGvec_ph0,CGvec_ph1
-   real (kind=RKIND), dimension(:), pointer :: CGvec_v0,CGvec_v1 ,CGvec_s0 ,CGvec_s1 ,CGvec_sh0,CGvec_sh1
-   real (kind=RKIND), dimension(:), pointer :: CGvec_t0,CGvec_t1 ,CGvec_q0 ,CGvec_q1 ,CGvec_qh0
-   real (kind=RKIND), dimension(:), pointer :: CGvec_w0,CGvec_w1 ,CGvec_wh0,CGvec_wh1,CGvec_y0
-   real (kind=RKIND), dimension(:), pointer :: CGvec_z0,CGvec_z1 ,CGvec_zh0,CGvec_zh1
+   real (kind=RKIND), dimension(:), pointer :: SIvec_r0,SIvec_r00,SIvec_r1 ,SIvec_rh0,SIvec_rh1,SIvec_ph0,SIvec_ph1
+   real (kind=RKIND), dimension(:), pointer :: SIvec_v0,SIvec_s0 ,SIvec_s1 ,SIvec_sh0,SIvec_sh1
+   real (kind=RKIND), dimension(:), pointer :: SIvec_t0,SIvec_t1 ,SIvec_q0 ,SIvec_q1 ,SIvec_qh0
+   real (kind=RKIND), dimension(:), pointer :: SIvec_w0,SIvec_w1 ,SIvec_wh0,SIvec_wh1,SIvec_y0
+   real (kind=RKIND), dimension(:), pointer :: SIvec_z0,SIvec_z1 ,SIvec_zh0,SIvec_zh1
 
    !--------------------------------------------------------------------
    !
@@ -587,33 +587,32 @@ contains
 
       ! Semi-implicit Array Pointer retrievals
       if (trim(config_time_integrator) == 'semi_implicit') then
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_r0', CGvec_r0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_r1', CGvec_r1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_v0', CGvec_v0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_v1', CGvec_v1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_w0', CGvec_w0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_w1', CGvec_w1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_t0', CGvec_t0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_q0', CGvec_q0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_s0', CGvec_s0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_s1', CGvec_s1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_t0', CGvec_t0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_t1', CGvec_t1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_y0', CGvec_y0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_z0', CGvec_z0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_z1', CGvec_z1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_r00', CGvec_r00)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_rh0', CGvec_rh0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_rh1', CGvec_rh1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_wh0', CGvec_wh0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_wh1', CGvec_wh1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_ph0', CGvec_ph0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_ph1', CGvec_ph1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_qh0', CGvec_qh0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_sh0', CGvec_sh0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_sh1', CGvec_sh1)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_zh0', CGvec_zh0)
-         call mpas_pool_get_array(diagnosticsPool, 'CGvec_zh1', CGvec_zh1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_r0', SIvec_r0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_r1', SIvec_r1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_v0', SIvec_v0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_w0', SIvec_w0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_w1', SIvec_w1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_t0', SIvec_t0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_q0', SIvec_q0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_s0', SIvec_s0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_s1', SIvec_s1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_t0', SIvec_t0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_t1', SIvec_t1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_y0', SIvec_y0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_z0', SIvec_z0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_z1', SIvec_z1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_r00', SIvec_r00)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_rh0', SIvec_rh0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_rh1', SIvec_rh1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_wh0', SIvec_wh0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_wh1', SIvec_wh1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_ph0', SIvec_ph0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_ph1', SIvec_ph1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_qh0', SIvec_qh0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_sh0', SIvec_sh0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_sh1', SIvec_sh1)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_zh0', SIvec_zh0)
+         call mpas_pool_get_array(diagnosticsPool, 'SIvec_zh1', SIvec_zh1)
       end if
 
       ! Copy diagnostic variables to accelerator

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -765,33 +765,33 @@ contains
       end if
       if ( trim(config_time_integrator) == 'semi_implicit' ) then
          !$acc enter data copyin(                       &
-         !$acc                   CGvec_r0,              &
-         !$acc                   CGvec_r00,             &
-         !$acc                   CGvec_r1,              &
-         !$acc                   CGvec_rh0,             &
-         !$acc                   CGvec_rh1,             &
-         !$acc                   CGvec_ph0,             &
-         !$acc                   CGvec_ph1,             &
-         !$acc                   CGvec_v0,              &
-         !$acc                   CGvec_v1,              &
-         !$acc                   CGvec_s0,              &
-         !$acc                   CGvec_s1,              &
-         !$acc                   CGvec_sh0,             &
-         !$acc                   CGvec_sh1,             &
-         !$acc                   CGvec_t0,              &
-         !$acc                   CGvec_t1,              &
-         !$acc                   CGvec_q0,              &
-         !$acc                   CGvec_q1,              &
-         !$acc                   CGvec_qh0,             &
-         !$acc                   CGvec_w0,              &
-         !$acc                   CGvec_w1,              &
-         !$acc                   CGvec_wh0,             &
-         !$acc                   CGvec_wh1,             &
-         !$acc                   CGvec_y0,              &
-         !$acc                   CGvec_z0,              &
-         !$acc                   CGvec_z1,              &
-         !$acc                   CGvec_zh0,             &
-         !$acc                   CGvec_zh1,             &
+         !$acc                   SIvec_r0,              &
+         !$acc                   SIvec_r00,             &
+         !$acc                   SIvec_r1,              &
+         !$acc                   SIvec_rh0,             &
+         !$acc                   SIvec_rh1,             &
+         !$acc                   SIvec_ph0,             &
+         !$acc                   SIvec_ph1,             &
+         !$acc                   SIvec_v0,              &
+         !$acc                   SIvec_v0,              &
+         !$acc                   SIvec_s0,              &
+         !$acc                   SIvec_s1,              &
+         !$acc                   SIvec_sh0,             &
+         !$acc                   SIvec_sh1,             &
+         !$acc                   SIvec_t0,              &
+         !$acc                   SIvec_t1,              &
+         !$acc                   SIvec_q0,              &
+         !$acc                   SIvec_q1,              &
+         !$acc                   SIvec_qh0,             &
+         !$acc                   SIvec_w0,              &
+         !$acc                   SIvec_w1,              &
+         !$acc                   SIvec_wh0,             &
+         !$acc                   SIvec_wh1,             &
+         !$acc                   SIvec_y0,              &
+         !$acc                   SIvec_z0,              &
+         !$acc                   SIvec_z1,              &
+         !$acc                   SIvec_zh0,             &
+         !$acc                   SIvec_zh1,             &
          !$acc                   barotropicCoriolisTerm &
          !$acc                   )
       end if
@@ -1002,33 +1002,33 @@ contains
       end if
       if ( trim(config_time_integrator) == 'semi_implicit' ) then
          !$acc exit data delete(                        &
-         !$acc                   CGvec_r0,              &
-         !$acc                   CGvec_r00,             &
-         !$acc                   CGvec_r1,              &
-         !$acc                   CGvec_rh0,             &
-         !$acc                   CGvec_rh1,             &
-         !$acc                   CGvec_ph0,             &
-         !$acc                   CGvec_ph1,             &
-         !$acc                   CGvec_v0,              &
-         !$acc                   CGvec_v1,              &
-         !$acc                   CGvec_s0,              &
-         !$acc                   CGvec_s1,              &
-         !$acc                   CGvec_sh0,             &
-         !$acc                   CGvec_sh1,             &
-         !$acc                   CGvec_t0,              &
-         !$acc                   CGvec_t1,              &
-         !$acc                   CGvec_q0,              &
-         !$acc                   CGvec_q1,              &
-         !$acc                   CGvec_qh0,             &
-         !$acc                   CGvec_w0,              &
-         !$acc                   CGvec_w1,              &
-         !$acc                   CGvec_wh0,             &
-         !$acc                   CGvec_wh1,             &
-         !$acc                   CGvec_y0,              &
-         !$acc                   CGvec_z0,              &
-         !$acc                   CGvec_z1,              &
-         !$acc                   CGvec_zh0,             &
-         !$acc                   CGvec_zh1,             &
+         !$acc                   SIvec_r0,              &
+         !$acc                   SIvec_r00,             &
+         !$acc                   SIvec_r1,              &
+         !$acc                   SIvec_rh0,             &
+         !$acc                   SIvec_rh1,             &
+         !$acc                   SIvec_ph0,             &
+         !$acc                   SIvec_ph1,             &
+         !$acc                   SIvec_v0,              &
+         !$acc                   SIvec_v0,              &
+         !$acc                   SIvec_s0,              &
+         !$acc                   SIvec_s1,              &
+         !$acc                   SIvec_sh0,             &
+         !$acc                   SIvec_sh1,             &
+         !$acc                   SIvec_t0,              &
+         !$acc                   SIvec_t1,              &
+         !$acc                   SIvec_q0,              &
+         !$acc                   SIvec_q1,              &
+         !$acc                   SIvec_qh0,             &
+         !$acc                   SIvec_w0,              &
+         !$acc                   SIvec_w1,              &
+         !$acc                   SIvec_wh0,             &
+         !$acc                   SIvec_wh1,             &
+         !$acc                   SIvec_y0,              &
+         !$acc                   SIvec_z0,              &
+         !$acc                   SIvec_z1,              &
+         !$acc                   SIvec_zh0,             &
+         !$acc                   SIvec_zh1,             &
          !$acc                   barotropicCoriolisTerm &
          !$acc                   )
       end if
@@ -1190,33 +1190,33 @@ contains
          nullify(salinitySurfaceRestoringTendency)
       end if
       if ( trim(config_time_integrator) == 'semi_implicit' ) then
-         nullify(CGvec_r0,              &
-                 CGvec_r00,             &
-                 CGvec_r1,              &
-                 CGvec_rh0,             &
-                 CGvec_rh1,             &
-                 CGvec_ph0,             &
-                 CGvec_ph1,             &
-                 CGvec_v0,              &
-                 CGvec_v1,              &
-                 CGvec_s0,              &
-                 CGvec_s1,              &
-                 CGvec_sh0,             &
-                 CGvec_sh1,             &
-                 CGvec_t0,              &
-                 CGvec_t1,              &
-                 CGvec_q0,              &
-                 CGvec_q1,              &
-                 CGvec_qh0,             &
-                 CGvec_w0,              &
-                 CGvec_w1,              &
-                 CGvec_wh0,             &
-                 CGvec_wh1,             &
-                 CGvec_y0,              &
-                 CGvec_z0,              &
-                 CGvec_z1,              &
-                 CGvec_zh0,             &
-                 CGvec_zh1,             &
+         nullify(SIvec_r0,              &
+                 SIvec_r00,             &
+                 SIvec_r1,              &
+                 SIvec_rh0,             &
+                 SIvec_rh1,             &
+                 SIvec_ph0,             &
+                 SIvec_ph1,             &
+                 SIvec_v0,              &
+                 SIvec_v0,              &
+                 SIvec_s0,              &
+                 SIvec_s1,              &
+                 SIvec_sh0,             &
+                 SIvec_sh1,             &
+                 SIvec_t0,              &
+                 SIvec_t1,              &
+                 SIvec_q0,              &
+                 SIvec_q1,              &
+                 SIvec_qh0,             &
+                 SIvec_w0,              &
+                 SIvec_w1,              &
+                 SIvec_wh0,             &
+                 SIvec_wh1,             &
+                 SIvec_y0,              &
+                 SIvec_z0,              &
+                 SIvec_z1,              &
+                 SIvec_zh0,             &
+                 SIvec_zh1,             &
                  barotropicCoriolisTerm)
       end if
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -314,8 +314,8 @@ contains
          ! tendencies.
          usePlanetVorticity = .false.
 
-      case ('semi_implicit')
-         ! For semi-implicit, Coriolis tendency uses eta/h because
+      case ('split_implicit')
+         ! For split implicit, Coriolis tendency uses eta/h because
          ! the Coriolis term is added separately to the momentum
          ! tendencies.
          usePlanetVorticity = .false.

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -151,7 +151,7 @@ contains
       do iCell = 1, nCellsSolve
         do k = minLevelCell(iCell), maxLevelCell(iCell)
           ! use ssh as a proxy too for baroclinic mode
-          if (trim(config_time_integrator) == 'split_explicit' .or. trim(config_time_integrator) == 'semi_implicit') then
+          if (trim(config_time_integrator) == 'split_explicit' .or. trim(config_time_integrator) == 'split_implicit') then
             layerThick = min(layerThicknessNew(k, iCell), (sshSubcycleNew(iCell)+bottomDepth(iCell))/maxLevelCell(iCell))
           else
             layerThick = layerThicknessNew(k, iCell)


### PR DESCRIPTION
See https://github.com/MPAS-Dev/MPAS-Model/pull/879

This PR modifies codes for the semi-implicit barotropic mode solver.
Here are main changes I've made for this PR compared to the former version.

- Significant cleanup as done in https://github.com/MPAS-Dev/MPAS-Model/pull/781
- Change of the linear iterative solver algorithm (reducing global and local communications)
    - from the preconditioned pipelined BiCGStab to the single-reduction BiCGStab
    - removal of local halo exchanges before preconditioning
- Change of scalar and array names used in the semi-implicit solver
    - from 'CG***' to 'SI***'
- Addition of the 'config_n_btr_si_large_iter' flag
    - The large barotropic system iteration loop is added.
    - Any positive integer. Default is 1, but less than 2.
    - Higher value of the  'config_n_btr_si_large_iter' can make the model more stable and accurate, but runtime for advance of the barotropic system will increase.
- Other changes
    - removal of the 'config_n_btr_si_outer_iter' flag
           - Instead, the outer iteration tolerance (1.0e-2) is hard coded.
    - more detailed notes on the semi-implicit solver
    - small bugs fix

Note: 
- This PR is not bit-for-bit compared to the previous semi-implicit code.
- By setting `config_btr_si_partition_match_mode = .true.`, this PR has the same pass/fail results of the nightly test suite with the split-explicit code.
  - For `config_btr_si_partition_match_mode = .false.` (default), partition tests fail, which is expected for the semi-implicit barotropic mode solver.

[NML]
[BFB]
