### PR TITLE
Fix CIMEROOTs for buildnml scripts

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -671,7 +671,6 @@
         <command name="load">sems-env</command>
         <command name="load">acme-env</command>
         <command name="load">sems-git</command>
-        <command name="load">sems-python/3.5.2</command>
         <command name="load">sems-cmake/3.19.1</command>
       </modules>
       <modules compiler="gnu">

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -11,7 +11,7 @@
 
 import os, sys, glob
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/data_comps/desp/cime_config/buildnml
+++ b/components/data_comps/desp/cime_config/buildnml
@@ -11,7 +11,7 @@
 
 import os, sys, glob
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -11,7 +11,7 @@
 
 import os, sys, glob
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -11,7 +11,7 @@
 
 import os, sys, glob
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -11,7 +11,7 @@
 
 import os, sys, glob, re
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -11,7 +11,7 @@
 
 import os, sys, glob
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -10,7 +10,7 @@
 
 import os, sys, glob
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/xcpl_comps/xatm/cime_config/buildnml
+++ b/components/xcpl_comps/xatm/cime_config/buildnml
@@ -6,7 +6,7 @@ build data model library
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/xcpl_comps/xglc/cime_config/buildnml
+++ b/components/xcpl_comps/xglc/cime_config/buildnml
@@ -6,7 +6,7 @@ build data model library
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/xcpl_comps/xice/cime_config/buildnml
+++ b/components/xcpl_comps/xice/cime_config/buildnml
@@ -6,7 +6,7 @@ build data model library
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/xcpl_comps/xlnd/cime_config/buildnml
+++ b/components/xcpl_comps/xlnd/cime_config/buildnml
@@ -6,7 +6,7 @@ build data model library
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/xcpl_comps/xocn/cime_config/buildnml
+++ b/components/xcpl_comps/xocn/cime_config/buildnml
@@ -6,7 +6,7 @@ build data model library
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/xcpl_comps/xrof/cime_config/buildnml
+++ b/components/xcpl_comps/xrof/cime_config/buildnml
@@ -6,7 +6,7 @@ build data model library
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/components/xcpl_comps/xwav/cime_config/buildnml
+++ b/components/xcpl_comps/xwav/cime_config/buildnml
@@ -6,7 +6,7 @@ build data model library
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/driver-mct/cime_config/buildnml
+++ b/driver-mct/cime_config/buildnml
@@ -9,7 +9,7 @@
 
 import os, sys, glob, itertools, re
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/driver-mct/unit_test/CMakeLists.txt
+++ b/driver-mct/unit_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(DRV_ROOT "${CIME_ROOT}/src/drivers/mct")
+set(DRV_ROOT "${SRC_ROOT}/driver-mct")
 
 add_definitions(
   -DNUM_COMP_INST_ATM=1
@@ -20,7 +20,7 @@ endif()
 # Add source directories from stubs. This should be done first, so that in the
 # case of name collisions, the drv versions take precedence (when there are two
 # files with the same name, the one added later wins).
-add_subdirectory(${CIME_ROOT}/src/share/unit_test_stubs/pio pio)
+add_subdirectory(${SRC_ROOT}/share/unit_test_stubs/pio pio)
 
 # Add drv source directories
 add_subdirectory(${DRV_ROOT}/shr drv_shr)

--- a/driver-moab/cime_config/buildnml
+++ b/driver-moab/cime_config/buildnml
@@ -9,7 +9,7 @@
 
 import os, sys, glob, itertools, re
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","cime")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *


### PR DESCRIPTION
It looks like these did not get updated when the scripts moved to
E3SM. Also, remove old python module load from mappy env.

[BFB]