### PR TITLE
Ykim/spock/gnu

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -56,6 +56,13 @@
     </directives>
   </batch_system>
 
+   <batch_system MACH="spock" type="slurm">
+     <queues>
+       <queue walltimemax="01:00:00" default="true">ecp</queue>
+       <queue walltimemax="01:00:00">batch</queue>
+     </queues>
+   </batch_system>
+
   <batch_system type="cobalt" >
     <batch_query>qstat</batch_query>
     <batch_submit>qsub</batch_submit>
@@ -72,7 +79,7 @@
       <arg flag="--cwd" name="CASEROOT"/>
       <arg flag="-A" name="CHARGE_ACCOUNT"/>
       <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
-      <arg flag="-n" name=" ($TOTALPES + $MAX_MPITASKS_PER_NODE - 1)/$MAX_MPITASKS_PER_NODE"/>
+      <arg flag="-n" name=" $TOTALPES/$MAX_MPITASKS_PER_NODE"/>
       <arg flag="-q" name="JOB_QUEUE"/>
       <arg flag="--mode script"/>
     </submit_args>
@@ -93,7 +100,7 @@
     <submit_args>
       <arg flag="-A" name="CHARGE_ACCOUNT"/>
       <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
-      <arg flag="-n" name=" ($TOTALPES + $MAX_MPITASKS_PER_NODE - 1)/$MAX_MPITASKS_PER_NODE"/>
+      <arg flag="-n" name=" $TOTALPES/$MAX_MPITASKS_PER_NODE"/>
       <arg flag="-q" name="JOB_QUEUE"/>
       <arg flag="--mode script"/>
     </submit_args>
@@ -271,6 +278,15 @@
       </queues>
     </batch_system>
 
+    <batch_system MACH="swing" type="slurm">
+      <directives>
+        <directive> --gres=gpu:1</directive>
+      </directives>
+      <queues>
+        <queue walltimemax="01:00:00" nodemax="6" default="true" strict="true">gpu</queue>
+      </queues>
+    </batch_system>
+
     <batch_system MACH="anvil" type="slurm" >
       <queues>
 	<queue walltimemax="48:00:00" nodemax="5" default="true" strict="true">acme-small</queue>
@@ -280,8 +296,12 @@
     </batch_system>
 
     <batch_system MACH="chrysalis" type="slurm" >
+      <directives>
+        <directive> --switches=$SHELL{echo "(`./xmlquery --value NUM_NODES` + 19) / 20" |bc}</directive>
+      </directives>
       <queues>
-	<queue walltimemax="03:00:00" nodemin="1" nodemax="512" default="true" strict="true">compute</queue>
+	<queue walltimemax="48:00:00" strict="true" nodemin="1" nodemax="492">compute</queue>
+	<queue walltimemax="04:00:00" strict="true" nodemin="1" nodemax="20" default="true">debug</queue>
       </queues>
     </batch_system>
 
@@ -355,14 +375,10 @@
     <batch_system MACH="jlse" type="cobalt_theta">
       <batch_submit>qsub</batch_submit>
       <queues>
-        <queue walltimemax="01:00:00" jobmin="1" jobmax="20" default="true">skylake_8180</queue>
-      </queues>
-    </batch_system>
-
-    <batch_system MACH="jlse-iris" type="cobalt_theta">
-      <batch_submit>qsub</batch_submit>
-      <queues>
-        <queue walltimemax="01:00:00" jobmin="1" jobmax="20" default="true">iris</queue>
+        <queue walltimemax="01:00:00" jobmin="1" jobmax="12" default="true">skylake_8180</queue>
+        <queue walltimemax="01:00:00" jobmin="1" jobmax="16">iris</queue>
+        <queue walltimemax="01:00:00" jobmin="1" jobmax="18">yarrow</queue>
+        <queue walltimemax="01:00:00" jobmin="1" jobmax="12">arcticus</queue>
       </queues>
     </batch_system>
 
@@ -489,19 +505,28 @@
        <directive>-P {{ project }}</directive>
      </directives>
      <directives compiler="!.*gpu">
-       <directive>-alloc_flags smt2</directive>
+       <directive>-alloc_flags smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</directive>
      </directives>
-     <directives compiler="ibmgpu">
-       <directive>-alloc_flags "gpumps smt2"</directive>
-     </directives>
-     <directives compiler="pgigpu">
-       <directive>-alloc_flags gpumps</directive>
-     </directives>
-     <directives compiler="gnugpu">
-       <directive>-alloc_flags gpumps</directive>
+     <directives compiler=".*gpu">
+       <directive>-alloc_flags "gpumps smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}"</directive>
      </directives>
      <queues>
-       <queue walltimemax="02:00" default="true">batch</queue>
+       <queue walltimemax="02:00" strict="true" default="true">batch</queue>
+     </queues>
+   </batch_system>
+
+   <batch_system MACH="ascent" type="lsf" >
+     <directives>
+       <directive>-P {{ project }}</directive>
+     </directives>
+     <directives compiler="!.*gpu">
+       <directive>-alloc_flags smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</directive>
+     </directives>
+     <directives compiler=".*gpu">
+       <directive>-alloc_flags "gpumps smt$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}"</directive>
+     </directives>
+     <queues>
+       <queue walltimemax="02:00" default="true" strict="true">batch</queue>
      </queues>
    </batch_system>
 

--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -2376,6 +2376,12 @@ flags should be captured within MPAS CMake files.
     <append COMP_NAME="gptl"> -fallow-argument-mismatch </append>
     <append> -Wno-implicit-interface  -fallow-invalid-boz -std=legacy </append>
   </FFLAGS>
+  <MPICC> cc  </MPICC>
+  <MPICXX> CC </MPICXX>
+  <MPIFC> ftn </MPIFC>
+  <SCC> cc </SCC>
+  <SCXX> CC </SCXX>
+  <SFC> ftn </SFC>
 </compiler>
 
 <compiler MACH="userdefined">

--- a/cime_config/machines/config_compilers.xml
+++ b/cime_config/machines/config_compilers.xml
@@ -195,6 +195,9 @@ flags should be captured within MPAS CMake files.
     <!-- http://gcc.gnu.org/onlinedocs/gfortran/ -->
     <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRGNU</append>
   </CPPDEFS>
+  <CPPDEFS>
+    <append DEBUG="TRUE"> -DYAKL_DEBUG </append>
+  </CPPDEFS>
   <CXX_LINKER>FORTRAN</CXX_LINKER>
   <FC_AUTO_R8>
     <base> -fdefault-real-8 </base>
@@ -241,6 +244,12 @@ flags should be captured within MPAS CMake files.
     <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp </append>
     <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt </append>
   </CFLAGS>
+  <CXXFLAGS>
+    <base> -g -qfullpath -qmaxmem=-1 -qphsinfo </base>
+    <append DEBUG="FALSE"> -O2  </append>
+    <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp </append>
+    <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt </append>
+  </CXXFLAGS>
   <CPPDEFS>
     <!-- http://publib.boulder.ibm.com/infocenter/comphelp/v7v91/index.jsp
  Notes:  (see xlf user's guide for the details)
@@ -260,6 +269,7 @@ flags should be captured within MPAS CMake files.
   -qinitauto=...  => initializes automatic variables
   -->
     <append> -DFORTRAN_SAME -DCPRIBM</append>
+    <append COMP_NAME="eam"> -DUSE_CBOOL </append>
   </CPPDEFS>
   <CPRE>-WF,-D</CPRE>
   <FC_AUTO_R8>
@@ -622,7 +632,7 @@ flags should be captured within MPAS CMake files.
 
 <compiler OS="CNL">
   <CMAKE_OPTS>
-    <base> -DCMAKE_SYSTEM_NAME=Catamount</base>
+    <append MPILIB="!impi"> -DCMAKE_SYSTEM_NAME=Catamount </append>
   </CMAKE_OPTS>
   <CPPDEFS>
     <append> -DLINUX </append>
@@ -676,9 +686,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CXX_LIBS>
     <base>-lstdc++</base>
   </CXX_LIBS>
@@ -750,6 +757,9 @@ flags should be captured within MPAS CMake files.
   <LDFLAGS>
     <append compile_threaded="TRUE"> -static-intel</append>
   </LDFLAGS>
+  <MPICC  MPILIB="impi"> mpiicc  </MPICC>
+  <MPICXX MPILIB="impi"> mpiicpc </MPICXX>
+  <MPIFC  MPILIB="impi"> mpiifort </MPIFC>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
   <SLIBS>
     <append> $SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} </append>
@@ -759,83 +769,26 @@ flags should be captured within MPAS CMake files.
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
   <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
-</compiler>
-
-<compiler MACH="anvil" COMPILER="intel18">
-  <CPPDEFS>
-    <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
-  </CPPDEFS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
-  <SLIBS>
-    <append> $SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} </append>
-    <append> $SHELL{$ENV{NETCDF_C_PATH}/bin/nc-config --libs} </append>
-    <append>-Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group -lpthread -lm -ldl</append>
-  </SLIBS>
-  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
-  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
-  <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
-  <CFLAGS>
-    <base> -O2 -fp-model precise -std=gnu99 </base>
-    <append compile_threaded="TRUE"> -qopenmp -static-intel</append>
-    <append compile_threaded="TRUE" DEBUG="TRUE">-heap-arrays</append>
-    <append DEBUG="FALSE"> -O2 -debug minimal </append>
-    <append DEBUG="TRUE"> -O0 -g </append>
-  </CFLAGS>
-  <CXXFLAGS>
-    <base> -std=c++14 -fp-model source </base>
-    <append compile_threaded="TRUE"> -qopenmp -static-intel</append>
-    <append DEBUG="TRUE"> -O0 -g </append>
-    <append DEBUG="FALSE"> -O2 </append>
-  </CXXFLAGS>
-  <CPPDEFS>
-    <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL</append>
-  </CPPDEFS>
-  <CXX_LDFLAGS>
-    <base> -cxxlib </base>
-  </CXX_LDFLAGS>
-  <CXX_LINKER>FORTRAN</CXX_LINKER>
-  <FC_AUTO_R8>
-    <base> -r8 </base>
-  </FC_AUTO_R8>
-  <FFLAGS>
-    <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source </base>
-    <append compile_threaded="TRUE"> -qopenmp -static-intel</append>
-    <append compile_threaded="TRUE" DEBUG="TRUE">-heap-arrays</append>
-    <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
-    <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
-    <append> $SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --fflags} </append>
-  </FFLAGS>
-  <FFLAGS_NOOPT>
-    <base> -O0 </base>
-  </FFLAGS_NOOPT>
-  <FIXEDFLAGS>
-    <base> -fixed -132 </base>
-  </FIXEDFLAGS>
-  <FREEFLAGS>
-    <base> -free </base>
-  </FREEFLAGS>
-  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
-  <LDFLAGS>
-    <append compile_threaded="TRUE"> -qopenmp -static-intel</append>
-  </LDFLAGS>
-  <MPICC> mpicc </MPICC>
-  <MPICXX> mpicxx </MPICXX>
-  <MPIFC> mpif90 </MPIFC>
-  <SCC> icc </SCC>
-  <SCXX> icpc </SCXX>
-  <SFC> ifort </SFC>
-  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
 <compiler MACH="chrysalis" COMPILER="intel">
   <CPPDEFS>
     <append COMP_NAME="gptl">-DHAVE_SLASHPROC</append>
   </CPPDEFS>
+  <CFLAGS>
+    <append>-static-intel</append>
+    <append> -march=core-avx2 </append>
+    <append DEBUG="FALSE"> -O3 </append>
+  </CFLAGS>
+  <CXXFLAGS>
+    <append>-static-intel</append>
+    <append> -axCORE-AVX2 </append>
+    <append DEBUG="FALSE"> -O3 </append>
+  </CXXFLAGS>
   <FFLAGS>
-    <append DEBUG="FALSE">-O2 -debug minimal -qno-opt-dynamic-align</append>
+    <append>-static-intel</append>
+    <append> -axCORE-AVX2 </append>
+    <append DEBUG="FALSE">-O3 -qno-opt-dynamic-align</append>
   </FFLAGS>
   <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
   <SLIBS>
@@ -844,12 +797,6 @@ flags should be captured within MPAS CMake files.
   <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
   <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
   <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
-  <CFLAGS>
-    <append>-static-intel</append>
-  </CFLAGS>
-  <FFLAGS>
-    <append>-static-intel</append>
-  </FFLAGS>
   <LDFLAGS>
     <append>-static-intel </append>
   </LDFLAGS>
@@ -914,9 +861,6 @@ flags should be captured within MPAS CMake files.
 </compiler>
 
 <compiler MACH="blues" COMPILER="pgigpu">
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DGPU </append>
     <append COMP_NAME="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY</append>
