### PR TITLE
Add support for new IG and BG grids

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -4686,17 +4686,17 @@
     </gridmap>
 
     <gridmap glc_grid="mpas.gis1to10km" lnd_grid="ne30np4.pg2">
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10km_mono.200602.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10km_bilin.200602.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne30pg2_mono.200602.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne30pg2_mono.200602.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10km_mono.210304.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10km_bilin.210304.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne30pg2_mono.210304.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne30pg2_mono.210304.nc</map>
     </gridmap>
 
     <gridmap glc_grid="mpas.gis1to10km" lnd_grid="r0125">
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r0125/map_r0125_to_gis1to10km_mono.200602.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r0125/map_r0125_to_gis1to10km_bilin.200602.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_r0125_mono.200602.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_r0125_mono.200602.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r0125/map_r0125_to_gis1to10km_mono.210304.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r0125/map_r0125_to_gis1to10km_bilin.210304.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_r0125_mono.210304.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_r0125_mono.210304.nc</map>
     </gridmap>
 
     <gridmap glc_grid="mpas.gis1to10km" ocn_grid="oEC60to30v3">
@@ -4711,14 +4711,14 @@
     </gridmap>
 
     <gridmap glc_grid="mpas.gis1to10km" ocn_grid="EC30to60E2r2">
-      <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_EC30to60E2r2_to_gis1to10km_aave.200602.nc</map>
-      <map name="OCN2GLC_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_EC30to60E2r2_to_gis1to10km_bilin.200602.nc</map>
-      <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
-      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
-      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
-      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
-      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
-      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
+      <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_gis1to10km_aave.210304.nc</map>
+      <map name="OCN2GLC_SMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_gis1to10km_bilin.210304.nc</map>
+      <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.210304.nc</map>
+      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.210304.nc</map>
+      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.210304.nc</map>
+      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.210304.nc</map>
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.210304.nc</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.210304.nc</map>
     </gridmap>
 
     <!-- ====================  -->

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1599,15 +1599,24 @@
       <mask>oEC60to30v3</mask>
     </model_grid>
 
-    <model_grid alias="ne120pg2_oECv3_gis1to10" compset="_MALI">
-      <grid name="atm">ne120np4.pg2</grid>
-      <grid name="lnd">ne120np4.pg2</grid>
-      <grid name="ocnice">oEC60to30v3</grid>
-      <grid name="rof">r05</grid>
-      <!-- grid name="rof">r0125</grid -->
+    <model_grid alias="ne30pg2_r0125_EC30to60E2r2_gis1to10" compset="_MALI">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">r0125</grid>
+      <grid name="ocnice">EC30to60E2r2</grid>
+      <grid name="rof">r0125</grid>
       <grid name="glc">mpas.gis1to10km</grid>
       <grid name="wav">null</grid>
-      <mask>oEC60to30v3</mask>
+      <mask>EC30to60E2r2</mask>
+    </model_grid>
+
+    <model_grid alias="ne120pg2_r0125_EC30to60E2r2_gis1to10" compset="_MALI">
+      <grid name="atm">ne120np4.pg2</grid>
+      <grid name="lnd">r0125</grid>
+      <grid name="ocnice">EC30to60E2r2</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">mpas.gis1to10km</grid>
+      <grid name="wav">null</grid>
+      <mask>EC30to60E2r2</mask>
     </model_grid>
 
     <model_grid alias="f09_g16_g" compset="_MALI">
@@ -4683,13 +4692,12 @@
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne30pg2_mono.200602.nc</map>
     </gridmap>
 
-    <gridmap glc_grid="mpas.gis1to10km" lnd_grid="ne120pg2">
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_gis1to10km_mono.200602.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_gis1to10km_bilin.200602.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne120pg2_mono.200602.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne120pg2_mono.200602.nc</map>
+    <gridmap glc_grid="mpas.gis1to10km" lnd_grid="r0125">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r0125/map_r0125_to_gis1to10km_mono.200602.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r0125/map_r0125_to_gis1to10km_bilin.200602.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_r0125_mono.200602.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_r0125_mono.200602.nc</map>
     </gridmap>
-
 
     <gridmap glc_grid="mpas.gis1to10km" ocn_grid="oEC60to30v3">
       <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_gis1to10km_aave.200602.nc</map>
