### PR TITLE
Corrects the calculation of solar zenith angle, which was off by a timestep

### DIFF
--- a/share/streams/shr_dmodel_mod.F90
+++ b/share/streams/shr_dmodel_mod.F90
@@ -672,7 +672,7 @@ CONTAINS
     rDateUB = real(mDateUB,R8) + real(mSecUB,R8)/spd
     call t_stopf(trim(lstr)//'_setup')
 
-    if (rDateM < rDateLB .or. rDateM > rDateUB) then
+    if (rDateM < rDateLB .or. rDateM >= rDateUB) then
        call t_startf(trim(lstr)//'_fbound')
        if (my_task == master_task) then
           !       call shr_stream_findBounds(stream,mDate,mSec,                 &

--- a/share/streams/shr_tInterp_mod.F90
+++ b/share/streams/shr_tInterp_mod.F90
@@ -305,25 +305,17 @@ contains
     tod     = tod1
     do while( reday < reday2) ! mid-interval t-steps thru interval [LB,UB]
 
+       !--- get next cosz value for t-avg ---
+       call shr_tInterp_getCosz(cosz,lonr,latr,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar)
+       n = n + ldt
+       tavCosz = tavCosz + cosz*real(ldt,SHR_KIND_R8)  ! add to partial sum
+
        !--- advance to next time in [LB,UB] ---
        ymd0 = ymd
        tod0 = tod
        reday0 = reday
        call shr_cal_advDateInt(ldt,'seconds',ymd0,tod0,ymd,tod,calendar)
        call shr_cal_timeSet(reday,ymd,tod,calendar)
-
-       if (reday > reday2) then
-          ymd = ymd2
-          tod = tod2
-          timeint = reday2-reday0
-          call ESMF_TimeIntervalGet(timeint,s_i8=dtsec)
-          ldt = dtsec
-       endif
-
-       !--- get next cosz value for t-avg ---
-       call shr_tInterp_getCosz(cosz,lonr,latr,ymd,tod,eccen,mvelpp,lambm0,obliqr,calendar)
-       n = n + ldt
-       tavCosz = tavCosz + cosz*real(ldt,SHR_KIND_R8)  ! add to partial sum
 
     end do
     tavCosz = tavCosz/real(n,SHR_KIND_R8) ! form t-avg


### PR DESCRIPTION
The solar zenith angle calculation used by the data models was off by one timestep. This issue was first reported by CESM  in [ESMCI Issue #3380](https://github.com/ESMCI/cime/issues/3380) and subsequently fixed in [ESCOMP PR #123](https://github.com/ESCOMP/CDEPS/pull/123). This PR implements that solution in E3SM.

Fixes #4575 

[non-BFB] for configurations with data models