### PR TITLE
Add separate lines for icebergs to the cpl heat and water budgets

### DIFF
--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -137,35 +137,37 @@ module seq_diag_mct
   integer(in),parameter :: f_hlatf     = 8     ! heat : latent, fusion, snow
   integer(in),parameter :: f_hioff     = 9     ! heat : latent, fusion, frozen runoff
   integer(in),parameter :: f_hsen      =10     ! heat : sensible
-  integer(in),parameter :: f_hh2ot     =11     ! heat : water temperature
-  integer(in),parameter :: f_wfrz      =12     ! water: freezing
-  integer(in),parameter :: f_wmelt     =13     ! water: melting
-  integer(in),parameter :: f_wrain     =14     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow     =15     ! water: precip, frozen
-  integer(in),parameter :: f_wevap     =16     ! water: evaporation
-  integer(in),parameter :: f_wroff     =17     ! water: runoff/flood
-  integer(in),parameter :: f_wioff     =18     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_16O  =19     ! water: freezing
-  integer(in),parameter :: f_wmelt_16O =20     ! water: melting
-  integer(in),parameter :: f_wrain_16O =21     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_16O =22     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_16O =23     ! water: evaporation
-  integer(in),parameter :: f_wroff_16O =24     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_16O =25     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_18O  =26     ! water: freezing
-  integer(in),parameter :: f_wmelt_18O =27     ! water: melting
-  integer(in),parameter :: f_wrain_18O =28     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_18O =29     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_18O =30     ! water: evaporation
-  integer(in),parameter :: f_wroff_18O =31     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_18O =32     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_HDO  =33     ! water: freezing
-  integer(in),parameter :: f_wmelt_HDO =34     ! water: melting
-  integer(in),parameter :: f_wrain_HDO =35     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_HDO =36     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_HDO =37     ! water: evaporation
-  integer(in),parameter :: f_wroff_HDO =38     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_HDO =39     ! water: frozen runoff
+  integer(in),parameter :: f_hberg     =11     ! heat : data icebergs
+  integer(in),parameter :: f_hh2ot     =12     ! heat : water temperature
+  integer(in),parameter :: f_wfrz      =13     ! water: freezing
+  integer(in),parameter :: f_wmelt     =14     ! water: melting
+  integer(in),parameter :: f_wrain     =15     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow     =16     ! water: precip, frozen
+  integer(in),parameter :: f_wberg     =17     ! water: data icebergs
+  integer(in),parameter :: f_wevap     =18     ! water: evaporation
+  integer(in),parameter :: f_wroff     =19     ! water: runoff/flood
+  integer(in),parameter :: f_wioff     =20     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_16O  =21     ! water: freezing
+  integer(in),parameter :: f_wmelt_16O =22     ! water: melting
+  integer(in),parameter :: f_wrain_16O =23     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_16O =24     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_16O =25     ! water: evaporation
+  integer(in),parameter :: f_wroff_16O =26     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_16O =27     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_18O  =28     ! water: freezing
+  integer(in),parameter :: f_wmelt_18O =29     ! water: melting
+  integer(in),parameter :: f_wrain_18O =30     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_18O =31     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_18O =32     ! water: evaporation
+  integer(in),parameter :: f_wroff_18O =33     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_18O =34     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_HDO  =35     ! water: freezing
+  integer(in),parameter :: f_wmelt_HDO =36     ! water: melting
+  integer(in),parameter :: f_wrain_HDO =37     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_HDO =38     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_HDO =39     ! water: evaporation
+  integer(in),parameter :: f_wroff_HDO =40     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_HDO =41     ! water: frozen runoff
 
   integer(in),parameter :: f_size     = f_wioff_HDO   ! Total array size of all elements
   integer(in),parameter :: f_a        = f_area        ! 1st index for area
