### PR TITLE
CIME Update

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -85,10 +85,10 @@
     </rpointer>
     <test_file_names>
       <tfile disposition="copy">rpointer.ice</tfile>
-      <tfile disposition="copy">mpassi.rst.1976-01-01_00000.nc</tfile>
-      <tfile disposition="copy">mpassi.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
-      <tfile disposition="move">mpassi.hist.1976-01-01_00000.nc</tfile>
-      <tfile disposition="move">mpassi.hist.am.regionalStatistics.0001.01.nc</tfile>
+      <tfile disposition="copy">casename.mpassi.rst.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">casename.mpassi.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">casename.mpassi.hist.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">casename.mpassi.hist.am.regionalStatistics.0001.01.nc</tfile>
     </test_file_names>
   </comp_archive_spec>
 
@@ -103,10 +103,10 @@
     </rpointer>
     <test_file_names>
       <tfile disposition="copy">rpointer.ocn</tfile>
-      <tfile disposition="copy">mpaso.rst.1976-01-01_00000.nc</tfile>
-      <tfile disposition="copy">mpaso.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
-      <tfile disposition="move">mpaso.hist.am.globalStats.1976-01-01.nc</tfile>
-      <tfile disposition="move">mpaso.hist.am.highFrequencyOutput.1976-01-01_00.00.00.nc</tfile>
+      <tfile disposition="copy">casename.mpaso.rst.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">casename.mpaso.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">casename.mpaso.hist.am.globalStats.1976-01-01.nc</tfile>
+      <tfile disposition="move">casename.mpaso.hist.am.highFrequencyOutput.1976-01-01_00.00.00.nc</tfile>
     </test_file_names>
   </comp_archive_spec>
 
@@ -121,10 +121,10 @@
     </rpointer>
     <test_file_names>
       <tfile disposition="copy">rpointer.glc</tfile>
-      <tfile disposition="copy">mali.rst.1976-01-01_00000.nc</tfile>
-      <tfile disposition="copy">mali.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
-      <tfile disposition="move">mali.hist.am.globalStats.1976-01-01.nc</tfile>
-      <tfile disposition="move">mali.hist.am.highFrequencyOutput.1976-01-01_00.00.00.nc</tfile>
+      <tfile disposition="copy">casename.mali.rst.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">casename.mali.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">casename.mali.hist.am.globalStats.1976-01-01.nc</tfile>
+      <tfile disposition="move">casename.mali.hist.am.highFrequencyOutput.1976-01-01_00.00.00.nc</tfile>
     </test_file_names>
   </comp_archive_spec>
 


### PR DESCRIPTION
to c6f489356fd385c465eec285b0321c09c12b2e97

Fixes:
1) check the size of read only xml files for 0 size
2) Fix e3sm archiving, GIT files, preview_run
3) Prepend the casename to mpas component restart file search in st_archive
4) Fix replay archive when replay.sh is not +w

Fixes #4424 

[BFB]