### PR TITLE
Add namelist variable for MMF CRM orientation

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3693,6 +3693,9 @@ add_default($nl, 'use_crm_accel');
 add_default($nl, 'crm_accel_uv');
 add_default($nl, 'crm_accel_factor');
 
+# MMF CRM domain orientation
+add_default($nl, 'MMF_orientation_angle');
+
 add_default($nl, 'do_aerocom_ind3');
 my $aerocom_ind3 = $nl->get_value('do_aerocom_ind3');
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -796,6 +796,9 @@
 <use_MMF_VT use_MMF_VT="1"> .true. </use_MMF_VT>
 <MMF_VT_wn_max            > 0      </MMF_VT_wn_max>
 
+<MMF_orientation_angle yes3Dval=0 > 1.57079632679 </MMF_orientation_angle>
+<MMF_orientation_angle yes3Dval=1 > 0.0           </MMF_orientation_angle>
+
 <do_aerocom_ind3                > .false. </do_aerocom_ind3>
 <do_aerocom_ind3  aerocom_ind3="1" > .true.  </do_aerocom_ind3>
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -796,8 +796,8 @@
 <use_MMF_VT use_MMF_VT="1"> .true. </use_MMF_VT>
 <MMF_VT_wn_max            > 0      </MMF_VT_wn_max>
 
-<MMF_orientation_angle yes3Dval=0 > 1.57079632679 </MMF_orientation_angle>
-<MMF_orientation_angle yes3Dval=1 > 0.0           </MMF_orientation_angle>
+<MMF_orientation_angle yes3Dval=0 > 90.0 </MMF_orientation_angle>
+<MMF_orientation_angle yes3Dval=1 >  0.0 </MMF_orientation_angle>
 
 <do_aerocom_ind3                > .false. </do_aerocom_ind3>
 <do_aerocom_ind3  aerocom_ind3="1" > .true.  </do_aerocom_ind3>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4058,14 +4058,14 @@ Default: sam1mom
 
 <entry id="MMF_orientation_angle" type="real" category="conv"
        group="phys_ctl_nl" valid_values="">
-Angle of CRM domain in radians used to apply large scale wind forcing.
+Angle of CRM domain in degrees used to apply large scale wind forcing.
 Default value depends on whether CRM domain is 2D or 3D. For 2D runs a value 
-of pi/2=90deg used for a south-north orientation to reduce precipitation biases
+of 90deg used for a south-north orientation to reduce precipitation biases
 that tend to occur when the CRM aligns with the prevailing wind.
-A value of -1 can be specified to enable a randomly rotating CRM orientation.
+A value of -1 enables an experimental randomly rotating CRM orientation.
 Defaults: 
-  2D: 1.57079632679
-  3D: 0
+  2D CRM: 90 (i.e. north-south)
+  3D CRM: 0
 </entry>
 
 <entry id="MMF_VT_wn_max" type="real" category="conv"

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4056,6 +4056,18 @@ Type of E3SM-MMF microphysics scheme employed.
 Default: sam1mom
 </entry>
 
+<entry id="MMF_orientation_angle" type="real" category="conv"
+       group="phys_ctl_nl" valid_values="">
+Angle of CRM domain in radians used to apply large scale wind forcing.
+Default value depends on whether CRM domain is 2D or 3D. For 2D runs a value 
+of pi/2=90deg used for a south-north orientation to reduce precipitation biases
+that tend to occur when the CRM aligns with the prevailing wind.
+A value of -1 can be specified to enable a randomly rotating CRM orientation.
+Defaults: 
+  2D: 1.57079632679
+  3D: 0
+</entry>
+
 <entry id="MMF_VT_wn_max" type="real" category="conv"
        group="phys_ctl_nl" valid_values="">
 Wavenumber cutoff for filtered MMF variance transport. 

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -61,7 +61,6 @@
       <value compset="_EAM%MMF[12]"           >-crm sam</value>
       <value compset="_EAM%MMFXX"             >-crm samxx</value>
       <value compset="_EAM%MMFOMP"            >-crm samomp</value>