@@ -185,8 +187,8 @@ module seq_diag_mct
 
        (/'        area','     hfreeze','       hmelt','      hnetsw','       hlwdn', &
        '       hlwup','     hlatvap','     hlatfus','      hiroff','        hsen', &
-       '    hh2otemp','     wfreeze','       wmelt','       wrain','       wsnow', &
-       '       wevap','     wrunoff','     wfrzrof',                               &
+       '       hberg','    hh2otemp','     wfreeze','       wmelt','       wrain', &
+       '       wsnow','       wberg','       wevap','     wrunoff','     wfrzrof', &
        ' wfreeze_16O','   wmelt_16O','   wrain_16O','   wsnow_16O',                &
        '   wevap_16O',' wrunoff_16O',' wfrzrof_16O',                               &
        ' wfreeze_18O','   wmelt_18O','   wrain_18O','   wsnow_18O',                &
@@ -302,6 +304,8 @@ module seq_diag_mct
 
   integer :: index_i2x_Fioi_melth
   integer :: index_i2x_Fioi_meltw
+  integer :: index_i2x_Fioi_bergh
+  integer :: index_i2x_Fioi_bergw
   integer :: index_i2x_Fioi_salt
   integer :: index_i2x_Faii_swnet
   integer :: index_i2x_Fioi_swpen
@@ -1454,26 +1458,22 @@ contains
           ca_i =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ki,n)
           nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_o
 
-          if (index_x2o_Fioi_bergw == 0) then
-             nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_meltw,n)
-          else
-             nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + &
-                  (ca_o+ca_i)*(x2o_o%rAttr(index_x2o_Fioi_meltw,n)+x2o_o%rAttr(index_x2o_Fioi_bergw,n))
-          endif
-
-          if (index_x2o_Fioi_bergh == 0) then
-             nf = f_hmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_melth,n)
-          else
-             nf = f_hmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + &
-                  (ca_o+ca_i)*(x2o_o%rAttr(index_x2o_Fioi_melth,n)+x2o_o%rAttr(index_x2o_Fioi_bergh,n))
-          endif
-
+          nf = f_hmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_melth,n)
           nf = f_hswnet; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_swnet,n)
           nf = f_hlwdn ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_lwdn,n)
+          nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_meltw,n)
           nf = f_wrain ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_rain,n)
           nf = f_wsnow ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_snow,n)
           nf = f_wroff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofl,n)
           nf = f_wioff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofi,n)
+
+          if (index_x2o_Fioi_bergw /= 0) then
+             nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
+          endif
+
+          if (index_x2o_Fioi_bergh /= 0) then
+             nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergh,n)
+          endif
 
           if ( flds_wiso_ocn )then
              nf = f_wmelt_16O;
@@ -1589,6 +1589,8 @@ contains
     if (present(do_i2x)) then
        index_i2x_Fioi_melth  = mct_aVect_indexRA(i2x_i,'Fioi_melth')
        index_i2x_Fioi_meltw  = mct_aVect_indexRA(i2x_i,'Fioi_meltw')
+       index_i2x_Fioi_bergh  = mct_aVect_indexRA(i2x_i,'PFioi_bergh', perrWith='quiet')
+       index_i2x_Fioi_bergw  = mct_aVect_indexRA(i2x_i,'PFioi_bergw', perrWith='quiet')
        index_i2x_Fioi_swpen  = mct_aVect_indexRA(i2x_i,'Fioi_swpen')
        index_i2x_Faii_swnet  = mct_aVect_indexRA(i2x_i,'Faii_swnet')
        index_i2x_Faii_lwup   = mct_aVect_indexRA(i2x_i,'Faii_lwup')
@@ -1626,6 +1628,14 @@ contains
           nf = f_hlatv ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_lat,n)
           nf = f_hsen  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_sen,n)
           nf = f_wevap ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_evap,n)
+
+          if (index_i2x_Fioi_bergw /= 0) then
+             nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergw,n)
+          endif
+
+          if (index_i2x_Fioi_bergh /= 0) then
+             nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergh,n)
+          endif
 
           if ( flds_wiso_ice )then
              nf = f_wmelt_16O;
@@ -1691,6 +1701,7 @@ contains
                (ca_o+ca_i)*max(0.0_r8,x2i_i%rAttr(index_x2i_Fioo_frazil,n))
           nf = f_hfrz ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - &
                (ca_o+ca_i)*max(0.0_r8,x2i_i%rAttr(index_x2i_Fioo_q,n))
+
           if ( flds_wiso_ice_x2i )then
              nf  = f_wrain_16O;
              budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + &


### PR DESCRIPTION
Adds coupler budget lines for "hberg" and "wberg", corresponding to heat from icebergs and water from icebergs, to support cryo configurations with data icebergs (DIB).

[BFB]