### PR TITLE
Fixes xactive lnd dry deposition simulation

### DIFF
--- a/components/elm/src/biogeochem/DryDepVelocity.F90
+++ b/components/elm/src/biogeochem/DryDepVelocity.F90
@@ -49,11 +49,11 @@ Module DryDepVelocity
   use abortutils           , only : endrun
   use clm_time_manager     , only : get_nstep, get_curr_date, get_curr_time
   use spmdMod              , only : masterproc
-  use seq_drydep_mod_elm       , only : n_drydep, drydep_list
-  use seq_drydep_mod_elm       , only : drydep_method, DD_XLND
-  use seq_drydep_mod_elm       , only : index_o3=>o3_ndx, index_o3a=>o3a_ndx, index_so2=>so2_ndx, index_h2=>h2_ndx
-  use seq_drydep_mod_elm       , only : index_co=>co_ndx, index_ch4=>ch4_ndx, index_pan=>pan_ndx
-  use seq_drydep_mod_elm       , only : index_xpan=>xpan_ndx
+  use seq_drydep_mod       , only : n_drydep, drydep_list
+  use seq_drydep_mod       , only : drydep_method, DD_XLND
+  use seq_drydep_mod       , only : index_o3=>o3_ndx, index_o3a=>o3a_ndx, index_so2=>so2_ndx, index_h2=>h2_ndx
+  use seq_drydep_mod       , only : index_co=>co_ndx, index_ch4=>ch4_ndx, index_pan=>pan_ndx
+  use seq_drydep_mod       , only : index_xpan=>xpan_ndx
   use decompMod            , only : bounds_type
   use elm_varcon           , only : namep
   use atm2lndType          , only : atm2lnd_type
@@ -102,7 +102,7 @@ CONTAINS
     !
     ! !USES:
       use shr_infnan_mod , only : nan => shr_infnan_nan, assignment(=)
-    use seq_drydep_mod_elm , only : n_drydep, drydep_method, DD_XLND
+    use seq_drydep_mod , only : n_drydep, drydep_method, DD_XLND
     use elm_varcon , only : spval
     !
     ! !ARGUMENTS:
@@ -133,8 +133,8 @@ CONTAINS
     ! !USES:
       !$acc routine seq
     use shr_const_mod  , only : tmelt => shr_const_tkfrz
-    use seq_drydep_mod_elm , only : seq_drydep_setHCoeff, mapping, drat, foxd
-    use seq_drydep_mod_elm , only : rcls, h2_a, h2_b, h2_c, ri, rac, rclo, rlu, rgss, rgso
+    use seq_drydep_mod , only : seq_drydep_setHCoeff, mapping, drat, foxd
+    use seq_drydep_mod , only : rcls, h2_a, h2_b, h2_c, ri, rac, rclo, rlu, rgss, rgso
     use landunit_varcon, only : istsoil, istice, istice_mec, istdlak, istwet
     use elm_varctl     , only : iulog
     use pftvarcon      , only : noveg, ndllf_evr_tmp_tree, ndllf_evr_brl_tree

--- a/components/elm/src/main/lnd2atmMod.F90
+++ b/components/elm/src/main/lnd2atmMod.F90
@@ -13,7 +13,7 @@ module lnd2atmMod
   use elm_varcon           , only : rair, grav, cpair, hfus, tfrz, spval
   use elm_varctl           , only : iulog, use_c13, use_cn, use_lch4, use_voc, use_fates
   use tracer_varcon        , only : is_active_betr_bgc
-  use seq_drydep_mod_elm   , only : n_drydep, drydep_method, DD_XLND
+  use seq_drydep_mod   , only : n_drydep, drydep_method, DD_XLND
   use decompMod            , only : bounds_type
   use subgridAveMod        , only : p2g, c2g
   use lnd2atmType          , only : lnd2atm_type


### PR DESCRIPTION
This fix applies to all the atmosphere NGD runs with chemistry and the BGC tests coupling with chemistry.

Fixes #4470 

[non-BFB] for the simulations with the 'xactive_lnd' dry deposition method.
