### PR TITLE
Eliminate recursve call to the CPL:RUN timer

### DIFF
--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -4243,7 +4243,7 @@ contains
        ! ocn budget
        !----------------------------------------------------------
        if (do_budgets) then
-          call cime_run_calc_budgets3()
+          call cime_run_calc_budgets3(in_cplrun=.true.)
        endif
 
        if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
@@ -4753,7 +4753,7 @@ contains
 
 !----------------------------------------------------------------------------------
 
-  subroutine cime_run_calc_budgets1()
+  subroutine cime_run_calc_budgets1(in_cplrun)
 
     !----------------------------------------------------------
     ! Budget with old fractions
@@ -4766,9 +4766,21 @@ contains
     ! it will also use the current r2x_ox here which is the value from the last timestep
     ! consistent with the ocean coupling
 
+    logical,intent(in),optional :: in_cplrun  ! flag indicating whether routine
+                                              ! called within the scope of the
+                                              ! CPL:RUN timer
+
+    logical :: lcplrun
+    !-------------------------------------------------------------------------------
+
+    lcplrun  = .true.
+    if (present(in_cplrun)) then
+       lcplrun = .not. in_cplrun
+    endif
+    
     if (iamin_CPLID) then
        call cime_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:BUDGET1_BARRIER')
-       call t_drvstartf ('CPL:BUDGET1',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
+       call t_drvstartf ('CPL:BUDGET1',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        if (lnd_present) then
           call seq_diag_lnd_mct(lnd(ens1), fractions_lx(ens1), infodata, do_l2x=.true., do_x2l=.true.)
        endif
@@ -4778,35 +4790,47 @@ contains
        if (ice_present) then
           call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_x2i=.true.)
        endif
-       call t_drvstopf  ('CPL:BUDGET1',cplrun=.true.,budget=.true.)
+       call t_drvstopf  ('CPL:BUDGET1',cplrun=lcplrun,budget=.true.)
     end if
   end subroutine cime_run_calc_budgets1
 
 !----------------------------------------------------------------------------------
 
-  subroutine cime_run_calc_budgets2()
+  subroutine cime_run_calc_budgets2(in_cplrun)
 
     !----------------------------------------------------------
     ! Budget with new fractions
     !----------------------------------------------------------
 
+    logical,intent(in),optional :: in_cplrun  ! flag indicating whether routine
+                                              ! called within the scope of the
+                                              ! CPL:RUN timer
+
+    logical :: lcplrun
+    !-------------------------------------------------------------------------------
+
+    lcplrun  = .true.
+    if (present(in_cplrun)) then
+       lcplrun = .not. in_cplrun
+    endif
+    
     if (iamin_CPLID) then
        call cime_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:BUDGET2_BARRIER')
 
-       call t_drvstartf ('CPL:BUDGET2',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
+       call t_drvstartf ('CPL:BUDGET2',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        if (atm_present) then
           call seq_diag_atm_mct(atm(ens1), fractions_ax(ens1), infodata, do_a2x=.true., do_x2a=.true.)
        endif
        if (ice_present) then
           call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_i2x=.true.)
        endif
-       call t_drvstopf  ('CPL:BUDGET2',cplrun=.true.,budget=.true.)
+       call t_drvstopf  ('CPL:BUDGET2',cplrun=lcplrun,budget=.true.)
 
-       call t_drvstartf ('CPL:BUDGET3',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
+       call t_drvstartf ('CPL:BUDGET3',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        call seq_diag_accum_mct()
-       call t_drvstopf  ('CPL:BUDGET3',cplrun=.true.,budget=.true.)
+       call t_drvstopf  ('CPL:BUDGET3',cplrun=lcplrun,budget=.true.)
 
-       call t_drvstartf ('CPL:BUDGETF',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
+       call t_drvstartf ('CPL:BUDGETF',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        if (.not. dead_comps) then
           call seq_diag_print_mct(EClock_d,stop_alarm,budget_inst, &
                budget_daily, budget_month, budget_ann, budget_ltann, &
@@ -4814,25 +4838,37 @@ contains
        endif
        call seq_diag_zero_mct(EClock=EClock_d)
 
-       call t_drvstopf  ('CPL:BUDGETF',cplrun=.true.,budget=.true.)
+       call t_drvstopf  ('CPL:BUDGETF',cplrun=lcplrun,budget=.true.)
     end if
   end subroutine cime_run_calc_budgets2
 
 !----------------------------------------------------------------------------------
 
-  subroutine cime_run_calc_budgets3()
+  subroutine cime_run_calc_budgets3(in_cplrun)
 
     !----------------------------------------------------------
     ! ocn budget (rasm_option2)
     !----------------------------------------------------------
 
+    logical,intent(in),optional :: in_cplrun  ! flag indicating whether routine
+                                              ! called within the scope of the
+                                              ! CPL:RUN timer
+
+    logical :: lcplrun
+    !-------------------------------------------------------------------------------
+
+    lcplrun  = .true.
+    if (present(in_cplrun)) then
+       lcplrun = .not. in_cplrun
+    endif
+    
     if (iamin_CPLID) then
        call cime_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:BUDGET0_BARRIER')
-       call t_drvstartf ('CPL:BUDGET0',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
+       call t_drvstartf ('CPL:BUDGET0',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
        call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), infodata, &
             do_o2x=.true., do_x2o=.true., do_xao=.true.)
-       call t_drvstopf ('CPL:BUDGET0',cplrun=.true.,budget=.true.)
+       call t_drvstopf ('CPL:BUDGET0',cplrun=lcplrun,budget=.true.)
     end if
   end subroutine cime_run_calc_budgets3
 


### PR DESCRIPTION
The following logic in cime_run_atmocn_setup (in cime_comp_mod.F90):

   call t_drvstartf ('CPL:ATMOCNP',cplrun=.true.,barrier=mpicom_CPLID,hashint=hashint(7))
   ...
   if (do_budgets) then
      call cime_run_calc_budgets3()
   endif
   ...
   call t_drvstopf  ('CPL:ATMOCNP',cplrun=.true.,hashint=hashint(7))

and in cime_run_calc_budgets (also in cime_comp_mod.F90):

   call t_drvstartf ('CPL:BUDGET0',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
   ...
   call t_drvstopf ('CPL:BUDGET0',cplrun=.true.,budget=.true.)

nests calls to the CPL:RUN timer, leading to recursion being recorded
in the timing library. This is not a bug, but it is also not necessary.
Everything in the CPL:ATMOCNP timer is marked as being in the CPL:RUN
timer. It adds nothing to redundantly mark the CPL:BUDGET0 timer as
being in the CPL:RUN timer.

Here an optional logical parameter 'in_cplrun' is added to
cime_run_calc_budgets3, and to cime_run_calc_budgets1 and
cime_run_calc_budgets2 for consistency, such that if set to 'true' it
indicates that the call to the routine is already inside of the
CPL:RUN timer and that this should not be set again within the
routine.

Fixes #4496

BFB