### PR TITLE
add CFC11, CFC12 tracers

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -1061,6 +1061,20 @@ add_default($nl, 'config_use_idealAgeTracers_exponential_decay');
 add_default($nl, 'config_use_idealAgeTracers_idealAge_forcing');
 add_default($nl, 'config_use_idealAgeTracers_ttd_forcing');
 
+###############################################
+# Namelist group: tracer_forcing_CFCTracers #
+###############################################
+
+add_default($nl, 'config_use_CFCTracers');
+add_default($nl, 'config_use_CFCTracers_surface_bulk_forcing');
+add_default($nl, 'config_use_CFCTracers_surface_restoring');
+add_default($nl, 'config_use_CFCTracers_interior_restoring');
+add_default($nl, 'config_use_CFCTracers_exponential_decay');
+add_default($nl, 'config_use_CFCTracers_idealAge_forcing');
+add_default($nl, 'config_use_CFCTracers_ttd_forcing');
+add_default($nl, 'config_use_CFC11');
+add_default($nl, 'config_use_CFC12');
+
 ##################################
 # Namelist group: AM_globalStats #
 ##################################
@@ -1651,6 +1665,7 @@ my @groups = qw(run_modes
                 tracer_forcing_dmstracers
                 tracer_forcing_macromoleculestracers
                 tracer_forcing_idealagetracers
+                tracer_forcing_cfctracers
                 am_globalstats
                 am_surfaceareaweightedaverages
                 am_watermasscensus

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -543,6 +543,17 @@
 <config_use_idealAgeTracers_idealAge_forcing>.true.</config_use_idealAgeTracers_idealAge_forcing>
 <config_use_idealAgeTracers_ttd_forcing>.false.</config_use_idealAgeTracers_ttd_forcing>
 
+<!-- tracer_forcing_CFCTracers -->
+<config_use_CFCTracers>.false.</config_use_CFCTracers>
+<config_use_CFCTracers_surface_bulk_forcing>.false.</config_use_CFCTracers_surface_bulk_forcing>
+<config_use_CFCTracers_surface_restoring>.false.</config_use_CFCTracers_surface_restoring>
+<config_use_CFCTracers_interior_restoring>.false.</config_use_CFCTracers_interior_restoring>
+<config_use_CFCTracers_exponential_decay>.false.</config_use_CFCTracers_exponential_decay>
+<config_use_CFCTracers_idealAge_forcing>.false.</config_use_CFCTracers_idealAge_forcing>
+<config_use_CFCTracers_ttd_forcing>.false.</config_use_CFCTracers_ttd_forcing>
+<config_use_CFC11>.true.</config_use_CFC11>
+<config_use_CFC12>.true.</config_use_CFC12>
+
 <!-- AM_globalStats -->
 <config_AM_globalStats_enable>.true.</config_AM_globalStats_enable>
 <config_AM_globalStats_compute_interval>'output_interval'</config_AM_globalStats_compute_interval>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -2766,6 +2766,79 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<!-- tracer_forcing_CFCTracers -->
+
+<entry id="config_use_CFCTracers" type="logical"
+        category="tracer_forcing_CFCTracers" group="tracer_forcing_CFCTracers">
+if true, the 'CFCTracers' category is enabled for the run
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_CFCTracers_surface_bulk_forcing" type="logical"
+        category="tracer_forcing_CFCTracers" group="tracer_forcing_CFCTracers">
+if true, surface bulk forcing from coupler is added to surfaceTracerFlux in 'CFCTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_CFCTracers_surface_restoring" type="logical"
+        category="tracer_forcing_CFCTracers" group="tracer_forcing_CFCTracers">
+if true, surface restoring source is applied to tracers in 'CFCTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_CFCTracers_interior_restoring" type="logical"
+        category="tracer_forcing_CFCTracers" group="tracer_forcing_CFCTracers">
+if true, interior restoring source is applied to tracers in 'CFCTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_CFCTracers_exponential_decay" type="logical"
+        category="tracer_forcing_CFCTracers" group="tracer_forcing_CFCTracers">
+if true, exponential decay source is applied to tracers in 'CFCTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_CFCTracers_idealAge_forcing" type="logical"
+        category="tracer_forcing_CFCTracers" group="tracer_forcing_CFCTracers">
+if true, idealAge forcing source is applied to tracers in 'CFCTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_CFCTracers_ttd_forcing" type="logical"
+        category="tracer_forcing_CFCTracers" group="tracer_forcing_CFCTracers">
+if true, transit time distribution forcing source is applied to tracers in 'CFCTracers' category
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_CFC11" type="logical"
+        category="tracer_forcing_CFCTracers" group="tracer_forcing_CFCTracers">
+if true, CFC11 tracer is enabled for the run
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_CFC12" type="logical"
+        category="tracer_forcing_CFCTracers" group="tracer_forcing_CFCTracers">
+if true, CFC12 tracer is enabled for the run
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
 
 <!-- AM_globalStats -->
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -56,6 +56,7 @@ module ocn_comp_mct
    use ocn_tracer_short_wave_absorption
    use ocn_tracer_short_wave_absorption_variable
    use ocn_tracer_ecosys
+   use ocn_tracer_CFC
    use ocn_tracer_surface_restoring
    use ocn_gm
    use ocn_config
@@ -199,6 +200,7 @@ contains
     character(len=StrKIND), pointer :: tempCharConfig
 
     logical, pointer :: config_use_ecosysTracers
+    logical, pointer :: config_use_CFCTracers
     logical, pointer :: config_use_activeTracers_surface_restoring
     logical, pointer :: config_use_surface_salinity_monthly_restoring
     character (len=StrKIND), pointer :: config_land_ice_flux_mode
@@ -699,6 +701,14 @@ contains
         call mpas_timer_stop('io_ecosys')
     endif
 
+    ! read initial data required for CFC forcing
+    call mpas_pool_get_config(domain % configs, 'config_use_CFCTracers', config_use_CFCTracers)
+    if (config_use_CFCTracers) then
+        call mpas_timer_start('io_CFC',.false.)
+        call ocn_get_CFCData(domain_ptr % streamManager, domain, domain % clock, .true.)
+        call mpas_timer_stop('io_CFC')
+    endif
+
     ! read initial data required for monthly surface salinity restoring
     call mpas_pool_get_config(domain % configs, 'config_use_activeTracers_surface_restoring',  &
                                                  config_use_activeTracers_surface_restoring)
@@ -875,6 +885,7 @@ contains
       logical :: streamActive, debugOn
       logical, pointer :: config_write_output_on_startup
       logical, pointer :: config_use_ecosysTracers
+      logical, pointer :: config_use_CFCTracers
       logical, pointer :: config_use_activeTracers_surface_restoring
       logical, pointer :: config_use_surface_salinity_monthly_restoring
       character (len=StrKIND), pointer :: config_restart_timestamp_name
@@ -985,6 +996,14 @@ contains
            call mpas_timer_start('io_ecosys',.false.)
            call ocn_get_ecosysData(domain % streamManager, domain, domain_ptr % clock, .false.)
            call mpas_timer_stop('io_ecosys')
+         endif
+
+         ! read next time level data required for CFC forcing
+         call mpas_pool_get_config(domain % configs, 'config_use_CFCTracers', config_use_CFCTracers)
+         if (config_use_CFCTracers) then
+           call mpas_timer_start('io_CFC',.false.)
+           call ocn_get_CFCData(domain % streamManager, domain, domain_ptr % clock, .false.)
+           call mpas_timer_stop('io_CFC')
          endif
 
          ! read next time level data required for monthly surface salinity restoring
@@ -1104,6 +1123,8 @@ contains
          if(trim(config_sw_absorption_type)=='ohlmann00') call ocn_shortwave_forcing_write_restart(domain_ptr)
 
          if (config_use_ecosysTracers) call ocn_ecosys_forcing_write_restart(domain_ptr)
+
+         if (config_use_CFCTracers) call ocn_CFC_forcing_write_restart(domain_ptr)
 
          if (config_use_activeTracers_surface_restoring .and. config_use_surface_salinity_monthly_restoring)  &
              call ocn_salinity_restoring_forcing_write_restart(domain_ptr)
@@ -1572,6 +1593,7 @@ contains
                        config_use_DMSTracers_sea_ice_coupling,  &
                        config_use_MacroMoleculesTracers,  &
                        config_use_MacroMoleculesTracers_sea_ice_coupling, &
+                       config_use_CFCTracers,  &
                        config_remove_AIS_coupler_runoff, &
                        config_cvmix_kpp_use_theory_wave
 
@@ -1591,7 +1613,8 @@ contains
                                      ecosysAuxiliary,      &
                                      ecosysSeaIceCoupling, &
                                      DMSSeaIceCoupling,    &
-                                     MacroMoleculesSeaIceCoupling
+                                     MacroMoleculesSeaIceCoupling,      &
+                                     CFCAuxiliary
 
    integer, pointer :: nCellsSolve
 
@@ -1652,6 +1675,7 @@ contains
                                                atmosphericPressure, iceFraction, &
                                                seaIcePressure, windSpeedSquared10m, &
                                                atmosphericCO2, atmosphericCO2_ALT_CO2,  &
+                                               windSpeedSquared10mCFC, &
                                                iceFluxDIC,       &
                                                iceFluxDON, &
                                                iceFluxNO3, &
@@ -1717,6 +1741,7 @@ contains
                                                 config_use_DMSTracers_sea_ice_coupling)
    call mpas_pool_get_config(domain % configs, 'config_use_MacroMoleculesTracers_sea_ice_coupling',  &
                                                 config_use_MacroMoleculesTracers_sea_ice_coupling)
