### PR TITLE
Update the software environment and compiler versisons on Summit

### DIFF
--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -1598,6 +1598,7 @@ flags should be captured within MPAS CMake files.
   </FFLAGS>
   <CPPDEFS>
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
+    <append > -DTHRUST_IGNORE_CUB_VERSION_CHECK </append>
   </CPPDEFS>
   <SLIBS>
     <append MPILIB="mpi-serial">-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2836,8 +2836,7 @@
       <executable>jsrun</executable>
       <arguments>
         <arg name="exit_on_error">-X 1</arg>
-        <arg name="num_rs">--nrs $ENV{NUM_RS}</arg>
-        <arg name="rs_per_node">--rs_per_host $ENV{RS_PER_NODE}</arg>
+        <arg name="num_rs">$SHELL{if [ {{ total_tasks }} -eq 1 ];then echo --nrs 1 --rs_per_host 1;else echo --nrs $NUM_RS --rs_per_host $RS_PER_NODE;fi}</arg>
         <arg name="tasks_per_rs">--tasks_per_rs $SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
         <arg name="distribute">-d plane:$SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
         <arg name="cpu_per_rs">--cpu_per_rs $ENV{CPU_PER_RS}</arg>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2859,7 +2859,6 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="list"/>
         <command name="load">DefApps</command>
         <command name="load">python/3.7-anaconda3</command>
         <command name="load">subversion/1.14.0</command>
@@ -2867,9 +2866,10 @@
         <command name="load">cmake/3.20.2</command>
         <command name="load">essl/6.3.0</command>
         <command name="load">netlib-lapack/3.8.0</command>
+        <command name="list"/>
       </modules>
       <modules compiler="pgi.*">
-        <command name="load">nvhpc</command>
+        <command name="load">nvhpc/21.3</command>
       </modules>
       <modules compiler="pgigpu">
         <command name="load">cuda/10.1.243</command>
@@ -2883,26 +2883,14 @@
       <modules compiler="ibmgpu">
         <command name="load">cuda/10.1.243</command>
       </modules>
-      <modules compiler="gnu">
-        <command name="load">gcc/9.1.0</command>
-      </modules>
-      <modules compiler="gnugpu">
+      <modules compiler="gnu.*">
         <command name="load">gcc/9.1.0</command>
       </modules>
       <modules>
         <command name="load">netcdf-c/4.8.0</command>
         <command name="load">netcdf-fortran/4.4.5</command>
       </modules>
-      <modules compiler="ibm" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.4.0.3-20210112</command>
-      </modules>
-      <modules compiler="pgi.*" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.4.0.3-20210112</command>
-      </modules>
-      <modules compiler="gnu" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.4.0.3-20210112</command>
-      </modules>
-      <modules compiler="gnugpu" mpilib="!mpi-serial">
+      <modules mpilib="!mpi-serial">
         <command name="load">spectrum-mpi/10.4.0.3-20210112</command>
       </modules>
       <modules>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2828,9 +2828,11 @@
     <MAX_TASKS_PER_NODE>84</MAX_TASKS_PER_NODE>
     <MAX_TASKS_PER_NODE compiler="pgigpu">18</MAX_TASKS_PER_NODE>
     <MAX_TASKS_PER_NODE compiler="gnugpu">42</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE compiler="ibmgpu">42</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>84</MAX_MPITASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE compiler="pgigpu">18</MAX_MPITASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE compiler="gnugpu">42</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="ibmgpu">42</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="spectrum-mpi">
       <executable>jsrun</executable>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2850,34 +2850,33 @@
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
-      <init_path lang="sh">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/lmod/init/sh</init_path>
-      <init_path lang="csh">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/lmod/init/csh</init_path>
-      <init_path lang="python">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/lmod/init/env_modules_python.py</init_path>
-      <init_path lang="perl">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/lmod/init/perl</init_path>
+      <init_path lang="sh">/sw/summit/lmod/8.4/init/sh</init_path>
+      <init_path lang="csh">/sw/summit/lmod/8.4/init/csh</init_path>
+      <init_path lang="python">/sw/summit/lmod/8.4/init/env_modules_python.py</init_path>
+      <init_path lang="perl">/sw/summit/lmod/8.4/init/perl</init_path>
       <cmd_path lang="perl">module</cmd_path>
