### PR TITLE
Fix MMF AQP/RCE compsets

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2-MMF-1mom.xml
+++ b/components/eam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2-MMF-1mom.xml
@@ -19,7 +19,6 @@
 <convproc_do_gas>.false.</convproc_do_gas>
 <convproc_method_activate>2</convproc_method_activate>
 <demott_ice_nuc>.true.</demott_ice_nuc>
-<liqcf_fix>.false.</liqcf_fix>
 <regen_fix>.true.</regen_fix>
 <resus_fix>.true.</resus_fix>
 <mam_amicphys_optaa>1</mam_amicphys_optaa>

--- a/components/eam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2-MMF-2mom.xml
+++ b/components/eam/bld/namelist_files/use_cases/2000_cam5_av1c-04p2-MMF-2mom.xml
@@ -19,7 +19,6 @@
 <convproc_do_gas>.false.</convproc_do_gas>
 <convproc_method_activate>2</convproc_method_activate>
 <demott_ice_nuc>.true.</demott_ice_nuc>
-<liqcf_fix>.false.</liqcf_fix>
 <regen_fix>.true.</regen_fix>
 <resus_fix>.true.</resus_fix>
 <mam_amicphys_optaa>1</mam_amicphys_optaa>

--- a/components/eam/bld/namelist_files/use_cases/aquaplanet_MMF-1mom.xml
+++ b/components/eam/bld/namelist_files/use_cases/aquaplanet_MMF-1mom.xml
@@ -57,7 +57,6 @@
 <convproc_do_gas>.false.</convproc_do_gas>
 <convproc_method_activate>2</convproc_method_activate>
 <demott_ice_nuc>.true.</demott_ice_nuc>
-<liqcf_fix>.false.</liqcf_fix>
 <regen_fix>.true.</regen_fix>
 <resus_fix>.true.</resus_fix>
 <mam_amicphys_optaa>1</mam_amicphys_optaa>

--- a/components/eam/bld/namelist_files/use_cases/scam_arm97_MMF-1mom.xml
+++ b/components/eam/bld/namelist_files/use_cases/scam_arm97_MMF-1mom.xml
@@ -41,9 +41,6 @@
 <f11vmr>676.0526e-12</f11vmr>
 <f12vmr>537.05e-12</f12vmr> -->
 
-<!-- For Polar mods -->
-<liqcf_fix>.false.</liqcf_fix>
-
 <!-- For comprehensive history -->
 <history_aerosol>.true.</history_aerosol>
 <history_aero_optics>.true.</history_aero_optics>

--- a/components/eam/bld/namelist_files/use_cases/scam_rico_MMF-1mom.xml
+++ b/components/eam/bld/namelist_files/use_cases/scam_rico_MMF-1mom.xml
@@ -35,15 +35,12 @@
 <aerodep_flx_file>mam4_0.9x1.2_L72_2000clim_c170323.nc</aerodep_flx_file>
 <aerodep_flx_cycle_yr>1</aerodep_flx_cycle_yr>
 
-<!-- 2000 GHG values from AR5 (from ghg_hist_1765-2012_c130501.nc) 
+<!-- 2000 GHG values from AR5 (from ghg_hist_1765-2012_c130501.nc) -->
 <!-- <co2vmr>368.865e-6</co2vmr> Set by CCSM_CO2_PPMV in config_compset.xml -->
 <ch4vmr>1751.022e-9</ch4vmr>
 <n2ovmr>315.85e-9</n2ovmr>
 <f11vmr>676.0526e-12</f11vmr>
 <f12vmr>537.05e-12</f12vmr> -->
-
-<!-- For Polar mods -->
-<liqcf_fix>.false.</liqcf_fix>
 
 <!-- For comprehensive history -->
 <history_aerosol>.true.</history_aerosol>

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -67,9 +67,9 @@
       <value compset="_EAM%MMF2"              >-chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero </value>
       <value compset="_EAM%MMF2-ECPP"         >-use_ECPP </value>
       <value compset="_EAM%MMF[12XO]"         >-crm_nx 64 -crm_nx_rad 16 -crm_ny 1 -crm_ny_rad 1 </value>
