### PR TITLE
remove se_fv_nphys namelist variable

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -548,15 +548,6 @@ add_default($nl, 'start_type');
 my $dyn = $cfg->get('dyn');
 if ($dyn =~ /se/) {add_default($nl, 'vect_map', 'val'=>'cart3d');}
 
-if ($dyn =~ /se/) {
-  my $npg = $cfg->get('npg');
-  my $se_fv_nphys = $nl->get_value('se_fv_nphys');
-  if (defined($se_fv_nphys) and $se_fv_nphys != $npg) {
-    die "$ProgName - ERROR: se_fv_nphys should not be set by the user\n";
-  }
-  add_default($nl, 'se_fv_nphys', 'val'=>$npg);
-}
-
 # Adiabatic or Ideal physics
 my $phys = $cfg->get('phys');
 if ($phys eq 'adiabatic') { add_default($nl, 'atm_adiabatic',  'val'=>'.true.'); }

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -5857,15 +5857,6 @@ high-order algorithms implemented in gllfvremap_mod.
 Default: (set by dycore).  
 </entry>
 
-<entry id="se_fv_nphys" type="integer" category="se"
-       group="dyn_se_inparm" valid_values="" >
-Number of equally-spaced horizontal physics points per spectral
-element. A number greater than zero will define [se_fv_nphys] equally
-spaced physics points in each direction (e.g., se_fv_nphys = 2 will
-result in 4 equally-spaced physics points per element).
-Default: set based on atmosphere grid
-</entry>
-
 <!-- CAM I/O  -->
 
 <entry id="pio_stride" type="integer" category="pio"


### PR DESCRIPTION
se_fv_nphys is an old variable from the original physgrid implementation that is no longer needed.

[BFB]