### PR TITLE
GPU port and reorganization of ocean tracer advection

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -20,9 +20,6 @@
 		<dim name="maxEdges2" units="unitless"
 			 description="Two times the largest number of edges any polygon within the grid has."
 		/>
-		<dim name="nAdvectionCells" definition="maxEdges2+0" units="unitless"
-			 description="The largest number of advection cells for any edge."
-		/>
 		<dim name="nVertices" units="unitless"
 			 description="The total number of cells in the dual grid. Also the number of corners in the primary grid."
 		/>
@@ -2232,30 +2229,6 @@
 		<var name="oceanFracObserved" type="real" dimensions="nCells" units="unitless"
 			 description="fraction of each cell containing ocean, used to determine which cells are culled as land."
 			 packages="initMode"
-		/>
-		<var name="derivTwo" type="real" dimensions="maxEdges2 TWO nEdges" units="m^{-2}"
-			 description="Value of the second derivative of the polynomial used for reconstruction of cell center quantities at edges."
-			 packages="forwardMode;analysisMode"
-		/>
-		<var name="advCoefs" type="real" dimensions="nAdvectionCells nEdges" units="m"
-			 description="Weighting coefficients used for reconstruction of cell center quantities at edges. Used in advection routines."
-			 packages="forwardMode;analysisMode"
-		/>
-		<var name="advCoefs3rd" type="real" dimensions="nAdvectionCells nEdges" units="m"
-			 description="Wegihting coefficients used for reconstruction of cell center quantities at edges. Used in advection routines."
-			 packages="forwardMode;analysisMode"
-		/>
-		<var name="advCellsForEdge" type="integer" dimensions="nAdvectionCells nEdges" units="unitless"
-			 description="List of cells used to reconstruct a cell quantity at an edge. Used in advection routines."
-			 packages="forwardMode;analysisMode"
-		/>
-		<var name="nAdvCellsForEdge" type="integer" dimensions="nEdges" units="unitless"
-			 description="Number of cells used in reconstruction of cell center quantities at an edge. Used in advection routines."
-			 packages="forwardMode;analysisMode"
-		/>
-		<var name="highOrderAdvectionMask" type="integer" dimensions="nVertLevels nEdges" units="unitless"
-			 description="Mask for high order advection. Values are 1 if high order is used, and 0 if not."
-			 packages="forwardMode;analysisMode"
 		/>
 		<var name="coeffs_reconstruct" type="real" dimensions="R3 maxEdges nCells" units="unitless"
 			 description="Coefficients to reconstruct velocity vectors at cells centers."

--- a/components/mpas-ocean/src/ocean.cmake
+++ b/components/mpas-ocean/src/ocean.cmake
@@ -66,6 +66,7 @@ list(APPEND RAW_SOURCES
   core_ocean/shared/mpas_ocn_tracer_advection.F
   core_ocean/shared/mpas_ocn_tracer_advection_mono.F
   core_ocean/shared/mpas_ocn_tracer_advection_std.F
+  core_ocean/shared/mpas_ocn_tracer_advection_vert.F
   core_ocean/shared/mpas_ocn_tracer_advection_shared.F
   core_ocean/shared/mpas_ocn_tracer_nonlocalflux.F
   core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F

--- a/components/mpas-ocean/src/ocean.cmake
+++ b/components/mpas-ocean/src/ocean.cmake
@@ -66,6 +66,7 @@ list(APPEND RAW_SOURCES
   core_ocean/shared/mpas_ocn_tracer_advection.F
   core_ocean/shared/mpas_ocn_tracer_advection_mono.F
   core_ocean/shared/mpas_ocn_tracer_advection_std.F
+  core_ocean/shared/mpas_ocn_tracer_advection_shared.F
   core_ocean/shared/mpas_ocn_tracer_nonlocalflux.F
   core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
   core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -39,6 +39,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_tracer_advection.o \
 	   mpas_ocn_tracer_advection_mono.o \
 	   mpas_ocn_tracer_advection_std.o \
+	   mpas_ocn_tracer_advection_shared.o \
 	   mpas_ocn_tracer_nonlocalflux.o \
 	   mpas_ocn_tracer_short_wave_absorption.o \
 	   mpas_ocn_tracer_short_wave_absorption_jerlov.o \
@@ -122,11 +123,13 @@ mpas_ocn_tracer_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_tracer_hmix_del4.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_advection.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_tracer_advection_mono.o mpas_ocn_tracer_advection_std.o
+mpas_ocn_tracer_advection.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_tracer_advection_mono.o mpas_ocn_tracer_advection_std.o mpas_ocn_tracer_advection_shared.o
 
-mpas_ocn_tracer_advection_mono.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
+mpas_ocn_tracer_advection_mono.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_tracer_advection_shared.o
 
-mpas_ocn_tracer_advection_std.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_tracer_advection_std.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_tracer_advection_shared.o
+
+mpas_ocn_tracer_advection_shared.o: mpas_ocn_mesh.o
 
 mpas_ocn_tracer_hmix_redi.o: mpas_ocn_constants.o mpas_ocn_config.o
 

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -39,6 +39,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_tracer_advection.o \
 	   mpas_ocn_tracer_advection_mono.o \
 	   mpas_ocn_tracer_advection_std.o \
+	   mpas_ocn_tracer_advection_vert.o \
 	   mpas_ocn_tracer_advection_shared.o \
 	   mpas_ocn_tracer_nonlocalflux.o \
 	   mpas_ocn_tracer_short_wave_absorption.o \
@@ -123,11 +124,13 @@ mpas_ocn_tracer_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_tracer_hmix_del4.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_advection.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_tracer_advection_mono.o mpas_ocn_tracer_advection_std.o mpas_ocn_tracer_advection_shared.o
+mpas_ocn_tracer_advection.o: mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_tracer_advection_mono.o mpas_ocn_tracer_advection_std.o mpas_ocn_tracer_advection_vert.o mpas_ocn_tracer_advection_shared.o
 
-mpas_ocn_tracer_advection_mono.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_tracer_advection_shared.o
+mpas_ocn_tracer_advection_mono.o: mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_tracer_advection_vert.o mpas_ocn_tracer_advection_shared.o
 
-mpas_ocn_tracer_advection_std.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_tracer_advection_shared.o
+mpas_ocn_tracer_advection_std.o: mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_tracer_advection_vert.o mpas_ocn_tracer_advection_shared.o
+
+mpas_ocn_tracer_advection_vert.o: mpas_ocn_mesh.o mpas_ocn_config.o
 
 mpas_ocn_tracer_advection_shared.o: mpas_ocn_mesh.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
@@ -31,7 +31,6 @@ module ocn_init_routines
    use mpas_rbf_interpolation
    use mpas_vector_operations
    use mpas_vector_reconstruction
-   use mpas_tracer_advection_helpers
 
    use ocn_diagnostics
    use ocn_diagnostics_variables
@@ -103,7 +102,7 @@ contains
       integer :: i, iEdge, iCell, k
       integer :: err1
 
-      integer, dimension(:,:), pointer :: highOrderAdvectionMaskTmp, boundaryCellTmp
+      integer, dimension(:,:), pointer :: boundaryCellTmp
       integer, dimension(:,:), pointer :: edgeSignOnCellTmp, edgeSignOnVertexTmp
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
@@ -126,22 +125,11 @@ contains
 
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
-      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', highOrderAdvectionMaskTmp)
       call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCellTmp)
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
 
-      call mpas_initialize_deriv_two(meshPool, derivTwo, err)
-      call mpas_tracer_advection_coefficients(meshPool, &
-          config_horiz_tracer_adv_order, derivTwo, advCoefs, &
-          advCoefs3rd, nAdvCellsForEdge, advCellsForEdge, &
-          err1, maxLevelCell, highOrderAdvectionMaskTmp, &
-          boundaryCellTmp)
-      err = ior(err, err1)
-
-      ! Update ocn_mesh variables for highOrderAdvectionMask
-      highOrderAdvectionMask = real(highOrderAdvectionMaskTmp, kind=RKIND)
 
       if (.not. config_do_restart) then
          do iCell=1,nCells

--- a/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
@@ -44,6 +44,12 @@ module ocn_mesh
    !----------------------------------------------------------------------------
    !{{{
 
+   logical, public :: &
+      onSphere        ! this mesh is on the sphere
+
+   real (kind=RKIND), public :: &
+      sphereRadius    ! radius of sphere for spherical meshes
+
    integer, public :: &! mesh, array sizes
       nCellsAll, &! total number of local (owned+halo) cells in primary
       nEdgesAll, &! total number of local edge midpoints
@@ -213,6 +219,12 @@ contains
          maxDensityLocal, maxDensityGlobal ! temps for mesh density
 
       ! scalar pointers for retrieval, but convert to actual scalars in struct
+      logical, pointer :: &
+         on_a_sphere
+
+      real (kind=RKIND), pointer :: &
+         sphere_radius
+
       integer, pointer :: &! mesh dimensions
          nCellsTmp, &!
          nEdgesTmp, &!
@@ -271,6 +283,12 @@ contains
       ! many variables already initialized based on read of mesh file
       !-----------------------------------------------------------------
 
+      ! set all mesh properties
+      call mpas_pool_get_config(meshPool, 'on_a_sphere', &
+                                           on_a_sphere)
+      call mpas_pool_get_config(meshPool, 'sphere_radius', &
+                                           sphere_radius)
+
       ! set all mesh dimensions
       call mpas_pool_get_dimension(meshPool, 'nCells', &
                                    nCellsTmp)
@@ -298,6 +316,8 @@ contains
                                    nVerticesArrayTmp)
 
       ! translate scalar pointers to scalars in new mesh structure
+      onSphere = on_a_sphere
+      sphereRadius = sphere_radius
       maxEdges = maxEdgesTmp
       maxEdges2 = maxEdges2Tmp
       vertexDegree = vertexDegreeTmp
@@ -576,6 +596,8 @@ contains
       !-----------------------------------------------------------------
 
          !$acc enter data copyin( &
+         !$acc                   onSphere,                 &
+         !$acc                   sphereRadius,             &
          !$acc                   nCellsAll,                &
          !$acc                   nEdgesAll,                &
          !$acc                   nVerticesAll,             &
@@ -711,7 +733,9 @@ contains
       ! First remove data from the device. Must remove components first,
       ! then remove the mesh type itself.
 
-      !$acc exit data delete(nCellsAll,         &
+      !$acc exit data delete(onSphere,          &
+      !$acc                  sphereRadius,      &
+      !$acc                  nCellsAll,         &
       !$acc                  nEdgesAll,         &
       !$acc                  nVerticesAll,      &
       !$acc                  nCellsOwned,       &
@@ -805,6 +829,8 @@ contains
       !$acc                  edgeAreaFractionOfCell)
 
       ! Reset all scalars to zero
+      onSphere  = .false.
+      sphereRadius = 0.0_RKIND
       nCellsAll = 0
       nEdgesAll = 0
       nVerticesAll = 0
@@ -1161,7 +1187,9 @@ contains
       ! NOTE: if we end up computing some fields on the device during
       !       init, the update must go the opposite direction (update host)
 
-      !$acc update device(nCellsAll,                &
+      !$acc update device(onSphere,                 &
+      !$acc               sphereRadius,             &
+      !$acc               nCellsAll,                &
       !$acc               nEdgesAll,                &
       !$acc               nVerticesAll,             &
       !$acc               nCellsOwned,              &

--- a/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
@@ -61,8 +61,7 @@ module ocn_mesh
       maxEdges2, &! 2x the largest number of edges any polygon has
       vertexDegree, &! number of cells or edges touching each vertex
       nVertLevels, &! number of vertical levels
-      nVertLevelsP1, &! number of vertical interfaces (levels plus one)
-      nAdvectionCells  ! largest number of advection cells for any edge
+      nVertLevelsP1 ! number of vertical interfaces (levels plus one)
 
    integer, public, dimension(:), allocatable :: &
       nCellsHalo, &! number of owned+halo(n) cells in local domain
@@ -82,7 +81,6 @@ module ocn_mesh
       maxLevelEdgeBot, &! max ocean level at bottom of edge column
       maxLevelVertexTop, &! max ocean level at top    of each vertex
       maxLevelVertexBot, &! max ocean level at bottom of each vertex
-      nAdvCellsForEdge, &! number of cells contrib to advection at edge
       indexToCellID, &! global ID of each local cell
       indexToEdgeID, &! global ID of each local edge
       indexToVertexID    ! global ID of each local vertex
@@ -96,8 +94,7 @@ module ocn_mesh
       verticesOnCell, &! index of vertices connected to each cell
       cellsOnVertex, &! index of cells connected to each vertex
       edgesOnVertex, &! index of edges connected to each vertex
-      kiteIndexOnCell, &! index of kite associated with each cell
-      advCellsForEdge  ! index of cells contrib to advective flux at edge
+      kiteIndexOnCell ! index of kite associated with each cell
 
    real(kind=RKIND), public, dimension(:), pointer :: &
       latCell, &! latitude  of cell centers
@@ -143,20 +140,16 @@ module ocn_mesh
       boundaryCell, &! mask for boundary cells    at each level
       boundaryVertex, &! mask for boundary vertices at each level
       edgeSignOnCell, &! sign of edge contributions to a cell
-      edgeSignOnVertex, &! sign of edge contributions to a vertex
-      highOrderAdvectionMask ! mask for high order advection contributions
+      edgeSignOnVertex ! sign of edge contributions to a vertex
 
    real(kind=RKIND), public, dimension(:, :), pointer :: &
       weightsOnEdge, &! weights on each edge
       kiteAreasOnVertex, &! real (vertexDegree nVertices)
       edgeTangentVectors, &! tangent unit vector at edge
       edgeNormalVectors, &! normal  unit vector at edge
-      localVerticalUnitVectors, &! local unit vector iin vertical
-      advCoefs, &! mesh-based advection coefficients
-      advCoefs3rd         ! mesh-based advection coeffs for high order
+      localVerticalUnitVectors ! local unit vector iin vertical
 
    real(kind=RKIND), public, dimension(:, :, :), pointer :: &
-      derivTwo, &! 2nd derivative of edge reconstruction polynomial
       cellTangentPlane, &! two vectors defining tangent plane at cell center
       coeffs_reconstruct  ! coeffs for reconstructing vectors at cell centers
 
@@ -233,8 +226,7 @@ contains
          maxEdges2Tmp, &!
          vertexDegreeTmp, &!
          nVertLevelsTmp, &!
-         nVertLevelsP1Tmp, &!
-         nAdvectionCellsTmp  !
+         nVertLevelsP1Tmp !
 
       ! temporary pointers for converting index arrays
       integer, dimension(:), pointer :: &
@@ -248,7 +240,6 @@ contains
          edgeMaskTmp, &
          vertexMaskTmp, &
          cellMaskTmp, &
-         highOrderAdvectionMaskTmp, &
          edgeSignOnCellTmp, &
          edgeSignOnVertexTmp, &
          boundaryEdgeTmp, &
@@ -306,8 +297,6 @@ contains
                                    nVertLevelsTmp)
       call mpas_pool_get_dimension(meshPool, 'nVertLevelsP1', &
                                    nVertLevelsP1Tmp)
-      call mpas_pool_get_dimension(meshPool, 'nAdvectionCells', &
-                                nAdvectionCellsTmp)
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', &
                                    nCellsArrayTmp)
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', &
@@ -323,7 +312,6 @@ contains
       vertexDegree = vertexDegreeTmp
       nVertLevels = nVertLevelsTmp
       nVertLevelsP1 = nVertLevelsP1Tmp
-      nAdvectionCells = nAdvectionCellsTmp
 
       ! convert previous index limits into new halo definitions
       nCellsAll = nCellsTmp
@@ -376,8 +364,6 @@ contains
                                maxLevelVertexTop)
       call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', &
                                maxLevelVertexBot)
-      call mpas_pool_get_array(meshPool, 'nAdvCellsForEdge', &
-                               nAdvCellsForEdge)
       call mpas_pool_get_array(meshPool, 'indexToCellID', &
                                indexToCellID)
       call mpas_pool_get_array(meshPool, 'indexToEdgeID', &
@@ -402,8 +388,6 @@ contains
                                edgesOnVertex)
       call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', &
                                kiteIndexOnCell)
-      call mpas_pool_get_array(meshPool, 'advCellsForEdge', &
-                               advCellsForEdge)
 
       ! now set a number of physics and numerical properties of mesh
       call mpas_pool_get_array(meshPool, 'latCell', &
@@ -479,12 +463,6 @@ contains
                                edgeNormalVectors)
       call mpas_pool_get_array(meshPool, 'localVerticalUnitVectors', &
                                localVerticalUnitVectors)
-      call mpas_pool_get_array(meshPool, 'advCoefs', &
-                               advCoefs)
-      call mpas_pool_get_array(meshPool, 'advCoefs3rd', &
-                               advCoefs3rd)
-      call mpas_pool_get_array(meshPool, 'derivTwo', &
-                               derivTwo)
       call mpas_pool_get_array(meshPool, 'cellTangentPlane', &
                                cellTangentPlane)
       call mpas_pool_get_array(meshPool, 'coeffs_reconstruct', &
@@ -499,8 +477,6 @@ contains
                                vertexMaskTmp)
       call mpas_pool_get_array(meshPool, 'cellMask', &
                                cellMaskTmp)
-      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', &
-                               highOrderAdvectionMaskTmp)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
                                edgeSignOnCellTmp)
       call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
@@ -521,7 +497,6 @@ contains
             boundaryVertex(nVertLevels, nVerticesAll+1), &
             edgeSignOnCell(maxEdges, nCellsAll+1), &
             edgeSignOnVertex(maxEdges, nVerticesAll+1), &
-            highOrderAdvectionMask(nVertLevels, nEdgesAll+1), &
             invAreaCell(nCellsAll+1))
 
       !-----------------------------------------------------------------
@@ -563,8 +538,6 @@ contains
       do k = 1, nVertLevels
          edgeMaskTmp(k, n) = nint(edgeMask(k,n))
          boundaryEdgeTmp(k, n) = nint(boundaryEdge(k,n))
-         highOrderAdvectionMaskTmp(k,n) = &
-            real(highOrderAdvectionMask(k,n))
       end do
       end do
 
@@ -609,7 +582,6 @@ contains
          !$acc                   vertexDegree,             &
          !$acc                   nVertLevels,              &
          !$acc                   nVertLevelsP1,            &
-         !$acc                   nAdvectionCells,          &
          !$acc                   nEdgesHalo,               &
          !$acc                   nCellsHalo,               &
          !$acc                   nVerticesHalo,            &
@@ -625,7 +597,6 @@ contains
          !$acc                   maxLevelEdgeBot,          &
          !$acc                   maxLevelVertexTop,        &
          !$acc                   maxLevelVertexBot,        &
-         !$acc                   nAdvCellsForEdge,         &
          !$acc                   indexToCellID,            &
          !$acc                   indexToEdgeID,            &
          !$acc                   indexToVertexID,          &
@@ -638,7 +609,6 @@ contains
          !$acc                   cellsOnVertex,            &
          !$acc                   edgesOnVertex,            &
          !$acc                   kiteIndexOnCell,          &
-         !$acc                   advCellsForEdge,          &
          !$acc                   latCell,                  &
          !$acc                   lonCell,                  &
          !$acc                   xCell,                    &
@@ -678,15 +648,11 @@ contains
          !$acc                   boundaryVertex,           &
          !$acc                   edgeSignOnCell,           &
          !$acc                   edgeSignOnVertex,         &
-         !$acc                   highOrderAdvectionMask,   &
          !$acc                   weightsOnEdge,            &
          !$acc                   kiteAreasOnVertex,        &
          !$acc                   edgeTangentVectors,       &
          !$acc                   edgeNormalVectors,        &
          !$acc                   localVerticalUnitVectors, &
-         !$acc                   advCoefs,                 &
-         !$acc                   advCoefs3rd,              &
-         !$acc                   derivTwo,                 &
          !$acc                   cellTangentPlane,         &
          !$acc                   coeffs_reconstruct,       &
          !$acc                   edgeAreaFractionOfCell)
@@ -746,7 +712,6 @@ contains
       !$acc                  vertexDegree,      &
       !$acc                  nVertLevels,       &
       !$acc                  nVertLevelsP1,     &
-      !$acc                  nAdvectionCells,   &
       !$acc                  nEdgesHalo,        &
       !$acc                  nCellsHalo,        &
       !$acc                  nVerticesHalo,     &
@@ -762,7 +727,6 @@ contains
       !$acc                  maxLevelEdgeBot,   &
       !$acc                  maxLevelVertexTop, &
       !$acc                  maxLevelVertexBot, &
-      !$acc                  nAdvCellsForEdge,  &
       !$acc                  indexToCellID,     &
       !$acc                  indexToEdgeID,     &
       !$acc                  indexToVertexID,   &
@@ -775,7 +739,6 @@ contains
       !$acc                  cellsOnVertex,     &
       !$acc                  edgesOnVertex,     &
       !$acc                  kiteIndexOnCell,   &
-      !$acc                  advCellsForEdge,   &
       !$acc                  latCell,           &
       !$acc                  lonCell,           &
       !$acc                  xCell,             &
@@ -815,15 +778,11 @@ contains
       !$acc                  boundaryVertex,    &
       !$acc                  edgeSignOnCell,    &
       !$acc                  edgeSignOnVertex,  &
-      !$acc                  highOrderAdvectionMask,&
       !$acc                  weightsOnEdge,     &
       !$acc                  kiteAreasOnVertex, &
       !$acc                  edgeTangentVectors,&
       !$acc                  edgeNormalVectors, &
       !$acc                  localVerticalUnitVectors, &
-      !$acc                  advCoefs,          &
-      !$acc                  advCoefs3rd,       &
-      !$acc                  derivTwo,          &
       !$acc                  cellTangentPlane,  &
       !$acc                  coeffs_reconstruct,&
       !$acc                  edgeAreaFractionOfCell)
@@ -842,7 +801,6 @@ contains
       vertexDegree = 0
       nVertLevels = 0
       nVertLevelsP1 = 0
-      nAdvectionCells = 0
 
       ! Now nullify all pointers to invalidate fields
       ! If this becomes the only mesh structure and mesh pool is eliminated,
@@ -860,7 +818,6 @@ contains
                maxLevelEdgeBot, &
                maxLevelVertexTop, &
                maxLevelVertexBot, &
-               nAdvCellsForEdge, &
                indexToCellID, &
                indexToEdgeID, &
                indexToVertexID, &
@@ -873,7 +830,6 @@ contains
                cellsOnVertex, &
                edgesOnVertex, &
                kiteIndexOnCell, &
-               advCellsForEdge, &
                latCell, &
                lonCell, &
                xCell, &
@@ -909,9 +865,6 @@ contains
                edgeTangentVectors, &
                edgeNormalVectors, &
                localVerticalUnitVectors, &
-               advCoefs, &
-               advCoefs3rd, &
-               derivTwo, &
                cellTangentPlane, &
                coeffs_reconstruct)
 
@@ -926,7 +879,6 @@ contains
                   boundaryVertex, &
                   edgeSignOnCell, &
                   edgeSignOnVertex, &
-                  highOrderAdvectionMask, &
                   edgeAreaFractionOfCell, &
                   invAreaCell)
 
@@ -971,7 +923,6 @@ contains
          edgeMaskTmp, &
          vertexMaskTmp, &
          cellMaskTmp, &
-         highOrderAdvectionMaskTmp, &
          edgeSignOnCellTmp, &
          edgeSignOnVertexTmp, &
          boundaryEdgeTmp, &
@@ -1006,8 +957,6 @@ contains
       !                                    maxLevelVertexTop)
       !call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', &
       !                                    maxLevelVertexBot)
-      !call mpas_pool_get_array(meshPool, 'nAdvCellsForEdge',  &
-      !                                    nAdvCellsForEdge)
       !call mpas_pool_get_array(meshPool, 'indexToCellID',     &
       !                                    indexToCellID)
       !call mpas_pool_get_array(meshPool, 'indexToEdgeID',     &
@@ -1032,8 +981,6 @@ contains
       !                                    edgesOnVertex)
       !call mpas_pool_get_array(meshPool, 'kiteIndexOnCell',   &
       !                                    kiteIndexOnCell)
-      !call mpas_pool_get_array(meshPool, 'advCellsForEdge',   &
-      !                                    advCellsForEdge)
 
       ! these are also pointers that do not require updating
       ! now set a number of physics and numerical properties of mesh
@@ -1110,12 +1057,6 @@ contains
       !                                    edgeNormalVectors)
       !call mpas_pool_get_array(meshPool, 'localVerticalUnitVectors',  &
       !                                    localVerticalUnitVectors)
-      !call mpas_pool_get_array(meshPool, 'advCoefs',                  &
-      !                                    advCoefs)
-      !call mpas_pool_get_array(meshPool, 'advCoefs3rd',               &
-      !                                    advCoefs3rd)
-      !call mpas_pool_get_array(meshPool, 'derivTwo',                  &
-      !                                    derivTwo)
       !call mpas_pool_get_array(meshPool, 'cellTangentPlane',          &
       !                                    cellTangentPlane)
       !call mpas_pool_get_array(meshPool, 'coeffs_reconstruct',        &
@@ -1130,8 +1071,6 @@ contains
                                vertexMaskTmp)
       call mpas_pool_get_array(meshPool, 'cellMask', &
                                cellMaskTmp)
-      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', &
-                               highOrderAdvectionMaskTmp)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
                                edgeSignOnCellTmp)
       call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
@@ -1162,8 +1101,6 @@ contains
       do k = 1, nVertLevels
          edgeMask(k, n) = real(edgeMaskTmp(k, n), RKIND)
          boundaryEdge(k, n) = real(boundaryEdgeTmp(k, n), RKIND)
-         highOrderAdvectionMask(k, n) = &
-            real(highOrderAdvectionMaskTmp(k, n), RKIND)
       end do
       end do
 
@@ -1200,7 +1137,6 @@ contains
       !$acc               vertexDegree,             &
       !$acc               nVertLevels,              &
       !$acc               nVertLevelsP1,            &
