### PR TITLE
Add timers to EAM to provide context to SCORPIO timers

### DIFF
--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -151,8 +151,13 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
 
    if ( nsrest == 0 )then
 
+      call t_startf('cam_initfiles_open')
       call cam_initfiles_open()
+      call t_stopf('cam_initfiles_open')
+
+      call t_startf('cam_initial')
       call cam_initial(dyn_in, dyn_out, NLFileName=filein)
+      call t_stopf('cam_initial')
 
       ! Allocate and setup surface exchange data
       call atm2hub_alloc(cam_out)
@@ -160,7 +165,9 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
 
    else
 
+      call t_startf('cam_read_restart')
       call cam_read_restart ( cam_in, cam_out, dyn_in, dyn_out, pbuf2d, stop_ymd, stop_tod, NLFileName=filein )
+      call t_stopf('cam_read_restart')
 
      ! Commented out the hub2atm_alloc call as it overwrite cam_in, which is undesirable. The fields in cam_in are necessary for getting BFB restarts
 	 ! There are no side effects of commenting out this call as this call allocates cam_in and cam_in allocation has already been done in cam_init
@@ -170,7 +177,9 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
 #endif
    end if
 
+   call t_startf('phys_init')
    call phys_init( phys_state, phys_tend, pbuf2d,  cam_out )
+   call t_stopf('phys_init')
 
    call bldfld ()       ! master field list (if branch, only does hash tables)
 
@@ -188,7 +197,6 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
 
    if (single_column) call scm_intht()
    call intht()
-
 
 end subroutine cam_init
 

--- a/components/eam/src/control/cam_restart.F90
+++ b/components/eam/src/control/cam_restart.F90
@@ -213,8 +213,14 @@ end subroutine restart_printopts
       call cam_pio_createfile(File, trim(fname))
       call timemgr_init_restart(File)
 
+      call t_startf("init_restart_dynamics")
       call init_restart_dynamics(File, dyn_out)
+      call t_stopf("init_restart_dynamics")
+
+      call t_startf("init_restart_physics")
       call init_restart_physics(File, pbuf2d)
+      call t_stopf("init_restart_physics")
+
       call init_restart_history(File)
 
       ierr = PIO_Put_att(File, PIO_GLOBAL, 'caseid', caseid)
@@ -229,7 +235,9 @@ end subroutine restart_printopts
       !-----------------------------------------------------------------------
       ! Dynamics, physics, History
       !-----------------------------------------------------------------------
+      call t_startf("timemgr_write_restart")
       call timemgr_write_restart(File)
+      call t_stopf("timemgr_write_restart")
 
       call t_startf("write_restart_dynamics")
       call write_restart_dynamics(File, dyn_out)
@@ -362,8 +370,10 @@ end subroutine restart_printopts
    ierr = pio_get_att(File, PIO_GLOBAL, 'WNUMMAX', tmp_rgrid)
    if(ierr==PIO_NOERR) wnummax=tmp_rgrid
    call PIO_SetErrorHandling(File, PIO_INTERNAL_ERROR)
-   call timemgr_read_restart(File)
 
+   call t_startf('timemgr_read_restart')
+   call timemgr_read_restart(File)
+   call t_stopf('timemgr_read_restart')
 
    if(masterproc) then
 
@@ -385,7 +395,10 @@ end subroutine restart_printopts
       !-----------------------------------------------------------------------
 
    call initcom ()
+
+   call t_startf('read_restart_dynamics')
    call read_restart_dynamics(File, dyn_in, dyn_out, NLFileName)   
+   call t_stopf('read_restart_dynamics')
 
    call hub2atm_alloc( cam_in )
    call atm2hub_alloc( cam_out )
@@ -394,10 +407,14 @@ end subroutine restart_printopts
    ! Initialize physics grid reference pressures (needed by initialize_radbuffer)
    call ref_pres_init()
 
+   call t_startf('read_restart_physics')
    call read_restart_physics( File, cam_in, cam_out, pbuf2d )
+   call t_stopf('read_restart_physics')
 
    if (nlres .and. .not.lbrnch) then
+      call t_startf('read_restart_history')
       call read_restart_history ( File )
+      call t_stopf('read_restart_history')
    end if
 
    call pio_closefile(File)
