### PR TITLE
Reduce optimization on files with long build times on Chrysalis

### DIFF
--- a/cime_config/machines/Depends.chrysalis.intel.cmake
+++ b/cime_config/machines/Depends.chrysalis.intel.cmake
@@ -1,0 +1,12 @@
+# Reduce optimization on files with long compile times
+set(O2MODELSRC
+  eam/src/physics/cam/micro_mg_cam.F90      # ~2027 seconds
+  elm/src/data_types/VegetationDataType.F90 # ~ 930 seconds
+)
+if (NOT DEBUG)
+  foreach(ITEM IN LISTS O2MODELSRC)
+    e3sm_remove_flags("${ITEM}" "-O3")
+    e3sm_add_flags("${ITEM}" "-O2")
+  endforeach()
+endif()
+


### PR DESCRIPTION
Reduce -O3 to -O2 for
- eam/src/physics/cam/micro_mg_cam.F90 (now builds in ~27 secs)
- elm/src/data_types/VegetationDataType.F90 (~232 secs)

This reduces total build time for `SMS_P12x2.ne4_oQU240.A_WCYCL1850` on 
- master: 2748 secs (46 mins)
- branch: 994 secs (17 mins or 2.7x faster)

Run-time throughput is not affected:
- master: 18.548 sypd
- branch: 18.621 sypd

[BFB]