-      !$acc               nAdvectionCells,          &
       !$acc               nEdgesHalo,               &
       !$acc               nCellsHalo,               &
       !$acc               nVerticesHalo,            &
@@ -1216,7 +1152,6 @@ contains
       !$acc               maxLevelEdgeBot,          &
       !$acc               maxLevelVertexTop,        &
       !$acc               maxLevelVertexBot,        &
-      !$acc               nAdvCellsForEdge,         &
       !$acc               indexToCellID,            &
       !$acc               indexToEdgeID,            &
       !$acc               indexToVertexID,          &
@@ -1229,7 +1164,6 @@ contains
       !$acc               cellsOnVertex,            &
       !$acc               edgesOnVertex,            &
       !$acc               kiteIndexOnCell,          &
-      !$acc               advCellsForEdge,          &
       !$acc               latCell,                  &
       !$acc               lonCell,                  &
       !$acc               xCell,                    &
@@ -1269,15 +1203,11 @@ contains
       !$acc               boundaryVertex,           &
       !$acc               edgeSignOnCell,           &
       !$acc               edgeSignOnVertex,         &
-      !$acc               highOrderAdvectionMask,   &
       !$acc               weightsOnEdge,            &
       !$acc               kiteAreasOnVertex,        &
       !$acc               edgeTangentVectors,       &
       !$acc               edgeNormalVectors,        &
       !$acc               localVerticalUnitVectors, &
-      !$acc               advCoefs,                 &
-      !$acc               advCoefs3rd,              &
-      !$acc               derivTwo,                 &
       !$acc               cellTangentPlane,         &
       !$acc               coeffs_reconstruct,       &
       !$acc               edgeAreaFractionOfCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -636,9 +636,22 @@ contains
       ! allocate and transfer data not specific to tracer groups
       allocate(normalThicknessFlux(nVertLevels, nEdgesAll+1))
 
+      !$acc enter data create(normalThicknessFlux) &
+      !$acc            copyin(layerThickness)
+      !TEMPORARY - once diagnotics module ported, these should already
+      !            be on the device
+      !$acc update device (normalTransportVelocity, layerThickEdge, &
+      !$acc                vertAleTransportTop)
+
       ! compute transport velocity to use for all tracers
+#ifdef MPAS_OPENACC
+      !$acc parallel loop collapse(2) &
+      !$acc    present(normalThicknessFlux, normalTransportVelocity, &
+      !$acc            layerThickEdge)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
+#endif
       do iEdge = 1,nEdgesAll
       do k = 1,nVertLevels
          normalThicknessFlux(k,iEdge) = &
@@ -646,8 +659,10 @@ contains
                  layerThickEdge(k, iEdge)
       end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
       !
       ! Start computation of tracer tendencies.
@@ -1023,6 +1038,9 @@ contains
             call mpas_timer_stop("TTD " // groupName)
          endif ! TTD
 
+         !$acc enter data &
+         !$acc    copyin(tracerGroup, tracerGroupTend)
+
          !
          ! Accumulate tendencies for all tracers
          ! First is the horizontal advection term
@@ -1033,6 +1051,15 @@ contains
                             normalThicknessFlux, vertAleTransportTop, &
                             layerThickness, dt, tracerGroupTend, &
                             computeBudgets)
+
+         !$acc update host (activeTracerHorizontalAdvectionEdgeFlux, &
+         !$acc              activeTracerHorizontalAdvectionTendency, &
+         !$acc              activeTracerVerticalAdvectionTopFlux, &
+         !$acc              activeTracerVerticalAdvectionTendency)
+
+         !$acc exit data &
+         !$acc    copyout(tracerGroupTend) &
+         !$acc    delete(tracerGroup)
 
          !
          ! Add horizontal tracer diffusion,
@@ -1220,6 +1247,8 @@ contains
       end if ! active only
       end if ! member is field
       end do ! loop over tracer groups
+
+      !$acc exit data delete (normalThicknessFlux, layerThickness)
 
       deallocate(normalThicknessFlux)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -1031,8 +1031,8 @@ contains
          ! routine
          call ocn_tracer_advection_tend(tracerGroup, &
                             normalThicknessFlux, vertAleTransportTop, &
-                            layerThickness, dt, meshPool, tracerGroupTend, &
-                            groupName)
+                            layerThickness, dt, tracerGroupTend, &
+                            computeBudgets)
 
          !
          ! Add horizontal tracer diffusion,

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection.F
@@ -28,8 +28,8 @@ module ocn_tracer_advection
    use ocn_tracer_advection_shared
    use ocn_tracer_advection_std
    use ocn_tracer_advection_mono
+   use ocn_tracer_advection_vert
 
-   use ocn_constants
    use ocn_config
    use ocn_mesh
 
@@ -133,7 +133,7 @@ module ocn_tracer_advection
 
       !*** local variables
 
-      integer :: errTmp ! temporary error flag
+      integer :: err1, err2, err3, err4 ! local error flags
 
       ! end preamble
       !-------------
@@ -146,28 +146,21 @@ module ocn_tracer_advection
       monotonicOn  = config_monotonic
 
       ! set all other options from submodule initialization routines
-      call ocn_tracerAdvectSharedInit(config_horiz_tracer_adv_order, err)
-
-      call ocn_tracer_advection_std_init(config_horiz_tracer_adv_order,    &
-                                         config_vert_tracer_adv_order,     &
-                                         config_coef_3rd_order,            &
-                                         config_check_tracer_monotonicity, &
-                                         errTmp)
-      call ocn_tracer_advection_mono_init(config_num_halos,                 &
-                                          config_horiz_tracer_adv_order,    &
-                                          config_vert_tracer_adv_order,     &
-                                          config_coef_3rd_order,            &
-                                          config_check_tracer_monotonicity, &
-                                          err)
+      call ocn_tracer_advection_shared_init(err1)
+      call ocn_tracer_advection_std_init   (err2)
+      call ocn_tracer_advection_mono_init  (err3)
+      call ocn_tracer_advection_vert_init  (err4)
 
       ! if an error is returned from init routines, write an error
       ! message and return a non-zero error code
-      if (err /= 0 .or. errTmp /= 0) then
+      if (err1 /= 0 .or. err2 /= 0 .or. err3 /=0 .or. err4 /= 0) then
          err = 1
          call mpas_log_write(                                 &
             'Error encountered during tracer advection init', &
             MPAS_LOG_ERR, masterOnly=.true.)
       endif
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_advection_init!}}}
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection.F
@@ -25,6 +25,7 @@ module ocn_tracer_advection
    use mpas_kind_types
    use mpas_timer
 
+   use ocn_tracer_advection_shared
    use ocn_tracer_advection_std
    use ocn_tracer_advection_mono
 
@@ -145,6 +146,8 @@ module ocn_tracer_advection
       monotonicOn  = config_monotonic
 
       ! set all other options from submodule initialization routines