@@ -414,7 +431,10 @@ end subroutine restart_printopts
    ! Initialize ghg surface values.
 
    call chem_surfvals_init()
+
+   call t_startf('clean_iodesc_list')
    call clean_iodesc_list()
+   call t_stopf('clean_iodesc_list')
 
  end subroutine cam_read_restart
 

--- a/components/eam/src/control/startup_initialconds.F90
+++ b/components/eam/src/control/startup_initialconds.F90
@@ -31,7 +31,8 @@ subroutine initial_conds(dyn_in)
    use inidat,        only: read_inidat
    use dyn_comp,      only: dyn_import_t
    use cam_pio_utils, only: clean_iodesc_list
-
+   use perf_mod,      only: t_startf, t_stopf
+   
    type(dyn_import_t),  intent(inout) :: dyn_in
 
    ! Local variables
@@ -47,11 +48,15 @@ subroutine initial_conds(dyn_in)
 #endif
 
    ! Read in initial data
+   call t_startf('read_inidat')
    fh_ini  => initial_file_get_id()
    fh_topo => topo_file_get_id()
    call read_inidat(fh_ini, fh_topo, dyn_in)
+   call t_stopf('read_inidat')
 
+   call t_startf('clean_iodesc_list')
    call clean_iodesc_list()
+   call t_stopf('clean_iodesc_list')
 
 end subroutine initial_conds
 

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -235,7 +235,7 @@ CONTAINS
 
        endif
 
-       call t_startf("shr_taskmap_write")
+       call t_startf('shr_taskmap_write')
        call shr_taskmap_write(iulog, mpicom_atm,                    &
                               'ATM #'//trim(adjustl(c_inst_index)), &
                               verbose=verbose_taskmap_output,       &
@@ -243,7 +243,7 @@ CONTAINS
                               save_nnodes=nsmps,                    &
                               save_task_node_map=proc_smp_map       )
        call shr_sys_flush(iulog)
-       call t_stopf("shr_taskmap_write")
+       call t_stopf('shr_taskmap_write')
 
        ! 
        ! Consistency check                              
@@ -289,9 +289,11 @@ CONTAINS
        !
        ! Read namelist
        !
+       call t_startf('read_namelist')
        filein = "atm_in" // trim(inst_suffix)
        call read_namelist(single_column_in=single_column, scmlat_in=scmlat, &
             scmlon_in=scmlon, nlfilename_in=filein)
+       call t_stopf('read_namelist')
        !
        ! Initialize cam time manager
        !
@@ -312,9 +314,11 @@ CONTAINS
        ! Set defaults then override with user-specified input and initialize time manager
        ! Note that the following arguments are needed to cam_init for timemgr_restart only
        !
+       call t_startf('cam_init')
        call cam_init( cam_out, cam_in, mpicom_atm, &
             start_ymd, start_tod, ref_ymd, ref_tod, stop_ymd, stop_tod, &
             perpetual_run, perpetual_ymd, calendar)
+       call t_stopf('cam_init')
        !
        ! Check consistency of restart time information with input clock
        !
@@ -393,14 +397,25 @@ CONTAINS
        call seq_timemgr_EClockGetData(EClock,curr_ymd=CurrentYMD, StepNo=StepNo, dtime=DTime_Sync )
        if (StepNo == 0) then
           call atm_import( x2a_a%rattr, cam_in )
+
+          call t_startf('CAM_run1')
           call cam_run1 ( cam_in, cam_out ) 
+          call t_stopf('CAM_run1')
+          
           call atm_export( cam_out, a2x_a%rattr )
        else
+
+          call t_startf('atm_read_srfrest_mct')
           call atm_read_srfrest_mct( EClock, x2a_a, a2x_a )
+          call t_stopf('atm_read_srfrest_mct')
+
           ! Sent .true. as an optional argument so that restart_init is set to .true.  in atm_import
 	      ! This will ensure BFB restarts whenever qneg4 updates fluxes on the restart time step
           call atm_import( x2a_a%rattr, cam_in, .true. )
+
+          call t_startf('cam_run1')
           call cam_run1 ( cam_in, cam_out ) 
+          call t_stopf('cam_run1')
        end if
 
        ! Compute time of next radiation computation, like in run method for exact restart