-      <cmd_path lang="python">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/7.7.10/libexec/lmod python</cmd_path>
+      <cmd_path lang="python">/sw/summit/lmod/8.4/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="ls"/>
+        <command name="list"/>
         <command name="load">DefApps</command>
-        <command name="load">python/3.7.0</command>
-        <command name="load">subversion/1.9.3</command>
-        <command name="load">git/2.13.0</command>
+        <command name="load">python/3.7-anaconda3</command>
+        <command name="load">subversion/1.14.0</command>
+        <command name="load">git/2.31.1</command>
         <command name="load">cmake/3.20.2</command>
-        <command name="load">essl/6.1.0-2</command>
+        <command name="load">essl/6.3.0</command>
         <command name="load">netlib-lapack/3.8.0</command>
       </modules>
       <modules compiler="pgi.*">
-        <command name="load">pgi/19.9</command>
-        <command name="load">pgi-cxx14/default</command>
+        <command name="load">nvhpc</command>
       </modules>
       <modules compiler="pgigpu">
         <command name="load">cuda/10.1.243</command>
       </modules>
       <modules compiler="gnugpu">
-        <command name="load">cuda/10.1.105</command>
+        <command name="load">cuda/11.0.3</command>
       </modules>
       <modules compiler="ibm.*">
         <command name="load">xl/16.1.1-9</command>
@@ -2886,37 +2885,37 @@
         <command name="load">cuda/10.1.243</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gcc/8.1.1</command>
+        <command name="load">gcc/9.1.0</command>
       </modules>
       <modules compiler="gnugpu">
-        <command name="load">gcc/8.1.1</command>
+        <command name="load">gcc/9.1.0</command>
       </modules>
       <modules>
-        <command name="load">netcdf/4.6.1</command>
-        <command name="load">netcdf-fortran/4.4.4</command>
+        <command name="load">netcdf-c/4.8.0</command>
+        <command name="load">netcdf-fortran/4.4.5</command>
       </modules>
       <modules compiler="ibm" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
+        <command name="load">spectrum-mpi/10.4.0.3-20210112</command>
       </modules>
       <modules compiler="pgi.*" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
+        <command name="load">spectrum-mpi/10.4.0.3-20210112</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
+        <command name="load">spectrum-mpi/10.4.0.3-20210112</command>
       </modules>
       <modules compiler="gnugpu" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
+        <command name="load">spectrum-mpi/10.4.0.3-20210112</command>
       </modules>
       <modules>
-        <command name="load">parallel-netcdf/1.8.1</command>
-        <command name="load">hdf5/1.10.4</command>
+        <command name="load">parallel-netcdf/1.12.2</command>
+        <command name="load">hdf5/1.10.7</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
     <environment_variables>
-      <env name="NETCDF_C_PATH">$ENV{OLCF_NETCDF_ROOT}</env>
+      <env name="NETCDF_C_PATH">$ENV{OLCF_NETCDF_C_ROOT}</env>
       <env name="NETCDF_FORTRAN_PATH">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
       <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
       <env name="PGI_ACC_POOL_ALLOC">0</env>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2879,7 +2879,7 @@
         <command name="load">cuda/11.0.3</command>
       </modules>
       <modules compiler="ibm.*">
-        <command name="load">xl/16.1.1-9</command>
+        <command name="load">xl/16.1.1-10</command>
       </modules>
       <modules compiler="ibmgpu">
         <command name="load">cuda/10.1.243</command>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2909,10 +2909,6 @@
       <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
       <env name="PGI_ACC_POOL_ALLOC">0</env>
     </environment_variables>