+      call ocn_tracerAdvectSharedInit(config_horiz_tracer_adv_order, err)
+
       call ocn_tracer_advection_std_init(config_horiz_tracer_adv_order,    &
                                          config_vert_tracer_adv_order,     &
                                          config_coef_3rd_order,            &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_tracer_advection
 !
@@ -13,20 +13,16 @@
 !> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
 !> \date   October 2017, updated May 2019
 !> \details
-!>  This module contains initialization and driver routines for computing tracer
-!>  advection tendencies. It primarily calls submodule routines based on user
-!>  choices for advection options.
+!>  This module contains initialization and driver routines for
+!>  computing tracer advection tendencies. It primarily calls submodule
+!>  routines based on user choices for advection options.
 !
-!-------------------------------------------------------------------------------
+!-----------------------------------------------------------------------
 
 module ocn_tracer_advection
 
    ! module includes
    use mpas_kind_types
-   use mpas_derived_types
-   use mpas_pool_routines
-   use mpas_sort
-   use mpas_hash
    use mpas_timer
 
    use ocn_tracer_advection_std
@@ -34,6 +30,7 @@ module ocn_tracer_advection
 
    use ocn_constants
    use ocn_config
+   use ocn_mesh
 
    implicit none
    private
@@ -44,15 +41,14 @@ module ocn_tracer_advection
              ocn_tracer_advection_tend
 
    ! privat module variables
-   logical :: tracerAdvOn !< flag to turn on tracer advection
-   logical :: monotonicOn !< flag to choose a monotone advection scheme
-   logical :: budgetDiagsOn !< flag to compute active tracer budgets
+   logical :: tracerAdvOff  !< flag to turn off tracer advection
+   logical :: monotonicOn   !< flag to choose a monotone advection scheme
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!***********************************************************************
 
    contains
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!***********************************************************************
 !
 !  routine ocn_tracer_advection_tend
 !
@@ -61,15 +57,14 @@ module ocn_tracer_advection
 !> \date   October 2017, updated May 2019
 !> \details
 !>  This routine is the driver routine for computing tracer advection
-!>  tendencies. It simply calls submodule tendency routines based on choice of
-!>  algorithm.
+!>  tendencies. It simply calls submodule tendency routines based on
+!>  choice of algorithm.
 !
-!-------------------------------------------------------------------------------
+!-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_advection_tend(tracers, normalThicknessFlux, w,       &
-                                        layerThickness, dt, meshPool,          &
-                                        tend,    &
-                                        tracerGroupName)!{{{
+   subroutine ocn_tracer_advection_tend(tracers, normalThicknessFlux, &
+                                        w, layerThickness, dt, tend,  &
+                                        computeBudgets)!{{{
 
       !*** Input/Output parameters
 
@@ -79,88 +74,44 @@ module ocn_tracer_advection
       !*** Input parameters
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
-         tracers             !< [in] Current tracer values
+         tracers               !< [in] Current tracer values
+
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalThicknessFlux !< [in] Thickness weighted horizontal velocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         w                   !< [in] Vertical velocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickness      !< [in] Thickness field
+         normalThicknessFlux, &!< [in] Thickness weighted horiz velocity
+         w,                   &!< [in] Vertical velocity
+         layerThickness        !< [in] Thickness field
+
       real (kind=RKIND), intent(in) :: &
-         dt                  !< [in] Time step
-      type (mpas_pool_type), intent(in) :: &
-         meshPool            !< [in] Mesh information
-      character (len=*), intent(in) :: &
-         tracerGroupName     !< [in] Tracer name to check if active tracers
+         dt                    !< [in] Time step
 
-      !*** Local variables
-
-      logical :: &
+      logical, intent(in) :: &
          computeBudgets      ! flag to compute active tracer budget
-
-      real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
-         advCoefs, advCoefs3rd ! advection coefficients
-
-      integer, dimension(:), pointer, contiguous :: &
-         minLevelCell,    &! index of min level at each cell
-         maxLevelCell,    &! index of max level at each cell
-         minLevelEdgeBot, &! min level at edge with both cells active
-         maxLevelEdgeTop, &! max level at edge with both cells active
-         nAdvCellsForEdge  ! number of advective cells for each edge
-      integer, dimension(:,:), pointer, contiguous :: &!
-         highOrderAdvectionMask, &! mask for higher order contributions
-         edgeSignOnCell,  &! sign at cell edge for fluxes
-         advCellsForEdge   ! index of advective cells for each edge
 
       ! end of preamble
       !----------------
       ! begin code
 
       ! immediate return if tracer advection not selected
-      if(.not. tracerAdvOn) return
+      if (tracerAdvOff) return
 
       call mpas_timer_start("tracer adv")
-
-      ! extract pool variables
-      call mpas_pool_get_array(meshPool, 'advCoefs', advCoefs)
-      call mpas_pool_get_array(meshPool, 'advCoefs3rd', advCoefs3rd)
-      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', &
-                                          highOrderAdvectionMask)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-      call mpas_pool_get_array(meshPool, 'nAdvCellsForEdge', nAdvCellsForEdge)
-      call mpas_pool_get_array(meshPool, 'advCellsForEdge', advCellsForEdge)
-
-      ! determine whether active tracer budgets should be computed
-      computeBudgets = (budgetDiagsOn .and. tracerGroupName == 'activeTracers')
 
       ! call specific advection routine based on choice of monotonicity
       if (monotonicOn) then
          call ocn_tracer_advection_mono_tend(tend, tracers, layerThickness,    &
                                              normalThicknessFlux, w, dt,       &
-                                             advCoefs, advCoefs3rd,            &
-                                             nAdvCellsForEdge, advCellsForEdge,&
-                                             minLevelCell, maxLevelCell,       &
-                                             minLevelEdgeBot, maxLevelEdgeTop, &
-                                             highOrderAdvectionMask,           &
-                                             edgeSignOnCell, meshPool,         &
                                              computeBudgets)
 
       else
-         call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &
-            nAdvCellsForEdge, advCellsForEdge, normalThicknessFlux, w, layerThickness, &
-            layerThickness, dt, meshPool, tend, minLevelCell, maxLevelCell, &
-            minLevelEdgeBot, maxLevelEdgeTop, highOrderAdvectionMask, edgeSignOnCell)
+         call ocn_tracer_advection_std_tend(tracers, normalThicknessFlux, &
+                                            w, layerThickness, dt, tend)
       endif
 
       call mpas_timer_stop("tracer adv")
 
    end subroutine ocn_tracer_advection_tend!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!***********************************************************************
 !
 !  routine ocn_tracer_advection_init
 !
@@ -171,7 +122,7 @@ module ocn_tracer_advection
 !>  This routine is the driver routine for initializing various tracer
 !>  advection choices and variables.
 !
-!-------------------------------------------------------------------------------
+!-----------------------------------------------------------------------
 
    subroutine ocn_tracer_advection_init(err)!{{{
 
@@ -190,17 +141,21 @@ module ocn_tracer_advection
       err = 0 ! initialize error code to success
 
       ! set some basic flags for options
-      tracerAdvOn = .not. config_disable_tr_adv
-      monotonicOn = config_monotonic
-      budgetDiagsOn = config_compute_active_tracer_budgets
+      tracerAdvOff = config_disable_tr_adv
+      monotonicOn  = config_monotonic
 
       ! set all other options from submodule initialization routines
-      call ocn_tracer_advection_std_init(config_horiz_tracer_adv_order, &
-                     config_vert_tracer_adv_order, config_coef_3rd_order, &
-                     config_check_tracer_monotonicity, errTmp)
-      call ocn_tracer_advection_mono_init(config_num_halos, config_horiz_tracer_adv_order,    &
-                                          config_vert_tracer_adv_order, config_coef_3rd_order, &
-                                          config_check_tracer_monotonicity, err)
+      call ocn_tracer_advection_std_init(config_horiz_tracer_adv_order,    &
+                                         config_vert_tracer_adv_order,     &
+                                         config_coef_3rd_order,            &
+                                         config_check_tracer_monotonicity, &
+                                         errTmp)
+      call ocn_tracer_advection_mono_init(config_num_halos,                 &
+                                          config_horiz_tracer_adv_order,    &
+                                          config_vert_tracer_adv_order,     &
+                                          config_coef_3rd_order,            &
+                                          config_check_tracer_monotonicity, &
+                                          err)
 
       ! if an error is returned from init routines, write an error
       ! message and return a non-zero error code
@@ -213,8 +168,8 @@ module ocn_tracer_advection
 
    end subroutine ocn_tracer_advection_init!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!***********************************************************************
 
 end module ocn_tracer_advection
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_tracer_advection_mono
 !
@@ -16,7 +16,7 @@
 !>  This module contains routines for monotonic advection of tracers
 !>  using a Flux Corrected Transport (FCT) algorithm
 !
-!-------------------------------------------------------------------------------
+!-----------------------------------------------------------------------
 
 module ocn_tracer_advection_mono
 
@@ -25,14 +25,10 @@ module ocn_tracer_advection_mono
    use mpas_timer
 #endif
    use mpas_kind_types
-   use mpas_derived_types
-   use mpas_dmpar
-   use mpas_pool_routines
-   use mpas_io_units
-   use mpas_threading
    use mpas_tracer_advection_helpers
 
    use ocn_constants
+   use ocn_mesh
    use ocn_diagnostics_variables
 
    implicit none
@@ -51,33 +47,15 @@ module ocn_tracer_advection_mono
       vertOrder3 = 3,    &!< 3rd order scheme
       vertOrder4 = 4      !< 4th order scheme
 
-   ! These temporary allocatable arrays will eventually be moved back into
-   ! the tendency routine, but must be declared here for now so that they
-   ! retain the shared attribute. Once the threading model has been changed,
-   ! these should become thread private again with reduced size
-
-   real (kind=RKIND), dimension(:,:), allocatable :: &
-      tracerCur,     &! reordered current tracer
-      tracerMax,     &! max tracer in neighbors for limiting
-      tracerMin,     &! min tracer in neighbors for limiting
-      hNewInv,       &! inverse of new layer thickness
-      hProv,         &! provisional layer thickness
-      hProvInv,      &! inverse of provisional layer thickness
-      flxIn,         &! flux coming into each cell
-      flxOut,        &! flux going out of each cell
-      workTend,      &! temp for holding some tendency values
-      lowOrderFlx,   &! low order flux for FCT
-      highOrderFlx    ! high order flux for FCT
-
    ! public method interfaces
    public :: ocn_tracer_advection_mono_tend, &
              ocn_tracer_advection_mono_init
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!**********************************************************************
 
    contains
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!**********************************************************************
 !
 !  routine ocn_tracer_advection_mono_tend
 !
@@ -85,64 +63,44 @@ module ocn_tracer_advection_mono
 !> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
 !> \date   October 2017, updated May 2019
 !> \details
-!>  This routine computes the monotonic tracer horizontal advection tendency
-!>  using a flux-corrected transport (FCT) algorithm.
+!>  This routine computes the monotonic tracer horizontal advection
+!>  tendency using a flux-corrected transport (FCT) algorithm.
 !
-!-------------------------------------------------------------------------------
+!-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_advection_mono_tend(tend, tracers, layerThickness,    &
-                                             normalThicknessFlux, w, dt,       &
-                                             advCoefs, advCoefs3rd,            &
-                                             nAdvCellsForEdge, advCellsForEdge,&
-                                             minLevelCell, maxLevelCell,       &
-                                             minLevelEdgeBot, maxLevelEdgeTop, &
-                                             highOrderAdvectionMask,           &
-                                             edgeSignOnCell, meshPool,         &
-                                             computeBudgets)!{{{
+   subroutine ocn_tracer_advection_mono_tend( &
+                                        tend, tracers, layerThickness, &
+                                        normalThicknessFlux, w, dt,    &
+                                        computeBudgets)!{{{
 
-      !*** Input/Output parameters
+      !-----------------------------------------------------------------
+      ! Input/Output parameters
+      !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
-         tend            !< [in,out] Tracer tendency to which advection added
+         tend    !< [inout] Tracer tendency to which advection added
 
-      !*** Input parameters
+      !-----------------------------------------------------------------
+      ! Input parameters
+      !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
-         tracers             !< [in] Current tracer values
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickness      !< [in] Thickness
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalThicknessFlux !< [in] Thichness weighted velocitiy
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         w                   !< [in] Vertical velocity
-      real (kind=RKIND), intent(in) :: &
-         dt                  !< [in] Timestep
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         advCoefs            !< [in] Coefficients for 2nd order advection
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         advCoefs3rd         !< [in] Coeffs for missing 3rd/4th order advection
-      integer, dimension(:), intent(in) :: &
-         nAdvCellsForEdge    !< [in] Number of advection cells for each edge
-      integer, dimension(:,:), intent(in) :: &
-         advCellsForEdge     !< [in] List of advection cells for each edge
-      integer, dimension(:), intent(in) :: &
-         minLevelCell        !< [in] Index to min level at cell center
-      integer, dimension(:), intent(in) :: &
-         maxLevelCell        !< [in] Index to max level at cell center
-      integer, dimension(:), intent(in) :: &
-         minLevelEdgeBot     !< [in] Indx min edge lvl with both non-land cells
-      integer, dimension(:), intent(in) :: &
-         maxLevelEdgeTop     !< [in] Indx max edge lvl with both non-land cells
-      integer, dimension(:,:), intent(in) :: &
-         highOrderAdvectionMask !< [in] Mask for high order advection
-      integer, dimension(:,:), intent(in) :: &
-         edgeSignOnCell         !< [in] Sign for flux from edge on each cell
-      type (mpas_pool_type), intent(in) :: &
-         meshPool               !< [in] Mesh information
-      logical, intent(in) :: &
-         computeBudgets         !< [in] Flag to compute active tracer budgets
+         tracers               !< [in] Current tracer values
 
-      !*** Local variables
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness,      &!< [in] Thickness
+         normalThicknessFlux, &!< [in] Thichness weighted velocitiy
+         w                     !< [in] Vertical velocity
+
+      real (kind=RKIND), intent(in) :: &
+         dt                    !< [in] Timestep
+
+      logical, intent(in) :: &
+         computeBudgets        !< [in] Flag to compute active tracer budgets
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
 
       integer ::          &
          i, iCell, iEdge, &! horz indices
@@ -152,19 +110,6 @@ module ocn_tracer_advection_mono
          nVertLevels,     &! total num vertical levels
          iTracer,         &! tracer index
          numTracers        ! total number of tracers
-
-      ! pointers for mesh variables retrieved from mesh pool
-      integer, dimension(:), pointer, contiguous :: &
-         nCellsArray,   &! number of cells for each halo depth
-         nEdgesArray,   &! number of edges for each halo depth
-         nEdgesOnCell    ! number of edges on each cell
-      integer, dimension(:,:), pointer, contiguous :: &
-         cellsOnEdge,   &! indices of cells on edges
-         cellsOnCell,   &! indices of cells on cells
-         edgesOnCell     ! indices of edges on cells
-      real (kind=RKIND), dimension(:),   pointer, contiguous :: &
-         dvEdge,            &! edge metric
-         areaCell            ! cell area
 
       real (kind=RKIND) ::  &
          signedFactor,      &! temp factor including flux sign
@@ -181,9 +126,22 @@ module ocn_tracer_advection_mono
          verticalWeightKm1, &! vertical weighting
          coef1, coef3        ! temporary coefficients
 
-      real (kind=RKIND), dimension(size(tracers, dim=2)) :: &
+      real (kind=RKIND), dimension(:), allocatable :: &
          wgtTmp,            &! vertical temporaries for
          flxTmp, sgnTmp      !   high-order flux computation
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerCur,     &! reordered current tracer
+         tracerMax,     &! max tracer in neighbors for limiting
+         tracerMin,     &! min tracer in neighbors for limiting
+         hNewInv,       &! inverse of new layer thickness
+         hProv,         &! provisional layer thickness
+         hProvInv,      &! inverse of provisional layer thickness
+         flxIn,         &! flux coming into each cell
+         flxOut,        &! flux going out of each cell
+         workTend,      &! temp for holding some tendency values
+         lowOrderFlx,   &! low order flux for FCT
+         highOrderFlx    ! high order flux for FCT
 
       real (kind=RKIND), parameter :: &
          eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
@@ -195,24 +153,16 @@ module ocn_tracer_advection_mono
 #ifdef _ADV_TIMERS
       call mpas_timer_start('startup')
 #endif
-      ! Get mesh data
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-
       ! Get dimensions
-      nVertLevels = size(tracers,dim=2)
       numTracers  = size(tracers,dim=1)
-      nCells = nCellsArray(size(nCellsArray))
-      nEdges = nEdgesArray(size(nEdgesArray))
+      nCells = nCellsAll
+      nEdges = nEdgesAll
 
       ! allocate temporary arrays
-      allocate(tracerCur   (nVertLevels  ,nCells+1), &
+      allocate(wgtTmp      (nVertLevels), &
+               flxTmp      (nVertlevels), &
+               sgnTmp      (nVertLevels), &
+               tracerCur   (nVertLevels  ,nCells+1), &
                tracerMin   (nVertLevels  ,nCells), &
                tracerMax   (nVertLevels  ,nCells), &
                hNewInv     (nVertLevels  ,nCells), &
@@ -269,7 +219,7 @@ module ocn_tracer_advection_mono
         call mpas_timer_start('cell init')
 #endif
         ! reset nCells to include all cells
-        nCells = nCellsArray( size(nCellsArray) )
+        nCells = nCellsAll
 
         ! Extract current tracer and change index order to improve locality
         !$omp parallel
@@ -289,7 +239,7 @@ module ocn_tracer_advection_mono
 #endif
 
         ! set nCells to first halo level
-        nCells = nCellsArray( 2 )
+        nCells = nCellsHalo(1)
 
         ! Determine bounds on tracer (tracerMin and tracerMax) from
         ! surrounding cells for later limiting.
@@ -319,7 +269,7 @@ module ocn_tracer_advection_mono
         !$omp end parallel
 
         ! Need all the edges around the 1 halo cells and owned cells
-        nEdges = nEdgesArray( 3 )
+        nEdges = nEdgesHalo(2)
 
         ! Compute the high order horizontal flux
 
@@ -360,8 +310,8 @@ module ocn_tracer_advection_mono
           ! Remove low order flux from the high order flux
           ! Store left over high order flux in highOrderFlx array
           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-            tracerWeight = iand(highOrderAdvectionMask(k, iEdge)+1, 1) &
-                         * (dvEdge(iEdge) * 0.5_RKIND)                 &
+            tracerWeight = (1.0_RKIND - highOrderAdvectionMask(k,iEdge)) &
+                         * (dvEdge(iEdge) * 0.5_RKIND)                   &
                          * normalThicknessFlux(k, iEdge)
 
             lowOrderFlx(k,iEdge) = dvEdge(iEdge) * &
@@ -384,7 +334,7 @@ module ocn_tracer_advection_mono
         call mpas_timer_start('scale factor build')
 #endif
         ! Initialize flux arrays for all cells
-        nCells = nCellsArray(size(nCellsArray))
+        nCells = nCellsAll
 
         !$omp parallel
         !$omp do schedule(runtime)
@@ -399,7 +349,7 @@ module ocn_tracer_advection_mono
         !$omp end parallel
 
         ! Need one halo of cells around owned cells
-        nCells = nCellsArray( 2 )
+        nCells = nCellsHalo(1)
 
         !$omp parallel
         !$omp do schedule(runtime) &
@@ -461,7 +411,7 @@ module ocn_tracer_advection_mono
         call mpas_timer_start('rescale horiz fluxes')
 #endif
         ! Need all of the edges around owned cells
-        nEdges = nEdgesArray( 2 )
+        nEdges = nEdgesHalo(1)
         !  rescale the high order horizontal fluxes
         !$omp parallel
         !$omp do schedule(runtime) private(cell1, cell2, k)
@@ -482,7 +432,7 @@ module ocn_tracer_advection_mono
         call mpas_timer_start('flux accumulate')
 #endif
 
-        nCells = nCellsArray( 1 )
+        nCells = nCellsOwned
         ! Accumulate the scaled high order vertical tendencies, and the upwind tendencies
         !$omp parallel
         !$omp do schedule(runtime) private(invAreaCell1, signedFactor, i, iEdge, k)
@@ -522,7 +472,7 @@ module ocn_tracer_advection_mono
 
            !$omp parallel
            !$omp do schedule(runtime) private(k)
-           do iEdge = 1,nEdgesArray( 2 )
+           do iEdge = 1,nEdgesHalo(2)
            do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
               ! Save u*h*T flux on edge for analysis. This variable will be
               ! divided by h at the end of the time step.
@@ -533,7 +483,7 @@ module ocn_tracer_advection_mono
            !$omp end do
 
            !$omp do schedule(runtime) private(k)
-           do iCell = 1, nCellsArray( 1 )
+           do iCell = 1, nCellsOwned
            do k = minLevelCell(iCell), maxLevelCell(iCell)
               activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
                                                      workTend(k,iCell)
@@ -545,7 +495,7 @@ module ocn_tracer_advection_mono
         end if ! computeBudgets
 
         if (monotonicityCheck) then
-           nCells = nCellsArray( 1 )
+           nCells = nCellsOwned
            ! Check tracer values against local min,max to detect
            ! non-monotone values and write warning if found
            !$omp parallel
@@ -584,7 +534,7 @@ module ocn_tracer_advection_mono
 #ifdef _ADV_TIMERS
         call mpas_timer_start('cell init')
 #endif
-        nCells = nCellsArray( size(nCellsArray) )
+        nCells = nCellsAll
         ! Initialize variables for use in this iTracer iteration
         !$omp parallel
         !$omp do schedule(runtime) private(k)
@@ -607,7 +557,7 @@ module ocn_tracer_advection_mono
 #endif
 
         ! Need all owned and 1 halo cells
-        nCells = nCellsArray( 2 )
+        nCells = nCellsHalo(1)
 
         ! Determine bounds on tracerCur from neighbor values for limiting
         !$omp parallel
@@ -769,7 +719,7 @@ module ocn_tracer_advection_mono
         call mpas_timer_start('scale factor build')
 #endif
         ! Need one halo of cells around owned cells
-        nCells = nCellsArray( 2 )
+        nCells = nCellsHalo(1)
         !$omp parallel
         !$omp do schedule(runtime) &
         !$omp private(k, tracerMinNew, tracerMaxNew, tracerUpwindNew, scaleFactor)
@@ -807,7 +757,7 @@ module ocn_tracer_advection_mono
         call mpas_timer_start('flux accumulate')
 #endif
 
-        nCells = nCellsArray( 1 )
+        nCells = nCellsOwned
         ! Accumulate the scaled high order vertical tendencies
         ! and the upwind tendencies
         !$omp parallel
@@ -862,7 +812,7 @@ module ocn_tracer_advection_mono
         end if ! computeBudgets
 
         if (monotonicityCheck) then
-          nCells = nCellsArray( 1 )
+          nCells = nCellsOwned
           ! Check for monotonicity of new tracer value
           !$omp parallel
           !$omp do schedule(runtime) private(k, tracerNew)
@@ -898,7 +848,10 @@ module ocn_tracer_advection_mono
 #ifdef _ADV_TIMERS
       call mpas_timer_start('deallocates')
 #endif
-      deallocate(tracerCur,    &
+      deallocate(wgtTmp,       &
+                 flxTmp,       &
+                 sgnTmp,       &
+                 tracerCur,    &
                  tracerMin,    &
                  tracerMax,    &
                  hNewInv,      &
@@ -916,7 +869,7 @@ module ocn_tracer_advection_mono
 
    end subroutine ocn_tracer_advection_mono_tend!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!**********************************************************************
 !
 !  routine ocn_tracer_advection_mono_init
 !
@@ -927,7 +880,7 @@ module ocn_tracer_advection_mono
 !>  This routine initializes monotonic tracer advection quantities for
 !>  the flux-corrected transport (FCT) algorithm.
 !
-!-------------------------------------------------------------------------------
+!-----------------------------------------------------------------------
 
    subroutine ocn_tracer_advection_mono_init(nHalos, horizAdvOrder,        &
                                              vertAdvOrder, inCoef3rdOrder, &
@@ -1000,7 +953,7 @@ module ocn_tracer_advection_mono
 
    end subroutine ocn_tracer_advection_mono_init!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!**********************************************************************
 
 end module ocn_tracer_advection_mono
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -25,11 +25,11 @@ module ocn_tracer_advection_mono
    use mpas_timer
 #endif
    use mpas_kind_types
-   use mpas_tracer_advection_helpers
 
    use ocn_constants
    use ocn_mesh
    use ocn_diagnostics_variables
+   use ocn_tracer_advection_shared
 
    implicit none
    private

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -102,12 +102,12 @@ module ocn_tracer_advection_mono
          cell1, cell2,    &! neighbor cell indices
          nCells, nEdges,  &! numbers of cells or edges
          k,k2,kmin, kmax, &! vert index variants
+         kmin1, kmax1,    &! vert index variants
          iTracer,         &! tracer index
          numTracers        ! total number of tracers
 
       real (kind=RKIND) ::  &
          signedFactor,      &! temp factor including flux sign
-         tracerNew,         &! updated tracer
          tracerMinNew,      &! updated tracer minimum
          tracerMaxNew,      &! updated tracer maximum
          tracerUpwindNew,   &! tracer updated with upwind flx
@@ -143,28 +143,36 @@ module ocn_tracer_advection_mono
       ! begin code
 
 #ifdef _ADV_TIMERS
-      call mpas_timer_start('startup')
+      call mpas_timer_start('allocates')
 #endif
       ! Get dimensions
       numTracers  = size(tracers,dim=1)
-      nCells = nCellsAll
-      nEdges = nEdgesAll
 
       ! allocate temporary arrays
       allocate(wgtTmp      (nVertLevels), &
                flxTmp      (nVertLevels), &
                sgnTmp      (nVertLevels), &
-               tracerCur   (nVertLevels  ,nCells+1), &
-               tracerMin   (nVertLevels  ,nCells), &
-               tracerMax   (nVertLevels  ,nCells), &
-               hNewInv     (nVertLevels  ,nCells), &
-               hProv       (nVertLevels  ,nCells), &
-               hProvInv    (nVertLevels  ,nCells), &
-               flxIn       (nVertLevels  ,nCells+1), &
-               flxOut      (nVertLevels  ,nCells+1), &
-               workTend    (nVertLevels  ,nCells+1), &
-               lowOrderFlx (nVertLevels+1,max(nCells,nEdges)+1), &
-               highOrderFlx(nVertLevels+1,max(nCells,nEdges)+1))
+               tracerCur   (nVertLevels  ,nCellsAll+1), &
+               tracerMin   (nVertLevels  ,nCellsAll), &
+               tracerMax   (nVertLevels  ,nCellsAll), &
+               hNewInv     (nVertLevels  ,nCellsAll), &
+               hProv       (nVertLevels  ,nCellsAll), &
+               hProvInv    (nVertLevels  ,nCellsAll), &
+               flxIn       (nVertLevels  ,nCellsAll+1), &
+               flxOut      (nVertLevels  ,nCellsAll+1), &
+               workTend    (nVertLevels  ,nCellsAll+1), &
+               lowOrderFlx (nVertLevels+1,max(nCellsAll,nEdgesAll)+1), &
+               highOrderFlx(nVertLevels+1,max(nCellsAll,nEdgesAll)+1))
+
+      !$acc enter data create(wgtTmp, flxTmp, sgnTmp, &
+      !$acc                   tracerCur, tracerMin, tracerMax, &
+      !$acc                   hNewInv, hProv, hProvInv, flxIn, flxOut, &
+      !$acc                   workTend, lowOrderFlx, highOrderFlx)
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('allocates')
+      call mpas_timer_start('prov thickness')
+#endif
 
       ! Compute some provisional layer thicknesses
       ! Note: This assumes we are in the first part of the horizontal/
@@ -172,36 +180,51 @@ module ocn_tracer_advection_mono
       ! we dont flip order and horizontal is always first.
       ! See notes in commit 2cd4a89d.
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(areaCell, dvEdge, minLevelCell, maxLevelCell, &
+      !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
+      !$acc            layerThickness, normalThicknessFlux, w, &
+      !$acc            hProv, hProvInv, hNewInv) &
+      !$acc    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
+#else
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, kmin, kmax, k, i, iEdge, signedFactor)
-      do iCell = 1, nCells
-        invAreaCell1 = dt/areaCell(iCell)
-        kmin = minLevelCell(iCell)
-        kmax = maxLevelCell(iCell)
-        do k = kmin, kmax
-          hProv(k, iCell) = layerThickness(k, iCell)
-        end do
-        do i = 1, nEdgesOnCell(iCell)
-          iEdge = edgesOnCell(i,iCell)
-          signedFactor = invAreaCell1*dvEdge(iEdge)*edgeSignOnCell(i,iCell)
-          ! Provisional layer thickness is after horizontal thickness flux only
-          do k = kmin, kmax
-            hProv(k, iCell) = hProv(k, iCell) &
-                            + signedFactor*normalThicknessFlux(k,iEdge)
-          end do
-        end do
-        ! New layer thickness is after horizontal and vertical thickness flux
-        do k = kmin, kmax
-          hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
-          hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
-                                         dt*w(k,iCell) + dt*w(k+1, iCell))
-        end do
+      !$omp do schedule(runtime) &
+      !$omp    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
+#endif
+      do iCell = 1, nCellsAll
+         invAreaCell1 = dt/areaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+         do k = kmin, kmax
+            hProv(k, iCell) = layerThickness(k, iCell)
+         end do
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i,iCell)
+            signedFactor = invAreaCell1*dvEdge(iEdge)* &
+                           edgeSignOnCell(i,iCell)
+            ! Provisional layer thickness is after horizontal
+            ! thickness flux only
+            do k = kmin, kmax
+               hProv(k,iCell) = hProv(k,iCell) &
+                              + signedFactor*normalThicknessFlux(k,iEdge)
+            end do
+         end do
+         ! New layer thickness is after horizontal and vertical
+         ! thickness flux
+         do k = kmin, kmax
+            hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
+            hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
+                                dt*w(k,iCell) + dt*w(k+1, iCell))
+         end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
 #ifdef _ADV_TIMERS
-      call mpas_timer_stop('startup')
+      call mpas_timer_stop('prov thickness')
 #endif
 
       ! Loop over tracers. One tracer is advected at a time.
@@ -210,24 +233,29 @@ module ocn_tracer_advection_mono
 #ifdef _ADV_TIMERS
         call mpas_timer_start('cell init')
 #endif
-        ! reset nCells to include all cells
-        nCells = nCellsAll
 
         ! Extract current tracer and change index order to improve locality
+#ifdef MPAS_OPENACC
+        !$acc parallel loop collapse(2) &
+        !$acc    present(tracerCur, tracers)
+#else
         !$omp parallel
         !$omp do schedule(runtime) private(k)
-        do iCell = 1, nCells+1
+#endif
+        do iCell = 1, nCellsAll+1
         do k=1, nVertLevels
            tracerCur(k,iCell) = tracers(iTracer,k,iCell)
         end do ! k loop
         end do ! iCell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
         ! Compute the high and low order horizontal fluxes.
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('cell init')
-        call mpas_timer_start('horiz flux')
+        call mpas_timer_start('tracer bounds')
 #endif
 
         ! set nCells to first halo level
@@ -236,167 +264,220 @@ module ocn_tracer_advection_mono
         ! Determine bounds on tracer (tracerMin and tracerMax) from
         ! surrounding cells for later limiting.
 
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, nEdgesOnCell, &
+        !$acc            cellsOnCell, tracerCur, tracerMin, tracerMax) &
+        !$acc    private(k, kmin, kmax, kmin1, kmax1, i, cell2)
+#else
         !$omp parallel
-        !$omp do schedule(runtime) private(k, i, cell2, kmin, kmax)
+        !$omp do schedule(runtime) &
+        !$omp    private(k, kmin, kmax, kmin1, kmax1, i, cell2)
+#endif
         do iCell = 1, nCells
-          do k=minLevelCell(iCell), maxLevelCell(iCell)
-            tracerMin(k,iCell) = tracerCur(k,iCell)
-            tracerMax(k,iCell) = tracerCur(k,iCell)
-          end do
-          do i = 1, nEdgesOnCell(iCell)
-            cell2 = cellsOnCell(i,iCell)
-            kmin  = max(minLevelCell(iCell), &
-                        minLevelCell(cell2))
-            kmax  = min(maxLevelCell(iCell), &
-                        maxLevelCell(cell2))
-            do k=1, kmax
-              tracerMax(k,iCell) = max(tracerMax(k,iCell), &
-                                       tracerCur(k,cell2))
-              tracerMin(k,iCell) = min(tracerMin(k,iCell), &
-                                       tracerCur(k,cell2))
-            end do ! k loop
-          end do ! i loop over nEdgesOnCell
-        end do
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+           do k=kmin,kmax
+              tracerMin(k,iCell) = tracerCur(k,iCell)
+              tracerMax(k,iCell) = tracerCur(k,iCell)
+           end do
+           do i = 1, nEdgesOnCell(iCell)
+              cell2 = cellsOnCell(i,iCell)
+              kmin1 = max(kmin, minLevelCell(cell2))
+              kmax1 = min(kmax, maxLevelCell(cell2))
+              do k=kmin1,kmax1
+                 tracerMax(k,iCell) = max(tracerMax(k,iCell), &
+                                          tracerCur(k,cell2))
+                 tracerMin(k,iCell) = min(tracerMin(k,iCell), &
+                                          tracerCur(k,cell2))
+              end do ! k loop
+           end do ! i loop over nEdgesOnCell
+        end do ! cell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('tracer bounds')
+        call mpas_timer_start('horiz flux')
+#endif
         ! Need all the edges around the 1 halo cells and owned cells
         nEdges = nEdgesHalo(2)
 
         ! Compute the high order horizontal flux
 
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, minLevelEdgeBot, &
+        !$acc            maxLevelEdgeTop, nAdvCellsForEdge, & 
+        !$acc            advCellsForEdge, cellsOnEdge, dvEdge, &
+        !$acc            advMaskHighOrder, advCoefs, advCoefs3rd, &
+        !$acc            tracerCur, normalThicknessFlux, &
+        !$acc            highOrderFlx, lowOrderFlx) &
+        !$acc    private(i, k, icell, cell1, cell2, coef1, coef3, &
+        !$acc            wgtTmp, sgnTmp, flxTmp, tracerWeight)
+#else
         !$omp parallel
         !$omp do schedule(runtime) &
-        !$omp private(cell1, cell2, k, wgtTmp, sgnTmp, flxTmp, i, iCell, coef1, coef3, &
-        !$omp         tracerWeight)
+        !$omp    private(i, k, icell, cell1, cell2, coef1, coef3, &
+        !$omp            wgtTmp, sgnTmp, flxTmp, tracerWeight)
+#endif
         do iEdge = 1, nEdges
-          cell1 = cellsOnEdge(1, iEdge)
-          cell2 = cellsOnEdge(2, iEdge)
+           cell1 = cellsOnEdge(1, iEdge)
+           cell2 = cellsOnEdge(2, iEdge)
 
-          ! compute some common intermediate factors
-          do k = 1, nVertLevels
-             wgtTmp(k) = normalThicknessFlux(k,iEdge)* &
-                         advMaskHighOrder(k,iEdge)
-             sgnTmp(k) = sign(1.0_RKIND, &
-                              normalThicknessFlux(k,iEdge))
-             flxTmp(k) = 0.0_RKIND
-          end do
+           ! compute some common intermediate factors
+           do k = 1, nVertLevels
+              wgtTmp(k) = normalThicknessFlux(k,iEdge)* &
+                          advMaskHighOrder(k,iEdge)
+              sgnTmp(k) = sign(1.0_RKIND, &
+                               normalThicknessFlux(k,iEdge))
+              flxTmp(k) = 0.0_RKIND
+           end do
 
-          ! Compute 3rd or 4th fluxes where requested.
-          do i = 1, nAdvCellsForEdge(iEdge)
-            iCell = advCellsForEdge(i,iEdge)
-            coef1 = advCoefs       (i,iEdge)
-            coef3 = advCoefs3rd    (i,iEdge)*coef3rdOrder
-            do k = minLevelCell(iCell), maxLevelCell(iCell)
-              flxTmp(k) = flxTmp(k) + tracerCur(k,iCell)* &
-                          wgtTmp(k)*(coef1 + coef3*sgnTmp(k))
-            end do ! k loop
-          end do ! i loop over nAdvCellsForEdge
+           ! Compute 3rd or 4th fluxes where requested.
+           do i = 1, nAdvCellsForEdge(iEdge)
+              iCell = advCellsForEdge(i,iEdge)
+              coef1 = advCoefs       (i,iEdge)
+              coef3 = advCoefs3rd    (i,iEdge)*coef3rdOrder
+              do k = minLevelCell(iCell), maxLevelCell(iCell)
+                 flxTmp(k) = flxTmp(k) + tracerCur(k,iCell)* &
+                             wgtTmp(k)*(coef1 + coef3*sgnTmp(k))
+              end do ! k loop
+           end do ! i loop over nAdvCellsForEdge
 
-          do k=1,nVertLevels
-             highOrderFlx(k,iEdge) = flxTmp(k)
-          end do
+           do k=1,nVertLevels
+              highOrderFlx(k,iEdge) = flxTmp(k)
+           end do
 
-          ! Compute 2nd order fluxes where needed.
-          ! Also compute low order upwind horizontal flux (monotonic and diffused)
-          ! Remove low order flux from the high order flux
-          ! Store left over high order flux in highOrderFlx array
-          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-            tracerWeight = (1.0_RKIND - advMaskHighOrder(k,iEdge)) &
-                         * (dvEdge(iEdge) * 0.5_RKIND)                   &
-                         * normalThicknessFlux(k, iEdge)
+           ! Compute 2nd order fluxes where needed.
+           ! Also compute low order upwind horizontal flux (monotonic)
+           ! Remove low order flux from the high order flux
+           ! Store left over high order flux in highOrderFlx array
+           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+              tracerWeight = (1.0_RKIND - advMaskHighOrder(k,iEdge)) &
+                           * (dvEdge(iEdge) * 0.5_RKIND)             &
+                           * normalThicknessFlux(k, iEdge)
 
-            lowOrderFlx(k,iEdge) = dvEdge(iEdge) * &
+              lowOrderFlx(k,iEdge) = dvEdge(iEdge) * &
                (max(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracerCur(k,cell1) &
               + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracerCur(k,cell2))
 
-            highOrderFlx(k, iEdge) = highOrderFlx(k, iedge) &
-                                   + tracerWeight * (tracerCur(k, cell1) &
-                                                   + tracerCur(k, cell2))
+              highOrderFlx(k,iEdge) = highOrderFlx(k,iedge) &
+                                    + tracerWeight*(tracerCur(k,cell1) &
+                                                  + tracerCur(k,cell2))
 
-            highOrderFlx(k,iEdge) = highOrderFlx(k,iEdge) &
-                                  -  lowOrderFlx(k,iEdge)
-          end do ! k loop
+              highOrderFlx(k,iEdge) = highOrderFlx(k,iEdge) &
+                                    -  lowOrderFlx(k,iEdge)
+           end do ! k loop
         end do ! iEdge loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('horiz flux')
         call mpas_timer_start('scale factor build')
 #endif
-        ! Initialize flux arrays for all cells
-        nCells = nCellsAll
 
+        ! Initialize flux arrays for all cells
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present (workTend, flxIn, flxOut)
+#else
         !$omp parallel
         !$omp do schedule(runtime)
-        do iCell = 1, nCells+1
+#endif
+        do iCell = 1, nCellsAll+1
         do k=1, nVertLevels
            workTend(k, iCell) = 0.0_RKIND
            flxIn   (k, iCell) = 0.0_RKIND
            flxOut  (k, iCell) = 0.0_RKIND
         end do ! k loop
         end do ! iCell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
         ! Need one halo of cells around owned cells
         nCells = nCellsHalo(1)
 
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
+        !$acc            minLevelCell, maxLevelCell, areaCell, &
+        !$acc            nEdgesOnCell, edgesOnCell, cellsOnEdge, &
+        !$acc            edgeSignOnCell, layerThickness, hProvInv, &
+        !$acc            tracerCur, tracerMax, tracerMin, workTend, &
+        !$acc            flxOut, flxIn, lowOrderFlx, highOrderFlx) &
+        !$acc    private(i, k, iEdge, cell1, cell2, &
+        !$acc            invAreaCell1, signedFactor, scaleFactor, &
+        !$acc            tracerUpwindNew, tracerMinNew, tracerMaxNew)
+#else
         !$omp parallel
         !$omp do schedule(runtime) &
-        !$omp private(invAreaCell1, i, iEdge, cell1, cell2, signedFactor, k, &
-        !$omp         tracerUpwindNew, tracerMinNew, tracerMaxNew, scaleFactor)
+        !$omp    private(i, k, iEdge, cell1, cell2, &
+        !$omp            invAreaCell1, signedFactor, scaleFactor, &
+        !$omp            tracerUpwindNew, tracerMinNew, tracerMaxNew)
+#endif
         do iCell = 1, nCells
-          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
-          ! Finish computing the low order horizontal fluxes
-          ! Upwind fluxes are accumulated in workTend
-          do i = 1, nEdgesOnCell(iCell)
-            iEdge = edgesOnCell(i, iCell)
-            cell1 = cellsOnEdge(1,iEdge)
-            cell2 = cellsOnEdge(2,iEdge)
-            signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
+           ! Finish computing the low order horizontal fluxes
+           ! Upwind fluxes are accumulated in workTend
+           do i = 1, nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(i, iCell)
+              cell1 = cellsOnEdge(1,iEdge)
+              cell2 = cellsOnEdge(2,iEdge)
+              signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
 
-            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-              ! Here workTend is the advection tendency due to the
-              ! upwind (low order) fluxes.
-              workTend(k,iCell) = workTend(k,iCell) &
-                                + signedFactor*lowOrderFlx(k,iEdge)
+              do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
-              ! Accumulate remaining high order fluxes
-              flxOut(k,iCell) = flxOut(k,iCell) + min(0.0_RKIND,  &
-                                signedFactor*highOrderFlx(k,iEdge))
-              flxIn (k,iCell) = flxIn (k,iCell) + max(0.0_RKIND,  &
-                                signedFactor*highOrderFlx(k,iEdge))
+                 ! Here workTend is the advection tendency due to the
+                 ! upwind (low order) fluxes.
+                 workTend(k,iCell) = workTend(k,iCell) &
+                                   + signedFactor*lowOrderFlx(k,iEdge)
 
-            end do
-          end do
+                 ! Accumulate remaining high order fluxes
+                 flxOut(k,iCell) = flxOut(k,iCell) + min(0.0_RKIND,  &
+                                   signedFactor*highOrderFlx(k,iEdge))
+                 flxIn (k,iCell) = flxIn (k,iCell) + max(0.0_RKIND,  &
+                                   signedFactor*highOrderFlx(k,iEdge))
 
-          ! Build the factors for the FCT
-          ! Computed using the bounds that were computed previously,
-          ! and the bounds on the newly updated value
-          ! Factors are placed in the flxIn and flxOut arrays
-          do k = minLevelCell(iCell), maxLevelCell(iCell)
-            ! Here workTend is the upwind tendency
-            tracerUpwindNew = (tracerCur(k,iCell)*layerThickness(k,iCell) &
-                             + dt*workTend(k,iCell)) * hProvInv(k,iCell)
-            tracerMinNew = tracerUpwindNew &
-                         + dt*flxOut(k,iCell)*hProvInv(k,iCell)
-            tracerMaxNew = tracerUpwindNew &
-                         + dt*flxIn (k,iCell)*hProvInv(k,iCell)
+              end do
+           end do
 
-            scaleFactor = (tracerMax(k,iCell) - tracerUpwindNew)/ &
-                          (tracerMaxNew - tracerUpwindNew + eps)
-            flxIn (k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
+           ! Build the factors for the FCT
+           ! Computed using the bounds that were computed previously,
+           ! and the bounds on the newly updated value
+           ! Factors are placed in the flxIn and flxOut arrays
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              ! Here workTend is the upwind tendency
+              tracerUpwindNew = (tracerCur(k,iCell)*layerThickness(k,iCell) &
+                              + dt*workTend(k,iCell))*hProvInv(k,iCell)
+              tracerMinNew = tracerUpwindNew &
+                           + dt*flxOut(k,iCell)*hProvInv(k,iCell)
+              tracerMaxNew = tracerUpwindNew &
+                           + dt*flxIn (k,iCell)*hProvInv(k,iCell)
 
-            scaleFactor = (tracerUpwindNew - tracerMin(k,iCell))/ &
-                          (tracerUpwindNew - tracerMinNew + eps)
-            flxOut(k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
-          end do ! k loop
+              scaleFactor = (tracerMax(k,iCell) - tracerUpwindNew)/ &
+                            (tracerMaxNew - tracerUpwindNew + eps)
+              flxIn (k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+              scaleFactor = (tracerUpwindNew - tracerMin(k,iCell))/ &
+                            (tracerUpwindNew - tracerMinNew + eps)
+              flxOut(k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+           end do ! k loop
         end do ! iCell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('scale factor build')
@@ -405,66 +486,102 @@ module ocn_tracer_advection_mono
         ! Need all of the edges around owned cells
         nEdges = nEdgesHalo(1)
         !  rescale the high order horizontal fluxes
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
+        !$acc            cellsOnEdge, highOrderFlx, flxIn, flxOut) &
+        !$acc    private(k, cell1, cell2)
+#else
         !$omp parallel
-        !$omp do schedule(runtime) private(cell1, cell2, k)
+        !$omp do schedule(runtime) private(k, cell1, cell2)
+#endif
         do iEdge = 1, nEdges
-          cell1 = cellsOnEdge(1,iEdge)
-          cell2 = cellsOnEdge(2,iEdge)
-          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-            highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
-                                    min(flxOut(k,cell1), flxIn (k,cell2)) &
-                                  + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
-                                    min(flxIn (k,cell1), flxOut(k,cell2))
-          end do ! k loop
+           cell1 = cellsOnEdge(1,iEdge)
+           cell2 = cellsOnEdge(2,iEdge)
+           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+              highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                      min(flxOut(k,cell1), flxIn (k,cell2)) &
+                                    + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                      min(flxIn (k,cell1), flxOut(k,cell2))
+           end do ! k loop
         end do ! iEdge loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
+
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('rescale horiz fluxes')
         call mpas_timer_start('flux accumulate')
 #endif
 
-        nCells = nCellsOwned
-        ! Accumulate the scaled high order vertical tendencies, and the upwind tendencies
+        ! Accumulate the scaled high order vertical tendencies
+        ! and the upwind tendencies
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
+        !$acc            minLevelCell, maxLevelCell, areaCell, &
+        !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
+        !$acc            workTend, highOrderFlx, layerThickness, &
+        !$acc            tracerCur, hProvInv, tend) &
+        !$acc    private(i, k, iEdge, invAreaCell1, signedFactor) 
+#else
         !$omp parallel
-        !$omp do schedule(runtime) private(invAreaCell1, signedFactor, i, iEdge, k)
-        do iCell = 1, nCells
-          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+        !$omp do schedule(runtime) &
+        !$omp    private(i, k, iEdge, invAreaCell1, signedFactor) 
+#endif
+        do iCell = 1, nCellsOwned
+           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
-          ! Accumulate the scaled high order horizontal tendencies
-          do i = 1, nEdgesOnCell(iCell)
-            iEdge = edgesOnCell(i, iCell)
-            signedFactor = invAreaCell1 * edgeSignOnCell(i, iCell)
-            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-              ! workTend on the RHS is the upwind tendency
-              ! workTend on the LHS is the total horizontal advection tendency
-              workTend(k,iCell) = workTend(k,iCell) &
-                                + signedFactor * highOrderFlx(k, iEdge)
-            end do
-          end do
+           ! Accumulate the scaled high order horizontal tendencies
+           do i = 1, nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(i, iCell)
+              signedFactor = invAreaCell1*edgeSignOnCell(i,iCell)
+              do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+                 ! workTend on RHS is upwind tendency
+                 ! workTend on LHS is total horiz advect tendency
+                 workTend(k,iCell) = workTend(k,iCell) &
+                                   + signedFactor*highOrderFlx(k,iEdge)
+              end do
+           end do
 
-          do k = minLevelCell(iCell), maxLevelCell(iCell)
-            ! workTend on the RHS is the total horizontal advection tendency
-            ! tracerCur on LHS is the  provisional tracer after horizontal fluxes only.
-            tracerCur(k,iCell) = (tracerCur(k,iCell)*layerThickness(k,iCell) &
-                                  + dt*workTend(k,iCell))*hProvInv(k,iCell)
-            tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + workTend(k,iCell)
-          end do
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              ! workTend  on RHS is total horiz advection tendency
+              ! tracerCur on LHS is provisional tracer after
+              !                     horizontal fluxes only.
+              tracerCur(k,iCell) = (tracerCur(k,iCell)* &
+                                    layerThickness(k,iCell) &
+                                    + dt*workTend(k,iCell)) &
+                                 * hProvInv(k,iCell)
+              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) &
+                                    + workTend(k,iCell)
+           end do
 
         end do ! iCell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('flux accumulate')
-        call mpas_timer_start('advect diags')
+        call mpas_timer_start('advect diags horiz')
 #endif
         ! Compute budget and monotonicity diagnostics if needed
         if (computeBudgets) then
 
+           nEdges = nEdgesHalo(2)
+#ifdef MPAS_OPENACC
+           !$acc parallel loop private(k) &
+           !$acc    present(activeTracerHorizontalAdvectionEdgeFlux, &
+           !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
+           !$acc            lowOrderFlx, highOrderFlx, dvEdge)
+#else
            !$omp parallel
            !$omp do schedule(runtime) private(k)
-           do iEdge = 1,nEdgesHalo(2)
+#endif
+           do iEdge = 1,nEdges
            do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
               ! Save u*h*T flux on edge for analysis. This variable will be
               ! divided by h at the end of the time step.
@@ -472,27 +589,40 @@ module ocn_tracer_advection_mono
                  (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
            enddo
            enddo
+#ifndef MPAS_OPENACC
            !$omp end do
+#endif
 
+#ifdef MPAS_OPENACC
+           !$acc parallel loop private(k) &
+           !$acc    present(activeTracerHorizontalAdvectionTendency, &
+           !$acc            minLevelCell, maxLevelCell, workTend)
+#else
            !$omp do schedule(runtime) private(k)
+#endif
            do iCell = 1, nCellsOwned
            do k = minLevelCell(iCell), maxLevelCell(iCell)
               activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
                                                      workTend(k,iCell)
            end do
            end do ! iCell loop
+#ifndef MPAS_OPENACC
            !$omp end do
            !$omp end parallel
+#endif
 
         end if ! computeBudgets
 
         if (monotonicityCheck) then
-           nCells = nCellsOwned
            ! Check tracer values against local min,max to detect
            ! non-monotone values and write warning if found
+
+           ! Perform check on host since print involved
+           !$acc update host(tracerCur, tracerMin, tracerMax)
+
            !$omp parallel
            !$omp do schedule(runtime) private(k)
-           do iCell = 1, nCells
+           do iCell = 1, nCellsOwned
            do k = minLevelCell(iCell), maxLevelCell(iCell)
               if(tracerCur(k,iCell) < tracerMin(k, iCell)-eps) then
                  call mpas_log_write( &
@@ -513,7 +643,7 @@ module ocn_tracer_advection_mono
            !$omp end parallel
         end if ! monotonicity check
 #ifdef _ADV_TIMERS
-        call mpas_timer_stop('advect diags')
+        call mpas_timer_stop('advect diags horiz')
 #endif
 
         !-----------------------------------------------------------------------
@@ -524,235 +654,333 @@ module ocn_tracer_advection_mono
         !-----------------------------------------------------------------------
 
 #ifdef _ADV_TIMERS
-        call mpas_timer_start('cell init')
+        call mpas_timer_start('cell init vert')
 #endif
-        nCells = nCellsAll
         ! Initialize variables for use in this iTracer iteration
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop collapse(2) present(workTend)
+#else
         !$omp parallel
         !$omp do schedule(runtime) private(k)
-        do iCell = 1, nCells
+#endif
+        do iCell = 1, nCellsAll
         do k=1, nVertLevels
            workTend(k, iCell) = 0.0_RKIND
         end do ! k loop
         end do ! iCell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
-#ifdef _ADV_TIMERS
-        call mpas_timer_stop('cell init')
 #endif
 
 #ifdef _ADV_TIMERS
-        call mpas_timer_start('vertical flux')
+        call mpas_timer_stop('cell init vert')
+        call mpas_timer_start('vertical bounds')
 #endif
 
         ! Need all owned and 1 halo cells
         nCells = nCellsHalo(1)
 
         ! Determine bounds on tracerCur from neighbor values for limiting
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(tracerCur, tracerMin, tracerMax, &
+        !$acc            minLevelCell, maxLevelCell) &
+        !$acc    private(k, kmin, kmax)
+#else
         !$omp parallel
-        !$omp do schedule(runtime) private(kmin, kmax, k)
+        !$omp do schedule(runtime) private(k, kmin, kmax)
+#endif
         do iCell = 1, nCells
-          kmin = minLevelCell(iCell)
-          kmax = maxLevelCell(iCell)
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
 
-          ! take care of top cell
-          tracerMax(kmin,iCell) = max(tracerCur(1,iCell), &
-                                      tracerCur(2,iCell))
-          tracerMin(kmin,iCell) = min(tracerCur(1,iCell), &
-                                      tracerCur(2,iCell))
-          do k=kmin+1,kmax-1
-            tracerMax(k,iCell) = max(tracerCur(k-1,iCell), &
-                                     tracerCur(k  ,iCell), &
-                                     tracerCur(k+1,iCell))
-            tracerMin(k,iCell) = min(tracerCur(k-1,iCell), &
-                                     tracerCur(k  ,iCell), &
-                                     tracerCur(k+1,iCell))
-          end do
-          ! finish with bottom cell
-          tracerMax(kmax,iCell) = max(tracerCur(kmax  ,iCell), &
-                                      tracerCur(kmax-1,iCell))
-          tracerMin(kmax,iCell) = min(tracerCur(kmax  ,iCell), &
-                                      tracerCur(kmax-1,iCell))
+           ! take care of top cell
+           tracerMax(kmin,iCell) = max(tracerCur(1,iCell), &
+                                       tracerCur(2,iCell))
+           tracerMin(kmin,iCell) = min(tracerCur(1,iCell), &
+                                       tracerCur(2,iCell))
+           do k=kmin+1,kmax-1
+              tracerMax(k,iCell) = max(tracerCur(k-1,iCell), &
+                                       tracerCur(k  ,iCell), &
+                                       tracerCur(k+1,iCell))
+              tracerMin(k,iCell) = min(tracerCur(k-1,iCell), &
+                                       tracerCur(k  ,iCell), &
+                                       tracerCur(k+1,iCell))
+           end do
+           ! finish with bottom cell
+           tracerMax(kmax,iCell) = max(tracerCur(kmax  ,iCell), &
+                                       tracerCur(kmax-1,iCell))
+           tracerMin(kmax,iCell) = min(tracerCur(kmax  ,iCell), &
+                                       tracerCur(kmax-1,iCell))
         end do ! cell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical bounds')
+        call mpas_timer_start('vertical flux high')
+#endif
 
         ! Compute the high order vertical fluxes based on order selected.
 
         call ocn_tracer_advection_vert_flx(tracerCur, w, hProv, &
                                            highOrderFlx)
 
-        ! Compute low order upwind vertical flux (monotonic and diffused)
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical flux high')
+        call mpas_timer_start('vertical flux')
+#endif
+
+        ! Compute low order upwind vertical flux (monotonic)
         ! Remove low order flux from the high order flux.
         ! Store left over high order flux in highOrderFlx array.
 
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, w, tracerCur, &
+        !$acc            lowOrderFlx, highOrderFlx, workTend, &
+        !$acc            flxIn, flxOut) &
+        !$acc    private(k, kmin, kmax)
+#else
         !$omp parallel
-        !$omp do schedule(runtime) private(kmin, kmax, k)
+        !$omp do schedule(runtime) private(k, kmin, kmax)
+#endif
         do iCell = 1, nCells
-          kmin = minLevelCell(iCell)
-          kmax = maxLevelCell(iCell)
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
 
-          lowOrderFlx(kmin,iCell) = 0.0_RKIND
-          do k = kmin+1, kmax
-            lowOrderFlx(k,iCell) = &
-                min(0.0_RKIND,w(k,iCell))*tracerCur(k-1,iCell) + &
-                max(0.0_RKIND,w(k,iCell))*tracerCur(k  ,iCell)
-            highOrderFlx(k,iCell) = highOrderFlx(k,iCell) - &
-                                     lowOrderFlx(k,iCell)
-          end do ! k loop
-          lowOrderFlx(kmax+1,iCell) = 0.0_RKIND
+           lowOrderFlx(kmin,iCell) = 0.0_RKIND
+           do k = kmin+1, kmax
+              lowOrderFlx(k,iCell) = &
+                    min(0.0_RKIND,w(k,iCell))*tracerCur(k-1,iCell) + &
+                    max(0.0_RKIND,w(k,iCell))*tracerCur(k  ,iCell)
+              highOrderFlx(k,iCell) = highOrderFlx(k,iCell) &
+                                    -  lowOrderFlx(k,iCell)
+           end do ! k loop
+           lowOrderFlx(kmax+1,iCell) = 0.0_RKIND
 
-          ! Upwind fluxes are accumulated in workTend
-          ! flxIn contains the total remaining high order flux into iCell
-          !          it is positive.
-          ! flxOut contains the total remaining high order flux out of iCell
-          !           it is negative
-          do k = kmin, kmax
-            workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
-                              - lowOrderFlx(k  ,iCell)
-            flxIn (k, iCell) = max(0.0_RKIND, highOrderFlx(k+1, iCell)) &
-                             - min(0.0_RKIND, highOrderFlx(k  , iCell))
-            flxOut(k, iCell) = min(0.0_RKIND, highOrderFlx(k+1, iCell)) &
-                             - max(0.0_RKIND, highOrderFlx(k  , iCell))
-          end do ! k Loop
+           ! Upwind fluxes are accumulated in workTend
+           ! flxIn  contains total remaining high order flux into iCell
+           !          it is positive.
+           ! flxOut contains total remaining high order flux out of iCell
+           !          it is negative
+           do k = kmin,kmax
+              workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
+                                - lowOrderFlx(k  ,iCell)
+              flxIn (k,iCell) = max(0.0_RKIND, highOrderFlx(k+1,iCell)) &
+                              - min(0.0_RKIND, highOrderFlx(k  ,iCell))
+              flxOut(k,iCell) = min(0.0_RKIND, highOrderFlx(k+1,iCell)) &
+                              - max(0.0_RKIND, highOrderFlx(k  ,iCell))
+           end do ! k Loop
         end do ! iCell Loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('vertical flux')
         call mpas_timer_start('scale factor build')
 #endif
-        ! Need one halo of cells around owned cells
-        nCells = nCellsHalo(1)
+
+        ! Build the scale factors to limit flux for FCT
+        ! Computed using the bounds that were computed previously,
+        ! and the bounds on the newly updated value
+        ! Factors are placed in the flxIn and flxOut arrays
+
+        nCells = nCellsHalo(1) ! Need one halo around owned cells
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, hProv, hNewInv, &
+        !$acc            tracerCur, tracerMax, tracerMin, &
+        !$acc            workTend, flxIn, flxOut) &
+        !$acc    private(k, tracerMinNew, tracerMaxNew, &
+        !$acc            tracerUpwindNew, scaleFactor) 
+#else
         !$omp parallel
         !$omp do schedule(runtime) &
-        !$omp private(k, tracerMinNew, tracerMaxNew, tracerUpwindNew, scaleFactor)
+        !$omp    private(k, tracerMinNew, tracerMaxNew, &
+        !$omp            tracerUpwindNew, scaleFactor)
+#endif
         do iCell = 1, nCells
 
-          ! Build the scale factors to limit flux for FCT
-          ! Computed using the bounds that were computed previously,
-          ! and the bounds on the newly updated value
-          ! Factors are placed in the flxIn and flxOut arrays
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              ! workTend on the RHS is the upwind tendency
+              tracerMinNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                           + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
+                           * hNewInv(k,iCell)
+              tracerMaxNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                           + dt*(workTend(k,iCell)+flxIn(k,iCell))) &
+                           * hNewInv(k,iCell)
+              tracerUpwindNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                              + dt*workTend(k,iCell)) * hNewInv(k,iCell)
 
-          do k = minLevelCell(iCell), maxLevelCell(iCell)
-            ! workTend on the RHS is the upwind tendency
-            tracerMinNew = (tracerCur(k,iCell)*hProv(k,iCell) &
-                         + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
-                         * hNewInv(k,iCell)
-            tracerMaxNew = (tracerCur(k,iCell)*hProv(k,iCell) &
-                         + dt*(workTend(k,iCell)+flxIn(k,iCell))) &
-                         * hNewInv(k,iCell)
-            tracerUpwindNew = (tracerCur(k,iCell)*hProv(k,iCell) &
-                            + dt*workTend(k,iCell)) * hNewInv(k,iCell)
+              scaleFactor = (tracerMax(k,iCell)-tracerUpwindNew)/ &
+                            (tracerMaxNew-tracerUpwindNew+eps)
+              flxIn (k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
 
-            scaleFactor = (tracerMax(k,iCell)-tracerUpwindNew)/ &
-                          (tracerMaxNew-tracerUpwindNew+eps)
-            flxIn (k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
-
-            scaleFactor = (tracerUpwindNew-tracerMin(k,iCell))/ &
-                          (tracerUpwindNew-tracerMinNew+eps)
-            flxOut(k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
-          end do ! k loop
+              scaleFactor = (tracerUpwindNew-tracerMin(k,iCell))/ &
+                            (tracerUpwindNew-tracerMinNew+eps)
+              flxOut(k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+           end do ! k loop
         end do ! iCell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
+
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('scale factor build')
         call mpas_timer_start('flux accumulate')
 #endif
 
-        nCells = nCellsOwned
         ! Accumulate the scaled high order vertical tendencies
         ! and the upwind tendencies
-        !$omp parallel
-        !$omp do schedule(runtime) private(kmin, kmax, k, flux)
-        do iCell = 1, nCells
-          kmin = minLevelCell(iCell)
-          kmax = maxLevelCell(iCell)
-          ! rescale the high order vertical flux
-          do k = kmin+1, kmax
-            flux =  highOrderFlx(k,iCell)
-            highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
-                                    min(flxOut(k  ,iCell), &
-                                        flxIn (k-1,iCell)) &
-                                  + min(0.0_RKIND,flux)*   &
-                                    min(flxOut(k-1,iCell), &
-                                        flxIn (k  ,iCell))
-          end do ! k loop
 
-          do k = kmin,kmax
-            ! workTend on the RHS is the upwind tendency
-            ! workTend on the LHS is the total vertical advection tendency
-            workTend(k, iCell) = workTend(k, iCell)       &
-                               + (highOrderFlx(k+1,iCell) &
-                                - highOrderFlx(k  ,iCell))
-            tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + workTend(k,iCell)
-          end do ! k loop
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, highOrderFlx, &
+        !$acc            flxIn, flxOut, workTend, tend) &
+        !$acc    private(k, kmin, kmax, flux)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k, kmin, kmax, flux)
+#endif
+        do iCell = 1, nCellsOwned
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+           ! rescale the high order vertical flux
+           do k = kmin+1, kmax
+              flux =  highOrderFlx(k,iCell)
+              highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
+                                      min(flxOut(k  ,iCell), &
+                                          flxIn (k-1,iCell)) &
+                                    + min(0.0_RKIND,flux)*   &
+                                      min(flxOut(k-1,iCell), &
+                                          flxIn (k  ,iCell))
+           end do ! k loop
+
+           do k = kmin,kmax
+              ! workTend on the RHS is upwind tendency
+              ! workTend on the LHS is total vertical advection tendency
+              workTend(k, iCell) = workTend(k, iCell)       &
+                                 + (highOrderFlx(k+1,iCell) &
+                                  - highOrderFlx(k  ,iCell))
+              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) &
+                                    + workTend(k,iCell)
+           end do ! k loop
 
         end do ! iCell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
         ! Compute advection diagnostics and monotonicity checks if requested
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('flux accumulate')
-        call mpas_timer_start('advect diags')
+        call mpas_timer_start('advect diags vert')
 #endif
         if (computeBudgets) then
+
+#ifdef MPAS_OPENACC
+           !$acc parallel loop &
+           !$acc    present(lowOrderFlx, highOrderFlx, workTend, &
+           !$acc            activeTracerVerticalAdvectionTopFlux, &
+           !$acc            activeTracerVerticalAdvectionTendency, &
+           !$acc            minLevelCell, maxLevelCell) &
+           !$acc    private(k, kmin, kmax)
+#else
            !$omp parallel
-           !$omp do schedule(runtime) private(k)
-           do iCell = 1, nCells
-              do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
+           !$omp do schedule(runtime) private(k,kmin,kmax)
+#endif
+           do iCell = 1, nCellsOwned
+              kmin = minLevelCell(iCell)
+              kmax = maxLevelCell(iCell)
+              do k = kmin+1,kmax
                  activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
                     lowOrderFlx(k,iCell) + highOrderFlx(k,iCell)
               end do
-              do k = minLevelCell(iCell), maxLevelCell(iCell)
+              do k = kmin,kmax
                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
                     workTend(k,iCell)
               end do
            end do ! iCell loop
+#ifndef MPAS_OPENACC
            !$omp end do
            !$omp end parallel
+#endif
         end if ! computeBudgets
 
         if (monotonicityCheck) then
-          nCells = nCellsOwned
-          ! Check for monotonicity of new tracer value
-          !$omp parallel
-          !$omp do schedule(runtime) private(k, tracerNew)
-          do iCell = 1, nCells
-          do k = minLevelCell(iCell), maxLevelCell(iCell)
-             ! workTend on the RHS is the total vertical advection tendency
-             tracerNew = (tracerCur(k, iCell)*hProv(k, iCell) &
-                          + dt*workTend(k, iCell))*hNewInv(k, iCell)
 
-             if (tracerNew < tracerMin(k, iCell)-eps) then
-                call mpas_log_write( &
+           ! Check for monotonicity of new tracer value
+           ! Use flxIn as a temp for new tracer value
+
+#ifdef MPAS_OPENACC
+           !$acc parallel loop collapse(2) &
+           !$acc    present(flxIn, tracerCur, hProv, hNewInv, &
+           !$acc            workTend, cellMask)
+#else
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+#endif
+           do iCell = 1,nCellsOwned
+           do k = 1,nVertLevels
+              ! workTend on the RHS is total vertical advection tendency
+              flxIn(k,iCell) = (tracerCur(k, iCell)*hProv(k, iCell) &
+                             + dt*workTend(k, iCell)) &
+                             * hNewInv(k,iCell)*cellMask(k,iCell)
+           end do ! vert
+           end do ! cell loop
+#ifndef MPAS_OPENACC
+           !$omp end do
+           !$omp end parallel
+#endif
+
+           ! Transfer new tracer values to host for diagnostic check
+           !$acc update host(flxIn)
+
+           ! Print out info for cells that are out of bounds
+           ! flxIn holds new tracer values
+           do iCell = 1, nCellsOwned
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              if (flxIn(k,iCell) < tracerMin(k, iCell)-eps) then
+                 call mpas_log_write( &
                    'Vertical minimum out of bounds on tracer: $i $i $i $r $r ',&
                    MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
-                   realArgs=(/ tracerMin(k, iCell), tracerNew /) )
-             end if
-
-             if (tracerNew > tracerMax(k,iCell)+eps) then
-                call mpas_log_write( &
+                   realArgs=(/ tracerMin(k,iCell), flxIn(k,iCell) /) )
+              end if
+              if (flxIn(k,iCell) > tracerMax(k,iCell)+eps) then
+                 call mpas_log_write( &
                    'Vertical maximum out of bounds on tracer: $i $i $i $r $r ',&
                     MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
-                    realArgs=(/ tracerMax(k, iCell), tracerNew /) )
-             end if
-          end do
-          end do
-          !$omp end do
-          !$omp end parallel
+                    realArgs=(/ tracerMax(k,iCell), flxIn(k,iCell) /) )
+              end if
+           end do
+           end do
+
         end if ! monotonicity check
 #ifdef _ADV_TIMERS
-        call mpas_timer_stop('advect diags')
+        call mpas_timer_stop('advect diags vert')
 #endif
       end do ! iTracer loop
 
 #ifdef _ADV_TIMERS
       call mpas_timer_start('deallocates')
 #endif
+      !$acc exit data delete(wgtTmp, flxTmp, sgnTmp, &
+      !$acc                  tracerCur, tracerMin, tracerMax, &
+      !$acc                  hNewInv, hProv, hProvInv, flxIn, flxOut, &
+      !$acc                  workTend, lowOrderFlx, highOrderFlx)
+
       deallocate(wgtTmp,       &
                  flxTmp,       &
                  sgnTmp,       &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -107,7 +107,6 @@ module ocn_tracer_advection_mono
          cell1, cell2,    &! neighbor cell indices
          nCells, nEdges,  &! numbers of cells or edges
          k,k2,kmin, kmax, &! vert index variants
-         nVertLevels,     &! total num vertical levels
          iTracer,         &! tracer index
          numTracers        ! total number of tracers
 
@@ -160,7 +159,7 @@ module ocn_tracer_advection_mono
 
       ! allocate temporary arrays
       allocate(wgtTmp      (nVertLevels), &
-               flxTmp      (nVertlevels), &
+               flxTmp      (nVertLevels), &
                sgnTmp      (nVertLevels), &
                tracerCur   (nVertLevels  ,nCells+1), &
                tracerMin   (nVertLevels  ,nCells), &
@@ -283,8 +282,8 @@ module ocn_tracer_advection_mono
 
           ! compute some common intermediate factors
           do k = 1, nVertLevels
-             wgtTmp(k) = normalThicknessFlux   (k,iEdge)* &
-                         highOrderAdvectionMask(k,iEdge)
+             wgtTmp(k) = normalThicknessFlux(k,iEdge)* &
+                         advMaskHighOrder(k,iEdge)
              sgnTmp(k) = sign(1.0_RKIND, &
                               normalThicknessFlux(k,iEdge))
              flxTmp(k) = 0.0_RKIND
@@ -310,7 +309,7 @@ module ocn_tracer_advection_mono
           ! Remove low order flux from the high order flux
           ! Store left over high order flux in highOrderFlx array
           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-            tracerWeight = (1.0_RKIND - highOrderAdvectionMask(k,iEdge)) &
+            tracerWeight = (1.0_RKIND - advMaskHighOrder(k,iEdge)) &
                          * (dvEdge(iEdge) * 0.5_RKIND)                   &
                          * normalThicknessFlux(k, iEdge)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -26,10 +26,11 @@ module ocn_tracer_advection_mono
 #endif
    use mpas_kind_types
 
-   use ocn_constants
+   use ocn_config
    use ocn_mesh
    use ocn_diagnostics_variables
    use ocn_tracer_advection_shared
+   use ocn_tracer_advection_vert
 
    implicit none
    private
@@ -40,12 +41,6 @@ module ocn_tracer_advection_mono
       coef3rdOrder        !< high-order horizontal coefficient
    logical ::            &
       monotonicityCheck   !< flag to check monotonicity
-   integer ::            &
-      vertOrder           !< choice of order for vertical advection
-   integer, parameter :: &! enum for supported vertical algorithm order
-      vertOrder2 = 2,    &!< 2nd order scheme
-      vertOrder3 = 3,    &!< 3rd order scheme
-      vertOrder4 = 4      !< 4th order scheme
 
    ! public method interfaces
    public :: ocn_tracer_advection_mono_tend, &
@@ -121,8 +116,6 @@ module ocn_tracer_advection_mono
          tracerWeight,      &! tracer weighting temporary
          invAreaCell1,      &! inverse cell area
          invAreaCell2,      &! inverse cell area
-         verticalWeightK,   &! vertical weighting
-         verticalWeightKm1, &! vertical weighting
          coef1, coef3        ! temporary coefficients
 
       real (kind=RKIND), dimension(:), allocatable :: &
@@ -538,12 +531,9 @@ module ocn_tracer_advection_mono
         !$omp parallel
         !$omp do schedule(runtime) private(k)
         do iCell = 1, nCells
-          do k=1, nVertLevels
-            highOrderFlx(k, iCell) = 0.0_RKIND
-            workTend(k, iCell) = 0.0_RKIND
-          end do ! k loop
-          highOrderFlx(nVertLevels+1, iCell) = 0.0_RKIND
-
+        do k=1, nVertLevels
+           workTend(k, iCell) = 0.0_RKIND
+        end do ! k loop
         end do ! iCell loop
         !$omp end do
         !$omp end parallel
@@ -588,104 +578,20 @@ module ocn_tracer_advection_mono
         !$omp end parallel
 
         ! Compute the high order vertical fluxes based on order selected.
-        ! Special cases for top and bottom layers handled in following loop.
 
-        select case (vertOrder)
-        case (vertOrder4)
+        call ocn_tracer_advection_vert_flx(tracerCur, w, hProv, &
+                                           highOrderFlx)
 
-          !$omp parallel
-          !$omp do schedule(runtime) private(kmin, kmax, k)
-          do iCell = 1, nCells
-            kmin = minLevelCell(iCell)
-            kmax = maxLevelCell(iCell)
-            do k=kmin+2,kmax-1
-              highOrderFlx(k, iCell) = w(k,iCell)*( &
-                  7.0_RKIND*(tracerCur(k  ,iCell) + tracerCur(k-1,iCell)) - &
-                            (tracerCur(k+1,iCell) + tracerCur(k-2,iCell)))/ &
-                  12.0_RKIND
-
-            end do
-          end do ! cell loop
-          !$omp end do
-          !$omp end parallel
-
-        case (vertOrder3)
-
-          !$omp parallel
-          !$omp do schedule(runtime) private(kmin, kmax, k)
-          do iCell = 1, nCells
-            kmin = minLevelCell(iCell)
-            kmax = maxLevelCell(iCell)
-            do k=kmin+2,kmax-1
-              highOrderFlx(k, iCell) = (w(k,iCell)* &
-                   (7.0_RKIND*(tracerCur(k  ,iCell) + tracerCur(k-1,iCell)) - &
-                              (tracerCur(k+1,iCell) + tracerCur(k-2,iCell))) - &
-                        coef3rdOrder*abs(w(k,iCell))* &
-                             ((tracerCur(k+1,iCell) - tracerCur(k-2,iCell)) - &
-                    3.0_RKIND*(tracerCur(k  ,iCell) - tracerCur(k-1,iCell))))/ &
-                   12.0_RKIND
-
-
-            end do
-          end do ! cell loop
-          !$omp end do
-          !$omp end parallel
-
-       case (vertOrder2)
-
-          !$omp parallel
-          !$omp do schedule(runtime) private(kmin, kmax, k, verticalWeightK, verticalWeightKm1)
-          do iCell = 1, nCells
-            kmin = minLevelCell(iCell)
-            kmax = maxLevelCell(iCell)
-            do k=kmin+2,kmax-1
-              verticalWeightK   = hProv(k-1,iCell) / &
-                                 (hProv(k  ,iCell) + hProv(k-1,iCell))
-              verticalWeightKm1 = hProv(k  ,iCell) / &
-                                 (hProv(k  ,iCell) + hProv(k-1,iCell))
-              highOrderFlx(k,iCell) = w(k,iCell)* &
-                                 (verticalWeightK  *tracerCur(k  ,iCell) + &
-                                  verticalWeightKm1*tracerCur(k-1,iCell))
-            end do
-          end do ! cell loop
-          !$omp end do
-          !$omp end parallel
-
-        end select ! vertical order
-
-        ! Treat special cases for high order flux
         ! Compute low order upwind vertical flux (monotonic and diffused)
         ! Remove low order flux from the high order flux.
         ! Store left over high order flux in highOrderFlx array.
+
         !$omp parallel
-        !$omp do schedule(runtime) private(kmin, kmax, verticalWeightK, verticalWeightKm1, k)
+        !$omp do schedule(runtime) private(kmin, kmax, k)
         do iCell = 1, nCells
           kmin = minLevelCell(iCell)
           kmax = maxLevelCell(iCell)
-          ! Next-to-top cell in column is second-order
-          highOrderFlx(kmin,iCell) = 0.0_RKIND
-          if (kmax > kmin) then
-            k = kmin+1
-            verticalWeightK   = hProv(k-1,iCell) / &
-                               (hProv(k  ,iCell) + hProv(k-1,iCell))
-            verticalWeightKm1 = hProv(k  ,iCell) / &
-                               (hProv(k  ,iCell) + hProv(k-1,iCell))
-            highOrderFlx(k,iCell) = w(k,iCell)* &
-                               (verticalWeightK  *tracerCur(k  ,iCell) + &
-                                verticalWeightKm1*tracerCur(k-1,iCell))
-          end if
-          ! Deepest vertical cell in column is second order
-          k = max(kmin+1,kmax)
-          verticalWeightK   = hProv(k-1,iCell) / &
-                             (hProv(k  ,iCell) + hProv(k-1,iCell))
-          verticalWeightKm1 = hProv(k  ,iCell) / &
-                             (hProv(k  ,iCell) + hProv(k-1,iCell))
-          highOrderFlx(k,iCell) = w(k,iCell)* &
-                             (verticalWeightK  *tracerCur(k  ,iCell) + &
-                              verticalWeightKm1*tracerCur(k-1,iCell))
-          highOrderFlx(k+1,iCell) = 0.0_RKIND
 
-          ! Compute low order (upwind) flux and remove from high order
           lowOrderFlx(kmin,iCell) = 0.0_RKIND
           do k = kmin+1, kmax
             lowOrderFlx(k,iCell) = &
@@ -881,22 +787,7 @@ module ocn_tracer_advection_mono
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_advection_mono_init(nHalos, horizAdvOrder,        &
-                                             vertAdvOrder, inCoef3rdOrder, &
-                                             checkMonotonicity, err)!{{{
-
-      !*** input parameters
-
-      integer, intent(in) :: &
-         nHalos               !< [in] number of halos in current simulation
-      integer, intent(in) :: &
-         horizAdvOrder        !< [in] order for horizontal advection
-      integer, intent(in) :: &
-         vertAdvOrder         !< [in] order for vertical advection
-      real (kind=RKIND), intent(in) :: &
-         inCoef3rdOrder       !< [in] coefficient for blending advection orders
-      logical, intent(in) :: &
-         checkMonotonicity    !< [in] flag to check monotonicity of tracers
+   subroutine ocn_tracer_advection_mono_init(err)!{{{
 
       !*** output parameters
 
@@ -910,7 +801,7 @@ module ocn_tracer_advection_mono
       err = 0 ! initialize error code to success
 
       ! Check that the halo is wide enough for FCT
-      if (nHalos < 3) then
+      if (config_num_halos < 3) then
          call mpas_log_write( &
             'Monotonic advection cannot be used with less than 3 halos.', &
             MPAS_LOG_CRIT)
@@ -918,11 +809,11 @@ module ocn_tracer_advection_mono
       end if
 
       ! Set blending coefficient if 3rd order horizontal advection chosen
-      select case (horizAdvOrder)
+      select case (config_horiz_tracer_adv_order)
       case (2)
          coef3rdOrder = 0.0_RKIND
       case (3)
-         coef3rdOrder = inCoef3rdOrder
+         coef3rdOrder = config_coef_3rd_order
       case (4)
          coef3rdOrder = 0.0_RKIND
       case default
@@ -932,28 +823,13 @@ module ocn_tracer_advection_mono
             MPAS_LOG_WARN)
       end select ! horizontal advection order
 
-      ! Set vertical advection order
-      select case (vertAdvOrder)
-      case (2)
-         vertOrder = vertOrder2
-      case (3)
-         vertOrder = vertOrder3
-      case (4)
-         vertOrder = vertOrder4
-      case default
-         vertOrder = vertOrder2
-         call mpas_log_write( &
-            'Invalid value for vertical advection order, defaulting to 2', &
-            MPAS_LOG_WARN)
-      end select ! vertical advection order
-
       ! Set flag for checking monotonicity
-      monotonicityCheck = checkMonotonicity
+      monotonicityCheck = config_check_tracer_monotonicity
 
    end subroutine ocn_tracer_advection_mono_init!}}}
 
-!**********************************************************************
+!***********************************************************************
 
 end module ocn_tracer_advection_mono
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
@@ -1,0 +1,739 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  mpas_ocn_tracer_advection_shared
+!
+!> \brief MPAS ocean tracer advection common coefficients and variables
+!> \author Doug Jacobsen
+!> \date   03/09/12
+!> \details
+!>  This module contains the routines and arrays for some common 
+!>  tracer advection quantities.
+!
+!-----------------------------------------------------------------------
+
+module ocn_tracer_advection_shared
+
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_hash
+   use mpas_sort
+   use mpas_geometry_utils
+   use mpas_log
+
+   use ocn_mesh
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   ! Public variables (should only be used by other advection modules)
+   !--------------------------------------------------------------------
+
+   integer, public :: &
+      nAdvCellsMax     ! largest number of advection cells for any edge
+
+   integer, public, dimension(:), allocatable :: &
+      nAdvCellsForEdgeNew ! number of cells contrib to advection at edge
+
+   integer, public, dimension(:,:), allocatable :: &
+      advCellsForEdgeNew ! index of cells contributing to advection at edge
+
+   real (kind=RKIND), public, dimension(:,:), allocatable :: &
+      advCoefsNew,    &! common advection coefficients
+      advCoefs3rdNew, &! common advection coeffs for high order
+      advMaskHighOrder ! mask for high order advection terms
+
+   !--------------------------------------------------------------------
+   ! Public member functions 
+   !-------------------------------------------------------------------- 
+
+   public :: ocn_tracerAdvectSharedInit
+
+!***********************************************************************
+
+   contains
+
+!***********************************************************************
+!
+!  routine ocn_tracerAdvectSharedInit
+!
+!> \brief MPAS tracer advection coefficients
+!> \author Doug Jacobsen, Bill Skamarock
+!> \date   03/09/12
+!> \details
+!>  This routine precomputes advection coefficients for horizontal
+!>  advection of tracers.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracerAdvectSharedInit(advOrder, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         advOrder            !< [in] Order of horizontal advection
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] Error flag
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         n, i, k,      &! loop indices for neighbor, vertical loops
+         iEdge, iCell, &! loop indices for edge, cell loops
+         cell1, cell2   ! neighbor cell indices across edge
+
+      integer, dimension(:), allocatable :: &
+         cellIndx       ! cell indices gathered from neighbors 
+
+      integer, dimension(:,:), allocatable :: &
+         cellIndxSorted ! nbr cell indices sorted
+
+      real (kind=RKIND), dimension(:,:,:), allocatable :: &
+         derivTwo !< 2nd derivative values for polynomial fit to tracers
+
+      type (hashtable) :: cell_hash
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      err = 0 ! initialize error code
+
+      ! define max number of advection cells as max number of edges*2
+      nAdvCellsMax = maxEdges2
+
+      ! Allocate common variables
+      allocate(nAdvCellsForEdgeNew (             nEdgesAll),   &
+                advCellsForEdgeNew (nAdvCellsMax,nEdgesAll), &
+                advCoefsNew        (nAdvCellsMax,nEdgesAll), &
+                advCoefs3rdNew     (nAdvCellsMax,nEdgesAll), &
+                advMaskHighOrder(nVertLevels ,nEdgesAll), &
+                derivTwo      (nAdvCellsMax,2,nEdgesAll))
+
+      ! Compute derivTwo array
+      call computeDerivTwo(derivTwo, err)
+      if (err /= 0) then
+         call mpas_log_write( &
+            'Error computing derivTwo in ocn advect shared init ', &
+             MPAS_LOG_CRIT)
+         deallocate (derivTwo)
+         return
+      endif
+
+      allocate(cellIndx      (   maxEdges2 + 2), &
+               cellIndxSorted(2, maxEdges2 + 2))
+
+      ! Compute masks and coefficients
+      do iEdge = 1, nEdgesAll
+         nAdvCellsForEdgeNew(iEdge) = 0
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+
+         ! at boundaries, must stay at low order
+         do k = 1, nVertLevels
+            if (boundaryCell(k,cell1) == 1 .or. &
+                boundaryCell(k,cell2) == 1) then
+               advMaskHighOrder(k,iEdge) = 0.0_RKIND
+            else
+               advMaskHighOrder(k,iEdge) = 1.0_RKIND
+            end if
+         end do
+
+         ! do only if this edge flux is needed to update owned cells
+         if (cell1 <= nCellsAll .and. cell2 <= nCellsAll) then
+            ! Insert cellsOnEdge to list of advection cells
+            call mpas_hash_init(cell_hash)
+            call mpas_hash_insert(cell_hash, cell1)
+            call mpas_hash_insert(cell_hash, cell2)
+            cellIndx(1) = cell1
+            cellIndx(2) = cell2
+            cellIndxSorted(1,1) = indexToCellID(cell1)
+            cellIndxSorted(2,1) = cell1
+            cellIndxSorted(1,2) = indexToCellID(cell2)
+            cellIndxSorted(2,2) = cell2
+            n = 2
+
+            ! Build unique list of cells used for advection on edge
+            ! by expanding to the extended neighbor cells
+            do i = 1, nEdgesOnCell(cell1)
+               if (.not. mpas_hash_search(cell_hash, &
+                                          cellsOnCell(i,cell1))) then
+                  n = n + 1
+                  cellIndx(n) = cellsOnCell(i, cell1)
+                  cellIndxSorted(1,n) = indexToCellID(cellsOnCell(i,cell1))
+                  cellIndxSorted(2,n) = cellsOnCell(i,cell1)
+                  call mpas_hash_insert(cell_hash,cellsOnCell(i,cell1))
+               end if
+            end do
+
+            do i = 1, nEdgesOnCell(cell2)
+               if(.not. mpas_hash_search(cell_hash, &
+                                         cellsOnCell(i, cell2))) then
+                  n = n + 1
+                  cellIndx(n) = cellsOnCell(i, cell2)
+                  cellIndxSorted(1,n) = indexToCellID(cellsOnCell(i,cell2))
+                  cellIndxSorted(2,n) = cellsOnCell(i,cell2)
+                  call mpas_hash_insert(cell_hash, cellsOnCell(i,cell2))
+               end if
+            end do
+
+            call mpas_hash_destroy(cell_hash)
+
+            ! sort the cell indices by cellID
+            call mpas_quicksort(n, cellIndxSorted)
+
+            ! store local cell indices for high-order calculations
+            nAdvCellsForEdgeNew(iEdge) = n
+            do iCell = 1, nAdvCellsForEdgeNew(iEdge)
+               advCellsForEdgeNew(iCell,iEdge) = cellIndxSorted(2,iCell)
+            end do
+
+            ! equation 7 in Skamarock, W. C., & Gassmann, A. (2011):
+            ! F(u,psi)_{i+1/2} = u_{i+1/2} *
+            !  [   1/2 (psi_{i+1} + psi_i)                       term 1
+            !    - 1/12(dx^2psi_{i+1} + dx^2psi_i)               term 2
+            !    + sign(u) beta/12 (dx^2psi_{i+1} - dx^2psi_i)]  term 3
+            !                                         (note minus sign)
+            !
+            ! advCoefs accounts for terms 1 and 2 in SG11 equation 7.
+            ! Term 1 is the 2nd-order flux-function term. advCoefs
+            ! accounts for this with the "+ 0.5" lines below. In the
+            ! advection routines that use these coefficients, the
+            ! 2nd-order flux loop is then skipped. Term 2 is the
+            ! 4th-order flux-function term. advCoefs accounts for
+            ! term 3, the beta term. beta > 0 corresponds to the
+            ! third-order flux function. The - sign in the derivTwo
+            ! accumulation is for the i+1 part of term 3, while
+            ! the + sign is for the i part.
+
+            do i=1,nAdvCellsMax
+               advCoefsNew    (i,iEdge) = 0.0_RKIND
+               advCoefs3rdNew(i,iEdge) = 0.0_RKIND
+            end do
+
+            ! pull together third and fourth order contributions to the
+            ! flux first from cell1
+            i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                    nAdvCellsForEdgeNew(iEdge), indexToCellID(cell1))
+            if (i <= nAdvCellsForEdgeNew(iEdge)) then
+               advCoefsNew    (i,iEdge) = advCoefsNew(i,iEdge) + &
+                                        derivTwo(1,1,iEdge)
+               advCoefs3rdNew(i,iEdge) = advCoefs3rdNew(i,iEdge) + &
+                                        derivTwo(1,1,iEdge)
+            end if
+
+            do iCell = 1, nEdgesOnCell(cell1)
+               i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                              nAdvCellsForEdgeNew(iEdge), &
+                              indexToCellID(cellsOnCell(iCell,cell1)))
+               if (i <= nAdvCellsForEdgeNew(iEdge)) then
+                  advCoefsNew(i,iEdge)     = advCoefsNew(i,iEdge) + &
+                                           derivTwo(iCell+1,1,iEdge)
+                  advCoefs3rdNew(i,iEdge) = advCoefs3rdNew(i,iEdge) + &
+                                           derivTwo(iCell+1,1,iEdge)
+               end if
+            end do
+
+            ! pull together third and fourth order contributions to the
+            ! flux now from cell2
+            i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                       nAdvCellsForEdgeNew(iEdge), indexToCellID(cell2))
+            if (i <= nAdvCellsForEdgeNew(iEdge)) then
+               advCoefsNew    (i,iEdge) = advCoefsNew(i,iEdge) + &
+                                        derivTwo(1,2,iEdge)
+               advCoefs3rdNew(i,iEdge) = advCoefs3rdNew(i,iEdge) - &
+                                        derivTwo(1,2,iEdge)
+            end if
+
+            do iCell = 1, nEdgesOnCell(cell2)
+               i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                           nAdvCellsForEdgeNew(iEdge), &
+                           indexToCellID(cellsOnCell(iCell,cell2)))
+               if (i <= nAdvCellsForEdgeNew(iEdge)) then
+                  advCoefsNew(i,iEdge)     = advCoefsNew(i,iEdge) + &
+                                           derivTwo(iCell+1,2,iEdge)
+                  advCoefs3rdNew(i,iEdge) = advCoefs3rdNew(i,iEdge) - &
+                                           derivTwo(iCell+1,2,iEdge)
+               end if
+            end do
+
+            do iCell = 1,nAdvCellsForEdgeNew(iEdge)
+               advCoefsNew    (iCell,iEdge) = - (dcEdge(iEdge)**2)* &
+                                      advCoefsNew(iCell,iEdge) / 12.
+               advCoefs3rdNew(iCell,iEdge) = - (dcEdge(iEdge)**2)* &
+                                  advCoefs3rdNew(iCell,iEdge) / 12.
+            end do
+
+            ! 2nd order centered contribution
+            ! place this in the main flux weights
+            i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                                   nAdvCellsForEdgeNew(iEdge), &
+                                   indexToCellID(cell1))
+            if (i <= nAdvCellsForEdgeNew(iEdge)) then
+               advCoefsNew(i,iEdge) = advCoefsNew(i, iEdge) + 0.5
+            end if
+
+            i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                                   nAdvCellsForEdgeNew(iEdge), &
+                                   indexToCellID(cell2))
+            if (i <= nAdvCellsForEdgeNew(iEdge)) then
+               advCoefsNew(i,iEdge) = advCoefsNew(i, iEdge) + 0.5
+            end if
+
+            ! multiply by edge length - thus the flux is just dt*ru
+            ! times the results of the vector-vector multiply
+            do iCell=1,nAdvCellsForEdgeNew(iEdge)
+               advCoefsNew    (iCell,iEdge) = dvEdge(iEdge)* &
+                                            advCoefsNew    (iCell,iEdge)
+               advCoefs3rdNew(iCell,iEdge) = dvEdge(iEdge)* &
+                                            advCoefs3rdNew(iCell,iEdge)
+            end do
+         end if  ! only do for edges of owned-cells
+      end do ! end loop over edges
+
+      deallocate(cellIndx, &
+                 cellIndxSorted, &
+                 derivTwo)
+
+      ! If 2nd order advection, disable high-order terms by
+      ! setting mask to zero.
+      if (advOrder == 2) advMaskHighOrder(:,:) = 0.0_RKIND
+
+      print *,nEdgesAll, nAdvCellsMax
+      do iEdge = 1,nEdgesAll
+      do i=1,nAdvCellsMax
+         if (advCoefsNew(i,iEdge) /= advCoefs(i,iEdge)) &
+            print *, i,iEdge,advCoefsNew(i,iEdge), advCoefs(i,iEdge)
+         if (advCoefs3rdNew(i,iEdge) /= advCoefs3rd(i,iEdge)) &
+            print *, i,iEdge,advCoefs3rdNew(i,iEdge), advCoefs3rd(i,iEdge)
+      end do
+      end do
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracerAdvectSharedInit !}}}
+
+!***********************************************************************
+!
+!  routine computeDerivTwo
+!
+!> \brief MPAS deriv two computation
+!> \author Doug Jacobsen, Bill Skamarock
+!> \date   03/09/12
+!> \details
+!>  This routine precomputes the second derivative values for tracer
+!>  advection. It computes cell coefficients for the polynomial fit
+!>  as described in:
+!>  Skamarock, W. C., & Gassmann, A. (2011). 
+!>    Conservative Transport Schemes for Spherical Geodesic Meshs:
+!>    High-Order Flux Operators for ODE-Based Time Integration. 
+!>    Monthly Weather Review, 139(9), 2962-2975.
+!>    doi:10.1175/MWR-D-10-05056.1
+!>  This is performed during model initialization.
+!
+!-----------------------------------------------------------------------
+
+   subroutine computeDerivTwo(derivTwo, err)!{{{
+                                      
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(out) :: &
+         derivTwo !< [out] 2nd deriv values of polynomial for tracer fit
+
+      integer, intent(out) :: err !< [out] returned error flag
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      logical :: &
+         addCell,      &! flag for adding cell add to list 
+         doCell         ! flag for whether to process cell
+
+      integer, parameter :: &
+         polynomial_order = 2  ! option for polynomial order, forced to 2
+
+      integer :: &
+         i, j, k, n,   &! loop counters
+         ip1, ip2,     &! temps for i+1, i+2
+         iCell, iEdge, &! loop indices for cell, edge loops
+         ma, na, cell_add, mw
+
+      real (kind=RKIND) :: &
+         xec, yec, zec,    &! arc bisection coords
+         thetae_tmp,       &! angle
+         xv1, xv2, yv1, yv2, zv1, zv2, &! vertex cart coords
+         pii,              &! pi math constant
+         length_scale,     &! length scale
+         cos2t, costsint, sin2t  ! trig function temps
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         thetae          ! sphere angle between vectors 
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         theta_abs,     &! sphere angle
+         angle_2d        ! 2d angle
+
+      integer, dimension(25) :: cell_list
+
+      real (kind=RKIND), dimension(25) :: &
+         xc, yc, zc,    &! cell center coordinates
+         xp, yp,        &!
+         thetav, thetat, dl_sphere
+
+      real (kind=RKIND) :: &
+         amatrix(25,25), bmatrix(25,25), wmatrix(25,25)
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! set return code and check proper poly order
+      err = 0
+
+      if (polynomial_order > 2) then
+        call mpas_log_write( &
+           'Polynomial for second derivitave can only be 2',  &
+           MPAS_LOG_ERR)
+        err = 1
+        return
+      end if
+
+      ! allocate local arrays
+      allocate(thetae(2, nEdgesAll))
+      allocate(theta_abs(nCellsAll))
+      allocate(angle_2d(maxEdges))
+
+      ! Initialize derivTwo and pi
+
+      pii = 2.*asin(1.0)
+      derivTwo(:,:,:) = 0.0_RKIND
+
+      do iCell = 1, nCellsAll
+
+         cell_list(1) = iCell
+         do i=2, nEdgesOnCell(iCell)+1
+            cell_list(i) = cellsOnCell(i-1,iCell)
+         end do
+         n = nEdgesOnCell(iCell) + 1
+
+         !if ( polynomial_order > 2 ) then
+         !   do i=2, nEdgesOnCell(iCell) + 1
+         !      do j=1, nEdgesOnCell( cell_list(i) )
+         !         cell_add = cellsOnCell(j,cell_list(i))
+         !         addCell = .true.
+         !         do k=1,n
+         !            if ( cell_add == cell_list(k) ) addCell = .false.
+         !         end do
+         !         if (addCell) then
+         !            n = n+1
+         !            cell_list(n) = cell_add
+         !         end if
+         !      end do
+         !   end do
+         !end if
+ 
+         ! check to see if we are reaching outside the halo
+
+         doCell = .true.
+         do i=1,n
+            if (cell_list(i) > nCellsAll) doCell = .false.
+         end do
+
+         if ( .not. doCell ) cycle
+
+         ! compute poynomial fit for this cell if all needed
+         ! neighbors exist
+         if ( onSphere ) then
+
+            do i=1,n
+               j = cell_list(i) + 1
+               xc(i) = xCell(j) / sphereRadius
+               yc(i) = yCell(j) / sphereRadius
+               zc(i) = zCell(j) / sphereRadius
+            end do
+
+            if ( zc(1) == 1.0_RKIND) then
+               theta_abs(iCell) = pii/2.0_RKIND
+            else
+               theta_abs(iCell) = pii/2.0_RKIND &
+                        - mpas_sphere_angle( xc(1), yc(1), zc(1), &
+                                             xc(2), yc(2), zc(2), &
+                                   0.0_RKIND, 0.0_RKIND, 1.0_RKIND) 
+            end if
+
+            ! angles from cell center to neighbor centers (thetav)
+
+            do i=1,n-1
+   
+               ip2 = i+2
+               if (ip2 > n) ip2 = 2
+    
+               thetav(i) = mpas_sphere_angle(xc(  1), yc(  1), zc(  1),&
+                                             xc(i+1), yc(i+1), zc(i+1),&
+                                             xc(ip2), yc(ip2), zc(ip2))
+
+               dl_sphere(i) = sphereRadius* &
+                              mpas_arc_length(xc(  1),yc(  1),zc(  1), &
+                                              xc(i+1),yc(i+1),zc(i+1))
+            end do
+
+            length_scale = 1.0_RKIND
+            do i=1,n-1
+               dl_sphere(i) = dl_sphere(i)/length_scale
+            end do
+
+            ! thetat(1) = 0.  !  this defines the x direction, cell center 1 -> 
+            ! this defines the x direction, longitude line
+            thetat(1) = theta_abs(iCell)
+            do i=2,n-1
+               thetat(i) = thetat(i-1) + thetav(i-1)
+            end do
+   
+            do i=1,n-1
+               xp(i) = cos(thetat(i)) * dl_sphere(i)
+               yp(i) = sin(thetat(i)) * dl_sphere(i)
+            end do
+
+         else     ! On an x-y plane
+
+            do i=1,n-1
+
+               angle_2d(i) = angleEdge(edgesOnCell(i,iCell))
+               iEdge = edgesOnCell(i,iCell)
+               if ( iCell .ne. cellsOnEdge(1,iEdge)) &
+                  angle_2d(i) = angle_2d(i) - pii
+
+               xp(i) = dcEdge(edgesOnCell(i,iCell)) * cos(angle_2d(i))
+               yp(i) = dcEdge(edgesOnCell(i,iCell)) * sin(angle_2d(i))
+
+            end do
+
+         end if
+
+
+         ma = n-1
+         mw = nEdgesOnCell(iCell)
+
+         bmatrix = 0.
+         amatrix = 0.
+         wmatrix = 0.
+
+         if (polynomial_order == 2) then
+            na = 6
+            ma = ma+1
+  
+            amatrix(1,1) = 1.
+            wmatrix(1,1) = 1.
+            do i=2,ma
+               amatrix(i,1) = 1.
+               amatrix(i,2) = xp(i-1)
+               amatrix(i,3) = yp(i-1)
+               amatrix(i,4) = xp(i-1)**2
+               amatrix(i,5) = xp(i-1) * yp(i-1)
+               amatrix(i,6) = yp(i-1)**2
+   
+               wmatrix(i,i) = 1.
+            end do
+ 
+         else if (polynomial_order == 3) then
+            na = 10
+            ma = ma+1
+  
+            amatrix(1,1) = 1.
+            wmatrix(1,1) = 1.
+            do i=2,ma
+               amatrix(i,1) = 1.
+               amatrix(i,2) = xp(i-1)
+               amatrix(i,3) = yp(i-1)
+   
+               amatrix(i,4) = xp(i-1)**2
+               amatrix(i,5) = xp(i-1) * yp(i-1)
+               amatrix(i,6) = yp(i-1)**2
+   
+               amatrix(i,7) = xp(i-1)**3
+               amatrix(i,8) = yp(i-1) * (xp(i-1)**2)
+               amatrix(i,9) = xp(i-1) * (yp(i-1)**2)
+               amatrix(i,10) = yp(i-1)**3
+   
+               wmatrix(i,i) = 1.
+ 
+            end do
+
+         else
+            na = 15
+            ma = ma+1
+  
+            amatrix(1,1) = 1.
+            wmatrix(1,1) = 1.
+            do i=2,ma
+               amatrix(i,1) = 1.
+               amatrix(i,2) = xp(i-1)
+               amatrix(i,3) = yp(i-1)
+   
+               amatrix(i,4) = xp(i-1)**2
+               amatrix(i,5) = xp(i-1) * yp(i-1)
+               amatrix(i,6) = yp(i-1)**2
+   
+               amatrix(i,7) = xp(i-1)**3
+               amatrix(i,8) = yp(i-1) * (xp(i-1)**2)
+               amatrix(i,9) = xp(i-1) * (yp(i-1)**2)
+               amatrix(i,10) = yp(i-1)**3
+   
+               amatrix(i,11) = xp(i-1)**4
+               amatrix(i,12) = yp(i-1) * (xp(i-1)**3)
+               amatrix(i,13) = (xp(i-1)**2)*(yp(i-1)**2)
+               amatrix(i,14) = xp(i-1) * (yp(i-1)**3)
+               amatrix(i,15) = yp(i-1)**4
+   
+               wmatrix(i,i) = 1.
+  
+            end do
+ 
+            do i=1,mw
+               wmatrix(i,i) = 1.
+            end do
+ 
+         end if
+ 
+         call mpas_poly_fit_2( amatrix, bmatrix, wmatrix, ma, na, 25 )
+
+         do i=1, nEdgesOnCell(iCell)
+            ip1 = i+1
+            if (ip1 > n-1) ip1 = 1
+  
+            iEdge = edgesOnCell(i,iCell)
+
+            if ( onSphere ) then
+              xv1 = xVertex(verticesOnEdge(1,iedge)) / sphereRadius
+              yv1 = yVertex(verticesOnEdge(1,iedge)) / sphereRadius
+              zv1 = zVertex(verticesOnEdge(1,iedge)) / sphereRadius
+              xv2 = xVertex(verticesOnEdge(2,iedge)) / sphereRadius
+              yv2 = yVertex(verticesOnEdge(2,iedge)) / sphereRadius
+              zv2 = zVertex(verticesOnEdge(2,iedge)) / sphereRadius
+            else
+              xv1 = xVertex(verticesOnEdge(1,iedge))
+              yv1 = yVertex(verticesOnEdge(1,iedge))
+              zv1 = zVertex(verticesOnEdge(1,iedge))
+              xv2 = xVertex(verticesOnEdge(2,iedge))
+              yv2 = yVertex(verticesOnEdge(2,iedge))
+              zv2 = zVertex(verticesOnEdge(2,iedge))
+            end if
+  
+            if ( onSphere ) then
+               call mpas_arc_bisect( xv1, yv1, zv1,  &
+                                xv2, yv2, zv2,  &
+                                xec, yec, zec   )
+  
+               thetae_tmp = mpas_sphere_angle( xc(1),   yc(1),   zc(1),    &
+                                          xc(i+1), yc(i+1), zc(i+1),  &
+                                          xec,     yec,     zec       )
+               thetae_tmp = thetae_tmp + thetat(i)
+               if (iCell == cellsOnEdge(1,iEdge)) then
+                  thetae(1, edgesOnCell(i,iCell)) = thetae_tmp
+               else
+                  thetae(2, edgesOnCell(i,iCell)) = thetae_tmp
+               end if
+            end if
+  
+         end do
+
+         ! fill second derivative stencil for rk advection 
+
+         do i=1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i,iCell)
+  
+  
+            if ( onSphere ) then
+               if (iCell == cellsOnEdge(1,iEdge)) then
+  
+                  cos2t = cos(thetae(1, edgesOnCell(i,iCell)))
+                  sin2t = sin(thetae(1, edgesOnCell(i,iCell)))
+                  costsint = cos2t*sin2t
+                  cos2t = cos2t**2
+                  sin2t = sin2t**2
+   
+                  do j=1,n
+                     derivTwo(j,1,iEdge) =   2.*cos2t*bmatrix(4,j)  &
+                                            + 2.*costsint*bmatrix(5,j)  &
+                                            + 2.*sin2t*bmatrix(6,j)
+                  end do
+               else
+     
+                  cos2t = cos(thetae(2, edgesOnCell(i,iCell)))
+                  sin2t = sin(thetae(2, edgesOnCell(i,iCell)))
+                  costsint = cos2t*sin2t
+                  cos2t = cos2t**2
+                  sin2t = sin2t**2
+      
+                  do j=1,n
+                     derivTwo(j,2,iEdge) =   2.*cos2t*bmatrix(4,j)  &
+                                            + 2.*costsint*bmatrix(5,j)  &
+                                            + 2.*sin2t*bmatrix(6,j)
+                  end do
+               end if
+
+            else
+
+               cos2t = cos(angle_2d(i))
+               sin2t = sin(angle_2d(i))
+               costsint = cos2t*sin2t
+               cos2t = cos2t**2
+               sin2t = sin2t**2
+
+!               do j=1,n
+!
+!                  derivTwo(j,1,iEdge) =   2.*xe(iEdge)*xe(iEdge)*bmatrix(4,j)  &
+!                                         + 2.*xe(iEdge)*ye(iEdge)*bmatrix(5,j)  &
+!                                         + 2.*ye(iEdge)*ye(iEdge)*bmatrix(6,j)
+!               end do
+
+               if (iCell == cellsOnEdge(1,iEdge)) then
+                  do j=1,n
+                     derivTwo(j,1,iEdge) =   2.*cos2t*bmatrix(4,j)  &
+                                            + 2.*costsint*bmatrix(5,j)  &
+                                            + 2.*sin2t*bmatrix(6,j)
+                  end do
+               else
+                  do j=1,n
+                     derivTwo(j,2,iEdge) =   2.*cos2t*bmatrix(4,j)  &
+                                            + 2.*costsint*bmatrix(5,j)  &
+                                            + 2.*sin2t*bmatrix(6,j)
+                  end do
+               end if
+
+            end if
+         end do
+ 
+      end do ! end of loop over cells
+
+      deallocate(thetae)
+      deallocate(theta_abs)
+      deallocate(angle_2d)
+
+   !--------------------------------------------------------------------
+
+   end subroutine computeDerivTwo !}}}
+
+!***********************************************************************
+
+end module ocn_tracer_advection_shared
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
@@ -27,6 +27,7 @@ module ocn_tracer_advection_shared
    use mpas_geometry_utils
    use mpas_log
 
+   use ocn_config
    use ocn_mesh
 
    implicit none
@@ -55,7 +56,7 @@ module ocn_tracer_advection_shared
    ! Public member functions 
    !-------------------------------------------------------------------- 
 
-   public :: ocn_tracerAdvectSharedInit
+   public :: ocn_tracer_advection_shared_init
 
 !***********************************************************************
 
@@ -63,7 +64,7 @@ module ocn_tracer_advection_shared
 
 !***********************************************************************
 !
-!  routine ocn_tracerAdvectSharedInit
+!  routine ocn_tracer_advection_shared_init
 !
 !> \brief MPAS tracer advection coefficients
 !> \author Doug Jacobsen, Bill Skamarock
@@ -74,14 +75,7 @@ module ocn_tracer_advection_shared
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracerAdvectSharedInit(advOrder, err)!{{{
-
-      !-----------------------------------------------------------------
-      ! Input variables
-      !-----------------------------------------------------------------
-
-      integer, intent(in) :: &
-         advOrder            !< [in] Order of horizontal advection
+   subroutine ocn_tracer_advection_shared_init(err)!{{{
 
       !-----------------------------------------------------------------
       ! Output variables
@@ -313,11 +307,12 @@ module ocn_tracer_advection_shared
 
       ! If 2nd order advection, disable high-order terms by
       ! setting mask to zero.
-      if (advOrder == 2) advMaskHighOrder(:,:) = 0.0_RKIND
+      if (config_horiz_tracer_adv_order == 2) &
+         advMaskHighOrder(:,:) = 0.0_RKIND
 
    !--------------------------------------------------------------------
 
-   end subroutine ocn_tracerAdvectSharedInit !}}}
+   end subroutine ocn_tracer_advection_shared_init !}}}
 
 !***********************************************************************
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
@@ -41,14 +41,14 @@ module ocn_tracer_advection_shared
       nAdvCellsMax     ! largest number of advection cells for any edge
 
    integer, public, dimension(:), allocatable :: &
-      nAdvCellsForEdgeNew ! number of cells contrib to advection at edge
+      nAdvCellsForEdge ! number of cells contrib to advection at edge
 
    integer, public, dimension(:,:), allocatable :: &
-      advCellsForEdgeNew ! index of cells contributing to advection at edge
+      advCellsForEdge ! index of cells contributing to advection at edge
 
    real (kind=RKIND), public, dimension(:,:), allocatable :: &
-      advCoefsNew,    &! common advection coefficients
-      advCoefs3rdNew, &! common advection coeffs for high order
+      advCoefs,       &! common advection coefficients
+      advCoefs3rd,    &! common advection coeffs for high order
       advMaskHighOrder ! mask for high order advection terms
 
    !--------------------------------------------------------------------
@@ -119,10 +119,10 @@ module ocn_tracer_advection_shared
       nAdvCellsMax = maxEdges2
 
       ! Allocate common variables
-      allocate(nAdvCellsForEdgeNew (             nEdgesAll),   &
-                advCellsForEdgeNew (nAdvCellsMax,nEdgesAll), &
-                advCoefsNew        (nAdvCellsMax,nEdgesAll), &
-                advCoefs3rdNew     (nAdvCellsMax,nEdgesAll), &
+      allocate(nAdvCellsForEdge (             nEdgesAll),   &
+                advCellsForEdge (nAdvCellsMax,nEdgesAll), &
+                advCoefs        (nAdvCellsMax,nEdgesAll), &
+                advCoefs3rd     (nAdvCellsMax,nEdgesAll), &
                 advMaskHighOrder(nVertLevels ,nEdgesAll), &
                 derivTwo      (nAdvCellsMax,2,nEdgesAll))
 
@@ -141,7 +141,7 @@ module ocn_tracer_advection_shared
 
       ! Compute masks and coefficients
       do iEdge = 1, nEdgesAll
-         nAdvCellsForEdgeNew(iEdge) = 0
+         nAdvCellsForEdge(iEdge) = 0
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
@@ -199,9 +199,9 @@ module ocn_tracer_advection_shared
             call mpas_quicksort(n, cellIndxSorted)
 
             ! store local cell indices for high-order calculations
-            nAdvCellsForEdgeNew(iEdge) = n
-            do iCell = 1, nAdvCellsForEdgeNew(iEdge)
-               advCellsForEdgeNew(iCell,iEdge) = cellIndxSorted(2,iCell)
+            nAdvCellsForEdge(iEdge) = n
+            do iCell = 1, nAdvCellsForEdge(iEdge)
+               advCellsForEdge(iCell,iEdge) = cellIndxSorted(2,iCell)
             end do
 
             ! equation 7 in Skamarock, W. C., & Gassmann, A. (2011):
@@ -223,86 +223,86 @@ module ocn_tracer_advection_shared
             ! the + sign is for the i part.
 
             do i=1,nAdvCellsMax
-               advCoefsNew    (i,iEdge) = 0.0_RKIND
-               advCoefs3rdNew(i,iEdge) = 0.0_RKIND
+               advCoefs   (i,iEdge) = 0.0_RKIND
+               advCoefs3rd(i,iEdge) = 0.0_RKIND
             end do
 
             ! pull together third and fourth order contributions to the
             ! flux first from cell1
             i = mpas_binary_search(cellIndxSorted, 2, 1, &
-                    nAdvCellsForEdgeNew(iEdge), indexToCellID(cell1))
-            if (i <= nAdvCellsForEdgeNew(iEdge)) then
-               advCoefsNew    (i,iEdge) = advCoefsNew(i,iEdge) + &
-                                        derivTwo(1,1,iEdge)
-               advCoefs3rdNew(i,iEdge) = advCoefs3rdNew(i,iEdge) + &
-                                        derivTwo(1,1,iEdge)
+                    nAdvCellsForEdge(iEdge), indexToCellID(cell1))
+            if (i <= nAdvCellsForEdge(iEdge)) then
+               advCoefs   (i,iEdge) = advCoefs   (i,iEdge) &
+                                    +  derivTwo(1,1,iEdge)
+               advCoefs3rd(i,iEdge) = advCoefs3rd(i,iEdge) &
+                                    +  derivTwo(1,1,iEdge)
             end if
 
             do iCell = 1, nEdgesOnCell(cell1)
                i = mpas_binary_search(cellIndxSorted, 2, 1, &
-                              nAdvCellsForEdgeNew(iEdge), &
+                              nAdvCellsForEdge(iEdge), &
                               indexToCellID(cellsOnCell(iCell,cell1)))
-               if (i <= nAdvCellsForEdgeNew(iEdge)) then
-                  advCoefsNew(i,iEdge)     = advCoefsNew(i,iEdge) + &
-                                           derivTwo(iCell+1,1,iEdge)
-                  advCoefs3rdNew(i,iEdge) = advCoefs3rdNew(i,iEdge) + &
-                                           derivTwo(iCell+1,1,iEdge)
+               if (i <= nAdvCellsForEdge(iEdge)) then
+                  advCoefs   (i,iEdge) = advCoefs   (i,iEdge) &
+                                       + derivTwo(iCell+1,1,iEdge)
+                  advCoefs3rd(i,iEdge) = advCoefs3rd(i,iEdge) &
+                                       + derivTwo(iCell+1,1,iEdge)
                end if
             end do
 
             ! pull together third and fourth order contributions to the
             ! flux now from cell2
             i = mpas_binary_search(cellIndxSorted, 2, 1, &
-                       nAdvCellsForEdgeNew(iEdge), indexToCellID(cell2))
-            if (i <= nAdvCellsForEdgeNew(iEdge)) then
-               advCoefsNew    (i,iEdge) = advCoefsNew(i,iEdge) + &
-                                        derivTwo(1,2,iEdge)
-               advCoefs3rdNew(i,iEdge) = advCoefs3rdNew(i,iEdge) - &
-                                        derivTwo(1,2,iEdge)
+                       nAdvCellsForEdge(iEdge), indexToCellID(cell2))
+            if (i <= nAdvCellsForEdge(iEdge)) then
+               advCoefs   (i,iEdge) = advCoefs   (i,iEdge) &
+                                    +  derivTwo(1,2,iEdge)
+               advCoefs3rd(i,iEdge) = advCoefs3rd(i,iEdge) &
+                                    -  derivTwo(1,2,iEdge)
             end if
 
             do iCell = 1, nEdgesOnCell(cell2)
                i = mpas_binary_search(cellIndxSorted, 2, 1, &
-                           nAdvCellsForEdgeNew(iEdge), &
+                           nAdvCellsForEdge(iEdge), &
                            indexToCellID(cellsOnCell(iCell,cell2)))
-               if (i <= nAdvCellsForEdgeNew(iEdge)) then
-                  advCoefsNew(i,iEdge)     = advCoefsNew(i,iEdge) + &
-                                           derivTwo(iCell+1,2,iEdge)
-                  advCoefs3rdNew(i,iEdge) = advCoefs3rdNew(i,iEdge) - &
-                                           derivTwo(iCell+1,2,iEdge)
+               if (i <= nAdvCellsForEdge(iEdge)) then
+                  advCoefs   (i,iEdge) = advCoefs   (i,iEdge) &
+                                       + derivTwo(iCell+1,2,iEdge)
+                  advCoefs3rd(i,iEdge) = advCoefs3rd(i,iEdge) &
+                                       - derivTwo(iCell+1,2,iEdge)
                end if
             end do
 
-            do iCell = 1,nAdvCellsForEdgeNew(iEdge)
-               advCoefsNew    (iCell,iEdge) = - (dcEdge(iEdge)**2)* &
-                                      advCoefsNew(iCell,iEdge) / 12.
-               advCoefs3rdNew(iCell,iEdge) = - (dcEdge(iEdge)**2)* &
-                                  advCoefs3rdNew(iCell,iEdge) / 12.
+            do iCell = 1,nAdvCellsForEdge(iEdge)
+               advCoefs   (iCell,iEdge) = - (dcEdge(iEdge)**2)* &
+                                     advCoefs(iCell,iEdge) / 12.
+               advCoefs3rd(iCell,iEdge) = - (dcEdge(iEdge)**2)* &
+                                  advCoefs3rd(iCell,iEdge) / 12.
             end do
 
             ! 2nd order centered contribution
             ! place this in the main flux weights
             i = mpas_binary_search(cellIndxSorted, 2, 1, &
-                                   nAdvCellsForEdgeNew(iEdge), &
+                                   nAdvCellsForEdge(iEdge), &
                                    indexToCellID(cell1))
-            if (i <= nAdvCellsForEdgeNew(iEdge)) then
-               advCoefsNew(i,iEdge) = advCoefsNew(i, iEdge) + 0.5
+            if (i <= nAdvCellsForEdge(iEdge)) then
+               advCoefs(i,iEdge) = advCoefs(i, iEdge) + 0.5
             end if
 
             i = mpas_binary_search(cellIndxSorted, 2, 1, &
-                                   nAdvCellsForEdgeNew(iEdge), &
+                                   nAdvCellsForEdge(iEdge), &
                                    indexToCellID(cell2))
-            if (i <= nAdvCellsForEdgeNew(iEdge)) then
-               advCoefsNew(i,iEdge) = advCoefsNew(i, iEdge) + 0.5
+            if (i <= nAdvCellsForEdge(iEdge)) then
+               advCoefs(i,iEdge) = advCoefs(i, iEdge) + 0.5
             end if
 
             ! multiply by edge length - thus the flux is just dt*ru
             ! times the results of the vector-vector multiply
-            do iCell=1,nAdvCellsForEdgeNew(iEdge)
-               advCoefsNew    (iCell,iEdge) = dvEdge(iEdge)* &
-                                            advCoefsNew    (iCell,iEdge)
-               advCoefs3rdNew(iCell,iEdge) = dvEdge(iEdge)* &
-                                            advCoefs3rdNew(iCell,iEdge)
+            do iCell=1,nAdvCellsForEdge(iEdge)
+               advCoefs   (iCell,iEdge) = dvEdge(iEdge)* &
+                                          advCoefs   (iCell,iEdge)
+               advCoefs3rd(iCell,iEdge) = dvEdge(iEdge)* &
+                                          advCoefs3rd(iCell,iEdge)
             end do
          end if  ! only do for edges of owned-cells
       end do ! end loop over edges
@@ -315,15 +315,6 @@ module ocn_tracer_advection_shared
       ! setting mask to zero.
       if (advOrder == 2) advMaskHighOrder(:,:) = 0.0_RKIND
 
-      print *,nEdgesAll, nAdvCellsMax
-      do iEdge = 1,nEdgesAll
-      do i=1,nAdvCellsMax
-         if (advCoefsNew(i,iEdge) /= advCoefs(i,iEdge)) &
-            print *, i,iEdge,advCoefsNew(i,iEdge), advCoefs(i,iEdge)
-         if (advCoefs3rdNew(i,iEdge) /= advCoefs3rd(i,iEdge)) &
-            print *, i,iEdge,advCoefs3rdNew(i,iEdge), advCoefs3rd(i,iEdge)
-      end do
-      end do
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracerAdvectSharedInit !}}}
@@ -464,7 +455,7 @@ module ocn_tracer_advection_shared
          if ( onSphere ) then
 
             do i=1,n
-               j = cell_list(i) + 1
+               j = cell_list(i)
                xc(i) = xCell(j) / sphereRadius
                yc(i) = yCell(j) / sphereRadius
                zc(i) = zCell(j) / sphereRadius
@@ -527,7 +518,6 @@ module ocn_tracer_advection_shared
             end do
 
          end if
-
 
          ma = n-1
          mw = nEdgesOnCell(iCell)
@@ -639,12 +629,13 @@ module ocn_tracer_advection_shared
   
             if ( onSphere ) then
                call mpas_arc_bisect( xv1, yv1, zv1,  &
-                                xv2, yv2, zv2,  &
-                                xec, yec, zec   )
+                                     xv2, yv2, zv2,  &
+                                     xec, yec, zec   )
   
-               thetae_tmp = mpas_sphere_angle( xc(1),   yc(1),   zc(1),    &
-                                          xc(i+1), yc(i+1), zc(i+1),  &
-                                          xec,     yec,     zec       )
+               thetae_tmp = mpas_sphere_angle( &
+                                          xc(  1), yc(  1), zc(  1), &
+                                          xc(i+1), yc(i+1), zc(i+1), &
+                                          xec,     yec,     zec      )
                thetae_tmp = thetae_tmp + thetat(i)
                if (iCell == cellsOnEdge(1,iEdge)) then
                   thetae(1, edgesOnCell(i,iCell)) = thetae_tmp
@@ -660,7 +651,6 @@ module ocn_tracer_advection_shared
          do i=1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
   
-  
             if ( onSphere ) then
                if (iCell == cellsOnEdge(1,iEdge)) then
   
@@ -671,10 +661,11 @@ module ocn_tracer_advection_shared
                   sin2t = sin2t**2
    
                   do j=1,n
-                     derivTwo(j,1,iEdge) =   2.*cos2t*bmatrix(4,j)  &
-                                            + 2.*costsint*bmatrix(5,j)  &
-                                            + 2.*sin2t*bmatrix(6,j)
+                     derivTwo(j,1,iEdge) = 2.*cos2t   *bmatrix(4,j) &
+                                         + 2.*costsint*bmatrix(5,j) &
+                                         + 2.*sin2t   *bmatrix(6,j)
                   end do
+
                else
      
                   cos2t = cos(thetae(2, edgesOnCell(i,iCell)))
@@ -684,9 +675,9 @@ module ocn_tracer_advection_shared
                   sin2t = sin2t**2
       
                   do j=1,n
-                     derivTwo(j,2,iEdge) =   2.*cos2t*bmatrix(4,j)  &
-                                            + 2.*costsint*bmatrix(5,j)  &
-                                            + 2.*sin2t*bmatrix(6,j)
+                     derivTwo(j,2,iEdge) = 2.*cos2t   *bmatrix(4,j) &
+                                         + 2.*costsint*bmatrix(5,j) &
+                                         + 2.*sin2t   *bmatrix(6,j)
                   end do
                end if
 
@@ -707,15 +698,15 @@ module ocn_tracer_advection_shared
 
                if (iCell == cellsOnEdge(1,iEdge)) then
                   do j=1,n
-                     derivTwo(j,1,iEdge) =   2.*cos2t*bmatrix(4,j)  &
-                                            + 2.*costsint*bmatrix(5,j)  &
-                                            + 2.*sin2t*bmatrix(6,j)
+                     derivTwo(j,1,iEdge) = 2.*cos2t   *bmatrix(4,j) &
+                                         + 2.*costsint*bmatrix(5,j) &
+                                         + 2.*sin2t   *bmatrix(6,j)
                   end do
                else
                   do j=1,n
-                     derivTwo(j,2,iEdge) =   2.*cos2t*bmatrix(4,j)  &
-                                            + 2.*costsint*bmatrix(5,j)  &
-                                            + 2.*sin2t*bmatrix(6,j)
+                     derivTwo(j,2,iEdge) = 2.*cos2t   *bmatrix(4,j) &
+                                         + 2.*costsint*bmatrix(5,j) &
+                                         + 2.*sin2t   *bmatrix(6,j)
                   end do
                end if
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
@@ -310,6 +310,10 @@ module ocn_tracer_advection_shared
       if (config_horiz_tracer_adv_order == 2) &
          advMaskHighOrder(:,:) = 0.0_RKIND
 
+      ! Copy module variables to device
+      !$acc enter data copyin(nAdvCellsForEdge, advCellsForEdge, &
+      !$acc                   advCoefs, advCoefs3rd, advMaskHighOrder)
+
    !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_advection_shared_init !}}}

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_tracer_advection_std
 !
