### PR TITLE
Add min level indices to global stats

### DIFF
--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -234,8 +234,8 @@ contains
       integer, pointer :: nVertLevels, nCellsSolve, nEdgesSolve, nVerticesSolve, num_activeTracers
 
       integer, parameter :: kMaxVariables = 1024 ! this must be a little more than double the number of variables to be reduced
-      integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, maxLevelVertexBot, &
-         landiceMask
+      integer, dimension(:), pointer :: minLevelCell, minLevelEdgeBot, minLevelVertexTop, maxLevelCell, &
+          maxLevelEdgeTop, maxLevelVertexBot, landiceMask
 
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_TimeInterval_type) :: timeStep
@@ -340,6 +340,9 @@ contains
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
          call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)
+         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+         call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+         call mpas_pool_get_array(meshPool, 'minLevelVertexTop', minLevelVertexTop)
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
          call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
@@ -391,7 +394,7 @@ contains
          ! layerThickness
          variableIndex = variableIndex + 1
          call ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                            maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                            minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                             layerThickness(:,1:nCellsSolve), sums_tmp(variableIndex), &
                             sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
                             maxes_tmp(variableIndex), verticalSumMins_tmp(variableIndex), &
@@ -406,7 +409,7 @@ contains
          ! normalVelocity
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
-                              maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
+                              minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
                               layerThickEdge(:,1:nEdgesSolve), &
                               normalVelocity(:,1:nEdgesSolve), sums_tmp(variableIndex), &
                               sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
@@ -423,7 +426,7 @@ contains
          ! tangentialVelocity
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
-                              maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
+                              minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
                               layerThickEdge(:,1:nEdgesSolve), &
                               tangentialVelocity(:,1:nEdgesSolve), &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
@@ -440,7 +443,7 @@ contains
          ! layerThicknessEdge
          variableIndex = variableIndex + 1
          call ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
-                            maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
+                            minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
                             layerThickEdge(:,1:nEdgesSolve), sums_tmp(variableIndex), &
                             sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
                             maxes_tmp(variableIndex), verticalSumMins_tmp(variableIndex), &
@@ -455,7 +458,7 @@ contains
          ! relativeVorticity
          variableIndex = variableIndex + 1
          call ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nVerticesSolve, &
-                            maxLevelVertexBot(1:nVerticesSolve), &
+                            minLevelVertexTop(1:nVerticesSolve), maxLevelVertexBot(1:nVerticesSolve), &
                             areaTriangle(1:nVerticesSolve), &
                             relativeVorticity(:,1:nVerticesSolve), &
                             sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
@@ -474,7 +477,7 @@ contains
          enstrophy(:,:)=relativeVorticity(:,1:nVerticesSolve)**2
          variableIndex = variableIndex + 1
          call ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nVerticesSolve, &
-                            maxLevelVertexBot(1:nVerticesSolve), &
+                            minLevelVertexTop(1:nVerticesSolve), maxLevelVertexBot(1:nVerticesSolve), &
                             areaTriangle(1:nVerticesSolve), enstrophy(:,:), &
                             sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                             mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -491,7 +494,7 @@ contains
          ! kineticEnergyCell
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                              maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                              minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                               layerThickness(:,1:nCellsSolve), &
                               kineticEnergyCell(:,1:nCellsSolve), &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
@@ -511,7 +514,7 @@ contains
   + normPlanetVortEdge(:,1:nEdgesSolve)
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
-                              maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
+                              minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
                               layerThickEdge(:,1:nEdgesSolve), &
                               normalizedAbsoluteVorticity(:,1:nEdgesSolve), &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
@@ -529,7 +532,7 @@ contains
          ! pressure
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                              maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                              minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                               layerThickness(:,1:nCellsSolve), pressure(:,1:nCellsSolve), &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                               mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -545,7 +548,7 @@ contains
          ! montgomeryPotential
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                              maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                              minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                               layerThickness(:,1:nCellsSolve), &
                               montgomeryPotential(:,1:nCellsSolve), &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
