### PR TITLE
Fix desp buildnml

### DIFF
--- a/components/data_comps/desp/cime_config/buildnml
+++ b/components/data_comps/desp/cime_config/buildnml
@@ -97,7 +97,6 @@ def buildnml(case, caseroot, compname):
     expect (os.path.isdir(user_xml_dir),
             "user_xml_dir %s does not exist " %user_xml_dir)
 
-    breakpoint()
     # NOTE: User definition *replaces* existing definition.
     files = Files()
     definition_file = [files.get_value("NAMELIST_DEFINITION_FILE",

--- a/components/data_comps/desp/cime_config/buildnml
+++ b/components/data_comps/desp/cime_config/buildnml
@@ -19,6 +19,7 @@ from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
 from CIME.utils import expect, safe_copy
 from CIME.buildnml import create_namelist_infile, parse_input
+from CIME.XML.files import Files
 
 logger = logging.getLogger(__name__)
 
@@ -96,9 +97,12 @@ def buildnml(case, caseroot, compname):
     expect (os.path.isdir(user_xml_dir),
             "user_xml_dir %s does not exist " %user_xml_dir)
 
+    breakpoint()
     # NOTE: User definition *replaces* existing definition.
-    namelist_xml_dir = os.path.join(cimeroot, "src", "components", "data_comps_mct", compname, "cime_config")
-    definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_desp.xml")]
+    files = Files()
+    definition_file = [files.get_value("NAMELIST_DEFINITION_FILE",
+                                       {"component":"desp"})]
+
     user_definition = os.path.join(user_xml_dir, "namelist_definition_desp.xml")
     if os.path.isfile(user_definition):
         definition_file = [user_definition]
@@ -106,7 +110,7 @@ def buildnml(case, caseroot, compname):
         expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
     # Create the namelist generator object - independent of instance
-    nmlgen = NamelistGenerator(case, definition_file)
+    nmlgen = NamelistGenerator(case, definition_file, files=files)
 
     #----------------------------------------------------
     # Clear out old data.


### PR DESCRIPTION
`buildnml` for the `desp` component was using a path that was
locally constructed rather than using CIME config files. This fixes
`buildnml` to use the `NAMELIST_DEFINITION_FILE` variable
to get the path, this is inline with other components.