@@ -936,6 +880,38 @@ flags should be captured within MPAS CMake files.
   </LDFLAGS>
   <SLIBS>
     <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} -llapack -lblas </append>
+    <append>$SHELL{$ENV{NETCDF_C_PATH}/bin/nc-config --libs} </append>
+  </SLIBS>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
+</compiler>
+
+<compiler MACH="swing" COMPILER="pgigpu">
+  <CPPDEFS>
+    <append> -DGPU </append>
+    <append COMP_NAME="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY</append>
+  </CPPDEFS>
+  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2 -Mvect=nosimd </append>
+  </CFLAGS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2 -Mvect=nosimd -DSUMMITDEV_PGI -DHAVE_IEEE_ARITHMETIC -DNO_R16 </append>
+  </FFLAGS>
+  <FFLAGS>
+    <append DEBUG="TRUE"> -DSUMMITDEV_PGI -DHAVE_IEEE_ARITHMETIC -DNO_R16 </append>
+  </FFLAGS>
+  <LDFLAGS>
+    <append> -Minline -ta=tesla:ccall,fastmath,loadcache:L1,unroll,fma,managed,deepcopy,nonvvm -Mcuda -Minfo=accel </append>
+  </LDFLAGS>
+  <SLIBS>
+    <append>$SHELL{$ENV{NETCDF_FORTRAN_PATH}/bin/nf-config --flibs} -llapack -lblas</append>
     <append>$SHELL{$ENV{NETCDF_C_PATH}/bin/nc-config --libs} </append>
   </SLIBS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
@@ -1000,7 +976,7 @@ flags should be captured within MPAS CMake files.
 
 <compiler MACH="cascade" COMPILER="intel">
   <CONFIG_ARGS>
-    <base> --host=Linux --enable-filesystem-hints=lustre</base>
+    <base> --enable-filesystem-hints=lustre</base>
   </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
@@ -1039,9 +1015,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
   </CPPDEFS>
@@ -1061,9 +1034,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
   </CPPDEFS>
@@ -1083,9 +1053,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 -kind=byte </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
   </CPPDEFS>
@@ -1105,9 +1072,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
   </CPPDEFS>
@@ -1129,9 +1093,6 @@ flags should be captured within MPAS CMake files.
     <append DEBUG="FALSE"> -O2 </append>
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
   </CPPDEFS>
@@ -1159,9 +1120,6 @@ flags should be captured within MPAS CMake files.
     <base>-lstdc++</base>
   </CXX_LIBS>
   <CXX_LINKER>FORTRAN</CXX_LINKER>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
   </CPPDEFS>
@@ -1185,9 +1143,6 @@ flags should be captured within MPAS CMake files.
 
 <compiler MACH="cori-haswell" COMPILER="intel">
   <ALBANY_PATH>/global/cfs/cdirs/e3sm/software/albany-trilinos/albany-install-2020-08-07</ALBANY_PATH>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <FFLAGS>
     <base> -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml </base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align </append>
@@ -1215,16 +1170,19 @@ flags should be captured within MPAS CMake files.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
 </compiler>
 
 <compiler MACH="cori-knl" COMPILER="intel">
-  <ALBANY_PATH>/global/cfs/cdirs/e3sm/software/albany-trilinos/albany-install-2020-08-07</ALBANY_PATH>
+  <ALBANY_PATH>/global/homes/m/mperego/e3sm-software/albany-trilinos/albany-install-2021-01-05</ALBANY_PATH>
+  <CONFIG_ARGS>
+    <base> --host=cray </base>
+  </CONFIG_ARGS>
   <CFLAGS>
     <append MPILIB="impi"> -axMIC-AVX512 -xCORE-AVX2 </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DARCH_MIC_KNL </append>
   </CPPDEFS>
@@ -1262,6 +1220,9 @@ flags should be captured within MPAS CMake files.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
 </compiler>
 
 <compiler MACH="ghost" COMPILER="intel">
@@ -1269,9 +1230,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <ESMF_LIBDIR>/projects/ccsm/esmf-6.3.0rp1/lib/libO/Linux.intel.64.openmpi.default</ESMF_LIBDIR>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
@@ -1358,9 +1316,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CXX_LIBS>
     <base>-lstdc++ -lmpi_cxx</base>
   </CXX_LIBS>
@@ -1411,9 +1366,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CXX_LIBS>
     <base>-lstdc++</base>
   </CXX_LIBS>
@@ -1436,9 +1388,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CXX_LIBS>
     <base>-lstdc++ -lmpi_cxx</base>
   </CXX_LIBS>
@@ -1460,9 +1409,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CXX_LIBS>
     <base>-lstdc++</base>
   </CXX_LIBS>
@@ -1485,9 +1431,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CXX_LIBS>
     <base>-lstdc++ -lmpi_cxx</base>
   </CXX_LIBS>
@@ -1568,9 +1511,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <ESMF_LIBDIR>/projects/ccsm/esmf-6.3.0rp1/lib/libO/Linux.intel.64.openmpi.default</ESMF_LIBDIR>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
@@ -1591,9 +1531,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append> -xCORE-AVX2 </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
     <append COMP_NAME="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
@@ -1627,9 +1564,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
@@ -1637,9 +1571,12 @@ flags should be captured within MPAS CMake files.
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
   <SLIBS>
-    <append MPILIB="mpi-serial">-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
-    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
+    <append MPILIB="mpi-serial">-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
   </SLIBS>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>
   <MPIFC> mpif90 </MPIFC>
@@ -1656,9 +1593,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
@@ -1666,9 +1600,12 @@ flags should be captured within MPAS CMake files.
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
   <SLIBS>
-    <append MPILIB="mpi-serial">-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
-    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
+    <append MPILIB="mpi-serial">-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
   </SLIBS>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
   <MPICXX> mpiCC </MPICXX>
   <!-- These are the same as the parent
   <MPICC> mpicc </MPICC>
@@ -1688,9 +1625,6 @@ flags should be captured within MPAS CMake files.
 </compiler>
 
 <compiler MACH="summit" COMPILER="ibm">
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX  </append>
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
@@ -1704,9 +1638,233 @@ flags should be captured within MPAS CMake files.
     <append>  -Wl,--relax -Wl,--allow-multiple-definition </append>
   </LDFLAGS>
   <SLIBS>
-    <append MPILIB="mpi-serial">-lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
-    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack </append>
+    <append MPILIB="mpi-serial">-lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack </append>
   </SLIBS>
+  <CXX_LIBS>
+    <base>-L/sw/summit/gcc/8.1.1/lib64 -lstdc++ -L$ENV{OLCF_XLC_ROOT}/lib -libmc++</base>
+  </CXX_LIBS>
+  <MPICC> mpicc </MPICC>
+  <MPICXX> mpiCC </MPICXX>
+  <MPIFC> mpif90 </MPIFC>
+  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  <SCC> xlc_r </SCC>
+  <SFC> xlf90_r </SFC>
+  <SCXX> xlc++_r </SCXX>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <KOKKOS_OPTIONS> --arch=Power9 --with-serial </KOKKOS_OPTIONS>
+</compiler>
+
+<compiler MACH="summit" COMPILER="ibmgpu">
+  <CFLAGS>
+    <base> -g -qfullpath -qmaxmem=-1 -qphsinfo </base>
+    <append DEBUG="FALSE"> -O3  </append>
+    <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp </append>
+    <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt </append>
+  </CFLAGS>
+  <CXXFLAGS>
+    <base> -g -qfullpath -qmaxmem=-1 -qphsinfo </base>
+    <append DEBUG="FALSE"> -O2  </append>
+    <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp </append>
+    <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt </append>
+  </CXXFLAGS>
+  <CPPDEFS>
+    <append> -DFORTRAN_SAME -DCPRIBM</append>
+    <append COMP_NAME="eam"> -DUSE_CBOOL </append>
+    <append> -DLINUX  </append>
+    <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
+  </CPPDEFS>
+  <CPRE>-WF,-D</CPRE>
+  <FC_AUTO_R8>
+    <base> -qrealsize=8 </base>
+  </FC_AUTO_R8>
+  <FFLAGS>
+    <base> -g -qfullpath -qmaxmem=-1 -qphsinfo </base>
+    <append DEBUG="FALSE"> -O2 -qstrict -Q </append>
+    <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp </append>
+    <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt </append>
+    <append> -qzerosize -qfree=f90 -qxlf2003=polymorphic</append>
+    <append> -qspillsize=2500 -qextname=flush </append>
+    <append COMP_NAME="cice" compile_threaded="TRUE"> -qsmp=omp:noopt </append>
+  </FFLAGS>
+  <FFLAGS_NOOPT>
+    <base> -O0 </base>
+  </FFLAGS_NOOPT>
+  <FIXEDFLAGS>
+    <base>  -qsuffix=f=f -qfixed=132 </base>
+  </FIXEDFLAGS>
+  <FREEFLAGS>
+    <base> -qsuffix=f=f90:cpp=F90  </base>
+  </FREEFLAGS>
+  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
+  <LDFLAGS>
+    <append> -Wl,--relax -Wl,--allow-multiple-definition </append>
+    <append>-qsmp -qoffload -lcudart -L$ENV{CUDA_DIR}/lib64</append>
+  </LDFLAGS>
+  <SLIBS>
+    <append MPILIB="mpi-serial">-lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack </append>
+  </SLIBS>
+  <CXX_LIBS>
+    <base>-L/sw/summit/gcc/8.1.1/lib64 -lstdc++ -L$ENV{OLCF_XLC_ROOT}/lib -libmc++</base>
+  </CXX_LIBS>
+  <MPICC> mpicc </MPICC>
+  <MPICXX> mpiCC </MPICXX>
+  <MPIFC> mpif90 </MPIFC>
+  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  <SCC> xlc_r </SCC>
+  <SFC> xlf90_r </SFC>
+  <SCXX> xlc++_r </SCXX>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <KOKKOS_OPTIONS> --arch=Power9 --with-serial </KOKKOS_OPTIONS>
+</compiler>
+
+<compiler MACH="summit" COMPILER="pgi">
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2 -Mvect=nosimd </append>
+  </CFLAGS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2 -DSUMMITDEV_PGI </append>
+  </FFLAGS>
+  <CPPDEFS>
+    <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
+  </CPPDEFS>
+  <SLIBS>
+    <append> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+  </SLIBS>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
+  <MPICC> mpicc </MPICC>
+  <MPICXX> mpiCC </MPICXX>
+  <MPIFC> mpif90 </MPIFC>
+  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  <SCC> pgcc </SCC>
+  <SCXX> pgc++ </SCXX>
+  <SFC> pgfortran </SFC>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+</compiler>
+
+<compiler MACH="summit" COMPILER="pgigpu">
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2 -Mvect=nosimd </append>
+  </CFLAGS>
+  <CPPDEFS>
+    <append> -DGPU </append>
+    <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
+  </CPPDEFS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2 -Mvect=nosimd -DSUMMITDEV_PGI -DHAVE_IEEE_ARITHMETIC -DNO_R16 </append>
+  </FFLAGS>
+  <FFLAGS>
+    <append DEBUG="TRUE"> -DSUMMITDEV_PGI -DHAVE_IEEE_ARITHMETIC -DNO_R16 </append>
+  </FFLAGS>
+  <LDFLAGS>
+    <append> -Minline -ta=nvidia,cc70,fastmath,loadcache:L1,unroll,fma,managed,ptxinfo -Mcuda -Minfo=accel </append>
+  </LDFLAGS>
+  <SLIBS>
+    <append> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+  </SLIBS>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
+  <KOKKOS_OPTIONS> --arch=Power9,Volta70 --with-cuda=$ENV{CUDA_DIR} --with-cuda-options=enable_lambda</KOKKOS_OPTIONS>
+  <MPICC> mpicc </MPICC>
+  <MPICXX> mpiCC </MPICXX>
+  <MPIFC> mpif90 </MPIFC>
+  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  <SCC> pgcc </SCC>
+  <SFC> pgfortran </SFC>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+</compiler>
+
+<compiler MACH="ascent" COMPILER="gnu">
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2  </append>
+  </CFLAGS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2 </append>
+  </FFLAGS>
+  <CPPDEFS>
+    <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
+  </CPPDEFS>
+  <SLIBS>
+    <append MPILIB="mpi-serial">-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+  </SLIBS>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
+  <MPICC> mpicc </MPICC>
+  <MPICXX> mpiCC </MPICXX>
+  <MPIFC> mpif90 </MPIFC>
+  <SCC> gcc </SCC>
+  <SCXX> g++ </SCXX>
+  <SFC> gfortran </SFC>
+  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+</compiler>
+
+<compiler MACH="ascent" COMPILER="gnugpu">
+  <CFLAGS>
+    <append DEBUG="FALSE"> -O2  </append>
+  </CFLAGS>
+  <FFLAGS>
+    <append DEBUG="FALSE"> -O2 </append>
+  </FFLAGS>
+  <CPPDEFS>
+    <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
+  </CPPDEFS>
+  <SLIBS>
+    <append MPILIB="mpi-serial">-L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+  </SLIBS>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
+  <MPICXX> mpiCC </MPICXX>
+  <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
+  <NETCDF_C_PATH>$ENV{NETCDF_C_PATH}</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>$ENV{NETCDF_FORTRAN_PATH}</NETCDF_FORTRAN_PATH>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <CUDA_FLAGS>
+    <append> -O3 -arch sm_70 --use_fast_math </append>
+  </CUDA_FLAGS>
+  <USE_CUDA>TRUE</USE_CUDA>
+</compiler>
+
+<compiler MACH="ascent" COMPILER="ibm">
+  <CPPDEFS>
+    <append> -DLINUX  </append>
+    <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
+  </CPPDEFS>
+  <FFLAGS>
+    <append> -qzerosize -qfree=f90 -qxlf2003=polymorphic</append>
+    <append> -qspillsize=2500 -qextname=flush </append>
+    <append COMP_NAME="cice" compile_threaded="TRUE"> -qsmp=omp:noopt </append>
+  </FFLAGS>
+  <LDFLAGS>
+    <append>  -Wl,--relax -Wl,--allow-multiple-definition </append>
+  </LDFLAGS>
+  <SLIBS>
+    <append MPILIB="mpi-serial">-lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack </append>
+  </SLIBS>
+  <CXX_LIBS>
+    <base>-lstdc++ -L$ENV{OLCF_XLC_ROOT}/lib -libmc++</base>
+  </CXX_LIBS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>
   <MPIFC> mpif90 </MPIFC>