+   call mpas_pool_get_config(domain % configs, 'config_use_CFCTracers', config_use_CFCTracers)
    call mpas_pool_get_config(domain % configs, 'config_remove_AIS_coupler_runoff', config_remove_AIS_coupler_runoff)
    call mpas_pool_get_config(domain % configs, 'config_cvmix_kpp_use_theory_wave', config_cvmix_kpp_use_theory_wave)
 
@@ -1875,6 +1900,13 @@ contains
 
          iceFluxDMS => iceFluxDMSField % array
          iceFluxDMSP => iceFluxDMSPField % array
+      endif
+
+      ! CFC fields
+      if (config_use_CFCTracers) then
+         call mpas_pool_get_subpool(forcingPool, 'CFCAuxiliary', CFCAuxiliary)
+         call mpas_pool_get_field(CFCAuxiliary, 'windSpeedSquared10mCFC', windSpeedSquared10mField)
+         windSpeedSquared10mCFC => windSpeedSquared10mField % array
       endif
 
       if (config_remove_AIS_coupler_runoff) then
@@ -2107,6 +2139,13 @@ contains
            endif
          endif
 
+        ! CFC fields
+        if (config_use_CFCTracers) then
+           if ( windSpeedSquared10mField % isActive ) then
+              windSpeedSquared10mCFC(i) = x2o_o % rAttr(index_x2o_So_duu10n, n)
+           end if
+        end if
+
       end do
 
       block_ptr => block_ptr % next
@@ -2187,6 +2226,12 @@ contains
 
       call mpas_pool_get_field(DMSSeaIceCoupling, 'iceFluxDMS', iceFluxDMSField)
       call mpas_pool_get_field(DMSSeaIceCoupling, 'iceFluxDMSP', iceFluxDMSPField)
+   endif
+
+   ! CFC fields
+   if (config_use_CFCTracers) then
+      call mpas_pool_get_subpool(forcingPool, 'CFCAuxiliary', CFCAuxiliary)
+      call mpas_pool_get_field(CFCAuxiliary, 'windSpeedSquared10mCFC', windSpeedSquared10mField)
    endif
 
    if ( windStressMeridionalField % isActive ) then
@@ -2356,6 +2401,13 @@ contains
       if ( iceFluxDMSPField % isActive ) then
          call mpas_dmpar_exch_halo_field(iceFluxDMSPField)
       endif
+   endif
+
+   ! CFC fields
+   if (config_use_CFCTracers .and. .not. config_use_ecosysTracers) then
+      if ( windSpeedSquared10mField % isActive ) then
+         call mpas_dmpar_exch_halo_field(windSpeedSquared10mField)
+      end if
    endif
 
    ! global sum of removed runoff

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -71,6 +71,7 @@ module ocn_forward_mode
    use ocn_tracer_DMS
    use ocn_tracer_MacroMolecules
    use ocn_tracer_ideal_age
+   use ocn_tracer_CFC
    use ocn_tracer_surface_restoring
    use ocn_gm
 
@@ -442,6 +443,8 @@ module ocn_forward_mode
       ierr = ior(ierr,err_tmp)
       call ocn_tracer_ideal_age_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