@@ -16,18 +16,15 @@
 !>  This module contains routines for advection of tracers using a standard
 !>  FV algorithm in MPAS discretization.
 !
-!-------------------------------------------------------------------------------
+!-----------------------------------------------------------------------
 
 module ocn_tracer_advection_std
 
    ! module includes
    use mpas_kind_types
    use mpas_derived_types
-   use mpas_pool_routines
-   use mpas_io_units
-   use mpas_threading
-
-   use mpas_tracer_advection_helpers
+   use mpas_log
+   use ocn_mesh
 
    implicit none
    private
@@ -49,9 +46,11 @@ module ocn_tracer_advection_std
    public :: ocn_tracer_advection_std_tend, &
              ocn_tracer_advection_std_init
 
+!***********************************************************************
+
    contains
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!***********************************************************************
 !
 !  routine ocn_tracer_advection_std_tend
 !
@@ -63,153 +62,255 @@ module ocn_tracer_advection_std
 !>  Both horizontal and vertical.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_tracer_advection_std_tend(tracers, adv_coefs, adv_coefs_3rd, nAdvCellsForEdge, advCellsForEdge, &!{{{
-                                             normalThicknessFlux, w, layerThickness, verticalCellSize, dt, meshPool, &
-                                             tend, minLevelCell, maxLevelCell, minLevelEdgeBot, maxLevelEdgeTop, &
-                                             highOrderAdvectionMask, edgeSignOnCell)
 
-      real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers !< Input: current tracer values
-      real (kind=RKIND), dimension(:,:), intent(in) :: adv_coefs !< Input: Advection coefficients for 2nd order advection
-      real (kind=RKIND), dimension(:,:), intent(in) :: adv_coefs_3rd !< Input: Advection coeffs for blending in 3rd/4th order
-      integer, dimension(:), intent(in) :: nAdvCellsForEdge !< Input: Number of advection cells for each edge
-      integer, dimension(:,:), intent(in) :: advCellsForEdge !< Input: List of advection cells for each edge
-      real (kind=RKIND), dimension(:,:), intent(in) :: normalThicknessFlux !< Input: Thichness weighted velocitiy
-      real (kind=RKIND), dimension(:,:), intent(in) :: w !< Input: Vertical velocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness !< Input: Thickness
-      real (kind=RKIND), dimension(:,:), intent(in) :: verticalCellSize !< Input: Distance between vertical interfaces of a cell
-      real (kind=RKIND), intent(in) :: dt !< Input: Timestep
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: tend !< Input/Output: Tracer tendency
-      integer, dimension(:), pointer :: minLevelCell, maxLevelCell !< Input: Index to min,max level at cell center
-      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop !< Input: Index to min,max level at edge with non-land cells on both sides
-      integer, dimension(:,:), pointer :: highOrderAdvectionMask !< Input: Mask for high order advection
-      integer, dimension(:, :), pointer :: edgeSignOnCell !< Input: Sign for flux from edge on each cell.
+   subroutine ocn_tracer_advection_std_tend(tracers, normalThicknessFlux, &
+                                            w, layerThickness, dt, tend)
 
-      integer :: i, iCell, iEdge, k, iTracer, cell1, cell2
-      integer :: nVertLevels, num_tracers
-      integer, pointer :: nCells, nEdges, nCellsSolve, maxEdges
-      integer, dimension(:), pointer :: nEdgesOnCell
-      integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnCell, edgesOnCell
+      !-----------------------------------------------------------------
+      ! Input/Output variables
+      !-----------------------------------------------------------------
 
-      real (kind=RKIND) :: tracer_weight, invAreaCell1
-      real (kind=RKIND) :: verticalWeightK, verticalWeightKm1
-      real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell, verticalDivergenceFactor
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend            !< [inout] Accumulated tracer tendency
 
-      real (kind=RKIND), dimension(:,:), allocatable :: tracer_cur
-      real (kind=RKIND), dimension(:,:), allocatable :: high_order_horiz_flux
-      real (kind=RKIND), dimension(:,:), allocatable :: high_order_vert_flux
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
 
-      real (kind=RKIND), parameter :: eps = 1.e-10_RKIND
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers               !< [in] current tracer values
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalThicknessFlux, &!< [in] Thickness weighted velocitiy
+         w,                   &!< [in] Vertical velocity
+         layerThickness        !< [in] Thickness
+
+      real (kind=RKIND), intent(in) :: &
+         dt                    !< [in] Timestep
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         i, k,         &! loop indices for neighbors, vertical
+         kmin, kmax,   &! min, max active vertical layers
+         iCell, iEdge, &! loop indices for cells, edges
+         iTracer,      &! tracer index
+         cell1, cell2, &! neighbor cell indices across edge
+         numTracers
+
+      real (kind=RKIND) :: &
+         tracerWgt,        &! local temporary
+         invAreaCell1,     &! inverse cell area
+         verticalWeightK,  &! weights for vertical advection
+         verticalWeightKm1,&! weights for vertical advection
+         vertDivFactor      ! vertical divergence factor
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerCur,        &! reordered tracer at current time
+         highOrderHorzFlx, &! high-order flux in horizontal
+         highOrderVertFlx   ! high-order flux in vertical
+
+      real (kind=RKIND), parameter :: &
+         eps = 1.e-10_RKIND  ! small value to avoid div by zero
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
       ! Get dimensions
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-      call mpas_pool_get_dimension(meshPool, 'maxEdges', maxEdges)
-      nVertLevels = size(tracers,dim=2)
-      num_tracers = size(tracers,dim=1)
+      numTracers = size(tracers,dim=1)
 
-      ! Initialize pointers
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      ! Allocate some arrays
+      allocate(tracerCur       (nVertLevels, nCellsAll), &
+               highOrderHorzFlx(nVertLevels, nEdgesAll), &
+               highOrderVertFlx(nVertLevels, nCellsAll))
 
-      allocate(verticalDivergenceFactor(nVertLevels))
-      verticalDivergenceFactor = 1.0_RKIND
+      ! Loop over tracers. One tracer is advected at a time. It is
+      ! copied into a temporary array in order to improve locality
+      do iTracer = 1, numTracers
 
-      allocate(high_order_horiz_flux(nVertLevels, nEdges), &
-               tracer_cur(nVertLevels, nCells), &
-               high_order_vert_flux(nVertLevels, nCells))
-
-      ! Loop over tracers. One tracer is advected at a time. It is copied into a temporary array in order to improve locality
-      do iTracer = 1, num_tracers
         ! Initialize variables for use in this iTracer iteration
         !$omp parallel
-        !$omp do schedule(runtime)
-        do iCell = 1, nCells
-           tracer_cur(:, iCell) = tracers(iTracer, :, iCell)
-
-           high_order_vert_flux(:, iCell) = 0.0_RKIND
+        !$omp do schedule(runtime) private(k)
+        do iCell = 1, nCellsAll
+        do k=1,nVertLevels
+           tracerCur(k,iCell) = tracers(iTracer,k,iCell)
+           highOrderVertFlx(k, iCell) = 0.0_RKIND
+        end do
         end do
         !$omp end do
 
-        !$omp do schedule(runtime)
-        do iEdge = 1, nEdges
-           high_order_horiz_flux(:, iEdge) = 0.0_RKIND
+        !$omp do schedule(runtime) private(k)
+        do iEdge = 1, nEdgesAll
+        do k=1,nVertLevels
+           highOrderHorzFlx(k, iEdge) = 0.0_RKIND
+        end do
         end do
         !$omp end do
 
-        !  Compute the high order vertical flux. Also determine bounds on tracer_cur.
-        !$omp do schedule(runtime) private(k, verticalWeightK, verticalWeightKm1)
-        do iCell = 1, nCells
-          k = max(minLevelCell(iCell), min(maxLevelCell(iCell), minLevelCell(iCell)+1))
-          verticalWeightK = verticalCellSize(k-1, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
-          verticalWeightKm1 = verticalCellSize(k, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
-          high_order_vert_flux(k,iCell) = w(k,iCell)*(verticalWeightK*tracer_cur(k,iCell)+verticalWeightKm1*tracer_cur(k-1,iCell))
+        ! Compute the high order vertical flux.
 
-          do k=minLevelCell(iCell)+2,maxLevelCell(iCell)-1
-             select case (vertOrder)
-             case (vertOrder4)
-               high_order_vert_flux(k, iCell) = mpas_tracer_advection_vflux4( tracer_cur(k-2,iCell),tracer_cur(k-1,iCell),  &
-                                      tracer_cur(k  ,iCell),tracer_cur(k+1,iCell), w(k,iCell))
-             case (vertOrder3)
-               high_order_vert_flux(k, iCell) = mpas_tracer_advection_vflux3( tracer_cur(k-2,iCell),tracer_cur(k-1,iCell),  &
-                                      tracer_cur(k  ,iCell),tracer_cur(k+1,iCell), w(k,iCell), coef3rdOrder )
-             case (vertOrder2)
-               verticalWeightK = verticalCellSize(k-1, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
-               verticalWeightKm1 = verticalCellSize(k, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
-               high_order_vert_flux(k,iCell) = w(k, iCell) * (verticalWeightK * tracer_cur(k, iCell) &
-                                             + verticalWeightKm1 * tracer_cur(k-1, iCell))
-             end select ! vertOrder
-          end do
+        ! First take care of levels at top, bottom defaulting
+        ! to lower order
 
-          k = max(minLevelCell(iCell), maxLevelCell(iCell))
-          verticalWeightK = verticalCellSize(k-1, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
-          verticalWeightKm1 = verticalCellSize(k, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
-          high_order_vert_flux(k,iCell) = w(k,iCell)*(verticalWeightK*tracer_cur(k,iCell)+verticalWeightKm1*tracer_cur(k-1,iCell))
+        !$omp do schedule(runtime) &
+        !$omp    private(k, verticalWeightK, verticalWeightKm1)
+        do iCell = 1, nCellsAll
+           ! top active level
+           k = max(minLevelCell(iCell), &
+                   min(maxLevelCell(iCell), minLevelCell(iCell)+1))
+           verticalWeightK   = layerThickness(k-1,iCell) / &
+                              (layerThickness(k  ,iCell) + &
+                               layerThickness(k-1,iCell))
+           verticalWeightKm1 = layerThickness(k  ,iCell) / &
+                              (layerThickness(k  ,iCell) + &
+                               layerThickness(k-1,iCell))
+           highOrderVertFlx(k,iCell) = w(k,iCell)&
+                            *(verticalWeightK  *tracerCur(k  ,iCell) + &
+                              verticalWeightKm1*tracerCur(k-1,iCell))
+
+           ! lowest active level
+           k = max(minLevelCell(iCell), maxLevelCell(iCell))
+           verticalWeightK   = layerThickness(k-1,iCell) / &
+                              (layerThickness(k  ,iCell) + &
+                               layerThickness(k-1,iCell))
+           verticalWeightKm1 = layerThickness(k  ,iCell) / &
+                              (layerThickness(k  ,iCell) + &
+                               layerThickness(k-1,iCell))
+           highOrderVertFlx(k,iCell) = w(k,iCell)* &
+                            (verticalWeightK  *tracerCur(k  ,iCell) + &
+                             verticalWeightKm1*tracerCur(k-1,iCell))
         end do ! iCell Loop
         !$omp end do
 
-        !  Compute the high order horizontal flux
-        !$omp do schedule(runtime) private(cell1, cell2, k, tracer_weight, i, iCell)
-        do iEdge = 1, nEdges
+        ! Now computer interior layers at high order based on
+        ! user-requested order
+
+        select case (vertOrder)
+        case (vertOrder4)
+
+           !$omp do schedule(runtime) &
+           !$omp    private(k, kmin, kmax, &
+           !$omp            verticalWeightK, verticalWeightKm1)
+           do iCell = 1, nCellsAll
+              kmin = minLevelCell(iCell)
+              kmax = maxLevelCell(iCell)
+              do k=kmin+2,kmax-1
+                 highOrderVertFlx(k, iCell) = w(k,iCell)* &
+                                 ( 7.0_RKIND*(tracerCur(k  ,iCell)+ &
+                                              tracerCur(k-1,iCell)) &
+                                           - (tracerCur(k+1,iCell)+ &
+                                              tracerCur(k-2,iCell)))/&
+                                              12.0_RKIND
+              end do ! vertical loop
+           end do ! iCell Loop
+           !$omp end do
+
+        case (vertOrder3)
+
+           !$omp do schedule(runtime) &
+           !$omp    private(k, kmin, kmax, &
+           !$omp            verticalWeightK, verticalWeightKm1)
+           do iCell = 1, nCellsAll
+              kmin = minLevelCell(iCell)
+              kmax = maxLevelCell(iCell)
+              do k=kmin+2,kmax-1
+                 highOrderVertFlx(k, iCell) = (w(k,iCell)* &
+                                 (7.0_RKIND * (tracerCur(k  ,iCell)+ &
+                                               tracerCur(k-1,iCell)) - &
+                                              (tracerCur(k+1,iCell)+ &
+                                               tracerCur(k-2,iCell))) - &
+                              coef3rdOrder*abs(w(k,iCell))* &
+                                             ((tracerCur(k+1,iCell)- &
+                                               tracerCur(k-2,iCell)) - &
+                                    3.0_RKIND*(tracerCur(k  ,iCell)- &
+                                               tracerCur(k-1,iCell))))/ &
+                                               12.0_RKIND
+              end do ! vertical loop
+           end do ! iCell Loop
+           !$omp end do
+
+        case (vertOrder2)
+
+           !$omp do schedule(runtime) &
+           !$omp    private(k, kmin, kmax, &
+           !$omp            verticalWeightK, verticalWeightKm1)
+           do iCell = 1, nCellsAll
+              kmin = minLevelCell(iCell)
+              kmax = maxLevelCell(iCell)
+              do k=kmin+2,kmax-1
+                 verticalWeightK   = layerThickness(k-1,iCell) / &
+                                    (layerThickness(k  ,iCell) + &
+                                     layerThickness(k-1,iCell))
+                 verticalWeightKm1 = layerThickness(k  ,iCell) / &
+                                    (layerThickness(k  ,iCell) + &
+                                     layerThickness(k-1,iCell))
+                 highOrderVertFlx(k,iCell) = w(k, iCell) * &
+                           (verticalWeightK  *tracerCur(k  ,iCell) + &
+                            verticalWeightKm1*tracerCur(k-1,iCell))
+              end do ! vertical loop
+           end do ! iCell Loop
+           !$omp end do
+
+        end select ! vertOrder
+
+        ! Compute the high order horizontal flux
+
+        !$omp do schedule(runtime) &
+        !$omp    private(cell1, cell2, k, kmix, kmax, tracerWgt, i, iCell)
+        do iEdge = 1, nEdgesAll
           cell1 = cellsOnEdge(1, iEdge)
           cell2 = cellsOnEdge(2, iEdge)
+          kmin = minLevelEdgeBot(iEdge)
+          kmax = maxLevelEdgeTop(iEdge)
 
           ! Compute 2nd order fluxes where needed.
-          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-            tracer_weight = iand(highOrderAdvectionMask(k, iEdge)+1, 1) * (dvEdge(iEdge) * 0.5_RKIND) &
-                           * normalThicknessFlux(k, iEdge)
+          do k = kmin, kmax
+            tracerWgt = (1.0_RKIND - highOrderAdvectionMask(k,iEdge)) &
+                      * (dvEdge(iEdge) * 0.5_RKIND) &
+                      * normalThicknessFlux(k, iEdge)
 
-            high_order_horiz_flux(k, iEdge) = high_order_horiz_flux(k, iedge) + tracer_weight &
-                                            * (tracer_cur(k, cell1) + tracer_cur(k, cell2))
+            highOrderHorzFlx(k, iEdge) = highOrderHorzFlx(k, iedge) &
+                                       + tracerWgt*(tracerCur(k,cell1) &
+                                                  + tracerCur(k,cell2))
           end do ! k loop
 
           ! Compute 3rd or 4th fluxes where requested.
           do i = 1, nAdvCellsForEdge(iEdge)
             iCell = advCellsForEdge(i,iEdge)
-            do k = minLevelCell(iCell), maxLevelCell(iCell)
-              tracer_weight = highOrderAdvectionMask(k, iEdge) * (adv_coefs(i,iEdge) + coef3rdOrder &
-                            * sign(1.0_RKIND,normalThicknessFlux(k,iEdge))*adv_coefs_3rd(i,iEdge))
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
 
-              tracer_weight = normalThicknessFlux(k,iEdge)*tracer_weight
-              high_order_horiz_flux(k,iEdge) = high_order_horiz_flux(k,iEdge) + tracer_weight * tracer_cur(k,iCell)
+            do k = kmin,kmax
+              tracerWgt = highOrderAdvectionMask(k,iEdge) &
+                        * (advCoefs(i,iEdge) + coef3rdOrder &
+                        * sign(1.0_RKIND,normalThicknessFlux(k,iEdge)) &
+                        * advCoefs3rd(i,iEdge))
+
+              tracerWgt = normalThicknessFlux(k,iEdge)*tracerWgt
+              highOrderHorzFlx(k,iEdge) = highOrderHorzFlx(k,iEdge) &
+                                        + tracerWgt*tracerCur(k,iCell)
             end do ! k loop
           end do ! i loop over nAdvCellsForEdge
         end do ! iEdge loop
         !$omp end do
 
         ! Accumulate the scaled high order horizontal tendencies
-        !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k)
-        do iCell = 1, nCells
+        !$omp do schedule(runtime) &
+        !$omp    private(invAreaCell1, i, iEdge, k, kmin, kmax)
+        do iCell = 1, nCellsAll
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
           do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
-            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + edgeSignOnCell(i, iCell) * high_order_horiz_flux(k, iEdge) &
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
+
+            do k = kmin,kmax
+              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) &
+                                      + edgeSignOnCell(i, iCell) &
+                                      * highOrderHorzFlx(k, iEdge) &
                                       * invAreaCell1
             end do
           end do
@@ -217,23 +318,27 @@ module ocn_tracer_advection_std
         !$omp end do
 
         ! Accumulate the scaled high order vertical tendencies.
-        !$omp do schedule(runtime) private(k)
-        do iCell = 1, nCellsSolve
-          do k = minLevelCell(iCell),maxLevelCell(iCell)
-            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + verticalDivergenceFactor(k) * (high_order_vert_flux(k+1, iCell) &
-                                    - high_order_vert_flux(k, iCell))
-          end do ! k loop
+        vertDivFactor = 1.0_RKIND
+        !$omp do schedule(runtime) private(k,kmin,kmax)
+        do iCell = 1, nCellsOwned
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+
+           do k = kmin,kmax
+              tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + &
+                         vertDivFactor*(highOrderVertFlx(k+1, iCell) &
+                                      - highOrderVertFlx(k, iCell))
+           end do ! k loop
         end do ! iCell loop
         !$omp end do
         !$omp end parallel
       end do ! iTracer loop
 
-      deallocate(tracer_cur, high_order_horiz_flux, high_order_vert_flux)
-      deallocate(verticalDivergenceFactor)
+      deallocate(tracerCur, highOrderHorzFlx, highOrderVertFlx)
 
    end subroutine ocn_tracer_advection_std_tend!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!***********************************************************************
 !
 !  routine ocn_tracer_advection_std_init
 !
@@ -241,10 +346,10 @@ module ocn_tracer_advection_std
 !> \author Doug Jacobsen, Phil Jones
 !> \date   03/09/12, updated May 2019
 !> \details
-!>  This routine initializes constants and choices for the standard tracer
-!>  advection tendency.
+!>  This routine initializes constants and choices for the standard
+!>  tracer advection tendency.
 !
-!-------------------------------------------------------------------------------
+!-----------------------------------------------------------------------
 
    subroutine ocn_tracer_advection_std_init(horzAdvOrder, vertAdvOrder, &
                                             inCoef3rdOrder,             &
@@ -305,8 +410,8 @@ module ocn_tracer_advection_std
 
    end subroutine ocn_tracer_advection_std_init!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!***********************************************************************
 
 end module ocn_tracer_advection_std
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
@@ -25,6 +25,7 @@ module ocn_tracer_advection_std
    use mpas_derived_types
    use mpas_log
    use ocn_mesh
+   use ocn_tracer_advection_shared
 
    implicit none
    private
@@ -407,6 +408,8 @@ module ocn_tracer_advection_std
          'Invalid value for vertical advection order, defaulting to 2nd order',&
          MPAS_LOG_WARN)
       end select ! vertAdvOrder
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_tracer_advection_std_init!}}}
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
@@ -24,8 +24,10 @@ module ocn_tracer_advection_std
    use mpas_kind_types
    use mpas_derived_types
    use mpas_log
+   use ocn_config
    use ocn_mesh
    use ocn_tracer_advection_shared
+   use ocn_tracer_advection_vert
 
    implicit none
    private
@@ -34,14 +36,6 @@ module ocn_tracer_advection_std
    ! private module variables
    real (kind=RKIND) :: &
       coef3rdOrder       !< coefficient for blending high-order terms
-
-   integer :: vertOrder  !< choice of order for vertical advection
-   integer, parameter :: &! enumerator for supported vertical adv order
-      vertOrder2=2,      &!< 2nd order
-      vertOrder3=3,      &!< 3rd order
-      vertOrder4=4        !< 4th order
-
-   logical :: monotonicityCheck !< flag to check monotonicity
 
    ! public method interfaces
    public :: ocn_tracer_advection_std_tend, &
@@ -104,8 +98,6 @@ module ocn_tracer_advection_std
       real (kind=RKIND) :: &
          tracerWgt,        &! local temporary
          invAreaCell1,     &! inverse cell area
-         verticalWeightK,  &! weights for vertical advection
-         verticalWeightKm1,&! weights for vertical advection
          vertDivFactor      ! vertical divergence factor
 
       real (kind=RKIND), dimension(:,:), allocatable :: &
@@ -124,9 +116,9 @@ module ocn_tracer_advection_std
       numTracers = size(tracers,dim=1)
 
       ! Allocate some arrays
-      allocate(tracerCur       (nVertLevels, nCellsAll), &
-               highOrderHorzFlx(nVertLevels, nEdgesAll), &
-               highOrderVertFlx(nVertLevels, nCellsAll))
+      allocate(tracerCur       (nVertLevels  , nCellsAll), &
+               highOrderHorzFlx(nVertLevels  , nEdgesAll), &
+               highOrderVertFlx(nVertLevels+1, nCellsAll))
 
       ! Loop over tracers. One tracer is advected at a time. It is
       ! copied into a temporary array in order to improve locality
@@ -138,7 +130,6 @@ module ocn_tracer_advection_std
         do iCell = 1, nCellsAll
         do k=1,nVertLevels
            tracerCur(k,iCell) = tracers(iTracer,k,iCell)
-           highOrderVertFlx(k, iCell) = 0.0_RKIND
         end do
         end do
         !$omp end do
@@ -153,109 +144,8 @@ module ocn_tracer_advection_std
 
         ! Compute the high order vertical flux.
 
-        ! First take care of levels at top, bottom defaulting
-        ! to lower order
-
-        !$omp do schedule(runtime) &
-        !$omp    private(k, verticalWeightK, verticalWeightKm1)
-        do iCell = 1, nCellsAll
-           ! top active level
-           k = max(minLevelCell(iCell), &
-                   min(maxLevelCell(iCell), minLevelCell(iCell)+1))
-           verticalWeightK   = layerThickness(k-1,iCell) / &
-                              (layerThickness(k  ,iCell) + &
-                               layerThickness(k-1,iCell))
-           verticalWeightKm1 = layerThickness(k  ,iCell) / &
-                              (layerThickness(k  ,iCell) + &
-                               layerThickness(k-1,iCell))
-           highOrderVertFlx(k,iCell) = w(k,iCell)&
-                            *(verticalWeightK  *tracerCur(k  ,iCell) + &
-                              verticalWeightKm1*tracerCur(k-1,iCell))
-
-           ! lowest active level
-           k = max(minLevelCell(iCell), maxLevelCell(iCell))
-           verticalWeightK   = layerThickness(k-1,iCell) / &
-                              (layerThickness(k  ,iCell) + &
-                               layerThickness(k-1,iCell))
-           verticalWeightKm1 = layerThickness(k  ,iCell) / &
-                              (layerThickness(k  ,iCell) + &
-                               layerThickness(k-1,iCell))
-           highOrderVertFlx(k,iCell) = w(k,iCell)* &
-                            (verticalWeightK  *tracerCur(k  ,iCell) + &
-                             verticalWeightKm1*tracerCur(k-1,iCell))
-        end do ! iCell Loop
-        !$omp end do
-
-        ! Now computer interior layers at high order based on
-        ! user-requested order
-
-        select case (vertOrder)
-        case (vertOrder4)
-
-           !$omp do schedule(runtime) &
-           !$omp    private(k, kmin, kmax, &
-           !$omp            verticalWeightK, verticalWeightKm1)
-           do iCell = 1, nCellsAll
-              kmin = minLevelCell(iCell)
-              kmax = maxLevelCell(iCell)
-              do k=kmin+2,kmax-1
-                 highOrderVertFlx(k, iCell) = w(k,iCell)* &
-                                 ( 7.0_RKIND*(tracerCur(k  ,iCell)+ &
-                                              tracerCur(k-1,iCell)) &
-                                           - (tracerCur(k+1,iCell)+ &
-                                              tracerCur(k-2,iCell)))/&
-                                              12.0_RKIND
-              end do ! vertical loop
-           end do ! iCell Loop
-           !$omp end do
-
-        case (vertOrder3)
-
-           !$omp do schedule(runtime) &
-           !$omp    private(k, kmin, kmax, &
-           !$omp            verticalWeightK, verticalWeightKm1)
-           do iCell = 1, nCellsAll
-              kmin = minLevelCell(iCell)
-              kmax = maxLevelCell(iCell)
-              do k=kmin+2,kmax-1
-                 highOrderVertFlx(k, iCell) = (w(k,iCell)* &
-                                 (7.0_RKIND * (tracerCur(k  ,iCell)+ &
-                                               tracerCur(k-1,iCell)) - &
-                                              (tracerCur(k+1,iCell)+ &
-                                               tracerCur(k-2,iCell))) - &
-                              coef3rdOrder*abs(w(k,iCell))* &
-                                             ((tracerCur(k+1,iCell)- &
-                                               tracerCur(k-2,iCell)) - &
-                                    3.0_RKIND*(tracerCur(k  ,iCell)- &
-                                               tracerCur(k-1,iCell))))/ &
-                                               12.0_RKIND
-              end do ! vertical loop
-           end do ! iCell Loop
-           !$omp end do
-
-        case (vertOrder2)
-
-           !$omp do schedule(runtime) &
-           !$omp    private(k, kmin, kmax, &
-           !$omp            verticalWeightK, verticalWeightKm1)
-           do iCell = 1, nCellsAll
-              kmin = minLevelCell(iCell)
-              kmax = maxLevelCell(iCell)
-              do k=kmin+2,kmax-1
-                 verticalWeightK   = layerThickness(k-1,iCell) / &
-                                    (layerThickness(k  ,iCell) + &
-                                     layerThickness(k-1,iCell))
-                 verticalWeightKm1 = layerThickness(k  ,iCell) / &
-                                    (layerThickness(k  ,iCell) + &
-                                     layerThickness(k-1,iCell))
-                 highOrderVertFlx(k,iCell) = w(k, iCell) * &
-                           (verticalWeightK  *tracerCur(k  ,iCell) + &
-                            verticalWeightKm1*tracerCur(k-1,iCell))
-              end do ! vertical loop
-           end do ! iCell Loop
-           !$omp end do
-
-        end select ! vertOrder
+        call ocn_tracer_advection_vert_flx(tracerCur, w, &
+                           layerThickness, highOrderVertFlx)
 
         ! Compute the high order horizontal flux
 
@@ -352,20 +242,7 @@ module ocn_tracer_advection_std
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_advection_std_init(horzAdvOrder, vertAdvOrder, &
-                                            inCoef3rdOrder,             &
-                                            checkMonotonicity, err) !{{{
-
-      !*** input parameters
-
-      integer, intent(in) :: &
-         horzAdvOrder         !< [in] Order for horizontal advection
-      integer, intent(in) :: &
-         vertAdvOrder         !< [in] Order for vertical advection
-      real (kind=RKIND), intent(in) :: &
-         inCoef3rdOrder       !< [in] Coefficient for blending advection orders
-      logical, intent(in) :: &
-         checkMonotonicity    !< [in] Flag to check on monotonicity of tracers
+   subroutine ocn_tracer_advection_std_init(err) !{{{
 
       !*** output parameters
 
@@ -377,15 +254,12 @@ module ocn_tracer_advection_std
 
       err = 0 ! set error code to success
 
-      ! set monotonicity flag
-      monotonicityCheck = checkMonotonicity
-
       ! set 3rd order coefficient based on horizontal order choice
-      select case (horzAdvOrder)
+      select case (config_horiz_tracer_adv_order)
       case (2)
          coef3rdOrder = 0.0_RKIND
       case (3)
-         coef3rdOrder = inCoef3rdOrder
+         coef3rdOrder = config_coef_3rd_order
       case (4)
          coef3rdOrder = 0.0_RKIND
       case default
@@ -393,21 +267,6 @@ module ocn_tracer_advection_std
             'Invalid value for horz advection order, defaulting to 2nd order', &
             MPAS_LOG_WARN)
       end select ! horzAdvOrder
-
-      ! set choice of vertical advection order
-      select case (vertAdvOrder)
-      case (2)
-         vertOrder = vertOrder2
-      case (3)
-         vertOrder = vertOrder3
-      case (4)
-         vertOrder = vertOrder4
-      case default
-         vertOrder = vertOrder2
-         call mpas_log_write( &
-         'Invalid value for vertical advection order, defaulting to 2nd order',&
-         MPAS_LOG_WARN)
-      end select ! vertAdvOrder
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
@@ -269,7 +269,7 @@ module ocn_tracer_advection_std
 
           ! Compute 2nd order fluxes where needed.
           do k = kmin, kmax
-            tracerWgt = (1.0_RKIND - highOrderAdvectionMask(k,iEdge)) &
+            tracerWgt = (1.0_RKIND - advMaskHighOrder(k,iEdge)) &
                       * (dvEdge(iEdge) * 0.5_RKIND) &
                       * normalThicknessFlux(k, iEdge)
 
@@ -285,7 +285,7 @@ module ocn_tracer_advection_std
             kmax = maxLevelCell(iCell)
 
             do k = kmin,kmax
-              tracerWgt = highOrderAdvectionMask(k,iEdge) &
+              tracerWgt = advMaskHighOrder(k,iEdge) &
                         * (advCoefs(i,iEdge) + coef3rdOrder &
                         * sign(1.0_RKIND,normalThicknessFlux(k,iEdge)) &
                         * advCoefs3rd(i,iEdge))

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
@@ -102,8 +102,8 @@ module ocn_tracer_advection_std
 
       real (kind=RKIND), dimension(:,:), allocatable :: &
          tracerCur,        &! reordered tracer at current time
-         highOrderHorzFlx, &! high-order flux in horizontal
-         highOrderVertFlx   ! high-order flux in vertical
+         highOrderFlxHorz, &! high-order flux in horizontal
+         highOrderFlxVert   ! high-order flux in vertical
 
       real (kind=RKIND), parameter :: &
          eps = 1.e-10_RKIND  ! small value to avoid div by zero
@@ -117,40 +117,68 @@ module ocn_tracer_advection_std
 
       ! Allocate some arrays
       allocate(tracerCur       (nVertLevels  , nCellsAll), &
-               highOrderHorzFlx(nVertLevels  , nEdgesAll), &
-               highOrderVertFlx(nVertLevels+1, nCellsAll))
+               highOrderFlxHorz(nVertLevels  , nEdgesAll), &
+               highOrderFlxVert(nVertLevels+1, nCellsAll))
+
+      !$acc enter data &
+      !$acc    create(tracerCur, highOrderFlxHorz, highOrderFlxVert)
 
       ! Loop over tracers. One tracer is advected at a time. It is
       ! copied into a temporary array in order to improve locality
       do iTracer = 1, numTracers
 
         ! Initialize variables for use in this iTracer iteration
+#ifdef MPAS_OPENACC
+        !$acc parallel loop collapse(2) &
+        !$acc    present(tracerCur, tracers)
+#else
         !$omp parallel
         !$omp do schedule(runtime) private(k)
+#endif
         do iCell = 1, nCellsAll
         do k=1,nVertLevels
            tracerCur(k,iCell) = tracers(iTracer,k,iCell)
         end do
         end do
+#ifndef MPAS_OPENACC
         !$omp end do
+#endif
 
+#ifdef MPAS_OPENACC
+        !$acc parallel loop collapse(2) &
+        !$acc    present(highOrderFlxHorz)
+#else
         !$omp do schedule(runtime) private(k)
+#endif
         do iEdge = 1, nEdgesAll
         do k=1,nVertLevels
-           highOrderHorzFlx(k, iEdge) = 0.0_RKIND
+           highOrderFlxHorz(k, iEdge) = 0.0_RKIND
         end do
         end do
+#ifndef MPAS_OPENACC
         !$omp end do
+#endif
 
         ! Compute the high order vertical flux.
 
         call ocn_tracer_advection_vert_flx(tracerCur, w, &
-                           layerThickness, highOrderVertFlx)
+                           layerThickness, highOrderFlxVert)
 
         ! Compute the high order horizontal flux
 
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
+        !$acc            minLevelCell, maxLevelCell, cellsOnEdge, &
+        !$acc            nAdvCellsForEdge, advCellsForEdge, dvEdge, &
+        !$acc            advMaskHighOrder, advCoefs, advCoefs3rd, &
+        !$acc            normalThicknessFlux, highOrderFlxHorz, &
+        !$acc            tracerCur) &
+        !$acc    private(i,iCell,cell1,cell2, k, kmin, kmax, tracerWgt) 
+#else
         !$omp do schedule(runtime) &
-        !$omp    private(cell1, cell2, k, kmix, kmax, tracerWgt, i, iCell)
+        !$omp    private(i,iCell,cell1,cell2, k, kmin, kmax, tracerWgt) 
+#endif
         do iEdge = 1, nEdgesAll
           cell1 = cellsOnEdge(1, iEdge)
           cell2 = cellsOnEdge(2, iEdge)
@@ -163,7 +191,7 @@ module ocn_tracer_advection_std
                       * (dvEdge(iEdge) * 0.5_RKIND) &
                       * normalThicknessFlux(k, iEdge)
 
-            highOrderHorzFlx(k, iEdge) = highOrderHorzFlx(k, iedge) &
+            highOrderFlxHorz(k, iEdge) = highOrderFlxHorz(k, iedge) &
                                        + tracerWgt*(tracerCur(k,cell1) &
                                                   + tracerCur(k,cell2))
           end do ! k loop
@@ -181,16 +209,26 @@ module ocn_tracer_advection_std
                         * advCoefs3rd(i,iEdge))
 
               tracerWgt = normalThicknessFlux(k,iEdge)*tracerWgt
-              highOrderHorzFlx(k,iEdge) = highOrderHorzFlx(k,iEdge) &
+              highOrderFlxHorz(k,iEdge) = highOrderFlxHorz(k,iEdge) &
                                         + tracerWgt*tracerCur(k,iCell)
             end do ! k loop
           end do ! i loop over nAdvCellsForEdge
         end do ! iEdge loop
+#ifndef MPAS_OPENACC
         !$omp end do
+#endif
 
         ! Accumulate the scaled high order horizontal tendencies
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
+        !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
+        !$acc            areaCell, tend, highOrderFlxHorz) &
+        !$acc    private(i, iEdge, k, kmin, kmax, invAreaCell1)
+#else
         !$omp do schedule(runtime) &
-        !$omp    private(invAreaCell1, i, iEdge, k, kmin, kmax)
+        !$omp    private(i, iEdge, k, kmin, kmax, invAreaCell1)
+#endif
         do iCell = 1, nCellsAll
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
           do i = 1, nEdgesOnCell(iCell)
@@ -201,31 +239,46 @@ module ocn_tracer_advection_std
             do k = kmin,kmax
               tend(iTracer, k, iCell) = tend(iTracer, k, iCell) &
                                       + edgeSignOnCell(i, iCell) &
-                                      * highOrderHorzFlx(k, iEdge) &
+                                      * highOrderFlxHorz(k, iEdge) &
                                       * invAreaCell1
             end do
           end do
         end do
+#ifndef MPAS_OPENACC
         !$omp end do
+#endif
 
         ! Accumulate the scaled high order vertical tendencies.
         vertDivFactor = 1.0_RKIND
-        !$omp do schedule(runtime) private(k,kmin,kmax)
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, tend, &
+        !$acc            highOrderFlxVert) &
+        !$acc    private(k, kmin, kmax)
+#else
+        !$omp do schedule(runtime) private(k, kmin, kmax)
+#endif
         do iCell = 1, nCellsOwned
            kmin = minLevelCell(iCell)
            kmax = maxLevelCell(iCell)
 
            do k = kmin,kmax
               tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + &
-                         vertDivFactor*(highOrderVertFlx(k+1, iCell) &
-                                      - highOrderVertFlx(k, iCell))
+                         vertDivFactor*(highOrderFlxVert(k+1, iCell) &
+                                      - highOrderFlxVert(k, iCell))
            end do ! k loop
         end do ! iCell loop
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
       end do ! iTracer loop
 
-      deallocate(tracerCur, highOrderHorzFlx, highOrderVertFlx)
+      !$acc exit data &
+      !$acc    delete(tracerCur, highOrderFlxHorz, highOrderFlxVert)
+
+      deallocate(tracerCur, highOrderFlxHorz, highOrderFlxVert)
 
    end subroutine ocn_tracer_advection_std_tend!}}}
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_vert.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_vert.F
@@ -105,14 +105,20 @@ module ocn_tracer_advection_vert
       ! Initialize return flux to zero
       ! Also ensures that top and bottom fluxes are zero
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop collapse(2) present(vertFlx)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
+#endif
       do iCell = 1, nCellsAll
       do k=1,nVertLevels+1
          vertFlx(k,iCell) = 0.0_RKIND
       end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
       ! Compute flux for interior layers at high order based on
       ! user-requested order
