### PR TITLE
Remove swrad_off and lwrad_off flags

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3981,18 +3981,6 @@ Initialize with observed aerosols from IOP file.
 Default: FALSE
 </entry>
 
-<entry id="swrad_off" type="logical" category="scam"
-       group="cam_inparm" valid_values="">
-Assume night time (turn off SW rad).
-Default: FALSE
-</entry>
-
-<entry id="lwrad_off" type="logical" category="scam"
-       group="cam_inparm" valid_values="">
-Turn off LW radiation computation.
-Default: FALSE
-</entry>
-
 <entry id="precip_off" type="logical" category="scm"
        group="cam_inparm" valid_values="">
 Turn off microphysics computation.

--- a/components/eam/src/control/runtime_opts.F90
+++ b/components/eam/src/control/runtime_opts.F90
@@ -173,8 +173,6 @@ logical  :: scm_relaxation
 logical  :: scm_diurnal_avg
 logical  :: scm_crm_mode
 logical  :: scm_observed_aero
-logical  :: swrad_off
-logical  :: lwrad_off
 logical  :: precip_off
 
 contains
@@ -326,7 +324,7 @@ contains
    namelist /cam_inparm/ iopfile,scm_iop_srf_prop,scm_relaxation, &
                          scm_relaxation_low, scm_relaxation_high, &
                          scm_diurnal_avg,scm_crm_mode,scm_clubb_iop_name, &
-                         scm_observed_aero,swrad_off,lwrad_off, precip_off
+                         scm_observed_aero, precip_off
 
 !-----------------------------------------------------------------------
 
@@ -370,8 +368,6 @@ contains
         scm_diurnal_avg_out=scm_diurnal_avg, &
         scm_crm_mode_out=scm_crm_mode, &
         scm_observed_aero_out=scm_observed_aero, &
-        swrad_off_out=swrad_off, &
-        lwrad_off_out=lwrad_off, &
         precip_off_out=precip_off, &
         scm_clubb_iop_name_out=scm_clubb_iop_name)
    end if
@@ -449,8 +445,6 @@ contains
                             scm_diurnal_avg_in=scm_diurnal_avg, &
                             scm_crm_mode_in=scm_crm_mode, &
                             scm_observed_aero_in=scm_observed_aero, &
-                            swrad_off_in=swrad_off, &
-                            lwrad_off_in=lwrad_off, &
                             precip_off_in=precip_off, &
                             scm_clubb_iop_name_in=scm_clubb_iop_name)
       end if

--- a/components/eam/src/control/scamMod.F90
+++ b/components/eam/src/control/scamMod.F90
@@ -183,8 +183,6 @@ module scamMod
   logical*4, public ::  scm_iop_srf_prop   ! use the specified surface properties
   logical*4, public ::  scm_relaxation! use relaxation
   logical*4, public ::  scm_observed_aero ! use observed aerosols in SCM file
-  logical*4, public ::  swrad_off     ! turn off SW radiation (assume night)
-  logical*4, public ::  lwrad_off     ! turn off LW radiation
   logical*4, public ::  precip_off    ! turn off precipitation processes
   logical*4, public ::  use_replay    ! use e3sm generated forcing 
   logical*4, public ::  use_3dfrc     ! use 3d forcing
@@ -202,10 +200,10 @@ module scamMod
 
 
 subroutine scam_default_opts( scmlat_out,scmlon_out,iopfile_out, &
-	single_column_out,scm_iop_srf_prop_out, scm_relaxation_out, &
-	scm_relaxation_low_out, scm_relaxation_high_out, &
+        single_column_out,scm_iop_srf_prop_out, scm_relaxation_out, &
+        scm_relaxation_low_out, scm_relaxation_high_out, &
         scm_diurnal_avg_out, scm_crm_mode_out, scm_observed_aero_out, &
-	swrad_off_out, lwrad_off_out, precip_off_out, scm_clubb_iop_name_out)
+        precip_off_out, scm_clubb_iop_name_out)
 !-----------------------------------------------------------------------
    real(r8), intent(out), optional :: scmlat_out,scmlon_out
    character*(max_path_len), intent(out), optional ::  iopfile_out
