### PR TITLE
switched from device_resident to create for small arrays in ocn EOS

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_jm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_jm.F
@@ -62,23 +62,10 @@ module ocn_equation_of_state_jm
    !
    !--------------------------------------------------------------------
 
-   !*** temporary array to hold modified T,S for EOS calculation
-   !*** declared here to make it thread-shared - could be replaced
-   !***   by a local subroutine temporary in a different thread model
-
-   real (kind=RKIND), dimension(:,:), allocatable :: &
-      tracerTemp, tracerSalt
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(tracerTemp, tracerSalt)
-#endif
-
    !*** depth-based reference pressure for pressure term in eq state
 
    real (kind=RKIND), dimension(:), allocatable :: &
       ocnEqStatePRef   ! reference pressure at each layer
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(ocnEqStatePRef)
-#endif
 
    !*** valid range of T,S for Jackett and McDougall
 
@@ -234,8 +221,12 @@ contains
 
       real (kind=RKIND), dimension(:), allocatable :: &
          p, p2 ! temporary pressure scalars
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerTemp,          &! modified temperature
+         tracerSalt            ! modified salinity
 #ifdef MPAS_OPENACC
-      !$acc declare device_resident(p, p2)
+      !$acc declare device_resident(tracerTemp, tracerSalt)
 #endif
 
       real (kind=RKIND) :: &
@@ -255,6 +246,9 @@ contains
       !*** allocate and compute pressure array
 
       allocate(p(nVertLevels),p2(nVertLevels))
+#ifdef MPAS_OPENACC
+      !$acc enter data create(p, p2)
+#endif
 
       ! Determine pressure to use in density calculation
       !  If kDisplaced=0, in-situ density is returned (no displacement)
@@ -287,7 +281,8 @@ contains
       if (kDisplacedLocal == 0) then
          ! use pressure at in situ level
 #ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector
+         !$acc parallel loop gang vector &
+         !$acc    present(p, p2, ocnEqStatePRef)
 #endif
          do k=1,nVertLevels
             p (k) = ocnEqStatePRef(k)
@@ -295,7 +290,8 @@ contains
          enddo
       else ! kDisplacedLocal /= 0
 #ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector
+         !$acc parallel loop gang vector &
+         !$acc    present(p, p2, ocnEqStatePRef)
 #endif
          do k=1,nVertLevels
             ! determine level to which parcel is displaced
@@ -314,9 +310,9 @@ contains
       !*** compute modified T,S to account for displacement and
       !*** valid range
 
-! For MPAS_OPENACC, these are device resident only
-      allocate(tracerTemp(nVertLevels,nCells))
-      allocate(tracerSalt(nVertLevels,nCells))
+      ! For OpenACC, these are device resident only
+      allocate(tracerTemp(nVertLevels,nCells), &
+               tracerSalt(nVertLevels,nCells))
 
       if (displacementType == 'surfaceDisplaced') then
 
@@ -368,7 +364,7 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector collapse(2) &
-      !$acc&   present(density)
+      !$acc&   present(density, p, p2)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
@@ -425,9 +421,11 @@ contains
       !$omp end parallel
 #endif
 
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(p, p2)
+#endif
       deallocate(p,p2)
-      deallocate(tracerTemp)
-      deallocate(tracerSalt)
+      deallocate(tracerTemp, tracerSalt)
 
    !--------------------------------------------------------------------
 
@@ -533,8 +531,12 @@ contains
 
       real (kind=RKIND), dimension(:), allocatable :: &
          p, p2 ! temporary pressure scalars
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerTemp,          &! modified temperature
+         tracerSalt            ! modified salinity
 #ifdef MPAS_OPENACC
-      !$acc declare device_resident(p, p2)
+      !$acc declare device_resident(tracerTemp, tracerSalt)
 #endif
 
       !-----------------------------------------------------------------
@@ -546,6 +548,9 @@ contains
       !*** allocate and compute pressure array
 
       allocate(p(nVertLevels),p2(nVertLevels))
+#ifdef MPAS_OPENACC
+      !$acc enter data create(p, p2)
+#endif
 
       ! Determine pressure to use in density calculation
       !  If kDisplaced=0, in-situ density is returned (no displacement)
@@ -578,7 +583,8 @@ contains
       if (kDisplacedLocal == 0) then
          ! use pressure at in situ level
 #ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector
+         !$acc parallel loop gang vector &
+         !$acc    present(p, p2, ocnEqStatePRef)
 #endif
          do k=1,nVertLevels
             p (k) = ocnEqStatePRef(k)
@@ -586,7 +592,8 @@ contains
          enddo
       else ! kDisplacedLocal /= 0
 #ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector
+         !$acc parallel loop gang vector &
+         !$acc    present(p, p2, ocnEqStatePRef)
 #endif
          do k=1,nVertLevels
             ! determine level to which parcel is displaced
@@ -605,9 +612,9 @@ contains
       !*** compute modified T,S to account for displacement and
       !*** valid range
 
-! For MPAS_OPENACC, these are device resident only
-      allocate(tracerTemp(nVertLevels,nCells))
-      allocate(tracerSalt(nVertLevels,nCells))
+      ! For OpenACC, these are device resident only
+      allocate(tracerTemp(nVertLevels,nCells), &
+               tracerSalt(nVertLevels,nCells))
 
       if (displacementType == 'surfaceDisplaced') then
 
@@ -659,7 +666,7 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector collapse(2)     &
-      !$acc&   present(density,                       &
+      !$acc&   present(density, p, p2,                &
       !$acc&           thermalExpansionCoeff,         &
       !$acc&           salineContractionCoeff)
 #else
@@ -764,9 +771,11 @@ contains
       !$omp end parallel
 #endif
 
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(p, p2)
+#endif
       deallocate(p,p2)
-      deallocate(tracerTemp)
-      deallocate(tracerSalt)
+      deallocate(tracerTemp, tracerSalt)
 
    !--------------------------------------------------------------------
 
@@ -857,9 +866,6 @@ contains
 
       allocate(ocnEqStatePRef(nVertLevels))
 
-#ifdef MPAS_OPENACC
-!$acc serial
-#endif
       depth = 0.5_RKIND*refBottomDepth(1)
       ocnEqStatePRef(1) = &
            0.059808_RKIND  *(exp(-0.025_RKIND*depth) - 1.0_RKIND) &
@@ -873,7 +879,7 @@ contains
             + 2.28405e-7_RKIND*depth**2
       enddo
 #ifdef MPAS_OPENACC
-!$acc end serial
+      !$acc enter data copyin(ocnEqStatePRef)
 #endif
 
    !--------------------------------------------------------------------


### PR DESCRIPTION
The nvhpc 21.3 compiler on Summit was failing to build the OpenACC form of the ocean equation_of_state_jm routine with the device_resident declaration for small arrays. This fix switches to the more generic OpenACC create/delete paradigm for these arrays while still retaining device_resident for the larger T,S temporaries.

Change is bit-for-bit for both CPU and GPU configurations (impacts data transfers only) as tested on a QU240 case with the JM EOS enabled.

[bfb]
Fixes #4577