-    <environment_variables compiler="ibm.*">
-      <env name="XLC_USR_CONFIG">/gpfs/alpine/cli115/world-shared/e3sm/tools/xlc/xlc.cfg.rhel.7.6.gcc.8.1.1.cuda.10.1</env>
-      <env name="LD_LIBRARY_PATH">/sw/summit/gcc/8.1.1/lib64:$ENV{LD_LIBRARY_PATH}</env>
-    </environment_variables>
     <environment_variables mpilib="!mpi-serial">
       <env name="HDF5_PATH">$ENV{OLCF_HDF5_ROOT}</env>
       <env name="PNETCDF_PATH">$ENV{OLCF_PARALLEL_NETCDF_ROOT}</env>


### PR DESCRIPTION
After recent Summit update, some old versions of the software environment and compilers have been removed. So this PR is to update them to the new default versions or versions that have been tested on Summit.  Main updates include:

- update PGI to nvhpc/21.3
- update GNU to 9.1.0
- update IBM to 16.1.1-10
- update spectrum-mpi to 10.4.0.3-20210112
- update the '--nrs' parameter for scm. Thanks Azamat.

Some e3sm_integration test suite  results (total(fail)):
- GNU: build: 95(0), run: 95(14)
```
    FAIL ERP_Ld3.ne30pg2_EC30to60E2r2.WCYCL1850.summit_gnu.allactive-pioroot1 RUN time=135
    FAIL ERS.ne11_oQU240.A_WCYCL1850.summit_gnu RUN time=51
    FAIL NCK.ne11_oQU240.A_WCYCL1850.summit_gnu RUN time=51
    FAIL PEM_Ln9.ne30pg2_EC30to60E2r2.WCYCL1850.summit_gnu RUN time=125
    FAIL PET_Ln9_PS.ne30pg2_EC30to60E2r2.WCYCL1850.summit_gnu.allactive-mach-pet RUN time=61
    FAIL SMS.T62_oQU120_ais20.MPAS_LISIO_TEST.summit_gnu RUN time=25
    FAIL SMS_D_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850.summit_gnu.allactive-wcprod RUN time=5883
    FAIL SMS_D_Ld1.ne30pg2_r05_EC30to60E2r2.A_WCYCL1850S_CMIP6.summit_gnu RUN time=6000
    FAIL SMS_D_Ln5.conusx4v1_conusx4v1.FC5AV1C-L.summit_gnu RUN time=2160
    FAIL SMS_D_Ln5.ne4_ne4.FC5AV1C-L.summit_gnu.eam-clubb_sp RUN time=78
    FAIL SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPECACNT_1850.summit_gnu.elm-bgcexp RUN time=126
    FAIL SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPRDCTC_1850.summit_gnu.elm-bgcexp RUN time=126
    FAIL SMS_P12x2.ne4_oQU240.A_WCYCL1850.summit_gnu.allactive-mach_mods RUN time=41
    FAIL SMS_R_Ld5.ne4_ne4.FSCM5A97.summit_gnu.eam-scm RUN time=566
```
- GNUGPU: build: 64(0), run: 64(10)
```
    FAIL NCK.ne11_oQU240.A_WCYCL1850.summit_gnugpu RUN time=55
    FAIL PEM_Ln9.ne30pg2_EC30to60E2r2.WCYCL1850.summit_gnugpu RUN time=99
    FAIL PET_Ln9_PS.ne30pg2_EC30to60E2r2.WCYCL1850.summit_gnugpu.allactive-mach-pet RUN time=559
    FAIL SMS.T62_oQU120_ais20.MPAS_LISIO_TEST.summit_gnugpu RUN time=23
    FAIL SMS_D_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850.summit_gnugpu.allactive-wcprod RUN time=6486
    FAIL SMS_D_Ld1.ne30pg2_r05_EC30to60E2r2.A_WCYCL1850S_CMIP6.summit_gnugpu RUN time=6781
    FAIL SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPECACNT_1850.summit_gnugpu.elm-bgcexp RUN time=100
    FAIL SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPRDCTC_1850.summit_gnugpu.elm-bgcexp RUN time=84
    FAIL SMS_P12x2.ne4_oQU240.A_WCYCL1850.summit_gnugpu.allactive-mach_mods RUN time=40
    FAIL SMS_R_Ld5.ne4_ne4.FSCM5A97.summit_gnugpu.eam-scm RUN time=11
```
- IBM: build: 95(1), run: 94: (3)
```
    FAIL ERS_Ld20.f45_f45.IELMFATES.summit_ibm.elm-fates RUN time=131
    FAIL SMS.ne4_ne4.FC5AV1C-L.summit_ibm.eam-thetanh_ftype2 RUN time=181
    FAIL SMS_R_Ld5.ne4_ne4.FSCM5A97.summit_ibm.eam-scm RUN time=9
```
- IBMGPU: build: 95(1), run: 94: (20)
```
    FAIL ERP_Ld3.ne30pg2_EC30to60E2r2.WCYCL1850.summit_ibmgpu.allactive-pioroot1 RUN time=7199
    FAIL ERP_Ln9.ne4pg2_ne4pg2.F-MMFXX.summit_ibmgpu.eam-mmf_fixed_subcycle RUN time=7205
    FAIL ERS.ne11_oQU240.A_WCYCL1850.summit_ibmgpu RUN time=7198
    FAIL ERS_Ld20.f45_f45.IELMFATES.summit_ibmgpu.elm-fates RUN time=129
    FAIL ERS_Ln9.ne4pg2_ne4pg2.F-MMF1-RCEMIP.summit_ibmgpu RUN time=1864
    FAIL ERS_Ln9.ne4pg2_ne4pg2.F-MMF1.summit_ibmgpu.eam-mmf_crmout RUN time=1860
    FAIL ERS_Ln9.ne4pg2_ne4pg2.F-MMFXX.summit_ibmgpu.eam-mmf_use_VT RUN time=1859
    FAIL ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMFOMP.summit_ibmgpu RUN time=1862
    FAIL ERS_Ln9_P96x1.ne4pg2_ne4pg2.F-MMFXX.summit_ibmgpu.eam-mmf_use_ESMT RUN time=1864
    FAIL NCK.ne11_oQU240.A_WCYCL1850.summit_ibmgpu RUN time=7200
    FAIL PEM_Ln9.ne30pg2_EC30to60E2r2.WCYCL1850.summit_ibmgpu RUN time=7198
    FAIL PET_Ln9_PS.ne30pg2_EC30to60E2r2.WCYCL1850.summit_ibmgpu.allactive-mach-pet RUN time=1861
    FAIL SMS.T62_oQU120_ais20.MPAS_LISIO_TEST.summit_ibmgpu RUN time=2705
    FAIL SMS_D_Ld1.T62_oEC60to30v3.DTESTM.summit_ibmgpu RUN time=7202
    FAIL SMS_D_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850.summit_ibmgpu.allactive-wcprod RUN time=7198
    FAIL SMS_D_Ld1.ne30pg2_r05_EC30to60E2r2.A_WCYCL1850S_CMIP6.summit_ibmgpu RUN time=7198
    FAIL SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPECACNT_1850.summit_ibmgpu.elm-bgcexp RUN time=7201
    FAIL SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPRDCTC_1850.summit_ibmgpu.elm-bgcexp RUN time=7200
    FAIL SMS_P12x2.ne4_oQU240.A_WCYCL1850.summit_ibmgpu.allactive-mach_mods RUN time=1860
    FAIL SMS_R_Ld5.ne4_ne4.FSCM5A97.summit_ibmgpu.eam-scm RUN time=12
```

- nvhpc, so many run-time error. see issue #4479 