### PR TITLE
Change bubble test init in standalone homme

### DIFF
--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -269,9 +269,10 @@ module control_mod
   real (kind=real_kind), public :: bubble_xyradius = 2000.0!bubble radius along x or y axis
   real (kind=real_kind), public :: bubble_zradius = 1500.0 !bubble radius along z axis
   logical,               public :: bubble_cosine  = .TRUE. !bubble uniform or cosine
-  logical,               public :: bubble_moist  = .FALSE. ! 
-  real (kind=real_kind), public :: bubble_moist_dq = 0.0   !bubble dQ parameter
-  integer,               public :: bubble_prec_type = 0    !0 kessler, 1 rj
+  logical,               public :: bubble_moist  = .FALSE.    ! 
+  real (kind=real_kind), public :: bubble_moist_drh = 0.0     !bubble dRH parameter
+  real (kind=real_kind), public :: bubble_rh_background = 0.0 !bubble RH parameter
+  integer,               public :: bubble_prec_type = 0       !0 kessler, 1 rj
   logical,               protected :: case_planar_bubble = .FALSE.
 
   public :: set_planar_defaults

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -118,7 +118,8 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     bubble_zradius, &
     bubble_cosine, &
     bubble_moist, &
-    bubble_moist_dq, &
+    bubble_moist_drh, &
+    bubble_rh_background, &
     bubble_prec_type, &
     case_planar_bubble
 #endif
@@ -352,7 +353,8 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       bubble_zradius, &
       bubble_cosine, &
       bubble_moist, &
-      bubble_moist_dq, &
+      bubble_moist_drh, &
+      bubble_rh_background, &
       bubble_prec_type
     namelist /vert_nl/        &
       vform,              &
@@ -835,7 +837,8 @@ endif
     call MPI_bcast(bubble_zradius ,1,MPIreal_t   ,par%root,par%comm,ierr)
     call MPI_bcast(bubble_cosine ,1,MPIlogical_t,par%root,par%comm,ierr)
     call MPI_bcast(bubble_moist ,1,MPIlogical_t,par%root,par%comm,ierr)
-    call MPI_bcast(bubble_moist_dq ,1,MPIreal_t,par%root,par%comm,ierr)
+    call MPI_bcast(bubble_moist_drh ,1,MPIreal_t,par%root,par%comm,ierr)
+    call MPI_bcast(bubble_rh_background ,1,MPIreal_t,par%root,par%comm,ierr)
     call MPI_bcast(bubble_prec_type, 1, MPIinteger_t, par%root,par%comm,ierr)
 
     call MPI_bcast(case_planar_bubble,1,MPIlogical_t,par%root,par%comm,ierr)

--- a/components/homme/src/test_src/dry_planar.F90
+++ b/components/homme/src/test_src/dry_planar.F90
@@ -352,7 +352,6 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
                    (y-bubble_xycenter) * (y-bubble_xycenter) / bubble_xyradius / bubble_xyradius )
         endif
       
-        rh = 0.75
         if ( rr < 1.0 ) then
           if (bubble_cosine) then
             offset = cos(rr*dd_pi / 2.0 )

--- a/components/homme/src/test_src/dry_planar.F90
+++ b/components/homme/src/test_src/dry_planar.F90
@@ -26,8 +26,12 @@ module dry_planar_tests
                                 p0	= 100000.d0, &! reference pressure (Pa)
                                 kappa   = Rd/cp
 
+!consts for kessler-defined qsat
   real(rl), parameter :: bubble_const1=3.8, bubble_const2=17.27, bubble_const3=273.0, bubble_const4=36.0
-
+!consts for RJ-defined qsat
+  real(rl), parameter :: bubble_t0_const=273.16, bubble_epsilo=Rgas/Rwater_vapor, bubble_e0=610.78
+!this one is used in dcmip as 2.5e6 instead of the one in cam, 2.501e6
+  real(rl), parameter :: bubble_latvap=2.5e6
 
   real(rl):: zi(nlevp), zm(nlev)                                          ! z coordinates
   real(rl):: ddn_hyai(nlevp), ddn_hybi(nlevp)                             ! vertical derivativess of hybrid coefficients
@@ -209,7 +213,8 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
   real(rl):: zero_mid_init(np,np,nlev),zero_int_init(np,np,nlevp), &
              dp_init(np,np,nlev),ps_init(np,np), &
              phis_init(np,np,nlevp),t_init(np,np,nlev),p_init(np,np,nlev), &
-             zi_init(np,np,nlevp), zm_init(np,np,nlev)
+             zi_init(np,np,nlevp), zm_init(np,np,nlev), &
+             rh
              
   if (qsize < 3 .and. bubble_moist) then
     call abortmp('planar moist bubble requires at least 3 tracers')
@@ -228,7 +233,7 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
      print *, 'bubble_zradius', bubble_zradius
      print *, 'bubble_cosine', bubble_cosine
      print *, 'bubble_moist', bubble_moist
-     print *, 'bubble_moist_dq', bubble_moist_dq
+     print *, 'bubble_moist_dq (RH param)', bubble_moist_dq
      print *, 'bubble_prec_type (0 is Kessler (default), 1 is RJ)', bubble_prec_type
   endif
 
@@ -287,9 +292,24 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
   !for the background state
   if (bubble_moist) then
     !build specific humidity at saturation qs as in dcmip2016-kessler
