### PR TITLE
Fix MMF damping and variance transport test mod

### DIFF
--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_VT/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_VT/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange --append -id CAM_CONFIG_OPTS -val " -use_MMF_VT -cppdefs ' -DMMF_DIR_NS -DMMF_VT_KMAX=4 ' "
+./xmlchange --append -id CAM_CONFIG_OPTS -val " -use_MMF_VT "

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_VT/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_VT/user_nl_eam
@@ -1,1 +1,1 @@
-MMF_VT_wn_max = 4
+mmf_vt_wn_max = 4

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_VT/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/mmf_use_VT/user_nl_eam
@@ -1,0 +1,1 @@
+MMF_VT_wn_max = 4


### PR DESCRIPTION
This fixes two loosely related issues that cropped up in MMF tests using intel with variance transport enabled. One issue has to do with a bug in the C++ damping routine that only affects tests with intel. The other change has to do with updating the VT test mod to use the namelist variable for the filtered variance transport mode. 

[BFB]