@@ -563,7 +566,7 @@ contains
          variableIndex = variableIndex + 1
          workArray = vertVelocityTop(1:nVertLevels,1:nCellsSolve)
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                              maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                              minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                               layerThickness(:,1:nCellsSolve), workArray, &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                               mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -580,7 +583,7 @@ contains
          variableIndex = variableIndex + 1
          workArray = vertAleTransportTop(1:nVertLevels,1:nCellsSolve)
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                              maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                              minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                               layerThickness(:,1:nCellsSolve), workArray, &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                               mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -597,7 +600,7 @@ contains
          variableIndex = variableIndex + 1
          if (thicknessFilterActive) then
             call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                                 maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                                 minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                                  layerThickness(:,1:nCellsSolve), &
                                  lowFreqDivergence(:,1:nCellsSolve), &
                                  sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
@@ -629,7 +632,7 @@ contains
          variableIndex = variableIndex + 1
          if (thicknessFilterActive) then
             call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                                 maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                                 minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                                  layerThickness(:,1:nCellsSolve), &
                                  highFreqThickness(:,1:nCellsSolve), &
                                  sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
@@ -662,7 +665,7 @@ contains
             variableIndex = variableIndex + 1
             workArray = activeTracers(iTracer,:,1:nCellsSolve)
             call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                                 maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                                 minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                                  layerThickness(:,1:nCellsSolve), workArray, &
                                  sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                                  mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -679,7 +682,7 @@ contains
          ! layerThickness from previous timestep
          variableIndex = variableIndex + 1
          call ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                            maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                            minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                             layerThicknessPreviousTimestep(:,1:nCellsSolve), &
                             sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                             mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -696,7 +699,7 @@ contains
          variableIndex = variableIndex + 1
          if ( associated(frazilLayerThicknessTendency) ) then
             call ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nCellsSolve, &
-                               maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
+                               minLevelCell(1:nCellsSolve), maxLevelCell(1:nCellsSolve), areaCell(1:nCellsSolve), &
                                frazilLayerThicknessTendency(:,1:nCellsSolve), &
                                sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                                mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -1060,7 +1063,8 @@ contains
 
          localCFL = 0.0_RKIND
          do iEdge = 1,nEdgesSolve
-            localCFL = max(localCFL, maxval(dt*abs(normalVelocity(1:maxLevelEdgeTop(iEdge),iEdge))/dcEdge(iEdge)))
+            localCFL = max(localCFL, &
+                           maxval(dt*abs(normalVelocity(minLevelEdgeBot(iedge):maxLevelEdgeTop(iEdge),iEdge))/dcEdge(iEdge)))
          end do
          nMaxes = nMaxes + 1
          maxes(nMaxes) = localCFL
@@ -1470,14 +1474,14 @@ contains
 
    end subroutine ocn_finalize_global_stats!}}}
 