@@ -1719,15 +1877,22 @@ flags should be captured within MPAS CMake files.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
-<compiler MACH="summit" COMPILER="ibmgpu">
+<compiler MACH="ascent" COMPILER="ibmgpu">
   <CFLAGS>
     <base> -g -qfullpath -qmaxmem=-1 -qphsinfo </base>
     <append DEBUG="FALSE"> -O3  </append>
     <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp </append>
     <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt </append>
   </CFLAGS>
+  <CXXFLAGS>
+    <base> -g -qfullpath -qmaxmem=-1 -qphsinfo </base>
+    <append DEBUG="FALSE"> -O2  </append>
+    <append DEBUG="FALSE" compile_threaded="TRUE"> -qsmp=omp </append>
+    <append DEBUG="TRUE" compile_threaded="TRUE"> -qsmp=omp:noopt </append>
+  </CXXFLAGS>
   <CPPDEFS>
     <append> -DFORTRAN_SAME -DCPRIBM</append>
+    <append COMP_NAME="eam"> -DUSE_CBOOL </append>
     <append> -DLINUX  </append>
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
@@ -1755,17 +1920,17 @@ flags should be captured within MPAS CMake files.
     <base> -qsuffix=f=f90:cpp=F90  </base>
   </FREEFLAGS>
   <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <LDFLAGS>
     <append> -Wl,--relax -Wl,--allow-multiple-definition </append>
     <append>-qsmp -qoffload -lcudart -L$ENV{CUDA_DIR}/lib64</append>
   </LDFLAGS>
   <SLIBS>
-    <append MPILIB="mpi-serial">-lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
-    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack </append>
+    <append MPILIB="mpi-serial">-lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
+    <append MPILIB="!mpi-serial"> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -lxlopt -lxl -lxlsmp -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack </append>
   </SLIBS>
+  <CXX_LIBS>
+    <base>-lstdc++ -L$ENV{OLCF_XLC_ROOT}/lib -libmc++</base>
+  </CXX_LIBS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>
   <MPIFC> mpif90 </MPIFC>
@@ -1778,13 +1943,10 @@ flags should be captured within MPAS CMake files.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
-<compiler MACH="summit" COMPILER="pgi">
+<compiler MACH="ascent" COMPILER="pgi">
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 -Mvect=nosimd </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 -DSUMMITDEV_PGI </append>
   </FFLAGS>
@@ -1792,15 +1954,12 @@ flags should be captured within MPAS CMake files.
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
   <SLIBS>
-    <append> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
+    <append> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
   </SLIBS>
   <CXX_LINKER>FORTRAN</CXX_LINKER>
-  <!--
-  Summit (backup in case defaults are not picking up):
   <CXX_LIBS>
-    <base>/sw/summit/gcc/6.4.0/lib/gcc/powerpc64le-none-linux-gnu/6.4.0/crtbegin.o -L/sw/summit/gcc/6.4.0/lib64 -lstdc++ -latomic</base>
+    <base>-lstdc++</base>
   </CXX_LIBS>
-  -->
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>
   <MPIFC> mpif90 </MPIFC>
@@ -1813,14 +1972,11 @@ flags should be captured within MPAS CMake files.
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
-<compiler MACH="summit" COMPILER="pgigpu">
+<compiler MACH="ascent" COMPILER="pgigpu">
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 -Mvect=nosimd </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-    <CPPDEFS>
+  <CPPDEFS>
     <append> -DGPU </append>
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
@@ -1834,9 +1990,12 @@ flags should be captured within MPAS CMake files.
     <append> -Minline -ta=nvidia,cc70,fastmath,loadcache:L1,unroll,fma,managed,ptxinfo -Mcuda -Minfo=accel </append>
   </LDFLAGS>
   <SLIBS>
-    <append> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{NETLIB_LAPACK_PATH}/lib -llapack</append>
+    <append> -L$ENV{PNETCDF_PATH}/lib -lpnetcdf -L$ENV{HDF5_PATH}/lib -lhdf5_hl -lhdf5 -L$ENV{NETCDF_C_PATH}/lib -lnetcdf -L$ENV{NETCDF_FORTRAN_PATH}/lib -lnetcdff -L$ENV{ESSL_PATH}/lib64 -lessl -L$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib -llapack</append>
   </SLIBS>
   <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <CXX_LIBS>
+    <base>-lstdc++</base>
+  </CXX_LIBS>
   <KOKKOS_OPTIONS> --arch=Power9,Volta70 --with-cuda=$ENV{CUDA_DIR} --with-cuda-options=enable_lambda</KOKKOS_OPTIONS>
   <MPICC> mpicc </MPICC>
   <MPICXX> mpiCC </MPICXX>
@@ -1853,9 +2012,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DNO_SHR_VMATH -DCNL </append>
   </CPPDEFS>
@@ -1878,9 +2034,6 @@ flags should be captured within MPAS CMake files.
   <CFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DNO_SHR_VMATH -DCNL </append>
   </CPPDEFS>
@@ -1900,9 +2053,6 @@ flags should be captured within MPAS CMake files.
 </compiler>
 
 <compiler MACH="theta" COMPILER="gnu">
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
     <append DEBUG="TRUE"> -O0 </append>
@@ -1921,13 +2071,13 @@ flags should be captured within MPAS CMake files.
 
 <compiler MACH="theta" COMPILER="intel">
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DARCH_MIC_KNL </append>
   </CPPDEFS>
   <FFLAGS>
-    <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent</base>
+    <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent -fimf-use-svml=true</base>
     <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align -fp-speculation=off</append>
     <append> -DHAVE_ERF_INTRINSICS </append>
   </FFLAGS>
@@ -1941,9 +2091,6 @@ flags should be captured within MPAS CMake files.
 </compiler>
 
 <compiler MACH="tulip" COMPILER="gnu">
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append COMP_NAME="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
@@ -1958,9 +2105,6 @@ flags should be captured within MPAS CMake files.
 </compiler>
 
 <compiler MACH="theta" COMPILER="cray">
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CFLAGS>
     <append DEBUG="FALSE"> -O1 </append>
   </CFLAGS>
@@ -1978,61 +2122,34 @@ flags should be captured within MPAS CMake files.
   </CXXFLAGS>
 </compiler>
 
-<compiler MACH="jlse" COMPILER="intel">
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
-  <CPPDEFS>
-    <append> -DHAVE_SLASHPROC </append>
-  </CPPDEFS>
+<!-- CRL  Add new compiler "oneapi-ifort" for "jlse" machine configuration -->
+<compiler COMPILER="oneapi-ifort">
   <FFLAGS>
-    <base>-convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model consistent</base>
-    <append DEBUG="FALSE"> -O2 -debug minimal -qno-opt-dynamic-align -fp-speculation=off</append>
-  </FFLAGS>
-  <MPIFC  MPILIB="impi">mpiifort</MPIFC>
-  <MPICC  MPILIB="impi">mpiicc</MPICC>
-  <MPICXX MPILIB="impi">mpiicpc</MPICXX>
-  <SCC>icc</SCC>
-  <SCXX>icpc</SCXX>
-  <SFC>ifort</SFC>
-  <SLIBS>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -Wl,-rpath -Wl,$ENV{NETCDF_PATH}/lib -mkl</append>
-    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nc-config --libs}</append>
-  </SLIBS>
-  <NETCDF_PATH>$ENV{NETCDF_PATH}</NETCDF_PATH>
-  <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
-</compiler>
-
-<compiler MACH="jlse-iris" COMPILER="intelgpu">
-  <FFLAGS>
-    <base>-convert big_endian -assume byterecl -assume realloc_lhs -fp-model consistent</base>
+    <base>-convert big_endian -assume byterecl -traceback -assume realloc_lhs -fp-model consistent</base>
     <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="FALSE"> -O2 </append>
     <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
   </FFLAGS>
   <CFLAGS>
-    <base> -fp-model precise -std=gnu99 </base>
+    <base> -fp-model precise -std=gnu99 -traceback </base>
     <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="FALSE"> -O2 </append>
     <append DEBUG="TRUE"> -O0 -g </append>
   </CFLAGS>
   <CXXFLAGS>
-    <base> -std=c++14 -fp-model source </base>
+    <base> -std=c++14 -fp-model precise -traceback </base>
     <append compile_threaded="TRUE"> -qopenmp </append>
     <append DEBUG="FALSE"> -O2 </append>
     <append DEBUG="TRUE"> -O0 -g </append>
   </CXXFLAGS>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
   <CXX_LDFLAGS>
     <base> -cxxlib </base>
   </CXX_LDFLAGS>
-  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
-  <CXX_LINKER>FORTRAN</CXX_LINKER>
   <CPPDEFS>
     <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL -DHAVE_SLASHPROC </append>
   </CPPDEFS>
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <FC_AUTO_R8>
     <base> -r8 </base>
   </FC_AUTO_R8>
@@ -2046,12 +2163,12 @@ flags should be captured within MPAS CMake files.
     <base> -free </base>
   </FREEFLAGS>
   <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
-  <MPIFC>mpiifx</MPIFC>
-  <MPICC>mpiicx</MPICC>
-  <MPICXX>mpiicpx</MPICXX>
-  <SCC>icx</SCC>
-  <SCXX>icpx</SCXX>
-  <SFC>ifx</SFC>
+  <MPIFC>mpif90</MPIFC>
+  <MPICC>mpicc</MPICC>
+  <MPICXX>mpicxx</MPICXX>
+  <SCC>icc</SCC>
+  <SCXX>icpc</SCXX>
+  <SFC>ifort</SFC>
   <LDFLAGS>
     <append compile_threaded="TRUE"> -qopenmp </append>
   </LDFLAGS>
@@ -2062,11 +2179,71 @@ flags should be captured within MPAS CMake files.
   <NETCDF_PATH>$ENV{NETCDF_PATH}</NETCDF_PATH>
   <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
 </compiler>