@@ -605,8 +620,10 @@ CONTAINS
     ! Write merged surface data restart file if appropriate
     
     if (rstwr_sync) then
+       call t_startf('atm_write_srfrest_mct')
        call atm_write_srfrest_mct( x2a_a, a2x_a, &
             yr_spec=yr_sync, mon_spec=mon_sync, day_spec=day_sync, sec_spec=tod_sync)
+       call t_stopf('atm_write_srfrest_mct')
     end if
     
     ! Check for consistency of internal cam clock with master sync clock 
@@ -646,9 +663,9 @@ CONTAINS
     type(mct_aVect)             ,intent(inout) :: x2a_a
     type(mct_aVect)             ,intent(inout) :: a2x_a
 
-    call t_startf("cam_final")
+    call t_startf('cam_final')
     call cam_final( cam_out, cam_in )
-    call t_stopf("cam_final")
+    call t_stopf('cam_final')
 
   end subroutine atm_final_mct
 

--- a/components/eam/src/dynamics/se/dyn_comp.F90
+++ b/components/eam/src/dynamics/se/dyn_comp.F90
@@ -132,7 +132,9 @@ CONTAINS
     if (use_moisture) moisture='wet'
 
     ! Initialize hybrid coordinate arrays.
+    call t_startf('hycoef_init')
     call hycoef_init(fh)
+    call t_stopf('hycoef_init')
 
     ! Initialize physics grid reference pressures (needed by initialize_radbuffer)
     call ref_pres_init()
@@ -146,7 +148,9 @@ CONTAINS
 #endif
 
     if(par%dynproc) then
+       call t_startf('prim_init1')
        call prim_init1(elem,par,dom_mt,TimeLevel)
+       call t_stopf('prim_init1')
 
        dyn_in%elem => elem
        dyn_out%elem => elem
@@ -303,7 +307,11 @@ CONTAINS
           ! new run, scale mass to value given in namelist, if needed
           call prim_set_mass(elem, TimeLevel,hybrid,hvcoord,nets,nete)
        endif
+
+       call t_startf('prim_init2')
        call prim_init2(elem,hybrid,nets,nete, TimeLevel, hvcoord)
+       call t_stopf('prim_init2')
+
 #ifdef HORIZ_OPENMP
        !$OMP END PARALLEL 
 #endif
@@ -359,10 +367,10 @@ CONTAINS
        if (.not. use_3dfrc) then
          do n=1,se_nsplit
            ! forward-in-time RK, with subcycling
-           call t_startf("prim_run_sybcycle")
+           call t_startf('prim_run_subcycle')
            call prim_run_subcycle(dyn_state%elem,hybrid,nets,nete,&
                tstep, single_column, TimeLevel, hvcoord, n)
-           call t_stopf("prim_run_sybcycle")
+           call t_stopf('prim_run_subcycle')
          end do
        endif
 

--- a/components/eam/src/dynamics/se/inidat.F90
+++ b/components/eam/src/dynamics/se/inidat.F90
@@ -21,6 +21,8 @@ module inidat
   use cam_control_mod, only : ideal_phys, aqua_planet, pertlim, seed_custom, seed_clock, new_random
   use random_xgc, only: init_ranx, ranx
   use scamMod, only: single_column, precip_off, scmlat, scmlon
+  use perf_mod, only: t_startf, t_stopf
+
   implicit none
   private
   public read_inidat
@@ -175,8 +177,12 @@ contains
 
     fieldname = 'U'
     tmp = 0.0_r8
+
+    call t_startf('read_inidat_infld')
     call infld(fieldname, ncid_ini, ncol_name, 'lev', 1, npsq,          &
          1, nlev, 1, nelemd, tmp, found, gridname=grid_name)
+    call t_stopf('read_inidat_infld')
+
     if(.not. found) then
        call endrun('Could not find U field on input datafile')
     end if
@@ -195,8 +201,12 @@ contains
 
     fieldname = 'V'
     tmp = 0.0_r8
+
+    call t_startf('read_inidat_infld')
     call infld(fieldname, ncid_ini, ncol_name, 'lev', 1, npsq,          &
          1, nlev, 1, nelemd, tmp, found, gridname=grid_name)
+    call t_stopf('read_inidat_infld')
+
     if(.not. found) then
        call endrun('Could not find V field on input datafile')
     end if