+      call ocn_tracer_CFC_init(domain, err_tmp)
+      ierr = ior(ierr,err_tmp)
       if (ierr /= 0) then
          call mpas_log_write( &
               'Error initializing tracer tendency modules', &
@@ -595,6 +598,13 @@ module ocn_forward_mode
         call mpas_timer_stop('io_ecosys')
       endif
 
+      ! read initial data required for CFC forcing
+      if (config_use_CFCTracers) then
+        call mpas_timer_start('io_CFC',.false.)
+        call ocn_get_CFCData(domain % streamManager, domain, domain % clock, .true.)
+        call mpas_timer_stop('io_CFC')
+      endif
+
       ! read initial data required for monthly surface salinity restoring
       ! always execute this call as initial data needed regardless of alarm
       if (config_use_activeTracers_surface_restoring .and. config_use_surface_salinity_monthly_restoring) then
@@ -738,6 +748,13 @@ module ocn_forward_mode
            call mpas_timer_start('io_ecosys',.false.)
            call ocn_get_ecosysData(domain % streamManager, domain, domain % clock, .false.)
            call mpas_timer_stop('io_ecosys')
+         endif
+
+         ! read next time level data required for CFC forcing
+         if (config_use_CFCTracers) then
+           call mpas_timer_start('io_CFC',.false.)
+           call ocn_get_CFCData(domain % streamManager, domain, domain % clock, .false.)
+           call mpas_timer_stop('io_CFC')
          endif
 
          ! read next time level data required for monthly surface salinity restoring

--- a/components/mpas-ocean/src/ocean.cmake
+++ b/components/mpas-ocean/src/ocean.cmake
@@ -76,6 +76,7 @@ list(APPEND RAW_SOURCES
   core_ocean/shared/mpas_ocn_tracer_interior_restoring.F
   core_ocean/shared/mpas_ocn_tracer_exponential_decay.F
   core_ocean/shared/mpas_ocn_tracer_ideal_age.F
+  core_ocean/shared/mpas_ocn_tracer_CFC.F
   core_ocean/shared/mpas_ocn_tracer_TTD.F
   core_ocean/shared/mpas_ocn_tracer_ecosys.F
   core_ocean/shared/mpas_ocn_tracer_DMS.F

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -53,6 +53,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_tracer_ecosys.o \
 	   mpas_ocn_tracer_DMS.o \
 	   mpas_ocn_tracer_MacroMolecules.o \
+	   mpas_ocn_tracer_CFC.o \
 	   mpas_ocn_high_freq_thickness_hmix_del2.o \
 	   mpas_ocn_tracer_surface_flux_to_tend.o \
 	   mpas_ocn_test.o \
@@ -76,7 +77,7 @@ all: $(OBJS)
 
 mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
 
-mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_tidal_potential_forcing.o mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o
+mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_tracer_CFC.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_tidal_potential_forcing.o mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o
 
 mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_surface_land_ice_fluxes.o
 
@@ -199,6 +200,8 @@ mpas_ocn_tracer_ecosys.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_framew
 mpas_ocn_tracer_DMS.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_tracer_MacroMolecules.o: mpas_ocn_constants.o mpas_ocn_config.o
+
+mpas_ocn_tracer_CFC.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_tracer_surface_flux_to_tend.o: mpas_ocn_constants.o mpas_ocn_config.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -50,6 +50,7 @@ module ocn_tendency
    use ocn_tracer_ecosys
    use ocn_tracer_DMS
    use ocn_tracer_MacroMolecules
+   use ocn_tracer_CFC
 
    use ocn_thick_hadv
    use ocn_thick_vadv
@@ -512,6 +513,8 @@ contains
          err,                &! internal error flag 
          timeLevel,          &! time level to use for state variables
          indxTemp, indxSalt, &! tracer index for temperature, salinity
+         indxCFC11,          &! tracer index for CFC11
+         indxCFC12,          &! tracer index for CFC12
          nTracersGroup,      &! number of tracers in each tracer group
          nTracersEcosys       ! number of ecosystem tracers
 
@@ -542,6 +545,8 @@ contains
       ! pointers for retrieving data from pools
       integer, pointer :: &
          indexTemperature, indexSalinity ! tracer index for temp,salt
+      integer, pointer :: &
+         indexCFC11, indexCFC12 ! tracer indicies for CFCs
 
       logical, pointer :: & ! option configuration flags
          config_use_tracerGroup, &
@@ -876,6 +881,31 @@ contains
                                   tracerGroupSurfaceFlux, err)
 
          endif ! MacroMolecules
+
+         !
+         ! compute CFC surface fluxes, there are no interior sources/sinks
+         !
+         if ( groupName == 'CFCTracers' ) then
+
+            call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                     activeTracers, timeLevel)
+
+            indxCFC11 = 0
+            indxCFC12 = 0
+            if (config_use_CFC11) then
+              call mpas_pool_get_dimension(tracersPool, 'index_CFC11', indexCFC11)
+              indxCFC11 = indexCFC11 ! convert to int scalar due to problems with int scalar pointers
+            endif
+            if (config_use_CFC12) then
+              call mpas_pool_get_dimension(tracersPool, 'index_CFC12', indexCFC12)
+              indxCFC12 = indexCFC12 ! convert to int scalar due to problems with int scalar pointers
+            endif
+                                                 
+            call ocn_tracer_CFC_surface_flux_compute(activeTracers, &
+                                        tracerGroup, forcingPool,  &
+                                        nTracersGroup, nCellsOwned, &
+                                        indxTemp, indxSalt, tracerGroupSurfaceFlux, indxCFC11, indxCFC12, err)
+         endif ! CFC
 
          !
          ! ocean surface restoring

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_CFC.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_CFC.F
@@ -1,0 +1,651 @@
+! copyright (c) 2013,  los alamos national security, llc (lans)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_tracer_CFC
+!
+!> \brief MPAS ocean CFC
+!> \author Mathew Maltrud
+!> \date   12/22/2016
+!> \details
+!>  This module contains routines for computing evolution of CFC11 and CFC12
+!
+!-----------------------------------------------------------------------
+
+module ocn_tracer_CFC
+
+   use mpas_timer
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_forcing
+   use ocn_framework_forcing
+   use mpas_timekeeping
+   use ocn_constants
+   use ocn_config
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_tracer_CFC_compute, &
+             ocn_tracer_CFC_surface_flux_compute,  &
+             ocn_tracer_CFC_init,  &
+             ocn_get_CFCData,  &
+             ocn_CFC_forcing_write_restart
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+!  solubility coefficients
+   real (kind=RKIND), dimension(11:12) :: a1sol, a2sol, a3sol, a4sol, b1sol, b2sol, b3sol
+
+!  schmidt number coefficients
+   real (kind=RKIND), dimension(11:12) :: a1schmidt, a2schmidt, a3schmidt, a4schmidt
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_tracer_CFC_compute
+!
+!> \brief   computes a tracer tendency due to CFC
+!> \author  Mathew Maltrud
+!> \date    12/22/2016
+!> \details
+!>  This routine computes a tracer tendency for CFC11 and/or CFC12
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_CFC_compute!{{{
+
+! no CFC sources/sinks
+
+   end subroutine ocn_tracer_CFC_compute!}}}
+
+!***********************************************************************
+!
+!  routine ocn_tracer_CFC_surface_flux_compute
+!
+!> \brief   computes a tracer tendency due to CFC surface fluxes
+!> \author  Mathew Maltrud
+!> \date    12/22/2016
+!> \details
+!>  This routine computes a tracer tendency due to CFC surface fluxes
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_CFC_surface_flux_compute(activeTracers, CFCTracers, forcingPool, nTracers,   &
+      nCellsSolve, indexTemperature, indexSalinity, CFCSurfaceFlux, indexCFC11, indexCFC12, err)!{{{
+
+
+ use ocn_config
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      ! two dimensional arrays
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         CFCSurfaceFlux
+
+      ! three dimensional arrays
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         CFCTracers
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         activeTracers
+
+      ! scalars
+      integer, intent(in) :: nTracers, nCellsSolve, indexTemperature, indexSalinity, indexCFC11, indexCFC12
+
+      type (mpas_pool_type), intent(inout) :: forcingPool
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), pointer :: CFC11FluxDiagnostics,  &
+                                        CFC12FluxDiagnostics,  &
+                                        CFCAuxiliary
+
+      integer :: numColumns, column, iCell, iTracer, iLevelSurface
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         pCFC11,   &
+         pCFC12,   &
+         atmosphericPressure,   &
+         iceFraction,          &
+         windSpeedSquared10m,  &
+         CFC11_flux_ifrac,  &
+         CFC11_flux_xkw,    &
+         CFC11_flux_atm_press,  &
+         CFC11_flux_pv,     &
+         CFC11_flux_schmidt,&
+         CFC11_flux_sat,    &
+         CFC11_flux_surf,   &
+         CFC11_flux_ws,     &
+         CFC12_flux_ifrac,  &
+         CFC12_flux_xkw,    &
+         CFC12_flux_atm_press,  &
+         CFC12_flux_pv,     &
+         CFC12_flux_schmidt,&
+         CFC12_flux_sat,    &
+         CFC12_flux_surf,   &
+         CFC12_flux_ws
+
+      real (kind=RKIND) :: &
+!        xkw_coeff = 8.6e-7_RKIND,  &       ! xkw_coeff = 0.0031 m/hr s^2/m^2, older OCMIP value
+         xkw_coeff = 9.6361e-7_RKIND,  &    ! xkw_coeff = 0.00337 m/hr s^2/m^2
+         PascalsToAtmospheres = 1.0_RKIND/101.325e+3_RKIND,  &
+         mSquared_to_cmSquared = 1.0e+4_RKIND
+
+      real (kind=RKIND) :: &
+         xkw_ice,   &
+         sst,   &
+         sss,   &
+         saturation_CFC11_1atm,   &
+         saturation_CFC12_1atm,   &
+         CFC_flux_ifrac_nonNegative,   &
+         CFC_flux_ifrac_clamped
+
+      err = 0
+
+      call mpas_timer_start("CFC surface flux")
+
+      call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
+      call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
+      call mpas_pool_get_subpool(forcingPool, 'CFCAuxiliary', CFCAuxiliary)
+      call mpas_pool_get_array(CFCAuxiliary, 'windSpeedSquared10mCFC', windSpeedSquared10m)
+
+      if (config_use_CFC11) then
+        call mpas_pool_get_array(CFCAuxiliary, 'pCFC11', pCFC11)
+        call mpas_pool_get_subpool(forcingPool, 'CFC11FluxDiagnostics', CFC11FluxDiagnostics)
+        call mpas_pool_get_array(CFC11FluxDiagnostics, 'CFC11_flux_xkw', CFC11_flux_xkw)
+        call mpas_pool_get_array(CFC11FluxDiagnostics, 'CFC11_flux_atm_press', CFC11_flux_atm_press)
+        call mpas_pool_get_array(CFC11FluxDiagnostics, 'CFC11_flux_pv', CFC11_flux_pv)
+        call mpas_pool_get_array(CFC11FluxDiagnostics, 'CFC11_flux_schmidt', CFC11_flux_schmidt)
+        call mpas_pool_get_array(CFC11FluxDiagnostics, 'CFC11_flux_sat', CFC11_flux_sat)
+        call mpas_pool_get_array(CFC11FluxDiagnostics, 'CFC11_flux_surf', CFC11_flux_surf)
+        call mpas_pool_get_array(CFC11FluxDiagnostics, 'CFC11_flux_ws', CFC11_flux_ws)
+        call mpas_pool_get_array(CFC11FluxDiagnostics, 'CFC11_flux_ifrac', CFC11_flux_ifrac)
+      endif
+
+      if (config_use_CFC12) then
+        call mpas_pool_get_array(CFCAuxiliary, 'pCFC12', pCFC12)
+        call mpas_pool_get_subpool(forcingPool, 'CFC12FluxDiagnostics', CFC12FluxDiagnostics)
+        call mpas_pool_get_array(CFC12FluxDiagnostics, 'CFC12_flux_xkw', CFC12_flux_xkw)
+        call mpas_pool_get_array(CFC12FluxDiagnostics, 'CFC12_flux_atm_press', CFC12_flux_atm_press)
+        call mpas_pool_get_array(CFC12FluxDiagnostics, 'CFC12_flux_pv', CFC12_flux_pv)
+        call mpas_pool_get_array(CFC12FluxDiagnostics, 'CFC12_flux_schmidt', CFC12_flux_schmidt)
+        call mpas_pool_get_array(CFC12FluxDiagnostics, 'CFC12_flux_sat', CFC12_flux_sat)
+        call mpas_pool_get_array(CFC12FluxDiagnostics, 'CFC12_flux_surf', CFC12_flux_surf)
+        call mpas_pool_get_array(CFC12FluxDiagnostics, 'CFC12_flux_ws', CFC12_flux_ws)
+        call mpas_pool_get_array(CFC12FluxDiagnostics, 'CFC12_flux_ifrac', CFC12_flux_ifrac)
+      endif
+
+      numColumns = 1
+      column = 1
+      iLevelSurface = 1
+
+      !DWJ 08/05/2016: This loop needs OpenMP added to it.
+      do iCell=1,nCellsSolve
+
+       CFC_flux_ifrac_nonNegative = max(iceFraction(iCell), 0.0_RKIND)
+       CFC_flux_ifrac_clamped = min(CFC_flux_ifrac_nonNegative, 1.0_RKIND)
+
+       xkw_ice = (1.0_RKIND - CFC_flux_ifrac_clamped) * xkw_coeff * windSpeedSquared10m(iCell)
+
+       sst = activeTracers(indexTemperature,iLevelSurface,iCell)
+       sss = activeTracers(indexSalinity,iLevelSurface,iCell)
+
+       if (config_use_CFC11) then
+
+          CFC11_flux_schmidt(iCell) = SCHMIDT_CFC(sst, 11)
+
+          saturation_CFC11_1atm = pCFC11(iCell) * SOLUBILITY_CFC(sst, sss, 11)
+
+          CFC11_flux_pv(iCell) = xkw_ice * sqrt(660.0_RKIND / CFC11_flux_schmidt(iCell))
+          CFC11_flux_atm_press(iCell) = atmosphericPressure(iCell)*PascalsToAtmospheres
+          CFC11_flux_sat(iCell) = CFC11_flux_atm_press(iCell) * saturation_CFC11_1atm
+          CFC11_flux_surf(iCell) = max(0.0_RKIND, CFCTracers(indexCFC11,iLevelSurface,iCell))
+          CFCSurfaceFlux(indexCFC11,iCell) = CFC11_flux_pv(iCell) *   &
+             (CFC11_flux_sat(iCell) - CFC11_flux_surf(iCell))
+          CFC11_flux_xkw(iCell) = xkw_ice
+          CFC11_flux_ifrac(iCell) = CFC_flux_ifrac_clamped
+          CFC11_flux_ws(iCell) = sqrt(windSpeedSquared10m(iCell))
+
+       endif  !  config_use_CFC11
+
+       if (config_use_CFC12) then
+
+          CFC12_flux_schmidt(iCell) = SCHMIDT_CFC(sst, 12)
+
+          saturation_CFC12_1atm = pCFC12(iCell) * SOLUBILITY_CFC(sst, sss, 12)
+
+          CFC12_flux_pv(iCell) = xkw_ice * sqrt(660.0_RKIND / CFC12_flux_schmidt(iCell))
+          CFC12_flux_atm_press(iCell) = atmosphericPressure(iCell)*PascalsToAtmospheres
+          CFC12_flux_sat(iCell) = CFC12_flux_atm_press(iCell) * saturation_CFC12_1atm
+          CFC12_flux_surf(iCell) = max(0.0_RKIND, CFCTracers(indexCFC12,iLevelSurface,iCell))
+          CFCSurfaceFlux(indexCFC12,iCell) = CFC12_flux_pv(iCell) *   &
+             (CFC12_flux_sat(iCell) - CFC12_flux_surf(iCell))
+          CFC12_flux_xkw(iCell) = xkw_ice
+          CFC12_flux_ifrac(iCell) = CFC_flux_ifrac_clamped
+          CFC12_flux_ws(iCell) = sqrt(windSpeedSquared10m(iCell))
+
+       endif  !  config_use_CFC12
+
+      enddo  !  iCell
+
+      call mpas_timer_stop("CFC surface flux")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_CFC_surface_flux_compute!}}}
+
+!***********************************************************************
+!
+!  routine ocn_tracer_CFC_init
+!
+!> \brief   Initializes ocean CFC11 and CFC12
+!> \author  Mathew Maltrud
+!> \date    12/28/2016
+!> \details
+!>  This routine initializes fields required for CFC tracers
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_CFC_init(domain,err)!{{{
+
+!NOTE:  called from mpas_ocn_forward_mode.F
+
+      type (domain_type), intent(inout) :: domain !< Input/Output: domain information
+
+      integer, intent(out) :: err !< Output: error flag
+
+      type (mpas_pool_type), pointer :: statePool
+      type (mpas_pool_type), pointer :: tracersPool
+      type (mpas_pool_type), pointer :: forcingPool
+      type (mpas_pool_type), pointer :: CFCAuxiliary
+      type (mpas_pool_type), pointer :: CFCAnnualForcing
+
+      ! three dimensional pointers
+      real (kind=RKIND), dimension(:,:,:), pointer :: &
+        CFCTracers
+
+! input flux components in CFCAuxiliary
+      real (kind=RKIND), dimension(:), pointer :: &
+         pCFC11,    &
+         pCFC12
+
+! input flux components in CFCAnnualForcing
+      real (kind=RKIND), dimension(:), pointer :: &
+         atmCFC11,    &
+         atmCFC12
+
+      character(len=strKIND) :: &
+         forcingIntervalAnnual,  &
+         forcingReferenceTimeAnnual
+
+      type (MPAS_Time_Type) :: currTime
+      integer :: ierr
+      character(len=StrKIND)  :: timeStamp
+
+!-----------------------------------------------------------------------
+!-----------------------------------------------------------------------
+
+      err = 0
+
+      if (.not. config_use_CFCTracers) return
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
+      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+      call mpas_pool_get_array(tracersPool, 'CFCTracers', CFCTracers, 1)
+
+!-----------------------------------------------------------------------
+!     schmidt number coefficients for CFC 11
+!-----------------------------------------------------------------------
+      a1schmidt(11) = 3501.8_RKIND
+      a2schmidt(11) = -210.31_RKIND
+      a3schmidt(11) =    6.1851_RKIND
+      a4schmidt(11) =   -0.07513_RKIND
+
+!-----------------------------------------------------------------------
+!     schmidt number coefficients for CFC 12
+!-----------------------------------------------------------------------
+      a1schmidt(12) = 3845.4_RKIND
+      a2schmidt(12) = -228.95_RKIND
+      a3schmidt(12) =    6.1908_RKIND
+      a4schmidt(12) =   -0.067430_RKIND
+
+!-----------------------------------------------------------------------
+!     solubility coefficients for CFC 11
+!-----------------------------------------------------------------------
+      a1sol ( 11) = -229.9261_RKIND
+      a2sol ( 11) =  319.6552_RKIND
+      a3sol ( 11) =  119.4471_RKIND
+      a4sol ( 11) =   -1.39165_RKIND
+      b1sol ( 11) =   -0.142382_RKIND
+      b2sol ( 11) =    0.091459_RKIND
+      b3sol ( 11) =   -0.0157274_RKIND
+
+!-----------------------------------------------------------------------
+!     solubility coefficients for CFC 12
+!-----------------------------------------------------------------------
+      a1sol ( 12) = -218.0971_RKIND
+      a2sol ( 12) =  298.9702_RKIND
+      a3sol ( 12) =  113.8049_RKIND
+      a4sol ( 12) =   -1.39165_RKIND
+      b1sol ( 12) =   -0.143566_RKIND
+      b2sol ( 12) =    0.091015_RKIND
+      b3sol ( 12) =   -0.0153924_RKIND
+
+!-----------------------------------------------------------------------
+! initialize annual forcing to be read from file
+!-----------------------------------------------------------------------
+
+      forcingIntervalAnnual = "0001-00-00_00:00:00"
+      forcingReferenceTimeAnnual = "1936-07-01_00:00:00"
+
+      currTime = mpas_get_clock_time(domain % clock, MPAS_NOW, ierr)
+      call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=ierr)
+
+      call MPAS_forcing_init_group( forcingGroupHead,  &
+                "CFCAnnualAtmosphericForcing", &
+                domain, &
+                trim(timeStamp), &
+                '1936-07-01_00:00:00', &
+                '0080-00-00_00:00:00', &
+                config_do_restart)
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'forcing', forcingPool)
+      call mpas_pool_get_subpool(forcingPool, 'CFCAuxiliary', CFCAuxiliary)
+      if (config_use_CFC11) call mpas_pool_get_array(CFCAuxiliary, 'pCFC11', pCFC11)
+      if (config_use_CFC12) call mpas_pool_get_array(CFCAuxiliary, 'pCFC12', pCFC12)
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'CFCAnnualForcing', CFCAnnualForcing)
+      if (config_use_CFC11) call mpas_pool_get_array(CFCAnnualForcing, 'atmCFC11', atmCFC11)
+      if (config_use_CFC12) call mpas_pool_get_array(CFCAnnualForcing, 'atmCFC12', atmCFC12)
+
+      if (config_use_CFC11) call MPAS_forcing_init_field( domain % streamManager, &
+                                      forcingGroupHead, &
+                                      'CFCAnnualAtmosphericForcing', &
+                                      'atmCFC11', &
+                                      'CFC_annual_mole_fraction', &
+                                      'CFCAnnualForcing',  &
+                                      'atmCFC11',  &
+                                      'linear',  &
+                                      forcingReferenceTimeAnnual,  &
+                                      forcingIntervalAnnual)
+
+      if (config_use_CFC12) call MPAS_forcing_init_field( domain % streamManager, &
+                                      forcingGroupHead, &
+                                      'CFCAnnualAtmosphericForcing', &
+                                      'atmCFC12', &
+                                      'CFC_annual_mole_fraction', &
+                                      'CFCAnnualForcing',  &
+                                      'atmCFC12',  &
+                                      'linear',  &
+                                      forcingReferenceTimeAnnual,  &
+                                      forcingIntervalAnnual)
+
+      call MPAS_forcing_init_field_data( forcingGroupHead, &
+        'CFCAnnualAtmosphericForcing',  &
+         domain % streamManager,  &
+         config_do_restart, &
+         .false.)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_CFC_init!}}}
+
+!***********************************************************************
+
+!***********************************************************************
+!
+!  function SCHMIDT_CFC(Temperature,CFCmolecule)
+!
+!> \brief   computes the Schmidt Number for CFC11 and CFC 12
+!> \author  Mathew Maltrud
+!> \date    12/28/2016
+!> \details
+!>  CFC 11 and 12 schmidt number as a function of temperature.
+!>  ref: Zheng et al (1998), JGR, vol 103,No C1
+!>  Temperature: temperature (degree Celcius)
+!>  CFCmolecule: = 11 for CFC-11,  12 for CFC-12
+!>  J-C Dutay - LSCE
+!-----------------------------------------------------------------------
+
+   function SCHMIDT_CFC(Temperature,CFCmolecule)
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), intent(in) :: Temperature
+      integer, intent(in) :: CFCmolecule
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND) :: SCHMIDT_CFC
+
+      SCHMIDT_CFC = a1schmidt(CFCmolecule) + a2schmidt(CFCmolecule) * Temperature + &
+                    a3schmidt(CFCmolecule) *Temperature*Temperature +  &
+                    a4schmidt(CFCmolecule) *Temperature*Temperature*Temperature
+
+   end function SCHMIDT_CFC
+
+!***********************************************************************
+!
+!  function SOLUBILITY_CFC(Temperature,Salinity,CFCmolecule)
+!
+!> \brief   computes CFC 11 and 12 Solubilities in seawater
+!> \author  Mathew Maltrud
+!> \date    12/28/2016
+!> \details
+!>    computes CFC 11 and 12 Solubilities in seawater
+!>    ref: Warner & Weiss (1985) , Deep Sea Research, vol32
+!>    Temperature:       temperature (degree Celcius)
+!>    Salinity   :       salinity    (o/oo)
+!>    CFCmolecule:       11 = CFC-11, 12 = CFC-12
+!>    SOLUBILITY_CFC:  in mol/m3/pptv
+!>              1 pptv = 1 part per trillion = 10^-12 atm = 1 picoatm
+!>    J-C Dutay - LSCE
+!
+!-----------------------------------------------------------------------
+
+   function SOLUBILITY_CFC(Temperature,Salinity,CFCmolecule)
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), intent(in) :: Temperature, Salinity
+      integer, intent(in) :: CFCmolecule
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND) :: p01SSTKelvin
+      real (kind=RKIND) :: SOLUBILITY_CFC
+
+      p01SSTKelvin = (Temperature + T0_Kelvin)* 0.01_RKIND
+
+      SOLUBILITY_CFC  &
+          = exp ( a1sol ( CFCmolecule)   &
+          +       a2sol ( CFCmolecule)/ p01SSTKelvin   &
+          +       a3sol ( CFCmolecule)* log ( p01SSTKelvin )   &
+          +       a4sol ( CFCmolecule)* p01SSTKelvin * p01SSTKelvin   &
+          +       Salinity*(   &
+                    ( b3sol( CFCmolecule)*p01SSTKelvin + b2sol( CFCmolecule) )*p01SSTKelvin + b1sol(CFCmolecule) )  &
+                   )
+
+!     conversion from mol/(l * atm) to mol/(m^3 * atm)
+!     ------------------------------------------------
+      SOLUBILITY_CFC = SOLUBILITY_CFC * 1000.0_RKIND
+
+!     conversion from mol/(m^3 * atm) to mol/(m3 * pptv)
+!     --------------------------------------------------
+      SOLUBILITY_CFC = SOLUBILITY_CFC * 1.0e-12_RKIND
+
+   end function SOLUBILITY_CFC
+
+!***********************************************************************
+
+!***********************************************************************
+!
+!  routine get_CFCData
+!
+!> \brief   retrieve data needed to compute CFC surface fluxes
+!> \author  Mathew Maltrud
+!> \date    08/31/21
+!> \details
+!>  This routine calls mpas_forcing routines to acquire needed CFC forcing data and interpolates
+!>    between time levels.  directly copied from ocn_get_ecosysData.
+!
+!-----------------------------------------------------------------------
+
+    subroutine ocn_get_CFCData( streamManager, &
+        domain, &
+        simulationClock, &
+        firstTimeStep) !{{{
+
+        type (MPAS_streamManager_type), intent(inout) :: streamManager
+
+        type (domain_type) :: domain
+        type (MPAS_timeInterval_type) :: timeStepCFC
+        type (MPAS_clock_type) :: simulationClock
+
+        logical, intent(in) :: firstTimeStep
+        real(kind=RKIND) :: dt
+
+        type (mpas_pool_type), pointer :: forcingPool
+        type (mpas_pool_type), pointer :: meshPool
+        type (mpas_pool_type), pointer :: CFCAuxiliary
+        type (mpas_pool_type), pointer :: CFCAnnualForcing
+
+        real (kind=RKIND), dimension(:), pointer :: &
+         pCFC11,         &
+         pCFC12
+
+! input flux components in CFCAnnualForcing
+        real (kind=RKIND), dimension(:), pointer :: &
+         atmCFC11,         &
+         atmCFC12
+
+        integer, pointer :: nCells
+        integer :: iCell
+
+        call mpas_set_timeInterval(timeStepCFC,timeString=config_dt)
+        call mpas_get_timeInterval(timeStepCFC,dt=dt)
+
+        if (firstTimeStep .and. config_do_restart) then
+          call MPAS_forcing_get_forcing(forcingGroupHead, &
+             'CFCAnnualAtmosphericForcing', streamManager, 0.0_RKIND)
+        else
+          call MPAS_forcing_get_forcing(forcingGroupHead, &
+             'CFCAnnualAtmosphericForcing', streamManager, dt)
+        endif
+
+        call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+        call mpas_pool_get_subpool(domain % blocklist % structs, 'forcing', forcingPool)
+        call mpas_pool_get_subpool(forcingPool, 'CFCAuxiliary', CFCAuxiliary)
+        call mpas_pool_get_subpool(domain % blocklist % structs, 'CFCAnnualForcing', CFCAnnualForcing)
+
+        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
+        if (config_use_CFC11) then
+          call mpas_pool_get_array(CFCAuxiliary, 'pCFC11', pCFC11)
+          call mpas_pool_get_array(CFCAnnualForcing, 'atmCFC11', atmCFC11)
+          do iCell = 1, nCells
+             pCFC11(iCell) = atmCFC11(iCell)
+          enddo
+        endif
+
+        if (config_use_CFC12) then
+          call mpas_pool_get_array(CFCAuxiliary, 'pCFC12', pCFC12)
+          call mpas_pool_get_array(CFCAnnualForcing, 'atmCFC12', atmCFC12)
+          do iCell = 1, nCells
+             pCFC12(iCell) = atmCFC12(iCell)
+          enddo
+        endif
+
+    end subroutine ocn_get_CFCData!}}}
+
+!***********************************************************************
+!
+!  routine ocn_CFC_forcing_write_restart
+!
+!> \brief   writes restart timestamp for CFC data to be read in on future restart
+!> \author  Mathew Maltrud
+!> \date    03/07/2016
+
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_CFC_forcing_write_restart(domain)!{{{
+
+      type(domain_type) :: domain
+
+      call MPAS_forcing_write_restart_times(forcingGroupHead)
+
+    end subroutine ocn_CFC_forcing_write_restart!}}}
+
+end module ocn_tracer_CFC
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
@@ -1,0 +1,248 @@
+	<nml_record name="tracer_forcing_CFCTracers">
+		<nml_option name="config_use_CFCTracers" type="logical" default_value=".false." units="unitless"
+			description="if true, the 'CFCGRP' category is enabled for the run"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_CFCTracers_surface_bulk_forcing" type="logical" default_value=".false." units="unitless"
+			description="if true, surface bulk forcing from coupler is added to surfaceTracerFlux in 'CFCGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_CFCTracers_surface_restoring" type="logical" default_value=".false." units="unitless"
+			description="if true, surface restoring source is applied to tracers in 'CFCGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_CFCTracers_interior_restoring" type="logical" default_value=".false." units="unitless"
+			description="if true, interior restoring source is applied to tracers in 'CFCGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_CFCTracers_exponential_decay" type="logical" default_value=".false." units="unitless"
+			description="if true, exponential decay source is applied to tracers in 'CFCGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_CFCTracers_idealAge_forcing" type="logical" default_value=".false." units="unitless"
+			description="if true, idealAge forcing source is applied to tracers in 'CFCGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_CFCTracers_ttd_forcing" type="logical" default_value=".false." units="unitless"
+			description="if true, transit time distribution forcing source is applied to tracers in 'CFCGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_CFC11" type="logical" default_value=".true." units="unitless"
+			description="if true, CFC11 is enabled for the run"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_CFC12" type="logical" default_value=".true." units="unitless"
+			description="if true, CFC12 is enabled for the run"
+			possible_values=".true. or .false."
+		/>
+	</nml_record>
+
+	<packages>
+		<package name="CFCTracersPKG" description="This package includes variables required to include CFCGRP."/>
+		<package name="CFCTracersBulkRestoringPKG" description="This package includes variables required to compute bulk restoring on the CFC tracer group."/>
+		<package name="CFCTracersSurfaceRestoringPKG" description="This package includes variables required to compute surface restoring on the CFC tracer group."/>
+		<package name="CFCTracersInteriorRestoringPKG" description="This package includes variables required to compute interior restoring on the CFC tracer group."/>
+		<package name="CFCTracersExponentialDecayPKG" description="This package includes variables required to compute exponential decay on the CFC tracer group."/>
+		<package name="CFCTracersIdealAgePKG" description="This package includes variables required to compute ideal age forcing on the CFC tracer group."/>
+		<package name="CFCTracersTTDPKG" description="This package includes variables required to compute transit-time distribution forcing on the CFC tracer group."/>
+	</packages>
+
+	<var_struct name="state" time_levs="2">
+		<var_struct name="tracers" time_levs="2">
+			<var_array name="CFCTracers" dimensions="nVertLevels nCells Time" type="real" packages="CFCTracersPKG"  default_value="0.0">
+				<!-- Add constituents of tracer group -->
+				<var name="CFC11" array_group="CFCGRP" units="mmol m^{-3}"
+			description="CFC11"
+				/>
+				<var name="CFC12" array_group="CFCGRP" units="mmol m^{-3}"
+			description="CFC12"
+				/>
+			</var_array>
+		</var_struct>
+	</var_struct>
+
+	<var_struct name="tend" time_levs="1">
+		<var_struct name="tracersTend" time_levs="1">
+			<var_array name="CFCTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersPKG">
+				<!-- Add constituents of tracer group -->
+				<var name="CFC11Tend" array_group="CFCGRP" units="mmol m^{-3} s^{-1}"
+			description="CFC11 Tendency"
+				/>
+				<var name="CFC12Tend" array_group="CFCGRP" units="mmol m^{-3} s^{-1}"
+			description="CFC12 Tendency"
+				/>
+			</var_array>
+		</var_struct>
+	</var_struct>
+
+	<var_struct name="forcing" time_levs="1">
+		<var_struct name="tracersSurfaceFlux" time_levs="1">
+			<var_array name="CFCTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="CFCTracersPKG">
+				<!-- Add constituents of tracer group -->
+				<var name="CFC11SurfaceFlux" array_group="CFCSurfaceFluxGRP" units="mmol m^{-3} m s^{-1}"
+			description="CFC11 Surface Flux"
+				/>
+				<var name="CFC12SurfaceFlux" array_group="CFCSurfaceFluxGRP" units="mmol m^{-3} m s^{-1}"
+			description="CFC12 Surface Flux"
+				/>
+			</var_array>
+			<var_array name="CFCTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="CFCTracersPKG">
+				<!-- Add constituents of tracer group -->
+				<var name="CFCSurfaceFluxRunoff" array_group="CFCSurfaceFluxRunoffGRP" units="mmol m^{-3} m s^{-1}"
+					description="CFC11 Surface Flux Due to Runoff"
+				/>
+				<var name="CFC12SurfaceFluxRunoff" array_group="CFCSurfaceFluxRunoffGRP" units="mmol m^{-3} m s^{-1}"
+					description="CFC12 Surface Flux Due to Runoff"
+				/>
+			</var_array>
+			<var_array name="CFCTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="CFCTracersPKG">
+				<!-- Add constituents of tracer group -->
+				<var name="CFCSurfaceFluxRemoved" array_group="CFCSurfaceFluxRemovedGRP" units="mmol m^{-3} m s^{-1}"
+					description="CFC11 Surface Flux that is ignored"
+				/>
+				<var name="CFC12SurfaceFluxRemoved" array_group="CFCSurfaceFluxRemovedGRP" units="mmol m^{-3} m s^{-1}"
+					description="CFC12 Surface Flux that is ignored"
+				/>
+			</var_array>
+		</var_struct>
+
+                <var_struct name="CFC11FluxDiagnostics" time_levs="1" packages="CFCTracersPKG">
+                        <var name="CFC11_flux_ifrac" type="real" dimensions="nCells Time" units="none"
+                                description="Ice Fraction used in CFC11 flux calculation"
+                        />
+                        <var name="CFC11_flux_xkw" type="real" dimensions="nCells Time" units="none"
+                                description="XKW used in CFC11 flux calculation"
+                        />
+                        <var name="CFC11_flux_atm_press" type="real" dimensions="nCells Time" units="unknown"
+                                description="Atm Pressure used in CFC11 flux calculation"
+                        />
+                        <var name="CFC11_flux_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
+                                description="Piston Velocity used in CFC11 flux calculation"
+                        />
+                        <var name="CFC11_flux_schmidt" type="real" dimensions="nCells Time" units="none"
+                                description="Schmidt Number used in CFC11 flux calculation"
+                        />
+                        <var name="CFC11_flux_sat" type="real" dimensions="nCells Time" units="mmolS m^{3}"
+                                description="CFC11 Saturation used in CFC11 flux calculation"
+                        />
+                        <var name="CFC11_flux_surf" type="real" dimensions="nCells Time" units="mmolS m^{3}"
+                                description="Surface CFC11 Values used in CFC11 flux calculation"
+                        />
+                        <var name="CFC11_flux_ws" type="real" dimensions="nCells Time" units="m s^{-1}"
+                                description="Wind Speed used in CFC11 flux calculation"
+                        />
+                </var_struct>
+                <var_struct name="CFC12FluxDiagnostics" time_levs="1" packages="CFCTracersPKG">
+                        <var name="CFC12_flux_ifrac" type="real" dimensions="nCells Time" units="none"
+                                description="Ice Fraction used in CFC12 flux calculation"
+                        />
+                        <var name="CFC12_flux_xkw" type="real" dimensions="nCells Time" units="none"
+                                description="XKW used in CFC12 flux calculation"
+                        />
+                        <var name="CFC12_flux_atm_press" type="real" dimensions="nCells Time" units="unknown"
+                                description="Atm Pressure used in CFC12 flux calculation"
+                        />
+                        <var name="CFC12_flux_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
+                                description="Piston Velocity used in CFC12 flux calculation"
+                        />
+                        <var name="CFC12_flux_schmidt" type="real" dimensions="nCells Time" units="none"
+                                description="Schmidt Number used in CFC12 flux calculation"
+                        />
+                        <var name="CFC12_flux_sat" type="real" dimensions="nCells Time" units="mmolS m^{3}"
+                                description="CFC12 Saturation used in CFC12 flux calculation"
+                        />
+                        <var name="CFC12_flux_surf" type="real" dimensions="nCells Time" units="mmolS m^{3}"
+                                description="Surface CFC12 Values used in CFC12 flux calculation"
+                        />
+                        <var name="CFC12_flux_ws" type="real" dimensions="nCells Time" units="m s^{-1}"
+                                description="Wind Speed used in CFC12 flux calculation"
+                        />
+                </var_struct>
+
+		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
+			<var_array name="CFCTracersPistonVelocity" type="real" dimensions="nCells Time" packages="CFCTracersSurfaceRestoringPKG">
+				<var name="CFC11PistonVelocity" array_group="CFCPVGRP" units="m s^{-1}"
+			 description="A non-negative field controlling the rate at which CFC11 is restored to CFC11SurfaceRestoringValue"
+				/>
+				<var name="CFC12PistonVelocity" array_group="CFCPVGRP" units="m s^{-1}"
+			 description="A non-negative field controlling the rate at which CFC12 is restored to CFC12SurfaceRestoringValue"
+				/>
+			</var_array>
+			<var_array name="CFCTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="CFCTracersSurfaceRestoringPKG">
+				<var name="CFC11SurfaceRestoringValue" array_group="CFCSRVGRP" units="mmol m^{3}"
+			 description="Tracer is restored toward this field at a rate controlled by CFC11PistonVelocity."
+				/>
+				<var name="CFC12SurfaceRestoringValue" array_group="CFCSRVGRP" units="mmol m^{3}"
+			 description="Tracer is restored toward this field at a rate controlled by CFC12PistonVelocity."
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
+			<var_array name="CFCTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersInteriorRestoringPKG">
+				<var name="CFC11InteriorRestoringRate" array_group="CFCIRRGRP" units="{s}^-1"
+			 description="A non-negative field controlling the rate at which CFC11 is restored to CFC11InteriorRestoringValue"
+				/>
+				<var name="CFC12InteriorRestoringRate" array_group="CFCIRRGRP" units="{s}^-1"
+			 description="A non-negative field controlling the rate at which CFC12 is restored to CFC12InteriorRestoringValue"
+				/>
+			</var_array>
+			<var_array name="CFCTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersInteriorRestoringPKG">
+				<var name="CFC11InteriorRestoringValue" array_group="CFCIRVGRP" units="mmol m^{3}"
+			 description="Tracer is restored toward this field at a rate controlled by CFC11InteriorRestoringRate."
+				/>
+				<var name="CFC12InteriorRestoringValue" array_group="CFCIRVGRP" units="mmol m^{3}"
+			 description="Tracer is restored toward this field at a rate controlled by CFC12InteriorRestoringRate."
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersExponentialDecayFields" time_levs="1">
+			<var_array name="CFCTracersExponentialDecayRate" type="real" dimensions="Time" packages="CFCTracersExponentialDecayPKG">
+				<var name="CFC11ExponentialDecayRate" array_group="CFCGRP" units="s^{-1}"
+			 description="A non-negative field controlling the exponential decay of CFC11"
+				/>
+				<var name="CFC12ExponentialDecayRate" array_group="CFCGRP" units="s"
+			 description="A non-negative field controlling the exponential decay of CFC12"
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersIdealAgeFields" time_levs="1">
+			<var_array name="CFCTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="CFCTracersIdealAgePKG">
+				<var name="CFC11IdealAgeMask" array_group="CFCGRP" units="unitless"
+			 description="In top layer, CFC11 is reset to CFC11 * CFC11IdealAgeMask, valid values of CFC11IdealAgeMask or 0 and 1"
+				/>
+				<var name="CFC12IdealAgeMask" array_group="CFCGRP" units="unitless"
+			 description="In top layer, CFC12 is reset to CFC12 * CFC12IdealAgeMask, valid values of CFC12IdealAgeMask or 0 and 1"
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersTTDFields" time_levs="1">
+			<var_array name="CFC11TracersTTDMask" type="real" dimensions="nCells Time" packages="CFCTracersTTDPKG">
+				<var name="CFC11TTDMask" array_group="CFCGRP" units="unitless"
+			 description="In top layer, CFC11 is reset to TTDMask, valid values of CFC11TTDMask or 0 and 1"
+				/>
+				<var name="CFC12TTDMask" array_group="CFCGRP" units="unitless"
+			 description="In top layer, CFC12 is reset to CFC12TTDMask, valid values of CFC12TTDMask or 0 and 1"
+				/>
+			</var_array>
+		</var_struct>
+		<var_struct name="CFCAuxiliary" time_levs="1" packages="CFCTracersPKG">
+			<var name="pCFC11" type="real" dimensions="nCells Time" units="mole fraction"
+				description="Mole Fraction of Atmospheric CFC11"
+			/>
+			<var name="pCFC12" type="real" dimensions="nCells Time" units="mole fraction"
+				description="Mole Fraction of Atmospheric CFC12"
+			/>
+			<var name="windSpeedSquared10mCFC" type="real" dimensions="nCells Time" units="m^{2} s^{-2} default_value="0.0""
+				description="10 meter atmospheric wind speed squared"
+			/>
+                </var_struct>
+	</var_struct>
+        <var_struct name="CFCAnnualForcing" time_levs="1">
+                <var name="atmCFC11" type="real" dimensions="nCells Time" units="mole fraction"
+                        description="Mole Fraction of Atmospheric CFC11"
+                />
+                <var name="atmCFC12" type="real" dimensions="nCells Time" units="mole fraction"
+                        description="Mole Fraction of Atmospheric CFC12"
+                />
+        </var_struct>
+