@@ -120,8 +126,15 @@ module ocn_tracer_advection_vert
       select case (vertOrder)
       case (vertOrder4)
 
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(minLevelCell, maxLevelCell, w, &
+         !$acc            vertFlx, tracer) &
+         !$acc    private(k, kmin, kmax)
+#else
          !$omp do schedule(runtime) &
          !$omp    private(k, kmin, kmax)
+#endif
          do iCell = 1, nCellsAll
             kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
@@ -134,12 +147,21 @@ module ocn_tracer_advection_vert
                                                 12.0_RKIND
             end do ! vertical loop
          end do ! iCell Loop
+#ifndef MPAS_OPENACC
          !$omp end do
+#endif
 
       case (vertOrder3)
 
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(minLevelCell, maxLevelCell, w, &
+         !$acc            vertFlx, tracer) &
+         !$acc    private(k, kmin, kmax)
+#else
          !$omp do schedule(runtime) &
          !$omp    private(k, kmin, kmax)
+#endif
          do iCell = 1, nCellsAll
             kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
@@ -157,13 +179,23 @@ module ocn_tracer_advection_vert
                                                  12.0_RKIND
             end do ! vertical loop
          end do ! iCell Loop
+#ifndef MPAS_OPENACC
          !$omp end do
+#endif
 
       case (vertOrder2)
 
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(minLevelCell, maxLevelCell, w, &
+         !$acc            layerThick, vertFlx, tracer) &
+         !$acc    private(k, kmin, kmax, &
+         !$acc            verticalWeightK, verticalWeightKm1)
+#else
          !$omp do schedule(runtime) &
          !$omp    private(k, kmin, kmax, &
          !$omp            verticalWeightK, verticalWeightKm1)
