### PR TITLE
Add backup HTTP server with Singularity source tarball

### DIFF
--- a/.circleci/container.sh
+++ b/.circleci/container.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 
-wget -t 3  http://portal.nersc.gov/project/e3sm/lukasz/e3sm.sif
-if [ $? -eq 0 ]; then
-    exit 0;
+wget -t 3 -O e3sm.sif http://portal.nersc.gov/project/e3sm/lukasz/e3sm.sif || \
+    wget -t 3 -O e3sm.sif https://dabdceba-6d04-11e5-ba46-22000b92c6ec.e.globus.org/containers/public/e3sm.sif
+if [ $? -ne 0 ]; then
+    exit -1
 fi
-
-wget -t 3 https://dabdceba-6d04-11e5-ba46-22000b92c6ec.e.globus.org/containers/public/e3sm.sif
-if [ $? -eq 0 ]; then
-    exit 0;
-fi
-
-exit -1

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -2,13 +2,21 @@
 
 go version
 
+export VERSION=3.5.3
+
+function download
+{
+    wget -t 3 -O singularity-${VERSION}.tar.gz http://portal.nersc.gov/project/e3sm/lukasz/singularity-${VERSION}.tar.gz || \
+        wget -t 3 -O singularity-${VERSION}.tar.gz https://dabdceba-6d04-11e5-ba46-22000b92c6ec.e.globus.org/containers/public/singularity-${VERSION}.tar.gz
+    return $?
+}
+
 # Install Singularity
-export VERSION=3.5.3 && # adjust this as necessary \
-    wget https://dabdceba-6d04-11e5-ba46-22000b92c6ec.e.globus.org/containers/public/singularity-${VERSION}.tar.gz && \
+download && \
     tar -xzf singularity-${VERSION}.tar.gz && \
     cd singularity/
-./mconfig && \
-    make -C ./builddir && \
-    sudo make -C ./builddir install
-
-singularity --version
+#./mconfig && \
+#    make -C ./builddir && \
+#    sudo make -C ./builddir install
+#
+#singularity --version


### PR DESCRIPTION
Add the NERSC HTTP as a primary server with the Singularity source code tarball and use the ALCF Petrel HTTP server as a backup server. If the CircleCI test script fails when downloading the tarball from the server, the script falls back to the ALCF Petrel HTTP server.