-      <value compset="_EAM%MMF"               >-cppdefs ' -DMMF_DIR_NS ' </value>
       <value compset="_EAM%MMF"               >-rad rrtmgp </value>
       <value compset="_EAM%MMF[1XO]"          >-MMF_microphysics_scheme sam1mom -chem none</value>
       <value compset="_EAM%MMF2"              >-MMF_microphysics_scheme m2005 </value>

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_fixed_subcycle/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_fixed_subcycle/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange --append -id CAM_CONFIG_OPTS -val " -cppdefs ' -DMMF_DIR_NS -DMMF_FIXED_SUBCYCLE ' "
+./xmlchange --append -id CAM_CONFIG_OPTS -val " -cppdefs ' -DMMF_FIXED_SUBCYCLE ' "

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_ESMT/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_ESMT/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange --append -id CAM_CONFIG_OPTS -val " -cppdefs ' -DMMF_DIR_NS -DMMF_ESMT -DMMF_USE_ESMT ' "
+./xmlchange --append -id CAM_CONFIG_OPTS -val " -cppdefs ' -DMMF_ESMT -DMMF_USE_ESMT ' "

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_VT/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_VT/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange --append -id CAM_CONFIG_OPTS -val " -use_MMF_VT -cppdefs ' -DMMF_DIR_NS -DMMF_VT_KMAX=4 ' "
+./xmlchange --append -id CAM_CONFIG_OPTS -val " -use_MMF_VT -cppdefs ' -DMMF_VT_KMAX=4 ' "

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -459,7 +459,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
                         history_clubb_out, ieflx_opt_out, conv_water_in_rad_out, cam_chempkg_out, &
                         prog_modal_aero_out, macrop_scheme_out, &
                         use_MMF_out, use_ECPP_out, MMF_microphysics_scheme_out, &
-                        use_MMF_VT_out, MMF_VT_wn_max_out, &
+                        MMF_orientation_angle_out, use_MMF_VT_out, MMF_VT_wn_max_out, &
                         use_crm_accel_out, crm_accel_factor_out, crm_accel_uv_out, &
                         do_clubb_sgs_out, do_tms_out, state_debug_checks_out, &
                         linearize_pbl_winds_out, export_gustiness_out, &
@@ -491,6 +491,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    character(len=16), intent(out), optional :: radiation_scheme_out
    character(len=16), intent(out), optional :: macrop_scheme_out
    character(len=16), intent(out), optional :: MMF_microphysics_scheme_out
+   real(r8),          intent(out), optional :: MMF_orientation_angle_out
    logical,           intent(out), optional :: use_MMF_out
    logical,           intent(out), optional :: use_ECPP_out
    logical,           intent(out), optional :: use_MMF_VT_out
@@ -565,6 +566,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(radiation_scheme_out    ) ) radiation_scheme_out     = radiation_scheme
 
    if ( present(MMF_microphysics_scheme_out ) ) MMF_microphysics_scheme_out  = MMF_microphysics_scheme
+   if ( present(MMF_orientation_angle_out   ) ) MMF_orientation_angle_out    = MMF_orientation_angle
    if ( present(use_MMF_out             ) ) use_MMF_out              = use_MMF
    if ( present(use_ECPP_out            ) ) use_ECPP_out             = use_ECPP
    if ( present(use_MMF_VT_out          ) ) use_MMF_VT_out           = use_MMF_VT

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -61,7 +61,7 @@ integer           :: conv_water_in_rad    = unset_int  ! 0==> No; 1==> Yes-Arith
                                                        ! 2==> Yes-Average in emissivity.
 
 character(len=16) :: MMF_microphysics_scheme  = unset_str  ! MMF microphysics package
-real(r8)          :: MMF_orientation_angle= 0.D0       ! CRM acceleration factor
+real(r8)          :: MMF_orientation_angle= 0.D0       ! CRM orientation angle [deg]
 logical           :: use_MMF              = .false.    ! true => use MMF / super-parameterization
 logical           :: use_ECPP             = .false.    ! true => use explicit-cloud parameterized-pollutants
 logical           :: use_MMF_VT           = .false.    ! true => use MMF variance transport
@@ -385,7 +385,7 @@ subroutine phys_ctl_readnl(nlfile)
          call endrun('phys_setopts: illegal value of MMF_microphysics_scheme')
       end if
       ! check value of MMF_orientation_angle
-      if ( MMF_orientation_angle<0 .or. MMF_orientation_angle>(pi*2) ) then
+      if ( MMF_orientation_angle<0 .or. MMF_orientation_angle>(360) ) then
          if ( MMF_orientation_angle/=-1) then
             write(iulog,*)'phys_setopts: illegal value of MMF_orientation_angle:', MMF_orientation_angle
             call endrun('phys_setopts: illegal value of MMF_orientation_angle')

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -555,7 +555,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    real(r8) :: tmp_rh_cnt                          ! temporary relative humidity count
 
    ! variables for changing CRM orientation
-   real(crm_rknd) :: MMF_orientation_angle
+   real(crm_rknd) :: MMF_orientation_angle         ! CRM orientation [deg] (convert to radians)
    real(crm_rknd) :: unif_rand1, unif_rand2        ! uniform random numbers 
    real(crm_rknd) :: norm_rand                     ! normally distributed random number - Box-Muller (1958)
    real(crm_rknd) :: crm_rotation_std              ! scaling factor for rotation (std dev of rotation angle)