@@ -214,8 +224,12 @@ contains
 
     fieldname = 'T'
     tmp = 0.0_r8
+
+    call t_startf('read_inidat_infld')
     call infld(fieldname, ncid_ini, ncol_name, 'lev', 1, npsq,          &
          1, nlev, 1, nelemd, tmp, found, gridname=grid_name)
+    call t_stopf('read_inidat_infld')
+
     if(.not. found) then
        call endrun('Could not find T field on input datafile')
     end if
@@ -318,9 +332,12 @@ contains
 	  else
 	    
 	    tmp = 0.0_r8
+
+            call t_startf('read_inidat_infld')
             call infld(cnst_name(m_cnst), ncid_ini, ncol_name, 'lev',      &
                  1, npsq, 1, nlev, 1, nelemd, tmp, found, gridname=grid_name)
-	    
+            call t_stopf('read_inidat_infld')
+
 	  endif
        end if
        if(.not. found) then
@@ -405,8 +422,12 @@ contains
 
     fieldname = 'PS'
     tmp(:,1,:) = 0.0_r8
+
+    call t_startf('read_inidat_infld')
     call infld(fieldname, ncid_ini, ncol_name,      &
          1, npsq, 1, nelemd, tmp(:,1,:), found, gridname=grid_name)
+    call t_stopf('read_inidat_infld')
+
     if(.not. found) then
        call endrun('Could not find PS field on input datafile')
     end if
@@ -440,13 +461,21 @@ contains
       fieldname = 'PHIS'
       tmp(:,1,:) = 0.0_r8
       if (fv_nphys == 0) then
+
+         call t_startf('read_inidat_infld')
          call infld(fieldname, ncid_topo, ncol_name,      &
               1, npsq, 1, nelemd, tmp(:,1,:), found, gridname=grid_name)
+         call t_stopf('read_inidat_infld')
+
       else
          ! Attempt to read a mixed GLL-FV topo file, which contains PHIS_d in
          ! addition to PHIS.
+
+         call t_startf('read_inidat_infld')
          call infld(trim(fieldname) // '_d', ncid_topo, ncol_name, &
               1, npsq, 1, nelemd, tmp(:,1,:), found, gridname=grid_name)
+         call t_stopf('read_inidat_infld')
+
          if (found) then
             if (masterproc) then
                write(iulog,*) 'reading GLL ', trim(fieldname) // '_d', &
@@ -459,8 +488,12 @@ contains
                     ' on gridname physgrid_d'
             end if
             read_pg_grid = .true.
+
+            call t_startf('read_inidat_infld')
             call infld(fieldname, ncid_topo, 'ncol', 1, nphys_sq, &
                  1, nelemd, phis_tmp, found, gridname='physgrid_d')
+            call t_stopf('read_inidat_infld')
+
             call gfr_fv_phys_to_dyn_topo(par, dom_mt, elem, phis_tmp)
          end if
       end if

--- a/components/eam/src/dynamics/se/inital.F90
+++ b/components/eam/src/dynamics/se/inital.F90
@@ -24,7 +24,8 @@ subroutine cam_initial(dyn_in, dyn_out, NLFileName)
    use cam_initfiles,        only: initial_file_get_id
    use startup_initialconds, only: initial_conds
    use cam_logfile,          only: iulog
-
+   use perf_mod,             only: t_startf, t_stopf
+   
    ! modules from SE
    use parallel_mod, only : par
 
@@ -33,7 +34,9 @@ subroutine cam_initial(dyn_in, dyn_out, NLFileName)
    character(len=*),   intent(in)  :: NLFileName
    !----------------------------------------------------------------------
 
+   call t_startf('dyn_init1')
    call dyn_init1(initial_file_get_id(), NLFileName, dyn_in, dyn_out)
+   call t_stopf('dyn_init1')
 
    ! Define physics data structures
    if(par%masterproc  ) write(iulog,*) 'Running phys_grid_init()'
@@ -55,10 +58,16 @@ subroutine cam_initial(dyn_in, dyn_out, NLFileName)
    call chem_surfvals_init()
 
    if(par%masterproc  ) write(iulog,*) 'Reading initial data'
+
+   call t_startf('initial_conds')
    call initial_conds(dyn_in)