@@ -215,8 +213,6 @@ subroutine scam_default_opts( scmlat_out,scmlon_out,iopfile_out, &
    logical, intent(out), optional ::  scm_diurnal_avg_out
    logical, intent(out), optional ::  scm_crm_mode_out
    logical, intent(out), optional ::  scm_observed_aero_out
-   logical, intent(out), optional ::  swrad_off_out
-   logical, intent(out), optional ::  lwrad_off_out
    logical, intent(out), optional ::  precip_off_out
    real(r8), intent(out), optional ::  scm_relaxation_low_out
    real(r8), intent(out), optional ::  scm_relaxation_high_out   
@@ -233,8 +229,6 @@ subroutine scam_default_opts( scmlat_out,scmlon_out,iopfile_out, &
    if ( present(scm_diurnal_avg_out) )  scm_diurnal_avg_out = .false.
    if ( present(scm_crm_mode_out) )     scm_crm_mode_out  = .false.
    if ( present(scm_observed_aero_out)) scm_observed_aero_out = .false.
-   if ( present(swrad_off_out))         swrad_off_out = .false.
-   if ( present(lwrad_off_out))         lwrad_off_out = .false.
    if ( present(precip_off_out))        precip_off_out = .false.
    if ( present(scm_clubb_iop_name_out) ) scm_clubb_iop_name_out  = ' '
 
@@ -242,9 +236,9 @@ end subroutine scam_default_opts
 
 subroutine scam_setopts( scmlat_in, scmlon_in,iopfile_in,single_column_in, &
                          scm_iop_srf_prop_in, scm_relaxation_in, &
-			 scm_relaxation_low_in, scm_relaxation_high_in, &
+                         scm_relaxation_low_in, scm_relaxation_high_in, &
                          scm_diurnal_avg_in, scm_crm_mode_in, scm_observed_aero_in, &
-			 swrad_off_in, lwrad_off_in, precip_off_in, scm_clubb_iop_name_in)
+                         precip_off_in, scm_clubb_iop_name_in)
 !-----------------------------------------------------------------------
   real(r8), intent(in), optional       :: scmlon_in, scmlat_in
   character*(max_path_len), intent(in), optional :: iopfile_in
@@ -254,8 +248,6 @@ subroutine scam_setopts( scmlat_in, scmlon_in,iopfile_in,single_column_in, &
   logical, intent(in), optional        :: scm_diurnal_avg_in
   logical, intent(in), optional        :: scm_crm_mode_in
   logical, intent(in), optional        :: scm_observed_aero_in
-  logical, intent(in), optional        :: swrad_off_in
-  logical, intent(in), optional        :: lwrad_off_in
   logical, intent(in), optional        :: precip_off_in
   character(len=*), intent(in), optional :: scm_clubb_iop_name_in
   real(r8), intent(in), optional       :: scm_relaxation_low_in
@@ -294,14 +286,6 @@ subroutine scam_setopts( scmlat_in, scmlon_in,iopfile_in,single_column_in, &
 
   if (present (scm_observed_aero_in)) then
      scm_observed_aero=scm_observed_aero_in
-  endif
-
-  if (present (swrad_off_in)) then
-     swrad_off=swrad_off_in
-  endif
-
-  if (present (lwrad_off_in)) then
-     lwrad_off=lwrad_off_in
   endif
   
   if (present (precip_off_in)) then

--- a/components/eam/src/physics/crm/rrtmg/radiation.F90
+++ b/components/eam/src/physics/crm/rrtmg/radiation.F90
@@ -34,8 +34,7 @@ use cam_abortutils,  only: endrun
 use error_messages,  only: handle_err
 use cam_control_mod, only: lambm0, obliqr, mvelpp, eccen
 use scamMod,         only: scm_crm_mode, single_column,have_cld,cldobs,&
-                           have_clwp,clwpobs,have_tg,tground,swrad_off,&
-                           lwrad_off
+                           have_clwp,clwpobs,have_tg,tground
 use perf_mod,        only: t_startf, t_stopf
 use cam_logfile,     only: iulog
 
@@ -1330,14 +1329,6 @@ end function radiation_nextsw_cday
     calday = get_curr_calday()
     call zenith (calday, clat, clon, coszrs, ncol, dt_avg)
     
-    ! We can bypass the shortwave calculation by setting the cosine of the solar
-    ! zenith angle to zero for all columns, because the shortwave code collapses
-    ! the inputs to daytime-only arrays. In case the swrad_off flag is set then,
-    ! we force shortwave to not be calculated by setting coszrs = 0.
-    if (swrad_off) then
-      coszrs(:)=0._r8
-    endif    
-
     ! Output cosine solar zenith angle
     call outfld('COSZRS', coszrs(1:ncol), ncol, lchnk)
 
@@ -2106,21 +2097,6 @@ end function radiation_nextsw_cday
                          clm_seed,     lu,           ld                                            )
                 call t_stopf ('rad_rrtmg_lw')
 
-                if (lwrad_off) then
-                  qrl(:,:) = 0._r8
-                  qrlc(:,:) = 0._r8
-                  flns(:) = 0._r8
-                  flnt(:) = 0._r8
-                  flnsc(:) = 0._r8
-                  flntc(:) = 0._r8
-                  cam_out%flwds(:) = 0._r8
-                  flut(:) = 0._r8
-                  flutc(:) = 0._r8
-                  fnl(:,:) = 0._r8
-                  fcnl(:,:) = 0._r8
-                  fldsc(:) = 0._r8
-                end if !lwrad_off
-    
                 do i=1,ncol
                   lwcf(i)=flutc(i) - flut(i)
                 end do

--- a/components/eam/src/physics/crm/rrtmg/radiation.F90
+++ b/components/eam/src/physics/crm/rrtmg/radiation.F90
@@ -367,18 +367,17 @@ real(r8) function radiation_nextsw_cday()
    nstep  = get_nstep()
    dtime  = get_step_size()
    offset = 0
-   do while (.not. dosw)
-      nstep = nstep + 1
-      offset = offset + dtime
-      if (radiation_do('sw', nstep)) then
-         radiation_nextsw_cday = get_curr_calday(offset=offset) 
-         dosw = .true.
-      end if
-   end do
-   if(radiation_nextsw_cday == -1._r8) then
-      call endrun('error in radiation_nextsw_cday')
+   if (iradsw/=0) then
+      do while (.not. dosw)
+         nstep = nstep + 1
+         offset = offset + dtime
+         if (radiation_do('sw', nstep)) then
+            radiation_nextsw_cday = get_curr_calday(offset=offset) 
+            dosw = .true.
+         end if
+      end do
    end if
-        
+
 end function radiation_nextsw_cday
 
 !================================================================================================

--- a/components/eam/src/physics/crm/rrtmg/radiation.F90
+++ b/components/eam/src/physics/crm/rrtmg/radiation.F90
@@ -323,20 +323,24 @@ function radiation_do(op, timestep)
    end if
 
    select case (op)
-
-   case ('sw') ! do a shortwave heating calc this timestep?
-      radiation_do = nstep == 0  .or.  iradsw == 1                     &
-                    .or. (mod(nstep-1,iradsw) == 0  .and.  nstep /= 1) &
-                    .or. nstep <= irad_always
-
-   case ('lw') ! do a longwave heating calc this timestep?
-      radiation_do = nstep == 0  .or.  iradlw == 1                     &
-                    .or. (mod(nstep-1,iradlw) == 0  .and.  nstep /= 1) &
-                    .or. nstep <= irad_always
-
-   case default
-      call endrun('radiation_do: unknown operation:'//op)
-
+      case ('sw') ! do a shortwave heating calc this timestep?
+         if (iradsw==0) then
+            radiation_do = .false.
+         else
+            radiation_do = nstep == 0 .or. iradsw == 1                     &
+                          .or. (mod(nstep-1,iradsw) == 0 .and. nstep /= 1) &
+                          .or. nstep <= irad_always
+         end if
+      case ('lw') ! do a longwave heating calc this timestep?
+         if (iradlw==0) then
+            radiation_do = .false.
+         else
+            radiation_do = nstep == 0 .or. iradlw == 1                     &
+                          .or. (mod(nstep-1,iradlw) == 0 .and. nstep /= 1) &
+                          .or. nstep <= irad_always
+         end if
+      case default
+         call endrun('radiation_do: unknown operation:'//op)
    end select
 end function radiation_do
 

--- a/components/eam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/crm/rrtmgp/radiation.F90
@@ -14,7 +14,7 @@ module radiation
    use shr_kind_mod,     only: r8=>shr_kind_r8, cl=>shr_kind_cl
    use ppgrid,           only: pcols, pver, pverp, begchunk, endchunk
    use cam_abortutils,   only: endrun
-   use scamMod,          only: scm_crm_mode, single_column, swrad_off
+   use scamMod,          only: scm_crm_mode, single_column
    use rad_constituents, only: N_DIAG
    use radconstants,     only: &
       nswbands, nlwbands, &
@@ -1446,11 +1446,6 @@ contains
                ! history buffer
                call set_cosine_solar_zenith_angle(state, dt_avg, coszrs(1:ncol))
                call outfld('COSZRS', coszrs(1:ncol), ncol, state%lchnk)
-
-               ! If the swrad_off flag is set, meaning we should not do SW radiation, then 
-               ! we just set coszrs to zero everywhere. TODO: why not just set dosw false 
-               ! and skip the loop?
-               if (swrad_off) coszrs(:) = 0._r8
 
                ! Gather night/day column indices for subsetting SW inputs; we only want to
                ! do the shortwave radiative transfer during the daytime to save

--- a/components/eam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/crm/rrtmgp/radiation.F90
@@ -364,13 +364,21 @@ contains
       ! and the longwave. In practice, these are probably usually the same.
       select case (op)
          case ('sw') ! do a shortwave heating calc this timestep?
-            radiation_do = nstep == 0 .or. iradsw == 1                     &
-                          .or. (mod(nstep-1,iradsw) == 0 .and. nstep /= 1) &
-                          .or. nstep <= irad_always
+            if (iradsw==0) then
+               radiation_do = .false.
+            else
+               radiation_do = nstep == 0 .or. iradsw == 1                     &
+                             .or. (mod(nstep-1,iradsw) == 0 .and. nstep /= 1) &
+                             .or. nstep <= irad_always
+            end if
          case ('lw') ! do a longwave heating calc this timestep?
-            radiation_do = nstep == 0 .or. iradlw == 1                     &
-                          .or. (mod(nstep-1,iradlw) == 0 .and. nstep /= 1) &
-                          .or. nstep <= irad_always
+            if (iradlw==0) then
+               radiation_do = .false.
+            else
+               radiation_do = nstep == 0 .or. iradlw == 1                     &
+                             .or. (mod(nstep-1,iradlw) == 0 .and. nstep /= 1) &
+                             .or. nstep <= irad_always
+            end if
          case default
             call endrun('radiation_do: unknown operation:'//op)
       end select

--- a/components/eam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/crm/rrtmgp/radiation.F90
@@ -409,18 +409,17 @@ contains
       nstep  = get_nstep()
       dtime  = get_step_size()
       offset = 0
-      do while (.not. dosw)
-         nstep = nstep + 1
-         offset = offset + dtime
-         if (radiation_do('sw', nstep)) then
-            radiation_nextsw_cday = get_curr_calday(offset=offset) 
-            dosw = .true.
-         end if
-      end do
-      if(radiation_nextsw_cday == -1._r8) then
-         call endrun('error in radiation_nextsw_cday')
+      if (iradsw/=0) then
+         do while (.not. dosw)
+            nstep = nstep + 1
+            offset = offset + dtime
+            if (radiation_do('sw', nstep)) then
+               radiation_nextsw_cday = get_curr_calday(offset=offset) 
+               dosw = .true.
+            end if
+         end do
       end if
-           
+  
    end function radiation_nextsw_cday
 
    !================================================================================================

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -303,20 +303,24 @@ function radiation_do(op, timestep)
    end if
 
    select case (op)
-
-   case ('sw') ! do a shortwave heating calc this timestep?
-      radiation_do = nstep == 0  .or.  iradsw == 1                     &
-                    .or. (mod(nstep-1,iradsw) == 0  .and.  nstep /= 1) &
-                    .or. nstep <= irad_always
-
-   case ('lw') ! do a longwave heating calc this timestep?
-      radiation_do = nstep == 0  .or.  iradlw == 1                     &
-                    .or. (mod(nstep-1,iradlw) == 0  .and.  nstep /= 1) &
-                    .or. nstep <= irad_always
-
-   case default
-      call endrun('radiation_do: unknown operation:'//op)
-
+      case ('sw') ! do a shortwave heating calc this timestep?
+         if (iradsw==0) then
+            radiation_do = .false.
+         else
+            radiation_do = nstep == 0 .or. iradsw == 1                     &
+                          .or. (mod(nstep-1,iradsw) == 0 .and. nstep /= 1) &
+                          .or. nstep <= irad_always
+         end if
+      case ('lw') ! do a longwave heating calc this timestep?
+         if (iradlw==0) then
+            radiation_do = .false.
+         else
+            radiation_do = nstep == 0 .or. iradlw == 1                     &
+                          .or. (mod(nstep-1,iradlw) == 0 .and. nstep /= 1) &
+                          .or. nstep <= irad_always
+         end if
+      case default
+         call endrun('radiation_do: unknown operation:'//op)
    end select
 end function radiation_do
 

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -24,8 +24,7 @@ use cam_abortutils,      only: endrun
 use error_messages,  only: handle_err
 use cam_control_mod, only: lambm0, obliqr, mvelpp, eccen
 use scamMod,         only: scm_crm_mode, single_column,have_cld,cldobs,&
-                           have_clwp,clwpobs,have_tg,tground,swrad_off,&
-                           lwrad_off
+                           have_clwp,clwpobs,have_tg,tground
 use perf_mod,        only: t_startf, t_stopf
 use cam_logfile,     only: iulog
 
@@ -1111,10 +1110,6 @@ end function radiation_nextsw_cday
     call get_rlat_all_p(lchnk, ncol, clat)
     call get_rlon_all_p(lchnk, ncol, clon)
     call zenith (calday, clat, clon, coszrs, ncol, dt_avg)
-    
-    if (swrad_off) then
-       coszrs(:)=0._r8 ! coszrs is only output for zenith
-    endif    
 
     call output_rad_data(  pbuf, state, cam_in, landm, coszrs )
 
@@ -1464,22 +1459,7 @@ end function radiation_nextsw_cday
                        clm_seed,     lu,           ld                                            )
                   call t_stopf ('rad_rrtmg_lw')
 
-                  if (lwrad_off) then
-                     qrl(:,:) = 0._r8
-                     qrlc(:,:) = 0._r8
-                     flns(:) = 0._r8
-                     flnt(:) = 0._r8
-                     flnsc(:) = 0._r8
-                     flntc(:) = 0._r8
-                     cam_out%flwds(:) = 0._r8
-                     flut(:) = 0._r8
-                     flutc(:) = 0._r8
-                     fnl(:,:) = 0._r8
-                     fcnl(:,:) = 0._r8
-                     fldsc(:) = 0._r8
-                  end if !lwrad_off
-		  
-		  do i=1,ncol
+                  do i=1,ncol
                      lwcf(i)=flutc(i) - flut(i)
                   end do
 

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -347,18 +347,17 @@ real(r8) function radiation_nextsw_cday()
    nstep  = get_nstep()
    dtime  = get_step_size()
    offset = 0
-   do while (.not. dosw)
-      nstep = nstep + 1
-      offset = offset + dtime
-      if (radiation_do('sw', nstep)) then
-         radiation_nextsw_cday = get_curr_calday(offset=offset) 
-         dosw = .true.
-      end if
-   end do
-   if(radiation_nextsw_cday == -1._r8) then
-      call endrun('error in radiation_nextsw_cday')
+   if (iradsw/=0) then
+      do while (.not. dosw)
+         nstep = nstep + 1
+         offset = offset + dtime
+         if (radiation_do('sw', nstep)) then
+            radiation_nextsw_cday = get_curr_calday(offset=offset) 
+            dosw = .true.
+         end if
+      end do
    end if
-        
+
 end function radiation_nextsw_cday
 
 !================================================================================================

--- a/components/eam/src/physics/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/rrtmgp/radiation.F90
@@ -15,7 +15,7 @@ module radiation
    use ppgrid,           only: pcols, pver, pverp, begchunk, endchunk
    use cam_abortutils,   only: endrun
    use cam_history_support, only: add_hist_coord
-   use scamMod,          only: scm_crm_mode, single_column, swrad_off
+   use scamMod,          only: scm_crm_mode, single_column
    use rad_constituents, only: N_DIAG
    use radconstants,     only: nswbands, nlwbands, &
       get_band_index_sw, get_band_index_lw, test_get_band_index, &
@@ -1281,10 +1281,6 @@ contains
          ! Get cosine solar zenith angle for current time step. 
          call set_cosine_solar_zenith_angle(state, dt_avg, coszrs(1:ncol))
          call outfld('COSZRS', coszrs(1:ncol), ncol, state%lchnk)
-         ! If the swrad_off flag is set, meaning we should not do SW radiation, then 
-         ! we just set coszrs to zero everywhere. TODO: why not just set dosw false 
-         ! and skip the loop?
-         if (swrad_off) coszrs(:) = 0._r8
 
          ! Do shortwave cloud optics calculations
          call t_startf('rad_cld_optics_sw')

--- a/components/eam/src/physics/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/rrtmgp/radiation.F90
@@ -358,13 +358,21 @@ contains
       ! and the longwave. In practice, these are probably usually the same.
       select case (op)
          case ('sw') ! do a shortwave heating calc this timestep?
-            radiation_do = nstep == 0 .or. iradsw == 1                     &
-                          .or. (mod(nstep-1,iradsw) == 0 .and. nstep /= 1) &
-                          .or. nstep <= irad_always
+            if (iradsw==0) then
+               radiation_do = .false.
+            else
+               radiation_do = nstep == 0 .or. iradsw == 1                     &
+                             .or. (mod(nstep-1,iradsw) == 0 .and. nstep /= 1) &
+                             .or. nstep <= irad_always
+            end if
          case ('lw') ! do a longwave heating calc this timestep?
-            radiation_do = nstep == 0 .or. iradlw == 1                     &
-                          .or. (mod(nstep-1,iradlw) == 0 .and. nstep /= 1) &
-                          .or. nstep <= irad_always
+            if (iradlw==0) then
+               radiation_do = .false.
+            else
+               radiation_do = nstep == 0 .or. iradlw == 1                     &
+                             .or. (mod(nstep-1,iradlw) == 0 .and. nstep /= 1) &
+                             .or. nstep <= irad_always
+            end if
          case default
             call endrun('radiation_do: unknown operation:'//op)
       end select

--- a/components/eam/src/physics/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/rrtmgp/radiation.F90
@@ -403,18 +403,17 @@ contains
       nstep  = get_nstep()
       dtime  = get_step_size()
       offset = 0
-      do while (.not. dosw)
-         nstep = nstep + 1
-         offset = offset + dtime
-         if (radiation_do('sw', nstep)) then
-            radiation_nextsw_cday = get_curr_calday(offset=offset) 
-            dosw = .true.
-         end if
-      end do
-      if(radiation_nextsw_cday == -1._r8) then
-         call endrun('error in radiation_nextsw_cday')
+      if (iradsw/=0) then
+         do while (.not. dosw)
+            nstep = nstep + 1
+            offset = offset + dtime
+            if (radiation_do('sw', nstep)) then
+               radiation_nextsw_cday = get_curr_calday(offset=offset) 
+               dosw = .true.
+            end if
+         end do
       end if
-           
+
    end function radiation_nextsw_cday
 
    !================================================================================================


### PR DESCRIPTION
This removes the swrad_off and lwrad_off flags for disabling radiation in SCM simualtions in favor of using iradsw=0 and iradlw=0 for disabling radiation. 

[BFB]