+#endif
          do iCell = 1, nCellsAll
             kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
@@ -179,7 +211,9 @@ module ocn_tracer_advection_vert
                             verticalWeightKm1*tracer(k-1,iCell))
             end do ! vertical loop
          end do ! iCell Loop
+#ifndef MPAS_OPENACC
          !$omp end do
+#endif
 
       end select ! vertOrder
 
@@ -187,8 +221,17 @@ module ocn_tracer_advection_vert
       ! layers near the top and bottom where high-order forms
       ! can not be computed.
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(minLevelCell, maxLevelCell, w, &
+      !$acc            layerThick, vertFlx, tracer) &
+      !$acc    private(k, kmin, kmax, &
+      !$acc            verticalWeightK, verticalWeightKm1)
+#else
       !$omp do schedule(runtime) &
-      !$omp    private(k, verticalWeightK, verticalWeightKm1)
+      !$omp    private(k, kmin, kmax, &
+      !$omp            verticalWeightK verticalWeightKm1)
+#endif
       do iCell = 1, nCellsAll
          kmin = minLevelCell(iCell)
          kmax = maxLevelCell(iCell)
@@ -219,7 +262,9 @@ module ocn_tracer_advection_vert
                            verticalWeightKm1*tracer(k-1,iCell))
          end if ! kmax > kmin
       end do ! iCell Loop
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_vert.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_vert.F
@@ -1,0 +1,280 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_tracer_advection_vert
+!
+!> \brief MPAS standard tracer advection
+!> \author Doug Jacobsen, Phil Jones
+!> \date   03/09/12, separated and revised 7/2021
+!> \details
+!>  This module contains routines for computing vertical advection
+!>  fluxes for use in overall tracer advection tendency routines.
+!
+!-----------------------------------------------------------------------
+
+module ocn_tracer_advection_vert
+
+   ! module includes
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_log
+
+   use ocn_config
+   use ocn_mesh
+
+   implicit none
+   private
+   save
+
+   ! private module variables
+   real (kind=RKIND) ::  &
+      coef3rdOrder        !< high-order coefficient
+
+   integer :: vertOrder   !< choice of order for vertical advection
+   integer, parameter :: &! enumerator for supported vertical adv order
+      vertOrder2=2,      &!< 2nd order
+      vertOrder3=3,      &!< 3rd order
+      vertOrder4=4        !< 4th order
+
+   ! public method interfaces
+   public :: ocn_tracer_advection_vert_flx, &
+             ocn_tracer_advection_vert_init
+
+!***********************************************************************
+
+   contains
+
+!***********************************************************************
+!
+!  routine ocn_tracer_advection_vert_flx
+!
+!> \brief Computes vertical tracer advection fluxes
+!> \author Doug Jacobsen
+!> \date   03/09/12, separated and revised 7/2021
+!> \details
+!>  This routine computes the high-order vertical tracer advection
+!>  based on requested order.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_advection_vert_flx(tracer, w, layerThick, &
+                                            vertFlx)
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         vertFlx         !< [out] high-order vertical advection flux
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracer          !< [in] current tracer values
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         w,             &!< [in] Vertical velocity
+         layerThick      !< [in] Layer thickness to use for advection
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell,            &! cell address
+         k, kmin, kmax      ! current, min, max vertical layer indices
+
+      real (kind=RKIND) :: &
+         verticalWeightK,  &! weights for vertical advection
+         verticalWeightKm1  ! weights for vertical advection
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Compute the high order vertical flux.
+
+      ! Initialize return flux to zero
+      ! Also ensures that top and bottom fluxes are zero
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+      do iCell = 1, nCellsAll
+      do k=1,nVertLevels+1
+         vertFlx(k,iCell) = 0.0_RKIND
+      end do
+      end do
+      !$omp end do
+
+      ! Compute flux for interior layers at high order based on
+      ! user-requested order
+
+      select case (vertOrder)
+      case (vertOrder4)
+
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kmin, kmax)
+         do iCell = 1, nCellsAll
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+            do k=kmin+2,kmax-1
+               vertFlx(k, iCell) = w(k,iCell)* &
+                                   ( 7.0_RKIND*(tracer(k  ,iCell)+ &
+                                                tracer(k-1,iCell)) &
+                                             - (tracer(k+1,iCell)+ &
+                                                tracer(k-2,iCell)))/&
+                                                12.0_RKIND
+            end do ! vertical loop
+         end do ! iCell Loop
+         !$omp end do
+
+      case (vertOrder3)
+
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kmin, kmax)
+         do iCell = 1, nCellsAll
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+            do k=kmin+2,kmax-1
+               vertFlx(k, iCell) = (w(k,iCell)* &
+                                   (7.0_RKIND * (tracer(k  ,iCell)+ &
+                                                 tracer(k-1,iCell)) - &
+                                                (tracer(k+1,iCell)+ &
+                                                 tracer(k-2,iCell))) - &
+                                coef3rdOrder*abs(w(k,iCell))* &
+                                               ((tracer(k+1,iCell)- &
+                                                 tracer(k-2,iCell)) - &
+                                      3.0_RKIND*(tracer(k  ,iCell)- &
+                                                 tracer(k-1,iCell))))/ &
+                                                 12.0_RKIND
+            end do ! vertical loop
+         end do ! iCell Loop
+         !$omp end do
+
+      case (vertOrder2)
+
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kmin, kmax, &
+         !$omp            verticalWeightK, verticalWeightKm1)
+         do iCell = 1, nCellsAll
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+            do k=kmin+2,kmax-1
+               verticalWeightK   = layerThick(k-1,iCell) / &
+                                  (layerThick(k  ,iCell) + &
+                                   layerThick(k-1,iCell))
+               verticalWeightKm1 = layerThick(k  ,iCell) / &
+                                  (layerThick(k  ,iCell) + &
+                                   layerThick(k-1,iCell))
+               vertFlx(k,iCell) = w(k, iCell) * &
+                           (verticalWeightK  *tracer(k  ,iCell) + &
+                            verticalWeightKm1*tracer(k-1,iCell))
+            end do ! vertical loop
+         end do ! iCell Loop
+         !$omp end do
+
+      end select ! vertOrder
+
+      ! Now take care of the edge cases, reducing order for
+      ! layers near the top and bottom where high-order forms
+      ! can not be computed.
+
+      !$omp do schedule(runtime) &
+      !$omp    private(k, verticalWeightK, verticalWeightKm1)
+      do iCell = 1, nCellsAll
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+         ! at top, flux is zero (already initialized)
+         ! at next-to-top (kmin+1), reduce to 2nd order
+         !   but avoid case where 0 or 1 active layer (kmax <= kmin)
+         if (kmax > kmin) then
+            k = kmin+1
+            verticalWeightK   = layerThick(k-1,iCell) / &
+                               (layerThick(k  ,iCell) + &
+                                layerThick(k-1,iCell))
+            verticalWeightKm1 = layerThick(k  ,iCell) / &
+                               (layerThick(k  ,iCell) + &
+                                layerThick(k-1,iCell))
+            vertFlx(k,iCell) = w(k,iCell)&
+                          *(verticalWeightK  *tracer(k  ,iCell) + &
+                            verticalWeightKm1*tracer(k-1,iCell))
+            ! Deepest active level also at 2nd order
+            k = kmax
+            verticalWeightK   = layerThick(k-1,iCell) / &
+                               (layerThick(k  ,iCell) + &
+                                layerThick(k-1,iCell))
+            verticalWeightKm1 = layerThick(k  ,iCell) / &
+                               (layerThick(k  ,iCell) + &
+                                layerThick(k-1,iCell))
+            vertFlx(k,iCell) = w(k,iCell)* &
+                          (verticalWeightK  *tracer(k  ,iCell) + &
+                           verticalWeightKm1*tracer(k-1,iCell))
+         end if ! kmax > kmin
+      end do ! iCell Loop
+      !$omp end do
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_advection_vert_flx !}}}
+
+!***********************************************************************
+!
+!  routine ocn_tracer_advection_vert_init
+!
+!> \brief Initializes vertical tracer advection flux computation.
+!> \author Doug Jacobsen, Phil Jones
+!> \date   03/09/12, updated May 2019
+!> \details
+!>  This routine initializes constants and choices for the computation
+!>  of vertical tracer advection fluxes.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_advection_vert_init(err) !{{{
+
+      !*** output parameters
+
+      integer, intent(out) :: err !< [out] Error Flag
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+      err = 0 ! set error code to success
+
+      ! set choice of vertical advection order
+      select case (config_vert_tracer_adv_order)
+      case (2)
+         vertOrder = vertOrder2
+         coef3rdOrder = 0.0_RKIND
+      case (3)
+         vertOrder = vertOrder3
+         coef3rdOrder = config_coef_3rd_order
+      case (4)
+         vertOrder = vertOrder4
+         coef3rdOrder = 0.0_RKIND
+      case default
+         vertOrder = vertOrder2
+         coef3rdOrder = 0.0_RKIND
+         call mpas_log_write( &
+         'Invalid value for vertical advection order, defaulting to 2nd order',&
+         MPAS_LOG_WARN)
+      end select ! vertAdvOrder
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_advection_vert_init!}}}
+
+!***********************************************************************
+
+end module ocn_tracer_advection_vert
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_vert.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_vert.F
@@ -230,7 +230,7 @@ module ocn_tracer_advection_vert
 #else
       !$omp do schedule(runtime) &
       !$omp    private(k, kmin, kmax, &
-      !$omp            verticalWeightK verticalWeightKm1)
+      !$omp            verticalWeightK, verticalWeightKm1)
 #endif
       do iCell = 1, nCellsAll
          kmin = minLevelCell(iCell)
@@ -264,6 +264,7 @@ module ocn_tracer_advection_vert
       end do ! iCell Loop
 #ifndef MPAS_OPENACC
       !$omp end do
+      !$omp end parallel
 #endif
 
    !--------------------------------------------------------------------


### PR DESCRIPTION
Initial GPU port for the ocean tracer advection routines that also includes some significant reorganization of these routines. In particular, this includes:
   - OpenACC port for all advection options, including loop directives and data transfers
   - Move of several advection-specific variables out of Registry and into local module allocatables to reduce size of mesh struct
   - move of some advection coefficient calculations out of framework and into local coefficient module
   - extraction of some common vertical flux calculation into a vertical module shared by both advection options
   - removal of some leftover pool retrievals and other general cleanup

Should be bit-for-bit when running on CPU (tested only with PGI on summit so far). 
Fixes #4386 