+<!-- CRL  End of "oneapi-ifort" compiler -->
+
+<!-- CRL  Add new compiler "oneapi-ifx" for "jlse" machine configuration -->
+<compiler COMPILER="oneapi-ifx">
+  <FFLAGS>
+    <base> -traceback -convert big_endian -assume byterecl -assume realloc_lhs -fp-model precise</base>
+    <append compile_threaded="TRUE"> -qopenmp </append>
+    <append DEBUG="FALSE"> -O2 </append>
+    <append DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </append>
+  </FFLAGS>
+  <CFLAGS>
+    <base> -traceback -fp-model precise -std=gnu99 </base>
+    <append compile_threaded="TRUE"> -qopenmp </append>
+    <append DEBUG="FALSE"> -O2 </append>
+    <append DEBUG="TRUE"> -O0 -g </append>
+  </CFLAGS>
+  <CXXFLAGS>
+    <base> -traceback -std=c++17 -fp-model precise </base>
+    <append compile_threaded="TRUE"> -qopenmp </append>
+    <append DEBUG="FALSE"> -O2 </append>
+    <append DEBUG="TRUE"> -O0 -g </append>
+  </CXXFLAGS>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <CXX_LDFLAGS>
+    <base> -cxxlib </base>
+  </CXX_LDFLAGS>
+  <CPPDEFS>
+    <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL -DHAVE_SLASHPROC </append>
+  </CPPDEFS>
+  <FC_AUTO_R8>
+    <base> -r8 </base>
+  </FC_AUTO_R8>
+  <FFLAGS_NOOPT>
+    <base> -O0 </base>
+  </FFLAGS_NOOPT>
+  <FIXEDFLAGS>
+    <base> -fixed -132 </base>
+  </FIXEDFLAGS>
+  <FREEFLAGS>
+    <base> -free </base>
+  </FREEFLAGS>
+  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
+  <!-- CRL begin modifications to use OneAPI compilers -->
+  <MPIFC>mpiifx</MPIFC>
+  <MPICC>mpiicx</MPICC>
+  <MPICXX>mpiicpx</MPICXX>
+  <SCC>icx</SCC>
+  <SCXX>icpx</SCXX>
+  <SFC>ifx</SFC>
+  <!-- CRL end modifications to use OneAPI compilers -->
+  <LDFLAGS>
+    <append compile_threaded="TRUE"> -qopenmp </append>
+  </LDFLAGS>
+  <SLIBS>
+    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -Wl,-rpath -Wl,$ENV{NETCDF_PATH}/lib -qmkl</append>
+    <append>$SHELL{$ENV{NETCDF_PATH}/bin/nc-config --libs}</append>
+    <append> -fiopenmp -fopenmp-targets=spir64 </append>
+  </SLIBS>
+  <NETCDF_PATH>$ENV{NETCDF_PATH}</NETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
+</compiler>
+<!-- CRL  End of "oneapi-ifx" compiler -->
 
 <compiler MACH="jlse" COMPILER="gnu">
-  <CONFIG_ARGS>
-    <base> --host=Linux </base>
-  </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
@@ -2079,7 +2256,7 @@ flags should be captured within MPAS CMake files.
   <SLIBS>
     <append>$SHELL{$ENV{NETCDF_PATH}/bin/nf-config --flibs} -Wl,-rpath -Wl,$ENV{NETCDF_PATH}/lib</append>
     <append>$SHELL{$ENV{NETCDF_PATH}/bin/nc-config --libs}</append>
-    <append>-L/gpfs/jlse-fs0/projects/climate/soft/libs -llapack -lblas</append>
+    <append>-L/home/azamat/soft/libs -llapack -lblas</append>
   </SLIBS>
   <NETCDF_PATH>$ENV{NETCDF_PATH}</NETCDF_PATH>
   <PNETCDF_PATH>$ENV{PNETCDF_PATH}</PNETCDF_PATH>
@@ -2192,6 +2369,13 @@ flags should be captured within MPAS CMake files.
   <NETCDF_PATH>$ENV{NETCDF_PATH}</NETCDF_PATH>
   <!--<SCC MPILIB="mpi-serial">gcc</SCC>
   <SFC MPILIB="mpi-serial">gfortran</SFC>-->
+</compiler>
+
+<compiler COMPILER="gnu" MACH="spock">
+  <FFLAGS>
+    <append COMP_NAME="gptl"> -fallow-argument-mismatch </append>
+    <append> -Wno-implicit-interface  -fallow-invalid-boz -std=legacy </append>
+  </FFLAGS>
 </compiler>
 
 <compiler MACH="userdefined">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -100,9 +100,11 @@
       </modules>
 
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu/8.1.0</command>
-        <command name="load">cray-hdf5/1.12.0.4</command>
-        <command name="load">cray-netcdf/4.7.4.4</command>
+        <command name="load">PrgEnv-gnu/8.0.0</command>
+        <command name="load">cray-mpich/8.1.7</command>
+        <command name="load">cray-hdf5/1.12.0.6</command>
+        <command name="load">cray-netcdf/4.7.4.5</command>
+        <command name="load">cray-libsci/21.06.1.1</command>
         <command name="load">zlib/1.2.11</command>
         <command name="load">subversion/1.14.0</command>
         <command name="load">git/2.31.1</command>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -55,6 +55,65 @@
      This allows using a different mpirun command to launch unit tests
 
   -->
+  <machine MACH="spock">
+    <DESC>Spock. NCCS moderate-security system that contains similar hardware and software as the upcoming Frontier system at ORNL.</DESC>
+    <NODENAME_REGEX>.*spock.*</NODENAME_REGEX>
+    <OS>CNL</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <PROJECT>cli133</PROJECT>
+    <CIME_OUTPUT_ROOT>/gpfs/alpine/$PROJECT/scratch/$ENV{USER}/e3sm_scratch</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/gpfs/alpine/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/gpfs/alpine/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <CCSM_CPRNC>/gpfs/alpine/cli133/world-shared/grnydawn/e3sm/tools/cprnc_spock/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <NTEST_PARALLEL_JOBS>1</NTEST_PARALLEL_JOBS>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>e3sm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="label"> --label</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ num_nodes }}</arg>
+      </arguments>
+    </mpirun>
+
+    <module_system type="module" allow_error="true">
+      <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/usr/share/lmod/lmod/init/csh</init_path>
+      <init_path lang="perl">/usr/share/lmod/lmod/init/perl</init_path>
+      <init_path lang="python">/usr/share/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+
+      <modules>
+        <command name="purge"/>
+        <command name="load">DefApps</command>
+        <command name="load">cray-python</command>
+      </modules>
+
+      <modules compiler="gnu">
+        <command name="load">PrgEnv-gnu/8.1.0</command>
+        <command name="load">cray-hdf5/1.12.0.4</command>
+        <command name="load">cray-netcdf/4.7.4.4</command>
+        <command name="load">zlib/1.2.11</command>
+        <command name="load">subversion/1.14.0</command>
+        <command name="load">git/2.31.1</command>
+        <command name="load">cmake/3.20.2</command>
+      </modules>
+    </module_system>
+
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+  </machine>
   <machine MACH="cori-haswell">
     <DESC>Cori. XC40 Cray system at NERSC. Haswell partition. os is CNL, 32 pes/node, batch system is SLURM</DESC>
     <NODENAME_REGEX>cori-knl-is-default</NODENAME_REGEX>
@@ -179,7 +238,8 @@
         <command name="rm">git</command>
         <command name="load">git</command>
         <command name="rm">cmake</command>
-        <command name="load">cmake/3.14.4</command>
+        <command name="load">cmake/3.20.2</command>
+        <command name="load">perl5-extras</command>
       </modules>
     </module_system>
 
@@ -331,7 +391,8 @@
         <command name="rm">git</command>
         <command name="load">git</command>
         <command name="rm">cmake</command>
-        <command name="load">cmake/3.14.4</command>
+        <command name="load">cmake/3.20.2</command>
+        <command name="load">perl5-extras</command>
       </modules>
 
       <!--command name="list">&gt;&amp; ml.txt</command-->
@@ -350,7 +411,7 @@
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
-      <env name="CRAYPE_LINK_TYPE">static</env>      
+      <env name="CRAYPE_LINK_TYPE">static</env>
     </environment_variables>
 
     <environment_variables mpilib="mpt">
@@ -521,7 +582,7 @@
     <BASELINE_ROOT>$ENV{HOME}/projects/e3sm/baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
     <GMAKE>make</GMAKE>
-    <GMAKE_J>16</GMAKE_J>
+    <GMAKE_J>4</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <SUPPORTED_BY>lukasz at uchicago dot edu</SUPPORTED_BY>
@@ -557,7 +618,7 @@
     <DESC>Linux workstation for Jenkins testing</DESC>
     <NODENAME_REGEX>(melvin|watson|s999964|climate|penn|sems)</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <PROXY>sonproxy.sandia.gov:80</PROXY>
+    <PROXY>proxy.sandia.gov:80</PROXY>
     <COMPILERS>gnu,intel</COMPILERS>
     <MPILIBS>openmpi</MPILIBS>
     <SAVE_TIMING_DIR>/sems-data-store/ACME/timings</SAVE_TIMING_DIR>
@@ -596,7 +657,7 @@
         <command name="load">acme-env</command>
         <command name="load">sems-git</command>
         <command name="load">acme-binutils</command>
-        <command name="load">sems-python/2.7.9</command>
+        <command name="load">sems-python/3.5.2</command>
         <command name="load">sems-cmake/3.12.2</command>
       </modules>
       <modules compiler="gnu">
@@ -631,7 +692,7 @@
     <DESC>Huge Linux workstation for Sandia climate scientists</DESC>
     <NODENAME_REGEX>mappy</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <PROXY>wwwproxy.sandia.gov:80</PROXY>
+    <PROXY>proxy.sandia.gov:80</PROXY>
     <COMPILERS>gnu,intel</COMPILERS>
     <MPILIBS>openmpi</MPILIBS>
     <SAVE_TIMING_DIR>/sems-data-store/ACME/mappy/timings</SAVE_TIMING_DIR>
@@ -669,8 +730,8 @@
         <command name="load">sems-env</command>
         <command name="load">acme-env</command>
         <command name="load">sems-git</command>
-        <command name="load">sems-python/2.7.9</command>
-        <command name="load">sems-cmake/3.12.2</command>
+        <command name="load">sems-python/3.5.2</command>
+        <command name="load">sems-cmake/3.19.1</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">acme-gcc/8.1.0</command>
@@ -819,9 +880,6 @@
       <init_path lang="sh">/software/common/adm/packages/softenv-1.6.2/etc/softenv-load.sh</init_path>
       <cmd_path lang="csh">source /software/common/adm/packages/softenv-1.6.2/etc/softenv-aliases.csh ; soft</cmd_path>
       <cmd_path lang="sh">source /software/common/adm/packages/softenv-1.6.2/etc/softenv-aliases.sh ; soft</cmd_path>
-      <modules>
-        <command name="add">+cmake-3.12.4</command>
-      </modules>
       <modules compiler="gnu">
         <command name="add">+gcc-8.2.0</command>
       </modules>
@@ -829,6 +887,7 @@
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <environment_variables mpilib="mpi-serial">
+      <env name="PATH">/soft/apps/packages/climate/cmake/3.18.4/bin:/soft/apps/packages/climate/gmake/bin:$ENV{PATH}</env>
       <!-- We currently don't have a soft env for serial hdf5 and szip built with gcc 8.2.0 -->
       <env name="LD_LIBRARY_PATH">/soft/apps/packages/climate/hdf5/1.8.16-serial/gcc-8.2.0/lib:/soft/apps/packages/climate/szip/2.1/gcc-8.2.0/lib:$ENV{LD_LIBRARY_PATH}</env>
       <!-- We currently don't have a soft env for netcdf serial built with gcc 8.2.0 -->
@@ -838,7 +897,7 @@
       <!-- We currently don't have a soft env for parallel hdf5 and szip built with gcc 8.2.0 -->
       <env name="LD_LIBRARY_PATH">/soft/apps/packages/climate/hdf5/1.8.16-parallel/mpich-3.3.2/gcc-8.2.0/lib:/soft/apps/packages/climate/szip/2.1/gcc-8.2.0/lib:$ENV{LD_LIBRARY_PATH}</env>
       <!-- We currently don't have a soft env for mpich 3.3.2 built with gcc 8.2.0 -->
-      <env name="PATH">/soft/apps/packages/climate/mpich/3.3.2/gcc-8.2.0/bin:$ENV{PATH}</env>
+      <env name="PATH">/soft/apps/packages/climate/mpich/3.3.2/gcc-8.2.0/bin:/soft/apps/packages/climate/cmake/3.18.4/bin:/soft/apps/packages/climate/gmake/bin:$ENV{PATH}</env>
       <!-- We currently don't have a soft env for parallel hdf5 built with mpich 3.3.2 and gcc 8.2.0 -->
       <env name="HDF5_PATH">/soft/apps/packages/climate/hdf5/1.8.16-parallel/mpich-3.3.2/gcc-8.2.0</env>
       <!-- We currently don't have a soft env for netcdf parallel built with mpich 3.3.2 and gcc 8.2.0 -->
@@ -848,7 +907,7 @@
     </environment_variables>
     <environment_variables mpilib="openmpi">
       <!-- We currently don't have a soft env for openmpi 2.1.5, zlib, szip, hdf5, NetCDF and PnetCDF libraries -->
