### PR TITLE
add ideal age tracer

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -1048,6 +1048,18 @@ add_default($nl, 'config_use_MacroMoleculesTracers_ttd_forcing');
 add_default($nl, 'config_use_MacroMoleculesTracers_surface_value');
 add_default($nl, 'config_use_MacroMoleculesTracers_sea_ice_coupling');
 
+###############################################
+# Namelist group: tracer_forcing_idealAgeTracers #
+###############################################
+
+add_default($nl, 'config_use_idealAgeTracers');
+add_default($nl, 'config_use_idealAgeTracers_surface_bulk_forcing');
+add_default($nl, 'config_use_idealAgeTracers_surface_restoring');
+add_default($nl, 'config_use_idealAgeTracers_interior_restoring');
+add_default($nl, 'config_use_idealAgeTracers_exponential_decay');
+add_default($nl, 'config_use_idealAgeTracers_idealAge_forcing');
+add_default($nl, 'config_use_idealAgeTracers_ttd_forcing');
+
 ##################################
 # Namelist group: AM_globalStats #
 ##################################
@@ -1637,6 +1649,7 @@ my @groups = qw(run_modes
                 tracer_forcing_ecosystracers
                 tracer_forcing_dmstracers
                 tracer_forcing_macromoleculestracers
+                tracer_forcing_idealagetracers
                 am_globalstats
                 am_surfaceareaweightedaverages
                 am_watermasscensus

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -565,6 +565,15 @@
 <config_use_MacroMoleculesTracers_surface_value>.false.</config_use_MacroMoleculesTracers_surface_value>
 <config_use_MacroMoleculesTracers_sea_ice_coupling>.false.</config_use_MacroMoleculesTracers_sea_ice_coupling>
 
+<!-- tracer_forcing_idealAgeTracers -->
+<config_use_idealAgeTracers>.false.</config_use_idealAgeTracers>
+<config_use_idealAgeTracers_surface_bulk_forcing>.false.</config_use_idealAgeTracers_surface_bulk_forcing>
+<config_use_idealAgeTracers_surface_restoring>.false.</config_use_idealAgeTracers_surface_restoring>
+<config_use_idealAgeTracers_interior_restoring>.false.</config_use_idealAgeTracers_interior_restoring>
+<config_use_idealAgeTracers_exponential_decay>.false.</config_use_idealAgeTracers_exponential_decay>
+<config_use_idealAgeTracers_idealAge_forcing>.true.</config_use_idealAgeTracers_idealAge_forcing>
+<config_use_idealAgeTracers_ttd_forcing>.false.</config_use_idealAgeTracers_ttd_forcing>
+
 <!-- AM_globalStats -->
 <config_AM_globalStats_enable>.true.</config_AM_globalStats_enable>
 <config_AM_globalStats_compute_interval>'output_interval'</config_AM_globalStats_compute_interval>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -2700,6 +2700,64 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<!-- tracer_forcing_idealAgeTracers -->
+
+<entry id="config_use_idealAgeTracers" type="logical"
+	category="tracer_forcing_idealAgeTracers" group="tracer_forcing_idealAgeTracers">
+if true, the 'idealAgeTracers' category is enabled for the run
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_idealAgeTracers_surface_bulk_forcing" type="logical"
+	category="tracer_forcing_idealAgeTracers" group="tracer_forcing_idealAgeTracers">
+if true, surface bulk forcing from coupler is added to surfaceTracerFlux in 'idealAgeTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_idealAgeTracers_surface_restoring" type="logical"
+	category="tracer_forcing_idealAgeTracers" group="tracer_forcing_idealAgeTracers">
+if true, surface restoring source is applied to tracers in 'idealAgeTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_idealAgeTracers_interior_restoring" type="logical"
+	category="tracer_forcing_idealAgeTracers" group="tracer_forcing_idealAgeTracers">
+if true, interior restoring source is applied to tracers in 'idealAgeTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_idealAgeTracers_exponential_decay" type="logical"
+	category="tracer_forcing_idealAgeTracers" group="tracer_forcing_idealAgeTracers">
+if true, exponential decay source is applied to tracers in 'idealAgeTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_idealAgeTracers_idealAge_forcing" type="logical"
+	category="tracer_forcing_idealAgeTracers" group="tracer_forcing_idealAgeTracers">
+if true, idealAge forcing source is applied to tracers in 'idealAgeTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_idealAgeTracers_ttd_forcing" type="logical"
+	category="tracer_forcing_idealAgeTracers" group="tracer_forcing_idealAgeTracers">
+if true, transit time distribution forcing source is applied to tracers in 'idealAgeTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- AM_globalStats -->
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -70,6 +70,7 @@ module ocn_forward_mode
    use ocn_tracer_ecosys
    use ocn_tracer_DMS
    use ocn_tracer_MacroMolecules
+   use ocn_tracer_ideal_age
    use ocn_tracer_surface_restoring
    use ocn_gm
 
@@ -438,6 +439,8 @@ module ocn_forward_mode
       call ocn_tracer_DMS_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
       call ocn_tracer_MacroMolecules_init(domain, err_tmp)
+      ierr = ior(ierr,err_tmp)
+      call ocn_tracer_ideal_age_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
       if (ierr /= 0) then
          call mpas_log_write( &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -162,7 +162,8 @@ module ocn_time_integration_si
          tracersTendPool,   &! structure holding tracer tendencies
          forcingPool,       &! structure holding forcing variables
          scratchPool,       &! structure holding temporary variables
-         swForcingPool       ! structure holding short-wave forcing vars
+         swForcingPool,     &! structure holding short-wave forcing vars
+         tracersIdealAgeFieldsPool     ! structure holding idealAge-related fields
 
       logical :: &
          activeTracersOnly   ! only compute tendencies for active tracers
@@ -245,7 +246,8 @@ module ocn_time_integration_si
          highFreqThicknessCur,        &! high frq thick at current time
          highFreqThicknessNew,        &! high frq thick at new     time
          lowFreqDivergenceCur,        &! low frq div    at current time
-         lowFreqDivergenceNew          ! low frq div    at new     time
+         lowFreqDivergenceNew,        &! low frq div    at new     time
+         tracerGroupIdealAgeMask       ! mask for resetting surface ideal age
 
       type (field1DReal), pointer :: &
          effectiveDensityField         ! field pointer for halo update
@@ -3021,6 +3023,28 @@ module ocn_time_integration_si
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
          if (groupItr%memberType == MPAS_POOL_FIELD) then
+
+            ! Reset iAge to zero where mask == 0
+            if (trim(groupItr%memberName) == 'idealAgeTracers') then
+                call mpas_pool_get_array(tracersPool, &
+                                         groupItr%memberName, &
+                                         tracersGroupNew, 2)
+                call mpas_pool_get_subpool(forcingPool, &
+                                           'tracersIdealAgeFields', &
+                                            tracersIdealAgeFieldsPool)
+                call mpas_pool_get_array(tracersIdealAgeFieldsPool, &
+                                         'idealAgeTracersIdealAgeMask', &
+                                          tracerGroupIdealAgeMask)
+
+                !$omp parallel
+                !$omp do schedule(runtime)
+                do iCell = 1, nCellsAll
+                   tracersGroupNew(1,1,iCell) = tracerGroupIdealAgeMask(1,iCell)*tracersGroupNew(1,1,iCell)
+                end do ! cells
+                !$omp end do
+                !$omp end parallel
+             endif
+
             call mpas_dmpar_field_halo_exch(domain, &
                          groupItr%memberName, timeLevel=2)
          end if

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -140,7 +140,8 @@ module ocn_time_integration_split
          tracersTendPool,   &! structure holding tracer tendencies
          forcingPool,       &! structure holding forcing variables
          scratchPool,       &! structure holding temporary variables
-         swForcingPool       ! structure holding short-wave forcing vars
+         swForcingPool,     &! structure holding short-wave forcing vars
+         tracersIdealAgeFieldsPool     ! structure holding idealAge-related fields
 
       logical :: &
          activeTracersOnly   ! only compute tendencies for active tracers
@@ -207,7 +208,8 @@ module ocn_time_integration_split
          highFreqThicknessCur,        &! high frq thick at current time
          highFreqThicknessNew,        &! high frq thick at new     time
          lowFreqDivergenceCur,        &! low frq div    at current time
-         lowFreqDivergenceNew          ! low frq div    at new     time
+         lowFreqDivergenceNew,        &! low frq div    at new     time
+         tracerGroupIdealAgeMask       ! mask for resetting surface ideal age
 
       type (field1DReal), pointer :: &
          effectiveDensityField         ! field pointer for halo update
@@ -1917,6 +1919,28 @@ module ocn_time_integration_split
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
          if (groupItr%memberType == MPAS_POOL_FIELD) then
+
+            ! Reset iAge to zero where mask == 0
+            if (trim(groupItr%memberName) == 'idealAgeTracers') then
+                call mpas_pool_get_array(tracersPool, &
+                                         groupItr%memberName, &
+                                         tracersGroupNew, 2)
+                call mpas_pool_get_subpool(forcingPool, &
+                                           'tracersIdealAgeFields', &
+                                            tracersIdealAgeFieldsPool)
+                call mpas_pool_get_array(tracersIdealAgeFieldsPool, &
+                                         'idealAgeTracersIdealAgeMask', &
+                                          tracerGroupIdealAgeMask)
+
+                !$omp parallel
+                !$omp do schedule(runtime)
+                do iCell = 1, nCellsAll
+                   tracersGroupNew(1,1,iCell) = tracerGroupIdealAgeMask(1,iCell)*tracersGroupNew(1,1,iCell)
+                end do ! cells
+                !$omp end do
+                !$omp end parallel
+             endif
+
             call mpas_dmpar_field_halo_exch(domain, &
                          groupItr%memberName, timeLevel=2)
          end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -974,9 +974,9 @@ contains
          !
          if (config_use_tracerGroup_idealAge_forcing) then
             call mpas_timer_start("ideal age " // groupName)
-            call mpas_log_write( &
-                        "WARNING: ideal age not fully tested", &
-                        MPAS_LOG_WARN)
+            if (trim(groupName) /= 'idealAgeTracers') call mpas_log_write( &
+                                                      "WARNING: ideal age not fully tested", &
+                                                      MPAS_LOG_WARN)
 
             call mpas_pool_get_subpool(forcingPool, &
                                        'tracersIdealAgeFields', &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
@@ -9,9 +9,9 @@
 !
 !  ocn_tracer_ideal_age
 !
-!> \brief MPAS ocean restoring
-!> \author Todd Ringler
-!> \date   06/08/2015
+!> \brief MPAS ideal age tracer routines
+!> \author Mathew Maltrud
+!> \date   08/19/2021
 !> \details
 !>  This module contains routines for computing the tracer tendency due to restoring
 !
@@ -58,8 +58,8 @@ contains
 !  routine ocn_tracer_ideal_age_compute
 !
 !> \brief   computes a tracer tendency to approximate ideal age
-!> \author  Todd Ringler
-!> \date    06/09/2015
+!> \author  Mathew Maltrud
+!> \date    08/19/2021
 !> \details
 !>  This routine computes a tracer tendency to approximate ideal age
 !
@@ -112,26 +112,31 @@ contains
 
       integer :: iCell, iLevel, iTracer
 
-      !move to ocean constants
-      real (kind=RKIND), parameter :: c0 = 0.0_RKIND
-      real (kind=RKIND), parameter :: c1 = 1.0_RKIND
-
       err = 0
 
+      ! add a tendency increment equivalent to "dt" to entire domain below top level
       !$omp parallel
       !$omp do schedule(runtime) private(iLevel, iTracer)
       do iCell=1,nCellsSolve
-        do iLevel=minLevelCell(iCell),maxLevelCell(iCell)
+        do iLevel=minLevelCell(iCell) + 1, maxLevelCell(iCell)
           do iTracer=1,nTracers
-             ! zero tracers at surface to zero where idealAgeMask == zero
-             ! idealAgeMask should be equal to 1.0 elsewhere
-             tracers(iTracer, iLevel, iCell) = idealAgeMask(iTracer, iCell) * tracers(iTracer, iLevel, iCell)
-
-             ! add a tendency increment equivalent to "dt" to entire domain
-             tracer_tend(iTracer, iLevel, iCell) =   tracer_tend(iTracer, iLevel, iCell) +  &
-                                                     layerThickness(iLevel,iCell) * c1
+             tracer_tend(iTracer, iLevel, iCell) = tracer_tend(iTracer, iLevel, iCell) +  &
+                layerThickness(iLevel,iCell)
           enddo
         enddo
+      enddo
+      !$omp end do
+      !$omp end parallel
+
+      ! zero surface tendency where mask == 0
+      !$omp parallel
+      !$omp do schedule(runtime) private(iLevel, iTracer)
+      do iCell=1,nCellsSolve
+        iLevel = 1
+          do iTracer=1,nTracers
+             tracer_tend(iTracer, iLevel, iCell) = tracer_tend(iTracer, iLevel, iCell) +  &
+                idealAgeMask(iTracer, iCell)*layerThickness(iLevel,iCell)
+          enddo
       enddo
       !$omp end do
       !$omp end parallel
@@ -145,20 +150,44 @@ contains
 !  routine ocn_tracer_ideal_age_init
 !
 !> \brief   Initializes ocean ideal age
-!> \author  Todd Ringler
-!> \date    06/09/2015
+!> \author  Mathew Maltrud
+!> \date    08/19/2021
 !> \details
 !>  This routine initializes fields required for tracer ideal age
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_ideal_age_init(err)!{{{
+   subroutine ocn_tracer_ideal_age_init(domain,err)!{{{
+
+      type (domain_type), intent(inout) :: domain !< Input/Output: domain information
 
       integer, intent(out) :: err !< Output: error flag
 
+      type (mpas_pool_type), pointer :: forcingPool
+      type (mpas_pool_type), pointer :: tracersIdealAgeFieldsPool
+
+      integer, dimension(:), pointer :: &
+         landIceMask
+
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         idealAgeMask
+
       err = 0
 
-   !--------------------------------------------------------------------
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'forcing', forcingPool)
+      call mpas_pool_get_subpool(forcingPool, &
+                                 'tracersIdealAgeFields', &
+                                  tracersIdealAgeFieldsPool)
+      call mpas_pool_get_array(tracersIdealAgeFieldsPool, &
+                               'idealAgeTracersIdealAgeMask', &
+                                idealAgeMask)
+
+      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+
+      ! set mask = 0 for open ocean
+      ! set mask = 1 under ice shelves
+      idealAgeMask = 0.0_RKIND
+      where (landIceMask /= 0) idealAgeMask(1,:) = 1.0_RKIND
 
    end subroutine ocn_tracer_ideal_age_init!}}}
 

--- a/components/mpas-ocean/src/tracer_groups/Registry_idealAge.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_idealAge.xml
@@ -1,0 +1,123 @@
+        <nml_record name="tracer_forcing_idealAgeTracers">
+		<nml_option name="config_use_idealAgeTracers" type="logical" default_value=".false." units="unitless"
+			description="if true, the 'idealAgeTracers' category is enabled for the run"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_idealAgeTracers_surface_bulk_forcing" type="logical" default_value=".false." units="unitless"
+			description="if true, surface bulk forcing from coupler is added to surfaceTracerFlux in 'idealAgeTracers' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_idealAgeTracers_surface_restoring" type="logical" default_value=".false." units="unitless"
+			description="if true, surface restoring source is applied to tracers in 'idealAgeTracers' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_idealAgeTracers_interior_restoring" type="logical" default_value=".false." units="unitless"
+			description="if true, interior restoring source is applied to tracers in 'idealAgeTracers' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_idealAgeTracers_exponential_decay" type="logical" default_value=".false." units="unitless"
+			description="if true, exponential decay source is applied to tracers in 'idealAgeTracers' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_idealAgeTracers_idealAge_forcing" type="logical" default_value=".false." units="unitless"
+			description="if true, idealAge forcing source is applied to tracers in 'idealAgeTracers' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_idealAgeTracers_ttd_forcing" type="logical" default_value=".false." units="unitless"
+			description="if true, transit time distribution forcing source is applied to tracers in 'idealAgeTracers' category"
+			possible_values=".true. or .false."
+		/>
+	</nml_record>
+
+	<packages>
+		<package name="idealAgeTracersPKG" description="This package includes variables required to include idealAge."/>
+		<package name="idealAgeTracersBulkRestoringPKG" description="This package includes variables required to compute bulk restoring on the idealAgeTracers group."/>
+		<package name="idealAgeTracersSurfaceRestoringPKG" description="This package includes variables required to compute surface restoring on the idealAgeTracers group."/>
+		<package name="idealAgeTracersInteriorRestoringPKG" description="This package includes variables required to compute interior restoring on the idealAgeTracers group."/>
+		<package name="idealAgeTracersExponentialDecayPKG" description="This package includes variables required to compute exponential decay on the idealAgeTracers group."/>
+		<package name="idealAgeTracersIdealAgePKG" description="This package includes variables required to compute ideal age forcing on the idealAgeTracers group."/>
+		<package name="idealAgeTracersTTDPKG" description="This package includes variables required to compute transit-time distribution forcing on the idealAgeTracers group."/>
+	</packages>
+
+	<var_struct name="state" time_levs="2">
+		<var_struct name="tracers" time_levs="2">
+			<var_array name="idealAgeTracers" dimensions="nVertLevels nCells Time" type="real" packages="idealAgeTracersPKG">
+				<var name="iAge" array_group="iAgeGRP" units="seconds" description="tracer for ideal age"
+				/>
+			</var_array>
+		</var_struct>
+	</var_struct>
+
+	<var_struct name="tend" time_levs="1">
+		<var_struct name="tracersTend" time_levs="1">
+			<var_array name="idealAgeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="idealAgeTracersPKG">
+				<var name="iAgeTend" array_group="iAgeGRP" units="seconds/second" description="Tendency for iAge"
+				/>
+			</var_array>
+		</var_struct>
+	</var_struct>
+
+   	<var_struct name="forcing" time_levs="1">
+		<var_struct name="tracersSurfaceFlux" time_levs="1">
+			<var_array name="idealAgeTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="idealAgeTracersPKG">
+				<var name="iAgeSurfaceFlux" array_group="idealAgeluxGRP" units="none"
+			 description="Flux of iAge through the ocean surface. Positive into ocean."
+				/>
+			</var_array>
+			<var_array name="idealAgeTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="idealAgeTracersPKG">
+				<var name="iAgeSurfaceFluxRunoff" array_group="iAgeRunoffFluxGRP" units="none"
+			 description="Flux of iAge through the ocean surface due to river runoff. Positive into ocean."
+				/>
+			</var_array>
+			<var_array name="idealAgeTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="idealAgeTracersPKG">
+				<var name="iAgeSurfaceFluxRemoved" array_group="iAgeRemovedFluxGRP" units="none"
+			 description="Flux of iAge that is ignored coming into the ocean. Positive into ocean."
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
+			<var_array name="idealAgeTracersPistonVelocity" type="real" dimensions="nCells Time" packages="idealAgeTracersSurfaceRestoringPKG">
+				<var name="iAgePistonVelocity" array_group="iAgeRestoringGRP" units="none"
+			 description="A non-negative field controlling the rate at which iAge is restored to iAgeSurfaceRestoringValue"
+				/>
+			</var_array>
+			<var_array name="idealAgeTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="idealAgeTracersSurfaceRestoringPKG">
+				<var name="iAgeSurfaceRestoringValue" array_group="iAgeRestoringGRP" units="none"
+			 description="iAge is restored toward this field at a rate controlled by iAgePistonVelocity."
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
+			<var_array name="idealAgeTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="idealAgeTracersInteriorRestoringPKG">
+				<var name="iAgeInteriorRestoringRate" array_group="iAgeRestoringGRP" units="none"
+				 description="A non-negative field controlling the rate at which iAge is restored to iAgeInteriorRestoringValue"
+				/>
+			</var_array>
+			<var_array name="idealAgeTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="idealAgeTracersInteriorRestoringPKG">
+				<var name="iAgeInteriorRestoringValue" array_group="iAgeRestoringGRP" units="none"
+				 description="iAge is restored toward this field at a rate controlled by iAgeInteriorRestoringRate."
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersExponentialDecayFields" time_levs="1">
+			<var_array name="idealAgeTracersExponentialDecayRate" type="real" dimensions="Time" packages="idealAgeTracersExponentialDecayPKG">
+				<var name="iAgeExponentialDecayRate" array_group="iAgeRestoringGRP" units="none"
+			 description="A non-negative field controlling the exponential decay of iAge"
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersIdealAgeFields" time_levs="1">
+			<var_array name="idealAgeTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="idealAgeTracersIdealAgePKG">
+				<var name="iAgeIdealAgeMask" array_group="iAgeRestoringGRP" units="none"
+			 description="In top layer, iAge is reset to iAge * iAgeIdealAgeMask, valid values of iAgeIdealAgeMask or 0 and 1"
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersTTDFields" time_levs="1">
+			<var_array name="idealAgeTracersTTDMask" type="real" dimensions="nCells Time" packages="idealAgeTracersTTDPKG">
+				<var name="iAgeTTDMask" array_group="iAgeRestoringGRP" units="none"
+			 description="In top layer, iAge is reset to TTDMask, valid values of iAgeTTDMask or 0 and 1"
+				/>
+			</var_array>
+		</var_struct>
+	</var_struct>

--- a/components/mpas-ocean/src/tracer_groups/Registry_tracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_tracers.xml
@@ -3,4 +3,5 @@
 #include "Registry_ecosys.xml"
 #include "Registry_DMS.xml"
 #include "Registry_MacroMolecules.xml"
+#include "Registry_idealAge.xml"
 //#include "Registry_TEMPLATEGRP.xml"


### PR DESCRIPTION
Add classic ideal age as a new passive tracer to the ocean, which is used to help trace ocean ventilation, for example. The tracer source is effectively just an increment of dt, and the surface value is reset to zero in the top layer every timestep (except for under ice shelves). This feature is turned off by default.  Note, this is the second PR attempt since i named the first one incorrectly (#4484).