### PR TITLE
Update Sandiatoss3 gcc compiler

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -907,7 +907,6 @@
         <command name="load">sems-env</command>
         <command name="load">acme-env</command>
         <command name="load">sems-git</command>
-        <command name="load">sems-python/3.5.2</command>
         <command name="load">sems-cmake/3.19.1</command>
         <command name="load">gnu/6.3.1</command>
         <command name="load">sems-intel/17.0.0</command>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -909,7 +909,7 @@
         <command name="load">sems-git</command>
         <command name="load">sems-python/3.5.2</command>
         <command name="load">sems-cmake/3.19.1</command>
-        <command name="load">gnu/4.9.2</command>
+        <command name="load">gnu/6.3.1</command>
         <command name="load">sems-intel/17.0.0</command>
       </modules>
       <modules mpilib="!mpi-serial">


### PR DESCRIPTION
We don't use GCC directly, but we do use its stdlibc++. Kokkos
now requires a newer stdlibc++, so we have to load a newer gcc
module.

[BFB]