+   call t_stopf('initial_conds')
+
    if(par%masterproc  ) write(iulog,*) 'Done Reading initial data'
 
+   call t_startf('dyn_init2')
    call dyn_init2(dyn_in)
+   call t_stopf('dyn_init2')
 
 end subroutine cam_initial
 

--- a/components/eam/src/dynamics/se/restart_dynamics.F90
+++ b/components/eam/src/dynamics/se/restart_dynamics.F90
@@ -6,6 +6,7 @@ module restart_dynamics
   use spmd_utils,  only : iam
   use cam_logfile, only : iulog
   use control_mod, only : theta_hydrostatic_mode
+  use perf_mod,    only : t_startf, t_stopf
 
   implicit none
 
@@ -404,7 +405,9 @@ CONTAINS
 !how to place a check so that someone does not restart nh from hy file?
 !is hy restart run from nh ok?
 
+    call t_startf('dyn_init1')
     call dyn_init1(file, NLFileName, dyn_in, dyn_out)
+    call t_stopf('dyn_init1')
 
     ! Define physics data structures
     if(par%masterproc  ) write(iulog,*) 'Running phys_grid_init()'
@@ -676,7 +679,9 @@ CONTAINS
 
     deallocate(qdesc_dp)
 
+    call t_startf('dyn_init2')
     call dyn_init2(dyn_in)
+    call t_stopf('dyn_init2')
 
    if (par%dynproc) then
    else

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -387,12 +387,17 @@ subroutine phys_inidat( cam_out, pbuf2d )
        if (masterproc) write(iulog,*) 'NOT AN AQUA_PLANET simulation, initialize &
                                       &sgh, sgh30, land m using data from file.'
        fh_topo=>topo_file_get_id()
+       call t_startf('phys_inidat_infld')
        call infld('SGH', fh_topo, dim1name, dim2name, 1, pcols, begchunk, endchunk, &
             sgh, found, gridname='physgrid')
+       call t_stopf('phys_inidat_infld')
        if(.not. found) call endrun('ERROR: SGH not found on topo file')
 
+       call t_startf('phys_inidat_infld')
        call infld('SGH30', fh_topo, dim1name, dim2name, 1, pcols, begchunk, endchunk, &
             sgh30, found, gridname='physgrid')
+       call t_stopf('phys_inidat_infld')
+       
        if(.not. found) then
           if (masterproc) write(iulog,*) 'Warning: Error reading SGH30 from topo file.'
           if (masterproc) write(iulog,*) 'The field SGH30 will be filled using data from SGH.'
@@ -402,8 +407,11 @@ subroutine phys_inidat( cam_out, pbuf2d )
 
     allocate(tptr(1:pcols,begchunk:endchunk))
 
+    call t_startf('phys_inidat_infld')
     call infld('PBLH', fh_ini, dim1name, dim2name, 1, pcols, begchunk, endchunk, &
          tptr(:,:), found, gridname='physgrid')
+    call t_stopf('phys_inidat_infld')
+    
     if(.not. found) then
        tptr(:,:) = 0._r8
        if (masterproc) write(iulog,*) 'PBLH initialized to 0.'
@@ -771,7 +779,9 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     if (adiabatic .or. ideal_phys) return
 
     if (nsrest .eq. 0) then
+       call t_startf ('phys_inidat')
        call phys_inidat(cam_out, pbuf2d) 
+       call t_stopf ('phys_inidat')
     end if
     
     ! wv_saturation is relatively independent of everything else and
@@ -782,15 +792,22 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     if (cam3_aero_data_on) call cam3_aero_data_init(phys_state)
 
     ! Initialize rad constituents and their properties
+    call t_startf ('rad_cnst_init')
     call rad_cnst_init()
+    call t_stopf ('rad_cnst_init')
+    
     call aer_rad_props_init()
     call cloud_rad_props_init()
 
     ! solar irradiance data modules
+    call t_startf ('solar_data_init')
     call solar_data_init()
+    call t_stopf ('solar_data_init')
 
     ! Prognostic chemistry.
+    call t_startf ('chem_init')
     call chem_init(phys_state,pbuf2d, species_class)
+    call t_stopf ('chem_init')
 
     ! Prescribed tracers
     call prescribed_ozone_init()
