### PR TITLE
For Cori, update cmake version to 3.21.3 to avoid module warning

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -179,7 +179,7 @@
         <command name="rm">git</command>
         <command name="load">git</command>
         <command name="rm">cmake</command>
-        <command name="load">cmake/3.20.2</command>
+        <command name="load">cmake/3.21.3</command>
         <command name="load">perl5-extras</command>
       </modules>
     </module_system>
@@ -332,7 +332,7 @@
         <command name="rm">git</command>
         <command name="load">git</command>
         <command name="rm">cmake</command>
-        <command name="load">cmake/3.20.2</command>
+        <command name="load">cmake/3.21.3</command>
         <command name="load">perl5-extras</command>
       </modules>
 


### PR DESCRIPTION
On Sep 21, NERSC updated default cmake version. The old version (that we were using) is still there, however, a module warning now appears if that it used. If CIME detects a warning/error from a module command, it will fail. This behavior can be turned off (using allow_error=true) and I tested that. However, in this case, it seems easy enough to simply update cmake version just to avoid this. (Thanks @whannah1)

Fixes #4548

[bfb]