--- a/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
@@ -106,122 +106,122 @@
 			</var_array>
 		</var_struct>
 
-                <var_struct name="CFC11FluxDiagnostics" time_levs="1" packages="CFCTracersPKG">
-                        <var name="CFC11_flux_ifrac" type="real" dimensions="nCells Time" units="none"
-                                description="Ice Fraction used in CFC11 flux calculation"
-                        />
-                        <var name="CFC11_flux_xkw" type="real" dimensions="nCells Time" units="none"
-                                description="XKW used in CFC11 flux calculation"
-                        />
-                        <var name="CFC11_flux_atm_press" type="real" dimensions="nCells Time" units="unknown"
-                                description="Atm Pressure used in CFC11 flux calculation"
-                        />
-                        <var name="CFC11_flux_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
-                                description="Piston Velocity used in CFC11 flux calculation"
-                        />
-                        <var name="CFC11_flux_schmidt" type="real" dimensions="nCells Time" units="none"
-                                description="Schmidt Number used in CFC11 flux calculation"
-                        />
-                        <var name="CFC11_flux_sat" type="real" dimensions="nCells Time" units="mol m^{3}"
-                                description="CFC11 Saturation used in CFC11 flux calculation"
-                        />
-                        <var name="CFC11_flux_surf" type="real" dimensions="nCells Time" units="mol m^{3}"
-                                description="Surface CFC11 Values used in CFC11 flux calculation"
-                        />
-                        <var name="CFC11_flux_ws" type="real" dimensions="nCells Time" units="m s^{-1}"
-                                description="Wind Speed used in CFC11 flux calculation"
-                        />
-                </var_struct>
-                <var_struct name="CFC12FluxDiagnostics" time_levs="1" packages="CFCTracersPKG">
-                        <var name="CFC12_flux_ifrac" type="real" dimensions="nCells Time" units="none"
-                                description="Ice Fraction used in CFC12 flux calculation"
-                        />
-                        <var name="CFC12_flux_xkw" type="real" dimensions="nCells Time" units="none"
-                                description="XKW used in CFC12 flux calculation"
-                        />
-                        <var name="CFC12_flux_atm_press" type="real" dimensions="nCells Time" units="unknown"
-                                description="Atm Pressure used in CFC12 flux calculation"
-                        />
-                        <var name="CFC12_flux_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
-                                description="Piston Velocity used in CFC12 flux calculation"
-                        />
-                        <var name="CFC12_flux_schmidt" type="real" dimensions="nCells Time" units="none"
-                                description="Schmidt Number used in CFC12 flux calculation"
-                        />
-                        <var name="CFC12_flux_sat" type="real" dimensions="nCells Time" units="mol m^{3}"
-                                description="CFC12 Saturation used in CFC12 flux calculation"
-                        />
-                        <var name="CFC12_flux_surf" type="real" dimensions="nCells Time" units="mol m^{3}"
-                                description="Surface CFC12 Values used in CFC12 flux calculation"
-                        />
-                        <var name="CFC12_flux_ws" type="real" dimensions="nCells Time" units="m s^{-1}"
-                                description="Wind Speed used in CFC12 flux calculation"
-                        />
-                </var_struct>
+		<var_struct name="CFC11FluxDiagnostics" time_levs="1" packages="CFCTracersPKG">
+			<var name="CFC11_flux_ifrac" type="real" dimensions="nCells Time" units="none"
+				description="Ice Fraction used in CFC11 flux calculation"
+			/>
+			<var name="CFC11_flux_xkw" type="real" dimensions="nCells Time" units="none"
+				description="XKW used in CFC11 flux calculation"
+			/>
+			<var name="CFC11_flux_atm_press" type="real" dimensions="nCells Time" units="unknown"
+				description="Atm Pressure used in CFC11 flux calculation"
+			/>
+			<var name="CFC11_flux_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
+				description="Piston Velocity used in CFC11 flux calculation"
+			/>
+			<var name="CFC11_flux_schmidt" type="real" dimensions="nCells Time" units="none"
+				description="Schmidt Number used in CFC11 flux calculation"
+			/>
+			<var name="CFC11_flux_sat" type="real" dimensions="nCells Time" units="mol m^{3}"
+				description="CFC11 Saturation used in CFC11 flux calculation"
+			/>
+			<var name="CFC11_flux_surf" type="real" dimensions="nCells Time" units="mol m^{3}"
+				description="Surface CFC11 Values used in CFC11 flux calculation"
+			/>
+			<var name="CFC11_flux_ws" type="real" dimensions="nCells Time" units="m s^{-1}"
+				description="Wind Speed used in CFC11 flux calculation"
+			/>
+		</var_struct>
+		<var_struct name="CFC12FluxDiagnostics" time_levs="1" packages="CFCTracersPKG">
+			<var name="CFC12_flux_ifrac" type="real" dimensions="nCells Time" units="none"
+				description="Ice Fraction used in CFC12 flux calculation"
+			/>
+			<var name="CFC12_flux_xkw" type="real" dimensions="nCells Time" units="none"
+				description="XKW used in CFC12 flux calculation"
+			/>
+			<var name="CFC12_flux_atm_press" type="real" dimensions="nCells Time" units="unknown"
+				description="Atm Pressure used in CFC12 flux calculation"
+			/>
+			<var name="CFC12_flux_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
+				description="Piston Velocity used in CFC12 flux calculation"
+			/>
+			<var name="CFC12_flux_schmidt" type="real" dimensions="nCells Time" units="none"
+				description="Schmidt Number used in CFC12 flux calculation"
+			/>
+			<var name="CFC12_flux_sat" type="real" dimensions="nCells Time" units="mol m^{3}"
+				description="CFC12 Saturation used in CFC12 flux calculation"
+			/>
+			<var name="CFC12_flux_surf" type="real" dimensions="nCells Time" units="mol m^{3}"
+				description="Surface CFC12 Values used in CFC12 flux calculation"
+			/>
+			<var name="CFC12_flux_ws" type="real" dimensions="nCells Time" units="m s^{-1}"
+				description="Wind Speed used in CFC12 flux calculation"
+			/>
+		</var_struct>
 
 		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
 			<var_array name="CFCTracersPistonVelocity" type="real" dimensions="nCells Time" packages="CFCTracersSurfaceRestoringPKG">
 				<var name="CFC11PistonVelocity" array_group="CFCPVGRP" units="m s^{-1}"
