### PR TITLE
Ocean SI code - Fix bugs, add OpenMP directives, SI flag change

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -830,7 +830,7 @@ add_default($nl, 'config_btr_gam3_velWt2');
 add_default($nl, 'config_btr_solve_SSH2');
 
 ####################################
-# Namelist group: semi_implicit_ts #
+# Namelist group: split_implicit_ts #
 ####################################
 
 add_default($nl, 'config_btr_si_preconditioner');
@@ -1626,7 +1626,7 @@ my @groups = qw(run_modes
                 eos_wright
                 split_timestep_share
                 split_explicit_ts
-                semi_implicit_ts
+                split_implicit_ts
                 ale_vertical_grid
                 ale_frequency_filtered_thickness
                 debug

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -28,7 +28,7 @@ my @groups = qw(run_modes
                 eos_wright
                 split_timestep_share
                 split_explicit_ts
-                semi_implicit_ts
+                split_implicit_ts
                 ale_vertical_grid
                 ale_frequency_filtered_thickness
                 debug

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -363,7 +363,7 @@ add_default($nl, 'config_btr_gam3_velWt2');
 add_default($nl, 'config_btr_solve_SSH2');
 
 ####################################
-# Namelist group: semi_implicit_ts #
+# Namelist group: split_implicit_ts #
 ####################################
 
 add_default($nl, 'config_btr_si_preconditioner');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -430,7 +430,7 @@
 <config_btr_gam3_velWt2>1.0</config_btr_gam3_velWt2>
 <config_btr_solve_SSH2>.false.</config_btr_solve_SSH2>
 
-<!-- semi_implicit_ts -->
+<!-- split_implicit_ts -->
 <config_btr_si_preconditioner>'ras'</config_btr_si_preconditioner>
 <config_btr_si_tolerance>1.0e-9</config_btr_si_tolerance>
 <config_n_btr_si_large_iter>1</config_n_btr_si_large_iter>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -196,7 +196,7 @@ Default: Defined in namelist_defaults.xml
 	category="time_integration" group="time_integration">
 Time integration method.
 
-Valid values: 'split_explicit', 'RK4', 'unsplit_explicit', 'semi_implicit'
+Valid values: 'split_explicit', 'RK4', 'unsplit_explicit', 'split_implicit'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1804,10 +1804,10 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- semi_implicit_ts -->
+<!-- split_implicit_ts -->
 
 <entry id="config_btr_si_preconditioner" type="char*1024"
-	category="semi_implicit_ts" group="semi_implicit_ts">
+	category="split_implicit_ts" group="split_implicit_ts">
 Type of preconditioner for the barotropic mode solver
 
 Valid values: ras, block_jacobi, jacobi, none
@@ -1815,7 +1815,7 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_btr_si_tolerance" type="real"
-	category="semi_implicit_ts" group="semi_implicit_ts">
+	category="split_implicit_ts" group="split_implicit_ts">
 Tolerance for the barotropic mode solver
 
 Valid values: any positive real, but typically less than 1.0e-9
@@ -1823,7 +1823,7 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_n_btr_si_large_iter" type="integer"
-	category="semi_implicit_ts" group="semi_implicit_ts">
+	category="split_implicit_ts" group="split_implicit_ts">
 number of large barotropic system iterations
 
 any positive integer, but typically 1 and less than 2
@@ -1831,8 +1831,8 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_btr_si_partition_match_mode" type="logical"
-	category="semi_implicit_ts" group="semi_implicit_ts">
-If true, the semi-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing.
+	category="split_implicit_ts" group="split_implicit_ts">
+If true, the split-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -191,7 +191,7 @@
 		/>
 		<nml_option name="config_time_integrator" type="character" default_value="split_explicit" units="unitless"
 					description="Time integration method."
-					possible_values="'split_explicit', 'RK4', 'unsplit_explicit', 'semi_implicit'"
+					possible_values="'split_explicit', 'RK4', 'unsplit_explicit', 'split_implicit'"
 		/>
 	</nml_record>
 	<nml_record name="hmix" mode="forward">
@@ -1149,7 +1149,7 @@
 					possible_values=".true. or .false."
 		/>
 	</nml_record>
-	<nml_record name="semi_implicit_ts" mode="forward">
+	<nml_record name="split_implicit_ts" mode="forward">
 		<nml_option name="config_btr_si_preconditioner" type="character" default_value="ras" units="unitless"
 					description="Type of preconditioner for the barotropic mode solver"
 					possible_values="ras, block_jacobi, jacobi, none"
@@ -1163,7 +1163,7 @@
                                         possible_values="any positive integer, but typically 1 and less than 2"
                 />
 		<nml_option name="config_btr_si_partition_match_mode" type="logical" default_value=".false." units="unitless"
-					description="If true, the semi-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing."
+					description="If true, the split-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing."
 					possible_values=".true. or .false."
 		/>
 	</nml_record>
@@ -1371,7 +1371,7 @@
 		<package name="variableShortwave" description="This package includes variables required to compute spatially variable shortwave extinction coefficients"/>
 
 		<package name="splitTimeIntegrator" description="This package includes variables required for either the split or unsplit explicit time integrators."/>
-		<package name="semiImplicitTimePKG" description="This package includes variables required for semi-implicit time integrators."/>
+		<package name="semiImplicitTimePKG" description="This package includes variables required for split-implicit time integrators."/>
 		<package name="thicknessFilter" description="This package includes variables required for frequency filtered thickness."/>
 		<package name="windStressBulkPKG" description="This package includes varibles required for bulk wind stress forcing."/>
 		<package name="variableBottomDragPKG" description="This package includes varibles required for variable bottom drag."/>
@@ -2944,117 +2944,117 @@
 		<var name="pressureAdjustedSSH" type="real" dimensions="nCells Time" units="m"
 			 description="sea surface height adjusted by sea surface pressure"
 		/>
-		<!-- FIELD semi_implicit time stepping -->
+		<!-- FIELD split_implicit time stepping -->
 		<var name="barotropicCoriolisTerm" type="real" dimensions="nEdges Time" units="m s^{-2}"
-			description="f * uPerp for the semi-implicit time stepping"
+			description="f * uPerp for the split-implicit time stepping"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_r0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_r1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_rh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_rh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_r00" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_ph0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_ph1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_v0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_s0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_s1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_sh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_sh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_w0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_w1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_wh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_wh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_q0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_q1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_qh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_qh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_z0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_z1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_zh0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_zh1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_t0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_t1" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 		<var name="SIvec_y0" type="real" dimensions="nCells Time" units="unitless"
-			description="A vector used in the semi-implicit barotropic mode solver"
+			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
 	</var_struct>

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
@@ -351,7 +351,7 @@ contains
 
          ! split explicit specific arrays
          call mpas_pool_get_config(ocnConfigs, 'config_time_integrator', config_time_integrator)
-         if ( config_time_integrator == trim('split_explicit') .or.  config_time_integrator == trim('semi_implicit') ) then
+         if ( config_time_integrator == trim('split_explicit') .or.  config_time_integrator == trim('split_implicit') ) then
            call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocity, 1)
            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocity, 1)
          endif

