### PR TITLE
Only send ocean CO2 flux to cpl if atm is expecting it

### DIFF
--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2479,7 +2479,7 @@ contains
        end if
 
        ! BGC fields
-       if (config_use_ecosysTracers) then
+       if (config_use_ecosysTracers .and. index_o2x_Faoo_fco2_ocn /= 0) then
           ! convert from mmolC/m2/s to kg CO2/m2/s
           o2x_o % rAttr(index_o2x_Faoo_fco2_ocn, n) = avgCO2_gas_flux(i)*44.e-6_RKIND
        endif


### PR DESCRIPTION
Make sure that index_o2x_Faoo_fco2_ocn has a non-zero value before loading the co2 surface flux for export.  Memory corruption can occur without this fix. 

Fixes #4394

[BFB]