### PR TITLE
Adds default value for PIO_NETCDF_FORMAT esp component

### DIFF
--- a/driver-mct/cime_config/namelist_definition_modelio.xml
+++ b/driver-mct/cime_config/namelist_definition_modelio.xml
@@ -172,6 +172,7 @@
     <value component="glc">$GLC_PIO_NETCDF_FORMAT</value>
     <value component="wav">$WAV_PIO_NETCDF_FORMAT</value>
     <value component="iac">$IAC_PIO_NETCDF_FORMAT</value>
+    <value component="esp">$ESP_PIO_NETCDF_FORMAT</value>
     </values>
   </entry>
 


### PR DESCRIPTION
* Adds missing default value for PIO_NETCDF_FORMAT's esp component.

Fixes #4372 