-      <env name="PATH">/soft/apps/packages/climate/openmpi/2.1.5/gcc-8.2.0/bin:$ENV{PATH}</env>
+      <env name="PATH">/soft/apps/packages/climate/openmpi/2.1.5/gcc-8.2.0/bin:/soft/apps/packages/climate/cmake/3.18.4/bin:/soft/apps/packages/climate/gmake/bin:$ENV{PATH}</env>
       <env name="ZLIB_PATH">/soft/apps/packages/climate/zlib/1.2.11/gcc-8.2.0-static</env>
       <env name="SZIP_PATH">/soft/apps/packages/climate/szip/2.1/gcc-8.2.0-static</env>
       <env name="HDF5_PATH">/soft/apps/packages/climate/hdf5/1.8.12-parallel/openmpi-2.1.5/gcc-8.2.0-static</env>
@@ -864,10 +923,10 @@
     <DESC>SNL clust</DESC>
     <NODENAME_REGEX>(skybridge|chama)</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <PROXY>wwwproxy.sandia.gov:80</PROXY>
+    <PROXY>proxy.sandia.gov:80</PROXY>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>openmpi</MPILIBS>
-    <PROJECT>fy190158</PROJECT>
+    <PROJECT>fy210162</PROJECT>
     <SAVE_TIMING_DIR>/projects/ccsm/timings</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>/gpfs1/$USER/acme_scratch/sandiatoss3</CIME_OUTPUT_ROOT>
@@ -907,9 +966,8 @@
         <command name="load">sems-env</command>
         <command name="load">acme-env</command>
         <command name="load">sems-git</command>
-        <command name="load">sems-python/2.7.9</command>
-        <command name="load">sems-cmake/3.12.2</command>
-        <command name="load">gnu/4.9.2</command>
+        <command name="load">sems-cmake/3.19.1</command>
+        <command name="load">gnu/6.3.1</command>
         <command name="load">sems-intel/17.0.0</command>
       </modules>
       <modules mpilib="!mpi-serial">
@@ -941,10 +999,10 @@
     <DESC>SNL clust</DESC>
     <NODENAME_REGEX>ghost-login</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <PROXY>wwwproxy.sandia.gov:80</PROXY>
+    <PROXY>proxy.sandia.gov:80</PROXY>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>openmpi</MPILIBS>
-    <PROJECT>fy190158</PROJECT>
+    <PROJECT>fy210162</PROJECT>
 
     <CIME_OUTPUT_ROOT>/gscratch/$USER/acme_scratch/ghost</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/projects/ccsm/inputdata</DIN_LOC_ROOT>
@@ -982,7 +1040,7 @@
         <command name="purge"/>
         <command name="load">sems-env</command>
         <command name="load">sems-git</command>
-        <command name="load">sems-python/2.7.9</command>
+        <command name="load">sems-python/3.5.2</command>
         <command name="load">sems-cmake</command>
         <command name="load">gnu/4.9.2</command>
         <command name="load">sems-intel/16.0.2</command>
@@ -1010,14 +1068,16 @@
 
   <machine MACH="anvil">
     <DESC>ANL/LCRC Linux Cluster</DESC>
-    <NODENAME_REGEX>blueslogin.*.lcrc.anl.gov</NODENAME_REGEX>
+    <NODENAME_REGEX>b.*.lcrc.anl.gov</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>intel,intel18,gnu</COMPILERS>
-    <MPILIBS>mvapich</MPILIBS>
+    <COMPILERS>intel,gnu</COMPILERS>
+    <MPILIBS>impi,openmpi,mvapich</MPILIBS>
     <PROJECT>condo</PROJECT>
     <SAVE_TIMING_DIR>/lcrc/group/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>/lcrc/group/e3sm/$USER/scratch/anvil</CIME_OUTPUT_ROOT>
+    <CIME_HTML_ROOT>/lcrc/group/e3sm/public_html/$ENV{USER}</CIME_HTML_ROOT>
+    <CIME_URL_ROOT>https://web.lcrc.anl.gov/public/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/lcrc/group/e3sm/data/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/lcrc/group/e3sm/data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/lcrc/group/e3sm/$USER/archive/$CASE</DOUT_S_ROOT>
@@ -1036,11 +1096,8 @@
         <arg name="num_tasks"> -l -n {{ total_tasks }} -N {{ num_nodes }} --kill-on-bad-exit </arg>
         <arg name="binding">--cpu_bind=cores</arg>
         <arg name="thread_count">-c $ENV{OMP_NUM_THREADS}</arg>
-        <arg name="placement">-m plane=$SHELL{echo 36/$OMP_NUM_THREADS|bc}</arg>
+        <arg name="placement">-m plane={{ tasks_per_node }}</arg>
       </arguments>
-    </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable/>
     </mpirun>
     <module_system type="module">
       <init_path lang="sh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/sh;export MODULEPATH=$MODULEPATH:/software/centos7/spack-latest/share/spack/lmod/linux-centos7-x86_64/Core</init_path>
@@ -1051,40 +1108,58 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">cmake/3.14.2-gvwazz3</command>
+        <command name="load">cmake/3.20.3-vedypwm</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/17.0.0-pwabdn2</command>
-        <command name="load">intel-mkl/2017.1.132-6qy7y5f</command>
-        <command name="load">netcdf/4.4.1-tckdgwl</command>
-        <command name="load">netcdf-cxx/4.2-3qkutvv</command>
-        <command name="load">netcdf-fortran/4.4.4-urmb6ss</command>
+        <command name="load">gcc/7.4.0</command>
+        <command name="load">intel/20.0.4-lednsve</command>
+        <command name="load">intel-mkl/2020.4.304-voqlapk</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich">
-        <command name="load">mvapich2/2.2-verbs-qwuab3b</command>
-        <command name="load">parallel-netcdf/1.11.0-6qz7skn</command>
+        <command name="load">mvapich2/2.3.6-verbs-x4iz7lq</command>
+        <command name="load">netcdf-c/4.4.1-gei7x7w</command>
+        <command name="load">netcdf-cxx/4.2-db2f5or</command>
+        <command name="load">netcdf-fortran/4.4.4-b4ldb3a</command>
+        <command name="load">parallel-netcdf/1.11.0-kj4jsvt</command>
       </modules>
-      <modules compiler="intel18">
-        <command name="load">intel/18.0.4-62uvgmb</command>
-        <command name="load">intel-mkl/2018.4.274-jwaeshj</command>
-        <command name="load">netcdf/4.4.1-fijcsqi</command>
-        <command name="load">netcdf-cxx/4.2-cixenix</command>
-        <command name="load">netcdf-fortran/4.4.4-mmtrep3</command>
+      <modules compiler="intel" mpilib="impi">
+        <command name="load">intel-mpi/2019.9.304-i42whlw</command>
+        <command name="load">netcdf-c/4.4.1-blyisdg</command>
+        <command name="load">netcdf-cxx/4.2-gkqc6fq</command>
+        <command name="load">netcdf-fortran/4.4.4-eanrh5t</command>
+        <command name="load">parallel-netcdf/1.11.0-y3nmmej</command>
       </modules>
-      <modules compiler="intel18" mpilib="mvapich">
-        <command name="load">mvapich2/2.2-verbs-m57bia7</command>
-        <command name="load">parallel-netcdf/1.11.0-ny4vo3o</command>
+      <modules compiler="intel" mpilib="openmpi">
+        <command name="load">openmpi/4.1.1-v3b3npd</command>
+        <command name="load">netcdf-c/4.4.1-smyuxme</command>
+        <command name="load">netcdf-cxx/4.2-kfb2aag</command>
+        <command name="load">netcdf-fortran/4.4.4-mablvyc</command>
+        <command name="load">parallel-netcdf/1.11.0-x4n5s7k</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">gcc/8.2.0-xhxgy33</command>
-        <command name="load">intel-mkl/2018.4.274-2amycpi</command>
+        <command name="load">intel-mkl/2020.4.304-d6zw4xa</command>
+      </modules>
+      <modules compiler="gnu" mpilib="mvapich">
         <command name="load">netcdf/4.4.1-ve2zfkw</command>
         <command name="load">netcdf-cxx/4.2-2rkopdl</command>
         <command name="load">netcdf-fortran/4.4.4-thtylny</command>
-      </modules>
-      <modules compiler="gnu" mpilib="mvapich">
         <command name="load">mvapich2/2.2-verbs-ppznoge</command>
         <command name="load">parallel-netcdf/1.11.0-c22b2bn</command>
+      </modules>
+      <modules compiler="gnu" mpilib="impi">
+        <command name="load">intel-mpi/2019.9.304-rxpzd6p</command>
+        <command name="load">netcdf-c/4.4.1-fysjgfx</command>
+        <command name="load">netcdf-cxx/4.2-oaiw2v6</command>
+        <command name="load">netcdf-fortran/4.4.4-kxgkaop</command>
+        <command name="load">parallel-netcdf/1.11.0-fce7akl</command>
+      </modules>
+      <modules compiler="gnu" mpilib="openmpi">
+        <command name="load">openmpi/4.1.1-x5n4m36</command>
+        <command name="load">netcdf-c/4.4.1-mtfptpl</command>
+        <command name="load">netcdf-cxx/4.2-osp27dq</command>
+        <command name="load">netcdf-fortran/4.4.4-5yd6dos</command>
+        <command name="load">parallel-netcdf/1.11.0-a7ohxsg</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -1094,24 +1169,26 @@
     <environment_variables>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
-      <env name="PATH">/lcrc/group/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
-    </environment_variables>
-    <environment_variables mpilib="!mpi-serial">
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
+      <env name="PATH">/lcrc/group/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
     </environment_variables>
     <environment_variables mpilib="mvapich">
       <env name="MV2_ENABLE_AFFINITY">0</env>
       <env name="MV2_SHOW_CPU_BINDING">1</env>
+      <env name="MV2_HOMOGENEOUS_CLUSTER">1</env>
     </environment_variables>
     <environment_variables mpilib="mvapich" DEBUG="TRUE">
       <env name="MV2_DEBUG_SHOW_BACKTRACE">1</env>
       <env name="MV2_SHOW_ENV_INFO">2</env>
     </environment_variables>
+    <environment_variables mpilib="impi" DEBUG="TRUE">
+      <env name="I_MPI_DEBUG">10</env>
+    </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="intel|intel18">
-      <env name="KMP_AFFINITY">granularity=core,scatter</env>
+    <environment_variables SMP_PRESENT="TRUE" compiler="intel">
+      <env name="KMP_AFFINITY">granularity=core,balanced</env>
       <env name="KMP_HOT_TEAMS_MODE">1</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
@@ -1124,7 +1201,7 @@
     <NODENAME_REGEX>chr.*</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>impi,openmpi</MPILIBS>
+    <MPILIBS>openmpi,impi</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/lcrc/group/e3sm/PERF_Chrysalis</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
@@ -1136,17 +1213,18 @@
     <CCSM_CPRNC>/lcrc/group/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_integration</TESTS>
+    <NTEST_PARALLEL_JOBS>8</NTEST_PARALLEL_JOBS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>E3SM</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
         <arg name="num_tasks">--mpi=pmi2 -l -n {{ total_tasks }} -N {{ num_nodes }} --kill-on-bad-exit </arg>
