### PR TITLE
change default MMF time step

### DIFF
--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -406,9 +406,9 @@
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DATM.*_DICE.*_POP2.*_WW3">4</value>
       <value compset="_DATM.*_DICE.*_POP2.*_DWAV">4</value>
-      <!-- a shorter timestep is needed for stability in MMF compsets -->
-      <value compset="_EAM%MMF"      grid="a%ne4np4">96</value>
-      <value compset="_EAM%MMF"      grid="a%ne4np4.pg2">72</value>
+      <!-- a shorter timestep is needed for stability in MMF  -->
+      <!-- Use for all "low res" grids (i.e. ne4, ne30, ne45) -->
+      <value compset="_EAM%MMF">72</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Change the default atmosphere time step of 20 min (ATM_NCPL=72) to apply to all MMF cases on any grid. 

[BFB]