-			 description="A non-negative field controlling the rate at which CFC11 is restored to CFC11SurfaceRestoringValue"
+				description="A non-negative field controlling the rate at which CFC11 is restored to CFC11SurfaceRestoringValue"
 				/>
 				<var name="CFC12PistonVelocity" array_group="CFCPVGRP" units="m s^{-1}"
-			 description="A non-negative field controlling the rate at which CFC12 is restored to CFC12SurfaceRestoringValue"
+				description="A non-negative field controlling the rate at which CFC12 is restored to CFC12SurfaceRestoringValue"
 				/>
 			</var_array>
 			<var_array name="CFCTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="CFCTracersSurfaceRestoringPKG">
 				<var name="CFC11SurfaceRestoringValue" array_group="CFCSRVGRP" units="mol m^{3}"
-			 description="Tracer is restored toward this field at a rate controlled by CFC11PistonVelocity."
+				description="Tracer is restored toward this field at a rate controlled by CFC11PistonVelocity."
 				/>
 				<var name="CFC12SurfaceRestoringValue" array_group="CFCSRVGRP" units="mol m^{3}"
-			 description="Tracer is restored toward this field at a rate controlled by CFC12PistonVelocity."
+				description="Tracer is restored toward this field at a rate controlled by CFC12PistonVelocity."
 				/>
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
 			<var_array name="CFCTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersInteriorRestoringPKG">
 				<var name="CFC11InteriorRestoringRate" array_group="CFCIRRGRP" units="{s}^-1"
