### PR TITLE
Update F compsets with mpas-seaice for prescribed ice mode

### DIFF
--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -57,6 +57,11 @@
   </compset>
 
   <compset>
+    <alias>F20TR-MPASSI</alias>
+    <lname>20TR_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>F2010SC5-CMIP6</alias>
     <lname>2010S_EAM%CMIP6_ELM%SPBC_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
@@ -67,13 +72,13 @@
   </compset>
 
   <compset>
-    <alias>FSCM5A97</alias>
-    <lname>AR97_EAM%SCAM_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <alias>F2010-MPASSI</alias>
+    <lname>2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
-    <alias>F2010SC5-CMIP6-MPASSI</alias>
-    <lname>2010S_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <alias>FSCM5A97</alias>
+    <lname>AR97_EAM%SCAM_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>


### PR DESCRIPTION
F20TR-MPASSI is added for 20th century transient AMIP with
prescribed ice mode from mpas-seaice. Existing F2010SC5-CMIP6-MPASSI
is renamed as F2010-MPASSI. Note that F2010SC5-CMIP6-MPASSI
was using use_case file 2010S_cam5_CMIP6.xml, which would override the
final v2 default values for clubb_tk1 and gw_convect_hcf.

[BFB] for existing compsets