### PR TITLE
Fix the CircleCI script that installs Singularity

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -15,8 +15,8 @@ function download
 download && \
     tar -xzf singularity-${VERSION}.tar.gz && \
     cd singularity/
-#./mconfig && \
-#    make -C ./builddir && \
-#    sudo make -C ./builddir install
-#
-#singularity --version
+./mconfig && \
+    make -C ./builddir && \
+    sudo make -C ./builddir install
+
+singularity --version


### PR DESCRIPTION
This PR removes a bug that was introduced with the last PR that added a backup HTTP server with the Singularity source code tarball.