+
+    if(bubble_prec_type == 0) then
+    !kessler
     do k=1,nlevp
        qi_s(k) = bubble_const1 / pi(k) * exp( bubble_const2 * (Ti(k) - bubble_const3) / ( Ti(k) - bubble_const4 ) )
     enddo
+    elseif(bubble_prec_type == 1) then
+    !RJ physics
+    do k=1,nlevp
+       !dcmip line
+       !qsat = epsilo * e0 / p(k) * exp(-(latvap/rh2o) * ((one/t(k))-(one/T0)))
+       qi_s(k) = bubble_epsilo * bubble_e0 / pi(k) * &
+                 exp(-(bubble_latvap/Rwater_vapor) * ((1.0/Ti(k))-(1.0/bubble_t0_const)))
+    enddo
+    else
+    call abortmp('planar moist bubble bubble_prec_type should be 0 or 1')
+    endif   
+
   else
      qi_s(1:nlevp) = 0.0
   endif
@@ -330,9 +350,10 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
                    (y-bubble_xycenter) * (y-bubble_xycenter) / bubble_xyradius / bubble_xyradius )
         endif
       
-        !set pot. temperature on interfaces
-        if ( rr < 1.0 ) then 
 
+#if 0       
+!old 
+        if ( rr < 1.0 ) then 
           if (bubble_cosine) then
             offset = cos(rr*dd_pi / 2.0 )
             th0(k) = bubble_T0 + bubble_dT * offset
@@ -342,15 +363,33 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
             th0(k) = bubble_T0 + bubble_dT
             qi(k)  = qi_s(k)   + bubble_moist_dq
           endif
-
         else
-
           !set to reference profile
           th0(k) = bubble_T0
           qi(k) = qi_s(k)  
-
         endif
-
+#else
+!new
+        rh = 0.75
+        if ( rr < 1.0 ) then
+          if (bubble_cosine) then
+            offset = cos(rr*dd_pi / 2.0 )
+            th0(k) = bubble_T0 + bubble_dT * offset
+            rh = rh + bubble_moist_dq * offset
+            !rh=1.0
+          else
+            !0/1 nonsmooth function
+            th0(k) = bubble_T0 + bubble_dT
+            rh = rh + bubble_moist_dq
+            !rh=1.0
+          endif
+        else
+          !set to reference profile
+          th0(k) = bubble_T0
+          !rh = ...
+        endif
+        qi(k) = rh * qi_s(k)
+#endif
       enddo ! k loop
 
       !set theta on midlevels and then T from theta, exner
@@ -361,6 +400,9 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
       if (bubble_moist) then
         do k=1,nlev
           elem(ie)%state%Q(i,j,k,1) =   ( qi(k) + qi(k+1) ) / 2.0
+
+!this is not good FOR KESSLER, temp hack          
+!          elem(ie)%state%Q(i,j,k,2) =   ( qi_s(k) + qi_s(k+1) ) / 2.0
         enddo        
       else
         elem(ie)%state%Q(i,j,:,1) =   0.0
@@ -378,7 +420,10 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
   !Q   (np,np,nlev,qsize_d)   
   !Qdp (np,np,nlev,qsize_d,2) 
   if (bubble_moist) then
+
      ii=2
+!!!! not KESSLER!, temp hack          
+!     ii=3
   else 
      ii=1
   endif
@@ -390,7 +435,7 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
      elem(ie)%state%Q(:,:,:,ii:qsize) = 0.0
 
      !sets hydro phi from (perturbed) theta and pressure, checks for hydrostatic balance after that, saves a state
-     !call tests_finalize(elem(ie),hvcoord)
+     call tests_finalize(elem(ie),hvcoord)
   enddo
 
 end subroutine bubble_init

--- a/components/homme/src/test_src/dry_planar.F90
+++ b/components/homme/src/test_src/dry_planar.F90
@@ -331,7 +331,6 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
   enddo; enddo
 
   ! set the rest of conditions for each element
-  rh=bubble_rh_background
   do ie = nets,nete
     do j=1,np; do i=1,np
 
@@ -352,6 +351,7 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
                    (y-bubble_xycenter) * (y-bubble_xycenter) / bubble_xyradius / bubble_xyradius )
         endif
       
+        rh=bubble_rh_background
         if ( rr < 1.0 ) then
           if (bubble_cosine) then
             offset = cos(rr*dd_pi / 2.0 )

--- a/components/homme/src/test_src/dry_planar.F90
+++ b/components/homme/src/test_src/dry_planar.F90
@@ -406,7 +406,7 @@ subroutine bubble_init(elem,hybrid,hvcoord,nets,nete,f)
      elem(ie)%state%Q(:,:,:,ii:qsize) = 0.0
 
      !sets hydro phi from (perturbed) theta and pressure, checks for hydrostatic balance after that, saves a state
-     call tests_finalize(elem(ie),hvcoord)
+     !call tests_finalize(elem(ie),hvcoord)
   enddo
 
 end subroutine bubble_init

--- a/components/homme/test/reg_test/namelists/thetanh-moist-bubble.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-moist-bubble.nl
@@ -55,7 +55,8 @@
   bubble_moist=.true.
   bubble_T0=300.0
   bubble_dT=2.0
-  bubble_moist_dq=0.2
+  bubble_rh_background=0.7
+  bubble_moist_drh=0.2
   bubble_prec_type=0
 /
 &vert_nl


### PR DESCRIPTION
This fixes an oversaturated state in the moist bubble initialization. Also, qsat in initialization now depends on RJ or Kessler physics. 

[nonbfb] for 1 homme test, moist bubble.