### PR TITLE
Fix OpenMP thread pinning with SMT on Summit

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -489,16 +489,10 @@
        <directive>-P {{ project }}</directive>
      </directives>
      <directives compiler="!.*gpu">
-       <directive>-alloc_flags smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</directive>
+       <directive>-alloc_flags smt$ENV{SMT_MODE}</directive>
      </directives>
-     <directives compiler="ibmgpu">
-       <directive>-alloc_flags "gpumps smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}"</directive>
-     </directives>
-     <directives compiler="pgigpu">
-       <directive>-alloc_flags "gpumps smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}"</directive>
-     </directives>
-     <directives compiler="gnugpu">
-       <directive>-alloc_flags "gpumps smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}"</directive>
+     <directives compiler=".*gpu">
+       <directive>-alloc_flags "gpumps smt$ENV{SMT_MODE}"</directive>
      </directives>
      <queues>
        <queue walltimemax="02:00" default="true">batch</queue>

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -504,16 +504,10 @@
        <directive>-P {{ project }}</directive>
      </directives>
      <directives compiler="!.*gpu">
-       <directive>-alloc_flags smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</directive>
+       <directive>-alloc_flags smt$ENV{SMT_MODE}</directive>
      </directives>
-     <directives compiler="ibmgpu">
-       <directive>-alloc_flags "gpumps smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}"</directive>
-     </directives>
-     <directives compiler="pgigpu">
-       <directive>-alloc_flags "gpumps smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}"</directive>
-     </directives>
-     <directives compiler="gnugpu">
-       <directive>-alloc_flags "gpumps smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}"</directive>
+     <directives compiler=".*gpu">
+       <directive>-alloc_flags "gpumps smt$ENV{SMT_MODE}"</directive>
      </directives>
      <queues>
        <queue walltimemax="02:00" default="true" strict="true">batch</queue>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2902,7 +2902,7 @@
         <arg name="distribute">-d plane:$SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
         <arg name="cpu_per_rs">--cpu_per_rs $ENV{CPU_PER_RS}</arg>
         <arg name="gpu_per_rs">--gpu_per_rs $ENV{GPU_PER_RS}</arg>
-        <arg name="bind">--bind packed:smt:$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</arg>
+        <arg name="bind">--bind packed:smt:$ENV{OMP_NUM_THREADS}</arg>
         <arg name="latency_priority">--latency_priority $ENV{LTC_PRT}</arg>
         <arg name="stdio_mode">--stdio_mode prepended</arg>
       </arguments>
@@ -2975,6 +2975,7 @@
       <env name="GPU_PER_RS">0</env>
       <env name="LTC_PRT">cpu-cpu</env>
       <env name="NUM_RS">$SHELL{echo "2*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+      <env name="SMT_MODE">$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</env>
     </environment_variables>
     <environment_variables compiler="ibmgpu">
       <env name="RS_PER_NODE">6</env>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2742,14 +2742,16 @@
     <mpirun mpilib="spectrum-mpi">
       <executable>jsrun</executable>
       <arguments>
-        <arg name="nthreads">-X 1 -E OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="exit_on_error">-X 1</arg>
         <arg name="num_rs">--nrs $ENV{NUM_RS}</arg>
         <arg name="rs_per_node">--rs_per_host $ENV{RS_PER_NODE}</arg>
         <arg name="tasks_per_rs">--tasks_per_rs $SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
         <arg name="distribute">-d plane:$SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
         <arg name="cpu_per_rs">--cpu_per_rs $ENV{CPU_PER_RS}</arg>
         <arg name="gpu_per_rs">--gpu_per_rs $ENV{GPU_PER_RS}</arg>
-        <arg name="bind">--bind packed:smt:$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="task_bind">--bind packed:smt:$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="nthreads">-E OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="thread_bind">-E OMP_PROC_BIND=spread -E OMP_PLACES=threads -E OMP_STACKSIZE=256M</arg>
         <arg name="latency_priority">--latency_priority $ENV{LTC_PRT}</arg>
         <arg name="stdio_mode">--stdio_mode prepended</arg>
       </arguments>
@@ -2830,9 +2832,6 @@
       <env name="HDF5_PATH">$ENV{OLCF_HDF5_ROOT}</env>
       <env name="PNETCDF_PATH">$ENV{OLCF_PARALLEL_NETCDF_ROOT}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
-      <env name="OMP_STACKSIZE">128M</env>
-    </environment_variables>
     <environment_variables>
       <env name="RS_PER_NODE">2</env>
       <env name="CPU_PER_RS">21</env>
@@ -2895,14 +2894,16 @@
     <mpirun mpilib="spectrum-mpi">
       <executable>jsrun</executable>
       <arguments>
-        <arg name="nthreads">-X 1 -E OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="exit_on_error">-X 1</arg>
         <arg name="num_rs">--nrs $ENV{NUM_RS}</arg>
         <arg name="rs_per_node">--rs_per_host $ENV{RS_PER_NODE}</arg>
         <arg name="tasks_per_rs">--tasks_per_rs $SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
         <arg name="distribute">-d plane:$SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
         <arg name="cpu_per_rs">--cpu_per_rs $ENV{CPU_PER_RS}</arg>
         <arg name="gpu_per_rs">--gpu_per_rs $ENV{GPU_PER_RS}</arg>
-        <arg name="bind">--bind packed:smt:$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="task_bind">--bind packed:smt:$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="nthreads">-E OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="thread_bind">-E OMP_PROC_BIND=spread -E OMP_PLACES=threads -E OMP_STACKSIZE=256M</arg>
         <arg name="latency_priority">--latency_priority $ENV{LTC_PRT}</arg>
         <arg name="stdio_mode">--stdio_mode prepended</arg>
       </arguments>
@@ -2965,9 +2966,6 @@
       <env name="HDF5_PATH">$ENV{OLCF_HDF5_ROOT}</env>
       <env name="PNETCDF_PATH">$ENV{OLCF_PARALLEL_NETCDF_ROOT}</env>
       <env name="PGI_ACC_POOL_ALLOC">0</env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
-      <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
     <environment_variables>
       <env name="RS_PER_NODE">2</env>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2749,7 +2749,7 @@
         <arg name="distribute">-d plane:$SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
         <arg name="cpu_per_rs">--cpu_per_rs $ENV{CPU_PER_RS}</arg>
         <arg name="gpu_per_rs">--gpu_per_rs $ENV{GPU_PER_RS}</arg>
-        <arg name="bind">--bind packed:smt:$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</arg>
+        <arg name="bind">--bind packed:smt:$ENV{OMP_NUM_THREADS}</arg>
         <arg name="latency_priority">--latency_priority $ENV{LTC_PRT}</arg>
         <arg name="stdio_mode">--stdio_mode prepended</arg>
       </arguments>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2839,6 +2839,7 @@
       <env name="GPU_PER_RS">0</env>
       <env name="LTC_PRT">cpu-cpu</env>
       <env name="NUM_RS">$SHELL{echo "2*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+      <env name="SMT_MODE">$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</env>
     </environment_variables>
     <environment_variables compiler="ibmgpu">
       <env name="RS_PER_NODE">6</env>


### PR DESCRIPTION
When multi-threading with OpenMP, MPI tasks need to be given `NTHRDS` number of hwthreads.

[BFB]