### PR TITLE
For Cori, update version for cmake to avoid module error at setup

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -181,7 +181,7 @@
       <command name="rm">git</command>
       <command name="load">git</command>
       <command name="rm">cmake</command>
-      <command name="load">cmake/3.14.4</command>
+      <command name="load">cmake/3.21.3</command>
       <command name="load">perl5-extras</command>
     </modules>
   </module_system>
@@ -331,7 +331,7 @@
       <command name="rm">git</command>
       <command name="load">git</command>
       <command name="rm">cmake</command>
-      <command name="load">cmake/3.14.4</command>
+      <command name="load">cmake/3.21.3</command>
       <command name="load">perl5-extras</command>
     </modules>
 


### PR DESCRIPTION
Same change as PR #4550 
On Sep 21, NERSC updated default cmake version. The old version (that we were using) is still there, however, a module warning now appears if that it used. If CIME detects a warning/error from a module command, it will fail. This behavior can be turned off (using allow_error=true) and I tested that. However, in this case, it seems easy enough to simply update cmake version just to avoid this. 

Fixes #4548

[bfb]