### PR TITLE
Push chunk loop into crm_physics()

### DIFF
--- a/components/eam/src/physics/crm/crm_ecpp_output_module.F90
+++ b/components/eam/src/physics/crm/crm_ecpp_output_module.F90
@@ -9,6 +9,7 @@ module crm_ecpp_output_module
    public crm_ecpp_output_type
    public crm_ecpp_output_initialize
    public crm_ecpp_output_finalize
+   public crm_ecpp_output_copy
 
    !------------------------------------------------------------------------------------------------
    type crm_ecpp_output_type
@@ -91,6 +92,36 @@ contains
       if (allocated(output%wwqui_bnd       )) deallocate(output%wwqui_bnd       )
       if (allocated(output%wwqui_cloudy_bnd)) deallocate(output%wwqui_cloudy_bnd)
    end subroutine crm_ecpp_output_finalize
+   !------------------------------------------------------------------------------------------------
+   subroutine crm_ecpp_output_copy(output, output_copy, col_beg, col_end)
+      type(crm_ecpp_output_type), intent(in   ) :: output
+      type(crm_ecpp_output_type), intent(inout) :: output_copy
+      integer,                    intent(in   ) :: col_beg
+      integer,                    intent(in   ) :: col_end
+      integer :: ncol_copy
+      ncol_copy = col_end - col_beg + 1
+      output_copy%abnd            (1:ncol_copy,:,:,:,:) = output%abnd            (col_beg:col_end,:,:,:,:)
+      output_copy%abnd_tf         (1:ncol_copy,:,:,:,:) = output%abnd_tf         (col_beg:col_end,:,:,:,:)
+      output_copy%massflxbnd      (1:ncol_copy,:,:,:,:) = output%massflxbnd      (col_beg:col_end,:,:,:,:)
+      output_copy%acen            (1:ncol_copy,:,:,:,:) = output%acen            (col_beg:col_end,:,:,:,:)
+      output_copy%acen_tf         (1:ncol_copy,:,:,:,:) = output%acen_tf         (col_beg:col_end,:,:,:,:)
+      output_copy%rhcen           (1:ncol_copy,:,:,:,:) = output%rhcen           (col_beg:col_end,:,:,:,:)
+      output_copy%qcloudcen       (1:ncol_copy,:,:,:,:) = output%qcloudcen       (col_beg:col_end,:,:,:,:)
+      output_copy%qicecen         (1:ncol_copy,:,:,:,:) = output%qicecen         (col_beg:col_end,:,:,:,:)
+      output_copy%qlsinkcen       (1:ncol_copy,:,:,:,:) = output%qlsinkcen       (col_beg:col_end,:,:,:,:)
+      output_copy%precrcen        (1:ncol_copy,:,:,:,:) = output%precrcen        (col_beg:col_end,:,:,:,:)
+      output_copy%precsolidcen    (1:ncol_copy,:,:,:,:) = output%precsolidcen    (col_beg:col_end,:,:,:,:)
+      output_copy%qlsink_afcen    (1:ncol_copy,:,:,:,:) = output%qlsink_afcen    (col_beg:col_end,:,:,:,:)
+      output_copy%qlsink_bfcen    (1:ncol_copy,:,:,:,:) = output%qlsink_bfcen    (col_beg:col_end,:,:,:,:)
+      output_copy%qlsink_avgcen   (1:ncol_copy,:,:,:,:) = output%qlsink_avgcen   (col_beg:col_end,:,:,:,:)
+      output_copy%praincen        (1:ncol_copy,:,:,:,:) = output%praincen        (col_beg:col_end,:,:,:,:)
+      output_copy%wupthresh_bnd   (1:ncol_copy,:)       = output%wupthresh_bnd   (col_beg:col_end,:)
+      output_copy%wdownthresh_bnd (1:ncol_copy,:)       = output%wdownthresh_bnd (col_beg:col_end,:)
+      output_copy%wwqui_cen       (1:ncol_copy,:)       = output%wwqui_cen       (col_beg:col_end,:)
+      output_copy%wwqui_bnd       (1:ncol_copy,:)       = output%wwqui_bnd       (col_beg:col_end,:)
+      output_copy%wwqui_cloudy_cen(1:ncol_copy,:)       = output%wwqui_cloudy_cen(col_beg:col_end,:)
+      output_copy%wwqui_cloudy_bnd(1:ncol_copy,:)       = output%wwqui_cloudy_bnd(col_beg:col_end,:)
+   end subroutine crm_ecpp_output_copy
    !------------------------------------------------------------------------------------------------
 
 end module crm_ecpp_output_module

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -368,7 +368,8 @@ subroutine crm_history_init(species_class)
 end subroutine crm_history_init
 !---------------------------------------------------------------------------------------------------
 !---------------------------------------------------------------------------------------------------
-subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, crm_ecpp_output, qrs, qrl)
+subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, & 
+                           crm_ecpp_output, qrs, qrl, icrm_beg, icrm_end)
    use physics_types,          only: physics_state, physics_tend, physics_ptend
    use phys_control,           only: phys_getopts
    use crm_state_module,       only: crm_state_type
@@ -391,6 +392,9 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, crm_ecp
 
    real(r8), dimension(:,:), intent(in) :: qrs        ! shortwave radiative heating rate
    real(r8), dimension(:,:), intent(in) :: qrl        ! longwave radiative heating rate
+   
+   integer, intent(in) :: icrm_beg ! CRM dimension index range
+   integer, intent(in) :: icrm_end ! CRM dimension index range
 
    !----------------------------------------------------------------------------
    ! local variables
@@ -405,7 +409,7 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, crm_ecp
    integer :: lchnk                    ! chunk identifier
    integer :: ncol                     ! number of atmospheric columns
    integer :: ixcldliq, ixcldice       ! liquid and ice constituent indices
-   integer :: i, k                     ! loop iterators
+   integer :: i, k, icrm               ! loop iterators
    logical :: use_ECPP
    logical :: use_MMF_VT
    character(len=16) :: MMF_microphysics_scheme
@@ -464,64 +468,64 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, crm_ecp
 
    !----------------------------------------------------------------------------
    ! CRM condensate and precipitation on CRM grid
-   call outfld('CRM_QC  ',crm_output%qcl,         pcols, lchnk )
-   call outfld('CRM_QI  ',crm_output%qci,         pcols, lchnk )
-   call outfld('CRM_QPC ',crm_output%qpl,         pcols, lchnk )
-   call outfld('CRM_QPI ',crm_output%qpi,         pcols, lchnk )
-   call outfld('CRM_PREC',crm_output%prec_crm,    pcols, lchnk )
-   call outfld('CRM_TK ', crm_output%tk(:,:,:,:), pcols, lchnk )  
-   call outfld('CRM_TKH', crm_output%tkh(:,:,:,:),pcols, lchnk ) 
+   call outfld('CRM_QC  ',crm_output%qcl     (icrm_beg:icrm_end,:,:,:),pcols, lchnk )
+   call outfld('CRM_QI  ',crm_output%qci     (icrm_beg:icrm_end,:,:,:),pcols, lchnk )
+   call outfld('CRM_QPC ',crm_output%qpl     (icrm_beg:icrm_end,:,:,:),pcols, lchnk )
+   call outfld('CRM_QPI ',crm_output%qpi     (icrm_beg:icrm_end,:,:,:),pcols, lchnk )
+   call outfld('CRM_PREC',crm_output%prec_crm(icrm_beg:icrm_end,:,:),  pcols, lchnk )
+   call outfld('CRM_TK ', crm_output%tk      (icrm_beg:icrm_end,:,:,:),pcols, lchnk )  
+   call outfld('CRM_TKH', crm_output%tkh     (icrm_beg:icrm_end,:,:,:),pcols, lchnk ) 
 
    !----------------------------------------------------------------------------
    ! CRM domain average condensate and precipitation