@@ -4700,6 +4708,17 @@
       <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_oEC60to30v3_aave.200602.nc</map>
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_oEC60to30v3_aave.200602.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_oEC60to30v3_aave.200602.nc</map>
+    </gridmap>
+
+    <gridmap glc_grid="mpas.gis1to10km" ocn_grid="EC30to60E2r2">
+      <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_EC30to60E2r2_to_gis1to10km_aave.200602.nc</map>
+      <map name="OCN2GLC_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_EC30to60E2r2_to_gis1to10km_bilin.200602.nc</map>
+      <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
+      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
+      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
+      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_EC30to60E2r2_aave.200602.nc</map>
     </gridmap>
 
     <!-- ====================  -->

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2820,8 +2820,8 @@
       <file grid="lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_oRRS18to6v3.200212.nc</file>
       <file grid="atm" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_WC14to60E2r3.200929.nc</file>
       <file grid="lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_WC14to60E2r3.200929.nc</file>
-      <file grid="atm" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_EC30to60E2r2.21XXXX.nc</file>
-      <file grid="lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_EC30to60E2r2.21XXXX.nc</file>
+      <file grid="atm" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_EC30to60E2r2.210312.nc</file>
+      <file grid="lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_EC30to60E2r2.210312.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_gx1v6.191017.nc</file>
       <desc>r0125 is 1/8 degree river routing grid:</desc>
     </domain>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2550,8 +2550,8 @@
       <ny>1</ny>
       <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_oEC60to30v3.200511.nc</file>
       <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_oEC60to30v3.200511.nc</file>
-      <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_EC30to60E2r2.21XXXX.nc</file>
-      <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_EC30to60E2r2.21XXXX.nc</file>
+      <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_EC30to60E2r2.210312.nc</file>
+      <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_EC30to60E2r2.210312.nc</file>
       <desc>ne120np4 is Spectral Elem 1/4-deg grid w/ 2x2 FV physics grid</desc>
     </domain>
 
@@ -4573,10 +4573,9 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_oEC60to30v3_smoothed.r150e300.190812.nc</map>
     </gridmap>
 
-    <!-- placeholder for new r0125 runoff files -->
     <gridmap ocn_grid="EC30to60E2r2" rof_grid="r0125">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r0125_to_EC30to60E2r2_smoothed.r150e300.201005.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_EC30to60E2r2_smoothed.r150e300.201005.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r0125_to_EC30to60E2r2_smoothed.r150e300.210311.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_EC30to60E2r2_smoothed.r150e300.210311.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oEC60to30wLI" rof_grid="r05">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2820,8 +2820,8 @@
       <file grid="lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_oRRS18to6v3.200212.nc</file>
       <file grid="atm" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_WC14to60E2r3.200929.nc</file>
       <file grid="lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_WC14to60E2r3.200929.nc</file>
-      <file grid="atm" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_EC30to60E2r2.210312.nc</file>
-      <file grid="lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_EC30to60E2r2.210312.nc</file>
+      <file grid="atm" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_EC30to60E2r2.210412.nc</file>
+      <file grid="lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_EC30to60E2r2.210412.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_gx1v6.191017.nc</file>
       <desc>r0125 is 1/8 degree river routing grid:</desc>
     </domain>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2550,6 +2550,8 @@
       <ny>1</ny>
       <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_oEC60to30v3.200511.nc</file>
       <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_oEC60to30v3.200511.nc</file>
+      <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_EC30to60E2r2.21XXXX.nc</file>
+      <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_EC30to60E2r2.21XXXX.nc</file>
       <desc>ne120np4 is Spectral Elem 1/4-deg grid w/ 2x2 FV physics grid</desc>
     </domain>
 
@@ -2818,6 +2820,8 @@
       <file grid="lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_oRRS18to6v3.200212.nc</file>
       <file grid="atm" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_WC14to60E2r3.200929.nc</file>
       <file grid="lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_WC14to60E2r3.200929.nc</file>
+      <file grid="atm" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_EC30to60E2r2.21XXXX.nc</file>
+      <file grid="lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_EC30to60E2r2.21XXXX.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r0125_gx1v6.191017.nc</file>
       <desc>r0125 is 1/8 degree river routing grid:</desc>
     </domain>
