### PR TITLE
fixed allocate error in ocean del4 tracer mixing

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
@@ -166,10 +166,10 @@ contains
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
 
-      allocate(delsq_tracer(num_tracers, nVertLevels, nCells))
-
       ! Need 1 halo around owned cells
       nCells = nCellsArray( 2 )
+
+      allocate(delsq_tracer(num_tracers, nVertLevels, nCells))
 
       ! first del2: div(h \nabla \phi) at cell center
       !$omp parallel


### PR DESCRIPTION
fixes a bug in which a temp was being allocated before one of the dimensions was defined, causing a malloc corruption error

Because this was a pretty egregious error, it's unlikely any of our current tests actually exercise this code and I could only verify it runs to completion and gives bit-for-bit when del4 is off. 

Fixes #4581 