-   call outfld('MMF_QC    ',crm_output%qc_mean, pcols ,lchnk )
-   call outfld('MMF_QI    ',crm_output%qi_mean, pcols ,lchnk )
-   call outfld('MMF_QS    ',crm_output%qs_mean, pcols ,lchnk )
-   call outfld('MMF_QG    ',crm_output%qg_mean, pcols ,lchnk )
-   call outfld('MMF_QR    ',crm_output%qr_mean, pcols ,lchnk )
+   call outfld('MMF_QC    ',crm_output%qc_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
+   call outfld('MMF_QI    ',crm_output%qi_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
+   call outfld('MMF_QS    ',crm_output%qs_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
+   call outfld('MMF_QG    ',crm_output%qg_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
+   call outfld('MMF_QR    ',crm_output%qr_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
 
    !----------------------------------------------------------------------------
    ! CRM domain average fluxes
-   call outfld('MMF_QTFLX ',crm_output%flux_qt,        pcols, lchnk )
-   call outfld('MMF_UFLX  ',crm_output%flux_u,         pcols, lchnk )
-   call outfld('MMF_VFLX  ',crm_output%flux_v,         pcols, lchnk )
-   call outfld('MMF_TKE   ',crm_output%tkez,           pcols, lchnk )
-   call outfld('MMF_TKEW  ',crm_output%tkew,           pcols, lchnk )
-   call outfld('MMF_TKES  ',crm_output%tkesgsz,        pcols, lchnk )
-   call outfld('MMF_TK    ',crm_output%tkz,            pcols, lchnk )
-   call outfld('MMF_QTFLXS',crm_output%fluxsgs_qt,     pcols, lchnk )
-   call outfld('MMF_QPFLX ',crm_output%flux_qp,        pcols, lchnk )
-   call outfld('MMF_PFLX  ',crm_output%precflux,       pcols, lchnk )
-   call outfld('MMF_QTLS  ',crm_output%qt_ls,          pcols, lchnk )
-   call outfld('MMF_QTTR  ',crm_output%qt_trans,       pcols, lchnk )
-   call outfld('MMF_QPTR  ',crm_output%qp_trans,       pcols, lchnk )
-   call outfld('MMF_QPEVP ',crm_output%qp_evp,         pcols, lchnk )
-   call outfld('MMF_QPFALL',crm_output%qp_fall,        pcols, lchnk )
-   call outfld('MMF_QPSRC ',crm_output%qp_src,         pcols, lchnk )
-   call outfld('MMF_TLS   ',crm_output%t_ls,           pcols, lchnk )
+   call outfld('MMF_QTFLX ',crm_output%flux_qt   (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_UFLX  ',crm_output%flux_u    (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_VFLX  ',crm_output%flux_v    (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_TKE   ',crm_output%tkez      (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_TKEW  ',crm_output%tkew      (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_TKES  ',crm_output%tkesgsz   (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_TK    ',crm_output%tkz       (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_QTFLXS',crm_output%fluxsgs_qt(icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_QPFLX ',crm_output%flux_qp   (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_PFLX  ',crm_output%precflux  (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_QTLS  ',crm_output%qt_ls     (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_QTTR  ',crm_output%qt_trans  (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_QPTR  ',crm_output%qp_trans  (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_QPEVP ',crm_output%qp_evp    (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_QPFALL',crm_output%qp_fall   (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_QPSRC ',crm_output%qp_src    (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_TLS   ',crm_output%t_ls      (icrm_beg:icrm_end,:), pcols, lchnk )
 
    ! NOTE: these should overwrite cloud outputs from non-MMF routines
-   call outfld('CLOUD   ',crm_output%cld,    pcols, lchnk )
-   call outfld('CLDTOT  ',crm_output%cltot,  pcols, lchnk )
-   call outfld('CLDHGH  ',crm_output%clhgh,  pcols, lchnk )
-   call outfld('CLDMED  ',crm_output%clmed,  pcols, lchnk )
-   call outfld('CLDLOW  ',crm_output%cllow,  pcols, lchnk )
-   call outfld('MMF_CLDTOP',crm_output%cldtop, pcols, lchnk )
+   call outfld('CLOUD   ',crm_output%cld     (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('CLDTOT  ',crm_output%cltot   (icrm_beg:icrm_end),   pcols, lchnk )
+   call outfld('CLDHGH  ',crm_output%clhgh   (icrm_beg:icrm_end),   pcols, lchnk )
+   call outfld('CLDMED  ',crm_output%clmed   (icrm_beg:icrm_end),   pcols, lchnk )
+   call outfld('CLDLOW  ',crm_output%cllow   (icrm_beg:icrm_end),   pcols, lchnk )
+   call outfld('MMF_CLDTOP',crm_output%cldtop(icrm_beg:icrm_end,:), pcols, lchnk )
 
-   call outfld('MMF_SUBCYCLE_FAC',crm_output%subcycle_factor  ,pcols,lchnk)
+   call outfld('MMF_SUBCYCLE_FAC',crm_output%subcycle_factor(icrm_beg:icrm_end), pcols,lchnk)
 
    !----------------------------------------------------------------------------
    ! CRM mass flux
-   call outfld('MMF_MC    ', crm_output%mctot,  pcols, lchnk )
-   call outfld('MMF_MCUP  ', crm_output%mcup,   pcols, lchnk )
-   call outfld('MMF_MCDN  ', crm_output%mcdn,   pcols, lchnk )
-   call outfld('MMF_MCUUP ', crm_output%mcuup,  pcols, lchnk )
-   call outfld('MMF_MCUDN ', crm_output%mcudn,  pcols, lchnk )
-   call outfld('MU_CRM  ', crm_output%mu_crm, pcols, lchnk )
-   call outfld('MD_CRM  ', crm_output%md_crm, pcols, lchnk )
-   call outfld('EU_CRM  ', crm_output%eu_crm, pcols, lchnk )
-   call outfld('DU_CRM  ', crm_output%du_crm, pcols, lchnk )
-   call outfld('ED_CRM  ', crm_output%ed_crm, pcols, lchnk )
+   call outfld('MMF_MC    ', crm_output%mctot (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_MCUP  ', crm_output%mcup  (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_MCDN  ', crm_output%mcdn  (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_MCUUP ', crm_output%mcuup (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_MCUDN ', crm_output%mcudn (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MU_CRM    ', crm_output%mu_crm(icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MD_CRM    ', crm_output%md_crm(icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('EU_CRM    ', crm_output%eu_crm(icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('DU_CRM    ', crm_output%du_crm(icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('ED_CRM    ', crm_output%ed_crm(icrm_beg:icrm_end,:), pcols, lchnk )
 
 #ifdef m2005
    if (MMF_microphysics_scheme .eq. 'm2005') then
@@ -529,40 +533,40 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, crm_ecp
       ! Be cautious to use them here. They are defined in crm codes, and these codes are called only 
       ! after the subroutine of crm is called. So they can only be used after the 'crm' subroutine. 
       ! incl, inci, ... can not be used here, for they are defined before we call them???
-      call outfld('CRM_NC ',crm_state%nc(:,:,:,:), pcols, lchnk )
-      call outfld('CRM_NI ',crm_state%ni(:,:,:,:), pcols, lchnk )
-      call outfld('CRM_NR ',crm_state%nr(:,:,:,:), pcols, lchnk )
-      call outfld('CRM_NS ',crm_state%ns(:,:,:,:), pcols, lchnk )
-      call outfld('CRM_NG ',crm_state%ng(:,:,:,:), pcols, lchnk )
-      call outfld('CRM_QR ',crm_state%qr(:,:,:,:), pcols, lchnk )
-      call outfld('CRM_QS ',crm_state%qs(:,:,:,:), pcols, lchnk )
-      call outfld('CRM_QG ',crm_state%qg(:,:,:,:), pcols, lchnk )
+      call outfld('CRM_NC ',crm_state%nc(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
+      call outfld('CRM_NI ',crm_state%ni(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
+      call outfld('CRM_NR ',crm_state%nr(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
+      call outfld('CRM_NS ',crm_state%ns(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
+      call outfld('CRM_NG ',crm_state%ng(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
+      call outfld('CRM_QR ',crm_state%qr(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
+      call outfld('CRM_QS ',crm_state%qs(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
+      call outfld('CRM_QG ',crm_state%qg(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
       
-      call outfld('CRM_WVAR',crm_output%wvar, pcols, lchnk)
+      call outfld('CRM_WVAR',crm_output%wvar(icrm_beg:icrm_end,:,:,:), pcols, lchnk)
 
-      call outfld('CRM_AUT', crm_output%aut, pcols, lchnk)
-      call outfld('CRM_ACC', crm_output%acc, pcols, lchnk)
-      call outfld('CRM_MLT', crm_output%mlt, pcols, lchnk)
-      call outfld('CRM_SUB', crm_output%sub, pcols, lchnk)
-      call outfld('CRM_DEP', crm_output%dep, pcols, lchnk)
-      call outfld('CRM_CON', crm_output%con, pcols, lchnk)
-      call outfld('CRM_EVPC',crm_output%evpc,pcols, lchnk)
-      call outfld('CRM_EVPR',crm_output%evpr,pcols, lchnk)
+      call outfld('CRM_AUT', crm_output%aut (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
+      call outfld('CRM_ACC', crm_output%acc (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
+      call outfld('CRM_MLT', crm_output%mlt (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
+      call outfld('CRM_SUB', crm_output%sub (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
+      call outfld('CRM_DEP', crm_output%dep (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
+      call outfld('CRM_CON', crm_output%con (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
+      call outfld('CRM_EVPC',crm_output%evpc(icrm_beg:icrm_end,:,:,:), pcols, lchnk)
+      call outfld('CRM_EVPR',crm_output%evpr(icrm_beg:icrm_end,:,:,:), pcols, lchnk)
       
-      call outfld('A_AUT', crm_output%aut_a, pcols, lchnk)
-      call outfld('A_ACC', crm_output%acc_a, pcols, lchnk)
-      call outfld('A_MLT', crm_output%mlt_a, pcols, lchnk)
-      call outfld('A_SUB', crm_output%sub_a, pcols, lchnk)
-      call outfld('A_DEP', crm_output%dep_a, pcols, lchnk)
-      call outfld('A_CON', crm_output%con_a, pcols, lchnk)
-      call outfld('A_EVPC',crm_output%evpc_a,pcols, lchnk)
-      call outfld('A_EVPR',crm_output%evpr_a,pcols, lchnk)
+      call outfld('A_AUT', crm_output%aut_a (icrm_beg:icrm_end,:), pcols, lchnk)
+      call outfld('A_ACC', crm_output%acc_a (icrm_beg:icrm_end,:), pcols, lchnk)
+      call outfld('A_MLT', crm_output%mlt_a (icrm_beg:icrm_end,:), pcols, lchnk)
+      call outfld('A_SUB', crm_output%sub_a (icrm_beg:icrm_end,:), pcols, lchnk)
+      call outfld('A_DEP', crm_output%dep_a (icrm_beg:icrm_end,:), pcols, lchnk)
+      call outfld('A_CON', crm_output%con_a (icrm_beg:icrm_end,:), pcols, lchnk)
+      call outfld('A_EVPC',crm_output%evpc_a(icrm_beg:icrm_end,:), pcols, lchnk)
+      call outfld('A_EVPR',crm_output%evpr_a(icrm_beg:icrm_end,:), pcols, lchnk)
 
-      call outfld('MMF_NC    ',crm_output%nc_mean, pcols, lchnk )
-      call outfld('MMF_NI    ',crm_output%ni_mean, pcols, lchnk )
-      call outfld('MMF_NS    ',crm_output%ns_mean, pcols, lchnk )
-      call outfld('MMF_NG    ',crm_output%ng_mean, pcols, lchnk )
-      call outfld('MMF_NR    ',crm_output%nr_mean, pcols, lchnk )
+      call outfld('MMF_NC    ',crm_output%nc_mean(icrm_beg:icrm_end,:), pcols, lchnk )
+      call outfld('MMF_NI    ',crm_output%ni_mean(icrm_beg:icrm_end,:), pcols, lchnk )
+      call outfld('MMF_NS    ',crm_output%ns_mean(icrm_beg:icrm_end,:), pcols, lchnk )
+      call outfld('MMF_NG    ',crm_output%ng_mean(icrm_beg:icrm_end,:), pcols, lchnk )
+      call outfld('MMF_NR    ',crm_output%nr_mean(icrm_beg:icrm_end,:), pcols, lchnk )
    endif ! m2005
 #endif /* m2005 */
 
@@ -572,14 +576,15 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, crm_ecp
    tgliqwp(:ncol) = 0.
    do k = 1,pver
       do i = 1,ncol
-         cicewp(i,k) = crm_output%gicewp(i,k) * 1.0e-3 / max(0.01_r8,crm_output%cld(i,k)) ! In-cloud ice water path.  g/m2 --> kg/m2
-         cliqwp(i,k) = crm_output%gliqwp(i,k) * 1.0e-3 / max(0.01_r8,crm_output%cld(i,k)) ! In-cloud liquid water path. g/m2 --> kg/m2
-         tgicewp(i)  = tgicewp(i) + crm_output%gicewp(i,k) *1.0e-3 ! grid cell mean ice water path.  g/m2 --> kg/m2
-         tgliqwp(i)  = tgliqwp(i) + crm_output%gliqwp(i,k) *1.0e-3 ! grid cell mean ice water path.  g/m2 --> kg/m2
+         icrm = icrm_beg - 1 + i
+         cicewp(i,k) = crm_output%gicewp(icrm,k) * 1.0e-3 / max(0.01_r8,crm_output%cld(icrm,k)) ! In-cloud ice water path.  g/m2 --> kg/m2
+         cliqwp(i,k) = crm_output%gliqwp(icrm,k) * 1.0e-3 / max(0.01_r8,crm_output%cld(icrm,k)) ! In-cloud liquid water path. g/m2 --> kg/m2
+         tgicewp(i)  = tgicewp(i) + crm_output%gicewp(icrm,k) *1.0e-3 ! grid cell mean ice water path.  g/m2 --> kg/m2
+         tgliqwp(i)  = tgliqwp(i) + crm_output%gliqwp(icrm,k) *1.0e-3 ! grid cell mean ice water path.  g/m2 --> kg/m2
       end do
    end do
    tgwp(:ncol) = tgicewp(:ncol) + tgliqwp(:ncol)
-   gwp(:ncol,:pver) = crm_output%gicewp(:ncol,:pver) + crm_output%gliqwp(:ncol,:pver)
+   gwp(:ncol,:pver) = crm_output%gicewp(icrm_beg:icrm_end,:pver) + crm_output%gliqwp(icrm_beg:icrm_end,:pver)
    cwp(:ncol,:pver) = cicewp(:ncol,:pver) + cliqwp(:ncol,:pver)
 
    call outfld('GCLDLWP' ,gwp,     pcols, lchnk)
@@ -593,34 +598,34 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, crm_ecp
    ! ECPP
 #ifdef ECPP
    if (use_ECPP) then
-      call outfld('ACEN    ',      crm_ecpp_output%acen,             pcols, lchnk )
-      call outfld('ABND    ',      crm_ecpp_output%abnd,             pcols, lchnk )
-      call outfld('ACEN_TF ',      crm_ecpp_output%acen_tf,          pcols, lchnk )
-      call outfld('ABND_TF ',      crm_ecpp_output%abnd_tf,          pcols, lchnk )
-      call outfld('MASFBND ',      crm_ecpp_output%massflxbnd,       pcols, lchnk )
-      call outfld('RHCEN   ',      crm_ecpp_output%rhcen,            pcols, lchnk )
-      call outfld('QCCEN   ',      crm_ecpp_output%qcloudcen,        pcols, lchnk )
-      call outfld('QICEN   ',      crm_ecpp_output%qicecen,          pcols, lchnk )
-      call outfld('QSINK_AFCEN',   crm_ecpp_output%qlsink_afcen,     pcols, lchnk )
-      call outfld('PRECRCEN',      crm_ecpp_output%precrcen,         pcols, lchnk )
-      call outfld('PRECSCEN',      crm_ecpp_output%precsolidcen,     pcols, lchnk )
-      call outfld('WUPTHRES',      crm_ecpp_output%wupthresh_bnd,    pcols, lchnk )
-      call outfld('WDNTHRES',      crm_ecpp_output%wdownthresh_bnd,  pcols, lchnk )
-      call outfld('WWQUI_CEN',     crm_ecpp_output%wwqui_cen,        pcols, lchnk )
-      call outfld('WWQUI_CLD_CEN', crm_ecpp_output%wwqui_cloudy_cen, pcols, lchnk )
-      call outfld('WWQUI_BND',     crm_ecpp_output%wwqui_cen,        pcols, lchnk )
-      call outfld('WWQUI_CLD_BND', crm_ecpp_output%wwqui_cloudy_cen, pcols, lchnk )
-      call outfld('QSINK_BFCEN',   crm_ecpp_output%qlsink_bfcen,     pcols, lchnk )
-      call outfld('QSINK_AVGCEN',  crm_ecpp_output%qlsink_avgcen,    pcols, lchnk )
-      call outfld('PRAINCEN',      crm_ecpp_output%praincen,         pcols, lchnk )
+      call outfld('ACEN    ',      crm_ecpp_output%acen            (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('ABND    ',      crm_ecpp_output%abnd            (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('ACEN_TF ',      crm_ecpp_output%acen_tf         (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('ABND_TF ',      crm_ecpp_output%abnd_tf         (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('MASFBND ',      crm_ecpp_output%massflxbnd      (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('RHCEN   ',      crm_ecpp_output%rhcen           (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('QCCEN   ',      crm_ecpp_output%qcloudcen       (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('QICEN   ',      crm_ecpp_output%qicecen         (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('QSINK_AFCEN',   crm_ecpp_output%qlsink_afcen    (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('PRECRCEN',      crm_ecpp_output%precrcen        (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('PRECSCEN',      crm_ecpp_output%precsolidcen    (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('WUPTHRES',      crm_ecpp_output%wupthresh_bnd   (icrm_beg:icrm_end,:),       pcols, lchnk )
+      call outfld('WDNTHRES',      crm_ecpp_output%wdownthresh_bnd (icrm_beg:icrm_end,:),       pcols, lchnk )
+      call outfld('WWQUI_CEN',     crm_ecpp_output%wwqui_cen       (icrm_beg:icrm_end,:),       pcols, lchnk )
+      call outfld('WWQUI_CLD_CEN', crm_ecpp_output%wwqui_cloudy_cen(icrm_beg:icrm_end,:),       pcols, lchnk )
+      call outfld('WWQUI_BND',     crm_ecpp_output%wwqui_cen       (icrm_beg:icrm_end,:),       pcols, lchnk )
+      call outfld('WWQUI_CLD_BND', crm_ecpp_output%wwqui_cloudy_cen(icrm_beg:icrm_end,:),       pcols, lchnk )
+      call outfld('QSINK_BFCEN',   crm_ecpp_output%qlsink_bfcen    (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('QSINK_AVGCEN',  crm_ecpp_output%qlsink_avgcen   (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('PRAINCEN',      crm_ecpp_output%praincen        (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
    end if ! use_ECPP
 #endif /* ECPP */
 
    !----------------------------------------------------------------------------
    ! CRM momentum tendencies
 #if defined( MMF_ESMT )
-   call outfld('U_TEND_ESMT',crm_output%u_tend_esmt, pcols, lchnk )
-   call outfld('V_TEND_ESMT',crm_output%v_tend_esmt, pcols, lchnk )
+   call outfld('U_TEND_ESMT',crm_output%u_tend_esmt(icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('V_TEND_ESMT',crm_output%v_tend_esmt(icrm_beg:icrm_end,:), pcols, lchnk )
 #endif /* MMF_ESMT */
 
 #if defined(MMF_MOMENTUM_FEEDBACK) || defined(MMF_ESMT)
@@ -633,12 +638,12 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, crm_ecp
    if (use_MMF_VT) then
       call cnst_get_ind( 'VT_T', idx_vt_t )
       call cnst_get_ind( 'VT_Q', idx_vt_q )
-      call outfld('MMF_VT_T',      state%q(:,:,idx_vt_t), pcols, lchnk )
-      call outfld('MMF_VT_Q',      state%q(:,:,idx_vt_q), pcols, lchnk )
-      call outfld('MMF_VT_TEND_T', ptend%q(:,:,idx_vt_t), pcols, lchnk )
-      call outfld('MMF_VT_TEND_Q', ptend%q(:,:,idx_vt_q), pcols, lchnk )
-      call outfld('MMF_VT_TLS',    crm_output%t_vt_ls,    pcols, lchnk )
-      call outfld('MMF_VT_QLS',    crm_output%q_vt_ls,    pcols, lchnk )
+      call outfld('MMF_VT_T',      state%q(:,:,idx_vt_t),                   pcols, lchnk )
+      call outfld('MMF_VT_Q',      state%q(:,:,idx_vt_q),                   pcols, lchnk )
+      call outfld('MMF_VT_TEND_T', ptend%q(:,:,idx_vt_t),                   pcols, lchnk )
+      call outfld('MMF_VT_TEND_Q', ptend%q(:,:,idx_vt_q),                   pcols, lchnk )
+      call outfld('MMF_VT_TLS',    crm_output%t_vt_ls(icrm_beg:icrm_end,:), pcols, lchnk )
+      call outfld('MMF_VT_QLS',    crm_output%q_vt_ls(icrm_beg:icrm_end,:), pcols, lchnk )
    end if
 
    !----------------------------------------------------------------------------

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -447,85 +447,88 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    ! CRM_QRS + CRM_QRL output in radiation_tend will show a time lag.
 
    ! GCM level rad heating tendencies
-   call outfld('MMF_QRL   ',qrl/cpair, pcols, lchnk )
-   call outfld('MMF_QRS   ',qrs/cpair, pcols, lchnk )
+   call outfld('MMF_QRL   ',qrl/cpair, ncol, lchnk )
+   call outfld('MMF_QRS   ',qrs/cpair, ncol, lchnk )
 
    ! Why do we output this here?
    call outfld('PRES    ',state%pmid, pcols, lchnk )
    call outfld('DPRES   ',state%pdel, pcols, lchnk )
 
    ! CRM state variables on CRM grid
-   call outfld('CRM_U   ',crm_state%u_wind,      pcols, lchnk )
-   call outfld('CRM_V   ',crm_state%v_wind,      pcols, lchnk )
-   call outfld('CRM_W   ',crm_state%w_wind,      pcols, lchnk )
-   call outfld('CRM_T   ',crm_state%temperature, pcols, lchnk )
+   call outfld('CRM_U   ',crm_state%u_wind     (icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+   call outfld('CRM_V   ',crm_state%v_wind     (icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+   call outfld('CRM_W   ',crm_state%w_wind     (icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+   call outfld('CRM_T   ',crm_state%temperature(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
 
    if (MMF_microphysics_scheme .eq. 'sam1mom') then
-      call outfld('CRM_QV  ',(crm_state%qt-crm_output%qcl-crm_output%qci), pcols, lchnk )
+      call outfld('CRM_QV  ',(crm_state%qt(icrm_beg:icrm_end,:,:,:)    &
+                              -crm_output%qcl(icrm_beg:icrm_end,:,:,:) &
+                              -crm_output%qci(icrm_beg:icrm_end,:,:,:)), ncol, lchnk )
    else if (MMF_microphysics_scheme .eq. 'm2005') then 
-      call outfld('CRM_QV  ',crm_state%qt-crm_output%qcl, pcols, lchnk )
+      call outfld('CRM_QV  ', crm_state%qt(icrm_beg:icrm_end,:,:,:)    &
+                              -crm_output%qcl(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
    endif
 
    !----------------------------------------------------------------------------
    ! CRM condensate and precipitation on CRM grid
-   call outfld('CRM_QC  ',crm_output%qcl     (icrm_beg:icrm_end,:,:,:),pcols, lchnk )
-   call outfld('CRM_QI  ',crm_output%qci     (icrm_beg:icrm_end,:,:,:),pcols, lchnk )
-   call outfld('CRM_QPC ',crm_output%qpl     (icrm_beg:icrm_end,:,:,:),pcols, lchnk )
-   call outfld('CRM_QPI ',crm_output%qpi     (icrm_beg:icrm_end,:,:,:),pcols, lchnk )
-   call outfld('CRM_PREC',crm_output%prec_crm(icrm_beg:icrm_end,:,:),  pcols, lchnk )
-   call outfld('CRM_TK ', crm_output%tk      (icrm_beg:icrm_end,:,:,:),pcols, lchnk )  
-   call outfld('CRM_TKH', crm_output%tkh     (icrm_beg:icrm_end,:,:,:),pcols, lchnk ) 
+   call outfld('CRM_QC  ',crm_output%qcl     (icrm_beg:icrm_end,:,:,:),ncol, lchnk )
+   call outfld('CRM_QI  ',crm_output%qci     (icrm_beg:icrm_end,:,:,:),ncol, lchnk )
+   call outfld('CRM_QPC ',crm_output%qpl     (icrm_beg:icrm_end,:,:,:),ncol, lchnk )
+   call outfld('CRM_QPI ',crm_output%qpi     (icrm_beg:icrm_end,:,:,:),ncol, lchnk )
+   call outfld('CRM_PREC',crm_output%prec_crm(icrm_beg:icrm_end,:,:),  ncol, lchnk )
+   call outfld('CRM_TK ', crm_output%tk      (icrm_beg:icrm_end,:,:,:),ncol, lchnk )  
+   call outfld('CRM_TKH', crm_output%tkh     (icrm_beg:icrm_end,:,:,:),ncol, lchnk ) 
 
    !----------------------------------------------------------------------------
    ! CRM domain average condensate and precipitation
-   call outfld('MMF_QC    ',crm_output%qc_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
-   call outfld('MMF_QI    ',crm_output%qi_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
-   call outfld('MMF_QS    ',crm_output%qs_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
-   call outfld('MMF_QG    ',crm_output%qg_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
-   call outfld('MMF_QR    ',crm_output%qr_mean(icrm_beg:icrm_end,:), pcols ,lchnk )
+   call outfld('MMF_QC    ',crm_output%qc_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
+   call outfld('MMF_QI    ',crm_output%qi_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
+   call outfld('MMF_QS    ',crm_output%qs_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
+   call outfld('MMF_QG    ',crm_output%qg_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
+   call outfld('MMF_QR    ',crm_output%qr_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
 
    !----------------------------------------------------------------------------
    ! CRM domain average fluxes
-   call outfld('MMF_QTFLX ',crm_output%flux_qt   (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_UFLX  ',crm_output%flux_u    (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_VFLX  ',crm_output%flux_v    (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_TKE   ',crm_output%tkez      (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_TKEW  ',crm_output%tkew      (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_TKES  ',crm_output%tkesgsz   (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_TK    ',crm_output%tkz       (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_QTFLXS',crm_output%fluxsgs_qt(icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_QPFLX ',crm_output%flux_qp   (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_PFLX  ',crm_output%precflux  (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_QTLS  ',crm_output%qt_ls     (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_QTTR  ',crm_output%qt_trans  (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_QPTR  ',crm_output%qp_trans  (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_QPEVP ',crm_output%qp_evp    (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_QPFALL',crm_output%qp_fall   (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_QPSRC ',crm_output%qp_src    (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_TLS   ',crm_output%t_ls      (icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_QTFLX ',crm_output%flux_qt   (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_UFLX  ',crm_output%flux_u    (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_VFLX  ',crm_output%flux_v    (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_TKE   ',crm_output%tkez      (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_TKEW  ',crm_output%tkew      (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_TKES  ',crm_output%tkesgsz   (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_TK    ',crm_output%tkz       (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_QTFLXS',crm_output%fluxsgs_qt(icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_QPFLX ',crm_output%flux_qp   (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_PFLX  ',crm_output%precflux  (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_QTLS  ',crm_output%qt_ls     (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_QTTR  ',crm_output%qt_trans  (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_QPTR  ',crm_output%qp_trans  (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_QPEVP ',crm_output%qp_evp    (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_QPFALL',crm_output%qp_fall   (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_QPSRC ',crm_output%qp_src    (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_TLS   ',crm_output%t_ls      (icrm_beg:icrm_end,:), ncol, lchnk )
 
    ! NOTE: these should overwrite cloud outputs from non-MMF routines
-   call outfld('CLOUD   ',crm_output%cld     (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('CLDTOT  ',crm_output%cltot   (icrm_beg:icrm_end),   pcols, lchnk )
-   call outfld('CLDHGH  ',crm_output%clhgh   (icrm_beg:icrm_end),   pcols, lchnk )
-   call outfld('CLDMED  ',crm_output%clmed   (icrm_beg:icrm_end),   pcols, lchnk )
-   call outfld('CLDLOW  ',crm_output%cllow   (icrm_beg:icrm_end),   pcols, lchnk )
-   call outfld('MMF_CLDTOP',crm_output%cldtop(icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('CLOUD   ',crm_output%cld     (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('CLDTOT  ',crm_output%cltot   (icrm_beg:icrm_end),   ncol, lchnk )
+   call outfld('CLDHGH  ',crm_output%clhgh   (icrm_beg:icrm_end),   ncol, lchnk )
+   call outfld('CLDMED  ',crm_output%clmed   (icrm_beg:icrm_end),   ncol, lchnk )
+   call outfld('CLDLOW  ',crm_output%cllow   (icrm_beg:icrm_end),   ncol, lchnk )
+   call outfld('MMF_CLDTOP',crm_output%cldtop(icrm_beg:icrm_end,:), ncol, lchnk )
 
-   call outfld('MMF_SUBCYCLE_FAC',crm_output%subcycle_factor(icrm_beg:icrm_end), pcols,lchnk)
+   call outfld('MMF_SUBCYCLE_FAC',crm_output%subcycle_factor(icrm_beg:icrm_end), ncol,lchnk)
 
    !----------------------------------------------------------------------------
    ! CRM mass flux
-   call outfld('MMF_MC    ', crm_output%mctot (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_MCUP  ', crm_output%mcup  (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_MCDN  ', crm_output%mcdn  (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_MCUUP ', crm_output%mcuup (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MMF_MCUDN ', crm_output%mcudn (icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MU_CRM    ', crm_output%mu_crm(icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('MD_CRM    ', crm_output%md_crm(icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('EU_CRM    ', crm_output%eu_crm(icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('DU_CRM    ', crm_output%du_crm(icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('ED_CRM    ', crm_output%ed_crm(icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('MMF_MC    ', crm_output%mctot (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_MCUP  ', crm_output%mcup  (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_MCDN  ', crm_output%mcdn  (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_MCUUP ', crm_output%mcuup (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_MCUDN ', crm_output%mcudn (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MU_CRM    ', crm_output%mu_crm(icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MD_CRM    ', crm_output%md_crm(icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('EU_CRM    ', crm_output%eu_crm(icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('DU_CRM    ', crm_output%du_crm(icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('ED_CRM    ', crm_output%ed_crm(icrm_beg:icrm_end,:), ncol, lchnk )
 
 #ifdef m2005
    if (MMF_microphysics_scheme .eq. 'm2005') then
@@ -533,40 +536,40 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
       ! Be cautious to use them here. They are defined in crm codes, and these codes are called only 
       ! after the subroutine of crm is called. So they can only be used after the 'crm' subroutine. 
       ! incl, inci, ... can not be used here, for they are defined before we call them???
-      call outfld('CRM_NC ',crm_state%nc(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
-      call outfld('CRM_NI ',crm_state%ni(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
-      call outfld('CRM_NR ',crm_state%nr(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
-      call outfld('CRM_NS ',crm_state%ns(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
-      call outfld('CRM_NG ',crm_state%ng(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
-      call outfld('CRM_QR ',crm_state%qr(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
-      call outfld('CRM_QS ',crm_state%qs(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
-      call outfld('CRM_QG ',crm_state%qg(icrm_beg:icrm_end,:,:,:), pcols, lchnk )
+      call outfld('CRM_NC ',crm_state%nc(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_NI ',crm_state%ni(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_NR ',crm_state%nr(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_NS ',crm_state%ns(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_NG ',crm_state%ng(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_QR ',crm_state%qr(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_QS ',crm_state%qs(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_QG ',crm_state%qg(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
       
-      call outfld('CRM_WVAR',crm_output%wvar(icrm_beg:icrm_end,:,:,:), pcols, lchnk)
+      call outfld('CRM_WVAR',crm_output%wvar(icrm_beg:icrm_end,:,:,:), ncol, lchnk)
 
-      call outfld('CRM_AUT', crm_output%aut (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
-      call outfld('CRM_ACC', crm_output%acc (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
-      call outfld('CRM_MLT', crm_output%mlt (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
-      call outfld('CRM_SUB', crm_output%sub (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
-      call outfld('CRM_DEP', crm_output%dep (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
-      call outfld('CRM_CON', crm_output%con (icrm_beg:icrm_end,:,:,:), pcols, lchnk)
-      call outfld('CRM_EVPC',crm_output%evpc(icrm_beg:icrm_end,:,:,:), pcols, lchnk)
-      call outfld('CRM_EVPR',crm_output%evpr(icrm_beg:icrm_end,:,:,:), pcols, lchnk)
+      call outfld('CRM_AUT', crm_output%aut (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_ACC', crm_output%acc (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_MLT', crm_output%mlt (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_SUB', crm_output%sub (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_DEP', crm_output%dep (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_CON', crm_output%con (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_EVPC',crm_output%evpc(icrm_beg:icrm_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_EVPR',crm_output%evpr(icrm_beg:icrm_end,:,:,:), ncol, lchnk)
       
-      call outfld('A_AUT', crm_output%aut_a (icrm_beg:icrm_end,:), pcols, lchnk)
-      call outfld('A_ACC', crm_output%acc_a (icrm_beg:icrm_end,:), pcols, lchnk)
-      call outfld('A_MLT', crm_output%mlt_a (icrm_beg:icrm_end,:), pcols, lchnk)
-      call outfld('A_SUB', crm_output%sub_a (icrm_beg:icrm_end,:), pcols, lchnk)
-      call outfld('A_DEP', crm_output%dep_a (icrm_beg:icrm_end,:), pcols, lchnk)
-      call outfld('A_CON', crm_output%con_a (icrm_beg:icrm_end,:), pcols, lchnk)
-      call outfld('A_EVPC',crm_output%evpc_a(icrm_beg:icrm_end,:), pcols, lchnk)
-      call outfld('A_EVPR',crm_output%evpr_a(icrm_beg:icrm_end,:), pcols, lchnk)
+      call outfld('A_AUT', crm_output%aut_a (icrm_beg:icrm_end,:), ncol, lchnk)
+      call outfld('A_ACC', crm_output%acc_a (icrm_beg:icrm_end,:), ncol, lchnk)
+      call outfld('A_MLT', crm_output%mlt_a (icrm_beg:icrm_end,:), ncol, lchnk)
+      call outfld('A_SUB', crm_output%sub_a (icrm_beg:icrm_end,:), ncol, lchnk)
+      call outfld('A_DEP', crm_output%dep_a (icrm_beg:icrm_end,:), ncol, lchnk)
+      call outfld('A_CON', crm_output%con_a (icrm_beg:icrm_end,:), ncol, lchnk)
+      call outfld('A_EVPC',crm_output%evpc_a(icrm_beg:icrm_end,:), ncol, lchnk)
+      call outfld('A_EVPR',crm_output%evpr_a(icrm_beg:icrm_end,:), ncol, lchnk)
 
-      call outfld('MMF_NC    ',crm_output%nc_mean(icrm_beg:icrm_end,:), pcols, lchnk )
-      call outfld('MMF_NI    ',crm_output%ni_mean(icrm_beg:icrm_end,:), pcols, lchnk )
-      call outfld('MMF_NS    ',crm_output%ns_mean(icrm_beg:icrm_end,:), pcols, lchnk )
-      call outfld('MMF_NG    ',crm_output%ng_mean(icrm_beg:icrm_end,:), pcols, lchnk )
-      call outfld('MMF_NR    ',crm_output%nr_mean(icrm_beg:icrm_end,:), pcols, lchnk )
+      call outfld('MMF_NC    ',crm_output%nc_mean(icrm_beg:icrm_end,:), ncol, lchnk )
+      call outfld('MMF_NI    ',crm_output%ni_mean(icrm_beg:icrm_end,:), ncol, lchnk )
+      call outfld('MMF_NS    ',crm_output%ns_mean(icrm_beg:icrm_end,:), ncol, lchnk )
+      call outfld('MMF_NG    ',crm_output%ng_mean(icrm_beg:icrm_end,:), ncol, lchnk )
+      call outfld('MMF_NR    ',crm_output%nr_mean(icrm_beg:icrm_end,:), ncol, lchnk )
    endif ! m2005
 #endif /* m2005 */
 
@@ -587,45 +590,45 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    gwp(:ncol,:pver) = crm_output%gicewp(icrm_beg:icrm_end,:pver) + crm_output%gliqwp(icrm_beg:icrm_end,:pver)
    cwp(:ncol,:pver) = cicewp(:ncol,:pver) + cliqwp(:ncol,:pver)
 
-   call outfld('GCLDLWP' ,gwp,     pcols, lchnk)
-   call outfld('TGCLDCWP',tgwp,    pcols, lchnk)
-   call outfld('TGCLDLWP',tgliqwp, pcols, lchnk)
-   call outfld('TGCLDIWP',tgicewp, pcols, lchnk)
-   call outfld('ICLDTWP' ,cwp,     pcols, lchnk)
-   call outfld('ICLDIWP' ,cicewp,  pcols, lchnk)
+   call outfld('GCLDLWP' ,gwp,     ncol, lchnk)
+   call outfld('TGCLDCWP',tgwp,    ncol, lchnk)
+   call outfld('TGCLDLWP',tgliqwp, ncol, lchnk)
+   call outfld('TGCLDIWP',tgicewp, ncol, lchnk)
+   call outfld('ICLDTWP' ,cwp,     ncol, lchnk)
+   call outfld('ICLDIWP' ,cicewp,  ncol, lchnk)
 
    !----------------------------------------------------------------------------
    ! ECPP
 #ifdef ECPP
    if (use_ECPP) then
-      call outfld('ACEN    ',      crm_ecpp_output%acen            (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('ABND    ',      crm_ecpp_output%abnd            (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('ACEN_TF ',      crm_ecpp_output%acen_tf         (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('ABND_TF ',      crm_ecpp_output%abnd_tf         (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('MASFBND ',      crm_ecpp_output%massflxbnd      (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('RHCEN   ',      crm_ecpp_output%rhcen           (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('QCCEN   ',      crm_ecpp_output%qcloudcen       (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('QICEN   ',      crm_ecpp_output%qicecen         (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('QSINK_AFCEN',   crm_ecpp_output%qlsink_afcen    (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('PRECRCEN',      crm_ecpp_output%precrcen        (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('PRECSCEN',      crm_ecpp_output%precsolidcen    (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('WUPTHRES',      crm_ecpp_output%wupthresh_bnd   (icrm_beg:icrm_end,:),       pcols, lchnk )
-      call outfld('WDNTHRES',      crm_ecpp_output%wdownthresh_bnd (icrm_beg:icrm_end,:),       pcols, lchnk )
-      call outfld('WWQUI_CEN',     crm_ecpp_output%wwqui_cen       (icrm_beg:icrm_end,:),       pcols, lchnk )
-      call outfld('WWQUI_CLD_CEN', crm_ecpp_output%wwqui_cloudy_cen(icrm_beg:icrm_end,:),       pcols, lchnk )
-      call outfld('WWQUI_BND',     crm_ecpp_output%wwqui_cen       (icrm_beg:icrm_end,:),       pcols, lchnk )
-      call outfld('WWQUI_CLD_BND', crm_ecpp_output%wwqui_cloudy_cen(icrm_beg:icrm_end,:),       pcols, lchnk )
-      call outfld('QSINK_BFCEN',   crm_ecpp_output%qlsink_bfcen    (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('QSINK_AVGCEN',  crm_ecpp_output%qlsink_avgcen   (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
-      call outfld('PRAINCEN',      crm_ecpp_output%praincen        (icrm_beg:icrm_end,:,:,:,:), pcols, lchnk )
+      call outfld('ACEN    ',      crm_ecpp_output%acen            (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('ABND    ',      crm_ecpp_output%abnd            (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('ACEN_TF ',      crm_ecpp_output%acen_tf         (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('ABND_TF ',      crm_ecpp_output%abnd_tf         (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('MASFBND ',      crm_ecpp_output%massflxbnd      (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('RHCEN   ',      crm_ecpp_output%rhcen           (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('QCCEN   ',      crm_ecpp_output%qcloudcen       (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('QICEN   ',      crm_ecpp_output%qicecen         (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('QSINK_AFCEN',   crm_ecpp_output%qlsink_afcen    (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('PRECRCEN',      crm_ecpp_output%precrcen        (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('PRECSCEN',      crm_ecpp_output%precsolidcen    (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('WUPTHRES',      crm_ecpp_output%wupthresh_bnd   (icrm_beg:icrm_end,:),       ncol, lchnk )
+      call outfld('WDNTHRES',      crm_ecpp_output%wdownthresh_bnd (icrm_beg:icrm_end,:),       ncol, lchnk )
+      call outfld('WWQUI_CEN',     crm_ecpp_output%wwqui_cen       (icrm_beg:icrm_end,:),       ncol, lchnk )
+      call outfld('WWQUI_CLD_CEN', crm_ecpp_output%wwqui_cloudy_cen(icrm_beg:icrm_end,:),       ncol, lchnk )
+      call outfld('WWQUI_BND',     crm_ecpp_output%wwqui_cen       (icrm_beg:icrm_end,:),       ncol, lchnk )
+      call outfld('WWQUI_CLD_BND', crm_ecpp_output%wwqui_cloudy_cen(icrm_beg:icrm_end,:),       ncol, lchnk )
+      call outfld('QSINK_BFCEN',   crm_ecpp_output%qlsink_bfcen    (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('QSINK_AVGCEN',  crm_ecpp_output%qlsink_avgcen   (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('PRAINCEN',      crm_ecpp_output%praincen        (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
    end if ! use_ECPP
 #endif /* ECPP */
 
    !----------------------------------------------------------------------------
    ! CRM momentum tendencies
 #if defined( MMF_ESMT )
-   call outfld('U_TEND_ESMT',crm_output%u_tend_esmt(icrm_beg:icrm_end,:), pcols, lchnk )
-   call outfld('V_TEND_ESMT',crm_output%v_tend_esmt(icrm_beg:icrm_end,:), pcols, lchnk )
+   call outfld('U_TEND_ESMT',crm_output%u_tend_esmt(icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('V_TEND_ESMT',crm_output%v_tend_esmt(icrm_beg:icrm_end,:), ncol, lchnk )
 #endif /* MMF_ESMT */
 
 #if defined(MMF_MOMENTUM_FEEDBACK) || defined(MMF_ESMT)
@@ -638,12 +641,12 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    if (use_MMF_VT) then
       call cnst_get_ind( 'VT_T', idx_vt_t )
       call cnst_get_ind( 'VT_Q', idx_vt_q )
-      call outfld('MMF_VT_T',      state%q(:,:,idx_vt_t),                   pcols, lchnk )
-      call outfld('MMF_VT_Q',      state%q(:,:,idx_vt_q),                   pcols, lchnk )
-      call outfld('MMF_VT_TEND_T', ptend%q(:,:,idx_vt_t),                   pcols, lchnk )
-      call outfld('MMF_VT_TEND_Q', ptend%q(:,:,idx_vt_q),                   pcols, lchnk )
-      call outfld('MMF_VT_TLS',    crm_output%t_vt_ls(icrm_beg:icrm_end,:), pcols, lchnk )
-      call outfld('MMF_VT_QLS',    crm_output%q_vt_ls(icrm_beg:icrm_end,:), pcols, lchnk )
+      call outfld('MMF_VT_T',      state%q(:,:,idx_vt_t),                   ncol, lchnk )
+      call outfld('MMF_VT_Q',      state%q(:,:,idx_vt_q),                   ncol, lchnk )
+      call outfld('MMF_VT_TEND_T', ptend%q(:,:,idx_vt_t),                   ncol, lchnk )
+      call outfld('MMF_VT_TEND_Q', ptend%q(:,:,idx_vt_q),                   ncol, lchnk )
+      call outfld('MMF_VT_TLS',    crm_output%t_vt_ls(icrm_beg:icrm_end,:), ncol, lchnk )
+      call outfld('MMF_VT_QLS',    crm_output%q_vt_ls(icrm_beg:icrm_end,:), ncol, lchnk )
    end if
 
    !----------------------------------------------------------------------------

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -428,7 +428,7 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    ncol  = state%ncol
 
    ! Subtract radiative heating for MMF_DT output
-   MMF_DT_out(:ncol,:pver) = ( ptend%s(:ncol,:pver) - qrs(:ncol,:pver) - qrl(:ncol,:pver) )/cpair
+   MMF_DT_out(1:ncol,:pver) = ( ptend%s(1:ncol,:pver) - qrs(1:ncol,:pver) - qrl(1:ncol,:pver) )/cpair
 
    !----------------------------------------------------------------------------
    ! CRM domain average Tendencies
@@ -447,12 +447,12 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    ! CRM_QRS + CRM_QRL output in radiation_tend will show a time lag.
 
    ! GCM level rad heating tendencies
-   call outfld('MMF_QRL   ',qrl/cpair, ncol, lchnk )
-   call outfld('MMF_QRS   ',qrs/cpair, ncol, lchnk )
+   call outfld('MMF_QRL   ',qrl(1:ncol)/cpair, ncol, lchnk )
+   call outfld('MMF_QRS   ',qrs(1:ncol)/cpair, ncol, lchnk )
 
    ! Why do we output this here?
-   call outfld('PRES    ',state%pmid, pcols, lchnk )
-   call outfld('DPRES   ',state%pdel, pcols, lchnk )
+   call outfld('PRES    ',state%pmid(1:ncol), ncol, lchnk )
+   call outfld('DPRES   ',state%pdel(1:ncol), ncol, lchnk )
 
    ! CRM state variables on CRM grid
    call outfld('CRM_U   ',crm_state%u_wind     (icol_beg:icol_end,:,:,:), ncol, lchnk )
@@ -575,8 +575,8 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
 
    !----------------------------------------------------------------------------
    ! Compute liquid water paths (for diagnostics only)
-   tgicewp(:ncol) = 0.
-   tgliqwp(:ncol) = 0.
+   tgicewp(1:ncol) = 0.
+   tgliqwp(1:ncol) = 0.
    do k = 1,pver
       do i = 1,ncol
          icol = icol_beg - 1 + i
@@ -586,16 +586,16 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
          tgliqwp(i)  = tgliqwp(i) + crm_output%gliqwp(icol,k) *1.0e-3 ! grid cell mean ice water path.  g/m2 --> kg/m2
       end do
    end do
-   tgwp(:ncol) = tgicewp(:ncol) + tgliqwp(:ncol)
-   gwp(:ncol,:pver) = crm_output%gicewp(icol_beg:icol_end,:pver) + crm_output%gliqwp(icol_beg:icol_end,:pver)
-   cwp(:ncol,:pver) = cicewp(:ncol,:pver) + cliqwp(:ncol,:pver)
+   tgwp(1:ncol) = tgicewp(1:ncol) + tgliqwp(1:ncol)
+   gwp(1:ncol,:pver) = crm_output%gicewp(icol_beg:icol_end,:pver) + crm_output%gliqwp(icol_beg:icol_end,:pver)
+   cwp(1:ncol,:pver) = cicewp(1:ncol,:pver) + cliqwp(1:ncol,:pver)
 
-   call outfld('GCLDLWP' ,gwp,     ncol, lchnk)
-   call outfld('TGCLDCWP',tgwp,    ncol, lchnk)
-   call outfld('TGCLDLWP',tgliqwp, ncol, lchnk)
-   call outfld('TGCLDIWP',tgicewp, ncol, lchnk)
-   call outfld('ICLDTWP' ,cwp,     ncol, lchnk)
-   call outfld('ICLDIWP' ,cicewp,  ncol, lchnk)
+   call outfld('GCLDLWP' ,gwp(1:ncol),     ncol, lchnk)
+   call outfld('TGCLDCWP',tgwp(1:ncol),    ncol, lchnk)
+   call outfld('TGCLDLWP',tgliqwp(1:ncol), ncol, lchnk)
+   call outfld('TGCLDIWP',tgicewp(1:ncol), ncol, lchnk)
+   call outfld('ICLDTWP' ,cwp(1:ncol),     ncol, lchnk)
+   call outfld('ICLDIWP' ,cicewp(1:ncol),  ncol, lchnk)
 
    !----------------------------------------------------------------------------
    ! ECPP

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -369,7 +369,7 @@ end subroutine crm_history_init
 !---------------------------------------------------------------------------------------------------
 !---------------------------------------------------------------------------------------------------
 subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, & 
-                           crm_ecpp_output, qrs, qrl, icrm_beg, icrm_end)
+                           crm_ecpp_output, qrs, qrl, icol_beg, icol_end)
    use physics_types,          only: physics_state, physics_tend, physics_ptend
    use phys_control,           only: phys_getopts
    use crm_state_module,       only: crm_state_type
@@ -393,8 +393,8 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    real(r8), dimension(:,:), intent(in) :: qrs        ! shortwave radiative heating rate
    real(r8), dimension(:,:), intent(in) :: qrl        ! longwave radiative heating rate
    
-   integer, intent(in) :: icrm_beg ! CRM dimension index range
-   integer, intent(in) :: icrm_end ! CRM dimension index range
+   integer, intent(in) :: icol_beg ! CRM dimension index range
+   integer, intent(in) :: icol_end ! CRM dimension index range
 
    !----------------------------------------------------------------------------
    ! local variables
@@ -409,7 +409,7 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    integer :: lchnk                    ! chunk identifier
    integer :: ncol                     ! number of atmospheric columns
    integer :: ixcldliq, ixcldice       ! liquid and ice constituent indices
-   integer :: i, k, icrm               ! loop iterators
+   integer :: i, k, icol               ! loop iterators
    logical :: use_ECPP
    logical :: use_MMF_VT
    character(len=16) :: MMF_microphysics_scheme
@@ -455,80 +455,80 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    call outfld('DPRES   ',state%pdel, pcols, lchnk )
 
    ! CRM state variables on CRM grid
-   call outfld('CRM_U   ',crm_state%u_wind     (icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-   call outfld('CRM_V   ',crm_state%v_wind     (icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-   call outfld('CRM_W   ',crm_state%w_wind     (icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-   call outfld('CRM_T   ',crm_state%temperature(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+   call outfld('CRM_U   ',crm_state%u_wind     (icol_beg:icol_end,:,:,:), ncol, lchnk )
+   call outfld('CRM_V   ',crm_state%v_wind     (icol_beg:icol_end,:,:,:), ncol, lchnk )
+   call outfld('CRM_W   ',crm_state%w_wind     (icol_beg:icol_end,:,:,:), ncol, lchnk )
+   call outfld('CRM_T   ',crm_state%temperature(icol_beg:icol_end,:,:,:), ncol, lchnk )
 
    if (MMF_microphysics_scheme .eq. 'sam1mom') then
-      call outfld('CRM_QV  ',(crm_state%qt(icrm_beg:icrm_end,:,:,:)    &
-                              -crm_output%qcl(icrm_beg:icrm_end,:,:,:) &
-                              -crm_output%qci(icrm_beg:icrm_end,:,:,:)), ncol, lchnk )
+      call outfld('CRM_QV  ',(crm_state%qt(icol_beg:icol_end,:,:,:)    &
+                              -crm_output%qcl(icol_beg:icol_end,:,:,:) &
+                              -crm_output%qci(icol_beg:icol_end,:,:,:)), ncol, lchnk )
    else if (MMF_microphysics_scheme .eq. 'm2005') then 
-      call outfld('CRM_QV  ', crm_state%qt(icrm_beg:icrm_end,:,:,:)    &
-                              -crm_output%qcl(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_QV  ', crm_state%qt(icol_beg:icol_end,:,:,:)    &
+                              -crm_output%qcl(icol_beg:icol_end,:,:,:), ncol, lchnk )
    endif
 
    !----------------------------------------------------------------------------
    ! CRM condensate and precipitation on CRM grid
-   call outfld('CRM_QC  ',crm_output%qcl     (icrm_beg:icrm_end,:,:,:),ncol, lchnk )
-   call outfld('CRM_QI  ',crm_output%qci     (icrm_beg:icrm_end,:,:,:),ncol, lchnk )
-   call outfld('CRM_QPC ',crm_output%qpl     (icrm_beg:icrm_end,:,:,:),ncol, lchnk )
-   call outfld('CRM_QPI ',crm_output%qpi     (icrm_beg:icrm_end,:,:,:),ncol, lchnk )
-   call outfld('CRM_PREC',crm_output%prec_crm(icrm_beg:icrm_end,:,:),  ncol, lchnk )
-   call outfld('CRM_TK ', crm_output%tk      (icrm_beg:icrm_end,:,:,:),ncol, lchnk )  
-   call outfld('CRM_TKH', crm_output%tkh     (icrm_beg:icrm_end,:,:,:),ncol, lchnk ) 
+   call outfld('CRM_QC  ',crm_output%qcl     (icol_beg:icol_end,:,:,:),ncol, lchnk )
+   call outfld('CRM_QI  ',crm_output%qci     (icol_beg:icol_end,:,:,:),ncol, lchnk )
+   call outfld('CRM_QPC ',crm_output%qpl     (icol_beg:icol_end,:,:,:),ncol, lchnk )
+   call outfld('CRM_QPI ',crm_output%qpi     (icol_beg:icol_end,:,:,:),ncol, lchnk )
+   call outfld('CRM_PREC',crm_output%prec_crm(icol_beg:icol_end,:,:),  ncol, lchnk )
+   call outfld('CRM_TK ', crm_output%tk      (icol_beg:icol_end,:,:,:),ncol, lchnk )  
+   call outfld('CRM_TKH', crm_output%tkh     (icol_beg:icol_end,:,:,:),ncol, lchnk ) 
 
    !----------------------------------------------------------------------------
    ! CRM domain average condensate and precipitation
-   call outfld('MMF_QC    ',crm_output%qc_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
-   call outfld('MMF_QI    ',crm_output%qi_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
-   call outfld('MMF_QS    ',crm_output%qs_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
-   call outfld('MMF_QG    ',crm_output%qg_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
-   call outfld('MMF_QR    ',crm_output%qr_mean(icrm_beg:icrm_end,:), ncol ,lchnk )
+   call outfld('MMF_QC    ',crm_output%qc_mean(icol_beg:icol_end,:), ncol ,lchnk )
+   call outfld('MMF_QI    ',crm_output%qi_mean(icol_beg:icol_end,:), ncol ,lchnk )
+   call outfld('MMF_QS    ',crm_output%qs_mean(icol_beg:icol_end,:), ncol ,lchnk )
+   call outfld('MMF_QG    ',crm_output%qg_mean(icol_beg:icol_end,:), ncol ,lchnk )
+   call outfld('MMF_QR    ',crm_output%qr_mean(icol_beg:icol_end,:), ncol ,lchnk )
 
    !----------------------------------------------------------------------------
    ! CRM domain average fluxes
-   call outfld('MMF_QTFLX ',crm_output%flux_qt   (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_UFLX  ',crm_output%flux_u    (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_VFLX  ',crm_output%flux_v    (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_TKE   ',crm_output%tkez      (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_TKEW  ',crm_output%tkew      (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_TKES  ',crm_output%tkesgsz   (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_TK    ',crm_output%tkz       (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_QTFLXS',crm_output%fluxsgs_qt(icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_QPFLX ',crm_output%flux_qp   (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_PFLX  ',crm_output%precflux  (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_QTLS  ',crm_output%qt_ls     (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_QTTR  ',crm_output%qt_trans  (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_QPTR  ',crm_output%qp_trans  (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_QPEVP ',crm_output%qp_evp    (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_QPFALL',crm_output%qp_fall   (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_QPSRC ',crm_output%qp_src    (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_TLS   ',crm_output%t_ls      (icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_QTFLX ',crm_output%flux_qt   (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_UFLX  ',crm_output%flux_u    (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_VFLX  ',crm_output%flux_v    (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_TKE   ',crm_output%tkez      (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_TKEW  ',crm_output%tkew      (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_TKES  ',crm_output%tkesgsz   (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_TK    ',crm_output%tkz       (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_QTFLXS',crm_output%fluxsgs_qt(icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_QPFLX ',crm_output%flux_qp   (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_PFLX  ',crm_output%precflux  (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_QTLS  ',crm_output%qt_ls     (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_QTTR  ',crm_output%qt_trans  (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_QPTR  ',crm_output%qp_trans  (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_QPEVP ',crm_output%qp_evp    (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_QPFALL',crm_output%qp_fall   (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_QPSRC ',crm_output%qp_src    (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_TLS   ',crm_output%t_ls      (icol_beg:icol_end,:), ncol, lchnk )
 
    ! NOTE: these should overwrite cloud outputs from non-MMF routines
-   call outfld('CLOUD   ',crm_output%cld     (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('CLDTOT  ',crm_output%cltot   (icrm_beg:icrm_end),   ncol, lchnk )
-   call outfld('CLDHGH  ',crm_output%clhgh   (icrm_beg:icrm_end),   ncol, lchnk )
-   call outfld('CLDMED  ',crm_output%clmed   (icrm_beg:icrm_end),   ncol, lchnk )
-   call outfld('CLDLOW  ',crm_output%cllow   (icrm_beg:icrm_end),   ncol, lchnk )
-   call outfld('MMF_CLDTOP',crm_output%cldtop(icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('CLOUD   ',crm_output%cld     (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('CLDTOT  ',crm_output%cltot   (icol_beg:icol_end),   ncol, lchnk )
+   call outfld('CLDHGH  ',crm_output%clhgh   (icol_beg:icol_end),   ncol, lchnk )
+   call outfld('CLDMED  ',crm_output%clmed   (icol_beg:icol_end),   ncol, lchnk )
+   call outfld('CLDLOW  ',crm_output%cllow   (icol_beg:icol_end),   ncol, lchnk )
+   call outfld('MMF_CLDTOP',crm_output%cldtop(icol_beg:icol_end,:), ncol, lchnk )
 
-   call outfld('MMF_SUBCYCLE_FAC',crm_output%subcycle_factor(icrm_beg:icrm_end), ncol,lchnk)
+   call outfld('MMF_SUBCYCLE_FAC',crm_output%subcycle_factor(icol_beg:icol_end), ncol,lchnk)
 
    !----------------------------------------------------------------------------
    ! CRM mass flux
-   call outfld('MMF_MC    ', crm_output%mctot (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_MCUP  ', crm_output%mcup  (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_MCDN  ', crm_output%mcdn  (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_MCUUP ', crm_output%mcuup (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MMF_MCUDN ', crm_output%mcudn (icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MU_CRM    ', crm_output%mu_crm(icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('MD_CRM    ', crm_output%md_crm(icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('EU_CRM    ', crm_output%eu_crm(icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('DU_CRM    ', crm_output%du_crm(icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('ED_CRM    ', crm_output%ed_crm(icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('MMF_MC    ', crm_output%mctot (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_MCUP  ', crm_output%mcup  (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_MCDN  ', crm_output%mcdn  (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_MCUUP ', crm_output%mcuup (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MMF_MCUDN ', crm_output%mcudn (icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MU_CRM    ', crm_output%mu_crm(icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('MD_CRM    ', crm_output%md_crm(icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('EU_CRM    ', crm_output%eu_crm(icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('DU_CRM    ', crm_output%du_crm(icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('ED_CRM    ', crm_output%ed_crm(icol_beg:icol_end,:), ncol, lchnk )
 
 #ifdef m2005
    if (MMF_microphysics_scheme .eq. 'm2005') then
@@ -536,40 +536,40 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
       ! Be cautious to use them here. They are defined in crm codes, and these codes are called only 
       ! after the subroutine of crm is called. So they can only be used after the 'crm' subroutine. 
       ! incl, inci, ... can not be used here, for they are defined before we call them???
-      call outfld('CRM_NC ',crm_state%nc(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-      call outfld('CRM_NI ',crm_state%ni(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-      call outfld('CRM_NR ',crm_state%nr(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-      call outfld('CRM_NS ',crm_state%ns(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-      call outfld('CRM_NG ',crm_state%ng(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-      call outfld('CRM_QR ',crm_state%qr(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-      call outfld('CRM_QS ',crm_state%qs(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
-      call outfld('CRM_QG ',crm_state%qg(icrm_beg:icrm_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_NC ',crm_state%nc(icol_beg:icol_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_NI ',crm_state%ni(icol_beg:icol_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_NR ',crm_state%nr(icol_beg:icol_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_NS ',crm_state%ns(icol_beg:icol_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_NG ',crm_state%ng(icol_beg:icol_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_QR ',crm_state%qr(icol_beg:icol_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_QS ',crm_state%qs(icol_beg:icol_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_QG ',crm_state%qg(icol_beg:icol_end,:,:,:), ncol, lchnk )
       
-      call outfld('CRM_WVAR',crm_output%wvar(icrm_beg:icrm_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_WVAR',crm_output%wvar(icol_beg:icol_end,:,:,:), ncol, lchnk)
 
-      call outfld('CRM_AUT', crm_output%aut (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
-      call outfld('CRM_ACC', crm_output%acc (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
-      call outfld('CRM_MLT', crm_output%mlt (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
-      call outfld('CRM_SUB', crm_output%sub (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
-      call outfld('CRM_DEP', crm_output%dep (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
-      call outfld('CRM_CON', crm_output%con (icrm_beg:icrm_end,:,:,:), ncol, lchnk)
-      call outfld('CRM_EVPC',crm_output%evpc(icrm_beg:icrm_end,:,:,:), ncol, lchnk)
-      call outfld('CRM_EVPR',crm_output%evpr(icrm_beg:icrm_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_AUT', crm_output%aut (icol_beg:icol_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_ACC', crm_output%acc (icol_beg:icol_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_MLT', crm_output%mlt (icol_beg:icol_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_SUB', crm_output%sub (icol_beg:icol_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_DEP', crm_output%dep (icol_beg:icol_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_CON', crm_output%con (icol_beg:icol_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_EVPC',crm_output%evpc(icol_beg:icol_end,:,:,:), ncol, lchnk)
+      call outfld('CRM_EVPR',crm_output%evpr(icol_beg:icol_end,:,:,:), ncol, lchnk)
       
-      call outfld('A_AUT', crm_output%aut_a (icrm_beg:icrm_end,:), ncol, lchnk)
-      call outfld('A_ACC', crm_output%acc_a (icrm_beg:icrm_end,:), ncol, lchnk)
-      call outfld('A_MLT', crm_output%mlt_a (icrm_beg:icrm_end,:), ncol, lchnk)
-      call outfld('A_SUB', crm_output%sub_a (icrm_beg:icrm_end,:), ncol, lchnk)
-      call outfld('A_DEP', crm_output%dep_a (icrm_beg:icrm_end,:), ncol, lchnk)
-      call outfld('A_CON', crm_output%con_a (icrm_beg:icrm_end,:), ncol, lchnk)
-      call outfld('A_EVPC',crm_output%evpc_a(icrm_beg:icrm_end,:), ncol, lchnk)
-      call outfld('A_EVPR',crm_output%evpr_a(icrm_beg:icrm_end,:), ncol, lchnk)
+      call outfld('A_AUT', crm_output%aut_a (icol_beg:icol_end,:), ncol, lchnk)
+      call outfld('A_ACC', crm_output%acc_a (icol_beg:icol_end,:), ncol, lchnk)
+      call outfld('A_MLT', crm_output%mlt_a (icol_beg:icol_end,:), ncol, lchnk)
+      call outfld('A_SUB', crm_output%sub_a (icol_beg:icol_end,:), ncol, lchnk)
+      call outfld('A_DEP', crm_output%dep_a (icol_beg:icol_end,:), ncol, lchnk)
+      call outfld('A_CON', crm_output%con_a (icol_beg:icol_end,:), ncol, lchnk)
+      call outfld('A_EVPC',crm_output%evpc_a(icol_beg:icol_end,:), ncol, lchnk)
+      call outfld('A_EVPR',crm_output%evpr_a(icol_beg:icol_end,:), ncol, lchnk)
 
-      call outfld('MMF_NC    ',crm_output%nc_mean(icrm_beg:icrm_end,:), ncol, lchnk )
-      call outfld('MMF_NI    ',crm_output%ni_mean(icrm_beg:icrm_end,:), ncol, lchnk )
-      call outfld('MMF_NS    ',crm_output%ns_mean(icrm_beg:icrm_end,:), ncol, lchnk )
-      call outfld('MMF_NG    ',crm_output%ng_mean(icrm_beg:icrm_end,:), ncol, lchnk )
-      call outfld('MMF_NR    ',crm_output%nr_mean(icrm_beg:icrm_end,:), ncol, lchnk )
+      call outfld('MMF_NC    ',crm_output%nc_mean(icol_beg:icol_end,:), ncol, lchnk )
+      call outfld('MMF_NI    ',crm_output%ni_mean(icol_beg:icol_end,:), ncol, lchnk )
+      call outfld('MMF_NS    ',crm_output%ns_mean(icol_beg:icol_end,:), ncol, lchnk )
+      call outfld('MMF_NG    ',crm_output%ng_mean(icol_beg:icol_end,:), ncol, lchnk )
+      call outfld('MMF_NR    ',crm_output%nr_mean(icol_beg:icol_end,:), ncol, lchnk )
    endif ! m2005
 #endif /* m2005 */
 
@@ -579,15 +579,15 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    tgliqwp(:ncol) = 0.
    do k = 1,pver
       do i = 1,ncol
-         icrm = icrm_beg - 1 + i
-         cicewp(i,k) = crm_output%gicewp(icrm,k) * 1.0e-3 / max(0.01_r8,crm_output%cld(icrm,k)) ! In-cloud ice water path.  g/m2 --> kg/m2
-         cliqwp(i,k) = crm_output%gliqwp(icrm,k) * 1.0e-3 / max(0.01_r8,crm_output%cld(icrm,k)) ! In-cloud liquid water path. g/m2 --> kg/m2
-         tgicewp(i)  = tgicewp(i) + crm_output%gicewp(icrm,k) *1.0e-3 ! grid cell mean ice water path.  g/m2 --> kg/m2
-         tgliqwp(i)  = tgliqwp(i) + crm_output%gliqwp(icrm,k) *1.0e-3 ! grid cell mean ice water path.  g/m2 --> kg/m2
+         icol = icol_beg - 1 + i
+         cicewp(i,k) = crm_output%gicewp(icol,k) * 1.0e-3 / max(0.01_r8,crm_output%cld(icol,k)) ! In-cloud ice water path.  g/m2 --> kg/m2
+         cliqwp(i,k) = crm_output%gliqwp(icol,k) * 1.0e-3 / max(0.01_r8,crm_output%cld(icol,k)) ! In-cloud liquid water path. g/m2 --> kg/m2
+         tgicewp(i)  = tgicewp(i) + crm_output%gicewp(icol,k) *1.0e-3 ! grid cell mean ice water path.  g/m2 --> kg/m2
+         tgliqwp(i)  = tgliqwp(i) + crm_output%gliqwp(icol,k) *1.0e-3 ! grid cell mean ice water path.  g/m2 --> kg/m2
       end do
    end do
    tgwp(:ncol) = tgicewp(:ncol) + tgliqwp(:ncol)
-   gwp(:ncol,:pver) = crm_output%gicewp(icrm_beg:icrm_end,:pver) + crm_output%gliqwp(icrm_beg:icrm_end,:pver)
+   gwp(:ncol,:pver) = crm_output%gicewp(icol_beg:icol_end,:pver) + crm_output%gliqwp(icol_beg:icol_end,:pver)
    cwp(:ncol,:pver) = cicewp(:ncol,:pver) + cliqwp(:ncol,:pver)
 
    call outfld('GCLDLWP' ,gwp,     ncol, lchnk)
@@ -601,34 +601,34 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    ! ECPP
 #ifdef ECPP
    if (use_ECPP) then
-      call outfld('ACEN    ',      crm_ecpp_output%acen            (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('ABND    ',      crm_ecpp_output%abnd            (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('ACEN_TF ',      crm_ecpp_output%acen_tf         (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('ABND_TF ',      crm_ecpp_output%abnd_tf         (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('MASFBND ',      crm_ecpp_output%massflxbnd      (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('RHCEN   ',      crm_ecpp_output%rhcen           (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('QCCEN   ',      crm_ecpp_output%qcloudcen       (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('QICEN   ',      crm_ecpp_output%qicecen         (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('QSINK_AFCEN',   crm_ecpp_output%qlsink_afcen    (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('PRECRCEN',      crm_ecpp_output%precrcen        (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('PRECSCEN',      crm_ecpp_output%precsolidcen    (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('WUPTHRES',      crm_ecpp_output%wupthresh_bnd   (icrm_beg:icrm_end,:),       ncol, lchnk )
-      call outfld('WDNTHRES',      crm_ecpp_output%wdownthresh_bnd (icrm_beg:icrm_end,:),       ncol, lchnk )
-      call outfld('WWQUI_CEN',     crm_ecpp_output%wwqui_cen       (icrm_beg:icrm_end,:),       ncol, lchnk )
-      call outfld('WWQUI_CLD_CEN', crm_ecpp_output%wwqui_cloudy_cen(icrm_beg:icrm_end,:),       ncol, lchnk )
-      call outfld('WWQUI_BND',     crm_ecpp_output%wwqui_cen       (icrm_beg:icrm_end,:),       ncol, lchnk )
-      call outfld('WWQUI_CLD_BND', crm_ecpp_output%wwqui_cloudy_cen(icrm_beg:icrm_end,:),       ncol, lchnk )
-      call outfld('QSINK_BFCEN',   crm_ecpp_output%qlsink_bfcen    (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('QSINK_AVGCEN',  crm_ecpp_output%qlsink_avgcen   (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
-      call outfld('PRAINCEN',      crm_ecpp_output%praincen        (icrm_beg:icrm_end,:,:,:,:), ncol, lchnk )
+      call outfld('ACEN    ',      crm_ecpp_output%acen            (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('ABND    ',      crm_ecpp_output%abnd            (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('ACEN_TF ',      crm_ecpp_output%acen_tf         (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('ABND_TF ',      crm_ecpp_output%abnd_tf         (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('MASFBND ',      crm_ecpp_output%massflxbnd      (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('RHCEN   ',      crm_ecpp_output%rhcen           (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('QCCEN   ',      crm_ecpp_output%qcloudcen       (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('QICEN   ',      crm_ecpp_output%qicecen         (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('QSINK_AFCEN',   crm_ecpp_output%qlsink_afcen    (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('PRECRCEN',      crm_ecpp_output%precrcen        (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('PRECSCEN',      crm_ecpp_output%precsolidcen    (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('WUPTHRES',      crm_ecpp_output%wupthresh_bnd   (icol_beg:icol_end,:),       ncol, lchnk )
+      call outfld('WDNTHRES',      crm_ecpp_output%wdownthresh_bnd (icol_beg:icol_end,:),       ncol, lchnk )
+      call outfld('WWQUI_CEN',     crm_ecpp_output%wwqui_cen       (icol_beg:icol_end,:),       ncol, lchnk )
+      call outfld('WWQUI_CLD_CEN', crm_ecpp_output%wwqui_cloudy_cen(icol_beg:icol_end,:),       ncol, lchnk )
+      call outfld('WWQUI_BND',     crm_ecpp_output%wwqui_cen       (icol_beg:icol_end,:),       ncol, lchnk )
+      call outfld('WWQUI_CLD_BND', crm_ecpp_output%wwqui_cloudy_cen(icol_beg:icol_end,:),       ncol, lchnk )
+      call outfld('QSINK_BFCEN',   crm_ecpp_output%qlsink_bfcen    (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('QSINK_AVGCEN',  crm_ecpp_output%qlsink_avgcen   (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
+      call outfld('PRAINCEN',      crm_ecpp_output%praincen        (icol_beg:icol_end,:,:,:,:), ncol, lchnk )
    end if ! use_ECPP
 #endif /* ECPP */
 
    !----------------------------------------------------------------------------
    ! CRM momentum tendencies
 #if defined( MMF_ESMT )
-   call outfld('U_TEND_ESMT',crm_output%u_tend_esmt(icrm_beg:icrm_end,:), ncol, lchnk )
-   call outfld('V_TEND_ESMT',crm_output%v_tend_esmt(icrm_beg:icrm_end,:), ncol, lchnk )
+   call outfld('U_TEND_ESMT',crm_output%u_tend_esmt(icol_beg:icol_end,:), ncol, lchnk )
+   call outfld('V_TEND_ESMT',crm_output%v_tend_esmt(icol_beg:icol_end,:), ncol, lchnk )
 #endif /* MMF_ESMT */
 
 #if defined(MMF_MOMENTUM_FEEDBACK) || defined(MMF_ESMT)
@@ -645,8 +645,8 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
       call outfld('MMF_VT_Q',      state%q(:,:,idx_vt_q),                   ncol, lchnk )
       call outfld('MMF_VT_TEND_T', ptend%q(:,:,idx_vt_t),                   ncol, lchnk )
       call outfld('MMF_VT_TEND_Q', ptend%q(:,:,idx_vt_q),                   ncol, lchnk )
-      call outfld('MMF_VT_TLS',    crm_output%t_vt_ls(icrm_beg:icrm_end,:), ncol, lchnk )
-      call outfld('MMF_VT_QLS',    crm_output%q_vt_ls(icrm_beg:icrm_end,:), ncol, lchnk )
+      call outfld('MMF_VT_TLS',    crm_output%t_vt_ls(icol_beg:icol_end,:), ncol, lchnk )
+      call outfld('MMF_VT_QLS',    crm_output%q_vt_ls(icol_beg:icol_end,:), ncol, lchnk )
    end if
 
    !----------------------------------------------------------------------------

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -380,7 +380,7 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    use ppgrid,                 only: pcols, pver, pverp
    use physconst,              only: cpair
    use cam_history,            only: outfld
-   
+   use cam_abortutils,         only: endrun
    !----------------------------------------------------------------------------
    ! interface variables
    type(physics_state),              intent(in) :: state             ! Global model state 
@@ -398,6 +398,7 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
 
    !----------------------------------------------------------------------------
    ! local variables
+   character*15 :: subname='crm_history_out'
    real(r8) :: cwp       (pcols,pver)  ! in-cloud cloud (total) water path (kg/m2)
    real(r8) :: gwp       (pcols,pver)  ! grid-box cloud (total) water path (kg/m2)
    real(r8) :: cicewp    (pcols,pver)  ! in-cloud cloud ice water path (kg/m2)
@@ -416,6 +417,11 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    integer :: idx_vt_t, idx_vt_q
 
    !----------------------------------------------------------------------------
+
+   ! check that icol bounds are correct
+   if ( (icol_end-icol_beg+1) /= ncol ) then
+      call endrun(trim(subname)//': icol_beg and icol_end bounds do not match ncol')
+   end if
 
    call cnst_get_ind('CLDLIQ', ixcldliq)
    call cnst_get_ind('CLDICE', ixcldice)

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -438,10 +438,10 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
 
    !----------------------------------------------------------------------------
    ! CRM domain average Tendencies
-   call outfld('MMF_DT    ',MMF_DT_out,            pcols, lchnk ) 
-   call outfld('MMF_DQ    ',ptend%q(1,1,1),        pcols, lchnk )
-   call outfld('MMF_DQC   ',ptend%q(1,1,ixcldliq), pcols, lchnk )
-   call outfld('MMF_DQI   ',ptend%q(1,1,ixcldice), pcols, lchnk )
+   call outfld('MMF_DT    ',MMF_DT_out(1:ncol,:),       ncol, lchnk ) 
+   call outfld('MMF_DQ    ',ptend%q(1:ncol,1,1),        ncol, lchnk )
+   call outfld('MMF_DQC   ',ptend%q(1:ncol,1,ixcldliq), ncol, lchnk )
+   call outfld('MMF_DQI   ',ptend%q(1:ncol,1,ixcldice), ncol, lchnk )
 
    ! CRM radiative heating rate
    ! NOTE: We output the radiative heating rates (MMF_QRS and MMF_QRL) here 
@@ -638,8 +638,8 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
 #endif /* MMF_ESMT */
 
 #if defined(MMF_MOMENTUM_FEEDBACK) || defined(MMF_ESMT)
-   call outfld('MMF_DU',ptend%u, pcols, lchnk )
-   call outfld('MMF_DV',ptend%v, pcols, lchnk )
+   call outfld('MMF_DU',ptend%u(1:ncol,:), ncol, lchnk )
+   call outfld('MMF_DV',ptend%v(1:ncol,:), ncol, lchnk )
 #endif /* MMF_MOMENTUM_FEEDBACK or MMF_ESMT */
 
    !----------------------------------------------------------------------------

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -453,12 +453,12 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    ! CRM_QRS + CRM_QRL output in radiation_tend will show a time lag.
 
    ! GCM level rad heating tendencies
-   call outfld('MMF_QRL   ',qrl(1:ncol)/cpair, ncol, lchnk )
-   call outfld('MMF_QRS   ',qrs(1:ncol)/cpair, ncol, lchnk )
+   call outfld('MMF_QRL   ',qrl(1:ncol,1:pver)/cpair, ncol, lchnk )
+   call outfld('MMF_QRS   ',qrs(1:ncol,1:pver)/cpair, ncol, lchnk )
 
    ! Why do we output this here?
-   call outfld('PRES    ',state%pmid(1:ncol), ncol, lchnk )
-   call outfld('DPRES   ',state%pdel(1:ncol), ncol, lchnk )
+   call outfld('PRES    ',state%pmid(1:ncol,1:pver), ncol, lchnk )
+   call outfld('DPRES   ',state%pdel(1:ncol,1:pver), ncol, lchnk )
 
    ! CRM state variables on CRM grid
    call outfld('CRM_U   ',crm_state%u_wind     (icol_beg:icol_end,:,:,:), ncol, lchnk )
@@ -596,12 +596,12 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    gwp(1:ncol,:pver) = crm_output%gicewp(icol_beg:icol_end,:pver) + crm_output%gliqwp(icol_beg:icol_end,:pver)
    cwp(1:ncol,:pver) = cicewp(1:ncol,:pver) + cliqwp(1:ncol,:pver)
 
-   call outfld('GCLDLWP' ,gwp(1:ncol),     ncol, lchnk)
-   call outfld('TGCLDCWP',tgwp(1:ncol),    ncol, lchnk)
-   call outfld('TGCLDLWP',tgliqwp(1:ncol), ncol, lchnk)
-   call outfld('TGCLDIWP',tgicewp(1:ncol), ncol, lchnk)
-   call outfld('ICLDTWP' ,cwp(1:ncol),     ncol, lchnk)
-   call outfld('ICLDIWP' ,cicewp(1:ncol),  ncol, lchnk)
+   call outfld('GCLDLWP' ,gwp(1:ncol,1:pver),    ncol, lchnk)
+   call outfld('TGCLDCWP',tgwp(1:ncol),          ncol, lchnk)
+   call outfld('TGCLDLWP',tgliqwp(1:ncol),       ncol, lchnk)
+   call outfld('TGCLDIWP',tgicewp(1:ncol),       ncol, lchnk)
+   call outfld('ICLDTWP' ,cwp(1:ncol,1:pver),    ncol, lchnk)
+   call outfld('ICLDIWP' ,cicewp(1:ncol,1:pver), ncol, lchnk)
 
    !----------------------------------------------------------------------------
    ! ECPP

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -418,6 +418,9 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
 
    !----------------------------------------------------------------------------
 
+   lchnk = state%lchnk
+   ncol  = state%ncol
+
    ! check that icol bounds are correct
    if ( (icol_end-icol_beg+1) /= ncol ) then
       call endrun(trim(subname)//': icol_beg and icol_end bounds do not match ncol')
@@ -429,9 +432,6 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    call phys_getopts(use_ECPP_out = use_ECPP)
    call phys_getopts(use_MMF_VT_out = use_MMF_VT)
    call phys_getopts(MMF_microphysics_scheme_out = MMF_microphysics_scheme)
-
-   lchnk = state%lchnk
-   ncol  = state%ncol
 
    ! Subtract radiative heating for MMF_DT output
    MMF_DT_out(1:ncol,:pver) = ( ptend%s(1:ncol,:pver) - qrs(1:ncol,:pver) - qrl(1:ncol,:pver) )/cpair

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -607,7 +607,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
    real(crm_rknd), pointer :: crm_u (:,:,:,:) ! CRM u-wind component
    real(crm_rknd), pointer :: crm_v (:,:,:,:) ! CRM v-wind component
    real(crm_rknd), pointer :: crm_w (:,:,:,:) ! CRM w-wind component
-   real(crm_rknd), pointer :: crm_t (:,:,:,:) ! CRM temperuture
+   real(crm_rknd), pointer :: crm_t (:,:,:,:) ! CRM temperature
    real(crm_rknd), pointer :: crm_qt(:,:,:,:) ! CRM total water
 
    real(crm_rknd), pointer :: crm_qp(:,:,:,:) ! 1-mom mass mixing ratio of precipitating condensate
@@ -1091,8 +1091,11 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
 
       call t_startf ('crm_call')
 
-      call crm(1, ncrms, ztodt, pver, &
-               crm_input, crm_state, crm_rad, &
+      call crm(ncrms, ztodt, pver, &
+               crm_input, crm_state, &
+               crm_rad%qrad, crm_rad%temperature, &
+               crm_rad%qv, crm_rad%qc, crm_rad%qi, crm_rad%cld, &
+               crm_rad%nc, crm_rad%ni, crm_rad%qs, crm_rad%ns, &
                crm_ecpp_output, crm_output, crm_clear_rh, &
                latitude0, longitude0, gcolp, nstep, &
                use_MMF_VT_tmp, MMF_VT_wn_max, &
@@ -1106,7 +1109,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
 
       ! Fortran classes don't translate to C++ classes, we we have to separate
       ! this stuff out when calling the C++ routinte crm(...)
-      call crm(ncol, ncrms, ztodt, pver, crm_input%bflxls, crm_input%wndls, crm_input%zmid, crm_input%zint, &
+      call crm(ncrms, ncrms, ztodt, pver, crm_input%bflxls, crm_input%wndls, crm_input%zmid, crm_input%zint, &
                crm_input%pmid, crm_input%pint, crm_input%pdel, crm_input%ul, crm_input%vl, &
                crm_input%tl, crm_input%qccl, crm_input%qiil, crm_input%ql, crm_input%tau00, &
 #ifdef MMF_ESMT

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -24,7 +24,7 @@ module crm_physics
    public :: crm_surface_flux_bypass_tend
    public :: m2005_effradius
 
-   integer :: ncrms = -1 ! total number of CRMs summed over all chunks in task
+   integer, public :: ncrms = -1 ! total number of CRMs summed over all chunks in task
 
    ! Constituent names
    character(len=8), parameter :: cnst_names(8) = (/'CLDLIQ', 'CLDICE','NUMLIQ','NUMICE', &
@@ -1306,16 +1306,16 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
                ideep_crm(i) = i*1.0  ! For convective transport
             end do
 
-            call pbuf_set_field(pbuf, pbuf_get_index('TKE_CRM'), TKE_tmp )
-            call pbuf_set_field(pbuf, pbuf_get_index('TK_CRM'), crm_output%tkz   (ncol_sum+1:ncol_sum+ncol,1:pver) )
-            call pbuf_set_field(pbuf, pbuf_get_index('MU_CRM'), crm_output%mu_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
-            call pbuf_set_field(pbuf, pbuf_get_index('MD_CRM'), crm_output%md_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
-            call pbuf_set_field(pbuf, pbuf_get_index('EU_CRM'), crm_output%eu_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
-            call pbuf_set_field(pbuf, pbuf_get_index('DU_CRM'), crm_output%du_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
-            call pbuf_set_field(pbuf, pbuf_get_index('ED_CRM'), crm_output%eu_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
-            call pbuf_set_field(pbuf, pbuf_get_index('JT_CRM'), crm_output%jt_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
-            call pbuf_set_field(pbuf, pbuf_get_index('MX_CRM'), crm_output%mx_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
-            call pbuf_set_field(pbuf, pbuf_get_index('IDEEP_CRM'), ideep_crm )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('TKE_CRM'), TKE_tmp )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('TK_CRM'), crm_output%tkz   (ncol_sum+1:ncol_sum+ncol,1:pver) )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('MU_CRM'), crm_output%mu_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('MD_CRM'), crm_output%md_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('EU_CRM'), crm_output%eu_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('DU_CRM'), crm_output%du_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('ED_CRM'), crm_output%eu_crm(ncol_sum+1:ncol_sum+ncol,1:pver) )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('JT_CRM'), crm_output%jt_crm(ncol_sum+1:ncol_sum+ncol) )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('MX_CRM'), crm_output%mx_crm(ncol_sum+1:ncol_sum+ncol) )
+            call pbuf_set_field(pbuf_chunk, pbuf_get_index('IDEEP_CRM'), ideep_crm )
 
             crm_ecpp_output%qlsinkcen = crm_ecpp_output%qlsink_avgcen
          

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -784,31 +784,32 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
          crm_qt(1:ncol,:,:,:) = 0.0_r8
 
          do i = 1,ncol
+            icrm = ncol_sum + i
             do k = 1,crm_nz
                m = pver-k+1
 
-               crm_u(i,:,:,k) = state%u(i,m) * cos( crm_angle(i) ) + state%v(i,m) * sin( crm_angle(i) )
-               crm_v(i,:,:,k) = state%v(i,m) * cos( crm_angle(i) ) - state%u(i,m) * sin( crm_angle(i) )
-               crm_w(i,:,:,k) = 0.
-               crm_t(i,:,:,k) = state%t(i,m)
+               crm_u(icrm,:,:,k) = state(c)%u(i,m) * cos( crm_angle(i) ) + state(c)%v(i,m) * sin( crm_angle(i) )
+               crm_v(icrm,:,:,k) = state(c)%v(i,m) * cos( crm_angle(i) ) - state(c)%u(i,m) * sin( crm_angle(i) )
+               crm_w(icrm,:,:,k) = 0.
+               crm_t(icrm,:,:,k) = state(c)%t(i,m)
 
                ! Initialize microphysics arrays
                if (MMF_microphysics_scheme .eq. 'sam1mom') then
-                  crm_qt(i,:,:,k) = state%q(i,m,1)+state%q(i,m,ixcldliq)+state%q(i,m,ixcldice)
-                  crm_qp(i,:,:,k) = 0.0_r8
-                  crm_qn(i,:,:,k) = state%q(i,m,ixcldliq)+state%q(i,m,ixcldice)
+                  crm_qt(icrm,:,:,k) = state(c)%q(i,m,1)+state(c)%q(i,m,ixcldliq)+state(c)%q(i,m,ixcldice)
+                  crm_qp(icrm,:,:,k) = 0.0_r8
+                  crm_qn(icrm,:,:,k) = state(c)%q(i,m,ixcldliq)+state(c)%q(i,m,ixcldice)
                else if (MMF_microphysics_scheme .eq. 'm2005') then
-                  crm_qt(i,:,:,k) = state%q(i,m,1)+state%q(i,m,ixcldliq)
-                  crm_qc(i,:,:,k) = state%q(i,m,ixcldliq)
-                  crm_qi(i,:,:,k) = state%q(i,m,ixcldice)
-                  crm_nc(i,:,:,k) = 0.0_r8
-                  crm_qr(i,:,:,k) = 0.0_r8
-                  crm_nr(i,:,:,k) = 0.0_r8
-                  crm_ni(i,:,:,k) = 0.0_r8
-                  crm_qs(i,:,:,k) = 0.0_r8
-                  crm_ns(i,:,:,k) = 0.0_r8
-                  crm_qg(i,:,:,k) = 0.0_r8
-                  crm_ng(i,:,:,k) = 0.0_r8
+                  crm_qt(icrm,:,:,k) = state(c)%q(i,m,1)+state(c)%q(i,m,ixcldliq)
+                  crm_qc(icrm,:,:,k) = state(c)%q(i,m,ixcldliq)
+                  crm_qi(icrm,:,:,k) = state(c)%q(i,m,ixcldice)
+                  crm_nc(icrm,:,:,k) = 0.0_r8
+                  crm_qr(icrm,:,:,k) = 0.0_r8
+                  crm_nr(icrm,:,:,k) = 0.0_r8
+                  crm_ni(icrm,:,:,k) = 0.0_r8
+                  crm_qs(icrm,:,:,k) = 0.0_r8
+                  crm_ns(icrm,:,:,k) = 0.0_r8
+                  crm_qg(icrm,:,:,k) = 0.0_r8
+                  crm_ng(icrm,:,:,k) = 0.0_r8
                end if
 
             end do
@@ -833,8 +834,8 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
             m = pver-k+1
             do i = 1,ncol
                crm_qrad   (i,:,:,k) = 0.
-               crm_t_rad  (i,:,:,k) = state%t(i,m)
-               crm_qv_rad (i,:,:,k) = state%q(i,m,1)
+               crm_t_rad  (i,:,:,k) = state(c)%t(i,m)
+               crm_qv_rad (i,:,:,k) = state(c)%q(i,m,1)
                crm_qc_rad (i,:,:,k) = 0.
                crm_qi_rad (i,:,:,k) = 0.
                crm_cld_rad(i,:,:,k) = 0.
@@ -1047,7 +1048,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
          phase = 1  ! interstital aerosols only
          do i = 1,ncol
             icrm = ncol_sum + i
-            air_density(i,1:pver) = state%pmid(i,1:pver) / (287.15*state%t(i,1:pver))
+            air_density(i,1:pver) = state(c)%pmid(i,1:pver) / (287.15*state(c)%t(i,1:pver))
             do k = 1, pver
                do m = 1, ntot_amode
                   call loadaer( state(c), pbuf_chunk, i, i, k, m, air_density, phase, &
@@ -1300,7 +1301,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
 
             do i = 1,ncol
                icrm = ncol_sum + i
-               air_density(i,1:pver) = state%pmid(i,1:pver) / (287.15*state%t(i,1:pver))
+               air_density(i,1:pver) = state(c)%pmid(i,1:pver) / (287.15*state(c)%t(i,1:pver))
                TKE_tmp(i,1:pver) = crm_output%tkez(i,1:pver) / air_density(i,1:pver)
                ideep_crm(i) = i*1.0  ! For convective transport
             end do

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -1089,10 +1089,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
       call t_startf ('crm_call')
 
       call crm(ncrms, ztodt, pver, &
-               crm_input, crm_state, &
-               crm_rad%qrad, crm_rad%temperature, &
-               crm_rad%qv, crm_rad%qc, crm_rad%qi, crm_rad%cld, &
-               crm_rad%nc, crm_rad%ni, crm_rad%qs, crm_rad%ns, &
+               crm_input, crm_state, crm_rad, &
                crm_ecpp_output, crm_output, crm_clear_rh, &
                latitude0, longitude0, gcolp, nstep, &
                use_MMF_VT_tmp, MMF_VT_wn_max, &

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -24,6 +24,8 @@ module crm_physics
    public :: crm_surface_flux_bypass_tend
    public :: m2005_effradius
 
+   integer :: ncrms = -1 ! total number of CRMs summed over all chunks in task
+
    ! Constituent names
    character(len=8), parameter :: cnst_names(8) = (/'CLDLIQ', 'CLDICE','NUMLIQ','NUMICE', &
                                                     'RAINQM', 'SNOWQM','NUMRAI','NUMSNO'/)
@@ -65,6 +67,7 @@ subroutine crm_physics_register()
    use spmd_utils,          only: masterproc
    use physconst,           only: cpair, mwh2o, mwdry
    use ppgrid,              only: pcols, pver, pverp
+   use phys_grid,           only: get_ncols_p
    use physics_buffer,      only: dyn_time_lvls, pbuf_add_field, dtype_r8, pbuf_get_index
    use phys_control,        only: phys_getopts, use_gw_convect
    use constituents,        only: cnst_add
@@ -133,6 +136,14 @@ subroutine crm_physics_register()
       print*,'CRM Microphysics = ',MMF_microphysics_scheme
       print*,'_____________________________________________________________'
    end if
+
+   !----------------------------------------------------------------------------
+   ! Determine total number of CRMs per task
+   !----------------------------------------------------------------------------
+   ncrms = 0
+   do c=begchunk, endchunk
+      ncrms = ncrms + get_ncols_p(c)
+   end do
 
    !----------------------------------------------------------------------------
    ! Setup CRM internal parameters

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -443,7 +443,7 @@ end subroutine crm_physics_final
 !===================================================================================================
 !===================================================================================================
 
-subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
+subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, &
                             species_class, crm_ecpp_output, &
                             mmf_qchk_prec_dp, mmf_qchk_snow_dp, mmf_rad_flux)
    !------------------------------------------------------------------------------------------------
@@ -451,53 +451,54 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    ! Original Author: Marat Khairoutdinov
    !------------------------------------------------------------------------------------------------
    use perf_mod
-   use physics_buffer,  only: physics_buffer_desc, pbuf_old_tim_idx, pbuf_get_index, &
-                              dyn_time_lvls, pbuf_get_field, pbuf_set_field
-   use physics_types,   only: physics_state, physics_tend, physics_ptend, physics_ptend_init
-   use camsrfexch,      only: cam_in_t, cam_out_t
-   use time_manager,    only: is_first_step, get_nstep
-   use crmdims,         only: crm_nx, crm_ny, crm_nz, crm_nx_rad, crm_ny_rad
-   use physconst,       only: cpair, latvap, latice, gravit, cappa, pi
-   use constituents,    only: pcnst, cnst_get_ind
+   use physics_buffer,        only: physics_buffer_desc, pbuf_old_tim_idx, pbuf_get_index, &
+                                    dyn_time_lvls, pbuf_get_field, pbuf_set_field, pbuf_get_chunk
+   use physics_types,         only: physics_state, physics_tend, physics_ptend, physics_ptend_init
+   use camsrfexch,            only: cam_in_t, cam_out_t
+   use time_manager,          only: is_first_step, get_nstep
+   use crmdims,               only: crm_nx, crm_ny, crm_nz, crm_nx_rad, crm_ny_rad
+   use physconst,             only: cpair, latvap, latice, gravit, cappa, pi
+   use constituents,          only: pcnst, cnst_get_ind
 #if defined(MMF_SAMXX)
-   use cpp_interface_mod, only: crm
+   use cpp_interface_mod,     only: crm
 #elif defined(MMF_SAM) || defined(MMF_SAMOMP)
-   use crm_module       , only: crm
+   use crm_module,            only: crm
 #endif
-   use params_kind,          only: crm_rknd
-   use phys_control,    only: phys_getopts, phys_do_flux_avg
-   use crm_history,     only: crm_history_out
-   use wv_saturation,   only: qsat_water
+   use params_kind,           only: crm_rknd
+   use phys_control,          only: phys_getopts, phys_do_flux_avg
+   use crm_history,           only: crm_history_out
+   use wv_saturation,         only: qsat_water
 #if (defined  m2005 && defined MODAL_AERO)  
    ! modal_aero_data only exists if MODAL_AERO
-   use modal_aero_data, only: ntot_amode, ntot_amode
-   use ndrop,           only: loadaer
+   use modal_aero_data,       only: ntot_amode, ntot_amode
+   use ndrop,                 only: loadaer
 #endif
 
    use RNG_MT ! random number generator for randomly rotating CRM orientation
 
-   use crm_state_module,       only: crm_state_type, crm_state_initialize, crm_state_finalize
-   use crm_rad_module,         only: crm_rad_type, crm_rad_initialize, crm_rad_finalize
-   use crm_input_module,       only: crm_input_type, crm_input_initialize, crm_input_finalize
-   use crm_output_module,      only: crm_output_type, crm_output_initialize, crm_output_finalize
-   use crm_ecpp_output_module, only: crm_ecpp_output_type
+   use crm_state_module,      only: crm_state_type, crm_state_initialize, crm_state_finalize
+   use crm_rad_module,        only: crm_rad_type, crm_rad_initialize, crm_rad_finalize
+   use crm_input_module,      only: crm_input_type, crm_input_initialize, crm_input_finalize
+   use crm_output_module,     only: crm_output_type, crm_output_initialize, crm_output_finalize
+   use crm_ecpp_output_module,only: crm_ecpp_output_type
 
-   use iso_c_binding, only: c_bool
-   use phys_grid    , only: get_rlon_p, get_rlat_p, get_gcol_p  
-   use spmd_utils,          only: masterproc
+   use iso_c_binding,         only: c_bool
+   use phys_grid,             only: get_rlon_p, get_rlat_p, get_gcol_p  
+   use spmd_utils,            only: masterproc
+   use openacc_utils
 
-   real(r8),                        intent(in   ) :: ztodt            ! global model time increment and CRM run length
-   type(physics_state),             intent(in   ) :: state            ! Global model state 
-   type(physics_tend),              intent(in   ) :: tend             ! 
-   type(physics_ptend),             intent(  out) :: ptend            ! output tendencies
-   type(physics_buffer_desc),       pointer       :: pbuf(:)          ! physics buffer
-   type(cam_in_t),                  intent(in   ) :: cam_in           ! atm input from coupler
-   type(cam_out_t),                 intent(inout) :: cam_out          ! atm output to coupler
-   integer,                         intent(in   ) :: species_class(:) ! aerosol species type
-   type(crm_ecpp_output_type),      intent(inout) :: crm_ecpp_output  ! output data for ECPP calculations
-   real(r8), dimension(pcols),      intent(  out) :: mmf_qchk_prec_dp ! precipitation diagostic (liq+ice)  used for check_energy_chng
-   real(r8), dimension(pcols),      intent(  out) :: mmf_qchk_snow_dp ! precipitation diagostic (ice only) used for check_energy_chng
-   real(r8), dimension(pcols),      intent(  out) :: mmf_rad_flux     ! radiative flux diagnostic used for check_energy_chng
+   real(r8),                                        intent(in   ) :: ztodt            ! global model time increment and CRM run length
+   type(physics_state),dimension(begchunk:endchunk),intent(in   ) :: state            ! Global model state 
+   type(physics_tend), dimension(begchunk:endchunk),intent(in   ) :: tend             ! 
+   type(physics_ptend),dimension(begchunk:endchunk),intent(  out) :: ptend            ! output tendencies
+   type(physics_buffer_desc), pointer                             :: pbuf2d(:,:)      ! physics buffer
+   type(cam_in_t),     dimension(begchunk:endchunk),intent(in   ) :: cam_in           ! atm input from coupler
+   type(cam_out_t),    dimension(begchunk:endchunk),intent(inout) :: cam_out          ! atm output to coupler
+   integer,                                         intent(in   ) :: species_class(:) ! aerosol species type
+   type(crm_ecpp_output_type),                      intent(inout) :: crm_ecpp_output  ! output data for ECPP calculations
+   real(r8), dimension(begchunk:endchunk,pcols),    intent(  out) :: mmf_qchk_prec_dp ! precipitation diagostic (liq+ice)  used for check_energy_chng
+   real(r8), dimension(begchunk:endchunk,pcols),    intent(  out) :: mmf_qchk_snow_dp ! precipitation diagostic (ice only) used for check_energy_chng
+   real(r8), dimension(begchunk:endchunk,pcols),    intent(  out) :: mmf_rad_flux     ! radiative flux diagnostic used for check_energy_chng
 
    !------------------------------------------------------------------------------------------------
    ! Local variables 

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -648,7 +648,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
    crm_accel_uv = crm_accel_uv_tmp
 
    if (masterproc) then
-     if (use_crm_accel .and. MMF_microphysics_scheme/='sam1mom') then
+     if (use_crm_accel .and. trim(MMF_microphysics_scheme)/='sam1mom') then
        write(0,*) "CRM time step relaxation is only compatible with sam1mom microphysics"
        call endrun('crm main')
      endif

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -706,8 +706,8 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    call pbuf_get_field(pbuf, crm_qrad_idx,    crm_qrad)
    crm_rad%qrad(1:ncol,:,:,:) = crm_qrad(1:ncol,:,:,:)
 
-   call pbuf_get_field(pbuf, pbuf_get_index('PREC_DP'),  prec_dp  )
-   call pbuf_get_field(pbuf, pbuf_get_index('SNOW_DP'),  snow_dp  )
+   call pbuf_get_field(pbuf, prec_dp_idx,  prec_dp  )
+   call pbuf_get_field(pbuf, snow_dp_idx,  snow_dp  )
 
    prec_dp  = 0.
    snow_dp  = 0.

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -45,6 +45,9 @@ module crm_physics
    integer :: ttend_dp_idx     = -1
    integer :: mmf_clear_rh_idx = -1
    integer :: crm_angle_idx    = -1
+   integer :: cld_idx          = -1
+   integer :: prec_dp_idx      = -1
+   integer :: snow_dp_idx      = -1
 
    integer :: crm_t_rad_idx    = -1
    integer :: crm_qv_rad_idx   = -1
@@ -89,7 +92,7 @@ subroutine crm_physics_register()
 #endif
    !----------------------------------------------------------------------------
    ! local variables
-   integer idx
+   integer :: idx, c
    logical           :: use_ECPP
    logical           :: use_MMF_VT
    character(len=16) :: MMF_microphysics_scheme
@@ -97,26 +100,25 @@ subroutine crm_physics_register()
    integer, dimension(1) :: dims_gcm_1D
    integer, dimension(2) :: dims_gcm_2D
    integer, dimension(3) :: dims_gcm_3D
-   integer, dimension(3) :: dims_crm_2D
    integer, dimension(4) :: dims_crm_3D
    integer, dimension(4) :: dims_crm_rad
-#ifdef MODAL_AERO
-   integer, dimension(5) :: dims_crm_aer
-#endif
    integer :: cnst_ind ! dummy for adding new constituents for variance transport
    !----------------------------------------------------------------------------
 #ifdef MMF_SAMXX
    call gator_init()
 #endif
+
+   ! Determine total number of CRMs per task
+   ncrms = 0
+   do c=begchunk, endchunk
+      ncrms = ncrms + get_ncols_p(c)
+   end do
+
    dims_gcm_1D  = (/pcols/)
    dims_gcm_2D  = (/pcols, pver/)
    dims_gcm_3D  = (/pcols,pver,dyn_time_lvls/)
-   dims_crm_2D  = (/pcols, crm_nx, crm_ny/)
-   dims_crm_3D  = (/pcols, crm_nx, crm_ny, crm_nz/)
+   dims_crm_3D  = (/ncrms, crm_nx, crm_ny, crm_nz/)
    dims_crm_rad = (/pcols, crm_nx_rad, crm_ny_rad, crm_nz/)
-#ifdef MODAL_AERO
-   dims_crm_aer = (/pcols, crm_nx_rad, crm_ny_rad, crm_nz, ntot_amode/)
-#endif
 
    call phys_getopts( use_ECPP_out = use_ECPP )
    call phys_getopts( use_MMF_VT_out = use_MMF_VT )
@@ -138,14 +140,6 @@ subroutine crm_physics_register()
       print*,'CRM Microphysics = ',MMF_microphysics_scheme
       print*,'_____________________________________________________________'
    end if
-
-   !----------------------------------------------------------------------------
-   ! Determine total number of CRMs per task
-   !----------------------------------------------------------------------------
-   ncrms = 0
-   do c=begchunk, endchunk
-      ncrms = ncrms + get_ncols_p(c)
-   end do
 
    !----------------------------------------------------------------------------
    ! Setup CRM internal parameters
@@ -435,6 +429,9 @@ subroutine crm_physics_init(state, pbuf2d, species_class)
 
    ! set pbuf indices
    mmf_clear_rh_idx = pbuf_get_index('MMF_CLEAR_RH')
+   cld_idx          = pbuf_get_index('CLD')
+   prec_dp_idx      = pbuf_get_index('PREC_DP')
+   snow_dp_idx      = pbuf_get_index('SNOW_DP')
 
 end subroutine crm_physics_init
 

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -3,11 +3,11 @@ module crm_physics
 ! Purpose: Provides the interface to the crm code for the MMF configuration
 !---------------------------------------------------------------------------------------------------
    use shr_kind_mod,    only: r8 => shr_kind_r8
-   use shr_sys_mod,     only: shr_sys_flush
+   use shr_sys_mod,     only: shr_sys_flush   
    use cam_abortutils,  only: endrun
    use cam_logfile,     only: iulog
    use physics_types,   only: physics_state, physics_tend
-   use ppgrid,          only: pcols, pver, pverp
+   use ppgrid,          only: begchunk, endchunk, pcols, pver, pverp
    use constituents,    only: pcnst
 #ifdef MODAL_AERO
    use modal_aero_data, only: ntot_amode
@@ -71,7 +71,6 @@ subroutine crm_physics_register()
 !---------------------------------------------------------------------------------------------------
    use spmd_utils,          only: masterproc
    use physconst,           only: cpair, mwh2o, mwdry
-   use ppgrid,              only: pcols, pver, pverp
    use phys_grid,           only: get_ncols_p
    use physics_buffer,      only: dyn_time_lvls, pbuf_add_field, dtype_r8, pbuf_get_index
    use phys_control,        only: phys_getopts, use_gw_convect
@@ -310,7 +309,6 @@ subroutine crm_physics_init(state, pbuf2d, species_class)
 #ifdef ECPP
    use module_ecpp_ppdriver2, only: papampollu_init
 #endif
-   use ppgrid,                only: begchunk, endchunk
    use constituents,          only: pcnst, cnst_get_ind
    !----------------------------------------------------------------------------
    ! interface variables
@@ -452,7 +450,6 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    ! Purpose: CRM interface for the MMF configuration to update GCM state
    ! Original Author: Marat Khairoutdinov
    !------------------------------------------------------------------------------------------------
-   use ppgrid
    use perf_mod
    use physics_buffer,  only: physics_buffer_desc, pbuf_old_tim_idx, pbuf_get_index, &
                               dyn_time_lvls, pbuf_get_field, pbuf_set_field
@@ -1504,7 +1501,6 @@ subroutine crm_surface_flux_bypass_tend(state, cam_in, ptend)
    use physics_types,   only: physics_state, physics_ptend, physics_ptend_init
    use physics_buffer,  only: physics_buffer_desc
    use camsrfexch,      only: cam_in_t
-   use ppgrid,          only: begchunk, endchunk, pcols, pver
    use constituents,    only: pcnst
    use physconst,       only: gravit
 

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -38,6 +38,8 @@ module crm_physics
    integer :: ixsnow    = -1   ! snow index
    integer :: ixnumrain = -1   ! rain number index
    integer :: ixnumsnow = -1   ! snow number index
+   integer :: idx_vt_t  = -1   ! CRM variance transport - liquid static energy
+   integer :: idx_vt_q  = -1   ! CRM variance transport - total water
 
    ! Physics buffer indices  
    integer :: ttend_dp_idx     = -1
@@ -152,9 +154,9 @@ subroutine crm_physics_register()
 
    if (use_MMF_VT) then
       ! add variance tracers
-      call cnst_add('VT_T', real(0,r8), real(0,r8), real(0,r8), cnst_ind, &
+      call cnst_add('VT_T', real(0,r8), real(0,r8), real(0,r8), idx_vt_t, &
                     longname='VT_T', readiv=.false., mixtype='dry',cam_outfld=.false.)
-      call cnst_add('VT_Q', real(0,r8), real(0,r8), real(0,r8), cnst_ind, &
+      call cnst_add('VT_Q', real(0,r8), real(0,r8), real(0,r8), idx_vt_q, &
                     longname='VT_Q', readiv=.false., mixtype='dry',cam_outfld=.false.)
    end if
 
@@ -330,7 +332,6 @@ subroutine crm_physics_init(state, pbuf2d, species_class)
    logical :: use_ECPP
    logical :: use_MMF_VT
    character(len=16) :: MMF_microphysics_scheme
-   integer :: idx_vt_t, idx_vt_q
    integer :: lchnk, ncol
    !----------------------------------------------------------------------------
    call phys_getopts(use_ECPP_out = use_ECPP)
@@ -372,8 +373,6 @@ subroutine crm_physics_init(state, pbuf2d, species_class)
 
    if (use_MMF_VT) then
       ! initialize variance transport tracers
-      call cnst_get_ind( 'VT_T', idx_vt_t )
-      call cnst_get_ind( 'VT_Q', idx_vt_q )
       do lchnk = begchunk, endchunk
          ncol  = state(lchnk)%ncol
          state(lchnk)%q(:ncol,:pver,idx_vt_t) = 0
@@ -601,7 +600,6 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
    logical(c_bool)             :: use_crm_accel
    logical(c_bool)             :: crm_accel_uv
    integer                     :: igstep
-   integer                     :: idx_vt_t, idx_vt_q  ! variance transport constituent indices
 
    ! pointers for crm_rad data on pbuf
    real(crm_rknd), pointer :: crm_qrad   (:,:,:,:) ! rad heating
@@ -1148,8 +1146,6 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
       ptend%q(:ncol,:pver,ixcldice) = crm_output%qiltend(1:ncol,1:pver)
 
       if (use_MMF_VT) then
-         call cnst_get_ind( 'VT_T', idx_vt_t )
-         call cnst_get_ind( 'VT_Q', idx_vt_q )
          ptend%q(1:ncol,1:pver,idx_vt_t) = crm_output%t_vt_tend(1:ncol,1:pver)
          ptend%q(1:ncol,1:pver,idx_vt_q) = crm_output%q_vt_tend(1:ncol,1:pver)
       end if
@@ -1253,8 +1249,6 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf, cam_in, cam_out, &
       ptend%lv           = .FALSE.
 
       if (use_MMF_VT) then
-         call cnst_get_ind( 'VT_T', idx_vt_t )
-         call cnst_get_ind( 'VT_Q', idx_vt_q )
          ptend%lq(idx_vt_t) = .TRUE.
          ptend%lq(idx_vt_q) = .TRUE.
       end if

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -837,7 +837,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
   ncol_sum = 0
   do c=begchunk, endchunk
     ncol_beg(c) = ncol_sum + 1
-    ncol_end(c) = ncol_sum + phys_state(c)%ncol + 1
+    ncol_end(c) = ncol_sum + phys_state(c)%ncol
     ncol_sum = ncol_sum + phys_state(c)%ncol
   end do
 

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -697,7 +697,8 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
   use flux_avg,               only: flux_avg_init
   use check_energy,           only: check_energy_chng
   use crm_physics,            only: ncrms, crm_physics_tend
-  use crm_ecpp_output_module, only: crm_ecpp_output_type, crm_ecpp_output_initialize
+  use crm_ecpp_output_module, only: crm_ecpp_output_type, crm_ecpp_output_initialize, &
+                                    crm_ecpp_output_copy, crm_ecpp_output_finalize
   !-----------------------------------------------------------------------------
   ! Interface arguments
   !-----------------------------------------------------------------------------
@@ -727,11 +728,15 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
   ! stuff for calling crm_physics_tend
   type(physics_ptend), dimension(begchunk:endchunk) :: ptend ! indivdual parameterization tendencies
   logical           :: use_ECPP
-  real(r8), dimension(pcols) :: mmf_qchk_prec_dp  ! CRM precipitation diagostic (liq+ice)  used for check_energy_chng
-  real(r8), dimension(pcols) :: mmf_qchk_snow_dp  ! CRM precipitation diagostic (ice only) used for check_energy_chng
-  real(r8), dimension(pcols) :: mmf_rad_flux      ! CRM radiative flux diagnostic used for check_energy_chng
+  real(r8), dimension(begchunk:endchunk,pcols) :: mmf_qchk_prec_dp  ! CRM precipitation diagostic (liq+ice)  used for check_energy_chng
+  real(r8), dimension(begchunk:endchunk,pcols) :: mmf_qchk_snow_dp  ! CRM precipitation diagostic (ice only) used for check_energy_chng
+  real(r8), dimension(begchunk:endchunk,pcols) :: mmf_rad_flux      ! CRM radiative flux diagnostic used for check_energy_chng
 
-  type(crm_ecpp_output_type) :: crm_ecpp_output(begchunk:endchunk) ! CRM output data for ECPP calculations
+  type(crm_ecpp_output_type) :: crm_ecpp_output       ! CRM output data for ECPP calculations
+  type(crm_ecpp_output_type) :: crm_ecpp_output_chunk ! CRM output data for ECPP calculations (copy)
+  integer  :: ncol_sum
+  integer  :: ncol_beg(begchunk:endchunk)
+  integer  :: ncol_end(begchunk:endchunk)
 
   integer  :: itim_old, cldo_idx, cld_idx   ! pbuf indices  
   real(r8), pointer, dimension(:,:) :: cld  ! cloud fraction
@@ -805,9 +810,8 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
   ! CRM physics
   !-----------------------------------------------------------------------------  
   if (use_ECPP) then
-    do c=begchunk, endchunk
-      call crm_ecpp_output_initialize(crm_ecpp_output(c),phys_state(c)%ncol,pver)
-    end do
+    call crm_ecpp_output_initialize(crm_ecpp_output_chunk,pcols,pver)
+    call crm_ecpp_output_initialize(crm_ecpp_output,      ncrms,pver)
   end if
 
   call t_startf('crm_physics_tend')
@@ -829,6 +833,14 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
   call t_barrierf('sync_bc_physics', mpicom)
   call t_startf ('bc_physics2')
 
+  ! Determine column start and end indices for crm_ecpp_output
+  ncol_sum = 0
+  do c=begchunk, endchunk
+    ncol_beg(c) = ncol_sum + 1
+    ncol_end(c) = ncol_sum + phys_state(c)%ncol + 1
+    ncol_sum = ncol_sum + phys_state(c)%ncol
+  end do
+
 !$OMP PARALLEL DO PRIVATE (C, beg_count, phys_buffer_chunk, end_count, chunk_cost)
   do c=begchunk, endchunk
 
@@ -837,10 +849,12 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
     ! Output physics terms to IC file
     phys_buffer_chunk => pbuf_get_chunk(pbuf2d, c)
 
+    if (use_ECPP) call crm_ecpp_output_copy( crm_ecpp_output, crm_ecpp_output_chunk, ncol_beg(c), ncol_end(c))
+
     call tphysbc2(ztodt, fsns(1,c), fsnt(1,c), flns(1,c), flnt(1,c), &
                  phys_state(c), phys_tend(c), phys_buffer_chunk, &
                  fsds(1,c), sgh(1,c), sgh30(1,c), &
-                 cam_out(c), cam_in(c), crm_ecpp_output(c) )
+                 cam_out(c), cam_in(c), crm_ecpp_output_chunk )
 
     end_count = shr_sys_irtc(irtc_rate)
     chunk_cost = real( (end_count-beg_count), r8)/real(irtc_rate, r8)
@@ -850,6 +864,11 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
 
   call t_stopf ('bc_physics2')
   call t_stopf ('bc_physics')
+
+  if (use_ECPP) then
+    call crm_ecpp_output_finalize(crm_ecpp_output_chunk)
+    call crm_ecpp_output_finalize(crm_ecpp_output)
+  end if
 
   !-----------------------------------------------------------------------------
   !-----------------------------------------------------------------------------
@@ -1302,7 +1321,6 @@ subroutine tphysbc1(ztodt, fsns, fsnt, flns, flnt, &
   use output_aerocom_aie,     only: do_aerocom_ind3
   use phys_control,           only: use_qqflx_fixer, use_mass_borrower
   use crm_physics,            only: crm_physics_tend, crm_surface_flux_bypass_tend
-  use crm_ecpp_output_module, only: crm_ecpp_output_type, crm_ecpp_output_initialize, crm_ecpp_output_finalize
   use cloud_diagnostics,      only: cloud_diagnostics_calc
 
   implicit none
@@ -1590,7 +1608,7 @@ subroutine tphysbc2(ztodt, fsns, fsnt, flns, flnt, &
   use tropopause,             only: tropopause_output
   use output_aerocom_aie,     only: do_aerocom_ind3, cloud_top_aerocom
   use cloud_diagnostics,      only: cloud_diagnostics_calc
-  use crm_ecpp_output_module, only: crm_ecpp_output_type, crm_ecpp_output_finalize
+  use crm_ecpp_output_module, only: crm_ecpp_output_type
   use camsrfexch,             only: cam_export
 #if defined( ECPP )
    use module_ecpp_ppdriver2, only: parampollu_driver2
@@ -1760,8 +1778,6 @@ subroutine tphysbc2(ztodt, fsns, fsnt, flns, flnt, &
       call t_stopf ('ecpp')
 
     end if ! nstep.ne.0 .and. mod(nstep, necpp).eq.0
-
-    call crm_ecpp_output_finalize(crm_ecpp_output)
 
   end if ! use_ECPP
 #endif /* ECPP */

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -696,7 +696,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
   use comsrf,           only: fsns, fsnt, flns, sgh, sgh30, flnt, fsds
   use flux_avg,               only: flux_avg_init
   use check_energy,           only: check_energy_chng
-  use crm_physics,            only: crm_physics_tend
+  use crm_physics,            only: ncrms, crm_physics_tend
   use crm_ecpp_output_module, only: crm_ecpp_output_type, crm_ecpp_output_initialize
   !-----------------------------------------------------------------------------
   ! Interface arguments
@@ -804,24 +804,23 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
   !-----------------------------------------------------------------------------
   ! CRM physics
   !-----------------------------------------------------------------------------  
+  if (use_ECPP) then
+    do c=begchunk, endchunk
+      call crm_ecpp_output_initialize(crm_ecpp_output(c),phys_state(c)%ncol,pver)
+    end do
+  end if
+
+  call t_startf('crm_physics_tend')
+  call crm_physics_tend(ztodt, phys_state, phys_tend, ptend,  &
+                        pbuf2d, cam_in, cam_out,              &
+                        species_class, crm_ecpp_output,       &
+                        mmf_qchk_prec_dp, mmf_qchk_snow_dp, mmf_rad_flux )
+  call t_stopf('crm_physics_tend')
+
   do c=begchunk, endchunk
-
-    phys_buffer_chunk => pbuf_get_chunk(pbuf2d, c)
-
-    ! Initialize variable for ECPP data
-    if (use_ECPP) call crm_ecpp_output_initialize(crm_ecpp_output(c),phys_state(c)%ncol,pver)
-
-    call t_startf('crm_physics_tend')
-    call crm_physics_tend(ztodt, phys_state(c), phys_tend(c), ptend(c), &
-                          phys_buffer_chunk, cam_in(c), cam_out(c),    &
-                          species_class, crm_ecpp_output(c),       &
-                          mmf_qchk_prec_dp, mmf_qchk_snow_dp, mmf_rad_flux )
     call physics_update(phys_state(c), ptend(c), ztodt, phys_tend(c))
-    call t_stopf('crm_physics_tend')
-
     call check_energy_chng(phys_state(c), phys_tend(c), "crm_tend", nstep, ztodt, zero, &
-                           mmf_qchk_prec_dp, mmf_qchk_snow_dp, mmf_rad_flux)
-
+                           mmf_qchk_prec_dp(c,:), mmf_qchk_snow_dp(c,:), mmf_rad_flux(c,:))
   end do
 
   !-----------------------------------------------------------------------------

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -811,9 +811,8 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
   end if
 
   call t_startf('crm_physics_tend')
-  call crm_physics_tend(ztodt, phys_state, phys_tend, ptend,  &
-                        pbuf2d, cam_in, cam_out,              &
-                        species_class, crm_ecpp_output,       &
+  call crm_physics_tend(ztodt, phys_state, phys_tend, ptend, pbuf2d, cam_in, cam_out, &
+                        species_class, crm_ecpp_output, &
                         mmf_qchk_prec_dp, mmf_qchk_snow_dp, mmf_rad_flux )
   call t_stopf('crm_physics_tend')
 

--- a/components/eam/src/physics/crm/sam/crm_module.F90
+++ b/components/eam/src/physics/crm/sam/crm_module.F90
@@ -1,4 +1,6 @@
-
+!---------------------------------------------------------------------------------------------------
+! MMF main driver (original version by Marat Khairoutdinov)
+!---------------------------------------------------------------------------------------------------
 module crm_module
   use openacc_utils, only: prefetch
   use perf_mod
@@ -25,7 +27,7 @@ module crm_module
   use damping_mod
   use ice_fall_mod
   use coriolis_mod
-
+  use setparm_mod,            only: setparm
   use crm_state_module,       only: crm_state_type
   use crm_rad_module,         only: crm_rad_type
   use crm_input_module,       only: crm_input_type
@@ -34,16 +36,14 @@ module crm_module
 #ifdef ECPP  
   use module_ecpp_crm_driver, only: ecpp_crm_stat, ecpp_crm_init, ecpp_crm_cleanup
 #endif
-!---------------------------------------------------------------
-!  Super-parameterization's main driver
-!  Marat Khairoutdinov, 2001-2009
-!---------------------------------------------------------------
-use setparm_mod, only : setparm
 
 contains
 
-subroutine crm(lchnk, ncrms, dt_gl, plev,       &
-                crm_input, crm_state, crm_rad,  &
+subroutine crm( ncrms, dt_gl, plev,       &
+                crm_input, crm_state, &
+                crm_rad_qrad, crm_rad_temperature, &
+                crm_rad_qv, crm_rad_qc, crm_rad_qi, crm_rad_cld, &
+                crm_rad_nc, crm_rad_ni, crm_rad_qs, crm_rad_ns, &
                 crm_ecpp_output, crm_output, crm_clear_rh, &
                 latitude0, longitude0, gcolp, igstep, &
                 use_VT, VT_wn_max, &
@@ -81,14 +81,21 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
     !-----------------------------------------------------------------------------------------------
     ! Interface variable declarations
     !-----------------------------------------------------------------------------------------------
-
-    integer , intent(in   ) :: lchnk                            ! chunk identifier (only for lat/lon and random seed)
     integer , intent(in   ) :: ncrms                            ! Number of "vector" GCM columns to push down into CRM for SIMD vectorization / more threading
     integer , intent(in   ) :: plev                             ! number of levels in parent model
     real(r8), intent(in   ) :: dt_gl                            ! global model's time step
     type(crm_input_type), target,intent(in   ) :: crm_input
     type(crm_state_type), target,intent(inout) :: crm_state
-    type(crm_rad_type),   target,intent(inout) :: crm_rad
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qrad
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_temperature
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qv
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qc
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qi
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_cld
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_nc
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_ni
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qs
+    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_ns
     type(crm_ecpp_output_type)  ,intent(inout) :: crm_ecpp_output
     type(crm_output_type),target,intent(inout) :: crm_output
     real(r8), dimension(ncrms,nzm), intent(  out) :: crm_clear_rh
@@ -159,12 +166,6 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
 
     real(r8), allocatable :: crm_clear_rh_cnt(:,:) ! counter for clear air relative humidity
 
-    real(crm_rknd), pointer :: crm_rad_temperature  (:,:,:,:)
-    real(crm_rknd), pointer :: crm_rad_qv           (:,:,:,:)
-    real(crm_rknd), pointer :: crm_rad_qc           (:,:,:,:)
-    real(crm_rknd), pointer :: crm_rad_qi           (:,:,:,:)
-    real(crm_rknd), pointer :: crm_rad_cld          (:,:,:,:)
-    real(crm_rknd), pointer :: crm_rad_qrad         (:,:,:,:)
     real(crm_rknd), pointer :: crm_state_u_wind     (:,:,:,:)
     real(crm_rknd), pointer :: crm_state_v_wind     (:,:,:,:)
     real(crm_rknd), pointer :: crm_state_w_wind     (:,:,:,:)
@@ -252,13 +253,6 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
 #endif
   if (use_VT) call allocate_VT(ncrms)
 
-  crm_rad_temperature => crm_rad%temperature(1:ncrms,:,:,:)
-  crm_rad_qv          => crm_rad%qv         (1:ncrms,:,:,:)
-  crm_rad_qc          => crm_rad%qc         (1:ncrms,:,:,:)
-  crm_rad_qi          => crm_rad%qi         (1:ncrms,:,:,:)
-  crm_rad_cld         => crm_rad%cld        (1:ncrms,:,:,:)
-  crm_rad_qrad        => crm_rad%qrad       (1:ncrms,:,:,:)
-
   crm_state_u_wind      => crm_state%u_wind     (1:ncrms,:,:,:)
   crm_state_v_wind      => crm_state%v_wind     (1:ncrms,:,:,:)
   crm_state_w_wind      => crm_state%w_wind     (1:ncrms,:,:,:)
@@ -283,10 +277,10 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
   crm_rad_qi  = 0.
   crm_rad_cld = 0.
 #ifdef m2005
-  crm_rad%nc = 0.0
-  crm_rad%ni = 0.0
-  crm_rad%qs = 0.0
-  crm_rad%ns = 0.0
+  crm_rad_nc = 0.0
+  crm_rad_ni = 0.0
+  crm_rad_qs = 0.0
+  crm_rad_ns = 0.0
 #endif /* m2005 */
   do icrm = 1 , ncrms
     bflx(icrm) = crm_input%bflxls(icrm)
@@ -981,13 +975,13 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
             endif
 #ifdef m2005
             !$acc atomic update
-            crm_rad%nc         (icrm,i_rad,j_rad,k) = crm_rad%nc         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,incl)
+            crm_rad_nc         (icrm,i_rad,j_rad,k) = crm_rad_nc         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,incl)
             !$acc atomic update
-            crm_rad%ni         (icrm,i_rad,j_rad,k) = crm_rad%ni         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,inci)
+            crm_rad_ni         (icrm,i_rad,j_rad,k) = crm_rad_ni         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,inci)
             !$acc atomic update
-            crm_rad%qs         (icrm,i_rad,j_rad,k) = crm_rad%qs         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,iqs )
+            crm_rad_qs         (icrm,i_rad,j_rad,k) = crm_rad_qs         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,iqs )
             !$acc atomic update
-            crm_rad%ns         (icrm,i_rad,j_rad,k) = crm_rad%ns         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,ins )
+            crm_rad_ns         (icrm,i_rad,j_rad,k) = crm_rad_ns         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,ins )
 #endif
           enddo
         enddo
@@ -1076,10 +1070,10 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
           crm_rad_qi         (icrm,i,j,k) = crm_rad_qi         (icrm,i,j,k) * tmp1
           crm_rad_cld        (icrm,i,j,k) = crm_rad_cld        (icrm,i,j,k) * tmp1
 #ifdef m2005
-          crm_rad%nc         (icrm,i,j,k) = crm_rad%nc         (icrm,i,j,k) * tmp1
-          crm_rad%ni         (icrm,i,j,k) = crm_rad%ni         (icrm,i,j,k) * tmp1
-          crm_rad%qs         (icrm,i,j,k) = crm_rad%qs         (icrm,i,j,k) * tmp1
-          crm_rad%ns         (icrm,i,j,k) = crm_rad%ns         (icrm,i,j,k) * tmp1
+          crm_rad_nc         (icrm,i,j,k) = crm_rad_nc         (icrm,i,j,k) * tmp1
+          crm_rad_ni         (icrm,i,j,k) = crm_rad_ni         (icrm,i,j,k) * tmp1
+          crm_rad_qs         (icrm,i,j,k) = crm_rad_qs         (icrm,i,j,k) * tmp1
+          crm_rad_ns         (icrm,i,j,k) = crm_rad_ns         (icrm,i,j,k) * tmp1
 #endif /* m2005 */
         enddo
       enddo

--- a/components/eam/src/physics/crm/sam/crm_module.F90
+++ b/components/eam/src/physics/crm/sam/crm_module.F90
@@ -40,10 +40,7 @@ module crm_module
 contains
 
 subroutine crm( ncrms, dt_gl, plev,       &
-                crm_input, crm_state, &
-                crm_rad_qrad, crm_rad_temperature, &
-                crm_rad_qv, crm_rad_qc, crm_rad_qi, crm_rad_cld, &
-                crm_rad_nc, crm_rad_ni, crm_rad_qs, crm_rad_ns, &
+                crm_input, crm_state, crm_rad, &
                 crm_ecpp_output, crm_output, crm_clear_rh, &
                 latitude0, longitude0, gcolp, igstep, &
                 use_VT, VT_wn_max, &
@@ -86,16 +83,7 @@ subroutine crm( ncrms, dt_gl, plev,       &
     real(r8), intent(in   ) :: dt_gl                            ! global model's time step
     type(crm_input_type), target,intent(in   ) :: crm_input
     type(crm_state_type), target,intent(inout) :: crm_state
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qrad
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_temperature
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qv
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qc
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qi
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_cld
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_nc
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_ni
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qs
-    real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_ns
+    type(crm_rad_type),   target,intent(inout) :: crm_rad
     type(crm_ecpp_output_type)  ,intent(inout) :: crm_ecpp_output
     type(crm_output_type),target,intent(inout) :: crm_output
     real(r8), dimension(ncrms,nzm), intent(  out) :: crm_clear_rh
@@ -165,6 +153,17 @@ subroutine crm( ncrms, dt_gl, plev,       &
     real(r8), allocatable :: mdi_crm(:,:)     ! mass flux down at the interface
 
     real(r8), allocatable :: crm_clear_rh_cnt(:,:) ! counter for clear air relative humidity
+
+    real(crm_rknd), pointer :: crm_rad_temperature  (:,:,:,:)
+    real(crm_rknd), pointer :: crm_rad_qv           (:,:,:,:)
+    real(crm_rknd), pointer :: crm_rad_qc           (:,:,:,:)
+    real(crm_rknd), pointer :: crm_rad_qi           (:,:,:,:)
+    real(crm_rknd), pointer :: crm_rad_cld          (:,:,:,:)
+    real(crm_rknd), pointer :: crm_rad_qrad         (:,:,:,:)
+    real(crm_rknd), pointer :: crm_rad_nc           (:,:,:,:)
+    real(crm_rknd), pointer :: crm_rad_ni           (:,:,:,:)
+    real(crm_rknd), pointer :: crm_rad_qs           (:,:,:,:)
+    real(crm_rknd), pointer :: crm_rad_ns           (:,:,:,:)
 
     real(crm_rknd), pointer :: crm_state_u_wind     (:,:,:,:)
     real(crm_rknd), pointer :: crm_state_v_wind     (:,:,:,:)
@@ -252,6 +251,19 @@ subroutine crm( ncrms, dt_gl, plev,       &
   call allocate_scalar_momentum(ncrms)
 #endif
   if (use_VT) call allocate_VT(ncrms)
+
+  crm_rad_temperature => crm_rad%temperature(1:ncrms,:,:,:)
+  crm_rad_qv          => crm_rad%qv         (1:ncrms,:,:,:)
+  crm_rad_qc          => crm_rad%qc         (1:ncrms,:,:,:)
+  crm_rad_qi          => crm_rad%qi         (1:ncrms,:,:,:)
+  crm_rad_cld         => crm_rad%cld        (1:ncrms,:,:,:)
+  crm_rad_qrad        => crm_rad%qrad       (1:ncrms,:,:,:)
+#ifdef m2005
+  crm_rad_nc => crm_rad%nc(1:ncrms,:,:,:)
+  crm_rad_ni => crm_rad%ni(1:ncrms,:,:,:)
+  crm_rad_qs => crm_rad%qs(1:ncrms,:,:,:)
+  crm_rad_ns => crm_rad%ns(1:ncrms,:,:,:)
+#endif /* m2005 */
 
   crm_state_u_wind      => crm_state%u_wind     (1:ncrms,:,:,:)
   crm_state_v_wind      => crm_state%v_wind     (1:ncrms,:,:,:)

--- a/components/eam/src/physics/crm/samomp/crm_module.F90
+++ b/components/eam/src/physics/crm/samomp/crm_module.F90
@@ -1,4 +1,6 @@
-
+!---------------------------------------------------------------------------------------------------
+! MMF main driver (original version by Marat Khairoutdinov)
+!---------------------------------------------------------------------------------------------------
 module crm_module
   use perf_mod
   use task_init_mod, only: task_init
@@ -24,7 +26,7 @@ module crm_module
   use damping_mod
   use ice_fall_mod
   use coriolis_mod
-
+  use setparm_mod,            only: setparm
   use crm_state_module,       only: crm_state_type
   use crm_rad_module,         only: crm_rad_type
   use crm_input_module,       only: crm_input_type
@@ -33,16 +35,14 @@ module crm_module
 #ifdef ECPP  
   use module_ecpp_crm_driver, only: ecpp_crm_stat, ecpp_crm_init, ecpp_crm_cleanup
 #endif
-!---------------------------------------------------------------
-!  Super-parameterization's main driver
-!  Marat Khairoutdinov, 2001-2009
-!---------------------------------------------------------------
-use setparm_mod, only : setparm
 
 contains
 
-subroutine crm(lchnk, ncrms, dt_gl, plev,       &
-                crm_input, crm_state, crm_rad,  &
+subroutine crm( ncrms, dt_gl, plev,       &
+                crm_input, crm_state,  &
+                crm_rad_qrad, crm_rad_temperature, &
+                crm_rad_qv, crm_rad_qc, crm_rad_qi, crm_rad_cld, &
+                crm_rad_nc, crm_rad_ni, crm_rad_qs, crm_rad_ns, &
                 crm_ecpp_output, crm_output, crm_clear_rh, &
                 latitude0, longitude0, gcolp, igstep, &
                 use_VT, VT_wn_max, &
@@ -79,14 +79,21 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
   !-----------------------------------------------------------------------------------------------
   ! Interface variable declarations
   !-----------------------------------------------------------------------------------------------
-
-  integer , intent(in   ) :: lchnk                            ! chunk identifier (only for lat/lon and random seed)
   integer , intent(in   ) :: ncrms                            ! Number of "vector" GCM columns to push down into CRM for SIMD vectorization / more threading
   integer , intent(in   ) :: plev                             ! number of levels in parent model
   real(r8), intent(in   ) :: dt_gl                            ! global model's time step
   type(crm_input_type), target,intent(in   ) :: crm_input
   type(crm_state_type), target,intent(inout) :: crm_state
-  type(crm_rad_type),   target,intent(inout) :: crm_rad
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qrad
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_temperature
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qv
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qc
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qi
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_cld
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_nc
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_ni
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qs
+  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_ns
   type(crm_ecpp_output_type), intent(inout) :: crm_ecpp_output
   type(crm_output_type), target, intent(inout) :: crm_output
   real(r8), dimension(ncrms,nzm), intent(  out) :: crm_clear_rh
@@ -309,12 +316,6 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
   real(crm_rknd), pointer :: crm_output_crm_snw(:,:,:)
 #endif
 
-  real(crm_rknd), pointer :: crm_rad_temperature  (:,:,:,:)
-  real(crm_rknd), pointer :: crm_rad_qv           (:,:,:,:)
-  real(crm_rknd), pointer :: crm_rad_qc           (:,:,:,:)
-  real(crm_rknd), pointer :: crm_rad_qi           (:,:,:,:)
-  real(crm_rknd), pointer :: crm_rad_cld          (:,:,:,:)
-  real(crm_rknd), pointer :: crm_rad_qrad         (:,:,:,:)
   real(crm_rknd), pointer :: crm_state_u_wind     (:,:,:,:)
   real(crm_rknd), pointer :: crm_state_v_wind     (:,:,:,:)
   real(crm_rknd), pointer :: crm_state_w_wind     (:,:,:,:)
@@ -369,10 +370,10 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
   crm_rad_qi  = 0.
   crm_rad_cld = 0.
 #ifdef m2005
-  crm_rad%nc = 0.0
-  crm_rad%ni = 0.0
-  crm_rad%qs = 0.0
-  crm_rad%ns = 0.0
+  crm_rad_nc = 0.0
+  crm_rad_ni = 0.0
+  crm_rad_qs = 0.0
+  crm_rad_ns = 0.0
 #endif /* m2005 */
   do icrm = 1 , ncrms
     bflx(icrm) = crm_input_bflxls(icrm)
@@ -1085,13 +1086,13 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
             endif
 #ifdef m2005
             !$omp atomic update
-            crm_rad%nc         (icrm,i_rad,j_rad,k) = crm_rad%nc         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,incl)
+            crm_rad_nc         (icrm,i_rad,j_rad,k) = crm_rad_nc         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,incl)
             !$omp atomic update
-            crm_rad%ni         (icrm,i_rad,j_rad,k) = crm_rad%ni         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,inci)
+            crm_rad_ni         (icrm,i_rad,j_rad,k) = crm_rad_ni         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,inci)
             !$omp atomic update
-            crm_rad%qs         (icrm,i_rad,j_rad,k) = crm_rad%qs         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,iqs )
+            crm_rad_qs         (icrm,i_rad,j_rad,k) = crm_rad_qs         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,iqs )
             !$omp atomic update
-            crm_rad%ns         (icrm,i_rad,j_rad,k) = crm_rad%ns         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,ins )
+            crm_rad_ns         (icrm,i_rad,j_rad,k) = crm_rad_ns         (icrm,i_rad,j_rad,k) + micro_field(icrm,i,j,k,ins )
 #endif
           enddo
         enddo
@@ -1180,10 +1181,10 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
           crm_rad_qi         (icrm,i,j,k) = crm_rad_qi         (icrm,i,j,k) * tmp1
           crm_rad_cld        (icrm,i,j,k) = crm_rad_cld        (icrm,i,j,k) * tmp1
 #ifdef m2005
-          crm_rad%nc         (icrm,i,j,k) = crm_rad%nc         (icrm,i,j,k) * tmp1
-          crm_rad%ni         (icrm,i,j,k) = crm_rad%ni         (icrm,i,j,k) * tmp1
-          crm_rad%qs         (icrm,i,j,k) = crm_rad%qs         (icrm,i,j,k) * tmp1
-          crm_rad%ns         (icrm,i,j,k) = crm_rad%ns         (icrm,i,j,k) * tmp1
+          crm_rad_nc         (icrm,i,j,k) = crm_rad_nc         (icrm,i,j,k) * tmp1
+          crm_rad_ni         (icrm,i,j,k) = crm_rad_ni         (icrm,i,j,k) * tmp1
+          crm_rad_qs         (icrm,i,j,k) = crm_rad_qs         (icrm,i,j,k) * tmp1
+          crm_rad_ns         (icrm,i,j,k) = crm_rad_ns         (icrm,i,j,k) * tmp1
 #endif /* m2005 */
         enddo
       enddo
@@ -1960,13 +1961,6 @@ subroutine crm(lchnk, ncrms, dt_gl, plev,       &
     crm_output_crm_snw   => crm_output%crm_snw(:,:,:)
 #endif
     crm_output_subcycle_factor => crm_output%subcycle_factor(:)
-
-    crm_rad_temperature => crm_rad%temperature(1:ncrms,:,:,:)
-    crm_rad_qv          => crm_rad%qv         (1:ncrms,:,:,:)
-    crm_rad_qc          => crm_rad%qc         (1:ncrms,:,:,:)
-    crm_rad_qi          => crm_rad%qi         (1:ncrms,:,:,:)
-    crm_rad_cld         => crm_rad%cld        (1:ncrms,:,:,:)
-    crm_rad_qrad        => crm_rad%qrad       (1:ncrms,:,:,:)
 
     crm_state_u_wind      => crm_state%u_wind     (1:ncrms,:,:,:)
     crm_state_v_wind      => crm_state%v_wind     (1:ncrms,:,:,:)

--- a/components/eam/src/physics/crm/samomp/crm_module.F90
+++ b/components/eam/src/physics/crm/samomp/crm_module.F90
@@ -39,10 +39,7 @@ module crm_module
 contains
 
 subroutine crm( ncrms, dt_gl, plev,       &
-                crm_input, crm_state,  &
-                crm_rad_qrad, crm_rad_temperature, &
-                crm_rad_qv, crm_rad_qc, crm_rad_qi, crm_rad_cld, &
-                crm_rad_nc, crm_rad_ni, crm_rad_qs, crm_rad_ns, &
+                crm_input, crm_state, crm_rad, &
                 crm_ecpp_output, crm_output, crm_clear_rh, &
                 latitude0, longitude0, gcolp, igstep, &
                 use_VT, VT_wn_max, &
@@ -84,16 +81,7 @@ subroutine crm( ncrms, dt_gl, plev,       &
   real(r8), intent(in   ) :: dt_gl                            ! global model's time step
   type(crm_input_type), target,intent(in   ) :: crm_input
   type(crm_state_type), target,intent(inout) :: crm_state
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qrad
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_temperature
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qv
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qc
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qi
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_cld
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_nc
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_ni
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_qs
-  real(crm_rknd), dimension(ncrms,crm_nx_rad,crm_ny_rad,crm_nz), intent(inout) :: crm_rad_ns
+  type(crm_rad_type),   target,intent(inout) :: crm_rad
   type(crm_ecpp_output_type), intent(inout) :: crm_ecpp_output
   type(crm_output_type), target, intent(inout) :: crm_output
   real(r8), dimension(ncrms,nzm), intent(  out) :: crm_clear_rh
@@ -315,6 +303,17 @@ subroutine crm( ncrms, dt_gl, plev,       &
   real(crm_rknd), pointer :: crm_output_crm_pcp(:,:,:)
   real(crm_rknd), pointer :: crm_output_crm_snw(:,:,:)
 #endif
+
+  real(crm_rknd), pointer :: crm_rad_temperature  (:,:,:,:)
+  real(crm_rknd), pointer :: crm_rad_qv           (:,:,:,:)
+  real(crm_rknd), pointer :: crm_rad_qc           (:,:,:,:)
+  real(crm_rknd), pointer :: crm_rad_qi           (:,:,:,:)
+  real(crm_rknd), pointer :: crm_rad_cld          (:,:,:,:)
+  real(crm_rknd), pointer :: crm_rad_qrad         (:,:,:,:)
+  real(crm_rknd), pointer :: crm_rad_nc           (:,:,:,:)
+  real(crm_rknd), pointer :: crm_rad_ni           (:,:,:,:)
+  real(crm_rknd), pointer :: crm_rad_qs           (:,:,:,:)
+  real(crm_rknd), pointer :: crm_rad_ns           (:,:,:,:)
 
   real(crm_rknd), pointer :: crm_state_u_wind     (:,:,:,:)
   real(crm_rknd), pointer :: crm_state_v_wind     (:,:,:,:)
@@ -1961,6 +1960,20 @@ subroutine crm( ncrms, dt_gl, plev,       &
     crm_output_crm_snw   => crm_output%crm_snw(:,:,:)
 #endif
     crm_output_subcycle_factor => crm_output%subcycle_factor(:)
+
+    crm_rad_temperature => crm_rad%temperature(1:ncrms,:,:,:)
+    crm_rad_qv          => crm_rad%qv         (1:ncrms,:,:,:)
+    crm_rad_qc          => crm_rad%qc         (1:ncrms,:,:,:)
+    crm_rad_qi          => crm_rad%qi         (1:ncrms,:,:,:)
+    crm_rad_cld         => crm_rad%cld        (1:ncrms,:,:,:)
+    crm_rad_qrad        => crm_rad%qrad       (1:ncrms,:,:,:)
+
+#ifdef m2005
+    crm_rad_nc => crm_rad%nc(1:ncrms,:,:,:)
+    crm_rad_ni => crm_rad%ni(1:ncrms,:,:,:)
+    crm_rad_qs => crm_rad%qs(1:ncrms,:,:,:)
+    crm_rad_ns => crm_rad%ns(1:ncrms,:,:,:)
+#endif /* m2005 */
 
     crm_state_u_wind      => crm_state%u_wind     (1:ncrms,:,:,:)
     crm_state_v_wind      => crm_state%v_wind     (1:ncrms,:,:,:)


### PR DESCRIPTION
This refactors the way the CRM is called so that all CRM instances in a single task can be run at once on the GPU, rather than all CRMs in a given "chunk". On properly configured GPU cases the speedup from this change is significant, and there is no notable change to CPU configurations tested on Summit and Cori-KNL. The changes required to push the chunk loop down are quite substantial, but there were additional complications from the crm_history() subroutine and the crm_rad and  crm_ecpp_output data structures that required more extensive changes. A new "ncrms" variable is defined in crm_physics to define the dimension of variables that hold all CRMs in a task (i.e. combined across all chunks in a task).

Note about testing - the changes are non-BFB for MMF tests only because the grouping of CRM columns has changed, which changes the the time step and sedimentation subcycling. Otherwise the changes are BFB, which can be demonstrated using the mmf_fixed_subcycle test mod. 

[BFB] - except for MMF tests without mmf_fixed_subcycle test mod