@@ -3455,6 +3459,14 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_oEC60to30v3_bilin.200331.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne120pg2_mono.200331.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne120pg2_mono.200331.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne120np4.pg2" ocn_grid="EC30to60E2r2">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_EC30to60E2r2_mono.210311.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_EC30to60E2r2_bilin.210311.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_EC30to60E2r2_bilin.210311.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne120pg2_mono.210311.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne120pg2_mono.210311.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4.pg2" lnd_grid="r05">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1589,6 +1589,27 @@
       <mask>oEC60to30v3</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_oECv3_gis1to10" compset="_MALI">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">ne30np4.pg2</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.gis1to10km</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
+
+    <model_grid alias="ne120pg2_oECv3_gis1to10" compset="_MALI">
+      <grid name="atm">ne120np4.pg2</grid>
+      <grid name="lnd">ne120np4.pg2</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <!-- grid name="rof">r0125</grid -->
+      <grid name="glc">mpas.gis1to10km</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
+
     <model_grid alias="f09_g16_g" compset="_MALI">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
@@ -4654,6 +4675,21 @@
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_r05_mono.200602.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_r05_mono.200602.nc</map>
     </gridmap>
+
+    <gridmap glc_grid="mpas.gis1to10km" lnd_grid="ne30pg2">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10km_mono.200602.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10km_bilin.200602.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne30pg2_mono.200602.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne30pg2_mono.200602.nc</map>
+    </gridmap>
+
+    <gridmap glc_grid="mpas.gis1to10km" lnd_grid="ne120pg2">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_gis1to10km_mono.200602.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_gis1to10km_bilin.200602.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne120pg2_mono.200602.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne120pg2_mono.200602.nc</map>
+    </gridmap>
+
 
     <gridmap glc_grid="mpas.gis1to10km" ocn_grid="oEC60to30v3">
       <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_gis1to10km_aave.200602.nc</map>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -4561,6 +4561,12 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_oEC60to30v3_smoothed.r150e300.190812.nc</map>
     </gridmap>
 
+    <!-- placeholder for new r0125 runoff files -->
+    <gridmap ocn_grid="EC30to60E2r2" rof_grid="r0125">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r0125_to_EC30to60E2r2_smoothed.r150e300.201005.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_EC30to60E2r2_smoothed.r150e300.201005.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="oEC60to30wLI" rof_grid="r05">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30wLI_smoothed.r300e600.160926.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30wLI_smoothed.r300e600.160926.nc</map>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -4685,7 +4685,7 @@
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_r05_mono.200602.nc</map>
     </gridmap>
 
-    <gridmap glc_grid="mpas.gis1to10km" lnd_grid="ne30pg2">
+    <gridmap glc_grid="mpas.gis1to10km" lnd_grid="ne30np4.pg2">
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10km_mono.200602.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10km_bilin.200602.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10km_to_ne30pg2_mono.200602.nc</map>

