### PR TITLE
Update v2 default nml parameters for northamericarrm

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -395,13 +395,11 @@
 <config_calc_surface_temperature>true</config_calc_surface_temperature>
 <config_use_form_drag>false</config_use_form_drag>
 <config_use_high_frequency_coupling>true</config_use_high_frequency_coupling>
-<config_use_high_frequency_coupling ice_grid="WC14to60E2r3">false</config_use_high_frequency_coupling>
 <config_use_high_frequency_coupling ice_grid="WCAtl12to45E2r4">false</config_use_high_frequency_coupling>
 <config_use_high_frequency_coupling ice_grid="SOwISC12to60E2r4">false</config_use_high_frequency_coupling>
 <config_use_high_frequency_coupling ice_grid="ECwISC30to60E2r1">false</config_use_high_frequency_coupling>
 <config_use_high_frequency_coupling ice_grid="EC30to60E2r2">false</config_use_high_frequency_coupling>
 <config_boundary_layer_iteration_number>10</config_boundary_layer_iteration_number>
-<config_boundary_layer_iteration_number ice_grid="WC14to60E2r3">5</config_boundary_layer_iteration_number>
 <config_boundary_layer_iteration_number ice_grid="WCAtl12to45E2r4">5</config_boundary_layer_iteration_number>
 <config_boundary_layer_iteration_number ice_grid="SOwISC12to60E2r4">5</config_boundary_layer_iteration_number>
 <config_boundary_layer_iteration_number ice_grid="ECwISC30to60E2r1">5</config_boundary_layer_iteration_number>

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -390,8 +390,8 @@
       <value compset=".+" grid="a%ne1024np4">1152</value>
       <value compset=".+" grid="a%ne0np4_arm_x8v3" >144</value>
       <value compset=".+" grid="a%ne0np4_conus_x4v1" >96</value>
-      <value compset=".+" grid="a%ne0np4_northamericax4v1" >96</value>
-      <value compset=".+" grid="a%ne0np4_antarcticax4v1" >96</value>
+      <value compset=".+" grid="a%ne0np4_northamericax4v1" >48</value>
+      <value compset=".+" grid="a%ne0np4_antarcticax4v1" >48</value>
       <value compset=".+" grid="a%ne0np4_svalbard_x8v1" >144</value>
       <value compset=".+" grid="a%ne0np4_sooberingoa_x4x8v1" >144</value>
       <value compset=".+" grid="a%ne0np4_enax4v1" >96</value>


### PR DESCRIPTION
ATM_NCPL=48 and the following parameters for MPASSI are made default for
the northamericarrm grid.

 config_use_high_frequency_coupling = true
 config_boundary_layer_iteration_number = 10

[BFB] non-BFB when using atm grid northamericax4v1 and/or ocn/ice grid WC14to60E2r3