### PR TITLE
Add OpenMPI modules on Anvil

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1078,14 +1078,28 @@
       </modules>
       <modules compiler="gnu">
         <command name="load">gcc/8.2.0-xhxgy33</command>
-        <command name="load">intel-mkl/2018.4.274-2amycpi</command>
+        <command name="load">intel-mkl/2020.4.304-d6zw4xa</command>
+      </modules>
+      <modules compiler="gnu" mpilib="mvapich">
         <command name="load">netcdf/4.4.1-ve2zfkw</command>
         <command name="load">netcdf-cxx/4.2-2rkopdl</command>
         <command name="load">netcdf-fortran/4.4.4-thtylny</command>
-      </modules>
-      <modules compiler="gnu" mpilib="mvapich">
         <command name="load">mvapich2/2.2-verbs-ppznoge</command>
         <command name="load">parallel-netcdf/1.11.0-c22b2bn</command>
+      </modules>
+      <modules compiler="gnu" mpilib="impi">
+        <command name="load">intel-mpi/2019.9.304-rxpzd6p</command>
+        <command name="load">netcdf-c/4.4.1-fysjgfx</command>
+        <command name="load">netcdf-cxx/4.2-oaiw2v6</command>
+        <command name="load">netcdf-fortran/4.4.4-kxgkaop</command>
+        <command name="load">parallel-netcdf/1.11.0-fce7akl</command>
+      </modules>
+      <modules compiler="gnu" mpilib="openmpi">
+        <command name="load">openmpi/4.1.1-x5n4m36</command>
+        <command name="load">netcdf-c/4.4.1-mtfptpl</command>
+        <command name="load">netcdf-cxx/4.2-osp27dq</command>
+        <command name="load">netcdf-fortran/4.4.4-5yd6dos</command>
+        <command name="load">parallel-netcdf/1.11.0-a7ohxsg</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1013,7 +1013,7 @@
     <NODENAME_REGEX>b.*.lcrc.anl.gov</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>impi,mvapich</MPILIBS>
+    <MPILIBS>impi,openmpi,mvapich</MPILIBS>
     <PROJECT>condo</PROJECT>
     <SAVE_TIMING_DIR>/lcrc/group/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
@@ -1068,6 +1068,13 @@
         <command name="load">netcdf-cxx/4.2-gkqc6fq</command>
         <command name="load">netcdf-fortran/4.4.4-eanrh5t</command>
         <command name="load">parallel-netcdf/1.11.0-y3nmmej</command>
+      </modules>
+      <modules compiler="intel" mpilib="openmpi">
+        <command name="load">openmpi/4.1.1-v3b3npd</command>
+        <command name="load">netcdf-c/4.4.1-smyuxme</command>
+        <command name="load">netcdf-cxx/4.2-kfb2aag</command>
+        <command name="load">netcdf-fortran/4.4.4-mablvyc</command>
+        <command name="load">parallel-netcdf/1.11.0-x4n5s7k</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">gcc/8.2.0-xhxgy33</command>


### PR DESCRIPTION
Add OpenMPI modules for Intel on Anvil. Also add IntelMPI and OpenMPI modules for GNU on Anvil.

[BFB]