### PR TITLE
Remove LANDM_COSLAT and replace uses with LANDFRAC

### DIFF
--- a/components/eam/src/dynamics/se/dyn_comp.F90
+++ b/components/eam/src/dynamics/se/dyn_comp.F90
@@ -225,7 +225,7 @@ CONTAINS
     use time_mod,         only: time_at
     use control_mod,      only: runtype
     use cam_control_mod,  only: aqua_planet, ideal_phys, adiabatic
-    use comsrf,           only: landm, sgh, sgh30
+    use comsrf,           only: sgh, sgh30
     use cam_instance,     only: inst_index
     use element_ops,      only: set_thermostate
 
@@ -284,7 +284,6 @@ CONTAINS
           do ie=nets,nete
              elem(ie)%state%phis(:,:)=0.0_r8
           end do
-          if(allocated(landm)) landm=0.0_r8
           if(allocated(sgh)) sgh=0.0_r8
           if(allocated(sgh30)) sgh30=0.0_r8
        end if

--- a/components/eam/src/physics/cam/cldwat.F90
+++ b/components/eam/src/physics/cam/cldwat.F90
@@ -262,7 +262,7 @@ subroutine pcond (lchnk   ,ncol    , &
                   cme     ,prodprec,prodsnow,evapprec,evapsnow,evapheat, prfzheat, &     
                   meltheat,precip  ,snowab  ,deltat  ,fwaut   , &
                   fsaut   ,fracw   ,fsacw   ,fsaci   ,lctend  , &
-                  rhdfda  ,rhu00   ,seaicef, zi      ,ice2pr, liq2pr, &
+                  rhdfda  ,rhu00   ,landfrac,seaicef ,zi      ,ice2pr, liq2pr, &
                   liq2snow, snowh, rkflxprc, rkflxsnw, pracwo, psacwo, psacio)
 !----------------------------------------------------------------------- 
 ! 
@@ -308,9 +308,10 @@ subroutine pcond (lchnk   ,ncol    , &
    real(r8), intent(in) :: lctend(pcols,pver)   ! cloud liquid water tendencies   ====wlin
    real(r8), intent(in) :: rhdfda(pcols,pver)   ! dG(a)/da, rh=G(a), when rh>u00  ====wlin
    real(r8), intent(in) :: rhu00 (pcols,pver)   ! Rhlim for cloud                 ====wlin
+   real(r8), intent(in) :: landfrac(pcols)      ! land fraction  (fraction)
    real(r8), intent(in) :: seaicef(pcols)       ! sea ice fraction  (fraction)
    real(r8), intent(in) :: zi(pcols,pverp)      ! layer interfaces (m)
-    real(r8), intent(in) :: snowh(pcols)         ! Snow depth over land, water equivalent (m)
+   real(r8), intent(in) :: snowh(pcols)         ! Snow depth over land, water equivalent (m)
 !
 ! Output Arguments
 !
@@ -660,7 +661,7 @@ subroutine pcond (lchnk   ,ncol    , &
                          k       ,prprov  ,snowab,  t       ,p        , &
                          cwm     ,cldm    ,cldmax  ,fice(1,k),coef    , &
                          fwaut(1,k),fsaut(1,k),fracw(1,k),fsacw(1,k),fsaci(1,k), &
-                         seaicef, snowh, pracwo(1,k), psacwo(1,k), psacio(1,k))
+                         landfrac, seaicef, snowh, pracwo(1,k), psacwo(1,k), psacio(1,k))
 
 !
 ! calculate the precip rate
@@ -911,7 +912,7 @@ subroutine findmcnew (lchnk   ,ncol    , &
                       k       ,precab  ,snowab,  t       ,p       , &
                       cwm     ,cldm    ,cldmax  ,fice    ,coef    , &
                       fwaut   ,fsaut   ,fracw   ,fsacw   ,fsaci   , &
-                      seaicef ,snowh,  pracwo, psacwo, psacio )
+                      landfrac,seaicef ,snowh   ,pracwo  ,psacwo  , psacio )
  
 !----------------------------------------------------------------------- 
 ! 
