### PR TITLE
Reset grid and compset for F2010 tests with RRM

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -160,7 +160,7 @@ _TESTS = {
             "PET_Ln9_PS.ne30pg2_EC30to60E2r2.WCYCL1850.allactive-mach-pet",
             "PEM_Ln9.ne30pg2_EC30to60E2r2.WCYCL1850",
             "ERP_Ld3.ne30pg2_EC30to60E2r2.WCYCL1850.allactive-pioroot1",
-            "SMS_D_Ln5.conusx4v1_conusx4v1.F2010",
+            "SMS_D_Ln5.conusx4v1_r05_oECv3.F2010",
             "SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPECACNT_1850.elm-bgcexp",
             "SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPRDCTC_1850.elm-bgcexp",
             "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
@@ -195,9 +195,9 @@ _TESTS = {
     #e3sm tests for RRM grids
     "e3sm_rrm" : {
         "tests" : (
-            "SMS_D_Ln5.conusx4v1_conusx4v1.F2010",
-            "SMS_D_Ln5.enax4v1_enax4v1.F2010",
-            "SMS_D_Ln5.twpx4v1_twpx4v1.F2010",
+            "SMS_D_Ln5.conusx4v1_r05_oECv3.F2010",
+            "SMS_D_Ln5.enax4v1_enax4v1.F2010-CICE",
+            "SMS_D_Ln5.twpx4v1_twpx4v1.F2010-CICE",
             )
         },
 


### PR DESCRIPTION
The existing bi-grid config for RRM test cannot work with MPASSI.
For conusx4v1, continue to use F2010 but changed to use tri-grid
conusx4v1_r05_oECv3. For enax4v1 and twpx4v1, continue to use
bi-grid but changed compset to F2010-CICE. The current arrangement
is based on availability of grid for using MPASSI and the inputdata.

[BFB] except for new test with conusx4v1_r05_oECv3