--- a/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
@@ -208,13 +208,13 @@ module ocn_core_interface
       if ( forwardModeActive ) then
          if (    config_time_integrator == trim('split_explicit') &
             .or. config_time_integrator == trim('unsplit_explicit') &
-            .or. config_time_integrator == trim('semi_implicit') ) then
+            .or. config_time_integrator == trim('split_implicit') ) then
             splitTimeIntegratorActive = .true.
          end if
       endif
       call mpas_pool_get_package(packagePool, 'semiImplicitTimePKGActive', semiImplicitTimePKGActive)
       if ( forwardModeActive ) then
-         if (config_time_integrator == trim('semi_implicit') ) then
+         if (config_time_integrator == trim('split_implicit') ) then
             semiImplicitTimePKGActive = .true.
          end if
       endif

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
@@ -200,7 +200,7 @@ module ocn_time_integration
          timeIntegratorChoice = timeIntUnsplitExplicit
          call ocn_time_integration_split_init(domain)
 
-      case ('semi_implicit')
+      case ('split_implicit')
          timeIntegratorChoice = timeIntSemiImplicit
          call ocn_time_integration_si_init(domain, dt)
 
@@ -216,7 +216,7 @@ module ocn_time_integration
             'Incorrect choice for config_time_integrator:' // &
              trim(config_time_integrator) // &
              '   choices are: RK4, split_explicit, ' // &
-                 'unsplit_explicit, semi_implicit', MPAS_LOG_ERR)
+                 'unsplit_explicit, split_implicit', MPAS_LOG_ERR)
 
       end select
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -9,17 +9,17 @@
 !
 !  ocn_time_integration_si
 !
-!> \brief MPAS ocean semi-implicit time integration scheme
+!> \brief MPAS ocean split-implicit time integration scheme
 !> \author Mark Petersen, Doug Jacobsen, Todd Ringler
 !> \date   September 2011 (split explicit base code)
 !
 !> \author Hyun-Gyu Kang (Oak Ridge National Laboratory)
-!> \date   September 2019 (semi-implicit code)
+!> \date   September 2019 (split-implicit code)
 !> \details
-!>  This module contains the routines for the semi-implicit
+!>  This module contains the routines for the split-implicit
 !>  time integration scheme based on the split-explicit code.
 !>  Only stage 2 (barotropic mode) is changed from the explicit
-!>  subcycling scheme to the semi-implicit scheme.
+!>  subcycling scheme to the split-implicit scheme.
 !
 !-----------------------------------------------------------------------
 
@@ -89,7 +89,7 @@ module ocn_time_integration_si
    real (kind=RKIND) :: &
       useVelocityCorrection ! mask for velocity correction
 
-   ! Global variables for the semi-implicit time stepper ---------------
+   ! Global variables for the split-implicit time stepper ---------------
    real (kind=RKIND), allocatable,dimension(:)   :: &
       prec_ivmat    ! an inversed preconditioning matrix
    real (kind=RKIND) :: &