-        <arg name="binding">--cpu_bind=cores</arg>
-        <arg name="thread_count">-c $ENV{OMP_NUM_THREADS}</arg>
+        <arg name="binding"> $SHELL{if [ 64 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>	
+        <arg name="thread_count">-c $SHELL{echo 128/ {{ tasks_per_node }} |bc}</arg>
         <arg name="placement">-m plane={{ tasks_per_node }}</arg>
       </arguments>
     </mpirun>
@@ -1161,18 +1239,19 @@
         <command name="purge"/>
         <command name="load">subversion/1.14.0-e4smcy3</command>
         <command name="load">perl/5.32.0-bsnc6lt</command>
+        <command name="load">cmake/3.19.1-yisciec</command>
       </modules>
       <modules compiler="intel">
         <command name="load">intel/20.0.4-kodw73g</command>
         <command name="load">intel-mkl/2020.4.304-g2qaxzf</command>
       </modules>
       <modules compiler="intel" mpilib="openmpi">
-        <command name="load">openmpi/4.0.4-hpcx-cy5n3ft</command>
-        <command name="load">hdf5/1.8.16-m3bsibs</command>
-        <command name="load">netcdf-c/4.4.1-7ejgpdm</command>
-        <command name="load">netcdf-cxx/4.2-sag6n3x</command>
-        <command name="load">netcdf-fortran/4.4.4-sjzkwoc</command>
-        <command name="load">parallel-netcdf/1.11.0-l362p2g</command>
+        <command name="load">openmpi/4.1.1-qiqkjbu</command>
+        <command name="load">hdf5/1.8.16-35xugty</command>
+        <command name="load">netcdf-c/4.4.1-2vngykq</command>
+        <command name="load">netcdf-cxx/4.2-gzago6i</command>
+        <command name="load">netcdf-fortran/4.4.4-2kddbib</command>
+        <command name="load">parallel-netcdf/1.11.0-go65een</command>
       </modules>
       <modules compiler="intel" mpilib="impi">
         <command name="load">intel-mpi/2019.9.304-tkzvizk</command>
@@ -1187,12 +1266,12 @@
         <command name="load">intel-mkl/2020.4.304-n3b5fye</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-        <command name="load">openmpi/4.0.4-hpcx-hghvhj5</command>
-        <command name="load">hdf5/1.10.7-sbsigon</command>
-        <command name="load">netcdf-c/4.7.4-a4uk6zy</command>
-        <command name="load">netcdf-cxx/4.2-fz347dw</command>
-        <command name="load">netcdf-fortran/4.5.3-i5ah7u2</command>
-        <command name="load">parallel-netcdf/1.12.1-e7w4x32</command>
+        <command name="load">openmpi/4.1.1-73gbwq4</command>
+        <command name="load">hdf5/1.8.16-dqjdy2d</command>
+        <command name="load">netcdf-c/4.4.1-y6dun2a</command>
+        <command name="load">netcdf-cxx/4.2-vwlvgn6</command>
+        <command name="load">netcdf-fortran/4.4.4-4lnfxki</command>
+        <command name="load">parallel-netcdf/1.11.0-3x2favk</command>
       </modules>
       <modules compiler="gnu" mpilib="impi">
         <command name="load">intel-mpi/2019.9.304-jdih7h5</command>
@@ -1216,15 +1295,14 @@
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="intel">
-      <env name="KMP_AFFINITY">granularity=core,scatter</env>
-      <env name="KMP_HOT_TEAMS_MODE">1</env>
+    <environment_variables SMP_PRESENT="TRUE" compiler="intel" MAX_TASKS_PER_NODE="!128">
+      <env name="KMP_AFFINITY">granularity=core,balanced</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="intel" MAX_TASKS_PER_NODE="128">
+      <env name="KMP_AFFINITY">granularity=thread,balanced</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>
-    </environment_variables>
-    <environment_variables mpilib="openmpi">
-      <env name="UCX_TLS">sm,ud</env>
     </environment_variables>
   </machine>
 
@@ -1268,7 +1346,7 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">cmake/3.14.2-gvwazz3</command>
+        <command name="load">cmake/3.20.3-vedypwm</command>
       </modules>
       <modules compiler="pgigpu">
         <command name="load">nvhpc/20.9-5brtudu</command>
@@ -1297,6 +1375,75 @@
     <environment_variables mpilib="mvapich" DEBUG="TRUE">
       <env name="MV2_DEBUG_SHOW_BACKTRACE">1</env>
       <env name="MV2_SHOW_ENV_INFO">2</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE">
+      <env name="OMP_STACKSIZE">64M</env>
+      <env name="OMP_PLACES">cores</env>
+    </environment_variables>
+  </machine>
+
+  <machine MACH="swing">
+    <DESC>ANL/LCRC Linux Cluster: 6x 128c EPYC nodes with 8x A100 GPUs</DESC>
+    <NODENAME_REGEX>gpulogin.*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>pgigpu</COMPILERS>
+    <MPILIBS>openmpi</MPILIBS>
+    <PROJECT>e3sm</PROJECT>
+    <SAVE_TIMING_DIR>/lcrc/group/e3sm</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>/lcrc/group/e3sm/$USER/scratch/swing</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/lcrc/group/e3sm/data/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lcrc/group/e3sm/data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/lcrc/group/e3sm/$USER/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/lcrc/group/e3sm/baselines/swing/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/lcrc/group/e3sm/soft/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_gpu</TESTS>
+    <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>E3SM</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="num_tasks"> -l -n {{ total_tasks }} -N {{ num_nodes }} -K </arg>
+        <arg name="binding">$SHELL{if [ 128 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;}</arg>
+        <arg name="thread_count">-c $SHELL{echo 256/ {{ tasks_per_node }} |bc}</arg>
+        <arg name="placement">-m plane={{ tasks_per_node }}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="sh">/gpfs/fs1/soft/swing/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-5tuyfdb/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/gpfs/fs1/soft/swing/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-5tuyfdb/lmod/lmod/init/csh</init_path>
+      <init_path lang="python">/gpfs/fs1/soft/swing/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-5tuyfdb/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="python">/gpfs/fs1/soft/swing/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-5tuyfdb/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="load">cmake/3.21.1-e5i6eks</command>
+      </modules>
+      <modules compiler="pgigpu">
+        <command name="load">nvhpc/20.9-37zsymt</command>
+        <command name="load">cuda/11.1.1-nkh7mm7</command>
+        <command name="load">openmpi/4.1.1-r6ebr2e</command>
+        <command name="load">netcdf-c/4.7.4-zppo53l</command>
+        <command name="load">netcdf-cxx/4.2-wjm7fye</command>
+        <command name="load">netcdf-fortran/4.5.3-srsajjs</command>
+        <command name="load">parallel-netcdf/1.12.1-75szceu</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
+    <environment_variables>
+      <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
+      <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
+      <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
+      <env name="PATH">/lcrc/group/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
@@ -1352,7 +1499,7 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">cmake/3.13.4-354d6wl</command>
+        <command name="load">cmake/3.20.3-vedypwm</command>
       </modules>
       <modules compiler="intel">
         <command name="load">intel/18.0.4-443hhug</command>
@@ -1558,7 +1705,7 @@
         <command name="rm">cray-netcdf</command>
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="load">craype/2.6.5</command>
-        <command name="load">cmake/3.14.5</command>
+        <command name="load">cmake/3.18.0</command>
       </modules>
       <modules compiler="intel">
         <command name="rm">PrgEnv-gnu</command>
@@ -1595,7 +1742,7 @@
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
     <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
-      <env name="PERL5LIB">/projects/ccsm/e3sm/libs/perl5</env>
+      <env name="PATH">/projects/ccsm/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
       <env name="MPAS_TOOL_DIR">/projects/ccsm/e3sm/tools/mpas</env>
       <env name="HDF5_DISABLE_VERSION_CHECK">1</env>
       <env name="labeling">-e PMI_LABEL_ERROUT=1</env>
@@ -1613,9 +1760,9 @@
     <DESC>ANL experimental/evaluation cluster, batch system is cobalt</DESC>
     <NODENAME_REGEX>jlse.*</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>impi,openmpi</MPILIBS>
-    <CIME_OUTPUT_ROOT>/gpfs/jlse-fs0/projects/climate/$USER/scratch/jlse</CIME_OUTPUT_ROOT>
+    <COMPILERS>oneapi-ifx,oneapi-ifort,gnu</COMPILERS>
+    <MPILIBS>mpich,impi,openmpi</MPILIBS>
+    <CIME_OUTPUT_ROOT>/gpfs/jlse-fs0/projects/climate/$USER/scratch</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/gpfs/jlse-fs0/projects/climate/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/gpfs/jlse-fs0/projects/climate/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
@@ -1629,7 +1776,7 @@
     <MAX_TASKS_PER_NODE>112</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>112</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-    <mpirun mpilib="impi">
+    <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
         <arg name="num_tasks">-l -n {{ total_tasks }}</arg>
@@ -1645,61 +1792,33 @@
     <module_system type="module" allow_error="true">
       <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
       <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
-      <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
       <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
-      <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
       <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
       <modules>
 	<command name="purge"/>
         <command name="use">/soft/modulefiles</command>
         <command name="use">/soft/packaging/spack-builds/modules/linux-rhel7-x86_64</command>
+        <command name="use">/soft/restricted/CNDA/modulefiles</command>
+        <command name="use">/home/azamat/soft/modulefiles</command>
         <command name="load">cmake/3.17.0-gcc-9.3.0-5dgh2gv</command>
       </modules>
-      <modules compiler="intel">
-	<command name="load">intel/2019</command>
-      </modules>
-      <modules compiler="intel" mpilib="impi">
-	<command name="load">intelmpi/2019-intel</command>
+      <modules compiler="!gnu">
+	<command name="load">e3sm-env-vars/2021.06.10</command>
+	<command name="load">oneapi/2021.04.30.003</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">gcc/9.2.0</command>
+        <command name="unload">cmake</command>
+	<command name="load">gcc/8.2.0</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <environment_variables>
-      <env name="PATH">/home/azamat/perl5/bin:$ENV{PATH}</env>
-      <env name="PERL5LIB">/home/azamat/perl5/lib/perl5</env>
-      <env name="PERL_LOCAL_LIB_ROOT">/home/azamat/perl5</env>
-      <env name="PERL_MB_OPT">"--install_base \"/home/azamat/perl5\""</env>
-      <env name="PERL_MM_OPT">"INSTALL_BASE=/home/azamat/perl5"</env>
-    </environment_variables>
-    <environment_variables compiler="intel">
-      <env name="NETCDF_PATH">/gpfs/jlse-fs0/projects/climate/soft/netcdf/4.4.1c-4.2cxx-4.4.4f/intel19</env>
-    </environment_variables>
-    <environment_variables compiler="gnu">
-      <env name="NETCDF_PATH">/gpfs/jlse-fs0/projects/climate/soft/netcdf/4.4.1c-4.2cxx-4.4.4f/gcc9.2.0</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="impi">
-      <env name="PNETCDF_PATH">/gpfs/jlse-fs0/projects/climate/soft/pnetcdf/1.12.1/intel19</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="openmpi">
-      <env name="OMPI_CC">icc</env>
-      <env name="OMPI_CXX">icpc</env>
-      <env name="OMPI_FC">ifort</env>
-      <env name="PATH">/gpfs/jlse-fs0/projects/climate/soft/openmpi/2.1.6/intel19/bin:$ENV{PATH}</env>
-      <env name="LD_LIBRARY_PATH">/gpfs/jlse-fs0/projects/climate/soft/openmpi/2.1.6/intel19/lib:$ENV{LD_LIBRARY_PATH}</env>
-      <env name="PNETCDF_PATH">/gpfs/jlse-fs0/projects/climate/soft/pnetcdf/1.12.1/openmpi2.1.6</env>
-    </environment_variables>
-    <environment_variables compiler="gnu" mpilib="openmpi">
-      <env name="OMPI_CC">gcc</env>
-      <env name="OMPI_CXX">g++</env>
-      <env name="OMPI_FC">gfortran</env>
-      <env name="PATH">/gpfs/jlse-fs0/projects/climate/soft/openmpi/2.1.6/gcc9.2.0/bin:$ENV{PATH}</env>
-      <env name="LD_LIBRARY_PATH">/gpfs/jlse-fs0/projects/climate/soft/openmpi/2.1.6/gcc9.2.0/lib:$ENV{LD_LIBRARY_PATH}</env>
-      <env name="PNETCDF_PATH">/gpfs/jlse-fs0/projects/climate/soft/pnetcdf/1.12.1/openmpi2.1.6-gcc9.2.0</env>
+      <env name="PATH">/home/azamat/soft/perl/5.32.0/bin:$ENV{PATH}</env>
+      <env name="NETCDF_PATH">/home/azamat/soft/netcdf/4.4.1c-4.2cxx-4.4.4f/oneapi-2020.12.15.004-intel_mpi-2019.4.243</env>
+      <env name="PNETCDF_PATH">/home/azamat/soft/pnetcdf/1.12.1/oneapi-2020.12.15.004-intel_mpi-2019.4.243</env>
     </environment_variables>
     <environment_variables mpilib="impi">
       <env name="I_MPI_DEBUG">10</env>
@@ -1707,85 +1826,43 @@
       <env name="I_MPI_PIN_ORDER">spread</env>
       <env name="I_MPI_PIN_CELL">unit</env>
     </environment_variables>
+    <environment_variables compiler="intel" mpilib="openmpi">
+      <env name="OMPI_CC">icc</env>
+      <env name="OMPI_CXX">icpc</env>
+      <env name="OMPI_FC">ifort</env>
+      <env name="PATH">/home/azamat/soft/openmpi/2.1.6/intel19/bin:$ENV{PATH}</env>
+      <env name="LD_LIBRARY_PATH">/home/azamat/soft/openmpi/2.1.6/intel19/lib:$ENV{LD_LIBRARY_PATH}</env>
+      <env name="NETCDF_PATH">/home/azamat/soft/netcdf/4.4.1c-4.2cxx-4.4.4f/intel19-openmpi2.1.6</env>
+      <env name="PNETCDF_PATH">/home/azamat/soft/pnetcdf/1.12.1/intel19-openmpi2.1.6</env>
+    </environment_variables>
+    <environment_variables compiler="gnu" mpilib="openmpi">
+      <env name="OMPI_CC">gcc</env>
+      <env name="OMPI_CXX">g++</env>
+      <env name="OMPI_FC">gfortran</env>
+      <env name="LD_LIBRARY_PATH">/home/azamat/soft/openmpi/2.1.6/gcc8.2.0/lib:/home/azamat/soft/libs:$ENV{LD_LIBRARY_PATH}</env>
+      <env name="PATH">/home/azamat/soft/openmpi/2.1.6/gcc8.2.0/bin:/home/azamat/soft/cmake/3.18.5/bin:$ENV{PATH}</env>
+      <env name="CMAKE_ROOT">/home/azamat/soft/cmake/3.18.5</env>
+      <env name="ACLOCAL_PATH">/home/azamat/soft/cmake/3.18.5/share/aclocal</env>
+      <env name="CMAKE_PREFIX_PATH">/home/azamat/soft/cmake/3.18.5</env>
+      <env name="NETCDF_PATH">/home/azamat/soft/netcdf/4.4.1c-4.2cxx-4.4.4f/gcc8.2.0-openmpi2.1.6</env>
+      <env name="PNETCDF_PATH">/home/azamat/soft/pnetcdf/1.12.1/gcc8.2.0-openmpi2.1.6</env>
+    </environment_variables>
+    <environment_variables compiler="oneapi-ifx">
+      <env name="LIBOMPTARGET_DEBUG">0</env><!--default 0, max 5 -->
+      <!--env name="OMP_TARGET_OFFLOAD">DISABLED</env--><!--set this for CPU-only runs-->
+    </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="intel">
-      <env name="KMP_AFFINITY">verbose,granularity=thread,scatter</env>
+      <env name="KMP_AFFINITY">verbose,granularity=thread,balanced</env>
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE" compiler="!intel">
       <env name="OMP_PLACES">threads</env>
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
   </machine>
-
-<machine MACH="jlse-iris">
-    <DESC>ANL experimental/evaluation cluster, batch system is cobalt</DESC>
-    <NODENAME_REGEX>jlse.*</NODENAME_REGEX>
-    <OS>LINUX</OS>
-    <COMPILERS>intelgpu</COMPILERS>
-    <MPILIBS>mpich</MPILIBS>
-    <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/home/azamat/acme/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/home/azamat/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>$ENV{HOME}/acme/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/home/azamat/acme/tools/cprnc/cprnc</CCSM_CPRNC>
-    <GMAKE_J>8</GMAKE_J>
-    <TESTS>acme_developer</TESTS>
-    <BATCH_SYSTEM>cobalt_theta</BATCH_SYSTEM>
-    <SUPPORTED_BY>e3sm</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-    <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-    <mpirun mpilib="default">
-      <executable>mpirun</executable>
-      <arguments>
-        <arg name="num_tasks">-l -n $TOTALPES</arg>
-      </arguments>
-    </mpirun>
-    <module_system type="module" allow_error="true">
-      <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
-      <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
-      <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
-      <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
-      <cmd_path lang="sh">module</cmd_path>
-      <cmd_path lang="csh">module</cmd_path>
-      <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
-      <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
-      <modules>
-	<command name="purge"/>
-	<command name="use">/soft/modulefiles</command>
-	<command name="use">/soft/packaging/spack-builds/modules/linux-rhel7-x86_64</command>
-	<command name="use">/soft/restricted/intel_dga/modulefiles</command>
-	<command name="load">cmake/3.17.0-gcc-9.3.0-5dgh2gv</command>
-      </modules>
-      <modules compiler="intelgpu">
-        <command name="load">omp</command>
-        <command name="load">mkl</command>
-	<command name="load">mpi</command>
-      </modules>
-    </module_system>
-    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
-    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-    <environment_variables>
-      <env name="MPICH_ENV_DISPLAY">1</env>
-      <env name="MPICH_VERSION_DISPLAY">1</env>
-      <env name="MPICH_CPUMASK_DISPLAY">1</env>
-      <env name="MPICH_MEMORY_REPORT">1</env>
-      <env name="PATH">/home/azamat/perl5/bin:$ENV{PATH}</env>
-      <env name="PERL5LIB">/home/azamat/perl5/lib/perl5</env>
-     <env name="PERL_LOCAL_LIB_ROOT">/home/azamat/perl5</env>
-      <env name="PERL_MB_OPT">"--install_base \"/home/azamat/perl5\""</env>
-      <env name="PERL_MM_OPT">"INSTALL_BASE=/home/azamat/perl5"</env>
-    </environment_variables>
-    <environment_variables compiler="intelgpu">
-      <env name="LD_LIBRARY_PATH">/home/wuda/soft/hdf5/1.8.16-parallel/intel18/lib:/home/wuda/soft/szip/2.1.1/intel18/lib:/home/wuda/soft/zlib/1.2.11/intel18/lib:$ENV{LD_LIBRARY_PATH}</env>
-      <env name="HDF5_PATH">/home/wuda/soft/hdf5/1.8.16-parallel/intel18</env>
-      <env name="NETCDF_PATH">/home/wuda/soft/netcdf/4.4.1c-4.2cxx-4.4.4f-parallel/intel18</env>
-      <env name="PNETCDF_PATH">/home/wuda/soft/pnetcdf/1.12.0/intel18</env>
-      <env name="I_MPI_DEBUG">10</env>
-      <env name="I_MPI_PIN_CELL">core</env>
-    </environment_variables>
-</machine>
 
   <machine MACH="sooty">
     <DESC>PNL cluster, OS is Linux, batch system is SLURM</DESC>
@@ -2110,9 +2187,10 @@
         <command name="purge"/>
       </modules>
       <modules>
-        <command name="load">cmake/3.11.4</command>
+        <command name="load">cmake/3.19.6</command>
       </modules>
       <modules compiler="intel">
+        <command name="load">gcc/8.1.0</command>
         <command name="load">intel/19.0.5</command>
       </modules>
       <modules compiler="pgi">
@@ -2140,6 +2218,9 @@
     <environment_variables>
       <env name="NETCDF_HOME">$ENV{NETCDF_ROOT}/</env>
       <env name="MKL_PATH">$ENV{MKLROOT}</env>
+    </environment_variables>
+    <environment_variables compiler="intel">
+      <env name="LD_LIBRARY_PATH">/share/apps/gcc/8.1.0/lib:/share/apps/gcc/8.1.0/lib64:$ENV{LD_LIBRARY_PATH}</env>
     </environment_variables>
     <environment_variables mpilib="mvapich2">
       <env name="MV2_ENABLE_AFFINITY">0</env>
@@ -2686,22 +2767,22 @@
     <GMAKE_J>4</GMAKE_J>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>rgknox and glemieux at lbl dot gov</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>12</MAX_MPITASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="mpi-serial">
       <executable>mpirun</executable>
       <arguments>
         <arg name="num_tasks">-np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="default">
+
       <executable>mpirun</executable>
       <arguments>
         <arg name="num_tasks">-np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
       </arguments>
+      
     </mpirun>
     <module_system type="module">
       <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
@@ -2755,12 +2836,12 @@
     <COMPILERS>gnu</COMPILERS>
     <MPILIBS>mpi-serial</MPILIBS>
     <PROJECT>ngeet</PROJECT>
-    <CIME_OUTPUT_ROOT>/home/lbleco/e3sm/</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/home/lbleco/cesm/cesm_input_datasets/</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/home/lbleco/cesm/cesm_input_datasets/atm/datm7/</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>/home/lbleco/acme/cesm_archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/home/lbleco/acme/cesm_baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/home/lbleco/cesm/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
+    <CIME_OUTPUT_ROOT>/raid1/lbleco/e3sm/</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/raid1/lbleco/cesm/cesm_input_datasets/</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/raid1/lbleco/cesm/cesm_input_datasets/atm/datm7/</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/raid1/lbleco/acme/cesm_archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/raid1/lbleco/acme/cesm_baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/raid1/lbleco/cesm/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>1</GMAKE_J>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <SUPPORTED_BY>rgknox at lbl gov</SUPPORTED_BY>
@@ -2791,9 +2872,6 @@
     <SAVE_TIMING_DIR>/gpfs/alpine/proj-shared/$PROJECT</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>cli115,cli127</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>/gpfs/alpine/$PROJECT/proj-shared/$ENV{USER}/e3sm_scratch</CIME_OUTPUT_ROOT>
-    <!-- In case you wish to try HOME for building to check for filesystem issues, uncomment following -->
-    <!-- You may have to change RUNDIR below to use scratch file sustem.  -->
-    <!-- <CIME_OUTPUT_ROOT>$ENV{HOME}/e3sm_scratch/$PROJECT</CIME_OUTPUT_ROOT> -->
     <DIN_LOC_ROOT>/gpfs/alpine/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/gpfs/alpine/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/gpfs/alpine/$PROJECT/proj-shared/$ENV{USER}/archive/$CASE</DOUT_S_ROOT>
@@ -2811,57 +2889,197 @@
     <MAX_MPITASKS_PER_NODE compiler="pgigpu">18</MAX_MPITASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE compiler="gnugpu">42</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="spectrum-mpi" compiler="ibmgpu">
-      <executable>/gpfs/alpine/world-shared/cli115/mpirun.summit</executable>
-      <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ tasks_per_node }} -gpu</arg>
-      </arguments>
-    </mpirun>
-    <mpirun mpilib="spectrum-mpi" compiler="pgigpu">
-      <executable>/gpfs/alpine/world-shared/cli115/mpirun.summit</executable>
-      <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ tasks_per_node }} -gpu</arg>
-      </arguments>
-    </mpirun>
-    <mpirun mpilib="spectrum-mpi" compiler="gnugpu">
-      <executable>/gpfs/alpine/world-shared/cli115/mpirun.summit</executable>
-      <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ tasks_per_node }} -gpu</arg>
-      </arguments>
-    </mpirun>
     <mpirun mpilib="spectrum-mpi">