-   subroutine ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nElements, maxLevel, areas, field, &!{{{
+   subroutine ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nElements, minLevel, maxLevel, areas, field, &!{{{
       localSum, localRMS, localMin, localMax, localVertSumMin, localVertSumMax)
 
       implicit none
 
       type (dm_info), intent(in) :: dminfo
       integer, intent(in) :: nVertLevels, nElements
-      integer, dimension(nElements), intent(in) :: maxLevel
+      integer, dimension(nElements), intent(in) :: minLevel, maxLevel
       real (kind=RKIND), dimension(nElements), intent(in) :: areas
       real (kind=RKIND), dimension(nVertLevels, nElements), intent(in) :: field
       real (kind=RKIND), intent(out) :: localSum, localRMS, localMin, localMax, localVertSumMin, &
@@ -1494,19 +1498,19 @@ contains
       localVertSumMax = -1.0e34_RKIND
 
       do elementIndex = 1, nElements
-        colSum = sum(field(1:maxLevel(elementIndex),elementIndex))
+        colSum = sum(field(minLevel(elementIndex):maxLevel(elementIndex),elementIndex))
         localSum = localSum + areas(elementIndex) * colSum
-        colRMS = sum(field(1:maxLevel(elementIndex),elementIndex)**2)
+        colRMS = sum(field(minLevel(elementIndex):maxLevel(elementIndex),elementIndex)**2)
         localRMS = localRMS + areas(elementIndex) * colRMS
-        localMin = min(localMin,minval(field(1:maxLevel(elementIndex),elementIndex)))
-        localMax = max(localMax,maxval(field(1:maxLevel(elementIndex),elementIndex)))
+        localMin = min(localMin,minval(field(minLevel(elementIndex):maxLevel(elementIndex),elementIndex)))
+        localMax = max(localMax,maxval(field(minLevel(elementIndex):maxLevel(elementIndex),elementIndex)))
         localVertSumMin = min(localVertSumMin,colSum)
         localVertSumMax = max(localVertSumMax,colSum)
       end do
 
    end subroutine ocn_compute_field_area_weighted_local_stats_max_level!}}}
 
-   subroutine ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nElements, maxLevel, areas, & !{{{
+   subroutine ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nElements, minLevel, maxLevel, areas, & !{{{
                               layerThickness, field, localSum, localRMS, localMin, &
                               localMax, localVertSumMin, localVertSumMax)
 
@@ -1514,7 +1518,7 @@ contains
 
       type (dm_info), intent(in) :: dminfo
       integer, intent(in) :: nVertLevels, nElements
-      integer, dimension(nElements), intent(in) :: maxLevel
+      integer, dimension(nElements), intent(in) :: minLevel, maxLevel
       real (kind=RKIND), dimension(nElements), intent(in) :: areas
       real (kind=RKIND), dimension(nVertLevels, nElements), intent(in) :: layerThickness
       real (kind=RKIND), dimension(nVertLevels, nElements), intent(in) :: field
@@ -1533,14 +1537,14 @@ contains
       localVertSumMax = -1.0e34_RKIND
 
       do elementIndex = 1, nElements
-        thicknessWeightedColSum = sum(layerThickness(1:maxLevel(elementIndex),elementIndex) &
-                                * field(1:maxLevel(elementIndex),elementIndex))
+        thicknessWeightedColSum = sum(layerThickness(minLevel(elementIndex):maxLevel(elementIndex),elementIndex) &
+                                * field(minLevel(elementIndex):maxLevel(elementIndex),elementIndex))
         localSum = localSum + areas(elementIndex) * thicknessWeightedColSum
-        thicknessWeightedColRMS = sum(layerThickness(1:maxLevel(elementIndex),elementIndex) &
-                                * field(1:maxLevel(elementIndex),elementIndex)**2)
+        thicknessWeightedColRMS = sum(layerThickness(minLevel(elementIndex):maxLevel(elementIndex),elementIndex) &
+                                * field(minLevel(elementIndex):maxLevel(elementIndex),elementIndex)**2)
         localRMS = localRMS + areas(elementIndex) * thicknessWeightedColRMS
-        localMin = min(localMin,minval(field(1:maxLevel(elementIndex),elementIndex)))
-        localMax = max(localMax,maxval(field(1:maxLevel(elementIndex),elementIndex)))
+        localMin = min(localMin,minval(field(minLevel(elementIndex):maxLevel(elementIndex),elementIndex)))
+        localMax = max(localMax,maxval(field(minLevel(elementIndex):maxLevel(elementIndex),elementIndex)))
         localVertSumMin = min(localVertSumMin,thicknessWeightedColSum)
         localVertSumMax = max(localVertSumMax,thicknessWeightedColSum)
       end do


### PR DESCRIPTION
This merge adds `minLevelCell`, `minLevelEdgeTop` and `minLevelVertexBot` to the `globalStats` analysis member so that inactive top layers are excluded from stats.

[BFB]