### PR TITLE
Add CIME HTML dir on Anvil for atm non-bfb tests

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1018,6 +1018,8 @@
     <SAVE_TIMING_DIR>/lcrc/group/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>/lcrc/group/e3sm/$USER/scratch/anvil</CIME_OUTPUT_ROOT>
+    <CIME_HTML_ROOT>/lcrc/group/e3sm/public_html/$ENV{USER}</CIME_HTML_ROOT>
+    <CIME_URL_ROOT>https://web.lcrc.anl.gov/public/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/lcrc/group/e3sm/data/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/lcrc/group/e3sm/data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/lcrc/group/e3sm/$USER/archive/$CASE</DOUT_S_ROOT>


### PR DESCRIPTION
This adds the CIME_URL_ROOT and CIME_HTML_ROOT for Anvil, which is used by CIME in the non-bit for bit tests to make evv4esm results available on a public facing webpage.

This change places the results in the test user's sub-directory as a top-level sub-directory in the E3SM project (e.g. https://web.lcrc.anl.gov/public/e3sm/e3smtest for the "e3smtest" user).