-			 description="A non-negative field controlling the rate at which CFC11 is restored to CFC11InteriorRestoringValue"
+				description="A non-negative field controlling the rate at which CFC11 is restored to CFC11InteriorRestoringValue"
 				/>
 				<var name="CFC12InteriorRestoringRate" array_group="CFCIRRGRP" units="{s}^-1"
-			 description="A non-negative field controlling the rate at which CFC12 is restored to CFC12InteriorRestoringValue"
+				description="A non-negative field controlling the rate at which CFC12 is restored to CFC12InteriorRestoringValue"
 				/>
 			</var_array>
 			<var_array name="CFCTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersInteriorRestoringPKG">
 				<var name="CFC11InteriorRestoringValue" array_group="CFCIRVGRP" units="mol m^{3}"
-			 description="Tracer is restored toward this field at a rate controlled by CFC11InteriorRestoringRate."
+				description="Tracer is restored toward this field at a rate controlled by CFC11InteriorRestoringRate."
 				/>
 				<var name="CFC12InteriorRestoringValue" array_group="CFCIRVGRP" units="mol m^{3}"
-			 description="Tracer is restored toward this field at a rate controlled by CFC12InteriorRestoringRate."
+				description="Tracer is restored toward this field at a rate controlled by CFC12InteriorRestoringRate."
 				/>
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersExponentialDecayFields" time_levs="1">
 			<var_array name="CFCTracersExponentialDecayRate" type="real" dimensions="Time" packages="CFCTracersExponentialDecayPKG">
 				<var name="CFC11ExponentialDecayRate" array_group="CFCGRP" units="s^{-1}"
