### PR TITLE
Remove old MMF "SP" compsets

### DIFF
--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -55,18 +55,7 @@
       <!-- Later settings of "-chem" take precedence over earlier ones. -->
       <value compset="_EAM%WC"       >-chem waccm_mozart_mam3</value>
       <value compset="_EAM%WCMX"  >-waccmx</value>
-      <!-- old MMF / super-parameterization compsets -->
-      <!-- These are needed to test against the ECP fork  -->
-      <!-- they will be removed in a future PR -->
-      <value compset="_EAM%SP[12]V1"        >-use_MMF -crm_adv MPDATA -nlev 72 -crm_nz 58 -crm_dx 1000 -crm_dt 5 </value>
-      <value compset="_EAM%SP[12]V1"        >-microphys mg2  </value>
-      <value compset="_EAM%SP[12]V1"        >-cppdefs ' -DMMF_DIR_NS ' </value>
-      <value compset="_EAM%SP[12]V1"        >-rad rrtmg </value>
-      <value compset="_EAM%SP1V1"           >-MMF_microphysics_scheme sam1mom -chem none </value>
-      <value compset="_EAM%SP2V1"           >-MMF_microphysics_scheme m2005 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero </value>
-      <value compset="_EAM%SP2V1-ECPP"      >-use_ECPP </value>
-      <value compset="_EAM%SP[12]V1_"       >-crm_nx 64 -crm_ny 1 -crm_nx_rad 16 -crm_ny_rad 1 </value>
-      <!-- New MMF / super-parameterization compsets -->
+      <!-- MMF compset (i.e. super-parameterization) -->
       <value compset="_EAM%MMF"               >-use_MMF -crm_adv MPDATA -nlev 72 -crm_nz 58 </value>
       <value compset="_EAM%MMF"               >-crm_dx 1000 -crm_dt 5 </value>
       <value compset="_EAM%MMF[12]"           >-crm sam</value>
@@ -160,8 +149,6 @@
       <!-- Radiative-Convective Equilibrium (RCE) -->
       <value compset="_EAM%RCE"      >RCEMIP_EAMv1</value>
       <!-- MMF / Super-Parameterization -->
-      <value compset="2000(?:SOI)?_EAM%SP1"     >2000_cam5_av1c-04p2-MMF-1mom</value>
-      <value compset="2000(?:SOI)?_EAM%SP2"     >2000_cam5_av1c-04p2-MMF-2mom</value>
       <value compset="2000(?:SOI)?_EAM%MMF[1XO]">2000_cam5_av1c-04p2-MMF-1mom</value>
       <value compset="2000(?:SOI)?_EAM%MMF2"    >2000_cam5_av1c-04p2-MMF-2mom</value>
       <value compset="_EAM%MMF*-RCE"    >RCEMIP_EAMv1</value>
@@ -238,11 +225,7 @@
     <desc compset="_EAM%MG1M"   >MG1.0 w/ modified activation:</desc>
     <desc compset="_EAM%UNI"    >UNICON (modified mg1.0):</desc>
     <desc compset="EAM.*_BGC%B">EAM prognostic CO2 cycle turned on.</desc>
-    <!-- old MMF / Super-Parameterization -->
-    <desc compset="_EAM%SP1V1_"    >SP-E3SM with 64x1km CRM, RRTMG radiation, 1-mom micro, prescribed aerosol</desc>
-    <desc compset="_EAM%SP2V1_"    >SP-E3SM with 64x1km CRM, RRTMG radiation, 2-mom micro, prognostic aerosol</desc>
-    <desc compset="_EAM%SP2V1-ECPP">SP-E3SM with 64x1km CRM, RRTMG radiation, 2-mom micro, prognostic aerosol, ECPP</desc>
-    <!-- new MMF / Super-Parameterization -->
+    <!-- MMF / Super-Parameterization -->
     <desc compset="_EAM%MMF1"     >E3SM-MMF (Fortran) with 64x1km CRM, RRTMGP radiation, 1-mom micro, prescribed aerosol</desc>
     <desc compset="_EAM%MMF2-ECPP">E3SM-MMF (Fortran) with 64x1km CRM, RRTMGP radiation, 2-mom micro, prognostic aerosol, ECPP </desc>
     <desc compset="_EAM%MMFXX"    >E3SM-MMF (C++) with 64x1km CRM, RRTMGP radiation, 1-mom micro, prescribed aerosol</desc>

--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -243,18 +243,6 @@
   <!-- ****************************************** -->
 
   <!-- ********** F compsets ********** -->
-
-  <!-- Old MMF compsets for comparing with original ECP fork -->
-  <compset>
-    <alias>FSP1V1</alias>
-    <lname>2000_EAM%SP1V1_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
-  </compset>
-  <compset>
-    <alias>FSP2V1</alias>
-    <lname>2000_EAM%SP2V1_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
-  </compset>
-
-  <!-- New MMF compsets for new implementation in E3SM repo -->
   <compset>
     <alias>F-MMF1</alias>
     <lname>2000_EAM%MMF1_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -407,9 +407,6 @@
       <value compset="_DATM.*_DICE.*_POP2.*_WW3">4</value>
       <value compset="_DATM.*_DICE.*_POP2.*_DWAV">4</value>
       <!-- a shorter timestep is needed for stability in MMF compsets -->
-      <!-- (i.e. super-parameterization, MMF, CRM) -->
-      <value compset="_EAM%SP"       grid="a%ne4np4">96</value>
-      <value compset="_EAM%SP.*ECPP" grid="a%ne4np4">72</value>
       <value compset="_EAM%MMF"      grid="a%ne4np4">96</value>
       <value compset="_EAM%MMF"      grid="a%ne4np4.pg2">72</value>
     </values>


### PR DESCRIPTION
This removes the "SP" compsets copied from the original ECP fork, which are no longer needed. 

[BFB]