### PR TITLE
Update the LC machine config files to newer cmake version

### DIFF
--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -1967,6 +1967,7 @@ flags should be captured within MPAS CMake files.
   <SLIBS>
     <append> -llapack -lblas</append>
   </SLIBS>
+  <KOKKOS_OPTIONS> --with-serial --with-openmp --cxxflags='-cxxlib=/usr/tce/packages/gcc/gcc-8.3.1/rh' --ldflags='-L/usr/tce/packages/gcc/gcc-8.3.1/rh/lib/gcc/x86_64-redhat-linux/8/'</KOKKOS_OPTIONS>
   <MPI_LIB_NAME> mpich</MPI_LIB_NAME>
   <MPI_PATH>/usr/tce/packages/mvapich2/mvapich2-2.2-intel-18.0.1/</MPI_PATH>
   <NETCDF_PATH>/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-18.0.1/</NETCDF_PATH>
@@ -1989,6 +1990,7 @@ flags should be captured within MPAS CMake files.
   <SLIBS>
     <append> -llapack -lblas</append>
   </SLIBS>
+  <KOKKOS_OPTIONS> --with-serial --with-openmp --cxxflags='-cxxlib=/usr/tce/packages/gcc/gcc-8.3.1/rh' --ldflags='-L/usr/tce/packages/gcc/gcc-8.3.1/rh/lib/gcc/x86_64-redhat-linux/8/'</KOKKOS_OPTIONS>
   <MPI_LIB_NAME> mpich</MPI_LIB_NAME>
   <MPI_PATH>/usr/tce/packages/mvapich2/mvapich2-2.2-intel-18.0.1/</MPI_PATH>
   <NETCDF_PATH>/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-18.0.1/</NETCDF_PATH>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1438,7 +1438,7 @@
         <command name="load">git</command>
         <command name="load">intel/19.0.4</command>
         <command name="load">mvapich2/2.3</command>
-        <command name="load">cmake/3.14.5</command>
+        <command name="load">cmake/3.18.0</command>
         <command name="load">netcdf-fortran/4.4.4</command>
         <command name="load">pnetcdf/1.9.0</command>
       </modules>
@@ -1490,7 +1490,7 @@
         <command name="load">git</command>
         <command name="load">intel/19.0.4</command>
         <command name="load">mvapich2/2.3</command>
-        <command name="load">cmake/3.14.5</command>
+        <command name="load">cmake/3.18.0</command>
         <command name="load">netcdf-fortran/4.4.4</command>
         <command name="load">pnetcdf/1.9.0</command>
       </modules>


### PR DESCRIPTION
This commit updates the cmake version used by the two Livermore
Computing machines quartz and syrah.

The recent update to Kokkos requires a cmake version of 3.16 or
higher.

[BFB]