### PR TITLE
Fix standalone MPAS builds under OSX

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -356,8 +356,8 @@ gfortran:
 gfortran-clang:
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
-	"CC_PARALLEL = mpicc -cc=clang" \
-	"CXX_PARALLEL = mpicxx -cxx=clang++" \
+	"CC_PARALLEL = mpicc" \
+	"CXX_PARALLEL = mpicxx" \
 	"FC_SERIAL = gfortran" \
 	"CC_SERIAL = clang" \
 	"CXX_SERIAL = clang++" \

--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -930,7 +930,13 @@ ifdef MPAS_EXTERNAL_CPPFLAGS
 endif
 ####################################################
 ifeq "$(USE_PIO2)" "true"
-	override LIBS += -lstdc++
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Darwin)
+    	override LIBS += -lc++
+    else
+    	override LIBS += -lstdc++
+    endif
+
 endif
 
 ifeq "$(CONTINUE)" "true"


### PR DESCRIPTION
This merge switches to the flag for including the standard c++ library (needed by SCORPIO) under OSX to `-lc++`, not `-lstdc++`.

OSX is also the most common platform where we use `gfortran` and `clang` compilers.  OpenMPI on OSX does not support flags `-cc=clang` and `-cxx=clang++`.  These flags also do not seem to be needed.

[BFB]