-      <!-- Use a helper script to tweak jsrun options -->
-      <executable>/gpfs/alpine/world-shared/cli115/mpirun.summit</executable>
-      <!-- <executable>jsrun</executable> -->
+      <executable>jsrun</executable>
       <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ tasks_per_node }}</arg>
+        <arg name="exit_on_error">-X 1</arg>
+        <arg name="num_rs">--nrs $ENV{NUM_RS}</arg>
+        <arg name="rs_per_node">--rs_per_host $ENV{RS_PER_NODE}</arg>
+        <arg name="tasks_per_rs">--tasks_per_rs $SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
+        <arg name="distribute">-d plane:$SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
+        <arg name="cpu_per_rs">--cpu_per_rs $ENV{CPU_PER_RS}</arg>
+        <arg name="gpu_per_rs">--gpu_per_rs $ENV{GPU_PER_RS}</arg>
+        <arg name="task_bind">--bind packed:smt:$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="nthreads">-E OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="thread_bind">-E OMP_PROC_BIND=spread -E OMP_PLACES=threads -E OMP_STACKSIZE=256M</arg>
+        <arg name="latency_priority">--latency_priority $ENV{LTC_PRT}</arg>
+        <arg name="stdio_mode">--stdio_mode prepended</arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
-      <!-- list of init_path elements, one per supported language e.g. sh, perl, python-->
       <init_path lang="sh">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/lmod/init/sh</init_path>
       <init_path lang="csh">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/lmod/init/csh</init_path>
       <init_path lang="python">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/lmod/init/env_modules_python.py</init_path>
       <init_path lang="perl">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/lmod/init/perl</init_path>
-      <!-- list of cmd_path elements, one for every supported language, e.g. sh, perl, python -->
       <cmd_path lang="perl">module</cmd_path>
       <cmd_path lang="python">/sw/summit/lmod/7.7.10/rhel7.3_gnu4.8.5/lmod/7.7.10/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
-
-      <!-- Always execute -->
       <modules>
         <command name="purge"/>
         <command name="ls"/>
         <command name="load">DefApps</command>
-        <command name="load">python/3.5.2</command>
+        <command name="load">python/3.7.0</command>
         <command name="load">subversion/1.9.3</command>
         <command name="load">git/2.13.0</command>
-        <command name="load">cmake/3.13.4</command>
+        <command name="load">cmake/3.20.2</command>
         <command name="load">essl/6.1.0-2</command>
         <command name="load">netlib-lapack/3.8.0</command>
       </modules>
