### PR TITLE
Adding libstdc++ to libs

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -929,6 +929,9 @@ ifdef MPAS_EXTERNAL_CPPFLAGS
 	override CPPFLAGS += $(MPAS_EXTERNAL_CPPFLAGS)
 endif
 ####################################################
+ifeq "$(USE_PIO2)" "true"
+	override LIBS += -lstdc++
+endif
 
 ifeq "$(CONTINUE)" "true"
 all: mpas_main


### PR DESCRIPTION
Adding a link to the stdc++ library when using PIO2. Scorpio has some C++ code that requires the addition of the C++ standard library. This fixes the build on Darwin with the PIO2 library for the PGI, GCC and Intel builds (pgi, fortran and ifort) as well as the PGI OpenACC build (pgi-summit), all with OpenMPI. The change has been tested for builds on Darwin and Grizzly.

Currently the builds with the three compilers fail with different, non-informative errors. This fix can also be done by setting the MPAS_EXTERNAL_LIBS variable to -lstdc++. This latter approach can be used to fix older builds. It is unlikely that the mpif90 compiler wrapper would include the C++ standard library, so this fix is likely to be necessary on all platforms. In any case, a duplicate library inclusion should not cause a problem.

[BFB]