### PR TITLE
Update Makefile for MPAS to use $LAPACK/lib64

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -673,6 +673,8 @@ ifneq (, $(shell ls $(LAPACK)/liblapack.*))
 	LIBS += -L$(LAPACK)
 else ifneq (, $(shell ls $(LAPACK)/lib/liblapack.*))
 	LIBS += -L$(LAPACK)/lib
+else ifneq (, $(shell ls $(LAPACK)/lib64/liblapack.*))
+	LIBS += -L$(LAPACK)/lib64
 else
 $(error liblapack.* does NOT exist in $(LAPACK) or $(LAPACK)/lib)
 endif


### PR DESCRIPTION
This PR updates MPAS Makefile to use LAPACK library in $LAPACK/lib64, as some systems such as Summit do not have $LAPACK/lib. This file is used by the standalone MPAS models and does not impact E3SM.

[BFB]