### PR TITLE
 Update elm surfdata_map and IC files for 1950 compsets

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -170,8 +170,9 @@ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.ICLM45BC.ne30_ne30.d0241119c.clm2.r.nc
 </finidat>
 
-<fsurdat hgrid="ne30np4.pg2"   sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_c201210.nc</fsurdat>
+<finidat hgrid="ne30np4.pg2" maxpft="17" mask="EC30to60E2r2" use_cn=".false." ic_ymd="19500101" more_vertlayers=".false." 
+sim_year="1950" glc_nec="0" use_crop=".false.">lnd/clm2/initdata/20210802.ICRUELM-1950.ne30pg2_EC30to60E2r2.elm.r.0051-01-01-00000.nc
+</finidat>
 
 <!-- HOMME grid ne120 resolution -->
 
@@ -344,6 +345,13 @@ lnd/clm2/surfdata_map/surfdata_1x1_brazil_simyr1850_c140610.nc</fsurdat>
 
 <fsurdat hgrid="ne30np4"      sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_c180306.nc</fsurdat>
+
+<fsurdat hgrid="ne30np4.pg2"   sim_year="1850" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_c201210.nc</fsurdat>
+
+<fsurdat hgrid="ne30np4.pg2"   sim_year="1950" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1950_c210729.nc</fsurdat>
+
 <fsurdat hgrid="ne16np4"      sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne16np4_simyr1850_c160108.nc</fsurdat>
 <fsurdat hgrid="ne120np4"     sim_year="1850" >

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -350,7 +350,7 @@ lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_c180306.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_c201210.nc</fsurdat>
 
 <fsurdat hgrid="ne30np4.pg2"   sim_year="1950" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne30npg2_simyr1950_c210729.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1950_c210729.nc</fsurdat>
 
 <fsurdat hgrid="ne16np4"      sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne16np4_simyr1850_c160108.nc</fsurdat>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -350,7 +350,7 @@ lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_c180306.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_c201210.nc</fsurdat>
 
 <fsurdat hgrid="ne30np4.pg2"   sim_year="1950" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1950_c210729.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne30npg2_simyr1950_c210729.nc</fsurdat>
 
 <fsurdat hgrid="ne16np4"      sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne16np4_simyr1850_c160108.nc</fsurdat>

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1291,7 +1291,7 @@ If TRUE, irrigation will be active (find surface datasets with active irrigation
 
 <entry id="sim_year" type="integer" category="default_settings"
        group="default_settings" valid_values=
-"1000,850,1100,1350,1600,1850,1855,1865,1875,1885,1895,1905,1915,1925,1935,1945,1955,1965,1975,1985,1995,2000,2005,2010,2015,2025,2035,2045,2055,2065,2075,2085,2095,2100,2105">
+"1000,850,1100,1350,1600,1850,1855,1865,1875,1885,1895,1905,1915,1925,1935,1945,1950,1955,1965,1975,1985,1995,2000,2005,2010,2015,2025,2035,2045,2055,2065,2075,2085,2095,2100,2105">
 Year to simulate and to provide datasets for (such as surface datasets, initial conditions, aerosol-deposition, Nitrogen deposition rates etc.)
 A sim_year of 1000 corresponds to data used for testing only, NOT corresponding to any real datasets.
 A sim_year greater than 2005 corresponds to rcp scenario data

--- a/components/elm/bld/namelist_files/use_cases/1950_CMIP6_control.xml
+++ b/components/elm/bld/namelist_files/use_cases/1950_CMIP6_control.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<use_case_desc>Conditions to simulate 1950 land-use</use_case_desc>
+
+<sim_year>1950</sim_year>
+
+<sim_year_range>constant</sim_year_range>
+
+<stream_year_first_ndep phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_first_ndep>
+<stream_year_last_ndep  phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_last_ndep>
+
+<stream_year_first_pdep phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_first_pdep>
+<stream_year_last_pdep  phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_last_pdep>
+
+<stream_year_first_popdens phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_first_popdens>
+<stream_year_last_popdens  phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_last_popdens>
+
+</namelist_defaults>

--- a/components/elm/cime_config/config_component.xml
+++ b/components/elm/cime_config/config_component.xml
@@ -74,8 +74,7 @@
       <value compset="20TR.*_EAM%CMIP6_ELM">20thC_CMIP6_transient</value>
       <value compset="20TR(?:SOI)?_EAM%CMIP6_ELM*_BGC%B">20thC_CMIP6bgc_transient</value> 
       <value compset="20TR.*_ELM%[^_]*BGC">20thC_bgc_transient</value>
-      <value compset="1950(?:SOI)?_EAM%CMIP6-LR.*_ELM">1950_CMIP6LR_control</value>
-      <value compset="1950(?:SOI)?_EAM%CMIP6-HR_ELM">1950_CMIP6HR_control</value>
+      <value compset="1950(?:SOI)?_EAM%CMIP6_ELM">1950_CMIP6_control</value>
       <value compset="2010(?:SOI)?_EAM%CMIP6_ELM">2010_CMIP6_control</value>
       <value compset="2010S.*_EAM%CMIP6_ELM">2010_CMIP6_control</value>
       <value compset="SSP585(?:SOI)?_EAM%CMIP6_ELM">2015-2100_SSP585_transient</value>


### PR DESCRIPTION
1950 compsets for ne30pg2 are currently using surfdata_ne30pg2_simyr2000_c190408.nc
and do not specify an finidat file. This PR sets to use the simyr1950
surfdata map and specify an IC file generated by land-only spin-up with
CRUNCEPv7 forcing cycling between 1941 and 1960.

[BFB] except for 1950 compsets
