### PR TITLE
removal of  one paired #ifndef CPL_BYPASS ... #endif in driver-mct/main/cime_comp.mod.F90

### DIFF
--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -2464,7 +2464,6 @@ contains
 
     ! --- Write out performance data for initialization
     call seq_timemgr_EClockGetData( EClock_d, curr_ymd=ymd, curr_tod=tod)
-#ifndef CPL_BYPASS
     ! Report on memory usage
     call shr_mem_getusage(msize,mrss)
 
@@ -2606,7 +2605,6 @@ contains
           endif
        endif ! iamroot_CPLID
     endif ! info_mprof > 0
-#endif
     ! Write out a timing file checkpoint
     write(timing_file,'(a,i8.8,a1,i5.5)') &
           trim(tchkpt_dir)//"/model_timing"//trim(cpl_inst_tag)//"_",ymd,"_",tod


### PR DESCRIPTION
When code building with -DCPL_BYPASS, an option heavily used by ELM modelers, that '#ifndef ... #endif' causes 'mlog' and 'c_mprof_file' not initialized, and later cause unit free error in cime_final(): L3685-3686.