### PR TITLE
Fix quotes to agree with XML format

### DIFF
--- a/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
@@ -232,7 +232,7 @@
 			<var name="pCFC12" type="real" dimensions="nCells Time" units="mole fraction"
 				description="Mole Fraction of Atmospheric CFC12"
 			/>
-			<var name="windSpeedSquared10mCFC" type="real" dimensions="nCells Time" units="m^{2} s^{-2} default_value="0.0""
+			<var name="windSpeedSquared10mCFC" type="real" dimensions="nCells Time" units="m^{2} s^{-2}" default_value="0.0"
 				description="10 meter atmospheric wind speed squared"
 			/>
 		</var_struct>


### PR DESCRIPTION
Fixes a minor XML issue in the Registry_CFC.xml file in mpas-ocean. This will allow the XML parser we use to autogenerate bld files to work.

Fixes #4579 

[BFB]