@@ -690,7 +690,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    else
 
       ! use static CRM orientation (no rotation) - only set pbuf values once
-      if (is_first_step()) crm_angle(1:ncol) = MMF_orientation_angle
+      if (is_first_step()) crm_angle(1:ncol) = MMF_orientation_angle * pi/180.
 
    end if
 

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -659,7 +659,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    !------------------------------------------------------------------------------------------------
    ! Set CRM orientation angle
    !------------------------------------------------------------------------------------------------
-   if (MMF_orientation_angle==-1)
+   if (MMF_orientation_angle==-1) then
 
       crm_rotation_std    = 20. * pi/180.                 ! std deviation of normal distribution for CRM rotation [radians]
       crm_rotation_offset = 90. * pi/180. * ztodt/86400.  ! This means that a CRM should rotate 90 deg / day on average

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -1,7 +1,3 @@
-#if defined( MMF_ORIENT_RAND ) && defined( MMF_DIR_NS )
-#undef MMF_DIR_NS
-#endif
-
 module crm_physics
 !---------------------------------------------------------------------------------------------------
 ! Purpose: Provides the interface to the crm code for the MMF configuration
@@ -456,7 +452,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    use camsrfexch,      only: cam_in_t, cam_out_t
    use time_manager,    only: is_first_step, get_nstep
    use crmdims,         only: crm_nx, crm_ny, crm_nz, crm_nx_rad, crm_ny_rad
-   use physconst,       only: cpair, latvap, latice, gravit, cappa
+   use physconst,       only: cpair, latvap, latice, gravit, cappa, pi
    use constituents,    only: pcnst, cnst_get_ind
 #if defined(MMF_SAMXX)
    use cpp_interface_mod, only: crm
@@ -473,9 +469,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    use ndrop,           only: loadaer
 #endif
 
-#if defined( MMF_ORIENT_RAND )
-   use RNG_MT ! random number generator for randomly rotating CRM orientation (MMF_ORIENT_RAND)
-#endif
+   use RNG_MT ! random number generator for randomly rotating CRM orientation
 
    use crm_state_module,       only: crm_state_type, crm_state_initialize, crm_state_finalize
    use crm_rad_module,         only: crm_rad_type, crm_rad_initialize, crm_rad_finalize
@@ -560,8 +554,11 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    real(r8) :: tmp_rh_cnt                          ! temporary relative humidity count
 
    ! variables for changing CRM orientation
-   real(crm_rknd), parameter        :: pi   = 3.14159265359
-   real(crm_rknd), parameter        :: pix2 = 6.28318530718
+   real(crm_rknd) :: MMF_orientation_angle
+   real(crm_rknd) :: unif_rand1, unif_rand2        ! uniform random numbers 
+   real(crm_rknd) :: norm_rand                     ! normally distributed random number - Box-Muller (1958)
+   real(crm_rknd) :: crm_rotation_std              ! scaling factor for rotation (std dev of rotation angle)
+   real(crm_rknd) :: crm_rotation_offset           ! offset to specify preferred rotation direction 
    real(crm_rknd), dimension(pcols) :: crm_angle
 
    ! surface flux variables for using adjusted fluxes from flux_avg_run
@@ -580,14 +577,6 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    type(crm_rad_type)    :: crm_rad
    type(crm_input_type)  :: crm_input
    type(crm_output_type) :: crm_output
-
-#if defined( MMF_ORIENT_RAND )
-   real(crm_rknd) :: unif_rand1           ! uniform random number 
-   real(crm_rknd) :: unif_rand2           ! uniform random number 
-   real(crm_rknd) :: norm_rand            ! normally distributed random number - Box-Muller (1958)
-   real(crm_rknd) :: crm_rotation_std     ! scaling factor for rotation (std dev of rotation angle)
-   real(crm_rknd) :: crm_rotation_offset  ! offset to specify preferred rotation direction 
-#endif
 
    real(crm_rknd), allocatable :: crm_clear_rh(:,:) ! clear air relative humidity for aerosol wateruptake
 
@@ -637,13 +626,10 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
 
    !------------------------------------------------------------------------------------------------
    !------------------------------------------------------------------------------------------------
-#if defined( MMF_ORIENT_RAND )
-   crm_rotation_std    = 20. * pi/180.                 ! std deviation of normal distribution for CRM rotation [radians]
-   crm_rotation_offset = 90. * pi/180. * ztodt/86400.  ! This means that a CRM should rotate 90 deg / day on average
-#endif
 
    call phys_getopts(use_ECPP_out = use_ECPP)
    call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
+   call phys_getopts(MMF_orientation_angle_out = MMF_orientation_angle)
 
    use_MMF_VT = .false.
    call phys_getopts(use_MMF_VT_out = use_MMF_VT_tmp)