@@ -801,11 +818,15 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     !when is_cmip6_volc is true ,cmip6 style volcanic file is read
     !Initialized to .false. here but it gets its values from prescribed_volcaero_init
     is_cmip6_volc = .false. 
+    call t_startf ('prescribed_volcaero_init')
     call prescribed_volcaero_init(is_cmip6_volc)
+    call t_stopf ('prescribed_volcaero_init')
 
     ! Initialize ocean data
     if (has_mam_mom) then
+       call t_startf ('init_ocean_data')
        call init_ocean_data()
+       call t_stopf ('init_ocean_data')
     end if
 
     ! co2 cycle            
@@ -833,7 +854,9 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
 
     call tsinti(tmelt, latvap, rair, stebol, latice)
 
+    call t_startf ('radiation_init')
     call radiation_init(phys_state)
+    call t_stopf ('radiation_init')
 
     call rad_solar_var_init()
 
@@ -868,7 +891,10 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     call metdata_phys_init()
 #endif
     call sslt_rebin_init()
+    
+    call t_startf ('tropopause_init')
     call tropopause_init()
+    call t_stopf ('tropopause_init')
 
     if(do_aerocom_ind3) call output_aerocom_aie_init()
 
@@ -980,15 +1006,14 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
     call check_energy_gmean(phys_state, pbuf2d, ztodt, nstep)
     call t_stopf ('chk_en_gmean')
 
-    call t_stopf ('physpkg_st1')
-
+    
     if ( adiabatic .or. ideal_phys )then
+       call t_stopf ('physpkg_st1')
+	
        call t_startf ('bc_physics')
        call phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
        call t_stopf ('bc_physics')
     else
-       call t_startf ('physpkg_st1')
-
        call pbuf_allocate(pbuf2d, 'physpkg')
        call diag_allocate()
 
@@ -996,7 +1021,9 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
        ! Advance time information
        !-----------------------------------------------------------------------
 
+       call t_startf('phys_timestep_init')
        call phys_timestep_init( phys_state, cam_out, pbuf2d)
+       call t_stopf('phys_timestep_init')
 
        call t_stopf ('physpkg_st1')
 
@@ -1031,7 +1058,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
           call diag_physvar_ic ( c,  phys_buffer_chunk, cam_out(c), cam_in(c) )
           call t_stopf ('diag_physvar_ic')
 
