### PR TITLE
Reduce MPAS output

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -566,7 +566,11 @@
 <config_use_MacroMoleculesTracers_sea_ice_coupling>.false.</config_use_MacroMoleculesTracers_sea_ice_coupling>
 
 <!-- AM_globalStats -->
-<config_AM_globalStats_enable>.false.</config_AM_globalStats_enable>
+<config_AM_globalStats_enable>.true.</config_AM_globalStats_enable>
+<config_AM_globalStats_enable ocn_grid="oQU480">.false.</config_AM_globalStats_enable>
+<config_AM_globalStats_enable ocn_grid="oQU240">.false.</config_AM_globalStats_enable>
+<config_AM_globalStats_enable ocn_grid="oQU240wLI">.false.</config_AM_globalStats_enable>
+<config_AM_globalStats_enable ocn_grid="oQU120">.false.</config_AM_globalStats_enable>
 <config_AM_globalStats_compute_interval>'output_interval'</config_AM_globalStats_compute_interval>
 <config_AM_globalStats_compute_on_startup>.true.</config_AM_globalStats_compute_on_startup>
 <config_AM_globalStats_write_on_startup>.false.</config_AM_globalStats_write_on_startup>
@@ -644,7 +648,11 @@
 <config_AM_testComputeInterval_output_stream>'testComputeIntervalOutput'</config_AM_testComputeInterval_output_stream>
 
 <!-- AM_highFrequencyOutput -->
-<config_AM_highFrequencyOutput_enable>.false.</config_AM_highFrequencyOutput_enable>
+<config_AM_highFrequencyOutput_enable>.true.</config_AM_highFrequencyOutput_enable>
+<config_AM_highFrequencyOutput_enable ocn_grid="oQU480">.false.</config_AM_highFrequencyOutput_enable>
+<config_AM_highFrequencyOutput_enable ocn_grid="oQU240">.false.</config_AM_highFrequencyOutput_enable>
+<config_AM_highFrequencyOutput_enable ocn_grid="oQU240wLI">.false.</config_AM_highFrequencyOutput_enable>
+<config_AM_highFrequencyOutput_enable ocn_grid="oQU120">.false.</config_AM_highFrequencyOutput_enable>
 <config_AM_highFrequencyOutput_compute_interval>'output_interval'</config_AM_highFrequencyOutput_compute_interval>
 <config_AM_highFrequencyOutput_output_stream>'highFrequencyOutput'</config_AM_highFrequencyOutput_output_stream>
 <config_AM_highFrequencyOutput_compute_on_startup>.false.</config_AM_highFrequencyOutput_compute_on_startup>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -566,7 +566,7 @@
 <config_use_MacroMoleculesTracers_sea_ice_coupling>.false.</config_use_MacroMoleculesTracers_sea_ice_coupling>
 
 <!-- AM_globalStats -->
-<config_AM_globalStats_enable>.true.</config_AM_globalStats_enable>
+<config_AM_globalStats_enable>.false.</config_AM_globalStats_enable>
 <config_AM_globalStats_compute_interval>'output_interval'</config_AM_globalStats_compute_interval>
 <config_AM_globalStats_compute_on_startup>.true.</config_AM_globalStats_compute_on_startup>
 <config_AM_globalStats_write_on_startup>.false.</config_AM_globalStats_write_on_startup>
@@ -644,7 +644,7 @@
 <config_AM_testComputeInterval_output_stream>'testComputeIntervalOutput'</config_AM_testComputeInterval_output_stream>
 
 <!-- AM_highFrequencyOutput -->
-<config_AM_highFrequencyOutput_enable>.true.</config_AM_highFrequencyOutput_enable>
+<config_AM_highFrequencyOutput_enable>.false.</config_AM_highFrequencyOutput_enable>
 <config_AM_highFrequencyOutput_compute_interval>'output_interval'</config_AM_highFrequencyOutput_compute_interval>
 <config_AM_highFrequencyOutput_output_stream>'highFrequencyOutput'</config_AM_highFrequencyOutput_output_stream>
 <config_AM_highFrequencyOutput_compute_on_startup>.false.</config_AM_highFrequencyOutput_compute_on_startup>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -449,7 +449,11 @@
 <config_AM_temperatures_write_on_startup>true</config_AM_temperatures_write_on_startup>
 
 <!-- AM_regionalStatistics -->