--- a/components/elm/bld/ELMBuildNamelist.pm
+++ b/components/elm/bld/ELMBuildNamelist.pm
@@ -2132,12 +2132,12 @@ sub setup_logic_glacier {
   # to also respond to GLC_TWO_WAY_COUPLING, by not bothering to send / map
   # these fields - so we want to ensure that CLM is truly listening to this
   # shared xml variable and not overriding it)
-  my $var = "glc_do_dynglacier";
-  my $val = logical_to_fortran($envxml_ref->{$clm_upvar});
-  add_default($opts->{'test'}, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'val'=>$val);
-  if (lc($nl->get_value($var)) ne lc($val)) {
-    fatal_error("glc_do_dynglacier can only be set via the env variable $clm_upvar: it can NOT be set in user_nl_clm\n");
-  }
+  #  my $var = "glc_do_dynglacier";
+  #  my $val = logical_to_fortran($envxml_ref->{$clm_upvar});
+  #  add_default($opts->{'test'}, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'val'=>$val);
+  #  if (lc($nl->get_value($var)) ne lc($val)) {
+  #    fatal_error("glc_do_dynglacier can only be set via the env variable $clm_upvar: it can NOT be set in user_nl_clm\n");
+  #  }
   
   my $var = "maxpatch_glcmec";
   add_default($opts->{'test'}, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'val'=>$nl_flags->{'glc_nec'} );

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -508,6 +508,8 @@ this mask will have smb calculated over the entire global land surface
 <fglcmask hgrid="0.9x1.25" glc_grid="mpas.gis20km">glc/cism/griddata/glcmaskdata_0.9x1.25_Gland5km.nc</fglcmask>  <!-- the CISM one works fine for this mesh -->
 <fglcmask hgrid="0.9x1.25" glc_grid="mpas.ais20km">lnd/clm2/griddata/glcmaskdata_0.9x1.25_60S.nc</fglcmask>
 <fglcmask hgrid="r05"      glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_0.5x0.5_GIS_AIS.nc</fglcmask>
+<fglcmask hgrid="r0125"      glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_0.125x0.125_gis1to10km.nc</fglcmask>
+<fglcmask hgrid="ne30pg2"      glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_ne30pg2_gis1to10km.nc</fglcmask>
 
 <!-- Land topo datasets (when running glc_nec) (relative to {csmdata}) -->
 <flndtopo hgrid="ne30np4"  >lnd/clm2/griddata/topodata_ne30np4_USGS_171002.nc</flndtopo>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -166,7 +166,7 @@ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 </finidat>
 
 <fsurdat hgrid="ne30np4.pg2"   sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_c201210.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc</fsurdat>
 
 <!-- HOMME grid ne120 resolution -->
 
@@ -237,7 +237,7 @@ lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr2010_c191025.nc</fsurdat>
 <fsurdat hgrid="r05"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr2010_c191025.nc</fsurdat>
 <fsurdat hgrid="ne30np4.pg2"   sim_year="2010" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr2010_c201210.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr2000_c210402.nc</fsurdat>
 
 <!-- for present day simulations - year 2000 -->
 <fsurdat hgrid="360x720cru"   sim_year="2000" use_crop=".false." >
@@ -263,7 +263,7 @@ lnd/clm2/surfdata_map/surfdata_10x15_simyr2000_c130927.nc</fsurdat>
 <fsurdat hgrid="ne30np4"     sim_year="2000" >
 lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2000_c190730.nc</fsurdat>
 <fsurdat hgrid="ne30np4.pg2" sim_year="2000" >
-lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr2000_c190408.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr2000_c210402.nc</fsurdat>
 <fsurdat hgrid="ne120np4"     sim_year="2000" >
 lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2000_c160309.nc</fsurdat>
 <fsurdat hgrid="ne16np4"      sim_year="2000" use_crop=".false." >
@@ -508,8 +508,8 @@ this mask will have smb calculated over the entire global land surface
 <fglcmask hgrid="0.9x1.25" glc_grid="mpas.gis20km">glc/cism/griddata/glcmaskdata_0.9x1.25_Gland5km.nc</fglcmask>  <!-- the CISM one works fine for this mesh -->
 <fglcmask hgrid="0.9x1.25" glc_grid="mpas.ais20km">lnd/clm2/griddata/glcmaskdata_0.9x1.25_60S.nc</fglcmask>
 <fglcmask hgrid="r05"      glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_0.5x0.5_GIS_AIS.nc</fglcmask>
-<fglcmask hgrid="r0125"    glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmask_r0125_GIS_AIS.210407.nc</fglcmask>
-<fglcmask hgrid="ne30np4.pg2"  glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmask_ne30pg2_GIS_AIS.210407.nc</fglcmask>
+<fglcmask hgrid="r0125"    glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_r0125_GIS_AIS.210407.nc</fglcmask>
+<fglcmask hgrid="ne30np4.pg2"  glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_ne30pg2_GIS_AIS.210407.nc</fglcmask>
 
 <!-- Land topo datasets (when running glc_nec) (relative to {csmdata}) -->
 <flndtopo hgrid="ne30np4"  >lnd/clm2/griddata/topodata_ne30np4_USGS_171002.nc</flndtopo>
@@ -518,7 +518,8 @@ this mask will have smb calculated over the entire global land surface
 <flndtopo hgrid="48x96"     >lnd/clm2/griddata/topodata_48x96_USGS_070110.nc</flndtopo>
 <flndtopo hgrid="r05"       >lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609.nc</flndtopo>
 <flndtopo hgrid="r0125"     >lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr1850_c190730.nc</flndtopo>
-<flndtopo hgrid="ne30np4.pg2"      >lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_c201210.nc</flndtopo>
+<!--flndtopo hgrid="ne30np4.pg2"      >lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_c201210.nc</flndtopo-->
+<flndtopo hgrid="ne30np4.pg2"      >lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc</flndtopo>
 
 <!-- SNICAR (SNow, ICe, and Aerosol Radiative model) datasets -->
 <!--  ***********  Resolution independent:   ***********  -->

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -508,8 +508,8 @@ this mask will have smb calculated over the entire global land surface
 <fglcmask hgrid="0.9x1.25" glc_grid="mpas.gis20km">glc/cism/griddata/glcmaskdata_0.9x1.25_Gland5km.nc</fglcmask>  <!-- the CISM one works fine for this mesh -->
 <fglcmask hgrid="0.9x1.25" glc_grid="mpas.ais20km">lnd/clm2/griddata/glcmaskdata_0.9x1.25_60S.nc</fglcmask>
 <fglcmask hgrid="r05"      glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_0.5x0.5_GIS_AIS.nc</fglcmask>
-<fglcmask hgrid="r0125"    glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_r0125_GIS1to10km.nc</fglcmask>
-<fglcmask hgrid="ne30np4.pg2"  glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_ne30pg2_GIS1to10km.nc</fglcmask>
+<fglcmask hgrid="r0125"    glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmask_r0125_GIS_AIS.210407.nc</fglcmask>
+<fglcmask hgrid="ne30np4.pg2"  glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmask_ne30pg2_GIS_AIS.210407.nc</fglcmask>
 
 <!-- Land topo datasets (when running glc_nec) (relative to {csmdata}) -->
 <flndtopo hgrid="ne30np4"  >lnd/clm2/griddata/topodata_ne30np4_USGS_171002.nc</flndtopo>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -508,8 +508,8 @@ this mask will have smb calculated over the entire global land surface
 <fglcmask hgrid="0.9x1.25" glc_grid="mpas.gis20km">glc/cism/griddata/glcmaskdata_0.9x1.25_Gland5km.nc</fglcmask>  <!-- the CISM one works fine for this mesh -->
 <fglcmask hgrid="0.9x1.25" glc_grid="mpas.ais20km">lnd/clm2/griddata/glcmaskdata_0.9x1.25_60S.nc</fglcmask>
 <fglcmask hgrid="r05"      glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_0.5x0.5_GIS_AIS.nc</fglcmask>
-<fglcmask hgrid="r0125"      glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_0.125x0.125_gis1to10km.nc</fglcmask>
-<fglcmask hgrid="ne30pg2"      glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_ne30pg2_gis1to10km.nc</fglcmask>
+<fglcmask hgrid="r0125"    glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_r0125_GIS1to10km.nc</fglcmask>
+<fglcmask hgrid="ne30np4.pg2"  glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_ne30pg2_GIS1to10km.nc</fglcmask>
 
 <!-- Land topo datasets (when running glc_nec) (relative to {csmdata}) -->
 <flndtopo hgrid="ne30np4"  >lnd/clm2/griddata/topodata_ne30np4_USGS_171002.nc</flndtopo>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -517,6 +517,8 @@ this mask will have smb calculated over the entire global land surface
 <flndtopo hgrid="1.9x2.5"   >lnd/clm2/griddata/topodata_1.9x2.5_USGS_061130.nc</flndtopo>
 <flndtopo hgrid="48x96"     >lnd/clm2/griddata/topodata_48x96_USGS_070110.nc</flndtopo>
 <flndtopo hgrid="r05"       >lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609.nc</flndtopo>
+<flndtopo hgrid="r0125"     >lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr1850_c190730.nc</flndtopo>
+<flndtopo hgrid="ne30np4.pg2"      >lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_c201210.nc</flndtopo>
 
 <!-- SNICAR (SNow, ICe, and Aerosol Radiative model) datasets -->
 <!--  ***********  Resolution independent:   ***********  -->


### PR DESCRIPTION
Adds grid support for:
* ne30pg2_oECv3_gis1to10
* ne30pg2_r0125_EC30to60E2r2_gis1to10
* ne120pg2_r0125_EC30to60E2r2_gis1to10

Brings in all necessary mapping/domain files, and changes some ELM fsurdat files to include new versions with elevation class information.

[NML]
[BFB] for all currently tested configurations