-      <!-- List of modules elements, executing commands if compiler and mpilib condition applies -->
+      <modules compiler="pgi.*">
+        <command name="load">pgi/19.9</command>
+        <command name="load">pgi-cxx14/default</command>
+      </modules>
+      <modules compiler="pgigpu">
+        <command name="load">cuda/10.1.243</command>
+      </modules>
+      <modules compiler="gnugpu">
+        <command name="load">cuda/10.1.105</command>
+      </modules>
+      <modules compiler="ibm.*">
+        <command name="load">xl/16.1.1-9</command>
+      </modules>
+      <modules compiler="ibmgpu">
+        <command name="load">cuda/10.1.243</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">gcc/8.1.1</command>
+      </modules>
+      <modules compiler="gnugpu">
+        <command name="load">gcc/8.1.1</command>
+      </modules>
+      <modules>
+        <command name="load">netcdf/4.6.1</command>
+        <command name="load">netcdf-fortran/4.4.4</command>
+      </modules>
+      <modules compiler="ibm" mpilib="!mpi-serial">
+        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
+      </modules>
+      <modules compiler="pgi.*" mpilib="!mpi-serial">
+        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
+      </modules>
+      <modules compiler="gnu" mpilib="!mpi-serial">
+        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
+      </modules>
+      <modules compiler="gnugpu" mpilib="!mpi-serial">
+        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
+      </modules>
+      <modules>
+        <command name="load">parallel-netcdf/1.8.1</command>
+        <command name="load">hdf5/1.10.4</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <environment_variables>
+      <env name="NETCDF_C_PATH">$ENV{OLCF_NETCDF_ROOT}</env>
+      <env name="NETCDF_FORTRAN_PATH">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
+      <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
+      <env name="PGI_ACC_POOL_ALLOC">0</env>
+    </environment_variables>
+    <environment_variables compiler="ibm.*">
+      <env name="XLC_USR_CONFIG">/gpfs/alpine/cli115/world-shared/e3sm/tools/xlc/xlc.cfg.rhel.7.6.gcc.8.1.1.cuda.10.1</env>
+      <env name="LD_LIBRARY_PATH">/sw/summit/gcc/8.1.1/lib64:$ENV{LD_LIBRARY_PATH}</env>
+    </environment_variables>
+    <environment_variables mpilib="!mpi-serial">
+      <env name="HDF5_PATH">$ENV{OLCF_HDF5_ROOT}</env>
+      <env name="PNETCDF_PATH">$ENV{OLCF_PARALLEL_NETCDF_ROOT}</env>
+    </environment_variables>
+    <environment_variables>
+      <env name="RS_PER_NODE">2</env>
+      <env name="CPU_PER_RS">21</env>
+      <env name="GPU_PER_RS">0</env>
+      <env name="LTC_PRT">cpu-cpu</env>
+      <env name="NUM_RS">$SHELL{echo "2*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+      <env name="SMT_MODE">$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</env>
+    </environment_variables>
+    <environment_variables compiler="ibmgpu">
+      <env name="RS_PER_NODE">6</env>
+      <env name="CPU_PER_RS">7</env>
+      <env name="GPU_PER_RS">1</env>
+      <env name="LTC_PRT">gpu-cpu</env>
+      <env name="NUM_RS">$SHELL{echo "6*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+    </environment_variables>
+    <environment_variables compiler="pgigpu">
+      <env name="RS_PER_NODE">6</env>
+      <env name="CPU_PER_RS">3</env>
+      <env name="GPU_PER_RS">1</env>
+      <env name="LTC_PRT">gpu-cpu</env>
+      <env name="NUM_RS">$SHELL{echo "6*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+    </environment_variables>
+    <environment_variables compiler="gnugpu">
+      <env name="RS_PER_NODE">6</env>
+      <env name="CPU_PER_RS">7</env>
+      <env name="GPU_PER_RS">1</env>
+      <env name="LTC_PRT">gpu-cpu</env>
+      <env name="NUM_RS">$SHELL{echo "6*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+    </environment_variables>
+  </machine>
+
+  <machine MACH="ascent">
+    <DESC>ORNL Ascent. Node: 2x POWER9 + 6x Volta V100, 22 cores/socket, 4 HW threads/core.</DESC>
+    <NODENAME_REGEX>.*ascent.*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>ibm,ibmgpu,pgi,pgigpu,gnu,gnugpu</COMPILERS>
+    <MPILIBS>spectrum-mpi</MPILIBS>
+    <PROJECT>cli115</PROJECT>
+    <CHARGE_ACCOUNT>cli115</CHARGE_ACCOUNT>
+    <SAVE_TIMING_DIR>/gpfs/wolf/proj-shared/$PROJECT</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>cli115</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>/gpfs/wolf/$PROJECT/proj-shared/$ENV{USER}/e3sm_scratch</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/gpfs/wolf/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/gpfs/wolf/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/gpfs/wolf/$PROJECT/proj-shared/$ENV{USER}/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/gpfs/wolf/cli115/world-shared/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/gpfs/wolf/cli115/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_integration</TESTS>
+    <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
+    <BATCH_SYSTEM>lsf</BATCH_SYSTEM>
+    <SUPPORTED_BY>e3sm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>84</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE compiler="pgigpu">18</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE compiler="gnugpu">42</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>84</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="pgigpu">18</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="gnugpu">42</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="spectrum-mpi">
+      <executable>jsrun</executable>
+      <arguments>
+        <arg name="exit_on_error">-X 1</arg>
+        <arg name="num_rs">--nrs $ENV{NUM_RS}</arg>
+        <arg name="rs_per_node">--rs_per_host $ENV{RS_PER_NODE}</arg>
+        <arg name="tasks_per_rs">--tasks_per_rs $SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
+        <arg name="distribute">-d plane:$SHELL{echo "({{ tasks_per_node }} + $RS_PER_NODE - 1)/$RS_PER_NODE"|bc}</arg>
+        <arg name="cpu_per_rs">--cpu_per_rs $ENV{CPU_PER_RS}</arg>
+        <arg name="gpu_per_rs">--gpu_per_rs $ENV{GPU_PER_RS}</arg>
+        <arg name="task_bind">--bind packed:smt:$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="nthreads">-E OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="thread_bind">-E OMP_PROC_BIND=spread -E OMP_PLACES=threads -E OMP_STACKSIZE=256M</arg>
+        <arg name="latency_priority">--latency_priority $ENV{LTC_PRT}</arg>
+        <arg name="stdio_mode">--stdio_mode prepended</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module" allow_error="true">
+      <init_path lang="sh">/sw/ascent/lmod/7.8.2/rhel7.5_4.8.5/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/sw/ascent/lmod/7.8.2/rhel7.5_4.8.5/lmod/lmod/init/csh</init_path>
+      <init_path lang="python">/sw/ascent/lmod/7.8.2/rhel7.5_4.8.5/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="python">/sw/ascent/lmod/7.8.2/rhel7.5_4.8.5/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="ls"/>
+        <command name="load">DefApps</command>
+        <command name="load">python/3.7.0</command>
+        <command name="load">subversion/1.9.3</command>
+        <command name="load">git/2.13.0</command>
+        <command name="load">cmake/3.18.2</command>
+        <command name="load">essl/6.1.0-2</command>
+        <command name="load">netlib-lapack/3.8.0</command>
+      </modules>
       <modules compiler="pgi.*">
         <command name="load">pgi/19.9</command>
         <command name="load">pgi-cxx14/default</command>
@@ -2885,67 +3103,54 @@
         <command name="load">gcc/8.1.1</command>
       </modules>
       <modules>
+        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
         <command name="load">netcdf/4.6.1</command>
         <command name="load">netcdf-fortran/4.4.4</command>
-      </modules>
-      <!-- mpi lib settings -->
-      <!-- Sometimes,same versions of libraries are not available for different compilers, hence the split below -->
-      <modules compiler="ibm" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
-      </modules>
-      <modules compiler="pgi.*" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
-      </modules>
-      <modules compiler="gnu" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
-      </modules>
-      <modules compiler="gnugpu" mpilib="!mpi-serial">
-        <command name="load">spectrum-mpi/10.3.1.2-20200121</command>
-      </modules>
-
-      <modules>
         <command name="load">parallel-netcdf/1.8.1</command>
         <command name="load">hdf5/1.10.4</command>
       </modules>
-
     </module_system>
-    <!-- <RUNDIR>/gpfs/alpine/$PROJECT/proj-shared/$ENV{USER}/e3sm_scratch/$CASE/run</RUNDIR> -->
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
-    <!-- Ref: https://www.olcf.ornl.gov/for-users/system-user-guides/summit/ -->
-    <!-- 1 core/socket not available for application, so 168 = 42cores*4 in smt4 mode  -->
-
-    <!-- Useful jsrun options:
-     -n	(hyphen-hyphen)nrs	Number of resource sets
-     -a	(hyphen-hyphen)tasks_per_rs	Number of tasks per resource set
-     -c	(hyphen-hyphen)cpu_per_rs	Number of CPUs per resource set. Threads per rs.
-     -g	(hyphen-hyphen)gpu_per_rs	Number of GPUs per resource set
-     -r	(hyphen-hyphen)rs_per_host	Number of resource sets per host
-     -->
-
-    <!-- Default -->
     <environment_variables>
-      <env name="COMPILER">$COMPILER</env>
-      <env name="MPILIB">$MPILIB</env>
+      <env name="PATH">/gpfs/wolf/cli115/world-shared/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
       <env name="NETCDF_C_PATH">$ENV{OLCF_NETCDF_ROOT}</env>
       <env name="NETCDF_FORTRAN_PATH">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
-      <env name="NETCDF_PATH">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
-      <env name="NETCDFF">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
       <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
-      <env name="NETLIB_LAPACK_PATH">$ENV{OLCF_NETLIB_LAPACK_ROOT}</env>
-      <env name="PGI_ACC_POOL_ALLOC">0</env>
-    </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
-      <env name="OMP_STACKSIZE">128M</env>
-    </environment_variables>
-    <environment_variables mpilib="!mpi-serial">
       <env name="HDF5_PATH">$ENV{OLCF_HDF5_ROOT}</env>
       <env name="PNETCDF_PATH">$ENV{OLCF_PARALLEL_NETCDF_ROOT}</env>
+      <env name="PGI_ACC_POOL_ALLOC">0</env>
     </environment_variables>
-    <!-- <environment_variables mpilib="!mpi-serial" compiler="pgigpu"> -->
-      <!-- <env name="OMPI_CXX">$SRCROOT/externals/kokkos/bin/nvcc_wrapper</env> -->
-    <!-- </environment_variables> -->
+    <environment_variables>
+      <env name="RS_PER_NODE">2</env>
+      <env name="CPU_PER_RS">21</env>
+      <env name="GPU_PER_RS">0</env>
+      <env name="LTC_PRT">cpu-cpu</env>
+      <env name="NUM_RS">$SHELL{echo "2*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+      <env name="SMT_MODE">$SHELL{echo "(`./xmlquery --value MAX_TASKS_PER_NODE`+41)/42"|bc}</env>
+    </environment_variables>
+    <environment_variables compiler="ibmgpu">
+      <env name="RS_PER_NODE">6</env>
+      <env name="CPU_PER_RS">7</env>
+      <env name="GPU_PER_RS">1</env>
+      <env name="LTC_PRT">gpu-cpu</env>
+      <env name="NUM_RS">$SHELL{echo "6*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+    </environment_variables>
+    <environment_variables compiler="pgigpu">
+      <env name="RS_PER_NODE">6</env>
+      <env name="CPU_PER_RS">3</env>
+      <env name="GPU_PER_RS">1</env>
+      <env name="LTC_PRT">gpu-cpu</env>
+      <env name="NUM_RS">$SHELL{echo "6*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+    </environment_variables>
+    <environment_variables compiler="gnugpu">
+      <env name="RS_PER_NODE">6</env>
+      <env name="CPU_PER_RS">7</env>
+      <env name="GPU_PER_RS">1</env>
+      <env name="LTC_PRT">gpu-cpu</env>
+      <env name="NUM_RS">$SHELL{echo "6*((`./xmlquery --value TOTAL_TASKS` + `./xmlquery --value TASKS_PER_NODE` - 1)/`./xmlquery --value TASKS_PER_NODE`)"|bc}</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="modex">


### PR DESCRIPTION
This pull request is to add cime configurations for GNU compiler support at ORNL Spock system.

the request contains additions to the following configuration files:
- config_machines.xml
- config_compilers.xml
- config_batch.xml

The changes are tested on Spock using "e3sm_developer" test suite. Among 45 test cases, 40 cases are passed and 5 cases are failed. The 5 failed cases are related to missing input Netcdf file for MPAS Ocean model.

NOTE: To compile, modifications in “ODEMod.F90” at “$E3SM_HOME/components/elm/src/external_models/sbetr/src/betr/betr_math” was required, which is a part of an external submodule.

Further details are written in this confluence page: https://acme-climate.atlassian.net/l/c/CxfqrSzL