### PR TITLE
Adding CRYO1950 compset

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -350,6 +350,11 @@
 </compset>
 
 <compset>
+  <alias>CRYO1950</alias>
+  <lname>1950SOI_EAM%CMIP6_ELM%SPBC_MPASSI%DIB_MPASO%IBISMF_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
   <alias>A_WCYCL1850-DIB</alias>
   <lname>1850_EAM%AV1C-L_ELM%SPBC_MPASSI%DIB_MPASO%IB_MOSART_SGLC_SWAV</lname>
 </compset>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -174,6 +174,10 @@ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 sim_year="1950" glc_nec="0" use_crop=".false.">lnd/clm2/initdata/20210802.ICRUELM-1950.ne30pg2_EC30to60E2r2.elm.r.0051-01-01-00000.nc
 </finidat>
 
+<finidat hgrid="ne30np4.pg2" maxpft="17" mask="SOwISC12to60E2r4" use_cn=".false." ic_ymd="19500101" more_vertlayers=".false."
+sim_year="1950" glc_nec="0" use_crop=".false.">lnd/clm2/initdata/20210817.ICRUELM-1950.ne30pg2_SOwISC12to60E2r4.elm.r.0051-01-01-00000.nc
+</finidat>
+
 <!-- HOMME grid ne120 resolution -->
 
 <finidat hgrid="ne120np4"   maxpft="17"  mask="gx1v6" use_cn=".false." ic_ymd="18500101" more_vertlayers=".false."


### PR DESCRIPTION
Adds a new Cryosphere compset that is similar to WCYCL1950, except uses Cryosphere settings for Antarctic runoff (disables Antarctic runoff from the coupler to the ocn, includes ice-shelf melt fluxes and data icebergs). This compset points to spun-up ocn/ice initial conditions (restarts from a one month G-case).

[BFB] for all currently tested configurations.