### PR TITLE
Ensure sync is called before freedecomp

### DIFF
--- a/components/cice/src/drivers/cpl/ice_history_write.F90
+++ b/components/cice/src/drivers/cpl/ice_history_write.F90
@@ -621,6 +621,12 @@
          endif
       enddo ! num_avail_hist_fields
 
+      ! -------------------------
+      ! clean-up PIO descriptors
+      ! -------------------------
+      call pio_freedecomp(File,iodesc2d)
+      call pio_freedecomp(File,iodesc3d)
+
       !-----------------------------------------------------------------
       ! close output dataset
       !-----------------------------------------------------------------
@@ -641,12 +647,6 @@
 !    msize0,' MB (highwater) ',mrss0,' MB (usage)'
 !     endif
       
-      ! -------------------------
-      ! clean-up PIO descriptors
-      ! -------------------------
-      call pio_freedecomp(File,iodesc2d)
-      call pio_freedecomp(File,iodesc3d)
-
       !-------------------------
       !  Test memory usage
       !-------------------------


### PR DESCRIPTION
Freeing decompositions in CICE history write routine
before the file close.

The corresponding change in E3SM master was added in
PR #3607

Fixes #4415

[BFB]