@@ -673,50 +659,40 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    !------------------------------------------------------------------------------------------------
    ! Set CRM orientation angle
    !------------------------------------------------------------------------------------------------
-   crm_angle(:) = 0
+   if (MMF_orientation_angle==-1)
 
-#if defined( MMF_ORIENT_RAND )
-   !------------------------------------------------------------------------------------------------
-   ! Rotate the CRM using a random walk
-   !------------------------------------------------------------------------------------------------
-   if ( (crm_ny.eq.1) .or. (crm_nx.eq.1) ) then
+      crm_rotation_std    = 20. * pi/180.                 ! std deviation of normal distribution for CRM rotation [radians]
+      crm_rotation_offset = 90. * pi/180. * ztodt/86400.  ! This means that a CRM should rotate 90 deg / day on average
 
-      if (.not. is_first_step()) then
-         ! get current crm angle from pbuf, except on first step
-         call pbuf_get_field(pbuf, pbuf_get_index('CRM_ANGLE'), crm_angle)
+      ! Rotate the CRM using a random walk
+      if ( (crm_ny.eq.1) .or. (crm_nx.eq.1) ) then
+         if (.not. is_first_step()) then
+            ! get current crm angle from pbuf, except on first step
+            call pbuf_get_field(pbuf, pbuf_get_index('CRM_ANGLE'), crm_angle)
+         end if
+         do i = 1,ncol
+            ! set the seed based on the chunk and column index (duplicate seeds are ok)
+            call RNG_MT_set_seed( lchnk + i + nstep )
+            ! Generate a pair of uniform random numbers
+            call RNG_MT_gen_rand(unif_rand1)
+            call RNG_MT_gen_rand(unif_rand2)
+            ! Box-Muller (1958) method of obtaining a Gaussian distributed random number
+            norm_rand = sqrt(-2.*log(unif_rand1))*cos(pi*2*unif_rand2)
+            crm_angle(i) = crm_angle(i) + norm_rand * crm_rotation_std + crm_rotation_offset
+            ! Adjust CRM orientation angle to be between 0 and 2*pi
+            if ( crm_angle(i).lt. 0.   ) crm_angle(i) = crm_angle(i) + pi*2
+            if ( crm_angle(i).gt.(pi*2)) crm_angle(i) = crm_angle(i) - pi*2
+         end do ! i
+         ! write current crm_angle to pbuf
+         call pbuf_set_field(pbuf, pbuf_get_index('CRM_ANGLE'), crm_angle)
       end if
 
-      do i = 1,ncol
+   else
 
-         ! set the seed based on the chunk and column index (duplicate seeds are ok)
-         call RNG_MT_set_seed( lchnk + i + nstep )
+      ! use static CRM orientation (no rotation)
+      crm_angle(:ncol) = MMF_orientation_angle
 
-         ! Generate a pair of uniform random numbers
-         call RNG_MT_gen_rand(unif_rand1)
-         call RNG_MT_gen_rand(unif_rand2)
-
-         ! Box-Muller (1958) method of obtaining a Gaussian distributed random number
-         norm_rand = sqrt(-2.*log(unif_rand1))*cos(pix2*unif_rand2)
-         crm_angle(i) = crm_angle(i) + norm_rand * crm_rotation_std + crm_rotation_offset
-
-         ! Adjust CRM orientation angle to be between 0 and 2*pi
-         if ( crm_angle(i) .lt. 0. )   crm_angle(i) = crm_angle(i) + pix2
-         if ( crm_angle(i) .gt. pix2 ) crm_angle(i) = crm_angle(i) - pix2
-
-      end do ! i
-
-      ! write current crm_angle to pbuf
-      call pbuf_set_field(pbuf, pbuf_get_index('CRM_ANGLE'), crm_angle)
    end if
-#else /* MMF_ORIENT_RAND */
-   !------------------------------------------------------------------------------------------------
-   ! use static CRM orientation (no rotation)
-   !------------------------------------------------------------------------------------------------
-#if defined( MMF_DIR_NS )
-    if (crm_ny.eq.1) crm_angle(:ncol) = pi/2.
-#endif /* MMF_DIR_NS */
-
-#endif /* MMF_ORIENT_RAND */
 
    !------------------------------------------------------------------------------------------------
    ! Retrieve pbuf fields and constituent indices


### PR DESCRIPTION
This replaces the MMF_DIR_NS and MMF_ORIENT_RAND preprocessor flags with a namelist variable "MMF_orientation_angle", specified in degrees. The angle defaults to 90 for 2D MMF cases and 0 for 3D cases. The random rotation mode can be enabled with MMF_orientation_angle=-1. Changes are non-BFB because the value of pi was changed to use the physconst value instead of a locally defined value with arbitrary precision.

[BFB] except for MMF