@@ -119,14 +119,14 @@ module ocn_time_integration_si
 !
 !  ocn_time_integration_si
 !
-!> \brief MPAS ocean semi-implicit time integration scheme
+!> \brief MPAS ocean split-implicit time integration scheme
 !> \author Mark Petersen, Doug Jacobsen, Todd Ringler
 !> \date   September 2011 (split explicit base code)
 !> \author Hyun-Gyu Kang (Oak Ridge National Laboratory)
-!> \date   JAN 2019 (semi-implicit code)
+!> \date   JAN 2019 (split-implicit code)
 !> \details
 !>  This routine integrates a master time step (dt) using a
-!>  semi-implicit time integrator.
+!>  split-implicit time integrator.
 !
 !-----------------------------------------------------------------------
 
@@ -286,16 +286,8 @@ module ocn_time_integration_si
 
       ! Semi-implicit variables
       real (kind=RKIND), dimension(2) :: &
-         SIcst_allreduce2,       &! array for local  summations
+         SIcst_allreduce_local2, &! array for local  summations
          SIcst_allreduce_global2  ! array for global summations
-      real (kind=RKIND), dimension(2) :: &
-         SIcst_allreduce_local2   ! array for local  summations
-      real (kind=RKIND), dimension(3) :: &
-         SIcst_allreduce3,       &! array for local  summations
-         SIcst_allreduce_global3  ! array for global summations
-      real (kind=RKIND), dimension(5) :: &
-         SIcst_allreduce5,       &! array for local  summations
-         SIcst_allreduce_global5  ! array for global summations
       real (kind=RKIND), dimension(9) :: &
          SIcst_allreduce_local9, &! array for local  summations
          SIcst_allreduce_global9,&! array for global summations
@@ -612,17 +604,31 @@ module ocn_time_integration_si
          ! normalTransportVelocity) for momentum advection.
          ! Use the most recent time level available.
 
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
+         !$acc update device(layerThickEdge)
+#endif
          if (associated(highFreqThicknessNew)) then
+#ifdef MPAS_OPENACC
+            !$acc enter data copyin(highFreqThicknessNew)
+#endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
+#ifdef MPAS_OPENACC
+            !$acc exit data delete(highFreqThicknessNew)
+#endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
          endif
+#ifdef MPAS_OPENACC
+         !$acc exit data delete(layerThicknessCur, normalVelocityCur, sshCur)
+         !$acc update host(vertAleTransportTop)
+#endif
 
          call ocn_tend_vel(tendPool, statePool, forcingPool, &
                            stage1_tend_time, dt)
@@ -730,10 +736,10 @@ module ocn_time_integration_si
 
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         ! Stage 2: Barotropic velocity (2D) prediction, semi-implicit
+         ! Stage 2: Barotropic velocity (2D) prediction, split-implicit
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          !
-         ! The semi-implicit barotropic mode solver
+         ! The split-implicit barotropic mode solver
          !    - uses the preconditioned communication-avoiding
          !      (single-reduction) BiCGStab method 
          !      (Cool and Vanroose, 2017) as a linear iterative solver
@@ -779,7 +785,7 @@ module ocn_time_integration_si
          !                SSH and BtrVel at time (n+1)
          !
          !
-         ! Reference: Kang et al. (2021): A scalable semi-implicit
+         ! Reference: Kang et al. (2021): A scalable split-implicit
          !            barotropic mode solver for the MPAS-Ocean, JAMES
          !
          !
@@ -902,6 +908,11 @@ module ocn_time_integration_si
    
             call mpas_timer_start("si btr residual")
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendb1,sshTendb2,sshTendAx,iEdge, &
+            !$omp         cell1,cell2,sshEdgeCur,thicknessSumCur, &
+            !$omp         sshDiffCur,fluxb1,fluxb2,fluxAx,sshCurArea)
             do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
@@ -954,6 +965,8 @@ module ocn_time_integration_si
                SIvec_r00(iCell) = SIvec_r0(iCell)
    
             end do ! iCell
+            !$omp end do
+            !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
    
@@ -994,6 +1007,10 @@ module ocn_time_integration_si
    
             ! SpMV -------------------------------------------------------!
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeCur, &
+            !$omp         thicknessSumCur,sshDiffCur,fluxAx,sshCurArea )
             do iCell = 1, nPrecVec
    
                sshTendAx = 0.0_RKIND
@@ -1028,7 +1045,8 @@ module ocn_time_integration_si
                SIvec_w0(iCell) = -sshCurArea - sshTendAx
    
             end do ! iCell
-   
+            !$omp end do
+            !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
    
@@ -1067,9 +1085,12 @@ module ocn_time_integration_si
             call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
             call mpas_timer_stop("si halo r0")
    
-   
             ! SpMV -------------------------------------------------------!
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeCur, &
+            !$omp         thicknessSumCur,sshDiffCur,fluxAx,sshCurArea )
             do iCell = 1, nPrecVec
    
                sshTendAx = 0.0_RKIND