-			 description="A non-negative field controlling the exponential decay of CFC11"
+				description="A non-negative field controlling the exponential decay of CFC11"
 				/>
 				<var name="CFC12ExponentialDecayRate" array_group="CFCGRP" units="s"
-			 description="A non-negative field controlling the exponential decay of CFC12"
+				description="A non-negative field controlling the exponential decay of CFC12"
 				/>
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersIdealAgeFields" time_levs="1">
 			<var_array name="CFCTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="CFCTracersIdealAgePKG">
 				<var name="CFC11IdealAgeMask" array_group="CFCGRP" units="unitless"
-			 description="In top layer, CFC11 is reset to CFC11 * CFC11IdealAgeMask, valid values of CFC11IdealAgeMask or 0 and 1"
+				description="In top layer, CFC11 is reset to CFC11 * CFC11IdealAgeMask, valid values of CFC11IdealAgeMask or 0 and 1"
 				/>
 				<var name="CFC12IdealAgeMask" array_group="CFCGRP" units="unitless"
-			 description="In top layer, CFC12 is reset to CFC12 * CFC12IdealAgeMask, valid values of CFC12IdealAgeMask or 0 and 1"
+				description="In top layer, CFC12 is reset to CFC12 * CFC12IdealAgeMask, valid values of CFC12IdealAgeMask or 0 and 1"
 				/>
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersTTDFields" time_levs="1">
 			<var_array name="CFC11TracersTTDMask" type="real" dimensions="nCells Time" packages="CFCTracersTTDPKG">
 				<var name="CFC11TTDMask" array_group="CFCGRP" units="unitless"
-			 description="In top layer, CFC11 is reset to TTDMask, valid values of CFC11TTDMask or 0 and 1"
+				description="In top layer, CFC11 is reset to TTDMask, valid values of CFC11TTDMask or 0 and 1"
 				/>
 				<var name="CFC12TTDMask" array_group="CFCGRP" units="unitless"
-			 description="In top layer, CFC12 is reset to CFC12TTDMask, valid values of CFC12TTDMask or 0 and 1"
+				description="In top layer, CFC12 is reset to CFC12TTDMask, valid values of CFC12TTDMask or 0 and 1"
 				/>
 			</var_array>
 		</var_struct>