-          call tphysbc (ztodt, fsns(1,c), fsnt(1,c), flns(1,c), flnt(1,c), phys_state(c), &
+          call tphysbc (ztodt, fsns(1,c), fsnt(1,c), flns(1,c), flnt(1,c), phys_state(c),        &
                        phys_tend(c), phys_buffer_chunk,  fsds(1,c),                       &
                        sgh(1,c), sgh30(1,c), cam_out(c), cam_in(c) )
 
@@ -1814,7 +1841,7 @@ end if ! l_ac_energy_chk
 
 end subroutine tphysac
 
-subroutine tphysbc (ztodt,                          &
+subroutine tphysbc (ztodt,               &
        fsns,    fsnt,    flns,    flnt,    state,   &
        tend,    pbuf,     fsds,                     &
        sgh, sgh30, cam_out, cam_in )
@@ -2744,17 +2771,24 @@ subroutine phys_timestep_init(phys_state, cam_out, pbuf2d)
   call solar_data_advance()
 
   ! Time interpolate for chemistry.
+  call t_startf('chem_timestep_init')
   call chem_timestep_init(phys_state, pbuf2d)
+  call t_stopf('chem_timestep_init')
 
   ! Prescribed tracers
   call prescribed_ozone_adv(phys_state, pbuf2d)
   call prescribed_ghg_adv(phys_state, pbuf2d)
   call prescribed_aero_adv(phys_state, pbuf2d)
   call aircraft_emit_adv(phys_state, pbuf2d)
+
+  call t_startf('prescribed_volcaero_adv')
   call prescribed_volcaero_adv(phys_state, pbuf2d)
+  call t_stopf('prescribed_volcaero_adv')
 
   if (has_mam_mom) then
+     call t_startf('advance_ocean_data')
      call advance_ocean_data(phys_state, pbuf2d)
+     call t_stopf('advance_ocean_data')
   end if
 
   ! prescribed aerosol deposition fluxes

--- a/components/eam/src/physics/cam/restart_physics.F90
+++ b/components/eam/src/physics/cam/restart_physics.F90
@@ -18,6 +18,7 @@ module restart_physics
                                 pio_put_var, pio_get_var
   use cospsimulator_intr, only: docosp
   use radiation,          only: cosp_cnt_init, cosp_cnt, rad_randn_seedrst, kiss_seed_num
+  use perf_mod,           only: t_startf, t_stopf
 
   implicit none
   private
@@ -215,14 +216,18 @@ module restart_physics
       !-----------------------------------------------------------------------
 
       ! Write grid vars
+      call t_startf("cam_grid_write_var")
       call cam_grid_write_var(File, phys_decomp)
+      call t_stopf("cam_grid_write_var")
 
       ! Physics buffer
       if (is_subcol_on()) then
          call subcol_write_restart(File)
       end if
 
+      call t_startf("pbuf_write_restart")
       call pbuf_write_restart(File, pbuf2d)
+      call t_stopf("pbuf_write_restart")
 
       physgrid = cam_grid_id('physgrid')
       call cam_grid_dimensions(physgrid, gdims(1:2), nhdims)
@@ -230,12 +235,20 @@ module restart_physics
       if ( .not. adiabatic .and. .not. ideal_phys )then
 
          ! data for chemistry
+         call t_startf("chem_write_restart")
          call chem_write_restart(File)
+         call t_stopf("chem_write_restart")
 
          call write_prescribed_ozone_restart(File)
          call write_prescribed_ghg_restart(File)
+
+         call t_startf("write_prescribed_aero_restart")
          call write_prescribed_aero_restart(File)
+         call t_stopf("write_prescribed_aero_restart")
+
+         call t_startf("write_prescribed_volcaero_restart")
          call write_prescribed_volcaero_restart(File)
+         call t_stopf("write_prescribed_volcaero_restart")
  
          do i=begchunk,endchunk
             ncol = cam_out(i)%ncol
@@ -458,7 +471,9 @@ module restart_physics
         call subcol_read_restart(File)
      end if
 
+     call t_startf("pbuf_read_restart")
      call pbuf_read_restart(File, pbuf2d)
+     call t_stopf("pbuf_read_restart")
 
      csize=endchunk-begchunk+1
      dims(1) = pcols
@@ -479,11 +494,17 @@ module restart_physics
      if ( .not. adiabatic .and. .not. ideal_phys )then
 
         ! data for chemistry
+        call t_startf ('chem_read_restart')
         call chem_read_restart(File)
+        call t_stopf ('chem_read_restart')
 
         call read_prescribed_ozone_restart(File)
         call read_prescribed_ghg_restart(File)
+
+        call t_startf ('read_prescribed_aero_restart')
         call read_prescribed_aero_restart(File)
+        call t_stopf ('read_prescribed_aero_restart')
+
         call read_prescribed_volcaero_restart(File)
 
         allocate(tmpfield2(pcols, begchunk:endchunk))


### PR DESCRIPTION
SCORPIO has introduced some new timers. Unfortunately, the existing
timers in EAM are not sufficient to localize where the SCORPIO calls
are coming from. Here new timers are added to provide the missing
context. A few timers are also added to provide context for these
added timers and for some of the already existing timers.

The logic for the timer physpkg_st1 is also changed, so that the
count during the initialization is '1' instead of '2', and the count
is halved in the run loop.

Also, some places have timer names in double quotes in calls to
t_startf/t_stopf and some have them in single quotes. Changed double
quotes to single quotes in some files, to impose consistency within
the file.

Finally, a timer name typo (prim_run_sybcycle) is corrected (to
prim_run_subcycle).

For an initial run, 28 new timers are introduced into the
initialization and 13 new timers are introduced into the run loop.
Comparing the number of lines in the process 0 timing file for
a watercycle case, there are 41 more lines of timer data after
implementing these modifications, in agreement with the new
timer count.

For a continuation run, 30 new timers are introduced into the
initialization and 13 new timers are introduced into the run loop.
Comparing the number of lines in the process 0 timing file for
a watercycle case, there are 43 more lines of timer data after
implementing these modifications, in agreement with the new
timer count.

Fixes #4469 

BFB