### PR TITLE
Add surface pressure to grad ssh

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -403,7 +403,7 @@ contains
                              vertAleTransportTop, tendVel, err)
 
       ! Add pressure gradient
-      call ocn_vel_pressure_grad_tend(ssh, pressure, &
+      call ocn_vel_pressure_grad_tend(ssh, pressure, surfacePressure, &
                                montgomeryPotential, zMid, &
                                density, potentialDensity, &
                                indxTemp, indxSalt, activeTracers, &
@@ -414,7 +414,7 @@ contains
       call ocn_compute_tidal_potential_forcing(err)
       if (config_time_integrator == 'RK4') then
         ! for split explicit, tidal forcing is added in barotropic subcycles
-        call ocn_vel_tidal_potential_tend(ssh, tendVel, err) 
+        call ocn_vel_tidal_potential_tend(ssh,surfacePressure, tendVel, err)
       endif
 
       ! Add horizontal mixing

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_pressure_grad.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_pressure_grad.F
@@ -93,7 +93,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_pressure_grad_tend(ssh, pressure, &
+   subroutine ocn_vel_pressure_grad_tend(ssh, pressure, surfacePressure, &
                                   montgomeryPotential, zMid, &
                                   density, potentialDensity, &
                                   indxT, indxS, tracers, &
@@ -111,7 +111,8 @@ contains
          indxS                !< [in] tracer array index for salt
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         ssh                  !< [in] sea surface height
+         ssh,                &!< [in] sea surface height
+         surfacePressure      !< [in] surface pressure
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          pressure,            &!< [in] Pressure field
@@ -192,7 +193,7 @@ contains
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
          !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, &
-         !$acc            tend, edgeMask, ssh) &
+         !$acc            tend, edgeMask, ssh,surfacePressure) &
          !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax)
 #else
          !$omp parallel
@@ -208,8 +209,10 @@ contains
 
             do k=kMin,kMax
                tend(k,iEdge) = tend(k,iEdge) - &
-                               gravity*edgeMask(k,iEdge)*invdcEdge* &
-                               (ssh(cell2) - ssh(cell1))
+                               edgeMask(k,iEdge)*invdcEdge* &
+                               (  gravity*(ssh(cell2) - ssh(cell1)) &
+                                + density0Inv*(  surfacePressure(cell2) &
+                                               - surfacePressure(cell1)) )
             end do
          end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
@@ -65,7 +65,8 @@ module ocn_vel_tidal_potential
    !*** physical constants
    real (kind=RKIND) ::  &
       betaSelfAttrLoad,  &! self-attraction and loading beta
-      tidalPotRamp        ! scale for ramping tidal potential
+      tidalPotRamp, &     ! scale for ramping tidal potential
+      rho0gInv            ! 1 / rho0 / gravity
 
    !*** eventually these will be private module arrays and 
    !*** not in the forcing pool so retain pointers here as placeholders
@@ -110,14 +111,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_tidal_potential_tend(ssh, tend, err)!{{{
+   subroutine ocn_vel_tidal_potential_tend(ssh, surfacePressure, tend, err)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         ssh             !< [in] Sea surface height
+         ssh, surfacePressure             !< [in] Sea surface height
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -156,7 +157,7 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, edgeMask, &
-      !$acc            tidalPotEta, ssh, tend) &
+      !$acc            tidalPotEta, ssh, surfacePressure, tend) &
       !$acc    private(cell1, cell2, invdcEdge, potentialGrad, k, kMax)
 #else
       !$omp parallel do schedule(runtime) &
@@ -169,9 +170,10 @@ contains
          kMax = maxLevelEdgeTop(iEdge)
 
          potentialGrad = - gravity*invdcEdge* &
-                         (tidalPotEta(cell2) - tidalPotEta(cell1) + &
-                          betaSelfAttrLoad* &
-                          (ssh(cell2) - ssh(cell1)))
+            (  tidalPotEta(cell2) - tidalPotEta(cell1) &
+             + betaSelfAttrLoad &
+              *((ssh(cell2) - ssh(cell1)) &
+                + rho0gInv*(surfacePressure(cell2) - surfacePressure(cell1))))
 
          do k=1,kMax
             tend(k,iEdge) = tend(k,iEdge) - &
@@ -320,7 +322,7 @@ contains
       tidalPotentialOff = .true.
       betaSelfAttrLoad  = 0.0_RKIND
       tidalPotRamp      = 1.0e20_RKIND
- 
+      rho0gInv = 1.0_RKIND / rho_sw / gravity
       !*** If tidal potential turned on, set all relevant variables
 
       if (config_use_tidal_potential_forcing) then


### PR DESCRIPTION
This PR adds a the contribution of surface pressure to the (grad ssh) term. 

This does not affect the default E3SM pressure gradient configuration (`config_pressure_gradient_type = 'Jacobian_from_TS'`), which is for layered models, and already starts with the surface pressure when computing pressure down the column. 

The grad ssh option (`config_pressure_gradient_type = 'ssh_gradient'`) is used for single-layer tide simulations for ICOM. It was missing the surface pressure, which was required to run with land ice cavities, but will also be needed to include atmospheric and sea ice pressure contributions. No new name-list options are added.

[BFB]