@@ -235,14 +235,14 @@
 			<var name="windSpeedSquared10mCFC" type="real" dimensions="nCells Time" units="m^{2} s^{-2} default_value="0.0""
 				description="10 meter atmospheric wind speed squared"
 			/>
-                </var_struct>
+		</var_struct>
 	</var_struct>
-        <var_struct name="CFCAnnualForcing" time_levs="1">
-                <var name="atmCFC11" type="real" dimensions="nCells Time" units="mole fraction"
-                        description="Mole Fraction of Atmospheric CFC11"
-                />
-                <var name="atmCFC12" type="real" dimensions="nCells Time" units="mole fraction"
-                        description="Mole Fraction of Atmospheric CFC12"
-                />
-        </var_struct>
+	<var_struct name="CFCAnnualForcing" time_levs="1">
+		<var name="atmCFC11" type="real" dimensions="nCells Time" units="mole fraction"
+			description="Mole Fraction of Atmospheric CFC11"
+		/>
+		<var name="atmCFC12" type="real" dimensions="nCells Time" units="mole fraction"
+			description="Mole Fraction of Atmospheric CFC12"
+		/>
+	</var_struct>
 

--- a/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
@@ -51,10 +51,10 @@
 		<var_struct name="tracers" time_levs="2">
 			<var_array name="CFCTracers" dimensions="nVertLevels nCells Time" type="real" packages="CFCTracersPKG"  default_value="0.0">
 				<!-- Add constituents of tracer group -->
-				<var name="CFC11" array_group="CFCGRP" units="mmol m^{-3}"
+				<var name="CFC11" array_group="CFCGRP" units="mol m^{-3}"
 			description="CFC11"
 				/>
-				<var name="CFC12" array_group="CFCGRP" units="mmol m^{-3}"
+				<var name="CFC12" array_group="CFCGRP" units="mol m^{-3}"
 			description="CFC12"
 				/>
 			</var_array>
@@ -65,10 +65,10 @@
 		<var_struct name="tracersTend" time_levs="1">
 			<var_array name="CFCTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersPKG">
 				<!-- Add constituents of tracer group -->
-				<var name="CFC11Tend" array_group="CFCGRP" units="mmol m^{-3} s^{-1}"
+				<var name="CFC11Tend" array_group="CFCGRP" units="mol m^{-3} s^{-1}"
 			description="CFC11 Tendency"
 				/>
-				<var name="CFC12Tend" array_group="CFCGRP" units="mmol m^{-3} s^{-1}"
+				<var name="CFC12Tend" array_group="CFCGRP" units="mol m^{-3} s^{-1}"
 			description="CFC12 Tendency"
 				/>
 			</var_array>
@@ -79,28 +79,28 @@
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
 			<var_array name="CFCTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="CFCTracersPKG">
 				<!-- Add constituents of tracer group -->
-				<var name="CFC11SurfaceFlux" array_group="CFCSurfaceFluxGRP" units="mmol m^{-3} m s^{-1}"
+				<var name="CFC11SurfaceFlux" array_group="CFCSurfaceFluxGRP" units="mol m^{-3} m s^{-1}"
 			description="CFC11 Surface Flux"
 				/>
-				<var name="CFC12SurfaceFlux" array_group="CFCSurfaceFluxGRP" units="mmol m^{-3} m s^{-1}"
+				<var name="CFC12SurfaceFlux" array_group="CFCSurfaceFluxGRP" units="mol m^{-3} m s^{-1}"
 			description="CFC12 Surface Flux"
 				/>
 			</var_array>
 			<var_array name="CFCTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="CFCTracersPKG">
 				<!-- Add constituents of tracer group -->
-				<var name="CFCSurfaceFluxRunoff" array_group="CFCSurfaceFluxRunoffGRP" units="mmol m^{-3} m s^{-1}"
+				<var name="CFCSurfaceFluxRunoff" array_group="CFCSurfaceFluxRunoffGRP" units="mol m^{-3} m s^{-1}"
 					description="CFC11 Surface Flux Due to Runoff"
 				/>
-				<var name="CFC12SurfaceFluxRunoff" array_group="CFCSurfaceFluxRunoffGRP" units="mmol m^{-3} m s^{-1}"
+				<var name="CFC12SurfaceFluxRunoff" array_group="CFCSurfaceFluxRunoffGRP" units="mol m^{-3} m s^{-1}"
 					description="CFC12 Surface Flux Due to Runoff"
 				/>
 			</var_array>
 			<var_array name="CFCTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="CFCTracersPKG">
 				<!-- Add constituents of tracer group -->
-				<var name="CFCSurfaceFluxRemoved" array_group="CFCSurfaceFluxRemovedGRP" units="mmol m^{-3} m s^{-1}"
+				<var name="CFCSurfaceFluxRemoved" array_group="CFCSurfaceFluxRemovedGRP" units="mol m^{-3} m s^{-1}"
 					description="CFC11 Surface Flux that is ignored"
 				/>
-				<var name="CFC12SurfaceFluxRemoved" array_group="CFCSurfaceFluxRemovedGRP" units="mmol m^{-3} m s^{-1}"
+				<var name="CFC12SurfaceFluxRemoved" array_group="CFCSurfaceFluxRemovedGRP" units="mol m^{-3} m s^{-1}"
 					description="CFC12 Surface Flux that is ignored"
 				/>
 			</var_array>
@@ -122,10 +122,10 @@
                         <var name="CFC11_flux_schmidt" type="real" dimensions="nCells Time" units="none"
                                 description="Schmidt Number used in CFC11 flux calculation"
                         />
-                        <var name="CFC11_flux_sat" type="real" dimensions="nCells Time" units="mmolS m^{3}"
+                        <var name="CFC11_flux_sat" type="real" dimensions="nCells Time" units="mol m^{3}"
                                 description="CFC11 Saturation used in CFC11 flux calculation"
                         />
-                        <var name="CFC11_flux_surf" type="real" dimensions="nCells Time" units="mmolS m^{3}"
+                        <var name="CFC11_flux_surf" type="real" dimensions="nCells Time" units="mol m^{3}"
                                 description="Surface CFC11 Values used in CFC11 flux calculation"
                         />
                         <var name="CFC11_flux_ws" type="real" dimensions="nCells Time" units="m s^{-1}"
@@ -148,10 +148,10 @@
                         <var name="CFC12_flux_schmidt" type="real" dimensions="nCells Time" units="none"
                                 description="Schmidt Number used in CFC12 flux calculation"
                         />
-                        <var name="CFC12_flux_sat" type="real" dimensions="nCells Time" units="mmolS m^{3}"
+                        <var name="CFC12_flux_sat" type="real" dimensions="nCells Time" units="mol m^{3}"
                                 description="CFC12 Saturation used in CFC12 flux calculation"
                         />
-                        <var name="CFC12_flux_surf" type="real" dimensions="nCells Time" units="mmolS m^{3}"
+                        <var name="CFC12_flux_surf" type="real" dimensions="nCells Time" units="mol m^{3}"
                                 description="Surface CFC12 Values used in CFC12 flux calculation"
                         />
                         <var name="CFC12_flux_ws" type="real" dimensions="nCells Time" units="m s^{-1}"
@@ -169,10 +169,10 @@
 				/>
 			</var_array>
 			<var_array name="CFCTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="CFCTracersSurfaceRestoringPKG">
-				<var name="CFC11SurfaceRestoringValue" array_group="CFCSRVGRP" units="mmol m^{3}"
+				<var name="CFC11SurfaceRestoringValue" array_group="CFCSRVGRP" units="mol m^{3}"
 			 description="Tracer is restored toward this field at a rate controlled by CFC11PistonVelocity."
 				/>
-				<var name="CFC12SurfaceRestoringValue" array_group="CFCSRVGRP" units="mmol m^{3}"
+				<var name="CFC12SurfaceRestoringValue" array_group="CFCSRVGRP" units="mol m^{3}"
 			 description="Tracer is restored toward this field at a rate controlled by CFC12PistonVelocity."
 				/>
 			</var_array>
@@ -187,10 +187,10 @@
 				/>
 			</var_array>
 			<var_array name="CFCTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersInteriorRestoringPKG">
-				<var name="CFC11InteriorRestoringValue" array_group="CFCIRVGRP" units="mmol m^{3}"
+				<var name="CFC11InteriorRestoringValue" array_group="CFCIRVGRP" units="mol m^{3}"
 			 description="Tracer is restored toward this field at a rate controlled by CFC11InteriorRestoringRate."
 				/>
-				<var name="CFC12InteriorRestoringValue" array_group="CFCIRVGRP" units="mmol m^{3}"
+				<var name="CFC12InteriorRestoringValue" array_group="CFCIRVGRP" units="mol m^{3}"
 			 description="Tracer is restored toward this field at a rate controlled by CFC12InteriorRestoringRate."
 				/>
 			</var_array>

--- a/components/mpas-ocean/src/tracer_groups/Registry_tracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_tracers.xml
@@ -4,4 +4,5 @@
 #include "Registry_DMS.xml"
 #include "Registry_MacroMolecules.xml"
 #include "Registry_idealAge.xml"
+#include "Registry_CFC.xml"
 //#include "Registry_TEMPLATEGRP.xml"


### PR DESCRIPTION
This PR adds the capability for the ocean to simulate CFC11 and CFC12 as passive tracers following the OCMIP protocol (http://ocmip5.ipsl.jussieu.fr/OCMIP/phase2/simulations/CFC/HOWTO-CFC.html).  This capability is inactive by default and requires a time series of annual average atmospheric mole fractions to be read in as a new stream in streams.ocean.

[NML]
[BFB]