### PR TITLE
Add MCT as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,6 @@
 [submodule "components/mpas-ocean/src/gotm"]
 	path = components/mpas-ocean/src/gotm
 	url = git@github.com:E3SM-Project/GOTMcode.git
+[submodule "externals/mct"]
+	path = externals/mct
+	url = git@github.com:MCSclimate/MCT.git


### PR DESCRIPTION
Add MCT as a submodules in E3SM/externals and use latest version 2.11.0
This will be used instead of the source in cime/src/externals which is
being removed.  Not active until a future PR makes changes to the CIME build.

[BFB]