@@ -928,7 +929,6 @@ subroutine findmcnew (lchnk   ,ncol    , &
 ! 
 !-----------------------------------------------------------------------
    use phys_grid, only: get_rlat_all_p
-   use comsrf,        only: landm
 !
 ! input args
 !
@@ -943,9 +943,10 @@ subroutine findmcnew (lchnk   ,ncol    , &
    real(r8), intent(in) :: cldmax(pcols)        ! max cloud fraction above this level
    real(r8), intent(in) :: cwm(pcols)           ! condensate mixing ratio (kg/kg)
    real(r8), intent(in) :: fice(pcols)          ! fraction of cwat that is ice
+   real(r8), intent(in) :: landfrac(pcols)      ! land fraction 
    real(r8), intent(in) :: seaicef(pcols)       ! sea ice fraction 
    real(r8), intent(in) :: snowab(pcols)        ! rate of snow from above (kg / (m**2 * s))
-    real(r8), intent(in) :: snowh(pcols)         ! Snow depth over land, water equivalent (m)
+   real(r8), intent(in) :: snowh(pcols)         ! Snow depth over land, water equivalent (m)
 
 ! output arguments
    real(r8), intent(out) :: coef(pcols)          ! conversion rate (1/s)
@@ -1130,7 +1131,7 @@ subroutine findmcnew (lchnk   ,ncol    , &
       ! Modify for snow depth over land
       capn = capn + (capnc-capn) * min(1.0_r8,max(0.0_r8,snowh(i)*10._r8))
       ! Ramp between polluted value over land to clean value over ocean.
-      capn = capn + (capnc-capn) * min(1.0_r8,max(0.0_r8,1.0_r8-landm(i,lchnk)))
+      capn = capn + (capnc-capn) * min(1.0_r8,max(0.0_r8,1.0_r8-landfrac(i)))
       ! Ramp between the resultant value and a sea ice value in the presence of ice.
       capn = capn + (capnsi-capn) * min(1.0_r8,max(0.0_r8,seaicef(i)))
 ! end jrm
@@ -1138,8 +1139,8 @@ subroutine findmcnew (lchnk   ,ncol    , &
 #ifdef DEBUG2
       if ( (lat(i) == latlook(1)) .or. (lat(i) == latlook(2)) ) then
          if (i == ilook(1)) then
-            write(iulog,*) ' findmcnew: lat, k, seaicef, landm, wp, capnoice, capn ', &
-                 lat(i), k, seaicef(i), landm(i,lat(i)), wp, capnoice, capn
+            write(iulog,*) ' findmcnew: lat, k, seaicef, landfrac, wp, capnoice, capn ', &
+                 lat(i), k, seaicef(i), landfrac(i), wp, capnoice, capn
          endif
       endif
 #endif

--- a/components/eam/src/physics/cam/comsrf.F90
+++ b/components/eam/src/physics/cam/comsrf.F90
@@ -34,13 +34,12 @@ module comsrf
 !
 ! Public data
 !
-  public landm, sgh, sgh30, fv, ram1, soilw, fsns, fsds
+  public sgh, sgh30, fv, ram1, soilw, fsns, fsds
   public fsnt, flns, flnt, srfrpdel, psm1, prcsnw
   public trefmxav, trefmnav
 
-  real(r8), allocatable:: landm(:,:)     ! land/ocean/sea ice flag
-  real(r8), allocatable:: sgh(:,:)       ! land/ocean/sea ice flag
-  real(r8), allocatable:: sgh30(:,:)     ! land/ocean/sea ice flag
+  real(r8), allocatable:: sgh(:,:)       ! Subgrid surface roughness
+  real(r8), allocatable:: sgh30(:,:)     ! Subgrid surface roughness
   real(r8), allocatable:: fv(:,:)        ! needed for dry dep velocities (over land)
   real(r8), allocatable:: ram1(:,:)      ! needed for dry dep velocities (over land)
   real(r8), allocatable:: soilw(:,:)     ! needed for dust emission (over land)
@@ -99,7 +98,6 @@ CONTAINS
     integer k,c      ! level, constituent indices
 
     if(.not. (adiabatic .or. ideal_phys)) then
-       allocate (landm   (pcols,begchunk:endchunk))
        allocate (sgh     (pcols,begchunk:endchunk))
        allocate (sgh30   (pcols,begchunk:endchunk))
 
@@ -121,7 +119,6 @@ CONTAINS
        ! elements of the array outside valid surface points must be set to
        ! zero if these fields are to be written to netcdf history files.
        !
-       landm    (:,:) = nan
        sgh      (:,:) = nan
        sgh30    (:,:) = nan
        fsns     (:,:) = nan

--- a/components/eam/src/physics/cam/pkg_cld_sediment.F90
+++ b/components/eam/src/physics/cam/pkg_cld_sediment.F90
@@ -96,7 +96,7 @@ end subroutine cld_sediment_readnl
 
   subroutine cld_sediment_vel (ncol,                               &
        icefrac , landfrac, ocnfrac , pmid    , pdel    , t       , &
-       cloud   , cldliq  , cldice  , pvliq   , pvice   , landm, snowh)
+       cloud   , cldliq  , cldice  , pvliq   , pvice   , snowh)
 
 !----------------------------------------------------------------------
 
@@ -147,7 +147,6 @@ end subroutine cld_sediment_readnl
 
     real(r8), intent(out) :: pvliq (pcols,pverp)    ! vertical velocity of cloud liquid drops (Pa/s)
     real(r8), intent(out) :: pvice (pcols,pverp)    ! vertical velocity of cloud ice particles (Pa/s)
-    real(r8), intent(in) :: landm(pcols)            ! land fraction ramped over water
 ! -> note that pvel is at the interfaces (loss from cell is based on pvel(k+1))
 
 ! Local variables
@@ -183,7 +182,7 @@ end subroutine cld_sediment_readnl
     pvliq(:ncol,:) = 0._r8
 
     ! get effective radius of liquid drop
-    call reltab(ncol, t, landfrac, landm, icefrac, rel, snowh)
+    call reltab(ncol, t, landfrac, icefrac, rel, snowh)
 
     do k = 1,pver
        do i = 1,ncol

--- a/components/eam/src/physics/cam/pkg_cldoptics.F90
+++ b/components/eam/src/physics/cam/pkg_cldoptics.F90
@@ -21,8 +21,7 @@ module pkg_cldoptics
 contains
 
 !===============================================================================
-  subroutine cldefr(lchnk   ,ncol    , &
-       landfrac,t       ,rel     ,rei     ,ps      ,pmid    , landm, icefrac, snowh)
+  subroutine cldefr(lchnk, ncol, t, rel, rei, ps, pmid, landfrac, icefrac, snowh)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -47,7 +46,6 @@ contains
     real(r8), intent(in) :: t(pcols,pver)        ! Temperature
     real(r8), intent(in) :: ps(pcols)            ! Surface pressure
     real(r8), intent(in) :: pmid(pcols,pver)     ! Midpoint pressures
-    real(r8), intent(in) :: landm(pcols)
     real(r8), intent(in) :: snowh(pcols)         ! Snow depth over land, water equivalent (m)
 !
 ! Output arguments
@@ -56,7 +54,7 @@ contains
     real(r8), intent(out) :: rei(pcols,pver)      ! Ice effective drop size (microns)
 !
 ! following Kiehl
-         call reltab(ncol, t, landfrac, landm, icefrac, rel, snowh)
+         call reltab(ncol, t, landfrac, icefrac, rel, snowh)
 
 ! following Kristjansson and Mitchell
          call reitab(ncol, t, rei)
@@ -277,7 +275,7 @@ contains
 
 
 !===============================================================================
-  subroutine reltab(ncol, t, landfrac, landm, icefrac, rel, snowh)
+  subroutine reltab(ncol, t, landfrac, icefrac, rel, snowh)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -298,7 +296,6 @@ contains
     real(r8), intent(in) :: landfrac(pcols)      ! Land fraction
     real(r8), intent(in) :: icefrac(pcols)       ! Ice fraction
     real(r8), intent(in) :: snowh(pcols)         ! Snow depth over land, water equivalent (m)
-    real(r8), intent(in) :: landm(pcols)         ! Land fraction ramping to zero over ocean
     real(r8), intent(in) :: t(pcols,pver)        ! Temperature
 
 !
@@ -327,7 +324,7 @@ contains
           ! Modify for snow depth over land
           rel(i,k) = rel(i,k) + (rliqocean-rel(i,k)) * min(1.0_r8,max(0.0_r8,snowh(i)*10._r8))
           ! Ramp between polluted value over land to clean value over ocean.
-          rel(i,k) = rel(i,k) + (rliqocean-rel(i,k)) * min(1.0_r8,max(0.0_r8,1.0_r8-landm(i)))
+          rel(i,k) = rel(i,k) + (rliqocean-rel(i,k)) * min(1.0_r8,max(0.0_r8,1.0_r8-landfrac(i)))
           ! Ramp between the resultant value and a sea ice value in the presence of ice.
           rel(i,k) = rel(i,k) + (rliqice-rel(i,k)) * min(1.0_r8,max(0.0_r8,icefrac(i)))
 ! end jrm

--- a/components/eam/src/physics/cam/radiation_data.F90
+++ b/components/eam/src/physics/cam/radiation_data.F90
@@ -29,7 +29,6 @@ module radiation_data
        lndfrc_fldn    = 'rad_lndfrc      ' , &
        icefrc_fldn    = 'rad_icefrc      ' , &
        snowh_fldn     = 'rad_snowh       ' , &
-       landm_fldn     = 'rad_landm       ' , &
        asdir_fldn     = 'rad_asdir       ' , &
        asdif_fldn     = 'rad_asdif       ' , &
        aldir_fldn     = 'rad_aldir       ' , &
@@ -160,8 +159,6 @@ contains
          'radiation input: ice fraction')
     call addfld (snowh_fldn,        horiz_only,    rad_data_avgflag,  'm',&
          'radiation input: water equivalent snow depth')
-    call addfld (landm_fldn,     horiz_only,    rad_data_avgflag,  'none',&
-         'radiation input: land mask: ocean(0), continent(1), transition(0-1)')
 
     call addfld (asdir_fldn,        horiz_only,    rad_data_avgflag,  '1',&
          'radiation input: short wave direct albedo', flag_xyfill=.true.)
@@ -239,7 +236,6 @@ contains
     call add_default (lndfrc_fldn,    rad_data_histfile_num, ' ')
     call add_default (icefrc_fldn,    rad_data_histfile_num, ' ')
     call add_default (snowh_fldn,     rad_data_histfile_num, ' ')
-    call add_default (landm_fldn,     rad_data_histfile_num, ' ')
     call add_default (asdir_fldn,     rad_data_histfile_num, ' ')
     call add_default (asdif_fldn,     rad_data_histfile_num, ' ')
     call add_default (aldir_fldn,     rad_data_histfile_num, ' ')
@@ -318,7 +314,7 @@ contains
 
   !================================================================================================
   !================================================================================================
-  subroutine output_rad_data(  pbuf, state, cam_in, landm, coszen )
+  subroutine output_rad_data(  pbuf, state, cam_in, coszen )
 
     use physics_types,    only: physics_state
     use camsrfexch,       only: cam_in_t     
@@ -330,7 +326,6 @@ contains
     
     type(physics_state), intent(in), target :: state
     type(cam_in_t),      intent(in) :: cam_in
-    real(r8),            intent(in) :: landm(pcols)
     real(r8),            intent(in) :: coszen(pcols)
 
     ! Local variables
@@ -373,7 +368,6 @@ contains
     call outfld(lndfrc_fldn, cam_in%landfrac,  pcols, lchnk)
     call outfld(icefrc_fldn, cam_in%icefrac,   pcols, lchnk)
     call outfld(snowh_fldn,  cam_in%snowhland, pcols, lchnk)
-    call outfld(landm_fldn,  landm,            pcols, lchnk)
     call outfld(temp_fldn,   state%t,               pcols, lchnk   )
     call outfld(pdel_fldn,   state%pdel,            pcols, lchnk   )
     call outfld(pdeldry_fldn,state%pdeldry,         pcols, lchnk   )

--- a/components/eam/src/physics/cam/stratiform.F90
+++ b/components/eam/src/physics/cam/stratiform.F90
@@ -346,7 +346,7 @@ end subroutine stratiform_init
 
 subroutine stratiform_tend( &
    state, ptend_all, pbuf, dtime, icefrac, &
-   landfrac, ocnfrac, landm, snowh, dlf,   &
+   landfrac, ocnfrac, snowh, dlf,   &
    dlf2, rliq, cmfmc, cmfmc2, ts,          &
    sst, zdu)
 
@@ -379,7 +379,6 @@ subroutine stratiform_tend( &
    real(r8), intent(in)  :: icefrac (pcols)          ! Sea ice fraction (fraction)
    real(r8), intent(in)  :: landfrac(pcols)          ! Land fraction (fraction)
    real(r8), intent(in)  :: ocnfrac (pcols)          ! Ocean fraction (fraction)
-   real(r8), intent(in)  :: landm(pcols)             ! Land fraction ramped over water
    real(r8), intent(in)  :: snowh(pcols)             ! Snow depth over land, water equivalent (m)
 
    real(r8), intent(in)  :: dlf(pcols,pver)          ! Detrained water from convection schemes
@@ -548,7 +547,7 @@ subroutine stratiform_tend( &
    call cld_sediment_vel( ncol,                                                           &
                           icefrac, landfrac, ocnfrac, state1%pmid, state1%pdel, state1%t, &
                           cld, state1%q(:,:,ixcldliq), state1%q(:,:,ixcldice),            & 
-                          pvliq, pvice, landm, snowh )
+                          pvliq, pvice, snowh )
    
    wsedl(:ncol,:pver) = pvliq(:ncol,:pver)/gravit/(state1%pmid(:ncol,:pver)/(287.15_r8*state1%t(:ncol,:pver)))
 
@@ -748,13 +747,13 @@ subroutine stratiform_tend( &
    call pbuf_get_field(pbuf, ls_flxsnw_idx, rkflxsnw)
 
    call t_startf('pcond')
-   call pcond( lchnk, ncol,                                                &
-               state1%t, ttend, state1%q(1,1,1), qtend, state1%omega,      &
-               totcw, state1%pmid , state1%pdel, cld, fice, fsnow,         &
-               qme, prain, prodsnow, nevapr, evapsnow, evapheat, prfzheat, &
-               meltheat, prec_pcw, snow_pcw, dtime, fwaut,                 &
-               fsaut, fracw, fsacw, fsaci, ltend,                          &
-               rhdfda, rhu00, icefrac, state1%zi, ice2pr, liq2pr,          &
+   call pcond( lchnk, ncol,                                                 &
+               state1%t, ttend, state1%q(1,1,1), qtend, state1%omega,       &
+               totcw, state1%pmid , state1%pdel, cld, fice, fsnow,          &
+               qme, prain, prodsnow, nevapr, evapsnow, evapheat, prfzheat,  &
+               meltheat, prec_pcw, snow_pcw, dtime, fwaut,                  &
+               fsaut, fracw, fsacw, fsaci, ltend,                           &
+               rhdfda, rhu00, landfrac, icefrac, state1%zi, ice2pr, liq2pr, &
                liq2snow, snowh, rkflxprc, rkflxsnw, pracwo, psacwo, psacio )
    call t_stopf('pcond')
 
@@ -907,7 +906,7 @@ subroutine stratiform_tend( &
   
    ! Cloud water and ice particle sizes, saved in physics buffer for radiation
 
-   call cldefr( lchnk, ncol, landfrac, state1%t, rel, rei, state1%ps, state1%pmid, landm, icefrac, snowh )
+   call cldefr( lchnk, ncol, state1%t, rel, rei, state1%ps, state1%pmid, landfrac, icefrac, snowh )
 
    call outfld('REL', rel, pcols, lchnk)
    call outfld('REI', rei, pcols, lchnk)

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -212,7 +212,7 @@ subroutine phys_inidat( cam_out, pbuf2d )
   use pio,                 only: file_desc_t
   use ncdio_atm,           only: infld
   use short_lived_species, only: initialize_short_lived_species
-  use comsrf,              only: landm, sgh, sgh30
+  use comsrf,              only: sgh, sgh30
   use cam_control_mod,     only: aqua_planet
   !---------------------------------------------------------------------------
   !---------------------------------------------------------------------------
@@ -249,8 +249,7 @@ subroutine phys_inidat( cam_out, pbuf2d )
   if(aqua_planet) then
     sgh = 0._r8
     sgh30 = 0._r8
-    landm = 0._r8
-    if (masterproc) write(iulog,*) 'AQUA_PLANET simulation, sgh, sgh30, landm initialized to 0.'
+    if (masterproc) write(iulog,*) 'AQUA_PLANET simulation, sgh, sgh30 initialized to 0.'
   else    
     if (masterproc) write(iulog,*) 'NOT AN AQUA_PLANET simulation, initialize sgh, sgh30, land m using data from file.'
     fh_topo=>topo_file_get_id()
@@ -263,9 +262,6 @@ subroutine phys_inidat( cam_out, pbuf2d )
       if (masterproc) write(iulog,*) 'The field SGH30 will be filled using data from SGH.'
       sgh30 = sgh
     end if
-
-    call infld('LANDM_COSLAT', fh_topo, dim1name, dim2name, 1, pcols, begchunk, endchunk, landm, found, gridname='physgrid')
-    if(.not.found) call endrun(' ERROR: LANDM_COSLAT not found on topo dataset.')
   end if
 
   allocate(tptr(1:pcols,begchunk:endchunk))
@@ -689,7 +685,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
   use cam_diagnostics,  only: diag_allocate, diag_physvar_ic
   use check_energy,     only: check_energy_gmean
   use physics_buffer,   only: physics_buffer_desc, pbuf_get_chunk, pbuf_allocate, pbuf_old_tim_idx, pbuf_get_index
-  use comsrf,           only: fsns, fsnt, flns, sgh, sgh30, flnt, landm, fsds
+  use comsrf,           only: fsns, fsnt, flns, sgh, sgh30, flnt, fsds
   use flux_avg,               only: flux_avg_init
   use check_energy,           only: check_energy_chng
   use crm_physics,            only: crm_physics_tend
@@ -786,7 +782,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
 
     call tphysbc1(ztodt, fsns(1,c), fsnt(1,c), flns(1,c), flnt(1,c), &
                  phys_state(c), phys_tend(c), phys_buffer_chunk, &
-                 fsds(1,c), landm(1,c), sgh(1,c), sgh30(1,c), &
+                 fsds(1,c), sgh(1,c), sgh30(1,c), &
                  cam_out(c), cam_in(c) )
 
     end_count = shr_sys_irtc(irtc_rate)
@@ -837,7 +833,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
 
     call tphysbc2(ztodt, fsns(1,c), fsnt(1,c), flns(1,c), flnt(1,c), &
                  phys_state(c), phys_tend(c), phys_buffer_chunk, &
-                 fsds(1,c), landm(1,c), sgh(1,c), sgh30(1,c), &
+                 fsds(1,c), sgh(1,c), sgh30(1,c), &
                  cam_out(c), cam_in(c), crm_ecpp_output(c) )
 
     end_count = shr_sys_irtc(irtc_rate)
@@ -1275,7 +1271,7 @@ end subroutine tphysac
 
 subroutine tphysbc1(ztodt, fsns, fsnt, flns, flnt, &
                    state, tend, pbuf, fsds, &
-                   landm, sgh, sgh30, cam_out, cam_in )
+                   sgh, sgh30, cam_out, cam_in )
   !----------------------------------------------------------------------------- 
   ! Purpose: Evaluate physics processes BEFORE coupling to sfc components
   !          Phase 1 - energy fixer and dry adjustment
@@ -1313,7 +1309,6 @@ subroutine tphysbc1(ztodt, fsns, fsnt, flns, flnt, &
   real(r8),            intent(inout) :: flns(pcols)   ! Srf longwave cooling (up-down) flux
   real(r8),            intent(inout) :: flnt(pcols)   ! Net outgoing lw flux at model top
   real(r8),            intent(inout) :: fsds(pcols)   ! Surface solar down flux
-  real(r8),            intent(in   ) :: landm(pcols)  ! land fraction ramp
   real(r8),            intent(in   ) :: sgh(pcols)    ! Std. deviation of orography
   real(r8),            intent(in   ) :: sgh30(pcols)  ! Std. deviation of 30 s orography for tms
   type(physics_state), intent(inout) :: state
@@ -1561,7 +1556,7 @@ end subroutine tphysbc1
 
 subroutine tphysbc2(ztodt, fsns, fsnt, flns, flnt, &
                    state, tend, pbuf, fsds, &
-                   landm, sgh, sgh30, cam_out, cam_in, crm_ecpp_output )
+                   sgh, sgh30, cam_out, cam_in, crm_ecpp_output )
   !----------------------------------------------------------------------------- 
   ! Purpose: Evaluate physics processes BEFORE coupling to sfc components
   !          Phase 2 - aerosols, radiation, and diagnostics
@@ -1607,7 +1602,6 @@ subroutine tphysbc2(ztodt, fsns, fsnt, flns, flnt, &
   real(r8),                  intent(inout) :: flns(pcols)   ! Srf longwave cooling (up-down) flux
   real(r8),                  intent(inout) :: flnt(pcols)   ! Net outgoing lw flux at model top
   real(r8),                  intent(inout) :: fsds(pcols)   ! Surface solar down flux
-  real(r8),                  intent(in   ) :: landm(pcols)  ! land fraction ramp
   real(r8),                  intent(in   ) :: sgh(pcols)    ! Std. deviation of orography
   real(r8),                  intent(in   ) :: sgh30(pcols)  ! Std. deviation of 30 s orography for tms
   type(physics_state),       intent(inout) :: state
@@ -1829,7 +1823,7 @@ subroutine tphysbc2(ztodt, fsns, fsnt, flns, flnt, &
   if (l_rad) then
     call t_startf('radiation')
     call radiation_tend(state,ptend, pbuf, cam_out, cam_in, &
-                        cam_in%landfrac, landm, cam_in%icefrac, cam_in%snowhland, &
+                        cam_in%landfrac, cam_in%icefrac, cam_in%snowhland, &
                         fsns, fsnt, flns, flnt, fsds, &
                         net_flx, is_cmip6_volc, ztodt, clear_rh=mmf_clear_rh)
     call t_stopf('radiation')

--- a/components/eam/src/physics/crm/rrtmg/radiation.F90
+++ b/components/eam/src/physics/crm/rrtmg/radiation.F90
@@ -841,7 +841,7 @@ end function radiation_nextsw_cday
   
   subroutine radiation_tend( state, ptend,pbuf, &
        cam_out, cam_in, &
-       landfrac,landm,icefrac,snowh, &
+       landfrac,icefrac,snowh, &
        fsns,    fsnt, flns,    flnt,  &
        fsds, net_flx, is_cmip6_volc)
 
@@ -935,7 +935,6 @@ end function radiation_nextsw_cday
     ! Arguments
     logical,  intent(in)    :: is_cmip6_volc    ! true if cmip6 style volcanic file is read otherwise false 
     real(r8), intent(in)    :: landfrac(pcols)  ! land fraction
-    real(r8), intent(in)    :: landm(pcols)     ! land fraction ramp
     real(r8), intent(in)    :: icefrac(pcols)   ! land fraction
     real(r8), intent(in)    :: snowh(pcols)     ! Snow depth (liquid water equivalent)
 #ifdef MODAL_AERO
@@ -1344,7 +1343,7 @@ end function radiation_nextsw_cday
     ! The output_rad_data routine is intended to output all of the data needed
     ! to run the radiation code offline. This functionality may or may not be
     ! supported, and definitely is NOT for SP simulations.
-    call output_rad_data(  pbuf, state, cam_in, landm, coszrs )
+    call output_rad_data(  pbuf, state, cam_in, coszrs )
 
     ! Gather night/day column indices.
     Nday = 0
@@ -1518,7 +1517,7 @@ end function radiation_nextsw_cday
 
       ! calculate effective radius - moved outside of ii,jj loops for 1-moment microphysics
       if (MMF_microphysics_scheme .eq. 'sam1mom') then 
-        call cldefr( lchnk, ncol, landfrac, state%t, rel, rei, state%ps, state%pmid, landm, icefrac, snowh )
+        call cldefr( lchnk, ncol, state%t, rel, rei, state%ps, state%pmid, landfrac, icefrac, snowh )
       end if
 
       ! Start loop over CRM columns; the strategy here is to loop over each CRM

--- a/components/eam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/crm/rrtmgp/radiation.F90
@@ -1104,7 +1104,7 @@ contains
    ! a lot more GPU-friendly, but we still need to refactor the aerosol optics
    ! code to accomplish this, which is a big task.
    subroutine radiation_tend(state_in,ptend,    pbuf,          cam_out, cam_in,  &
-                             landfrac,landm,    icefrac,       snowh,            &
+                             landfrac,icefrac,  snowh,                           &
                              fsns,    fsnt,     flns,          flnt,             &
                              fsds,    net_flux, is_cmip6_volc, dt,               &
                              clear_rh                                            )
@@ -1191,7 +1191,6 @@ contains
       ! These are not used anymore and exist only because the radiation call is
       ! inflexible
       real(r8), intent(in)    :: landfrac(pcols)  ! land fraction
-      real(r8), intent(in)    :: landm(pcols)     ! land fraction ramp
       real(r8), intent(in)    :: icefrac(pcols)   ! land fraction
       real(r8), intent(in)    :: snowh(pcols)     ! Snow depth (liquid water equivalent)
 
@@ -1431,7 +1430,7 @@ contains
 
                ! Calculate effective radius for optics used with single-moment microphysics
                if (use_MMF .and. (trim(MMF_microphysics_scheme) .eq. 'sam1mom')) then 
-                  call cldefr(state%lchnk, ncol, landfrac, state%t, rel, rei, state%ps, state%pmid, landm, icefrac, snowh)
+                  call cldefr(state%lchnk, ncol, state%t, rel, rei, state%ps, state%pmid, landfrac, icefrac, snowh)
                end if
 
                ! Get albedo. This uses CAM routines internally and just provides a

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -813,7 +813,7 @@ end function radiation_nextsw_cday
   
   subroutine radiation_tend(state,ptend, pbuf, &
        cam_out, cam_in, &
-       landfrac,landm,icefrac,snowh, &
+       landfrac,icefrac,snowh, &
        fsns,    fsnt, flns,    flnt,  &
        fsds, net_flx, is_cmip6_volc, dt)
 
@@ -874,7 +874,6 @@ end function radiation_nextsw_cday
     logical,  intent(in)    :: is_cmip6_volc    ! true if cmip6 style volcanic file is read otherwise false 
     real(r8), intent(in)    :: landfrac(pcols)  ! land fraction
     real(r8), intent(in)    :: dt               ! time step(s)
-    real(r8), intent(in)    :: landm(pcols)     ! land fraction ramp
     real(r8), intent(in)    :: icefrac(pcols)   ! land fraction
     real(r8), intent(in)    :: snowh(pcols)     ! Snow depth (liquid water equivalent)
     real(r8), intent(inout) :: fsns(pcols)      ! Surface solar absorbed flux
@@ -1116,7 +1115,7 @@ end function radiation_nextsw_cday
        coszrs(:)=0._r8 ! coszrs is only output for zenith
     endif    
 
-    call output_rad_data(  pbuf, state, cam_in, landm, coszrs )
+    call output_rad_data(  pbuf, state, cam_in, coszrs )
 
     ! Gather night/day column indices.
     Nday = 0

--- a/components/eam/src/physics/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/rrtmgp/radiation.F90
@@ -1047,7 +1047,7 @@ contains
    ! Primary output from this routine is the heating tendency due to radiative
    ! transfer, as a ptend object.
    subroutine radiation_tend(state,   ptend,    pbuf,          cam_out, cam_in,  &
-                             landfrac,landm,    icefrac,       snowh,            &
+                             landfrac,icefrac,  snowh,                           &
                              fsns,    fsnt,     flns,          flnt,             &
                              fsds,    net_flux, is_cmip6_volc, dt                )
 
@@ -1118,7 +1118,6 @@ contains
       ! These are not used anymore and exist only because the radiation call is
       ! inflexible
       real(r8), intent(in)    :: landfrac(pcols)  ! land fraction
-      real(r8), intent(in)    :: landm(pcols)     ! land fraction ramp
       real(r8), intent(in)    :: icefrac(pcols)   ! land fraction
       real(r8), intent(in)    :: snowh(pcols)     ! Snow depth (liquid water equivalent)
 

--- a/components/eam/tools/topo_tool/bin_to_cube/README
+++ b/components/eam/tools/topo_tool/bin_to_cube/README
@@ -1,8 +1,6 @@
 This program reads USGS 30-sec terrain dataset from NetCDF file and bins it to an approximately 
 3km cubed-sphere grid and outputs the data in netCDF format.
 
-The LANDM_COSLAT field is read in from a separate netCDF file and linearly interpolated to the 3km cubed-sphere grid.
-
 Input files needed:
 
 1. USGS raw data in netCDF format: usgs-rawdata.nc (must be placed in same dirctory as the executables)
@@ -11,12 +9,6 @@ Input files needed:
    File may be found at:
 
    $CESMDATA/inputdata/atm/cam/gtopo30data/usgs-rawdata.nc
-
-2. landm_coslat dataset (must be placed in same dirctory as the executables). E.g.:
-
-   ln -s /fs/cgd/csm/inputdata/atm/cam2/hrtopo/landm_coslat.nc .
-
-   The landm_coslat field is not used in CAM5!
 
 Output file:
 


### PR DESCRIPTION
Remove the LANDM variable from the COMSRF module and replace all uses
with cam_in%landfrac. LANDM was previously read in from the LANDM_COSLAT
variable in the topography dataset. This was a smoothed version of the
input topography, but was actually inconsistent with the land fraction
data specified by the surface models. Instead of carrying around two
versions of land fraction, we opt to remove the LANDM variable and
instead use a land fraction consistent with the surface models. This
will be BFB for all currently supported configurations *except* for MMF,
where we were still using the old cloud effective radius calculations
with LANDM instead of LANDFRAC. Since these are switched over to use
LANDFRAC now, the results will be non-BFB but should still be
reasonable. Also, any cases using RK microphysics will DIFF because
`stratiform_tend` was also using LANDM, buried down in the findmcnew
routine, and also in the effective radii computation. The code was
changed here but *not tested* for this configuration because we do not
have a supported configuration for that microphysics package at the
moment. 

Fixes #4276

[non-BFB] only for MMF cases.