### PR TITLE
Remove unused nml section prescribed_ozone and use consistent oxid file

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6-1pctCO2.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6-1pctCO2.xml
@@ -32,14 +32,6 @@
 <history_aerosol    >.true.</history_aerosol>
 <history_aero_optics>.true.</history_aero_optics>
 
-<!-- 1850 ozone data is from Jean-Francois Lamarque -->
-<!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->
-<prescribed_ozone_datapath>atm/cam/ozone</prescribed_ozone_datapath>
-<prescribed_ozone_file    >ozone_1.9x2.5_L26_1850clim_c090420.nc</prescribed_ozone_file>
-<prescribed_ozone_name    >O3</prescribed_ozone_name>
-<prescribed_ozone_type    >CYCLICAL</prescribed_ozone_type>
-<prescribed_ozone_cycle_yr>1850</prescribed_ozone_cycle_yr>
-
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type         >CYCLICAL</ext_frc_type>
 <ext_frc_cycle_yr     >1850</ext_frc_cycle_yr>
@@ -69,7 +61,7 @@
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
 <tracer_cnst_cycle_yr>1849</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20181106.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
 
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6.xml
@@ -28,14 +28,6 @@
 <history_aerosol    >.true.</history_aerosol>
 <history_aero_optics>.true.</history_aero_optics>
 
-<!-- 1850 ozone data is from Jean-Francois Lamarque -->
-<!-- NOTE: I don't think this is used when rad_climate uses advected O3, but I don't think it does any harm either -->
-<prescribed_ozone_datapath>atm/cam/ozone</prescribed_ozone_datapath>
-<prescribed_ozone_file    >ozone_1.9x2.5_L26_1850clim_c090420.nc</prescribed_ozone_file>
-<prescribed_ozone_name    >O3</prescribed_ozone_name>
-<prescribed_ozone_type    >CYCLICAL</prescribed_ozone_type>
-<prescribed_ozone_cycle_yr>1850</prescribed_ozone_cycle_yr>
-
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type         >CYCLICAL</ext_frc_type>
 <ext_frc_cycle_yr     >1850</ext_frc_cycle_yr>
@@ -65,7 +57,7 @@
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
 <tracer_cnst_cycle_yr>1849</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20181106.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
 
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->

--- a/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP6.xml
@@ -52,7 +52,7 @@
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
 <tracer_cnst_cycle_yr>1955</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20181106.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
 

--- a/components/eam/bld/namelist_files/use_cases/2010_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_eam_CMIP6.xml
@@ -61,7 +61,7 @@
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
 <tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c180203.nc</tracer_cnst_file>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20181106.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
 


### PR DESCRIPTION
Prescribed_ozone_nl section is not needed for E3SMv2 production compsets
but still appear in some of them. There are two versions of prescribed
oxidant files for aerosol chemistry among the V2 comppsets, but they are
converted from the same netcdf4 source file. Use_case files are updated
to consistently use the one that records the detailed history of the
conversion.

[BFB] No impact on simulation results. NML diffs expected for 1850, 1950
         and 2010 WCYCL and F compsets