### PR TITLE
Adding libstdc++ to libs

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -929,6 +929,9 @@ ifdef MPAS_EXTERNAL_CPPFLAGS
 	override CPPFLAGS += $(MPAS_EXTERNAL_CPPFLAGS)
 endif
 ####################################################
+ifeq "$(USE_PIO2)" "true"
+	override LIBS += -lstdc++
+endif
 
 ifeq "$(CONTINUE)" "true"
 all: mpas_main


### PR DESCRIPTION
Resubmitting with descriptive branch name.

Adding a link to the stdc++ library when using PIO2. Scorpio has some C++ code that requires the addition of the C++ standard library. This fixes the build on Darwin with the PIO2 library for the PGI, GCC and Intel builds (pgi, fortran and ifort) as well as the PGI OpenACC build (pgi-summit), all with OpenMPI. The change has been tested for builds on Darwin and Grizzly.