-<config_AM_regionalStatistics_enable>false</config_AM_regionalStatistics_enable>
+<config_AM_regionalStatistics_enable>true</config_AM_regionalStatistics_enable>
+<config_AM_regionalStatistics_enable ice_grid="oQU480">false</config_AM_regionalStatistics_enable>
+<config_AM_regionalStatistics_enable ice_grid="oQU240">false</config_AM_regionalStatistics_enable>
+<config_AM_regionalStatistics_enable ice_grid="oQU240wLI">false</config_AM_regionalStatistics_enable>
+<config_AM_regionalStatistics_enable ice_grid="oQU120">false</config_AM_regionalStatistics_enable>
 <config_AM_regionalStatistics_enable prognostic_mode="prescribed">false</config_AM_regionalStatistics_enable>
 <config_AM_regionalStatistics_compute_interval>'0000-00-01_00:00:00'</config_AM_regionalStatistics_compute_interval>
 <config_AM_regionalStatistics_output_stream>'regionalStatisticsOutput'</config_AM_regionalStatistics_output_stream>
@@ -548,7 +552,11 @@
 <config_AM_icePresent_write_on_startup>false</config_AM_icePresent_write_on_startup>
 
 <!-- AM_timeSeriesStatsDaily -->
-<config_AM_timeSeriesStatsDaily_enable>false</config_AM_timeSeriesStatsDaily_enable>
+<config_AM_timeSeriesStatsDaily_enable>true</config_AM_timeSeriesStatsDaily_enable>
+<config_AM_timeSeriesStatsDaily_enable ice_grid="oQU480">false</config_AM_timeSeriesStatsDaily_enable>
+<config_AM_timeSeriesStatsDaily_enable ice_grid="oQU240">false</config_AM_timeSeriesStatsDaily_enable>
+<config_AM_timeSeriesStatsDaily_enable ice_grid="oQU240wLI">false</config_AM_timeSeriesStatsDaily_enable>
+<config_AM_timeSeriesStatsDaily_enable ice_grid="oQU120">false</config_AM_timeSeriesStatsDaily_enable>
 <config_AM_timeSeriesStatsDaily_enable prognostic_mode="prescribed">false</config_AM_timeSeriesStatsDaily_enable>
 <config_AM_timeSeriesStatsDaily_compute_on_startup>false</config_AM_timeSeriesStatsDaily_compute_on_startup>
 <config_AM_timeSeriesStatsDaily_write_on_startup>false</config_AM_timeSeriesStatsDaily_write_on_startup>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -449,7 +449,7 @@
 <config_AM_temperatures_write_on_startup>true</config_AM_temperatures_write_on_startup>
 
 <!-- AM_regionalStatistics -->
-<config_AM_regionalStatistics_enable>true</config_AM_regionalStatistics_enable>
+<config_AM_regionalStatistics_enable>false</config_AM_regionalStatistics_enable>
 <config_AM_regionalStatistics_enable prognostic_mode="prescribed">false</config_AM_regionalStatistics_enable>
 <config_AM_regionalStatistics_compute_interval>'0000-00-01_00:00:00'</config_AM_regionalStatistics_compute_interval>
 <config_AM_regionalStatistics_output_stream>'regionalStatisticsOutput'</config_AM_regionalStatistics_output_stream>
@@ -548,7 +548,7 @@
 <config_AM_icePresent_write_on_startup>false</config_AM_icePresent_write_on_startup>
 
 <!-- AM_timeSeriesStatsDaily -->
-<config_AM_timeSeriesStatsDaily_enable>true</config_AM_timeSeriesStatsDaily_enable>
+<config_AM_timeSeriesStatsDaily_enable>false</config_AM_timeSeriesStatsDaily_enable>
 <config_AM_timeSeriesStatsDaily_enable prognostic_mode="prescribed">false</config_AM_timeSeriesStatsDaily_enable>
 <config_AM_timeSeriesStatsDaily_compute_on_startup>false</config_AM_timeSeriesStatsDaily_compute_on_startup>
 <config_AM_timeSeriesStatsDaily_write_on_startup>false</config_AM_timeSeriesStatsDaily_write_on_startup>


### PR DESCRIPTION
Turn off netcdf output for
- mpassi.hist.am.regionalStatistics
- mpassi.hist.am.timeSeriesStatsDaily
- mpaso.hist.am.globalStats
- mpaso.hist.am.highFrequencyOutput

[BFB]