@@ -1114,7 +1135,8 @@ module ocn_time_integration_si
                SIvec_s0(iCell)  = 0.0_RKIND
    
             end do ! iCell
-   
+            !$omp end do
+            !$omp end parallel
    
             ! Reduction --------------------------------------------------!
             SIcst_r00r0 = 0.0_RKIND
@@ -1182,6 +1204,8 @@ module ocn_time_integration_si
    
                iter = iter + 1
    
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1, nPrecVec
                   SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
                                    * (SIvec_ph0(iCell) - SIcst_omega0     &
@@ -1208,7 +1232,8 @@ module ocn_time_integration_si
                   SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
                                                        * SIvec_z1(iCell)
                end do ! iCell
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Preconditioning -----------------------------------------!
    
@@ -1250,6 +1275,10 @@ module ocn_time_integration_si
    
                ! SpMV ----------------------------------------------------!
    
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
                do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
    
@@ -1285,7 +1314,8 @@ module ocn_time_integration_si
                   SIvec_v0(iCell) = -sshLagArea - sshTendAx
    
                end do ! iCell
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Reduction -----------------------------------------------!
                SIcst_r00s0 = 0.0_RKIND
@@ -1321,12 +1351,12 @@ module ocn_time_integration_si
                                             * SIvec_t0(iCell)
    
                   SIcst_r00v0 = SIcst_r00v0 + SIvec_r00(iCell) &
-                                            * SIvec_v0(iCell) ! v1
+                                            * SIvec_v0(iCell)
    
                   SIcst_q0q0 = SIcst_q0q0   + SIvec_q0(iCell) &
                                             * SIvec_q0(iCell)
                end do
-   
+
                SIcst_allreduce_local9(1) = SIcst_r00s0
                SIcst_allreduce_local9(2) = SIcst_r00z0
                SIcst_allreduce_local9(3) = SIcst_q0y0 
@@ -1381,6 +1411,8 @@ module ocn_time_integration_si
                      - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
                      + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
    
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1,nPrecVec
                   sshSubcycleNew(iCell) = sshSubcycleNew(iCell)           &
                                         + SIcst_alpha0 * SIvec_ph1(iCell) &
@@ -1397,7 +1429,8 @@ module ocn_time_integration_si
                                    * ( SIvec_t0(iCell) - SIcst_alpha0     &
                                                        * SIvec_v0(iCell))
                end do
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Preconditioning -----------------------------------------!
    
@@ -1439,6 +1472,10 @@ module ocn_time_integration_si
    
                ! SpMV ----------------------------------------------------!
    
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
                do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
    
@@ -1473,9 +1510,9 @@ module ocn_time_integration_si
    
                   SIvec_t1(iCell) = -sshLagArea - sshTendAx
                end do ! iCell
-   
-               ! End reduction -------------------------------------------!
-   
+               !$omp end do
+               !$omp end parallel
+
                SIcst_rho1 = SIcst_r00q0_global - SIcst_omega0 * SIcst_r00y0_global 
    
                SIcst_gamma1 = SIcst_r00y0_global - SIcst_omega0 * SIcst_r00t0_global  &
@@ -1489,7 +1526,10 @@ module ocn_time_integration_si
                             / ( SIcst_gamma1 + SIcst_beta0 * SIcst_r00s0_global   &
                                              - SIcst_beta0 * SIcst_omega0  &
                                                            * SIcst_r00z0_global )
-   
+               SIcst_rho0         = SIcst_rho1
+
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1,nPrecVec
                   SIvec_r0(iCell) = SIvec_r1(iCell)
                   SIvec_s0(iCell) = SIvec_s1(iCell)
@@ -1503,13 +1543,12 @@ module ocn_time_integration_si
                   SIvec_wh0(iCell) = SIvec_wh1(iCell)
                   SIvec_zh0(iCell) = SIvec_zh1(iCell)
                end do ! iCell
-   
-               SIcst_rho0         = SIcst_rho1
+               !$omp end do
+               !$omp end parallel
    
             !-------------------------------------------------------------!
             end do ! do iter
             !-------------------------------------------------------------!
-    
    
             !   boundary update on sshNew
             call mpas_timer_start("si halo iter")
@@ -1519,18 +1558,25 @@ module ocn_time_integration_si
    
             call mpas_timer_stop("si btr iteration")
    
-   
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             ! Stage 2.4 : The barotropic velocity update
             !             using the lagged SSH
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    
             call mpas_timer_start("si btr vel update")
+
+            !$omp parallel
+            !$omp do schedule(runtime)
             do iCell = 1,nCellsAll
                ! Use of sshNew to save the lagged SSH
                sshNew(iCell) = sshSubcycleNew(iCell)
             end do
+            !$omp end do
+            !$omp end parallel
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(temp_mask,cell1,cell2)
             do iEdge = 1,nEdgesHalo( edgeHaloComputeCounter-1 )
                temp_mask = edgeMask(1, iEdge)
    
@@ -1551,6 +1597,8 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
@@ -1569,7 +1617,10 @@ module ocn_time_integration_si
             end do
             !$omp end do
             !$omp end parallel
-   
+
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(temp_mask,cell1,cell2)
             do iEdge = 1,nEdgesHalo(2)
                temp_mask = edgeMask(1, iEdge)
    
@@ -1582,6 +1633,8 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)        &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
@@ -1617,6 +1670,13 @@ module ocn_time_integration_si
    
             ! SpMV -------------------------------------------------------!
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendb1,sshTendb2,sshTendAx,iEdge, &
+            !$omp         cell1,cell2,sshEdgeCur,sshEdgeLag,sshEdgeMid, &
+            !$omp         thicknessSumCur,thicknessSumMid, &
+            !$omp         thicknessSumLag,sshDiffCur,sshDiffLag, &
+            !$omp         fluxb1,fluxb2,fluxAx,sshCurArea,sshLagArea)
             do iCell = 1, nPrecVec
                sshTendb1 = 0.0_RKIND
                sshTendb2 = 0.0_RKIND