-      <value compset="_EAM%MMF*-AQUA"         >-aquaplanet </value>
-      <value compset="_EAM%MMF*-RCE"          >-aquaplanet -rce </value>
-      <value compset="_EAM%MMF[12XO]*-SCM"    >-scam </value>
+      <value compset="_EAM%MMF.*-AQUA"        >-aquaplanet </value>
+      <value compset="_EAM%MMF.*-RCE"         >-aquaplanet -rce </value>
+      <value compset="_EAM%MMF.*-SCM"         >-scam </value>
 
       <!--  -->
       <value compset="GEOS_EAM"       >-offline_dyn</value>
@@ -152,10 +152,10 @@
       <!-- MMF / Super-Parameterization -->
       <value compset="2000(?:SOI)?_EAM%MMF[1XO]">2000_cam5_av1c-04p2-MMF-1mom</value>
       <value compset="2000(?:SOI)?_EAM%MMF2"    >2000_cam5_av1c-04p2-MMF-2mom</value>
-      <value compset="_EAM%MMF*-RCE"    >RCEMIP_EAMv1</value>
-      <value compset="_EAM%MMF*-AQUA"   >aquaplanet_MMF-1mom</value>
-      <value compset="AR97_EAM%MMF[1XO]*-SCM"   >scam_arm97_MMF-1mom</value>
-      <value compset="RICO_EAM%MMF[1XO]*-SCM"   >scam_rico_MMF-1mom</value>
+      <value compset="_EAM%MMF.*-RCE"    >RCEMIP_EAMv1</value>
+      <value compset="_EAM%MMF.*-AQUA"   >aquaplanet_MMF-1mom</value>
+      <value compset="AR97_EAM%MMF.*-SCM"   >scam_arm97_MMF-1mom</value>
+      <value compset="RICO_EAM%MMF.*-SCM"   >scam_rico_MMF-1mom</value>
     </values>
 
     <group>run_component_cam</group>
@@ -245,8 +245,8 @@
     <value compset="DOCN%AQP">$SRCROOT/components/eam/cime_config/usermods_dirs/aquap</value>
     <value compset="DOCN%SOMAQP">$SRCROOT/components/eam/cime_config/usermods_dirs/aquap</value>
     <value compset="EAM%RCE">$SRCROOT/components/eam/cime_config/usermods_dirs/rcemip</value>
-    <value compset="EAM%MMF*-RCE">$SRCROOT/components/eam/cime_config/usermods_dirs/rcemip</value>
-    <value compset="EAM%MMF[12OX]*-SCM">$SRCROOT/components/eam/cime_config/usermods_dirs/scm</value>
+    <value compset="EAM%MMF.*-RCE">$SRCROOT/components/eam/cime_config/usermods_dirs/rcemip</value>
+    <value compset="EAM%MMF.*-SCM">$SRCROOT/components/eam/cime_config/usermods_dirs/scm</value>
     <value compset="EAM%SCAM">$SRCROOT/components/eam/cime_config/usermods_dirs/scm</value>
     </values>
     <group>run_component_cam</group>

--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -313,7 +313,7 @@
       <values>
 	<value  compset="GEOS_">GREGORIAN</value>
 	<value  compset="EAM%SCAM">GREGORIAN</value>
-	<value  compset="EAM%MMF[12OX]*-SCM">GREGORIAN</value>
+	<value  compset="EAM%MMF.*-SCM">GREGORIAN</value>
       </values>
     </entry>
 
@@ -356,7 +356,7 @@
 
     <entry id="PTS_MODE">
       <values>
-        <value compset="EAM%MMF[12XO]*-SCM">TRUE</value>
+        <value compset="EAM%MMF.*-SCM">TRUE</value>
       </values>
     </entry>
     


### PR DESCRIPTION
This fixes the wildcards used to specify compset options for certain MMF compsets. There are also some additional changes to the MMF physpkg.F90 initialization code to avoid using the microp_aero module. This ensures MMF cases will avoid an error that gets throw if liqcf_fix=true. The microp_aero code and the liqcf_fix option are irrelevant for all MMF configurations. 

fixes issue #4474 

[BFB] except for MMF AQP and RCE compsets