### PR TITLE
Fmyuan/bugfix budg flux g

### DIFF
--- a/components/elm/src/biogeochem/CNPBudgetMod.F90
+++ b/components/elm/src/biogeochem/CNPBudgetMod.F90
@@ -857,7 +857,7 @@ contains
     ! !LOCAL VARIABLES:
     integer :: f, s, s_beg, s_end ! data array indicies
     real(r8) :: time_integrated_flux, state_net_change
-    real(r8), parameter :: error_tol = 0.01_r8
+    real(r8), parameter :: error_tol = 0.01_r8, error_tol_orig = 1.0e-8_r8
 
     write(iulog,*   )''
     write(iulog,*   )'NET CARBON FLUXES : period ',trim(pname(ip)),': date = ',cdate,sec
@@ -914,7 +914,10 @@ contains
     state_net_change = (budg_stateG(s_totc_end, ip) - budg_stateG(s_totc_beg, ip))*unit_conversion + &
          budg_stateG(s_c_error,ip) *unit_conversion
 
-    if (abs(time_integrated_flux - state_net_change) > error_tol) then
+    ! The error tolerance is 1.e-8 (kg/m2) in EcosystemBalanceCheckMod.F90,
+    ! It's better to be consistent. Note: 1.e-8*unit_conversion is ~0.79.
+    !if (abs(time_integrated_flux - state_net_change) > error_tol) then
+    if (abs(time_integrated_flux - state_net_change) > error_tol_orig*unit_conversion) then
        write(iulog,*)'time integrated flux = ',time_integrated_flux
        write(iulog,*)'net change in state  = ',state_net_change
        write(iulog,*)'error                = ',abs(time_integrated_flux - state_net_change)

--- a/components/elm/src/biogeochem/CNPBudgetMod.F90
+++ b/components/elm/src/biogeochem/CNPBudgetMod.F90
@@ -367,7 +367,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine Reset(mode, budg_fluxL, budg_fluxG, budg_fluxN, budg_stateL, budg_stateG)
     !
-    use clm_time_manager, only : get_curr_date, get_prev_date
+    use clm_time_manager, only : get_curr_date, get_prev_date, get_nstep
     !
     implicit none
     !
@@ -376,7 +376,7 @@ contains
     !
     integer :: year, mon, day, sec
     integer :: ip
-    character(*),parameter :: subName = '(WaterBudget_Reset) '
+    character(*),parameter :: subName = '(CNPBudget_Reset) '
 
     if (.not.present(mode)) then
        call get_curr_date(year, mon, day, sec)
@@ -399,6 +399,11 @@ contains
              budg_fluxN(:,ip)  = 0.0_r8
           endif
           if (ip==p_ann .and. mon==1 .and. day==1 .and. sec==0) then
+             budg_fluxL(:,ip)  = 0.0_r8
+             budg_fluxG(:,ip)  = 0.0_r8
+             budg_fluxN(:,ip)  = 0.0_r8
+          endif
+          if (ip==p_inf .and. get_nstep()==1) then
              budg_fluxL(:,ip)  = 0.0_r8
              budg_fluxG(:,ip)  = 0.0_r8
              budg_fluxN(:,ip)  = 0.0_r8

--- a/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
+++ b/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
@@ -954,7 +954,11 @@ contains
             grc_coutputs(g) = grc_coutputs(g) + grc_som_c_yield(g)
          end if
 
-         grc_errcb(g) = (grc_cinputs(g) - grc_coutputs(g))*dt - (end_totc(g) - beg_totc(g))
+         ! To be consistent with CNPBudgetMod.F90: L876-879, it shall include 'grc_errcb' from
+         ! after calling 'EndGridCBalanceAfterDynSubgridDriver()'.
+         !grc_errcb(g) = (grc_cinputs(g) - grc_coutputs(g))*dt - (end_totc(g) - beg_totc(g))
+         grc_errcb(g) = grc_errcb(g) + &
+            (grc_cinputs(g) - grc_coutputs(g))*dt - (end_totc(g) - beg_totc(g))
 
          if (grc_errcb(g) > error_tol .and. nstep > 1) then
             write(iulog,*)'grid cbalance error = ', grc_errcb(g), g

--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -2464,7 +2464,6 @@ contains
 
     ! --- Write out performance data for initialization
     call seq_timemgr_EClockGetData( EClock_d, curr_ymd=ymd, curr_tod=tod)
-#ifndef CPL_BYPASS
     ! Report on memory usage
     call shr_mem_getusage(msize,mrss)
 
@@ -2606,7 +2605,6 @@ contains
           endif
        endif ! iamroot_CPLID
     endif ! info_mprof > 0
-#endif
     ! Write out a timing file checkpoint
     write(timing_file,'(a,i8.8,a1,i5.5)') &
           trim(tchkpt_dir)//"/model_timing"//trim(cpl_inst_tag)//"_",ymd,"_",tod


### PR DESCRIPTION
The ELM 'CNPBudgetMod' has bug relevant to 'all_time' flux integral ('p_inf' in the code). It will crash model when it runs into end of first year, if continuing from a pre-stage restart file. A simple test is to run ELM in about 25 years of accelerated_spinup (ad_spinup) first, then run normal spinup from it, model would crash when first year ends. 

A suggested change to this same modules is to modify its error checking tolerance. It should be consistent with what criteria used in EcosystemBalanceCheckMod. For unknown reason, that grid-level budget errors appear accumulated with time, until some points of over 0.01 error-tolerance which crashing model. A single point tests show this crashing might occur around 200 years of spinup run. 