@@ -1680,7 +1740,8 @@ module ocn_time_integration_si
                                 -(-sshLagArea - sshTendAx)
                SIvec_r00(iCell) = SIvec_r0(iCell)
             end do ! iCell
-   
+            !$omp end do
+            !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
    
@@ -1722,6 +1783,10 @@ module ocn_time_integration_si
    
             ! SpMV -------------------------------------------------------!
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+            !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
             do iCell = 1, nPrecVec
    
                sshTendAx = 0.0_RKIND
@@ -1751,13 +1816,14 @@ module ocn_time_integration_si
                             * fluxAx * dvEdge(iEdge)
                end do ! i
    
-               sshCurArea = R1_alpha1s_g_dts * SIvec_rh0(iCell) &
+               sshLagArea = R1_alpha1s_g_dts * SIvec_rh0(iCell) &
                                              * areaCell(iCell)
    
-               SIvec_w0(iCell) = -sshCurArea - sshTendAx
+               SIvec_w0(iCell) = -sshLagArea - sshTendAx
    
             end do ! iCell
-   
+            !$omp end do
+            !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
    
@@ -1798,6 +1864,10 @@ module ocn_time_integration_si
    
    
             ! SpMV -------------------------------------------------------!
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+            !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
             do iCell = 1, nPrecVec
    
                sshTendAx = 0.0_RKIND
@@ -1819,19 +1889,19 @@ module ocn_time_integration_si
                                         bottomDepth(cell2))
    
                   ! nabla (ssh^0)
-                  sshDiffCur = (SIvec_wh0(cell2) - SIvec_wh0(cell1)) &
+                  sshDiffLag = (SIvec_wh0(cell2) - SIvec_wh0(cell1)) &
                              / dcEdge(iEdge)
    
-                  fluxAx = thicknessSumLag * sshDiffCur
+                  fluxAx = thicknessSumLag * sshDiffLag
    
                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
                             * fluxAx * dvEdge(iEdge)
                end do ! i
    
-               sshCurArea = R1_alpha1s_g_dts * SIvec_wh0(iCell) &
+               sshLagArea = R1_alpha1s_g_dts * SIvec_wh0(iCell) &
                           * areaCell(iCell)
    
-               SIvec_t0(iCell) = -sshCurArea - sshTendAx
+               SIvec_t0(iCell) = -sshLagArea - sshTendAx
    
                SIvec_ph0(iCell) = 0.0_RKIND
                SIvec_sh0(iCell) = 0.0_RKIND
@@ -1841,6 +1911,8 @@ module ocn_time_integration_si
                SIvec_s0(iCell)  = 0.0_RKIND
    
             end do ! iCell
+            !$omp end do
+            !$omp end parallel
    
    
             ! Reduction -----------------------------------------------!
@@ -1856,7 +1928,6 @@ module ocn_time_integration_si
    
             SIcst_allreduce_local2(1) = SIcst_r00r0
             SIcst_allreduce_local2(2) = SIcst_r00w0
-   
    
             ! Global sum across CPUs
             call mpas_timer_start("si reduction r0")
@@ -1911,6 +1982,8 @@ module ocn_time_integration_si
    
                iter = iter + 1
    
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1, nPrecVec
                   SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
                                    * (SIvec_ph0(iCell) - SIcst_omega0     &
@@ -1937,7 +2010,8 @@ module ocn_time_integration_si
                   SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
                                                        * SIvec_z1(iCell)
                end do ! iCell
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Preconditioning -----------------------------------------!
                if ( trim(config_btr_si_preconditioner) == 'ras' ) then
@@ -1978,6 +2052,10 @@ module ocn_time_integration_si
    
                ! SpMV ----------------------------------------------------!
    
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
                do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
    
@@ -2007,12 +2085,14 @@ module ocn_time_integration_si
                                * fluxAx * dvEdge(iEdge)
                   end do ! i
    
-                  sshLagArea = R1_alpha1s_g_dts * SIvec_zh1(iCell) * areaCell(iCell)
+                  sshLagArea = R1_alpha1s_g_dts * SIvec_zh1(iCell) &
+                             * areaCell(iCell)
    
                   SIvec_v0(iCell) = -sshLagArea - sshTendAx
    
                end do ! iCell
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Reduction -----------------------------------------------!
                SIcst_r00s0 = 0.0_RKIND
@@ -2048,7 +2128,7 @@ module ocn_time_integration_si
                                             * SIvec_t0(iCell)
    
                   SIcst_r00v0 = SIcst_r00v0 + SIvec_r00(iCell) &
-                                            * SIvec_v0(iCell) ! v1
+                                            * SIvec_v0(iCell)
    
                   SIcst_q0q0 = SIcst_q0q0   + SIvec_q0(iCell) &
                                             * SIvec_q0(iCell)
@@ -2107,6 +2187,8 @@ module ocn_time_integration_si
                      - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
                      + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
    
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1,nPrecVec
                   sshSubcycleNew(iCell) = sshSubcycleNew(iCell)           &
                                         + SIcst_alpha0 * SIvec_ph1(iCell) &
@@ -2123,7 +2205,8 @@ module ocn_time_integration_si
                                    * ( SIvec_t0(iCell) - SIcst_alpha0     &
                                                        * SIvec_v0(iCell))
                end do
-   
+               !$omp end do
+               !$omp end parallel
    
                ! Preconditioning -----------------------------------------!
                if ( trim(config_btr_si_preconditioner) == 'ras' ) then
@@ -2161,9 +2244,12 @@ module ocn_time_integration_si
                call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh1')
                call mpas_timer_stop("si halo iter")
    
-   
                ! SpMV ----------------------------------------------------!
    
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
+               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
                do iCell = 1, nPrecVec
                   sshTendAx = 0.0_RKIND
    
@@ -2198,6 +2284,8 @@ module ocn_time_integration_si
    
                   SIvec_t1(iCell) = -sshLagArea - sshTendAx
                end do ! iCell
+               !$omp end do
+               !$omp end parallel
    
                SIcst_rho1 = SIcst_r00q0_global - SIcst_omega0 * SIcst_r00y0_global 
    
@@ -2212,6 +2300,10 @@ module ocn_time_integration_si
                             / ( SIcst_gamma1 + SIcst_beta0 * SIcst_r00s0_global   &
                                              - SIcst_beta0 * SIcst_omega0  &
                                                            * SIcst_r00z0_global )
+               SIcst_rho0 = SIcst_rho1
+
+               !$omp parallel
+               !$omp do schedule(runtime)
                do iCell = 1,nPrecVec
                   SIvec_r0(iCell) = SIvec_r1(iCell)
                   SIvec_s0(iCell) = SIvec_s1(iCell)
@@ -2225,8 +2317,8 @@ module ocn_time_integration_si
                   SIvec_wh0(iCell) = SIvec_wh1(iCell)
                   SIvec_zh0(iCell) = SIvec_zh1(iCell)
                end do ! iCell
-   
-               SIcst_rho0         = SIcst_rho1
+               !$omp end do
+               !$omp end parallel
    
                if ( iter > int(mean_num_cells*5) ) then
                   call mpas_log_write(&
@@ -2260,6 +2352,9 @@ module ocn_time_integration_si
    
             call mpas_timer_start("si btr vel update")
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(temp_mask,cell1,cell2)
             do iEdge = 1, nEdgesHalo(2)
                temp_mask = edgeMask(1, iEdge)
    
@@ -2280,6 +2375,8 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
             !$omp parallel
             !$omp do schedule(runtime) private(CoriolisTerm, i, eoe)
@@ -2299,6 +2396,9 @@ module ocn_time_integration_si
             !$omp end do
             !$omp end parallel
    
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(temp_mask,cell1,cell2)
             do iEdge = 1, nEdgesOwned
                temp_mask = edgeMask(1, iEdge)
    
@@ -2312,8 +2412,12 @@ module ocn_time_integration_si
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
-   
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(cell1,cell2,sshEdge,thicknessSum)
             do iEdge = 1, nEdgesOwned
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
@@ -2323,9 +2427,6 @@ module ocn_time_integration_si
                normalBarotropicVelocitySubcycleCur(iEdge)                &
                   = 0.5_RKIND*normalBarotropicVelocitySubcycleNew(iEdge) &
                   + 0.5_RKIND*normalBarotropicVelocityCur(iEdge)
-   
-               normalBarotropicVelocityNew(iEdge) &
-                  = normalBarotropicVelocitySubcycleCur(iEdge)
    
                          ! 0.25 = 0.5 * 0.5
                sshEdge = 0.25_RKIND * (  sshSubcycleCur(cell1)   &
@@ -2341,6 +2442,8 @@ module ocn_time_integration_si
                          + normalBarotropicVelocityCur(iEdge) )       &
                          * thicknessSum
             end do ! iEdge
+            !$omp end do
+            !$omp end parallel
    
    
             ! boundary update on F
@@ -2348,9 +2451,6 @@ module ocn_time_integration_si
             call mpas_dmpar_exch_group_create(domain, finalBtrGroupName)
             call mpas_dmpar_exch_group_add_field(domain, &
                       finalBtrGroupName, 'barotropicThicknessFlux')
-            call mpas_dmpar_exch_group_add_field(domain,             &
-                      finalBtrGroupName, 'normalBarotropicVelocity', &
-                                                       timeLevel=2)
             call mpas_dmpar_exch_group_add_field(domain,             &
                       finalBtrGroupName,                             &
                                  'normalBarotropicVelocitySubcycle', &
@@ -2360,6 +2460,15 @@ module ocn_time_integration_si
             call mpas_dmpar_exch_group_destroy(domain, finalBtrGroupName)
             call mpas_timer_stop("si halo btr vel")
    
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdgesAll
+               normalBarotropicVelocityNew(iEdge)              &
+                  = normalBarotropicVelocitySubcycleCur(iEdge) 
+            end do ! iEdge
+            !$omp end do
+            !$omp end parallel
+
             call mpas_timer_stop("si btr vel update")
 
          !-------------------------------------------------------------!
@@ -2473,17 +2582,31 @@ module ocn_time_integration_si
          ! layerThickEdge because layerThickness has not yet
          ! been computed for time level 2.
          call mpas_timer_start('thick vert trans vel top')
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessCur, sshCur)
+         !$acc update device(layerThickEdge, normalTransportVelocity)
+#endif
          if (associated(highFreqThicknessNew)) then
+#ifdef MPAS_OPENACC
+            !$acc enter data copyin(highFreqThicknessNew)
+#endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
+#ifdef MPAS_OPENACC
+            !$acc exit data delete(highFreqThicknessNew)
+#endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)
          endif
+#ifdef MPAS_OPENACC
+         !$acc exit data delete(layerThicknessCur, sshCur)
+         !$acc update host(vertAleTransportTop, normalTransportVelocity)
+#endif
          call mpas_timer_stop('thick vert trans vel top')
 
          call ocn_tend_thick(tendPool, forcingPool, meshPool)
@@ -3000,11 +3123,11 @@ module ocn_time_integration_si
 !
 !  routine ocn_time_integration_si_init
 !
-!> \brief   Initialize semi-implicit time stepping within MPAS-Ocean
+!> \brief   Initialize split-implicit time stepping within MPAS-Ocean
 !> \author  Mark Petersen
 !> \date    September 2011
 !
-!> \author  Hyun-Gyu Kang (ORNL, for the semi-implicit code)
+!> \author  Hyun-Gyu Kang (ORNL, for the split-implicit code)
 !> \date    September 2019
 !> \details
 !>  This routine initializes variables required for the split-implicit
@@ -3069,7 +3192,7 @@ module ocn_time_integration_si
          normalBaroclinicVelocity, &! normal baroclinic velocity
          normalVelocity             ! normal velocity (total)
 
-      real (kind=RKIND), dimension(:), pointer :: sshCur
+      real (kind=RKIND), dimension(:), pointer :: ssh
 
 #ifndef USE_LAPACK
       call mpas_log_write( &
@@ -3088,12 +3211,12 @@ module ocn_time_integration_si
 
       select case (trim(config_time_integrator))
 
-      case ('semi_implicit')
+      case ('split_implicit')
 
          call mpas_log_write( &
          '***********************************************************')
          call mpas_log_write( &
-         'The semi-implicit time integration is configured')
+         'The split-implicit time integration is configured')
          call mpas_log_write( &
          '***********************************************************')
 
@@ -3150,7 +3273,7 @@ module ocn_time_integration_si
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
-      call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
+      call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
 
       nCells = nCellsArray(config_num_halos)
       nEdges = nEdgesArray(config_num_halos+1)
@@ -3263,7 +3386,7 @@ module ocn_time_integration_si
 
       ! Detection of ISMF (Temporariliy implemented. 
       !                    This will be revised in next SI version)
-      ! If ISMF is detected, the semi-implicit barotropic mode solver
+      ! If ISMF is detected, the split-implicit barotropic mode solver
       ! will solve a 'quasi-linear' barotropic system for the more 
       ! stable solver convergence.
       do iCell = 1, nCells
@@ -3276,21 +3399,16 @@ module ocn_time_integration_si
          end do
 
          ! copy zTop(1,iCell) into sea-surface height array
-         sshCur(iCell) = zTop(minLevelCell(iCell),iCell)
+         ssh(iCell) = zTop(minLevelCell(iCell),iCell)
       end do
 
-      tmp1 = minval(sshCur)
+      tmp1 = minval(ssh)
       call mpas_dmpar_min_real(domain % dminfo, tmp1,tmp2 )
 
       si_ismf = 1
       if ( tmp2 < -10.d0 ) then
          si_ismf = 0
       endif
-
-      ! Reinitialize ssh and zTop
-      sshCur(:) = 0.0
-      zTop(:,:) = 0.0
-
 
       ! Impliciness parameters
       alpha1= 0.5_RKIND
@@ -3313,10 +3431,7 @@ module ocn_time_integration_si
       !      version.
       nSiLargeIter = config_n_btr_si_large_iter
 
-      if ( tmp2 < -10.d0 .and. nSiLargeIter == 1 ) then ! For ISMF case
-         nSiLargeIter = 2
-         dt_si = dt_si / real(nSiLargeIter)
-      elseif ( numTSIterations == 1 ) then
+      if ( numTSIterations == 1 ) then
          nSiLargeIter = 2
       else
          nSiLargeIter = config_n_btr_si_large_iter
@@ -3331,7 +3446,7 @@ module ocn_time_integration_si
                            * gravity * dt_si)
       R1_alpha1_g      = 1.0_RKIND/(gravity*alpha1)
 
-      ! Compute preconditioner for the semi-implicit barotropic
+      ! Compute preconditioner for the split-implicit barotropic
       !  mode solver
       call mpas_log_write(' Building a preconditioning matrix: ')
       call mpas_timer_start("preconditioning matrix build")
@@ -3351,7 +3466,7 @@ module ocn_time_integration_si
 !> \date    September 2019
 !> \details
 !>  This routine constructs preconditioners for the
-!>  semi-implicit time stepper.
+!>  split-implicit time stepper.
 !
 !-----------------------------------------------------------------------
    subroutine ocn_time_integrator_si_preconditioner(domain, dt)!{{{

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -3213,7 +3213,7 @@ contains
          fCoef = 1
       elseif (trim(config_time_integrator) == 'split_explicit' &
         .or.trim(config_time_integrator) == 'unsplit_explicit' &
-        .or.trim(config_time_integrator) == 'semi_implicit') then
+        .or.trim(config_time_integrator) == 'split_implicit') then
           ! For split explicit, PV is eta/h because the Coriolis term
           ! is added separately to the momentum tendencies.
           fCoef = 0

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -586,7 +586,7 @@ contains
                 surfacePressure)
 
       ! Semi-implicit Array Pointer retrievals
-      if (trim(config_time_integrator) == 'semi_implicit') then
+      if (trim(config_time_integrator) == 'split_implicit') then
          call mpas_pool_get_array(diagnosticsPool, 'SIvec_r0', SIvec_r0)
          call mpas_pool_get_array(diagnosticsPool, 'SIvec_r1', SIvec_r1)
          call mpas_pool_get_array(diagnosticsPool, 'SIvec_v0', SIvec_v0)
@@ -763,7 +763,7 @@ contains
          !$acc                   salinitySurfaceRestoringTendency  &
          !$acc                   )
       end if
-      if ( trim(config_time_integrator) == 'semi_implicit' ) then
+      if ( trim(config_time_integrator) == 'split_implicit' ) then
          !$acc enter data copyin(                       &
          !$acc                   SIvec_r0,              &
          !$acc                   SIvec_r00,             &
@@ -1000,7 +1000,7 @@ contains
          !$acc                   salinitySurfaceRestoringTendency  &
          !$acc                   )
       end if
-      if ( trim(config_time_integrator) == 'semi_implicit' ) then
+      if ( trim(config_time_integrator) == 'split_implicit' ) then
          !$acc exit data delete(                        &
          !$acc                   SIvec_r0,              &
          !$acc                   SIvec_r00,             &
@@ -1189,7 +1189,7 @@ contains
       if ( config_use_activeTracers_surface_restoring ) then
          nullify(salinitySurfaceRestoringTendency)
       end if
-      if ( trim(config_time_integrator) == 'semi_implicit' ) then
+      if ( trim(config_time_integrator) == 'split_implicit' ) then
          nullify(SIvec_r0,              &
                  SIvec_r00,             &
                  SIvec_r1,              &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -314,8 +314,8 @@ contains
          ! tendencies.
          usePlanetVorticity = .false.
 
-      case ('semi_implicit')
-         ! For semi-implicit, Coriolis tendency uses eta/h because
+      case ('split_implicit')
+         ! For split implicit, Coriolis tendency uses eta/h because
          ! the Coriolis term is added separately to the momentum
          ! tendencies.
          usePlanetVorticity = .false.

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -151,7 +151,7 @@ contains
       do iCell = 1, nCellsSolve
         do k = minLevelCell(iCell), maxLevelCell(iCell)
           ! use ssh as a proxy too for baroclinic mode
-          if (trim(config_time_integrator) == 'split_explicit' .or. trim(config_time_integrator) == 'semi_implicit') then
+          if (trim(config_time_integrator) == 'split_explicit' .or. trim(config_time_integrator) == 'split_implicit') then
             layerThick = min(layerThicknessNew(k, iCell), (sshSubcycleNew(iCell)+bottomDepth(iCell))/maxLevelCell(iCell))
           else
             layerThick = layerThicknessNew(k, iCell)


### PR DESCRIPTION
This PR fixes bugs on the updated SI codes, added OpenMP directives for the SI solver, and changed the flag of the semi-implicit barotropic mode solver (`config_time_intesgrator`) from `semi_implicit` to `split_implicit`.